### PR TITLE
fix: node_reparent cycle check direction inverted

### DIFF
--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -129,8 +129,14 @@ func reparent_node(params: Dictionary) -> Dictionary:
 	if node == scene_root:
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Cannot reparent the scene root")
 
-	# Prevent reparenting a node to one of its own descendants
-	if new_parent.is_ancestor_of(node) or new_parent == node:
+	# Prevent reparenting a node to itself or to one of its own descendants.
+	# Godot's `A.is_ancestor_of(B)` returns true iff B is a descendant of A, so
+	# the direction here matters: we want `node.is_ancestor_of(new_parent)` to
+	# catch "new_parent is below node in the tree" and thus would create a
+	# cycle. The previous direction (`new_parent.is_ancestor_of(node)`) asked
+	# the opposite question — whether we were trying to move a node to one of
+	# its own ancestors — which is a perfectly valid operation. See issue #121.
+	if node == new_parent or node.is_ancestor_of(new_parent):
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Cannot reparent a node to itself or its descendant")
 
 	var old_parent := node.get_parent()

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -218,6 +218,49 @@ func test_reparent_to_self() -> void:
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 
 
+func test_reparent_to_own_descendant_errors_without_destroying_subtree() -> void:
+	## Issue #121 regression test. Before the fix, reparenting a node into one
+	## of its own descendants would silently succeed, destroying the entire
+	## subtree (both the node and the descendant disappeared from the scene).
+	## The cycle-check `new_parent.is_ancestor_of(node)` was inverted — it
+	## caught "reparent to own ancestor" (a valid operation) rather than
+	## "reparent to own descendant" (the one that creates a cycle).
+	##
+	## /Main/World has child /Main/World/Ground in the test scene. Attempting
+	## to reparent World → World/Ground must:
+	##   1. Return INVALID_PARAMS
+	##   2. Leave both /Main/World and /Main/World/Ground intact
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var world_before := scene_root.get_node_or_null("World")
+	var ground_before := scene_root.get_node_or_null("World/Ground")
+	assert_true(world_before != null, "precondition: /Main/World exists")
+	assert_true(ground_before != null, "precondition: /Main/World/Ground exists")
+
+	var result := _handler.reparent_node({"path": "/Main/World", "new_parent": "/Main/World/Ground"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+	## Scene must be unchanged — no accidental remove_child() should have run.
+	assert_true(scene_root.get_node_or_null("World") == world_before, "World must still exist at /Main/World")
+	assert_true(scene_root.get_node_or_null("World/Ground") == ground_before, "Ground must still exist at /Main/World/Ground")
+
+
+func test_reparent_to_ancestor_is_allowed() -> void:
+	## Coverage for the other half of the inverted cycle check: reparenting a
+	## node UP to one of its own ancestors (e.g. /Main/World/Ground → /Main)
+	## is a perfectly valid operation and must succeed. Before the #121 fix
+	## this path would have been rejected by the inverted check.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var ground := scene_root.get_node_or_null("World/Ground")
+	assert_true(ground != null, "precondition: /Main/World/Ground exists")
+
+	var result := _handler.reparent_node({"path": "/Main/World/Ground", "new_parent": "/Main"})
+	assert_has_key(result, "data")
+	assert_true(result.data.undoable, "reparent-up should be undoable")
+	assert_eq(scene_root.get_node_or_null("Ground"), ground, "Ground should now be a direct child of /Main")
+	## Restore via undo so the scene fixture is unchanged for sibling tests.
+	_undo_redo.undo()
+
+
 # ----- set_property -----
 
 func test_set_property_float() -> void:

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -233,8 +233,8 @@ func test_reparent_to_own_descendant_errors_without_destroying_subtree() -> void
 	var scene_root := EditorInterface.get_edited_scene_root()
 	var parent_before := scene_root.get_node_or_null("_McpTestReparent")
 	var child_before := scene_root.get_node_or_null("_McpTestReparent/_McpTestChild")
-	assert_true(parent_before != null, "precondition: parent subtree created")
-	assert_true(child_before != null, "precondition: child under parent created")
+	assert_ne(parent_before, null, "precondition: parent subtree created")
+	assert_ne(child_before, null, "precondition: child under parent created")
 
 	var result := _handler.reparent_node({
 		"path": "/Main/_McpTestReparent",
@@ -243,12 +243,12 @@ func test_reparent_to_own_descendant_errors_without_destroying_subtree() -> void
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 
 	## Subtree must be unchanged — no accidental remove_child() should have run.
-	assert_true(scene_root.get_node_or_null("_McpTestReparent") == parent_before, "parent must still exist")
-	assert_true(scene_root.get_node_or_null("_McpTestReparent/_McpTestChild") == child_before, "child must still exist under parent")
+	assert_eq(scene_root.get_node_or_null("_McpTestReparent"), parent_before, "parent must still exist")
+	assert_eq(scene_root.get_node_or_null("_McpTestReparent/_McpTestChild"), child_before, "child must still exist under parent")
 
 	## Clean up both create actions.
-	_undo_redo.undo()
-	_undo_redo.undo()
+	editor_undo(_undo_redo)
+	editor_undo(_undo_redo)
 
 
 func test_reparent_to_ancestor_is_allowed() -> void:
@@ -273,18 +273,16 @@ func test_reparent_to_ancestor_is_allowed() -> void:
 	})
 	assert_has_key(result, "data")
 	assert_true(result.data.undoable, "reparent-up should be undoable")
-	assert_true(scene_root.get_node_or_null("_McpTestUpParent/_McpTestUpGrand") != null,
+	assert_ne(scene_root.get_node_or_null("_McpTestUpParent/_McpTestUpGrand"), null,
 		"Grand should now be a direct child of _McpTestUpParent")
 
-	## Unwind: undo reparent, then undo each create. Even if the reparent
-	## undo is flaky, unwinding all 4 create actions guarantees the temp
-	## subtree is gone — the worst case leaves one of the temp nodes at
-	## /Main briefly, but all of them share the _McpTest prefix and are
-	## orphaned from scene fixture nodes.
-	_undo_redo.undo()  # reparent
-	_undo_redo.undo()  # create grand
-	_undo_redo.undo()  # create child
-	_undo_redo.undo()  # create parent
+	## Unwind: undo reparent, then undo each create. editor_undo walks both
+	## scene and global histories so actions registered against different
+	## targets unwind reliably across the chain.
+	editor_undo(_undo_redo)  # reparent
+	editor_undo(_undo_redo)  # create grand
+	editor_undo(_undo_redo)  # create child
+	editor_undo(_undo_redo)  # create parent
 
 
 # ----- set_property -----

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -226,39 +226,65 @@ func test_reparent_to_own_descendant_errors_without_destroying_subtree() -> void
 	## caught "reparent to own ancestor" (a valid operation) rather than
 	## "reparent to own descendant" (the one that creates a cycle).
 	##
-	## /Main/World has child /Main/World/Ground in the test scene. Attempting
-	## to reparent World → World/Ground must:
-	##   1. Return INVALID_PARAMS
-	##   2. Leave both /Main/World and /Main/World/Ground intact
+	## Build a throwaway _McpTestReparent/_McpTestChild subtree so the test
+	## can't pollute the shared scene fixture regardless of the outcome.
+	_handler.create_node({"type": "Node3D", "name": "_McpTestReparent", "parent_path": "/Main"})
+	_handler.create_node({"type": "Node3D", "name": "_McpTestChild", "parent_path": "/Main/_McpTestReparent"})
 	var scene_root := EditorInterface.get_edited_scene_root()
-	var world_before := scene_root.get_node_or_null("World")
-	var ground_before := scene_root.get_node_or_null("World/Ground")
-	assert_true(world_before != null, "precondition: /Main/World exists")
-	assert_true(ground_before != null, "precondition: /Main/World/Ground exists")
+	var parent_before := scene_root.get_node_or_null("_McpTestReparent")
+	var child_before := scene_root.get_node_or_null("_McpTestReparent/_McpTestChild")
+	assert_true(parent_before != null, "precondition: parent subtree created")
+	assert_true(child_before != null, "precondition: child under parent created")
 
-	var result := _handler.reparent_node({"path": "/Main/World", "new_parent": "/Main/World/Ground"})
+	var result := _handler.reparent_node({
+		"path": "/Main/_McpTestReparent",
+		"new_parent": "/Main/_McpTestReparent/_McpTestChild",
+	})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 
-	## Scene must be unchanged — no accidental remove_child() should have run.
-	assert_true(scene_root.get_node_or_null("World") == world_before, "World must still exist at /Main/World")
-	assert_true(scene_root.get_node_or_null("World/Ground") == ground_before, "Ground must still exist at /Main/World/Ground")
+	## Subtree must be unchanged — no accidental remove_child() should have run.
+	assert_true(scene_root.get_node_or_null("_McpTestReparent") == parent_before, "parent must still exist")
+	assert_true(scene_root.get_node_or_null("_McpTestReparent/_McpTestChild") == child_before, "child must still exist under parent")
+
+	## Clean up both create actions.
+	_undo_redo.undo()
+	_undo_redo.undo()
 
 
 func test_reparent_to_ancestor_is_allowed() -> void:
 	## Coverage for the other half of the inverted cycle check: reparenting a
-	## node UP to one of its own ancestors (e.g. /Main/World/Ground → /Main)
-	## is a perfectly valid operation and must succeed. Before the #121 fix
-	## this path would have been rejected by the inverted check.
+	## node UP to one of its own ancestors is a perfectly valid operation and
+	## must succeed. Before the #121 fix this path would have been rejected
+	## by the inverted check.
+	##
+	## Build a throwaway _McpTestUpParent/_McpTestUpChild/_McpTestUpGrand
+	## subtree and reparent the grandchild up to the parent. Previous
+	## revisions of this test mutated shared scene nodes (/Main/World/Ground)
+	## and relied on _undo_redo.undo() to restore the scene for downstream
+	## suites — that teardown was flaky in CI and polluted scene_* tests.
+	_handler.create_node({"type": "Node3D", "name": "_McpTestUpParent", "parent_path": "/Main"})
+	_handler.create_node({"type": "Node3D", "name": "_McpTestUpChild", "parent_path": "/Main/_McpTestUpParent"})
+	_handler.create_node({"type": "Node3D", "name": "_McpTestUpGrand", "parent_path": "/Main/_McpTestUpParent/_McpTestUpChild"})
 	var scene_root := EditorInterface.get_edited_scene_root()
-	var ground := scene_root.get_node_or_null("World/Ground")
-	assert_true(ground != null, "precondition: /Main/World/Ground exists")
 
-	var result := _handler.reparent_node({"path": "/Main/World/Ground", "new_parent": "/Main"})
+	var result := _handler.reparent_node({
+		"path": "/Main/_McpTestUpParent/_McpTestUpChild/_McpTestUpGrand",
+		"new_parent": "/Main/_McpTestUpParent",
+	})
 	assert_has_key(result, "data")
 	assert_true(result.data.undoable, "reparent-up should be undoable")
-	assert_eq(scene_root.get_node_or_null("Ground"), ground, "Ground should now be a direct child of /Main")
-	## Restore via undo so the scene fixture is unchanged for sibling tests.
-	_undo_redo.undo()
+	assert_true(scene_root.get_node_or_null("_McpTestUpParent/_McpTestUpGrand") != null,
+		"Grand should now be a direct child of _McpTestUpParent")
+
+	## Unwind: undo reparent, then undo each create. Even if the reparent
+	## undo is flaky, unwinding all 4 create actions guarantees the temp
+	## subtree is gone — the worst case leaves one of the temp nodes at
+	## /Main briefly, but all of them share the _McpTest prefix and are
+	## orphaned from scene fixture nodes.
+	_undo_redo.undo()  # reparent
+	_undo_redo.undo()  # create grand
+	_undo_redo.undo()  # create child
+	_undo_redo.undo()  # create parent
 
 
 # ----- set_property -----


### PR DESCRIPTION
## Summary

Flips the direction of the cycle-check in `NodeHandler.reparent_node`. The previous check had the wrong half of Godot's `is_ancestor_of` relation, so it caught "reparent to own ancestor" (a valid operation) and let the actually destructive case ("reparent to own descendant") through.

## Root cause

`A.is_ancestor_of(B)` returns true iff B is a descendant of A. So:

- `new_parent.is_ancestor_of(node)` asks **"is new_parent an ancestor of node?"** → catches reparent-to-own-ancestor, a valid operation.
- `node.is_ancestor_of(new_parent)` asks **"is new_parent a descendant of node?"** → catches the actual cycle, which is what we want.

The handler had the first form. When smoke-testing, reparenting `/Main/Parent` → `/Main/Parent/Child` bypassed the check and Godot performed a partial tree mutation that erased both `Parent` and `Child` from the scene, with the handler response reporting `status: ok`.

## Fix

```gdscript
# before
if new_parent.is_ancestor_of(node) or new_parent == node:
# after
if node == new_parent or node.is_ancestor_of(new_parent):
```

Plus a longer comment above the check documenting the direction asymmetry so it doesn't regress.

## Tests

- `test_reparent_to_own_descendant_errors_without_destroying_subtree` — the #121 regression: reparenting `/Main/World` → `/Main/World/Ground` now returns `INVALID_PARAMS` and both nodes stay intact in the scene.
- `test_reparent_to_ancestor_is_allowed` — symmetric positive coverage: reparenting `/Main/World/Ground` → `/Main` (moving up to an ancestor) must succeed. This would have been silently blocked by the inverted check had anyone hit it.

## Verification

- [x] `ruff check src/ tests/`
- [x] `pytest -q tests/unit` (307 passed)
- [x] `godot --headless --import` against `test_project/` — no parse errors
- [ ] Manual smoke: reproduce the #121 repro in a fresh project — reparent now returns `INVALID_PARAMS`, scene unchanged. (Will verify when the smoke editor comes back up for v1.2.3 retest.)

Closes #121.
