### PR TITLE
fix: distinguish retryable EDITOR_NOT_READY states (#85)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 <p align="center">
   <img src="docs/images/huddemo.gif" alt="Cyberpunk HUD demo" width="800"><br>
-  <em>UI demo built in ~2 hours with zero coding, zero image gen, all programmatically drawn by Godot AI</em>
+  <em>UI demo built in ~2 hours with zero coding, zero image gen, all programmatically drawn by Godot AI — <a href="https://github.com/hi-godot/cyberpunk-hud-demo">source</a></em>
 </p>
 
 ---

--- a/src/godot_ai/godot_client/client.py
+++ b/src/godot_ai/godot_client/client.py
@@ -15,10 +15,20 @@ logger = logging.getLogger(__name__)
 class GodotCommandError(Exception):
     """Raised when a Godot plugin command returns an error response."""
 
-    def __init__(self, code: str, message: str):
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        data: dict[str, Any] | None = None,
+    ):
         self.code = code
         self.message = message
-        super().__init__(f"{code}: {message}")
+        self.data = data or {}
+        if self.data:
+            suffix = " [" + ", ".join(f"{k}={v}" for k, v in self.data.items()) + "]"
+            super().__init__(f"{code}: {message}{suffix}")
+        else:
+            super().__init__(f"{code}: {message}")
 
 
 class GodotClient:

--- a/src/godot_ai/handlers/_readiness.py
+++ b/src/godot_ai/handlers/_readiness.py
@@ -6,9 +6,12 @@ from godot_ai.godot_client.client import GodotCommandError
 from godot_ai.protocol.errors import ErrorCode
 from godot_ai.runtime.interface import Runtime
 
-_READINESS_MESSAGES = {
-    "importing": "Editor is importing resources — try again shortly",
-    "playing": "Editor is in play mode — stop the game first",
+# (message, retryable). Retryable means the condition clears on its own
+# (Godot finishes reimporting); non-retryable requires the caller to change
+# state (stop the game).
+_READINESS_INFO: dict[str, tuple[str, bool]] = {
+    "importing": ("Editor is importing resources — try again shortly", True),
+    "playing": ("Editor is in play mode — stop the game first", False),
 }
 
 
@@ -20,12 +23,21 @@ def require_writable(runtime: Runtime) -> None:
     allowed through — individual handlers already reject when no scene
     is open.  If no session exists, this is a no-op; the downstream
     ``send_command`` will raise on its own.
+
+    The raised error carries ``data={"retryable": bool, "state": str}`` so
+    callers can distinguish a transient ``importing`` window (retry with
+    backoff) from a terminal ``playing`` state (stop the game first).
     """
     session = runtime.get_active_session()
     if session is None:
         return
 
     readiness = session.readiness
-    message = _READINESS_MESSAGES.get(readiness)
-    if message is not None:
-        raise GodotCommandError(code=ErrorCode.EDITOR_NOT_READY, message=message)
+    info = _READINESS_INFO.get(readiness)
+    if info is not None:
+        message, retryable = info
+        raise GodotCommandError(
+            code=ErrorCode.EDITOR_NOT_READY,
+            message=message,
+            data={"retryable": retryable, "state": readiness},
+        )

--- a/tests/unit/test_readiness.py
+++ b/tests/unit/test_readiness.py
@@ -45,6 +45,11 @@ def test_require_writable_rejects_importing():
         require_writable(_make_runtime("importing"))
     assert exc_info.value.code == ErrorCode.EDITOR_NOT_READY
     assert "importing" in exc_info.value.message
+    assert exc_info.value.data == {"retryable": True, "state": "importing"}
+    # Structured hints are also embedded in the serialized form so MCP
+    # clients that only see str(exc) can still distinguish retryable cases.
+    assert "retryable=True" in str(exc_info.value)
+    assert "state=importing" in str(exc_info.value)
 
 
 def test_require_writable_rejects_playing():
@@ -52,12 +57,20 @@ def test_require_writable_rejects_playing():
         require_writable(_make_runtime("playing"))
     assert exc_info.value.code == ErrorCode.EDITOR_NOT_READY
     assert "play mode" in exc_info.value.message
+    assert exc_info.value.data == {"retryable": False, "state": "playing"}
+    assert "retryable=False" in str(exc_info.value)
 
 
 def test_session_readiness_in_to_dict():
     session = _make_session("importing")
     d = session.to_dict()
     assert d["readiness"] == "importing"
+
+
+def test_godot_command_error_without_data_preserves_legacy_format():
+    err = GodotCommandError(code=ErrorCode.EDITOR_NOT_READY, message="oops")
+    assert err.data == {}
+    assert str(err) == "EDITOR_NOT_READY: oops"
 
 
 def test_session_readiness_defaults_to_ready():


### PR DESCRIPTION
## Summary

- `GodotCommandError` now accepts an optional `data: dict` and, when populated, embeds it as a `[k=v, ...]` suffix in `str(exc)` so MCP clients that only see the serialized exception can extract structured hints without string-matching the human-readable message.
- `require_writable` attaches `data={"retryable": bool, "state": str}` to the `EDITOR_NOT_READY` error it raises — `importing` is retryable, `playing` is not.
- Backward compatible: callers that don't pass `data=` get the existing `"CODE: message"` format unchanged.

Closes #85.

## Why this change

The same `EDITOR_NOT_READY` code was raised for both the ~1-2s `importing` window right after a `filesystem_write_text` (genuinely transient — retry with backoff works) and for the `playing` state (caller needs to stop the game). Agents had no programmatic way to tell them apart, so they resorted to string-matching the message — brittle.

This takes option 2 from the issue (structured `retryable` hint) and additionally folds it into `str(exc)` so it survives FastMCP's exception-to-error serialization, which is all the MCP client currently sees.

## Scope

Python-only. No plugin/GDScript changes. `ErrorDetail` wire protocol is unchanged — if the plugin ever needs to emit structured error data itself, that's a follow-up that plumbs `data` through `envelope.py` and the raising site in `client.py`.

## Test plan

- [x] `pytest` — all 519 tests pass
- [x] New assertions cover both the `.data` field and the serialized-form contract for importing + playing
- [x] New `test_godot_command_error_without_data_preserves_legacy_format` pins backward compat for the no-data path
- [x] `ruff check` + `ruff format --check` clean on touched files
- [ ] Live smoke against a running Godot editor — **not done locally** (see note below)

## Note on live smoke

This was run by the `godot-ai-issue-fixer` scheduled task in auto mode without a live Godot session pointed at this worktree's `test_project/`. The change is pure-Python in the readiness-gating path with full unit coverage of the happy path, both rejection branches, and the backward-compat path. Reviewers who want to exercise it live: drive `filesystem_write_text` on a large asset to hit the `importing` window, then immediately call any write tool and inspect the resulting error for the `[retryable=True, state=importing]` suffix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
