### PR TITLE
fix(dock): clear FOREIGN_PORT warning when port-8000 adoption succeeds

### DIFF
--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -57,9 +57,17 @@ var _spawn_state: String = McpSpawnState.OK
 ## moment we respawn with `--refresh` so a second failure falls through
 ## to CRASHED instead of looping.
 var _refresh_retried: bool = false
+## Bounded deadline for `_watch_for_adoption_confirmation`. Zero when
+## disarmed. See that function's docstring.
+var _adoption_watch_deadline_ms: int = 0
 
 
 func _enter_tree() -> void:
+	## `_process` is only used by the adoption-confirmation watcher; keep
+	## it off until `_watch_for_adoption_confirmation` arms it, so the
+	## plugin has zero per-frame cost in the common case.
+	set_process(false)
+
 	## Register port overrides before spawn so `http_port()` / `ws_port()`
 	## return the user's configured values (if any) when `_start_server`
 	## builds the CLI args.
@@ -379,13 +387,16 @@ func _start_server() -> void:
 			_wait_for_port_free(port, 3.0)
 			## Fall through to spawn.
 		else:
-			## No record claiming this port — a foreign process owns it. We
-			## don't touch it, but the WebSocket handshake will never succeed
-			## because the foreign process doesn't speak MCP. Surface this to
-			## the dock so the user can pick a different port instead of
-			## watching "Disconnected" forever.
+			## No record claiming this port. Could be a non-MCP process
+			## (the handshake will never succeed → user sees FOREIGN_PORT
+			## and picks a different port) OR another editor's MCP server
+			## whose managed-record we just don't have locally — in which
+			## case our WebSocket WILL open and the diagnostic would be a
+			## lie. Flag FOREIGN_PORT preemptively, and arm a one-shot
+			## watcher that clears it if adoption actually succeeds.
 			_server_started_this_session = true
 			_set_spawn_state(McpSpawnState.FOREIGN_PORT)
+			_watch_for_adoption_confirmation()
 			print("MCP | foreign server already running on port %d, using existing" % port)
 			return
 
@@ -454,6 +465,48 @@ func _set_spawn_state(state: String) -> void:
 	if _spawn_state != McpSpawnState.OK:
 		return
 	_spawn_state = state
+
+
+## Arm the one-shot connection watcher. Called from `_start_server`'s
+## FOREIGN_PORT branch: we flagged the diagnostic preemptively assuming
+## the port holder doesn't speak MCP, but if it turns out to be another
+## editor's server our WebSocket will open and we need to retract the
+## diagnostic.
+##
+## We intentionally poll `_connection.is_connected` from `_process`
+## instead of wiring a new signal on Connection — signals would be
+## cleaner, but `class_name Connection` is cached by the editor across
+## plugin disable/enable, and a self-update that added a new signal
+## crashes `_enter_tree` with "invalid access to property" until the
+## user restarts Godot. Polling only reads `is_connected` (present on
+## every shipped Connection), so upgrades stay hot-reloadable.
+##
+## The watch self-disarms after SPAWN_GRACE_MS so per-frame cost drops
+## back to zero even if the foreign occupant never opens a WebSocket.
+func _watch_for_adoption_confirmation() -> void:
+	_adoption_watch_deadline_ms = Time.get_ticks_msec() + SPAWN_GRACE_MS
+	set_process(true)
+
+
+func _process(_delta: float) -> void:
+	if _connection != null and _connection.is_connected:
+		_on_connection_established()
+		_adoption_watch_deadline_ms = 0
+		set_process(false)
+		return
+	if Time.get_ticks_msec() >= _adoption_watch_deadline_ms:
+		_adoption_watch_deadline_ms = 0
+		set_process(false)
+
+
+## Bypasses `_set_spawn_state`'s first-writer-wins guard: the WebSocket
+## opening proves the occupant is a compatible MCP server (another
+## editor's session), so the preemptive FOREIGN_PORT diagnostic was a
+## false alarm and the dock shouldn't render the banner next to the
+## green "Connected" dot.
+func _on_connection_established() -> void:
+	if _spawn_state == McpSpawnState.FOREIGN_PORT:
+		_spawn_state = McpSpawnState.OK
 
 
 ## Start a 1s-tick timer that watches the spawned server for up to

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -190,6 +190,124 @@ func test_get_server_status_shape_is_stable() -> void:
 	assert_has_key(status, "exit_ms")
 
 
+func test_connection_established_clears_foreign_port() -> void:
+	## User-visible regression: on editor restart when a previous session's
+	## server is still on port 8000, `_start_server` hits the "no matching
+	## managed-server record" branch and preemptively sets FOREIGN_PORT.
+	## If the occupant happens to speak MCP (the common case — it's another
+	## editor's server), the WebSocket still connects and the dock ends up
+	## showing both "Connected" (green dot) and "Another process is already
+	## bound to port 8000" (warning banner). `_on_connection_established`
+	## must clear FOREIGN_PORT once the connection actually opens.
+	_seed_managed_record(99999, "other-version")
+	var plugin := GodotAiPlugin.new()
+	plugin._set_spawn_state(McpSpawnState.FOREIGN_PORT)
+	assert_eq(
+		plugin.get_server_status().get("state", ""),
+		McpSpawnState.FOREIGN_PORT,
+		"precondition: FOREIGN_PORT must be set before adoption-confirmation fires"
+	)
+
+	plugin._on_connection_established()
+	var state: String = plugin.get_server_status().get("state", "")
+	plugin.free()
+
+	assert_eq(
+		state,
+		McpSpawnState.OK,
+		"successful adoption (WebSocket opened) must clear FOREIGN_PORT diagnostic"
+	)
+
+
+func test_connection_established_preserves_crashed_state() -> void:
+	## Sanity check for the guard: only FOREIGN_PORT is preemptive enough
+	## to need post-hoc clearing. Other diagnoses (CRASHED, PORT_EXCLUDED,
+	## NO_COMMAND) are terminal — the server never came up, so no
+	## WebSocket can open and `_on_connection_established` should never
+	## fire in those states in the real flow. But if it ever does, don't
+	## paper over a real failure.
+	var plugin := GodotAiPlugin.new()
+	plugin._set_spawn_state(McpSpawnState.CRASHED)
+	plugin._on_connection_established()
+	var state: String = plugin.get_server_status().get("state", "")
+	plugin.free()
+	assert_eq(
+		state,
+		McpSpawnState.CRASHED,
+		"_on_connection_established must only clear FOREIGN_PORT, not other diagnoses"
+	)
+
+
+func test_watch_for_adoption_confirmation_arms_bounded_deadline() -> void:
+	## `_start_server`'s FOREIGN_PORT branch arms the adoption watcher
+	## instead of passively waiting. The watcher must be bounded — an
+	## un-bounded `set_process(true)` would poll every frame forever if
+	## the foreign occupant never opens a WebSocket, so we latch a
+	## deadline SPAWN_GRACE_MS in the future. `_process` self-disarms on
+	## first successful connect OR on deadline expiry, whichever comes
+	## first. This test just pins the deadline-arming half of the contract.
+	var plugin := GodotAiPlugin.new()
+	assert_eq(plugin._adoption_watch_deadline_ms, 0, "precondition: deadline disarmed")
+	var before_ms := Time.get_ticks_msec()
+	plugin._watch_for_adoption_confirmation()
+	var deadline := plugin._adoption_watch_deadline_ms
+	plugin.free()
+	assert_true(deadline >= before_ms, "deadline must be set into the future")
+	## Lower bound: SPAWN_GRACE_MS minus a generous 100ms slack for any
+	## scheduler jitter between `before_ms` and the latching call.
+	assert_true(
+		deadline - before_ms >= GodotAiPlugin.SPAWN_GRACE_MS - 100,
+		"deadline must be ~SPAWN_GRACE_MS (%dms) into the future" % GodotAiPlugin.SPAWN_GRACE_MS
+	)
+
+
+func test_process_clears_foreign_port_on_successful_connection() -> void:
+	## Integration test for the full adoption-confirm loop:
+	## `_watch_for_adoption_confirmation` arms the deadline + `_process`,
+	## then `_process` reads `_connection.is_connected` each frame. The
+	## previous two tests exercise each half in isolation; this one wires
+	## them together with a real Connection whose `_connected` we flip.
+	## Without this, a refactor that broke the `is_connected` check in
+	## `_process` (e.g. reading the wrong property) would slip through.
+	var plugin := GodotAiPlugin.new()
+	var conn := Connection.new()
+	plugin._connection = conn
+	plugin._set_spawn_state(McpSpawnState.FOREIGN_PORT)
+	plugin._watch_for_adoption_confirmation()
+	assert_true(plugin._adoption_watch_deadline_ms > 0, "precondition: watcher armed")
+
+	conn._connected = true  # simulate WebSocket STATE_OPEN transition
+	plugin._process(0.0)
+	var state: String = plugin.get_server_status().get("state", "")
+	var deadline := plugin._adoption_watch_deadline_ms
+	conn.free()
+	plugin.free()
+
+	assert_eq(state, McpSpawnState.OK, "_process must clear FOREIGN_PORT on first connect")
+	assert_eq(deadline, 0, "_process must disarm the deadline on successful adoption")
+
+
+func test_process_self_disarms_after_deadline_without_connect() -> void:
+	## If the foreign occupant never opens a WebSocket (e.g. it's a
+	## genuine non-MCP process), the watcher must give up after
+	## SPAWN_GRACE_MS so `_process` stops running every frame. The deadline
+	## stays zero afterwards, serving as the "disarmed" sentinel.
+	var plugin := GodotAiPlugin.new()
+	var conn := Connection.new()
+	plugin._connection = conn
+	plugin._set_spawn_state(McpSpawnState.FOREIGN_PORT)
+	plugin._adoption_watch_deadline_ms = Time.get_ticks_msec() - 1  # already expired
+	plugin.set_process(true)
+	plugin._process(0.0)
+	var state: String = plugin.get_server_status().get("state", "")
+	var deadline := plugin._adoption_watch_deadline_ms
+	conn.free()
+	plugin.free()
+
+	assert_eq(state, McpSpawnState.FOREIGN_PORT, "deadline expiry must leave FOREIGN_PORT set")
+	assert_eq(deadline, 0, "_process must zero the deadline on timeout")
+
+
 func _seed_managed_record(pid: int, version: String) -> void:
 	var es := EditorInterface.get_editor_settings()
 	if es == null:


### PR DESCRIPTION
## Summary

- `_start_server` flags `FOREIGN_PORT` preemptively when port 8000 is held by a process with no matching managed-record. But if the occupant turns out to be another editor's MCP server, the WebSocket still opens — and the dock was showing both "Connected" (green dot) AND the "Another process is already bound to port 8000" warning banner at the same time.
- Adds a bounded adoption-confirmation watcher: the FOREIGN_PORT branch arms `_watch_for_adoption_confirmation`, which sets a deadline at `now + SPAWN_GRACE_MS` and enables `_process`. `_process` polls `_connection.is_connected`; on first true reading → clears FOREIGN_PORT → OK; on deadline expiry → leaves FOREIGN_PORT set. Either way, `set_process(false)` returns the plugin to zero per-frame cost.
- Polling (not signals) is deliberate — a new signal on `class_name Connection` crashes on self-update because Godot caches the old Connection across plugin disable/enable, so `_enter_tree` hits "Invalid access to property 'new_signal_name'" until the user restarts the editor. `is_connected` has been on Connection since the plugin's first release, so this approach stays hot-reloadable across version bumps.

## Test plan

- [x] `plugin_lifecycle` suite — 14/14 pass (5 new tests):
  - `test_connection_established_clears_foreign_port` — handler clears FOREIGN_PORT when state is set
  - `test_connection_established_preserves_crashed_state` — handler is a no-op for other diagnoses
  - `test_watch_for_adoption_confirmation_arms_bounded_deadline` — deadline lands at `~now + SPAWN_GRACE_MS`
  - `test_process_clears_foreign_port_on_successful_connection` — full loop: arm → flip `_connected` → `_process` → state cleared, deadline zeroed
  - `test_process_self_disarms_after_deadline_without_connect` — pre-expire the deadline, verify FOREIGN_PORT stays set and deadline zeroes
- [x] Live verification — launched the worktree's test_project editor against a running port-8000 server; log showed `foreign server already running on port 8000, using existing` → `connected to server` (the exact bug path), dock stayed green-dot-only with no banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)
