### PR TITLE
fix: cleanup.rm hint on newly-created files (#82)

### DIFF
--- a/plugin/addons/godot_ai/handlers/filesystem_handler.gd
+++ b/plugin/addons/godot_ai/handlers/filesystem_handler.gd
@@ -51,6 +51,8 @@ func write_file(params: Dictionary) -> Dictionary:
 		if err != OK:
 			return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to create directory: %s" % dir_path)
 
+	var existed_before := FileAccess.file_exists(path)
+
 	var file := FileAccess.open(path, FileAccess.WRITE)
 	if file == null:
 		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to open file for writing: %s" % path)
@@ -61,14 +63,14 @@ func write_file(params: Dictionary) -> Dictionary:
 	# Trigger reimport so the editor recognises the new/changed file
 	EditorInterface.get_resource_filesystem().scan()
 
-	return {
-		"data": {
-			"path": path,
-			"size": content.length(),
-			"undoable": false,
-			"reason": "File system operations cannot be undone via editor undo",
-		}
+	var data := {
+		"path": path,
+		"size": content.length(),
+		"undoable": false,
+		"reason": "File system operations cannot be undone via editor undo",
 	}
+	ResourceIO.attach_cleanup_hint(data, existed_before, [path])
+	return {"data": data}
 
 
 func reimport(params: Dictionary) -> Dictionary:

--- a/plugin/addons/godot_ai/handlers/script_handler.gd
+++ b/plugin/addons/godot_ai/handlers/script_handler.gd
@@ -31,6 +31,8 @@ func create_script(params: Dictionary) -> Dictionary:
 		if err != OK:
 			return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to create directory: %s" % dir_path)
 
+	var existed_before := FileAccess.file_exists(path)
+
 	var file := FileAccess.open(path, FileAccess.WRITE)
 	if file == null:
 		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to open file for writing: %s" % path)
@@ -41,14 +43,16 @@ func create_script(params: Dictionary) -> Dictionary:
 	# Trigger reimport so the editor recognises the new file
 	EditorInterface.get_resource_filesystem().scan()
 
-	return {
-		"data": {
-			"path": path,
-			"size": content.length(),
-			"undoable": false,
-			"reason": "File system operations cannot be undone via editor undo",
-		}
+	var data := {
+		"path": path,
+		"size": content.length(),
+		"undoable": false,
+		"reason": "File system operations cannot be undone via editor undo",
 	}
+	# `.gd.uid` is the sidecar Godot generates on scan; list both so the caller
+	# can rm the full set in one go.
+	ResourceIO.attach_cleanup_hint(data, existed_before, [path, path + ".uid"])
+	return {"data": data}
 
 
 func read_script(params: Dictionary) -> Dictionary:

--- a/plugin/addons/godot_ai/utils/resource_io.gd
+++ b/plugin/addons/godot_ai/utils/resource_io.gd
@@ -86,7 +86,21 @@ static func save_to_disk(res: Resource, resource_path: String, overwrite: bool, 
 		"undoable": false,
 		"reason": "File creation is persistent; delete the file manually to revert",
 	}
+	attach_cleanup_hint(data, existed_before, [resource_path])
 	# merge with overwrite=true so callers (e.g. curve_set_points editing an
 	# existing .tres) can supply a domain-specific `reason`.
 	data.merge(extra_fields, true)
 	return {"data": data}
+
+
+## Attach a `cleanup.rm` hint listing `paths` to `data` — only when the call
+## just created a new file (`existed_before == false`). On overwrite the field
+## is omitted because the caller already had the file on disk, and handing
+## them a cleanup list would invite dropping user content instead of just
+## scratch artifacts. Used by write-and-return handlers (create_script,
+## filesystem_write_text, resource_create/save_to_disk) so callers running
+## transient smoke tests can rm artifacts without tracking paths. See #82.
+static func attach_cleanup_hint(data: Dictionary, existed_before: bool, paths: Array) -> void:
+	if existed_before:
+		return
+	data["cleanup"] = {"rm": paths}

--- a/src/godot_ai/tools/filesystem.py
+++ b/src/godot_ai/tools/filesystem.py
@@ -39,6 +39,12 @@ def register_filesystem_tools(mcp: FastMCP) -> None:
         a filesystem scan so the editor picks up changes. Parent
         directories are created automatically if needed.
 
+        When this call creates a new file (the path did not exist before),
+        the response includes `data.cleanup.rm` listing the path — callers
+        running transient smoke tests can feed that list into a final cleanup
+        step. On overwrite the field is omitted so the caller doesn't rm a
+        file they already had on disk.
+
         Args:
             path: File path starting with res:// (e.g. "res://data/config.json").
             content: Text content to write. Empty creates a blank file.

--- a/src/godot_ai/tools/resource.py
+++ b/src/godot_ai/tools/resource.py
@@ -141,7 +141,10 @@ def register_resource_tools(mcp: FastMCP) -> None:
         - path+property: instantiate and assign to the node slot in one
           undoable action (undo restores the previous value).
         - resource_path: instantiate and save as a .tres/.res file on disk
-          (not undoable — file creation is persistent).
+          (not undoable — file creation is persistent). When the file did
+          not exist before, the response includes `data.cleanup.rm` listing
+          it so callers running transient smoke tests can feed the list into
+          a final cleanup step; omitted on overwrite.
 
         For compound resources with their own authoring tools, prefer those:
         material_create (Materials), animation_create (Animations),

--- a/src/godot_ai/tools/script.py
+++ b/src/godot_ai/tools/script.py
@@ -23,6 +23,12 @@ def register_script_tools(mcp: FastMCP) -> None:
         If the file already exists it will be overwritten. Triggers a
         filesystem scan so the editor picks up the new file.
 
+        When this call creates a new file (the path did not exist before),
+        the response includes `data.cleanup.rm` listing the `.gd` plus the
+        `.gd.uid` sidecar Godot generates — callers running transient smoke
+        tests can feed that list into a final cleanup step. On overwrite the
+        field is omitted so the caller doesn't rm files they already had.
+
         Args:
             path: File path starting with res:// (e.g. "res://scripts/player.gd").
             content: GDScript source code to write. Empty creates a blank file.

--- a/test_project/tests/test_filesystem.gd
+++ b/test_project/tests/test_filesystem.gd
@@ -61,6 +61,9 @@ func test_read_file_not_found() -> void:
 
 func test_write_file_basic() -> void:
 	var path := "res://tests/_mcp_test_written.txt"
+	# Make sure no stale copy is on disk so this call is a fresh create.
+	if FileAccess.file_exists(path):
+		DirAccess.remove_absolute(path)
 	var content := "Written by MCP\nSecond line\n"
 	var result := _handler.write_file({"path": path, "content": content})
 	assert_has_key(result, "data")
@@ -72,6 +75,22 @@ func test_write_file_basic() -> void:
 	var file := FileAccess.open(path, FileAccess.READ)
 	assert_eq(file.get_as_text(), content)
 	file.close()
+	# Cleanup hint lists the freshly-written path (issue #82).
+	assert_has_key(result.data, "cleanup")
+	assert_eq(result.data.cleanup.rm, [path])
+
+
+func test_write_file_overwrite_omits_cleanup_hint() -> void:
+	## Second write to the same path is an overwrite; dropping a cleanup hint
+	## on overwrite would invite callers to rm files they already had.
+	var path := "res://tests/_mcp_test_overwrite.txt"
+	var first := _handler.write_file({"path": path, "content": "v1\n"})
+	assert_has_key(first, "data")
+	assert_has_key(first.data, "cleanup")
+	var second := _handler.write_file({"path": path, "content": "v2\n"})
+	assert_has_key(second, "data")
+	assert_false(second.data.has("cleanup"), "Overwrite must not emit a cleanup hint")
+	DirAccess.remove_absolute(path)
 
 
 func test_write_file_missing_path() -> void:

--- a/test_project/tests/test_resource.gd
+++ b/test_project/tests/test_resource.gd
@@ -397,6 +397,9 @@ func test_create_resource_saves_to_disk() -> void:
 	assert_eq(result.data.resource_class, "BoxShape3D")
 	assert_false(result.data.undoable)
 	assert_true(FileAccess.file_exists(out_path), "File should exist at %s" % out_path)
+	# Cleanup hint lists the freshly-written .tres (issue #82).
+	assert_has_key(result.data, "cleanup")
+	assert_eq(result.data.cleanup.rm, [out_path])
 	# Round-trip through ResourceLoader to verify the saved .tres is valid.
 	var loaded := ResourceLoader.load(out_path)
 	assert_true(loaded is BoxShape3D)
@@ -428,6 +431,8 @@ func test_create_resource_save_refuses_overwrite_without_flag() -> void:
 	})
 	assert_has_key(third, "data")
 	assert_true(third.data.overwritten)
+	# Overwrite must not emit a cleanup hint — the caller already had the file.
+	assert_false(third.data.has("cleanup"), "Overwrite must not emit a cleanup hint")
 	DirAccess.remove_absolute(ProjectSettings.globalize_path(out_path))
 
 

--- a/test_project/tests/test_script.gd
+++ b/test_project/tests/test_script.gd
@@ -61,7 +61,24 @@ func test_create_script_basic() -> void:
 	var file := FileAccess.open(path, FileAccess.READ)
 	assert_eq(file.get_as_text(), content)
 	file.close()
+	# Cleanup hint lists .gd and .gd.uid for freshly-created scripts (issue #82).
+	assert_has_key(result.data, "cleanup")
+	assert_eq(result.data.cleanup.rm, [path, path + ".uid"])
 	# Clean up
+	DirAccess.remove_absolute(path)
+
+
+func test_create_script_overwrite_omits_cleanup_hint() -> void:
+	## On overwrite the caller already had the file on disk; cleanup.rm would
+	## point them at user content, not just scratch — so the field is omitted.
+	var path := "res://tests/_mcp_test_overwrite.gd"
+	var first := FileAccess.open(path, FileAccess.WRITE)
+	assert_true(first != null)
+	first.store_string("extends Node\n")
+	first.close()
+	var result := _handler.create_script({"path": path, "content": "extends Node\n# v2\n"})
+	assert_has_key(result, "data")
+	assert_false(result.data.has("cleanup"), "Overwrite must not emit a cleanup hint")
 	DirAccess.remove_absolute(path)
 
 


### PR DESCRIPTION
## Summary

Implements option 3 (cleanup_hint) from #82: file-creating tools now include a `data.cleanup.rm` list of freshly-written paths in their success response, but only when the file did not exist before the call. Callers running transient smoke tests can feed the list straight into a final cleanup step without remembering artifact paths.

- `script_create` → `cleanup.rm = [path, path + ".uid"]` (covers the `.gd.uid` sidecar Godot writes on scan)
- `filesystem_write_text` → `cleanup.rm = [path]`
- `resource_create` (with `resource_path`) → `cleanup.rm = [resource_path]`

On overwrite-in-place the field is omitted. Overwriting a user's existing file shouldn't hand them a list that looks like "rm these" — that would silently invite dropping user content rather than scratch artifacts.

Shared helper `ResourceIO.attach_cleanup_hint(data, existed_before, paths)` keeps the rationale comment in one place and makes the three call sites one-liners.

## Scope

- Plugin: `script_handler.create_script`, `filesystem_handler.write_file`, `resource_io.save_to_disk` (the latter serves `resource_create`, `environment_create`, `gradient_texture_create`, `curve_set_points`, etc.)
- Python: docstring additions on the three tools so agents know the hint is there.
- Tests: positive + overwrite cases added to `test_script.gd`, `test_filesystem.gd`, `test_resource.gd`.

Backward-compatible: existing callers that do not read the field see no change.

## Closes

Closes #82.

## Test plan

- [x] `pytest` — 520 tests pass locally
- [x] Godot GDScript unit tests added (present/absent cleanup hint on create vs overwrite for all three tools)
- [ ] Live-smoke in a running Godot editor pointed at this worktree — **not run** in this scheduled-task session. Reviewer should verify with a fresh `script_create res://_smoke.gd` → confirm `data.cleanup.rm == ["res://_smoke.gd", "res://_smoke.gd.uid"]`, then a second call to the same path (overwrite) omits the field.

## Out of scope

The richer option 1 from #82 (session-scoped write ledger with `session_writes_list` / `session_writes_purge`) is deliberately deferred — this PR takes the cheap capture-the-common-case path, leaves the agent in charge of honoring the hint, and doesn't introduce persistent state the plugin has to maintain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
