### PR TITLE
feat(tools): promote node CRUD + batch_execute to Core (#194)

### DIFF
--- a/plugin/addons/godot_ai/tool_catalog.gd
+++ b/plugin/addons/godot_ai/tool_catalog.gd
@@ -10,12 +10,18 @@ extends RefCounted
 ## this file against actual tool registration and fails CI when they drift;
 ## the failure message prints the up-to-date catalog body for paste-over.
 ##
-## The five core tools are always registered and cannot be excluded — they
-## render as a single grayed-out "Core" row in the UI.
+## The core tools are always registered and cannot be excluded — they render
+## as a single grayed-out "Core" row in the UI.
 
 const CORE_TOOLS := [
+	"batch_execute",
 	"editor_state",
+	"node_create",
+	"node_delete",
 	"node_get_properties",
+	"node_rename",
+	"node_reparent",
+	"node_set_property",
 	"scene_get_hierarchy",
 	"session_activate",
 	"session_list",
@@ -31,7 +37,6 @@ const DOMAINS := [
 	{"id": "animation", "label": "animation", "count": 16, "tools": ["animation_add_method_track", "animation_add_property_track", "animation_create", "animation_create_simple", "animation_delete", "animation_get", "animation_list", "animation_play", "animation_player_create", "animation_preset_fade", "animation_preset_pulse", "animation_preset_shake", "animation_preset_slide", "animation_set_autoplay", "animation_stop", "animation_validate"]},
 	{"id": "audio", "label": "audio", "count": 6, "tools": ["audio_list", "audio_play", "audio_player_create", "audio_player_set_playback", "audio_player_set_stream", "audio_stop"]},
 	{"id": "autoload", "label": "autoload", "count": 3, "tools": ["autoload_add", "autoload_list", "autoload_remove"]},
-	{"id": "batch", "label": "batch", "count": 1, "tools": ["batch_execute"]},
 	{"id": "camera", "label": "camera", "count": 8, "tools": ["camera_apply_preset", "camera_configure", "camera_create", "camera_follow_2d", "camera_get", "camera_list", "camera_set_damping_2d", "camera_set_limits_2d"]},
 	{"id": "client", "label": "client", "count": 3, "tools": ["client_configure", "client_remove", "client_status"]},
 	{"id": "control", "label": "control", "count": 1, "tools": ["control_draw_recipe"]},
@@ -41,7 +46,7 @@ const DOMAINS := [
 	{"id": "filesystem", "label": "filesystem", "count": 4, "tools": ["filesystem_read_text", "filesystem_reimport", "filesystem_search", "filesystem_write_text"]},
 	{"id": "input_map", "label": "input_map", "count": 4, "tools": ["input_map_add_action", "input_map_bind_event", "input_map_list", "input_map_remove_action"]},
 	{"id": "material", "label": "material", "count": 8, "tools": ["material_apply_preset", "material_apply_to_node", "material_assign", "material_create", "material_get", "material_list", "material_set_param", "material_set_shader_param"]},
-	{"id": "node", "label": "node", "count": 12, "tools": ["node_add_to_group", "node_create", "node_delete", "node_duplicate", "node_find", "node_get_children", "node_get_groups", "node_move", "node_remove_from_group", "node_rename", "node_reparent", "node_set_property"]},
+	{"id": "node", "label": "node", "count": 7, "tools": ["node_add_to_group", "node_duplicate", "node_find", "node_get_children", "node_get_groups", "node_move", "node_remove_from_group"]},
 	{"id": "particle", "label": "particle", "count": 7, "tools": ["particle_apply_preset", "particle_create", "particle_get", "particle_restart", "particle_set_draw_pass", "particle_set_main", "particle_set_process"]},
 	{"id": "physics_shape", "label": "physics_shape", "count": 1, "tools": ["physics_shape_autofit"]},
 	{"id": "project", "label": "project", "count": 4, "tools": ["project_run", "project_settings_get", "project_settings_set", "project_stop"]},

--- a/src/godot_ai/server.py
+++ b/src/godot_ai/server.py
@@ -149,6 +149,7 @@ def create_server(
     register_editor_tools(mcp, include_non_core="editor" not in exclude)
     register_scene_tools(mcp, include_non_core="scene" not in exclude)
     register_node_tools(mcp, include_non_core="node" not in exclude)
+    register_batch_tools(mcp, include_non_core="batch" not in exclude)
 
     ## Non-core-bearing domains: dropped wholesale when excluded.
     if "project" not in exclude:
@@ -169,8 +170,6 @@ def create_server(
         register_input_map_tools(mcp)
     if "testing" not in exclude:
         register_testing_tools(mcp)
-    if "batch" not in exclude:
-        register_batch_tools(mcp)
     if "ui" not in exclude:
         register_ui_tools(mcp)
     if "control" not in exclude:

--- a/src/godot_ai/tools/batch.py
+++ b/src/godot_ai/tools/batch.py
@@ -8,11 +8,15 @@ from fastmcp import Context, FastMCP
 
 from godot_ai.handlers import batch as batch_handlers
 from godot_ai.runtime.direct import DirectRuntime
-from godot_ai.tools import DEFER_META, JsonCoerced
+from godot_ai.tools import JsonCoerced
 
 
-def register_batch_tools(mcp: FastMCP) -> None:
-    @mcp.tool(meta=DEFER_META)
+def register_batch_tools(mcp: FastMCP, *, include_non_core: bool = True) -> None:
+    ## batch has no non-core tools — `include_non_core` is accepted for a
+    ## uniform call signature across core-bearing domains.
+    del include_non_core
+
+    @mcp.tool()
     async def batch_execute(
         ctx: Context,
         commands: Annotated[list[dict], JsonCoerced],

--- a/src/godot_ai/tools/domains.py
+++ b/src/godot_ai/tools/domains.py
@@ -52,23 +52,32 @@ DOMAINS: tuple[str, ...] = (
 ## Domains that contain at least one core (always-loaded) tool. When the
 ## user excludes one of these, only its non-core tools are dropped; the
 ## core tool is still registered.
-CORE_BEARING_DOMAINS: frozenset[str] = frozenset({"session", "editor", "scene", "node"})
+CORE_BEARING_DOMAINS: frozenset[str] = frozenset({"session", "editor", "scene", "node", "batch"})
 
-## The 5 core tools that survive any exclusion. Displayed as a disabled
-## "Core" row in the plugin UI. Order mirrors the flat namespace the
-## server exposes; not functionally significant.
+## Core tools that survive any exclusion — the minimum viable agent surface
+## (read state, build and edit scene trees, compose multi-step edits).
+## Displayed as a disabled "Core" row in the plugin UI. Order mirrors the
+## flat namespace the server exposes; not functionally significant.
 CORE_TOOLS: tuple[str, ...] = (
     "session_list",
     "session_activate",
     "editor_state",
     "scene_get_hierarchy",
     "node_get_properties",
+    "node_create",
+    "node_delete",
+    "node_set_property",
+    "node_reparent",
+    "node_rename",
+    "batch_execute",
 )
 
-## Domains the user can toggle off. `session` has no non-core tools, so
-## excluding it would be a no-op; we reject it up front so an accidental
-## `--exclude-domains session` doesn't silently do nothing.
-EXCLUDABLE_DOMAINS: frozenset[str] = frozenset(DOMAINS) - {"session"}
+## Domains the user can toggle off. A domain is excludable iff at least one
+## of its tools is non-core; if every tool is in CORE_TOOLS, excluding the
+## domain would be a no-op — we reject those up front so an accidental
+## `--exclude-domains session` doesn't silently do nothing. When a future
+## domain ends up fully-core, add it here.
+EXCLUDABLE_DOMAINS: frozenset[str] = frozenset(DOMAINS) - {"session", "batch"}
 
 
 def parse_exclude_list(raw: str | Iterable[str] | None) -> set[str]:

--- a/src/godot_ai/tools/node.py
+++ b/src/godot_ai/tools/node.py
@@ -24,10 +24,7 @@ def register_node_tools(mcp: FastMCP, *, include_non_core: bool = True) -> None:
         runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await node_handlers.node_get_properties(runtime, path=path)
 
-    if not include_non_core:
-        return
-
-    @mcp.tool(meta=DEFER_META)
+    @mcp.tool()
     async def node_create(
         ctx: Context,
         type: str = "",
@@ -66,6 +63,133 @@ def register_node_tools(mcp: FastMCP, *, include_non_core: bool = True) -> None:
             scene_path=scene_path,
             scene_file=scene_file,
         )
+
+    @mcp.tool()
+    async def node_delete(
+        ctx: Context, path: str, scene_file: str = "", session_id: str = ""
+    ) -> dict:
+        """Delete a node from the scene tree.
+
+        Removes the node at the given path. This operation is undoable
+        via Ctrl+Z in the Godot editor. Cannot delete the scene root.
+
+        Args:
+            path: Scene path of the node to delete (e.g. "/Main/Enemy").
+            scene_file: Optional "res://..." path. When non-empty, the mutation
+                fails with EDITED_SCENE_MISMATCH if the editor's current scene
+                doesn't match — use it to guard multi-call sequences against
+                silent scene-drift between calls.
+            session_id: Optional Godot session to target. Empty = active session.
+        """
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
+        return await node_handlers.node_delete(runtime, path=path, scene_file=scene_file)
+
+    @mcp.tool()
+    async def node_set_property(
+        ctx: Context,
+        path: str,
+        property: str,
+        value: str | int | float | bool | dict | list | None,
+        scene_file: str = "",
+        session_id: str = "",
+    ) -> dict:
+        """Set a property on a node.
+
+        Coerces `value` to match the property's declared type:
+
+        - Vector2/Vector3: dict with x/y/z keys
+        - Color: dict with r/g/b/a keys, or hex string ("#ff0000")
+        - NodePath: string ("../Other/Node")
+        - Resource: res:// path string (loads and assigns); pass null or "" to clear.
+          For a fresh built-in Resource instance, pass a dict with a "__class__"
+          key — e.g. value={"__class__": "BoxMesh", "size": {"x": 2, "y": 2, "z": 2}}
+          instantiates a BoxMesh with that size and assigns it. See resource_create
+          for more control (save to .tres, validation errors).
+        - StringName: plain string
+        - Array/Dictionary: pass a JSON list/object
+        - bool/int/float: JSON primitives
+
+        Args:
+            path: Scene path of the node (e.g. "/Main/Camera3D").
+            property: Property name (e.g. "fov", "position", "visible", "mesh", "remote_path").
+            value: New value for the property. Pass null (or "" for Resource properties) to clear.
+            scene_file: Optional "res://..." path. When non-empty, the mutation
+                fails with EDITED_SCENE_MISMATCH if the editor's current scene
+                doesn't match — use it to guard multi-call sequences against
+                silent scene-drift between calls.
+            session_id: Optional Godot session to target. Empty = active session.
+        """
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
+        return await node_handlers.node_set_property(
+            runtime,
+            path=path,
+            property=property,
+            value=value,
+            scene_file=scene_file,
+        )
+
+    @mcp.tool()
+    async def node_reparent(
+        ctx: Context,
+        path: str,
+        new_parent: str,
+        scene_file: str = "",
+        session_id: str = "",
+    ) -> dict:
+        """Move a node to a new parent in the scene tree.
+
+        Reparents the node, preserving its children. Cannot reparent the
+        scene root or move a node to one of its own descendants.
+
+        Args:
+            path: Scene path of the node to move (e.g. "/Main/Player").
+            new_parent: Scene path of the new parent (e.g. "/Main/World").
+            scene_file: Optional "res://..." path. When non-empty, the mutation
+                fails with EDITED_SCENE_MISMATCH if the editor's current scene
+                doesn't match — use it to guard multi-call sequences against
+                silent scene-drift between calls.
+            session_id: Optional Godot session to target. Empty = active session.
+        """
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
+        return await node_handlers.node_reparent(
+            runtime, path=path, new_parent=new_parent, scene_file=scene_file
+        )
+
+    @mcp.tool()
+    async def node_rename(
+        ctx: Context,
+        path: str,
+        new_name: str,
+        scene_file: str = "",
+        session_id: str = "",
+    ) -> dict:
+        """Rename a node in the scene tree.
+
+        Changes the node's `name`. Fails if a sibling already has that name,
+        or if the name contains `/`, `:`, or `@`. Cannot rename the scene root.
+
+        Note: `NodePath` properties on OTHER nodes that pointed at this node
+        (e.g. a camera's `remote_path`) will not be auto-updated. Scripts that
+        reference this node by name (`$OldName`, `get_node("OldName")`) also
+        need manual fixes. Children of the renamed node keep working because
+        their paths are relative.
+
+        Args:
+            path: Scene path of the node to rename (e.g. "/Main/Player").
+            new_name: New name for the node (e.g. "Hero").
+            scene_file: Optional "res://..." path. When non-empty, the mutation
+                fails with EDITED_SCENE_MISMATCH if the editor's current scene
+                doesn't match — use it to guard multi-call sequences against
+                silent scene-drift between calls.
+            session_id: Optional Godot session to target. Empty = active session.
+        """
+        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
+        return await node_handlers.node_rename(
+            runtime, path=path, new_name=new_name, scene_file=scene_file
+        )
+
+    if not include_non_core:
+        return
 
     @mcp.tool(meta=DEFER_META)
     async def node_find(
@@ -126,130 +250,6 @@ def register_node_tools(mcp: FastMCP, *, include_non_core: bool = True) -> None:
         """
         runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await node_handlers.node_get_groups(runtime, path=path)
-
-    @mcp.tool(meta=DEFER_META)
-    async def node_delete(
-        ctx: Context, path: str, scene_file: str = "", session_id: str = ""
-    ) -> dict:
-        """Delete a node from the scene tree.
-
-        Removes the node at the given path. This operation is undoable
-        via Ctrl+Z in the Godot editor. Cannot delete the scene root.
-
-        Args:
-            path: Scene path of the node to delete (e.g. "/Main/Enemy").
-            scene_file: Optional "res://..." path. When non-empty, the mutation
-                fails with EDITED_SCENE_MISMATCH if the editor's current scene
-                doesn't match — use it to guard multi-call sequences against
-                silent scene-drift between calls.
-            session_id: Optional Godot session to target. Empty = active session.
-        """
-        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
-        return await node_handlers.node_delete(runtime, path=path, scene_file=scene_file)
-
-    @mcp.tool(meta=DEFER_META)
-    async def node_reparent(
-        ctx: Context,
-        path: str,
-        new_parent: str,
-        scene_file: str = "",
-        session_id: str = "",
-    ) -> dict:
-        """Move a node to a new parent in the scene tree.
-
-        Reparents the node, preserving its children. Cannot reparent the
-        scene root or move a node to one of its own descendants.
-
-        Args:
-            path: Scene path of the node to move (e.g. "/Main/Player").
-            new_parent: Scene path of the new parent (e.g. "/Main/World").
-            scene_file: Optional "res://..." path. When non-empty, the mutation
-                fails with EDITED_SCENE_MISMATCH if the editor's current scene
-                doesn't match — use it to guard multi-call sequences against
-                silent scene-drift between calls.
-            session_id: Optional Godot session to target. Empty = active session.
-        """
-        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
-        return await node_handlers.node_reparent(
-            runtime, path=path, new_parent=new_parent, scene_file=scene_file
-        )
-
-    @mcp.tool(meta=DEFER_META)
-    async def node_set_property(
-        ctx: Context,
-        path: str,
-        property: str,
-        value: str | int | float | bool | dict | list | None,
-        scene_file: str = "",
-        session_id: str = "",
-    ) -> dict:
-        """Set a property on a node.
-
-        Coerces `value` to match the property's declared type:
-
-        - Vector2/Vector3: dict with x/y/z keys
-        - Color: dict with r/g/b/a keys, or hex string ("#ff0000")
-        - NodePath: string ("../Other/Node")
-        - Resource: res:// path string (loads and assigns); pass null or "" to clear.
-          For a fresh built-in Resource instance, pass a dict with a "__class__"
-          key — e.g. value={"__class__": "BoxMesh", "size": {"x": 2, "y": 2, "z": 2}}
-          instantiates a BoxMesh with that size and assigns it. See resource_create
-          for more control (save to .tres, validation errors).
-        - StringName: plain string
-        - Array/Dictionary: pass a JSON list/object
-        - bool/int/float: JSON primitives
-
-        Args:
-            path: Scene path of the node (e.g. "/Main/Camera3D").
-            property: Property name (e.g. "fov", "position", "visible", "mesh", "remote_path").
-            value: New value for the property. Pass null (or "" for Resource properties) to clear.
-            scene_file: Optional "res://..." path. When non-empty, the mutation
-                fails with EDITED_SCENE_MISMATCH if the editor's current scene
-                doesn't match — use it to guard multi-call sequences against
-                silent scene-drift between calls.
-            session_id: Optional Godot session to target. Empty = active session.
-        """
-        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
-        return await node_handlers.node_set_property(
-            runtime,
-            path=path,
-            property=property,
-            value=value,
-            scene_file=scene_file,
-        )
-
-    @mcp.tool(meta=DEFER_META)
-    async def node_rename(
-        ctx: Context,
-        path: str,
-        new_name: str,
-        scene_file: str = "",
-        session_id: str = "",
-    ) -> dict:
-        """Rename a node in the scene tree.
-
-        Changes the node's `name`. Fails if a sibling already has that name,
-        or if the name contains `/`, `:`, or `@`. Cannot rename the scene root.
-
-        Note: `NodePath` properties on OTHER nodes that pointed at this node
-        (e.g. a camera's `remote_path`) will not be auto-updated. Scripts that
-        reference this node by name (`$OldName`, `get_node("OldName")`) also
-        need manual fixes. Children of the renamed node keep working because
-        their paths are relative.
-
-        Args:
-            path: Scene path of the node to rename (e.g. "/Main/Player").
-            new_name: New name for the node (e.g. "Hero").
-            scene_file: Optional "res://..." path. When non-empty, the mutation
-                fails with EDITED_SCENE_MISMATCH if the editor's current scene
-                doesn't match — use it to guard multi-call sequences against
-                silent scene-drift between calls.
-            session_id: Optional Godot session to target. Empty = active session.
-        """
-        runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
-        return await node_handlers.node_rename(
-            runtime, path=path, new_name=new_name, scene_file=scene_file
-        )
 
     @mcp.tool(meta=DEFER_META)
     async def node_duplicate(

--- a/tests/unit/test_tool_domains.py
+++ b/tests/unit/test_tool_domains.py
@@ -63,14 +63,20 @@ def test_parse_rejects_core_only_session_domain():
         parse_exclude_list("session")
 
 
+def test_parse_rejects_core_only_batch_domain():
+    ## `batch` is all-core — same reasoning as session.
+    with pytest.raises(ValueError, match="batch"):
+        parse_exclude_list("batch")
+
+
 def test_core_bearing_domains_are_all_known():
     assert CORE_BEARING_DOMAINS <= set(DOMAINS)
 
 
-def test_excludable_domains_excludes_session_only():
-    ## session has only core tools → never excludable. Every other registered
-    ## domain must be excludable.
-    assert EXCLUDABLE_DOMAINS == set(DOMAINS) - {"session"}
+def test_excludable_domains_excludes_all_core_only_domains():
+    ## session and batch have only core tools → never excludable. Every other
+    ## registered domain must be excludable.
+    assert EXCLUDABLE_DOMAINS == set(DOMAINS) - {"session", "batch"}
 
 
 # --- create_server() filtering ---
@@ -94,13 +100,15 @@ def test_create_server_drops_whole_non_core_domain():
 
 
 def test_create_server_preserves_core_when_core_bearing_domain_excluded():
-    ## Excluding `node` drops node_create, node_find, … but keeps
+    ## Excluding `node` drops node_find, node_duplicate, … but keeps the
+    ## node CRUD core tools (node_create, node_set_property, …) and
     ## node_get_properties. Same for editor/scene.
     trimmed = set(_list_tools(create_server(exclude_domains={"editor", "scene", "node"})))
     for core_name in CORE_TOOLS:
         assert core_name in trimmed, f"{core_name} should survive exclusion"
     ## And the non-core members really are gone.
-    assert "node_create" not in trimmed
+    assert "node_find" not in trimmed
+    assert "node_duplicate" not in trimmed
     assert "editor_selection_get" not in trimmed
     assert "scene_open" not in trimmed
 


### PR DESCRIPTION
## Summary

Closes #194.

The previous Core tier (`editor_state`, `scene_get_hierarchy`, `node_get_properties`, `session_list`, `session_activate`) was observation-only. An agent that shrunk the tool set to fit a client cap (e.g. Antigravity's 100-tool limit) by un-checking everything except Core could inspect a scene but couldn't change it — no `node_create`, no `node_set_property`, no `batch_execute`. That's not a useful baseline.

This promotes the basic write loop into Core so the always-on tier is the minimum viable agent surface, not the minimum readable surface.

**Promoted to `CORE_TOOLS`:**
- `node_create`, `node_delete`, `node_set_property`, `node_reparent`, `node_rename` (CRUD primitives — no readable substitute)
- `batch_execute` (the multiplier that makes a 100-tool budget tractable)

**Domain bookkeeping:**
- `batch` joins `CORE_BEARING_DOMAINS` alongside `session`, `editor`, `scene`, `node`.
- `batch` is removed from `EXCLUDABLE_DOMAINS` (same logic as `session`: every tool in the domain is core, so excluding it would be a silent no-op — we hard-fail in `parse_exclude_list` instead).
- `register_batch_tools` accepts an `include_non_core` kwarg for uniform call signature with the other core-bearing registrars (mirrors `register_session_tools`).

**Not promoted** (recoverable from `scene_get_hierarchy` or otherwise non-essential):
- `node_find`, `node_get_children`, `node_get_groups`, `node_duplicate`, `node_move`, `node_add_to_group`, `node_remove_from_group`

`script_attach` / `script_create` were called out as a possible follow-up in #194 ("agent that can build a scene tree but not attach behavior is still half-useful") — left for a separate PR per the issue's own suggestion.

## Files

- `src/godot_ai/tools/domains.py` — extends `CORE_TOOLS` (5 → 11), adds `"batch"` to `CORE_BEARING_DOMAINS`, removes it from `EXCLUDABLE_DOMAINS`. Tightens the comment to state the derivation rule for fully-core domains.
- `src/godot_ai/tools/node.py` — moves 5 tool definitions above the `if not include_non_core: return` gate; drops `meta=DEFER_META`. Bodies/signatures unchanged.
- `src/godot_ai/tools/batch.py` — adds uniform `include_non_core` flag (no-op for now), drops `meta=DEFER_META`.
- `src/godot_ai/server.py` — moves `register_batch_tools` into the core-bearing block.
- `plugin/addons/godot_ai/tool_catalog.gd` — adds 6 tools to `CORE_TOOLS`, removes the `batch` domain row, trims the `node` domain entry (12 → 7).
- `tests/unit/test_tool_domains.py` — adds `test_parse_rejects_core_only_batch_domain`; generalizes the "session is the only non-excludable domain" test; updates `test_create_server_preserves_core_when_core_bearing_domain_excluded` to use `node_find`/`node_duplicate` as the "really gone" sentinels (since `node_create` is now core).

## Test plan

- [x] `pytest -v` — 564/564 passing locally
- [x] `ruff check src/ tests/` — clean
- [x] `tests/unit/test_tool_domains.py::test_gdscript_catalog_matches_python_registration` — parity test passing (this is the load-bearing check that the GDScript mirror in `tool_catalog.gd` matches actual Python registration)
- [x] `/simplify` — three reviewer agents in parallel; only nit was a comment polish, applied
- [x] `/review` — approved

**Live Godot smoke test was not run** — no Godot binary was available in this CI environment. Mitigations:
- The change is metadata-only on the Python side: dropping `meta=DEFER_META` on 6 decorators and shifting their position relative to the `include_non_core` gate. No GDScript handler logic changed.
- The catalog parity test re-parses `tool_catalog.gd` and matches it against live `create_server().list_tools()` — a drift in the GDScript mirror would fail CI.
- Maintainers should still spot-check in a live editor before merging: open the dock's Tools tab, verify the Core row shows the 11 tools and the `batch` domain row is gone, the `node` domain shows 7 non-core tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GaZQR3eNyZJPQEhd1Rt2KU)_