### PR TITLE
ci: fix zip verify footer parsing in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,13 +75,14 @@ jobs:
 
       - name: Verify zip structure
         run: |
-          top=$(unzip -l godot-ai-plugin.zip | awk 'NR>3 && $NF!="" {print $NF}' | awk -F/ '{print $1}' | sort -u)
+          # unzip -Z1 lists only entry names, one per line, no header/footer
+          top=$(unzip -Z1 godot-ai-plugin.zip | awk -F/ '{print $1}' | sort -u)
           if [ "$top" != "godot-ai-plugin" ]; then
             echo "ERROR: expected single top-level folder 'godot-ai-plugin/' in zip, got:" >&2
             echo "$top" >&2
             exit 1
           fi
-          if ! unzip -l godot-ai-plugin.zip | grep -q 'godot-ai-plugin/addons/godot_ai/plugin.cfg'; then
+          if ! unzip -Z1 godot-ai-plugin.zip | grep -qx 'godot-ai-plugin/addons/godot_ai/plugin.cfg'; then
             echo "ERROR: plugin.cfg not at expected path godot-ai-plugin/addons/godot_ai/plugin.cfg" >&2
             exit 1
           fi


### PR DESCRIPTION
## Summary
Follow-up to #64. The `Verify zip structure` step used `unzip -l | awk 'NR>3'` which also captured the trailing "N files" footer, so the top-level entry check saw three values instead of one and failed on a zip that was actually structured correctly. v1.0.1's release job failed for this reason.

Switches to `unzip -Z1`, which prints only entry names (no header, no footer).

## Impact
- v1.0.1 tag exists and points at the fixed release.yml, but no GitHub Release was produced.
- After this merges I'll re-push the v1.0.1 tag so release.yml runs again and produces the assets.

## Test plan
- [x] Sanity-checked `unzip -Z1 godot-ai-plugin.zip` locally — clean entry list, no header/footer
- [ ] Release workflow succeeds on re-triggered v1.0.1 tag push

Co-Authored-By: Claude Opus 4.7 (1M context)
