### PR TITLE
fix(clients): OpenCode uses ~/.config on Windows, not $APPDATA

### DIFF
--- a/plugin/addons/godot_ai/clients/opencode.gd
+++ b/plugin/addons/godot_ai/clients/opencode.gd
@@ -12,7 +12,7 @@ func _init() -> void:
 	doc_url = "https://opencode.ai/docs/mcp-servers"
 	path_template = {
 		"unix": "~/.config/opencode/opencode.json",
-		"windows": "$APPDATA/opencode/opencode.json",
+		"windows": "$HOME/.config/opencode/opencode.json",
 	}
 	server_key_path = PackedStringArray(["mcp"])
 	entry_builder = func(_name: String, url: String) -> Dictionary:

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -934,6 +934,29 @@ func test_vscode_uses_servers_key_with_type_http() -> void:
 	assert_eq(entry.get("url", ""), "http://x")
 
 
+func test_opencode_client_uses_home_config_on_windows() -> void:
+	## Regression: OpenCode reads its MCP config from
+	## ~/.config/opencode/opencode.json on ALL platforms (verified via
+	## `opencode debug paths`). The Windows descriptor used to point at
+	## $APPDATA/opencode/opencode.json, so auto-configure silently wrote
+	## to a file OpenCode never read.
+	var c := McpClientRegistry.get_by_id("opencode")
+	assert_true(c != null, "opencode client must be registered")
+	assert_true(c.path_template.has("windows"), "opencode descriptor must declare a windows path_template entry")
+	var windows_template: String = c.path_template["windows"]
+	assert_contains(windows_template, "$HOME", "windows template must use $HOME, got: %s" % windows_template)
+	assert_false(windows_template.contains("$APPDATA"), "windows template must not use $APPDATA, got: %s" % windows_template)
+
+	var home := OS.get_environment("HOME")
+	if home.is_empty():
+		home = OS.get_environment("USERPROFILE")
+	if home.is_empty():
+		skip("HOME / USERPROFILE not set")
+		return
+	var resolved := McpPathTemplate.expand(windows_template)
+	assert_eq(resolved, home.path_join(".config/opencode/opencode.json"))
+
+
 # ----- helpers -----
 
 func _make_test_json_client(path: String) -> McpClient:


### PR DESCRIPTION
## Summary
- OpenCode reads its MCP config from `~/.config/opencode/opencode.json` on **all** platforms (macOS, Linux, Windows) — verified via `opencode debug paths`. Our Windows descriptor pointed at `$APPDATA/opencode/opencode.json`, so auto-configure silently wrote to a file OpenCode never read and the `godot-ai` MCP entry never appeared.
- Swap the Windows `path_template` entry in `plugin/addons/godot_ai/clients/opencode.gd` from `$APPDATA/opencode/opencode.json` to `$HOME/.config/opencode/opencode.json`. Unix entry unchanged.
- Add `test_opencode_client_uses_home_config_on_windows` in `test_project/tests/test_clients.gd` locking in the shape (`$HOME`, not `$APPDATA`) and verifying the expanded path resolves to `$HOME/.config/opencode/opencode.json`.

## Test plan
- [x] `pytest -v` — 563 passed, no regressions (this is GDScript-only but sanity-checked)
- [x] `ruff check src/ tests/` — all checks passed
- [ ] In Godot: open `test_project/`, run `test_run suite=clients` via MCP, confirm `test_opencode_client_uses_home_config_on_windows` passes
- [ ] On Windows: open the MCP dock, click Configure for OpenCode, confirm the entry lands in `%USERPROFILE%\.config\opencode\opencode.json` and `opencode` sees the server

🤖 Generated with [Claude Code](https://claude.com/claude-code)