### PR TITLE
ci: bump softprops/action-gh-release v2 -> v3 (Node 24)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
           echo "Zip structure verified: addons/godot_ai/... + LICENSE (multi-top)"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: godot-ai-plugin.zip
           generate_release_notes: true


### PR DESCRIPTION
v3.0.0 is a pure Node 20 -> Node 24 runtime bump ([release notes](https://github.com/softprops/action-gh-release/releases/tag/v3.0.0)). No behavior or input changes.

Closes the Node 20 warning on the build-plugin-zip job of release.yml. Follow-up to #109 and #110.