### PR TITLE
Add ui_set_text for single-prop text updates on Controls

### DIFF
--- a/plugin/addons/godot_ai/handlers/ui_handler.gd
+++ b/plugin/addons/godot_ai/handlers/ui_handler.gd
@@ -140,9 +140,6 @@ func set_anchor_preset(params: Dictionary) -> Dictionary:
 
 ## Set the visible `text` property on a UI Control (Label, Button + subclasses,
 ## LineEdit, TextEdit, RichTextLabel, LinkButton). Undoable.
-##
-## For RichTextLabel, the value is interpreted as BBCode iff the node's
-## existing `bbcode_enabled` is true — this tool does not toggle that flag.
 func set_text(params: Dictionary) -> Dictionary:
 	var node_path: String = params.get("path", "")
 	if node_path.is_empty():
@@ -161,18 +158,32 @@ func set_text(params: Dictionary) -> Dictionary:
 	var node := ScenePath.resolve(node_path, scene_root)
 	if node == null:
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % node_path)
+	var node_type := node.get_class()
 	if not node is Control:
 		return McpErrorCodes.make(
 			McpErrorCodes.INVALID_PARAMS,
-			"Node %s is not a Control (got %s)" % [node_path, node.get_class()]
+			"Node %s is not a Control (got %s)" % [node_path, node_type]
 		)
-	# Duck-type rather than allowlist: covers Label, Button and all of its
-	# subclasses (CheckBox, CheckButton, OptionButton, MenuButton, LinkButton),
-	# LineEdit, TextEdit, RichTextLabel — plus any future text-bearing Control.
-	if not ("text" in node):
+	# Scan get_property_list() (matches set_property / _apply_property in this
+	# repo) so we can both confirm `text` exists and that it's actually a String
+	# — guards against a custom Control whose `text` happens to be some other
+	# type, where set()-ing a String would silently mis-coerce.
+	var text_prop_type := TYPE_NIL
+	var has_text := false
+	for prop in node.get_property_list():
+		if prop.get("name", "") == "text":
+			has_text = true
+			text_prop_type = prop.get("type", TYPE_NIL)
+			break
+	if not has_text:
 		return McpErrorCodes.make(
 			McpErrorCodes.INVALID_PARAMS,
-			"Control %s has no 'text' property (got %s)" % [node_path, node.get_class()]
+			"Control %s has no 'text' property (got %s)" % [node_path, node_type]
+		)
+	if text_prop_type != TYPE_STRING:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Control %s has a non-string 'text' property (got %s)" % [node_path, node_type]
 		)
 
 	var old_value: String = node.get("text")
@@ -187,7 +198,7 @@ func set_text(params: Dictionary) -> Dictionary:
 			"path": node_path,
 			"text": text_value,
 			"old_text": old_value,
-			"node_type": node.get_class(),
+			"node_type": node_type,
 			"undoable": true,
 		}
 	}

--- a/plugin/addons/godot_ai/handlers/ui_handler.gd
+++ b/plugin/addons/godot_ai/handlers/ui_handler.gd
@@ -138,6 +138,61 @@ func set_anchor_preset(params: Dictionary) -> Dictionary:
 	}
 
 
+## Set the visible `text` property on a UI Control (Label, Button + subclasses,
+## LineEdit, TextEdit, RichTextLabel, LinkButton). Undoable.
+##
+## For RichTextLabel, the value is interpreted as BBCode iff the node's
+## existing `bbcode_enabled` is true — this tool does not toggle that flag.
+func set_text(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("path", "")
+	if node_path.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: path")
+
+	if not params.has("text"):
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: text")
+	var text_value: Variant = params["text"]
+	if typeof(text_value) != TYPE_STRING:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "text must be a string")
+
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+
+	var node := ScenePath.resolve(node_path, scene_root)
+	if node == null:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % node_path)
+	if not node is Control:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Node %s is not a Control (got %s)" % [node_path, node.get_class()]
+		)
+	# Duck-type rather than allowlist: covers Label, Button and all of its
+	# subclasses (CheckBox, CheckButton, OptionButton, MenuButton, LinkButton),
+	# LineEdit, TextEdit, RichTextLabel — plus any future text-bearing Control.
+	if not ("text" in node):
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Control %s has no 'text' property (got %s)" % [node_path, node.get_class()]
+		)
+
+	var old_value: String = node.get("text")
+
+	_undo_redo.create_action("MCP: Set %s text" % node.name)
+	_undo_redo.add_do_property(node, "text", text_value)
+	_undo_redo.add_undo_property(node, "text", old_value)
+	_undo_redo.commit_action()
+
+	return {
+		"data": {
+			"path": node_path,
+			"text": text_value,
+			"old_text": old_value,
+			"node_type": node.get_class(),
+			"undoable": true,
+		}
+	}
+
+
 # ============================================================================
 # build_layout — declarative nested-dict → Control tree in one undo action
 # ============================================================================

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -100,6 +100,7 @@ func _enter_tree() -> void:
 	_dispatcher.register("get_test_results", test_handler.get_test_results)
 	_dispatcher.register("batch_execute", batch_handler.batch_execute)
 	_dispatcher.register("set_anchor_preset", ui_handler.set_anchor_preset)
+	_dispatcher.register("set_text", ui_handler.set_text)
 	_dispatcher.register("build_layout", ui_handler.build_layout)
 	_dispatcher.register("create_theme", theme_handler.create_theme)
 	_dispatcher.register("theme_set_color", theme_handler.set_color)

--- a/src/godot_ai/handlers/ui.py
+++ b/src/godot_ai/handlers/ui.py
@@ -27,6 +27,18 @@ async def ui_set_anchor_preset(
     )
 
 
+async def ui_set_text(
+    runtime: Runtime,
+    path: str,
+    text: str,
+) -> dict:
+    require_writable(runtime)
+    return await runtime.send_command(
+        "set_text",
+        {"path": path, "text": text},
+    )
+
+
 async def ui_build_layout(
     runtime: Runtime,
     tree: dict[str, Any],

--- a/src/godot_ai/tools/ui.py
+++ b/src/godot_ai/tools/ui.py
@@ -56,6 +56,37 @@ def register_ui_tools(mcp: FastMCP) -> None:
         )
 
     @mcp.tool(meta=DEFER_META)
+    async def ui_set_text(
+        ctx: Context,
+        path: str,
+        text: str,
+        session_id: str = "",
+    ) -> dict:
+        """Set the visible text on a UI Control.
+
+        Convenience wrapper for the most common UI write: updating the caption /
+        label / content / placeholder-substitute text on a Control. Works for
+        Label, Button (and its subclasses: CheckBox, CheckButton, OptionButton,
+        MenuButton, LinkButton), LineEdit, TextEdit, and RichTextLabel —
+        anything exposing a `text` property. Equivalent to
+        node_set_property(path, "text", ...) but discoverable under UI keywords.
+
+        For RichTextLabel, the stored value is interpreted as BBCode iff the
+        node's `bbcode_enabled` is already true; this tool does not toggle that
+        flag. Toggle it via node_set_property if needed.
+
+        Keywords: label, button, caption, textbox, line edit, text edit, string,
+        content, rich text, bbcode, hud, dialog.
+
+        Args:
+            path: Scene path to a text-bearing Control (e.g. "/Main/HUD/Score").
+            text: New text value.
+            session_id: Optional Godot session to target. Empty = active session.
+        """
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
+        return await ui_handlers.ui_set_text(runtime, path=path, text=text)
+
+    @mcp.tool(meta=DEFER_META)
     async def ui_build_layout(
         ctx: Context,
         tree: Annotated[dict[str, Any], JsonCoerced],

--- a/test_project/tests/test_ui.gd
+++ b/test_project/tests/test_ui.gd
@@ -39,6 +39,19 @@ func _remove_control(path: String) -> void:
 		node.queue_free()
 
 
+# Add an already-constructed Control subclass (Label, Button, LineEdit, ...) to
+# the scene root under the given name. Returns path, or "" if scene not ready.
+func _add_typed_control(ctl: Control, ctl_name: String) -> String:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		ctl.queue_free()
+		return ""
+	ctl.name = ctl_name
+	scene_root.add_child(ctl)
+	ctl.owner = scene_root
+	return "/" + scene_root.name + "/" + ctl_name
+
+
 # ----- set_anchor_preset: happy path -----
 
 func test_set_anchor_preset_full_rect() -> void:
@@ -197,6 +210,139 @@ func test_set_anchor_preset_is_undoable() -> void:
 	_undo_redo.undo()
 	assert_eq(ctl.anchor_left, before_left, "Undo should restore anchor_left")
 	assert_eq(ctl.anchor_right, before_right, "Undo should restore anchor_right")
+	_remove_control(path)
+
+
+# ============================================================================
+# set_text — set `text` on any text-bearing Control
+# ============================================================================
+
+
+func test_set_text_on_label() -> void:
+	var path := _add_typed_control(Label.new(), "TestSetTextLabel")
+	if path.is_empty():
+		skip("Scene not ready — _add_typed_control returned empty path")
+		return
+	var result := _handler.set_text({"path": path, "text": "Hello"})
+	assert_has_key(result, "data")
+	assert_eq(result.data.text, "Hello")
+	assert_eq(result.data.old_text, "")
+	assert_eq(result.data.node_type, "Label")
+	assert_true(result.data.undoable)
+	# Verify the live node was actually updated.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var label := ScenePath.resolve(path, scene_root) as Label
+	assert_eq(label.text, "Hello")
+	_remove_control(path)
+
+
+func test_set_text_on_button() -> void:
+	var path := _add_typed_control(Button.new(), "TestSetTextButton")
+	if path.is_empty():
+		skip("Scene not ready — _add_typed_control returned empty path")
+		return
+	var result := _handler.set_text({"path": path, "text": "Go"})
+	assert_has_key(result, "data")
+	assert_eq(result.data.text, "Go")
+	assert_eq(result.data.node_type, "Button")
+	_remove_control(path)
+
+
+func test_set_text_on_line_edit() -> void:
+	# LineEdit covers the interactive-input side of the duck-type path.
+	var path := _add_typed_control(LineEdit.new(), "TestSetTextLineEdit")
+	if path.is_empty():
+		skip("Scene not ready — _add_typed_control returned empty path")
+		return
+	var result := _handler.set_text({"path": path, "text": "input"})
+	assert_has_key(result, "data")
+	assert_eq(result.data.text, "input")
+	assert_eq(result.data.node_type, "LineEdit")
+	_remove_control(path)
+
+
+func test_set_text_replaces_existing_text() -> void:
+	var label := Label.new()
+	label.text = "old"
+	var path := _add_typed_control(label, "TestSetTextReplace")
+	if path.is_empty():
+		skip("Scene not ready — _add_typed_control returned empty path")
+		return
+	var result := _handler.set_text({"path": path, "text": "new"})
+	assert_has_key(result, "data")
+	assert_eq(result.data.text, "new")
+	assert_eq(result.data.old_text, "old")
+	_remove_control(path)
+
+
+func test_set_text_missing_path() -> void:
+	var result := _handler.set_text({"text": "hi"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_set_text_missing_text() -> void:
+	var path := _add_typed_control(Label.new(), "TestSetTextMissingText")
+	if path.is_empty():
+		skip("Scene not ready — _add_typed_control returned empty path")
+		return
+	var result := _handler.set_text({"path": path})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "text")
+	_remove_control(path)
+
+
+func test_set_text_rejects_non_string_value() -> void:
+	var path := _add_typed_control(Label.new(), "TestSetTextBadType")
+	if path.is_empty():
+		skip("Scene not ready — _add_typed_control returned empty path")
+		return
+	var result := _handler.set_text({"path": path, "text": 42})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	_remove_control(path)
+
+
+func test_set_text_unknown_node() -> void:
+	var result := _handler.set_text({"path": "/DoesNotExist", "text": "x"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_set_text_non_control_node() -> void:
+	# Scene root in the test project is a Node3D, not a Control.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root — is a scene open?")
+		return
+	var result := _handler.set_text({
+		"path": "/" + scene_root.name, "text": "x"
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "not a Control")
+
+
+func test_set_text_control_without_text_property() -> void:
+	# Panel is a Control but has no `text` property — should give a clear error,
+	# not silently no-op or crash.
+	var path := _add_typed_control(Panel.new(), "TestSetTextNoTextProp")
+	if path.is_empty():
+		skip("Scene not ready — _add_typed_control returned empty path")
+		return
+	var result := _handler.set_text({"path": path, "text": "x"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "text")
+	_remove_control(path)
+
+
+func test_set_text_is_undoable() -> void:
+	var label := Label.new()
+	label.text = "before"
+	var path := _add_typed_control(label, "TestSetTextUndo")
+	if path.is_empty():
+		skip("Scene not ready — _add_typed_control returned empty path")
+		return
+	_handler.set_text({"path": path, "text": "after"})
+	assert_eq(label.text, "after", "Apply should change text")
+	_undo_redo.undo()
+	assert_eq(label.text, "before", "Undo should restore prior text")
 	_remove_control(path)
 
 

--- a/test_project/tests/test_ui.gd
+++ b/test_project/tests/test_ui.gd
@@ -16,16 +16,21 @@ func suite_setup(ctx: Dictionary) -> void:
 	_handler = UiHandler.new(_undo_redo)
 
 
-# Create a Control named `TestHudPanel` under the scene root for a single test.
-# Returns the path, or empty string if the scene isn't ready.
-func _add_control(ctl_name: String = "TestHudPanel") -> String:
+# Add a Control under the scene root for a single test. If `ctl` is null,
+# creates a Panel; otherwise uses the provided (caller-allocated) instance.
+# Returns the scene path, or "" if the scene isn't ready — in which case an
+# already-allocated `ctl` is freed so the caller doesn't leak it.
+func _add_control(ctl_name: String = "TestHudPanel", ctl: Control = null) -> String:
 	var scene_root := EditorInterface.get_edited_scene_root()
 	if scene_root == null:
+		if ctl != null:
+			ctl.queue_free()
 		return ""
-	var panel := Panel.new()
-	panel.name = ctl_name
-	scene_root.add_child(panel)
-	panel.owner = scene_root
+	if ctl == null:
+		ctl = Panel.new()
+	ctl.name = ctl_name
+	scene_root.add_child(ctl)
+	ctl.owner = scene_root
 	return "/" + scene_root.name + "/" + ctl_name
 
 
@@ -37,19 +42,6 @@ func _remove_control(path: String) -> void:
 	if node != null:
 		node.get_parent().remove_child(node)
 		node.queue_free()
-
-
-# Add an already-constructed Control subclass (Label, Button, LineEdit, ...) to
-# the scene root under the given name. Returns path, or "" if scene not ready.
-func _add_typed_control(ctl: Control, ctl_name: String) -> String:
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		ctl.queue_free()
-		return ""
-	ctl.name = ctl_name
-	scene_root.add_child(ctl)
-	ctl.owner = scene_root
-	return "/" + scene_root.name + "/" + ctl_name
 
 
 # ----- set_anchor_preset: happy path -----
@@ -219,9 +211,9 @@ func test_set_anchor_preset_is_undoable() -> void:
 
 
 func test_set_text_on_label() -> void:
-	var path := _add_typed_control(Label.new(), "TestSetTextLabel")
+	var path := _add_control("TestSetTextLabel", Label.new())
 	if path.is_empty():
-		skip("Scene not ready — _add_typed_control returned empty path")
+		skip("Scene not ready — _add_control returned empty path")
 		return
 	var result := _handler.set_text({"path": path, "text": "Hello"})
 	assert_has_key(result, "data")
@@ -237,9 +229,9 @@ func test_set_text_on_label() -> void:
 
 
 func test_set_text_on_button() -> void:
-	var path := _add_typed_control(Button.new(), "TestSetTextButton")
+	var path := _add_control("TestSetTextButton", Button.new())
 	if path.is_empty():
-		skip("Scene not ready — _add_typed_control returned empty path")
+		skip("Scene not ready — _add_control returned empty path")
 		return
 	var result := _handler.set_text({"path": path, "text": "Go"})
 	assert_has_key(result, "data")
@@ -250,9 +242,9 @@ func test_set_text_on_button() -> void:
 
 func test_set_text_on_line_edit() -> void:
 	# LineEdit covers the interactive-input side of the duck-type path.
-	var path := _add_typed_control(LineEdit.new(), "TestSetTextLineEdit")
+	var path := _add_control("TestSetTextLineEdit", LineEdit.new())
 	if path.is_empty():
-		skip("Scene not ready — _add_typed_control returned empty path")
+		skip("Scene not ready — _add_control returned empty path")
 		return
 	var result := _handler.set_text({"path": path, "text": "input"})
 	assert_has_key(result, "data")
@@ -264,9 +256,9 @@ func test_set_text_on_line_edit() -> void:
 func test_set_text_replaces_existing_text() -> void:
 	var label := Label.new()
 	label.text = "old"
-	var path := _add_typed_control(label, "TestSetTextReplace")
+	var path := _add_control("TestSetTextReplace", label)
 	if path.is_empty():
-		skip("Scene not ready — _add_typed_control returned empty path")
+		skip("Scene not ready — _add_control returned empty path")
 		return
 	var result := _handler.set_text({"path": path, "text": "new"})
 	assert_has_key(result, "data")
@@ -281,9 +273,9 @@ func test_set_text_missing_path() -> void:
 
 
 func test_set_text_missing_text() -> void:
-	var path := _add_typed_control(Label.new(), "TestSetTextMissingText")
+	var path := _add_control("TestSetTextMissingText", Label.new())
 	if path.is_empty():
-		skip("Scene not ready — _add_typed_control returned empty path")
+		skip("Scene not ready — _add_control returned empty path")
 		return
 	var result := _handler.set_text({"path": path})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
@@ -292,9 +284,9 @@ func test_set_text_missing_text() -> void:
 
 
 func test_set_text_rejects_non_string_value() -> void:
-	var path := _add_typed_control(Label.new(), "TestSetTextBadType")
+	var path := _add_control("TestSetTextBadType", Label.new())
 	if path.is_empty():
-		skip("Scene not ready — _add_typed_control returned empty path")
+		skip("Scene not ready — _add_control returned empty path")
 		return
 	var result := _handler.set_text({"path": path, "text": 42})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
@@ -322,9 +314,9 @@ func test_set_text_non_control_node() -> void:
 func test_set_text_control_without_text_property() -> void:
 	# Panel is a Control but has no `text` property — should give a clear error,
 	# not silently no-op or crash.
-	var path := _add_typed_control(Panel.new(), "TestSetTextNoTextProp")
+	var path := _add_control("TestSetTextNoTextProp", Panel.new())
 	if path.is_empty():
-		skip("Scene not ready — _add_typed_control returned empty path")
+		skip("Scene not ready — _add_control returned empty path")
 		return
 	var result := _handler.set_text({"path": path, "text": "x"})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
@@ -335,9 +327,9 @@ func test_set_text_control_without_text_property() -> void:
 func test_set_text_is_undoable() -> void:
 	var label := Label.new()
 	label.text = "before"
-	var path := _add_typed_control(label, "TestSetTextUndo")
+	var path := _add_control("TestSetTextUndo", label)
 	if path.is_empty():
-		skip("Scene not ready — _add_typed_control returned empty path")
+		skip("Scene not ready — _add_control returned empty path")
 		return
 	_handler.set_text({"path": path, "text": "after"})
 	assert_eq(label.text, "after", "Apply should change text")

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -2771,6 +2771,65 @@ class TestUiSetAnchorPresetTool:
 
 
 # ---------------------------------------------------------------------------
+# ui_set_text
+# ---------------------------------------------------------------------------
+
+
+class TestUiSetTextTool:
+    async def test_forwards_path_and_text(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "set_text"
+            assert cmd["params"] == {"path": "/Main/HUD/Score", "text": "100"}
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "path": "/Main/HUD/Score",
+                    "text": "100",
+                    "old_text": "0",
+                    "node_type": "Label",
+                    "undoable": True,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "ui_set_text",
+            {"path": "/Main/HUD/Score", "text": "100"},
+        )
+        await task
+
+        assert result.data["text"] == "100"
+        assert result.data["old_text"] == "0"
+        assert result.data["node_type"] == "Label"
+        assert result.data["undoable"] is True
+
+    async def test_surfaces_plugin_error(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            await plugin.send_error(
+                cmd["request_id"],
+                "INVALID_PARAMS",
+                "Node /Main/Camera3D is not a Control (got Camera3D)",
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "ui_set_text",
+            {"path": "/Main/Camera3D", "text": "x"},
+            raise_on_error=False,
+        )
+        await task
+
+        assert result.is_error
+        assert "not a Control" in str(result.content)
+
+
+# ---------------------------------------------------------------------------
 # ui_build_layout
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
The most frequent UI write — setting a Label caption, Button label, LineEdit/TextEdit content, or RichTextLabel body — previously routed through `node_set_property(path, "text", ...)`. That works, but is hard to discover under UI keywords in tool-search. `ui_set_text` is a thin, namespaced, undoable wrapper: resolve the node, verify it's a Control with a String `text` property, set it via `add_do_property`/`add_undo_property`.

Property existence is verified via a `get_property_list()` scan (matching the pattern in `node_handler.set_property` and `ui_handler._apply_property`) and the declared type is checked against `TYPE_STRING` to guard against a hypothetical custom Control whose `text` is some other type. Covers Label, Button + subclasses (CheckBox, CheckButton, OptionButton, MenuButton, LinkButton), LineEdit, TextEdit, and RichTextLabel. BBCode is untouched — callers toggle `bbcode_enabled` via `node_set_property` if needed.

## Test coverage

Following the repo convention (CLAUDE.md §Testing), handler behavior lives in GDScript tests and the Python layer just exercises the MCP-tool boundary.

- **GDScript (`test_project/tests/test_ui.gd`)**: Label/Button/LineEdit happy paths, replacement of existing text, missing-path, missing-text, non-string value, unknown-node, non-Control node, Control without a `text` property, and undo.
- **Python integration (`tests/integration/test_mcp_tools.py`)**: passthrough of `path` + `text` to the plugin command, and surfacing of a plugin-side error (`INVALID_PARAMS` → tool result).

https://claude.ai/code/session_01Apbfysx9EWHmaRG1ubysw4