### PR TITLE
fix(camera): verify is_current after commit to close macOS headless race

### DIFF
--- a/plugin/addons/godot_ai/handlers/camera_handler.gd
+++ b/plugin/addons/godot_ai/handlers/camera_handler.gd
@@ -102,6 +102,20 @@ func _add_make_current_to_action(node: Node, type_str: String, scene_root: Node)
 		_undo_redo.add_undo_method(node, "clear_current")
 
 
+# Call AFTER commit_action() whenever the action registered a make_current DO.
+# Re-applies make_current() outside the action if the viewport doesn't yet
+# report the node as current. Idempotent — when the DO took effect normally
+# (the common path), this is a no-op. Closes a macOS-headless race where
+# `is_current()` can return false immediately after a committed
+# add_child → make_current sequence, leaving the handler's response
+# (current=true) out of sync with the viewport (observed CI run 24682342469).
+func _verify_current_after_commit(node: Node) -> void:
+	if node == null or not node.is_inside_tree():
+		return
+	if not _is_current(node):
+		node.make_current()
+
+
 # ============================================================================
 # camera_create
 # ============================================================================
@@ -144,6 +158,8 @@ func create_camera(params: Dictionary) -> Dictionary:
 		_add_make_current_to_action(node, type_str, scene_root)
 	_undo_redo.add_undo_method(parent, "remove_child", node)
 	_undo_redo.commit_action()
+	if make_current:
+		_verify_current_after_commit(node)
 
 	return {
 		"data": {
@@ -210,15 +226,19 @@ func configure(params: Dictionary) -> Dictionary:
 	for prop_name in coerced:
 		_undo_redo.add_do_property(node, prop_name, coerced[prop_name])
 		_undo_redo.add_undo_property(node, prop_name, old_values[prop_name])
+	var verify_current_after := false
 	if current_request != null:
 		var want_on: bool = bool(current_request)
 		var was_on: bool = _is_current(node)
 		if want_on and not was_on:
 			_add_make_current_to_action(node, type_str, scene_root)
+			verify_current_after = true
 		elif not want_on and was_on:
 			_undo_redo.add_do_method(node, "clear_current")
 			_undo_redo.add_undo_method(node, "make_current")
 	_undo_redo.commit_action()
+	if verify_current_after:
+		_verify_current_after_commit(node)
 
 	var applied: Array[String] = []
 	var serialized: Dictionary = {}
@@ -651,6 +671,8 @@ func apply_preset(params: Dictionary) -> Dictionary:
 		_add_make_current_to_action(node, type_str, scene_root)
 	_undo_redo.add_undo_method(parent, "remove_child", node)
 	_undo_redo.commit_action()
+	if make_current:
+		_verify_current_after_commit(node)
 
 	return {
 		"data": {


### PR DESCRIPTION
## Summary

- Add `_verify_current_after_commit(node)` helper in `CameraHandler`, called after each `commit_action()` that registered a `make_current` DO (create_camera, configure, apply_preset).
- The helper is a no-op on the common path — it only re-applies `make_current()` when the viewport disagrees with the committed action.

## Why

[PR #108](https://github.com/hi-godot/godot-ai/pull/108) collapsed the DO path to a single atomic `make_current()` (no more clear+make race window). That closed the main cause of the flake, but a residual macOS-headless race persists: `is_current()` can still return false immediately after a committed `add_child → make_current` sequence, leaving the handler's response (`current: true`) out of sync with the viewport.

Concretely, [run 24682342469](https://github.com/hi-godot/godot-ai/actions/runs/24682342469/job/72182602907) failed `test_get_returns_current_when_path_empty` with "Expected current, got first" — the just-created camera's viewport read disagreed with the action's DO method one frame later, so `get_camera({path: ""})` fell through to the `resolved_via == "first"` fallback.

The belt-and-suspenders re-apply is idempotent — when the DO took effect normally the check passes and nothing happens. It closes the viewport-readback window for immediate callers so the handler's response matches the viewport state.

## Test plan

- [x] Local GDScript camera suite — 32/32
- [x] Full Godot suite — 688/688 (28 suites)
- [x] pytest camera integration — 12/12
- [x] pytest unit — 300/300
- [ ] CI macOS flake no longer surfaces (will know after a few green runs)

Refs: #108, d2bb197 (atomic-UNDO fix), CI runs 24674252085, 24675424785, 24682342469.
