### PR TITLE
fix(dock): three-state dev-server button label matches actual behavior

### DIFF
--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -553,19 +553,45 @@ func _make_status_row(label_text: String, value_text: String, value_color: Color
 	return row
 
 
+## Pure helper — given the two independent server states, return the button
+## label and tooltip. Factored out so tests can cover all three states without
+## spinning up a real server or plugin.
+static func _dev_server_btn_state(has_managed: bool, dev_running: bool) -> Dictionary:
+	var port := McpClientConfigurator.SERVER_HTTP_PORT
+	if has_managed:
+		return {
+			"text": "Switch to dev mode (--reload)",
+			"tooltip": "Stops the plugin's managed server and replaces it with a --reload dev server on port %d. The dev server auto-restarts when you edit Python sources." % port,
+		}
+	if dev_running:
+		return {
+			"text": "Exit dev mode",
+			"tooltip": "Stops the external dev server on port %d so the plugin's managed server can take over on next reload." % port,
+		}
+	return {
+		"text": "Start dev server",
+		"tooltip": "Spawns a --reload dev server on port %d. Auto-restarts when you edit Python sources." % port,
+	}
+
+
 func _update_dev_server_btn() -> void:
 	if _dev_server_btn == null:
 		return
-	if _plugin and _plugin.is_dev_server_running():
-		_dev_server_btn.text = "Stop Dev Server"
-	else:
-		_dev_server_btn.text = "Start Dev Server"
+	if _plugin == null:
+		return
+	var state := _dev_server_btn_state(_plugin.has_managed_server(), _plugin.is_dev_server_running())
+	_dev_server_btn.text = state["text"]
+	_dev_server_btn.tooltip_text = state["tooltip"]
 
 
 func _on_dev_server_pressed() -> void:
 	if _plugin == null:
 		return
-	if _plugin.is_dev_server_running():
+	if _plugin.has_managed_server():
+		# Managed server running — swap it for a --reload dev server.
+		# start_dev_server() calls _stop_server() internally before spawning.
+		_plugin.start_dev_server()
+	elif _plugin.is_dev_server_running():
 		_plugin.stop_dev_server()
 	else:
 		_plugin.start_dev_server()

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -664,3 +664,8 @@ func stop_dev_server() -> void:
 func is_dev_server_running() -> bool:
 	## Returns true if a server is running on the HTTP port that we didn't start as managed.
 	return _server_pid <= 0 and _is_port_in_use(McpClientConfigurator.SERVER_HTTP_PORT)
+
+
+func has_managed_server() -> bool:
+	## Returns true if the plugin is currently managing a server process it spawned.
+	return _server_pid > 0

--- a/test_project/tests/test_dock_dev_server_btn.gd
+++ b/test_project/tests/test_dock_dev_server_btn.gd
@@ -1,0 +1,43 @@
+@tool
+extends McpTestSuite
+
+## Tests for McpDock._dev_server_btn_state — the three-state label/tooltip
+## for the dev-server toggle button. Before this fix, the button only keyed
+## on is_dev_server_running() (which returns false when the plugin's own
+## managed server is up), so it said "Start Dev Server" while actually
+## replacing the managed server with a --reload one. See Windows friction
+## from #159/#147 live testing.
+
+const McpDockScript = preload("res://addons/godot_ai/mcp_dock.gd")
+
+
+func suite_name() -> String:
+	return "dock_dev_server_btn"
+
+
+func test_state_managed_server_running() -> void:
+	var state: Dictionary = McpDockScript._dev_server_btn_state(true, false)
+	assert_contains(state["text"], "Switch to dev mode", "Managed-running state must not say 'Start'")
+	assert_contains(state["tooltip"], "replaces it", "Tooltip must disclose that the managed server is replaced")
+
+
+func test_state_foreign_dev_server_running() -> void:
+	var state: Dictionary = McpDockScript._dev_server_btn_state(false, true)
+	assert_contains(state["text"], "Exit dev mode")
+	assert_contains(state["tooltip"], "external dev server")
+
+
+func test_state_nothing_running() -> void:
+	var state: Dictionary = McpDockScript._dev_server_btn_state(false, false)
+	assert_eq(state["text"], "Start dev server")
+	assert_contains(state["tooltip"], "--reload")
+
+
+func test_state_both_true_prefers_managed() -> void:
+	## Defensive: if both signals are somehow true (shouldn't happen given the
+	## is_dev_server_running() definition — it requires _server_pid <= 0 — but
+	## don't let the UI lie if it does). Managed wins, so clicking swaps rather
+	## than claiming to "exit" a dev server that the user's managed server
+	## would actually replace.
+	var state: Dictionary = McpDockScript._dev_server_btn_state(true, true)
+	assert_contains(state["text"], "Switch to dev mode")


### PR DESCRIPTION
## Summary

- The dock's dev-server toggle keyed only on `is_dev_server_running()`, which returns `true` only when a *foreign* server holds port 8000 **and** the plugin has no managed server. In the common case (managed server up), the button said **"Start Dev Server"** — but clicking it killed the managed server and spawned a `--reload` one. No hint that the click was destructive.
- Surfaces the third state by adding `has_managed_server()` on `plugin.gd` and splitting the dock label/tooltip three ways:
  - managed running → **"Switch to dev mode (--reload)"**
  - dev server running → **"Exit dev mode"**
  - nothing running → **"Start dev server"**
- Label/tooltip selection factored into a pure static helper (`McpDock._dev_server_btn_state`) so tests cover all three states without spawning a real server.
- `is_dev_server_running()` semantics and `start_dev_server()` / `stop_dev_server()` behavior are unchanged — purely a UX honesty fix.

## Context

Flagged during live Windows smoke testing of [#159](https://github.com/hi-godot/godot-ai/pull/159) + [#147](https://github.com/hi-godot/godot-ai/pull/147) — users on Windows hit the misleading label after #159 made the managed-server PID tracking deterministic (so the common-case "managed is up" state became more reliably the one users see in the button).

## Note on test file name

The related #144 PR (`feat/dock-install-mode`, not yet merged) adds `test_project/tests/test_dock.gd`. To avoid a merge collision with that branch, new tests live in `test_project/tests/test_dock_dev_server_btn.gd`. Happy to fold them into `test_dock.gd` post-#144 if preferred.

## Test plan

- [ ] `project_run` test suite on the dock → all four `dock_dev_server_btn/*` tests pass
- [ ] In the dock (dev checkout mode), with the managed server running, confirm button reads "Switch to dev mode (--reload)" and tooltip describes replacement
- [ ] After clicking, button reads "Start dev server" once the --reload server owns the port (foreign from the plugin's POV — `_server_pid = -1`)
- [ ] Wait a moment until port scan sees the --reload server → button reads "Exit dev mode"

🤖 Generated with [Claude Code](https://claude.com/claude-code)