### PR TITLE
tests: close codecov gap on material/particle from #30

### DIFF
--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -3800,6 +3800,69 @@ class TestMaterialAssignTool:
         assert result.data["material_created"] is False
 
 
+class TestMaterialGetTool:
+    async def test_get_material(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "material_get"
+            assert cmd["params"] == {"path": "res://materials/red.tres"}
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "path": "res://materials/red.tres",
+                    "class": "StandardMaterial3D",
+                    "type": "standard",
+                    "properties": [
+                        {
+                            "name": "albedo_color",
+                            "type": "Color",
+                            "value": {"r": 1, "g": 0, "b": 0, "a": 1},
+                        }
+                    ],
+                    "property_count": 1,
+                    "shader_parameters": [],
+                    "shader_path": "",
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "material_get", {"path": "res://materials/red.tres"}
+        )
+        await task
+        assert result.data["class"] == "StandardMaterial3D"
+
+
+class TestMaterialListTool:
+    async def test_list_materials(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "material_list"
+            assert cmd["params"]["root"] == "res://materials"
+            assert cmd["params"]["type"] == "StandardMaterial3D"
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "materials": [
+                        {"path": "res://materials/red.tres", "class": "StandardMaterial3D"},
+                    ],
+                    "count": 1,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "material_list",
+            {"root": "res://materials", "type": "StandardMaterial3D"},
+        )
+        await task
+        assert result.data["count"] == 1
+
+
 class TestMaterialApplyToNodeTool:
     async def test_apply_inline(self, mcp_stack):
         client, plugin = mcp_stack
@@ -3972,6 +4035,43 @@ class TestParticleSetProcessTool:
         )
         await task
         assert "color_ramp" in result.data["applied"]
+
+
+class TestParticleSetDrawPassTool:
+    async def test_set_draw_pass_forwards_pass_and_mesh(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "particle_set_draw_pass"
+            assert cmd["params"]["pass"] == 2
+            assert cmd["params"]["mesh"] == "res://meshes/spark.mesh"
+            assert "texture" not in cmd["params"]
+            assert "material" not in cmd["params"]
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "path": "/Main/Fire",
+                    "pass": 2,
+                    "mesh_path": "res://meshes/spark.mesh",
+                    "mesh_class": "Mesh",
+                    "material_path": "",
+                    "draw_pass_mesh_created": False,
+                    "undoable": True,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "particle_set_draw_pass",
+            {
+                "node_path": "/Main/Fire",
+                "pass_": 2,
+                "mesh": "res://meshes/spark.mesh",
+            },
+        )
+        await task
+        assert result.data["pass"] == 2
 
 
 class TestParticleApplyPresetTool:

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -3113,7 +3113,22 @@ async def test_material_apply_to_node_handler():
     )
     sent = client.calls[-1]["params"]
     assert sent["params"] == {"albedo_color": "#00ff00", "metallic": 0.5}
+    assert "save_to" not in sent
     assert result["material_created"] is True
+
+
+async def test_material_apply_to_node_forwards_save_to():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    await material_handlers.material_apply_to_node(
+        runtime,
+        node_path="/Main/Box",
+        type="standard",
+        params={"albedo_color": "#ff00ff"},
+        save_to="res://materials/my_mat.tres",
+    )
+    sent = client.calls[-1]["params"]
+    assert sent["save_to"] == "res://materials/my_mat.tres"
 
 
 async def test_material_apply_preset_handler():
@@ -3218,6 +3233,22 @@ async def test_particle_set_draw_pass_handler():
     assert params["mesh"] == "res://meshes/spark.mesh"
     assert "texture" not in params
     assert "material" not in params
+
+
+async def test_particle_set_draw_pass_forwards_texture_and_material():
+    """2D particles use `texture`; 3D particles optionally overlay a `material`."""
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    await particle_handlers.particle_set_draw_pass(
+        runtime,
+        node_path="/Main/Rain2D",
+        texture="res://fx/raindrop.png",
+        material="res://materials/splash.tres",
+    )
+    params = client.calls[-1]["params"]
+    assert params["texture"] == "res://fx/raindrop.png"
+    assert params["material"] == "res://materials/splash.tres"
+    assert "mesh" not in params
 
 
 async def test_particle_restart_handler_is_nonwriting():


### PR DESCRIPTION
## Summary

Follow-up to #30 — closes the codecov/patch gap from that PR.

The coverage commit was pushed ~30 seconds after #30 squash-merged, so it missed the merge. The 9 previously-uncovered lines are all conditional branches (`if save_to:`, `if texture:`, `if material:`) and tool-body wiring that integration tests didn't reach.

## Coverage after this PR

| File | Before | After |
|---|---|---|
| `src/godot_ai/handlers/material.py` | 97.77% | **100%** |
| `src/godot_ai/handlers/particle.py` | 93.93% | **100%** |
| `src/godot_ai/tools/material.py` | 89.74% | **100%** |
| `src/godot_ai/tools/particle.py` | 94.28% | **100%** |

## What landed

5 new tests:

- `test_material_apply_to_node_forwards_save_to` — hits the `if save_to:` branch
- `test_particle_set_draw_pass_forwards_texture_and_material` — hits both `if texture:` and `if material:` branches
- `TestMaterialGetTool` integration — end-to-end `material_get` through the mcp_stack
- `TestMaterialListTool` integration — end-to-end `material_list` through the mcp_stack
- `TestParticleSetDrawPassTool` integration — end-to-end `particle_set_draw_pass` through the mcp_stack

## Test plan

- [x] `pytest -v` — 427 passed (up from 422)
- [x] Coverage 100% on all 4 new-module files (measured locally with `--cov-report=term-missing`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
