### PR TITLE
ci: dispatch release.yml from bump-and-release + skip-existing on PyPI

### DIFF
--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -1,9 +1,8 @@
 name: Bump and Release
 
-# Manually bumps plugin.cfg + pyproject.toml, commits, tags, and pushes.
-# The tag push then fires release.yml, which publishes to PyPI and creates
-# the GitHub release with the plugin ZIP. This workflow's job is purely the
-# version bump + tag.
+# Manually bumps plugin.cfg + pyproject.toml, commits, tags, pushes, and
+# then dispatches release.yml against the new tag — release.yml publishes
+# to PyPI and creates the GitHub Release with the plugin ZIP.
 
 on:
   workflow_dispatch:
@@ -59,5 +58,15 @@ jobs:
           git commit -m "Bump version to ${NEW}"
           git tag "v${NEW}"
           git push origin main --tags
-          # Tag push triggers .github/workflows/release.yml which publishes
-          # to PyPI and creates the GitHub Release with the plugin ZIP.
+
+      - name: Trigger release workflow
+        # The tag push above does NOT fire release.yml on its own — pushes
+        # authenticated by GITHUB_TOKEN are blocked from triggering other
+        # workflows (GitHub anti-loop safeguard). workflow_dispatch is the
+        # documented exception, so dispatch release.yml explicitly against
+        # the new tag ref.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NEW="${{ steps.next.outputs.version }}"
+          gh workflow run release.yml --ref "v${NEW}"

--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -18,6 +18,11 @@ on:
 
 permissions:
   contents: write
+  # actions: write is required so the "Trigger release workflow" step can
+  # call `gh workflow run release.yml` using the default GITHUB_TOKEN —
+  # without it the dispatch API returns "Resource not accessible by
+  # integration".
+  actions: write
 
 jobs:
   bump:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - "v*"
+  # Also dispatchable so bump-and-release.yml can invoke this workflow after
+  # tagging. A tag push authenticated by GITHUB_TOKEN does NOT trigger other
+  # workflows (GitHub anti-loop safeguard), but workflow_dispatch is the
+  # documented exception — it fires regardless of the source token.
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -48,6 +53,12 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # Idempotent re-runs: if this version is already on PyPI (e.g. a
+          # previous run published but a downstream job failed), skip the
+          # upload instead of erroring with "File already exists" — which
+          # would block the build-plugin-zip job that depends on this one.
+          skip-existing: true
 
   # Build the Godot plugin ZIP and attach it to the GitHub Release.
   # Runs after publish-pypi so the Python package is live on PyPI before the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Verify ref is a version tag
+        # Guard against a manual workflow_dispatch on a branch ref (e.g.
+        # `main`), which would otherwise fall through and fail the version
+        # check with a confusing "tag (main) does not match..." message.
+        run: |
+          if [[ ! "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: release.yml must run against a version tag (vX.Y.Z), got: $GITHUB_REF_NAME" >&2
+            echo "If dispatching manually, pick a v* tag in the ref dropdown." >&2
+            exit 1
+          fi
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,8 @@ on:
   push:
     tags:
       - "v*"
-  # Also dispatchable so bump-and-release.yml can invoke this workflow after
-  # tagging. A tag push authenticated by GITHUB_TOKEN does NOT trigger other
-  # workflows (GitHub anti-loop safeguard), but workflow_dispatch is the
-  # documented exception — it fires regardless of the source token.
+  # Dispatched explicitly by bump-and-release.yml — see that workflow's
+  # "Trigger release workflow" step for why the tag push alone isn't enough.
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Two release-workflow fixes bundled together:

* Add `workflow_dispatch` to release.yml and have bump-and-release.yml
  dispatch it via `gh workflow run --ref vX.Y.Z` after tagging. Fixes the
  long-standing issue where the tag push from bump-and-release didn't fire
  release.yml (GITHUB_TOKEN anti-loop safeguard blocks push-triggered
  cascades; workflow_dispatch is the documented exception). Closes #36
  and #69, eliminating the manual delete-and-re-push tag workaround.

* Add `skip-existing: true` to the pypa/gh-action-pypi-publish step so
  a re-triggered release on a tag whose version is already on PyPI no
  longer fails the publish-pypi job and block downstream build-plugin-zip.
  Closes #68.

The push trigger on release.yml is left in place as a backup so manual
tag pushes still publish.

https://claude.ai/code/session_01M7hmqyjNT5nFSw8CYdvQfQ