### PR TITLE
docs: add Godot Asset Library shields.io badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 [![CI](https://github.com/hi-godot/godot-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/hi-godot/godot-ai/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/hi-godot/godot-ai/graph/badge.svg)](https://codecov.io/gh/hi-godot/godot-ai)
+[![Godot Asset Library](https://img.shields.io/badge/Godot-Asset%20Library-478cbf?logo=godotengine&logoColor=white)](https://godotengine.org/asset-library/asset/5050)
 
 **Connect MCP clients directly to a live Godot editor** via the [Model Context Protocol](https://modelcontextprotocol.io/introduction). Over **120 MCP tools** ([full list](docs/TOOLS.md)) let AI assistants (Claude Code, Codex, Antigravity, etc.) build scenes, edit nodes and scripts, wire signals, and configure UI, materials, animations, particles, cameras, and environments.
 


### PR DESCRIPTION
## Summary
- Adds a third shields.io badge (Godot Asset Library) next to the existing CI and codecov badges
- Links directly to https://godotengine.org/asset-library/asset/5050

Context: this was in the original #59 change set but dropped out during the merge (the callout and image made it in, the badge line did not). Re-adding.

## Test plan
- [x] README renders with three badges in a row: CI, codecov, Godot Asset Library
- [x] Badge links to the asset library page

Generated with [Claude Code](https://claude.com/claude-code)
