### PR TITLE
fix(clients): guard Callable.call sites against stale post-reload crashes (#192)

### DIFF
--- a/plugin/addons/godot_ai/clients/_base.gd
+++ b/plugin/addons/godot_ai/clients/_base.gd
@@ -115,3 +115,15 @@ static func resolve_uvx_path() -> String:
 ## Callers splice this into the client-specific command shape.
 static func mcp_proxy_bridge_args(url: String) -> Array:
 	return ["mcp-proxy==" + MCP_PROXY_VERSION, "--transport", "streamablehttp", url]
+
+
+## Uniform error payload for every strategy site that invokes a
+## descriptor-supplied Callable. Toggling the plugin off/on frees the
+## McpClient the lambda captured; calling the stale Callable then crashes
+## Godot, so each site must `is_valid()`-guard first and surface this
+## restart-required hint instead. See issue #192.
+static func stale_callable_status(client: McpClient) -> Dictionary:
+	return {
+		"status": "error",
+		"message": "%s configurator was invalidated by a live plugin reload — restart the editor to recover." % client.display_name,
+	}

--- a/plugin/addons/godot_ai/clients/_cli_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_cli_strategy.gd
@@ -16,6 +16,8 @@ static func configure(client: McpClient, server_name: String, server_url: String
 		var pre_args = client.cli_unregister_args.call(server_name)
 		OS.execute(cli, pre_args, [], true)
 
+	if not client.cli_register_args.is_valid():
+		return McpClient.stale_callable_status(client)
 	var args = client.cli_register_args.call(server_name, server_url)
 	var output: Array = []
 	var exit_code := OS.execute(cli, args, output, true)
@@ -39,7 +41,7 @@ static func remove(client: McpClient, server_name: String) -> Dictionary:
 	if cli.is_empty():
 		return {"status": "error", "message": "%s CLI not found" % client.display_name}
 	if not client.cli_unregister_args.is_valid():
-		return {"status": "error", "message": "%s descriptor missing cli_unregister_args" % client.display_name}
+		return McpClient.stale_callable_status(client)
 	var args = client.cli_unregister_args.call(server_name)
 	var output: Array = []
 	var exit_code := OS.execute(cli, args, output, true)

--- a/plugin/addons/godot_ai/clients/_json_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_json_strategy.gd
@@ -14,6 +14,8 @@ static func configure(client: McpClient, server_name: String, server_url: String
 	var read := _read_or_init(path)
 	if not read["ok"]:
 		return {"status": "error", "message": "Refusing to overwrite %s: %s. Fix or move the file, then re-run Configure." % [path, read["error"]]}
+	if not client.entry_builder.is_valid():
+		return McpClient.stale_callable_status(client)
 	var config: Dictionary = read["data"]
 	var holder := _ensure_path(config, client.server_key_path)
 	holder[server_name] = client.entry_builder.call(server_name, server_url)

--- a/plugin/addons/godot_ai/clients/_toml_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_toml_strategy.gd
@@ -14,6 +14,8 @@ static func configure(client: McpClient, _server_name: String, server_url: Strin
 	var read := _read_or_init(path)
 	if not read["ok"]:
 		return {"status": "error", "message": "Refusing to overwrite %s: %s. Fix or move the file, then re-run Configure." % [path, read["error"]]}
+	if not client.toml_body_builder.is_valid():
+		return McpClient.stale_callable_status(client)
 	var lines: Array[String] = _split_lines(String(read["data"]))
 	var body: PackedStringArray = client.toml_body_builder.call(server_url)
 

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -756,6 +756,66 @@ func test_json_strategy_drift_with_verify_entry_callable() -> void:
 	)
 
 
+## #192 — Lambdas captured in McpClient._init() reference the descriptor
+## instance; toggling the plugin off/on in Project Settings frees the
+## instance and leaves the registry holding stale Callables that crash hard
+## the moment they're invoked. A default-constructed Callable is the closest
+## stand-in we can build in a test — both stale and unset report
+## `is_valid() == false`. The strategies must short-circuit with the shared
+## restart-the-editor message instead of dereferencing the invalid call.
+
+func test_json_strategy_returns_clean_error_when_entry_builder_callable_is_stale() -> void:
+	var path := _scratch_dir.path_join("stale_entry_builder.json")
+	_remove_if_exists(path)
+	var client := _make_test_json_client(path)
+	client.entry_builder = Callable()
+
+	var result := McpJsonStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+	_assert_stale_callable_error(result, client)
+	assert_false(FileAccess.file_exists(path), "Strategy must not write the config file when the callable is stale")
+
+
+func test_toml_strategy_returns_clean_error_when_body_builder_callable_is_stale() -> void:
+	var path := _scratch_dir.path_join("stale_toml_body.toml")
+	_remove_if_exists(path)
+	var client := _make_test_toml_client(path)
+	client.toml_body_builder = Callable()
+
+	var result := McpTomlStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+	_assert_stale_callable_error(result, client)
+	assert_false(FileAccess.file_exists(path), "Strategy must not write the config file when the callable is stale")
+
+
+func test_cli_strategy_returns_clean_error_when_register_args_callable_is_stale() -> void:
+	## The strategy resolves the CLI binary before invoking the Callable;
+	## point at `sh` / `cmd.exe` so the resolver succeeds on every test host
+	## and the guard is the line under test.
+	var client := McpClient.new()
+	client.id = "stale_cli_test"
+	client.display_name = "Stale CLI Test"
+	client.config_type = "cli"
+	client.cli_names = PackedStringArray(["cmd.exe"] if OS.get_name() == "Windows" else ["sh"])
+	client.cli_register_args = Callable()
+
+	var result := McpCliStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+	_assert_stale_callable_error(result, client)
+
+
+func test_cli_strategy_remove_returns_clean_error_when_unregister_args_callable_is_stale() -> void:
+	## remove() had a pre-existing guard with a different message; after #192
+	## it now routes through stale_callable_status alongside configure(). Same
+	## crash hazard, same recovery — keep the dock-facing wording uniform.
+	var client := McpClient.new()
+	client.id = "stale_cli_remove_test"
+	client.display_name = "Stale CLI Remove Test"
+	client.config_type = "cli"
+	client.cli_names = PackedStringArray(["cmd.exe"] if OS.get_name() == "Windows" else ["sh"])
+	client.cli_unregister_args = Callable()
+
+	var result := McpCliStrategy.remove(client, "godot-ai")
+	_assert_stale_callable_error(result, client)
+
+
 func test_json_strategy_supports_nested_key_path() -> void:
 	var path := _scratch_dir.path_join("nested.json")
 	_remove_if_exists(path)
@@ -1115,6 +1175,13 @@ func _assert_mcp_proxy_bridge_args(args: Variant, expected_url: String) -> void:
 	assert_contains(args, "--transport")
 	assert_contains(args, "streamablehttp")
 	assert_contains(args, expected_url)
+
+
+func _assert_stale_callable_error(result: Dictionary, client: McpClient) -> void:
+	assert_eq(result.get("status"), "error")
+	var msg: String = result.get("message", "")
+	assert_contains(msg, client.display_name, "stale-callable error must name the client, got: %s" % msg)
+	assert_contains(msg, "restart the editor", "stale-callable error must suggest editor restart, got: %s" % msg)
 
 
 func _make_test_json_client(path: String) -> McpClient:


### PR DESCRIPTION
## Summary

Closes #192. Toggling the godot_ai plugin off/on in Project Settings frees the `McpClient` descriptor instances that the per-client lambdas captured. Three `Callable.call(...)` sites then dereferenced null on the next click and crashed Godot with `Attempt to call function ' (Callable)' on a null instance`:

- `_json_strategy.gd::configure` — `entry_builder.call(...)`
- `_toml_strategy.gd::configure` — `toml_body_builder.call(...)`
- `_cli_strategy.gd::configure` — `cli_register_args.call(...)`

PR #190 had already added the same hazard's mitigation to `verify_entry` on the status path; this extends the pattern to every remaining unguarded site. Each site now `is_valid()`-guards first and surfaces a shared, dock-friendly "restart the editor to recover" message via a new `McpClient.stale_callable_status()` helper. The pre-existing `"descriptor missing cli_unregister_args"` branch in `remove()` collapses into the same helper (same root cause now that #192 is the only path to invalidity).

## Changes

- `plugin/addons/godot_ai/clients/_base.gd` — new `McpClient.stale_callable_status(client)` helper that returns the uniform `{"status": "error", "message": ...}` payload.
- `plugin/addons/godot_ai/clients/_json_strategy.gd`, `_toml_strategy.gd`, `_cli_strategy.gd` — each `is_valid()`-guards before its previously-unguarded `.call(...)` site.
- `plugin/addons/godot_ai/clients/_cli_strategy.gd::remove` — migrates the existing "descriptor missing" message to `stale_callable_status` (same failure mode now).
- `test_project/tests/test_clients.gd` — four regression tests (one per guarded `.call(...)` site) using a default-constructed `Callable()` as the closest stand-in for the post-reload stale state. Reuses the existing `_make_test_json_client` / `_make_test_toml_client` factories and adds a small `_assert_stale_callable_error` helper.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `pytest -q` — 563 passed
- [ ] **Live smoke pending — sandbox has no Godot binary.** GDScript tests need to be run via `test_run` from the editor; the SIGSEGV repro itself (toggle plugin off/on in Project Settings → click **Configure** on a JSON-backed client) needs a human pass to confirm the crash is gone before tagging.

## Out of scope

`_cli_strategy.gd::check_status` returns `NOT_CONFIGURED` on a stale `cli_status_check` callable, conflating post-reload with "never configured". Same bug class as #192 on the read path; deliberately deferred to a follow-up.

https://claude.ai/code/session_01W97ATVMFrk98wyZTfxbNkF


---
_Generated by [Claude Code](https://claude.ai/code/session_01W97ATVMFrk98wyZTfxbNkF)_