### PR TITLE
fix: reject node_rename on the scene root

### DIFF
--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -260,6 +260,14 @@ func rename_node(params: Dictionary) -> Dictionary:
 	if new_name.is_empty():
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: new_name")
 
+	## The scene root's name is baked into the .tscn serialization and is
+	## referenced by every NodePath that starts with `/<root>` (AnimationPlayer
+	## tracks, RemoteTransform3D targets, exported NodePath @vars, etc.).
+	## Renaming it silently breaks those references. The MCP tool's docstring
+	## has always promised "Cannot rename the scene root" — enforce it. #122
+	if node == scene_root:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Cannot rename the scene root")
+
 	if new_name.validate_node_name() != new_name:
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Invalid characters in name: %s" % new_name)
 
@@ -276,12 +284,10 @@ func rename_node(params: Dictionary) -> Dictionary:
 			}
 		}
 
-	# Scene root has no siblings, so skip sibling collision check.
-	if node != scene_root:
-		var parent := node.get_parent()
-		for sibling in parent.get_children():
-			if sibling != node and String(sibling.name) == new_name:
-				return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "A sibling already has the name '%s'" % new_name)
+	var parent := node.get_parent()
+	for sibling in parent.get_children():
+		if sibling != node and String(sibling.name) == new_name:
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "A sibling already has the name '%s'" % new_name)
 
 	_undo_redo.create_action("MCP: Rename %s to %s" % [old_name, new_name])
 	_undo_redo.add_do_property(node, "name", new_name)

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -476,21 +476,29 @@ func test_rename_node_basic() -> void:
 	_undo_redo.undo()
 
 
-func test_rename_node_scene_root() -> void:
-	# Renaming the scene root is allowed (not the .tscn file path, just the node name).
+func test_rename_node_scene_root_rejected() -> void:
+	## Issue #122 regression test. The tool docstring has always said
+	## "Cannot rename the scene root," but the handler silently allowed it
+	## until 1.2.3. The prior version of this test asserted the buggy
+	## behaviour (rename succeeds) — flipped to match the docstring.
+	##
+	## Renaming the scene root must be rejected because its name is baked
+	## into the .tscn serialization and into every NodePath that references
+	## `/<root>` (AnimationPlayer tracks, RemoteTransform3D targets,
+	## exported NodePath @vars, etc.). Silently renaming it breaks those
+	## references with no warning.
 	var scene_root := EditorInterface.get_edited_scene_root()
 	if scene_root == null:
 		skip("No scene root — is a scene open?")
 		return
 	var old_name := String(scene_root.name)
+
 	var result := _handler.rename_node({"path": "/" + old_name, "new_name": "RenamedTestRoot"})
-	assert_has_key(result, "data")
-	assert_eq(result.data.name, "RenamedTestRoot")
-	assert_true(result.data.undoable)
-	# Restore the original name to avoid polluting other tests.
-	var restore := _handler.rename_node({"path": "/RenamedTestRoot", "new_name": old_name})
-	assert_has_key(restore, "data")
-	assert_eq(String(scene_root.name), old_name)
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "scene root")
+
+	## Scene root must be unchanged.
+	assert_eq(String(scene_root.name), old_name, "scene root name must not have changed")
 
 
 func test_rename_node_missing_name() -> void:


### PR DESCRIPTION
## Summary

Adds the guard that `node_rename`'s docstring has always promised: "Cannot rename the scene root." The handler silently allowed it before — and the existing test `test_rename_node_scene_root` locked in the buggy behaviour, which is why the contradiction never surfaced until smoke-testing 1.2.2.

## Why it matters

The scene root's name is part of the `.tscn` on-disk serialization and is referenced by every `NodePath` property that starts with `/<root>`:

- AnimationPlayer tracks
- RemoteTransform3D targets
- Exported `@export var target: NodePath = "/Main/..."`
- Autoload wiring if the root name matches
- Signal connections with absolute target paths

A successful rename silently breaks all of them. An AI agent doing a "let me just rename this to something clearer" refactor can detach half the scene's behavior without seeing an error.

## Fix

One-line guard at the top of `rename_node` (before name-validation, before sibling-collision check):

```gdscript
if node == scene_root:
    return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Cannot rename the scene root")
```

Also drops the now-redundant `if node != scene_root` wrapper around the sibling-collision check — the scene-root case is short-circuited earlier so the wrapper is dead.

## Tests

- `test_rename_node_scene_root_rejected` — replaces the prior `test_rename_node_scene_root`, which asserted the buggy "rename succeeds" behaviour. Flipping it is an explicit call-out that the test was codifying a contradiction with its own tool's docstring.
- Asserts both the error code *and* the post-condition (scene root's `name` is unchanged) — guarding against a future half-mutation regression.

## Verification

- [x] `ruff check src/ tests/`
- [x] `pytest -q tests/unit` (307 passed)
- [x] `godot --headless --import` on `test_project/` — no parse errors
- [ ] Manual smoke: `node_rename(path="/Main", new_name="X")` returns `INVALID_PARAMS` and scene unchanged. (Deferred to v1.2.3 smoke.)

## Related

One of three tool-surface bugs surfaced by the v1.2.2 smoke-test Session B. Companion fixes: #121 (reparent cycle check direction), #123 (silent wrong-shape dict coercion).

Closes #122.
