### PR TITLE
chore: add CI regression-range helper script and document usage

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -29,6 +29,20 @@ test_run suite=scene         # run one suite
 test_results_get             # review last results
 ```
 
+### CI regression range helper
+
+When CI starts failing, identify the regression window (last green → first red):
+
+```bash
+script/ci-find-regression-range hi-godot/godot-ai ci.yml main
+```
+
+If your local clone has a valid `origin` GitHub remote, you can omit `owner/repo`:
+
+```bash
+script/ci-find-regression-range
+```
+
 ## Dev Server with Auto-Reload
 
 For Python-side changes without restarting Godot:

--- a/script/ci-find-regression-range
+++ b/script/ci-find-regression-range
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Identify the "last green" and "first red" commits for a workflow.
+#
+# Usage:
+#   script/ci-find-regression-range [owner/repo] [workflow_file] [branch]
+#
+# Examples:
+#   script/ci-find-regression-range hi-godot/godot-ai ci.yml main
+#
+# Requirements:
+#   - python3
+#   - GitHub API access (optionally authenticated via GH_TOKEN)
+set -euo pipefail
+
+REPO="${1:-}"
+WORKFLOW="${2:-ci.yml}"
+BRANCH="${3:-main}"
+
+if [[ -z "$REPO" ]]; then
+  ORIGIN_URL="$(git config --get remote.origin.url || true)"
+  if [[ "$ORIGIN_URL" =~ github.com[:/]([^/]+/[^/.]+)(\.git)?$ ]]; then
+    REPO="${BASH_REMATCH[1]}"
+  else
+    echo "ERROR: Could not infer owner/repo from git remote."
+    echo "Usage: $0 owner/repo [workflow_file] [branch]"
+    exit 1
+  fi
+fi
+
+python3 - "$REPO" "$WORKFLOW" "$BRANCH" <<'PY'
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+repo, workflow, branch = sys.argv[1:4]
+base = f"https://api.github.com/repos/{repo}/actions/workflows/{workflow}/runs"
+query = urllib.parse.urlencode({
+    "branch": branch,
+    "event": "push",
+    "status": "completed",
+    "per_page": 100,
+})
+url = f"{base}?{query}"
+
+headers = {
+    "Accept": "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+}
+token = os.getenv("GH_TOKEN")
+if token:
+    headers["Authorization"] = f"Bearer {token}"
+
+req = urllib.request.Request(url, headers=headers)
+try:
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        payload = json.load(resp)
+except urllib.error.HTTPError as exc:
+    body = exc.read().decode("utf-8", errors="replace")
+    print(f"ERROR: GitHub API request failed ({exc.code}): {body[:300]}")
+    sys.exit(1)
+except Exception as exc:
+    print(f"ERROR: GitHub API request failed: {exc}")
+    sys.exit(1)
+
+runs = payload.get("workflow_runs", [])
+if not runs:
+    print("No completed push runs found for this workflow/branch.")
+    sys.exit(1)
+
+recent_failures = []
+last_green = None
+for run in runs:
+    concl = run.get("conclusion")
+    if concl == "success":
+        last_green = run
+        break
+    if concl == "failure":
+        recent_failures.append(run)
+
+if last_green is None:
+    print("No successful run found in the fetched window (last 100 runs).")
+    sys.exit(1)
+
+if not recent_failures:
+    print("Latest run is green (no current failure streak found).")
+    print(f"Last green SHA: {last_green.get('head_sha')} ({last_green.get('html_url')})")
+    sys.exit(0)
+
+first_red = recent_failures[-1]
+
+base_sha = last_green.get("head_sha")
+head_sha = first_red.get("head_sha")
+compare_url = f"https://github.com/{repo}/compare/{base_sha}...{head_sha}"
+
+print(f"Repository:     {repo}")
+print(f"Workflow:       {workflow}")
+print(f"Branch:         {branch}")
+print()
+print("Last green run:")
+print(f"  id:           {last_green.get('id')}")
+print(f"  date:         {last_green.get('created_at')}")
+print(f"  sha:          {base_sha}")
+print(f"  url:          {last_green.get('html_url')}")
+print()
+print("First red run after that green:")
+print(f"  id:           {first_red.get('id')}")
+print(f"  date:         {first_red.get('created_at')}")
+print(f"  sha:          {head_sha}")
+print(f"  url:          {first_red.get('html_url')}")
+print()
+print(f"Compare commits: {compare_url}")
+PY


### PR DESCRIPTION
### Motivation

- CI sometimes reports surprising failures (for example “0 tests ran”), and identifying the exact commit window that introduced the regression is a common and time-sensitive debugging step. 
- Automating the discovery of the last successful run and the first failed run after it speeds root-cause investigation and narrows the commit range to inspect.

### Description

- Add `script/ci-find-regression-range`, a small shell wrapper that queries the GitHub Actions API and prints the last green run, the first red run after that, and a `compare` URL between the two SHAs. 
- The script accepts `owner/repo`, `workflow_file`, and `branch` arguments and falls back to inferring `owner/repo` from the `origin` remote when omitted. 
- The script uses only `python3` + the GitHub REST API (optionally authenticated via `GH_TOKEN`) and exits non-zero on API or lookup failures. 
- Document usage in `docs/CONTRIBUTING.md` under a new “CI regression range helper” section and add the executable script file at `script/ci-find-regression-range`.

### Testing

- Performed a syntax check with `bash -n script/ci-find-regression-range`, which succeeded. 
- Attempted a live API invocation with `script/ci-find-regression-range hi-godot/godot-ai ci.yml main`, which failed due to outbound GitHub API being blocked in the environment (HTTP tunnel 403) and not due to the script itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0dc52925883279d71cddc1d7c13c5)