### PR TITLE
docs: add star history chart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,4 +154,12 @@ See [CONTRIBUTING.md](docs/CONTRIBUTING.md) for development setup, testing, and 
 
 ---
 
+## Star History
+
+<a href="https://star-history.com/#hi-godot/godot-ai&Date">
+  <img src="https://api.star-history.com/svg?repos=hi-godot/godot-ai&type=Date" alt="Star History Chart" width="700">
+</a>
+
+---
+
 **License:** [MIT](LICENSE) | **Issues:** [GitHub](https://github.com/hi-godot/godot-ai/issues)


### PR DESCRIPTION
## Summary
- Add a **Star History** section to the README that renders a live star-history.com chart of the repo star count over time, linking to the interactive version.

## Test plan
- [ ] Confirm the chart renders on the rendered README on GitHub

Generated with [Claude Code](https://claude.com/claude-code)
