### PR TITLE
fix: project_run(autosave=false) skips Godot save-before-running (#81)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,8 @@ If you need worktree-specific test_project changes, use your own worktree (the o
 
 Write tools that mutate the scene (`script_attach`, `node_create`, `node_set_property`, etc.) dirty the scene in memory but don't touch disk. `project_run` with any mode internally calls `try_autosave()` → `_save_scene_with_preview()`, which **persists those in-memory mutations to the scene file on disk**. A common trap during live smoke tests: attach a throwaway script to `/Main`, run the scene to exercise `_ready()`, and discover the attachment is now committed to `test_project/main.tscn`.
 
-Two safe patterns:
+Three safe patterns:
+- **`project_run(autosave=False, …)`** suppresses Godot's save-before-running for the play call, so MCP scene mutations stay in memory and the `.tscn` on disk is untouched. Preferred for smoke tests; default stays `True` so existing callers see no behavior change.
 - **Attach to a throwaway scene** dedicated to smoke work, not to `main.tscn` or any scene a test suite depends on.
 - **Plan to revert**: after smoking, `git status` in the worktree and `git checkout -- test_project/<scene>` to undo any autosaved pollution. Verify before staging.
 

--- a/plugin/addons/godot_ai/handlers/project_handler.gd
+++ b/plugin/addons/godot_ai/handlers/project_handler.gd
@@ -69,6 +69,7 @@ func set_project_setting(params: Dictionary) -> Dictionary:
 
 func run_project(params: Dictionary) -> Dictionary:
 	var mode: String = params.get("mode", "main")
+	var autosave: bool = params.get("autosave", true)
 	if EditorInterface.is_playing_scene():
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Project is already running")
 
@@ -79,6 +80,21 @@ func run_project(params: Dictionary) -> Dictionary:
 	# around the play call — same pattern as SceneHandler.save_scene.
 	if _connection:
 		_connection.pause_processing = true
+
+	# try_autosave() reads run/auto_save/save_before_running every call, so
+	# toggling it off around the play call suppresses the save without
+	# touching the user's persisted preference. Issue #81.
+	var autosave_key := "run/auto_save/save_before_running"
+	var editor_settings: EditorSettings = null
+	if not autosave:
+		editor_settings = EditorInterface.get_editor_settings()
+	var prior_autosave: bool = true
+	var restore_setting := false
+	if editor_settings != null and editor_settings.has_setting(autosave_key):
+		prior_autosave = bool(editor_settings.get_setting(autosave_key))
+		editor_settings.set_setting(autosave_key, false)
+		restore_setting = true
+
 	var validation_error: Variant = null
 	match mode:
 		"main":
@@ -93,6 +109,10 @@ func run_project(params: Dictionary) -> Dictionary:
 				EditorInterface.play_custom_scene(scene_path)
 		_:
 			validation_error = McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Invalid mode '%s' — use 'main', 'current', or 'custom'" % mode)
+
+	if restore_setting:
+		editor_settings.set_setting(autosave_key, prior_autosave)
+
 	if _connection:
 		_connection.pause_processing = false
 
@@ -103,6 +123,7 @@ func run_project(params: Dictionary) -> Dictionary:
 		"data": {
 			"mode": mode,
 			"scene": params.get("scene", ""),
+			"autosave": autosave,
 			"undoable": false,
 			"reason": "Play/stop is a runtime action",
 		}

--- a/src/godot_ai/handlers/project.py
+++ b/src/godot_ai/handlers/project.py
@@ -24,10 +24,17 @@ async def project_settings_get(runtime: Runtime, key: str) -> dict:
     return await runtime.send_command("get_project_setting", {"key": key})
 
 
-async def project_run(runtime: Runtime, mode: str = "main", scene: str = "") -> dict:
-    params: dict[str, str] = {"mode": mode}
+async def project_run(
+    runtime: Runtime,
+    mode: str = "main",
+    scene: str = "",
+    autosave: bool = True,
+) -> dict:
+    params: dict[str, Any] = {"mode": mode}
     if scene:
         params["scene"] = scene
+    if not autosave:
+        params["autosave"] = False
     return await runtime.send_command("run_project", params)
 
 

--- a/src/godot_ai/tools/project.py
+++ b/src/godot_ai/tools/project.py
@@ -17,6 +17,7 @@ def register_project_tools(mcp: FastMCP) -> None:
         ctx: Context,
         mode: str = "main",
         scene: str = "",
+        autosave: bool = True,
         session_id: str = "",
     ) -> dict:
         """Run (play / start) the Godot project (game) from the editor.
@@ -29,10 +30,16 @@ def register_project_tools(mcp: FastMCP) -> None:
         Args:
             mode: Run mode — "main", "current", or "custom". Default "main".
             scene: Scene path (e.g. "res://levels/level1.tscn"). Required when mode is "custom".
+            autosave: When True (default), Godot's save-before-running behavior
+                persists any in-memory scene mutations to disk. Pass False for
+                smoke tests where MCP mutations (script_attach, node_create, …)
+                should stay in memory and the .tscn on disk should be untouched.
             session_id: Optional Godot session to target. Empty = active session.
         """
         runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
-        return await project_handlers.project_run(runtime, mode=mode, scene=scene)
+        return await project_handlers.project_run(
+            runtime, mode=mode, scene=scene, autosave=autosave
+        )
 
     @mcp.tool(meta=DEFER_META)
     async def project_stop(ctx: Context, session_id: str = "") -> dict:

--- a/test_project/tests/test_project.gd
+++ b/test_project/tests/test_project.gd
@@ -148,6 +148,28 @@ func test_run_project_custom_empty_scene() -> void:
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 
 
+func test_run_project_autosave_false_restores_editor_setting() -> void:
+	## Issue #81: autosave=false must restore run/auto_save/save_before_running
+	## to its prior value even on the validation-error path (mode invalid).
+	## Guards against future refactors dropping the restore branch.
+	var autosave_key := "run/auto_save/save_before_running"
+	var editor_settings := EditorInterface.get_editor_settings()
+	if editor_settings == null or not editor_settings.has_setting(autosave_key):
+		return  ## setting not present in this engine build; skip
+	var prior = editor_settings.get_setting(autosave_key)
+	editor_settings.set_setting(autosave_key, true)
+
+	var result := _handler.run_project({"mode": "invalid_mode", "autosave": false})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_eq(
+		bool(editor_settings.get_setting(autosave_key)),
+		true,
+		"save_before_running must be restored after run_project returns",
+	)
+
+	editor_settings.set_setting(autosave_key, prior)
+
+
 # ----- stop_project -----
 
 func test_stop_project_rejects_when_not_playing() -> void:

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -2515,6 +2515,33 @@ class TestProjectRunTool:
         assert not result.is_error
         assert result.data["scene"] == "res://levels/level1.tscn"
 
+    async def test_run_autosave_false_forwarded_to_plugin(self, mcp_stack):
+        # Issue #81: autosave=False must reach the plugin so it can suppress
+        # Godot's save-before-running and leave the .tscn on disk untouched.
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["params"]["autosave"] is False
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "mode": "current",
+                    "scene": "",
+                    "autosave": False,
+                    "undoable": False,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "project_run", {"mode": "current", "autosave": False}
+        )
+        await task
+
+        assert not result.is_error
+        assert result.data["autosave"] is False
+
 
 class TestProjectStopTool:
     async def test_stop_running_project(self, mcp_stack):

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -2700,6 +2700,22 @@ async def test_project_run_handler_custom_mode():
     }
 
 
+async def test_project_run_handler_autosave_default_omits_param():
+    # Issue #81: default autosave=True keeps the wire format minimal — older
+    # plugins never see the new key and behavior stays identical.
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    await project_handlers.project_run(runtime)
+    assert "autosave" not in client.calls[-1]["params"]
+
+
+async def test_project_run_handler_autosave_false_forwarded():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    await project_handlers.project_run(runtime, mode="current", autosave=False)
+    assert client.calls[-1]["params"] == {"mode": "current", "autosave": False}
+
+
 async def test_project_stop_handler():
     client = StubClient()
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)


### PR DESCRIPTION
## Summary

Closes #81. Adds an optional `autosave: bool = True` parameter to `project_run` so smoke tests can exercise a scene's runtime without persisting in-memory MCP mutations to disk.

- Plugin handler toggles `run/auto_save/save_before_running` off for the play call when `autosave=false`, then restores it. `try_autosave()` reads this setting every call, so per-call toggle suffices.
- Default `True` preserves existing behavior. Python handler only forwards the key on the wire when `False`, so older plugins keep working unchanged.
- Trims the Live-smoke scene hygiene note in CLAUDE.md to recommend the new opt-out.

## Test plan

- [x] `pytest -v` — 523 passed
- [x] GDScript suite via `test_run` — 677 passed (suite `project` includes the new `test_run_project_autosave_false_restores_editor_setting`)
- [x] Live-smoke in editor: `script_create` → `script_attach /Main ...` → `project_run(mode=current, autosave=false)` → md5(main.tscn) **unchanged**
- [x] Regression baseline: same flow with `autosave=true` (or omitted) → md5 **changes** (attachment persisted) — confirming the fix is doing real work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
