### PR TITLE
fix: seamless plugin self-update (#127, #132, #133)

### DIFF
--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -116,8 +116,16 @@ static func get_server_command() -> Array[String]:
 	var uvx := find_uvx()
 	if not uvx.is_empty():
 		var version := get_plugin_version()
-		print("MCP | using uvx (godot-ai~=%s)" % version)
-		return [uvx, "--from", "godot-ai~=%s" % version, "godot-ai"]
+		## Pin to the EXACT plugin version rather than `~=<minor>`. Under the
+		## tilde form, uvx was happy to reuse a cached tool env that matched
+		## the minor constraint — so an install that first spawned 1.2.0 kept
+		## using 1.2.0 even after 1.2.1/1.2.2 landed. Exact pinning makes the
+		## cache key version-specific: if the cached env matches, fast hit;
+		## otherwise uvx installs the exact version fresh. Keeps plugin and
+		## server version in lockstep without needing `--refresh-package` on
+		## every spawn. See issue #133.
+		print("MCP | using uvx (godot-ai==%s)" % version)
+		return [uvx, "--from", "godot-ai==%s" % version, "godot-ai"]
 
 	var system_cmd := _find_system_install()
 	if not system_cmd.is_empty():

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -815,18 +815,45 @@ func _install_update() -> void:
 	DirAccess.remove_absolute(zip_path)
 	DirAccess.remove_absolute(ProjectSettings.globalize_path(UPDATE_TEMP_DIR))
 
+	## Kill the old server before the reload so the re-enabled plugin spawns
+	## a fresh one against the new plugin version. Without this, the running
+	## Python process on port 8000 outlives the reload, `_start_server`
+	## short-circuits on "port already in use," and session_list reports
+	## `plugin_version != server_version` until the user restarts the
+	## editor. See issue #132.
+	if _plugin != null and _plugin.has_method("prepare_for_update_reload"):
+		_plugin.prepare_for_update_reload()
+
 	# Godot 4.4+ handles plugin reload safely. On 4.3 and older, toggling
 	# the plugin off/on can cause re-entrant server spawns, so we ask the
 	# user to restart the editor instead.
 	var version := Engine.get_version_info()
 	if version.get("minor", 0) >= 4:
-		_update_btn.text = "Reloading..."
-		_reload_after_update.call_deferred()
+		_update_btn.text = "Scanning..."
+		## Before reloading the plugin we MUST wait for Godot's filesystem
+		## scanner to see the newly-extracted files. Otherwise plugin.gd
+		## re-parses and its `class_name` references (GameLogBuffer,
+		## McpDebuggerPlugin, …) resolve against a ClassDB that hasn't
+		## picked up the new files yet — parse errors, dock tears down,
+		## plugin reports "enabled" with no UI. See issue #127.
+		var fs := EditorInterface.get_resource_filesystem()
+		if fs != null:
+			fs.filesystem_changed.connect(_on_filesystem_scanned_for_update, CONNECT_ONE_SHOT)
+			fs.scan()
+		else:
+			## Fallback: no filesystem accessor — defer and hope (matches
+			## the pre-#127 behaviour).
+			_reload_after_update.call_deferred()
 	else:
 		_update_btn.text = "Restart editor to apply"
 		_update_btn.disabled = true
 		_update_label.text = "Updated! Restart the editor."
 		_update_label.add_theme_color_override("font_color", Color.GREEN)
+
+
+func _on_filesystem_scanned_for_update() -> void:
+	_update_btn.text = "Reloading..."
+	_reload_after_update.call_deferred()
 
 
 func _reload_after_update() -> void:

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -322,6 +322,17 @@ func _stop_server() -> void:
 		_server_pid = -1
 
 
+## Prepare for a plugin-self-update reload cycle: kill the server process
+## and reset the re-entrancy guard so the re-enabled plugin spawns a fresh
+## server. Without the reset, `_start_server` short-circuits on the static
+## flag after the reload — even though we just freed the port — and the
+## new plugin ends up talking to whatever process inherited port 8000
+## (or, if none exists, the server never starts at all). See #132.
+func prepare_for_update_reload() -> void:
+	_stop_server()
+	_server_started_this_session = false
+
+
 func start_dev_server() -> void:
 	## Start a dev server with --reload that survives plugin reloads.
 	## Kills any managed server first, waits for the port to free, then spawns.

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -90,6 +90,30 @@ func test_server_launch_mode_agrees_with_get_server_command() -> void:
 		assert_true(mode != "unknown", "Non-empty command must map to a concrete mode, got %s" % mode)
 
 
+func test_uvx_server_command_uses_exact_pin_not_tilde() -> void:
+	## Regression guard for #133: the uvx branch of get_server_command must
+	## pin godot-ai with `==<version>`, not `~=<minor>`. With the tilde
+	## constraint, uvx would reuse a cached tool env that matched the
+	## minor — so an install first-spawning 1.2.0 would keep using 1.2.0
+	## after 1.2.1/1.2.2 landed. Exact pinning makes the cache key
+	## version-specific.
+	##
+	## Positive assertion only fires when the test env actually resolves
+	## to the uvx tier. In dev-venv environments (CI, most worktrees) the
+	## loop still runs as a negative assertion — no ~= anywhere — so a
+	## future regression that re-introduced the tilde would fail here too.
+	var cmd := McpClientConfigurator.get_server_command()
+	for arg in cmd:
+		assert_false(str(arg).contains("~="), "uvx command must not use ~= pin (got: %s)" % str(arg))
+	if McpClientConfigurator.get_server_launch_mode() == "uvx":
+		var has_exact_pin := false
+		for arg in cmd:
+			if str(arg).contains("godot-ai==") and str(arg).contains(McpClientConfigurator.get_plugin_version()):
+				has_exact_pin = true
+				break
+		assert_true(has_exact_pin, "uvx tier command should contain godot-ai==<plugin_version>; got %s" % str(cmd))
+
+
 # ----- path template -----
 
 func test_path_template_expands_home() -> void:


### PR DESCRIPTION
## Summary

Three interrelated bugs made the dock's **Update** button a broken path. This PR closes all three as a bundle because they share the same code path (`_install_update` + `get_server_command`) and a partial fix leaves the user with a broken update state.

| Issue | Symptom before | Fix |
|---|---|---|
| #127 | Dock disappears on update (`class_name` parse errors for files that exist on disk but aren't yet in ClassDB) | Scan filesystem + await `filesystem_changed` before reload |
| #132 | Post-update `session_list` reports `plugin_version != server_version` (old server outlives the reload) | Kill server + reset static re-entrancy guard before reload |
| #133 | uvx cache locks server to first-resolved patch version despite plugin update | Pin `godot-ai==<version>` instead of `~=<minor>` |

Together these make the "Update" click end-to-end: scan → reload (dock intact) → spawn fresh server → `session_list` reports matching versions. No manual editor restart or disable/enable dance.

## #127 — dock teardown on update

`_install_update` was calling `_reload_after_update.call_deferred()` on the very next frame after extracting the ZIP, racing Godot's filesystem scanner. `plugin.gd`'s `class_name` references (`GameLogBuffer`, `McpDebuggerPlugin`, etc.) resolved against a ClassDB that hadn't seen the newly-extracted files yet, so `plugin.gd` re-parse failed with `SCRIPT ERROR`. The plugin silently reported "enabled" with no UI; user had to manually disable → enable to recover. Reported by an agent watching an AssetLib 1.0.1 → 1.2.2 upgrade.

Fix in `mcp_dock.gd::_install_update`:

```gdscript
_update_btn.text = "Scanning..."
var fs := EditorInterface.get_resource_filesystem()
if fs != null:
    fs.filesystem_changed.connect(_on_filesystem_scanned_for_update, CONNECT_ONE_SHOT)
    fs.scan()
else:
    # Fallback preserves pre-#127 behaviour if no filesystem accessor.
    _reload_after_update.call_deferred()
```

Plus a new `_on_filesystem_scanned_for_update` that deferred-calls `_reload_after_update`.

## #132 — stale server survives the reload

Two compounding problems in `plugin.gd`:
1. `_install_update` didn't stop the running Python process before reloading the plugin. After reload, `_start_server` saw port 8000 was in use and short-circuited with "server already running, using existing". New plugin code → old server.
2. Even if the port had been freed, `_server_started_this_session` is a **static** flag that persists across `set_plugin_enabled` cycles. `_start_server` would have short-circuited anyway.

Fix adds a new public entry point:

```gdscript
# plugin.gd
func prepare_for_update_reload() -> void:
    _stop_server()
    _server_started_this_session = false
```

And has the dock call it before the reload toggle:

```gdscript
# mcp_dock.gd::_install_update
if _plugin != null and _plugin.has_method("prepare_for_update_reload"):
    _plugin.prepare_for_update_reload()
```

The `has_method` guard is belt-and-suspenders for running against a plugin binary that might predate this PR (shouldn't happen with the filesystem-await fix above, but cheap).

## #133 — uvx cache staleness

`get_server_command` was passing `uvx --from godot-ai~=<minor>`. Tilde-equals was permissive enough that uvx would reuse any cached `1.2.*` tool env — so an install first-spawning `1.2.0` kept using `1.2.0` after `1.2.1`/`1.2.2` landed. Updating the plugin alone wasn't enough; the user's uvx cache also had to expire (~24h) or be manually nuked.

Fix: pin to exact plugin version:

```gdscript
return [uvx, "--from", "godot-ai==%s" % version, "godot-ai"]
```

With `==`, uvx only cache-hits when the pin matches. Plugin bumps → uvx installs the exact new version on the next spawn. No `--refresh-package` cost on every cold start.

## Tests

- `test_uvx_server_command_uses_exact_pin_not_tilde` — negative assertion runs in any environment (no `~=` anywhere in the command). Positive assertion only fires when the test env happens to resolve to the uvx tier (command contains `godot-ai==<plugin_version>`).

Dock update flow + `prepare_for_update_reload` can't be meaningfully unit-tested in GDScript (they're UI + editor-lifecycle paths that hit the network or mutate the plugin enable state). Manual verification will happen during the next v1.2.3 smoke execution:

- [ ] Fresh AssetLib install of an older version (e.g. 1.2.2) → click Update → version bump to 1.2.3 → dock still visible, `session_list.plugin_version == session_list.server_version == 1.2.3` immediately.
- [ ] No `SCRIPT ERROR` lines in Godot console during the update.

## Verification

- [x] `ruff check src/ tests/`
- [x] `pytest -q tests/unit` (307 passed)
- [x] `godot --headless --import` — no parse errors
- [ ] Manual update-flow smoke (deferred to v1.2.3 smoke pass)

## Related

- Closes #127, #132, #133.
- Complements the detection work landed in 1.2.2 (#118 trustworthy `server_version`, #119 `server_launch_mode`): 1.2.2 let agents *notice* drift, this PR *prevents* drift.
- Remaining [#113](https://github.com/hi-godot/godot-ai/issues/113) follow-ups (dev `.venv` ancestor-walk Flow B, cold-start version check when user manually replaces files outside the dock path) are still open — those are operational frictions, not correctness regressions, and can be addressed post-1.2.3.
