### PR TITLE
fix: track actual port owner PID for uvx-tier servers

### DIFF
--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -276,19 +276,19 @@ func _ensure_game_helper_autoload() -> void:
 
 
 func _start_server() -> void:
-	## Four-way branch depending on port state + persisted managed-server
-	## record in EditorSettings. The record lets later editor sessions
-	## recognize and manage servers they didn't spawn themselves — without
-	## it, `_server_pid = -1` after a restart meant `prepare_for_update_reload`
-	## couldn't kill a server the update flow expected to replace. See #135.
+	## Branch on port state + EditorSettings record. The record lets a
+	## later editor session recognize and manage a server it didn't spawn
+	## itself; treating the stored `version` (not `pid`) as the "is this
+	## ours?" signal handles the uvx tier, where the recorded PID is a
+	## launcher that has long since exited. See #135 and #137.
 	##
-	##   port free                              -> spawn fresh, record PID
-	##   port in use, recorded PID alive,       -> adopt (set _server_pid
-	##     version matches                         from record; fast path)
-	##   port in use, recorded PID alive,       -> kill + respawn; handles
-	##     version mismatched                      manual file replace too
-	##   port in use, no live recorded PID      -> foreign server, just use
-	##                                             existing (don't touch)
+	##   port free                            -> spawn fresh, record PID
+	##   port in use, record.version matches  -> adopt the port owner
+	##                                              (self-heals stale PID)
+	##   port in use, record.version drifts   -> kill port owner + respawn
+	##                                              (fixes cold-start drift
+	##                                              from manual file replace)
+	##   port in use, no matching record      -> foreign server, leave alone
 	if _server_started_this_session:
 		## Guard against re-entrant spawns (e.g. plugin reload during update).
 		## The static flag persists across disable/enable cycles within the
@@ -300,24 +300,32 @@ func _start_server() -> void:
 
 	if _is_port_in_use(port):
 		var record := _read_managed_server_record()
-		if record.pid > 0 and _pid_alive(record.pid):
-			if record.version == current_version:
-				_server_pid = record.pid
-				_server_started_this_session = true
-				print("MCP | adopted managed server (PID %d, v%s)" % [record.pid, record.version])
-				return
-			## Version drift — our server but wrong version. Kill and respawn
-			## so the new plugin code talks to a matching server. Also
-			## recovers from the "user dropped a newer ZIP on disk outside
-			## the dock update flow, then restarted the editor" case.
+		if record.version == current_version:
+			## Version matches — this port is owned by a server we spawned
+			## at some point. Adopt the live port owner, ignoring any stale
+			## launcher PID that may still be in the record. Self-heal the
+			## record so next session's adopt can fast-path.
+			var owner := _find_pid_on_port(port)
+			if owner > 0:
+				_server_pid = owner
+				_write_managed_server_record(owner, current_version)
+			_server_started_this_session = true
+			print("MCP | adopted managed server (PID %d, v%s)" % [_server_pid, current_version])
+			return
+		if not record.version.is_empty():
+			## Version drift — our server but the plugin moved on. Kill
+			## the port owner (not the stale launcher PID) and respawn
+			## to match the current plugin version.
 			print("MCP | managed server v%s does not match plugin v%s, restarting"
 				% [record.version, current_version])
-			OS.kill(record.pid)
+			var owner := _find_pid_on_port(port)
+			if owner > 0:
+				OS.kill(owner)
 			_clear_managed_server_record()
 			_wait_for_port_free(port, 3.0)
 			## Fall through to spawn.
 		else:
-			## Foreign process on our port. Don't touch it. Just connect;
+			## No record claiming this port — foreign process. Don't touch;
 			## the WebSocket handshake will fail if it isn't actually ours
 			## and the reconnect loop will surface that.
 			_server_started_this_session = true
@@ -337,6 +345,10 @@ func _start_server() -> void:
 	_server_pid = OS.create_process(cmd, args)
 	if _server_pid > 0:
 		_server_started_this_session = true
+		## Record the launcher PID immediately so a same-session
+		## prepare_for_update_reload has something to kill. On the next
+		## editor start, _start_server's adopt branch self-heals the PID
+		## to the actual port owner (uvx's child).
 		_write_managed_server_record(_server_pid, current_version)
 		print("MCP | started server (PID %d, v%s): %s %s" % [_server_pid, current_version, cmd, " ".join(args)])
 	else:
@@ -355,12 +367,62 @@ func _is_port_in_use(port: int) -> bool:
 	return false
 
 
+## Return the PID currently listening on the given TCP port, or 0 if
+## the port is free. Used by the adopt and stop paths to recover the
+## real server PID when we can't trust _server_pid (e.g. uvx launcher
+## that has exited after spawning its child). See #137.
+func _find_pid_on_port(port: int) -> int:
+	var output: Array = []
+	if OS.get_name() == "Windows":
+		## netstat prints lines like:
+		##   TCP    0.0.0.0:8000    0.0.0.0:0    LISTENING    57865
+		var exit_code := OS.execute("netstat", ["-ano"], output, true)
+		if exit_code != 0 or output.is_empty():
+			return 0
+		for line in output:
+			var s := str(line)
+			if s.find(":%d " % port) >= 0 and s.find("LISTENING") >= 0:
+				var parts := s.split(" ", false)
+				if parts.size() > 0:
+					var pid := parts[parts.size() - 1].strip_edges()
+					if pid.is_valid_int():
+						return int(pid)
+		return 0
+	## POSIX: `lsof -ti:<port> -sTCP:LISTEN` returns only the PID.
+	var exit_code := OS.execute("lsof", ["-ti:%d" % port, "-sTCP:LISTEN"], output, true)
+	if exit_code != 0 or output.is_empty():
+		return 0
+	var pid_str := str(output[0]).strip_edges()
+	if pid_str.is_empty() or not pid_str.is_valid_int():
+		return 0
+	return int(pid_str)
+
+
 func _stop_server() -> void:
-	if _server_pid > 0:
+	if _server_pid <= 0:
+		return
+	## Kill both the process we tracked and the current port owner, if
+	## different. For direct-spawn tiers (.venv, system CLI) these are the
+	## same and we kill once. For the uvx tier the tracked PID is the
+	## launcher — which may be dead (adopted), still installing (about to
+	## spawn), or done spawning; killing both the launcher (if alive) and
+	## the port owner (if any) covers all three cases without races. See
+	## #137.
+	var killed: Array[int] = []
+	if _pid_alive(_server_pid):
 		OS.kill(_server_pid)
-		print("MCP | stopped server (PID %d)" % _server_pid)
-		_server_pid = -1
-		_clear_managed_server_record()
+		killed.append(_server_pid)
+	if _is_port_in_use(McpClientConfigurator.SERVER_HTTP_PORT):
+		var owner := _find_pid_on_port(McpClientConfigurator.SERVER_HTTP_PORT)
+		if owner > 0 and not killed.has(owner):
+			OS.kill(owner)
+			killed.append(owner)
+	if not killed.is_empty():
+		print("MCP | stopped server (PID %s)" % str(killed))
+	_server_pid = -1
+	_clear_managed_server_record()
+	## Brief wait so a follow-up spawn doesn't race a still-closing socket.
+	_wait_for_port_free(McpClientConfigurator.SERVER_HTTP_PORT, 2.0)
 
 
 ## True if the given PID corresponds to a live process. Uses POSIX `kill -0`


### PR DESCRIPTION
## Summary

Second-order fix for the update-flow correctness chain. #135 persisted managed-server state in EditorSettings but recorded `OS.create_process`'s return value, which for the uvx tier is the **launcher** PID — uvx installs the package, spawns the real Python server as a child, then exits. The launcher PID we recorded is dead within seconds, so `_pid_alive(recorded_pid) == false`, adopt path never triggers, `OS.kill` is a no-op, server drift persists after update.

**Surfaced during v1.2.5 → v1.2.6 smoke click:** plugin updated correctly, server stayed on 1.2.5 (same symptom as before #135, new underlying cause).

## The scenario

```
$ ps -p 57853                              # uvx — what we recorded
  PID TTY           TIME CMD                (dead)

$ ps -p 57865 -o pid,ppid,lstart            # Python — the real server
  PID  PPID STARTED
57865     1 Mon Apr 20 16:39:55 2026         ← PPID=1: orphaned by uvx exit

$ grep managed_server editor_settings-4.6.tres
godot_ai/managed_server_pid = 57853          ← points at dead launcher
godot_ai/managed_server_version = "1.2.5"    ← this is the signal we can trust
```

`_stop_server` calling `OS.kill(57853)` was a no-op. `_start_server`'s adopt branch failed on `_pid_alive(57853)`. Everything downstream fell apart.

## Fix

### `_start_server` adopt branch — use `version` as the truth signal

Old:
```gdscript
if record.pid > 0 and _pid_alive(record.pid):
    if record.version == current_version:
        # adopt — relies on launcher PID still being alive
```

New:
```gdscript
if record.version == current_version:
    # adopt — query port for the actual live PID, ignore stale record.pid
    var owner := _find_pid_on_port(port)
    if owner > 0:
        _server_pid = owner
        _write_managed_server_record(owner, current_version)  # self-heal
```

`record.version` is stable across launcher exits; `record.pid` is not. The port owner is the authoritative "who's actually serving."

### `_stop_server` — kill both tracked and port owner

Old: `OS.kill(_server_pid)` only.

New: kill the tracked PID (if alive — covers direct-spawn tiers and "launcher still installing" races) **and** the current port owner (if different — covers the normal uvx case where the launcher exited and its child owns the port). One pass, both covered, no race.

Plus a brief `_wait_for_port_free` after so a follow-up spawn doesn't race the still-closing socket.

### New helper: `_find_pid_on_port(port)`

POSIX: `lsof -ti:<port> -sTCP:LISTEN` → PID.
Windows: `netstat -ano` → parse the LISTENING line for the port.
Returns 0 on free or parse failure.

## What this closes end-to-end

| Scenario | Before #135 | After #135 | After #137 |
|---|---|---|---|
| Plugin update, dev `.venv` tier | server reused, drifts | works ✓ | works ✓ |
| Plugin update, system CLI tier | server reused, drifts | works ✓ | works ✓ |
| Plugin update, **uvx tier** (the default) | server reused, drifts | still drifts (launcher dead) | **works ✓** |
| Cold-start after manual ZIP replacement | silently stale | works ✓ | works ✓ |

## Tests

No new GDScript unit tests. `_find_pid_on_port` is a shell over `OS.execute`; testing in isolation would mock more than it verifies. End-to-end validation will be the v1.2.6 → v1.2.7 update-flow click once v1.2.7 ships.

## Verification

- [x] `ruff check src/ tests/`
- [x] `pytest -q tests/unit` (307 passed)
- [x] `godot --headless --import` — no parse errors
- [ ] Manual update-flow smoke after v1.2.7 ships

Closes #137. Completes the update-flow correctness work started in #134 and continued in #136.
