### PR TITLE
fix(server): hint on _manage op typos (#211); filter editor-internal list entries (#213)

### DIFF
--- a/plugin/addons/godot_ai/handlers/input_handler.gd
+++ b/plugin/addons/godot_ai/handlers/input_handler.gd
@@ -11,8 +11,11 @@ func list_actions(params: Dictionary) -> Dictionary:
 	var actions: Array[Dictionary] = []
 	for action_name in InputMap.get_actions():
 		var name_str := str(action_name)
-		var is_builtin := name_str.begins_with("ui_")
-		if is_builtin and not include_builtin:
+		## User-authored actions are exactly those persisted in project.godot;
+		## drops not just ``ui_*`` but also editor-runtime namespaces like
+		## ``spatial_editor/*``. See #213.
+		var is_user_action := ProjectSettings.has_setting("input/" + name_str)
+		if not include_builtin and not is_user_action:
 			continue
 		var events: Array[Dictionary] = []
 		for event in InputMap.action_get_events(action_name):
@@ -21,7 +24,7 @@ func list_actions(params: Dictionary) -> Dictionary:
 			"name": name_str,
 			"events": events,
 			"event_count": events.size(),
-			"is_builtin": is_builtin,
+			"is_builtin": not is_user_action,
 		})
 	return {"data": {"actions": actions, "count": actions.size()}}
 

--- a/plugin/addons/godot_ai/handlers/input_handler.gd
+++ b/plugin/addons/godot_ai/handlers/input_handler.gd
@@ -8,13 +8,18 @@ extends RefCounted
 
 func list_actions(params: Dictionary) -> Dictionary:
 	var include_builtin: bool = params.get("include_builtin", false)
+	## Authoritative source for user-authored actions is the ``[input]``
+	## section of ``project.godot``. ``ProjectSettings.has_setting`` is not
+	## reliable here because Godot registers ``ui_*`` defaults via
+	## ``GLOBAL_DEF_BASIC``, which makes ``has_setting`` return true for
+	## them. Reading the file via ``ConfigFile`` distinguishes the user's
+	## entries from engine-registered defaults regardless of namespace.
+	## See #213.
+	var user_authored := _read_user_authored_actions()
 	var actions: Array[Dictionary] = []
 	for action_name in InputMap.get_actions():
 		var name_str := str(action_name)
-		## User-authored actions are exactly those persisted in project.godot;
-		## drops not just ``ui_*`` but also editor-runtime namespaces like
-		## ``spatial_editor/*``. See #213.
-		var is_user_action := ProjectSettings.has_setting("input/" + name_str)
+		var is_user_action := user_authored.has(name_str)
 		if not include_builtin and not is_user_action:
 			continue
 		var events: Array[Dictionary] = []
@@ -27,6 +32,18 @@ func list_actions(params: Dictionary) -> Dictionary:
 			"is_builtin": not is_user_action,
 		})
 	return {"data": {"actions": actions, "count": actions.size()}}
+
+
+func _read_user_authored_actions() -> Dictionary:
+	var cfg := ConfigFile.new()
+	if cfg.load("res://project.godot") != OK:
+		return {}
+	if not cfg.has_section("input"):
+		return {}
+	var result: Dictionary = {}
+	for key in cfg.get_section_keys("input"):
+		result[key] = true
+	return result
 
 
 func add_action(params: Dictionary) -> Dictionary:

--- a/plugin/addons/godot_ai/handlers/signal_handler.gd
+++ b/plugin/addons/godot_ai/handlers/signal_handler.gd
@@ -68,12 +68,14 @@ func list_signals(params: Dictionary) -> Dictionary:
 	}
 
 
-## A target is "editor-internal" when it's a Node whose tree position is
-## outside the edited scene — typical case is the SceneTreeEditor dock
-## listening for visibility/script/state changes on every scene node. Such
-## connections aren't user-authored and would otherwise mislead an agent
-## into thinking the user wired them up by hand. Non-Node targets (autoload
-## singletons, anonymous Callables, etc.) stay visible.
+## A target is "editor-internal" when it's a Node sitting outside the edited
+## scene tree AND not an autoload singleton — typical case is the
+## SceneTreeEditor dock listening for visibility/script/state changes on
+## every scene node. Connections to autoloads (declared under ``autoload/*``
+## in ProjectSettings) are user-authored even though they live under
+## ``/root/<Name>`` rather than under the edited scene root, so they stay
+## visible. Non-Node targets (anonymous Callables, RefCounted listeners
+## etc.) also stay visible — we can't reliably classify them.
 func _is_editor_internal_target(target: Object, scene_root: Node) -> bool:
 	if not (target is Node):
 		return false
@@ -81,6 +83,8 @@ func _is_editor_internal_target(target: Object, scene_root: Node) -> bool:
 	if node_target == scene_root:
 		return false
 	if scene_root.is_ancestor_of(node_target):
+		return false
+	if ProjectSettings.has_setting("autoload/" + str(node_target.name)):
 		return false
 	return true
 

--- a/plugin/addons/godot_ai/handlers/signal_handler.gd
+++ b/plugin/addons/godot_ai/handlers/signal_handler.gd
@@ -24,6 +24,11 @@ func list_signals(params: Dictionary) -> Dictionary:
 	if node == null:
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_node_error(path, scene_root))
 
+	## Default: hide editor-internal connections (SceneTreeEditor observers
+	## live on every scene node and would otherwise dominate the response).
+	## Pass include_editor=true to see them. See #213.
+	var include_editor: bool = params.get("include_editor", false)
+
 	var signals: Array[Dictionary] = []
 	for sig in node.get_signal_list():
 		var args: Array[Dictionary] = []
@@ -35,12 +40,16 @@ func list_signals(params: Dictionary) -> Dictionary:
 		})
 
 	var connections: Array[Dictionary] = []
+	var editor_connection_count := 0
 	for sig in signals:
 		for conn in node.get_signal_connection_list(sig.name):
 			var callable: Callable = conn.get("callable", Callable())
 			var target := callable.get_object()
 			if target == null:
 				continue  # skip connections to freed objects
+			if not include_editor and _is_editor_internal_target(target, scene_root):
+				editor_connection_count += 1
+				continue
 			connections.append({
 				"signal": sig.name,
 				"target": ScenePath.from_node(target, scene_root) if target is Node else str(target),
@@ -54,8 +63,26 @@ func list_signals(params: Dictionary) -> Dictionary:
 			"signal_count": signals.size(),
 			"connections": connections,
 			"connection_count": connections.size(),
+			"editor_connection_count": editor_connection_count,
 		}
 	}
+
+
+## A target is "editor-internal" when it's a Node whose tree position is
+## outside the edited scene — typical case is the SceneTreeEditor dock
+## listening for visibility/script/state changes on every scene node. Such
+## connections aren't user-authored and would otherwise mislead an agent
+## into thinking the user wired them up by hand. Non-Node targets (autoload
+## singletons, anonymous Callables, etc.) stay visible.
+func _is_editor_internal_target(target: Object, scene_root: Node) -> bool:
+	if not (target is Node):
+		return false
+	var node_target: Node = target
+	if node_target == scene_root:
+		return false
+	if scene_root.is_ancestor_of(node_target):
+		return false
+	return true
 
 
 func connect_signal(params: Dictionary) -> Dictionary:

--- a/src/godot_ai/handlers/signal.py
+++ b/src/godot_ai/handlers/signal.py
@@ -6,8 +6,10 @@ from godot_ai.handlers._readiness import require_writable
 from godot_ai.runtime.interface import Runtime
 
 
-async def signal_list(runtime: Runtime, path: str) -> dict:
-    return await runtime.send_command("list_signals", {"path": path})
+async def signal_list(runtime: Runtime, path: str, include_editor: bool = False) -> dict:
+    return await runtime.send_command(
+        "list_signals", {"path": path, "include_editor": include_editor}
+    )
 
 
 async def signal_connect(

--- a/src/godot_ai/middleware/__init__.py
+++ b/src/godot_ai/middleware/__init__.py
@@ -6,10 +6,12 @@ from godot_ai.middleware.client_wrapper_kwargs import (
     CLIENT_WRAPPER_KWARGS,
     StripClientWrapperKwargs,
 )
+from godot_ai.middleware.op_typo_hint import HintOpTypoOnManage
 from godot_ai.middleware.parse_stringified_params import ParseStringifiedParams
 
 __all__ = [
     "CLIENT_WRAPPER_KWARGS",
+    "HintOpTypoOnManage",
     "ParseStringifiedParams",
     "StripClientWrapperKwargs",
 ]

--- a/src/godot_ai/middleware/op_typo_hint.py
+++ b/src/godot_ai/middleware/op_typo_hint.py
@@ -61,24 +61,31 @@ def _build_hint(
 ) -> str | None:
     """Return a ``Did you mean`` message for an op literal_error, else None.
 
-    Returns None — leaving Pydantic's normal message — when the error isn't
-    a ``literal_error`` on the ``op`` field. Other validation errors fall
-    through unchanged so unrelated bugs aren't masked.
+    Returns None — leaving Pydantic's normal message — in three cases:
+      1. The error doesn't include a ``literal_error`` on the ``op`` field.
+      2. The same call has additional validation errors (e.g. a wrong-typed
+         ``params``); rewriting would mask them.
+      3. The user's ``op`` value isn't a string in a way ``difflib`` can
+         compare; we still emit a clear "op must be a string" hint instead
+         of silently swapping in an empty placeholder.
     """
-    if not any(
-        err.get("type") == "literal_error" and err.get("loc") == ("op",) for err in exc.errors()
-    ):
+    errors = exc.errors()
+    if len(errors) != 1:
+        return None
+    err = errors[0]
+    if err.get("type") != "literal_error" or err.get("loc") != ("op",):
         return None
 
-    typed_op = ""
-    if isinstance(arguments, dict):
-        raw_op = arguments.get("op")
-        if isinstance(raw_op, str):
-            typed_op = raw_op
-
-    suggestions = difflib.get_close_matches(typed_op, candidates, n=3, cutoff=0.5)
+    raw_op = arguments.get("op") if isinstance(arguments, dict) else None
     valid_list = ", ".join(repr(c) for c in candidates)
+
+    if not isinstance(raw_op, str):
+        return (
+            f"op must be a string, got {type(raw_op).__name__} {raw_op!r}. Valid ops: {valid_list}."
+        )
+
+    suggestions = difflib.get_close_matches(raw_op, candidates, n=3, cutoff=0.5)
     if suggestions:
         sug_list = ", ".join(repr(s) for s in suggestions)
-        return f"Unknown op {typed_op!r} — did you mean {sug_list}? Valid ops: {valid_list}."
-    return f"Unknown op {typed_op!r}. Valid ops: {valid_list}."
+        return f"Unknown op {raw_op!r} — did you mean {sug_list}? Valid ops: {valid_list}."
+    return f"Unknown op {raw_op!r}. Valid ops: {valid_list}."

--- a/src/godot_ai/middleware/op_typo_hint.py
+++ b/src/godot_ai/middleware/op_typo_hint.py
@@ -1,0 +1,84 @@
+"""Augment Pydantic literal_error on ``<domain>_manage`` op typos with a hint.
+
+The ``op`` parameter on every rolled-up ``<domain>_manage`` tool is typed
+``Literal[...]`` of the registered op names (see ``tools/_meta_tool.py``).
+Pydantic validates this at the FastMCP schema boundary, so a typo like
+``node_manage(op="get_childen")`` surfaces as a plain ``literal_error``:
+
+    Input should be 'get_children', 'delete', 'rename', ...
+
+That message lists the alternatives but doesn't single out the closest
+match. Op-name typos are the most common rollup-misuse pattern (see #211),
+and the in-house ``difflib`` suggester in ``dispatch_manage_op`` never gets
+to fire — Pydantic rejects the call before any handler runs.
+
+This middleware catches the ``ValidationError`` for tools registered via
+``register_manage_tool`` when the failing field is ``op``, looks the
+candidate ops up in ``MANAGE_TOOL_OPS`` (the same registry that built the
+``Literal`` schema), and re-raises a ``ToolError`` whose message starts
+with a ``difflib.get_close_matches``-derived "Did you mean: ..." hint. The
+schema itself is unchanged, so tool-search-aware clients still see the
+full ``Literal`` enum.
+"""
+
+from __future__ import annotations
+
+import difflib
+import logging
+
+from fastmcp.exceptions import ToolError
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+from fastmcp.tools.base import ToolResult
+from mcp.types import CallToolRequestParams
+from pydantic import ValidationError
+
+from godot_ai.tools._meta_tool import MANAGE_TOOL_OPS
+
+logger = logging.getLogger(__name__)
+
+
+class HintOpTypoOnManage(Middleware):
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[CallToolRequestParams],
+        call_next: CallNext[CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        try:
+            return await call_next(context)
+        except ValidationError as exc:
+            candidates = MANAGE_TOOL_OPS.get(context.message.name)
+            if candidates is None:
+                raise
+            hint = _build_hint(exc, context.message.arguments, candidates)
+            if hint is None:
+                raise
+            logger.debug("Rewrote op typo error on %s: %s", context.message.name, hint)
+            raise ToolError(hint) from exc
+
+
+def _build_hint(
+    exc: ValidationError, arguments: dict | None, candidates: tuple[str, ...]
+) -> str | None:
+    """Return a ``Did you mean`` message for an op literal_error, else None.
+
+    Returns None — leaving Pydantic's normal message — when the error isn't
+    a ``literal_error`` on the ``op`` field. Other validation errors fall
+    through unchanged so unrelated bugs aren't masked.
+    """
+    if not any(
+        err.get("type") == "literal_error" and err.get("loc") == ("op",) for err in exc.errors()
+    ):
+        return None
+
+    typed_op = ""
+    if isinstance(arguments, dict):
+        raw_op = arguments.get("op")
+        if isinstance(raw_op, str):
+            typed_op = raw_op
+
+    suggestions = difflib.get_close_matches(typed_op, candidates, n=3, cutoff=0.5)
+    valid_list = ", ".join(repr(c) for c in candidates)
+    if suggestions:
+        sug_list = ", ".join(repr(s) for s in suggestions)
+        return f"Unknown op {typed_op!r} — did you mean {sug_list}? Valid ops: {valid_list}."
+    return f"Unknown op {typed_op!r}. Valid ops: {valid_list}."

--- a/src/godot_ai/server.py
+++ b/src/godot_ai/server.py
@@ -11,7 +11,11 @@ from dataclasses import dataclass
 from fastmcp import FastMCP
 
 from godot_ai.godot_client.client import GodotClient
-from godot_ai.middleware import ParseStringifiedParams, StripClientWrapperKwargs
+from godot_ai.middleware import (
+    HintOpTypoOnManage,
+    ParseStringifiedParams,
+    StripClientWrapperKwargs,
+)
 from godot_ai.resources.editor import register_editor_resources
 from godot_ai.resources.library import register_library_resources
 from godot_ai.resources.nodes import register_node_resources
@@ -149,6 +153,11 @@ def create_server(
     ## strict-mode Pydantic rejects them. Some clients (Cline) auto-serialize
     ## nested objects. See #206.
     mcp.add_middleware(ParseStringifiedParams())
+
+    ## Rewrite Pydantic literal_error on ``<domain>_manage`` op typos with a
+    ## ``difflib``-derived "Did you mean" hint, since op typos are the most
+    ## common rollup-misuse pattern. See #211.
+    mcp.add_middleware(HintOpTypoOnManage())
 
     exclude = set(exclude_domains or ())
     if exclude:

--- a/src/godot_ai/tools/_meta_tool.py
+++ b/src/godot_ai/tools/_meta_tool.py
@@ -40,6 +40,13 @@ from godot_ai.tools import DEFER_META
 OpHandler = Callable[..., Awaitable[dict] | dict]
 
 
+## Registry of registered ``<domain>_manage`` tools and their op names.
+## Populated by ``register_manage_tool`` so middleware (e.g.
+## ``HintOpTypoOnManage``) can reach the candidate list without
+## reverse-engineering Pydantic's human-readable error string.
+MANAGE_TOOL_OPS: dict[str, tuple[str, ...]] = {}
+
+
 def register_manage_tool(
     mcp: FastMCP,
     *,
@@ -66,6 +73,7 @@ def register_manage_tool(
     if not ops:
         raise ValueError(f"register_manage_tool: ops cannot be empty (tool {tool_name!r})")
 
+    MANAGE_TOOL_OPS[tool_name] = tuple(ops.keys())
     op_literal = Literal[tuple(ops.keys())]  # type: ignore[valid-type]
 
     async def manage(ctx: Context, op, params=None, session_id="") -> dict:

--- a/src/godot_ai/tools/input_map.py
+++ b/src/godot_ai/tools/input_map.py
@@ -15,8 +15,12 @@ Resource form: ``godot://input_map`` — prefer for active-session reads.
 
 Ops:
   • list(include_builtin=False)
-        List input actions and their bound events. Set include_builtin=True
-        to include Godot's built-in ``ui_*`` actions.
+        List input actions and their bound events. By default only
+        user-authored actions (those persisted in ``project.godot`` under
+        ``input/<name>``) are returned; pass ``include_builtin=True`` to
+        also surface Godot's ``ui_*`` and editor-runtime actions
+        (``spatial_editor/*``, etc.). The ``is_builtin`` field on each
+        entry is true for any action not authored by the user.
   • add_action(action, deadzone=0.5)
         Create a new empty input action.
   • remove_action(action)

--- a/src/godot_ai/tools/signal.py
+++ b/src/godot_ai/tools/signal.py
@@ -11,9 +11,12 @@ _DESCRIPTION = """\
 Signals (Godot's event/observer mechanism) — list, connect, disconnect.
 
 Ops:
-  • list(path)
+  • list(path, include_editor=False)
         List all signals on the node and their current connections (built-in
-        and custom).
+        and custom). By default editor-internal connections (the
+        SceneTreeEditor dock and friends) are filtered out — pass
+        ``include_editor=True`` to surface them. The response carries
+        ``editor_connection_count`` so an agent can tell how many were hidden.
   • connect(path, signal, target, method)
         Connect a signal from ``path`` to a method on the target node.
         Undoable.

--- a/test_project/tests/test_input.gd
+++ b/test_project/tests/test_input.gd
@@ -50,8 +50,18 @@ func test_list_actions_hides_editor_internal_namespaces() -> void:
 	## actions like ``spatial_editor/freelook_left`` leak through on the
 	## default (``include_builtin=False``) path. Cross-check that the new
 	## "must exist in project.godot" filter hides them.
-	var result := _handler.list_actions({})
-	for action in result.data.actions:
+	##
+	## The test project's project.godot has no ``[input]`` section so the
+	## default-filtered list is empty — comparing against the full
+	## ``include_builtin=true`` count is what proves the filter is doing
+	## work, not just iterating zero entries.
+	var with_builtin := _handler.list_actions({"include_builtin": true})
+	var default := _handler.list_actions({})
+	assert_has_key(with_builtin, "data")
+	assert_has_key(default, "data")
+	assert_true(with_builtin.data.count > default.data.count,
+		"include_builtin=true must surface entries the default filter hides")
+	for action in default.data.actions:
 		assert_false(str(action.name).begins_with("spatial_editor/"),
 			"Editor-internal spatial_editor/* must not appear in default list")
 		assert_false(str(action.name).begins_with("ui_"),

--- a/test_project/tests/test_input.gd
+++ b/test_project/tests/test_input.gd
@@ -33,13 +33,29 @@ func test_list_actions_excludes_builtins_by_default() -> void:
 	assert_has_key(result.data, "actions")
 	assert_has_key(result.data, "count")
 	for action in result.data.actions:
-		assert_false(action.is_builtin, "Default should exclude ui_* actions")
+		assert_false(action.is_builtin, "Default should only return user-authored actions")
+		## Cross-check: the action must actually exist in project.godot.
+		assert_true(ProjectSettings.has_setting("input/" + action.name),
+			"Default-filtered action should be authored in project.godot: %s" % action.name)
 
 
 func test_list_actions_with_builtins() -> void:
 	var result := _handler.list_actions({"include_builtin": true})
 	assert_has_key(result, "data")
 	assert_gt(result.data.count, 0, "Should have at least the built-in ui_* actions")
+
+
+func test_list_actions_hides_editor_internal_namespaces() -> void:
+	## Bug #213: the previous ``begins_with("ui_")`` filter let editor-runtime
+	## actions like ``spatial_editor/freelook_left`` leak through on the
+	## default (``include_builtin=False``) path. Cross-check that the new
+	## "must exist in project.godot" filter hides them.
+	var result := _handler.list_actions({})
+	for action in result.data.actions:
+		assert_false(str(action.name).begins_with("spatial_editor/"),
+			"Editor-internal spatial_editor/* must not appear in default list")
+		assert_false(str(action.name).begins_with("ui_"),
+			"Built-in ui_* must not appear in default list")
 
 
 # ----- add_action -----

--- a/test_project/tests/test_signal.gd
+++ b/test_project/tests/test_signal.gd
@@ -49,6 +49,43 @@ func test_list_signals_no_scene() -> void:
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 
 
+func test_list_signals_hides_editor_internal_connections_by_default() -> void:
+	## Bug #213: SceneTreeEditor observers connect to every scene node and
+	## previously surfaced as user-authored connections. Default filter
+	## drops connections whose target is outside the edited scene tree.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root — is a scene open?")
+		return
+	var path := "/" + scene_root.name
+	var result := _handler.list_signals({"path": path})
+	assert_has_key(result, "data")
+	assert_has_key(result.data, "connections")
+	assert_has_key(result.data, "editor_connection_count")
+	for conn in result.data.connections:
+		var target_path: String = conn.target
+		assert_false(target_path.contains("SceneTreeEditor"),
+			"Editor-internal SceneTreeEditor connection leaked into default list: %s" % target_path)
+		assert_false(target_path.contains("DockSlot"),
+			"Editor-internal dock connection leaked into default list: %s" % target_path)
+
+
+func test_list_signals_include_editor_surfaces_internal_connections() -> void:
+	## Opt-in flag returns the editor-side connections that the default
+	## filter hides. On a real editor scene there's almost always at least
+	## one — assert the include_editor count is >= the default count.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root — is a scene open?")
+		return
+	var path := "/" + scene_root.name
+	var default_result := _handler.list_signals({"path": path})
+	var full_result := _handler.list_signals({"path": path, "include_editor": true})
+	assert_has_key(full_result, "data")
+	assert_true(full_result.data.connection_count >= default_result.data.connection_count,
+		"include_editor should not hide any user connections")
+
+
 # ----- connect_signal -----
 
 func test_connect_signal_missing_params() -> void:

--- a/test_project/tests/test_signal.gd
+++ b/test_project/tests/test_signal.gd
@@ -86,6 +86,44 @@ func test_list_signals_include_editor_surfaces_internal_connections() -> void:
 		"include_editor should not hide any user connections")
 
 
+func test_is_editor_internal_target_keeps_autoload_targets() -> void:
+	## Bug #213 review: autoload singletons live under /root/<Name>, which
+	## is outside the edited scene tree, so a naive "outside scene_root"
+	## filter would also hide legitimate connections to autoloads. The
+	## ``autoload/<name>`` ProjectSetting whitelist must keep them visible.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root — is a scene open?")
+		return
+
+	## Inject a fake autoload entry and a Node sitting where an autoload
+	## would live (parented under a freestanding Node so we don't touch the
+	## edited scene). The Node's ``name`` matches the autoload key.
+	var setting_key := "autoload/_TestAutoloadFilter"
+	var had_before := ProjectSettings.has_setting(setting_key)
+	var before_value: Variant = ProjectSettings.get_setting(setting_key) if had_before else null
+	ProjectSettings.set_setting(setting_key, "*res://tests/does_not_exist.gd")
+
+	var fake_autoload := Node.new()
+	fake_autoload.name = "_TestAutoloadFilter"
+	var unrelated_target := Node.new()
+	unrelated_target.name = "_NotAnAutoload"
+	## Don't add to tree — the helper only needs the Node + a name + the
+	## ProjectSettings entry to classify it.
+
+	assert_false(_handler._is_editor_internal_target(fake_autoload, scene_root),
+		"Autoload-named node should NOT be classified as editor-internal")
+	assert_true(_handler._is_editor_internal_target(unrelated_target, scene_root),
+		"Non-autoload node outside the edited scene SHOULD be editor-internal")
+
+	fake_autoload.free()
+	unrelated_target.free()
+	if had_before:
+		ProjectSettings.set_setting(setting_key, before_value)
+	else:
+		ProjectSettings.set_setting(setting_key, null)
+
+
 # ----- connect_signal -----
 
 func test_connect_signal_missing_params() -> void:

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 
+import pytest
 import websockets
 
 # ---------------------------------------------------------------------------
@@ -6033,3 +6034,27 @@ class TestManageRollupAcceptsStringifiedParams:
         await task
 
         assert result.data["path"] == "res://demo.tscn"
+
+
+# ---------------------------------------------------------------------------
+# *_manage op typo "Did you mean" hint (#211)
+# ---------------------------------------------------------------------------
+
+
+class TestManageRollupHintsOnOpTypo:
+    async def test_op_typo_surfaces_did_you_mean_message(self, mcp_stack):
+        """Typo'd op hits the middleware hint, not the raw Pydantic enum dump."""
+        from fastmcp.exceptions import ToolError
+
+        client, _plugin = mcp_stack
+
+        with pytest.raises(ToolError) as info:
+            await client.call_tool(
+                "node_manage",
+                {"op": "get_childen", "params": {"path": "/Main"}},
+            )
+
+        msg = str(info.value)
+        assert "'get_childen'" in msg
+        assert "did you mean" in msg.lower()
+        assert "'get_children'" in msg

--- a/tests/unit/test_middleware_op_typo_hint.py
+++ b/tests/unit/test_middleware_op_typo_hint.py
@@ -28,7 +28,7 @@ def register_node_manage():
     MANAGE_TOOL_OPS.pop("node_manage", None)
 
 
-def _make_op_validation_error(typed: str, ops: tuple[str, ...]) -> ValidationError:
+def _make_op_validation_error(typed, ops: tuple[str, ...]) -> ValidationError:
     """Trigger a real Pydantic literal_error for a Literal[ops] field.
 
     Mirrors what FastMCP raises when a ``<domain>_manage`` call's ``op``
@@ -148,13 +148,68 @@ class TestHintOpTypoOnManage:
             await mw.on_call_tool(ctx, await _raise_call_next(RuntimeError("boom")))
 
     async def test_handles_missing_op_argument(self, register_node_manage):
-        ## ``op`` missing entirely is a different shape of error (a
-        ## ``missing`` type on most schemas, but Pydantic can still raise
-        ## a literal_error against an empty input). The middleware should
-        ## still emit a useful message even with no typed-op to compare.
+        ## arguments=None means the middleware can't recover what the user
+        ## sent. Surface "op must be a string" (not the misleading empty
+        ## placeholder ``Unknown op ''``) and still list the valid ops.
         mw = HintOpTypoOnManage()
         exc = _make_op_validation_error("", register_node_manage)
         ctx = _FakeContext(message=CallToolRequestParams(name="node_manage", arguments=None))
         with pytest.raises(ToolError) as info:
             await mw.on_call_tool(ctx, await _raise_call_next(exc))
-        assert "Valid ops" in str(info.value)
+        msg = str(info.value)
+        assert "must be a string" in msg
+        assert "Valid ops" in msg
+
+    async def test_handles_non_string_op_value(self, register_node_manage):
+        ## Pydantic raises literal_error when ``op`` is e.g. an int. We
+        ## should not coerce to ``''`` and emit ``Unknown op ''`` — instead
+        ## report the actual value and its type so the user can see what
+        ## they sent.
+        op_literal = Literal[register_node_manage]  # type: ignore[valid-type]
+        wrapper_ta = TypeAdapter(dict[str, op_literal])  # type: ignore[valid-type]
+        try:
+            wrapper_ta.validate_python({"op": 123})
+        except ValidationError as raised:
+            exc = raised
+        else:
+            raise AssertionError("Pydantic accepted int op unexpectedly")
+
+        mw = HintOpTypoOnManage()
+        ctx = _FakeContext(message=CallToolRequestParams(name="node_manage", arguments={"op": 123}))
+        with pytest.raises(ToolError) as info:
+            await mw.on_call_tool(ctx, await _raise_call_next(exc))
+        msg = str(info.value)
+        assert "must be a string" in msg
+        assert "int" in msg
+        assert "123" in msg
+        assert "Valid ops" in msg
+
+    async def test_does_not_mask_other_validation_errors(self, register_node_manage):
+        ## When a request fails on both ``op`` AND another field, rewriting
+        ## to a narrow op-only hint would silently drop the other errors.
+        ## Fall through to Pydantic's default message instead.
+        from pydantic import BaseModel
+
+        op_literal = Literal[register_node_manage]  # type: ignore[valid-type]
+
+        class _ManageCall(BaseModel):
+            op: op_literal  # type: ignore[valid-type]
+            params: dict | None = None
+
+        try:
+            _ManageCall(op="get_childen", params="not-a-dict")  # type: ignore[arg-type]
+        except ValidationError as raised:
+            exc = raised
+        else:
+            raise AssertionError("Pydantic accepted invalid call unexpectedly")
+        assert len(exc.errors()) >= 2  # sanity: we constructed multi-error case
+
+        mw = HintOpTypoOnManage()
+        ctx = _FakeContext(
+            message=CallToolRequestParams(
+                name="node_manage",
+                arguments={"op": "get_childen", "params": "not-a-dict"},
+            )
+        )
+        with pytest.raises(ValidationError):
+            await mw.on_call_tool(ctx, await _raise_call_next(exc))

--- a/tests/unit/test_middleware_op_typo_hint.py
+++ b/tests/unit/test_middleware_op_typo_hint.py
@@ -1,0 +1,160 @@
+"""Unit tests for the HintOpTypoOnManage middleware (#211)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import pytest
+from fastmcp.exceptions import ToolError
+from mcp.types import CallToolRequestParams
+from pydantic import TypeAdapter, ValidationError
+
+from godot_ai.middleware import HintOpTypoOnManage
+from godot_ai.tools._meta_tool import MANAGE_TOOL_OPS
+
+
+@dataclass
+class _FakeContext:
+    message: CallToolRequestParams
+
+
+@pytest.fixture
+def register_node_manage():
+    """Populate the registry like ``register_manage_tool`` would at boot."""
+    ops = ("get_children", "delete", "rename", "duplicate")
+    MANAGE_TOOL_OPS["node_manage"] = ops
+    yield ops
+    MANAGE_TOOL_OPS.pop("node_manage", None)
+
+
+def _make_op_validation_error(typed: str, ops: tuple[str, ...]) -> ValidationError:
+    """Trigger a real Pydantic literal_error for a Literal[ops] field.
+
+    Mirrors what FastMCP raises when a ``<domain>_manage`` call's ``op``
+    fails the schema's ``Literal[...]`` constraint, so the middleware sees
+    the same error shape it would in production.
+    """
+    op_literal = Literal[ops]  # type: ignore[valid-type]
+    ## Wrapping in dict[str, Literal[...]] reshapes the failing loc to look
+    ## like FastMCP's call schema (the field is ``op`` rather than the empty
+    ## top-level loc Pydantic would produce on a bare TypeAdapter).
+    wrapper_ta = TypeAdapter(dict[str, op_literal])  # type: ignore[valid-type]
+    try:
+        wrapper_ta.validate_python({"op": typed})
+    except ValidationError as wrapped:
+        return wrapped
+    raise AssertionError("Pydantic accepted typed value unexpectedly")
+
+
+async def _raise_call_next(exc: BaseException):
+    async def _call_next(_context):
+        raise exc
+
+    return _call_next
+
+
+async def _ok_call_next(_context):
+    return "ok"
+
+
+class TestHintOpTypoOnManage:
+    async def test_passes_through_when_handler_succeeds(self, register_node_manage):
+        mw = HintOpTypoOnManage()
+        ctx = _FakeContext(
+            message=CallToolRequestParams(name="node_manage", arguments={"op": "delete"})
+        )
+        assert await mw.on_call_tool(ctx, _ok_call_next) == "ok"
+
+    async def test_rewrites_op_typo_with_did_you_mean_hint(self, register_node_manage):
+        mw = HintOpTypoOnManage()
+        exc = _make_op_validation_error("get_childen", register_node_manage)
+        ctx = _FakeContext(
+            message=CallToolRequestParams(
+                name="node_manage",
+                arguments={"op": "get_childen", "params": {"path": "/Main"}},
+            )
+        )
+        with pytest.raises(ToolError) as info:
+            await mw.on_call_tool(ctx, await _raise_call_next(exc))
+
+        msg = str(info.value)
+        assert "'get_childen'" in msg
+        assert "did you mean" in msg.lower()
+        assert "'get_children'" in msg
+        ## The hint should keep the full valid-op list for the agent.
+        assert "'delete'" in msg
+        assert "'rename'" in msg
+
+    async def test_falls_back_to_valid_list_when_no_close_match(self):
+        ops = ("create", "delete")
+        MANAGE_TOOL_OPS["thing_manage"] = ops
+        try:
+            mw = HintOpTypoOnManage()
+            exc = _make_op_validation_error("xyzzy", ops)
+            ctx = _FakeContext(
+                message=CallToolRequestParams(name="thing_manage", arguments={"op": "xyzzy"})
+            )
+            with pytest.raises(ToolError) as info:
+                await mw.on_call_tool(ctx, await _raise_call_next(exc))
+
+            msg = str(info.value)
+            assert "'xyzzy'" in msg
+            assert "did you mean" not in msg.lower()
+            assert "'create'" in msg
+            assert "'delete'" in msg
+        finally:
+            MANAGE_TOOL_OPS.pop("thing_manage", None)
+
+    async def test_ignores_unregistered_tools(self):
+        ## Named verbs (e.g. ``editor_state``) that aren't registered through
+        ## ``register_manage_tool`` shouldn't have their errors rewritten —
+        ## they don't carry an ``op`` parameter and the user's actual mistake
+        ## might be something else entirely.
+        mw = HintOpTypoOnManage()
+        exc = _make_op_validation_error("creat", ("create", "delete"))
+        ctx = _FakeContext(
+            message=CallToolRequestParams(name="editor_state", arguments={"op": "creat"})
+        )
+        with pytest.raises(ValidationError):
+            await mw.on_call_tool(ctx, await _raise_call_next(exc))
+
+    async def test_passes_through_non_op_validation_errors(self, register_node_manage):
+        ## A literal_error on a different field (e.g. a typed param value)
+        ## must not be masked — the user gets Pydantic's normal message.
+        op_literal = Literal["create", "delete"]  # type: ignore[valid-type]
+        wrapper_ta = TypeAdapter(dict[str, op_literal])  # type: ignore[valid-type]
+        try:
+            wrapper_ta.validate_python({"some_other_field": "bad"})
+        except ValidationError as exc:
+            real = exc
+
+        mw = HintOpTypoOnManage()
+        ctx = _FakeContext(
+            message=CallToolRequestParams(
+                name="node_manage",
+                arguments={"op": "create", "some_other_field": "bad"},
+            )
+        )
+        with pytest.raises(ValidationError):
+            await mw.on_call_tool(ctx, await _raise_call_next(real))
+
+    async def test_passes_through_non_validation_exceptions(self, register_node_manage):
+        mw = HintOpTypoOnManage()
+        ctx = _FakeContext(
+            message=CallToolRequestParams(name="node_manage", arguments={"op": "create"})
+        )
+        with pytest.raises(RuntimeError, match="boom"):
+            await mw.on_call_tool(ctx, await _raise_call_next(RuntimeError("boom")))
+
+    async def test_handles_missing_op_argument(self, register_node_manage):
+        ## ``op`` missing entirely is a different shape of error (a
+        ## ``missing`` type on most schemas, but Pydantic can still raise
+        ## a literal_error against an empty input). The middleware should
+        ## still emit a useful message even with no typed-op to compare.
+        mw = HintOpTypoOnManage()
+        exc = _make_op_validation_error("", register_node_manage)
+        ctx = _FakeContext(message=CallToolRequestParams(name="node_manage", arguments=None))
+        with pytest.raises(ToolError) as info:
+            await mw.on_call_tool(ctx, await _raise_call_next(exc))
+        assert "Valid ops" in str(info.value)

--- a/tests/unit/test_middleware_parse_stringified_params.py
+++ b/tests/unit/test_middleware_parse_stringified_params.py
@@ -50,9 +50,7 @@ class TestParseStringifiedParams:
         seen: list[dict | None] = []
         mw = ParseStringifiedParams()
         original = {"op": "list", "params": {"limit": 10}}
-        ctx = _FakeContext(
-            message=CallToolRequestParams(name="session_manage", arguments=original)
-        )
+        ctx = _FakeContext(message=CallToolRequestParams(name="session_manage", arguments=original))
         await mw.on_call_tool(ctx, await _record_arguments_call_next(seen))
 
         ## Same dict identity: middleware mustn't reallocate when there's
@@ -94,9 +92,7 @@ class TestParseStringifiedParams:
     async def test_handles_none_arguments(self):
         seen: list[dict | None] = []
         mw = ParseStringifiedParams()
-        ctx = _FakeContext(
-            message=CallToolRequestParams(name="editor_state", arguments=None)
-        )
+        ctx = _FakeContext(message=CallToolRequestParams(name="editor_state", arguments=None))
         await mw.on_call_tool(ctx, await _record_arguments_call_next(seen))
         assert seen == [None]
 

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -2557,7 +2557,7 @@ async def test_signal_list_handler():
     assert result["signal_count"] == 2
     assert result["signals"][0]["name"] == "ready"
     assert client.calls[-1]["command"] == "list_signals"
-    assert client.calls[-1]["params"] == {"path": "/Main/Player"}
+    assert client.calls[-1]["params"] == {"path": "/Main/Player", "include_editor": False}
 
 
 async def test_signal_connect_handler():


### PR DESCRIPTION
Bundles two related rollup-surface fixes flagged by the post-#203 friction log.

## #211 — "Did you mean" hint on `<domain>_manage` op typos

`op` on every rolled-up tool is typed `Literal[...]`, so Pydantic rejects typos like `node_manage(op="get_childen")` at the FastMCP schema boundary — the in-house `difflib` suggester in `dispatch_manage_op` never gets to fire. CLAUDE.md already calls this out as a known limitation. Op-name typos are the most common rollup-misuse pattern, so closing the gap is high-value.

**Fix.** New `HintOpTypoOnManage` middleware that catches `pydantic.ValidationError` for tools registered through `register_manage_tool`, looks up the candidate ops in a new `MANAGE_TOOL_OPS: dict[str, tuple[str, ...]]` registry (populated at registration time, same source-of-truth as the `Literal[...]` schema), and re-raises a `ToolError` whose message starts with a `difflib.get_close_matches`-derived "Did you mean ..." hint. The schema is unchanged, so tool-search-aware clients still see the full `Literal` enum.

Going through the registry instead of regex-parsing Pydantic's human-readable `ctx.expected` string keeps the middleware decoupled from Pydantic's error-message format.

```text
Before: Input should be 'get_children', 'get_groups', 'delete', 'duplicate', 'rename', ...
 After: Unknown op 'get_childen' — did you mean 'get_children'? Valid ops: 'get_children', ...
```

## #213 — Hide editor-internal entries from `list` ops

Two `list` ops were leaking the editor's own wiring into responses an agent reading the result would mistake for user content:

- **`signal_manage(op="list")`** returned ~5 `SceneTreeEditor::*` observer connections per scene node (visibility/script/state-changed listeners on the editor dock side).
- **`input_map_manage(op="list", include_builtin=False)`** returned 16 `spatial_editor/*` actions (`freelook_*`, `viewport_orbit_modifier_*`, etc.) — the previous filter only dropped the `ui_*` namespace.

**Fix.**
- `signal_handler.gd::list_signals` drops connections whose target Node lives outside the edited scene tree (`scene_root != target and not scene_root.is_ancestor_of(target)`). The response gains `editor_connection_count` so an agent can tell how many were hidden, and `include_editor=true` opts back in.
- `input_handler.gd::list_actions` now only returns actions persisted under `input/<name>` in `project.godot` — that's the authoritative test for "user-authored." Editor-runtime namespaces (`ui_*`, `spatial_editor/*`, future ones) are hidden by default. `include_builtin=true` still surfaces them, and the `is_builtin` field flips to mean "not user-authored" so it covers both `ui_*` and the editor runtime cases.

## Tests

- 7 unit tests on the new middleware (op typo with close match, no close match, non-`_manage` tool fall-through, non-`op` validation error fall-through, non-validation exception fall-through, missing-op-arg, success path).
- 1 end-to-end integration test through the FastMCP stack confirms the hint reaches the client as a `ToolError`.
- GDScript suites gain coverage for the editor-internal filter on both signals and input actions, including the opt-in `include_editor` flag and the `spatial_editor/*` regression case.
- All 616 Python tests pass; `ruff check` and `ruff format` clean.

## Test plan

- [x] `pytest -v` — 616 passed
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [ ] Manual smoke in Godot editor (CI runs the GDScript test suite)

## Out of scope

#212 (fully-stringified `params` arg) is a misdiagnosis — the middleware shipped in #206/#207 already decodes `arguments["params"]` when it arrives as a string (see `tests/unit/test_middleware_parse_stringified_params.py::test_decodes_string_params_on_manage_call` and the integration test `test_scene_manage_with_stringified_params_carrying_values`). I'll close #212 with a pointer to those tests separately.

#210 (handler crash on bad input type → opaque INTERNAL_ERROR) needs GDScript handler-side input validation across many handlers and a dispatcher tweak; deferring to a follow-up PR.

https://claude.ai/code/session_01515hA6dPc5w9eFi3bGLm2Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01515hA6dPc5w9eFi3bGLm2Y)_