### PR TITLE
fix(clients): pin Roo Code config to streamable-http transport (#189)

### DIFF
--- a/plugin/addons/godot_ai/clients/cline.gd
+++ b/plugin/addons/godot_ai/clients/cline.gd
@@ -16,8 +16,18 @@ func _init() -> void:
 		"linux": "$XDG_CONFIG_HOME/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json",
 	}
 	server_key_path = PackedStringArray(["mcpServers"])
+	## Cline (like Roo) defaults a typeless entry to SSE transport, which
+	## returns HTTP 400 against our streamable-http endpoint on `/mcp`. Pin
+	## the type explicitly. Cline's schema uses "streamableHttp" (camelCase,
+	## see src/services/mcp/schemas.ts in the cline repo) — distinct from
+	## Roo's "streamable-http" string. Parallel to the Roo fix in #190.
 	entry_builder = func(_name: String, url: String) -> Dictionary:
-		return {"url": url, "disabled": false, "autoApprove": []}
+		return {"type": "streamableHttp", "url": url, "disabled": false, "autoApprove": []}
+	## Flag pre-fix entries (correct URL, missing or wrong "type") as drift so
+	## upgrading users get nudged to re-configure rather than silently keeping
+	## the broken SSE-default entry.
+	verify_entry = func(entry: Dictionary, url: String) -> bool:
+		return entry.get("url", "") == url and entry.get("type", "") == "streamableHttp"
 	detect_paths = PackedStringArray(path_template.values())
 	manual_command_builder = func(name: String, url: String, path: String) -> String:
-		return "Edit %s and add under \"mcpServers\":\n  \"%s\": { \"url\": \"%s\", \"disabled\": false, \"autoApprove\": [] }" % [path, name, url]
+		return "Edit %s and add under \"mcpServers\":\n  \"%s\": { \"type\": \"streamableHttp\", \"url\": \"%s\", \"disabled\": false, \"autoApprove\": [] }" % [path, name, url]

--- a/plugin/addons/godot_ai/clients/kilo_code.gd
+++ b/plugin/addons/godot_ai/clients/kilo_code.gd
@@ -13,8 +13,16 @@ func _init() -> void:
 		"linux": "$XDG_CONFIG_HOME/Code/User/globalStorage/kilocode.kilo-code/settings/mcp_settings.json",
 	}
 	server_key_path = PackedStringArray(["mcpServers"])
+	## Kilo Code (like Roo) defaults a typeless entry to SSE transport, which
+	## returns HTTP 400 against our streamable-http endpoint on `/mcp`. Pin
+	## the type explicitly. Parallel to the Roo fix in #190.
 	entry_builder = func(_name: String, url: String) -> Dictionary:
-		return {"url": url, "disabled": false, "alwaysAllow": []}
+		return {"type": "streamable-http", "url": url, "disabled": false, "alwaysAllow": []}
+	## Flag pre-fix entries (correct URL, missing or wrong "type") as drift so
+	## upgrading users get nudged to re-configure rather than silently keeping
+	## the broken SSE-default entry.
+	verify_entry = func(entry: Dictionary, url: String) -> bool:
+		return entry.get("url", "") == url and entry.get("type", "") == "streamable-http"
 	detect_paths = PackedStringArray(path_template.values())
 	manual_command_builder = func(name: String, url: String, path: String) -> String:
-		return "Edit %s and add under \"mcpServers\":\n  \"%s\": { \"url\": \"%s\", \"disabled\": false, \"alwaysAllow\": [] }" % [path, name, url]
+		return "Edit %s and add under \"mcpServers\":\n  \"%s\": { \"type\": \"streamable-http\", \"url\": \"%s\", \"disabled\": false, \"alwaysAllow\": [] }" % [path, name, url]

--- a/plugin/addons/godot_ai/clients/roo_code.gd
+++ b/plugin/addons/godot_ai/clients/roo_code.gd
@@ -13,8 +13,18 @@ func _init() -> void:
 		"linux": "$XDG_CONFIG_HOME/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json",
 	}
 	server_key_path = PackedStringArray(["mcpServers"])
+	## Roo defaults an entry with no "type" to SSE transport — which returns
+	## HTTP 400 against our streamable-http endpoint on `/mcp`. Pin the type
+	## explicitly so Roo negotiates streamable-http (the current MCP spec's
+	## recommended remote transport). See issue #189.
 	entry_builder = func(_name: String, url: String) -> Dictionary:
-		return {"url": url, "disabled": false, "alwaysAllow": []}
+		return {"type": "streamable-http", "url": url, "disabled": false, "alwaysAllow": []}
+	## Flag pre-#189 entries (correct URL, missing or wrong "type") as drift so
+	## the dock nudges the user to re-configure after upgrading. Without this,
+	## the URL-only default verifier says CONFIGURED and the broken SSE
+	## negotiation is invisible until Roo fails at connect time.
+	verify_entry = func(entry: Dictionary, url: String) -> bool:
+		return entry.get("url", "") == url and entry.get("type", "") == "streamable-http"
 	detect_paths = PackedStringArray(path_template.values())
 	manual_command_builder = func(name: String, url: String, path: String) -> String:
-		return "Edit %s and add under \"mcpServers\":\n  \"%s\": { \"url\": \"%s\", \"disabled\": false, \"alwaysAllow\": [] }" % [path, name, url]
+		return "Edit %s and add under \"mcpServers\":\n  \"%s\": { \"type\": \"streamable-http\", \"url\": \"%s\", \"disabled\": false, \"alwaysAllow\": [] }" % [path, name, url]

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -1006,6 +1006,65 @@ func test_roo_code_verify_flags_pre_189_typeless_entry_as_drift() -> void:
 	assert_false(c.verify_entry.call(url_drift, "http://x"), "URL drift must still register as drift")
 
 
+func test_cline_pins_streamable_http_transport() -> void:
+	## Parallel to the Roo #189 fix: without an explicit "type", Cline also
+	## defaults to SSE transport and our streamable-http /mcp endpoint returns
+	## HTTP 400. Cline's schema accepts "streamableHttp" (camelCase) — distinct
+	## from Roo's "streamable-http" — per src/services/mcp/schemas.ts upstream.
+	var c := McpClientRegistry.get_by_id("cline")
+	var entry: Dictionary = c.entry_builder.call("godot-ai", "http://x")
+	assert_eq(entry.get("type", ""), "streamableHttp")
+	assert_eq(entry.get("url", ""), "http://x")
+	var manual: String = c.manual_command_builder.call("godot-ai", "http://x", "/tmp/cline.json")
+	assert_contains(manual, "\"type\": \"streamableHttp\"")
+
+
+func test_cline_verify_flags_pre_fix_typeless_entry_as_drift() -> void:
+	## Users who configured Cline before this fix have a correct URL but no
+	## "type" field — the URL-only default verifier would report CONFIGURED and
+	## hide the broken SSE negotiation. verify_entry must treat a missing/wrong
+	## type as drift so the dock prompts them to re-configure.
+	var c := McpClientRegistry.get_by_id("cline")
+	assert_true(c.verify_entry.is_valid(), "cline must supply verify_entry")
+	var current: Dictionary = c.entry_builder.call("godot-ai", "http://x")
+	assert_true(c.verify_entry.call(current, "http://x"), "current entry must verify")
+	var legacy_typeless := {"url": "http://x", "disabled": false, "autoApprove": []}
+	assert_false(c.verify_entry.call(legacy_typeless, "http://x"), "pre-fix typeless entry must register as drift")
+	var legacy_sse := {"type": "sse", "url": "http://x", "disabled": false, "autoApprove": []}
+	assert_false(c.verify_entry.call(legacy_sse, "http://x"), "explicit sse entry must register as drift")
+	var wrong_case := {"type": "streamable-http", "url": "http://x", "disabled": false, "autoApprove": []}
+	assert_false(c.verify_entry.call(wrong_case, "http://x"), "Roo's kebab-case 'streamable-http' must register as drift in Cline (Cline accepts only 'streamableHttp')")
+	var url_drift := {"type": "streamableHttp", "url": "http://other", "disabled": false, "autoApprove": []}
+	assert_false(c.verify_entry.call(url_drift, "http://x"), "URL drift must still register as drift")
+
+
+func test_kilo_code_pins_streamable_http_transport() -> void:
+	## Parallel to the Roo #189 fix. Kilo Code is a Roo Code fork (legacy v5.x)
+	## and its McpHub.ts validates against {"stdio", "sse", "streamable-http"}
+	## — same kebab-case spelling as Roo, distinct from Cline's camelCase.
+	var c := McpClientRegistry.get_by_id("kilo_code")
+	var entry: Dictionary = c.entry_builder.call("godot-ai", "http://x")
+	assert_eq(entry.get("type", ""), "streamable-http")
+	assert_eq(entry.get("url", ""), "http://x")
+	var manual: String = c.manual_command_builder.call("godot-ai", "http://x", "/tmp/kilo.json")
+	assert_contains(manual, "\"type\": \"streamable-http\"")
+
+
+func test_kilo_code_verify_flags_pre_fix_typeless_entry_as_drift() -> void:
+	## Pre-fix Kilo entries have a correct URL but no "type" field. verify_entry
+	## must flag them as drift so the dock prompts a re-configure.
+	var c := McpClientRegistry.get_by_id("kilo_code")
+	assert_true(c.verify_entry.is_valid(), "kilo_code must supply verify_entry")
+	var current: Dictionary = c.entry_builder.call("godot-ai", "http://x")
+	assert_true(c.verify_entry.call(current, "http://x"), "current entry must verify")
+	var legacy_typeless := {"url": "http://x", "disabled": false, "alwaysAllow": []}
+	assert_false(c.verify_entry.call(legacy_typeless, "http://x"), "pre-fix typeless entry must register as drift")
+	var legacy_sse := {"type": "sse", "url": "http://x", "disabled": false, "alwaysAllow": []}
+	assert_false(c.verify_entry.call(legacy_sse, "http://x"), "explicit sse entry must register as drift")
+	var url_drift := {"type": "streamable-http", "url": "http://other", "disabled": false, "alwaysAllow": []}
+	assert_false(c.verify_entry.call(url_drift, "http://x"), "URL drift must still register as drift")
+
+
 func test_opencode_client_uses_home_config_on_windows() -> void:
 	## Regression: OpenCode reads its MCP config from
 	## ~/.config/opencode/opencode.json on ALL platforms (verified via

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -976,6 +976,36 @@ func test_vscode_uses_servers_key_with_type_http() -> void:
 	assert_eq(entry.get("url", ""), "http://x")
 
 
+func test_roo_code_pins_streamable_http_transport() -> void:
+	## Regression for #189: without an explicit "type", Roo defaults to SSE
+	## transport and our streamable-http /mcp endpoint returns HTTP 400.
+	## The entry and the manual-command string must both pin the type so the
+	## out-of-the-box config negotiates the right transport.
+	var c := McpClientRegistry.get_by_id("roo_code")
+	var entry: Dictionary = c.entry_builder.call("godot-ai", "http://x")
+	assert_eq(entry.get("type", ""), "streamable-http")
+	assert_eq(entry.get("url", ""), "http://x")
+	var manual: String = c.manual_command_builder.call("godot-ai", "http://x", "/tmp/roo.json")
+	assert_contains(manual, "\"type\": \"streamable-http\"")
+
+
+func test_roo_code_verify_flags_pre_189_typeless_entry_as_drift() -> void:
+	## Users who configured Roo before the #189 fix have a correct URL but no
+	## "type" field — the URL-only default verifier would report CONFIGURED and
+	## hide the broken SSE negotiation. verify_entry must treat a missing/wrong
+	## type as drift so the dock prompts them to re-configure.
+	var c := McpClientRegistry.get_by_id("roo_code")
+	assert_true(c.verify_entry.is_valid(), "roo_code must supply verify_entry")
+	var current: Dictionary = c.entry_builder.call("godot-ai", "http://x")
+	assert_true(c.verify_entry.call(current, "http://x"), "current entry must verify")
+	var legacy_typeless := {"url": "http://x", "disabled": false, "alwaysAllow": []}
+	assert_false(c.verify_entry.call(legacy_typeless, "http://x"), "pre-#189 typeless entry must register as drift")
+	var legacy_sse := {"type": "sse", "url": "http://x", "disabled": false, "alwaysAllow": []}
+	assert_false(c.verify_entry.call(legacy_sse, "http://x"), "explicit sse entry must register as drift")
+	var url_drift := {"type": "streamable-http", "url": "http://other", "disabled": false, "alwaysAllow": []}
+	assert_false(c.verify_entry.call(url_drift, "http://x"), "URL drift must still register as drift")
+
+
 func test_opencode_client_uses_home_config_on_windows() -> void:
 	## Regression: OpenCode reads its MCP config from
 	## ~/.config/opencode/opencode.json on ALL platforms (verified via


### PR DESCRIPTION
Fixes #189.

## Diagnosis

The plugin writes Roo Code's `mcp_settings.json` entry with just `{"url": ..., "disabled": false, "alwaysAllow": []}` — no `type` field. Per [Roo's transport docs](https://docs.roocode.com/features/mcp/server-transports), an entry without an explicit `type` defaults to **SSE** transport. Our server speaks **streamable-http** on `/mcp`, which rejects SSE's negotiation with HTTP 400 — hence the user's `SSE error: Non-200 status code (400)` in Roo's MCP settings pane.

## Fix

`plugin/addons/godot_ai/clients/roo_code.gd`:

1. **Entry builder** now emits `"type": "streamable-http"` alongside the URL — Roo negotiates the correct transport out of the box. The manual-command fallback string matches.
2. **`verify_entry`** checks both URL *and* `type == "streamable-http"`. Without this, users upgrading the plugin would keep their pre-fix (typeless) entry — URL still matches, so the default URL-only verifier would report `CONFIGURED` and mask the broken transport until Roo failed at connect time. With it, the dock shows drift and the "Configure" button rewrites the entry in the new shape.

Scoped narrowly to Roo per the issue — Cline / Kilo Code share the same base shape and may have parallel bugs, but I didn't touch them without a repro report.

## Test plan

- [x] `ruff check src/ tests/` passes
- [x] New GDScript regression tests in `test_project/tests/test_clients.gd`:
  - `test_roo_code_pins_streamable_http_transport` — entry + manual-command both carry `"type": "streamable-http"`
  - `test_roo_code_verify_flags_pre_189_typeless_entry_as_drift` — URL-only and `type: sse` entries both register as drift; URL drift still registers; fresh entry round-trips as a match
- [ ] Manual verify in Roo Code: Configure → see `mcp_settings.json` contains `"type": "streamable-http"` → Roo connects without the 400

---
_Generated by [Claude Code](https://claude.ai/code/session_01JwDFpqacaMgyH2gtedY2kG)_