### PR TITLE
chore: commit orphan .uid files for tracked GDScripts

### DIFF
--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd.uid
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd.uid
@@ -1,0 +1,1 @@
+uid://bd1k63iye1bsl

--- a/plugin/addons/godot_ai/runtime/game_helper.gd.uid
+++ b/plugin/addons/godot_ai/runtime/game_helper.gd.uid
@@ -1,0 +1,1 @@
+uid://gfybkdtsclti

--- a/plugin/addons/godot_ai/runtime/game_logger.gd.uid
+++ b/plugin/addons/godot_ai/runtime/game_logger.gd.uid
@@ -1,0 +1,1 @@
+uid://c88iybvp3v0ln

--- a/plugin/addons/godot_ai/tool_catalog.gd.uid
+++ b/plugin/addons/godot_ai/tool_catalog.gd.uid
@@ -1,0 +1,1 @@
+uid://d1vqyt4uyo378

--- a/plugin/addons/godot_ai/utils/game_log_buffer.gd.uid
+++ b/plugin/addons/godot_ai/utils/game_log_buffer.gd.uid
@@ -1,0 +1,1 @@
+uid://biojw0xl64haw

--- a/plugin/addons/godot_ai/utils/mcp_spawn_state.gd.uid
+++ b/plugin/addons/godot_ai/utils/mcp_spawn_state.gd.uid
@@ -1,0 +1,1 @@
+uid://coson6hlvkts4

--- a/plugin/addons/godot_ai/utils/resource_io.gd.uid
+++ b/plugin/addons/godot_ai/utils/resource_io.gd.uid
@@ -1,0 +1,1 @@
+uid://de2rwdoa4wabf

--- a/test_project/tests/test_dock_dev_server_btn.gd.uid
+++ b/test_project/tests/test_dock_dev_server_btn.gd.uid
@@ -1,0 +1,1 @@
+uid://bwmm6ghyge6tq

--- a/test_project/tests/test_netstat_parser.gd.uid
+++ b/test_project/tests/test_netstat_parser.gd.uid
@@ -1,0 +1,1 @@
+uid://dmcrq817tvctk

--- a/test_project/tests/test_plugin_lifecycle.gd.uid
+++ b/test_project/tests/test_plugin_lifecycle.gd.uid
@@ -1,0 +1,1 @@
+uid://ct840tfppkqlk


### PR DESCRIPTION
## Summary

Ten `.gd` files in `plugin/` and `test_project/tests/` are committed without their Godot-generated `.uid` companions. The rest of the repo's `.gd.uid` files **are** tracked (the `clients/` directory alone has ten of them in git), so these orphans are an inconsistency — Godot regenerates them locally on every fresh checkout and they show up as untracked noise in `git status`, tripping pre-commit / stop hooks.

Zero behavioral change. Just brings the `.uid` coverage in line with the rest of the repo.

## Files added

```
plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd.uid
plugin/addons/godot_ai/runtime/game_helper.gd.uid
plugin/addons/godot_ai/runtime/game_logger.gd.uid
plugin/addons/godot_ai/tool_catalog.gd.uid
plugin/addons/godot_ai/utils/game_log_buffer.gd.uid
plugin/addons/godot_ai/utils/mcp_spawn_state.gd.uid
plugin/addons/godot_ai/utils/resource_io.gd.uid
test_project/tests/test_dock_dev_server_btn.gd.uid
test_project/tests/test_netstat_parser.gd.uid
test_project/tests/test_plugin_lifecycle.gd.uid
```

Each file contains the single `uid://...` line Godot writes when it imports the script. Re-running `godot --import` on a clean checkout produces the same file content (deterministic per `.gd`).

## Test plan

- [x] `git status` clean after the commit.
- [x] `pytest -q` — 618 passed, no behavioral changes.
- [x] No `.gd` source files modified, so no GDScript test run necessary.

https://claude.ai/code/session_015YRcEbFHPutSD7Z77cwsGS

---
_Generated by [Claude Code](https://claude.ai/code/session_015YRcEbFHPutSD7Z77cwsGS)_