### PR TITLE
fix: awaitable command dispatcher + readiness-aware project_stop (#29)

### DIFF
--- a/plugin/addons/godot_ai/connection.gd
+++ b/plugin/addons/godot_ai/connection.gd
@@ -52,8 +52,7 @@ func _process(delta: float) -> void:
 			_check_state_changes()
 
 			if dispatcher:
-				for response in dispatcher.tick():
-					_send_json(response)
+				dispatcher.tick()
 
 		WebSocketPeer.STATE_CLOSED:
 			if _connected:

--- a/plugin/addons/godot_ai/dispatcher.gd
+++ b/plugin/addons/godot_ai/dispatcher.gd
@@ -2,12 +2,18 @@
 class_name McpDispatcher
 extends RefCounted
 
-## Routes incoming commands to handlers and manages the command queue
-## with a per-frame time budget.
+## Routes incoming commands to handlers and manages the command queue.
+##
+## Handlers may be synchronous or awaitable. Because a single awaitable
+## handler can span multiple frames, tick() kicks off a fire-and-forget
+## drain that delivers responses through `_response_sink`. Only one drain
+## runs at a time so ordering is preserved across `await` boundaries.
 
 var _command_queue: Array[Dictionary] = []
 var _handlers: Dictionary = {}  # command_name -> Callable
 var _log_buffer: McpLogBuffer
+var _response_sink: Callable = Callable()
+var _draining := false
 var mcp_logging := true
 
 
@@ -15,7 +21,12 @@ func _init(log_buffer: McpLogBuffer) -> void:
 	_log_buffer = log_buffer
 
 
-## Register a command handler. The callable receives (params: Dictionary) -> Dictionary.
+func set_response_sink(sink: Callable) -> void:
+	_response_sink = sink
+
+
+## Register a command handler. The callable receives (params: Dictionary) -> Dictionary
+## or an awaitable that eventually returns one.
 func register(command_name: String, handler: Callable) -> void:
 	_handlers[command_name] = handler
 
@@ -26,7 +37,7 @@ func register(command_name: String, handler: Callable) -> void:
 func dispatch_direct(command: String, params: Dictionary) -> Dictionary:
 	if not _handlers.has(command):
 		return McpErrorCodes.make(McpErrorCodes.UNKNOWN_COMMAND, "Unknown command: %s" % command)
-	return _call_handler(command, params)
+	return await _call_handler(command, params)
 
 
 ## Whether a command is registered.
@@ -66,24 +77,26 @@ func enqueue(cmd: Dictionary) -> void:
 const DEFERRED_RESPONSE := {"_deferred": true}
 
 
-## Process queued commands within a frame budget (milliseconds).
-## Returns an array of response dictionaries to send back.
-func tick(budget_ms: float = 4.0) -> Array[Dictionary]:
-	var responses: Array[Dictionary] = []
+## Start draining the queue. No-op if a drain is already in flight.
+func tick(budget_ms: float = 4.0) -> void:
+	if _draining or _command_queue.is_empty():
+		return
+	_drain(budget_ms)
+
+
+## Budget only bounds how many new commands we *start* in one window;
+## once a handler awaits we always see it through to completion.
+func _drain(budget_ms: float) -> void:
+	_draining = true
 	var start := Time.get_ticks_msec()
-	var idx := 0
-
-	while idx < _command_queue.size() and (Time.get_ticks_msec() - start) < budget_ms:
-		var cmd: Dictionary = _command_queue[idx]
-		var response := _dispatch(cmd)
-		if not response.get("_deferred", false):
-			responses.append(response)
-		idx += 1
-
-	if idx > 0:
-		_command_queue = _command_queue.slice(idx)
-
-	return responses
+	while not _command_queue.is_empty() and (Time.get_ticks_msec() - start) < budget_ms:
+		var cmd: Dictionary = _command_queue.pop_front()
+		var response: Dictionary = await _dispatch(cmd)
+		if response.get("_deferred", false):
+			continue
+		if _response_sink.is_valid():
+			_response_sink.call(response)
+	_draining = false
 
 
 func _dispatch(cmd: Dictionary) -> Dictionary:
@@ -103,7 +116,7 @@ func _dispatch(cmd: Dictionary) -> Dictionary:
 	var result: Dictionary
 
 	if _handlers.has(command):
-		result = _call_handler(command, params)
+		result = await _call_handler(command, params)
 	else:
 		result = McpErrorCodes.make(McpErrorCodes.UNKNOWN_COMMAND, "Unknown command: %s" % command)
 
@@ -128,7 +141,7 @@ func _dispatch(cmd: Dictionary) -> Dictionary:
 
 
 func _call_handler(command: String, params: Dictionary) -> Dictionary:
-	var result: Dictionary = _handlers[command].call(params)
+	var result: Dictionary = await _handlers[command].call(params)
 	## Handlers must return {"data": ...} on success or {"error": ...} on failure.
 	## Anything else (null, empty, missing keys) means the handler crashed
 	## mid-call — GDScript swallows the error and returns an empty dict.

--- a/plugin/addons/godot_ai/handlers/batch_handler.gd
+++ b/plugin/addons/godot_ai/handlers/batch_handler.gd
@@ -51,7 +51,7 @@ func batch_execute(params: Dictionary) -> Dictionary:
 		var cmd_name: String = item["command"]
 		var sub_params: Dictionary = item.get("params", {})
 
-		var raw_result: Dictionary = _dispatcher.dispatch_direct(cmd_name, sub_params)
+		var raw_result: Dictionary = await _dispatcher.dispatch_direct(cmd_name, sub_params)
 		var status: String = raw_result.get("status", "ok")
 
 		var result_entry: Dictionary = {"command": cmd_name, "status": status}

--- a/plugin/addons/godot_ai/handlers/project_handler.gd
+++ b/plugin/addons/godot_ai/handlers/project_handler.gd
@@ -135,11 +135,19 @@ func stop_project(_params: Dictionary) -> Dictionary:
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Project is not running")
 
 	EditorInterface.stop_playing_scene()
+	## Yield twice so Godot can tick the stop-play state change. After this
+	## is_playing_scene() reflects truth and Connection.get_readiness() is
+	## authoritative — callers can use `readiness_after` without polling.
+	var tree := Engine.get_main_loop() as SceneTree
+	if tree != null:
+		await tree.process_frame
+		await tree.process_frame
 	return {
 		"data": {
 			"stopped": true,
 			"undoable": false,
 			"reason": "Play/stop is a runtime action",
+			"readiness_after": Connection.get_readiness(),
 		}
 	}
 

--- a/plugin/addons/godot_ai/handlers/test_handler.gd
+++ b/plugin/addons/godot_ai/handlers/test_handler.gd
@@ -37,7 +37,7 @@ func run_tests(params: Dictionary) -> Dictionary:
 		"log_buffer": _log_buffer,
 	}
 
-	var results := _runner.run_suites(suites, suite_filter, test_filter, ctx, verbose)
+	var results: Dictionary = await _runner.run_suites(suites, suite_filter, test_filter, ctx, verbose)
 	if not discovery.errors.is_empty():
 		results["load_errors"] = discovery.errors
 	return {"data": results}

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -183,6 +183,7 @@ func _enter_tree() -> void:
 	)
 
 	_connection.dispatcher = _dispatcher
+	_dispatcher.set_response_sink(_connection._send_json)
 	add_child(_connection)
 
 	# Dock panel

--- a/plugin/addons/godot_ai/testing/test_runner.gd
+++ b/plugin/addons/godot_ai/testing/test_runner.gd
@@ -19,7 +19,11 @@ func run_suite(suite: McpTestSuite, test_filter: String = "") -> void:
 
 		suite._reset()
 		suite.setup()
-		suite.call(method_name)
+		## `await` a coroutine test method (a test that uses `await` internally
+		## returns a GDScriptFunctionState that must be awaited to run to
+		## completion). `await` on a non-coroutine return resolves immediately,
+		## so synchronous tests are unaffected.
+		await suite.call(method_name)
 		suite.teardown()
 
 		## Issue #19 defence: free any `_McpTest*` nodes the test created, even
@@ -98,7 +102,7 @@ func run_suites(suites: Array, suite_filter: String = "", test_filter: String = 
 				"assertion_count": 0,
 			})
 		else:
-			run_suite(suite, test_filter)
+			await run_suite(suite, test_filter)
 		suite.suite_teardown()
 
 		## Remove any nodes the suite left behind (failed undo, missing cleanup).

--- a/src/godot_ai/handlers/project.py
+++ b/src/godot_ai/handlers/project.py
@@ -39,23 +39,28 @@ async def project_run(
 
 
 async def project_stop(runtime: Runtime) -> dict:
-    """Stop the running game and wait for readiness to reflect the stop.
+    """Stop the running game and reflect the post-stop readiness.
 
-    The plugin's `_process` emits a `readiness_changed` event on the next
-    frame once `EditorInterface.is_playing_scene()` flips to false. A write
-    tool called immediately after this handler returns would otherwise race
-    the event and see stale `readiness="playing"`. We poll `session.readiness`
-    until it leaves "playing", bounded by a 1s timeout so a hung play process
-    doesn't block the handler indefinitely — in that case readiness stays
-    "playing" and the next write tool correctly blocks with EDITOR_NOT_READY.
+    The plugin's `stop_project` handler awaits two process_frames before
+    returning, so `readiness_after` in the response is authoritative — we
+    just copy it into the session and the next write tool sees truth
+    without a polling loop.
+
+    Older plugins (pre-#29) don't include `readiness_after`; fall back to
+    the legacy event-poll so a version-skew client still converges.
     """
     result = await runtime.send_command("stop_project")
     session = runtime.get_active_session()
-    if session is not None:
-        loop = asyncio.get_running_loop()
-        deadline = loop.time() + 1.0
-        while session.readiness == "playing" and loop.time() < deadline:
-            await asyncio.sleep(0.02)
+    if session is None:
+        return result
+    readiness_after = result.get("readiness_after")
+    if readiness_after is not None:
+        session.readiness = readiness_after
+        return result
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + 1.0
+    while session.readiness == "playing" and loop.time() < deadline:
+        await asyncio.sleep(0.02)
     return result
 
 

--- a/test_project/tests/test_batch.gd
+++ b/test_project/tests/test_batch.gd
@@ -45,34 +45,34 @@ func _undo_for_scene(scene_root: Node) -> UndoRedo:
 # ----- Validation -----
 
 func test_rejects_non_list_commands() -> void:
-	var result := _handler.batch_execute({"commands": "nope"})
+	var result: Dictionary = await _handler.batch_execute({"commands": "nope"})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 
 
 func test_rejects_empty_commands() -> void:
-	var result := _handler.batch_execute({"commands": []})
+	var result: Dictionary = await _handler.batch_execute({"commands": []})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 
 
 func test_rejects_missing_command_field() -> void:
-	var result := _handler.batch_execute({"commands": [{"params": {}}]})
+	var result: Dictionary = await _handler.batch_execute({"commands": [{"params": {}}]})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 
 
 func test_rejects_non_dict_item() -> void:
-	var result := _handler.batch_execute({"commands": [42]})
+	var result: Dictionary = await _handler.batch_execute({"commands": [42]})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 
 
 func test_rejects_unknown_subcommand() -> void:
-	var result := _handler.batch_execute({"commands": [{"command": "does_not_exist"}]})
+	var result: Dictionary = await _handler.batch_execute({"commands": [{"command": "does_not_exist"}]})
 	assert_is_error(result, McpErrorCodes.UNKNOWN_COMMAND)
 
 
 func test_unknown_command_error_mentions_plugin_names() -> void:
 	# Simulates the common mistake: passing MCP tool name "node_create"
 	# instead of the plugin command "create_node".
-	var result := _handler.batch_execute({"commands": [{"command": "node_create"}]})
+	var result: Dictionary = await _handler.batch_execute({"commands": [{"command": "node_create"}]})
 	assert_is_error(result, McpErrorCodes.UNKNOWN_COMMAND)
 	var msg: String = result.error.message
 	assert_contains(msg, "plugin command names", "error should explain naming convention")
@@ -80,7 +80,7 @@ func test_unknown_command_error_mentions_plugin_names() -> void:
 
 
 func test_unknown_command_populates_suggestions_field() -> void:
-	var result := _handler.batch_execute({"commands": [{"command": "node_create"}]})
+	var result: Dictionary = await _handler.batch_execute({"commands": [{"command": "node_create"}]})
 	assert_is_error(result, McpErrorCodes.UNKNOWN_COMMAND)
 	assert_has_key(result.error, "data")
 	assert_has_key(result.error.data, "suggestions")
@@ -91,7 +91,7 @@ func test_unknown_command_populates_suggestions_field() -> void:
 
 func test_unknown_command_empty_suggestions_when_no_match() -> void:
 	# Pure gibberish should still error cleanly, with suggestions empty or low-similarity.
-	var result := _handler.batch_execute({"commands": [{"command": "zzzqqqxxx_totally_bogus"}]})
+	var result: Dictionary = await _handler.batch_execute({"commands": [{"command": "zzzqqqxxx_totally_bogus"}]})
 	assert_is_error(result, McpErrorCodes.UNKNOWN_COMMAND)
 	assert_has_key(result.error, "data")
 	assert_has_key(result.error.data, "suggestions")
@@ -100,7 +100,7 @@ func test_unknown_command_empty_suggestions_when_no_match() -> void:
 
 
 func test_rejects_batch_execute_as_subcommand() -> void:
-	var result := _handler.batch_execute({
+	var result: Dictionary = await _handler.batch_execute({
 		"commands": [{"command": "batch_execute", "params": {}}],
 	})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
@@ -109,7 +109,7 @@ func test_rejects_batch_execute_as_subcommand() -> void:
 # ----- Success path -----
 
 func test_all_succeed_returns_results() -> void:
-	var result := _handler.batch_execute({
+	var result: Dictionary = await _handler.batch_execute({
 		"commands": [
 			{"command": "_ok_pure", "params": {}},
 			{"command": "_ok_pure", "params": {}},
@@ -125,7 +125,7 @@ func test_all_succeed_returns_results() -> void:
 
 
 func test_success_undoable_false_when_any_subcommand_not_undoable() -> void:
-	var result := _handler.batch_execute({
+	var result: Dictionary = await _handler.batch_execute({
 		"commands": [{"command": "_ok_pure", "params": {}}],
 	})
 	# _ok_pure returns undoable=false; batch reflects that.
@@ -135,7 +135,7 @@ func test_success_undoable_false_when_any_subcommand_not_undoable() -> void:
 # ----- Failure / stop semantics -----
 
 func test_stops_on_first_error() -> void:
-	var result := _handler.batch_execute({
+	var result: Dictionary = await _handler.batch_execute({
 		"commands": [
 			{"command": "_ok_pure", "params": {}},
 			{"command": "_fail_pure", "params": {}},
@@ -153,7 +153,7 @@ func test_stops_on_first_error() -> void:
 func test_no_rollback_when_undo_false() -> void:
 	var scene_root := EditorInterface.get_edited_scene_root()
 	var before_count := scene_root.get_child_count()
-	var result := _handler.batch_execute({
+	var result: Dictionary = await _handler.batch_execute({
 		"undo": false,
 		"commands": [
 			{"command": "create_node", "params": {"type": "Node3D", "name": "_BatchTempA", "parent_path": "/Main"}},
@@ -172,7 +172,7 @@ func test_no_rollback_when_undo_false() -> void:
 func test_rollback_on_failure_with_undo_true() -> void:
 	var scene_root := EditorInterface.get_edited_scene_root()
 	var before_count := scene_root.get_child_count()
-	var result := _handler.batch_execute({
+	var result: Dictionary = await _handler.batch_execute({
 		"commands": [
 			{"command": "create_node", "params": {"type": "Node3D", "name": "_BatchTempB", "parent_path": "/Main"}},
 			{"command": "_fail_pure", "params": {}},
@@ -188,7 +188,7 @@ func test_rollback_on_failure_with_undo_true() -> void:
 
 func test_real_multi_step_success() -> void:
 	var scene_root := EditorInterface.get_edited_scene_root()
-	var result := _handler.batch_execute({
+	var result: Dictionary = await _handler.batch_execute({
 		"commands": [
 			{"command": "create_node", "params": {"type": "Node3D", "name": "_BatchMulti", "parent_path": "/Main"}},
 			{"command": "set_property", "params": {"path": "/Main/_BatchMulti", "property": "position", "value": {"x": 1.0, "y": 2.0, "z": 3.0}}},

--- a/test_project/tests/test_dispatcher.gd
+++ b/test_project/tests/test_dispatcher.gd
@@ -1,9 +1,8 @@
 @tool
 extends McpTestSuite
 
-## Tests for McpDispatcher — specifically the crash-detection guardrail
-## that catches handlers returning malformed results (null, empty dict,
-## or dicts missing both "data" and "error" keys).
+## Tests for McpDispatcher — the crash-detection guardrail that catches
+## handlers returning malformed results, plus coroutine-handler support.
 
 
 func suite_name() -> String:
@@ -20,7 +19,7 @@ func test_dispatch_direct_converts_empty_dict_to_internal_error() -> void:
 	var d := _make_dispatcher()
 	d.mcp_logging = false
 	d.register("returns_empty", func(_p): return {})
-	var result := d.dispatch_direct("returns_empty", {})
+	var result: Dictionary = await d.dispatch_direct("returns_empty", {})
 	assert_is_error(result, McpErrorCodes.INTERNAL_ERROR)
 	assert_contains(result.error.message, "returns_empty")
 	assert_contains(result.error.message, "likely crashed")
@@ -32,7 +31,7 @@ func test_dispatch_direct_converts_null_result_to_internal_error() -> void:
 	## GDScript coerces null Variant to {} for typed Dictionary returns, so
 	## this ends up looking the same as the empty-dict case — still flagged.
 	d.register("returns_null", func(_p): return {})
-	var result := d.dispatch_direct("returns_null", {})
+	var result: Dictionary = await d.dispatch_direct("returns_null", {})
 	assert_is_error(result, McpErrorCodes.INTERNAL_ERROR)
 
 
@@ -42,7 +41,7 @@ func test_dispatch_direct_rejects_dict_missing_data_and_error_keys() -> void:
 	var d := _make_dispatcher()
 	d.mcp_logging = false
 	d.register("malformed", func(_p): return {"foo": "bar", "baz": 42})
-	var result := d.dispatch_direct("malformed", {})
+	var result: Dictionary = await d.dispatch_direct("malformed", {})
 	assert_is_error(result, McpErrorCodes.INTERNAL_ERROR)
 	assert_contains(result.error.message, "malformed")
 
@@ -51,7 +50,7 @@ func test_dispatch_direct_accepts_data_key() -> void:
 	var d := _make_dispatcher()
 	d.mcp_logging = false
 	d.register("good_data", func(_p): return {"data": {"value": 1}})
-	var result := d.dispatch_direct("good_data", {})
+	var result: Dictionary = await d.dispatch_direct("good_data", {})
 	assert_has_key(result, "data")
 	assert_eq(result.data.value, 1)
 
@@ -61,7 +60,7 @@ func test_dispatch_direct_accepts_error_key() -> void:
 	d.mcp_logging = false
 	d.register("good_error", func(_p):
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "bad input"))
-	var result := d.dispatch_direct("good_error", {})
+	var result: Dictionary = await d.dispatch_direct("good_error", {})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 	assert_eq(result.error.message, "bad input")
 
@@ -69,5 +68,69 @@ func test_dispatch_direct_accepts_error_key() -> void:
 func test_dispatch_direct_unknown_command_unchanged() -> void:
 	var d := _make_dispatcher()
 	d.mcp_logging = false
-	var result := d.dispatch_direct("never_registered", {})
+	var result: Dictionary = await d.dispatch_direct("never_registered", {})
 	assert_is_error(result, McpErrorCodes.UNKNOWN_COMMAND)
+
+
+# ----- coroutine handler support (#29) -----
+
+func _sync_handler(_p: Dictionary) -> Dictionary:
+	return {"data": {"kind": "sync"}}
+
+
+func _async_handler(_p: Dictionary) -> Dictionary:
+	var tree := Engine.get_main_loop() as SceneTree
+	await tree.process_frame
+	return {"data": {"kind": "async", "yielded": true}}
+
+
+func test_dispatch_direct_awaits_synchronous_handler() -> void:
+	var d := _make_dispatcher()
+	d.mcp_logging = false
+	d.register("sync", _sync_handler)
+	var result: Dictionary = await d.dispatch_direct("sync", {})
+	assert_has_key(result, "data")
+	assert_eq(result.data.kind, "sync")
+
+
+func test_dispatch_direct_awaits_coroutine_handler() -> void:
+	var d := _make_dispatcher()
+	d.mcp_logging = false
+	d.register("async", _async_handler)
+	var result: Dictionary = await d.dispatch_direct("async", {})
+	assert_has_key(result, "data")
+	assert_eq(result.data.kind, "async")
+	assert_eq(result.data.yielded, true)
+
+
+func test_tick_delivers_coroutine_response_via_sink() -> void:
+	var d := _make_dispatcher()
+	d.mcp_logging = false
+	d.register("async", _async_handler)
+	var received: Array[Dictionary] = []
+	d.set_response_sink(func(resp): received.append(resp))
+	d.enqueue({"request_id": "r1", "command": "async", "params": {}})
+	d.tick()
+	## Handler yields one frame inside _dispatch; yield two here to let the
+	## drain loop unwind and push through the sink.
+	var tree := Engine.get_main_loop() as SceneTree
+	await tree.process_frame
+	await tree.process_frame
+	assert_eq(received.size(), 1)
+	assert_eq(received[0].request_id, "r1")
+	assert_eq(received[0].status, "ok")
+	assert_eq(received[0].data.kind, "async")
+
+
+func test_tick_delivers_sync_response_via_sink() -> void:
+	var d := _make_dispatcher()
+	d.mcp_logging = false
+	d.register("sync", _sync_handler)
+	var received: Array[Dictionary] = []
+	d.set_response_sink(func(resp): received.append(resp))
+	d.enqueue({"request_id": "r2", "command": "sync", "params": {}})
+	d.tick()
+	assert_eq(received.size(), 1)
+	assert_eq(received[0].request_id, "r2")
+	assert_eq(received[0].status, "ok")
+	assert_eq(received[0].data.kind, "sync")

--- a/test_project/tests/test_project.gd
+++ b/test_project/tests/test_project.gd
@@ -173,5 +173,5 @@ func test_run_project_autosave_false_restores_editor_setting() -> void:
 # ----- stop_project -----
 
 func test_stop_project_rejects_when_not_playing() -> void:
-	var result := _handler.stop_project({})
+	var result: Dictionary = await _handler.stop_project({})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)

--- a/test_project/tests/test_runner.gd
+++ b/test_project/tests/test_runner.gd
@@ -80,7 +80,7 @@ class _SkippedSetupSuite extends McpTestSuite:
 
 func test_skip_records_separately_from_pass_fail() -> void:
 	var runner := McpTestRunner.new()
-	var result := runner.run_suites([_SkipSuite.new()])
+	var result: Dictionary = await runner.run_suites([_SkipSuite.new()])
 	assert_eq(result.skipped, 1, "one skipped test")
 	assert_eq(result.passed, 0, "skip does not count as pass")
 	assert_eq(result.failed, 0, "skip does not count as fail")
@@ -91,7 +91,7 @@ func test_skip_records_separately_from_pass_fail() -> void:
 
 func test_zero_assertion_test_is_flagged_as_failure() -> void:
 	var runner := McpTestRunner.new()
-	var result := runner.run_suites([_ZeroAssertSuite.new()])
+	var result: Dictionary = await runner.run_suites([_ZeroAssertSuite.new()])
 	assert_eq(result.failed, 1, "zero-assertion test should fail")
 	assert_eq(result.passed, 0)
 	assert_has_key(result, "failures")
@@ -100,7 +100,7 @@ func test_zero_assertion_test_is_flagged_as_failure() -> void:
 
 func test_single_assertion_test_passes() -> void:
 	var runner := McpTestRunner.new()
-	var result := runner.run_suites([_PassingSuite.new()])
+	var result: Dictionary = await runner.run_suites([_PassingSuite.new()])
 	assert_eq(result.passed, 1)
 	assert_eq(result.failed, 0)
 
@@ -113,7 +113,7 @@ func test_suite_setup_receives_deep_copy_of_ctx() -> void:
 	var ctx := {"top": "original", "nested": nested}
 	var suite := _CtxMutatorSuite.new()
 
-	runner.run_suites([suite], "", "", ctx)
+	await runner.run_suites([suite], "", "", ctx)
 
 	## The original ctx must be untouched — top level AND nested.
 	assert_eq(ctx.top, "original", "top-level key should not leak back")
@@ -128,7 +128,7 @@ func test_fail_setup_emits_one_suite_level_failure() -> void:
 	## A suite that calls fail_setup() in suite_setup should emit ONE result
 	## (not N per-test "0 assertions" results) and skip individual tests.
 	var runner := McpTestRunner.new()
-	var result := runner.run_suites([_FailedSetupSuite.new()])
+	var result: Dictionary = await runner.run_suites([_FailedSetupSuite.new()])
 	assert_eq(result.failed, 1, "exactly one suite-level failure")
 	assert_eq(result.passed, 0, "individual tests must not run")
 	assert_eq(result.total, 1, "one result, not per-test results")
@@ -142,7 +142,7 @@ func test_fail_setup_emits_one_suite_level_failure() -> void:
 func test_skip_suite_emits_one_suite_level_skip() -> void:
 	## skip_suite() is the no-precondition counterpart to fail_setup().
 	var runner := McpTestRunner.new()
-	var result := runner.run_suites([_SkippedSetupSuite.new()])
+	var result: Dictionary = await runner.run_suites([_SkippedSetupSuite.new()])
 	assert_eq(result.skipped, 1, "exactly one suite-level skip")
 	assert_eq(result.failed, 0)
 	assert_eq(result.passed, 0)
@@ -153,7 +153,7 @@ func test_failed_setup_does_not_run_other_suites_tests() -> void:
 	## Mixed: a failing suite should not poison the runner — subsequent
 	## suites must still execute normally.
 	var runner := McpTestRunner.new()
-	var result := runner.run_suites([_FailedSetupSuite.new(), _PassingSuite.new()])
+	var result: Dictionary = await runner.run_suites([_FailedSetupSuite.new(), _PassingSuite.new()])
 	assert_eq(result.failed, 1, "failing suite's suite-level failure")
 	assert_eq(result.passed, 1, "passing suite still ran")
 	assert_eq(result.total, 2)
@@ -169,7 +169,7 @@ func test_leaked_nodes_are_cleaned_up_after_suite() -> void:
 
 	var before_count := scene_root.get_child_count()
 	var runner := McpTestRunner.new()
-	runner.run_suites([_LeakingSuite.new()])
+	await runner.run_suites([_LeakingSuite.new()])
 
 	## The suite leaked one node; cleanup should have removed it.
 	assert_eq(scene_root.get_child_count(), before_count,

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -3726,6 +3726,44 @@ async def test_project_stop_handler_times_out_if_readiness_stuck():
     assert 0.9 <= elapsed < 1.5, f"Expected ~1s timeout, got {elapsed:.3f}s"
 
 
+async def test_project_stop_handler_uses_readiness_after_when_present():
+    """Issue #29: new plugin includes authoritative `readiness_after` in the
+    response, so the handler sets session.readiness directly and skips the
+    1s polling loop entirely — no `readiness_changed` event required."""
+    import time
+
+    from godot_ai.sessions.registry import Session
+
+    class ReadinessClient:
+        def __init__(self):
+            self.calls: list[dict] = []
+
+        async def send(self, command, params=None, session_id=None, timeout=5.0):
+            self.calls.append({"command": command, "params": params})
+            return {"stopped": True, "undoable": False, "readiness_after": "ready"}
+
+    client = ReadinessClient()
+    registry = SessionRegistry()
+    session = Session(
+        session_id="t@0003",
+        godot_version="4.6",
+        project_path="/tmp/test",
+        plugin_version="0.1.0",
+    )
+    session.readiness = "playing"
+    registry.register(session)
+    registry.set_active(session.session_id)
+    runtime = DirectRuntime(registry=registry, client=client)
+
+    t0 = time.monotonic()
+    result = await project_handlers.project_stop(runtime)
+    elapsed = time.monotonic() - t0
+    # No polling — the plugin already waited for the frame tick.
+    assert elapsed < 0.1, f"Expected no polling, got {elapsed:.3f}s"
+    assert session.readiness == "ready"
+    assert result["readiness_after"] == "ready"
+
+
 # ---------------------------------------------------------------------------
 # Material handler tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #29.

- **Dispatcher**: `tick()` is now a fire-and-forget drain that awaits handler coroutines serially and pushes responses through a `response_sink` callback. Handlers may be synchronous *or* use `await` internally; both paths round-trip uniformly through `dispatch_direct`. `batch_execute` and the test runner propagate `await` through sub-dispatches so coroutine handlers compose inside batches and suites.
- **project_stop**: plugin awaits two `process_frame`s so `is_playing_scene()` has time to flip, then returns `readiness_after` in the payload. Python `project_stop` consumes it directly, replacing the prior asyncio polling loop. Retains a polling fallback for plugin/server version skew.

## Why this matters

Several handlers need to observe engine state that only settles on the next idle tick (play/stop transitions, scene open/close, reimports). Without `await`, the Python layer had to poll — slower, racy, and the polling loops accumulated across handlers. This change is the infra for #29 and unblocks follow-ups that rely on post-op readiness being authoritative.

## Test plan

- [x] GDScript dispatcher suite (10/10) — includes new coroutine-handler tests: `test_dispatch_direct_awaits_synchronous_handler`, `test_dispatch_direct_awaits_coroutine_handler`, `test_tick_delivers_coroutine_response_via_sink`, `test_tick_delivers_sync_response_via_sink`.
- [x] pytest full suite — 524 passed.
- [x] Live smoke test via MCP: `project_run` → `project_stop` returned `readiness_after:"ready"`; immediate `node_create` after stop had no `EDITOR_NOT_READY` race. `batch_execute` with multi-step commands worked through the new await path.
- [x] `/simplify` review pass — pruned narrative comments, validated no duplication with existing utilities.

## Not in this PR (flagged for follow-up)

- `_drain` budget_ms now only caps *burst-starts*, not frame-time-spent (once a handler awaits, the drain sees it through). Consider renaming or resetting the budget across `await` boundaries.
- `readiness_after` is a stringly-typed cross-boundary key; no central constant. Worth a follow-up to consolidate readiness literals.
- `plugin.gd` wires the sink to `_connection._send_json` — reaches into a private-named method. A public `send_response` on `Connection` would be cleaner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)