### PR TITLE
fix: deterministic server PID tracking via pid-file + Windows netstat parser

### DIFF
--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -10,6 +10,14 @@ const GAME_HELPER_AUTOLOAD_PATH := "res://addons/godot_ai/runtime/game_helper.gd
 const MANAGED_SERVER_PID_SETTING := "godot_ai/managed_server_pid"
 const MANAGED_SERVER_VERSION_SETTING := "godot_ai/managed_server_version"
 
+## The Python server writes its own PID here on startup (passed as
+## `--pid-file`) and unlinks on clean exit. Deterministic replacement
+## for scraping `netstat -ano` to find the port owner — especially on
+## Windows where `OS.kill` on the uvx launcher doesn't take the Python
+## child with it, and the scrape was the only path to the real PID.
+## See issue for #154-era Windows update friction.
+const SERVER_PID_FILE := "user://godot_ai_server.pid"
+
 var _connection: Connection
 var _dispatcher: McpDispatcher
 var _log_buffer: McpLogBuffer
@@ -305,7 +313,7 @@ func _start_server() -> void:
 			## at some point. Adopt the live port owner, ignoring any stale
 			## launcher PID that may still be in the record. Self-heal the
 			## record so next session's adopt can fast-path.
-			var owner := _find_pid_on_port(port)
+			var owner := _find_managed_pid(port)
 			if owner > 0:
 				_server_pid = owner
 				_write_managed_server_record(owner, current_version)
@@ -318,10 +326,11 @@ func _start_server() -> void:
 			## to match the current plugin version.
 			print("MCP | managed server v%s does not match plugin v%s, restarting"
 				% [record.version, current_version])
-			var owner := _find_pid_on_port(port)
+			var owner := _find_managed_pid(port)
 			if owner > 0:
 				OS.kill(owner)
 			_clear_managed_server_record()
+			_clear_pid_file()
 			_wait_for_port_free(port, 3.0)
 			## Fall through to spawn.
 		else:
@@ -340,7 +349,16 @@ func _start_server() -> void:
 	var cmd: String = server_cmd[0]
 	var args: Array[String] = []
 	args.assign(server_cmd.slice(1))
-	args.append_array(["--transport", "streamable-http", "--port", str(port)])
+	args.append_array([
+		"--transport", "streamable-http",
+		"--port", str(port),
+		"--pid-file", ProjectSettings.globalize_path(SERVER_PID_FILE),
+	])
+
+	## Wipe any stale pid-file before spawning so a failed launch can't
+	## leave last session's PID sitting there for _find_managed_pid to
+	## read and act on.
+	_clear_pid_file()
 
 	_server_pid = OS.create_process(cmd, args)
 	if _server_pid > 0:
@@ -360,7 +378,7 @@ func _is_port_in_use(port: int) -> bool:
 	if OS.get_name() == "Windows":
 		var exit_code := OS.execute("netstat", ["-ano"], output, true)
 		if exit_code == 0 and output.size() > 0:
-			return output[0].find(":%d " % port) >= 0 and output[0].find("LISTENING") >= 0
+			return _parse_windows_netstat_listening(str(output[0]), port)
 	else:
 		var exit_code := OS.execute("lsof", ["-ti:%d" % port, "-sTCP:LISTEN"], output, true)
 		return exit_code == 0 and output.size() > 0 and not output[0].strip_edges().is_empty()
@@ -368,26 +386,23 @@ func _is_port_in_use(port: int) -> bool:
 
 
 ## Return the PID currently listening on the given TCP port, or 0 if
-## the port is free. Used by the adopt and stop paths to recover the
-## real server PID when we can't trust _server_pid (e.g. uvx launcher
-## that has exited after spawning its child). See #137.
+## the port is free. Netstat/lsof fallback; callers should prefer
+## `_find_managed_pid` which consults the Python-written pid-file first.
+##
+## Use when the pid-file is missing (pre-#154 server, or the server was
+## SIGKILL'd before writing it) to recover the port owner. On Windows
+## this parses `netstat -ano` line-by-line — Godot's `OS.execute` pushes
+## the whole stdout into `output[0]` as a single string, so an earlier
+## implementation that iterated `output` as if each element were a line
+## returned a garbage PID (the last whitespace-separated token in the
+## entire dump). See parser tests in tests/test_netstat_parser.gd.
 func _find_pid_on_port(port: int) -> int:
 	var output: Array = []
 	if OS.get_name() == "Windows":
-		## netstat prints lines like:
-		##   TCP    0.0.0.0:8000    0.0.0.0:0    LISTENING    57865
 		var exit_code := OS.execute("netstat", ["-ano"], output, true)
 		if exit_code != 0 or output.is_empty():
 			return 0
-		for line in output:
-			var s := str(line)
-			if s.find(":%d " % port) >= 0 and s.find("LISTENING") >= 0:
-				var parts := s.split(" ", false)
-				if parts.size() > 0:
-					var pid := parts[parts.size() - 1].strip_edges()
-					if pid.is_valid_int():
-						return int(pid)
-		return 0
+		return _parse_windows_netstat_pid(str(output[0]), port)
 	## POSIX: `lsof -ti:<port> -sTCP:LISTEN` returns only the PID.
 	var exit_code := OS.execute("lsof", ["-ti:%d" % port, "-sTCP:LISTEN"], output, true)
 	if exit_code != 0 or output.is_empty():
@@ -398,31 +413,127 @@ func _find_pid_on_port(port: int) -> int:
 	return int(pid_str)
 
 
+## Find the managed server PID deterministically: prefer the pid-file
+## the Python server writes on startup (see runtime_info.py), fall back
+## to scraping `netstat -ano` / `lsof` only when the file is missing or
+## stale. This is the replacement for raw port-scraping: on Windows the
+## uvx launcher PID doesn't cover the Python child, and netstat parsing
+## is fragile.
+##
+## Returns 0 when no server can be identified.
+func _find_managed_pid(port: int) -> int:
+	var pid := _read_pid_file()
+	if pid > 0 and _pid_alive(pid):
+		return pid
+	return _find_pid_on_port(port)
+
+
+## Parse the LISTENING line for `port` in a Windows `netstat -ano`
+## dump and return its PID, or 0 if no matching line is found.
+##
+## netstat prints rows like:
+##   TCP    0.0.0.0:8000    0.0.0.0:0    LISTENING    57865
+## (whitespace-separated, possibly with leading whitespace). Only rows
+## whose local address ends with `:<port>` AND state is `LISTENING`
+## qualify — substring-matching `:<port> ` against the whole dump was
+## the earlier bug; a remote address happening to include `:8000` would
+## false-positive.
+static func _parse_windows_netstat_pid(stdout: String, port: int) -> int:
+	var port_suffix := ":%d" % port
+	for line in stdout.split("\n"):
+		var s := line.strip_edges()
+		if s.is_empty():
+			continue
+		var fields := _split_on_whitespace(s)
+		## Minimum columns: proto, local, remote, state, pid
+		if fields.size() < 5:
+			continue
+		if fields[3] != "LISTENING":
+			continue
+		if not fields[1].ends_with(port_suffix):
+			continue
+		var pid_str := fields[fields.size() - 1]
+		if pid_str.is_valid_int():
+			return int(pid_str)
+	return 0
+
+
+## True if any row in a Windows `netstat -ano` dump is a LISTENING
+## entry for `port`. See `_parse_windows_netstat_pid` for the row
+## schema and why substring-matching the whole dump is wrong.
+static func _parse_windows_netstat_listening(stdout: String, port: int) -> bool:
+	return _parse_windows_netstat_pid(stdout, port) > 0
+
+
+static func _split_on_whitespace(s: String) -> PackedStringArray:
+	## `String.split(" ", false)` only splits on single spaces; netstat
+	## columns are separated by runs of spaces (and sometimes tabs).
+	## Collapse whitespace manually so PID-column extraction is robust.
+	var out: PackedStringArray = []
+	var cur := ""
+	for i in s.length():
+		var c := s.substr(i, 1)
+		if c == " " or c == "\t":
+			if not cur.is_empty():
+				out.append(cur)
+				cur = ""
+		else:
+			cur += c
+	if not cur.is_empty():
+		out.append(cur)
+	return out
+
+
+## Read the integer PID from SERVER_PID_FILE, or 0 if the file is
+## missing/empty/malformed. The file is written by the Python server
+## at startup (see --pid-file flag, plumbed in _start_server).
+static func _read_pid_file() -> int:
+	if not FileAccess.file_exists(SERVER_PID_FILE):
+		return 0
+	var f := FileAccess.open(SERVER_PID_FILE, FileAccess.READ)
+	if f == null:
+		return 0
+	var content := f.get_as_text().strip_edges()
+	f.close()
+	if content.is_empty() or not content.is_valid_int():
+		return 0
+	var pid := int(content)
+	return pid if pid > 0 else 0
+
+
+static func _clear_pid_file() -> void:
+	if FileAccess.file_exists(SERVER_PID_FILE):
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(SERVER_PID_FILE))
+
+
 func _stop_server() -> void:
 	if _server_pid <= 0:
 		return
-	## Kill both the process we tracked and the current port owner, if
-	## different. For direct-spawn tiers (.venv, system CLI) these are the
-	## same and we kill once. For the uvx tier the tracked PID is the
-	## launcher — which may be dead (adopted), still installing (about to
-	## spawn), or done spawning; killing both the launcher (if alive) and
-	## the port owner (if any) covers all three cases without races. See
-	## #137.
+	## Kill both the process we tracked and the real Python PID if they
+	## differ. For direct-spawn tiers (.venv, system CLI) these match
+	## and we kill once. For the uvx tier `_server_pid` is the launcher
+	## — may be dead (adopted), still installing, or done spawning; on
+	## Windows, `OS.kill` is `TerminateProcess` and does NOT walk the
+	## child tree, so without an independent read of the real PID the
+	## Python child survives and port 8000 stays held. `_find_managed_pid`
+	## reads the pid-file the server wrote at startup (deterministic),
+	## falling back to netstat/lsof if the file is missing.
+	var port := McpClientConfigurator.SERVER_HTTP_PORT
 	var killed: Array[int] = []
 	if _pid_alive(_server_pid):
 		OS.kill(_server_pid)
 		killed.append(_server_pid)
-	if _is_port_in_use(McpClientConfigurator.SERVER_HTTP_PORT):
-		var owner := _find_pid_on_port(McpClientConfigurator.SERVER_HTTP_PORT)
-		if owner > 0 and not killed.has(owner):
-			OS.kill(owner)
-			killed.append(owner)
+	var real_pid := _find_managed_pid(port)
+	if real_pid > 0 and not killed.has(real_pid):
+		OS.kill(real_pid)
+		killed.append(real_pid)
 	if not killed.is_empty():
 		print("MCP | stopped server (PID %s)" % str(killed))
 	_server_pid = -1
 	_clear_managed_server_record()
+	_clear_pid_file()
 	## Brief wait so a follow-up spawn doesn't race a still-closing socket.
-	_wait_for_port_free(McpClientConfigurator.SERVER_HTTP_PORT, 2.0)
+	_wait_for_port_free(port, 2.0)
 
 
 ## True if the given PID corresponds to a live process. Uses POSIX `kill -0`

--- a/src/godot_ai/__init__.py
+++ b/src/godot_ai/__init__.py
@@ -63,7 +63,20 @@ def main(argv: Sequence[str] | None = None) -> None:
         action="store_true",
         help="Auto-restart on source changes (dev mode, HTTP transports only)",
     )
+    parser.add_argument(
+        "--pid-file",
+        default=None,
+        help=(
+            "Write this process's PID to the given path on startup, unlink on "
+            "clean exit. The Godot plugin uses this to kill the real server "
+            "process when a launcher (uvx) PID would be unreliable."
+        ),
+    )
     args = parser.parse_args(argv)
+
+    from godot_ai.runtime_info import install_pid_file
+
+    install_pid_file(args.pid_file)
 
     if args.reload and args.transport in ("sse", "streamable-http"):
         from godot_ai.asgi import run_with_reload

--- a/src/godot_ai/runtime_info.py
+++ b/src/godot_ai/runtime_info.py
@@ -1,0 +1,48 @@
+"""Write the server's runtime PID to a file so the Godot plugin can kill
+the *real* Python process deterministically, even when a launcher (uvx,
+pipx) spawned us and its own PID is stale or untrackable.
+
+The plugin passes `--pid-file <absolute path>` and we write the integer
+PID on startup, then `atexit`-unlink on clean shutdown. On SIGTERM /
+`TerminateProcess` the file is left behind; the plugin already has the
+PID from the file and doesn't care whether we cleaned up.
+"""
+
+from __future__ import annotations
+
+import atexit
+import os
+from pathlib import Path
+
+
+def install_pid_file(path: str | os.PathLike[str] | None) -> Path | None:
+    """Write `os.getpid()` to `path` and register an atexit unlink.
+
+    Returns the resolved Path on success, None when `path` is falsy
+    (caller did not pass `--pid-file`). Any write error falls through
+    to the caller — we'd rather surface a broken install than silently
+    continue with the plugin unable to find our PID.
+    """
+    if not path:
+        return None
+
+    pid_path = Path(path).expanduser()
+    pid_path.parent.mkdir(parents=True, exist_ok=True)
+    pid_path.write_text(f"{os.getpid()}\n", encoding="utf-8")
+
+    def _cleanup() -> None:
+        ## Only unlink if the file still holds *our* PID. Prevents a
+        ## late atexit from racing a replacement server that already
+        ## overwrote the file with its own PID.
+        try:
+            current = pid_path.read_text(encoding="utf-8").strip()
+        except OSError:
+            return
+        if current == str(os.getpid()):
+            try:
+                pid_path.unlink()
+            except OSError:
+                pass
+
+    atexit.register(_cleanup)
+    return pid_path

--- a/test_project/tests/test_netstat_parser.gd
+++ b/test_project/tests/test_netstat_parser.gd
@@ -1,0 +1,184 @@
+@tool
+extends McpTestSuite
+
+## Tests for the Windows netstat parser in plugin.gd. These exercise
+## the pure-string parsers (no OS interaction) to prove the fix for
+## the bug where the parser iterated `output` as if each array element
+## were a line — but Godot's `OS.execute` pushes the whole stdout into
+## `output[0]` as a single string, so a substring match picked up
+## `:PORT` on one row and `LISTENING` on an unrelated row, and the
+## PID extractor returned the last whitespace-separated token in the
+## entire dump (garbage).
+
+const GodotAiPlugin := preload("res://addons/godot_ai/plugin.gd")
+
+
+func suite_name() -> String:
+	return "netstat_parser"
+
+
+# ----- realistic Windows netstat -ano output -----
+
+const NETSTAT_SAMPLE := """
+Active Connections
+
+  Proto  Local Address          Foreign Address        State           PID
+  TCP    0.0.0.0:135            0.0.0.0:0              LISTENING       1240
+  TCP    0.0.0.0:8000           0.0.0.0:0              LISTENING       57865
+  TCP    0.0.0.0:3389           0.0.0.0:0              LISTENING       4
+  TCP    127.0.0.1:49701        127.0.0.1:8000         ESTABLISHED     12345
+  TCP    [::]:80                [::]:0                 LISTENING       980
+  UDP    0.0.0.0:500            *:*                                    892
+"""
+
+
+func test_find_pid_returns_listening_row_for_port() -> void:
+	var pid := GodotAiPlugin._parse_windows_netstat_pid(NETSTAT_SAMPLE, 8000)
+	assert_eq(pid, 57865, "should return PID from the LISTENING row for :8000")
+
+
+func test_find_pid_ignores_established_rows_matching_port() -> void:
+	## Row 4 has :8000 in the Foreign Address column and state ESTABLISHED.
+	## Old parser matched `:8000` anywhere, new one requires the LISTENING
+	## column on the same row and the local address to end with :8000.
+	var pid := GodotAiPlugin._parse_windows_netstat_pid(NETSTAT_SAMPLE, 8000)
+	assert_true(pid != 12345, "must not return the ESTABLISHED row's PID")
+
+
+func test_find_pid_returns_zero_when_port_absent() -> void:
+	var pid := GodotAiPlugin._parse_windows_netstat_pid(NETSTAT_SAMPLE, 9999)
+	assert_eq(pid, 0, "no LISTENING row for this port -> 0")
+
+
+func test_find_pid_on_empty_output() -> void:
+	assert_eq(GodotAiPlugin._parse_windows_netstat_pid("", 8000), 0)
+
+
+func test_find_pid_on_garbage_output() -> void:
+	var junk := "oops something went wrong\nno header\n"
+	assert_eq(GodotAiPlugin._parse_windows_netstat_pid(junk, 8000), 0)
+
+
+func test_find_pid_handles_leading_whitespace_per_line() -> void:
+	## `netstat -ano` prints a two-space indent on every data row; the
+	## parser must strip it before splitting columns.
+	var sample := "  TCP    0.0.0.0:7070    0.0.0.0:0    LISTENING    42\n"
+	assert_eq(GodotAiPlugin._parse_windows_netstat_pid(sample, 7070), 42)
+
+
+func test_find_pid_rejects_non_integer_pid_column() -> void:
+	## Guard against accidentally returning a truncated column header.
+	var sample := "  TCP    0.0.0.0:8000    0.0.0.0:0    LISTENING    PID\n"
+	assert_eq(GodotAiPlugin._parse_windows_netstat_pid(sample, 8000), 0)
+
+
+func test_find_pid_ignores_port_substring_match() -> void:
+	## :80 must not match :8000, and :80001 must not match :8000.
+	var sample := (
+		"  TCP    0.0.0.0:80      0.0.0.0:0    LISTENING    111\n"
+		+ "  TCP    0.0.0.0:80001   0.0.0.0:0    LISTENING    222\n"
+		+ "  TCP    0.0.0.0:8000    0.0.0.0:0    LISTENING    333\n"
+	)
+	assert_eq(GodotAiPlugin._parse_windows_netstat_pid(sample, 8000), 333)
+
+
+func test_find_pid_matches_ipv6_listening() -> void:
+	var sample := "  TCP    [::]:8000    [::]:0    LISTENING    777\n"
+	assert_eq(GodotAiPlugin._parse_windows_netstat_pid(sample, 8000), 777)
+
+
+func test_find_pid_matches_loopback_bind() -> void:
+	var sample := "  TCP    127.0.0.1:8000    0.0.0.0:0    LISTENING    888\n"
+	assert_eq(GodotAiPlugin._parse_windows_netstat_pid(sample, 8000), 888)
+
+
+# ----- listening check -----
+
+func test_is_listening_true_when_port_has_listener() -> void:
+	assert_true(GodotAiPlugin._parse_windows_netstat_listening(NETSTAT_SAMPLE, 8000))
+
+
+func test_is_listening_false_when_port_absent() -> void:
+	assert_true(not GodotAiPlugin._parse_windows_netstat_listening(NETSTAT_SAMPLE, 9999))
+
+
+func test_is_listening_false_on_empty_output() -> void:
+	assert_true(not GodotAiPlugin._parse_windows_netstat_listening("", 8000))
+
+
+func test_is_listening_ignores_established_remote_port_match() -> void:
+	## The sample has an ESTABLISHED row with :8000 in the foreign column
+	## and no LISTENING row for :7070 — make sure we don't say :7070 is
+	## listening just because 7070 appears in ESTABLISHED somewhere.
+	var sample := "  TCP    127.0.0.1:49701    127.0.0.1:7070    ESTABLISHED    321\n"
+	assert_true(
+		not GodotAiPlugin._parse_windows_netstat_listening(sample, 7070),
+		"ESTABLISHED rows must not count as listeners for their foreign port",
+	)
+
+
+# ----- whitespace splitter -----
+
+func test_split_collapses_runs_of_spaces() -> void:
+	var fields := GodotAiPlugin._split_on_whitespace(
+		"TCP    0.0.0.0:8000    0.0.0.0:0    LISTENING    57865"
+	)
+	assert_eq(fields.size(), 5)
+	assert_eq(fields[0], "TCP")
+	assert_eq(fields[1], "0.0.0.0:8000")
+	assert_eq(fields[3], "LISTENING")
+	assert_eq(fields[4], "57865")
+
+
+func test_split_handles_tabs() -> void:
+	var fields := GodotAiPlugin._split_on_whitespace("a\tb  c")
+	assert_eq(fields.size(), 3)
+
+
+func test_split_empty_string() -> void:
+	var fields := GodotAiPlugin._split_on_whitespace("")
+	assert_eq(fields.size(), 0)
+
+
+# ----- pid-file round trip -----
+
+func test_read_pid_file_missing_returns_zero() -> void:
+	if FileAccess.file_exists(GodotAiPlugin.SERVER_PID_FILE):
+		## Start from a known-empty state; some earlier test may have
+		## left it behind.
+		GodotAiPlugin._clear_pid_file()
+	assert_eq(GodotAiPlugin._read_pid_file(), 0)
+
+
+func test_read_pid_file_round_trip() -> void:
+	var f := FileAccess.open(GodotAiPlugin.SERVER_PID_FILE, FileAccess.WRITE)
+	assert_true(f != null, "should be able to write to user://")
+	f.store_string("12345\n")
+	f.close()
+	assert_eq(GodotAiPlugin._read_pid_file(), 12345)
+	GodotAiPlugin._clear_pid_file()
+	assert_eq(GodotAiPlugin._read_pid_file(), 0, "clear should remove the file")
+
+
+func test_read_pid_file_rejects_non_integer() -> void:
+	var f := FileAccess.open(GodotAiPlugin.SERVER_PID_FILE, FileAccess.WRITE)
+	f.store_string("not-a-pid")
+	f.close()
+	assert_eq(GodotAiPlugin._read_pid_file(), 0)
+	GodotAiPlugin._clear_pid_file()
+
+
+func test_read_pid_file_rejects_negative() -> void:
+	var f := FileAccess.open(GodotAiPlugin.SERVER_PID_FILE, FileAccess.WRITE)
+	f.store_string("-5")
+	f.close()
+	assert_eq(GodotAiPlugin._read_pid_file(), 0)
+	GodotAiPlugin._clear_pid_file()
+
+
+func test_read_pid_file_tolerates_whitespace() -> void:
+	var f := FileAccess.open(GodotAiPlugin.SERVER_PID_FILE, FileAccess.WRITE)
+	f.store_string("  98765  \n")
+	f.close()
+	assert_eq(GodotAiPlugin._read_pid_file(), 98765)
+	GodotAiPlugin._clear_pid_file()

--- a/tests/unit/test_runtime_info.py
+++ b/tests/unit/test_runtime_info.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import atexit
+import os
+from pathlib import Path
+
+import pytest
+
+from godot_ai.runtime_info import install_pid_file
+
+
+@pytest.fixture
+def _unregister_atexit(monkeypatch):
+    """Capture atexit handlers registered during install_pid_file so the
+    test can invoke them explicitly and unregister them cleanly.
+    """
+    registered: list = []
+
+    real_register = atexit.register
+
+    def fake_register(fn, *args, **kwargs):
+        registered.append((fn, args, kwargs))
+        return real_register(fn, *args, **kwargs)
+
+    monkeypatch.setattr(atexit, "register", fake_register)
+    yield registered
+    for fn, _args, _kwargs in registered:
+        atexit.unregister(fn)
+
+
+def test_install_pid_file_writes_pid(tmp_path, _unregister_atexit):
+    pid_path = tmp_path / "godot_ai_server.pid"
+
+    result = install_pid_file(pid_path)
+
+    assert result == pid_path
+    assert pid_path.read_text(encoding="utf-8").strip() == str(os.getpid())
+
+
+def test_install_pid_file_none_is_noop(_unregister_atexit):
+    assert install_pid_file(None) is None
+    assert install_pid_file("") is None
+    assert _unregister_atexit == []
+
+
+def test_install_pid_file_creates_parent_dir(tmp_path, _unregister_atexit):
+    pid_path = tmp_path / "deep" / "nested" / "server.pid"
+
+    install_pid_file(pid_path)
+
+    assert pid_path.is_file()
+
+
+def test_install_pid_file_overwrites_stale_file(tmp_path, _unregister_atexit):
+    pid_path = tmp_path / "server.pid"
+    pid_path.write_text("99999\n", encoding="utf-8")
+
+    install_pid_file(pid_path)
+
+    assert pid_path.read_text(encoding="utf-8").strip() == str(os.getpid())
+
+
+def test_atexit_cleanup_unlinks_our_pid(tmp_path, _unregister_atexit):
+    pid_path = tmp_path / "server.pid"
+
+    install_pid_file(pid_path)
+    assert pid_path.is_file()
+
+    # atexit registers one handler; call it to simulate interpreter shutdown.
+    assert len(_unregister_atexit) == 1
+    cleanup_fn = _unregister_atexit[0][0]
+    cleanup_fn()
+
+    assert not pid_path.exists(), "atexit cleanup should have removed the file"
+
+
+def test_atexit_cleanup_skips_if_file_overwritten(tmp_path, _unregister_atexit):
+    ## Simulate: we wrote our PID, then a replacement server started
+    ## up and overwrote the file with its own PID. Our atexit must not
+    ## delete the replacement's file.
+    pid_path = tmp_path / "server.pid"
+    install_pid_file(pid_path)
+
+    other_pid = os.getpid() + 1_000_000  # guaranteed not our PID
+    pid_path.write_text(f"{other_pid}\n", encoding="utf-8")
+
+    cleanup_fn = _unregister_atexit[0][0]
+    cleanup_fn()
+
+    assert pid_path.is_file(), "should preserve a file claimed by a different PID"
+    assert pid_path.read_text(encoding="utf-8").strip() == str(other_pid)
+
+
+def test_atexit_cleanup_tolerates_missing_file(tmp_path, _unregister_atexit):
+    pid_path = tmp_path / "server.pid"
+    install_pid_file(pid_path)
+
+    pid_path.unlink()
+
+    cleanup_fn = _unregister_atexit[0][0]
+    cleanup_fn()  # must not raise
+
+
+def test_install_pid_file_expands_user(tmp_path, monkeypatch, _unregister_atexit):
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    path_arg = "~/server.pid"
+    result = install_pid_file(path_arg)
+
+    assert result == Path(path_arg).expanduser()
+    assert result == tmp_path / "server.pid"
+    assert result.is_file()
+
+
+def test_main_plumbs_pid_file_into_runtime_info(monkeypatch, tmp_path):
+    """End-to-end: `--pid-file` on the CLI should land in install_pid_file."""
+    pid_path = tmp_path / "via_cli.pid"
+    captured: dict[str, object] = {}
+
+    def fake_install(path):
+        captured["path"] = path
+        return Path(path) if path else None
+
+    monkeypatch.setattr("godot_ai.runtime_info.install_pid_file", fake_install)
+
+    ## Stub out the actual server run so the test doesn't bind a port.
+    class StubServer:
+        def run(self, **kwargs):
+            captured["run_kwargs"] = kwargs
+
+    monkeypatch.setattr("godot_ai.server.create_server", lambda ws_port: StubServer())
+
+    import godot_ai
+
+    godot_ai.main(
+        [
+            "--transport",
+            "streamable-http",
+            "--port",
+            "8123",
+            "--ws-port",
+            "9555",
+            "--pid-file",
+            str(pid_path),
+        ]
+    )
+
+    assert captured["path"] == str(pid_path)
+    assert captured["run_kwargs"] == {"transport": "streamable-http", "port": 8123}


### PR DESCRIPTION
The Windows dock-update flow left the old Python MCP server running:
`_stop_server` killed the uvx launcher PID (which on Windows does not
take the Python child with it, since `OS.kill` is `TerminateProcess`),
then tried to find the real port owner by scraping `netstat -ano` — but
the parser iterated `output` as if each array element were a line,
while Godot's `OS.execute` pushes the entire stdout into `output[0]`
as a single string. The result: PID-extraction returned the last
whitespace-separated token in the whole netstat dump (garbage), so
`OS.kill` either no-op'd or killed an unrelated process, port 8000
stayed held, and the re-enabled plugin fell through to the "foreign
server already running" branch — silently stuck on the old version
until an editor restart.

Two changes, belt-and-suspenders:

* Python server writes its own PID to `--pid-file <path>` at startup
  (`src/godot_ai/runtime_info.py`), unlinks on clean exit. Plugin
  passes `user://godot_ai_server.pid` and reads it in the new
  `_find_managed_pid` helper. Future upgrades skip netstat entirely.

* The netstat parser is now line-aware (splits on `\n`, verifies local
  address ends with `:PORT` and state is `LISTENING` on the *same*
  row) so existing installs upgrading from any pre-pid-file version
  can still kill the right PID via the fallback path.

Covered by `tests/unit/test_runtime_info.py` (pid-file lifecycle,
atexit cleanup, replacement-PID preservation) and
`test_project/tests/test_netstat_parser.gd` (realistic netstat
dumps, IPv6, substring-match pitfalls, whitespace handling, pid-file
round trip).

https://claude.ai/code/session_01S1uMAcVatu1iHkQ53QwNLX