### PR TITLE
fix(plugin): require sibling src/godot_ai before using a .venv

### DIFF
--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -254,7 +254,7 @@ static func _is_symlink(path: String) -> bool:
 static func get_server_command(refresh: bool = false) -> Array[String]:
 	## `mode_override() == "user"` skips the dev_venv tier even when a nearby
 	## .venv exists — the UI dropdown then becomes an actual workaround for
-	## the "user venv misidentified as dev checkout" bug (#178), not just a
+	## the "user venv misidentified as dev checkout" bug, not just a
 	## cosmetic relabel.
 	if mode_override() != "user":
 		var venv_python := _cached_venv_python()
@@ -338,7 +338,10 @@ static func _find_venv_python() -> String:
 ## venv if a sibling `src/godot_ai/` exists in the same parent dir — otherwise
 ## an unrelated user venv (e.g. `~/.venv` from a data-science side project)
 ## gets picked up and `python -m godot_ai` fails with ModuleNotFoundError about
-## 5s into startup, cascading into an infinite reconnect loop. See #178.
+## 5s into startup, cascading into an infinite reconnect loop. The retry-with-
+## refresh recovery in `plugin.gd::_should_retry_with_refresh` only fires on
+## the uvx tier, so the dev_venv misidentification has no escape hatch — the
+## detection has to be right the first time.
 static func _find_venv_python_in(start_dir: String) -> String:
 	var dir := start_dir.rstrip("/")
 	var python_name := "python" if OS.get_name() != "Windows" else "python.exe"

--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -252,10 +252,15 @@ static func _is_symlink(path: String) -> bool:
 ## other tiers: dev_venv and system resolve locally, so the flag has nowhere
 ## to go. See plugin.gd::_should_retry_with_refresh.
 static func get_server_command(refresh: bool = false) -> Array[String]:
-	var venv_python := _cached_venv_python()
-	if not venv_python.is_empty():
-		print("MCP | using dev venv: %s" % venv_python)
-		return [venv_python, "-m", "godot_ai"]
+	## `mode_override() == "user"` skips the dev_venv tier even when a nearby
+	## .venv exists — the UI dropdown then becomes an actual workaround for
+	## the "user venv misidentified as dev checkout" bug (#178), not just a
+	## cosmetic relabel.
+	if mode_override() != "user":
+		var venv_python := _cached_venv_python()
+		if not venv_python.is_empty():
+			print("MCP | using dev venv: %s" % venv_python)
+			return [venv_python, "-m", "godot_ai"]
 
 	var uvx := find_uvx()
 	if not uvx.is_empty():
@@ -288,7 +293,7 @@ static func get_server_command(refresh: bool = false) -> Array[String]:
 ## Returned as a stable string so handshakes and session_list can expose it
 ## to MCP callers. Values track the `Literal` on the Python side.
 static func get_server_launch_mode() -> String:
-	if not _cached_venv_python().is_empty():
+	if mode_override() != "user" and not _cached_venv_python().is_empty():
 		return "dev_venv"
 	if not find_uvx().is_empty():
 		return "uvx"
@@ -325,12 +330,22 @@ static func _cached_venv_python() -> String:
 
 
 static func _find_venv_python() -> String:
-	var dir := ProjectSettings.globalize_path("res://").rstrip("/")
+	return _find_venv_python_in(ProjectSettings.globalize_path("res://").rstrip("/"))
+
+
+## Pure path-based lookup so tests can drive it with a scratch dir instead of
+## monkey-patching `res://`. Only treats a `.venv/bin/python` as a godot-ai dev
+## venv if a sibling `src/godot_ai/` exists in the same parent dir — otherwise
+## an unrelated user venv (e.g. `~/.venv` from a data-science side project)
+## gets picked up and `python -m godot_ai` fails with ModuleNotFoundError about
+## 5s into startup, cascading into an infinite reconnect loop. See #178.
+static func _find_venv_python_in(start_dir: String) -> String:
+	var dir := start_dir.rstrip("/")
 	var python_name := "python" if OS.get_name() != "Windows" else "python.exe"
 	var venv_dir := ".venv/bin/" if OS.get_name() != "Windows" else ".venv/Scripts/"
 	for i in 5:
 		var venv_path := dir.path_join(venv_dir + python_name)
-		if FileAccess.file_exists(venv_path):
+		if FileAccess.file_exists(venv_path) and DirAccess.dir_exists_absolute(dir.path_join("src/godot_ai")):
 			return venv_path
 		var parent := dir.get_base_dir()
 		if parent == dir:

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -142,6 +142,84 @@ func test_find_worktree_src_dir_ignores_unrelated_src_directory() -> void:
 	DirAccess.remove_absolute(root)
 
 
+# ----- dev-venv detection requires sibling src/godot_ai -----
+#
+# Issue #178: `_find_venv_python` used to accept any `.venv/bin/python` it
+# found while walking up from `res://` — so a user with `~/.venv` (from an
+# unrelated Python project) got their venv picked up, `python -m godot_ai`
+# failed with ModuleNotFoundError ~5s in, and the reconnect logic looped
+# forever. These tests lock in the new rule: require a sibling `src/godot_ai/`
+# in the same parent dir before treating a `.venv` as a godot-ai dev venv.
+
+
+func test_find_venv_python_rejects_venv_without_godot_ai_src() -> void:
+	## The money test. Reproduces the reported bug scenario: a user HOME
+	## with `~/.venv/` from a data-science side project and no `src/godot_ai/`
+	## anywhere on the path. The plugin must fall through to the uvx tier
+	## instead of spawning the wrong interpreter.
+	var root := _scratch_dir.path_join("fake_user_home")
+	var venv_python := root.path_join(_venv_python_relpath())
+	DirAccess.make_dir_recursive_absolute(venv_python.get_base_dir())
+	_touch_file(venv_python)
+	assert_eq(McpClientConfigurator._find_venv_python_in(root), "", "Plain .venv with no sibling src/godot_ai/ must be rejected")
+	DirAccess.remove_absolute(venv_python)
+	DirAccess.remove_absolute(venv_python.get_base_dir())
+	DirAccess.remove_absolute(root.path_join(".venv"))
+	DirAccess.remove_absolute(root)
+
+
+func test_find_venv_python_accepts_venv_with_godot_ai_src() -> void:
+	## Positive case: real godot-ai dev checkout has both `.venv/` and
+	## `src/godot_ai/` as siblings at the worktree root. Both present →
+	## return the venv python path.
+	var root := _scratch_dir.path_join("fake_dev_checkout")
+	var venv_python := root.path_join(_venv_python_relpath())
+	DirAccess.make_dir_recursive_absolute(venv_python.get_base_dir())
+	_touch_file(venv_python)
+	DirAccess.make_dir_recursive_absolute(root.path_join("src/godot_ai"))
+	assert_eq(McpClientConfigurator._find_venv_python_in(root), venv_python)
+	DirAccess.remove_absolute(venv_python)
+	DirAccess.remove_absolute(venv_python.get_base_dir())
+	DirAccess.remove_absolute(root.path_join(".venv"))
+	DirAccess.remove_absolute(root.path_join("src/godot_ai"))
+	DirAccess.remove_absolute(root.path_join("src"))
+	DirAccess.remove_absolute(root)
+
+
+func test_find_venv_python_walks_up_from_nested_start_dir() -> void:
+	## Mirrors the real res:// layout: start_dir is `test_project/addons/*`
+	## deep inside a checkout; the venv and src/ live several levels up.
+	var root := _scratch_dir.path_join("nested_walk")
+	var deep := root.path_join("test_project/addons/pkg")
+	var venv_python := root.path_join(_venv_python_relpath())
+	DirAccess.make_dir_recursive_absolute(deep)
+	DirAccess.make_dir_recursive_absolute(venv_python.get_base_dir())
+	_touch_file(venv_python)
+	DirAccess.make_dir_recursive_absolute(root.path_join("src/godot_ai"))
+	assert_eq(McpClientConfigurator._find_venv_python_in(deep), venv_python)
+	DirAccess.remove_absolute(venv_python)
+	DirAccess.remove_absolute(venv_python.get_base_dir())
+	DirAccess.remove_absolute(root.path_join(".venv"))
+	DirAccess.remove_absolute(root.path_join("src/godot_ai"))
+	DirAccess.remove_absolute(root.path_join("src"))
+	DirAccess.remove_absolute(deep)
+	DirAccess.remove_absolute(root.path_join("test_project/addons"))
+	DirAccess.remove_absolute(root.path_join("test_project"))
+	DirAccess.remove_absolute(root)
+
+
+func test_find_venv_python_rejects_when_only_src_exists() -> void:
+	## Complement of the first test: `src/godot_ai/` present but no `.venv/`.
+	## Could happen if a user copied the source tree without running setup.
+	## Nothing to return — the helper is a venv locator, not a src locator.
+	var root := _scratch_dir.path_join("fake_src_only")
+	DirAccess.make_dir_recursive_absolute(root.path_join("src/godot_ai"))
+	assert_eq(McpClientConfigurator._find_venv_python_in(root), "")
+	DirAccess.remove_absolute(root.path_join("src/godot_ai"))
+	DirAccess.remove_absolute(root.path_join("src"))
+	DirAccess.remove_absolute(root)
+
+
 func test_uvx_server_command_uses_exact_pin_not_tilde() -> void:
 	## Regression guard for #133: the uvx branch of get_server_command must
 	## pin godot-ai with `==<version>`, not `~=<minor>`. With the tilde
@@ -243,6 +321,32 @@ func test_is_dev_checkout_forced_dev_mode() -> void:
 	var prior_env := OS.get_environment("GODOT_AI_MODE")
 	OS.set_environment("GODOT_AI_MODE", "dev")
 	assert_true(McpClientConfigurator.is_dev_checkout(), "GODOT_AI_MODE=dev must force dev mode")
+	if prior_env.is_empty():
+		OS.unset_environment("GODOT_AI_MODE")
+	else:
+		OS.set_environment("GODOT_AI_MODE", prior_env)
+	_restore_mode_override_setting(prior_setting)
+
+
+func test_get_server_command_forced_user_skips_dev_venv() -> void:
+	## Issue #178 workaround: forcing `user` mode must reroute
+	## `get_server_command` past the dev_venv tier, not just relabel the
+	## dock. Before this fix, a user whose `~/.venv` was wrongly detected
+	## had no UI-based escape — the dropdown would say "user install" but
+	## the spawn would still use the misidentified venv. Now flipping the
+	## override actually changes what gets spawned.
+	var prior_setting: Variant = _clear_mode_override_setting()
+	var prior_env := OS.get_environment("GODOT_AI_MODE")
+	OS.set_environment("GODOT_AI_MODE", "user")
+
+	assert_true(McpClientConfigurator.get_server_launch_mode() != "dev_venv", "mode=user must never resolve to dev_venv")
+
+	var cmd := McpClientConfigurator.get_server_command()
+	for arg in cmd:
+		var s := str(arg)
+		var is_venv_python := s.ends_with("/.venv/bin/python") or s.ends_with("\\.venv\\Scripts\\python.exe") or s.ends_with("/.venv/Scripts/python.exe")
+		assert_false(is_venv_python, "mode=user must not spawn a .venv python binary (got: %s)" % str(cmd))
+
 	if prior_env.is_empty():
 		OS.unset_environment("GODOT_AI_MODE")
 	else:
@@ -772,6 +876,19 @@ func _make_test_toml_client(path: String) -> McpClient:
 func _remove_if_exists(path: String) -> void:
 	if FileAccess.file_exists(path):
 		DirAccess.remove_absolute(path)
+
+
+## Relative path inside a scratch dir where `_find_venv_python_in` expects
+## to find the python binary — OS-dependent, mirrors the same conditional
+## in `client_configurator.gd::_find_venv_python_in`.
+func _venv_python_relpath() -> String:
+	return ".venv/Scripts/python.exe" if OS.get_name() == "Windows" else ".venv/bin/python"
+
+
+func _touch_file(path: String) -> void:
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	assert_true(f != null, "Failed to create scratch file at %s" % path)
+	f.close()
 
 
 ## Reset http/ws port overrides to the built-in defaults for the duration of

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -144,12 +144,12 @@ func test_find_worktree_src_dir_ignores_unrelated_src_directory() -> void:
 
 # ----- dev-venv detection requires sibling src/godot_ai -----
 #
-# Issue #178: `_find_venv_python` used to accept any `.venv/bin/python` it
-# found while walking up from `res://` — so a user with `~/.venv` (from an
-# unrelated Python project) got their venv picked up, `python -m godot_ai`
-# failed with ModuleNotFoundError ~5s in, and the reconnect logic looped
-# forever. These tests lock in the new rule: require a sibling `src/godot_ai/`
-# in the same parent dir before treating a `.venv` as a godot-ai dev venv.
+# `_find_venv_python` used to accept any `.venv/bin/python` it found while
+# walking up from `res://` — so a user with `~/.venv` (from an unrelated
+# Python project) got their venv picked up, `python -m godot_ai` failed with
+# ModuleNotFoundError ~5s in, and the reconnect logic looped forever. These
+# tests lock in the new rule: require a sibling `src/godot_ai/` in the same
+# parent dir before treating a `.venv` as a godot-ai dev venv.
 
 
 func test_find_venv_python_rejects_venv_without_godot_ai_src() -> void:
@@ -329,12 +329,12 @@ func test_is_dev_checkout_forced_dev_mode() -> void:
 
 
 func test_get_server_command_forced_user_skips_dev_venv() -> void:
-	## Issue #178 workaround: forcing `user` mode must reroute
-	## `get_server_command` past the dev_venv tier, not just relabel the
-	## dock. Before this fix, a user whose `~/.venv` was wrongly detected
-	## had no UI-based escape — the dropdown would say "user install" but
-	## the spawn would still use the misidentified venv. Now flipping the
-	## override actually changes what gets spawned.
+	## Forcing `user` mode must reroute `get_server_command` past the
+	## dev_venv tier, not just relabel the dock. Before this fix, a user
+	## whose `~/.venv` was wrongly detected had no UI-based escape — the
+	## dropdown would say "user install" but the spawn would still use
+	## the misidentified venv. Now flipping the override actually changes
+	## what gets spawned.
 	var prior_setting: Variant = _clear_mode_override_setting()
 	var prior_env := OS.get_environment("GODOT_AI_MODE")
 	OS.set_environment("GODOT_AI_MODE", "user")


### PR DESCRIPTION
## Summary

- Tighten dev-checkout detection in `_find_venv_python` to require BOTH `.venv/bin/python` AND a sibling `src/godot_ai/` in the same parent dir — a real godot-ai dev checkout always has both.
- Make `get_server_command` and `get_server_launch_mode` honor the `user` mode override by actually skipping the dev_venv tier, not just relabeling the dock.

## The bug

Reported by a user who installed via the release zip (not a git checkout) and had a `.venv/` in their HOME from an unrelated Python project. The plugin walked up 5 directories from `res://`, found `~/.venv/bin/python`, and spawned it against `python -m godot_ai`. That fails with `ModuleNotFoundError` ~5s in, and because the retry-with-refresh recovery in `plugin.gd::_should_retry_with_refresh` only fires on the `uvx` tier, the dev_venv tier looped forever:

```
MCP | using dev venv: /home/xxx/.venv/bin/python
MCP | started server (PID 6047, v1.4.1): /home/xxx/.venv/bin/python -m godot_ai --transport streamable-http --port 8000 --ws-port 9500 --pid-file /home/xxx/.local/share/godot/app_userdata/game/godot_ai_server.pid
MCP | plugin loaded
MCP | reconnecting in 1s (attempt 1)
MCP | reconnecting in 2s (attempt 2)
MCP | reconnecting in 4s (attempt 3)
MCP | server exited after 5439ms — see Godot output log
MCP | reconnecting in 8s (attempt 4)
MCP | reconnecting in 10s (attempt 5)
... [loops forever]
```

## Root cause

`plugin/addons/godot_ai/client_configurator.gd::_find_venv_python` walked up 5 dirs from `res://` and accepted ANY `.venv/bin/python` it found, with no check that it actually belonged to a godot-ai checkout. Downstream, `is_dev_checkout()` also used this heuristic, so the dock wrongly said "dev checkout — update via git pull" and hid the update path.

## The fix

`_find_venv_python` now delegates to a pure helper `_find_venv_python_in(start_dir)` — refactored so tests can drive it with a scratch dir instead of monkey-patching `res://`. The walk requires BOTH conditions:

```gdscript
if FileAccess.file_exists(venv_path) and DirAccess.dir_exists_absolute(dir.path_join("src/godot_ai")):
    return venv_path
```

A real dev checkout always has both; `~/.venv` alone falls through to uvx.

### Bundled: `Force user` mode override now actually reroutes the spawn

The dock's `Force user` mode override previously only flipped the cosmetic `is_dev_checkout()` label — `get_server_command` never consulted `mode_override()`, so the spawn still used the misidentified venv. Now `get_server_command` and `get_server_launch_mode` both skip the dev_venv tier when `mode_override() == "user"`. This makes the UI dropdown (and the `GODOT_AI_MODE=user` env var) a real workaround for affected users on 1.4.2.

## Workarounds for affected users on 1.4.2

1. `~/.venv/bin/pip install godot-ai` — makes the mis-detection accidentally correct.
2. Temporarily rename the offending venv: `mv ~/.venv ~/.venv-hide-from-godot`, reload plugin, rename back when done.
3. After this PR lands: set `GODOT_AI_MODE=user` before launching Godot, or pick `Force user` from the dock dropdown (requires Developer mode to be on).

## Test plan

- [x] `pytest -q` — 547 passed
- [x] `ruff check src/ tests/` — all checks passed
- [x] `test_run` via MCP against the worktree editor — 804 passed / 0 failed / 3 skipped
- [x] Four new GDScript tests in `test_project/tests/test_clients.gd`:
  - `test_find_venv_python_rejects_venv_without_godot_ai_src` (the money test — the exact reported bug scenario)
  - `test_find_venv_python_accepts_venv_with_godot_ai_src` (positive case)
  - `test_find_venv_python_walks_up_from_nested_start_dir` (mirrors real res:// depth)
  - `test_find_venv_python_rejects_when_only_src_exists` (complement — src without venv)
  - `test_get_server_command_forced_user_skips_dev_venv` (bundled routing fix)
- [x] End-to-end simulation: `mkdir -p /tmp/fake-user-home && python3 -m venv /tmp/fake-user-home/.venv`, minimal Godot project at `/tmp/fake-user-home/game/` with the plugin symlinked in. Before the fix: `MCP | using dev venv: /tmp/fake-user-home/.venv/bin/python` in the log, then crash loop. After the fix: no such log line, plugin falls through correctly.
- [x] Verified that legitimate dev checkouts still resolve to `dev_venv` (`session_list` on my worktree reports `server_launch_mode: dev_venv`, unrelated `/Users/davidsarno/testy/` still reports `uvx`).

Generated with [Claude Code](https://claude.com/claude-code)
