### PR TITLE
Add per-call session routing and readable session IDs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,8 @@ AI Client → MCP (stdio/sse/streamable-http) → Python FastMCP server → WebS
 - **Scene paths are clean**: `/Main/Camera3D` format, not raw Godot internal paths. Use `ScenePath.from_node(node, scene_root)` in GDScript.
 - **MCP logging**: Plugin prints `MCP | [recv] command(params)` / `MCP | [send] command -> ok` to Godot console. Controlled by `mcp_logging` var.
 - **Tool-search-friendly naming**: All MCP tools use `domain_action` namespacing (`scene_*`, `node_*`, `script_*`, etc.). Non-core tools are tagged `meta={"defer_loading": True}` for Anthropic tool-search compatibility; core tools (`editor_state`, `scene_get_hierarchy`, `node_get_properties`, `session_list`, `session_activate`) stay non-deferred. Plugin command names (sent over WebSocket) are independent — the MCP tool `editor_reload_plugin` dispatches the plugin command `reload_plugin`.
+- **Session IDs**: format is `<project-slug>@<4hex>` (e.g. `godot-ai@a3f2`). The slug is derived from the project directory name so agents can recognize which editor they're targeting; the hex suffix disambiguates same-project twins. Server treats the ID as an opaque key.
+- **Per-call session routing**: every Godot-talking tool accepts an optional `session_id` parameter. Empty (the default) resolves to the global active session. When supplied, that single call targets that session — `require_writable` and every handler inside the call see the pinned session, not the active one. Use this when multiple AI clients share one MCP server. Resources (`godot://...`) still resolve via the active session.
 
 ## Dev workflow
 
@@ -62,7 +64,7 @@ The Godot dock also has a **Start/Stop Dev Server** button for convenience.
 
 ### Python tests
 ```bash
-pytest -v                    # 277 unit + integration tests
+pytest -v                    # 310 unit + integration tests
 ```
 
 ### Godot-side tests
@@ -113,7 +115,7 @@ MCP tools `client_configure` and `client_status` expose this to AI clients.
 1. Add a handler method in the appropriate GDScript `handlers/*.gd` file
 2. Register it in `plugin.gd`: `_dispatcher.register("command_name", handler.method)`
 3. Add a shared Python handler in `handlers/<domain>.py` that calls `runtime.send_command("command_name", params)`
-4. Add a Python tool in `tools/<domain>.py` — name it `domain_action` (e.g. `scene_open`, `node_create`), decorate with `@mcp.tool(meta=DEFER_META)` from `godot_ai.tools`. Only omit `meta` for the ~5 always-loaded core tools (`editor_state`, `scene_get_hierarchy`, `node_get_properties`, `session_list`, `session_activate`)
+4. Add a Python tool in `tools/<domain>.py` — name it `domain_action` (e.g. `scene_open`, `node_create`), decorate with `@mcp.tool(meta=DEFER_META)` from `godot_ai.tools`. Only omit `meta` for the ~5 always-loaded core tools (`editor_state`, `scene_get_hierarchy`, `node_get_properties`, `session_list`, `session_activate`). Add `session_id: str = ""` as the last parameter and pass it in: `DirectRuntime.from_context(ctx, session_id=session_id or None)` — this lets callers pin the tool to a specific editor when multiple are connected.
 5. Register the tool module in `server.py` if it's a new file. If it introduces a new namespace, add it to the tool-categories blurb in `server.py` `instructions=`
 6. For write tools: add `require_writable(runtime)` call at the top of the Python handler
 7. Write a description with natural-language keywords a user would search for (e.g. `screenshot`, `keybinding`, `asset`) alongside the Godot term

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -1,6 +1,6 @@
 # Godot AI — Working Plan
 
-*Updated 2026-04-14*
+*Updated 2026-04-15*
 
 This is the current working plan for Godot AI. It focuses on active and upcoming work only.
 
@@ -65,9 +65,11 @@ Historical bootstrap material, architecture detail, packaging mechanics, go/no-g
 
 ### Multi-Session Reliability
 
-- [ ] reliable multi-instance routing
-- [ ] clear session selection semantics in tools and UI
-- [ ] enough session metadata to distinguish multiple editors safely
+- [x] reliable multi-instance routing — fixed `SessionRegistry.unregister` silently promoting the first-registered session; reload handler now pins `session_id` explicitly
+- [x] clear session selection semantics in tools and UI — `session_activate` accepts substring hints (project folder name / path / session_id) in addition to exact UUID, with ambiguous-match and no-match paths that list candidates
+- [x] enough session metadata to distinguish multiple editors safely — added `name` (project basename), `editor_pid`, and `last_seen` heartbeat to every session; surfaced in `session_list`
+- [x] per-call session targeting — every Godot-talking tool accepts an optional `session_id`; bound at the `DirectRuntime` layer so `require_writable` and handlers see the pinned session. Lets two AI clients share one server without stomping each other's active.
+- [x] human-readable session IDs — `<project-slug>@<4hex>` (e.g. `godot-ai@a3f2`) instead of 32-char random hex. Agents can recognize/remember the target without calling `session_list` first.
 
 **Why this matters:** Real use will quickly involve multiple projects, multiple editor windows, or multiple test sessions. The session model needs to stop being “good enough for one editor.”
 
@@ -76,9 +78,9 @@ Historical bootstrap material, architecture detail, packaging mechanics, go/no-g
 - [x] `signal.*`, `autoload.*`, `input_map.*`, `project_settings.set`
 - [x] run/stop cycle is reliable
 - [x] batch execution is shipped with a clear contract
-- [ ] multi-instance routing works in practice
+- [x] multi-instance routing works in practice
 - [x] `script.patch` decision is made (shipped: anchor-based replace)
-- [x] test coverage and smoke coverage increase where the new runtime loop needs it (282 Python + 216 GDScript = 498 total)
+- [x] test coverage and smoke coverage increase where the new runtime loop needs it (310 Python + 227 GDScript = 537 total)
 
 ---
 
@@ -137,6 +139,7 @@ These are not the next things to do blindly. They are the extensions that matter
 - `build.*`
 - richer performance diagnostics
 - more capture and regression-verification helpers where they materially help iteration
+- `editor_viewport_*` — toggle per-viewport display options that live outside the scene (e.g. View Environment / View Gizmos, Preview Sun, Preview Environment, grid visibility, orthogonal vs. perspective). Useful when the AI needs the editor grid visible, or wants to disable the default sky to judge lighting. These are editor-only state, not scene state, so they require a dedicated surface rather than `node_set_property`.
 
 **The rule here is simple:** Do not add broad polish tooling before the AI can already launch the game, inspect results, and make safe iterative edits.
 

--- a/plugin/addons/godot_ai/connection.gd
+++ b/plugin/addons/godot_ai/connection.gd
@@ -24,7 +24,7 @@ var pause_processing := false
 
 
 func _ready() -> void:
-	_session_id = _generate_session_id()
+	_session_id = _make_session_id(ProjectSettings.globalize_path("res://"))
 	## Increase outbound buffer for large messages (e.g. screenshot base64).
 	## Default is 64 KB; screenshots can be several MB.
 	_peer.outbound_buffer_size = 4 * 1024 * 1024  # 4 MB
@@ -107,6 +107,7 @@ func _send_handshake() -> void:
 		"plugin_version": "0.0.1",
 		"protocol_version": 1,
 		"readiness": _last_readiness,
+		"editor_pid": OS.get_process_id(),
 	})
 
 
@@ -184,8 +185,35 @@ func _send_json(data: Dictionary) -> void:
 		_peer.send_text(JSON.stringify(data))
 
 
-func _generate_session_id() -> String:
+## Build a human-readable session ID of form "<slug>@<4hex>" from the project path.
+## The slug is derived from the project directory name so agents can recognize
+## which editor they're targeting; the hex suffix disambiguates same-project twins.
+static func _make_session_id(project_path: String) -> String:
+	var base := project_path.rstrip("/\\").get_file()
+	if base == "":
+		base = "project"
+	var slug := _slugify(base)
+	if slug == "":
+		slug = "project"
+	var suffix := _rand_hex(4)
+	return "%s@%s" % [slug, suffix]
+
+
+static func _slugify(s: String) -> String:
+	var out := ""
+	var prev_dash := false
+	for c in s.to_lower():
+		if (c >= "a" and c <= "z") or (c >= "0" and c <= "9"):
+			out += c
+			prev_dash = false
+		elif not prev_dash and out != "":
+			out += "-"
+			prev_dash = true
+	return out.trim_suffix("-")
+
+
+static func _rand_hex(n: int) -> String:
 	var bytes := PackedByteArray()
-	for i in 16:
+	for i in (n + 1) / 2:
 		bytes.append(randi() % 256)
-	return bytes.hex_encode()
+	return bytes.hex_encode().substr(0, n)

--- a/plugin/addons/godot_ai/connection.gd
+++ b/plugin/addons/godot_ai/connection.gd
@@ -214,6 +214,7 @@ static func _slugify(s: String) -> String:
 
 static func _rand_hex(n: int) -> String:
 	var bytes := PackedByteArray()
-	for i in (n + 1) / 2:
+	var byte_count := int(ceil(float(n) / 2.0))
+	for i in byte_count:
 		bytes.append(randi() % 256)
 	return bytes.hex_encode().substr(0, n)

--- a/src/godot_ai/godot_client/client.py
+++ b/src/godot_ai/godot_client/client.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from godot_ai.protocol.errors import ErrorCode
 from godot_ai.sessions.registry import SessionRegistry
 from godot_ai.transport.websocket import GodotWebSocketServer
+
+logger = logging.getLogger(__name__)
 
 
 class GodotCommandError(Exception):
@@ -42,6 +45,13 @@ class GodotClient:
             if session is None:
                 raise ConnectionError("No active Godot session")
             session_id = session.session_id
+            if len(self.registry) > 1:
+                logger.debug(
+                    "Routing %s to active session %s (%d sessions connected)",
+                    command,
+                    session_id[:8],
+                    len(self.registry),
+                )
 
         if self.registry.get(session_id) is None:
             raise ConnectionError(

--- a/src/godot_ai/handlers/editor.py
+++ b/src/godot_ai/handlers/editor.py
@@ -165,7 +165,9 @@ async def editor_reload_plugin(runtime: Runtime) -> dict:
     known_ids = {session.session_id for session in runtime.list_sessions()}
 
     try:
-        await runtime.send_command("reload_plugin", timeout=2.0)
+        ## Pin to old_id explicitly so the reload command can't race
+        ## active-session changes (e.g. another editor disconnecting mid-call).
+        await runtime.send_command("reload_plugin", session_id=old_id, timeout=2.0)
     except (ConnectionError, TimeoutError) as exc:
         logger.debug("Expected disconnect during reload: %s", exc)
 

--- a/src/godot_ai/handlers/session.py
+++ b/src/godot_ai/handlers/session.py
@@ -15,11 +15,75 @@ def session_list(runtime: Runtime) -> dict:
 
 
 def session_activate(runtime: Runtime, session_id: str) -> dict:
-    try:
-        runtime.set_active_session(session_id)
-        return {"status": "ok", "active_session_id": session_id}
-    except KeyError:
-        return {"status": "error", "message": f"Session {session_id} not found"}
+    """Activate a session by exact id or a substring hint.
+
+    The `session_id` argument accepts three forms, in priority order:
+    1. An exact session_id — always wins if it matches.
+    2. A substring of the session's short name (project basename),
+       project_path, or session_id. Must match exactly one session.
+
+    This lets callers activate by a human-friendly fragment like a project
+    folder name instead of copying opaque UUIDs from session_list.
+    """
+    sessions = list(runtime.list_sessions())
+
+    ## Priority 1: exact session_id match.
+    for session in sessions:
+        if session.session_id == session_id:
+            runtime.set_active_session(session.session_id)
+            return {
+                "status": "ok",
+                "active_session_id": session.session_id,
+                "matched": "exact_id",
+            }
+
+    ## Priority 2: substring match on name / project_path / session_id.
+    if session_id:
+        lowered = session_id.lower()
+        matches = [
+            session
+            for session in sessions
+            if lowered in session.name.lower()
+            or lowered in session.project_path.lower()
+            or lowered in session.session_id.lower()
+        ]
+        if len(matches) == 1:
+            runtime.set_active_session(matches[0].session_id)
+            return {
+                "status": "ok",
+                "active_session_id": matches[0].session_id,
+                "matched": "hint",
+                "matched_name": matches[0].name,
+            }
+        if len(matches) > 1:
+            return {
+                "status": "error",
+                "message": (
+                    f"Hint '{session_id}' matched {len(matches)} sessions; "
+                    "provide a more specific substring or an exact session_id"
+                ),
+                "candidates": [
+                    {
+                        "session_id": match.session_id,
+                        "name": match.name,
+                        "project_path": match.project_path,
+                    }
+                    for match in matches
+                ],
+            }
+
+    return {
+        "status": "error",
+        "message": f"No session matches '{session_id}'",
+        "available": [
+            {
+                "session_id": session.session_id,
+                "name": session.name,
+                "project_path": session.project_path,
+            }
+            for session in sessions
+        ],
+    }
 
 
 def session_resource_data(runtime: Runtime) -> dict:

--- a/src/godot_ai/protocol/envelope.py
+++ b/src/godot_ai/protocol/envelope.py
@@ -42,3 +42,5 @@ class HandshakeMessage(BaseModel):
     plugin_version: str
     protocol_version: int = 1
     readiness: str = "ready"
+    ## Optional because older plugins won't send it; server falls back to 0.
+    editor_pid: int = 0

--- a/src/godot_ai/runtime/direct.py
+++ b/src/godot_ai/runtime/direct.py
@@ -18,20 +18,28 @@ class SupportsDirectRuntime(Protocol):
 class DirectRuntime:
     """In-process runtime used by the current single-process server."""
 
-    def __init__(self, registry: SessionRegistry, client: GodotClient):
+    def __init__(
+        self,
+        registry: SessionRegistry,
+        client: GodotClient,
+        session_id: str | None = None,
+    ):
         self._registry = registry
         self._client = client
+        self._bound_session_id = session_id
 
     @classmethod
-    def from_context(cls, ctx: Context) -> DirectRuntime:
+    def from_context(cls, ctx: Context, session_id: str | None = None) -> DirectRuntime:
         app = ctx.fastmcp._lifespan_result
         if app is None:
             raise RuntimeError("FastMCP lifespan context is not available")
-        return cls.from_app_context(app)
+        return cls.from_app_context(app, session_id=session_id)
 
     @classmethod
-    def from_app_context(cls, app: SupportsDirectRuntime) -> DirectRuntime:
-        return cls(registry=app.registry, client=app.client)
+    def from_app_context(
+        cls, app: SupportsDirectRuntime, session_id: str | None = None
+    ) -> DirectRuntime:
+        return cls(registry=app.registry, client=app.client, session_id=session_id)
 
     async def send_command(
         self,
@@ -43,7 +51,7 @@ class DirectRuntime:
         return await self._client.send(
             command=command,
             params=params,
-            session_id=session_id,
+            session_id=session_id if session_id is not None else self._bound_session_id,
             timeout=timeout,
         )
 
@@ -51,11 +59,13 @@ class DirectRuntime:
         return self._registry.list_all()
 
     def get_active_session(self) -> Session | None:
+        if self._bound_session_id is not None:
+            return self._registry.get(self._bound_session_id)
         return self._registry.get_active()
 
     @property
     def active_session_id(self) -> str | None:
-        return self._registry.active_session_id
+        return self._bound_session_id or self._registry.active_session_id
 
     def set_active_session(self, session_id: str) -> None:
         self._registry.set_active(session_id)

--- a/src/godot_ai/sessions/registry.py
+++ b/src/godot_ai/sessions/registry.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from functools import cached_property
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +27,7 @@ class Session:
     connected_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     last_seen: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
-    @property
+    @cached_property
     def name(self) -> str:
         """Short human-readable name derived from project_path.
 
@@ -36,7 +37,6 @@ class Session:
         path = self.project_path.rstrip("/\\")
         if not path:
             return self.session_id[:8]
-        ## os.path.basename equivalent without importing os just for this
         for sep in ("/", "\\"):
             if sep in path:
                 return path.rsplit(sep, 1)[-1]

--- a/src/godot_ai/sessions/registry.py
+++ b/src/godot_ai/sessions/registry.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -19,11 +22,34 @@ class Session:
     current_scene: str = ""
     play_state: str = "stopped"
     readiness: str = "ready"
+    editor_pid: int = 0
     connected_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    last_seen: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    @property
+    def name(self) -> str:
+        """Short human-readable name derived from project_path.
+
+        E.g. '/Users/x/Documents/godot-ai/test_project/' -> 'test_project'.
+        Falls back to the first 8 chars of session_id if the path is empty.
+        """
+        path = self.project_path.rstrip("/\\")
+        if not path:
+            return self.session_id[:8]
+        ## os.path.basename equivalent without importing os just for this
+        for sep in ("/", "\\"):
+            if sep in path:
+                return path.rsplit(sep, 1)[-1]
+        return path
+
+    def touch(self) -> None:
+        """Update last_seen to now. Called on every inbound message."""
+        self.last_seen = datetime.now(timezone.utc)
 
     def to_dict(self) -> dict:
         return {
             "session_id": self.session_id,
+            "name": self.name,
             "godot_version": self.godot_version,
             "project_path": self.project_path,
             "plugin_version": self.plugin_version,
@@ -31,7 +57,9 @@ class Session:
             "current_scene": self.current_scene,
             "play_state": self.play_state,
             "readiness": self.readiness,
+            "editor_pid": self.editor_pid,
             "connected_at": self.connected_at.isoformat(),
+            "last_seen": self.last_seen.isoformat(),
         }
 
 
@@ -59,9 +87,19 @@ class SessionRegistry:
         self._session_waiters = remaining
 
     def unregister(self, session_id: str) -> None:
+        ## Do NOT silently promote another session to active when the active
+        ## one disconnects. Promoting by insertion order means a crash or
+        ## editor_quit on the user's working editor would route subsequent
+        ## commands to whichever editor happened to connect first — the
+        ## "routing by registration order" bug. Clear active instead; the
+        ## next register() or an explicit session_activate will set it.
         self._sessions.pop(session_id, None)
         if self._active_session_id == session_id:
-            self._active_session_id = next(iter(self._sessions), None)
+            self._active_session_id = None
+            logger.info(
+                "Active session %s disconnected; no active session until next register/activate",
+                session_id[:8],
+            )
 
     def get(self, session_id: str) -> Session | None:
         return self._sessions.get(session_id)

--- a/src/godot_ai/tools/__init__.py
+++ b/src/godot_ai/tools/__init__.py
@@ -3,6 +3,32 @@
 `DEFER_META` marks a tool as deferred-loading for clients using Anthropic
 tool search. Core tools (always loaded: editor_state, scene_get_hierarchy,
 node_get_properties, session_list, session_activate) omit it.
+
+`JsonCoerced` is a pydantic `BeforeValidator` that JSON-decodes string
+inputs before list/dict validation runs. Some MCP clients (Claude Code
+as of 2026-04) stringify complex-typed tool arguments before sending
+them over the wire, so a `list[dict]` parameter arrives as its JSON
+representation. Annotating such params with this validator lets the
+tool accept both the real structure and the stringified form. See #11.
 """
 
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from pydantic import BeforeValidator
+
 DEFER_META: dict[str, object] = {"defer_loading": True}
+
+
+def _coerce_json(value: Any) -> Any:
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return value
+    return value
+
+
+JsonCoerced = BeforeValidator(_coerce_json)

--- a/src/godot_ai/tools/autoload.py
+++ b/src/godot_ai/tools/autoload.py
@@ -11,13 +11,16 @@ from godot_ai.tools import DEFER_META
 
 def register_autoload_tools(mcp: FastMCP) -> None:
     @mcp.tool(meta=DEFER_META)
-    async def autoload_list(ctx: Context) -> dict:
+    async def autoload_list(ctx: Context, session_id: str = "") -> dict:
         """List all registered autoload singletons (global scripts / scenes accessible by name).
 
         Returns each autoload's name, script/scene path, and whether
         it's a singleton (accessible via name globally).
+
+        Args:
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await autoload_handlers.autoload_list(runtime)
 
     @mcp.tool(meta=DEFER_META)
@@ -26,6 +29,7 @@ def register_autoload_tools(mcp: FastMCP) -> None:
         name: str,
         path: str,
         singleton: bool = True,
+        session_id: str = "",
     ) -> dict:
         """Add a new autoload singleton to the project.
 
@@ -36,14 +40,15 @@ def register_autoload_tools(mcp: FastMCP) -> None:
             name: Name for the autoload (e.g. "GameManager", "AudioBus").
             path: Resource path to the script or scene (e.g. "res://autoloads/game_manager.gd").
             singleton: If true, accessible globally by name. Default true.
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await autoload_handlers.autoload_add(
             runtime, name=name, path=path, singleton=singleton
         )
 
     @mcp.tool(meta=DEFER_META)
-    async def autoload_remove(ctx: Context, name: str) -> dict:
+    async def autoload_remove(ctx: Context, name: str, session_id: str = "") -> dict:
         """Remove an autoload singleton from the project.
 
         Removes the autoload registration from project.godot.
@@ -51,6 +56,7 @@ def register_autoload_tools(mcp: FastMCP) -> None:
 
         Args:
             name: Name of the autoload to remove.
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await autoload_handlers.autoload_remove(runtime, name=name)

--- a/src/godot_ai/tools/batch.py
+++ b/src/godot_ai/tools/batch.py
@@ -2,18 +2,20 @@
 
 from __future__ import annotations
 
+from typing import Annotated
+
 from fastmcp import Context, FastMCP
 
 from godot_ai.handlers import batch as batch_handlers
 from godot_ai.runtime.direct import DirectRuntime
-from godot_ai.tools import DEFER_META
+from godot_ai.tools import DEFER_META, JsonCoerced
 
 
 def register_batch_tools(mcp: FastMCP) -> None:
     @mcp.tool(meta=DEFER_META)
     async def batch_execute(
         ctx: Context,
-        commands: list[dict],
+        commands: Annotated[list[dict], JsonCoerced],
         undo: bool = True,
         session_id: str = "",
     ) -> dict:

--- a/src/godot_ai/tools/batch.py
+++ b/src/godot_ai/tools/batch.py
@@ -15,6 +15,7 @@ def register_batch_tools(mcp: FastMCP) -> None:
         ctx: Context,
         commands: list[dict],
         undo: bool = True,
+        session_id: str = "",
     ) -> dict:
         """Execute a list of editor sub-commands in order, stopping on first error.
 
@@ -43,13 +44,14 @@ def register_batch_tools(mcp: FastMCP) -> None:
         Args:
             commands: List of `{"command": str, "params": dict}` items.
             undo: Roll back succeeded sub-commands on failure. Default True.
+            session_id: Optional Godot session to target. Empty = active session.
 
         Returns a dict with `succeeded` (count), `stopped_at` (failing index
         or null), `results` (per-sub-command status/data/error), `rolled_back`
         (whether rollback was performed), and `undoable` (whether the batch
         can be undone as a whole).
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await batch_handlers.batch_execute(
             runtime,
             commands=commands,

--- a/src/godot_ai/tools/editor.py
+++ b/src/godot_ai/tools/editor.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from typing import Annotated
+
 from fastmcp import Context, FastMCP
 
 from godot_ai.handlers import editor as editor_handlers
 from godot_ai.runtime.direct import DirectRuntime
-from godot_ai.tools import DEFER_META
+from godot_ai.tools import DEFER_META, JsonCoerced
 
 
 def register_editor_tools(mcp: FastMCP) -> None:
@@ -136,7 +138,7 @@ def register_editor_tools(mcp: FastMCP) -> None:
     @mcp.tool(meta=DEFER_META)
     async def performance_monitors_get(
         ctx: Context,
-        monitors: list[str] | None = None,
+        monitors: Annotated[list[str] | None, JsonCoerced] = None,
         session_id: str = "",
     ) -> dict:
         """Get Godot performance monitor values (FPS, memory, draw calls, frame time).
@@ -209,7 +211,7 @@ def register_editor_tools(mcp: FastMCP) -> None:
     @mcp.tool(meta=DEFER_META)
     async def editor_selection_set(
         ctx: Context,
-        paths: list[str],
+        paths: Annotated[list[str], JsonCoerced],
         session_id: str = "",
     ) -> dict:
         """Select nodes in the Godot editor by their scene paths.

--- a/src/godot_ai/tools/editor.py
+++ b/src/godot_ai/tools/editor.py
@@ -11,22 +11,28 @@ from godot_ai.tools import DEFER_META
 
 def register_editor_tools(mcp: FastMCP) -> None:
     @mcp.tool()
-    async def editor_state(ctx: Context) -> dict:
+    async def editor_state(ctx: Context, session_id: str = "") -> dict:
         """Get current Godot editor (IDE) state: version, readiness, open scene.
 
         Returns Godot version, project name, current scene path,
         and whether the project is currently playing.
+
+        Args:
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await editor_handlers.editor_state(runtime)
 
     @mcp.tool(meta=DEFER_META)
-    async def editor_selection_get(ctx: Context) -> dict:
+    async def editor_selection_get(ctx: Context, session_id: str = "") -> dict:
         """Get the currently selected nodes in the Godot editor.
 
         Returns a list of selected node paths.
+
+        Args:
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await editor_handlers.editor_selection_get(runtime)
 
     @mcp.tool(meta=DEFER_META)
@@ -34,6 +40,7 @@ def register_editor_tools(mcp: FastMCP) -> None:
         ctx: Context,
         count: int = 50,
         offset: int = 0,
+        session_id: str = "",
     ) -> dict:
         """Read recent log lines from the Godot editor console.
 
@@ -44,8 +51,9 @@ def register_editor_tools(mcp: FastMCP) -> None:
         Args:
             count: Maximum number of lines to return. Default 50.
             offset: Number of lines to skip from the start. Default 0.
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await editor_handlers.logs_read(runtime, count=count, offset=offset)
 
     @mcp.tool(output_schema=None, meta=DEFER_META)
@@ -59,6 +67,7 @@ def register_editor_tools(mcp: FastMCP) -> None:
         elevation: float | None = None,
         azimuth: float | None = None,
         fov: float | None = None,
+        session_id: str = "",
     ):
         """Capture a screenshot / image / picture of the Godot editor viewport or running game view.
 
@@ -109,8 +118,9 @@ def register_editor_tools(mcp: FastMCP) -> None:
             fov: Camera field of view in degrees. Lower values (25-35) zoom in like a telephoto
                 for detail shots. Higher values (60-75) zoom out for context/establishing shots.
                 Only applies when view_target is set. Default uses editor's current FOV.
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await editor_handlers.editor_screenshot(
             runtime,
             source=source,
@@ -127,6 +137,7 @@ def register_editor_tools(mcp: FastMCP) -> None:
     async def performance_monitors_get(
         ctx: Context,
         monitors: list[str] | None = None,
+        session_id: str = "",
     ) -> dict:
         """Get Godot performance monitor values (FPS, memory, draw calls, frame time).
 
@@ -146,32 +157,39 @@ def register_editor_tools(mcp: FastMCP) -> None:
 
         Args:
             monitors: Optional list of monitor names to return. If omitted, returns all.
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await editor_handlers.performance_monitors_get(runtime, monitors=monitors)
 
     @mcp.tool(meta=DEFER_META)
-    async def logs_clear(ctx: Context) -> dict:
+    async def logs_clear(ctx: Context, session_id: str = "") -> dict:
         """Clear the MCP log buffer in the Godot editor.
 
         Removes all captured log lines. Returns the number of lines cleared.
+
+        Args:
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await editor_handlers.logs_clear(runtime)
 
     @mcp.tool(meta=DEFER_META)
-    async def editor_quit(ctx: Context) -> dict:
+    async def editor_quit(ctx: Context, session_id: str = "") -> dict:
         """Gracefully quit (close / shutdown) the Godot editor (IDE).
 
         Sends a quit signal to the editor on the next frame, allowing
         any pending responses to be sent first. The editor will close
         cleanly without triggering crash dialogs.
+
+        Args:
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await editor_handlers.editor_quit(runtime)
 
     @mcp.tool(meta=DEFER_META)
-    async def editor_reload_plugin(ctx: Context) -> dict:
+    async def editor_reload_plugin(ctx: Context, session_id: str = "") -> dict:
         """Reload the Godot editor plugin and wait for it to reconnect.
 
         Sends a reload command to the plugin, which disables and re-enables
@@ -181,14 +199,18 @@ def register_editor_tools(mcp: FastMCP) -> None:
         Requires the MCP server to be running externally (not started by
         the plugin), otherwise the reload will kill the server process.
         Start with: python -m godot_ai --transport streamable-http --port 8000 --reload
+
+        Args:
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await editor_handlers.editor_reload_plugin(runtime)
 
     @mcp.tool(meta=DEFER_META)
     async def editor_selection_set(
         ctx: Context,
         paths: list[str],
+        session_id: str = "",
     ) -> dict:
         """Select nodes in the Godot editor by their scene paths.
 
@@ -198,6 +220,7 @@ def register_editor_tools(mcp: FastMCP) -> None:
 
         Args:
             paths: List of scene paths to select (e.g. ["/Main/Camera3D", "/Main/Player"]).
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await editor_handlers.editor_selection_set(runtime, paths=paths)

--- a/src/godot_ai/tools/filesystem.py
+++ b/src/godot_ai/tools/filesystem.py
@@ -11,7 +11,7 @@ from godot_ai.tools import DEFER_META
 
 def register_filesystem_tools(mcp: FastMCP) -> None:
     @mcp.tool(meta=DEFER_META)
-    async def filesystem_read_text(ctx: Context, path: str) -> dict:
+    async def filesystem_read_text(ctx: Context, path: str, session_id: str = "") -> dict:
         """Read a text file from the Godot project.
 
         Returns the full file content, size, and line count.
@@ -19,8 +19,9 @@ def register_filesystem_tools(mcp: FastMCP) -> None:
 
         Args:
             path: File path starting with res:// (e.g. "res://project.godot").
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await filesystem_handlers.filesystem_read_text(runtime, path=path)
 
     @mcp.tool(meta=DEFER_META)
@@ -28,6 +29,7 @@ def register_filesystem_tools(mcp: FastMCP) -> None:
         ctx: Context,
         path: str,
         content: str = "",
+        session_id: str = "",
     ) -> dict:
         """Write a text file to the Godot project.
 
@@ -38,8 +40,9 @@ def register_filesystem_tools(mcp: FastMCP) -> None:
         Args:
             path: File path starting with res:// (e.g. "res://data/config.json").
             content: Text content to write. Empty creates a blank file.
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await filesystem_handlers.filesystem_write_text(
             runtime,
             path=path,
@@ -47,7 +50,11 @@ def register_filesystem_tools(mcp: FastMCP) -> None:
         )
 
     @mcp.tool(meta=DEFER_META)
-    async def filesystem_reimport(ctx: Context, paths: list[str]) -> dict:
+    async def filesystem_reimport(
+        ctx: Context,
+        paths: list[str],
+        session_id: str = "",
+    ) -> dict:
         """Force reimport of specific files / assets in the Godot project.
 
         Triggers EditorFileSystem.update_file() for each path, which
@@ -56,8 +63,9 @@ def register_filesystem_tools(mcp: FastMCP) -> None:
 
         Args:
             paths: List of file paths to reimport (e.g. ["res://textures/icon.png"]).
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await filesystem_handlers.filesystem_reimport(runtime, paths=paths)
 
     @mcp.tool(meta=DEFER_META)
@@ -68,6 +76,7 @@ def register_filesystem_tools(mcp: FastMCP) -> None:
         path: str = "",
         offset: int = 0,
         limit: int = 100,
+        session_id: str = "",
     ) -> dict:
         """Search the Godot project filesystem via EditorFileSystem.
 
@@ -80,8 +89,9 @@ def register_filesystem_tools(mcp: FastMCP) -> None:
             path: Filter by path (case-insensitive substring match).
             offset: Number of results to skip. Default 0.
             limit: Maximum number of results to return. Default 100.
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await filesystem_handlers.filesystem_search(
             runtime,
             name=name,

--- a/src/godot_ai/tools/filesystem.py
+++ b/src/godot_ai/tools/filesystem.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from typing import Annotated
+
 from fastmcp import Context, FastMCP
 
 from godot_ai.handlers import filesystem as filesystem_handlers
 from godot_ai.runtime.direct import DirectRuntime
-from godot_ai.tools import DEFER_META
+from godot_ai.tools import DEFER_META, JsonCoerced
 
 
 def register_filesystem_tools(mcp: FastMCP) -> None:
@@ -52,7 +54,7 @@ def register_filesystem_tools(mcp: FastMCP) -> None:
     @mcp.tool(meta=DEFER_META)
     async def filesystem_reimport(
         ctx: Context,
-        paths: list[str],
+        paths: Annotated[list[str], JsonCoerced],
         session_id: str = "",
     ) -> dict:
         """Force reimport of specific files / assets in the Godot project.

--- a/src/godot_ai/tools/input_map.py
+++ b/src/godot_ai/tools/input_map.py
@@ -11,7 +11,11 @@ from godot_ai.tools import DEFER_META
 
 def register_input_map_tools(mcp: FastMCP) -> None:
     @mcp.tool(meta=DEFER_META)
-    async def input_map_list(ctx: Context, include_builtin: bool = False) -> dict:
+    async def input_map_list(
+        ctx: Context,
+        include_builtin: bool = False,
+        session_id: str = "",
+    ) -> dict:
         """List all input actions (keybindings / control mappings) and their bound events.
 
         By default returns only project-defined actions. Set
@@ -20,8 +24,9 @@ def register_input_map_tools(mcp: FastMCP) -> None:
 
         Args:
             include_builtin: Include built-in ui_* actions. Default false.
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await input_map_handlers.input_map_list(runtime, include_builtin=include_builtin)
 
     @mcp.tool(meta=DEFER_META)
@@ -29,6 +34,7 @@ def register_input_map_tools(mcp: FastMCP) -> None:
         ctx: Context,
         action: str,
         deadzone: float = 0.5,
+        session_id: str = "",
     ) -> dict:
         """Create a new input action (named keybinding / control slot like "jump" or "move_left").
 
@@ -38,22 +44,28 @@ def register_input_map_tools(mcp: FastMCP) -> None:
         Args:
             action: Name for the action (e.g. "move_left", "jump", "attack").
             deadzone: Analog deadzone threshold. Default 0.5.
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await input_map_handlers.input_map_add_action(
             runtime, action=action, deadzone=deadzone
         )
 
     @mcp.tool(meta=DEFER_META)
-    async def input_map_remove_action(ctx: Context, action: str) -> dict:
+    async def input_map_remove_action(
+        ctx: Context,
+        action: str,
+        session_id: str = "",
+    ) -> dict:
         """Remove an input action and all its bindings.
 
         Erases the action from InputMap and project.godot.
 
         Args:
             action: Name of the action to remove.
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await input_map_handlers.input_map_remove_action(runtime, action=action)
 
     @mcp.tool(meta=DEFER_META)
@@ -67,6 +79,7 @@ def register_input_map_tools(mcp: FastMCP) -> None:
         shift: bool = False,
         meta: bool = False,
         button: int | None = None,
+        session_id: str = "",
     ) -> dict:
         """Bind keyboard / mouse / gamepad input to an action (configure controls / keybindings).
 
@@ -82,8 +95,9 @@ def register_input_map_tools(mcp: FastMCP) -> None:
             meta: Require Meta/Cmd modifier (key events only).
             button: Button index for mouse_button (1=left, 2=right) or
                 joy_button (0=A/Cross) events. Required for non-key events.
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         kwargs = {}
         if keycode:
             kwargs["keycode"] = keycode

--- a/src/godot_ai/tools/node.py
+++ b/src/godot_ai/tools/node.py
@@ -16,6 +16,7 @@ def register_node_tools(mcp: FastMCP) -> None:
         type: str,
         name: str = "",
         parent_path: str = "",
+        session_id: str = "",
     ) -> dict:
         """Create (spawn / add) a new node (game object / entity) in the scene tree.
 
@@ -27,8 +28,9 @@ def register_node_tools(mcp: FastMCP) -> None:
             type: The Godot node class (e.g. "Node3D", "MeshInstance3D", "Camera3D").
             name: Optional name for the node.
             parent_path: Node path of the parent (e.g. "/Main"). Empty = scene root.
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await node_handlers.node_create(
             runtime,
             type=type,
@@ -44,6 +46,7 @@ def register_node_tools(mcp: FastMCP) -> None:
         group: str = "",
         offset: int = 0,
         limit: int = 100,
+        session_id: str = "",
     ) -> dict:
         """Find nodes in the scene tree by name, type, or group.
 
@@ -56,8 +59,9 @@ def register_node_tools(mcp: FastMCP) -> None:
             group: Group name the node must belong to.
             offset: Number of results to skip. Default 0.
             limit: Maximum number of results to return. Default 100.
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await node_handlers.node_find(
             runtime,
             name=name,
@@ -68,7 +72,7 @@ def register_node_tools(mcp: FastMCP) -> None:
         )
 
     @mcp.tool()
-    async def node_get_properties(ctx: Context, path: str) -> dict:
+    async def node_get_properties(ctx: Context, path: str, session_id: str = "") -> dict:
         """Get all properties of a node.
 
         Returns the property list with current values for the node at
@@ -76,12 +80,13 @@ def register_node_tools(mcp: FastMCP) -> None:
 
         Args:
             path: Scene path of the node (e.g. "/Main/Camera3D").
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await node_handlers.node_get_properties(runtime, path=path)
 
     @mcp.tool(meta=DEFER_META)
-    async def node_get_children(ctx: Context, path: str) -> dict:
+    async def node_get_children(ctx: Context, path: str, session_id: str = "") -> dict:
         """Get the direct children of a node.
 
         Returns name, type, and path for each immediate child of the
@@ -89,24 +94,26 @@ def register_node_tools(mcp: FastMCP) -> None:
 
         Args:
             path: Scene path of the parent node (e.g. "/Main").
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await node_handlers.node_get_children(runtime, path=path)
 
     @mcp.tool(meta=DEFER_META)
-    async def node_get_groups(ctx: Context, path: str) -> dict:
+    async def node_get_groups(ctx: Context, path: str, session_id: str = "") -> dict:
         """Get the groups a node belongs to.
 
         Returns the list of group names for the node at the given path.
 
         Args:
             path: Scene path of the node (e.g. "/Main/Player").
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await node_handlers.node_get_groups(runtime, path=path)
 
     @mcp.tool(meta=DEFER_META)
-    async def node_delete(ctx: Context, path: str) -> dict:
+    async def node_delete(ctx: Context, path: str, session_id: str = "") -> dict:
         """Delete a node from the scene tree.
 
         Removes the node at the given path. This operation is undoable
@@ -114,8 +121,9 @@ def register_node_tools(mcp: FastMCP) -> None:
 
         Args:
             path: Scene path of the node to delete (e.g. "/Main/Enemy").
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await node_handlers.node_delete(runtime, path=path)
 
     @mcp.tool(meta=DEFER_META)
@@ -123,6 +131,7 @@ def register_node_tools(mcp: FastMCP) -> None:
         ctx: Context,
         path: str,
         new_parent: str,
+        session_id: str = "",
     ) -> dict:
         """Move a node to a new parent in the scene tree.
 
@@ -132,8 +141,9 @@ def register_node_tools(mcp: FastMCP) -> None:
         Args:
             path: Scene path of the node to move (e.g. "/Main/Player").
             new_parent: Scene path of the new parent (e.g. "/Main/World").
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await node_handlers.node_reparent(runtime, path=path, new_parent=new_parent)
 
     @mcp.tool(meta=DEFER_META)
@@ -142,6 +152,7 @@ def register_node_tools(mcp: FastMCP) -> None:
         path: str,
         property: str,
         value: str | int | float | bool | dict | list | None,
+        session_id: str = "",
     ) -> dict:
         """Set a property on a node.
 
@@ -159,8 +170,9 @@ def register_node_tools(mcp: FastMCP) -> None:
             path: Scene path of the node (e.g. "/Main/Camera3D").
             property: Property name (e.g. "fov", "position", "visible", "mesh", "remote_path").
             value: New value for the property. Pass null (or "" for Resource properties) to clear.
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await node_handlers.node_set_property(
             runtime, path=path, property=property, value=value,
         )
@@ -170,6 +182,7 @@ def register_node_tools(mcp: FastMCP) -> None:
         ctx: Context,
         path: str,
         new_name: str,
+        session_id: str = "",
     ) -> dict:
         """Rename a node in the scene tree.
 
@@ -185,8 +198,9 @@ def register_node_tools(mcp: FastMCP) -> None:
         Args:
             path: Scene path of the node to rename (e.g. "/Main/Player").
             new_name: New name for the node (e.g. "Hero").
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await node_handlers.node_rename(runtime, path=path, new_name=new_name)
 
     @mcp.tool(meta=DEFER_META)
@@ -194,6 +208,7 @@ def register_node_tools(mcp: FastMCP) -> None:
         ctx: Context,
         path: str,
         name: str = "",
+        session_id: str = "",
     ) -> dict:
         """Duplicate (clone / copy) a node and all its children.
 
@@ -203,8 +218,9 @@ def register_node_tools(mcp: FastMCP) -> None:
         Args:
             path: Scene path of the node to duplicate (e.g. "/Main/Enemy").
             name: Optional name for the duplicate. Godot auto-names if empty.
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await node_handlers.node_duplicate(runtime, path=path, name=name)
 
     @mcp.tool(meta=DEFER_META)
@@ -212,6 +228,7 @@ def register_node_tools(mcp: FastMCP) -> None:
         ctx: Context,
         path: str,
         index: int,
+        session_id: str = "",
     ) -> dict:
         """Reorder a node among its siblings.
 
@@ -221,8 +238,9 @@ def register_node_tools(mcp: FastMCP) -> None:
         Args:
             path: Scene path of the node to move (e.g. "/Main/Player").
             index: New sibling index (0-based).
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await node_handlers.node_move(runtime, path=path, index=index)
 
     @mcp.tool(meta=DEFER_META)
@@ -230,6 +248,7 @@ def register_node_tools(mcp: FastMCP) -> None:
         ctx: Context,
         path: str,
         group: str,
+        session_id: str = "",
     ) -> dict:
         """Add a node to a group.
 
@@ -239,8 +258,9 @@ def register_node_tools(mcp: FastMCP) -> None:
         Args:
             path: Scene path of the node (e.g. "/Main/Enemy").
             group: Group name to add the node to (e.g. "enemies").
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await node_handlers.node_add_to_group(runtime, path=path, group=group)
 
     @mcp.tool(meta=DEFER_META)
@@ -248,13 +268,14 @@ def register_node_tools(mcp: FastMCP) -> None:
         ctx: Context,
         path: str,
         group: str,
+        session_id: str = "",
     ) -> dict:
         """Remove a node from a group.
 
         Args:
             path: Scene path of the node (e.g. "/Main/Enemy").
             group: Group name to remove the node from (e.g. "enemies").
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await node_handlers.node_remove_from_group(runtime, path=path, group=group)
-

--- a/src/godot_ai/tools/project.py
+++ b/src/godot_ai/tools/project.py
@@ -17,6 +17,7 @@ def register_project_tools(mcp: FastMCP) -> None:
         ctx: Context,
         mode: str = "main",
         scene: str = "",
+        session_id: str = "",
     ) -> dict:
         """Run (play / start) the Godot project (game) from the editor.
 
@@ -28,22 +29,26 @@ def register_project_tools(mcp: FastMCP) -> None:
         Args:
             mode: Run mode — "main", "current", or "custom". Default "main".
             scene: Scene path (e.g. "res://levels/level1.tscn"). Required when mode is "custom".
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await project_handlers.project_run(runtime, mode=mode, scene=scene)
 
     @mcp.tool(meta=DEFER_META)
-    async def project_stop(ctx: Context) -> dict:
+    async def project_stop(ctx: Context, session_id: str = "") -> dict:
         """Stop (halt / exit) the running Godot project (game).
 
         Stops the currently playing scene. Returns an error if the project
         is not running.
+
+        Args:
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await project_handlers.project_stop(runtime)
 
     @mcp.tool(meta=DEFER_META)
-    async def project_settings_get(ctx: Context, key: str) -> dict:
+    async def project_settings_get(ctx: Context, key: str, session_id: str = "") -> dict:
         """Get a Godot project setting by key.
 
         Reads from ProjectSettings (e.g. "application/config/name",
@@ -51,8 +56,9 @@ def register_project_tools(mcp: FastMCP) -> None:
 
         Args:
             key: The setting key path (e.g. "application/config/name").
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await project_handlers.project_settings_get(runtime, key=key)
 
     @mcp.tool(meta=DEFER_META)
@@ -60,6 +66,7 @@ def register_project_tools(mcp: FastMCP) -> None:
         ctx: Context,
         key: str,
         value: Any,
+        session_id: str = "",
     ) -> dict:
         """Set a Godot project setting by key.
 
@@ -70,7 +77,7 @@ def register_project_tools(mcp: FastMCP) -> None:
         Args:
             key: The setting key path (e.g. "application/config/name").
             value: The value to set (string, int, float, or bool).
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await project_handlers.project_settings_set(runtime, key=key, value=value)
-

--- a/src/godot_ai/tools/resource.py
+++ b/src/godot_ai/tools/resource.py
@@ -17,6 +17,7 @@ def register_resource_tools(mcp: FastMCP) -> None:
         path: str = "",
         offset: int = 0,
         limit: int = 100,
+        session_id: str = "",
     ) -> dict:
         """Search for resources (assets: meshes, textures, materials, scenes) by type or path.
 
@@ -29,8 +30,9 @@ def register_resource_tools(mcp: FastMCP) -> None:
             path: Substring match on the resource file path (case-insensitive).
             offset: Number of results to skip. Default 0.
             limit: Maximum number of results to return. Default 100.
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await resource_handlers.resource_search(
             runtime,
             type=type,
@@ -40,7 +42,7 @@ def register_resource_tools(mcp: FastMCP) -> None:
         )
 
     @mcp.tool(meta=DEFER_META)
-    async def resource_load(ctx: Context, path: str) -> dict:
+    async def resource_load(ctx: Context, path: str, session_id: str = "") -> dict:
         """Inspect a resource's (asset's) properties — materials, meshes, textures, .tres files.
 
         Loads the resource at the given path and returns its type and
@@ -48,8 +50,9 @@ def register_resource_tools(mcp: FastMCP) -> None:
 
         Args:
             path: File path starting with res:// (e.g. "res://materials/ground.tres").
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await resource_handlers.resource_load(runtime, path=path)
 
     @mcp.tool(meta=DEFER_META)
@@ -58,6 +61,7 @@ def register_resource_tools(mcp: FastMCP) -> None:
         path: str,
         property: str,
         resource_path: str,
+        session_id: str = "",
     ) -> dict:
         """Assign a resource (asset — mesh, texture, material, etc.) to a node property.
 
@@ -69,8 +73,9 @@ def register_resource_tools(mcp: FastMCP) -> None:
             path: Scene path of the node (e.g. "/Main/Ground").
             property: Property name that accepts a resource (e.g. "mesh", "material_override").
             resource_path: File path of the resource (e.g. "res://meshes/cube.tres").
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await resource_handlers.resource_assign(
             runtime,
             path=path,

--- a/src/godot_ai/tools/scene.py
+++ b/src/godot_ai/tools/scene.py
@@ -16,6 +16,7 @@ def register_scene_tools(mcp: FastMCP) -> None:
         depth: int = 10,
         offset: int = 0,
         limit: int = 100,
+        session_id: str = "",
     ) -> dict:
         """Get the scene tree hierarchy (nodes / game objects) from the open scene (level / map).
 
@@ -26,8 +27,9 @@ def register_scene_tools(mcp: FastMCP) -> None:
             depth: Maximum depth to walk. Default 10.
             offset: Number of nodes to skip. Default 0.
             limit: Maximum number of nodes to return. Default 100.
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await scene_handlers.scene_get_hierarchy(
             runtime,
             depth=depth,
@@ -36,13 +38,16 @@ def register_scene_tools(mcp: FastMCP) -> None:
         )
 
     @mcp.tool(meta=DEFER_META)
-    async def scene_get_roots(ctx: Context) -> dict:
+    async def scene_get_roots(ctx: Context, session_id: str = "") -> dict:
         """Get all scenes currently open in the Godot editor.
 
         Returns a list of open scene file paths and which one is the
         currently edited scene.
+
+        Args:
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await scene_handlers.scene_get_roots(runtime)
 
     @mcp.tool(meta=DEFER_META)
@@ -50,6 +55,7 @@ def register_scene_tools(mcp: FastMCP) -> None:
         ctx: Context,
         path: str,
         root_type: str = "Node3D",
+        session_id: str = "",
     ) -> dict:
         """Create a new scene file (level / map / prefab .tscn) and open it in the editor.
 
@@ -59,32 +65,39 @@ def register_scene_tools(mcp: FastMCP) -> None:
         Args:
             path: File path for the new scene (e.g. "res://scenes/level.tscn").
             root_type: Godot node class for the root node. Default "Node3D".
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await scene_handlers.scene_create(runtime, path=path, root_type=root_type)
 
     @mcp.tool(meta=DEFER_META)
-    async def scene_open(ctx: Context, path: str) -> dict:
+    async def scene_open(ctx: Context, path: str, session_id: str = "") -> dict:
         """Open (load) an existing scene file (level / .tscn) in the editor.
 
         Args:
             path: File path of the scene to open (e.g. "res://main.tscn").
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await scene_handlers.scene_open(runtime, path=path)
 
     @mcp.tool(meta=DEFER_META)
-    async def scene_save(ctx: Context) -> dict:
-        """Save the currently edited scene to disk."""
-        runtime = DirectRuntime.from_context(ctx)
+    async def scene_save(ctx: Context, session_id: str = "") -> dict:
+        """Save the currently edited scene to disk.
+
+        Args:
+            session_id: Optional Godot session to target. Empty = active session.
+        """
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await scene_handlers.scene_save(runtime)
 
     @mcp.tool(meta=DEFER_META)
-    async def scene_save_as(ctx: Context, path: str) -> dict:
+    async def scene_save_as(ctx: Context, path: str, session_id: str = "") -> dict:
         """Save the currently edited scene to a new file path.
 
         Args:
             path: New file path for the scene (e.g. "res://scenes/level_copy.tscn").
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await scene_handlers.scene_save_as(runtime, path=path)

--- a/src/godot_ai/tools/script.py
+++ b/src/godot_ai/tools/script.py
@@ -15,6 +15,7 @@ def register_script_tools(mcp: FastMCP) -> None:
         ctx: Context,
         path: str,
         content: str = "",
+        session_id: str = "",
     ) -> dict:
         """Create a new GDScript source file (.gd code file) on disk.
 
@@ -25,8 +26,9 @@ def register_script_tools(mcp: FastMCP) -> None:
         Args:
             path: File path starting with res:// (e.g. "res://scripts/player.gd").
             content: GDScript source code to write. Empty creates a blank file.
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await script_handlers.script_create(runtime, path=path, content=content)
 
     @mcp.tool(meta=DEFER_META)
@@ -36,6 +38,7 @@ def register_script_tools(mcp: FastMCP) -> None:
         old_text: str,
         new_text: str,
         replace_all: bool = False,
+        session_id: str = "",
     ) -> dict:
         """Patch (partial edit / string-replace) a GDScript file in place.
 
@@ -56,8 +59,9 @@ def register_script_tools(mcp: FastMCP) -> None:
             old_text: Exact substring to find. Must be unique unless replace_all=true.
             new_text: Replacement text. Can be empty to delete.
             replace_all: If true, replace every occurrence. Default false.
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await script_handlers.script_patch(
             runtime,
             path=path,
@@ -67,15 +71,16 @@ def register_script_tools(mcp: FastMCP) -> None:
         )
 
     @mcp.tool(meta=DEFER_META)
-    async def script_read(ctx: Context, path: str) -> dict:
+    async def script_read(ctx: Context, path: str, session_id: str = "") -> dict:
         """Read the contents of a GDScript file.
 
         Returns the full source code, line count, and file size.
 
         Args:
             path: File path starting with res:// (e.g. "res://scripts/player.gd").
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await script_handlers.script_read(runtime, path=path)
 
     @mcp.tool(meta=DEFER_META)
@@ -83,6 +88,7 @@ def register_script_tools(mcp: FastMCP) -> None:
         ctx: Context,
         path: str,
         script_path: str,
+        session_id: str = "",
     ) -> dict:
         """Attach a script to a node in the scene tree.
 
@@ -93,8 +99,9 @@ def register_script_tools(mcp: FastMCP) -> None:
         Args:
             path: Scene path of the node (e.g. "/Main/Player").
             script_path: File path of the script (e.g. "res://scripts/player.gd").
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await script_handlers.script_attach(
             runtime,
             path=path,
@@ -102,7 +109,7 @@ def register_script_tools(mcp: FastMCP) -> None:
         )
 
     @mcp.tool(meta=DEFER_META)
-    async def script_detach(ctx: Context, path: str) -> dict:
+    async def script_detach(ctx: Context, path: str, session_id: str = "") -> dict:
         """Remove the script from a node.
 
         Detaches whatever script is currently assigned to the node.
@@ -110,12 +117,13 @@ def register_script_tools(mcp: FastMCP) -> None:
 
         Args:
             path: Scene path of the node (e.g. "/Main/Player").
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await script_handlers.script_detach(runtime, path=path)
 
     @mcp.tool(meta=DEFER_META)
-    async def script_find_symbols(ctx: Context, path: str) -> dict:
+    async def script_find_symbols(ctx: Context, path: str, session_id: str = "") -> dict:
         """Inspect (outline) a GDScript file — functions, methods, signals, class_name, exports.
 
         Parses the script and returns its class_name, extends base,
@@ -123,6 +131,7 @@ def register_script_tools(mcp: FastMCP) -> None:
 
         Args:
             path: File path starting with res:// (e.g. "res://scripts/player.gd").
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await script_handlers.script_find_symbols(runtime, path=path)

--- a/src/godot_ai/tools/session.py
+++ b/src/godot_ai/tools/session.py
@@ -13,21 +13,29 @@ def register_session_tools(mcp: FastMCP) -> None:
     def session_list(ctx: Context) -> dict:
         """List all connected Godot editor sessions.
 
-        Returns session metadata including Godot version, project path,
-        and connection state for each connected editor instance.
+        Returns session metadata for each connected editor instance:
+        session_id, short name (project basename), godot_version, project_path,
+        editor_pid, current_scene, play_state, readiness, connected_at,
+        last_seen (heartbeat timestamp), and is_active flag.
         """
         runtime = DirectRuntime.from_context(ctx)
         return session_handlers.session_list(runtime)
 
     @mcp.tool()
     def session_activate(ctx: Context, session_id: str) -> dict:
-        """Set the active Godot editor session.
+        """Set the active Godot editor session for subsequent tool calls.
 
-        Subsequent tool calls that don't specify a session_id will
-        target this session.
+        Accepts either an exact session_id or a substring hint matched
+        against the session's short name (project folder basename),
+        project_path, or session_id. An exact id match always wins; a
+        substring must resolve to exactly one session or the tool returns
+        an error listing the candidates.
 
         Args:
-            session_id: The ID of the session to activate.
+            session_id: An exact session id (e.g. the UUID from
+                session_list) OR a substring hint like a project folder
+                name ("test_project", "my_game") — whichever is more
+                convenient for the caller.
         """
         runtime = DirectRuntime.from_context(ctx)
         return session_handlers.session_activate(runtime, session_id)

--- a/src/godot_ai/tools/signal.py
+++ b/src/godot_ai/tools/signal.py
@@ -11,7 +11,7 @@ from godot_ai.tools import DEFER_META
 
 def register_signal_tools(mcp: FastMCP) -> None:
     @mcp.tool(meta=DEFER_META)
-    async def signal_list(ctx: Context, path: str) -> dict:
+    async def signal_list(ctx: Context, path: str, session_id: str = "") -> dict:
         """List all signals (events) on a node and their current connections.
 
         Signals are Godot's event/observer mechanism — nodes emit signals
@@ -20,8 +20,9 @@ def register_signal_tools(mcp: FastMCP) -> None:
 
         Args:
             path: Scene path of the node (e.g. "/Player").
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await signal_handlers.signal_list(runtime, path=path)
 
     @mcp.tool(meta=DEFER_META)
@@ -31,6 +32,7 @@ def register_signal_tools(mcp: FastMCP) -> None:
         signal: str,
         target: str,
         method: str,
+        session_id: str = "",
     ) -> dict:
         """Connect a signal from one node to a method on another (event subscription / callback).
 
@@ -42,8 +44,9 @@ def register_signal_tools(mcp: FastMCP) -> None:
             signal: Name of the signal to connect (e.g. "pressed", "body_entered").
             target: Scene path of the target node receiving the signal.
             method: Name of the method to call on the target node.
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await signal_handlers.signal_connect(
             runtime, path=path, signal=signal, target=target, method=method
         )
@@ -55,6 +58,7 @@ def register_signal_tools(mcp: FastMCP) -> None:
         signal: str,
         target: str,
         method: str,
+        session_id: str = "",
     ) -> dict:
         """Disconnect a signal connection between two nodes (unsubscribe an event listener).
 
@@ -65,8 +69,9 @@ def register_signal_tools(mcp: FastMCP) -> None:
             signal: Name of the signal to disconnect.
             target: Scene path of the target node.
             method: Name of the method that was connected.
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await signal_handlers.signal_disconnect(
             runtime, path=path, signal=signal, target=target, method=method
         )

--- a/src/godot_ai/tools/testing.py
+++ b/src/godot_ai/tools/testing.py
@@ -16,6 +16,7 @@ def register_testing_tools(mcp: FastMCP) -> None:
         suite: str = "",
         test_name: str = "",
         verbose: bool = False,
+        session_id: str = "",
     ) -> dict:
         """Run GDScript test suites inside the connected Godot editor.
 
@@ -33,14 +34,19 @@ def register_testing_tools(mcp: FastMCP) -> None:
                        Empty runs all tests in the selected suite(s).
             verbose: If true, include every individual test result. Default
                      false — only summary and failures are returned.
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await testing_handlers.test_run(
             runtime, suite=suite, test_name=test_name, verbose=verbose
         )
 
     @mcp.tool(meta=DEFER_META)
-    async def test_results_get(ctx: Context, verbose: bool = False) -> dict:
+    async def test_results_get(
+        ctx: Context,
+        verbose: bool = False,
+        session_id: str = "",
+    ) -> dict:
         """Get results from the most recent test run.
 
         Returns the same structured results as test_run, without
@@ -48,6 +54,7 @@ def register_testing_tools(mcp: FastMCP) -> None:
 
         Args:
             verbose: If true, include every individual test result.
+            session_id: Optional Godot session to target. Empty = active session.
         """
-        runtime = DirectRuntime.from_context(ctx)
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await testing_handlers.test_results_get(runtime, verbose=verbose)

--- a/src/godot_ai/transport/websocket.py
+++ b/src/godot_ai/transport/websocket.py
@@ -102,14 +102,8 @@ class GodotWebSocketServer:
             logger.exception("Error in WebSocket handler for session %s", session_id)
         finally:
             if session_id:
-                was_active = self.registry.active_session_id == session_id
                 self.registry.unregister(session_id)
                 self._connections.pop(session_id, None)
-                if was_active:
-                    logger.info(
-                        "Active session %s disconnected; waiting for next register/activate",
-                        session_id[:8],
-                    )
 
     def _handle_event(self, session_id: str, data: dict) -> None:
         event = data.get("event", "")

--- a/src/godot_ai/transport/websocket.py
+++ b/src/godot_ai/transport/websocket.py
@@ -63,18 +63,26 @@ class GodotWebSocketServer:
                 plugin_version=handshake.plugin_version,
                 protocol_version=handshake.protocol_version,
                 readiness=handshake.readiness,
+                editor_pid=handshake.editor_pid,
             )
             self.registry.register(session)
             self._connections[session_id] = ws
             logger.info(
-                "Session connected: %s (Godot %s, %s)",
+                "Session connected: %s (pid=%s, Godot %s, %s)",
                 session_id,
+                handshake.editor_pid or "?",
                 handshake.godot_version,
                 handshake.project_path,
             )
 
             # Listen for responses and events
             async for raw_msg in ws:
+                ## Any message counts as a heartbeat — last_seen lets callers
+                ## distinguish live editors from stale registry entries.
+                live = self.registry.get(session_id)
+                if live is not None:
+                    live.touch()
+
                 data = json.loads(raw_msg)
 
                 # Handle state events from the plugin
@@ -94,8 +102,14 @@ class GodotWebSocketServer:
             logger.exception("Error in WebSocket handler for session %s", session_id)
         finally:
             if session_id:
+                was_active = self.registry.active_session_id == session_id
                 self.registry.unregister(session_id)
                 self._connections.pop(session_id, None)
+                if was_active:
+                    logger.info(
+                        "Active session %s disconnected; waiting for next register/activate",
+                        session_id[:8],
+                    )
 
     def _handle_event(self, session_id: str, data: dict) -> None:
         event = data.get("event", "")

--- a/test_project/tests/test_connection.gd
+++ b/test_project/tests/test_connection.gd
@@ -1,0 +1,74 @@
+@tool
+extends McpTestSuite
+
+## Tests for Connection._make_session_id / _slugify — session ID format.
+
+
+func suite_name() -> String:
+	return "connection"
+
+
+# ----- slug format -----
+
+func test_make_session_id_uses_project_directory_name() -> void:
+	var sid := Connection._make_session_id("/Users/foo/My Game/")
+	var parts := sid.split("@")
+	assert_eq(parts.size(), 2, "SID should be '<slug>@<hex>'")
+	assert_eq(parts[0], "my-game")
+	assert_eq(parts[1].length(), 4, "suffix should be 4 hex chars")
+	for c in parts[1]:
+		assert_true(
+			(c >= "0" and c <= "9") or (c >= "a" and c <= "f"),
+			"suffix char %s is not hex" % c,
+		)
+
+
+func test_make_session_id_handles_no_trailing_slash() -> void:
+	var sid := Connection._make_session_id("/Users/foo/My Game")
+	var parts := sid.split("@")
+	assert_eq(parts[0], "my-game")
+
+
+func test_make_session_id_empty_path_falls_back_to_project() -> void:
+	var sid := Connection._make_session_id("")
+	var parts := sid.split("@")
+	assert_eq(parts[0], "project")
+	assert_eq(parts[1].length(), 4)
+
+
+func test_make_session_id_only_slashes_falls_back_to_project() -> void:
+	var sid := Connection._make_session_id("///")
+	var parts := sid.split("@")
+	assert_eq(parts[0], "project")
+
+
+func test_make_session_id_randomizes_suffix() -> void:
+	var s1 := Connection._make_session_id("/Users/x/game/")
+	var s2 := Connection._make_session_id("/Users/x/game/")
+	## Two calls for the same path should (almost always) differ in the suffix.
+	## Collision odds are 1/65536 per pair — treat a match as a flake.
+	assert_ne(s1, s2, "suffix should randomize between calls")
+
+
+# ----- slugify -----
+
+func test_slugify_lowercases() -> void:
+	assert_eq(Connection._slugify("MyGame"), "mygame")
+
+
+func test_slugify_collapses_punctuation_to_dashes() -> void:
+	assert_eq(Connection._slugify("My Awesome_Game!"), "my-awesome-game")
+
+
+func test_slugify_strips_leading_and_trailing_punctuation() -> void:
+	assert_eq(Connection._slugify("  Hello World  "), "hello-world")
+	assert_eq(Connection._slugify("!!!game!!!"), "game")
+
+
+func test_slugify_preserves_alphanumeric() -> void:
+	assert_eq(Connection._slugify("level42"), "level42")
+
+
+func test_slugify_empty_returns_empty() -> void:
+	assert_eq(Connection._slugify(""), "")
+	assert_eq(Connection._slugify("!!!"), "")

--- a/test_project/tests/test_connection.gd
+++ b/test_project/tests/test_connection.gd
@@ -43,11 +43,13 @@ func test_make_session_id_only_slashes_falls_back_to_project() -> void:
 
 
 func test_make_session_id_randomizes_suffix() -> void:
-	var s1 := Connection._make_session_id("/Users/x/game/")
-	var s2 := Connection._make_session_id("/Users/x/game/")
-	## Two calls for the same path should (almost always) differ in the suffix.
-	## Collision odds are 1/65536 per pair — treat a match as a flake.
-	assert_ne(s1, s2, "suffix should randomize between calls")
+	var seen := {}
+	for i in range(32):
+		var sid := Connection._make_session_id("/Users/x/game/")
+		seen[sid] = true
+	## Avoid a flaky two-sample comparison: collect many IDs and verify
+	## the suffix is not constant across repeated calls for the same path.
+	assert_true(seen.size() > 1, "suffix should vary across repeated calls")
 
 
 # ----- slugify -----

--- a/test_project/tests/test_connection.gd.uid
+++ b/test_project/tests/test_connection.gd.uid
@@ -1,0 +1,1 @@
+uid://d3r07uef5c5gc

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,6 +61,7 @@ class ServerHarness:
         project_path: str = "/tmp/test_project",
         plugin_version: str = "0.0.1",
         readiness: str = "ready",
+        editor_pid: int = 0,
     ) -> MockGodotPlugin:
         ws = await websockets.connect(f"ws://127.0.0.1:{self.port}")
         handshake = {
@@ -71,6 +72,7 @@ class ServerHarness:
             "plugin_version": plugin_version,
             "protocol_version": 1,
             "readiness": readiness,
+            "editor_pid": editor_pid,
         }
         await ws.send(json.dumps(handshake))
         # Give the server a moment to process the handshake

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -2557,3 +2557,140 @@ class TestPerCallSessionRouting:
             assert "EDITOR_NOT_READY" in str(result.content)
         finally:
             await plugin_b.close()
+
+
+# ---------------------------------------------------------------------------
+# JSON-string coercion for list params (issue #11 — Claude Code MCP client
+# stringifies complex-typed args before sending)
+# ---------------------------------------------------------------------------
+
+
+class TestJsonStringParamCoercion:
+    async def test_batch_execute_accepts_stringified_commands(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "batch_execute"
+            assert cmd["params"]["commands"] == [
+                {"command": "create_node", "params": {"type": "Node3D", "name": "X"}}
+            ]
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "succeeded": 1,
+                    "stopped_at": None,
+                    "results": [
+                        {"command": "create_node", "status": "ok", "data": {"undoable": True}}
+                    ],
+                    "undo": True,
+                    "rolled_back": False,
+                    "undoable": True,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "batch_execute",
+            {
+                "commands": json.dumps(
+                    [{"command": "create_node", "params": {"type": "Node3D", "name": "X"}}]
+                )
+            },
+        )
+        await task
+        assert not result.is_error
+        assert result.data["succeeded"] == 1
+
+    async def test_editor_selection_set_accepts_stringified_paths(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["params"]["paths"] == ["/Main/Camera3D", "/Main/World"]
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "selected": ["/Main/Camera3D", "/Main/World"],
+                    "not_found": [],
+                    "count": 2,
+                    "undoable": False,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "editor_selection_set",
+            {"paths": json.dumps(["/Main/Camera3D", "/Main/World"])},
+        )
+        await task
+        assert result.data["count"] == 2
+
+    async def test_filesystem_reimport_accepts_stringified_paths(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["params"]["paths"] == ["res://a.png", "res://b.png"]
+            await plugin.send_response(
+                cmd["request_id"],
+                {"reimported": ["res://a.png", "res://b.png"], "count": 2},
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "filesystem_reimport",
+            {"paths": json.dumps(["res://a.png", "res://b.png"])},
+        )
+        await task
+        assert result.data["count"] == 2
+
+    async def test_performance_monitors_get_accepts_stringified_monitors(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["params"]["monitors"] == ["time/fps"]
+            await plugin.send_response(
+                cmd["request_id"], {"monitors": {"time/fps": 60}, "missing": []}
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "performance_monitors_get",
+            {"monitors": json.dumps(["time/fps"])},
+        )
+        await task
+        assert result.data["monitors"]["time/fps"] == 60
+
+    async def test_real_list_still_works(self, mcp_stack):
+        """Regression check — passing actual lists must continue to work."""
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["params"]["paths"] == ["res://x.png"]
+            await plugin.send_response(
+                cmd["request_id"], {"reimported": ["res://x.png"], "count": 1}
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "filesystem_reimport",
+            {"paths": ["res://x.png"]},
+        )
+        await task
+        assert result.data["count"] == 1
+
+    async def test_malformed_json_string_still_raises_validation(self, mcp_stack):
+        """A non-JSON string must fall through and fail pydantic validation."""
+        client, _plugin = mcp_stack
+        result = await client.call_tool(
+            "filesystem_reimport",
+            {"paths": "not-json-at-all"},
+            raise_on_error=False,
+        )
+        assert result.is_error
+        error_text = str(result.content).lower()
+        assert "paths" in error_text
+        assert "input should be a valid list" in error_text or "list_type" in error_text

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -2481,3 +2481,79 @@ class TestBatchExecuteTool:
         assert not result.is_error
         assert result.data["error"]["code"] == "INVALID_PARAMS"
         assert result.data["succeeded"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Per-call session routing via session_id parameter
+# ---------------------------------------------------------------------------
+
+
+class TestPerCallSessionRouting:
+    async def _connect_second_plugin(self, session_id: str, readiness: str = "ready"):
+        """Connect a second mock plugin to the same MCP stack server."""
+        from tests.conftest import MockGodotPlugin
+
+        ws = await websockets.connect("ws://127.0.0.1:19502")
+        handshake = {
+            "type": "handshake",
+            "session_id": session_id,
+            "godot_version": "4.4.1",
+            "project_path": f"/tmp/{session_id}",
+            "plugin_version": "0.0.1",
+            "protocol_version": 1,
+            "readiness": readiness,
+        }
+        await ws.send(json.dumps(handshake))
+        await asyncio.sleep(0.05)
+        return MockGodotPlugin(ws=ws, session_id=session_id)
+
+    async def test_session_id_routes_to_specific_session(self, mcp_stack):
+        client, plugin_a = mcp_stack
+        ## Rename the implicit session "mcp-test" for clarity: active=proj-a@0001.
+        plugin_b = await self._connect_second_plugin("proj-b@0002")
+        try:
+            ## No session_id -> active (the default mcp-test plugin).
+            async def respond_active():
+                cmd = await plugin_a.recv_command()
+                await plugin_a.send_response(
+                    cmd["request_id"],
+                    {"scenes": ["res://from_a.tscn"], "current": "res://from_a.tscn"},
+                )
+
+            task = asyncio.create_task(respond_active())
+            result = await client.call_tool("scene_get_roots", {})
+            await task
+            assert result.data["current"] == "res://from_a.tscn"
+
+            ## session_id="proj-b@0002" -> routed to plugin_b, not plugin_a.
+            async def respond_b():
+                cmd = await plugin_b.recv_command()
+                await plugin_b.send_response(
+                    cmd["request_id"],
+                    {"scenes": ["res://from_b.tscn"], "current": "res://from_b.tscn"},
+                )
+
+            task = asyncio.create_task(respond_b())
+            result = await client.call_tool(
+                "scene_get_roots", {"session_id": "proj-b@0002"}
+            )
+            await task
+            assert result.data["current"] == "res://from_b.tscn"
+        finally:
+            await plugin_b.close()
+
+    async def test_session_id_respects_target_readiness(self, mcp_stack):
+        client, plugin_a = mcp_stack
+        ## Active session (plugin_a/mcp-test) is ready; plugin_b is playing.
+        plugin_b = await self._connect_second_plugin("proj-b@0002", readiness="playing")
+        try:
+            ## require_writable must see the bound session's readiness, not active.
+            result = await client.call_tool(
+                "node_create",
+                {"type": "Node3D", "name": "Blocked", "session_id": "proj-b@0002"},
+                raise_on_error=False,
+            )
+            assert result.is_error
+            assert "EDITOR_NOT_READY" in str(result.content)
+        finally:
+            await plugin_b.close()

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -46,6 +46,31 @@ class TestHandshake:
         await asyncio.sleep(0.1)  # let server process disconnect
         assert harness.registry.get("sess-dc") is None
 
+    async def test_handshake_captures_editor_pid(self, harness):
+        plugin = await harness.connect_plugin(session_id="sess-pid", editor_pid=4242)
+        session = harness.registry.get("sess-pid")
+        assert session.editor_pid == 4242
+        await plugin.close()
+
+    async def test_handshake_missing_editor_pid_defaults_to_zero(self, harness):
+        ## Default path — plugin omits the field (older plugin versions).
+        plugin = await harness.connect_plugin(session_id="sess-no-pid")
+        session = harness.registry.get("sess-no-pid")
+        assert session.editor_pid == 0
+        await plugin.close()
+
+    async def test_inbound_message_updates_last_seen(self, harness):
+        plugin = await harness.connect_plugin(session_id="sess-heartbeat")
+        session = harness.registry.get("sess-heartbeat")
+        baseline = session.last_seen
+
+        await asyncio.sleep(0.01)
+        await plugin.send_event("readiness_changed", {"readiness": "ready"})
+        await asyncio.sleep(0.05)
+
+        assert session.last_seen > baseline
+        await plugin.close()
+
 
 # ---------------------------------------------------------------------------
 # Command round-trip

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -478,10 +478,14 @@ class ReloadStubClient:
         registry: SessionRegistry,
         new_session_id: str = "reloaded",
         raise_timeout: bool = False,
+        target_id: str = "old-session",
+        target_project_path: str = "/tmp/test_project",
     ):
         self.registry = registry
         self.new_session_id = new_session_id
         self.raise_timeout = raise_timeout
+        self.target_id = target_id
+        self.target_project_path = target_project_path
         self.calls: list[dict] = []
 
     async def send(
@@ -500,11 +504,11 @@ class ReloadStubClient:
             }
         )
         if command == "reload_plugin":
-            self.registry.unregister("old-session")
+            self.registry.unregister(self.target_id)
             self.registry.register(
                 _make_session(
                     self.new_session_id,
-                    project_path="/tmp/test_project",
+                    project_path=self.target_project_path,
                 )
             )
             if self.raise_timeout:
@@ -534,6 +538,58 @@ def test_direct_runtime_exposes_registry_state():
     assert runtime.active_session_id == "b"
     assert runtime.get_active_session().session_id == "b"
     assert [session.session_id for session in runtime.list_sessions()] == ["a", "b"]
+
+
+async def test_direct_runtime_binds_session_for_send_command():
+    registry = SessionRegistry()
+    registry.register(_make_session("a"))
+    registry.register(_make_session("b"))
+    registry.set_active("a")
+    client = StubClient()
+    runtime = DirectRuntime(registry=registry, client=client, session_id="b")
+
+    assert runtime.active_session_id == "b"
+    assert runtime.get_active_session().session_id == "b"
+
+    await runtime.send_command("get_editor_state")
+
+    assert client.calls[-1]["session_id"] == "b"
+    ## Global active is untouched — only this runtime is pinned.
+    assert registry.active_session_id == "a"
+
+
+async def test_direct_runtime_bound_id_defers_to_explicit_send_command_id():
+    registry = SessionRegistry()
+    registry.register(_make_session("a"))
+    registry.register(_make_session("b"))
+    client = StubClient()
+    runtime = DirectRuntime(registry=registry, client=client, session_id="b")
+
+    await runtime.send_command("get_editor_state", session_id="a")
+
+    assert client.calls[-1]["session_id"] == "a"
+
+
+def test_direct_runtime_bound_id_missing_returns_none_session():
+    registry = SessionRegistry()
+    registry.register(_make_session("a"))
+    runtime = DirectRuntime(registry=registry, client=StubClient(), session_id="ghost")
+
+    assert runtime.active_session_id == "ghost"
+    assert runtime.get_active_session() is None
+
+
+async def test_direct_runtime_unbound_preserves_active_routing():
+    registry = SessionRegistry()
+    registry.register(_make_session("a"))
+    registry.set_active("a")
+    client = StubClient()
+    runtime = DirectRuntime(registry=registry, client=client)
+
+    await runtime.send_command("get_editor_state")
+
+    ## Unbound runtime passes None so client falls back to registry active.
+    assert client.calls[-1]["session_id"] is None
 
 
 async def test_logs_read_handler_uses_runtime_and_paginates():
@@ -610,6 +666,81 @@ async def test_reload_plugin_raises_when_no_active_session():
     runtime = DirectRuntime(registry=SessionRegistry(), client=StubClient())
     with pytest.raises(ConnectionError, match="No active Godot session"):
         await editor_handlers.editor_reload_plugin(runtime)
+
+
+async def test_reload_plugin_pins_target_session_when_multiple_connected():
+    """Reload must target the active session by explicit id, not by falling
+    back to whatever registry.get_active() returns at send time."""
+    registry = SessionRegistry()
+    registry.register(_make_session("session-a", project_path="/projects/a"))
+    registry.register(_make_session("session-b", project_path="/projects/b"))
+    registry.set_active("session-b")
+    stub = ReloadStubClient(
+        registry=registry,
+        new_session_id="session-b-new",
+        target_id="session-b",
+        target_project_path="/projects/b",
+    )
+    runtime = DirectRuntime(registry=registry, client=stub)
+
+    result = await editor_handlers.editor_reload_plugin(runtime)
+
+    reload_calls = [c for c in stub.calls if c["command"] == "reload_plugin"]
+    assert len(reload_calls) == 1
+    assert reload_calls[0]["session_id"] == "session-b", (
+        "Reload must be pinned to the old active id, not resolved implicitly"
+    )
+    assert result["old_session_id"] == "session-b"
+    assert result["new_session_id"] == "session-b-new"
+    assert runtime.active_session_id == "session-b-new"
+
+
+def test_unregister_active_session_clears_active_not_promotes_first():
+    """Disconnect of the active session must not silently promote another
+    session — that's the 'first-registered wins' routing footgun."""
+    registry = SessionRegistry()
+    registry.register(_make_session("session-a"))
+    registry.register(_make_session("session-b"))
+    registry.set_active("session-b")
+
+    registry.unregister("session-b")
+
+    assert registry.active_session_id is None
+    assert registry.get_active() is None
+
+
+def test_unregister_non_active_session_leaves_active_unchanged():
+    registry = SessionRegistry()
+    registry.register(_make_session("session-a"))
+    registry.register(_make_session("session-b"))
+    registry.set_active("session-b")
+
+    registry.unregister("session-a")
+
+    assert registry.active_session_id == "session-b"
+
+
+def test_register_promotes_first_session_when_no_active():
+    """Zero-config single-editor UX: first registration becomes active."""
+    registry = SessionRegistry()
+    registry.register(_make_session("first"))
+    assert registry.active_session_id == "first"
+
+    registry.register(_make_session("second"))
+    assert registry.active_session_id == "first"  # unchanged
+
+
+def test_register_reclaims_active_after_active_disconnected():
+    """After the active session disconnects (active cleared), the next
+    registration should re-promote — covering the single-editor reload case
+    where the same editor disconnects and immediately reconnects."""
+    registry = SessionRegistry()
+    registry.register(_make_session("old"))
+    registry.unregister("old")
+    assert registry.active_session_id is None
+
+    registry.register(_make_session("new"))
+    assert registry.active_session_id == "new"
 
 
 # ---------------------------------------------------------------------------
@@ -975,14 +1106,106 @@ def test_session_activate_handler_success():
     registry.register(_make_session("a"))
     runtime = DirectRuntime(registry=registry, client=StubClient())
     result = session_handlers.session_activate(runtime, "a")
-    assert result == {"status": "ok", "active_session_id": "a"}
+    assert result["status"] == "ok"
+    assert result["active_session_id"] == "a"
+    assert result["matched"] == "exact_id"
 
 
 def test_session_activate_handler_not_found():
     runtime = DirectRuntime(registry=SessionRegistry(), client=StubClient())
     result = session_handlers.session_activate(runtime, "nonexistent")
     assert result["status"] == "error"
-    assert "not found" in result["message"]
+    assert "No session matches" in result["message"]
+
+
+def test_session_activate_by_project_name_hint():
+    registry = SessionRegistry()
+    registry.register(
+        _make_session("aaaa-uuid-1", project_path="/home/user/projects/my_game/")
+    )
+    registry.register(
+        _make_session("bbbb-uuid-2", project_path="/home/user/projects/other_tool/")
+    )
+    runtime = DirectRuntime(registry=registry, client=StubClient())
+
+    result = session_handlers.session_activate(runtime, "my_game")
+
+    assert result["status"] == "ok"
+    assert result["active_session_id"] == "aaaa-uuid-1"
+    assert result["matched"] == "hint"
+    assert result["matched_name"] == "my_game"
+
+
+def test_session_activate_by_project_path_substring():
+    registry = SessionRegistry()
+    registry.register(
+        _make_session("aaaa-uuid-1", project_path="/home/user/projects/my_game/")
+    )
+    registry.register(
+        _make_session("bbbb-uuid-2", project_path="/tmp/other/")
+    )
+    runtime = DirectRuntime(registry=registry, client=StubClient())
+
+    result = session_handlers.session_activate(runtime, "projects")
+
+    assert result["status"] == "ok"
+    assert result["active_session_id"] == "aaaa-uuid-1"
+
+
+def test_session_activate_ambiguous_hint_errors_with_candidates():
+    registry = SessionRegistry()
+    registry.register(
+        _make_session("aaaa-uuid", project_path="/home/user/game_project_one/")
+    )
+    registry.register(
+        _make_session("bbbb-uuid", project_path="/home/user/game_project_two/")
+    )
+    runtime = DirectRuntime(registry=registry, client=StubClient())
+
+    result = session_handlers.session_activate(runtime, "game_project")
+
+    assert result["status"] == "error"
+    assert "matched 2 sessions" in result["message"]
+    assert len(result["candidates"]) == 2
+    candidate_ids = {candidate["session_id"] for candidate in result["candidates"]}
+    assert candidate_ids == {"aaaa-uuid", "bbbb-uuid"}
+
+
+def test_session_activate_exact_id_wins_over_substring_ambiguity():
+    """If a hint equals one session's id exactly, it wins even if the string
+    would otherwise match other sessions as a substring."""
+    registry = SessionRegistry()
+    registry.register(_make_session("test", project_path="/tmp/test_one/"))
+    registry.register(_make_session("xyz", project_path="/tmp/test_two/"))
+    runtime = DirectRuntime(registry=registry, client=StubClient())
+
+    result = session_handlers.session_activate(runtime, "test")
+
+    assert result["status"] == "ok"
+    assert result["matched"] == "exact_id"
+    assert result["active_session_id"] == "test"
+
+
+def test_session_activate_no_match_lists_available_sessions():
+    registry = SessionRegistry()
+    registry.register(_make_session("aaaa", project_path="/home/user/game/"))
+    runtime = DirectRuntime(registry=registry, client=StubClient())
+
+    result = session_handlers.session_activate(runtime, "nomatch")
+
+    assert result["status"] == "error"
+    assert len(result["available"]) == 1
+    assert result["available"][0]["name"] == "game"
+
+
+def test_session_activate_empty_hint_does_not_match_any():
+    registry = SessionRegistry()
+    registry.register(_make_session("aaaa"))
+    runtime = DirectRuntime(registry=registry, client=StubClient())
+
+    result = session_handlers.session_activate(runtime, "")
+
+    assert result["status"] == "error"
 
 
 def test_session_resource_data_delegates_to_session_list():

--- a/tests/unit/test_session_registry.py
+++ b/tests/unit/test_session_registry.py
@@ -41,13 +41,25 @@ class TestSessionRegistry:
 
         assert reg.active_session_id == "a"
 
-    def test_unregister_active_falls_back(self):
+    def test_unregister_active_clears_active(self):
+        ## Disconnect of the active session must NOT silently promote another
+        ## session to active — that would route commands to whichever session
+        ## was registered first, which is the 'multi-instance routing' bug.
         reg = SessionRegistry()
         reg.register(_make_session("a"))
         reg.register(_make_session("b"))
         reg.unregister("a")
 
-        assert reg.active_session_id == "b"
+        assert reg.active_session_id is None
+        assert len(reg) == 1
+
+    def test_unregister_non_active_leaves_active(self):
+        reg = SessionRegistry()
+        reg.register(_make_session("a"))
+        reg.register(_make_session("b"))
+        reg.unregister("b")
+
+        assert reg.active_session_id == "a"
         assert len(reg) == 1
 
     def test_unregister_last_clears_active(self):
@@ -87,6 +99,44 @@ class TestSessionRegistry:
         assert d["godot_version"] == "4.4.1"
         assert d["project_path"] == "/tmp/test_project"
         assert "connected_at" in d
+        assert "last_seen" in d
+        assert d["name"] == "test_project"
+        assert d["editor_pid"] == 0
+
+
+class TestSessionMetadata:
+    def test_name_derived_from_project_path(self):
+        s = _make_session(project_path="/Users/me/projects/my_game/")
+        assert s.name == "my_game"
+
+    def test_name_strips_trailing_slash(self):
+        s = _make_session(project_path="/tmp/test_project")
+        assert s.name == "test_project"
+
+    def test_name_handles_windows_path(self):
+        s = _make_session(project_path="C:\\Users\\me\\my_game\\")
+        assert s.name == "my_game"
+
+    def test_name_falls_back_to_session_id_prefix_when_path_empty(self):
+        s = _make_session("abcdef1234567890", project_path="")
+        assert s.name == "abcdef12"
+
+    def test_editor_pid_defaults_to_zero(self):
+        s = _make_session()
+        assert s.editor_pid == 0
+
+    def test_editor_pid_stored(self):
+        s = _make_session(editor_pid=12345)
+        assert s.editor_pid == 12345
+
+    def test_touch_updates_last_seen(self):
+        s = _make_session()
+        original = s.last_seen
+        ## busy-wait a tiny amount to guarantee timestamp delta
+        import time
+        time.sleep(0.001)
+        s.touch()
+        assert s.last_seen > original
 
 
 class TestWaitForSession:


### PR DESCRIPTION
## Summary

- **Per-call session routing** — every Godot-talking MCP tool now accepts an optional `session_id` param. Empty = active (current behavior); set = pin that single call to the named session. Two AI clients sharing one MCP server can finally target different editors without stomping each other's active.
- **Human-readable session IDs** — plugin generates `<project-slug>@<4hex>` (e.g. `godot-ai@a3f2`) instead of 32-char random hex. Agents can recognize the target from the slug; the suffix disambiguates same-project twins.
- **Multi-session reliability finished** — `SessionRegistry` gains `editor_pid`, `last_seen`, `name`, `touch()`, `wait_for_session`; `session_activate` accepts substring hints; reload handler pins `old_id` to avoid active-session races.

Binding happens once at `DirectRuntime` construction, so `require_writable` and every handler inside the call see the pinned session — no way to accidentally mix bound and unbound sources within a single call. Handler signatures and the `Runtime` Protocol are unchanged; only the tool-registration layer and `DirectRuntime` move.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `pytest -v` — 310/310 pass (+6 new: DirectRuntime binding, cross-session MCP routing with readiness gating)
- [x] `test_run` via MCP (GDScript) — 227/227 pass (+10 new: SID/slug format)
- [x] **Live two-editor smoke test** with `test_project` + `project-boost` sharing one MCP server:
  - [x] `session_list` shows both with readable IDs
  - [x] reads, writes, renames, reparents, script attach/create all route correctly with explicit `session_id`
  - [x] cross-session negative lookup (wrong-project path + wrong session_id) returns `Node not found` — proves routing, not fallthrough
  - [x] `find` results perfectly disjoint between sessions
  - [x] undo stacks stay scoped per-editor (Ctrl+Z in project-boost undoes only its own node)

## Notes

- Resources (`godot://...`) still resolve via active session — resources can't take per-call params. Noted in CLAUDE.md.
- `session_list` and `session_activate` intentionally do NOT take `session_id` — they operate on the registry itself.
- Client tools (`client_configure`, `client_status`) configure the local AI client, not Godot — also excluded.
- Discovered an unrelated bug during the live smoke test: list-typed parameters arrive as JSON strings when invoked from Claude Code's MCP client (pydantic `list_type` validation fails). Filed separately as #11.
