### PR TITLE
ci: print failing test detail in ci-reload-test step 8

### DIFF
--- a/script/ci-reload-test
+++ b/script/ci-reload-test
@@ -211,6 +211,8 @@ failed = content.get('failed', -1)
 passed = content.get('passed', 0)
 if failed != 0:
     print(f'FAIL: {failed} test(s) failed after reload churn (passed={passed})')
+    for f in content.get('failures', []):
+        print(f'  FAIL: {f[\"suite\"]}.{f[\"test\"]}: {f[\"message\"]}')
     sys.exit(1)
 print(f'Post-churn test suite OK: {passed} passed, {failed} failed')
 "


### PR DESCRIPTION
## Summary

`script/ci-reload-test` step 8 runs `test_run` after 10 plugin-reload iterations, but on failure only logs the count — the `failures[]` array (with suite, test, and message including [#108](https://github.com/hi-godot/godot-ai/pull/108)'s camera-undo diagnostic fields) was discarded.

PR [#112](https://github.com/hi-godot/godot-ai/pull/112)'s macOS run is the most recent instance:
```
FAIL: 1 test(s) failed after reload churn (passed=678)
```
No test name, no message. Post-churn flakes become guesswork.

## Change

Two lines: mirror the per-failure print block already in [`script/ci-godot-tests:117`](https://github.com/hi-godot/godot-ai/blob/main/script/ci-godot-tests#L117) into the post-churn step.

## Context

This is the narrow fix. The broader audit for similar silent-failure patterns across tests and CI scripts is tracked in [#114](https://github.com/hi-godot/godot-ai/issues/114).

## Test plan

- [x] `bash -n script/ci-reload-test` — syntax clean
- [x] Dry-run the inline Python against a synthetic `{failed: 1, failures: [...]}` payload — prints `FAIL: camera.test_...: <message>` as expected
- [ ] CI — macOS reload-test will surface real failing-test detail the next time it flakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
