### PR TITLE
fix(node): reject uncoercible values to Vector/Color slots instead of silent zero (#191)

### DIFF
--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -237,8 +237,10 @@ func set_property(params: Dictionary) -> Dictionary:
 		instantiated_resource = true
 	else:
 		value = _coerce_value(value, target_type)
-		## Refuse wrong-shape dicts that _coerce_value passed through (#123).
-		var coerce_err := _check_dict_coerce_failed(value, target_type)
+		## Refuse uncoercible values that would silently zero-default at
+		## `add_do_property` (#123 — wrong-shape dicts; #191 — non-dict
+		## values like Array/String/int landing on a Vector slot).
+		var coerce_err := _check_coerced(value, target_type, "Property '%s'" % property)
 		if coerce_err != null:
 			return coerce_err
 
@@ -497,19 +499,34 @@ const VECTOR2_KEYS: Array[String] = ["x", "y"]
 const VECTOR3_KEYS: Array[String] = ["x", "y", "z"]
 const COLOR_KEYS: Array[String] = ["r", "g", "b"]
 
+## Variant types that `_check_coerced` enforces on. Extracted to avoid
+## per-call array allocation in `set_property`'s hot path.
+const VECTORLIKE_TYPES: Array[int] = [TYPE_VECTOR2, TYPE_VECTOR3, TYPE_COLOR]
 
-## End-to-end coerce check for validation handlers (curve, texture,
-## resource properties). Returns a full `make(...)`-shaped error dict
-## (prefixed with `prefix`) if the value didn't land as the target
-## Variant type, else null. Dict-shape failures get the
+## Variant types whose String inputs `_coerce_value` will JSON-parse first
+## (clients/middleware sometimes stringify nested dict args — #191).
+## Superset of VECTORLIKE_TYPES; ARRAY/DICTIONARY land here too because
+## a stringified `"[1,2]"` should reach the consumer as an Array.
+const JSON_PARSE_STRING_TARGETS: Array[int] = [
+	TYPE_VECTOR2, TYPE_VECTOR3, TYPE_COLOR, TYPE_ARRAY, TYPE_DICTIONARY
+]
+
+
+## End-to-end coerce check for set_property and validation handlers
+## (curve, texture, resource properties). Returns a full `make(...)`-shaped
+## error dict (prefixed with `prefix`) if the value didn't land as the
+## target Variant type, else null. Dict-shape failures get the
 ## `_check_dict_coerce_failed` message (expected-vs-got keys); non-dict
-## non-Vector inputs (String, int, …) get a generic "must coerce"
-## message.
+## non-Vector inputs (String, int, …) get a generic "must coerce" message.
 ##
-## Only TYPE_VECTOR2 / TYPE_VECTOR3 / TYPE_COLOR are recognized — other
-## targets would false-negative on a valid value. Extend the match
-## alongside `_coerce_value` if you add a new coerce target.
+## Only TYPE_VECTOR2 / TYPE_VECTOR3 / TYPE_COLOR are gated — other targets
+## are passed through untouched (returns null) so this stays safe to call
+## generically from set_property without false-positives on TYPE_BOOL /
+## TYPE_FLOAT / TYPE_OBJECT / etc. Extend the match alongside `_coerce_value`
+## if you add a new coerce target.
 static func _check_coerced(value: Variant, target_type: int, prefix: String) -> Variant:
+	if not (target_type in VECTORLIKE_TYPES):
+		return null
 	var err = _check_dict_coerce_failed(value, target_type)
 	if err != null:
 		return McpErrorCodes.prefix_message(err, prefix)
@@ -562,12 +579,24 @@ static func _check_dict_coerce_failed(value: Variant, target_type: int) -> Varia
 ## type is known. Returns the coerced value on success, or the input
 ## unchanged on failure — callers detect the type mismatch via an
 ## `is <Type>` check (curve_handler, texture_handler) or via the
-## `_check_dict_coerce_failed` helper (set_property, resource_handler).
+## `_check_coerced` helper (set_property, resource_handler).
 ##
 ## Dictionary→Vector2/Vector3/Color cases REQUIRE all canonical keys;
 ## wrong-shape dicts flow through unchanged. See issue #123 — previous
 ## `dict.get(key, 0)` defaults silently zero-filled missing axes.
+##
+## String inputs to compound targets (Vector2/3/Color/Array/Dictionary)
+## are first parsed as JSON when they begin with `{` or `[` — some
+## clients/middleware stringify nested-dict tool args (#191). Hex Color
+## strings (`"#ff0000"`, `"red"`) bypass JSON parse and hit the
+## `Color(value)` constructor below.
 static func _coerce_value(value: Variant, target_type: int) -> Variant:
+	if value is String and target_type in JSON_PARSE_STRING_TARGETS:
+		var s: String = (value as String).strip_edges()
+		if s.begins_with("{") or s.begins_with("["):
+			var parsed = JSON.parse_string(s)
+			if parsed != null:
+				value = parsed
 	match target_type:
 		TYPE_VECTOR2:
 			if value is Dictionary and value.has_all(VECTOR2_KEYS):

--- a/plugin/addons/godot_ai/handlers/resource_handler.gd
+++ b/plugin/addons/godot_ai/handlers/resource_handler.gd
@@ -277,11 +277,11 @@ static func _apply_resource_properties(res: Resource, properties: Dictionary) ->
 			v = sub_res
 		else:
 			v = NodeHandler._coerce_value(v, target_type)
-			## Mirror set_property's coerce check so wrong-shape dicts error
-			## instead of writing zero-filled Variants (issue #123).
-			var coerce_err := NodeHandler._check_dict_coerce_failed(v, target_type)
+			## Mirror set_property's coerce check so uncoercible values error
+			## instead of writing zero-filled Variants (issues #123, #191).
+			var coerce_err := NodeHandler._check_coerced(v, target_type, "Property '%s'" % key)
 			if coerce_err != null:
-				return McpErrorCodes.prefix_message(coerce_err, "Property '%s'" % key)
+				return coerce_err
 		res.set(key, v)
 	return null
 

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -372,6 +372,106 @@ func test_set_property_color_rejects_vector3_shaped_dict() -> void:
 	assert_true(coerced is Dictionary, "Wrong-shape dict must flow through unchanged so caller's type check fires")
 
 
+func test_set_property_vector3_rejects_array() -> void:
+	## Issue #191: passing an Array to a Vector3 slot used to pass through
+	## _check_dict_coerce_failed (which only fires on dicts) and silently
+	## land Vector3.ZERO via Godot's add_do_property fallback.
+	_handler.create_node({"type": "Node3D", "name": "_McpTestArr", "parent_path": "/Main"})
+	var node := EditorInterface.get_edited_scene_root().get_node("_McpTestArr") as Node3D
+	var original := node.position
+
+	var result := _handler.set_property({
+		"path": "/Main/_McpTestArr",
+		"property": "position",
+		"value": [1, 2, 3],
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "Vector3")
+	assert_eq(node.position, original, "Position must be unchanged after a rejected coerce")
+	_undo_redo.undo()  # undo create
+
+
+func test_set_property_vector3_rejects_int() -> void:
+	## Issue #191: scalar input to a Vector3 slot is the most insidious
+	## case — Godot accepts the int and silently zero-fills.
+	_handler.create_node({"type": "Node3D", "name": "_McpTestInt", "parent_path": "/Main"})
+	var node := EditorInterface.get_edited_scene_root().get_node("_McpTestInt") as Node3D
+	var original := node.position
+
+	var result := _handler.set_property({
+		"path": "/Main/_McpTestInt",
+		"property": "position",
+		"value": 5,
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_eq(node.position, original, "Position must be unchanged after a rejected coerce")
+	_undo_redo.undo()  # undo create
+
+
+func test_set_property_color_rejects_array() -> void:
+	## Issue #191 mirror for Color targets.
+	_handler.create_node({
+		"type": "DirectionalLight3D",
+		"name": "_McpTestLight",
+		"parent_path": "/Main",
+	})
+	var result := _handler.set_property({
+		"path": "/Main/_McpTestLight",
+		"property": "light_color",
+		"value": [1, 0, 0],
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "Color")
+	_undo_redo.undo()  # undo create
+
+
+func test_set_property_vector3_accepts_json_string_dict() -> void:
+	## Issue #191: some MCP clients/middleware stringify nested-dict tool
+	## args (Cline's task_progress lookalikes, naive JSON-RPC bridges).
+	## Tolerate a JSON-encoded dict for compound targets so the call
+	## succeeds instead of silently zero-defaulting.
+	_handler.create_node({"type": "Node3D", "name": "_McpTestJsonV3", "parent_path": "/Main"})
+	var result := _handler.set_property({
+		"path": "/Main/_McpTestJsonV3",
+		"property": "position",
+		"value": '{"x": -8, "y": 4, "z": 1}',
+	})
+	assert_has_key(result, "data")
+	assert_true(result.data.undoable)
+	var node := EditorInterface.get_edited_scene_root().get_node("_McpTestJsonV3") as Node3D
+	assert_eq(node.position, Vector3(-8, 4, 1))
+	_undo_redo.undo()  # undo set
+	_undo_redo.undo()  # undo create
+
+
+func test_coerce_value_parses_json_string_for_vector3() -> void:
+	## Direct coercer check — JSON-encoded dict for a Vector3 slot must
+	## land as a real Vector3 (not pass through unchanged as a String).
+	var coerced = NodeHandler._coerce_value('{"x":1,"y":2,"z":3}', TYPE_VECTOR3)
+	assert_true(coerced is Vector3)
+	assert_eq(coerced, Vector3(1, 2, 3))
+
+
+func test_coerce_value_preserves_color_hex_string() -> void:
+	## The JSON-string parse path (#191) must not interfere with the
+	## existing Color-from-hex-string contract. Hex strings don't begin
+	## with `{` or `[`, so they bypass JSON.parse_string and go straight
+	## to the Color(value) constructor.
+	var coerced = NodeHandler._coerce_value("#ff0000", TYPE_COLOR)
+	assert_true(coerced is Color)
+	assert_eq(coerced.r, 1.0)
+	assert_eq(coerced.g, 0.0)
+	assert_eq(coerced.b, 0.0)
+
+
+func test_coerce_value_invalid_json_string_passes_through() -> void:
+	## Garbage JSON that begins with `{` shouldn't crash — JSON.parse_string
+	## returns null, the value stays as a String, and the caller's
+	## _check_coerced fires the loud error.
+	var coerced = NodeHandler._coerce_value("{not valid json}", TYPE_VECTOR3)
+	assert_true(coerced is String, "Unparseable JSON must flow through unchanged so the type check fires")
+
+
 func test_coerce_value_passes_right_shape_color() -> void:
 	var coerced = NodeHandler._coerce_value({"r": 1.0, "g": 0.5, "b": 0.0, "a": 1.0}, TYPE_COLOR)
 	assert_true(coerced is Color)

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -597,6 +597,43 @@ class TestNodeSetPropertyTool:
         assert result.data["old_value"] == 75
         assert result.data["undoable"] is True
 
+    async def test_set_property_dict_value_round_trips_intact(self, mcp_stack):
+        ## Issue #191 regression guard: Vector3 dicts must arrive at the
+        ## plugin as JSON objects, not as a stringified blob or coerced
+        ## primitive. The bug surfaces when middleware (or pydantic union
+        ## resolution) flattens the dict somewhere between the tool call
+        ## and the WebSocket frame; verifying the literal `params.value`
+        ## the plugin sees catches that drift before the GDScript-side
+        ## coercer ever runs.
+        client, plugin = mcp_stack
+        vec = {"x": -8.0, "y": 4.5, "z": 1.0}
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "set_property"
+            assert cmd["params"]["value"] == vec
+            assert isinstance(cmd["params"]["value"], dict)
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "path": "/Main/Player",
+                    "property": "position",
+                    "value": vec,
+                    "old_value": {"x": 0.0, "y": 0.0, "z": 0.0},
+                    "undoable": True,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "node_set_property",
+            {"path": "/Main/Player", "property": "position", "value": vec},
+        )
+        await task
+
+        assert result.data["value"] == vec
+        assert result.data["undoable"] is True
+
 
 # ---------------------------------------------------------------------------
 # node_rename


### PR DESCRIPTION
## Summary

Closes #191. `node_set_property` was returning `status=ok, undoable=true` for Vector3/Vector2/Color properties given uncoercible inputs (Array, scalar int, JSON-string-encoded dict, wrong-shape dict), but `add_do_property` silently default-constructed `Vector3.ZERO` so the actual mutation was data-corrupting (e.g. `position=[1,2,3]` became `(0,0,0)` on disk). The existing `_check_dict_coerce_failed` only fired for Dictionary inputs, so non-dict shapes sailed through to the silent-zero path.

## Fix

Three pieces, all in `plugin/addons/godot_ai/handlers/node_handler.gd` plus a mirror at `resource_handler.gd::_apply_resource_properties`:

1. **Broaden `_check_coerced`** to be safe-to-call for any `target_type` (early-return null when the target isn't `Vector2`/`Vector3`/`Color`), then use it from `set_property` and `_apply_resource_properties` instead of the narrower dict-only check. Now Array/scalar/JSON-string inputs to a Vector slot return `INVALID_PARAMS` with a `"Property 'X': must coerce to Vector3, got Array"` message instead of silently writing zero.

2. **Teach `_coerce_value` to JSON-parse String inputs** that begin with `{` or `[` for compound targets (`Vector2`/`3`/`Color`/`Array`/`Dictionary`). Handles middleware/clients that stringify nested-dict tool args (suggestion #2 from the issue). Hex Color strings still bypass to `Color(value)` since they don't begin with `{`/`[`.

3. **Extract `VECTORLIKE_TYPES` and `JSON_PARSE_STRING_TARGETS` as module consts** so the type-gate arrays aren't allocated on every `set_property` call (hot in `batch_execute`). GDScript doesn't intern array literals.

## Tests

- **GDScript** (`test_project/tests/test_node.gd`): rejects `[1,2,3]` and `5` to `position`, accepts `'{"x":-8,"y":4,"z":1}'` JSON-string and verifies `node.position == Vector3(-8,4,1)` (stored Variant check, not just response counts), preserves `"#ff0000"` hex Color, and verifies garbage JSON like `"{not valid json}"` passes through to the loud-error path.
- **Python integration** (`tests/integration/test_mcp_tools.py`): verifies a Vector3 dict round-trips through the FastMCP pipeline as a real `dict` (not stringified), guarding against pydantic union resolution or middleware flattening it before it reaches the plugin.

## Test plan
- [x] `pytest -q` — 564 passed (was 563; +1 new integration test)
- [x] `ruff check src/ tests/` — clean
- [x] GDScript tests added in `test_project/tests/test_node.gd` (7 new tests covering the previously-silent failure modes)
- [ ] Live smoke against running Godot editor — **not run**: this sandbox has no Godot binary. Reviewer running locally should `test_run suite=node` to confirm the new tests pass and that the existing `test_set_property_*` tests still pass.

## Out of scope

`Transform3D`/`Quaternion`/`Basis`/`Plane` are also compound types not currently in `_coerce_value` — they'd suffer the same silent-zero bug if an agent tried to set them. The doc comment on `_check_coerced` already says "extend the match alongside `_coerce_value` if you add a new coerce target" — leaving as a follow-up since #191 specifically calls out Vector2/3/Color.

https://claude.ai/code/session_0124t36fmiJtwQJeiER23uRd

---
_Generated by [Claude Code](https://claude.ai/code/session_0124t36fmiJtwQJeiER23uRd)_