### PR TITLE
ci: wrap release zip so AssetLib install lands in addons/

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,11 +61,31 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build plugin ZIP
+        # Wrap in an outer "godot-ai-plugin/" folder so Godot's AssetLib
+        # "Ignore asset root" default (which strips the zip's single top-level
+        # folder) removes the wrapper instead of addons/. A zip whose top
+        # entry is addons/ itself gets addons/ stripped on install, landing
+        # godot_ai/ at res:// outside the plugin path — the plugin never
+        # registers and scripts fail strict-warning parsing outside addons/.
         run: |
-          mkdir -p staging/addons
-          cp -r plugin/addons/godot_ai staging/addons/
+          mkdir -p staging/godot-ai-plugin/addons
+          cp -r plugin/addons/godot_ai staging/godot-ai-plugin/addons/
           cd staging
-          zip -r ../godot-ai-plugin.zip addons/
+          zip -r ../godot-ai-plugin.zip godot-ai-plugin/
+
+      - name: Verify zip structure
+        run: |
+          top=$(unzip -l godot-ai-plugin.zip | awk 'NR>3 && $NF!="" {print $NF}' | awk -F/ '{print $1}' | sort -u)
+          if [ "$top" != "godot-ai-plugin" ]; then
+            echo "ERROR: expected single top-level folder 'godot-ai-plugin/' in zip, got:" >&2
+            echo "$top" >&2
+            exit 1
+          fi
+          if ! unzip -l godot-ai-plugin.zip | grep -q 'godot-ai-plugin/addons/godot_ai/plugin.cfg'; then
+            echo "ERROR: plugin.cfg not at expected path godot-ai-plugin/addons/godot_ai/plugin.cfg" >&2
+            exit 1
+          fi
+          echo "Zip structure verified: godot-ai-plugin/addons/godot_ai/..."
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary
- Fixes golden-path AssetLib install breaking for every user on Godot 4.6.x
- Wraps the release zip in an outer \`godot-ai-plugin/\` folder so Godot's "Ignore asset root" default strips the wrapper instead of \`addons/\`
- Adds a verify step that fails the release job if the zip structure regresses

## Why this matters
Godot's AssetLib install dialog defaults **"Ignore asset root"** to **checked** when the zip has a single top-level folder. The prior zip shape:

\`\`\`
godot-ai-plugin.zip
└── addons/              ← top entry, gets stripped
    └── godot_ai/        ← lands at res://godot_ai/ ❌
\`\`\`

Installed files at \`res://godot_ai/\` (outside the plugin path). Two downstream failures:
1. Godot only scans \`res://addons/*/plugin.cfg\` for plugins — plugin never registers.
2. Godot's default \`debug/gdscript/warnings/exclude_addons=true\` only suppresses warnings for paths **under \`addons/\`**. Outside that, Godot 4.6.x promotes \`inferred_declaration\` warnings to errors, causing parse errors in handler scripts.

Locally installed copies (self-update, manual drops into \`addons/\`) worked because they bypassed AssetLib's install step entirely. AssetLib-installed copies always failed.

## Fix
New zip shape:

\`\`\`
godot-ai-plugin.zip
└── godot-ai-plugin/     ← wrapper, gets stripped by "Ignore asset root"
    └── addons/          ← survives
        └── godot_ai/    ← lands at res://addons/godot_ai/ ✅
\`\`\`

Works correctly in both "Ignore asset root" modes:
- Checked (default) → wrapper stripped → \`res://addons/godot_ai/\`
- Unchecked → full path preserved → \`res://godot-ai-plugin/addons/godot_ai/\` (still under addons/, still valid; user can rename the outer folder if they care)

## Test plan
- [x] Rebuild the zip locally with the new step
- [x] Simulate "Ignore asset root" CHECKED: strip top folder → confirm \`addons/godot_ai/plugin.cfg\` is present
- [x] Verify new \`Verify zip structure\` CI step catches regressions (top folder must be \`godot-ai-plugin\`, \`plugin.cfg\` must be at the expected path)
- [ ] After merge + next release tag, install from GitHub Release zip in a clean Godot 4.6.x project and confirm plugin registers
- [ ] AssetLib resubmission (pending for v1.0.0) will need the new zip — see below about replacing the v1.0.0 asset vs cutting v1.0.1

## Notes
- No GDScript or Python changes — this is strictly a packaging fix
- The existing AssetLib submission at \`v1.0.0\` currently points at the broken zip; after merge we need to either replace the v1.0.0 release asset in place or cut v1.0.1 and update the AssetLib URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)