### PR TITLE
docs: worktree scene-autosave + multi-session smoke hygiene

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,27 @@ Claude Code sessions often run in git worktrees (`.claude/worktrees/<name>/`). B
 
 If you need worktree-specific test_project changes, use your own worktree (the one your session created), commit frequently, and never point Godot at a worktree owned by another session.
 
+### Live-smoke scene hygiene
+
+Write tools that mutate the scene (`script_attach`, `node_create`, `node_set_property`, etc.) dirty the scene in memory but don't touch disk. `project_run` with any mode internally calls `try_autosave()` → `_save_scene_with_preview()`, which **persists those in-memory mutations to the scene file on disk**. A common trap during live smoke tests: attach a throwaway script to `/Main`, run the scene to exercise `_ready()`, and discover the attachment is now committed to `test_project/main.tscn`.
+
+Two safe patterns:
+- **Attach to a throwaway scene** dedicated to smoke work, not to `main.tscn` or any scene a test suite depends on.
+- **Plan to revert**: after smoking, `git status` in the worktree and `git checkout -- test_project/<scene>` to undo any autosaved pollution. Verify before staging.
+
+Also note: `script_create` and `filesystem_write_text` are **not undoable** — they write `.gd`/`.uid`/other files directly to disk and response bodies carry `"undoable": false` with a reason. Smoke artifacts need explicit cleanup (`rm` the file pair, or `git clean -n` first to preview).
+
+### Working in another session's worktree
+
+Sometimes you're directed at another session's PR worktree (e.g. to fix a bug their friction log surfaced) and that session still has in-flight uncommitted work in adjacent files. Coexist safely:
+
+1. **Inspect before you touch**: run `git status` and `git diff --stat` in the target worktree first so you know which files are already dirty — that's the other session's work, not your canvas.
+2. **Stage by explicit path**: `git add plugin/foo.gd test_project/tests/test_foo.gd`, never `git add .` or `git add -A`. Even if their uncommitted work looks related to yours, it isn't yours to commit.
+3. **Multi-editor is fine when you need the PR's live plugin code**: launch a second Godot editor pointed at the PR worktree's `test_project/` alongside any existing editor — both connect to the same MCP server on port 8000 and show up in `session_list`. Use `session_activate` to pin your commands to the right session. This beats killing the other session's editor or rsync'ing PR code over an unrelated project.
+4. **Accept the auto-clean risk**: a worktree owned by another session can be removed when that session exits. Commit (and ideally push) as soon as your fix and tests are green — don't leave uncommitted work in a worktree you don't own.
+5. **Revert your own autosave pollution** before committing (see "Live-smoke scene hygiene"). Running the scene during smoke will dirty the scene file with any in-memory mutations you staged.
+6. **Push only what's yours**: don't push the branch if it still contains another session's uncommitted experimental work — they may not be ready. When in doubt, commit locally and ask.
+
 ## Dev workflow
 
 ```bash


### PR DESCRIPTION
## Summary

Two worktree-safety traps surfaced while fixing a push_error/push_warning capture bug in another session's PR worktree ([PR #78](https://github.com/hi-godot/godot-ai/pull/78), commit [decb296](https://github.com/hi-godot/godot-ai/commit/decb296)). Neither was covered by existing CLAUDE.md guidance.

**Scene autosave pollution.** `script_attach` dirties the scene in memory; a subsequent `project_run` triggers `try_autosave()` → `_save_scene_with_preview()`, which persists those in-memory mutations to `test_project/main.tscn` on disk. Caught it via `git status` before committing; easy to miss.

**Multi-session coexistence.** The PR worktree had ~223 lines of uncommitted in-flight work from the session that owned it. The existing "never point Godot at another session's worktree" rule is too absolute — sometimes the PR's live plugin code is precisely what you need to smoke. Documents the multi-editor-one-server pattern (launch a second Godot on the PR's `test_project/`, connect to the same MCP server on port 8000, use `session_activate` to pin commands) as the right answer.

## Changes

- New `### Live-smoke scene hygiene` subsection: autosave trap + non-undoable `script_create`/`filesystem_write_text` cleanup.
- New `### Working in another session's worktree` subsection: six-step coexistence checklist covering inspection, explicit staging, multi-editor usage, auto-clean risk acceptance, pollution reversion, and push discipline.

Also closes the intent of the stale `docs/worktree-safety-guidelines` branch (already landed via [#55](https://github.com/hi-godot/godot-ai/pull/55), now behind main) — that branch can be deleted.

## Test plan

- [ ] Read the diff; content matches the friction log findings from PR #78's smoke session
- [ ] No code changes, no test impact
