### PR TITLE
fix(plugin): preserve managed-server record when _stop_server kill fails

### DIFF
--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -537,10 +537,28 @@ func _stop_server() -> void:
 	if not killed.is_empty():
 		print("MCP | stopped server (PID %s)" % str(killed))
 	_server_pid = -1
-	_clear_managed_server_record()
-	_clear_pid_file()
 	## Brief wait so a follow-up spawn doesn't race a still-closing socket.
 	_wait_for_port_free(port, 2.0)
+	## Only forget this server if the port is actually free. If the kill
+	## failed — e.g. a previous plugin version's buggy netstat parser
+	## targeted a bogus PID during the first v1.2.8 → v1.2.9 Update — then
+	## clearing the record would route the next _start_server down the
+	## "foreign server" branch, which leaves the zombie alone. Preserving
+	## the record keeps the next _start_server in the drift branch, which
+	## retries the kill with the current (fixed) parser. See issue filed
+	## as follow-up to PR #159.
+	_finalize_stop_if_port_free(port)
+
+
+## Clear the managed-server record and pid-file only if `port` is free.
+## Returns true when state was cleared. Extracted from `_stop_server` so
+## the "preserve on failed kill" contract is independently testable.
+func _finalize_stop_if_port_free(port: int) -> bool:
+	if _is_port_in_use(port):
+		return false
+	_clear_managed_server_record()
+	_clear_pid_file()
+	return true
 
 
 ## True if the given PID corresponds to a live process. Uses POSIX `kill -0`

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -9,6 +9,11 @@ extends McpTestSuite
 
 const GodotAiPlugin := preload("res://addons/godot_ai/plugin.gd")
 
+## Test port high enough to almost never collide with real services and
+## distinct from the plugin's SERVER_HTTP_PORT so the stop-finalize tests
+## don't interact with a developer's running managed server.
+const TEST_PORT := 65432
+
 
 func suite_name() -> String:
 	return "plugin_lifecycle"
@@ -22,6 +27,16 @@ func setup() -> void:
 
 func teardown() -> void:
 	GodotAiPlugin._server_started_this_session = false
+	## Stop-finalize tests write to EditorSettings + the pid-file on disk;
+	## scrub both so state doesn't leak across tests or outlast the suite.
+	var es := EditorInterface.get_editor_settings()
+	if es != null:
+		if es.has_setting(GodotAiPlugin.MANAGED_SERVER_PID_SETTING):
+			es.set_setting(GodotAiPlugin.MANAGED_SERVER_PID_SETTING, 0)
+		if es.has_setting(GodotAiPlugin.MANAGED_SERVER_VERSION_SETTING):
+			es.set_setting(GodotAiPlugin.MANAGED_SERVER_VERSION_SETTING, "")
+	if FileAccess.file_exists(GodotAiPlugin.SERVER_PID_FILE):
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(GodotAiPlugin.SERVER_PID_FILE))
 
 
 func test_exit_tree_resets_spawn_guard() -> void:
@@ -70,3 +85,80 @@ func test_exit_tree_is_idempotent_when_guard_already_false() -> void:
 		not GodotAiPlugin._server_started_this_session,
 		"_exit_tree must not flip the guard back to true"
 	)
+
+
+func test_finalize_stop_clears_state_when_port_is_free() -> void:
+	## When the kill succeeded and nothing holds the port anymore,
+	## _stop_server's cleanup should drop the managed-server record and
+	## the pid-file. Standard happy path.
+	_seed_managed_record(12345, "1.2.9")
+	_seed_pid_file(12345)
+	var plugin := GodotAiPlugin.new()
+
+	var cleared := plugin._finalize_stop_if_port_free(TEST_PORT)
+	plugin.free()
+
+	assert_true(cleared, "expected _finalize_stop_if_port_free to return true when port free")
+	assert_eq(
+		_read_record_version(),
+		"",
+		"managed-server record must be cleared when port is free"
+	)
+	assert_true(
+		not FileAccess.file_exists(GodotAiPlugin.SERVER_PID_FILE),
+		"pid-file must be cleared when port is free"
+	)
+
+
+func test_finalize_stop_preserves_state_when_port_still_in_use() -> void:
+	## The regression the fix prevents: a failed kill leaves the port
+	## occupied. If state were cleared anyway, the next _start_server
+	## would see no record and take the "foreign server" branch, leaving
+	## the zombie alive and the new plugin adopting an outdated server.
+	## Preserving record + pid-file routes the next start through the
+	## drift branch where the current (fixed) kill code gets a second
+	## shot. See the v1.2.8 → v1.2.9 Update flow regression.
+	var listener := TCPServer.new()
+	var listen_err := listener.listen(TEST_PORT, "127.0.0.1")
+	assert_eq(listen_err, OK, "test setup: must be able to bind TEST_PORT")
+
+	_seed_managed_record(54321, "1.2.9")
+	_seed_pid_file(54321)
+	var plugin := GodotAiPlugin.new()
+
+	var cleared := plugin._finalize_stop_if_port_free(TEST_PORT)
+	plugin.free()
+	listener.stop()
+
+	assert_false(cleared, "expected _finalize_stop_if_port_free to return false when port busy")
+	assert_eq(
+		_read_record_version(),
+		"1.2.9",
+		"managed-server record must be preserved so drift branch can retry the kill"
+	)
+	assert_true(
+		FileAccess.file_exists(GodotAiPlugin.SERVER_PID_FILE),
+		"pid-file must be preserved so next _find_managed_pid has the deterministic hint"
+	)
+
+
+func _seed_managed_record(pid: int, version: String) -> void:
+	var es := EditorInterface.get_editor_settings()
+	if es == null:
+		return
+	es.set_setting(GodotAiPlugin.MANAGED_SERVER_PID_SETTING, pid)
+	es.set_setting(GodotAiPlugin.MANAGED_SERVER_VERSION_SETTING, version)
+
+
+func _seed_pid_file(pid: int) -> void:
+	var f := FileAccess.open(GodotAiPlugin.SERVER_PID_FILE, FileAccess.WRITE)
+	assert_true(f != null, "test setup: must be able to write pid-file")
+	f.store_string(str(pid))
+	f.close()
+
+
+func _read_record_version() -> String:
+	var es := EditorInterface.get_editor_settings()
+	if es == null or not es.has_setting(GodotAiPlugin.MANAGED_SERVER_VERSION_SETTING):
+		return ""
+	return str(es.get_setting(GodotAiPlugin.MANAGED_SERVER_VERSION_SETTING))


### PR DESCRIPTION
## Summary

PR #159 made `_stop_server`'s kill deterministic — but only when the running plugin has the fixed netstat parser + pid-file support. Cross-version upgrades from a pre-fix release hit a residual gap, and it was discovered live during the v1.2.8 → v1.2.9 Update smoke test on Windows.

## Repro (the live failure we just hit)

1. User on v1.2.8 with the pre-fix server running on port 8000 (no pid-file).
2. Click **Update** in the dock.
3. Old plugin's `prepare_for_update_reload` → old `_stop_server`:
   - Old broken parser returns a bogus PID (literally `svchost` in our repro — PID 2764).
   - `OS.kill` silently no-ops on the wrong PID.
   - **But `_stop_server` clears the managed-server record anyway.**
4. Zip extracts, plugin re-enables with v1.2.9 code.
5. New `_start_server` at `plugin.gd:309` sees port held + **empty record** → hits the **foreign server** branch ("don't touch it") and adopts the zombie.
6. `session_list` → `plugin_version=1.2.9`, `server_version=1.2.8`. Dock says Connected but serves outdated protocol.
7. User closes Godot. Because the foreign branch never set `_server_pid`, `_exit_tree → _stop_server` early-returns on `_server_pid <= 0` — **the zombie Python survives editor shutdown.**

## Fix

Only clear the record + pid-file after verifying the port is actually free. If the port is still held after the kill + `_wait_for_port_free`, leave the state intact so the next `_start_server` sees version drift (record still claims the old version) and retries the kill with the current (fixed) parser via the drift branch.

Extracted the clear-on-free conditional into `_finalize_stop_if_port_free(port) -> bool` so it's independently unit-testable.

## Tests

Two new tests in `test_plugin_lifecycle.gd`:

- `test_finalize_stop_clears_state_when_port_is_free` — happy path
- `test_finalize_stop_preserves_state_when_port_still_in_use` — uses `TCPServer.listen` to hold the port, asserts record + pid-file survive

Teardown scrubs EditorSettings and the pid-file so state doesn't leak across tests.

## Why this matters for v1.2.9 users specifically

v1.2.8 was the last pre-fix release on PyPI. Anyone on v1.2.8 clicking Update → v1.2.9 hits the bug above. After this PR, subsequent upgrades (v1.2.9+ → anything) use deterministic kills from the start, so they don't need this safety net — but having the guard makes state tracking correct regardless.

## Related

- Exposes a gap not covered by #159 (the fix-forward PR) — discovered during the post-merge release smoke test, not testable pre-merge because it requires a PyPI-published pre-fix version to migrate from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)