### PR TITLE
feat: dock surfaces install mode (dev checkout vs vX.Y.Z) (#144)

### DIFF
--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -104,7 +104,15 @@ static func get_plugin_version() -> String:
 
 
 static func is_dev_checkout() -> bool:
-	return not _find_venv_python().is_empty()
+	return not _cached_venv_python().is_empty()
+
+
+## Mirrors the gate `_check_for_updates()` uses to suppress the update banner,
+## so the dock can explain to dev-checkout users why they never see it.
+static func get_install_mode_description() -> String:
+	if is_dev_checkout():
+		return "dev checkout — update via git pull"
+	return "v%s" % get_plugin_version()
 
 
 static func get_server_command() -> Array[String]:

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -16,6 +16,7 @@ var _plugin: EditorPlugin
 var _redock_btn: Button
 var _status_icon: ColorRect
 var _status_label: Label
+var _install_mode_label: Label
 var _client_grid: VBoxContainer
 var _client_configure_all_btn: Button
 var _clients_summary_label: Label
@@ -145,6 +146,11 @@ func _build_ui() -> void:
 	status_row.add_child(_redock_btn)
 
 	add_child(status_row)
+
+	_install_mode_label = Label.new()
+	_install_mode_label.text = "Install: %s" % McpClientConfigurator.get_install_mode_description()
+	_install_mode_label.add_theme_color_override("font_color", COLOR_MUTED)
+	add_child(_install_mode_label)
 
 	# --- Update banner (top of dock, hidden until check finds a newer version) ---
 	_update_banner = VBoxContainer.new()

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -90,6 +90,19 @@ func test_server_launch_mode_agrees_with_get_server_command() -> void:
 		assert_true(mode != "unknown", "Non-empty command must map to a concrete mode, got %s" % mode)
 
 
+func test_install_mode_description_matches_is_dev_checkout() -> void:
+	## Keep the dock's install-mode string locked to the same gate as the
+	## update-banner suppression in McpDock._check_for_updates, so the label
+	## can't silently disagree with whether the Update button will fire.
+	var description := McpClientConfigurator.get_install_mode_description()
+	assert_true(not description.is_empty(), "Install mode description must not be empty")
+	if McpClientConfigurator.is_dev_checkout():
+		assert_eq(description, "dev checkout — update via git pull")
+	else:
+		var expected := "v%s" % McpClientConfigurator.get_plugin_version()
+		assert_eq(description, expected)
+
+
 func test_uvx_server_command_uses_exact_pin_not_tilde() -> void:
 	## Regression guard for #133: the uvx branch of get_server_command must
 	## pin godot-ai with `==<version>`, not `~=<minor>`. With the tilde


### PR DESCRIPTION
## Summary

Closes #144. Adds a single-line `Install: …` label to the editor dock, always visible regardless of developer mode:

- Dev checkouts see `Install: dev checkout — update via git pull` — explains why the yellow update banner will never appear (`_check_for_updates()` early-returns on `is_dev_checkout()`, mcp_dock.gd:704).
- Regular installs see `Install: v<plugin_version>` — sanity-check which plugin build is running, especially before vs after clicking Update.

Drive-by: `McpClientConfigurator.is_dev_checkout()` now uses the existing `_cached_venv_python()` cache (same cache that `get_server_command()` and `get_server_launch_mode()` already use), removing a per-call 5-iteration parent-dir walk from three callers (`_check_for_updates`, `_refresh_setup_status`, and the new `get_install_mode_description`).

## Triage note

I surveyed all open issues and the friction log before picking this one. The friction log's open items are all marked FIXED or are workflow notes already addressed by `script/serve-this-worktree`. Among open issues: #129 was explicitly deferred by its author, #140 needs macOS-local debugging, and #143/#146 are feature/UX work too large to safely land without live-editor testing (see below). #144 is the cleanly bisect-friendly unit that ships on its own.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `pytest -q` — 536 passed in 83.36s
- [x] New GDScript test `test_install_mode_description_matches_is_dev_checkout` pins the label string to the `is_dev_checkout()` branch so the UI can't silently drift from the update-banner gate
- [ ] Live Godot smoke test — **not possible in this sandbox** (no Godot binary available); relying on CI matrix (Linux/macOS/Windows via `chickensoft-games/setup-godot`) to run the new GDScript test across all three OSes
- [ ] Manual dock verification after merge: open the dock on both a dev checkout and a regular install, confirm the correct line appears

https://claude.ai/code/session_01PtjhvY6HCgBejAKhN6KLLj