### PR TITLE
Update installation instructions to prioritize source installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,17 +41,19 @@
 
 ### 1. Install the plugin
 
-**Recommended — via the [Godot Asset Library](https://godotengine.org/asset-library/asset/5050):** in Godot, open the **AssetLib** tab, search for **Godot AI**, click **Download**, then **Install**.
-
-<details>
-<summary>Or install from source</summary>
+**Recommended — install from source** (always the latest):
 
 ```bash
 git clone https://github.com/hi-godot/godot-ai.git
 cp -r godot-ai/plugin/addons/godot_ai your-project/addons/
 ```
 
-Alternatively, [download the latest release ZIP](https://github.com/hi-godot/godot-ai/releases/latest) and extract `addons/godot_ai` into your project's `addons/` folder.
+Or [download the latest release ZIP](https://github.com/hi-godot/godot-ai/releases/latest) and extract `addons/godot_ai` into your project's `addons/` folder.
+
+<details>
+<summary>Or via the Godot Asset Library</summary>
+
+In Godot, open the **AssetLib** tab, search for **Godot AI**, click **Download**, then **Install**. Note: Asset Library updates lag behind GitHub, so this version may not be the most recent.
 
 </details>
 


### PR DESCRIPTION
## Summary
Updated the plugin installation documentation to reflect a change in recommended installation method, prioritizing source installation from GitHub over the Godot Asset Library.

## Key Changes
- Reordered installation methods to make source installation the primary recommendation
- Moved Asset Library installation to a collapsible details section as an alternative
- Added clarification that Asset Library updates lag behind GitHub releases
- Simplified wording for the ZIP download alternative method
- Restructured the installation section for better clarity and user guidance

## Rationale
This change emphasizes that users can get the latest features and fixes by installing directly from the GitHub repository, while acknowledging that the Asset Library option exists but may not always have the most recent version.

https://claude.ai/code/session_01T5iJiNdoihotBV9tbqXHaF