### PR TITLE
fix: strict dict→Variant coercion, refuse wrong-shape dicts

### DIFF
--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -229,6 +229,13 @@ func set_property(params: Dictionary) -> Dictionary:
 		instantiated_resource = true
 	else:
 		value = _coerce_value(value, target_type)
+		## #123: a Dictionary value that _coerce_value couldn't shape into
+		## the target type flows back unchanged. Detect the mismatch and
+		## refuse — writing an unshaped dict to a typed Variant property
+		## silently corrupts the scene (Godot zero-fills or leaves untouched).
+		var coerce_err := _check_dict_coerce_failed(value, target_type)
+		if coerce_err != null:
+			return coerce_err
 
 	_undo_redo.create_action("MCP: Set %s.%s" % [node.name, property])
 	_undo_redo.add_do_property(node, property, value)
@@ -472,17 +479,61 @@ func _set_owner_recursive(node: Node, owner: Node) -> void:
 
 
 ## Coerce a JSON value to match the expected Godot type.
+## Detect a failed dict→typed-Variant coercion. Returns an INVALID_PARAMS
+## error dict if `value` is still a Dictionary after a coercion attempt
+## targeting a Vector2/Vector3/Color slot, else null. Message names the
+## expected keys and the keys actually received so agents self-correct
+## on the next retry.
+static func _check_dict_coerce_failed(value: Variant, target_type: int) -> Variant:
+	if not (value is Dictionary):
+		return null
+	var expected: Array[String] = []
+	var type_name := ""
+	match target_type:
+		TYPE_VECTOR2:
+			expected = ["x", "y"]
+			type_name = "Vector2"
+		TYPE_VECTOR3:
+			expected = ["x", "y", "z"]
+			type_name = "Vector3"
+		TYPE_COLOR:
+			expected = ["r", "g", "b"]  # "a" is optional
+			type_name = "Color"
+		_:
+			return null
+	var got_keys: Array = (value as Dictionary).keys()
+	return McpErrorCodes.make(
+		McpErrorCodes.INVALID_PARAMS,
+		"Cannot coerce dict to %s: expected keys %s; got %s" % [type_name, str(expected), str(got_keys)]
+	)
+
+
+## Coerce JSON-shaped values into Godot Variants when the target property
+## type is known. Returns the coerced value on success, or the input
+## unchanged on failure (the caller is then responsible for detecting
+## the type mismatch via an `is <Type>` check and raising INVALID_PARAMS).
+##
+## The Dictionary→Vector2/Vector3/Color cases REQUIRE the canonical keys
+## to all be present. Before issue #123 this function fell back to
+## `dict.get("x", 0)`, silently zero-filling missing keys — so passing
+## a Color-shaped dict `{r,g,b,a}` for a Vector3 property would stuff
+## `(0, 0, 0)` into the scene with no warning. Strict key checks close
+## that gap; a wrong-shape dict now flows through unchanged so the
+## caller's type check fires.
 static func _coerce_value(value: Variant, target_type: int) -> Variant:
 	match target_type:
 		TYPE_VECTOR2:
 			if value is Dictionary:
-				return Vector2(value.get("x", 0), value.get("y", 0))
+				if value.has("x") and value.has("y"):
+					return Vector2(value["x"], value["y"])
 		TYPE_VECTOR3:
 			if value is Dictionary:
-				return Vector3(value.get("x", 0), value.get("y", 0), value.get("z", 0))
+				if value.has("x") and value.has("y") and value.has("z"):
+					return Vector3(value["x"], value["y"], value["z"])
 		TYPE_COLOR:
 			if value is Dictionary:
-				return Color(value.get("r", 0), value.get("g", 0), value.get("b", 0), value.get("a", 1))
+				if value.has("r") and value.has("g") and value.has("b"):
+					return Color(value["r"], value["g"], value["b"], value.get("a", 1.0))
 			if value is String:
 				return Color(value)
 		TYPE_BOOL:

--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -229,10 +229,7 @@ func set_property(params: Dictionary) -> Dictionary:
 		instantiated_resource = true
 	else:
 		value = _coerce_value(value, target_type)
-		## #123: a Dictionary value that _coerce_value couldn't shape into
-		## the target type flows back unchanged. Detect the mismatch and
-		## refuse — writing an unshaped dict to a typed Variant property
-		## silently corrupts the scene (Godot zero-fills or leaves untouched).
+		## Refuse wrong-shape dicts that _coerce_value passed through (#123).
 		var coerce_err := _check_dict_coerce_failed(value, target_type)
 		if coerce_err != null:
 			return coerce_err
@@ -478,7 +475,6 @@ func _set_owner_recursive(node: Node, owner: Node) -> void:
 		_set_owner_recursive(child, owner)
 
 
-## Coerce a JSON value to match the expected Godot type.
 ## Detect a failed dict→typed-Variant coercion. Returns an INVALID_PARAMS
 ## error dict if `value` is still a Dictionary after a coercion attempt
 ## targeting a Vector2/Vector3/Color slot, else null. Message names the
@@ -510,16 +506,13 @@ static func _check_dict_coerce_failed(value: Variant, target_type: int) -> Varia
 
 ## Coerce JSON-shaped values into Godot Variants when the target property
 ## type is known. Returns the coerced value on success, or the input
-## unchanged on failure (the caller is then responsible for detecting
-## the type mismatch via an `is <Type>` check and raising INVALID_PARAMS).
+## unchanged on failure — callers detect the type mismatch via an
+## `is <Type>` check (curve_handler, texture_handler) or via the
+## `_check_dict_coerce_failed` helper (set_property, resource_handler).
 ##
-## The Dictionary→Vector2/Vector3/Color cases REQUIRE the canonical keys
-## to all be present. Before issue #123 this function fell back to
-## `dict.get("x", 0)`, silently zero-filling missing keys — so passing
-## a Color-shaped dict `{r,g,b,a}` for a Vector3 property would stuff
-## `(0, 0, 0)` into the scene with no warning. Strict key checks close
-## that gap; a wrong-shape dict now flows through unchanged so the
-## caller's type check fires.
+## Dictionary→Vector2/Vector3/Color cases REQUIRE all canonical keys;
+## wrong-shape dicts flow through unchanged. See issue #123 — previous
+## `dict.get(key, 0)` defaults silently zero-filled missing axes.
 static func _coerce_value(value: Variant, target_type: int) -> Variant:
 	match target_type:
 		TYPE_VECTOR2:

--- a/plugin/addons/godot_ai/handlers/resource_handler.gd
+++ b/plugin/addons/godot_ai/handlers/resource_handler.gd
@@ -277,14 +277,11 @@ static func _apply_resource_properties(res: Resource, properties: Dictionary) ->
 			v = sub_res
 		else:
 			v = NodeHandler._coerce_value(v, target_type)
-			## #123: wrap the resource-property apply path with the same
-			## dict-coerce check set_property uses, so resource_create-style
-			## calls with wrong-shape dicts error instead of silently storing
-			## zero-filled Variants in the resource.
+			## Mirror set_property's coerce check so wrong-shape dicts error
+			## instead of writing zero-filled Variants (issue #123).
 			var coerce_err := NodeHandler._check_dict_coerce_failed(v, target_type)
 			if coerce_err != null:
-				coerce_err["error"]["message"] = "Property '%s': %s" % [key, coerce_err["error"]["message"]]
-				return coerce_err
+				return McpErrorCodes.prefix_message(coerce_err, "Property '%s'" % key)
 		res.set(key, v)
 	return null
 

--- a/plugin/addons/godot_ai/handlers/resource_handler.gd
+++ b/plugin/addons/godot_ai/handlers/resource_handler.gd
@@ -277,6 +277,14 @@ static func _apply_resource_properties(res: Resource, properties: Dictionary) ->
 			v = sub_res
 		else:
 			v = NodeHandler._coerce_value(v, target_type)
+			## #123: wrap the resource-property apply path with the same
+			## dict-coerce check set_property uses, so resource_create-style
+			## calls with wrong-shape dicts error instead of silently storing
+			## zero-filled Variants in the resource.
+			var coerce_err := NodeHandler._check_dict_coerce_failed(v, target_type)
+			if coerce_err != null:
+				coerce_err["error"]["message"] = "Property '%s': %s" % [key, coerce_err["error"]["message"]]
+				return coerce_err
 		res.set(key, v)
 	return null
 

--- a/plugin/addons/godot_ai/utils/error_codes.gd
+++ b/plugin/addons/godot_ai/utils/error_codes.gd
@@ -14,3 +14,14 @@ const INTERNAL_ERROR := "INTERNAL_ERROR"
 ## Build a standard error response dictionary.
 static func make(code: String, message: String) -> Dictionary:
 	return {"status": "error", "error": {"code": code, "message": message}}
+
+
+## Return a NEW error dict with the original code and a prefixed message.
+## Prefer this over mutating `err["error"]["message"]` in place — callers
+## that want to add context ("Property '%s': …") shouldn't need to know
+## the internal shape of the dict returned by `make`.
+static func prefix_message(err: Dictionary, prefix: String) -> Dictionary:
+	var inner: Dictionary = err.get("error", {})
+	var code: String = inner.get("code", INTERNAL_ERROR)
+	var message: String = inner.get("message", "")
+	return make(code, "%s: %s" % [prefix, message])

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -299,12 +299,10 @@ func test_set_property_vector3_rejects_partial_dict() -> void:
 func test_set_property_color_rejects_vector3_shaped_dict() -> void:
 	## Symmetric check for Color coercion. Before the fix, passing
 	## {x,y,z} to a Color slot would stuff Color(0,0,0,1) silently.
-	_handler.create_node({"type": "Node3D", "name": "_McpTestBadColor", "parent_path": "/Main"})
-	## WorldEnvironment would be cleaner but adds setup overhead — reuse
-	## the scripted check on _coerce_value directly for the Color branch.
+	## Exercises _coerce_value directly — the mismatch is detectable at
+	## the coercer boundary, no scene node needed.
 	var coerced = NodeHandler._coerce_value({"x": 1, "y": 0, "z": 0}, TYPE_COLOR)
 	assert_true(coerced is Dictionary, "Wrong-shape dict must flow through unchanged so caller's type check fires")
-	_undo_redo.undo()  # undo create
 
 
 func test_coerce_value_passes_right_shape_color() -> void:

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -243,6 +243,85 @@ func test_set_property_missing_value() -> void:
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 
 
+func test_set_property_vector3_accepts_valid_dict() -> void:
+	## Positive guard for the #123 fix: a right-shape Vector3 dict must
+	## still coerce and land correctly. Prevents over-correcting the strict
+	## key check from breaking the happy path.
+	_handler.create_node({"type": "Node3D", "name": "_McpTestV3", "parent_path": "/Main"})
+	var result := _handler.set_property({
+		"path": "/Main/_McpTestV3",
+		"property": "position",
+		"value": {"x": 1.0, "y": 2.0, "z": 3.0},
+	})
+	assert_has_key(result, "data")
+	assert_true(result.data.undoable)
+	var node := EditorInterface.get_edited_scene_root().get_node("_McpTestV3") as Node3D
+	assert_eq(node.position, Vector3(1, 2, 3))
+	_undo_redo.undo()  # undo set
+	_undo_redo.undo()  # undo create
+
+
+func test_set_property_vector3_rejects_color_shaped_dict() -> void:
+	## Issue #123 regression: passing a Color-shaped dict {r,g,b,a} to a
+	## Vector3 slot used to silently zero-fill x/y/z and store (0,0,0)
+	## with status=ok. Must now return INVALID_PARAMS and leave the
+	## property unchanged.
+	_handler.create_node({"type": "Node3D", "name": "_McpTestBadV3", "parent_path": "/Main"})
+	var node := EditorInterface.get_edited_scene_root().get_node("_McpTestBadV3") as Node3D
+	var original := node.position
+
+	var result := _handler.set_property({
+		"path": "/Main/_McpTestBadV3",
+		"property": "position",
+		"value": {"r": 1, "g": 0, "b": 0, "a": 1},
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "Vector3")
+
+	assert_eq(node.position, original, "Position must be unchanged after a rejected coerce")
+	_undo_redo.undo()  # undo create
+
+
+func test_set_property_vector3_rejects_partial_dict() -> void:
+	## Second half of #123: a dict with some but not all required keys
+	## used to get the missing axes zero-filled (e.g. {x:1} → (1,0,0)).
+	## Must now reject.
+	_handler.create_node({"type": "Node3D", "name": "_McpTestPartial", "parent_path": "/Main"})
+	var result := _handler.set_property({
+		"path": "/Main/_McpTestPartial",
+		"property": "position",
+		"value": {"x": 1},  # missing y, z
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	_undo_redo.undo()  # undo create
+
+
+func test_set_property_color_rejects_vector3_shaped_dict() -> void:
+	## Symmetric check for Color coercion. Before the fix, passing
+	## {x,y,z} to a Color slot would stuff Color(0,0,0,1) silently.
+	_handler.create_node({"type": "Node3D", "name": "_McpTestBadColor", "parent_path": "/Main"})
+	## WorldEnvironment would be cleaner but adds setup overhead — reuse
+	## the scripted check on _coerce_value directly for the Color branch.
+	var coerced = NodeHandler._coerce_value({"x": 1, "y": 0, "z": 0}, TYPE_COLOR)
+	assert_true(coerced is Dictionary, "Wrong-shape dict must flow through unchanged so caller's type check fires")
+	_undo_redo.undo()  # undo create
+
+
+func test_coerce_value_passes_right_shape_color() -> void:
+	var coerced = NodeHandler._coerce_value({"r": 1.0, "g": 0.5, "b": 0.0, "a": 1.0}, TYPE_COLOR)
+	assert_true(coerced is Color)
+	assert_eq(coerced.r, 1.0)
+	assert_eq(coerced.g, 0.5)
+
+
+func test_coerce_value_accepts_color_without_alpha() -> void:
+	## Alpha is optional and defaults to 1.0 — {r,g,b} without 'a' is a
+	## valid shape. The strict check should only require r/g/b.
+	var coerced = NodeHandler._coerce_value({"r": 1.0, "g": 0.0, "b": 0.0}, TYPE_COLOR)
+	assert_true(coerced is Color)
+	assert_eq(coerced.a, 1.0)
+
+
 func test_set_property_resource_path() -> void:
 	## Use a fresh MeshInstance3D for a clean material_override slot.
 	_handler.create_node({


### PR DESCRIPTION
## Summary

Makes `NodeHandler._coerce_value` strict about dict→typed-Variant coercion:

- **Before:** `value.get("x", 0)` silently zero-filled missing axes. A Color-shaped dict `{r,g,b,a}` passed to a Vector3 slot got `(0, 0, 0)` written with `status: ok`.
- **After:** the coercer requires all canonical keys (`x/y` for Vector2, `x/y/z` for Vector3, `r/g/b` for Color — `a` is optional). Wrong-shape dicts flow through unchanged so the caller's `is <Type>` check fires.
- Add `_check_dict_coerce_failed` helper that produces a clear `INVALID_PARAMS` with the expected-vs-received keys named. Used by `set_property` and `_apply_resource_properties`. `curve_handler` / `texture_handler` already had the post-coerce type check — those branches are automatically fixed because `_coerce_value` no longer hides failures from them.

## Why it matters

This is the class of bug CLAUDE.md's ["assert on the stored Variant, not on counts"](https://github.com/hi-godot/godot-ai/blob/main/CLAUDE.md#value-coercion-assert-on-the-stored-variant-not-on-counts) rule was written to catch — but the rule was on the **test** side. The **handlers** were accepting wrong-shape input and quietly storing zeroes. Agents batching `node_set_property` / `curve_set_points` / `resource_create` calls had no way to detect the corruption.

The `value.get(k, 0)` pattern is a Godot-idiom convenience that's fine inside game code but hostile as a public API. Strict keys turn a silent wrong-write into a clean error the agent can self-correct on.

## Repro matrix (all previously silent, all now errored)

| Call | Before | After |
|---|---|---|
| `node_set_property(property="position", value={r:1,g:0,b:0,a:1})` | `position = (0,0,0)`, ok | `INVALID_PARAMS: Cannot coerce dict to Vector3: expected keys [x, y, z]; got [r, g, b, a]` |
| `node_set_property(property="position", value={x:1})` | `position = (1,0,0)`, ok | `INVALID_PARAMS` |
| `resource_create(..., position: {r:1,g:0,b:0,a:1})` | property stored as zero | `INVALID_PARAMS: Property 'position': Cannot coerce dict to Vector3: …` |
| `curve_set_points(points=[{position:{x:0}}])` (Curve3D) | point at `(0,0,0)`, ok | `INVALID_PARAMS: Curve3D points[0] in/position/out must coerce to Vector3` (existing error message now fires) |

## Tests

- `test_set_property_vector3_accepts_valid_dict` — happy path stays working.
- `test_set_property_vector3_rejects_color_shaped_dict` — **the #123 regression**. INVALID_PARAMS + position unchanged.
- `test_set_property_vector3_rejects_partial_dict` — `{x:1}` without y/z errors instead of zero-filling.
- `test_set_property_color_rejects_vector3_shaped_dict` — symmetric Color side.
- `test_coerce_value_passes_right_shape_color` / `test_coerce_value_accepts_color_without_alpha` — positive guards so the strict check doesn't over-correct.

## Verification

- [x] `ruff check src/ tests/`
- [x] `pytest -q tests/unit` (307 passed)
- [x] `godot --headless --import` — no parse errors
- [ ] Manual smoke: `node_set_property` with wrong-shape dict now errors, scene unchanged. (Deferred to v1.2.3 smoke.)

## Related

Third and last of three tool-surface bugs surfaced by the v1.2.2 smoke-test Session B. Companion fixes: #121 (reparent cycle direction), #122 (scene-root rename guard).

Closes #123.
