### PR TITLE
ci: bump actions to Node.js 24 natives (checkout v6, setup-python v6, upload-artifact v7)

### DIFF
--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -28,7 +28,7 @@ jobs:
   bump:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Read current version
         id: current

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
         python-version: ["3.11", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -58,10 +58,10 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -105,7 +105,7 @@ jobs:
 
       - name: Upload build artifacts
         if: matrix.os == 'ubuntu-latest'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -115,7 +115,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: chickensoft-games/setup-godot@v2
         with:
@@ -123,7 +123,7 @@ jobs:
           use-dotnet: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -164,7 +164,7 @@ jobs:
     name: Game capture smoke / Linux
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: chickensoft-games/setup-godot@v2
         with:
@@ -175,7 +175,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y xvfb
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -202,7 +202,7 @@ jobs:
     name: Game capture smoke / macOS
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: chickensoft-games/setup-godot@v2
         with:
@@ -210,7 +210,7 @@ jobs:
           use-dotnet: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -234,7 +234,7 @@ jobs:
     name: Game capture smoke / Windows
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: chickensoft-games/setup-godot@v2
         with:
@@ -242,7 +242,7 @@ jobs:
           use-dotnet: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -271,7 +271,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: chickensoft-games/setup-godot@v2
         with:
@@ -279,7 +279,7 @@ jobs:
           use-dotnet: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -308,7 +308,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: chickensoft-games/setup-godot@v2
         with:
@@ -316,7 +316,7 @@ jobs:
           use-dotnet: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       id-token: write  # required for PyPI OIDC
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Verify ref is a version tag
         # Guard against a manual workflow_dispatch on a branch ref (e.g.
@@ -40,7 +40,7 @@ jobs:
           fi
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -78,7 +78,7 @@ jobs:
     needs: publish-pypi
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build plugin ZIP
         # Ship `addons/` + `LICENSE` at the zip's top level. The multi-top


### PR DESCRIPTION
## Summary

Silences the Node.js 20 deprecation warnings on every CI run by bumping pinned actions to the latest majors that natively run on Node 24.

| Action | Old | New |
|---|---|---|
| `actions/checkout` | `v4` | `v6` |
| `actions/setup-python` | `v5` | `v6` |
| `actions/upload-artifact` | `v4` | `v7` |

## Context

GitHub deprecated Node 20 for JS actions. Forced migration to Node 24 happens **June 2, 2026**; Node 20 is removed from runners **September 16, 2026**. No rush today, but cheap to get ahead of.

Inputs used in these workflows (`checkout` with defaults, `setup-python` with `python-version`, `upload-artifact` with `name` + `path`) are stable across all bumped majors — no YAML beyond the `@vX` pin needs changing.

## Test plan

- [ ] CI passes on all platforms (Linux / macOS / Windows / Python 3.11 + 3.13)
- [ ] No new warnings in the run annotations
