### PR TITLE
fix(clients): guard Callable.call sites against stale post-reload state (#192)

### DIFF
--- a/plugin/addons/godot_ai/clients/_base.gd
+++ b/plugin/addons/godot_ai/clients/_base.gd
@@ -115,3 +115,18 @@ static func resolve_uvx_path() -> String:
 ## Callers splice this into the client-specific command shape.
 static func mcp_proxy_bridge_args(url: String) -> Array:
 	return ["mcp-proxy==" + MCP_PROXY_VERSION, "--transport", "streamablehttp", url]
+
+
+## Strategy-shaped error for descriptor Callables that have outlived their
+## owning instance. `McpClient` Callables capture `self` from the descriptor
+## built in `_init()`; after a live plugin reload (Project Settings → Plugins
+## toggle off/on without restarting the editor), those Callables can outlive
+## the instance — `is_valid()` flips false and calling them crashes the
+## editor. Strategies must short-circuit to this error so the dock row
+## degrades to "failed [Retry]" instead of taking the editor down.
+## Restarting the editor rebuilds descriptors with fresh, valid Callables.
+static func stale_callable_error(client: McpClient, field: String) -> Dictionary:
+	return {
+		"status": "error",
+		"message": "%s: stale %s callable after live plugin reload — restart the editor and try again." % [client.display_name, field],
+	}

--- a/plugin/addons/godot_ai/clients/_cli_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_cli_strategy.gd
@@ -11,6 +11,9 @@ static func configure(client: McpClient, server_name: String, server_url: String
 	if cli.is_empty():
 		return {"status": "error", "message": "%s CLI not found" % client.display_name}
 
+	if not client.cli_register_args.is_valid():
+		return McpClient.stale_callable_error(client, "cli_register_args")
+
 	# Best-effort prior cleanup so re-configure is idempotent.
 	if client.cli_unregister_args.is_valid():
 		var pre_args = client.cli_unregister_args.call(server_name)

--- a/plugin/addons/godot_ai/clients/_json_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_json_strategy.gd
@@ -11,6 +11,9 @@ static func configure(client: McpClient, server_name: String, server_url: String
 	if path.is_empty():
 		return {"status": "error", "message": "Could not resolve config path for %s on this OS" % client.display_name}
 
+	if not client.entry_builder.is_valid():
+		return McpClient.stale_callable_error(client, "entry_builder")
+
 	var read := _read_or_init(path)
 	if not read["ok"]:
 		return {"status": "error", "message": "Refusing to overwrite %s: %s. Fix or move the file, then re-run Configure." % [path, read["error"]]}

--- a/plugin/addons/godot_ai/clients/_toml_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_toml_strategy.gd
@@ -11,6 +11,9 @@ static func configure(client: McpClient, _server_name: String, server_url: Strin
 	if path.is_empty():
 		return {"status": "error", "message": "Could not resolve config path for %s" % client.display_name}
 
+	if not client.toml_body_builder.is_valid():
+		return McpClient.stale_callable_error(client, "toml_body_builder")
+
 	var read := _read_or_init(path)
 	if not read["ok"]:
 		return {"status": "error", "message": "Refusing to overwrite %s: %s. Fix or move the file, then re-run Configure." % [path, read["error"]]}

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -822,7 +822,12 @@ func test_cli_strategy_returns_typed_error_on_stale_cli_register_args() -> void:
 	## "CLI not found" otherwise). Use the bash/sh interpreter that exists
 	## on every CI runner we ship for; if none is available the test
 	## skips rather than reporting a false negative.
-	var probe_names: Array[String] = ["sh", "bash"] if OS.get_name() != "Windows" else ["cmd.exe"]
+	var probe_names: Array[String] = []
+	if OS.get_name() == "Windows":
+		probe_names.append("cmd.exe")
+	else:
+		probe_names.append("sh")
+		probe_names.append("bash")
 	var resolved := McpCliFinder.find(probe_names)
 	if resolved.is_empty():
 		skip("No portable shell on PATH to exercise the CLI strategy")

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -775,6 +775,72 @@ func test_json_strategy_supports_nested_key_path() -> void:
 	assert_eq(status, McpClient.Status.CONFIGURED)
 
 
+# ----- stale-callable safety after live plugin reload (#192) -----
+#
+# `McpClient` descriptors hold Callables built in `_init()` that capture the
+# descriptor instance. After `set_plugin_enabled(false/true)` the editor can
+# end up with descriptors whose Callables outlived their owning instance —
+# `is_valid()` returns false, calling them crashes the editor. The strategies
+# must short-circuit to a typed error in that state so the dock row degrades
+# to "failed [Retry]" with an actionable message instead.
+#
+# We can't actually trigger a live plugin reload from inside a test without
+# tearing the runner down, so we simulate the post-reload state by pointing
+# the relevant Callable at the default `Callable()` (which has
+# `is_valid() == false` from construction).
+
+
+func test_json_strategy_returns_typed_error_on_stale_entry_builder() -> void:
+	var path := _scratch_dir.path_join("stale_entry_builder.json")
+	_remove_if_exists(path)
+	var client := _make_test_json_client(path)
+	client.entry_builder = Callable()  # simulates post-reload stale callable
+
+	var result := McpJsonStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+	assert_eq(result.get("status"), "error", "Stale entry_builder must return error, not crash")
+	assert_contains(result.get("message", ""), "stale")
+	assert_contains(result.get("message", ""), "entry_builder")
+	assert_false(FileAccess.file_exists(path), "Config file must not be written when builder is stale")
+
+
+func test_toml_strategy_returns_typed_error_on_stale_toml_body_builder() -> void:
+	var path := _scratch_dir.path_join("stale_body_builder.toml")
+	_remove_if_exists(path)
+	var client := _make_test_toml_client(path)
+	client.toml_body_builder = Callable()
+
+	var result := McpTomlStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+	assert_eq(result.get("status"), "error", "Stale toml_body_builder must return error, not crash")
+	assert_contains(result.get("message", ""), "stale")
+	assert_contains(result.get("message", ""), "toml_body_builder")
+	assert_false(FileAccess.file_exists(path), "Config file must not be written when builder is stale")
+
+
+func test_cli_strategy_returns_typed_error_on_stale_cli_register_args() -> void:
+	## The CLI strategy needs a resolvable cli executable name to reach the
+	## stale-callable check (the `_resolve_cli` step short-circuits with
+	## "CLI not found" otherwise). Use the bash/sh interpreter that exists
+	## on every CI runner we ship for; if none is available the test
+	## skips rather than reporting a false negative.
+	var probe_names: Array[String] = ["sh", "bash"] if OS.get_name() != "Windows" else ["cmd.exe"]
+	var resolved := McpCliFinder.find(probe_names)
+	if resolved.is_empty():
+		skip("No portable shell on PATH to exercise the CLI strategy")
+		return
+
+	var client := McpClient.new()
+	client.id = "cli_test"
+	client.display_name = "CLI Test"
+	client.config_type = "cli"
+	client.cli_names = PackedStringArray(probe_names)
+	# cli_register_args left as default Callable() — the stale state.
+
+	var result := McpCliStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+	assert_eq(result.get("status"), "error", "Stale cli_register_args must return error, not crash")
+	assert_contains(result.get("message", ""), "stale")
+	assert_contains(result.get("message", ""), "cli_register_args")
+
+
 # ----- TOML strategy round-trip -----
 
 func test_toml_strategy_round_trip() -> void:


### PR DESCRIPTION
Closes #192.

## Triage

Open issues at the time of this PR:

- **#192** — `_json_strategy.gd` crashes on stale Callables after live plugin reload
- **#191** — `node_set_property` silently coerces Vector3/Vector2 values to zero
- **#193** — Pydantic strict tool schemas reject Cline's `task_progress` kwarg
- **#194** — Promote node CRUD into Core
- **#181** — Tool profiles (large feature)
- **#129** — Test cleanup helper (explicitly defer)

These touch unrelated subsystems (clients, tools, schemas, tool catalog), so bundling them would hurt bisect-friendliness. Picked **#192** as a focused, bisect-friendly bug fix — real crash with a clear root cause, well-bounded scope, and testable without a live Godot via the existing `test_clients.gd` suite.

## Summary

After a live plugin reload (Project Settings → Plugins toggle off/on without restarting the editor), `McpClient` descriptor `Callable` fields built inside `_init()` capture `self` from the descriptor instance — that instance can be freed/recreated by the reload, leaving Callables whose `is_valid()` returns `false`. Calling them crashes the editor with:

```
ERROR: _json_strategy.gd:19 - Attempt to call function ' (Callable)' on a null instance.
```

PR #190 fixed the read path (`verify_entry` in JSON `check_status`). This extends the same defensive pattern to the previously-unguarded write path in all three `configure()` flows.

## Changes

- `_json_strategy.gd::configure` — guard `entry_builder`
- `_toml_strategy.gd::configure` — guard `toml_body_builder`
- `_cli_strategy.gd::configure` — guard `cli_register_args`
- New shared helper `McpClient.stale_callable_error(client, field)` keeps the message consistent and avoids cross-strategy dependencies.

Stale state now short-circuits to `{"status":"error","message":"<client>: stale <field> callable after live plugin reload — restart the editor and try again."}` so the dock row degrades to **failed [Retry]** with an actionable message instead of taking the editor down.

Verified all `Callable.call(...)` sites under `clients/` and `client_configurator.gd` are now guarded:

```
$ grep -rn '\.call(' plugin/addons/godot_ai/clients/ plugin/addons/godot_ai/client_configurator.gd
_cli_strategy.gd:19    cli_unregister_args.call    [pre-existing is_valid()]
_cli_strategy.gd:22    cli_register_args.call      [NEW guard above]
_cli_strategy.gd:37    cli_status_check.call       [pre-existing is_valid()]
_cli_strategy.gd:46    cli_unregister_args.call    [pre-existing is_valid()]
_json_strategy.gd:22   entry_builder.call          [NEW guard above]
_json_strategy.gd:47   verify_entry.call           [pre-existing is_valid() from PR #190]
_toml_strategy.gd:21   toml_body_builder.call      [NEW guard above]
client_configurator.gd:188 manual_command_builder.call [pre-existing is_valid()]
```

## Test plan

- [x] `pytest -q` — 563 passed (unchanged path; sanity check that nothing Python-side broke)
- [x] `ruff check src/ tests/` — clean
- [x] Three new GDScript tests added under `# ----- stale-callable safety after live plugin reload (#192) -----`. They simulate the post-reload state by assigning a default `Callable()` (always invalid) to the relevant descriptor field and verify the strategy returns a typed error rather than crashing.
- [ ] CI will run the GDScript suite (`script/ci-godot-tests`) — no Godot binary available locally to run them ahead of push.
- [ ] Live editor smoke (manual): toggle the plugin off/on in Project Settings → Plugins, click **Configure** on any JSON-backed client (Cline/Cursor/etc.). Should now show **failed [Retry]** with a stale-callable message instead of crashing the editor.

## Notes / followups (not in this PR)

The structural fix the issue mentions — moving descriptor lambdas to static methods so they don't capture `self` at all — is bigger and worth its own PR. This PR is the user-facing crash mitigation; it makes the live-reload dev loop usable today and is fully forward-compatible with that future refactor.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KQnNrupPYaursnBEfq6TSf)_