### PR TITLE
Fix setup-dev.ps1 crash in Windows PowerShell 5.1

### DIFF
--- a/script/setup-dev.ps1
+++ b/script/setup-dev.ps1
@@ -11,7 +11,7 @@ $ErrorActionPreference = 'Stop'
 $isWin = if ($PSVersionTable.PSVersion.Major -lt 6) {
     $env:OS -eq 'Windows_NT'
 } else {
-    [bool]$IsWindows
+    [bool](Get-Variable -Name IsWindows -ValueOnly -ErrorAction SilentlyContinue)
 }
 
 if (-not $isWin) {

--- a/script/setup-dev.ps1
+++ b/script/setup-dev.ps1
@@ -8,11 +8,15 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-if (-not $IsWindows -and $PSVersionTable.PSVersion.Major -ge 6) {
-    Write-Host "setup-dev.ps1 is Windows-only. On macOS/Linux, run script/setup-dev instead." -ForegroundColor Yellow
-    exit 0
-}
-if ($PSVersionTable.PSVersion.Major -lt 6 -and $env:OS -ne 'Windows_NT') {
+if ($PSVersionTable.PSVersion.Major -lt 6) {
+    if ($env:OS -eq 'Windows_NT') {
+        # Windows PowerShell 5.1: continue without touching $IsWindows
+        # (undefined before PowerShell 6).
+    } else {
+        Write-Host "setup-dev.ps1 is Windows-only. On macOS/Linux, run script/setup-dev instead." -ForegroundColor Yellow
+        exit 0
+    }
+} elseif (-not $IsWindows) {
     Write-Host "setup-dev.ps1 is Windows-only. On macOS/Linux, run script/setup-dev instead." -ForegroundColor Yellow
     exit 0
 }

--- a/script/setup-dev.ps1
+++ b/script/setup-dev.ps1
@@ -8,15 +8,13 @@
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-if ($PSVersionTable.PSVersion.Major -lt 6) {
-    if ($env:OS -eq 'Windows_NT') {
-        # Windows PowerShell 5.1: continue without touching $IsWindows
-        # (undefined before PowerShell 6).
-    } else {
-        Write-Host "setup-dev.ps1 is Windows-only. On macOS/Linux, run script/setup-dev instead." -ForegroundColor Yellow
-        exit 0
-    }
-} elseif (-not $IsWindows) {
+$isWin = if ($PSVersionTable.PSVersion.Major -lt 6) {
+    $env:OS -eq 'Windows_NT'
+} else {
+    [bool]$IsWindows
+}
+
+if (-not $isWin) {
     Write-Host "setup-dev.ps1 is Windows-only. On macOS/Linux, run script/setup-dev instead." -ForegroundColor Yellow
     exit 0
 }


### PR DESCRIPTION
### Motivation
- `script/setup-dev.ps1` referenced the automatic variable `$IsWindows` under `Set-StrictMode`, which is undefined in Windows PowerShell 5.1 and caused the script to fail before it could run.
- The goal is to preserve Windows-only early-exit behavior while avoiding touching `$IsWindows` on PS < 6 so the script works when invoked from `powershell.exe` (5.1).

### Description
- Reordered the platform/version guards in `script/setup-dev.ps1` to check `PSVersionTable.PSVersion.Major -lt 6` first so PS 5.1 logic runs before any reference to `$IsWindows`.
- For PS < 6 the script now uses `$env:OS -eq 'Windows_NT'` to detect Windows and continues without touching `$IsWindows` when appropriate.
- For PS 6+ the script still checks `-not $IsWindows` and preserves the existing Windows-only early exit messaging and behavior.

### Testing
- Attempted a PowerShell AST/parse check via `pwsh -NoLogo -NoProfile -Command "[void][System.Management.Automation.Language.Parser]::ParseFile('script/setup-dev.ps1',[ref]$null,[ref]$null); 'parse-ok'"`, but `pwsh` is not installed in the container so the parse check could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eacd079a488327a545eff43db9e5bd)