### PR TITLE
feat(plugin): GODOT_AI_MODE override for update-flow testing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,16 @@ This bumps `plugin.cfg` + `pyproject.toml`, commits, tags, and pushes. The `rele
 
 The dock checks the GitHub releases API on startup. If a newer version exists, a yellow banner appears with an "Update" button that downloads the release ZIP, extracts it over the current `addons/godot_ai/`, and reloads the plugin. The server process is unaffected.
 
+In dev checkouts the check is skipped: `is_dev_checkout()` detects a nearby `.venv` and short-circuits to avoid offering a path that would overwrite tracked source (the addons dir is a symlink into `plugin/`). Three override knobs let you exercise the update flow without leaving the repo (resolved in priority order):
+
+1. **Dock dropdown** (`Mode override` in the dev-section of the MCP dock) — visible when `Developer mode` is on. Persists via EditorSetting `godot_ai/mode_override`. Choices: `Auto` / `Force user` / `Force dev`. Changing the dropdown immediately re-runs the update check so you can flip to "Force user" and watch the yellow banner appear in the same frame.
+2. **`GODOT_AI_MODE` env var** — fallback for CLI launches and CI. Values: `user` / `dev`. Only takes effect when the dock dropdown is `Auto` (the UI selection always wins).
+3. Neither set → the `.venv`-proximity heuristic runs as before.
+
+When either override reports `user`, the yellow update banner's label includes `(forced)` so testers don't forget they're in override mode.
+
+`_install_update` keeps a physical data-safety guard (`addons_dir_is_symlink()`) independent of the mode override: even in forced-user mode the self-install bails if `res://addons/godot_ai` is a symlink. To actually test the end-to-end extract path, unpack a release zip over a plain-directory copy of the addons dir (or test from a standalone project outside the dev tree).
+
 ## Testing
 
 ### Python tests

--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -103,8 +103,70 @@ static func get_plugin_version() -> String:
 	return "0.0.1"
 
 
+## Override for the dev-vs-user heuristic. Accepted values:
+##   "dev"   — force dev-checkout mode (skip update check + self-install)
+##   "user"  — force user-install mode (run update check, allow self-install)
+##            as long as the data-safety guard (addons_dir_is_symlink) passes
+##   other / unset — "auto": fall back to the .venv-proximity heuristic
+##
+## Use `user` to test the AssetLib self-update flow from inside a dev
+## checkout (there's a .venv nearby but `addons/godot_ai` is a plain copy —
+## e.g. after unpacking a release zip into `test_project/`).
+##
+## Two ways to set it, resolved in priority order:
+##   1. EditorSettings → `godot_ai/mode_override` — UI dropdown in the dock,
+##      persists per-editor-install. Wins over the env var so a UI action
+##      always takes effect without relaunching the editor.
+##   2. Env var `GODOT_AI_MODE` — useful for CLI launches and CI.
+const MODE_OVERRIDE_ENV := "GODOT_AI_MODE"
+const MODE_OVERRIDE_SETTING := "godot_ai/mode_override"
+
+
+static func mode_override() -> String:
+	# 1. EditorSetting wins — the user explicitly chose via the dock dropdown.
+	#    Guarded on `Engine.is_editor_hint()` so this is a no-op when the
+	#    plugin code runs inside the game subprocess (where EditorInterface
+	#    isn't available). See CLAUDE.md "Game-side code: gate on
+	#    Engine.is_editor_hint(), not OS.has_feature("editor")".
+	if Engine.is_editor_hint():
+		var es := EditorInterface.get_editor_settings()
+		if es != null and es.has_setting(MODE_OVERRIDE_SETTING):
+			var setting_val := str(es.get_setting(MODE_OVERRIDE_SETTING)).strip_edges().to_lower()
+			if setting_val == "dev" or setting_val == "user":
+				return setting_val
+	# 2. Env var fallback.
+	var raw := OS.get_environment(MODE_OVERRIDE_ENV).strip_edges().to_lower()
+	if raw == "dev" or raw == "user":
+		return raw
+	return ""
+
+
 static func is_dev_checkout() -> bool:
+	match mode_override():
+		"dev":
+			return true
+		"user":
+			return false
 	return not _find_venv_python().is_empty()
+
+
+## Data-safety check for self-install: is `res://addons/godot_ai` a symbolic
+## link? In a dev checkout this points at the canonical `plugin/` source
+## tree, and writing files into it would clobber tracked source. This check
+## is independent of `is_dev_checkout()` so a forced-user mode override
+## still cannot extract a release zip over the symlink.
+static func addons_dir_is_symlink() -> bool:
+	return _is_symlink(ProjectSettings.globalize_path("res://addons/godot_ai"))
+
+
+## Mirrors the idiom used in `mcp_dock.gd::_resolve_plugin_symlink_target` —
+## open the parent dir and ask Godot via `DirAccess.is_link()`, which
+## handles symlinks on POSIX and reparse points on Windows natively.
+static func _is_symlink(path: String) -> bool:
+	if path.is_empty():
+		return false
+	var dir := DirAccess.open(path.get_base_dir())
+	return dir != null and dir.is_link(path)
 
 
 static func get_server_command() -> Array[String]:

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -5,6 +5,11 @@ extends VBoxContainer
 ## Editor dock panel showing MCP connection status, client config, and command log.
 
 const DEV_MODE_SETTING := "godot_ai/dev_mode"
+## Index ↔ persisted-value mapping for the mode-override dropdown. The array
+## index is the OptionButton item id; the string is what's written to the
+## EditorSetting and read by `McpClientConfigurator.mode_override()`.
+const MODE_OVERRIDE_VALUES := ["", "user", "dev"]
+const MODE_OVERRIDE_LABELS := ["Auto", "Force user", "Force dev"]
 static var COLOR_MUTED := Color(0.7, 0.7, 0.7)
 static var COLOR_HEADER := Color(0.95, 0.95, 0.95)
 
@@ -32,6 +37,7 @@ var _dev_section: VBoxContainer
 var _server_label: Label
 var _reconnect_btn: Button
 var _reload_btn: Button
+var _mode_override_btn: OptionButton
 var _setup_section: VBoxContainer
 var _setup_container: VBoxContainer
 var _dev_server_btn: Button
@@ -261,6 +267,23 @@ func _build_ui() -> void:
 	btn_row.add_child(_reload_btn)
 
 	_dev_section.add_child(btn_row)
+
+	# Dev-only override for testing the update-banner flow; persisted via EditorSettings.
+	var mode_row := HBoxContainer.new()
+	mode_row.add_theme_constant_override("separation", 6)
+	var mode_label := Label.new()
+	mode_label.text = "Mode override"
+	mode_label.tooltip_text = "Force dev or user mode for testing the update flow. Normally leave on Auto. GODOT_AI_MODE env var is the fallback when this is Auto."
+	mode_row.add_child(mode_label)
+	_mode_override_btn = OptionButton.new()
+	_mode_override_btn.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	for i in MODE_OVERRIDE_LABELS.size():
+		_mode_override_btn.add_item(MODE_OVERRIDE_LABELS[i], i)
+	_mode_override_btn.tooltip_text = mode_label.tooltip_text
+	_mode_override_btn.select(_mode_override_index_from_setting())
+	_mode_override_btn.item_selected.connect(_on_mode_override_selected)
+	mode_row.add_child(_mode_override_btn)
+	_dev_section.add_child(mode_row)
 
 	# --- Setup section (dev-only or when uv missing) ---
 	_setup_section = VBoxContainer.new()
@@ -581,6 +604,36 @@ func _apply_dev_mode_visibility() -> void:
 	_setup_section.visible = dev or uv_missing
 
 
+func _mode_override_index_from_setting() -> int:
+	var es := EditorInterface.get_editor_settings()
+	if es == null or not es.has_setting(McpClientConfigurator.MODE_OVERRIDE_SETTING):
+		return 0
+	var v := str(es.get_setting(McpClientConfigurator.MODE_OVERRIDE_SETTING)).strip_edges().to_lower()
+	return maxi(MODE_OVERRIDE_VALUES.find(v), 0)
+
+
+## Called whenever `is_dev_checkout()`'s answer could have changed — repaints
+## the install label/tooltip, rebuilds the setup container (Mode row, Dev
+## Server button vs uv status), and clears any stale update banner so a
+## fresh `_check_for_updates()` paints over a clean slate.
+func _refresh_install_mode_ui() -> void:
+	_install_label.text = _install_mode_text()
+	_install_label.tooltip_text = _install_mode_tooltip()
+	_refresh_setup_status()
+	_update_banner.visible = false
+	_latest_download_url = ""
+
+
+func _on_mode_override_selected(index: int) -> void:
+	var value: String = MODE_OVERRIDE_VALUES[index] if index >= 0 and index < MODE_OVERRIDE_VALUES.size() else ""
+	var es := EditorInterface.get_editor_settings()
+	if es != null:
+		es.set_setting(McpClientConfigurator.MODE_OVERRIDE_SETTING, value)
+	_refresh_install_mode_ui()
+	_check_for_updates()
+	print("MCP | mode override -> %s" % (value if value else "auto"))
+
+
 # --- Button handlers ---
 
 func _on_reload_plugin() -> void:
@@ -857,6 +910,12 @@ func _check_for_updates() -> void:
 	## follows the symlink and overwrites the user's source files in place.
 	## Devs update via `git pull`, not the dock — skip the GitHub check
 	## entirely to avoid even offering the destructive path. See #116.
+	##
+	## `is_dev_checkout()` honours the mode override (dock dropdown first,
+	## then `GODOT_AI_MODE` env var), so testers can force `user` mode to
+	## exercise the AssetLib update flow from inside a dev tree.
+	## `_install_update` still gates on the physical symlink check, so a
+	## forced-user mode can never clobber source.
 	if McpClientConfigurator.is_dev_checkout():
 		return
 	_http_request.request(RELEASES_URL, ["Accept: application/vnd.github+json"])
@@ -884,7 +943,14 @@ func _on_update_check_completed(result: int, response_code: int, _headers: Packe
 			_latest_download_url = asset.get("browser_download_url", "")
 			break
 
-	_update_label.text = "Update available: v%s" % remote_version
+	var label_text := "Update available: v%s" % remote_version
+	if McpClientConfigurator.mode_override() == "user":
+		## Visible hint so testers notice the banner is only showing because
+		## of a forced-user override (dock dropdown or GODOT_AI_MODE env
+		## var). Clicking Update in a symlinked dev tree safely bails in
+		## `_install_update` via the addons_dir_is_symlink guard.
+		label_text += " (forced)"
+	_update_label.text = label_text
 	_update_banner.visible = true
 
 
@@ -932,13 +998,14 @@ func _on_download_completed(result: int, response_code: int, _headers: PackedStr
 
 
 func _install_update() -> void:
-	## Belt-and-suspenders check. The banner is already gated on
-	## is_dev_checkout() in _check_for_updates, but a stale cached
-	## _latest_download_url or a code-path change that bypasses the banner
-	## gate would still reach here. In a dev checkout `addons/godot_ai/`
-	## is a symlink; writing into it clobbers the canonical source tree.
-	## Bail before touching disk. See #116.
-	if McpClientConfigurator.is_dev_checkout():
+	## Belt-and-suspenders data-safety check. `_check_for_updates` is gated
+	## on `is_dev_checkout()` (a UX heuristic the user can override via
+	## GODOT_AI_MODE=user), but the actual hazard we can never tolerate is
+	## writing release-zip files into a symlinked addons dir — that
+	## clobbers the canonical `plugin/` source tree. Symlink detection is
+	## independent of the mode override: even a forced-user mode aborts
+	## here if the target is a symlink. See #116.
+	if McpClientConfigurator.addons_dir_is_symlink():
 		_update_btn.text = "Dev checkout — update via git"
 		_update_btn.disabled = true
 		_update_banner.visible = false

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -615,13 +615,20 @@ func _mode_override_index_from_setting() -> int:
 ## Called whenever `is_dev_checkout()`'s answer could have changed — repaints
 ## the install label/tooltip, rebuilds the setup container (Mode row, Dev
 ## Server button vs uv status), and clears any stale update banner so a
-## fresh `_check_for_updates()` paints over a clean slate.
+## fresh `_check_for_updates()` paints over a clean slate. The Update
+## button state is reset too: a prior install attempt may have left it
+## disabled with text like "Dev checkout — update via git" or "Extract
+## failed"; without this reset, flipping the dropdown and re-checking
+## would re-open the banner with the stale button text.
 func _refresh_install_mode_ui() -> void:
 	_install_label.text = _install_mode_text()
 	_install_label.tooltip_text = _install_mode_tooltip()
 	_refresh_setup_status()
 	_update_banner.visible = false
 	_latest_download_url = ""
+	if _update_btn != null:
+		_update_btn.text = "Update"
+		_update_btn.disabled = false
 
 
 func _on_mode_override_selected(index: int) -> void:
@@ -630,7 +637,13 @@ func _on_mode_override_selected(index: int) -> void:
 	if es != null:
 		es.set_setting(McpClientConfigurator.MODE_OVERRIDE_SETTING, value)
 	_refresh_install_mode_ui()
-	_check_for_updates()
+	## Cancel any in-flight startup check before firing a new one, otherwise
+	## `_http_request.request()` can return ERR_BUSY and the dropdown flip
+	## silently fails to re-check. `call_deferred` lets the cancel settle
+	## before the new request goes out.
+	if _http_request != null:
+		_http_request.cancel_request()
+	_check_for_updates.call_deferred()
 	print("MCP | mode override -> %s" % (value if value else "auto"))
 
 

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -154,6 +154,191 @@ func test_uvx_server_command_uses_exact_pin_not_tilde() -> void:
 		assert_true(has_exact_pin, "uvx tier command should contain godot-ai==<plugin_version>; got %s" % str(cmd))
 
 
+# ----- mode override + symlink safety -----
+
+## Mode override has two sources (EditorSetting wins, env var is fallback).
+## These tests sit on isolated env-var territory — each one clears the
+## EditorSetting first so a stale UI selection in the editor running the
+## tests can't make the env-var path invisible. Any real UI selection is
+## saved + restored around the test body.
+
+func _clear_mode_override_setting() -> Variant:
+	## Save the current EditorSetting (if any), clear it, return the prior
+	## value so the test can restore. Returns null when the setting was
+	## unset entirely. Tests need the setting empty so the env var — which
+	## they DO control — takes effect.
+	var es := EditorInterface.get_editor_settings()
+	if es == null:
+		return null
+	var prior: Variant = null
+	if es.has_setting(McpClientConfigurator.MODE_OVERRIDE_SETTING):
+		prior = es.get_setting(McpClientConfigurator.MODE_OVERRIDE_SETTING)
+	es.set_setting(McpClientConfigurator.MODE_OVERRIDE_SETTING, "")
+	return prior
+
+
+func _restore_mode_override_setting(prior: Variant) -> void:
+	var es := EditorInterface.get_editor_settings()
+	if es == null:
+		return
+	es.set_setting(McpClientConfigurator.MODE_OVERRIDE_SETTING, prior if prior != null else "")
+
+
+func test_mode_override_returns_empty_when_unset() -> void:
+	var prior_setting: Variant = _clear_mode_override_setting()
+	var prior_env := OS.get_environment("GODOT_AI_MODE")
+	OS.unset_environment("GODOT_AI_MODE")
+	assert_eq(McpClientConfigurator.mode_override(), "")
+	if not prior_env.is_empty():
+		OS.set_environment("GODOT_AI_MODE", prior_env)
+	_restore_mode_override_setting(prior_setting)
+
+
+func test_mode_override_normalises_case_and_whitespace() -> void:
+	var prior_setting: Variant = _clear_mode_override_setting()
+	var prior_env := OS.get_environment("GODOT_AI_MODE")
+	OS.set_environment("GODOT_AI_MODE", "  USER  ")
+	assert_eq(McpClientConfigurator.mode_override(), "user")
+	OS.set_environment("GODOT_AI_MODE", "Dev")
+	assert_eq(McpClientConfigurator.mode_override(), "dev")
+	OS.set_environment("GODOT_AI_MODE", "whatever")
+	assert_eq(McpClientConfigurator.mode_override(), "", "unknown values fall back to auto")
+	if prior_env.is_empty():
+		OS.unset_environment("GODOT_AI_MODE")
+	else:
+		OS.set_environment("GODOT_AI_MODE", prior_env)
+	_restore_mode_override_setting(prior_setting)
+
+
+func test_is_dev_checkout_forced_user_mode() -> void:
+	## Without this override, the .venv-next-door heuristic would report
+	## true in any worktree that inherits the repo's .venv, making the
+	## update-check path untestable from dev. With the override, the flow
+	## can be exercised end-to-end.
+	var prior_setting: Variant = _clear_mode_override_setting()
+	var prior_env := OS.get_environment("GODOT_AI_MODE")
+	OS.set_environment("GODOT_AI_MODE", "user")
+	assert_false(McpClientConfigurator.is_dev_checkout(), "GODOT_AI_MODE=user must force user mode")
+	if prior_env.is_empty():
+		OS.unset_environment("GODOT_AI_MODE")
+	else:
+		OS.set_environment("GODOT_AI_MODE", prior_env)
+	_restore_mode_override_setting(prior_setting)
+
+
+func test_is_dev_checkout_forced_dev_mode() -> void:
+	var prior_setting: Variant = _clear_mode_override_setting()
+	var prior_env := OS.get_environment("GODOT_AI_MODE")
+	OS.set_environment("GODOT_AI_MODE", "dev")
+	assert_true(McpClientConfigurator.is_dev_checkout(), "GODOT_AI_MODE=dev must force dev mode")
+	if prior_env.is_empty():
+		OS.unset_environment("GODOT_AI_MODE")
+	else:
+		OS.set_environment("GODOT_AI_MODE", prior_env)
+	_restore_mode_override_setting(prior_setting)
+
+
+func test_addons_dir_is_symlink_returns_bool_without_crashing() -> void:
+	## Smoke test: the real value depends on how the test_project is laid
+	## out on the current machine. Inside the canonical worktree the addons
+	## dir is a symlink into plugin/addons/godot_ai, so we expect true; in
+	## a non-symlink layout (e.g. after a zip extract) the call must still
+	## return without crashing. The typed return forces a bool result.
+	var result: bool = McpClientConfigurator.addons_dir_is_symlink()
+	assert_true(result == true or result == false)
+
+
+func test_dropdown_flip_propagates_to_is_dev_checkout() -> void:
+	## End-to-end mechanism: flipping the dropdown value (via EditorSetting)
+	## must flip `is_dev_checkout()` regardless of what the .venv heuristic
+	## would otherwise return. This is the concrete chain the install label
+	## / update banner / `_check_for_updates` consume. The heuristic result
+	## varies by env (dev worktree has a .venv; CI uses system Python with
+	## no .venv in the repo root), so this test only asserts the overrides
+	## — both flips must work whether auto resolves to dev or user.
+	var es := EditorInterface.get_editor_settings()
+	if es == null:
+		skip("EditorInterface.get_editor_settings() unavailable in test env")
+		return
+	var had_setting := es.has_setting(McpClientConfigurator.MODE_OVERRIDE_SETTING)
+	var prior_setting: Variant = es.get_setting(McpClientConfigurator.MODE_OVERRIDE_SETTING) if had_setting else null
+	var prior_env := OS.get_environment("GODOT_AI_MODE")
+	OS.unset_environment("GODOT_AI_MODE")
+
+	# Dropdown=user → is_dev_checkout false (overrides heuristic in dev env,
+	# matches heuristic in CI — either way, must be false).
+	es.set_setting(McpClientConfigurator.MODE_OVERRIDE_SETTING, "user")
+	assert_false(McpClientConfigurator.is_dev_checkout(), "Dropdown='user' must force is_dev_checkout=false")
+
+	# Dropdown=dev → is_dev_checkout true (matches heuristic in dev env,
+	# overrides in CI — either way, must be true).
+	es.set_setting(McpClientConfigurator.MODE_OVERRIDE_SETTING, "dev")
+	assert_true(McpClientConfigurator.is_dev_checkout(), "Dropdown='dev' must force is_dev_checkout=true")
+
+	# Restore.
+	if had_setting:
+		es.set_setting(McpClientConfigurator.MODE_OVERRIDE_SETTING, prior_setting)
+	else:
+		es.set_setting(McpClientConfigurator.MODE_OVERRIDE_SETTING, "")
+	if not prior_env.is_empty():
+		OS.set_environment("GODOT_AI_MODE", prior_env)
+
+
+func test_editor_setting_beats_env_var() -> void:
+	## When both an EditorSetting and the env var are set, the EditorSetting
+	## wins — the UI dropdown always reflects the user's latest explicit
+	## choice even if a stale env var was inherited at launch.
+	var es := EditorInterface.get_editor_settings()
+	if es == null:
+		skip("EditorInterface.get_editor_settings() unavailable in test env")
+		return
+	var had_setting := es.has_setting(McpClientConfigurator.MODE_OVERRIDE_SETTING)
+	var prior_setting: Variant = es.get_setting(McpClientConfigurator.MODE_OVERRIDE_SETTING) if had_setting else null
+	var prior_env := OS.get_environment("GODOT_AI_MODE")
+
+	OS.set_environment("GODOT_AI_MODE", "dev")
+	es.set_setting(McpClientConfigurator.MODE_OVERRIDE_SETTING, "user")
+	assert_eq(McpClientConfigurator.mode_override(), "user", "EditorSetting=user must override env=dev")
+
+	es.set_setting(McpClientConfigurator.MODE_OVERRIDE_SETTING, "")
+	assert_eq(McpClientConfigurator.mode_override(), "dev", "Empty EditorSetting falls through to env var")
+
+	# Restore.
+	if had_setting:
+		es.set_setting(McpClientConfigurator.MODE_OVERRIDE_SETTING, prior_setting)
+	else:
+		# No cross-platform "erase" on EditorSettings — leave an empty string
+		# which `mode_override()` treats identically to unset.
+		es.set_setting(McpClientConfigurator.MODE_OVERRIDE_SETTING, "")
+	if prior_env.is_empty():
+		OS.unset_environment("GODOT_AI_MODE")
+	else:
+		OS.set_environment("GODOT_AI_MODE", prior_env)
+
+
+func test_is_symlink_detects_real_symlink() -> void:
+	## Create a temp symlink under user:// and assert the helper reports it
+	## as one. Skipped on Windows where `ln -s` requires admin privileges
+	## and the fsutil path isn't exercisable in a unit test.
+	if OS.get_name() == "Windows":
+		skip("symlink creation requires admin on Windows")
+		return
+	var target := _scratch_dir.path_join("symlink_target.txt")
+	var link := _scratch_dir.path_join("symlink_source")
+	_remove_if_exists(target)
+	_remove_if_exists(link)
+	var f := FileAccess.open(target, FileAccess.WRITE)
+	f.store_string("hello")
+	f.close()
+	var exit := OS.execute("ln", ["-s", target, link], [], true)
+	assert_eq(exit, 0, "ln -s must succeed in writable user://")
+	assert_true(McpClientConfigurator._is_symlink(link), "_is_symlink should detect freshly-created symlink")
+	assert_false(McpClientConfigurator._is_symlink(target), "_is_symlink should reject regular file")
+	# Cleanup
+	DirAccess.remove_absolute(link)
+	DirAccess.remove_absolute(target)
+
+
 # ----- path template -----
 
 func test_path_template_expands_home() -> void:

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -238,14 +238,14 @@ func test_is_dev_checkout_forced_dev_mode() -> void:
 	_restore_mode_override_setting(prior_setting)
 
 
-func test_addons_dir_is_symlink_returns_bool_without_crashing() -> void:
-	## Smoke test: the real value depends on how the test_project is laid
-	## out on the current machine. Inside the canonical worktree the addons
-	## dir is a symlink into plugin/addons/godot_ai, so we expect true; in
-	## a non-symlink layout (e.g. after a zip extract) the call must still
-	## return without crashing. The typed return forces a bool result.
-	var result: bool = McpClientConfigurator.addons_dir_is_symlink()
-	assert_true(result == true or result == false)
+func test_addons_dir_is_symlink_detects_canonical_layout() -> void:
+	## `test_project/addons/godot_ai` is committed as a symlink
+	## (git mode 120000) pointing at `plugin/addons/godot_ai`, so the
+	## data-safety check must resolve that layout to `true`. If this
+	## fails, either the symlink didn't survive the checkout (git not
+	## preserving symlinks on the test platform) or DirAccess.is_link()
+	## behaves unexpectedly — both are real bugs worth surfacing here.
+	assert_true(McpClientConfigurator.addons_dir_is_symlink(), "res://addons/godot_ai is committed as a symlink; addons_dir_is_symlink() should report true")
 
 
 func test_dropdown_flip_propagates_to_is_dev_checkout() -> void:


### PR DESCRIPTION
## Summary

- Add a dock-UI + env-var override (`EditorSetting "godot_ai/mode_override"` → `GODOT_AI_MODE` env var → auto heuristic) so the AssetLib self-update flow can be exercised from inside a dev checkout, where the `.venv`-proximity heuristic otherwise silences the update check.
- Decouple the `_install_update` data-safety guard from the dev-checkout heuristic: it now checks `addons_dir_is_symlink()` via native `DirAccess.is_link()` (reusing the idiom from `_resolve_plugin_symlink_target`), so a forced-user mode still bails on a symlinked addons dir and can never clobber `plugin/` source.
- New "Mode override" dropdown in the dock's dev section (visible only with **Developer mode** on). Flipping it re-runs `_check_for_updates()` immediately and shows `(forced)` on the banner so testers don't forget they're in override mode.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `godot --headless --import` — 0 parse errors
- [x] `pytest` — 547/547 Python tests pass
- [x] Live `test_run` against this worktree's editor — 754 pass / 0 fail / 14 skip across all suites; 34/34 in `clients` including 7 new mode-override tests
- [x] Live dock exercise: confirmed dropdown writes `godot_ai/mode_override` to EditorSettings, `MCP | mode override -> user` print fires, `is_dev_checkout()` flips, install label switches between "dev checkout — update via git pull" and `v<version>`
- [x] CI-safe: new `test_dropdown_flip_propagates_to_is_dev_checkout` asserts only the override-flip behavior (doesn't depend on the heuristic's auto-mode resolution, which differs between dev worktrees and CI system-Python environments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)