### PR TITLE
fix: v1.1.0 smoke-friction follow-up bundle (#83, #84, #86)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ Claude Code sessions often run in git worktrees (`.claude/worktrees/<name>/`). B
 
 - **File paths**: Your working directory is the worktree, not the repo root. Files you create live in that worktree.
 - **Godot editor**: The editor runs against a specific worktree's `test_project/`. The plugin is symlinked from that worktree's `plugin/` directory. Check `session_list` — the `project_path` field tells you which worktree the editor is using.
-- **Dev server**: The `--reload` dev server uses the root repo's `.venv` and `src/`, not the worktree's. Python code changes in any worktree won't take effect unless the root repo also has them (e.g. via `git pull`).
+- **Dev server**: The `--reload` dev server uses the root repo's `.venv` and `src/`, not the worktree's. Python code changes in any worktree won't take effect unless the root repo also has them (e.g. via `git pull`). To serve the worktree's own Python source, use `script/serve-this-worktree` (prepends the worktree's `src/` to `PYTHONPATH` and frees port 8000 before starting).
 - **Passing info between sessions**: When writing prompts, handoff notes, or file references intended for another session, **always include the full worktree path** or specify the worktree name. Relative paths like `docs/friction-log.md` are ambiguous — a different session may be in a different worktree or on `main`. Use the absolute path.
 - **Merging**: Worktree branches must be merged to `main` and pulled into other worktrees for changes to propagate. The plugin symlink means GDScript changes propagate within the same worktree immediately, but not across worktrees.
 

--- a/plugin/addons/godot_ai/handlers/animation_handler.gd
+++ b/plugin/addons/godot_ai/handlers/animation_handler.gd
@@ -672,7 +672,7 @@ func create_simple(params: Dictionary) -> Dictionary:
 				"via animation_add_property_track instead of two separate tweens.")
 		seen_paths[dup_key] = true
 
-	var resolved := _resolve_player(player_path)
+	var resolved := _resolve_or_create_player(player_path)
 	if resolved.has("error"):
 		return resolved
 	var player: AnimationPlayer = resolved.player
@@ -681,6 +681,8 @@ func create_simple(params: Dictionary) -> Dictionary:
 	if library == null:
 		library = AnimationLibrary.new()
 		created_library = true
+	var created_player: bool = resolved.get("player_created", false)
+	var player_parent: Node = resolved.get("player_parent", null)
 
 	var overwrite: bool = params.get("overwrite", false)
 	var old_anim: Animation = null
@@ -739,9 +741,11 @@ func create_simple(params: Dictionary) -> Dictionary:
 	for entry in per_track_keyframes:
 		_do_add_property_track(anim, entry.track_path, "linear", entry.keyframes)
 
-	# One atomic undo action.
+	# One atomic undo action — bundles player creation (if any), library
+	# creation (if any), and the animation add. A single Ctrl-Z rolls back all.
 	_commit_animation_add("MCP: Create animation %s (%d tracks)" % [anim_name, anim.get_track_count()],
-		player, library, created_library, anim_name, anim, old_anim)
+		player, library, created_library, anim_name, anim, old_anim,
+		player_parent, created_player)
 
 	return {
 		"data": {
@@ -751,6 +755,7 @@ func create_simple(params: Dictionary) -> Dictionary:
 			"loop_mode": loop_mode_str,
 			"track_count": anim.get_track_count(),
 			"library_created": created_library,
+			"animation_player_created": created_player,
 			"overwritten": old_anim != null,
 			"undoable": true,
 		}
@@ -1206,7 +1211,9 @@ static func _direction_offset(kind: String, direction: String, distance: float) 
 # ============================================================================
 
 ## Shared undo setup for create_animation and create_simple. Handles both
-## fresh-create and overwrite cases in a single atomic action.
+## fresh-create and overwrite cases in a single atomic action. When
+## `created_player` is true, also bundles the AnimationPlayer add_child into
+## the same action so a single Ctrl-Z rolls back player + library + anim.
 func _commit_animation_add(
 	action_label: String,
 	player: AnimationPlayer,
@@ -1215,8 +1222,16 @@ func _commit_animation_add(
 	anim_name: String,
 	anim: Animation,
 	old_anim: Animation,  ## null when not overwriting
+	player_parent: Node = null,  ## non-null only when created_player is true
+	created_player: bool = false,
 ) -> void:
 	_undo_redo.create_action(action_label)
+	if created_player and player_parent != null:
+		var scene_root := EditorInterface.get_edited_scene_root()
+		_undo_redo.add_do_method(player_parent, "add_child", player, true)
+		_undo_redo.add_do_method(player, "set_owner", scene_root)
+		_undo_redo.add_undo_method(player_parent, "remove_child", player)
+		_undo_redo.add_do_reference(player)
 	if created_library:
 		_undo_redo.add_do_method(player, "add_animation_library", "", library)
 		_undo_redo.add_undo_method(player, "remove_animation_library", "")
@@ -1257,6 +1272,52 @@ func _resolve_player(player_path: String) -> Dictionary:
 	if player.has_animation_library(""):
 		lib = player.get_animation_library("")
 	return {"player": player, "library": lib}
+
+
+## Like `_resolve_player`, but when the node at `player_path` doesn't exist,
+## prepare a fresh AnimationPlayer to be added at that path instead of
+## erroring. Parallels the existing library auto-create affordance — callers
+## bundle the `add_child` step into the same undo action so player + library
+## + animation roll back together. Returns the same shape as `_resolve_player`
+## plus `{player_created: bool, player_parent: Node}` when a new player is
+## staged. If the node exists but isn't an AnimationPlayer, errors exactly
+## like `_resolve_player` — that's a genuine type mismatch, not a missing node.
+func _resolve_or_create_player(player_path: String) -> Dictionary:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+	if ScenePath.resolve(player_path, scene_root) != null:
+		# Node exists — delegate so the type-mismatch error stays identical
+		# to _resolve_player's.
+		var existing := _resolve_player(player_path)
+		if not existing.has("error"):
+			existing["player_created"] = false
+		return existing
+
+	# Stage a fresh AnimationPlayer at player_path. Parent must exist (same
+	# rule as node_create) — otherwise the caller's path is ambiguous.
+	var parent_path := player_path.get_base_dir()
+	var new_name := player_path.get_file()
+	if new_name.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+			"Invalid player_path (no node name): %s" % player_path)
+	var parent: Node
+	if parent_path.is_empty() or parent_path == "/":
+		parent = scene_root
+	else:
+		parent = ScenePath.resolve(parent_path, scene_root)
+		if parent == null:
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+				"Node not found: %s (and its parent %s also does not exist — create the parent first)" %
+				[player_path, parent_path])
+	var new_player := AnimationPlayer.new()
+	new_player.name = new_name
+	return {
+		"player": new_player,
+		"library": null,
+		"player_created": true,
+		"player_parent": parent,
+	}
 
 
 ## Resolve for read operations (no library requirement).

--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -501,11 +501,26 @@ func clear_logs(_params: Dictionary) -> Dictionary:
 
 func reload_plugin(_params: Dictionary) -> Dictionary:
 	_log_buffer.log("reload_plugin requested, reloading next frame")
-	(func():
-		EditorInterface.set_plugin_enabled("res://addons/godot_ai/plugin.cfg", false)
-		EditorInterface.set_plugin_enabled("res://addons/godot_ai/plugin.cfg", true)
-	).call_deferred()
+	_do_reload_plugin.call_deferred()
 	return {"data": {"status": "reloading", "message": "Plugin reload initiated"}}
+
+
+## Force a filesystem rescan before toggling the plugin, so Godot's
+## class-name registry picks up any .gd files added since the last scan
+## (e.g. via git pull or an agent-driven sync). Without this, re-enable can
+## fail with "Could not find type X" when new class_name scripts are on disk
+## but not yet registered, leaving the plugin disabled with no recovery path
+## short of killing the editor. See issue #83.
+func _do_reload_plugin() -> void:
+	var fs := EditorInterface.get_resource_filesystem()
+	fs.scan()
+	var tree := Engine.get_main_loop() as SceneTree
+	# Cap the wait so a long scan (huge project) doesn't hang reload.
+	var deadline_ms := Time.get_ticks_msec() + 5000
+	while fs.is_scanning() and Time.get_ticks_msec() < deadline_ms:
+		await tree.process_frame
+	EditorInterface.set_plugin_enabled("res://addons/godot_ai/plugin.cfg", false)
+	EditorInterface.set_plugin_enabled("res://addons/godot_ai/plugin.cfg", true)
 
 
 func quit_editor(_params: Dictionary) -> Dictionary:

--- a/script/serve-this-worktree
+++ b/script/serve-this-worktree
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Serve the MCP dev server using *this worktree's* src/godot_ai, not the root
+# repo's editable-installed copy.
+#
+# Why: the shared .venv lives in the root repo and pip-installs the root's
+# src/godot_ai editable. When you launch Godot from a worktree, the plugin
+# spawns the root's python -m godot_ai, so Python-side changes in the worktree
+# are invisible. Prepending the worktree's src/ to PYTHONPATH makes
+# `import godot_ai` resolve to the worktree's source instead.
+#
+# Usage: script/serve-this-worktree [extra uvicorn/module args]
+#   e.g. script/serve-this-worktree --port 8001
+#
+# Kills any existing listener on the chosen port first so you don't stack
+# servers on top of the plugin-spawned one.
+
+set -euo pipefail
+
+PORT=8000
+# Pull --port out of args if present so we can free it before starting.
+ARGS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --port)
+            PORT="$2"
+            ARGS+=("$1" "$2")
+            shift 2
+            ;;
+        --port=*)
+            PORT="${1#*=}"
+            ARGS+=("$1")
+            shift
+            ;;
+        *)
+            ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+WORKTREE_ROOT="$(git rev-parse --show-toplevel)"
+# .venv and the editable install live in the main repo's common dir, not the
+# worktree. `git rev-parse --git-common-dir` returns that path (or the regular
+# .git if we're already on main), so .venv resolves correctly either way.
+COMMON_DIR="$(cd "$WORKTREE_ROOT" && git rev-parse --git-common-dir)"
+# --git-common-dir may return a relative path; absolutize via its parent.
+if [[ "$COMMON_DIR" != /* ]]; then
+    COMMON_DIR="$(cd "$WORKTREE_ROOT/$COMMON_DIR" && pwd)"
+fi
+ROOT_REPO="$(dirname "$COMMON_DIR")"
+
+VENV_PY="$ROOT_REPO/.venv/bin/python"
+if [[ ! -x "$VENV_PY" ]]; then
+    echo "error: $VENV_PY not found — run script/setup-dev in the root repo first" >&2
+    exit 1
+fi
+
+SRC="$WORKTREE_ROOT/src"
+if [[ ! -d "$SRC" ]]; then
+    echo "error: $SRC not found" >&2
+    exit 1
+fi
+
+# Free the port so we replace the plugin-spawned server rather than stack on it.
+if lsof -i ":$PORT" -sTCP:LISTEN -t >/dev/null 2>&1; then
+    echo "Stopping existing listener on port $PORT"
+    lsof -i ":$PORT" -sTCP:LISTEN -t | xargs kill 2>/dev/null || true
+    sleep 1
+fi
+
+echo "Serving worktree: $WORKTREE_ROOT"
+echo "Using venv:       $ROOT_REPO/.venv"
+echo "PYTHONPATH:       $SRC"
+
+export PYTHONPATH="$SRC${PYTHONPATH:+:$PYTHONPATH}"
+exec "$VENV_PY" -m godot_ai --transport streamable-http --port "$PORT" --reload "${ARGS[@]}"

--- a/src/godot_ai/tools/animation.py
+++ b/src/godot_ai/tools/animation.py
@@ -420,7 +420,13 @@ def register_animation_tools(mcp: FastMCP) -> None:
                      "duration": 0.4, "transition": "ease_in_out"}]
 
         Args:
-            player_path: Scene path to the AnimationPlayer.
+            player_path: Scene path to the AnimationPlayer. If no node exists
+                at that path, an AnimationPlayer is auto-created there (the
+                parent must exist, same rule as node_create). The creation is
+                bundled into the same undo action as the animation, so a
+                single Ctrl-Z rolls back player + library + animation.
+                The response includes ``animation_player_created: true`` when
+                this happens.
             name: Name for the new animation clip.
             tweens: List of tween spec dicts (see above).
             length: Total duration in seconds. Auto-computed if omitted.

--- a/test_project/tests/test_animation.gd
+++ b/test_project/tests/test_animation.gd
@@ -938,6 +938,87 @@ func test_create_simple_auto_attaches_default_library() -> void:
 	_remove_node(path)
 
 
+func test_create_simple_auto_creates_animation_player() -> void:
+	## Issue #86: agents hit "Node at /Root/Pivot is not an AnimationPlayer" or
+	## "Node not found" when the player doesn't exist yet. The tool now creates
+	## one at the given path (parent must exist), bundled into the same undo
+	## action so Ctrl-Z rolls back player + library + animation together.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root — is a scene open?")
+		return
+	var player_path := "/" + scene_root.name + "/AutoPlayer86"
+	if ScenePath.resolve(player_path, scene_root) != null:
+		skip("AutoPlayer86 already exists in scene — rerun after cleanup")
+		return
+
+	var result := _handler.create_simple({
+		"player_path": player_path,
+		"name": "bob",
+		"tweens": [
+			{"target": ".", "property": "position",
+			 "from": {"x": 0.0, "y": 0.0, "z": 0.0},
+			 "to": {"x": 0.0, "y": 2.0, "z": 0.0}, "duration": 1.0},
+		],
+	})
+	assert_has_key(result, "data")
+	assert_true(result.data.animation_player_created,
+		"animation_player_created should be true when the player didn't exist")
+	assert_true(result.data.library_created,
+		"library_created should be true — fresh player has no library")
+	var created := ScenePath.resolve(player_path, scene_root)
+	assert_true(created is AnimationPlayer,
+		"AnimationPlayer should exist at %s after create_simple" % player_path)
+	assert_true((created as AnimationPlayer).has_animation("bob"))
+
+	# Single Ctrl-Z rolls back everything.
+	_undo_redo.undo()
+	assert_true(ScenePath.resolve(player_path, scene_root) == null,
+		"undo should remove the auto-created AnimationPlayer from the scene")
+
+
+func test_create_simple_rejects_wrong_type_even_when_auto_create_enabled() -> void:
+	## Existing error when the path points at a non-AnimationPlayer stays —
+	## the caller picked a live node that happens to be a different class.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root — is a scene open?")
+		return
+	var decoy := Node.new()
+	decoy.name = "Decoy86"
+	scene_root.add_child(decoy)
+	decoy.owner = scene_root
+
+	var result := _handler.create_simple({
+		"player_path": "/" + scene_root.name + "/Decoy86",
+		"name": "x",
+		"tweens": [
+			{"target": ".", "property": "position",
+			 "from": {"x": 0}, "to": {"x": 1}, "duration": 1.0},
+		],
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "not an AnimationPlayer")
+	_remove_node("/" + scene_root.name + "/Decoy86")
+
+
+func test_create_simple_errors_when_parent_missing() -> void:
+	## Parent path must exist, matching node_create semantics.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root — is a scene open?")
+		return
+	var result := _handler.create_simple({
+		"player_path": "/" + scene_root.name + "/NoSuchParent/AutoPlayer",
+		"name": "x",
+		"tweens": [
+			{"target": ".", "property": "position",
+			 "from": {"x": 0}, "to": {"x": 1}, "duration": 1.0},
+		],
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
 func test_create_animation_reports_library_created_false_when_present() -> void:
 	var player_path := _add_player("TestLibExists")
 	if player_path.is_empty():


### PR DESCRIPTION
## Summary

Bundle of three small, independent, bisect-friendly fixes surfaced by the v1.1.0 smoke-friction log.

- **#83** — `editor_reload_plugin` now waits for filesystem scan to settle before toggling the plugin, avoiding a race where the plugin re-enables before `.uid` files are reimported.
- **#84** — `script/serve-this-worktree` helper: launches the MCP dev server with the current worktree's `src/` on `PYTHONPATH` so Python-side changes in a worktree are live without touching the root repo.
- **#86** — `animation_create_simple` now auto-creates a missing `AnimationPlayer` at `player_path`, bundled into the same undo action as the animation. Response carries `animation_player_created: bool`.

## Test plan

- [x] `ruff check src/ tests/` clean
- [x] `pytest -v` — 518 passed
- [x] Godot `test_run suite=animation` — 71/71 pass, including 3 new tests covering auto-create happy path, type-mismatch error preservation, and missing-parent error
- [x] Live smoke in Godot editor: `animation_create_simple` on a missing player creates player+animation; single Ctrl-Z rolls back both
- [x] Live smoke: `editor_reload_plugin` after touching a `.gd` file no longer errors on stale `.uid`

Closes #83
Closes #84
Closes #86

Generated with Claude Code
