### PR TITLE
feat(dock): surface install mode (dev checkout vs release) (#144)

### DIFF
--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -107,6 +107,52 @@ static func is_dev_checkout() -> bool:
 	return not _find_venv_python().is_empty()
 
 
+## Describes how the running plugin was installed. Powers the dock's
+## "Install: …" status line so users can self-diagnose why the Update
+## banner appears (or doesn't), and contributors across worktrees can
+## confirm which `plugin/` tree Godot is actually loading. See #144.
+##
+## Returns: {
+##   "is_dev": bool,           # true when a sibling .venv was found
+##   "version": String,        # from plugin.cfg, e.g. "1.2.8"
+##   "plugin_path": String,    # globalized res://addons/godot_ai path
+##   "resolved_path": String,  # symlink target when different, else ""
+## }
+static func get_install_info() -> Dictionary:
+	var plugin_path := ProjectSettings.globalize_path("res://addons/godot_ai").rstrip("/")
+	var resolved := _resolve_symlink(plugin_path)
+	return {
+		"is_dev": is_dev_checkout(),
+		"version": get_plugin_version(),
+		"plugin_path": plugin_path,
+		"resolved_path": resolved if resolved != plugin_path else "",
+	}
+
+
+## Best-effort symlink resolution. Returns the input path unchanged if the
+## OS tool isn't available or the path isn't a symlink.
+static func _resolve_symlink(path: String) -> String:
+	if path.is_empty():
+		return path
+	var output: Array = []
+	var exit_code: int
+	if OS.get_name() == "Windows":
+		# PowerShell's Get-Item exposes .Target for reparse points; absent on
+		# plain directories. Quote the path to survive spaces.
+		exit_code = OS.execute(
+			"powershell",
+			["-NoProfile", "-Command", "(Get-Item -LiteralPath '%s').Target" % path.replace("'", "''")],
+			output,
+			true,
+		)
+	else:
+		exit_code = OS.execute("readlink", ["-f", path], output, true)
+	if exit_code != 0 or output.is_empty():
+		return path
+	var resolved: String = output[0].strip_edges()
+	return resolved if not resolved.is_empty() else path
+
+
 static func get_server_command() -> Array[String]:
 	var venv_python := _cached_venv_python()
 	if not venv_python.is_empty():

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -16,6 +16,7 @@ var _plugin: EditorPlugin
 var _redock_btn: Button
 var _status_icon: ColorRect
 var _status_label: Label
+var _install_label: Label
 var _client_grid: VBoxContainer
 var _client_configure_all_btn: Button
 var _clients_summary_label: Label
@@ -145,6 +146,16 @@ func _build_ui() -> void:
 	status_row.add_child(_redock_btn)
 
 	add_child(status_row)
+
+	# Install-mode line: tells users whether they're on a tagged release
+	# (Update banner applies) or a dev checkout (updates via git pull).
+	# Surfaces info that otherwise only appears in the dev-mode Setup
+	# section. See #144.
+	_install_label = Label.new()
+	_install_label.add_theme_color_override("font_color", COLOR_MUTED)
+	_install_label.add_theme_font_size_override("font_size", 11)
+	_refresh_install_label()
+	add_child(_install_label)
 
 	# --- Update banner (top of dock, hidden until check finds a newer version) ---
 	_update_banner = VBoxContainer.new()
@@ -427,6 +438,20 @@ func _update_status() -> void:
 	_status_label.text = status_text
 
 	_update_dev_server_btn()
+
+
+func _refresh_install_label() -> void:
+	if _install_label == null:
+		return
+	var info := McpClientConfigurator.get_install_info()
+	if info.get("is_dev", false):
+		_install_label.text = "Install: dev checkout — update via git pull"
+		var resolved: String = info.get("resolved_path", "")
+		var path: String = resolved if not resolved.is_empty() else info.get("plugin_path", "")
+		_install_label.tooltip_text = "Plugin source: %s" % path
+	else:
+		_install_label.text = "Install: v%s" % info.get("version", "?")
+		_install_label.tooltip_text = "Use the Update banner to upgrade to the latest GitHub Release"
 
 
 func _update_log() -> void:

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -90,6 +90,23 @@ func test_server_launch_mode_agrees_with_get_server_command() -> void:
 		assert_true(mode != "unknown", "Non-empty command must map to a concrete mode, got %s" % mode)
 
 
+func test_get_install_info_shape_and_dev_checkout_agreement() -> void:
+	## `get_install_info()` powers the dock's "Install: …" status line (#144).
+	## Must always return the full shape so the dock can render a line without
+	## special-casing None. `is_dev` field must agree with the existing
+	## `is_dev_checkout()` predicate so both callers see the same view of
+	## the world.
+	var info := McpClientConfigurator.get_install_info()
+	for key in ["is_dev", "version", "plugin_path", "resolved_path"]:
+		assert_has_key(info, key)
+	assert_eq(typeof(info["is_dev"]), TYPE_BOOL)
+	assert_eq(info["is_dev"], McpClientConfigurator.is_dev_checkout(),
+		"is_dev must match is_dev_checkout()")
+	assert_true((info["version"] as String).length() >= 1, "version must be non-empty")
+	assert_true((info["plugin_path"] as String).ends_with("addons/godot_ai"),
+		"plugin_path should point at addons/godot_ai, got %s" % info["plugin_path"])
+
+
 func test_uvx_server_command_uses_exact_pin_not_tilde() -> void:
 	## Regression guard for #133: the uvx branch of get_server_command must
 	## pin godot-ai with `==<version>`, not `~=<minor>`. With the tilde


### PR DESCRIPTION
## Summary

- Adds a single-line `Install: …` label at the top of the MCP dock so every user (dev checkout, release install, `cp -r` install) can see how their plugin was installed — addresses [#144](https://github.com/hi-godot/godot-ai/issues/144).
- Dev contributors see `Install: dev checkout — update via git pull` with a tooltip showing the resolved symlink target so they can confirm which `plugin/` tree Godot is actually loading. Release users see `Install: v<version>` matching `plugin.cfg`.
- New `McpClientConfigurator.get_install_info()` helper centralises the detection logic; the existing `is_dev_checkout()` predicate is the source of truth for the `is_dev` field.

## Why

Today `_check_for_updates()` early-returns in dev checkouts so the yellow banner never shows, while `cp -r` users see the banner and can be silently downgraded from `main` to the last tagged release. Neither user has a way to self-diagnose — this surfaces the info already used by the update path.

## Test plan

- [x] `pytest -v` — 536/536 pass
- [x] `test_run` via MCP against live Godot editor — 706/706 GDScript tests pass (includes new `test_get_install_info_shape_and_dev_checkout_agreement`)
- [x] `ruff check src/ tests/` — clean
- [x] Live smoke: plugin reloaded against a running editor, dock renders `Install: dev checkout — update via git pull` with tooltip pointing at `/Users/davidsarno/godot-ai/plugin/addons/godot_ai`

Closes #144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
