### PR TITLE
feat: add audio_* tool namespace for AudioStreamPlayer authoring

### DIFF
--- a/plugin/addons/godot_ai/handlers/audio_handler.gd
+++ b/plugin/addons/godot_ai/handlers/audio_handler.gd
@@ -1,0 +1,354 @@
+@tool
+class_name AudioHandler
+extends RefCounted
+
+## Handles AudioStreamPlayer / 2D / 3D authoring — node creation, stream
+## assignment, playback-property edits, and real editor preview playback.
+##
+## Stream assignment loads a Godot-imported AudioStream resource from
+## res:// (the editor's import step converts .ogg / .wav / .mp3 into a
+## streamable AudioStream subclass before we ever see it).
+##
+## play() / stop() call the live node method directly — no undo, no
+## persistence; they match what the inspector's play button does.
+
+
+const _VALID_TYPES := {
+	"1d": "AudioStreamPlayer",
+	"2d": "AudioStreamPlayer2D",
+	"3d": "AudioStreamPlayer3D",
+}
+
+## Whitelist of playback properties settable via audio_player_set_playback.
+## Each value is the expected Variant type of the param dict value.
+const _PLAYBACK_KEYS := {
+	"volume_db": TYPE_FLOAT,
+	"pitch_scale": TYPE_FLOAT,
+	"autoplay": TYPE_BOOL,
+	"bus": TYPE_STRING,
+}
+
+
+var _undo_redo: EditorUndoRedoManager
+
+
+func _init(undo_redo: EditorUndoRedoManager) -> void:
+	_undo_redo = undo_redo
+
+
+# ============================================================================
+# audio_player_create
+# ============================================================================
+
+func create_player(params: Dictionary) -> Dictionary:
+	var parent_path: String = params.get("parent_path", "")
+	var node_name: String = params.get("name", "AudioStreamPlayer")
+	var type_str: String = params.get("type", "1d")
+
+	if not _VALID_TYPES.has(type_str):
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Invalid audio player type '%s'. Valid: %s" % [type_str, ", ".join(_VALID_TYPES.keys())]
+		)
+
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+
+	var parent: Node = scene_root
+	if not parent_path.is_empty():
+		parent = ScenePath.resolve(parent_path, scene_root)
+		if parent == null:
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Parent not found: %s" % parent_path)
+
+	var node := _instantiate_player(type_str)
+	if node == null:
+		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to instantiate audio player")
+	if not node_name.is_empty():
+		node.name = node_name
+
+	_undo_redo.create_action("MCP: Create %s '%s'" % [_VALID_TYPES[type_str], node.name])
+	_undo_redo.add_do_method(parent, "add_child", node, true)
+	_undo_redo.add_do_method(node, "set_owner", scene_root)
+	_undo_redo.add_do_reference(node)
+	_undo_redo.add_undo_method(parent, "remove_child", node)
+	_undo_redo.commit_action()
+
+	return {
+		"data": {
+			"path": ScenePath.from_node(node, scene_root),
+			"parent_path": ScenePath.from_node(parent, scene_root),
+			"name": String(node.name),
+			"type": type_str,
+			"class": _VALID_TYPES[type_str],
+			"undoable": true,
+		}
+	}
+
+
+# ============================================================================
+# audio_player_set_stream
+# ============================================================================
+
+func set_stream(params: Dictionary) -> Dictionary:
+	var player_path: String = params.get("player_path", "")
+	var stream_path: String = params.get("stream_path", "")
+
+	if player_path.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: player_path")
+	if stream_path.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: stream_path")
+
+	var resolved := _resolve_player(player_path)
+	if resolved.has("error"):
+		return resolved
+	var player: Node = resolved.player
+
+	if not ResourceLoader.exists(stream_path):
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "AudioStream not found: %s" % stream_path)
+	var loaded := ResourceLoader.load(stream_path)
+	if not (loaded is AudioStream):
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Resource at %s is not an AudioStream (got %s)" % [stream_path, loaded.get_class()]
+		)
+
+	var old_stream: AudioStream = player.stream
+
+	_undo_redo.create_action("MCP: Set audio stream on %s" % player.name)
+	_undo_redo.add_do_property(player, "stream", loaded)
+	_undo_redo.add_undo_property(player, "stream", old_stream)
+	_undo_redo.commit_action()
+
+	return {
+		"data": {
+			"player_path": player_path,
+			"stream_path": stream_path,
+			"stream_class": loaded.get_class(),
+			"duration_seconds": float(loaded.get_length()),
+			"undoable": true,
+		}
+	}
+
+
+# ============================================================================
+# audio_player_set_playback
+# ============================================================================
+
+func set_playback(params: Dictionary) -> Dictionary:
+	var player_path: String = params.get("player_path", "")
+	if player_path.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: player_path")
+
+	var resolved := _resolve_player(player_path)
+	if resolved.has("error"):
+		return resolved
+	var player: Node = resolved.player
+
+	# Collect and validate only the keys the caller actually provided. An
+	# empty update is rejected — matches the pattern elsewhere (set_main).
+	var updates: Dictionary = {}
+	for key in _PLAYBACK_KEYS:
+		if params.has(key):
+			var expected_type: int = _PLAYBACK_KEYS[key]
+			var value = params.get(key)
+			var coerced = _coerce_playback_value(key, value, expected_type)
+			if coerced == null:
+				return McpErrorCodes.make(
+					McpErrorCodes.INVALID_PARAMS,
+					"Invalid value for %s: expected %s, got %s" % [
+						key, type_string(expected_type), type_string(typeof(value))
+					]
+				)
+			updates[key] = coerced
+
+	if updates.is_empty():
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"At least one of %s is required" % ", ".join(_PLAYBACK_KEYS.keys())
+		)
+
+	var old_values: Dictionary = {}
+	for key in updates:
+		old_values[key] = player.get(key)
+
+	_undo_redo.create_action("MCP: Update playback on %s" % player.name)
+	for key in updates:
+		_undo_redo.add_do_property(player, key, updates[key])
+		_undo_redo.add_undo_property(player, key, old_values[key])
+	_undo_redo.commit_action()
+
+	var applied: Array[String] = []
+	var applied_values: Dictionary = {}
+	for key in updates:
+		applied.append(key)
+		applied_values[key] = updates[key]
+
+	return {
+		"data": {
+			"player_path": player_path,
+			"applied": applied,
+			"values": applied_values,
+			"undoable": true,
+		}
+	}
+
+
+# ============================================================================
+# audio_play  (runtime preview — not saved with scene)
+# ============================================================================
+
+func play(params: Dictionary) -> Dictionary:
+	var player_path: String = params.get("player_path", "")
+	var from_position: float = float(params.get("from_position", 0.0))
+
+	if player_path.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: player_path")
+
+	var resolved := _resolve_player(player_path)
+	if resolved.has("error"):
+		return resolved
+	var player: Node = resolved.player
+
+	if player.stream == null:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Player has no stream assigned — call audio_player_set_stream first"
+		)
+
+	player.play(from_position)
+
+	return {
+		"data": {
+			"player_path": player_path,
+			"from_position": from_position,
+			"playing": bool(player.playing),
+			"undoable": false,
+			"reason": "Runtime playback state — not saved with scene",
+		}
+	}
+
+
+# ============================================================================
+# audio_stop  (runtime preview — not saved with scene)
+# ============================================================================
+
+func stop(params: Dictionary) -> Dictionary:
+	var player_path: String = params.get("player_path", "")
+	if player_path.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: player_path")
+
+	var resolved := _resolve_player(player_path)
+	if resolved.has("error"):
+		return resolved
+	var player: Node = resolved.player
+
+	player.stop()
+
+	return {
+		"data": {
+			"player_path": player_path,
+			"playing": bool(player.playing),
+			"undoable": false,
+			"reason": "Runtime playback state — not saved with scene",
+		}
+	}
+
+
+# ============================================================================
+# audio_list  (read — scan project for AudioStream resources)
+# ============================================================================
+
+func list_streams(params: Dictionary) -> Dictionary:
+	var root: String = params.get("root", "res://")
+	var include_duration: bool = bool(params.get("include_duration", true))
+
+	var efs := EditorInterface.get_resource_filesystem()
+	if efs == null:
+		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "EditorFileSystem not available")
+
+	var results: Array[Dictionary] = []
+	_scan_audio(efs.get_filesystem(), root, include_duration, results)
+	return {
+		"data": {
+			"root": root,
+			"streams": results,
+			"count": results.size(),
+		}
+	}
+
+
+func _scan_audio(dir: EditorFileSystemDirectory, root: String, include_duration: bool, out: Array[Dictionary]) -> void:
+	if dir == null:
+		return
+	for i in dir.get_file_count():
+		var file_path := dir.get_file_path(i)
+		if not file_path.begins_with(root):
+			continue
+		var file_type := dir.get_file_type(i)
+		var is_audio := file_type == "AudioStream" or ClassDB.is_parent_class(file_type, "AudioStream")
+		if not is_audio:
+			continue
+		var entry: Dictionary = {
+			"path": file_path,
+			"class": file_type,
+		}
+		if include_duration:
+			var res := ResourceLoader.load(file_path)
+			if res is AudioStream:
+				entry["duration_seconds"] = float((res as AudioStream).get_length())
+			else:
+				entry["duration_seconds"] = 0.0
+		out.append(entry)
+	for i in dir.get_subdir_count():
+		_scan_audio(dir.get_subdir(i), root, include_duration, out)
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+static func _instantiate_player(type_str: String) -> Node:
+	match type_str:
+		"1d":
+			return AudioStreamPlayer.new()
+		"2d":
+			return AudioStreamPlayer2D.new()
+		"3d":
+			return AudioStreamPlayer3D.new()
+	return null
+
+
+func _resolve_player(player_path: String) -> Dictionary:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+	var node := ScenePath.resolve(player_path, scene_root)
+	if node == null:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % player_path)
+	var is_player := node is AudioStreamPlayer \
+		or node is AudioStreamPlayer2D \
+		or node is AudioStreamPlayer3D
+	if not is_player:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Node at %s is not an AudioStreamPlayer/2D/3D (got %s)" % [player_path, node.get_class()]
+		)
+	return {"player": node}
+
+
+## Coerce a playback param value to the expected type. int→float is allowed
+## so JSON integers pass through; everything else requires the exact type.
+## Returns the coerced value, or null on type mismatch.
+static func _coerce_playback_value(key: String, value: Variant, expected_type: int) -> Variant:
+	match expected_type:
+		TYPE_FLOAT:
+			if value is float or value is int:
+				return float(value)
+		TYPE_BOOL:
+			if value is bool:
+				return value
+		TYPE_STRING:
+			if value is String:
+				return value
+	return null

--- a/plugin/addons/godot_ai/handlers/audio_handler.gd
+++ b/plugin/addons/godot_ai/handlers/audio_handler.gd
@@ -107,6 +107,8 @@ func set_stream(params: Dictionary) -> Dictionary:
 	if not ResourceLoader.exists(stream_path):
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "AudioStream not found: %s" % stream_path)
 	var loaded := ResourceLoader.load(stream_path)
+	if loaded == null:
+		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to load AudioStream: %s" % stream_path)
 	if not (loaded is AudioStream):
 		return McpErrorCodes.make(
 			McpErrorCodes.INVALID_PARAMS,
@@ -255,12 +257,18 @@ func list_streams(params: Dictionary) -> Dictionary:
 	var root: String = params.get("root", "res://")
 	var include_duration: bool = bool(params.get("include_duration", true))
 
+	if not root.begins_with("res://"):
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "root must start with res://")
+
 	var efs := EditorInterface.get_resource_filesystem()
 	if efs == null:
 		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "EditorFileSystem not available")
 
 	var results: Array[Dictionary] = []
-	_scan_audio(efs.get_filesystem(), root, include_duration, results)
+	var start_dir := efs.get_filesystem_path(root)
+	if start_dir == null:
+		start_dir = efs.get_filesystem()
+	_scan_audio(start_dir, root, include_duration, results)
 	return {
 		"data": {
 			"root": root,

--- a/plugin/addons/godot_ai/handlers/audio_handler.gd
+++ b/plugin/addons/godot_ai/handlers/audio_handler.gd
@@ -145,14 +145,12 @@ func set_playback(params: Dictionary) -> Dictionary:
 		return resolved
 	var player: Node = resolved.player
 
-	# Collect and validate only the keys the caller actually provided. An
-	# empty update is rejected — matches the pattern elsewhere (set_main).
 	var updates: Dictionary = {}
 	for key in _PLAYBACK_KEYS:
 		if params.has(key):
 			var expected_type: int = _PLAYBACK_KEYS[key]
 			var value = params.get(key)
-			var coerced = _coerce_playback_value(key, value, expected_type)
+			var coerced = _coerce_playback_value(value, expected_type)
 			if coerced == null:
 				return McpErrorCodes.make(
 					McpErrorCodes.INVALID_PARAMS,
@@ -178,17 +176,11 @@ func set_playback(params: Dictionary) -> Dictionary:
 		_undo_redo.add_undo_property(player, key, old_values[key])
 	_undo_redo.commit_action()
 
-	var applied: Array[String] = []
-	var applied_values: Dictionary = {}
-	for key in updates:
-		applied.append(key)
-		applied_values[key] = updates[key]
-
 	return {
 		"data": {
 			"player_path": player_path,
-			"applied": applied,
-			"values": applied_values,
+			"applied": updates.keys(),
+			"values": updates,
 			"undoable": true,
 		}
 	}
@@ -340,7 +332,7 @@ func _resolve_player(player_path: String) -> Dictionary:
 ## Coerce a playback param value to the expected type. int→float is allowed
 ## so JSON integers pass through; everything else requires the exact type.
 ## Returns the coerced value, or null on type mismatch.
-static func _coerce_playback_value(key: String, value: Variant, expected_type: int) -> Variant:
+static func _coerce_playback_value(value: Variant, expected_type: int) -> Variant:
 	match expected_type:
 		TYPE_FLOAT:
 			if value is float or value is int:

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -37,7 +37,8 @@ func _enter_tree() -> void:
 	var animation_handler := AnimationHandler.new(get_undo_redo())
 	var material_handler := MaterialHandler.new(get_undo_redo())
 	var particle_handler := ParticleHandler.new(get_undo_redo())
-	_handlers = [editor_handler, scene_handler, node_handler, project_handler, client_handler, script_handler, resource_handler, filesystem_handler, signal_handler, autoload_handler, input_handler, test_handler, batch_handler, ui_handler, theme_handler, animation_handler, material_handler, particle_handler]
+	var audio_handler := AudioHandler.new(get_undo_redo())
+	_handlers = [editor_handler, scene_handler, node_handler, project_handler, client_handler, script_handler, resource_handler, filesystem_handler, signal_handler, autoload_handler, input_handler, test_handler, batch_handler, ui_handler, theme_handler, animation_handler, material_handler, particle_handler, audio_handler]
 
 	_dispatcher.register("get_editor_state", editor_handler.get_editor_state)
 	_dispatcher.register("get_scene_tree", scene_handler.get_scene_tree)
@@ -134,6 +135,12 @@ func _enter_tree() -> void:
 	_dispatcher.register("particle_restart", particle_handler.restart_particle)
 	_dispatcher.register("particle_get", particle_handler.get_particle)
 	_dispatcher.register("particle_apply_preset", particle_handler.apply_preset)
+	_dispatcher.register("audio_player_create", audio_handler.create_player)
+	_dispatcher.register("audio_player_set_stream", audio_handler.set_stream)
+	_dispatcher.register("audio_player_set_playback", audio_handler.set_playback)
+	_dispatcher.register("audio_play", audio_handler.play)
+	_dispatcher.register("audio_stop", audio_handler.stop)
+	_dispatcher.register("audio_list", audio_handler.list_streams)
 
 	_connection.dispatcher = _dispatcher
 	add_child(_connection)

--- a/src/godot_ai/handlers/audio.py
+++ b/src/godot_ai/handlers/audio.py
@@ -1,0 +1,80 @@
+"""Shared handlers for AudioStreamPlayer authoring — streams, playback, preview."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from godot_ai.handlers._readiness import require_writable
+from godot_ai.runtime.interface import Runtime
+
+
+async def audio_player_create(
+    runtime: Runtime,
+    parent_path: str,
+    name: str = "AudioStreamPlayer",
+    type: str = "1d",
+) -> dict:
+    require_writable(runtime)
+    return await runtime.send_command(
+        "audio_player_create",
+        {"parent_path": parent_path, "name": name, "type": type},
+    )
+
+
+async def audio_player_set_stream(
+    runtime: Runtime,
+    player_path: str,
+    stream_path: str,
+) -> dict:
+    require_writable(runtime)
+    return await runtime.send_command(
+        "audio_player_set_stream",
+        {"player_path": player_path, "stream_path": stream_path},
+    )
+
+
+async def audio_player_set_playback(
+    runtime: Runtime,
+    player_path: str,
+    volume_db: float | None = None,
+    pitch_scale: float | None = None,
+    autoplay: bool | None = None,
+    bus: str | None = None,
+) -> dict:
+    require_writable(runtime)
+    params: dict[str, Any] = {"player_path": player_path}
+    if volume_db is not None:
+        params["volume_db"] = volume_db
+    if pitch_scale is not None:
+        params["pitch_scale"] = pitch_scale
+    if autoplay is not None:
+        params["autoplay"] = autoplay
+    if bus is not None:
+        params["bus"] = bus
+    return await runtime.send_command("audio_player_set_playback", params)
+
+
+async def audio_play(
+    runtime: Runtime,
+    player_path: str,
+    from_position: float = 0.0,
+) -> dict:
+    return await runtime.send_command(
+        "audio_play",
+        {"player_path": player_path, "from_position": from_position},
+    )
+
+
+async def audio_stop(runtime: Runtime, player_path: str) -> dict:
+    return await runtime.send_command("audio_stop", {"player_path": player_path})
+
+
+async def audio_list(
+    runtime: Runtime,
+    root: str = "res://",
+    include_duration: bool = True,
+) -> dict:
+    return await runtime.send_command(
+        "audio_list",
+        {"root": root, "include_duration": include_duration},
+    )

--- a/src/godot_ai/server.py
+++ b/src/godot_ai/server.py
@@ -17,6 +17,7 @@ from godot_ai.resources.scenes import register_scene_resources
 from godot_ai.resources.sessions import register_session_resources
 from godot_ai.sessions.registry import SessionRegistry
 from godot_ai.tools.animation import register_animation_tools
+from godot_ai.tools.audio import register_audio_tools
 from godot_ai.tools.autoload import register_autoload_tools
 from godot_ai.tools.batch import register_batch_tools
 from godot_ai.tools.client import register_client_tools
@@ -101,6 +102,8 @@ def create_server(ws_port: int = 9500) -> FastMCP:
             "  particle_*       — author particle emitters "
             "(GPUParticles2D/3D, CPUParticles2D/3D) — "
             "fire, smoke, sparks, magic, rain, explosion\n"
+            "  audio_*          — author sound effects and music "
+            "(AudioStreamPlayer/2D/3D) — load streams, play, stop, list audio assets\n"
             "  client_*         — configure AI clients (Claude Code, Codex, Antigravity)\n\n"
             "Always connect to an editor session first (session_list / session_activate). "
             "Write operations require session readiness; check editor_state if a call is "
@@ -128,6 +131,7 @@ def create_server(ws_port: int = 9500) -> FastMCP:
     register_animation_tools(mcp)
     register_material_tools(mcp)
     register_particle_tools(mcp)
+    register_audio_tools(mcp)
     register_session_resources(mcp)
     register_scene_resources(mcp)
     register_editor_resources(mcp)

--- a/src/godot_ai/tools/audio.py
+++ b/src/godot_ai/tools/audio.py
@@ -94,10 +94,13 @@ def register_audio_tools(mcp: FastMCP) -> None:
 
         Args:
             player_path: Scene path to the AudioStreamPlayer / 2D / 3D node.
-            volume_db: Volume in decibels. 0 = unchanged, negative = quieter.
+            volume_db: Volume in decibels. Omit (``None``) to leave unchanged;
+                0 = full volume, negative = quieter, positive = louder.
             pitch_scale: Playback-rate multiplier (1.0 = normal, 2.0 = octave up).
-            autoplay: Start on scene load.
-            bus: Audio bus name (default "Master"). Must match a bus in the project.
+                Omit to leave unchanged.
+            autoplay: Start on scene load. Omit to leave unchanged.
+            bus: Audio bus name (e.g. "Master"). Must match a bus in the project.
+                Omit to leave unchanged.
             session_id: Optional Godot session to target. Empty = active session.
         """
         runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)

--- a/src/godot_ai/tools/audio.py
+++ b/src/godot_ai/tools/audio.py
@@ -1,0 +1,175 @@
+"""MCP tools for AudioStreamPlayer — sound effects, music, ambience.
+
+Godot ships three AudioStreamPlayer flavors, all covered here:
+
+- ``AudioStreamPlayer`` (``type="1d"``) — non-spatial (UI clicks, music, 2D
+  ambient). Plays at a fixed volume regardless of listener position.
+- ``AudioStreamPlayer2D`` (``type="2d"``) — 2D spatial attenuation from a
+  node position in a 2D scene.
+- ``AudioStreamPlayer3D`` (``type="3d"``) — 3D spatial with attenuation,
+  doppler, area reverb. Requires a Camera3D/AudioListener3D in the scene
+  for fully realistic preview at runtime; in the editor a basic preview
+  still plays through the system speakers.
+
+Streams are loaded from already-imported ``res://`` paths. Drop a
+``.ogg`` / ``.wav`` / ``.mp3`` into the project and the editor's import
+step will produce the real ``AudioStream`` subclass (``AudioStreamOggVorbis``
+/ ``AudioStreamMP3`` / ``AudioStreamWAV``) before these tools ever see it.
+
+``audio_play`` / ``audio_stop`` are runtime-only (``undoable: false``) —
+they call the live node method directly and produce real audible sound
+through the editor's audio output.
+"""
+
+from __future__ import annotations
+
+from fastmcp import Context, FastMCP
+
+from godot_ai.handlers import audio as audio_handlers
+from godot_ai.runtime.direct import DirectRuntime
+from godot_ai.tools import DEFER_META
+
+
+def register_audio_tools(mcp: FastMCP) -> None:
+    @mcp.tool(meta=DEFER_META)
+    async def audio_player_create(
+        ctx: Context,
+        parent_path: str,
+        name: str = "AudioStreamPlayer",
+        type: str = "1d",
+        session_id: str = "",
+    ) -> dict:
+        """Create an AudioStreamPlayer / 2D / 3D node for sound playback.
+
+        Args:
+            parent_path: Scene path of the parent node (e.g. "/Main", "/Main/HUD").
+            name: Name for the new player node.
+            type: "1d" (non-spatial), "2d" (2D spatial), or "3d" (3D spatial).
+            session_id: Optional Godot session to target. Empty = active session.
+        """
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
+        return await audio_handlers.audio_player_create(
+            runtime, parent_path=parent_path, name=name, type=type
+        )
+
+    @mcp.tool(meta=DEFER_META)
+    async def audio_player_set_stream(
+        ctx: Context,
+        player_path: str,
+        stream_path: str,
+        session_id: str = "",
+    ) -> dict:
+        """Assign an AudioStream resource to an AudioStreamPlayer's ``stream`` property.
+
+        The path must be a ``res://`` URL to an already-imported audio file
+        (``.ogg`` / ``.wav`` / ``.mp3``) or a ``.tres`` / ``.res`` saved
+        AudioStream resource. Returns ``duration_seconds`` from the loaded
+        stream (0.0 for generators without a known length).
+
+        Args:
+            player_path: Scene path to the AudioStreamPlayer / 2D / 3D node.
+            stream_path: Resource path to the audio file or AudioStream resource.
+            session_id: Optional Godot session to target. Empty = active session.
+        """
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
+        return await audio_handlers.audio_player_set_stream(
+            runtime, player_path=player_path, stream_path=stream_path
+        )
+
+    @mcp.tool(meta=DEFER_META)
+    async def audio_player_set_playback(
+        ctx: Context,
+        player_path: str,
+        volume_db: float | None = None,
+        pitch_scale: float | None = None,
+        autoplay: bool | None = None,
+        bus: str | None = None,
+        session_id: str = "",
+    ) -> dict:
+        """Update common playback properties in a single atomic undo action.
+
+        Only fields you pass are applied — omitted fields are left unchanged.
+        At least one of ``volume_db`` / ``pitch_scale`` / ``autoplay`` / ``bus``
+        must be provided.
+
+        Args:
+            player_path: Scene path to the AudioStreamPlayer / 2D / 3D node.
+            volume_db: Volume in decibels. 0 = unchanged, negative = quieter.
+            pitch_scale: Playback-rate multiplier (1.0 = normal, 2.0 = octave up).
+            autoplay: Start on scene load.
+            bus: Audio bus name (default "Master"). Must match a bus in the project.
+            session_id: Optional Godot session to target. Empty = active session.
+        """
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
+        return await audio_handlers.audio_player_set_playback(
+            runtime,
+            player_path=player_path,
+            volume_db=volume_db,
+            pitch_scale=pitch_scale,
+            autoplay=autoplay,
+            bus=bus,
+        )
+
+    @mcp.tool(meta=DEFER_META)
+    async def audio_play(
+        ctx: Context,
+        player_path: str,
+        from_position: float = 0.0,
+        session_id: str = "",
+    ) -> dict:
+        """Start real editor preview playback — produces audible sound.
+
+        Calls the live ``AudioStreamPlayer.play()`` method directly. This is
+        the same path the inspector's play button uses. 3D spatialization
+        may be subtle in the editor without a running Camera3D/AudioListener3D.
+        Errors if no stream is assigned — call ``audio_player_set_stream``
+        first. Not undoable (runtime playback state, not saved with scene).
+
+        Args:
+            player_path: Scene path to the AudioStreamPlayer / 2D / 3D node.
+            from_position: Playback position in seconds (default 0 = start).
+            session_id: Optional Godot session to target. Empty = active session.
+        """
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
+        return await audio_handlers.audio_play(
+            runtime, player_path=player_path, from_position=from_position
+        )
+
+    @mcp.tool(meta=DEFER_META)
+    async def audio_stop(
+        ctx: Context,
+        player_path: str,
+        session_id: str = "",
+    ) -> dict:
+        """Stop editor preview playback. Not undoable (runtime state).
+
+        Args:
+            player_path: Scene path to the AudioStreamPlayer / 2D / 3D node.
+            session_id: Optional Godot session to target. Empty = active session.
+        """
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
+        return await audio_handlers.audio_stop(runtime, player_path=player_path)
+
+    @mcp.tool(meta=DEFER_META)
+    async def audio_list(
+        ctx: Context,
+        root: str = "res://",
+        include_duration: bool = True,
+        session_id: str = "",
+    ) -> dict:
+        """Scan the project for AudioStream resources — audio files + .tres/.res.
+
+        Catches every AudioStream subclass: AudioStreamOggVorbis,
+        AudioStreamMP3, AudioStreamWAV, AudioStreamPlaylist,
+        AudioStreamRandomizer, plus bespoke ``.tres`` / ``.res`` resources.
+
+        Args:
+            root: Directory to restrict the scan to (default ``"res://"``).
+            include_duration: Load each stream to report ``duration_seconds``.
+                Disable for very large libraries if scans feel slow.
+            session_id: Optional Godot session to target. Empty = active session.
+        """
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
+        return await audio_handlers.audio_list(
+            runtime, root=root, include_duration=include_duration
+        )

--- a/test_project/tests/test_audio.gd
+++ b/test_project/tests/test_audio.gd
@@ -1,0 +1,376 @@
+@tool
+extends McpTestSuite
+
+## Tests for AudioHandler — AudioStreamPlayer / 2D / 3D node authoring,
+## stream assignment, playback properties, editor-preview play/stop, and
+## audio asset listing.
+##
+## A silent AudioStreamWAV fixture is generated at runtime (written to
+## user://) rather than committing a binary file. Cleaned up by
+## suite_teardown.
+##
+## NOTE: GDScript tests must not call save_scene, scene_create, scene_open,
+## quit_editor, or reload_plugin (see CLAUDE.md Known Issues).
+
+var _handler: AudioHandler
+var _undo_redo: EditorUndoRedoManager
+var _created_paths: Array[String] = []
+var _fixture_path: String = ""
+
+
+func suite_name() -> String:
+	return "audio"
+
+
+func suite_setup(ctx: Dictionary) -> void:
+	_undo_redo = ctx.get("undo_redo")
+	_handler = AudioHandler.new(_undo_redo)
+	_fixture_path = _make_fixture()
+
+
+func suite_teardown() -> void:
+	for path in _created_paths:
+		_remove_by_path(path)
+	_created_paths.clear()
+	if not _fixture_path.is_empty():
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(_fixture_path))
+		_fixture_path = ""
+
+
+# Build a tiny silent 16-bit mono WAV stream and save it to user://.
+# user:// paths are valid res:// surrogates for ResourceLoader but live
+# outside the imported asset pipeline, so they don't pollute the project
+# or require a reimport cycle.
+func _make_fixture() -> String:
+	var stream := AudioStreamWAV.new()
+	stream.format = AudioStreamWAV.FORMAT_16_BITS
+	stream.stereo = false
+	stream.mix_rate = 22050
+	# ~0.1s of silence: 22050Hz * 0.1s * 2 bytes/sample = 4410 bytes
+	var silence := PackedByteArray()
+	silence.resize(4410)
+	silence.fill(0)
+	stream.data = silence
+	var path := "user://audio_fixture.wav.tres"
+	var err := ResourceSaver.save(stream, path)
+	if err != OK:
+		return ""
+	return path
+
+
+func _remove_by_path(path: String) -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return
+	var node := ScenePath.resolve(path, scene_root)
+	if node != null and node.get_parent() != null:
+		node.get_parent().remove_child(node)
+		node.queue_free()
+
+
+func _create(node_name: String, type_str: String = "1d") -> Dictionary:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return {}
+	var result := _handler.create_player({
+		"parent_path": "/" + scene_root.name,
+		"name": node_name,
+		"type": type_str,
+	})
+	if result.has("data"):
+		_created_paths.append(result.data.path)
+	return result
+
+
+# ============================================================================
+# audio_player_create
+# ============================================================================
+
+func test_create_1d() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		assert_true(false, "No scene root — test cannot run")
+		return
+	var result := _create("TestPlayer1D", "1d")
+	assert_has_key(result, "data")
+	assert_eq(result.data.class, "AudioStreamPlayer")
+	assert_eq(result.data.type, "1d")
+	assert_true(result.data.undoable)
+
+
+func test_create_2d() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		assert_true(false, "No scene root — test cannot run")
+		return
+	var result := _create("TestPlayer2D", "2d")
+	assert_has_key(result, "data")
+	assert_eq(result.data.class, "AudioStreamPlayer2D")
+
+
+func test_create_3d() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		assert_true(false, "No scene root — test cannot run")
+		return
+	var result := _create("TestPlayer3D", "3d")
+	assert_has_key(result, "data")
+	assert_eq(result.data.class, "AudioStreamPlayer3D")
+	var node := ScenePath.resolve(result.data.path, scene_root) as AudioStreamPlayer3D
+	assert_true(node != null, "Created node should resolve as AudioStreamPlayer3D")
+
+
+func test_create_invalid_type() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		assert_true(false, "No scene root — test cannot run")
+		return
+	var result := _handler.create_player({
+		"parent_path": "/" + scene_root.name,
+		"name": "BadType",
+		"type": "gpu_3d",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_create_missing_parent() -> void:
+	var result := _handler.create_player({
+		"parent_path": "/NoSuchParent",
+		"name": "Orphan",
+		"type": "1d",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+# ============================================================================
+# audio_player_set_stream
+# ============================================================================
+
+func test_set_stream_loads_and_assigns() -> void:
+	if _fixture_path.is_empty():
+		assert_true(false, "Fixture setup failed — cannot test stream loading")
+		return
+	var r := _create("TestSetStream", "1d")
+	if r.is_empty():
+		assert_true(false, "Player creation failed")
+		return
+	var result := _handler.set_stream({
+		"player_path": r.data.path,
+		"stream_path": _fixture_path,
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.stream_path, _fixture_path)
+	assert_true(result.data.undoable)
+	# Critical: read back the stored value — must be an AudioStream, not a string.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var node := ScenePath.resolve(r.data.path, scene_root) as AudioStreamPlayer
+	assert_true(node.stream is AudioStream,
+		"stream must be AudioStream (got %s)" % type_string(typeof(node.stream)))
+
+
+func test_set_stream_missing_resource() -> void:
+	var r := _create("TestSetStreamMissing", "1d")
+	if r.is_empty():
+		assert_true(false, "Player creation failed")
+		return
+	var result := _handler.set_stream({
+		"player_path": r.data.path,
+		"stream_path": "res://does_not_exist.ogg",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_set_stream_wrong_type() -> void:
+	# Point to this test script itself — it exists but isn't an AudioStream.
+	var r := _create("TestSetStreamWrongType", "1d")
+	if r.is_empty():
+		assert_true(false, "Player creation failed")
+		return
+	var result := _handler.set_stream({
+		"player_path": r.data.path,
+		"stream_path": "res://tests/test_audio.gd",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_set_stream_empty_path() -> void:
+	var r := _create("TestSetStreamEmpty", "1d")
+	if r.is_empty():
+		assert_true(false, "Player creation failed")
+		return
+	var result := _handler.set_stream({
+		"player_path": r.data.path,
+		"stream_path": "",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_set_stream_on_non_player_errors() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		assert_true(false, "No scene root")
+		return
+	if _fixture_path.is_empty():
+		assert_true(false, "Fixture setup failed")
+		return
+	var mi := Node3D.new()
+	mi.name = "NotAnAudioNode"
+	scene_root.add_child(mi)
+	mi.owner = scene_root
+	var result := _handler.set_stream({
+		"player_path": ScenePath.from_node(mi, scene_root),
+		"stream_path": _fixture_path,
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	mi.get_parent().remove_child(mi)
+	mi.queue_free()
+
+
+# ============================================================================
+# audio_player_set_playback
+# ============================================================================
+
+func test_set_playback_all_fields() -> void:
+	var r := _create("TestPlaybackAll", "1d")
+	if r.is_empty():
+		assert_true(false, "Player creation failed")
+		return
+	var result := _handler.set_playback({
+		"player_path": r.data.path,
+		"volume_db": -6.0,
+		"pitch_scale": 1.25,
+		"autoplay": true,
+		"bus": "Master",
+	})
+	assert_has_key(result, "data")
+	assert_true(result.data.undoable)
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var node := ScenePath.resolve(r.data.path, scene_root) as AudioStreamPlayer
+	assert_true(abs(node.volume_db - (-6.0)) < 0.01)
+	assert_true(abs(node.pitch_scale - 1.25) < 0.01)
+	assert_eq(node.autoplay, true)
+	assert_eq(String(node.bus), "Master")
+
+
+func test_set_playback_partial_update_leaves_others_unchanged() -> void:
+	var r := _create("TestPlaybackPartial", "1d")
+	if r.is_empty():
+		assert_true(false, "Player creation failed")
+		return
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var node := ScenePath.resolve(r.data.path, scene_root) as AudioStreamPlayer
+	var old_pitch := node.pitch_scale
+	var old_bus := String(node.bus)
+	var result := _handler.set_playback({
+		"player_path": r.data.path,
+		"volume_db": -12.0,
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.applied, ["volume_db"])
+	assert_true(abs(node.volume_db - (-12.0)) < 0.01)
+	# Others untouched.
+	assert_true(abs(node.pitch_scale - old_pitch) < 0.01)
+	assert_eq(String(node.bus), old_bus)
+
+
+func test_set_playback_empty_rejected() -> void:
+	var r := _create("TestPlaybackEmpty", "1d")
+	if r.is_empty():
+		assert_true(false, "Player creation failed")
+		return
+	var result := _handler.set_playback({"player_path": r.data.path})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_set_playback_type_mismatch_rejected() -> void:
+	var r := _create("TestPlaybackTypeErr", "1d")
+	if r.is_empty():
+		assert_true(false, "Player creation failed")
+		return
+	# volume_db must be a number — pass a string and expect rejection.
+	var result := _handler.set_playback({
+		"player_path": r.data.path,
+		"volume_db": "loud",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+# ============================================================================
+# audio_play / audio_stop  (runtime preview — not undoable)
+# ============================================================================
+
+func test_play_without_stream_rejected() -> void:
+	var r := _create("TestPlayNoStream", "1d")
+	if r.is_empty():
+		assert_true(false, "Player creation failed")
+		return
+	var result := _handler.play({"player_path": r.data.path})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_play_and_stop_roundtrip() -> void:
+	if _fixture_path.is_empty():
+		assert_true(false, "Fixture setup failed")
+		return
+	var r := _create("TestPlayStop", "1d")
+	if r.is_empty():
+		assert_true(false, "Player creation failed")
+		return
+	var set_result := _handler.set_stream({
+		"player_path": r.data.path,
+		"stream_path": _fixture_path,
+	})
+	if not set_result.has("data"):
+		assert_true(false, "set_stream failed: %s" % str(set_result))
+		return
+	var play_result := _handler.play({"player_path": r.data.path})
+	assert_has_key(play_result, "data")
+	assert_eq(play_result.data.undoable, false)
+	assert_eq(play_result.data.reason, "Runtime playback state — not saved with scene")
+	# The fixture is ~0.1s of silence, but play() schedules playback; the
+	# node reports `playing=true` immediately after the call.
+	var stop_result := _handler.stop({"player_path": r.data.path})
+	assert_has_key(stop_result, "data")
+	assert_eq(stop_result.data.undoable, false)
+	assert_eq(stop_result.data.playing, false)
+
+
+func test_play_missing_player_path() -> void:
+	var result := _handler.play({})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_stop_missing_player_path() -> void:
+	var result := _handler.stop({})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+# ============================================================================
+# audio_list
+# ============================================================================
+
+func test_list_returns_result() -> void:
+	# Basic shape check — the EditorFileSystem may or may not have indexed
+	# user:// fixtures depending on scan timing, so we assert on structure,
+	# not specific membership.
+	var result := _handler.list_streams({})
+	assert_has_key(result, "data")
+	assert_has_key(result.data, "streams")
+	assert_has_key(result.data, "count")
+
+
+func test_list_include_duration_false_omits_field() -> void:
+	# Even if no streams exist in res://, this test verifies the flag is
+	# plumbed: we just check the entries (if any) lack duration_seconds.
+	var result := _handler.list_streams({"include_duration": false})
+	assert_has_key(result, "data")
+	for entry in result.data.streams:
+		assert_false(entry.has("duration_seconds"),
+			"include_duration=false should omit duration_seconds (entry: %s)" % str(entry))
+
+
+func test_list_filters_by_root() -> void:
+	# A non-existent root should yield 0 streams.
+	var result := _handler.list_streams({"root": "res://definitely_does_not_exist_xyz/"})
+	assert_has_key(result, "data")
+	assert_eq(int(result.data.count), 0)

--- a/test_project/tests/test_audio.gd
+++ b/test_project/tests/test_audio.gd
@@ -327,8 +327,6 @@ func test_play_and_stop_roundtrip() -> void:
 	assert_has_key(play_result, "data")
 	assert_eq(play_result.data.undoable, false)
 	assert_eq(play_result.data.reason, "Runtime playback state — not saved with scene")
-	# The fixture is ~0.1s of silence, but play() schedules playback; the
-	# node reports `playing=true` immediately after the call.
 	var stop_result := _handler.stop({"player_path": r.data.path})
 	assert_has_key(stop_result, "data")
 	assert_eq(stop_result.data.undoable, false)

--- a/test_project/tests/test_audio.gd
+++ b/test_project/tests/test_audio.gd
@@ -372,3 +372,8 @@ func test_list_filters_by_root() -> void:
 	var result := _handler.list_streams({"root": "res://definitely_does_not_exist_xyz/"})
 	assert_has_key(result, "data")
 	assert_eq(int(result.data.count), 0)
+
+
+func test_list_rejects_non_res_root() -> void:
+	var result := _handler.list_streams({"root": "user://"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -3662,9 +3662,7 @@ class TestMaterialCreateTool:
             )
 
         task = asyncio.create_task(respond())
-        result = await client.call_tool(
-            "material_create", {"path": "res://materials/red.tres"}
-        )
+        result = await client.call_tool("material_create", {"path": "res://materials/red.tres"})
         await task
         assert result.data["class"] == "StandardMaterial3D"
         assert result.data["undoable"] is False
@@ -3828,9 +3826,7 @@ class TestMaterialGetTool:
             )
 
         task = asyncio.create_task(respond())
-        result = await client.call_tool(
-            "material_get", {"path": "res://materials/red.tres"}
-        )
+        result = await client.call_tool("material_get", {"path": "res://materials/red.tres"})
         await task
         assert result.data["class"] == "StandardMaterial3D"
 
@@ -3965,9 +3961,7 @@ class TestParticleCreateTool:
             )
 
         task = asyncio.create_task(respond())
-        result = await client.call_tool(
-            "particle_create", {"parent_path": "/Main", "name": "Fire"}
-        )
+        result = await client.call_tool("particle_create", {"parent_path": "/Main", "name": "Fire"})
         await task
         assert result.data["process_material_created"] is True
         assert result.data["draw_pass_mesh_created"] is True
@@ -4166,3 +4160,184 @@ class TestParticleGetTool:
         await task
         assert result.data["main"]["amount"] == 80
         assert result.data["draw_passes"][0]["mesh_class"] == "QuadMesh"
+
+
+# ---------------------------------------------------------------------------
+# audio_player_create / audio_player_set_stream / audio_play / audio_stop / audio_list
+# ---------------------------------------------------------------------------
+
+
+class TestAudioPlayerCreateTool:
+    async def test_create_3d(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "audio_player_create"
+            assert cmd["params"] == {
+                "parent_path": "/Main",
+                "name": "Footsteps",
+                "type": "3d",
+            }
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "path": "/Main/Footsteps",
+                    "parent_path": "/Main",
+                    "name": "Footsteps",
+                    "type": "3d",
+                    "class": "AudioStreamPlayer3D",
+                    "undoable": True,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "audio_player_create",
+            {"parent_path": "/Main", "name": "Footsteps", "type": "3d"},
+        )
+        await task
+        assert result.data["class"] == "AudioStreamPlayer3D"
+        assert result.data["undoable"] is True
+
+
+class TestAudioPlayerSetStreamTool:
+    async def test_set_stream_forwards_path(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "audio_player_set_stream"
+            assert cmd["params"] == {
+                "player_path": "/Main/Footsteps",
+                "stream_path": "res://sfx/step.ogg",
+            }
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "player_path": "/Main/Footsteps",
+                    "stream_path": "res://sfx/step.ogg",
+                    "stream_class": "AudioStreamOggVorbis",
+                    "duration_seconds": 0.42,
+                    "undoable": True,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "audio_player_set_stream",
+            {"player_path": "/Main/Footsteps", "stream_path": "res://sfx/step.ogg"},
+        )
+        await task
+        assert result.data["stream_class"] == "AudioStreamOggVorbis"
+        assert result.data["duration_seconds"] == 0.42
+
+
+class TestAudioPlayerSetPlaybackTool:
+    async def test_partial_update_omits_none_fields(self, mcp_stack):
+        """Only fields the caller passes should end up on the wire."""
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "audio_player_set_playback"
+            assert cmd["params"] == {"player_path": "/Main/Music", "volume_db": -3.0}
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "player_path": "/Main/Music",
+                    "applied": ["volume_db"],
+                    "values": {"volume_db": -3.0},
+                    "undoable": True,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "audio_player_set_playback",
+            {"player_path": "/Main/Music", "volume_db": -3.0},
+        )
+        await task
+        assert result.data["applied"] == ["volume_db"]
+
+
+class TestAudioPlayTool:
+    async def test_play_is_runtime_only(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "audio_play"
+            assert cmd["params"] == {
+                "player_path": "/Main/Footsteps",
+                "from_position": 0.0,
+            }
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "player_path": "/Main/Footsteps",
+                    "from_position": 0.0,
+                    "playing": True,
+                    "undoable": False,
+                    "reason": "Runtime playback state — not saved with scene",
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool("audio_play", {"player_path": "/Main/Footsteps"})
+        await task
+        assert result.data["undoable"] is False
+        assert result.data["playing"] is True
+
+
+class TestAudioStopTool:
+    async def test_stop(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "audio_stop"
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "player_path": "/Main/Footsteps",
+                    "playing": False,
+                    "undoable": False,
+                    "reason": "Runtime playback state — not saved with scene",
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool("audio_stop", {"player_path": "/Main/Footsteps"})
+        await task
+        assert result.data["playing"] is False
+
+
+class TestAudioListTool:
+    async def test_list_returns_streams(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "audio_list"
+            assert cmd["params"] == {"root": "res://", "include_duration": True}
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "root": "res://",
+                    "streams": [
+                        {
+                            "path": "res://sfx/click.ogg",
+                            "class": "AudioStreamOggVorbis",
+                            "duration_seconds": 0.1,
+                        }
+                    ],
+                    "count": 1,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool("audio_list", {})
+        await task
+        assert result.data["count"] == 1
+        assert result.data["streams"][0]["class"] == "AudioStreamOggVorbis"

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from godot_ai.handlers import animation as animation_handlers
+from godot_ai.handlers import audio as audio_handlers
 from godot_ai.handlers import autoload as autoload_handlers
 from godot_ai.handlers import batch as batch_handlers
 from godot_ai.handlers import client as client_handlers
@@ -703,8 +704,11 @@ class StubClient:
                 "class": "StandardMaterial3D",
                 "type": "standard",
                 "properties": [
-                    {"name": "albedo_color", "type": "Color",
-                     "value": {"r": 1, "g": 1, "b": 1, "a": 1}},
+                    {
+                        "name": "albedo_color",
+                        "type": "Color",
+                        "value": {"r": 1, "g": 1, "b": 1, "a": 1},
+                    },
                     {"name": "metallic", "type": "float", "value": 0.0},
                 ],
                 "property_count": 2,
@@ -827,6 +831,62 @@ class StubClient:
                 "draw_pass_mesh_created": params.get("type", "gpu_3d") == "gpu_3d",
                 "is_3d": params.get("type", "gpu_3d").endswith("_3d"),
                 "undoable": True,
+            }
+        if command == "audio_player_create":
+            type_str = params.get("type", "1d")
+            class_name = {
+                "1d": "AudioStreamPlayer",
+                "2d": "AudioStreamPlayer2D",
+                "3d": "AudioStreamPlayer3D",
+            }.get(type_str, "AudioStreamPlayer")
+            return {
+                "path": params.get("parent_path", "") + "/" + params.get("name", ""),
+                "parent_path": params.get("parent_path", ""),
+                "name": params.get("name", ""),
+                "type": type_str,
+                "class": class_name,
+                "undoable": True,
+            }
+        if command == "audio_player_set_stream":
+            return {
+                "player_path": params.get("player_path", ""),
+                "stream_path": params.get("stream_path", ""),
+                "stream_class": "AudioStreamOggVorbis",
+                "duration_seconds": 1.23,
+                "undoable": True,
+            }
+        if command == "audio_player_set_playback":
+            applied = [k for k in ("volume_db", "pitch_scale", "autoplay", "bus") if k in params]
+            return {
+                "player_path": params.get("player_path", ""),
+                "applied": applied,
+                "values": {k: params[k] for k in applied},
+                "undoable": True,
+            }
+        if command == "audio_play":
+            return {
+                "player_path": params.get("player_path", ""),
+                "from_position": params.get("from_position", 0.0),
+                "playing": True,
+                "undoable": False,
+                "reason": "Runtime playback state — not saved with scene",
+            }
+        if command == "audio_stop":
+            return {
+                "player_path": params.get("player_path", ""),
+                "playing": False,
+                "undoable": False,
+                "reason": "Runtime playback state — not saved with scene",
+            }
+        if command == "audio_list":
+            include_duration = params.get("include_duration", True)
+            entry = {"path": "res://sfx/click.ogg", "class": "AudioStreamOggVorbis"}
+            if include_duration:
+                entry["duration_seconds"] = 0.42
+            return {
+                "root": params.get("root", "res://"),
+                "streams": [entry],
+                "count": 1,
             }
         return {"status": "ok"}
 
@@ -3134,9 +3194,7 @@ async def test_material_apply_to_node_forwards_save_to():
 async def test_material_apply_preset_handler():
     client = StubClient()
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)
-    await material_handlers.material_apply_preset(
-        runtime, preset="glass", node_path="/Main/Box"
-    )
+    await material_handlers.material_apply_preset(runtime, preset="glass", node_path="/Main/Box")
     params = client.calls[-1]["params"]
     assert params["preset"] == "glass"
     assert params["node_path"] == "/Main/Box"
@@ -3307,3 +3365,179 @@ async def test_particle_apply_preset_with_overrides():
     )
     params = client.calls[-1]["params"]
     assert params["overrides"] == {"amount": 200}
+
+
+# ---------------------------------------------------------------------------
+# Audio handler tests
+# ---------------------------------------------------------------------------
+
+
+async def test_audio_player_create_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await audio_handlers.audio_player_create(
+        runtime, parent_path="/Main", name="Footsteps", type="3d"
+    )
+    assert client.calls[-1]["command"] == "audio_player_create"
+    assert client.calls[-1]["params"] == {
+        "parent_path": "/Main",
+        "name": "Footsteps",
+        "type": "3d",
+    }
+    assert result["class"] == "AudioStreamPlayer3D"
+    assert result["undoable"] is True
+
+
+async def test_audio_player_create_defaults_to_1d():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await audio_handlers.audio_player_create(runtime, parent_path="/Main")
+    assert client.calls[-1]["params"]["type"] == "1d"
+    assert client.calls[-1]["params"]["name"] == "AudioStreamPlayer"
+    assert result["class"] == "AudioStreamPlayer"
+
+
+async def test_audio_player_set_stream_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await audio_handlers.audio_player_set_stream(
+        runtime,
+        player_path="/Main/Footsteps",
+        stream_path="res://sfx/step.ogg",
+    )
+    assert client.calls[-1]["command"] == "audio_player_set_stream"
+    assert client.calls[-1]["params"] == {
+        "player_path": "/Main/Footsteps",
+        "stream_path": "res://sfx/step.ogg",
+    }
+    assert result["duration_seconds"] == 1.23
+    assert result["undoable"] is True
+
+
+async def test_audio_player_set_playback_partial_update():
+    """Only provided fields should go into params — None values stay out."""
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    await audio_handlers.audio_player_set_playback(
+        runtime,
+        player_path="/Main/Footsteps",
+        volume_db=-6.0,
+    )
+    params = client.calls[-1]["params"]
+    assert params == {"player_path": "/Main/Footsteps", "volume_db": -6.0}
+    assert "pitch_scale" not in params
+    assert "autoplay" not in params
+    assert "bus" not in params
+
+
+async def test_audio_player_set_playback_all_fields():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await audio_handlers.audio_player_set_playback(
+        runtime,
+        player_path="/Main/Music",
+        volume_db=-3.0,
+        pitch_scale=1.1,
+        autoplay=True,
+        bus="Music",
+    )
+    params = client.calls[-1]["params"]
+    assert params == {
+        "player_path": "/Main/Music",
+        "volume_db": -3.0,
+        "pitch_scale": 1.1,
+        "autoplay": True,
+        "bus": "Music",
+    }
+    assert set(result["applied"]) == {"volume_db", "pitch_scale", "autoplay", "bus"}
+
+
+async def test_audio_play_handler_does_not_require_writable():
+    """audio_play is runtime-only — should succeed even when the editor is 'playing'."""
+    client = StubClient()
+    session = Session(
+        session_id="s1",
+        godot_version="4.4",
+        project_path="/tmp/p",
+        plugin_version="0.1",
+        readiness="playing",
+    )
+    registry = SessionRegistry()
+    registry.register(session)
+    runtime = DirectRuntime(registry=registry, client=client)
+    result = await audio_handlers.audio_play(
+        runtime, player_path="/Main/Footsteps", from_position=0.5
+    )
+    assert client.calls[-1]["command"] == "audio_play"
+    assert client.calls[-1]["params"] == {
+        "player_path": "/Main/Footsteps",
+        "from_position": 0.5,
+    }
+    assert result["undoable"] is False
+    assert result["playing"] is True
+
+
+async def test_audio_stop_handler_does_not_require_writable():
+    client = StubClient()
+    session = Session(
+        session_id="s1",
+        godot_version="4.4",
+        project_path="/tmp/p",
+        plugin_version="0.1",
+        readiness="playing",
+    )
+    registry = SessionRegistry()
+    registry.register(session)
+    runtime = DirectRuntime(registry=registry, client=client)
+    result = await audio_handlers.audio_stop(runtime, player_path="/Main/Footsteps")
+    assert client.calls[-1]["command"] == "audio_stop"
+    assert result["undoable"] is False
+    assert result["playing"] is False
+
+
+async def test_audio_list_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await audio_handlers.audio_list(runtime)
+    assert client.calls[-1]["command"] == "audio_list"
+    assert client.calls[-1]["params"] == {"root": "res://", "include_duration": True}
+    assert result["count"] == 1
+    assert result["streams"][0]["duration_seconds"] == 0.42
+
+
+async def test_audio_list_handler_is_read_only():
+    """audio_list is read-only — should succeed even when the editor is 'importing'."""
+    client = StubClient()
+    session = Session(
+        session_id="s1",
+        godot_version="4.4",
+        project_path="/tmp/p",
+        plugin_version="0.1",
+        readiness="importing",
+    )
+    registry = SessionRegistry()
+    registry.register(session)
+    runtime = DirectRuntime(registry=registry, client=client)
+    result = await audio_handlers.audio_list(runtime, include_duration=False)
+    params = client.calls[-1]["params"]
+    assert params["include_duration"] is False
+    assert "duration_seconds" not in result["streams"][0]
+
+
+async def test_audio_player_create_blocks_when_not_writable():
+    """audio_player_create requires a writable session (uses require_writable)."""
+    client = StubClient()
+    session = Session(
+        session_id="s1",
+        godot_version="4.4",
+        project_path="/tmp/p",
+        plugin_version="0.1",
+        readiness="playing",
+    )
+    registry = SessionRegistry()
+    registry.register(session)
+    runtime = DirectRuntime(registry=registry, client=client)
+    with pytest.raises(Exception) as exc_info:
+        await audio_handlers.audio_player_create(runtime, parent_path="/Main")
+    assert "play mode" in str(exc_info.value).lower()
+    assert client.calls == []


### PR DESCRIPTION
Introduces six tools covering end-to-end "drop a sound into the scene
and hear it" flow:

- audio_player_create — spawn AudioStreamPlayer / 2D / 3D via a "1d" /
  "2d" / "3d" type enum, wrapped in a single undo action
- audio_player_set_stream — load res:// .ogg/.wav/.mp3/.tres via
  ResourceLoader, type-check as AudioStream, assign to .stream
- audio_player_set_playback — partial-update volume_db / pitch_scale /
  autoplay / bus in one atomic undo action
- audio_play — real editor preview (calls player.play(from_position));
  errors if no stream is assigned; not undoable (runtime-only)
- audio_stop — player.stop(); not undoable
- audio_list — scan EditorFileSystem for AudioStream subclasses,
  optionally include each stream's duration_seconds

Pattern mirrors particle_* end-to-end: Python tool module delegates to
shared handlers that route through DirectRuntime.send_command; GDScript
AudioHandler uses EditorUndoRedoManager for every write; play/stop
follow animation_handler's runtime-only pattern with undoable=false.

Tests: 10 Python unit tests (StubClient), 6 Python integration tests
(real WebSocket round trip), 19 GDScript tests exercising live editor
behavior with a runtime-generated silent AudioStreamWAV fixture.