### PR TITLE
Prepare PyPI packaging: metadata, --version flag, release-smoke CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,67 @@ jobs:
       - name: Lint
         run: ruff check src/ tests/
 
+  release-smoke:
+    name: Release smoke / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Install built wheel in a clean venv
+        shell: bash
+        run: |
+          venv="${RUNNER_TEMP}/smoke-venv"
+          python -m venv "$venv"
+          if [ -f "$venv/bin/pip" ]; then
+            PIP="$venv/bin/pip"
+            GODOT_AI="$venv/bin/godot-ai"
+          else
+            PIP="$venv/Scripts/pip.exe"
+            GODOT_AI="$venv/Scripts/godot-ai.exe"
+          fi
+          "$PIP" install --upgrade pip
+          "$PIP" install dist/*.whl
+          "$GODOT_AI" --version
+          "$GODOT_AI" --help
+
+      - name: Install built sdist in a clean venv
+        shell: bash
+        run: |
+          venv="${RUNNER_TEMP}/smoke-sdist-venv"
+          python -m venv "$venv"
+          if [ -f "$venv/bin/pip" ]; then
+            PIP="$venv/bin/pip"
+            GODOT_AI="$venv/bin/godot-ai"
+          else
+            PIP="$venv/Scripts/pip.exe"
+            GODOT_AI="$venv/Scripts/godot-ai.exe"
+          fi
+          "$PIP" install --upgrade pip
+          "$PIP" install dist/*.tar.gz
+          "$GODOT_AI" --version
+
+      - name: Upload build artifacts
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
   godot-tests-linux:
     name: Godot tests / Linux
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,15 +70,16 @@ jobs:
         run: |
           venv="${RUNNER_TEMP}/smoke-venv"
           python -m venv "$venv"
-          if [ -f "$venv/bin/pip" ]; then
-            PIP="$venv/bin/pip"
+          if [ -x "$venv/bin/python" ]; then
+            PY="$venv/bin/python"
             GODOT_AI="$venv/bin/godot-ai"
           else
-            PIP="$venv/Scripts/pip.exe"
+            PY="$venv/Scripts/python.exe"
             GODOT_AI="$venv/Scripts/godot-ai.exe"
           fi
-          "$PIP" install --upgrade pip
-          "$PIP" install dist/*.whl
+          # Use `python -m pip` rather than the pip executable — on Windows,
+          # pip.exe can't replace itself mid-upgrade, which breaks smoke tests.
+          "$PY" -m pip install dist/*.whl
           "$GODOT_AI" --version
           "$GODOT_AI" --help
 
@@ -87,15 +88,14 @@ jobs:
         run: |
           venv="${RUNNER_TEMP}/smoke-sdist-venv"
           python -m venv "$venv"
-          if [ -f "$venv/bin/pip" ]; then
-            PIP="$venv/bin/pip"
+          if [ -x "$venv/bin/python" ]; then
+            PY="$venv/bin/python"
             GODOT_AI="$venv/bin/godot-ai"
           else
-            PIP="$venv/Scripts/pip.exe"
+            PY="$venv/Scripts/python.exe"
             GODOT_AI="$venv/Scripts/godot-ai.exe"
           fi
-          "$PIP" install --upgrade pip
-          "$PIP" install dist/*.tar.gz
+          "$PY" -m pip install dist/*.tar.gz
           "$GODOT_AI" --version
 
       - name: Upload build artifacts

--- a/docs/packaging-distribution.md
+++ b/docs/packaging-distribution.md
@@ -126,10 +126,12 @@ The install docs should explicitly cover:
 ## PyPI / `uvx` Publishing Work
 
 - [ ] verify `godot-ai` package availability and ownership
-- [ ] finalize metadata in `pyproject.toml`
+- [x] finalize metadata in `pyproject.toml` — authors, keywords, classifiers, project URLs, markdown readme content-type
 - [ ] publish to PyPI
 - [ ] verify `uvx godot-ai --help`
 - [ ] verify the plugin can discover and launch the published package cleanly
+
+CI release-smoke builds the wheel and sdist on every push, installs each into a clean venv, and invokes `godot-ai --version` / `--help` to catch entry-point and packaging regressions before publishing.
 
 The published package path should be treated as first-class, not as a fallback for people who “know Python.”
 
@@ -182,10 +184,10 @@ The binary path is only worth keeping if it remains boring and supportable.
 
 ### Tier 3: Release-Surface Smoke
 
-- verify `uvx godot-ai` path
-- verify package install path
-- verify binary startup path
-- verify AssetLib-installed plugin loads and connects to the server
+- [ ] verify `uvx godot-ai` path
+- [x] verify package install path — `release-smoke` job in `.github/workflows/ci.yml` builds wheel + sdist, installs both into a fresh venv on Linux/macOS/Windows, and runs the CLI entry point
+- [ ] verify binary startup path
+- [ ] verify AssetLib-installed plugin loads and connects to the server
 
 This tier is about install confidence, not deep correctness.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,13 +2,44 @@
 name = "godot-ai"
 version = "0.0.1"
 description = "Production-grade MCP server and AI tools for the Godot engine"
-readme = "README.md"
+readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"
+authors = [{ name = "Godot AI contributors" }]
+keywords = [
+    "godot",
+    "godot-engine",
+    "mcp",
+    "model-context-protocol",
+    "ai",
+    "llm",
+    "gamedev",
+    "editor-plugin",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Games/Entertainment",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Software Development :: Code Generators",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Operating System :: OS Independent",
+    "Environment :: Console",
+    "Framework :: AsyncIO",
+]
 dependencies = [
     "fastmcp>=3.0.0",
     "websockets>=13.0",
     "pydantic>=2.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/hi-godot/godot-ai"
+Repository = "https://github.com/hi-godot/godot-ai"
+Issues = "https://github.com/hi-godot/godot-ai/issues"
+Documentation = "https://github.com/hi-godot/godot-ai#readme"
 
 [project.optional-dependencies]
 dev = [

--- a/src/godot_ai/__init__.py
+++ b/src/godot_ai/__init__.py
@@ -11,6 +11,11 @@ __version__ = "0.0.1"
 def main(argv: Sequence[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Godot AI server")
     parser.add_argument(
+        "--version",
+        action="version",
+        version=f"godot-ai {__version__}",
+    )
+    parser.add_argument(
         "--transport",
         choices=["stdio", "sse", "streamable-http"],
         default="stdio",

--- a/tests/unit/test_cli_reload.py
+++ b/tests/unit/test_cli_reload.py
@@ -107,6 +107,14 @@ def test_main_runs_server_directly_without_reload(monkeypatch):
     assert server.run_calls == [{"transport": "streamable-http", "port": 8123}]
 
 
+def test_main_version_flag(capsys):
+    with pytest.raises(SystemExit) as excinfo:
+        godot_ai.main(["--version"])
+    assert excinfo.value.code == 0
+    captured = capsys.readouterr()
+    assert f"godot-ai {godot_ai.__version__}" in captured.out
+
+
 def test_get_dev_transport_rejects_unsupported(monkeypatch):
     monkeypatch.setenv(asgi.DEV_TRANSPORT_ENV, "stdio")
     with pytest.raises(ValueError, match="Unsupported dev transport"):


### PR DESCRIPTION
Phase 4 groundwork for publishing godot-ai to PyPI.

- pyproject.toml: add authors, keywords, classifiers, project URLs, and
  an explicit markdown content-type for the readme so PyPI renders it.
- godot_ai.main: add --version, so install smoke tests have a cheap
  probe for "the CLI entry point actually works."
- CI: add a release-smoke job on Linux/macOS/Windows that builds the
  wheel and sdist with `python -m build`, installs each into a clean
  venv, and runs `godot-ai --version` / `--help`. Catches packaging and
  entry-point regressions before we push to PyPI.
- docs/packaging-distribution.md: mark the metadata and package-install
  smoke items done, and note that the binary and uvx paths are still
  TODO.

Note: no LICENSE file has been added — that's a project-policy decision
I am deliberately leaving to the maintainers, and PyPI publishing will
want one before release.