### PR TITLE
feat: logs_read source=game surfaces running-game output

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -12,7 +12,7 @@ Godot AI exposes 120+ MCP tools. They're grouped below by domain.
 | `editor_selection_get` / `editor_selection_set` | Read or set the editor selection |
 | `editor_screenshot` | Capture the 3D editor viewport or the running game's framebuffer. `source="game"` works in every embed / floating / separate-window mode via the debugger-channel bridge (requires the `_mcp_game_helper` autoload, registered automatically when the plugin is enabled) |
 | `editor_reload_plugin` / `editor_quit` | Reload the plugin or quit the editor |
-| `logs_read` / `logs_clear` | Read or clear recent MCP log lines |
+| `logs_read` / `logs_clear` | Read or clear recent log lines. `source="plugin"` (default) returns MCP traffic; `source="game"` returns `print` / `push_error` / `push_warning` from the running game with per-run `run_id`, `is_running`, and `dropped_count`; `source="all"` returns both streams. Game capture requires Godot 4.5+ (Logger API) and the `_mcp_game_helper` autoload registered automatically by the plugin |
 | `performance_monitors_get` | Read Godot performance monitors (FPS, memory, draw calls, etc.) |
 | `batch_execute` | Run multiple plugin commands in one round trip |
 

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -30,6 +30,7 @@ const DEFAULT_TIMEOUT_SEC := 8.0
 const GAME_READY_WAIT_SEC := 20.0
 
 var _log_buffer: McpLogBuffer
+var _game_log_buffer: GameLogBuffer
 
 ## Pending request_id -> {connection, deadline_ts, timer}
 var _pending: Dictionary = {}
@@ -42,8 +43,9 @@ var _game_ready := false
 signal game_ready
 
 
-func _init(log_buffer: McpLogBuffer = null) -> void:
+func _init(log_buffer: McpLogBuffer = null, game_log_buffer: GameLogBuffer = null) -> void:
 	_log_buffer = log_buffer
+	_game_log_buffer = game_log_buffer
 
 
 func _has_capture(prefix: String) -> bool:
@@ -72,17 +74,39 @@ func _capture(message: String, data: Array, _session_id: int) -> bool:
 		"mcp:screenshot_error":
 			_on_screenshot_error(data)
 			return true
+		"mcp:log_batch":
+			_on_log_batch(data)
+			return true
 		"mcp:hello":
 			## Boot beacon from the game-side autoload. Tells us the
 			## game has registered its "mcp" capture and is safe to send
 			## take_screenshot to — before this, Godot's debugger would
-			## drop our message silently.
+			## drop our message silently. Also marks a fresh play
+			## cycle: rotate the game-log buffer so each run starts
+			## clean and gets a new run_id.
 			_game_ready = true
 			game_ready.emit()
-			if _log_buffer:
+			if _game_log_buffer:
+				var run_id := _game_log_buffer.clear_for_new_run()
+				if _log_buffer:
+					_log_buffer.log("[debug] <- mcp:hello from game_helper (run %s)" % run_id)
+			elif _log_buffer:
 				_log_buffer.log("[debug] <- mcp:hello from game_helper")
 			return true
 	return false
+
+
+func _on_log_batch(data: Array) -> void:
+	if _game_log_buffer == null:
+		return
+	## data layout: [[[level, text], [level, text], ...]]
+	if data.is_empty() or not (data[0] is Array):
+		return
+	var entries: Array = data[0]
+	for entry in entries:
+		if not (entry is Array) or entry.size() < 2:
+			continue
+		_game_log_buffer.append(str(entry[0]), str(entry[1]))
 
 
 ## Request a game-process framebuffer capture over the debugger channel.

--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -7,12 +7,14 @@ extends RefCounted
 var _log_buffer: McpLogBuffer
 var _connection: Connection
 var _debugger_plugin: McpDebuggerPlugin
+var _game_log_buffer: GameLogBuffer
 
 
-func _init(log_buffer: McpLogBuffer, connection: Connection = null, debugger_plugin: McpDebuggerPlugin = null) -> void:
+func _init(log_buffer: McpLogBuffer, connection: Connection = null, debugger_plugin: McpDebuggerPlugin = null, game_log_buffer: GameLogBuffer = null) -> void:
 	_log_buffer = log_buffer
 	_connection = connection
 	_debugger_plugin = debugger_plugin
+	_game_log_buffer = game_log_buffer
 
 
 func get_editor_state(_params: Dictionary) -> Dictionary:
@@ -37,14 +39,105 @@ func get_selection(_params: Dictionary) -> Dictionary:
 	return {"data": {"selected_paths": paths, "count": paths.size()}}
 
 
+const VALID_LOG_SOURCES := ["plugin", "game", "all"]
+
+
 func get_logs(params: Dictionary) -> Dictionary:
 	var count: int = params.get("count", 50)
-	var lines := _log_buffer.get_recent(count)
+	var offset: int = maxi(0, int(params.get("offset", 0)))
+	var source: String = params.get("source", "plugin")
+	if not source in VALID_LOG_SOURCES:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Invalid source '%s' — use 'plugin', 'game', or 'all'" % source,
+		)
+
+	match source:
+		"plugin":
+			return _get_plugin_logs(count, offset)
+		"game":
+			return _get_game_logs(count, offset)
+		"all":
+			return _get_all_logs(count, offset)
+	return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Unreachable")
+
+
+func _get_plugin_logs(count: int, offset: int) -> Dictionary:
+	var all_lines := _log_buffer.get_recent(_log_buffer.total_count())
+	var page: Array[Dictionary] = []
+	var stop := mini(all_lines.size(), offset + count)
+	for i in range(mini(offset, all_lines.size()), stop):
+		page.append({"source": "plugin", "level": "info", "text": all_lines[i]})
 	return {
 		"data": {
-			"lines": lines,
-			"total_count": _log_buffer.total_count(),
-			"returned_count": lines.size(),
+			"source": "plugin",
+			"lines": page,
+			"total_count": all_lines.size(),
+			"returned_count": page.size(),
+			"offset": offset,
+		}
+	}
+
+
+func _get_game_logs(count: int, offset: int) -> Dictionary:
+	if _game_log_buffer == null:
+		return {
+			"data": {
+				"source": "game",
+				"lines": [],
+				"total_count": 0,
+				"returned_count": 0,
+				"offset": offset,
+				"run_id": "",
+				"is_running": false,
+				"dropped_count": 0,
+			}
+		}
+	var page := _game_log_buffer.get_range(offset, count)
+	return {
+		"data": {
+			"source": "game",
+			"lines": page,
+			"total_count": _game_log_buffer.total_count(),
+			"returned_count": page.size(),
+			"offset": offset,
+			"run_id": _game_log_buffer.run_id(),
+			"is_running": EditorInterface.is_playing_scene(),
+			"dropped_count": _game_log_buffer.dropped_count(),
+		}
+	}
+
+
+func _get_all_logs(count: int, offset: int) -> Dictionary:
+	## Plugin lines have no timestamp, so we can't merge chronologically.
+	## Concatenate plugin then game and apply the offset/count window over
+	## the combined list. The per-line `source` field tells callers where
+	## each entry came from.
+	var combined: Array[Dictionary] = []
+	for line in _log_buffer.get_recent(_log_buffer.total_count()):
+		combined.append({"source": "plugin", "level": "info", "text": line})
+	if _game_log_buffer != null:
+		for entry in _game_log_buffer.get_range(0, _game_log_buffer.total_count()):
+			combined.append(entry)
+	var stop := mini(combined.size(), offset + count)
+	var page: Array[Dictionary] = []
+	for i in range(mini(offset, combined.size()), stop):
+		page.append(combined[i])
+	var run_id := ""
+	var dropped := 0
+	if _game_log_buffer != null:
+		run_id = _game_log_buffer.run_id()
+		dropped = _game_log_buffer.dropped_count()
+	return {
+		"data": {
+			"source": "all",
+			"lines": page,
+			"total_count": combined.size(),
+			"returned_count": page.size(),
+			"offset": offset,
+			"run_id": run_id,
+			"is_running": EditorInterface.is_playing_scene(),
+			"dropped_count": dropped,
 		}
 	}
 

--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -43,9 +43,12 @@ const VALID_LOG_SOURCES := ["plugin", "game", "all"]
 
 
 func get_logs(params: Dictionary) -> Dictionary:
-	var count: int = params.get("count", 50)
+	## Coerce defensively — MCP clients can send JSON numbers as floats or
+	## stray `null` values that would otherwise fail the typed locals
+	## before we ever reach the INVALID_PARAMS return below.
+	var count: int = maxi(0, int(params.get("count", 50)))
 	var offset: int = maxi(0, int(params.get("offset", 0)))
-	var source: String = params.get("source", "plugin")
+	var source: String = str(params.get("source", "plugin"))
 	if not source in VALID_LOG_SOURCES:
 		return McpErrorCodes.make(
 			McpErrorCodes.INVALID_PARAMS,

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -7,6 +7,7 @@ const GAME_HELPER_AUTOLOAD_PATH := "res://addons/godot_ai/runtime/game_helper.gd
 var _connection: Connection
 var _dispatcher: McpDispatcher
 var _log_buffer: McpLogBuffer
+var _game_log_buffer: GameLogBuffer
 var _dock: McpDock
 var _server_pid := -1
 var _handlers: Array = []  # prevent GC of RefCounted handlers
@@ -18,16 +19,17 @@ func _enter_tree() -> void:
 	_start_server()
 
 	_log_buffer = McpLogBuffer.new()
+	_game_log_buffer = GameLogBuffer.new()
 	_dispatcher = McpDispatcher.new(_log_buffer)
 
 	_connection = Connection.new()
 	_connection.log_buffer = _log_buffer
 
-	_debugger_plugin = McpDebuggerPlugin.new(_log_buffer)
+	_debugger_plugin = McpDebuggerPlugin.new(_log_buffer, _game_log_buffer)
 	add_debugger_plugin(_debugger_plugin)
 	_ensure_game_helper_autoload()
 
-	var editor_handler := EditorHandler.new(_log_buffer, _connection, _debugger_plugin)
+	var editor_handler := EditorHandler.new(_log_buffer, _connection, _debugger_plugin, _game_log_buffer)
 	var scene_handler := SceneHandler.new(_connection)
 	var node_handler := NodeHandler.new(get_undo_redo())
 	var project_handler := ProjectHandler.new(_connection)

--- a/plugin/addons/godot_ai/runtime/game_helper.gd
+++ b/plugin/addons/godot_ai/runtime/game_helper.gd
@@ -20,8 +20,17 @@ extends Node
 ## send_message that requires an active channel.
 
 const CAPTURE_PREFIX := "mcp"
+## Cap per-frame flush so a runaway print loop can't blow the debugger's
+## packet budget in a single send. Surplus stays queued for the next frame.
+const FLUSH_BATCH_LIMIT := 200
+
+const GAME_LOGGER_PATH := "res://addons/godot_ai/runtime/game_logger.gd"
 
 var _registered := false
+## Untyped because the McpGameLogger script is loaded dynamically (it
+## extends Logger, which only exists in Godot 4.5+).
+var _logger
+var _logger_attached := false
 
 
 func _ready() -> void:
@@ -38,20 +47,52 @@ func _ready() -> void:
 	## handshake completes; the capture sits until a message arrives.
 	EngineDebugger.register_message_capture(CAPTURE_PREFIX, _on_debug_message)
 	_registered = true
+	## Capture print() / printerr() / push_error() / push_warning() and
+	## ferry them to the editor in mcp:log_batch messages flushed from
+	## _process. Logger subclassing was added in Godot 4.5 — gate on
+	## ClassDB so the rest of the helper still loads on 4.4 (the logger
+	## script never gets parsed because we only load() it inside this
+	## branch).
+	if ClassDB.class_exists("Logger") and OS.has_method("add_logger"):
+		var logger_script := load(GAME_LOGGER_PATH)
+		if logger_script != null:
+			_logger = logger_script.new()
+			OS.call("add_logger", _logger)
+			_logger_attached = true
 	## Routed to the editor's Output panel via Godot's remote-stdout
 	## forwarder — handy when diagnosing why capture timed out.
-	print("[godot_ai game_helper] registered mcp capture (debugger active=%s)"
-		% EngineDebugger.is_active())
+	print("[godot_ai game_helper] registered mcp capture (debugger active=%s, logger=%s)"
+		% [EngineDebugger.is_active(), _logger_attached])
 	## Boot beacon so the editor side can confirm the autoload ran even
 	## if no screenshot was ever requested.
 	if EngineDebugger.is_active():
 		EngineDebugger.send_message("mcp:hello", [])
 
 
+func _process(_delta: float) -> void:
+	## Drain the logger queue on the main thread (Logger virtuals can fire
+	## from any thread; EngineDebugger.send_message is only safe from main).
+	if not _logger_attached or _logger == null:
+		return
+	if not EngineDebugger.is_active():
+		return
+	if not _logger.has_pending():
+		return
+	var pending: Array = _logger.drain()
+	while not pending.is_empty():
+		var batch := pending.slice(0, FLUSH_BATCH_LIMIT)
+		pending = pending.slice(FLUSH_BATCH_LIMIT)
+		EngineDebugger.send_message("mcp:log_batch", [batch])
+
+
 func _exit_tree() -> void:
 	if _registered:
 		EngineDebugger.unregister_message_capture(CAPTURE_PREFIX)
 		_registered = false
+	if _logger_attached and _logger != null and OS.has_method("remove_logger"):
+		OS.call("remove_logger", _logger)
+		_logger_attached = false
+		_logger = null
 
 
 ## Dispatched for messages prefixed "mcp:" on the debugger channel.

--- a/plugin/addons/godot_ai/runtime/game_helper.gd
+++ b/plugin/addons/godot_ai/runtime/game_helper.gd
@@ -31,6 +31,11 @@ var _registered := false
 ## extends Logger, which only exists in Godot 4.5+).
 var _logger
 var _logger_attached := false
+## Entries drained from the logger but not yet sent over the debugger
+## channel. Holds the tail of one drain() so we can bleed it out across
+## frames at FLUSH_BATCH_LIMIT per frame rather than blasting the whole
+## queue in a single _process tick.
+var _pending_outbound: Array = []
 
 
 func _ready() -> void:
@@ -72,17 +77,21 @@ func _ready() -> void:
 func _process(_delta: float) -> void:
 	## Drain the logger queue on the main thread (Logger virtuals can fire
 	## from any thread; EngineDebugger.send_message is only safe from main).
+	## Send at most one FLUSH_BATCH_LIMIT-sized batch per frame so a runaway
+	## print loop can't stall the game by shoving thousands of entries
+	## through the debugger packet path in a single tick. Surplus stays in
+	## `_pending_outbound` and bleeds out across subsequent frames.
 	if not _logger_attached or _logger == null:
 		return
 	if not EngineDebugger.is_active():
 		return
-	if not _logger.has_pending():
-		return
-	var pending: Array = _logger.drain()
-	while not pending.is_empty():
-		var batch := pending.slice(0, FLUSH_BATCH_LIMIT)
-		pending = pending.slice(FLUSH_BATCH_LIMIT)
-		EngineDebugger.send_message("mcp:log_batch", [batch])
+	if _pending_outbound.is_empty():
+		if not _logger.has_pending():
+			return
+		_pending_outbound = _logger.drain()
+	var batch := _pending_outbound.slice(0, FLUSH_BATCH_LIMIT)
+	_pending_outbound = _pending_outbound.slice(FLUSH_BATCH_LIMIT)
+	EngineDebugger.send_message("mcp:log_batch", [batch])
 
 
 func _exit_tree() -> void:

--- a/plugin/addons/godot_ai/runtime/game_logger.gd
+++ b/plugin/addons/godot_ai/runtime/game_logger.gd
@@ -17,8 +17,6 @@ extends Logger
 ## and the host (game_helper.gd) flushes once per frame from the main
 ## thread, where EngineDebugger.send_message is safe to call.
 
-const FLUSH_BATCH_LIMIT := 200
-
 var _pending: Array = []
 var _mutex := Mutex.new()
 
@@ -33,20 +31,39 @@ func _log_error(
 	function: String,
 	file: String,
 	line: int,
-	_code: String,
+	code: String,
 	rationale: String,
 	_editor_notify: bool,
 	error_type: int,
-	_script_backtraces: Array,
+	script_backtraces: Array,
 ) -> void:
 	## error_type: 0 = ERROR (push_error), 1 = WARNING (push_warning),
 	## 2 = SCRIPT, 3 = SHADER. Map warnings to "warn" so callers can filter
 	## without consulting the enum.
+	##
+	## Single-arg push_error("msg") / push_warning("msg") stores the user's
+	## string in `code` and leaves `rationale` empty; the two-arg form
+	## push_error(code, rationale) populates both. Fall back to `code` when
+	## `rationale` is missing — otherwise the user's message is silently lost.
+	##
+	## `file`/`line` for push_error/push_warning point into Godot's own C++
+	## source (core/variant/variant_utility.cpp). Prefer the first frame of
+	## `script_backtraces` so the capture shows the caller's GDScript location.
 	var level := "warn" if error_type == 1 else "error"
+	var message := rationale if not rationale.is_empty() else code
+	var src_file := file
+	var src_line := line
+	var src_function := function
+	for bt in script_backtraces:
+		if bt != null and bt.get_frame_count() > 0:
+			src_file = bt.get_frame_file(0)
+			src_line = bt.get_frame_line(0)
+			src_function = bt.get_frame_function(0)
+			break
 	var loc := ""
-	if not file.is_empty():
-		loc = "%s:%d @ %s" % [file, line, function] if not function.is_empty() else "%s:%d" % [file, line]
-	var text := "%s (%s)" % [rationale, loc] if not loc.is_empty() else rationale
+	if not src_file.is_empty():
+		loc = "%s:%d @ %s" % [src_file, src_line, src_function] if not src_function.is_empty() else "%s:%d" % [src_file, src_line]
+	var text := "%s (%s)" % [message, loc] if not loc.is_empty() else message
 	_append(level, text)
 
 

--- a/plugin/addons/godot_ai/runtime/game_logger.gd
+++ b/plugin/addons/godot_ai/runtime/game_logger.gd
@@ -1,0 +1,73 @@
+@tool
+extends Logger
+
+## Game-process Logger subclass.
+##
+## NOTE: deliberately no `class_name` — `extends Logger` requires the Logger
+## class which Godot only exposes from 4.5+. game_helper.gd loads this
+## script dynamically via load() after gating on
+## ClassDB.class_exists("Logger"), so the script never gets parsed on
+## older engines. Registered via OS.add_logger() from inside
+## the running game so we can intercept print(), printerr(), push_error(),
+## and push_warning() and ferry them back to the editor over the
+## EngineDebugger channel — the same bridge PR #76 uses for screenshots.
+##
+## Logger virtuals can be called from any thread (e.g. async loaders push
+## errors off the main thread). We accumulate into _pending under a Mutex
+## and the host (game_helper.gd) flushes once per frame from the main
+## thread, where EngineDebugger.send_message is safe to call.
+
+const FLUSH_BATCH_LIMIT := 200
+
+var _pending: Array = []
+var _mutex := Mutex.new()
+
+
+func _log_message(message: String, error: bool) -> void:
+	## `error` is true for printerr(), false for print().
+	var level := "error" if error else "info"
+	_append(level, message)
+
+
+func _log_error(
+	function: String,
+	file: String,
+	line: int,
+	_code: String,
+	rationale: String,
+	_editor_notify: bool,
+	error_type: int,
+	_script_backtraces: Array,
+) -> void:
+	## error_type: 0 = ERROR (push_error), 1 = WARNING (push_warning),
+	## 2 = SCRIPT, 3 = SHADER. Map warnings to "warn" so callers can filter
+	## without consulting the enum.
+	var level := "warn" if error_type == 1 else "error"
+	var loc := ""
+	if not file.is_empty():
+		loc = "%s:%d @ %s" % [file, line, function] if not function.is_empty() else "%s:%d" % [file, line]
+	var text := "%s (%s)" % [rationale, loc] if not loc.is_empty() else rationale
+	_append(level, text)
+
+
+func _append(level: String, text: String) -> void:
+	_mutex.lock()
+	_pending.append([level, text])
+	_mutex.unlock()
+
+
+## Drain the pending queue and return entries as [[level, text], ...].
+## Called from the main thread by game_helper each frame.
+func drain() -> Array:
+	_mutex.lock()
+	var out := _pending
+	_pending = []
+	_mutex.unlock()
+	return out
+
+
+func has_pending() -> bool:
+	_mutex.lock()
+	var any := not _pending.is_empty()
+	_mutex.unlock()
+	return any

--- a/plugin/addons/godot_ai/utils/game_log_buffer.gd
+++ b/plugin/addons/godot_ai/utils/game_log_buffer.gd
@@ -9,11 +9,21 @@ extends RefCounted
 ## structured dict so callers can filter by level. `run_id` rotates each time
 ## clear_for_new_run() fires (called on the game's mcp:hello boot beacon),
 ## giving agents a stable cursor for "lines since this play started".
+##
+## Implemented as a head-indexed circular buffer: `_storage` stays at most
+## MAX_LINES long, and once full, new appends overwrite the oldest slot at
+## `_head`. This keeps append O(1) on overflow — the previous `slice()`
+## approach reallocated the full retained array on every drop, which a very
+## chatty game would pay for thousands of times per second.
 
 const MAX_LINES := 2000
 const VALID_LEVELS := ["info", "warn", "error"]
 
-var _entries: Array[Dictionary] = []
+var _storage: Array[Dictionary] = []
+## Next write position within `_storage`. While filling (before first
+## wrap) equals `_storage.size()`; once full, points at the oldest entry
+## (the one about to be overwritten).
+var _head := 0
 var _run_id := ""
 var _dropped_count := 0
 
@@ -22,42 +32,46 @@ func append(level: String, text: String) -> void:
 	## Coerce unknown levels to "info" so a misbehaving sender can't poison
 	## downstream filters with arbitrary strings.
 	var safe_level := level if level in VALID_LEVELS else "info"
-	_entries.append({"source": "game", "level": safe_level, "text": text})
-	if _entries.size() > MAX_LINES:
-		var overflow := _entries.size() - MAX_LINES
-		_entries = _entries.slice(overflow)
-		_dropped_count += overflow
+	var entry := {"source": "game", "level": safe_level, "text": text}
+	if _storage.size() < MAX_LINES:
+		_storage.append(entry)
+		_head = _storage.size() % MAX_LINES
+		return
+	## Full — overwrite oldest in place, advance head, count the drop.
+	_storage[_head] = entry
+	_head = (_head + 1) % MAX_LINES
+	_dropped_count += 1
 
 
 func get_range(offset: int, count: int) -> Array[Dictionary]:
+	var size := _storage.size()
 	var start := maxi(0, offset)
-	var stop := mini(_entries.size(), start + count)
+	var stop := mini(size, start + count)
 	var out: Array[Dictionary] = []
 	for i in range(start, stop):
-		out.append(_entries[i])
+		out.append(_storage[_logical_to_physical(i)])
 	return out
 
 
 func get_recent(count: int) -> Array[Dictionary]:
-	var start := maxi(0, _entries.size() - count)
-	var out: Array[Dictionary] = []
-	for i in range(start, _entries.size()):
-		out.append(_entries[i])
-	return out
+	var size := _storage.size()
+	var start := maxi(0, size - count)
+	return get_range(start, size - start)
 
 
 ## Rotate the run identifier and drop all buffered entries. Called when the
 ## game-side autoload sends its mcp:hello beacon, marking a fresh play cycle.
 ## Returns the new run_id.
 func clear_for_new_run() -> String:
-	_entries.clear()
+	_storage.clear()
+	_head = 0
 	_dropped_count = 0
 	_run_id = _generate_run_id()
 	return _run_id
 
 
 func total_count() -> int:
-	return _entries.size()
+	return _storage.size()
 
 
 func run_id() -> String:
@@ -66,6 +80,15 @@ func run_id() -> String:
 
 func dropped_count() -> int:
 	return _dropped_count
+
+
+## Translate a logical index (0 = oldest retained) to a physical
+## `_storage` slot. Before the first wrap, storage-order is
+## logical-order. After wrapping, the oldest entry lives at `_head`.
+func _logical_to_physical(logical: int) -> int:
+	if _storage.size() < MAX_LINES:
+		return logical
+	return (_head + logical) % MAX_LINES
 
 
 static func _generate_run_id() -> String:

--- a/plugin/addons/godot_ai/utils/game_log_buffer.gd
+++ b/plugin/addons/godot_ai/utils/game_log_buffer.gd
@@ -1,0 +1,75 @@
+@tool
+class_name GameLogBuffer
+extends RefCounted
+
+## Ring buffer for game-process log lines (print, push_warning, push_error)
+## ferried back from the playing game over the EngineDebugger channel.
+##
+## Larger cap than McpLogBuffer because games can be noisy. Each entry is a
+## structured dict so callers can filter by level. `run_id` rotates each time
+## clear_for_new_run() fires (called on the game's mcp:hello boot beacon),
+## giving agents a stable cursor for "lines since this play started".
+
+const MAX_LINES := 2000
+const VALID_LEVELS := ["info", "warn", "error"]
+
+var _entries: Array[Dictionary] = []
+var _run_id := ""
+var _dropped_count := 0
+
+
+func append(level: String, text: String) -> void:
+	## Coerce unknown levels to "info" so a misbehaving sender can't poison
+	## downstream filters with arbitrary strings.
+	var safe_level := level if level in VALID_LEVELS else "info"
+	_entries.append({"source": "game", "level": safe_level, "text": text})
+	if _entries.size() > MAX_LINES:
+		var overflow := _entries.size() - MAX_LINES
+		_entries = _entries.slice(overflow)
+		_dropped_count += overflow
+
+
+func get_range(offset: int, count: int) -> Array[Dictionary]:
+	var start := maxi(0, offset)
+	var stop := mini(_entries.size(), start + count)
+	var out: Array[Dictionary] = []
+	for i in range(start, stop):
+		out.append(_entries[i])
+	return out
+
+
+func get_recent(count: int) -> Array[Dictionary]:
+	var start := maxi(0, _entries.size() - count)
+	var out: Array[Dictionary] = []
+	for i in range(start, _entries.size()):
+		out.append(_entries[i])
+	return out
+
+
+## Rotate the run identifier and drop all buffered entries. Called when the
+## game-side autoload sends its mcp:hello beacon, marking a fresh play cycle.
+## Returns the new run_id.
+func clear_for_new_run() -> String:
+	_entries.clear()
+	_dropped_count = 0
+	_run_id = _generate_run_id()
+	return _run_id
+
+
+func total_count() -> int:
+	return _entries.size()
+
+
+func run_id() -> String:
+	return _run_id
+
+
+func dropped_count() -> int:
+	return _dropped_count
+
+
+static func _generate_run_id() -> String:
+	## Opaque to agents — they only check equality. Time-based is plenty
+	## unique within a single editor session and avoids the RNG-seed
+	## reproducibility footgun.
+	return "r%d" % Time.get_ticks_msec()

--- a/src/godot_ai/handlers/editor.py
+++ b/src/godot_ai/handlers/editor.py
@@ -106,8 +106,14 @@ async def editor_screenshot(
             metadata["view_target_count"] = result["view_target_count"]
         if "view_target_not_found" in result:
             metadata["view_target_not_found"] = result["view_target_not_found"]
-    for key in ("elevation", "azimuth", "fov",
-                "aabb_center", "aabb_size", "aabb_longest_ground_axis"):
+    for key in (
+        "elevation",
+        "azimuth",
+        "fov",
+        "aabb_center",
+        "aabb_size",
+        "aabb_longest_ground_axis",
+    ):
         if key in result:
             metadata[key] = result[key]
 
@@ -124,9 +130,7 @@ async def editor_screenshot(
     ]
 
 
-async def performance_monitors_get(
-    runtime: Runtime, monitors: list[str] | None = None
-) -> dict:
+async def performance_monitors_get(runtime: Runtime, monitors: list[str] | None = None) -> dict:
     params: dict = {}
     if monitors:
         params["monitors"] = monitors
@@ -137,10 +141,77 @@ async def logs_clear(runtime: Runtime) -> dict:
     return await runtime.send_command("clear_logs")
 
 
-async def logs_read(runtime: Runtime, count: int = 50, offset: int = 0) -> dict:
-    result = await runtime.send_command("get_logs", {"count": 500})
+_VALID_LOG_SOURCES = ("plugin", "game", "all")
+
+
+async def logs_read(
+    runtime: Runtime,
+    count: int = 50,
+    offset: int = 0,
+    source: str = "plugin",
+    since_run_id: str = "",
+) -> dict:
+    if source not in _VALID_LOG_SOURCES:
+        raise ValueError(f"Invalid source '{source}' — use 'plugin', 'game', or 'all'")
+
+    if source == "plugin":
+        ## Backward-compatible shape: callers asking for the default
+        ## source still receive the historical {lines: [str], ...}
+        ## payload, so existing dashboards and tests don't break.
+        result = await runtime.send_command("get_logs", {"count": 500, "source": "plugin"})
+        ## The plugin response can be either the legacy `{lines: [str]}`
+        ## (older plugin versions) or the new structured shape
+        ## `{lines: [{source, level, text}], ...}`. Normalize to legacy
+        ## strings here so the public Python API doesn't shift under
+        ## existing callers.
+        raw_lines = result.get("lines", [])
+        flat: list[str] = []
+        for entry in raw_lines:
+            if isinstance(entry, dict):
+                flat.append(str(entry.get("text", "")))
+            else:
+                flat.append(str(entry))
+        return paginate(flat, offset, count, key="lines")
+
+    ## game / all: ask the plugin to apply offset+count itself so the
+    ## ring buffer's run_id, dropped_count, and is_running stay
+    ## authoritative on the editor side.
+    result = await runtime.send_command(
+        "get_logs", {"count": count, "offset": offset, "source": source}
+    )
+    run_id = result.get("run_id", "")
+    if since_run_id and run_id and run_id != since_run_id:
+        ## A new game run has started since the caller's last poll —
+        ## tell them to reset their cursor instead of returning stale
+        ## lines from the previous play session.
+        return {
+            "source": source,
+            "lines": [],
+            "total_count": 0,
+            "returned_count": 0,
+            "offset": 0,
+            "limit": count,
+            "has_more": False,
+            "run_id": run_id,
+            "is_running": result.get("is_running", False),
+            "dropped_count": result.get("dropped_count", 0),
+            "stale_run_id": True,
+        }
     lines = result.get("lines", [])
-    return paginate(lines, offset, count, key="lines")
+    total = int(result.get("total_count", len(lines)))
+    return {
+        "source": source,
+        "lines": lines,
+        "total_count": total,
+        "returned_count": len(lines),
+        "offset": offset,
+        "limit": count,
+        "has_more": offset + count < total,
+        "run_id": run_id,
+        "is_running": result.get("is_running", False),
+        "dropped_count": result.get("dropped_count", 0),
+        "stale_run_id": False,
+    }
 
 
 def _find_replacement_session(

--- a/src/godot_ai/tools/editor.py
+++ b/src/godot_ai/tools/editor.py
@@ -42,21 +42,51 @@ def register_editor_tools(mcp: FastMCP) -> None:
         ctx: Context,
         count: int = 50,
         offset: int = 0,
+        source: str = "plugin",
+        since_run_id: str = "",
         session_id: str = "",
     ) -> dict:
-        """Read recent log lines from the Godot editor console.
+        """Read recent log lines from the Godot editor or running game.
 
-        Returns paginated log lines captured by the MCP plugin,
-        including MCP command traffic when logging is enabled.
-        The buffer holds up to 500 lines; pagination windows into that.
+        Three sources are supported:
+
+        - "plugin" (default): MCP plugin's own recv/send/event traffic.
+          Buffer caps at 500 lines. Returns the historical
+          `{lines: [str], total_count, offset, limit, has_more}` shape.
+        - "game": stdout/stderr/push_error/push_warning from the playing
+          game. Captured via a Logger subclass inside the
+          `_mcp_game_helper` autoload (Godot 4.5+) and ferried over the
+          editor-debugger channel. Buffer caps at 2000 lines, clears on
+          each project_run, and survives play-stop. Each entry is a
+          `{source: "game", level: "info"|"warn"|"error", text}` dict.
+          The response also carries `run_id` (rotates per play),
+          `is_running`, and `dropped_count` (ring evictions since the
+          run started).
+        - "all": plugin lines first, then game lines, with `source` on
+          each entry so callers can split. No timestamp merge — pull
+          per-source if you need chronology.
+
+        Tail pattern: poll `logs_read(source="game", offset=N,
+        since_run_id=R)`. When `stale_run_id: true` comes back, reset
+        your offset to 0 and capture the new `run_id`.
 
         Args:
             count: Maximum number of lines to return. Default 50.
             offset: Number of lines to skip from the start. Default 0.
+            source: "plugin", "game", or "all". Default "plugin".
+            since_run_id: When set on a "game"/"all" call, the response
+                carries `stale_run_id: true` if the buffer has rotated to a
+                new run since this id was captured. Reset your offset on stale.
             session_id: Optional Godot session to target. Empty = active session.
         """
         runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
-        return await editor_handlers.logs_read(runtime, count=count, offset=offset)
+        return await editor_handlers.logs_read(
+            runtime,
+            count=count,
+            offset=offset,
+            source=source,
+            since_run_id=since_run_id,
+        )
 
     @mcp.tool(output_schema=None, meta=DEFER_META)
     async def editor_screenshot(

--- a/test_project/project.godot
+++ b/test_project/project.godot
@@ -18,6 +18,10 @@ config/name="MCP Test Project"
 run/main_scene="res://main.tscn"
 config/features=PackedStringArray("4.6")
 
+[autoload]
+
+_mcp_game_helper="*res://addons/godot_ai/runtime/game_helper.gd"
+
 [display]
 
 window/size/viewport_width=1920

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -427,10 +427,82 @@ func test_game_log_buffer_clear_for_new_run_rotates_run_id() -> void:
 	assert_eq(buf.dropped_count(), 0, "dropped_count resets on new run")
 
 
+func test_game_log_buffer_preserves_order_after_multiple_wraps() -> void:
+	## Post O(1)-circular-buffer rewrite: verify that two full wraps still
+	## leave entries in correct logical order, and that get_range across the
+	## wrap boundary doesn't return the physical-slot order by mistake.
+	var buf := GameLogBuffer.new()
+	var cap := GameLogBuffer.MAX_LINES
+	## Fill cap, then wrap 1.5 times: total 2.5 * cap writes.
+	var total := cap * 5 / 2
+	for i in range(total):
+		buf.append("info", "n %d" % i)
+	assert_eq(buf.total_count(), cap, "Buffer caps at MAX_LINES after many wraps")
+	assert_eq(buf.dropped_count(), total - cap, "dropped_count tracks every eviction")
+	## Oldest retained entry should be the first one that survived the drop.
+	var oldest := buf.get_range(0, 1)
+	assert_eq(oldest[0].text, "n %d" % (total - cap), "Oldest is first post-drop entry")
+	## Newest retained entry should be the last append.
+	var newest := buf.get_range(cap - 1, 1)
+	assert_eq(newest[0].text, "n %d" % (total - 1), "Newest is last append")
+	## Sanity — logical ordering is contiguous across the physical wrap.
+	var page := buf.get_range(0, cap)
+	for i in range(cap):
+		var expected := total - cap + i
+		assert_eq(page[i].text, "n %d" % expected, "Entry %d should be 'n %d'" % [i, expected])
+
+
+func test_game_log_buffer_get_recent_works_after_wrap() -> void:
+	var buf := GameLogBuffer.new()
+	var cap := GameLogBuffer.MAX_LINES
+	for i in range(cap + 10):
+		buf.append("info", "w %d" % i)
+	var tail := buf.get_recent(3)
+	assert_eq(tail.size(), 3)
+	assert_eq(tail[0].text, "w %d" % (cap + 10 - 3))
+	assert_eq(tail[1].text, "w %d" % (cap + 10 - 2))
+	assert_eq(tail[2].text, "w %d" % (cap + 10 - 1))
+
+
 # ----- get_logs source routing -----
 
 func test_get_logs_source_invalid_returns_error() -> void:
 	var result := _handler.get_logs({"source": "bogus"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "Invalid source")
+
+
+func test_get_logs_coerces_float_count_and_offset() -> void:
+	## JSON numbers decode to float in Godot — make sure typed locals
+	## don't blow up before the validator can report INVALID_PARAMS.
+	var plugin_buf := McpLogBuffer.new()
+	plugin_buf.log("a")
+	plugin_buf.log("b")
+	plugin_buf.log("c")
+	var handler := EditorHandler.new(plugin_buf)
+	var result := handler.get_logs({"count": 2.0, "offset": 1.0, "source": "plugin"})
+	assert_has_key(result, "data")
+	assert_eq(result.data.lines.size(), 2)
+	assert_contains(result.data.lines[0].text, "b")
+
+
+func test_get_logs_negative_count_floored_to_zero() -> void:
+	## maxi(0, ...) on count means a negative/garbage count returns an
+	## empty page instead of crashing or returning negative-index junk.
+	var plugin_buf := McpLogBuffer.new()
+	plugin_buf.log("only line")
+	var handler := EditorHandler.new(plugin_buf)
+	var result := handler.get_logs({"count": -5, "source": "plugin"})
+	assert_has_key(result, "data")
+	assert_eq(result.data.lines.size(), 0, "Negative count yields empty page")
+
+
+func test_get_logs_null_source_falls_through_to_invalid() -> void:
+	## Explicit null source after coercion becomes the string "<null>",
+	## which fails the VALID_LOG_SOURCES check — user gets INVALID_PARAMS
+	## rather than a GDScript type error.
+	var handler := EditorHandler.new(McpLogBuffer.new())
+	var result := handler.get_logs({"source": null})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 	assert_contains(result.error.message, "Invalid source")
 
@@ -535,3 +607,65 @@ func test_debugger_plugin_log_batch_no_buffer_is_safe() -> void:
 	var plugin := McpDebuggerPlugin.new(null, null)
 	plugin._capture("mcp:log_batch", [[["info", "x"]]], 0)
 	assert_true(true, "No crash when no game buffer is wired")
+
+
+# ----- GameLogger._log_error arg routing (PR #78 smoke bug) -----
+
+const _GAME_LOGGER_PATH := "res://addons/godot_ai/runtime/game_logger.gd"
+
+
+func test_game_logger_single_arg_push_warning_preserves_user_message() -> void:
+	## push_warning("warn-game") → code="warn-game", rationale="". The user's
+	## message must survive; before the fix, rationale was the only source and
+	## the text was discarded.
+	if not ClassDB.class_exists("Logger"):
+		skip("Logger class requires Godot 4.5+")
+		return
+	var logger = load(_GAME_LOGGER_PATH).new()
+	logger._log_error("push_warning", "core/variant/variant_utility.cpp", 1034, "warn-game", "", false, 1, [])
+	var pending: Array = logger.drain()
+	assert_eq(pending.size(), 1)
+	assert_eq(pending[0][0], "warn")
+	assert_contains(pending[0][1], "warn-game", "User's message text must survive single-arg push_warning")
+
+
+func test_game_logger_single_arg_push_error_preserves_user_message() -> void:
+	if not ClassDB.class_exists("Logger"):
+		skip("Logger class requires Godot 4.5+")
+		return
+	var logger = load(_GAME_LOGGER_PATH).new()
+	logger._log_error("push_error", "core/variant/variant_utility.cpp", 1000, "err-game", "", false, 0, [])
+	var pending: Array = logger.drain()
+	assert_eq(pending.size(), 1)
+	assert_eq(pending[0][0], "error")
+	assert_contains(pending[0][1], "err-game", "User's message text must survive single-arg push_error")
+
+
+func test_game_logger_two_arg_push_error_prefers_rationale() -> void:
+	## push_error(code, rationale) — rationale wins, code is not surfaced.
+	if not ClassDB.class_exists("Logger"):
+		skip("Logger class requires Godot 4.5+")
+		return
+	var logger = load(_GAME_LOGGER_PATH).new()
+	logger._log_error("my_func", "res://foo.gd", 42, "ERR_CODE", "detailed reason", false, 0, [])
+	var pending: Array = logger.drain()
+	assert_eq(pending.size(), 1)
+	assert_eq(pending[0][0], "error")
+	assert_contains(pending[0][1], "detailed reason", "Rationale should be used when present")
+	assert_true(not pending[0][1].contains("ERR_CODE"), "Code should not appear when rationale is present")
+
+
+func test_game_logger_printerr_routes_to_error_level() -> void:
+	## _log_message is the print/printerr channel — sanity-check it still works.
+	if not ClassDB.class_exists("Logger"):
+		skip("Logger class requires Godot 4.5+")
+		return
+	var logger = load(_GAME_LOGGER_PATH).new()
+	logger._log_message("oops", true)
+	logger._log_message("hi", false)
+	var pending: Array = logger.drain()
+	assert_eq(pending.size(), 2)
+	assert_eq(pending[0][0], "error")
+	assert_eq(pending[0][1], "oops")
+	assert_eq(pending[1][0], "info")
+	assert_eq(pending[1][1], "hi")

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -365,3 +365,173 @@ func test_screenshot_bogus_source() -> void:
 	var result := _handler.take_screenshot({"source": "bogus"})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 	assert_contains(result.error.message, "Invalid source")
+
+
+# ----- GameLogBuffer (issue #73) -----
+
+func test_game_log_buffer_append_and_get_range() -> void:
+	var buf := GameLogBuffer.new()
+	buf.append("info", "hello")
+	buf.append("warn", "almost out of fuel")
+	buf.append("error", "boom")
+	var entries := buf.get_range(0, 10)
+	assert_eq(entries.size(), 3)
+	assert_eq(entries[0].source, "game")
+	assert_eq(entries[0].level, "info")
+	assert_eq(entries[0].text, "hello")
+	assert_eq(entries[1].level, "warn")
+	assert_eq(entries[2].level, "error")
+	assert_eq(buf.total_count(), 3)
+
+
+func test_game_log_buffer_get_range_offset_and_count() -> void:
+	var buf := GameLogBuffer.new()
+	for i in range(5):
+		buf.append("info", "line %d" % i)
+	var page := buf.get_range(2, 2)
+	assert_eq(page.size(), 2)
+	assert_eq(page[0].text, "line 2")
+	assert_eq(page[1].text, "line 3")
+
+
+func test_game_log_buffer_unknown_level_coerces_to_info() -> void:
+	var buf := GameLogBuffer.new()
+	buf.append("not-a-level", "weird")
+	var entries := buf.get_range(0, 10)
+	assert_eq(entries[0].level, "info", "Unknown level should coerce to info")
+
+
+func test_game_log_buffer_ring_evicts_and_tracks_dropped() -> void:
+	var buf := GameLogBuffer.new()
+	var cap := GameLogBuffer.MAX_LINES
+	for i in range(cap + 5):
+		buf.append("info", "n %d" % i)
+	assert_eq(buf.total_count(), cap, "Buffer should cap at MAX_LINES")
+	assert_eq(buf.dropped_count(), 5, "Should record 5 evictions")
+	## Oldest 5 dropped: first remaining entry should be index 5.
+	var first := buf.get_range(0, 1)
+	assert_eq(first[0].text, "n 5")
+
+
+func test_game_log_buffer_clear_for_new_run_rotates_run_id() -> void:
+	var buf := GameLogBuffer.new()
+	buf.append("info", "before")
+	## Time.get_ticks_msec changes between calls — guarantees distinct ids.
+	var first_id := buf.clear_for_new_run()
+	assert_ne(first_id, "", "Initial clear should return a non-empty run id")
+	assert_eq(buf.total_count(), 0, "Buffer should be empty after clear")
+	OS.delay_msec(2)
+	buf.append("info", "after")
+	var second_id := buf.clear_for_new_run()
+	assert_ne(first_id, second_id, "Each clear should rotate the run id")
+	assert_eq(buf.dropped_count(), 0, "dropped_count resets on new run")
+
+
+# ----- get_logs source routing -----
+
+func test_get_logs_source_invalid_returns_error() -> void:
+	var result := _handler.get_logs({"source": "bogus"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "Invalid source")
+
+
+func test_get_logs_source_plugin_returns_structured_lines() -> void:
+	var plugin_buf := McpLogBuffer.new()
+	plugin_buf.log("first")
+	plugin_buf.log("second")
+	var handler := EditorHandler.new(plugin_buf)
+	var result := handler.get_logs({"source": "plugin", "count": 10})
+	assert_has_key(result, "data")
+	assert_eq(result.data.source, "plugin")
+	assert_eq(result.data.lines.size(), 2)
+	assert_eq(result.data.lines[0].source, "plugin")
+	assert_eq(result.data.lines[0].level, "info")
+	assert_contains(result.data.lines[0].text, "first")
+
+
+func test_get_logs_source_game_empty_when_no_buffer() -> void:
+	var handler := EditorHandler.new(McpLogBuffer.new())
+	var result := handler.get_logs({"source": "game", "count": 10})
+	assert_has_key(result, "data")
+	assert_eq(result.data.source, "game")
+	assert_eq(result.data.lines.size(), 0)
+	assert_eq(result.data.run_id, "")
+	assert_has_key(result.data, "is_running")
+	assert_has_key(result.data, "dropped_count")
+
+
+func test_get_logs_source_game_returns_buffered_entries() -> void:
+	var game_buf := GameLogBuffer.new()
+	game_buf.clear_for_new_run()
+	game_buf.append("info", "spawned 12 blocks")
+	game_buf.append("error", "null deref")
+	var handler := EditorHandler.new(McpLogBuffer.new(), null, null, game_buf)
+	var result := handler.get_logs({"source": "game", "count": 10})
+	assert_eq(result.data.source, "game")
+	assert_eq(result.data.lines.size(), 2)
+	assert_eq(result.data.lines[0].text, "spawned 12 blocks")
+	assert_eq(result.data.lines[1].level, "error")
+	assert_ne(result.data.run_id, "", "run_id should be set after clear_for_new_run")
+
+
+func test_get_logs_source_game_offset_applies() -> void:
+	var game_buf := GameLogBuffer.new()
+	for i in range(5):
+		game_buf.append("info", "g %d" % i)
+	var handler := EditorHandler.new(McpLogBuffer.new(), null, null, game_buf)
+	var result := handler.get_logs({"source": "game", "count": 2, "offset": 2})
+	assert_eq(result.data.returned_count, 2)
+	assert_eq(result.data.lines[0].text, "g 2")
+	assert_eq(result.data.lines[1].text, "g 3")
+	assert_eq(result.data.offset, 2)
+	assert_eq(result.data.total_count, 5)
+
+
+func test_get_logs_source_all_includes_both_streams() -> void:
+	var plugin_buf := McpLogBuffer.new()
+	plugin_buf.log("plugin-a")
+	plugin_buf.log("plugin-b")
+	var game_buf := GameLogBuffer.new()
+	game_buf.append("warn", "game-c")
+	var handler := EditorHandler.new(plugin_buf, null, null, game_buf)
+	var result := handler.get_logs({"source": "all", "count": 10})
+	assert_eq(result.data.source, "all")
+	assert_eq(result.data.lines.size(), 3)
+	## Plugin lines come first, then game.
+	assert_eq(result.data.lines[0].source, "plugin")
+	assert_eq(result.data.lines[1].source, "plugin")
+	assert_eq(result.data.lines[2].source, "game")
+	assert_eq(result.data.lines[2].level, "warn")
+	assert_eq(result.data.lines[2].text, "game-c")
+
+
+# ----- McpDebuggerPlugin: log batch capture (issue #73) -----
+
+func test_debugger_plugin_log_batch_appends_to_buffer() -> void:
+	var game_buf := GameLogBuffer.new()
+	var plugin := McpDebuggerPlugin.new(null, game_buf)
+	plugin._capture("mcp:log_batch", [[
+		["info", "alpha"],
+		["error", "beta"],
+	]], 0)
+	assert_eq(game_buf.total_count(), 2)
+	var entries := game_buf.get_range(0, 10)
+	assert_eq(entries[0].text, "alpha")
+	assert_eq(entries[1].level, "error")
+
+
+func test_debugger_plugin_hello_rotates_run_id() -> void:
+	var game_buf := GameLogBuffer.new()
+	game_buf.append("info", "stale from previous run")
+	var plugin := McpDebuggerPlugin.new(null, game_buf)
+	plugin._capture("mcp:hello", [], 0)
+	assert_eq(game_buf.total_count(), 0, "hello should clear the game buffer")
+	assert_ne(game_buf.run_id(), "", "hello should set a run_id")
+
+
+func test_debugger_plugin_log_batch_no_buffer_is_safe() -> void:
+	## Plugin started without a game buffer should silently no-op on
+	## log batches rather than crash — defensive for partial init.
+	var plugin := McpDebuggerPlugin.new(null, null)
+	plugin._capture("mcp:log_batch", [[["info", "x"]]], 0)
+	assert_true(true, "No crash when no game buffer is wired")

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -314,6 +314,76 @@ class TestLogsReadTool:
         assert data["limit"] == 3
         assert data["has_more"] is True
 
+    async def test_source_game_passes_through_and_returns_structured(self, mcp_stack):
+        client, plugin = mcp_stack
+        entries = [
+            {"source": "game", "level": "info", "text": "spawned 12 blocks"},
+            {"source": "game", "level": "warn", "text": "low fps"},
+            {"source": "game", "level": "error", "text": "null deref"},
+        ]
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "get_logs"
+            assert cmd["params"]["source"] == "game"
+            assert cmd["params"]["count"] == 50
+            assert cmd["params"]["offset"] == 0
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "source": "game",
+                    "lines": entries,
+                    "total_count": 3,
+                    "returned_count": 3,
+                    "offset": 0,
+                    "run_id": "rABC",
+                    "is_running": True,
+                    "dropped_count": 4,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool("logs_read", {"source": "game"})
+        await task
+
+        data = result.data
+        assert data["source"] == "game"
+        assert data["lines"] == entries
+        assert data["run_id"] == "rABC"
+        assert data["is_running"] is True
+        assert data["dropped_count"] == 4
+        assert data["stale_run_id"] is False
+
+    async def test_since_run_id_stale_returns_empty(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "source": "game",
+                    "lines": [
+                        {"source": "game", "level": "info", "text": "x"},
+                    ],
+                    "total_count": 1,
+                    "returned_count": 1,
+                    "offset": 0,
+                    "run_id": "rNEW",
+                    "is_running": True,
+                    "dropped_count": 0,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool("logs_read", {"source": "game", "since_run_id": "rOLD"})
+        await task
+
+        data = result.data
+        assert data["stale_run_id"] is True
+        assert data["lines"] == []
+        assert data["run_id"] == "rNEW"
+
 
 # ---------------------------------------------------------------------------
 # node_find

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -56,6 +56,39 @@ class StubClient:
         if command == "quit_editor":
             return {"status": "quitting", "message": "Editor quit initiated"}
         if command == "get_logs":
+            params_dict = params or {}
+            source = params_dict.get("source", "plugin")
+            if source == "game":
+                req_offset = int(params_dict.get("offset", 0))
+                req_count = int(params_dict.get("count", 50))
+                all_entries = [
+                    {"source": "game", "level": "info", "text": f"game {i}"} for i in range(5)
+                ]
+                page = all_entries[req_offset : req_offset + req_count]
+                return {
+                    "source": "game",
+                    "lines": page,
+                    "total_count": len(all_entries),
+                    "returned_count": len(page),
+                    "offset": req_offset,
+                    "run_id": "rstub",
+                    "is_running": True,
+                    "dropped_count": 0,
+                }
+            if source == "all":
+                return {
+                    "source": "all",
+                    "lines": [
+                        {"source": "plugin", "level": "info", "text": "p0"},
+                        {"source": "game", "level": "warn", "text": "g0"},
+                    ],
+                    "total_count": 2,
+                    "returned_count": 2,
+                    "offset": 0,
+                    "run_id": "rstub",
+                    "is_running": True,
+                    "dropped_count": 0,
+                }
             return {"lines": [f"line {i}" for i in range(6)]}
         if command == "get_project_setting":
             key = params["key"] if params else ""
@@ -1163,6 +1196,89 @@ async def test_logs_read_handler_uses_runtime_and_paginates():
     assert result["limit"] == 2
     assert result["total_count"] == 6
     assert result["has_more"] is True
+
+
+async def test_logs_read_handler_invalid_source_raises():
+    runtime = DirectRuntime(registry=SessionRegistry(), client=StubClient())
+
+    with pytest.raises(ValueError, match="Invalid source"):
+        await editor_handlers.logs_read(runtime, source="bogus")
+
+
+async def test_logs_read_handler_source_game_passes_through():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+
+    result = await editor_handlers.logs_read(runtime, count=2, offset=1, source="game")
+
+    ## Plugin params should carry source + offset/count so the buffer can
+    ## window itself authoritatively (preserving run_id semantics).
+    last_call = client.calls[-1]
+    assert last_call["command"] == "get_logs"
+    assert last_call["params"] == {"count": 2, "offset": 1, "source": "game"}
+
+    assert result["source"] == "game"
+    assert result["lines"] == [
+        {"source": "game", "level": "info", "text": "game 1"},
+        {"source": "game", "level": "info", "text": "game 2"},
+    ]
+    assert result["total_count"] == 5
+    assert result["returned_count"] == 2
+    assert result["run_id"] == "rstub"
+    assert result["is_running"] is True
+    assert result["dropped_count"] == 0
+    assert result["has_more"] is True
+    assert result["stale_run_id"] is False
+
+
+async def test_logs_read_handler_since_run_id_stale_returns_empty():
+    runtime = DirectRuntime(registry=SessionRegistry(), client=StubClient())
+
+    result = await editor_handlers.logs_read(runtime, source="game", since_run_id="r-old")
+
+    assert result["stale_run_id"] is True
+    assert result["lines"] == []
+    assert result["run_id"] == "rstub"
+
+
+async def test_logs_read_handler_source_all_returns_structured():
+    runtime = DirectRuntime(registry=SessionRegistry(), client=StubClient())
+
+    result = await editor_handlers.logs_read(runtime, source="all")
+
+    assert result["source"] == "all"
+    assert result["lines"][0]["source"] == "plugin"
+    assert result["lines"][1]["source"] == "game"
+    assert result["lines"][1]["level"] == "warn"
+    assert result["run_id"] == "rstub"
+
+
+async def test_logs_read_handler_plugin_normalizes_structured_payload():
+    ## A plugin upgrade ships structured entries even for source=plugin;
+    ## the public Python API still returns the legacy [str] shape for that
+    ## source so existing callers don't shift.
+    class StructuredPluginClient(StubClient):
+        async def send(self, command, params=None, session_id=None, timeout=5.0):
+            self.calls.append(
+                {
+                    "command": command,
+                    "params": params,
+                    "session_id": session_id,
+                    "timeout": timeout,
+                }
+            )
+            return {
+                "lines": [
+                    {"source": "plugin", "level": "info", "text": "structured 0"},
+                    {"source": "plugin", "level": "info", "text": "structured 1"},
+                ]
+            }
+
+    runtime = DirectRuntime(registry=SessionRegistry(), client=StructuredPluginClient())
+
+    result = await editor_handlers.logs_read(runtime, count=10)
+
+    assert result["lines"] == ["structured 0", "structured 1"]
 
 
 async def test_project_settings_resource_collects_results():
@@ -2290,9 +2406,7 @@ async def test_physics_shape_autofit_handler():
 async def test_physics_shape_autofit_minimal_omits_empty():
     client = StubClient()
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)
-    await physics_shape_handlers.physics_shape_autofit(
-        runtime, path="/Main/Body/Collision"
-    )
+    await physics_shape_handlers.physics_shape_autofit(runtime, path="/Main/Body/Collision")
     params = client.calls[-1]["params"]
     assert "source_path" not in params
     assert "shape_type" not in params
@@ -2314,9 +2428,7 @@ async def test_physics_shape_autofit_requires_writable():
     registry.register(session)
     runtime = DirectRuntime(registry=registry, client=client)
     with pytest.raises(GodotCommandError):
-        await physics_shape_handlers.physics_shape_autofit(
-            runtime, path="/Main/Body/Collision"
-        )
+        await physics_shape_handlers.physics_shape_autofit(runtime, path="/Main/Body/Collision")
 
 
 async def test_resource_create_requires_writable():


### PR DESCRIPTION
## Summary

Extends `logs_read` with a new `source="game"` mode that surfaces the **running game's** output — `print()`, `printerr()`, `push_warning()`, `push_error()` — instead of just the MCP plugin's own recv/send/event traffic. Agents can now verify runtime behavior: "did my `_ready` actually fire? did that physics body error? are my print statements showing the values I expect?"

Closes #73.

## Why

Before this PR, `logs_read` only reflected the plugin's view of its own work (`MCP | [recv] create_node(...)`, etc.). Anything the *game* printed was invisible to agents. The only workaround was to attach a human-run console — which defeats the point of driving Godot from an MCP client. Since PR #76 already established a debugger-message bridge between the plugin and the game process (for game-viewport screenshots), we can reuse that bridge to ferry log lines back.

## How it works

```
   game process                editor process              MCP client
  ┌──────────────┐          ┌─────────────────┐          ┌──────────┐
  │ print()      │          │                 │          │          │
  │ printerr()   │   mcp:   │ McpDebuggerPlug │          │          │
  │ push_warn()  │  log_    │  _capture()     │          │          │
  │ push_error() │  batch   │       ↓         │          │          │
  │      ↓       │ ───────→ │ GameLogBuffer   │ ←──────  │logs_read │
  │ GameLogger   │          │ (ring, cap=2000)│          │ source=  │
  │  (Logger     │          │                 │          │ "game"   │
  │   subclass)  │          │                 │          │          │
  └──────────────┘          └─────────────────┘          └──────────┘
   1 batch/frame,             structured entries,          offset/count
   Mutex-protected            run_id cursor                pagination
```

**Game side** (runs inside the playing game's OS process):

- `runtime/game_logger.gd` — new `Logger` subclass attached via `OS.add_logger()`. Catches all four log channels, buffers under a `Mutex` (Logger virtuals can fire off-main from async loaders / threaded resource imports), exposes `drain()` for the host. No `class_name` — loaded dynamically after an `OS.has_method("add_logger")` + `ClassDB.class_exists("Logger")` gate so the file isn't parsed on Godot 4.4 (the Logger class didn't exist yet).
- `runtime/game_helper.gd` — installs the logger on `_ready`, then on each `_process` sends **at most one** `FLUSH_BATCH_LIMIT`-sized batch over `EngineDebugger.send_message("mcp:log_batch", ...)`. Surplus stays in `_pending_outbound` and bleeds out across subsequent frames so a runaway `for i in 100000: print(i)` can't stall the editor.

**Editor side:**

- `utils/game_log_buffer.gd` — O(1) head-indexed circular buffer, cap 2000. Stores `{source: "game", level: "info"|"warn"|"error", text: str}` dicts. Tracks `run_id` (rotated on every `mcp:hello` boot beacon so each play cycle is a fresh cursor) and `dropped_count` (how many were evicted by overflow).
- `debugger/mcp_debugger_plugin.gd` — captures `mcp:log_batch` and appends to the game buffer. `mcp:hello` (already used as a "game has started" beacon) now also rotates `run_id` so agents can tell one run apart from the next.

**Python tool:**

- `handlers/editor.py` + `tools/editor.py` — `logs_read` takes a `source` parameter (`"plugin"` default, `"game"`, `"all"`) and an optional `since_run_id`. Plugin source keeps its legacy `{lines: [str]}` response shape for backward compatibility. Game/all return structured entries plus `run_id`, `is_running`, `dropped_count`, `stale_run_id`, `total_count`, `has_more`.

## API shape

```python
# Tail the game output from the current run:
logs_read(source="game", count=50)
# →
# {
#   "source": "game",
#   "lines": [
#     {"source": "game", "level": "info",  "text": "hello-game\n"},
#     {"source": "game", "level": "warn",  "text": "low fps"},
#     {"source": "game", "level": "error", "text": "null deref"},
#   ],
#   "total_count": 3, "returned_count": 3, "offset": 0, "limit": 50,
#   "has_more": false, "run_id": "r12345", "is_running": true,
#   "dropped_count": 0, "stale_run_id": false,
# }

# Incremental poll: pass the run_id you last saw.
# If the game restarted between polls, stale_run_id: true and lines: []
# tells you to reset your cursor.
logs_read(source="game", since_run_id="r12345")

# Merged view of plugin and game streams:
logs_read(source="all", count=50)
```

## Edge cases

- **Godot 4.4 compatibility** — `Logger` class and `OS.add_logger` are 4.5+. The loader script is only `load()`-ed inside the version gate, so 4.4 never parses it and the rest of the game helper still works (just without log capture).
- **Off-main-thread logging** — `Logger` virtuals can fire from any thread. `GameLogger` accumulates under a `Mutex`; the host drains from `_process` on the main thread before calling `EngineDebugger.send_message`, which is only safe from main.
- **Run rotation** — each `mcp:hello` beacon rotates `run_id` + clears the buffer. `logs_read(since_run_id=...)` with a stale id returns `stale_run_id: true` and an empty `lines` — callers reset their cursor instead of seeing last run's output.
- **Backpressure** — 2000-entry cap, one batch per frame, `dropped_count` surfaced so callers can detect "the game is spamming faster than I'm polling."
- **Per-value coercion** — `count`/`offset` come through as JSON floats from some clients; defensive `int()`/`str()` coercion in `get_logs` keeps malformed payloads from faulting before the `INVALID_PARAMS` return path can report the problem.
- **Single-arg `push_error`/`push_warning`** — Godot's Logger virtual passes the user's string in the `code` arg (not `rationale`) for the one-arg form. We fall back to `code` when `rationale` is empty, and walk `script_backtraces` to surface the user's GDScript caller location instead of Godot's internal C++ frame.

## Tests

- **Python** — 3 new integration tests in `tests/integration/test_mcp_tools.py` cover `source="game"` pass-through, `since_run_id` stale handling, and the merged-all view. 6 new unit tests in `tests/unit/test_runtime_handlers.py` cover the pagination + stale run id + invalid-source paths.
- **GDScript** — 20+ new tests in `test_project/tests/test_editor.gd` covering `GameLogBuffer` (append/get_range/offset/unknown level/ring eviction/clear_for_new_run/multi-wrap ordering/get_recent-after-wrap), `McpDebuggerPlugin._capture` (log_batch routing, hello rotation, safe no-op when buffer is absent), `get_logs` source routing (plugin/game/all/bogus, float coercion, negative count, null source), and `GameLogger._log_error` arg routing (single-arg push_error/push_warning, two-arg rationale preference, printerr level).
- **Live smoke on an M1 Mac** — verified the full pipeline end-to-end with a scene that fires `print`, `printerr`, `push_warning`, `push_error`, plus a 2500-print backpressure burst. Confirmed `total_count=2000` cap, `dropped_count=505`, editor stays at 145 FPS with 16ms `editor_state` round-trips during the spam.

## Commits since initial review

- `6735d45` — original feature (this description).
- `decb296` — fix single-arg `push_error`/`push_warning` capture. The logger was only reading `rationale`, so `push_warning("warn-game")` surfaced as `" (core/variant/variant_utility.cpp:1034 @ push_warning)"` — user message lost, location pointing at Godot's own C++. Now falls back to `code` and prefers `script_backtraces[0]` for the caller location. Adds 4 GDScript tests.
- `f1b92b7` — addresses Copilot review: O(1) circular `GameLogBuffer` (was reallocating on every drop), one-batch-per-frame cap actually enforced in `game_helper._process` (previous loop drained the whole queue), defensive `int()`/`str()` coercion in `get_logs`, and commits `test_project/project.godot`'s `_mcp_game_helper` autoload entry so fresh clones don't need a bootstrap run.
