### PR TITLE
Address retroactive review of PRs #17 and #21

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ The dock checks the GitHub releases API on startup. If a newer version exists, a
 
 ### Python tests
 ```bash
-pytest -v                    # 387 unit + integration tests
+pytest -v                    # 388 unit + integration tests
 ```
 
 ### Godot-side tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,6 +185,35 @@ JSON dicts like `{"r":1,"g":0,"b":0,"a":1}` only become `Color` / `Vector2` / `V
 
 GDScript tests that just assert `track_count == 1` will pass even when coercion is broken. **Always read back via `track_get_key_value(idx, k)` and assert `value is Color` / `value is Vector3` / etc.** `test_animation.gd` `test_add_property_track_coerces_vector3_dict` is the reference pattern. The same rule applies to any future handler that takes JSON values intended to land as typed Variants in the scene.
 
+Same principle for theme override pseudo-properties on Controls: use `get_theme_color_override`, `get_theme_constant_override`, `get_theme_font_size_override`, `get_theme_stylebox_override` in tests — **not** the fallback `get_theme_color` getters — so a broken override silently resolving via the theme fallback can't mask a bug. `test_ui.gd` `test_build_layout_theme_override_*` are the reference pattern.
+
+### Auto-generated indices: look up at undo time, not do time
+
+When a write tool mutates a resource whose index is assigned by Godot (`Animation.add_track` returns an int index, same for track keys, `MultiMesh.instance_count`, etc.), do **not** capture that index at do time and reuse it in the undo callable. Any other mutation landing between the do and the undo makes the index stale — the undo will then remove the wrong element (or error).
+
+Instead, undo via a helper that resolves the index at undo time via a stable lookup:
+
+```gdscript
+_undo_redo.add_undo_method(self, "_undo_remove_track_by_path", anim, track_path, Animation.TYPE_VALUE)
+
+func _undo_remove_track_by_path(anim: Animation, path: String, type: int) -> void:
+    var idx := anim.find_track(NodePath(path), type)
+    if idx >= 0:
+        anim.remove_track(idx)
+```
+
+See `animation_handler.gd::_undo_remove_track_by_path` for the reference pattern. Cover with a test that interleaves a second mutation between the do and undo of the first (`test_animation.gd::test_add_property_track_undo_survives_interleaving`).
+
+### Scene instancing: use GEN_EDIT_STATE_INSTANCE
+
+When a tool instantiates a PackedScene into the edited scene, pass `PackedScene.GEN_EDIT_STATE_INSTANCE` to `instantiate()`:
+
+```gdscript
+new_node = packed_scene.instantiate(PackedScene.GEN_EDIT_STATE_INSTANCE)
+```
+
+This makes Godot treat the result as a real scene instance: the root shows the foldout icon, the `.tscn` stores a reference to the sub-scene rather than an exploded subtree, and the instance can be swapped or toggled editable via the usual editor UI. Don't manually set descendant owners to your scene_root — descendants of a scene instance stay owned by their sub-scene; overriding that breaks the instance link. See `node_handler.gd::create_node`.
+
 ## Test coverage
 
 100% code coverage for core features, always. Every tool, handler, and protocol path must have both:

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -1,6 +1,6 @@
 # Godot AI — Working Plan
 
-*Updated 2026-04-16*
+*Updated 2026-04-16 (PR #28)*
 
 This is the current working plan for Godot AI. It focuses on active and upcoming work only.
 
@@ -28,7 +28,7 @@ Historical bootstrap material, architecture detail, packaging mechanics, go/no-g
 - [x] Runtime feedback loop: `project.run`/`project.stop`, `editor.screenshot`, `performance.get_monitors`, `logs.clear`
 - [ ] Runtime iteration loop is complete enough for AI-driven feel tuning
 - [ ] Release/install path is complete enough for new users
-- [~] Polished game-production extensions have started — `ui_*` (anchor presets, `ui_build_layout` composer, `theme_override_*` pseudo-properties), `theme_*` (color/constant/font-size/stylebox_flat with per-side overrides/apply), and `animation_*` (AnimationPlayer + `animation_create_simple` composer + delete/validate + overwrite support) shipped; `camera_*`, `audio_*`, and animation preset helpers still pending
+- [~] Polished game-production extensions have started — `ui_*` (anchor presets, `ui_build_layout` composer, `theme_override_*` pseudo-properties), `theme_*` (color/constant/font-size/stylebox_flat with nested `border`/`corners`/`margins`/`shadow` dicts, `apply`), and `animation_*` (AnimationPlayer + `animation_create_simple` composer + delete/validate + overwrite support, undo robust to history interleaving) shipped; `camera_*`, `audio_*`, and animation preset helpers still pending
 
 ## What This Plan Optimizes For
 
@@ -80,7 +80,7 @@ Historical bootstrap material, architecture detail, packaging mechanics, go/no-g
 - [x] batch execution is shipped with a clear contract
 - [x] multi-instance routing works in practice
 - [x] `script.patch` decision is made (shipped: anchor-based replace)
-- [x] test coverage and smoke coverage increase where the new runtime loop needs it (387 Python + 333 GDScript = 720 total)
+- [x] test coverage and smoke coverage increase where the new runtime loop needs it (388 Python + 345 GDScript = 733 total)
 
 ---
 

--- a/plugin/addons/godot_ai/handlers/animation_handler.gd
+++ b/plugin/addons/godot_ai/handlers/animation_handler.gd
@@ -226,6 +226,11 @@ func add_property_track(params: Dictionary) -> Dictionary:
 
 	# Validate + pre-coerce keyframes before mutating. Coercion errors
 	# surface as INVALID_PARAMS rather than silently inserting garbage keys.
+	# Resolve the target property's type ONCE — dense clips used to re-walk
+	# get_property_list() per keyframe.
+	var ctx := _resolve_track_prop_context(track_path, player)
+	if ctx.has("error"):
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ctx.error)
 	var coerced_keyframes: Array = []
 	for kf in keyframes:
 		if typeof(kf) != TYPE_DICTIONARY:
@@ -234,7 +239,7 @@ func add_property_track(params: Dictionary) -> Dictionary:
 			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Each keyframe must have a 'time' field")
 		if not "value" in kf:
 			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Each keyframe must have a 'value' field")
-		var coerce_result := _coerce_value_for_track(kf.get("value"), track_path, player)
+		var coerce_result := _coerce_with_context(kf.get("value"), ctx)
 		if coerce_result.has("error"):
 			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, coerce_result.error)
 		coerced_keyframes.append({
@@ -863,9 +868,21 @@ func _resolve_animation(player: AnimationPlayer, anim_name: String) -> Dictionar
 ## property doesn't, or when parsing a typed value (Color/Vector2/Vector3)
 ## clearly fails — better to reject than silently store garbage.
 static func _coerce_value_for_track(value: Variant, track_path: String, player: AnimationPlayer) -> Dictionary:
+	var ctx := _resolve_track_prop_context(track_path, player)
+	if ctx.has("error"):
+		return {"error": ctx.error}
+	return _coerce_with_context(value, ctx)
+
+
+## Resolve a track_path's target property type once, so callers coercing many
+## keyframes avoid walking `get_property_list()` on every one. Returns:
+##   {pass_through: true}                   — no resolution / authoring-time
+##   {pass_through: false, prop_type, prop_name}  — coerce against this type
+##   {error: msg}                           — property not found on target
+static func _resolve_track_prop_context(track_path: String, player: AnimationPlayer) -> Dictionary:
 	var colon := track_path.rfind(":")
 	if colon < 0:
-		return {"ok": value}
+		return {"pass_through": true}
 
 	var node_part := track_path.substr(0, colon)
 	var prop_part := track_path.substr(colon + 1)
@@ -878,22 +895,32 @@ static func _coerce_value_for_track(value: Variant, track_path: String, player: 
 		if root_node == null:
 			root_node = player.get_parent()
 	if root_node == null:
-		return {"ok": value}
+		return {"pass_through": true}
 
 	var target: Node = root_node.get_node_or_null(node_part)
 	if target == null:
 		# Target node isn't in the scene yet — authoring-time path. Pass through.
-		return {"ok": value}
+		return {"pass_through": true}
 
 	for p in target.get_property_list():
 		if p.name == prop_part:
-			return _coerce_for_type(value, p.get("type", TYPE_NIL), prop_part)
+			return {
+				"pass_through": false,
+				"prop_type": p.get("type", TYPE_NIL),
+				"prop_name": prop_part,
+			}
 
 	# Target exists but the property doesn't. Reject loudly — silently storing
 	# the raw value here produces garbage keyframes at playback time.
 	return {"error":
 		"Property '%s' not found on target '%s' (class %s)" %
 		[prop_part, node_part, target.get_class()]}
+
+
+static func _coerce_with_context(value: Variant, ctx: Dictionary) -> Dictionary:
+	if ctx.get("pass_through", false):
+		return {"ok": value}
+	return _coerce_for_type(value, ctx.prop_type, ctx.prop_name)
 
 
 ## Coerce a single value to the given Godot variant type. Returns

--- a/plugin/addons/godot_ai/handlers/animation_handler.gd
+++ b/plugin/addons/godot_ai/handlers/animation_handler.gd
@@ -156,19 +156,24 @@ func delete_animation(params: Dictionary) -> Dictionary:
 		return resolved
 	var player: AnimationPlayer = resolved.player
 
-	if not player.has_animation(anim_name):
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
-			"Animation '%s' not found on player at %s" % [anim_name, player_path])
-
-	var library: AnimationLibrary = resolved.library
-	if library == null:
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "No default library found")
-
-	var old_anim: Animation = library.get_animation(anim_name)
+	# Use _resolve_animation so we can delete from ANY library, not just the
+	# default. Mirrors the read-side symmetry with animation_get / animation_play
+	# which already search all libraries via _resolve_animation.
+	var anim_resolved := _resolve_animation(player, anim_name)
+	if anim_resolved.has("error"):
+		return anim_resolved
+	var old_anim: Animation = anim_resolved.animation
+	var library: AnimationLibrary = anim_resolved.library
+	# Clip key within the owning library — strips the "libname/" prefix if the
+	# caller passed a qualified name.
+	var clip_key: String = anim_name
+	var slash := anim_name.find("/")
+	if slash >= 0:
+		clip_key = anim_name.substr(slash + 1)
 
 	_undo_redo.create_action("MCP: Delete animation %s" % anim_name)
-	_undo_redo.add_do_method(library, "remove_animation", anim_name)
-	_undo_redo.add_undo_method(library, "add_animation", anim_name, old_anim)
+	_undo_redo.add_do_method(library, "remove_animation", clip_key)
+	_undo_redo.add_undo_method(library, "add_animation", clip_key, old_anim)
 	_undo_redo.add_do_reference(old_anim)  # prevent GC so undo→redo works
 	_undo_redo.commit_action()
 
@@ -176,6 +181,7 @@ func delete_animation(params: Dictionary) -> Dictionary:
 		"data": {
 			"player_path": player_path,
 			"animation_name": anim_name,
+			"library_key": anim_resolved.get("library_key", ""),
 			"undoable": true,
 		}
 	}
@@ -237,11 +243,12 @@ func add_property_track(params: Dictionary) -> Dictionary:
 			"transition": kf.get("transition", "linear"),
 		})
 
-	var baseline := anim.get_track_count()
-
 	_undo_redo.create_action("MCP: Add property track %s to %s" % [track_path, anim_name])
 	_undo_redo.add_do_method(self, "_do_add_property_track", anim, track_path, interp_str, coerced_keyframes)
-	_undo_redo.add_undo_method(anim, "remove_track", baseline)
+	# Undo locates the track by (path, type) at undo time rather than caching
+	# an index captured at do time. Cached indices go stale if any other track
+	# mutation lands between do and undo (Godot editor, another MCP call, etc.)
+	_undo_redo.add_undo_method(self, "_undo_remove_track_by_path", anim, track_path, Animation.TYPE_VALUE)
 	_undo_redo.commit_action()
 
 	return {
@@ -251,7 +258,6 @@ func add_property_track(params: Dictionary) -> Dictionary:
 			"track_path": track_path,
 			"interpolation": interp_str,
 			"keyframe_count": keyframes.size(),
-			"track_index": baseline,
 			"undoable": true,
 		}
 	}
@@ -306,6 +312,12 @@ func add_method_track(params: Dictionary) -> Dictionary:
 			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Each keyframe must have a 'time' field")
 		if not "method" in kf:
 			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Each keyframe must have a 'method' field")
+		var method_field = kf.get("method")
+		if typeof(method_field) != TYPE_STRING or (method_field as String).is_empty():
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "'method' must be a non-empty string")
+		if kf.has("args") and typeof(kf.get("args")) != TYPE_ARRAY:
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+				"'args' must be an array if provided (got %s)" % type_string(typeof(kf.get("args"))))
 
 	var resolved := _resolve_player(player_path)
 	if resolved.has("error"):
@@ -317,11 +329,10 @@ func add_method_track(params: Dictionary) -> Dictionary:
 		return anim_resolved
 	var anim: Animation = anim_resolved.animation
 
-	var baseline := anim.get_track_count()
-
 	_undo_redo.create_action("MCP: Add method track %s to %s" % [target_path, anim_name])
 	_undo_redo.add_do_method(self, "_do_add_method_track", anim, target_path, keyframes)
-	_undo_redo.add_undo_method(anim, "remove_track", baseline)
+	# Undo locates the track by (path, type) at undo time — see add_property_track.
+	_undo_redo.add_undo_method(self, "_undo_remove_track_by_path", anim, target_path, Animation.TYPE_METHOD)
 	_undo_redo.commit_action()
 
 	return {
@@ -330,10 +341,19 @@ func add_method_track(params: Dictionary) -> Dictionary:
 			"animation_name": anim_name,
 			"target_node_path": target_path,
 			"keyframe_count": keyframes.size(),
-			"track_index": baseline,
 			"undoable": true,
 		}
 	}
+
+
+## Remove a track identified by (path, type) at undo time. Robust to
+## history interleaving: if another track was added since the do, the
+## find_track call still resolves to the correct index. Returns silently
+## if the track is no longer present (e.g. a prior undo already removed it).
+func _undo_remove_track_by_path(anim: Animation, track_path: String, track_type: int) -> void:
+	var idx := anim.find_track(NodePath(track_path), track_type)
+	if idx >= 0:
+		anim.remove_track(idx)
 
 
 func _do_add_method_track(anim: Animation, target_path: String, keyframes: Array) -> void:
@@ -862,15 +882,18 @@ static func _coerce_value_for_track(value: Variant, track_path: String, player: 
 
 	var target: Node = root_node.get_node_or_null(node_part)
 	if target == null:
+		# Target node isn't in the scene yet — authoring-time path. Pass through.
 		return {"ok": value}
 
 	for p in target.get_property_list():
 		if p.name == prop_part:
 			return _coerce_for_type(value, p.get("type", TYPE_NIL), prop_part)
 
-	# Property not found on current target — pass through. The caller may
-	# plan to retarget the AnimationPlayer (set root_node) before playback.
-	return {"ok": value}
+	# Target exists but the property doesn't. Reject loudly — silently storing
+	# the raw value here produces garbage keyframes at playback time.
+	return {"error":
+		"Property '%s' not found on target '%s' (class %s)" %
+		[prop_part, node_part, target.get_class()]}
 
 
 ## Coerce a single value to the given Godot variant type. Returns

--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -31,6 +31,10 @@ func create_node(params: Dictionary) -> Dictionary:
 
 	if not scene_path.is_empty():
 		# Scene instancing path — load and instantiate a PackedScene.
+		# GEN_EDIT_STATE_INSTANCE makes the editor treat the result as a real
+		# scene instance (foldout icon, the .tscn stores a reference instead of
+		# an exploded subtree). Descendants remain owned by their sub-scene;
+		# setting their owner to our scene_root would break the instance link.
 		if not scene_path.begins_with("res://"):
 			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "scene_path must start with res://")
 		if not ResourceLoader.exists(scene_path):
@@ -38,7 +42,7 @@ func create_node(params: Dictionary) -> Dictionary:
 		var packed_scene = ResourceLoader.load(scene_path)
 		if packed_scene == null or not packed_scene is PackedScene:
 			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Resource at %s is not a PackedScene" % scene_path)
-		new_node = packed_scene.instantiate()
+		new_node = packed_scene.instantiate(PackedScene.GEN_EDIT_STATE_INSTANCE)
 		if new_node == null:
 			return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to instantiate scene: %s" % scene_path)
 	else:
@@ -62,10 +66,6 @@ func create_node(params: Dictionary) -> Dictionary:
 	_undo_redo.add_do_reference(new_node)
 	_undo_redo.add_undo_method(parent, "remove_child", new_node)
 	_undo_redo.commit_action()
-
-	# For instanced scenes, set owner on descendants so they serialize properly.
-	if not scene_path.is_empty():
-		_set_owner_recursive(new_node, scene_root)
 
 	var response := {
 		"name": new_node.name,

--- a/plugin/addons/godot_ai/handlers/signal_handler.gd
+++ b/plugin/addons/godot_ai/handlers/signal_handler.gd
@@ -117,17 +117,15 @@ func _resolve_signal_params(params: Dictionary) -> Dictionary:
 	if scene_root == null:
 		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
 
-	var source := ScenePath.resolve(params.path, scene_root)
-	if source == null:
-		source = _resolve_autoload(params.path)
-	if source == null:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Source node not found: %s (not in scene tree or autoloads)" % params.path)
+	var source_result := _resolve_node_or_autoload(params.path, scene_root, "Source")
+	if source_result.has("error"):
+		return source_result
+	var source: Node = source_result.node
 
-	var target := ScenePath.resolve(params.target, scene_root)
-	if target == null:
-		target = _resolve_autoload(params.target)
-	if target == null:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Target node not found: %s (not in scene tree or autoloads)" % params.target)
+	var target_result := _resolve_node_or_autoload(params.target, scene_root, "Target")
+	if target_result.has("error"):
+		return target_result
+	var target: Node = target_result.node
 
 	return {
 		"source": source,
@@ -138,16 +136,34 @@ func _resolve_signal_params(params: Dictionary) -> Dictionary:
 	}
 
 
-## Attempt to resolve a path as an autoload singleton.
-## Uses direct ProjectSettings lookup (O(1)) instead of scanning all properties.
-func _resolve_autoload(path: String) -> Node:
+## Resolve a path to a Node, with three distinct outcomes:
+##   1. Found in the edited scene tree → returns {node}
+##   2. Declared as an autoload AND instantiated at edit time → returns {node}
+##   3. Declared as an autoload but NOT instantiated at edit time → returns
+##      INVALID_PARAMS with guidance. Most autoloads are runtime-only, so a
+##      silent "not found" hides the real reason the connection can't be made.
+##   4. Not in scene and not a declared autoload → returns INVALID_PARAMS.
+func _resolve_node_or_autoload(path: String, scene_root: Node, role: String) -> Dictionary:
+	var node := ScenePath.resolve(path, scene_root)
+	if node != null:
+		return {"node": node}
+
 	var name := path.trim_prefix("/")
-	if not ProjectSettings.has_setting("autoload/" + name):
-		return null
-	var tree := Engine.get_main_loop()
-	if tree is SceneTree:
-		return (tree as SceneTree).root.get_node_or_null(name)
-	return null
+	if ProjectSettings.has_setting("autoload/" + name):
+		# Autoload is declared — see if the editor has it instanced.
+		var tree := Engine.get_main_loop()
+		if tree is SceneTree:
+			var live := (tree as SceneTree).root.get_node_or_null(name)
+			if live != null:
+				return {"node": live}
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+			"%s '%s' is a declared autoload but isn't instantiated in the editor. " % [role, name] +
+			"Most autoloads are runtime-only; edit-time signal connection isn't supported for them. " +
+			"Connect it from a script attached to the scene using @onready + connect(), " +
+			"or enable editor-instancing for this autoload in Project Settings > Autoload.")
+
+	return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+		"%s node not found: %s (not in scene tree or autoloads)" % [role, path])
 
 
 func _signal_response(source: Node, signal_name: String, target: Node, method: String, scene_root: Node) -> Dictionary:

--- a/plugin/addons/godot_ai/handlers/theme_handler.gd
+++ b/plugin/addons/godot_ai/handlers/theme_handler.gd
@@ -182,19 +182,19 @@ func _clear_scalar(theme_path: String, clearer: Callable, name: String, class_na
 # theme_set_stylebox_flat
 # ============================================================================
 
-## Compose a StyleBoxFlat from a flat param dict and assign it to a theme slot.
+## Compose a StyleBoxFlat and assign it to a theme slot.
 ##
-## Params beyond theme/class_name/name:
-##   bg_color            (Color, "#rrggbb", or "#rrggbbaa")
-##   border_color        (Color)
-##   border_width        (int) — applied to all sides
-##   corner_radius       (int) — applied to all corners
-##   content_margin      (float) — applied to all sides
-##   shadow_color        (Color)
-##   shadow_size         (int)
-##   shadow_offset_x     (float)
-##   shadow_offset_y     (float)
-##   anti_aliasing       (bool)
+## Parameters (beyond theme_path / class_name / name):
+##   bg_color       (Color, "#rrggbb", "#rrggbbaa", or {r,g,b,a})
+##   border_color   (Color)
+##   border         {all|top|bottom|left|right: int}  — side keys override `all`
+##   corners        {all|top_left|top_right|bottom_left|bottom_right: int}
+##   margins        {all|top|bottom|left|right: float}
+##   shadow         {color, size: int, offset_x: float, offset_y: float}
+##   anti_aliasing  (bool)
+##
+## Unknown keys inside any nested dict are rejected with INVALID_PARAMS so
+## typos fail loudly instead of silently being ignored.
 func set_stylebox_flat(params: Dictionary) -> Dictionary:
 	var load_result := _load_theme_from_params(params)
 	if load_result.has("error"):
@@ -221,33 +221,57 @@ func set_stylebox_flat(params: Dictionary) -> Dictionary:
 		if bc == null:
 			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Invalid border_color")
 		sb.border_color = bc
-	if params.has("border_width"):
-		sb.set_border_width_all(int(params.border_width))
-	for side_key in ["border_width_top", "border_width_bottom", "border_width_left", "border_width_right"]:
-		if params.has(side_key):
-			sb.set(side_key, int(params[side_key]))
-	if params.has("corner_radius"):
-		sb.set_corner_radius_all(int(params.corner_radius))
-	for corner_key in ["corner_radius_top_left", "corner_radius_top_right", "corner_radius_bottom_left", "corner_radius_bottom_right"]:
-		if params.has(corner_key):
-			sb.set(corner_key, int(params[corner_key]))
-	if params.has("content_margin"):
-		sb.set_content_margin_all(float(params.content_margin))
-	for margin_key in ["content_margin_top", "content_margin_bottom", "content_margin_left", "content_margin_right"]:
-		if params.has(margin_key):
-			sb.set(margin_key, float(params[margin_key]))
-	if params.has("shadow_color"):
-		var sc := _parse_color(params.shadow_color)
-		if sc == null:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Invalid shadow_color")
-		sb.shadow_color = sc
-	if params.has("shadow_size"):
-		sb.shadow_size = int(params.shadow_size)
-	if params.has("shadow_offset_x") or params.has("shadow_offset_y"):
-		sb.shadow_offset = Vector2(
-			float(params.get("shadow_offset_x", 0)),
-			float(params.get("shadow_offset_y", 0)),
-		)
+
+	# border: {all, top, bottom, left, right} — int widths
+	if params.has("border"):
+		var err := _apply_sides(sb, params.border, "border",
+			["top", "bottom", "left", "right"],
+			"border_width_",
+			TYPE_INT)
+		if err != "":
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, err)
+
+	# corners: {all, top_left, top_right, bottom_left, bottom_right} — int radii
+	if params.has("corners"):
+		var err2 := _apply_sides(sb, params.corners, "corners",
+			["top_left", "top_right", "bottom_left", "bottom_right"],
+			"corner_radius_",
+			TYPE_INT)
+		if err2 != "":
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, err2)
+
+	# margins: {all, top, bottom, left, right} — float padding
+	if params.has("margins"):
+		var err3 := _apply_sides(sb, params.margins, "margins",
+			["top", "bottom", "left", "right"],
+			"content_margin_",
+			TYPE_FLOAT)
+		if err3 != "":
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, err3)
+
+	# shadow: {color, size, offset_x, offset_y}
+	if params.has("shadow"):
+		if typeof(params.shadow) != TYPE_DICTIONARY:
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "'shadow' must be a dict with color/size/offset_x/offset_y")
+		var shadow: Dictionary = params.shadow
+		var allowed_shadow_keys := {"color": true, "size": true, "offset_x": true, "offset_y": true}
+		for k in shadow.keys():
+			if not allowed_shadow_keys.has(k):
+				return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+					"Unknown key in 'shadow': %s (valid: color, size, offset_x, offset_y)" % k)
+		if shadow.has("color"):
+			var sc := _parse_color(shadow.color)
+			if sc == null:
+				return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Invalid shadow.color")
+			sb.shadow_color = sc
+		if shadow.has("size"):
+			sb.shadow_size = int(shadow.size)
+		if shadow.has("offset_x") or shadow.has("offset_y"):
+			sb.shadow_offset = Vector2(
+				float(shadow.get("offset_x", 0)),
+				float(shadow.get("offset_y", 0)),
+			)
+
 	if params.has("anti_aliasing"):
 		sb.anti_aliasing = bool(params.anti_aliasing)
 
@@ -269,11 +293,55 @@ func set_stylebox_flat(params: Dictionary) -> Dictionary:
 			"name": name,
 			"stylebox_class": "StyleBoxFlat",
 			"bg_color": _serialize_value(sb.bg_color),
-			"border_width": sb.border_width_left,
-			"corner_radius": sb.corner_radius_top_left,
+			"border": {
+				"top": sb.border_width_top,
+				"bottom": sb.border_width_bottom,
+				"left": sb.border_width_left,
+				"right": sb.border_width_right,
+			},
+			"corners": {
+				"top_left": sb.corner_radius_top_left,
+				"top_right": sb.corner_radius_top_right,
+				"bottom_left": sb.corner_radius_bottom_left,
+				"bottom_right": sb.corner_radius_bottom_right,
+			},
+			"margins": {
+				"top": sb.content_margin_top,
+				"bottom": sb.content_margin_bottom,
+				"left": sb.content_margin_left,
+				"right": sb.content_margin_right,
+			},
 			"undoable": true,
 		}
 	}
+
+
+## Parse a {all, <side1>, <side2>, ...} dict and apply it to StyleBoxFlat via
+## its set_<prop_prefix><side> properties. Returns "" on success, an error
+## message on failure. Validates that only known keys are present.
+func _apply_sides(sb: StyleBoxFlat, sides_dict: Variant, dict_name: String,
+		side_names: Array, prop_prefix: String, value_type: int) -> String:
+	if typeof(sides_dict) != TYPE_DICTIONARY:
+		return "'%s' must be a dict with 'all' and/or side-specific keys" % dict_name
+	var valid_keys := {"all": true}
+	for s in side_names:
+		valid_keys[s] = true
+	for k in sides_dict.keys():
+		if not valid_keys.has(k):
+			return "Unknown key in '%s': %s (valid: all, %s)" % [
+				dict_name, k, ", ".join(side_names)
+			]
+	# Apply `all` first, then override with side-specific keys.
+	if sides_dict.has("all"):
+		var all_val: Variant = sides_dict.all
+		for s in side_names:
+			var v: Variant = int(all_val) if value_type == TYPE_INT else float(all_val)
+			sb.set(prop_prefix + s, v)
+	for s in side_names:
+		if sides_dict.has(s):
+			var v2: Variant = int(sides_dict[s]) if value_type == TYPE_INT else float(sides_dict[s])
+			sb.set(prop_prefix + s, v2)
+	return ""
 
 
 func _apply_stylebox(theme_path: String, name: String, class_name_param: String, sb: StyleBox) -> void:

--- a/src/godot_ai/handlers/project.py
+++ b/src/godot_ai/handlers/project.py
@@ -32,11 +32,23 @@ async def project_run(runtime: Runtime, mode: str = "main", scene: str = "") -> 
 
 
 async def project_stop(runtime: Runtime) -> dict:
+    """Stop the running game and wait for readiness to reflect the stop.
+
+    The plugin's `_process` emits a `readiness_changed` event on the next
+    frame once `EditorInterface.is_playing_scene()` flips to false. A write
+    tool called immediately after this handler returns would otherwise race
+    the event and see stale `readiness="playing"`. We poll `session.readiness`
+    until it leaves "playing", bounded by a 1s timeout so a hung play process
+    doesn't block the handler indefinitely — in that case readiness stays
+    "playing" and the next write tool correctly blocks with EDITOR_NOT_READY.
+    """
     result = await runtime.send_command("stop_project")
-    # Give the editor one frame to settle and emit `readiness_changed`.
-    # Without this, a tool call immediately after stop may see stale
-    # readiness="playing" and reject the command.
-    await asyncio.sleep(0.15)
+    session = runtime.get_active_session()
+    if session is not None:
+        loop = asyncio.get_event_loop()
+        deadline = loop.time() + 1.0
+        while session.readiness == "playing" and loop.time() < deadline:
+            await asyncio.sleep(0.02)
     return result
 
 

--- a/src/godot_ai/handlers/project.py
+++ b/src/godot_ai/handlers/project.py
@@ -45,7 +45,7 @@ async def project_stop(runtime: Runtime) -> dict:
     result = await runtime.send_command("stop_project")
     session = runtime.get_active_session()
     if session is not None:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         deadline = loop.time() + 1.0
         while session.readiness == "playing" and loop.time() < deadline:
             await asyncio.sleep(0.02)

--- a/src/godot_ai/handlers/theme.py
+++ b/src/godot_ai/handlers/theme.py
@@ -84,29 +84,11 @@ async def theme_set_stylebox_flat(
     name: str,
     bg_color: Any = None,
     border_color: Any = None,
-    border_width: int | None = None,
-    corner_radius: int | None = None,
-    content_margin: float | None = None,
-    shadow_color: Any = None,
-    shadow_size: int | None = None,
-    shadow_offset_x: float | None = None,
-    shadow_offset_y: float | None = None,
+    border: dict[str, Any] | None = None,
+    corners: dict[str, Any] | None = None,
+    margins: dict[str, Any] | None = None,
+    shadow: dict[str, Any] | None = None,
     anti_aliasing: bool | None = None,
-    # Per-side border width overrides
-    border_width_top: int | None = None,
-    border_width_bottom: int | None = None,
-    border_width_left: int | None = None,
-    border_width_right: int | None = None,
-    # Per-corner radius overrides
-    corner_radius_top_left: int | None = None,
-    corner_radius_top_right: int | None = None,
-    corner_radius_bottom_left: int | None = None,
-    corner_radius_bottom_right: int | None = None,
-    # Per-side content margin overrides
-    content_margin_top: float | None = None,
-    content_margin_bottom: float | None = None,
-    content_margin_left: float | None = None,
-    content_margin_right: float | None = None,
 ) -> dict:
     require_writable(runtime)
     params: dict[str, Any] = {
@@ -118,39 +100,16 @@ async def theme_set_stylebox_flat(
         params["bg_color"] = bg_color
     if border_color is not None:
         params["border_color"] = border_color
-    if border_width is not None:
-        params["border_width"] = border_width
-    if corner_radius is not None:
-        params["corner_radius"] = corner_radius
-    if content_margin is not None:
-        params["content_margin"] = content_margin
-    if shadow_color is not None:
-        params["shadow_color"] = shadow_color
-    if shadow_size is not None:
-        params["shadow_size"] = shadow_size
-    if shadow_offset_x is not None:
-        params["shadow_offset_x"] = shadow_offset_x
-    if shadow_offset_y is not None:
-        params["shadow_offset_y"] = shadow_offset_y
+    if border is not None:
+        params["border"] = border
+    if corners is not None:
+        params["corners"] = corners
+    if margins is not None:
+        params["margins"] = margins
+    if shadow is not None:
+        params["shadow"] = shadow
     if anti_aliasing is not None:
         params["anti_aliasing"] = anti_aliasing
-    # Per-side overrides
-    for key, val in [
-        ("border_width_top", border_width_top),
-        ("border_width_bottom", border_width_bottom),
-        ("border_width_left", border_width_left),
-        ("border_width_right", border_width_right),
-        ("corner_radius_top_left", corner_radius_top_left),
-        ("corner_radius_top_right", corner_radius_top_right),
-        ("corner_radius_bottom_left", corner_radius_bottom_left),
-        ("corner_radius_bottom_right", corner_radius_bottom_right),
-        ("content_margin_top", content_margin_top),
-        ("content_margin_bottom", content_margin_bottom),
-        ("content_margin_left", content_margin_left),
-        ("content_margin_right", content_margin_right),
-    ]:
-        if val is not None:
-            params[key] = val
     return await runtime.send_command("theme_set_stylebox_flat", params)
 
 

--- a/src/godot_ai/tools/theme.py
+++ b/src/godot_ai/tools/theme.py
@@ -8,13 +8,13 @@ property sets with one reusable stylesheet-like document.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
 from fastmcp import Context, FastMCP
 
 from godot_ai.handlers import theme as theme_handlers
 from godot_ai.runtime.direct import DirectRuntime
-from godot_ai.tools import DEFER_META
+from godot_ai.tools import DEFER_META, JsonCoerced
 
 
 def register_theme_tools(mcp: FastMCP) -> None:
@@ -128,26 +128,11 @@ def register_theme_tools(mcp: FastMCP) -> None:
         name: str,
         bg_color: Any = None,
         border_color: Any = None,
-        border_width: int | None = None,
-        corner_radius: int | None = None,
-        content_margin: float | None = None,
-        shadow_color: Any = None,
-        shadow_size: int | None = None,
-        shadow_offset_x: float | None = None,
-        shadow_offset_y: float | None = None,
+        border: Annotated[dict[str, Any] | None, JsonCoerced] = None,
+        corners: Annotated[dict[str, Any] | None, JsonCoerced] = None,
+        margins: Annotated[dict[str, Any] | None, JsonCoerced] = None,
+        shadow: Annotated[dict[str, Any] | None, JsonCoerced] = None,
         anti_aliasing: bool | None = None,
-        border_width_top: int | None = None,
-        border_width_bottom: int | None = None,
-        border_width_left: int | None = None,
-        border_width_right: int | None = None,
-        corner_radius_top_left: int | None = None,
-        corner_radius_top_right: int | None = None,
-        corner_radius_bottom_left: int | None = None,
-        corner_radius_bottom_right: int | None = None,
-        content_margin_top: float | None = None,
-        content_margin_bottom: float | None = None,
-        content_margin_left: float | None = None,
-        content_margin_right: float | None = None,
         session_id: str = "",
     ) -> dict:
         """Compose a StyleBoxFlat and assign it to a theme slot.
@@ -161,6 +146,10 @@ def register_theme_tools(mcp: FastMCP) -> None:
         Common slot names: "normal" (base Button/Panel background), "hover",
         "pressed", "focus", "disabled", "panel" (for Panel / PanelContainer).
 
+        The border/corners/margins/shadow dicts each accept an ``all`` key
+        that applies to every side and side-specific keys that override it.
+        Omit a dict entirely to leave those StyleBox defaults untouched.
+
         Args:
             theme_path: res:// path to the Theme .tres file.
             class_name: Theme type (e.g. "Button", "Panel", "PanelContainer",
@@ -169,26 +158,16 @@ def register_theme_tools(mcp: FastMCP) -> None:
                 "focus", "panel").
             bg_color: Background fill color (hex string, named, or r/g/b/a dict).
             border_color: Border color.
-            border_width: Border thickness in pixels — applied to all 4 sides.
-            corner_radius: Rounded-corner radius in pixels — applied to all 4 corners.
-            content_margin: Inner padding in pixels — applied to all 4 sides.
-            shadow_color: Drop shadow color.
-            shadow_size: Drop shadow blur size in pixels.
-            shadow_offset_x: Horizontal shadow offset.
-            shadow_offset_y: Vertical shadow offset.
+            border: Border widths in pixels. Keys: ``all``, ``top``, ``bottom``,
+                ``left``, ``right``. Side-specific keys override ``all``.
+                Example: ``{"all": 1, "top": 2}`` → top=2, others=1.
+            corners: Corner radii in pixels. Keys: ``all``, ``top_left``,
+                ``top_right``, ``bottom_left``, ``bottom_right``.
+            margins: Inner content padding in pixels. Keys: ``all``, ``top``,
+                ``bottom``, ``left``, ``right``.
+            shadow: Drop shadow. Keys: ``color``, ``size`` (blur, px),
+                ``offset_x``, ``offset_y``.
             anti_aliasing: Whether to anti-alias borders and corners.
-            border_width_top: Border thickness for top side only (overrides border_width).
-            border_width_bottom: Border thickness for bottom side only.
-            border_width_left: Border thickness for left side only.
-            border_width_right: Border thickness for right side only.
-            corner_radius_top_left: Corner radius for top-left (overrides corner_radius).
-            corner_radius_top_right: Corner radius for top-right.
-            corner_radius_bottom_left: Corner radius for bottom-left.
-            corner_radius_bottom_right: Corner radius for bottom-right.
-            content_margin_top: Content margin for top side (overrides content_margin).
-            content_margin_bottom: Content margin for bottom side.
-            content_margin_left: Content margin for left side.
-            content_margin_right: Content margin for right side.
             session_id: Optional Godot session to target. Empty = active session.
         """
         runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
@@ -199,26 +178,11 @@ def register_theme_tools(mcp: FastMCP) -> None:
             name=name,
             bg_color=bg_color,
             border_color=border_color,
-            border_width=border_width,
-            corner_radius=corner_radius,
-            content_margin=content_margin,
-            shadow_color=shadow_color,
-            shadow_size=shadow_size,
-            shadow_offset_x=shadow_offset_x,
-            shadow_offset_y=shadow_offset_y,
+            border=border,
+            corners=corners,
+            margins=margins,
+            shadow=shadow,
             anti_aliasing=anti_aliasing,
-            border_width_top=border_width_top,
-            border_width_bottom=border_width_bottom,
-            border_width_left=border_width_left,
-            border_width_right=border_width_right,
-            corner_radius_top_left=corner_radius_top_left,
-            corner_radius_top_right=corner_radius_top_right,
-            corner_radius_bottom_left=corner_radius_bottom_left,
-            corner_radius_bottom_right=corner_radius_bottom_right,
-            content_margin_top=content_margin_top,
-            content_margin_bottom=content_margin_bottom,
-            content_margin_left=content_margin_left,
-            content_margin_right=content_margin_right,
         )
 
     @mcp.tool(meta=DEFER_META)

--- a/test_project/tests/test_animation.gd
+++ b/test_project/tests/test_animation.gd
@@ -187,13 +187,15 @@ func test_add_property_track_basic() -> void:
 		return
 	_handler.create_animation({"player_path": player_path, "name": "anim", "length": 1.0})
 
+	# Scene root is Node3D — use .:position (a real Vector3 property) rather
+	# than .:modulate which doesn't exist on Node3D.
 	var result := _handler.add_property_track({
 		"player_path": player_path,
 		"animation_name": "anim",
-		"track_path": ".:modulate",
+		"track_path": ".:position",
 		"keyframes": [
-			{"time": 0.0, "value": {"r": 1.0, "g": 1.0, "b": 1.0, "a": 0.0}},
-			{"time": 1.0, "value": {"r": 1.0, "g": 1.0, "b": 1.0, "a": 1.0}},
+			{"time": 0.0, "value": {"x": 0.0, "y": 0.0, "z": 0.0}},
+			{"time": 1.0, "value": {"x": 1.0, "y": 0.0, "z": 0.0}},
 		],
 	})
 	assert_has_key(result, "data")
@@ -233,15 +235,110 @@ func test_add_property_track_is_undoable() -> void:
 	var player := ScenePath.resolve(player_path, scene_root) as AnimationPlayer
 	var anim: Animation = player.get_animation("anim")
 
+	# Scene root is Node3D — use .:visible (a real bool property) rather than
+	# the previous .:modulate which only worked because coercion used to silently
+	# fall through when the property didn't exist.
 	_handler.add_property_track({
 		"player_path": player_path,
 		"animation_name": "anim",
-		"track_path": ".:modulate",
-		"keyframes": [{"time": 0.0, "value": 1.0}, {"time": 1.0, "value": 0.0}],
+		"track_path": ".:visible",
+		"keyframes": [{"time": 0.0, "value": true}, {"time": 1.0, "value": false}],
 	})
 	assert_eq(anim.get_track_count(), 1)
 	_undo_redo.undo()
 	assert_eq(anim.get_track_count(), 0, "Undo should remove the track")
+	_remove_node(player_path)
+
+
+func test_add_property_track_rejects_missing_property() -> void:
+	# Scene root is Node3D — .modulate doesn't exist. Previously coercion
+	# passed through silently; now it errors.
+	var player_path := _add_player("TestMissingProp")
+	if player_path.is_empty():
+		return
+	_handler.create_animation({"player_path": player_path, "name": "anim", "length": 1.0})
+	var result := _handler.add_property_track({
+		"player_path": player_path,
+		"animation_name": "anim",
+		"track_path": ".:modulate",
+		"keyframes": [{"time": 0.0, "value": {"r": 1.0, "g": 0.0, "b": 0.0}}],
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "not found")
+	_remove_node(player_path)
+
+
+func test_add_property_track_undo_survives_interleaving() -> void:
+	# Stress-tests the find_track-at-undo-time pattern: if another track lands
+	# between do and undo, the undo must still remove the CORRECT track — not
+	# whatever happens to sit at the originally captured index.
+	var player_path := _add_player("TestInterleavedUndo")
+	if player_path.is_empty():
+		return
+	_handler.create_animation({"player_path": player_path, "name": "anim", "length": 1.0})
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var player := ScenePath.resolve(player_path, scene_root) as AnimationPlayer
+	var anim: Animation = player.get_animation("anim")
+
+	# Add track A on .:position.
+	_handler.add_property_track({
+		"player_path": player_path,
+		"animation_name": "anim",
+		"track_path": ".:position",
+		"keyframes": [{"time": 0.0, "value": {"x": 0.0, "y": 0.0, "z": 0.0}}],
+	})
+	assert_eq(anim.get_track_count(), 1, "After track A")
+
+	# Add track B on .:scale (interleaves track A's history).
+	_handler.add_property_track({
+		"player_path": player_path,
+		"animation_name": "anim",
+		"track_path": ".:scale",
+		"keyframes": [{"time": 0.0, "value": {"x": 1.0, "y": 1.0, "z": 1.0}}],
+	})
+	assert_eq(anim.get_track_count(), 2, "After track B")
+
+	# Undo B — should remove scale, leaving position.
+	_undo_redo.undo()
+	assert_eq(anim.get_track_count(), 1, "Undo B leaves one track")
+	assert_eq(anim.track_get_path(0), NodePath(".:position"), "Remaining track is position, not scale")
+
+	# Undo A — should remove position.
+	_undo_redo.undo()
+	assert_eq(anim.get_track_count(), 0, "Undo A leaves no tracks")
+
+	_remove_node(player_path)
+
+
+func test_add_method_track_rejects_bad_args() -> void:
+	# args must be an Array if provided — not a string, not a null.
+	var player_path := _add_player("TestBadArgs")
+	if player_path.is_empty():
+		return
+	_handler.create_animation({"player_path": player_path, "name": "anim", "length": 1.0})
+	var result := _handler.add_method_track({
+		"player_path": player_path,
+		"animation_name": "anim",
+		"target_node_path": ".",
+		"keyframes": [{"time": 0.0, "method": "queue_free", "args": "not an array"}],
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "args")
+	_remove_node(player_path)
+
+
+func test_add_method_track_rejects_empty_method() -> void:
+	var player_path := _add_player("TestEmptyMethod")
+	if player_path.is_empty():
+		return
+	_handler.create_animation({"player_path": player_path, "name": "anim", "length": 1.0})
+	var result := _handler.add_method_track({
+		"player_path": player_path,
+		"animation_name": "anim",
+		"target_node_path": ".",
+		"keyframes": [{"time": 0.0, "method": ""}],
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 	_remove_node(player_path)
 
 
@@ -536,10 +633,10 @@ func test_get_returns_track_detail() -> void:
 	_handler.add_property_track({
 		"player_path": player_path,
 		"animation_name": "fade",
-		"track_path": ".:modulate",
+		"track_path": ".:position",
 		"keyframes": [
-			{"time": 0.0, "value": {"r": 1.0, "g": 1.0, "b": 1.0, "a": 0.0}},
-			{"time": 1.0, "value": {"r": 1.0, "g": 1.0, "b": 1.0, "a": 1.0}},
+			{"time": 0.0, "value": {"x": 0.0, "y": 0.0, "z": 0.0}},
+			{"time": 1.0, "value": {"x": 10.0, "y": 0.0, "z": 0.0}},
 		],
 	})
 
@@ -584,6 +681,7 @@ func test_create_simple_explicit_length() -> void:
 	var player_path := _add_player("TestSimpleExplicit")
 	if player_path.is_empty():
 		return
+	# Scene root is Node3D — use .position, not .modulate (not present on Node3D).
 	var result := _handler.create_simple({
 		"player_path": player_path,
 		"name": "fade",
@@ -591,9 +689,9 @@ func test_create_simple_explicit_length() -> void:
 		"tweens": [
 			{
 				"target": ".",
-				"property": "modulate",
-				"from": {"r": 1.0, "g": 1.0, "b": 1.0, "a": 0.0},
-				"to": {"r": 1.0, "g": 1.0, "b": 1.0, "a": 1.0},
+				"property": "position",
+				"from": {"x": 0.0, "y": 0.0, "z": 0.0},
+				"to": {"x": 1.0, "y": 0.0, "z": 0.0},
 				"duration": 0.5,
 			}
 		],
@@ -611,7 +709,7 @@ func test_create_simple_multiple_tweens() -> void:
 		"player_path": player_path,
 		"name": "combo",
 		"tweens": [
-			{"target": ".", "property": "modulate", "from": {"r":1,"g":1,"b":1,"a":0}, "to": {"r":1,"g":1,"b":1,"a":1}, "duration": 0.5},
+			{"target": ".", "property": "scale", "from": {"x":1,"y":1,"z":1}, "to": {"x":2,"y":2,"z":2}, "duration": 0.5},
 			{"target": ".", "property": "position", "from": {"x": -200.0, "y": 0.0, "z": 0.0}, "to": {"x": 0.0, "y": 0.0, "z": 0.0}, "duration": 0.3, "delay": 0.1},
 		],
 	})
@@ -632,7 +730,7 @@ func test_create_simple_is_undoable() -> void:
 		"name": "pulse",
 		"loop_mode": "pingpong",
 		"tweens": [
-			{"target": ".", "property": "modulate", "from": "white", "to": "red", "duration": 0.5},
+			{"target": ".", "property": "scale", "from": {"x":1,"y":1,"z":1}, "to": {"x":2,"y":2,"z":2}, "duration": 0.5},
 		],
 	})
 	assert_true(player.has_animation("pulse"))
@@ -771,7 +869,7 @@ func test_create_simple_rejects_missing_tween_fields() -> void:
 	var result := _handler.create_simple({
 		"player_path": player_path,
 		"name": "bad",
-		"tweens": [{"target": ".", "property": "modulate"}],  # Missing from/to/duration
+		"tweens": [{"target": ".", "property": "position"}],  # Missing from/to/duration
 	})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 	_remove_node(player_path)
@@ -788,8 +886,8 @@ func test_create_simple_rejects_zero_length() -> void:
 		"name": "zerolen",
 		"length": 0.0,
 		"tweens": [
-			{"target": ".", "property": "modulate",
-			 "from": "white", "to": "red", "duration": 0.5},
+			{"target": ".", "property": "scale",
+			 "from": {"x":1,"y":1,"z":1}, "to": {"x":2,"y":2,"z":2}, "duration": 0.5},
 		],
 	})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
@@ -806,8 +904,8 @@ func test_create_simple_rejects_negative_length() -> void:
 		"name": "neglen",
 		"length": -1.0,
 		"tweens": [
-			{"target": ".", "property": "modulate",
-			 "from": "white", "to": "red", "duration": 0.5},
+			{"target": ".", "property": "scale",
+			 "from": {"x":1,"y":1,"z":1}, "to": {"x":2,"y":2,"z":2}, "duration": 0.5},
 		],
 	})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
@@ -915,6 +1013,37 @@ func test_delete_animation_basic() -> void:
 		if anim.name == "to_delete":
 			found = true
 	assert_true(found, "Undo should restore deleted animation")
+
+	_remove_node(player_path)
+
+
+func test_delete_animation_in_non_default_library() -> void:
+	# Previously delete only worked for animations in the default library and
+	# returned INTERNAL_ERROR "No default library found" for anything else.
+	# Now it searches all libraries symmetrically with animation_get / animation_play.
+	var player_path := _add_player("TestDeleteNonDefault")
+	if player_path.is_empty():
+		return
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var player := ScenePath.resolve(player_path, scene_root) as AnimationPlayer
+
+	var lib := AnimationLibrary.new()
+	var anim := Animation.new()
+	anim.length = 0.5
+	lib.add_animation(&"idle", anim)
+	player.add_animation_library(&"moves", lib)
+	assert_true(player.has_animation("moves/idle"), "Setup: library-qualified animation present")
+
+	var result := _handler.delete_animation({
+		"player_path": player_path, "animation_name": "moves/idle",
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.library_key, "moves")
+	assert_false(player.has_animation("moves/idle"), "Animation removed from non-default library")
+
+	# Undo restores it.
+	_undo_redo.undo()
+	assert_true(player.has_animation("moves/idle"), "Undo restored library-qualified animation")
 
 	_remove_node(player_path)
 

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -548,6 +548,79 @@ func test_create_node_from_scene_path() -> void:
 	assert_eq(scene_root.get_child_count(), before_count, "Cleanup should restore child count")
 
 
+func test_create_node_scene_path_preserves_instance_link() -> void:
+	# A scene instanced via GEN_EDIT_STATE_INSTANCE must carry scene_file_path
+	# so the editor treats it as a real instance (foldout icon, swappable, the
+	# .tscn stores a reference rather than an exploded subtree).
+	#
+	# We use a throwaway PackedScene to avoid self-instancing main.tscn.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return
+	var tmp_root := Node2D.new()
+	tmp_root.name = "TmpInstanceRoot"
+	var tmp_child := Node2D.new()
+	tmp_child.name = "TmpChild"
+	tmp_root.add_child(tmp_child)
+	tmp_child.owner = tmp_root
+	var packed := PackedScene.new()
+	packed.pack(tmp_root)
+	var tmp_path := "res://tests/_mcp_test_instance.tscn"
+	ResourceSaver.save(packed, tmp_path)
+	tmp_root.queue_free()
+
+	var result := _handler.create_node({
+		"scene_path": tmp_path,
+		"name": "InstancedTmp",
+	})
+	assert_has_key(result, "data")
+	var instanced: Node = scene_root.find_child("InstancedTmp", false, false)
+	assert_true(instanced != null, "Instanced node exists")
+	# The root of an instanced scene carries scene_file_path pointing to the .tscn.
+	assert_eq(instanced.scene_file_path, tmp_path, "scene_file_path preserves instance link")
+	# Descendants of an instance are NOT owned by our scene_root — they're owned
+	# by the sub-scene, which is what makes Godot treat it as an instance.
+	var desc: Node = instanced.find_child("TmpChild", false, false)
+	assert_true(desc != null, "Descendant exists")
+	assert_true(desc.owner != scene_root, "Descendant owner stays with sub-scene, not our scene_root")
+	# Cleanup.
+	instanced.get_parent().remove_child(instanced)
+	instanced.queue_free()
+	DirAccess.remove_absolute(tmp_path)
+
+
+func test_create_node_scene_path_undo_redo() -> void:
+	# Undo removes the instance; redo restores it with the same scene link.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return
+	var tmp_root := Node2D.new()
+	tmp_root.name = "UndoInstanceRoot"
+	var packed := PackedScene.new()
+	packed.pack(tmp_root)
+	var tmp_path := "res://tests/_mcp_test_undo_instance.tscn"
+	ResourceSaver.save(packed, tmp_path)
+	tmp_root.queue_free()
+
+	var before := scene_root.get_child_count()
+	_handler.create_node({"scene_path": tmp_path, "name": "UndoInstance"})
+	assert_eq(scene_root.get_child_count(), before + 1, "Instance added")
+
+	_undo_redo.undo()
+	assert_eq(scene_root.get_child_count(), before, "Undo removes the instance")
+	assert_true(scene_root.find_child("UndoInstance", false, false) == null, "No node after undo")
+
+	_undo_redo.redo()
+	assert_eq(scene_root.get_child_count(), before + 1, "Redo restores the instance")
+	var restored: Node = scene_root.find_child("UndoInstance", false, false)
+	assert_true(restored != null, "Instance back after redo")
+	assert_eq(restored.scene_file_path, tmp_path, "scene_file_path preserved through redo")
+	# Cleanup.
+	restored.get_parent().remove_child(restored)
+	restored.queue_free()
+	DirAccess.remove_absolute(tmp_path)
+
+
 func test_create_node_scene_path_not_found() -> void:
 	var result := _handler.create_node({
 		"scene_path": "res://nonexistent_scene.tscn",

--- a/test_project/tests/test_signal.gd
+++ b/test_project/tests/test_signal.gd
@@ -110,3 +110,36 @@ func test_connect_signal_autoload_not_found() -> void:
 	})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 	assert_contains(result.error.message, "not found")
+
+
+func test_connect_signal_declared_but_uninstantiated_autoload() -> void:
+	# An autoload declared in ProjectSettings but not instantiated at editor
+	# time (the common case) should produce a specific error that points the
+	# user at the right workaround, not a generic "not found".
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return
+	# Inject a fake autoload entry pointing to a script path that isn't loaded.
+	# We don't actually register it with the editor — just set the setting so
+	# our resolver's declared-but-uninstantiated branch fires.
+	var setting_key := "autoload/TestGhostAutoload"
+	var had_before := ProjectSettings.has_setting(setting_key)
+	var before_value: Variant = ProjectSettings.get_setting(setting_key) if had_before else null
+	ProjectSettings.set_setting(setting_key, "*res://tests/does_not_exist.gd")
+
+	var result := _handler.connect_signal({
+		"path": "TestGhostAutoload",
+		"signal": "ready",
+		"target": "/" + scene_root.name,
+		"method": "queue_free",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	# Error should mention "autoload" and guidance (@onready or runtime).
+	assert_contains(result.error.message, "autoload")
+	assert_contains(result.error.message, "runtime")
+
+	# Cleanup — restore previous setting state.
+	if had_before:
+		ProjectSettings.set_setting(setting_key, before_value)
+	else:
+		ProjectSettings.set_setting(setting_key, null)

--- a/test_project/tests/test_theme.gd
+++ b/test_project/tests/test_theme.gd
@@ -167,6 +167,7 @@ func test_theme_set_font_size() -> void:
 # ----- theme_set_stylebox_flat -----
 
 func test_theme_set_stylebox_flat_composes_fields() -> void:
+	# The `all` key inside each nested dict applies uniformly to all sides.
 	_make_theme()
 	var result := _handler.set_stylebox_flat({
 		"theme_path": TEST_THEME_PATH,
@@ -174,20 +175,80 @@ func test_theme_set_stylebox_flat_composes_fields() -> void:
 		"name": "normal",
 		"bg_color": "#101820",
 		"border_color": "#00ffff",
-		"border_width": 2,
-		"corner_radius": 8,
-		"content_margin": 12.0,
+		"border": {"all": 2},
+		"corners": {"all": 8},
+		"margins": {"all": 12.0},
 	})
 	assert_has_key(result, "data")
 	assert_eq(result.data.stylebox_class, "StyleBoxFlat")
-	assert_eq(result.data.border_width, 2)
-	assert_eq(result.data.corner_radius, 8)
+	assert_eq(result.data.border.top, 2)
+	assert_eq(result.data.corners.top_left, 8)
+	assert_eq(result.data.margins.top, 12.0)
 	var theme: Theme = ResourceLoader.load(TEST_THEME_PATH)
 	var sb: StyleBoxFlat = theme.get_stylebox("normal", "Button")
 	assert_true(sb != null, "StyleBox was saved")
 	assert_eq(sb.border_width_left, 2)
 	assert_eq(sb.corner_radius_top_left, 8)
 	assert_eq(sb.content_margin_left, 12.0)
+
+
+func test_theme_set_stylebox_flat_side_specific_overrides_all() -> void:
+	# Side-specific keys must override `all`.
+	_make_theme()
+	var result := _handler.set_stylebox_flat({
+		"theme_path": TEST_THEME_PATH,
+		"class_name": "Button",
+		"name": "normal",
+		"border": {"all": 1, "top": 4},
+		"corners": {"all": 0, "top_left": 16},
+		"margins": {"all": 2.0, "bottom": 10.0},
+	})
+	assert_has_key(result, "data")
+	# Response reflects the resolved per-side values.
+	assert_eq(result.data.border.top, 4)
+	assert_eq(result.data.border.bottom, 1)
+	assert_eq(result.data.border.left, 1)
+	assert_eq(result.data.border.right, 1)
+	assert_eq(result.data.corners.top_left, 16)
+	assert_eq(result.data.corners.top_right, 0)
+	assert_eq(result.data.margins.bottom, 10.0)
+	assert_eq(result.data.margins.top, 2.0)
+	# And the saved StyleBox matches.
+	var theme: Theme = ResourceLoader.load(TEST_THEME_PATH)
+	var sb: StyleBoxFlat = theme.get_stylebox("normal", "Button")
+	assert_eq(sb.border_width_top, 4)
+	assert_eq(sb.border_width_bottom, 1)
+	assert_eq(sb.corner_radius_top_left, 16)
+	assert_eq(sb.corner_radius_top_right, 0)
+	assert_eq(sb.content_margin_bottom, 10.0)
+
+
+func test_theme_set_stylebox_flat_shadow_nested_dict() -> void:
+	_make_theme()
+	var result := _handler.set_stylebox_flat({
+		"theme_path": TEST_THEME_PATH,
+		"class_name": "Button",
+		"name": "normal",
+		"shadow": {"color": "#00000080", "size": 6, "offset_x": 2.0, "offset_y": 3.0},
+	})
+	assert_has_key(result, "data")
+	var theme: Theme = ResourceLoader.load(TEST_THEME_PATH)
+	var sb: StyleBoxFlat = theme.get_stylebox("normal", "Button")
+	assert_eq(sb.shadow_size, 6)
+	assert_eq(sb.shadow_offset, Vector2(2.0, 3.0))
+
+
+func test_theme_set_stylebox_flat_rejects_unknown_nested_key() -> void:
+	# Typos in nested dicts must fail loudly, not be silently ignored.
+	_make_theme()
+	var result := _handler.set_stylebox_flat({
+		"theme_path": TEST_THEME_PATH,
+		"class_name": "Button",
+		"name": "normal",
+		"border": {"all": 1, "topp": 4},  # 'topp' not a real key
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "topp")
 
 
 func test_theme_set_stylebox_flat_rejects_bad_color() -> void:
@@ -321,7 +382,7 @@ func test_create_theme_creates_parent_directories() -> void:
 	DirAccess.remove_absolute("res://tests/_mcp_nested_dir")
 
 
-# ----- Friction fix: per-side stylebox parameters -----
+# ----- Per-side stylebox parameters via nested dicts -----
 
 func test_set_stylebox_flat_per_side_border_width() -> void:
 	_make_theme()
@@ -329,16 +390,14 @@ func test_set_stylebox_flat_per_side_border_width() -> void:
 		"theme_path": TEST_THEME_PATH,
 		"class_name": "Button",
 		"name": "normal",
-		"border_width": 1,
-		"border_width_top": 4,
-		"border_width_bottom": 2,
+		"border": {"all": 1, "top": 4, "bottom": 2},
 	})
 	assert_has_key(result, "data")
 	var theme: Theme = ResourceLoader.load(TEST_THEME_PATH)
 	var sb: StyleBoxFlat = theme.get_stylebox("normal", "Button")
 	assert_eq(sb.border_width_top, 4)
 	assert_eq(sb.border_width_bottom, 2)
-	assert_eq(sb.border_width_left, 1)  # uniform fallback
+	assert_eq(sb.border_width_left, 1)  # from `all`
 	assert_eq(sb.border_width_right, 1)
 
 
@@ -348,15 +407,13 @@ func test_set_stylebox_flat_per_corner_radius() -> void:
 		"theme_path": TEST_THEME_PATH,
 		"class_name": "Panel",
 		"name": "panel",
-		"corner_radius": 4,
-		"corner_radius_top_left": 12,
-		"corner_radius_bottom_right": 0,
+		"corners": {"all": 4, "top_left": 12, "bottom_right": 0},
 	})
 	assert_has_key(result, "data")
 	var theme: Theme = ResourceLoader.load(TEST_THEME_PATH)
 	var sb: StyleBoxFlat = theme.get_stylebox("panel", "Panel")
 	assert_eq(sb.corner_radius_top_left, 12)
-	assert_eq(sb.corner_radius_top_right, 4)  # uniform fallback
+	assert_eq(sb.corner_radius_top_right, 4)  # from `all`
 	assert_eq(sb.corner_radius_bottom_left, 4)
 	assert_eq(sb.corner_radius_bottom_right, 0)
 
@@ -367,8 +424,7 @@ func test_set_stylebox_flat_per_side_content_margin() -> void:
 		"theme_path": TEST_THEME_PATH,
 		"class_name": "PanelContainer",
 		"name": "panel",
-		"content_margin": 8.0,
-		"content_margin_top": 16.0,
+		"margins": {"all": 8.0, "top": 16.0},
 	})
 	assert_has_key(result, "data")
 	var theme: Theme = ResourceLoader.load(TEST_THEME_PATH)

--- a/test_project/tests/test_ui.gd
+++ b/test_project/tests/test_ui.gd
@@ -343,8 +343,12 @@ func test_build_layout_theme_override_color() -> void:
 	var label: Label = scene_root.find_child("TestOverrideColor", true, false)
 	assert_true(label != null, "Label should exist")
 	assert_true(label.has_theme_color_override("font_color"), "Color override should be set")
-	var c := label.get_theme_color("font_color")
-	assert_true(c.r > 0.9, "Red channel should be ~1.0")
+	# Read back via the *_override getter (not the fallback get_theme_color)
+	# so we're asserting on the stored Variant, not on any theme fallback path.
+	var stored: Color = label.get_theme_color_override("font_color")
+	assert_eq(stored.r, 1.0)
+	assert_eq(stored.g, 0.0)
+	assert_eq(stored.b, 0.0)
 	# Cleanup.
 	label.get_parent().remove_child(label)
 	label.queue_free()
@@ -367,7 +371,8 @@ func test_build_layout_theme_override_constant() -> void:
 	var vbox := scene_root.find_child("TestOverrideConst", true, false) as VBoxContainer
 	assert_true(vbox != null, "VBoxContainer should exist")
 	assert_true(vbox.has_theme_constant_override("separation"), "Constant override should be set")
-	assert_eq(vbox.get_theme_constant("separation"), 20)
+	# Read back via *_override getter — asserts the stored int, not a fallback.
+	assert_eq(vbox.get_theme_constant_override("separation"), 20)
 	vbox.get_parent().remove_child(vbox)
 	vbox.queue_free()
 
@@ -390,9 +395,45 @@ func test_build_layout_theme_override_font_size() -> void:
 	var label := scene_root.find_child("TestOverrideFontSize", true, false) as Label
 	assert_true(label != null, "Label should exist")
 	assert_true(label.has_theme_font_size_override("font_size"), "Font size override should be set")
-	assert_eq(label.get_theme_font_size("font_size"), 32)
+	# Read back via *_override getter.
+	assert_eq(label.get_theme_font_size_override("font_size"), 32)
 	label.get_parent().remove_child(label)
 	label.queue_free()
+
+
+func test_build_layout_theme_override_stylebox() -> void:
+	# theme_override_styles/ accepts a res:// path to a StyleBox resource.
+	# Previously untested — verifies that load + add_theme_stylebox_override
+	# actually install the resource.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return
+	# Create a throwaway StyleBoxFlat on disk.
+	var sb := StyleBoxFlat.new()
+	sb.bg_color = Color(0.1, 0.2, 0.3, 1.0)
+	var sb_path := "res://tests/_mcp_test_override_stylebox.tres"
+	ResourceSaver.save(sb, sb_path)
+
+	var result := _handler.build_layout({
+		"tree": {
+			"type": "Panel",
+			"name": "TestOverrideStyle",
+			"properties": {
+				"theme_override_styles/panel": sb_path,
+			},
+		},
+	})
+	assert_has_key(result, "data")
+	var panel := scene_root.find_child("TestOverrideStyle", true, false) as Panel
+	assert_true(panel != null, "Panel should exist")
+	assert_true(panel.has_theme_stylebox_override("panel"), "Stylebox override should be set")
+	var stored: StyleBox = panel.get_theme_stylebox_override("panel")
+	assert_true(stored is StyleBoxFlat, "Stored override is a StyleBoxFlat")
+	assert_eq((stored as StyleBoxFlat).bg_color, Color(0.1, 0.2, 0.3, 1.0))
+	# Cleanup.
+	panel.get_parent().remove_child(panel)
+	panel.queue_free()
+	DirAccess.remove_absolute(sb_path)
 
 
 func test_build_layout_theme_override_rejects_non_control() -> void:

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -2983,9 +2983,10 @@ class TestThemeSetStyleboxFlatTool:
             assert params["name"] == "normal"
             assert params["bg_color"] == "#101820"
             assert params["border_color"] == "#00ffff"
-            assert params["corner_radius"] == 8
+            assert params["corners"] == {"all": 8}
             # Fields not supplied must not be forwarded.
-            assert "shadow_size" not in params
+            assert "shadow" not in params
+            assert "margins" not in params
             await plugin.send_response(
                 cmd["request_id"],
                 {
@@ -2994,8 +2995,9 @@ class TestThemeSetStyleboxFlatTool:
                     "name": "normal",
                     "stylebox_class": "StyleBoxFlat",
                     "bg_color": {"r": 0.06, "g": 0.09, "b": 0.13, "a": 1.0},
-                    "border_width": 2,
-                    "corner_radius": 8,
+                    "border": {"top": 2, "bottom": 2, "left": 2, "right": 2},
+                    "corners": {"top_left": 8, "top_right": 8, "bottom_left": 8, "bottom_right": 8},
+                    "margins": {"top": 0, "bottom": 0, "left": 0, "right": 0},
                     "undoable": True,
                 },
             )
@@ -3009,26 +3011,24 @@ class TestThemeSetStyleboxFlatTool:
                 "name": "normal",
                 "bg_color": "#101820",
                 "border_color": "#00ffff",
-                "border_width": 2,
-                "corner_radius": 8,
+                "border": {"all": 2},
+                "corners": {"all": 8},
             },
         )
         await task
-        assert result.data["corner_radius"] == 8
+        assert result.data["corners"]["top_left"] == 8
 
-    async def test_per_side_params_forwarded(self, mcp_stack):
+    async def test_nested_dicts_with_overrides_forwarded(self, mcp_stack):
         client, plugin = mcp_stack
 
         async def respond():
             cmd = await plugin.recv_command()
             assert cmd["command"] == "theme_set_stylebox_flat"
             params = cmd["params"]
-            assert params["border_width"] == 1
-            assert params["border_width_top"] == 4
-            assert params["border_width_bottom"] == 2
-            assert "border_width_left" not in params
-            assert params["corner_radius_top_left"] == 12
-            assert params["content_margin_top"] == 16.0
+            assert params["border"] == {"all": 1, "top": 4, "bottom": 2}
+            assert params["corners"] == {"top_left": 12}
+            assert params["margins"] == {"top": 16.0}
+            assert params["shadow"] == {"color": "#000000", "size": 6}
             await plugin.send_response(
                 cmd["request_id"],
                 {
@@ -3037,8 +3037,14 @@ class TestThemeSetStyleboxFlatTool:
                     "name": "normal",
                     "stylebox_class": "StyleBoxFlat",
                     "bg_color": {"r": 0, "g": 0, "b": 0, "a": 1},
-                    "border_width": 1,
-                    "corner_radius": 4,
+                    "border": {"top": 4, "bottom": 2, "left": 1, "right": 1},
+                    "corners": {
+                        "top_left": 12,
+                        "top_right": 0,
+                        "bottom_left": 0,
+                        "bottom_right": 0,
+                    },
+                    "margins": {"top": 16.0, "bottom": 0, "left": 0, "right": 0},
                     "undoable": True,
                 },
             )
@@ -3050,15 +3056,15 @@ class TestThemeSetStyleboxFlatTool:
                 "theme_path": "res://themes/game.tres",
                 "class_name": "Button",
                 "name": "normal",
-                "border_width": 1,
-                "border_width_top": 4,
-                "border_width_bottom": 2,
-                "corner_radius_top_left": 12,
-                "content_margin_top": 16.0,
+                "border": {"all": 1, "top": 4, "bottom": 2},
+                "corners": {"top_left": 12},
+                "margins": {"top": 16.0},
+                "shadow": {"color": "#000000", "size": 6},
             },
         )
         await task
-        assert result.data["border_width"] == 1
+        assert result.data["border"]["top"] == 4
+        assert result.data["margins"]["top"] == 16.0
 
 
 class TestThemeApplyTool:
@@ -3243,7 +3249,6 @@ class TestAnimationAddPropertyTrackTool:
                     "track_path": "Panel:modulate",
                     "interpolation": "linear",
                     "keyframe_count": 2,
-                    "track_index": 0,
                     "undoable": True,
                 },
             )
@@ -3278,7 +3283,6 @@ class TestAnimationAddPropertyTrackTool:
                     "track_path": ".:modulate",
                     "interpolation": "linear",
                     "keyframe_count": 1,
-                    "track_index": 0,
                     "undoable": True,
                 },
             )
@@ -3314,7 +3318,6 @@ class TestAnimationAddMethodTrackTool:
                     "animation_name": "die",
                     "target_node_path": ".",
                     "keyframe_count": 1,
-                    "track_index": 0,
                     "undoable": True,
                 },
             )

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -381,14 +381,33 @@ class StubClient:
                 "undoable": True,
             }
         if command == "theme_set_stylebox_flat":
+            border = params.get("border") or {}
+            corners = params.get("corners") or {}
+            margins = params.get("margins") or {}
             return {
                 "path": params.get("theme_path", ""),
                 "class_name": params.get("class_name", ""),
                 "name": params.get("name", ""),
                 "stylebox_class": "StyleBoxFlat",
                 "bg_color": params.get("bg_color"),
-                "border_width": params.get("border_width", 0),
-                "corner_radius": params.get("corner_radius", 0),
+                "border": {
+                    "top": border.get("top", border.get("all", 0)),
+                    "bottom": border.get("bottom", border.get("all", 0)),
+                    "left": border.get("left", border.get("all", 0)),
+                    "right": border.get("right", border.get("all", 0)),
+                },
+                "corners": {
+                    "top_left": corners.get("top_left", corners.get("all", 0)),
+                    "top_right": corners.get("top_right", corners.get("all", 0)),
+                    "bottom_left": corners.get("bottom_left", corners.get("all", 0)),
+                    "bottom_right": corners.get("bottom_right", corners.get("all", 0)),
+                },
+                "margins": {
+                    "top": margins.get("top", margins.get("all", 0)),
+                    "bottom": margins.get("bottom", margins.get("all", 0)),
+                    "left": margins.get("left", margins.get("all", 0)),
+                    "right": margins.get("right", margins.get("all", 0)),
+                },
                 "undoable": True,
             }
         if command == "apply_theme":
@@ -564,7 +583,6 @@ class StubClient:
                 "track_path": params.get("track_path", ""),
                 "interpolation": params.get("interpolation", "linear"),
                 "keyframe_count": len(params.get("keyframes", [])),
-                "track_index": 0,
                 "undoable": True,
             }
         if command == "animation_add_method_track":
@@ -573,7 +591,6 @@ class StubClient:
                 "animation_name": params.get("animation_name", ""),
                 "target_node_path": params.get("target_node_path", ""),
                 "keyframe_count": len(params.get("keyframes", [])),
-                "track_index": 0,
                 "undoable": True,
             }
         if command == "animation_set_autoplay":
@@ -2275,18 +2292,19 @@ async def test_theme_set_stylebox_flat_handler_only_passes_provided_fields():
         class_name="Button",
         name="normal",
         bg_color="#101820",
-        corner_radius=8,
+        corners={"all": 8},
     )
     params = client.calls[-1]["params"]
     assert params["bg_color"] == "#101820"
-    assert params["corner_radius"] == 8
+    assert params["corners"] == {"all": 8}
     # Fields that weren't set should be absent, not None.
     assert "border_color" not in params
-    assert "shadow_size" not in params
+    assert "border" not in params
+    assert "shadow" not in params
     assert "anti_aliasing" not in params
 
 
-async def test_theme_set_stylebox_flat_handler_forwards_all_fields():
+async def test_theme_set_stylebox_flat_handler_forwards_nested_dicts():
     client = StubClient()
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)
     await theme_handlers.theme_set_stylebox_flat(
@@ -2296,47 +2314,18 @@ async def test_theme_set_stylebox_flat_handler_forwards_all_fields():
         name="panel",
         bg_color="#0a0a14",
         border_color="#00ffff",
-        border_width=2,
-        corner_radius=10,
-        content_margin=12.0,
-        shadow_color="#000000",
-        shadow_size=8,
-        shadow_offset_x=0,
-        shadow_offset_y=4,
+        border={"all": 2, "top": 4},
+        corners={"all": 10},
+        margins={"all": 12.0, "bottom": 20.0},
+        shadow={"color": "#000000", "size": 8, "offset_x": 0, "offset_y": 4},
         anti_aliasing=True,
     )
     params = client.calls[-1]["params"]
     assert params["anti_aliasing"] is True
-    assert params["shadow_offset_y"] == 4
-    assert params["content_margin"] == 12.0
-
-
-async def test_theme_set_stylebox_flat_handler_per_side_params():
-    """Per-side border/corner/margin params should be forwarded when provided."""
-    client = StubClient()
-    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
-    await theme_handlers.theme_set_stylebox_flat(
-        runtime,
-        theme_path="res://themes/game.tres",
-        class_name="Button",
-        name="normal",
-        border_width=1,
-        border_width_top=4,
-        border_width_bottom=2,
-        corner_radius_top_left=12,
-        content_margin_top=16.0,
-    )
-    params = client.calls[-1]["params"]
-    assert params["border_width"] == 1
-    assert params["border_width_top"] == 4
-    assert params["border_width_bottom"] == 2
-    assert params["corner_radius_top_left"] == 12
-    assert params["content_margin_top"] == 16.0
-    # Unset per-side params should be absent.
-    assert "border_width_left" not in params
-    assert "border_width_right" not in params
-    assert "corner_radius_top_right" not in params
-    assert "content_margin_bottom" not in params
+    assert params["border"] == {"all": 2, "top": 4}
+    assert params["corners"] == {"all": 10}
+    assert params["margins"] == {"all": 12.0, "bottom": 20.0}
+    assert params["shadow"]["offset_y"] == 4
 
 
 async def test_theme_apply_handler():
@@ -2755,8 +2744,8 @@ async def test_animation_validate_does_not_require_writable():
     )
 
 
-async def test_project_stop_handler_has_settle_delay():
-    """project_stop should include a brief settle delay."""
+async def test_project_stop_handler_returns_fast_when_no_session():
+    """Without an active session there's nothing to poll on — return immediately."""
     import time
 
     client = StubClient()
@@ -2764,5 +2753,66 @@ async def test_project_stop_handler_has_settle_delay():
     t0 = time.monotonic()
     await project_handlers.project_stop(runtime)
     elapsed = time.monotonic() - t0
-    assert elapsed >= 0.1, f"Expected >= 0.1s settle delay, got {elapsed:.3f}s"
+    assert elapsed < 0.1, f"Expected near-zero elapsed, got {elapsed:.3f}s"
     assert client.calls[-1]["command"] == "stop_project"
+
+
+async def test_project_stop_handler_waits_for_readiness_change():
+    """When session.readiness is 'playing', handler polls until it changes or timeout."""
+    import asyncio
+    import time
+
+    from godot_ai.sessions.registry import Session
+
+    client = StubClient()
+    registry = SessionRegistry()
+    session = Session(
+        session_id="t@0001",
+        godot_version="4.6",
+        project_path="/tmp/test",
+        plugin_version="0.1.0",
+    )
+    session.readiness = "playing"
+    registry.register(session)
+    registry.set_active(session.session_id)
+    runtime = DirectRuntime(registry=registry, client=client)
+
+    # Simulate the plugin's `readiness_changed` event arriving after ~50ms.
+    async def flip_readiness():
+        await asyncio.sleep(0.05)
+        session.readiness = "ready"
+
+    asyncio.create_task(flip_readiness())
+
+    t0 = time.monotonic()
+    await project_handlers.project_stop(runtime)
+    elapsed = time.monotonic() - t0
+    # Should complete when readiness flips, not wait the full 1s timeout.
+    assert elapsed < 0.5, f"Expected fast completion on readiness change, got {elapsed:.3f}s"
+    assert session.readiness == "ready"
+
+
+async def test_project_stop_handler_times_out_if_readiness_stuck():
+    """If readiness stays 'playing' (e.g. hung play process), handler returns after ~1s."""
+    import time
+
+    from godot_ai.sessions.registry import Session
+
+    client = StubClient()
+    registry = SessionRegistry()
+    session = Session(
+        session_id="t@0002",
+        godot_version="4.6",
+        project_path="/tmp/test",
+        plugin_version="0.1.0",
+    )
+    session.readiness = "playing"
+    registry.register(session)
+    registry.set_active(session.session_id)
+    runtime = DirectRuntime(registry=registry, client=client)
+
+    t0 = time.monotonic()
+    await project_handlers.project_stop(runtime)
+    elapsed = time.monotonic() - t0
+    # Timeout should fire ~1s and let the handler return.
+    assert 0.9 <= elapsed < 1.5, f"Expected ~1s timeout, got {elapsed:.3f}s"


### PR DESCRIPTION
## Summary

Nine follow-ups from a retroactive code review of the `animation_*` tool family (#17) and the cyberpunk HUD friction fixes (#21). Review surfaced a mix of confirmed bugs (undo/redo, coercion fall-through), test gaps (pseudo-property readback, interleaved-track undo), and brittle design choices (baseline-index undo, stylebox parameter sprawl).

### Bug fixes
- **Scene instancing**: `node_create scene_path` now uses `GEN_EDIT_STATE_INSTANCE` so the editor treats the result as a real scene instance. Removes the `_set_owner_recursive` that was running outside the undo action and also broke the instance link.
- **Animation track undo**: no longer caches `baseline = track_count` at do time. Resolves the index via `anim.find_track(path, type)` at undo time — robust to history interleaving.
- **Coercion honesty**: `_coerce_value_for_track` now errors when the target node exists but the property doesn't. Previously the raw value silently became a garbage keyframe.
- **Method-track validation**: `args` must be an Array; `method` must be non-empty. No more typed-assign crashes on bad JSON.
- **animation_delete**: reuses `_resolve_animation` so deleting from non-default libraries works (not just the default library).

### API reshape (breaking)
- **`theme_set_stylebox_flat`** flattened from 27 parameters to nested `border` / `corners` / `margins` / `shadow` dicts. Each takes `{all, <sides>}` with side keys overriding `all`. Unknown keys fail loudly. Tool was only merged in #21 and has no external clients yet.

### Architecture
- **`project_stop` readiness**: replaces the fixed 150ms sleep with a bounded poll on `session.readiness`. Reaches truth as soon as the existing `readiness_changed` event arrives (~17ms) instead of blanket-sleeping. 1s timeout for hung play processes.

### Test quality
- **UI pseudo-properties**: `test_ui.gd` now reads back via `get_theme_color_override` / `get_theme_constant_override` / `get_theme_font_size_override` / `get_theme_stylebox_override` — not the fallback getters — per the CLAUDE.md "assert on the stored Variant" rule. Added previously-missing `theme_override_styles/` test.

### Diagnostics
- **`signal_connect` autoloads**: distinguishes declared-but-uninstantiated autoloads from genuinely missing nodes. Clear error pointing users at `@onready`/runtime-connect as the workaround when the autoload isn't instanced at edit time.

### CLAUDE.md
New reference patterns for `find_track`-at-undo-time, `GEN_EDIT_STATE_INSTANCE`, and `get_theme_*_override` readback tests.

## Deferred to follow-up PR

Plugin dispatcher coroutine support + readiness Option C (plugin-side `await get_tree().process_frame`). Touches the hot path every MCP command flows through — isolating it into its own PR keeps this one's blast radius on the tools themselves and makes regression bisect trivial. Once that lands, the server-side polling loop in `project_stop` can be replaced with an authoritative `readiness_after` from the plugin response.

## Test plan

- [x] `ruff check src/ tests/` — all clean
- [x] `pytest -v` — 388 passed
- [x] Godot `test_run` on live editor — 345 passed across 15 suites
- [x] Live smoke: `theme_set_stylebox_flat` with `border={all:1, top:2}` → top=2, others=1
- [x] Live smoke: `animation_add_property_track` with `.:nonexistent_property` → INVALID_PARAMS
- [x] Live smoke: scene-instance undo/redo preserves `scene_file_path` (GDScript test coverage)
- [x] Live smoke: interleaved-track undo removes the correct track (GDScript test coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
