### PR TITLE
feat(dock): surface install mode so users know how updates work

### DIFF
--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -107,6 +107,17 @@ static func is_dev_checkout() -> bool:
 	return not _find_venv_python().is_empty()
 
 
+## Single-line install-mode description for the dock footer.
+## Mirrors `is_dev_checkout()` so users can self-diagnose why the update
+## banner is or isn't appearing: dev checkouts skip the GitHub check in
+## `_check_for_updates`, everyone else sees the banner when a newer release
+## tag is published. See #144.
+static func get_install_mode_label() -> String:
+	if is_dev_checkout():
+		return "Install: dev checkout — update via git pull"
+	return "Install: v%s" % get_plugin_version()
+
+
 static func get_server_command() -> Array[String]:
 	var venv_python := _cached_venv_python()
 	if not venv_python.is_empty():

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -282,6 +282,14 @@ func _build_ui() -> void:
 
 	add_child(HSeparator.new())
 
+	# Surfaces the result of `is_dev_checkout()` so users can self-diagnose
+	# why the update banner is or isn't appearing. See #144.
+	var install_label := Label.new()
+	install_label.text = McpClientConfigurator.get_install_mode_label()
+	install_label.add_theme_color_override("font_color", COLOR_MUTED)
+	install_label.add_theme_font_size_override("font_size", 11)
+	add_child(install_label)
+
 	# --- Dev mode toggle (always visible) ---
 	var dev_toggle_row := HBoxContainer.new()
 	var dev_toggle_label := Label.new()

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -90,6 +90,20 @@ func test_server_launch_mode_agrees_with_get_server_command() -> void:
 		assert_true(mode != "unknown", "Non-empty command must map to a concrete mode, got %s" % mode)
 
 
+func test_install_mode_label_agrees_with_is_dev_checkout() -> void:
+	## The dock footer surfaces `is_dev_checkout()` so users can self-diagnose
+	## why the update banner is or isn't appearing. Dev checkouts must say so
+	## plainly; everyone else gets the pinned version. See #144.
+	var label := McpClientConfigurator.get_install_mode_label()
+	assert_false(label.is_empty(), "install-mode label must not be empty")
+	if McpClientConfigurator.is_dev_checkout():
+		assert_contains(label, "dev checkout", "dev checkout should be surfaced in label: %s" % label)
+		assert_contains(label, "git pull", "dev checkout label should hint at git pull: %s" % label)
+	else:
+		var version := McpClientConfigurator.get_plugin_version()
+		assert_contains(label, version, "release install label should contain plugin version %s; got %s" % [version, label])
+
+
 func test_uvx_server_command_uses_exact_pin_not_tilde() -> void:
 	## Regression guard for #133: the uvx branch of get_server_command must
 	## pin godot-ai with `==<version>`, not `~=<minor>`. With the tilde


### PR DESCRIPTION
## Summary

Adds a muted always-visible footer line to the dock showing install mode:

- `Install: dev checkout — update via git pull` when `is_dev_checkout()` is true
- `Install: v<version>` otherwise

Mirrors the existing `is_dev_checkout()` check that already gates `_check_for_updates()` (`mcp_dock.gd:698-706`), so users can self-diagnose why the update banner does or doesn't appear — instead of wondering whether their install is a dev checkout, a README-style `cp -r` from `main`, or a release ZIP.

Closes #144.

## Scope

Stays tight to the issue's primary ask. The optional "symlink target path" bonus is intentionally deferred — it's marked optional in the issue, and a one-line derived label keeps this PR minimal and bisect-friendly.

## Changes

- `plugin/addons/godot_ai/client_configurator.gd` — new `get_install_mode_label()` static helper, derived from `is_dev_checkout()` + `get_plugin_version()` (no new state).
- `plugin/addons/godot_ai/mcp_dock.gd` — add a muted `Label` above the "Developer mode" toggle row in `_build_ui()`. Local var, not a member — set once at dock build, never read again.
- `test_project/tests/test_clients.gd` — unit test asserts label shape in both dev-venv and release tiers (mirrors the pattern of the existing `test_server_launch_mode_*` tests).

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `pytest -v` — 538 passed
- [ ] `test_run` in live Godot (I could not run this in the sandbox — no Godot binary available locally; CI will cover the GDScript suite)
- [ ] Live smoke: visual check that the footer appears in the dock for both a dev checkout and a release install, with the expected copy

https://claude.ai/code/session_01A5oN6Jo4g3pGQF9CYDU4cg