### PR TITLE
ci: revert zip wrapping + gitignore iCloud duplicates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,32 +61,41 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build plugin ZIP
-        # Wrap in an outer "godot-ai-plugin/" folder so Godot's AssetLib
-        # "Ignore asset root" default (which strips the zip's single top-level
-        # folder) removes the wrapper instead of addons/. A zip whose top
-        # entry is addons/ itself gets addons/ stripped on install, landing
-        # godot_ai/ at res:// outside the plugin path — the plugin never
-        # registers and scripts fail strict-warning parsing outside addons/.
+        # Keep `addons/` at the zip's top level. Godot's AssetLib install
+        # dialog ("Install from file" or AssetLib download) defaults
+        # "Ignore asset root" to UNCHECKED when the top entry is `addons/`,
+        # so files land at res://addons/godot_ai/ — the canonical plugin
+        # path where Godot's `debug/gdscript/warnings/exclude_addons` does
+        # the right thing.
         run: |
-          mkdir -p staging/godot-ai-plugin/addons
-          cp -r plugin/addons/godot_ai staging/godot-ai-plugin/addons/
+          mkdir -p staging/addons
+          cp -r plugin/addons/godot_ai staging/addons/
           cd staging
-          zip -r ../godot-ai-plugin.zip godot-ai-plugin/
+          zip -r ../godot-ai-plugin.zip addons/
 
       - name: Verify zip structure
         run: |
           # unzip -Z1 lists only entry names, one per line, no header/footer
           top=$(unzip -Z1 godot-ai-plugin.zip | awk -F/ '{print $1}' | sort -u)
-          if [ "$top" != "godot-ai-plugin" ]; then
-            echo "ERROR: expected single top-level folder 'godot-ai-plugin/' in zip, got:" >&2
+          if [ "$top" != "addons" ]; then
+            echo "ERROR: expected single top-level folder 'addons/' in zip, got:" >&2
             echo "$top" >&2
             exit 1
           fi
-          if ! unzip -Z1 godot-ai-plugin.zip | grep -qx 'godot-ai-plugin/addons/godot_ai/plugin.cfg'; then
-            echo "ERROR: plugin.cfg not at expected path godot-ai-plugin/addons/godot_ai/plugin.cfg" >&2
+          if ! unzip -Z1 godot-ai-plugin.zip | grep -qx 'addons/godot_ai/plugin.cfg'; then
+            echo "ERROR: plugin.cfg not at expected path addons/godot_ai/plugin.cfg" >&2
             exit 1
           fi
-          echo "Zip structure verified: godot-ai-plugin/addons/godot_ai/..."
+          # Guard against macOS iCloud-sync duplicates (filenames like `foo 2.gd`)
+          # sneaking in via a contaminated checkout. CI should never hit this
+          # on a fresh actions/checkout, but a manual build from a synced
+          # working tree could. Fail loudly if any are present.
+          if unzip -Z1 godot-ai-plugin.zip | grep -q ' 2\.'; then
+            echo "ERROR: zip contains iCloud-duplicate files (pattern ' 2.'):" >&2
+            unzip -Z1 godot-ai-plugin.zip | grep ' 2\.' >&2
+            exit 1
+          fi
+          echo "Zip structure verified: addons/godot_ai/..."
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,12 @@ export_presets.cfg
 # OS
 .DS_Store
 Thumbs.db
+# macOS iCloud sync duplicate files (e.g. "foo 2.gd", "foo.py 2.uid")
+* 2.gd
+* 2.gd.uid
+* 2.py
+*.gd 2.uid
+*.py 2.uid
 
 # Distribution
 *.dmg


### PR DESCRIPTION
## Summary
Reverts the zip wrapping introduced in #64 and adds `.gitignore` rules for macOS iCloud-sync duplicate files.

## Why revert
Real-world testing showed Godot 4.6.2's "Ignore asset root" default in the "Install from file" dialog is **unchecked** when the zip's top entry is a single folder other than `addons/`. With the wrapped zip:
- Default (unchecked) → files land at `res://godot-ai-plugin/addons/godot_ai/` ❌ — outside `res://addons/`, so `debug/gdscript/warnings/exclude_addons` doesn't apply → every handler script fails to parse on Godot 4.6.2

With `addons/` at the zip top (this revert):
- Default (unchecked) → files land at `res://addons/godot_ai/` ✅ — canonical plugin path, warnings suppressed, plugin registers

Confirmed with a headless Godot 4.6.2 boot against an install simulating the default: 0 parse errors, `MCP | plugin loaded`, `MCP | connected to server`.

## iCloud duplicate guard
A manual zip build from a working tree that has iCloud sync enabled can pull in stale duplicate files like `curve_handler 2.gd` — which collide with the canonical `curve_handler.gd` via duplicate `class_name` declarations, breaking the plugin even when installed at the correct path. Two-part defense:

1. `.gitignore` entries — keep these files out of the repo in the first place.
2. Verify step — fail the release job if any ` 2.` pattern files make it into the zip.

CI-built releases from a fresh `actions/checkout@v4` never hit this, but the v1.0.1 release asset was rebuilt manually during a release-day scramble and did. Asset has since been replaced.

## Test plan
- [x] Built clean zip locally with the reverted recipe
- [x] Headless Godot 4.6.2 load test: 0 parse errors, plugin registers
- [x] Replaced the v1.0.1 GitHub Release asset with the clean-recipe build
- [ ] User retests AssetLib "Install from file" in a fresh project on the re-downloaded zip
