### PR TITLE
fix(clients): bridge Claude Desktop & Zed via uvx mcp-proxy (drop npx dep)

### DIFF
--- a/plugin/addons/godot_ai/clients/_base.gd
+++ b/plugin/addons/godot_ai/clients/_base.gd
@@ -85,3 +85,33 @@ static func _array_from_packed(packed: PackedStringArray) -> Array[String]:
 	for s in packed:
 		out.append(s)
 	return out
+
+
+# ----- stdio→http bridge helpers (Claude Desktop, Zed) --------------------
+
+## Pinned mcp-proxy release used by every stdio-only client's bridge. uvx's
+## cache key is version-specific, so pinning guarantees all users run the
+## same vetted bridge — a malicious or broken future release on PyPI can't
+## silently break everyone's Configure flow. Bump deliberately when the
+## upstream publishes something we want.
+const MCP_PROXY_VERSION := "0.11.0"
+
+
+## Resolve `uvx` to an absolute path. GUI-launched apps (Claude Desktop,
+## Zed) often run with a minimal PATH that excludes ~/.local/bin on macOS /
+## Linux, so a bare "uvx" string in the config would fail at spawn time
+## with the same "Server disconnected" symptom we're trying to cure. The
+## shared three-tier McpCliFinder covers the well-known install dirs;
+## returns bare "uvx" as a last-resort fallback so the entry is still
+## well-formed even if the lookup failed.
+static func resolve_uvx_path() -> String:
+	var names: Array[String] = []
+	names.append("uvx.exe" if OS.get_name() == "Windows" else "uvx")
+	var resolved := McpCliFinder.find(names)
+	return resolved if not resolved.is_empty() else "uvx"
+
+
+## Build the `mcp-proxy` bridge argv (without the leading uvx command).
+## Callers splice this into the client-specific command shape.
+static func mcp_proxy_bridge_args(url: String) -> Array:
+	return ["mcp-proxy==" + MCP_PROXY_VERSION, "--transport", "streamablehttp", url]

--- a/plugin/addons/godot_ai/clients/claude_desktop.gd
+++ b/plugin/addons/godot_ai/clients/claude_desktop.gd
@@ -2,7 +2,8 @@
 extends McpClient
 
 ## Claude Desktop's mcpServers entries are stdio-only, so we bridge our HTTP
-## server through `npx mcp-remote <url>`.
+## server through `uvx mcp-proxy --transport streamablehttp <url>`. `uvx` is
+## already a plugin prereq, so this works without requiring Node.js.
 
 
 func _init() -> void:
@@ -17,13 +18,13 @@ func _init() -> void:
 	}
 	server_key_path = PackedStringArray(["mcpServers"])
 	entry_builder = func(_name: String, url: String) -> Dictionary:
-		return {"command": "npx", "args": ["-y", "mcp-remote", url]}
+		return {"command": "uvx", "args": ["mcp-proxy", "--transport", "streamablehttp", url]}
 	verify_entry = func(entry: Dictionary, url: String) -> bool:
 		# Accept both the bridge form we write and a future url-style entry.
 		if entry.get("url", "") == url:
 			return true
 		var args = entry.get("args", [])
-		return entry.get("command", "") == "npx" and args is Array and args.has(url)
+		return entry.get("command", "") == "uvx" and args is Array and args.has(url)
 	detect_paths = PackedStringArray(path_template.values())
 	manual_command_builder = func(name: String, url: String, path: String) -> String:
-		return "Edit %s and add under \"mcpServers\":\n  \"%s\": { \"command\": \"npx\", \"args\": [\"-y\", \"mcp-remote\", \"%s\"] }" % [path, name, url]
+		return "Edit %s and add under \"mcpServers\":\n  \"%s\": { \"command\": \"uvx\", \"args\": [\"mcp-proxy\", \"--transport\", \"streamablehttp\", \"%s\"] }" % [path, name, url]

--- a/plugin/addons/godot_ai/clients/claude_desktop.gd
+++ b/plugin/addons/godot_ai/clients/claude_desktop.gd
@@ -18,13 +18,17 @@ func _init() -> void:
 	}
 	server_key_path = PackedStringArray(["mcpServers"])
 	entry_builder = func(_name: String, url: String) -> Dictionary:
-		return {"command": "uvx", "args": ["mcp-proxy", "--transport", "streamablehttp", url]}
+		return {"command": McpClient.resolve_uvx_path(), "args": McpClient.mcp_proxy_bridge_args(url)}
 	verify_entry = func(entry: Dictionary, url: String) -> bool:
 		# Accept both the bridge form we write and a future url-style entry.
 		if entry.get("url", "") == url:
 			return true
+		var cmd: String = entry.get("command", "")
+		var uvx_like := cmd.get_file() == "uvx" or cmd.get_file() == "uvx.exe"
 		var args = entry.get("args", [])
-		return entry.get("command", "") == "uvx" and args is Array and args.has(url)
+		return uvx_like and args is Array and args.has(url)
 	detect_paths = PackedStringArray(path_template.values())
 	manual_command_builder = func(name: String, url: String, path: String) -> String:
-		return "Edit %s and add under \"mcpServers\":\n  \"%s\": { \"command\": \"uvx\", \"args\": [\"mcp-proxy\", \"--transport\", \"streamablehttp\", \"%s\"] }" % [path, name, url]
+		var uvx := McpClient.resolve_uvx_path()
+		var proxy_arg := "mcp-proxy==" + McpClient.MCP_PROXY_VERSION
+		return "Edit %s and add under \"mcpServers\":\n  \"%s\": { \"command\": \"%s\", \"args\": [\"%s\", \"--transport\", \"streamablehttp\", \"%s\"] }" % [path, name, uvx, proxy_arg, url]

--- a/plugin/addons/godot_ai/clients/zed.gd
+++ b/plugin/addons/godot_ai/clients/zed.gd
@@ -2,7 +2,8 @@
 extends McpClient
 
 ## Zed registers MCP servers under `context_servers.<name>` and only speaks
-## stdio, so we bridge through `npx mcp-remote <url>` like Claude Desktop.
+## stdio, so we bridge through `uvx mcp-proxy --transport streamablehttp <url>`
+## like Claude Desktop. `uvx` is already a plugin prereq.
 
 
 func _init() -> void:
@@ -18,7 +19,7 @@ func _init() -> void:
 	server_key_path = PackedStringArray(["context_servers"])
 	entry_builder = func(_name: String, url: String) -> Dictionary:
 		return {
-			"command": {"path": "npx", "args": ["-y", "mcp-remote", url]},
+			"command": {"path": "uvx", "args": ["mcp-proxy", "--transport", "streamablehttp", url]},
 			"settings": {},
 		}
 	verify_entry = func(entry: Dictionary, url: String) -> bool:
@@ -29,4 +30,4 @@ func _init() -> void:
 		return args is Array and args.has(url)
 	detect_paths = PackedStringArray(path_template.values())
 	manual_command_builder = func(name: String, url: String, path: String) -> String:
-		return "Edit %s and add under \"context_servers\":\n  \"%s\": { \"command\": { \"path\": \"npx\", \"args\": [\"-y\", \"mcp-remote\", \"%s\"] }, \"settings\": {} }" % [path, name, url]
+		return "Edit %s and add under \"context_servers\":\n  \"%s\": { \"command\": { \"path\": \"uvx\", \"args\": [\"mcp-proxy\", \"--transport\", \"streamablehttp\", \"%s\"] }, \"settings\": {} }" % [path, name, url]

--- a/plugin/addons/godot_ai/clients/zed.gd
+++ b/plugin/addons/godot_ai/clients/zed.gd
@@ -19,7 +19,7 @@ func _init() -> void:
 	server_key_path = PackedStringArray(["context_servers"])
 	entry_builder = func(_name: String, url: String) -> Dictionary:
 		return {
-			"command": {"path": "uvx", "args": ["mcp-proxy", "--transport", "streamablehttp", url]},
+			"command": {"path": McpClient.resolve_uvx_path(), "args": McpClient.mcp_proxy_bridge_args(url)},
 			"settings": {},
 		}
 	verify_entry = func(entry: Dictionary, url: String) -> bool:
@@ -30,4 +30,6 @@ func _init() -> void:
 		return args is Array and args.has(url)
 	detect_paths = PackedStringArray(path_template.values())
 	manual_command_builder = func(name: String, url: String, path: String) -> String:
-		return "Edit %s and add under \"context_servers\":\n  \"%s\": { \"command\": { \"path\": \"uvx\", \"args\": [\"mcp-proxy\", \"--transport\", \"streamablehttp\", \"%s\"] }, \"settings\": {} }" % [path, name, url]
+		var uvx := McpClient.resolve_uvx_path()
+		var proxy_arg := "mcp-proxy==" + McpClient.MCP_PROXY_VERSION
+		return "Edit %s and add under \"context_servers\":\n  \"%s\": { \"command\": { \"path\": \"%s\", \"args\": [\"%s\", \"--transport\", \"streamablehttp\", \"%s\"] }, \"settings\": {} }" % [path, name, uvx, proxy_arg, url]

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -920,12 +920,7 @@ func test_claude_desktop_bridges_via_uvx() -> void:
 	var c := McpClientRegistry.get_by_id("claude_desktop")
 	var entry: Dictionary = c.entry_builder.call("godot-ai", "http://x")
 	assert_eq(entry.get("command", ""), "uvx")
-	var args = entry.get("args", [])
-	assert_true(args is Array)
-	assert_contains(args, "mcp-proxy")
-	assert_contains(args, "--transport")
-	assert_contains(args, "streamablehttp")
-	assert_contains(args, "http://x")
+	_assert_mcp_proxy_bridge_args(entry.get("args", []), "http://x")
 
 
 func test_claude_desktop_verify_entry_accepts_uvx_form() -> void:
@@ -943,12 +938,7 @@ func test_zed_bridges_via_uvx() -> void:
 	var cmd = entry.get("command", {})
 	assert_true(cmd is Dictionary, "Zed entry.command must be a Dictionary (path+args shape)")
 	assert_eq(cmd.get("path", ""), "uvx")
-	var args = cmd.get("args", [])
-	assert_true(args is Array)
-	assert_contains(args, "mcp-proxy")
-	assert_contains(args, "--transport")
-	assert_contains(args, "streamablehttp")
-	assert_contains(args, "http://x")
+	_assert_mcp_proxy_bridge_args(cmd.get("args", []), "http://x")
 
 
 func test_vscode_uses_servers_key_with_type_http() -> void:
@@ -984,6 +974,17 @@ func test_opencode_client_uses_home_config_on_windows() -> void:
 
 
 # ----- helpers -----
+
+func _assert_mcp_proxy_bridge_args(args: Variant, expected_url: String) -> void:
+	## Shared shape check for any client that bridges stdio → streamable-http
+	## via `uvx mcp-proxy`. Keeps Claude Desktop / Zed / any future stdio-only
+	## client tests in lock-step with the bridge command shape.
+	assert_true(args is Array, "bridge args must be an Array, got: %s" % args)
+	assert_contains(args, "mcp-proxy")
+	assert_contains(args, "--transport")
+	assert_contains(args, "streamablehttp")
+	assert_contains(args, expected_url)
+
 
 func _make_test_json_client(path: String) -> McpClient:
 	var c := McpClient.new()

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -916,12 +916,38 @@ func test_gemini_cli_entry_uses_httpUrl() -> void:
 	assert_eq(entry.get("httpUrl", ""), "http://x")
 
 
-func test_claude_desktop_bridges_via_npx() -> void:
+func test_claude_desktop_bridges_via_uvx() -> void:
 	var c := McpClientRegistry.get_by_id("claude_desktop")
 	var entry: Dictionary = c.entry_builder.call("godot-ai", "http://x")
-	assert_eq(entry.get("command", ""), "npx")
+	assert_eq(entry.get("command", ""), "uvx")
 	var args = entry.get("args", [])
 	assert_true(args is Array)
+	assert_contains(args, "mcp-proxy")
+	assert_contains(args, "--transport")
+	assert_contains(args, "streamablehttp")
+	assert_contains(args, "http://x")
+
+
+func test_claude_desktop_verify_entry_accepts_uvx_form() -> void:
+	## Drift-detection: once we've written the new uvx entry, check_status
+	## must round-trip it as CONFIGURED (not MISMATCH). Guards against a
+	## verify_entry that still only recognises the old npx/mcp-remote shape.
+	var c := McpClientRegistry.get_by_id("claude_desktop")
+	var entry: Dictionary = c.entry_builder.call("godot-ai", "http://x")
+	assert_true(c.verify_entry.call(entry, "http://x"), "uvx entry should verify as a match")
+
+
+func test_zed_bridges_via_uvx() -> void:
+	var c := McpClientRegistry.get_by_id("zed")
+	var entry: Dictionary = c.entry_builder.call("godot-ai", "http://x")
+	var cmd = entry.get("command", {})
+	assert_true(cmd is Dictionary, "Zed entry.command must be a Dictionary (path+args shape)")
+	assert_eq(cmd.get("path", ""), "uvx")
+	var args = cmd.get("args", [])
+	assert_true(args is Array)
+	assert_contains(args, "mcp-proxy")
+	assert_contains(args, "--transport")
+	assert_contains(args, "streamablehttp")
 	assert_contains(args, "http://x")
 
 

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -919,7 +919,7 @@ func test_gemini_cli_entry_uses_httpUrl() -> void:
 func test_claude_desktop_bridges_via_uvx() -> void:
 	var c := McpClientRegistry.get_by_id("claude_desktop")
 	var entry: Dictionary = c.entry_builder.call("godot-ai", "http://x")
-	assert_eq(entry.get("command", ""), "uvx")
+	_assert_uvx_command(entry.get("command", ""))
 	_assert_mcp_proxy_bridge_args(entry.get("args", []), "http://x")
 
 
@@ -937,8 +937,34 @@ func test_zed_bridges_via_uvx() -> void:
 	var entry: Dictionary = c.entry_builder.call("godot-ai", "http://x")
 	var cmd = entry.get("command", {})
 	assert_true(cmd is Dictionary, "Zed entry.command must be a Dictionary (path+args shape)")
-	assert_eq(cmd.get("path", ""), "uvx")
+	_assert_uvx_command(cmd.get("path", ""))
 	_assert_mcp_proxy_bridge_args(cmd.get("args", []), "http://x")
+
+
+func test_zed_verify_entry_accepts_uvx_form() -> void:
+	## Parity with claude_desktop drift-detection test — if Zed's entry_builder
+	## changes but verify_entry isn't updated in lock-step, this catches it.
+	var c := McpClientRegistry.get_by_id("zed")
+	var entry: Dictionary = c.entry_builder.call("godot-ai", "http://x")
+	assert_true(c.verify_entry.call(entry, "http://x"), "uvx entry should verify as a match")
+
+
+func test_mcp_proxy_bridge_args_pins_version() -> void:
+	## Security: mcp-proxy is pulled from PyPI at first-connect. Pinning the
+	## version protects every user from a malicious or broken future release.
+	## If MCP_PROXY_VERSION ever changes, the pinned arg must change with it.
+	var args := McpClient.mcp_proxy_bridge_args("http://x")
+	assert_eq(args[0], "mcp-proxy==" + McpClient.MCP_PROXY_VERSION)
+
+
+func test_resolve_uvx_path_returns_nonempty() -> void:
+	## Fallback contract: even if McpCliFinder comes up empty (CI with no
+	## uvx installed), we must still emit a well-formed command string so
+	## the config file is valid. The bare "uvx" fallback is fine — the user
+	## will get the same spawn failure they would have had anyway.
+	var resolved := McpClient.resolve_uvx_path()
+	assert_false(resolved.is_empty())
+	assert_true(resolved.get_file() == "uvx" or resolved.get_file() == "uvx.exe", "resolved path must end in uvx or uvx.exe, got: %s" % resolved)
 
 
 func test_vscode_uses_servers_key_with_type_http() -> void:
@@ -975,12 +1001,28 @@ func test_opencode_client_uses_home_config_on_windows() -> void:
 
 # ----- helpers -----
 
+func _assert_uvx_command(cmd: Variant) -> void:
+	## The bridge command may be a bare "uvx"/"uvx.exe" (CI fallback) or an
+	## absolute path resolved by McpCliFinder. Either is fine — just assert
+	## the basename matches uvx.
+	assert_true(cmd is String, "command must be a String, got: %s" % cmd)
+	var cmd_str: String = cmd
+	var basename := cmd_str.get_file()
+	assert_true(basename == "uvx" or basename == "uvx.exe", "command must resolve to uvx/uvx.exe, got: %s" % cmd_str)
+
+
 func _assert_mcp_proxy_bridge_args(args: Variant, expected_url: String) -> void:
 	## Shared shape check for any client that bridges stdio → streamable-http
-	## via `uvx mcp-proxy`. Keeps Claude Desktop / Zed / any future stdio-only
-	## client tests in lock-step with the bridge command shape.
+	## via `uvx mcp-proxy`. The first arg is a pinned version spec like
+	## `mcp-proxy==0.11.0` — match by prefix so this doesn't have to churn
+	## every time MCP_PROXY_VERSION bumps.
 	assert_true(args is Array, "bridge args must be an Array, got: %s" % args)
-	assert_contains(args, "mcp-proxy")
+	var has_mcp_proxy := false
+	for a in args:
+		if a is String and (a as String).begins_with("mcp-proxy"):
+			has_mcp_proxy = true
+			break
+	assert_true(has_mcp_proxy, "args must include an mcp-proxy entry, got: %s" % args)
 	assert_contains(args, "--transport")
 	assert_contains(args, "streamablehttp")
 	assert_contains(args, expected_url)


### PR DESCRIPTION
## Summary

- Users without Node.js installed got `Server disconnected` in Claude Desktop after auto-configure — the generated config used `npx -y mcp-remote <url>` and `npx` wasn't on their PATH (originally reported in Slack by a non-technical user).
- Swap the bridge command to `uvx mcp-proxy --transport streamablehttp <url>`. `uvx` is already a hard prereq for the plugin (it launches the server itself for non-dev users), so no new user-facing dependency. [`mcp-proxy`](https://pypi.org/project/mcp-proxy/) is the Python equivalent of `mcp-remote` and is pip-installable, so uvx handles the ephemeral env.
- Same swap applied to Zed, which used the same bridge pattern.

## Test plan

- [x] Python unit + integration tests: `pytest -v` → 563 passed
- [x] Ruff lint: `ruff check src/ tests/` → clean
- [x] GDScript clients suite: `test_run suite=clients` → 55/55 (added 2 new tests: Zed bridge shape + Claude Desktop `verify_entry` round-trip)
- [x] Live smoke on Windows: `client_configure` → `claude_desktop_config.json` got the new `uvx mcp-proxy` entry; Claude Desktop restart showed godot-ai `running`; MCP log shows clean streamable-http negotiation (`HTTP/1.1 200 OK` on initialize / tools-list / resources-list / prompts-list)

## UX note worth following up separately

First-time `uvx mcp-proxy` install takes ~14s to fetch its 33 transitive deps. Claude Desktop shows "connecting..." with no progress feedback during that window — briefly confusing but recoverable (subsequent launches hit the uvx cache). Worth surfacing a one-line hint in the Godot dock next to the Claude Desktop Configure button, but not a blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)