### PR TITLE
chore(setup): Windows-aware setup-dev.ps1 for symlink checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ The plugin starts or reuses the Python server, connects over WebSocket, and expo
 
 See [CONTRIBUTING.md](docs/CONTRIBUTING.md) for development setup, testing, and PR guidelines.
 
+**Windows contributors:** run `.\script\setup-dev.ps1` in PowerShell. It requires Windows Developer Mode to be enabled — without it, the committed `test_project/addons/godot_ai` symlink checks out as a text file and the plugin fails to load. The script will prompt you with a link to the Settings page if Developer Mode is off.
+
 </details>
 
 ---

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,12 +2,32 @@
 
 ## Development Setup
 
+**macOS / Linux:**
+
 ```bash
 git clone https://github.com/hi-godot/godot-ai.git
 cd godot-ai
 script/setup-dev             # creates .venv, installs deps
 source .venv/bin/activate
 ```
+
+**Windows (PowerShell):**
+
+```powershell
+git clone https://github.com/hi-godot/godot-ai.git
+cd godot-ai
+.\script\setup-dev.ps1       # creates .venv, installs deps, fixes symlink
+.venv\Scripts\Activate.ps1
+```
+
+> **Windows contributors:** `setup-dev.ps1` requires **Windows Developer Mode**
+> to be enabled — if it isn't, the script prompts you with a link to the Settings
+> page (`ms-settings:developers`). Without Developer Mode + `core.symlinks=true`,
+> the committed symlink at `test_project/addons/godot_ai` checks out as a plain
+> text file, and the plugin fails to load with *"Attempt to open script
+> 'res://addons/godot_ai/runtime/game_helper.gd' resulted in error 'File not
+> found'"*. Every branch switch can re-break the symlink until `core.symlinks`
+> is set in the repo — which `setup-dev.ps1` handles for you.
 
 ## Testing
 

--- a/script/setup-dev.ps1
+++ b/script/setup-dev.ps1
@@ -1,0 +1,106 @@
+# Dev environment setup for Windows contributors.
+# Run once after cloning, or after recreating .venv:
+#     .\script\setup-dev.ps1
+#
+# On Linux/macOS use script/setup-dev (bash) instead.
+
+#Requires -Version 5.1
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not $IsWindows -and $PSVersionTable.PSVersion.Major -ge 6) {
+    Write-Host "setup-dev.ps1 is Windows-only. On macOS/Linux, run script/setup-dev instead." -ForegroundColor Yellow
+    exit 0
+}
+if ($PSVersionTable.PSVersion.Major -lt 6 -and $env:OS -ne 'Windows_NT') {
+    Write-Host "setup-dev.ps1 is Windows-only. On macOS/Linux, run script/setup-dev instead." -ForegroundColor Yellow
+    exit 0
+}
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
+Set-Location $repoRoot
+Write-Host "Repo: $repoRoot"
+
+# --- 1. Windows Developer Mode check --------------------------------------
+$devModeKey = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock'
+$devModeOn = $false
+try {
+    $val = Get-ItemPropertyValue -Path $devModeKey -Name 'AllowDevelopmentWithoutDevLicense' -ErrorAction Stop
+    $devModeOn = ($val -eq 1)
+} catch {
+    $devModeOn = $false
+}
+
+if (-not $devModeOn) {
+    Write-Host ""
+    Write-Host "================================================================" -ForegroundColor Yellow
+    Write-Host " Windows Developer Mode is OFF" -ForegroundColor Yellow
+    Write-Host "================================================================" -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "Without Developer Mode, git cannot create symlinks and the"
+    Write-Host "test_project/addons/godot_ai symlink will check out as a plain"
+    Write-Host "text file. Godot will then fail to load the plugin."
+    Write-Host ""
+    Write-Host "To enable Developer Mode:"
+    Write-Host "  1. Open Settings -> Privacy & security -> For developers"
+    Write-Host "     (or run: start ms-settings:developers)"
+    Write-Host "  2. Toggle 'Developer Mode' on"
+    Write-Host "  3. Re-run this script"
+    Write-Host ""
+    Write-Host "Alternatively, run this script from an Administrator PowerShell."
+    Write-Host ""
+    $resp = Read-Host "Continue anyway? Symlink hydration will likely fail. [y/N]"
+    if ($resp -notmatch '^[Yy]') {
+        Write-Host "Aborted. Enable Developer Mode and try again." -ForegroundColor Yellow
+        exit 1
+    }
+} else {
+    Write-Host "[ok] Windows Developer Mode is enabled."
+}
+
+# --- 2. core.symlinks for this repo ---------------------------------------
+& git config core.symlinks true
+if ($LASTEXITCODE -ne 0) { throw "git config core.symlinks true failed" }
+Write-Host "[ok] git config core.symlinks=true (local)."
+
+# --- 3. Re-materialize the plugin symlink ---------------------------------
+$symlinkPath = Join-Path $repoRoot 'test_project\addons\godot_ai'
+if (Test-Path -LiteralPath $symlinkPath) {
+    Remove-Item -LiteralPath $symlinkPath -Force -Recurse -ErrorAction SilentlyContinue
+}
+& git checkout HEAD -- 'test_project/addons/godot_ai'
+if ($LASTEXITCODE -ne 0) { throw "git checkout of test_project/addons/godot_ai failed" }
+
+$item = Get-Item -LiteralPath $symlinkPath -Force
+$isSymlink = ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0
+if ($isSymlink) {
+    Write-Host "[ok] test_project/addons/godot_ai is a symlink."
+} else {
+    Write-Host ""
+    Write-Host "[WARN] test_project/addons/godot_ai did NOT hydrate as a symlink." -ForegroundColor Yellow
+    Write-Host "       The plugin will not load in Godot until this is fixed."
+    Write-Host "       Most common cause: Windows Developer Mode is off."
+    Write-Host ""
+}
+
+# --- 4. Python venv via uv ------------------------------------------------
+$uv = Get-Command uv -ErrorAction SilentlyContinue
+if (-not $uv) {
+    Write-Host ""
+    Write-Host "[ERROR] 'uv' not found on PATH." -ForegroundColor Red
+    Write-Host "Install uv first:"
+    Write-Host '  powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"'
+    exit 1
+}
+
+if (-not (Test-Path -LiteralPath (Join-Path $repoRoot '.venv'))) {
+    & uv venv .venv
+    if ($LASTEXITCODE -ne 0) { throw "uv venv .venv failed" }
+}
+
+$venvPython = Join-Path $repoRoot '.venv\Scripts\python.exe'
+& uv pip install -e ".[dev]" --python $venvPython
+if ($LASTEXITCODE -ne 0) { throw "uv pip install -e .[dev] failed" }
+
+Write-Host ""
+Write-Host "Done. Activate with: .venv\Scripts\Activate.ps1" -ForegroundColor Green


### PR DESCRIPTION
## Summary

- Add `script/setup-dev.ps1` — a Windows-only sibling of `script/setup-dev` that gets a fresh clone into a working state without manual symlink gymnastics.
- Document the Windows flow in `docs/CONTRIBUTING.md` and point Windows contributors at the new script from the README's Contributing block.

## Problem

The repo has a committed symlink at `test_project/addons/godot_ai → ../../plugin/addons/godot_ai`. On Linux/macOS git creates it as a real symlink; on Windows it checks out as a 28-byte text file, and Godot fails to load the plugin:

```
ERROR: Attempt to open script 'res://addons/godot_ai/runtime/game_helper.gd' resulted in error 'File not found'.
WARNING: Addon 'res://addons/godot_ai/plugin.cfg' failed to load. No directory found. Removing from enabled plugins.
ERROR: Could not find base class "McpTestSuite".
```

Two things need to line up for git to materialize real symlinks on Windows:
1. **Windows Developer Mode** enabled (registry key `AllowDevelopmentWithoutDevLicense = 1`) or git running as admin.
2. **`git config core.symlinks true`** — not the default on Windows git installs.

If only one is set, the symlink silently checks out as a text file or is rejected at create time.

## What the script does

1. Detects Windows — no-ops with a friendly message on other OSes.
2. Reads `HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock\AllowDevelopmentWithoutDevLicense`. If off, prints a clear explanation with the `ms-settings:developers` link and offers to continue at the user's own risk. Does **not** try to toggle the registry itself (admin-only, invasive).
3. `git config core.symlinks true` (local to the repo).
4. Removes the stale text file at `test_project/addons/godot_ai`, re-runs `git checkout HEAD -- test_project/addons/godot_ai`, then verifies the result has the `ReparsePoint` attribute.
5. Creates `.venv` via `uv venv` and installs the project editable with `uv pip install -e ".[dev]"`.
6. Prints `Done. Activate with: .venv\Scripts\Activate.ps1`.

## Context

Flagged during Windows live smoke testing of #159 and #147 follow-ups — specifically during the integration-branch test where every `git switch` re-broke the symlink until `core.symlinks` was enabled locally.

## Test plan

- [ ] On a fresh Windows clone with Developer Mode **off**, run `.\script\setup-dev.ps1` and confirm the script warns clearly and exits (or is explicitly continued) without silently corrupting state.
- [ ] On a fresh Windows clone with Developer Mode **on**, run `.\script\setup-dev.ps1` end-to-end — confirm `(Get-Item test_project/addons/godot_ai).Attributes` includes `ReparsePoint`, the plugin loads in Godot, and `.venv\Scripts\Activate.ps1` + `pytest -v` passes.
- [ ] Smoke `.\script\setup-dev.ps1` a second time in the same repo (idempotency).
- [ ] `script/setup-dev` (bash) still works unchanged on macOS/Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)