### PR TITLE
fix(dock): prime uvx cache before tearing down server on self-update

### DIFF
--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -105,6 +105,15 @@ var _download_request: HTTPRequest
 var _update_label: Label
 var _update_btn: Button
 var _latest_download_url := ""
+var _remote_update_version := ""
+## Threaded precheck state. `uvx --refresh` re-queries PyPI for the target
+## version before we tear down the running server — guards against the
+## stale-index failure where uvx spawns, resolves "no such version," and
+## exits inside SPAWN_GRACE_MS, leaving the user in a reconnect loop when
+## the update was triggered within a minute of a fresh PyPI publish.
+var _update_precheck_thread: Thread
+var _update_precheck_timer: Timer
+var _update_precheck := {"done": false, "exit_code": -1, "output": ""}
 const RELEASES_URL := "https://api.github.com/repos/hi-godot/godot-ai/releases/latest"
 const RELEASES_PAGE := "https://github.com/hi-godot/godot-ai/releases/latest"
 const UPDATE_TEMP_DIR := "user://godot_ai_update/"
@@ -1155,6 +1164,7 @@ func _on_update_check_completed(result: int, response_code: int, _headers: Packe
 	var local_version := McpClientConfigurator.get_plugin_version()
 	if not _is_newer(remote_version, local_version):
 		return
+	_remote_update_version = remote_version
 
 	# Find the plugin ZIP asset URL
 	var assets: Array = json.get("assets", [])
@@ -1262,6 +1272,86 @@ func _install_update() -> void:
 	DirAccess.remove_absolute(zip_path)
 	DirAccess.remove_absolute(ProjectSettings.globalize_path(UPDATE_TEMP_DIR))
 
+	_run_update_precheck()
+
+
+## Verify uvx can actually fetch the target version from PyPI before we tear
+## down the running server. On a fresh release the user's uvx still has a
+## stale "latest versions" cache — the spawn-with-new-version silently fails
+## inside SPAWN_GRACE_MS and leaves the user in a reconnect loop (reported
+## on Discord for v1.3.2). `uvx --refresh` re-queries PyPI live; running it
+## in a Thread keeps the editor UI responsive while uvx hits the network.
+## Non-uvx launch tiers (dev_venv / system / unknown) don't resolve via
+## PyPI at spawn time so the precheck is skipped.
+func _run_update_precheck() -> void:
+	var launch_mode := McpClientConfigurator.get_server_launch_mode()
+	if launch_mode != "uvx":
+		_commit_update_reload()
+		return
+	var uvx := McpClientConfigurator.find_uvx()
+	if uvx.is_empty() or _remote_update_version.is_empty():
+		## No way to precheck — fall back to the old behaviour rather than
+		## blocking a legitimate update on our own missing inputs.
+		_commit_update_reload()
+		return
+
+	_update_btn.text = "Preparing server..."
+	_update_precheck = {"done": false, "exit_code": -1, "output": ""}
+	_update_precheck_thread = Thread.new()
+	_update_precheck_thread.start(_update_precheck_worker.bind(uvx, _remote_update_version))
+
+	if _update_precheck_timer == null:
+		_update_precheck_timer = Timer.new()
+		_update_precheck_timer.wait_time = 0.25
+		_update_precheck_timer.timeout.connect(_on_update_precheck_poll)
+		add_child(_update_precheck_timer)
+	_update_precheck_timer.start()
+
+
+func _update_precheck_worker(uvx: String, version: String) -> void:
+	var output: Array = []
+	var code := OS.execute(
+		uvx,
+		["--refresh", "--from", "godot-ai==" + version, "godot-ai", "--version"],
+		output,
+		true,
+	)
+	## Write result fields BEFORE flipping `done`. Main thread polls `done`;
+	## once it reads true it calls `wait_to_finish()` which fully syncs, so
+	## the subsequent reads of exit_code/output are safe.
+	_update_precheck.exit_code = code
+	_update_precheck.output = "\n".join(output)
+	_update_precheck.done = true
+
+
+func _on_update_precheck_poll() -> void:
+	if not _update_precheck.done:
+		return
+	_update_precheck_timer.stop()
+	_update_precheck_thread.wait_to_finish()
+	_update_precheck_thread = null
+	_apply_update_precheck_result(int(_update_precheck.exit_code), _update_precheck.output)
+
+
+## Dispatch on the precheck exit code. Split from the poll loop so tests can
+## exercise the UI-state transitions without spawning a real thread/process.
+func _apply_update_precheck_result(code: int, output: String) -> void:
+	if code == 0:
+		_commit_update_reload()
+		return
+	## Precheck failed — most commonly because PyPI's index still says this
+	## version doesn't exist (propagation delay right after a fresh publish).
+	## Leave the running server alone. The new plugin files are already on
+	## disk, so a later editor restart will pick them up with a fresh uvx
+	## index query (post-TTL) and the drift branch in `_start_server` will
+	## reconcile plugin/server versions.
+	print("MCP | update precheck failed (exit %d): %s" % [code, output])
+	_update_btn.text = "Retry update"
+	_update_btn.disabled = false
+	_update_label.text = "v%s still propagating — try again in a minute" % _remote_update_version
+
+
+func _commit_update_reload() -> void:
 	## Kill the old server before the reload so the re-enabled plugin spawns
 	## a fresh one against the new plugin version. Without this, the running
 	## Python process on port 8000 outlives the reload, `_start_server`

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -125,3 +125,22 @@ func test_dev_checkout_tooltip_exposes_symlink_target() -> void:
 	assert_contains(target, "godot_ai", "Symlink should point at a godot_ai plugin tree: %s" % target)
 	var tooltip: String = _dock._install_mode_tooltip()
 	assert_contains(tooltip, target, "Tooltip should embed the resolved target path")
+
+
+func test_update_precheck_failure_preserves_running_server() -> void:
+	## When `uvx --refresh --from godot-ai==<new>` fails — typically because
+	## PyPI's index cache still says the version doesn't exist right after a
+	## fresh publish — we MUST leave the running server alone and surface a
+	## retry hint. Tearing down the server before confirming uvx can resolve
+	## the new version is what put Discord users in an infinite reconnect
+	## loop (server exits ~5s after spawn, plugin reconnects forever).
+	_dock._build_ui()
+	_dock._remote_update_version = "9.9.9"
+	_dock._apply_update_precheck_result(1, "No solution found — godot-ai==9.9.9 is unsatisfiable")
+	assert_eq(_dock._update_btn.text, "Retry update",
+		"Failure must re-enable the button as a retry — not leave it stuck in 'Preparing server...'")
+	assert_false(_dock._update_btn.disabled, "User must be able to click to retry once PyPI propagates")
+	assert_contains(_dock._update_label.text, "9.9.9",
+		"Label must name the target version so the user knows which retry is pending")
+	assert_contains(_dock._update_label.text, "propagating",
+		"Label must explain the failure mode so the user doesn't assume their install is broken")


### PR DESCRIPTION
## Summary

- Self-update's destructive step (kill running server, reload plugin, spawn new version) races PyPI. When Update is clicked within minutes of a fresh release, uvx's index metadata cache doesn't yet know the new version exists, the spawn fails to resolve the pinned version, and the user sees an infinite reconnect loop.
- Fix: run `uvx --refresh --from godot-ai==<new> godot-ai --version` on a background Thread *before* the destructive step. On success, proceed with the kill + reload. On failure, leave the running server alone and flip the button to "Retry update" with a "still propagating" hint.
- Non-destructive by design: the downloaded plugin files are already on disk from the earlier extract step, so a later editor restart with a warm uvx cache completes the update via the drift branch either way.

## Context

Two distinct update-path bugs have shown up in recent versions:

1. **v1.2.x to v1.3.x**: buggy netstat PID parser killed the wrong PIDs, leaving the real server alive on port 8000. Fixed in v1.3.1 via the pid-file mechanism.
2. **v1.3.x onward**: uvx PyPI index-cache staleness (this PR). Confirmed by rolling back to v1.3.1, cutting v1.3.2, clicking Update with a cold cache (fails the same way) and again with a warm cache (succeeds).

A Discord user hit this right after the v1.3.1 publish; server log showed it exiting cleanly about 5s after spawn, matching the uvx resolve-failure timing.

## Test plan

- [x] `script/ci-check-gdscript` passes
- [x] Added `test_update_precheck_failure_preserves_running_server` to `test_project/tests/test_dock.gd` asserting the button re-enables as "Retry update" and the label names the target version plus propagating hint
- [ ] Full GDScript test suite in CI
- [ ] Manual verification on next real release: publish, immediately click Update in an editor on the prior version, expect the Retry banner rather than a dead server

Generated with Claude Code
