### PR TITLE
feat: resource_create + 6 companion tools for built-in Resource instantiation

### DIFF
--- a/plugin/addons/godot_ai/handlers/curve_handler.gd
+++ b/plugin/addons/godot_ai/handlers/curve_handler.gd
@@ -41,6 +41,7 @@ func set_points(params: Dictionary) -> Dictionary:
 
 	var curve: Resource
 	var node: Node = null
+	var curve_created := false
 	if has_file_target:
 		if not ResourceLoader.exists(resource_path):
 			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Resource not found: %s" % resource_path)
@@ -58,12 +59,22 @@ func set_points(params: Dictionary) -> Dictionary:
 				"Property '%s' not found on %s" % [property, node.get_class()]
 			)
 		curve = node.get(property)
+		# Auto-create a fresh Curve subclass if the slot is empty. Infer the
+		# concrete class from the property's hint_string (e.g. Path3D.curve's
+		# hint is "Curve3D"). Creation is bundled into the same undo action
+		# as the point-set below, so Ctrl-Z rolls back both.
+		if curve == null:
+			var inferred := _infer_curve_class(node, property)
+			if inferred.is_empty():
+				return McpErrorCodes.make(
+					McpErrorCodes.INVALID_PARAMS,
+					"Curve slot on %s.%s is null and the Curve class can't be inferred from the property hint — create one first with resource_create (type=Curve3D/Curve2D/Curve)" % [node.get_class(), property]
+				)
+			curve = ClassDB.instantiate(inferred)
+			if curve == null:
+				return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to instantiate %s" % inferred)
+			curve_created = true
 
-	if curve == null:
-		return McpErrorCodes.make(
-			McpErrorCodes.INVALID_PARAMS,
-			"Curve resource at the given location is null — create one first with resource_create (type=Curve3D/Curve2D/Curve)"
-		)
 	if not (curve is Curve or curve is Curve2D or curve is Curve3D):
 		return McpErrorCodes.make(
 			McpErrorCodes.INVALID_PARAMS,
@@ -96,10 +107,11 @@ func set_points(params: Dictionary) -> Dictionary:
 
 	# Inline (node-attached) path: swap the curve property so the action lands
 	# cleanly in scene history, mirroring the resource-swap pattern used by
-	# material_handler::assign_material.
-	var new_curve: Resource = curve.duplicate()
+	# material_handler::assign_material. When curve_created is true the
+	# "old" value is null — undo clears the slot back to empty.
+	var new_curve: Resource = curve if curve_created else curve.duplicate()
 	_apply_snapshot_to_curve(new_curve, new_snapshot)
-	var old_curve: Resource = curve
+	var old_curve: Resource = null if curve_created else curve
 
 	_undo_redo.create_action("MCP: Set %d points on %s.%s" % [new_snapshot.size(), node.name, property])
 	_undo_redo.add_do_property(node, property, new_curve)
@@ -113,9 +125,31 @@ func set_points(params: Dictionary) -> Dictionary:
 			"property": property,
 			"curve_class": new_curve.get_class(),
 			"point_count": new_snapshot.size(),
+			"curve_created": curve_created,
 			"undoable": true,
 		}
 	}
+
+
+## Infer the concrete Curve class to instantiate for a null property slot.
+## Reads the property's hint_string (set by Godot on resource-typed exports)
+## to get the exact accepted class name (e.g. "Curve3D" for Path3D.curve).
+## Returns empty string if no viable curve class can be determined.
+static func _infer_curve_class(node: Node, property: String) -> String:
+	for prop in node.get_property_list():
+		if prop.name != property:
+			continue
+		var hint_string: String = prop.get("hint_string", "")
+		if hint_string.is_empty():
+			return ""
+		if not ClassDB.class_exists(hint_string):
+			return ""
+		if hint_string == "Curve" or hint_string == "Curve2D" or hint_string == "Curve3D":
+			return hint_string
+		# Some custom properties may list a parent class; require an exact
+		# match against our three supported types to avoid surprises.
+		return ""
+	return ""
 
 
 ## Convert input `points` into a normalized snapshot of typed values for

--- a/plugin/addons/godot_ai/handlers/curve_handler.gd
+++ b/plugin/addons/godot_ai/handlers/curve_handler.gd
@@ -1,0 +1,225 @@
+@tool
+class_name CurveHandler
+extends RefCounted
+
+## Replaces all points on a Curve / Curve2D / Curve3D resource. The point
+## list shape depends on resource type (see `set_points` for the schemas).
+##
+## Dedicated tool rather than a property set because Curve2D/Curve3D.add_point
+## is a method call, not a property — resource_create's `properties` dict can't
+## reach it.
+
+var _undo_redo: EditorUndoRedoManager
+
+
+func _init(undo_redo: EditorUndoRedoManager) -> void:
+	_undo_redo = undo_redo
+
+
+func set_points(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("path", "")
+	var property: String = params.get("property", "")
+	var resource_path: String = params.get("resource_path", "")
+	var new_points: Array = params.get("points", [])
+
+	var has_node_target := not node_path.is_empty()
+	var has_file_target := not resource_path.is_empty()
+	if has_node_target and has_file_target:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Provide either path+property or resource_path, not both"
+		)
+	if not has_node_target and not has_file_target:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Must provide either path+property (node-attached curve) or resource_path (standalone .tres)"
+		)
+	if has_node_target and property.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: property")
+	if not (new_points is Array):
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "points must be an array")
+
+	var curve: Resource
+	var node: Node = null
+	if has_file_target:
+		if not ResourceLoader.exists(resource_path):
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Resource not found: %s" % resource_path)
+		curve = ResourceLoader.load(resource_path)
+	else:
+		var scene_root := EditorInterface.get_edited_scene_root()
+		if scene_root == null:
+			return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+		node = ScenePath.resolve(node_path, scene_root)
+		if node == null:
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % node_path)
+		if not (property in node):
+			return McpErrorCodes.make(
+				McpErrorCodes.INVALID_PARAMS,
+				"Property '%s' not found on %s" % [property, node.get_class()]
+			)
+		curve = node.get(property)
+
+	if curve == null:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Curve resource at the given location is null — create one first with resource_create (type=Curve3D/Curve2D/Curve)"
+		)
+	if not (curve is Curve or curve is Curve2D or curve is Curve3D):
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Resource is %s — must be Curve, Curve2D, or Curve3D" % curve.get_class()
+		)
+
+	var coerced := _coerce_points(curve, new_points)
+	if coerced.has("error"):
+		return coerced.error
+
+	var new_snapshot: Array = coerced.snapshot
+
+	if has_file_target:
+		_apply_snapshot_to_curve(curve, new_snapshot)
+		var save_err := ResourceSaver.save(curve, resource_path)
+		if save_err != OK:
+			return McpErrorCodes.make(
+				McpErrorCodes.INTERNAL_ERROR,
+				"Failed to save curve to %s: %s" % [resource_path, error_string(save_err)]
+			)
+		return {
+			"data": {
+				"resource_path": resource_path,
+				"curve_class": curve.get_class(),
+				"point_count": new_snapshot.size(),
+				"undoable": false,
+				"reason": "File save is persistent; edit the .tres file manually to revert",
+			}
+		}
+
+	# Inline (node-attached) path: swap the curve property so the action lands
+	# cleanly in scene history, mirroring the resource-swap pattern used by
+	# material_handler::assign_material.
+	var new_curve: Resource = curve.duplicate()
+	_apply_snapshot_to_curve(new_curve, new_snapshot)
+	var old_curve: Resource = curve
+
+	_undo_redo.create_action("MCP: Set %d points on %s.%s" % [new_snapshot.size(), node.name, property])
+	_undo_redo.add_do_property(node, property, new_curve)
+	_undo_redo.add_undo_property(node, property, old_curve)
+	_undo_redo.add_do_reference(new_curve)
+	_undo_redo.commit_action()
+
+	return {
+		"data": {
+			"path": node_path,
+			"property": property,
+			"curve_class": new_curve.get_class(),
+			"point_count": new_snapshot.size(),
+			"undoable": true,
+		}
+	}
+
+
+## Convert input `points` into a normalized snapshot of typed values for
+## the given curve type. Returns {snapshot: Array} on success or
+## {error: ...} on failure.
+static func _coerce_points(curve: Resource, points: Array) -> Dictionary:
+	var snapshot: Array = []
+	if curve is Curve:
+		for i in range(points.size()):
+			var p = points[i]
+			if not (p is Dictionary) or not p.has("offset") or not p.has("value"):
+				return {"error": McpErrorCodes.make(
+					McpErrorCodes.INVALID_PARAMS,
+					"Curve points[%d] must be {offset, value, [left_tangent, right_tangent]}" % i
+				)}
+			snapshot.append({
+				"offset": float(p["offset"]),
+				"value": float(p["value"]),
+				"left_tangent": float(p.get("left_tangent", 0.0)),
+				"right_tangent": float(p.get("right_tangent", 0.0)),
+			})
+	elif curve is Curve2D:
+		for i in range(points.size()):
+			var p2 = points[i]
+			if not (p2 is Dictionary) or not p2.has("position"):
+				return {"error": McpErrorCodes.make(
+					McpErrorCodes.INVALID_PARAMS,
+					"Curve2D points[%d] must have 'position' (and optional 'in', 'out')" % i
+				)}
+			var pos = NodeHandler._coerce_value(p2["position"], TYPE_VECTOR2)
+			var in_v = NodeHandler._coerce_value(p2.get("in", {"x": 0, "y": 0}), TYPE_VECTOR2)
+			var out_v = NodeHandler._coerce_value(p2.get("out", {"x": 0, "y": 0}), TYPE_VECTOR2)
+			if not (pos is Vector2 and in_v is Vector2 and out_v is Vector2):
+				return {"error": McpErrorCodes.make(
+					McpErrorCodes.INVALID_PARAMS,
+					"Curve2D points[%d] in/position/out must coerce to Vector2" % i
+				)}
+			snapshot.append({"position": pos, "in": in_v, "out": out_v})
+	else:  # Curve3D
+		for i in range(points.size()):
+			var p3 = points[i]
+			if not (p3 is Dictionary) or not p3.has("position"):
+				return {"error": McpErrorCodes.make(
+					McpErrorCodes.INVALID_PARAMS,
+					"Curve3D points[%d] must have 'position' (and optional 'in', 'out', 'tilt')" % i
+				)}
+			var pos3 = NodeHandler._coerce_value(p3["position"], TYPE_VECTOR3)
+			var in3 = NodeHandler._coerce_value(p3.get("in", {"x": 0, "y": 0, "z": 0}), TYPE_VECTOR3)
+			var out3 = NodeHandler._coerce_value(p3.get("out", {"x": 0, "y": 0, "z": 0}), TYPE_VECTOR3)
+			var tilt := float(p3.get("tilt", 0.0))
+			if not (pos3 is Vector3 and in3 is Vector3 and out3 is Vector3):
+				return {"error": McpErrorCodes.make(
+					McpErrorCodes.INVALID_PARAMS,
+					"Curve3D points[%d] in/position/out must coerce to Vector3" % i
+				)}
+			snapshot.append({"position": pos3, "in": in3, "out": out3, "tilt": tilt})
+	return {"snapshot": snapshot}
+
+
+static func _snapshot_curve(curve: Resource) -> Array:
+	var snapshot: Array = []
+	if curve is Curve:
+		var c: Curve = curve
+		for i in range(c.point_count):
+			snapshot.append({
+				"offset": c.get_point_position(i).x,
+				"value": c.get_point_position(i).y,
+				"left_tangent": c.get_point_left_tangent(i),
+				"right_tangent": c.get_point_right_tangent(i),
+			})
+	elif curve is Curve2D:
+		var c2: Curve2D = curve
+		for i in range(c2.point_count):
+			snapshot.append({
+				"position": c2.get_point_position(i),
+				"in": c2.get_point_in(i),
+				"out": c2.get_point_out(i),
+			})
+	elif curve is Curve3D:
+		var c3: Curve3D = curve
+		for i in range(c3.point_count):
+			snapshot.append({
+				"position": c3.get_point_position(i),
+				"in": c3.get_point_in(i),
+				"out": c3.get_point_out(i),
+				"tilt": c3.get_point_tilt(i),
+			})
+	return snapshot
+
+
+func _apply_snapshot_to_curve(curve: Resource, snapshot: Array) -> void:
+	curve.clear_points()
+	if curve is Curve:
+		for p: Dictionary in snapshot:
+			curve.add_point(
+				Vector2(p.offset, p.value),
+				p.left_tangent,
+				p.right_tangent
+			)
+	elif curve is Curve2D:
+		for p: Dictionary in snapshot:
+			curve.add_point(p.position, p["in"], p.out)
+	elif curve is Curve3D:
+		for i in range(snapshot.size()):
+			var p: Dictionary = snapshot[i]
+			curve.add_point(p.position, p["in"], p.out)
+			curve.set_point_tilt(i, p.tilt)

--- a/plugin/addons/godot_ai/handlers/curve_handler.gd
+++ b/plugin/addons/godot_ai/handlers/curve_handler.gd
@@ -45,7 +45,21 @@ func set_points(params: Dictionary) -> Dictionary:
 	if has_file_target:
 		if not ResourceLoader.exists(resource_path):
 			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Resource not found: %s" % resource_path)
-		curve = ResourceLoader.load(resource_path)
+		# ResourceLoader.load() returns Godot's cached Resource. Duplicate
+		# before mutating so: (a) open scenes holding a reference to this
+		# .tres don't silently see the new points outside any undo action,
+		# and (b) if ResourceSaver.save() fails we haven't corrupted the
+		# in-memory cache (cache/disk divergence). Also guard against
+		# ResourceLoader.exists() succeeding but load() returning null
+		# (corrupt .tres, unregistered class) — otherwise curve.get_class()
+		# on the response line below would crash the plugin.
+		var loaded_curve: Resource = ResourceLoader.load(resource_path)
+		if loaded_curve == null:
+			return McpErrorCodes.make(
+				McpErrorCodes.INTERNAL_ERROR,
+				"Failed to load curve from %s (file exists but load returned null — may be corrupt)" % resource_path
+			)
+		curve = loaded_curve.duplicate()
 	else:
 		var scene_root := EditorInterface.get_edited_scene_root()
 		if scene_root == null:
@@ -95,6 +109,12 @@ func set_points(params: Dictionary) -> Dictionary:
 				McpErrorCodes.INTERNAL_ERROR,
 				"Failed to save curve to %s: %s" % [resource_path, error_string(save_err)]
 			)
+		# Refresh the FileSystem dock so it picks up the edit without manual
+		# reimport. Sibling save-paths in this PR (_save_created_resource,
+		# _save_environment, _save_texture) all do this — keep consistent.
+		var efs := EditorInterface.get_resource_filesystem()
+		if efs != null:
+			efs.update_file(resource_path)
 		return {
 			"data": {
 				"resource_path": resource_path,

--- a/plugin/addons/godot_ai/handlers/curve_handler.gd.uid
+++ b/plugin/addons/godot_ai/handlers/curve_handler.gd.uid
@@ -1,0 +1,1 @@
+uid://dboqr06a1fvqx

--- a/plugin/addons/godot_ai/handlers/environment_handler.gd
+++ b/plugin/addons/godot_ai/handlers/environment_handler.gd
@@ -1,0 +1,194 @@
+@tool
+class_name EnvironmentHandler
+extends RefCounted
+
+## Creates an Environment (+ optional Sky + ProceduralSkyMaterial) chain and
+## either assigns it to a WorldEnvironment node or saves it to a .tres file.
+## Bundles sub-resource creation + assignment in a single undo action.
+
+var _undo_redo: EditorUndoRedoManager
+
+
+func _init(undo_redo: EditorUndoRedoManager) -> void:
+	_undo_redo = undo_redo
+
+
+const _PRESETS := {
+	"default": {"sky": true, "fog": false},
+	"clear": {"sky": true, "fog": false},
+	"sunset": {"sky": true, "fog": false},
+	"night": {"sky": true, "fog": false},
+	"fog": {"sky": true, "fog": true},
+}
+
+
+func create_environment(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("path", "")
+	var resource_path: String = params.get("resource_path", "")
+	var overwrite: bool = params.get("overwrite", false)
+	var preset: String = params.get("preset", "default")
+	var properties: Dictionary = params.get("properties", {})
+	var sky_param = params.get("sky", null)  # nullable — falls back to preset default
+
+	if node_path.is_empty() and resource_path.is_empty():
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Must provide either path (WorldEnvironment node) or resource_path (.tres file)"
+		)
+	if not node_path.is_empty() and not resource_path.is_empty():
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Provide either path or resource_path, not both"
+		)
+
+	if not _PRESETS.has(preset):
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Invalid preset '%s'. Valid: %s" % [preset, ", ".join(_PRESETS.keys())]
+		)
+
+	var preset_config: Dictionary = _PRESETS[preset]
+	var want_sky: bool = sky_param if sky_param != null else preset_config.sky
+
+	var env := Environment.new()
+	var sky: Sky = null
+	var sky_material: ProceduralSkyMaterial = null
+	if want_sky:
+		sky_material = ProceduralSkyMaterial.new()
+		sky = Sky.new()
+		sky.sky_material = sky_material
+		env.background_mode = Environment.BG_SKY
+		env.sky = sky
+	else:
+		env.background_mode = Environment.BG_CLEAR_COLOR
+
+	_apply_preset(env, sky_material, preset)
+	if preset_config.fog:
+		env.volumetric_fog_enabled = true
+		env.volumetric_fog_density = 0.03
+
+	if not properties.is_empty():
+		var apply_err := ResourceHandler._apply_resource_properties(env, properties)
+		if apply_err != null:
+			return apply_err
+
+	if not resource_path.is_empty():
+		return _save_environment(env, sky, sky_material, resource_path, overwrite, preset)
+	return _assign_environment(env, sky, sky_material, node_path, preset)
+
+
+static func _apply_preset(env: Environment, sky_material: ProceduralSkyMaterial, preset: String) -> void:
+	match preset:
+		"default", "clear":
+			if sky_material != null:
+				sky_material.sky_top_color = Color(0.38, 0.45, 0.55)
+				sky_material.sky_horizon_color = Color(0.65, 0.67, 0.7)
+				sky_material.ground_horizon_color = Color(0.65, 0.67, 0.7)
+				sky_material.ground_bottom_color = Color(0.2, 0.17, 0.13)
+				sky_material.sun_angle_max = 30.0
+			env.ambient_light_source = Environment.AMBIENT_SOURCE_SKY
+			env.ambient_light_energy = 1.0
+		"sunset":
+			if sky_material != null:
+				sky_material.sky_top_color = Color(0.25, 0.3, 0.55)
+				sky_material.sky_horizon_color = Color(1.0, 0.55, 0.3)
+				sky_material.ground_horizon_color = Color(0.85, 0.4, 0.25)
+				sky_material.ground_bottom_color = Color(0.2, 0.12, 0.1)
+			env.ambient_light_source = Environment.AMBIENT_SOURCE_SKY
+			env.ambient_light_color = Color(1.0, 0.75, 0.55)
+			env.ambient_light_energy = 0.8
+		"night":
+			if sky_material != null:
+				sky_material.sky_top_color = Color(0.02, 0.02, 0.07)
+				sky_material.sky_horizon_color = Color(0.05, 0.07, 0.15)
+				sky_material.ground_horizon_color = Color(0.04, 0.05, 0.1)
+				sky_material.ground_bottom_color = Color(0.0, 0.0, 0.02)
+			env.ambient_light_source = Environment.AMBIENT_SOURCE_COLOR
+			env.ambient_light_color = Color(0.2, 0.22, 0.35)
+			env.ambient_light_energy = 0.4
+		"fog":
+			if sky_material != null:
+				sky_material.sky_top_color = Color(0.65, 0.65, 0.7)
+				sky_material.sky_horizon_color = Color(0.8, 0.8, 0.82)
+				sky_material.ground_horizon_color = Color(0.7, 0.7, 0.72)
+				sky_material.ground_bottom_color = Color(0.3, 0.3, 0.32)
+			env.ambient_light_source = Environment.AMBIENT_SOURCE_SKY
+			env.ambient_light_energy = 0.7
+
+
+func _assign_environment(env: Environment, sky: Sky, sky_material: ProceduralSkyMaterial, node_path: String, preset: String) -> Dictionary:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+
+	var node := ScenePath.resolve(node_path, scene_root)
+	if node == null:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % node_path)
+	if not (node is WorldEnvironment):
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Node at %s is %s — must be WorldEnvironment" % [node_path, node.get_class()]
+		)
+
+	var old_env = (node as WorldEnvironment).environment
+
+	_undo_redo.create_action("MCP: Create Environment (%s) for %s" % [preset, node.name])
+	_undo_redo.add_do_property(node, "environment", env)
+	_undo_redo.add_undo_property(node, "environment", old_env)
+	_undo_redo.add_do_reference(env)
+	if sky != null:
+		_undo_redo.add_do_reference(sky)
+	if sky_material != null:
+		_undo_redo.add_do_reference(sky_material)
+	_undo_redo.commit_action()
+
+	return {
+		"data": {
+			"path": node_path,
+			"preset": preset,
+			"sky_created": sky != null,
+			"sky_material_class": sky_material.get_class() if sky_material != null else "",
+			"undoable": true,
+		}
+	}
+
+
+func _save_environment(env: Environment, _sky: Sky, _sky_material: ProceduralSkyMaterial, resource_path: String, overwrite: bool, preset: String) -> Dictionary:
+	if not resource_path.begins_with("res://"):
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "resource_path must start with res://")
+
+	var existed_before := FileAccess.file_exists(resource_path)
+	if existed_before and not overwrite:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Environment already exists at %s (pass overwrite=true to replace)" % resource_path
+		)
+
+	var dir_path := resource_path.get_base_dir()
+	var mkdir_err := DirAccess.make_dir_recursive_absolute(dir_path)
+	if mkdir_err != OK and mkdir_err != ERR_ALREADY_EXISTS:
+		return McpErrorCodes.make(
+			McpErrorCodes.INTERNAL_ERROR,
+			"Failed to create directory %s: %s" % [dir_path, error_string(mkdir_err)]
+		)
+
+	var save_err := ResourceSaver.save(env, resource_path)
+	if save_err != OK:
+		return McpErrorCodes.make(
+			McpErrorCodes.INTERNAL_ERROR,
+			"Failed to save Environment to %s: %s" % [resource_path, error_string(save_err)]
+		)
+
+	var efs := EditorInterface.get_resource_filesystem()
+	if efs != null:
+		efs.update_file(resource_path)
+
+	return {
+		"data": {
+			"resource_path": resource_path,
+			"preset": preset,
+			"overwritten": existed_before,
+			"undoable": false,
+			"reason": "File creation is persistent; delete the file manually to revert",
+		}
+	}

--- a/plugin/addons/godot_ai/handlers/environment_handler.gd.uid
+++ b/plugin/addons/godot_ai/handlers/environment_handler.gd.uid
@@ -1,0 +1,1 @@
+uid://b1k7jldwjp5jt

--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -192,6 +192,8 @@ func set_property(params: Dictionary) -> Dictionary:
 	# (scripted @export vars can report TYPE_NIL in the property list).
 	var target_type: int = prop_type if prop_type != TYPE_NIL else typeof(old_value)
 
+	var instantiated_resource := false
+
 	if target_type == TYPE_OBJECT and value is String:
 		if value == "":
 			value = null
@@ -200,12 +202,38 @@ func set_property(params: Dictionary) -> Dictionary:
 			if loaded == null:
 				return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Resource not found: %s" % value)
 			value = loaded
+	elif target_type == TYPE_OBJECT and value is Dictionary and value.has("__class__"):
+		# Shortcut: {"__class__": "BoxMesh", "size": {...}} instantiates a
+		# fresh Resource subclass and applies the remaining keys as
+		# properties. Mirrors resource_create's inline-assign path but
+		# avoids a separate tool call for the common case.
+		var type_str: String = value.get("__class__", "")
+		var class_err := ResourceHandler._validate_resource_class(type_str)
+		if class_err != null:
+			return class_err
+		var instance := ClassDB.instantiate(type_str)
+		if instance == null or not (instance is Resource):
+			return McpErrorCodes.make(
+				McpErrorCodes.INTERNAL_ERROR,
+				"Failed to instantiate %s as a Resource" % type_str
+			)
+		var res: Resource = instance
+		var remaining: Dictionary = (value as Dictionary).duplicate()
+		remaining.erase("__class__")
+		if not remaining.is_empty():
+			var apply_err := ResourceHandler._apply_resource_properties(res, remaining)
+			if apply_err != null:
+				return apply_err
+		value = res
+		instantiated_resource = true
 	else:
 		value = _coerce_value(value, target_type)
 
 	_undo_redo.create_action("MCP: Set %s.%s" % [node.name, property])
 	_undo_redo.add_do_property(node, property, value)
 	_undo_redo.add_undo_property(node, property, old_value)
+	if instantiated_resource:
+		_undo_redo.add_do_reference(value)
 	_undo_redo.commit_action()
 
 	return {

--- a/plugin/addons/godot_ai/handlers/physics_shape_handler.gd
+++ b/plugin/addons/godot_ai/handlers/physics_shape_handler.gd
@@ -1,0 +1,248 @@
+@tool
+class_name PhysicsShapeHandler
+extends RefCounted
+
+## Sizes a CollisionShape2D/CollisionShape3D to match a visual sibling's
+## bounds. Auto-creates the concrete Shape subclass when the slot is empty
+## or the requested type differs — bundling creation and sizing in a single
+## undo action.
+##
+## Shape type defaults: Box for 3D, Rectangle for 2D.
+
+var _undo_redo: EditorUndoRedoManager
+
+
+func _init(undo_redo: EditorUndoRedoManager) -> void:
+	_undo_redo = undo_redo
+
+
+const _SHAPE_3D_CLASSES := {
+	"box": "BoxShape3D",
+	"sphere": "SphereShape3D",
+	"capsule": "CapsuleShape3D",
+	"cylinder": "CylinderShape3D",
+}
+
+const _SHAPE_2D_CLASSES := {
+	"rectangle": "RectangleShape2D",
+	"circle": "CircleShape2D",
+	"capsule": "CapsuleShape2D",
+}
+
+
+func autofit(params: Dictionary) -> Dictionary:
+	var node_path: String = params.get("path", "")
+	if node_path.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: path")
+
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+
+	var node := ScenePath.resolve(node_path, scene_root)
+	if node == null:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % node_path)
+
+	var is_3d := node is CollisionShape3D
+	var is_2d := node is CollisionShape2D
+	if not (is_3d or is_2d):
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Node at %s is %s — must be CollisionShape3D or CollisionShape2D" % [node_path, node.get_class()]
+		)
+
+	var source_path: String = params.get("source_path", "")
+	var source: Node = null
+	if source_path.is_empty():
+		source = _find_bounds_sibling(node, is_3d)
+		if source == null:
+			return McpErrorCodes.make(
+				McpErrorCodes.INVALID_PARAMS,
+				"No visual sibling found to measure — pass source_path explicitly (e.g. a MeshInstance3D or Sprite2D)"
+			)
+	else:
+		source = ScenePath.resolve(source_path, scene_root)
+		if source == null:
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Source node not found: %s" % source_path)
+
+	var shape_type: String = params.get("shape_type", "box" if is_3d else "rectangle")
+	var type_map := _SHAPE_3D_CLASSES if is_3d else _SHAPE_2D_CLASSES
+	if not type_map.has(shape_type):
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Invalid shape_type '%s' for %s. Valid: %s" % [shape_type, node.get_class(), ", ".join(type_map.keys())]
+		)
+	var shape_class: String = type_map[shape_type]
+
+	# Measure the visual.
+	var bounds := _measure_bounds(source, is_3d)
+	if bounds.has("error"):
+		return bounds.error
+
+	# Reuse the existing shape if it already matches the requested class;
+	# otherwise create a fresh one of the right type in the same undo action.
+	var existing_shape: Shape3D = null
+	var existing_shape_2d: Shape2D = null
+	if is_3d:
+		existing_shape = node.shape
+	else:
+		existing_shape_2d = node.shape
+
+	var needs_new_shape := false
+	if is_3d:
+		needs_new_shape = existing_shape == null or existing_shape.get_class() != shape_class
+	else:
+		needs_new_shape = existing_shape_2d == null or existing_shape_2d.get_class() != shape_class
+
+	var target_shape: Resource
+	if needs_new_shape:
+		var instance := ClassDB.instantiate(shape_class)
+		if instance == null:
+			return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to instantiate %s" % shape_class)
+		target_shape = instance
+	else:
+		target_shape = existing_shape if is_3d else existing_shape_2d
+
+	# Compute and apply size.
+	var size_info := _apply_shape_size(target_shape, shape_type, bounds, is_3d)
+	var old_shape = existing_shape if is_3d else existing_shape_2d
+
+	_undo_redo.create_action("MCP: Autofit %s on %s" % [shape_class, node.name])
+	if needs_new_shape:
+		_undo_redo.add_do_property(node, "shape", target_shape)
+		_undo_redo.add_undo_property(node, "shape", old_shape)
+		_undo_redo.add_do_reference(target_shape)
+	else:
+		# Existing shape stays, but its size changes — snapshot size for undo.
+		for key in size_info.applied:
+			var new_val = target_shape.get(key)
+			var old_val = size_info.previous.get(key)
+			_undo_redo.add_do_property(target_shape, key, new_val)
+			_undo_redo.add_undo_property(target_shape, key, old_val)
+	_undo_redo.commit_action()
+
+	return {
+		"data": {
+			"path": node_path,
+			"source_path": ScenePath.from_node(source, scene_root) if source_path.is_empty() else source_path,
+			"shape_type": shape_type,
+			"shape_class": shape_class,
+			"shape_created": needs_new_shape,
+			"size": size_info.size_response,
+			"undoable": true,
+		}
+	}
+
+
+## Find the first sibling of `collision_node` that provides bounds we can
+## measure. For 3D: any VisualInstance3D (MeshInstance3D, CSGShape3D, etc.).
+## For 2D: Sprite2D or TextureRect with an item rect.
+static func _find_bounds_sibling(collision_node: Node, is_3d: bool) -> Node:
+	var parent := collision_node.get_parent()
+	if parent == null:
+		return null
+	for sibling in parent.get_children():
+		if sibling == collision_node:
+			continue
+		if is_3d and sibling is VisualInstance3D:
+			return sibling
+		if not is_3d and (sibling is Sprite2D or sibling is TextureRect):
+			return sibling
+	return null
+
+
+## Measure the visual bounds of `source`. Returns {aabb: AABB} for 3D or
+## {rect: Rect2} for 2D on success, or {error: ...} on failure.
+static func _measure_bounds(source: Node, is_3d: bool) -> Dictionary:
+	if is_3d:
+		if source is VisualInstance3D:
+			return {"aabb": (source as VisualInstance3D).get_aabb()}
+		return {"error": McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Source %s has no measurable 3D bounds (must be VisualInstance3D subclass)" % source.get_class()
+		)}
+	# 2D
+	if source is Sprite2D:
+		var s: Sprite2D = source
+		return {"rect": s.get_rect()}
+	if source is TextureRect:
+		var tr: TextureRect = source
+		return {"rect": Rect2(Vector2.ZERO, tr.size)}
+	return {"error": McpErrorCodes.make(
+		McpErrorCodes.INVALID_PARAMS,
+		"Source %s has no measurable 2D bounds (must be Sprite2D or TextureRect)" % source.get_class()
+	)}
+
+
+## Apply size to `shape` based on `bounds` and the requested shape_type.
+## Returns {applied: [property_names], previous: {name: old_value}, size_response: dict}.
+static func _apply_shape_size(shape: Resource, shape_type: String, bounds: Dictionary, is_3d: bool) -> Dictionary:
+	var applied: Array[String] = []
+	var previous := {}
+	var size_response := {}
+
+	if is_3d:
+		var aabb: AABB = bounds.aabb
+		var size_v: Vector3 = aabb.size
+		match shape_type:
+			"box":
+				previous["size"] = shape.get("size")
+				(shape as BoxShape3D).size = size_v
+				applied.append("size")
+				size_response = {"x": size_v.x, "y": size_v.y, "z": size_v.z}
+			"sphere":
+				var r := maxf(maxf(size_v.x, size_v.y), size_v.z) * 0.5
+				previous["radius"] = shape.get("radius")
+				(shape as SphereShape3D).radius = r
+				applied.append("radius")
+				size_response = {"radius": r}
+			"capsule":
+				var cap := shape as CapsuleShape3D
+				var r2 := maxf(size_v.x, size_v.z) * 0.5
+				var h := size_v.y
+				previous["radius"] = cap.radius
+				previous["height"] = cap.height
+				cap.radius = r2
+				cap.height = h
+				applied.append("radius")
+				applied.append("height")
+				size_response = {"radius": r2, "height": h}
+			"cylinder":
+				var cyl := shape as CylinderShape3D
+				var r3 := maxf(size_v.x, size_v.z) * 0.5
+				var ch := size_v.y
+				previous["radius"] = cyl.radius
+				previous["height"] = cyl.height
+				cyl.radius = r3
+				cyl.height = ch
+				applied.append("radius")
+				applied.append("height")
+				size_response = {"radius": r3, "height": ch}
+	else:
+		var rect: Rect2 = bounds.rect
+		var sz: Vector2 = rect.size
+		match shape_type:
+			"rectangle":
+				previous["size"] = shape.get("size")
+				(shape as RectangleShape2D).size = sz
+				applied.append("size")
+				size_response = {"x": sz.x, "y": sz.y}
+			"circle":
+				var cr := maxf(sz.x, sz.y) * 0.5
+				previous["radius"] = shape.get("radius")
+				(shape as CircleShape2D).radius = cr
+				applied.append("radius")
+				size_response = {"radius": cr}
+			"capsule":
+				var cap2 := shape as CapsuleShape2D
+				var cr2 := sz.x * 0.5
+				var ch2 := sz.y
+				previous["radius"] = cap2.radius
+				previous["height"] = cap2.height
+				cap2.radius = cr2
+				cap2.height = ch2
+				applied.append("radius")
+				applied.append("height")
+				size_response = {"radius": cr2, "height": ch2}
+
+	return {"applied": applied, "previous": previous, "size_response": size_response}

--- a/plugin/addons/godot_ai/handlers/physics_shape_handler.gd
+++ b/plugin/addons/godot_ai/handlers/physics_shape_handler.gd
@@ -153,10 +153,19 @@ static func _find_bounds_sibling(collision_node: Node, is_3d: bool) -> Node:
 
 ## Measure the visual bounds of `source`. Returns {aabb: AABB} for 3D or
 ## {rect: Rect2} for 2D on success, or {error: ...} on failure.
+## Bounds are returned in world-ish size (local extents scaled by the source
+## node's own transform scale) so a MeshInstance3D at scale=(2,2,2) gives an
+## 8× volume collider, not a unit collider.
 static func _measure_bounds(source: Node, is_3d: bool) -> Dictionary:
 	if is_3d:
 		if source is VisualInstance3D:
-			return {"aabb": (source as VisualInstance3D).get_aabb()}
+			var aabb: AABB = (source as VisualInstance3D).get_aabb()
+			# get_aabb() is local-space; pre-multiply by the source's scale
+			# so the collider tracks what you actually see in the viewport.
+			var scale_3d: Vector3 = (source as Node3D).transform.basis.get_scale()
+			aabb.position = aabb.position * scale_3d
+			aabb.size = aabb.size * scale_3d
+			return {"aabb": aabb}
 		return {"error": McpErrorCodes.make(
 			McpErrorCodes.INVALID_PARAMS,
 			"Source %s has no measurable 3D bounds (must be VisualInstance3D subclass)" % source.get_class()
@@ -164,10 +173,27 @@ static func _measure_bounds(source: Node, is_3d: bool) -> Dictionary:
 	# 2D
 	if source is Sprite2D:
 		var s: Sprite2D = source
-		return {"rect": s.get_rect()}
+		var srect: Rect2 = s.get_rect()
+		# get_rect() reports the local texture rect and ignores scale.
+		srect.position = srect.position * s.scale
+		srect.size = srect.size * s.scale
+		return {"rect": srect}
 	if source is TextureRect:
 		var tr: TextureRect = source
-		return {"rect": Rect2(Vector2.ZERO, tr.size)}
+		# tr.size is the Control's laid-out size, which is Vector2.ZERO
+		# before the first layout pass (e.g. just after the node was created
+		# via MCP). Fall back to the texture's own size when that happens,
+		# so autofit doesn't silently produce a zero-sized shape.
+		var tr_size: Vector2 = tr.size
+		if tr_size.is_zero_approx():
+			if tr.texture != null:
+				tr_size = tr.texture.get_size() * tr.scale
+			else:
+				return {"error": McpErrorCodes.make(
+					McpErrorCodes.INVALID_PARAMS,
+					"TextureRect at %s has zero layout size and no texture to fall back to — autofit would produce a zero-sized shape" % source.name
+				)}
+		return {"rect": Rect2(Vector2.ZERO, tr_size)}
 	return {"error": McpErrorCodes.make(
 		McpErrorCodes.INVALID_PARAMS,
 		"Source %s has no measurable 2D bounds (must be Sprite2D or TextureRect)" % source.get_class()
@@ -202,11 +228,14 @@ static func _apply_shape_size(shape: Resource, shape_type: String, bounds: Dicti
 				var h := size_v.y
 				previous["radius"] = cap.radius
 				previous["height"] = cap.height
+				# CapsuleShape3D enforces height >= 2*radius and silently
+				# clamps setters that would violate it. Read back the
+				# stored values so the response reflects reality.
 				cap.radius = r2
 				cap.height = h
 				applied.append("radius")
 				applied.append("height")
-				size_response = {"radius": r2, "height": h}
+				size_response = {"radius": cap.radius, "height": cap.height}
 			"cylinder":
 				var cyl := shape as CylinderShape3D
 				var r3 := maxf(size_v.x, size_v.z) * 0.5
@@ -217,7 +246,7 @@ static func _apply_shape_size(shape: Resource, shape_type: String, bounds: Dicti
 				cyl.height = ch
 				applied.append("radius")
 				applied.append("height")
-				size_response = {"radius": r3, "height": ch}
+				size_response = {"radius": cyl.radius, "height": cyl.height}
 	else:
 		var rect: Rect2 = bounds.rect
 		var sz: Vector2 = rect.size
@@ -239,10 +268,12 @@ static func _apply_shape_size(shape: Resource, shape_type: String, bounds: Dicti
 				var ch2 := sz.y
 				previous["radius"] = cap2.radius
 				previous["height"] = cap2.height
+				# CapsuleShape2D has the same height >= 2*radius invariant
+				# as its 3D counterpart; read back what Godot actually kept.
 				cap2.radius = cr2
 				cap2.height = ch2
 				applied.append("radius")
 				applied.append("height")
-				size_response = {"radius": cr2, "height": ch2}
+				size_response = {"radius": cap2.radius, "height": cap2.height}
 
 	return {"applied": applied, "previous": previous, "size_response": size_response}

--- a/plugin/addons/godot_ai/handlers/physics_shape_handler.gd.uid
+++ b/plugin/addons/godot_ai/handlers/physics_shape_handler.gd.uid
@@ -1,0 +1,1 @@
+uid://cdg8kthqla1cj

--- a/plugin/addons/godot_ai/handlers/resource_handler.gd
+++ b/plugin/addons/godot_ai/handlers/resource_handler.gd
@@ -259,6 +259,29 @@ static func _apply_resource_properties(res: Resource, properties: Dictionary) ->
 						"Resource not found at path '%s' for property '%s'" % [v, key]
 					)
 				v = loaded
+		elif target_type == TYPE_OBJECT and v is Dictionary and v.has("__class__"):
+			# Nested shortcut: the same {"__class__": "X", ...} form that
+			# node_handler.set_property accepts, now also supported here so
+			# resource_create/environment_create callers can populate
+			# sub-resource slots (ShaderMaterial.shader, etc.) in one shot.
+			var sub_type: String = v.get("__class__", "")
+			var class_err := _validate_resource_class(sub_type)
+			if class_err != null:
+				return class_err
+			var sub_instance := ClassDB.instantiate(sub_type)
+			if sub_instance == null or not (sub_instance is Resource):
+				return McpErrorCodes.make(
+					McpErrorCodes.INTERNAL_ERROR,
+					"Failed to instantiate %s as a Resource for property '%s'" % [sub_type, key]
+				)
+			var sub_res: Resource = sub_instance
+			var remaining: Dictionary = (v as Dictionary).duplicate()
+			remaining.erase("__class__")
+			if not remaining.is_empty():
+				var nested_err := _apply_resource_properties(sub_res, remaining)
+				if nested_err != null:
+					return nested_err
+			v = sub_res
 		else:
 			v = NodeHandler._coerce_value(v, target_type)
 		res.set(key, v)

--- a/plugin/addons/godot_ai/handlers/resource_handler.gd
+++ b/plugin/addons/godot_ai/handlers/resource_handler.gd
@@ -147,3 +147,209 @@ func assign_resource(params: Dictionary) -> Dictionary:
 			"undoable": true,
 		}
 	}
+
+
+## Instantiate a built-in Resource subclass, optionally apply `properties`,
+## and either assign it to a node slot (undoable) or save it to a .tres file
+## (not undoable — mirrors material_create). Exactly one home is required;
+## a resource with no home would be GC'd after the handler returns.
+func create_resource(params: Dictionary) -> Dictionary:
+	var type_str: String = params.get("type", "")
+	if type_str.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: type")
+
+	var properties: Dictionary = params.get("properties", {})
+	var node_path: String = params.get("path", "")
+	var property: String = params.get("property", "")
+	var resource_path: String = params.get("resource_path", "")
+	var overwrite: bool = params.get("overwrite", false)
+
+	var has_node_target := not node_path.is_empty()
+	var has_file_target := not resource_path.is_empty()
+
+	if has_node_target and has_file_target:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Provide either path+property (assign inline) or resource_path (save .tres), not both"
+		)
+	if not has_node_target and not has_file_target:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Must provide either path+property (assign inline) or resource_path (save .tres) — a dangling resource would be GC'd"
+		)
+	if has_node_target and property.is_empty():
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Missing required param: property (required when path is given)"
+		)
+
+	var class_err := _validate_resource_class(type_str)
+	if class_err != null:
+		return class_err
+
+	var instance := ClassDB.instantiate(type_str)
+	if instance == null:
+		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to instantiate %s" % type_str)
+	if not (instance is Resource):
+		return McpErrorCodes.make(
+			McpErrorCodes.INTERNAL_ERROR,
+			"Instantiated %s but result is not a Resource (got %s)" % [type_str, instance.get_class()]
+		)
+	var res: Resource = instance
+
+	if not properties.is_empty():
+		var apply_err := _apply_resource_properties(res, properties)
+		if apply_err != null:
+			return apply_err
+
+	if has_file_target:
+		return _save_created_resource(res, type_str, resource_path, overwrite, properties.size())
+	return _assign_created_resource(res, type_str, node_path, property, properties.size())
+
+
+## Validate that `type_str` names a concrete Resource subclass that we can
+## instantiate. Returns an error dict on failure, or null on success.
+static func _validate_resource_class(type_str: String) -> Variant:
+	if not ClassDB.class_exists(type_str):
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Unknown resource type: %s" % type_str)
+	if ClassDB.is_parent_class(type_str, "Node"):
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"%s is a Node type, not a Resource — use node_create instead" % type_str
+		)
+	if not ClassDB.is_parent_class(type_str, "Resource"):
+		var parent := ClassDB.get_parent_class(type_str)
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"%s is not a Resource type (extends %s)" % [type_str, parent]
+		)
+	if not ClassDB.can_instantiate(type_str):
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"%s is abstract and cannot be instantiated — use a concrete subclass (e.g. BoxMesh, BoxShape3D, StyleBoxFlat)" % type_str
+		)
+	return null
+
+
+## Apply a dict of property values to a freshly-instantiated Resource,
+## reusing NodeHandler's coercion so Vector3/Color/etc. dicts land typed.
+## Returns null on success or an error dict on failure.
+static func _apply_resource_properties(res: Resource, properties: Dictionary) -> Variant:
+	var prop_types := {}
+	for prop in res.get_property_list():
+		prop_types[prop.name] = prop.get("type", TYPE_NIL)
+	for key in properties.keys():
+		if not prop_types.has(key):
+			return McpErrorCodes.make(
+				McpErrorCodes.INVALID_PARAMS,
+				"Property '%s' not found on %s" % [key, res.get_class()]
+			)
+		var target_type: int = prop_types[key]
+		if target_type == TYPE_NIL:
+			target_type = typeof(res.get(key))
+		var v = properties[key]
+		if target_type == TYPE_OBJECT and v is String:
+			if v == "":
+				v = null
+			else:
+				var loaded := ResourceLoader.load(v)
+				if loaded == null:
+					return McpErrorCodes.make(
+						McpErrorCodes.INVALID_PARAMS,
+						"Resource not found at path '%s' for property '%s'" % [v, key]
+					)
+				v = loaded
+		else:
+			v = NodeHandler._coerce_value(v, target_type)
+		res.set(key, v)
+	return null
+
+
+func _assign_created_resource(res: Resource, type_str: String, node_path: String, property: String, applied_count: int) -> Dictionary:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+
+	var node := ScenePath.resolve(node_path, scene_root)
+	if node == null:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % node_path)
+
+	var found := false
+	var prop_type: int = TYPE_NIL
+	for prop in node.get_property_list():
+		if prop.name == property:
+			found = true
+			prop_type = prop.get("type", TYPE_NIL)
+			break
+	if not found:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Property '%s' not found on %s" % [property, node.get_class()]
+		)
+	if prop_type != TYPE_NIL and prop_type != TYPE_OBJECT:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Property '%s' on %s is not an Object slot (type %s)" % [property, node.get_class(), type_string(prop_type)]
+		)
+
+	var old_value = node.get(property)
+
+	_undo_redo.create_action("MCP: Create %s for %s.%s" % [type_str, node.name, property])
+	_undo_redo.add_do_property(node, property, res)
+	_undo_redo.add_undo_property(node, property, old_value)
+	_undo_redo.add_do_reference(res)
+	_undo_redo.commit_action()
+
+	return {
+		"data": {
+			"path": node_path,
+			"property": property,
+			"type": type_str,
+			"resource_class": res.get_class(),
+			"properties_applied": applied_count,
+			"undoable": true,
+		}
+	}
+
+
+func _save_created_resource(res: Resource, type_str: String, resource_path: String, overwrite: bool, applied_count: int) -> Dictionary:
+	if not resource_path.begins_with("res://"):
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "resource_path must start with res://")
+
+	var existed_before := FileAccess.file_exists(resource_path)
+	if existed_before and not overwrite:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Resource already exists at %s (pass overwrite=true to replace)" % resource_path
+		)
+
+	var dir_path := resource_path.get_base_dir()
+	var mkdir_err := DirAccess.make_dir_recursive_absolute(dir_path)
+	if mkdir_err != OK and mkdir_err != ERR_ALREADY_EXISTS:
+		return McpErrorCodes.make(
+			McpErrorCodes.INTERNAL_ERROR,
+			"Failed to create directory %s: %s" % [dir_path, error_string(mkdir_err)]
+		)
+
+	var save_err := ResourceSaver.save(res, resource_path)
+	if save_err != OK:
+		return McpErrorCodes.make(
+			McpErrorCodes.INTERNAL_ERROR,
+			"Failed to save resource to %s: %s" % [resource_path, error_string(save_err)]
+		)
+
+	var efs := EditorInterface.get_resource_filesystem()
+	if efs != null:
+		efs.update_file(resource_path)
+
+	return {
+		"data": {
+			"resource_path": resource_path,
+			"type": type_str,
+			"resource_class": res.get_class(),
+			"properties_applied": applied_count,
+			"overwritten": existed_before,
+			"undoable": false,
+			"reason": "File creation is persistent; delete the file manually to revert",
+		}
+	}

--- a/plugin/addons/godot_ai/handlers/texture_handler.gd
+++ b/plugin/addons/godot_ai/handlers/texture_handler.gd
@@ -1,0 +1,252 @@
+@tool
+class_name TextureHandler
+extends RefCounted
+
+## Creates procedural textures — GradientTexture2D (wrapping a Gradient)
+## and NoiseTexture2D (wrapping a FastNoiseLite). Assigns to a node slot
+## (undoable, bundles sub-resources) or saves to a .tres file.
+
+var _undo_redo: EditorUndoRedoManager
+
+
+func _init(undo_redo: EditorUndoRedoManager) -> void:
+	_undo_redo = undo_redo
+
+
+const _FILL_MODES := {
+	"linear": GradientTexture2D.FILL_LINEAR,
+	"radial": GradientTexture2D.FILL_RADIAL,
+	"square": GradientTexture2D.FILL_SQUARE,
+}
+
+const _NOISE_TYPES := {
+	"simplex": FastNoiseLite.TYPE_SIMPLEX,
+	"simplex_smooth": FastNoiseLite.TYPE_SIMPLEX_SMOOTH,
+	"perlin": FastNoiseLite.TYPE_PERLIN,
+	"cellular": FastNoiseLite.TYPE_CELLULAR,
+	"value": FastNoiseLite.TYPE_VALUE,
+	"value_cubic": FastNoiseLite.TYPE_VALUE_CUBIC,
+}
+
+
+# ============================================================================
+# gradient_texture_create
+# ============================================================================
+
+func create_gradient_texture(params: Dictionary) -> Dictionary:
+	var stops: Array = params.get("stops", [])
+	var width: int = params.get("width", 256)
+	var height: int = params.get("height", 1)
+	var fill: String = params.get("fill", "linear")
+
+	if stops.size() < 2:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"gradient_texture_create requires at least 2 stops, got %d" % stops.size()
+		)
+	if not _FILL_MODES.has(fill):
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Invalid fill '%s'. Valid: %s" % [fill, ", ".join(_FILL_MODES.keys())]
+		)
+
+	var home_err := _validate_home(params)
+	if home_err != null:
+		return home_err
+
+	var gradient := Gradient.new()
+	var offsets := PackedFloat32Array()
+	var colors := PackedColorArray()
+	for i in range(stops.size()):
+		var stop = stops[i]
+		if not stop is Dictionary:
+			return McpErrorCodes.make(
+				McpErrorCodes.INVALID_PARAMS,
+				"stops[%d] must be a dict with 'offset' and 'color' keys" % i
+			)
+		if not stop.has("offset") or not stop.has("color"):
+			return McpErrorCodes.make(
+				McpErrorCodes.INVALID_PARAMS,
+				"stops[%d] missing 'offset' or 'color' key" % i
+			)
+		offsets.append(float(stop["offset"]))
+		var color_value = NodeHandler._coerce_value(stop["color"], TYPE_COLOR)
+		if not (color_value is Color):
+			return McpErrorCodes.make(
+				McpErrorCodes.INVALID_PARAMS,
+				"stops[%d].color could not be coerced to Color" % i
+			)
+		colors.append(color_value)
+	gradient.offsets = offsets
+	gradient.colors = colors
+
+	var tex := GradientTexture2D.new()
+	tex.gradient = gradient
+	tex.width = width
+	tex.height = height
+	tex.fill = _FILL_MODES[fill]
+
+	return _finalize(tex, [gradient], params, "Gradient texture", {
+		"texture_class": "GradientTexture2D",
+		"gradient_class": "Gradient",
+		"stop_count": stops.size(),
+		"fill": fill,
+	})
+
+
+# ============================================================================
+# noise_texture_create
+# ============================================================================
+
+func create_noise_texture(params: Dictionary) -> Dictionary:
+	var noise_type: String = params.get("noise_type", "simplex_smooth")
+	var width: int = params.get("width", 512)
+	var height: int = params.get("height", 512)
+	var frequency: float = params.get("frequency", 0.01)
+	var seed_value: int = params.get("seed", 0)
+	var fractal_octaves: int = params.get("fractal_octaves", 0)  # 0 = leave default
+
+	if not _NOISE_TYPES.has(noise_type):
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Invalid noise_type '%s'. Valid: %s" % [noise_type, ", ".join(_NOISE_TYPES.keys())]
+		)
+
+	var home_err := _validate_home(params)
+	if home_err != null:
+		return home_err
+
+	var noise := FastNoiseLite.new()
+	noise.noise_type = _NOISE_TYPES[noise_type]
+	noise.frequency = frequency
+	noise.seed = seed_value
+	if fractal_octaves > 0:
+		noise.fractal_octaves = fractal_octaves
+
+	var tex := NoiseTexture2D.new()
+	tex.noise = noise
+	tex.width = width
+	tex.height = height
+
+	return _finalize(tex, [noise], params, "Noise texture", {
+		"texture_class": "NoiseTexture2D",
+		"noise_class": "FastNoiseLite",
+		"noise_type": noise_type,
+	})
+
+
+# ============================================================================
+# shared helpers
+# ============================================================================
+
+static func _validate_home(params: Dictionary) -> Variant:
+	var node_path: String = params.get("path", "")
+	var property: String = params.get("property", "")
+	var resource_path: String = params.get("resource_path", "")
+	var has_node_target := not node_path.is_empty()
+	var has_file_target := not resource_path.is_empty()
+	if has_node_target and has_file_target:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Provide either path+property or resource_path, not both"
+		)
+	if not has_node_target and not has_file_target:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Must provide either path+property (assign inline) or resource_path (save .tres)"
+		)
+	if has_node_target and property.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: property")
+	return null
+
+
+func _finalize(tex: Resource, sub_resources: Array, params: Dictionary, label: String, extra: Dictionary) -> Dictionary:
+	var node_path: String = params.get("path", "")
+	var property: String = params.get("property", "")
+	var resource_path: String = params.get("resource_path", "")
+	var overwrite: bool = params.get("overwrite", false)
+
+	if not resource_path.is_empty():
+		return _save_texture(tex, resource_path, overwrite, label, extra)
+	return _assign_texture(tex, sub_resources, node_path, property, label, extra)
+
+
+func _assign_texture(tex: Resource, sub_resources: Array, node_path: String, property: String, label: String, extra: Dictionary) -> Dictionary:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+	var node := ScenePath.resolve(node_path, scene_root)
+	if node == null:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % node_path)
+
+	var found := false
+	var prop_type: int = TYPE_NIL
+	for prop in node.get_property_list():
+		if prop.name == property:
+			found = true
+			prop_type = prop.get("type", TYPE_NIL)
+			break
+	if not found:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Property '%s' not found on %s" % [property, node.get_class()]
+		)
+	if prop_type != TYPE_NIL and prop_type != TYPE_OBJECT:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Property '%s' on %s is not an Object slot" % [property, node.get_class()]
+		)
+
+	var old_value = node.get(property)
+
+	_undo_redo.create_action("MCP: Create %s for %s.%s" % [label, node.name, property])
+	_undo_redo.add_do_property(node, property, tex)
+	_undo_redo.add_undo_property(node, property, old_value)
+	_undo_redo.add_do_reference(tex)
+	for sub in sub_resources:
+		_undo_redo.add_do_reference(sub)
+	_undo_redo.commit_action()
+
+	var data := {
+		"path": node_path,
+		"property": property,
+		"undoable": true,
+	}
+	data.merge(extra)
+	return {"data": data}
+
+
+func _save_texture(tex: Resource, resource_path: String, overwrite: bool, label: String, extra: Dictionary) -> Dictionary:
+	if not resource_path.begins_with("res://"):
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "resource_path must start with res://")
+	var existed_before := FileAccess.file_exists(resource_path)
+	if existed_before and not overwrite:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"%s already exists at %s (pass overwrite=true to replace)" % [label, resource_path]
+		)
+	var dir_path := resource_path.get_base_dir()
+	var mkdir_err := DirAccess.make_dir_recursive_absolute(dir_path)
+	if mkdir_err != OK and mkdir_err != ERR_ALREADY_EXISTS:
+		return McpErrorCodes.make(
+			McpErrorCodes.INTERNAL_ERROR,
+			"Failed to create directory %s: %s" % [dir_path, error_string(mkdir_err)]
+		)
+	var save_err := ResourceSaver.save(tex, resource_path)
+	if save_err != OK:
+		return McpErrorCodes.make(
+			McpErrorCodes.INTERNAL_ERROR,
+			"Failed to save %s to %s: %s" % [label, resource_path, error_string(save_err)]
+		)
+	var efs := EditorInterface.get_resource_filesystem()
+	if efs != null:
+		efs.update_file(resource_path)
+
+	var data := {
+		"resource_path": resource_path,
+		"overwritten": existed_before,
+		"undoable": false,
+		"reason": "File creation is persistent; delete the file manually to revert",
+	}
+	data.merge(extra)
+	return {"data": data}

--- a/plugin/addons/godot_ai/handlers/texture_handler.gd.uid
+++ b/plugin/addons/godot_ai/handlers/texture_handler.gd.uid
@@ -1,0 +1,1 @@
+uid://cmloikhre8lhe

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -39,7 +39,11 @@ func _enter_tree() -> void:
 	var particle_handler := ParticleHandler.new(get_undo_redo())
 	var camera_handler := CameraHandler.new(get_undo_redo())
 	var audio_handler := AudioHandler.new(get_undo_redo())
-	_handlers = [editor_handler, scene_handler, node_handler, project_handler, client_handler, script_handler, resource_handler, filesystem_handler, signal_handler, autoload_handler, input_handler, test_handler, batch_handler, ui_handler, theme_handler, animation_handler, material_handler, particle_handler, camera_handler, audio_handler]
+	var physics_shape_handler := PhysicsShapeHandler.new(get_undo_redo())
+	var environment_handler := EnvironmentHandler.new(get_undo_redo())
+	var texture_handler := TextureHandler.new(get_undo_redo())
+	var curve_handler := CurveHandler.new(get_undo_redo())
+	_handlers = [editor_handler, scene_handler, node_handler, project_handler, client_handler, script_handler, resource_handler, filesystem_handler, signal_handler, autoload_handler, input_handler, test_handler, batch_handler, ui_handler, theme_handler, animation_handler, material_handler, particle_handler, camera_handler, audio_handler, physics_shape_handler, environment_handler, texture_handler, curve_handler]
 
 	_dispatcher.register("get_editor_state", editor_handler.get_editor_state)
 	_dispatcher.register("get_scene_tree", scene_handler.get_scene_tree)
@@ -86,6 +90,7 @@ func _enter_tree() -> void:
 	_dispatcher.register("search_resources", resource_handler.search_resources)
 	_dispatcher.register("load_resource", resource_handler.load_resource)
 	_dispatcher.register("assign_resource", resource_handler.assign_resource)
+	_dispatcher.register("create_resource", resource_handler.create_resource)
 	_dispatcher.register("read_file", filesystem_handler.read_file)
 	_dispatcher.register("write_file", filesystem_handler.write_file)
 	_dispatcher.register("reimport", filesystem_handler.reimport)
@@ -156,6 +161,11 @@ func _enter_tree() -> void:
 	_dispatcher.register("audio_play", audio_handler.play)
 	_dispatcher.register("audio_stop", audio_handler.stop)
 	_dispatcher.register("audio_list", audio_handler.list_streams)
+	_dispatcher.register("physics_shape_autofit", physics_shape_handler.autofit)
+	_dispatcher.register("environment_create", environment_handler.create_environment)
+	_dispatcher.register("gradient_texture_create", texture_handler.create_gradient_texture)
+	_dispatcher.register("noise_texture_create", texture_handler.create_noise_texture)
+	_dispatcher.register("curve_set_points", curve_handler.set_points)
 
 	_connection.dispatcher = _dispatcher
 	add_child(_connection)

--- a/plugin/addons/godot_ai/testing/test_suite.gd
+++ b/plugin/addons/godot_ai/testing/test_suite.gd
@@ -56,6 +56,43 @@ func skip(reason: String = "") -> void:
 	_skip_reason = reason
 
 
+## Trigger an undo against whichever history (scene or global) holds the most
+## recent action. `EditorUndoRedoManager` in Godot 4.x doesn't expose `.undo()`
+## directly — you resolve the history's underlying UndoRedo and call it there.
+## Actions registered via `add_do_method(self, …)` with a non-scene target land
+## in GLOBAL_HISTORY, while actions on scene nodes land in the scene's history,
+## so we try both (matches the pattern in batch_handler.gd).
+func editor_undo(undo_redo: EditorUndoRedoManager) -> bool:
+	for ur in _collect_histories(undo_redo):
+		if ur.undo():
+			return true
+	return false
+
+
+## Mirror of `editor_undo` for redo.
+func editor_redo(undo_redo: EditorUndoRedoManager) -> bool:
+	for ur in _collect_histories(undo_redo):
+		if ur.redo():
+			return true
+	return false
+
+
+func _collect_histories(undo_redo: EditorUndoRedoManager) -> Array:
+	var out: Array = []
+	if undo_redo == null:
+		return out
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root != null:
+		var scene_id := undo_redo.get_object_history_id(scene_root)
+		var scene_ur := undo_redo.get_history_undo_redo(scene_id)
+		if scene_ur != null:
+			out.append(scene_ur)
+	var global_ur := undo_redo.get_history_undo_redo(EditorUndoRedoManager.GLOBAL_HISTORY)
+	if global_ur != null and not global_ur in out:
+		out.append(global_ur)
+	return out
+
+
 # ----- assertions -----
 
 func assert_true(condition: bool, msg: String = "") -> void:

--- a/src/godot_ai/handlers/curve.py
+++ b/src/godot_ai/handlers/curve.py
@@ -1,0 +1,24 @@
+"""Shared handlers for curve tools."""
+
+from __future__ import annotations
+
+from godot_ai.handlers._readiness import require_writable
+from godot_ai.runtime.interface import Runtime
+
+
+async def curve_set_points(
+    runtime: Runtime,
+    points: list,
+    path: str = "",
+    property: str = "",
+    resource_path: str = "",
+) -> dict:
+    require_writable(runtime)
+    params: dict = {"points": points}
+    if path:
+        params["path"] = path
+    if property:
+        params["property"] = property
+    if resource_path:
+        params["resource_path"] = resource_path
+    return await runtime.send_command("curve_set_points", params)

--- a/src/godot_ai/handlers/environment.py
+++ b/src/godot_ai/handlers/environment.py
@@ -1,0 +1,30 @@
+"""Shared handlers for environment tools."""
+
+from __future__ import annotations
+
+from godot_ai.handlers._readiness import require_writable
+from godot_ai.runtime.interface import Runtime
+
+
+async def environment_create(
+    runtime: Runtime,
+    path: str = "",
+    preset: str = "default",
+    properties: dict | None = None,
+    sky: bool | None = None,
+    resource_path: str = "",
+    overwrite: bool = False,
+) -> dict:
+    require_writable(runtime)
+    params: dict = {"preset": preset}
+    if path:
+        params["path"] = path
+    if resource_path:
+        params["resource_path"] = resource_path
+    if properties:
+        params["properties"] = properties
+    if sky is not None:
+        params["sky"] = sky
+    if overwrite:
+        params["overwrite"] = overwrite
+    return await runtime.send_command("environment_create", params)

--- a/src/godot_ai/handlers/physics_shape.py
+++ b/src/godot_ai/handlers/physics_shape.py
@@ -1,0 +1,21 @@
+"""Shared handlers for physics_shape tools."""
+
+from __future__ import annotations
+
+from godot_ai.handlers._readiness import require_writable
+from godot_ai.runtime.interface import Runtime
+
+
+async def physics_shape_autofit(
+    runtime: Runtime,
+    path: str,
+    source_path: str = "",
+    shape_type: str = "",
+) -> dict:
+    require_writable(runtime)
+    params: dict = {"path": path}
+    if source_path:
+        params["source_path"] = source_path
+    if shape_type:
+        params["shape_type"] = shape_type
+    return await runtime.send_command("physics_shape_autofit", params)

--- a/src/godot_ai/handlers/resource.py
+++ b/src/godot_ai/handlers/resource.py
@@ -36,3 +36,27 @@ async def resource_assign(
         "assign_resource",
         {"path": path, "property": property, "resource_path": resource_path},
     )
+
+
+async def resource_create(
+    runtime: Runtime,
+    type: str,
+    properties: dict | None = None,
+    path: str = "",
+    property: str = "",
+    resource_path: str = "",
+    overwrite: bool = False,
+) -> dict:
+    require_writable(runtime)
+    params: dict = {"type": type}
+    if properties:
+        params["properties"] = properties
+    if path:
+        params["path"] = path
+    if property:
+        params["property"] = property
+    if resource_path:
+        params["resource_path"] = resource_path
+    if overwrite:
+        params["overwrite"] = overwrite
+    return await runtime.send_command("create_resource", params)

--- a/src/godot_ai/handlers/texture.py
+++ b/src/godot_ai/handlers/texture.py
@@ -1,0 +1,68 @@
+"""Shared handlers for procedural texture tools."""
+
+from __future__ import annotations
+
+from godot_ai.handlers._readiness import require_writable
+from godot_ai.runtime.interface import Runtime
+
+
+def _target_params(
+    path: str,
+    property: str,
+    resource_path: str,
+    overwrite: bool,
+) -> dict:
+    params: dict = {}
+    if path:
+        params["path"] = path
+    if property:
+        params["property"] = property
+    if resource_path:
+        params["resource_path"] = resource_path
+    if overwrite:
+        params["overwrite"] = overwrite
+    return params
+
+
+async def gradient_texture_create(
+    runtime: Runtime,
+    stops: list,
+    width: int = 256,
+    height: int = 1,
+    fill: str = "linear",
+    path: str = "",
+    property: str = "",
+    resource_path: str = "",
+    overwrite: bool = False,
+) -> dict:
+    require_writable(runtime)
+    params = {"stops": stops, "width": width, "height": height, "fill": fill}
+    params.update(_target_params(path, property, resource_path, overwrite))
+    return await runtime.send_command("gradient_texture_create", params)
+
+
+async def noise_texture_create(
+    runtime: Runtime,
+    noise_type: str = "simplex_smooth",
+    width: int = 512,
+    height: int = 512,
+    frequency: float = 0.01,
+    seed: int = 0,
+    fractal_octaves: int = 0,
+    path: str = "",
+    property: str = "",
+    resource_path: str = "",
+    overwrite: bool = False,
+) -> dict:
+    require_writable(runtime)
+    params: dict = {
+        "noise_type": noise_type,
+        "width": width,
+        "height": height,
+        "frequency": frequency,
+        "seed": seed,
+    }
+    if fractal_octaves > 0:
+        params["fractal_octaves"] = fractal_octaves
+    params.update(_target_params(path, property, resource_path, overwrite))
+    return await runtime.send_command("noise_texture_create", params)

--- a/src/godot_ai/server.py
+++ b/src/godot_ai/server.py
@@ -22,12 +22,15 @@ from godot_ai.tools.autoload import register_autoload_tools
 from godot_ai.tools.batch import register_batch_tools
 from godot_ai.tools.camera import register_camera_tools
 from godot_ai.tools.client import register_client_tools
+from godot_ai.tools.curve import register_curve_tools
 from godot_ai.tools.editor import register_editor_tools
+from godot_ai.tools.environment import register_environment_tools
 from godot_ai.tools.filesystem import register_filesystem_tools
 from godot_ai.tools.input_map import register_input_map_tools
 from godot_ai.tools.material import register_material_tools
 from godot_ai.tools.node import register_node_tools
 from godot_ai.tools.particle import register_particle_tools
+from godot_ai.tools.physics_shape import register_physics_shape_tools
 from godot_ai.tools.project import register_project_tools
 from godot_ai.tools.resource import register_resource_tools
 from godot_ai.tools.scene import register_scene_tools
@@ -35,6 +38,7 @@ from godot_ai.tools.script import register_script_tools
 from godot_ai.tools.session import register_session_tools
 from godot_ai.tools.signal import register_signal_tools
 from godot_ai.tools.testing import register_testing_tools
+from godot_ai.tools.texture import register_texture_tools
 from godot_ai.tools.theme import register_theme_tools
 from godot_ai.tools.ui import register_ui_tools
 from godot_ai.transport.websocket import GodotWebSocketServer
@@ -81,7 +85,9 @@ def create_server(ws_port: int = 9500) -> FastMCP:
             "  scene_*          — open/save scenes (levels/maps), inspect the scene tree\n"
             "  node_*           — create, inspect, modify, duplicate, group, reparent nodes\n"
             "  script_*         — create, read, attach, detach, outline GDScript files\n"
-            "  resource_*       — search, load, assign resources (assets: meshes, textures, etc.)\n"
+            "  resource_*       — search, load, assign, and CREATE built-in Resources "
+            "(BoxMesh, BoxShape3D, Curve, Gradient, StyleBox*, PhysicsMaterial, etc.) "
+            "inline or as .tres files — see resource_create\n"
             "  signal_*         — list, connect, disconnect node signals (events / callbacks)\n"
             "  input_map_*      — manage input actions (keybindings, keyboard/mouse/gamepad)\n"
             "  autoload_*       — manage autoload singletons (global scripts)\n"
@@ -109,6 +115,15 @@ def create_server(ws_port: int = 9500) -> FastMCP:
             "(follow, bounds, zoom, damping, smoothing, drag margins, deadzone)\n"
             "  audio_*          — author sound effects and music "
             "(AudioStreamPlayer/2D/3D) — load streams, play, stop, list audio assets\n"
+            "  physics_shape_*  — size CollisionShape2D/3D to match sibling visuals "
+            "(box, sphere, capsule, cylinder / rectangle, circle, capsule)\n"
+            "  environment_*    — author WorldEnvironment chain "
+            "(Environment + Sky + SkyMaterial) with presets: "
+            "default, sunset, night, fog\n"
+            "  gradient_texture_*, noise_texture_* — procedural 2D textures "
+            "(gradients for Line2D/Sprite2D, FastNoiseLite + NoiseTexture2D for heightmaps)\n"
+            "  curve_*          — author Curve/Curve2D/Curve3D point lists "
+            "for Path3D routes, particle ramps, and easing curves\n"
             "  client_*         — configure AI clients (Claude Code, Codex, Antigravity)\n\n"
             "Always connect to an editor session first (session_list / session_activate). "
             "Write operations require session readiness; check editor_state if a call is "
@@ -138,6 +153,10 @@ def create_server(ws_port: int = 9500) -> FastMCP:
     register_particle_tools(mcp)
     register_camera_tools(mcp)
     register_audio_tools(mcp)
+    register_physics_shape_tools(mcp)
+    register_environment_tools(mcp)
+    register_texture_tools(mcp)
+    register_curve_tools(mcp)
     register_session_resources(mcp)
     register_scene_resources(mcp)
     register_editor_resources(mcp)

--- a/src/godot_ai/tools/curve.py
+++ b/src/godot_ai/tools/curve.py
@@ -34,6 +34,12 @@ def register_curve_tools(mcp: FastMCP) -> None:
         Line2D-like curves) or resource_path (a .tres file). Inline edits are
         undoable as a single action; .tres edits are persistent.
 
+        If the node's curve slot is empty, a fresh Curve/Curve2D/Curve3D is
+        auto-created (inferred from the property's class hint — Path3D.curve
+        → Curve3D, Path2D.curve → Curve2D, etc.) and bundled into the same
+        undo action. The response sets `curve_created: true` when this
+        happens.
+
         Dedicated tool rather than set_property because Curve2D/Curve3D.add_point
         is a method call, not a property — resource_create's properties dict
         can't reach it.

--- a/src/godot_ai/tools/curve.py
+++ b/src/godot_ai/tools/curve.py
@@ -1,0 +1,55 @@
+"""MCP tools for curve point authoring."""
+
+from __future__ import annotations
+
+from fastmcp import Context, FastMCP
+
+from godot_ai.handlers import curve as curve_handlers
+from godot_ai.runtime.direct import DirectRuntime
+from godot_ai.tools import DEFER_META
+
+
+def register_curve_tools(mcp: FastMCP) -> None:
+    @mcp.tool(meta=DEFER_META)
+    async def curve_set_points(
+        ctx: Context,
+        points: list,
+        path: str = "",
+        property: str = "",
+        resource_path: str = "",
+        session_id: str = "",
+    ) -> dict:
+        """Replace all points on a Curve / Curve2D / Curve3D resource.
+
+        Point list shape depends on the resource type:
+
+        - Curve (scalar control curve): [{"offset": 0.0, "value": 1.0,
+          "left_tangent": 0.0, "right_tangent": 0.0}, ...] — tangents optional.
+        - Curve2D (2D path): [{"position": {"x": 0, "y": 0}, "in": {...},
+          "out": {...}}, ...] — in/out default to zero (linear segments).
+        - Curve3D (3D path): [{"position": {"x": 0, "y": 0, "z": 0}, "in": {...},
+          "out": {...}, "tilt": 0.0}, ...] — all optional except position.
+
+        Either pass path+property (a curve slot on a node, e.g. Path3D.curve,
+        Line2D-like curves) or resource_path (a .tres file). Inline edits are
+        undoable as a single action; .tres edits are persistent.
+
+        Dedicated tool rather than set_property because Curve2D/Curve3D.add_point
+        is a method call, not a property — resource_create's properties dict
+        can't reach it.
+
+        Args:
+            points: Ordered list of point dicts (schema depends on curve type).
+            path: Scene path of a node holding the curve.
+            property: Property name on that node (e.g. "curve").
+            resource_path: res:// path of a standalone curve .tres file.
+            session_id: Optional Godot session.
+        """
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
+        return await curve_handlers.curve_set_points(
+            runtime,
+            points=points,
+            path=path,
+            property=property,
+            resource_path=resource_path,
+        )

--- a/src/godot_ai/tools/environment.py
+++ b/src/godot_ai/tools/environment.py
@@ -1,0 +1,60 @@
+"""MCP tools for Environment authoring."""
+
+from __future__ import annotations
+
+from fastmcp import Context, FastMCP
+
+from godot_ai.handlers import environment as environment_handlers
+from godot_ai.runtime.direct import DirectRuntime
+from godot_ai.tools import DEFER_META
+
+
+def register_environment_tools(mcp: FastMCP) -> None:
+    @mcp.tool(meta=DEFER_META)
+    async def environment_create(
+        ctx: Context,
+        path: str = "",
+        preset: str = "default",
+        properties: dict | None = None,
+        sky: bool | None = None,
+        resource_path: str = "",
+        overwrite: bool = False,
+        session_id: str = "",
+    ) -> dict:
+        """Create an Environment + Sky + ProceduralSkyMaterial chain for 3D scenes.
+
+        Instantiates the full Environment stack (background mode, ambient
+        light, optional procedural sky, optional volumetric fog), tuned to a
+        named preset. Either assigns to a WorldEnvironment node in one
+        undoable action, or saves the Environment to a .tres file.
+
+        Presets:
+        - "default" / "clear": bright procedural sky, daylight ambient.
+        - "sunset": warm orange horizon, warm ambient.
+        - "night": dark blue sky, low ambient.
+        - "fog": clear sky + volumetric fog enabled.
+
+        Pass `properties` (e.g. {"ambient_light_energy": 1.5}) to override
+        preset values on the Environment itself.
+
+        Args:
+            path: Scene path of a WorldEnvironment node (e.g. "/Main/World").
+                Mutually exclusive with resource_path.
+            preset: One of "default", "clear", "sunset", "night", "fog".
+            properties: Optional dict of Environment property overrides.
+            sky: Optional override for whether to create a Sky chain.
+                Defaults based on preset (true for all built-in presets).
+            resource_path: res:// destination for a saved Environment .tres.
+            overwrite: Allow replacing an existing file at resource_path.
+            session_id: Optional Godot session to target.
+        """
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
+        return await environment_handlers.environment_create(
+            runtime,
+            path=path,
+            preset=preset,
+            properties=properties,
+            sky=sky,
+            resource_path=resource_path,
+            overwrite=overwrite,
+        )

--- a/src/godot_ai/tools/node.py
+++ b/src/godot_ai/tools/node.py
@@ -167,7 +167,11 @@ def register_node_tools(mcp: FastMCP) -> None:
         - Vector2/Vector3: dict with x/y/z keys
         - Color: dict with r/g/b/a keys, or hex string ("#ff0000")
         - NodePath: string ("../Other/Node")
-        - Resource: res:// path string (loads and assigns); pass null or "" to clear
+        - Resource: res:// path string (loads and assigns); pass null or "" to clear.
+          For a fresh built-in Resource instance, pass a dict with a "__class__"
+          key — e.g. value={"__class__": "BoxMesh", "size": {"x": 2, "y": 2, "z": 2}}
+          instantiates a BoxMesh with that size and assigns it. See resource_create
+          for more control (save to .tres, validation errors).
         - StringName: plain string
         - Array/Dictionary: pass a JSON list/object
         - bool/int/float: JSON primitives

--- a/src/godot_ai/tools/physics_shape.py
+++ b/src/godot_ai/tools/physics_shape.py
@@ -1,0 +1,49 @@
+"""MCP tools for physics shape authoring."""
+
+from __future__ import annotations
+
+from fastmcp import Context, FastMCP
+
+from godot_ai.handlers import physics_shape as physics_shape_handlers
+from godot_ai.runtime.direct import DirectRuntime
+from godot_ai.tools import DEFER_META
+
+
+def register_physics_shape_tools(mcp: FastMCP) -> None:
+    @mcp.tool(meta=DEFER_META)
+    async def physics_shape_autofit(
+        ctx: Context,
+        path: str,
+        source_path: str = "",
+        shape_type: str = "",
+        session_id: str = "",
+    ) -> dict:
+        """Size a CollisionShape2D/CollisionShape3D to match a visual sibling's bounds.
+
+        Auto-creates the concrete shape subclass (BoxShape3D / SphereShape3D /
+        CapsuleShape3D / CylinderShape3D for 3D; RectangleShape2D /
+        CircleShape2D / CapsuleShape2D for 2D) if the shape slot is empty or
+        holds a shape of a different type. Creation + sizing bundle into one
+        undoable action.
+
+        The visual source defaults to a sibling VisualInstance3D
+        (MeshInstance3D, CSGShape3D, etc.) for 3D or a sibling Sprite2D /
+        TextureRect for 2D. Pass source_path explicitly for anything more
+        complex.
+
+        Args:
+            path: Scene path of the CollisionShape2D or CollisionShape3D.
+            source_path: Optional scene path of the visual node to measure.
+                Auto-detected from siblings when empty.
+            shape_type: Desired shape kind. For 3D: "box" (default), "sphere",
+                "capsule", "cylinder". For 2D: "rectangle" (default),
+                "circle", "capsule".
+            session_id: Optional Godot session to target. Empty = active.
+        """
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
+        return await physics_shape_handlers.physics_shape_autofit(
+            runtime,
+            path=path,
+            source_path=source_path,
+            shape_type=shape_type,
+        )

--- a/src/godot_ai/tools/resource.py
+++ b/src/godot_ai/tools/resource.py
@@ -82,3 +82,63 @@ def register_resource_tools(mcp: FastMCP) -> None:
             property=property,
             resource_path=resource_path,
         )
+
+    @mcp.tool(meta=DEFER_META)
+    async def resource_create(
+        ctx: Context,
+        type: str,
+        properties: dict | None = None,
+        path: str = "",
+        property: str = "",
+        resource_path: str = "",
+        overwrite: bool = False,
+        session_id: str = "",
+    ) -> dict:
+        """Instantiate a built-in Godot Resource subclass in-memory or as a .tres file.
+
+        Covers primitive meshes (BoxMesh, SphereMesh, CylinderMesh, CapsuleMesh,
+        PlaneMesh, TorusMesh, PrismMesh, QuadMesh), physics shapes (BoxShape3D,
+        SphereShape3D, CapsuleShape3D, CylinderShape3D, RectangleShape2D,
+        CircleShape2D, CapsuleShape2D, ...), curves (Curve, Curve2D, Curve3D),
+        gradients (Gradient), StyleBox variants, PhysicsMaterial, Environment,
+        Sky, SkyMaterial, ProceduralSkyMaterial, and any other concrete Resource
+        subclass — i.e. everything ClassDB.can_instantiate() allows.
+
+        Exactly one of {path+property, resource_path} must be given:
+        - path+property: instantiate and assign to the node slot in one
+          undoable action (undo restores the previous value).
+        - resource_path: instantiate and save as a .tres/.res file on disk
+          (not undoable — file creation is persistent).
+
+        For compound resources with their own authoring tools, prefer those:
+        material_create (Materials), animation_create (Animations),
+        theme_create (Themes). Use environment_create, gradient_texture_create,
+        noise_texture_create, physics_shape_autofit, or curve_set_points for
+        those specific families where composing sub-resources matters.
+
+        Args:
+            type: Godot class name to instantiate (e.g. "BoxMesh", "BoxShape3D",
+                "Curve", "StyleBoxFlat"). Must be a concrete Resource subclass.
+            properties: Optional dict of initial property values. Values are
+                coerced the same way set_property does — e.g. {"size": {"x": 2,
+                "y": 2, "z": 2}} lands as a Vector3, colors as Color, etc.
+            path: Scene path of a node to receive the resource (e.g.
+                "/Main/Mesh"). Mutually exclusive with resource_path.
+            property: Property name on that node (e.g. "mesh", "shape",
+                "texture"). Required when path is given.
+            resource_path: res:// destination to save as a .tres/.res file.
+                Mutually exclusive with path+property.
+            overwrite: Allow replacing an existing file at resource_path.
+                Default false.
+            session_id: Optional Godot session to target. Empty = active.
+        """
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
+        return await resource_handlers.resource_create(
+            runtime,
+            type=type,
+            properties=properties,
+            path=path,
+            property=property,
+            resource_path=resource_path,
+            overwrite=overwrite,
+        )

--- a/src/godot_ai/tools/texture.py
+++ b/src/godot_ai/tools/texture.py
@@ -1,0 +1,110 @@
+"""MCP tools for procedural texture authoring (gradient + noise)."""
+
+from __future__ import annotations
+
+from fastmcp import Context, FastMCP
+
+from godot_ai.handlers import texture as texture_handlers
+from godot_ai.runtime.direct import DirectRuntime
+from godot_ai.tools import DEFER_META
+
+
+def register_texture_tools(mcp: FastMCP) -> None:
+    @mcp.tool(meta=DEFER_META)
+    async def gradient_texture_create(
+        ctx: Context,
+        stops: list,
+        width: int = 256,
+        height: int = 1,
+        fill: str = "linear",
+        path: str = "",
+        property: str = "",
+        resource_path: str = "",
+        overwrite: bool = False,
+        session_id: str = "",
+    ) -> dict:
+        """Create a GradientTexture2D wrapping a Gradient from color stops.
+
+        Builds the Gradient resource with the provided (offset, color) stops,
+        wraps it in a GradientTexture2D, and either assigns it to a node
+        property (undoable, bundles both resources in one action) or saves it
+        to a .tres file.
+
+        Common target properties: Line2D.texture, Sprite2D.texture, TextureRect.texture.
+
+        Args:
+            stops: List of {"offset": float, "color": {"r","g","b","a"} or "#rrggbb"}
+                ordered by offset. Minimum 2 stops.
+            width: Texture width in pixels. Default 256.
+            height: Texture height in pixels. Default 1 (strip).
+            fill: Fill mode — "linear", "radial", or "square". Default "linear".
+            path: Scene path of the target node.
+            property: Property name on that node.
+            resource_path: res:// destination (.tres). Mutually exclusive with path.
+            overwrite: Allow replacing an existing file at resource_path.
+            session_id: Optional Godot session.
+        """
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
+        return await texture_handlers.gradient_texture_create(
+            runtime,
+            stops=stops,
+            width=width,
+            height=height,
+            fill=fill,
+            path=path,
+            property=property,
+            resource_path=resource_path,
+            overwrite=overwrite,
+        )
+
+    @mcp.tool(meta=DEFER_META)
+    async def noise_texture_create(
+        ctx: Context,
+        noise_type: str = "simplex_smooth",
+        width: int = 512,
+        height: int = 512,
+        frequency: float = 0.01,
+        seed: int = 0,
+        fractal_octaves: int = 0,
+        path: str = "",
+        property: str = "",
+        resource_path: str = "",
+        overwrite: bool = False,
+        session_id: str = "",
+    ) -> dict:
+        """Create a NoiseTexture2D wrapping a FastNoiseLite for procedural textures.
+
+        Useful for terrain heightmaps, cloud/smoke masks, detail maps,
+        organic-looking variation. Assigns to a node (undoable) or saves to
+        .tres. NoiseTexture2D generates asynchronously in Godot; the texture
+        resource is returned immediately and Godot fills the image data on its
+        worker thread.
+
+        Args:
+            noise_type: "simplex", "simplex_smooth" (default), "perlin",
+                "cellular", "value", or "value_cubic".
+            width: Texture width in pixels. Default 512.
+            height: Texture height in pixels. Default 512.
+            frequency: FastNoiseLite frequency (larger = finer detail). Default 0.01.
+            seed: Noise seed. Default 0.
+            fractal_octaves: Optional fractal octaves (0 = leave default).
+            path: Scene path of the target node.
+            property: Property name on that node.
+            resource_path: res:// destination (.tres).
+            overwrite: Allow replacing an existing file.
+            session_id: Optional Godot session.
+        """
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
+        return await texture_handlers.noise_texture_create(
+            runtime,
+            noise_type=noise_type,
+            width=width,
+            height=height,
+            frequency=frequency,
+            seed=seed,
+            fractal_octaves=fractal_octaves,
+            path=path,
+            property=property,
+            resource_path=resource_path,
+            overwrite=overwrite,
+        )

--- a/test_project/tests/test_curve.gd
+++ b/test_project/tests/test_curve.gd
@@ -298,6 +298,47 @@ func test_set_points_scalar_curve() -> void:
 	DirAccess.remove_absolute(ProjectSettings.globalize_path(out_path))
 
 
+# ----- regression: resource_path branch must not mutate the cached Resource -----
+
+func test_set_points_disk_path_does_not_mutate_cached_resource() -> void:
+	# If the handler mutates the loaded (cached) curve in place before saving,
+	# anything else that holds a reference to the same ResourceLoader cache
+	# would silently see the new points outside any undo action. Guard that.
+	var out_path := "res://test_tmp_cache_sharing.tres"
+	if FileAccess.file_exists(out_path):
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(out_path))
+	var c := Curve3D.new()
+	c.add_point(Vector3(99, 99, 99))  # unique marker point in the ORIGINAL
+	ResourceSaver.save(c, out_path)
+
+	# Warm the ResourceLoader cache by loading once — this is the object the
+	# handler's ResourceLoader.load() call will get back.
+	var cached: Curve3D = ResourceLoader.load(out_path)
+	assert_eq(cached.point_count, 1)
+	assert_eq(cached.get_point_position(0), Vector3(99, 99, 99))
+
+	var result := _handler.set_points({
+		"points": [
+			{"position": {"x": 0, "y": 0, "z": 0}},
+			{"position": {"x": 1, "y": 0, "z": 0}},
+		],
+		"resource_path": out_path,
+	})
+	assert_has_key(result, "data")
+
+	# The cached in-memory instance held by someone else (us, here) must
+	# remain unmodified. The handler should have duplicated before mutating.
+	assert_eq(cached.point_count, 1, "Cached Curve3D must not be mutated in place")
+	assert_eq(cached.get_point_position(0), Vector3(99, 99, 99))
+
+	# A fresh load, meanwhile, should reflect the newly-saved points.
+	var reloaded: Curve3D = ResourceLoader.load(out_path)
+	# If reloaded == cached (same cache slot), the cache may have been
+	# invalidated by the save; regardless, reloading should give us 2 points.
+	assert_gt(reloaded.point_count, 0)
+	DirAccess.remove_absolute(ProjectSettings.globalize_path(out_path))
+
+
 func test_set_points_3d_invalid_point_shape() -> void:
 	var p := _add_path_3d("TestCurve3DBadShape")
 	if p == null:

--- a/test_project/tests/test_curve.gd
+++ b/test_project/tests/test_curve.gd
@@ -73,26 +73,6 @@ func test_set_points_missing_property() -> void:
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 
 
-func test_set_points_null_curve_errors() -> void:
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		skip("No scene root")
-		return
-	var p := Path3D.new()
-	p.name = "NullCurvePath"
-	# Intentionally leave p.curve = null
-	scene_root.add_child(p)
-	p.set_owner(scene_root)
-	var result := _handler.set_points({
-		"points": [],
-		"path": p.get_path(),
-		"property": "curve",
-	})
-	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
-	assert_contains(result.error.message, "null")
-	_remove_node(p)
-
-
 func test_set_points_wrong_resource_type() -> void:
 	var scene_root := EditorInterface.get_edited_scene_root()
 	if scene_root == null:
@@ -114,6 +94,83 @@ func test_set_points_wrong_resource_type() -> void:
 
 
 # ----- Curve3D happy paths -----
+
+func test_set_points_auto_creates_curve3d_when_null() -> void:
+	# Regression: Path3D with curve=null should auto-create a fresh Curve3D
+	# in the same undo action, rather than requiring a separate resource_create.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root")
+		return
+	var p := Path3D.new()
+	p.name = "TestAutoCreate3D"
+	# Intentionally leave p.curve = null
+	scene_root.add_child(p)
+	p.set_owner(scene_root)
+	assert_true(p.curve == null, "Precondition: curve slot should be empty")
+
+	var result := _handler.set_points({
+		"points": [
+			{"position": {"x": 0, "y": 0, "z": 0}},
+			{"position": {"x": 1, "y": 0, "z": 0}},
+		],
+		"path": p.get_path(),
+		"property": "curve",
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.curve_class, "Curve3D")
+	assert_eq(result.data.point_count, 2)
+	assert_true(result.data.curve_created, "curve_created should be true when slot was null")
+	assert_true(p.curve is Curve3D)
+	assert_eq(p.curve.point_count, 2)
+
+	# Undo should clear the slot back to null, not leave the auto-created curve.
+	editor_undo(_undo_redo)
+	assert_true(p.curve == null, "Undo should clear the auto-created curve")
+	_remove_node(p)
+
+
+func test_set_points_auto_creates_curve2d_on_path2d() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root")
+		return
+	var p := Path2D.new()
+	p.name = "TestAutoCreate2D"
+	scene_root.add_child(p)
+	p.set_owner(scene_root)
+	assert_true(p.curve == null)
+
+	var result := _handler.set_points({
+		"points": [
+			{"position": {"x": 0, "y": 0}},
+			{"position": {"x": 100, "y": 0}},
+		],
+		"path": p.get_path(),
+		"property": "curve",
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.curve_class, "Curve2D")
+	assert_true(result.data.curve_created)
+	assert_true(p.curve is Curve2D)
+	_remove_node(p)
+
+
+func test_set_points_existing_curve_does_not_flag_created() -> void:
+	var p := _add_path_3d("TestExistingCurve")
+	if p == null:
+		skip("No scene root")
+		return
+	# Curve already exists from _add_path_3d
+	var result := _handler.set_points({
+		"points": [{"position": {"x": 0, "y": 0, "z": 0}}],
+		"path": p.get_path(),
+		"property": "curve",
+	})
+	assert_has_key(result, "data")
+	assert_false(result.data.curve_created, "curve_created should be false when slot already had a curve")
+	_remove_node(p)
+
 
 func test_set_points_3d_position_only_coerces_vector3() -> void:
 	var p := _add_path_3d("TestCurve3DPos")

--- a/test_project/tests/test_curve.gd
+++ b/test_project/tests/test_curve.gd
@@ -1,0 +1,255 @@
+@tool
+extends McpTestSuite
+
+## Tests for CurveHandler — set points on Curve/Curve2D/Curve3D resources.
+
+var _handler: CurveHandler
+var _undo_redo: EditorUndoRedoManager
+
+
+func suite_name() -> String:
+	return "curve"
+
+
+func suite_setup(ctx: Dictionary) -> void:
+	_undo_redo = ctx.get("undo_redo")
+	_handler = CurveHandler.new(_undo_redo)
+
+
+func _add_path_3d(node_name: String) -> Path3D:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return null
+	var p := Path3D.new()
+	p.name = node_name
+	p.curve = Curve3D.new()
+	scene_root.add_child(p)
+	p.set_owner(scene_root)
+	return p
+
+
+func _add_path_2d(node_name: String) -> Path2D:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return null
+	var p := Path2D.new()
+	p.name = node_name
+	p.curve = Curve2D.new()
+	scene_root.add_child(p)
+	p.set_owner(scene_root)
+	return p
+
+
+func _remove_node(node: Node) -> void:
+	if node == null:
+		return
+	if node.get_parent():
+		node.get_parent().remove_child(node)
+	node.queue_free()
+
+
+# ----- validation -----
+
+func test_set_points_no_home() -> void:
+	var result := _handler.set_points({"points": []})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_set_points_both_homes() -> void:
+	var result := _handler.set_points({
+		"points": [],
+		"path": "/Main/Path3D",
+		"property": "curve",
+		"resource_path": "res://curve.tres",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_set_points_missing_property() -> void:
+	var result := _handler.set_points({
+		"points": [],
+		"path": "/Main/Path3D",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_set_points_null_curve_errors() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root")
+		return
+	var p := Path3D.new()
+	p.name = "NullCurvePath"
+	# Intentionally leave p.curve = null
+	scene_root.add_child(p)
+	p.set_owner(scene_root)
+	var result := _handler.set_points({
+		"points": [],
+		"path": p.get_path(),
+		"property": "curve",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "null")
+	_remove_node(p)
+
+
+func test_set_points_wrong_resource_type() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root")
+		return
+	var mi := MeshInstance3D.new()
+	mi.name = "NotACurveHost"
+	mi.mesh = BoxMesh.new()
+	scene_root.add_child(mi)
+	mi.set_owner(scene_root)
+	var result := _handler.set_points({
+		"points": [],
+		"path": mi.get_path(),
+		"property": "mesh",  # BoxMesh, not a Curve
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "Curve")
+	_remove_node(mi)
+
+
+# ----- Curve3D happy paths -----
+
+func test_set_points_3d_position_only_coerces_vector3() -> void:
+	var p := _add_path_3d("TestCurve3DPos")
+	if p == null:
+		skip("No scene root")
+		return
+	var points := [
+		{"position": {"x": 0, "y": 0, "z": 0}},
+		{"position": {"x": 5, "y": 0, "z": 0}},
+		{"position": {"x": 5, "y": 5, "z": 0}},
+	]
+	var result := _handler.set_points({
+		"points": points,
+		"path": p.get_path(),
+		"property": "curve",
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.curve_class, "Curve3D")
+	assert_eq(result.data.point_count, 3)
+	assert_true(result.data.undoable)
+	# Assert on stored Variant — not just the count.
+	assert_eq(p.curve.point_count, 3)
+	assert_true(p.curve.get_point_position(0) is Vector3)
+	assert_eq(p.curve.get_point_position(0), Vector3(0, 0, 0))
+	assert_eq(p.curve.get_point_position(1), Vector3(5, 0, 0))
+	assert_eq(p.curve.get_point_position(2), Vector3(5, 5, 0))
+	_remove_node(p)
+
+
+func test_set_points_3d_with_tilts() -> void:
+	var p := _add_path_3d("TestCurve3DTilt")
+	if p == null:
+		skip("No scene root")
+		return
+	var points := [
+		{"position": {"x": 0, "y": 0, "z": 0}, "tilt": 0.0},
+		{"position": {"x": 1, "y": 0, "z": 0}, "tilt": 1.5},
+	]
+	var result := _handler.set_points({
+		"points": points,
+		"path": p.get_path(),
+		"property": "curve",
+	})
+	assert_has_key(result, "data")
+	assert_eq(p.curve.get_point_tilt(1), 1.5)
+	_remove_node(p)
+
+
+func test_set_points_3d_undo_restores_old_points() -> void:
+	var p := _add_path_3d("TestCurve3DUndo")
+	if p == null:
+		skip("No scene root")
+		return
+	# Prime the curve with an initial point so we have something to restore.
+	p.curve.add_point(Vector3(10, 10, 10))
+	assert_eq(p.curve.point_count, 1)
+	var result := _handler.set_points({
+		"points": [
+			{"position": {"x": 0, "y": 0, "z": 0}},
+			{"position": {"x": 1, "y": 0, "z": 0}},
+		],
+		"path": p.get_path(),
+		"property": "curve",
+	})
+	assert_has_key(result, "data")
+	assert_eq(p.curve.point_count, 2)
+	editor_undo(_undo_redo)
+	assert_eq(p.curve.point_count, 1)
+	assert_eq(p.curve.get_point_position(0), Vector3(10, 10, 10))
+	editor_redo(_undo_redo)
+	assert_eq(p.curve.point_count, 2)
+	_remove_node(p)
+
+
+# ----- Curve2D happy path -----
+
+func test_set_points_2d() -> void:
+	var p := _add_path_2d("TestCurve2D")
+	if p == null:
+		skip("No scene root")
+		return
+	var points := [
+		{"position": {"x": 0, "y": 0}},
+		{"position": {"x": 100, "y": 50}},
+	]
+	var result := _handler.set_points({
+		"points": points,
+		"path": p.get_path(),
+		"property": "curve",
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.curve_class, "Curve2D")
+	assert_true(p.curve.get_point_position(0) is Vector2)
+	assert_eq(p.curve.get_point_position(1), Vector2(100, 50))
+	_remove_node(p)
+
+
+# ----- Curve (scalar) happy path -----
+
+func test_set_points_scalar_curve() -> void:
+	# Use a CPUParticles2D-like host — but actually, scalar Curves are more
+	# commonly found on saved .tres files. Create and save one then edit it.
+	var out_path := "res://test_tmp_curve.tres"
+	if FileAccess.file_exists(out_path):
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(out_path))
+	var c := Curve.new()
+	ResourceSaver.save(c, out_path)
+	var result := _handler.set_points({
+		"points": [
+			{"offset": 0.0, "value": 0.0},
+			{"offset": 0.5, "value": 1.0, "left_tangent": 0.5, "right_tangent": -0.5},
+			{"offset": 1.0, "value": 0.0},
+		],
+		"resource_path": out_path,
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.curve_class, "Curve")
+	assert_eq(result.data.point_count, 3)
+	assert_false(result.data.undoable)
+	var loaded: Curve = ResourceLoader.load(out_path)
+	assert_eq(loaded.point_count, 3)
+	assert_eq(loaded.get_point_position(1).x, 0.5)
+	assert_eq(loaded.get_point_position(1).y, 1.0)
+	assert_eq(loaded.get_point_left_tangent(1), 0.5)
+	DirAccess.remove_absolute(ProjectSettings.globalize_path(out_path))
+
+
+func test_set_points_3d_invalid_point_shape() -> void:
+	var p := _add_path_3d("TestCurve3DBadShape")
+	if p == null:
+		skip("No scene root")
+		return
+	var result := _handler.set_points({
+		"points": [{"not_position": {"x": 0}}],
+		"path": p.get_path(),
+		"property": "curve",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	_remove_node(p)

--- a/test_project/tests/test_curve.gd.uid
+++ b/test_project/tests/test_curve.gd.uid
@@ -1,0 +1,1 @@
+uid://bdh1ymsayvk4o

--- a/test_project/tests/test_environment.gd
+++ b/test_project/tests/test_environment.gd
@@ -1,0 +1,189 @@
+@tool
+extends McpTestSuite
+
+## Tests for EnvironmentHandler — create Environment + Sky + SkyMaterial.
+
+var _handler: EnvironmentHandler
+var _undo_redo: EditorUndoRedoManager
+
+
+func suite_name() -> String:
+	return "environment"
+
+
+func suite_setup(ctx: Dictionary) -> void:
+	_undo_redo = ctx.get("undo_redo")
+	_handler = EnvironmentHandler.new(_undo_redo)
+
+
+func _add_world_env(env_name: String) -> WorldEnvironment:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return null
+	var we := WorldEnvironment.new()
+	we.name = env_name
+	scene_root.add_child(we)
+	we.set_owner(scene_root)
+	return we
+
+
+func _remove_node(node: Node) -> void:
+	if node == null:
+		return
+	if node.get_parent():
+		node.get_parent().remove_child(node)
+	node.queue_free()
+
+
+# ----- validation -----
+
+func test_create_no_home_errors() -> void:
+	var result := _handler.create_environment({"preset": "default"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_create_both_homes_errors() -> void:
+	var result := _handler.create_environment({
+		"path": "/Main/World",
+		"resource_path": "res://env.tres",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_create_invalid_preset() -> void:
+	var result := _handler.create_environment({
+		"path": "/Main/World",
+		"preset": "zapruder",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_create_target_not_world_environment() -> void:
+	var result := _handler.create_environment({
+		"path": "/Main/Camera3D",  # Camera3D, not WorldEnvironment
+		"preset": "default",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "WorldEnvironment")
+
+
+# ----- inline assign happy paths -----
+
+func test_create_default_assigns_environment_with_sky() -> void:
+	var we := _add_world_env("TestEnvDefault")
+	if we == null:
+		skip("No scene root")
+		return
+	var result := _handler.create_environment({
+		"path": we.get_path(),
+		"preset": "default",
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.preset, "default")
+	assert_true(result.data.sky_created)
+	assert_true(result.data.undoable)
+	# Assert on stored Variant — per CLAUDE.md.
+	assert_true(we.environment is Environment)
+	assert_true(we.environment.sky is Sky)
+	assert_true(we.environment.sky.sky_material is ProceduralSkyMaterial)
+	_remove_node(we)
+
+
+func test_create_sunset_tints_sky_material() -> void:
+	var we := _add_world_env("TestEnvSunset")
+	if we == null:
+		skip("No scene root")
+		return
+	var result := _handler.create_environment({
+		"path": we.get_path(),
+		"preset": "sunset",
+	})
+	assert_has_key(result, "data")
+	var mat: ProceduralSkyMaterial = we.environment.sky.sky_material
+	# Sunset horizon is orange — check it's *not* the default bluish.
+	assert_true(mat.sky_horizon_color is Color)
+	assert_true(mat.sky_horizon_color.r > mat.sky_horizon_color.b, "Sunset horizon should be warm (r > b)")
+	_remove_node(we)
+
+
+func test_create_fog_enables_volumetric_fog() -> void:
+	var we := _add_world_env("TestEnvFog")
+	if we == null:
+		skip("No scene root")
+		return
+	var result := _handler.create_environment({
+		"path": we.get_path(),
+		"preset": "fog",
+	})
+	assert_has_key(result, "data")
+	assert_true(we.environment.volumetric_fog_enabled)
+	assert_true(we.environment.volumetric_fog_density > 0.0)
+	_remove_node(we)
+
+
+func test_create_sky_false_skips_sky_chain() -> void:
+	var we := _add_world_env("TestEnvNoSky")
+	if we == null:
+		skip("No scene root")
+		return
+	var result := _handler.create_environment({
+		"path": we.get_path(),
+		"preset": "default",
+		"sky": false,
+	})
+	assert_has_key(result, "data")
+	assert_false(result.data.sky_created)
+	assert_true(we.environment.sky == null)
+	_remove_node(we)
+
+
+func test_create_properties_override_preset() -> void:
+	var we := _add_world_env("TestEnvOverride")
+	if we == null:
+		skip("No scene root")
+		return
+	var result := _handler.create_environment({
+		"path": we.get_path(),
+		"preset": "default",
+		"properties": {"ambient_light_energy": 2.5},
+	})
+	assert_has_key(result, "data")
+	assert_eq(we.environment.ambient_light_energy, 2.5)
+	_remove_node(we)
+
+
+func test_create_undo_restores_previous_environment() -> void:
+	var we := _add_world_env("TestEnvUndo")
+	if we == null:
+		skip("No scene root")
+		return
+	var prev_env = we.environment  # likely null
+	var result := _handler.create_environment({
+		"path": we.get_path(),
+		"preset": "night",
+	})
+	assert_has_key(result, "data")
+	assert_true(we.environment != null)
+	editor_undo(_undo_redo)
+	assert_eq(we.environment, prev_env)
+	editor_redo(_undo_redo)
+	assert_true(we.environment is Environment)
+	_remove_node(we)
+
+
+# ----- save to disk -----
+
+func test_create_saves_to_disk() -> void:
+	var out_path := "res://test_tmp_env.tres"
+	if FileAccess.file_exists(out_path):
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(out_path))
+	var result := _handler.create_environment({
+		"resource_path": out_path,
+		"preset": "clear",
+	})
+	assert_has_key(result, "data")
+	assert_false(result.data.undoable)
+	assert_true(FileAccess.file_exists(out_path))
+	var loaded := ResourceLoader.load(out_path)
+	assert_true(loaded is Environment)
+	DirAccess.remove_absolute(ProjectSettings.globalize_path(out_path))

--- a/test_project/tests/test_environment.gd.uid
+++ b/test_project/tests/test_environment.gd.uid
@@ -1,0 +1,1 @@
+uid://doi4vyuhtw2ij

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -295,6 +295,98 @@ func test_set_property_nonexistent_property() -> void:
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 
 
+# ----- set_property __class__ shortcut (fresh built-in Resource) -----
+
+func _add_mesh_instance_for_shortcut(node_name: String) -> Node:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return null
+	var mi := MeshInstance3D.new()
+	mi.name = node_name
+	scene_root.add_child(mi)
+	mi.set_owner(scene_root)
+	return mi
+
+
+func test_set_property_class_dict_instantiates_fresh_resource() -> void:
+	var mi := _add_mesh_instance_for_shortcut("TestClassDictBox")
+	if mi == null:
+		skip("No scene root — is a scene open?")
+		return
+	var result := _handler.set_property({
+		"path": "/%s/TestClassDictBox" % mi.get_parent().name,
+		"property": "mesh",
+		"value": {"__class__": "BoxMesh", "size": {"x": 2, "y": 3, "z": 4}},
+	})
+	assert_has_key(result, "data")
+	# Assert on stored Variant — not just the response — per CLAUDE.md.
+	assert_true(mi.mesh is BoxMesh, "mesh should be a BoxMesh instance")
+	assert_true(mi.mesh.size is Vector3)
+	assert_eq(mi.mesh.size.x, 2.0)
+	assert_eq(mi.mesh.size.z, 4.0)
+	# Undo should restore null.
+	editor_undo(_undo_redo)
+	assert_true(mi.mesh == null)
+	if mi.get_parent():
+		mi.get_parent().remove_child(mi)
+	mi.queue_free()
+
+
+func test_set_property_class_dict_invalid_class() -> void:
+	var mi := _add_mesh_instance_for_shortcut("TestClassDictBad")
+	if mi == null:
+		skip("No scene root — is a scene open?")
+		return
+	var result := _handler.set_property({
+		"path": "/%s/TestClassDictBad" % mi.get_parent().name,
+		"property": "mesh",
+		"value": {"__class__": "NotARealClass"},
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	if mi.get_parent():
+		mi.get_parent().remove_child(mi)
+	mi.queue_free()
+
+
+func test_set_property_class_dict_abstract_class() -> void:
+	var mi := _add_mesh_instance_for_shortcut("TestClassDictAbstract")
+	if mi == null:
+		skip("No scene root — is a scene open?")
+		return
+	# Shape3D is truly abstract per ClassDB.can_instantiate().
+	# PrimitiveMesh is technically instantiable, so it's not a good test target.
+	var result := _handler.set_property({
+		"path": "/%s/TestClassDictAbstract" % mi.get_parent().name,
+		"property": "mesh",
+		"value": {"__class__": "Shape3D"},
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "abstract")
+	if mi.get_parent():
+		mi.get_parent().remove_child(mi)
+	mi.queue_free()
+
+
+func test_set_property_resource_path_still_works() -> void:
+	# Regression: __class__ shortcut must not break the existing
+	# "string value = res:// path" behavior.
+	var mi := _add_mesh_instance_for_shortcut("TestResPathRegression")
+	if mi == null:
+		skip("No scene root — is a scene open?")
+		return
+	var result := _handler.set_property({
+		"path": "/%s/TestResPathRegression" % mi.get_parent().name,
+		"property": "material_override",
+		"value": TEST_MATERIAL_PATH,
+	})
+	assert_has_key(result, "data")
+	assert_true(mi.material_override is StandardMaterial3D)
+	editor_undo(_undo_redo)
+	if mi.get_parent():
+		mi.get_parent().remove_child(mi)
+	mi.queue_free()
+
+
 # ----- _coerce_value / _serialize_value unit coverage -----
 
 func test_coerce_array_passthrough() -> void:

--- a/test_project/tests/test_physics_shape.gd
+++ b/test_project/tests/test_physics_shape.gd
@@ -1,0 +1,236 @@
+@tool
+extends McpTestSuite
+
+## Tests for PhysicsShapeHandler — autofit CollisionShape* to sibling bounds.
+
+var _handler: PhysicsShapeHandler
+var _undo_redo: EditorUndoRedoManager
+
+
+func suite_name() -> String:
+	return "physics_shape"
+
+
+func suite_setup(ctx: Dictionary) -> void:
+	_undo_redo = ctx.get("undo_redo")
+	_handler = PhysicsShapeHandler.new(_undo_redo)
+
+
+# ----- helpers -----
+
+func _add_body_3d(body_name: String, mesh_size: Vector3) -> Dictionary:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return {}
+	var body := StaticBody3D.new()
+	body.name = body_name
+	scene_root.add_child(body)
+	body.set_owner(scene_root)
+
+	var mi := MeshInstance3D.new()
+	mi.name = "Mesh"
+	var box := BoxMesh.new()
+	box.size = mesh_size
+	mi.mesh = box
+	body.add_child(mi)
+	mi.set_owner(scene_root)
+
+	var col := CollisionShape3D.new()
+	col.name = "Collision"
+	body.add_child(col)
+	col.set_owner(scene_root)
+
+	return {"body": body, "mesh": mi, "collision": col}
+
+
+func _add_body_2d(body_name: String, rect_size: Vector2) -> Dictionary:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return {}
+	var body := StaticBody2D.new()
+	body.name = body_name
+	scene_root.add_child(body)
+	body.set_owner(scene_root)
+
+	var sprite := Sprite2D.new()
+	sprite.name = "Sprite"
+	# Create a tiny test texture so get_rect() returns non-zero bounds.
+	var img := Image.create(int(rect_size.x), int(rect_size.y), false, Image.FORMAT_RGBA8)
+	img.fill(Color.WHITE)
+	sprite.texture = ImageTexture.create_from_image(img)
+	body.add_child(sprite)
+	sprite.set_owner(scene_root)
+
+	var col := CollisionShape2D.new()
+	col.name = "Collision"
+	body.add_child(col)
+	col.set_owner(scene_root)
+
+	return {"body": body, "sprite": sprite, "collision": col}
+
+
+func _remove_node(node: Node) -> void:
+	if node == null:
+		return
+	if node.get_parent():
+		node.get_parent().remove_child(node)
+	node.queue_free()
+
+
+# ----- validation errors -----
+
+func test_autofit_missing_path() -> void:
+	var result := _handler.autofit({})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_autofit_node_not_found() -> void:
+	var result := _handler.autofit({"path": "/Main/NopeNotHere"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_autofit_node_is_not_collision_shape() -> void:
+	var result := _handler.autofit({"path": "/Main/Camera3D"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "CollisionShape")
+
+
+func test_autofit_invalid_shape_type_for_3d() -> void:
+	var parts := _add_body_3d("TestBadType3D", Vector3(2, 1, 1))
+	if parts.is_empty():
+		skip("No scene root")
+		return
+	var result := _handler.autofit({
+		"path": parts.collision.get_path(),
+		"shape_type": "rectangle",  # 2D-only type used in 3D context
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	_remove_node(parts.body)
+
+
+# ----- 3D happy paths -----
+
+func test_autofit_3d_box_creates_and_sizes_shape() -> void:
+	var parts := _add_body_3d("TestAutofit3DBox", Vector3(3, 1, 2))
+	if parts.is_empty():
+		skip("No scene root")
+		return
+	var result := _handler.autofit({"path": parts.collision.get_path()})
+	assert_has_key(result, "data")
+	assert_eq(result.data.shape_class, "BoxShape3D")
+	assert_true(result.data.shape_created)
+	assert_true(result.data.undoable)
+	# The auto-detected source_path must be a clean scene path, not an
+	# editor-internal viewport path. Regression guard.
+	assert_true(result.data.source_path.begins_with("/"), "source_path should be a scene path")
+	assert_false(result.data.source_path.contains("@SubViewport"), "source_path must not leak editor viewport wrapping")
+	assert_true(parts.collision.shape is BoxShape3D)
+	assert_true(parts.collision.shape.size is Vector3)
+	assert_eq(parts.collision.shape.size.x, 3.0)
+	assert_eq(parts.collision.shape.size.y, 1.0)
+	assert_eq(parts.collision.shape.size.z, 2.0)
+	editor_undo(_undo_redo)
+	assert_true(parts.collision.shape == null)
+	_remove_node(parts.body)
+
+
+func test_autofit_3d_sphere_uses_max_extent() -> void:
+	var parts := _add_body_3d("TestAutofit3DSphere", Vector3(4, 1, 2))
+	if parts.is_empty():
+		skip("No scene root")
+		return
+	var result := _handler.autofit({
+		"path": parts.collision.get_path(),
+		"shape_type": "sphere",
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.shape_class, "SphereShape3D")
+	assert_true(parts.collision.shape is SphereShape3D)
+	assert_eq(parts.collision.shape.radius, 2.0)  # max(4,1,2) / 2
+	_remove_node(parts.body)
+
+
+func test_autofit_3d_capsule_dims() -> void:
+	var parts := _add_body_3d("TestAutofit3DCap", Vector3(2, 4, 2))
+	if parts.is_empty():
+		skip("No scene root")
+		return
+	var result := _handler.autofit({
+		"path": parts.collision.get_path(),
+		"shape_type": "capsule",
+	})
+	assert_has_key(result, "data")
+	assert_true(parts.collision.shape is CapsuleShape3D)
+	assert_eq(parts.collision.shape.radius, 1.0)  # max(x,z) / 2
+	assert_eq(parts.collision.shape.height, 4.0)
+	_remove_node(parts.body)
+
+
+func test_autofit_3d_reuses_existing_shape_of_same_type() -> void:
+	var parts := _add_body_3d("TestAutofit3DReuse", Vector3(1, 1, 1))
+	if parts.is_empty():
+		skip("No scene root")
+		return
+	var existing := BoxShape3D.new()
+	existing.size = Vector3(0.1, 0.1, 0.1)
+	parts.collision.shape = existing
+	var result := _handler.autofit({"path": parts.collision.get_path()})
+	assert_has_key(result, "data")
+	assert_false(result.data.shape_created, "Existing BoxShape3D should be reused")
+	assert_eq(parts.collision.shape, existing, "Shape object identity should be preserved on reuse")
+	assert_eq(parts.collision.shape.size.x, 1.0)
+	_remove_node(parts.body)
+
+
+# ----- 2D happy path -----
+
+func test_autofit_2d_rectangle() -> void:
+	var parts := _add_body_2d("TestAutofit2DRect", Vector2(32, 48))
+	if parts.is_empty():
+		skip("No scene root")
+		return
+	var result := _handler.autofit({"path": parts.collision.get_path()})
+	assert_has_key(result, "data")
+	assert_eq(result.data.shape_class, "RectangleShape2D")
+	assert_true(parts.collision.shape is RectangleShape2D)
+	assert_true(parts.collision.shape.size is Vector2)
+	assert_eq(parts.collision.shape.size.x, 32.0)
+	assert_eq(parts.collision.shape.size.y, 48.0)
+	_remove_node(parts.body)
+
+
+# ----- source auto-detection -----
+
+func test_autofit_no_sibling_visual_errors() -> void:
+	# Wrap in a fresh Node3D so the scene root's other children don't leak
+	# in as sibling candidates.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root")
+		return
+	var isolated := Node3D.new()
+	isolated.name = "IsolatedCollisionHost"
+	scene_root.add_child(isolated)
+	isolated.set_owner(scene_root)
+	var col := CollisionShape3D.new()
+	col.name = "LonelyCollision"
+	isolated.add_child(col)
+	col.set_owner(scene_root)
+	var result := _handler.autofit({"path": col.get_path()})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "source_path")
+	_remove_node(isolated)
+
+
+func test_autofit_explicit_source_path() -> void:
+	var parts := _add_body_3d("TestAutofitExplicit", Vector3(5, 2, 3))
+	if parts.is_empty():
+		skip("No scene root")
+		return
+	var result := _handler.autofit({
+		"path": parts.collision.get_path(),
+		"source_path": parts.mesh.get_path(),
+	})
+	assert_has_key(result, "data")
+	assert_eq(parts.collision.shape.size.x, 5.0)
+	_remove_node(parts.body)

--- a/test_project/tests/test_physics_shape.gd
+++ b/test_project/tests/test_physics_shape.gd
@@ -234,3 +234,143 @@ func test_autofit_explicit_source_path() -> void:
 	assert_has_key(result, "data")
 	assert_eq(parts.collision.shape.size.x, 5.0)
 	_remove_node(parts.body)
+
+
+# ----- regression: capsule silent clamp (height >= 2*radius) -----
+
+func test_autofit_3d_capsule_reports_actual_stored_values_after_clamp() -> void:
+	# Wide-short source: 4×1×4 mesh. Naive code would try radius=2, height=1,
+	# but CapsuleShape3D enforces height >= 2*radius and silently clamps.
+	# The response must reflect what Godot actually stored, not what we asked.
+	var parts := _add_body_3d("TestAutofitCapsuleClamp", Vector3(4, 1, 4))
+	if parts.is_empty():
+		skip("No scene root")
+		return
+	var result := _handler.autofit({
+		"path": parts.collision.get_path(),
+		"shape_type": "capsule",
+	})
+	assert_has_key(result, "data")
+	var cap: CapsuleShape3D = parts.collision.shape
+	assert_true(cap != null)
+	# Regression: response.size.{radius,height} must equal cap.{radius,height}
+	# after Godot's clamp. If this assertion fires with mismatched values,
+	# the tool was lying about what it stored.
+	assert_eq(result.data.size.radius, cap.radius)
+	assert_eq(result.data.size.height, cap.height)
+	# Invariant Godot enforces: height >= 2*radius
+	assert_true(cap.height >= 2.0 * cap.radius, "CapsuleShape3D invariant must hold")
+	_remove_node(parts.body)
+
+
+func test_autofit_2d_capsule_reports_actual_stored_values_after_clamp() -> void:
+	var parts := _add_body_2d("TestAutofit2DCapsuleClamp", Vector2(100, 20))
+	if parts.is_empty():
+		skip("No scene root")
+		return
+	var result := _handler.autofit({
+		"path": parts.collision.get_path(),
+		"shape_type": "capsule",
+	})
+	assert_has_key(result, "data")
+	var cap: CapsuleShape2D = parts.collision.shape
+	assert_true(cap != null)
+	assert_eq(result.data.size.radius, cap.radius)
+	assert_eq(result.data.size.height, cap.height)
+	assert_true(cap.height >= 2.0 * cap.radius, "CapsuleShape2D invariant must hold")
+	_remove_node(parts.body)
+
+
+# ----- regression: _measure_bounds must honor source scale -----
+
+func test_autofit_3d_honors_source_scale() -> void:
+	# Unit mesh scaled by (2,2,2) — the collider should match the visible
+	# 2×2×2 volume, not the 1×1×1 local AABB.
+	var parts := _add_body_3d("TestAutofitScaled3D", Vector3(1, 1, 1))
+	if parts.is_empty():
+		skip("No scene root")
+		return
+	(parts.mesh as MeshInstance3D).scale = Vector3(2, 2, 2)
+	var result := _handler.autofit({"path": parts.collision.get_path()})
+	assert_has_key(result, "data")
+	assert_true(parts.collision.shape is BoxShape3D)
+	assert_eq(parts.collision.shape.size.x, 2.0, "Scaled source must produce 2-unit collider")
+	assert_eq(parts.collision.shape.size.y, 2.0)
+	assert_eq(parts.collision.shape.size.z, 2.0)
+	_remove_node(parts.body)
+
+
+func test_autofit_2d_sprite_honors_source_scale() -> void:
+	var parts := _add_body_2d("TestAutofitScaled2D", Vector2(32, 32))
+	if parts.is_empty():
+		skip("No scene root")
+		return
+	(parts.sprite as Sprite2D).scale = Vector2(2, 2)
+	var result := _handler.autofit({"path": parts.collision.get_path()})
+	assert_has_key(result, "data")
+	assert_true(parts.collision.shape is RectangleShape2D)
+	assert_eq(parts.collision.shape.size.x, 64.0, "Scaled Sprite2D should yield 64px width")
+	assert_eq(parts.collision.shape.size.y, 64.0)
+	_remove_node(parts.body)
+
+
+# ----- regression: TextureRect with zero layout size -----
+
+func test_autofit_2d_texture_rect_zero_size_falls_back_to_texture() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root")
+		return
+	var body := StaticBody2D.new()
+	body.name = "TestTexRectFallback"
+	scene_root.add_child(body)
+	body.set_owner(scene_root)
+
+	var tr := TextureRect.new()
+	tr.name = "Visual"
+	# Intentionally leave size = (0, 0) — this is what you'd see just after
+	# creating the node via MCP before any layout pass has run.
+	var img := Image.create(24, 48, false, Image.FORMAT_RGBA8)
+	img.fill(Color.WHITE)
+	tr.texture = ImageTexture.create_from_image(img)
+	body.add_child(tr)
+	tr.set_owner(scene_root)
+
+	var col := CollisionShape2D.new()
+	col.name = "Collision"
+	body.add_child(col)
+	col.set_owner(scene_root)
+
+	var result := _handler.autofit({"path": col.get_path()})
+	assert_has_key(result, "data")
+	assert_true(col.shape is RectangleShape2D)
+	# Should fall back to texture.get_size() = (24, 48), NOT silently produce zero.
+	assert_eq(col.shape.size.x, 24.0)
+	assert_eq(col.shape.size.y, 48.0)
+	_remove_node(body)
+
+
+func test_autofit_2d_texture_rect_zero_size_no_texture_errors() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root")
+		return
+	var body := StaticBody2D.new()
+	body.name = "TestTexRectNoTex"
+	scene_root.add_child(body)
+	body.set_owner(scene_root)
+
+	var tr := TextureRect.new()
+	tr.name = "Visual"  # no texture assigned, no size
+	body.add_child(tr)
+	tr.set_owner(scene_root)
+
+	var col := CollisionShape2D.new()
+	col.name = "Collision"
+	body.add_child(col)
+	col.set_owner(scene_root)
+
+	var result := _handler.autofit({"path": col.get_path()})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "zero")
+	_remove_node(body)

--- a/test_project/tests/test_physics_shape.gd.uid
+++ b/test_project/tests/test_physics_shape.gd.uid
@@ -1,0 +1,1 @@
+uid://b2s875uiir4iy

--- a/test_project/tests/test_resource.gd
+++ b/test_project/tests/test_resource.gd
@@ -343,3 +343,70 @@ func test_create_resource_undo_survives_interleaving() -> void:
 	editor_undo(_undo_redo)  # undo mesh assign
 	assert_true(mi.mesh == null or not (mi.mesh is BoxMesh), "Undo should have removed the BoxMesh")
 	_remove_node(mi)
+
+
+# ----- regression: properties dict __class__ shortcut for nested Resource slots -----
+
+func test_create_resource_nested_class_dict_instantiates_sub_resource() -> void:
+	# resource_create type=GradientTexture2D properties={gradient: {__class__: Gradient}}
+	# should land a real Gradient in .gradient, not leave the slot empty while
+	# reporting properties_applied: 1.
+	var s := _add_mesh_instance("TestNestedClass")
+	if s == null:
+		skip("No scene root — is a scene open?")
+		return
+	# Use GradientTexture2D → Gradient sub-resource as the test case (flat,
+	# no shader dependencies required).
+	s.mesh = PlaneMesh.new()
+	s.material_override = StandardMaterial3D.new()
+	# Assign a GradientTexture2D via resource_create with a nested Gradient.
+	var result := _handler.create_resource({
+		"type": "GradientTexture2D",
+		"path": "/%s/TestNestedClass" % s.get_parent().name,
+		"property": "material_override",  # material_override accepts any Material, so this will fail
+	})
+	# Actually reposition this test: use a 2D host so we can target a
+	# texture property on a TextureRect, which accepts Texture2D (GradientTexture2D).
+	_remove_node(s)
+
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var tr := TextureRect.new()
+	tr.name = "TestNestedClassTR"
+	scene_root.add_child(tr)
+	tr.set_owner(scene_root)
+	var r2 := _handler.create_resource({
+		"type": "GradientTexture2D",
+		"path": tr.get_path(),
+		"property": "texture",
+		"properties": {
+			"gradient": {
+				"__class__": "Gradient",
+			},
+		},
+	})
+	assert_has_key(r2, "data", "Expected data response; got: %s" % str(r2))
+	assert_true(tr.texture is GradientTexture2D)
+	# Regression: .gradient must be a real Gradient, not null and not a Dictionary.
+	assert_true(tr.texture.gradient is Gradient, "Nested __class__ must instantiate sub-resource")
+	_remove_node(tr)
+
+
+func test_create_resource_nested_class_dict_invalid_class() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root")
+		return
+	var tr := TextureRect.new()
+	tr.name = "TestNestedBadClass"
+	scene_root.add_child(tr)
+	tr.set_owner(scene_root)
+	var result := _handler.create_resource({
+		"type": "GradientTexture2D",
+		"path": tr.get_path(),
+		"property": "texture",
+		"properties": {
+			"gradient": {"__class__": "NotARealClass"},
+		},
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	_remove_node(tr)

--- a/test_project/tests/test_resource.gd
+++ b/test_project/tests/test_resource.gd
@@ -107,3 +107,239 @@ func test_assign_resource_resource_not_found() -> void:
 		"resource_path": "res://nonexistent.tres",
 	})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+# ----- create_resource -----
+
+func _add_mesh_instance(node_name: String = "TestMesh") -> Node:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return null
+	var mi := MeshInstance3D.new()
+	mi.name = node_name
+	scene_root.add_child(mi)
+	mi.set_owner(scene_root)
+	return mi
+
+
+func _remove_node(node: Node) -> void:
+	if node == null:
+		return
+	if node.get_parent() != null:
+		node.get_parent().remove_child(node)
+	node.queue_free()
+
+
+func test_create_resource_missing_type() -> void:
+	var result := _handler.create_resource({"path": "/Main/Foo", "property": "mesh"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "type")
+
+
+func test_create_resource_no_home_errors() -> void:
+	var result := _handler.create_resource({"type": "BoxMesh"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "path")
+
+
+func test_create_resource_both_homes_errors() -> void:
+	var result := _handler.create_resource({
+		"type": "BoxMesh",
+		"path": "/Main/Foo",
+		"property": "mesh",
+		"resource_path": "res://foo.tres",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "not both")
+
+
+func test_create_resource_unknown_class() -> void:
+	var result := _handler.create_resource({
+		"type": "NotARealClass",
+		"path": "/Main/Foo",
+		"property": "mesh",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "Unknown")
+
+
+func test_create_resource_node_class_redirects_to_create_node() -> void:
+	var result := _handler.create_resource({
+		"type": "Node3D",
+		"path": "/Main/Foo",
+		"property": "mesh",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "node_create")
+
+
+func test_create_resource_non_resource_class() -> void:
+	# RefCounted is neither Node nor Resource — should error.
+	var result := _handler.create_resource({
+		"type": "RefCounted",
+		"path": "/Main/Foo",
+		"property": "mesh",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "not a Resource")
+
+
+func test_create_resource_abstract_class() -> void:
+	# Shape3D is the abstract base of BoxShape3D/SphereShape3D/etc., and
+	# ClassDB.can_instantiate("Shape3D") returns false.
+	var result := _handler.create_resource({
+		"type": "Shape3D",
+		"path": "/Main/Foo",
+		"property": "mesh",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "abstract")
+
+
+func test_create_resource_assigns_box_mesh_typed() -> void:
+	var mi := _add_mesh_instance("TestBoxMesh")
+	if mi == null:
+		skip("No scene root — is a scene open?")
+		return
+	var result := _handler.create_resource({
+		"type": "BoxMesh",
+		"path": "/%s/TestBoxMesh" % mi.get_parent().name,
+		"property": "mesh",
+		"properties": {"size": {"x": 2, "y": 3, "z": 4}},
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.resource_class, "BoxMesh")
+	assert_true(result.data.undoable)
+	# Assert on the stored Variant, not just the response — per CLAUDE.md
+	# "assert on stored Variant, not counts".
+	assert_true(mi.mesh is BoxMesh, "mesh should be a BoxMesh instance")
+	assert_true(mi.mesh.size is Vector3, "size should be coerced to Vector3")
+	assert_eq(mi.mesh.size.x, 2.0)
+	assert_eq(mi.mesh.size.y, 3.0)
+	assert_eq(mi.mesh.size.z, 4.0)
+	_remove_node(mi)
+
+
+func test_create_resource_undo_restores_previous_value() -> void:
+	var mi := _add_mesh_instance("TestUndo")
+	if mi == null:
+		skip("No scene root — is a scene open?")
+		return
+	var old_mesh: Mesh = mi.mesh  # likely null
+	var result := _handler.create_resource({
+		"type": "SphereMesh",
+		"path": "/%s/TestUndo" % mi.get_parent().name,
+		"property": "mesh",
+	})
+	assert_has_key(result, "data")
+	assert_true(mi.mesh is SphereMesh)
+	editor_undo(_undo_redo)
+	assert_eq(mi.mesh, old_mesh, "Undo should restore the previous mesh value")
+	editor_redo(_undo_redo)
+	assert_true(mi.mesh is SphereMesh, "Redo should re-apply the SphereMesh")
+	_remove_node(mi)
+
+
+func test_create_resource_property_not_on_node() -> void:
+	var mi := _add_mesh_instance("TestBadProp")
+	if mi == null:
+		skip("No scene root — is a scene open?")
+		return
+	var result := _handler.create_resource({
+		"type": "BoxMesh",
+		"path": "/%s/TestBadProp" % mi.get_parent().name,
+		"property": "not_a_real_property",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	_remove_node(mi)
+
+
+func test_create_resource_unknown_property_in_properties_dict() -> void:
+	var mi := _add_mesh_instance("TestBadPropKey")
+	if mi == null:
+		skip("No scene root — is a scene open?")
+		return
+	var result := _handler.create_resource({
+		"type": "BoxMesh",
+		"path": "/%s/TestBadPropKey" % mi.get_parent().name,
+		"property": "mesh",
+		"properties": {"not_a_real_field": 42},
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	_remove_node(mi)
+
+
+func test_create_resource_saves_to_disk() -> void:
+	var out_path := "res://test_tmp_box.tres"
+	# Clean up any prior test artifact.
+	if FileAccess.file_exists(out_path):
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(out_path))
+	var result := _handler.create_resource({
+		"type": "BoxShape3D",
+		"resource_path": out_path,
+		"properties": {"size": {"x": 1, "y": 2, "z": 3}},
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.resource_class, "BoxShape3D")
+	assert_false(result.data.undoable)
+	assert_true(FileAccess.file_exists(out_path), "File should exist at %s" % out_path)
+	# Round-trip through ResourceLoader to verify the saved .tres is valid.
+	var loaded := ResourceLoader.load(out_path)
+	assert_true(loaded is BoxShape3D)
+	assert_true(loaded.size is Vector3)
+	assert_eq(loaded.size.x, 1.0)
+	# Clean up.
+	DirAccess.remove_absolute(ProjectSettings.globalize_path(out_path))
+
+
+func test_create_resource_save_refuses_overwrite_without_flag() -> void:
+	var out_path := "res://test_tmp_overwrite.tres"
+	if FileAccess.file_exists(out_path):
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(out_path))
+	var first := _handler.create_resource({
+		"type": "BoxShape3D",
+		"resource_path": out_path,
+	})
+	assert_has_key(first, "data")
+	var second := _handler.create_resource({
+		"type": "BoxShape3D",
+		"resource_path": out_path,
+	})
+	assert_is_error(second, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(second.error.message, "overwrite")
+	var third := _handler.create_resource({
+		"type": "BoxShape3D",
+		"resource_path": out_path,
+		"overwrite": true,
+	})
+	assert_has_key(third, "data")
+	assert_true(third.data.overwritten)
+	DirAccess.remove_absolute(ProjectSettings.globalize_path(out_path))
+
+
+func test_create_resource_undo_survives_interleaving() -> void:
+	# Per CLAUDE.md "Auto-generated indices: look up at undo time" — ensure
+	# undo of a resource_create survives an unrelated mutation in between.
+	var mi := _add_mesh_instance("TestInterleave")
+	if mi == null:
+		skip("No scene root — is a scene open?")
+		return
+	var result := _handler.create_resource({
+		"type": "BoxMesh",
+		"path": "/%s/TestInterleave" % mi.get_parent().name,
+		"property": "mesh",
+	})
+	assert_has_key(result, "data")
+	var assigned_mesh = mi.mesh
+	assert_true(assigned_mesh is BoxMesh)
+	# Interleave: rename the node through a separate undo action.
+	_undo_redo.create_action("MCP: interleaved rename")
+	_undo_redo.add_do_property(mi, "name", "Renamed")
+	_undo_redo.add_undo_property(mi, "name", "TestInterleave")
+	_undo_redo.commit_action()
+	# Undo the interleaved action first, then the original — mesh should
+	# still revert cleanly.
+	editor_undo(_undo_redo)  # undo rename
+	editor_undo(_undo_redo)  # undo mesh assign
+	assert_true(mi.mesh == null or not (mi.mesh is BoxMesh), "Undo should have removed the BoxMesh")
+	_remove_node(mi)

--- a/test_project/tests/test_texture.gd
+++ b/test_project/tests/test_texture.gd
@@ -1,0 +1,193 @@
+@tool
+extends McpTestSuite
+
+## Tests for TextureHandler — GradientTexture2D + NoiseTexture2D creation.
+
+var _handler: TextureHandler
+var _undo_redo: EditorUndoRedoManager
+
+
+func suite_name() -> String:
+	return "texture"
+
+
+func suite_setup(ctx: Dictionary) -> void:
+	_undo_redo = ctx.get("undo_redo")
+	_handler = TextureHandler.new(_undo_redo)
+
+
+func _add_sprite_2d(name: String) -> Sprite2D:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return null
+	var s := Sprite2D.new()
+	s.name = name
+	scene_root.add_child(s)
+	s.set_owner(scene_root)
+	return s
+
+
+func _remove_node(node: Node) -> void:
+	if node == null:
+		return
+	if node.get_parent():
+		node.get_parent().remove_child(node)
+	node.queue_free()
+
+
+# ----- gradient_texture_create validation -----
+
+func test_gradient_requires_two_stops() -> void:
+	var result := _handler.create_gradient_texture({
+		"stops": [{"offset": 0.0, "color": {"r": 1, "g": 0, "b": 0, "a": 1}}],
+		"path": "/Main/Line",
+		"property": "texture",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_gradient_invalid_fill() -> void:
+	var result := _handler.create_gradient_texture({
+		"stops": [
+			{"offset": 0.0, "color": "#ff0000"},
+			{"offset": 1.0, "color": "#0000ff"},
+		],
+		"fill": "not_a_fill_mode",
+		"path": "/Main/Line",
+		"property": "texture",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_gradient_no_home_errors() -> void:
+	var result := _handler.create_gradient_texture({
+		"stops": [
+			{"offset": 0.0, "color": "#ff0000"},
+			{"offset": 1.0, "color": "#0000ff"},
+		],
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_gradient_stop_missing_keys() -> void:
+	var result := _handler.create_gradient_texture({
+		"stops": [
+			{"offset": 0.0},
+			{"offset": 1.0, "color": "#0000ff"},
+		],
+		"path": "/Main/Line",
+		"property": "texture",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+# ----- gradient_texture_create happy paths -----
+
+func test_gradient_assigns_typed_gradient_and_colors() -> void:
+	var s := _add_sprite_2d("TestGradSprite")
+	if s == null:
+		skip("No scene root")
+		return
+	var result := _handler.create_gradient_texture({
+		"stops": [
+			{"offset": 0.0, "color": {"r": 1, "g": 0, "b": 0, "a": 1}},
+			{"offset": 1.0, "color": {"r": 0, "g": 0, "b": 1, "a": 1}},
+		],
+		"fill": "radial",
+		"path": s.get_path(),
+		"property": "texture",
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.stop_count, 2)
+	assert_true(result.data.undoable)
+	# Assert on stored Variant — per CLAUDE.md.
+	assert_true(s.texture is GradientTexture2D)
+	assert_true(s.texture.gradient is Gradient)
+	var g: Gradient = s.texture.gradient
+	assert_eq(g.offsets.size(), 2)
+	assert_eq(g.offsets[0], 0.0)
+	assert_eq(g.offsets[1], 1.0)
+	# The assertion that matters per CLAUDE.md:
+	# colors must remain Color, not a raw dict.
+	assert_true(g.colors[0] is Color)
+	assert_eq(g.colors[0].r, 1.0)
+	assert_eq(g.colors[1].b, 1.0)
+	assert_eq(s.texture.fill, GradientTexture2D.FILL_RADIAL)
+	editor_undo(_undo_redo)
+	assert_true(s.texture == null)
+	_remove_node(s)
+
+
+func test_gradient_saves_to_disk() -> void:
+	var out_path := "res://test_tmp_grad.tres"
+	if FileAccess.file_exists(out_path):
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(out_path))
+	var result := _handler.create_gradient_texture({
+		"stops": [
+			{"offset": 0.0, "color": "#ff0000"},
+			{"offset": 1.0, "color": "#0000ff"},
+		],
+		"resource_path": out_path,
+	})
+	assert_has_key(result, "data")
+	assert_false(result.data.undoable)
+	assert_true(FileAccess.file_exists(out_path))
+	var loaded := ResourceLoader.load(out_path)
+	assert_true(loaded is GradientTexture2D)
+	DirAccess.remove_absolute(ProjectSettings.globalize_path(out_path))
+
+
+# ----- noise_texture_create -----
+
+func test_noise_invalid_type() -> void:
+	var result := _handler.create_noise_texture({
+		"noise_type": "not_a_noise",
+		"path": "/Main/Foo",
+		"property": "texture",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_noise_assigns_typed_chain() -> void:
+	var s := _add_sprite_2d("TestNoiseSprite")
+	if s == null:
+		skip("No scene root")
+		return
+	var result := _handler.create_noise_texture({
+		"noise_type": "perlin",
+		"width": 64,
+		"height": 64,
+		"frequency": 0.05,
+		"seed": 7,
+		"fractal_octaves": 3,
+		"path": s.get_path(),
+		"property": "texture",
+	})
+	assert_has_key(result, "data")
+	assert_true(result.data.undoable)
+	assert_true(s.texture is NoiseTexture2D)
+	assert_true(s.texture.noise is FastNoiseLite)
+	var n: FastNoiseLite = s.texture.noise
+	assert_eq(n.noise_type, FastNoiseLite.TYPE_PERLIN)
+	assert_eq(n.seed, 7)
+	assert_eq(n.fractal_octaves, 3)
+	editor_undo(_undo_redo)
+	assert_true(s.texture == null)
+	_remove_node(s)
+
+
+func test_noise_saves_to_disk() -> void:
+	var out_path := "res://test_tmp_noise.tres"
+	if FileAccess.file_exists(out_path):
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(out_path))
+	var result := _handler.create_noise_texture({
+		"noise_type": "simplex_smooth",
+		"width": 32,
+		"height": 32,
+		"resource_path": out_path,
+	})
+	assert_has_key(result, "data")
+	assert_true(FileAccess.file_exists(out_path))
+	var loaded := ResourceLoader.load(out_path)
+	assert_true(loaded is NoiseTexture2D)
+	DirAccess.remove_absolute(ProjectSettings.globalize_path(out_path))

--- a/test_project/tests/test_texture.gd.uid
+++ b/test_project/tests/test_texture.gd.uid
@@ -1,0 +1,1 @@
+uid://d2rln3mbem2bd

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -1417,6 +1417,289 @@ class TestResourceAssignTool:
 
 
 # ---------------------------------------------------------------------------
+# resource_create
+# ---------------------------------------------------------------------------
+
+
+class TestResourceCreateTool:
+    async def test_create_and_assign_inline(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "create_resource"
+            assert cmd["params"]["type"] == "BoxMesh"
+            assert cmd["params"]["path"] == "/Main/Mesh"
+            assert cmd["params"]["property"] == "mesh"
+            assert cmd["params"]["properties"] == {"size": {"x": 2, "y": 2, "z": 2}}
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "path": "/Main/Mesh",
+                    "property": "mesh",
+                    "type": "BoxMesh",
+                    "resource_class": "BoxMesh",
+                    "properties_applied": 1,
+                    "undoable": True,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "resource_create",
+            {
+                "type": "BoxMesh",
+                "path": "/Main/Mesh",
+                "property": "mesh",
+                "properties": {"size": {"x": 2, "y": 2, "z": 2}},
+            },
+        )
+        await task
+
+        assert result.data["resource_class"] == "BoxMesh"
+        assert result.data["undoable"] is True
+
+    async def test_create_and_save_to_disk(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "create_resource"
+            assert cmd["params"]["type"] == "BoxShape3D"
+            assert cmd["params"]["resource_path"] == "res://shapes/box.tres"
+            assert cmd["params"]["overwrite"] is True
+            assert "path" not in cmd["params"]
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "resource_path": "res://shapes/box.tres",
+                    "type": "BoxShape3D",
+                    "resource_class": "BoxShape3D",
+                    "properties_applied": 1,
+                    "overwritten": True,
+                    "undoable": False,
+                    "reason": "File creation is persistent; delete the file manually to revert",
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "resource_create",
+            {
+                "type": "BoxShape3D",
+                "resource_path": "res://shapes/box.tres",
+                "properties": {"size": {"x": 1, "y": 2, "z": 1}},
+                "overwrite": True,
+            },
+        )
+        await task
+
+        assert result.data["resource_class"] == "BoxShape3D"
+        assert result.data["overwritten"] is True
+        assert result.data["undoable"] is False
+
+
+# ---------------------------------------------------------------------------
+# curve_set_points
+# ---------------------------------------------------------------------------
+
+
+class TestCurveSetPointsTool:
+    async def test_set_points_on_node_curve(self, mcp_stack):
+        client, plugin = mcp_stack
+        points = [
+            {"position": {"x": 0, "y": 0, "z": 0}},
+            {"position": {"x": 5, "y": 0, "z": 0}},
+        ]
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "curve_set_points"
+            assert cmd["params"]["path"] == "/Main/Path3D"
+            assert cmd["params"]["property"] == "curve"
+            assert len(cmd["params"]["points"]) == 2
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "path": "/Main/Path3D",
+                    "property": "curve",
+                    "curve_class": "Curve3D",
+                    "point_count": 2,
+                    "undoable": True,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "curve_set_points",
+            {"points": points, "path": "/Main/Path3D", "property": "curve"},
+        )
+        await task
+
+        assert result.data["curve_class"] == "Curve3D"
+        assert result.data["point_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# gradient_texture_create / noise_texture_create
+# ---------------------------------------------------------------------------
+
+
+class TestTextureTools:
+    async def test_gradient_texture_inline(self, mcp_stack):
+        client, plugin = mcp_stack
+        stops = [
+            {"offset": 0.0, "color": {"r": 1, "g": 0, "b": 0, "a": 1}},
+            {"offset": 1.0, "color": {"r": 0, "g": 0, "b": 1, "a": 1}},
+        ]
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "gradient_texture_create"
+            assert cmd["params"]["fill"] == "linear"
+            assert len(cmd["params"]["stops"]) == 2
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "path": "/Main/Line",
+                    "property": "texture",
+                    "texture_class": "GradientTexture2D",
+                    "gradient_class": "Gradient",
+                    "stop_count": 2,
+                    "fill": "linear",
+                    "undoable": True,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "gradient_texture_create",
+            {
+                "stops": stops,
+                "path": "/Main/Line",
+                "property": "texture",
+            },
+        )
+        await task
+
+        assert result.data["texture_class"] == "GradientTexture2D"
+        assert result.data["stop_count"] == 2
+
+    async def test_noise_texture_save(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "noise_texture_create"
+            assert cmd["params"]["noise_type"] == "simplex"
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "resource_path": "res://noise.tres",
+                    "texture_class": "NoiseTexture2D",
+                    "noise_class": "FastNoiseLite",
+                    "noise_type": "simplex",
+                    "overwritten": False,
+                    "undoable": False,
+                    "reason": "File creation is persistent; delete the file manually to revert",
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "noise_texture_create",
+            {
+                "noise_type": "simplex",
+                "resource_path": "res://noise.tres",
+            },
+        )
+        await task
+
+        assert result.data["texture_class"] == "NoiseTexture2D"
+        assert result.data["undoable"] is False
+
+
+# ---------------------------------------------------------------------------
+# environment_create
+# ---------------------------------------------------------------------------
+
+
+class TestEnvironmentCreateTool:
+    async def test_create_inline_with_preset(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "environment_create"
+            assert cmd["params"]["path"] == "/Main/World"
+            assert cmd["params"]["preset"] == "sunset"
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "path": "/Main/World",
+                    "preset": "sunset",
+                    "sky_created": True,
+                    "sky_material_class": "ProceduralSkyMaterial",
+                    "undoable": True,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "environment_create",
+            {"path": "/Main/World", "preset": "sunset"},
+        )
+        await task
+
+        assert result.data["preset"] == "sunset"
+        assert result.data["sky_created"] is True
+
+
+# ---------------------------------------------------------------------------
+# physics_shape_autofit
+# ---------------------------------------------------------------------------
+
+
+class TestPhysicsShapeAutofitTool:
+    async def test_autofit_3d_box(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "physics_shape_autofit"
+            assert cmd["params"]["path"] == "/Main/Body/Collision"
+            assert cmd["params"]["source_path"] == "/Main/Body/Mesh"
+            assert cmd["params"]["shape_type"] == "box"
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "path": "/Main/Body/Collision",
+                    "source_path": "/Main/Body/Mesh",
+                    "shape_type": "box",
+                    "shape_class": "BoxShape3D",
+                    "shape_created": True,
+                    "size": {"x": 2.0, "y": 1.0, "z": 1.0},
+                    "undoable": True,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "physics_shape_autofit",
+            {
+                "path": "/Main/Body/Collision",
+                "source_path": "/Main/Body/Mesh",
+                "shape_type": "box",
+            },
+        )
+        await task
+
+        assert result.data["shape_class"] == "BoxShape3D"
+        assert result.data["shape_created"] is True
+        assert result.data["size"]["x"] == 2.0
+
+
+# ---------------------------------------------------------------------------
 # filesystem_read_text
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -10,12 +10,15 @@ from godot_ai.handlers import autoload as autoload_handlers
 from godot_ai.handlers import batch as batch_handlers
 from godot_ai.handlers import camera as camera_handlers
 from godot_ai.handlers import client as client_handlers
+from godot_ai.handlers import curve as curve_handlers
 from godot_ai.handlers import editor as editor_handlers
+from godot_ai.handlers import environment as environment_handlers
 from godot_ai.handlers import filesystem as filesystem_handlers
 from godot_ai.handlers import input_map as input_map_handlers
 from godot_ai.handlers import material as material_handlers
 from godot_ai.handlers import node as node_handlers
 from godot_ai.handlers import particle as particle_handlers
+from godot_ai.handlers import physics_shape as physics_shape_handlers
 from godot_ai.handlers import project as project_handlers
 from godot_ai.handlers import resource as resource_handlers
 from godot_ai.handlers import scene as scene_handlers
@@ -23,6 +26,7 @@ from godot_ai.handlers import script as script_handlers
 from godot_ai.handlers import session as session_handlers
 from godot_ai.handlers import signal as signal_handlers
 from godot_ai.handlers import testing as testing_handlers
+from godot_ai.handlers import texture as texture_handlers
 from godot_ai.handlers import theme as theme_handlers
 from godot_ai.handlers import ui as ui_handlers
 from godot_ai.runtime.direct import DirectRuntime
@@ -274,6 +278,107 @@ class StubClient:
                 "property": params.get("property", ""),
                 "resource_path": params.get("resource_path", ""),
                 "resource_type": "StandardMaterial3D",
+                "undoable": True,
+            }
+        if command == "curve_set_points":
+            if params.get("resource_path"):
+                return {
+                    "resource_path": params["resource_path"],
+                    "curve_class": "Curve3D",
+                    "point_count": len(params.get("points", [])),
+                    "undoable": False,
+                    "reason": "File save is persistent; edit the .tres file manually to revert",
+                }
+            return {
+                "path": params.get("path", ""),
+                "property": params.get("property", ""),
+                "curve_class": "Curve3D",
+                "point_count": len(params.get("points", [])),
+                "undoable": True,
+            }
+        if command == "gradient_texture_create":
+            if params.get("resource_path"):
+                return {
+                    "resource_path": params["resource_path"],
+                    "texture_class": "GradientTexture2D",
+                    "gradient_class": "Gradient",
+                    "stop_count": len(params.get("stops", [])),
+                    "fill": params.get("fill", "linear"),
+                    "overwritten": False,
+                    "undoable": False,
+                    "reason": "File creation is persistent; delete the file manually to revert",
+                }
+            return {
+                "path": params.get("path", ""),
+                "property": params.get("property", ""),
+                "texture_class": "GradientTexture2D",
+                "gradient_class": "Gradient",
+                "stop_count": len(params.get("stops", [])),
+                "fill": params.get("fill", "linear"),
+                "undoable": True,
+            }
+        if command == "noise_texture_create":
+            if params.get("resource_path"):
+                return {
+                    "resource_path": params["resource_path"],
+                    "texture_class": "NoiseTexture2D",
+                    "noise_class": "FastNoiseLite",
+                    "noise_type": params.get("noise_type", "simplex_smooth"),
+                    "overwritten": False,
+                    "undoable": False,
+                    "reason": "File creation is persistent; delete the file manually to revert",
+                }
+            return {
+                "path": params.get("path", ""),
+                "property": params.get("property", ""),
+                "texture_class": "NoiseTexture2D",
+                "noise_class": "FastNoiseLite",
+                "noise_type": params.get("noise_type", "simplex_smooth"),
+                "undoable": True,
+            }
+        if command == "environment_create":
+            if params.get("resource_path"):
+                return {
+                    "resource_path": params["resource_path"],
+                    "preset": params.get("preset", "default"),
+                    "overwritten": False,
+                    "undoable": False,
+                    "reason": "File creation is persistent; delete the file manually to revert",
+                }
+            return {
+                "path": params.get("path", ""),
+                "preset": params.get("preset", "default"),
+                "sky_created": params.get("sky", True) is not False,
+                "sky_material_class": "ProceduralSkyMaterial",
+                "undoable": True,
+            }
+        if command == "physics_shape_autofit":
+            return {
+                "path": params.get("path", ""),
+                "source_path": params.get("source_path", "/auto"),
+                "shape_type": params.get("shape_type", "box"),
+                "shape_class": "BoxShape3D",
+                "shape_created": True,
+                "size": {"x": 2.0, "y": 1.0, "z": 1.0},
+                "undoable": True,
+            }
+        if command == "create_resource":
+            if params.get("resource_path"):
+                return {
+                    "resource_path": params["resource_path"],
+                    "type": params.get("type", ""),
+                    "resource_class": params.get("type", ""),
+                    "properties_applied": len(params.get("properties", {}) or {}),
+                    "overwritten": False,
+                    "undoable": False,
+                    "reason": "File creation is persistent; delete the file manually to revert",
+                }
+            return {
+                "path": params.get("path", ""),
+                "property": params.get("property", ""),
+                "type": params.get("type", ""),
+                "resource_class": params.get("type", ""),
+                "properties_applied": len(params.get("properties", {}) or {}),
                 "undoable": True,
             }
         if command == "read_file":
@@ -1849,6 +1954,339 @@ async def test_resource_assign_handler():
         "property": "mesh",
         "resource_path": "res://cube.tres",
     }
+
+
+async def test_resource_create_assign_inline_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await resource_handlers.resource_create(
+        runtime,
+        type="BoxMesh",
+        path="/Main/Mesh",
+        property="mesh",
+        properties={"size": {"x": 2, "y": 2, "z": 2}},
+    )
+    assert result["resource_class"] == "BoxMesh"
+    assert result["undoable"] is True
+    assert client.calls[-1]["params"] == {
+        "type": "BoxMesh",
+        "properties": {"size": {"x": 2, "y": 2, "z": 2}},
+        "path": "/Main/Mesh",
+        "property": "mesh",
+    }
+
+
+async def test_resource_create_save_to_disk_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await resource_handlers.resource_create(
+        runtime,
+        type="BoxShape3D",
+        resource_path="res://shapes/box.tres",
+        overwrite=True,
+    )
+    assert result["resource_class"] == "BoxShape3D"
+    assert result["undoable"] is False
+    assert client.calls[-1]["params"] == {
+        "type": "BoxShape3D",
+        "resource_path": "res://shapes/box.tres",
+        "overwrite": True,
+    }
+
+
+async def test_resource_create_minimal_omits_empty_params():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    await resource_handlers.resource_create(
+        runtime,
+        type="BoxMesh",
+        path="/Main/Mesh",
+        property="mesh",
+    )
+    # Omitted optional params should NOT appear in the outgoing params dict
+    # so the plugin sees a clean "either/or" shape.
+    params = client.calls[-1]["params"]
+    assert "resource_path" not in params
+    assert "overwrite" not in params
+    assert "properties" not in params
+
+
+async def test_curve_set_points_inline_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    points = [
+        {"position": {"x": 0, "y": 0, "z": 0}},
+        {"position": {"x": 5, "y": 0, "z": 0}},
+    ]
+    result = await curve_handlers.curve_set_points(
+        runtime,
+        points=points,
+        path="/Main/Path3D",
+        property="curve",
+    )
+    assert result["point_count"] == 2
+    assert result["undoable"] is True
+    assert client.calls[-1]["params"] == {
+        "points": points,
+        "path": "/Main/Path3D",
+        "property": "curve",
+    }
+
+
+async def test_curve_set_points_disk_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await curve_handlers.curve_set_points(
+        runtime,
+        points=[{"position": {"x": 0, "y": 0, "z": 0}}],
+        resource_path="res://paths/main.tres",
+    )
+    assert result["undoable"] is False
+    assert client.calls[-1]["params"]["resource_path"] == "res://paths/main.tres"
+
+
+async def test_curve_set_points_requires_writable():
+    from godot_ai.godot_client.client import GodotCommandError
+    from godot_ai.sessions.registry import Session
+
+    client = StubClient()
+    session = Session(
+        session_id="s1",
+        godot_version="4.4",
+        project_path="/tmp/p",
+        plugin_version="0.1",
+        readiness="importing",
+    )
+    registry = SessionRegistry()
+    registry.register(session)
+    runtime = DirectRuntime(registry=registry, client=client)
+    with pytest.raises(GodotCommandError):
+        await curve_handlers.curve_set_points(
+            runtime,
+            points=[],
+            path="/Main/Path3D",
+            property="curve",
+        )
+
+
+async def test_gradient_texture_create_inline_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    stops = [
+        {"offset": 0.0, "color": {"r": 1, "g": 0, "b": 0, "a": 1}},
+        {"offset": 1.0, "color": {"r": 0, "g": 0, "b": 1, "a": 1}},
+    ]
+    result = await texture_handlers.gradient_texture_create(
+        runtime,
+        stops=stops,
+        path="/Main/Line",
+        property="texture",
+        fill="radial",
+    )
+    assert result["texture_class"] == "GradientTexture2D"
+    assert result["stop_count"] == 2
+    assert result["fill"] == "radial"
+    params = client.calls[-1]["params"]
+    assert params["stops"] == stops
+    assert params["fill"] == "radial"
+    assert params["path"] == "/Main/Line"
+    assert params["property"] == "texture"
+
+
+async def test_gradient_texture_create_requires_writable():
+    from godot_ai.godot_client.client import GodotCommandError
+    from godot_ai.sessions.registry import Session
+
+    client = StubClient()
+    session = Session(
+        session_id="s1",
+        godot_version="4.4",
+        project_path="/tmp/p",
+        plugin_version="0.1",
+        readiness="importing",
+    )
+    registry = SessionRegistry()
+    registry.register(session)
+    runtime = DirectRuntime(registry=registry, client=client)
+    with pytest.raises(GodotCommandError):
+        await texture_handlers.gradient_texture_create(
+            runtime,
+            stops=[{"offset": 0, "color": "#f00"}, {"offset": 1, "color": "#00f"}],
+            path="/Main/Line",
+            property="texture",
+        )
+
+
+async def test_noise_texture_create_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await texture_handlers.noise_texture_create(
+        runtime,
+        noise_type="perlin",
+        resource_path="res://textures/noise.tres",
+        frequency=0.05,
+        seed=42,
+        fractal_octaves=4,
+    )
+    assert result["texture_class"] == "NoiseTexture2D"
+    assert result["noise_type"] == "perlin"
+    params = client.calls[-1]["params"]
+    assert params["noise_type"] == "perlin"
+    assert params["frequency"] == 0.05
+    assert params["seed"] == 42
+    assert params["fractal_octaves"] == 4
+    assert params["resource_path"] == "res://textures/noise.tres"
+
+
+async def test_noise_texture_create_requires_writable():
+    from godot_ai.godot_client.client import GodotCommandError
+    from godot_ai.sessions.registry import Session
+
+    client = StubClient()
+    session = Session(
+        session_id="s1",
+        godot_version="4.4",
+        project_path="/tmp/p",
+        plugin_version="0.1",
+        readiness="importing",
+    )
+    registry = SessionRegistry()
+    registry.register(session)
+    runtime = DirectRuntime(registry=registry, client=client)
+    with pytest.raises(GodotCommandError):
+        await texture_handlers.noise_texture_create(
+            runtime, path="/Main/Sprite", property="texture"
+        )
+
+
+async def test_environment_create_inline_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await environment_handlers.environment_create(
+        runtime,
+        path="/Main/World",
+        preset="sunset",
+    )
+    assert result["preset"] == "sunset"
+    assert result["undoable"] is True
+    assert client.calls[-1]["params"] == {
+        "preset": "sunset",
+        "path": "/Main/World",
+    }
+
+
+async def test_environment_create_save_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await environment_handlers.environment_create(
+        runtime,
+        resource_path="res://environments/night.tres",
+        preset="night",
+        sky=False,
+        overwrite=True,
+    )
+    assert result["undoable"] is False
+    assert client.calls[-1]["params"] == {
+        "preset": "night",
+        "resource_path": "res://environments/night.tres",
+        "sky": False,
+        "overwrite": True,
+    }
+
+
+async def test_environment_create_requires_writable():
+    from godot_ai.godot_client.client import GodotCommandError
+    from godot_ai.sessions.registry import Session
+
+    client = StubClient()
+    session = Session(
+        session_id="s1",
+        godot_version="4.4",
+        project_path="/tmp/p",
+        plugin_version="0.1",
+        readiness="importing",
+    )
+    registry = SessionRegistry()
+    registry.register(session)
+    runtime = DirectRuntime(registry=registry, client=client)
+    with pytest.raises(GodotCommandError):
+        await environment_handlers.environment_create(runtime, path="/Main/World")
+
+
+async def test_physics_shape_autofit_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await physics_shape_handlers.physics_shape_autofit(
+        runtime,
+        path="/Main/Body/Collision",
+        source_path="/Main/Body/Mesh",
+        shape_type="box",
+    )
+    assert result["shape_class"] == "BoxShape3D"
+    assert result["shape_created"] is True
+    assert client.calls[-1]["params"] == {
+        "path": "/Main/Body/Collision",
+        "source_path": "/Main/Body/Mesh",
+        "shape_type": "box",
+    }
+
+
+async def test_physics_shape_autofit_minimal_omits_empty():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    await physics_shape_handlers.physics_shape_autofit(
+        runtime, path="/Main/Body/Collision"
+    )
+    params = client.calls[-1]["params"]
+    assert "source_path" not in params
+    assert "shape_type" not in params
+
+
+async def test_physics_shape_autofit_requires_writable():
+    from godot_ai.godot_client.client import GodotCommandError
+    from godot_ai.sessions.registry import Session
+
+    client = StubClient()
+    session = Session(
+        session_id="s1",
+        godot_version="4.4",
+        project_path="/tmp/p",
+        plugin_version="0.1",
+        readiness="importing",
+    )
+    registry = SessionRegistry()
+    registry.register(session)
+    runtime = DirectRuntime(registry=registry, client=client)
+    with pytest.raises(GodotCommandError):
+        await physics_shape_handlers.physics_shape_autofit(
+            runtime, path="/Main/Body/Collision"
+        )
+
+
+async def test_resource_create_requires_writable():
+    """Write tools must raise EDITOR_NOT_READY when editor is importing."""
+    from godot_ai.godot_client.client import GodotCommandError
+    from godot_ai.sessions.registry import Session
+
+    client = StubClient()
+    session = Session(
+        session_id="s1",
+        godot_version="4.4",
+        project_path="/tmp/p",
+        plugin_version="0.1",
+        readiness="importing",
+    )
+    registry = SessionRegistry()
+    registry.register(session)
+    runtime = DirectRuntime(registry=registry, client=client)
+
+    with pytest.raises(GodotCommandError):
+        await resource_handlers.resource_create(
+            runtime,
+            type="BoxMesh",
+            path="/Main/Mesh",
+            property="mesh",
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds seven MCP tools for authoring built-in Godot Resources, closing the gap that surfaced when Claude Haiku tried to assign a `BoxMesh` to `MeshInstance3D.mesh` and found no path to instantiate a built-in Resource subclass (`set_property` treats strings as `res://` paths; `resource_assign` requires an existing `.tres`; no creation tool existed).

**New tools (all deferred-loaded):**

- `resource_create` — instantiate any concrete `Resource` subclass with optional `properties` dict; assign inline (undoable) or save as `.tres`.
- `physics_shape_autofit` — size `CollisionShape2D`/`CollisionShape3D` to match a sibling visual's AABB; auto-creates the shape subclass when the slot is empty. Supports box / sphere / capsule / cylinder (3D) and rectangle / circle / capsule (2D).
- `environment_create` — `WorldEnvironment` + `Environment` + `Sky` + `ProceduralSkyMaterial` chain with presets (`default`, `sunset`, `night`, `fog`).
- `gradient_texture_create` — `Gradient` + `GradientTexture2D` from ordered color stops, with fill modes.
- `noise_texture_create` — `FastNoiseLite` + `NoiseTexture2D` with noise type / frequency / seed / fractal octaves.
- `curve_set_points` — replace points on `Curve` / `Curve2D` / `Curve3D` (scene-history-friendly via resource-swap pattern).

**`set_property` extension:** `value={"__class__": "BoxMesh", "size": {"x":2,"y":2,"z":2}}` now instantiates a fresh Resource subclass and assigns it inline — matches what an agent intuitively tries first.

## Testing

- 499 Python tests passing (`pytest -v`).
- 582 GDScript tests passing across 26 suites (69 new).
- Live smoke tested each tool against a running Godot editor (create + assign + undo + error cases).

## Incidental fixes pulled in while iterating

- `EditorUndoRedoManager` in Godot 4.6.2 doesn't expose `.undo()` directly. Added `editor_undo` / `editor_redo` helpers to `McpTestSuite` that resolve both scene and global histories via `get_history_undo_redo`, matching the pattern in `batch_handler.gd`. Existing tests using `_undo_redo.undo()` were tolerated by 4.6.2's method-missing fallback; new tests use the proper helper.
- `physics_shape_autofit` response now returns a clean scene path for the auto-detected `source_path` (was leaking the editor-internal viewport wrapping like `/root/@EditorNode.../ @SubViewport.../Main/...`).

## Follow-ups spawned separately

- Investigate repeated-`editor_reload_plugin` state corruption (triggered a SIGSEGV in `ResourceFormatSaverGDScript::recognize` during iteration; fresh Godot launches are unaffected).
- Fix the client-configuration popup opening by default after PR #43.

## Test plan

- [ ] `pytest -v` on this branch — all 499 green
- [ ] Open Godot on `test_project/`, run `test_run` via MCP — 582 / 582 green
- [ ] Smoke: `resource_create type="BoxMesh" path="/Main/Mesh" property="mesh"` → mesh appears, Ctrl-Z reverts
- [ ] Smoke: `physics_shape_autofit path="/Main/Body/Collision"` on a body with a sibling `MeshInstance3D` → shape sizes match
- [ ] Smoke: `environment_create path="/Main/WorldEnvironment" preset="sunset"` → sky renders warm
- [ ] Smoke: error paths (abstract class, non-Resource class, missing home) return friendly messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)