### PR TITLE
fix(handlers): hide editor-internal entries from list ops

### DIFF
--- a/plugin/addons/godot_ai/handlers/input_handler.gd
+++ b/plugin/addons/godot_ai/handlers/input_handler.gd
@@ -12,7 +12,12 @@ func list_actions(params: Dictionary) -> Dictionary:
 	for action_name in InputMap.get_actions():
 		var name_str := str(action_name)
 		var is_builtin := name_str.begins_with("ui_")
-		if is_builtin and not include_builtin:
+		if not include_builtin and is_builtin:
+			continue
+		# Editor-runtime actions (e.g. spatial_editor/freelook_left) live in
+		# InputMap but never appear under input/ in project.godot. Treat
+		# "user-authored" as "registered in ProjectSettings".
+		if not include_builtin and not ProjectSettings.has_setting("input/" + name_str):
 			continue
 		var events: Array[Dictionary] = []
 		for event in InputMap.action_get_events(action_name):

--- a/plugin/addons/godot_ai/handlers/input_handler.gd
+++ b/plugin/addons/godot_ai/handlers/input_handler.gd
@@ -15,8 +15,9 @@ func list_actions(params: Dictionary) -> Dictionary:
 		if not include_builtin and is_builtin:
 			continue
 		# Editor-runtime actions (e.g. spatial_editor/freelook_left) live in
-		# InputMap but never appear under input/ in project.godot. Treat
-		# "user-authored" as "registered in ProjectSettings".
+		# InputMap but never appear under input/ in project.godot. When
+		# include_builtin is false, treat only non-ui_* actions registered in
+		# ProjectSettings as "user-authored".
 		if not include_builtin and not ProjectSettings.has_setting("input/" + name_str):
 			continue
 		var events: Array[Dictionary] = []

--- a/plugin/addons/godot_ai/handlers/signal_handler.gd
+++ b/plugin/addons/godot_ai/handlers/signal_handler.gd
@@ -35,12 +35,18 @@ func list_signals(params: Dictionary) -> Dictionary:
 		})
 
 	var connections: Array[Dictionary] = []
+	var editor_connection_count := 0
 	for sig in signals:
 		for conn in node.get_signal_connection_list(sig.name):
 			var callable: Callable = conn.get("callable", Callable())
 			var target := callable.get_object()
 			if target == null:
 				continue  # skip connections to freed objects
+			# Editor UI (SceneTreeEditor, docks) wires observers on scene
+			# nodes — hide them so agents see only user-authored connections.
+			if target is Node and not _is_user_target(target, scene_root):
+				editor_connection_count += 1
+				continue
 			connections.append({
 				"signal": sig.name,
 				"target": ScenePath.from_node(target, scene_root) if target is Node else str(target),
@@ -54,8 +60,23 @@ func list_signals(params: Dictionary) -> Dictionary:
 			"signal_count": signals.size(),
 			"connections": connections,
 			"connection_count": connections.size(),
+			"editor_connection_count": editor_connection_count,
 		}
 	}
+
+
+## True if target is in the edited scene tree, or a registered autoload directly under /root.
+static func _is_user_target(target: Node, scene_root: Node) -> bool:
+	if target == scene_root or scene_root.is_ancestor_of(target):
+		return true
+	var tree := target.get_tree()
+	if tree == null or target.get_parent() != tree.root:
+		return false
+	return _is_declared_autoload(target.name)
+
+
+static func _is_declared_autoload(name: StringName) -> bool:
+	return ProjectSettings.has_setting("autoload/" + name)
 
 
 func connect_signal(params: Dictionary) -> Dictionary:
@@ -151,7 +172,7 @@ func _resolve_node_or_autoload(path: String, scene_root: Node, role: String) -> 
 		return {"node": node}
 
 	var name := path.trim_prefix("/")
-	if ProjectSettings.has_setting("autoload/" + name):
+	if _is_declared_autoload(name):
 		# Autoload is declared — see if the editor has it instanced.
 		var tree := Engine.get_main_loop()
 		if tree is SceneTree:

--- a/src/godot_ai/tools/input_map.py
+++ b/src/godot_ai/tools/input_map.py
@@ -15,8 +15,10 @@ Resource form: ``godot://input_map`` — prefer for active-session reads.
 
 Ops:
   • list(include_builtin=False)
-        List input actions and their bound events. Set include_builtin=True
-        to include Godot's built-in ``ui_*`` actions.
+        List user-authored input actions (those persisted under ``input/`` in
+        ``project.godot``) with their bound events. Set include_builtin=True
+        to also include Godot's built-in ``ui_*`` actions and editor-runtime
+        actions (``spatial_editor/*`` etc.) that live only in the InputMap.
   • add_action(action, deadzone=0.5)
         Create a new empty input action.
   • remove_action(action)

--- a/src/godot_ai/tools/input_map.py
+++ b/src/godot_ai/tools/input_map.py
@@ -15,10 +15,11 @@ Resource form: ``godot://input_map`` — prefer for active-session reads.
 
 Ops:
   • list(include_builtin=False)
-        List user-authored input actions (those persisted under ``input/`` in
-        ``project.godot``) with their bound events. Set include_builtin=True
-        to also include Godot's built-in ``ui_*`` actions and editor-runtime
-        actions (``spatial_editor/*`` etc.) that live only in the InputMap.
+        List project-defined non-``ui_*`` input actions persisted under
+        ``input/`` in ``project.godot`` with their bound events. Set
+        include_builtin=True to also include Godot's built-in ``ui_*``
+        actions and editor-runtime actions (``spatial_editor/*`` etc.) that
+        live only in the InputMap.
   • add_action(action, deadzone=0.5)
         Create a new empty input action.
   • remove_action(action)

--- a/src/godot_ai/tools/signal.py
+++ b/src/godot_ai/tools/signal.py
@@ -13,7 +13,9 @@ Signals (Godot's event/observer mechanism) — list, connect, disconnect.
 Ops:
   • list(path)
         List all signals on the node and their current connections (built-in
-        and custom).
+        and custom). Editor-internal listeners (SceneTreeEditor, dock UI) are
+        hidden from ``connections``; their count is reported separately as
+        ``editor_connection_count``.
   • connect(path, signal, target, method)
         Connect a signal from ``path`` to a method on the target node.
         Undoable.

--- a/test_project/tests/test_input.gd
+++ b/test_project/tests/test_input.gd
@@ -42,6 +42,48 @@ func test_list_actions_with_builtins() -> void:
 	assert_gt(result.data.count, 0, "Should have at least the built-in ui_* actions")
 
 
+func test_list_actions_filters_editor_runtime_actions() -> void:
+	## Editor-runtime actions (e.g. spatial_editor/freelook_left) live in
+	## InputMap but never appear under input/ in project.godot. Simulate one by
+	## adding directly to InputMap without registering a ProjectSettings entry,
+	## and confirm list_actions(include_builtin=False) hides it.
+	const RUNTIME_ACTION := "_McpTestRuntimeAction"
+	if InputMap.has_action(RUNTIME_ACTION):
+		InputMap.erase_action(RUNTIME_ACTION)
+	InputMap.add_action(RUNTIME_ACTION)
+	# Capture-then-tear-down-then-assert: collect listings, then erase the
+	# runtime action, then check. Keeps the fixture from leaking past this
+	# test if any assertion fails.
+	var precondition_in_settings := ProjectSettings.has_setting("input/" + RUNTIME_ACTION)
+	var default_names := _action_names(_handler.list_actions({}))
+	var full_names := _action_names(_handler.list_actions({"include_builtin": true}))
+	InputMap.erase_action(RUNTIME_ACTION)
+
+	assert_false(precondition_in_settings,
+		"Precondition: the simulated runtime action must not be in ProjectSettings")
+	assert_false(default_names.has(RUNTIME_ACTION),
+		"Editor-runtime actions (no input/<name> in project.godot) should be hidden by default")
+	assert_true(full_names.has(RUNTIME_ACTION),
+		"include_builtin=True should expose every InputMap action, including runtime-only ones")
+
+
+func test_list_actions_includes_user_authored() -> void:
+	## A user-authored action (registered in ProjectSettings via add_action)
+	## must appear in the default include_builtin=False listing.
+	_handler.add_action({"action": TEST_ACTION})
+	var names := _action_names(_handler.list_actions({}))
+	_handler.remove_action({"action": TEST_ACTION})
+	assert_true(names.has(TEST_ACTION),
+		"User-authored action should appear in default listing")
+
+
+func _action_names(result: Dictionary) -> Array:
+	var names: Array = []
+	for action in result.data.actions:
+		names.append(action.name)
+	return names
+
+
 # ----- add_action -----
 
 func test_add_action_missing_name() -> void:

--- a/test_project/tests/test_signal.gd
+++ b/test_project/tests/test_signal.gd
@@ -31,6 +31,57 @@ func test_list_signals_returns_signals() -> void:
 	assert_gt(result.data.signal_count, 0, "Root node should have signals")
 
 
+func test_list_signals_filters_editor_internal_connections() -> void:
+	## list_signals should hide connections whose target lives outside the
+	## edited scene (editor UI like SceneTreeEditor wires up observers on the
+	## scene root). Simulate by parking a Node directly under /root and
+	## connecting one of the scene root's signals to it — structurally
+	## identical to an editor-internal listener.
+	const OBSERVER_NAME := "_McpTestFakeEditorObserver"
+	const SIG_NAME := "renamed"  # Stable Node signal — every scene root has it.
+
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root — is a scene open?")
+		return
+	var tree := scene_root.get_tree()
+	if tree == null:
+		skip("Scene tree unavailable")
+		return
+	var path := "/" + scene_root.name
+
+	var baseline := _handler.list_signals({"path": path})
+	var before_user: int = baseline.data.connection_count
+	var before_editor: int = baseline.data.editor_connection_count
+
+	# Capture-then-tear-down-then-assert: gather all values into locals, fully
+	# undo the fixture, only then run asserts. Guarantees the fake observer
+	# never leaks past this test even if every assertion fails.
+	var observer := Node.new()
+	observer.name = OBSERVER_NAME
+	tree.root.add_child(observer)
+	var callable := Callable(observer, "queue_free")
+	scene_root.connect(SIG_NAME, callable)
+
+	var result := _handler.list_signals({"path": path})
+	var observed_targets: Array = []
+	for conn in result.data.connections:
+		observed_targets.append(str(conn.target))
+	var observed_user_count: int = result.data.connection_count
+	var observed_editor_count: int = result.data.editor_connection_count
+
+	scene_root.disconnect(SIG_NAME, callable)
+	observer.queue_free()
+
+	for target_str in observed_targets:
+		assert_false(target_str.contains(OBSERVER_NAME),
+			"connections[] must not include nodes parked outside the edited scene")
+	assert_eq(observed_user_count, before_user,
+		"User-visible connection count must not include editor-internal listeners")
+	assert_eq(observed_editor_count, before_editor + 1,
+		"Editor-internal listener should be tallied separately, not in connections[]")
+
+
 func test_list_signals_missing_path() -> void:
 	var result := _handler.list_signals({})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)


### PR DESCRIPTION
Closes #213.

## Summary

Two `list` ops surfaced editor-internal state as if it were user content:

- `signal_manage(op="list", params={"path": "/Main"})` returned 5 connections to `SceneTreeEditor` / dock UI observers (`visibility_changed`, `child_order_changed`, etc.) — the editor's own listeners on the scene root.
- `input_map_manage(op="list", params={})` (default `include_builtin=False`) returned 16 `spatial_editor/*` entries in a project with **zero** user-defined input actions — the editor runtime's freelook / orbit / zoom modifier bindings.

Agents reading either response saw the editor's plumbing attributed to the project.

## Changes

- **`signal_handler.gd::list_signals`** — drop connections whose target isn't part of the edited scene tree (and isn't a registered autoload directly under `/root`). Editor listeners are now tallied in a separate, additive `editor_connection_count` field so callers can still detect hidden observers without seeing each one in `connections[]`. Autoload-name lookup extracted to a small `_is_declared_autoload` helper, also reused by the existing `_resolve_node_or_autoload`.
- **`input_handler.gd::list_actions`** — when `include_builtin=False`, also skip any action that has no `input/<name>` entry in `ProjectSettings`. Editor-runtime actions added via `InputMap.add_action` (without ProjectSettings persistence) are now hidden by default; user-authored actions added via our `add_action` op are persisted to `ProjectSettings` and pass the filter.
- **Tool descriptions** for `signal_manage` and `input_map_manage` updated to document the new filtering shape.
- **GDScript tests** cover both filters. Both new tests follow a capture-then-tear-down-then-assert pattern so a mid-test failure can never leak the simulated fixture into a subsequent run; fixture nodes/actions use the `_McpTest…` prefix that the test runner's safety-net cleanup already recognises.

## Backwards compatibility

- `editor_connection_count` is a purely additive field — older Python integration tests don't read it and stay green (608/608 passing locally).
- `connections[]` shrinks to user wiring only; no existing caller iterates it semantically.
- The resource form `godot://input_map` calls `input_map_list` with the default `include_builtin=False`, so it gets the new filtering for free.

## Test plan

- [x] `pytest -q` — 608 passed
- [x] `ruff check src/ tests/` — clean
- [ ] **GDScript tests** — exercised in CI's Godot test matrix (`script/ci-godot-tests`). The new tests are `test_signal.gd::test_list_signals_filters_editor_internal_connections` and `test_input.gd::test_list_actions_filters_editor_runtime_actions` / `test_list_actions_includes_user_authored`.
- [ ] **Live editor smoke** — could not run in this sandbox (no Godot binary available). The fix follows the issue's repro exactly: open a fresh `Node3D` scene with zero user input actions, then `signal_manage(op="list", params={"path": "/Main"})` should now return `connection_count: 0, editor_connection_count: 5`, and `input_map_manage(op="list", params={})` should return `count: 0`.

https://claude.ai/code/session_01XYciuLk4eoJsJnbspC74p2

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYciuLk4eoJsJnbspC74p2)_