### PR TITLE
feat: surface install mode in dock (dev checkout vs release)

### DIFF
--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -107,6 +107,64 @@ static func is_dev_checkout() -> bool:
 	return not _find_venv_python().is_empty()
 
 
+## Human-readable install-mode summary for the dock UI.
+##
+## The dock surfaces this so users can tell at a glance whether their plugin
+## is a dev checkout (updates via `git pull`) or a regular install (updates
+## via the in-dock banner against the latest GitHub Release). See #144 —
+## before this, a README `git clone + cp -r` user had no way to know that
+## pressing the yellow Update button would silently downgrade them to the
+## last tagged release.
+##
+## Returns a Dictionary with:
+##   - label (String): one-line text for the dock row
+##   - tooltip (String): longer hover text explaining the update path
+##   - is_dev (bool): mirrors is_dev_checkout() — exposed so callers don't
+##     have to call both methods
+##   - symlink_target (String): resolved target of `addons/godot_ai` when it's
+##     a symlink (empty otherwise). Helps contributors working across
+##     worktrees confirm which `plugin/` tree Godot is using.
+static func describe_install_mode() -> Dictionary:
+	var is_dev := is_dev_checkout()
+	var version := get_plugin_version()
+	if is_dev:
+		var symlink_target := _resolve_addon_symlink()
+		var tooltip := "Plugin is a dev checkout — update via `git pull` in the source tree."
+		if not symlink_target.is_empty():
+			tooltip += "\nSymlinked to: %s" % symlink_target
+		return {
+			"label": "Install: dev checkout — update via git pull",
+			"tooltip": tooltip,
+			"is_dev": true,
+			"symlink_target": symlink_target,
+		}
+	return {
+		"label": "Install: v%s" % version,
+		"tooltip": "Plugin installed from a release (ZIP or Asset Library). Updates via the in-dock banner.",
+		"is_dev": false,
+		"symlink_target": "",
+	}
+
+
+## Resolve `res://addons/godot_ai` through any symlink to its real target.
+## Returns "" on Windows (no POSIX readlink) or when the path isn't a symlink.
+static func _resolve_addon_symlink() -> String:
+	if OS.get_name() == "Windows":
+		return ""
+	var addon_path := ProjectSettings.globalize_path("res://addons/godot_ai").rstrip("/")
+	var output: Array = []
+	# `readlink -f` resolves the full chain; works on Linux (GNU) and modern
+	# macOS (BSD readlink supports -f since 10.13). If it fails, we return "".
+	if OS.execute("readlink", ["-f", addon_path], output, true) != 0:
+		return ""
+	if output.is_empty():
+		return ""
+	var resolved: String = String(output[0]).strip_edges()
+	if resolved.is_empty() or resolved == addon_path:
+		return ""
+	return resolved
+
+
 static func get_server_command() -> Array[String]:
 	var venv_python := _cached_venv_python()
 	if not venv_python.is_empty():

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -16,6 +16,7 @@ var _plugin: EditorPlugin
 var _redock_btn: Button
 var _status_icon: ColorRect
 var _status_label: Label
+var _install_label: Label
 var _client_grid: VBoxContainer
 var _client_configure_all_btn: Button
 var _clients_summary_label: Label
@@ -145,6 +146,19 @@ func _build_ui() -> void:
 	status_row.add_child(_redock_btn)
 
 	add_child(status_row)
+
+	# --- Install mode row (always visible, tells users how updates work) ---
+	# See #144: README `git clone + cp -r` users had no way to tell their install
+	# from a dev checkout, so pressing the yellow Update banner could silently
+	# downgrade them to the last tagged release. Surfacing mode+version lets
+	# them self-diagnose before acting.
+	_install_label = Label.new()
+	_install_label.add_theme_color_override("font_color", COLOR_MUTED)
+	_install_label.add_theme_font_size_override("font_size", 11)
+	_install_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_install_label.mouse_filter = Control.MOUSE_FILTER_PASS
+	_refresh_install_label()
+	add_child(_install_label)
 
 	# --- Update banner (top of dock, hidden until check finds a newer version) ---
 	_update_banner = VBoxContainer.new()
@@ -691,6 +705,14 @@ func _apply_row_status(client_id: String, status: McpClient.Status, error_msg: S
 			configure_btn.text = "Retry"
 			remove_btn.visible = false
 			name_label.text = "%s — %s" % [base_name, error_msg] if not error_msg.is_empty() else base_name
+
+
+# --- Install mode ---
+
+func _refresh_install_label() -> void:
+	var info := McpClientConfigurator.describe_install_mode()
+	_install_label.text = info["label"]
+	_install_label.tooltip_text = info["tooltip"]
 
 
 # --- Update check & self-update ---

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -114,6 +114,57 @@ func test_uvx_server_command_uses_exact_pin_not_tilde() -> void:
 		assert_true(has_exact_pin, "uvx tier command should contain godot-ai==<plugin_version>; got %s" % str(cmd))
 
 
+# ----- install mode description (#144) -----
+
+
+func test_describe_install_mode_returns_required_keys() -> void:
+	var info := McpClientConfigurator.describe_install_mode()
+	for key in ["label", "tooltip", "is_dev", "symlink_target"]:
+		assert_has_key(info, key, "describe_install_mode() missing key: %s" % key)
+	assert_true(info.get("label", "") is String and not info["label"].is_empty(), "label must be non-empty String")
+	assert_true(info.get("tooltip", "") is String and not info["tooltip"].is_empty(), "tooltip must be non-empty String")
+	assert_true(info.get("is_dev") is bool, "is_dev must be bool")
+	assert_true(info.get("symlink_target") is String, "symlink_target must be String (may be empty)")
+
+
+func test_describe_install_mode_agrees_with_is_dev_checkout() -> void:
+	## Guard against the two accessors drifting — describe_install_mode is the
+	## dock-facing summary and MUST derive its is_dev flag from the same
+	## predicate the update-check path uses, or the dock would claim "dev
+	## checkout" for a user who still gets the downgrade-Update banner.
+	var info := McpClientConfigurator.describe_install_mode()
+	assert_eq(info.get("is_dev"), McpClientConfigurator.is_dev_checkout(), "is_dev must match is_dev_checkout()")
+
+
+func test_describe_install_mode_label_reflects_mode() -> void:
+	var info := McpClientConfigurator.describe_install_mode()
+	var label: String = info.get("label", "")
+	if info.get("is_dev"):
+		assert_contains(label, "dev checkout", "dev-mode label should say 'dev checkout' (got %s)" % label)
+		assert_contains(label, "git pull", "dev-mode label should mention git pull (got %s)" % label)
+	else:
+		var ver := McpClientConfigurator.get_plugin_version()
+		assert_contains(label, "v%s" % ver, "release-mode label should embed the plugin version (got %s)" % label)
+
+
+func test_describe_install_mode_symlink_target_consistent() -> void:
+	## Non-dev installs never set symlink_target. Dev-mode may or may not
+	## depending on whether the addon path is a real symlink in this env
+	## (CI may copy the addon instead of symlinking). Assert the envelope:
+	## - non-dev => symlink_target is empty
+	## - dev + non-empty => path exists and is absolute
+	var info := McpClientConfigurator.describe_install_mode()
+	var target: String = info.get("symlink_target", "")
+	if not info.get("is_dev"):
+		assert_true(target.is_empty(), "release installs must not expose symlink_target (got %s)" % target)
+		return
+	if target.is_empty():
+		skip("no symlink in this dev-mode environment (addon path may be a plain copy)")
+		return
+	assert_true(target.begins_with("/") or target.substr(1, 1) == ":", "symlink_target should be absolute (got %s)" % target)
+	assert_true(DirAccess.dir_exists_absolute(target) or FileAccess.file_exists(target), "symlink_target should exist on disk: %s" % target)
+
+
 # ----- path template -----
 
 func test_path_template_expands_home() -> void:


### PR DESCRIPTION
## Summary

Closes #144.

Adds an always-visible "Install: …" row under the connection status in the MCP dock so users can tell at a glance whether their plugin is a dev checkout or a release install. Before this, a README `git clone + cp -r` user had no way to tell the modes apart and could silently downgrade themselves by pressing the yellow Update banner — the ZIP overwrite rolls back any `main`-era changes past the last tagged release.

**What the dock now shows:**

- **Release install**: `Install: v1.2.8` (hover tooltip: "Plugin installed from a release (ZIP or Asset Library). Updates via the in-dock banner.")
- **Dev checkout**: `Install: dev checkout — update via git pull` (hover tooltip includes the resolved symlink target when `addons/godot_ai` is a symlink — useful for contributors juggling worktrees per the CLAUDE.md gotcha).

## Design

- `McpClientConfigurator.describe_install_mode()` is the single public accessor. Returns `{label, tooltip, is_dev, symlink_target}` as a Dictionary — mirrors the existing dict-envelope convention the module already uses (e.g. `configure(...)` returns `{status, message}`).
- `is_dev` is derived from the existing `is_dev_checkout()` predicate so it cannot drift from the condition `_check_for_updates()` uses to skip the Update banner — a unit test locks the two together.
- Symlink resolution shells out to `readlink -f` (Windows returns empty; BSD readlink on macOS 10.13+ supports `-f`). Called once at dock build in `_build_ui`; no hot-path implications.

## Test plan

- [x] `ruff check src/ tests/` passes
- [x] `pytest` — all 536 Python tests pass locally
- [x] New GDScript tests in `test_project/tests/test_clients.gd` cover: required-key presence, `is_dev` ↔ `is_dev_checkout()` agreement (regression guard), per-mode label shape, and `symlink_target` envelope invariants
- [ ] **Live editor smoke test not run** — the Linux sandbox this PR was authored from has no Godot binary. Needs a reviewer to open `test_project/` in Godot and visually confirm:
  - Dock shows an "Install: …" row under the status icon on first paint
  - Dev-checkout installs read `Install: dev checkout — update via git pull`, tooltip includes the symlink target
  - Release installs read `Install: v<version>`, tooltip mentions the in-dock banner
  - `test_run` on the `clients` suite passes

## Risks

- **Low**: if `plugin.cfg` is hand-edited while the dock is open, the label goes stale. Not practical — plugin reload rebuilds the dock.
- **Low**: `readlink -f` subprocess fires once per `_build_ui`. On heavy-AV systems the spawn could block briefly; on failure the label still renders (degrades the tooltip only).

https://claude.ai/code/session_01P8bjqwZpPYtBPJUgwY1Mnc