### PR TITLE
fix: harden plugin _exit_tree teardown against reload crashes (#46)

### DIFF
--- a/plugin/addons/godot_ai/connection.gd
+++ b/plugin/addons/godot_ai/connection.gd
@@ -80,6 +80,17 @@ func disconnect_from_server() -> void:
 		_connected = false
 
 
+## Full pre-free cleanup for plugin unload: stop _process, close the
+## socket, and drop dispatcher/log_buffer refs so their Callable-held
+## RefCounted handlers decref before plugin.gd clears _handlers.
+## See issue #46 and plugin.gd::_exit_tree.
+func teardown() -> void:
+	set_process(false)
+	disconnect_from_server()
+	dispatcher = null
+	log_buffer = null
+
+
 func _connect_to_server() -> void:
 	var err := _peer.connect_to_url(_url)
 	if err != OK:

--- a/plugin/addons/godot_ai/dispatcher.gd
+++ b/plugin/addons/godot_ai/dispatcher.gd
@@ -20,6 +20,15 @@ func register(command_name: String, handler: Callable) -> void:
 	_handlers[command_name] = handler
 
 
+## Drop registered handlers, queued commands, and the log buffer ref so
+## plugin.gd can release RefCounted handlers before Godot reloads their
+## class_name scripts (issue #46). After clear(), the dispatcher is inert.
+func clear() -> void:
+	_handlers.clear()
+	_command_queue.clear()
+	_log_buffer = null
+
+
 ## Invoke a registered handler directly by name. Returns the handler's raw
 ## response dict (no request_id or status wrapping). Returns an UNKNOWN_COMMAND
 ## error dict if the command is not registered. Used by batch_execute.

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -204,10 +204,7 @@ func _exit_tree() -> void:
 	# Stop inbound work first so _process can't enqueue new commands or
 	# null-deref log_buffer on the next tick mid-teardown.
 	if _connection:
-		_connection.set_process(false)
-		_connection.disconnect_from_server()
-		_connection.dispatcher = null
-		_connection.log_buffer = null
+		_connection.teardown()
 
 	# Break the Callable -> handler ref chain before dropping _handlers, so the
 	# array clear actually decrefs the handler RefCounteds to zero.

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -195,17 +195,43 @@ func _enter_tree() -> void:
 
 
 func _exit_tree() -> void:
+	## Outer-to-inner teardown. Dispatcher Callables hold RefCounted handlers
+	## alive past the point where Godot reloads their class_name scripts — the
+	## first post-reload call into a typed-array-holding handler (e.g.
+	## GameLogBuffer._storage) then SIGSEGVs against a stale class descriptor.
+	## See issue #46.
+
+	# Stop inbound work first so _process can't enqueue new commands or
+	# null-deref log_buffer on the next tick mid-teardown.
+	if _connection:
+		_connection.set_process(false)
+		_connection.disconnect_from_server()
+		_connection.dispatcher = null
+		_connection.log_buffer = null
+
+	# Break the Callable -> handler ref chain before dropping _handlers, so the
+	# array clear actually decrefs the handler RefCounteds to zero.
+	if _dispatcher:
+		_dispatcher.clear()
+
+	# Handler destructors run here, while their class_name scripts are still loaded.
+	_handlers.clear()
+
 	if _dock:
 		remove_control_from_docks(_dock)
 		_dock.queue_free()
 		_dock = null
 	if _connection:
-		_connection.disconnect_from_server()
 		_connection.queue_free()
 		_connection = null
 	if _debugger_plugin:
 		remove_debugger_plugin(_debugger_plugin)
 		_debugger_plugin = null
+
+	_dispatcher = null
+	_log_buffer = null
+	_game_log_buffer = null
+
 	_stop_server()
 	print("MCP | plugin unloaded")
 

--- a/script/ci-reload-test
+++ b/script/ci-reload-test
@@ -154,4 +154,65 @@ if not version:
 print(f'Post-reload health OK: {project} on Godot {version}')
 "
 
+# --- Step 6: Exercise the game-logs path (issue #46 crash site) ---
+# Before the cleanup fix in _exit_tree, logs_read(source=game) on the
+# new plugin would segfault at GameLogBuffer.get_range's first _storage
+# access. This asserts the handler's typed array stays valid across a reload.
+echo "Verifying logs_read source=game..."
+GAMELOGS_RESULT=$(mcp_call_or_die "logs_read source=game" logs_read '{"count":10,"source":"game"}')
+echo "$GAMELOGS_RESULT" | python3 -c "
+import json, sys
+content = json.loads(sys.stdin.read())
+# A fresh editor has no game logs yet — we only care the call returned
+# without SIGSEGV and reports a sane shape. 'source' should echo 'game'.
+if content.get('source') != 'game':
+    print(f'FAIL: logs_read source=game returned wrong source: {content}')
+    sys.exit(1)
+total = content.get('total_count', -1)
+if total < 0:
+    print(f'FAIL: logs_read source=game missing total_count: {content}')
+    sys.exit(1)
+print(f'Game-logs path OK: total={total}, returned={content.get(\"returned_count\", 0)}')
+"
+
+# --- Step 7: Multi-reload churn (cumulative corruption regression) ---
+# The original issue report saw crashes after ~10 reloads. Do 9 more
+# reloads (10 total with step 2 above) interleaved with cheap tool
+# calls — catches both single-reload and cumulative-state regressions.
+echo "Running 9 more reload iterations..."
+for i in $(seq 2 10); do
+  mcp_call_or_die "editor_reload_plugin #$i" editor_reload_plugin '{}' > /dev/null
+  # Rotate the post-reload probe across the three reported-stable tools.
+  case $(( i % 3 )) in
+    0)
+      mcp_call_or_die "editor_state after reload #$i" editor_state '{}' > /dev/null
+      ;;
+    1)
+      mcp_call_or_die "node_find after reload #$i" node_find '{"name":"ReloadTestCube"}' > /dev/null
+      ;;
+    2)
+      mcp_call_or_die "logs_read source=game after reload #$i" logs_read '{"count":5,"source":"game"}' > /dev/null
+      ;;
+  esac
+  echo "  reload #$i OK"
+done
+
+# --- Step 8: Post-churn test_run (ResourceSaver.save path from issue #46) ---
+# The original crash report was "~10 reloads then run full test suite" —
+# the failing backtrace went through ResourceSaver::save during test
+# cleanup. Running the suite here exercises that exact path on top of
+# all the accumulated reload state.
+echo "Running GDScript test suite on reloaded plugin..."
+TESTS_RESULT=$(mcp_call_or_die "test_run post-churn" test_run '{"verbose":false}')
+echo "$TESTS_RESULT" | python3 -c "
+import json, sys
+content = json.loads(sys.stdin.read())
+failed = content.get('failed', -1)
+passed = content.get('passed', 0)
+if failed != 0:
+    print(f'FAIL: {failed} test(s) failed after reload churn (passed={passed})')
+    sys.exit(1)
+print(f'Post-churn test suite OK: {passed} passed, {failed} failed')
+"
+
 echo "Reload smoke test passed"


### PR DESCRIPTION
## Summary

- Fix SIGSEGV on the first post-reload method call into a handler after `editor_reload_plugin`: dispatcher Callables kept RefCounted handlers alive past the point where Godot reloaded their `class_name` scripts, so the next method call dereferenced a stale class descriptor.
- Add deterministic teardown in `plugin.gd::_exit_tree`: stop `Connection._process`, null its dispatcher/log_buffer refs, call new `McpDispatcher.clear()` to break the Callable -> handler ref chain, then `_handlers.clear()` so RefCounteds destruct while their scripts are still loaded.
- Extend `script/ci-reload-test` with the `logs_read source=game` crash-site probe, a 10-reload churn loop, and a full `test_run` on the reloaded plugin -- matching the issue's "~10 reloads then run test suite" repro.

Closes #46.

## Test plan

- [x] `pytest -x -q` -- 523 passed
- [x] GDScript `test_run` against live editor -- 679 passed (0 failed)
- [x] `script/ci-reload-test` end-to-end -- all 8 steps pass (10 reloads + post-churn test_run)
- [x] Manual smoke: `logs_read source=game` after first reload returns cleanly (previously SIGSEGV)
- [x] Manual smoke: 10 consecutive reloads interleaved with `editor_state`/`node_find`/`logs_read` probes, editor stays alive

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)
