### PR TITLE
fix(handlers): type-check JSON params; dispatcher echoes args on malformed result (#210)

### DIFF
--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd.uid
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd.uid
@@ -1,0 +1,1 @@
+uid://bd1k63iye1bsl

--- a/plugin/addons/godot_ai/dispatcher.gd
+++ b/plugin/addons/godot_ai/dispatcher.gd
@@ -136,14 +136,30 @@ func _dispatch(cmd: Dictionary) -> Dictionary:
 	return result
 
 
+## Truncate JSON-stringified args at this many chars when stuffing them into
+## a malformed-result error message — large dicts shouldn't bloat the
+## response, but a few hundred chars usually pinpoints which param was the
+## wrong shape.
+const _MALFORMED_ARGS_MAX := 400
+
+
 func _call_handler(command: String, params: Dictionary) -> Dictionary:
 	var result: Dictionary = _handlers[command].call(params)
 	## Handlers must return {"data": ...} on success or {"error": ...} on failure.
 	## Anything else (null, empty, missing keys) means the handler crashed
 	## mid-call — GDScript swallows the error and returns an empty dict.
 	if result == null or not (result.has("data") or result.has("error") or result.has("_deferred")):
-		return McpErrorCodes.make(
-			McpErrorCodes.INTERNAL_ERROR,
-			"Handler '%s' returned malformed result (likely crashed — check Godot console)" % command,
-		)
+		var safe_params := params.duplicate()
+		safe_params.erase("_request_id")
+		var args_json := JSON.stringify(safe_params)
+		if args_json.length() > _MALFORMED_ARGS_MAX:
+			args_json = args_json.substr(0, _MALFORMED_ARGS_MAX) + "..."
+		var msg := (
+			"Handler '%s' returned malformed result — likely a runtime error in the handler "
+			+ "(e.g. param type mismatch). Check the Godot console for the GDScript backtrace. "
+			+ "Args received: %s"
+		) % [command, args_json]
+		if mcp_logging and _log_buffer != null:
+			_log_buffer.log("[error] %s -> malformed result; args=%s" % [command, args_json])
+		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, msg)
 	return result

--- a/plugin/addons/godot_ai/handlers/_param_validators.gd
+++ b/plugin/addons/godot_ai/handlers/_param_validators.gd
@@ -1,0 +1,46 @@
+@tool
+class_name McpParamValidators
+extends RefCounted
+
+## Type-check a JSON-decoded param Variant before assigning it into a typed
+## GDScript local. The dispatcher only catches handler crashes as an opaque
+## "malformed result" (issue #210), so a typed assignment like
+##   var group: String = params.get("group", "")
+## will runtime-error and bubble up without telling the caller which param
+## was the wrong shape. Handlers should guard untrusted values with one of
+## the require_*() helpers below and return its error dict on mismatch.
+
+
+## Returns null iff `value` is a String or StringName. On any other type
+## returns an INVALID_PARAMS error dict whose message names both `name` and
+## the actual Variant type (via Godot's built-in `type_string`).
+static func require_string(name: String, value: Variant) -> Variant:
+	var t := typeof(value)
+	if t == TYPE_STRING or t == TYPE_STRING_NAME:
+		return null
+	return McpErrorCodes.make(
+		McpErrorCodes.INVALID_PARAMS,
+		"Param '%s' must be a String, got %s" % [name, type_string(t)],
+	)
+
+
+## Returns null iff `value` is an int. Floats are rejected — JSON decoders
+## that emit `1.0` for an integer slot will surface a clear error here
+## rather than silently truncating downstream.
+static func require_int(name: String, value: Variant) -> Variant:
+	if typeof(value) == TYPE_INT:
+		return null
+	return McpErrorCodes.make(
+		McpErrorCodes.INVALID_PARAMS,
+		"Param '%s' must be an int, got %s" % [name, type_string(typeof(value))],
+	)
+
+
+## Returns null iff `value` is a bool.
+static func require_bool(name: String, value: Variant) -> Variant:
+	if typeof(value) == TYPE_BOOL:
+		return null
+	return McpErrorCodes.make(
+		McpErrorCodes.INVALID_PARAMS,
+		"Param '%s' must be a bool, got %s" % [name, type_string(typeof(value))],
+	)

--- a/plugin/addons/godot_ai/handlers/_param_validators.gd.uid
+++ b/plugin/addons/godot_ai/handlers/_param_validators.gd.uid
@@ -1,0 +1,1 @@
+uid://difa877m8dsla

--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -417,7 +417,11 @@ func add_to_group(params: Dictionary) -> Dictionary:
 	var node: Node = resolved.node
 	var node_path: String = resolved.path
 
-	var group: String = params.get("group", "")
+	var group_value: Variant = params.get("group", "")
+	var type_err := McpParamValidators.require_string("group", group_value)
+	if type_err != null:
+		return type_err
+	var group: String = group_value
 	if group.is_empty():
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: group")
 
@@ -445,7 +449,11 @@ func remove_from_group(params: Dictionary) -> Dictionary:
 	var node: Node = resolved.node
 	var node_path: String = resolved.path
 
-	var group: String = params.get("group", "")
+	var group_value: Variant = params.get("group", "")
+	var type_err := McpParamValidators.require_string("group", group_value)
+	if type_err != null:
+		return type_err
+	var group: String = group_value
 	if group.is_empty():
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: group")
 

--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -421,7 +421,7 @@ func add_to_group(params: Dictionary) -> Dictionary:
 	var type_err := McpParamValidators.require_string("group", group_value)
 	if type_err != null:
 		return type_err
-	var group: String = group_value
+	var group := String(group_value)
 	if group.is_empty():
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: group")
 
@@ -453,7 +453,7 @@ func remove_from_group(params: Dictionary) -> Dictionary:
 	var type_err := McpParamValidators.require_string("group", group_value)
 	if type_err != null:
 		return type_err
-	var group: String = group_value
+	var group := String(group_value)
 	if group.is_empty():
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: group")
 

--- a/plugin/addons/godot_ai/runtime/game_helper.gd.uid
+++ b/plugin/addons/godot_ai/runtime/game_helper.gd.uid
@@ -1,0 +1,1 @@
+uid://gfybkdtsclti

--- a/plugin/addons/godot_ai/runtime/game_logger.gd.uid
+++ b/plugin/addons/godot_ai/runtime/game_logger.gd.uid
@@ -1,0 +1,1 @@
+uid://c88iybvp3v0ln

--- a/plugin/addons/godot_ai/tool_catalog.gd.uid
+++ b/plugin/addons/godot_ai/tool_catalog.gd.uid
@@ -1,0 +1,1 @@
+uid://d1vqyt4uyo378

--- a/plugin/addons/godot_ai/utils/game_log_buffer.gd.uid
+++ b/plugin/addons/godot_ai/utils/game_log_buffer.gd.uid
@@ -1,0 +1,1 @@
+uid://biojw0xl64haw

--- a/plugin/addons/godot_ai/utils/mcp_spawn_state.gd.uid
+++ b/plugin/addons/godot_ai/utils/mcp_spawn_state.gd.uid
@@ -1,0 +1,1 @@
+uid://coson6hlvkts4

--- a/plugin/addons/godot_ai/utils/resource_io.gd.uid
+++ b/plugin/addons/godot_ai/utils/resource_io.gd.uid
@@ -1,0 +1,1 @@
+uid://de2rwdoa4wabf

--- a/test_project/tests/test_dispatcher.gd
+++ b/test_project/tests/test_dispatcher.gd
@@ -23,7 +23,7 @@ func test_dispatch_direct_converts_empty_dict_to_internal_error() -> void:
 	var result := d.dispatch_direct("returns_empty", {})
 	assert_is_error(result, McpErrorCodes.INTERNAL_ERROR)
 	assert_contains(result.error.message, "returns_empty")
-	assert_contains(result.error.message, "likely crashed")
+	assert_contains(result.error.message, "malformed result")
 
 
 func test_dispatch_direct_converts_null_result_to_internal_error() -> void:
@@ -71,3 +71,66 @@ func test_dispatch_direct_unknown_command_unchanged() -> void:
 	d.mcp_logging = false
 	var result := d.dispatch_direct("never_registered", {})
 	assert_is_error(result, McpErrorCodes.UNKNOWN_COMMAND)
+
+
+# ----- malformed-result error surfaces args + writes to log buffer (#210) -----
+
+
+func test_malformed_result_message_includes_received_args() -> void:
+	## When a handler crashes / returns junk, the agent has no way to inspect
+	## Godot's console. Surface what the handler was called with so the
+	## agent can spot a param type mismatch from outside the editor.
+	var d := _make_dispatcher()
+	d.mcp_logging = false
+	d.register("crashy", func(_p): return {})
+	var result := d.dispatch_direct("crashy", {"path": "/Main", "group": ["a", "b"]})
+	assert_is_error(result, McpErrorCodes.INTERNAL_ERROR)
+	assert_contains(result.error.message, "crashy")
+	assert_contains(result.error.message, "/Main")
+	assert_contains(result.error.message, "group")
+
+
+func test_malformed_result_message_strips_internal_request_id() -> void:
+	## The dispatcher threads `_request_id` into the duplicated params dict
+	## for handlers that need it (deferred responses); it must not leak back
+	## into a user-facing error message.
+	var d := _make_dispatcher()
+	d.mcp_logging = false
+	d.register("crashy", func(_p): return {})
+	var result := d.dispatch_direct("crashy", {"_request_id": "secret-rid-123"})
+	assert_is_error(result, McpErrorCodes.INTERNAL_ERROR)
+	assert_true(
+		result.error.message.find("secret-rid-123") == -1,
+		"_request_id must not appear in the user-facing error message",
+	)
+
+
+func test_malformed_result_writes_error_line_to_log_buffer() -> void:
+	## logs_read is the only out-of-editor channel for post-crash context.
+	## Confirm a line lands there alongside the protocol response.
+	var buf := McpLogBuffer.new()
+	var d := McpDispatcher.new(buf)
+	d.mcp_logging = true
+	d.register("crashy", func(_p): return {})
+	d.dispatch_direct("crashy", {"path": "/Main"})
+	var lines := buf.get_recent(20)
+	var found := false
+	for line in lines:
+		if line.find("[error]") != -1 and line.find("crashy") != -1:
+			found = true
+			break
+	assert_true(found, "malformed result should log an [error] line")
+
+
+func test_malformed_result_truncates_long_args() -> void:
+	## Avoid bloating responses with huge param dumps — a few hundred chars
+	## is usually enough to identify the bad field.
+	var d := _make_dispatcher()
+	d.mcp_logging = false
+	d.register("crashy", func(_p): return {})
+	var big := ""
+	for i in range(200):
+		big += "x"
+	var result := d.dispatch_direct("crashy", {"blob": big + big + big})
+	assert_is_error(result, McpErrorCodes.INTERNAL_ERROR)
+	assert_contains(result.error.message, "...")

--- a/test_project/tests/test_dock_dev_server_btn.gd.uid
+++ b/test_project/tests/test_dock_dev_server_btn.gd.uid
@@ -1,0 +1,1 @@
+uid://bwmm6ghyge6tq

--- a/test_project/tests/test_netstat_parser.gd.uid
+++ b/test_project/tests/test_netstat_parser.gd.uid
@@ -1,0 +1,1 @@
+uid://dmcrq817tvctk

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -1120,6 +1120,26 @@ func test_remove_from_group_rejects_array_value() -> void:
 	assert_contains(result.error.message, "Array")
 
 
+func test_add_to_group_accepts_string_name_value() -> void:
+	## JSON only carries TYPE_STRING, but internal callers may pass a
+	## StringName. The validator accepts both; the handler converts via
+	## String() before the typed local so the assignment can't trip a
+	## StringName→String type-mismatch at runtime.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var cam := ScenePath.resolve("/Main/Camera3D", scene_root)
+	if cam and cam.is_in_group("_mcp_test_sn_group"):
+		cam.remove_from_group("_mcp_test_sn_group")
+
+	var result := _handler.add_to_group({
+		"path": "/Main/Camera3D",
+		"group": &"_mcp_test_sn_group",
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.group, "_mcp_test_sn_group")
+	assert_true(result.data.undoable)
+	_undo_redo.undo()
+
+
 # ----- set_selection -----
 
 func test_set_selection_basic() -> void:

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -1094,6 +1094,32 @@ func test_remove_from_group_missing_group() -> void:
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 
 
+func test_add_to_group_rejects_array_value() -> void:
+	## Repro for #210: the meta-tool layer JSON-decodes string-shaped values
+	## like `"[\"a\",\"b\"]"` into an Array before the handler sees them.
+	## Without input validation the typed assignment `var group: String =
+	## ...` would runtime-error and the dispatcher would only surface an
+	## opaque INTERNAL_ERROR. With validation, the agent gets an actionable
+	## INVALID_PARAMS instead.
+	var result := _handler.add_to_group({
+		"path": "/Main/Camera3D",
+		"group": ["a", "b"],
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "group")
+	assert_contains(result.error.message, "Array")
+
+
+func test_remove_from_group_rejects_array_value() -> void:
+	var result := _handler.remove_from_group({
+		"path": "/Main/Camera3D",
+		"group": ["a", "b"],
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "group")
+	assert_contains(result.error.message, "Array")
+
+
 # ----- set_selection -----
 
 func test_set_selection_basic() -> void:

--- a/test_project/tests/test_param_validators.gd
+++ b/test_project/tests/test_param_validators.gd
@@ -1,0 +1,84 @@
+@tool
+extends McpTestSuite
+
+## Tests for McpParamValidators — the type-check helpers handlers call on
+## values pulled from JSON-decoded params before assigning them into typed
+## GDScript locals (issue #210).
+
+
+func suite_name() -> String:
+	return "param_validators"
+
+
+# ----- require_string -----
+
+func test_require_string_accepts_string() -> void:
+	var err: Variant = McpParamValidators.require_string("group", "ok")
+	assert_eq(err, null)
+
+
+func test_require_string_accepts_string_name() -> void:
+	var err: Variant = McpParamValidators.require_string("group", &"sn")
+	assert_eq(err, null)
+
+
+func test_require_string_rejects_array() -> void:
+	var err: Dictionary = McpParamValidators.require_string("group", ["a", "b"])
+	assert_is_error(err, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(err.error.message, "group")
+	assert_contains(err.error.message, "Array")
+
+
+func test_require_string_rejects_dict() -> void:
+	var err: Dictionary = McpParamValidators.require_string("group", {"key": "val"})
+	assert_is_error(err, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(err.error.message, "Dictionary")
+
+
+func test_require_string_rejects_int() -> void:
+	var err: Dictionary = McpParamValidators.require_string("group", 42)
+	assert_is_error(err, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(err.error.message, "int")
+
+
+func test_require_string_rejects_null() -> void:
+	var err: Dictionary = McpParamValidators.require_string("group", null)
+	assert_is_error(err, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(err.error.message, "Nil")
+
+
+# ----- require_int -----
+
+func test_require_int_accepts_int() -> void:
+	var err: Variant = McpParamValidators.require_int("count", 7)
+	assert_eq(err, null)
+
+
+func test_require_int_rejects_float() -> void:
+	var err: Dictionary = McpParamValidators.require_int("count", 1.5)
+	assert_is_error(err, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(err.error.message, "float")
+
+
+func test_require_int_rejects_string() -> void:
+	var err: Dictionary = McpParamValidators.require_int("count", "7")
+	assert_is_error(err, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(err.error.message, "String")
+
+
+# ----- require_bool -----
+
+func test_require_bool_accepts_bool() -> void:
+	var err_true: Variant = McpParamValidators.require_bool("flag", true)
+	var err_false: Variant = McpParamValidators.require_bool("flag", false)
+	assert_eq(err_true, null)
+	assert_eq(err_false, null)
+
+
+func test_require_bool_rejects_int() -> void:
+	## GDScript will happily coerce 0/1 into bool elsewhere, but JSON sends
+	## booleans as booleans — agents passing 1 for a bool slot are confused
+	## and deserve an explicit error rather than silent coercion.
+	var err: Dictionary = McpParamValidators.require_bool("flag", 1)
+	assert_is_error(err, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(err.error.message, "int")

--- a/test_project/tests/test_param_validators.gd.uid
+++ b/test_project/tests/test_param_validators.gd.uid
@@ -1,0 +1,1 @@
+uid://cbq8u6qlh78wf

--- a/test_project/tests/test_plugin_lifecycle.gd.uid
+++ b/test_project/tests/test_plugin_lifecycle.gd.uid
@@ -1,0 +1,1 @@
+uid://ct840tfppkqlk

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -764,6 +764,44 @@ class TestNodeGroupTools:
 
         assert result.data["group"] == "enemies"
 
+    async def test_add_to_group_array_value_returns_invalid_params(self, mcp_stack):
+        ## #210 repro: agent passes `group` as a JSON-string-looking list. The
+        ## meta-tool layer's `_coerce_json_strings` decodes it into an Array
+        ## before the plugin sees it (recv shows `"group":["a","b"]`). Without
+        ## the GDScript-side typeof() guard added in this fix, the typed
+        ## assignment `var group: String = ...` runtime-errored and the
+        ## dispatcher surfaced an opaque INTERNAL_ERROR. With the guard, the
+        ## plugin now sends back a structured INVALID_PARAMS that names the
+        ## bad param. We mock the plugin sending the new error shape and
+        ## confirm the meta-tool surfaces it cleanly to the client.
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "add_to_group"
+            ## The coercion middleware decoded the JSON-list string into a
+            ## real array. The plugin now type-checks the value and rejects.
+            assert cmd["params"]["group"] == ["a", "b"]
+            await plugin.send_error(
+                cmd["request_id"],
+                "INVALID_PARAMS",
+                "Param 'group' must be a String, got Array",
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "node_manage",
+            {
+                "op": "add_to_group",
+                "params": {"path": "/Main/Enemy", "group": '["a","b"]'},
+            },
+            raise_on_error=False,
+        )
+        await task
+        assert result.is_error
+        assert "must be a String" in str(result.content)
+        assert "group" in str(result.content)
+
 
 # ---------------------------------------------------------------------------
 # editor_selection_set


### PR DESCRIPTION
## Summary

Closes #210. Two coordinated fixes for the "agent passes a JSON-list-shaped string for a String slot, handler runtime-errors, dispatcher emits opaque INTERNAL_ERROR" trap.

### 1. Plugin-side type validation

New `McpParamValidators` helper (`require_string` / `require_int` / `require_bool`) backed by Godot's built-in `type_string` for the actual-type label. Used by `node_handler.gd::add_to_group` and `remove_from_group` to guard the typed assignment

```gdscript
var group: String = params.get("group", "")
```

that was the original repro path. The meta-tool layer's `_coerce_json_strings` (`tools/_meta_tool.py`) decodes a value like `"[\"a\",\"b\"]"` into a real Array before the plugin sees it, and the typed assignment was runtime-erroring. With the guard, agents now get a structured

```
INVALID_PARAMS: Param 'group' must be a String, got Array
```

instead of the previous opaque INTERNAL_ERROR.

### 2. Dispatcher transparency on malformed results

`dispatcher.gd::_call_handler` now, on the malformed-result path:

- JSON-stringifies the received args (truncated at 400 chars), strips internal `_request_id`, embeds them in the error message — so the agent can spot a param type mismatch from outside the Godot console.
- Writes a separate `[error] <command> -> malformed result; args=...` line to the log buffer when `mcp_logging` is on. `logs_read` now surfaces post-crash context that was previously visible only in the Godot console.
- Updates the user-facing message to point at "param type mismatch" as the common cause.

Wire protocol unchanged — the args echo lives inside `error.message`. Surfacing structured `error.data` would need an `ErrorDetail` envelope change, which is out of scope.

## Tests

**Python** (609/609 passing, ruff clean):
- New `TestNodeGroupTools::test_add_to_group_array_value_returns_invalid_params` — round-trips the issue's repro through FastMCP + meta-tool + mock plugin.

**GDScript** (883/883 passing on a live Godot 4.6.2 editor — see live smoke below):
- New `test_param_validators.gd` suite: 11 tests across `require_string` / `require_int` / `require_bool` covering String, StringName, Array, Dict, int, float, null, bool inputs.
- `test_node.gd`: `test_add_to_group_rejects_array_value` and `test_remove_from_group_rejects_array_value` exercising the wiring at both call sites.
- `test_dispatcher.gd`: 4 new tests — args appear in error message, internal `_request_id` is stripped, `[error]` line lands in log buffer, long args truncate with `...`.

## Live smoke (Godot 4.6.2, Linux)

```
test_run → total:897 passed:883 failed:0 (load_errors:0)

# Issue #210 repro:
node_manage(op="add_to_group", params={"path":"/Main/Camera3D","group":"[\"a\",\"b\"]"})
→ isError: True
→ INVALID_PARAMS: Param 'group' must be a String, got Array

# Same repro on remove_from_group with a Dict value:
→ INVALID_PARAMS: Param 'group' must be a String, got Dictionary

# Happy path still works:
node_manage(op="add_to_group", params={..., "group":"_smoke_test_group"})
→ {"group":"_smoke_test_group","path":"/Main/Camera3D","undoable":true}
```

## Out of scope

The issue's "Suggested scope" notes a sweep across all `*_handler.gd` files for missing `typeof()` guards on JSON-sourced params. This PR ships the helper and applies it to the reported call sites; a follow-up sweep can reuse the helper without further infra work. The dispatcher transparency improvement benefits *all* future malformed-result cases regardless of which handler crashed.

## Test plan

- [x] `pytest -q` — 609 passed
- [x] `ruff check src/ tests/` — clean
- [x] Live `test_run` against Godot 4.6.2 — 883 passed, 0 failed, 0 load errors
- [x] Live MCP repro of issue #210 — confirmed new INVALID_PARAMS shape
- [x] Happy path smoke — still produces undoable mutation

https://claude.ai/code/session_011JFWUcED6WzaZXkR62wCmQ

---
_Generated by [Claude Code](https://claude.ai/code/session_011JFWUcED6WzaZXkR62wCmQ)_