### PR TITLE
chore: track missing .gd.uid sidecars

### DIFF
--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd.uid
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd.uid
@@ -1,0 +1,1 @@
+uid://bd1k63iye1bsl

--- a/plugin/addons/godot_ai/runtime/game_helper.gd.uid
+++ b/plugin/addons/godot_ai/runtime/game_helper.gd.uid
@@ -1,0 +1,1 @@
+uid://gfybkdtsclti

--- a/plugin/addons/godot_ai/runtime/game_logger.gd.uid
+++ b/plugin/addons/godot_ai/runtime/game_logger.gd.uid
@@ -1,0 +1,1 @@
+uid://c88iybvp3v0ln

--- a/plugin/addons/godot_ai/tool_catalog.gd.uid
+++ b/plugin/addons/godot_ai/tool_catalog.gd.uid
@@ -1,0 +1,1 @@
+uid://d1vqyt4uyo378

--- a/plugin/addons/godot_ai/utils/game_log_buffer.gd.uid
+++ b/plugin/addons/godot_ai/utils/game_log_buffer.gd.uid
@@ -1,0 +1,1 @@
+uid://biojw0xl64haw

--- a/plugin/addons/godot_ai/utils/mcp_spawn_state.gd.uid
+++ b/plugin/addons/godot_ai/utils/mcp_spawn_state.gd.uid
@@ -1,0 +1,1 @@
+uid://coson6hlvkts4

--- a/plugin/addons/godot_ai/utils/resource_io.gd.uid
+++ b/plugin/addons/godot_ai/utils/resource_io.gd.uid
@@ -1,0 +1,1 @@
+uid://de2rwdoa4wabf

--- a/test_project/tests/test_dock_dev_server_btn.gd.uid
+++ b/test_project/tests/test_dock_dev_server_btn.gd.uid
@@ -1,0 +1,1 @@
+uid://bwmm6ghyge6tq

--- a/test_project/tests/test_netstat_parser.gd.uid
+++ b/test_project/tests/test_netstat_parser.gd.uid
@@ -1,0 +1,1 @@
+uid://dmcrq817tvctk

--- a/test_project/tests/test_plugin_lifecycle.gd.uid
+++ b/test_project/tests/test_plugin_lifecycle.gd.uid
@@ -1,0 +1,1 @@
+uid://ct840tfppkqlk


### PR DESCRIPTION
## Summary

Triage: every open issue (#210, #211, #213) is already covered — #211 and #213 landed on `main` via #218 (commit `176a668`); #210 has PR #221 in flight with live smoke complete. No outstanding work.

While standing down, the stop hook flagged 10 untracked `.gd.uid` files. These are Godot-generated UUID sidecars for `.gd` files that already exist in the index. 101 sibling `.uid` files in the repo are tracked, so these were an oversight rather than a deliberate exclusion. Pure metadata hygiene — no code changes, no behavior change.

## Files added

- `plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd.uid`
- `plugin/addons/godot_ai/runtime/game_helper.gd.uid`
- `plugin/addons/godot_ai/runtime/game_logger.gd.uid`
- `plugin/addons/godot_ai/tool_catalog.gd.uid`
- `plugin/addons/godot_ai/utils/game_log_buffer.gd.uid`
- `plugin/addons/godot_ai/utils/mcp_spawn_state.gd.uid`
- `plugin/addons/godot_ai/utils/resource_io.gd.uid`
- `test_project/tests/test_dock_dev_server_btn.gd.uid`
- `test_project/tests/test_netstat_parser.gd.uid`
- `test_project/tests/test_plugin_lifecycle.gd.uid`

Each file contains a single `uid://...` line, identical in shape to every tracked `.uid` in the repo.

## Test plan

- [x] No code changed; existing tests unaffected.
- [x] `git status` clean after commit.

https://claude.ai/code/session_01EDq3F5XSYV3hmakqDAT4QK

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDq3F5XSYV3hmakqDAT4QK)_