### PR TITLE
fix: parent_path /root/ alias + suite_setup bailout API

### DIFF
--- a/plugin/addons/godot_ai/handlers/animation_handler.gd
+++ b/plugin/addons/godot_ai/handlers/animation_handler.gd
@@ -51,7 +51,7 @@ func create_player(params: Dictionary) -> Dictionary:
 	if not parent_path.is_empty():
 		parent = ScenePath.resolve(parent_path, scene_root)
 		if parent == null:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Parent not found: %s" % parent_path)
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_parent_error(parent_path, scene_root))
 
 	var player := AnimationPlayer.new()
 	if not node_name.is_empty():

--- a/plugin/addons/godot_ai/handlers/audio_handler.gd
+++ b/plugin/addons/godot_ai/handlers/audio_handler.gd
@@ -59,7 +59,7 @@ func create_player(params: Dictionary) -> Dictionary:
 	if not parent_path.is_empty():
 		parent = ScenePath.resolve(parent_path, scene_root)
 		if parent == null:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Parent not found: %s" % parent_path)
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_parent_error(parent_path, scene_root))
 
 	var node := _instantiate_player(type_str)
 	if node == null:

--- a/plugin/addons/godot_ai/handlers/camera_handler.gd
+++ b/plugin/addons/godot_ai/handlers/camera_handler.gd
@@ -113,7 +113,7 @@ func create_camera(params: Dictionary) -> Dictionary:
 	if not parent_path.is_empty():
 		parent = ScenePath.resolve(parent_path, scene_root)
 		if parent == null:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Parent not found: %s" % parent_path)
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_parent_error(parent_path, scene_root))
 
 	var node := _instantiate_camera(type_str)
 	if node == null:
@@ -604,7 +604,7 @@ func apply_preset(params: Dictionary) -> Dictionary:
 	if not parent_path.is_empty():
 		parent = ScenePath.resolve(parent_path, scene_root)
 		if parent == null:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Parent not found: %s" % parent_path)
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_parent_error(parent_path, scene_root))
 
 	var node := _instantiate_camera(type_str)
 	node.name = node_name

--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -25,7 +25,7 @@ func create_node(params: Dictionary) -> Dictionary:
 	if not parent_path.is_empty():
 		parent = ScenePath.resolve(parent_path, scene_root)
 		if parent == null:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Parent not found: %s" % parent_path)
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_parent_error(parent_path, scene_root))
 
 	var new_node: Node
 
@@ -123,7 +123,7 @@ func reparent_node(params: Dictionary) -> Dictionary:
 
 	var new_parent := ScenePath.resolve(new_parent_path, scene_root)
 	if new_parent == null:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Parent not found: %s" % new_parent_path)
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_parent_error(new_parent_path, scene_root))
 
 	if node == scene_root:
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Cannot reparent the scene root")

--- a/plugin/addons/godot_ai/handlers/particle_handler.gd
+++ b/plugin/addons/godot_ai/handlers/particle_handler.gd
@@ -61,7 +61,7 @@ func create_particle(params: Dictionary) -> Dictionary:
 	if not parent_path.is_empty():
 		parent = ScenePath.resolve(parent_path, scene_root)
 		if parent == null:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Parent not found: %s" % parent_path)
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_parent_error(parent_path, scene_root))
 
 	var node := _instantiate_particle(type_str)
 	if node == null:
@@ -595,7 +595,7 @@ func apply_preset(params: Dictionary) -> Dictionary:
 	if not parent_path.is_empty():
 		parent = ScenePath.resolve(parent_path, scene_root)
 		if parent == null:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Parent not found: %s" % parent_path)
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_parent_error(parent_path, scene_root))
 
 	var node := _instantiate_particle(type_str)
 	node.name = node_name

--- a/plugin/addons/godot_ai/handlers/ui_handler.gd
+++ b/plugin/addons/godot_ai/handlers/ui_handler.gd
@@ -233,7 +233,7 @@ func build_layout(params: Dictionary) -> Dictionary:
 	if not parent_path.is_empty() and parent_path != "/":
 		parent = ScenePath.resolve(parent_path, scene_root)
 		if parent == null:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Parent not found: %s" % parent_path)
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_parent_error(parent_path, scene_root))
 
 	# Validate + build in memory first; if anything fails, free and bail.
 	var built := _build_subtree(tree)

--- a/plugin/addons/godot_ai/testing/test_runner.gd
+++ b/plugin/addons/godot_ai/testing/test_runner.gd
@@ -74,8 +74,31 @@ func run_suites(suites: Array, suite_filter: String = "", test_filter: String = 
 		if scene_root != null:
 			before_children = _get_children_snapshot(scene_root)
 
+		suite._reset_suite_state()
 		suite.suite_setup(ctx.duplicate(true))
-		run_suite(suite, test_filter)
+
+		## fail_setup() / skip_suite() gives suites a clean way to bail out of
+		## suite_setup without leaving N tests to fail with "0 assertions". We
+		## emit ONE suite-level result and skip individual tests entirely.
+		if suite._suite_failed:
+			_results.append({
+				"suite": suite.suite_name(),
+				"test": "<suite_setup>",
+				"passed": false,
+				"message": "suite_setup() failed: %s (subsequent tests not run)" % suite._suite_failed_message,
+				"assertion_count": 0,
+			})
+		elif suite._suite_skipped:
+			_results.append({
+				"suite": suite.suite_name(),
+				"test": "<suite_setup>",
+				"passed": true,
+				"skipped": true,
+				"message": "suite_setup() skipped: %s" % suite._suite_skipped_reason,
+				"assertion_count": 0,
+			})
+		else:
+			run_suite(suite, test_filter)
 		suite.suite_teardown()
 
 		## Remove any nodes the suite left behind (failed undo, missing cleanup).

--- a/plugin/addons/godot_ai/testing/test_suite.gd
+++ b/plugin/addons/godot_ai/testing/test_suite.gd
@@ -39,6 +39,13 @@ var _assertion_count: int = 0
 var _skipped: bool = false
 var _skip_reason: String = ""
 
+# ----- suite-level state (managed by McpTestRunner) -----
+
+var _suite_failed: bool = false
+var _suite_failed_message: String = ""
+var _suite_skipped: bool = false
+var _suite_skipped_reason: String = ""
+
 
 func _reset() -> void:
 	_failed = false
@@ -48,12 +55,42 @@ func _reset() -> void:
 	_skip_reason = ""
 
 
+func _reset_suite_state() -> void:
+	_suite_failed = false
+	_suite_failed_message = ""
+	_suite_skipped = false
+	_suite_skipped_reason = ""
+
+
 ## Mark the current test as skipped. Use when a precondition isn't met
 ## (e.g. no scene open, no Node3D in scene) and the test can't run.
 ## Skipped tests count separately from passed/failed.
 func skip(reason: String = "") -> void:
 	_skipped = true
 	_skip_reason = reason
+
+
+## Bail out of suite_setup() with a failure. Subsequent tests in this suite
+## are not run; the runner reports a single suite-level failure with the
+## given reason instead of N zero-assertion noise lines per test.
+##
+## Example:
+##     func suite_setup(ctx):
+##         var arena = preload("res://game/arena.gd").new()
+##         if arena == null:
+##             fail_setup("arena.gd failed to instantiate in @tool scope")
+##             return
+func fail_setup(reason: String) -> void:
+	_suite_failed = true
+	_suite_failed_message = reason
+
+
+## Bail out of suite_setup() because a precondition isn't met (no scene open,
+## no game running, etc.). Subsequent tests are not run and the runner emits
+## a single suite-level skip rather than per-test skip noise.
+func skip_suite(reason: String) -> void:
+	_suite_skipped = true
+	_suite_skipped_reason = reason
 
 
 ## Trigger an undo against whichever history (scene or global) holds the most

--- a/plugin/addons/godot_ai/utils/scene_path.gd
+++ b/plugin/addons/godot_ai/utils/scene_path.gd
@@ -17,9 +17,25 @@ static func from_node(node: Node, scene_root: Node) -> String:
 
 
 ## Resolve a clean scene path like "/Main/Camera3D" to the actual node.
+##
+## Accepts three forms, all relative to the edited scene root:
+##   "/Main"          — explicit root prefix (canonical)
+##   "/Main/Camera3D" — descendant path
+##   "Main/Camera3D"  — bare relative
+##
+## Also accepts SceneTree-style "/root/<root_name>[/...]" as an alias for the
+## edited scene root. Agents reach for /root/Foo right after creating a scene
+## because that's where scenes live at runtime under SceneTree; we honor it
+## so the call doesn't fail with a confusing "not found" error.
 static func resolve(scene_path: String, scene_root: Node) -> Node:
 	if scene_root == null:
 		return null
+
+	## SceneTree-style /root/<name> alias: strip the /root prefix and recurse.
+	if scene_path == "/root":
+		return scene_root
+	if scene_path.begins_with("/root/"):
+		return resolve(scene_path.substr(5), scene_root)  # keep leading slash
 
 	var root_prefix := "/" + scene_root.name
 	if scene_path == root_prefix:
@@ -30,3 +46,15 @@ static func resolve(scene_path: String, scene_root: Node) -> Node:
 
 	# Try as-is (relative path)
 	return scene_root.get_node_or_null(scene_path)
+
+
+## Format a "parent not found" error that names the path convention.
+## Agents routinely try /root/Foo or absolute SceneTree paths; the bare
+## "Parent not found: X" gave them no hint that paths are scene-relative.
+static func format_parent_error(path: String, scene_root: Node) -> String:
+	var root_name := scene_root.name if scene_root != null else "<no scene>"
+	return (
+		"Parent not found: %s. parent_path is relative to the edited scene root "
+		"(e.g. \"/%s\" or \"\"), not the SceneTree. Scene root is \"/%s\"."
+		% [path, root_name, root_name]
+	)

--- a/plugin/addons/godot_ai/utils/scene_path.gd
+++ b/plugin/addons/godot_ai/utils/scene_path.gd
@@ -18,23 +18,28 @@ static func from_node(node: Node, scene_root: Node) -> String:
 
 ## Resolve a clean scene path like "/Main/Camera3D" to the actual node.
 ##
-## Accepts three forms, all relative to the edited scene root:
+## Accepts forms relative to the edited scene root:
 ##   "/Main"          — explicit root prefix (canonical)
 ##   "/Main/Camera3D" — descendant path
-##   "Main/Camera3D"  — bare relative
+##   "Camera3D"       — bare relative to scene_root
+##   "World/Ground"   — nested bare relative to scene_root
 ##
-## Also accepts SceneTree-style "/root/<root_name>[/...]" as an alias for the
-## edited scene root. Agents reach for /root/Foo right after creating a scene
-## because that's where scenes live at runtime under SceneTree; we honor it
-## so the call doesn't fail with a confusing "not found" error.
+## Also accepts SceneTree-style "/root/<scene_root_name>[/...]" as an alias for
+## the edited scene root. Agents reach for /root/Foo right after creating a
+## scene because that's where scenes live at runtime; we honor it so the call
+## doesn't fail with a confusing "not found" error. The alias only kicks in
+## when the segment after /root matches the scene root's name — paths like
+## "/root/@EditorNode@.../Main/..." (returned by Node.get_path() in the editor)
+## fall through to the absolute-path fallback unchanged.
 static func resolve(scene_path: String, scene_root: Node) -> Node:
 	if scene_root == null:
 		return null
 
-	## SceneTree-style /root/<name> alias: strip the /root prefix and recurse.
-	if scene_path == "/root":
-		return scene_root
-	if scene_path.begins_with("/root/"):
+	## /root/<scene_root_name>[/...] alias: strip the /root prefix and recurse.
+	## Match the scene root by name explicitly so we don't capture editor-
+	## internal paths that legitimately live under /root.
+	var alias_prefix := "/root/" + scene_root.name
+	if scene_path == alias_prefix or scene_path.begins_with(alias_prefix + "/"):
 		return resolve(scene_path.substr(5), scene_root)  # keep leading slash
 
 	var root_prefix := "/" + scene_root.name
@@ -44,13 +49,17 @@ static func resolve(scene_path: String, scene_root: Node) -> Node:
 		var relative := scene_path.substr(root_prefix.length() + 1)
 		return scene_root.get_node_or_null(relative)
 
-	# Try as-is (relative path)
+	# Try as-is (relative path, or absolute SceneTree path).
 	return scene_root.get_node_or_null(scene_path)
 
 
 ## Format a "parent not found" error that names the path convention.
 ## Agents routinely try /root/Foo or absolute SceneTree paths; the bare
 ## "Parent not found: X" gave them no hint that paths are scene-relative.
+## Wording is generic ("Paths are relative...") so the helper works for any
+## param name (parent_path, new_parent, …).
 static func format_parent_error(path: String, scene_root: Node) -> String:
-	var root_name := str(scene_root.name) if scene_root != null else "<no scene>"
-	return "Parent not found: %s. parent_path is relative to the edited scene root (e.g. \"/%s\" or \"\"), not the SceneTree. Scene root is \"/%s\"." % [path, root_name, root_name]
+	if scene_root == null:
+		return "Parent not found: %s. No edited scene is open." % path
+	var root_name := str(scene_root.name)
+	return "Parent not found: %s. Paths are relative to the edited scene root (e.g. \"/%s\" or \"\"), not the SceneTree. Scene root is \"/%s\"." % [path, root_name, root_name]

--- a/plugin/addons/godot_ai/utils/scene_path.gd
+++ b/plugin/addons/godot_ai/utils/scene_path.gd
@@ -52,9 +52,5 @@ static func resolve(scene_path: String, scene_root: Node) -> Node:
 ## Agents routinely try /root/Foo or absolute SceneTree paths; the bare
 ## "Parent not found: X" gave them no hint that paths are scene-relative.
 static func format_parent_error(path: String, scene_root: Node) -> String:
-	var root_name := scene_root.name if scene_root != null else "<no scene>"
-	return (
-		"Parent not found: %s. parent_path is relative to the edited scene root "
-		"(e.g. \"/%s\" or \"\"), not the SceneTree. Scene root is \"/%s\"."
-		% [path, root_name, root_name]
-	)
+	var root_name := str(scene_root.name) if scene_root != null else "<no scene>"
+	return "Parent not found: %s. parent_path is relative to the edited scene root (e.g. \"/%s\" or \"\"), not the SceneTree. Scene root is \"/%s\"." % [path, root_name, root_name]

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -147,6 +147,31 @@ func test_create_node_non_node_type() -> void:
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 
 
+func test_create_node_accepts_root_alias_for_parent_path() -> void:
+	## Agents reach for /root/Main right after scene creation. Resolve it as
+	## an alias for the edited scene root rather than failing.
+	var result := _handler.create_node({
+		"type": "Node3D",
+		"name": "_McpTestRootAlias",
+		"parent_path": "/root/Main",
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.parent_path, "/Main", "should resolve to scene root")
+	_undo_redo.undo()
+
+
+func test_create_node_parent_not_found_error_names_convention() -> void:
+	## The plain "Parent not found: X" error doesn't tell the agent that
+	## paths are scene-relative. The upgraded message must spell that out.
+	var result := _handler.create_node({
+		"type": "Node3D",
+		"parent_path": "/SomeBogusPath",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "relative to the edited scene root")
+	assert_contains(result.error.message, "Scene root is")
+
+
 # ----- delete_node -----
 
 func test_delete_node_basic() -> void:

--- a/test_project/tests/test_runner.gd
+++ b/test_project/tests/test_runner.gd
@@ -56,6 +56,26 @@ class _LeakingSuite extends McpTestSuite:
 		assert_true(true)
 
 
+class _FailedSetupSuite extends McpTestSuite:
+	func suite_name() -> String: return "inner_failed_setup"
+	func suite_setup(_ctx: Dictionary) -> void:
+		fail_setup("arena.gd cannot instantiate in @tool scope")
+	func test_a() -> void:
+		assert_true(true)  # never runs
+	func test_b() -> void:
+		assert_true(true)  # never runs
+
+
+class _SkippedSetupSuite extends McpTestSuite:
+	func suite_name() -> String: return "inner_skipped_setup"
+	func suite_setup(_ctx: Dictionary) -> void:
+		skip_suite("no scene open")
+	func test_a() -> void:
+		assert_true(true)  # never runs
+	func test_b() -> void:
+		assert_true(true)  # never runs
+
+
 # ----- skip() semantics -----
 
 func test_skip_records_separately_from_pass_fail() -> void:
@@ -100,6 +120,43 @@ func test_suite_setup_receives_deep_copy_of_ctx() -> void:
 	assert_false(ctx.has("new_top"), "new top-level key should not leak back")
 	assert_false(nested.has("injected"), "nested dict should be deep-copied")
 	assert_eq(nested.value, 1, "nested value should be unchanged")
+
+
+# ----- suite-level failure (issue #75) -----
+
+func test_fail_setup_emits_one_suite_level_failure() -> void:
+	## A suite that calls fail_setup() in suite_setup should emit ONE result
+	## (not N per-test "0 assertions" results) and skip individual tests.
+	var runner := McpTestRunner.new()
+	var result := runner.run_suites([_FailedSetupSuite.new()])
+	assert_eq(result.failed, 1, "exactly one suite-level failure")
+	assert_eq(result.passed, 0, "individual tests must not run")
+	assert_eq(result.total, 1, "one result, not per-test results")
+	assert_has_key(result, "failures")
+	var failure: Dictionary = result.failures[0]
+	assert_eq(failure.test, "<suite_setup>")
+	assert_contains(failure.message, "arena.gd cannot instantiate")
+	assert_contains(failure.message, "subsequent tests not run")
+
+
+func test_skip_suite_emits_one_suite_level_skip() -> void:
+	## skip_suite() is the no-precondition counterpart to fail_setup().
+	var runner := McpTestRunner.new()
+	var result := runner.run_suites([_SkippedSetupSuite.new()])
+	assert_eq(result.skipped, 1, "exactly one suite-level skip")
+	assert_eq(result.failed, 0)
+	assert_eq(result.passed, 0)
+	assert_eq(result.total, 1)
+
+
+func test_failed_setup_does_not_run_other_suites_tests() -> void:
+	## Mixed: a failing suite should not poison the runner — subsequent
+	## suites must still execute normally.
+	var runner := McpTestRunner.new()
+	var result := runner.run_suites([_FailedSetupSuite.new(), _PassingSuite.new()])
+	assert_eq(result.failed, 1, "failing suite's suite-level failure")
+	assert_eq(result.passed, 1, "passing suite still ran")
+	assert_eq(result.total, 2)
 
 
 # ----- leaked-node cleanup -----

--- a/test_project/tests/test_scene_path.gd
+++ b/test_project/tests/test_scene_path.gd
@@ -52,14 +52,7 @@ func test_resolve_nested_descendant() -> void:
 	root.queue_free()
 
 
-# ----- resolve: /root/ alias (issue #71) -----
-
-func test_resolve_root_alias_returns_scene_root() -> void:
-	## /root is a SceneTree-style alias for the edited scene root.
-	var root := _make_tree()
-	assert_eq(ScenePath.resolve("/root", root), root)
-	root.queue_free()
-
+# ----- resolve: /root/<scene_root_name> alias (issue #71) -----
 
 func test_resolve_root_alias_with_scene_name_returns_scene_root() -> void:
 	## /root/Main → scene root. This is the agent's most common mistake;
@@ -85,6 +78,20 @@ func test_resolve_root_alias_nested_descendant() -> void:
 	root.queue_free()
 
 
+func test_resolve_does_not_hijack_editor_internal_root_paths() -> void:
+	## Node.get_path() inside the editor returns paths like
+	## /root/@EditorNode@.../Main/X. Those legitimately live under /root but
+	## the segment after /root is NOT the scene_root's name — the alias must
+	## not swallow them, or absolute-path lookups break for every handler
+	## that resolves a node by its real SceneTree path.
+	var root := _make_tree()
+	## Path doesn't match alias prefix "/root/Main" → falls through to the
+	## absolute-path fallback (which returns null here because root isn't
+	## actually in any SceneTree, but the key behavior is "don't strip /root").
+	assert_eq(ScenePath.resolve("/root/@EditorNode@1/Main/Camera3D", root), null)
+	root.queue_free()
+
+
 # ----- resolve: failure cases -----
 
 func test_resolve_unknown_path_returns_null() -> void:
@@ -101,16 +108,28 @@ func test_resolve_null_scene_root_returns_null() -> void:
 
 func test_format_parent_error_names_scene_root() -> void:
 	var root := _make_tree()
-	var msg := ScenePath.format_parent_error("/root/Main", root)
-	assert_contains(msg, "/root/Main")
+	var msg := ScenePath.format_parent_error("/SomeBogusPath", root)
+	assert_contains(msg, "/SomeBogusPath")
 	assert_contains(msg, "/Main")
 	assert_contains(msg, "relative to the edited scene root")
 	assert_contains(msg, "not the SceneTree")
 	root.queue_free()
 
 
-func test_format_parent_error_handles_null_root() -> void:
-	## Defensive: format_parent_error shouldn't crash if scene_root is null
-	## (which can happen if a check is misordered in a handler).
+func test_format_parent_error_uses_generic_paths_wording() -> void:
+	## Helper is shared across param names (parent_path, new_parent, …); the
+	## message must not hardcode any specific param name.
+	var root := _make_tree()
+	var msg := ScenePath.format_parent_error("/X", root)
+	assert_false(msg.contains("parent_path"), "should not name a specific param")
+	assert_contains(msg, "Paths are relative")
+	root.queue_free()
+
+
+func test_format_parent_error_null_root_returns_actionable_message() -> void:
+	## When no scene is open there's no scene_root to suggest. Return a
+	## message that points at the real problem instead of "/<no scene>".
 	var msg := ScenePath.format_parent_error("/Foo", null)
 	assert_contains(msg, "/Foo")
+	assert_contains(msg, "No edited scene is open")
+	assert_false(msg.contains("<no scene>"), "should not leak placeholder")

--- a/test_project/tests/test_scene_path.gd
+++ b/test_project/tests/test_scene_path.gd
@@ -1,0 +1,116 @@
+@tool
+extends McpTestSuite
+
+## Tests for ScenePath — the path resolver/formatter shared by every
+## scene-mutating handler. Uses a freestanding Node tree (no dependency
+## on the edited scene) so behavior is deterministic.
+
+
+func suite_name() -> String:
+	return "scene_path"
+
+
+# ----- helpers -----
+
+func _make_tree() -> Node:
+	## Returns: scene_root("Main") with /Main/Camera3D and /Main/World/Ground.
+	var main := Node.new()
+	main.name = "Main"
+	var cam := Node.new()
+	cam.name = "Camera3D"
+	main.add_child(cam)
+	var world := Node.new()
+	world.name = "World"
+	main.add_child(world)
+	var ground := Node.new()
+	ground.name = "Ground"
+	world.add_child(ground)
+	return main
+
+
+# ----- resolve: existing canonical forms -----
+
+func test_resolve_root_prefix_returns_scene_root() -> void:
+	var root := _make_tree()
+	assert_eq(ScenePath.resolve("/Main", root), root)
+	root.queue_free()
+
+
+func test_resolve_descendant_via_root_prefix() -> void:
+	var root := _make_tree()
+	var cam := ScenePath.resolve("/Main/Camera3D", root)
+	assert_ne(cam, null, "should find Camera3D")
+	assert_eq(cam.name, "Camera3D")
+	root.queue_free()
+
+
+func test_resolve_nested_descendant() -> void:
+	var root := _make_tree()
+	var ground := ScenePath.resolve("/Main/World/Ground", root)
+	assert_ne(ground, null)
+	assert_eq(ground.name, "Ground")
+	root.queue_free()
+
+
+# ----- resolve: /root/ alias (issue #71) -----
+
+func test_resolve_root_alias_returns_scene_root() -> void:
+	## /root is a SceneTree-style alias for the edited scene root.
+	var root := _make_tree()
+	assert_eq(ScenePath.resolve("/root", root), root)
+	root.queue_free()
+
+
+func test_resolve_root_alias_with_scene_name_returns_scene_root() -> void:
+	## /root/Main → scene root. This is the agent's most common mistake;
+	## resolving it (instead of erroring) saves a round trip.
+	var root := _make_tree()
+	assert_eq(ScenePath.resolve("/root/Main", root), root)
+	root.queue_free()
+
+
+func test_resolve_root_alias_with_descendant() -> void:
+	var root := _make_tree()
+	var cam := ScenePath.resolve("/root/Main/Camera3D", root)
+	assert_ne(cam, null)
+	assert_eq(cam.name, "Camera3D")
+	root.queue_free()
+
+
+func test_resolve_root_alias_nested_descendant() -> void:
+	var root := _make_tree()
+	var ground := ScenePath.resolve("/root/Main/World/Ground", root)
+	assert_ne(ground, null)
+	assert_eq(ground.name, "Ground")
+	root.queue_free()
+
+
+# ----- resolve: failure cases -----
+
+func test_resolve_unknown_path_returns_null() -> void:
+	var root := _make_tree()
+	assert_eq(ScenePath.resolve("/Main/DoesNotExist", root), null)
+	root.queue_free()
+
+
+func test_resolve_null_scene_root_returns_null() -> void:
+	assert_eq(ScenePath.resolve("/Main", null), null)
+
+
+# ----- format_parent_error: agent-readable message -----
+
+func test_format_parent_error_names_scene_root() -> void:
+	var root := _make_tree()
+	var msg := ScenePath.format_parent_error("/root/Main", root)
+	assert_contains(msg, "/root/Main")
+	assert_contains(msg, "/Main")
+	assert_contains(msg, "relative to the edited scene root")
+	assert_contains(msg, "not the SceneTree")
+	root.queue_free()
+
+
+func test_format_parent_error_handles_null_root() -> void:
+	## Defensive: format_parent_error shouldn't crash if scene_root is null
+	## (which can happen if a check is misordered in a handler).
+	var msg := ScenePath.format_parent_error("/Foo", null)
+	assert_contains(msg, "/Foo")


### PR DESCRIPTION
Bundles two friction-log fixes from 2026-04-17. Both touch isolated, low-risk areas — easy to review together, easy to revert in isolation.

## Closes

- Closes #71 — `parent_path` accepts `/root/` alias + better "Parent not found" error
- Closes #75 — test runner captures `suite_setup()` bailouts cleanly

(Also closed #48 and #69 separately — both already addressed in `main`; just unstamped issues.)

## Changes

### #71 — `parent_path` `/root/` alias

Agents reach for `parent_path="/root/Foo"` right after `scene_create`, because the SceneTree mental model is sticky. Today that returns `Parent not found: /root/Foo` with no hint that paths are scene-relative.

- `ScenePath.resolve` now treats `/root` and `/root/<name>[/...]` as aliases for the edited scene root.
- New `ScenePath.format_parent_error` helper produces a message that spells out the convention and names the actual scene root. All six "Parent not found" sites (node, camera, ui, animation, audio, particle handlers) route through it.

Before:
```
INVALID_PARAMS: Parent not found: /root/Foo
```

After:
```
INVALID_PARAMS: Parent not found: /SomeBogusPath. parent_path is relative
to the edited scene root (e.g. "/Main" or ""), not the SceneTree.
Scene root is "/Main".
```

(And `/root/Main` just works — no error.)

### #75 — `suite_setup` bailout API

When `suite_setup()` throws (e.g. instantiating `RigidBody3D` in `@tool` scope), every test in the suite reports `"0 assertions — likely skipped its logic"`. The author has no signal pointing back at setup.

GDScript can't intercept `push_error` generically (Godot's `Logger` class isn't subclassable from script), so the pragmatic fix is an opt-in bailout API:

- `McpTestSuite.fail_setup(reason)` — bail with a failure
- `McpTestSuite.skip_suite(reason)` — bail with a skip
- `McpTestRunner` detects either after `suite_setup` and emits **one** suite-level result (named `<suite_setup>`) instead of N noisy per-test failures. Subsequent tests in the failed suite don't run; other suites continue normally.

Example:
```gdscript
func suite_setup(_ctx):
    var arena = preload("res://game/arena.gd").new()
    if arena == null:
        fail_setup("arena.gd cannot instantiate in @tool scope")
        return
```

The runner reports one result:
```
inner_failed_setup / <suite_setup>: suite_setup() failed: arena.gd cannot
instantiate in @tool scope (subsequent tests not run)
```

The existing zero-assertion guardrail still fires for genuine zero-assertion cases.

## Tests

- `test_scene_path.gd` (new) — 11 cases covering canonical resolve, `/root/` alias, failure cases, and `format_parent_error`.
- `test_node.gd` — added create_node `/root/Main` acceptance test + asserted the upgraded error message names the convention.
- `test_runner.gd` — three cases for `fail_setup`, `skip_suite`, and cross-suite isolation (a failing setup must not poison subsequent suites).

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `pytest -q` — 511 passed
- [ ] CI GDScript suite — green
- [ ] Live smoke against editor: `node_create(parent_path="/root/Main")` succeeds; `node_create(parent_path="/Bogus")` returns the upgraded error

🤖 Generated with [Claude Code](https://claude.com/claude-code)