### PR TITLE
Fix editor refocus client status refresh

### DIFF
--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -168,6 +168,29 @@ static func check_status_for_url(id: String, url: String) -> McpClient.Status:
 	return _dispatch_check_status(client, url)
 
 
+static func check_status_for_url_with_cli_path(id: String, url: String, cli_path: String) -> McpClient.Status:
+	var client := McpClientRegistry.get_by_id(id)
+	if client == null:
+		return McpClient.Status.NOT_CONFIGURED
+	if client.config_type == "cli" and cli_path.is_empty():
+		return McpClient.Status.NOT_CONFIGURED
+	return _dispatch_check_status_with_cli_path(client, url, cli_path)
+
+
+static func client_status_probe_snapshot(id: String) -> Dictionary:
+	var client := McpClientRegistry.get_by_id(id)
+	if client == null:
+		return {}
+	var cli_path := ""
+	var installed := false
+	if client.config_type == "cli":
+		cli_path = McpCliStrategy.resolve_cli_path(client)
+		installed = not cli_path.is_empty()
+	else:
+		installed = client.is_installed()
+	return {"id": id, "cli_path": cli_path, "installed": installed}
+
+
 static func remove(id: String) -> Dictionary:
 	var client := McpClientRegistry.get_by_id(id)
 	if client == null:
@@ -202,13 +225,19 @@ static func _dispatch_remove(client: McpClient) -> Dictionary:
 
 
 static func _dispatch_check_status(client: McpClient, url: String) -> McpClient.Status:
+	return _dispatch_check_status_with_cli_path(client, url, "")
+
+
+static func _dispatch_check_status_with_cli_path(client: McpClient, url: String, cli_path: String) -> McpClient.Status:
 	match client.config_type:
 		"json":
 			return McpJsonStrategy.check_status(client, SERVER_NAME, url)
 		"toml":
 			return McpTomlStrategy.check_status(client, SERVER_NAME, url)
 		"cli":
-			return McpCliStrategy.check_status(client, SERVER_NAME, url)
+			if cli_path.is_empty():
+				return McpCliStrategy.check_status(client, SERVER_NAME, url)
+			return McpCliStrategy.check_status_with_cli_path(client, SERVER_NAME, url, cli_path)
 	return McpClient.Status.NOT_CONFIGURED
 
 

--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -161,6 +161,13 @@ static func check_status(id: String) -> McpClient.Status:
 	return _dispatch_check_status(client, http_url())
 
 
+static func check_status_for_url(id: String, url: String) -> McpClient.Status:
+	var client := McpClientRegistry.get_by_id(id)
+	if client == null:
+		return McpClient.Status.NOT_CONFIGURED
+	return _dispatch_check_status(client, url)
+
+
 static func remove(id: String) -> Dictionary:
 	var client := McpClientRegistry.get_by_id(id)
 	if client == null:

--- a/plugin/addons/godot_ai/clients/_cli_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_cli_strategy.gd
@@ -28,7 +28,10 @@ static func configure(client: McpClient, server_name: String, server_url: String
 
 
 static func check_status(client: McpClient, server_name: String, server_url: String) -> McpClient.Status:
-	var cli := _resolve_cli(client)
+	return check_status_with_cli_path(client, server_name, server_url, _resolve_cli(client))
+
+
+static func check_status_with_cli_path(client: McpClient, server_name: String, server_url: String, cli: String) -> McpClient.Status:
 	if cli.is_empty():
 		return McpClient.Status.NOT_CONFIGURED
 	if not client.cli_status_check.is_valid():
@@ -53,3 +56,7 @@ static func remove(client: McpClient, server_name: String) -> Dictionary:
 
 static func _resolve_cli(client: McpClient) -> String:
 	return McpCliFinder.find(McpClient._array_from_packed(client.cli_names))
+
+
+static func resolve_cli_path(client: McpClient) -> String:
+	return _resolve_cli(client)

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -11,6 +11,7 @@ const DEV_MODE_SETTING := "godot_ai/dev_mode"
 const MODE_OVERRIDE_VALUES := ["", "user", "dev"]
 const MODE_OVERRIDE_LABELS := ["Auto", "Force user", "Force dev"]
 const CLIENT_STATUS_REFRESH_COOLDOWN_MSEC := 15 * 1000
+const CLIENT_STATUS_REFRESH_TIMEOUT_MSEC := 30 * 1000
 static var COLOR_MUTED := Color(0.7, 0.7, 0.7)
 static var COLOR_HEADER := Color(0.95, 0.95, 0.95)
 ## Used for "in-progress" / "stale, action needed" UI: the startup-grace
@@ -90,6 +91,11 @@ var _client_status_refresh_in_flight := false
 var _client_status_refresh_pending := false
 var _client_status_refresh_pending_force := false
 var _last_client_status_refresh_completed_msec: int = 0
+var _client_status_refresh_started_msec: int = 0
+var _client_status_refresh_generation: int = 0
+var _client_status_refresh_shutdown_requested := false
+var _client_status_refresh_timed_out := false
+static var _orphaned_client_status_refresh_threads: Array[Thread] = []
 
 # Dev-mode only
 var _dev_section: VBoxContainer
@@ -158,9 +164,22 @@ func _ready() -> void:
 func _process(_delta: float) -> void:
 	if _connection == null:
 		return
+	_prune_orphaned_client_status_refresh_threads()
+	_check_client_status_refresh_timeout()
 	_update_status()
 	if _log_section.visible:
 		_update_log()
+
+
+func _exit_tree() -> void:
+	_client_status_refresh_shutdown_requested = true
+	_client_status_refresh_generation += 1
+	if _client_status_refresh_thread != null:
+		_orphaned_client_status_refresh_threads.append(_client_status_refresh_thread)
+		_client_status_refresh_thread = null
+	_client_status_refresh_in_flight = false
+	_client_status_refresh_pending = false
+	_client_status_refresh_pending_force = false
 
 
 func _notification(what: int) -> void:
@@ -509,7 +528,7 @@ func _build_ui() -> void:
 	# Apply initial dev-mode visibility
 	_apply_dev_mode_visibility()
 	_refresh_setup_status.call_deferred()
-	_refresh_clients_summary.call_deferred()
+	_request_client_status_refresh.call_deferred(true)
 
 
 func _make_header(text: String) -> Label:
@@ -574,6 +593,7 @@ func _build_client_row(client_id: String) -> void:
 
 	_client_rows[client_id] = {
 		"dot": dot,
+		"status": McpClient.Status.NOT_CONFIGURED,
 		"name_label": name_label,
 		"configure_btn": configure_btn,
 		"remove_btn": remove_btn,
@@ -1097,9 +1117,11 @@ func _on_refresh_clients_pressed() -> void:
 
 
 func _on_configure_all_clients() -> void:
+	if _client_status_refresh_in_flight:
+		return
 	for client_id in _client_rows:
-		var dot: ColorRect = _client_rows[client_id]["dot"]
-		if dot.color == Color.GREEN:
+		var status: McpClient.Status = _client_rows[client_id].get("status", McpClient.Status.NOT_CONFIGURED)
+		if status == McpClient.Status.CONFIGURED:
 			continue
 		_on_configure_client(String(client_id))
 	_refresh_clients_summary()
@@ -1370,27 +1392,30 @@ func _on_tools_discard_confirmed() -> void:
 
 
 func _refresh_clients_summary() -> void:
-	# Count from row dot colors — `_apply_row_status` is the single source of
-	# truth, and reading colors avoids re-running filesystem-hitting status
-	# checks on every refresh. Also re-derives the drift banner from the same
-	# dots so per-row mutations (Configure/Reconfigure/Remove on a row in the
-	# Clients & Tools window) keep the dock-level banner in sync without an
-	# extra sweep — without this, the banner stays stale after a successful
-	# Reconfigure until the next explicit refresh or window-open sweep. See #166.
+	# Count from cached row status values — `_apply_row_status` is the single
+	# source of truth, and reading cached status avoids re-running
+	# filesystem/CLI-hitting checks on every refresh. The same cache re-derives
+	# the drift banner so per-row mutations (Configure/Reconfigure/Remove on a
+	# row in the Clients & Tools window) keep the dock-level banner in sync
+	# without an extra sweep. See #166 and #226.
 	if _clients_summary_label == null:
 		return
 	var configured := 0
 	var mismatched_ids: Array[String] = []
 	for client_id in _client_rows:
-		var c := (_client_rows[client_id]["dot"] as ColorRect).color
-		if c == Color.GREEN:
+		var status: McpClient.Status = _client_rows[client_id].get("status", McpClient.Status.NOT_CONFIGURED)
+		if status == McpClient.Status.CONFIGURED:
 			configured += 1
-		elif c == COLOR_AMBER:
+		elif status == McpClient.Status.CONFIGURED_MISMATCH:
 			mismatched_ids.append(client_id)
 	var text := "%d / %d configured" % [configured, _client_rows.size()]
 	if mismatched_ids.size() > 0:
 		text += " (%d stale)" % mismatched_ids.size()
+	if _client_status_refresh_in_flight:
+		text += " (checking...)" if not _client_status_refresh_timed_out else " (client probe still running)"
 	_clients_summary_label.text = text
+	if _client_configure_all_btn != null:
+		_client_configure_all_btn.disabled = _client_status_refresh_in_flight
 	_refresh_drift_banner(mismatched_ids)
 
 
@@ -1426,50 +1451,115 @@ func _is_client_status_refresh_in_cooldown() -> bool:
 	return Time.get_ticks_msec() - _last_client_status_refresh_completed_msec < CLIENT_STATUS_REFRESH_COOLDOWN_MSEC
 
 
+func _has_client_status_refresh_timed_out() -> bool:
+	if not _client_status_refresh_in_flight:
+		return false
+	if _client_status_refresh_started_msec <= 0:
+		return false
+	return Time.get_ticks_msec() - _client_status_refresh_started_msec >= CLIENT_STATUS_REFRESH_TIMEOUT_MSEC
+
+
+func _check_client_status_refresh_timeout() -> void:
+	if not _has_client_status_refresh_timed_out():
+		return
+	if _client_status_refresh_timed_out:
+		return
+	_client_status_refresh_timed_out = true
+	_refresh_clients_summary()
+
+
+func _abandon_client_status_refresh_thread() -> void:
+	## GDScript cannot interrupt a blocking `OS.execute(..., true)` call in a
+	## worker. If a CLI probe hangs, orphan this run, bump the generation so any
+	## late result becomes a no-op, and let a forced/manual refresh start a fresh
+	## probe slot. Completed orphan threads are pruned from `_process`.
+	_client_status_refresh_generation += 1
+	if _client_status_refresh_thread != null:
+		_orphaned_client_status_refresh_threads.append(_client_status_refresh_thread)
+		_client_status_refresh_thread = null
+	_client_status_refresh_in_flight = false
+	_client_status_refresh_pending = false
+	_client_status_refresh_pending_force = false
+	_client_status_refresh_timed_out = false
+	_client_status_refresh_started_msec = 0
+	_refresh_clients_summary()
+
+
+func _prune_orphaned_client_status_refresh_threads() -> void:
+	for i in range(_orphaned_client_status_refresh_threads.size() - 1, -1, -1):
+		var thread := _orphaned_client_status_refresh_threads[i]
+		if thread == null:
+			_orphaned_client_status_refresh_threads.remove_at(i)
+		elif not thread.is_alive():
+			thread.wait_to_finish()
+			_orphaned_client_status_refresh_threads.remove_at(i)
+
+
 func _request_client_status_refresh(force: bool = false) -> bool:
 	## Stale-while-refreshing: do not clear dots, summary, or the drift banner
 	## when a refresh is requested. The existing UI remains visible until the
 	## background worker's result is applied on the main thread.
 	if _client_status_refresh_in_flight:
-		_client_status_refresh_pending = true
-		_client_status_refresh_pending_force = _client_status_refresh_pending_force or force
+		if force and _has_client_status_refresh_timed_out():
+			_abandon_client_status_refresh_thread()
+		else:
+			_client_status_refresh_pending = true
+			_client_status_refresh_pending_force = _client_status_refresh_pending_force or force
+			_refresh_clients_summary()
+			return false
+	if _client_status_refresh_shutdown_requested:
 		return false
 	if not force and _is_client_status_refresh_in_cooldown():
 		return false
 	if _client_rows.is_empty():
 		return false
 
-	var client_ids: Array[String] = []
+	var client_probes: Array[Dictionary] = []
 	for client_id in _client_rows:
-		client_ids.append(String(client_id))
+		client_probes.append(McpClientConfigurator.client_status_probe_snapshot(String(client_id)))
 	var server_url := McpClientConfigurator.http_url()
 
 	_client_status_refresh_in_flight = true
 	_client_status_refresh_pending = false
 	_client_status_refresh_pending_force = false
+	_client_status_refresh_timed_out = false
+	_client_status_refresh_started_msec = Time.get_ticks_msec()
+	_client_status_refresh_generation += 1
+	var generation := _client_status_refresh_generation
+	_refresh_clients_summary()
 	_client_status_refresh_thread = Thread.new()
 	var err := _client_status_refresh_thread.start(
-		Callable(self, "_run_client_status_refresh_worker").bind(client_ids, server_url)
+		Callable(self, "_run_client_status_refresh_worker").bind(client_probes, server_url, generation)
 	)
 	if err != OK:
 		_client_status_refresh_in_flight = false
+		_client_status_refresh_timed_out = false
 		_client_status_refresh_thread = null
+		_refresh_clients_summary()
 		return false
 	return true
 
 
-func _run_client_status_refresh_worker(client_ids: Array[String], server_url: String) -> void:
+func _run_client_status_refresh_worker(client_probes: Array[Dictionary], server_url: String, generation: int) -> void:
 	var results: Dictionary = {}
-	for client_id in client_ids:
-		var status := McpClientConfigurator.check_status_for_url(client_id, server_url)
-		var installed := false
-		if status == McpClient.Status.NOT_CONFIGURED:
-			installed = McpClientConfigurator.is_installed(client_id)
+	for probe in client_probes:
+		var client_id := String(probe.get("id", ""))
+		if client_id.is_empty():
+			continue
+		var status := McpClientConfigurator.check_status_for_url_with_cli_path(
+			client_id,
+			server_url,
+			String(probe.get("cli_path", ""))
+		)
+		var installed := bool(probe.get("installed", false))
 		results[client_id] = {"status": status, "installed": installed}
-	call_deferred("_apply_client_status_refresh_results", results)
+	if not _client_status_refresh_shutdown_requested:
+		call_deferred("_apply_client_status_refresh_results", results, generation)
 
 
-func _apply_client_status_refresh_results(results: Dictionary) -> void:
+func _apply_client_status_refresh_results(results: Dictionary, generation: int) -> void:
+	if generation != _client_status_refresh_generation or _client_status_refresh_shutdown_requested:
+		return
 	if _client_status_refresh_thread != null:
 		_client_status_refresh_thread.wait_to_finish()
 		_client_status_refresh_thread = null
@@ -1482,9 +1572,10 @@ func _apply_client_status_refresh_results(results: Dictionary) -> void:
 			"",
 			result.get("installed", false)
 		)
-	_refresh_clients_summary()
 	_last_client_status_refresh_completed_msec = Time.get_ticks_msec()
 	_client_status_refresh_in_flight = false
+	_client_status_refresh_timed_out = false
+	_refresh_clients_summary()
 
 	if _client_status_refresh_pending:
 		var pending_force := _client_status_refresh_pending_force
@@ -1540,6 +1631,7 @@ func _apply_row_status(
 	var row: Dictionary = _client_rows.get(client_id, {})
 	if row.is_empty():
 		return
+	row["status"] = status
 	var dot: ColorRect = row["dot"]
 	var configure_btn: Button = row["configure_btn"]
 	var remove_btn: Button = row["remove_btn"]

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -10,6 +10,7 @@ const DEV_MODE_SETTING := "godot_ai/dev_mode"
 ## EditorSetting and read by `McpClientConfigurator.mode_override()`.
 const MODE_OVERRIDE_VALUES := ["", "user", "dev"]
 const MODE_OVERRIDE_LABELS := ["Auto", "Force user", "Force dev"]
+const CLIENT_STATUS_REFRESH_COOLDOWN_MSEC := 15 * 1000
 static var COLOR_MUTED := Color(0.7, 0.7, 0.7)
 static var COLOR_HEADER := Color(0.95, 0.95, 0.95)
 ## Used for "in-progress" / "stale, action needed" UI: the startup-grace
@@ -53,9 +54,11 @@ var _client_rows: Dictionary = {}
 
 # Drift banner — surfaced near the Clients section when one or more clients
 # have a stored entry whose URL no longer matches `http_url()` (typical after
-# the user changes `godot_ai/http_port`). Event-driven: refreshed on
-# plugin enter, after Apply+Reload, when the Clients window opens, and on
-# editor focus-in. See #166.
+# the user changes `godot_ai/http_port`). Refreshes are stale-while-refreshing:
+# cached row dots/banner remain visible while a background worker performs the
+# potentially blocking config/CLI probes, then the main thread applies results.
+# Automatic focus-in refreshes use a short cooldown to avoid repeated sweeps
+# during tab-away/tab-back churn. See #166 and #226.
 var _drift_banner: VBoxContainer
 var _drift_label: Label
 ## Handles for the Setup section's "Server" row. `_update_status` keeps
@@ -79,15 +82,14 @@ var _version_restart_btn: Button
 ## (a) the Reconfigure button reuses this list instead of re-running
 ## `check_status` per row (saves ~18 filesystem reads per click), and
 ## (b) `_refresh_drift_banner` early-returns when the set is unchanged so
-## focus-in sweeps don't repaint identical text. Mirrors the
+## repeated explicit refreshes don't repaint identical text. Mirrors the
 ## `_last_server_status` pattern used by the crash panel.
 var _last_mismatched_ids: Array[String] = []
-## Debounce for `NOTIFICATION_APPLICATION_FOCUS_IN`. Each focus-in costs
-## ~18 filesystem reads on the main thread; a 2s window collapses
-## fast alt-tab cycles into a single sweep without making the banner
-## feel stale.
-var _last_focus_sweep_msec: int = 0
-const FOCUS_SWEEP_MIN_MSEC := 2000
+var _client_status_refresh_thread: Thread
+var _client_status_refresh_in_flight := false
+var _client_status_refresh_pending := false
+var _client_status_refresh_pending_force := false
+var _last_client_status_refresh_completed_msec: int = 0
 
 # Dev-mode only
 var _dev_section: VBoxContainer
@@ -166,17 +168,15 @@ func _notification(what: int) -> void:
 	if what == NOTIFICATION_PARENTED or what == NOTIFICATION_UNPARENTED:
 		_update_redock_visibility.call_deferred()
 	elif what == NOTIFICATION_APPLICATION_FOCUS_IN:
-		## Catches the case where the user edits an MCP client config in
-		## another app (or runs `claude mcp add` in a terminal) while Godot
-		## was unfocused. Debounced so a fast alt-tab cycle doesn't fire
-		## one sweep per focus-in. See #166.
-		if _client_rows.is_empty():
-			return
-		var now := Time.get_ticks_msec()
-		if now - _last_focus_sweep_msec < FOCUS_SWEEP_MIN_MSEC:
-			return
-		_last_focus_sweep_msec = now
-		_refresh_all_client_statuses.call_deferred()
+		if _should_refresh_client_statuses_on_focus_in():
+			_request_client_status_refresh(false)
+
+
+func _should_refresh_client_statuses_on_focus_in() -> bool:
+	## Focus-in is part of Godot/editor window activation. Keep automatic refresh,
+	## but only through the async/cooldown-protected path; never run a blocking
+	## client-status sweep directly from this notification.
+	return true
 
 
 func _is_floating() -> bool:
@@ -380,6 +380,12 @@ func _build_ui() -> void:
 	_clients_summary_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	clients_row.add_child(_clients_summary_label)
 
+	var clients_refresh_btn := Button.new()
+	clients_refresh_btn.text = "Refresh"
+	clients_refresh_btn.tooltip_text = "Refresh client status in the background. Cached status stays visible while checks run."
+	clients_refresh_btn.pressed.connect(_on_refresh_clients_pressed)
+	clients_row.add_child(clients_refresh_btn)
+
 	var clients_open_btn := Button.new()
 	clients_open_btn.text = "Clients & Tools"
 	clients_open_btn.tooltip_text = "Open the MCP settings window — configure AI clients or disable tool domains to fit under a client's hard tool-count cap (e.g. Antigravity's 100)."
@@ -503,7 +509,7 @@ func _build_ui() -> void:
 	# Apply initial dev-mode visibility
 	_apply_dev_mode_visibility()
 	_refresh_setup_status.call_deferred()
-	_refresh_all_client_statuses.call_deferred()
+	_refresh_clients_summary.call_deferred()
 
 
 func _make_header(text: String) -> Label:
@@ -1086,22 +1092,27 @@ func _on_remove_client(client_id: String) -> void:
 	_refresh_clients_summary()
 
 
+func _on_refresh_clients_pressed() -> void:
+	_request_client_status_refresh(true)
+
+
 func _on_configure_all_clients() -> void:
-	for client_id in McpClientConfigurator.client_ids():
-		if McpClientConfigurator.check_status(client_id) == McpClient.Status.CONFIGURED:
+	for client_id in _client_rows:
+		var dot: ColorRect = _client_rows[client_id]["dot"]
+		if dot.color == Color.GREEN:
 			continue
-		_on_configure_client(client_id)
+		_on_configure_client(String(client_id))
 	_refresh_clients_summary()
 
 
 func _on_open_clients_window() -> void:
 	if _clients_window == null:
 		return
-	## Re-sweep before the user has time to act on stale dot colors. Deferred
-	## so the popup paints immediately with last-known state — the fresh
-	## colors land on the next frame. Synchronous would block the popup paint
-	## for ~18 filesystem reads (~100-300ms with AV scanning). See #166.
-	_refresh_all_client_statuses.call_deferred()
+	## Re-sweep before the user has time to act on stale dot colors. The request
+	## is async/stale-while-refreshing so the popup paints immediately with
+	## last-known state; the fresh colors land when the background worker returns.
+	## This is an explicit user action, so it bypasses the focus-in cooldown.
+	_request_client_status_refresh(true)
 	## Also re-sync the Tools tab from the persisted setting — another
 	## editor instance (or a hand-edit of editor_settings-4.tres) may have
 	## changed the excluded list while the window was closed.
@@ -1365,7 +1376,7 @@ func _refresh_clients_summary() -> void:
 	# dots so per-row mutations (Configure/Reconfigure/Remove on a row in the
 	# Clients & Tools window) keep the dock-level banner in sync without an
 	# extra sweep — without this, the banner stays stale after a successful
-	# Reconfigure until the next focus-in or window-open sweep. See #166.
+	# Reconfigure until the next explicit refresh or window-open sweep. See #166.
 	if _clients_summary_label == null:
 		return
 	var configured := 0
@@ -1403,15 +1414,83 @@ func _on_copy_manual_command(client_id: String) -> void:
 
 
 func _refresh_all_client_statuses() -> void:
-	## Single sweep: pass the per-client status through `_apply_row_status` for
-	## the row UI, then let `_refresh_clients_summary` re-derive the count and
-	## the drift banner from the dots. Each client's `check_status` is one
-	## filesystem read — fine to do all of them on the handful of trigger
-	## events documented in #166.
+	## Compatibility wrapper for older explicit call sites. Treat this as a manual
+	## refresh: it bypasses focus-in cooldown but still runs probes off the editor
+	## main thread.
+	_request_client_status_refresh(true)
+
+
+func _is_client_status_refresh_in_cooldown() -> bool:
+	if _last_client_status_refresh_completed_msec <= 0:
+		return false
+	return Time.get_ticks_msec() - _last_client_status_refresh_completed_msec < CLIENT_STATUS_REFRESH_COOLDOWN_MSEC
+
+
+func _request_client_status_refresh(force: bool = false) -> bool:
+	## Stale-while-refreshing: do not clear dots, summary, or the drift banner
+	## when a refresh is requested. The existing UI remains visible until the
+	## background worker's result is applied on the main thread.
+	if _client_status_refresh_in_flight:
+		_client_status_refresh_pending = true
+		_client_status_refresh_pending_force = _client_status_refresh_pending_force or force
+		return false
+	if not force and _is_client_status_refresh_in_cooldown():
+		return false
+	if _client_rows.is_empty():
+		return false
+
+	var client_ids: Array[String] = []
 	for client_id in _client_rows:
-		var status := McpClientConfigurator.check_status(client_id)
-		_apply_row_status(client_id, status)
+		client_ids.append(String(client_id))
+	var server_url := McpClientConfigurator.http_url()
+
+	_client_status_refresh_in_flight = true
+	_client_status_refresh_pending = false
+	_client_status_refresh_pending_force = false
+	_client_status_refresh_thread = Thread.new()
+	var err := _client_status_refresh_thread.start(
+		Callable(self, "_run_client_status_refresh_worker").bind(client_ids, server_url)
+	)
+	if err != OK:
+		_client_status_refresh_in_flight = false
+		_client_status_refresh_thread = null
+		return false
+	return true
+
+
+func _run_client_status_refresh_worker(client_ids: Array[String], server_url: String) -> void:
+	var results: Dictionary = {}
+	for client_id in client_ids:
+		var status := McpClientConfigurator.check_status_for_url(client_id, server_url)
+		var installed := false
+		if status == McpClient.Status.NOT_CONFIGURED:
+			installed = McpClientConfigurator.is_installed(client_id)
+		results[client_id] = {"status": status, "installed": installed}
+	call_deferred("_apply_client_status_refresh_results", results)
+
+
+func _apply_client_status_refresh_results(results: Dictionary) -> void:
+	if _client_status_refresh_thread != null:
+		_client_status_refresh_thread.wait_to_finish()
+		_client_status_refresh_thread = null
+
+	for client_id in results:
+		var result: Dictionary = results[client_id]
+		_apply_row_status(
+			String(client_id),
+			result.get("status", McpClient.Status.NOT_CONFIGURED),
+			"",
+			result.get("installed", false)
+		)
 	_refresh_clients_summary()
+	_last_client_status_refresh_completed_msec = Time.get_ticks_msec()
+	_client_status_refresh_in_flight = false
+
+	if _client_status_refresh_pending:
+		var pending_force := _client_status_refresh_pending_force
+		_client_status_refresh_pending = false
+		_client_status_refresh_pending_force = false
+		_request_client_status_refresh(pending_force)
 
 
 func _refresh_drift_banner(mismatched_ids: Array[String]) -> void:
@@ -1452,7 +1531,12 @@ func _on_reconfigure_mismatched() -> void:
 	_refresh_all_client_statuses()
 
 
-func _apply_row_status(client_id: String, status: McpClient.Status, error_msg: String = "") -> void:
+func _apply_row_status(
+	client_id: String,
+	status: McpClient.Status,
+	error_msg: String = "",
+	installed_override: Variant = null,
+) -> void:
 	var row: Dictionary = _client_rows.get(client_id, {})
 	if row.is_empty():
 		return
@@ -1471,7 +1555,7 @@ func _apply_row_status(client_id: String, status: McpClient.Status, error_msg: S
 			dot.color = COLOR_MUTED
 			configure_btn.text = "Configure"
 			remove_btn.visible = false
-			var installed := McpClientConfigurator.is_installed(client_id)
+			var installed: bool = installed_override if installed_override != null else McpClientConfigurator.is_installed(client_id)
 			name_label.text = base_name if installed else "%s  (not detected)" % base_name
 		McpClient.Status.CONFIGURED_MISMATCH:
 			## Amber matches the dock-level drift banner so a glance at the

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -138,6 +138,25 @@ func test_drift_banner_clears_after_per_row_reconfigure() -> void:
 		"Cache must drop the now-green client so a follow-up Reconfigure-mismatched click is a no-op")
 
 
+func test_focus_in_auto_refresh_is_enabled_with_async_cooldown() -> void:
+	## Focus-in should still refresh client status, but the refresh path must be
+	## async/cooldown-protected so it does not run blocking CLI checks on the
+	## editor thread during OS/window refocus.
+	assert_true(_dock._should_refresh_client_statuses_on_focus_in(),
+		"Editor focus-in should request the async client-status refresh")
+	assert_eq(McpDockScript.CLIENT_STATUS_REFRESH_COOLDOWN_MSEC, 15 * 1000,
+		"Focus-in refresh cooldown is intentionally short and explicit")
+
+
+func test_refresh_cooldown_helper_only_blocks_automatic_refreshes() -> void:
+	_dock._last_client_status_refresh_completed_msec = Time.get_ticks_msec()
+	assert_true(_dock._is_client_status_refresh_in_cooldown(),
+		"Recent automatic refresh should be inside cooldown")
+	_dock._last_client_status_refresh_completed_msec = 0
+	assert_false(_dock._is_client_status_refresh_in_cooldown(),
+		"No completed refresh means no cooldown")
+
+
 ## Shared fixture for the three version-label tests. Inject a Label + Button
 ## + Connection onto the dock so the pure refresh logic can be exercised
 ## without depending on whether the test environment resolves as user mode

--- a/tests/unit/test_editor_focus_refocus.py
+++ b/tests/unit/test_editor_focus_refocus.py
@@ -50,6 +50,53 @@ def test_clients_window_open_requests_nonblocking_refresh() -> None:
     assert "_refresh_all_client_statuses.call_deferred" not in block
 
 
+def test_initial_paint_requests_async_status_refresh() -> None:
+    """Cold editor open should still populate client dots without waiting for focus-in."""
+
+    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+    build_block = source.split("func _build_ui() -> void:", 1)[1].split("\n\nfunc ", 1)[0]
+
+    assert "_request_client_status_refresh.call_deferred(true)" in build_block
+
+
+def test_worker_uses_main_thread_probe_snapshot_for_cli_paths() -> None:
+    """CLI path discovery caches should not be mutated from the refresh worker."""
+
+    dock_source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+    configurator_source = (PLUGIN_ROOT / "client_configurator.gd").read_text()
+    cli_source = (PLUGIN_ROOT / "clients" / "_cli_strategy.gd").read_text()
+    worker_block = dock_source.split("func _run_client_status_refresh_worker", 1)[1].split(
+        "\n\nfunc ", 1
+    )[0]
+
+    assert "client_status_probe_snapshot" in dock_source
+    assert "check_status_for_url_with_cli_path" in worker_block
+    assert "McpClientConfigurator.is_installed" not in worker_block
+    assert "resolve_cli_path" in configurator_source
+    assert "check_status_with_cli_path" in cli_source
+
+
+def test_refresh_timeout_can_abandon_stale_worker_results() -> None:
+    """A hung CLI probe should not permanently own the refresh slot."""
+
+    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+
+    assert "CLIENT_STATUS_REFRESH_TIMEOUT_MSEC := 30 * 1000" in source
+    assert "_client_status_refresh_generation" in source
+    assert "_abandon_client_status_refresh_thread" in source
+    assert "generation != _client_status_refresh_generation" in source
+
+
+def test_configure_all_uses_cached_status_not_dot_color() -> None:
+    """Configure-all must not make correctness decisions from stale UI colors."""
+
+    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+    block = source.split("func _on_configure_all_clients() -> void:", 1)[1].split("\n\nfunc ", 1)[0]
+
+    assert 'get("status", McpClient.Status.NOT_CONFIGURED)' in block
+    assert "dot.color" not in block
+
+
 def _focus_in_block(source: str) -> str:
     marker = "NOTIFICATION_APPLICATION_FOCUS_IN"
     start = source.index(marker)

--- a/tests/unit/test_editor_focus_refocus.py
+++ b/tests/unit/test_editor_focus_refocus.py
@@ -1,0 +1,56 @@
+"""Regression tests for editor focus/refocus behavior."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[2] / "plugin" / "addons" / "godot_ai"
+
+
+def test_focus_in_uses_async_cooled_down_refresh_instead_of_blocking_sweep() -> None:
+    """Focus-in should keep automatic refresh without blocking the editor thread."""
+
+    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+
+    assert "NOTIFICATION_APPLICATION_FOCUS_IN" in source
+    assert "CLIENT_STATUS_REFRESH_COOLDOWN_MSEC := 15 * 1000" in source
+    assert "_request_client_status_refresh(false)" in source
+    assert "_refresh_all_client_statuses()" not in _focus_in_block(source)
+
+
+def test_client_status_refresh_runs_on_background_thread_and_applies_deferred() -> None:
+    """Blocking client probes should run off-thread; UI updates should apply deferred."""
+
+    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+
+    assert "var _client_status_refresh_thread: Thread" in source
+    assert "_client_status_refresh_thread.start" in source
+    assert "McpClientConfigurator.check_status" in source
+    assert "call_deferred(\"_apply_client_status_refresh_results" in source
+
+
+def test_client_status_refresh_coalesces_and_manual_refresh_bypasses_cooldown() -> None:
+    """Duplicate automatic refreshes should coalesce; manual actions stay explicit."""
+
+    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+
+    assert "if _client_status_refresh_in_flight:" in source
+    assert "_client_status_refresh_pending = true" in source
+    assert "if not force and _is_client_status_refresh_in_cooldown()" in source
+    assert "_request_client_status_refresh(true)" in source
+
+
+def test_clients_window_open_requests_nonblocking_refresh() -> None:
+    """Opening Clients & Tools should not schedule a deferred synchronous sweep."""
+
+    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+    block = source.split("func _on_open_clients_window() -> void:", 1)[1].split("\nfunc ", 1)[0]
+
+    assert "_request_client_status_refresh(" in block
+    assert "_refresh_all_client_statuses.call_deferred" not in block
+
+
+def _focus_in_block(source: str) -> str:
+    marker = "NOTIFICATION_APPLICATION_FOCUS_IN"
+    start = source.index(marker)
+    return source[start : source.index("\n\n", start)]


### PR DESCRIPTION
## Summary
- Keeps automatic client status refresh on editor focus-in, but moves status probes to a background thread so blocking CLI checks do not freeze the editor.
- Adds stale-while-refreshing UI behavior, one-in-flight coalescing, and a 15s cooldown for automatic refocus refreshes while preserving manual refresh.
- Adds focused regression tests for refocus behavior and client-status refresh semantics.

## Validation
- `uv run ruff check src tests`
- `uv run pytest tests/unit/test_asgi_session_diagnostics.py tests/unit/test_cli_reload.py tests/unit/test_editor_focus_refocus.py` — 29 passed
- `uv run pytest tests` — 637 passed
- Manual validation in Godot: repeated tab-away/tab-back no longer freezes while Godot-AI is enabled

Fixes #226