### PR TITLE
ci: bump codecov-action v5 -> v6 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: ./coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Follow-up to #109. v5 transitively pins `actions/github-script@60a0d83` (v7.0.1, Node 20). codecov fixed this on 2026-03-26; v6 has the Node 24 bump. Closes the last Node 20 deprecation warning.

See [codecov-action#1919](https://github.com/codecov/codecov-action/issues/1919).