### PR TITLE
Add Phase 3 Batch 1: readiness gating + signal/autoload/input_map tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,14 +60,15 @@ The Godot dock also has a **Start/Stop Dev Server** button for convenience.
 
 ### Python tests
 ```bash
-pytest -v                    # 192 unit + integration tests
+pytest -v                    # 227 unit + integration tests
 ```
 
 ### Godot-side tests
 GDScript test suites in `test_project/tests/` exercise handlers inside the running editor. Run via MCP:
 ```
-run_tests                    # run all suites
+run_tests                    # compact: summary + failures only
 run_tests suite=scene        # run one suite
+run_tests verbose=true       # include every individual test result
 get_test_results             # review last results
 ```
 
@@ -79,6 +80,22 @@ Test suites extend `McpTestSuite` (assertion methods: `assert_true`, `assert_eq`
 2. Open a scene (e.g. `main.tscn`)
 3. Plugin starts the server automatically; logs should show `Session connected`
 4. Use `/mcp` in Claude Code to connect
+
+## Pre-commit smoke test
+
+**Always do this before every commit.** Python mocks don't catch GDScript bugs, editor API regressions, or undo/redo issues.
+
+1. `ruff check src/ tests/` — lint passes
+2. `pytest -v` — all Python tests pass
+3. Open `test_project/` in Godot (or launch: `/Applications/Godot_mono.app/Contents/MacOS/Godot --editor --path test_project/`)
+4. `session_activate` the test_project session if multiple editors are connected
+5. `run_tests` via MCP — all GDScript tests pass (0 failures)
+6. **Live smoke test** new/changed features against the real editor:
+   - Call each new tool and verify the response makes sense
+   - For write tools: verify the change is visible in the editor, and verify undo works (Ctrl+Z in Godot)
+   - For read tools: compare response against what you see in the editor
+   - Check `editor_state` to confirm readiness field is present
+7. Only commit when all of the above are green
 
 ## Client configuration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ AI Client → MCP (stdio/sse/streamable-http) → Python FastMCP server → WebS
 - **Protocol**: JSON over WebSocket. Request/response with `request_id` correlation. Handshake on connect.
 - **Session model**: Multiple Godot editors can connect. Tools route through active session.
 - **Handler/Runtime layer**: Shared handlers in `src/godot_ai/handlers/` contain tool logic. They depend on a `Runtime` protocol (`runtime/interface.py`), implemented by `DirectRuntime` for the in-process server. Tools and resources are thin wrappers that create a runtime and delegate.
+- **Readiness gating**: Write operations check session readiness (`ready`/`importing`/`playing`/`no_scene`) before executing. Plugin sends readiness in handshake and via `readiness_changed` events. Python `require_writable()` in `handlers/_readiness.py` gates all write handlers.
 
 ## Key conventions
 
@@ -60,7 +61,7 @@ The Godot dock also has a **Start/Stop Dev Server** button for convenience.
 
 ### Python tests
 ```bash
-pytest -v                    # 227 unit + integration tests
+pytest -v                    # 234 unit + integration tests
 ```
 
 ### Godot-side tests
@@ -113,7 +114,8 @@ MCP tools `client_configure` and `client_status` expose this to AI clients.
 3. Add a shared Python handler in `handlers/<domain>.py` that calls `runtime.send_command("command_name", params)`
 4. Add a Python tool in `tools/<domain>.py` that creates `DirectRuntime` and delegates to the handler
 5. Register the tool module in `server.py` if it's a new file
-6. Add tests: handler unit test, Python integration test, AND GDScript test in `test_project/tests/`
+6. For write tools: add `require_writable(runtime)` call at the top of the Python handler
+7. Add tests: handler unit test, Python integration test, AND GDScript test in `test_project/tests/`
 
 ## Write tools must be undoable
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -592,7 +592,7 @@ All write tools check readiness before executing:
 ### Phase 2 exit criteria
 - [x] All Batch 5-7 tools implemented and tested
 - [x] Undo works for node operations (create, delete, reparent, set_property, duplicate, move, group ops)
-- [ ] Write operations are gated on readiness
+- [x] Write operations are gated on readiness (session tracks readiness state via events, Python handlers call require_writable() before writes)
 - [x] Manual test: ask Claude to create a scene with 5 nodes and a script — it can (smoke tested: 7 nodes, player script with 3 signals/4 exports/3 functions, attached, properties set)
 - [x] 60+ passing tests (192 Python + 124 GDScript = 316 total)
 
@@ -634,8 +634,13 @@ All write tools check readiness before executing:
 - Session selection UI or tool parameter
 - Session metadata includes enough info to distinguish (project path, window title)
 
+### Phase 3 progress
+- [x] Batch 1: Signal, autoload, input_map, project_settings_set — 11 new tools, 14 new GDScript handlers
+- [x] Readiness gating — GDScript computes readiness (ready/importing/playing/no_scene), sends events, Python gates all write operations
+- [x] 227 Python tests + 152 Godot-side tests = 379 total
+
 ### Phase 3 exit criteria
-- [ ] Signal, autoload, input_map tools work
+- [x] Signal, autoload, input_map tools work (signal_list/connect/disconnect, autoload_list/add/remove, input_map_list/add_action/remove_action/bind_event, project_settings_set)
 - [ ] Project run/stop cycle works reliably
 - [ ] Batch execution handles partial failures
 - [ ] Multi-instance: two Godot editors connected, commands route correctly

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -637,7 +637,9 @@ All write tools check readiness before executing:
 ### Phase 3 progress
 - [x] Batch 1: Signal, autoload, input_map, project_settings_set — 11 new tools, 14 new GDScript handlers
 - [x] Readiness gating — GDScript computes readiness (ready/importing/playing/no_scene), sends events, Python gates all write operations
-- [x] 227 Python tests + 152 Godot-side tests = 379 total
+- [x] Autoload path validation — `res://` prefix + file existence check (security hardening)
+- [x] Compact test output — summary + failures only by default, verbose opt-in
+- [x] 234 Python tests + 156 Godot-side tests = 390 total
 
 ### Phase 3 exit criteria
 - [x] Signal, autoload, input_map tools work (signal_list/connect/disconnect, autoload_list/add/remove, input_map_list/add_action/remove_action/bind_event, project_settings_set)

--- a/plugin/addons/godot_ai/connection.gd
+++ b/plugin/addons/godot_ai/connection.gd
@@ -94,6 +94,7 @@ func _attempt_reconnect() -> void:
 
 
 func _send_handshake() -> void:
+	_last_readiness = get_readiness()
 	_send_json({
 		"type": "handshake",
 		"session_id": _session_id,
@@ -101,6 +102,7 @@ func _send_handshake() -> void:
 		"project_path": ProjectSettings.globalize_path("res://"),
 		"plugin_version": "0.0.1",
 		"protocol_version": 1,
+		"readiness": _last_readiness,
 	})
 
 
@@ -129,6 +131,18 @@ func _hook_editor_signals() -> void:
 
 var _last_scene_path := ""
 var _last_play_state := false
+var _last_readiness := ""
+
+
+## Compute current editor readiness from live Godot state.
+static func get_readiness() -> String:
+	if EditorInterface.get_resource_filesystem().is_scanning():
+		return "importing"
+	if EditorInterface.is_playing_scene():
+		return "playing"
+	if EditorInterface.get_edited_scene_root() == null:
+		return "no_scene"
+	return "ready"
 
 
 ## Check for scene/play state changes each frame (lightweight polling).
@@ -147,6 +161,13 @@ func _check_state_changes() -> void:
 		send_event("play_state_changed", {"play_state": state})
 		if log_buffer:
 			log_buffer.log("[event] play_state_changed -> %s" % state)
+
+	var readiness := get_readiness()
+	if readiness != _last_readiness:
+		_last_readiness = readiness
+		send_event("readiness_changed", {"readiness": readiness})
+		if log_buffer:
+			log_buffer.log("[event] readiness -> %s" % readiness)
 
 
 func _get_current_scene_path() -> String:

--- a/plugin/addons/godot_ai/handlers/autoload_handler.gd
+++ b/plugin/addons/godot_ai/handlers/autoload_handler.gd
@@ -1,0 +1,87 @@
+@tool
+class_name AutoloadHandler
+extends RefCounted
+
+## Handles autoload listing, adding, and removing via ProjectSettings.
+
+
+func list_autoloads(_params: Dictionary) -> Dictionary:
+	var autoloads: Array[Dictionary] = []
+	for prop in ProjectSettings.get_property_list():
+		var key: String = prop.get("name", "")
+		if not key.begins_with("autoload/"):
+			continue
+		var name := key.substr("autoload/".length())
+		var raw_value: String = ProjectSettings.get_setting(key, "")
+		var is_singleton := raw_value.begins_with("*")
+		var path := raw_value.substr(1) if is_singleton else raw_value
+		autoloads.append({
+			"name": name,
+			"path": path,
+			"singleton": is_singleton,
+		})
+	return {"data": {"autoloads": autoloads, "count": autoloads.size()}}
+
+
+func add_autoload(params: Dictionary) -> Dictionary:
+	var name: String = params.get("name", "")
+	var path: String = params.get("path", "")
+	var singleton: bool = params.get("singleton", true)
+
+	if name.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: name")
+	if path.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: path")
+	if not path.begins_with("res://"):
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Path must start with res:// (got: %s)" % path)
+	if not FileAccess.file_exists(path):
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "File not found: %s" % path)
+
+	var key := "autoload/%s" % name
+	if ProjectSettings.has_setting(key):
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Autoload '%s' already exists" % name)
+
+	var value := ("*" if singleton else "") + path
+	ProjectSettings.set_setting(key, value)
+	ProjectSettings.set_initial_value(key, "")
+	ProjectSettings.set_as_basic(key, true)
+	var err := ProjectSettings.save()
+	if err != OK:
+		ProjectSettings.clear(key)
+		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to save project settings (error %d)" % err)
+
+	return {
+		"data": {
+			"name": name,
+			"path": path,
+			"singleton": singleton,
+			"undoable": false,
+			"reason": "Autoload changes are saved to project.godot",
+		}
+	}
+
+
+func remove_autoload(params: Dictionary) -> Dictionary:
+	var name: String = params.get("name", "")
+	if name.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: name")
+
+	var key := "autoload/%s" % name
+	if not ProjectSettings.has_setting(key):
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Autoload '%s' not found" % name)
+
+	var old_value: String = ProjectSettings.get_setting(key, "")
+	ProjectSettings.clear(key)
+	var err := ProjectSettings.save()
+	if err != OK:
+		ProjectSettings.set_setting(key, old_value)
+		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to save project settings (error %d)" % err)
+
+	return {
+		"data": {
+			"name": name,
+			"removed": true,
+			"undoable": false,
+			"reason": "Autoload changes are saved to project.godot",
+		}
+	}

--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -19,6 +19,7 @@ func get_editor_state(_params: Dictionary) -> Dictionary:
 			"project_name": ProjectSettings.get_setting("application/config/name", ""),
 			"current_scene": scene_root.scene_file_path if scene_root else "",
 			"is_playing": EditorInterface.is_playing_scene(),
+			"readiness": Connection.get_readiness(),
 		}
 	}
 

--- a/plugin/addons/godot_ai/handlers/input_handler.gd
+++ b/plugin/addons/godot_ai/handlers/input_handler.gd
@@ -1,0 +1,200 @@
+@tool
+class_name InputHandler
+extends RefCounted
+
+## Handles input action listing, creation, removal, and event binding.
+## Actions are persisted via ProjectSettings so they survive editor restarts.
+
+
+func list_actions(params: Dictionary) -> Dictionary:
+	var include_builtin: bool = params.get("include_builtin", false)
+	var actions: Array[Dictionary] = []
+	for action_name in InputMap.get_actions():
+		var name_str := str(action_name)
+		var is_builtin := name_str.begins_with("ui_")
+		if is_builtin and not include_builtin:
+			continue
+		var events: Array[Dictionary] = []
+		for event in InputMap.action_get_events(action_name):
+			events.append(_serialize_event(event))
+		actions.append({
+			"name": name_str,
+			"events": events,
+			"event_count": events.size(),
+			"is_builtin": is_builtin,
+		})
+	return {"data": {"actions": actions, "count": actions.size()}}
+
+
+func add_action(params: Dictionary) -> Dictionary:
+	var action: String = params.get("action", "")
+	var deadzone: float = params.get("deadzone", 0.5)
+
+	if action.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: action")
+
+	if InputMap.has_action(action):
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Action '%s' already exists" % action)
+
+	InputMap.add_action(action, deadzone)
+
+	var key := "input/%s" % action
+	ProjectSettings.set_setting(key, {
+		"deadzone": deadzone,
+		"events": [],
+	})
+	var err := ProjectSettings.save()
+	if err != OK:
+		InputMap.erase_action(action)
+		ProjectSettings.clear(key)
+		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to save project settings (error %d)" % err)
+
+	return {
+		"data": {
+			"action": action,
+			"deadzone": deadzone,
+			"undoable": false,
+			"reason": "Input actions are saved to project.godot",
+		}
+	}
+
+
+func remove_action(params: Dictionary) -> Dictionary:
+	var action: String = params.get("action", "")
+	if action.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: action")
+
+	if not InputMap.has_action(action):
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Action '%s' not found" % action)
+
+	var key := "input/%s" % action
+	var old_setting = ProjectSettings.get_setting(key) if ProjectSettings.has_setting(key) else null
+	InputMap.erase_action(action)
+
+	if old_setting != null:
+		ProjectSettings.clear(key)
+		var err := ProjectSettings.save()
+		if err != OK:
+			InputMap.add_action(action)
+			ProjectSettings.set_setting(key, old_setting)
+			return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to save project settings (error %d)" % err)
+
+	return {
+		"data": {
+			"action": action,
+			"removed": true,
+			"undoable": false,
+			"reason": "Input actions are saved to project.godot",
+		}
+	}
+
+
+func bind_event(params: Dictionary) -> Dictionary:
+	var action: String = params.get("action", "")
+	var event_type: String = params.get("event_type", "")
+
+	if action.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: action")
+	if event_type.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: event_type")
+
+	if not InputMap.has_action(action):
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Action '%s' not found" % action)
+
+	var event: InputEvent = _create_event(event_type, params)
+	if event == null:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Unsupported event_type: %s (use key, mouse_button, or joy_button)" % event_type)
+
+	InputMap.action_add_event(action, event)
+
+	var err := _save_action_events(action)
+	if err != OK:
+		InputMap.action_erase_event(action, event)
+		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to save project settings (error %d)" % err)
+
+	return {
+		"data": {
+			"action": action,
+			"event": _serialize_event(event),
+			"undoable": false,
+			"reason": "Input bindings are saved to project.godot",
+		}
+	}
+
+
+func _create_event(event_type: String, params: Dictionary) -> InputEvent:
+	match event_type:
+		"key":
+			var ev := InputEventKey.new()
+			var keycode_str: String = params.get("keycode", "")
+			if keycode_str.is_empty():
+				return null
+			ev.keycode = OS.find_keycode_from_string(keycode_str)
+			if ev.keycode == KEY_NONE:
+				return null
+			ev.ctrl_pressed = params.get("ctrl", false)
+			ev.alt_pressed = params.get("alt", false)
+			ev.shift_pressed = params.get("shift", false)
+			ev.meta_pressed = params.get("meta", false)
+			return ev
+		"mouse_button":
+			var ev := InputEventMouseButton.new()
+			var button: int = params.get("button", 0)
+			if button <= 0:
+				return null
+			ev.button_index = button
+			return ev
+		"joy_button":
+			var ev := InputEventJoypadButton.new()
+			if not params.has("button"):
+				return null
+			ev.button_index = int(params.get("button", 0))
+			return ev
+	return null
+
+
+func _serialize_event(event: InputEvent) -> Dictionary:
+	if event is InputEventKey:
+		return {
+			"type": "key",
+			"keycode": OS.get_keycode_string(event.keycode),
+			"physical_keycode": OS.get_keycode_string(event.physical_keycode),
+			"ctrl": event.ctrl_pressed,
+			"alt": event.alt_pressed,
+			"shift": event.shift_pressed,
+			"meta": event.meta_pressed,
+		}
+	if event is InputEventMouseButton:
+		return {
+			"type": "mouse_button",
+			"button": event.button_index,
+		}
+	if event is InputEventJoypadButton:
+		return {
+			"type": "joy_button",
+			"button": event.button_index,
+		}
+	if event is InputEventJoypadMotion:
+		return {
+			"type": "joy_axis",
+			"axis": event.axis,
+			"axis_value": event.axis_value,
+		}
+	return {"type": event.get_class(), "string": str(event)}
+
+
+func _save_action_events(action: String) -> int:
+	var events: Array = []
+	for event in InputMap.action_get_events(action):
+		events.append(event)
+	var key := "input/%s" % action
+	var deadzone: float = 0.5
+	if ProjectSettings.has_setting(key):
+		var existing = ProjectSettings.get_setting(key)
+		if existing is Dictionary:
+			deadzone = existing.get("deadzone", 0.5)
+	ProjectSettings.set_setting(key, {
+		"deadzone": deadzone,
+		"events": events,
+	})
+	return ProjectSettings.save()

--- a/plugin/addons/godot_ai/handlers/input_handler.gd
+++ b/plugin/addons/godot_ai/handlers/input_handler.gd
@@ -75,7 +75,12 @@ func remove_action(params: Dictionary) -> Dictionary:
 		ProjectSettings.clear(key)
 		var err := ProjectSettings.save()
 		if err != OK:
-			InputMap.add_action(action)
+			var dz: float = old_setting.get("deadzone", 0.5) if old_setting is Dictionary else 0.5
+			InputMap.add_action(action, dz)
+			if old_setting is Dictionary:
+				for ev in old_setting.get("events", []):
+					if ev is InputEvent:
+						InputMap.action_add_event(action, ev)
 			ProjectSettings.set_setting(key, old_setting)
 			return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to save project settings (error %d)" % err)
 
@@ -188,13 +193,19 @@ func _save_action_events(action: String) -> int:
 	for event in InputMap.action_get_events(action):
 		events.append(event)
 	var key := "input/%s" % action
+	var had_setting := ProjectSettings.has_setting(key)
+	var old_setting = ProjectSettings.get_setting(key) if had_setting else null
 	var deadzone: float = 0.5
-	if ProjectSettings.has_setting(key):
-		var existing = ProjectSettings.get_setting(key)
-		if existing is Dictionary:
-			deadzone = existing.get("deadzone", 0.5)
+	if old_setting is Dictionary:
+		deadzone = old_setting.get("deadzone", 0.5)
 	ProjectSettings.set_setting(key, {
 		"deadzone": deadzone,
 		"events": events,
 	})
-	return ProjectSettings.save()
+	var err := ProjectSettings.save()
+	if err != OK:
+		if had_setting:
+			ProjectSettings.set_setting(key, old_setting)
+		else:
+			ProjectSettings.clear(key)
+	return err

--- a/plugin/addons/godot_ai/handlers/project_handler.gd
+++ b/plugin/addons/godot_ai/handlers/project_handler.gd
@@ -23,6 +23,38 @@ func get_project_setting(params: Dictionary) -> Dictionary:
 	}
 
 
+func set_project_setting(params: Dictionary) -> Dictionary:
+	var key: String = params.get("key", "")
+	if key.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: key")
+
+	if not params.has("value"):
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: value")
+
+	var value = params.get("value")
+	var had_setting := ProjectSettings.has_setting(key)
+	var old_value = ProjectSettings.get_setting(key) if had_setting else null
+	ProjectSettings.set_setting(key, value)
+	var err := ProjectSettings.save()
+	if err != OK:
+		if had_setting:
+			ProjectSettings.set_setting(key, old_value)
+		else:
+			ProjectSettings.clear(key)
+		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to save project settings (error %d)" % err)
+
+	return {
+		"data": {
+			"key": key,
+			"value": NodeHandler._serialize_value(value),
+			"old_value": NodeHandler._serialize_value(old_value),
+			"type": type_string(typeof(value)),
+			"undoable": false,
+			"reason": "ProjectSettings changes are saved to disk",
+		}
+	}
+
+
 func search_filesystem(params: Dictionary) -> Dictionary:
 	var name_filter: String = params.get("name", "")
 	var type_filter: String = params.get("type", "")

--- a/plugin/addons/godot_ai/handlers/signal_handler.gd
+++ b/plugin/addons/godot_ai/handlers/signal_handler.gd
@@ -1,0 +1,144 @@
+@tool
+class_name SignalHandler
+extends RefCounted
+
+## Handles signal listing, connecting, and disconnecting on scene nodes.
+
+var _undo_redo: EditorUndoRedoManager
+
+
+func _init(undo_redo: EditorUndoRedoManager) -> void:
+	_undo_redo = undo_redo
+
+
+func list_signals(params: Dictionary) -> Dictionary:
+	var path: String = params.get("path", "")
+	if path.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: path")
+
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+
+	var node := ScenePath.resolve(path, scene_root)
+	if node == null:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % path)
+
+	var signals: Array[Dictionary] = []
+	for sig in node.get_signal_list():
+		var args: Array[Dictionary] = []
+		for arg in sig.get("args", []):
+			args.append({"name": arg.get("name", ""), "type": type_string(arg.get("type", 0))})
+		signals.append({
+			"name": sig.get("name", ""),
+			"args": args,
+		})
+
+	var connections: Array[Dictionary] = []
+	for sig in signals:
+		for conn in node.get_signal_connection_list(sig.name):
+			var callable: Callable = conn.get("callable", Callable())
+			var target := callable.get_object()
+			connections.append({
+				"signal": sig.name,
+				"target": ScenePath.from_node(target, scene_root) if target is Node else str(target),
+				"method": callable.get_method(),
+			})
+
+	return {
+		"data": {
+			"path": ScenePath.from_node(node, scene_root),
+			"signals": signals,
+			"signal_count": signals.size(),
+			"connections": connections,
+			"connection_count": connections.size(),
+		}
+	}
+
+
+func connect_signal(params: Dictionary) -> Dictionary:
+	var resolved := _resolve_signal_params(params)
+	if resolved.has("error"):
+		return resolved
+
+	var source: Node = resolved.source
+	var target: Node = resolved.target
+	var signal_name: String = resolved.signal_name
+	var method: String = resolved.method
+	var scene_root: Node = resolved.scene_root
+
+	if not source.has_signal(signal_name):
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Signal '%s' not found on %s" % [signal_name, params.path])
+
+	if not target.has_method(method):
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Method '%s' not found on %s" % [method, params.target])
+
+	var callable := Callable(target, method)
+	if source.is_connected(signal_name, callable):
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Signal '%s' already connected to %s.%s" % [signal_name, params.target, method])
+
+	_undo_redo.create_action("MCP: Connect signal %s" % signal_name)
+	_undo_redo.add_do_method(source, "connect", signal_name, callable)
+	_undo_redo.add_undo_method(source, "disconnect", signal_name, callable)
+	_undo_redo.commit_action()
+
+	return {"data": _signal_response(source, signal_name, target, method, scene_root)}
+
+
+func disconnect_signal(params: Dictionary) -> Dictionary:
+	var resolved := _resolve_signal_params(params)
+	if resolved.has("error"):
+		return resolved
+
+	var source: Node = resolved.source
+	var target: Node = resolved.target
+	var signal_name: String = resolved.signal_name
+	var method: String = resolved.method
+	var scene_root: Node = resolved.scene_root
+
+	var callable := Callable(target, method)
+	if not source.is_connected(signal_name, callable):
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Signal '%s' is not connected to %s.%s" % [signal_name, params.target, method])
+
+	_undo_redo.create_action("MCP: Disconnect signal %s" % signal_name)
+	_undo_redo.add_do_method(source, "disconnect", signal_name, callable)
+	_undo_redo.add_undo_method(source, "connect", signal_name, callable)
+	_undo_redo.commit_action()
+
+	return {"data": _signal_response(source, signal_name, target, method, scene_root)}
+
+
+func _resolve_signal_params(params: Dictionary) -> Dictionary:
+	for key in ["path", "signal", "target", "method"]:
+		if params.get(key, "").is_empty():
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: %s" % key)
+
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+
+	var source := ScenePath.resolve(params.path, scene_root)
+	if source == null:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Source node not found: %s" % params.path)
+
+	var target := ScenePath.resolve(params.target, scene_root)
+	if target == null:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Target node not found: %s" % params.target)
+
+	return {
+		"source": source,
+		"target": target,
+		"signal_name": params.signal,
+		"method": params.method,
+		"scene_root": scene_root,
+	}
+
+
+func _signal_response(source: Node, signal_name: String, target: Node, method: String, scene_root: Node) -> Dictionary:
+	return {
+		"source": ScenePath.from_node(source, scene_root),
+		"signal": signal_name,
+		"target": ScenePath.from_node(target, scene_root),
+		"method": method,
+		"undoable": true,
+	}

--- a/plugin/addons/godot_ai/handlers/test_handler.gd
+++ b/plugin/addons/godot_ai/handlers/test_handler.gd
@@ -19,6 +19,7 @@ func _init(undo_redo: EditorUndoRedoManager, log_buffer: McpLogBuffer) -> void:
 func run_tests(params: Dictionary) -> Dictionary:
 	var suite_filter: String = params.get("suite", "")
 	var test_filter: String = params.get("test_name", "")
+	var verbose: bool = params.get("verbose", false)
 
 	var suites := _discover_suites()
 	if suites.is_empty():
@@ -29,12 +30,13 @@ func run_tests(params: Dictionary) -> Dictionary:
 		"log_buffer": _log_buffer,
 	}
 
-	var results := _runner.run_suites(suites, suite_filter, test_filter, ctx)
+	var results := _runner.run_suites(suites, suite_filter, test_filter, ctx, verbose)
 	return {"data": results}
 
 
-func get_test_results(_params: Dictionary) -> Dictionary:
-	return {"data": _runner.get_results()}
+func get_test_results(params: Dictionary) -> Dictionary:
+	var verbose: bool = params.get("verbose", false)
+	return {"data": _runner.get_results(verbose)}
 
 
 func _discover_suites() -> Array[McpTestSuite]:

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -26,8 +26,11 @@ func _enter_tree() -> void:
 	var script_handler := ScriptHandler.new(get_undo_redo())
 	var resource_handler := ResourceHandler.new(get_undo_redo())
 	var filesystem_handler := FilesystemHandler.new()
+	var signal_handler := SignalHandler.new(get_undo_redo())
+	var autoload_handler := AutoloadHandler.new()
+	var input_handler := InputHandler.new()
 	var test_handler := TestHandler.new(get_undo_redo(), _log_buffer)
-	_handlers = [editor_handler, scene_handler, node_handler, project_handler, client_handler, script_handler, resource_handler, filesystem_handler, test_handler]
+	_handlers = [editor_handler, scene_handler, node_handler, project_handler, client_handler, script_handler, resource_handler, filesystem_handler, signal_handler, autoload_handler, input_handler, test_handler]
 
 	_dispatcher.register("get_editor_state", editor_handler.get_editor_state)
 	_dispatcher.register("get_scene_tree", scene_handler.get_scene_tree)
@@ -54,6 +57,7 @@ func _enter_tree() -> void:
 	_dispatcher.register("reload_plugin", editor_handler.reload_plugin)
 	_dispatcher.register("quit_editor", editor_handler.quit_editor)
 	_dispatcher.register("get_project_setting", project_handler.get_project_setting)
+	_dispatcher.register("set_project_setting", project_handler.set_project_setting)
 	_dispatcher.register("search_filesystem", project_handler.search_filesystem)
 	_dispatcher.register("configure_client", client_handler.configure_client)
 	_dispatcher.register("check_client_status", client_handler.check_client_status)
@@ -68,6 +72,16 @@ func _enter_tree() -> void:
 	_dispatcher.register("read_file", filesystem_handler.read_file)
 	_dispatcher.register("write_file", filesystem_handler.write_file)
 	_dispatcher.register("reimport", filesystem_handler.reimport)
+	_dispatcher.register("list_signals", signal_handler.list_signals)
+	_dispatcher.register("connect_signal", signal_handler.connect_signal)
+	_dispatcher.register("disconnect_signal", signal_handler.disconnect_signal)
+	_dispatcher.register("list_autoloads", autoload_handler.list_autoloads)
+	_dispatcher.register("add_autoload", autoload_handler.add_autoload)
+	_dispatcher.register("remove_autoload", autoload_handler.remove_autoload)
+	_dispatcher.register("list_actions", input_handler.list_actions)
+	_dispatcher.register("add_action", input_handler.add_action)
+	_dispatcher.register("remove_action", input_handler.remove_action)
+	_dispatcher.register("bind_event", input_handler.bind_event)
 	_dispatcher.register("run_tests", test_handler.run_tests)
 	_dispatcher.register("get_test_results", test_handler.get_test_results)
 

--- a/plugin/addons/godot_ai/testing/test_runner.gd
+++ b/plugin/addons/godot_ai/testing/test_runner.gd
@@ -30,7 +30,7 @@ func run_suite(suite: McpTestSuite, test_filter: String = "") -> void:
 		})
 
 
-func run_suites(suites: Array, suite_filter: String = "", test_filter: String = "", ctx: Dictionary = {}) -> Dictionary:
+func run_suites(suites: Array, suite_filter: String = "", test_filter: String = "", ctx: Dictionary = {}, verbose: bool = false) -> Dictionary:
 	_results.clear()
 	var start := Time.get_ticks_msec()
 
@@ -42,27 +42,38 @@ func run_suites(suites: Array, suite_filter: String = "", test_filter: String = 
 		suite.suite_teardown()
 
 	_last_run_ms = Time.get_ticks_msec() - start
-	return get_results()
+	return get_results(verbose)
 
 
-func get_results() -> Dictionary:
+func get_results(verbose: bool = false) -> Dictionary:
 	var passed := 0
 	var failed := 0
 	var failures: Array[Dictionary] = []
+	var suites_seen := {}
 	for r in _results:
+		suites_seen[r.suite] = true
 		if r.passed:
 			passed += 1
 		else:
 			failed += 1
 			failures.append(r)
-	return {
+
+	var result := {
 		"passed": passed,
 		"failed": failed,
 		"total": _results.size(),
 		"duration_ms": _last_run_ms,
-		"failures": failures,
-		"results": _results,
+		"suites_run": suites_seen.keys(),
+		"suite_count": suites_seen.size(),
 	}
+
+	if not failures.is_empty():
+		result["failures"] = failures
+
+	if verbose:
+		result["results"] = _results
+
+	return result
 
 
 func clear() -> void:

--- a/src/godot_ai/handlers/_readiness.py
+++ b/src/godot_ai/handlers/_readiness.py
@@ -1,0 +1,31 @@
+"""Readiness gating for write operations."""
+
+from __future__ import annotations
+
+from godot_ai.godot_client.client import GodotCommandError
+from godot_ai.protocol.errors import ErrorCode
+from godot_ai.runtime.interface import Runtime
+
+_READINESS_MESSAGES = {
+    "importing": "Editor is importing resources — try again shortly",
+    "playing": "Editor is in play mode — stop the game first",
+}
+
+
+def require_writable(runtime: Runtime) -> None:
+    """Check that the active session is in a writable state.
+
+    Raises GodotCommandError with EDITOR_NOT_READY if the editor is
+    importing or playing.  The ``ready`` and ``no_scene`` states are
+    allowed through — individual handlers already reject when no scene
+    is open.  If no session exists, this is a no-op; the downstream
+    ``send_command`` will raise on its own.
+    """
+    session = runtime.get_active_session()
+    if session is None:
+        return
+
+    readiness = session.readiness
+    message = _READINESS_MESSAGES.get(readiness)
+    if message is not None:
+        raise GodotCommandError(code=ErrorCode.EDITOR_NOT_READY, message=message)

--- a/src/godot_ai/handlers/autoload.py
+++ b/src/godot_ai/handlers/autoload.py
@@ -1,0 +1,28 @@
+"""Shared handlers for autoload tools."""
+
+from __future__ import annotations
+
+from godot_ai.handlers._readiness import require_writable
+from godot_ai.runtime.interface import Runtime
+
+
+async def autoload_list(runtime: Runtime) -> dict:
+    return await runtime.send_command("list_autoloads")
+
+
+async def autoload_add(
+    runtime: Runtime,
+    name: str,
+    path: str,
+    singleton: bool = True,
+) -> dict:
+    require_writable(runtime)
+    return await runtime.send_command(
+        "add_autoload",
+        {"name": name, "path": path, "singleton": singleton},
+    )
+
+
+async def autoload_remove(runtime: Runtime, name: str) -> dict:
+    require_writable(runtime)
+    return await runtime.send_command("remove_autoload", {"name": name})

--- a/src/godot_ai/handlers/filesystem.py
+++ b/src/godot_ai/handlers/filesystem.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from godot_ai.handlers._readiness import require_writable
 from godot_ai.runtime.interface import Runtime
 
 
@@ -10,6 +11,7 @@ async def filesystem_read_text(runtime: Runtime, path: str) -> dict:
 
 
 async def filesystem_write_text(runtime: Runtime, path: str, content: str = "") -> dict:
+    require_writable(runtime)
     return await runtime.send_command(
         "write_file",
         {"path": path, "content": content},
@@ -17,4 +19,5 @@ async def filesystem_write_text(runtime: Runtime, path: str, content: str = "") 
 
 
 async def import_reimport(runtime: Runtime, paths: list[str]) -> dict:
+    require_writable(runtime)
     return await runtime.send_command("reimport", {"paths": paths})

--- a/src/godot_ai/handlers/input_map.py
+++ b/src/godot_ai/handlers/input_map.py
@@ -1,0 +1,44 @@
+"""Shared handlers for input map tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from godot_ai.handlers._readiness import require_writable
+from godot_ai.runtime.interface import Runtime
+
+
+async def input_map_list(runtime: Runtime, include_builtin: bool = False) -> dict:
+    params: dict[str, Any] = {}
+    if include_builtin:
+        params["include_builtin"] = True
+    return await runtime.send_command("list_actions", params)
+
+
+async def input_map_add_action(
+    runtime: Runtime,
+    action: str,
+    deadzone: float = 0.5,
+) -> dict:
+    require_writable(runtime)
+    return await runtime.send_command(
+        "add_action",
+        {"action": action, "deadzone": deadzone},
+    )
+
+
+async def input_map_remove_action(runtime: Runtime, action: str) -> dict:
+    require_writable(runtime)
+    return await runtime.send_command("remove_action", {"action": action})
+
+
+async def input_map_bind_event(
+    runtime: Runtime,
+    action: str,
+    event_type: str,
+    **kwargs: Any,
+) -> dict:
+    require_writable(runtime)
+    params: dict[str, Any] = {"action": action, "event_type": event_type}
+    params.update(kwargs)
+    return await runtime.send_command("bind_event", params)

--- a/src/godot_ai/handlers/node.py
+++ b/src/godot_ai/handlers/node.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from godot_ai.handlers._readiness import require_writable
 from godot_ai.runtime.interface import Runtime
 from godot_ai.tools._pagination import paginate
 
 
 async def node_create(runtime: Runtime, type: str, name: str = "", parent_path: str = "") -> dict:
+    require_writable(runtime)
     return await runtime.send_command(
         "create_node",
         {"type": type, "name": name, "parent_path": parent_path},
@@ -41,10 +43,12 @@ async def node_get_groups(runtime: Runtime, path: str) -> dict:
 
 
 async def node_delete(runtime: Runtime, path: str) -> dict:
+    require_writable(runtime)
     return await runtime.send_command("delete_node", {"path": path})
 
 
 async def node_reparent(runtime: Runtime, path: str, new_parent: str) -> dict:
+    require_writable(runtime)
     return await runtime.send_command(
         "reparent_node",
         {"path": path, "new_parent": new_parent},
@@ -52,6 +56,7 @@ async def node_reparent(runtime: Runtime, path: str, new_parent: str) -> dict:
 
 
 async def node_set_property(runtime: Runtime, path: str, property: str, value) -> dict:
+    require_writable(runtime)
     return await runtime.send_command(
         "set_property",
         {"path": path, "property": property, "value": value},
@@ -59,6 +64,7 @@ async def node_set_property(runtime: Runtime, path: str, property: str, value) -
 
 
 async def node_duplicate(runtime: Runtime, path: str, name: str = "") -> dict:
+    require_writable(runtime)
     return await runtime.send_command(
         "duplicate_node",
         {"path": path, "name": name},
@@ -66,6 +72,7 @@ async def node_duplicate(runtime: Runtime, path: str, name: str = "") -> dict:
 
 
 async def node_move(runtime: Runtime, path: str, index: int) -> dict:
+    require_writable(runtime)
     return await runtime.send_command(
         "move_node",
         {"path": path, "index": index},
@@ -73,6 +80,7 @@ async def node_move(runtime: Runtime, path: str, index: int) -> dict:
 
 
 async def node_add_to_group(runtime: Runtime, path: str, group: str) -> dict:
+    require_writable(runtime)
     return await runtime.send_command(
         "add_to_group",
         {"path": path, "group": group},
@@ -80,6 +88,7 @@ async def node_add_to_group(runtime: Runtime, path: str, group: str) -> dict:
 
 
 async def node_remove_from_group(runtime: Runtime, path: str, group: str) -> dict:
+    require_writable(runtime)
     return await runtime.send_command(
         "remove_from_group",
         {"path": path, "group": group},
@@ -87,5 +96,6 @@ async def node_remove_from_group(runtime: Runtime, path: str, group: str) -> dic
 
 
 async def editor_selection_set(runtime: Runtime, paths: list[str]) -> dict:
+    require_writable(runtime)
     return await runtime.send_command("set_selection", {"paths": paths})
 

--- a/src/godot_ai/handlers/project.py
+++ b/src/godot_ai/handlers/project.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
+from godot_ai.handlers._readiness import require_writable
 from godot_ai.runtime.interface import Runtime
 from godot_ai.tools._pagination import paginate
 
@@ -21,6 +23,11 @@ COMMON_SETTINGS = [
 
 async def project_settings_get(runtime: Runtime, key: str) -> dict:
     return await runtime.send_command("get_project_setting", {"key": key})
+
+
+async def project_settings_set(runtime: Runtime, key: str, value: Any) -> dict:
+    require_writable(runtime)
+    return await runtime.send_command("set_project_setting", {"key": key, "value": value})
 
 
 async def filesystem_search(

--- a/src/godot_ai/handlers/resource.py
+++ b/src/godot_ai/handlers/resource.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from godot_ai.handlers._readiness import require_writable
 from godot_ai.runtime.interface import Runtime
 from godot_ai.tools._pagination import paginate
 
@@ -30,6 +31,7 @@ async def resource_assign(
     property: str,
     resource_path: str,
 ) -> dict:
+    require_writable(runtime)
     return await runtime.send_command(
         "assign_resource",
         {"path": path, "property": property, "resource_path": resource_path},

--- a/src/godot_ai/handlers/scene.py
+++ b/src/godot_ai/handlers/scene.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from godot_ai.handlers._readiness import require_writable
 from godot_ai.runtime.interface import Runtime
 from godot_ai.tools._pagination import paginate
 
@@ -22,6 +23,7 @@ async def scene_get_roots(runtime: Runtime) -> dict:
 
 
 async def scene_create(runtime: Runtime, path: str, root_type: str = "Node3D") -> dict:
+    require_writable(runtime)
     return await runtime.send_command(
         "create_scene",
         {"path": path, "root_type": root_type},
@@ -29,14 +31,17 @@ async def scene_create(runtime: Runtime, path: str, root_type: str = "Node3D") -
 
 
 async def scene_open(runtime: Runtime, path: str) -> dict:
+    require_writable(runtime)
     return await runtime.send_command("open_scene", {"path": path})
 
 
 async def scene_save(runtime: Runtime) -> dict:
+    require_writable(runtime)
     return await runtime.send_command("save_scene")
 
 
 async def scene_save_as(runtime: Runtime, path: str) -> dict:
+    require_writable(runtime)
     return await runtime.send_command("save_scene_as", {"path": path})
 
 

--- a/src/godot_ai/handlers/script.py
+++ b/src/godot_ai/handlers/script.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from godot_ai.handlers._readiness import require_writable
 from godot_ai.runtime.interface import Runtime
 
 
 async def script_create(runtime: Runtime, path: str, content: str = "") -> dict:
+    require_writable(runtime)
     return await runtime.send_command(
         "create_script",
         {"path": path, "content": content},
@@ -17,6 +19,7 @@ async def script_read(runtime: Runtime, path: str) -> dict:
 
 
 async def script_attach(runtime: Runtime, path: str, script_path: str) -> dict:
+    require_writable(runtime)
     return await runtime.send_command(
         "attach_script",
         {"path": path, "script_path": script_path},
@@ -24,6 +27,7 @@ async def script_attach(runtime: Runtime, path: str, script_path: str) -> dict:
 
 
 async def script_detach(runtime: Runtime, path: str) -> dict:
+    require_writable(runtime)
     return await runtime.send_command("detach_script", {"path": path})
 
 

--- a/src/godot_ai/handlers/signal.py
+++ b/src/godot_ai/handlers/signal.py
@@ -1,0 +1,38 @@
+"""Shared handlers for signal tools."""
+
+from __future__ import annotations
+
+from godot_ai.handlers._readiness import require_writable
+from godot_ai.runtime.interface import Runtime
+
+
+async def signal_list(runtime: Runtime, path: str) -> dict:
+    return await runtime.send_command("list_signals", {"path": path})
+
+
+async def signal_connect(
+    runtime: Runtime,
+    path: str,
+    signal: str,
+    target: str,
+    method: str,
+) -> dict:
+    require_writable(runtime)
+    return await runtime.send_command(
+        "connect_signal",
+        {"path": path, "signal": signal, "target": target, "method": method},
+    )
+
+
+async def signal_disconnect(
+    runtime: Runtime,
+    path: str,
+    signal: str,
+    target: str,
+    method: str,
+) -> dict:
+    require_writable(runtime)
+    return await runtime.send_command(
+        "disconnect_signal",
+        {"path": path, "signal": signal, "target": target, "method": method},
+    )

--- a/src/godot_ai/handlers/testing.py
+++ b/src/godot_ai/handlers/testing.py
@@ -2,18 +2,30 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from godot_ai.runtime.interface import Runtime
 
 
-async def run_tests(runtime: Runtime, suite: str = "", test_name: str = "") -> dict:
-    params: dict[str, str] = {}
+async def run_tests(
+    runtime: Runtime,
+    suite: str = "",
+    test_name: str = "",
+    verbose: bool = False,
+) -> dict:
+    params: dict[str, Any] = {}
     if suite:
         params["suite"] = suite
     if test_name:
         params["test_name"] = test_name
+    if verbose:
+        params["verbose"] = True
     return await runtime.send_command("run_tests", params, timeout=30.0)
 
 
-async def get_test_results(runtime: Runtime) -> dict:
-    return await runtime.send_command("get_test_results")
+async def get_test_results(runtime: Runtime, verbose: bool = False) -> dict:
+    params: dict[str, Any] = {}
+    if verbose:
+        params["verbose"] = True
+    return await runtime.send_command("get_test_results", params)
 

--- a/src/godot_ai/protocol/envelope.py
+++ b/src/godot_ai/protocol/envelope.py
@@ -41,3 +41,4 @@ class HandshakeMessage(BaseModel):
     project_path: str
     plugin_version: str
     protocol_version: int = 1
+    readiness: str = "ready"

--- a/src/godot_ai/server.py
+++ b/src/godot_ai/server.py
@@ -16,15 +16,18 @@ from godot_ai.resources.project import register_project_resources
 from godot_ai.resources.scenes import register_scene_resources
 from godot_ai.resources.sessions import register_session_resources
 from godot_ai.sessions.registry import SessionRegistry
+from godot_ai.tools.autoload import register_autoload_tools
 from godot_ai.tools.client import register_client_tools
 from godot_ai.tools.editor import register_editor_tools
 from godot_ai.tools.filesystem import register_filesystem_tools
+from godot_ai.tools.input_map import register_input_map_tools
 from godot_ai.tools.node import register_node_tools
 from godot_ai.tools.project import register_project_tools
 from godot_ai.tools.resource import register_resource_tools
 from godot_ai.tools.scene import register_scene_tools
 from godot_ai.tools.script import register_script_tools
 from godot_ai.tools.session import register_session_tools
+from godot_ai.tools.signal import register_signal_tools
 from godot_ai.tools.testing import register_testing_tools
 from godot_ai.transport.websocket import GodotWebSocketServer
 
@@ -76,6 +79,9 @@ def create_server(ws_port: int = 9500) -> FastMCP:
     register_resource_tools(mcp)
     register_filesystem_tools(mcp)
     register_client_tools(mcp)
+    register_signal_tools(mcp)
+    register_autoload_tools(mcp)
+    register_input_map_tools(mcp)
     register_testing_tools(mcp)
     register_session_resources(mcp)
     register_scene_resources(mcp)

--- a/src/godot_ai/sessions/registry.py
+++ b/src/godot_ai/sessions/registry.py
@@ -18,6 +18,7 @@ class Session:
     protocol_version: int = 1
     current_scene: str = ""
     play_state: str = "stopped"
+    readiness: str = "ready"
     connected_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
     def to_dict(self) -> dict:
@@ -29,6 +30,7 @@ class Session:
             "protocol_version": self.protocol_version,
             "current_scene": self.current_scene,
             "play_state": self.play_state,
+            "readiness": self.readiness,
             "connected_at": self.connected_at.isoformat(),
         }
 

--- a/src/godot_ai/tools/autoload.py
+++ b/src/godot_ai/tools/autoload.py
@@ -1,0 +1,55 @@
+"""MCP tools for managing Godot autoload singletons."""
+
+from __future__ import annotations
+
+from fastmcp import Context, FastMCP
+
+from godot_ai.handlers import autoload as autoload_handlers
+from godot_ai.runtime.direct import DirectRuntime
+
+
+def register_autoload_tools(mcp: FastMCP) -> None:
+    @mcp.tool()
+    async def autoload_list(ctx: Context) -> dict:
+        """List all registered autoload singletons.
+
+        Returns each autoload's name, script/scene path, and whether
+        it's a singleton (accessible via name globally).
+        """
+        runtime = DirectRuntime.from_context(ctx)
+        return await autoload_handlers.autoload_list(runtime)
+
+    @mcp.tool()
+    async def autoload_add(
+        ctx: Context,
+        name: str,
+        path: str,
+        singleton: bool = True,
+    ) -> dict:
+        """Add a new autoload singleton to the project.
+
+        Registers a GDScript or PackedScene as an autoload that loads
+        automatically when the project starts. Saved to project.godot.
+
+        Args:
+            name: Name for the autoload (e.g. "GameManager", "AudioBus").
+            path: Resource path to the script or scene (e.g. "res://autoloads/game_manager.gd").
+            singleton: If true, accessible globally by name. Default true.
+        """
+        runtime = DirectRuntime.from_context(ctx)
+        return await autoload_handlers.autoload_add(
+            runtime, name=name, path=path, singleton=singleton
+        )
+
+    @mcp.tool()
+    async def autoload_remove(ctx: Context, name: str) -> dict:
+        """Remove an autoload singleton from the project.
+
+        Removes the autoload registration from project.godot.
+        Does not delete the underlying script or scene file.
+
+        Args:
+            name: Name of the autoload to remove.
+        """
+        runtime = DirectRuntime.from_context(ctx)
+        return await autoload_handlers.autoload_remove(runtime, name=name)

--- a/src/godot_ai/tools/input_map.py
+++ b/src/godot_ai/tools/input_map.py
@@ -1,0 +1,101 @@
+"""MCP tools for managing Godot input map actions and bindings."""
+
+from __future__ import annotations
+
+from fastmcp import Context, FastMCP
+
+from godot_ai.handlers import input_map as input_map_handlers
+from godot_ai.runtime.direct import DirectRuntime
+
+
+def register_input_map_tools(mcp: FastMCP) -> None:
+    @mcp.tool()
+    async def input_map_list(ctx: Context, include_builtin: bool = False) -> dict:
+        """List all input actions and their bound events.
+
+        By default returns only project-defined actions. Set
+        include_builtin=true to also include Godot's built-in ui_*
+        actions.
+
+        Args:
+            include_builtin: Include built-in ui_* actions. Default false.
+        """
+        runtime = DirectRuntime.from_context(ctx)
+        return await input_map_handlers.input_map_list(runtime, include_builtin=include_builtin)
+
+    @mcp.tool()
+    async def input_map_add_action(
+        ctx: Context,
+        action: str,
+        deadzone: float = 0.5,
+    ) -> dict:
+        """Create a new input action.
+
+        Adds an empty input action that can have events bound to it.
+        Saved to project.godot.
+
+        Args:
+            action: Name for the action (e.g. "move_left", "jump", "attack").
+            deadzone: Analog deadzone threshold. Default 0.5.
+        """
+        runtime = DirectRuntime.from_context(ctx)
+        return await input_map_handlers.input_map_add_action(
+            runtime, action=action, deadzone=deadzone
+        )
+
+    @mcp.tool()
+    async def input_map_remove_action(ctx: Context, action: str) -> dict:
+        """Remove an input action and all its bindings.
+
+        Erases the action from InputMap and project.godot.
+
+        Args:
+            action: Name of the action to remove.
+        """
+        runtime = DirectRuntime.from_context(ctx)
+        return await input_map_handlers.input_map_remove_action(runtime, action=action)
+
+    @mcp.tool()
+    async def input_map_bind_event(
+        ctx: Context,
+        action: str,
+        event_type: str,
+        keycode: str = "",
+        ctrl: bool = False,
+        alt: bool = False,
+        shift: bool = False,
+        meta: bool = False,
+        button: int = 0,
+    ) -> dict:
+        """Bind an input event to an action.
+
+        Adds a key press, mouse button, or gamepad button to an existing
+        action. Saved to project.godot.
+
+        Args:
+            action: Name of the action to bind to.
+            event_type: One of "key", "mouse_button", or "joy_button".
+            keycode: Key name for "key" events (e.g. "W", "Space", "Escape").
+            ctrl: Require Ctrl modifier (key events only).
+            alt: Require Alt modifier (key events only).
+            shift: Require Shift modifier (key events only).
+            meta: Require Meta/Cmd modifier (key events only).
+            button: Button index for mouse_button (1=left, 2=right) or joy_button events.
+        """
+        runtime = DirectRuntime.from_context(ctx)
+        kwargs = {}
+        if keycode:
+            kwargs["keycode"] = keycode
+        if ctrl:
+            kwargs["ctrl"] = ctrl
+        if alt:
+            kwargs["alt"] = alt
+        if shift:
+            kwargs["shift"] = shift
+        if meta:
+            kwargs["meta"] = meta
+        if event_type in ("mouse_button", "joy_button"):
+            kwargs["button"] = button
+        return await input_map_handlers.input_map_bind_event(
+            runtime, action=action, event_type=event_type, **kwargs
+        )

--- a/src/godot_ai/tools/input_map.py
+++ b/src/godot_ai/tools/input_map.py
@@ -65,7 +65,7 @@ def register_input_map_tools(mcp: FastMCP) -> None:
         alt: bool = False,
         shift: bool = False,
         meta: bool = False,
-        button: int = 0,
+        button: int | None = None,
     ) -> dict:
         """Bind an input event to an action.
 
@@ -80,7 +80,8 @@ def register_input_map_tools(mcp: FastMCP) -> None:
             alt: Require Alt modifier (key events only).
             shift: Require Shift modifier (key events only).
             meta: Require Meta/Cmd modifier (key events only).
-            button: Button index for mouse_button (1=left, 2=right) or joy_button events.
+            button: Button index for mouse_button (1=left, 2=right) or
+                joy_button (0=A/Cross) events. Required for non-key events.
         """
         runtime = DirectRuntime.from_context(ctx)
         kwargs = {}
@@ -94,7 +95,7 @@ def register_input_map_tools(mcp: FastMCP) -> None:
             kwargs["shift"] = shift
         if meta:
             kwargs["meta"] = meta
-        if event_type in ("mouse_button", "joy_button"):
+        if button is not None:
             kwargs["button"] = button
         return await input_map_handlers.input_map_bind_event(
             runtime, action=action, event_type=event_type, **kwargs

--- a/src/godot_ai/tools/project.py
+++ b/src/godot_ai/tools/project.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from fastmcp import Context, FastMCP
 
 from godot_ai.handlers import project as project_handlers
@@ -21,6 +23,25 @@ def register_project_tools(mcp: FastMCP) -> None:
         """
         runtime = DirectRuntime.from_context(ctx)
         return await project_handlers.project_settings_get(runtime, key=key)
+
+    @mcp.tool()
+    async def project_settings_set(
+        ctx: Context,
+        key: str,
+        value: Any,
+    ) -> dict:
+        """Set a Godot project setting by key.
+
+        Writes to ProjectSettings and saves to project.godot.
+        Common keys: "application/config/name",
+        "display/window/size/viewport_width", "physics/2d/default_gravity".
+
+        Args:
+            key: The setting key path (e.g. "application/config/name").
+            value: The value to set (string, int, float, or bool).
+        """
+        runtime = DirectRuntime.from_context(ctx)
+        return await project_handlers.project_settings_set(runtime, key=key, value=value)
 
     @mcp.tool()
     async def filesystem_search(

--- a/src/godot_ai/tools/signal.py
+++ b/src/godot_ai/tools/signal.py
@@ -1,0 +1,69 @@
+"""MCP tools for signal listing, connecting, and disconnecting."""
+
+from __future__ import annotations
+
+from fastmcp import Context, FastMCP
+
+from godot_ai.handlers import signal as signal_handlers
+from godot_ai.runtime.direct import DirectRuntime
+
+
+def register_signal_tools(mcp: FastMCP) -> None:
+    @mcp.tool()
+    async def signal_list(ctx: Context, path: str) -> dict:
+        """List all signals on a node and their current connections.
+
+        Returns both built-in and custom signals, plus any active
+        signal connections.
+
+        Args:
+            path: Scene path of the node (e.g. "/Player").
+        """
+        runtime = DirectRuntime.from_context(ctx)
+        return await signal_handlers.signal_list(runtime, path=path)
+
+    @mcp.tool()
+    async def signal_connect(
+        ctx: Context,
+        path: str,
+        signal: str,
+        target: str,
+        method: str,
+    ) -> dict:
+        """Connect a signal from one node to a method on another node.
+
+        Creates an undoable signal connection in the scene.
+
+        Args:
+            path: Scene path of the source node emitting the signal.
+            signal: Name of the signal to connect (e.g. "pressed", "body_entered").
+            target: Scene path of the target node receiving the signal.
+            method: Name of the method to call on the target node.
+        """
+        runtime = DirectRuntime.from_context(ctx)
+        return await signal_handlers.signal_connect(
+            runtime, path=path, signal=signal, target=target, method=method
+        )
+
+    @mcp.tool()
+    async def signal_disconnect(
+        ctx: Context,
+        path: str,
+        signal: str,
+        target: str,
+        method: str,
+    ) -> dict:
+        """Disconnect a signal connection between two nodes.
+
+        Removes an existing signal connection. Undoable.
+
+        Args:
+            path: Scene path of the source node.
+            signal: Name of the signal to disconnect.
+            target: Scene path of the target node.
+            method: Name of the method that was connected.
+        """
+        runtime = DirectRuntime.from_context(ctx)
+        return await signal_handlers.signal_disconnect(
+            runtime, path=path, signal=signal, target=target, method=method
+        )

--- a/src/godot_ai/tools/testing.py
+++ b/src/godot_ai/tools/testing.py
@@ -14,28 +14,39 @@ def register_testing_tools(mcp: FastMCP) -> None:
         ctx: Context,
         suite: str = "",
         test_name: str = "",
+        verbose: bool = False,
     ) -> dict:
         """Run GDScript test suites inside the connected Godot editor.
 
         Discovers test_*.gd scripts in the project's res://tests/ directory,
-        instantiates them, and runs all test_* methods. Returns structured
-        pass/fail results.
+        instantiates them, and runs all test_* methods.
+
+        By default returns a compact summary (pass/fail counts, suite names,
+        duration) plus only the failures. Set verbose=true to include every
+        individual test result.
 
         Args:
             suite: Run only the named suite (e.g. "scene", "node", "editor").
                    Empty runs all suites.
             test_name: Run only tests whose name contains this substring.
                        Empty runs all tests in the selected suite(s).
+            verbose: If true, include every individual test result. Default
+                     false — only summary and failures are returned.
         """
         runtime = DirectRuntime.from_context(ctx)
-        return await testing_handlers.run_tests(runtime, suite=suite, test_name=test_name)
+        return await testing_handlers.run_tests(
+            runtime, suite=suite, test_name=test_name, verbose=verbose
+        )
 
     @mcp.tool()
-    async def get_test_results(ctx: Context) -> dict:
+    async def get_test_results(ctx: Context, verbose: bool = False) -> dict:
         """Get results from the most recent test run.
 
         Returns the same structured results as run_tests, without
         re-executing. Useful for reviewing results after a run.
+
+        Args:
+            verbose: If true, include every individual test result.
         """
         runtime = DirectRuntime.from_context(ctx)
-        return await testing_handlers.get_test_results(runtime)
+        return await testing_handlers.get_test_results(runtime, verbose=verbose)

--- a/src/godot_ai/transport/websocket.py
+++ b/src/godot_ai/transport/websocket.py
@@ -57,6 +57,7 @@ class GodotWebSocketServer:
                 project_path=handshake.project_path,
                 plugin_version=handshake.plugin_version,
                 protocol_version=handshake.protocol_version,
+                readiness=handshake.readiness,
             )
             self.registry.register(session)
             self._connections[session_id] = ws
@@ -104,6 +105,9 @@ class GodotWebSocketServer:
         elif event == "play_state_changed":
             session.play_state = event_data.get("play_state", "stopped")
             logger.info("Session %s: play state -> %s", session_id[:8], session.play_state)
+        elif event == "readiness_changed":
+            session.readiness = event_data.get("readiness", "ready")
+            logger.info("Session %s: readiness -> %s", session_id[:8], session.readiness)
 
     async def send_command(
         self,

--- a/test_project/tests/test_autoload.gd
+++ b/test_project/tests/test_autoload.gd
@@ -1,0 +1,121 @@
+@tool
+extends McpTestSuite
+
+## Tests for AutoloadHandler — autoload listing, adding, and removing.
+
+var _handler: AutoloadHandler
+const TEST_AUTOLOAD_NAME := "_McpTestAutoload"
+
+
+func suite_name() -> String:
+	return "autoload"
+
+
+func suite_setup(_ctx: Dictionary) -> void:
+	_handler = AutoloadHandler.new()
+
+
+func suite_teardown() -> void:
+	## Clean up any test autoload left behind
+	var key := "autoload/%s" % TEST_AUTOLOAD_NAME
+	if ProjectSettings.has_setting(key):
+		ProjectSettings.clear(key)
+		ProjectSettings.save()
+
+
+# ----- list_autoloads -----
+
+func test_list_autoloads() -> void:
+	var result := _handler.list_autoloads({})
+	assert_has_key(result, "data")
+	assert_has_key(result.data, "autoloads")
+	assert_has_key(result.data, "count")
+
+
+# ----- add_autoload -----
+
+func test_add_autoload_missing_name() -> void:
+	var result := _handler.add_autoload({})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_add_autoload_missing_path() -> void:
+	var result := _handler.add_autoload({"name": TEST_AUTOLOAD_NAME})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_add_autoload_invalid_path_prefix() -> void:
+	var result := _handler.add_autoload({
+		"name": TEST_AUTOLOAD_NAME,
+		"path": "/absolute/path/evil.gd",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_add_autoload_user_path_rejected() -> void:
+	var result := _handler.add_autoload({
+		"name": TEST_AUTOLOAD_NAME,
+		"path": "user://evil.gd",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_add_autoload_nonexistent_file() -> void:
+	var result := _handler.add_autoload({
+		"name": TEST_AUTOLOAD_NAME,
+		"path": "res://nonexistent_autoload_xyz.gd",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_add_and_remove_autoload() -> void:
+	var result := _handler.add_autoload({
+		"name": TEST_AUTOLOAD_NAME,
+		"path": "res://tests/test_autoload.gd",
+		"singleton": true,
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.name, TEST_AUTOLOAD_NAME)
+	assert_eq(result.data.singleton, true)
+
+	## Verify it shows up in the list
+	var list_result := _handler.list_autoloads({})
+	var found := false
+	for al in list_result.data.autoloads:
+		if al.name == TEST_AUTOLOAD_NAME:
+			found = true
+			break
+	assert_true(found, "Autoload should appear in list after adding")
+
+	## Remove it
+	var remove_result := _handler.remove_autoload({"name": TEST_AUTOLOAD_NAME})
+	assert_has_key(remove_result, "data")
+	assert_eq(remove_result.data.removed, true)
+
+
+func test_add_autoload_duplicate() -> void:
+	## Add once
+	_handler.add_autoload({
+		"name": TEST_AUTOLOAD_NAME,
+		"path": "res://tests/test_autoload.gd",
+	})
+	## Add again should fail
+	var result := _handler.add_autoload({
+		"name": TEST_AUTOLOAD_NAME,
+		"path": "res://tests/test_autoload.gd",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	## Cleanup
+	_handler.remove_autoload({"name": TEST_AUTOLOAD_NAME})
+
+
+# ----- remove_autoload -----
+
+func test_remove_autoload_missing_name() -> void:
+	var result := _handler.remove_autoload({})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_remove_autoload_not_found() -> void:
+	var result := _handler.remove_autoload({"name": "_NoSuchAutoload"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)

--- a/test_project/tests/test_input.gd
+++ b/test_project/tests/test_input.gd
@@ -1,0 +1,126 @@
+@tool
+extends McpTestSuite
+
+## Tests for InputHandler — input action listing, adding, removing, binding.
+
+var _handler: InputHandler
+const TEST_ACTION := "_mcp_test_action"
+
+
+func suite_name() -> String:
+	return "input"
+
+
+func suite_setup(_ctx: Dictionary) -> void:
+	_handler = InputHandler.new()
+
+
+func suite_teardown() -> void:
+	## Clean up any test actions
+	if InputMap.has_action(TEST_ACTION):
+		InputMap.erase_action(TEST_ACTION)
+	var key := "input/%s" % TEST_ACTION
+	if ProjectSettings.has_setting(key):
+		ProjectSettings.clear(key)
+		ProjectSettings.save()
+
+
+# ----- list_actions -----
+
+func test_list_actions_excludes_builtins_by_default() -> void:
+	var result := _handler.list_actions({})
+	assert_has_key(result, "data")
+	assert_has_key(result.data, "actions")
+	assert_has_key(result.data, "count")
+	for action in result.data.actions:
+		assert_false(action.is_builtin, "Default should exclude ui_* actions")
+
+
+func test_list_actions_with_builtins() -> void:
+	var result := _handler.list_actions({"include_builtin": true})
+	assert_has_key(result, "data")
+	assert_gt(result.data.count, 0, "Should have at least the built-in ui_* actions")
+
+
+# ----- add_action -----
+
+func test_add_action_missing_name() -> void:
+	var result := _handler.add_action({})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_add_and_remove_action() -> void:
+	var result := _handler.add_action({"action": TEST_ACTION})
+	assert_has_key(result, "data")
+	assert_eq(result.data.action, TEST_ACTION)
+
+	## Verify it exists
+	assert_true(InputMap.has_action(TEST_ACTION), "Action should exist after adding")
+
+	## Remove it
+	var remove_result := _handler.remove_action({"action": TEST_ACTION})
+	assert_has_key(remove_result, "data")
+	assert_eq(remove_result.data.removed, true)
+	assert_false(InputMap.has_action(TEST_ACTION), "Action should not exist after removing")
+
+
+func test_add_action_duplicate() -> void:
+	_handler.add_action({"action": TEST_ACTION})
+	var result := _handler.add_action({"action": TEST_ACTION})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	_handler.remove_action({"action": TEST_ACTION})
+
+
+# ----- remove_action -----
+
+func test_remove_action_missing_name() -> void:
+	var result := _handler.remove_action({})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_remove_action_not_found() -> void:
+	var result := _handler.remove_action({"action": "_nonexistent_action_xyz"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+# ----- bind_event -----
+
+func test_bind_event_missing_params() -> void:
+	var result := _handler.bind_event({})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+	result = _handler.bind_event({"action": TEST_ACTION})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_bind_event_unknown_action() -> void:
+	var result := _handler.bind_event({
+		"action": "_nonexistent_action",
+		"event_type": "key",
+		"keycode": "Space",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_bind_event_unsupported_type() -> void:
+	_handler.add_action({"action": TEST_ACTION})
+	var result := _handler.bind_event({
+		"action": TEST_ACTION,
+		"event_type": "unsupported",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	_handler.remove_action({"action": TEST_ACTION})
+
+
+func test_bind_key_event() -> void:
+	_handler.add_action({"action": TEST_ACTION})
+	var result := _handler.bind_event({
+		"action": TEST_ACTION,
+		"event_type": "key",
+		"keycode": "Space",
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.action, TEST_ACTION)
+	assert_has_key(result.data, "event")
+	assert_eq(result.data.event.type, "key")
+	_handler.remove_action({"action": TEST_ACTION})

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -263,6 +263,12 @@ func test_move_node_out_of_range() -> void:
 # ----- add_to_group / remove_from_group -----
 
 func test_add_to_group() -> void:
+	## Ensure clean state: remove from group if left over from a previous run
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var cam := ScenePath.resolve("/Main/Camera3D", scene_root)
+	if cam and cam.is_in_group("_mcp_test_group"):
+		cam.remove_from_group("_mcp_test_group")
+
 	var result := _handler.add_to_group({
 		"path": "/Main/Camera3D",
 		"group": "_mcp_test_group",

--- a/test_project/tests/test_project.gd
+++ b/test_project/tests/test_project.gd
@@ -41,6 +41,36 @@ func test_get_project_setting_viewport_width() -> void:
 	assert_eq(result.data.type, "int")
 
 
+# ----- set_project_setting -----
+
+func test_set_project_setting_roundtrip() -> void:
+	## Read the current name, set a new one, then restore
+	var original := _handler.get_project_setting({"key": "application/config/name"})
+	var old_name = original.data.value
+
+	var result := _handler.set_project_setting({
+		"key": "application/config/name",
+		"value": "_McpTestName",
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.key, "application/config/name")
+	assert_eq(result.data.value, "_McpTestName")
+	assert_has_key(result.data, "old_value")
+
+	## Restore
+	_handler.set_project_setting({"key": "application/config/name", "value": old_name})
+
+
+func test_set_project_setting_missing_key() -> void:
+	var result := _handler.set_project_setting({})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_set_project_setting_missing_value() -> void:
+	var result := _handler.set_project_setting({"key": "application/config/name"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
 # ----- search_filesystem -----
 
 func test_search_filesystem_by_name() -> void:

--- a/test_project/tests/test_script.gd
+++ b/test_project/tests/test_script.gd
@@ -109,6 +109,13 @@ func test_read_script_not_found() -> void:
 # ----- attach_script -----
 
 func test_attach_script_basic() -> void:
+	# Clean up any leftover node from a prior run
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var stale := ScenePath.resolve("/Main/_McpTestAttach", scene_root)
+	if stale:
+		stale.get_parent().remove_child(stale)
+		stale.queue_free()
+
 	# Create a temporary node to attach to
 	var node_handler := NodeHandler.new(_undo_redo)
 	node_handler.create_node({"type": "Node3D", "name": "_McpTestAttach", "parent_path": "/Main"})

--- a/test_project/tests/test_signal.gd
+++ b/test_project/tests/test_signal.gd
@@ -1,0 +1,95 @@
+@tool
+extends McpTestSuite
+
+## Tests for SignalHandler — signal listing, connecting, and disconnecting.
+
+var _handler: SignalHandler
+var _undo_redo: EditorUndoRedoManager
+
+
+func suite_name() -> String:
+	return "signal"
+
+
+func suite_setup(ctx: Dictionary) -> void:
+	_undo_redo = ctx.get("undo_redo")
+	_handler = SignalHandler.new(_undo_redo)
+
+
+# ----- list_signals -----
+
+func test_list_signals_returns_signals() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return
+	var path := "/" + scene_root.name
+	var result := _handler.list_signals({"path": path})
+	assert_has_key(result, "data")
+	assert_has_key(result.data, "signals")
+	assert_has_key(result.data, "signal_count")
+	assert_gt(result.data.signal_count, 0, "Root node should have signals")
+
+
+func test_list_signals_missing_path() -> void:
+	var result := _handler.list_signals({})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_list_signals_unknown_node() -> void:
+	var result := _handler.list_signals({"path": "/NonExistentNode"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_list_signals_no_scene() -> void:
+	## If no scene is open this should report EDITOR_NOT_READY.
+	## We can't easily test this in-editor since a scene is always open,
+	## so just verify the path validation works.
+	var result := _handler.list_signals({"path": "/BogusRoot/BogusChild"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+# ----- connect_signal -----
+
+func test_connect_signal_missing_params() -> void:
+	var result := _handler.connect_signal({})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+	result = _handler.connect_signal({"path": "/Main"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+	result = _handler.connect_signal({"path": "/Main", "signal": "ready"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+	result = _handler.connect_signal({"path": "/Main", "signal": "ready", "target": "/Main"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_connect_signal_unknown_source() -> void:
+	var result := _handler.connect_signal({
+		"path": "/NoSuchNode",
+		"signal": "ready",
+		"target": "/Main",
+		"method": "_ready",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+# ----- disconnect_signal -----
+
+func test_disconnect_signal_missing_params() -> void:
+	var result := _handler.disconnect_signal({})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_disconnect_signal_not_connected() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return
+	var path := "/" + scene_root.name
+	var result := _handler.disconnect_signal({
+		"path": path,
+		"signal": "ready",
+		"target": path,
+		"method": "_nonexistent_method",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,7 @@ class ServerHarness:
         godot_version: str = "4.4.1",
         project_path: str = "/tmp/test_project",
         plugin_version: str = "0.0.1",
+        readiness: str = "ready",
     ) -> MockGodotPlugin:
         ws = await websockets.connect(f"ws://127.0.0.1:{self.port}")
         handshake = {
@@ -69,6 +70,7 @@ class ServerHarness:
             "project_path": project_path,
             "plugin_version": plugin_version,
             "protocol_version": 1,
+            "readiness": readiness,
         }
         await ws.send(json.dumps(handshake))
         # Give the server a moment to process the handshake

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -698,6 +698,42 @@ class TestProjectSettingsGetTool:
 
 
 # ---------------------------------------------------------------------------
+# project_settings_set
+# ---------------------------------------------------------------------------
+
+
+class TestProjectSettingsSetTool:
+    async def test_set_setting(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "set_project_setting"
+            assert cmd["params"]["key"] == "display/window/size/viewport_width"
+            assert cmd["params"]["value"] == 1920
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "key": "display/window/size/viewport_width",
+                    "value": 1920,
+                    "old_value": 1152,
+                    "type": "int",
+                    "undoable": False,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "project_settings_set",
+            {"key": "display/window/size/viewport_width", "value": 1920},
+        )
+        await task
+
+        assert result.data["value"] == 1920
+        assert result.data["old_value"] == 1152
+
+
+# ---------------------------------------------------------------------------
 # filesystem_search
 # ---------------------------------------------------------------------------
 
@@ -1368,3 +1404,470 @@ class TestImportReimportTool:
 
         assert result.data["reimported_count"] == 2
         assert result.data["not_found_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# signal_list / signal_connect / signal_disconnect
+# ---------------------------------------------------------------------------
+
+
+class TestSignalListTool:
+    async def test_list_signals(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "list_signals"
+            assert cmd["params"]["path"] == "/Main/Button"
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "path": "/Main/Button",
+                    "signals": [{"name": "pressed", "args": []}],
+                    "signal_count": 1,
+                    "connections": [],
+                    "connection_count": 0,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool("signal_list", {"path": "/Main/Button"})
+        await task
+
+        assert result.data["signal_count"] == 1
+        assert result.data["signals"][0]["name"] == "pressed"
+
+
+class TestSignalConnectTool:
+    async def test_connect_signal(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "connect_signal"
+            assert cmd["params"]["signal"] == "pressed"
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "source": "/Main/Button",
+                    "signal": "pressed",
+                    "target": "/Main/Player",
+                    "method": "_on_pressed",
+                    "undoable": True,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "signal_connect",
+            {
+                "path": "/Main/Button",
+                "signal": "pressed",
+                "target": "/Main/Player",
+                "method": "_on_pressed",
+            },
+        )
+        await task
+
+        assert result.data["undoable"] is True
+
+
+class TestSignalDisconnectTool:
+    async def test_disconnect_signal(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "disconnect_signal"
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "source": "/Main/Button",
+                    "signal": "pressed",
+                    "target": "/Main/Player",
+                    "method": "_on_pressed",
+                    "undoable": True,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "signal_disconnect",
+            {
+                "path": "/Main/Button",
+                "signal": "pressed",
+                "target": "/Main/Player",
+                "method": "_on_pressed",
+            },
+        )
+        await task
+
+        assert result.data["undoable"] is True
+
+
+# ---------------------------------------------------------------------------
+# autoload_list / autoload_add / autoload_remove
+# ---------------------------------------------------------------------------
+
+
+class TestAutoloadListTool:
+    async def test_list_autoloads(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "list_autoloads"
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "autoloads": [
+                        {
+                            "name": "GameManager",
+                            "path": "res://autoloads/game_manager.gd",
+                            "singleton": True,
+                        },
+                    ],
+                    "count": 1,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool("autoload_list", {})
+        await task
+
+        assert result.data["count"] == 1
+        assert result.data["autoloads"][0]["name"] == "GameManager"
+
+
+class TestAutoloadAddTool:
+    async def test_add_autoload(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "add_autoload"
+            assert cmd["params"]["name"] == "AudioBus"
+            assert cmd["params"]["path"] == "res://audio_bus.gd"
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "name": "AudioBus",
+                    "path": "res://audio_bus.gd",
+                    "singleton": True,
+                    "undoable": False,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "autoload_add",
+            {"name": "AudioBus", "path": "res://audio_bus.gd"},
+        )
+        await task
+
+        assert result.data["name"] == "AudioBus"
+
+
+class TestAutoloadRemoveTool:
+    async def test_remove_autoload(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "remove_autoload"
+            assert cmd["params"]["name"] == "AudioBus"
+            await plugin.send_response(
+                cmd["request_id"],
+                {"name": "AudioBus", "removed": True, "undoable": False},
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool("autoload_remove", {"name": "AudioBus"})
+        await task
+
+        assert result.data["removed"] is True
+
+
+# ---------------------------------------------------------------------------
+# input_map_list / input_map_add_action / input_map_remove_action / input_map_bind_event
+# ---------------------------------------------------------------------------
+
+
+class TestInputMapListTool:
+    async def test_list_actions(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "list_actions"
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "actions": [
+                        {"name": "jump", "events": [], "event_count": 0, "is_builtin": False},
+                    ],
+                    "count": 1,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool("input_map_list", {})
+        await task
+
+        assert result.data["count"] == 1
+        assert result.data["actions"][0]["name"] == "jump"
+
+
+class TestInputMapAddActionTool:
+    async def test_add_action(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "add_action"
+            assert cmd["params"]["action"] == "attack"
+            await plugin.send_response(
+                cmd["request_id"],
+                {"action": "attack", "deadzone": 0.5, "undoable": False},
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "input_map_add_action", {"action": "attack"}
+        )
+        await task
+
+        assert result.data["action"] == "attack"
+
+
+class TestInputMapRemoveActionTool:
+    async def test_remove_action(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "remove_action"
+            assert cmd["params"]["action"] == "attack"
+            await plugin.send_response(
+                cmd["request_id"],
+                {"action": "attack", "removed": True, "undoable": False},
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "input_map_remove_action", {"action": "attack"}
+        )
+        await task
+
+        assert result.data["removed"] is True
+
+
+class TestInputMapBindEventTool:
+    async def test_bind_key_event(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "bind_event"
+            assert cmd["params"]["action"] == "jump"
+            assert cmd["params"]["event_type"] == "key"
+            assert cmd["params"]["keycode"] == "Space"
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "action": "jump",
+                    "event": {"type": "key", "keycode": "Space"},
+                    "undoable": False,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "input_map_bind_event",
+            {"action": "jump", "event_type": "key", "keycode": "Space"},
+        )
+        await task
+
+        assert result.data["event"]["type"] == "key"
+        assert result.data["event"]["keycode"] == "Space"
+
+    async def test_bind_key_event_with_modifiers(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["params"]["ctrl"] is True
+            assert cmd["params"]["alt"] is True
+            assert cmd["params"]["shift"] is True
+            assert cmd["params"]["meta"] is True
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "action": "save",
+                    "event": {"type": "key", "keycode": "S", "ctrl": True},
+                    "undoable": False,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "input_map_bind_event",
+            {
+                "action": "save",
+                "event_type": "key",
+                "keycode": "S",
+                "ctrl": True,
+                "alt": True,
+                "shift": True,
+                "meta": True,
+            },
+        )
+        await task
+
+        assert result.data["event"]["type"] == "key"
+
+    async def test_bind_mouse_button_event(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["params"]["event_type"] == "mouse_button"
+            assert cmd["params"]["button"] == 1
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "action": "shoot",
+                    "event": {"type": "mouse_button", "button": 1},
+                    "undoable": False,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "input_map_bind_event",
+            {"action": "shoot", "event_type": "mouse_button", "button": 1},
+        )
+        await task
+
+        assert result.data["event"]["type"] == "mouse_button"
+        assert result.data["event"]["button"] == 1
+
+
+# ---------------------------------------------------------------------------
+# input_map_list (include_builtin)
+# ---------------------------------------------------------------------------
+
+
+class TestInputMapListBuiltinFilter:
+    async def test_list_with_include_builtin(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "list_actions"
+            assert cmd["params"]["include_builtin"] is True
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "actions": [
+                        {"name": "ui_accept", "events": [], "event_count": 0, "is_builtin": True},
+                    ],
+                    "count": 1,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "input_map_list", {"include_builtin": True}
+        )
+        await task
+
+        assert result.data["count"] == 1
+        assert result.data["actions"][0]["is_builtin"] is True
+
+
+# ---------------------------------------------------------------------------
+# Readiness gating
+# ---------------------------------------------------------------------------
+
+
+class TestReadinessGating:
+    async def _set_readiness(self, plugin, readiness: str) -> None:
+        """Send a readiness_changed event and wait for it to be processed."""
+        await plugin.send_event("readiness_changed", {"readiness": readiness})
+        await asyncio.sleep(0.05)
+
+    async def test_write_tool_rejected_when_importing(self, mcp_stack):
+        client, plugin = mcp_stack
+        await self._set_readiness(plugin, "importing")
+
+        result = await client.call_tool(
+            "node_create", {"type": "Node3D", "name": "Blocked"},
+            raise_on_error=False,
+        )
+
+        assert result.is_error
+        assert "EDITOR_NOT_READY" in str(result.content)
+
+    async def test_write_tool_rejected_when_playing(self, mcp_stack):
+        client, plugin = mcp_stack
+        await self._set_readiness(plugin, "playing")
+
+        result = await client.call_tool("scene_save", {}, raise_on_error=False)
+
+        assert result.is_error
+        assert "EDITOR_NOT_READY" in str(result.content)
+
+    async def test_read_tool_allowed_when_importing(self, mcp_stack):
+        client, plugin = mcp_stack
+        await self._set_readiness(plugin, "importing")
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "get_editor_state"
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "godot_version": "4.4.1",
+                    "project_name": "Test",
+                    "current_scene": "",
+                    "is_playing": False,
+                    "readiness": "importing",
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool("editor_state", {})
+        await task
+
+        assert not result.is_error
+
+    async def test_write_tool_works_after_readiness_restored(self, mcp_stack):
+        client, plugin = mcp_stack
+        # First set importing to block writes
+        await self._set_readiness(plugin, "importing")
+        result = await client.call_tool(
+            "node_create", {"type": "Node3D", "name": "Blocked"},
+            raise_on_error=False,
+        )
+        assert result.is_error
+
+        # Restore readiness
+        await self._set_readiness(plugin, "ready")
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "create_node"
+            await plugin.send_response(
+                cmd["request_id"],
+                {"path": "/Main/Unblocked", "type": "Node3D"},
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "node_create", {"type": "Node3D", "name": "Unblocked"}
+        )
+        await task
+
+        assert not result.is_error
+        assert result.data["path"] == "/Main/Unblocked"

--- a/tests/integration/test_project_tools.py
+++ b/tests/integration/test_project_tools.py
@@ -51,6 +51,42 @@ class TestProjectSettingsGet:
         await plugin.close()
 
 
+class TestProjectSettingsSet:
+    async def test_set_project_setting_roundtrip(self, harness):
+        plugin = await harness.connect_plugin()
+        client = GodotClient(harness.server, harness.registry)
+
+        async def mock_handler():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "set_project_setting"
+            assert cmd["params"] == {
+                "key": "display/window/size/viewport_width",
+                "value": 1920,
+            }
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "key": "display/window/size/viewport_width",
+                    "value": 1920,
+                    "old_value": 1152,
+                    "type": "int",
+                    "undoable": False,
+                },
+            )
+
+        handler_task = asyncio.create_task(mock_handler())
+        result = await client.send(
+            "set_project_setting",
+            {"key": "display/window/size/viewport_width", "value": 1920},
+        )
+        await handler_task
+
+        assert result["key"] == "display/window/size/viewport_width"
+        assert result["value"] == 1920
+        assert result["old_value"] == 1152
+        await plugin.close()
+
+
 class TestFilesystemSearch:
     async def test_search_by_name(self, harness):
         plugin = await harness.connect_plugin()

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -31,6 +31,15 @@ class TestHandshake:
         assert session.project_path == "/home/user/my_game"
         await plugin.close()
 
+    async def test_handshake_sets_readiness_from_plugin(self, harness):
+        plugin = await harness.connect_plugin(
+            session_id="sess-importing",
+            readiness="importing",
+        )
+        session = harness.registry.get("sess-importing")
+        assert session.readiness == "importing"
+        await plugin.close()
+
     async def test_disconnect_unregisters_session(self, harness):
         plugin = await harness.connect_plugin(session_id="sess-dc")
         await plugin.close()
@@ -167,6 +176,20 @@ class TestEvents:
 
         session = harness.registry.get("evt-2")
         assert session.play_state == "playing"
+        await plugin.close()
+
+    async def test_readiness_changed_event(self, harness):
+        plugin = await harness.connect_plugin(session_id="evt-3")
+        session = harness.registry.get("evt-3")
+        assert session.readiness == "ready"
+
+        await plugin.send_event("readiness_changed", {"readiness": "importing"})
+        await asyncio.sleep(0.05)
+        assert session.readiness == "importing"
+
+        await plugin.send_event("readiness_changed", {"readiness": "ready"})
+        await asyncio.sleep(0.05)
+        assert session.readiness == "ready"
         await plugin.close()
 
 

--- a/tests/unit/test_readiness.py
+++ b/tests/unit/test_readiness.py
@@ -1,0 +1,70 @@
+"""Unit tests for readiness gating."""
+
+from __future__ import annotations
+
+import pytest
+
+from godot_ai.godot_client.client import GodotCommandError
+from godot_ai.handlers._readiness import require_writable
+from godot_ai.protocol.errors import ErrorCode
+from godot_ai.runtime.direct import DirectRuntime
+from godot_ai.sessions.registry import Session, SessionRegistry
+
+
+def _make_session(readiness: str = "ready") -> Session:
+    return Session(
+        session_id="test-001",
+        godot_version="4.4.1",
+        project_path="/tmp/test",
+        plugin_version="0.0.1",
+        readiness=readiness,
+    )
+
+
+def _make_runtime(readiness: str = "ready") -> DirectRuntime:
+    registry = SessionRegistry()
+    registry.register(_make_session(readiness))
+    return DirectRuntime(registry=registry, client=object())
+
+
+def test_require_writable_passes_when_ready():
+    require_writable(_make_runtime("ready"))
+
+
+def test_require_writable_passes_when_no_scene():
+    require_writable(_make_runtime("no_scene"))
+
+
+def test_require_writable_passes_when_no_session():
+    runtime = DirectRuntime(registry=SessionRegistry(), client=object())
+    require_writable(runtime)  # no-op, no error
+
+
+def test_require_writable_rejects_importing():
+    with pytest.raises(GodotCommandError) as exc_info:
+        require_writable(_make_runtime("importing"))
+    assert exc_info.value.code == ErrorCode.EDITOR_NOT_READY
+    assert "importing" in exc_info.value.message
+
+
+def test_require_writable_rejects_playing():
+    with pytest.raises(GodotCommandError) as exc_info:
+        require_writable(_make_runtime("playing"))
+    assert exc_info.value.code == ErrorCode.EDITOR_NOT_READY
+    assert "play mode" in exc_info.value.message
+
+
+def test_session_readiness_in_to_dict():
+    session = _make_session("importing")
+    d = session.to_dict()
+    assert d["readiness"] == "importing"
+
+
+def test_session_readiness_defaults_to_ready():
+    session = Session(
+        session_id="x",
+        godot_version="4.4.1",
+        project_path="/tmp",
+        plugin_version="0.0.1",
+    )
+    assert session.readiness == "ready"

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -4,15 +4,18 @@ from __future__ import annotations
 
 import pytest
 
+from godot_ai.handlers import autoload as autoload_handlers
 from godot_ai.handlers import client as client_handlers
 from godot_ai.handlers import editor as editor_handlers
 from godot_ai.handlers import filesystem as filesystem_handlers
+from godot_ai.handlers import input_map as input_map_handlers
 from godot_ai.handlers import node as node_handlers
 from godot_ai.handlers import project as project_handlers
 from godot_ai.handlers import resource as resource_handlers
 from godot_ai.handlers import scene as scene_handlers
 from godot_ai.handlers import script as script_handlers
 from godot_ai.handlers import session as session_handlers
+from godot_ai.handlers import signal as signal_handlers
 from godot_ai.handlers import testing as testing_handlers
 from godot_ai.runtime.direct import DirectRuntime
 from godot_ai.sessions.registry import Session, SessionRegistry
@@ -44,6 +47,16 @@ class StubClient:
         if command == "get_project_setting":
             key = params["key"] if params else ""
             return {"key": key, "value": f"value:{key}"}
+        if command == "set_project_setting":
+            key = params.get("key", "")
+            value = params.get("value")
+            return {
+                "key": key,
+                "value": value,
+                "old_value": None,
+                "type": type(value).__name__,
+                "undoable": False,
+            }
         if command == "get_editor_state":
             return {
                 "current_scene": "res://main.tscn",
@@ -133,9 +146,23 @@ class StubClient:
         if command == "search_filesystem":
             return {"files": [{"path": f"res://file_{i}.gd"} for i in range(3)]}
         if command == "run_tests":
-            return {"passed": 5, "failed": 0, "results": []}
+            return {
+                "passed": 5,
+                "failed": 0,
+                "total": 5,
+                "duration_ms": 12,
+                "suites_run": ["scene", "node"],
+                "suite_count": 2,
+            }
         if command == "get_test_results":
-            return {"passed": 5, "failed": 0, "results": []}
+            return {
+                "passed": 5,
+                "failed": 0,
+                "total": 5,
+                "duration_ms": 12,
+                "suites_run": ["scene", "node"],
+                "suite_count": 2,
+            }
         if command == "configure_client":
             return {"status": "ok", "client": params.get("client", "")}
         if command == "check_client_status":
@@ -225,6 +252,86 @@ class StubClient:
                 "not_found": [],
                 "reimported_count": len(paths),
                 "not_found_count": 0,
+                "undoable": False,
+            }
+        if command == "list_signals":
+            return {
+                "path": params.get("path", ""),
+                "signals": [
+                    {"name": "ready", "args": []},
+                    {"name": "tree_entered", "args": []},
+                ],
+                "signal_count": 2,
+                "connections": [],
+                "connection_count": 0,
+            }
+        if command == "connect_signal":
+            return {
+                "source": params.get("path", ""),
+                "signal": params.get("signal", ""),
+                "target": params.get("target", ""),
+                "method": params.get("method", ""),
+                "undoable": True,
+            }
+        if command == "disconnect_signal":
+            return {
+                "source": params.get("path", ""),
+                "signal": params.get("signal", ""),
+                "target": params.get("target", ""),
+                "method": params.get("method", ""),
+                "undoable": True,
+            }
+        if command == "list_autoloads":
+            return {
+                "autoloads": [
+                    {
+                        "name": "GameManager",
+                        "path": "res://autoloads/game_manager.gd",
+                        "singleton": True,
+                    },
+                ],
+                "count": 1,
+            }
+        if command == "add_autoload":
+            return {
+                "name": params.get("name", ""),
+                "path": params.get("path", ""),
+                "singleton": params.get("singleton", True),
+                "undoable": False,
+            }
+        if command == "remove_autoload":
+            return {
+                "name": params.get("name", ""),
+                "removed": True,
+                "undoable": False,
+            }
+        if command == "list_actions":
+            return {
+                "actions": [
+                    {"name": "ui_accept", "events": [], "event_count": 0, "is_builtin": True},
+                    {"name": "jump", "events": [], "event_count": 0, "is_builtin": False},
+                ],
+                "count": 2,
+            }
+        if command == "add_action":
+            return {
+                "action": params.get("action", ""),
+                "deadzone": params.get("deadzone", 0.5),
+                "undoable": False,
+            }
+        if command == "remove_action":
+            return {
+                "action": params.get("action", ""),
+                "removed": True,
+                "undoable": False,
+            }
+        if command == "bind_event":
+            return {
+                "action": params.get("action", ""),
+                "event": {
+                    "type": params.get("event_type", ""),
+                    "keycode": params.get("keycode", ""),
+                },
                 "undoable": False,
             }
         return {"status": "ok"}
@@ -665,6 +772,27 @@ async def test_get_test_results_handler():
     assert client.calls[-1]["command"] == "get_test_results"
 
 
+async def test_run_tests_handler_verbose():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    await testing_handlers.run_tests(runtime, verbose=True)
+    assert client.calls[-1]["params"] == {"verbose": True}
+
+
+async def test_get_test_results_handler_verbose():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    await testing_handlers.get_test_results(runtime, verbose=True)
+    assert client.calls[-1]["params"] == {"verbose": True}
+
+
+async def test_input_map_list_handler_with_include_builtin():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    await input_map_handlers.input_map_list(runtime, include_builtin=True)
+    assert client.calls[-1]["params"] == {"include_builtin": True}
+
+
 # ---------------------------------------------------------------------------
 # Client handler tests
 # ---------------------------------------------------------------------------
@@ -750,6 +878,21 @@ async def test_filesystem_search_handler():
     assert len(result["files"]) == 2
     assert result["total_count"] == 3
     assert client.calls[-1]["params"] == {"name": "file", "type": "GDScript", "path": "res://"}
+
+
+async def test_project_settings_set_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await project_handlers.project_settings_set(
+        runtime, key="display/window/size/viewport_width", value=1920
+    )
+    assert result["key"] == "display/window/size/viewport_width"
+    assert result["value"] == 1920
+    assert client.calls[-1]["command"] == "set_project_setting"
+    assert client.calls[-1]["params"] == {
+        "key": "display/window/size/viewport_width",
+        "value": 1920,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -936,3 +1079,128 @@ async def test_project_settings_resource_data_collects_errors():
     assert "application/config/name" in error_keys
     # Other settings should still succeed
     assert len(result["settings"]) == len(project_handlers.COMMON_SETTINGS) - 1
+
+
+# ---------------------------------------------------------------------------
+# Signal handler tests
+# ---------------------------------------------------------------------------
+
+
+async def test_signal_list_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await signal_handlers.signal_list(runtime, path="/Main/Player")
+    assert result["signal_count"] == 2
+    assert result["signals"][0]["name"] == "ready"
+    assert client.calls[-1]["command"] == "list_signals"
+    assert client.calls[-1]["params"] == {"path": "/Main/Player"}
+
+
+async def test_signal_connect_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await signal_handlers.signal_connect(
+        runtime,
+        path="/Main/Button",
+        signal="pressed",
+        target="/Main/Player",
+        method="_on_button_pressed",
+    )
+    assert result["signal"] == "pressed"
+    assert result["undoable"] is True
+    assert client.calls[-1]["command"] == "connect_signal"
+
+
+async def test_signal_disconnect_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await signal_handlers.signal_disconnect(
+        runtime,
+        path="/Main/Button",
+        signal="pressed",
+        target="/Main/Player",
+        method="_on_button_pressed",
+    )
+    assert result["signal"] == "pressed"
+    assert result["undoable"] is True
+    assert client.calls[-1]["command"] == "disconnect_signal"
+
+
+# ---------------------------------------------------------------------------
+# Autoload handler tests
+# ---------------------------------------------------------------------------
+
+
+async def test_autoload_list_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await autoload_handlers.autoload_list(runtime)
+    assert result["count"] == 1
+    assert result["autoloads"][0]["name"] == "GameManager"
+    assert client.calls[-1]["command"] == "list_autoloads"
+
+
+async def test_autoload_add_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await autoload_handlers.autoload_add(
+        runtime, name="AudioBus", path="res://autoloads/audio_bus.gd"
+    )
+    assert result["name"] == "AudioBus"
+    assert result["path"] == "res://autoloads/audio_bus.gd"
+    assert client.calls[-1]["command"] == "add_autoload"
+
+
+async def test_autoload_remove_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await autoload_handlers.autoload_remove(runtime, name="GameManager")
+    assert result["name"] == "GameManager"
+    assert result["removed"] is True
+    assert client.calls[-1]["command"] == "remove_autoload"
+
+
+# ---------------------------------------------------------------------------
+# Input map handler tests
+# ---------------------------------------------------------------------------
+
+
+async def test_input_map_list_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await input_map_handlers.input_map_list(runtime)
+    assert result["count"] == 2
+    assert result["actions"][0]["name"] == "ui_accept"
+    assert client.calls[-1]["command"] == "list_actions"
+
+
+async def test_input_map_add_action_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await input_map_handlers.input_map_add_action(
+        runtime, action="jump", deadzone=0.3
+    )
+    assert result["action"] == "jump"
+    assert result["deadzone"] == 0.3
+    assert client.calls[-1]["command"] == "add_action"
+
+
+async def test_input_map_remove_action_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await input_map_handlers.input_map_remove_action(runtime, action="jump")
+    assert result["action"] == "jump"
+    assert result["removed"] is True
+    assert client.calls[-1]["command"] == "remove_action"
+
+
+async def test_input_map_bind_event_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await input_map_handlers.input_map_bind_event(
+        runtime, action="jump", event_type="key", keycode="Space"
+    )
+    assert result["action"] == "jump"
+    assert result["event"]["type"] == "key"
+    assert client.calls[-1]["command"] == "bind_event"
+    assert client.calls[-1]["params"]["keycode"] == "Space"


### PR DESCRIPTION
## Summary

- **Readiness gating** — closes Phase 2. GDScript computes editor readiness (`ready`/`importing`/`playing`/`no_scene`), sends it in handshake + events. Python `require_writable()` gates all 20 write handlers, rejecting with `EDITOR_NOT_READY` when unsafe.
- **12 new MCP tools**: `project_settings_set`, `signal_list`/`connect`/`disconnect`, `autoload_list`/`add`/`remove`, `input_map_list`/`add_action`/`remove_action`/`bind_event`
- **Test output compacted** — `run_tests` returns summary + failures only by default; `verbose=true` for full per-test results
- **Save rollback** — all `ProjectSettings` mutators restore in-memory state on save failure
- **Code quality** — deduplicated readiness logic (static `Connection.get_readiness()`), extracted shared signal param validation, `input_map_list` filters builtins by default

228 Python + 153 GDScript = **381 total tests**, all passing.

## Test plan

- [x] `ruff check src/ tests/` — lint clean
- [x] `pytest -v` — 228 Python tests pass
- [x] `run_tests` via MCP — 153 GDScript tests pass (10 suites)
- [x] Live smoke test: `editor_state` readiness field, `signal_list`/`connect`/`disconnect`, `autoload_add`/`list`/`remove`, `input_map_add_action`/`bind_event` (key + joy_button 0)/`remove_action`, `project_settings_set` roundtrip, `input_map_list` default vs `include_builtin=true`
- [x] Verified readiness is set from handshake (not defaulted) after reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)