### PR TITLE
fix(clients): verify Configure/Remove actually landed before reporting ok (#201)

### DIFF
--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -141,7 +141,38 @@ static func configure(id: String) -> Dictionary:
 	var client := McpClientRegistry.get_by_id(id)
 	if client == null:
 		return {"status": "error", "message": "Unknown client: %s" % id}
+	## Capture `url` once so a port flip in EditorSettings between write and
+	## verify can't trigger a spurious CONFIGURED_MISMATCH against an entry
+	## that just landed correctly.
 	var url := http_url()
+	var result := _dispatch_configure(client, url)
+	## Trust-but-verify: a strategy may report ok and have actually written the
+	## file, yet the entry is missing/stale on the read-back path — most often
+	## because the user's installed client is reading a different file than
+	## `path_template` resolves to (issue #201). Re-read the live state and
+	## surface a clear error before the dock reports a bogus green dot.
+	return _verify_post_state(client, result, McpClient.Status.CONFIGURED, url, "configure")
+
+
+static func check_status(id: String) -> McpClient.Status:
+	var client := McpClientRegistry.get_by_id(id)
+	if client == null:
+		return McpClient.Status.NOT_CONFIGURED
+	return _dispatch_check_status(client, http_url())
+
+
+static func remove(id: String) -> Dictionary:
+	var client := McpClientRegistry.get_by_id(id)
+	if client == null:
+		return {"status": "error", "message": "Unknown client: %s" % id}
+	var url := http_url()
+	var result := _dispatch_remove(client)
+	return _verify_post_state(client, result, McpClient.Status.NOT_CONFIGURED, url, "remove")
+
+
+# --- Strategy dispatch + verify (testable seam) --------------------------
+
+static func _dispatch_configure(client: McpClient, url: String) -> Dictionary:
 	match client.config_type:
 		"json":
 			return McpJsonStrategy.configure(client, SERVER_NAME, url)
@@ -149,14 +180,21 @@ static func configure(id: String) -> Dictionary:
 			return McpTomlStrategy.configure(client, SERVER_NAME, url)
 		"cli":
 			return McpCliStrategy.configure(client, SERVER_NAME, url)
-	return {"status": "error", "message": "Unknown config_type for %s: %s" % [id, client.config_type]}
+	return {"status": "error", "message": "Unknown config_type for %s: %s" % [client.id, client.config_type]}
 
 
-static func check_status(id: String) -> McpClient.Status:
-	var client := McpClientRegistry.get_by_id(id)
-	if client == null:
-		return McpClient.Status.NOT_CONFIGURED
-	var url := http_url()
+static func _dispatch_remove(client: McpClient) -> Dictionary:
+	match client.config_type:
+		"json":
+			return McpJsonStrategy.remove(client, SERVER_NAME)
+		"toml":
+			return McpTomlStrategy.remove(client, SERVER_NAME)
+		"cli":
+			return McpCliStrategy.remove(client, SERVER_NAME)
+	return {"status": "error", "message": "Unknown config_type for %s: %s" % [client.id, client.config_type]}
+
+
+static func _dispatch_check_status(client: McpClient, url: String) -> McpClient.Status:
 	match client.config_type:
 		"json":
 			return McpJsonStrategy.check_status(client, SERVER_NAME, url)
@@ -167,18 +205,32 @@ static func check_status(id: String) -> McpClient.Status:
 	return McpClient.Status.NOT_CONFIGURED
 
 
-static func remove(id: String) -> Dictionary:
-	var client := McpClientRegistry.get_by_id(id)
-	if client == null:
-		return {"status": "error", "message": "Unknown client: %s" % id}
-	match client.config_type:
-		"json":
-			return McpJsonStrategy.remove(client, SERVER_NAME)
-		"toml":
-			return McpTomlStrategy.remove(client, SERVER_NAME)
-		"cli":
-			return McpCliStrategy.remove(client, SERVER_NAME)
-	return {"status": "error", "message": "Unknown config_type for %s: %s" % [id, client.config_type]}
+## After a configure/remove returns ok, re-read the live status. If it doesn't
+## match `expected`, replace the result with an error that names the actual
+## status and the resolved config path so the user can self-diagnose. The
+## strategy's own error path is left untouched — already actionable.
+static func _verify_post_state(
+	client: McpClient,
+	result: Dictionary,
+	expected: McpClient.Status,
+	url: String,
+	action: String,
+) -> Dictionary:
+	if result.get("status") != "ok":
+		return result
+	var actual := _dispatch_check_status(client, url)
+	if actual == expected:
+		return result
+	var path := client.resolved_config_path()
+	var path_hint := "" if path.is_empty() else " Inspect %s and remove the godot-ai entry by hand if needed." % path
+	return {
+		"status": "error",
+		"message": "%s reported %s ok but verification still reads %s (expected %s).%s" % [
+			client.display_name, action,
+			McpClient.status_label(actual), McpClient.status_label(expected),
+			path_hint,
+		],
+	}
 
 
 static func manual_command(id: String) -> String:

--- a/plugin/addons/godot_ai/clients/_base.gd
+++ b/plugin/addons/godot_ai/clients/_base.gd
@@ -13,6 +13,22 @@ extends RefCounted
 ## banner instead of conflating it with "you never configured this client".
 enum Status { NOT_CONFIGURED, CONFIGURED, CONFIGURED_MISMATCH, ERROR }
 
+
+## Lowercase string label for a `Status` value. Single source of truth so the
+## MCP `client_status` tool, the dock, and the verify-after-write diagnostic
+## in `McpClientConfigurator` all emit the same names — agents pattern-match
+## against this set, so a fifth value being silently introduced would break
+## them.
+static func status_label(status: Status) -> String:
+	match status:
+		Status.CONFIGURED:
+			return "configured"
+		Status.NOT_CONFIGURED:
+			return "not_configured"
+		Status.CONFIGURED_MISMATCH:
+			return "configured_mismatch"
+	return "error"
+
 var id: String = ""                              ## stable key, e.g. "cursor"
 var display_name: String = ""                    ## "Cursor"
 var config_type: String = ""                     ## "json" | "toml" | "cli"

--- a/plugin/addons/godot_ai/handlers/client_handler.gd
+++ b/plugin/addons/godot_ai/handlers/client_handler.gd
@@ -33,18 +33,10 @@ func check_client_status(_params: Dictionary) -> Dictionary:
 	var clients := []
 	for client_id in McpClientConfigurator.client_ids():
 		var status := McpClientConfigurator.check_status(client_id)
-		var status_str := "error"
-		match status:
-			McpClient.Status.CONFIGURED:
-				status_str = "configured"
-			McpClient.Status.NOT_CONFIGURED:
-				status_str = "not_configured"
-			McpClient.Status.CONFIGURED_MISMATCH:
-				status_str = "configured_mismatch"
 		clients.append({
 			"id": client_id,
 			"display_name": McpClientConfigurator.client_display_name(client_id),
-			"status": status_str,
+			"status": McpClient.status_label(status),
 			"installed": McpClientConfigurator.is_installed(client_id),
 		})
 	return {"data": {"clients": clients}}

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -847,6 +847,113 @@ func test_toml_strategy_preserves_other_sections() -> void:
 	assert_contains(content, "[mcp_servers.\"godot-ai\"]")
 
 
+# ----- configure/remove verify-after-write (#201) -----
+#
+# A strategy returning `status: ok` is necessary but not sufficient — a write
+# can land on a file the user's installed client doesn't actually read (path
+# resolution mismatch), or a remove can be a silent no-op when the entry was
+# stored under an unexpected key. The facade re-reads live state after every
+# successful write so the dock surfaces a real error instead of a green dot
+# the user can't act on.
+
+func test_verify_post_state_passes_through_strategy_error() -> void:
+	## A strategy-level error must not be transmuted into a verification
+	## error — the original message is more actionable. Same client doesn't
+	## even need to be touched on the verify side.
+	var client := _make_test_json_client(_scratch_dir.path_join("verify_passthrough.json"))
+	var err_result := {"status": "error", "message": "original strategy failure"}
+	var got: Dictionary = McpClientConfigurator._verify_post_state(
+		client, err_result, McpClient.Status.CONFIGURED, _verify_test_url(), "configure",
+	)
+	assert_eq(got, err_result, "Verify must not rewrite strategy errors")
+
+
+func test_verify_post_state_returns_ok_when_actual_matches_expected() -> void:
+	var path := _scratch_dir.path_join("verify_match.json")
+	_remove_if_exists(path)
+	var client := _make_test_json_client(path)
+	var url := _verify_test_url()
+	# Establish CONFIGURED state on disk so the verify read sees what the
+	# strategy claims it wrote.
+	McpJsonStrategy.configure(client, McpClientConfigurator.SERVER_NAME, url)
+	var ok_result := {"status": "ok", "message": "wrote"}
+	var got: Dictionary = McpClientConfigurator._verify_post_state(
+		client, ok_result, McpClient.Status.CONFIGURED, url, "configure",
+	)
+	assert_eq(got, ok_result, "Verify must pass through ok results when state matches")
+
+
+func test_verify_post_state_errors_when_configure_did_not_land() -> void:
+	## The classic #201 shape: strategy reports ok but the entry isn't on
+	## disk after the fact (e.g. the strategy wrote to a stale temp file, or
+	## the read-back path resolves elsewhere). Surface a loud error with the
+	## resolved config path so the user can self-diagnose instead of staring
+	## at a green dot in the dock.
+	var path := _scratch_dir.path_join("verify_missing.json")
+	_remove_if_exists(path)
+	var client := _make_test_json_client(path)
+	# File doesn't exist → check_status returns NOT_CONFIGURED → verify
+	# rejects the spurious "ok".
+	var ok_result := {"status": "ok", "message": "claims to have written"}
+	var got: Dictionary = McpClientConfigurator._verify_post_state(
+		client, ok_result, McpClient.Status.CONFIGURED, _verify_test_url(), "configure",
+	)
+	assert_eq(got.get("status"), "error")
+	var msg: String = got.get("message", "")
+	assert_contains(msg, "not_configured", "Error must name the actual status: %s" % msg)
+	assert_contains(msg, "configured", "Error must name the expected status: %s" % msg)
+	assert_contains(msg, path, "Error must include the resolved config path: %s" % msg)
+
+
+func test_verify_post_state_errors_when_remove_left_entry_behind() -> void:
+	## Symmetric case: remove returns ok but the entry still parses on
+	## read-back. Most realistic in TOML clients with multiple aliases or
+	## JSON files where the user maintains a custom server_name we don't
+	## know about — but the contract is the same: never lie to the dock.
+	var path := _scratch_dir.path_join("verify_leftover.json")
+	_remove_if_exists(path)
+	var client := _make_test_json_client(path)
+	var url := _verify_test_url()
+	# Real configure so the entry is actually present.
+	McpJsonStrategy.configure(client, McpClientConfigurator.SERVER_NAME, url)
+	var ok_result := {"status": "ok", "message": "claims removed"}
+	var got: Dictionary = McpClientConfigurator._verify_post_state(
+		client, ok_result, McpClient.Status.NOT_CONFIGURED, url, "remove",
+	)
+	assert_eq(got.get("status"), "error")
+	var msg: String = got.get("message", "")
+	assert_contains(msg, "configured", "Error must name the actual status: %s" % msg)
+	assert_contains(msg, "not_configured", "Error must name the expected status: %s" % msg)
+	assert_contains(msg, path, "Error must include the resolved config path: %s" % msg)
+
+
+func test_verify_post_state_treats_drift_as_failure_after_configure() -> void:
+	## CONFIGURED_MISMATCH is "entry present but URL is wrong" — for a
+	## just-completed configure that wrote `http_url()`, drift means the
+	## write didn't actually update the URL. Treat as a verification
+	## failure so the dock can't show a green dot for stale state.
+	var path := _scratch_dir.path_join("verify_drift_after_configure.json")
+	_remove_if_exists(path)
+	var client := _make_test_json_client(path)
+	# Pre-seed an entry with a stale URL.
+	var seed := {"mcpServers": {McpClientConfigurator.SERVER_NAME: {"url": "http://stale/"}}}
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	f.store_string(JSON.stringify(seed))
+	f.close()
+	var ok_result := {"status": "ok", "message": "wrote — but didn't"}
+	var got: Dictionary = McpClientConfigurator._verify_post_state(
+		client, ok_result, McpClient.Status.CONFIGURED, _verify_test_url(), "configure",
+	)
+	assert_eq(got.get("status"), "error")
+	assert_contains(got.get("message", ""), "configured_mismatch")
+
+
+## Pinned URL for verify tests so a port flip in EditorSettings between
+## suite_setup and the assertion can't drift us from match to mismatch.
+func _verify_test_url() -> String:
+	return "http://127.0.0.1:%d/mcp" % McpClientConfigurator.DEFAULT_HTTP_PORT
+
+
 # ----- atomic write -----
 
 func test_atomic_write_replaces_existing_content() -> void:


### PR DESCRIPTION
Closes #201.

## Triage

Open issues at the time of this PR:

- **#201** — Reconfigure / Remove buttons "didn't work for me. I had to remove it manually." **Picked.** Single-issue PR. The other 6 open issues either have an in-flight PR (#191/#192/#193/#194 → PRs #195/#196/#197/#198/#199/#200) or are explicitly deferred (#181 large feature, #129 cleanup that says "out of scope").
- No bundle was justified — every other actionable issue is already claimed.

## Summary

User reported (issue #201) that the dock's **Reconfigure** and **Remove** buttons "didn't work" and they had to manually edit `mcp.json`. Tracing the flow surfaced an architectural gap: every strategy (`json` / `toml` / `cli`) returns `status: ok` and the dock's `_on_configure_client` / `_on_remove_client` immediately set the row to green/muted **without re-reading the file**. A strategy can return ok and still leave the desired end state unrealised:

- **Silent no-op on Remove**: `_json_strategy.gd::remove` only erases the entry if `holder.has(server_name)` is true; otherwise it returns ok without writing. Entry stored under any other key path silently survives.
- **Path-resolution mismatch**: write succeeds atomically, but the user's installed client reads a different file than `path_template` resolved to. Dock shows green; client still misses the entry.
- **Atomic write succeeded but content didn't change as expected**: extreme-edge race or filesystem quirk.

## Fix

`McpClientConfigurator` now re-reads `check_status` after every successful configure/remove and surfaces an error with the resolved config path when the live state doesn't match the expected end state. The URL is captured **once** at entry so a port flip in `EditorSettings` between write and verify can't trip a spurious `CONFIGURED_MISMATCH` against an entry that just landed correctly.

```gdscript
static func configure(id: String) -> Dictionary:
    var client := McpClientRegistry.get_by_id(id)
    if client == null: return {"status": "error", ...}
    var url := http_url()                              # captured once
    var result := _dispatch_configure(client, url)
    return _verify_post_state(client, result, McpClient.Status.CONFIGURED, url, "configure")
```

Diagnostic shape on verification failure:

```
Cline reported configure ok but verification still reads not_configured (expected configured). Inspect /Users/.../cline/mcp_settings.json and remove the godot-ai entry by hand if needed.
```

The user's symptom — green dot but no actual entry — becomes a red row + manual command panel, exactly the path the dock already has for genuine strategy errors.

## Refactor

- Strategy dispatch lifted out of `configure` / `remove` / `check_status` into private `_dispatch_configure(client, url)` / `_dispatch_remove(client)` / `_dispatch_check_status(client, url)` helpers. Cleaner verify wiring (the post-write check just calls `_dispatch_check_status` with the same captured URL) and one match-by-`config_type` per operation instead of inline-with-control-flow.
- Status-to-string label collapsed into a shared **`McpClient.status_label(Status)`** static method. `ClientHandler.check_client_status` was carrying a parallel match block (5 lines, exact duplicate semantics) that could drift out of sync with any future enum addition. The MCP `client_status` tool, the dock, and the new verify diagnostic now all emit the same names — agents already pattern-match against `["configured", "not_configured", "configured_mismatch", "error"]`, so a fifth value being silently introduced would break them.

## Tests

5 new GDScript tests in `test_project/tests/test_clients.gd` cover every branch of `_verify_post_state`:

- `test_verify_post_state_passes_through_strategy_error` — strategy error must not be transmuted into a verification error (original message is more actionable).
- `test_verify_post_state_returns_ok_when_actual_matches_expected` — happy path; strategy wrote correctly, check_status confirms, ok flows through unchanged.
- `test_verify_post_state_errors_when_configure_did_not_land` — the classic #201 shape: ok-result for a configure but the file isn't on disk → loud error with the resolved config path.
- `test_verify_post_state_errors_when_remove_left_entry_behind` — symmetric remove case: ok-result but the entry still parses on read-back.
- `test_verify_post_state_treats_drift_as_failure_after_configure` — `CONFIGURED_MISMATCH` post-configure means the write didn't update the URL; treated as a verification failure so the dock can't show a green dot for stale state.

Each error-path test asserts the diagnostic message names **both** actual and expected status **and** includes the resolved config path verbatim — guards against the "Counts instead of stored Variants" anti-pattern from CLAUDE.md (the test would still pass if the message just said "verification failed" without the diagnostic).

The 5 tests use a pinned `_verify_test_url()` helper so a port override in EditorSettings (set by another test in the suite) can't drift them between match and mismatch.

## Test plan

- [x] `pytest -q` — 563 passed, 0 failed
- [x] `ruff check src/ tests/` — clean
- [x] `script/ci-check-gdscript` — All GDScript files OK (no parse errors after the new tests + `_base.gd` static method addition)
- [ ] **Live smoke pending — sandbox has no Godot binary.** GDScript suite will run via CI's `script/ci-godot-tests`. Manual checks worth confirming when a human picks this up:
  - Configure a JSON-backed client (Cline / Cursor) — dock dot turns green, file written. Repeat — still green.
  - Manually corrupt the post-write file (delete the godot-ai entry while leaving the rest of `mcpServers`) and click Reconfigure — should still go green (configure rewrites the entry, verify reads it back).
  - Force a verify failure (e.g. write-protect the parent dir between write and verify) and confirm the dock surfaces the error with the resolved path in the row name.
  - `client_status` MCP tool returns the same status strings as before (`configured`, `not_configured`, `configured_mismatch`, `error`) — the shared `McpClient.status_label` helper preserves the contract.

## Notes / followups (deliberately not in this PR)

- The structural concern PR #195/#196 fixes (stale Callables after live plugin reload) is independent of this fix. The two stack cleanly: if `entry_builder` is stale, the strategy returns an error → verify pass-through preserves it. If the strategy succeeds but check_status sees stale `verify_entry`, that's a separate degradation worth its own follow-up — the verify step here will report `configured_mismatch` even though the write was correct, which is technically a false positive on a stale-callable system. In practice both paths look up the same `McpClient` from the registry, so they're either both fresh or both stale.
- The 5 new tests drive `_verify_post_state` directly. A future test that goes through `configure(id)` end-to-end against a real registered client would tighten the integration coverage, but doing so requires registering a synthetic client in `McpClientRegistry` (or temporarily mutating `_by_id`), which adds fragility for marginal gain over the existing strategy-level happy-path tests + new verify-helper tests.
- Issue text mentions "if there are several MCPs configured" — the multi-entry-in-one-file scenario was already covered by `test_json_strategy_preserves_other_servers` and `test_toml_strategy_preserves_other_sections`. This PR doesn't change that path; it just adds the verify safety net on top.

https://claude.ai/code/session_01BafwQPtzNJe7kjZja3fYdA

---
_Generated by [Claude Code](https://claude.ai/code/session_01BafwQPtzNJe7kjZja3fYdA)_