### PR TITLE
docs: slim README, move tool tables to docs/TOOLS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,9 @@
 [![CI](https://github.com/hi-godot/godot-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/hi-godot/godot-ai/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/hi-godot/godot-ai/graph/badge.svg)](https://codecov.io/gh/hi-godot/godot-ai)
 
-**Connect MCP clients directly to a live Godot editor.** Godot AI bridges AI assistants (Claude Code, Codex, Antigravity, etc.) with your Godot Editor via the [Model Context Protocol](https://modelcontextprotocol.io/introduction).
+**Connect MCP clients directly to a live Godot editor** via the [Model Context Protocol](https://modelcontextprotocol.io/introduction). Over **120 MCP tools** ([full list](docs/TOOLS.md)) let AI assistants (Claude Code, Codex, Antigravity, etc.) build scenes, edit nodes and scripts, wire signals, and configure UI, materials, animations, particles, cameras, and environments.
 
-Over **120 MCP tools** to directly control editor functions: build and edit scenes, create and reparent nodes, set properties, attach and edit scripts and signals. Create and configure polished UI, resources, materials, animations, particles, cameras, and environments.
-
-> 🎉 **Now on the [Godot Asset Library](https://godotengine.org/asset-library/asset/5050)** — one-click install from Godot's **AssetLib** tab. You'll still need [uv](https://docs.astral.sh/uv/) on your system for the Python server (see [Quick Start](#quick-start))
+> 🎉 **Now on the [Godot Asset Library](https://godotengine.org/asset-library/asset/5050)** — one-click install from Godot's **AssetLib** tab. You'll still need [uv](https://docs.astral.sh/uv/) for the Python server (see [Quick Start](#quick-start)).
 <p align="center"><img src="docs/images/assetlib.png" alt="Godot AI on the Godot Asset Library" width="520"></p>
 
 *Independent community project, not affiliated with the [Godot Foundation](https://godot.foundation). Godot Engine is [MIT-licensed](https://godotengine.org/license).*
@@ -23,33 +21,10 @@ Over **120 MCP tools** to directly control editor functions: build and edit scen
 ### Prerequisites
 
 - Godot `4.3+` (`4.4+` recommended)
-- [uv](https://docs.astral.sh/uv/) (used to install the Python server)
-  <details>
-  <summary>Install uv</summary>
-
-  **macOS / Linux:**
-  ```bash
-  curl -LsSf https://astral.sh/uv/install.sh | sh
-  ```
-
-  **Windows (PowerShell):**
-  ```powershell
-  powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
-  ```
-
-  **Homebrew (macOS / Linux):**
-  ```bash
-  brew install uv
-  ```
-
-  **pipx:**
-  ```bash
-  pipx install uv
-  ```
-
-  See the [uv install docs](https://docs.astral.sh/uv/getting-started/installation/) for more options.
-
-  </details>
+- [uv](https://docs.astral.sh/uv/) (for the Python server):
+  - **macOS / Linux:** `curl -LsSf https://astral.sh/uv/install.sh | sh`
+  - **Windows (PowerShell):** `powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"`
+  - Other options: [uv install docs](https://docs.astral.sh/uv/getting-started/installation/)
 - An MCP client ([Claude Code](https://docs.anthropic.com/en/docs/claude-code) | [Codex](https://openai.com/index/codex/) | [Antigravity](https://www.antigravity.dev/))
 
 ### 1. Install the plugin
@@ -111,131 +86,7 @@ snippet.
 
 ---
 
-<details>
-<summary><strong>Available Tools</strong></summary>
-
-### Sessions and Editor
-
-| Tool | Description |
-|------|-------------|
-| `session_list` | List connected Godot editor sessions |
-| `session_activate` | Set the active session for multi-editor routing |
-| `editor_state` | Read Godot version, project name, current scene, and play state |
-| `editor_selection_get` / `editor_selection_set` | Read or set the editor selection |
-| `editor_screenshot` | Capture the editor viewport or a sub-viewport |
-| `editor_reload_plugin` / `editor_quit` | Reload the plugin or quit the editor |
-| `logs_read` / `logs_clear` | Read or clear recent MCP log lines |
-| `performance_monitors_get` | Read Godot performance monitors (FPS, memory, draw calls, etc.) |
-| `batch_execute` | Run multiple plugin commands in one round trip |
-
-### Scene and Nodes
-
-| Tool | Description |
-|------|-------------|
-| `scene_create` / `scene_open` / `scene_save` / `scene_save_as` | Create, open, and save scenes |
-| `scene_get_hierarchy` / `scene_get_roots` | Read the scene tree or list open scenes |
-| `node_create` / `node_delete` / `node_duplicate` | Create, delete, or duplicate nodes |
-| `node_rename` / `node_reparent` / `node_move` | Rename, reparent, or reorder nodes |
-| `node_find` | Search nodes by name, type, or group |
-| `node_get_properties` / `node_set_property` | Read or write node properties |
-| `node_get_children` | Read direct children for a node |
-| `node_add_to_group` / `node_remove_from_group` / `node_get_groups` | Manage group membership |
-
-### Scripts and Signals
-
-| Tool | Description |
-|------|-------------|
-| `script_create` / `script_read` / `script_patch` | Create, read, or patch GDScript files |
-| `script_attach` / `script_detach` | Attach or detach scripts from nodes |
-| `script_find_symbols` | Find class, function, or signal symbols in project scripts |
-| `signal_list` / `signal_connect` / `signal_disconnect` | Inspect and wire up signals |
-
-### Resources, Materials, Textures
-
-| Tool | Description |
-|------|-------------|
-| `resource_create` / `resource_load` / `resource_assign` / `resource_get_info` / `resource_search` | Create, load, assign, and search `.tres` / `.res` resources |
-| `material_create` / `material_list` / `material_get` | Create and inspect materials |
-| `material_assign` / `material_apply_to_node` / `material_apply_preset` | Assign materials and apply named presets |
-| `material_set_param` / `material_set_shader_param` | Set material or shader parameters |
-| `gradient_texture_create` / `noise_texture_create` | Generate gradient or noise textures |
-| `curve_set_points` | Set points on a `Curve` resource |
-
-### UI, Controls, Theme
-
-| Tool | Description |
-|------|-------------|
-| `ui_build_layout` | Build a Control layout tree from a recipe |
-| `ui_set_text` / `ui_set_anchor_preset` | Set Control text or anchor preset |
-| `control_draw_recipe` | Attach a procedural draw recipe script to a Control |
-| `theme_create` / `theme_apply` | Create themes and apply them to Controls |
-| `theme_set_color` / `theme_set_constant` / `theme_set_font_size` / `theme_set_stylebox_flat` | Edit theme entries |
-
-### Animation
-
-| Tool | Description |
-|------|-------------|
-| `animation_player_create` | Create an `AnimationPlayer` node |
-| `animation_create` / `animation_create_simple` / `animation_delete` | Create or delete animations |
-| `animation_list` / `animation_get` / `animation_validate` | Inspect and validate animations |
-| `animation_add_property_track` / `animation_add_method_track` | Add property or method tracks |
-| `animation_play` / `animation_stop` / `animation_set_autoplay` | Playback controls |
-| `animation_preset_fade` / `animation_preset_pulse` / `animation_preset_shake` / `animation_preset_slide` | Named animation presets |
-
-### Audio
-
-| Tool | Description |
-|------|-------------|
-| `audio_player_create` / `audio_list` | Create and list audio players |
-| `audio_play` / `audio_stop` | Control playback |
-| `audio_player_set_stream` / `audio_player_set_playback` | Assign streams and tune playback |
-
-### Particles, Environment, Camera
-
-| Tool | Description |
-|------|-------------|
-| `particle_create` / `particle_get` / `particle_restart` | Create, inspect, restart particle systems |
-| `particle_set_main` / `particle_set_process` / `particle_set_draw_pass` / `particle_apply_preset` | Configure particle nodes |
-| `environment_create` | Create a `WorldEnvironment` with a configured `Environment` |
-| `camera_create` / `camera_list` / `camera_get` | Create and inspect cameras |
-| `camera_configure` / `camera_apply_preset` | Tune camera settings or apply presets |
-| `camera_follow_2d` / `camera_set_limits_2d` / `camera_set_damping_2d` | 2D camera helpers |
-| `physics_shape_autofit` | Auto-fit a collision shape to a mesh |
-
-### Project, Filesystem, Input
-
-| Tool | Description |
-|------|-------------|
-| `project_settings_get` / `project_settings_set` | Read or write Godot project settings |
-| `project_run` / `project_stop` | Run or stop the project from the editor |
-| `autoload_add` / `autoload_remove` / `autoload_list` | Manage autoload singletons |
-| `filesystem_search` / `filesystem_read_text` / `filesystem_write_text` / `filesystem_reimport` | Search, read, write, and reimport project files |
-| `input_map_add_action` / `input_map_remove_action` / `input_map_bind_event` / `input_map_list` | Manage the project input map |
-
-### Testing and Client Setup
-
-| Tool | Description |
-|------|-------------|
-| `test_run` | Run GDScript test suites inside the editor |
-| `test_results_get` | Read the most recent test results without rerunning |
-| `client_configure` / `client_remove` / `client_status` | Configure, remove, or check supported MCP clients |
-
-</details>
-
-<details>
-<summary><strong>MCP Resources</strong></summary>
-
-| Resource URI | Description |
-|-------------|-------------|
-| `godot://sessions` | Connected editor sessions with metadata |
-| `godot://scene/current` | Current scene path, project name, and play state |
-| `godot://scene/hierarchy` | Full scene hierarchy from the active editor |
-| `godot://selection/current` | Current editor selection |
-| `godot://project/info` | Active project metadata |
-| `godot://project/settings` | Common project settings subset |
-| `godot://logs/recent` | Recent editor log lines |
-
-</details>
+**Tools and resources:** see [docs/TOOLS.md](docs/TOOLS.md) for the full list of 120+ MCP tools and resources, grouped by domain.
 
 <details>
 <summary><strong>Manual Client Configuration</strong></summary>

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1,0 +1,121 @@
+# Available Tools
+
+Godot AI exposes 120+ MCP tools. They're grouped below by domain.
+
+## Sessions and Editor
+
+| Tool | Description |
+|------|-------------|
+| `session_list` | List connected Godot editor sessions |
+| `session_activate` | Set the active session for multi-editor routing |
+| `editor_state` | Read Godot version, project name, current scene, and play state |
+| `editor_selection_get` / `editor_selection_set` | Read or set the editor selection |
+| `editor_screenshot` | Capture the editor viewport or a sub-viewport |
+| `editor_reload_plugin` / `editor_quit` | Reload the plugin or quit the editor |
+| `logs_read` / `logs_clear` | Read or clear recent MCP log lines |
+| `performance_monitors_get` | Read Godot performance monitors (FPS, memory, draw calls, etc.) |
+| `batch_execute` | Run multiple plugin commands in one round trip |
+
+## Scene and Nodes
+
+| Tool | Description |
+|------|-------------|
+| `scene_create` / `scene_open` / `scene_save` / `scene_save_as` | Create, open, and save scenes |
+| `scene_get_hierarchy` / `scene_get_roots` | Read the scene tree or list open scenes |
+| `node_create` / `node_delete` / `node_duplicate` | Create, delete, or duplicate nodes |
+| `node_rename` / `node_reparent` / `node_move` | Rename, reparent, or reorder nodes |
+| `node_find` | Search nodes by name, type, or group |
+| `node_get_properties` / `node_set_property` | Read or write node properties |
+| `node_get_children` | Read direct children for a node |
+| `node_add_to_group` / `node_remove_from_group` / `node_get_groups` | Manage group membership |
+
+## Scripts and Signals
+
+| Tool | Description |
+|------|-------------|
+| `script_create` / `script_read` / `script_patch` | Create, read, or patch GDScript files |
+| `script_attach` / `script_detach` | Attach or detach scripts from nodes |
+| `script_find_symbols` | Find class, function, or signal symbols in project scripts |
+| `signal_list` / `signal_connect` / `signal_disconnect` | Inspect and wire up signals |
+
+## Resources, Materials, Textures
+
+| Tool | Description |
+|------|-------------|
+| `resource_create` / `resource_load` / `resource_assign` / `resource_get_info` / `resource_search` | Create, load, assign, and search `.tres` / `.res` resources |
+| `material_create` / `material_list` / `material_get` | Create and inspect materials |
+| `material_assign` / `material_apply_to_node` / `material_apply_preset` | Assign materials and apply named presets |
+| `material_set_param` / `material_set_shader_param` | Set material or shader parameters |
+| `gradient_texture_create` / `noise_texture_create` | Generate gradient or noise textures |
+| `curve_set_points` | Set points on a `Curve` resource |
+
+## UI, Controls, Theme
+
+| Tool | Description |
+|------|-------------|
+| `ui_build_layout` | Build a Control layout tree from a recipe |
+| `ui_set_text` / `ui_set_anchor_preset` | Set Control text or anchor preset |
+| `control_draw_recipe` | Attach a procedural draw recipe script to a Control |
+| `theme_create` / `theme_apply` | Create themes and apply them to Controls |
+| `theme_set_color` / `theme_set_constant` / `theme_set_font_size` / `theme_set_stylebox_flat` | Edit theme entries |
+
+## Animation
+
+| Tool | Description |
+|------|-------------|
+| `animation_player_create` | Create an `AnimationPlayer` node |
+| `animation_create` / `animation_create_simple` / `animation_delete` | Create or delete animations |
+| `animation_list` / `animation_get` / `animation_validate` | Inspect and validate animations |
+| `animation_add_property_track` / `animation_add_method_track` | Add property or method tracks |
+| `animation_play` / `animation_stop` / `animation_set_autoplay` | Playback controls |
+| `animation_preset_fade` / `animation_preset_pulse` / `animation_preset_shake` / `animation_preset_slide` | Named animation presets |
+
+## Audio
+
+| Tool | Description |
+|------|-------------|
+| `audio_player_create` / `audio_list` | Create and list audio players |
+| `audio_play` / `audio_stop` | Control playback |
+| `audio_player_set_stream` / `audio_player_set_playback` | Assign streams and tune playback |
+
+## Particles, Environment, Camera
+
+| Tool | Description |
+|------|-------------|
+| `particle_create` / `particle_get` / `particle_restart` | Create, inspect, restart particle systems |
+| `particle_set_main` / `particle_set_process` / `particle_set_draw_pass` / `particle_apply_preset` | Configure particle nodes |
+| `environment_create` | Create a `WorldEnvironment` with a configured `Environment` |
+| `camera_create` / `camera_list` / `camera_get` | Create and inspect cameras |
+| `camera_configure` / `camera_apply_preset` | Tune camera settings or apply presets |
+| `camera_follow_2d` / `camera_set_limits_2d` / `camera_set_damping_2d` | 2D camera helpers |
+| `physics_shape_autofit` | Auto-fit a collision shape to a mesh |
+
+## Project, Filesystem, Input
+
+| Tool | Description |
+|------|-------------|
+| `project_settings_get` / `project_settings_set` | Read or write Godot project settings |
+| `project_run` / `project_stop` | Run or stop the project from the editor |
+| `autoload_add` / `autoload_remove` / `autoload_list` | Manage autoload singletons |
+| `filesystem_search` / `filesystem_read_text` / `filesystem_write_text` / `filesystem_reimport` | Search, read, write, and reimport project files |
+| `input_map_add_action` / `input_map_remove_action` / `input_map_bind_event` / `input_map_list` | Manage the project input map |
+
+## Testing and Client Setup
+
+| Tool | Description |
+|------|-------------|
+| `test_run` | Run GDScript test suites inside the editor |
+| `test_results_get` | Read the most recent test results without rerunning |
+| `client_configure` / `client_remove` / `client_status` | Configure, remove, or check supported MCP clients |
+
+## MCP Resources
+
+| Resource URI | Description |
+|-------------|-------------|
+| `godot://sessions` | Connected editor sessions with metadata |
+| `godot://scene/current` | Current scene path, project name, and play state |
+| `godot://scene/hierarchy` | Full scene hierarchy from the active editor |
+| `godot://selection/current` | Current editor selection |
+| `godot://project/info` | Active project metadata |
+| `godot://project/settings` | Common project settings subset |
+| `godot://logs/recent` | Recent editor log lines |


### PR DESCRIPTION
Move the ~100-line Available Tools and MCP Resources tables out of the
README into docs/TOOLS.md. Collapse the uv install dropdown to the two
primary one-liners plus a docs link, and tighten the intro paragraph.

README drops from ~300 to ~150 lines while keeping all content one
click away.