### PR TITLE
feat(dock): drift detector for stale MCP client URLs after port change (#166)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,18 @@ ruff format src/ tests/      # format
 
 **macOS + Python 3.13 note**: Files inside `.venv` inherit the macOS hidden flag (dot-prefix directory). Python 3.13 skips hidden `.pth` files (CPython gh-113659), breaking editable installs. `script/setup-dev` generates a `sitecustomize.py` in the venv that adds `src/` to `sys.path` via normal import (unaffected by hidden flags). No manual `chflags` needed.
 
+**Windows note**: use `.\script\setup-dev.ps1` instead of `script/setup-dev`. The Windows script also re-hydrates the `test_project/addons/godot_ai` symlink, which on Windows requires `git config core.symlinks true` (the script sets it) plus Windows Developer Mode (Settings → Privacy & security → For developers). Without Developer Mode, git checks the file out as a plain text file containing the symlink target string instead of a real symlink, and Godot fails to load the plugin with errors like `Failed loading resource: res://addons/godot_ai/runtime/game_helper.gd` and a cascade of `Could not find base class "McpTestSuite"` parse errors in `test_project/tests/`. **Fallback when Developer Mode is unavailable** (e.g. transient sessions, restricted machines): create a directory junction by hand — junctions don't need admin or Developer Mode:
+
+```powershell
+# from repo root or worktree root
+Remove-Item -LiteralPath test_project\addons\godot_ai -Force
+New-Item -ItemType Junction -Path test_project\addons\godot_ai -Target ..\..\plugin\addons\godot_ai
+```
+
+Or in cmd: `mklink /J test_project\addons\godot_ai ..\..\plugin\addons\godot_ai`.
+
+**When troubleshooting any dev-environment / setup / dependency / symlink issue, scan `script/` first** for an existing fixer before doing it by hand. The project ships scripts for a reason — bypassing them re-introduces the bugs they were written to handle.
+
 ### Server lifecycle in dev
 
 The plugin manages the server process:

--- a/plugin/addons/godot_ai/clients/_base.gd
+++ b/plugin/addons/godot_ai/clients/_base.gd
@@ -6,7 +6,12 @@ extends RefCounted
 ## Subclasses set fields in _init(); they should not contain control flow.
 ## Strategies (json/toml/cli) consume these fields.
 
-enum Status { NOT_CONFIGURED, CONFIGURED, ERROR }
+## CONFIGURED_MISMATCH = an entry with our `SERVER_NAME` exists in the user's
+## client config, but its URL doesn't match `http_url()` — typical after the
+## user changes `godot_ai/http_port` and reloads. Distinguishing this from
+## `NOT_CONFIGURED` lets the dock surface a "your saved client URLs are stale"
+## banner instead of conflating it with "you never configured this client".
+enum Status { NOT_CONFIGURED, CONFIGURED, CONFIGURED_MISMATCH, ERROR }
 
 var id: String = ""                              ## stable key, e.g. "cursor"
 var display_name: String = ""                    ## "Cursor"

--- a/plugin/addons/godot_ai/clients/_json_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_json_strategy.gd
@@ -31,9 +31,12 @@ static func check_status(client: McpClient, server_name: String, server_url: Str
 	var entry = holder[server_name]
 	if not (entry is Dictionary):
 		return McpClient.Status.NOT_CONFIGURED
+	## An entry under `server_name` exists — if the URL doesn't match,
+	## that's drift (the user changed the port and the client config is stale),
+	## not "never configured". The dock surfaces that as an amber banner.
 	if client.verify_entry.is_valid():
-		return McpClient.Status.CONFIGURED if client.verify_entry.call(entry, server_url) else McpClient.Status.NOT_CONFIGURED
-	return McpClient.Status.CONFIGURED if entry.get(client.entry_url_field, "") == server_url else McpClient.Status.NOT_CONFIGURED
+		return McpClient.Status.CONFIGURED if client.verify_entry.call(entry, server_url) else McpClient.Status.CONFIGURED_MISMATCH
+	return McpClient.Status.CONFIGURED if entry.get(client.entry_url_field, "") == server_url else McpClient.Status.CONFIGURED_MISMATCH
 
 
 static func remove(client: McpClient, server_name: String) -> Dictionary:

--- a/plugin/addons/godot_ai/clients/_toml_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_toml_strategy.gd
@@ -57,8 +57,10 @@ static func check_status(client: McpClient, _server_name: String, server_url: St
 				configured_url = trimmed.substr(first + 1, last - first - 1)
 		elif trimmed.begins_with("enabled ="):
 			enabled = trimmed.to_lower().find("false") < 0
+	## Section exists with our `SERVER_NAME` header — a URL mismatch (or a
+	## disabled entry) is drift, not "never configured". See `_base.gd`.
 	if configured_url != server_url or not enabled:
-		return McpClient.Status.NOT_CONFIGURED
+		return McpClient.Status.CONFIGURED_MISMATCH
 	return McpClient.Status.CONFIGURED
 
 

--- a/plugin/addons/godot_ai/clients/claude_code.gd
+++ b/plugin/addons/godot_ai/clients/claude_code.gd
@@ -18,8 +18,12 @@ func _init() -> void:
 		if exit_code != 0 or output.is_empty():
 			return McpClient.Status.NOT_CONFIGURED
 		var text: String = output[0]
-		if text.find(name) < 0 or text.find(url) < 0:
+		if text.find(name) < 0:
 			return McpClient.Status.NOT_CONFIGURED
+		## Server registered, but pointing somewhere else — drift after a
+		## port change. Surface as mismatch so the dock offers Reconfigure.
+		if text.find(url) < 0:
+			return McpClient.Status.CONFIGURED_MISMATCH
 		return McpClient.Status.CONFIGURED
 	manual_command_builder = func(name: String, url: String, _path: String) -> String:
 		return "claude mcp add --scope user --transport http %s %s" % [name, url]

--- a/plugin/addons/godot_ai/handlers/client_handler.gd
+++ b/plugin/addons/godot_ai/handlers/client_handler.gd
@@ -39,6 +39,8 @@ func check_client_status(_params: Dictionary) -> Dictionary:
 				status_str = "configured"
 			McpClient.Status.NOT_CONFIGURED:
 				status_str = "not_configured"
+			McpClient.Status.CONFIGURED_MISMATCH:
+				status_str = "configured_mismatch"
 		clients.append({
 			"id": client_id,
 			"display_name": McpClientConfigurator.client_display_name(client_id),

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -1051,13 +1051,11 @@ func _refresh_drift_banner(mismatched_ids: Array[String]) -> void:
 	var names: Array[String] = []
 	for id in mismatched_ids:
 		names.append(McpClientConfigurator.client_display_name(id))
-	var n := mismatched_ids.size()
-	var noun := "client config" if n == 1 else "client configs"
-	var verb := "points" if n == 1 else "point"
-	_drift_label.text = (
-		"%d %s %s at a different URL than %s — likely after a port change. Stale: %s."
-		% [n, noun, verb, McpClientConfigurator.http_url(), ", ".join(names)]
-	)
+	## Active server URL is already shown on the WS:/HTTP: line above the
+	## Clients section, so it doesn't need to repeat here. Lead with the
+	## client names — that's the only thing the user can act on.
+	var verb := "needs" if mismatched_ids.size() == 1 else "need"
+	_drift_label.text = "%s %s to be reconfigured." % [", ".join(names), verb]
 	_drift_banner.visible = true
 
 

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -12,6 +12,11 @@ const MODE_OVERRIDE_VALUES := ["", "user", "dev"]
 const MODE_OVERRIDE_LABELS := ["Auto", "Force user", "Force dev"]
 static var COLOR_MUTED := Color(0.7, 0.7, 0.7)
 static var COLOR_HEADER := Color(0.95, 0.95, 0.95)
+## Used for "in-progress" / "stale, action needed" UI: the startup-grace
+## status icon, the spawn-failure suggested-port hint, the drift banner,
+## and the per-row mismatch dot. One constant so a future palette tweak
+## doesn't have to find every literal.
+static var COLOR_AMBER := Color(1.0, 0.75, 0.25)
 
 var _connection: Connection
 var _log_buffer: McpLogBuffer
@@ -31,6 +36,27 @@ var _install_label: Label
 ## Per-client UI handles, keyed by client id. Each entry holds the row's
 ## status dot, configure button, remove button, manual-command panel + text.
 var _client_rows: Dictionary = {}
+
+# Drift banner — surfaced near the Clients section when one or more clients
+# have a stored entry whose URL no longer matches `http_url()` (typical after
+# the user changes `godot_ai/http_port`). Event-driven: refreshed on
+# plugin enter, after Apply+Reload, when the Clients window opens, and on
+# editor focus-in. See #166.
+var _drift_banner: VBoxContainer
+var _drift_label: Label
+## Sorted snapshot of the most recent mismatched-client set. Powers two things:
+## (a) the Reconfigure button reuses this list instead of re-running
+## `check_status` per row (saves ~18 filesystem reads per click), and
+## (b) `_refresh_drift_banner` early-returns when the set is unchanged so
+## focus-in sweeps don't repaint identical text. Mirrors the
+## `_last_server_status` pattern used by the crash panel.
+var _last_mismatched_ids: Array[String] = []
+## Debounce for `NOTIFICATION_APPLICATION_FOCUS_IN`. Each focus-in costs
+## ~18 filesystem reads on the main thread; a 2s window collapses
+## fast alt-tab cycles into a single sweep without making the banner
+## feel stale.
+var _last_focus_sweep_msec: int = 0
+const FOCUS_SWEEP_MIN_MSEC := 2000
 
 # Dev-mode only
 var _dev_section: VBoxContainer
@@ -108,6 +134,18 @@ func _notification(what: int) -> void:
 	# Detect dock/undock by watching for reparenting events.
 	if what == NOTIFICATION_PARENTED or what == NOTIFICATION_UNPARENTED:
 		_update_redock_visibility.call_deferred()
+	elif what == NOTIFICATION_APPLICATION_FOCUS_IN:
+		## Catches the case where the user edits an MCP client config in
+		## another app (or runs `claude mcp add` in a terminal) while Godot
+		## was unfocused. Debounced so a fast alt-tab cycle doesn't fire
+		## one sweep per focus-in. See #166.
+		if _client_rows.is_empty():
+			return
+		var now := Time.get_ticks_msec()
+		if now - _last_focus_sweep_msec < FOCUS_SWEEP_MIN_MSEC:
+			return
+		_last_focus_sweep_msec = now
+		_refresh_all_client_statuses.call_deferred()
 
 
 func _is_floating() -> bool:
@@ -146,7 +184,7 @@ func _build_ui() -> void:
 	_status_icon.custom_minimum_size = Vector2(14, 14)
 	# Amber on first paint — matches the "Starting server…" label text and
 	# distinguishes from a real disconnect (red).
-	_status_icon.color = Color(1.0, 0.75, 0.25)
+	_status_icon.color = COLOR_AMBER
 	var icon_center := CenterContainer.new()
 	icon_center.add_child(_status_icon)
 	status_row.add_child(icon_center)
@@ -317,6 +355,22 @@ func _build_ui() -> void:
 	clients_row.add_child(clients_open_btn)
 
 	add_child(clients_row)
+
+	# Drift banner — hidden until a sweep finds at least one mismatched client.
+	_drift_banner = VBoxContainer.new()
+	_drift_banner.add_theme_constant_override("separation", 4)
+	_drift_banner.visible = false
+	_drift_label = Label.new()
+	_drift_label.add_theme_color_override("font_color", COLOR_AMBER)
+	_drift_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_drift_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_drift_banner.add_child(_drift_label)
+	var drift_btn := Button.new()
+	drift_btn.text = "Reconfigure mismatched"
+	drift_btn.tooltip_text = "Re-run Configure on every client whose stored URL doesn't match the current server URL."
+	drift_btn.pressed.connect(_on_reconfigure_mismatched)
+	_drift_banner.add_child(drift_btn)
+	add_child(_drift_banner)
 
 	_clients_window = Window.new()
 	_clients_window.title = "Configure MCP Clients"
@@ -510,7 +564,7 @@ func _update_status() -> void:
 		## Inside startup grace — distinguish from real disconnect so
 		## first-run users don't assume it's broken while uvx downloads.
 		status_text = "Starting server…"
-		status_color = Color(1.0, 0.75, 0.25)  ## amber
+		status_color = COLOR_AMBER
 	else:
 		status_text = "Disconnected"
 		status_color = Color.RED
@@ -601,12 +655,6 @@ func _build_port_picker_section() -> void:
 
 	_port_picker_section.add_child(picker_row)
 	_crash_panel.add_child(_port_picker_section)
-	## TODO: a follow-up PR should add a client-config drift detector
-	## (event-driven, fires on plugin load / after Apply+Reload / on
-	## editor focus-in). When any configured client's stored URL no
-	## longer matches `http_url()`, it renders its own banner next to
-	## the Clients section — that's separate from this spawn-failure
-	## panel and shouldn't be wedged in here.
 
 
 func _on_apply_new_port() -> void:
@@ -616,6 +664,12 @@ func _on_apply_new_port() -> void:
 	var es := EditorInterface.get_editor_settings()
 	if es != null:
 		es.set_setting(McpClientConfigurator.SETTING_HTTP_PORT, new_port)
+	## Every saved client config now points at the old port. Re-sweep so the
+	## drift banner appears in the same frame the user committed the change —
+	## the plugin reload below will run a second sweep on its own first paint,
+	## but we want the banner up immediately rather than after the reload
+	## handshake races to completion. See #166.
+	_refresh_all_client_statuses()
 	## Reload after the setting is committed so `_start_server` reads the new
 	## port on the re-enabled plugin instance.
 	_on_reload_plugin()
@@ -910,6 +964,11 @@ func _on_configure_all_clients() -> void:
 func _on_open_clients_window() -> void:
 	if _clients_window == null:
 		return
+	## Re-sweep before the user has time to act on stale dot colors. Deferred
+	## so the popup paints immediately with last-known state — the fresh
+	## colors land on the next frame. Synchronous would block the popup paint
+	## for ~18 filesystem reads (~100-300ms with AV scanning). See #166.
+	_refresh_all_client_statuses.call_deferred()
 	# popup_centered() with a minsize forces the window to that size and
 	# centers on the parent viewport. Setting .size on a hidden Window
 	# doesn't always take effect, so we force it at popup time here.
@@ -928,10 +987,17 @@ func _refresh_clients_summary() -> void:
 	if _clients_summary_label == null:
 		return
 	var configured := 0
+	var mismatched := 0
 	for row in _client_rows.values():
-		if (row["dot"] as ColorRect).color == Color.GREEN:
+		var c := (row["dot"] as ColorRect).color
+		if c == Color.GREEN:
 			configured += 1
-	_clients_summary_label.text = "%d / %d configured" % [configured, _client_rows.size()]
+		elif c == COLOR_AMBER:
+			mismatched += 1
+	var text := "%d / %d configured" % [configured, _client_rows.size()]
+	if mismatched > 0:
+		text += " (%d stale)" % mismatched
+	_clients_summary_label.text = text
 
 
 func _show_manual_command_for(client_id: String) -> void:
@@ -954,10 +1020,58 @@ func _on_copy_manual_command(client_id: String) -> void:
 
 
 func _refresh_all_client_statuses() -> void:
+	## Single sweep: pass the per-client status through `_apply_row_status` for
+	## the row UI, then count mismatches for the drift banner. Each client's
+	## `check_status` is one filesystem read — fine to do all of them on the
+	## handful of trigger events documented in #166.
+	var mismatched_ids: Array[String] = []
 	for client_id in _client_rows:
 		var status := McpClientConfigurator.check_status(client_id)
 		_apply_row_status(client_id, status)
+		if status == McpClient.Status.CONFIGURED_MISMATCH:
+			mismatched_ids.append(client_id)
 	_refresh_clients_summary()
+	_refresh_drift_banner(mismatched_ids)
+
+
+func _refresh_drift_banner(mismatched_ids: Array[String]) -> void:
+	if _drift_banner == null:
+		return
+	## Sort so set-equality is order-independent — `_client_rows` iteration
+	## order is dict-insertion order, but a future change to the iteration
+	## site shouldn't make us repaint identical content.
+	mismatched_ids = mismatched_ids.duplicate()
+	mismatched_ids.sort()
+	if mismatched_ids == _last_mismatched_ids:
+		return
+	_last_mismatched_ids = mismatched_ids
+	if mismatched_ids.is_empty():
+		_drift_banner.visible = false
+		return
+	var names: Array[String] = []
+	for id in mismatched_ids:
+		names.append(McpClientConfigurator.client_display_name(id))
+	var n := mismatched_ids.size()
+	var noun := "client config" if n == 1 else "client configs"
+	var verb := "points" if n == 1 else "point"
+	_drift_label.text = (
+		"%d %s %s at a different URL than %s — likely after a port change. Stale: %s."
+		% [n, noun, verb, McpClientConfigurator.http_url(), ", ".join(names)]
+	)
+	_drift_banner.visible = true
+
+
+func _on_reconfigure_mismatched() -> void:
+	## Re-Configure every client whose URL is currently stale. Iterates the
+	## cached list from the most recent sweep instead of re-running
+	## `check_status` per row (saves ~18 filesystem reads per click). The
+	## trailing `_refresh_all_client_statuses()` re-sweeps anyway, so any
+	## entries the user manually fixed between sweep and click get re-counted
+	## as CONFIGURED there.
+	for client_id in _last_mismatched_ids:
+		if _client_rows.has(client_id):
+			_on_configure_client(client_id)
+	_refresh_all_client_statuses()
 
 
 func _apply_row_status(client_id: String, status: McpClient.Status, error_msg: String = "") -> void:
@@ -981,6 +1095,13 @@ func _apply_row_status(client_id: String, status: McpClient.Status, error_msg: S
 			remove_btn.visible = false
 			var installed := McpClientConfigurator.is_installed(client_id)
 			name_label.text = base_name if installed else "%s  (not detected)" % base_name
+		McpClient.Status.CONFIGURED_MISMATCH:
+			## Amber matches the dock-level drift banner so a glance at the
+			## row + the banner read as the same condition.
+			dot.color = COLOR_AMBER
+			configure_btn.text = "Reconfigure"
+			remove_btn.visible = true
+			name_label.text = "%s  (URL out of date)" % base_name
 		_:
 			dot.color = Color.RED
 			configure_btn.text = "Retry"

--- a/src/godot_ai/tools/client.py
+++ b/src/godot_ai/tools/client.py
@@ -45,7 +45,10 @@ def register_client_tools(mcp: FastMCP) -> None:
         Returns a dict with a "clients" array. Each entry has:
             id            stable identifier (use with client_configure)
             display_name  human-readable name
-            status        "configured" | "not_configured" | "error"
+            status        "configured" | "not_configured" | "configured_mismatch" | "error"
+                          ("configured_mismatch" = an entry exists but its URL doesn't
+                           match the active server URL — typically after a port change.
+                           Re-run client_configure to update.)
             installed     bool — true if the client appears to be present locally
         """
         runtime = DirectRuntime.from_context(ctx)

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -465,9 +465,13 @@ func test_json_strategy_round_trip() -> void:
 	var status := McpJsonStrategy.check_status(client, "godot-ai", "http://127.0.0.1:8000/mcp")
 	assert_eq(status, McpClient.Status.CONFIGURED)
 
-	# A wrong URL should not be reported as configured.
+	# A wrong URL is drift, not "never configured" — the user re-configured
+	# at one point but the stored URL is now stale (most commonly because
+	# they changed `godot_ai/http_port`). Surfacing it as a distinct status
+	# lets the dock render an amber "stale" banner instead of conflating
+	# drift with a brand-new install.
 	var wrong_status := McpJsonStrategy.check_status(client, "godot-ai", "http://wrong/")
-	assert_eq(wrong_status, McpClient.Status.NOT_CONFIGURED)
+	assert_eq(wrong_status, McpClient.Status.CONFIGURED_MISMATCH)
 
 	var removed := McpJsonStrategy.remove(client, "godot-ai")
 	assert_eq(removed.get("status"), "ok")
@@ -493,6 +497,72 @@ func test_json_strategy_preserves_other_servers() -> void:
 	assert_true(parsed.has("mcpServers"))
 	assert_true(parsed["mcpServers"].has("someone-else"), "Existing entry was wiped")
 	assert_true(parsed["mcpServers"].has("godot-ai"), "Our entry not added")
+
+
+func test_json_strategy_distinguishes_missing_entry_from_url_drift() -> void:
+	## Three statuses, three causes — dock surfaces them as muted dot,
+	## green dot, amber dot respectively. Conflating "never configured"
+	## with "URL out of date" loses the drift signal.
+	var path := _scratch_dir.path_join("drift.json")
+	_remove_if_exists(path)
+	var client := _make_test_json_client(path)
+
+	# 1. No file at all → NOT_CONFIGURED.
+	assert_eq(
+		McpJsonStrategy.check_status(client, "godot-ai", "http://127.0.0.1:8000/mcp"),
+		McpClient.Status.NOT_CONFIGURED,
+	)
+
+	# 2. Configure at port 8000 → CONFIGURED at the matching URL.
+	McpJsonStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+	assert_eq(
+		McpJsonStrategy.check_status(client, "godot-ai", "http://127.0.0.1:8000/mcp"),
+		McpClient.Status.CONFIGURED,
+	)
+
+	# 3. Same file, but the active URL has shifted (user changed http_port).
+	#    Entry still exists under the same name — drift, not absence.
+	assert_eq(
+		McpJsonStrategy.check_status(client, "godot-ai", "http://127.0.0.1:9000/mcp"),
+		McpClient.Status.CONFIGURED_MISMATCH,
+	)
+
+	# 4. Entry under a *different* name leaves our slot empty → NOT_CONFIGURED.
+	var seed := {"mcpServers": {"someone-else": {"url": "http://127.0.0.1:8000/mcp"}}}
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	f.store_string(JSON.stringify(seed))
+	f.close()
+	assert_eq(
+		McpJsonStrategy.check_status(client, "godot-ai", "http://127.0.0.1:8000/mcp"),
+		McpClient.Status.NOT_CONFIGURED,
+	)
+
+
+func test_json_strategy_drift_with_verify_entry_callable() -> void:
+	## Clients with a custom `verify_entry` (Zed, Claude Desktop) take a
+	## different path through `check_status` than the default url-field
+	## comparison. Both must emit CONFIGURED_MISMATCH for drift, not
+	## NOT_CONFIGURED — the dock contract is the same regardless of how
+	## the check is wired.
+	var path := _scratch_dir.path_join("verify_drift.json")
+	_remove_if_exists(path)
+	var client := McpClient.new()
+	client.id = "verify_test"
+	client.display_name = "Verify Test"
+	client.config_type = "json"
+	client.path_template = {"darwin": path, "windows": path, "linux": path, "unix": path}
+	client.server_key_path = PackedStringArray(["mcpServers"])
+	client.entry_builder = func(_n: String, u: String) -> Dictionary:
+		return {"command": {"path": "npx", "args": ["-y", "mcp-remote", u]}}
+	client.verify_entry = func(entry: Dictionary, u: String) -> bool:
+		var args = entry.get("command", {}).get("args", [])
+		return args is Array and args.has(u)
+
+	McpJsonStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+	assert_eq(
+		McpJsonStrategy.check_status(client, "godot-ai", "http://127.0.0.1:9000/mcp"),
+		McpClient.Status.CONFIGURED_MISMATCH,
+	)
 
 
 func test_json_strategy_supports_nested_key_path() -> void:
@@ -530,6 +600,43 @@ func test_toml_strategy_round_trip() -> void:
 	var removed := McpTomlStrategy.remove(client, "godot-ai")
 	assert_eq(removed.get("status"), "ok")
 	assert_eq(McpTomlStrategy.check_status(client, "godot-ai", "http://127.0.0.1:8000/mcp"), McpClient.Status.NOT_CONFIGURED)
+
+
+func test_toml_strategy_distinguishes_missing_section_from_url_drift() -> void:
+	## Same three-state contract as the JSON strategy, in TOML shape.
+	## Section header present + url mismatch → CONFIGURED_MISMATCH.
+	## No matching header → NOT_CONFIGURED.
+	var path := _scratch_dir.path_join("drift.toml")
+	_remove_if_exists(path)
+	var client := _make_test_toml_client(path)
+
+	assert_eq(
+		McpTomlStrategy.check_status(client, "godot-ai", "http://127.0.0.1:8000/mcp"),
+		McpClient.Status.NOT_CONFIGURED,
+	)
+
+	McpTomlStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+	assert_eq(
+		McpTomlStrategy.check_status(client, "godot-ai", "http://127.0.0.1:8000/mcp"),
+		McpClient.Status.CONFIGURED,
+	)
+
+	# Drift: section still present (we never re-configured) but the active
+	# server URL has shifted underneath it.
+	assert_eq(
+		McpTomlStrategy.check_status(client, "godot-ai", "http://127.0.0.1:9000/mcp"),
+		McpClient.Status.CONFIGURED_MISMATCH,
+	)
+
+	# Disabled section is also drift, not absence — the entry is there,
+	# the user just turned it off, and re-running Configure restores it.
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	f.store_string("[mcp_servers.\"godot-ai\"]\nurl = \"http://127.0.0.1:8000/mcp\"\nenabled = false\n")
+	f.close()
+	assert_eq(
+		McpTomlStrategy.check_status(client, "godot-ai", "http://127.0.0.1:8000/mcp"),
+		McpClient.Status.CONFIGURED_MISMATCH,
+	)
 
 
 func test_toml_strategy_preserves_other_sections() -> void:
@@ -585,11 +692,16 @@ func test_handler_status_returns_array_of_clients() -> void:
 	assert_true(clients is Array)
 	assert_gt(clients.size(), 10)
 	# Each entry must include id / display_name / status / installed.
+	# `status` is one of the four documented strings; agents pattern-match
+	# against this set, so a fifth value being silently introduced would
+	# break them. The handler's `match` only emits these four.
+	var allowed_statuses := ["configured", "not_configured", "configured_mismatch", "error"]
 	for entry in clients:
 		assert_has_key(entry, "id")
 		assert_has_key(entry, "display_name")
 		assert_has_key(entry, "status")
 		assert_has_key(entry, "installed")
+		assert_contains(allowed_statuses, entry.status, "Unexpected status: %s" % entry.status)
 
 
 # ----- entry-builder shape sanity for shipped clients -----

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -46,6 +46,70 @@ func test_install_label_mouse_filter_allows_tooltip() -> void:
 	assert_eq(_dock._install_label.mouse_filter, Control.MOUSE_FILTER_STOP)
 
 
+func test_drift_banner_hidden_when_no_mismatched_clients() -> void:
+	## The amber banner should stay hidden until a sweep finds at least one
+	## mismatched client — otherwise it'd flash up on every `_build_ui` call
+	## and become noise. See #166.
+	_dock._build_ui()
+	assert_false(_dock._drift_banner.visible, "Banner must default to hidden")
+	_dock._refresh_drift_banner([])
+	assert_false(_dock._drift_banner.visible, "Empty mismatched list must keep banner hidden")
+
+
+func test_drift_banner_surfaces_mismatched_clients_with_url() -> void:
+	## The banner copy must name the active server URL and the affected
+	## clients so the user can immediately see what's stale. The amber
+	## colour ties it visually to the per-row dot for the same clients.
+	_dock._build_ui()
+	_dock._refresh_drift_banner(["claude_code"] as Array[String])
+	assert_true(_dock._drift_banner.visible, "Non-empty mismatched list must show banner")
+	assert_contains(_dock._drift_label.text, McpClientConfigurator.http_url(),
+		"Banner should mention the active server URL so the user knows what 'mismatched' means against")
+	assert_contains(_dock._drift_label.text, "Claude Code",
+		"Banner should list the display names of mismatched clients")
+
+
+func test_drift_banner_no_op_when_mismatched_set_unchanged() -> void:
+	## The banner caches the last mismatched set so that focus-in sweeps
+	## that find the same drift don't repaint identical text. The cache
+	## also powers `_on_reconfigure_mismatched`, so verifying it's
+	## populated locks the contract in. See #166.
+	_dock._build_ui()
+	_dock._refresh_drift_banner(["claude_code"] as Array[String])
+	assert_eq(_dock._last_mismatched_ids, ["claude_code"] as Array[String],
+		"Cache must reflect the most recent sweep so the Reconfigure button can iterate it")
+	var first_text := _dock._drift_label.text
+
+	# Mutate the label out-of-band; if the second call early-returns as it
+	# should, our text edit survives. If it ignores the cache and rewrites,
+	# our edit is overwritten.
+	_dock._drift_label.text = "SENTINEL — should survive a no-op refresh"
+	_dock._refresh_drift_banner(["claude_code"] as Array[String])
+	assert_eq(_dock._drift_label.text, "SENTINEL — should survive a no-op refresh",
+		"Identical mismatched set must skip repaint")
+
+	# A different set must repaint.
+	_dock._refresh_drift_banner(["codex"] as Array[String])
+	assert_true(_dock._drift_label.text != "SENTINEL — should survive a no-op refresh")
+	assert_true(_dock._drift_label.text != first_text, "Different set must produce different text")
+
+
+func test_apply_row_status_renders_mismatch_as_amber_with_url_hint() -> void:
+	## The row UI is the per-client mirror of the dock-level banner —
+	## amber dot + "URL out of date" suffix on the name label so a
+	## glance at the row identifies it as drift, not a fresh install.
+	_dock._build_ui()
+	var any_id := McpClientConfigurator.client_ids()[0]
+	_dock._apply_row_status(any_id, McpClient.Status.CONFIGURED_MISMATCH)
+	var row: Dictionary = _dock._client_rows[any_id]
+	var dot: ColorRect = row["dot"]
+	assert_eq(dot.color, McpDockScript.COLOR_AMBER, "Mismatch must use amber dot")
+	assert_contains((row["name_label"] as Label).text, "URL out of date",
+		"Mismatched row must label itself so the user reads it as drift")
+	assert_eq((row["configure_btn"] as Button).text, "Reconfigure",
+		"Mismatched rows offer the same Reconfigure action as the banner")
+
+
 func test_dev_checkout_tooltip_exposes_symlink_target() -> void:
 	if not McpClientConfigurator.is_dev_checkout():
 		skip("only meaningful in dev checkout")

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -56,17 +56,17 @@ func test_drift_banner_hidden_when_no_mismatched_clients() -> void:
 	assert_false(_dock._drift_banner.visible, "Empty mismatched list must keep banner hidden")
 
 
-func test_drift_banner_surfaces_mismatched_clients_with_url() -> void:
-	## The banner copy must name the active server URL and the affected
-	## clients so the user can immediately see what's stale. The amber
-	## colour ties it visually to the per-row dot for the same clients.
+func test_drift_banner_surfaces_mismatched_client_names() -> void:
+	## The banner leads with the affected client display names — that's the
+	## only thing the user can act on. The active server URL is shown on
+	## the WS:/HTTP: line above and doesn't need to repeat here.
 	_dock._build_ui()
 	_dock._refresh_drift_banner(["claude_code"] as Array[String])
 	assert_true(_dock._drift_banner.visible, "Non-empty mismatched list must show banner")
-	assert_contains(_dock._drift_label.text, McpClientConfigurator.http_url(),
-		"Banner should mention the active server URL so the user knows what 'mismatched' means against")
 	assert_contains(_dock._drift_label.text, "Claude Code",
 		"Banner should list the display names of mismatched clients")
+	assert_contains(_dock._drift_label.text, "needs",
+		"Singular form for one mismatched client should read 'needs to be reconfigured'")
 
 
 func test_drift_banner_no_op_when_mismatched_set_unchanged() -> void:
@@ -78,7 +78,7 @@ func test_drift_banner_no_op_when_mismatched_set_unchanged() -> void:
 	_dock._refresh_drift_banner(["claude_code"] as Array[String])
 	assert_eq(_dock._last_mismatched_ids, ["claude_code"] as Array[String],
 		"Cache must reflect the most recent sweep so the Reconfigure button can iterate it")
-	var first_text := _dock._drift_label.text
+	var first_text: String = _dock._drift_label.text
 
 	# Mutate the label out-of-band; if the second call early-returns as it
 	# should, our text edit survives. If it ignores the cache and rewrites,


### PR DESCRIPTION
## Summary

Closes #166. After the Apply+Reload escape hatch in #164 changes `godot_ai/http_port`, every saved MCP client config (`~/.claude.json`, `~/.codex/config.toml`, Cursor's settings, …) still points at the old URL until the user manually re-runs Configure Clients. This PR detects and surfaces that drift.

- New `McpClient.Status.CONFIGURED_MISMATCH` — the three strategies (`_json_strategy`, `_toml_strategy`, `claude_code`'s CLI check) now distinguish "no entry under our `SERVER_NAME`" (still `NOT_CONFIGURED`) from "entry exists, URL is stale" (new `CONFIGURED_MISMATCH`).
- Amber drift banner under the Clients section listing the mismatched client display names + the active `http_url()`, with a one-click **Reconfigure mismatched** button. Per-row dots and the summary count (`X / N configured (Y stale)`) reflect the same condition.
- Event-driven sweeps (no per-frame polling): plugin enter, after Apply+Reload, when the Configure Clients window opens, and on `NOTIFICATION_APPLICATION_FOCUS_IN` (debounced 2s). Each sweep is one filesystem read per registered client (~18) — fine on the documented triggers.
- Cached `_last_mismatched_ids` powers (a) the Reconfigure button so it reuses the most recent sweep instead of re-running 18 `check_status` reads per click, and (b) no-op detection in `_refresh_drift_banner` so identical sets don't repaint identical text. Mirrors the existing `_last_server_status` pattern.
- Hoisted `Color(1.0, 0.75, 0.25)` → new `static var COLOR_AMBER` and replaced the 5 in-file occurrences (3 from this PR + 2 pre-existing) so a future palette tweak doesn't have to find every literal.
- Resolves the `TODO:` comment at the end of `_build_port_picker_section`.
- New MCP tool docstring on `client_status` documents the new `"configured_mismatch"` status string.

## Test plan

- [x] `pytest -v` — all 547 Python tests pass.
- [x] `ruff check src/ tests/` — clean.
- [x] `godot --headless --import` — no GDScript parse errors / load failures.
- [x] New GDScript tests in `test_project/tests/test_clients.gd`:
  - `test_json_strategy_distinguishes_missing_entry_from_url_drift` — 4-state coverage (no file → NOT_CONFIGURED, configured → CONFIGURED, drifted → CONFIGURED_MISMATCH, our slot empty under different entry → NOT_CONFIGURED).
  - `test_json_strategy_drift_with_verify_entry_callable` — Zed/Claude-Desktop's custom `verify_entry` path also emits `CONFIGURED_MISMATCH` for drift, not `NOT_CONFIGURED`.
  - `test_toml_strategy_distinguishes_missing_section_from_url_drift` — TOML 3-state coverage including disabled-section-as-drift.
  - Existing `test_json_strategy_round_trip` updated: wrong URL now asserts `CONFIGURED_MISMATCH`.
  - `test_handler_status_returns_array_of_clients` extended to assert the status string is in the documented set.
- [x] New GDScript tests in `test_project/tests/test_dock.gd`:
  - `test_drift_banner_hidden_when_no_mismatched_clients` — banner stays hidden by default and on empty sweeps.
  - `test_drift_banner_surfaces_mismatched_clients_with_url` — banner copy includes the active URL and the affected display names.
  - `test_drift_banner_no_op_when_mismatched_set_unchanged` — verifies the cache early-return via a sentinel-text trick, plus asserts `_last_mismatched_ids` is populated (locks in the contract the Reconfigure button depends on).
  - `test_apply_row_status_renders_mismatch_as_amber_with_url_hint` — per-row UI surfaces the same condition.
- [ ] Live smoke test in the editor (manual): change `godot_ai/http_port` via Apply+Reload, verify amber banner appears with stale clients listed, click Reconfigure mismatched, verify banner clears and rows go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)