### PR TITLE
fix: v1.1.0 install-smoke UX bundle (#87, #88, #89)

### DIFF
--- a/plugin/addons/godot_ai/handlers/animation_handler.gd
+++ b/plugin/addons/godot_ai/handlers/animation_handler.gd
@@ -1323,13 +1323,24 @@ static func _coerce_value_for_track(value: Variant, track_path: String, player: 
 ##   {pass_through: true}                   — no resolution / authoring-time
 ##   {pass_through: false, prop_type, prop_name}  — coerce against this type
 ##   {error: msg}                           — property not found on target
+##
+## Supports Godot's native NodePath subpath form `property:sub` (e.g.
+## `position:y`, `modulate:a`) — splits on the FIRST colon (node↔property
+## boundary), resolves the base property on the target, and for known
+## scalar subpaths (x/y/z/w on vectors, r/g/b/a on Color) narrows the
+## coerce target to TYPE_FLOAT so JSON numbers land as floats, not dicts.
 static func _resolve_track_prop_context(track_path: String, player: AnimationPlayer) -> Dictionary:
-	var colon := track_path.rfind(":")
+	var colon := track_path.find(":")
 	if colon < 0:
 		return {"pass_through": true}
 
 	var node_part := track_path.substr(0, colon)
-	var prop_part := track_path.substr(colon + 1)
+	var prop_full := track_path.substr(colon + 1)
+
+	# Property may include a subpath: "position:y", "modulate:a", etc.
+	var sub_colon := prop_full.find(":")
+	var prop_base := prop_full if sub_colon < 0 else prop_full.substr(0, sub_colon)
+	var prop_sub := "" if sub_colon < 0 else prop_full.substr(sub_colon + 1)
 
 	var root_node: Node = null
 	if player.is_inside_tree():
@@ -1347,18 +1358,54 @@ static func _resolve_track_prop_context(track_path: String, player: AnimationPla
 		return {"pass_through": true}
 
 	for p in target.get_property_list():
-		if p.name == prop_part:
+		if p.name == prop_base:
+			var base_type: int = p.get("type", TYPE_NIL)
+			var coerce_type := base_type
+			if not prop_sub.is_empty():
+				var sub_type := _subpath_component_type(base_type, prop_sub)
+				if sub_type == TYPE_NIL:
+					# Unknown subpath component — pass through so Godot's own
+					# NodePath resolution raises at playback if it's truly bogus,
+					# rather than fabricating a coerce error for a valid-but-
+					# uncommon form (e.g. Transform3D subpaths).
+					return {"pass_through": true}
+				coerce_type = sub_type
 			return {
 				"pass_through": false,
-				"prop_type": p.get("type", TYPE_NIL),
-				"prop_name": prop_part,
+				"prop_type": coerce_type,
+				"prop_name": prop_full,
 			}
 
 	# Target exists but the property doesn't. Reject loudly — silently storing
 	# the raw value here produces garbage keyframes at playback time.
 	return {"error":
 		"%s (target path: '%s')" %
-		[McpPropertyErrors.build_message(target, prop_part), node_part]}
+		[McpPropertyErrors.build_message(target, prop_base), node_part]}
+
+
+## Component letters accepted on each aggregate base type, paired with the
+## scalar Variant type the component resolves to. A subpath like `position:y`
+## on a Vector3 maps to TYPE_FLOAT; on a Vector3i it maps to TYPE_INT.
+const _SUBPATH_COMPONENTS := {
+	TYPE_VECTOR2: ["xy", TYPE_FLOAT],
+	TYPE_VECTOR3: ["xyz", TYPE_FLOAT],
+	TYPE_VECTOR4: ["xyzw", TYPE_FLOAT],
+	TYPE_QUATERNION: ["xyzw", TYPE_FLOAT],
+	TYPE_COLOR: ["rgba", TYPE_FLOAT],
+	TYPE_VECTOR2I: ["xy", TYPE_INT],
+	TYPE_VECTOR3I: ["xyz", TYPE_INT],
+	TYPE_VECTOR4I: ["xyzw", TYPE_INT],
+}
+
+
+## Map a `property:sub` subpath to its scalar component type. Returns
+## TYPE_NIL when the base type / subkey pair isn't one we recognise —
+## callers pass-through in that case rather than mis-coerce.
+static func _subpath_component_type(base_type: int, sub: String) -> int:
+	var entry = _SUBPATH_COMPONENTS.get(base_type)
+	if entry == null or sub.length() != 1:
+		return TYPE_NIL
+	return entry[1] if (entry[0] as String).contains(sub) else TYPE_NIL
 
 
 static func _coerce_with_context(value: Variant, ctx: Dictionary) -> Dictionary:

--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -445,13 +445,16 @@ func _get_visual_aabb(node: Node3D) -> AABB:
 ## Calculate a camera Transform3D that frames the given AABB nicely.
 ## elevation_deg: camera elevation (0 = level, 90 = directly above). Default 25.
 ## azimuth_deg: camera azimuth (0 = front, 90 = right side). Default 30.
-## padding: distance multiplier for breathing room (1.2 = tight, 2.5 = context). Default 1.2.
-func _frame_transform_for_aabb(aabb: AABB, fov_degrees: float = 75.0, elevation_deg: float = 25.0, azimuth_deg: float = 30.0, padding: float = 1.2) -> Transform3D:
+## padding: distance multiplier for breathing room (1.2 = tight, 2.5 = context). Default 1.8.
+func _frame_transform_for_aabb(aabb: AABB, fov_degrees: float = 75.0, elevation_deg: float = 25.0, azimuth_deg: float = 30.0, padding: float = 1.8) -> Transform3D:
 	var center := aabb.get_center()
 	var radius := aabb.size.length() * 0.5
 	var fov_rad := deg_to_rad(fov_degrees)
 	var distance := radius / tan(fov_rad * 0.5) * padding
-	distance = maxf(distance, radius * 2.0)
+	## Floor with an absolute offset so unit-scale AABBs don't place the camera
+	## inside or against the target. `radius * 2.0` alone scales to zero as the
+	## AABB shrinks; the +1.0 guarantees a minimum of ~1 world-unit of standoff.
+	distance = maxf(distance, radius * 2.0 + 1.0)
 	var elev := deg_to_rad(elevation_deg)
 	var azim := deg_to_rad(azimuth_deg)
 	var cam_pos := center + Vector3(

--- a/plugin/addons/godot_ai/handlers/material_handler.gd
+++ b/plugin/addons/godot_ai/handlers/material_handler.gd
@@ -114,9 +114,9 @@ func set_param(params: Dictionary) -> Dictionary:
 	var mat: Material = load_result.material
 	var mat_path: String = load_result.path
 
-	var property: String = params.get("property", "")
+	var property: String = params.get("param", "")
 	if property.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: property")
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: param")
 
 	if not ("value" in params):
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: value")

--- a/src/godot_ai/handlers/material.py
+++ b/src/godot_ai/handlers/material.py
@@ -25,13 +25,13 @@ async def material_create(
 async def material_set_param(
     runtime: Runtime,
     path: str,
-    property: str,
+    param: str,
     value: Any,
 ) -> dict:
     require_writable(runtime)
     return await runtime.send_command(
         "material_set_param",
-        {"path": path, "property": property, "value": value},
+        {"path": path, "param": param, "value": value},
     )
 
 

--- a/src/godot_ai/tools/material.py
+++ b/src/godot_ai/tools/material.py
@@ -83,19 +83,19 @@ def register_material_tools(mcp: FastMCP) -> None:
     async def material_set_param(
         ctx: Context,
         path: str,
-        property: str,
+        param: str,
         value: Any,
         session_id: str = "",
     ) -> dict:
         """Set a built-in property on a material .tres file.
 
         Works for StandardMaterial3D / ORMMaterial3D / CanvasItemMaterial.
-        Property names match the Godot class reference (e.g. "albedo_color",
+        Param names match the Godot class reference (e.g. "albedo_color",
         "metallic", "roughness", "emission_enabled", "emission",
         "emission_energy_multiplier", "normal_enabled", "normal_texture",
         "albedo_texture", "transparency").
 
-        Enum-valued properties accept either an int or a string name:
+        Enum-valued params accept either an int or a string name:
         ``transparency="alpha"`` → ``TRANSPARENCY_ALPHA``;
         ``shading_mode="unshaded"`` → ``SHADING_MODE_UNSHADED``.
 
@@ -103,7 +103,7 @@ def register_material_tools(mcp: FastMCP) -> None:
 
         Args:
             path: res:// path to the material .tres file.
-            property: Property name (e.g. "albedo_color", "metallic",
+            param: Property name (e.g. "albedo_color", "metallic",
                 "emission_enabled", "transparency").
             value: Value to set. Colors accept hex strings, named colors,
                 or {r, g, b, a} dicts. Vectors accept {x, y, z} dicts.
@@ -112,7 +112,7 @@ def register_material_tools(mcp: FastMCP) -> None:
         """
         runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await material_handlers.material_set_param(
-            runtime, path=path, property=property, value=value
+            runtime, path=path, param=param, value=value
         )
 
     @mcp.tool(meta=DEFER_META)

--- a/test_project/tests/test_animation.gd
+++ b/test_project/tests/test_animation.gd
@@ -404,6 +404,79 @@ func test_add_property_track_coerces_vector3_dict() -> void:
 	_remove_node(player_path)
 
 
+func test_add_property_track_accepts_vector_subpath() -> void:
+	# Godot-native NodePath subpath form (`position:y`) must resolve to the
+	# `y` float component, not error as "Property 'y' not found".
+	var player_path := _add_player("TestSubpathVec")
+	if player_path.is_empty():
+		skip("Scene not ready — _add_player returned empty path")
+		return
+	_handler.create_animation({"player_path": player_path, "name": "bob", "length": 1.0})
+	var result := _handler.add_property_track({
+		"player_path": player_path,
+		"animation_name": "bob",
+		"track_path": ".:position:y",
+		"keyframes": [
+			{"time": 0.0, "value": 0.0},
+			{"time": 1.0, "value": 2.0},
+		],
+	})
+	assert_has_key(result, "data")
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var player := ScenePath.resolve(player_path, scene_root) as AnimationPlayer
+	var anim: Animation = player.get_animation("bob")
+	var k0 = anim.track_get_key_value(0, 0)
+	var k1 = anim.track_get_key_value(0, 1)
+	# Subpath coercion must land scalar floats in the keyframes — never a
+	# Vector3 dict masquerading as a keyframe value.
+	assert_true(k0 is float, "keyframe 0 should be float for position:y subpath")
+	assert_true(k1 is float, "keyframe 1 should be float for position:y subpath")
+	assert_eq(k1, 2.0)
+	_remove_node(player_path)
+
+
+func test_create_simple_accepts_color_subpath() -> void:
+	# Fade-just-the-alpha flow: `modulate:a` subpath targets a Color component,
+	# which must coerce to float so the animation plays an alpha ramp, not a
+	# broken dict-valued track.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var sprite := Sprite2D.new()
+	sprite.name = "SubpathAlphaSprite"
+	scene_root.add_child(sprite)
+	sprite.owner = scene_root
+
+	var player_path := _add_player("TestSubpathAlpha")
+	if player_path.is_empty():
+		sprite.get_parent().remove_child(sprite)
+		sprite.queue_free()
+		skip("Scene not ready — _add_player returned empty path")
+		return
+	var result := _handler.create_simple({
+		"player_path": player_path,
+		"name": "fade",
+		"tweens": [
+			{
+				"target": "SubpathAlphaSprite",
+				"property": "modulate:a",
+				"from": 1.0,
+				"to": 0.0,
+				"duration": 0.5,
+			},
+		],
+	})
+	assert_has_key(result, "data")
+	var player := ScenePath.resolve(player_path, scene_root) as AnimationPlayer
+	var anim: Animation = player.get_animation("fade")
+	var k0 = anim.track_get_key_value(0, 0)
+	var k1 = anim.track_get_key_value(0, 1)
+	assert_true(k0 is float, "from value should coerce to float for modulate:a")
+	assert_true(k1 is float, "to value should coerce to float for modulate:a")
+	assert_eq(k1, 0.0)
+	_remove_node(player_path)
+	sprite.get_parent().remove_child(sprite)
+	sprite.queue_free()
+
+
 func test_create_simple_coerces_vector3() -> void:
 	# Auto-length + coerce path in one test.
 	var player_path := _add_player("TestCoerceSimple")

--- a/test_project/tests/test_material.gd
+++ b/test_project/tests/test_material.gd
@@ -131,7 +131,7 @@ func test_set_param_color_hex() -> void:
 	_make_material()
 	var result := _handler.set_param({
 		"path": TEST_MATERIAL_PATH,
-		"property": "albedo_color",
+		"param": "albedo_color",
 		"value": "#ff0000",
 	})
 	assert_has_key(result, "data")
@@ -146,7 +146,7 @@ func test_set_param_color_dict() -> void:
 	_make_material()
 	var result := _handler.set_param({
 		"path": TEST_MATERIAL_PATH,
-		"property": "albedo_color",
+		"param": "albedo_color",
 		"value": {"r": 0.5, "g": 0.25, "b": 0.75, "a": 1.0},
 	})
 	assert_has_key(result, "data")
@@ -159,7 +159,7 @@ func test_set_param_metallic_float() -> void:
 	_make_material()
 	var result := _handler.set_param({
 		"path": TEST_MATERIAL_PATH,
-		"property": "metallic",
+		"param": "metallic",
 		"value": 0.9,
 	})
 	assert_has_key(result, "data")
@@ -171,7 +171,7 @@ func test_set_param_bool() -> void:
 	_make_material()
 	var result := _handler.set_param({
 		"path": TEST_MATERIAL_PATH,
-		"property": "emission_enabled",
+		"param": "emission_enabled",
 		"value": true,
 	})
 	assert_has_key(result, "data")
@@ -181,7 +181,7 @@ func test_set_param_transparency_enum_by_name() -> void:
 	_make_material()
 	var result := _handler.set_param({
 		"path": TEST_MATERIAL_PATH,
-		"property": "transparency",
+		"param": "transparency",
 		"value": "alpha",
 	})
 	assert_has_key(result, "data")
@@ -193,7 +193,7 @@ func test_set_param_shading_mode_enum() -> void:
 	_make_material()
 	var result := _handler.set_param({
 		"path": TEST_MATERIAL_PATH,
-		"property": "shading_mode",
+		"param": "shading_mode",
 		"value": "unshaded",
 	})
 	assert_has_key(result, "data")
@@ -205,7 +205,7 @@ func test_set_param_invalid_enum_by_name() -> void:
 	_make_material()
 	var result := _handler.set_param({
 		"path": TEST_MATERIAL_PATH,
-		"property": "transparency",
+		"param": "transparency",
 		"value": "not_a_mode",
 	})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
@@ -215,7 +215,7 @@ func test_set_param_unknown_property() -> void:
 	_make_material()
 	var result := _handler.set_param({
 		"path": TEST_MATERIAL_PATH,
-		"property": "does_not_exist",
+		"param": "does_not_exist",
 		"value": 1.0,
 	})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
@@ -224,7 +224,7 @@ func test_set_param_unknown_property() -> void:
 func test_set_param_material_not_found() -> void:
 	var result := _handler.set_param({
 		"path": "res://nope_material.tres",
-		"property": "metallic",
+		"param": "metallic",
 		"value": 0.5,
 	})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
@@ -234,7 +234,7 @@ func test_set_param_missing_value() -> void:
 	_make_material()
 	var result := _handler.set_param({
 		"path": TEST_MATERIAL_PATH,
-		"property": "metallic",
+		"param": "metallic",
 	})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -4479,13 +4479,13 @@ class TestMaterialSetParamTool:
         async def respond():
             cmd = await plugin.recv_command()
             assert cmd["command"] == "material_set_param"
-            assert cmd["params"]["property"] == "albedo_color"
+            assert cmd["params"]["param"] == "albedo_color"
             assert cmd["params"]["value"] == "#ff0000"
             await plugin.send_response(
                 cmd["request_id"],
                 {
                     "path": "res://materials/red.tres",
-                    "property": "albedo_color",
+                    "param": "albedo_color",
                     "value": {"r": 1, "g": 0, "b": 0, "a": 1},
                     "previous_value": {"r": 1, "g": 1, "b": 1, "a": 1},
                     "undoable": True,
@@ -4497,7 +4497,7 @@ class TestMaterialSetParamTool:
             "material_set_param",
             {
                 "path": "res://materials/red.tres",
-                "property": "albedo_color",
+                "param": "albedo_color",
                 "value": "#ff0000",
             },
         )

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -860,7 +860,7 @@ class StubClient:
         if command == "material_set_param":
             return {
                 "path": params.get("path", ""),
-                "property": params.get("property", ""),
+                "param": params.get("param", ""),
                 "value": params.get("value"),
                 "previous_value": None,
                 "undoable": True,
@@ -3750,10 +3750,11 @@ async def test_material_set_param_handler():
     result = await material_handlers.material_set_param(
         runtime,
         path="res://materials/red.tres",
-        property="albedo_color",
+        param="albedo_color",
         value="#ff0000",
     )
     assert client.calls[-1]["command"] == "material_set_param"
+    assert client.calls[-1]["params"]["param"] == "albedo_color"
     assert client.calls[-1]["params"]["value"] == "#ff0000"
     assert result["undoable"] is True
 


### PR DESCRIPTION
## Summary

Bundled fixes for three install-smoke friction points surfaced in the v1.1.0 smoke runs:

- **#87** `animation_add_property_track` / `animation_create_simple` — parse the node-vs-property split with `find(":")` instead of `rfind(":")` so vector/color subpaths like `position:y` and `modulate:a` resolve correctly. Keyframe values are now coerced to the component type (e.g. float for `modulate:a`).
- **#88** `material_set_param` — rename the kwarg from `property` to `param` to match the tool name and the convention used elsewhere in the API. **Breaking** for callers passing the old `property=` kwarg.
- **#89** `editor_screenshot view_target=` — raise the framing padding default to 1.8 and floor the camera distance with an absolute +1.0 offset so unit-scale AABBs aren't clipped at the near plane.

## Test plan

- [x] `pytest` — 518/518 pass
- [x] GDScript `test_run` — 668/668 pass across 28 suites (includes two new tests exercising the subpath parser)
- [x] `ruff check src/ tests/` — clean
- [x] Live-smoke #89: `editor_screenshot view_target=/Root/Pivot/Cube` on a unit-cube scene returns a properly-framed image (previously clipped)

Do not merge — scheduled-task output.

Generated with [Claude Code](https://claude.com/claude-code)
