### PR TITLE
fix(handlers): "Did you mean" suggestion in Node not found errors

### DIFF
--- a/plugin/addons/godot_ai/handlers/animation_handler.gd
+++ b/plugin/addons/godot_ai/handlers/animation_handler.gd
@@ -1286,7 +1286,7 @@ func _resolve_player(player_path: String, create_if_missing: bool = false) -> Di
 	var node := ScenePath.resolve(player_path, scene_root)
 	if node == null:
 		if not create_if_missing:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % player_path)
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_node_error(player_path, scene_root))
 		return _instantiate_player(player_path, scene_root)
 	if not node is AnimationPlayer:
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
@@ -1388,7 +1388,7 @@ func _resolve_player_read(player_path: String) -> Dictionary:
 		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
 	var node := ScenePath.resolve(player_path, scene_root)
 	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % player_path)
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_node_error(player_path, scene_root))
 	if not node is AnimationPlayer:
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
 			"Node at %s is not an AnimationPlayer (got %s)" % [player_path, node.get_class()])

--- a/plugin/addons/godot_ai/handlers/audio_handler.gd
+++ b/plugin/addons/godot_ai/handlers/audio_handler.gd
@@ -325,7 +325,7 @@ func _resolve_player(player_path: String) -> Dictionary:
 		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
 	var node := ScenePath.resolve(player_path, scene_root)
 	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % player_path)
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_node_error(player_path, scene_root))
 	var is_player := node is AudioStreamPlayer \
 		or node is AudioStreamPlayer2D \
 		or node is AudioStreamPlayer3D

--- a/plugin/addons/godot_ai/handlers/camera_handler.gd
+++ b/plugin/addons/godot_ai/handlers/camera_handler.gd
@@ -563,7 +563,7 @@ func get_camera(params: Dictionary) -> Dictionary:
 	else:
 		node = ScenePath.resolve(camera_path, scene_root)
 		if node == null:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % camera_path)
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_node_error(camera_path, scene_root))
 		if not _is_camera(node):
 			return McpErrorCodes.make(
 				McpErrorCodes.INVALID_PARAMS,
@@ -751,7 +751,7 @@ func _resolve_camera(params: Dictionary) -> Dictionary:
 		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
 	var node := ScenePath.resolve(node_path, scene_root)
 	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % node_path)
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_node_error(node_path, scene_root))
 	if not _is_camera(node):
 		return McpErrorCodes.make(
 			McpErrorCodes.INVALID_PARAMS,

--- a/plugin/addons/godot_ai/handlers/control_draw_recipe_handler.gd
+++ b/plugin/addons/godot_ai/handlers/control_draw_recipe_handler.gd
@@ -33,7 +33,7 @@ func control_draw_recipe(params: Dictionary) -> Dictionary:
 
 	var node := ScenePath.resolve(path, scene_root)
 	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % path)
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_node_error(path, scene_root))
 	if not node is Control:
 		return McpErrorCodes.make(
 			McpErrorCodes.INVALID_PARAMS,

--- a/plugin/addons/godot_ai/handlers/curve_handler.gd
+++ b/plugin/addons/godot_ai/handlers/curve_handler.gd
@@ -56,7 +56,7 @@ func set_points(params: Dictionary) -> Dictionary:
 			return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
 		node = ScenePath.resolve(node_path, scene_root)
 		if node == null:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % node_path)
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_node_error(node_path, scene_root))
 		if not (property in node):
 			return McpErrorCodes.make(
 				McpErrorCodes.INVALID_PARAMS,

--- a/plugin/addons/godot_ai/handlers/environment_handler.gd
+++ b/plugin/addons/godot_ai/handlers/environment_handler.gd
@@ -118,7 +118,7 @@ func _assign_environment(env: Environment, sky: Sky, sky_material: ProceduralSky
 
 	var node := ScenePath.resolve(node_path, scene_root)
 	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % node_path)
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_node_error(node_path, scene_root))
 	if not (node is WorldEnvironment):
 		return McpErrorCodes.make(
 			McpErrorCodes.INVALID_PARAMS,

--- a/plugin/addons/godot_ai/handlers/material_handler.gd
+++ b/plugin/addons/godot_ai/handlers/material_handler.gd
@@ -349,7 +349,7 @@ func assign_material(params: Dictionary) -> Dictionary:
 
 	var node := ScenePath.resolve(node_path, scene_root)
 	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % node_path)
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_node_error(node_path, scene_root))
 
 	var slot: String = params.get("slot", "override")
 	var resource_path: String = params.get("resource_path", "")
@@ -443,7 +443,7 @@ func apply_to_node(params: Dictionary) -> Dictionary:
 
 	var node := ScenePath.resolve(node_path, scene_root)
 	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % node_path)
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_node_error(node_path, scene_root))
 
 	var slot: String = params.get("slot", "override")
 	var slot_result := _resolve_slot_property(node, slot)
@@ -583,7 +583,7 @@ func apply_preset(params: Dictionary) -> Dictionary:
 			return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
 		var node := ScenePath.resolve(node_path, scene_root)
 		if node == null:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % node_path)
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_node_error(node_path, scene_root))
 		var slot_result := _resolve_slot_property(node, params.get("slot", "override"))
 		if slot_result.has("error"):
 			return slot_result

--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -724,7 +724,7 @@ func _resolve_node(params: Dictionary) -> Dictionary:
 	var scene_root: Node = scene_check.node
 	var node := ScenePath.resolve(node_path, scene_root)
 	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % node_path)
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_node_error(node_path, scene_root))
 	return {"node": node, "path": node_path, "scene_root": scene_root}
 
 

--- a/plugin/addons/godot_ai/handlers/particle_handler.gd
+++ b/plugin/addons/godot_ai/handlers/particle_handler.gd
@@ -712,7 +712,7 @@ func _resolve_particle(params: Dictionary) -> Dictionary:
 		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
 	var node := ScenePath.resolve(node_path, scene_root)
 	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % node_path)
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_node_error(node_path, scene_root))
 	var is_particle := node is GPUParticles3D or node is GPUParticles2D \
 		or node is CPUParticles3D or node is CPUParticles2D
 	if not is_particle:

--- a/plugin/addons/godot_ai/handlers/physics_shape_handler.gd
+++ b/plugin/addons/godot_ai/handlers/physics_shape_handler.gd
@@ -41,7 +41,7 @@ func autofit(params: Dictionary) -> Dictionary:
 
 	var node := ScenePath.resolve(node_path, scene_root)
 	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % node_path)
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_node_error(node_path, scene_root))
 
 	var is_3d := node is CollisionShape3D
 	var is_2d := node is CollisionShape2D

--- a/plugin/addons/godot_ai/handlers/resource_handler.gd
+++ b/plugin/addons/godot_ai/handlers/resource_handler.gd
@@ -113,7 +113,7 @@ func assign_resource(params: Dictionary) -> Dictionary:
 
 	var node := ScenePath.resolve(node_path, scene_root)
 	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % node_path)
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_node_error(node_path, scene_root))
 
 	# Verify property exists
 	var found := false
@@ -294,7 +294,7 @@ func _assign_created_resource(res: Resource, type_str: String, node_path: String
 
 	var node := ScenePath.resolve(node_path, scene_root)
 	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % node_path)
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_node_error(node_path, scene_root))
 
 	var found := false
 	var prop_type: int = TYPE_NIL

--- a/plugin/addons/godot_ai/handlers/script_handler.gd
+++ b/plugin/addons/godot_ai/handlers/script_handler.gd
@@ -164,7 +164,7 @@ func attach_script(params: Dictionary) -> Dictionary:
 
 	var node := ScenePath.resolve(node_path, scene_root)
 	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % node_path)
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_node_error(node_path, scene_root))
 
 	if not ResourceLoader.exists(script_path):
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Script not found: %s" % script_path)
@@ -202,7 +202,7 @@ func detach_script(params: Dictionary) -> Dictionary:
 
 	var node := ScenePath.resolve(node_path, scene_root)
 	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % node_path)
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_node_error(node_path, scene_root))
 
 	var old_script: Script = node.get_script()
 	if old_script == null:

--- a/plugin/addons/godot_ai/handlers/signal_handler.gd
+++ b/plugin/addons/godot_ai/handlers/signal_handler.gd
@@ -22,7 +22,7 @@ func list_signals(params: Dictionary) -> Dictionary:
 
 	var node := ScenePath.resolve(path, scene_root)
 	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % path)
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_node_error(path, scene_root))
 
 	var signals: Array[Dictionary] = []
 	for sig in node.get_signal_list():

--- a/plugin/addons/godot_ai/handlers/texture_handler.gd
+++ b/plugin/addons/godot_ai/handlers/texture_handler.gd
@@ -154,7 +154,7 @@ func _assign_texture(tex: Resource, sub_resources: Array, node_path: String, pro
 		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
 	var node := ScenePath.resolve(node_path, scene_root)
 	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % node_path)
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_node_error(node_path, scene_root))
 
 	var found := false
 	var prop_type: int = TYPE_NIL

--- a/plugin/addons/godot_ai/handlers/theme_handler.gd
+++ b/plugin/addons/godot_ai/handlers/theme_handler.gd
@@ -395,7 +395,7 @@ func apply_theme(params: Dictionary) -> Dictionary:
 
 	var node := ScenePath.resolve(node_path, scene_root)
 	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % node_path)
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_node_error(node_path, scene_root))
 	if not node is Control and not node is Window:
 		return McpErrorCodes.make(
 			McpErrorCodes.INVALID_PARAMS,

--- a/plugin/addons/godot_ai/handlers/ui_handler.gd
+++ b/plugin/addons/godot_ai/handlers/ui_handler.gd
@@ -87,7 +87,7 @@ func set_anchor_preset(params: Dictionary) -> Dictionary:
 
 	var node := ScenePath.resolve(node_path, scene_root)
 	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % node_path)
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_node_error(node_path, scene_root))
 	if not node is Control:
 		return McpErrorCodes.make(
 			McpErrorCodes.INVALID_PARAMS,
@@ -157,7 +157,7 @@ func set_text(params: Dictionary) -> Dictionary:
 
 	var node := ScenePath.resolve(node_path, scene_root)
 	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Node not found: %s" % node_path)
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_node_error(node_path, scene_root))
 	var node_type := node.get_class()
 	if not node is Control:
 		return McpErrorCodes.make(

--- a/plugin/addons/godot_ai/utils/scene_path.gd
+++ b/plugin/addons/godot_ai/utils/scene_path.gd
@@ -90,3 +90,34 @@ static func format_parent_error(path: String, scene_root: Node) -> String:
 		return "Parent not found: %s. No edited scene is open." % path
 	var root_name := str(scene_root.name)
 	return "Parent not found: %s. Paths are relative to the edited scene root (e.g. \"/%s\" or \"\"), not the SceneTree. Scene root is \"/%s\"." % [path, root_name, root_name]
+
+
+## Format a "node not found" error that names the path convention and, when
+## possible, suggests a corrected path. Agents routinely pass /root/Foo
+## (runtime SceneTree) or unprefixed names; the bare "Node not found: X"
+## gives no hint that paths are edited-scene-relative.
+##
+## Suggestion logic (highest-confidence first):
+##   1. /root/<X>[/...] where <X> is not the scene root → suggest /<sceneRoot>/<X>[/...]
+##   2. path doesn't start with "/" → suggest "/<sceneRoot>/<path>"
+##   3. otherwise no concrete "did you mean", just the convention reminder.
+static func format_node_error(path: String, scene_root: Node) -> String:
+	if scene_root == null:
+		return "Node not found: %s. No edited scene is open." % path
+	var root_name := str(scene_root.name)
+	var suggestion := ""
+
+	if path.begins_with("/root/"):
+		var after_root := path.substr(6)  # "/root/" is 6 chars
+		# Only suggest if the segment after /root/ isn't already the scene root
+		# (resolve() handles /root/<sceneRoot>/... as an alias, so a failure
+		# with that prefix means a deeper segment is wrong — no clean rewrite).
+		var first_seg := after_root.split("/")[0]
+		if first_seg != root_name and not first_seg.is_empty():
+			suggestion = "/" + root_name + "/" + after_root
+	elif not path.begins_with("/") and not path.is_empty():
+		suggestion = "/" + root_name + "/" + path
+
+	if suggestion.is_empty():
+		return "Node not found: %s. Paths are relative to the edited scene root (e.g. \"/%s/Child\"), not runtime /root/... paths. Scene root is \"/%s\"." % [path, root_name, root_name]
+	return "Node not found: %s. Did you mean \"%s\"? Paths are relative to the edited scene root, not runtime /root/... paths. Scene root is \"/%s\"." % [path, suggestion, root_name]

--- a/src/godot_ai/tools/batch.py
+++ b/src/godot_ai/tools/batch.py
@@ -34,6 +34,10 @@ def register_batch_tools(mcp: FastMCP) -> None:
         that modify the currently edited scene. `batch_execute` itself is not
         allowed as a sub-command.
 
+        Scene paths are relative to the edited scene root (e.g. "/Main/Enemy"),
+        NOT runtime "/root/..." paths. The example below assumes the scene
+        root is named "Main" — substitute the actual root name.
+
         Example:
             commands=[
               {"command": "create_node",

--- a/src/godot_ai/tools/node.py
+++ b/src/godot_ai/tools/node.py
@@ -58,7 +58,9 @@ def register_node_tools(mcp: FastMCP, *, include_non_core: bool = True) -> None:
         active-session reads.
 
         Args:
-            path: Scene path of the node (e.g. "/Main/Camera3D").
+            path: Scene path relative to the edited scene root (e.g.
+                "/Main/Camera3D"), NOT runtime "/root/..." paths. Derive
+                from prior tool responses or scene_get_hierarchy.
             session_id: Optional Godot session to target. Empty = active session.
         """
         runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
@@ -86,10 +88,14 @@ def register_node_tools(mcp: FastMCP, *, include_non_core: bool = True) -> None:
         Args:
             type: Godot node class (e.g. "Node3D", "MeshInstance3D").
             name: Optional name; Godot auto-names if empty.
-            parent_path: Parent scene path (e.g. "/Main"). Empty = scene root.
+            parent_path: Parent path relative to the edited scene root (e.g.
+                "/Main"), NOT runtime "/root/...". Empty = scene root.
             scene_path: Optional res:// path of a PackedScene to instantiate.
             scene_file: Optional editor-scene guard (EDITED_SCENE_MISMATCH).
             session_id: Optional Godot session to target. Empty = active session.
+
+        Returns the created node's full path in ``data.path`` — use it as the
+        prefix for subsequent commands targeting this node.
         """
         runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
         return await node_handlers.node_create(
@@ -122,7 +128,8 @@ def register_node_tools(mcp: FastMCP, *, include_non_core: bool = True) -> None:
         - StringName: plain string. Array/Dictionary: JSON list/object.
 
         Args:
-            path: Scene path of the node.
+            path: Scene path relative to the edited scene root (e.g.
+                "/Main/Camera3D"), NOT runtime "/root/..." paths.
             property: Property name (e.g. "fov", "position", "mesh").
             value: New value. Pass null (or "" for resources) to clear.
             scene_file: Optional editor-scene guard.

--- a/test_project/tests/test_scene_path.gd
+++ b/test_project/tests/test_scene_path.gd
@@ -135,6 +135,77 @@ func test_format_parent_error_null_root_returns_actionable_message() -> void:
 	assert_false(msg.contains("<no scene>"), "should not leak placeholder")
 
 
+# ----- format_node_error: agent-readable message with "did you mean" -----
+
+func test_format_node_error_root_prefix_suggests_scene_relative_path() -> void:
+	## The signature mistake (Cline's failure mode): /root/<NotSceneRoot>/...
+	## We can rewrite that to /<sceneRoot>/<rest> with high confidence.
+	var root := _make_tree()
+	var msg := ScenePath.format_node_error("/root/Cube0", root)
+	assert_contains(msg, "/root/Cube0")
+	assert_contains(msg, "Did you mean")
+	assert_contains(msg, "/Main/Cube0")
+	assert_contains(msg, "/Main")
+	root.queue_free()
+
+
+func test_format_node_error_root_prefix_with_descendant_suggests_full_rewrite() -> void:
+	var root := _make_tree()
+	var msg := ScenePath.format_node_error("/root/Foo/Bar/Baz", root)
+	assert_contains(msg, "Did you mean")
+	assert_contains(msg, "/Main/Foo/Bar/Baz")
+	root.queue_free()
+
+
+func test_format_node_error_root_prefix_matching_scene_root_no_suggestion() -> void:
+	## /root/Main/... is already aliased by resolve(), so a failure with that
+	## prefix means a deeper segment is wrong — there's no clean rewrite to
+	## suggest. Fall back to the convention reminder.
+	var root := _make_tree()
+	var msg := ScenePath.format_node_error("/root/Main/Nope", root)
+	assert_false(msg.contains("Did you mean"), "no clean rewrite available")
+	assert_contains(msg, "relative to the edited scene root")
+	root.queue_free()
+
+
+func test_format_node_error_unprefixed_path_suggests_scene_relative() -> void:
+	## Bare "Cube0" with no leading slash → suggest "/Main/Cube0".
+	var root := _make_tree()
+	var msg := ScenePath.format_node_error("Cube0", root)
+	assert_contains(msg, "Did you mean")
+	assert_contains(msg, "/Main/Cube0")
+	root.queue_free()
+
+
+func test_format_node_error_already_relative_path_no_suggestion() -> void:
+	## /Main/Nope is correctly formatted but doesn't resolve — no rewrite
+	## possible, just remind about the convention so the agent can re-check
+	## the actual node names via scene_get_hierarchy.
+	var root := _make_tree()
+	var msg := ScenePath.format_node_error("/Main/Nope", root)
+	assert_false(msg.contains("Did you mean"))
+	assert_contains(msg, "Node not found: /Main/Nope")
+	assert_contains(msg, "/Main")
+	root.queue_free()
+
+
+func test_format_node_error_null_root_returns_actionable_message() -> void:
+	var msg := ScenePath.format_node_error("/root/Foo", null)
+	assert_contains(msg, "/root/Foo")
+	assert_contains(msg, "No edited scene is open")
+	assert_false(msg.contains("<no scene>"), "should not leak placeholder")
+
+
+func test_format_node_error_mentions_runtime_root_anti_pattern() -> void:
+	## The message must explicitly call out that /root/... is wrong, not just
+	## that "paths are relative". Agents need the antipattern named to
+	## connect their mistake to the fix.
+	var root := _make_tree()
+	var msg := ScenePath.format_node_error("/root/X", root)
+	assert_contains(msg, "/root/")
+	root.queue_free()
+
+
 # ----- require_edited_scene: multi-call scene-drift guard (issue #74) -----
 
 func test_require_edited_scene_empty_expected_returns_current_root() -> void:


### PR DESCRIPTION
## Summary

AI clients (verified with Cline + Roo Code in a multi-client pressure test) repeatedly assume runtime SceneTree paths like `/root/Cube0` and hit a bare `Node not found: /root/Cube0` with no hint that paths are edited-scene-relative. The fix lives where clients actually see it — error messages and tool docstrings — not in docs files they do not read.

- New `ScenePath.format_node_error(path, scene_root)` produces messages like:
  > *Node not found: /root/Cube0. Did you mean "/Main/Cube0"? Paths are relative to the edited scene root, not runtime /root/... paths. Scene root is "/Main".*
- "Did you mean" fires for `/root/X` (where X≠sceneRoot) and unprefixed paths (`Cube0` → `/Main/Cube0`)
- All 22 "Node not found: %s" callsites across 16 handlers route through the helper
- Tool docstrings on `node_get_properties` / `node_create` / `node_set_property` / `batch_execute` explicitly call out: *"relative to the edited scene root, NOT runtime /root/... paths"* — and `node_create` now points at `data.path` in the response as the prefix to use for follow-up commands

## Background

Cline's failure mode: `batch_execute` first sub-command (`create_node`) returned `path: "/YellowCube/Cube0"`, but Cline ignored it and built the next sub-command path as `/root/Cube0`. The bare error gave no hint that `/root/...` was the wrong addressing model. Roo Code hit a different but adjacent issue (strict JSON generator collapsing nested objects) — the docs change here does not help Roo, but error messages help every client that gets the path wrong.

Existing `ScenePath.format_parent_error` already covered this for `parent_path`; this PR extends the same pattern to the much-larger surface of node-resolution errors and adds the rewrite-suggestion logic on top.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `pytest -v` — 598 passed
- [x] `test_run suite=scene_path verbose=true` — 22/22 pass (7 new + 15 existing), every branch covered
- [x] `test_run` (full) — 856/859 pass, 0 failed, 3 skipped (no regressions across 34 suites)
- [x] Live error-message smoke against the editor:
  - [x] `node_get_properties(/root/Cube0)` → suggests `/Main/Cube0`
  - [x] `node_get_properties(Cube0)` (unprefixed) → suggests `/Main/Cube0`
  - [x] `node_get_properties(/root/Main/DoesNotExist)` → falls back to convention reminder (no clean rewrite)
  - [x] `node_get_properties(/Main/Nope)` → falls back (path format is correct, just does not exist)
  - [x] `node_set_property(/root/Cube0, ...)` → smart error
  - [x] `batch_execute([{set_property: /root/Enemy ...}])` → smart error in sub-result + top-level
  - [x] `node_manage(op=get_children, /root/SomeNode)` → smart error
- [x] Happy paths still work: `/Main/Camera3D` and `/root/Main/Camera3D` (alias) both resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)
