### PR TITLE
build: stop tracking test_project/addons/godot_ai as a git symlink (#185)

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -8,6 +8,11 @@
 #
 # We only run on branch-level checkouts. File-level checkouts (e.g.
 # `git checkout -- some_file`) shouldn't re-verify the whole worktree.
+#
+# The hook's job: make sure test_project/addons/godot_ai exists and points
+# into this worktree's plugin/. Since the link is no longer tracked in git
+# (see #185 / .gitignore), git never creates or updates it on checkout —
+# this hook is how freshly-added worktrees get their link.
 
 set -e
 
@@ -26,7 +31,7 @@ fi
 
 # Don't block checkout on verification failure — just warn loudly.
 # A failing verify halting `git worktree add` would be more disruptive
-# than helpful. The auto-heal path catches the common Windows case.
+# than helpful.
 "$repo_top/script/verify-worktree" || {
     echo ""
     echo "[post-checkout] Worktree verification reported problems."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Build plugin symlink
+        run: bash script/verify-worktree
+
       - uses: chickensoft-games/setup-godot@v2
         with:
           version: 4.6.2
@@ -166,6 +169,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Build plugin symlink
+        run: bash script/verify-worktree
+
       - uses: chickensoft-games/setup-godot@v2
         with:
           version: 4.6.2
@@ -204,6 +210,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Build plugin symlink
+        run: bash script/verify-worktree
+
       - uses: chickensoft-games/setup-godot@v2
         with:
           version: 4.6.2
@@ -235,6 +244,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
+
+      - name: Build plugin junction
+        shell: bash
+        run: bash script/verify-worktree
 
       - uses: chickensoft-games/setup-godot@v2
         with:
@@ -273,6 +286,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Build plugin symlink
+        run: bash script/verify-worktree
+
       - uses: chickensoft-games/setup-godot@v2
         with:
           version: 4.6.2
@@ -309,6 +325,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+
+      - name: Build plugin junction
+        shell: bash
+        run: bash script/verify-worktree
 
       - uses: chickensoft-games/setup-godot@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,13 @@ Thumbs.db
 *.exe
 *.AppImage
 
+# Plugin symlink/junction into test_project/ — built locally by
+# script/setup-dev (bash) or script/setup-dev.ps1 (Windows). Not tracked
+# because a committed symlink checks out as a plain text file on Windows
+# without Developer Mode and fights multi-step git ops (rebase,
+# cherry-pick) on every platform. See #185.
+test_project/addons/godot_ai
+
 # Local demo scene (not tracked in repo)
 test_project/tests/space_city.tscn
 test_project/tests/space_city_assets/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ AI Client → MCP (stdio/sse/streamable-http) → Python FastMCP server → WebS
 
 ## Key conventions
 
-- **GDScript plugin is the canonical copy** in `plugin/`. `test_project/addons/godot_ai` is a symlink — no copy needed.
+- **GDScript plugin is the canonical copy** in `plugin/`. `test_project/addons/godot_ai` is a locally-built symlink (or Windows junction) into `plugin/addons/godot_ai` — not tracked in git, created by `script/setup-dev` / `script/verify-worktree`.
 - **Error codes**: Defined in `protocol/errors.py` (Python) and `utils/error_codes.gd` (GDScript). Keep in sync. Use Godot's built-in `error_string(err)` to translate numeric error codes in error messages — do not write a custom lookup table.
 - **Tools return `dict`**: Handlers call `runtime.send_command(command, params)` which returns a dict or raises. Tools create a `DirectRuntime` and delegate to handlers.
 - **Plugin runs on main thread**: All GDScript executes in `_process()` with a 4ms frame budget. Never block. Use `call_deferred` for scene tree mutations.
@@ -42,18 +42,20 @@ Claude Code sessions often run in git worktrees (`.claude/worktrees/<name>/`). B
 
 ### Worktree health: `script/verify-worktree` + `post-checkout` hook
 
+`test_project/addons/godot_ai` is **not tracked in git** (see `.gitignore` and #185). Every working copy builds the link locally — as a symlink on Unix, as a directory junction on Windows. This avoids the Windows-without-Dev-Mode text-file-fallback trap and stops `git rebase` / `cherry-pick` from fighting the link on every checkout.
+
 Before editing *anything* in `plugin/` in a worktree, the worktree must pass two invariants:
 
 1. `plugin/addons/godot_ai/plugin.gd` exists (the worktree's `plugin/` is populated, not empty or sparse).
-2. `test_project/addons/godot_ai` is a real symlink (or Windows directory junction) into **this worktree's** `plugin/addons/godot_ai` — not a plain text file, not a stale copy, not pointing into main.
+2. `test_project/addons/godot_ai` is a real symlink (or Windows directory junction) into **this worktree's** `plugin/addons/godot_ai`.
 
-`script/verify-worktree` (bash, works in git-bash on Windows) checks both and auto-heals the symlink via `mklink /J` when possible. It runs automatically via a `post-checkout` hook on every `git worktree add` and `git checkout <branch>`, so a freshly-created worktree is healthy by the time you start editing.
+`script/verify-worktree` (bash, works in git-bash on Windows) checks both. If the link is missing or broken it creates/repairs it via `ln -s` or `mklink /J` — no admin rights, no Windows Developer Mode required. It runs automatically via a `post-checkout` hook on every `git worktree add` and `git checkout <branch>`, so a freshly-created worktree is healthy by the time you start editing.
 
 Wiring: `script/setup-dev` and `setup-dev.ps1` copy `.githooks/post-checkout` into `.git/hooks/post-checkout` (the default path git always looks at). `.git/hooks/` is shared across all worktrees of a clone, so one install covers every future worktree forever. A fresh clone on a new machine needs setup-dev run once before the hook is active — after that, it's automatic. (We don't use `core.hooksPath=.githooks` because git resolves that relative path against main's working tree, which may be on a branch without `.githooks/` — a trap that wasted a whole debugging cycle.)
 
-**If you find a broken worktree** (empty `plugin/`, or `test_project/addons/godot_ai` is a text file): do NOT `git add` anything. Run `script/verify-worktree` to heal, or re-create the worktree. Committing plugin/ edits from a broken worktree stages phantom deletions that overwrite the canonical plugin code in main on push. This has happened 4+ times — the hook now prevents it.
+**If you find a broken worktree** (empty `plugin/`, or the link missing/stale): do NOT `git add` anything. Run `script/verify-worktree` to heal, or re-create the worktree. Committing plugin/ edits from a broken worktree stages phantom deletions that overwrite the canonical plugin code in main on push.
 
-**Parallel plugin development IS supported** — each worktree has its own `plugin/` (standard git worktree semantics) and its own symlinked `test_project/addons/godot_ai`. Multiple Godot editors, one per worktree, all connect to the same MCP server on :8000; use `session_activate` (or `session_id` per call) to route. The ban is only on editing in *broken* worktrees.
+**Parallel plugin development IS supported** — each worktree has its own `plugin/` (standard git worktree semantics) and its own locally-built `test_project/addons/godot_ai` link. Multiple Godot editors, one per worktree, all connect to the same MCP server on :8000; use `session_activate` (or `session_id` per call) to route. The ban is only on editing in *broken* worktrees.
 
 ### Godot editor + worktree safety
 
@@ -104,11 +106,11 @@ ruff format src/ tests/      # format
 
 **macOS + Python 3.13 note**: Files inside `.venv` inherit the macOS hidden flag (dot-prefix directory). Python 3.13 skips hidden `.pth` files (CPython gh-113659), breaking editable installs. `script/setup-dev` generates a `sitecustomize.py` in the venv that adds `src/` to `sys.path` via normal import (unaffected by hidden flags). No manual `chflags` needed.
 
-**Windows note**: use `.\script\setup-dev.ps1` instead of `script/setup-dev`. The Windows script also re-hydrates the `test_project/addons/godot_ai` symlink, which on Windows requires `git config core.symlinks true` (the script sets it) plus Windows Developer Mode (Settings → Privacy & security → For developers). Without Developer Mode, git checks the file out as a plain text file containing the symlink target string instead of a real symlink, and Godot fails to load the plugin with errors like `Failed loading resource: res://addons/godot_ai/runtime/game_helper.gd` and a cascade of `Could not find base class "McpTestSuite"` parse errors in `test_project/tests/`. **Fallback when Developer Mode is unavailable** (e.g. transient sessions, restricted machines): create a directory junction by hand — junctions don't need admin or Developer Mode:
+**Windows note**: use `.\script\setup-dev.ps1` instead of `script/setup-dev`. The Windows script creates `test_project\addons\godot_ai` as a directory junction — no admin rights and no Windows Developer Mode required. If you ever need to recreate the link by hand (e.g. outside setup-dev), either form works:
 
 ```powershell
 # from repo root or worktree root
-Remove-Item -LiteralPath test_project\addons\godot_ai -Force
+Remove-Item -LiteralPath test_project\addons\godot_ai -Force -ErrorAction SilentlyContinue
 New-Item -ItemType Junction -Path test_project\addons\godot_ai -Target ..\..\plugin\addons\godot_ai
 ```
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The plugin starts or reuses the Python server, connects over WebSocket, and expo
 
 See [CONTRIBUTING.md](docs/CONTRIBUTING.md) for development setup, testing, and PR guidelines.
 
-**Windows contributors:** run `.\script\setup-dev.ps1` in PowerShell. It requires Windows Developer Mode to be enabled — without it, the committed `test_project/addons/godot_ai` symlink checks out as a text file and the plugin fails to load. The script will prompt you with a link to the Settings page if Developer Mode is off.
+**Windows contributors:** run `.\script\setup-dev.ps1` in PowerShell. It builds `test_project\addons\godot_ai` as a directory junction — no admin rights and no Windows Developer Mode required.
 
 </details>
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -7,7 +7,7 @@
 ```bash
 git clone https://github.com/hi-godot/godot-ai.git
 cd godot-ai
-script/setup-dev             # creates .venv, installs deps, installs git hooks
+script/setup-dev             # creates .venv, installs deps, builds plugin symlink, installs git hooks
 source .venv/bin/activate
 ```
 
@@ -16,27 +16,21 @@ source .venv/bin/activate
 ```powershell
 git clone https://github.com/hi-godot/godot-ai.git
 cd godot-ai
-.\script\setup-dev.ps1       # creates .venv, installs deps, fixes symlink, installs git hooks
+.\script\setup-dev.ps1       # creates .venv, installs deps, builds plugin junction, installs git hooks
 .venv\Scripts\Activate.ps1
 ```
 
-> **One-time per clone:** `setup-dev` installs a `post-checkout` git hook
-> (from `.githooks/`) into `.git/hooks/`. The hook auto-verifies worktree
-> integrity on every `git worktree add` and `git checkout <branch>` —
-> specifically, that `plugin/` is populated and `test_project/addons/godot_ai`
-> is a real symlink/junction into this worktree's `plugin/`. It auto-heals
-> the Windows text-file-fallback symlink via `mklink /J`. You only need to
-> run `setup-dev` once per clone; the hook fires in every worktree of that
-> clone from then on.
+> **Plugin link is built locally, not tracked in git.** `test_project/addons/godot_ai`
+> is a symlink (Unix) or directory junction (Windows) into `plugin/addons/godot_ai`,
+> created fresh by `setup-dev`. A clone without running `setup-dev` has no link and
+> Godot won't find the plugin. The Windows flavor uses `mklink /J`, which works
+> without admin rights and without Windows Developer Mode.
 
-> **Windows contributors:** `setup-dev.ps1` requires **Windows Developer Mode**
-> to be enabled — if it isn't, the script prompts you with a link to the Settings
-> page (`ms-settings:developers`). Without Developer Mode + `core.symlinks=true`,
-> the committed symlink at `test_project/addons/godot_ai` checks out as a plain
-> text file, and the plugin fails to load with *"Attempt to open script
-> 'res://addons/godot_ai/runtime/game_helper.gd' resulted in error 'File not
-> found'"*. Every branch switch can re-break the symlink until `core.symlinks`
-> is set in the repo — which `setup-dev.ps1` handles for you.
+> **One-time per clone:** `setup-dev` installs a `post-checkout` git hook
+> (from `.githooks/`) into `.git/hooks/`. The hook auto-builds the plugin
+> link on every `git worktree add` and `git checkout <branch>`, so every
+> future worktree of this clone gets a working link automatically. You only
+> need to run `setup-dev` once per clone.
 
 ## Testing
 

--- a/script/setup-dev
+++ b/script/setup-dev
@@ -25,8 +25,10 @@ fi
 # Clear any stale core.hooksPath from earlier setup-dev runs that used it.
 git config --unset core.hooksPath 2>/dev/null || true
 
-# Verify this checkout is healthy (plugin/ populated, test_project symlink OK).
-# Auto-heals the Windows text-file symlink fallback when possible.
+# Build (or repair) the test_project/addons/godot_ai -> plugin/addons/godot_ai
+# link. The link is not tracked in git (see #185 / .gitignore); this script
+# creates it on fresh clones and every `git worktree add` does the same via
+# the post-checkout hook.
 ./script/verify-worktree || true
 
 if [ ! -d .venv ]; then

--- a/script/setup-dev.ps1
+++ b/script/setup-dev.ps1
@@ -21,49 +21,7 @@ $repoRoot = Resolve-Path (Join-Path $PSScriptRoot '..')
 Set-Location $repoRoot
 Write-Host "Repo: $repoRoot"
 
-# --- 1. Windows Developer Mode check --------------------------------------
-$devModeKey = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock'
-$devModeOn = $false
-try {
-    $val = Get-ItemPropertyValue -Path $devModeKey -Name 'AllowDevelopmentWithoutDevLicense' -ErrorAction Stop
-    $devModeOn = ($val -eq 1)
-} catch {
-    $devModeOn = $false
-}
-
-if (-not $devModeOn) {
-    Write-Host ""
-    Write-Host "================================================================" -ForegroundColor Yellow
-    Write-Host " Windows Developer Mode is OFF" -ForegroundColor Yellow
-    Write-Host "================================================================" -ForegroundColor Yellow
-    Write-Host ""
-    Write-Host "Without Developer Mode, git cannot create symlinks and the"
-    Write-Host "test_project/addons/godot_ai symlink will check out as a plain"
-    Write-Host "text file. Godot will then fail to load the plugin."
-    Write-Host ""
-    Write-Host "To enable Developer Mode:"
-    Write-Host "  1. Open Settings -> Privacy & security -> For developers"
-    Write-Host "     (or run: start ms-settings:developers)"
-    Write-Host "  2. Toggle 'Developer Mode' on"
-    Write-Host "  3. Re-run this script"
-    Write-Host ""
-    Write-Host "Alternatively, run this script from an Administrator PowerShell."
-    Write-Host ""
-    $resp = Read-Host "Continue anyway? Symlink hydration will likely fail. [y/N]"
-    if ($resp -notmatch '^[Yy]') {
-        Write-Host "Aborted. Enable Developer Mode and try again." -ForegroundColor Yellow
-        exit 1
-    }
-} else {
-    Write-Host "[ok] Windows Developer Mode is enabled."
-}
-
-# --- 2. core.symlinks for this repo ---------------------------------------
-& git config core.symlinks true
-if ($LASTEXITCODE -ne 0) { throw "git config core.symlinks true failed" }
-Write-Host "[ok] git config core.symlinks=true (local)."
-
-# --- 2b. Install git hooks to .git/hooks/ ---------------------------------
+# --- 1. Install git hooks to .git/hooks/ ----------------------------------
 # Copy .githooks/* (tracked) into .git/hooks/ (untracked, local-only) so
 # they fire on `git worktree add` and `git checkout <branch>` regardless
 # of which branch the main repo is currently on. .git/hooks/ is the path
@@ -87,27 +45,46 @@ if ($LASTEXITCODE -eq 0) {
     Write-Host "[ok] Cleared stale core.hooksPath config."
 }
 
-# --- 3. Re-materialize the plugin symlink ---------------------------------
-$symlinkPath = Join-Path $repoRoot 'test_project\addons\godot_ai'
-if (Test-Path -LiteralPath $symlinkPath) {
-    Remove-Item -LiteralPath $symlinkPath -Force -Recurse -ErrorAction SilentlyContinue
+# --- 2. Build the test_project plugin junction ----------------------------
+# The link is not tracked in git (see #185 / .gitignore). A directory
+# junction works without admin rights or Windows Developer Mode — unlike
+# real symlinks — so any Windows contributor can run this without changing
+# system settings.
+$addonsDir = Join-Path $repoRoot 'test_project\addons'
+if (-not (Test-Path -LiteralPath $addonsDir)) {
+    New-Item -ItemType Directory -Path $addonsDir -Force | Out-Null
 }
-& git checkout HEAD -- 'test_project/addons/godot_ai'
-if ($LASTEXITCODE -ne 0) { throw "git checkout of test_project/addons/godot_ai failed" }
 
-$item = Get-Item -LiteralPath $symlinkPath -Force
-$isSymlink = ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0
-if ($isSymlink) {
-    Write-Host "[ok] test_project/addons/godot_ai is a symlink."
+$linkPath = Join-Path $addonsDir 'godot_ai'
+$targetPath = Join-Path $repoRoot 'plugin\addons\godot_ai'
+
+# If something already exists at the link path (stale junction, leftover
+# text file from an old clone, or a copy), remove it so we can build fresh.
+if (Test-Path -LiteralPath $linkPath) {
+    $existing = Get-Item -LiteralPath $linkPath -Force
+    $isReparse = ($existing.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0
+    if ($isReparse) {
+        # Use cmd /c rmdir so Windows treats the junction as a pointer and
+        # does NOT recurse into the target directory — avoids the Windows
+        # junction-deletion data-loss footgun that motivated #185.
+        & cmd /c rmdir (($linkPath) -replace '/', '\')
+    } else {
+        Remove-Item -LiteralPath $linkPath -Force -Recurse
+    }
+}
+
+& cmd /c mklink /J (($linkPath) -replace '/', '\') (($targetPath) -replace '/', '\') | Out-Null
+if ($LASTEXITCODE -ne 0) { throw "mklink /J failed for $linkPath -> $targetPath" }
+
+$item = Get-Item -LiteralPath $linkPath -Force
+$isSymlinkOrJunction = ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0
+if ($isSymlinkOrJunction -and (Test-Path -LiteralPath (Join-Path $linkPath 'plugin.gd'))) {
+    Write-Host "[ok] test_project\addons\godot_ai -> plugin\addons\godot_ai (junction)"
 } else {
-    Write-Host ""
-    Write-Host "[WARN] test_project/addons/godot_ai did NOT hydrate as a symlink." -ForegroundColor Yellow
-    Write-Host "       The plugin will not load in Godot until this is fixed."
-    Write-Host "       Most common cause: Windows Developer Mode is off."
-    Write-Host ""
+    throw "test_project\addons\godot_ai did not materialize as a working junction."
 }
 
-# --- 4. Python venv via uv ------------------------------------------------
+# --- 3. Python venv via uv ------------------------------------------------
 $uv = Get-Command uv -ErrorAction SilentlyContinue
 if (-not $uv) {
     Write-Host ""

--- a/script/verify-worktree
+++ b/script/verify-worktree
@@ -1,21 +1,20 @@
 #!/usr/bin/env bash
-# Verify a worktree (or main checkout) is safe to edit plugin/ code in.
+# Verify a worktree (or main checkout) is safe to edit plugin/ code in, and
+# ensure test_project/addons/godot_ai points to this worktree's plugin/.
 #
 # Invariants enforced:
-#   1. plugin/addons/godot_ai/plugin.gd exists (plugin/ is populated, not
-#      empty or partially-tracked).
+#   1. plugin/addons/godot_ai/plugin.gd exists (plugin/ is populated).
 #   2. test_project/addons/godot_ai resolves to this worktree's
-#      plugin/addons/godot_ai via symlink or (on Windows) directory junction
-#      — NOT a plain text file, NOT a copy, NOT pointing elsewhere.
+#      plugin/addons/godot_ai via symlink or (on Windows) directory junction.
 #
-# On Windows without Developer Mode, git checks the symlink out as a plain
-# text file containing the target string. This script auto-heals by
-# recreating it as a directory junction (no admin / Developer Mode needed).
+# The link is NOT tracked in git (see .gitignore) — this script builds it
+# locally from scratch on fresh clones and `git worktree add`, and repairs
+# it if something mangled it. It's idempotent and safe to run anytime.
 #
 # Exit codes:
-#   0  everything OK (or auto-healed)
+#   0  link OK (already valid or just created/repaired)
 #   1  plugin/ missing or sparse — cannot auto-fix, abort
-#   2  symlink broken AND auto-heal failed
+#   2  link creation failed (permission / FS error)
 
 set -euo pipefail
 cd "$(dirname "$0")/.."
@@ -35,7 +34,7 @@ if [ ! -f plugin/addons/godot_ai/plugin.gd ]; then
     exit 1
 fi
 
-# --- Invariant 2: symlink points into this worktree's plugin/ ------------
+# --- Invariant 2: link points into this worktree's plugin/ ---------------
 link="test_project/addons/godot_ai"
 expected_target_abs="$repo_root/plugin/addons/godot_ai"
 
@@ -48,9 +47,8 @@ if [ -L "$link" ]; then
     fi
 elif [ -d "$link" ]; then
     # Could be a Windows junction. Compare contents via plugin.gd presence.
+    # On Windows, junctions appear as directories to bash.
     if [ -f "$link/plugin.gd" ]; then
-        # Heuristic: if the file inside matches our plugin.gd by inode/size, trust it.
-        # On Windows, junctions appear as directories to bash.
         link_ok=1
     fi
 fi
@@ -60,13 +58,11 @@ if [ "$link_ok" = "1" ]; then
     exit 0
 fi
 
-# Broken: text-file fallback, missing, or wrong target.
-yellow "[WARN] $link is not a valid symlink/junction into this worktree's plugin/."
+# Missing, broken, or pointing elsewhere — (re)create it.
+mkdir -p "$(dirname "$link")"
 
-# --- Auto-heal: try junction on Windows, symlink elsewhere ----------------
 case "${OS:-}${OSTYPE:-}" in
     *Windows_NT*|*msys*|*cygwin*)
-        yellow "       Attempting to repair via directory junction (Windows)..."
         # Remove whatever's there (text file, empty dir, broken link)
         rm -rf "$link" 2>/dev/null || true
         # cmd.exe mklink /J doesn't need admin or Developer Mode.
@@ -77,20 +73,19 @@ case "${OS:-}${OSTYPE:-}" in
         target_win="$(cygpath -w "$expected_target_abs" 2>/dev/null || echo "$expected_target_abs")"
         # MSYS_NO_PATHCONV=1 prevents git-bash from rewriting /J and /C as paths.
         if MSYS_NO_PATHCONV=1 cmd.exe /C mklink /J "$link_win" "$target_win" >/dev/null 2>&1; then
-            green "[ok] Recreated $link as a directory junction."
+            green "[ok] Created $link as a directory junction."
             exit 0
         else
             red "[FAIL] Could not create junction. Run manually from PowerShell:"
-            echo "       Remove-Item -LiteralPath test_project\\addons\\godot_ai -Force"
+            echo "       Remove-Item -LiteralPath test_project\\addons\\godot_ai -Force -ErrorAction SilentlyContinue"
             echo "       New-Item -ItemType Junction -Path test_project\\addons\\godot_ai -Target ..\\..\\plugin\\addons\\godot_ai"
             exit 2
         fi
         ;;
     *)
-        yellow "       Attempting to repair via symlink..."
         rm -rf "$link" 2>/dev/null || true
         if ln -s "../../plugin/addons/godot_ai" "$link"; then
-            green "[ok] Recreated $link as a symlink."
+            green "[ok] Created $link as a symlink."
             exit 0
         else
             red "[FAIL] Could not create symlink at $link."

--- a/test_project/addons/godot_ai
+++ b/test_project/addons/godot_ai
@@ -1,1 +1,0 @@
-../../plugin/addons/godot_ai


### PR DESCRIPTION
Closes #185.

## Summary
The `test_project/addons/godot_ai` symlink is no longer tracked in git. Every working copy builds the link locally — symlink on Unix, directory junction on Windows — via `script/setup-dev` / `script/setup-dev.ps1` / `script/verify-worktree` / the `post-checkout` hook / a new CI step.

## Why
Committing the link (mode `120000`) caused two recurring problems:

1. **Windows data loss.** Without Developer Mode, git checks the symlink out as a plain text file. Replacing a Windows junction with that text file can traverse into the target and wipe `plugin/addons/godot_ai/` — the phantom-deletion bug the repo has hit 4+ times.
2. **Multi-step git ops break on every platform.** `git rebase` does many internal checkouts; the post-checkout heal hook re-creates the junction after each one, producing an unstaged change that blocks the next rebase step. Documented workaround today is `git update-index --skip-worktree` — easy to forget.

With the link built locally:
- `mklink /J` works without admin rights or Developer Mode, so Windows contributors stop needing to toggle system settings.
- Nothing in the index fights `git rebase` / `cherry-pick` anymore.
- The data-loss path on junction-replace is permanently closed.

## Trade-off
A fresh `git clone` on Unix no longer gives you a working `test_project/` in one step — you must run `script/setup-dev` first. Windows already required `setup-dev.ps1`, so this only changes the Unix flow, and it unifies UX across platforms.

## Changes
- **`.gitignore`**: ignore `test_project/addons/godot_ai`.
- **`git rm --cached test_project/addons/godot_ai`** (leaves the link on disk in existing clones; next `git pull` will remove it, and `setup-dev` / the post-checkout hook will rebuild it).
- **`script/verify-worktree`**: now creates the link (and parent dir) when absent, not just when broken. Dropped "text-file fallback" framing — that case won't occur post-migration.
- **`script/setup-dev.ps1`**: removed Developer Mode check, removed `core.symlinks=true` config, replaced `git checkout`-based rehydration with direct `mklink /J`. Uses `cmd /c rmdir` to delete stale junctions (avoids the target-directory-traversal footgun).
- **`.githooks/post-checkout`**: updated comment explaining the hook's new role — ensuring the link exists for freshly-added worktrees.
- **`.github/workflows/ci.yml`**: added `bash script/verify-worktree` step right after checkout in every Godot-side job (Linux / macOS / Windows `godot-tests` + `game-capture-smoke`). CI builds its own link now rather than depending on `actions/checkout` to materialize a tracked symlink.
- **`CLAUDE.md` / `docs/CONTRIBUTING.md` / `README.md`**: updated worktree-health and Windows-setup notes, dropped Developer Mode warning.

## Test plan
- [x] `./script/verify-worktree` on a healthy tree → reports `[ok] …` (no-op).
- [x] Delete the symlink, re-run `verify-worktree` → recreates it as a symlink; `git status` stays clean (gitignore effective).
- [x] Delete the whole `test_project/addons/` directory, re-run `verify-worktree` → creates the dir and the link.
- [x] `bash -n` all three modified shell scripts → parse cleanly.
- [x] `git ls-files test_project/addons/godot_ai` → empty (no longer tracked).
- [x] CI: verify the new "Build plugin symlink/junction" step succeeds on Linux/macOS/Windows and downstream Godot jobs still load the plugin.
- [x] Windows contributor without Developer Mode: run `setup-dev.ps1`, confirm junction materializes and Godot loads the plugin. _(Validated manually on Windows 11, Dev Mode off, pwsh 7 — junction created, attributes `Directory, ReparsePoint`, Godot loads plugin cleanly with no `Failed loading resource` / `Could not find base class` / `Parse Error` lines, MCP session connects. `bash script/verify-worktree` auto-heal also confirmed working from Git Bash on the same machine.)_

Side-note: running `setup-dev.ps1` from Windows PowerShell 5.1 (vs. pwsh 7) hits a pre-existing strict-mode `\$IsWindows` bug — tracked in #187, not a regression from this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CDgqyvHixNcVpfRiqeBVxy)_