### PR TITLE
Add theme_* authoring tools and ui_build_layout composer

### DIFF
--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -175,12 +175,36 @@ Use a small 2D top-down roguelite as the first benchmark, but keep it room-based
 - [x] create and mutate small Godot projects safely in the editor
 - [ ] support the kind of runtime iteration needed to make the benchmark feel good
 
+### UI Scenarios The Current Stack Can Already Scaffold
+
+With `ui_set_anchor_preset`, `ui_build_layout`, and the `theme_*` authoring
+family in place, an agent can one-shot a styled, anchored, undoable Control
+tree for each of these benchmark-relevant UI surfaces — `theme_*` defines the
+look once, `ui_build_layout` places it, `signal_connect` wires behavior:
+
+- **Roguelite HUD** — health bottom-left, ammo bottom-right, score / boss bar top-center, minimap / combo top-right; one theme applied at `/Main/HUD` styles everything inside
+- **Pause menu overlay** — full-rect dim panel, centered `VBoxContainer` with Resume / Settings / Quit buttons, themed hover/pressed states
+- **Upgrade-draft screen** — centered bordered `Panel` with three side-by-side `Button` cards; rounded corners, drop shadow, and border from one `theme_set_stylebox_flat`
+- **Game-over screen** — dim overlay, YOU DIED label, stats `Label` filled by the game script, Retry / MainMenu / Quit button row
+- **Settings menu** — dialog panel with labeled slider rows (`HBoxContainer` of Label + HSlider) for master/music/SFX volume, fullscreen `CheckBox`, uniform spacing via `theme_set_constant`
+- **Dialogue box** — `bottom_wide` panel with portrait `TextureRect`, name + message `RichTextLabel`, continue hint; game code mutates `.text` per line
+- **Main menu** — logo top-center, title centered, vertical stack of nav buttons
+- **Inventory grid** — `GridContainer` of themed `Panel` slots each holding an icon `TextureRect` and quantity `Label`; re-skinnable by swapping the theme
+- **Tutorial prompt** — small themed `Panel` anchored where the tutorial wants it, styled key-cap via stylebox, text mutated as the tutorial progresses
+- **Boss overlay** — `top_wide` panel with name Label, wide `ProgressBar` for health, horizontal row of phase indicators; phase color changes via a single `theme_set_color` update
+
+Each of these is a single-prompt target today. What these scenarios still
+cannot express is juice: hover animations, slide-ins, shake on damage, sound
+feedback, custom fonts, and pixel-art 9-slice buttons. Those are blocked by
+the `animation_player.*` / `audio.*` / `theme_set_font` / `theme_set_stylebox_texture` gaps
+tracked above.
+
 ### What Must Exist Before This Is A Fair Benchmark
 
 - [x] run/stop plus screenshot capture and basic performance sampling
 - [ ] `batch.execute` and a safe partial-edit story
 - [ ] data-authoring surface for upgrades, enemies, room data, and reusable scenes
-- [ ] `ui.*` for HUD and upgrade selection
+- [~] `ui.*` for HUD and upgrade selection — anchor presets, declarative `ui_build_layout` composer, and `theme_*` authoring shipped; still need `ui_set_text`, `theme_set_font`, `theme_set_stylebox_texture` for pixel-art / custom typography
 - [ ] `camera.*` for follow, bounds, zoom, and shake
 - [ ] `animation_player.*` and `audio.*` for combat readability and feel
 - [ ] `particles.*` / `shader.*` / `material.*` for hit juice and feedback clarity

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -122,10 +122,18 @@ These are not the next things to do blindly. They are the extensions that matter
 ### Tier 1: Needed for Better 2D Game Production
 
 - `ui.*` for HUDs, pause menus, upgrade draft screens, game-over flows, and theme/layout work
+  - [x] `ui_set_anchor_preset` — wrap `Control.set_anchors_and_offsets_preset`
+  - [x] `ui_build_layout` — declarative nested-dict → atomic Control subtree
+  - [x] `theme_create` / `theme_set_color` / `theme_set_constant` / `theme_set_font_size` / `theme_set_stylebox_flat` / `theme_apply` — Theme authoring (Godot's CSS-analog)
+  - [ ] `theme_set_stylebox_texture` — 9-slice image-backed styleboxes for pixel-art UI (buttons, panels with real artwork)
+  - [ ] `theme_set_font` + `theme_set_icon` — custom typography and icon sets (needs a Font / Texture2D resource handler first)
+  - [ ] `ui_set_text` convenience — one call to set `.text` across Label / Button / LineEdit / RichTextLabel without remembering per-class property quirks
 - `camera.*` for follow, bounds, zoom, and screen shake
 - `resource.create` / `resource.save` / `resource.instantiate`
 - `scene.instantiate` and `scene.inherit`
+  - [ ] critical path for reusable `button.tscn` / `enemy.tscn` instanced into many parent scenes — the piece that turns the UI composer and node_create flows into "real Godot project structure" instead of one-shot scene builds
 - `animation_player.*` / `animation_tree.*`
+  - [ ] needed for UI juice (hover pulse, slide-in menus, fade transitions), combat readability (shake on damage, hit-stop), and general feel — the current stack can build static HUDs but cannot animate them
 - `audio.*`
 
 ### Tier 2: Strong Polish Multipliers

--- a/plugin/addons/godot_ai/handlers/theme_handler.gd
+++ b/plugin/addons/godot_ai/handlers/theme_handler.gd
@@ -1,0 +1,377 @@
+@tool
+class_name ThemeHandler
+extends RefCounted
+
+## Handles Theme resource authoring: creating, modifying color/constant/font-size/
+## stylebox slots, and applying a theme to a Control subtree.
+##
+## Themes are Godot's equivalent of USS: a Theme holds (class, name) -> value
+## entries (colors, constants, fonts, font_sizes, styleboxes, icons) which
+## cascade down a Control subtree when the theme is assigned at any ancestor.
+## One well-authored theme replaces hundreds of per-node property sets.
+
+var _undo_redo: EditorUndoRedoManager
+
+
+func _init(undo_redo: EditorUndoRedoManager) -> void:
+	_undo_redo = undo_redo
+
+
+# ============================================================================
+# theme_create
+# ============================================================================
+
+func create_theme(params: Dictionary) -> Dictionary:
+	var path: String = params.get("path", "")
+	var overwrite: bool = params.get("overwrite", false)
+
+	var err := _validate_res_path(path, ".tres")
+	if err != null:
+		return err
+
+	if FileAccess.file_exists(path) and not overwrite:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Theme already exists at %s (pass overwrite=true to replace)" % path
+		)
+
+	var theme := Theme.new()
+	var save_err := ResourceSaver.save(theme, path)
+	if save_err != OK:
+		return McpErrorCodes.make(
+			McpErrorCodes.INTERNAL_ERROR,
+			"Failed to save theme to %s (error %d)" % [path, save_err]
+		)
+
+	# Make sure the editor's filesystem picks up the new file.
+	var efs := EditorInterface.get_resource_filesystem()
+	if efs != null:
+		efs.update_file(path)
+
+	return {
+		"data": {
+			"path": path,
+			"overwritten": overwrite and FileAccess.file_exists(path),
+			"undoable": false,
+			"reason": "File creation is persistent; delete the file manually to revert",
+		}
+	}
+
+
+# ============================================================================
+# theme_set_color / theme_set_constant / theme_set_font_size
+# ============================================================================
+
+func set_color(params: Dictionary) -> Dictionary:
+	return _set_scalar(params, "color", func(theme, name, cls): return theme.get_color(name, cls),
+		func(theme, name, cls, val): theme.set_color(name, cls, val),
+		func(theme, name, cls): theme.clear_color(name, cls),
+		func(theme, name, cls): return theme.has_color(name, cls),
+		func(v): return _parse_color(v))
+
+
+func set_constant(params: Dictionary) -> Dictionary:
+	return _set_scalar(params, "constant", func(theme, name, cls): return theme.get_constant(name, cls),
+		func(theme, name, cls, val): theme.set_constant(name, cls, int(val)),
+		func(theme, name, cls): theme.clear_constant(name, cls),
+		func(theme, name, cls): return theme.has_constant(name, cls),
+		func(v): return int(v))
+
+
+func set_font_size(params: Dictionary) -> Dictionary:
+	return _set_scalar(params, "font_size", func(theme, name, cls): return theme.get_font_size(name, cls),
+		func(theme, name, cls, val): theme.set_font_size(name, cls, int(val)),
+		func(theme, name, cls): theme.clear_font_size(name, cls),
+		func(theme, name, cls): return theme.has_font_size(name, cls),
+		func(v): return int(v))
+
+
+# Shared implementation for scalar Theme slots (color, constant, font_size).
+# Captures old value, applies new value, saves to disk, registers undo that
+# restores the old value and saves again.
+func _set_scalar(
+	params: Dictionary,
+	kind: String,
+	getter: Callable,
+	setter: Callable,
+	clearer: Callable,
+	has_fn: Callable,
+	parser: Callable,
+) -> Dictionary:
+	var load_result := _load_theme_from_params(params)
+	if load_result.has("error"):
+		return load_result
+	var theme: Theme = load_result.theme
+	var theme_path: String = load_result.path
+
+	var class_name_param: String = params.get("class_name", "")
+	if class_name_param.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: class_name")
+
+	var name: String = params.get("name", "")
+	if name.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: name")
+
+	if not "value" in params:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: value")
+
+	var parsed = parser.call(params.get("value"))
+	if parsed == null and params.get("value") != null:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Invalid %s value: %s" % [kind, params.get("value")])
+
+	var had_before: bool = has_fn.call(theme, name, class_name_param)
+	var before_value = getter.call(theme, name, class_name_param) if had_before else null
+
+	_undo_redo.create_action("MCP: Theme set %s %s/%s" % [kind, class_name_param, name])
+	_undo_redo.add_do_method(self, "_apply_scalar", theme_path, setter, name, class_name_param, parsed)
+	if had_before:
+		_undo_redo.add_undo_method(self, "_apply_scalar", theme_path, setter, name, class_name_param, before_value)
+	else:
+		_undo_redo.add_undo_method(self, "_clear_scalar", theme_path, clearer, name, class_name_param)
+	_undo_redo.commit_action()
+
+	return {
+		"data": {
+			"path": theme_path,
+			"kind": kind,
+			"class_name": class_name_param,
+			"name": name,
+			"value": _serialize_value(parsed),
+			"previous_value": _serialize_value(before_value) if had_before else null,
+			"undoable": true,
+		}
+	}
+
+
+func _apply_scalar(theme_path: String, setter: Callable, name: String, class_name_param: String, value: Variant) -> void:
+	var theme: Theme = ResourceLoader.load(theme_path)
+	if theme == null:
+		return
+	setter.call(theme, name, class_name_param, value)
+	ResourceSaver.save(theme, theme_path)
+
+
+func _clear_scalar(theme_path: String, clearer: Callable, name: String, class_name_param: String) -> void:
+	var theme: Theme = ResourceLoader.load(theme_path)
+	if theme == null:
+		return
+	clearer.call(theme, name, class_name_param)
+	ResourceSaver.save(theme, theme_path)
+
+
+# ============================================================================
+# theme_set_stylebox_flat
+# ============================================================================
+
+## Compose a StyleBoxFlat from a flat param dict and assign it to a theme slot.
+##
+## Params beyond theme/class_name/name:
+##   bg_color            (Color, "#rrggbb", or "#rrggbbaa")
+##   border_color        (Color)
+##   border_width        (int) — applied to all sides
+##   corner_radius       (int) — applied to all corners
+##   content_margin      (float) — applied to all sides
+##   shadow_color        (Color)
+##   shadow_size         (int)
+##   shadow_offset_x     (float)
+##   shadow_offset_y     (float)
+##   anti_aliasing       (bool)
+func set_stylebox_flat(params: Dictionary) -> Dictionary:
+	var load_result := _load_theme_from_params(params)
+	if load_result.has("error"):
+		return load_result
+	var theme: Theme = load_result.theme
+	var theme_path: String = load_result.path
+
+	var class_name_param: String = params.get("class_name", "")
+	if class_name_param.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: class_name")
+
+	var name: String = params.get("name", "")
+	if name.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: name")
+
+	var sb := StyleBoxFlat.new()
+	if params.has("bg_color"):
+		var bg := _parse_color(params.bg_color)
+		if bg == null:
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Invalid bg_color")
+		sb.bg_color = bg
+	if params.has("border_color"):
+		var bc := _parse_color(params.border_color)
+		if bc == null:
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Invalid border_color")
+		sb.border_color = bc
+	if params.has("border_width"):
+		sb.set_border_width_all(int(params.border_width))
+	if params.has("corner_radius"):
+		sb.set_corner_radius_all(int(params.corner_radius))
+	if params.has("content_margin"):
+		sb.set_content_margin_all(float(params.content_margin))
+	if params.has("shadow_color"):
+		var sc := _parse_color(params.shadow_color)
+		if sc == null:
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Invalid shadow_color")
+		sb.shadow_color = sc
+	if params.has("shadow_size"):
+		sb.shadow_size = int(params.shadow_size)
+	if params.has("shadow_offset_x") or params.has("shadow_offset_y"):
+		sb.shadow_offset = Vector2(
+			float(params.get("shadow_offset_x", 0)),
+			float(params.get("shadow_offset_y", 0)),
+		)
+	if params.has("anti_aliasing"):
+		sb.anti_aliasing = bool(params.anti_aliasing)
+
+	var had_before := theme.has_stylebox(name, class_name_param)
+	var before_sb: StyleBox = theme.get_stylebox(name, class_name_param) if had_before else null
+
+	_undo_redo.create_action("MCP: Theme set stylebox %s/%s" % [class_name_param, name])
+	_undo_redo.add_do_method(self, "_apply_stylebox", theme_path, name, class_name_param, sb)
+	if had_before:
+		_undo_redo.add_undo_method(self, "_apply_stylebox", theme_path, name, class_name_param, before_sb)
+	else:
+		_undo_redo.add_undo_method(self, "_clear_stylebox", theme_path, name, class_name_param)
+	_undo_redo.commit_action()
+
+	return {
+		"data": {
+			"path": theme_path,
+			"class_name": class_name_param,
+			"name": name,
+			"stylebox_class": "StyleBoxFlat",
+			"bg_color": _serialize_value(sb.bg_color),
+			"border_width": sb.border_width_left,
+			"corner_radius": sb.corner_radius_top_left,
+			"undoable": true,
+		}
+	}
+
+
+func _apply_stylebox(theme_path: String, name: String, class_name_param: String, sb: StyleBox) -> void:
+	var theme: Theme = ResourceLoader.load(theme_path)
+	if theme == null:
+		return
+	theme.set_stylebox(name, class_name_param, sb)
+	ResourceSaver.save(theme, theme_path)
+
+
+func _clear_stylebox(theme_path: String, name: String, class_name_param: String) -> void:
+	var theme: Theme = ResourceLoader.load(theme_path)
+	if theme == null:
+		return
+	theme.clear_stylebox(name, class_name_param)
+	ResourceSaver.save(theme, theme_path)
+
+
+# ============================================================================
+# theme_apply — assign a theme to a Control
+# ============================================================================
+
+func apply_theme(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("node_path", "")
+	if node_path.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: node_path")
+
+	var theme_path: String = params.get("theme_path", "")
+	var theme: Theme = null
+	if not theme_path.is_empty():
+		var path_err := _validate_res_path(theme_path, ".tres")
+		if path_err != null:
+			return path_err
+		if not ResourceLoader.exists(theme_path):
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Theme not found: %s" % theme_path)
+		theme = ResourceLoader.load(theme_path)
+		if theme == null or not theme is Theme:
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Resource at %s is not a Theme" % theme_path)
+
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+
+	var node := ScenePath.resolve(node_path, scene_root)
+	if node == null:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % node_path)
+	if not node is Control and not node is Window:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Node %s is not a Control or Window (got %s)" % [node_path, node.get_class()]
+		)
+
+	var before_theme: Theme = node.theme
+	_undo_redo.create_action("MCP: Apply theme to %s" % node.name)
+	_undo_redo.add_do_property(node, "theme", theme)
+	_undo_redo.add_undo_property(node, "theme", before_theme)
+	_undo_redo.commit_action()
+
+	return {
+		"data": {
+			"node_path": node_path,
+			"theme_path": theme_path if theme != null else "",
+			"cleared": theme == null,
+			"undoable": true,
+		}
+	}
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+func _load_theme_from_params(params: Dictionary) -> Dictionary:
+	var theme_path: String = params.get("theme_path", "")
+	var err := _validate_res_path(theme_path, ".tres")
+	if err != null:
+		return err
+	if not ResourceLoader.exists(theme_path):
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Theme not found: %s" % theme_path)
+	var theme: Theme = ResourceLoader.load(theme_path)
+	if theme == null or not theme is Theme:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Resource at %s is not a Theme" % theme_path)
+	return {"theme": theme, "path": theme_path}
+
+
+static func _validate_res_path(path: String, required_suffix: String) -> Variant:
+	if path.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: theme_path")
+	if not path.begins_with("res://"):
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Path must start with res:// (got %s)" % path)
+	if not path.ends_with(required_suffix):
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Path must end with %s (got %s)" % [required_suffix, path]
+		)
+	return null
+
+
+## Parse a color from Color, "#rrggbb", "#rrggbbaa", named (red/blue/...) or dict.
+## Returns null if the input cannot be parsed.
+static func _parse_color(value: Variant) -> Variant:
+	if value is Color:
+		return value
+	if value is String:
+		var s: String = value
+		# Color.from_string returns the default on parse failure, so call it twice
+		# with distinct sentinels — if both agree, parsing succeeded.
+		var sentinel_a := Color(0, 0, 0, 0)
+		var sentinel_b := Color(1, 1, 1, 1)
+		var a := Color.from_string(s, sentinel_a)
+		var b := Color.from_string(s, sentinel_b)
+		if a != b:
+			return null
+		return a
+	if value is Dictionary:
+		var d: Dictionary = value
+		if d.has("r") and d.has("g") and d.has("b"):
+			return Color(float(d.r), float(d.g), float(d.b), float(d.get("a", 1.0)))
+	return null
+
+
+static func _serialize_value(value: Variant) -> Variant:
+	if value == null:
+		return null
+	if value is Color:
+		return {"r": value.r, "g": value.g, "b": value.b, "a": value.a}
+	if value is Vector2:
+		return {"x": value.x, "y": value.y}
+	return value

--- a/plugin/addons/godot_ai/handlers/theme_handler.gd
+++ b/plugin/addons/godot_ai/handlers/theme_handler.gd
@@ -25,11 +25,14 @@ func create_theme(params: Dictionary) -> Dictionary:
 	var path: String = params.get("path", "")
 	var overwrite: bool = params.get("overwrite", false)
 
-	var err := _validate_res_path(path, ".tres")
+	var err := _validate_res_path(path, ".tres", "path")
 	if err != null:
 		return err
 
-	if FileAccess.file_exists(path) and not overwrite:
+	# Capture whether the file was already there BEFORE the save so we can
+	# report `overwritten` accurately (after save the file always exists).
+	var existed_before := FileAccess.file_exists(path)
+	if existed_before and not overwrite:
 		return McpErrorCodes.make(
 			McpErrorCodes.INVALID_PARAMS,
 			"Theme already exists at %s (pass overwrite=true to replace)" % path
@@ -51,7 +54,7 @@ func create_theme(params: Dictionary) -> Dictionary:
 	return {
 		"data": {
 			"path": path,
-			"overwritten": overwrite and FileAccess.file_exists(path),
+			"overwritten": existed_before,
 			"undoable": false,
 			"reason": "File creation is persistent; delete the file manually to revert",
 		}
@@ -115,9 +118,15 @@ func _set_scalar(
 	if not "value" in params:
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: value")
 
-	var parsed = parser.call(params.get("value"))
-	if parsed == null and params.get("value") != null:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Invalid %s value: %s" % [kind, params.get("value")])
+	var raw_value = params.get("value")
+	if raw_value == null:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Invalid %s value: null (pass a concrete value; use the appropriate clear command to remove a slot)" % kind
+		)
+	var parsed = parser.call(raw_value)
+	if parsed == null:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Invalid %s value: %s" % [kind, raw_value])
 
 	var had_before: bool = has_fn.call(theme, name, class_name_param)
 	var before_value = getter.call(theme, name, class_name_param) if had_before else null
@@ -331,15 +340,18 @@ func _load_theme_from_params(params: Dictionary) -> Dictionary:
 	return {"theme": theme, "path": theme_path}
 
 
-static func _validate_res_path(path: String, required_suffix: String) -> Variant:
+static func _validate_res_path(path: String, required_suffix: String, param_name: String = "theme_path") -> Variant:
 	if path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: theme_path")
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: %s" % param_name)
 	if not path.begins_with("res://"):
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Path must start with res:// (got %s)" % path)
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"%s must start with res:// (got %s)" % [param_name, path]
+		)
 	if not path.ends_with(required_suffix):
 		return McpErrorCodes.make(
 			McpErrorCodes.INVALID_PARAMS,
-			"Path must end with %s (got %s)" % [required_suffix, path]
+			"%s must end with %s (got %s)" % [param_name, required_suffix, path]
 		)
 	return null
 

--- a/plugin/addons/godot_ai/handlers/ui_handler.gd
+++ b/plugin/addons/godot_ai/handlers/ui_handler.gd
@@ -136,3 +136,196 @@ func set_anchor_preset(params: Dictionary) -> Dictionary:
 			"undoable": true,
 		}
 	}
+
+
+# ============================================================================
+# build_layout — declarative nested-dict → Control tree in one undo action
+# ============================================================================
+
+## Build a tree of Control nodes atomically.
+##
+## Params:
+##   tree         - Dictionary describing the root node. Required fields: "type".
+##                  Optional: "name", "properties" (dict), "anchor_preset",
+##                  "anchor_margin", "theme" (res:// path), "children" (array).
+##   parent_path  - Parent scene path. Empty or "/" = scene root.
+##
+## Validation is done before any scene mutation: class names, property
+## existence, and res:// paths are all checked up-front. If anything is
+## invalid, no node is created.
+func build_layout(params: Dictionary) -> Dictionary:
+	var tree = params.get("tree")
+	if typeof(tree) != TYPE_DICTIONARY:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: tree (must be a dictionary)")
+
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+
+	var parent_path: String = params.get("parent_path", "")
+	var parent: Node = scene_root
+	if not parent_path.is_empty() and parent_path != "/":
+		parent = ScenePath.resolve(parent_path, scene_root)
+		if parent == null:
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Parent not found: %s" % parent_path)
+
+	# Validate + build in memory first; if anything fails, free and bail.
+	var built := _build_subtree(tree)
+	if built.has("error"):
+		return built
+	var root_node: Node = built.node
+	var created: Array[Node] = built.created
+
+	_undo_redo.create_action("MCP: Build UI layout (%d nodes)" % created.size())
+	_undo_redo.add_do_method(parent, "add_child", root_node, true)
+	_undo_redo.add_do_method(root_node, "set_owner", scene_root)
+	for n in created:
+		_undo_redo.add_do_method(n, "set_owner", scene_root)
+		_undo_redo.add_do_reference(n)
+	_undo_redo.add_undo_method(parent, "remove_child", root_node)
+	_undo_redo.commit_action()
+
+	return {
+		"data": {
+			"root_path": ScenePath.from_node(root_node, scene_root),
+			"node_count": created.size(),
+			"undoable": true,
+		}
+	}
+
+
+## Recursively instantiate + configure a node and its children in memory.
+## Returns {"node": root, "created": [all descendants incl. root]} or {"error": ...}.
+func _build_subtree(spec: Dictionary) -> Dictionary:
+	var node_type: String = spec.get("type", "")
+	if node_type.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Every layout node requires a 'type'")
+	if not ClassDB.class_exists(node_type):
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Unknown type: %s" % node_type)
+	if not ClassDB.is_parent_class(node_type, "Node"):
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "%s is not a Node type" % node_type)
+
+	var node: Node = ClassDB.instantiate(node_type)
+	if node == null:
+		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to instantiate %s" % node_type)
+
+	var node_name: String = spec.get("name", "")
+	if not node_name.is_empty():
+		node.name = node_name
+
+	# Properties.
+	if spec.has("properties"):
+		var props = spec.get("properties")
+		if typeof(props) != TYPE_DICTIONARY:
+			node.free()
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "properties must be a dictionary")
+		for key in props:
+			var value = props[key]
+			var apply_err := _apply_property(node, str(key), value)
+			if apply_err != null:
+				node.free()
+				return apply_err
+
+	# Theme (res:// path -> Resource).
+	if spec.has("theme"):
+		var theme_path: String = str(spec.get("theme", ""))
+		if not theme_path.is_empty():
+			if not theme_path.begins_with("res://"):
+				node.free()
+				return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "theme must be a res:// path")
+			if not ResourceLoader.exists(theme_path):
+				node.free()
+				return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Theme not found: %s" % theme_path)
+			var theme_res: Resource = ResourceLoader.load(theme_path)
+			if not node is Control and not node is Window:
+				node.free()
+				return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "theme can only be set on Control / Window (got %s)" % node_type)
+			node.theme = theme_res
+
+	# Anchor preset — applied before children so children inherit sensible anchors.
+	if spec.has("anchor_preset"):
+		var preset_name: String = str(spec.get("anchor_preset", "")).to_lower()
+		if not _PRESETS.has(preset_name):
+			node.free()
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Unknown anchor_preset: %s" % preset_name)
+		if not node is Control:
+			node.free()
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "anchor_preset requires a Control (got %s)" % node_type)
+		var preset_value: int = _PRESETS[preset_name]
+		var margin: int = int(spec.get("anchor_margin", 0))
+		(node as Control).set_anchors_and_offsets_preset(preset_value, Control.PRESET_MODE_MINSIZE, margin)
+
+	var created: Array[Node] = [node]
+	if spec.has("children"):
+		var children = spec.get("children")
+		if typeof(children) != TYPE_ARRAY:
+			node.free()
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "children must be an array")
+		for child_spec in children:
+			if typeof(child_spec) != TYPE_DICTIONARY:
+				node.free()
+				return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "each child must be a dictionary")
+			var child_result := _build_subtree(child_spec)
+			if child_result.has("error"):
+				node.free()
+				return child_result
+			var child_node: Node = child_result.node
+			node.add_child(child_node)
+			for n in child_result.created:
+				created.append(n)
+	return {"node": node, "created": created}
+
+
+## Apply a property to a newly-instantiated node. Handles Color/Vector2/NodePath
+## coercion from JSON-friendly forms. Returns null on success, error dict on failure.
+func _apply_property(node: Node, prop: String, value: Variant) -> Variant:
+	var found := false
+	var prop_type := TYPE_NIL
+	for p in node.get_property_list():
+		if p.name == prop:
+			found = true
+			prop_type = p.get("type", TYPE_NIL)
+			break
+	if not found:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Property '%s' not found on %s" % [prop, node.get_class()]
+		)
+
+	var coerced := _coerce_for_type(value, prop_type)
+	node.set(prop, coerced)
+	return null
+
+
+static func _coerce_for_type(value: Variant, prop_type: int) -> Variant:
+	match prop_type:
+		TYPE_COLOR:
+			if value is Color:
+				return value
+			if value is String:
+				var a := Color.from_string(value, Color(0, 0, 0, 0))
+				var b := Color.from_string(value, Color(1, 1, 1, 1))
+				if a == b:
+					return a
+			if value is Dictionary and value.has("r") and value.has("g") and value.has("b"):
+				return Color(float(value.r), float(value.g), float(value.b), float(value.get("a", 1.0)))
+		TYPE_VECTOR2:
+			if value is Vector2:
+				return value
+			if value is Dictionary and value.has("x") and value.has("y"):
+				return Vector2(float(value.x), float(value.y))
+			if value is Array and value.size() == 2:
+				return Vector2(float(value[0]), float(value[1]))
+		TYPE_VECTOR2I:
+			if value is Vector2i:
+				return value
+			if value is Dictionary and value.has("x") and value.has("y"):
+				return Vector2i(int(value.x), int(value.y))
+			if value is Array and value.size() == 2:
+				return Vector2i(int(value[0]), int(value[1]))
+		TYPE_NODE_PATH:
+			if value is NodePath:
+				return value
+			if value is String:
+				return NodePath(value)
+	return value

--- a/plugin/addons/godot_ai/handlers/ui_handler.gd
+++ b/plugin/addons/godot_ai/handlers/ui_handler.gd
@@ -237,10 +237,13 @@ func _build_subtree(spec: Dictionary) -> Dictionary:
 				node.free()
 				return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Theme not found: %s" % theme_path)
 			var theme_res: Resource = ResourceLoader.load(theme_path)
+			if theme_res == null or not theme_res is Theme:
+				node.free()
+				return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "theme path must point to a Theme resource: %s" % theme_path)
 			if not node is Control and not node is Window:
 				node.free()
 				return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "theme can only be set on Control / Window (got %s)" % node_type)
-			node.theme = theme_res
+			node.theme = theme_res as Theme
 
 	# Anchor preset — applied before children so children inherit sensible anchors.
 	if spec.has("anchor_preset"):
@@ -292,40 +295,59 @@ func _apply_property(node: Node, prop: String, value: Variant) -> Variant:
 			"Property '%s' not found on %s" % [prop, node.get_class()]
 		)
 
-	var coerced := _coerce_for_type(value, prop_type)
-	node.set(prop, coerced)
+	var coercion := _coerce_for_type(value, prop_type)
+	if not coercion.ok:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Property '%s' on %s expects type %s (cannot coerce %s)" % [
+				prop, node.get_class(), type_string(prop_type), value
+			]
+		)
+	node.set(prop, coercion.value)
 	return null
 
 
-static func _coerce_for_type(value: Variant, prop_type: int) -> Variant:
+## Coerce a JSON-friendly value to the target Godot type. Returns
+## {"ok": true, "value": coerced} on success, {"ok": false} on failure.
+## For types we don't explicitly coerce, the value is returned as-is
+## (Godot will typecheck at set() time and fail loudly if it disagrees).
+static func _coerce_for_type(value: Variant, prop_type: int) -> Dictionary:
 	match prop_type:
 		TYPE_COLOR:
 			if value is Color:
-				return value
+				return {"ok": true, "value": value}
 			if value is String:
 				var a := Color.from_string(value, Color(0, 0, 0, 0))
 				var b := Color.from_string(value, Color(1, 1, 1, 1))
 				if a == b:
-					return a
+					return {"ok": true, "value": a}
+				return {"ok": false}
 			if value is Dictionary and value.has("r") and value.has("g") and value.has("b"):
-				return Color(float(value.r), float(value.g), float(value.b), float(value.get("a", 1.0)))
+				return {
+					"ok": true,
+					"value": Color(float(value.r), float(value.g), float(value.b), float(value.get("a", 1.0))),
+				}
+			return {"ok": false}
 		TYPE_VECTOR2:
 			if value is Vector2:
-				return value
+				return {"ok": true, "value": value}
 			if value is Dictionary and value.has("x") and value.has("y"):
-				return Vector2(float(value.x), float(value.y))
+				return {"ok": true, "value": Vector2(float(value.x), float(value.y))}
 			if value is Array and value.size() == 2:
-				return Vector2(float(value[0]), float(value[1]))
+				return {"ok": true, "value": Vector2(float(value[0]), float(value[1]))}
+			return {"ok": false}
 		TYPE_VECTOR2I:
 			if value is Vector2i:
-				return value
+				return {"ok": true, "value": value}
 			if value is Dictionary and value.has("x") and value.has("y"):
-				return Vector2i(int(value.x), int(value.y))
+				return {"ok": true, "value": Vector2i(int(value.x), int(value.y))}
 			if value is Array and value.size() == 2:
-				return Vector2i(int(value[0]), int(value[1]))
+				return {"ok": true, "value": Vector2i(int(value[0]), int(value[1]))}
+			return {"ok": false}
 		TYPE_NODE_PATH:
 			if value is NodePath:
-				return value
+				return {"ok": true, "value": value}
 			if value is String:
-				return NodePath(value)
-	return value
+				return {"ok": true, "value": NodePath(value)}
+			return {"ok": false}
+	return {"ok": true, "value": value}

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -32,7 +32,8 @@ func _enter_tree() -> void:
 	var test_handler := TestHandler.new(get_undo_redo(), _log_buffer)
 	var batch_handler := BatchHandler.new(_dispatcher, get_undo_redo())
 	var ui_handler := UiHandler.new(get_undo_redo())
-	_handlers = [editor_handler, scene_handler, node_handler, project_handler, client_handler, script_handler, resource_handler, filesystem_handler, signal_handler, autoload_handler, input_handler, test_handler, batch_handler, ui_handler]
+	var theme_handler := ThemeHandler.new(get_undo_redo())
+	_handlers = [editor_handler, scene_handler, node_handler, project_handler, client_handler, script_handler, resource_handler, filesystem_handler, signal_handler, autoload_handler, input_handler, test_handler, batch_handler, ui_handler, theme_handler]
 
 	_dispatcher.register("get_editor_state", editor_handler.get_editor_state)
 	_dispatcher.register("get_scene_tree", scene_handler.get_scene_tree)
@@ -95,6 +96,13 @@ func _enter_tree() -> void:
 	_dispatcher.register("get_test_results", test_handler.get_test_results)
 	_dispatcher.register("batch_execute", batch_handler.batch_execute)
 	_dispatcher.register("set_anchor_preset", ui_handler.set_anchor_preset)
+	_dispatcher.register("build_layout", ui_handler.build_layout)
+	_dispatcher.register("create_theme", theme_handler.create_theme)
+	_dispatcher.register("theme_set_color", theme_handler.set_color)
+	_dispatcher.register("theme_set_constant", theme_handler.set_constant)
+	_dispatcher.register("theme_set_font_size", theme_handler.set_font_size)
+	_dispatcher.register("theme_set_stylebox_flat", theme_handler.set_stylebox_flat)
+	_dispatcher.register("apply_theme", theme_handler.apply_theme)
 
 	_connection.dispatcher = _dispatcher
 	add_child(_connection)

--- a/src/godot_ai/handlers/theme.py
+++ b/src/godot_ai/handlers/theme.py
@@ -1,0 +1,134 @@
+"""Shared handlers for Theme authoring (colors, stylebox, apply)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from godot_ai.handlers._readiness import require_writable
+from godot_ai.runtime.interface import Runtime
+
+
+async def theme_create(
+    runtime: Runtime,
+    path: str,
+    overwrite: bool = False,
+) -> dict:
+    require_writable(runtime)
+    return await runtime.send_command(
+        "create_theme",
+        {"path": path, "overwrite": overwrite},
+    )
+
+
+async def theme_set_color(
+    runtime: Runtime,
+    theme_path: str,
+    class_name: str,
+    name: str,
+    value: Any,
+) -> dict:
+    require_writable(runtime)
+    return await runtime.send_command(
+        "theme_set_color",
+        {
+            "theme_path": theme_path,
+            "class_name": class_name,
+            "name": name,
+            "value": value,
+        },
+    )
+
+
+async def theme_set_constant(
+    runtime: Runtime,
+    theme_path: str,
+    class_name: str,
+    name: str,
+    value: int,
+) -> dict:
+    require_writable(runtime)
+    return await runtime.send_command(
+        "theme_set_constant",
+        {
+            "theme_path": theme_path,
+            "class_name": class_name,
+            "name": name,
+            "value": value,
+        },
+    )
+
+
+async def theme_set_font_size(
+    runtime: Runtime,
+    theme_path: str,
+    class_name: str,
+    name: str,
+    value: int,
+) -> dict:
+    require_writable(runtime)
+    return await runtime.send_command(
+        "theme_set_font_size",
+        {
+            "theme_path": theme_path,
+            "class_name": class_name,
+            "name": name,
+            "value": value,
+        },
+    )
+
+
+async def theme_set_stylebox_flat(
+    runtime: Runtime,
+    theme_path: str,
+    class_name: str,
+    name: str,
+    bg_color: Any = None,
+    border_color: Any = None,
+    border_width: int | None = None,
+    corner_radius: int | None = None,
+    content_margin: float | None = None,
+    shadow_color: Any = None,
+    shadow_size: int | None = None,
+    shadow_offset_x: float | None = None,
+    shadow_offset_y: float | None = None,
+    anti_aliasing: bool | None = None,
+) -> dict:
+    require_writable(runtime)
+    params: dict[str, Any] = {
+        "theme_path": theme_path,
+        "class_name": class_name,
+        "name": name,
+    }
+    if bg_color is not None:
+        params["bg_color"] = bg_color
+    if border_color is not None:
+        params["border_color"] = border_color
+    if border_width is not None:
+        params["border_width"] = border_width
+    if corner_radius is not None:
+        params["corner_radius"] = corner_radius
+    if content_margin is not None:
+        params["content_margin"] = content_margin
+    if shadow_color is not None:
+        params["shadow_color"] = shadow_color
+    if shadow_size is not None:
+        params["shadow_size"] = shadow_size
+    if shadow_offset_x is not None:
+        params["shadow_offset_x"] = shadow_offset_x
+    if shadow_offset_y is not None:
+        params["shadow_offset_y"] = shadow_offset_y
+    if anti_aliasing is not None:
+        params["anti_aliasing"] = anti_aliasing
+    return await runtime.send_command("theme_set_stylebox_flat", params)
+
+
+async def theme_apply(
+    runtime: Runtime,
+    node_path: str,
+    theme_path: str = "",
+) -> dict:
+    require_writable(runtime)
+    return await runtime.send_command(
+        "apply_theme",
+        {"node_path": node_path, "theme_path": theme_path},
+    )

--- a/src/godot_ai/handlers/ui.py
+++ b/src/godot_ai/handlers/ui.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from godot_ai.handlers._readiness import require_writable
 from godot_ai.runtime.interface import Runtime
 
@@ -22,4 +24,16 @@ async def ui_set_anchor_preset(
             "resize_mode": resize_mode,
             "margin": margin,
         },
+    )
+
+
+async def ui_build_layout(
+    runtime: Runtime,
+    tree: dict[str, Any],
+    parent_path: str = "",
+) -> dict:
+    require_writable(runtime)
+    return await runtime.send_command(
+        "build_layout",
+        {"tree": tree, "parent_path": parent_path},
     )

--- a/src/godot_ai/server.py
+++ b/src/godot_ai/server.py
@@ -30,6 +30,7 @@ from godot_ai.tools.script import register_script_tools
 from godot_ai.tools.session import register_session_tools
 from godot_ai.tools.signal import register_signal_tools
 from godot_ai.tools.testing import register_testing_tools
+from godot_ai.tools.theme import register_theme_tools
 from godot_ai.tools.ui import register_ui_tools
 from godot_ai.transport.websocket import GodotWebSocketServer
 
@@ -85,7 +86,10 @@ def create_server(ws_port: int = 9500) -> FastMCP:
             "  logs_*           — read or clear the editor log buffer\n"
             "  test_*           — run GDScript test suites and fetch results\n"
             "  batch_execute    — compose multi-step scene edits atomically\n"
-            "  ui_*             — Control layout helpers (anchor presets for HUD / menus)\n"
+            "  ui_*             — Control layout helpers "
+            "(anchor presets, declarative layout builder)\n"
+            "  theme_*          — author Theme resources "
+            "(colors, stylebox, font sizes) — Godot's CSS-like styling\n"
             "  client_*         — configure AI clients (Claude Code, Codex, Antigravity)\n\n"
             "Always connect to an editor session first (session_list / session_activate). "
             "Write operations require session readiness; check editor_state if a call is "
@@ -109,6 +113,7 @@ def create_server(ws_port: int = 9500) -> FastMCP:
     register_testing_tools(mcp)
     register_batch_tools(mcp)
     register_ui_tools(mcp)
+    register_theme_tools(mcp)
     register_session_resources(mcp)
     register_scene_resources(mcp)
     register_editor_resources(mcp)

--- a/src/godot_ai/tools/theme.py
+++ b/src/godot_ai/tools/theme.py
@@ -1,0 +1,210 @@
+"""MCP tools for Theme authoring — Godot's equivalent of USS stylesheets.
+
+A Theme resource holds (class, name) -> value entries (colors, constants,
+font sizes, styleboxes, icons) that cascade down a Control subtree when
+assigned at any ancestor. Authoring a theme replaces dozens of per-node
+property sets with one reusable stylesheet-like document.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp import Context, FastMCP
+
+from godot_ai.handlers import theme as theme_handlers
+from godot_ai.runtime.direct import DirectRuntime
+from godot_ai.tools import DEFER_META
+
+
+def register_theme_tools(mcp: FastMCP) -> None:
+    @mcp.tool(meta=DEFER_META)
+    async def theme_create(
+        ctx: Context,
+        path: str,
+        overwrite: bool = False,
+        session_id: str = "",
+    ) -> dict:
+        """Create a new empty Theme resource (.tres) at a res:// path.
+
+        A Theme is Godot's stylesheet-like resource. After creating one,
+        use theme_set_color, theme_set_constant, theme_set_font_size, and
+        theme_set_stylebox_flat to populate its slots, then theme_apply
+        to assign it to a Control subtree.
+
+        Args:
+            path: Destination res:// path ending in .tres (e.g.
+                "res://ui/themes/cyberpunk.tres").
+            overwrite: If true, overwrite any existing theme at that path.
+                Default false (errors if the file already exists).
+            session_id: Optional Godot session to target. Empty = active session.
+        """
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
+        return await theme_handlers.theme_create(runtime, path=path, overwrite=overwrite)
+
+    @mcp.tool(meta=DEFER_META)
+    async def theme_set_color(
+        ctx: Context,
+        theme_path: str,
+        class_name: str,
+        name: str,
+        value: Any,
+        session_id: str = "",
+    ) -> dict:
+        """Set a color slot on a Theme (e.g. Label.font_color, Button.font_hover_color).
+
+        Args:
+            theme_path: res:// path to the Theme .tres file.
+            class_name: Theme type (usually a Control subclass name like
+                "Label", "Button", "Panel", "LineEdit").
+            name: Color slot name (e.g. "font_color", "font_hover_color",
+                "font_disabled_color", "caret_color").
+            value: Color as "#rrggbb", "#rrggbbaa", named ("red", "cyan"),
+                or {"r": 0.1, "g": 0.1, "b": 0.2, "a": 1.0}.
+            session_id: Optional Godot session to target. Empty = active session.
+        """
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
+        return await theme_handlers.theme_set_color(
+            runtime, theme_path=theme_path, class_name=class_name, name=name, value=value
+        )
+
+    @mcp.tool(meta=DEFER_META)
+    async def theme_set_constant(
+        ctx: Context,
+        theme_path: str,
+        class_name: str,
+        name: str,
+        value: int,
+        session_id: str = "",
+    ) -> dict:
+        """Set an integer constant on a Theme (spacing, margins, padding).
+
+        Use for layout constants like VBoxContainer.separation,
+        MarginContainer.margin_left, GridContainer.h_separation.
+
+        Args:
+            theme_path: res:// path to the Theme .tres file.
+            class_name: Theme type (e.g. "VBoxContainer", "HBoxContainer",
+                "MarginContainer", "GridContainer").
+            name: Constant slot name (e.g. "separation", "margin_left",
+                "h_separation", "v_separation").
+            value: Integer value (pixels).
+            session_id: Optional Godot session to target. Empty = active session.
+        """
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
+        return await theme_handlers.theme_set_constant(
+            runtime, theme_path=theme_path, class_name=class_name, name=name, value=value
+        )
+
+    @mcp.tool(meta=DEFER_META)
+    async def theme_set_font_size(
+        ctx: Context,
+        theme_path: str,
+        class_name: str,
+        name: str,
+        value: int,
+        session_id: str = "",
+    ) -> dict:
+        """Set a font size slot on a Theme (text size per control class).
+
+        Args:
+            theme_path: res:// path to the Theme .tres file.
+            class_name: Theme type (e.g. "Label", "Button", "LineEdit",
+                "RichTextLabel").
+            name: Font size slot name (usually "font_size").
+            value: Size in pixels.
+            session_id: Optional Godot session to target. Empty = active session.
+        """
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
+        return await theme_handlers.theme_set_font_size(
+            runtime, theme_path=theme_path, class_name=class_name, name=name, value=value
+        )
+
+    @mcp.tool(meta=DEFER_META)
+    async def theme_set_stylebox_flat(
+        ctx: Context,
+        theme_path: str,
+        class_name: str,
+        name: str,
+        bg_color: Any = None,
+        border_color: Any = None,
+        border_width: int | None = None,
+        corner_radius: int | None = None,
+        content_margin: float | None = None,
+        shadow_color: Any = None,
+        shadow_size: int | None = None,
+        shadow_offset_x: float | None = None,
+        shadow_offset_y: float | None = None,
+        anti_aliasing: bool | None = None,
+        session_id: str = "",
+    ) -> dict:
+        """Compose a StyleBoxFlat and assign it to a theme slot.
+
+        StyleBoxFlat is the workhorse styled-rectangle for panels, buttons,
+        line edits, etc. One call sets background color, border, rounded
+        corners, drop shadow, and content padding — all in a single
+        reusable stylebox that the theme applies everywhere the named slot
+        is used.
+
+        Common slot names: "normal" (base Button/Panel background), "hover",
+        "pressed", "focus", "disabled", "panel" (for Panel / PanelContainer).
+
+        Args:
+            theme_path: res:// path to the Theme .tres file.
+            class_name: Theme type (e.g. "Button", "Panel", "PanelContainer",
+                "LineEdit").
+            name: StyleBox slot name (e.g. "normal", "hover", "pressed",
+                "focus", "panel").
+            bg_color: Background fill color (hex string, named, or r/g/b/a dict).
+            border_color: Border color.
+            border_width: Border thickness in pixels — applied to all 4 sides.
+            corner_radius: Rounded-corner radius in pixels — applied to all 4 corners.
+            content_margin: Inner padding in pixels — applied to all 4 sides.
+            shadow_color: Drop shadow color.
+            shadow_size: Drop shadow blur size in pixels.
+            shadow_offset_x: Horizontal shadow offset.
+            shadow_offset_y: Vertical shadow offset.
+            anti_aliasing: Whether to anti-alias borders and corners.
+            session_id: Optional Godot session to target. Empty = active session.
+        """
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
+        return await theme_handlers.theme_set_stylebox_flat(
+            runtime,
+            theme_path=theme_path,
+            class_name=class_name,
+            name=name,
+            bg_color=bg_color,
+            border_color=border_color,
+            border_width=border_width,
+            corner_radius=corner_radius,
+            content_margin=content_margin,
+            shadow_color=shadow_color,
+            shadow_size=shadow_size,
+            shadow_offset_x=shadow_offset_x,
+            shadow_offset_y=shadow_offset_y,
+            anti_aliasing=anti_aliasing,
+        )
+
+    @mcp.tool(meta=DEFER_META)
+    async def theme_apply(
+        ctx: Context,
+        node_path: str,
+        theme_path: str = "",
+        session_id: str = "",
+    ) -> dict:
+        """Assign a Theme resource to a Control (cascades to descendants).
+
+        Setting the theme at the top of a UI subtree is the usual pattern:
+        one theme applied at /Main/HUD styles every button, label, panel,
+        and container inside it. To clear a theme, pass an empty theme_path.
+
+        Args:
+            node_path: Scene path to a Control or Window node.
+            theme_path: res:// path to the Theme .tres file. Empty string
+                clears the theme.
+            session_id: Optional Godot session to target. Empty = active session.
+        """
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
+        return await theme_handlers.theme_apply(
+            runtime, node_path=node_path, theme_path=theme_path
+        )

--- a/src/godot_ai/tools/ui.py
+++ b/src/godot_ai/tools/ui.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from typing import Annotated, Any
+
 from fastmcp import Context, FastMCP
 
 from godot_ai.handlers import ui as ui_handlers
 from godot_ai.runtime.direct import DirectRuntime
-from godot_ai.tools import DEFER_META
+from godot_ai.tools import DEFER_META, JsonCoerced
 
 
 def register_ui_tools(mcp: FastMCP) -> None:
@@ -51,4 +53,67 @@ def register_ui_tools(mcp: FastMCP) -> None:
             preset=preset,
             resize_mode=resize_mode,
             margin=margin,
+        )
+
+    @mcp.tool(meta=DEFER_META)
+    async def ui_build_layout(
+        ctx: Context,
+        tree: Annotated[dict[str, Any], JsonCoerced],
+        parent_path: str = "",
+        session_id: str = "",
+    ) -> dict:
+        """Build a UI subtree atomically from a declarative nested spec.
+
+        One call turns a nested description into a fully-constructed,
+        configured, themed, anchored Control tree under a parent. Faster
+        and more reliable than a sequence of node_create + node_set_property
+        + ui_set_anchor_preset + theme_apply calls; everything commits (or
+        fails and rolls back) as one undo action. This is the closest thing
+        to writing UXML and getting UI back.
+
+        Tree spec (per node):
+            type           - Godot class name (required, e.g. "VBoxContainer",
+                             "Panel", "Label", "Button", "HBoxContainer",
+                             "MarginContainer", "TextureRect").
+            name           - Node name (optional).
+            properties     - Dict of property -> value (optional). Color values
+                             accept hex strings; Vector2 accepts {"x": ,"y": }
+                             or [x, y]; strings go to text/icon paths; ints to
+                             size_flags_*, separation, etc.
+            anchor_preset  - Optional preset name (full_rect, center, top_left,
+                             top_wide, right_wide, ...). Applied after properties.
+            anchor_margin  - Optional margin in pixels for the anchor preset.
+            theme          - Optional res:// path to a Theme; applies to this
+                             subtree. Use theme_create + theme_set_* first.
+            children       - Optional array of nested child specs.
+
+        Example — a pause menu:
+            {
+              "type": "Panel", "name": "PauseMenu", "anchor_preset": "full_rect",
+              "theme": "res://ui/themes/game.tres",
+              "children": [{
+                "type": "VBoxContainer", "anchor_preset": "center",
+                "properties": {"separation": 16},
+                "children": [
+                  {"type": "Label", "properties": {"text": "Paused"}},
+                  {"type": "Button", "name": "Resume",
+                   "properties": {"text": "Resume"}},
+                  {"type": "Button", "name": "Quit",
+                   "properties": {"text": "Quit"}}
+                ]
+              }]
+            }
+
+        All nodes are validated (types exist, properties exist, res:// paths
+        resolve) before any scene mutation. If anything is invalid, no node
+        is created. Ctrl+Z in Godot undoes the entire build in one step.
+
+        Args:
+            tree: Root node spec (see above). Nested structure supported.
+            parent_path: Scene path to attach under. Empty or "/" = scene root.
+            session_id: Optional Godot session to target. Empty = active session.
+        """
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
+        return await ui_handlers.ui_build_layout(
+            runtime, tree=tree, parent_path=parent_path
         )

--- a/test_project/tests/test_theme.gd
+++ b/test_project/tests/test_theme.gd
@@ -1,0 +1,262 @@
+@tool
+extends McpTestSuite
+
+## Tests for ThemeHandler — Theme resource authoring.
+
+var _handler: ThemeHandler
+var _undo_redo: EditorUndoRedoManager
+
+const TEST_THEME_PATH := "res://tests/_mcp_test_theme.tres"
+
+
+func suite_name() -> String:
+	return "theme"
+
+
+func suite_setup(ctx: Dictionary) -> void:
+	_undo_redo = ctx.get("undo_redo")
+	_handler = ThemeHandler.new(_undo_redo)
+
+
+func suite_teardown() -> void:
+	if FileAccess.file_exists(TEST_THEME_PATH):
+		DirAccess.remove_absolute(TEST_THEME_PATH)
+
+
+func _make_theme() -> void:
+	# Ensure the test theme file exists fresh.
+	if FileAccess.file_exists(TEST_THEME_PATH):
+		DirAccess.remove_absolute(TEST_THEME_PATH)
+	_handler.create_theme({"path": TEST_THEME_PATH})
+
+
+# ----- create_theme -----
+
+func test_create_theme_writes_file() -> void:
+	if FileAccess.file_exists(TEST_THEME_PATH):
+		DirAccess.remove_absolute(TEST_THEME_PATH)
+	var result := _handler.create_theme({"path": TEST_THEME_PATH})
+	assert_has_key(result, "data")
+	assert_eq(result.data.path, TEST_THEME_PATH)
+	assert_true(FileAccess.file_exists(TEST_THEME_PATH), "Theme file should exist after create")
+
+
+func test_create_theme_requires_res_path() -> void:
+	var result := _handler.create_theme({"path": "/tmp/foo.tres"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_create_theme_requires_tres_suffix() -> void:
+	var result := _handler.create_theme({"path": "res://foo.txt"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_create_theme_rejects_existing_without_overwrite() -> void:
+	_make_theme()
+	var result := _handler.create_theme({"path": TEST_THEME_PATH})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_create_theme_overwrite_allowed() -> void:
+	_make_theme()
+	var result := _handler.create_theme({"path": TEST_THEME_PATH, "overwrite": true})
+	assert_has_key(result, "data")
+
+
+# ----- theme_set_color -----
+
+func test_theme_set_color_accepts_hex() -> void:
+	_make_theme()
+	var result := _handler.set_color({
+		"theme_path": TEST_THEME_PATH,
+		"class_name": "Label",
+		"name": "font_color",
+		"value": "#e0e0ff",
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.kind, "color")
+	assert_true(result.data.undoable)
+	# Reload from disk to confirm it was persisted.
+	var theme: Theme = ResourceLoader.load(TEST_THEME_PATH)
+	assert_true(theme.has_color("font_color", "Label"))
+	var c := theme.get_color("font_color", "Label")
+	assert_true(abs(c.r - 0.8784) < 0.01, "Color parsed from hex")
+
+
+func test_theme_set_color_accepts_dict() -> void:
+	_make_theme()
+	var result := _handler.set_color({
+		"theme_path": TEST_THEME_PATH,
+		"class_name": "Label",
+		"name": "font_color",
+		"value": {"r": 0.5, "g": 0.3, "b": 0.1, "a": 1.0},
+	})
+	assert_has_key(result, "data")
+
+
+func test_theme_set_color_rejects_garbage_string() -> void:
+	_make_theme()
+	var result := _handler.set_color({
+		"theme_path": TEST_THEME_PATH,
+		"class_name": "Label",
+		"name": "font_color",
+		"value": "not-a-color-at-all-!!",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_theme_set_color_missing_theme_path() -> void:
+	var result := _handler.set_color({
+		"class_name": "Label",
+		"name": "font_color",
+		"value": "#ff0000",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_theme_set_color_missing_class_name() -> void:
+	_make_theme()
+	var result := _handler.set_color({
+		"theme_path": TEST_THEME_PATH,
+		"name": "font_color",
+		"value": "#ff0000",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_theme_set_color_theme_not_found() -> void:
+	var result := _handler.set_color({
+		"theme_path": "res://nope/does_not_exist.tres",
+		"class_name": "Label",
+		"name": "font_color",
+		"value": "#ff0000",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+# ----- theme_set_constant -----
+
+func test_theme_set_constant() -> void:
+	_make_theme()
+	var result := _handler.set_constant({
+		"theme_path": TEST_THEME_PATH,
+		"class_name": "VBoxContainer",
+		"name": "separation",
+		"value": 16,
+	})
+	assert_has_key(result, "data")
+	var theme: Theme = ResourceLoader.load(TEST_THEME_PATH)
+	assert_eq(theme.get_constant("separation", "VBoxContainer"), 16)
+
+
+# ----- theme_set_font_size -----
+
+func test_theme_set_font_size() -> void:
+	_make_theme()
+	var result := _handler.set_font_size({
+		"theme_path": TEST_THEME_PATH,
+		"class_name": "Label",
+		"name": "font_size",
+		"value": 24,
+	})
+	assert_has_key(result, "data")
+	var theme: Theme = ResourceLoader.load(TEST_THEME_PATH)
+	assert_eq(theme.get_font_size("font_size", "Label"), 24)
+
+
+# ----- theme_set_stylebox_flat -----
+
+func test_theme_set_stylebox_flat_composes_fields() -> void:
+	_make_theme()
+	var result := _handler.set_stylebox_flat({
+		"theme_path": TEST_THEME_PATH,
+		"class_name": "Button",
+		"name": "normal",
+		"bg_color": "#101820",
+		"border_color": "#00ffff",
+		"border_width": 2,
+		"corner_radius": 8,
+		"content_margin": 12.0,
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.stylebox_class, "StyleBoxFlat")
+	assert_eq(result.data.border_width, 2)
+	assert_eq(result.data.corner_radius, 8)
+	var theme: Theme = ResourceLoader.load(TEST_THEME_PATH)
+	var sb: StyleBoxFlat = theme.get_stylebox("normal", "Button")
+	assert_true(sb != null, "StyleBox was saved")
+	assert_eq(sb.border_width_left, 2)
+	assert_eq(sb.corner_radius_top_left, 8)
+	assert_eq(sb.content_margin_left, 12.0)
+
+
+func test_theme_set_stylebox_flat_rejects_bad_color() -> void:
+	_make_theme()
+	var result := _handler.set_stylebox_flat({
+		"theme_path": TEST_THEME_PATH,
+		"class_name": "Button",
+		"name": "normal",
+		"bg_color": "not a color!!",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+# ----- theme_apply -----
+
+func test_theme_apply_to_control() -> void:
+	_make_theme()
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return
+	var panel := Panel.new()
+	panel.name = "TestThemedPanel"
+	scene_root.add_child(panel)
+	panel.owner = scene_root
+	var path := "/" + scene_root.name + "/TestThemedPanel"
+
+	var result := _handler.apply_theme({
+		"node_path": path,
+		"theme_path": TEST_THEME_PATH,
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.cleared, false)
+	assert_true(panel.theme != null, "Theme should be assigned to panel")
+
+	# Clean up.
+	panel.get_parent().remove_child(panel)
+	panel.queue_free()
+
+
+func test_theme_apply_clear_with_empty_path() -> void:
+	_make_theme()
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return
+	var panel := Panel.new()
+	panel.name = "TestClearThemePanel"
+	panel.theme = ResourceLoader.load(TEST_THEME_PATH)
+	scene_root.add_child(panel)
+	panel.owner = scene_root
+	var path := "/" + scene_root.name + "/TestClearThemePanel"
+
+	var result := _handler.apply_theme({"node_path": path, "theme_path": ""})
+	assert_has_key(result, "data")
+	assert_eq(result.data.cleared, true)
+	assert_true(panel.theme == null, "Theme should be cleared")
+
+	panel.get_parent().remove_child(panel)
+	panel.queue_free()
+
+
+func test_theme_apply_rejects_non_control() -> void:
+	_make_theme()
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return
+	# Scene root is a Node3D — not a Control.
+	var result := _handler.apply_theme({
+		"node_path": "/" + scene_root.name,
+		"theme_path": TEST_THEME_PATH,
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "not a Control")

--- a/test_project/tests/test_theme.gd
+++ b/test_project/tests/test_theme.gd
@@ -260,3 +260,40 @@ func test_theme_apply_rejects_non_control() -> void:
 	})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 	assert_contains(result.error.message, "not a Control")
+
+
+# ----- Regression: Copilot review fixes -----
+
+func test_theme_set_color_rejects_null_value() -> void:
+	_make_theme()
+	var result := _handler.set_color({
+		"theme_path": TEST_THEME_PATH,
+		"class_name": "Label",
+		"name": "font_color",
+		"value": null,
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "null")
+
+
+func test_create_theme_overwritten_flag_tracks_pre_save_state() -> void:
+	# Fresh location — overwritten must be false even when overwrite=true.
+	if FileAccess.file_exists(TEST_THEME_PATH):
+		DirAccess.remove_absolute(TEST_THEME_PATH)
+	var result := _handler.create_theme({"path": TEST_THEME_PATH, "overwrite": true})
+	assert_has_key(result, "data")
+	assert_eq(result.data.overwritten, false, "Overwritten should be false on fresh create")
+
+	# Second call: now it should be true.
+	var result2 := _handler.create_theme({"path": TEST_THEME_PATH, "overwrite": true})
+	assert_has_key(result2, "data")
+	assert_eq(result2.data.overwritten, true, "Overwritten should be true on second create")
+
+
+func test_create_theme_missing_path_names_param_correctly() -> void:
+	# Error message should name `path`, not `theme_path`, for theme_create.
+	var result := _handler.create_theme({})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "path")
+	# Make sure it's NOT using the default "theme_path" label.
+	assert_true(result.error.message.find("theme_path") == -1, "Error should say 'path', not 'theme_path'")

--- a/test_project/tests/test_ui.gd
+++ b/test_project/tests/test_ui.gd
@@ -296,3 +296,26 @@ func test_build_layout_is_undoable() -> void:
 	assert_eq(scene_root.get_child_count(), before_count + 1)
 	_undo_redo.undo()
 	assert_eq(scene_root.get_child_count(), before_count, "Undo should remove the whole built tree")
+
+
+func test_build_layout_rejects_non_theme_resource() -> void:
+	# A .tres that is not a Theme — use a StandardMaterial3D saved to disk.
+	var bogus_path := "res://tests/_mcp_test_not_a_theme.tres"
+	var mat := StandardMaterial3D.new()
+	ResourceSaver.save(mat, bogus_path)
+	var result := _handler.build_layout({
+		"tree": {"type": "Panel", "theme": bogus_path}
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "Theme resource")
+	if FileAccess.file_exists(bogus_path):
+		DirAccess.remove_absolute(bogus_path)
+
+
+func test_build_layout_rejects_uncoercible_property() -> void:
+	# Label.modulate is a Color — "not a color" must be rejected (not silently passed).
+	var result := _handler.build_layout({
+		"tree": {"type": "Label", "properties": {"modulate": "not a color!!"}}
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "modulate")

--- a/test_project/tests/test_ui.gd
+++ b/test_project/tests/test_ui.gd
@@ -188,3 +188,111 @@ func test_set_anchor_preset_is_undoable() -> void:
 	assert_eq(ctl.anchor_left, before_left, "Undo should restore anchor_left")
 	assert_eq(ctl.anchor_right, before_right, "Undo should restore anchor_right")
 	_remove_control(path)
+
+
+# ============================================================================
+# build_layout — declarative UI tree composer
+# ============================================================================
+
+
+func test_build_layout_creates_simple_tree() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return
+	var spec := {
+		"type": "Panel",
+		"name": "TestBuildSimple",
+		"children": [
+			{"type": "Label", "name": "Title", "properties": {"text": "Hello"}},
+			{"type": "Button", "name": "Go", "properties": {"text": "Go"}},
+		],
+	}
+	var result := _handler.build_layout({"tree": spec})
+	assert_has_key(result, "data")
+	assert_eq(result.data.node_count, 3)
+	var root := ScenePath.resolve(result.data.root_path, scene_root)
+	assert_true(root != null)
+	assert_true(root is Panel)
+	assert_eq(root.get_child_count(), 2)
+	var label: Label = root.get_node("Title")
+	assert_eq(label.text, "Hello")
+
+	# Clean up.
+	root.get_parent().remove_child(root)
+	root.queue_free()
+
+
+func test_build_layout_rejects_unknown_type() -> void:
+	var result := _handler.build_layout({"tree": {"type": "NotARealClass"}})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_build_layout_rejects_non_node_type() -> void:
+	# Resource is not a Node.
+	var result := _handler.build_layout({"tree": {"type": "Resource"}})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_build_layout_rejects_missing_type() -> void:
+	var result := _handler.build_layout({"tree": {"name": "NoType"}})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_build_layout_rejects_unknown_property() -> void:
+	# Label has no "bogus_prop".
+	var result := _handler.build_layout({
+		"tree": {"type": "Label", "properties": {"bogus_prop": 1}}
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_build_layout_rejects_bad_parent_path() -> void:
+	var result := _handler.build_layout({
+		"tree": {"type": "Panel"}, "parent_path": "/Nowhere/Nope"
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_build_layout_applies_anchor_preset_and_coerces_color() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return
+	var spec := {
+		"type": "ColorRect",
+		"name": "TestBuildColor",
+		"anchor_preset": "full_rect",
+		"properties": {"color": "#112233"},
+	}
+	var result := _handler.build_layout({"tree": spec})
+	assert_has_key(result, "data")
+	var node: ColorRect = ScenePath.resolve(result.data.root_path, scene_root)
+	assert_true(node != null)
+	assert_eq(node.anchor_right, 1.0, "anchor_preset=full_rect should set anchor_right=1")
+	# Color coerced from hex — "#112233" -> r~=0.067, g~=0.133, b~=0.2
+	assert_true(abs(node.color.r - 0.067) < 0.05)
+
+	node.get_parent().remove_child(node)
+	node.queue_free()
+
+
+func test_build_layout_rejects_anchor_preset_on_non_control() -> void:
+	# Node doesn't inherit from Control, so anchor_preset must be rejected.
+	var result := _handler.build_layout({
+		"tree": {"type": "Node", "anchor_preset": "center"}
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_build_layout_is_undoable() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return
+	var before_count := scene_root.get_child_count()
+	var result := _handler.build_layout({
+		"tree": {"type": "Panel", "name": "TestBuildUndo",
+			"children": [{"type": "Label"}, {"type": "Button"}]}
+	})
+	assert_has_key(result, "data")
+	assert_eq(scene_root.get_child_count(), before_count + 1)
+	_undo_redo.undo()
+	assert_eq(scene_root.get_child_count(), before_count, "Undo should remove the whole built tree")

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -2772,3 +2772,308 @@ class TestUiSetAnchorPresetTool:
 
         assert result.data["margin"] == 16
         assert result.data["resize_mode"] == "keep_size"
+
+
+# ---------------------------------------------------------------------------
+# ui_build_layout
+# ---------------------------------------------------------------------------
+
+
+class TestUiBuildLayoutTool:
+    async def test_forwards_tree_and_parent(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "build_layout"
+            assert cmd["params"]["tree"]["type"] == "VBoxContainer"
+            assert cmd["params"]["parent_path"] == "/Main/HUD"
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "root_path": "/Main/HUD/PauseMenu",
+                    "node_count": 4,
+                    "undoable": True,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "ui_build_layout",
+            {
+                "tree": {
+                    "type": "VBoxContainer",
+                    "name": "PauseMenu",
+                    "children": [
+                        {"type": "Label", "properties": {"text": "Paused"}},
+                        {"type": "Button", "properties": {"text": "Resume"}},
+                    ],
+                },
+                "parent_path": "/Main/HUD",
+            },
+        )
+        await task
+
+        assert result.data["node_count"] == 4
+        assert result.data["undoable"] is True
+
+    async def test_accepts_stringified_tree_via_json_coercion(self, mcp_stack):
+        """Some MCP clients stringify complex args — JsonCoerced must decode them."""
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            # After JsonCoerced, the tree is a real dict, not a string.
+            assert cmd["params"]["tree"]["type"] == "Panel"
+            await plugin.send_response(
+                cmd["request_id"],
+                {"root_path": "/Panel", "node_count": 1, "undoable": True},
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "ui_build_layout",
+            {"tree": '{"type": "Panel"}'},
+        )
+        await task
+        assert result.data["node_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# theme_create / theme_set_* / theme_apply
+# ---------------------------------------------------------------------------
+
+
+class TestThemeCreateTool:
+    async def test_create_theme(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "create_theme"
+            assert cmd["params"] == {
+                "path": "res://ui/themes/game.tres",
+                "overwrite": False,
+            }
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "path": "res://ui/themes/game.tres",
+                    "overwritten": False,
+                    "undoable": False,
+                    "reason": "File creation is persistent",
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "theme_create", {"path": "res://ui/themes/game.tres"}
+        )
+        await task
+        assert result.data["path"] == "res://ui/themes/game.tres"
+
+
+class TestThemeSetColorTool:
+    async def test_set_color_hex(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "theme_set_color"
+            assert cmd["params"]["value"] == "#e0e0ff"
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "path": "res://ui/themes/game.tres",
+                    "kind": "color",
+                    "class_name": "Label",
+                    "name": "font_color",
+                    "value": {"r": 0.88, "g": 0.88, "b": 1.0, "a": 1.0},
+                    "previous_value": None,
+                    "undoable": True,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "theme_set_color",
+            {
+                "theme_path": "res://ui/themes/game.tres",
+                "class_name": "Label",
+                "name": "font_color",
+                "value": "#e0e0ff",
+            },
+        )
+        await task
+        assert result.data["kind"] == "color"
+        assert result.data["undoable"] is True
+
+
+class TestThemeSetConstantTool:
+    async def test_set_constant(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["params"]["value"] == 16
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "path": "res://ui/themes/game.tres",
+                    "kind": "constant",
+                    "class_name": "VBoxContainer",
+                    "name": "separation",
+                    "value": 16,
+                    "previous_value": None,
+                    "undoable": True,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "theme_set_constant",
+            {
+                "theme_path": "res://ui/themes/game.tres",
+                "class_name": "VBoxContainer",
+                "name": "separation",
+                "value": 16,
+            },
+        )
+        await task
+        assert result.data["value"] == 16
+
+
+class TestThemeSetFontSizeTool:
+    async def test_set_font_size(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["params"]["value"] == 24
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "path": "res://ui/themes/game.tres",
+                    "kind": "font_size",
+                    "class_name": "Label",
+                    "name": "font_size",
+                    "value": 24,
+                    "previous_value": None,
+                    "undoable": True,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "theme_set_font_size",
+            {
+                "theme_path": "res://ui/themes/game.tres",
+                "class_name": "Label",
+                "name": "font_size",
+                "value": 24,
+            },
+        )
+        await task
+        assert result.data["value"] == 24
+
+
+class TestThemeSetStyleboxFlatTool:
+    async def test_composes_stylebox_fields(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "theme_set_stylebox_flat"
+            params = cmd["params"]
+            assert params["class_name"] == "Button"
+            assert params["name"] == "normal"
+            assert params["bg_color"] == "#101820"
+            assert params["border_color"] == "#00ffff"
+            assert params["corner_radius"] == 8
+            # Fields not supplied must not be forwarded.
+            assert "shadow_size" not in params
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "path": "res://ui/themes/game.tres",
+                    "class_name": "Button",
+                    "name": "normal",
+                    "stylebox_class": "StyleBoxFlat",
+                    "bg_color": {"r": 0.06, "g": 0.09, "b": 0.13, "a": 1.0},
+                    "border_width": 2,
+                    "corner_radius": 8,
+                    "undoable": True,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "theme_set_stylebox_flat",
+            {
+                "theme_path": "res://ui/themes/game.tres",
+                "class_name": "Button",
+                "name": "normal",
+                "bg_color": "#101820",
+                "border_color": "#00ffff",
+                "border_width": 2,
+                "corner_radius": 8,
+            },
+        )
+        await task
+        assert result.data["corner_radius"] == 8
+
+
+class TestThemeApplyTool:
+    async def test_apply(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "apply_theme"
+            assert cmd["params"] == {
+                "node_path": "/Main/HUD",
+                "theme_path": "res://ui/themes/game.tres",
+            }
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "node_path": "/Main/HUD",
+                    "theme_path": "res://ui/themes/game.tres",
+                    "cleared": False,
+                    "undoable": True,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "theme_apply",
+            {
+                "node_path": "/Main/HUD",
+                "theme_path": "res://ui/themes/game.tres",
+            },
+        )
+        await task
+        assert result.data["cleared"] is False
+
+    async def test_apply_empty_clears(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["params"]["theme_path"] == ""
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "node_path": "/Main/HUD",
+                    "theme_path": "",
+                    "cleared": True,
+                    "undoable": True,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "theme_apply", {"node_path": "/Main/HUD"}
+        )
+        await task
+        assert result.data["cleared"] is True

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -18,6 +18,7 @@ from godot_ai.handlers import script as script_handlers
 from godot_ai.handlers import session as session_handlers
 from godot_ai.handlers import signal as signal_handlers
 from godot_ai.handlers import testing as testing_handlers
+from godot_ai.handlers import theme as theme_handlers
 from godot_ai.handlers import ui as ui_handlers
 from godot_ai.runtime.direct import DirectRuntime
 from godot_ai.sessions.registry import Session, SessionRegistry
@@ -334,6 +335,66 @@ class StubClient:
                 "margin": params.get("margin", 0),
                 "anchors": {"left": 0.0, "top": 0.0, "right": 1.0, "bottom": 1.0},
                 "offsets": {"left": 0.0, "top": 0.0, "right": 0.0, "bottom": 0.0},
+                "undoable": True,
+            }
+        if command == "build_layout":
+            return {
+                "root_path": "/Main/HUD/PauseMenu",
+                "node_count": 5,
+                "undoable": True,
+            }
+        if command == "create_theme":
+            return {
+                "path": params.get("path", ""),
+                "overwritten": False,
+                "undoable": False,
+            }
+        if command == "theme_set_color":
+            return {
+                "path": params.get("theme_path", ""),
+                "kind": "color",
+                "class_name": params.get("class_name", ""),
+                "name": params.get("name", ""),
+                "value": params.get("value"),
+                "previous_value": None,
+                "undoable": True,
+            }
+        if command == "theme_set_constant":
+            return {
+                "path": params.get("theme_path", ""),
+                "kind": "constant",
+                "class_name": params.get("class_name", ""),
+                "name": params.get("name", ""),
+                "value": params.get("value"),
+                "previous_value": None,
+                "undoable": True,
+            }
+        if command == "theme_set_font_size":
+            return {
+                "path": params.get("theme_path", ""),
+                "kind": "font_size",
+                "class_name": params.get("class_name", ""),
+                "name": params.get("name", ""),
+                "value": params.get("value"),
+                "previous_value": None,
+                "undoable": True,
+            }
+        if command == "theme_set_stylebox_flat":
+            return {
+                "path": params.get("theme_path", ""),
+                "class_name": params.get("class_name", ""),
+                "name": params.get("name", ""),
+                "stylebox_class": "StyleBoxFlat",
+                "bg_color": params.get("bg_color"),
+                "border_width": params.get("border_width", 0),
+                "corner_radius": params.get("corner_radius", 0),
+                "undoable": True,
+            }
+        if command == "apply_theme":
+            return {
+                "node_path": params.get("node_path", ""),
+                "theme_path": params.get("theme_path", ""),
+                "cleared": not params.get("theme_path"),
                 "undoable": True,
             }
         if command == "list_actions":
@@ -2005,3 +2066,178 @@ async def test_ui_set_anchor_preset_handler_passes_resize_mode_and_margin():
         "resize_mode": "keep_size",
         "margin": 12,
     }
+
+
+# ---------------------------------------------------------------------------
+# UI build_layout handler tests
+# ---------------------------------------------------------------------------
+
+
+async def test_ui_build_layout_handler_forwards_tree_and_parent():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    tree = {
+        "type": "VBoxContainer",
+        "name": "PauseMenu",
+        "properties": {"separation": 16},
+        "children": [{"type": "Label", "properties": {"text": "Paused"}}],
+    }
+    result = await ui_handlers.ui_build_layout(
+        runtime, tree=tree, parent_path="/Main/HUD"
+    )
+    assert client.calls[-1]["command"] == "build_layout"
+    assert client.calls[-1]["params"] == {"tree": tree, "parent_path": "/Main/HUD"}
+    assert result["node_count"] == 5
+
+
+async def test_ui_build_layout_handler_defaults_parent_to_empty():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    await ui_handlers.ui_build_layout(runtime, tree={"type": "Panel"})
+    assert client.calls[-1]["params"]["parent_path"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Theme handler tests
+# ---------------------------------------------------------------------------
+
+
+async def test_theme_create_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await theme_handlers.theme_create(
+        runtime, path="res://ui/themes/game.tres"
+    )
+    assert client.calls[-1]["command"] == "create_theme"
+    assert client.calls[-1]["params"] == {
+        "path": "res://ui/themes/game.tres",
+        "overwrite": False,
+    }
+    assert result["path"] == "res://ui/themes/game.tres"
+
+
+async def test_theme_create_handler_overwrite_passthrough():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    await theme_handlers.theme_create(
+        runtime, path="res://ui/themes/game.tres", overwrite=True
+    )
+    assert client.calls[-1]["params"]["overwrite"] is True
+
+
+async def test_theme_set_color_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await theme_handlers.theme_set_color(
+        runtime,
+        theme_path="res://ui/themes/game.tres",
+        class_name="Label",
+        name="font_color",
+        value="#e0e0ff",
+    )
+    assert client.calls[-1]["command"] == "theme_set_color"
+    assert client.calls[-1]["params"] == {
+        "theme_path": "res://ui/themes/game.tres",
+        "class_name": "Label",
+        "name": "font_color",
+        "value": "#e0e0ff",
+    }
+    assert result["class_name"] == "Label"
+
+
+async def test_theme_set_constant_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    await theme_handlers.theme_set_constant(
+        runtime,
+        theme_path="res://ui/themes/game.tres",
+        class_name="VBoxContainer",
+        name="separation",
+        value=12,
+    )
+    assert client.calls[-1]["command"] == "theme_set_constant"
+    assert client.calls[-1]["params"]["value"] == 12
+
+
+async def test_theme_set_font_size_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    await theme_handlers.theme_set_font_size(
+        runtime,
+        theme_path="res://ui/themes/game.tres",
+        class_name="Label",
+        name="font_size",
+        value=24,
+    )
+    assert client.calls[-1]["command"] == "theme_set_font_size"
+    assert client.calls[-1]["params"]["value"] == 24
+
+
+async def test_theme_set_stylebox_flat_handler_only_passes_provided_fields():
+    """Unset optional params must not be forwarded — lets the plugin side keep
+    StyleBoxFlat defaults when a caller only wants to set a few fields."""
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    await theme_handlers.theme_set_stylebox_flat(
+        runtime,
+        theme_path="res://ui/themes/game.tres",
+        class_name="Button",
+        name="normal",
+        bg_color="#101820",
+        corner_radius=8,
+    )
+    params = client.calls[-1]["params"]
+    assert params["bg_color"] == "#101820"
+    assert params["corner_radius"] == 8
+    # Fields that weren't set should be absent, not None.
+    assert "border_color" not in params
+    assert "shadow_size" not in params
+    assert "anti_aliasing" not in params
+
+
+async def test_theme_set_stylebox_flat_handler_forwards_all_fields():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    await theme_handlers.theme_set_stylebox_flat(
+        runtime,
+        theme_path="res://ui/themes/game.tres",
+        class_name="Panel",
+        name="panel",
+        bg_color="#0a0a14",
+        border_color="#00ffff",
+        border_width=2,
+        corner_radius=10,
+        content_margin=12.0,
+        shadow_color="#000000",
+        shadow_size=8,
+        shadow_offset_x=0,
+        shadow_offset_y=4,
+        anti_aliasing=True,
+    )
+    params = client.calls[-1]["params"]
+    assert params["anti_aliasing"] is True
+    assert params["shadow_offset_y"] == 4
+    assert params["content_margin"] == 12.0
+
+
+async def test_theme_apply_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    await theme_handlers.theme_apply(
+        runtime,
+        node_path="/Main/HUD",
+        theme_path="res://ui/themes/game.tres",
+    )
+    assert client.calls[-1]["command"] == "apply_theme"
+    assert client.calls[-1]["params"] == {
+        "node_path": "/Main/HUD",
+        "theme_path": "res://ui/themes/game.tres",
+    }
+
+
+async def test_theme_apply_handler_clears_when_empty():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await theme_handlers.theme_apply(runtime, node_path="/Main/HUD")
+    assert client.calls[-1]["params"]["theme_path"] == ""
+    assert result["cleared"] is True


### PR DESCRIPTION
Stacks on top of #15 (the base branch is `claude/ui-anchor-preset`, not `main` — GitHub will auto-retarget to `main` once #15 merges). The diff below is only the theme + composer work.

Godot's answer to Unity's UXML+USS in one PR. `Theme` is Godot's CSS-analog — a `.tres` resource holding `(class, name) → value` entries that cascade down a Control subtree when assigned. Combined with a declarative layout builder, this is the closest the MCP surface gets to *"write markup, see styled UI."*

## Summary

**Theme tools (6):**
- `theme_create` — new empty Theme at `res://... .tres`
- `theme_set_color` — e.g. `Label.font_color`, `Button.font_hover_color`
- `theme_set_constant` — e.g. `VBoxContainer.separation`, `MarginContainer` margins
- `theme_set_font_size` — per-class text size
- `theme_set_stylebox_flat` — compose `StyleBoxFlat` (bg, border, corner radius, content margin, drop shadow, AA) and assign to a theme slot in one call — the 90% case for Panel / Button / LineEdit styling
- `theme_apply` — assign a Theme to a Control; empty path clears

**`ui_build_layout`:**
- Nested dict → atomic Control subtree. Node spec: `type` + `name` + `properties` + `anchor_preset` + `theme` + `children`.
- Validates everything up-front (types exist, properties exist on their owning class, `res://` paths resolve). If anything fails, no node is created.
- Builds in memory, then attaches under one undo action — Ctrl+Z rolls the entire subtree back in one step. No half-built HUDs.
- Type coercion for Color (hex or dict), Vector2/Vector2i (dict or 2-tuple), NodePath (string).
- Accepts stringified JSON via `JsonCoerced` for clients that stringify complex args.

Example one-shot pause menu:
```json
{
  "type": "Panel", "name": "PauseMenu", "anchor_preset": "full_rect",
  "theme": "res://ui/themes/game.tres",
  "children": [{
    "type": "VBoxContainer", "anchor_preset": "center",
    "properties": {"separation": 16},
    "children": [
      {"type": "Label", "properties": {"text": "Paused"}},
      {"type": "Button", "name": "Resume", "properties": {"text": "Resume"}},
      {"type": "Button", "name": "Quit", "properties": {"text": "Quit"}}
    ]
  }]
}
```

## Test plan

- [x] `ruff check` clean
- [x] 341 Python tests pass locally (+20 vs post-#15: handler unit + tool integration for all 7 new tools, plus `JsonCoerced` regression)
- [x] New GDScript `test_theme.gd` — theme create (path validation, overwrite semantics), color (hex/dict/bad input/missing params), constant, font_size, stylebox field composition, apply to Control, clear, non-Control rejection
- [x] Extended `test_ui.gd` with `build_layout` — simple tree, unknown/non-Node/missing type, unknown property, bad parent path, anchor_preset + Color coercion, anchor_preset-on-non-Control rejection, undo restores tree
- [ ] Live smoke against a real editor — Godot-side suites run in CI via `Godot tests / {Linux,macOS,Windows}`

## Notes

- `theme_create` is marked `undoable: false` (with a reason in the response) because file creation is persistent.
- Theme slot changes are undoable; the handler captures the previous slot state and re-saves the resource on undo.
- Scope: StyleBoxFlat is the 90% case; `StyleBoxTexture` (9-slice images) would be a natural follow-up but wants its own design pass.
- `font_*` slots on a Theme still require a `Font` resource — that's a separate `theme_set_font` we can add once the icon/font-resource handling is hashed out.
