### PR TITLE
feat(tools): --exclude-domains CLI + dock UI for tool-capped clients (#170)

### DIFF
--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -30,6 +30,14 @@ const SETTING_WS_PORT := "godot_ai/ws_port"
 const MIN_PORT := 1024
 const MAX_PORT := 65535
 
+## Comma-separated list of tool domains to drop from the server at spawn
+## time. Maps 1:1 onto the `--exclude-domains` CLI flag. Set via the dock's
+## "Tools" tab; a change requires a server restart (the dock handles this
+## by triggering a plugin reload). Unknown names are warned about on the
+## Python side and skipped, so an EditorSetting left over from a previous
+## plugin version can't wedge the spawn.
+const SETTING_EXCLUDED_DOMAINS := "godot_ai/excluded_domains"
+
 
 ## Active HTTP port: user override (if in range) or `DEFAULT_HTTP_PORT`.
 static func http_port() -> int:
@@ -78,6 +86,25 @@ static func _register_port_setting(es: EditorSettings, key: String, default_port
 		"hint": PROPERTY_HINT_RANGE,
 		"hint_string": "%d,%d,1" % [MIN_PORT, MAX_PORT],
 	})
+
+
+## Read the `godot_ai/excluded_domains` EditorSetting as a canonicalized
+## comma-separated list (sorted, deduplicated, whitespace-stripped). Returns
+## "" when the setting is missing or resolves to an empty set — callers can
+## skip appending the flag in that case so older servers that don't know
+## `--exclude-domains` don't see an empty argument.
+static func excluded_domains() -> String:
+	var es := EditorInterface.get_editor_settings()
+	if es == null or not es.has_setting(SETTING_EXCLUDED_DOMAINS):
+		return ""
+	var raw := str(es.get_setting(SETTING_EXCLUDED_DOMAINS))
+	var parts := PackedStringArray()
+	for p in raw.split(","):
+		var t := p.strip_edges()
+		if not t.is_empty() and parts.find(t) == -1:
+			parts.append(t)
+	parts.sort()
+	return ",".join(parts)
 
 
 ## Walk `start`..`start+span-1` and return the first port that is NOT

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -33,6 +33,20 @@ var _clients_window: Window
 var _dev_mode_toggle: CheckButton
 var _install_label: Label
 
+# Tools tab (secondary window, Tab 2) — domain-exclusion UI for clients
+# that cap total tool count (Antigravity: 100). Pending set is mutated by
+# checkbox clicks; saved set reflects what the spawned server actually
+# sees. `Apply & Restart Server` writes pending → setting and triggers a
+# plugin reload so the new server comes up with the trimmed list.
+var _tools_pending_excluded: PackedStringArray = PackedStringArray()
+var _tools_saved_excluded: PackedStringArray = PackedStringArray()
+var _tools_domain_checkboxes: Dictionary = {}
+var _tools_count_label: Label
+var _tools_apply_btn: Button
+var _tools_reset_btn: Button
+var _tools_dirty_warning: Label
+var _tools_close_confirm: ConfirmationDialog
+
 ## Per-client UI handles, keyed by client id. Each entry holds the row's
 ## status dot, configure button, remove button, manual-command panel + text.
 var _client_rows: Dictionary = {}
@@ -350,7 +364,8 @@ func _build_ui() -> void:
 	clients_row.add_child(_clients_summary_label)
 
 	var clients_open_btn := Button.new()
-	clients_open_btn.text = "Configure Clients"
+	clients_open_btn.text = "Clients & Tools"
+	clients_open_btn.tooltip_text = "Open the MCP settings window — configure AI clients or disable tool domains to fit under a client's hard tool-count cap (e.g. Antigravity's 100)."
 	clients_open_btn.pressed.connect(_on_open_clients_window)
 	clients_row.add_child(clients_open_btn)
 
@@ -373,8 +388,8 @@ func _build_ui() -> void:
 	add_child(_drift_banner)
 
 	_clients_window = Window.new()
-	_clients_window.title = "Configure MCP Clients"
-	_clients_window.min_size = Vector2i(560, 400)
+	_clients_window.title = "MCP Clients & Tools"
+	_clients_window.min_size = Vector2i(560, 460)
 	_clients_window.visible = false
 	_clients_window.close_requested.connect(_on_clients_window_close_requested)
 	add_child(_clients_window)
@@ -388,22 +403,32 @@ func _build_ui() -> void:
 	window_margin.add_theme_constant_override("margin_bottom", 12)
 	_clients_window.add_child(window_margin)
 
-	var window_body := VBoxContainer.new()
-	window_body.add_theme_constant_override("separation", 8)
-	window_margin.add_child(window_body)
+	## Two-tab secondary window: Clients (existing per-client rows) and Tools
+	## (domain-exclusion checkboxes for clients that cap total tool count,
+	## like Antigravity at 100). Adding a third tab is one more _build_*_tab
+	## call and a set_tab_title line — no surgery on the rest of the window.
+	var tabs := TabContainer.new()
+	tabs.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	tabs.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	window_margin.add_child(tabs)
+
+	var clients_tab := VBoxContainer.new()
+	clients_tab.name = "Clients"
+	clients_tab.add_theme_constant_override("separation", 8)
+	tabs.add_child(clients_tab)
 
 	_client_configure_all_btn = Button.new()
 	_client_configure_all_btn.text = "Configure all"
 	_client_configure_all_btn.tooltip_text = "Configure every client that isn't already pointing at this server"
 	_client_configure_all_btn.size_flags_horizontal = Control.SIZE_SHRINK_END
 	_client_configure_all_btn.pressed.connect(_on_configure_all_clients)
-	window_body.add_child(_client_configure_all_btn)
+	clients_tab.add_child(_client_configure_all_btn)
 
 	var clients_scroll := ScrollContainer.new()
 	clients_scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	clients_scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	clients_scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
-	window_body.add_child(clients_scroll)
+	clients_tab.add_child(clients_scroll)
 
 	_client_grid = VBoxContainer.new()
 	_client_grid.add_theme_constant_override("separation", 4)
@@ -412,6 +437,8 @@ func _build_ui() -> void:
 
 	for client_id in McpClientConfigurator.client_ids():
 		_build_client_row(client_id)
+
+	_build_tools_tab(tabs)
 
 	add_child(HSeparator.new())
 
@@ -992,6 +1019,11 @@ func _on_open_clients_window() -> void:
 	## colors land on the next frame. Synchronous would block the popup paint
 	## for ~18 filesystem reads (~100-300ms with AV scanning). See #166.
 	_refresh_all_client_statuses.call_deferred()
+	## Also re-sync the Tools tab from the persisted setting — another
+	## editor instance (or a hand-edit of editor_settings-4.tres) may have
+	## changed the excluded list while the window was closed.
+	_reset_tools_pending_from_setting()
+	_refresh_tools_ui_state()
 	# popup_centered() with a minsize forces the window to that size and
 	# centers on the parent viewport. Setting .size on a hidden Window
 	# doesn't always take effect, so we force it at popup time here.
@@ -999,6 +1031,246 @@ func _on_open_clients_window() -> void:
 
 
 func _on_clients_window_close_requested() -> void:
+	if _clients_window == null:
+		return
+	## If the user has checked/unchecked domains without applying, a close
+	## would silently throw the pending state away. Prompt; if they confirm
+	## discard, reset pending → saved so the window shows the persisted
+	## state the next time they open it.
+	if _tools_pending_excluded != _tools_saved_excluded:
+		_show_tools_close_confirm()
+		return
+	_clients_window.hide()
+
+
+# --- Tools tab (domain exclusion) ---
+
+func _build_tools_tab(tabs: TabContainer) -> void:
+	## Tab 2 — domain-exclusion checkboxes. Rendered once, on dock construction.
+	## `_reset_tools_pending_from_setting()` re-syncs checkbox state from the
+	## saved setting each time the window opens.
+	var tools_tab := VBoxContainer.new()
+	tools_tab.name = "Tools"
+	tools_tab.add_theme_constant_override("separation", 8)
+	tabs.add_child(tools_tab)
+
+	var intro := Label.new()
+	intro.text = (
+		"Some MCP clients cap tools per connection (Antigravity: 100). "
+		+ "Uncheck a domain to drop its non-core tools from this server. "
+		+ "Core tools stay on. Changes require a server restart."
+	)
+	intro.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	intro.add_theme_color_override("font_color", COLOR_MUTED)
+	intro.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	tools_tab.add_child(intro)
+
+	var count_row := HBoxContainer.new()
+	count_row.add_theme_constant_override("separation", 8)
+	var count_header := Label.new()
+	count_header.text = "Enabled:"
+	count_header.add_theme_color_override("font_color", COLOR_MUTED)
+	count_row.add_child(count_header)
+	_tools_count_label = Label.new()
+	_tools_count_label.add_theme_font_size_override("font_size", 15)
+	count_row.add_child(_tools_count_label)
+	_tools_dirty_warning = Label.new()
+	_tools_dirty_warning.add_theme_color_override("font_color", COLOR_AMBER)
+	_tools_dirty_warning.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_tools_dirty_warning.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+	_tools_dirty_warning.visible = false
+	_tools_dirty_warning.text = "Unapplied changes"
+	count_row.add_child(_tools_dirty_warning)
+	tools_tab.add_child(count_row)
+
+	tools_tab.add_child(HSeparator.new())
+
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+	tools_tab.add_child(scroll)
+
+	var grid := VBoxContainer.new()
+	grid.add_theme_constant_override("separation", 4)
+	grid.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	scroll.add_child(grid)
+
+	## Core pseudo-row — disabled checkbox, always checked. Shows the 5
+	## always-loaded tools as a single line item so the user can see where
+	## their baseline tool budget goes without listing individual core names
+	## inline (tooltip has them).
+	var core_row := HBoxContainer.new()
+	core_row.add_theme_constant_override("separation", 8)
+	var core_chk := CheckBox.new()
+	core_chk.button_pressed = true
+	core_chk.disabled = true
+	core_chk.focus_mode = Control.FOCUS_NONE
+	core_row.add_child(core_chk)
+	var core_label := Label.new()
+	core_label.text = "Core (always on)"
+	core_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	core_row.add_child(core_label)
+	var core_count := Label.new()
+	core_count.text = "%d tools" % McpToolCatalog.CORE_TOOLS.size()
+	core_count.add_theme_color_override("font_color", COLOR_MUTED)
+	core_row.add_child(core_count)
+	core_row.tooltip_text = ", ".join(McpToolCatalog.CORE_TOOLS)
+	grid.add_child(core_row)
+
+	grid.add_child(HSeparator.new())
+
+	_tools_domain_checkboxes.clear()
+	for entry in McpToolCatalog.DOMAINS:
+		_build_tools_domain_row(grid, entry)
+
+	tools_tab.add_child(HSeparator.new())
+
+	var footer := HBoxContainer.new()
+	footer.add_theme_constant_override("separation", 8)
+
+	_tools_apply_btn = Button.new()
+	_tools_apply_btn.text = "Apply && Restart Server"
+	_tools_apply_btn.tooltip_text = "Save the excluded list to Editor Settings and reload the plugin so the server respawns with --exclude-domains."
+	_tools_apply_btn.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_tools_apply_btn.pressed.connect(_on_tools_apply)
+	footer.add_child(_tools_apply_btn)
+
+	_tools_reset_btn = Button.new()
+	_tools_reset_btn.text = "Reset to defaults"
+	_tools_reset_btn.tooltip_text = "Re-enable every domain (no --exclude-domains flag). Still needs Apply."
+	_tools_reset_btn.pressed.connect(_on_tools_reset)
+	footer.add_child(_tools_reset_btn)
+
+	tools_tab.add_child(footer)
+
+	_tools_close_confirm = ConfirmationDialog.new()
+	_tools_close_confirm.title = "Discard unapplied changes?"
+	_tools_close_confirm.dialog_text = (
+		"You've checked/unchecked domains but haven't clicked Apply.\n"
+		+ "Close the window and discard those changes?"
+	)
+	_tools_close_confirm.ok_button_text = "Discard"
+	_tools_close_confirm.confirmed.connect(_on_tools_discard_confirmed)
+	add_child(_tools_close_confirm)
+
+	_reset_tools_pending_from_setting()
+	_refresh_tools_ui_state()
+
+
+func _build_tools_domain_row(parent: VBoxContainer, entry: Dictionary) -> void:
+	var row := HBoxContainer.new()
+	row.add_theme_constant_override("separation", 8)
+
+	var chk := CheckBox.new()
+	chk.button_pressed = true  # default; `_reset_tools_pending_from_setting` corrects
+	chk.toggled.connect(_on_tools_domain_toggled.bind(String(entry["id"])))
+	row.add_child(chk)
+
+	var name_label := Label.new()
+	name_label.text = String(entry["label"])
+	name_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	row.add_child(name_label)
+
+	var count_label := Label.new()
+	count_label.text = "%d tools" % int(entry["count"])
+	count_label.add_theme_color_override("font_color", COLOR_MUTED)
+	row.add_child(count_label)
+
+	## Hover tooltip = flat list of tool names in this domain. Lets the
+	## user decide without leaving the dock (e.g. "I just want to drop
+	## `animation_preset_*` — do I lose anything else?").
+	var tools_list: Array = entry.get("tools", [])
+	row.tooltip_text = ", ".join(tools_list)
+	name_label.tooltip_text = row.tooltip_text
+	count_label.tooltip_text = row.tooltip_text
+
+	parent.add_child(row)
+	_tools_domain_checkboxes[String(entry["id"])] = chk
+
+
+func _reset_tools_pending_from_setting() -> void:
+	## Read the saved setting → pending/saved arrays, then sync checkbox state.
+	## Unknown domain names in the setting (e.g. from an older plugin
+	## version) are silently dropped — matches the Python side's
+	## warn-and-continue behavior when it sees an unknown name.
+	var saved_raw := McpClientConfigurator.excluded_domains()
+	var saved := PackedStringArray()
+	if not saved_raw.is_empty():
+		for part in saved_raw.split(","):
+			var t := part.strip_edges()
+			if t.is_empty():
+				continue
+			if _tools_domain_checkboxes.has(t) and saved.find(t) == -1:
+				saved.append(t)
+	saved.sort()
+	_tools_saved_excluded = saved
+	_tools_pending_excluded = saved.duplicate()
+	for id in _tools_domain_checkboxes:
+		var chk: CheckBox = _tools_domain_checkboxes[id]
+		## `set_pressed_no_signal` — mutating programmatically should not
+		## fire the toggled handler, which would mutate pending back.
+		chk.set_pressed_no_signal(_tools_pending_excluded.find(id) == -1)
+
+
+func _on_tools_domain_toggled(pressed: bool, domain_id: String) -> void:
+	var idx := _tools_pending_excluded.find(domain_id)
+	if pressed and idx != -1:
+		_tools_pending_excluded.remove_at(idx)
+	elif not pressed and idx == -1:
+		_tools_pending_excluded.append(domain_id)
+		_tools_pending_excluded.sort()
+	_refresh_tools_ui_state()
+
+
+func _refresh_tools_ui_state() -> void:
+	if _tools_count_label == null:
+		return
+	var enabled := McpToolCatalog.enabled_tool_count(_tools_pending_excluded)
+	var total := McpToolCatalog.total_tool_count()
+	_tools_count_label.text = "%d / %d" % [enabled, total]
+	var dirty := _tools_pending_excluded != _tools_saved_excluded
+	_tools_dirty_warning.visible = dirty
+	_tools_apply_btn.disabled = not dirty
+	## Color the count when the user is over Antigravity's cap — a soft
+	## signal that their selection still won't fit. 100 is the Antigravity
+	## limit; other clients may cap higher, so this is advisory only.
+	if enabled > 100:
+		_tools_count_label.add_theme_color_override("font_color", COLOR_AMBER)
+	else:
+		_tools_count_label.remove_theme_color_override("font_color")
+
+
+func _on_tools_apply() -> void:
+	var canonical_excluded := McpToolCatalog.canonical(_tools_pending_excluded)
+	var es := EditorInterface.get_editor_settings()
+	if es != null:
+		es.set_setting(McpClientConfigurator.SETTING_EXCLUDED_DOMAINS, canonical_excluded)
+	_tools_saved_excluded = _tools_pending_excluded.duplicate()
+	_refresh_tools_ui_state()
+	## Plugin reload respawns the server with the new `--exclude-domains`
+	## flag (see `plugin.gd::_build_server_flags`). Mirrors the port-change
+	## Apply flow.
+	_on_reload_plugin()
+
+
+func _on_tools_reset() -> void:
+	_tools_pending_excluded = PackedStringArray()
+	for id in _tools_domain_checkboxes:
+		var chk: CheckBox = _tools_domain_checkboxes[id]
+		chk.set_pressed_no_signal(true)
+	_refresh_tools_ui_state()
+
+
+func _show_tools_close_confirm() -> void:
+	if _tools_close_confirm == null:
+		return
+	_tools_close_confirm.popup_centered()
+
+
+func _on_tools_discard_confirmed() -> void:
+	_reset_tools_pending_from_setting()
+	_refresh_tools_ui_state()
 	if _clients_window != null:
 		_clients_window.hide()
 

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -779,6 +779,14 @@ static func _build_server_flags(port: int, ws_port: int) -> Array[String]:
 		"--ws-port", str(ws_port),
 		"--pid-file", ProjectSettings.globalize_path(SERVER_PID_FILE),
 	])
+	## Append `--exclude-domains` only when the user has actually picked at
+	## least one domain to drop. Skipping the empty case keeps spawns
+	## compatible with older (pre-1.4.2) servers that don't know the flag —
+	## relevant during staggered plugin/server upgrades in user-mode installs.
+	var excluded := McpClientConfigurator.excluded_domains()
+	if not excluded.is_empty():
+		flags.append("--exclude-domains")
+		flags.append(excluded)
 	return flags
 
 

--- a/plugin/addons/godot_ai/tool_catalog.gd
+++ b/plugin/addons/godot_ai/tool_catalog.gd
@@ -1,0 +1,88 @@
+@tool
+class_name McpToolCatalog
+extends RefCounted
+
+## Mirror of src/godot_ai/tools/domains.py — drives the dock's Tools tab
+## so the UI can render checkboxes, tool counts, and tooltips without
+## round-tripping to a running server.
+##
+## DO NOT EDIT by hand. tests/unit/test_tool_catalog_parity.py verifies
+## this file against actual tool registration and fails CI when they drift;
+## the failure message prints the up-to-date catalog body for paste-over.
+##
+## The five core tools are always registered and cannot be excluded — they
+## render as a single grayed-out "Core" row in the UI.
+
+const CORE_TOOLS := [
+	"editor_state",
+	"node_get_properties",
+	"scene_get_hierarchy",
+	"session_activate",
+	"session_list",
+]
+
+## Ordered list of user-toggleable domains. Each entry:
+##   id:    matches the name passed to `--exclude-domains`
+##   label: human-friendly display (same as id for now, kept separate so
+##          a future renaming doesn't break the setting)
+##   count: number of NON-CORE tools in this domain
+##   tools: flat list of tool names registered by this domain (non-core only)
+const DOMAINS := [
+	{"id": "animation", "label": "animation", "count": 16, "tools": ["animation_add_method_track", "animation_add_property_track", "animation_create", "animation_create_simple", "animation_delete", "animation_get", "animation_list", "animation_play", "animation_player_create", "animation_preset_fade", "animation_preset_pulse", "animation_preset_shake", "animation_preset_slide", "animation_set_autoplay", "animation_stop", "animation_validate"]},
+	{"id": "audio", "label": "audio", "count": 6, "tools": ["audio_list", "audio_play", "audio_player_create", "audio_player_set_playback", "audio_player_set_stream", "audio_stop"]},
+	{"id": "autoload", "label": "autoload", "count": 3, "tools": ["autoload_add", "autoload_list", "autoload_remove"]},
+	{"id": "batch", "label": "batch", "count": 1, "tools": ["batch_execute"]},
+	{"id": "camera", "label": "camera", "count": 8, "tools": ["camera_apply_preset", "camera_configure", "camera_create", "camera_follow_2d", "camera_get", "camera_list", "camera_set_damping_2d", "camera_set_limits_2d"]},
+	{"id": "client", "label": "client", "count": 3, "tools": ["client_configure", "client_remove", "client_status"]},
+	{"id": "control", "label": "control", "count": 1, "tools": ["control_draw_recipe"]},
+	{"id": "curve", "label": "curve", "count": 1, "tools": ["curve_set_points"]},
+	{"id": "editor", "label": "editor", "count": 8, "tools": ["editor_quit", "editor_reload_plugin", "editor_screenshot", "editor_selection_get", "editor_selection_set", "logs_clear", "logs_read", "performance_monitors_get"]},
+	{"id": "environment", "label": "environment", "count": 1, "tools": ["environment_create"]},
+	{"id": "filesystem", "label": "filesystem", "count": 4, "tools": ["filesystem_read_text", "filesystem_reimport", "filesystem_search", "filesystem_write_text"]},
+	{"id": "input_map", "label": "input_map", "count": 4, "tools": ["input_map_add_action", "input_map_bind_event", "input_map_list", "input_map_remove_action"]},
+	{"id": "material", "label": "material", "count": 8, "tools": ["material_apply_preset", "material_apply_to_node", "material_assign", "material_create", "material_get", "material_list", "material_set_param", "material_set_shader_param"]},
+	{"id": "node", "label": "node", "count": 12, "tools": ["node_add_to_group", "node_create", "node_delete", "node_duplicate", "node_find", "node_get_children", "node_get_groups", "node_move", "node_remove_from_group", "node_rename", "node_reparent", "node_set_property"]},
+	{"id": "particle", "label": "particle", "count": 7, "tools": ["particle_apply_preset", "particle_create", "particle_get", "particle_restart", "particle_set_draw_pass", "particle_set_main", "particle_set_process"]},
+	{"id": "physics_shape", "label": "physics_shape", "count": 1, "tools": ["physics_shape_autofit"]},
+	{"id": "project", "label": "project", "count": 4, "tools": ["project_run", "project_settings_get", "project_settings_set", "project_stop"]},
+	{"id": "resource", "label": "resource", "count": 5, "tools": ["resource_assign", "resource_create", "resource_get_info", "resource_load", "resource_search"]},
+	{"id": "scene", "label": "scene", "count": 5, "tools": ["scene_create", "scene_get_roots", "scene_open", "scene_save", "scene_save_as"]},
+	{"id": "script", "label": "script", "count": 6, "tools": ["script_attach", "script_create", "script_detach", "script_find_symbols", "script_patch", "script_read"]},
+	{"id": "signal", "label": "signal", "count": 3, "tools": ["signal_connect", "signal_disconnect", "signal_list"]},
+	{"id": "testing", "label": "testing", "count": 2, "tools": ["test_results_get", "test_run"]},
+	{"id": "texture", "label": "texture", "count": 2, "tools": ["gradient_texture_create", "noise_texture_create"]},
+	{"id": "theme", "label": "theme", "count": 6, "tools": ["theme_apply", "theme_create", "theme_set_color", "theme_set_constant", "theme_set_font_size", "theme_set_stylebox_flat"]},
+	{"id": "ui", "label": "ui", "count": 3, "tools": ["ui_build_layout", "ui_set_anchor_preset", "ui_set_text"]},
+]
+
+
+## Total tool count when no domains are excluded. Used for the "Enabled: N / M"
+## readout in the Tools tab without looping the catalog on every repaint.
+static func total_tool_count() -> int:
+	var n := CORE_TOOLS.size()
+	for d in DOMAINS:
+		n += int(d["count"])
+	return n
+
+
+## Tool count remaining after excluding the given set of domain ids.
+static func enabled_tool_count(excluded: PackedStringArray) -> int:
+	var n := CORE_TOOLS.size()
+	for d in DOMAINS:
+		if excluded.find(d["id"]) == -1:
+			n += int(d["count"])
+	return n
+
+
+## Canonical comma-separated string for a set of domain ids — sorted and
+## deduplicated so two equivalent settings (entered in different orders)
+## hash to the same EditorSetting value. Matches `excluded_domains()` in
+## client_configurator.gd.
+static func canonical(excluded: PackedStringArray) -> String:
+	var seen := PackedStringArray()
+	for e in excluded:
+		var t := e.strip_edges()
+		if not t.is_empty() and seen.find(t) == -1:
+			seen.append(t)
+	seen.sort()
+	return ",".join(seen)

--- a/src/godot_ai/__init__.py
+++ b/src/godot_ai/__init__.py
@@ -72,7 +72,25 @@ def main(argv: Sequence[str] | None = None) -> None:
             "process when a launcher (uvx) PID would be unreliable."
         ),
     )
+    parser.add_argument(
+        "--exclude-domains",
+        default="",
+        help=(
+            "Comma-separated list of tool domains to drop from registration "
+            "(e.g. 'audio,particle,theme'). Core tools (editor_state, "
+            "scene_get_hierarchy, node_get_properties, session_list, "
+            "session_activate) are always registered. Use this to fit under "
+            "a client's hard tool-count cap (Antigravity limits to 100)."
+        ),
+    )
     args = parser.parse_args(argv)
+
+    from godot_ai.tools.domains import parse_exclude_list
+
+    try:
+        exclude_domains = parse_exclude_list(args.exclude_domains)
+    except ValueError as exc:
+        parser.error(str(exc))
 
     from godot_ai.runtime_info import install_pid_file
 
@@ -81,12 +99,17 @@ def main(argv: Sequence[str] | None = None) -> None:
     if args.reload and args.transport in ("sse", "streamable-http"):
         from godot_ai.asgi import run_with_reload
 
-        run_with_reload(transport=args.transport, port=args.port, ws_port=args.ws_port)
+        run_with_reload(
+            transport=args.transport,
+            port=args.port,
+            ws_port=args.ws_port,
+            exclude_domains=exclude_domains,
+        )
         return
 
     from godot_ai.server import create_server
 
-    server = create_server(ws_port=args.ws_port)
+    server = create_server(ws_port=args.ws_port, exclude_domains=exclude_domains)
 
     transport_kwargs = {}
     if args.transport in ("sse", "streamable-http"):

--- a/src/godot_ai/asgi.py
+++ b/src/godot_ai/asgi.py
@@ -10,6 +10,7 @@ import uvicorn
 
 DEV_TRANSPORT_ENV = "GODOT_AI_DEV_TRANSPORT"
 DEV_WS_PORT_ENV = "GODOT_AI_DEV_WS_PORT"
+DEV_EXCLUDE_DOMAINS_ENV = "GODOT_AI_DEV_EXCLUDE_DOMAINS"
 RELOADABLE_TRANSPORTS = {"sse", "streamable-http"}
 
 
@@ -31,18 +32,27 @@ def _get_dev_ws_port() -> int:
 def create_app():
     """Create the FastMCP ASGI app for uvicorn's reload supervisor."""
     from godot_ai.server import create_server
+    from godot_ai.tools.domains import parse_exclude_list
 
-    server = create_server(ws_port=_get_dev_ws_port())
+    exclude_domains = parse_exclude_list(os.environ.get(DEV_EXCLUDE_DOMAINS_ENV, ""))
+    server = create_server(ws_port=_get_dev_ws_port(), exclude_domains=exclude_domains)
     return server.http_app(transport=_get_dev_transport())
 
 
-def run_with_reload(*, transport: str, port: int, ws_port: int) -> None:
+def run_with_reload(
+    *,
+    transport: str,
+    port: int,
+    ws_port: int,
+    exclude_domains: set[str] | None = None,
+) -> None:
     """Run the HTTP transport through uvicorn's supported reload path."""
     if transport not in RELOADABLE_TRANSPORTS:
         raise ValueError(f"Reload is only supported for HTTP transports, got {transport}")
 
     os.environ[DEV_TRANSPORT_ENV] = transport
     os.environ[DEV_WS_PORT_ENV] = str(ws_port)
+    os.environ[DEV_EXCLUDE_DOMAINS_ENV] = ",".join(sorted(exclude_domains or set()))
 
     src_dir = str(Path(__file__).resolve().parent.parent)
     uvicorn.run(

--- a/src/godot_ai/server.py
+++ b/src/godot_ai/server.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 
@@ -54,7 +54,11 @@ class AppContext:
     client: GodotClient
 
 
-def create_server(ws_port: int = 9500) -> FastMCP:
+def create_server(
+    ws_port: int = 9500,
+    *,
+    exclude_domains: Iterable[str] | None = None,
+) -> FastMCP:
     logging.basicConfig(level=logging.INFO, format="%(name)s | %(message)s")
 
     # Capture ws_port in the lifespan closure
@@ -135,32 +139,62 @@ def create_server(ws_port: int = 9500) -> FastMCP:
         lifespan=_lifespan,
     )
 
-    register_session_tools(mcp)
-    register_editor_tools(mcp)
-    register_scene_tools(mcp)
-    register_node_tools(mcp)
-    register_project_tools(mcp)
-    register_script_tools(mcp)
-    register_resource_tools(mcp)
-    register_filesystem_tools(mcp)
-    register_client_tools(mcp)
-    register_signal_tools(mcp)
-    register_autoload_tools(mcp)
-    register_input_map_tools(mcp)
-    register_testing_tools(mcp)
-    register_batch_tools(mcp)
-    register_ui_tools(mcp)
-    register_control_tools(mcp)
-    register_theme_tools(mcp)
-    register_animation_tools(mcp)
-    register_material_tools(mcp)
-    register_particle_tools(mcp)
-    register_camera_tools(mcp)
-    register_audio_tools(mcp)
-    register_physics_shape_tools(mcp)
-    register_environment_tools(mcp)
-    register_texture_tools(mcp)
-    register_curve_tools(mcp)
+    exclude = set(exclude_domains or ())
+    if exclude:
+        logger.info("Excluding tool domains: %s", ", ".join(sorted(exclude)))
+
+    ## Core-bearing domains: always registered; `include_non_core=False` keeps
+    ## only the core tool alive when the user excluded that domain.
+    register_session_tools(mcp, include_non_core="session" not in exclude)
+    register_editor_tools(mcp, include_non_core="editor" not in exclude)
+    register_scene_tools(mcp, include_non_core="scene" not in exclude)
+    register_node_tools(mcp, include_non_core="node" not in exclude)
+
+    ## Non-core-bearing domains: dropped wholesale when excluded.
+    if "project" not in exclude:
+        register_project_tools(mcp)
+    if "script" not in exclude:
+        register_script_tools(mcp)
+    if "resource" not in exclude:
+        register_resource_tools(mcp)
+    if "filesystem" not in exclude:
+        register_filesystem_tools(mcp)
+    if "client" not in exclude:
+        register_client_tools(mcp)
+    if "signal" not in exclude:
+        register_signal_tools(mcp)
+    if "autoload" not in exclude:
+        register_autoload_tools(mcp)
+    if "input_map" not in exclude:
+        register_input_map_tools(mcp)
+    if "testing" not in exclude:
+        register_testing_tools(mcp)
+    if "batch" not in exclude:
+        register_batch_tools(mcp)
+    if "ui" not in exclude:
+        register_ui_tools(mcp)
+    if "control" not in exclude:
+        register_control_tools(mcp)
+    if "theme" not in exclude:
+        register_theme_tools(mcp)
+    if "animation" not in exclude:
+        register_animation_tools(mcp)
+    if "material" not in exclude:
+        register_material_tools(mcp)
+    if "particle" not in exclude:
+        register_particle_tools(mcp)
+    if "camera" not in exclude:
+        register_camera_tools(mcp)
+    if "audio" not in exclude:
+        register_audio_tools(mcp)
+    if "physics_shape" not in exclude:
+        register_physics_shape_tools(mcp)
+    if "environment" not in exclude:
+        register_environment_tools(mcp)
+    if "texture" not in exclude:
+        register_texture_tools(mcp)
+    if "curve" not in exclude:
+        register_curve_tools(mcp)
     register_session_resources(mcp)
     register_scene_resources(mcp)
     register_editor_resources(mcp)

--- a/src/godot_ai/tools/domains.py
+++ b/src/godot_ai/tools/domains.py
@@ -1,0 +1,95 @@
+"""Tool-domain catalog and exclude-list parsing.
+
+Some MCP clients (notably Antigravity) reject connections whose total tool
+count exceeds a hard limit (100 for Antigravity). `defer_loading` meta only
+helps clients that speak Anthropic's tool-search — others still see every
+registered tool at handshake time. To fit under such limits, the server
+accepts `--exclude-domains` and drops whole domains' non-core tools before
+registration.
+
+This module is the single source of truth for:
+  - the canonical ordered list of domains (`DOMAINS`)
+  - which domains contain always-on core tools (`CORE_BEARING_DOMAINS`)
+  - the core tools themselves (`CORE_TOOLS`) — shown as an "always on" row
+    in the plugin's Tools UI
+  - `parse_exclude_list(raw)` — CLI/plugin input parser
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+## Registration order matches server.create_server(). Keep in sync.
+DOMAINS: tuple[str, ...] = (
+    "session",
+    "editor",
+    "scene",
+    "node",
+    "project",
+    "script",
+    "resource",
+    "filesystem",
+    "client",
+    "signal",
+    "autoload",
+    "input_map",
+    "testing",
+    "batch",
+    "ui",
+    "control",
+    "theme",
+    "animation",
+    "material",
+    "particle",
+    "camera",
+    "audio",
+    "physics_shape",
+    "environment",
+    "texture",
+    "curve",
+)
+
+## Domains that contain at least one core (always-loaded) tool. When the
+## user excludes one of these, only its non-core tools are dropped; the
+## core tool is still registered.
+CORE_BEARING_DOMAINS: frozenset[str] = frozenset({"session", "editor", "scene", "node"})
+
+## The 5 core tools that survive any exclusion. Displayed as a disabled
+## "Core" row in the plugin UI. Order mirrors the flat namespace the
+## server exposes; not functionally significant.
+CORE_TOOLS: tuple[str, ...] = (
+    "session_list",
+    "session_activate",
+    "editor_state",
+    "scene_get_hierarchy",
+    "node_get_properties",
+)
+
+## Domains the user can toggle off. `session` has no non-core tools, so
+## excluding it would be a no-op; we reject it up front so an accidental
+## `--exclude-domains session` doesn't silently do nothing.
+EXCLUDABLE_DOMAINS: frozenset[str] = frozenset(DOMAINS) - {"session"}
+
+
+def parse_exclude_list(raw: str | Iterable[str] | None) -> set[str]:
+    """Parse a comma-separated string (or iterable) of domain names.
+
+    Whitespace and empty entries are ignored. Unknown names raise
+    ValueError with the offending names listed — callers decide whether
+    to surface the error (CLI: hard-fail) or degrade (plugin: warn).
+    """
+    if raw is None:
+        return set()
+    if isinstance(raw, str):
+        parts = [p.strip() for p in raw.split(",")]
+    else:
+        parts = [str(p).strip() for p in raw]
+    names = {p for p in parts if p}
+    unknown = names - EXCLUDABLE_DOMAINS
+    if unknown:
+        raise ValueError(
+            "Unknown or non-excludable domain(s): "
+            + ", ".join(sorted(unknown))
+            + f". Valid: {', '.join(sorted(EXCLUDABLE_DOMAINS))}."
+        )
+    return names

--- a/src/godot_ai/tools/editor.py
+++ b/src/godot_ai/tools/editor.py
@@ -11,7 +11,7 @@ from godot_ai.runtime.direct import DirectRuntime
 from godot_ai.tools import DEFER_META, JsonCoerced
 
 
-def register_editor_tools(mcp: FastMCP) -> None:
+def register_editor_tools(mcp: FastMCP, *, include_non_core: bool = True) -> None:
     @mcp.tool()
     async def editor_state(ctx: Context, session_id: str = "") -> dict:
         """Get current Godot editor (IDE) state: version, readiness, open scene.
@@ -24,6 +24,9 @@ def register_editor_tools(mcp: FastMCP) -> None:
         """
         runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await editor_handlers.editor_state(runtime)
+
+    if not include_non_core:
+        return
 
     @mcp.tool(meta=DEFER_META)
     async def editor_selection_get(ctx: Context, session_id: str = "") -> dict:

--- a/src/godot_ai/tools/node.py
+++ b/src/godot_ai/tools/node.py
@@ -9,7 +9,24 @@ from godot_ai.runtime.direct import DirectRuntime
 from godot_ai.tools import DEFER_META
 
 
-def register_node_tools(mcp: FastMCP) -> None:
+def register_node_tools(mcp: FastMCP, *, include_non_core: bool = True) -> None:
+    @mcp.tool()
+    async def node_get_properties(ctx: Context, path: str, session_id: str = "") -> dict:
+        """Get all properties of a node.
+
+        Returns the property list with current values for the node at
+        the given scene path.
+
+        Args:
+            path: Scene path of the node (e.g. "/Main/Camera3D").
+            session_id: Optional Godot session to target. Empty = active session.
+        """
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
+        return await node_handlers.node_get_properties(runtime, path=path)
+
+    if not include_non_core:
+        return
+
     @mcp.tool(meta=DEFER_META)
     async def node_create(
         ctx: Context,
@@ -82,20 +99,6 @@ def register_node_tools(mcp: FastMCP) -> None:
             offset=offset,
             limit=limit,
         )
-
-    @mcp.tool()
-    async def node_get_properties(ctx: Context, path: str, session_id: str = "") -> dict:
-        """Get all properties of a node.
-
-        Returns the property list with current values for the node at
-        the given scene path.
-
-        Args:
-            path: Scene path of the node (e.g. "/Main/Camera3D").
-            session_id: Optional Godot session to target. Empty = active session.
-        """
-        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
-        return await node_handlers.node_get_properties(runtime, path=path)
 
     @mcp.tool(meta=DEFER_META)
     async def node_get_children(ctx: Context, path: str, session_id: str = "") -> dict:

--- a/src/godot_ai/tools/scene.py
+++ b/src/godot_ai/tools/scene.py
@@ -9,7 +9,7 @@ from godot_ai.runtime.direct import DirectRuntime
 from godot_ai.tools import DEFER_META
 
 
-def register_scene_tools(mcp: FastMCP) -> None:
+def register_scene_tools(mcp: FastMCP, *, include_non_core: bool = True) -> None:
     @mcp.tool()
     async def scene_get_hierarchy(
         ctx: Context,
@@ -36,6 +36,9 @@ def register_scene_tools(mcp: FastMCP) -> None:
             offset=offset,
             limit=limit,
         )
+
+    if not include_non_core:
+        return
 
     @mcp.tool(meta=DEFER_META)
     async def scene_get_roots(ctx: Context, session_id: str = "") -> dict:

--- a/src/godot_ai/tools/session.py
+++ b/src/godot_ai/tools/session.py
@@ -8,7 +8,11 @@ from godot_ai.handlers import session as session_handlers
 from godot_ai.runtime.direct import DirectRuntime
 
 
-def register_session_tools(mcp: FastMCP) -> None:
+def register_session_tools(mcp: FastMCP, *, include_non_core: bool = True) -> None:
+    ## session has no non-core tools — `include_non_core` is accepted for a
+    ## uniform call signature across core-bearing domains.
+    del include_non_core
+
     @mcp.tool()
     def session_list(ctx: Context) -> dict:
         """List all connected Godot editor sessions.

--- a/tests/unit/test_cli_reload.py
+++ b/tests/unit/test_cli_reload.py
@@ -26,20 +26,23 @@ class StubServer:
 def test_create_app_uses_env_config(monkeypatch):
     app = object()
     server = StubServer(app)
-    calls: dict[str, int] = {}
+    calls: dict[str, object] = {}
 
-    def fake_create_server(ws_port: int):
+    def fake_create_server(ws_port: int, *, exclude_domains=None):
         calls["ws_port"] = ws_port
+        calls["exclude_domains"] = exclude_domains
         return server
 
     monkeypatch.setenv(asgi.DEV_TRANSPORT_ENV, "streamable-http")
     monkeypatch.setenv(asgi.DEV_WS_PORT_ENV, "9555")
+    monkeypatch.setenv(asgi.DEV_EXCLUDE_DOMAINS_ENV, "audio,theme")
     monkeypatch.setattr("godot_ai.server.create_server", fake_create_server)
 
     result = asgi.create_app()
 
     assert result is app
     assert calls["ws_port"] == 9555
+    assert calls["exclude_domains"] == {"audio", "theme"}
     assert server.http_calls == [{"transport": "streamable-http"}]
 
 
@@ -52,9 +55,15 @@ def test_run_with_reload_uses_uvicorn_factory(monkeypatch):
 
     monkeypatch.delenv(asgi.DEV_TRANSPORT_ENV, raising=False)
     monkeypatch.delenv(asgi.DEV_WS_PORT_ENV, raising=False)
+    monkeypatch.delenv(asgi.DEV_EXCLUDE_DOMAINS_ENV, raising=False)
     monkeypatch.setattr(asgi.uvicorn, "run", fake_run)
 
-    asgi.run_with_reload(transport="streamable-http", port=8123, ws_port=9555)
+    asgi.run_with_reload(
+        transport="streamable-http",
+        port=8123,
+        ws_port=9555,
+        exclude_domains={"audio", "theme"},
+    )
 
     assert calls["app"] == "godot_ai.asgi:create_app"
     assert calls["kwargs"] == {
@@ -70,6 +79,11 @@ def test_run_with_reload_uses_uvicorn_factory(monkeypatch):
     }
     assert asgi._get_dev_transport() == "streamable-http"
     assert asgi._get_dev_ws_port() == 9555
+    ## Canonicalized comma-separated list — set order isn't guaranteed, so
+    ## `run_with_reload` sorts before writing the env var.
+    import os
+
+    assert os.environ[asgi.DEV_EXCLUDE_DOMAINS_ENV] == "audio,theme"
 
 
 def test_main_uses_reloadable_runner_for_http_reload(monkeypatch):
@@ -88,15 +102,17 @@ def test_main_uses_reloadable_runner_for_http_reload(monkeypatch):
         "transport": "streamable-http",
         "port": 8123,
         "ws_port": 9555,
+        "exclude_domains": set(),
     }
 
 
 def test_main_runs_server_directly_without_reload(monkeypatch):
     server = StubServer(app=None)
-    calls: dict[str, int] = {}
+    calls: dict[str, object] = {}
 
-    def fake_create_server(ws_port: int):
+    def fake_create_server(ws_port: int, *, exclude_domains=None):
         calls["ws_port"] = ws_port
+        calls["exclude_domains"] = exclude_domains
         return server
 
     monkeypatch.setattr("godot_ai.server.create_server", fake_create_server)
@@ -104,7 +120,56 @@ def test_main_runs_server_directly_without_reload(monkeypatch):
     godot_ai.main(["--transport", "streamable-http", "--port", "8123", "--ws-port", "9555"])
 
     assert calls["ws_port"] == 9555
+    assert calls["exclude_domains"] == set()
     assert server.run_calls == [{"transport": "streamable-http", "port": 8123}]
+
+
+def test_main_forwards_exclude_domains_to_create_server(monkeypatch):
+    server = StubServer(app=None)
+    calls: dict[str, object] = {}
+
+    def fake_create_server(ws_port: int, *, exclude_domains=None):
+        calls["exclude_domains"] = exclude_domains
+        return server
+
+    monkeypatch.setattr("godot_ai.server.create_server", fake_create_server)
+
+    godot_ai.main(
+        [
+            "--transport",
+            "stdio",
+            "--exclude-domains",
+            "audio, particle ,theme",
+        ]
+    )
+
+    ## Whitespace is stripped and duplicates collapsed; the set has no order.
+    assert calls["exclude_domains"] == {"audio", "particle", "theme"}
+
+
+def test_main_rejects_unknown_exclude_domain(monkeypatch, capsys):
+    monkeypatch.setattr(
+        "godot_ai.server.create_server",
+        lambda ws_port, *, exclude_domains=None: pytest.fail("should not reach create_server"),
+    )
+    with pytest.raises(SystemExit) as excinfo:
+        godot_ai.main(["--transport", "stdio", "--exclude-domains", "bogus,audio"])
+    assert excinfo.value.code != 0
+    captured = capsys.readouterr()
+    assert "Unknown or non-excludable" in captured.err
+    assert "bogus" in captured.err
+
+
+def test_main_rejects_non_excludable_core_domain(monkeypatch):
+    monkeypatch.setattr(
+        "godot_ai.server.create_server",
+        lambda ws_port, *, exclude_domains=None: pytest.fail("should not reach create_server"),
+    )
+    ## `session` has only core tools, so excluding it would be a silent no-op.
+    ## The parser rejects it up front rather than letting the user think they
+    ## trimmed something.
+    with pytest.raises(SystemExit):
+        godot_ai.main(["--transport", "stdio", "--exclude-domains", "session"])
 
 
 def test_main_version_flag(capsys):

--- a/tests/unit/test_runtime_info.py
+++ b/tests/unit/test_runtime_info.py
@@ -138,7 +138,10 @@ def test_main_plumbs_pid_file_into_runtime_info(monkeypatch, tmp_path):
         def run(self, **kwargs):
             captured["run_kwargs"] = kwargs
 
-    monkeypatch.setattr("godot_ai.server.create_server", lambda ws_port: StubServer())
+    monkeypatch.setattr(
+        "godot_ai.server.create_server",
+        lambda ws_port, *, exclude_domains=None: StubServer(),
+    )
 
     import godot_ai
 

--- a/tests/unit/test_tool_domains.py
+++ b/tests/unit/test_tool_domains.py
@@ -1,0 +1,183 @@
+"""Tests for the tool-domain catalog and `--exclude-domains` filtering."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from pathlib import Path
+
+import pytest
+
+from godot_ai.server import create_server
+from godot_ai.tools.domains import (
+    CORE_BEARING_DOMAINS,
+    CORE_TOOLS,
+    DOMAINS,
+    EXCLUDABLE_DOMAINS,
+    parse_exclude_list,
+)
+
+## Path to the GDScript catalog the dock UI reads. Parity test below parses
+## it and verifies it matches live registration — if this file moves, update
+## here and in the dock.
+_CATALOG_GD = (
+    Path(__file__).resolve().parent.parent.parent
+    / "plugin"
+    / "addons"
+    / "godot_ai"
+    / "tool_catalog.gd"
+)
+
+
+def _list_tools(server) -> list[str]:
+    tools = asyncio.run(server.list_tools())
+    return [t.name for t in tools]
+
+
+# --- domains.parse_exclude_list ---
+
+
+def test_parse_empty_returns_empty_set():
+    assert parse_exclude_list(None) == set()
+    assert parse_exclude_list("") == set()
+    assert parse_exclude_list("   ") == set()
+
+
+def test_parse_strips_whitespace_and_dedupes():
+    assert parse_exclude_list("audio, particle ,theme,audio") == {"audio", "particle", "theme"}
+
+
+def test_parse_accepts_iterable():
+    assert parse_exclude_list(["audio", "theme"]) == {"audio", "theme"}
+
+
+def test_parse_rejects_unknown_names():
+    with pytest.raises(ValueError, match="Unknown or non-excludable"):
+        parse_exclude_list("audio,bogus")
+
+
+def test_parse_rejects_core_only_session_domain():
+    ## `session` is all-core — excluding it is a no-op. Hard-fail so users
+    ## don't assume they trimmed something they didn't.
+    with pytest.raises(ValueError, match="session"):
+        parse_exclude_list("session")
+
+
+def test_core_bearing_domains_are_all_known():
+    assert CORE_BEARING_DOMAINS <= set(DOMAINS)
+
+
+def test_excludable_domains_excludes_session_only():
+    ## session has only core tools → never excludable. Every other registered
+    ## domain must be excludable.
+    assert EXCLUDABLE_DOMAINS == set(DOMAINS) - {"session"}
+
+
+# --- create_server() filtering ---
+
+
+def test_create_server_full_registration_matches_domain_count():
+    ## Sanity: total tools equal core (5) + sum of non-core-per-domain.
+    ## The exact number (125) will drift as tools are added; the relationship
+    ## between exclusion and tool count is what we pin.
+    full = set(_list_tools(create_server()))
+    assert set(CORE_TOOLS) <= full
+
+
+def test_create_server_drops_whole_non_core_domain():
+    full = set(_list_tools(create_server()))
+    trimmed = set(_list_tools(create_server(exclude_domains={"audio"})))
+    dropped = full - trimmed
+    ## Every dropped tool must be from the excluded domain; nothing else.
+    assert dropped, "excluding 'audio' should drop at least one tool"
+    assert all(t.startswith("audio_") for t in dropped)
+
+
+def test_create_server_preserves_core_when_core_bearing_domain_excluded():
+    ## Excluding `node` drops node_create, node_find, … but keeps
+    ## node_get_properties. Same for editor/scene.
+    trimmed = set(_list_tools(create_server(exclude_domains={"editor", "scene", "node"})))
+    for core_name in CORE_TOOLS:
+        assert core_name in trimmed, f"{core_name} should survive exclusion"
+    ## And the non-core members really are gone.
+    assert "node_create" not in trimmed
+    assert "editor_selection_get" not in trimmed
+    assert "scene_open" not in trimmed
+
+
+def test_create_server_ignores_unknown_domain_names_via_set_input():
+    ## `create_server` accepts any iterable; only the CLI parser enforces
+    ## known names. This lets the plugin pass a set that may contain a
+    ## stale domain id from a previous version without wedging the spawn.
+    ## (Unknown names are a no-op here because no registration is gated
+    ## on them.)
+    trimmed = set(_list_tools(create_server(exclude_domains={"audio", "ghost_domain"})))
+    assert not any(t.startswith("audio_") for t in trimmed)
+
+
+# --- GDScript catalog parity ---
+
+
+def _parse_gd_catalog() -> tuple[list[str], dict[str, list[str]]]:
+    """Parse tool_catalog.gd into (core_tools, {domain_id: [tool_names]})."""
+    text = _CATALOG_GD.read_text()
+
+    core_match = re.search(r"const CORE_TOOLS := \[(.*?)\]", text, re.DOTALL)
+    assert core_match, "CORE_TOOLS block not found in tool_catalog.gd"
+    core_tools = re.findall(r'"([^"]+)"', core_match.group(1))
+
+    domains_match = re.search(r"const DOMAINS := \[(.*?)^\]", text, re.DOTALL | re.MULTILINE)
+    assert domains_match, "DOMAINS block not found in tool_catalog.gd"
+    domain_entries = re.findall(
+        r'\{"id": "([^"]+)",\s*"label":\s*"[^"]*",\s*"count":\s*(\d+),\s*"tools":\s*\[([^\]]*)\]\}',
+        domains_match.group(1),
+    )
+    domains: dict[str, list[str]] = {}
+    for dom_id, count_str, tools_str in domain_entries:
+        tools = re.findall(r'"([^"]+)"', tools_str)
+        assert int(count_str) == len(tools), (
+            f"{dom_id}: declared count {count_str} != actual tool list length {len(tools)}"
+        )
+        domains[dom_id] = tools
+    return core_tools, domains
+
+
+def test_gdscript_catalog_matches_python_registration():
+    """If this fails, tool_catalog.gd drifted from src/godot_ai/tools/*.
+
+    The failure message lists what's missing/extra per domain so a developer
+    can update the GDScript const. Regenerate with:
+
+        python -c "from godot_ai.server import create_server; \\
+                   from godot_ai.tools.domains import EXCLUDABLE_DOMAINS; \\
+                   import asyncio; \\
+                   full = {t.name for t in asyncio.run(create_server().list_tools())}; \\
+                   for d in sorted(EXCLUDABLE_DOMAINS): \\
+                       trimmed = {t.name for t in asyncio.run( \\
+                           create_server(exclude_domains=[d]).list_tools())}; \\
+                       print(d, sorted(full - trimmed))"
+    """
+    gd_core, gd_domains = _parse_gd_catalog()
+
+    assert sorted(gd_core) == sorted(CORE_TOOLS), (
+        f"CORE_TOOLS drift — GDScript has {sorted(gd_core)}, Python has {sorted(CORE_TOOLS)}"
+    )
+
+    assert set(gd_domains) == EXCLUDABLE_DOMAINS, (
+        f"Domain set drift — GDScript has {sorted(gd_domains)}, "
+        f"Python has {sorted(EXCLUDABLE_DOMAINS)}"
+    )
+
+    full = {t.name for t in asyncio.run(create_server().list_tools())}
+    for domain in sorted(EXCLUDABLE_DOMAINS):
+        trimmed = {
+            t.name for t in asyncio.run(create_server(exclude_domains=[domain]).list_tools())
+        }
+        expected = sorted(full - trimmed)
+        actual = sorted(gd_domains[domain])
+        assert actual == expected, (
+            f"Domain '{domain}' drift:\n"
+            f"  GDScript lists: {actual}\n"
+            f"  Actually registered: {expected}\n"
+            f"  Fix: update tool_catalog.gd"
+        )


### PR DESCRIPTION
Fixes #170.

Antigravity rejects MCP servers above 100 tools per connection; we register 125 and `defer_loading` only helps clients that speak Anthropic tool-search. This adds a domain-level exclusion mechanism so users can trim the surface to fit under any hard cap.

## Summary

- **Server**: `--exclude-domains audio,particle,theme` CLI flag, plus `create_server(*, exclude_domains=...)` that gates each `register_*_tools` call. Core tools (`editor_state`, `scene_get_hierarchy`, `node_get_properties`, `session_list`, `session_activate`) always register, so `editor`/`scene`/`node` can be excluded without losing the 5-tool baseline. `session` (all-core) is rejected as excludable up front to avoid silent no-ops.
- **Plugin**: the "Configure Clients" button becomes **"Clients & Tools"** and opens a secondary window with a `TabContainer`. Tab 1 = the existing per-client configurator (no behavior change). Tab 2 = Tools:
  - Disabled "Core (always on)" row showing the 5 core tools.
  - One checkbox per excludable domain, with tool count and a hover tooltip listing the actual tool names.
  - Live **Enabled: N / M** readout that turns amber when the selection still exceeds 100 (Antigravity's cap).
  - **Apply & Restart Server** writes `godot_ai/excluded_domains` to EditorSettings and reloads the plugin so the server respawns with the new flag (same pattern as the existing port-change "Apply + Reload"). **Reset to defaults** re-ticks everything.
  - `ConfirmationDialog` on close-with-unapplied-changes.
- **Parity**: `plugin/addons/godot_ai/tool_catalog.gd` mirrors `src/godot_ai/tools/domains.py`. A Python test parses the GDScript catalog and diffs it against live registration — if anyone adds a tool without updating the catalog, CI fails with a diff.

## Design notes

- Restart *is* required: FastMCP doesn't support dynamic tool removal in a way every client respects, and Antigravity enforces the cap at handshake — live-toggling can't fix their case anyway. The server has to come up with the trimmed list.
- Unknown domain names: the CLI hard-fails (so users know they typo'd); `create_server` accepts unknown names in its `Iterable[str]` for forward compatibility, so a stale EditorSetting from a previous plugin version can't wedge the spawn.
- Plugin only appends `--exclude-domains` when the setting is non-empty, so pre-1.4.2 servers that don't know the flag never see it.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `pytest -v` — **562 passed** (23 directly exercise the new code: parse strictness, `create_server` filtering, core preservation, unknown-name tolerance, CLI success/error paths, and the GDScript catalog parity diff)
- [ ] Live smoke in Godot editor: open dock → **Clients & Tools** → uncheck `audio` + `particle` → **Apply & Restart Server** → verify `session_list` shows the new tool count and `audio_*` / `particle_*` are gone from the client
- [ ] Live smoke: **Reset to defaults** re-enables everything after Apply
- [ ] Live smoke: close window with unsaved checkbox changes → ConfirmationDialog appears → **Discard** resets pending to saved
- [ ] Live smoke: configure Antigravity, confirm ≤100 tool selection connects cleanly

https://claude.ai/code/session_0158hhKLJ4xyXFiY8avFs8D3