### PR TITLE
feat: add editor_screenshot source=&quot;cinematic&quot;

### DIFF
--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -227,6 +227,12 @@ func take_screenshot(params: Dictionary) -> Dictionary:
 			viewport = EditorInterface.get_editor_viewport_3d()
 			if viewport == null:
 				return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No 3D viewport available")
+		"cinematic":
+			## Render through the scene's `current=true` Camera3D into a
+			## throwaway SubViewport so the output shows the scene as the
+			## game camera sees it — full environment, no editor gizmos,
+			## no grid, no selection outlines — without running the game.
+			return _take_cinematic_screenshot(max_resolution)
 		"game":
 			if not EditorInterface.is_playing_scene():
 				return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Game is not running — use source='viewport' or start the project first")
@@ -244,7 +250,7 @@ func take_screenshot(params: Dictionary) -> Dictionary:
 			_debugger_plugin.request_game_screenshot(request_id, max_resolution, _connection)
 			return McpDispatcher.DEFERRED_RESPONSE
 		_:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Invalid source '%s' — use 'viewport' or 'game'" % source)
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Invalid source '%s' — use 'viewport', 'cinematic', or 'game'" % source)
 
 	## Handle view_target: temporarily reposition the editor's own camera to
 	## frame one or more target nodes, force a render, capture, then restore.
@@ -393,6 +399,93 @@ func take_screenshot(params: Dictionary) -> Dictionary:
 		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to capture image from %s" % source)
 
 	return _finalize_image(image, source, max_resolution)
+
+
+## Capture the scene as the active Camera3D sees it, without running the game.
+## Spawns a throwaway SubViewport under the scene root so it inherits the
+## scene's World3D (environment, lighting, sky). A Camera3D mirroring the
+## scene camera's render properties is set current on the SubViewport, one
+## frame is force-drawn, and the image is grabbed before teardown.
+func _take_cinematic_screenshot(max_resolution: int) -> Dictionary:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+
+	var scene_cam: Camera3D = null
+	for cam in CameraHandler._list_cameras_in_scene(scene_root, "3d"):
+		if cam.is_current():
+			scene_cam = cam
+			break
+	if scene_cam == null:
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"No Camera3D with current=true in scene — mark one as current or use source='viewport'",
+		)
+
+	var subviewport := SubViewport.new()
+	subviewport.size = _cinematic_viewport_size(max_resolution)
+	subviewport.render_target_update_mode = SubViewport.UPDATE_ONCE
+	## own_world_3d=false inherits the scene's World3D so WorldEnvironment,
+	## DirectionalLight3D, and reflection probes apply to the render.
+	subviewport.own_world_3d = false
+	## Transient child — never set_owner, so the node stays out of the saved
+	## scene even if the editor autosaves mid-capture.
+	scene_root.add_child(subviewport)
+
+	var cam_copy := Camera3D.new()
+	subviewport.add_child(cam_copy)
+	cam_copy.fov = scene_cam.fov
+	cam_copy.near = scene_cam.near
+	cam_copy.far = scene_cam.far
+	cam_copy.projection = scene_cam.projection
+	cam_copy.size = scene_cam.size
+	cam_copy.frustum_offset = scene_cam.frustum_offset
+	cam_copy.h_offset = scene_cam.h_offset
+	cam_copy.v_offset = scene_cam.v_offset
+	cam_copy.keep_aspect = scene_cam.keep_aspect
+	cam_copy.cull_mask = scene_cam.cull_mask
+	cam_copy.environment = scene_cam.environment
+	cam_copy.attributes = scene_cam.attributes
+	cam_copy.compositor = scene_cam.compositor
+	## global_transform must be set after add_child so the basis resolves
+	## against the tree, not the parent-less identity transform.
+	cam_copy.global_transform = scene_cam.global_transform
+	cam_copy.current = true
+
+	RenderingServer.force_draw(false)
+
+	var image: Image = subviewport.get_texture().get_image()
+
+	## Immediate free (not queue_free) so a burst of cinematic calls can't
+	## stack pending-delete SubViewports under scene_root between frames.
+	scene_root.remove_child(subviewport)
+	subviewport.free()
+
+	if image == null or image.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Cinematic render produced an empty image")
+
+	var result := _finalize_image(image, "cinematic", max_resolution)
+	result.data["camera_path"] = ScenePath.from_node(scene_cam, scene_root)
+	return result
+
+
+## Render at the project's configured viewport aspect so the scene camera's
+## `keep_aspect` framing matches what the game would show. Scaled down to
+## `max_resolution` up front to avoid rendering pixels that `_finalize_image`
+## would just Lanczos-downscale away.
+static func _cinematic_viewport_size(max_resolution: int) -> Vector2i:
+	var w := int(ProjectSettings.get_setting("display/window/size/viewport_width", 1280))
+	var h := int(ProjectSettings.get_setting("display/window/size/viewport_height", 720))
+	if w <= 0 or h <= 0:
+		w = 1280
+		h = 720
+	if max_resolution > 0:
+		var longest := maxi(w, h)
+		if longest > max_resolution:
+			var scale := float(max_resolution) / float(longest)
+			w = maxi(1, int(w * scale))
+			h = maxi(1, int(h * scale))
+	return Vector2i(w, h)
 
 
 func _finalize_image(image: Image, source: String, max_resolution: int) -> Dictionary:

--- a/src/godot_ai/handlers/editor.py
+++ b/src/godot_ai/handlers/editor.py
@@ -113,6 +113,7 @@ async def editor_screenshot(
         "aabb_center",
         "aabb_size",
         "aabb_longest_ground_axis",
+        "camera_path",
     ):
         if key in result:
             metadata[key] = result[key]

--- a/src/godot_ai/tools/editor.py
+++ b/src/godot_ai/tools/editor.py
@@ -106,7 +106,17 @@ def register_editor_tools(mcp: FastMCP) -> None:
         Takes a screenshot and optionally returns it as an inline image.
 
         Sources:
-        - "viewport": Captures the 3D editor viewport (default).
+        - "viewport": Captures the 3D editor viewport (default). Shows
+          gizmos, grid, selection outlines — the editor's working view.
+        - "cinematic": Renders the scene through its active Camera3D
+          (the one with `current=true`) without running the game. Full
+          environment and post-processing applied, no gizmos, no grid,
+          no selection outlines. Use this for "show me what the player
+          will see". Errors with INVALID_PARAMS if no Camera3D in the
+          scene has `current=true`. Response includes `camera_path` so
+          callers know which camera was picked. Ignores view_target /
+          coverage / elevation / azimuth / fov — the framing is the
+          scene camera's framing.
         - "game": Captures the running game's own framebuffer (only available
           when the project is running). Works regardless of whether Game
           Embed Mode is on or off, and regardless of whether the game
@@ -135,7 +145,7 @@ def register_editor_tools(mcp: FastMCP) -> None:
         4. Repeat until you have the coverage you need (up to ~15 shots).
 
         Args:
-            source: Capture source — "viewport" or "game". Default "viewport".
+            source: Capture source — "viewport", "cinematic", or "game". Default "viewport".
             max_resolution: Maximum resolution (longest edge) for the returned image.
                 Images larger than this are downscaled. Default 640. Set to 0 for full resolution.
             include_image: Whether to include the image data in the response. Default True.

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -385,6 +385,104 @@ func test_screenshot_bogus_source() -> void:
 	assert_contains(result.error.message, "Invalid source")
 
 
+func test_screenshot_bogus_source_message_lists_cinematic() -> void:
+	## Make sure the error message surfaces the cinematic option alongside
+	## the two older sources — agents discovering the tool via errors
+	## should learn about the new source without reading docs.
+	var result := _handler.take_screenshot({"source": "bogus"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "cinematic")
+
+
+# ----- source="cinematic" (issue #143) -----
+
+static func _find_current_camera_3d(scene_root: Node) -> Camera3D:
+	## Local helper: walk the scene and return the first Camera3D with
+	## is_current()=true. Mirrors the lookup the cinematic handler does.
+	## Kept as a test-only helper so the production code stays free of
+	## single-call utilities.
+	for cam in CameraHandler._list_cameras_in_scene(scene_root, "3d"):
+		if cam.is_current():
+			return cam
+	return null
+
+
+func test_screenshot_cinematic_no_scene_errors() -> void:
+	## With no scene loaded there is nowhere to host the SubViewport. We
+	## can't easily close the currently-open scene from a test, so this
+	## test only executes when a scene is not open (skip otherwise).
+	if EditorInterface.get_edited_scene_root() != null:
+		skip("A scene is open; the no-scene branch requires an empty editor")
+		return
+	var result := _handler.take_screenshot({"source": "cinematic"})
+	assert_is_error(result, McpErrorCodes.EDITOR_NOT_READY)
+
+
+func test_screenshot_cinematic_no_active_camera_errors() -> void:
+	## main.tscn has /Main/Camera3D with current=true — temporarily flip
+	## it off so the handler must report the empty-active-camera case.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene open")
+		return
+	var existing := _find_current_camera_3d(scene_root)
+	if existing == null:
+		## Already in the shape we want; just call the handler.
+		var r := _handler.take_screenshot({"source": "cinematic"})
+		assert_is_error(r, McpErrorCodes.INVALID_PARAMS)
+		assert_contains(r.error.message, "current=true")
+		return
+	existing.current = false
+	var result := _handler.take_screenshot({"source": "cinematic"})
+	existing.current = true
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "current=true")
+
+
+func test_screenshot_cinematic_returns_camera_path() -> void:
+	## When a Camera3D with current=true is present, the response must
+	## surface its scene path so callers know which camera was picked.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene open")
+		return
+	var cam := _find_current_camera_3d(scene_root)
+	if cam == null:
+		skip("Scene has no Camera3D with current=true")
+		return
+	var expected_path := ScenePath.from_node(cam, scene_root)
+	var result := _handler.take_screenshot({"source": "cinematic"})
+	if not result.has("data"):
+		## Headless render can fail to produce an image; error path is
+		## acceptable so long as it's INTERNAL_ERROR with a clear msg
+		## (INVALID_PARAMS was already covered above).
+		assert_is_error(result, McpErrorCodes.INTERNAL_ERROR)
+		return
+	assert_eq(result.data.source, "cinematic")
+	assert_eq(result.data.camera_path, expected_path)
+	assert_has_key(result.data, "image_base64")
+	assert_true(result.data.width > 0, "Cinematic image should have a positive width")
+	assert_true(result.data.height > 0, "Cinematic image should have a positive height")
+
+
+func test_screenshot_cinematic_does_not_pollute_scene_tree() -> void:
+	## The throwaway SubViewport must be freed by the time the handler
+	## returns — otherwise every screenshot accretes a child node and
+	## eventually dirties the saved scene.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene open")
+		return
+	var cam := _find_current_camera_3d(scene_root)
+	if cam == null:
+		skip("Scene has no Camera3D with current=true")
+		return
+	var before := scene_root.get_child_count()
+	_handler.take_screenshot({"source": "cinematic"})
+	var after := scene_root.get_child_count()
+	assert_eq(after, before, "SubViewport must not survive the call")
+
+
 # ----- GameLogBuffer (issue #73) -----
 
 func test_game_log_buffer_append_and_get_range() -> void:

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -685,6 +685,8 @@ class StubClient:
                 "format": "png",
                 "image_base64": img_b64,
             }
+            if params.get("source") == "cinematic":
+                result["camera_path"] = "/Main/Camera3D"
             if params.get("view_target"):
                 result["view_target"] = params["view_target"]
                 result["view_target_count"] = len(
@@ -2955,6 +2957,23 @@ async def test_editor_screenshot_handler_fov_passes_param():
     )
     assert client.calls[-1]["params"]["fov"] == 30.0
     assert result["fov"] == 30.0
+
+
+async def test_editor_screenshot_handler_cinematic_source():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    await editor_handlers.editor_screenshot(runtime, source="cinematic", include_image=False)
+    assert client.calls[-1]["params"]["source"] == "cinematic"
+
+
+async def test_editor_screenshot_handler_cinematic_surfaces_camera_path():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await editor_handlers.editor_screenshot(
+        runtime, source="cinematic", include_image=False
+    )
+    assert result["source"] == "cinematic"
+    assert result["camera_path"] == "/Main/Camera3D"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #143.

## Summary

Adds a third `source` option to `editor_screenshot`: `"cinematic"`. It renders the scene through its active `Camera3D` (the one with `current=true`) into a throwaway `SubViewport` so the output shows the game's-eye view &mdash; full environment, lighting, and post-processing, with **no editor gizmos, grid, or selection outlines** &mdash; without having to run the project.

## Motivation (from #143)

Today, agents have two ways to see a scene:
- `source="viewport"` shows the editor's 3D viewport, which is cluttered with gizmos/grid/outlines.
- `source="game"` requires the project to actually be running (and the game-helper autoload to have beaconed ready).

Neither answers the common question "**what will the player see?**" for a scene that isn't currently running. `cinematic` fills that gap.

## How it works

- Spawns a transient `SubViewport` under the scene root with `own_world_3d=false` so it inherits the scene's `WorldEnvironment`, `DirectionalLight3D`, reflection probes, etc.
- Mirrors the scene camera's render properties onto a temporary `Camera3D` (fov, near/far, projection, size, frustum/h/v offset, keep_aspect, cull_mask, environment, attributes, compositor, global_transform) and makes it `current` on the subviewport.
- `RenderingServer.force_draw(false)` renders one frame synchronously.
- The texture is grabbed, the subtree is freed (`remove_child` + immediate `free()`, not `queue_free`, so bursts of cinematic calls can't stack pending-delete nodes).
- Response includes `camera_path` so callers know which camera was picked.

Errors:
- `EDITOR_NOT_READY` if no scene is open.
- `INVALID_PARAMS` if no `Camera3D` has `current=true` &mdash; the message tells the agent to mark one current or fall back to `source="viewport"`.
- `INTERNAL_ERROR` if the render produced an empty image (headless edge case).

Viewport aspect is derived from `display/window/size/viewport_{width,height}`, then scaled down to `max_resolution` up front so we don't render pixels that `_finalize_image` would just Lanczos-downscale away.

## Triage note

Before picking this issue, I walked every open issue + every `friction_log.md` entry looking for bundleable no-bisect cleanup. Every candidate already had a competing open PR against it (mostly small fixes), so I picked **#143** as a bigger bisect-friendly feature where the PR can stand on its own.

## Code-reuse / simplify pass

Three parallel review agents (reuse / quality / efficiency) flagged findings. Applied:
- Replaced a hand-rolled Camera3D walker with `CameraHandler._list_cameras_in_scene(scene_root, "3d")` + `is_current()` loop.
- Dropped redundant defaults (`disable_3d`, `transparent_bg`).
- Switched teardown from `queue_free` to immediate `remove_child` + `free()` to avoid accretion during bursts.
- Extracted `_cinematic_viewport_size(max_resolution)` so the render target is pre-scaled to max_resolution instead of always 1280x720.
- Added the missing `h_offset` / `v_offset` mirror.
- Trimmed over-explanatory comments.

## Test plan

- [x] `ruff check src/ tests/` &mdash; clean.
- [x] `pytest -v` &mdash; **538 passed** (baseline 536 + 2 new cinematic tests).
- [ ] GDScript tests (`test_run`) &mdash; **cannot run in this sandbox** (no Godot binary available). Relying on the CI matrix (Linux/macOS/Windows chickensoft-games/setup-godot) to exercise the new `test_screenshot_cinematic_*` and `test_screenshot_bogus_source_message_lists_cinematic` cases.
- [ ] Live smoke test via MCP &mdash; **cannot run in this sandbox** (no Godot binary). Reviewers should verify once locally: open `test_project`, call `editor_screenshot source="cinematic"`, expect the image of the scene without gizmos/grid and with `camera_path: "/Main/Camera3D"`.

## Tests added

Python (`tests/unit/test_runtime_handlers.py`):
- `test_editor_screenshot_handler_cinematic_source` &mdash; single-image shape still holds.
- `test_editor_screenshot_handler_cinematic_surfaces_camera_path` &mdash; `camera_path` flows through the metadata passthrough.

GDScript (`test_project/tests/test_editor.gd`):
- `test_screenshot_bogus_source_message_lists_cinematic` &mdash; error surfaces the new option so discovery-via-error works.
- `test_screenshot_cinematic_no_scene_errors` &mdash; `EDITOR_NOT_READY` when no scene open.
- `test_screenshot_cinematic_no_active_camera_errors` &mdash; `INVALID_PARAMS` with a "current=true" hint.
- `test_screenshot_cinematic_returns_camera_path` &mdash; success path surfaces the selected camera's scene path.
- `test_screenshot_cinematic_does_not_pollute_scene_tree` &mdash; subviewport doesn't survive the call.

https://claude.ai/code/session_01AthoTjwbg8f1rNPm2g5GVi