### PR TITLE
feat(dock): client-config drift detector for stale URLs

### DIFF
--- a/plugin/addons/godot_ai/clients/_base.gd
+++ b/plugin/addons/godot_ai/clients/_base.gd
@@ -6,7 +6,11 @@ extends RefCounted
 ## Subclasses set fields in _init(); they should not contain control flow.
 ## Strategies (json/toml/cli) consume these fields.
 
-enum Status { NOT_CONFIGURED, CONFIGURED, ERROR }
+## CONFIGURED_MISMATCH distinguishes "entry exists but URL is stale" from
+## "no entry at all" (NOT_CONFIGURED). The dock uses this to offer a
+## "Reconfigure mismatched" escape hatch after a port change without making
+## the user remember which clients they configured. See issue #166.
+enum Status { NOT_CONFIGURED, CONFIGURED, CONFIGURED_MISMATCH, ERROR }
 
 var id: String = ""                              ## stable key, e.g. "cursor"
 var display_name: String = ""                    ## "Cursor"

--- a/plugin/addons/godot_ai/clients/_json_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_json_strategy.gd
@@ -31,9 +31,12 @@ static func check_status(client: McpClient, server_name: String, server_url: Str
 	var entry = holder[server_name]
 	if not (entry is Dictionary):
 		return McpClient.Status.NOT_CONFIGURED
+	# Entry exists — if URL doesn't match our current server, it's drift, not absence.
+	# Lets the dock surface a "Reconfigure" banner after a port change instead of
+	# letting a stale URL silently disguise itself as "not configured".
 	if client.verify_entry.is_valid():
-		return McpClient.Status.CONFIGURED if client.verify_entry.call(entry, server_url) else McpClient.Status.NOT_CONFIGURED
-	return McpClient.Status.CONFIGURED if entry.get(client.entry_url_field, "") == server_url else McpClient.Status.NOT_CONFIGURED
+		return McpClient.Status.CONFIGURED if client.verify_entry.call(entry, server_url) else McpClient.Status.CONFIGURED_MISMATCH
+	return McpClient.Status.CONFIGURED if entry.get(client.entry_url_field, "") == server_url else McpClient.Status.CONFIGURED_MISMATCH
 
 
 static func remove(client: McpClient, server_name: String) -> Dictionary:

--- a/plugin/addons/godot_ai/clients/_toml_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_toml_strategy.gd
@@ -57,8 +57,10 @@ static func check_status(client: McpClient, _server_name: String, server_url: St
 				configured_url = trimmed.substr(first + 1, last - first - 1)
 		elif trimmed.begins_with("enabled ="):
 			enabled = trimmed.to_lower().find("false") < 0
-	if configured_url != server_url or not enabled:
+	if not enabled:
 		return McpClient.Status.NOT_CONFIGURED
+	if configured_url != server_url:
+		return McpClient.Status.CONFIGURED_MISMATCH
 	return McpClient.Status.CONFIGURED
 
 

--- a/plugin/addons/godot_ai/clients/claude_code.gd
+++ b/plugin/addons/godot_ai/clients/claude_code.gd
@@ -18,8 +18,12 @@ func _init() -> void:
 		if exit_code != 0 or output.is_empty():
 			return McpClient.Status.NOT_CONFIGURED
 		var text: String = output[0]
-		if text.find(name) < 0 or text.find(url) < 0:
+		if text.find(name) < 0:
 			return McpClient.Status.NOT_CONFIGURED
+		# Server name is present but the URL isn't — drift (usually a port change).
+		# Surfacing as MISMATCH lets the dock offer a one-click reconfigure.
+		if text.find(url) < 0:
+			return McpClient.Status.CONFIGURED_MISMATCH
 		return McpClient.Status.CONFIGURED
 	manual_command_builder = func(name: String, url: String, _path: String) -> String:
 		return "claude mcp add --scope user --transport http %s %s" % [name, url]

--- a/plugin/addons/godot_ai/handlers/client_handler.gd
+++ b/plugin/addons/godot_ai/handlers/client_handler.gd
@@ -39,6 +39,8 @@ func check_client_status(_params: Dictionary) -> Dictionary:
 				status_str = "configured"
 			McpClient.Status.NOT_CONFIGURED:
 				status_str = "not_configured"
+			McpClient.Status.CONFIGURED_MISMATCH:
+				status_str = "configured_mismatch"
 		clients.append({
 			"id": client_id,
 			"display_name": McpClientConfigurator.client_display_name(client_id),

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -12,6 +12,7 @@ const MODE_OVERRIDE_VALUES := ["", "user", "dev"]
 const MODE_OVERRIDE_LABELS := ["Auto", "Force user", "Force dev"]
 static var COLOR_MUTED := Color(0.7, 0.7, 0.7)
 static var COLOR_HEADER := Color(0.95, 0.95, 0.95)
+static var COLOR_DRIFT := Color(1.0, 0.75, 0.25)  ## amber — drifted client URL
 
 var _connection: Connection
 var _log_buffer: McpLogBuffer
@@ -25,12 +26,36 @@ var _client_grid: VBoxContainer
 var _client_configure_all_btn: Button
 var _clients_summary_label: Label
 var _clients_window: Window
+## Drift banner — shown when ≥1 client has CONFIGURED_MISMATCH status
+## (usually after the user moves http_port). See issue #166.
+var _drift_banner: HBoxContainer
+var _drift_label: Label
+var _drift_reconfigure_btn: Button
 var _dev_mode_toggle: CheckButton
 var _install_label: Label
 
 ## Per-client UI handles, keyed by client id. Each entry holds the row's
 ## status dot, configure button, remove button, manual-command panel + text.
 var _client_rows: Dictionary = {}
+
+## Authoritative per-client status, keyed by client id. `_apply_row_status`
+## is the single writer; summary + drift banner + reconfigure-drifted read
+## from here instead of re-reading the dot color as state. Avoids a subtle
+## bug where a future theme change recolors the dot and silently breaks
+## the count.
+var _client_statuses: Dictionary = {}
+
+## Monotonic clock of the last focus-triggered status sweep. CLI clients
+## shell out (`claude mcp list`), so alt-tabbing rapidly between apps
+## must not re-run them on every focus event.
+var _last_focus_sweep_msec: int = 0
+const FOCUS_SWEEP_COOLDOWN_MSEC := 2000
+
+## Last drift count rendered into the banner. `_refresh_drift_banner` is
+## called from every client refresh — short-circuiting when nothing
+## changed keeps the label text from flickering and avoids redundant
+## layout passes.
+var _last_drift_count: int = -1
 
 # Dev-mode only
 var _dev_section: VBoxContainer
@@ -108,6 +133,18 @@ func _notification(what: int) -> void:
 	# Detect dock/undock by watching for reparenting events.
 	if what == NOTIFICATION_PARENTED or what == NOTIFICATION_UNPARENTED:
 		_update_redock_visibility.call_deferred()
+	# Re-sweep client statuses when the editor window regains focus so drift
+	# caused by external edits (another agent, a manual config edit, a peer
+	# session changing http_port) surfaces without making the user reopen
+	# the Clients window. Event-driven — no per-frame polling.
+	elif what == NOTIFICATION_APPLICATION_FOCUS_IN:
+		if _client_rows.is_empty():
+			return
+		var now := Time.get_ticks_msec()
+		if now - _last_focus_sweep_msec < FOCUS_SWEEP_COOLDOWN_MSEC:
+			return
+		_last_focus_sweep_msec = now
+		_refresh_all_client_statuses.call_deferred()
 
 
 func _is_floating() -> bool:
@@ -317,6 +354,21 @@ func _build_ui() -> void:
 	clients_row.add_child(clients_open_btn)
 
 	add_child(clients_row)
+
+	_drift_banner = HBoxContainer.new()
+	_drift_banner.add_theme_constant_override("separation", 6)
+	_drift_banner.visible = false
+	_drift_label = Label.new()
+	_drift_label.add_theme_color_override("font_color", COLOR_DRIFT)
+	_drift_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_drift_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_drift_banner.add_child(_drift_label)
+	_drift_reconfigure_btn = Button.new()
+	_drift_reconfigure_btn.text = "Reconfigure"
+	_drift_reconfigure_btn.tooltip_text = "Rewrite every client whose stored URL no longer matches this server"
+	_drift_reconfigure_btn.pressed.connect(_on_reconfigure_drifted_clients)
+	_drift_banner.add_child(_drift_reconfigure_btn)
+	add_child(_drift_banner)
 
 	_clients_window = Window.new()
 	_clients_window.title = "Configure MCP Clients"
@@ -601,12 +653,6 @@ func _build_port_picker_section() -> void:
 
 	_port_picker_section.add_child(picker_row)
 	_crash_panel.add_child(_port_picker_section)
-	## TODO: a follow-up PR should add a client-config drift detector
-	## (event-driven, fires on plugin load / after Apply+Reload / on
-	## editor focus-in). When any configured client's stored URL no
-	## longer matches `http_url()`, it renders its own banner next to
-	## the Clients section — that's separate from this spawn-failure
-	## panel and shouldn't be wedged in here.
 
 
 func _on_apply_new_port() -> void:
@@ -910,9 +956,9 @@ func _on_configure_all_clients() -> void:
 func _on_open_clients_window() -> void:
 	if _clients_window == null:
 		return
-	# popup_centered() with a minsize forces the window to that size and
-	# centers on the parent viewport. Setting .size on a hidden Window
-	# doesn't always take effect, so we force it at popup time here.
+	# Deferred so the popup can paint first; the sweep hits CLI shell-outs
+	# (`claude mcp list`) and would otherwise stall the window open.
+	_refresh_all_client_statuses.call_deferred()
 	_clients_window.popup_centered(Vector2i(640, 600))
 
 
@@ -922,16 +968,42 @@ func _on_clients_window_close_requested() -> void:
 
 
 func _refresh_clients_summary() -> void:
-	# Count from row dot colors — `_apply_row_status` is the single source of
-	# truth, and reading colors avoids re-running filesystem-hitting status
-	# checks on every refresh.
 	if _clients_summary_label == null:
 		return
 	var configured := 0
-	for row in _client_rows.values():
-		if (row["dot"] as ColorRect).color == Color.GREEN:
+	var drifted := 0
+	for status in _client_statuses.values():
+		if status == McpClient.Status.CONFIGURED:
 			configured += 1
+		elif status == McpClient.Status.CONFIGURED_MISMATCH:
+			drifted += 1
 	_clients_summary_label.text = "%d / %d configured" % [configured, _client_rows.size()]
+	_refresh_drift_banner(drifted)
+
+
+func _refresh_drift_banner(drifted: int) -> void:
+	if _drift_banner == null:
+		return
+	if drifted == _last_drift_count:
+		return
+	_last_drift_count = drifted
+	if drifted <= 0:
+		_drift_banner.visible = false
+		return
+	var port := McpClientConfigurator.http_port()
+	_drift_label.text = (
+		"%d client%s still point at an older URL (current: 127.0.0.1:%d)."
+		% [drifted, "" if drifted == 1 else "s", port]
+	)
+	_drift_banner.visible = true
+
+
+func _on_reconfigure_drifted_clients() -> void:
+	for client_id in _client_statuses:
+		if _client_statuses[client_id] != McpClient.Status.CONFIGURED_MISMATCH:
+			continue
+		_on_configure_client(client_id)
+	_refresh_clients_summary()
 
 
 func _show_manual_command_for(client_id: String) -> void:
@@ -964,6 +1036,7 @@ func _apply_row_status(client_id: String, status: McpClient.Status, error_msg: S
 	var row: Dictionary = _client_rows.get(client_id, {})
 	if row.is_empty():
 		return
+	_client_statuses[client_id] = status
 	var dot: ColorRect = row["dot"]
 	var configure_btn: Button = row["configure_btn"]
 	var remove_btn: Button = row["remove_btn"]
@@ -975,6 +1048,11 @@ func _apply_row_status(client_id: String, status: McpClient.Status, error_msg: S
 			configure_btn.text = "Reconfigure"
 			remove_btn.visible = true
 			name_label.text = base_name
+		McpClient.Status.CONFIGURED_MISMATCH:
+			dot.color = COLOR_DRIFT
+			configure_btn.text = "Reconfigure"
+			remove_btn.visible = true
+			name_label.text = "%s  (stale URL)" % base_name
 		McpClient.Status.NOT_CONFIGURED:
 			dot.color = COLOR_MUTED
 			configure_btn.text = "Configure"

--- a/src/godot_ai/tools/client.py
+++ b/src/godot_ai/tools/client.py
@@ -45,7 +45,10 @@ def register_client_tools(mcp: FastMCP) -> None:
         Returns a dict with a "clients" array. Each entry has:
             id            stable identifier (use with client_configure)
             display_name  human-readable name
-            status        "configured" | "not_configured" | "error"
+            status        "configured" | "configured_mismatch" | "not_configured" | "error"
+                          "configured_mismatch" means an entry exists but the stored
+                          URL no longer matches this server (usually after a port
+                          change) — call client_configure to refresh.
             installed     bool — true if the client appears to be present locally
         """
         runtime = DirectRuntime.from_context(ctx)

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -15,6 +15,11 @@ var _scratch_dir: String
 ## port if a test fails mid-flight.
 var _saved_http_port: Variant = null
 var _saved_ws_port: Variant = null
+## Captures `{client_id: original_path_template}` for any registry descriptor
+## a test redirects to a scratch file. `suite_teardown` restores these so a
+## mid-test failure (null deref, unexpected exception) can't leak a scratch
+## path into the next test run.
+var _registry_path_backups: Dictionary = {}
 
 
 func suite_name() -> String:
@@ -38,7 +43,25 @@ func suite_teardown() -> void:
 	# stays around for the next run; only the JSON / TOML files matter.
 	for f in DirAccess.get_files_at(_scratch_dir):
 		DirAccess.remove_absolute(_scratch_dir.path_join(f))
+	for client_id in _registry_path_backups:
+		var client := McpClientRegistry.get_by_id(client_id)
+		if client != null:
+			client.path_template = _registry_path_backups[client_id]
+	_registry_path_backups.clear()
 	_restore_port_settings()
+
+
+## Redirect a registered client's path_template to a scratch file for the
+## duration of the suite. Records the original so suite_teardown can restore
+## it even if the test fails mid-assertion.
+func _redirect_client_path(client_id: String, path: String) -> McpClient:
+	var client := McpClientRegistry.get_by_id(client_id)
+	if client == null:
+		return null
+	if not _registry_path_backups.has(client_id):
+		_registry_path_backups[client_id] = client.path_template
+	client.path_template = {"darwin": path, "windows": path, "linux": path, "unix": path}
+	return client
 
 
 # ----- registry sanity -----
@@ -465,9 +488,10 @@ func test_json_strategy_round_trip() -> void:
 	var status := McpJsonStrategy.check_status(client, "godot-ai", "http://127.0.0.1:8000/mcp")
 	assert_eq(status, McpClient.Status.CONFIGURED)
 
-	# A wrong URL should not be reported as configured.
+	# A wrong URL means drift (entry exists, stale URL), not absence.
+	# The dock uses this to show the "Reconfigure" banner after a port change.
 	var wrong_status := McpJsonStrategy.check_status(client, "godot-ai", "http://wrong/")
-	assert_eq(wrong_status, McpClient.Status.NOT_CONFIGURED)
+	assert_eq(wrong_status, McpClient.Status.CONFIGURED_MISMATCH)
 
 	var removed := McpJsonStrategy.remove(client, "godot-ai")
 	assert_eq(removed.get("status"), "ok")
@@ -629,6 +653,121 @@ func test_vscode_uses_servers_key_with_type_http() -> void:
 	var entry: Dictionary = c.entry_builder.call("godot-ai", "http://x")
 	assert_eq(entry.get("type", ""), "http")
 	assert_eq(entry.get("url", ""), "http://x")
+
+
+# ----- drift detection (CONFIGURED_MISMATCH) -----
+#
+# The dock's client-config drift banner (issue #166) fires when a stored
+# client entry exists but its URL no longer matches the server. These tests
+# lock in the three strategies' discrimination between NOT_CONFIGURED
+# (no entry) and CONFIGURED_MISMATCH (entry present, wrong URL).
+
+
+func test_json_strategy_reports_drift_not_absent_when_url_changes() -> void:
+	var path := _scratch_dir.path_join("drift.json")
+	_remove_if_exists(path)
+	var client := _make_test_json_client(path)
+	assert_eq(McpJsonStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp").get("status"), "ok")
+	# Server moved to a new port — stored entry is now stale.
+	assert_eq(
+		McpJsonStrategy.check_status(client, "godot-ai", "http://127.0.0.1:8321/mcp"),
+		McpClient.Status.CONFIGURED_MISMATCH,
+		"Stored URL no longer matches — should report drift, not absence",
+	)
+
+
+func test_json_strategy_reports_not_configured_when_entry_absent() -> void:
+	var path := _scratch_dir.path_join("absent.json")
+	_remove_if_exists(path)
+	var client := _make_test_json_client(path)
+	# File doesn't exist yet — nothing configured.
+	assert_eq(
+		McpJsonStrategy.check_status(client, "godot-ai", "http://127.0.0.1:8000/mcp"),
+		McpClient.Status.NOT_CONFIGURED,
+	)
+
+
+func test_json_strategy_drift_uses_custom_verify_entry() -> void:
+	# Clients with a custom verifier (e.g. Antigravity's `serverUrl`/`disabled`
+	# pair) must still distinguish drift from absence. When verify_entry
+	# rejects a present entry, result should be MISMATCH, not NOT_CONFIGURED.
+	var path := _scratch_dir.path_join("verify_drift.json")
+	_remove_if_exists(path)
+	var client := McpClient.new()
+	client.id = "verify_test"
+	client.display_name = "Verify Test"
+	client.config_type = "json"
+	client.path_template = {"darwin": path, "windows": path, "linux": path, "unix": path}
+	client.server_key_path = PackedStringArray(["mcpServers"])
+	client.entry_builder = func(_n: String, u: String) -> Dictionary:
+		return {"serverUrl": u, "disabled": false}
+	client.verify_entry = func(entry: Dictionary, url: String) -> bool:
+		return entry.get("serverUrl", "") == url and not entry.get("disabled", true)
+
+	assert_eq(McpJsonStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp").get("status"), "ok")
+	assert_eq(
+		McpJsonStrategy.check_status(client, "godot-ai", "http://127.0.0.1:9000/mcp"),
+		McpClient.Status.CONFIGURED_MISMATCH,
+	)
+
+
+func test_toml_strategy_reports_drift_when_url_changes() -> void:
+	var path := _scratch_dir.path_join("drift.toml")
+	_remove_if_exists(path)
+	var client := _make_test_toml_client(path)
+	assert_eq(McpTomlStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp").get("status"), "ok")
+	assert_eq(
+		McpTomlStrategy.check_status(client, "godot-ai", "http://127.0.0.1:8321/mcp"),
+		McpClient.Status.CONFIGURED_MISMATCH,
+	)
+
+
+func test_toml_strategy_enabled_false_reports_not_configured() -> void:
+	# A present-but-disabled Codex section is closer to absence than drift —
+	# the user explicitly opted out. Surfacing it as MISMATCH would be noisy
+	# (the reconfigure CTA would silently re-enable a server the user turned
+	# off).
+	var path := _scratch_dir.path_join("disabled.toml")
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	f.store_string("[mcp_servers.\"godot-ai\"]\nurl = \"http://127.0.0.1:8000/mcp\"\nenabled = false\n")
+	f.close()
+	var client := _make_test_toml_client(path)
+	assert_eq(
+		McpTomlStrategy.check_status(client, "godot-ai", "http://127.0.0.1:8000/mcp"),
+		McpClient.Status.NOT_CONFIGURED,
+	)
+
+
+func test_handler_emits_configured_mismatch_string() -> void:
+	# End-to-end: configure a real registered client against a scratch JSON
+	# file, flip the plugin's http_port so the stored URL becomes stale, and
+	# assert the handler's wire output includes "configured_mismatch" for
+	# that client. Lands the enum → string mapping without relying on a
+	# duplicate match statement inside the test.
+	var path := _scratch_dir.path_join("handler_drift_cursor.json")
+	_remove_if_exists(path)
+	var cursor := _redirect_client_path("cursor", path)
+	assert_true(cursor != null, "cursor client missing from registry")
+
+	_clear_port_settings()
+	var es := EditorInterface.get_editor_settings()
+	assert_true(es != null, "EditorSettings unavailable")
+	es.set_setting(McpClientConfigurator.SETTING_HTTP_PORT, 8000)
+	assert_eq(McpClientConfigurator.configure("cursor").get("status"), "ok")
+
+	# Move the port so the stored URL no longer matches.
+	es.set_setting(McpClientConfigurator.SETTING_HTTP_PORT, 8321)
+
+	var result := _handler.check_client_status({})
+	assert_has_key(result, "data")
+	var entries: Array = result.data.clients
+	var cursor_status := ""
+	for entry in entries:
+		if entry.get("id", "") == "cursor":
+			cursor_status = entry.get("status", "")
+			break
+	assert_eq(cursor_status, "configured_mismatch")
+	_clear_port_settings()
 
 
 # ----- helpers -----

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -46,6 +46,33 @@ func test_install_label_mouse_filter_allows_tooltip() -> void:
 	assert_eq(_dock._install_label.mouse_filter, Control.MOUSE_FILTER_STOP)
 
 
+func test_drift_banner_hidden_when_no_drift() -> void:
+	_dock._build_ui()
+	# Fresh dock with everything NOT_CONFIGURED by default → banner stays hidden.
+	_dock._refresh_drift_banner(0)
+	assert_false(_dock._drift_banner.visible, "Banner must stay hidden when no clients drifted")
+
+
+func test_drift_banner_visible_with_count_and_port() -> void:
+	_dock._build_ui()
+	_dock._refresh_drift_banner(3)
+	assert_true(_dock._drift_banner.visible, "Banner must surface when any client drifted")
+	# Label cites the drifted count and the current port so the user knows
+	# which server the reconfigure will point at. Prevents head-scratching
+	# about "3 clients drifted but drifted from what?".
+	var text: String = _dock._drift_label.text
+	assert_contains(text, "3")
+	assert_contains(text, str(McpClientConfigurator.http_port()))
+
+
+func test_drift_banner_singular_vs_plural() -> void:
+	_dock._build_ui()
+	_dock._refresh_drift_banner(1)
+	assert_contains(_dock._drift_label.text, "1 client ", "Singular count must not pluralize")
+	_dock._refresh_drift_banner(2)
+	assert_contains(_dock._drift_label.text, "2 clients", "Plural count must pluralize")
+
+
 func test_dev_checkout_tooltip_exposes_symlink_target() -> void:
 	if not McpClientConfigurator.is_dev_checkout():
 		skip("only meaningful in dev checkout")


### PR DESCRIPTION
## Summary

- Adds a `CONFIGURED_MISMATCH` client status distinguishing "entry exists but URL is stale" from "no entry at all." After the user changes `http_port` via the picker, previously-configured clients silently kept pointing at the old URL and still looked green in the dock.
- New amber banner above the Clients row cites the drifted count + current port, with a single **Reconfigure** button that rewrites every mismatched entry.
- JSON / TOML / CLI strategies updated to detect mismatch; handler emits the new `"configured_mismatch"` wire string.
- Dock refactor: `_client_statuses` dict is the single source of truth (no more color-as-state), FOCUS_IN sweeps are debounced (2s cooldown) so rapid alt-tab does not re-shell-out CLI clients, and banner refresh short-circuits when the count is unchanged.
- Event-driven refresh only — no per-frame polling.

Closes #166.

## Test plan

- [x] `pytest` — 547 passed
- [x] `ruff check` — clean
- [x] GDScript `test_run` — 774 passed / 14 skipped / 0 failed across 33 suites
- [x] New tests: 6 strategy-level (`test_clients.gd`: JSON drift vs absent, TOML enabled=false vs URL mismatch, custom `verify_entry`, handler wire-string emission) + 3 dock-level (`test_dock.gd`: banner hidden when no drift, shows count+port, singular vs plural)
- [x] Live smoke via MCP `client_status` — all 18 clients report correct statuses
- [ ] Manual in-editor smoke of the amber banner after an Apply+Reload port change (reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
