### PR TITLE
Add LICENSE and README to plugin folder for AssetLib

### DIFF
--- a/plugin/addons/godot_ai/LICENSE
+++ b/plugin/addons/godot_ai/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Godot AI contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugin/addons/godot_ai/README.md
+++ b/plugin/addons/godot_ai/README.md
@@ -1,0 +1,27 @@
+# Godot AI
+
+Connect AI assistants to a live Godot editor via the [Model Context Protocol](https://modelcontextprotocol.io/introduction) (MCP).
+
+Godot AI bridges Claude Code, Codex, Antigravity, and other MCP clients with your editor — inspect scenes, create nodes, modify properties, run tests, search project files, and more, all from a prompt.
+
+## Quick Start
+
+1. Copy `addons/godot_ai/` into your project's `addons/` folder
+2. Enable the plugin: **Project > Project Settings > Plugins > Godot AI**
+3. Pick your MCP client in the **Godot AI** dock and press **Configure**
+
+The plugin auto-starts the MCP server and connects over WebSocket. No manual configuration required.
+
+## Requirements
+
+- Godot 4.3+ (4.4+ recommended)
+- [uv](https://docs.astral.sh/uv/) (used to install the Python server)
+- An MCP client ([Claude Code](https://docs.anthropic.com/en/docs/claude-code) | [Codex](https://openai.com/index/codex/) | [Antigravity](https://www.antigravity.dev/))
+
+## Documentation
+
+Full documentation, contributing guide, and source code: [github.com/hi-godot/godot-ai](https://github.com/hi-godot/godot-ai)
+
+## License
+
+[MIT](LICENSE)


### PR DESCRIPTION
## Summary
- Copies root MIT LICENSE into `plugin/addons/godot_ai/`
- Adds a concise plugin-specific README with quick start, requirements, and links
- Required by AssetLib submission guidelines — reviewers expect these inside the addon directory

## Test plan
- [ ] Verify `plugin/addons/godot_ai/LICENSE` matches root LICENSE
- [ ] Verify `plugin/addons/godot_ai/README.md` renders correctly on GitHub
- [ ] Confirm plugin still loads in Godot with the new files present

🤖 Generated with [Claude Code](https://claude.com/claude-code)