### PR TITLE
fix(server): strip Cline's task_progress kwarg before pydantic validation (#193)

### DIFF
--- a/src/godot_ai/middleware/__init__.py
+++ b/src/godot_ai/middleware/__init__.py
@@ -1,0 +1,10 @@
+"""FastMCP middleware for the Godot AI server."""
+
+from __future__ import annotations
+
+from godot_ai.middleware.client_wrapper_kwargs import (
+    CLIENT_WRAPPER_KWARGS,
+    StripClientWrapperKwargs,
+)
+
+__all__ = ["CLIENT_WRAPPER_KWARGS", "StripClientWrapperKwargs"]

--- a/src/godot_ai/middleware/client_wrapper_kwargs.py
+++ b/src/godot_ai/middleware/client_wrapper_kwargs.py
@@ -1,0 +1,46 @@
+"""Strip known client-injected wrapper kwargs before pydantic tool validation.
+
+FastMCP tool schemas are pydantic-strict (`extra="forbid"`); without this
+middleware, any client that decorates every `tools/call` with an extra
+kwarg (e.g. Cline's `task_progress`) costs every call a wasted retry. A
+narrow allowlist is preferred over a blanket `extra="ignore"` so typo'd
+real parameter names still surface as validation errors. See #193.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+from fastmcp.tools.base import ToolResult
+from mcp.types import CallToolRequestParams
+
+logger = logging.getLogger(__name__)
+
+
+## Add a new entry only when a real client is observed injecting it on
+## every call against an unrelated server (i.e. it's a wrapper convention,
+## not a server-specific param the user mistyped).
+CLIENT_WRAPPER_KWARGS: frozenset[str] = frozenset({"task_progress"})
+
+
+class StripClientWrapperKwargs(Middleware):
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[CallToolRequestParams],
+        call_next: CallNext[CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        arguments = context.message.arguments
+        if arguments:
+            stripped: list[str] = []
+            for key in CLIENT_WRAPPER_KWARGS:
+                if key in arguments:
+                    del arguments[key]
+                    stripped.append(key)
+            if stripped:
+                logger.debug(
+                    "Stripped client wrapper kwarg(s) %s from %s",
+                    stripped,
+                    context.message.name,
+                )
+        return await call_next(context)

--- a/src/godot_ai/server.py
+++ b/src/godot_ai/server.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from fastmcp import FastMCP
 
 from godot_ai.godot_client.client import GodotClient
+from godot_ai.middleware import StripClientWrapperKwargs
 from godot_ai.resources.editor import register_editor_resources
 from godot_ai.resources.library import register_library_resources
 from godot_ai.resources.nodes import register_node_resources
@@ -139,6 +140,10 @@ def create_server(
         ),
         lifespan=_lifespan,
     )
+
+    ## Tolerate known client-injected wrapper kwargs (Cline's task_progress,
+    ## etc.) so strict pydantic schemas don't reject every call. See #193.
+    mcp.add_middleware(StripClientWrapperKwargs())
 
     exclude = set(exclude_domains or ())
     if exclude:

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -1013,6 +1013,18 @@ class TestSessionTools:
         result = await client.call_tool("session_activate", {"session_id": "no-such-session"})
         assert result.data["status"] == "error"
 
+    async def test_call_tolerates_cline_task_progress_kwarg(self, mcp_stack):
+        ## #193 — Cline injects `task_progress` into every tools/call. With
+        ## strict pydantic schemas the call would otherwise fail with
+        ## `Unexpected keyword argument` and force a wasteful retry.
+        client, _plugin = mcp_stack
+        result = await client.call_tool(
+            "session_list",
+            {"task_progress": "- [x] checked the editor state"},
+        )
+        assert result.data["count"] == 1
+        assert result.data["sessions"][0]["session_id"] == "mcp-test"
+
     async def test_session_list_reports_server_launch_mode_from_handshake(self, harness):
         ## End-to-end: plugin sends server_launch_mode in handshake →
         ## websocket parses it → Session stores it → session_list surfaces it.

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -1019,8 +1019,12 @@ class TestSessionTools:
         ## `Unexpected keyword argument` and force a wasteful retry.
         client, _plugin = mcp_stack
         result = await client.call_tool(
-            "session_list",
-            {"task_progress": "- [x] checked the editor state"},
+            "session_manage",
+            {
+                "op": "list",
+                "params": {},
+                "task_progress": "- [x] checked the editor state",
+            },
         )
         assert result.data["count"] == 1
         assert result.data["sessions"][0]["session_id"] == "mcp-test"

--- a/tests/unit/test_middleware_client_wrapper_kwargs.py
+++ b/tests/unit/test_middleware_client_wrapper_kwargs.py
@@ -1,0 +1,84 @@
+"""Unit tests for the StripClientWrapperKwargs middleware (#193)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from mcp.types import CallToolRequestParams
+
+from godot_ai.middleware import CLIENT_WRAPPER_KWARGS, StripClientWrapperKwargs
+
+
+@dataclass
+class _FakeContext:
+    message: CallToolRequestParams
+
+
+async def _record_arguments_call_next(seen: list[dict[str, Any] | None]):
+    async def _call_next(context: _FakeContext) -> str:
+        seen.append(context.message.arguments)
+        return "ok"
+
+    return _call_next
+
+
+class TestStripClientWrapperKwargs:
+    async def test_strips_known_wrapper_kwarg(self):
+        seen: list[dict | None] = []
+        mw = StripClientWrapperKwargs()
+        ctx = _FakeContext(
+            message=CallToolRequestParams(
+                name="session_list",
+                arguments={"task_progress": "- [x] step", "session_id": "s1"},
+            )
+        )
+        result = await mw.on_call_tool(ctx, await _record_arguments_call_next(seen))
+
+        assert result == "ok"
+        assert seen == [{"session_id": "s1"}]
+
+    async def test_passes_through_when_no_wrapper_kwarg_present(self):
+        seen: list[dict | None] = []
+        mw = StripClientWrapperKwargs()
+        original = {"session_id": "s1"}
+        ctx = _FakeContext(
+            message=CallToolRequestParams(name="session_activate", arguments=original)
+        )
+        await mw.on_call_tool(ctx, await _record_arguments_call_next(seen))
+
+        ## Same dict identity — middleware mustn't reallocate when nothing to strip.
+        assert seen[0] is ctx.message.arguments
+
+    async def test_handles_none_arguments(self):
+        seen: list[dict | None] = []
+        mw = StripClientWrapperKwargs()
+        ctx = _FakeContext(message=CallToolRequestParams(name="editor_state", arguments=None))
+        await mw.on_call_tool(ctx, await _record_arguments_call_next(seen))
+        assert seen == [None]
+
+    async def test_handles_empty_arguments(self):
+        seen: list[dict | None] = []
+        mw = StripClientWrapperKwargs()
+        ctx = _FakeContext(message=CallToolRequestParams(name="editor_state", arguments={}))
+        await mw.on_call_tool(ctx, await _record_arguments_call_next(seen))
+        assert seen == [{}]
+
+    async def test_unknown_extra_kwarg_passes_through_unchanged(self):
+        ## Allowlist — typos and server-specific params reach the tool so
+        ## pydantic still surfaces real client bugs as validation errors.
+        seen: list[dict | None] = []
+        mw = StripClientWrapperKwargs()
+        ctx = _FakeContext(
+            message=CallToolRequestParams(
+                name="session_list",
+                arguments={"task_progres": "typo", "bogus": 1},
+            )
+        )
+        await mw.on_call_tool(ctx, await _record_arguments_call_next(seen))
+        assert seen == [{"task_progres": "typo", "bogus": 1}]
+
+    def test_allowlist_contains_task_progress(self):
+        ## Pinned: removing task_progress without replacing the workaround
+        ## reintroduces the Cline failure mode from #193.
+        assert "task_progress" in CLIENT_WRAPPER_KWARGS


### PR DESCRIPTION
Closes #193.

## Triage

Open issues at the time of this PR:

- **#191** — Vector3/Vector2 silent zero-coercion → already in flight (PR #197).
- **#192** — stale Callable crash after live plugin reload → already in flight (PRs #195 / #196).
- **#193** — Cline `task_progress` kwarg rejected by strict pydantic schemas. **Picked.** Single-subsystem (FastMCP middleware), well-scoped, real per-call regression for Cline users, bisect-friendly.
- **#194** — promote node CRUD into Core → already in flight (PR #198).
- **#181** — Tool profiles. Large feature, separate PR.
- **#129** — explicitly deferred ("Out-of-scope … When to revisit").

Single-issue PR. Considered bundling with #194 (the other "tools-layer" issue) but #194 is a registration-tier change and #193 is a request-pipeline change — bundling would harm bisect-friendliness with no shared lift.

## Summary

FastMCP tool schemas are pydantic-strict (`extra="forbid"`). Cline injects `task_progress` (its progress-tracking feature) into every `tools/call` unconditionally — they don't gate it on a server capability flag — so each call failed with:

```
1 validation error for call[session_list]
task_progress
  Unexpected keyword argument [type=unexpected_keyword_argument,
  input_value='- [x] ...', input_type=str]
```

The agent self-recovers, but every Cline tool call costs an extra round-trip and a noisy validation error. For a long planning session that's tens of wasted calls.

This PR adds a small FastMCP middleware that pops a narrow allowlist of known client-injected wrapper kwargs from the call arguments before they reach pydantic. The allowlist is preferred over a blanket `extra="ignore"` (issue option 1) so typo'd real parameter names still surface as validation errors rather than being silently dropped. Per the issue, option 2 was the recommended balance.

## Changes

- `src/godot_ai/middleware/__init__.py` (new) — package shim, re-exports `CLIENT_WRAPPER_KWARGS` and `StripClientWrapperKwargs`. Matches `src/godot_ai/tools/__init__.py`'s pattern.
- `src/godot_ai/middleware/client_wrapper_kwargs.py` (new) — `StripClientWrapperKwargs(Middleware).on_call_tool` pops any allowlisted keys (currently `{"task_progress"}`) from `context.message.arguments` in a single pass. No allocation in the common no-strip path; the dict-identity assertion in the unit test pins this guarantee. Logs at DEBUG when something was stripped.
- `src/godot_ai/server.py` — registers the middleware via `mcp.add_middleware(...)` immediately after creating the FastMCP instance.
- `tests/unit/test_middleware_client_wrapper_kwargs.py` (new) — 6 unit tests: strip happy path, no-op pass-through with dict-identity check, `None` arguments, empty dict, unknown-extra-kwarg pass-through (proves the allowlist doesn't blanket-loosen), and a regression pin that `task_progress` stays in the allowlist.
- `tests/integration/test_mcp_tools.py` — adds `test_call_tolerates_cline_task_progress_kwarg` exercising the full FastMCP `Client → server → tool` stack with `task_progress` injected. Mirrors the issue's repro shape.

Adding a new wrapper kwarg in the future is one frozenset edit.

## Test plan

- [x] `pytest -q` — 570 passed, 0 failed (was 563 pre-PR + 7 new tests).
- [x] `ruff check src/ tests/` — clean.
- [x] Direct repro confirmed: with the middleware disabled the same `client.call_tool('session_list', {'task_progress': '...'})` raises `Unexpected keyword argument [type=unexpected_keyword_argument, input_value='- [x] checked'`; with it enabled the call succeeds.
- [ ] **Live smoke pending — sandbox has no Godot binary.** Plugin/GDScript code is untouched (Python-only change to the MCP request pipeline), so the GDScript suite is unaffected and CI's `script/ci-godot-tests` is sufficient. The end-to-end Cline repro (configure godot-ai in Cline, ask the agent to call any two tools, observe no `Unexpected keyword argument` retries) needs a human pass.

## Notes / followups (deliberately not in this PR)

- The issue mentions other clients may add similar wrappers (Cursor, Continue). The frozenset is the single point of extension when one shows up — adding `"some_other_kwarg"` is a one-line change.
- The issue's option 3 (`**kwargs` sink on every tool) was not pursued — it's the most boilerplate, the most explicit, and the least graceful to remove if a future FastMCP version adds a `model_config` knob.
- A small risk: a future godot-ai tool that genuinely needs a parameter named `task_progress` would have it silently stripped. None exist today (`grep -r task_progress src/` returns only the new middleware). If the conflict ever arises, the fix is to either rename the new tool's parameter or upstream the strip-list as a per-tool opt-out.

---
_Generated by [Claude Code](https://claude.ai/code/session_0118Hu5DtCvnMPQBXHiFGr4A)_