### PR TITLE
fix(handlers): drop editor-internal entries from list_signals/list_actions

### DIFF
--- a/plugin/addons/godot_ai/handlers/input_handler.gd
+++ b/plugin/addons/godot_ai/handlers/input_handler.gd
@@ -7,11 +7,17 @@ extends RefCounted
 
 
 func list_actions(params: Dictionary) -> Dictionary:
+	## Default returns only user-authored actions — those persisted to
+	## ``project.godot`` under ``input/<name>``. Editor-runtime actions like
+	## ``ui_*`` (built-ins) and ``spatial_editor/*`` (the 3D viewport's
+	## freelook/orbit/pan keybindings) live only on InputMap and are filtered
+	## out unless ``include_builtin`` is true.
 	var include_builtin: bool = params.get("include_builtin", false)
 	var actions: Array[Dictionary] = []
 	for action_name in InputMap.get_actions():
 		var name_str := str(action_name)
-		var is_builtin := name_str.begins_with("ui_")
+		var is_user_defined := ProjectSettings.has_setting("input/" + name_str)
+		var is_builtin := not is_user_defined
 		if is_builtin and not include_builtin:
 			continue
 		var events: Array[Dictionary] = []

--- a/plugin/addons/godot_ai/handlers/signal_handler.gd
+++ b/plugin/addons/godot_ai/handlers/signal_handler.gd
@@ -24,6 +24,8 @@ func list_signals(params: Dictionary) -> Dictionary:
 	if node == null:
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ScenePath.format_node_error(path, scene_root))
 
+	var include_editor_internal: bool = params.get("include_editor_internal", false)
+
 	var signals: Array[Dictionary] = []
 	for sig in node.get_signal_list():
 		var args: Array[Dictionary] = []
@@ -35,16 +37,23 @@ func list_signals(params: Dictionary) -> Dictionary:
 		})
 
 	var connections: Array[Dictionary] = []
+	var editor_connection_count := 0
 	for sig in signals:
 		for conn in node.get_signal_connection_list(sig.name):
 			var callable: Callable = conn.get("callable", Callable())
 			var target := callable.get_object()
 			if target == null:
 				continue  # skip connections to freed objects
+			var origin := _connection_origin(target, scene_root)
+			if origin == "editor":
+				editor_connection_count += 1
+				if not include_editor_internal:
+					continue
 			connections.append({
 				"signal": sig.name,
 				"target": ScenePath.from_node(target, scene_root) if target is Node else str(target),
 				"method": callable.get_method(),
+				"origin": origin,
 			})
 
 	return {
@@ -54,8 +63,29 @@ func list_signals(params: Dictionary) -> Dictionary:
 			"signal_count": signals.size(),
 			"connections": connections,
 			"connection_count": connections.size(),
+			"editor_connection_count": editor_connection_count,
 		}
 	}
+
+
+## Classify where a signal's target object lives.
+## Returns "scene" (in/under the edited scene), "autoload" (a registered
+## ProjectSettings autoload), or "editor" (anything else — usually the editor
+## docks observing the SceneTree).
+static func _connection_origin(target: Object, scene_root: Node) -> String:
+	if not (target is Node):
+		return "scene"
+	var node := target as Node
+	if node == scene_root or scene_root.is_ancestor_of(node):
+		return "scene"
+	var tree := node.get_tree()
+	if tree != null and tree.root != null:
+		var cursor := node
+		while cursor.get_parent() != null and cursor.get_parent() != tree.root:
+			cursor = cursor.get_parent()
+		if cursor.get_parent() == tree.root and ProjectSettings.has_setting("autoload/" + str(cursor.name)):
+			return "autoload"
+	return "editor"
 
 
 func connect_signal(params: Dictionary) -> Dictionary:

--- a/plugin/addons/godot_ai/handlers/signal_handler.gd
+++ b/plugin/addons/godot_ai/handlers/signal_handler.gd
@@ -69,12 +69,19 @@ func list_signals(params: Dictionary) -> Dictionary:
 
 
 ## Classify where a signal's target object lives.
-## Returns "scene" (in/under the edited scene), "autoload" (a registered
-## ProjectSettings autoload), or "editor" (anything else — usually the editor
-## docks observing the SceneTree).
+## Returns one of:
+##   "scene"    — target is a Node in or under the edited scene root.
+##   "autoload" — target is a Node under a registered ProjectSettings autoload
+##                that's instantiated at edit time.
+##   "object"   — target is a non-Node Object (typically a Resource / RefCounted
+##                held by user scripts). Kept in the default list because it's
+##                almost always user-authored data.
+##   "editor"   — Node target outside the scene tree and not an autoload, e.g.
+##                the SceneTreeEditor dock observing scene state. Filtered out
+##                of the default list.
 static func _connection_origin(target: Object, scene_root: Node) -> String:
 	if not (target is Node):
-		return "scene"
+		return "object"
 	var node := target as Node
 	if node == scene_root or scene_root.is_ancestor_of(node):
 		return "scene"

--- a/src/godot_ai/handlers/signal.py
+++ b/src/godot_ai/handlers/signal.py
@@ -6,8 +6,15 @@ from godot_ai.handlers._readiness import require_writable
 from godot_ai.runtime.interface import Runtime
 
 
-async def signal_list(runtime: Runtime, path: str) -> dict:
-    return await runtime.send_command("list_signals", {"path": path})
+async def signal_list(
+    runtime: Runtime,
+    path: str,
+    include_editor_internal: bool = False,
+) -> dict:
+    params: dict = {"path": path}
+    if include_editor_internal:
+        params["include_editor_internal"] = True
+    return await runtime.send_command("list_signals", params)
 
 
 async def signal_connect(

--- a/src/godot_ai/resources/library.py
+++ b/src/godot_ai/resources/library.py
@@ -34,7 +34,11 @@ def register_library_resources(mcp: FastMCP) -> None:
 
     @mcp.resource("godot://input_map", mime_type="application/json")
     async def get_input_map(ctx: Context) -> dict[str, Any]:
-        """All input map actions and their bound events. Excludes built-in ui_*."""
+        """User-authored input map actions and their bound events.
+
+        Returns only actions persisted to ``project.godot``. Editor-runtime
+        actions (``ui_*``, ``spatial_editor/*``, etc.) are excluded.
+        """
         runtime = DirectRuntime.from_context(ctx)
         return await safe_payload(input_map_handlers.input_map_list(runtime))
 

--- a/src/godot_ai/tools/input_map.py
+++ b/src/godot_ai/tools/input_map.py
@@ -15,8 +15,9 @@ Resource form: ``godot://input_map`` — prefer for active-session reads.
 
 Ops:
   • list(include_builtin=False)
-        List input actions and their bound events. Set include_builtin=True
-        to include Godot's built-in ``ui_*`` actions.
+        List user-authored input actions (those persisted to ``project.godot``)
+        and their bound events. Set include_builtin=True to also include
+        editor-runtime actions like ``ui_*`` and ``spatial_editor/*``.
   • add_action(action, deadzone=0.5)
         Create a new empty input action.
   • remove_action(action)

--- a/src/godot_ai/tools/signal.py
+++ b/src/godot_ai/tools/signal.py
@@ -11,9 +11,13 @@ _DESCRIPTION = """\
 Signals (Godot's event/observer mechanism) — list, connect, disconnect.
 
 Ops:
-  • list(path)
-        List all signals on the node and their current connections (built-in
-        and custom).
+  • list(path, include_editor_internal=False)
+        List all signals on the node and their connections. Editor-internal
+        observer connections (e.g. the SceneTree dock listening for
+        ``child_order_changed``) are filtered out by default and counted in
+        ``editor_connection_count``; set include_editor_internal=True to see
+        them. Each connection carries an ``origin`` of ``"scene"``,
+        ``"autoload"``, or ``"editor"``.
   • connect(path, signal, target, method)
         Connect a signal from ``path`` to a method on the target node.
         Undoable.

--- a/src/godot_ai/tools/signal.py
+++ b/src/godot_ai/tools/signal.py
@@ -16,8 +16,10 @@ Ops:
         observer connections (e.g. the SceneTree dock listening for
         ``child_order_changed``) are filtered out by default and counted in
         ``editor_connection_count``; set include_editor_internal=True to see
-        them. Each connection carries an ``origin`` of ``"scene"``,
-        ``"autoload"``, or ``"editor"``.
+        them. Each connection carries an ``origin`` of ``"scene"`` (Node in
+        the edited scene), ``"autoload"`` (a registered autoload),
+        ``"object"`` (non-Node Object target — kept by default), or
+        ``"editor"`` (filtered by default).
   • connect(path, signal, target, method)
         Connect a signal from ``path`` to a method on the target node.
         Undoable.

--- a/test_project/tests/test_input.gd
+++ b/test_project/tests/test_input.gd
@@ -42,6 +42,59 @@ func test_list_actions_with_builtins() -> void:
 	assert_gt(result.data.count, 0, "Should have at least the built-in ui_* actions")
 
 
+func test_list_actions_default_excludes_spatial_editor() -> void:
+	## ``spatial_editor/*`` actions (3D viewport freelook/orbit/pan) live on
+	## InputMap but are not in ``project.godot``. They must not surface in the
+	## default user-facing list — agents would otherwise mistake them for
+	## actions the project author wired up.
+	var with_builtin := _handler.list_actions({"include_builtin": true})
+	var saw_spatial_editor := false
+	for action in with_builtin.data.actions:
+		if action.name.begins_with("spatial_editor/"):
+			saw_spatial_editor = true
+			break
+	assert_true(
+		saw_spatial_editor,
+		"Sanity: editor should expose spatial_editor/* actions when include_builtin=true",
+	)
+	var result := _handler.list_actions({})
+	for action in result.data.actions:
+		assert_false(
+			action.name.begins_with("spatial_editor/"),
+			"Default list leaked spatial_editor action: %s" % action.name,
+		)
+		assert_false(action.is_builtin, "Default list should expose only user-defined actions")
+
+
+func test_list_actions_default_returns_user_defined_action() -> void:
+	## A user-added action must round-trip through the default (filtered) list.
+	_handler.add_action({"action": TEST_ACTION})
+	var result := _handler.list_actions({})
+	var found := false
+	for action in result.data.actions:
+		if action.name == TEST_ACTION:
+			found = true
+			assert_false(action.is_builtin, "User-added action must not be flagged as built-in")
+			break
+	assert_true(found, "User-defined action %s should appear in default list" % TEST_ACTION)
+	_handler.remove_action({"action": TEST_ACTION})
+
+
+func test_list_actions_with_builtins_includes_spatial_editor_when_present() -> void:
+	## When asked, the listing surfaces editor-runtime actions verbatim (so
+	## power users can inspect them). At minimum a Godot 4 editor exposes
+	## ``spatial_editor/freelook_left``; if your fork stripped them, the assert
+	## stays satisfied because we only check via a flag.
+	var result := _handler.list_actions({"include_builtin": true})
+	assert_gt(result.data.count, 0)
+	var saw_non_user := false
+	for action in result.data.actions:
+		if action.is_builtin:
+			saw_non_user = true
+			break
+	assert_true(saw_non_user, "include_builtin=true should expose at least one editor-runtime action")
+
+
 # ----- add_action -----
 
 func test_add_action_missing_name() -> void:

--- a/test_project/tests/test_input.gd
+++ b/test_project/tests/test_input.gd
@@ -81,10 +81,11 @@ func test_list_actions_default_returns_user_defined_action() -> void:
 
 
 func test_list_actions_with_builtins_includes_spatial_editor_when_present() -> void:
-	## When asked, the listing surfaces editor-runtime actions verbatim (so
-	## power users can inspect them). At minimum a Godot 4 editor exposes
-	## ``spatial_editor/freelook_left``; if your fork stripped them, the assert
-	## stays satisfied because we only check via a flag.
+	## When asked, the listing surfaces built-in/editor-runtime actions so
+	## power users can inspect them. Some Godot 4 editor builds expose
+	## actions such as ``spatial_editor/freelook_left``, but this test only
+	## asserts the more general contract: include_builtin=true must return at
+	## least one action flagged as built-in.
 	var result := _handler.list_actions({"include_builtin": true})
 	assert_gt(result.data.count, 0)
 	var saw_non_user := false

--- a/test_project/tests/test_signal.gd
+++ b/test_project/tests/test_signal.gd
@@ -56,7 +56,7 @@ func test_list_signals_filters_editor_internal_by_default() -> void:
 	for conn in result.data.connections:
 		assert_has_key(conn, "origin")
 		assert_true(
-			conn.origin == "scene" or conn.origin == "autoload",
+			conn.origin == "scene" or conn.origin == "autoload" or conn.origin == "object",
 			"Default list should not return origin=%s" % conn.origin,
 		)
 

--- a/test_project/tests/test_signal.gd
+++ b/test_project/tests/test_signal.gd
@@ -41,6 +41,50 @@ func test_list_signals_unknown_node() -> void:
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 
 
+func test_list_signals_filters_editor_internal_by_default() -> void:
+	## The SceneTree dock observes signals like ``child_order_changed`` on every
+	## scene root. Without filtering those leak into the response and look like
+	## user-authored connections. By default we drop them and surface a count.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root — is a scene open?")
+		return
+	var path := "/" + scene_root.name
+	var result := _handler.list_signals({"path": path})
+	assert_has_key(result, "data")
+	assert_has_key(result.data, "editor_connection_count")
+	for conn in result.data.connections:
+		assert_has_key(conn, "origin")
+		assert_true(
+			conn.origin == "scene" or conn.origin == "autoload",
+			"Default list should not return origin=%s" % conn.origin,
+		)
+
+
+func test_list_signals_include_editor_internal_returns_them() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root — is a scene open?")
+		return
+	var path := "/" + scene_root.name
+	var default_result := _handler.list_signals({"path": path})
+	var with_editor := _handler.list_signals({"path": path, "include_editor_internal": true})
+	assert_has_key(with_editor, "data")
+	assert_true(
+		with_editor.data.connection_count >= default_result.data.connection_count,
+		"include_editor_internal must not drop connections",
+	)
+	## If the editor surfaces internal observers at all, at least one entry
+	## should have origin="editor" when the flag is on.
+	if with_editor.data.editor_connection_count > 0:
+		var saw_editor := false
+		for conn in with_editor.data.connections:
+			if conn.origin == "editor":
+				saw_editor = true
+				break
+		assert_true(saw_editor, "include_editor_internal should surface origin=editor entries")
+
+
 func test_list_signals_no_scene() -> void:
 	## If no scene is open this should report EDITOR_NOT_READY.
 	## We can't easily test this in-editor since a scene is always open,

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -2111,6 +2111,44 @@ class TestSignalListTool:
         assert result.data["signals"][0]["name"] == "pressed"
 
 
+class TestSignalListEditorInternalFilter:
+    async def test_list_passes_include_editor_internal_through(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "list_signals"
+            assert cmd["params"]["include_editor_internal"] is True
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "path": "/Main",
+                    "signals": [],
+                    "signal_count": 0,
+                    "connections": [
+                        {
+                            "signal": "child_order_changed",
+                            "target": "/Main/../../EditorNode/SceneTreeEditor",
+                            "method": "_node_renamed",
+                            "origin": "editor",
+                        }
+                    ],
+                    "connection_count": 1,
+                    "editor_connection_count": 1,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "signal_manage",
+            {"op": "list", "params": {"path": "/Main", "include_editor_internal": True}},
+        )
+        await task
+
+        assert result.data["connections"][0]["origin"] == "editor"
+        assert result.data["editor_connection_count"] == 1
+
+
 class TestSignalConnectTool:
     async def test_connect_signal(self, mcp_stack):
         client, plugin = mcp_stack


### PR DESCRIPTION
## Summary

Closes #213. Bundles the two cases the issue itself recommended bundling — same conceptual fix (filter editor-runtime state out of "list" ops by default) applied to two surface ops.

Before this PR:

- `signal_manage(op="list", params={"path": "/Main"})` returned 5 `SceneTreeEditor` dock observer connections (`child_order_changed`, `editor_state_changed`, `script_changed`, …) with target paths escaping the edited scene root via `/Main/../../../../EditorNode/...`. An agent reading `connection_count: 5` would assume the user wired these up.
- `input_map_manage(op="list")` (default `include_builtin=False`) returned 16 `spatial_editor/*` entries on a project with zero user-defined actions. The old filter only stripped `ui_*`, missing every other editor-runtime namespace.

## Changes

### `plugin/addons/godot_ai/handlers/signal_handler.gd`
- New static `_connection_origin(target, scene_root) -> "scene" | "autoload" | "editor"`. Walks up to the SceneTree root child to distinguish autoloads from editor docks.
- `list_signals` tags every connection with `origin`, drops `origin == "editor"` unless `include_editor_internal=true`, and surfaces `editor_connection_count` either way so callers can see how many were filtered.

### `plugin/addons/godot_ai/handlers/input_handler.gd`
- `list_actions` redefines "user-defined" as `ProjectSettings.has_setting("input/<name>")`. The old `name.begins_with("ui_")` heuristic missed `spatial_editor/*` entirely; the new check filters them and any future editor-runtime namespace.
- Behavior change for one edge case: a user who customized `ui_accept` (writing an override into `project.godot`) will now see it in the default list. That's the more correct semantics — it's their customization.

### Python + descriptions
- `signal_list` handler grows an `include_editor_internal: bool = False` kwarg.
- Tool descriptions for `signal_manage` and `input_map_manage` updated; `godot://input_map` resource docstring updated.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `pytest -q` — 609 passed, including new `TestSignalListEditorInternalFilter` class
- [x] New GDScript tests added: `test_list_signals_filters_editor_internal_by_default`, `test_list_signals_include_editor_internal_returns_them`, `test_list_actions_default_excludes_spatial_editor`, `test_list_actions_default_returns_user_defined_action`, `test_list_actions_with_builtins_includes_spatial_editor_when_present`
- [ ] **Live smoke against a real Godot editor was not possible from this sandbox** — no Godot binary available. Before merging, please run:
  - `test_run` via MCP — confirm all GDScript suites pass
  - `signal_manage(op="list", params={"path":"/Main"})` on a fresh `Node3D` scene — `connections` should be empty (or only autoloads), `editor_connection_count` should be ≥ 5
  - `input_map_manage(op="list", params={})` on a project with zero user actions — `count` should be 0
  - `input_map_manage(op="list", params={"include_builtin": true})` — should still surface `ui_*` and `spatial_editor/*` entries with `is_builtin: true`

https://claude.ai/code/session_01WUnuY27FZq21dM33rDCgPm

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUnuY27FZq21dM33rDCgPm)_