### PR TITLE
ci: publish godot-ai to PyPI on release tag

### DIFF
--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -1,5 +1,10 @@
 name: Bump and Release
 
+# Manually bumps plugin.cfg + pyproject.toml, commits, tags, and pushes.
+# The tag push then fires release.yml, which publishes to PyPI and creates
+# the GitHub release with the plugin ZIP. This workflow's job is purely the
+# version bump + tag.
+
 on:
   workflow_dispatch:
     inputs:
@@ -54,17 +59,5 @@ jobs:
           git commit -m "Bump version to ${NEW}"
           git tag "v${NEW}"
           git push origin main --tags
-
-      - name: Build plugin ZIP
-        run: |
-          mkdir -p staging/addons
-          cp -r plugin/addons/godot_ai staging/addons/
-          cd staging
-          zip -r ../godot-ai-plugin.zip addons/
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: v${{ steps.next.outputs.version }}
-          files: godot-ai-plugin.zip
-          generate_release_notes: true
+          # Tag push triggers .github/workflows/release.yml which publishes
+          # to PyPI and creates the GitHub Release with the plugin ZIP.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,54 @@ permissions:
   contents: write
 
 jobs:
-  release:
+  # Publish the Python server package to PyPI FIRST so that by the time the
+  # plugin ZIP is released and users self-update, the matching Python package
+  # is already available on PyPI for `uvx --from godot-ai~=<version> godot-ai`
+  # to resolve.
+  #
+  # Uses PyPI Trusted Publishing (OIDC) — no API tokens / secrets required.
+  # Requires a one-time pending-publisher setup on PyPI (see README or the
+  # PR description).
+  publish-pypi:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # required for PyPI OIDC
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install build tools
+        run: python -m pip install --upgrade build
+
+      - name: Verify package version matches tag
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg=$(python -c "import tomllib; print(tomllib.loads(open('pyproject.toml','rb').read().decode())['project']['version'])")
+          if [ "$tag" != "$pkg" ]; then
+            echo "ERROR: tag ($tag) does not match pyproject.toml version ($pkg)" >&2
+            exit 1
+          fi
+          echo "Tag and package version match: $tag"
+
+      - name: Build sdist + wheel
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  # Build the Godot plugin ZIP and attach it to the GitHub Release.
+  # Runs after publish-pypi so the Python package is live on PyPI before the
+  # plugin ZIP download becomes available — prevents a racing user from
+  # installing the plugin and having uvx fail to resolve the Python package.
+  build-plugin-zip:
+    runs-on: ubuntu-latest
+    needs: publish-pypi
+
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

Publishes the `godot-ai` Python package to PyPI on every `v*` tag, so the plugin's tier-2 server discovery (`uvx --from godot-ai~=<plugin_version> godot-ai`) can actually resolve a package. Today PyPI returns 404 for `godot-ai`, which means a fresh user following the README install steps can never start the MCP server.

## What changed

- **`.github/workflows/release.yml`** gains a `publish-pypi` job that runs before the existing `build-plugin-zip` job:
  - Verifies the git tag matches `pyproject.toml`'s `version` (catches desync early).
  - Builds sdist + wheel with `python -m build`.
  - Publishes via `pypa/gh-action-pypi-publish@release/v1` using PyPI Trusted Publishing (OIDC). No API tokens / repo secrets.
- The `build-plugin-zip` job depends on `publish-pypi` so PyPI has the matching Python package **before** the GitHub Release (with plugin ZIP) becomes downloadable. A user whose plugin self-updates the moment the release drops won't race the PyPI upload.
- **`.github/workflows/bump-and-release.yml`** no longer builds its own ZIP or creates a GitHub Release — it now just bumps `plugin.cfg` + `pyproject.toml`, tags, and pushes. The tag push fires `release.yml` which handles both PyPI and the GitHub Release. Removes duplicate release-creation that would have raced with the new publish step.

## Why this flow is safe for self-update

The plugin's server discovery (`client_configurator.gd:get_server_command`) reads the plugin version from `plugin.cfg` and asks uvx for `godot-ai~=<plugin_version>`. The compatible-release operator (`~=0.4.0` means `>=0.4.0, <0.5.dev0`) keeps user installs on the same minor line. So:

- Plugin 0.4.0 installed → `uvx --from godot-ai~=0.4.0 godot-ai` → PyPI resolves to any 0.4.x ✓
- User self-updates to plugin 0.5.0 → `plugin.cfg` version changes → next `_start_server()` asks `godot-ai~=0.5.0` → PyPI resolves to 0.5.x ✓

The new publish flow guarantees that every plugin release has a matching PyPI version available.

## What the repo owner still needs to do (one-time)

PyPI Trusted Publishing needs the publisher to be registered **before** the first publish. Steps:

1. Sign in at https://pypi.org.
2. Go to **Your projects** → **Publishing** (or directly: https://pypi.org/manage/account/publishing/).
3. Click **Add a new pending publisher**.
4. Fill in:
   - **PyPI Project Name**: `godot-ai`
   - **Owner**: `hi-godot`
   - **Repository name**: `godot-ai`
   - **Workflow name**: `release.yml`
   - **Environment name**: *(leave blank for first setup; add later if you want deployment protection rules)*
5. Save.

After that, the next `v*` tag push automatically publishes. On first publish, PyPI "claims" the project name and converts the pending publisher into a permanent one.

### If you'd rather use a token

Token-based publishing is less elegant (rotation + secret management) but works without the pending-publisher dance. To switch: create a PyPI API token scoped to the project, add it to GitHub repo secrets as `PYPI_API_TOKEN`, and change the publish step to:

```yaml
- name: Publish to PyPI
  uses: pypa/gh-action-pypi-publish@release/v1
  with:
    password: ${{ secrets.PYPI_API_TOKEN }}
```

Recommend sticking with Trusted Publishing — it's the PyPI-endorsed path and removes a class of secret-leak risks.

## Test plan

- [x] `python -m build` produces `godot_ai-0.4.0-py3-none-any.whl` + `godot_ai-0.4.0.tar.gz` cleanly (ran locally)
- [x] `pyproject.toml` has all PyPI-required metadata (name, version, description, readme, license via classifiers, authors, dependencies, urls, scripts)
- [ ] After merge + PyPI pending-publisher setup: run `bump-and-release.yml` with bump=`patch` (0.4.0 → 0.4.1) to smoke-test end-to-end PyPI publish
- [ ] Verify `uvx --from godot-ai~=0.4.1 godot-ai --version` resolves from PyPI after the release completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
