### PR TITLE
test: assert editor_undo/editor_redo return true at load-bearing sites

### DIFF
--- a/test_project/tests/test_curve.gd
+++ b/test_project/tests/test_curve.gd
@@ -125,7 +125,7 @@ func test_set_points_auto_creates_curve3d_when_null() -> void:
 	assert_eq(p.curve.point_count, 2)
 
 	# Undo should clear the slot back to null, not leave the auto-created curve.
-	editor_undo(_undo_redo)
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 	assert_true(p.curve == null, "Undo should clear the auto-created curve")
 	_remove_node(p)
 
@@ -237,10 +237,10 @@ func test_set_points_3d_undo_restores_old_points() -> void:
 	})
 	assert_has_key(result, "data")
 	assert_eq(p.curve.point_count, 2)
-	editor_undo(_undo_redo)
+	assert_true(editor_undo(_undo_redo), "curve point_count undo should succeed")
 	assert_eq(p.curve.point_count, 1)
 	assert_eq(p.curve.get_point_position(0), Vector3(10, 10, 10))
-	editor_redo(_undo_redo)
+	assert_true(editor_redo(_undo_redo), "curve point_count redo should succeed")
 	assert_eq(p.curve.point_count, 2)
 	_remove_node(p)
 

--- a/test_project/tests/test_environment.gd
+++ b/test_project/tests/test_environment.gd
@@ -164,9 +164,9 @@ func test_create_undo_restores_previous_environment() -> void:
 	})
 	assert_has_key(result, "data")
 	assert_true(we.environment != null)
-	editor_undo(_undo_redo)
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 	assert_eq(we.environment, prev_env)
-	editor_redo(_undo_redo)
+	assert_true(editor_redo(_undo_redo), "redo should succeed")
 	assert_true(we.environment is Environment)
 	_remove_node(we)
 

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -494,7 +494,7 @@ func test_set_property_class_dict_instantiates_fresh_resource() -> void:
 	assert_eq(mi.mesh.size.x, 2.0)
 	assert_eq(mi.mesh.size.z, 4.0)
 	# Undo should restore null.
-	editor_undo(_undo_redo)
+	assert_true(editor_undo(_undo_redo), "mesh undo should succeed")
 	assert_true(mi.mesh == null)
 	if mi.get_parent():
 		mi.get_parent().remove_child(mi)

--- a/test_project/tests/test_physics_shape.gd
+++ b/test_project/tests/test_physics_shape.gd
@@ -129,7 +129,7 @@ func test_autofit_3d_box_creates_and_sizes_shape() -> void:
 	assert_eq(parts.collision.shape.size.x, 3.0)
 	assert_eq(parts.collision.shape.size.y, 1.0)
 	assert_eq(parts.collision.shape.size.z, 2.0)
-	editor_undo(_undo_redo)
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 	assert_true(parts.collision.shape == null)
 	_remove_node(parts.body)
 

--- a/test_project/tests/test_resource.gd
+++ b/test_project/tests/test_resource.gd
@@ -266,9 +266,9 @@ func test_create_resource_undo_restores_previous_value() -> void:
 	})
 	assert_has_key(result, "data")
 	assert_true(mi.mesh is SphereMesh)
-	editor_undo(_undo_redo)
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 	assert_eq(mi.mesh, old_mesh, "Undo should restore the previous mesh value")
-	editor_redo(_undo_redo)
+	assert_true(editor_redo(_undo_redo), "redo should succeed")
 	assert_true(mi.mesh is SphereMesh, "Redo should re-apply the SphereMesh")
 	_remove_node(mi)
 
@@ -458,8 +458,8 @@ func test_create_resource_undo_survives_interleaving() -> void:
 	_undo_redo.commit_action()
 	# Undo the interleaved action first, then the original — mesh should
 	# still revert cleanly.
-	editor_undo(_undo_redo)  # undo rename
-	editor_undo(_undo_redo)  # undo mesh assign
+	assert_true(editor_undo(_undo_redo), "undo rename should succeed")
+	assert_true(editor_undo(_undo_redo), "undo mesh assign should succeed")
 	assert_true(mi.mesh == null or not (mi.mesh is BoxMesh), "Undo should have removed the BoxMesh")
 	_remove_node(mi)
 

--- a/test_project/tests/test_texture.gd
+++ b/test_project/tests/test_texture.gd
@@ -150,7 +150,7 @@ func test_gradient_assigns_typed_gradient_and_colors() -> void:
 	assert_eq(g.colors[0].r, 1.0)
 	assert_eq(g.colors[1].b, 1.0)
 	assert_eq(s.texture.fill, GradientTexture2D.FILL_RADIAL)
-	editor_undo(_undo_redo)
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 	assert_true(s.texture == null)
 	_remove_node(s)
 
@@ -208,7 +208,7 @@ func test_noise_assigns_typed_chain() -> void:
 	assert_eq(n.noise_type, FastNoiseLite.TYPE_PERLIN)
 	assert_eq(n.seed, 7)
 	assert_eq(n.fractal_octaves, 3)
-	editor_undo(_undo_redo)
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 	assert_true(s.texture == null)
 	_remove_node(s)
 


### PR DESCRIPTION
## Triage note

Before picking work I walked every open issue and every entry in `friction_log.md`:

- **Every open issue already has at least one competing open PR** (#140 → #151, #143 → #145/#152, #144 → #147/#149/#153, #146 → #148/#150). #129 is explicitly deferred by its author ("Out-of-scope for v1.2.3 release"). No unclaimed bundle among the open issues.
- The friction log's only non-FIXED entry is the `--reload` uvicorn worktree-src note, which `script/serve-this-worktree` already addresses.

Looking back at recently closed work, **issue #114 ("Audit tests and CI scripts for silent-failure / masking patterns")** was closed by PR #142 — but #142 only swept the silent-`return` pattern (one of several listed in #114). The checklist item

> Tests that depend on `editor_undo()` / `editor_redo()` without asserting the helper returned `true`.

was not swept. I ran a hygiene survey of the 28 GDScript test files and found **17 unchecked `editor_undo`/`editor_redo` calls**, 13 of which are load-bearing (immediately followed by an assertion on post-undo state — the silent-no-op case that #114 called out). That's the bundle shipped here.

## Summary

Wraps 13 load-bearing `editor_undo(_undo_redo)` / `editor_redo(_undo_redo)` calls across 6 test files in `assert_true(..., "...")`, matching the reference pattern already in use at `test_project/tests/test_camera.gd:214-215`. If the helper silently no-ops, the test now fails loudly instead of passing coincidentally.

Cleanup-only undo calls (no post-undo assertion to protect) in `test_node.gd:250-251, 282-285, 553` are intentionally **not** wrapped — per CLAUDE.md the rule is scoped to "tests that assert post-undo state".

Changed files and sites:

| file | lines |
|------|-------|
| `test_curve.gd` | 128 (undo), 240 (undo), 243 (redo) |
| `test_environment.gd` | 167 (undo), 169 (redo) |
| `test_node.gd` | 497 (undo) |
| `test_physics_shape.gd` | 132 (undo) |
| `test_resource.gd` | 269 (undo), 271 (redo), 461 (interleaved undo), 462 (interleaved undo) |
| `test_texture.gd` | 153 (undo), 211 (undo) |

## Simplify + Review pass

Three parallel reuse/quality/efficiency reviewers were run on the diff. Findings applied:

- Two over-generic messages tightened for grep-ability on failure: `test_curve.gd:240/243` → `"curve point_count undo/redo should succeed"`; `test_node.gd:497` → `"mesh undo should succeed"`.
- No shared `assert_undo_succeeded` helper added — at 13 sites the 1-line inline form is clearer than introducing a wrapper that would obscure the existing `editor_undo` return-value contract.
- Efficiency reviewer confirmed wrapping in `assert_true(...)` is semantically identical: GDScript evaluates args before the call, so the undo always runs regardless of `_failed` state.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `pytest -q` — **536 passed** (no Python code changed; sanity check)
- [ ] **GDScript `test_run` — cannot run in this sandbox** (no Godot binary available). The diff is mechanical enough (assert_true wrap, no logic change) that CI's chickensoft-games/setup-godot matrix on Linux/macOS/Windows will exercise it.
- [ ] **Live smoke — cannot run in this sandbox** (no Godot binary). A reviewer with a running editor can confirm `test_run` in the session is green on this branch; the expected outcome is no change in pass count (these tests were already green; the assertions just tighten what "green" means).

## Risk

Low. No production code touched. Worst case: a previously-green test silently relying on a no-op undo now fails loudly — that's the intended signal.

https://claude.ai/code/session_0114vcEpmoWjanz2pYw4SRac