### PR TITLE
Make MCP tool surface tool-search friendly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,10 +113,11 @@ MCP tools `client_configure` and `client_status` expose this to AI clients.
 1. Add a handler method in the appropriate GDScript `handlers/*.gd` file
 2. Register it in `plugin.gd`: `_dispatcher.register("command_name", handler.method)`
 3. Add a shared Python handler in `handlers/<domain>.py` that calls `runtime.send_command("command_name", params)`
-4. Add a Python tool in `tools/<domain>.py` that creates `DirectRuntime` and delegates to the handler
-5. Register the tool module in `server.py` if it's a new file
+4. Add a Python tool in `tools/<domain>.py` — name it `domain_action` (e.g. `scene_open`, `node_create`), decorate with `@mcp.tool(meta=DEFER_META)` from `godot_ai.tools`. Only omit `meta` for the ~5 always-loaded core tools (`editor_state`, `scene_get_hierarchy`, `node_get_properties`, `session_list`, `session_activate`)
+5. Register the tool module in `server.py` if it's a new file. If it introduces a new namespace, add it to the tool-categories blurb in `server.py` `instructions=`
 6. For write tools: add `require_writable(runtime)` call at the top of the Python handler
-7. Add tests: handler unit test, Python integration test, AND GDScript test in `test_project/tests/`
+7. Write a description with natural-language keywords a user would search for (e.g. `screenshot`, `keybinding`, `asset`) alongside the Godot term
+8. Add tests: handler unit test, Python integration test, AND GDScript test in `test_project/tests/`
 
 ## Write tools must be undoable
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ AI Client → MCP (stdio/sse/streamable-http) → Python FastMCP server → WebS
 - **Plugin runs on main thread**: All GDScript executes in `_process()` with a 4ms frame budget. Never block. Use `call_deferred` for scene tree mutations.
 - **Scene paths are clean**: `/Main/Camera3D` format, not raw Godot internal paths. Use `ScenePath.from_node(node, scene_root)` in GDScript.
 - **MCP logging**: Plugin prints `MCP | [recv] command(params)` / `MCP | [send] command -> ok` to Godot console. Controlled by `mcp_logging` var.
+- **Tool-search-friendly naming**: All MCP tools use `domain_action` namespacing (`scene_*`, `node_*`, `script_*`, etc.). Non-core tools are tagged `meta={"defer_loading": True}` for Anthropic tool-search compatibility; core tools (`editor_state`, `scene_get_hierarchy`, `node_get_properties`, `session_list`, `session_activate`) stay non-deferred. Plugin command names (sent over WebSocket) are independent — the MCP tool `editor_reload_plugin` dispatches the plugin command `reload_plugin`.
 
 ## Dev workflow
 
@@ -53,7 +54,7 @@ This uses `src/godot_ai/asgi.py` to run uvicorn with its factory reload path. Uv
 
 ### Plugin reload
 
-The `reload_plugin` MCP tool triggers a live plugin reload inside Godot (`EditorInterface.set_plugin_enabled` off/on). Requires the server to be running externally (not managed by the plugin). The Python handler waits for the new session via `SessionRegistry.wait_for_session()`.
+The `editor_reload_plugin` MCP tool triggers a live plugin reload inside Godot (`EditorInterface.set_plugin_enabled` off/on). Requires the server to be running externally (not managed by the plugin). The Python handler waits for the new session via `SessionRegistry.wait_for_session()`.
 
 The Godot dock also has a **Start/Stop Dev Server** button for convenience.
 
@@ -67,10 +68,10 @@ pytest -v                    # 277 unit + integration tests
 ### Godot-side tests
 GDScript test suites in `test_project/tests/` exercise handlers inside the running editor. Run via MCP:
 ```
-run_tests                    # compact: summary + failures only
-run_tests suite=scene        # run one suite
-run_tests verbose=true       # include every individual test result
-get_test_results             # review last results
+test_run                     # compact: summary + failures only
+test_run suite=scene         # run one suite
+test_run verbose=true        # include every individual test result
+test_results_get             # review last results
 ```
 
 Test suites extend `McpTestSuite` (assertion methods: `assert_true`, `assert_eq`, `assert_has_key`, `assert_contains`, `assert_is_error`, etc.). Drop `test_*.gd` files in `res://tests/` and they're auto-discovered.
@@ -90,7 +91,7 @@ Test suites extend `McpTestSuite` (assertion methods: `assert_true`, `assert_eq`
 2. `pytest -v` — all Python tests pass
 3. Open `test_project/` in Godot (or launch: `/Applications/Godot_mono.app/Contents/MacOS/Godot --editor --path test_project/`)
 4. `session_activate` the test_project session if multiple editors are connected
-5. `run_tests` via MCP — all GDScript tests pass (0 failures)
+5. `test_run` via MCP — all GDScript tests pass (0 failures)
 6. **Live smoke test** new/changed features against the real editor:
    - Call each new tool and verify the response makes sense
    - For write tools: verify the change is visible in the editor, and verify undo works (Ctrl+Z in Godot)
@@ -143,7 +144,7 @@ New features don't ship without tests. Regressions are caught before they merge.
 
 - **Re-entrant `_process()` during save**: `EditorInterface.save_scene()` internally renders a preview thumbnail, which triggers frame processing. If `Connection._process()` runs during this, WebSocket polling and command dispatch re-enter, crashing Godot (`SIGABRT` in `_save_scene_with_preview`). Fixed by setting `Connection.pause_processing = true` around save calls in `SceneHandler`. Any new handler that calls `save_scene()`, `save_scene_as()`, or `save_all_scenes()` must do the same.
 - **GDScript tests must not call `EditorInterface.save_scene()` or `scene_create`/`scene_open`**: These trigger modal dialogs or scene switches that freeze or crash the test runner. Test only validation/error paths for these operations in GDScript; full behavior is covered by Python integration tests.
-- **GDScript tests must not call `quit_editor` or `reload_plugin`**: These terminate or restart the plugin, killing the test runner. Tested via Python integration tests and CI smoke scripts (`script/ci-quit-test`, `script/ci-reload-test`).
+- **GDScript tests must not call `quit_editor` or `reload_plugin`**: These terminate or restart the plugin, killing the test runner. Tested via Python integration tests and CI smoke scripts (`script/ci-quit-test`, `script/ci-reload-test`). (Note: plugin command names stay `quit_editor` / `reload_plugin`; the MCP tool names are `editor_quit` / `editor_reload_plugin`.)
 
 ## What NOT to do
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -24,9 +24,9 @@ ruff format src/ tests/      # format
 GDScript test suites run inside the connected editor via MCP:
 
 ```
-run_tests                    # run all suites
-run_tests suite=scene        # run one suite
-get_test_results             # review last results
+test_run                     # run all suites
+test_run suite=scene         # run one suite
+test_results_get             # review last results
 ```
 
 ## Dev Server with Auto-Reload

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -102,12 +102,12 @@ Release is not just packaging. It is install flow, docs, smoke coverage, and sup
 
 Anthropic's tool search (`tool_search_tool_regex_20251119` / `tool_search_tool_bm25_20251119`) lets clients defer loading tool definitions until the model searches for them. Our surface will grow past the 30-50 tool threshold where selection accuracy starts to degrade, so the MCP server needs to be a good citizen in that system.
 
-- [ ] audit every tool name for consistent, searchable namespacing (`scene_*`, `node_*`, `script_*`, `signal_*`, `input_map_*`, `editor_*`, `project_*`, `resource_*`, `filesystem_*`, etc.) — no ambiguous or one-off prefixes
-- [ ] audit every tool description so it contains the keywords a user would naturally use to describe the task (e.g. `screenshot`, `viewport`, `game view`, `input action`, `autoload singleton`) in addition to the Godot term
-- [ ] audit argument names and argument descriptions — tool search indexes these too
-- [ ] document which tools should stay non-deferred (the 3-5 most common: likely `editor_state`, `scene_get_hierarchy`, `node_get_properties`, plus session tools) and mark the rest `defer_loading: true` in the server's MCP advertisement where the protocol permits
-- [ ] add a short "available tool categories" blurb to the server's MCP server instructions so clients using tool search have a map of what to search for
-- [ ] verify the published surface still works for clients that do not use tool search (no tool should require a specific discovery path)
+- [x] audit every tool name for consistent, searchable namespacing (`scene_*`, `node_*`, `script_*`, `signal_*`, `input_map_*`, `editor_*`, `project_*`, `resource_*`, `filesystem_*`, etc.) — no ambiguous or one-off prefixes
+- [x] audit every tool description so it contains the keywords a user would naturally use to describe the task (e.g. `screenshot`, `viewport`, `game view`, `input action`, `autoload singleton`) in addition to the Godot term
+- [x] audit argument names and argument descriptions — tool search indexes these too
+- [x] document which tools should stay non-deferred (the 3-5 most common: likely `editor_state`, `scene_get_hierarchy`, `node_get_properties`, plus session tools) and mark the rest `defer_loading: true` in the server's MCP advertisement where the protocol permits
+- [x] add a short "available tool categories" blurb to the server's MCP server instructions so clients using tool search have a map of what to search for
+- [x] verify the published surface still works for clients that do not use tool search (no tool should require a specific discovery path)
 
 **Why this matters:** Once the tool count crosses ~50, clients that load every definition upfront start paying a real context-window tax and the model starts picking wrong tools. Writing names and descriptions with search in mind is cheap now and costly to retrofit later.
 

--- a/script/ci-godot-tests
+++ b/script/ci-godot-tests
@@ -79,11 +79,11 @@ if [ "$FINAL_COUNT" -eq 0 ] 2>/dev/null; then
   exit 1
 fi
 
-# Call run_tests
+# Call test_run
 echo "Running handler tests..."
 RESULT=$(curl -s "$SERVER_URL" -X POST "${HEADERS[@]}" \
   -H "Mcp-Session-Id: $SESSION_ID" \
-  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"run_tests","arguments":{}}}')
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"test_run","arguments":{}}}')
 
 # Parse and report results
 echo "$RESULT" | python3 -c "
@@ -110,7 +110,7 @@ for line in raw.split('\n'):
             sys.exit(1)
         break
 else:
-    print('ERROR: No valid response from run_tests')
+    print('ERROR: No valid response from test_run')
     print(f'Raw response: {raw[:500]}')
     sys.exit(1)
 "

--- a/script/ci-reload-test
+++ b/script/ci-reload-test
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Smoke-test the reload_plugin tool in CI.
+# Smoke-test the editor_reload_plugin tool in CI.
 # 1. Creates a node (cube) via the OLD plugin
 # 2. Reloads the plugin, verifies new session ID
 # 3. Checks the log buffer is fresh (proves handlers were rebuilt)
@@ -88,8 +88,8 @@ print(f'Created node: {path}')
 "
 
 # --- Step 2: Reload the plugin ---
-echo "Calling reload_plugin..."
-RELOAD_RESULT=$(mcp_call_or_die "reload_plugin" reload_plugin '{}')
+echo "Calling editor_reload_plugin..."
+RELOAD_RESULT=$(mcp_call_or_die "editor_reload_plugin" editor_reload_plugin '{}')
 echo "$RELOAD_RESULT" | python3 -c "
 import json, sys
 content = json.loads(sys.stdin.read())
@@ -97,13 +97,13 @@ status = content.get('status', '')
 old_id = content.get('old_session_id', '')
 new_id = content.get('new_session_id', '')
 if status != 'reloaded':
-    print(f'FAIL: reload_plugin returned status={status!r}, expected \"reloaded\"')
+    print(f'FAIL: editor_reload_plugin returned status={status!r}, expected \"reloaded\"')
     print(f'Full response: {content}')
     sys.exit(1)
 if old_id == new_id:
     print(f'FAIL: old and new session IDs are the same: {old_id}')
     sys.exit(1)
-print(f'reload_plugin OK: {old_id[:12]}... -> {new_id[:12]}...')
+print(f'editor_reload_plugin OK: {old_id[:12]}... -> {new_id[:12]}...')
 "
 
 # --- Step 3: Verify log buffer is fresh (proves plugin fully rebuilt) ---

--- a/src/godot_ai/handlers/editor.py
+++ b/src/godot_ai/handlers/editor.py
@@ -9,6 +9,7 @@ import logging
 from fastmcp.tools.base import Image as McpImage
 from mcp.types import TextContent
 
+from godot_ai.handlers._readiness import require_writable
 from godot_ai.runtime.interface import Runtime
 from godot_ai.sessions.registry import Session
 from godot_ai.tools._pagination import paginate
@@ -123,7 +124,7 @@ async def editor_screenshot(
     ]
 
 
-async def performance_get_monitors(
+async def performance_monitors_get(
     runtime: Runtime, monitors: list[str] | None = None
 ) -> dict:
     params: dict = {}
@@ -156,7 +157,7 @@ def _find_replacement_session(
     return None
 
 
-async def reload_plugin(runtime: Runtime) -> dict:
+async def editor_reload_plugin(runtime: Runtime) -> dict:
     active = runtime.get_active_session()
     if active is None:
         raise ConnectionError("No active Godot session")
@@ -188,6 +189,11 @@ async def reload_plugin(runtime: Runtime) -> dict:
 
 async def editor_quit(runtime: Runtime) -> dict:
     return await runtime.send_command("quit_editor")
+
+
+async def editor_selection_set(runtime: Runtime, paths: list[str]) -> dict:
+    require_writable(runtime)
+    return await runtime.send_command("set_selection", {"paths": paths})
 
 
 async def selection_resource_data(runtime: Runtime) -> dict:

--- a/src/godot_ai/handlers/filesystem.py
+++ b/src/godot_ai/handlers/filesystem.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from godot_ai.handlers._readiness import require_writable
 from godot_ai.runtime.interface import Runtime
+from godot_ai.tools._pagination import paginate
 
 
 async def filesystem_read_text(runtime: Runtime, path: str) -> dict:
@@ -18,6 +19,25 @@ async def filesystem_write_text(runtime: Runtime, path: str, content: str = "") 
     )
 
 
-async def import_reimport(runtime: Runtime, paths: list[str]) -> dict:
+async def filesystem_reimport(runtime: Runtime, paths: list[str]) -> dict:
     require_writable(runtime)
     return await runtime.send_command("reimport", {"paths": paths})
+
+
+async def filesystem_search(
+    runtime: Runtime,
+    name: str = "",
+    type: str = "",
+    path: str = "",
+    offset: int = 0,
+    limit: int = 100,
+) -> dict:
+    params: dict[str, str] = {}
+    if name:
+        params["name"] = name
+    if type:
+        params["type"] = type
+    if path:
+        params["path"] = path
+    result = await runtime.send_command("search_filesystem", params)
+    return paginate(result.get("files", []), offset, limit, key="files")

--- a/src/godot_ai/handlers/node.py
+++ b/src/godot_ai/handlers/node.py
@@ -94,8 +94,3 @@ async def node_remove_from_group(runtime: Runtime, path: str, group: str) -> dic
         {"path": path, "group": group},
     )
 
-
-async def editor_selection_set(runtime: Runtime, paths: list[str]) -> dict:
-    require_writable(runtime)
-    return await runtime.send_command("set_selection", {"paths": paths})
-

--- a/src/godot_ai/handlers/project.py
+++ b/src/godot_ai/handlers/project.py
@@ -7,7 +7,6 @@ from typing import Any
 
 from godot_ai.handlers._readiness import require_writable
 from godot_ai.runtime.interface import Runtime
-from godot_ai.tools._pagination import paginate
 
 COMMON_SETTINGS = [
     "application/config/name",
@@ -39,25 +38,6 @@ async def project_stop(runtime: Runtime) -> dict:
 async def project_settings_set(runtime: Runtime, key: str, value: Any) -> dict:
     require_writable(runtime)
     return await runtime.send_command("set_project_setting", {"key": key, "value": value})
-
-
-async def filesystem_search(
-    runtime: Runtime,
-    name: str = "",
-    type: str = "",
-    path: str = "",
-    offset: int = 0,
-    limit: int = 100,
-) -> dict:
-    params: dict[str, str] = {}
-    if name:
-        params["name"] = name
-    if type:
-        params["type"] = type
-    if path:
-        params["path"] = path
-    result = await runtime.send_command("search_filesystem", params)
-    return paginate(result.get("files", []), offset, limit, key="files")
 
 
 def project_info_resource_data(runtime: Runtime) -> dict:

--- a/src/godot_ai/handlers/testing.py
+++ b/src/godot_ai/handlers/testing.py
@@ -7,7 +7,7 @@ from typing import Any
 from godot_ai.runtime.interface import Runtime
 
 
-async def run_tests(
+async def test_run(
     runtime: Runtime,
     suite: str = "",
     test_name: str = "",
@@ -23,7 +23,7 @@ async def run_tests(
     return await runtime.send_command("run_tests", params, timeout=30.0)
 
 
-async def get_test_results(runtime: Runtime, verbose: bool = False) -> dict:
+async def test_results_get(runtime: Runtime, verbose: bool = False) -> dict:
     params: dict[str, Any] = {}
     if verbose:
         params["verbose"] = True

--- a/src/godot_ai/server.py
+++ b/src/godot_ai/server.py
@@ -66,8 +66,29 @@ def create_server(ws_port: int = 9500) -> FastMCP:
 
     mcp = FastMCP(
         "Godot AI",
-        instructions="Production-grade Godot MCP server with persistent editor integration. "
-        "Use session tools to manage connections to Godot editor instances.",
+        instructions=(
+            "Production-grade Godot MCP server with persistent editor integration.\n\n"
+            "Tool categories (namespace prefixes — useful for tool-search queries):\n"
+            "  session_*        — list and activate connected editor sessions\n"
+            "  editor_*         — editor state, selection, screenshot, logs, quit, reload plugin\n"
+            "  scene_*          — open/save scenes (levels/maps), inspect the scene tree\n"
+            "  node_*           — create, inspect, modify, duplicate, group, reparent nodes\n"
+            "  script_*         — create, read, attach, detach, outline GDScript files\n"
+            "  resource_*       — search, load, assign resources (assets: meshes, textures, etc.)\n"
+            "  signal_*         — list, connect, disconnect node signals (events / callbacks)\n"
+            "  input_map_*      — manage input actions (keybindings, keyboard/mouse/gamepad)\n"
+            "  autoload_*       — manage autoload singletons (global scripts)\n"
+            "  project_*        — run/stop the game, read/write project settings\n"
+            "  filesystem_*     — read/write text files, search assets, reimport\n"
+            "  performance_*    — FPS, memory, draw calls, and other runtime metrics\n"
+            "  logs_*           — read or clear the editor log buffer\n"
+            "  test_*           — run GDScript test suites and fetch results\n"
+            "  batch_execute    — compose multi-step scene edits atomically\n"
+            "  client_*         — configure AI clients (Claude Code, Codex, Antigravity)\n\n"
+            "Always connect to an editor session first (session_list / session_activate). "
+            "Write operations require session readiness; check editor_state if a call is "
+            "rejected as 'not writable'."
+        ),
         lifespan=_lifespan,
     )
 

--- a/src/godot_ai/tools/__init__.py
+++ b/src/godot_ai/tools/__init__.py
@@ -1,0 +1,8 @@
+"""MCP tool modules.
+
+`DEFER_META` marks a tool as deferred-loading for clients using Anthropic
+tool search. Core tools (always loaded: editor_state, scene_get_hierarchy,
+node_get_properties, session_list, session_activate) omit it.
+"""
+
+DEFER_META: dict[str, object] = {"defer_loading": True}

--- a/src/godot_ai/tools/autoload.py
+++ b/src/godot_ai/tools/autoload.py
@@ -6,12 +6,13 @@ from fastmcp import Context, FastMCP
 
 from godot_ai.handlers import autoload as autoload_handlers
 from godot_ai.runtime.direct import DirectRuntime
+from godot_ai.tools import DEFER_META
 
 
 def register_autoload_tools(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def autoload_list(ctx: Context) -> dict:
-        """List all registered autoload singletons.
+        """List all registered autoload singletons (global scripts / scenes accessible by name).
 
         Returns each autoload's name, script/scene path, and whether
         it's a singleton (accessible via name globally).
@@ -19,7 +20,7 @@ def register_autoload_tools(mcp: FastMCP) -> None:
         runtime = DirectRuntime.from_context(ctx)
         return await autoload_handlers.autoload_list(runtime)
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def autoload_add(
         ctx: Context,
         name: str,
@@ -41,7 +42,7 @@ def register_autoload_tools(mcp: FastMCP) -> None:
             runtime, name=name, path=path, singleton=singleton
         )
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def autoload_remove(ctx: Context, name: str) -> dict:
         """Remove an autoload singleton from the project.
 

--- a/src/godot_ai/tools/batch.py
+++ b/src/godot_ai/tools/batch.py
@@ -6,10 +6,11 @@ from fastmcp import Context, FastMCP
 
 from godot_ai.handlers import batch as batch_handlers
 from godot_ai.runtime.direct import DirectRuntime
+from godot_ai.tools import DEFER_META
 
 
 def register_batch_tools(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def batch_execute(
         ctx: Context,
         commands: list[dict],

--- a/src/godot_ai/tools/client.py
+++ b/src/godot_ai/tools/client.py
@@ -6,10 +6,11 @@ from fastmcp import Context, FastMCP
 
 from godot_ai.handlers import client as client_handlers
 from godot_ai.runtime.direct import DirectRuntime
+from godot_ai.tools import DEFER_META
 
 
 def register_client_tools(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def client_configure(ctx: Context, client: str) -> dict:
         """Configure an AI client to connect to the Godot AI server.
 
@@ -22,7 +23,7 @@ def register_client_tools(mcp: FastMCP) -> None:
         runtime = DirectRuntime.from_context(ctx)
         return await client_handlers.client_configure(runtime, client=client)
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def client_status(ctx: Context) -> dict:
         """Check which AI clients are configured to use Godot AI.
 

--- a/src/godot_ai/tools/editor.py
+++ b/src/godot_ai/tools/editor.py
@@ -6,12 +6,13 @@ from fastmcp import Context, FastMCP
 
 from godot_ai.handlers import editor as editor_handlers
 from godot_ai.runtime.direct import DirectRuntime
+from godot_ai.tools import DEFER_META
 
 
 def register_editor_tools(mcp: FastMCP) -> None:
     @mcp.tool()
     async def editor_state(ctx: Context) -> dict:
-        """Get the current Godot editor state.
+        """Get current Godot editor (IDE) state: version, readiness, open scene.
 
         Returns Godot version, project name, current scene path,
         and whether the project is currently playing.
@@ -19,7 +20,7 @@ def register_editor_tools(mcp: FastMCP) -> None:
         runtime = DirectRuntime.from_context(ctx)
         return await editor_handlers.editor_state(runtime)
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def editor_selection_get(ctx: Context) -> dict:
         """Get the currently selected nodes in the Godot editor.
 
@@ -28,7 +29,7 @@ def register_editor_tools(mcp: FastMCP) -> None:
         runtime = DirectRuntime.from_context(ctx)
         return await editor_handlers.editor_selection_get(runtime)
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def logs_read(
         ctx: Context,
         count: int = 50,
@@ -47,7 +48,7 @@ def register_editor_tools(mcp: FastMCP) -> None:
         runtime = DirectRuntime.from_context(ctx)
         return await editor_handlers.logs_read(runtime, count=count, offset=offset)
 
-    @mcp.tool(output_schema=None)
+    @mcp.tool(output_schema=None, meta=DEFER_META)
     async def editor_screenshot(
         ctx: Context,
         source: str = "viewport",
@@ -59,7 +60,7 @@ def register_editor_tools(mcp: FastMCP) -> None:
         azimuth: float | None = None,
         fov: float | None = None,
     ):
-        """Capture a screenshot from the Godot editor.
+        """Capture a screenshot / image / picture of the Godot editor viewport or running game view.
 
         Takes a screenshot and optionally returns it as an inline image.
 
@@ -122,12 +123,12 @@ def register_editor_tools(mcp: FastMCP) -> None:
             fov=fov,
         )
 
-    @mcp.tool()
-    async def performance_get_monitors(
+    @mcp.tool(meta=DEFER_META)
+    async def performance_monitors_get(
         ctx: Context,
         monitors: list[str] | None = None,
     ) -> dict:
-        """Get Godot performance monitor values.
+        """Get Godot performance monitor values (FPS, memory, draw calls, frame time).
 
         Returns values from Godot's Performance singleton: FPS, memory usage,
         object counts, render stats, physics stats, and navigation stats.
@@ -147,9 +148,9 @@ def register_editor_tools(mcp: FastMCP) -> None:
             monitors: Optional list of monitor names to return. If omitted, returns all.
         """
         runtime = DirectRuntime.from_context(ctx)
-        return await editor_handlers.performance_get_monitors(runtime, monitors=monitors)
+        return await editor_handlers.performance_monitors_get(runtime, monitors=monitors)
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def logs_clear(ctx: Context) -> dict:
         """Clear the MCP log buffer in the Godot editor.
 
@@ -158,9 +159,9 @@ def register_editor_tools(mcp: FastMCP) -> None:
         runtime = DirectRuntime.from_context(ctx)
         return await editor_handlers.logs_clear(runtime)
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def editor_quit(ctx: Context) -> dict:
-        """Gracefully quit the Godot editor.
+        """Gracefully quit (close / shutdown) the Godot editor (IDE).
 
         Sends a quit signal to the editor on the next frame, allowing
         any pending responses to be sent first. The editor will close
@@ -169,8 +170,8 @@ def register_editor_tools(mcp: FastMCP) -> None:
         runtime = DirectRuntime.from_context(ctx)
         return await editor_handlers.editor_quit(runtime)
 
-    @mcp.tool()
-    async def reload_plugin(ctx: Context) -> dict:
+    @mcp.tool(meta=DEFER_META)
+    async def editor_reload_plugin(ctx: Context) -> dict:
         """Reload the Godot editor plugin and wait for it to reconnect.
 
         Sends a reload command to the plugin, which disables and re-enables
@@ -182,4 +183,21 @@ def register_editor_tools(mcp: FastMCP) -> None:
         Start with: python -m godot_ai --transport streamable-http --port 8000 --reload
         """
         runtime = DirectRuntime.from_context(ctx)
-        return await editor_handlers.reload_plugin(runtime)
+        return await editor_handlers.editor_reload_plugin(runtime)
+
+    @mcp.tool(meta=DEFER_META)
+    async def editor_selection_set(
+        ctx: Context,
+        paths: list[str],
+    ) -> dict:
+        """Select nodes in the Godot editor by their scene paths.
+
+        Replaces the current selection with the specified nodes. Any
+        paths that don't resolve to existing nodes are reported in
+        the not_found list.
+
+        Args:
+            paths: List of scene paths to select (e.g. ["/Main/Camera3D", "/Main/Player"]).
+        """
+        runtime = DirectRuntime.from_context(ctx)
+        return await editor_handlers.editor_selection_set(runtime, paths=paths)

--- a/src/godot_ai/tools/filesystem.py
+++ b/src/godot_ai/tools/filesystem.py
@@ -6,10 +6,11 @@ from fastmcp import Context, FastMCP
 
 from godot_ai.handlers import filesystem as filesystem_handlers
 from godot_ai.runtime.direct import DirectRuntime
+from godot_ai.tools import DEFER_META
 
 
 def register_filesystem_tools(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def filesystem_read_text(ctx: Context, path: str) -> dict:
         """Read a text file from the Godot project.
 
@@ -22,7 +23,7 @@ def register_filesystem_tools(mcp: FastMCP) -> None:
         runtime = DirectRuntime.from_context(ctx)
         return await filesystem_handlers.filesystem_read_text(runtime, path=path)
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def filesystem_write_text(
         ctx: Context,
         path: str,
@@ -45,9 +46,9 @@ def register_filesystem_tools(mcp: FastMCP) -> None:
             content=content,
         )
 
-    @mcp.tool()
-    async def import_reimport(ctx: Context, paths: list[str]) -> dict:
-        """Force reimport of specific files in the Godot project.
+    @mcp.tool(meta=DEFER_META)
+    async def filesystem_reimport(ctx: Context, paths: list[str]) -> dict:
+        """Force reimport of specific files / assets in the Godot project.
 
         Triggers EditorFileSystem.update_file() for each path, which
         forces the editor to re-scan and reimport the files. Useful
@@ -57,4 +58,35 @@ def register_filesystem_tools(mcp: FastMCP) -> None:
             paths: List of file paths to reimport (e.g. ["res://textures/icon.png"]).
         """
         runtime = DirectRuntime.from_context(ctx)
-        return await filesystem_handlers.import_reimport(runtime, paths=paths)
+        return await filesystem_handlers.filesystem_reimport(runtime, paths=paths)
+
+    @mcp.tool(meta=DEFER_META)
+    async def filesystem_search(
+        ctx: Context,
+        name: str = "",
+        type: str = "",
+        path: str = "",
+        offset: int = 0,
+        limit: int = 100,
+    ) -> dict:
+        """Search the Godot project filesystem via EditorFileSystem.
+
+        Finds files by name, resource type, or path pattern. At least one
+        filter must be provided. Results are paginated.
+
+        Args:
+            name: Filter by filename (case-insensitive substring match).
+            type: Filter by resource type (e.g. "PackedScene", "GDScript", "Texture2D").
+            path: Filter by path (case-insensitive substring match).
+            offset: Number of results to skip. Default 0.
+            limit: Maximum number of results to return. Default 100.
+        """
+        runtime = DirectRuntime.from_context(ctx)
+        return await filesystem_handlers.filesystem_search(
+            runtime,
+            name=name,
+            type=type,
+            path=path,
+            offset=offset,
+            limit=limit,
+        )

--- a/src/godot_ai/tools/input_map.py
+++ b/src/godot_ai/tools/input_map.py
@@ -6,12 +6,13 @@ from fastmcp import Context, FastMCP
 
 from godot_ai.handlers import input_map as input_map_handlers
 from godot_ai.runtime.direct import DirectRuntime
+from godot_ai.tools import DEFER_META
 
 
 def register_input_map_tools(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def input_map_list(ctx: Context, include_builtin: bool = False) -> dict:
-        """List all input actions and their bound events.
+        """List all input actions (keybindings / control mappings) and their bound events.
 
         By default returns only project-defined actions. Set
         include_builtin=true to also include Godot's built-in ui_*
@@ -23,13 +24,13 @@ def register_input_map_tools(mcp: FastMCP) -> None:
         runtime = DirectRuntime.from_context(ctx)
         return await input_map_handlers.input_map_list(runtime, include_builtin=include_builtin)
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def input_map_add_action(
         ctx: Context,
         action: str,
         deadzone: float = 0.5,
     ) -> dict:
-        """Create a new input action.
+        """Create a new input action (named keybinding / control slot like "jump" or "move_left").
 
         Adds an empty input action that can have events bound to it.
         Saved to project.godot.
@@ -43,7 +44,7 @@ def register_input_map_tools(mcp: FastMCP) -> None:
             runtime, action=action, deadzone=deadzone
         )
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def input_map_remove_action(ctx: Context, action: str) -> dict:
         """Remove an input action and all its bindings.
 
@@ -55,7 +56,7 @@ def register_input_map_tools(mcp: FastMCP) -> None:
         runtime = DirectRuntime.from_context(ctx)
         return await input_map_handlers.input_map_remove_action(runtime, action=action)
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def input_map_bind_event(
         ctx: Context,
         action: str,
@@ -67,10 +68,9 @@ def register_input_map_tools(mcp: FastMCP) -> None:
         meta: bool = False,
         button: int | None = None,
     ) -> dict:
-        """Bind an input event to an action.
+        """Bind keyboard / mouse / gamepad input to an action (configure controls / keybindings).
 
-        Adds a key press, mouse button, or gamepad button to an existing
-        action. Saved to project.godot.
+        Adds the event to an existing action. Saved to project.godot.
 
         Args:
             action: Name of the action to bind to.

--- a/src/godot_ai/tools/node.py
+++ b/src/godot_ai/tools/node.py
@@ -6,17 +6,18 @@ from fastmcp import Context, FastMCP
 
 from godot_ai.handlers import node as node_handlers
 from godot_ai.runtime.direct import DirectRuntime
+from godot_ai.tools import DEFER_META
 
 
 def register_node_tools(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def node_create(
         ctx: Context,
         type: str,
         name: str = "",
         parent_path: str = "",
     ) -> dict:
-        """Create a new node in the scene tree.
+        """Create (spawn / add) a new node (game object / entity) in the scene tree.
 
         Creates a node of the given type and adds it as a child of the
         specified parent. If no parent is given, adds to the scene root.
@@ -35,7 +36,7 @@ def register_node_tools(mcp: FastMCP) -> None:
             parent_path=parent_path,
         )
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def node_find(
         ctx: Context,
         name: str = "",
@@ -79,7 +80,7 @@ def register_node_tools(mcp: FastMCP) -> None:
         runtime = DirectRuntime.from_context(ctx)
         return await node_handlers.node_get_properties(runtime, path=path)
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def node_get_children(ctx: Context, path: str) -> dict:
         """Get the direct children of a node.
 
@@ -92,7 +93,7 @@ def register_node_tools(mcp: FastMCP) -> None:
         runtime = DirectRuntime.from_context(ctx)
         return await node_handlers.node_get_children(runtime, path=path)
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def node_get_groups(ctx: Context, path: str) -> dict:
         """Get the groups a node belongs to.
 
@@ -104,7 +105,7 @@ def register_node_tools(mcp: FastMCP) -> None:
         runtime = DirectRuntime.from_context(ctx)
         return await node_handlers.node_get_groups(runtime, path=path)
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def node_delete(ctx: Context, path: str) -> dict:
         """Delete a node from the scene tree.
 
@@ -117,7 +118,7 @@ def register_node_tools(mcp: FastMCP) -> None:
         runtime = DirectRuntime.from_context(ctx)
         return await node_handlers.node_delete(runtime, path=path)
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def node_reparent(
         ctx: Context,
         path: str,
@@ -135,7 +136,7 @@ def register_node_tools(mcp: FastMCP) -> None:
         runtime = DirectRuntime.from_context(ctx)
         return await node_handlers.node_reparent(runtime, path=path, new_parent=new_parent)
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def node_set_property(
         ctx: Context,
         path: str,
@@ -158,13 +159,13 @@ def register_node_tools(mcp: FastMCP) -> None:
             runtime, path=path, property=property, value=value,
         )
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def node_duplicate(
         ctx: Context,
         path: str,
         name: str = "",
     ) -> dict:
-        """Duplicate a node and all its children.
+        """Duplicate (clone / copy) a node and all its children.
 
         Creates a deep copy of the node and adds it as a sibling.
         Cannot duplicate the scene root.
@@ -176,7 +177,7 @@ def register_node_tools(mcp: FastMCP) -> None:
         runtime = DirectRuntime.from_context(ctx)
         return await node_handlers.node_duplicate(runtime, path=path, name=name)
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def node_move(
         ctx: Context,
         path: str,
@@ -194,7 +195,7 @@ def register_node_tools(mcp: FastMCP) -> None:
         runtime = DirectRuntime.from_context(ctx)
         return await node_handlers.node_move(runtime, path=path, index=index)
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def node_add_to_group(
         ctx: Context,
         path: str,
@@ -212,7 +213,7 @@ def register_node_tools(mcp: FastMCP) -> None:
         runtime = DirectRuntime.from_context(ctx)
         return await node_handlers.node_add_to_group(runtime, path=path, group=group)
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def node_remove_from_group(
         ctx: Context,
         path: str,
@@ -227,19 +228,3 @@ def register_node_tools(mcp: FastMCP) -> None:
         runtime = DirectRuntime.from_context(ctx)
         return await node_handlers.node_remove_from_group(runtime, path=path, group=group)
 
-    @mcp.tool()
-    async def editor_selection_set(
-        ctx: Context,
-        paths: list[str],
-    ) -> dict:
-        """Select nodes in the Godot editor by their scene paths.
-
-        Replaces the current selection with the specified nodes. Any
-        paths that don't resolve to existing nodes are reported in
-        the not_found list.
-
-        Args:
-            paths: List of scene paths to select (e.g. ["/Main/Camera3D", "/Main/Player"]).
-        """
-        runtime = DirectRuntime.from_context(ctx)
-        return await node_handlers.editor_selection_set(runtime, paths=paths)

--- a/src/godot_ai/tools/project.py
+++ b/src/godot_ai/tools/project.py
@@ -1,4 +1,4 @@
-"""MCP tools for project settings and filesystem search."""
+"""MCP tools for project settings and run/stop."""
 
 from __future__ import annotations
 
@@ -8,16 +8,17 @@ from fastmcp import Context, FastMCP
 
 from godot_ai.handlers import project as project_handlers
 from godot_ai.runtime.direct import DirectRuntime
+from godot_ai.tools import DEFER_META
 
 
 def register_project_tools(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def project_run(
         ctx: Context,
         mode: str = "main",
         scene: str = "",
     ) -> dict:
-        """Run the Godot project from the editor.
+        """Run (play / start) the Godot project (game) from the editor.
 
         Starts the game in one of three modes:
         - "main": Run the project's main scene (default).
@@ -31,9 +32,9 @@ def register_project_tools(mcp: FastMCP) -> None:
         runtime = DirectRuntime.from_context(ctx)
         return await project_handlers.project_run(runtime, mode=mode, scene=scene)
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def project_stop(ctx: Context) -> dict:
-        """Stop the running Godot project.
+        """Stop (halt / exit) the running Godot project (game).
 
         Stops the currently playing scene. Returns an error if the project
         is not running.
@@ -41,7 +42,7 @@ def register_project_tools(mcp: FastMCP) -> None:
         runtime = DirectRuntime.from_context(ctx)
         return await project_handlers.project_stop(runtime)
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def project_settings_get(ctx: Context, key: str) -> dict:
         """Get a Godot project setting by key.
 
@@ -54,7 +55,7 @@ def register_project_tools(mcp: FastMCP) -> None:
         runtime = DirectRuntime.from_context(ctx)
         return await project_handlers.project_settings_get(runtime, key=key)
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def project_settings_set(
         ctx: Context,
         key: str,
@@ -73,33 +74,3 @@ def register_project_tools(mcp: FastMCP) -> None:
         runtime = DirectRuntime.from_context(ctx)
         return await project_handlers.project_settings_set(runtime, key=key, value=value)
 
-    @mcp.tool()
-    async def filesystem_search(
-        ctx: Context,
-        name: str = "",
-        type: str = "",
-        path: str = "",
-        offset: int = 0,
-        limit: int = 100,
-    ) -> dict:
-        """Search the Godot project filesystem via EditorFileSystem.
-
-        Finds files by name, resource type, or path pattern. At least one
-        filter must be provided. Results are paginated.
-
-        Args:
-            name: Filter by filename (case-insensitive substring match).
-            type: Filter by resource type (e.g. "PackedScene", "GDScript", "Texture2D").
-            path: Filter by path (case-insensitive substring match).
-            offset: Number of results to skip. Default 0.
-            limit: Maximum number of results to return. Default 100.
-        """
-        runtime = DirectRuntime.from_context(ctx)
-        return await project_handlers.filesystem_search(
-            runtime,
-            name=name,
-            type=type,
-            path=path,
-            offset=offset,
-            limit=limit,
-        )

--- a/src/godot_ai/tools/resource.py
+++ b/src/godot_ai/tools/resource.py
@@ -6,10 +6,11 @@ from fastmcp import Context, FastMCP
 
 from godot_ai.handlers import resource as resource_handlers
 from godot_ai.runtime.direct import DirectRuntime
+from godot_ai.tools import DEFER_META
 
 
 def register_resource_tools(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def resource_search(
         ctx: Context,
         type: str = "",
@@ -17,7 +18,7 @@ def register_resource_tools(mcp: FastMCP) -> None:
         offset: int = 0,
         limit: int = 100,
     ) -> dict:
-        """Search for resources in the Godot project by type or path.
+        """Search for resources (assets: meshes, textures, materials, scenes) by type or path.
 
         At least one filter must be provided. Results are paginated.
         Type matching includes subclasses (e.g. type="Texture2D" finds
@@ -38,9 +39,9 @@ def register_resource_tools(mcp: FastMCP) -> None:
             limit=limit,
         )
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def resource_load(ctx: Context, path: str) -> dict:
-        """Inspect a resource's properties.
+        """Inspect a resource's (asset's) properties — materials, meshes, textures, .tres files.
 
         Loads the resource at the given path and returns its type and
         all editor-visible properties with their current values.
@@ -51,14 +52,14 @@ def register_resource_tools(mcp: FastMCP) -> None:
         runtime = DirectRuntime.from_context(ctx)
         return await resource_handlers.resource_load(runtime, path=path)
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def resource_assign(
         ctx: Context,
         path: str,
         property: str,
         resource_path: str,
     ) -> dict:
-        """Assign a resource to a node property.
+        """Assign a resource (asset — mesh, texture, material, etc.) to a node property.
 
         Loads the resource at resource_path and sets it on the specified
         property of the node at path. This operation is undoable via

--- a/src/godot_ai/tools/scene.py
+++ b/src/godot_ai/tools/scene.py
@@ -6,6 +6,7 @@ from fastmcp import Context, FastMCP
 
 from godot_ai.handlers import scene as scene_handlers
 from godot_ai.runtime.direct import DirectRuntime
+from godot_ai.tools import DEFER_META
 
 
 def register_scene_tools(mcp: FastMCP) -> None:
@@ -16,7 +17,7 @@ def register_scene_tools(mcp: FastMCP) -> None:
         offset: int = 0,
         limit: int = 100,
     ) -> dict:
-        """Get the scene tree hierarchy from the currently open scene.
+        """Get the scene tree hierarchy (nodes / game objects) from the open scene (level / map).
 
         Returns a paginated flat list of nodes with name, type, path,
         and child count. Walks the tree up to the specified depth.
@@ -34,7 +35,7 @@ def register_scene_tools(mcp: FastMCP) -> None:
             limit=limit,
         )
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def scene_get_roots(ctx: Context) -> dict:
         """Get all scenes currently open in the Godot editor.
 
@@ -44,13 +45,13 @@ def register_scene_tools(mcp: FastMCP) -> None:
         runtime = DirectRuntime.from_context(ctx)
         return await scene_handlers.scene_get_roots(runtime)
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def scene_create(
         ctx: Context,
         path: str,
         root_type: str = "Node3D",
     ) -> dict:
-        """Create a new scene file and open it in the editor.
+        """Create a new scene file (level / map / prefab .tscn) and open it in the editor.
 
         Creates a scene with the specified root node type, saves it to
         disk, and opens it for editing.
@@ -62,9 +63,9 @@ def register_scene_tools(mcp: FastMCP) -> None:
         runtime = DirectRuntime.from_context(ctx)
         return await scene_handlers.scene_create(runtime, path=path, root_type=root_type)
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def scene_open(ctx: Context, path: str) -> dict:
-        """Open an existing scene file in the editor.
+        """Open (load) an existing scene file (level / .tscn) in the editor.
 
         Args:
             path: File path of the scene to open (e.g. "res://main.tscn").
@@ -72,13 +73,13 @@ def register_scene_tools(mcp: FastMCP) -> None:
         runtime = DirectRuntime.from_context(ctx)
         return await scene_handlers.scene_open(runtime, path=path)
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def scene_save(ctx: Context) -> dict:
         """Save the currently edited scene to disk."""
         runtime = DirectRuntime.from_context(ctx)
         return await scene_handlers.scene_save(runtime)
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def scene_save_as(ctx: Context, path: str) -> dict:
         """Save the currently edited scene to a new file path.
 

--- a/src/godot_ai/tools/script.py
+++ b/src/godot_ai/tools/script.py
@@ -6,16 +6,17 @@ from fastmcp import Context, FastMCP
 
 from godot_ai.handlers import script as script_handlers
 from godot_ai.runtime.direct import DirectRuntime
+from godot_ai.tools import DEFER_META
 
 
 def register_script_tools(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def script_create(
         ctx: Context,
         path: str,
         content: str = "",
     ) -> dict:
-        """Create a new GDScript file on disk.
+        """Create a new GDScript source file (.gd code file) on disk.
 
         Writes the given content to a .gd file in the Godot project.
         If the file already exists it will be overwritten. Triggers a
@@ -28,7 +29,7 @@ def register_script_tools(mcp: FastMCP) -> None:
         runtime = DirectRuntime.from_context(ctx)
         return await script_handlers.script_create(runtime, path=path, content=content)
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def script_read(ctx: Context, path: str) -> dict:
         """Read the contents of a GDScript file.
 
@@ -40,7 +41,7 @@ def register_script_tools(mcp: FastMCP) -> None:
         runtime = DirectRuntime.from_context(ctx)
         return await script_handlers.script_read(runtime, path=path)
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def script_attach(
         ctx: Context,
         path: str,
@@ -63,7 +64,7 @@ def register_script_tools(mcp: FastMCP) -> None:
             script_path=script_path,
         )
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def script_detach(ctx: Context, path: str) -> dict:
         """Remove the script from a node.
 
@@ -76,9 +77,9 @@ def register_script_tools(mcp: FastMCP) -> None:
         runtime = DirectRuntime.from_context(ctx)
         return await script_handlers.script_detach(runtime, path=path)
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def script_find_symbols(ctx: Context, path: str) -> dict:
-        """Inspect a GDScript file for functions, signals, and exports.
+        """Inspect (outline) a GDScript file — functions, methods, signals, class_name, exports.
 
         Parses the script and returns its class_name, extends base,
         function definitions, signal declarations, and @export variables.

--- a/src/godot_ai/tools/signal.py
+++ b/src/godot_ai/tools/signal.py
@@ -6,15 +6,17 @@ from fastmcp import Context, FastMCP
 
 from godot_ai.handlers import signal as signal_handlers
 from godot_ai.runtime.direct import DirectRuntime
+from godot_ai.tools import DEFER_META
 
 
 def register_signal_tools(mcp: FastMCP) -> None:
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def signal_list(ctx: Context, path: str) -> dict:
-        """List all signals on a node and their current connections.
+        """List all signals (events) on a node and their current connections.
 
-        Returns both built-in and custom signals, plus any active
-        signal connections.
+        Signals are Godot's event/observer mechanism — nodes emit signals
+        that other nodes subscribe to via `signal_connect`. Returns both
+        built-in and custom signals, plus any active connections.
 
         Args:
             path: Scene path of the node (e.g. "/Player").
@@ -22,7 +24,7 @@ def register_signal_tools(mcp: FastMCP) -> None:
         runtime = DirectRuntime.from_context(ctx)
         return await signal_handlers.signal_list(runtime, path=path)
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def signal_connect(
         ctx: Context,
         path: str,
@@ -30,9 +32,10 @@ def register_signal_tools(mcp: FastMCP) -> None:
         target: str,
         method: str,
     ) -> dict:
-        """Connect a signal from one node to a method on another node.
+        """Connect a signal from one node to a method on another (event subscription / callback).
 
-        Creates an undoable signal connection in the scene.
+        Creates an undoable signal connection in the scene. Equivalent
+        to Godot's `Node.connect()` and the editor's Node > Signals panel.
 
         Args:
             path: Scene path of the source node emitting the signal.
@@ -45,7 +48,7 @@ def register_signal_tools(mcp: FastMCP) -> None:
             runtime, path=path, signal=signal, target=target, method=method
         )
 
-    @mcp.tool()
+    @mcp.tool(meta=DEFER_META)
     async def signal_disconnect(
         ctx: Context,
         path: str,
@@ -53,7 +56,7 @@ def register_signal_tools(mcp: FastMCP) -> None:
         target: str,
         method: str,
     ) -> dict:
-        """Disconnect a signal connection between two nodes.
+        """Disconnect a signal connection between two nodes (unsubscribe an event listener).
 
         Removes an existing signal connection. Undoable.
 

--- a/src/godot_ai/tools/testing.py
+++ b/src/godot_ai/tools/testing.py
@@ -6,11 +6,12 @@ from fastmcp import Context, FastMCP
 
 from godot_ai.handlers import testing as testing_handlers
 from godot_ai.runtime.direct import DirectRuntime
+from godot_ai.tools import DEFER_META
 
 
 def register_testing_tools(mcp: FastMCP) -> None:
-    @mcp.tool()
-    async def run_tests(
+    @mcp.tool(meta=DEFER_META)
+    async def test_run(
         ctx: Context,
         suite: str = "",
         test_name: str = "",
@@ -34,19 +35,19 @@ def register_testing_tools(mcp: FastMCP) -> None:
                      false — only summary and failures are returned.
         """
         runtime = DirectRuntime.from_context(ctx)
-        return await testing_handlers.run_tests(
+        return await testing_handlers.test_run(
             runtime, suite=suite, test_name=test_name, verbose=verbose
         )
 
-    @mcp.tool()
-    async def get_test_results(ctx: Context, verbose: bool = False) -> dict:
+    @mcp.tool(meta=DEFER_META)
+    async def test_results_get(ctx: Context, verbose: bool = False) -> dict:
         """Get results from the most recent test run.
 
-        Returns the same structured results as run_tests, without
+        Returns the same structured results as test_run, without
         re-executing. Useful for reviewing results after a run.
 
         Args:
             verbose: If true, include every individual test result.
         """
         runtime = DirectRuntime.from_context(ctx)
-        return await testing_handlers.get_test_results(runtime, verbose=verbose)
+        return await testing_handlers.test_results_get(runtime, verbose=verbose)

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -824,7 +824,7 @@ class TestReloadPluginTool:
             return ws
 
         task = asyncio.create_task(simulate_reload())
-        result = await client.call_tool("reload_plugin", {})
+        result = await client.call_tool("editor_reload_plugin", {})
         new_ws = await task
 
         assert result.data["status"] == "reloaded"
@@ -909,7 +909,7 @@ class TestTestingTools:
             await plugin.send_response(cmd["request_id"], {"passed": 3, "failed": 0, "results": []})
 
         task = asyncio.create_task(respond())
-        result = await client.call_tool("run_tests", {})
+        result = await client.call_tool("test_run", {})
         await task
         assert result.data["passed"] == 3
 
@@ -923,7 +923,7 @@ class TestTestingTools:
             await plugin.send_response(cmd["request_id"], {"passed": 2, "failed": 0, "results": []})
 
         task = asyncio.create_task(respond())
-        result = await client.call_tool("run_tests", {"suite": "scene"})
+        result = await client.call_tool("test_run", {"suite": "scene"})
         await task
         assert result.data["passed"] == 2
 
@@ -936,7 +936,7 @@ class TestTestingTools:
             await plugin.send_response(cmd["request_id"], {"passed": 5, "failed": 1, "results": []})
 
         task = asyncio.create_task(respond())
-        result = await client.call_tool("get_test_results", {})
+        result = await client.call_tool("test_results_get", {})
         await task
         assert result.data["failed"] == 1
 
@@ -1398,7 +1398,7 @@ class TestImportReimportTool:
 
         task = asyncio.create_task(respond())
         result = await client.call_tool(
-            "import_reimport", {"paths": ["res://icon.png", "res://logo.png"]}
+            "filesystem_reimport", {"paths": ["res://icon.png", "res://logo.png"]}
         )
         await task
 
@@ -1980,7 +1980,7 @@ class TestProjectStopTool:
 
 
 # ---------------------------------------------------------------------------
-# performance_get_monitors
+# editor_screenshot
 # ---------------------------------------------------------------------------
 
 
@@ -2230,11 +2230,11 @@ class TestEditorScreenshotTool:
 
 
 # ---------------------------------------------------------------------------
-# performance_get_monitors
+# performance_monitors_get
 # ---------------------------------------------------------------------------
 
 
-class TestPerformanceGetMonitorsTool:
+class TestPerformanceMonitorsGetTool:
     async def test_get_all_monitors(self, mcp_stack):
         client, plugin = mcp_stack
 
@@ -2253,7 +2253,7 @@ class TestPerformanceGetMonitorsTool:
             )
 
         task = asyncio.create_task(respond())
-        result = await client.call_tool("performance_get_monitors", {})
+        result = await client.call_tool("performance_monitors_get", {})
         await task
 
         assert not result.is_error
@@ -2276,7 +2276,7 @@ class TestPerformanceGetMonitorsTool:
 
         task = asyncio.create_task(respond())
         result = await client.call_tool(
-            "performance_get_monitors",
+            "performance_monitors_get",
             {"monitors": ["time/fps"]},
         )
         await task

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -559,7 +559,7 @@ async def test_reload_plugin_returns_existing_replacement_session_without_wait_r
         client=ReloadStubClient(registry=registry, new_session_id="new-session"),
     )
 
-    result = await editor_handlers.reload_plugin(runtime)
+    result = await editor_handlers.editor_reload_plugin(runtime)
 
     assert result == {
         "status": "reloaded",
@@ -581,7 +581,7 @@ async def test_reload_plugin_handles_disconnect_before_ack_if_replacement_is_pre
         ),
     )
 
-    result = await editor_handlers.reload_plugin(runtime)
+    result = await editor_handlers.editor_reload_plugin(runtime)
 
     assert result["new_session_id"] == "new-after-timeout"
     assert runtime.active_session_id == "new-after-timeout"
@@ -590,7 +590,7 @@ async def test_reload_plugin_handles_disconnect_before_ack_if_replacement_is_pre
 async def test_reload_plugin_raises_when_no_active_session():
     runtime = DirectRuntime(registry=SessionRegistry(), client=StubClient())
     with pytest.raises(ConnectionError, match="No active Godot session"):
-        await editor_handlers.reload_plugin(runtime)
+        await editor_handlers.editor_reload_plugin(runtime)
 
 
 # ---------------------------------------------------------------------------
@@ -851,7 +851,7 @@ async def test_node_remove_from_group_handler():
 async def test_editor_selection_set_handler():
     client = StubClient()
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)
-    result = await node_handlers.editor_selection_set(
+    result = await editor_handlers.editor_selection_set(
         runtime,
         paths=["/Main/Camera3D", "/Main/World"],
     )
@@ -868,7 +868,7 @@ async def test_editor_selection_set_handler():
 async def test_run_tests_handler_with_no_params():
     client = StubClient()
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)
-    result = await testing_handlers.run_tests(runtime)
+    result = await testing_handlers.test_run(runtime)
     assert result["passed"] == 5
     assert client.calls[-1]["params"] == {}
 
@@ -876,14 +876,14 @@ async def test_run_tests_handler_with_no_params():
 async def test_run_tests_handler_with_suite_and_test_name():
     client = StubClient()
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)
-    await testing_handlers.run_tests(runtime, suite="scene", test_name="test_tree")
+    await testing_handlers.test_run(runtime, suite="scene", test_name="test_tree")
     assert client.calls[-1]["params"] == {"suite": "scene", "test_name": "test_tree"}
 
 
 async def test_get_test_results_handler():
     client = StubClient()
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)
-    result = await testing_handlers.get_test_results(runtime)
+    result = await testing_handlers.test_results_get(runtime)
     assert result["passed"] == 5
     assert client.calls[-1]["command"] == "get_test_results"
 
@@ -891,14 +891,14 @@ async def test_get_test_results_handler():
 async def test_run_tests_handler_verbose():
     client = StubClient()
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)
-    await testing_handlers.run_tests(runtime, verbose=True)
+    await testing_handlers.test_run(runtime, verbose=True)
     assert client.calls[-1]["params"] == {"verbose": True}
 
 
 async def test_get_test_results_handler_verbose():
     client = StubClient()
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)
-    await testing_handlers.get_test_results(runtime, verbose=True)
+    await testing_handlers.test_results_get(runtime, verbose=True)
     assert client.calls[-1]["params"] == {"verbose": True}
 
 
@@ -983,7 +983,7 @@ def test_project_info_resource_data_no_session():
 async def test_filesystem_search_handler():
     client = StubClient()
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)
-    result = await project_handlers.filesystem_search(
+    result = await filesystem_handlers.filesystem_search(
         runtime,
         name="file",
         type="GDScript",
@@ -1161,7 +1161,7 @@ async def test_filesystem_write_text_handler():
 async def test_import_reimport_handler():
     client = StubClient()
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)
-    result = await filesystem_handlers.import_reimport(
+    result = await filesystem_handlers.filesystem_reimport(
         runtime,
         paths=["res://icon.png", "res://logo.png"],
     )
@@ -1173,7 +1173,7 @@ async def test_import_reimport_handler():
 async def test_filesystem_search_handler_empty_params():
     client = StubClient()
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)
-    await project_handlers.filesystem_search(runtime)
+    await filesystem_handlers.filesystem_search(runtime)
     assert client.calls[-1]["params"] == {}
 
 
@@ -1603,7 +1603,7 @@ async def test_editor_screenshot_handler_fov_passes_param():
 async def test_performance_get_monitors_handler_all():
     client = StubClient()
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)
-    result = await editor_handlers.performance_get_monitors(runtime)
+    result = await editor_handlers.performance_monitors_get(runtime)
     assert result["monitor_count"] == 3
     assert result["monitors"]["time/fps"] == 60.0
     assert client.calls[-1]["command"] == "get_performance_monitors"
@@ -1613,7 +1613,7 @@ async def test_performance_get_monitors_handler_all():
 async def test_performance_get_monitors_handler_filtered():
     client = StubClient()
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)
-    await editor_handlers.performance_get_monitors(runtime, monitors=["time/fps"])
+    await editor_handlers.performance_monitors_get(runtime, monitors=["time/fps"])
     assert client.calls[-1]["params"] == {"monitors": ["time/fps"]}
 
 


### PR DESCRIPTION
## Summary

- Renames 5 tools to consistent `domain_action` namespacing and moves 2 tools (`editor_selection_set`, `filesystem_search`) to their correct domain files
- Enriches tool descriptions with natural-language keywords (screenshot, keybinding, asset, event / callback, etc.) to improve BM25 tool-search ranking
- Tags 55 non-core tools with `meta={"defer_loading": True}` via a shared `DEFER_META` constant. Core tools stay loaded: `editor_state`, `scene_get_hierarchy`, `node_get_properties`, `session_list`, `session_activate`
- Adds a tool-categories blurb to `server.py` `instructions=` so tool-search clients have a discovery map of every namespace

## Renames

| Before | After |
|---|---|
| `run_tests` | `test_run` |
| `get_test_results` | `test_results_get` |
| `reload_plugin` | `editor_reload_plugin` |
| `import_reimport` | `filesystem_reimport` |
| `performance_get_monitors` | `performance_monitors_get` |

Plugin-side WebSocket command names unchanged; only the MCP tool names were renamed.

## Test plan

- [x] `ruff check src/ tests/` clean
- [x] `pytest -v` — 277/277 Python tests pass
- [x] `test_run` via MCP — 191/191 GDScript tests pass (all 11 suites)
- [x] Live smoke: `editor_state`, `performance_monitors_get`, `filesystem_search`, `filesystem_reimport`, `editor_selection_set`, `test_run`
- [x] Verified deferred-loading works in Claude Code via `/context` (60 tools Available, only called ones Loaded)
- [x] Natural-language tool-pick probe: "run the gdscript tests" → resolves to `test_run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)