### PR TITLE
Support end-to-end reload workflow + codex configurator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Run handler tests
         run: bash script/ci-godot-tests
 
+      - name: Reload smoke test
+        run: bash script/ci-reload-test
+
   godot-tests-macos:
     name: Godot tests / macOS
     runs-on: macos-latest
@@ -100,6 +103,9 @@ jobs:
 
       - name: Run handler tests
         run: bash script/ci-godot-tests
+
+      - name: Reload smoke test
+        run: bash script/ci-reload-test
 
   godot-tests-windows:
     name: Godot tests / Windows
@@ -134,3 +140,7 @@ jobs:
       - name: Run handler tests
         shell: bash
         run: bash script/ci-godot-tests
+
+      - name: Reload smoke test
+        shell: bash
+        run: bash script/ci-reload-test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,19 +7,20 @@ A production-grade MCP server for Godot. Python server (FastMCP v3) communicates
 ## Architecture
 
 ```
-AI Client → MCP (stdio/sse) → Python FastMCP server → WebSocket (port 9500) → Godot EditorPlugin
+AI Client → MCP (stdio/sse/streamable-http) → Python FastMCP server → WebSocket (port 9500) → Godot EditorPlugin
 ```
 
 - **Python server**: `src/godot_ai/` — FastMCP v3, async, lifespan manages WebSocket server
-- **GDScript plugin**: `plugin/addons/godot_ai/` — canonical source; copied into `test_project/addons/` for testing
+- **GDScript plugin**: `plugin/addons/godot_ai/` — canonical source; symlinked into `test_project/addons/` for testing
 - **Protocol**: JSON over WebSocket. Request/response with `request_id` correlation. Handshake on connect.
 - **Session model**: Multiple Godot editors can connect. Tools route through active session.
+- **Handler/Runtime layer**: Shared handlers in `src/godot_ai/handlers/` contain tool logic. They depend on a `Runtime` protocol (`runtime/interface.py`), implemented by `DirectRuntime` for the in-process server. Tools and resources are thin wrappers that create a runtime and delegate.
 
 ## Key conventions
 
 - **GDScript plugin is the canonical copy** in `plugin/`. `test_project/addons/godot_ai` is a symlink — no copy needed.
 - **Error codes**: Defined in `protocol/errors.py` (Python) and `utils/error_codes.gd` (GDScript). Keep in sync.
-- **Tools return `dict`**: `GodotClient.send()` returns `response.data` (a dict) or raises `GodotCommandError`. Tools just `return await app.client.send(...)`.
+- **Tools return `dict`**: Handlers call `runtime.send_command(command, params)` which returns a dict or raises. Tools create a `DirectRuntime` and delegate to handlers.
 - **Plugin runs on main thread**: All GDScript executes in `_process()` with a 4ms frame budget. Never block. Use `call_deferred` for scene tree mutations.
 - **Scene paths are clean**: `/Main/Camera3D` format, not raw Godot internal paths. Use `ScenePath.from_node(node, scene_root)` in GDScript.
 - **MCP logging**: Plugin prints `MCP | [recv] command(params)` / `MCP | [send] command -> ok` to Godot console. Controlled by `mcp_logging` var.
@@ -40,21 +41,26 @@ ruff format src/ tests/      # format
 ### Server lifecycle in dev
 
 The plugin manages the server process:
-- **Reload Plugin** in the Godot dock kills the old server, starts a new one from `.venv/bin/python -m godot_ai`
-- After Reload Plugin, do `/mcp` in Claude Code to reconnect
-
-The plugin prefers the local `.venv` over system-installed `godot-ai` so dev checkouts always use source code.
+- On startup, plugin checks if port 8000 is already in use. If yes, uses existing server. If no, spawns `.venv/bin/python -m godot_ai --transport streamable-http --port 8000`.
+- The plugin prefers the local `.venv` over system-installed `godot-ai` so dev checkouts always use source code.
 
 For Python auto-reload during dev (no need to touch Godot):
 ```bash
 python -m godot_ai --transport streamable-http --port 8000 --reload
 ```
+This uses `src/godot_ai/asgi.py` to run uvicorn with its factory reload path. Uvicorn watches `src/` for changes and restarts the server process automatically. The plugin auto-reconnects.
+
+### Plugin reload
+
+The `reload_plugin` MCP tool triggers a live plugin reload inside Godot (`EditorInterface.set_plugin_enabled` off/on). Requires the server to be running externally (not managed by the plugin). The Python handler waits for the new session via `SessionRegistry.wait_for_session()`.
+
+The Godot dock also has a **Start/Stop Dev Server** button for convenience.
 
 ## Testing
 
 ### Python tests
 ```bash
-pytest -v                    # 81 unit + integration tests
+pytest -v                    # 140 unit + integration tests
 ```
 
 ### Godot-side tests
@@ -78,17 +84,19 @@ Test suites extend `McpTestSuite` (assertion methods: `assert_true`, `assert_eq`
 
 The plugin can configure MCP clients via `client_configurator.gd`:
 - **Claude Code**: uses `claude mcp add` CLI to register the server
+- **Codex**: writes TOML config to `~/.codex/config.toml`
 - **Antigravity**: writes directly to `~/.gemini/antigravity/mcp_config.json`
 
 MCP tools `client_configure` and `client_status` expose this to AI clients.
 
 ## Adding a new tool
 
-1. Add a handler method in the appropriate `handlers/*.gd` file
+1. Add a handler method in the appropriate GDScript `handlers/*.gd` file
 2. Register it in `plugin.gd`: `_dispatcher.register("command_name", handler.method)`
-3. Add a Python tool in `tools/<domain>.py` that calls `app.client.send("command_name", params)`
-4. Register the tool module in `server.py` if it's a new file
-5. Add tests: Python integration test in `tests/` AND GDScript test in `test_project/tests/`
+3. Add a shared Python handler in `handlers/<domain>.py` that calls `runtime.send_command("command_name", params)`
+4. Add a Python tool in `tools/<domain>.py` that creates `DirectRuntime` and delegates to the handler
+5. Register the tool module in `server.py` if it's a new file
+6. Add tests: handler unit test, Python integration test, AND GDScript test in `test_project/tests/`
 
 ## Write tools must be undoable
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -207,9 +207,10 @@ addons/godot_ai/
 ├── dispatcher.gd          # Command queue, frame-budget dispatch, handler routing
 ├── mcp_dock.gd            # Editor dock panel
 ├── handlers/
-│   ├── editor_handler.gd  # editor_state, selection, logs
+│   ├── editor_handler.gd  # editor_state, selection, logs, reload_plugin
 │   ├── scene_handler.gd   # scene tree reading
 │   ├── node_handler.gd    # node create (with undo)
+│   ├── project_handler.gd # project settings, filesystem search
 │   └── client_handler.gd  # client configure/status
 └── utils/
     ├── scene_path.gd       # from_node(), resolve()
@@ -425,7 +426,7 @@ The product should be useful for inspection and navigation before any write tool
 | Reconnect button | `Button` | Calls `_attempt_reconnect()` |
 | Reload Plugin button | `Button` | Toggles plugin off/on |
 | Setup status | Dev mode / uv version | Auto-detected |
-| Client config | Configure buttons per client | Claude Code, Antigravity |
+| Client config | Configure buttons per client | Claude Code, Codex, Antigravity |
 
 ### Pagination design
 
@@ -450,8 +451,14 @@ Large results (scene trees with 1000+ nodes, long log buffers) need pagination:
 - [x] Batch 3: Project reads (project_settings.get, filesystem.search)
 - [x] Batch 4: MCP Resources (7 resources: sessions, scene/current, scene/hierarchy, selection/current, project/info, project/settings, logs/recent)
 - [x] Batch 5: Editor dock panel with setup status
-- [x] Batch 6: Test harness (44 Godot-side + 81 Python = 125 total tests)
+- [x] Batch 6: Test harness (44 Godot-side + 140 Python = 184 total tests)
 - [x] Pagination for large results (offset/limit on scene_get_hierarchy, logs_read, node_find, filesystem_search)
+- [x] Handler/runtime abstraction layer (shared handlers depend on Runtime protocol, not FastMCP context)
+- [x] Codex client configurator (TOML config at `~/.codex/config.toml`)
+- [x] `reload_plugin` tool — triggers live plugin reload, waits for new session via Future-based waiter
+- [x] ASGI reloadable entrypoint (`--reload` uses uvicorn factory path for Python auto-reload)
+- [x] Dev server start/stop controls in Godot dock panel
+- [x] Reload smoke test in CI (creates node, reloads plugin, verifies log buffer fresh + scene tree survived)
 - [ ] Manual test: Claude describes the open scene
 
 ---
@@ -500,10 +507,12 @@ Run on every push and PR. Three-tier matrix:
 - Runs on release tags only (not every push)
 
 **Setup tasks:**
-- [ ] Create `.github/workflows/ci.yml` with Tier 1 (Python tests)
-- [ ] Add Tier 2 with Godot headless (investigate `chickensoft-games/setup-godot` action)
-- [ ] Add Tier 3 for release smoke tests
-- [ ] Add status badges to README
+- [x] Create `.github/workflows/ci.yml` with Tier 1 (Python tests) — 6 jobs: 3 OS x 2 Python versions
+- [x] Add Tier 2 with Godot headless — 3 jobs: Linux (Docker), macOS, Windows using `chickensoft-games/setup-godot`
+- [x] Add reload smoke test to Tier 2 (reload_plugin e2e on all 3 OSes)
+- [x] Add Codecov integration with patch coverage check
+- [x] Add status badges to README
+- [ ] Add Tier 3 for release smoke tests (uvx install path)
 
 ---
 

--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -279,9 +279,7 @@ static func _read_codex_config() -> String:
 
 static func _write_codex_config(content: String) -> bool:
 	var config_path := _get_codex_config_path()
-	var dir_path := config_path.get_base_dir()
-	if not DirAccess.dir_exists_absolute(dir_path):
-		DirAccess.make_dir_recursive_absolute(dir_path)
+	DirAccess.make_dir_recursive_absolute(config_path.get_base_dir())
 	var file := FileAccess.open(config_path, FileAccess.WRITE)
 	if file == null:
 		return false

--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -2,10 +2,10 @@
 class_name McpClientConfigurator
 extends RefCounted
 
-## Configures MCP clients (Claude Code, Antigravity, etc.) to connect to
+## Configures MCP clients (Claude Code, Codex, Antigravity, etc.) to connect to
 ## the Godot MCP Studio server.
 
-enum ClientType { CLAUDE_CODE, ANTIGRAVITY }
+enum ClientType { CLAUDE_CODE, CODEX, ANTIGRAVITY }
 enum ConfigStatus { NOT_CONFIGURED, CONFIGURED, ERROR }
 
 const SERVER_NAME := "godot-ai"
@@ -16,6 +16,7 @@ const SERVER_HTTP_URL := "http://127.0.0.1:%d/mcp" % SERVER_HTTP_PORT
 ## Map client name strings to enum values.
 const CLIENT_TYPE_MAP := {
 	"claude_code": ClientType.CLAUDE_CODE,
+	"codex": ClientType.CODEX,
 	"antigravity": ClientType.ANTIGRAVITY,
 }
 
@@ -24,6 +25,8 @@ static func configure(client: ClientType) -> Dictionary:
 	match client:
 		ClientType.CLAUDE_CODE:
 			return _configure_claude_code()
+		ClientType.CODEX:
+			return _configure_codex()
 		ClientType.ANTIGRAVITY:
 			return _configure_antigravity()
 	return {"status": "error", "message": "Unknown client type"}
@@ -33,6 +36,8 @@ static func check_status(client: ClientType) -> ConfigStatus:
 	match client:
 		ClientType.CLAUDE_CODE:
 			return _check_claude_code()
+		ClientType.CODEX:
+			return _check_codex()
 		ClientType.ANTIGRAVITY:
 			return _check_antigravity()
 	return ConfigStatus.NOT_CONFIGURED
@@ -42,6 +47,8 @@ static func remove(client: ClientType) -> Dictionary:
 	match client:
 		ClientType.CLAUDE_CODE:
 			return _remove_claude_code()
+		ClientType.CODEX:
+			return _remove_codex()
 		ClientType.ANTIGRAVITY:
 			return _remove_antigravity()
 	return {"status": "error", "message": "Unknown client type"}
@@ -237,6 +244,178 @@ static func _remove_claude_code() -> Dictionary:
 		return {"status": "ok", "message": "Claude Code configuration removed"}
 	var err_msg: String = output[0].strip_edges() if output.size() > 0 else "Unknown error"
 	return {"status": "error", "message": "Failed to remove: %s" % err_msg}
+
+
+# --- Codex ---
+
+static func _get_codex_config_path() -> String:
+	return OS.get_environment("HOME").path_join(".codex/config.toml")
+
+
+static func _codex_server_header() -> String:
+	return "[mcp_servers.\"%s\"]" % SERVER_NAME
+
+
+static func _codex_legacy_server_header() -> String:
+	return "[mcp_servers.%s]" % SERVER_NAME.replace("-", "_")
+
+
+static func _codex_server_prefixes() -> Array[String]:
+	return [
+		"[mcp_servers.\"%s\"" % SERVER_NAME,
+		"[mcp_servers.%s" % SERVER_NAME.replace("-", "_"),
+	]
+
+
+static func _read_codex_config() -> String:
+	var config_path := _get_codex_config_path()
+	var file := FileAccess.open(config_path, FileAccess.READ)
+	if file == null:
+		return ""
+	var content := file.get_as_text()
+	file.close()
+	return content
+
+
+static func _write_codex_config(content: String) -> bool:
+	var config_path := _get_codex_config_path()
+	var dir_path := config_path.get_base_dir()
+	if not DirAccess.dir_exists_absolute(dir_path):
+		DirAccess.make_dir_recursive_absolute(dir_path)
+	var file := FileAccess.open(config_path, FileAccess.WRITE)
+	if file == null:
+		return false
+	file.store_string(content)
+	file.close()
+	return true
+
+
+static func _split_lines(content: String) -> Array[String]:
+	var lines: Array[String] = []
+	for line in content.split("\n"):
+		lines.append(line)
+	return lines
+
+
+static func _find_codex_server_section(lines: Array[String]) -> Dictionary:
+	var headers := [_codex_server_header(), _codex_legacy_server_header()]
+	for i in range(lines.size()):
+		var trimmed := lines[i].strip_edges()
+		if headers.has(trimmed):
+			var end := lines.size()
+			for j in range(i + 1, lines.size()):
+				var next_trimmed := lines[j].strip_edges()
+				if next_trimmed.begins_with("[") and next_trimmed.ends_with("]"):
+					end = j
+					break
+			return {"start": i, "end": end}
+	return {}
+
+
+static func _is_codex_server_section_header(trimmed: String) -> bool:
+	for prefix in _codex_server_prefixes():
+		if trimmed.begins_with(prefix):
+			return true
+	return false
+
+
+static func _join_lines(lines: Array[String]) -> String:
+	return "\n".join(lines)
+
+
+static func _configure_codex() -> Dictionary:
+	var content := _read_codex_config()
+	var lines := _split_lines(content)
+	var section := _find_codex_server_section(lines)
+	var server_lines: Array[String] = [
+		_codex_server_header(),
+		"url = \"%s\"" % SERVER_HTTP_URL,
+		"enabled = true",
+	]
+
+	if section.is_empty():
+		if not lines.is_empty() and not lines[-1].strip_edges().is_empty():
+			lines.append("")
+		lines.append_array(server_lines)
+	else:
+		var start: int = section["start"]
+		var end: int = section["end"]
+		var filtered_body: Array[String] = []
+		for i in range(start + 1, end):
+			var trimmed := lines[i].strip_edges()
+			if trimmed.begins_with("url ="):
+				continue
+			if trimmed.begins_with("enabled ="):
+				continue
+			filtered_body.append(lines[i])
+
+		var updated: Array[String] = []
+		updated.append_array(lines.slice(0, start))
+		updated.append_array(server_lines)
+		updated.append_array(filtered_body)
+		updated.append_array(lines.slice(end))
+		lines = updated
+
+	if not _write_codex_config(_join_lines(lines)):
+		return {"status": "error", "message": "Cannot write to %s" % _get_codex_config_path()}
+	return {"status": "ok", "message": "Codex configured (HTTP: %s)" % SERVER_HTTP_URL}
+
+
+static func _check_codex() -> ConfigStatus:
+	var content := _read_codex_config()
+	if content.is_empty():
+		return ConfigStatus.NOT_CONFIGURED
+
+	var lines := _split_lines(content)
+	var section := _find_codex_server_section(lines)
+	if section.is_empty():
+		return ConfigStatus.NOT_CONFIGURED
+
+	var start: int = section["start"]
+	var end: int = section["end"]
+	var configured_url := ""
+	var enabled := true
+	for i in range(start + 1, end):
+		var trimmed := lines[i].strip_edges()
+		if trimmed.begins_with("url ="):
+			var first_quote := trimmed.find("\"")
+			var last_quote := trimmed.rfind("\"")
+			if first_quote >= 0 and last_quote > first_quote:
+				configured_url = trimmed.substr(first_quote + 1, last_quote - first_quote - 1)
+		elif trimmed.begins_with("enabled ="):
+			enabled = trimmed.to_lower().find("false") < 0
+
+	if configured_url != SERVER_HTTP_URL:
+		return ConfigStatus.NOT_CONFIGURED
+	if not enabled:
+		return ConfigStatus.NOT_CONFIGURED
+	return ConfigStatus.CONFIGURED
+
+
+static func _remove_codex() -> Dictionary:
+	var content := _read_codex_config()
+	if content.is_empty():
+		return {"status": "ok", "message": "Not configured"}
+
+	var lines := _split_lines(content)
+	var updated: Array[String] = []
+	var i := 0
+	while i < lines.size():
+		var trimmed := lines[i].strip_edges()
+		if _is_codex_server_section_header(trimmed):
+			i += 1
+			while i < lines.size():
+				var next_trimmed := lines[i].strip_edges()
+				if next_trimmed.begins_with("[") and next_trimmed.ends_with("]"):
+					break
+				i += 1
+			continue
+		updated.append(lines[i])
+		i += 1
+
+	if not _write_codex_config(_join_lines(updated)):
+		return {"status": "error", "message": "Cannot write to %s" % _get_codex_config_path()}
+	return {"status": "ok", "message": "Codex configuration removed"}
 
 
 # --- Antigravity ---

--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -249,7 +249,10 @@ static func _remove_claude_code() -> Dictionary:
 # --- Codex ---
 
 static func _get_codex_config_path() -> String:
-	return OS.get_environment("HOME").path_join(".codex/config.toml")
+	var home := OS.get_environment("HOME")
+	if home.is_empty():
+		home = OS.get_environment("USERPROFILE")
+	return home.path_join(".codex/config.toml")
 
 
 static func _codex_server_header() -> String:

--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -42,3 +42,12 @@ func get_logs(params: Dictionary) -> Dictionary:
 			"returned_count": lines.size(),
 		}
 	}
+
+
+func reload_plugin(_params: Dictionary) -> Dictionary:
+	_log_buffer.log("reload_plugin requested, reloading next frame")
+	(func():
+		EditorInterface.set_plugin_enabled("res://addons/godot_ai/plugin.cfg", false)
+		EditorInterface.set_plugin_enabled("res://addons/godot_ai/plugin.cfg", true)
+	).call_deferred()
+	return {"data": {"status": "reloading", "message": "Plugin reload initiated"}}

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -6,6 +6,7 @@ extends VBoxContainer
 
 var _connection: Connection
 var _log_buffer: McpLogBuffer
+var _plugin: EditorPlugin
 
 var _status_icon: ColorRect
 var _status_label: Label
@@ -19,14 +20,16 @@ var _last_connected := false
 
 # Setup UI
 var _setup_container: VBoxContainer
+var _dev_server_btn: Button
 
 # Client config UI
 var _client_rows: Dictionary = {}  # client_name -> {status_label, button}
 
 
-func setup(connection: Connection, log_buffer: McpLogBuffer) -> void:
+func setup(connection: Connection, log_buffer: McpLogBuffer, plugin: EditorPlugin) -> void:
 	_connection = connection
 	_log_buffer = log_buffer
+	_plugin = plugin
 
 
 func _ready() -> void:
@@ -178,6 +181,8 @@ func _update_status() -> void:
 		_status_label.text = "Disconnected"
 		_session_label.text = ""
 
+	_update_dev_server_btn()
+
 
 func _update_log() -> void:
 	if _log_buffer == null:
@@ -215,10 +220,16 @@ func _refresh_setup_status() -> void:
 	# Clear previous indicators
 	for child in _setup_container.get_children():
 		child.queue_free()
+	_dev_server_btn = null
 
 	var is_dev := McpClientConfigurator.is_dev_checkout()
 	if is_dev:
 		_setup_container.add_child(_make_status_row("Mode", "Dev (venv)", Color.CYAN))
+		_dev_server_btn = Button.new()
+		_dev_server_btn.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		_dev_server_btn.pressed.connect(_on_dev_server_pressed)
+		_update_dev_server_btn()
+		_setup_container.add_child(_dev_server_btn)
 		return
 
 	# User mode — check for uv
@@ -253,6 +264,26 @@ func _make_status_row(label_text: String, value_text: String, value_color: Color
 	row.add_child(value)
 
 	return row
+
+
+func _update_dev_server_btn() -> void:
+	if _dev_server_btn == null:
+		return
+	if _plugin and _plugin.is_dev_server_running():
+		_dev_server_btn.text = "Stop Dev Server"
+	else:
+		_dev_server_btn.text = "Start Dev Server"
+
+
+func _on_dev_server_pressed() -> void:
+	if _plugin == null:
+		return
+	if _plugin.is_dev_server_running():
+		_plugin.stop_dev_server()
+	else:
+		_plugin.start_dev_server()
+	# Defer UI update to let port state settle
+	_update_dev_server_btn.call_deferred()
 
 
 func _on_install_uv() -> void:

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -114,34 +114,31 @@ func _stop_server() -> void:
 		_server_pid = -1
 
 
-func start_dev_server() -> bool:
+func start_dev_server() -> void:
 	## Start a dev server with --reload that survives plugin reloads.
-	## Kills any managed server first.
+	## Kills any managed server first, waits for the port to free, then spawns.
 	_stop_server()
-	# Small delay to let the port free up
-	await get_tree().create_timer(0.5).timeout
+	get_tree().create_timer(0.5).timeout.connect(func():
+		var server_cmd := McpClientConfigurator.get_server_command()
+		if server_cmd.is_empty():
+			push_warning("MCP | could not find server command for dev server")
+			return
 
-	var server_cmd := McpClientConfigurator.get_server_command()
-	if server_cmd.is_empty():
-		push_warning("MCP | could not find server command for dev server")
-		return false
+		var cmd: String = server_cmd[0]
+		var inner_args: Array[String] = []
+		inner_args.assign(server_cmd.slice(1))
+		inner_args.append_array([
+			"--transport", "streamable-http",
+			"--port", str(McpClientConfigurator.SERVER_HTTP_PORT),
+			"--reload",
+		])
 
-	var cmd: String = server_cmd[0]
-	var args: Array[String] = []
-	args.assign(server_cmd.slice(1))
-	args.append_array([
-		"--transport", "streamable-http",
-		"--port", str(McpClientConfigurator.SERVER_HTTP_PORT),
-		"--reload",
-	])
-
-	var pid := OS.create_process(cmd, args)
-	if pid > 0:
-		print("MCP | started dev server with --reload (PID %d): %s %s" % [pid, cmd, " ".join(args)])
-		return true
-	else:
-		push_warning("MCP | failed to start dev server")
-		return false
+		var pid := OS.create_process(cmd, inner_args)
+		if pid > 0:
+			print("MCP | started dev server with --reload (PID %d): %s %s" % [pid, cmd, " ".join(inner_args)])
+		else:
+			push_warning("MCP | failed to start dev server")
+	)
 
 
 func stop_dev_server() -> void:
@@ -155,7 +152,7 @@ func stop_dev_server() -> void:
 	var port := McpClientConfigurator.SERVER_HTTP_PORT
 	if OS.get_name() == "Windows":
 		# Find PID listening on port, then kill
-		var exit_code := OS.execute("cmd", ["/c", "for /f \"tokens=5\" %a in ('netstat -ano ^| findstr :%d ^| findstr LISTENING') do taskkill /PID %a /F" % port], output, true)
+		var exit_code := OS.execute("cmd", ["/c", "for /f \"tokens=5\" %%a in ('netstat -ano ^| findstr :%d ^| findstr LISTENING') do taskkill /PID %%a /F" % port], output, true)
 		if exit_code == 0:
 			print("MCP | stopped dev server on port %d" % port)
 	else:

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -52,7 +52,7 @@ func _enter_tree() -> void:
 	_dock.setup(_connection, _log_buffer, self)
 	add_control_to_dock(DOCK_SLOT_RIGHT_BL, _dock)
 
-	_log_buffer.log("plugin loaded [reload-smoke]")
+	_log_buffer.log("plugin loaded")
 
 
 func _exit_tree() -> void:

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -33,6 +33,7 @@ func _enter_tree() -> void:
 	_dispatcher.register("get_children", node_handler.get_children)
 	_dispatcher.register("get_groups", node_handler.get_groups)
 	_dispatcher.register("get_logs", editor_handler.get_logs)
+	_dispatcher.register("reload_plugin", editor_handler.reload_plugin)
 	_dispatcher.register("get_project_setting", project_handler.get_project_setting)
 	_dispatcher.register("search_filesystem", project_handler.search_filesystem)
 	_dispatcher.register("configure_client", client_handler.configure_client)
@@ -48,10 +49,10 @@ func _enter_tree() -> void:
 	# Dock panel
 	_dock = McpDock.new()
 	_dock.name = "Godot AI"
-	_dock.setup(_connection, _log_buffer)
+	_dock.setup(_connection, _log_buffer, self)
 	add_control_to_dock(DOCK_SLOT_RIGHT_BL, _dock)
 
-	_log_buffer.log("plugin loaded")
+	_log_buffer.log("plugin loaded [reload-smoke]")
 
 
 func _exit_tree() -> void:
@@ -111,3 +112,58 @@ func _stop_server() -> void:
 		OS.kill(_server_pid)
 		print("MCP | stopped server (PID %d)" % _server_pid)
 		_server_pid = -1
+
+
+func start_dev_server() -> bool:
+	## Start a dev server with --reload that survives plugin reloads.
+	## Kills any managed server first.
+	_stop_server()
+	# Small delay to let the port free up
+	await get_tree().create_timer(0.5).timeout
+
+	var server_cmd := McpClientConfigurator.get_server_command()
+	if server_cmd.is_empty():
+		push_warning("MCP | could not find server command for dev server")
+		return false
+
+	var cmd: String = server_cmd[0]
+	var args: Array[String] = []
+	args.assign(server_cmd.slice(1))
+	args.append_array([
+		"--transport", "streamable-http",
+		"--port", str(McpClientConfigurator.SERVER_HTTP_PORT),
+		"--reload",
+	])
+
+	var pid := OS.create_process(cmd, args)
+	if pid > 0:
+		print("MCP | started dev server with --reload (PID %d): %s %s" % [pid, cmd, " ".join(args)])
+		return true
+	else:
+		push_warning("MCP | failed to start dev server")
+		return false
+
+
+func stop_dev_server() -> void:
+	## Stop any server running on the HTTP port (by port, not PID).
+	## Used for dev servers whose PID we don't track across reloads.
+	if _server_pid > 0:
+		# We have a managed server — use normal stop
+		_stop_server()
+		return
+	var output: Array = []
+	var port := McpClientConfigurator.SERVER_HTTP_PORT
+	if OS.get_name() == "Windows":
+		# Find PID listening on port, then kill
+		var exit_code := OS.execute("cmd", ["/c", "for /f \"tokens=5\" %a in ('netstat -ano ^| findstr :%d ^| findstr LISTENING') do taskkill /PID %a /F" % port], output, true)
+		if exit_code == 0:
+			print("MCP | stopped dev server on port %d" % port)
+	else:
+		var exit_code := OS.execute("bash", ["-c", "lsof -ti:%d -sTCP:LISTEN | xargs kill 2>/dev/null" % port], output, true)
+		if exit_code == 0:
+			print("MCP | stopped dev server on port %d" % port)
+
+
+func is_dev_server_running() -> bool:
+	## Returns true if a server is running on the HTTP port that we didn't start as managed.
+	return _server_pid <= 0 and _is_port_in_use(McpClientConfigurator.SERVER_HTTP_PORT)

--- a/script/ci-reload-test
+++ b/script/ci-reload-test
@@ -1,12 +1,44 @@
 #!/usr/bin/env bash
 # Smoke-test the reload_plugin tool in CI.
-# Calls reload_plugin via MCP, waits for the new session, then verifies
-# the plugin is alive by calling editor_state.
+# 1. Creates a node (cube) via the OLD plugin
+# 2. Reloads the plugin, verifies new session ID
+# 3. Checks the log buffer is fresh (proves handlers were rebuilt)
+# 4. Finds the cube via the NEW plugin (proves scene tree continuity)
+#
 # Expects: Python server running on port 8000, Godot editor with plugin connected.
 set -euo pipefail
 
 SERVER_URL="http://127.0.0.1:8000/mcp"
 HEADERS=(-H "Content-Type: application/json" -H "Accept: application/json, text/event-stream")
+REQ_ID=0
+
+# Helper: call an MCP tool and return the parsed content JSON.
+# Usage: mcp_call <tool_name> '<json_arguments>'
+# Prints the parsed content to stdout. Exits 1 on failure.
+mcp_call() {
+  local tool="$1"
+  local args="${2:-\{\}}"
+  REQ_ID=$((REQ_ID + 1))
+  local raw
+  raw=$(curl -s --max-time 30 "$SERVER_URL" -X POST "${HEADERS[@]}" \
+    -H "Mcp-Session-Id: $SESSION_ID" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":$REQ_ID,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args}}")
+  echo "$raw" | python3 -c "
+import json, sys
+raw = sys.stdin.read()
+for line in raw.split('\n'):
+    if line.startswith('data: '):
+        data = json.loads(line[6:])
+        content = data.get('result', {}).get('structuredContent', {})
+        if not content:
+            text = data.get('result', {}).get('content', [{}])[0].get('text', '{}')
+            content = json.loads(text)
+        print(json.dumps(content))
+        sys.exit(0)
+print('{}')
+sys.exit(1)
+"
+}
 
 # Initialize MCP session
 echo "Initializing MCP session..."
@@ -23,69 +55,84 @@ curl -s "$SERVER_URL" -X POST "${HEADERS[@]}" \
   -H "Mcp-Session-Id: $SESSION_ID" \
   -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' > /dev/null
 
-# Call reload_plugin (may take several seconds while plugin restarts)
-echo "Calling reload_plugin..."
-RELOAD_RESULT=$(curl -s --max-time 30 "$SERVER_URL" -X POST "${HEADERS[@]}" \
-  -H "Mcp-Session-Id: $SESSION_ID" \
-  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"reload_plugin","arguments":{}}}')
-
-# Parse reload result
-echo "$RELOAD_RESULT" | python3 -c "
+# --- Step 1: Create a cube with the OLD plugin ---
+echo "Creating test node with old plugin..."
+CREATE_RESULT=$(mcp_call node_create '{"type":"MeshInstance3D","name":"ReloadTestCube","parent_path":""}')
+echo "$CREATE_RESULT" | python3 -c "
 import json, sys
-raw = sys.stdin.read()
-for line in raw.split('\n'):
-    if line.startswith('data: '):
-        data = json.loads(line[6:])
-        content = data.get('result', {}).get('structuredContent', {})
-        if not content:
-            text = data.get('result', {}).get('content', [{}])[0].get('text', '{}')
-            content = json.loads(text)
-        status = content.get('status', '')
-        old_id = content.get('old_session_id', '')
-        new_id = content.get('new_session_id', '')
-        if status != 'reloaded':
-            print(f'FAIL: reload_plugin returned status={status!r}, expected \"reloaded\"')
-            print(f'Full response: {content}')
-            sys.exit(1)
-        if old_id == new_id:
-            print(f'FAIL: old and new session IDs are the same: {old_id}')
-            sys.exit(1)
-        print(f'reload_plugin OK: {old_id[:12]}... -> {new_id[:12]}...')
-        break
-else:
-    print('FAIL: No valid response from reload_plugin')
-    print(f'Raw: {raw[:500]}')
+content = json.loads(sys.stdin.read())
+path = content.get('path', '')
+if not path:
+    print(f'FAIL: node_create did not return a path: {content}')
     sys.exit(1)
+print(f'Created node: {path}')
 "
 
-# Verify the plugin is alive after reload
-echo "Verifying plugin health..."
-HEALTH_RESULT=$(curl -s --max-time 10 "$SERVER_URL" -X POST "${HEADERS[@]}" \
-  -H "Mcp-Session-Id: $SESSION_ID" \
-  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"editor_state","arguments":{}}}')
+# --- Step 2: Reload the plugin ---
+echo "Calling reload_plugin..."
+RELOAD_RESULT=$(mcp_call reload_plugin)
+echo "$RELOAD_RESULT" | python3 -c "
+import json, sys
+content = json.loads(sys.stdin.read())
+status = content.get('status', '')
+old_id = content.get('old_session_id', '')
+new_id = content.get('new_session_id', '')
+if status != 'reloaded':
+    print(f'FAIL: reload_plugin returned status={status!r}, expected \"reloaded\"')
+    print(f'Full response: {content}')
+    sys.exit(1)
+if old_id == new_id:
+    print(f'FAIL: old and new session IDs are the same: {old_id}')
+    sys.exit(1)
+print(f'reload_plugin OK: {old_id[:12]}... -> {new_id[:12]}...')
+"
 
+# --- Step 3: Verify log buffer is fresh (proves plugin fully rebuilt) ---
+echo "Checking log buffer..."
+LOGS_RESULT=$(mcp_call logs_read '{"count":20}')
+echo "$LOGS_RESULT" | python3 -c "
+import json, sys
+content = json.loads(sys.stdin.read())
+lines = content.get('lines', [])
+total = content.get('total_count', -1)
+if not lines:
+    print('FAIL: logs_read returned no lines after reload')
+    sys.exit(1)
+if 'plugin loaded' not in lines[0]:
+    print(f'FAIL: first log line should be \"plugin loaded\", got: {lines[0]!r}')
+    sys.exit(1)
+if total > 20:
+    print(f'WARN: log buffer has {total} lines — expected a small fresh buffer')
+print(f'Log buffer OK: {total} lines, starts with \"{lines[0]}\"')
+"
+
+# --- Step 4: Find the cube with the NEW plugin (scene tree survived) ---
+echo "Finding test node with new plugin..."
+FIND_RESULT=$(mcp_call node_find '{"name":"ReloadTestCube"}')
+echo "$FIND_RESULT" | python3 -c "
+import json, sys
+content = json.loads(sys.stdin.read())
+nodes = content.get('nodes', [])
+if not nodes:
+    print('FAIL: ReloadTestCube not found after reload — scene tree did not survive')
+    sys.exit(1)
+node = nodes[0]
+print(f'Found node: {node.get(\"name\", \"?\")} ({node.get(\"type\", \"?\")})')
+"
+
+# --- Step 5: Verify editor_state works ---
+echo "Verifying editor_state..."
+HEALTH_RESULT=$(mcp_call editor_state)
 echo "$HEALTH_RESULT" | python3 -c "
 import json, sys
-raw = sys.stdin.read()
-for line in raw.split('\n'):
-    if line.startswith('data: '):
-        data = json.loads(line[6:])
-        content = data.get('result', {}).get('structuredContent', {})
-        if not content:
-            text = data.get('result', {}).get('content', [{}])[0].get('text', '{}')
-            content = json.loads(text)
-        version = content.get('godot_version', '')
-        project = content.get('project_name', '')
-        if not version:
-            print(f'FAIL: editor_state missing godot_version after reload')
-            print(f'Full response: {content}')
-            sys.exit(1)
-        print(f'Post-reload health OK: {project} on Godot {version}')
-        break
-else:
-    print('FAIL: No valid response from editor_state after reload')
-    print(f'Raw: {raw[:500]}')
+content = json.loads(sys.stdin.read())
+version = content.get('godot_version', '')
+project = content.get('project_name', '')
+if not version:
+    print(f'FAIL: editor_state missing godot_version after reload')
+    print(f'Full response: {content}')
     sys.exit(1)
+print(f'Post-reload health OK: {project} on Godot {version}')
 "
 
 echo "Reload smoke test passed"

--- a/script/ci-reload-test
+++ b/script/ci-reload-test
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Smoke-test the reload_plugin tool in CI.
+# Calls reload_plugin via MCP, waits for the new session, then verifies
+# the plugin is alive by calling editor_state.
+# Expects: Python server running on port 8000, Godot editor with plugin connected.
+set -euo pipefail
+
+SERVER_URL="http://127.0.0.1:8000/mcp"
+HEADERS=(-H "Content-Type: application/json" -H "Accept: application/json, text/event-stream")
+
+# Initialize MCP session
+echo "Initializing MCP session..."
+SESSION_ID=$(curl -si "$SERVER_URL" -X POST "${HEADERS[@]}" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"ci-reload","version":"1.0"}}}' \
+  2>&1 | grep -i 'mcp-session-id' | tr -d '\r' | awk '{print $2}')
+
+if [ -z "$SESSION_ID" ]; then
+  echo "ERROR: Could not initialize MCP session"
+  exit 1
+fi
+
+curl -s "$SERVER_URL" -X POST "${HEADERS[@]}" \
+  -H "Mcp-Session-Id: $SESSION_ID" \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' > /dev/null
+
+# Call reload_plugin (may take several seconds while plugin restarts)
+echo "Calling reload_plugin..."
+RELOAD_RESULT=$(curl -s --max-time 30 "$SERVER_URL" -X POST "${HEADERS[@]}" \
+  -H "Mcp-Session-Id: $SESSION_ID" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"reload_plugin","arguments":{}}}')
+
+# Parse reload result
+echo "$RELOAD_RESULT" | python3 -c "
+import json, sys
+raw = sys.stdin.read()
+for line in raw.split('\n'):
+    if line.startswith('data: '):
+        data = json.loads(line[6:])
+        content = data.get('result', {}).get('structuredContent', {})
+        if not content:
+            text = data.get('result', {}).get('content', [{}])[0].get('text', '{}')
+            content = json.loads(text)
+        status = content.get('status', '')
+        old_id = content.get('old_session_id', '')
+        new_id = content.get('new_session_id', '')
+        if status != 'reloaded':
+            print(f'FAIL: reload_plugin returned status={status!r}, expected \"reloaded\"')
+            print(f'Full response: {content}')
+            sys.exit(1)
+        if old_id == new_id:
+            print(f'FAIL: old and new session IDs are the same: {old_id}')
+            sys.exit(1)
+        print(f'reload_plugin OK: {old_id[:12]}... -> {new_id[:12]}...')
+        break
+else:
+    print('FAIL: No valid response from reload_plugin')
+    print(f'Raw: {raw[:500]}')
+    sys.exit(1)
+"
+
+# Verify the plugin is alive after reload
+echo "Verifying plugin health..."
+HEALTH_RESULT=$(curl -s --max-time 10 "$SERVER_URL" -X POST "${HEADERS[@]}" \
+  -H "Mcp-Session-Id: $SESSION_ID" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"editor_state","arguments":{}}}')
+
+echo "$HEALTH_RESULT" | python3 -c "
+import json, sys
+raw = sys.stdin.read()
+for line in raw.split('\n'):
+    if line.startswith('data: '):
+        data = json.loads(line[6:])
+        content = data.get('result', {}).get('structuredContent', {})
+        if not content:
+            text = data.get('result', {}).get('content', [{}])[0].get('text', '{}')
+            content = json.loads(text)
+        version = content.get('godot_version', '')
+        project = content.get('project_name', '')
+        if not version:
+            print(f'FAIL: editor_state missing godot_version after reload')
+            print(f'Full response: {content}')
+            sys.exit(1)
+        print(f'Post-reload health OK: {project} on Godot {version}')
+        break
+else:
+    print('FAIL: No valid response from editor_state after reload')
+    print(f'Raw: {raw[:500]}')
+    sys.exit(1)
+"
+
+echo "Reload smoke test passed"

--- a/script/ci-reload-test
+++ b/script/ci-reload-test
@@ -12,12 +12,11 @@ SERVER_URL="http://127.0.0.1:8000/mcp"
 HEADERS=(-H "Content-Type: application/json" -H "Accept: application/json, text/event-stream")
 REQ_ID=0
 
-# Helper: call an MCP tool and return the parsed content JSON.
-# Usage: mcp_call <tool_name> '<json_arguments>'
-# Prints the parsed content to stdout. Exits 1 on failure.
+# Helper: call an MCP tool and extract the content JSON from the SSE response.
+# Prints parsed content to stdout; diagnostics to stderr. Returns 1 on failure.
 mcp_call() {
   local tool="$1"
-  local args="${2:-\{\}}"
+  local args="$2"
   REQ_ID=$((REQ_ID + 1))
   local raw
   raw=$(curl -s --max-time 30 "$SERVER_URL" -X POST "${HEADERS[@]}" \
@@ -29,15 +28,35 @@ raw = sys.stdin.read()
 for line in raw.split('\n'):
     if line.startswith('data: '):
         data = json.loads(line[6:])
-        content = data.get('result', {}).get('structuredContent', {})
+        result = data.get('result', {})
+        if result.get('isError'):
+            msg = result.get('content', [{}])[0].get('text', 'unknown error')
+            print(f'Tool error: {msg}', file=sys.stderr)
+            print('{}')
+            sys.exit(1)
+        content = result.get('structuredContent', {})
         if not content:
-            text = data.get('result', {}).get('content', [{}])[0].get('text', '{}')
+            text = result.get('content', [{}])[0].get('text', '{}')
             content = json.loads(text)
         print(json.dumps(content))
         sys.exit(0)
+print(f'No SSE data in response (first 500 chars): {raw[:500]}', file=sys.stderr)
 print('{}')
 sys.exit(1)
 "
+}
+
+# Helper: call mcp_call and capture output. On failure, print the captured output and exit.
+mcp_call_or_die() {
+  local label="$1"
+  shift
+  local result
+  if ! result=$(mcp_call "$@"); then
+    echo "FAIL at $label (tool: $1)"
+    echo "Captured output: $result"
+    exit 1
+  fi
+  echo "$result"
 }
 
 # Initialize MCP session
@@ -57,7 +76,7 @@ curl -s "$SERVER_URL" -X POST "${HEADERS[@]}" \
 
 # --- Step 1: Create a cube with the OLD plugin ---
 echo "Creating test node with old plugin..."
-CREATE_RESULT=$(mcp_call node_create '{"type":"MeshInstance3D","name":"ReloadTestCube","parent_path":""}')
+CREATE_RESULT=$(mcp_call_or_die "node_create" node_create '{"type":"MeshInstance3D","name":"ReloadTestCube","parent_path":""}')
 echo "$CREATE_RESULT" | python3 -c "
 import json, sys
 content = json.loads(sys.stdin.read())
@@ -70,7 +89,7 @@ print(f'Created node: {path}')
 
 # --- Step 2: Reload the plugin ---
 echo "Calling reload_plugin..."
-RELOAD_RESULT=$(mcp_call reload_plugin)
+RELOAD_RESULT=$(mcp_call_or_die "reload_plugin" reload_plugin '{}')
 echo "$RELOAD_RESULT" | python3 -c "
 import json, sys
 content = json.loads(sys.stdin.read())
@@ -89,7 +108,7 @@ print(f'reload_plugin OK: {old_id[:12]}... -> {new_id[:12]}...')
 
 # --- Step 3: Verify log buffer is fresh (proves plugin fully rebuilt) ---
 echo "Checking log buffer..."
-LOGS_RESULT=$(mcp_call logs_read '{"count":20}')
+LOGS_RESULT=$(mcp_call_or_die "logs_read" logs_read '{"count":20}')
 echo "$LOGS_RESULT" | python3 -c "
 import json, sys
 content = json.loads(sys.stdin.read())
@@ -108,7 +127,7 @@ print(f'Log buffer OK: {total} lines, starts with \"{lines[0]}\"')
 
 # --- Step 4: Find the cube with the NEW plugin (scene tree survived) ---
 echo "Finding test node with new plugin..."
-FIND_RESULT=$(mcp_call node_find '{"name":"ReloadTestCube"}')
+FIND_RESULT=$(mcp_call_or_die "node_find" node_find '{"name":"ReloadTestCube"}')
 echo "$FIND_RESULT" | python3 -c "
 import json, sys
 content = json.loads(sys.stdin.read())
@@ -122,7 +141,7 @@ print(f'Found node: {node.get(\"name\", \"?\")} ({node.get(\"type\", \"?\")})')
 
 # --- Step 5: Verify editor_state works ---
 echo "Verifying editor_state..."
-HEALTH_RESULT=$(mcp_call editor_state)
+HEALTH_RESULT=$(mcp_call_or_die "editor_state" editor_state '{}')
 echo "$HEALTH_RESULT" | python3 -c "
 import json, sys
 content = json.loads(sys.stdin.read())

--- a/src/godot_ai/__init__.py
+++ b/src/godot_ai/__init__.py
@@ -1,11 +1,14 @@
 """Godot AI — production-grade Godot MCP server."""
 
+from __future__ import annotations
+
 import argparse
+from collections.abc import Sequence
 
 __version__ = "0.0.1"
 
 
-def main():
+def main(argv: Sequence[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Godot AI server")
     parser.add_argument(
         "--transport",
@@ -24,7 +27,13 @@ def main():
         action="store_true",
         help="Auto-restart on source changes (dev mode, HTTP transports only)",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
+
+    if args.reload and args.transport in ("sse", "streamable-http"):
+        from godot_ai.asgi import run_with_reload
+
+        run_with_reload(transport=args.transport, port=args.port, ws_port=args.ws_port)
+        return
 
     from godot_ai.server import create_server
 
@@ -33,10 +42,5 @@ def main():
     transport_kwargs = {}
     if args.transport in ("sse", "streamable-http"):
         transport_kwargs["port"] = args.port
-        if args.reload:
-            transport_kwargs["uvicorn_config"] = {
-                "reload": True,
-                "reload_dirs": ["src"],
-            }
 
     server.run(transport=args.transport, **transport_kwargs)

--- a/src/godot_ai/asgi.py
+++ b/src/godot_ai/asgi.py
@@ -1,0 +1,59 @@
+"""ASGI factory and dev runner for reloadable HTTP transports."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import fastmcp
+import uvicorn
+
+DEV_TRANSPORT_ENV = "GODOT_AI_DEV_TRANSPORT"
+DEV_WS_PORT_ENV = "GODOT_AI_DEV_WS_PORT"
+RELOADABLE_TRANSPORTS = {"sse", "streamable-http"}
+
+
+def _get_dev_transport() -> str:
+    transport = os.environ.get(DEV_TRANSPORT_ENV, "streamable-http")
+    if transport not in RELOADABLE_TRANSPORTS:
+        raise ValueError(f"Unsupported dev transport: {transport}")
+    return transport
+
+
+def _get_dev_ws_port() -> int:
+    raw = os.environ.get(DEV_WS_PORT_ENV, "9500")
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise ValueError(f"Invalid {DEV_WS_PORT_ENV}: {raw}") from exc
+
+
+def create_app():
+    """Create the FastMCP ASGI app for uvicorn's reload supervisor."""
+    from godot_ai.server import create_server
+
+    server = create_server(ws_port=_get_dev_ws_port())
+    return server.http_app(transport=_get_dev_transport())
+
+
+def run_with_reload(*, transport: str, port: int, ws_port: int) -> None:
+    """Run the HTTP transport through uvicorn's supported reload path."""
+    if transport not in RELOADABLE_TRANSPORTS:
+        raise ValueError(f"Reload is only supported for HTTP transports, got {transport}")
+
+    os.environ[DEV_TRANSPORT_ENV] = transport
+    os.environ[DEV_WS_PORT_ENV] = str(ws_port)
+
+    src_dir = str(Path(__file__).resolve().parent.parent)
+    uvicorn.run(
+        "godot_ai.asgi:create_app",
+        factory=True,
+        host=fastmcp.settings.host,
+        port=port,
+        log_level=fastmcp.settings.log_level.lower(),
+        timeout_graceful_shutdown=2,
+        lifespan="on",
+        ws="websockets-sansio",
+        reload=True,
+        reload_dirs=[src_dir],
+    )

--- a/src/godot_ai/handlers/__init__.py
+++ b/src/godot_ai/handlers/__init__.py
@@ -1,0 +1,2 @@
+"""Shared handlers used by tool and resource wrappers."""
+

--- a/src/godot_ai/handlers/client.py
+++ b/src/godot_ai/handlers/client.py
@@ -1,0 +1,14 @@
+"""Shared handlers for client configuration tools."""
+
+from __future__ import annotations
+
+from godot_ai.runtime.interface import Runtime
+
+
+async def client_configure(runtime: Runtime, client: str) -> dict:
+    return await runtime.send_command("configure_client", {"client": client})
+
+
+async def client_status(runtime: Runtime) -> dict:
+    return await runtime.send_command("check_client_status")
+

--- a/src/godot_ai/handlers/editor.py
+++ b/src/godot_ai/handlers/editor.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import logging
 
 from godot_ai.runtime.interface import Runtime
@@ -46,33 +45,28 @@ async def reload_plugin(runtime: Runtime) -> dict:
         raise ConnectionError("No active Godot session")
     old_id = active.session_id
     known_ids = {session.session_id for session in runtime.list_sessions()}
-    deadline = asyncio.get_running_loop().time() + 15.0
 
     try:
         await runtime.send_command("reload_plugin", timeout=2.0)
     except (ConnectionError, TimeoutError) as exc:
         logger.debug("Expected disconnect during reload: %s", exc)
 
-    while True:
-        new_session = _find_replacement_session(
-            list(runtime.list_sessions()),
-            known_ids=known_ids,
-            project_path=active.project_path,
-        )
-        if new_session is not None:
-            runtime.set_active_session(new_session.session_id)
-            return {
-                "status": "reloaded",
-                "old_session_id": old_id,
-                "new_session_id": new_session.session_id,
-            }
+    # Check if a replacement session already appeared during the reload command
+    # (handles the race where the new session registers before we start waiting)
+    new_session = _find_replacement_session(
+        list(runtime.list_sessions()),
+        known_ids=known_ids,
+        project_path=active.project_path,
+    )
+    if new_session is None:
+        new_session = await runtime.wait_for_session(exclude_id=old_id, timeout=15.0)
 
-        if asyncio.get_running_loop().time() >= deadline:
-            raise TimeoutError(
-                f"Timed out waiting for reloaded session for project {active.project_path}"
-            )
-
-        await asyncio.sleep(0.05)
+    runtime.set_active_session(new_session.session_id)
+    return {
+        "status": "reloaded",
+        "old_session_id": old_id,
+        "new_session_id": new_session.session_id,
+    }
 
 
 async def selection_resource_data(runtime: Runtime) -> dict:

--- a/src/godot_ai/handlers/editor.py
+++ b/src/godot_ai/handlers/editor.py
@@ -1,0 +1,83 @@
+"""Shared handlers for editor tools and resources."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from godot_ai.runtime.interface import Runtime
+from godot_ai.sessions.registry import Session
+from godot_ai.tools._pagination import paginate
+
+logger = logging.getLogger(__name__)
+
+
+async def editor_state(runtime: Runtime) -> dict:
+    return await runtime.send_command("get_editor_state")
+
+
+async def editor_selection_get(runtime: Runtime) -> dict:
+    return await runtime.send_command("get_selection")
+
+
+async def logs_read(runtime: Runtime, count: int = 50, offset: int = 0) -> dict:
+    result = await runtime.send_command("get_logs", {"count": 500})
+    lines = result.get("lines", [])
+    return paginate(lines, offset, count, key="lines")
+
+
+def _find_replacement_session(
+    sessions: list[Session],
+    known_ids: set[str],
+    project_path: str,
+) -> Session | None:
+    for session in sessions:
+        if session.session_id in known_ids:
+            continue
+        if session.project_path != project_path:
+            continue
+        return session
+    return None
+
+
+async def reload_plugin(runtime: Runtime) -> dict:
+    active = runtime.get_active_session()
+    if active is None:
+        raise ConnectionError("No active Godot session")
+    old_id = active.session_id
+    known_ids = {session.session_id for session in runtime.list_sessions()}
+    deadline = asyncio.get_running_loop().time() + 15.0
+
+    try:
+        await runtime.send_command("reload_plugin", timeout=2.0)
+    except (ConnectionError, TimeoutError) as exc:
+        logger.debug("Expected disconnect during reload: %s", exc)
+
+    while True:
+        new_session = _find_replacement_session(
+            list(runtime.list_sessions()),
+            known_ids=known_ids,
+            project_path=active.project_path,
+        )
+        if new_session is not None:
+            runtime.set_active_session(new_session.session_id)
+            return {
+                "status": "reloaded",
+                "old_session_id": old_id,
+                "new_session_id": new_session.session_id,
+            }
+
+        if asyncio.get_running_loop().time() >= deadline:
+            raise TimeoutError(
+                f"Timed out waiting for reloaded session for project {active.project_path}"
+            )
+
+        await asyncio.sleep(0.05)
+
+
+async def selection_resource_data(runtime: Runtime) -> dict:
+    return await editor_selection_get(runtime)
+
+
+async def logs_resource_data(runtime: Runtime) -> dict:
+    return await runtime.send_command("get_logs", {"count": 100})

--- a/src/godot_ai/handlers/node.py
+++ b/src/godot_ai/handlers/node.py
@@ -1,0 +1,41 @@
+"""Shared handlers for node tools."""
+
+from __future__ import annotations
+
+from godot_ai.runtime.interface import Runtime
+from godot_ai.tools._pagination import paginate
+
+
+async def node_create(runtime: Runtime, type: str, name: str = "", parent_path: str = "") -> dict:
+    return await runtime.send_command(
+        "create_node",
+        {"type": type, "name": name, "parent_path": parent_path},
+    )
+
+
+async def node_find(
+    runtime: Runtime,
+    name: str = "",
+    type: str = "",
+    group: str = "",
+    offset: int = 0,
+    limit: int = 100,
+) -> dict:
+    result = await runtime.send_command(
+        "find_nodes",
+        {"name": name, "type": type, "group": group},
+    )
+    return paginate(result.get("nodes", []), offset, limit, key="nodes")
+
+
+async def node_get_properties(runtime: Runtime, path: str) -> dict:
+    return await runtime.send_command("get_node_properties", {"path": path})
+
+
+async def node_get_children(runtime: Runtime, path: str) -> dict:
+    return await runtime.send_command("get_children", {"path": path})
+
+
+async def node_get_groups(runtime: Runtime, path: str) -> dict:
+    return await runtime.send_command("get_groups", {"path": path})
+

--- a/src/godot_ai/handlers/project.py
+++ b/src/godot_ai/handlers/project.py
@@ -1,0 +1,72 @@
+"""Shared handlers for project tools and resources."""
+
+from __future__ import annotations
+
+import asyncio
+
+from godot_ai.runtime.interface import Runtime
+from godot_ai.tools._pagination import paginate
+
+COMMON_SETTINGS = [
+    "application/config/name",
+    "application/config/description",
+    "application/run/main_scene",
+    "display/window/size/viewport_width",
+    "display/window/size/viewport_height",
+    "rendering/renderer/rendering_method",
+    "physics/2d/default_gravity",
+    "physics/3d/default_gravity",
+]
+
+
+async def project_settings_get(runtime: Runtime, key: str) -> dict:
+    return await runtime.send_command("get_project_setting", {"key": key})
+
+
+async def filesystem_search(
+    runtime: Runtime,
+    name: str = "",
+    type: str = "",
+    path: str = "",
+    offset: int = 0,
+    limit: int = 100,
+) -> dict:
+    params: dict[str, str] = {}
+    if name:
+        params["name"] = name
+    if type:
+        params["type"] = type
+    if path:
+        params["path"] = path
+    result = await runtime.send_command("search_filesystem", params)
+    return paginate(result.get("files", []), offset, limit, key="files")
+
+
+def project_info_resource_data(runtime: Runtime) -> dict:
+    session = runtime.get_active_session()
+    if session is None:
+        return {"error": "No active Godot session", "connected": False}
+
+    info = session.to_dict()
+    info.pop("connected_at", None)
+    return info
+
+
+async def project_settings_resource_data(runtime: Runtime) -> dict:
+    async def _fetch(key: str) -> tuple[str, object | None, str | None]:
+        try:
+            result = await runtime.send_command("get_project_setting", {"key": key})
+            return key, result.get("value"), None
+        except Exception as exc:
+            return key, None, str(exc)
+
+    results = await asyncio.gather(*[_fetch(key) for key in COMMON_SETTINGS])
+    settings: dict[str, object | None] = {}
+    errors: list[dict[str, str]] = []
+    for key, value, error in results:
+        if error:
+            errors.append({"key": key, "error": error})
+        else:
+            settings[key] = value
+    return {"settings": settings, "errors": errors if errors else None}
+

--- a/src/godot_ai/handlers/scene.py
+++ b/src/godot_ai/handlers/scene.py
@@ -1,0 +1,35 @@
+"""Shared handlers for scene tools and resources."""
+
+from __future__ import annotations
+
+from godot_ai.runtime.interface import Runtime
+from godot_ai.tools._pagination import paginate
+
+
+async def scene_get_hierarchy(
+    runtime: Runtime,
+    depth: int = 10,
+    offset: int = 0,
+    limit: int = 100,
+) -> dict:
+    result = await runtime.send_command("get_scene_tree", {"depth": depth})
+    nodes = result.get("nodes", [])
+    return {"root": result.get("root", ""), **paginate(nodes, offset, limit, key="nodes")}
+
+
+async def scene_get_roots(runtime: Runtime) -> dict:
+    return await runtime.send_command("get_open_scenes")
+
+
+async def current_scene_resource_data(runtime: Runtime) -> dict:
+    state = await runtime.send_command("get_editor_state")
+    return {
+        "current_scene": state.get("current_scene", ""),
+        "project_name": state.get("project_name", ""),
+        "is_playing": state.get("is_playing", False),
+    }
+
+
+async def scene_hierarchy_resource_data(runtime: Runtime) -> dict:
+    return await runtime.send_command("get_scene_tree", {"depth": 10})
+

--- a/src/godot_ai/handlers/session.py
+++ b/src/godot_ai/handlers/session.py
@@ -1,0 +1,27 @@
+"""Shared handlers for session tools and resources."""
+
+from __future__ import annotations
+
+from godot_ai.runtime.interface import Runtime
+
+
+def session_list(runtime: Runtime) -> dict:
+    sessions = runtime.list_sessions()
+    active_id = runtime.active_session_id
+    return {
+        "sessions": [{**s.to_dict(), "is_active": s.session_id == active_id} for s in sessions],
+        "count": len(sessions),
+    }
+
+
+def session_activate(runtime: Runtime, session_id: str) -> dict:
+    try:
+        runtime.set_active_session(session_id)
+        return {"status": "ok", "active_session_id": session_id}
+    except KeyError:
+        return {"status": "error", "message": f"Session {session_id} not found"}
+
+
+def session_resource_data(runtime: Runtime) -> dict:
+    return session_list(runtime)
+

--- a/src/godot_ai/handlers/testing.py
+++ b/src/godot_ai/handlers/testing.py
@@ -1,0 +1,19 @@
+"""Shared handlers for testing tools."""
+
+from __future__ import annotations
+
+from godot_ai.runtime.interface import Runtime
+
+
+async def run_tests(runtime: Runtime, suite: str = "", test_name: str = "") -> dict:
+    params: dict[str, str] = {}
+    if suite:
+        params["suite"] = suite
+    if test_name:
+        params["test_name"] = test_name
+    return await runtime.send_command("run_tests", params)
+
+
+async def get_test_results(runtime: Runtime) -> dict:
+    return await runtime.send_command("get_test_results")
+

--- a/src/godot_ai/resources/editor.py
+++ b/src/godot_ai/resources/editor.py
@@ -6,22 +6,25 @@ import json
 
 from fastmcp import Context, FastMCP
 
+from godot_ai.handlers import editor as editor_handlers
+from godot_ai.runtime.direct import DirectRuntime
+
 
 def register_editor_resources(mcp: FastMCP) -> None:
     @mcp.resource("godot://selection/current", mime_type="application/json")
     async def get_current_selection(ctx: Context) -> str:
         """Currently selected nodes in the Godot editor."""
-        app = ctx.lifespan_context
+        runtime = DirectRuntime.from_context(ctx)
         try:
-            return json.dumps(await app.client.send("get_selection"))
-        except Exception as e:
-            return json.dumps({"error": str(e), "connected": False})
+            return json.dumps(await editor_handlers.selection_resource_data(runtime))
+        except Exception as exc:
+            return json.dumps({"error": str(exc), "connected": False})
 
     @mcp.resource("godot://logs/recent", mime_type="application/json")
     async def get_recent_logs(ctx: Context) -> str:
         """Last 100 log lines from the Godot editor console."""
-        app = ctx.lifespan_context
+        runtime = DirectRuntime.from_context(ctx)
         try:
-            return json.dumps(await app.client.send("get_logs", {"count": 100}))
-        except Exception as e:
-            return json.dumps({"error": str(e), "connected": False})
+            return json.dumps(await editor_handlers.logs_resource_data(runtime))
+        except Exception as exc:
+            return json.dumps({"error": str(exc), "connected": False})

--- a/src/godot_ai/resources/project.py
+++ b/src/godot_ai/resources/project.py
@@ -2,55 +2,25 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 
 from fastmcp import Context, FastMCP
 
-COMMON_SETTINGS = [
-    "application/config/name",
-    "application/config/description",
-    "application/run/main_scene",
-    "display/window/size/viewport_width",
-    "display/window/size/viewport_height",
-    "rendering/renderer/rendering_method",
-    "physics/2d/default_gravity",
-    "physics/3d/default_gravity",
-]
+from godot_ai.handlers import project as project_handlers
+from godot_ai.runtime.direct import DirectRuntime
+
+COMMON_SETTINGS = project_handlers.COMMON_SETTINGS
 
 
 def register_project_resources(mcp: FastMCP) -> None:
     @mcp.resource("godot://project/info", mime_type="application/json")
     async def get_project_info(ctx: Context) -> str:
         """Project name, Godot version, paths, and play state."""
-        app = ctx.lifespan_context
-        session = app.registry.get_active()
-        if session is None:
-            return json.dumps({"error": "No active Godot session", "connected": False})
-
-        info = session.to_dict()
-        info.pop("connected_at", None)
-        return json.dumps(info)
+        runtime = DirectRuntime.from_context(ctx)
+        return json.dumps(project_handlers.project_info_resource_data(runtime))
 
     @mcp.resource("godot://project/settings", mime_type="application/json")
     async def get_project_settings(ctx: Context) -> str:
         """Common project settings subset (display, physics, rendering)."""
-        app = ctx.lifespan_context
-
-        async def _fetch(key: str) -> tuple[str, object | None, str | None]:
-            try:
-                result = await app.client.send("get_project_setting", {"key": key})
-                return key, result.get("value"), None
-            except Exception as e:
-                return key, None, str(e)
-
-        results = await asyncio.gather(*[_fetch(key) for key in COMMON_SETTINGS])
-        settings = {}
-        errors = []
-        for key, value, error in results:
-            if error:
-                errors.append({"key": key, "error": error})
-            else:
-                settings[key] = value
-
-        return json.dumps({"settings": settings, "errors": errors if errors else None})
+        runtime = DirectRuntime.from_context(ctx)
+        return json.dumps(await project_handlers.project_settings_resource_data(runtime))

--- a/src/godot_ai/resources/scenes.py
+++ b/src/godot_ai/resources/scenes.py
@@ -6,27 +6,25 @@ import json
 
 from fastmcp import Context, FastMCP
 
+from godot_ai.handlers import scene as scene_handlers
+from godot_ai.runtime.direct import DirectRuntime
+
 
 def register_scene_resources(mcp: FastMCP) -> None:
     @mcp.resource("godot://scene/current", mime_type="application/json")
     async def get_current_scene(ctx: Context) -> str:
         """Current scene path and root node info from the active Godot editor."""
-        app = ctx.lifespan_context
+        runtime = DirectRuntime.from_context(ctx)
         try:
-            state = await app.client.send("get_editor_state")
-            return json.dumps({
-                "current_scene": state.get("current_scene", ""),
-                "project_name": state.get("project_name", ""),
-                "is_playing": state.get("is_playing", False),
-            })
-        except Exception as e:
-            return json.dumps({"error": str(e), "connected": False})
+            return json.dumps(await scene_handlers.current_scene_resource_data(runtime))
+        except Exception as exc:
+            return json.dumps({"error": str(exc), "connected": False})
 
     @mcp.resource("godot://scene/hierarchy", mime_type="application/json")
     async def get_scene_hierarchy(ctx: Context) -> str:
         """Full scene tree hierarchy from the active Godot editor."""
-        app = ctx.lifespan_context
+        runtime = DirectRuntime.from_context(ctx)
         try:
-            return json.dumps(await app.client.send("get_scene_tree", {"depth": 10}))
-        except Exception as e:
-            return json.dumps({"error": str(e), "connected": False})
+            return json.dumps(await scene_handlers.scene_hierarchy_resource_data(runtime))
+        except Exception as exc:
+            return json.dumps({"error": str(exc), "connected": False})

--- a/src/godot_ai/resources/sessions.py
+++ b/src/godot_ai/resources/sessions.py
@@ -6,15 +6,13 @@ import json
 
 from fastmcp import Context, FastMCP
 
+from godot_ai.handlers import session as session_handlers
+from godot_ai.runtime.direct import DirectRuntime
+
 
 def register_session_resources(mcp: FastMCP) -> None:
     @mcp.resource("godot://sessions", mime_type="application/json")
     def get_sessions(ctx: Context) -> str:
         """All connected Godot editor sessions and their metadata."""
-        app = ctx.lifespan_context
-        sessions = app.registry.list_all()
-        active_id = app.registry.active_session_id
-        return json.dumps({
-            "sessions": [{**s.to_dict(), "is_active": s.session_id == active_id} for s in sessions],
-            "count": len(sessions),
-        })
+        runtime = DirectRuntime.from_context(ctx)
+        return json.dumps(session_handlers.session_resource_data(runtime))

--- a/src/godot_ai/runtime/__init__.py
+++ b/src/godot_ai/runtime/__init__.py
@@ -1,0 +1,2 @@
+"""Runtime adapters for shared tool/resource handlers."""
+

--- a/src/godot_ai/runtime/direct.py
+++ b/src/godot_ai/runtime/direct.py
@@ -1,0 +1,66 @@
+"""Direct, in-process runtime adapter."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from fastmcp import Context
+
+from godot_ai.godot_client.client import GodotClient
+from godot_ai.sessions.registry import Session, SessionRegistry
+
+
+class SupportsDirectRuntime(Protocol):
+    registry: SessionRegistry
+    client: GodotClient
+
+
+class DirectRuntime:
+    """In-process runtime used by the current single-process server."""
+
+    def __init__(self, registry: SessionRegistry, client: GodotClient):
+        self._registry = registry
+        self._client = client
+
+    @classmethod
+    def from_context(cls, ctx: Context) -> DirectRuntime:
+        app = ctx.fastmcp._lifespan_result
+        if app is None:
+            raise RuntimeError("FastMCP lifespan context is not available")
+        return cls.from_app_context(app)
+
+    @classmethod
+    def from_app_context(cls, app: SupportsDirectRuntime) -> DirectRuntime:
+        return cls(registry=app.registry, client=app.client)
+
+    async def send_command(
+        self,
+        command: str,
+        params: dict[str, Any] | None = None,
+        session_id: str | None = None,
+        timeout: float = 5.0,
+    ) -> dict[str, Any]:
+        return await self._client.send(
+            command=command,
+            params=params,
+            session_id=session_id,
+            timeout=timeout,
+        )
+
+    def list_sessions(self) -> list[Session]:
+        return self._registry.list_all()
+
+    def get_active_session(self) -> Session | None:
+        return self._registry.get_active()
+
+    @property
+    def active_session_id(self) -> str | None:
+        return self._registry.active_session_id
+
+    def set_active_session(self, session_id: str) -> None:
+        self._registry.set_active(session_id)
+
+    async def wait_for_session(
+        self, exclude_id: str | None = None, timeout: float = 15.0
+    ) -> Session:
+        return await self._registry.wait_for_session(exclude_id=exclude_id, timeout=timeout)

--- a/src/godot_ai/runtime/interface.py
+++ b/src/godot_ai/runtime/interface.py
@@ -1,0 +1,34 @@
+"""Runtime interface consumed by shared handlers."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, Protocol
+
+from godot_ai.sessions.registry import Session
+
+
+class Runtime(Protocol):
+    """Minimal runtime surface shared handlers rely on."""
+
+    async def send_command(
+        self,
+        command: str,
+        params: dict[str, Any] | None = None,
+        session_id: str | None = None,
+        timeout: float = 5.0,
+    ) -> dict[str, Any]: ...
+
+    def list_sessions(self) -> Sequence[Session]: ...
+
+    def get_active_session(self) -> Session | None: ...
+
+    @property
+    def active_session_id(self) -> str | None: ...
+
+    def set_active_session(self, session_id: str) -> None: ...
+
+    async def wait_for_session(
+        self, exclude_id: str | None = None, timeout: float = 15.0
+    ) -> Session: ...
+

--- a/src/godot_ai/sessions/registry.py
+++ b/src/godot_ai/sessions/registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
@@ -38,11 +39,22 @@ class SessionRegistry:
     def __init__(self):
         self._sessions: dict[str, Session] = {}
         self._active_session_id: str | None = None
+        self._session_waiters: list[tuple[asyncio.Future, str | None]] = []
 
     def register(self, session: Session) -> None:
         self._sessions[session.session_id] = session
         if self._active_session_id is None:
             self._active_session_id = session.session_id
+        # Notify any waiters blocked on wait_for_session()
+        remaining = []
+        for future, exclude_id in self._session_waiters:
+            if future.done():
+                continue
+            if exclude_id is not None and session.session_id == exclude_id:
+                remaining.append((future, exclude_id))
+                continue
+            future.set_result(session)
+        self._session_waiters = remaining
 
     def unregister(self, session_id: str) -> None:
         self._sessions.pop(session_id, None)
@@ -68,6 +80,20 @@ class SessionRegistry:
     @property
     def active_session_id(self) -> str | None:
         return self._active_session_id
+
+    async def wait_for_session(
+        self, exclude_id: str | None = None, timeout: float = 15.0
+    ) -> Session:
+        """Block until a new session registers (optionally excluding one ID).
+
+        Raises TimeoutError if no matching session appears within timeout.
+        """
+        future: asyncio.Future[Session] = asyncio.get_event_loop().create_future()
+        self._session_waiters.append((future, exclude_id))
+        try:
+            return await asyncio.wait_for(future, timeout=timeout)
+        except asyncio.TimeoutError:
+            raise TimeoutError("Timed out waiting for new session") from None
 
     def __len__(self) -> int:
         return len(self._sessions)

--- a/src/godot_ai/sessions/registry.py
+++ b/src/godot_ai/sessions/registry.py
@@ -88,14 +88,17 @@ class SessionRegistry:
 
         Raises TimeoutError if no matching session appears within timeout.
         """
-        future: asyncio.Future[Session] = asyncio.get_event_loop().create_future()
+        future: asyncio.Future[Session] = asyncio.get_running_loop().create_future()
         entry = (future, exclude_id)
         self._session_waiters.append(entry)
         try:
             return await asyncio.wait_for(future, timeout=timeout)
         except asyncio.TimeoutError:
-            self._session_waiters = [w for w in self._session_waiters if w is not entry]
             raise TimeoutError("Timed out waiting for new session") from None
+        finally:
+            self._session_waiters = [w for w in self._session_waiters if w is not entry]
+            if not future.done():
+                future.cancel()
 
     def __len__(self) -> int:
         return len(self._sessions)

--- a/src/godot_ai/sessions/registry.py
+++ b/src/godot_ai/sessions/registry.py
@@ -89,10 +89,12 @@ class SessionRegistry:
         Raises TimeoutError if no matching session appears within timeout.
         """
         future: asyncio.Future[Session] = asyncio.get_event_loop().create_future()
-        self._session_waiters.append((future, exclude_id))
+        entry = (future, exclude_id)
+        self._session_waiters.append(entry)
         try:
             return await asyncio.wait_for(future, timeout=timeout)
         except asyncio.TimeoutError:
+            self._session_waiters = [w for w in self._session_waiters if w is not entry]
             raise TimeoutError("Timed out waiting for new session") from None
 
     def __len__(self) -> int:

--- a/src/godot_ai/tools/client.py
+++ b/src/godot_ai/tools/client.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from fastmcp import Context, FastMCP
 
+from godot_ai.handlers import client as client_handlers
+from godot_ai.runtime.direct import DirectRuntime
+
 
 def register_client_tools(mcp: FastMCP) -> None:
     @mcp.tool()
@@ -14,10 +17,10 @@ def register_client_tools(mcp: FastMCP) -> None:
         how to launch and connect to this server.
 
         Args:
-            client: The client to configure. Options: "claude_code", "antigravity".
+            client: The client to configure. Options: "claude_code", "codex", "antigravity".
         """
-        app = ctx.lifespan_context
-        return await app.client.send("configure_client", {"client": client})
+        runtime = DirectRuntime.from_context(ctx)
+        return await client_handlers.client_configure(runtime, client=client)
 
     @mcp.tool()
     async def client_status(ctx: Context) -> dict:
@@ -26,5 +29,5 @@ def register_client_tools(mcp: FastMCP) -> None:
         Returns the configuration status of each supported client:
         "configured", "not_configured", or "error".
         """
-        app = ctx.lifespan_context
-        return await app.client.send("check_client_status")
+        runtime = DirectRuntime.from_context(ctx)
+        return await client_handlers.client_status(runtime)

--- a/src/godot_ai/tools/editor.py
+++ b/src/godot_ai/tools/editor.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from fastmcp import Context, FastMCP
 
-from godot_ai.tools._pagination import paginate
+from godot_ai.handlers import editor as editor_handlers
+from godot_ai.runtime.direct import DirectRuntime
 
 
 def register_editor_tools(mcp: FastMCP) -> None:
@@ -15,8 +16,8 @@ def register_editor_tools(mcp: FastMCP) -> None:
         Returns Godot version, project name, current scene path,
         and whether the project is currently playing.
         """
-        app = ctx.lifespan_context
-        return await app.client.send("get_editor_state")
+        runtime = DirectRuntime.from_context(ctx)
+        return await editor_handlers.editor_state(runtime)
 
     @mcp.tool()
     async def editor_selection_get(ctx: Context) -> dict:
@@ -24,8 +25,8 @@ def register_editor_tools(mcp: FastMCP) -> None:
 
         Returns a list of selected node paths.
         """
-        app = ctx.lifespan_context
-        return await app.client.send("get_selection")
+        runtime = DirectRuntime.from_context(ctx)
+        return await editor_handlers.editor_selection_get(runtime)
 
     @mcp.tool()
     async def logs_read(
@@ -43,8 +44,20 @@ def register_editor_tools(mcp: FastMCP) -> None:
             count: Maximum number of lines to return. Default 50.
             offset: Number of lines to skip from the start. Default 0.
         """
-        app = ctx.lifespan_context
-        # Fetch the full buffer so offset/limit/total_count are accurate
-        result = await app.client.send("get_logs", {"count": 500})
-        lines = result.get("lines", [])
-        return paginate(lines, offset, count, key="lines")
+        runtime = DirectRuntime.from_context(ctx)
+        return await editor_handlers.logs_read(runtime, count=count, offset=offset)
+
+    @mcp.tool()
+    async def reload_plugin(ctx: Context) -> dict:
+        """Reload the Godot editor plugin and wait for it to reconnect.
+
+        Sends a reload command to the plugin, which disables and re-enables
+        itself on the next frame. The tool then waits for the new session
+        to connect before returning.
+
+        Requires the MCP server to be running externally (not started by
+        the plugin), otherwise the reload will kill the server process.
+        Start with: python -m godot_ai --transport streamable-http --port 8000 --reload
+        """
+        runtime = DirectRuntime.from_context(ctx)
+        return await editor_handlers.reload_plugin(runtime)

--- a/src/godot_ai/tools/node.py
+++ b/src/godot_ai/tools/node.py
@@ -28,7 +28,12 @@ def register_node_tools(mcp: FastMCP) -> None:
             parent_path: Node path of the parent (e.g. "/Main"). Empty = scene root.
         """
         runtime = DirectRuntime.from_context(ctx)
-        return await node_handlers.node_create(runtime, type=type, name=name, parent_path=parent_path)
+        return await node_handlers.node_create(
+            runtime,
+            type=type,
+            name=name,
+            parent_path=parent_path,
+        )
 
     @mcp.tool()
     async def node_find(

--- a/src/godot_ai/tools/node.py
+++ b/src/godot_ai/tools/node.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from fastmcp import Context, FastMCP
 
-from godot_ai.tools._pagination import paginate
+from godot_ai.handlers import node as node_handlers
+from godot_ai.runtime.direct import DirectRuntime
 
 
 def register_node_tools(mcp: FastMCP) -> None:
@@ -26,11 +27,8 @@ def register_node_tools(mcp: FastMCP) -> None:
             name: Optional name for the node.
             parent_path: Node path of the parent (e.g. "/Main"). Empty = scene root.
         """
-        app = ctx.lifespan_context
-        return await app.client.send(
-            "create_node",
-            {"type": type, "name": name, "parent_path": parent_path},
-        )
+        runtime = DirectRuntime.from_context(ctx)
+        return await node_handlers.node_create(runtime, type=type, name=name, parent_path=parent_path)
 
     @mcp.tool()
     async def node_find(
@@ -53,12 +51,15 @@ def register_node_tools(mcp: FastMCP) -> None:
             offset: Number of results to skip. Default 0.
             limit: Maximum number of results to return. Default 100.
         """
-        app = ctx.lifespan_context
-        result = await app.client.send(
-            "find_nodes",
-            {"name": name, "type": type, "group": group},
+        runtime = DirectRuntime.from_context(ctx)
+        return await node_handlers.node_find(
+            runtime,
+            name=name,
+            type=type,
+            group=group,
+            offset=offset,
+            limit=limit,
         )
-        return paginate(result.get("nodes", []), offset, limit, key="nodes")
 
     @mcp.tool()
     async def node_get_properties(ctx: Context, path: str) -> dict:
@@ -70,8 +71,8 @@ def register_node_tools(mcp: FastMCP) -> None:
         Args:
             path: Scene path of the node (e.g. "/Main/Camera3D").
         """
-        app = ctx.lifespan_context
-        return await app.client.send("get_node_properties", {"path": path})
+        runtime = DirectRuntime.from_context(ctx)
+        return await node_handlers.node_get_properties(runtime, path=path)
 
     @mcp.tool()
     async def node_get_children(ctx: Context, path: str) -> dict:
@@ -83,8 +84,8 @@ def register_node_tools(mcp: FastMCP) -> None:
         Args:
             path: Scene path of the parent node (e.g. "/Main").
         """
-        app = ctx.lifespan_context
-        return await app.client.send("get_children", {"path": path})
+        runtime = DirectRuntime.from_context(ctx)
+        return await node_handlers.node_get_children(runtime, path=path)
 
     @mcp.tool()
     async def node_get_groups(ctx: Context, path: str) -> dict:
@@ -95,5 +96,5 @@ def register_node_tools(mcp: FastMCP) -> None:
         Args:
             path: Scene path of the node (e.g. "/Main/Player").
         """
-        app = ctx.lifespan_context
-        return await app.client.send("get_groups", {"path": path})
+        runtime = DirectRuntime.from_context(ctx)
+        return await node_handlers.node_get_groups(runtime, path=path)

--- a/src/godot_ai/tools/project.py
+++ b/src/godot_ai/tools/project.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from fastmcp import Context, FastMCP
 
-from godot_ai.tools._pagination import paginate
+from godot_ai.handlers import project as project_handlers
+from godot_ai.runtime.direct import DirectRuntime
 
 
 def register_project_tools(mcp: FastMCP) -> None:
@@ -18,8 +19,8 @@ def register_project_tools(mcp: FastMCP) -> None:
         Args:
             key: The setting key path (e.g. "application/config/name").
         """
-        app = ctx.lifespan_context
-        return await app.client.send("get_project_setting", {"key": key})
+        runtime = DirectRuntime.from_context(ctx)
+        return await project_handlers.project_settings_get(runtime, key=key)
 
     @mcp.tool()
     async def filesystem_search(
@@ -42,13 +43,12 @@ def register_project_tools(mcp: FastMCP) -> None:
             offset: Number of results to skip. Default 0.
             limit: Maximum number of results to return. Default 100.
         """
-        app = ctx.lifespan_context
-        params: dict = {}
-        if name:
-            params["name"] = name
-        if type:
-            params["type"] = type
-        if path:
-            params["path"] = path
-        result = await app.client.send("search_filesystem", params)
-        return paginate(result.get("files", []), offset, limit, key="files")
+        runtime = DirectRuntime.from_context(ctx)
+        return await project_handlers.filesystem_search(
+            runtime,
+            name=name,
+            type=type,
+            path=path,
+            offset=offset,
+            limit=limit,
+        )

--- a/src/godot_ai/tools/scene.py
+++ b/src/godot_ai/tools/scene.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from fastmcp import Context, FastMCP
 
-from godot_ai.tools._pagination import paginate
+from godot_ai.handlers import scene as scene_handlers
+from godot_ai.runtime.direct import DirectRuntime
 
 
 def register_scene_tools(mcp: FastMCP) -> None:
@@ -25,10 +26,13 @@ def register_scene_tools(mcp: FastMCP) -> None:
             offset: Number of nodes to skip. Default 0.
             limit: Maximum number of nodes to return. Default 100.
         """
-        app = ctx.lifespan_context
-        result = await app.client.send("get_scene_tree", {"depth": depth})
-        nodes = result.get("nodes", [])
-        return {"root": result.get("root", ""), **paginate(nodes, offset, limit, key="nodes")}
+        runtime = DirectRuntime.from_context(ctx)
+        return await scene_handlers.scene_get_hierarchy(
+            runtime,
+            depth=depth,
+            offset=offset,
+            limit=limit,
+        )
 
     @mcp.tool()
     async def scene_get_roots(ctx: Context) -> dict:
@@ -37,5 +41,5 @@ def register_scene_tools(mcp: FastMCP) -> None:
         Returns a list of open scene file paths and which one is the
         currently edited scene.
         """
-        app = ctx.lifespan_context
-        return await app.client.send("get_open_scenes")
+        runtime = DirectRuntime.from_context(ctx)
+        return await scene_handlers.scene_get_roots(runtime)

--- a/src/godot_ai/tools/session.py
+++ b/src/godot_ai/tools/session.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from fastmcp import Context, FastMCP
 
+from godot_ai.handlers import session as session_handlers
+from godot_ai.runtime.direct import DirectRuntime
+
 
 def register_session_tools(mcp: FastMCP) -> None:
     @mcp.tool()
@@ -13,13 +16,8 @@ def register_session_tools(mcp: FastMCP) -> None:
         Returns session metadata including Godot version, project path,
         and connection state for each connected editor instance.
         """
-        app = ctx.lifespan_context
-        sessions = app.registry.list_all()
-        active_id = app.registry.active_session_id
-        return {
-            "sessions": [{**s.to_dict(), "is_active": s.session_id == active_id} for s in sessions],
-            "count": len(sessions),
-        }
+        runtime = DirectRuntime.from_context(ctx)
+        return session_handlers.session_list(runtime)
 
     @mcp.tool()
     def session_activate(ctx: Context, session_id: str) -> dict:
@@ -31,9 +29,5 @@ def register_session_tools(mcp: FastMCP) -> None:
         Args:
             session_id: The ID of the session to activate.
         """
-        app = ctx.lifespan_context
-        try:
-            app.registry.set_active(session_id)
-            return {"status": "ok", "active_session_id": session_id}
-        except KeyError:
-            return {"status": "error", "message": f"Session {session_id} not found"}
+        runtime = DirectRuntime.from_context(ctx)
+        return session_handlers.session_activate(runtime, session_id)

--- a/src/godot_ai/tools/testing.py
+++ b/src/godot_ai/tools/testing.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from fastmcp import Context, FastMCP
 
+from godot_ai.handlers import testing as testing_handlers
+from godot_ai.runtime.direct import DirectRuntime
+
 
 def register_testing_tools(mcp: FastMCP) -> None:
     @mcp.tool()
@@ -24,13 +27,8 @@ def register_testing_tools(mcp: FastMCP) -> None:
             test_name: Run only tests whose name contains this substring.
                        Empty runs all tests in the selected suite(s).
         """
-        app = ctx.lifespan_context
-        params = {}
-        if suite:
-            params["suite"] = suite
-        if test_name:
-            params["test_name"] = test_name
-        return await app.client.send("run_tests", params)
+        runtime = DirectRuntime.from_context(ctx)
+        return await testing_handlers.run_tests(runtime, suite=suite, test_name=test_name)
 
     @mcp.tool()
     async def get_test_results(ctx: Context) -> dict:
@@ -39,5 +37,5 @@ def register_testing_tools(mcp: FastMCP) -> None:
         Returns the same structured results as run_tests, without
         re-executing. Useful for reviewing results after a run.
         """
-        app = ctx.lifespan_context
-        return await app.client.send("get_test_results")
+        runtime = DirectRuntime.from_context(ctx)
+        return await testing_handlers.get_test_results(runtime)

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import json
+
+import websockets
 
 # ---------------------------------------------------------------------------
 # scene_get_hierarchy
@@ -12,10 +15,7 @@ import asyncio
 class TestSceneGetHierarchyTool:
     async def test_returns_paginated_nodes(self, mcp_stack):
         client, plugin = mcp_stack
-        nodes = [
-            {"name": f"Node{i}", "type": "Node3D", "path": f"/Root/Node{i}"}
-            for i in range(5)
-        ]
+        nodes = [{"name": f"Node{i}", "type": "Node3D", "path": f"/Root/Node{i}"} for i in range(5)]
 
         async def respond():
             cmd = await plugin.recv_command()
@@ -120,9 +120,7 @@ class TestEditorSelectionGetTool:
         async def respond():
             cmd = await plugin.recv_command()
             assert cmd["command"] == "get_selection"
-            await plugin.send_response(
-                cmd["request_id"], {"selected": ["/Main/Camera3D"]}
-            )
+            await plugin.send_response(cmd["request_id"], {"selected": ["/Main/Camera3D"]})
 
         task = asyncio.create_task(respond())
         result = await client.call_tool("editor_selection_get", {})
@@ -236,9 +234,7 @@ class TestNodeReadTools:
         async def respond():
             cmd = await plugin.recv_command()
             assert cmd["command"] == "get_groups"
-            await plugin.send_response(
-                cmd["request_id"], {"groups": ["enemies", "damageable"]}
-            )
+            await plugin.send_response(cmd["request_id"], {"groups": ["enemies", "damageable"]})
 
         task = asyncio.create_task(respond())
         result = await client.call_tool("node_get_groups", {"path": "/Main/Enemy"})
@@ -293,9 +289,7 @@ class TestProjectSettingsGetTool:
             )
 
         task = asyncio.create_task(respond())
-        result = await client.call_tool(
-            "project_settings_get", {"key": "application/config/name"}
-        )
+        result = await client.call_tool("project_settings_get", {"key": "application/config/name"})
         await task
 
         assert result.data["value"] == "MyGame"
@@ -309,10 +303,7 @@ class TestProjectSettingsGetTool:
 class TestFilesystemSearchTool:
     async def test_returns_paginated_files(self, mcp_stack):
         client, plugin = mcp_stack
-        files = [
-            {"path": f"res://scripts/script_{i}.gd", "type": "GDScript"}
-            for i in range(8)
-        ]
+        files = [{"path": f"res://scripts/script_{i}.gd", "type": "GDScript"} for i in range(8)]
 
         async def respond():
             cmd = await plugin.recv_command()
@@ -330,3 +321,51 @@ class TestFilesystemSearchTool:
         assert data["total_count"] == 8
         assert data["offset"] == 5
         assert data["has_more"] is False
+
+
+# ---------------------------------------------------------------------------
+# reload_plugin
+# ---------------------------------------------------------------------------
+# No GDScript test for reload_plugin — calling it triggers a real plugin
+# reload that kills the test runner.
+
+
+class TestReloadPluginTool:
+    async def test_reload_cycle(self, mcp_stack):
+        """Full reload cycle: ack, disconnect, reconnect with new session."""
+        client, plugin = mcp_stack
+        ws_port = 19502  # matches mcp_stack fixture
+
+        async def simulate_reload():
+            # Receive the reload command and ack it
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "reload_plugin"
+            await plugin.send_response(
+                cmd["request_id"],
+                {"status": "reloading", "message": "Plugin reload initiated"},
+            )
+            # Simulate the plugin dying and reconnecting
+            await plugin.close()
+            await asyncio.sleep(0.1)
+            # Reconnect as a new session
+            ws = await websockets.connect(f"ws://127.0.0.1:{ws_port}")
+            handshake = {
+                "type": "handshake",
+                "session_id": "reloaded-session",
+                "godot_version": "4.4.1",
+                "project_path": "/tmp/test_project",
+                "plugin_version": "0.0.1",
+                "protocol_version": 1,
+            }
+            await ws.send(json.dumps(handshake))
+            await asyncio.sleep(0.05)
+            return ws
+
+        task = asyncio.create_task(simulate_reload())
+        result = await client.call_tool("reload_plugin", {})
+        new_ws = await task
+
+        assert result.data["status"] == "reloaded"
+        assert result.data["old_session_id"] == "mcp-test"
+        assert result.data["new_session_id"] == "reloaded-session"
+        await new_ws.close()

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -369,3 +369,199 @@ class TestReloadPluginTool:
         assert result.data["old_session_id"] == "mcp-test"
         assert result.data["new_session_id"] == "reloaded-session"
         await new_ws.close()
+
+
+# ---------------------------------------------------------------------------
+# session_list / session_activate
+# ---------------------------------------------------------------------------
+
+
+class TestSessionTools:
+    async def test_session_list_returns_connected_session(self, mcp_stack):
+        client, plugin = mcp_stack
+        result = await client.call_tool("session_list", {})
+        assert result.data["count"] == 1
+        assert result.data["sessions"][0]["session_id"] == "mcp-test"
+        assert result.data["sessions"][0]["is_active"] is True
+
+    async def test_session_activate_existing(self, mcp_stack):
+        client, plugin = mcp_stack
+        result = await client.call_tool("session_activate", {"session_id": "mcp-test"})
+        assert result.data["status"] == "ok"
+
+    async def test_session_activate_nonexistent(self, mcp_stack):
+        client, plugin = mcp_stack
+        result = await client.call_tool("session_activate", {"session_id": "no-such-session"})
+        assert result.data["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# client_configure / client_status
+# ---------------------------------------------------------------------------
+
+
+class TestClientTools:
+    async def test_client_status(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "check_client_status"
+            await plugin.send_response(
+                cmd["request_id"],
+                {"claude_code": "configured", "codex": "not_configured"},
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool("client_status", {})
+        await task
+        assert result.data["claude_code"] == "configured"
+
+    async def test_client_configure(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "configure_client"
+            assert cmd["params"]["client"] == "codex"
+            await plugin.send_response(cmd["request_id"], {"status": "ok"})
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool("client_configure", {"client": "codex"})
+        await task
+        assert result.data["status"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# run_tests / get_test_results
+# ---------------------------------------------------------------------------
+
+
+class TestTestingTools:
+    async def test_run_tests(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "run_tests"
+            await plugin.send_response(
+                cmd["request_id"], {"passed": 3, "failed": 0, "results": []}
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool("run_tests", {})
+        await task
+        assert result.data["passed"] == 3
+
+    async def test_run_tests_with_suite(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "run_tests"
+            assert cmd["params"]["suite"] == "scene"
+            await plugin.send_response(
+                cmd["request_id"], {"passed": 2, "failed": 0, "results": []}
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool("run_tests", {"suite": "scene"})
+        await task
+        assert result.data["passed"] == 2
+
+    async def test_get_test_results(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "get_test_results"
+            await plugin.send_response(
+                cmd["request_id"], {"passed": 5, "failed": 1, "results": []}
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool("get_test_results", {})
+        await task
+        assert result.data["failed"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Resource reads (through MCP client)
+# ---------------------------------------------------------------------------
+
+
+class TestResourceReads:
+    async def test_read_sessions_resource(self, mcp_stack):
+        client, plugin = mcp_stack
+        result = await client.read_resource("godot://sessions")
+        data = json.loads(result[0].text)
+        assert data["count"] == 1
+        assert data["sessions"][0]["session_id"] == "mcp-test"
+
+    async def test_read_project_info_resource(self, mcp_stack):
+        client, plugin = mcp_stack
+        result = await client.read_resource("godot://project/info")
+        data = json.loads(result[0].text)
+        assert data["session_id"] == "mcp-test"
+
+    async def test_read_selection_resource(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "get_selection"
+            await plugin.send_response(cmd["request_id"], {"selected": ["/Main/Cam"]})
+
+        task = asyncio.create_task(respond())
+        result = await client.read_resource("godot://selection/current")
+        await task
+        data = json.loads(result[0].text)
+        assert data["selected"] == ["/Main/Cam"]
+
+    async def test_read_logs_resource(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "get_logs"
+            await plugin.send_response(cmd["request_id"], {"lines": ["log line 1"]})
+
+        task = asyncio.create_task(respond())
+        result = await client.read_resource("godot://logs/recent")
+        await task
+        data = json.loads(result[0].text)
+        assert "lines" in data
+
+    async def test_read_scene_current_resource(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "get_editor_state"
+            await plugin.send_response(
+                cmd["request_id"],
+                {"current_scene": "res://main.tscn", "project_name": "Test", "is_playing": False},
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.read_resource("godot://scene/current")
+        await task
+        data = json.loads(result[0].text)
+        assert data["current_scene"] == "res://main.tscn"
+
+    async def test_read_scene_hierarchy_resource(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "get_scene_tree"
+            await plugin.send_response(
+                cmd["request_id"],
+                {"root": "Main", "nodes": [{"name": "Camera3D"}]},
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.read_resource("godot://scene/hierarchy")
+        await task
+        data = json.loads(result[0].text)
+        assert data["root"] == "Main"

--- a/tests/unit/test_cli_reload.py
+++ b/tests/unit/test_cli_reload.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import fastmcp
+import pytest
 
 import godot_ai
 from godot_ai import asgi
@@ -104,3 +105,20 @@ def test_main_runs_server_directly_without_reload(monkeypatch):
 
     assert calls["ws_port"] == 9555
     assert server.run_calls == [{"transport": "streamable-http", "port": 8123}]
+
+
+def test_get_dev_transport_rejects_unsupported(monkeypatch):
+    monkeypatch.setenv(asgi.DEV_TRANSPORT_ENV, "stdio")
+    with pytest.raises(ValueError, match="Unsupported dev transport"):
+        asgi._get_dev_transport()
+
+
+def test_get_dev_ws_port_rejects_non_integer(monkeypatch):
+    monkeypatch.setenv(asgi.DEV_WS_PORT_ENV, "abc")
+    with pytest.raises(ValueError, match="Invalid"):
+        asgi._get_dev_ws_port()
+
+
+def test_run_with_reload_rejects_non_http_transport():
+    with pytest.raises(ValueError, match="Reload is only supported for HTTP"):
+        asgi.run_with_reload(transport="stdio", port=8000, ws_port=9500)

--- a/tests/unit/test_cli_reload.py
+++ b/tests/unit/test_cli_reload.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import fastmcp
+
+import godot_ai
+from godot_ai import asgi
+
+
+class StubServer:
+    def __init__(self, app):
+        self.app = app
+        self.http_calls: list[dict] = []
+        self.run_calls: list[dict] = []
+
+    def http_app(self, *, transport: str):
+        self.http_calls.append({"transport": transport})
+        return self.app
+
+    def run(self, **kwargs) -> None:
+        self.run_calls.append(kwargs)
+
+
+def test_create_app_uses_env_config(monkeypatch):
+    app = object()
+    server = StubServer(app)
+    calls: dict[str, int] = {}
+
+    def fake_create_server(ws_port: int):
+        calls["ws_port"] = ws_port
+        return server
+
+    monkeypatch.setenv(asgi.DEV_TRANSPORT_ENV, "streamable-http")
+    monkeypatch.setenv(asgi.DEV_WS_PORT_ENV, "9555")
+    monkeypatch.setattr("godot_ai.server.create_server", fake_create_server)
+
+    result = asgi.create_app()
+
+    assert result is app
+    assert calls["ws_port"] == 9555
+    assert server.http_calls == [{"transport": "streamable-http"}]
+
+
+def test_run_with_reload_uses_uvicorn_factory(monkeypatch):
+    calls: dict[str, object] = {}
+
+    def fake_run(app, **kwargs):
+        calls["app"] = app
+        calls["kwargs"] = kwargs
+
+    monkeypatch.delenv(asgi.DEV_TRANSPORT_ENV, raising=False)
+    monkeypatch.delenv(asgi.DEV_WS_PORT_ENV, raising=False)
+    monkeypatch.setattr(asgi.uvicorn, "run", fake_run)
+
+    asgi.run_with_reload(transport="streamable-http", port=8123, ws_port=9555)
+
+    assert calls["app"] == "godot_ai.asgi:create_app"
+    assert calls["kwargs"] == {
+        "factory": True,
+        "host": fastmcp.settings.host,
+        "port": 8123,
+        "log_level": fastmcp.settings.log_level.lower(),
+        "timeout_graceful_shutdown": 2,
+        "lifespan": "on",
+        "ws": "websockets-sansio",
+        "reload": True,
+        "reload_dirs": [str(Path(asgi.__file__).resolve().parent.parent)],
+    }
+    assert asgi._get_dev_transport() == "streamable-http"
+    assert asgi._get_dev_ws_port() == 9555
+
+
+def test_main_uses_reloadable_runner_for_http_reload(monkeypatch):
+    calls: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        "godot_ai.asgi.run_with_reload",
+        lambda **kwargs: calls.setdefault("kwargs", kwargs),
+    )
+
+    godot_ai.main(["--transport", "streamable-http", "--port", "8123", "--ws-port", "9555", "--reload"])
+
+    assert calls["kwargs"] == {
+        "transport": "streamable-http",
+        "port": 8123,
+        "ws_port": 9555,
+    }
+
+
+def test_main_runs_server_directly_without_reload(monkeypatch):
+    server = StubServer(app=None)
+    calls: dict[str, int] = {}
+
+    def fake_create_server(ws_port: int):
+        calls["ws_port"] = ws_port
+        return server
+
+    monkeypatch.setattr("godot_ai.server.create_server", fake_create_server)
+
+    godot_ai.main(["--transport", "streamable-http", "--port", "8123", "--ws-port", "9555"])
+
+    assert calls["ws_port"] == 9555
+    assert server.run_calls == [{"transport": "streamable-http", "port": 8123}]

--- a/tests/unit/test_cli_reload.py
+++ b/tests/unit/test_cli_reload.py
@@ -79,7 +79,9 @@ def test_main_uses_reloadable_runner_for_http_reload(monkeypatch):
         lambda **kwargs: calls.setdefault("kwargs", kwargs),
     )
 
-    godot_ai.main(["--transport", "streamable-http", "--port", "8123", "--ws-port", "9555", "--reload"])
+    godot_ai.main(
+        ["--transport", "streamable-http", "--port", "8123", "--ws-port", "9555", "--reload"]
+    )
 
     assert calls["kwargs"] == {
         "transport": "streamable-http",

--- a/tests/unit/test_resources.py
+++ b/tests/unit/test_resources.py
@@ -17,8 +17,12 @@ class TestResourceRegistration:
     """Verify all expected resources are registered on the server."""
 
     async def _resource_uris(self, mcp) -> set[str]:
-        resources = await mcp.get_resources()
-        return {str(uri) for uri in resources}
+        if hasattr(mcp, "list_resources"):
+            resources = await mcp.list_resources()
+        else:
+            resources = await mcp.get_resources()
+
+        return {str(getattr(resource, "uri", resource)) for resource in resources}
 
     async def test_sessions_resource_registered(self, mcp):
         assert "godot://sessions" in await self._resource_uris(mcp)

--- a/tests/unit/test_resources.py
+++ b/tests/unit/test_resources.py
@@ -17,8 +17,8 @@ class TestResourceRegistration:
     """Verify all expected resources are registered on the server."""
 
     async def _resource_uris(self, mcp) -> set[str]:
-        resources = await mcp.list_resources()
-        return {str(r.uri) for r in resources}
+        resources = await mcp.get_resources()
+        return {str(uri) for uri in resources}
 
     async def test_sessions_resource_registered(self, mcp):
         assert "godot://sessions" in await self._resource_uris(mcp)

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+import pytest
+
+from godot_ai.handlers import client as client_handlers
 from godot_ai.handlers import editor as editor_handlers
+from godot_ai.handlers import node as node_handlers
 from godot_ai.handlers import project as project_handlers
+from godot_ai.handlers import scene as scene_handlers
 from godot_ai.handlers import session as session_handlers
+from godot_ai.handlers import testing as testing_handlers
 from godot_ai.runtime.direct import DirectRuntime
 from godot_ai.sessions.registry import Session, SessionRegistry
 
@@ -33,6 +39,42 @@ class StubClient:
         if command == "get_project_setting":
             key = params["key"] if params else ""
             return {"key": key, "value": f"value:{key}"}
+        if command == "get_editor_state":
+            return {
+                "current_scene": "res://main.tscn",
+                "project_name": "TestProject",
+                "is_playing": False,
+                "godot_version": "4.4.1",
+            }
+        if command == "get_selection":
+            return {"selected": ["/Main/Camera3D"]}
+        if command == "get_scene_tree":
+            return {
+                "root": "Main",
+                "nodes": [{"name": f"Node{i}", "type": "Node3D"} for i in range(3)],
+            }
+        if command == "get_open_scenes":
+            return {"scenes": ["res://main.tscn"], "current": "res://main.tscn"}
+        if command == "find_nodes":
+            return {"nodes": [{"name": "Player", "type": "CharacterBody3D"}]}
+        if command == "create_node":
+            return {"path": "/Main/NewNode", "type": params.get("type", "Node")}
+        if command == "get_node_properties":
+            return {"properties": [{"name": "position", "value": "(0, 0, 0)"}]}
+        if command == "get_children":
+            return {"children": [{"name": "Child1", "type": "Node3D"}]}
+        if command == "get_groups":
+            return {"groups": ["enemies"]}
+        if command == "search_filesystem":
+            return {"files": [{"path": f"res://file_{i}.gd"} for i in range(3)]}
+        if command == "run_tests":
+            return {"passed": 5, "failed": 0, "results": []}
+        if command == "get_test_results":
+            return {"passed": 5, "failed": 0, "results": []}
+        if command == "configure_client":
+            return {"status": "ok", "client": params.get("client", "")}
+        if command == "check_client_status":
+            return {"claude_code": "configured", "codex": "not_configured"}
         return {"status": "ok"}
 
 
@@ -168,3 +210,260 @@ async def test_reload_plugin_handles_disconnect_before_ack_if_replacement_is_pre
 
     assert result["new_session_id"] == "new-after-timeout"
     assert runtime.active_session_id == "new-after-timeout"
+
+
+async def test_reload_plugin_raises_when_no_active_session():
+    runtime = DirectRuntime(registry=SessionRegistry(), client=StubClient())
+    with pytest.raises(ConnectionError, match="No active Godot session"):
+        await editor_handlers.reload_plugin(runtime)
+
+
+# ---------------------------------------------------------------------------
+# Editor handler passthrough tests
+# ---------------------------------------------------------------------------
+
+
+async def test_editor_state_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await editor_handlers.editor_state(runtime)
+    assert result["project_name"] == "TestProject"
+    assert client.calls[-1]["command"] == "get_editor_state"
+
+
+async def test_editor_selection_get_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await editor_handlers.editor_selection_get(runtime)
+    assert result["selected"] == ["/Main/Camera3D"]
+
+
+async def test_selection_resource_data_handler():
+    runtime = DirectRuntime(registry=SessionRegistry(), client=StubClient())
+    result = await editor_handlers.selection_resource_data(runtime)
+    assert "selected" in result
+
+
+async def test_logs_resource_data_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await editor_handlers.logs_resource_data(runtime)
+    assert "lines" in result
+    assert client.calls[-1]["params"] == {"count": 100}
+
+
+# ---------------------------------------------------------------------------
+# Scene handler tests
+# ---------------------------------------------------------------------------
+
+
+async def test_scene_get_hierarchy_handler():
+    runtime = DirectRuntime(registry=SessionRegistry(), client=StubClient())
+    result = await scene_handlers.scene_get_hierarchy(runtime, depth=5, offset=0, limit=2)
+    assert result["root"] == "Main"
+    assert len(result["nodes"]) == 2
+    assert result["total_count"] == 3
+    assert result["has_more"] is True
+
+
+async def test_scene_get_roots_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await scene_handlers.scene_get_roots(runtime)
+    assert result["scenes"] == ["res://main.tscn"]
+
+
+async def test_current_scene_resource_data_handler():
+    runtime = DirectRuntime(registry=SessionRegistry(), client=StubClient())
+    result = await scene_handlers.current_scene_resource_data(runtime)
+    assert result["current_scene"] == "res://main.tscn"
+    assert result["project_name"] == "TestProject"
+    assert result["is_playing"] is False
+
+
+async def test_scene_hierarchy_resource_data_handler():
+    runtime = DirectRuntime(registry=SessionRegistry(), client=StubClient())
+    result = await scene_handlers.scene_hierarchy_resource_data(runtime)
+    assert "nodes" in result
+
+
+# ---------------------------------------------------------------------------
+# Node handler tests
+# ---------------------------------------------------------------------------
+
+
+async def test_node_create_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await node_handlers.node_create(
+        runtime, type="Sprite2D", name="MySprite", parent_path="/Main",
+    )
+    assert result["type"] == "Sprite2D"
+    expected = {"type": "Sprite2D", "name": "MySprite", "parent_path": "/Main"}
+    assert client.calls[-1]["params"] == expected
+
+
+async def test_node_find_handler_paginates():
+    runtime = DirectRuntime(registry=SessionRegistry(), client=StubClient())
+    result = await node_handlers.node_find(runtime, name="Player", offset=0, limit=10)
+    assert result["nodes"] == [{"name": "Player", "type": "CharacterBody3D"}]
+    assert result["total_count"] == 1
+
+
+async def test_node_get_properties_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await node_handlers.node_get_properties(runtime, path="/Main/Camera3D")
+    assert "properties" in result
+    assert client.calls[-1]["params"] == {"path": "/Main/Camera3D"}
+
+
+async def test_node_get_children_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await node_handlers.node_get_children(runtime, path="/Main")
+    assert result["children"] == [{"name": "Child1", "type": "Node3D"}]
+
+
+async def test_node_get_groups_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await node_handlers.node_get_groups(runtime, path="/Main/Enemy")
+    assert result["groups"] == ["enemies"]
+
+
+# ---------------------------------------------------------------------------
+# Testing handler tests
+# ---------------------------------------------------------------------------
+
+
+async def test_run_tests_handler_with_no_params():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await testing_handlers.run_tests(runtime)
+    assert result["passed"] == 5
+    assert client.calls[-1]["params"] == {}
+
+
+async def test_run_tests_handler_with_suite_and_test_name():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    await testing_handlers.run_tests(runtime, suite="scene", test_name="test_tree")
+    assert client.calls[-1]["params"] == {"suite": "scene", "test_name": "test_tree"}
+
+
+async def test_get_test_results_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await testing_handlers.get_test_results(runtime)
+    assert result["passed"] == 5
+    assert client.calls[-1]["command"] == "get_test_results"
+
+
+# ---------------------------------------------------------------------------
+# Client handler tests
+# ---------------------------------------------------------------------------
+
+
+async def test_client_configure_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await client_handlers.client_configure(runtime, client="codex")
+    assert result["client"] == "codex"
+    assert client.calls[-1]["params"] == {"client": "codex"}
+
+
+async def test_client_status_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await client_handlers.client_status(runtime)
+    assert result["claude_code"] == "configured"
+    assert client.calls[-1]["command"] == "check_client_status"
+
+
+# ---------------------------------------------------------------------------
+# Session handler tests
+# ---------------------------------------------------------------------------
+
+
+def test_session_activate_handler_success():
+    registry = SessionRegistry()
+    registry.register(_make_session("a"))
+    runtime = DirectRuntime(registry=registry, client=StubClient())
+    result = session_handlers.session_activate(runtime, "a")
+    assert result == {"status": "ok", "active_session_id": "a"}
+
+
+def test_session_activate_handler_not_found():
+    runtime = DirectRuntime(registry=SessionRegistry(), client=StubClient())
+    result = session_handlers.session_activate(runtime, "nonexistent")
+    assert result["status"] == "error"
+    assert "not found" in result["message"]
+
+
+def test_session_resource_data_delegates_to_session_list():
+    registry = SessionRegistry()
+    registry.register(_make_session("a"))
+    runtime = DirectRuntime(registry=registry, client=StubClient())
+    result = session_handlers.session_resource_data(runtime)
+    assert result["count"] == 1
+    assert result["sessions"][0]["session_id"] == "a"
+
+
+# ---------------------------------------------------------------------------
+# Project handler tests
+# ---------------------------------------------------------------------------
+
+
+def test_project_info_resource_data_with_active_session():
+    registry = SessionRegistry()
+    registry.register(_make_session("proj-1"))
+    runtime = DirectRuntime(registry=registry, client=StubClient())
+    result = project_handlers.project_info_resource_data(runtime)
+    assert result["session_id"] == "proj-1"
+    assert "connected_at" not in result
+
+
+def test_project_info_resource_data_no_session():
+    runtime = DirectRuntime(registry=SessionRegistry(), client=StubClient())
+    result = project_handlers.project_info_resource_data(runtime)
+    assert result["error"] == "No active Godot session"
+    assert result["connected"] is False
+
+
+async def test_filesystem_search_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await project_handlers.filesystem_search(
+        runtime, name="file", type="GDScript", path="res://", offset=0, limit=2,
+    )
+    assert len(result["files"]) == 2
+    assert result["total_count"] == 3
+    assert client.calls[-1]["params"] == {"name": "file", "type": "GDScript", "path": "res://"}
+
+
+async def test_filesystem_search_handler_empty_params():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    await project_handlers.filesystem_search(runtime)
+    assert client.calls[-1]["params"] == {}
+
+
+async def test_project_settings_resource_data_collects_errors():
+    """When a setting fetch raises, the error is collected not propagated."""
+
+    class FailingClient(StubClient):
+        async def send(self, command, params=None, **kwargs):
+            if command == "get_project_setting":
+                key = params["key"] if params else ""
+                if key == "application/config/name":
+                    raise RuntimeError("connection lost")
+            return await super().send(command, params, **kwargs)
+
+    runtime = DirectRuntime(registry=SessionRegistry(), client=FailingClient())
+    result = await project_handlers.project_settings_resource_data(runtime)
+    assert result["errors"] is not None
+    error_keys = [e["key"] for e in result["errors"]]
+    assert "application/config/name" in error_keys
+    # Other settings should still succeed
+    assert len(result["settings"]) == len(project_handlers.COMMON_SETTINGS) - 1

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
-
 from godot_ai.handlers import editor as editor_handlers
 from godot_ai.handlers import project as project_handlers
 from godot_ai.handlers import session as session_handlers

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -1,0 +1,172 @@
+"""Unit tests for the direct runtime adapter and shared handlers."""
+
+from __future__ import annotations
+
+import asyncio
+
+from godot_ai.handlers import editor as editor_handlers
+from godot_ai.handlers import project as project_handlers
+from godot_ai.handlers import session as session_handlers
+from godot_ai.runtime.direct import DirectRuntime
+from godot_ai.sessions.registry import Session, SessionRegistry
+
+
+class StubClient:
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    async def send(
+        self,
+        command: str,
+        params: dict | None = None,
+        session_id: str | None = None,
+        timeout: float = 5.0,
+    ) -> dict:
+        self.calls.append(
+            {
+                "command": command,
+                "params": params,
+                "session_id": session_id,
+                "timeout": timeout,
+            }
+        )
+        if command == "get_logs":
+            return {"lines": [f"line {i}" for i in range(6)]}
+        if command == "get_project_setting":
+            key = params["key"] if params else ""
+            return {"key": key, "value": f"value:{key}"}
+        return {"status": "ok"}
+
+
+class ReloadStubClient:
+    def __init__(
+        self,
+        registry: SessionRegistry,
+        new_session_id: str = "reloaded",
+        raise_timeout: bool = False,
+    ):
+        self.registry = registry
+        self.new_session_id = new_session_id
+        self.raise_timeout = raise_timeout
+        self.calls: list[dict] = []
+
+    async def send(
+        self,
+        command: str,
+        params: dict | None = None,
+        session_id: str | None = None,
+        timeout: float = 5.0,
+    ) -> dict:
+        self.calls.append(
+            {
+                "command": command,
+                "params": params,
+                "session_id": session_id,
+                "timeout": timeout,
+            }
+        )
+        if command == "reload_plugin":
+            self.registry.unregister("old-session")
+            self.registry.register(
+                _make_session(
+                    self.new_session_id,
+                    project_path="/tmp/test_project",
+                )
+            )
+            if self.raise_timeout:
+                raise TimeoutError("disconnect during reload")
+            return {"status": "reloading", "message": "Plugin reload initiated"}
+        return {"status": "ok"}
+
+
+def _make_session(session_id: str = "test-001", **overrides) -> Session:
+    defaults = {
+        "session_id": session_id,
+        "godot_version": "4.4.1",
+        "project_path": "/tmp/test_project",
+        "plugin_version": "0.0.1",
+    }
+    defaults.update(overrides)
+    return Session(**defaults)
+
+
+def test_direct_runtime_exposes_registry_state():
+    registry = SessionRegistry()
+    registry.register(_make_session("a"))
+    registry.register(_make_session("b"))
+    registry.set_active("b")
+    runtime = DirectRuntime(registry=registry, client=StubClient())
+
+    assert runtime.active_session_id == "b"
+    assert runtime.get_active_session().session_id == "b"
+    assert [session.session_id for session in runtime.list_sessions()] == ["a", "b"]
+
+
+async def test_logs_read_handler_uses_runtime_and_paginates():
+    runtime = DirectRuntime(registry=SessionRegistry(), client=StubClient())
+
+    result = await editor_handlers.logs_read(runtime, count=2, offset=3)
+
+    assert result["lines"] == ["line 3", "line 4"]
+    assert result["offset"] == 3
+    assert result["limit"] == 2
+    assert result["total_count"] == 6
+    assert result["has_more"] is True
+
+
+async def test_project_settings_resource_collects_results():
+    runtime = DirectRuntime(registry=SessionRegistry(), client=StubClient())
+
+    result = await project_handlers.project_settings_resource_data(runtime)
+
+    assert result["settings"]["application/config/name"] == "value:application/config/name"
+    assert result["errors"] is None
+
+
+def test_session_handlers_keep_active_flag_shape():
+    registry = SessionRegistry()
+    registry.register(_make_session("a"))
+    registry.register(_make_session("b"))
+    registry.set_active("b")
+    runtime = DirectRuntime(registry=registry, client=StubClient())
+
+    result = session_handlers.session_list(runtime)
+
+    sessions = {session["session_id"]: session["is_active"] for session in result["sessions"]}
+    assert sessions == {"a": False, "b": True}
+
+
+async def test_reload_plugin_returns_existing_replacement_session_without_wait_race():
+    registry = SessionRegistry()
+    registry.register(_make_session("old-session"))
+    runtime = DirectRuntime(
+        registry=registry,
+        client=ReloadStubClient(registry=registry, new_session_id="new-session"),
+    )
+
+    result = await editor_handlers.reload_plugin(runtime)
+
+    assert result == {
+        "status": "reloaded",
+        "old_session_id": "old-session",
+        "new_session_id": "new-session",
+    }
+    assert runtime.active_session_id == "new-session"
+
+
+async def test_reload_plugin_handles_disconnect_before_ack_if_replacement_is_present():
+    registry = SessionRegistry()
+    registry.register(_make_session("old-session"))
+    runtime = DirectRuntime(
+        registry=registry,
+        client=ReloadStubClient(
+            registry=registry,
+            new_session_id="new-after-timeout",
+            raise_timeout=True,
+        ),
+    )
+
+    result = await editor_handlers.reload_plugin(runtime)
+
+    assert result["new_session_id"] == "new-after-timeout"
+    assert runtime.active_session_id == "new-after-timeout"

--- a/tests/unit/test_session_registry.py
+++ b/tests/unit/test_session_registry.py
@@ -91,7 +91,7 @@ class TestSessionRegistry:
 
 class TestWaitForSession:
     async def test_resolves_immediately_if_session_already_registered(self):
-        """If a session registers before wait starts, it resolves on the next one."""
+        """Waiter installed before registration resolves as soon as session registers."""
         reg = SessionRegistry()
         s = _make_session("new-1")
 

--- a/tests/unit/test_session_registry.py
+++ b/tests/unit/test_session_registry.py
@@ -1,5 +1,7 @@
 """Tests for SessionRegistry."""
 
+import asyncio
+
 import pytest
 
 from godot_ai.sessions.registry import Session, SessionRegistry
@@ -85,3 +87,47 @@ class TestSessionRegistry:
         assert d["godot_version"] == "4.4.1"
         assert d["project_path"] == "/tmp/test_project"
         assert "connected_at" in d
+
+
+class TestWaitForSession:
+    async def test_resolves_immediately_if_session_already_registered(self):
+        """If a session registers before wait starts, it resolves on the next one."""
+        reg = SessionRegistry()
+        s = _make_session("new-1")
+
+        async def register_soon():
+            await asyncio.sleep(0.05)
+            reg.register(s)
+
+        asyncio.create_task(register_soon())
+        result = await reg.wait_for_session(timeout=2.0)
+        assert result.session_id == "new-1"
+
+    async def test_blocks_then_resolves(self):
+        reg = SessionRegistry()
+
+        async def register_later():
+            await asyncio.sleep(0.1)
+            reg.register(_make_session("delayed"))
+
+        asyncio.create_task(register_later())
+        result = await reg.wait_for_session(timeout=2.0)
+        assert result.session_id == "delayed"
+
+    async def test_timeout_raises(self):
+        reg = SessionRegistry()
+        with pytest.raises(TimeoutError, match="Timed out"):
+            await reg.wait_for_session(timeout=0.1)
+
+    async def test_ignores_excluded_id(self):
+        reg = SessionRegistry()
+
+        async def register_both():
+            await asyncio.sleep(0.05)
+            reg.register(_make_session("old-1"))  # excluded
+            await asyncio.sleep(0.05)
+            reg.register(_make_session("new-1"))  # should match
+
+        asyncio.create_task(register_both())
+        result = await reg.wait_for_session(exclude_id="old-1", timeout=2.0)
+        assert result.session_id == "new-1"


### PR DESCRIPTION
## Summary

This PR wires the reload workflow all the way through for local development:

- adds a shared runtime/handler layer for editor, scene, node, project, client, session, and testing flows
- makes `reload_plugin` robust against fast reconnect races by detecting the replacement session directly
- adds a real reloadable ASGI entrypoint for HTTP transports via `godot_ai.asgi`
- switches `python -m godot_ai --transport streamable-http --port 8000 --reload` onto Uvicorn's supported import-string/factory reload path
- adds first-class Codex configurator support in `client_configurator.gd`, including configure/status/remove handling for `~/.codex/config.toml`
- updates the Godot plugin dock and dev-server workflow so plugin reload, server reload, and client configuration can be exercised together
- adds regression coverage for runtime handlers, CLI reload wiring, session waiting, client flows, and MCP tool reload behavior

## Root Cause

There were two separate failure modes behind the expected reload behavior:

1. Python dev reload was effectively a no-op. We were passing `reload=True` through FastMCP's in-memory app path, but Uvicorn only activates its reload supervisor when the app is provided as an import string/factory.
2. The MCP `reload_plugin` wrapper could miss a very fast reconnect. If the replacement Godot session registered before the waiter was installed, the tool would hang until timeout even though the plugin had already reloaded.

This PR also folds in the related Codex client configuration work that was needed to exercise the end-to-end workflow from the editor side.

## Codex Configurator

- adds `codex` to the supported client set alongside Claude Code and Antigravity
- manages the `godot-ai` MCP server entry in `~/.codex/config.toml`
- supports configure, status, and remove flows for Codex
- routes the Python-side client tools through the new runtime/handler layer instead of calling the lifespan context directly

## Impact

- Python edits now trigger a real server restart in dev `--reload` mode.
- Native `reload_plugin` now returns reliably after the plugin reconnects.
- Codex can be configured from the plugin-side client configurator flow as part of the same workflow.
- The plugin-side dev workflow and client configurator flow can be reviewed together instead of requiring manual restarts or hand-waving around timeouts.

## Validation

Automated:

- `pytest -q tests/unit/test_cli_reload.py tests/unit/test_runtime_handlers.py tests/unit/test_session_registry.py tests/unit/test_resources.py tests/integration/test_mcp_tools.py`

Live verification:

- started the external MCP server in `--reload` mode and confirmed Uvicorn launched a real WatchFiles reloader
- made a temporary Python marker change and confirmed WatchFiles restarted the worker and native `editor_state` reflected the new server-side marker
- made a temporary plugin marker change and confirmed native `reload_plugin` returned a new session id and `logs_read` showed the updated plugin-side marker
- reverted both temporary markers and confirmed the live editor returned to the normal state
