### PR TITLE
feat(dock): surface install mode to users (#144)

### DIFF
--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -146,6 +146,17 @@ func _build_ui() -> void:
 
 	add_child(status_row)
 
+	# Install-mode line — so a git-clone user doesn't press the yellow Update
+	# banner below and silently downgrade from main to the last release tag.
+	# See #144.
+	var install_label := Label.new()
+	install_label.add_theme_color_override("font_color", COLOR_MUTED)
+	install_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	install_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	install_label.text = _install_mode_text()
+	install_label.tooltip_text = _install_mode_tooltip()
+	add_child(install_label)
+
 	# --- Update banner (top of dock, hidden until check finds a newer version) ---
 	_update_banner = VBoxContainer.new()
 	_update_banner.add_theme_constant_override("separation", 4)
@@ -533,6 +544,34 @@ func _refresh_setup_status() -> void:
 		install_btn.text = "Install uv"
 		install_btn.pressed.connect(_on_install_uv)
 		_setup_container.add_child(install_btn)
+
+
+func _install_mode_text() -> String:
+	if McpClientConfigurator.is_dev_checkout():
+		return "Install: dev checkout — update via git pull"
+	return "Install: v%s" % McpClientConfigurator.get_plugin_version()
+
+
+func _install_mode_tooltip() -> String:
+	if not McpClientConfigurator.is_dev_checkout():
+		return "Plugin installed from a release ZIP, Asset Library, or source copy. Update button in this dock downloads the latest GitHub release."
+	var target := _resolve_plugin_symlink_target()
+	if target.is_empty():
+		return "Plugin source tree resolved via local .venv — press Reload Plugin after editing."
+	return "Plugin source: %s\nPress Reload Plugin after editing." % target
+
+
+func _resolve_plugin_symlink_target() -> String:
+	var addons_path := ProjectSettings.globalize_path("res://addons/godot_ai")
+	var dir := DirAccess.open(addons_path.get_base_dir())
+	if dir == null or not dir.is_link(addons_path):
+		return ""
+	var target := dir.read_link(addons_path)
+	if target.is_empty():
+		return ""
+	if target.is_relative_path():
+		target = addons_path.get_base_dir().path_join(target).simplify_path()
+	return target
 
 
 func _make_status_row(label_text: String, value_text: String, value_color: Color) -> HBoxContainer:

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -21,6 +21,7 @@ var _client_configure_all_btn: Button
 var _clients_summary_label: Label
 var _clients_window: Window
 var _dev_mode_toggle: CheckButton
+var _install_label: Label
 
 ## Per-client UI handles, keyed by client id. Each entry holds the row's
 ## status dot, configure button, remove button, manual-command panel + text.
@@ -149,13 +150,14 @@ func _build_ui() -> void:
 	# Install-mode line — so a git-clone user doesn't press the yellow Update
 	# banner below and silently downgrade from main to the last release tag.
 	# See #144.
-	var install_label := Label.new()
-	install_label.add_theme_color_override("font_color", COLOR_MUTED)
-	install_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	install_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	install_label.text = _install_mode_text()
-	install_label.tooltip_text = _install_mode_tooltip()
-	add_child(install_label)
+	_install_label = Label.new()
+	_install_label.add_theme_color_override("font_color", COLOR_MUTED)
+	_install_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_install_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_install_label.text = _install_mode_text()
+	_install_label.tooltip_text = _install_mode_tooltip()
+	_install_label.mouse_filter = Control.MOUSE_FILTER_STOP
+	add_child(_install_label)
 
 	# --- Update banner (top of dock, hidden until check finds a newer version) ---
 	_update_banner = VBoxContainer.new()

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -39,6 +39,13 @@ func test_install_mode_tooltip_is_nonempty() -> void:
 	assert_false(tooltip.is_empty(), "Tooltip must not be empty")
 
 
+func test_install_label_mouse_filter_allows_tooltip() -> void:
+	# Label.mouse_filter defaults to IGNORE, which silently swallows hover
+	# events and prevents tooltip_text from ever firing. Regression guard.
+	_dock._build_ui()
+	assert_eq(_dock._install_label.mouse_filter, Control.MOUSE_FILTER_STOP)
+
+
 func test_dev_checkout_tooltip_exposes_symlink_target() -> void:
 	if not McpClientConfigurator.is_dev_checkout():
 		skip("only meaningful in dev checkout")

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -1,0 +1,56 @@
+@tool
+extends McpTestSuite
+
+## Tests for McpDock's install-mode surfacing (see #144). Cannot mock the
+## static McpClientConfigurator calls, so we just assert the text tracks
+## whatever mode the current test environment is actually running in.
+
+const McpDockScript = preload("res://addons/godot_ai/mcp_dock.gd")
+
+var _dock: Node
+
+
+func suite_name() -> String:
+	return "dock"
+
+
+func suite_setup(_ctx: Dictionary) -> void:
+	_dock = McpDockScript.new()
+
+
+func suite_teardown() -> void:
+	if _dock != null:
+		_dock.free()
+		_dock = null
+
+
+func test_install_mode_text_matches_environment() -> void:
+	var text: String = _dock._install_mode_text()
+	assert_true(text.begins_with("Install: "), "Expected prefix 'Install: ', got: %s" % text)
+	if McpClientConfigurator.is_dev_checkout():
+		assert_contains(text, "dev checkout", "Dev-checkout env should label as such")
+		assert_contains(text, "git pull", "Dev-checkout text should mention git pull")
+	else:
+		assert_contains(text, "v%s" % McpClientConfigurator.get_plugin_version())
+
+
+func test_install_mode_tooltip_is_nonempty() -> void:
+	var tooltip: String = _dock._install_mode_tooltip()
+	assert_false(tooltip.is_empty(), "Tooltip must not be empty")
+
+
+func test_dev_checkout_tooltip_exposes_symlink_target() -> void:
+	if not McpClientConfigurator.is_dev_checkout():
+		skip("only meaningful in dev checkout")
+		return
+	var target: String = _dock._resolve_plugin_symlink_target()
+	if target.is_empty():
+		# e.g. developer without a symlink (flat checkout inside test_project);
+		# tooltip must still be readable.
+		var tooltip: String = _dock._install_mode_tooltip()
+		assert_contains(tooltip, "Reload Plugin")
+		return
+	assert_true(target.is_absolute_path(), "Resolved symlink target must be absolute: %s" % target)
+	assert_contains(target, "godot_ai", "Symlink should point at a godot_ai plugin tree: %s" % target)
+	var tooltip: String = _dock._install_mode_tooltip()
+	assert_contains(tooltip, target, "Tooltip should embed the resolved target path")

--- a/test_project/tests/test_dock.gd.uid
+++ b/test_project/tests/test_dock.gd.uid
@@ -1,0 +1,1 @@
+uid://ber635iylss4x


### PR DESCRIPTION
## Summary

Closes #144. Adds a single-line install-mode label to the MCP dock so a user can tell at a glance whether updates come from `git pull` (dev checkout) or the dock's self-update button (regular install). Without this, a git-clone user can silently downgrade from `main` to the last release tag by pressing the yellow Update banner.

The label reads one of:
- `Install: dev checkout — update via git pull` (dev checkout)
- `Install: v<version>` (regular install)

For dev checkouts the tooltip resolves the `addons/godot_ai` symlink target so contributors juggling worktrees can confirm which plugin tree the running editor is actually pointing at — addressing the "third confusing case" in the issue.

Pure surfacing of information already detected by `McpClientConfigurator.is_dev_checkout()` / `get_plugin_version()`; no behavioural change to update flow or `_check_for_updates()`.

## Test plan

- [x] `pytest` — 536 passed
- [x] `ruff check src/ tests/ plugin/` — clean
- [x] `test_run` in live editor — 708/708 (705 existing + 3 new in `test_dock` suite)
- [x] Helpers validated via headless Godot (`_install_mode_text`, `_install_mode_tooltip`, `_resolve_plugin_symlink_target`)
- [ ] Visual verification of label in the dock — automated-run session could not open a `request_access` prompt; recommend eyeballing the dock on this branch before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
