### PR TITLE
feat: session_list reports server_version alongside plugin_version

### DIFF
--- a/src/godot_ai/sessions/registry.py
+++ b/src/godot_ai/sessions/registry.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from functools import cached_property
 
+from godot_ai import __version__ as _SERVER_VERSION
+
 logger = logging.getLogger(__name__)
 
 
@@ -53,6 +55,7 @@ class Session:
             "godot_version": self.godot_version,
             "project_path": self.project_path,
             "plugin_version": self.plugin_version,
+            "server_version": _SERVER_VERSION,
             "protocol_version": self.protocol_version,
             "current_scene": self.current_scene,
             "play_state": self.play_state,

--- a/src/godot_ai/tools/session.py
+++ b/src/godot_ai/tools/session.py
@@ -15,8 +15,10 @@ def register_session_tools(mcp: FastMCP) -> None:
 
         Returns session metadata for each connected editor instance:
         session_id, short name (project basename), godot_version, project_path,
-        editor_pid, current_scene, play_state, readiness, connected_at,
-        last_seen (heartbeat timestamp), and is_active flag.
+        plugin_version, server_version (this running MCP server's package
+        version — same for every session), editor_pid, current_scene,
+        play_state, readiness, connected_at, last_seen (heartbeat timestamp),
+        and is_active flag.
         """
         runtime = DirectRuntime.from_context(ctx)
         return session_handlers.session_list(runtime)

--- a/tests/unit/test_session_registry.py
+++ b/tests/unit/test_session_registry.py
@@ -103,6 +103,14 @@ class TestSessionRegistry:
         assert d["name"] == "test_project"
         assert d["editor_pid"] == 0
 
+    def test_to_dict_includes_server_version(self):
+        from godot_ai import __version__ as running_version
+
+        s = _make_session()
+        d = s.to_dict()
+        assert d["server_version"] == running_version
+        assert d["plugin_version"] == "0.0.1"
+
 
 class TestSessionMetadata:
     def test_name_derived_from_project_path(self):


### PR DESCRIPTION
## Summary

`session_list` now reports `server_version` — the running Python MCP server package version — alongside the existing `plugin_version`. Same value for every session since one server serves them all.

## Why

Users running a mix of dev-venv, uvx, and PyPI installs cannot currently tell from inside the MCP which server version is actually answering. The plugin tier fallback in `client_configurator.gd` (`.venv → uvx → system`) can silently pick an unexpected tier, and if the plugin auto-updates to 1.2.0 but uvx still resolves an older cached wheel, nothing in the protocol surfaces the mismatch.

Adding `server_version` lets callers compare against `plugin_version` at a glance. Drove this directly from an in-session troubleshooting loop where verifying the expected PyPI version was loaded required `ps eww`, `lsof`, and `__PYVENV_LAUNCHER__` inspection.

## Implementation

Source of truth is `importlib.metadata.version("godot-ai")`, already exposed as `godot_ai.__version__` (falls back to `0+unknown` for unbuilt source trees). Imported once at module load and folded into `Session.to_dict()` — no per-session storage needed.

## Test plan

- [x] `pytest -v` — 527 passed (new test: `test_to_dict_includes_server_version`)
- [x] `ruff check src/ tests/` — clean
- [ ] Post-merge live smoke: `session_list` via MCP shows both `plugin_version` and `server_version` keys (requires server restart since the running dev server was spawned without `--reload`)

## Not in scope

- `editor_state` does not currently expose `plugin_version` either; no parallel change needed.
- Surfacing `server_version` in the dock UI — separate UX question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
