### PR TITLE
feat: session_list reports server_launch_mode

### DIFF
--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -128,6 +128,19 @@ static func get_server_command() -> Array[String]:
 	return []
 
 
+## Which tier `get_server_command` would resolve to, without side-effects.
+## Returned as a stable string so handshakes and session_list can expose it
+## to MCP callers. Values track the `Literal` on the Python side.
+static func get_server_launch_mode() -> String:
+	if not _cached_venv_python().is_empty():
+		return "dev_venv"
+	if not find_uvx().is_empty():
+		return "uvx"
+	if not _find_system_install().is_empty():
+		return "system"
+	return "unknown"
+
+
 static func find_uvx() -> String:
 	var names: Array[String] = []
 	names.append("uvx.exe" if OS.get_name() == "Windows" else "uvx")

--- a/plugin/addons/godot_ai/connection.gd
+++ b/plugin/addons/godot_ai/connection.gd
@@ -119,6 +119,7 @@ func _send_handshake() -> void:
 		"protocol_version": 1,
 		"readiness": _last_readiness,
 		"editor_pid": OS.get_process_id(),
+		"server_launch_mode": McpClientConfigurator.get_server_launch_mode(),
 	})
 
 

--- a/src/godot_ai/protocol/envelope.py
+++ b/src/godot_ai/protocol/envelope.py
@@ -44,3 +44,8 @@ class HandshakeMessage(BaseModel):
     readiness: str = "ready"
     ## Optional because older plugins won't send it; server falls back to 0.
     editor_pid: int = 0
+    ## Which launcher tier the plugin resolved for the Python server. Older
+    ## plugins omit the field entirely, which lands as "unknown" on the
+    ## server — distinguishable from a live detection that returned
+    ## "unknown" only by plugin_version.
+    server_launch_mode: str = "unknown"

--- a/src/godot_ai/sessions/registry.py
+++ b/src/godot_ai/sessions/registry.py
@@ -26,6 +26,12 @@ class Session:
     play_state: str = "stopped"
     readiness: str = "ready"
     editor_pid: int = 0
+    ## Which launcher tier the plugin resolved the Python server from —
+    ## "dev_venv" | "uvx" | "system" | "unknown". Lets agents notice when a
+    ## plugin-level update left an older server running, or when a stray
+    ## dev `.venv` is silently overriding the published install. Older
+    ## plugins omit this in the handshake; default is "unknown".
+    server_launch_mode: str = "unknown"
     connected_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     last_seen: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
@@ -61,6 +67,7 @@ class Session:
             "play_state": self.play_state,
             "readiness": self.readiness,
             "editor_pid": self.editor_pid,
+            "server_launch_mode": self.server_launch_mode,
             "connected_at": self.connected_at.isoformat(),
             "last_seen": self.last_seen.isoformat(),
         }

--- a/src/godot_ai/tools/session.py
+++ b/src/godot_ai/tools/session.py
@@ -16,9 +16,11 @@ def register_session_tools(mcp: FastMCP) -> None:
         Returns session metadata for each connected editor instance:
         session_id, short name (project basename), godot_version, project_path,
         plugin_version, server_version (this running MCP server's package
-        version — same for every session), editor_pid, current_scene,
-        play_state, readiness, connected_at, last_seen (heartbeat timestamp),
-        and is_active flag.
+        version — same for every session), editor_pid, server_launch_mode
+        (which launcher tier the plugin resolved the running server from:
+        "dev_venv" | "uvx" | "system" | "unknown"), current_scene, play_state,
+        readiness, connected_at, last_seen (heartbeat timestamp), and
+        is_active flag.
         """
         runtime = DirectRuntime.from_context(ctx)
         return session_handlers.session_list(runtime)

--- a/src/godot_ai/transport/websocket.py
+++ b/src/godot_ai/transport/websocket.py
@@ -64,6 +64,7 @@ class GodotWebSocketServer:
                 protocol_version=handshake.protocol_version,
                 readiness=handshake.readiness,
                 editor_pid=handshake.editor_pid,
+                server_launch_mode=handshake.server_launch_mode,
             )
             self.registry.register(session)
             self._connections[session_id] = ws

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -66,6 +66,30 @@ func test_every_client_has_manual_command() -> void:
 		assert_true(not cmd.is_empty(), "%s missing manual command" % client_id)
 
 
+# ----- server launch mode -----
+
+
+func test_server_launch_mode_returns_known_string() -> void:
+	## get_server_launch_mode() powers the handshake field agents read to
+	## detect plugin/server version drift. Always returns one of four
+	## documented values so callers can pattern-match without guessing.
+	var mode := McpClientConfigurator.get_server_launch_mode()
+	assert_contains(["dev_venv", "uvx", "system", "unknown"], mode, "Unexpected launch mode: %s" % mode)
+
+
+func test_server_launch_mode_agrees_with_get_server_command() -> void:
+	## The two accessors resolve the same tiers; if get_server_command
+	## returns a non-empty command, get_server_launch_mode must not be
+	## "unknown" (and vice versa). Keeps the pair in sync against future
+	## refactors that add a fourth launcher to one but not the other.
+	var cmd := McpClientConfigurator.get_server_command()
+	var mode := McpClientConfigurator.get_server_launch_mode()
+	if cmd.is_empty():
+		assert_eq(mode, "unknown", "Empty command should map to unknown mode")
+	else:
+		assert_true(mode != "unknown", "Non-empty command must map to a concrete mode, got %s" % mode)
+
+
 # ----- path template -----
 
 func test_path_template_expands_home() -> void:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,7 @@ class ServerHarness:
         plugin_version: str = "0.0.1",
         readiness: str = "ready",
         editor_pid: int = 0,
+        server_launch_mode: str | None = None,
     ) -> MockGodotPlugin:
         ws = await websockets.connect(f"ws://127.0.0.1:{self.port}")
         handshake = {
@@ -74,6 +75,11 @@ class ServerHarness:
             "readiness": readiness,
             "editor_pid": editor_pid,
         }
+        ## Older plugins don't send server_launch_mode at all; keep the field
+        ## absent when caller passes None so tests can exercise both the
+        ## legacy ("falls through to 'unknown'") and explicit paths.
+        if server_launch_mode is not None:
+            handshake["server_launch_mode"] = server_launch_mode
         await ws.send(json.dumps(handshake))
         # Give the server a moment to process the handshake
         await asyncio.sleep(0.05)

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -987,6 +987,32 @@ class TestSessionTools:
         result = await client.call_tool("session_activate", {"session_id": "no-such-session"})
         assert result.data["status"] == "error"
 
+    async def test_session_list_reports_server_launch_mode_from_handshake(self, harness):
+        ## End-to-end: plugin sends server_launch_mode in handshake →
+        ## websocket parses it → Session stores it → session_list surfaces it.
+        ## This is the signal agents use to detect "plugin self-updated but
+        ## old server still running" drift described in #113.
+        plugin = await harness.connect_plugin(
+            session_id="dev-session", server_launch_mode="dev_venv"
+        )
+        try:
+            session = harness.registry.get("dev-session")
+            assert session is not None
+            assert session.to_dict()["server_launch_mode"] == "dev_venv"
+        finally:
+            await plugin.close()
+
+    async def test_session_list_reports_unknown_for_legacy_plugin(self, harness):
+        ## Legacy plugin that doesn't send the field — envelope default
+        ## lands as "unknown" rather than dropping the handshake.
+        plugin = await harness.connect_plugin(session_id="legacy-session")
+        try:
+            session = harness.registry.get("legacy-session")
+            assert session is not None
+            assert session.to_dict()["server_launch_mode"] == "unknown"
+        finally:
+            await plugin.close()
+
 
 # ---------------------------------------------------------------------------
 # client_configure / client_status
@@ -2534,9 +2560,7 @@ class TestProjectRunTool:
             )
 
         task = asyncio.create_task(respond())
-        result = await client.call_tool(
-            "project_run", {"mode": "current", "autosave": False}
-        )
+        result = await client.call_tool("project_run", {"mode": "current", "autosave": False})
         await task
 
         assert not result.is_error

--- a/tests/unit/test_protocol.py
+++ b/tests/unit/test_protocol.py
@@ -95,3 +95,28 @@ class TestHandshakeMessage:
         parsed = json.loads(raw)
         assert parsed["type"] == "handshake"
         assert parsed["session_id"] == "sess-001"
+
+    def test_server_launch_mode_defaults_to_unknown(self):
+        ## Older plugins omit server_launch_mode; server should parse the
+        ## handshake cleanly rather than reject it, and default to "unknown"
+        ## so agents can distinguish "old plugin" from "mode could not be
+        ## determined" via plugin_version.
+        msg = HandshakeMessage(
+            session_id="sess-001",
+            godot_version="4.4.1",
+            project_path="/tmp/project",
+            plugin_version="0.0.1",
+        )
+        assert msg.server_launch_mode == "unknown"
+
+    def test_server_launch_mode_parsed_when_supplied(self):
+        msg = HandshakeMessage.model_validate(
+            {
+                "session_id": "sess-001",
+                "godot_version": "4.4.1",
+                "project_path": "/tmp/project",
+                "plugin_version": "0.0.1",
+                "server_launch_mode": "dev_venv",
+            }
+        )
+        assert msg.server_launch_mode == "dev_venv"

--- a/tests/unit/test_session_registry.py
+++ b/tests/unit/test_session_registry.py
@@ -111,6 +111,18 @@ class TestSessionRegistry:
         assert d["server_version"] == running_version
         assert d["plugin_version"] == "0.0.1"
 
+    def test_server_launch_mode_defaults_to_unknown(self):
+        ## A legacy plugin that doesn't populate server_launch_mode lands
+        ## as "unknown" — agents can detect this alongside plugin_version
+        ## to tell "old plugin" from "mode not detectable on this system".
+        s = _make_session()
+        assert s.server_launch_mode == "unknown"
+        assert s.to_dict()["server_launch_mode"] == "unknown"
+
+    def test_server_launch_mode_round_trips_through_to_dict(self):
+        s = _make_session(server_launch_mode="dev_venv")
+        assert s.to_dict()["server_launch_mode"] == "dev_venv"
+
 
 class TestSessionMetadata:
     def test_name_derived_from_project_path(self):
@@ -142,6 +154,7 @@ class TestSessionMetadata:
         original = s.last_seen
         ## busy-wait a tiny amount to guarantee timestamp delta
         import time
+
         time.sleep(0.001)
         s.touch()
         assert s.last_seen > original


### PR DESCRIPTION
## Summary

- Plugin's WebSocket handshake now includes `server_launch_mode`: `"dev_venv"` / `"uvx"` / `"system"` / `"unknown"`.
- `HandshakeMessage` accepts the field (defaulting to `"unknown"` for older plugins).
- `Session` stores it and emits it from `to_dict()`, so `session_list` surfaces it alongside `server_version` / `plugin_version`.
- New sibling accessor `McpClientConfigurator.get_server_launch_mode()` reuses the tier resolution already in `get_server_command()` — no duplication of per-tier detection logic in multiple places (both call through to `_cached_venv_python`, `find_uvx`, and `_find_system_install`).
- `session_list` MCP tool description is updated so agents discover the new field.

## Why

Pulled out of issue #113 as its own PR — [proposal #4](https://github.com/hi-godot/godot-ai/issues/113) in that issue's design sketch. Today smoke tests have to `ps aux | grep Godot` to answer:

> Am I testing the released uvx server, or did a stale `.venv` quietly win the launcher race?

That's fragile and easy to skip. With `server_launch_mode` in the session metadata, agents can read the authoritative answer straight from `session_list`. This complements `server_version` (#112) — together they pin down (source-code version, launch tier) so drift is visible at a glance.

No new UI. Field is read-only through MCP.

## Test plan

- [x] `ruff check src/ tests/`
- [x] `pytest -q tests/unit/` — 304 passed (all unit tests green)
- [x] `pytest -q tests/integration/test_mcp_tools.py::TestSessionTools` — 5 passed (session-routing tests green)
- [x] `godot --headless --import` against `test_project/` — no GDScript parse errors
- [x] Added GDScript test in `test_clients.gd`: asserts `get_server_launch_mode()` returns one of the four documented values and agrees with `get_server_command()` emptiness
- [x] Added Python unit tests for `Session.server_launch_mode` default / round-trip and `HandshakeMessage.server_launch_mode` parsing / default
- [x] Added integration tests that exercise the full handshake → Session → `to_dict` path, including a legacy-plugin handshake (field omitted) that defaults to `"unknown"`
- [ ] Manual verification after release: from a dev editor, `session_list` should report `"server_launch_mode": "dev_venv"`. From a clean-room uvx install, `"uvx"`.

## Notes on test-suite flake

Running the full `pytest` suite locally today produces ~189 failures on clean main (baseline — before this PR). They trace to integration-test port contention in the `mcp_stack` / `harness` fixtures (`conftest.py`): servers bound to fixed ports 19500 / 19502 don't always release between tests. **Not introduced by this PR** — verified by stashing and running baseline. Would benefit from a focused follow-up (ephemeral port selection + explicit `await server.stop()` in teardown), intentionally out of scope here.

Refs #113.
