### PR TITLE
feat: control_draw_recipe + reusable DrawRecipe runtime

### DIFF
--- a/plugin/addons/godot_ai/handlers/control_draw_recipe_handler.gd
+++ b/plugin/addons/godot_ai/handlers/control_draw_recipe_handler.gd
@@ -1,0 +1,340 @@
+@tool
+class_name ControlDrawRecipeHandler
+extends RefCounted
+
+## Handles the control_draw_recipe MCP command. Attaches a shared DrawRecipe
+## script to a Control and stores the caller's ordered draw ops in node
+## metadata under "_ops". The DrawRecipe script dispatches each op to a
+## CanvasItem draw_* call in _draw(). One Ctrl+Z reverts script + meta as a
+## single undo step.
+
+const DRAW_RECIPE_SCRIPT := preload("res://addons/godot_ai/runtime/draw_recipe.gd")
+
+var _undo_redo: EditorUndoRedoManager
+
+
+func _init(undo_redo: EditorUndoRedoManager) -> void:
+	_undo_redo = undo_redo
+
+
+func control_draw_recipe(params: Dictionary) -> Dictionary:
+	var path: String = params.get("path", "")
+	var ops_raw: Variant = params.get("ops", null)
+	var clear_existing: bool = bool(params.get("clear_existing", true))
+
+	if path.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: path")
+	if typeof(ops_raw) != TYPE_ARRAY:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "ops must be an Array")
+
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+
+	var node := ScenePath.resolve(path, scene_root)
+	if node == null:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % path)
+	if not node is Control:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"control_draw_recipe requires a Control node, got %s" % node.get_class()
+		)
+
+	var coerced := _coerce_ops(ops_raw)
+	if coerced.has("error"):
+		return coerced
+	var coerced_ops: Array = coerced.ops
+
+	var old_script: Variant = node.get_script()
+	var script_replaced := false
+	if old_script != null and old_script != DRAW_RECIPE_SCRIPT:
+		if not clear_existing:
+			return McpErrorCodes.make(
+				McpErrorCodes.INVALID_PARAMS,
+				(
+					"Node %s already has a script. Pass clear_existing=true to replace."
+					% path
+				)
+			)
+		script_replaced = true
+
+	var had_meta := node.has_meta("_ops")
+	var old_ops: Variant = node.get_meta("_ops") if had_meta else null
+
+	_undo_redo.create_action("MCP: Draw recipe on %s" % node.name)
+	_undo_redo.add_do_method(node, "set_script", DRAW_RECIPE_SCRIPT)
+	_undo_redo.add_do_method(node, "set_meta", "_ops", coerced_ops)
+	_undo_redo.add_do_method(node, "queue_redraw")
+	_undo_redo.add_undo_method(node, "set_script", old_script)
+	if had_meta:
+		_undo_redo.add_undo_method(node, "set_meta", "_ops", old_ops)
+	else:
+		_undo_redo.add_undo_method(node, "remove_meta", "_ops")
+	_undo_redo.add_undo_method(node, "queue_redraw")
+	_undo_redo.commit_action()
+
+	return {
+		"data":
+		{
+			"path": ScenePath.from_node(node, scene_root),
+			"ops_count": coerced_ops.size(),
+			"script_attached": old_script == null,
+			"script_replaced": script_replaced,
+			"undoable": true,
+		}
+	}
+
+
+## Populate a freshly-instantiated Control with the draw recipe in memory
+## (no undo action). Used by PR2's pattern_corner_brackets, which wraps the
+## node-add + set_script/set_meta in its own create_action.
+static func attach_recipe_to(node: Control, coerced_ops: Array) -> void:
+	node.set_script(DRAW_RECIPE_SCRIPT)
+	node.set_meta("_ops", coerced_ops)
+
+
+## Validate and coerce every op dict. Returns {"ops": Array} or an error dict.
+func _coerce_ops(ops: Array) -> Dictionary:
+	var result: Array = []
+	for i in ops.size():
+		var op: Variant = ops[i]
+		if typeof(op) != TYPE_DICTIONARY:
+			return McpErrorCodes.make(
+				McpErrorCodes.INVALID_PARAMS, "ops[%d] must be a dictionary" % i
+			)
+		var coerced := _coerce_single_op(op, i)
+		if coerced.has("error"):
+			return coerced
+		result.append(coerced.op)
+	return {"ops": result}
+
+
+func _coerce_single_op(op: Dictionary, idx: int) -> Dictionary:
+	var draw_type: String = op.get("draw", "")
+	if draw_type.is_empty():
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS, "ops[%d]: missing 'draw' field" % idx
+		)
+	match draw_type:
+		"line":
+			return _coerce_line(op, idx)
+		"rect":
+			return _coerce_rect(op, idx)
+		"arc":
+			return _coerce_arc(op, idx)
+		"circle":
+			return _coerce_circle(op, idx)
+		"polyline":
+			return _coerce_polyline_or_polygon(op, idx, "polyline")
+		"polygon":
+			return _coerce_polyline_or_polygon(op, idx, "polygon")
+		"string":
+			return _coerce_string(op, idx)
+	return McpErrorCodes.make(
+		McpErrorCodes.INVALID_PARAMS,
+		"ops[%d]: unknown draw type '%s'" % [idx, draw_type]
+	)
+
+
+func _require_fields(op: Dictionary, idx: int, kind: String, fields: Array) -> Dictionary:
+	for f in fields:
+		if not op.has(f):
+			return McpErrorCodes.make(
+				McpErrorCodes.INVALID_PARAMS,
+				"ops[%d] (%s): missing '%s'" % [idx, kind, f]
+			)
+	return {}
+
+
+func _coerce_line(op: Dictionary, idx: int) -> Dictionary:
+	var missing := _require_fields(op, idx, "line", ["from", "to", "color"])
+	if missing.has("error"):
+		return missing
+	var frm := UiHandler._coerce_for_type(op.from, TYPE_VECTOR2)
+	if not frm.ok:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS, "ops[%d] (line): invalid 'from'" % idx
+		)
+	var to_ := UiHandler._coerce_for_type(op.to, TYPE_VECTOR2)
+	if not to_.ok:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS, "ops[%d] (line): invalid 'to'" % idx
+		)
+	var c := UiHandler._coerce_for_type(op.color, TYPE_COLOR)
+	if not c.ok:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS, "ops[%d] (line): invalid 'color'" % idx
+		)
+	var out := {"draw": "line", "from": frm.value, "to": to_.value, "color": c.value}
+	if op.has("width"):
+		out["width"] = float(op.width)
+	if op.has("antialiased"):
+		out["antialiased"] = bool(op.antialiased)
+	return {"op": out}
+
+
+func _coerce_rect(op: Dictionary, idx: int) -> Dictionary:
+	var missing := _require_fields(op, idx, "rect", ["rect", "color"])
+	if missing.has("error"):
+		return missing
+	var r := UiHandler._coerce_for_type(op.rect, TYPE_RECT2)
+	if not r.ok:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS, "ops[%d] (rect): invalid 'rect'" % idx
+		)
+	var c := UiHandler._coerce_for_type(op.color, TYPE_COLOR)
+	if not c.ok:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS, "ops[%d] (rect): invalid 'color'" % idx
+		)
+	var out := {"draw": "rect", "rect": r.value, "color": c.value}
+	if op.has("filled"):
+		out["filled"] = bool(op.filled)
+	if op.has("width"):
+		out["width"] = float(op.width)
+	return {"op": out}
+
+
+func _coerce_arc(op: Dictionary, idx: int) -> Dictionary:
+	var missing := _require_fields(
+		op, idx, "arc", ["center", "radius", "start_angle", "end_angle", "color"]
+	)
+	if missing.has("error"):
+		return missing
+	var center := UiHandler._coerce_for_type(op.center, TYPE_VECTOR2)
+	if not center.ok:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS, "ops[%d] (arc): invalid 'center'" % idx
+		)
+	var c := UiHandler._coerce_for_type(op.color, TYPE_COLOR)
+	if not c.ok:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS, "ops[%d] (arc): invalid 'color'" % idx
+		)
+	var out := {
+		"draw": "arc",
+		"center": center.value,
+		"radius": float(op.radius),
+		"start_angle": float(op.start_angle),
+		"end_angle": float(op.end_angle),
+		"color": c.value,
+	}
+	if op.has("point_count"):
+		out["point_count"] = int(op.point_count)
+	if op.has("width"):
+		out["width"] = float(op.width)
+	if op.has("antialiased"):
+		out["antialiased"] = bool(op.antialiased)
+	return {"op": out}
+
+
+func _coerce_circle(op: Dictionary, idx: int) -> Dictionary:
+	var missing := _require_fields(op, idx, "circle", ["center", "radius", "color"])
+	if missing.has("error"):
+		return missing
+	var center := UiHandler._coerce_for_type(op.center, TYPE_VECTOR2)
+	if not center.ok:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS, "ops[%d] (circle): invalid 'center'" % idx
+		)
+	var c := UiHandler._coerce_for_type(op.color, TYPE_COLOR)
+	if not c.ok:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS, "ops[%d] (circle): invalid 'color'" % idx
+		)
+	return {
+		"op":
+		{
+			"draw": "circle",
+			"center": center.value,
+			"radius": float(op.radius),
+			"color": c.value,
+		}
+	}
+
+
+func _coerce_polyline_or_polygon(op: Dictionary, idx: int, kind: String) -> Dictionary:
+	if not op.has("points"):
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS, "ops[%d] (%s): missing 'points'" % [idx, kind]
+		)
+	if typeof(op.points) != TYPE_ARRAY:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"ops[%d] (%s): 'points' must be an Array" % [idx, kind]
+		)
+	var points := PackedVector2Array()
+	for j in op.points.size():
+		var p := UiHandler._coerce_for_type(op.points[j], TYPE_VECTOR2)
+		if not p.ok:
+			return McpErrorCodes.make(
+				McpErrorCodes.INVALID_PARAMS,
+				"ops[%d] (%s): points[%d] invalid" % [idx, kind, j]
+			)
+		points.append(p.value)
+
+	var out := {"draw": kind, "points": points}
+
+	if op.has("colors"):
+		if typeof(op.colors) != TYPE_ARRAY:
+			return McpErrorCodes.make(
+				McpErrorCodes.INVALID_PARAMS,
+				"ops[%d] (%s): 'colors' must be an Array" % [idx, kind]
+			)
+		var colors := PackedColorArray()
+		for k in op.colors.size():
+			var ck := UiHandler._coerce_for_type(op.colors[k], TYPE_COLOR)
+			if not ck.ok:
+				return McpErrorCodes.make(
+					McpErrorCodes.INVALID_PARAMS,
+					"ops[%d] (%s): colors[%d] invalid" % [idx, kind, k]
+				)
+			colors.append(ck.value)
+		out["colors"] = colors
+	elif op.has("color"):
+		var c := UiHandler._coerce_for_type(op.color, TYPE_COLOR)
+		if not c.ok:
+			return McpErrorCodes.make(
+				McpErrorCodes.INVALID_PARAMS, "ops[%d] (%s): invalid 'color'" % [idx, kind]
+			)
+		out["color"] = c.value
+	else:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"ops[%d] (%s): missing 'color' or 'colors'" % [idx, kind]
+		)
+
+	if op.has("width"):
+		out["width"] = float(op.width)
+	if op.has("antialiased"):
+		out["antialiased"] = bool(op.antialiased)
+	return {"op": out}
+
+
+func _coerce_string(op: Dictionary, idx: int) -> Dictionary:
+	var missing := _require_fields(op, idx, "string", ["position", "text", "color"])
+	if missing.has("error"):
+		return missing
+	var pos := UiHandler._coerce_for_type(op.position, TYPE_VECTOR2)
+	if not pos.ok:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS, "ops[%d] (string): invalid 'position'" % idx
+		)
+	var c := UiHandler._coerce_for_type(op.color, TYPE_COLOR)
+	if not c.ok:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS, "ops[%d] (string): invalid 'color'" % idx
+		)
+	var out := {
+		"draw": "string",
+		"position": pos.value,
+		"text": str(op.text),
+		"color": c.value,
+	}
+	if op.has("font_size"):
+		out["font_size"] = int(op.font_size)
+	if op.has("align"):
+		out["align"] = int(op.align)
+	if op.has("max_width"):
+		out["max_width"] = float(op.max_width)
+	return {"op": out}

--- a/plugin/addons/godot_ai/handlers/control_draw_recipe_handler.gd
+++ b/plugin/addons/godot_ai/handlers/control_draw_recipe_handler.gd
@@ -46,7 +46,6 @@ func control_draw_recipe(params: Dictionary) -> Dictionary:
 	var coerced_ops: Array = coerced.ops
 
 	var old_script: Variant = node.get_script()
-	var script_replaced := false
 	if old_script != null and old_script != DRAW_RECIPE_SCRIPT:
 		if not clear_existing:
 			return McpErrorCodes.make(
@@ -56,7 +55,6 @@ func control_draw_recipe(params: Dictionary) -> Dictionary:
 					% path
 				)
 			)
-		script_replaced = true
 
 	var had_meta := node.has_meta("_ops")
 	var old_ops: Variant = node.get_meta("_ops") if had_meta else null
@@ -79,7 +77,7 @@ func control_draw_recipe(params: Dictionary) -> Dictionary:
 			"path": ScenePath.from_node(node, scene_root),
 			"ops_count": coerced_ops.size(),
 			"script_attached": old_script == null,
-			"script_replaced": script_replaced,
+			"script_replaced": old_script != null and old_script != DRAW_RECIPE_SCRIPT,
 			"undoable": true,
 		}
 	}
@@ -146,25 +144,28 @@ func _require_fields(op: Dictionary, idx: int, kind: String, fields: Array) -> D
 	return {}
 
 
+func _coerce_typed(value: Variant, prop_type: int, idx: int, kind: String, field: String) -> Dictionary:
+	var r := UiHandler._coerce_for_type(value, prop_type)
+	if r.ok:
+		return {"ok": true, "value": r.value}
+	return McpErrorCodes.make(
+		McpErrorCodes.INVALID_PARAMS, "ops[%d] (%s): invalid '%s'" % [idx, kind, field]
+	)
+
+
 func _coerce_line(op: Dictionary, idx: int) -> Dictionary:
 	var missing := _require_fields(op, idx, "line", ["from", "to", "color"])
 	if missing.has("error"):
 		return missing
-	var frm := UiHandler._coerce_for_type(op.from, TYPE_VECTOR2)
-	if not frm.ok:
-		return McpErrorCodes.make(
-			McpErrorCodes.INVALID_PARAMS, "ops[%d] (line): invalid 'from'" % idx
-		)
-	var to_ := UiHandler._coerce_for_type(op.to, TYPE_VECTOR2)
-	if not to_.ok:
-		return McpErrorCodes.make(
-			McpErrorCodes.INVALID_PARAMS, "ops[%d] (line): invalid 'to'" % idx
-		)
-	var c := UiHandler._coerce_for_type(op.color, TYPE_COLOR)
-	if not c.ok:
-		return McpErrorCodes.make(
-			McpErrorCodes.INVALID_PARAMS, "ops[%d] (line): invalid 'color'" % idx
-		)
+	var frm := _coerce_typed(op.from, TYPE_VECTOR2, idx, "line", "from")
+	if frm.has("error"):
+		return frm
+	var to_ := _coerce_typed(op.to, TYPE_VECTOR2, idx, "line", "to")
+	if to_.has("error"):
+		return to_
+	var c := _coerce_typed(op.color, TYPE_COLOR, idx, "line", "color")
+	if c.has("error"):
+		return c
 	var out := {"draw": "line", "from": frm.value, "to": to_.value, "color": c.value}
 	if op.has("width"):
 		out["width"] = float(op.width)
@@ -177,16 +178,12 @@ func _coerce_rect(op: Dictionary, idx: int) -> Dictionary:
 	var missing := _require_fields(op, idx, "rect", ["rect", "color"])
 	if missing.has("error"):
 		return missing
-	var r := UiHandler._coerce_for_type(op.rect, TYPE_RECT2)
-	if not r.ok:
-		return McpErrorCodes.make(
-			McpErrorCodes.INVALID_PARAMS, "ops[%d] (rect): invalid 'rect'" % idx
-		)
-	var c := UiHandler._coerce_for_type(op.color, TYPE_COLOR)
-	if not c.ok:
-		return McpErrorCodes.make(
-			McpErrorCodes.INVALID_PARAMS, "ops[%d] (rect): invalid 'color'" % idx
-		)
+	var r := _coerce_typed(op.rect, TYPE_RECT2, idx, "rect", "rect")
+	if r.has("error"):
+		return r
+	var c := _coerce_typed(op.color, TYPE_COLOR, idx, "rect", "color")
+	if c.has("error"):
+		return c
 	var out := {"draw": "rect", "rect": r.value, "color": c.value}
 	if op.has("filled"):
 		out["filled"] = bool(op.filled)
@@ -201,16 +198,12 @@ func _coerce_arc(op: Dictionary, idx: int) -> Dictionary:
 	)
 	if missing.has("error"):
 		return missing
-	var center := UiHandler._coerce_for_type(op.center, TYPE_VECTOR2)
-	if not center.ok:
-		return McpErrorCodes.make(
-			McpErrorCodes.INVALID_PARAMS, "ops[%d] (arc): invalid 'center'" % idx
-		)
-	var c := UiHandler._coerce_for_type(op.color, TYPE_COLOR)
-	if not c.ok:
-		return McpErrorCodes.make(
-			McpErrorCodes.INVALID_PARAMS, "ops[%d] (arc): invalid 'color'" % idx
-		)
+	var center := _coerce_typed(op.center, TYPE_VECTOR2, idx, "arc", "center")
+	if center.has("error"):
+		return center
+	var c := _coerce_typed(op.color, TYPE_COLOR, idx, "arc", "color")
+	if c.has("error"):
+		return c
 	var out := {
 		"draw": "arc",
 		"center": center.value,
@@ -232,16 +225,12 @@ func _coerce_circle(op: Dictionary, idx: int) -> Dictionary:
 	var missing := _require_fields(op, idx, "circle", ["center", "radius", "color"])
 	if missing.has("error"):
 		return missing
-	var center := UiHandler._coerce_for_type(op.center, TYPE_VECTOR2)
-	if not center.ok:
-		return McpErrorCodes.make(
-			McpErrorCodes.INVALID_PARAMS, "ops[%d] (circle): invalid 'center'" % idx
-		)
-	var c := UiHandler._coerce_for_type(op.color, TYPE_COLOR)
-	if not c.ok:
-		return McpErrorCodes.make(
-			McpErrorCodes.INVALID_PARAMS, "ops[%d] (circle): invalid 'color'" % idx
-		)
+	var center := _coerce_typed(op.center, TYPE_VECTOR2, idx, "circle", "center")
+	if center.has("error"):
+		return center
+	var c := _coerce_typed(op.color, TYPE_COLOR, idx, "circle", "color")
+	if c.has("error"):
+		return c
 	return {
 		"op":
 		{
@@ -315,16 +304,12 @@ func _coerce_string(op: Dictionary, idx: int) -> Dictionary:
 	var missing := _require_fields(op, idx, "string", ["position", "text", "color"])
 	if missing.has("error"):
 		return missing
-	var pos := UiHandler._coerce_for_type(op.position, TYPE_VECTOR2)
-	if not pos.ok:
-		return McpErrorCodes.make(
-			McpErrorCodes.INVALID_PARAMS, "ops[%d] (string): invalid 'position'" % idx
-		)
-	var c := UiHandler._coerce_for_type(op.color, TYPE_COLOR)
-	if not c.ok:
-		return McpErrorCodes.make(
-			McpErrorCodes.INVALID_PARAMS, "ops[%d] (string): invalid 'color'" % idx
-		)
+	var pos := _coerce_typed(op.position, TYPE_VECTOR2, idx, "string", "position")
+	if pos.has("error"):
+		return pos
+	var c := _coerce_typed(op.color, TYPE_COLOR, idx, "string", "color")
+	if c.has("error"):
+		return c
 	var out := {
 		"draw": "string",
 		"position": pos.value,

--- a/plugin/addons/godot_ai/handlers/control_draw_recipe_handler.gd.uid
+++ b/plugin/addons/godot_ai/handlers/control_draw_recipe_handler.gd.uid
@@ -1,0 +1,1 @@
+uid://buat1mt0fjlqb

--- a/plugin/addons/godot_ai/handlers/ui_handler.gd
+++ b/plugin/addons/godot_ai/handlers/ui_handler.gd
@@ -472,6 +472,28 @@ static func _coerce_for_type(value: Variant, prop_type: int) -> Dictionary:
 			if value is Array and value.size() == 2:
 				return {"ok": true, "value": Vector2i(int(value[0]), int(value[1]))}
 			return {"ok": false}
+		TYPE_RECT2:
+			if value is Rect2:
+				return {"ok": true, "value": value}
+			if value is Array and value.size() == 4:
+				return {
+					"ok": true,
+					"value":
+					Rect2(float(value[0]), float(value[1]), float(value[2]), float(value[3])),
+				}
+			if value is Dictionary:
+				if value.has("x") and value.has("y") and value.has("w") and value.has("h"):
+					return {
+						"ok": true,
+						"value":
+						Rect2(float(value.x), float(value.y), float(value.w), float(value.h)),
+					}
+				if value.has("position") and value.has("size"):
+					var pos := _coerce_for_type(value.position, TYPE_VECTOR2)
+					var sz := _coerce_for_type(value.size, TYPE_VECTOR2)
+					if pos.ok and sz.ok:
+						return {"ok": true, "value": Rect2(pos.value, sz.value)}
+			return {"ok": false}
 		TYPE_NODE_PATH:
 			if value is NodePath:
 				return {"ok": true, "value": value}

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -43,7 +43,8 @@ func _enter_tree() -> void:
 	var environment_handler := EnvironmentHandler.new(get_undo_redo())
 	var texture_handler := TextureHandler.new(get_undo_redo())
 	var curve_handler := CurveHandler.new(get_undo_redo())
-	_handlers = [editor_handler, scene_handler, node_handler, project_handler, client_handler, script_handler, resource_handler, filesystem_handler, signal_handler, autoload_handler, input_handler, test_handler, batch_handler, ui_handler, theme_handler, animation_handler, material_handler, particle_handler, camera_handler, audio_handler, physics_shape_handler, environment_handler, texture_handler, curve_handler]
+	var control_draw_recipe_handler := ControlDrawRecipeHandler.new(get_undo_redo())
+	_handlers = [editor_handler, scene_handler, node_handler, project_handler, client_handler, script_handler, resource_handler, filesystem_handler, signal_handler, autoload_handler, input_handler, test_handler, batch_handler, ui_handler, theme_handler, animation_handler, material_handler, particle_handler, camera_handler, audio_handler, physics_shape_handler, environment_handler, texture_handler, curve_handler, control_draw_recipe_handler]
 
 	_dispatcher.register("get_editor_state", editor_handler.get_editor_state)
 	_dispatcher.register("get_scene_tree", scene_handler.get_scene_tree)
@@ -167,6 +168,9 @@ func _enter_tree() -> void:
 	_dispatcher.register("gradient_texture_create", texture_handler.create_gradient_texture)
 	_dispatcher.register("noise_texture_create", texture_handler.create_noise_texture)
 	_dispatcher.register("curve_set_points", curve_handler.set_points)
+	_dispatcher.register(
+		"control_draw_recipe", control_draw_recipe_handler.control_draw_recipe
+	)
 
 	_connection.dispatcher = _dispatcher
 	add_child(_connection)

--- a/plugin/addons/godot_ai/runtime/draw_recipe.gd
+++ b/plugin/addons/godot_ai/runtime/draw_recipe.gd
@@ -1,0 +1,100 @@
+@tool
+extends Control
+
+## Runtime helper attached by control_draw_recipe and pattern_corner_brackets.
+## Reads an array of op dicts from node metadata under key "_ops" and dispatches
+## each to a CanvasItem draw call in _draw(). The ops list is set by the handler
+## via set_meta; this script is deterministic — re-setting meta + queue_redraw
+## is enough to update the visuals.
+
+const META_KEY := "_ops"
+
+
+func _ready() -> void:
+	queue_redraw()
+
+
+func _draw() -> void:
+	if not has_meta(META_KEY):
+		return
+	var ops: Variant = get_meta(META_KEY)
+	if typeof(ops) != TYPE_ARRAY:
+		return
+	for op in ops:
+		if typeof(op) != TYPE_DICTIONARY:
+			continue
+		match op.get("draw", ""):
+			"line":
+				draw_line(
+					op.from,
+					op.to,
+					op.color,
+					float(op.get("width", 1.0)),
+					bool(op.get("antialiased", false))
+				)
+			"rect":
+				draw_rect(
+					op.rect,
+					op.color,
+					bool(op.get("filled", true)),
+					float(op.get("width", 1.0))
+				)
+			"arc":
+				draw_arc(
+					op.center,
+					float(op.radius),
+					float(op.start_angle),
+					float(op.end_angle),
+					int(op.get("point_count", 32)),
+					op.color,
+					float(op.get("width", 1.0)),
+					bool(op.get("antialiased", false))
+				)
+			"circle":
+				draw_circle(op.center, float(op.radius), op.color)
+			"polyline":
+				draw_polyline(
+					op.points,
+					op.color,
+					float(op.get("width", 1.0)),
+					bool(op.get("antialiased", false))
+				)
+			"polygon":
+				var colors: PackedColorArray = (
+					op.colors if op.has("colors") else PackedColorArray([op.color])
+				)
+				draw_polygon(op.points, colors)
+			"string":
+				var font: Font = get_theme_default_font()
+				if font == null:
+					continue
+				draw_string(
+					font,
+					op.position,
+					str(op.text),
+					int(op.get("align", HORIZONTAL_ALIGNMENT_LEFT)),
+					float(op.get("max_width", -1.0)),
+					int(op.get("font_size", 16)),
+					op.color
+				)
+			"corner_brackets":
+				# Synthesized op used by pattern_corner_brackets. Draws 8 line
+				# segments at the four corners of self.size, so brackets track
+				# parent resizes. Emitted by PatternHandler, not control_draw_recipe.
+				var L := float(op.get("length", 18.0))
+				var T := float(op.get("thickness", 2.0))
+				var c: Color = op.color
+				var w := size.x
+				var h := size.y
+				# Top-left
+				draw_line(Vector2(0, 0), Vector2(L, 0), c, T)
+				draw_line(Vector2(0, 0), Vector2(0, L), c, T)
+				# Top-right
+				draw_line(Vector2(w, 0), Vector2(w - L, 0), c, T)
+				draw_line(Vector2(w, 0), Vector2(w, L), c, T)
+				# Bottom-left
+				draw_line(Vector2(0, h), Vector2(L, h), c, T)
+				draw_line(Vector2(0, h), Vector2(0, h - L), c, T)
+				# Bottom-right
+				draw_line(Vector2(w, h), Vector2(w - L, h), c, T)
+				draw_line(Vector2(w, h), Vector2(w, h - L), c, T)

--- a/plugin/addons/godot_ai/runtime/draw_recipe.gd.uid
+++ b/plugin/addons/godot_ai/runtime/draw_recipe.gd.uid
@@ -1,0 +1,1 @@
+uid://da3fqfqv6gtgm

--- a/plugin/addons/godot_ai/testing/test_suite.gd
+++ b/plugin/addons/godot_ai/testing/test_suite.gd
@@ -181,3 +181,32 @@ func assert_is_error(result: Dictionary, expected_code: String = "", msg: String
 	if expected_code and result.error.get("code", "") != expected_code:
 		_failed = true
 		_message = msg if msg else "Expected error code %s, got %s" % [expected_code, result.error.get("code", "")]
+
+
+# ----- scene helpers (shared across suites that create/remove Controls) -----
+
+## Add a Control under the scene root. Creates a Panel if ctl is null.
+## Returns the scene path, or "" when no scene is open — in which case a
+## caller-supplied ctl is freed to prevent leaks.
+func _add_control(ctl_name: String, ctl: Control = null) -> String:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		if ctl != null:
+			ctl.queue_free()
+		return ""
+	if ctl == null:
+		ctl = Panel.new()
+	ctl.name = ctl_name
+	scene_root.add_child(ctl)
+	ctl.owner = scene_root
+	return "/" + scene_root.name + "/" + ctl_name
+
+
+func _remove_control(path: String) -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return
+	var node := ScenePath.resolve(path, scene_root)
+	if node != null:
+		node.get_parent().remove_child(node)
+		node.queue_free()

--- a/src/godot_ai/handlers/control.py
+++ b/src/godot_ai/handlers/control.py
@@ -1,0 +1,19 @@
+"""Shared handlers for Control-level vector decoration (control_draw_recipe)."""
+
+from __future__ import annotations
+
+from godot_ai.handlers._readiness import require_writable
+from godot_ai.runtime.interface import Runtime
+
+
+async def control_draw_recipe(
+    runtime: Runtime,
+    path: str,
+    ops: list[dict],
+    clear_existing: bool = True,
+) -> dict:
+    require_writable(runtime)
+    return await runtime.send_command(
+        "control_draw_recipe",
+        {"path": path, "ops": ops, "clear_existing": clear_existing},
+    )

--- a/src/godot_ai/server.py
+++ b/src/godot_ai/server.py
@@ -22,6 +22,7 @@ from godot_ai.tools.autoload import register_autoload_tools
 from godot_ai.tools.batch import register_batch_tools
 from godot_ai.tools.camera import register_camera_tools
 from godot_ai.tools.client import register_client_tools
+from godot_ai.tools.control import register_control_tools
 from godot_ai.tools.curve import register_curve_tools
 from godot_ai.tools.editor import register_editor_tools
 from godot_ai.tools.environment import register_environment_tools
@@ -99,6 +100,8 @@ def create_server(ws_port: int = 9500) -> FastMCP:
             "  batch_execute    — compose multi-step scene edits atomically\n"
             "  ui_*             — Control layout helpers "
             "(anchor presets, declarative layout builder)\n"
+            "  control_*        — attach vector _draw() ops to Controls "
+            "(gauges, radar, corner brackets, scanlines, crosshairs, waveforms)\n"
             "  theme_*          — author Theme resources "
             "(colors, stylebox, font sizes) — Godot's CSS-like styling\n"
             "  animation_*      — AnimationPlayer authoring "
@@ -147,6 +150,7 @@ def create_server(ws_port: int = 9500) -> FastMCP:
     register_testing_tools(mcp)
     register_batch_tools(mcp)
     register_ui_tools(mcp)
+    register_control_tools(mcp)
     register_theme_tools(mcp)
     register_animation_tools(mcp)
     register_material_tools(mcp)

--- a/src/godot_ai/tools/control.py
+++ b/src/godot_ai/tools/control.py
@@ -1,0 +1,99 @@
+"""MCP tools for Control-node vector decoration.
+
+Use control_draw_recipe when you need a Control to display vector graphics
+that go beyond what anchors, nested Controls, or textures produce — radar
+sweeps, gauge arcs, corner bracket frames, crosshairs, tick marks, waveform
+traces, HUD overlays built out of lines and polygons. One MCP call attaches
+a shared DrawRecipe script to the target Control and stores an ordered
+list of draw operations in node metadata; the script dispatches each op
+inside _draw() every repaint. No disk file is written, no per-node GDScript
+is generated, and re-invoking the tool idempotently replaces the op list.
+
+Keywords: vector, draw, gauge, radar, scanline, bracket, crosshair, tick,
+waveform, hud, overlay, shape, canvas, line, rect, arc, circle, polyline,
+polygon.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastmcp import Context, FastMCP
+
+from godot_ai.handlers import control as control_handlers
+from godot_ai.runtime.direct import DirectRuntime
+from godot_ai.tools import DEFER_META, JsonCoerced
+
+
+def register_control_tools(mcp: FastMCP) -> None:
+    @mcp.tool(meta=DEFER_META)
+    async def control_draw_recipe(
+        ctx: Context,
+        path: str,
+        ops: Annotated[list[dict], JsonCoerced],
+        clear_existing: bool = True,
+        session_id: str = "",
+    ) -> dict:
+        """Attach a declarative list of vector _draw() ops to a Control node.
+
+        One call produces a vector-decorated widget — radar sweep, gauge,
+        corner-bracket frame, crosshair, tick marks, HUD border — without
+        authoring or attaching a custom GDScript. Ops persist as node
+        metadata ("_ops"); the shared DrawRecipe script at
+        res://addons/godot_ai/runtime/draw_recipe.gd replays them in _draw().
+        Idempotent: a second call replaces the op list. Single Ctrl+Z
+        reverts both the script attach and the metadata in one undo step.
+
+        Coordinates are relative to the Control's local (0,0) — its top-left.
+
+        Supported ops (each a dict with "draw" key plus op-specific fields):
+
+            line       - {"draw": "line", "from": [x,y], "to": [x,y],
+                          "color": ..., "width": 1.0, "antialiased": false}
+            rect       - {"draw": "rect", "rect": [x,y,w,h] or {x,y,w,h} or
+                          {position, size}, "color": ..., "filled": true,
+                          "width": 1.0}
+            arc        - {"draw": "arc", "center": [x,y], "radius": 40,
+                          "start_angle": 0.0, "end_angle": 1.57, "color": ...,
+                          "point_count": 32, "width": 2.0,
+                          "antialiased": false}
+            circle     - {"draw": "circle", "center": [x,y], "radius": 5,
+                          "color": ...}
+            polyline   - {"draw": "polyline", "points": [[x,y], ...],
+                          "color": ..., "width": 1.0, "antialiased": false}
+            polygon    - {"draw": "polygon", "points": [[x,y], ...],
+                          "color": ... OR "colors": [color, ...]}
+            string     - {"draw": "string", "position": [x,y], "text": "...",
+                          "color": ..., "font_size": 16, "align": 0,
+                          "max_width": -1.0}
+
+        Value coercion:
+            Colors accept "#rrggbb", "#rrggbbaa", named strings ("red",
+                "magenta", "transparent"), or {"r","g","b","a"?}.
+            Points accept {"x","y"} or [x, y].
+            Angles are radians.
+
+        Example — draw an L-shaped corner bracket (two lines) on a Panel:
+            control_draw_recipe(
+                path="/Main/HUD/VitalsPanel",
+                ops=[
+                    {"draw": "line", "from": [0,0], "to": [18,0],
+                     "color": "#00eaff", "width": 2},
+                    {"draw": "line", "from": [0,0], "to": [0,18],
+                     "color": "#00eaff", "width": 2},
+                ],
+            )
+
+        Args:
+            path: Scene path to a Control node (Panel, ColorRect, Label, …).
+            ops: Ordered list of draw op dicts.
+            clear_existing: If true (default), replace any existing script on
+                the node (except the DrawRecipe script itself, which is always
+                replaceable). If false and the node already has a user script,
+                the call errors so user-authored code isn't silently lost.
+            session_id: Optional Godot session to target. Empty = active.
+        """
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
+        return await control_handlers.control_draw_recipe(
+            runtime, path=path, ops=ops, clear_existing=clear_existing
+        )

--- a/test_project/tests/test_control_draw_recipe.gd
+++ b/test_project/tests/test_control_draw_recipe.gd
@@ -1,0 +1,418 @@
+@tool
+extends McpTestSuite
+
+## Live-editor tests for ControlDrawRecipeHandler — control_draw_recipe command.
+## Covers: op validation, value coercion (Color/Vector2/Rect2/PackedVector2Array),
+## script attachment, meta persistence, undo/redo round-trips, error paths.
+
+const DRAW_RECIPE_SCRIPT := preload("res://addons/godot_ai/runtime/draw_recipe.gd")
+
+var _handler: ControlDrawRecipeHandler
+var _undo_redo: EditorUndoRedoManager
+
+
+func suite_name() -> String:
+	return "control_draw_recipe"
+
+
+func suite_setup(ctx: Dictionary) -> void:
+	_undo_redo = ctx.get("undo_redo")
+	_handler = ControlDrawRecipeHandler.new(_undo_redo)
+
+
+func _add_control(ctl_name: String, ctl: Control = null) -> String:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		if ctl != null:
+			ctl.queue_free()
+		return ""
+	if ctl == null:
+		ctl = Panel.new()
+	ctl.name = ctl_name
+	scene_root.add_child(ctl)
+	ctl.owner = scene_root
+	return "/" + scene_root.name + "/" + ctl_name
+
+
+func _remove_control(path: String) -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return
+	var node := ScenePath.resolve(path, scene_root)
+	if node != null:
+		node.get_parent().remove_child(node)
+		node.queue_free()
+
+
+# ----- happy-path op types -----
+
+
+func test_line_op_lands_and_coerces() -> void:
+	var path := _add_control("TestLineRecipe")
+	if path.is_empty():
+		skip("Scene not ready")
+		return
+	var result := _handler.control_draw_recipe(
+		{
+			"path": path,
+			"ops":
+			[
+				{
+					"draw": "line",
+					"from": [0, 0],
+					"to": {"x": 18, "y": 0},
+					"color": "#00eaff",
+					"width": 2,
+				}
+			],
+		}
+	)
+	assert_has_key(result, "data")
+	assert_eq(result.data.ops_count, 1)
+	assert_true(result.data.script_attached, "script should attach on clean node")
+	assert_false(result.data.script_replaced)
+	assert_true(result.data.undoable)
+
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var node := ScenePath.resolve(path, scene_root)
+	assert_true(node.get_script() == DRAW_RECIPE_SCRIPT, "DrawRecipe script attached")
+	assert_true(node.has_meta("_ops"), "_ops meta set")
+
+	var stored: Array = node.get_meta("_ops")
+	assert_eq(stored.size(), 1)
+	var op: Dictionary = stored[0]
+	assert_true(op.from is Vector2, "from coerced to Vector2")
+	assert_eq(op.from, Vector2(0, 0))
+	assert_true(op.to is Vector2, "to coerced to Vector2")
+	assert_eq(op.to, Vector2(18, 0))
+	assert_true(op.color is Color, "color coerced to Color")
+	assert_eq(op.color, Color("#00eaff"))
+
+	_remove_control(path)
+
+
+func test_rect_op_all_dict_forms() -> void:
+	var path := _add_control("TestRectRecipe")
+	if path.is_empty():
+		skip("Scene not ready")
+		return
+	var result := _handler.control_draw_recipe(
+		{
+			"path": path,
+			"ops":
+			[
+				{"draw": "rect", "rect": [0, 0, 10, 10], "color": "red"},
+				{
+					"draw": "rect",
+					"rect": {"x": 5, "y": 5, "w": 20, "h": 20},
+					"color": "#00ff00",
+				},
+				{
+					"draw": "rect",
+					"rect": {"position": {"x": 30, "y": 30}, "size": [5, 5]},
+					"color": "blue",
+				},
+			],
+		}
+	)
+	assert_has_key(result, "data")
+	assert_eq(result.data.ops_count, 3)
+
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var node := ScenePath.resolve(path, scene_root)
+	var stored: Array = node.get_meta("_ops")
+	assert_true(stored[0].rect is Rect2)
+	assert_eq(stored[0].rect, Rect2(0, 0, 10, 10))
+	assert_eq(stored[1].rect, Rect2(5, 5, 20, 20))
+	assert_eq(stored[2].rect, Rect2(30, 30, 5, 5))
+	_remove_control(path)
+
+
+func test_polyline_points_stored_as_packed_array() -> void:
+	var path := _add_control("TestPolylineRecipe")
+	if path.is_empty():
+		skip("Scene not ready")
+		return
+	var result := _handler.control_draw_recipe(
+		{
+			"path": path,
+			"ops":
+			[
+				{
+					"draw": "polyline",
+					"points": [[0, 0], [10, 5], {"x": 20, "y": 0}],
+					"color": "#ff00ff",
+					"width": 1.5,
+				}
+			],
+		}
+	)
+	assert_has_key(result, "data")
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var node := ScenePath.resolve(path, scene_root)
+	var stored: Array = node.get_meta("_ops")
+	var pts: Variant = stored[0].points
+	assert_eq(typeof(pts), TYPE_PACKED_VECTOR2_ARRAY, "points stored as PackedVector2Array")
+	assert_eq(pts.size(), 3)
+	assert_eq(pts[0], Vector2(0, 0))
+	assert_eq(pts[2], Vector2(20, 0))
+	_remove_control(path)
+
+
+func test_all_op_types_accepted() -> void:
+	var path := _add_control("TestAllOps")
+	if path.is_empty():
+		skip("Scene not ready")
+		return
+	var result := _handler.control_draw_recipe(
+		{
+			"path": path,
+			"ops":
+			[
+				{
+					"draw": "line",
+					"from": [0, 0],
+					"to": [10, 10],
+					"color": "red",
+				},
+				{
+					"draw": "rect",
+					"rect": [0, 0, 5, 5],
+					"color": "red",
+				},
+				{
+					"draw": "arc",
+					"center": [10, 10],
+					"radius": 5,
+					"start_angle": 0.0,
+					"end_angle": 1.57,
+					"color": "blue",
+				},
+				{"draw": "circle", "center": [5, 5], "radius": 3, "color": "green"},
+				{
+					"draw": "polyline",
+					"points": [[0, 0], [5, 5]],
+					"color": "white",
+				},
+				{
+					"draw": "polygon",
+					"points": [[0, 0], [5, 0], [5, 5]],
+					"color": "cyan",
+				},
+				{"draw": "string", "position": [1, 1], "text": "hi", "color": "white"},
+			],
+		}
+	)
+	assert_has_key(result, "data")
+	assert_eq(result.data.ops_count, 7)
+	_remove_control(path)
+
+
+# ----- undo / redo -----
+
+
+func test_undo_reverts_clean_node() -> void:
+	var path := _add_control("TestUndoClean")
+	if path.is_empty():
+		skip("Scene not ready")
+		return
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var node := ScenePath.resolve(path, scene_root)
+
+	var result := _handler.control_draw_recipe(
+		{
+			"path": path,
+			"ops":
+			[{"draw": "line", "from": [0, 0], "to": [5, 5], "color": "red"}],
+		}
+	)
+	assert_has_key(result, "data")
+	assert_true(node.has_meta("_ops"))
+	assert_true(node.get_script() == DRAW_RECIPE_SCRIPT)
+
+	_undo_redo.undo()
+	assert_false(node.has_meta("_ops"), "undo should remove _ops meta")
+	assert_true(node.get_script() == null, "undo should remove the script")
+
+	_undo_redo.redo()
+	assert_true(node.has_meta("_ops"), "redo re-applies meta")
+	assert_true(node.get_script() == DRAW_RECIPE_SCRIPT, "redo re-attaches script")
+	_remove_control(path)
+
+
+func test_undo_preserves_prior_meta() -> void:
+	# If the node already had _ops meta, undo must restore it (not remove it).
+	var path := _add_control("TestUndoPrior")
+	if path.is_empty():
+		skip("Scene not ready")
+		return
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var node := ScenePath.resolve(path, scene_root)
+
+	var ops_a: Array = [{"draw": "circle", "center": [1, 1], "radius": 1, "color": "red"}]
+	var r1 := _handler.control_draw_recipe({"path": path, "ops": ops_a})
+	assert_has_key(r1, "data")
+
+	var ops_b: Array = [{"draw": "circle", "center": [2, 2], "radius": 2, "color": "blue"}]
+	var r2 := _handler.control_draw_recipe({"path": path, "ops": ops_b})
+	assert_has_key(r2, "data")
+	var after_b: Array = node.get_meta("_ops")
+	assert_eq(after_b[0].radius, 2.0)
+
+	_undo_redo.undo()
+	var restored: Array = node.get_meta("_ops")
+	assert_eq(restored[0].radius, 1.0, "undo should restore prior _ops meta")
+	assert_true(node.get_script() == DRAW_RECIPE_SCRIPT, "script still attached")
+	_remove_control(path)
+
+
+# ----- error paths -----
+
+
+func test_missing_path_errors() -> void:
+	var result := _handler.control_draw_recipe({"ops": []})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_non_array_ops_errors() -> void:
+	var result := _handler.control_draw_recipe({"path": "/Main", "ops": "nope"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_node_not_found_errors() -> void:
+	var result := _handler.control_draw_recipe({"path": "/Bogus/Path", "ops": []})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_non_control_rejected() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("Scene not ready")
+		return
+	var n := Node2D.new()
+	n.name = "TestNonControl"
+	scene_root.add_child(n)
+	n.owner = scene_root
+	var path := "/" + scene_root.name + "/" + n.name
+
+	var result := _handler.control_draw_recipe({"path": path, "ops": []})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "Control")
+
+	scene_root.remove_child(n)
+	n.queue_free()
+
+
+func test_missing_required_op_field_errors() -> void:
+	var path := _add_control("TestMissingField")
+	if path.is_empty():
+		skip("Scene not ready")
+		return
+	var result := _handler.control_draw_recipe(
+		{"path": path, "ops": [{"draw": "line", "from": [0, 0], "color": "red"}]}
+	)
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "'to'")
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var node := ScenePath.resolve(path, scene_root)
+	assert_false(node.has_meta("_ops"), "invalid op must not mutate node")
+	assert_true(node.get_script() == null)
+	_remove_control(path)
+
+
+func test_unknown_draw_type_errors() -> void:
+	var path := _add_control("TestUnknownDraw")
+	if path.is_empty():
+		skip("Scene not ready")
+		return
+	var result := _handler.control_draw_recipe(
+		{"path": path, "ops": [{"draw": "triangle", "color": "red"}]}
+	)
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "unknown draw type")
+	_remove_control(path)
+
+
+func test_existing_user_script_rejected_when_clear_existing_false() -> void:
+	var path := _add_control("TestUserScript")
+	if path.is_empty():
+		skip("Scene not ready")
+		return
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var node := ScenePath.resolve(path, scene_root)
+
+	var user_script := GDScript.new()
+	user_script.source_code = "@tool\nextends Control\n"
+	user_script.reload()
+	node.set_script(user_script)
+	assert_true(node.get_script() != null)
+
+	var r1 := _handler.control_draw_recipe(
+		{"path": path, "ops": [], "clear_existing": false}
+	)
+	assert_is_error(r1, McpErrorCodes.INVALID_PARAMS)
+	assert_true(node.get_script() == user_script, "user script preserved on error")
+
+	var r2 := _handler.control_draw_recipe(
+		{"path": path, "ops": [], "clear_existing": true}
+	)
+	assert_has_key(r2, "data")
+	assert_true(r2.data.script_replaced, "script_replaced should be true")
+	_remove_control(path)
+
+
+func test_reinvoke_idempotent_replaces_meta() -> void:
+	var path := _add_control("TestReinvoke")
+	if path.is_empty():
+		skip("Scene not ready")
+		return
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var node := ScenePath.resolve(path, scene_root)
+
+	var r1 := _handler.control_draw_recipe(
+		{
+			"path": path,
+			"ops":
+			[{"draw": "circle", "center": [1, 1], "radius": 1, "color": "red"}],
+		}
+	)
+	assert_has_key(r1, "data")
+	assert_true(r1.data.script_attached)
+
+	var r2 := _handler.control_draw_recipe(
+		{
+			"path": path,
+			"ops":
+			[
+				{"draw": "circle", "center": [2, 2], "radius": 2, "color": "blue"},
+				{
+					"draw": "line",
+					"from": [0, 0],
+					"to": [3, 3],
+					"color": "white",
+				},
+			],
+		}
+	)
+	assert_has_key(r2, "data")
+	var stored: Array = node.get_meta("_ops")
+	assert_eq(stored.size(), 2, "re-invoking replaces ops list")
+	_remove_control(path)
+
+
+func test_zero_ops_succeeds() -> void:
+	# Empty ops is a valid no-op draw — supports "clear the recipe" idioms.
+	var path := _add_control("TestZeroOps")
+	if path.is_empty():
+		skip("Scene not ready")
+		return
+	var result := _handler.control_draw_recipe({"path": path, "ops": []})
+	assert_has_key(result, "data")
+	assert_eq(result.data.ops_count, 0)
+
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var node := ScenePath.resolve(path, scene_root)
+	assert_true(node.has_meta("_ops"))
+	var stored: Array = node.get_meta("_ops")
+	assert_eq(stored.size(), 0)
+	_remove_control(path)

--- a/test_project/tests/test_control_draw_recipe.gd
+++ b/test_project/tests/test_control_draw_recipe.gd
@@ -20,29 +20,6 @@ func suite_setup(ctx: Dictionary) -> void:
 	_handler = ControlDrawRecipeHandler.new(_undo_redo)
 
 
-func _add_control(ctl_name: String, ctl: Control = null) -> String:
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		if ctl != null:
-			ctl.queue_free()
-		return ""
-	if ctl == null:
-		ctl = Panel.new()
-	ctl.name = ctl_name
-	scene_root.add_child(ctl)
-	ctl.owner = scene_root
-	return "/" + scene_root.name + "/" + ctl_name
-
-
-func _remove_control(path: String) -> void:
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return
-	var node := ScenePath.resolve(path, scene_root)
-	if node != null:
-		node.get_parent().remove_child(node)
-		node.queue_free()
-
 
 # ----- happy-path op types -----
 

--- a/test_project/tests/test_control_draw_recipe.gd.uid
+++ b/test_project/tests/test_control_draw_recipe.gd.uid
@@ -1,0 +1,1 @@
+uid://d1k4whecqnn3g

--- a/test_project/tests/test_ui.gd
+++ b/test_project/tests/test_ui.gd
@@ -16,33 +16,6 @@ func suite_setup(ctx: Dictionary) -> void:
 	_handler = UiHandler.new(_undo_redo)
 
 
-# Add a Control under the scene root for a single test. If `ctl` is null,
-# creates a Panel; otherwise uses the provided (caller-allocated) instance.
-# Returns the scene path, or "" if the scene isn't ready — in which case an
-# already-allocated `ctl` is freed so the caller doesn't leak it.
-func _add_control(ctl_name: String = "TestHudPanel", ctl: Control = null) -> String:
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		if ctl != null:
-			ctl.queue_free()
-		return ""
-	if ctl == null:
-		ctl = Panel.new()
-	ctl.name = ctl_name
-	scene_root.add_child(ctl)
-	ctl.owner = scene_root
-	return "/" + scene_root.name + "/" + ctl_name
-
-
-func _remove_control(path: String) -> void:
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return
-	var node := ScenePath.resolve(path, scene_root)
-	if node != null:
-		node.get_parent().remove_child(node)
-		node.queue_free()
-
 
 # ----- set_anchor_preset: happy path -----
 

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -5261,6 +5261,8 @@ class TestCameraApplyPresetTool:
             },
         )
         await task
+
+
 # audio_player_create / audio_player_set_stream / audio_play / audio_stop / audio_list
 # ---------------------------------------------------------------------------
 
@@ -5439,3 +5441,99 @@ class TestAudioListTool:
         await task
         assert result.data["count"] == 1
         assert result.data["streams"][0]["class"] == "AudioStreamOggVorbis"
+
+
+# ---------------------------------------------------------------------------
+# control_draw_recipe
+# ---------------------------------------------------------------------------
+
+
+class TestControlDrawRecipeTool:
+    async def test_forwards_ops_and_clear_existing(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        ops = [
+            {"draw": "line", "from": [0, 0], "to": [18, 0], "color": "#00eaff", "width": 2},
+            {"draw": "line", "from": [0, 0], "to": [0, 18], "color": "#00eaff", "width": 2},
+        ]
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "control_draw_recipe"
+            assert cmd["params"]["path"] == "/Main/HUD/Panel"
+            assert cmd["params"]["ops"] == ops
+            assert cmd["params"]["clear_existing"] is True
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "path": "/Main/HUD/Panel",
+                    "ops_count": 2,
+                    "script_attached": True,
+                    "script_replaced": False,
+                    "undoable": True,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "control_draw_recipe",
+            {"path": "/Main/HUD/Panel", "ops": ops},
+        )
+        await task
+        assert result.data["ops_count"] == 2
+        assert result.data["undoable"] is True
+        assert result.data["script_attached"] is True
+
+    async def test_clear_existing_false_forwarded(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["params"]["clear_existing"] is False
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "path": "/Foo",
+                    "ops_count": 0,
+                    "script_attached": False,
+                    "script_replaced": False,
+                    "undoable": True,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        await client.call_tool(
+            "control_draw_recipe",
+            {"path": "/Foo", "ops": [], "clear_existing": False},
+        )
+        await task
+
+    async def test_json_coerced_ops_accepted_as_string(self, mcp_stack):
+        """Some MCP clients stringify list[dict] args; JsonCoerced handles it."""
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["params"]["ops"] == [
+                {"draw": "circle", "center": [5, 5], "radius": 3, "color": "red"}
+            ]
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "path": "/Foo",
+                    "ops_count": 1,
+                    "script_attached": True,
+                    "script_replaced": False,
+                    "undoable": True,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        await client.call_tool(
+            "control_draw_recipe",
+            {
+                "path": "/Foo",
+                "ops": '[{"draw":"circle","center":[5,5],"radius":3,"color":"red"}]',
+            },
+        )
+        await task

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -10,6 +10,7 @@ from godot_ai.handlers import autoload as autoload_handlers
 from godot_ai.handlers import batch as batch_handlers
 from godot_ai.handlers import camera as camera_handlers
 from godot_ai.handlers import client as client_handlers
+from godot_ai.handlers import control as control_handlers
 from godot_ai.handlers import curve as curve_handlers
 from godot_ai.handlers import editor as editor_handlers
 from godot_ai.handlers import environment as environment_handlers
@@ -477,6 +478,15 @@ class StubClient:
             return {
                 "root_path": "/Main/HUD/PauseMenu",
                 "node_count": 5,
+                "undoable": True,
+            }
+        if command == "control_draw_recipe":
+            ops_list = params.get("ops", []) if params else []
+            return {
+                "path": params.get("path", "") if params else "",
+                "ops_count": len(ops_list),
+                "script_attached": True,
+                "script_replaced": False,
                 "undoable": True,
             }
         if command == "create_theme":
@@ -2942,6 +2952,44 @@ async def test_ui_build_layout_handler_defaults_parent_to_empty():
 
 
 # ---------------------------------------------------------------------------
+# control_draw_recipe handler tests
+# ---------------------------------------------------------------------------
+
+
+async def test_control_draw_recipe_handler_forwards_ops_list():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    ops = [
+        {"draw": "line", "from": [0, 0], "to": [18, 0], "color": "#00eaff", "width": 2},
+        {"draw": "circle", "center": [10, 10], "radius": 3, "color": "red"},
+    ]
+    result = await control_handlers.control_draw_recipe(runtime, path="/Main/HUD/Panel", ops=ops)
+    assert client.calls[-1]["command"] == "control_draw_recipe"
+    assert client.calls[-1]["params"] == {
+        "path": "/Main/HUD/Panel",
+        "ops": ops,
+        "clear_existing": True,
+    }
+    assert result["ops_count"] == 2
+    assert result["undoable"] is True
+
+
+async def test_control_draw_recipe_handler_clear_existing_false():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    await control_handlers.control_draw_recipe(runtime, path="/Foo", ops=[], clear_existing=False)
+    assert client.calls[-1]["params"]["clear_existing"] is False
+
+
+async def test_control_draw_recipe_handler_empty_ops():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await control_handlers.control_draw_recipe(runtime, path="/Foo", ops=[])
+    assert client.calls[-1]["params"]["ops"] == []
+    assert result["ops_count"] == 0
+
+
+# ---------------------------------------------------------------------------
 # Theme handler tests
 # ---------------------------------------------------------------------------
 
@@ -3985,6 +4033,8 @@ async def test_camera_list_handler():
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)
     await camera_handlers.camera_list(runtime)
     assert client.calls[-1]["command"] == "camera_list"
+
+
 # ---------------------------------------------------------------------------
 # Audio handler tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `control_draw_recipe` MCP tool: attach a declarative list of vector `_draw()` ops to any `Control` node — lines, rects, arcs, circles, polylines, polygons, strings
- Introduces `res://addons/godot_ai/runtime/draw_recipe.gd`: a shared `@tool extends Control` script that reads ops from node metadata (`_ops`) and dispatches each to a `CanvasItem` draw call in `_draw()`. No per-node GDScript generated; re-invoking idempotently replaces the op list
- Adds `TYPE_RECT2` coercion to `UiHandler._coerce_for_type` (array, `{x,y,w,h}`, and `{position,size}` dict forms)
- Single Ctrl+Z reverts both script attachment and metadata in one undo step
- Exposes `attach_recipe_to(node, ops)` static helper for use by future pattern handlers (e.g. `pattern_corner_brackets`)

## Test plan

- [ ] 481 Python tests pass (`pytest -v`)
- [ ] 15/15 GDScript tests pass (`test_run suite=control_draw_recipe`) — covers all op types, coercion (Color/Vector2/Rect2/PackedVector2Array), undo/redo round-trips, error paths
- [ ] 39/39 UI suite still passing (regression check after `_add_control` moved to base class)
- [ ] Live smoke test: dark panel + blue circle + cyan corner brackets + text rendered correctly over 3D scene via CanvasLayer

🤖 Generated with [Claude Code](https://claude.com/claude-code)