### PR TITLE
fix(worktrees): install hooks to .git/hooks/ instead of core.hooksPath

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,9 +47,9 @@ Before editing *anything* in `plugin/` in a worktree, the worktree must pass two
 1. `plugin/addons/godot_ai/plugin.gd` exists (the worktree's `plugin/` is populated, not empty or sparse).
 2. `test_project/addons/godot_ai` is a real symlink (or Windows directory junction) into **this worktree's** `plugin/addons/godot_ai` — not a plain text file, not a stale copy, not pointing into main.
 
-`script/verify-worktree` (bash, works in git-bash on Windows) checks both and auto-heals the symlink via `mklink /J` when possible. It runs automatically via `.githooks/post-checkout` on every `git worktree add` and `git checkout <branch>`, so a freshly-created worktree is healthy by the time you start editing.
+`script/verify-worktree` (bash, works in git-bash on Windows) checks both and auto-heals the symlink via `mklink /J` when possible. It runs automatically via a `post-checkout` hook on every `git worktree add` and `git checkout <branch>`, so a freshly-created worktree is healthy by the time you start editing.
 
-Wiring: `script/setup-dev` and `setup-dev.ps1` both run `git config core.hooksPath .githooks` once. Worktrees share `.git/config` with the main repo, so the hook fires in every worktree automatically.
+Wiring: `script/setup-dev` and `setup-dev.ps1` copy `.githooks/post-checkout` into `.git/hooks/post-checkout` (the default path git always looks at). `.git/hooks/` is shared across all worktrees of a clone, so one install covers every future worktree forever. A fresh clone on a new machine needs setup-dev run once before the hook is active — after that, it's automatic. (We don't use `core.hooksPath=.githooks` because git resolves that relative path against main's working tree, which may be on a branch without `.githooks/` — a trap that wasted a whole debugging cycle.)
 
 **If you find a broken worktree** (empty `plugin/`, or `test_project/addons/godot_ai` is a text file): do NOT `git add` anything. Run `script/verify-worktree` to heal, or re-create the worktree. Committing plugin/ edits from a broken worktree stages phantom deletions that overwrite the canonical plugin code in main on push. This has happened 4+ times — the hook now prevents it.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -7,7 +7,7 @@
 ```bash
 git clone https://github.com/hi-godot/godot-ai.git
 cd godot-ai
-script/setup-dev             # creates .venv, installs deps
+script/setup-dev             # creates .venv, installs deps, installs git hooks
 source .venv/bin/activate
 ```
 
@@ -16,9 +16,18 @@ source .venv/bin/activate
 ```powershell
 git clone https://github.com/hi-godot/godot-ai.git
 cd godot-ai
-.\script\setup-dev.ps1       # creates .venv, installs deps, fixes symlink
+.\script\setup-dev.ps1       # creates .venv, installs deps, fixes symlink, installs git hooks
 .venv\Scripts\Activate.ps1
 ```
+
+> **One-time per clone:** `setup-dev` installs a `post-checkout` git hook
+> (from `.githooks/`) into `.git/hooks/`. The hook auto-verifies worktree
+> integrity on every `git worktree add` and `git checkout <branch>` —
+> specifically, that `plugin/` is populated and `test_project/addons/godot_ai`
+> is a real symlink/junction into this worktree's `plugin/`. It auto-heals
+> the Windows text-file-fallback symlink via `mklink /J`. You only need to
+> run `setup-dev` once per clone; the hook fires in every worktree of that
+> clone from then on.
 
 > **Windows contributors:** `setup-dev.ps1` requires **Windows Developer Mode**
 > to be enabled — if it isn't, the script prompts you with a link to the Settings

--- a/script/setup-dev
+++ b/script/setup-dev
@@ -3,10 +3,27 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-# Enable shared hooks (.githooks/post-checkout auto-verifies worktrees
-# on `git worktree add` / `git checkout <branch>`). Safe to run repeatedly;
-# git worktrees share .git/config with the main repo, so setting once covers all.
-git config core.hooksPath .githooks
+# Install git hooks to .git/hooks/ so they fire on `git worktree add` and
+# `git checkout <branch>` regardless of which branch the main repo is on.
+#
+# We copy from .githooks/ (tracked) into .git/hooks/ (untracked, local-only).
+# Why not core.hooksPath=.githooks? Because git resolves that relative path
+# against the main repo's working tree, which may be on a branch that doesn't
+# contain .githooks/ — in which case the hook is silently invisible to every
+# worktree. Installing into .git/hooks/ (the default path git always checks)
+# avoids that trap. .git/hooks/ is shared across all worktrees, so one install
+# covers every future worktree of this clone.
+GIT_DIR="$(git rev-parse --git-common-dir)"
+if [ -d .githooks ]; then
+    for hook in .githooks/*; do
+        [ -f "$hook" ] || continue
+        name="$(basename "$hook")"
+        cp "$hook" "$GIT_DIR/hooks/$name"
+        chmod +x "$GIT_DIR/hooks/$name"
+    done
+fi
+# Clear any stale core.hooksPath from earlier setup-dev runs that used it.
+git config --unset core.hooksPath 2>/dev/null || true
 
 # Verify this checkout is healthy (plugin/ populated, test_project symlink OK).
 # Auto-heals the Windows text-file symlink fallback when possible.

--- a/script/setup-dev.ps1
+++ b/script/setup-dev.ps1
@@ -63,11 +63,29 @@ if (-not $devModeOn) {
 if ($LASTEXITCODE -ne 0) { throw "git config core.symlinks true failed" }
 Write-Host "[ok] git config core.symlinks=true (local)."
 
-# --- 2b. Shared hooks: post-checkout auto-verifies worktrees --------------
-# Git worktrees share .git/config with the main repo, so setting once covers all.
-& git config core.hooksPath .githooks
-if ($LASTEXITCODE -ne 0) { throw "git config core.hooksPath .githooks failed" }
-Write-Host "[ok] git config core.hooksPath=.githooks (post-checkout now auto-runs verify-worktree)."
+# --- 2b. Install git hooks to .git/hooks/ ---------------------------------
+# Copy .githooks/* (tracked) into .git/hooks/ (untracked, local-only) so
+# they fire on `git worktree add` and `git checkout <branch>` regardless
+# of which branch the main repo is currently on. .git/hooks/ is the path
+# git always checks, and it is shared across all worktrees of this clone.
+#
+# We don't use core.hooksPath=.githooks because git resolves that relative
+# path against the main repo's working tree — if main is on a branch that
+# doesn't contain .githooks/, the hook is silently invisible.
+$gitCommonDir = (& git rev-parse --git-common-dir).Trim()
+if ($LASTEXITCODE -ne 0) { throw "git rev-parse --git-common-dir failed" }
+if (Test-Path -LiteralPath '.githooks') {
+    $hooksTargetDir = Join-Path $gitCommonDir 'hooks'
+    Get-ChildItem -LiteralPath '.githooks' -File | ForEach-Object {
+        Copy-Item -LiteralPath $_.FullName -Destination (Join-Path $hooksTargetDir $_.Name) -Force
+    }
+    Write-Host "[ok] Installed .githooks/* into $hooksTargetDir"
+}
+# Clear any stale core.hooksPath from earlier setup-dev runs that used it.
+& git config --unset core.hooksPath 2>$null
+if ($LASTEXITCODE -eq 0) {
+    Write-Host "[ok] Cleared stale core.hooksPath config."
+}
 
 # --- 3. Re-materialize the plugin symlink ---------------------------------
 $symlinkPath = Join-Path $repoRoot 'test_project\addons\godot_ai'


### PR DESCRIPTION
## Summary

Followup to #180. The `core.hooksPath=.githooks` approach from that PR had a silent failure mode that I discovered while smoke-testing: if main's working tree is on a branch that doesn't contain `.githooks/`, git resolves the relative hook path against a directory that doesn't exist and no worktree fires the hook. Symptom: a naive agent in a fresh Claude Code worktree sees `test_project/addons/godot_ai` still checked out as a 28-byte text file because auto-heal never ran.

## What changed

- `script/setup-dev` and `setup-dev.ps1` now copy `.githooks/*` into `\$(git rev-parse --git-common-dir)/hooks/` — git's default hook path, which is shared across all worktrees of a clone.
- Both scripts unset the stale `core.hooksPath` config from the previous PR if present.
- `CLAUDE.md` — updated worktree-health section; explicitly documents the `core.hooksPath`-vs-`.git/hooks/` footgun so future contributors don't repeat it.
- `docs/CONTRIBUTING.md` — one-paragraph note that setup-dev installs the hook (contributor-facing; main README unchanged).

## Trade-off

`.git/hooks/` isn't tracked in git (intentional — prevents `git clone` from auto-executing code). So the hook has to be installed via setup-dev once per clone. After that, every future worktree fires it automatically via shared `\$GIT_COMMON_DIR`. CI runners that clone fresh each run won't have the hook unless setup-dev runs there too — but CI doesn't create worktrees, so that's a non-issue.

## Verified

- Installed `.git/hooks/post-checkout` manually on my machine. Deleted the symlink in this worktree, ran `git checkout <branch>`, watched the hook fire and auto-heal via `mklink /J`.
- `setup-dev` dry-run: `git rev-parse --git-common-dir` correctly returns `main-repo/.git` even from inside a worktree.

## Test plan

- [x] Smoke: delete `test_project/addons/godot_ai`, `git checkout <branch>`, confirm hook heals.
- [x] Verify `setup-dev` resolves `git-common-dir` correctly from a worktree (so re-running from a worktree still installs into main's `.git/hooks/`).
- [ ] Fresh clone + `script/setup-dev` on macOS/Linux — confirm hook install succeeds and `git worktree add` fires it.
- [ ] Fresh clone + `script/setup-dev.ps1` on Windows — same check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)