### PR TITLE
fix(dock): refresh drift banner after per-row Reconfigure

### DIFF
--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -1361,21 +1361,26 @@ func _on_tools_discard_confirmed() -> void:
 func _refresh_clients_summary() -> void:
 	# Count from row dot colors — `_apply_row_status` is the single source of
 	# truth, and reading colors avoids re-running filesystem-hitting status
-	# checks on every refresh.
+	# checks on every refresh. Also re-derives the drift banner from the same
+	# dots so per-row mutations (Configure/Reconfigure/Remove on a row in the
+	# Clients & Tools window) keep the dock-level banner in sync without an
+	# extra sweep — without this, the banner stays stale after a successful
+	# Reconfigure until the next focus-in or window-open sweep. See #166.
 	if _clients_summary_label == null:
 		return
 	var configured := 0
-	var mismatched := 0
-	for row in _client_rows.values():
-		var c := (row["dot"] as ColorRect).color
+	var mismatched_ids: Array[String] = []
+	for client_id in _client_rows:
+		var c := (_client_rows[client_id]["dot"] as ColorRect).color
 		if c == Color.GREEN:
 			configured += 1
 		elif c == COLOR_AMBER:
-			mismatched += 1
+			mismatched_ids.append(client_id)
 	var text := "%d / %d configured" % [configured, _client_rows.size()]
-	if mismatched > 0:
-		text += " (%d stale)" % mismatched
+	if mismatched_ids.size() > 0:
+		text += " (%d stale)" % mismatched_ids.size()
 	_clients_summary_label.text = text
+	_refresh_drift_banner(mismatched_ids)
 
 
 func _show_manual_command_for(client_id: String) -> void:
@@ -1399,17 +1404,14 @@ func _on_copy_manual_command(client_id: String) -> void:
 
 func _refresh_all_client_statuses() -> void:
 	## Single sweep: pass the per-client status through `_apply_row_status` for
-	## the row UI, then count mismatches for the drift banner. Each client's
-	## `check_status` is one filesystem read — fine to do all of them on the
-	## handful of trigger events documented in #166.
-	var mismatched_ids: Array[String] = []
+	## the row UI, then let `_refresh_clients_summary` re-derive the count and
+	## the drift banner from the dots. Each client's `check_status` is one
+	## filesystem read — fine to do all of them on the handful of trigger
+	## events documented in #166.
 	for client_id in _client_rows:
 		var status := McpClientConfigurator.check_status(client_id)
 		_apply_row_status(client_id, status)
-		if status == McpClient.Status.CONFIGURED_MISMATCH:
-			mismatched_ids.append(client_id)
 	_refresh_clients_summary()
-	_refresh_drift_banner(mismatched_ids)
 
 
 func _refresh_drift_banner(mismatched_ids: Array[String]) -> void:

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -110,6 +110,34 @@ func test_apply_row_status_renders_mismatch_as_amber_with_url_hint() -> void:
 		"Mismatched rows offer the same Reconfigure action as the banner")
 
 
+func test_drift_banner_clears_after_per_row_reconfigure() -> void:
+	## Regression: clicking Reconfigure on a row in the Clients & Tools window
+	## updates the row dot, but the dock-level drift banner used to stay stale
+	## ("Claude Code needs to be reconfigured") until the next sweep. The fix
+	## routes per-row mutations through `_refresh_clients_summary`, which now
+	## re-derives the banner from row dots so banner, summary count, and
+	## `_last_mismatched_ids` cache all stay in sync.
+	_dock._build_ui()
+	var any_id := McpClientConfigurator.client_ids()[0]
+
+	# Simulate a sweep finding this client mismatched.
+	_dock._apply_row_status(any_id, McpClient.Status.CONFIGURED_MISMATCH)
+	_dock._refresh_clients_summary()
+	assert_true(_dock._drift_banner.visible,
+		"Banner must surface once a row goes amber")
+	assert_eq(_dock._last_mismatched_ids, [any_id] as Array[String],
+		"Reconfigure-mismatched cache must reflect the amber row")
+
+	# Simulate the user clicking Reconfigure on that row in the full window —
+	# `_on_configure_client` flips the dot to green and calls summary refresh.
+	_dock._apply_row_status(any_id, McpClient.Status.CONFIGURED)
+	_dock._refresh_clients_summary()
+	assert_false(_dock._drift_banner.visible,
+		"Banner must clear once the last amber row is reconfigured")
+	assert_eq(_dock._last_mismatched_ids, [] as Array[String],
+		"Cache must drop the now-green client so a follow-up Reconfigure-mismatched click is a no-op")
+
+
 ## Shared fixture for the three version-label tests. Inject a Label + Button
 ## + Connection onto the dock so the pure refresh logic can be exercised
 ## without depending on whether the test environment resolves as user mode


### PR DESCRIPTION
## Summary
- Fix the dock summary banner ("Claude Code needs to be reconfigured") staying stale after a successful Reconfigure click on a row in the Clients & Tools window. The row dot flipped green but the banner kept its old text until the next sweep.
- Route the drift-banner refresh through `_refresh_clients_summary`, which already re-reads row dot colors (the single source of truth, set by `_apply_row_status`). Every per-row mutation handler already calls the summary, so banner + count + `_last_mismatched_ids` cache now stay in sync — no extra filesystem-hitting sweep, no new signal/bus needed (dock and window share state in one script).
- Add a regression test in `test_project/tests/test_dock.gd` that simulates a sweep finding an amber row, then a Reconfigure flipping it green, and asserts the banner clears and the cache is empty.

## Test plan
- [x] `script/ci-check-gdscript` passes (GDScript parses cleanly)
- [ ] In Godot: open `test_project/`, click "Clients & Tools", click Reconfigure on a row whose URL is stale; close window; verify the dock summary banner has cleared.
- [ ] `test_run suite=dock` — new `test_drift_banner_clears_after_per_row_reconfigure` passes alongside the existing drift-banner suite.

Surfaced incidentally during smoke of #196/#197 integration on 2026-04-25; not related to those PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
