### PR TITLE
fix(plugin): retry uvx spawn with --refresh on stale PyPI index (#172)

### DIFF
--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -246,7 +246,12 @@ static func _is_symlink(path: String) -> bool:
 	return dir != null and dir.is_link(path)
 
 
-static func get_server_command() -> Array[String]:
+## `refresh` forces uvx to re-fetch PyPI index metadata on spawn — used by
+## `_start_server`'s one-shot retry when the first attempt exited fast with
+## no pid-file on the uvx tier (stale-index-cache failure mode). No-op on
+## other tiers: dev_venv and system resolve locally, so the flag has nowhere
+## to go. See plugin.gd::_should_retry_with_refresh.
+static func get_server_command(refresh: bool = false) -> Array[String]:
 	var venv_python := _cached_venv_python()
 	if not venv_python.is_empty():
 		print("MCP | using dev venv: %s" % venv_python)
@@ -263,8 +268,12 @@ static func get_server_command() -> Array[String]:
 		## otherwise uvx installs the exact version fresh. Keeps plugin and
 		## server version in lockstep without needing `--refresh-package` on
 		## every spawn. See issue #133.
-		print("MCP | using uvx (godot-ai==%s)" % version)
-		return [uvx, "--from", "godot-ai==%s" % version, "godot-ai"]
+		print("MCP | using uvx (godot-ai==%s)%s" % [version, " [refresh]" if refresh else ""])
+		var cmd: Array[String] = [uvx]
+		if refresh:
+			cmd.append("--refresh")
+		cmd.append_array(["--from", "godot-ai==%s" % version, "godot-ai"])
+		return cmd
 
 	var system_cmd := _find_system_install()
 	if not system_cmd.is_empty():

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -105,15 +105,6 @@ var _download_request: HTTPRequest
 var _update_label: Label
 var _update_btn: Button
 var _latest_download_url := ""
-var _remote_update_version := ""
-## Threaded precheck state. `uvx --refresh` re-queries PyPI for the target
-## version before we tear down the running server — guards against the
-## stale-index failure where uvx spawns, resolves "no such version," and
-## exits inside SPAWN_GRACE_MS, leaving the user in a reconnect loop when
-## the update was triggered within a minute of a fresh PyPI publish.
-var _update_precheck_thread: Thread
-var _update_precheck_timer: Timer
-var _update_precheck := {"done": false, "exit_code": -1, "output": ""}
 const RELEASES_URL := "https://api.github.com/repos/hi-godot/godot-ai/releases/latest"
 const RELEASES_PAGE := "https://github.com/hi-godot/godot-ai/releases/latest"
 const UPDATE_TEMP_DIR := "user://godot_ai_update/"
@@ -642,6 +633,13 @@ static func _crash_body_for_state(state: String) -> String:
 		McpSpawnState.FOREIGN_PORT:
 			return "Another process is already bound to port %d. Pick a free port or stop the other process." % port
 		McpSpawnState.CRASHED:
+			## Both spawn attempts failed on the uvx tier — almost always
+			## means PyPI hasn't propagated this version yet (~10 min after
+			## publish). `_start_server` already tried `--refresh` once, so
+			## the next realistic move is to wait and reload.
+			if McpClientConfigurator.get_server_launch_mode() == "uvx":
+				var version := McpClientConfigurator.get_plugin_version()
+				return "The server exited before the WebSocket handshake, even after a `uvx --refresh` retry. If this is a brand-new release, PyPI's index may still be propagating (~10 min). Wait a moment and click Reload Plugin to retry, or check Godot's output log for Python's traceback. Target: godot-ai==%s." % version
 			return "The server exited before the WebSocket handshake. Check Godot's output log (bottom panel) for Python's traceback."
 		McpSpawnState.NO_COMMAND:
 			return "No godot-ai server found. Install `uv` via the Setup panel above, or run `pip install godot-ai`."
@@ -1164,7 +1162,6 @@ func _on_update_check_completed(result: int, response_code: int, _headers: Packe
 	var local_version := McpClientConfigurator.get_plugin_version()
 	if not _is_newer(remote_version, local_version):
 		return
-	_remote_update_version = remote_version
 
 	# Find the plugin ZIP asset URL
 	var assets: Array = json.get("assets", [])
@@ -1272,92 +1269,17 @@ func _install_update() -> void:
 	DirAccess.remove_absolute(zip_path)
 	DirAccess.remove_absolute(ProjectSettings.globalize_path(UPDATE_TEMP_DIR))
 
-	_run_update_precheck()
-
-
-## Verify uvx can actually fetch the target version from PyPI before we tear
-## down the running server. On a fresh release the user's uvx still has a
-## stale "latest versions" cache — the spawn-with-new-version silently fails
-## inside SPAWN_GRACE_MS and leaves the user in a reconnect loop (reported
-## on Discord for v1.3.2). `uvx --refresh` re-queries PyPI live; running it
-## in a Thread keeps the editor UI responsive while uvx hits the network.
-## Non-uvx launch tiers (dev_venv / system / unknown) don't resolve via
-## PyPI at spawn time so the precheck is skipped.
-func _run_update_precheck() -> void:
-	var launch_mode := McpClientConfigurator.get_server_launch_mode()
-	if launch_mode != "uvx":
-		_commit_update_reload()
-		return
-	var uvx := McpClientConfigurator.find_uvx()
-	if uvx.is_empty() or _remote_update_version.is_empty():
-		## No way to precheck — fall back to the old behaviour rather than
-		## blocking a legitimate update on our own missing inputs.
-		_commit_update_reload()
-		return
-
-	_update_btn.text = "Preparing server..."
-	_update_precheck = {"done": false, "exit_code": -1, "output": ""}
-	_update_precheck_thread = Thread.new()
-	_update_precheck_thread.start(_update_precheck_worker.bind(uvx, _remote_update_version))
-
-	if _update_precheck_timer == null:
-		_update_precheck_timer = Timer.new()
-		_update_precheck_timer.wait_time = 0.25
-		_update_precheck_timer.timeout.connect(_on_update_precheck_poll)
-		add_child(_update_precheck_timer)
-	_update_precheck_timer.start()
-
-
-func _update_precheck_worker(uvx: String, version: String) -> void:
-	var output: Array = []
-	var code := OS.execute(
-		uvx,
-		["--refresh", "--from", "godot-ai==" + version, "godot-ai", "--version"],
-		output,
-		true,
-	)
-	## Write result fields BEFORE flipping `done`. Main thread polls `done`;
-	## once it reads true it calls `wait_to_finish()` which fully syncs, so
-	## the subsequent reads of exit_code/output are safe.
-	_update_precheck.exit_code = code
-	_update_precheck.output = "\n".join(output)
-	_update_precheck.done = true
-
-
-func _on_update_precheck_poll() -> void:
-	if not _update_precheck.done:
-		return
-	_update_precheck_timer.stop()
-	_update_precheck_thread.wait_to_finish()
-	_update_precheck_thread = null
-	_apply_update_precheck_result(int(_update_precheck.exit_code), _update_precheck.output)
-
-
-## Dispatch on the precheck exit code. Split from the poll loop so tests can
-## exercise the UI-state transitions without spawning a real thread/process.
-func _apply_update_precheck_result(code: int, output: String) -> void:
-	if code == 0:
-		_commit_update_reload()
-		return
-	## Precheck failed — most commonly because PyPI's index still says this
-	## version doesn't exist (propagation delay right after a fresh publish).
-	## Leave the running server alone. The new plugin files are already on
-	## disk, so a later editor restart will pick them up with a fresh uvx
-	## index query (post-TTL) and the drift branch in `_start_server` will
-	## reconcile plugin/server versions.
-	print("MCP | update precheck failed (exit %d): %s" % [code, output])
-	_update_btn.text = "Retry update"
-	_update_btn.disabled = false
-	_update_label.text = "v%s still propagating — try again in a minute" % _remote_update_version
-
-
-func _commit_update_reload() -> void:
 	## Kill the old server before the reload so the re-enabled plugin spawns
 	## a fresh one against the new plugin version. Without this, the running
 	## Python process on port 8000 outlives the reload, `_start_server`
 	## short-circuits on "port already in use," and session_list reports
 	## `plugin_version != server_version` until the user restarts the
 	## editor. See issue #132.
+	##
+	## Stale-PyPI-index recovery (#171/#172): the new `_start_server` self-heals
+	## by retrying once with `uvx --refresh` when the first spawn dies without
+	## writing the pid-file on the uvx tier. Every spawn path benefits — this
+	## removes the need for a dock-side precheck before the reload.
 	if _plugin != null and _plugin.has_method("prepare_for_update_reload"):
 		_plugin.prepare_for_update_reload()
 

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -51,6 +51,12 @@ var _server_watch_timer: Timer = null
 ## set at the exact point of failure and never cleared during the
 ## plugin session — reload the plugin to retry.
 var _spawn_state: String = McpSpawnState.OK
+## One-shot guard for the stale-uvx-index recovery (see
+## `_should_retry_with_refresh`). Reset at the top of `_start_server` so
+## each fresh spawn attempt gets its own refresh budget; set to true the
+## moment we respawn with `--refresh` so a second failure falls through
+## to CRASHED instead of looping.
+var _refresh_retried: bool = false
 
 
 func _enter_tree() -> void:
@@ -339,6 +345,8 @@ func _start_server() -> void:
 		## same editor session, preventing cascading server process creation.
 		return
 
+	_refresh_retried = false
+
 	var port := McpClientConfigurator.http_port()
 	var ws_port := McpClientConfigurator.ws_port()
 	var current_version := McpClientConfigurator.get_plugin_version()
@@ -491,6 +499,10 @@ func _check_server_health() -> void:
 		_server_pid = real_pid
 	elif not _pid_alive(_server_pid):
 		if elapsed >= SPAWN_GRACE_MS and _spawn_state == McpSpawnState.OK:
+			if _should_retry_with_refresh():
+				_refresh_retried = true
+				_respawn_with_refresh()
+				return
 			_server_exit_ms = elapsed
 			_set_spawn_state(McpSpawnState.CRASHED)
 			_log_buffer.log("server exited after %dms — see Godot output log" % _server_exit_ms)
@@ -499,6 +511,78 @@ func _check_server_health() -> void:
 	if elapsed >= SERVER_WATCH_MS:
 		## Server survived startup — stop watching. Mid-session crashes
 		## after this point surface via the WebSocket disconnect path.
+		_stop_server_watch()
+
+
+## True when the first spawn looks like a stale-uvx-index failure and we
+## haven't already retried. Fail signal: launcher process already declared
+## dead by the caller, pid-file was never written (Python never got to
+## argparse), and we're on the uvx tier (the only tier where `--refresh`
+## means anything). Bug #172 — after a fresh PyPI publish, uvx's local
+## index metadata keeps saying the new version doesn't exist for ~10 min,
+## which cascaded into an infinite reconnect loop pre-#171. Retry-at-spawn
+## catches every entry path (Update, Reload Plugin, Reconnect, editor
+## restart, crash recovery) — unlike the older Update-only precheck.
+func _should_retry_with_refresh() -> bool:
+	return _retry_with_refresh_allowed(
+		_refresh_retried,
+		McpClientConfigurator.get_server_launch_mode(),
+		_read_pid_file(),
+	)
+
+
+## Pure decision helper — environment-state readers stay in the instance
+## method above, the logic lives here so tests can drive the three inputs
+## directly without spoofing static caches or pid-files on disk.
+static func _retry_with_refresh_allowed(already_retried: bool, launch_mode: String, pid_from_file: int) -> bool:
+	return (
+		not already_retried
+		and launch_mode == "uvx"
+		and pid_from_file == 0
+	)
+
+
+## Re-run `OS.create_process` with `--refresh` prepended to the uvx args
+## and reset the watch-loop baseline so the next tick evaluates the new
+## process, not the dead one. Does NOT flip `_server_started_this_session`
+## again (already true), does NOT touch the managed-server record (the
+## launcher PID is disposable — what matters is the Python child, which
+## writes its own pid-file if it gets that far).
+func _respawn_with_refresh() -> void:
+	var server_cmd := McpClientConfigurator.get_server_command(true)
+	if server_cmd.is_empty():
+		## Can't happen in practice — we only reach here after a successful
+		## first resolve of `get_server_command()` at the top of `_start_server`
+		## — but keep the shape symmetric so a future refactor doesn't silently
+		## break the retry.
+		return
+	var cmd: String = server_cmd[0]
+	var args: Array[String] = []
+	args.assign(server_cmd.slice(1))
+	var port := McpClientConfigurator.http_port()
+	var ws_port := McpClientConfigurator.ws_port()
+	args.append_array([
+		"--transport", "streamable-http",
+		"--port", str(port),
+		"--ws-port", str(ws_port),
+		"--pid-file", ProjectSettings.globalize_path(SERVER_PID_FILE),
+	])
+	_clear_pid_file()
+	_log_buffer.log("retrying with --refresh (PyPI index may be stale)")
+	print("MCP | retrying with --refresh (PyPI index may be stale)")
+	_server_pid = OS.create_process(cmd, args)
+	if _server_pid > 0:
+		_server_spawn_ms = Time.get_ticks_msec()
+		_server_exit_ms = 0
+		var current_version := McpClientConfigurator.get_plugin_version()
+		_write_managed_server_record(_server_pid, current_version)
+		print("MCP | retried server (PID %d, v%s): %s %s" % [_server_pid, current_version, cmd, " ".join(args)])
+	else:
+		## OS.create_process returned -1 on the retry — can't distinguish this
+		## from a real crash, so surface CRASHED immediately rather than
+		## looping. `_refresh_retried` is already true so we won't try again.
+		_set_spawn_state(McpSpawnState.CRASHED)
+		_log_buffer.log("refresh retry failed to spawn — see Godot output log")
 		_stop_server_watch()
 
 

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -785,7 +785,7 @@ func _finalize_stop_if_port_free(port: int) -> bool:
 ## Windows tasklist equivalent. Used by _start_server to distinguish a live
 ## managed server that outlived its editor from a stale EditorSettings
 ## record pointing at a PID that no longer exists.
-func _pid_alive(pid: int) -> bool:
+static func _pid_alive(pid: int) -> bool:
 	if pid <= 0:
 		return false
 	if OS.get_name() == "Windows":
@@ -800,8 +800,20 @@ func _pid_alive(pid: int) -> bool:
 			if str(line).find("\"%d\"" % pid) >= 0:
 				return true
 		return false
-	var exit_code := OS.execute("kill", ["-0", str(pid)], [], true)
-	return exit_code == 0
+	## `kill -0` returns 0 for BOTH running and zombie processes, and Godot
+	## never `waitpid`s on `OS.create_process` children — so an `uvx` launcher
+	## that fails-fast (~40ms for "no solution" on a bogus version, or a stale
+	## PyPI index) lingers as a zombie forever. `kill -0` would report it as
+	## alive, blocking the spawn-failure branch in `_check_server_health` from
+	## ever firing. Ask `ps` for the actual process state instead. State column
+	## codes on Darwin/Linux: running/sleeping (R/S/D/I/T), zombie (Z),
+	## unknown-but-exited (empty output / non-zero exit). See #172.
+	var output: Array = []
+	var exit_code := OS.execute("ps", ["-p", str(pid), "-o", "stat="], output, true)
+	if exit_code != 0 or output.is_empty():
+		return false
+	var stat := str(output[0]).strip_edges()
+	return not stat.is_empty() and not stat.begins_with("Z")
 
 
 ## Poll until the given port is no longer bound, or the timeout elapses.

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -398,12 +398,7 @@ func _start_server() -> void:
 	var cmd: String = server_cmd[0]
 	var args: Array[String] = []
 	args.assign(server_cmd.slice(1))
-	args.append_array([
-		"--transport", "streamable-http",
-		"--port", str(port),
-		"--ws-port", str(ws_port),
-		"--pid-file", ProjectSettings.globalize_path(SERVER_PID_FILE),
-	])
+	args.append_array(_build_server_flags(port, ws_port))
 
 	## Wipe any stale pid-file before spawning so a failed launch can't
 	## leave last session's PID sitting there for _find_managed_pid to
@@ -559,17 +554,9 @@ func _respawn_with_refresh() -> void:
 	var cmd: String = server_cmd[0]
 	var args: Array[String] = []
 	args.assign(server_cmd.slice(1))
-	var port := McpClientConfigurator.http_port()
-	var ws_port := McpClientConfigurator.ws_port()
-	args.append_array([
-		"--transport", "streamable-http",
-		"--port", str(port),
-		"--ws-port", str(ws_port),
-		"--pid-file", ProjectSettings.globalize_path(SERVER_PID_FILE),
-	])
+	args.append_array(_build_server_flags(McpClientConfigurator.http_port(), McpClientConfigurator.ws_port()))
 	_clear_pid_file()
 	_log_buffer.log("retrying with --refresh (PyPI index may be stale)")
-	print("MCP | retrying with --refresh (PyPI index may be stale)")
 	_server_pid = OS.create_process(cmd, args)
 	if _server_pid > 0:
 		_server_spawn_ms = Time.get_ticks_msec()
@@ -780,11 +767,26 @@ func _finalize_stop_if_port_free(port: int) -> bool:
 	return true
 
 
-## True if the given PID corresponds to a live process. Uses POSIX `kill -0`
-## (doesn't actually kill — just probes whether the process exists) or the
-## Windows tasklist equivalent. Used by _start_server to distinguish a live
+## Shared tail of the server CLI: transport, ports, and `--pid-file`. Both
+## the initial spawn in `_start_server` and the `--refresh` retry in
+## `_respawn_with_refresh` go through here so a new flag added in one place
+## can't silently drop out of the other.
+static func _build_server_flags(port: int, ws_port: int) -> Array[String]:
+	var flags: Array[String] = []
+	flags.assign([
+		"--transport", "streamable-http",
+		"--port", str(port),
+		"--ws-port", str(ws_port),
+		"--pid-file", ProjectSettings.globalize_path(SERVER_PID_FILE),
+	])
+	return flags
+
+
+## True if the given PID corresponds to a live (non-zombie) process.
+## POSIX uses `ps -o stat=` (see inline comment for the zombie rationale);
+## Windows uses `tasklist`. Called by `_start_server` to distinguish a live
 ## managed server that outlived its editor from a stale EditorSettings
-## record pointing at a PID that no longer exists.
+## record, and by `_check_server_health` to detect a fast-failing launcher.
 static func _pid_alive(pid: int) -> bool:
 	if pid <= 0:
 		return false

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -127,20 +127,15 @@ func test_dev_checkout_tooltip_exposes_symlink_target() -> void:
 	assert_contains(tooltip, target, "Tooltip should embed the resolved target path")
 
 
-func test_update_precheck_failure_preserves_running_server() -> void:
-	## When `uvx --refresh --from godot-ai==<new>` fails — typically because
-	## PyPI's index cache still says the version doesn't exist right after a
-	## fresh publish — we MUST leave the running server alone and surface a
-	## retry hint. Tearing down the server before confirming uvx can resolve
-	## the new version is what put Discord users in an infinite reconnect
-	## loop (server exits ~5s after spawn, plugin reconnects forever).
-	_dock._build_ui()
-	_dock._remote_update_version = "9.9.9"
-	_dock._apply_update_precheck_result(1, "No solution found — godot-ai==9.9.9 is unsatisfiable")
-	assert_eq(_dock._update_btn.text, "Retry update",
-		"Failure must re-enable the button as a retry — not leave it stuck in 'Preparing server...'")
-	assert_false(_dock._update_btn.disabled, "User must be able to click to retry once PyPI propagates")
-	assert_contains(_dock._update_label.text, "9.9.9",
-		"Label must name the target version so the user knows which retry is pending")
-	assert_contains(_dock._update_label.text, "propagating",
-		"Label must explain the failure mode so the user doesn't assume their install is broken")
+func test_crashed_body_mentions_pypi_propagation_on_uvx_tier() -> void:
+	## When both spawn attempts fail on the uvx tier, the dock panel should
+	## explain that PyPI propagation is the likely cause — so the user
+	## doesn't assume their install is corrupt. Non-uvx tiers keep the
+	## original traceback hint. See #172.
+	var body := McpDockScript._crash_body_for_state(McpSpawnState.CRASHED)
+	assert_false(body.is_empty(), "CRASHED body must not be empty")
+	if McpClientConfigurator.get_server_launch_mode() == "uvx":
+		assert_contains(body, "PyPI", "uvx-tier body should name PyPI as the likely cause")
+		assert_contains(body, "Reload Plugin", "uvx-tier body should direct the user to the retry action")
+	else:
+		assert_contains(body, "output log", "Non-uvx body should still point at Godot's traceback")

--- a/test_project/tests/test_plugin.gd
+++ b/test_project/tests/test_plugin.gd
@@ -87,3 +87,53 @@ func test_get_server_command_default_omits_refresh() -> void:
 		return
 	for token in cmd:
 		assert_ne(token, "--refresh", "default get_server_command must never include --refresh")
+
+
+func test_pid_alive_rejects_zombie_children() -> void:
+	## Regression guard for the zombie-blindness that defeated the first
+	## draft of the retry wiring: `kill -0` returns success for BOTH
+	## running and zombie processes, and Godot never `waitpid`s on its
+	## `OS.create_process` children. A fast-failing uvx launcher would
+	## linger as a zombie, `_pid_alive` would report true forever, and
+	## the "launcher died" branch in `_check_server_health` (which
+	## gates both CRASHED transitions and the --refresh retry) would
+	## never fire. See #172.
+	if OS.get_name() == "Windows":
+		## Windows doesn't have POSIX zombies — `tasklist` shows the
+		## process as gone the moment it exits.
+		skip("zombie semantics are POSIX-specific")
+		return
+	var pid := OS.create_process("sleep", ["0"])
+	assert_gt(pid, 0, "must successfully spawn the sleep child")
+	## Give the child time to exit and enter zombie state (waiting for
+	## its parent — us — to reap it). 300ms is generous for a `sleep 0`
+	## that exits essentially instantly; under load 100ms can be flaky.
+	OS.delay_msec(300)
+	assert_false(
+		GodotAiPlugin._pid_alive(pid),
+		"zombie (exited, unreaped) child must NOT be reported as alive",
+	)
+
+
+func test_pid_alive_reports_running_process_as_alive() -> void:
+	## Positive case: our own process PID must be reported alive. Pairs
+	## with the zombie test — catches a regression where the ps-based
+	## check became too strict (e.g. rejects normal sleeping processes).
+	var own_pid := OS.get_process_id()
+	assert_gt(own_pid, 0, "sanity: OS.get_process_id must return a positive pid")
+	assert_true(
+		GodotAiPlugin._pid_alive(own_pid),
+		"the test runner's own process must be reported as alive",
+	)
+
+
+func test_pid_alive_returns_false_for_nonexistent_pid() -> void:
+	## PID 1 (init/launchd) always exists on any running POSIX system, so
+	## use a high PID that's essentially guaranteed free. `ps` exits non-zero
+	## when the PID doesn't exist, which must map to false, not true.
+	assert_false(
+		GodotAiPlugin._pid_alive(2147483646),
+		"a non-existent PID must be reported as dead",
+	)
+	assert_false(GodotAiPlugin._pid_alive(0), "pid <= 0 is never alive")
+	assert_false(GodotAiPlugin._pid_alive(-1), "negative pid is never alive")

--- a/test_project/tests/test_plugin.gd
+++ b/test_project/tests/test_plugin.gd
@@ -1,0 +1,89 @@
+@tool
+extends McpTestSuite
+
+## Tests for the uvx stale-index self-heal in `_start_server` (see #172).
+## The full retry path re-spawns via `OS.create_process`, which we can't
+## cleanly intercept — so these tests target the pure decision helper
+## `_retry_with_refresh_allowed` that gates the retry. Surface area that
+## `_should_retry_with_refresh` exercises (static-cache reads, pid-file
+## I/O) is deliberately kept out of the helper under test.
+
+const GodotAiPlugin := preload("res://addons/godot_ai/plugin.gd")
+
+
+func suite_name() -> String:
+	return "plugin"
+
+
+func test_retry_fires_on_uvx_tier_with_no_pid_file() -> void:
+	## Classic stale-index scenario: uvx resolved the release to nothing,
+	## Python never ran (so no pid-file), and we haven't retried yet.
+	assert_true(
+		GodotAiPlugin._retry_with_refresh_allowed(false, "uvx", 0),
+		"uvx tier + no pid-file + not retried must trigger the --refresh retry",
+	)
+
+
+func test_no_retry_on_dev_venv_tier() -> void:
+	## `--refresh` is a uvx-only flag. Dev-venv spawns `python -m godot_ai`,
+	## which has no resolve step to refresh — retrying would be a no-op.
+	assert_false(
+		GodotAiPlugin._retry_with_refresh_allowed(false, "dev_venv", 0),
+		"dev_venv tier must not attempt a --refresh retry",
+	)
+
+
+func test_no_retry_on_system_tier() -> void:
+	## System installs don't go through uvx either.
+	assert_false(
+		GodotAiPlugin._retry_with_refresh_allowed(false, "system", 0),
+		"system tier must not attempt a --refresh retry",
+	)
+
+
+func test_no_retry_when_already_retried() -> void:
+	## One-shot guard: once we've retried, subsequent spawn failures must
+	## fall through to CRASHED instead of looping on --refresh.
+	assert_false(
+		GodotAiPlugin._retry_with_refresh_allowed(true, "uvx", 0),
+		"already-retried must skip even on uvx with no pid-file",
+	)
+
+
+func test_no_retry_when_pid_file_present() -> void:
+	## Python wrote its pid-file, then the process died — that's a real
+	## Python-side crash, not a uvx resolve failure. `--refresh` won't
+	## help; the user needs the traceback in Godot's output log.
+	assert_false(
+		GodotAiPlugin._retry_with_refresh_allowed(false, "uvx", 12345),
+		"pid-file present means Python started — don't blame uvx",
+	)
+
+
+func test_get_server_command_with_refresh_inserts_flag_on_uvx_tier() -> void:
+	## End-to-end sanity for the refresh param plumbed into
+	## `get_server_command`. Only meaningful when the current env
+	## actually resolves to the uvx tier.
+	if McpClientConfigurator.get_server_launch_mode() != "uvx":
+		skip("only meaningful on uvx tier")
+		return
+	var cmd_plain := McpClientConfigurator.get_server_command(false)
+	var cmd_refresh := McpClientConfigurator.get_server_command(true)
+	assert_false(cmd_plain.is_empty(), "uvx-tier plain command must be non-empty")
+	assert_false(cmd_refresh.is_empty(), "uvx-tier refresh command must be non-empty")
+	assert_eq(cmd_refresh[0], cmd_plain[0], "uvx executable must match between variants")
+	assert_eq(cmd_refresh[1], "--refresh", "--refresh must land as cmd[1], before --from")
+	assert_eq(cmd_refresh[2], "--from", "plain --from must follow --refresh")
+	assert_eq(cmd_refresh.size(), cmd_plain.size() + 1, "refresh variant must add exactly one flag")
+
+
+func test_get_server_command_default_omits_refresh() -> void:
+	## Warm-path invariant: the default no-arg call never adds --refresh.
+	## Covers every existing caller (start_dev_server, _start_server's
+	## first spawn, etc.) that relies on the flag-free shape.
+	var cmd := McpClientConfigurator.get_server_command()
+	if cmd.is_empty():
+		skip("no server command available in this env")
+		return
+	for token in cmd:
+		assert_ne(token, "--refresh", "default get_server_command must never include --refresh")

--- a/test_project/tests/test_plugin.gd.uid
+++ b/test_project/tests/test_plugin.gd.uid
@@ -1,0 +1,1 @@
+uid://cttoms7127oet


### PR DESCRIPTION
## Summary

- Every `_start_server` spawn path now self-heals once against a stale uvx PyPI index — not just the Update button that #171 covered. Reload Plugin, Reconnect, editor restart, and crash recovery all retry with `--refresh` on the first failure.
- `--refresh` is **failure-only and one-shot per `_start_server`** — the warm path is unchanged.
- Double-failure surfaces a uvx-aware CRASHED body that names PyPI propagation as the likely cause, so the user knows to wait and retry rather than assume their install is corrupt.
- #171's Update-button precheck is removed — redundant with the new retry, and user observation proved it wasn't actually sufficient on its own (the precheck's warm index didn't guarantee the follow-up spawn reused it).
- **Also fixes a latent zombie-blindness bug in `_pid_alive`** that would have made the retry wiring dead code. `kill -0 <pid>` returns success for both running and zombie processes, and Godot never `waitpid`s on `OS.create_process` children — so a fast-failing uvx launcher (~40ms on "No solution found") lingers as a zombie indefinitely and the "launcher died" branch in `_check_server_health` never fires. Replaced with `ps -o stat=` so zombie state (`Z`) maps to false. Discovered during live smoke — without this fix, the first smoke attempt's retry never triggered.

Fixes #172.

## Implementation

- `_retry_with_refresh_allowed(already_retried, launch_mode, pid_from_file)` is a **pure static** decision helper — no statics, no I/O — so the four retry rules (one-shot, uvx-only, pid-file-means-Python-ran-don't-blame-uvx, and the positive case) are directly driveable from tests.
- Instance wrapper `_should_retry_with_refresh` reads the environment (static caches, pid-file on disk) and delegates.
- `_respawn_with_refresh` calls `get_server_command(refresh=true)`, clears the pid-file, resets `_server_spawn_ms`, and keeps the watch timer running so the next poll evaluates the new process, not the dead one.
- `get_server_command(refresh: bool = false)` prepends `--refresh` to uvx args only when asked — default keeps every existing caller unchanged.
- `_pid_alive` is now `static` (so tests can drive it without constructing a plugin instance) and uses `ps -o stat=` on POSIX, rejecting any state string that starts with `Z`. Windows tasklist path is unchanged.

## Test plan

- [x] Unit tests: 10 new tests in `test_project/tests/test_plugin.gd` — 7 for the retry decision + `--refresh` flag placement, 3 for `_pid_alive` (zombie rejection via `sleep 0` + 300ms delay, live-process positive, nonexistent-pid negatives).
- [x] `ruff check src/ tests/` clean.
- [x] `pytest -v` — 547/547 passing.
- [x] `godot --import` parse check clean (no SCRIPT ERROR / Parse Error).
- [x] `test_run` via MCP on this worktree — 794/797 passing, 0 failed, 3 env-gated skips.
- [x] Live smoke (double-failure): forced `godot-ai==99.99.99` in `plugin.cfg`, confirmed two spawn attempts fail and dock surfaces the uvx-aware CRASHED body mentioning PyPI propagation.
- [x] Live smoke (happy-path recovery): contrived wrapper-uvx that forces `UV_OFFLINE=1` for spawns without `--refresh` + empty `~/.cache/uv/simple-v*/pypi/godot-ai.rkyv`. Confirmed first spawn fails ("No solution found" in ~40ms), plugin logs `retrying with --refresh (PyPI index may be stale)`, retry succeeds, and the dock shows green "Connected" with readiness events flowing. This required the zombie fix above — with `kill -0`, the retry never fired.

Generated with [Claude Code](https://claude.com/claude-code)
