### PR TITLE
fix(plugin): reset spawn re-entrancy guard in _exit_tree so reload-plugin respawns

### DIFF
--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -244,6 +244,13 @@ func _exit_tree() -> void:
 	_game_log_buffer = null
 
 	_stop_server()
+	## Symmetric with prepare_for_update_reload: the static guard persists
+	## across disable/enable within a single editor session, so the re-enabled
+	## plugin instance's _start_server would short-circuit and never respawn.
+	## Pre-#159 this was masked — the old kill path usually left Python alive
+	## and the new instance adopted it on port 8000. Now that _stop_server is
+	## deterministic, nothing is left to adopt and the reload hangs.
+	_server_started_this_session = false
 	print("MCP | plugin unloaded")
 
 

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -1,0 +1,72 @@
+@tool
+extends McpTestSuite
+
+## Tests for the plugin's re-entrancy guard across disable/enable cycles.
+## Regression coverage for the reload-plugin hang exposed by #159: once
+## _stop_server became deterministic, the static _server_started_this_session
+## flag persisted across disable/enable and made the re-enabled plugin's
+## _start_server short-circuit with no server to adopt.
+
+const GodotAiPlugin := preload("res://addons/godot_ai/plugin.gd")
+
+
+func suite_name() -> String:
+	return "plugin_lifecycle"
+
+
+func setup() -> void:
+	## The flag is a class-level static; leave it in a known state between
+	## tests so ordering can't mask a regression.
+	GodotAiPlugin._server_started_this_session = false
+
+
+func teardown() -> void:
+	GodotAiPlugin._server_started_this_session = false
+
+
+func test_exit_tree_resets_spawn_guard() -> void:
+	## The bug: after a successful spawn, the static flag stays true across
+	## a plugin disable/enable cycle (same editor session). When the new
+	## plugin instance's _enter_tree calls _start_server, the guard fires
+	## and no respawn happens — the dock sits in "reconnecting…" forever.
+	## Fix: _exit_tree must reset the flag so the next enable starts clean.
+	GodotAiPlugin._server_started_this_session = true
+	var plugin := GodotAiPlugin.new()
+	## _stop_server early-returns on the default _server_pid (-1), and every
+	## teardown branch in _exit_tree is null-guarded — so calling it on a
+	## freshly constructed (never-entered-tree) instance is safe and does
+	## not touch the editor or spawn processes.
+	plugin._exit_tree()
+	plugin.free()
+	assert_true(
+		not GodotAiPlugin._server_started_this_session,
+		"_exit_tree must clear the re-entrancy guard so the re-enabled plugin respawns"
+	)
+
+
+func test_prepare_for_update_reload_resets_spawn_guard() -> void:
+	## Companion path used by the dock's Update button flow. Kept distinct
+	## from _exit_tree because the update sequence calls this *before* the
+	## disable/enable toggle, whereas _exit_tree runs *during* teardown.
+	GodotAiPlugin._server_started_this_session = true
+	var plugin := GodotAiPlugin.new()
+	plugin.prepare_for_update_reload()
+	plugin.free()
+	assert_true(
+		not GodotAiPlugin._server_started_this_session,
+		"prepare_for_update_reload must clear the re-entrancy guard before the toggle"
+	)
+
+
+func test_exit_tree_is_idempotent_when_guard_already_false() -> void:
+	## If the plugin is disabled twice in a row (or disabled without ever
+	## having spawned), the second _exit_tree must still leave the flag
+	## false. Guards against accidental inversion of the reset.
+	GodotAiPlugin._server_started_this_session = false
+	var plugin := GodotAiPlugin.new()
+	plugin._exit_tree()
+	plugin.free()
+	assert_true(
+		not GodotAiPlugin._server_started_this_session,
+		"_exit_tree must not flip the guard back to true"
+	)


### PR DESCRIPTION
## Summary
- Fixes a latent bug in `plugin/addons/godot_ai/plugin.gd` exposed by [#159](https://github.com/hi-godot/godot-ai/pull/159). After `_stop_server` became deterministic (pid-file + fixed netstat parser), toggling the plugin off/on left the editor stuck with no server: the static `_server_started_this_session` flag persisted across disable/enable within a single editor session, and the re-enabled instance's `_start_server` short-circuited on the guard with nothing on port 8000 to adopt. Pre-#159 the stale Python process usually survived and the new instance adopted it, masking this.
- One-line fix: reset the flag in `_exit_tree` right after `_stop_server`, symmetric with the existing reset in `prepare_for_update_reload`. Every disable path now leaves the guard clean.
- Adds `test_project/tests/test_plugin_lifecycle.gd` with regression coverage for both reset paths (`_exit_tree`, `prepare_for_update_reload`) and idempotence.

## Why both reset sites are needed
`prepare_for_update_reload` is called by the dock's **Update** flow (`mcp_dock.gd:827`) *before* the disable/enable toggle. The dock's **Reload Plugin** button (`mcp_dock.gd:484`) and the `editor_reload_plugin` MCP tool (`handlers/editor_handler.gd:601`) both toggle the plugin directly without calling `prepare_for_update_reload` — so they were hitting the bug. Putting the reset in `_exit_tree` covers those paths without disturbing the Update flow.

## Out of scope
- No changes to `_stop_server` kill logic or the pid-file / netstat code from #159.
- No changes to `_start_server`'s adopt / drift / foreign branching.
- Static `_server_started_this_session` kept — its original intent (prevent re-entrant spawns within a single active plugin lifetime) is still valid.

## Test plan
- [x] Found and fixed during Windows live smoke test of #159.
- [x] Verified three consecutive `editor_reload_plugin` calls respawn cleanly on both `dev_venv` and `uvx` tiers; kill + respawn cycle produced three distinct Python PIDs, each cleanly replacing the previous, with pid-file contents tracking the port owner at each step.
- [ ] Reviewer: run the new `test_plugin_lifecycle` suite via the existing `test_run` harness.
- [ ] Reviewer: toggle plugin off/on via the dock's **Reload Plugin** button and confirm the dock reconnects (not the infinite "Disconnected → reconnecting…").

Credit: found during Windows live smoke test of [#159](https://github.com/hi-godot/godot-ai/pull/159).