### PR TITLE
plugin: capture server startup crashes + surface actionable hints

### DIFF
--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -43,6 +43,14 @@ var _last_connected := false
 var _last_status_text := ""
 var _startup_grace_until_msec: int = 0
 
+## Crash banner (always visible, shown only when the plugin captures a
+## startup crash). See #146 — gives users the error text + a hint
+## instead of a silent reconnect spinner.
+var _crash_banner: VBoxContainer
+var _crash_hint_label: Label
+var _crash_output: RichTextLabel
+var _last_crash_signature := ""
+
 # First-run grace: uvx installs 60+ Python packages on first run (can take
 # 10-30s on a slow connection). Don't scare users with "Disconnected" during
 # that window — show "Starting server…" instead. After this expires, fall
@@ -145,6 +153,49 @@ func _build_ui() -> void:
 	status_row.add_child(_redock_btn)
 
 	add_child(status_row)
+
+	# --- Crash banner (hidden until the plugin captures a startup exit) ---
+	_crash_banner = VBoxContainer.new()
+	_crash_banner.add_theme_constant_override("separation", 4)
+	_crash_banner.visible = false
+
+	var crash_header := Label.new()
+	crash_header.text = "Server exited during startup"
+	crash_header.add_theme_font_size_override("font_size", 15)
+	crash_header.add_theme_color_override("font_color", Color(1.0, 0.4, 0.4))
+	_crash_banner.add_child(crash_header)
+
+	_crash_hint_label = Label.new()
+	_crash_hint_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_crash_hint_label.add_theme_color_override("font_color", Color(1.0, 0.85, 0.3))
+	_crash_banner.add_child(_crash_hint_label)
+
+	_crash_output = RichTextLabel.new()
+	_crash_output.bbcode_enabled = false
+	_crash_output.selection_enabled = true
+	_crash_output.scroll_active = true
+	_crash_output.fit_content = false
+	_crash_output.custom_minimum_size = Vector2(0, 100)
+	_crash_banner.add_child(_crash_output)
+
+	var crash_btn_row := HBoxContainer.new()
+	crash_btn_row.add_theme_constant_override("separation", 6)
+
+	var crash_restart_btn := Button.new()
+	crash_restart_btn.text = "Restart server"
+	crash_restart_btn.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	crash_restart_btn.pressed.connect(_on_crash_restart)
+	crash_btn_row.add_child(crash_restart_btn)
+
+	var crash_copy_btn := Button.new()
+	crash_copy_btn.text = "Copy output"
+	crash_copy_btn.pressed.connect(_on_crash_copy_output)
+	crash_btn_row.add_child(crash_copy_btn)
+
+	_crash_banner.add_child(crash_btn_row)
+	_crash_banner.add_child(HSeparator.new())
+
+	add_child(_crash_banner)
 
 	# --- Update banner (top of dock, hidden until check finds a newer version) ---
 	_update_banner = VBoxContainer.new()
@@ -403,12 +454,18 @@ func _build_client_row(client_id: String) -> void:
 
 func _update_status() -> void:
 	var connected := _connection.is_connected
+	var exit_info := _get_server_exit_info()
 	var status_text: String
 	var status_color: Color
 
 	if connected:
 		status_text = "Connected"
 		status_color = Color.GREEN
+	elif not exit_info.is_empty():
+		## Server crashed during startup — promote to hard-red regardless
+		## of the grace window. #146
+		status_text = "Server exited"
+		status_color = Color.RED
 	elif Time.get_ticks_msec() < _startup_grace_until_msec:
 		# Inside startup grace — distinguish from real disconnect so first-run
 		# users don't assume it's broken while uvx is downloading packages.
@@ -417,6 +474,8 @@ func _update_status() -> void:
 	else:
 		status_text = "Disconnected"
 		status_color = Color.RED
+
+	_refresh_crash_banner(exit_info)
 
 	var changed := connected != _last_connected or status_text != _last_status_text
 	if not changed:
@@ -427,6 +486,73 @@ func _update_status() -> void:
 	_status_label.text = status_text
 
 	_update_dev_server_btn()
+
+
+func _get_server_exit_info() -> Dictionary:
+	if _plugin == null or not _plugin.has_method("get_server_exit_info"):
+		return {}
+	return _plugin.get_server_exit_info()
+
+
+func _refresh_crash_banner(exit_info: Dictionary) -> void:
+	if _crash_banner == null:
+		return
+	if exit_info.is_empty():
+		if _crash_banner.visible:
+			_crash_banner.visible = false
+			_last_crash_signature = ""
+		return
+
+	var hint: Dictionary = exit_info.get("hint", {})
+	var hint_text := str(hint.get("text", ""))
+	var output_lines: Array = exit_info.get("output", [])
+	var output_text := str(exit_info.get("output_text", ""))
+	## Signature lets us skip rebuilds on every frame while the banner
+	## is sticky — only refresh when the captured payload actually
+	## changes (e.g. after a restart). Hash the output text so two
+	## distinct failures can't collide on line-count + hint id alone.
+	var signature := "%s|%d" % [hint.get("id", ""), output_text.hash()]
+	if _crash_banner.visible and signature == _last_crash_signature:
+		return
+	_last_crash_signature = signature
+
+	if hint_text.is_empty():
+		_crash_hint_label.text = "The MCP server process exited shortly after starting. Captured output below — check for a port conflict, missing dependency, or Python error."
+	else:
+		_crash_hint_label.text = hint_text
+
+	_crash_output.clear()
+	if output_lines.is_empty():
+		_crash_output.add_text("(no output captured)")
+	else:
+		for line in output_lines:
+			_crash_output.add_text(str(line) + "\n")
+
+	_crash_banner.visible = true
+
+
+func _on_crash_restart() -> void:
+	if _plugin != null and _plugin.has_method("restart_server_after_exit"):
+		_plugin.restart_server_after_exit()
+	if _connection != null:
+		_connection.disconnect_from_server()
+		_connection._attempt_reconnect()
+	## Reset the grace window so the status flashes amber ("Starting server…")
+	## rather than jumping straight back to red while the fresh spawn warms up.
+	_startup_grace_until_msec = Time.get_ticks_msec() + STARTUP_GRACE_MSEC
+	_last_status_text = ""
+
+
+func _on_crash_copy_output() -> void:
+	var info := _get_server_exit_info()
+	if info.is_empty():
+		return
+	var text := str(info.get("output_text", ""))
+	var hint: Dictionary = info.get("hint", {})
+	var hint_text := str(hint.get("text", ""))
+	if not hint_text.is_empty():
+		text = "%s\n\n%s" % [hint_text, text]
+	DisplayServer.clipboard_set(text)
 
 
 func _update_log() -> void:

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -20,8 +20,19 @@ var _handlers: Array = []  # prevent GC of RefCounted handlers
 var _debugger_plugin: McpDebuggerPlugin
 static var _server_started_this_session := false  # guard against re-entrant spawns
 
+## Captures server stdout/stderr and watches for early exit so the dock
+## can surface startup crashes (e.g. Windows port reservation / WinError
+## 10013) instead of spinning in "reconnecting…" forever. See #146.
+var _server_spawn: McpServerSpawn
+var _server_exit_info: Dictionary = {}
+
 
 func _enter_tree() -> void:
+	## `_process` is only needed while watching a freshly-spawned server;
+	## `_start_server` / `start_dev_server` turn it on after a successful
+	## pipe'd spawn, and `_process` itself turns it back off once the
+	## watch window ends or an exit is observed. See #146.
+	set_process(false)
 	_start_server()
 
 	_log_buffer = McpLogBuffer.new()
@@ -236,6 +247,9 @@ func _exit_tree() -> void:
 	_game_log_buffer = null
 
 	_stop_server()
+	if _server_spawn != null:
+		_server_spawn.release()
+		_server_spawn = null
 	print("MCP | plugin unloaded")
 
 
@@ -338,21 +352,46 @@ func _start_server() -> void:
 		return
 
 	var cmd: String = server_cmd[0]
-	var args: Array[String] = []
-	args.assign(server_cmd.slice(1))
-	args.append_array(["--transport", "streamable-http", "--port", str(port)])
+	var packed_args := _build_server_args(server_cmd.slice(1), port, false)
 
-	_server_pid = OS.create_process(cmd, args)
+	_server_spawn = McpServerSpawn.new()
+	_server_pid = _server_spawn.start(cmd, packed_args)
 	if _server_pid > 0:
 		_server_started_this_session = true
+		_server_exit_info = {}
 		## Record the launcher PID immediately so a same-session
 		## prepare_for_update_reload has something to kill. On the next
 		## editor start, _start_server's adopt branch self-heals the PID
 		## to the actual port owner (uvx's child).
 		_write_managed_server_record(_server_pid, current_version)
-		print("MCP | started server (PID %d, v%s): %s %s" % [_server_pid, current_version, cmd, " ".join(args)])
+		print("MCP | started server (PID %d, v%s): %s %s" % [_server_pid, current_version, cmd, " ".join(packed_args)])
+		if _server_spawn.was_piped():
+			set_process(true)
+		else:
+			## Fallback path (no pipes) — nothing to watch, so release
+			## the helper instead of running `_process` forever.
+			_server_spawn = null
 	else:
 		push_warning("MCP | failed to start server")
+		_server_spawn = null
+
+
+## Build the argv tail for the MCP server: the resolved command's own
+## tail, plus the transport/port flags (and --reload for dev servers).
+## Shared by `_start_server` and `start_dev_server`. `prefix` is the
+## `Array[String]` returned by `McpClientConfigurator.get_server_command()`
+## minus its first element (the program name).
+func _build_server_args(prefix: Array, port: int, with_reload: bool) -> PackedStringArray:
+	var args := PackedStringArray()
+	for a in prefix:
+		args.append(a)
+	args.append("--transport")
+	args.append("streamable-http")
+	args.append("--port")
+	args.append(str(port))
+	if with_reload:
+		args.append("--reload")
+	return args
 
 
 func _is_port_in_use(port: int) -> bool:
@@ -514,19 +553,22 @@ func start_dev_server() -> void:
 			return
 
 		var cmd: String = server_cmd[0]
-		var inner_args: Array[String] = []
-		inner_args.assign(server_cmd.slice(1))
-		inner_args.append_array([
-			"--transport", "streamable-http",
-			"--port", str(McpClientConfigurator.SERVER_HTTP_PORT),
-			"--reload",
-		])
+		var packed_args := _build_server_args(
+			server_cmd.slice(1), McpClientConfigurator.SERVER_HTTP_PORT, true
+		)
 
-		var pid := OS.create_process(cmd, inner_args)
+		_server_spawn = McpServerSpawn.new()
+		var pid := _server_spawn.start(cmd, packed_args)
 		if pid > 0:
-			print("MCP | started dev server with --reload (PID %d): %s %s" % [pid, cmd, " ".join(inner_args)])
+			_server_exit_info = {}
+			print("MCP | started dev server with --reload (PID %d): %s %s" % [pid, cmd, " ".join(packed_args)])
+			if _server_spawn.was_piped():
+				set_process(true)
+			else:
+				_server_spawn = null
 		else:
 			push_warning("MCP | failed to start dev server")
+			_server_spawn = null
 	)
 
 
@@ -553,3 +595,54 @@ func stop_dev_server() -> void:
 func is_dev_server_running() -> bool:
 	## Returns true if a server is running on the HTTP port that we didn't start as managed.
 	return _server_pid <= 0 and _is_port_in_use(McpClientConfigurator.SERVER_HTTP_PORT)
+
+
+func _process(_delta: float) -> void:
+	## Drive the spawn watcher from the editor's main loop. The helper
+	## returns true on the frame it first observes an exit; after that we
+	## snapshot the exit info for the dock and stop polling. See #146.
+	## `set_process(true)` is called after a successful pipe'd spawn;
+	## we turn it back off here once the spawn is done being watched.
+	if _server_spawn == null:
+		set_process(false)
+		return
+	if not _server_exit_info.is_empty():
+		set_process(false)
+		return
+	if _server_spawn.tick():
+		_server_exit_info = _server_spawn.exit_info(McpClientConfigurator.SERVER_HTTP_PORT)
+		var lines: Array = _server_exit_info.get("output", [])
+		var hint_dict: Dictionary = _server_exit_info.get("hint", {})
+		var hint_text: String = hint_dict.get("text", "")
+		var elapsed: int = _server_exit_info.get("elapsed_msec", 0)
+		push_warning("MCP | server exited %dms after spawn (%d lines captured)" % [elapsed, lines.size()])
+		if not hint_text.is_empty():
+			push_warning("MCP | %s" % hint_text)
+		for line in lines:
+			print("MCP | [server] %s" % line)
+	elif _server_spawn.is_past_watch_window():
+		_server_spawn.release()
+		_server_spawn = null
+		set_process(false)
+
+
+## Snapshot of the last server-spawn exit, if any. Empty dict while the
+## server is alive (or was never spawned by this session). Read by the
+## dock to show a crash banner with captured output + one-liner hint.
+## See #146.
+func get_server_exit_info() -> Dictionary:
+	return _server_exit_info
+
+
+## Clear the captured exit state and re-run the spawn path. Used by the
+## dock's crash-banner "Restart" button so the user can try again after
+## fixing the underlying cause (port reservation, missing module, etc.).
+func restart_server_after_exit() -> void:
+	_server_exit_info = {}
+	if _server_spawn != null:
+		_server_spawn.release()
+		_server_spawn = null
+	_server_pid = -1
+	_server_started_this_session = false
+	_clear_managed_server_record()
+	_start_server()  # turns `set_process` back on if the new spawn has pipes

--- a/plugin/addons/godot_ai/utils/server_spawn.gd
+++ b/plugin/addons/godot_ai/utils/server_spawn.gd
@@ -1,0 +1,225 @@
+@tool
+class_name McpServerSpawn
+extends RefCounted
+
+## Spawns the MCP server via `OS.execute_with_pipe` and captures
+## stdout/stderr so the dock can surface crashes instead of spinning
+## in "reconnecting…" forever. See issue #146.
+##
+## Usage:
+##   var spawn := McpServerSpawn.new()
+##   var pid := spawn.start(cmd, args)
+##   # every frame while watching:
+##   if spawn.tick():
+##       var info := spawn.exit_info(port)
+##       # info.output, info.output_text, info.hint, info.elapsed_msec
+##
+## The watch window (SPAWN_WATCH_MSEC) exists to catch startup crashes
+## without tying the editor to the child process for its entire life —
+## a healthy server living 60+ seconds is considered "up" and the helper
+## releases the pipes.
+
+## Watch window after spawn, in ms. Anything that survives this long
+## without exiting is considered a healthy startup and we stop draining.
+const SPAWN_WATCH_MSEC := 15 * 1000
+
+## Cap on retained output lines (ring buffer). Errors are usually small
+## (< 30 lines); the cap exists to bound memory if someone misconfigures
+## the server to spew before exiting.
+const MAX_OUTPUT_LINES := 60
+
+## How often `tick()` actually probes liveness / drains pipes. `tick()`
+## can be called every frame, but `_is_pid_alive` shells out to `kill -0`
+## / `tasklist` which is too expensive to run at 60 Hz.
+const POLL_INTERVAL_MSEC := 500
+
+## Safety cap on lines pulled from a single pipe in one drain pass, so a
+## chatty child can't monopolise the frame. Any remaining lines are
+## picked up on the next tick (or the final post-exit drain).
+const MAX_LINES_PER_DRAIN := 200
+
+## Hint ID constants. Returned in the "id" field of classify_error so
+## callers/tests can match without stringly-typed comparisons.
+const HINT_WINERROR_10013 := "winerror_10013"
+const HINT_PORT_IN_USE := "port_in_use"
+const HINT_MISSING_MODULE := "missing_module"
+
+var pid: int = -1
+var _stdio: FileAccess
+var _stderr: FileAccess
+var _output_lines: Array[String] = []
+var _spawn_msec: int = 0
+var _exited := false
+var _exit_observed_msec: int = 0
+var _last_poll_msec: int = 0
+
+
+## Pure helper: turn captured server output into a one-liner hint the
+## dock can display above the raw output. Returns {"id": String, "text": String};
+## `id` is "" when no pattern matched. Public-static so it's easily tested.
+static func classify_error(output_text: String, port: int) -> Dictionary:
+	var lower := output_text.to_lower()
+	## Windows port reservation (Hyper-V / WSL2 / Docker Desktop) —
+	## different code from plain "in use". See issue #146 motivating case.
+	if lower.find("winerror 10013") >= 0 or lower.find("forbidden by its access permissions") >= 0:
+		return {
+			"id": HINT_WINERROR_10013,
+			"text": (
+				"Port %d is reserved by Windows (often Hyper-V / WSL2 / Docker Desktop). "
+				+ "In an admin PowerShell: `net stop winnat; net start winnat`, then click Restart."
+			) % port,
+		}
+	if (lower.find("winerror 10048") >= 0
+			or lower.find("errno 98") >= 0
+			or lower.find("address already in use") >= 0):
+		return {
+			"id": HINT_PORT_IN_USE,
+			"text": (
+				"Port %d is already in use. Stop the process holding it, or configure a different MCP port."
+			) % port,
+		}
+	if lower.find("modulenotfounderror") >= 0 or lower.find("no module named") >= 0:
+		return {
+			"id": HINT_MISSING_MODULE,
+			"text": "Python module missing — the uv cache may be corrupt. Try `uv cache clean`, then click Restart.",
+		}
+	return {"id": "", "text": ""}
+
+
+## Spawn the server. Returns the child PID on success, -1 on failure.
+## If `OS.execute_with_pipe` returns an empty Dictionary (unsupported or
+## failed spawn), falls back to fire-and-forget `OS.create_process` — the
+## crash banner can't light up for that fallback spawn (no pipes), so the
+## helper is unusable for monitoring and the caller should drop it.
+## `was_piped()` reports which path was taken.
+func start(cmd: String, args: PackedStringArray) -> int:
+	_reset()
+	var result := OS.execute_with_pipe(cmd, args, false)
+	if result.is_empty():
+		pid = OS.create_process(cmd, args)
+		return pid
+	pid = int(result.get("pid", -1))
+	_stdio = result.get("stdio", null)
+	_stderr = result.get("stderr", null)
+	_spawn_msec = Time.get_ticks_msec()
+	return pid
+
+
+## True iff the last `start()` successfully opened pipes and we can
+## monitor the child. False after the `OS.create_process` fallback —
+## callers use this to skip registering the spawn for ticking.
+func was_piped() -> bool:
+	return _spawn_msec != 0
+
+
+## Poll the child once. Drains any available stdout/stderr into the
+## ring buffer and checks whether the process has exited. Returns true
+## on the first tick where the exit is observed; false otherwise.
+##
+## Call repeatedly (e.g. from the dock's `_process`) until either the
+## exit is detected or `is_past_watch_window()` returns true — at which
+## point call `release()` to drop the pipes.
+func tick() -> bool:
+	if _exited or pid <= 0:
+		return false
+	var now := Time.get_ticks_msec()
+	if now - _last_poll_msec < POLL_INTERVAL_MSEC:
+		return false
+	_last_poll_msec = now
+	_drain()
+	if not _is_pid_alive(pid):
+		_exited = true
+		_exit_observed_msec = now
+		## One final drain: the child has closed its pipe ends, so any
+		## last bytes are now readable without blocking.
+		_drain()
+		return true
+	return false
+
+
+## True once the spawn-watch window has elapsed. Used by the owner to
+## decide when to stop polling a server that started cleanly.
+func is_past_watch_window() -> bool:
+	if _spawn_msec == 0:
+		return false
+	return Time.get_ticks_msec() - _spawn_msec > SPAWN_WATCH_MSEC
+
+
+func is_exited() -> bool:
+	return _exited
+
+
+## Snapshot of exit state for the dock. Empty when the child is still
+## alive (or was never spawned). `OS.execute_with_pipe` doesn't expose a
+## real exit code to the parent, so we omit it — the captured output is
+## the actionable signal.
+func exit_info(port: int) -> Dictionary:
+	if not _exited:
+		return {}
+	var output_text := "\n".join(_output_lines)
+	var hint := classify_error(output_text, port)
+	var elapsed_msec := _exit_observed_msec - _spawn_msec
+	return {
+		"output": _output_lines.duplicate(),
+		"output_text": output_text,
+		"hint": hint,
+		"elapsed_msec": elapsed_msec,
+	}
+
+
+## Drop the pipes so the FileAccess handles close. Safe to call
+## multiple times.
+func release() -> void:
+	_stdio = null
+	_stderr = null
+
+
+func _reset() -> void:
+	pid = -1
+	_stdio = null
+	_stderr = null
+	_output_lines.clear()
+	_spawn_msec = 0
+	_exited = false
+	_exit_observed_msec = 0
+	_last_poll_msec = 0
+
+
+func _drain() -> void:
+	var pipes: Array[FileAccess] = [_stdio, _stderr]
+	for pipe in pipes:
+		if pipe == null:
+			continue
+		for _i in MAX_LINES_PER_DRAIN:
+			if pipe.eof_reached():
+				break
+			var line := pipe.get_line()
+			## `get_line()` on a non-blocking pipe returns "" when no
+			## data is ready. It also returns "" for a real empty line
+			## in the stream; we accept that minor noise (a blank line
+			## is rarely load-bearing in Python tracebacks) rather than
+			## risk blocking the editor with a byte-at-a-time read.
+			if line.is_empty():
+				break
+			_output_lines.append(line)
+			if _output_lines.size() > MAX_OUTPUT_LINES:
+				_output_lines.remove_at(0)
+
+
+## Duplicated from `plugin.gd::_pid_alive` on purpose — keeps this
+## helper self-contained. Keep the two implementations in sync if
+## either one grows.
+static func _is_pid_alive(p: int) -> bool:
+	if p <= 0:
+		return false
+	if OS.get_name() == "Windows":
+		var output: Array = []
+		var exit_code := OS.execute("tasklist", ["/FI", "PID eq %d" % p, "/NH", "/FO", "CSV"], output, true)
+		if exit_code != 0 or output.is_empty():
+			return false
+		for line in output:
+			if str(line).find("\"%d\"" % p) >= 0:
+				return true
+		return false
+	var exit_code := OS.execute("kill", ["-0", str(p)], [], true)
+	return exit_code == 0

--- a/test_project/tests/test_server_spawn.gd
+++ b/test_project/tests/test_server_spawn.gd
@@ -1,0 +1,119 @@
+@tool
+extends McpTestSuite
+
+## Tests for McpServerSpawn — issue #146. Only the pure helper
+## (`classify_error`) is covered here; the actual pipe capture + PID
+## watching requires a real child process and is covered by the live
+## smoke path in the PR.
+
+
+func suite_name() -> String:
+	return "server_spawn"
+
+
+# ----- classify_error -----
+
+func test_classify_error_recognises_winerror_10013() -> void:
+	var text := (
+		"[Errno 13] error while attempting to bind on address ('127.0.0.1', 8000):\n"
+		+ "[winerror 10013] an attempt was made to access a socket in a way forbidden by its access permissions"
+	)
+	var hint := McpServerSpawn.classify_error(text, 8000)
+	assert_eq(hint.get("id"), McpServerSpawn.HINT_WINERROR_10013)
+	assert_contains(str(hint.get("text")), "8000")
+	assert_contains(str(hint.get("text")), "winnat")
+
+
+func test_classify_error_matches_forbidden_permissions_phrase() -> void:
+	## The WinError 10013 hint also triggers on the English phrase alone,
+	## since some error formatters render it without the numeric code.
+	var text := "OSError: forbidden by its access permissions"
+	var hint := McpServerSpawn.classify_error(text, 9000)
+	assert_eq(hint.get("id"), McpServerSpawn.HINT_WINERROR_10013)
+	assert_contains(str(hint.get("text")), "9000")
+
+
+func test_classify_error_recognises_port_in_use_linux() -> void:
+	var text := "OSError: [Errno 98] Address already in use"
+	var hint := McpServerSpawn.classify_error(text, 8000)
+	assert_eq(hint.get("id"), McpServerSpawn.HINT_PORT_IN_USE)
+	assert_contains(str(hint.get("text")), "8000")
+
+
+func test_classify_error_recognises_port_in_use_windows() -> void:
+	var text := "OSError: [WinError 10048] Only one usage of each socket address ..."
+	var hint := McpServerSpawn.classify_error(text, 8000)
+	assert_eq(hint.get("id"), McpServerSpawn.HINT_PORT_IN_USE)
+
+
+func test_classify_error_recognises_port_in_use_plain_text() -> void:
+	## "address already in use" without an errno number (e.g. uvicorn's
+	## own log formatter).
+	var text := "ERROR: address already in use"
+	var hint := McpServerSpawn.classify_error(text, 8000)
+	assert_eq(hint.get("id"), McpServerSpawn.HINT_PORT_IN_USE)
+
+
+func test_classify_error_recognises_missing_module() -> void:
+	var text := "ModuleNotFoundError: No module named 'godot_ai'"
+	var hint := McpServerSpawn.classify_error(text, 8000)
+	assert_eq(hint.get("id"), McpServerSpawn.HINT_MISSING_MODULE)
+	assert_contains(str(hint.get("text")), "uv cache clean")
+
+
+func test_classify_error_recognises_no_module_named_phrase() -> void:
+	## Python's traceback sometimes prints the "No module named" line
+	## without the ModuleNotFoundError prefix.
+	var text := "ImportError: No module named 'mcp'"
+	var hint := McpServerSpawn.classify_error(text, 8000)
+	assert_eq(hint.get("id"), McpServerSpawn.HINT_MISSING_MODULE)
+
+
+func test_classify_error_returns_empty_for_unknown() -> void:
+	var text := "INFO:     Started server process [29096]\nuvicorn running"
+	var hint := McpServerSpawn.classify_error(text, 8000)
+	assert_eq(hint.get("id"), "")
+	assert_eq(str(hint.get("text")), "")
+
+
+func test_classify_error_interpolates_correct_port() -> void:
+	var text := "[winerror 10013] forbidden by its access permissions"
+	var hint_8000 := McpServerSpawn.classify_error(text, 8000)
+	var hint_9001 := McpServerSpawn.classify_error(text, 9001)
+	assert_contains(str(hint_8000.get("text")), "8000")
+	assert_contains(str(hint_9001.get("text")), "9001")
+	assert_true(
+		not str(hint_8000.get("text")).contains("9001"),
+		"hint for port 8000 should not mention 9001",
+	)
+
+
+# ----- helper identity -----
+
+func test_is_past_watch_window_false_before_start() -> void:
+	## A freshly-constructed helper that was never spawned should not
+	## claim to have passed its watch window — otherwise the plugin's
+	## `_process` would drop the (never-used) spawn on the first tick.
+	var spawn := McpServerSpawn.new()
+	assert_true(
+		not spawn.is_past_watch_window(),
+		"fresh McpServerSpawn should not report past watch window",
+	)
+	assert_true(not spawn.is_exited(), "fresh spawn should not be exited")
+	assert_eq(spawn.exit_info(8000), {}, "fresh spawn should have empty exit_info")
+
+
+func test_exit_info_is_empty_until_exit_observed() -> void:
+	var spawn := McpServerSpawn.new()
+	## pid stays -1 without a real spawn; tick should be a no-op and
+	## exit_info should stay empty.
+	assert_true(not spawn.tick(), "tick with no pid should return false")
+	assert_eq(spawn.exit_info(8000), {})
+
+
+func test_classify_error_is_case_insensitive() -> void:
+	## `classify_error` normalises to lowercase — capitalisation
+	## differences across Python / OS formatters shouldn't matter.
+	var text_mixed := "ErRnO 98 Address Already In Use"
+	var hint := McpServerSpawn.classify_error(text_mixed, 8000)
+	assert_eq(hint.get("id"), McpServerSpawn.HINT_PORT_IN_USE)


### PR DESCRIPTION
Closes #146.

## Summary

- Replace fire-and-forget `OS.create_process` in the spawn paths with a new `McpServerSpawn` helper that uses `OS.execute_with_pipe` to drain stdout/stderr and watch for early exit during the 15s post-spawn window.
- On observed exit, snapshot the captured output + a one-liner hint (`classify_error`) and expose it via `plugin.get_server_exit_info()`.
- Dock renders a crash banner with the hint (amber), the captured output (selectable RichTextLabel), and **Restart server** / **Copy output** buttons.
- Status label goes hard-red "Server exited" during startup grace instead of spinning in "Starting server…" forever.

## Motivating case (from #146)

A Windows user with Hyper-V / WSL2 / Docker Desktop installed has port 8000 reserved. The Python server prints a `[WinError 10013]` and exits immediately. Before this PR: silent "reconnecting…" spinner, no actionable signal. After: banner with

> Port 8000 is reserved by Windows (often Hyper-V / WSL2 / Docker Desktop). In an admin PowerShell: `net stop winnat; net start winnat`, then click Restart.

`classify_error` also recognizes WinError 10048 / Errno 98 / "address already in use" (port in use) and `ModuleNotFoundError` / "No module named" (uv cache corruption — suggests `uv cache clean`).

## Implementation notes

- `McpServerSpawn` is a `RefCounted` helper in `plugin/addons/godot_ai/utils/server_spawn.gd`. Pure `classify_error` is a `static func` for easy unit testing.
- Rate-limited liveness probes: `tick()` only shells out to `kill -0` / `tasklist` every 500ms, not every frame.
- `set_process(true)` is turned on after a successful pipe'd spawn and turned back off as soon as the watch window expires or an exit is observed — zero per-frame overhead for a healthy server.
- Fallback when `OS.execute_with_pipe` returns empty: call `OS.create_process` (original behavior), drop the helper (`was_piped() == false`), don't spin `_process` forever.
- The `_start_server` + `start_dev_server` arg building was extracted into a shared `_build_server_args(prefix, port, with_reload)` helper — the two sites had near-identical inline argv assembly.
- Banner uses a hash-based signature to skip per-frame rebuilds while it's sticky.

## Test plan

- [x] `ruff check src/ tests/` — passes
- [x] `pytest -q` — all 536 Python tests pass
- [x] 12 new GDScript tests (`test_project/tests/test_server_spawn.gd`) covering `classify_error` across all branches (WinError 10013, 10048, errno 98, "address already in use", ModuleNotFoundError, "No module named", unknown), case-insensitivity, port interpolation isolation, and fresh-spawn invariants.
- [ ] **Live smoke was not possible in this environment (no Godot binary).** Recommended manual smoke before merge:
  1. Open `test_project/` in Godot with the plugin enabled.
  2. Force a crash: temporarily shadow `--port 8000` with a reserved or busy port (or run `python -m http.server 8000` before enabling the plugin).
  3. Confirm the dock shows the red "Server exited" label + crash banner with a hint ("Port 8000 is already in use.").
  4. Stop the conflict, click **Restart server**, confirm the banner hides and the status returns to green "Connected".
  5. Click **Copy output** and paste into a scratch buffer — should contain the hint + captured traceback.

## Out of scope

- The dock's `_on_crash_restart` calls `Connection._attempt_reconnect()` (private). This matches the pre-existing `_on_reconnect` pattern at line 617; promoting to a public `Connection.reconnect()` is a separate cleanup.
- `_is_pid_alive` is duplicated between `McpServerSpawn` and `plugin.gd::_pid_alive`. Comment acknowledges it; consolidation into a shared `utils/process_probe.gd` is a follow-up.

https://claude.ai/code/session_011dhFudUzwYEN4FKAje2nMJ