### PR TITLE
fix: draw_recipe filled-rect warning + readiness message polish (#98)

### DIFF
--- a/friction_log.md
+++ b/friction_log.md
@@ -19,7 +19,7 @@ running on `/Users/davidsarno/godot-assetlib-download-test/` — not the
 worktree's own `test_project/`. The installed plugin was 1.0.1; the PR
 code had to be rsync'd over from the worktree.
 
-### bug — `push_error("msg")` / `push_warning("msg")` lose the user's text
+### bug — `push_error("msg")` / `push_warning("msg")` lose the user's text — FIXED in PR #78
 
 `plugin/addons/godot_ai/runtime/game_logger.gd::_log_error` reads only the
 `rationale` argument from Godot's `Logger` virtual. For the **single-arg**
@@ -63,7 +63,7 @@ works correctly — the defect only hits the common single-arg case.
 Repro: `push_warning("warn-game"); push_error("err-game")` in `_ready()`,
 `project_run`, `logs_read(source="game")` → lines 3-4 in the response.
 
-### friction — `editor_reload_plugin` can't recover from newly-added files on disk
+### friction — `editor_reload_plugin` can't recover from newly-added files on disk — FIXED (editor_handler.gd now `fs.scan()` awaits before re-enabling)
 
 Sequence that breaks: rsync PR plugin over an older installed copy (adds
 new `.gd` files that declare `class_name`) → `editor_reload_plugin` →
@@ -118,7 +118,7 @@ to get PR code into the server. CLAUDE.md's worktree section already
 warns about this; a dock button or script one-liner for "restart server
 against *this* worktree" would remove the last of the friction.
 
-### friction — `scene_create` briefly rejects with `EDITOR_NOT_READY: importing`
+### friction — `scene_create` briefly rejects with `EDITOR_NOT_READY: importing` — FIXED in PR #95 (retryable/state hints on EDITOR_NOT_READY)
 
 Right after a `filesystem_write_text`, readiness flips to `importing` for
 ~1-2s while Godot reimports. `editor_state` still reports `no_scene`

--- a/plugin/addons/godot_ai/runtime/draw_recipe.gd
+++ b/plugin/addons/godot_ai/runtime/draw_recipe.gd
@@ -33,12 +33,19 @@ func _draw() -> void:
 					bool(op.get("antialiased", false))
 				)
 			"rect":
-				draw_rect(
-					op.rect,
-					op.color,
-					bool(op.get("filled", true)),
-					float(op.get("width", 1.0))
-				)
+				# Godot warns if `width` is passed when `filled` is true —
+				# width has no effect on filled rects. Split the call so we
+				# only pass width when stroking an outline.
+				var filled := bool(op.get("filled", true))
+				if filled:
+					draw_rect(op.rect, op.color, true)
+				else:
+					draw_rect(
+						op.rect,
+						op.color,
+						false,
+						float(op.get("width", 1.0))
+					)
 			"arc":
 				draw_arc(
 					op.center,

--- a/src/godot_ai/handlers/_readiness.py
+++ b/src/godot_ai/handlers/_readiness.py
@@ -11,7 +11,7 @@ from godot_ai.runtime.interface import Runtime
 # state (stop the game).
 _READINESS_INFO: dict[str, tuple[str, bool]] = {
     "importing": ("Editor is importing resources — try again shortly", True),
-    "playing": ("Editor is in play mode — stop the game first", False),
+    "playing": ("Editor is in play mode — call project_stop to stop the game, then retry", False),
 }
 
 

--- a/test_project/tests/test_control_draw_recipe.gd
+++ b/test_project/tests/test_control_draw_recipe.gd
@@ -105,6 +105,39 @@ func test_rect_op_all_dict_forms() -> void:
 	_remove_control(path)
 
 
+func test_rect_outline_preserves_width() -> void:
+	# filled=false takes the width branch of draw_recipe.gd's rect op.
+	# When filled=true (the default), width is dropped to silence Godot's
+	# "width has no effect when filled is true" warning (issue #98).
+	var path := _add_control("TestRectOutline")
+	if path.is_empty():
+		skip("Scene not ready")
+		return
+	var result := _handler.control_draw_recipe(
+		{
+			"path": path,
+			"ops":
+			[
+				{
+					"draw": "rect",
+					"rect": [0, 0, 10, 10],
+					"color": "red",
+					"filled": false,
+					"width": 3,
+				}
+			],
+		}
+	)
+	assert_has_key(result, "data")
+
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var node := ScenePath.resolve(path, scene_root)
+	var stored: Array = node.get_meta("_ops")
+	assert_eq(stored[0].filled, false)
+	assert_eq(stored[0].width, 3.0)
+	_remove_control(path)
+
+
 func test_polyline_points_stored_as_packed_array() -> void:
 	var path := _add_control("TestPolylineRecipe")
 	if path.is_empty():

--- a/tests/unit/test_readiness.py
+++ b/tests/unit/test_readiness.py
@@ -57,6 +57,9 @@ def test_require_writable_rejects_playing():
         require_writable(_make_runtime("playing"))
     assert exc_info.value.code == ErrorCode.EDITOR_NOT_READY
     assert "play mode" in exc_info.value.message
+    # The message names the recovery tool so MCP clients don't have to
+    # infer "how do I unstick this" from the state string alone.
+    assert "project_stop" in exc_info.value.message
     assert exc_info.value.data == {"retryable": False, "state": "playing"}
     assert "retryable=False" in str(exc_info.value)
 


### PR DESCRIPTION
## Summary

Small-fix bundle from the smoke friction-log triage:

- **`draw_recipe.gd`**: split the `rect` op into filled / outline branches so `width` is only passed when `filled=false`. Godot emits `"width has no effect when filled is true"` per call-site, so a recipe with ~20 decorative filled rects produces ~20 identical warnings on scene load. Closes #98.
- **`_readiness.py`**: the `"playing"` `EDITOR_NOT_READY` message now names `project_stop` as the recovery tool instead of the vaguer "stop the game first".
- **`friction_log.md`**: mark three already-resolved entries as **FIXED**:
  - single-arg `push_error`/`push_warning` text loss → landed in PR #78
  - `editor_reload_plugin` + newly-added `.gd` files → `editor_handler.gd` already `fs.scan()`s and awaits before toggling
  - `scene_create` `EDITOR_NOT_READY: importing` retryability → PR #95

## Test plan

- [x] `pytest` — **523/523** pass (includes new `project_stop` assertion in `test_require_writable_rejects_playing`)
- [x] Godot `test_run` — **680/680** pass (includes new `test_rect_outline_preserves_width` in the `control_draw_recipe` suite, 16/16)
- [x] Live smoke: launched worktree-specific Godot + dev server on :8001/:9501, connected, ran both suites end-to-end
- [x] `/simplify` — diff is minimal and already clean; inline WHY comment in `draw_recipe.gd` is a deliberate regression guard
- [x] `/review` — small, surgical, bisect-friendly; no API surface change, no new params

## Risk

Minimal. `_draw()` adds one local + one branch (negligible hot-path cost). `_readiness.py` change is message-text only — the `ErrorCode` and structured `data={"retryable", "state"}` are untouched, so MCP clients matching on those are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)