### PR TITLE
fix(clients): refuse to overwrite unreadable config instead of wiping other MCPs

### DIFF
--- a/plugin/addons/godot_ai/clients/_json_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_json_strategy.gd
@@ -11,7 +11,10 @@ static func configure(client: McpClient, server_name: String, server_url: String
 	if path.is_empty():
 		return {"status": "error", "message": "Could not resolve config path for %s on this OS" % client.display_name}
 
-	var config := _read_or_init(path)
+	var read := _read_or_init(path)
+	if not read["ok"]:
+		return {"status": "error", "message": "Refusing to overwrite %s: %s. Fix or move the file, then re-run Configure." % [path, read["error"]]}
+	var config: Dictionary = read["data"]
 	var holder := _ensure_path(config, client.server_key_path)
 	holder[server_name] = client.entry_builder.call(server_name, server_url)
 
@@ -24,7 +27,10 @@ static func check_status(client: McpClient, server_name: String, server_url: Str
 	var path := client.resolved_config_path()
 	if path.is_empty() or not FileAccess.file_exists(path):
 		return McpClient.Status.NOT_CONFIGURED
-	var config := _read_or_init(path)
+	var read := _read_or_init(path)
+	if not read["ok"]:
+		return McpClient.Status.NOT_CONFIGURED
+	var config: Dictionary = read["data"]
 	var holder := _walk_path(config, client.server_key_path)
 	if not (holder is Dictionary) or not holder.has(server_name):
 		return McpClient.Status.NOT_CONFIGURED
@@ -43,7 +49,10 @@ static func remove(client: McpClient, server_name: String) -> Dictionary:
 	var path := client.resolved_config_path()
 	if path.is_empty() or not FileAccess.file_exists(path):
 		return {"status": "ok", "message": "Not configured"}
-	var config := _read_or_init(path)
+	var read := _read_or_init(path)
+	if not read["ok"]:
+		return {"status": "error", "message": "Refusing to rewrite %s: %s." % [path, read["error"]]}
+	var config: Dictionary = read["data"]
 	var holder := _walk_path(config, client.server_key_path)
 	if holder is Dictionary and holder.has(server_name):
 		holder.erase(server_name)
@@ -52,23 +61,35 @@ static func remove(client: McpClient, server_name: String) -> Dictionary:
 	return {"status": "ok", "message": "%s configuration removed" % client.display_name}
 
 
+## Returns {"ok": true, "data": Dictionary} when the file is absent or parses
+## cleanly, and {"ok": false, "error": String} when the file exists with
+## non-empty content we cannot safely round-trip. Callers must NOT fall back
+## to an empty dict on the error path — doing so blows away the user's other
+## MCP entries on the next write.
 static func _read_or_init(path: String) -> Dictionary:
 	if not FileAccess.file_exists(path):
-		return {}
+		return {"ok": true, "data": {}}
 	var file := FileAccess.open(path, FileAccess.READ)
 	if file == null:
-		return {}
+		var err := FileAccess.get_open_error()
+		return {"ok": false, "error": "could not open for reading (error %d)" % err}
 	var content := file.get_as_text()
 	file.close()
+	# Strip a UTF-8 BOM if present — some editors (notably on Windows) save
+	# JSON with a leading ﻿, which Godot's JSON.parse rejects outright.
+	# Previously this landed on the "unparseable → wipe" path.
+	if content.begins_with("﻿"):
+		content = content.substr(1)
 	if content.strip_edges().is_empty():
-		return {}
+		return {"ok": true, "data": {}}
 	var json := JSON.new()
 	if json.parse(content) != OK:
-		push_warning("MCP | JSON parse error in %s: %s (line %d)" % [path, json.get_error_message(), json.get_error_line()])
-		return {}
-	if json.data is Dictionary:
-		return json.data
-	return {}
+		var msg := "JSON parse error on line %d: %s" % [json.get_error_line(), json.get_error_message()]
+		push_warning("MCP | %s in %s" % [msg, path])
+		return {"ok": false, "error": msg}
+	if not (json.data is Dictionary):
+		return {"ok": false, "error": "top-level value is %s, expected object" % type_string(typeof(json.data))}
+	return {"ok": true, "data": json.data}
 
 
 ## Walk a key path, creating intermediate Dicts as needed. Returns the leaf Dict.

--- a/plugin/addons/godot_ai/clients/_toml_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_toml_strategy.gd
@@ -11,8 +11,10 @@ static func configure(client: McpClient, _server_name: String, server_url: Strin
 	if path.is_empty():
 		return {"status": "error", "message": "Could not resolve config path for %s" % client.display_name}
 
-	var content := _read_text(path)
-	var lines := _split_lines(content)
+	var read := _read_or_init(path)
+	if not read["ok"]:
+		return {"status": "error", "message": "Refusing to overwrite %s: %s. Fix or move the file, then re-run Configure." % [path, read["error"]]}
+	var lines: Array[String] = _split_lines(String(read["data"]))
 	var body: PackedStringArray = client.toml_body_builder.call(server_url)
 
 	var section := _find_section(lines, _all_headers(client))
@@ -41,7 +43,10 @@ static func check_status(client: McpClient, _server_name: String, server_url: St
 	var path := client.resolved_config_path()
 	if path.is_empty() or not FileAccess.file_exists(path):
 		return McpClient.Status.NOT_CONFIGURED
-	var lines := _split_lines(_read_text(path))
+	var read := _read_or_init(path)
+	if not read["ok"]:
+		return McpClient.Status.NOT_CONFIGURED
+	var lines: Array[String] = _split_lines(String(read["data"]))
 	var section := _find_section(lines, _all_headers(client))
 	if section.is_empty():
 		return McpClient.Status.NOT_CONFIGURED
@@ -68,7 +73,10 @@ static func remove(client: McpClient, _server_name: String) -> Dictionary:
 	var path := client.resolved_config_path()
 	if path.is_empty() or not FileAccess.file_exists(path):
 		return {"status": "ok", "message": "Not configured"}
-	var lines := _split_lines(_read_text(path))
+	var read := _read_or_init(path)
+	if not read["ok"]:
+		return {"status": "error", "message": "Refusing to rewrite %s: %s." % [path, read["error"]]}
+	var lines: Array[String] = _split_lines(String(read["data"]))
 	var headers := _all_headers(client)
 
 	var output: Array[String] = []
@@ -92,15 +100,20 @@ static func remove(client: McpClient, _server_name: String) -> Dictionary:
 
 # --- helpers --------------------------------------------------------------
 
-static func _read_text(path: String) -> String:
+## Returns {"ok": true, "data": String} when the file is absent or readable,
+## and {"ok": false, "error": String} when the file exists but cannot be
+## opened. Callers must NOT fall back to an empty string on the error path —
+## doing so blows away the user's other MCP entries on the next write.
+static func _read_or_init(path: String) -> Dictionary:
 	if not FileAccess.file_exists(path):
-		return ""
+		return {"ok": true, "data": ""}
 	var f := FileAccess.open(path, FileAccess.READ)
 	if f == null:
-		return ""
+		var err := FileAccess.get_open_error()
+		return {"ok": false, "error": "could not open for reading (error %d)" % err}
 	var t := f.get_as_text()
 	f.close()
-	return t
+	return {"ok": true, "data": t}
 
 
 static func _split_lines(content: String) -> Array[String]:

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -603,6 +603,93 @@ func test_json_strategy_preserves_other_servers() -> void:
 	assert_true(parsed["mcpServers"].has("godot-ai"), "Our entry not added")
 
 
+func test_json_strategy_refuses_to_overwrite_unparseable_file() -> void:
+	## Regression: if the config file exists but we can't parse it (trailing
+	## comma, stray comment, truncated write), `configure()` used to silently
+	## fall back to `{}` and write only the godot-ai entry — wiping every
+	## other MCP the user had configured. Now it must refuse and surface an
+	## error so the user can inspect and recover.
+	var path := _scratch_dir.path_join("unparseable.json")
+	var bogus := "{\n  \"mcpServers\": {\n    \"someone-else\": {\"url\": \"http://other/\"},  // trailing comment\n  }\n"
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	f.store_string(bogus)
+	f.close()
+
+	var client := _make_test_json_client(path)
+	var result := McpJsonStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+	assert_eq(result.get("status"), "error", "Configure must error on unparseable JSON, not silently overwrite")
+	var msg: String = result.get("message", "")
+	assert_true(msg.find("Refusing to overwrite") >= 0, "Error message should flag refusal: %s" % msg)
+
+	# File on disk must be byte-for-byte what the user wrote. Anything else
+	# is data loss.
+	var check_file := FileAccess.open(path, FileAccess.READ)
+	var preserved := check_file.get_as_text()
+	check_file.close()
+	assert_eq(preserved, bogus, "Unparseable config file must not be mutated")
+
+
+func test_json_strategy_refuses_to_overwrite_non_object_root() -> void:
+	## JSON that parses fine but whose root isn't an object (a bare array, a
+	## string, a number) also can't be safely merged into. Refuse rather
+	## than overwriting.
+	var path := _scratch_dir.path_join("non_object_root.json")
+	var bogus := "[\"some\", \"array\"]"
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	f.store_string(bogus)
+	f.close()
+
+	var client := _make_test_json_client(path)
+	var result := McpJsonStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+	assert_eq(result.get("status"), "error")
+
+	var check_file := FileAccess.open(path, FileAccess.READ)
+	assert_eq(check_file.get_as_text(), bogus, "Non-object-root config must not be mutated")
+	check_file.close()
+
+
+func test_json_strategy_tolerates_utf8_bom() -> void:
+	## JSON saved with a UTF-8 BOM (common from Windows editors) parses as
+	## invalid under Godot's JSON.parse. Under the old strategy that meant a
+	## silent fall-through to `{}` and a wipe on the next write. The strategy
+	## must strip the BOM and preserve existing entries.
+	var path := _scratch_dir.path_join("bom.json")
+	var seed := {"mcpServers": {"someone-else": {"url": "http://other/"}}}
+	var body := "﻿" + JSON.stringify(seed)
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	f.store_string(body)
+	f.close()
+
+	var client := _make_test_json_client(path)
+	var result := McpJsonStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+	assert_eq(result.get("status"), "ok", "BOM-prefixed JSON should parse after strip")
+
+	var check_file := FileAccess.open(path, FileAccess.READ)
+	var parsed = JSON.parse_string(check_file.get_as_text())
+	check_file.close()
+	assert_true(parsed is Dictionary and parsed.has("mcpServers"))
+	assert_true(parsed["mcpServers"].has("someone-else"), "Existing entry wiped after BOM parse recovery")
+	assert_true(parsed["mcpServers"].has("godot-ai"), "godot-ai entry not added")
+
+
+func test_json_strategy_remove_refuses_unparseable_file() -> void:
+	## remove() has the same wipe-risk as configure() — it also round-trips
+	## through _read_or_init and writes back. Must refuse on bad input.
+	var path := _scratch_dir.path_join("remove_unparseable.json")
+	var bogus := "{not-valid-json"
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	f.store_string(bogus)
+	f.close()
+
+	var client := _make_test_json_client(path)
+	var result := McpJsonStrategy.remove(client, "godot-ai")
+	assert_eq(result.get("status"), "error")
+
+	var check_file := FileAccess.open(path, FileAccess.READ)
+	assert_eq(check_file.get_as_text(), bogus, "Unparseable config must not be mutated on remove")
+	check_file.close()
+
+
 func test_json_strategy_distinguishes_missing_entry_from_url_drift() -> void:
 	## Three statuses, three causes — dock surfaces them as muted dot,
 	## green dot, amber dot respectively. Conflating "never configured"


### PR DESCRIPTION
## Summary

A user reported the Configure button wiped their entire opencode MCP config, leaving only the `godot-ai` entry. The JSON strategy's `_read_or_init` silently returned `{}` whenever the existing file couldn't be read as a Dictionary — unreadable (permission / lock), JSON parse failure, BOM-prefixed bytes, or a non-object root — and `configure()` then wrote that empty dict back with only our entry merged in. The TOML strategy had the same shape: `_read_text` returned `""` on an open failure and the write tacked our section onto empty content. In both cases every other MCP the user had configured was lost on the next Configure click.

## Fix

- Both `_read_or_init` helpers now return `{ok, data, error}`. On the error path `configure()` and `remove()` refuse to write and return a human-readable error naming the file and the specific reason ("JSON parse error on line 3: …", "could not open for reading (error 7)", "top-level value is array, expected object"). The user's file on disk is left untouched.
- JSON strategy now auto-strips a leading UTF-8 BOM before parsing. That's a plausible trigger on Windows editors — previously BOM-prefixed valid JSON landed on the "unparseable → wipe" path.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] Python `pytest tests/unit/` — 318/318 pass
- [x] `--import` smoke — no GDScript parse errors
- [x] Live GDScript test suite against a headless Godot 4.6.2 editor — 809/823 pass, 0 failures
- [x] Four new regression tests in the `clients` suite all pass:
  - `test_json_strategy_refuses_to_overwrite_unparseable_file`
  - `test_json_strategy_refuses_to_overwrite_non_object_root`
  - `test_json_strategy_remove_refuses_unparseable_file`
  - `test_json_strategy_tolerates_utf8_bom`

Each regression test writes the bad input, calls `configure()`/`remove()`, asserts the result is `"error"`, and crucially asserts the on-disk bytes are unchanged — the whole point of the fix is that the user's data survives.

https://claude.ai/code/session_01QjaAG2DbmN5DZdbxyQWPzp

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjaAG2DbmN5DZdbxyQWPzp)_