### PR TITLE
Add ui_set_anchor_preset — Control layout presets for HUD and menus

### DIFF
--- a/plugin/addons/godot_ai/handlers/ui_handler.gd
+++ b/plugin/addons/godot_ai/handlers/ui_handler.gd
@@ -1,0 +1,138 @@
+@tool
+class_name UiHandler
+extends RefCounted
+
+## Handles UI-specific (Control) layout helpers: anchor presets, etc.
+##
+## Anchors/offsets are the worst part of Control layout to set one-property-at-a-time.
+## This handler wraps Godot's built-in presets (FULL_RECT, CENTER, TOP_LEFT, ...) so
+## callers can set a whole layout with one command, with proper undo.
+
+var _undo_redo: EditorUndoRedoManager
+
+
+const _PRESETS := {
+	"top_left": Control.PRESET_TOP_LEFT,
+	"top_right": Control.PRESET_TOP_RIGHT,
+	"bottom_left": Control.PRESET_BOTTOM_LEFT,
+	"bottom_right": Control.PRESET_BOTTOM_RIGHT,
+	"center_left": Control.PRESET_CENTER_LEFT,
+	"center_top": Control.PRESET_CENTER_TOP,
+	"center_right": Control.PRESET_CENTER_RIGHT,
+	"center_bottom": Control.PRESET_CENTER_BOTTOM,
+	"center": Control.PRESET_CENTER,
+	"left_wide": Control.PRESET_LEFT_WIDE,
+	"top_wide": Control.PRESET_TOP_WIDE,
+	"right_wide": Control.PRESET_RIGHT_WIDE,
+	"bottom_wide": Control.PRESET_BOTTOM_WIDE,
+	"vcenter_wide": Control.PRESET_VCENTER_WIDE,
+	"hcenter_wide": Control.PRESET_HCENTER_WIDE,
+	"full_rect": Control.PRESET_FULL_RECT,
+}
+
+const _RESIZE_MODES := {
+	"minsize": Control.PRESET_MODE_MINSIZE,
+	"keep_width": Control.PRESET_MODE_KEEP_WIDTH,
+	"keep_height": Control.PRESET_MODE_KEEP_HEIGHT,
+	"keep_size": Control.PRESET_MODE_KEEP_SIZE,
+}
+
+const _ANCHOR_OFFSET_PROPS := [
+	"anchor_left", "anchor_top", "anchor_right", "anchor_bottom",
+	"offset_left", "offset_top", "offset_right", "offset_bottom",
+]
+
+
+func _init(undo_redo: EditorUndoRedoManager) -> void:
+	_undo_redo = undo_redo
+
+
+## Apply a Control layout preset (anchors + offsets) to a UI node.
+##
+## Params:
+##   path        - scene path to a Control node (required)
+##   preset      - preset name: full_rect, center, top_left, ... (required)
+##   resize_mode - minsize | keep_width | keep_height | keep_size (default: minsize)
+##   margin      - integer margin in pixels from the anchor edges (default: 0)
+func set_anchor_preset(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("path", "")
+	if node_path.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: path")
+
+	var preset_name: String = str(params.get("preset", "")).to_lower()
+	if preset_name.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: preset")
+	if not _PRESETS.has(preset_name):
+		var names := _PRESETS.keys()
+		names.sort()
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Unknown preset '%s'. Valid: %s" % [preset_name, ", ".join(names)]
+		)
+
+	var resize_mode_name: String = str(params.get("resize_mode", "minsize")).to_lower()
+	if not _RESIZE_MODES.has(resize_mode_name):
+		var names := _RESIZE_MODES.keys()
+		names.sort()
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Unknown resize_mode '%s'. Valid: %s" % [resize_mode_name, ", ".join(names)]
+		)
+
+	var margin: int = int(params.get("margin", 0))
+
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+
+	var node := ScenePath.resolve(node_path, scene_root)
+	if node == null:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % node_path)
+	if not node is Control:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Node %s is not a Control (got %s)" % [node_path, node.get_class()]
+		)
+
+	var control := node as Control
+	var preset_value: int = _PRESETS[preset_name]
+	var resize_mode_value: int = _RESIZE_MODES[resize_mode_name]
+
+	# Snapshot before so we can undo every property the preset may have touched.
+	var before: Dictionary = {}
+	for prop in _ANCHOR_OFFSET_PROPS:
+		before[prop] = control.get(prop)
+
+	_undo_redo.create_action("MCP: Set %s anchor preset %s" % [control.name, preset_name])
+	_undo_redo.add_do_method(
+		control, "set_anchors_and_offsets_preset", preset_value, resize_mode_value, margin
+	)
+	for prop in _ANCHOR_OFFSET_PROPS:
+		_undo_redo.add_undo_property(control, prop, before[prop])
+	_undo_redo.commit_action()
+
+	var after: Dictionary = {}
+	for prop in _ANCHOR_OFFSET_PROPS:
+		after[prop] = control.get(prop)
+
+	return {
+		"data": {
+			"path": node_path,
+			"preset": preset_name,
+			"resize_mode": resize_mode_name,
+			"margin": margin,
+			"anchors": {
+				"left": after.anchor_left,
+				"top": after.anchor_top,
+				"right": after.anchor_right,
+				"bottom": after.anchor_bottom,
+			},
+			"offsets": {
+				"left": after.offset_left,
+				"top": after.offset_top,
+				"right": after.offset_right,
+				"bottom": after.offset_bottom,
+			},
+			"undoable": true,
+		}
+	}

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -31,7 +31,8 @@ func _enter_tree() -> void:
 	var input_handler := InputHandler.new()
 	var test_handler := TestHandler.new(get_undo_redo(), _log_buffer)
 	var batch_handler := BatchHandler.new(_dispatcher, get_undo_redo())
-	_handlers = [editor_handler, scene_handler, node_handler, project_handler, client_handler, script_handler, resource_handler, filesystem_handler, signal_handler, autoload_handler, input_handler, test_handler, batch_handler]
+	var ui_handler := UiHandler.new(get_undo_redo())
+	_handlers = [editor_handler, scene_handler, node_handler, project_handler, client_handler, script_handler, resource_handler, filesystem_handler, signal_handler, autoload_handler, input_handler, test_handler, batch_handler, ui_handler]
 
 	_dispatcher.register("get_editor_state", editor_handler.get_editor_state)
 	_dispatcher.register("get_scene_tree", scene_handler.get_scene_tree)
@@ -93,6 +94,7 @@ func _enter_tree() -> void:
 	_dispatcher.register("run_tests", test_handler.run_tests)
 	_dispatcher.register("get_test_results", test_handler.get_test_results)
 	_dispatcher.register("batch_execute", batch_handler.batch_execute)
+	_dispatcher.register("set_anchor_preset", ui_handler.set_anchor_preset)
 
 	_connection.dispatcher = _dispatcher
 	add_child(_connection)

--- a/src/godot_ai/handlers/ui.py
+++ b/src/godot_ai/handlers/ui.py
@@ -1,0 +1,25 @@
+"""Shared handlers for UI (Control layout) tools."""
+
+from __future__ import annotations
+
+from godot_ai.handlers._readiness import require_writable
+from godot_ai.runtime.interface import Runtime
+
+
+async def ui_set_anchor_preset(
+    runtime: Runtime,
+    path: str,
+    preset: str,
+    resize_mode: str = "minsize",
+    margin: int = 0,
+) -> dict:
+    require_writable(runtime)
+    return await runtime.send_command(
+        "set_anchor_preset",
+        {
+            "path": path,
+            "preset": preset,
+            "resize_mode": resize_mode,
+            "margin": margin,
+        },
+    )

--- a/src/godot_ai/server.py
+++ b/src/godot_ai/server.py
@@ -30,6 +30,7 @@ from godot_ai.tools.script import register_script_tools
 from godot_ai.tools.session import register_session_tools
 from godot_ai.tools.signal import register_signal_tools
 from godot_ai.tools.testing import register_testing_tools
+from godot_ai.tools.ui import register_ui_tools
 from godot_ai.transport.websocket import GodotWebSocketServer
 
 logger = logging.getLogger(__name__)
@@ -84,6 +85,7 @@ def create_server(ws_port: int = 9500) -> FastMCP:
             "  logs_*           — read or clear the editor log buffer\n"
             "  test_*           — run GDScript test suites and fetch results\n"
             "  batch_execute    — compose multi-step scene edits atomically\n"
+            "  ui_*             — Control layout helpers (anchor presets for HUD / menus)\n"
             "  client_*         — configure AI clients (Claude Code, Codex, Antigravity)\n\n"
             "Always connect to an editor session first (session_list / session_activate). "
             "Write operations require session readiness; check editor_state if a call is "
@@ -106,6 +108,7 @@ def create_server(ws_port: int = 9500) -> FastMCP:
     register_input_map_tools(mcp)
     register_testing_tools(mcp)
     register_batch_tools(mcp)
+    register_ui_tools(mcp)
     register_session_resources(mcp)
     register_scene_resources(mcp)
     register_editor_resources(mcp)

--- a/src/godot_ai/tools/ui.py
+++ b/src/godot_ai/tools/ui.py
@@ -1,0 +1,54 @@
+"""MCP tools for UI (Control) authoring — HUD, pause menu, upgrade screens, etc."""
+
+from __future__ import annotations
+
+from fastmcp import Context, FastMCP
+
+from godot_ai.handlers import ui as ui_handlers
+from godot_ai.runtime.direct import DirectRuntime
+from godot_ai.tools import DEFER_META
+
+
+def register_ui_tools(mcp: FastMCP) -> None:
+    @mcp.tool(meta=DEFER_META)
+    async def ui_set_anchor_preset(
+        ctx: Context,
+        path: str,
+        preset: str,
+        resize_mode: str = "minsize",
+        margin: int = 0,
+        session_id: str = "",
+    ) -> dict:
+        """Apply a Control layout preset (anchors and offsets) to a UI node.
+
+        Wraps Godot's Control.set_anchors_and_offsets_preset — the fast way to
+        pin a HUD element, panel, pause menu, upgrade draft screen, or game-over
+        overlay to an edge, corner, or the full viewport. Much simpler than
+        setting anchor_left / anchor_top / anchor_right / anchor_bottom and the
+        four offset_* properties one at a time.
+
+        The target node must be a Control (or subclass — Panel, Label, Button,
+        Container, VBoxContainer, HBoxContainer, MarginContainer, etc.). Change
+        is undoable.
+
+        Args:
+            path: Scene path to a Control node (e.g. "/Main/HUD/HealthBar").
+            preset: Layout preset name. One of:
+                top_left, top_right, bottom_left, bottom_right,
+                center_left, center_top, center_right, center_bottom, center,
+                left_wide, top_wide, right_wide, bottom_wide,
+                vcenter_wide, hcenter_wide, full_rect.
+            resize_mode: How the existing size is handled when applying the
+                preset. One of: minsize (default — resize to minimum),
+                keep_width, keep_height, keep_size.
+            margin: Margin in pixels from the anchor edges. Default 0.
+            session_id: Optional Godot session to target. Empty = active session.
+        """
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
+        return await ui_handlers.ui_set_anchor_preset(
+            runtime,
+            path=path,
+            preset=preset,
+            resize_mode=resize_mode,
+            margin=margin,
+        )

--- a/test_project/tests/test_ui.gd
+++ b/test_project/tests/test_ui.gd
@@ -1,0 +1,190 @@
+@tool
+extends McpTestSuite
+
+## Tests for UiHandler — Control layout helpers (anchor presets).
+
+var _handler: UiHandler
+var _undo_redo: EditorUndoRedoManager
+
+
+func suite_name() -> String:
+	return "ui"
+
+
+func suite_setup(ctx: Dictionary) -> void:
+	_undo_redo = ctx.get("undo_redo")
+	_handler = UiHandler.new(_undo_redo)
+
+
+# Create a Control named `TestHudPanel` under the scene root for a single test.
+# Returns the path, or empty string if the scene isn't ready.
+func _add_control(ctl_name: String = "TestHudPanel") -> String:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return ""
+	var panel := Panel.new()
+	panel.name = ctl_name
+	scene_root.add_child(panel)
+	panel.owner = scene_root
+	return "/" + scene_root.name + "/" + ctl_name
+
+
+func _remove_control(path: String) -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return
+	var node := ScenePath.resolve(path, scene_root)
+	if node != null:
+		node.get_parent().remove_child(node)
+		node.queue_free()
+
+
+# ----- set_anchor_preset: happy path -----
+
+func test_set_anchor_preset_full_rect() -> void:
+	var path := _add_control("TestUiFullRect")
+	if path.is_empty():
+		return
+	var result := _handler.set_anchor_preset({"path": path, "preset": "full_rect"})
+	assert_has_key(result, "data")
+	assert_eq(result.data.preset, "full_rect")
+	assert_eq(result.data.anchors.left, 0.0)
+	assert_eq(result.data.anchors.top, 0.0)
+	assert_eq(result.data.anchors.right, 1.0)
+	assert_eq(result.data.anchors.bottom, 1.0)
+	assert_true(result.data.undoable)
+	_remove_control(path)
+
+
+func test_set_anchor_preset_center() -> void:
+	var path := _add_control("TestUiCenter")
+	if path.is_empty():
+		return
+	var result := _handler.set_anchor_preset({"path": path, "preset": "center"})
+	assert_has_key(result, "data")
+	assert_eq(result.data.anchors.left, 0.5)
+	assert_eq(result.data.anchors.top, 0.5)
+	assert_eq(result.data.anchors.right, 0.5)
+	assert_eq(result.data.anchors.bottom, 0.5)
+	_remove_control(path)
+
+
+func test_set_anchor_preset_top_left_with_margin() -> void:
+	var path := _add_control("TestUiTopLeftMargin")
+	if path.is_empty():
+		return
+	var result := _handler.set_anchor_preset({
+		"path": path, "preset": "top_left", "margin": 8
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.margin, 8)
+	assert_eq(result.data.anchors.left, 0.0)
+	assert_eq(result.data.anchors.top, 0.0)
+	# offset_left/top should be shifted by the margin
+	assert_eq(result.data.offsets.left, 8.0)
+	assert_eq(result.data.offsets.top, 8.0)
+	_remove_control(path)
+
+
+func test_set_anchor_preset_accepts_mixed_case() -> void:
+	var path := _add_control("TestUiMixedCase")
+	if path.is_empty():
+		return
+	var result := _handler.set_anchor_preset({"path": path, "preset": "Full_Rect"})
+	assert_has_key(result, "data")
+	assert_eq(result.data.preset, "full_rect")
+	_remove_control(path)
+
+
+func test_set_anchor_preset_keep_size_mode() -> void:
+	var path := _add_control("TestUiKeepSize")
+	if path.is_empty():
+		return
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var node := ScenePath.resolve(path, scene_root)
+	(node as Control).size = Vector2(100, 50)
+	var result := _handler.set_anchor_preset({
+		"path": path, "preset": "center", "resize_mode": "keep_size"
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.resize_mode, "keep_size")
+	# With keep_size on PRESET_CENTER, width/height should remain 100/50.
+	var size := (node as Control).size
+	assert_eq(size.x, 100.0)
+	assert_eq(size.y, 50.0)
+	_remove_control(path)
+
+
+# ----- set_anchor_preset: validation errors -----
+
+func test_set_anchor_preset_missing_path() -> void:
+	var result := _handler.set_anchor_preset({"preset": "full_rect"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_set_anchor_preset_missing_preset() -> void:
+	var path := _add_control("TestUiMissingPreset")
+	if path.is_empty():
+		return
+	var result := _handler.set_anchor_preset({"path": path})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	_remove_control(path)
+
+
+func test_set_anchor_preset_unknown_preset() -> void:
+	var path := _add_control("TestUiUnknownPreset")
+	if path.is_empty():
+		return
+	var result := _handler.set_anchor_preset({"path": path, "preset": "not_a_preset"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	# Error message should list valid options so the agent can recover.
+	assert_contains(result.error.message, "full_rect")
+	_remove_control(path)
+
+
+func test_set_anchor_preset_unknown_resize_mode() -> void:
+	var path := _add_control("TestUiUnknownResize")
+	if path.is_empty():
+		return
+	var result := _handler.set_anchor_preset({
+		"path": path, "preset": "center", "resize_mode": "stretch"
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	_remove_control(path)
+
+
+func test_set_anchor_preset_unknown_node() -> void:
+	var result := _handler.set_anchor_preset({
+		"path": "/DoesNotExist", "preset": "full_rect"
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_set_anchor_preset_non_control_node() -> void:
+	# Scene root in the test project is a Node3D, not a Control.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return
+	var result := _handler.set_anchor_preset({
+		"path": "/" + scene_root.name, "preset": "full_rect"
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "not a Control")
+
+
+# ----- undo -----
+
+func test_set_anchor_preset_is_undoable() -> void:
+	var path := _add_control("TestUiUndo")
+	if path.is_empty():
+		return
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var ctl := ScenePath.resolve(path, scene_root) as Control
+	var before_left := ctl.anchor_left
+	var before_right := ctl.anchor_right
+	_handler.set_anchor_preset({"path": path, "preset": "full_rect"})
+	assert_eq(ctl.anchor_right, 1.0, "Apply should change anchor_right")
+	_undo_redo.undo()
+	assert_eq(ctl.anchor_left, before_left, "Undo should restore anchor_left")
+	assert_eq(ctl.anchor_right, before_right, "Undo should restore anchor_right")
+	_remove_control(path)

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -2694,3 +2694,81 @@ class TestJsonStringParamCoercion:
         error_text = str(result.content).lower()
         assert "paths" in error_text
         assert "input should be a valid list" in error_text or "list_type" in error_text
+
+
+# ---------------------------------------------------------------------------
+# ui_set_anchor_preset
+# ---------------------------------------------------------------------------
+
+
+class TestUiSetAnchorPresetTool:
+    async def test_defaults_resize_mode_and_margin(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "set_anchor_preset"
+            assert cmd["params"] == {
+                "path": "/Main/HUD",
+                "preset": "full_rect",
+                "resize_mode": "minsize",
+                "margin": 0,
+            }
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "path": "/Main/HUD",
+                    "preset": "full_rect",
+                    "resize_mode": "minsize",
+                    "margin": 0,
+                    "anchors": {"left": 0.0, "top": 0.0, "right": 1.0, "bottom": 1.0},
+                    "offsets": {"left": 0.0, "top": 0.0, "right": 0.0, "bottom": 0.0},
+                    "undoable": True,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "ui_set_anchor_preset",
+            {"path": "/Main/HUD", "preset": "full_rect"},
+        )
+        await task
+
+        assert result.data["preset"] == "full_rect"
+        assert result.data["anchors"]["right"] == 1.0
+        assert result.data["undoable"] is True
+
+    async def test_passes_resize_mode_and_margin(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["params"]["resize_mode"] == "keep_size"
+            assert cmd["params"]["margin"] == 16
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "path": "/Main/HUD/Panel",
+                    "preset": "center",
+                    "resize_mode": "keep_size",
+                    "margin": 16,
+                    "anchors": {"left": 0.5, "top": 0.5, "right": 0.5, "bottom": 0.5},
+                    "offsets": {"left": -50.0, "top": -25.0, "right": 50.0, "bottom": 25.0},
+                    "undoable": True,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "ui_set_anchor_preset",
+            {
+                "path": "/Main/HUD/Panel",
+                "preset": "center",
+                "resize_mode": "keep_size",
+                "margin": 16,
+            },
+        )
+        await task
+
+        assert result.data["margin"] == 16
+        assert result.data["resize_mode"] == "keep_size"

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -18,6 +18,7 @@ from godot_ai.handlers import script as script_handlers
 from godot_ai.handlers import session as session_handlers
 from godot_ai.handlers import signal as signal_handlers
 from godot_ai.handlers import testing as testing_handlers
+from godot_ai.handlers import ui as ui_handlers
 from godot_ai.runtime.direct import DirectRuntime
 from godot_ai.sessions.registry import Session, SessionRegistry
 
@@ -324,6 +325,16 @@ class StubClient:
                 "name": params.get("name", ""),
                 "removed": True,
                 "undoable": False,
+            }
+        if command == "set_anchor_preset":
+            return {
+                "path": params.get("path", ""),
+                "preset": params.get("preset", ""),
+                "resize_mode": params.get("resize_mode", "minsize"),
+                "margin": params.get("margin", 0),
+                "anchors": {"left": 0.0, "top": 0.0, "right": 1.0, "bottom": 1.0},
+                "offsets": {"left": 0.0, "top": 0.0, "right": 0.0, "bottom": 0.0},
+                "undoable": True,
             }
         if command == "list_actions":
             return {
@@ -1954,3 +1965,43 @@ async def test_batch_execute_rejects_empty_list():
     result = await batch_handlers.batch_execute(runtime, commands=[])
     assert result["error"]["code"] == "INVALID_PARAMS"
     assert not client.calls
+
+
+# ---------------------------------------------------------------------------
+# UI handler tests
+# ---------------------------------------------------------------------------
+
+
+async def test_ui_set_anchor_preset_handler_defaults():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await ui_handlers.ui_set_anchor_preset(
+        runtime, path="/Main/HUD", preset="full_rect"
+    )
+    assert client.calls[-1]["command"] == "set_anchor_preset"
+    assert client.calls[-1]["params"] == {
+        "path": "/Main/HUD",
+        "preset": "full_rect",
+        "resize_mode": "minsize",
+        "margin": 0,
+    }
+    assert result["preset"] == "full_rect"
+    assert result["undoable"] is True
+
+
+async def test_ui_set_anchor_preset_handler_passes_resize_mode_and_margin():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    await ui_handlers.ui_set_anchor_preset(
+        runtime,
+        path="/Main/Hud/Panel",
+        preset="center",
+        resize_mode="keep_size",
+        margin=12,
+    )
+    assert client.calls[-1]["params"] == {
+        "path": "/Main/Hud/Panel",
+        "preset": "center",
+        "resize_mode": "keep_size",
+        "margin": 12,
+    }


### PR DESCRIPTION
First entry in the `ui_*` tool family from the plan's Tier 1 "needed for better 2D game production" list. Wraps `Control.set_anchors_and_offsets_preset` so agents can pin a HUD element, pause menu, or upgrade-draft panel to an edge / corner / full rect with one call instead of eight coupled property sets.

## Summary

- `plugin/addons/godot_ai/handlers/ui_handler.gd` — maps string preset names (`full_rect`, `center`, `top_left`, `top_right`, `bottom_left`, `bottom_right`, `center_left`, `center_top`, `center_right`, `center_bottom`, `left_wide`, `top_wide`, `right_wide`, `bottom_wide`, `vcenter_wide`, `hcenter_wide`) and resize-mode names (`minsize`, `keep_size`, `keep_width`, `keep_height`) to the `Control` enums, validates the node is a `Control`, and records an undo that restores all 8 anchor/offset properties.
- `plugin.gd` registers `UiHandler` and dispatches `set_anchor_preset`.
- `src/godot_ai/tools/ui.py` + `handlers/ui.py` add the MCP tool `ui_set_anchor_preset` (defer-loaded, session-targetable, `require_writable` gating).
- `server.py` registers the tools and documents the `ui_*` namespace in the instructions blurb.

## Test plan

- [x] `ruff check` clean
- [x] 321 Python tests pass locally (4 new: handler-unit x2, tool-integration x2)
- [x] New GDScript suite `test_ui.gd` covers happy path (full_rect, center, top_left+margin, keep_size, mixed-case preset), validation errors (missing path, missing preset, unknown preset, unknown resize_mode, unknown node, non-Control target), and undo restoration — run in CI via `Godot tests / {Linux,macOS,Windows}`
- [ ] Live smoke against a real editor — Godot-side test suite runs in CI; can't exercise the editor interactively from the dev environment

## Notes

Deliberately scoped to one tool. Follow-up `ui_*` tools (text setter, container helpers, theme assignment) are next candidates from the same Tier 1 list but each wants its own design pass.
