### PR TITLE
fix: gate self-updater on dev checkout to prevent symlink overwrite

### DIFF
--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -693,6 +693,13 @@ func _apply_row_status(client_id: String, status: McpClient.Status, error_msg: S
 # --- Update check & self-update ---
 
 func _check_for_updates() -> void:
+	## In a dev checkout `addons/godot_ai/` is a symlink into the canonical
+	## `plugin/` tree, so `FileAccess.open(..., WRITE)` during self-update
+	## follows the symlink and overwrites the user's source files in place.
+	## Devs update via `git pull`, not the dock — skip the GitHub check
+	## entirely to avoid even offering the destructive path. See #116.
+	if McpClientConfigurator.is_dev_checkout():
+		return
 	_http_request.request(RELEASES_URL, ["Accept: application/vnd.github+json"])
 
 
@@ -766,6 +773,18 @@ func _on_download_completed(result: int, response_code: int, _headers: PackedStr
 
 
 func _install_update() -> void:
+	## Belt-and-suspenders check. The banner is already gated on
+	## is_dev_checkout() in _check_for_updates, but a stale cached
+	## _latest_download_url or a code-path change that bypasses the banner
+	## gate would still reach here. In a dev checkout `addons/godot_ai/`
+	## is a symlink; writing into it clobbers the canonical source tree.
+	## Bail before touching disk. See #116.
+	if McpClientConfigurator.is_dev_checkout():
+		_update_btn.text = "Dev checkout — update via git"
+		_update_btn.disabled = true
+		_update_banner.visible = false
+		return
+
 	var zip_path := ProjectSettings.globalize_path(UPDATE_TEMP_ZIP)
 	var install_base := ProjectSettings.globalize_path("res://")
 


### PR DESCRIPTION
## Summary

- Gates `_check_for_updates` and `_install_update` on `McpClientConfigurator.is_dev_checkout()` so the dock's self-updater is a no-op in any dev checkout (any tree with a `.venv/` in a parent dir).
- The banner's "don't even offer the destructive path" posture matches the existing `_setup_section` pattern at `mcp_dock.gd:479`.
- Keeps a second gate inside `_install_update` as belt-and-suspenders in case a future code path reaches the installer without going through the banner.

## Why

`test_project/addons/godot_ai` is a symlink into `plugin/addons/godot_ai/` in the documented dev-checkout layout. The previous extractor wrote each file with `FileAccess.open(..., FileAccess.WRITE)`, which follows symlinks on POSIX — so clicking Update silently overwrote the user's git working tree with whatever was in the release ZIP. No warning, no preview, no dirty-check. Issue #116 has the full repro and root-cause trace.

## Test plan

- [x] `ruff check src/ tests/`
- [x] `pytest -v` (527 passed)
- [x] `godot --headless --import` against `test_project/` → no parse errors
- [ ] Manual verification (reviewer / next smoke session): temporarily drop `plugin.cfg` version to `1.2.0` in a dev checkout, restart the editor, confirm the Update banner does **not** appear. Plain-clone behavior (non-symlinked `addons/godot_ai/`) unchanged — banner still shows.

Closes #116.
