### PR TITLE
Update docs for release workflow, self-update, and new tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,13 +58,25 @@ This uses `src/godot_ai/asgi.py` to run uvicorn with its factory reload path. Uv
 
 The `editor_reload_plugin` MCP tool triggers a live plugin reload inside Godot (`EditorInterface.set_plugin_enabled` off/on). Requires the server to be running externally (not managed by the plugin). The Python handler waits for the new session via `SessionRegistry.wait_for_session()`.
 
-The Godot dock also has a **Start/Stop Dev Server** button for convenience.
+The Godot dock also has a **Start/Stop Dev Server** button for convenience (visible in developer mode).
+
+### Releasing
+
+Use the GitHub Actions workflow to cut a release:
+```bash
+gh workflow run bump-and-release.yml -f bump=patch   # or minor / major
+```
+This bumps `plugin.cfg` + `pyproject.toml`, commits, tags, and pushes. The `release.yml` workflow triggers on the tag and builds a `godot-ai-plugin.zip` attached to the GitHub Release.
+
+### Self-update
+
+The dock checks the GitHub releases API on startup. If a newer version exists, a yellow banner appears with an "Update" button that downloads the release ZIP, extracts it over the current `addons/godot_ai/`, and reloads the plugin. The server process is unaffected.
 
 ## Testing
 
 ### Python tests
 ```bash
-pytest -v                    # 373 unit + integration tests
+pytest -v                    # 375 unit + integration tests
 ```
 
 ### Godot-side tests
@@ -111,8 +123,11 @@ current working tree's `test_project/`.
 
 The plugin can configure MCP clients via `client_configurator.gd`:
 - **Claude Code**: uses `claude mcp add` CLI to register the server
+- **Claude Desktop**: writes JSON config to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows) with `npx mcp-remote` bridge
 - **Codex**: writes TOML config to `~/.codex/config.toml`
 - **Antigravity**: writes directly to `~/.gemini/antigravity/mcp_config.json`
+
+If auto-configure can't find a client's CLI (common with GUI-launched editors that have limited PATH), the dock shows a "Run this manually" panel with a copyable command.
 
 MCP tools `client_configure` and `client_status` expose this to AI clients.
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -1,6 +1,6 @@
 # Godot AI — Working Plan
 
-*Updated 2026-04-15*
+*Updated 2026-04-16*
 
 This is the current working plan for Godot AI. It focuses on active and upcoming work only.
 
@@ -80,7 +80,7 @@ Historical bootstrap material, architecture detail, packaging mechanics, go/no-g
 - [x] batch execution is shipped with a clear contract
 - [x] multi-instance routing works in practice
 - [x] `script.patch` decision is made (shipped: anchor-based replace)
-- [x] test coverage and smoke coverage increase where the new runtime loop needs it (373 Python + 307 GDScript = 680 total)
+- [x] test coverage and smoke coverage increase where the new runtime loop needs it (375 Python + 312 GDScript = 687 total)
 
 ---
 
@@ -88,11 +88,12 @@ Historical bootstrap material, architecture detail, packaging mechanics, go/no-g
 
 See [Packaging & Distribution](packaging-distribution.md) for full detail. The short version:
 
-- [ ] clean install docs for Claude Code, Codex, and other MCP clients
+- [x] clean install docs for Claude Code, Claude Desktop, Codex, and Antigravity (README + dock auto-configure with manual fallback)
 - [ ] PyPI / `uvx` path works reliably
 - [ ] desktop binary path is real, not aspirational
-- [ ] plugin is downloadable from the Godot AssetLib
-- [ ] CI covers Python tests, Godot-side tests, and release-smoke install paths
+- [~] plugin is downloadable from the Godot AssetLib — release ZIP workflow ships `godot-ai-plugin.zip` via GitHub Releases; AssetLib submission in progress; dock has self-update check
+- [x] CI covers Python tests, Godot-side tests, and release-smoke install paths (3 OS × 2 Python + 3 OS Godot + release-smoke)
+- [x] bump-and-release workflow — `gh workflow run bump-and-release.yml -f bump=patch/minor/major` bumps versions, commits, tags, and triggers release build
 - [ ] compatibility guidance is published and maintained
 - [ ] a new user can get from zero to working in under 10 minutes
 
@@ -211,7 +212,7 @@ tracked above.
 ### What Must Exist Before This Is A Fair Benchmark
 
 - [x] run/stop plus screenshot capture and basic performance sampling
-- [ ] `batch.execute` and a safe partial-edit story
+- [x] `batch.execute` and a safe partial-edit story
 - [ ] data-authoring surface for upgrades, enemies, room data, and reusable scenes
 - [~] `ui.*` for HUD and upgrade selection — anchor presets, declarative `ui_build_layout` composer, and `theme_*` authoring shipped; still need `ui_set_text`, `theme_set_font`, `theme_set_stylebox_texture` for pixel-art / custom typography
 - [ ] `camera.*` for follow, bounds, zoom, and shake


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: Add releasing section (bump workflow), self-update docs, Claude Desktop client config, manual fallback note, bump test count to 375
- **implementation-plan.md**: Update Phase 4 progress (CI, install docs, release workflow, AssetLib), check off batch.execute in benchmark, bump test counts to 687
- **skill.md** (local): Add 20 missing tools to inventory, update project structure, add releasing section

## Test plan
- [ ] Verify CLAUDE.md accurately reflects current dev workflow
- [ ] Verify implementation-plan.md checkboxes match actual state

🤖 Generated with [Claude Code](https://claude.com/claude-code)