### PR TITLE
fix: read __version__ from pyproject.toml first, dist-info as fallback

### DIFF
--- a/src/godot_ai/__init__.py
+++ b/src/godot_ai/__init__.py
@@ -3,17 +3,40 @@
 from __future__ import annotations
 
 import argparse
+import tomllib
 from collections.abc import Sequence
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
+from pathlib import Path
 
-try:
-    __version__ = _pkg_version("godot-ai")
-except PackageNotFoundError:
-    # In-tree / unbuilt source tree (e.g. running pytest from a checkout
-    # without an editable install). Package metadata is only available after
-    # install, so fall back to a placeholder rather than crashing.
-    __version__ = "0+unknown"
+
+def _resolve_version(package_file: str | Path) -> str:
+    ## Try pyproject.toml first. Editable installs pin the dist-info
+    ## METADATA at install time, so `importlib.metadata.version("godot-ai")`
+    ## returns whatever the version was when the venv was created — e.g.
+    ## "0.0.1" on a venv made before the first release bump. Reading the
+    ## live pyproject keeps `godot_ai.__version__` and `session_list`'s
+    ## `server_version` honest against the current source tree.
+    ##
+    ## Order matters: dev checkouts have both a pyproject and dist-info;
+    ## wheel installs only have dist-info. Pyproject wins when both exist.
+    pyproject = Path(package_file).resolve().parent.parent.parent / "pyproject.toml"
+    if pyproject.is_file():
+        try:
+            with pyproject.open("rb") as f:
+                data = tomllib.load(f)
+            version = data.get("project", {}).get("version")
+            if isinstance(version, str) and version:
+                return version
+        except (OSError, tomllib.TOMLDecodeError):
+            pass
+    try:
+        return _pkg_version("godot-ai")
+    except PackageNotFoundError:
+        return "0+unknown"
+
+
+__version__ = _resolve_version(__file__)
 
 
 def main(argv: Sequence[str] | None = None) -> None:

--- a/tests/unit/test_version.py
+++ b/tests/unit/test_version.py
@@ -1,33 +1,99 @@
-"""Tests for the `__version__` attribute's package-metadata fallback."""
+"""Tests for the `__version__` attribute's resolution order."""
 
 from __future__ import annotations
 
 import importlib
 import importlib.metadata
+import tomllib
+from pathlib import Path
 
 
-def test_version_reads_from_package_metadata():
-    """When installed, __version__ matches importlib.metadata's answer."""
+def _pyproject_version() -> str:
+    pyproject = Path(__file__).resolve().parent.parent.parent / "pyproject.toml"
+    with pyproject.open("rb") as f:
+        return tomllib.load(f)["project"]["version"]
+
+
+def test_version_matches_pyproject():
+    ## Editable installs freeze their dist-info METADATA at the version
+    ## that was current when the venv was created, so relying on
+    ## importlib.metadata silently drifts from the source tree after
+    ## every version bump. Anchoring __version__ to pyproject keeps
+    ## session_list's server_version honest.
     import godot_ai
 
-    expected = importlib.metadata.version("godot-ai")
-    assert godot_ai.__version__ == expected
+    assert godot_ai.__version__ == _pyproject_version()
 
 
-def test_version_falls_back_when_package_not_installed(monkeypatch):
-    """Bare source checkouts (no install) fall back to a PEP 440 local-version
-    placeholder instead of raising at import time."""
+def test_resolve_version_prefers_pyproject_over_metadata(tmp_path, monkeypatch):
+    from godot_ai import _resolve_version
+
+    repo_root = tmp_path / "repo"
+    pkg_dir = repo_root / "src" / "godot_ai"
+    pkg_dir.mkdir(parents=True)
+    (repo_root / "pyproject.toml").write_text('[project]\nversion = "7.0.0"\n')
+    fake_pkg_file = pkg_dir / "__init__.py"
+    fake_pkg_file.write_text("")
+
+    ## Even if installed-metadata disagrees, pyproject wins when present.
     import godot_ai
 
-    def raise_not_found(name: str) -> str:
-        raise importlib.metadata.PackageNotFoundError(name)
+    monkeypatch.setattr(godot_ai, "_pkg_version", lambda _name: "9.9.9")
 
-    # Patch at the source so the reload re-binds to the faulty version.
-    monkeypatch.setattr(importlib.metadata, "version", raise_not_found)
-    reloaded = importlib.reload(godot_ai)
-    try:
-        assert reloaded.__version__ == "0+unknown"
-    finally:
-        # Restore real version for subsequent tests that might read it.
-        monkeypatch.undo()
-        importlib.reload(godot_ai)
+    assert _resolve_version(fake_pkg_file) == "7.0.0"
+
+
+def test_resolve_version_falls_back_to_metadata_when_pyproject_missing(tmp_path, monkeypatch):
+    from godot_ai import _resolve_version
+
+    repo_root = tmp_path / "repo"
+    pkg_dir = repo_root / "src" / "godot_ai"
+    pkg_dir.mkdir(parents=True)
+    fake_pkg_file = pkg_dir / "__init__.py"
+    fake_pkg_file.write_text("")
+
+    import godot_ai
+
+    monkeypatch.setattr(godot_ai, "_pkg_version", lambda _name: "9.9.9")
+
+    assert _resolve_version(fake_pkg_file) == "9.9.9"
+
+
+def test_resolve_version_falls_back_to_placeholder_when_nothing_available(
+    tmp_path, monkeypatch
+):
+    from godot_ai import _resolve_version
+
+    repo_root = tmp_path / "repo"
+    pkg_dir = repo_root / "src" / "godot_ai"
+    pkg_dir.mkdir(parents=True)
+    fake_pkg_file = pkg_dir / "__init__.py"
+    fake_pkg_file.write_text("")
+
+    def raise_not_found(_name: str) -> str:
+        raise importlib.metadata.PackageNotFoundError("godot-ai")
+
+    import godot_ai
+
+    monkeypatch.setattr(godot_ai, "_pkg_version", raise_not_found)
+
+    assert _resolve_version(fake_pkg_file) == "0+unknown"
+
+
+def test_resolve_version_skips_malformed_pyproject(tmp_path, monkeypatch):
+    ## Corrupt / half-written pyproject shouldn't propagate a TOMLDecodeError
+    ## on import — fall through to metadata.
+    from godot_ai import _resolve_version
+
+    repo_root = tmp_path / "repo"
+    pkg_dir = repo_root / "src" / "godot_ai"
+    pkg_dir.mkdir(parents=True)
+    (repo_root / "pyproject.toml").write_text("[project\nversion = malformed")
+    fake_pkg_file = pkg_dir / "__init__.py"
+    fake_pkg_file.write_text("")
+
+    import godot_ai
+
+    monkeypatch.setattr(godot_ai, "_pkg_version", lambda _name: "9.9.9")
+
+    assert _resolve_version(fake_pkg_file) == "9.9.9"


### PR DESCRIPTION
## Summary

- `godot_ai.__version__` now reads from `pyproject.toml` when the package is imported from a source tree that has one next to it, falling back to `importlib.metadata.version("godot-ai")` and then to `"0+unknown"`.
- Same fix propagates to `session_list`'s `server_version` field (it reads through `godot_ai.__version__`).

## Why

Editable installs (our `script/setup-dev` flow) pin `.dist-info/METADATA` at install time. Once a venv is created when pyproject was at some version, `importlib.metadata.version("godot-ai")` keeps returning that version forever — even after the source tree moves on. That means:

- A dev venv made before the first real release reports `server_version: "0.0.1"` today, against a 1.2.1 source tree.
- Every version-drift debugging session starts with "oh right, ignore that number."
- Smoke tests that check "am I on the right version?" can't trust the server's own answer.

Pyproject-first is honest about the source tree. Wheel / pipx / uvx installs don't ship a pyproject adjacent to the package, so they fall through to the metadata path unchanged. This is surfaced in [#113](https://github.com/hi-godot/godot-ai/issues/113) as a separate gap from the two flows in that issue's summary.

## Test plan

- [x] `ruff check src/ tests/`
- [x] `pytest -v` (530 passed, +3 net vs. main)
- [x] `tests/unit/test_version.py` covers: pyproject-wins-over-metadata, metadata-fallback-when-pyproject-missing, placeholder-when-neither, malformed-pyproject-falls-through-gracefully
- [x] Manual: `.venv/bin/python -c "import godot_ai; print(godot_ai.__version__)"` returns `1.2.1` after the fix (was `0.0.1` before on long-lived venvs)
