### PR TITLE
fix(server): accept stringified params on *_manage rollups (#206)

### DIFF
--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -203,6 +203,16 @@ func set_property(params: Dictionary) -> Dictionary:
 
 	var instantiated_resource := false
 
+	# Some MCP clients (Cline) stringify the documented {"__class__": "BoxMesh", ...}
+	# value before sending. Promote that string back to a Dictionary here so the
+	# `__class__` branch below handles it, instead of the next branch treating
+	# the JSON blob as a res:// path and emitting "Resource not found: {...}".
+	# See #206.
+	if target_type == TYPE_OBJECT and value is String and value.begins_with("{"):
+		var json := JSON.new()
+		if json.parse(value) == OK and json.data is Dictionary and (json.data as Dictionary).has("__class__"):
+			value = json.data
+
 	if target_type == TYPE_OBJECT and value is String:
 		if value == "":
 			value = null

--- a/src/godot_ai/middleware/__init__.py
+++ b/src/godot_ai/middleware/__init__.py
@@ -6,5 +6,10 @@ from godot_ai.middleware.client_wrapper_kwargs import (
     CLIENT_WRAPPER_KWARGS,
     StripClientWrapperKwargs,
 )
+from godot_ai.middleware.parse_stringified_params import ParseStringifiedParams
 
-__all__ = ["CLIENT_WRAPPER_KWARGS", "StripClientWrapperKwargs"]
+__all__ = [
+    "CLIENT_WRAPPER_KWARGS",
+    "ParseStringifiedParams",
+    "StripClientWrapperKwargs",
+]

--- a/src/godot_ai/middleware/parse_stringified_params.py
+++ b/src/godot_ai/middleware/parse_stringified_params.py
@@ -1,0 +1,51 @@
+"""Decode stringified ``params`` on ``<domain>_manage`` calls before validation.
+
+PR #203 collapsed ~118 per-verb tools into 39 named verbs plus per-domain
+``<domain>_manage`` rollups. Each rollup takes ``op: Literal[...]`` and
+``params: dict[str, Any] | None``, validated strictly by Pydantic.
+
+Some MCP clients (Cline observed in the wild) auto-serialize nested-object
+arguments before sending. Their ``tools/call`` arrives with
+``arguments["params"]`` as a JSON string, and Pydantic strict-mode rejects
+the call before any handler runs. This middleware intercepts ``*_manage``
+calls and JSON-decodes a string ``params`` slot in place, so downstream
+validation sees the dict the client meant to send. See #206.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+from fastmcp.tools.base import ToolResult
+from mcp.types import CallToolRequestParams
+
+logger = logging.getLogger(__name__)
+
+
+class ParseStringifiedParams(Middleware):
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[CallToolRequestParams],
+        call_next: CallNext[CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        arguments = context.message.arguments
+        if arguments and context.message.name.endswith("_manage"):
+            raw = arguments.get("params")
+            if isinstance(raw, str):
+                try:
+                    parsed = json.loads(raw)
+                except json.JSONDecodeError:
+                    ## Leave untouched so Pydantic surfaces a normal
+                    ## validation error rather than a confusing one
+                    ## triggered by a half-decoded value.
+                    pass
+                else:
+                    arguments["params"] = parsed
+                    logger.debug(
+                        "Decoded stringified params on %s (%d chars)",
+                        context.message.name,
+                        len(raw),
+                    )
+        return await call_next(context)

--- a/src/godot_ai/server.py
+++ b/src/godot_ai/server.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from fastmcp import FastMCP
 
 from godot_ai.godot_client.client import GodotClient
-from godot_ai.middleware import StripClientWrapperKwargs
+from godot_ai.middleware import ParseStringifiedParams, StripClientWrapperKwargs
 from godot_ai.resources.editor import register_editor_resources
 from godot_ai.resources.library import register_library_resources
 from godot_ai.resources.nodes import register_node_resources
@@ -144,6 +144,11 @@ def create_server(
     ## Tolerate known client-injected wrapper kwargs (Cline's task_progress,
     ## etc.) so strict pydantic schemas don't reject every call. See #193.
     mcp.add_middleware(StripClientWrapperKwargs())
+
+    ## Decode stringified ``params`` on ``<domain>_manage`` calls before
+    ## strict-mode Pydantic rejects them. Some clients (Cline) auto-serialize
+    ## nested objects. See #206.
+    mcp.add_middleware(ParseStringifiedParams())
 
     exclude = set(exclude_domains or ())
     if exclude:

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -5974,3 +5974,62 @@ class TestControlDrawRecipeTool:
             },
         )
         await task
+
+
+# ---------------------------------------------------------------------------
+# *_manage with stringified params (#206)
+# ---------------------------------------------------------------------------
+
+
+class TestManageRollupAcceptsStringifiedParams:
+    async def test_scene_manage_with_stringified_params(self, mcp_stack):
+        """Cline-style stringified params dict reaches the handler intact."""
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "get_open_scenes"
+            await plugin.send_response(
+                cmd["request_id"],
+                {"scenes": ["res://main.tscn"], "current": "res://main.tscn"},
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "scene_manage",
+            {"op": "get_roots", "params": "{}"},
+        )
+        await task
+
+        assert result.data["current"] == "res://main.tscn"
+
+    async def test_scene_manage_with_stringified_params_carrying_values(self, mcp_stack):
+        """Stringified params with real keys land in the underlying handler."""
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "create_scene"
+            assert cmd["params"]["path"] == "res://demo.tscn"
+            assert cmd["params"]["root_type"] == "Node3D"
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "path": "res://demo.tscn",
+                    "root_type": "Node3D",
+                    "root_name": "demo",
+                    "undoable": False,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "scene_manage",
+            {
+                "op": "create",
+                "params": '{"path": "res://demo.tscn", "root_type": "Node3D"}',
+            },
+        )
+        await task
+
+        assert result.data["path"] == "res://demo.tscn"

--- a/tests/unit/test_middleware_parse_stringified_params.py
+++ b/tests/unit/test_middleware_parse_stringified_params.py
@@ -1,0 +1,137 @@
+"""Unit tests for the ParseStringifiedParams middleware (#206)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from mcp.types import CallToolRequestParams
+
+from godot_ai.middleware import ParseStringifiedParams
+
+
+@dataclass
+class _FakeContext:
+    message: CallToolRequestParams
+
+
+async def _record_arguments_call_next(seen: list[dict[str, Any] | None]):
+    async def _call_next(context: _FakeContext) -> str:
+        seen.append(context.message.arguments)
+        return "ok"
+
+    return _call_next
+
+
+class TestParseStringifiedParams:
+    async def test_decodes_string_params_on_manage_call(self):
+        seen: list[dict | None] = []
+        mw = ParseStringifiedParams()
+        ctx = _FakeContext(
+            message=CallToolRequestParams(
+                name="resource_manage",
+                arguments={
+                    "op": "create",
+                    "params": '{"type": "BoxMesh", "properties": {"size": {"x": 5}}}',
+                },
+            )
+        )
+        result = await mw.on_call_tool(ctx, await _record_arguments_call_next(seen))
+
+        assert result == "ok"
+        assert seen == [
+            {
+                "op": "create",
+                "params": {"type": "BoxMesh", "properties": {"size": {"x": 5}}},
+            }
+        ]
+
+    async def test_passes_through_dict_params_unchanged(self):
+        seen: list[dict | None] = []
+        mw = ParseStringifiedParams()
+        original = {"op": "list", "params": {"limit": 10}}
+        ctx = _FakeContext(
+            message=CallToolRequestParams(name="session_manage", arguments=original)
+        )
+        await mw.on_call_tool(ctx, await _record_arguments_call_next(seen))
+
+        ## Same dict identity: middleware mustn't reallocate when there's
+        ## nothing to decode.
+        assert seen[0] is ctx.message.arguments
+        assert seen[0] == original
+
+    async def test_does_not_touch_non_manage_tool_calls(self):
+        ## Flat-arg tools that legitimately take a string ``params`` slot
+        ## (none today, but the boundary should hold) must reach the handler
+        ## with the raw string. Limiting decode to ``*_manage`` gives us a
+        ## single, narrow slot to reason about.
+        seen: list[dict | None] = []
+        mw = ParseStringifiedParams()
+        ctx = _FakeContext(
+            message=CallToolRequestParams(
+                name="node_set_property",
+                arguments={"params": '{"x": 1}'},
+            )
+        )
+        await mw.on_call_tool(ctx, await _record_arguments_call_next(seen))
+        assert seen == [{"params": '{"x": 1}'}]
+
+    async def test_invalid_json_left_for_pydantic_to_reject(self):
+        ## A genuine string-typed param that happens to look like JSON but
+        ## doesn't parse should reach Pydantic untouched, so the user gets
+        ## a normal validation error instead of a decoder traceback.
+        seen: list[dict | None] = []
+        mw = ParseStringifiedParams()
+        ctx = _FakeContext(
+            message=CallToolRequestParams(
+                name="resource_manage",
+                arguments={"op": "create", "params": "{not valid json"},
+            )
+        )
+        await mw.on_call_tool(ctx, await _record_arguments_call_next(seen))
+        assert seen == [{"op": "create", "params": "{not valid json"}]
+
+    async def test_handles_none_arguments(self):
+        seen: list[dict | None] = []
+        mw = ParseStringifiedParams()
+        ctx = _FakeContext(
+            message=CallToolRequestParams(name="editor_state", arguments=None)
+        )
+        await mw.on_call_tool(ctx, await _record_arguments_call_next(seen))
+        assert seen == [None]
+
+    async def test_handles_missing_params_key(self):
+        seen: list[dict | None] = []
+        mw = ParseStringifiedParams()
+        ctx = _FakeContext(
+            message=CallToolRequestParams(name="session_manage", arguments={"op": "list"})
+        )
+        await mw.on_call_tool(ctx, await _record_arguments_call_next(seen))
+        assert seen == [{"op": "list"}]
+
+    async def test_decodes_json_array_params(self):
+        ## ``params`` is typed dict-or-None on the rollups, so a JSON-array
+        ## payload will still fail Pydantic — but the middleware shouldn't
+        ## be the one rejecting it. Decode it and let validation handle it.
+        seen: list[dict | None] = []
+        mw = ParseStringifiedParams()
+        ctx = _FakeContext(
+            message=CallToolRequestParams(
+                name="node_manage", arguments={"op": "delete", "params": "[1, 2, 3]"}
+            )
+        )
+        await mw.on_call_tool(ctx, await _record_arguments_call_next(seen))
+        assert seen == [{"op": "delete", "params": [1, 2, 3]}]
+
+    async def test_non_string_params_untouched(self):
+        ## Already-decoded, list, or other types pass straight through —
+        ## downstream validation will accept dicts and reject the rest.
+        seen: list[dict | None] = []
+        mw = ParseStringifiedParams()
+        ctx = _FakeContext(
+            message=CallToolRequestParams(
+                name="node_manage", arguments={"op": "delete", "params": 42}
+            )
+        )
+        await mw.on_call_tool(ctx, await _record_arguments_call_next(seen))
+        assert seen == [{"op": "delete", "params": 42}]


### PR DESCRIPTION
## Summary

- Add `ParseStringifiedParams` middleware that JSON-decodes a string `params` slot on any `*_manage` tool call before Pydantic validates. Mirrors the `StripClientWrapperKwargs` middleware shape from #199.
- Fix the parallel case in `node_set_property.value` inside the GDScript handler: when target is `TYPE_OBJECT` and value arrives as a JSON string of `{"__class__": ...}`, parse it back to a Dictionary so the existing `__class__` instantiation branch handles it, instead of the next branch treating the JSON blob as a `res://` path and emitting `Resource not found: {...}`.
- 8 new unit tests covering the middleware happy/edge paths.
- 2 new integration tests calling `scene_manage` with stringified params through the full FastMCP stack.

Closes #206.

## Why

PR #203 collapsed ~118 per-verb tools into 39 named verbs + per-domain `<domain>_manage` rollups. Each rollup's `params` field is typed strict-dict via Pydantic. Some MCP clients (Cline confirmed) auto-serialize nested-object arguments before sending — every such call was rejected with `Input should be a valid dictionary` before any handler ran.

A blanket `extra="ignore"` would silence the error but also silently drop typo'd real params. The narrow middleware approach keeps strict validation everywhere except this one slot we know clients stringify.

## Test plan

- [x] `pytest` — full suite, 601 passed (was 591 + 10 new).
- [x] Live smoke against fixed server: pre-fix `resource_manage` with stringified `params` died at Pydantic; post-fix the request reaches the handler and returns a meaningful "Must provide either path+property…" error from the handler itself.
- [ ] Manual smoke from a Cline session with the fixed server — out of scope for this PR but the integration test exercises the same wire path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
