### PR TITLE
fix(signal): allow autoload descendants + canonical /root/... target paths

### DIFF
--- a/plugin/addons/godot_ai/handlers/signal_handler.gd
+++ b/plugin/addons/godot_ai/handlers/signal_handler.gd
@@ -52,7 +52,7 @@ func list_signals(params: Dictionary) -> Dictionary:
 				continue
 			connections.append({
 				"signal": sig.name,
-				"target": ScenePath.from_node(target, scene_root) if target is Node else str(target),
+				"target": _format_target_path(target, scene_root),
 				"method": callable.get_method(),
 			})
 
@@ -69,13 +69,14 @@ func list_signals(params: Dictionary) -> Dictionary:
 
 
 ## A target is "editor-internal" when it's a Node sitting outside the edited
-## scene tree AND not an autoload singleton — typical case is the
-## SceneTreeEditor dock listening for visibility/script/state changes on
+## scene tree AND not anywhere under a declared autoload — typical case is
+## the SceneTreeEditor dock listening for visibility/script/state changes on
 ## every scene node. Connections to autoloads (declared under ``autoload/*``
 ## in ProjectSettings) are user-authored even though they live under
-## ``/root/<Name>`` rather than under the edited scene root, so they stay
-## visible. Non-Node targets (anonymous Callables, RefCounted listeners
-## etc.) also stay visible — we can't reliably classify them.
+## ``/root/<Name>`` rather than under the edited scene root, so the autoload
+## root *and* any descendant of it stay visible. Non-Node targets
+## (anonymous Callables, RefCounted listeners etc.) also stay visible — we
+## can't reliably classify them.
 func _is_editor_internal_target(target: Object, scene_root: Node) -> bool:
 	if not (target is Node):
 		return false
@@ -84,9 +85,50 @@ func _is_editor_internal_target(target: Object, scene_root: Node) -> bool:
 		return false
 	if scene_root.is_ancestor_of(node_target):
 		return false
-	if ProjectSettings.has_setting("autoload/" + str(node_target.name)):
+	if _is_under_autoload(node_target):
 		return false
 	return true
+
+
+## True if `node` is a declared autoload root or sits anywhere under one.
+## When the node is in the SceneTree we read its absolute path
+## (``/root/<Name>/...``) and check the first segment after ``/root/``;
+## this covers connections to deep descendants of editor-instanced
+## autoloads (e.g. ``/root/MyAutoload/Foo/Bar``). When the node isn't in
+## the tree (test fixtures often construct nodes in isolation), we walk
+## the parent chain and match each ancestor's ``name`` against the
+## autoload key as a best-effort fallback.
+static func _is_under_autoload(node: Node) -> bool:
+	if node.is_inside_tree():
+		var path := str(node.get_path())
+		if not path.begins_with("/root/"):
+			return false
+		var first_segment := path.substr(6).split("/", true, 1)[0]
+		return ProjectSettings.has_setting("autoload/" + first_segment)
+	var cursor: Node = node
+	while cursor != null:
+		if ProjectSettings.has_setting("autoload/" + str(cursor.name)):
+			return true
+		cursor = cursor.get_parent()
+	return false
+
+
+## Serialize a connection's target path. Descendants of (or equal to) the
+## edited scene root render as the usual scene-relative form
+## (``/Main/Camera3D``). Non-descendants — autoload subtrees in particular
+## — render as their canonical absolute SceneTree path
+## (``/root/MyAutoload/Child``) instead of a scene-relative path full of
+## ``..`` segments, which agents can't navigate back to. Non-Node targets
+## (anonymous Callables, etc.) fall back to their string representation.
+static func _format_target_path(target: Object, scene_root: Node) -> String:
+	if not (target is Node):
+		return str(target)
+	var node_target: Node = target
+	if node_target == scene_root or scene_root.is_ancestor_of(node_target):
+		return ScenePath.from_node(node_target, scene_root)
+	if node_target.is_inside_tree():
+		return str(node_target.get_path())
+	return ScenePath.from_node(node_target, scene_root)
 
 
 func connect_signal(params: Dictionary) -> Dictionary:

--- a/test_project/tests/test_signal.gd
+++ b/test_project/tests/test_signal.gd
@@ -124,6 +124,87 @@ func test_is_editor_internal_target_keeps_autoload_targets() -> void:
 		ProjectSettings.set_setting(setting_key, null)
 
 
+func test_is_editor_internal_target_keeps_autoload_descendants() -> void:
+	## Copilot review on #222: the previous filter only allowed autoload
+	## *roots*. Connections targeting a node *under* an autoload (e.g.
+	## /root/MyAutoload/Child) were misclassified as editor-internal and
+	## hidden from list_signals. Exercise the detached parent-chain
+	## fallback used by the helper when the fixture isn't reachable from
+	## /root — the real production path (in-tree autoloads with
+	## /root/<Name>/... paths) is exercised by the underlying
+	## ProjectSettings + Node.get_path() machinery.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root — is a scene open?")
+		return
+
+	var setting_key := "autoload/_TestAutoloadDescendants"
+	var had_before := ProjectSettings.has_setting(setting_key)
+	var before_value: Variant = ProjectSettings.get_setting(setting_key) if had_before else null
+	ProjectSettings.set_setting(setting_key, "*res://tests/does_not_exist.gd")
+
+	## Detached fixture: child whose parent name matches the autoload key.
+	var fake_parent := Node.new()
+	fake_parent.name = "_TestAutoloadDescendants"
+	var detached_child := Node.new()
+	detached_child.name = "Child"
+	var detached_grandchild := Node.new()
+	detached_grandchild.name = "GrandChild"
+	fake_parent.add_child(detached_child)
+	detached_child.add_child(detached_grandchild)
+
+	## Sanity-check the fixture before exercising the helper, so a setup
+	## regression doesn't masquerade as a logic bug.
+	assert_true(ProjectSettings.has_setting(setting_key),
+		"setup: autoload setting should be present after set_setting")
+	assert_eq(detached_child.get_parent(), fake_parent,
+		"setup: detached_child.get_parent() should be fake_parent")
+
+	assert_false(_handler._is_editor_internal_target(detached_child, scene_root),
+		"Direct autoload child should NOT be classified as editor-internal")
+	assert_false(_handler._is_editor_internal_target(detached_grandchild, scene_root),
+		"Deeper autoload descendant should NOT be classified as editor-internal")
+
+	fake_parent.free()
+	if had_before:
+		ProjectSettings.set_setting(setting_key, before_value)
+	else:
+		ProjectSettings.set_setting(setting_key, null)
+
+
+func test_format_target_path_uses_absolute_for_non_descendants() -> void:
+	## Copilot review on #222: when list_signals surfaces a connection
+	## targeting a non-descendant (e.g. an autoload subtree) the previous
+	## ScenePath.from_node() output was a scene-relative path with ``..``
+	## segments like ``/Main/../../root/MyAutoload/Child`` — unparseable for
+	## agents and not round-trippable through scene-path resolution. The
+	## new formatter emits the canonical absolute SceneTree path for
+	## non-descendants instead.
+	##
+	## We use the editor's own base Control as a guaranteed-in-tree node
+	## that lives outside the edited scene; mutating /root from a test is
+	## fragile in editor context, so we read from existing tree nodes only.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root — is a scene open?")
+		return
+	var base := EditorInterface.get_base_control()
+	if base == null or not base.is_inside_tree():
+		skip("Editor base control not available")
+		return
+	if scene_root.is_ancestor_of(base):
+		skip("base control is inside edited scene — fixture invalid")
+		return
+
+	var formatted := SignalHandler._format_target_path(base, scene_root)
+	assert_eq(formatted, str(base.get_path()),
+		"Non-descendant in-tree target should serialize as its absolute SceneTree path, got: %s" % formatted)
+	assert_true(formatted.begins_with("/root/"),
+		"Absolute SceneTree path should start with /root/, got: %s" % formatted)
+	assert_false(formatted.contains(".."),
+		"Formatted target path must not contain '..' segments: %s" % formatted)
+
+
 # ----- connect_signal -----
 
 func test_connect_signal_missing_params() -> void:


### PR DESCRIPTION
## Context — what changed since the original PR

The original `signal_list` / `input_map_list` filter from this PR shipped via #218 (commit `176a668`) on main, with a more thorough implementation (opt-in `include_editor` flag, `editor_connection_count`, `ConfigFile`-based input filter, autoload-root allowance). That made #222's original commits a no-op against main, so this PR has been **reset onto current main** and now carries a single follow-up commit addressing the two unresolved Copilot review threads.

## Summary

Two issues Copilot flagged on the original PR still applied to main's version after #218 landed:

1. **Autoload children misclassified as editor-internal.** `_is_editor_internal_target` only allowed autoload *roots* (matched the target's own `name` against `autoload/<name>`). A connection targeting any node *under* an autoload — e.g. `/root/MyAutoload/Foo/Bar` — failed the check and was silently dropped from `signal_manage(op="list")`.

2. **Non-descendant target paths laden with `..` segments.** When the filter let a non-descendant connection through (autoload subtree, etc.), `ScenePath.from_node(target, scene_root)` produced something like `/Main/../../root/MyAutoload/Child`. Agents can't navigate that back, and the path isn't round-trippable through the resolver.

## Fix

- **`SignalHandler._is_under_autoload(node)`** — new static helper. For in-tree nodes, parses the absolute SceneTree path (`/root/<seg>/...`) and checks `seg` against `autoload/<seg>` in `ProjectSettings`. For detached test fixtures, walks the parent chain matching each ancestor's `name`. Replaces the old single-name check inside `_is_editor_internal_target`.
- **`SignalHandler._format_target_path(target, scene_root)`** — new static helper. Descendants of (or equal to) `scene_root` keep the existing scene-relative form (`/Main/Camera3D`). In-tree non-descendants render as their canonical absolute SceneTree path (`/root/MyAutoload/Child`). Non-Node targets and detached non-descendants fall back to existing behavior.

## Test plan

- [x] `pytest -v` — 618 passed; `ruff check` clean.
- [x] New GDScript tests in `test_project/tests/test_signal.gd`:
  - `test_is_editor_internal_target_keeps_autoload_descendants` — exercises the parent-chain walk for nested fixtures under an autoload-named parent.
  - `test_format_target_path_uses_absolute_for_non_descendants` — uses `EditorInterface.get_base_control()` (guaranteed in-tree, outside the edited scene) to confirm the formatter emits the absolute `/root/...` path with no `..` segments.
- [x] **Live smoke run** against the test_project editor (Godot 4.6.2):
  - Full `test_run` — 872 passed / 0 failed / 14 skipped across 34 suites.
  - `test_run suite=signal` — 15/15 pass.
  - `signal_manage(op="list", params={"path":"/Main"})` returns `connection_count: 0`, `editor_connection_count: 5`, with no `..`-laden targets in the filtered output.

Closes the Copilot review threads on #222.

https://claude.ai/code/session_015YRcEbFHPutSD7Z77cwsGS