### PR TITLE
refactor: extract _reject_if_scene_root across four node handlers

### DIFF
--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -88,8 +88,9 @@ func delete_node(params: Dictionary) -> Dictionary:
 	var node_path: String = resolved.path
 	var scene_root: Node = resolved.scene_root
 
-	if node == scene_root:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Cannot delete the scene root")
+	var root_err := _reject_if_scene_root(node, scene_root, "delete")
+	if root_err != null:
+		return root_err
 
 	var parent := node.get_parent()
 	var idx := node.get_index()
@@ -126,8 +127,9 @@ func reparent_node(params: Dictionary) -> Dictionary:
 	if new_parent == null:
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_parent_error(new_parent_path, scene_root))
 
-	if node == scene_root:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Cannot reparent the scene root")
+	var root_err := _reject_if_scene_root(node, scene_root, "reparent")
+	if root_err != null:
+		return root_err
 
 	# Prevent reparenting a node to one of its own descendants
 	if new_parent.is_ancestor_of(node) or new_parent == node:
@@ -307,8 +309,9 @@ func duplicate_node(params: Dictionary) -> Dictionary:
 	var node_path: String = resolved.path
 	var scene_root: Node = resolved.scene_root
 
-	if node == scene_root:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Cannot duplicate the scene root")
+	var root_err := _reject_if_scene_root(node, scene_root, "duplicate")
+	if root_err != null:
+		return root_err
 
 	var parent := node.get_parent()
 	var dup: Node = node.duplicate()
@@ -349,8 +352,9 @@ func move_node(params: Dictionary) -> Dictionary:
 	var node_path: String = resolved.path
 	var scene_root: Node = resolved.scene_root
 
-	if node == scene_root:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Cannot reorder the scene root")
+	var root_err := _reject_if_scene_root(node, scene_root, "reorder")
+	if root_err != null:
+		return root_err
 
 	if not "index" in params:
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: index")
@@ -609,6 +613,14 @@ func _resolve_node(params: Dictionary) -> Dictionary:
 	if node == null:
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % node_path)
 	return {"node": node, "path": node_path, "scene_root": scene_root}
+
+
+## Reject operations targeting the scene root. Returns an INVALID_PARAMS error
+## dict with "Cannot <op> the scene root", or null if `node` is not the root.
+static func _reject_if_scene_root(node: Node, scene_root: Node, op: String) -> Variant:
+	if node == scene_root:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Cannot %s the scene root" % op)
+	return null
 
 
 ## Convert a Godot Variant to a JSON-safe value.


### PR DESCRIPTION
## Summary
- Four handlers in `NodeHandler` (`delete_node`, `reparent_node`, `duplicate_node`, `move_node`) each had an identical two-line guard rejecting operations on the scene root — identical except for the verb in the error message. Extract a single static helper.
- Motivation: five-ish copies of the same check is divergence bait. The next handler added with a similar guard is likely to re-implement with a slightly different code path or a slightly different message. One helper means there's only one place to get it right.

## What changed
- New static helper `_reject_if_scene_root(node, scene_root, op: String) -> Variant` near `_resolve_node`. Returns the error dict on failure, `null` on success — matching the shape of `_validate_resource_class` / `_apply_resource_properties` in `resource_handler.gd`.
- Four call sites converted:
  - `delete_node` (was `plugin/addons/godot_ai/handlers/node_handler.gd:91`) → ""Cannot delete the scene root""
  - `reparent_node` (was :129) → ""Cannot reparent the scene root""
  - `duplicate_node` (was :310) → ""Cannot duplicate the scene root""
  - `move_node` (was :352, error says ""reorder"") → ""Cannot reorder the scene root""
- Error code (`INVALID_PARAMS`) and final message strings are **byte-identical** to the prior inline checks. No behavior change.

## Note on `rename_node`
The task description listed `rename_node` as a fifth call site, but `rename_node` does not currently have a scene-root guard and explicitly **allows** renaming the scene root (see the existing `test_rename_node_scene_root` test). Not touching rename behavior in this refactor. If a future bugfix adds a guard there, it'll be a one-line call to this same helper.

## Test plan
- [x] `script/ci-check-gdscript` — all GDScript parses clean
- [x] `ruff check src/ tests/` — clean
- [x] `pytest -q` — 536 passed
- [ ] CI (Linux / macOS / Windows) GDScript test suites — will run on push. The `test_node.gd` suite covers all four guarded error paths (`test_delete_node_scene_root`, `test_reparent_scene_root`, `test_duplicate_scene_root`, `test_move_node_scene_root`) and asserts on `McpErrorCodes.INVALID_PARAMS`, which is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)