### PR TITLE
fix: capture real game pixels for editor_screenshot(source="game")

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,118 @@ jobs:
         timeout-minutes: 2
         run: bash script/ci-quit-test
 
+  # Separate job from godot-tests-*: the capture smoke test needs a real
+  # rendering driver (null RenderingDevice in --headless produces empty
+  # framebuffers) and a display server. Linux uses xvfb-run; macOS and
+  # Windows CI runners have a real graphics stack and run the editor
+  # windowed. This job verifies editor_screenshot(source="game") round-
+  # trips real game pixels — see closes #72.
+  game-capture-smoke-linux:
+    name: Game capture smoke / Linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: chickensoft-games/setup-godot@v2
+        with:
+          version: 4.6.2
+          use-dotnet: false
+
+      - name: Install xvfb
+        run: sudo apt-get update && sudo apt-get install -y xvfb
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Start MCP server
+        run: bash script/ci-start-server
+
+      - name: Import project
+        timeout-minutes: 3
+        run: godot --headless --path test_project --import || true
+
+      - name: Start Godot editor with rendering driver
+        run: |
+          xvfb-run -a --server-args="-screen 0 1280x720x24" \
+            godot --rendering-driver opengl3 --path test_project --editor &
+
+      - name: Run capture smoke test
+        timeout-minutes: 5
+        run: python script/ci-game-capture-smoke
+
+  game-capture-smoke-macos:
+    name: Game capture smoke / macOS
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: chickensoft-games/setup-godot@v2
+        with:
+          version: 4.6.2
+          use-dotnet: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Start MCP server
+        run: bash script/ci-start-server
+
+      - name: Import project
+        run: godot --headless --path test_project --import || true
+
+      - name: Start Godot editor
+        run: godot --path test_project --editor &
+
+      - name: Run capture smoke test
+        timeout-minutes: 5
+        run: python script/ci-game-capture-smoke
+
+  game-capture-smoke-windows:
+    name: Game capture smoke / Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: chickensoft-games/setup-godot@v2
+        with:
+          version: 4.6.2
+          use-dotnet: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Start MCP server
+        shell: bash
+        run: bash script/ci-start-server
+
+      - name: Import project
+        shell: bash
+        run: godot --headless --path test_project --import || true
+
+      - name: Start Godot editor
+        shell: bash
+        run: godot --path test_project --editor &
+
+      - name: Run capture smoke test
+        timeout-minutes: 5
+        shell: bash
+        run: python script/ci-game-capture-smoke
+
   godot-tests-macos:
     name: Godot tests / macOS
     runs-on: macos-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,22 @@ when auto-configure can't find a CLI.
 7. Write a description with natural-language keywords a user would search for (e.g. `screenshot`, `keybinding`, `asset`) alongside the Godot term
 8. Add tests: handler unit test, Python integration test, AND GDScript test in `test_project/tests/`
 
+## Deferred responses (tools whose reply flows out-of-band)
+
+The dispatcher runs handlers synchronously and auto-sends one response per command. For work whose reply arrives over a different channel — currently only `editor_screenshot(source="game")`, which waits on Godot's editor-debugger bus to ferry a PNG back from the game process — use the deferred pattern:
+
+- Return `McpDispatcher.DEFERRED_RESPONSE` (a `{"_deferred": true}` sentinel dict). `tick()` skips auto-sending for these. `_call_handler` recognises it alongside `data` / `error` so the sentinel doesn't trip the malformed-result guard.
+- Read the incoming request id from `params["_request_id"]`. The dispatcher injects it on a **duplicated** params dict so the original queued command isn't mutated. Hand it off to whatever async source will produce the reply.
+- When the reply arrives, call `Connection.send_deferred_response(request_id, payload)`. `payload` must carry `data` or `error` in the same shape handlers normally return. The method attaches `request_id`, infers `status`, and pushes the JSON over the WebSocket.
+
+This is the only pattern in the plugin that decouples response from handler-return. Reach for it only when the work can't fit in a frame and the reply genuinely has to flow back later (IPC, remote-debugger queries, multi-frame renders). Everything else should stay synchronous.
+
+## Game-side code: gate on `Engine.is_editor_hint()`, not `OS.has_feature("editor")`
+
+Code shipped as an autoload (e.g. `plugin/addons/godot_ai/runtime/game_helper.gd`) that's intended to run only in the game subprocess must guard on `Engine.is_editor_hint()`. `OS.has_feature("editor")` is a compile-time `TOOLS_ENABLED` check — it returns true in the game subprocess too, because play-in-editor spawns the game with the same editor binary. `is_editor_hint()` is the runtime-context check.
+
+Corollary for the plugin side: when registering a game-side autoload via `add_autoload_singleton`, also call `ProjectSettings.save()` explicitly. `EditorPlugin.add_autoload_singleton` only mutates in-memory settings — the subprocess reads project.godot from disk, so without an explicit save the autoload is missing in the child process. See `plugin.gd::_ensure_game_helper_autoload`.
+
 ## Write tools must be undoable
 
 Every tool that mutates the scene (create, delete, reparent, set_property, etc.) must use `EditorUndoRedoManager`. No exceptions. The pattern:

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -10,7 +10,7 @@ Godot AI exposes 120+ MCP tools. They're grouped below by domain.
 | `session_activate` | Set the active session for multi-editor routing |
 | `editor_state` | Read Godot version, project name, current scene, and play state |
 | `editor_selection_get` / `editor_selection_set` | Read or set the editor selection |
-| `editor_screenshot` | Capture the editor viewport or a sub-viewport |
+| `editor_screenshot` | Capture the 3D editor viewport or the running game's framebuffer. `source="game"` works in every embed / floating / separate-window mode via the debugger-channel bridge (requires the `_mcp_game_helper` autoload, registered automatically when the plugin is enabled) |
 | `editor_reload_plugin` / `editor_quit` | Reload the plugin or quit the editor |
 | `logs_read` / `logs_clear` | Read or clear recent MCP log lines |
 | `performance_monitors_get` | Read Godot performance monitors (FPS, memory, draw calls, etc.) |

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -69,6 +69,10 @@ plugin/addons/godot_ai/
 │   ├── resource_handler.gd
 │   ├── project_handler.gd
 │   └── batch_handler.gd
+├── debugger/
+│   └── mcp_debugger_plugin.gd   ## editor-side debugger-channel bridge
+├── runtime/
+│   └── game_helper.gd           ## autoload that runs inside the game
 ├── state/
 │   ├── session_state.gd
 │   └── log_buffer.gd
@@ -192,6 +196,67 @@ The architecture should treat these as tracked jobs with:
 - explicit partial-failure reporting when the work is composite
 
 `batch.execute` in particular should promise ordered execution and clear per-step results, not fake atomicity.
+
+---
+
+## Game-Process Capture Bridge
+
+The running game is always a separate OS child process — "Embed Game Mode"
+on Windows and Linux (and macOS 4.5+) just reparents the game's window into
+the editor via `SetParent` / `XReparentWindow` / remote-layer. The editor
+never has direct access to the game's framebuffer through its own
+`Viewport`, so anything that needs pixels from the running game has to ask
+the game for them.
+
+The plugin does this over Godot's editor-debugger channel — the same
+channel Godot itself uses for the Remote scene tree, profiler, and
+live-edit — via three cooperating pieces:
+
+- `plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd` — an
+  `EditorDebuggerPlugin` that registers on `_enter_tree`. `_has_capture`
+  claims the `"mcp"` prefix. `_capture` routes the replies that come back
+  from the game: `mcp:hello` (boot beacon), `mcp:screenshot_response`,
+  `mcp:screenshot_error`.
+- `plugin/addons/godot_ai/runtime/game_helper.gd` — an autoload the plugin
+  registers as `_mcp_game_helper` via direct `ProjectSettings.set_setting`
+  + `save()` on `_enter_tree` (the `EditorPlugin.add_autoload_singleton`
+  convenience method only mutates in-memory settings and doesn't persist
+  before Godot spawns the subprocess). The autoload guards on
+  `Engine.is_editor_hint()` so it no-ops inside the editor itself — not
+  `OS.has_feature("editor")`, which is a compile-time `TOOLS_ENABLED`
+  check that returns true in the game subprocess too because it runs the
+  same editor binary.
+- Capture flow: the editor-side plugin waits for the game to beacon
+  `mcp:hello` (proving its `EngineDebugger.register_message_capture("mcp",
+  ...)` has run — Godot silently drops messages to unregistered prefixes),
+  then sends `mcp:take_screenshot`. The game's capture replies with a PNG
+  of `get_tree().root.get_texture().get_image()` as base64. The
+  editor-side plugin pushes the reply back over the MCP WebSocket via
+  `Connection.send_deferred_response` with the original `request_id`.
+
+### Deferred-Response Pattern
+
+The MCP dispatcher runs handlers synchronously and sends one response per
+command. Game capture can't fit that shape: the reply arrives arbitrarily
+later over a different channel. The dispatcher supports this via a
+sentinel:
+
+- Handlers that produce their reply out-of-band return
+  `McpDispatcher.DEFERRED_RESPONSE` (a dict containing `{"_deferred":
+  true}`). `tick()` skips auto-sending for these.
+- The dispatcher threads the incoming `request_id` through `params` under
+  the `"_request_id"` key (on a duplicated params dict — the original
+  queued command is not mutated). Deferred handlers read it and hand it
+  off to whatever async source ultimately produces the reply.
+- When the reply arrives (debugger capture, timeout, etc.), the async
+  source calls `Connection.send_deferred_response(request_id, payload)`,
+  which JSON-serialises with `request_id` attached and ships it over the
+  WebSocket just like a normal response.
+
+This is the only pattern in the plugin today that decouples response from
+handler-return. New tools should only reach for it when the work can't
+fit in a frame and the reply genuinely has to flow back later — think
+IPC, remote-debugger queries, multi-frame renders.
 
 ---
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -104,11 +104,12 @@ If a tool has undo semantics, readiness constraints, or cross-session behavior, 
 
 ## CI Expectations
 
-The CI stack should exercise at least three tiers:
+The CI stack should exercise at least four tiers:
 
 - Python unit and integration tests (3 OS x 2 Python versions)
-- Godot-side editor test suites (3 OS via `chickensoft-games/setup-godot@v2` on GitHub Actions runners)
+- Godot-side editor test suites (3 OS via `chickensoft-games/setup-godot@v2` on GitHub Actions runners) — **headless**; no rendering
 - release-surface smoke, especially install and packaging paths once distribution work is active (3 OS)
+- **pixel-level capture smoke** for tools that cross the editor → game-process boundary (3 OS). The `game-capture-smoke-{linux,macos,windows}` jobs launch Godot with a real rendering driver (`xvfb-run -a ... godot --rendering-driver opengl3` on Linux, windowed on macOS and Windows), play `test_project/capture_smoke.tscn` (four colored quadrants), round-trip `editor_screenshot(source="game")` through the debugger-channel bridge, decode the returned PNG with Pillow, and assert the centre of each quadrant matches the expected color within tolerance. Catches regressions in the `_mcp_game_helper` autoload registration, the `DEFERRED_RESPONSE` dispatcher path, and the `Connection.send_deferred_response` reply pipeline — none of which are exercised by the headless Godot test suite.
 
 ### CI hardening measures
 

--- a/plugin/addons/godot_ai/connection.gd
+++ b/plugin/addons/godot_ai/connection.gd
@@ -126,6 +126,17 @@ func send_event(event_name: String, data: Dictionary = {}) -> void:
 	_send_json({"type": "event", "event": event_name, "data": data})
 
 
+## Push a command response for a request_id whose handler deferred its reply
+## (see McpDispatcher.DEFERRED_RESPONSE). `payload` must carry either a `data`
+## or `error` field in the same shape handlers normally return.
+func send_deferred_response(request_id: String, payload: Dictionary) -> void:
+	var response := payload.duplicate()
+	response["request_id"] = request_id
+	if not response.has("status"):
+		response["status"] = "ok" if payload.has("data") else "error"
+	_send_json(response)
+
+
 func _hook_editor_signals() -> void:
 	# Scene change: poll in _process since there's no direct signal for scene switch
 	# Play state: EditorInterface signals

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -21,11 +21,25 @@ const CAPTURE_PREFIX := "mcp"
 ## register the autoload's capture. 8s keeps the message responsive for
 ## interactive users while still covering slow-CI startup.
 const DEFAULT_TIMEOUT_SEC := 8.0
+## How long to wait for the game-side autoload to beacon mcp:hello
+## before sending the screenshot request. Godot's debugger drops
+## messages whose prefix has no registered capture, so sending
+## take_screenshot before the game registers its "mcp" capture is a
+## silent black hole. On CI the game subprocess has been observed
+## taking ~15s to boot + register.
+const GAME_READY_WAIT_SEC := 20.0
 
 var _log_buffer: McpLogBuffer
 
 ## Pending request_id -> {connection, deadline_ts, timer}
 var _pending: Dictionary = {}
+
+## Flipped true when the game-side autoload sends its "mcp:hello" boot
+## beacon on _ready. Reset when the debugger session drops (game stop).
+## Guards request_game_screenshot so we never send into a debugger
+## channel whose receiving capture hasn't been registered yet.
+var _game_ready := false
+signal game_ready
 
 
 func _init(log_buffer: McpLogBuffer = null) -> void:
@@ -46,9 +60,12 @@ func _capture(message: String, data: Array, _session_id: int) -> bool:
 			_on_screenshot_error(data)
 			return true
 		"mcp:hello":
-			## Unsolicited boot beacon from the game-side autoload so the
-			## editor log buffer can prove the autoload actually loaded
-			## and registered, independent of capture requests.
+			## Boot beacon from the game-side autoload. Tells us the
+			## game has registered its "mcp" capture and is safe to send
+			## take_screenshot to — before this, Godot's debugger would
+			## drop our message silently.
+			_game_ready = true
+			game_ready.emit()
 			if _log_buffer:
 				_log_buffer.log("[debug] <- mcp:hello from game_helper")
 			return true
@@ -69,6 +86,26 @@ func request_game_screenshot(
 		push_warning("MCP debugger: screenshot request missing request_id")
 		return
 
+	var tree := Engine.get_main_loop() as SceneTree
+	if tree == null:
+		_send_error(connection, request_id, McpErrorCodes.INTERNAL_ERROR,
+			"Editor main loop is not a SceneTree — cannot schedule capture")
+		return
+
+	## Wait for the game-side autoload to register its "mcp" capture
+	## before sending. Godot's debugger drops messages whose prefix isn't
+	## registered, so sending early is a silent black hole. On a
+	## well-warmed desktop this returns immediately; on a slow CI runner
+	## it can take 10-20s for the game subprocess to boot.
+	if not _game_ready:
+		if _log_buffer:
+			_log_buffer.log("[debug] waiting for game_helper hello (%s)" % request_id)
+		await _wait_for_game_ready(tree, GAME_READY_WAIT_SEC)
+	if not _game_ready:
+		_send_error(connection, request_id, McpErrorCodes.INTERNAL_ERROR,
+			"Game-side autoload never registered its debugger capture within %ds. Is the game actually running? Check Project Settings → Autoload for _mcp_game_helper." % int(GAME_READY_WAIT_SEC))
+		return
+
 	var session: EditorDebuggerSession = _first_active_session()
 	if session == null:
 		_send_error(connection, request_id, McpErrorCodes.INTERNAL_ERROR,
@@ -76,20 +113,23 @@ func request_game_screenshot(
 		return
 
 	_pending[request_id] = {"connection": connection}
-	## MainLoop has no create_timer — it's a SceneTree method. We're inside
-	## the editor, where the main loop is always a SceneTree, but GDScript's
-	## static typing still needs the cast. `create_timer` doesn't declare a
-	## return type in the engine bindings we see, so type `timer` explicitly
-	## rather than inferring.
-	var tree := Engine.get_main_loop() as SceneTree
-	if tree != null:
-		var timer: SceneTreeTimer = tree.create_timer(timeout_sec)
-		timer.timeout.connect(func() -> void: _on_timeout(request_id))
-		_pending[request_id]["timer"] = timer
+	var timer: SceneTreeTimer = tree.create_timer(timeout_sec)
+	timer.timeout.connect(func() -> void: _on_timeout(request_id))
+	_pending[request_id]["timer"] = timer
 
 	session.send_message("mcp:take_screenshot", [request_id, max_resolution])
 	if _log_buffer:
 		_log_buffer.log("[debug] -> mcp:take_screenshot (%s)" % request_id)
+
+
+## Resolve when either mcp:hello arrives (_game_ready flips true) or
+## `max_wait_sec` elapses. Polls each frame via process_frame rather
+## than a monolithic sleep so the editor stays responsive and timing is
+## tight once the hello lands.
+func _wait_for_game_ready(tree: SceneTree, max_wait_sec: float) -> void:
+	var deadline := Time.get_ticks_msec() + int(max_wait_sec * 1000.0)
+	while not _game_ready and Time.get_ticks_msec() < deadline:
+		await tree.process_frame
 
 
 func _first_active_session() -> EditorDebuggerSession:

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -66,9 +66,16 @@ func request_game_screenshot(
 		return
 
 	_pending[request_id] = {"connection": connection}
-	var timer := Engine.get_main_loop().create_timer(timeout_sec)
-	timer.timeout.connect(func(): _on_timeout(request_id))
-	_pending[request_id]["timer"] = timer
+	## MainLoop has no create_timer — it's a SceneTree method. We're inside
+	## the editor, where the main loop is always a SceneTree, but GDScript's
+	## static typing still needs the cast. `create_timer` doesn't declare a
+	## return type in the engine bindings we see, so type `timer` explicitly
+	## rather than inferring.
+	var tree := Engine.get_main_loop() as SceneTree
+	if tree != null:
+		var timer: SceneTreeTimer = tree.create_timer(timeout_sec)
+		timer.timeout.connect(func() -> void: _on_timeout(request_id))
+		_pending[request_id]["timer"] = timer
 
 	session.send_message("mcp:take_screenshot", [request_id, max_resolution])
 	if _log_buffer:

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -50,6 +50,19 @@ func _has_capture(prefix: String) -> bool:
 	return prefix == CAPTURE_PREFIX
 
 
+## Fires when a debugger session attaches — once for the editor's own
+## self-session at startup, and again each time the user hits Play and a
+## new game subprocess connects. Reset _game_ready so the next capture
+## request waits for the (new) game's mcp:hello beacon before sending,
+## avoiding stale-flag timeouts across Play→Stop→Play cycles.
+##
+## Do NOT log here: add_debugger_plugin() triggers this virtual before
+## plugin.gd's _enter_tree logs "plugin loaded", and ci-reload-test
+## asserts "plugin loaded" is the first line after a plugin reload.
+func _setup_session(_session_id: int) -> void:
+	_game_ready = false
+
+
 func _capture(message: String, data: Array, _session_id: int) -> bool:
 	## Godot passes the full "prefix:tail" string as `message`.
 	match message:
@@ -75,7 +88,10 @@ func _capture(message: String, data: Array, _session_id: int) -> bool:
 ## Request a game-process framebuffer capture over the debugger channel.
 ## Reply is pushed back through `connection` out-of-band because the MCP
 ## dispatcher has already returned a deferred-response marker for this
-## request_id.
+## request_id. Synchronous from the caller's perspective — if the
+## game-side autoload hasn't beaconed yet, the wait + send run as a
+## fire-and-forget coroutine kicked off from here. Structured this way
+## so the call site in EditorHandler stays a plain non-await invocation.
 func request_game_screenshot(
 	request_id: String,
 	max_resolution: int,
@@ -92,20 +108,48 @@ func request_game_screenshot(
 			"Editor main loop is not a SceneTree — cannot schedule capture")
 		return
 
-	## Wait for the game-side autoload to register its "mcp" capture
-	## before sending. Godot's debugger drops messages whose prefix isn't
-	## registered, so sending early is a silent black hole. On a
-	## well-warmed desktop this returns immediately; on a slow CI runner
-	## it can take 10-20s for the game subprocess to boot.
-	if not _game_ready:
-		if _log_buffer:
-			_log_buffer.log("[debug] waiting for game_helper hello (%s)" % request_id)
-		await _wait_for_game_ready(tree, GAME_READY_WAIT_SEC)
+	if _game_ready:
+		_send_take_screenshot(tree, request_id, max_resolution, connection, timeout_sec)
+		return
+
+	## Not ready yet — run the wait-then-send flow as a detached
+	## coroutine. It keeps itself alive via the signal subscription on
+	## tree.process_frame; the caller doesn't need to (and shouldn't)
+	## await this entrypoint.
+	if _log_buffer:
+		_log_buffer.log("[debug] waiting for game_helper hello (%s)" % request_id)
+	_wait_then_send(tree, request_id, max_resolution, connection, timeout_sec)
+
+
+## Coroutine: poll each editor frame until the mcp:hello beacon arrives
+## (flipping _game_ready true) or the deadline elapses. Once resolved,
+## either dispatch the capture or return an actionable timeout error.
+func _wait_then_send(
+	tree: SceneTree,
+	request_id: String,
+	max_resolution: int,
+	connection: Connection,
+	timeout_sec: float,
+) -> void:
+	var deadline := Time.get_ticks_msec() + int(GAME_READY_WAIT_SEC * 1000.0)
+	while not _game_ready and Time.get_ticks_msec() < deadline:
+		await tree.process_frame
 	if not _game_ready:
 		_send_error(connection, request_id, McpErrorCodes.INTERNAL_ERROR,
 			"Game-side autoload never registered its debugger capture within %ds. Is the game actually running? Check Project Settings → Autoload for _mcp_game_helper." % int(GAME_READY_WAIT_SEC))
 		return
+	_send_take_screenshot(tree, request_id, max_resolution, connection, timeout_sec)
 
+
+## Send the mcp:take_screenshot message and arm the reply timeout.
+## Assumes _game_ready is true.
+func _send_take_screenshot(
+	tree: SceneTree,
+	request_id: String,
+	max_resolution: int,
+	connection: Connection,
+	timeout_sec: float,
+) -> void:
 	var session: EditorDebuggerSession = _first_active_session()
 	if session == null:
 		_send_error(connection, request_id, McpErrorCodes.INTERNAL_ERROR,
@@ -120,16 +164,6 @@ func request_game_screenshot(
 	session.send_message("mcp:take_screenshot", [request_id, max_resolution])
 	if _log_buffer:
 		_log_buffer.log("[debug] -> mcp:take_screenshot (%s)" % request_id)
-
-
-## Resolve when either mcp:hello arrives (_game_ready flips true) or
-## `max_wait_sec` elapses. Polls each frame via process_frame rather
-## than a monolithic sleep so the editor stays responsive and timing is
-## tight once the hello lands.
-func _wait_for_game_ready(tree: SceneTree, max_wait_sec: float) -> void:
-	var deadline := Time.get_ticks_msec() + int(max_wait_sec * 1000.0)
-	while not _game_ready and Time.get_ticks_msec() < deadline:
-		await tree.process_frame
 
 
 func _first_active_session() -> EditorDebuggerSession:

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -1,0 +1,152 @@
+@tool
+class_name McpDebuggerPlugin
+extends EditorDebuggerPlugin
+
+## Editor-side half of the game-process capture bridge.
+##
+## The game-side counterpart (`plugin/addons/godot_ai/runtime/game_helper.gd`,
+## registered as autoload `_mcp_game_helper`) listens on EngineDebugger's
+## message channel. This plugin sends "mcp:take_screenshot" requests and
+## routes the replies back through the WebSocket Connection using the
+## request_id the MCP dispatcher threaded through params.
+##
+## Why this exists: the game always runs as a separate OS process. Even
+## "Embed Game Mode" on Windows/Linux (and macOS 4.5+) just reparents the
+## game's window into the editor — the game's framebuffer is never reachable
+## from the editor's Viewport. The debugger channel is the engine's own
+## supported IPC and works identically regardless of embed mode.
+
+const CAPTURE_PREFIX := "mcp"
+const DEFAULT_TIMEOUT_SEC := 3.0
+
+var _log_buffer: McpLogBuffer
+
+## Pending request_id -> {connection, deadline_ts, timer}
+var _pending: Dictionary = {}
+
+
+func _init(log_buffer: McpLogBuffer = null) -> void:
+	_log_buffer = log_buffer
+
+
+func _has_capture(prefix: String) -> bool:
+	return prefix == CAPTURE_PREFIX
+
+
+func _capture(message: String, data: Array, _session_id: int) -> bool:
+	## Godot passes the full "prefix:tail" string as `message`.
+	match message:
+		"mcp:screenshot_response":
+			_on_screenshot_response(data)
+			return true
+		"mcp:screenshot_error":
+			_on_screenshot_error(data)
+			return true
+	return false
+
+
+## Request a game-process framebuffer capture over the debugger channel.
+## Reply is pushed back through `connection` out-of-band because the MCP
+## dispatcher has already returned a deferred-response marker for this
+## request_id.
+func request_game_screenshot(
+	request_id: String,
+	max_resolution: int,
+	connection: Connection,
+	timeout_sec: float = DEFAULT_TIMEOUT_SEC,
+) -> void:
+	if request_id.is_empty():
+		push_warning("MCP debugger: screenshot request missing request_id")
+		return
+
+	var session: EditorDebuggerSession = _first_active_session()
+	if session == null:
+		_send_error(connection, request_id, McpErrorCodes.INTERNAL_ERROR,
+			"No active debugger session — is the game actually running and started from this editor?")
+		return
+
+	_pending[request_id] = {"connection": connection}
+	var timer := Engine.get_main_loop().create_timer(timeout_sec)
+	timer.timeout.connect(func(): _on_timeout(request_id))
+	_pending[request_id]["timer"] = timer
+
+	session.send_message("mcp:take_screenshot", [request_id, max_resolution])
+	if _log_buffer:
+		_log_buffer.log("[debug] -> mcp:take_screenshot (%s)" % request_id)
+
+
+func _first_active_session() -> EditorDebuggerSession:
+	for s in get_sessions():
+		if s is EditorDebuggerSession and s.is_active():
+			return s
+	return null
+
+
+func _on_screenshot_response(data: Array) -> void:
+	if data.size() < 6:
+		push_warning("MCP debugger: malformed screenshot response (expected 6 fields, got %d)" % data.size())
+		return
+	var request_id: String = data[0]
+	var pending = _pending.get(request_id)
+	if pending == null:
+		## Timed out or unknown — silently drop.
+		return
+	_clear_pending(request_id)
+
+	var connection: Connection = pending.connection
+	if connection == null or not is_instance_valid(connection):
+		return
+
+	connection.send_deferred_response(request_id, {
+		"data": {
+			"source": "game",
+			"width": int(data[2]),
+			"height": int(data[3]),
+			"original_width": int(data[4]),
+			"original_height": int(data[5]),
+			"format": "png",
+			"image_base64": data[1],
+		}
+	})
+	if _log_buffer:
+		_log_buffer.log("[debug] <- mcp:screenshot_response (%s)" % request_id)
+
+
+func _on_screenshot_error(data: Array) -> void:
+	if data.size() < 2:
+		return
+	var request_id: String = data[0]
+	var message: String = data[1]
+	var pending = _pending.get(request_id)
+	if pending == null:
+		return
+	_clear_pending(request_id)
+	var connection: Connection = pending.connection
+	if connection == null or not is_instance_valid(connection):
+		return
+	_send_error(connection, request_id, McpErrorCodes.INTERNAL_ERROR, message)
+
+
+func _on_timeout(request_id: String) -> void:
+	var pending = _pending.get(request_id)
+	if pending == null:
+		return
+	_pending.erase(request_id)
+	var connection: Connection = pending.connection
+	if connection == null or not is_instance_valid(connection):
+		return
+	_send_error(connection, request_id, McpErrorCodes.INTERNAL_ERROR,
+		"Game screenshot timed out. The running game must include the _mcp_game_helper autoload (added automatically when the plugin is enabled — check Project Settings → Autoload). If the autoload is missing, re-enable the plugin and relaunch the game. For headless or custom-main-loop builds, use source='viewport' instead.")
+	if _log_buffer:
+		_log_buffer.log("[debug] !! screenshot timeout (%s)" % request_id)
+
+
+func _send_error(connection: Connection, request_id: String, code: String, message: String) -> void:
+	if connection == null or not is_instance_valid(connection):
+		return
+	var err := McpErrorCodes.make(code, message)
+	connection.send_deferred_response(request_id, err)
+
+
+func _clear_pending(request_id: String) -> void:
+	_pending.erase(request_id)

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -17,7 +17,10 @@ extends EditorDebuggerPlugin
 ## supported IPC and works identically regardless of embed mode.
 
 const CAPTURE_PREFIX := "mcp"
-const DEFAULT_TIMEOUT_SEC := 3.0
+## CI runners under xvfb can be slow to spin up the game subprocess and
+## register the autoload's capture. 8s keeps the message responsive for
+## interactive users while still covering slow-CI startup.
+const DEFAULT_TIMEOUT_SEC := 8.0
 
 var _log_buffer: McpLogBuffer
 

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -36,6 +36,15 @@ func _has_capture(prefix: String) -> bool:
 	return prefix == CAPTURE_PREFIX
 
 
+func _setup_session(session_id: int) -> void:
+	## Fires when a game (or remote debugger) attaches. If the CI smoke
+	## test never prints "[debug] session attached" for the capture
+	## request_id's window, the problem is that the game never started a
+	## debug session at all — autoload never ran, or play was rejected.
+	if _log_buffer:
+		_log_buffer.log("[debug] session attached (id=%d)" % session_id)
+
+
 func _capture(message: String, data: Array, _session_id: int) -> bool:
 	## Godot passes the full "prefix:tail" string as `message`.
 	match message:
@@ -44,6 +53,13 @@ func _capture(message: String, data: Array, _session_id: int) -> bool:
 			return true
 		"mcp:screenshot_error":
 			_on_screenshot_error(data)
+			return true
+		"mcp:hello":
+			## Unsolicited boot beacon from the game-side autoload so the
+			## editor log buffer can prove the autoload actually loaded
+			## and registered, independent of capture requests.
+			if _log_buffer:
+				_log_buffer.log("[debug] <- mcp:hello from game_helper")
 			return true
 	return false
 

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -36,15 +36,6 @@ func _has_capture(prefix: String) -> bool:
 	return prefix == CAPTURE_PREFIX
 
 
-func _setup_session(session_id: int) -> void:
-	## Fires when a game (or remote debugger) attaches. If the CI smoke
-	## test never prints "[debug] session attached" for the capture
-	## request_id's window, the problem is that the game never started a
-	## debug session at all — autoload never ran, or play was rejected.
-	if _log_buffer:
-		_log_buffer.log("[debug] session attached (id=%d)" % session_id)
-
-
 func _capture(message: String, data: Array, _session_id: int) -> bool:
 	## Godot passes the full "prefix:tail" string as `message`.
 	match message:

--- a/plugin/addons/godot_ai/dispatcher.gd
+++ b/plugin/addons/godot_ai/dispatcher.gd
@@ -58,6 +58,14 @@ func enqueue(cmd: Dictionary) -> void:
 	_command_queue.append(cmd)
 
 
+## Handlers whose response flows out-of-band (e.g. debugger-channel capture)
+## return this marker so tick() skips auto-sending a response. The handler is
+## responsible for pushing the final response via Connection._send_json when
+## the async operation completes. The request_id is threaded through params
+## under the "_request_id" key so the handler can correlate the response.
+const DEFERRED_RESPONSE := {"_deferred": true}
+
+
 ## Process queued commands within a frame budget (milliseconds).
 ## Returns an array of response dictionaries to send back.
 func tick(budget_ms: float = 4.0) -> Array[Dictionary]:
@@ -68,7 +76,8 @@ func tick(budget_ms: float = 4.0) -> Array[Dictionary]:
 	while idx < _command_queue.size() and (Time.get_ticks_msec() - start) < budget_ms:
 		var cmd: Dictionary = _command_queue[idx]
 		var response := _dispatch(cmd)
-		responses.append(response)
+		if not response.get("_deferred", false):
+			responses.append(response)
 		idx += 1
 
 	if idx > 0:
@@ -81,9 +90,12 @@ func _dispatch(cmd: Dictionary) -> Dictionary:
 	var request_id: String = cmd.get("request_id", "")
 	var command: String = cmd.get("command", "")
 	var params: Dictionary = cmd.get("params", {})
+	## Thread the request_id through for handlers that produce deferred
+	## responses. Handlers not using this field simply ignore it.
+	params["_request_id"] = request_id
 
 	if mcp_logging:
-		_log_buffer.log("[recv] %s(%s)" % [command, JSON.stringify(params)])
+		_log_buffer.log("[recv] %s(%s)" % [command, JSON.stringify(cmd.get("params", {}))])
 
 	var result: Dictionary
 
@@ -91,6 +103,11 @@ func _dispatch(cmd: Dictionary) -> Dictionary:
 		result = _call_handler(command, params)
 	else:
 		result = McpErrorCodes.make(McpErrorCodes.UNKNOWN_COMMAND, "Unknown command: %s" % command)
+
+	if result.get("_deferred", false):
+		if mcp_logging:
+			_log_buffer.log("[defer] %s (request %s)" % [command, request_id])
+		return result
 
 	result["request_id"] = request_id
 	if not result.has("status"):
@@ -112,7 +129,7 @@ func _call_handler(command: String, params: Dictionary) -> Dictionary:
 	## Handlers must return {"data": ...} on success or {"error": ...} on failure.
 	## Anything else (null, empty, missing keys) means the handler crashed
 	## mid-call — GDScript swallows the error and returns an empty dict.
-	if result == null or not (result.has("data") or result.has("error")):
+	if result == null or not (result.has("data") or result.has("error") or result.has("_deferred")):
 		return McpErrorCodes.make(
 			McpErrorCodes.INTERNAL_ERROR,
 			"Handler '%s' returned malformed result (likely crashed — check Godot console)" % command,

--- a/plugin/addons/godot_ai/dispatcher.gd
+++ b/plugin/addons/godot_ai/dispatcher.gd
@@ -89,13 +89,16 @@ func tick(budget_ms: float = 4.0) -> Array[Dictionary]:
 func _dispatch(cmd: Dictionary) -> Dictionary:
 	var request_id: String = cmd.get("request_id", "")
 	var command: String = cmd.get("command", "")
-	var params: Dictionary = cmd.get("params", {})
-	## Thread the request_id through for handlers that produce deferred
-	## responses. Handlers not using this field simply ignore it.
+	var raw_params: Dictionary = cmd.get("params", {})
+	## Duplicate so the internal _request_id key we thread through doesn't
+	## mutate the queued command's params (which is the same dict we're
+	## about to JSON-log below, and which later readers like batch_execute
+	## shouldn't see dispatcher-internal metadata from).
+	var params: Dictionary = raw_params.duplicate()
 	params["_request_id"] = request_id
 
 	if mcp_logging:
-		_log_buffer.log("[recv] %s(%s)" % [command, JSON.stringify(cmd.get("params", {}))])
+		_log_buffer.log("[recv] %s(%s)" % [command, JSON.stringify(raw_params)])
 
 	var result: Dictionary
 

--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -6,11 +6,13 @@ extends RefCounted
 
 var _log_buffer: McpLogBuffer
 var _connection: Connection
+var _debugger_plugin: McpDebuggerPlugin
 
 
-func _init(log_buffer: McpLogBuffer, connection: Connection = null) -> void:
+func _init(log_buffer: McpLogBuffer, connection: Connection = null, debugger_plugin: McpDebuggerPlugin = null) -> void:
 	_log_buffer = log_buffer
 	_connection = connection
+	_debugger_plugin = debugger_plugin
 
 
 func get_editor_state(_params: Dictionary) -> Dictionary:
@@ -128,11 +130,19 @@ func take_screenshot(params: Dictionary) -> Dictionary:
 		"game":
 			if not EditorInterface.is_playing_scene():
 				return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Game is not running — use source='viewport' or start the project first")
-			# The game viewport is the editor window's root viewport, not a SubViewport.
-			# Using the main screen's viewport captures the game view area.
-			viewport = EditorInterface.get_editor_main_screen().get_viewport()
-			if viewport == null:
-				return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "Could not access game viewport")
+			## The game is always a separate OS process (embedded mode just
+			## reparents its window into the editor). Reach the framebuffer
+			## via the debugger channel: the `_mcp_game_helper` autoload
+			## inside the game process replies with a PNG, and
+			## McpDebuggerPlugin pushes the response back through our
+			## WebSocket with the same request_id via Connection.send_deferred_response.
+			if _debugger_plugin == null or _connection == null:
+				return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Debugger bridge unavailable — plugin may not be fully initialised")
+			var request_id: String = params.get("_request_id", "")
+			if request_id.is_empty():
+				return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Missing request_id — cannot correlate deferred response")
+			_debugger_plugin.request_game_screenshot(request_id, max_resolution, _connection)
+			return McpDispatcher.DEFERRED_RESPONSE
 		_:
 			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Invalid source '%s' — use 'viewport' or 'game'" % source)
 

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -217,17 +217,31 @@ func _enable_plugin() -> void:
 
 
 func _disable_plugin() -> void:
-	if ProjectSettings.has_setting("autoload/" + GAME_HELPER_AUTOLOAD_NAME):
-		remove_autoload_singleton(GAME_HELPER_AUTOLOAD_NAME)
+	var key := "autoload/" + GAME_HELPER_AUTOLOAD_NAME
+	if not ProjectSettings.has_setting(key):
+		return
+	ProjectSettings.clear(key)
+	ProjectSettings.save()
 
 
 func _ensure_game_helper_autoload() -> void:
-	## Idempotent: only add if absent. Godot errors if you add an existing
-	## autoload name, and we call this from both _enter_tree (for already-
-	## enabled plugins) and _enable_plugin (for first-time enable).
-	if ProjectSettings.has_setting("autoload/" + GAME_HELPER_AUTOLOAD_NAME):
-		return
-	add_autoload_singleton(GAME_HELPER_AUTOLOAD_NAME, GAME_HELPER_AUTOLOAD_PATH)
+	## Write the autoload directly to ProjectSettings and save immediately.
+	## EditorPlugin.add_autoload_singleton only mutates in-memory settings —
+	## the on-disk project.godot is only persisted when the editor saves
+	## (e.g. on quit). CI spawns the game subprocess before any save fires,
+	## so the child process never sees the autoload and the capture times
+	## out. Mirror AutoloadHandler's pattern: set_setting + save().
+	var key := "autoload/" + GAME_HELPER_AUTOLOAD_NAME
+	var value := "*" + GAME_HELPER_AUTOLOAD_PATH  # "*" prefix = singleton
+	if ProjectSettings.get_setting(key, "") == value:
+		return  ## already registered with the right target
+	ProjectSettings.set_setting(key, value)
+	ProjectSettings.set_initial_value(key, "")
+	ProjectSettings.set_as_basic(key, true)
+	var err := ProjectSettings.save()
+	if err != OK:
+		push_warning("MCP: failed to save project.godot after registering %s autoload (error %d)"
+			% [GAME_HELPER_AUTOLOAD_NAME, err])
 
 
 func _start_server() -> void:

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -1,12 +1,16 @@
 @tool
 extends EditorPlugin
 
+const GAME_HELPER_AUTOLOAD_NAME := "_mcp_game_helper"
+const GAME_HELPER_AUTOLOAD_PATH := "res://addons/godot_ai/runtime/game_helper.gd"
+
 var _connection: Connection
 var _dispatcher: McpDispatcher
 var _log_buffer: McpLogBuffer
 var _dock: McpDock
 var _server_pid := -1
 var _handlers: Array = []  # prevent GC of RefCounted handlers
+var _debugger_plugin: McpDebuggerPlugin
 static var _server_started_this_session := false  # guard against re-entrant spawns
 
 
@@ -19,7 +23,11 @@ func _enter_tree() -> void:
 	_connection = Connection.new()
 	_connection.log_buffer = _log_buffer
 
-	var editor_handler := EditorHandler.new(_log_buffer, _connection)
+	_debugger_plugin = McpDebuggerPlugin.new(_log_buffer)
+	add_debugger_plugin(_debugger_plugin)
+	_ensure_game_helper_autoload()
+
+	var editor_handler := EditorHandler.new(_log_buffer, _connection, _debugger_plugin)
 	var scene_handler := SceneHandler.new(_connection)
 	var node_handler := NodeHandler.new(get_undo_redo())
 	var project_handler := ProjectHandler.new(_connection)
@@ -193,8 +201,33 @@ func _exit_tree() -> void:
 		_connection.disconnect_from_server()
 		_connection.queue_free()
 		_connection = null
+	if _debugger_plugin:
+		remove_debugger_plugin(_debugger_plugin)
+		_debugger_plugin = null
 	_stop_server()
 	print("MCP | plugin unloaded")
+
+
+## Register the game-side autoload on plugin enable. Runs the helper inside
+## the game process so the editor-side debugger plugin can request
+## framebuffer captures over EngineDebugger messages. Removed on
+## _disable_plugin so disabling the plugin leaves project.godot clean.
+func _enable_plugin() -> void:
+	_ensure_game_helper_autoload()
+
+
+func _disable_plugin() -> void:
+	if ProjectSettings.has_setting("autoload/" + GAME_HELPER_AUTOLOAD_NAME):
+		remove_autoload_singleton(GAME_HELPER_AUTOLOAD_NAME)
+
+
+func _ensure_game_helper_autoload() -> void:
+	## Idempotent: only add if absent. Godot errors if you add an existing
+	## autoload name, and we call this from both _enter_tree (for already-
+	## enabled plugins) and _enable_plugin (for first-time enable).
+	if ProjectSettings.has_setting("autoload/" + GAME_HELPER_AUTOLOAD_NAME):
+		return
+	add_autoload_singleton(GAME_HELPER_AUTOLOAD_NAME, GAME_HELPER_AUTOLOAD_PATH)
 
 
 func _start_server() -> void:

--- a/plugin/addons/godot_ai/runtime/game_helper.gd
+++ b/plugin/addons/godot_ai/runtime/game_helper.gd
@@ -23,21 +23,21 @@ var _registered := false
 
 
 func _ready() -> void:
-	## Only run in a game process. Autoloads without @tool shouldn't
-	## instantiate in the editor, but belt-and-braces in case a tool-mode
-	## addon pulls us in.
-	if OS.has_feature("editor"):
+	## Only run in the game process, not in the editor. Use is_editor_hint
+	## — NOT OS.has_feature("editor"), which is a BUILD-config check
+	## (TOOLS_ENABLED) and returns true in the game subprocess too because
+	## the game is spawned with the same editor binary. is_editor_hint is
+	## the runtime-context check: true only inside the editor GUI, false
+	## in play-from-editor. The earlier has_feature check was causing us
+	## to skip registration in the game and time out every capture.
+	if Engine.is_editor_hint():
 		return
-	## Register unconditionally. register_message_capture is safe to call
-	## before the debugger is active — the capture sits until a message
-	## arrives. Don't gate on EngineDebugger.is_active(): at _ready time
-	## the debug-channel handshake may not have completed yet, and if we
-	## skip registration we'll never notice it later.
+	## register_message_capture is safe to call before the debugger
+	## handshake completes; the capture sits until a message arrives.
 	EngineDebugger.register_message_capture(CAPTURE_PREFIX, _on_debug_message)
 	_registered = true
-	## Print is picked up by Godot's remote-stdout forwarder so it shows
-	## up in the editor's Output panel — useful for diagnosing why a
-	## capture request timed out.
+	## Routed to the editor's Output panel via Godot's remote-stdout
+	## forwarder — handy when diagnosing why capture timed out.
 	print("[godot_ai game_helper] registered mcp capture (debugger active=%s)"
 		% EngineDebugger.is_active())
 	## Boot beacon so the editor side can confirm the autoload ran even

--- a/plugin/addons/godot_ai/runtime/game_helper.gd
+++ b/plugin/addons/godot_ai/runtime/game_helper.gd
@@ -23,14 +23,13 @@ var _registered := false
 
 
 func _ready() -> void:
-	if OS.has_feature("editor") == false and not EngineDebugger.is_active():
-		## Non-editor, non-debug export build — nothing to do. The editor
-		## debugger is how the plugin reaches us; without it there's no caller.
-		return
+	## Only run in a game process with an active editor-debugger link. Skip
+	## in-editor (autoloads without @tool shouldn't instantiate in the
+	## editor, but belt-and-braces) and in exported release builds where
+	## the debugger channel doesn't exist.
 	if OS.has_feature("editor"):
-		## We are in the editor context (autoloads run here during plugin
-		## editor instantiation). Stay silent — the editor side of the plugin
-		## does its own handling.
+		return
+	if not EngineDebugger.is_active():
 		return
 	EngineDebugger.register_message_capture(CAPTURE_PREFIX, _on_debug_message)
 	_registered = true

--- a/plugin/addons/godot_ai/runtime/game_helper.gd
+++ b/plugin/addons/godot_ai/runtime/game_helper.gd
@@ -14,8 +14,10 @@ extends Node
 ## This autoload solves that by replying to "mcp:take_screenshot" debug
 ## messages with a PNG of Viewport.get_texture() from inside the game.
 ##
-## No-ops in the editor (OS.has_feature("editor")) and when the debugger
-## channel is inactive (e.g. exported release builds).
+## No-ops in the editor (Engine.is_editor_hint) and silently sits idle
+## when the debugger channel is inactive (e.g. exported release builds)
+## — register_message_capture is safe to call either way, it's
+## send_message that requires an active channel.
 
 const CAPTURE_PREFIX := "mcp"
 

--- a/plugin/addons/godot_ai/runtime/game_helper.gd
+++ b/plugin/addons/godot_ai/runtime/game_helper.gd
@@ -1,0 +1,102 @@
+extends Node
+
+## Godot AI MCP — game-process helper.
+##
+## Registered as an autoload by plugin.gd when the Godot AI plugin is enabled.
+## Runs in the running game process (separate from the editor) so the plugin
+## can request the game's framebuffer over the editor-debugger channel.
+##
+## The editor never has direct access to the game's pixels: even when "Embed
+## Game Mode" is on, the game is still a separate OS child process whose
+## window is reparented into the editor via Win32 SetParent / X11
+## XReparentWindow / macOS remote layer (Godot PR godotengine/godot#99010).
+## So viewport-texture capture on the editor side never contains game pixels.
+## This autoload solves that by replying to "mcp:take_screenshot" debug
+## messages with a PNG of Viewport.get_texture() from inside the game.
+##
+## No-ops in the editor (OS.has_feature("editor")) and when the debugger
+## channel is inactive (e.g. exported release builds).
+
+const CAPTURE_PREFIX := "mcp"
+
+var _registered := false
+
+
+func _ready() -> void:
+	if OS.has_feature("editor") == false and not EngineDebugger.is_active():
+		## Non-editor, non-debug export build — nothing to do. The editor
+		## debugger is how the plugin reaches us; without it there's no caller.
+		return
+	if OS.has_feature("editor"):
+		## We are in the editor context (autoloads run here during plugin
+		## editor instantiation). Stay silent — the editor side of the plugin
+		## does its own handling.
+		return
+	EngineDebugger.register_message_capture(CAPTURE_PREFIX, _on_debug_message)
+	_registered = true
+
+
+func _exit_tree() -> void:
+	if _registered:
+		EngineDebugger.unregister_message_capture(CAPTURE_PREFIX)
+		_registered = false
+
+
+## Dispatched for messages prefixed "mcp:" on the debugger channel.
+## Different Godot versions pass either the tail ("take_screenshot") or the
+## full message ("mcp:take_screenshot") to the capture callable — accept
+## both forms so this works across 4.2/4.3/4.4/4.5.
+func _on_debug_message(message: String, data: Array) -> bool:
+	var action := message.trim_prefix("mcp:")
+	match action:
+		"take_screenshot":
+			_handle_take_screenshot(data)
+			return true
+	return false
+
+
+func _handle_take_screenshot(data: Array) -> void:
+	var request_id: String = data[0] if data.size() > 0 else ""
+	var max_resolution: int = int(data[1]) if data.size() > 1 else 0
+
+	var viewport := get_tree().root
+	if viewport == null:
+		_reply_error(request_id, "No game root viewport available")
+		return
+
+	var texture := viewport.get_texture()
+	if texture == null:
+		_reply_error(request_id, "Root viewport has no texture (headless?)")
+		return
+
+	var image := texture.get_image()
+	if image == null or image.is_empty():
+		_reply_error(request_id, "Captured an empty image from game viewport")
+		return
+
+	var original_width := image.get_width()
+	var original_height := image.get_height()
+
+	if max_resolution > 0:
+		var longest := maxi(original_width, original_height)
+		if longest > max_resolution:
+			var scale := float(max_resolution) / float(longest)
+			var new_w := maxi(1, int(original_width * scale))
+			var new_h := maxi(1, int(original_height * scale))
+			image.resize(new_w, new_h, Image.INTERPOLATE_LANCZOS)
+
+	var png := image.save_png_to_buffer()
+	var b64 := Marshalls.raw_to_base64(png)
+
+	EngineDebugger.send_message("mcp:screenshot_response", [
+		request_id,
+		b64,
+		image.get_width(),
+		image.get_height(),
+		original_width,
+		original_height,
+	])
+
+
+func _reply_error(request_id: String, message: String) -> void:
+	EngineDebugger.send_message("mcp:screenshot_error", [request_id, message])

--- a/plugin/addons/godot_ai/runtime/game_helper.gd
+++ b/plugin/addons/godot_ai/runtime/game_helper.gd
@@ -23,16 +23,27 @@ var _registered := false
 
 
 func _ready() -> void:
-	## Only run in a game process with an active editor-debugger link. Skip
-	## in-editor (autoloads without @tool shouldn't instantiate in the
-	## editor, but belt-and-braces) and in exported release builds where
-	## the debugger channel doesn't exist.
+	## Only run in a game process. Autoloads without @tool shouldn't
+	## instantiate in the editor, but belt-and-braces in case a tool-mode
+	## addon pulls us in.
 	if OS.has_feature("editor"):
 		return
-	if not EngineDebugger.is_active():
-		return
+	## Register unconditionally. register_message_capture is safe to call
+	## before the debugger is active — the capture sits until a message
+	## arrives. Don't gate on EngineDebugger.is_active(): at _ready time
+	## the debug-channel handshake may not have completed yet, and if we
+	## skip registration we'll never notice it later.
 	EngineDebugger.register_message_capture(CAPTURE_PREFIX, _on_debug_message)
 	_registered = true
+	## Print is picked up by Godot's remote-stdout forwarder so it shows
+	## up in the editor's Output panel — useful for diagnosing why a
+	## capture request timed out.
+	print("[godot_ai game_helper] registered mcp capture (debugger active=%s)"
+		% EngineDebugger.is_active())
+	## Boot beacon so the editor side can confirm the autoload ran even
+	## if no screenshot was ever requested.
+	if EngineDebugger.is_active():
+		EngineDebugger.send_message("mcp:hello", [])
 
 
 func _exit_tree() -> void:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ dev = [
     "pytest-asyncio>=0.24",
     "pytest-cov>=6.0",
     "ruff>=0.8",
+    # Used by script/ci-game-capture-smoke to decode PNG frames from the
+    # running game and assert the expected colored quadrants are present.
+    "pillow>=10.0",
 ]
 build = [
     "pyinstaller>=6.0",

--- a/script/ci-game-capture-smoke
+++ b/script/ci-game-capture-smoke
@@ -165,10 +165,55 @@ def _within_tolerance(a: tuple[int, int, int], b: tuple[int, int, int]) -> bool:
     return all(abs(x - y) <= COLOR_TOLERANCE for x, y in zip(a, b))
 
 
+def _dump_diagnostics(session_id: str) -> None:
+    """On failure, print everything that could explain what happened."""
+    try:
+        autoloads = _tool_call(session_id, "autoload_list", {}, 900)
+        print("\n[diag] autoloads:", json.dumps(autoloads, indent=2))
+    except Exception as exc:
+        print(f"[diag] autoload_list failed: {exc}")
+    try:
+        ## project.godot on disk — did ProjectSettings.save() actually persist
+        ## the autoload entry before the subprocess spawned?
+        proj = _tool_call(
+            session_id,
+            "filesystem_read_text",
+            {"path": "res://project.godot"},
+            901,
+        )
+        text = proj.get("content", "")
+        in_autoload = False
+        lines_out: list[str] = []
+        for line in text.splitlines():
+            if line.startswith("[autoload]"):
+                in_autoload = True
+            elif line.startswith("[") and in_autoload:
+                in_autoload = False
+            if in_autoload:
+                lines_out.append(line)
+        print("[diag] project.godot [autoload] section:")
+        for line in lines_out or ["  (section missing)"]:
+            print(f"    {line}")
+    except Exception as exc:
+        print(f"[diag] filesystem_read_file failed: {exc}")
+    try:
+        logs = _tool_call(session_id, "logs_read", {"count": 50}, 902)
+        print("[diag] recent plugin logs:")
+        for line in logs.get("lines", []):
+            print(f"    {line}")
+    except Exception as exc:
+        print(f"[diag] logs_read failed: {exc}")
+
+
 def main() -> int:
     print(f"Connecting to MCP server at {SERVER_URL}")
     session_id = _initialize_session()
     _wait_for_godot_session(session_id)
+
+    ## Dump autoload state BEFORE we touch the game — tells us whether the
+    ## plugin's _enter_tree actually persisted _mcp_game_helper, which is the
+    ## hinge for the whole capture path.
+    _dump_diagnostics(session_id)
 
     print(f"Opening {SCENE_PATH}")
     _tool_call(session_id, "scene_open", {"path": SCENE_PATH}, 10)
@@ -179,8 +224,10 @@ def main() -> int:
 
     try:
         _wait_for_is_playing(session_id)
-        ## Let the game render a few frames before capturing.
-        time.sleep(1.5)
+        ## Give the game subprocess time to register its EngineDebugger
+        ## capture after main-loop startup. On CI this can take noticeably
+        ## longer than interactive use, so be generous here.
+        time.sleep(4.0)
 
         print("Capturing source='game'")
         ## Fetch metadata (include_image=False) first: this is the easiest
@@ -251,6 +298,10 @@ def main() -> int:
 
         print("\nCapture smoke test PASSED")
         return 0
+    except Exception:
+        print("\nCapture smoke test raised — dumping diagnostics:", file=sys.stderr)
+        _dump_diagnostics(session_id)
+        raise
     finally:
         try:
             _tool_call(session_id, "project_stop", {}, 999, timeout=10)

--- a/script/ci-game-capture-smoke
+++ b/script/ci-game-capture-smoke
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""
+End-to-end smoke test for editor_screenshot(source="game").
+
+Drives a running Godot editor (launched separately by CI with a real
+rendering driver, typically under xvfb-run on Linux) through the MCP
+streamable-HTTP transport:
+
+  1. wait for the plugin's WebSocket session to register
+  2. open res://capture_smoke.tscn (four colored quadrants)
+  3. run the project in that scene
+  4. poll editor_state until is_playing=true, then settle for a beat
+  5. call editor_screenshot(source="game")
+  6. decode the returned PNG, sample the centre of each quadrant
+  7. assert each sample matches red / green / blue / white within tolerance
+  8. stop the project
+
+Exits non-zero on any failure — each assertion prints a diagnostic line so
+CI logs show exactly which quadrant drifted.
+
+The core capture path is independent of Godot's render backend, but only
+returns game pixels when Godot can actually rasterise — on a headless
+runner the RenderingDevice is null and get_texture().get_image() is empty.
+CI must launch Godot with a rendering driver (opengl3 is the most
+forgiving on xvfb).
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+from PIL import Image
+
+SERVER_URL = os.environ.get("MCP_SERVER_URL", "http://127.0.0.1:8000/mcp")
+HEADERS = {
+    "Content-Type": "application/json",
+    "Accept": "application/json, text/event-stream",
+}
+
+SCENE_PATH = "res://capture_smoke.tscn"
+## (label, sample fraction x, sample fraction y, expected RGB)
+QUADRANTS = [
+    ("red", 0.25, 0.25, (255, 0, 0)),
+    ("green", 0.75, 0.25, (0, 255, 0)),
+    ("blue", 0.25, 0.75, (0, 0, 255)),
+    ("white", 0.75, 0.75, (255, 255, 255)),
+]
+## Generous tolerance: default Godot 2D rendering is gamma-correct and the
+## "pure red/green/blue" ColorRects come back as slightly darkened sRGB after
+## the framebuffer's linear → sRGB conversion. 40/255 easily covers that
+## while still catching "returned editor UI instead of game pixels".
+COLOR_TOLERANCE = 40
+
+
+def _post(session_id: str | None, body: dict, timeout: float = 10.0) -> dict:
+    headers = dict(HEADERS)
+    if session_id:
+        headers["Mcp-Session-Id"] = session_id
+    req = urllib.request.Request(
+        SERVER_URL,
+        data=json.dumps(body).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        raw = resp.read().decode("utf-8")
+        new_session = resp.headers.get("mcp-session-id")
+    result = {"_session_id": new_session, "_raw": raw}
+    for line in raw.splitlines():
+        if line.startswith("data: "):
+            result.update(json.loads(line[6:]))
+            break
+    else:
+        try:
+            result.update(json.loads(raw))
+        except json.JSONDecodeError:
+            pass
+    return result
+
+
+def _tool_call(
+    session_id: str,
+    name: str,
+    args: dict,
+    request_id: int,
+    timeout: float = 30.0,
+) -> dict:
+    body = {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": "tools/call",
+        "params": {"name": name, "arguments": args},
+    }
+    resp = _post(session_id, body, timeout=timeout)
+    ## Prefer structuredContent; fall back to the text block the transport
+    ## wraps around dict/list results.
+    result = resp.get("result", {})
+    sc = result.get("structuredContent")
+    if sc:
+        return sc
+    content = result.get("content") or []
+    for block in content:
+        if block.get("type") == "text":
+            try:
+                return json.loads(block["text"])
+            except json.JSONDecodeError:
+                return {"_text": block["text"]}
+    return {"_raw": resp.get("_raw", "")}
+
+
+def _initialize_session() -> str:
+    body = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-03-26",
+            "capabilities": {},
+            "clientInfo": {"name": "ci-game-capture-smoke", "version": "1.0"},
+        },
+    }
+    resp = _post(None, body)
+    session_id = resp.get("_session_id")
+    if not session_id:
+        raw = resp.get("_raw", "")[:300]
+        raise RuntimeError(f"No Mcp-Session-Id in initialize response: {raw}")
+    _post(session_id, {"jsonrpc": "2.0", "method": "notifications/initialized"})
+    return session_id
+
+
+def _wait_for_godot_session(session_id: str, timeout: float = 120.0) -> None:
+    deadline = time.monotonic() + timeout
+    last_err: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            result = _tool_call(session_id, "session_list", {}, 2)
+            if result.get("count", 0) > 0:
+                print(f"Godot session connected: {result.get('active_session_id') or result}")
+                return
+        except (urllib.error.URLError, RuntimeError) as exc:
+            last_err = exc
+        time.sleep(2)
+    raise RuntimeError(f"Godot session never registered; last err: {last_err}")
+
+
+def _wait_for_is_playing(session_id: str, timeout: float = 30.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        state = _tool_call(session_id, "editor_state", {}, 100)
+        if state.get("is_playing"):
+            print(f"Project is playing (readiness={state.get('readiness')})")
+            return
+        time.sleep(0.5)
+    raise RuntimeError("Project never reached is_playing=true")
+
+
+def _within_tolerance(a: tuple[int, int, int], b: tuple[int, int, int]) -> bool:
+    return all(abs(x - y) <= COLOR_TOLERANCE for x, y in zip(a, b))
+
+
+def main() -> int:
+    print(f"Connecting to MCP server at {SERVER_URL}")
+    session_id = _initialize_session()
+    _wait_for_godot_session(session_id)
+
+    print(f"Opening {SCENE_PATH}")
+    _tool_call(session_id, "scene_open", {"path": SCENE_PATH}, 10)
+    time.sleep(1)
+
+    print("Running project (current scene)")
+    _tool_call(session_id, "project_run", {"mode": "current"}, 11, timeout=20)
+
+    try:
+        _wait_for_is_playing(session_id)
+        ## Let the game render a few frames before capturing.
+        time.sleep(1.5)
+
+        print("Capturing source='game'")
+        ## Fetch metadata (include_image=False) first: this is the easiest
+        ## way to assert the capture actually succeeded on the plugin side.
+        meta = _tool_call(
+            session_id,
+            "editor_screenshot",
+            {"source": "game", "include_image": False, "max_resolution": 0},
+            13,
+            timeout=20,
+        )
+        if "source" in meta and meta["source"] != "game":
+            raise RuntimeError(f"Metadata source mismatch: {meta}")
+        if meta.get("error"):
+            raise RuntimeError(f"editor_screenshot returned error: {meta}")
+
+        ## For the image bytes, go back to the raw server response for the
+        ## include_image=True call: the transport puts an image content
+        ## block alongside the text block, base64-encoded.
+        body = {
+            "jsonrpc": "2.0",
+            "id": 14,
+            "method": "tools/call",
+            "params": {
+                "name": "editor_screenshot",
+                "arguments": {"source": "game", "include_image": True, "max_resolution": 0},
+            },
+        }
+        resp = _post(session_id, body, timeout=20)
+        raw = resp.get("_raw", "")
+        image_b64: str | None = None
+        for line in raw.splitlines():
+            if not line.startswith("data: "):
+                continue
+            data = json.loads(line[6:])
+            for block in data.get("result", {}).get("content", []):
+                if block.get("type") == "image" and block.get("mimeType", "").startswith("image/"):
+                    image_b64 = block.get("data")
+                    break
+            if image_b64:
+                break
+        if not image_b64:
+            raise RuntimeError(f"No image block in response. Raw: {raw[:500]}")
+
+        png = base64.b64decode(image_b64)
+        img = Image.open(io.BytesIO(png)).convert("RGB")
+        print(f"Got PNG {img.width}x{img.height} ({len(png)} bytes)")
+
+        if img.width < 64 or img.height < 64:
+            raise RuntimeError(f"Image too small to sample: {img.width}x{img.height}")
+
+        failures: list[str] = []
+        for label, fx, fy, expected in QUADRANTS:
+            x = int(img.width * fx)
+            y = int(img.height * fy)
+            actual = img.getpixel((x, y))
+            match = _within_tolerance(actual, expected)
+            symbol = "OK" if match else "FAIL"
+            print(f"  [{symbol}] {label:>6} @ ({x}, {y}): got {actual}, expected ~{expected}")
+            if not match:
+                failures.append(f"{label} at ({x}, {y}): got {actual}, expected {expected}")
+
+        if failures:
+            print("\nCapture smoke test FAILED:")
+            for f in failures:
+                print(f"  - {f}")
+            return 1
+
+        print("\nCapture smoke test PASSED")
+        return 0
+    finally:
+        try:
+            _tool_call(session_id, "project_stop", {}, 999, timeout=10)
+        except Exception as exc:
+            print(f"(cleanup) project_stop failed: {exc}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/godot_ai/tools/editor.py
+++ b/src/godot_ai/tools/editor.py
@@ -77,7 +77,14 @@ def register_editor_tools(mcp: FastMCP) -> None:
 
         Sources:
         - "viewport": Captures the 3D editor viewport (default).
-        - "game": Captures the game viewport (only available when the project is running).
+        - "game": Captures the running game's own framebuffer (only available
+          when the project is running). Works regardless of whether Game
+          Embed Mode is on or off, and regardless of whether the game
+          workspace is docked or floating — the game is always a separate
+          OS process, and the plugin reaches it via Godot's debugger
+          channel (the same channel the profiler and remote scene tree
+          use). Requires the `_mcp_game_helper` autoload, which the plugin
+          registers automatically when it's enabled.
 
         When include_image is True (default), returns the image as an MCP
         ImageContent block that vision-capable AI models can analyze directly.

--- a/test_project/capture_smoke.tscn
+++ b/test_project/capture_smoke.tscn
@@ -1,0 +1,36 @@
+[gd_scene format=3 uid="uid://c4pturem0k3"]
+
+; CI game-capture smoke-test scene.
+;
+; Four solid-color quadrants fill the game window so script/ci-game-capture-smoke
+; can sample the centre of each quadrant and assert that editor_screenshot
+; (source="game") actually returned the game's framebuffer and not the editor
+; UI. Do not edit the colors or layout without updating that script.
+
+[node name="Root" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="Red" type="ColorRect" parent="."]
+anchor_right = 0.5
+anchor_bottom = 0.5
+color = Color(1, 0, 0, 1)
+
+[node name="Green" type="ColorRect" parent="."]
+anchor_left = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+color = Color(0, 1, 0, 1)
+
+[node name="Blue" type="ColorRect" parent="."]
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 1.0
+color = Color(0, 0, 1, 1)
+
+[node name="White" type="ColorRect" parent="."]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 1.0
+color = Color(1, 1, 1, 1)

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -100,6 +100,25 @@ func test_screenshot_game_not_playing() -> void:
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 
 
+func test_debugger_plugin_capture_prefix() -> void:
+	var plugin := McpDebuggerPlugin.new()
+	assert_true(plugin._has_capture("mcp"), "Should accept 'mcp' prefix")
+	assert_true(not plugin._has_capture("foo"), "Should reject other prefixes")
+
+
+func test_debugger_plugin_ignores_unknown_messages() -> void:
+	var plugin := McpDebuggerPlugin.new()
+	assert_true(not plugin._capture("mcp:not_a_real_message", [], 0), "Unknown mcp message returns false")
+
+
+func test_debugger_plugin_screenshot_error_unknown_request() -> void:
+	## _on_screenshot_error for an unknown request_id must silently drop
+	## (the request already timed out or was reaped) without crashing.
+	var plugin := McpDebuggerPlugin.new()
+	plugin._on_screenshot_error(["unknown-id", "whatever"])
+	assert_true(true, "No crash when replying to unknown request_id")
+
+
 func test_screenshot_view_target_not_found() -> void:
 	var result := _handler.take_screenshot({"source": "viewport", "view_target": "/Main/NonExistent"})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)


### PR DESCRIPTION
editor_screenshot(source="game") was capturing the editor's main-screen
viewport instead of the running game. That only ever accidentally worked
when the game's reparented window happened to cover the right region —
on macOS separate-window play (the default before 4.5), it silently
returned editor UI.

Root cause: the game is always a separate OS process. "Embed Game Mode"
just reparents its window into the editor (Win32 SetParent, X11
XReparentWindow, macOS remote layer) — the framebuffer is never
reachable from the editor's Viewport.

Fix: reach the game's framebuffer over Godot's editor-debugger channel,
which the engine already uses for the remote scene tree and profiler.

- plugin/addons/godot_ai/runtime/game_helper.gd: autoload in the game
  process that registers an EngineDebugger "mcp" capture and replies to
  "mcp:take_screenshot" with a PNG of get_tree().root.get_texture().
- plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd: editor-side
  EditorDebuggerPlugin that sends the request and routes the reply back
  through the MCP WebSocket using the original request_id.
- plugin/addons/godot_ai/dispatcher.gd: add DEFERRED_RESPONSE sentinel
  so handlers can defer their reply and push it later via the new
  Connection.send_deferred_response.
- plugin.gd: add_debugger_plugin in _enter_tree, add_autoload_singleton
  on _enable_plugin (idempotent), clean up on disable/unload.
- editor_handler.gd: source="game" now goes through the debugger bridge
  instead of EditorInterface.get_editor_main_screen().get_viewport().

Works identically whether the game is embedded, floating, or in its own
OS window, on macOS, Linux, and Windows. Times out with an actionable
remediation message if the _mcp_game_helper autoload is missing.

Closes #72

https://claude.ai/code/session_015de8g1azxFGGyU9CfvAsbv