### PR TITLE
ci: ship release zip multi-top-level (addons/ + LICENSE) to disable Ignore-asset-root strip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,29 +61,36 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build plugin ZIP
-        # Keep `addons/` at the zip's top level. Godot's AssetLib install
-        # dialog ("Install from file" or AssetLib download) defaults
-        # "Ignore asset root" to UNCHECKED when the top entry is `addons/`,
-        # so files land at res://addons/godot_ai/ — the canonical plugin
-        # path where Godot's `debug/gdscript/warnings/exclude_addons` does
-        # the right thing.
+        # Ship `addons/` + `LICENSE` at the zip's top level. The multi-top
+        # shape matters: Godot's AssetLib install dialog defaults "Ignore
+        # asset root" to CHECKED whenever it detects a single top-level
+        # folder, which would strip `addons/` and drop `godot_ai/` at
+        # res:// — outside the plugin path and outside the addons-warning
+        # exclusion. With two top-level entries, Godot doesn't offer the
+        # strip option, so files land as-archived at res://addons/godot_ai/
+        # regardless of any user-toggled preference.
         run: |
           mkdir -p staging/addons
           cp -r plugin/addons/godot_ai staging/addons/
+          cp LICENSE staging/
           cd staging
-          zip -r ../godot-ai-plugin.zip addons/
+          zip -r ../godot-ai-plugin.zip addons/ LICENSE
 
       - name: Verify zip structure
         run: |
           # unzip -Z1 lists only entry names, one per line, no header/footer
-          top=$(unzip -Z1 godot-ai-plugin.zip | awk -F/ '{print $1}' | sort -u)
-          if [ "$top" != "addons" ]; then
-            echo "ERROR: expected single top-level folder 'addons/' in zip, got:" >&2
-            echo "$top" >&2
+          tops=$(unzip -Z1 godot-ai-plugin.zip | awk -F/ '{print $1}' | sort -u | tr '\n' ' ' | sed 's/ $//')
+          if [ "$tops" != "LICENSE addons" ]; then
+            echo "ERROR: expected top-level entries 'LICENSE addons' in zip, got:" >&2
+            echo "  $tops" >&2
             exit 1
           fi
           if ! unzip -Z1 godot-ai-plugin.zip | grep -qx 'addons/godot_ai/plugin.cfg'; then
             echo "ERROR: plugin.cfg not at expected path addons/godot_ai/plugin.cfg" >&2
+            exit 1
+          fi
+          if ! unzip -Z1 godot-ai-plugin.zip | grep -qx 'LICENSE'; then
+            echo "ERROR: LICENSE not present at zip root" >&2
             exit 1
           fi
           # Guard against macOS iCloud-sync duplicates (filenames like `foo 2.gd`)
@@ -95,7 +102,7 @@ jobs:
             unzip -Z1 godot-ai-plugin.zip | grep ' 2\.' >&2
             exit 1
           fi
-          echo "Zip structure verified: addons/godot_ai/..."
+          echo "Zip structure verified: addons/godot_ai/... + LICENSE (multi-top)"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary
Ship the plugin zip with `addons/` + `LICENSE` at the top level, instead of a single `addons/` folder.

## Why
Tested today on a clean project against the real AssetLib-download install flow: Godot defaults **"Ignore asset root" to CHECKED** when the zip has a single top-level folder. That behavior strips the top entry. With `addons/` as the only top:
- AssetLib-download flow, default checked → `addons/` stripped → files at `res://godot_ai/` ❌ — outside the plugin path, outside the addons-warning exclusion, plugin fails to load on Godot 4.6.x

With two top-level entries (`addons/` + `LICENSE`), Godot does not offer the strip option, and files install as-archived:
- `res://addons/godot_ai/...` ✅ canonical plugin path
- `res://LICENSE` — harmless, common convention (many AssetLib plugins ship this way)

No matter what users toggle, the path is correct.

This PR codifies the shape in `release.yml` so future tagged releases produce it automatically. The v1.0.1 GitHub Release asset has already been replaced with a hand-built zip matching this shape.

## Note: PR #66 was an intermediate step
#66 reverted my wrapped-zip experiment back to single-top `addons/`. That fixed the "Install from file" default (which I had originally broken) but left the AssetLib-download default-checked case broken. This PR completes the picture.

## Verify-step updates
- Checks for both top-level entries (`LICENSE addons`, alphabetical)
- Confirms `addons/godot_ai/plugin.cfg` and `LICENSE` are both present
- Keeps the ` 2.` iCloud-duplicate guard from #66

## Test plan
- [x] Built the zip locally with the new recipe
- [x] Installed via AssetLib "Import..." in Godot 4.6.2 — expected multi-top behavior
- [ ] Once AssetLib resubmission is approved and serves v1.0.1, test the real AssetLib-download install on a clean project
