### PR TITLE
fix(clients): make descriptors data-only — drop hot-reloadable Callables (#229)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,16 +229,24 @@ The plugin auto-configures 18+ MCP clients via a registry + strategy system in
 `plugin/addons/godot_ai/clients/`:
 
 - `_base.gd` — `McpClient` descriptor (data only: id, display_name, config_type,
-  path_template, server_key_path, entry_builder, …)
+  path_template, server_key_path, entry_url_field, entry_extra_fields,
+  entry_uvx_bridge, cli_register_template, cli_status_args, toml_body_template,
+  …). Descriptors carry no `Callable` fields and no control flow — strategies
+  interpret the data. The `test_descriptors_are_data_only` suite enforces this
+  (issue #229: hot-reloaded per-client lambdas raced with worker threads).
 - `_registry.gd` — explicit `preload(...)` list of every client. Adding a client
   means: write `clients/<name>.gd` extending `McpClient`, then append one
   preload here. No edits to dock or facade required.
 - `_json_strategy.gd` / `_toml_strategy.gd` / `_cli_strategy.gd` — three
   reusable writers, selected by descriptor `config_type`. **No per-client
-  branching** inside strategies — non-standard entry shapes (Claude Desktop's
-  `npx mcp-remote` bridge, Antigravity's `serverUrl`, Zed's `command`/`settings`
-  shape) supply their own `entry_builder` (and optionally a `verify_entry`
-  callable for status checks).
+  branching** inside strategies — non-standard entry shapes are expressed
+  declaratively: `entry_url_field` overrides the URL key (Antigravity's
+  `serverUrl`, Gemini's `httpUrl`); `entry_extra_fields` adds verbatim keys
+  (Roo's `type: streamable-http`, OpenCode's `enabled: true`); `entry_uvx_bridge`
+  composes the stdio→HTTP bridge shape for stdio-only clients (Claude Desktop's
+  `flat`, Zed's `nested`).
+- `_manual_command.gd` — synthesizes the dock's "Run this manually" string
+  from the same declarative fields. No per-client builders.
 - `_path_template.gd` — expands `~`, `$HOME`, `$APPDATA`, `$XDG_CONFIG_HOME`,
   `$LOCALAPPDATA`, `$USERPROFILE`; picks the right per-OS entry from a
   `{"darwin": ..., "windows": ..., "linux": ...}` (or `"unix"` shorthand) map.

--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -235,9 +235,9 @@ static func _verify_post_state(
 
 static func manual_command(id: String) -> String:
 	var client := McpClientRegistry.get_by_id(id)
-	if client == null or not client.manual_command_builder.is_valid():
+	if client == null:
 		return ""
-	return client.manual_command_builder.call(SERVER_NAME, http_url(), client.resolved_config_path())
+	return McpManualCommand.build(client, SERVER_NAME, http_url(), client.resolved_config_path())
 
 
 static func is_installed(id: String) -> bool:

--- a/plugin/addons/godot_ai/clients/_base.gd
+++ b/plugin/addons/godot_ai/clients/_base.gd
@@ -4,19 +4,14 @@ extends RefCounted
 
 ## Descriptor for one MCP client (Cursor, Claude Desktop, Codex, ...).
 ##
-## Subclasses set fields in `_init()` and contain NO Callables, NO control
-## flow, NO logic. Strategies (json/toml/cli) interpret these fields.
+## Subclasses set fields in `_init()` and MUST NOT carry Callables — strategies
+## (json/toml/cli) interpret the data. Enforced by
+## `test_clients.gd::test_descriptors_are_data_only`.
 ##
-## This is enforced by `test_clients.gd::test_descriptors_are_data_only` —
-## any Variant property whose runtime value is a `Callable` fails the suite.
-##
-## Why: per-client `.gd` files get hot-reloaded on disk-mtime change. Any
-## descriptor-supplied lambda is GDScript bytecode living in a hot-reloadable
-## script — if a worker thread is mid-call when the file gets swapped (git
-## checkout, in-IDE save, the dock's self-update flow) the IP walks off a
-## cliff and the editor SEGVs (issue #229). It also independently solves the
-## "stale Callable after plugin disable+enable" crash from issue #192:
-## without Callables there's nothing to go stale.
+## Why no Callables: per-client `.gd` files get hot-reloaded on disk-mtime
+## change. A worker thread mid-call into a descriptor lambda races the
+## bytecode swap and SEGVs (issue #229). Bonus: also obsoletes the stale-
+## Callable workaround from #192.
 
 ## CONFIGURED_MISMATCH = an entry with our `SERVER_NAME` exists in the user's
 ## client config, but its URL doesn't match `http_url()` — typical after the
@@ -69,12 +64,16 @@ var entry_url_field: String = "url"
 var entry_extra_fields: Dictionary = {}
 
 ## stdio→HTTP bridge mode for clients that don't speak HTTP natively.
-##   ""        — no bridge; entry is `{[entry_url_field]: url, **entry_extra_fields}`
-##   "flat"    — Claude Desktop shape: `{"command": <uvx>, "args": [...bridge...]}`
-##               Verifier ALSO accepts a future url-style entry.
-##   "nested"  — Zed shape: `{"command": {"path": <uvx>, "args": [...]}, "settings": {}}`
-##               Verifier requires the bridge form (no url-style fallback).
-var entry_uvx_bridge: String = ""
+##   NONE    — entry is `{[entry_url_field]: url, **entry_extra_fields}`
+##   FLAT    — Claude Desktop shape: `{"command": <uvx>, "args": [...bridge...]}`
+##             Verifier ALSO accepts a future url-style entry.
+##   NESTED  — Zed shape: `{"command": {"path": <uvx>, "args": [...]}, "settings": {}}`
+##             Verifier requires the bridge form (no url-style fallback).
+##
+## Enum (vs. String) so a typo in a descriptor fails at parse time instead of
+## silently falling through `match` to the non-bridge path.
+enum UvxBridge { NONE, FLAT, NESTED }
+var entry_uvx_bridge: UvxBridge = UvxBridge.NONE
 
 ## Paths whose existence implies the user has this client installed.
 ## Used purely for the dock's "installed" badge.
@@ -124,6 +123,16 @@ static func _array_from_packed(packed: PackedStringArray) -> Array[String]:
 	var out: Array[String] = []
 	for s in packed:
 		out.append(s)
+	return out
+
+
+## Slice a PackedStringArray into a new PackedStringArray over [from, to).
+## Used by `_toml_strategy` and `_manual_command` to peel the section path
+## apart for `[a.b."c"]` header rendering.
+static func _packed_slice(packed: PackedStringArray, from: int, to: int) -> PackedStringArray:
+	var out := PackedStringArray()
+	for i in range(from, to):
+		out.append(packed[i])
 	return out
 
 

--- a/plugin/addons/godot_ai/clients/_base.gd
+++ b/plugin/addons/godot_ai/clients/_base.gd
@@ -56,15 +56,31 @@ var server_key_path: PackedStringArray = PackedStringArray()
 ## "url" by default; some clients use "serverUrl" or "httpUrl".
 var entry_url_field: String = "url"
 
-## Verbatim extra fields merged into the entry alongside `entry_url_field`.
-## Used to pin transport `type` (Cline / Roo / Kilo / VS Code), set
-## `disabled: false` flags, etc. The default verifier asserts every key here
-## still has the declared value in a stored entry — a typeless legacy entry
-## fails verification and surfaces as drift.
+## Required entry fields — written on every Configure AND verified by the
+## default verifier. Use this for transport pins (e.g. `type:
+## "streamable-http"`) where a missing/wrong value breaks negotiation: a
+## legacy entry without the pin fails verification and surfaces as drift.
+##
+## DO NOT put user-mutable state here (auto-approval lists, `disabled`
+## flags, opt-in toggles). Verifying those treats every user customisation
+## as drift, and Configure-All-Mismatched then silently overwrites them
+## back to defaults — see the `entry_initial_fields` doc below.
 var entry_extra_fields: Dictionary = {}
 
+## Default fields written ONLY when the entry doesn't yet exist. Reconfigure
+## preserves whatever the user (or the client itself) has set; the verifier
+## ignores these keys entirely. Use for opt-in flags and user-state arrays —
+## e.g. Roo / Cline / Kilo `alwaysAllow` / `autoApprove` lists, `disabled:
+## false`, `isActive: true`. The pre-#229 behaviour was equivalent: per-
+## client `entry_builder` lambdas seeded these as defaults but the
+## per-client `verify_entry` lambdas only checked transport pins, so a
+## user-customised array was `CONFIGURED`, not drift. Splitting the field
+## restores that contract under the data-only descriptor model.
+var entry_initial_fields: Dictionary = {}
+
 ## stdio→HTTP bridge mode for clients that don't speak HTTP natively.
-##   NONE    — entry is `{[entry_url_field]: url, **entry_extra_fields}`
+##   NONE    — entry is `{[entry_url_field]: url, **entry_extra_fields,
+##             ...entry_initial_fields (only for new entries)}`
 ##   FLAT    — Claude Desktop shape: `{"command": <uvx>, "args": [...bridge...]}`
 ##             Verifier ALSO accepts a future url-style entry.
 ##   NESTED  — Zed shape: `{"command": {"path": <uvx>, "args": [...]}, "settings": {}}`

--- a/plugin/addons/godot_ai/clients/_base.gd
+++ b/plugin/addons/godot_ai/clients/_base.gd
@@ -3,8 +3,20 @@ class_name McpClient
 extends RefCounted
 
 ## Descriptor for one MCP client (Cursor, Claude Desktop, Codex, ...).
-## Subclasses set fields in _init(); they should not contain control flow.
-## Strategies (json/toml/cli) consume these fields.
+##
+## Subclasses set fields in `_init()` and contain NO Callables, NO control
+## flow, NO logic. Strategies (json/toml/cli) interpret these fields.
+##
+## This is enforced by `test_clients.gd::test_descriptors_are_data_only` —
+## any Variant property whose runtime value is a `Callable` fails the suite.
+##
+## Why: per-client `.gd` files get hot-reloaded on disk-mtime change. Any
+## descriptor-supplied lambda is GDScript bytecode living in a hot-reloadable
+## script — if a worker thread is mid-call when the file gets swapped (git
+## checkout, in-IDE save, the dock's self-update flow) the IP walks off a
+## cliff and the editor SEGVs (issue #229). It also independently solves the
+## "stale Callable after plugin disable+enable" crash from issue #192:
+## without Callables there's nothing to go stale.
 
 ## CONFIGURED_MISMATCH = an entry with our `SERVER_NAME` exists in the user's
 ## client config, but its URL doesn't match `http_url()` — typical after the
@@ -45,14 +57,24 @@ var path_template: Dictionary = {}
 ## OpenCode:                               ["mcp"]
 var server_key_path: PackedStringArray = PackedStringArray()
 
-## func(server_name: String, server_url: String) -> Dictionary
-## Returns the JSON object stored under server_key_path[server_name].
-var entry_builder: Callable = Callable()
-
-## Optional: custom verifier. func(entry: Dictionary, server_url: String) -> bool
-## Defaults: a JSON entry passes if entry[entry_url_field] == server_url.
+## Field inside the entry dict that holds our server URL.
+## "url" by default; some clients use "serverUrl" or "httpUrl".
 var entry_url_field: String = "url"
-var verify_entry: Callable = Callable()
+
+## Verbatim extra fields merged into the entry alongside `entry_url_field`.
+## Used to pin transport `type` (Cline / Roo / Kilo / VS Code), set
+## `disabled: false` flags, etc. The default verifier asserts every key here
+## still has the declared value in a stored entry — a typeless legacy entry
+## fails verification and surfaces as drift.
+var entry_extra_fields: Dictionary = {}
+
+## stdio→HTTP bridge mode for clients that don't speak HTTP natively.
+##   ""        — no bridge; entry is `{[entry_url_field]: url, **entry_extra_fields}`
+##   "flat"    — Claude Desktop shape: `{"command": <uvx>, "args": [...bridge...]}`
+##               Verifier ALSO accepts a future url-style entry.
+##   "nested"  — Zed shape: `{"command": {"path": <uvx>, "args": [...]}, "settings": {}}`
+##               Verifier requires the bridge form (no url-style fallback).
+var entry_uvx_bridge: String = ""
 
 ## Paths whose existence implies the user has this client installed.
 ## Used purely for the dock's "installed" badge.
@@ -60,22 +82,24 @@ var detect_paths: PackedStringArray = PackedStringArray()
 
 # CLI clients --------------------------------------------------------------
 var cli_names: PackedStringArray = PackedStringArray()
-var cli_register_args: Callable = Callable()
-var cli_unregister_args: Callable = Callable()
-var cli_status_check: Callable = Callable()  ## func(cli_path, name, url) -> Status
+## Argument templates with `{name}` and `{url}` tokens; the strategy
+## substitutes them at call time. Tokens are matched verbatim — no escaping
+## semantics, no shell expansion. Today only `claude_code` populates these.
+var cli_register_template: PackedStringArray = PackedStringArray()
+var cli_unregister_template: PackedStringArray = PackedStringArray()
+## Args run to read current state; stdout is scanned for the server name and
+## URL. Presence of `name` AND `url` → CONFIGURED, name only → MISMATCH,
+## neither → NOT_CONFIGURED.
+var cli_status_args: PackedStringArray = PackedStringArray()
 
 # Codex / TOML clients -----------------------------------------------------
 ## Dotted TOML path under which our entry lives, e.g. ["mcp_servers", "godot-ai"].
 ## Strategies build the [section."name"] header from this.
 var toml_section_path: PackedStringArray = PackedStringArray()
 var toml_legacy_section_aliases: PackedStringArray = PackedStringArray()
-## Lines (without the [header]) emitted under the section.
-## func(server_url) -> PackedStringArray
-var toml_body_builder: Callable = Callable()
-
-# Manual fallback ----------------------------------------------------------
-## func(server_name, server_url, resolved_path) -> String
-var manual_command_builder: Callable = Callable()
+## Lines (without the [header]) emitted under the section, with `{url}`
+## tokens. Substituted at call time.
+var toml_body_template: PackedStringArray = PackedStringArray()
 
 
 ## Resolved absolute config path for this client on the current OS.
@@ -131,15 +155,3 @@ static func resolve_uvx_path() -> String:
 ## Callers splice this into the client-specific command shape.
 static func mcp_proxy_bridge_args(url: String) -> Array:
 	return ["mcp-proxy==" + MCP_PROXY_VERSION, "--transport", "streamablehttp", url]
-
-
-## Uniform error payload for every strategy site that invokes a
-## descriptor-supplied Callable. Toggling the plugin off/on frees the
-## McpClient the lambda captured; calling the stale Callable then crashes
-## Godot, so each site must `is_valid()`-guard first and surface this
-## restart-required hint instead. See issue #192.
-static func stale_callable_status(client: McpClient) -> Dictionary:
-	return {
-		"status": "error",
-		"message": "%s configurator was invalidated by a live plugin reload — restart the editor to recover." % client.display_name,
-	}

--- a/plugin/addons/godot_ai/clients/_cli_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_cli_strategy.gd
@@ -3,7 +3,9 @@ class_name McpCliStrategy
 extends RefCounted
 
 ## Strategy for MCP clients that own their own state via a CLI (e.g.
-## `claude mcp add`). Descriptors supply the arg lists; this just runs them.
+## `claude mcp add`). Reads `cli_register_template` / `cli_unregister_template`
+## / `cli_status_args` from the descriptor and substitutes `{name}` / `{url}`
+## tokens. No descriptor-supplied Callables — see `_base.gd` for why.
 
 
 static func configure(client: McpClient, server_name: String, server_url: String) -> Dictionary:
@@ -12,13 +14,13 @@ static func configure(client: McpClient, server_name: String, server_url: String
 		return {"status": "error", "message": "%s CLI not found" % client.display_name}
 
 	# Best-effort prior cleanup so re-configure is idempotent.
-	if client.cli_unregister_args.is_valid():
-		var pre_args = client.cli_unregister_args.call(server_name)
+	if not client.cli_unregister_template.is_empty():
+		var pre_args := _format_args(client.cli_unregister_template, server_name, server_url)
 		OS.execute(cli, pre_args, [], true)
 
-	if not client.cli_register_args.is_valid():
-		return McpClient.stale_callable_status(client)
-	var args = client.cli_register_args.call(server_name, server_url)
+	if client.cli_register_template.is_empty():
+		return {"status": "error", "message": "%s descriptor missing cli_register_template" % client.display_name}
+	var args := _format_args(client.cli_register_template, server_name, server_url)
 	var output: Array = []
 	var exit_code := OS.execute(cli, args, output, true)
 	if exit_code == 0:
@@ -27,28 +29,60 @@ static func configure(client: McpClient, server_name: String, server_url: String
 	return {"status": "error", "message": "Failed to configure %s: %s" % [client.display_name, err]}
 
 
+## Run the descriptor's `cli_status_args`, scan stdout for `server_name` and
+## `server_url`. The matching rule is the only sensible one for "list MCP
+## entries" output across CLI clients we currently support: name AND url
+## present → CONFIGURED; name only → MISMATCH; neither → NOT_CONFIGURED.
 static func check_status(client: McpClient, server_name: String, server_url: String) -> McpClient.Status:
 	var cli := _resolve_cli(client)
 	if cli.is_empty():
 		return McpClient.Status.NOT_CONFIGURED
-	if not client.cli_status_check.is_valid():
+	if client.cli_status_args.is_empty():
 		return McpClient.Status.NOT_CONFIGURED
-	return client.cli_status_check.call(cli, server_name, server_url)
+	var output: Array = []
+	var exit_code := OS.execute(cli, McpClient._array_from_packed(client.cli_status_args), output, true)
+	if exit_code != 0 or output.is_empty():
+		return McpClient.Status.NOT_CONFIGURED
+	var text: String = output[0]
+	if text.find(server_name) < 0:
+		return McpClient.Status.NOT_CONFIGURED
+	## Server registered, but pointing somewhere else — drift after a
+	## port change. Surface as mismatch so the dock offers Reconfigure.
+	if text.find(server_url) < 0:
+		return McpClient.Status.CONFIGURED_MISMATCH
+	return McpClient.Status.CONFIGURED
 
 
 static func remove(client: McpClient, server_name: String) -> Dictionary:
 	var cli := _resolve_cli(client)
 	if cli.is_empty():
 		return {"status": "error", "message": "%s CLI not found" % client.display_name}
-	if not client.cli_unregister_args.is_valid():
-		return McpClient.stale_callable_status(client)
-	var args = client.cli_unregister_args.call(server_name)
+	if client.cli_unregister_template.is_empty():
+		return {"status": "error", "message": "%s descriptor missing cli_unregister_template" % client.display_name}
+	var args := _format_args(client.cli_unregister_template, server_name, "")
 	var output: Array = []
 	var exit_code := OS.execute(cli, args, output, true)
 	if exit_code == 0:
 		return {"status": "ok", "message": "%s configuration removed" % client.display_name}
 	var err: String = output[0].strip_edges() if output.size() > 0 else "exit code %d" % exit_code
 	return {"status": "error", "message": "Failed to remove %s: %s" % [client.display_name, err]}
+
+
+## Substitute `{name}` and `{url}` tokens in every template entry.
+## Tokens match verbatim — `{name_suffix}` is NOT touched, so callers don't
+## have to worry about partial-token collisions in their argv.
+static func format_args(template: PackedStringArray, server_name: String, server_url: String) -> Array[String]:
+	return _format_args(template, server_name, server_url)
+
+
+static func _format_args(template: PackedStringArray, server_name: String, server_url: String) -> Array[String]:
+	var out: Array[String] = []
+	for arg in template:
+		var s := String(arg)
+		s = s.replace("{name}", server_name)
+		s = s.replace("{url}", server_url)
+		out.append(s)
+	return out
 
 
 static func _resolve_cli(client: McpClient) -> String:

--- a/plugin/addons/godot_ai/clients/_json_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_json_strategy.gd
@@ -17,7 +17,12 @@ static func configure(client: McpClient, server_name: String, server_url: String
 		return {"status": "error", "message": "Refusing to overwrite %s: %s. Fix or move the file, then re-run Configure." % [path, read["error"]]}
 	var config: Dictionary = read["data"]
 	var holder := _ensure_path(config, client.server_key_path)
-	holder[server_name] = build_entry(client, server_url)
+	## Pass the existing entry through so `build_entry` can preserve user-mutable
+	## state (auto-approval lists, `disabled` toggles) instead of resetting it
+	## to descriptor defaults on every Configure click. See `entry_initial_fields`
+	## docs in `_base.gd`.
+	var existing: Variant = holder.get(server_name, null)
+	holder[server_name] = build_entry(client, server_url, existing)
 
 	if not McpAtomicWrite.write(path, JSON.stringify(config, "\t")):
 		return {"status": "error", "message": "Cannot write to %s" % path}
@@ -61,10 +66,14 @@ static func remove(client: McpClient, server_name: String) -> Dictionary:
 
 
 ## Synthesize the entry dict the strategy will write under
-## `server_key_path[server_name]`. For non-bridge clients this is just
-## `{[entry_url_field]: url, **entry_extra_fields}`. For bridge clients
-## (Claude Desktop, Zed) it composes the uvx + mcp-proxy command shape.
-static func build_entry(client: McpClient, server_url: String) -> Dictionary:
+## `server_key_path[server_name]`. For non-bridge clients this is the
+## existing entry (if any) with `entry_url_field` + every
+## `entry_extra_fields` key force-set (the verified type pins) and every
+## `entry_initial_fields` key set ONLY when absent (preserves user state
+## like `alwaysAllow`/`autoApprove` arrays). For bridge clients (Claude
+## Desktop, Zed) it composes the uvx + mcp-proxy command shape unconditionally
+## — the bridge form has no user-mutable surface.
+static func build_entry(client: McpClient, server_url: String, existing: Variant = null) -> Dictionary:
 	match client.entry_uvx_bridge:
 		McpClient.UvxBridge.FLAT:
 			return {
@@ -79,9 +88,13 @@ static func build_entry(client: McpClient, server_url: String) -> Dictionary:
 				},
 				"settings": {},
 			}
-	var entry: Dictionary = {client.entry_url_field: server_url}
+	var entry: Dictionary = (existing as Dictionary).duplicate() if existing is Dictionary else {}
+	entry[client.entry_url_field] = server_url
 	for k in client.entry_extra_fields:
 		entry[k] = client.entry_extra_fields[k]
+	for k in client.entry_initial_fields:
+		if not entry.has(k):
+			entry[k] = client.entry_initial_fields[k]
 	return entry
 
 

--- a/plugin/addons/godot_ai/clients/_json_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_json_strategy.gd
@@ -66,12 +66,12 @@ static func remove(client: McpClient, server_name: String) -> Dictionary:
 ## (Claude Desktop, Zed) it composes the uvx + mcp-proxy command shape.
 static func build_entry(client: McpClient, server_url: String) -> Dictionary:
 	match client.entry_uvx_bridge:
-		"flat":
+		McpClient.UvxBridge.FLAT:
 			return {
 				"command": McpClient.resolve_uvx_path(),
 				"args": McpClient.mcp_proxy_bridge_args(server_url),
 			}
-		"nested":
+		McpClient.UvxBridge.NESTED:
 			return {
 				"command": {
 					"path": McpClient.resolve_uvx_path(),
@@ -95,7 +95,7 @@ static func build_entry(client: McpClient, server_url: String) -> Dictionary:
 ## entries that lack the type field fail verification and surface as drift.
 static func verify_entry(client: McpClient, entry: Dictionary, server_url: String) -> bool:
 	match client.entry_uvx_bridge:
-		"flat":
+		McpClient.UvxBridge.FLAT:
 			# Future url-style entry: accept if Claude Desktop ever speaks HTTP natively.
 			if entry.get(client.entry_url_field, "") == server_url:
 				return true
@@ -105,7 +105,7 @@ static func verify_entry(client: McpClient, entry: Dictionary, server_url: Strin
 			var uvx_like := (cmd as String).get_file() == "uvx" or (cmd as String).get_file() == "uvx.exe"
 			var args = entry.get("args", [])
 			return uvx_like and args is Array and args.has(server_url)
-		"nested":
+		McpClient.UvxBridge.NESTED:
 			var cmd_obj = entry.get("command", {})
 			if not (cmd_obj is Dictionary):
 				return false

--- a/plugin/addons/godot_ai/clients/_json_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_json_strategy.gd
@@ -3,7 +3,8 @@ class_name McpJsonStrategy
 extends RefCounted
 
 ## Read–merge–write strategy for JSON-backed MCP clients.
-## All knobs come from the McpClient descriptor — no per-client branches in here.
+## All knobs come from the McpClient descriptor as plain data — no Callables.
+## See `_base.gd` for why descriptors are data-only.
 
 
 static func configure(client: McpClient, server_name: String, server_url: String) -> Dictionary:
@@ -14,11 +15,9 @@ static func configure(client: McpClient, server_name: String, server_url: String
 	var read := _read_or_init(path)
 	if not read["ok"]:
 		return {"status": "error", "message": "Refusing to overwrite %s: %s. Fix or move the file, then re-run Configure." % [path, read["error"]]}
-	if not client.entry_builder.is_valid():
-		return McpClient.stale_callable_status(client)
 	var config: Dictionary = read["data"]
 	var holder := _ensure_path(config, client.server_key_path)
-	holder[server_name] = client.entry_builder.call(server_name, server_url)
+	holder[server_name] = build_entry(client, server_url)
 
 	if not McpAtomicWrite.write(path, JSON.stringify(config, "\t")):
 		return {"status": "error", "message": "Cannot write to %s" % path}
@@ -42,9 +41,7 @@ static func check_status(client: McpClient, server_name: String, server_url: Str
 	## An entry under `server_name` exists — if the URL doesn't match,
 	## that's drift (the user changed the port and the client config is stale),
 	## not "never configured". The dock surfaces that as an amber banner.
-	if client.verify_entry.is_valid():
-		return McpClient.Status.CONFIGURED if client.verify_entry.call(entry, server_url) else McpClient.Status.CONFIGURED_MISMATCH
-	return McpClient.Status.CONFIGURED if entry.get(client.entry_url_field, "") == server_url else McpClient.Status.CONFIGURED_MISMATCH
+	return McpClient.Status.CONFIGURED if verify_entry(client, entry, server_url) else McpClient.Status.CONFIGURED_MISMATCH
 
 
 static func remove(client: McpClient, server_name: String) -> Dictionary:
@@ -61,6 +58,65 @@ static func remove(client: McpClient, server_name: String) -> Dictionary:
 		if not McpAtomicWrite.write(path, JSON.stringify(config, "\t")):
 			return {"status": "error", "message": "Cannot write to %s" % path}
 	return {"status": "ok", "message": "%s configuration removed" % client.display_name}
+
+
+## Synthesize the entry dict the strategy will write under
+## `server_key_path[server_name]`. For non-bridge clients this is just
+## `{[entry_url_field]: url, **entry_extra_fields}`. For bridge clients
+## (Claude Desktop, Zed) it composes the uvx + mcp-proxy command shape.
+static func build_entry(client: McpClient, server_url: String) -> Dictionary:
+	match client.entry_uvx_bridge:
+		"flat":
+			return {
+				"command": McpClient.resolve_uvx_path(),
+				"args": McpClient.mcp_proxy_bridge_args(server_url),
+			}
+		"nested":
+			return {
+				"command": {
+					"path": McpClient.resolve_uvx_path(),
+					"args": McpClient.mcp_proxy_bridge_args(server_url),
+				},
+				"settings": {},
+			}
+	var entry: Dictionary = {client.entry_url_field: server_url}
+	for k in client.entry_extra_fields:
+		entry[k] = client.entry_extra_fields[k]
+	return entry
+
+
+## Default verifier for a stored entry. For bridge clients, recognise the
+## bridge form (and, for `flat`, the future url-style form too — keeps the
+## tolerance Claude Desktop has had since the npx-bridge migration).
+##
+## For non-bridge clients: assert `entry[entry_url_field] == url` AND every
+## key in `entry_extra_fields` matches verbatim. Type-pinning for Cline /
+## Roo / Kilo (`type: "streamable-http"` etc.) falls out of this — pre-fix
+## entries that lack the type field fail verification and surface as drift.
+static func verify_entry(client: McpClient, entry: Dictionary, server_url: String) -> bool:
+	match client.entry_uvx_bridge:
+		"flat":
+			# Future url-style entry: accept if Claude Desktop ever speaks HTTP natively.
+			if entry.get(client.entry_url_field, "") == server_url:
+				return true
+			var cmd = entry.get("command", "")
+			if not (cmd is String):
+				return false
+			var uvx_like := (cmd as String).get_file() == "uvx" or (cmd as String).get_file() == "uvx.exe"
+			var args = entry.get("args", [])
+			return uvx_like and args is Array and args.has(server_url)
+		"nested":
+			var cmd_obj = entry.get("command", {})
+			if not (cmd_obj is Dictionary):
+				return false
+			var nargs = cmd_obj.get("args", [])
+			return nargs is Array and nargs.has(server_url)
+	if entry.get(client.entry_url_field, "") != server_url:
+		return false
+	for k in client.entry_extra_fields:
+		if entry.get(k) != client.entry_extra_fields[k]:
+			return false
+	return true
 
 
 ## Returns {"ok": true, "data": Dictionary} when the file is absent or parses

--- a/plugin/addons/godot_ai/clients/_manual_command.gd
+++ b/plugin/addons/godot_ai/clients/_manual_command.gd
@@ -1,0 +1,107 @@
+@tool
+class_name McpManualCommand
+extends RefCounted
+
+## Synthesize the "Run this manually" string the dock surfaces when
+## auto-configure can't find a CLI / write a file. Generated from the
+## descriptor's declarative fields — there is no per-client builder
+## Callable. See `_base.gd` for why descriptors are data-only.
+
+
+static func build(client: McpClient, server_name: String, server_url: String, resolved_path: String) -> String:
+	match client.config_type:
+		"cli":
+			return _build_cli(client, server_name, server_url)
+		"json":
+			return _build_json(client, server_name, server_url, resolved_path)
+		"toml":
+			return _build_toml(client, server_name, server_url, resolved_path)
+	return ""
+
+
+## CLI clients: format the register template against the *short* CLI name so
+## the user can paste it into a terminal regardless of where their binary
+## lives. (The auto-configure path resolves to an absolute uvx-style path;
+## that's noise for a paste-into-terminal hint.)
+static func _build_cli(client: McpClient, server_name: String, server_url: String) -> String:
+	if client.cli_register_template.is_empty() or client.cli_names.is_empty():
+		return ""
+	var short_name: String = String(client.cli_names[0])
+	# Prefer the non-.exe form for a cross-platform-looking command line.
+	for n in client.cli_names:
+		if not String(n).ends_with(".exe"):
+			short_name = String(n)
+			break
+	var args := McpCliStrategy.format_args(client.cli_register_template, server_name, server_url)
+	var parts: Array[String] = [short_name]
+	parts.append_array(args)
+	return " ".join(parts)
+
+
+static func _build_json(client: McpClient, server_name: String, server_url: String, resolved_path: String) -> String:
+	var entry := McpJsonStrategy.build_entry(client, server_url)
+	var entry_text := _format_entry_inline(entry)
+	var key := client.server_key_path[0] if client.server_key_path.size() > 0 else "mcpServers"
+	return "Edit %s and add under \"%s\":\n  \"%s\": %s" % [resolved_path, key, server_name, entry_text]
+
+
+static func _build_toml(client: McpClient, _server_name: String, server_url: String, resolved_path: String) -> String:
+	var header := _toml_header(client)
+	var body := McpTomlStrategy.format_body(client.toml_body_template, server_url)
+	var lines: Array[String] = ["Edit %s and add:" % resolved_path, "  %s" % header]
+	for b in body:
+		lines.append("  %s" % String(b))
+	return "\n".join(lines)
+
+
+## Mirrors the [section."name"] header `_toml_strategy._primary_header`
+## emits, kept here so the manual-command text matches the file we'd write.
+static func _toml_header(client: McpClient) -> String:
+	var parts := client.toml_section_path
+	if parts.size() < 2:
+		return "[%s]" % ".".join(parts)
+	var section := ".".join(McpClient._array_from_packed(_packed_slice(parts, 0, parts.size() - 1)))
+	var name := parts[parts.size() - 1]
+	return "[%s.\"%s\"]" % [section, name]
+
+
+## Format an entry dict as a single inline JSON-ish string, matching the
+## pre-refactor manual-command style: `{ "k": v, "k": v }` with spaces.
+## Pre-existing manual-command tests assert the exact substring shape; this
+## keeps them stable.
+static func _format_entry_inline(entry: Dictionary) -> String:
+	var parts: Array[String] = []
+	for k in entry:
+		parts.append("\"%s\": %s" % [String(k), _format_value(entry[k])])
+	if parts.is_empty():
+		return "{}"
+	return "{ %s }" % ", ".join(parts)
+
+
+static func _format_value(value: Variant) -> String:
+	if value is String:
+		return "\"%s\"" % value
+	if value is bool:
+		return "true" if value else "false"
+	if value is Array:
+		var arr_parts: Array[String] = []
+		for v in value:
+			arr_parts.append(_format_value(v))
+		return "[%s]" % ", ".join(arr_parts)
+	if value is Dictionary:
+		var d_parts: Array[String] = []
+		for k in value:
+			d_parts.append("\"%s\": %s" % [String(k), _format_value(value[k])])
+		if d_parts.is_empty():
+			return "{}"
+		return "{ %s }" % ", ".join(d_parts)
+	if value == null:
+		return "null"
+	return str(value)
+
+
+static func _packed_slice(packed: PackedStringArray, from: int, to: int) -> PackedStringArray:
+	var out := PackedStringArray()
+	for i in range(from, to):
+		out.append(packed[i])
+	return out

--- a/plugin/addons/godot_ai/clients/_manual_command.gd
+++ b/plugin/addons/godot_ai/clients/_manual_command.gd
@@ -69,20 +69,26 @@ static func _toml_header(client: McpClient) -> String:
 ## pre-refactor manual-command style: `{ "k": v, "k": v }` with spaces.
 ## Pre-existing manual-command tests assert the exact substring shape; this
 ## keeps them stable.
+##
+## Uses `JSON.stringify` for every leaf String (key OR value) so paths
+## containing backslashes / quotes / newlines render as syntactically valid
+## JSON. A Windows uvx path like `C:\Users\foo\uvx.exe` would otherwise be
+## emitted as `"C:\Users\foo\uvx.exe"` — invalid JSON, unsafe to paste.
 static func _format_entry_inline(entry: Dictionary) -> String:
 	var parts: Array[String] = []
 	for k in entry:
-		parts.append("\"%s\": %s" % [String(k), _format_value(entry[k])])
+		parts.append("%s: %s" % [JSON.stringify(String(k)), _format_value(entry[k])])
 	if parts.is_empty():
 		return "{}"
 	return "{ %s }" % ", ".join(parts)
 
 
 static func _format_value(value: Variant) -> String:
-	if value is String:
-		return "\"%s\"" % value
-	if value is bool:
-		return "true" if value else "false"
+	# Strings, bools, numbers, null all round-trip correctly through JSON.stringify
+	# without spurious quoting of non-string scalars (true → `true`, 5 → `5`).
+	# Arrays and Dictionaries are formatted manually so the inline ` { k: v } `
+	# spacing matches the pre-refactor manual-command output shape that tests
+	# pin with assert_contains.
 	if value is Array:
 		var arr_parts: Array[String] = []
 		for v in value:
@@ -91,10 +97,8 @@ static func _format_value(value: Variant) -> String:
 	if value is Dictionary:
 		var d_parts: Array[String] = []
 		for k in value:
-			d_parts.append("\"%s\": %s" % [String(k), _format_value(value[k])])
+			d_parts.append("%s: %s" % [JSON.stringify(String(k)), _format_value(value[k])])
 		if d_parts.is_empty():
 			return "{}"
 		return "{ %s }" % ", ".join(d_parts)
-	if value == null:
-		return "null"
-	return str(value)
+	return JSON.stringify(value)

--- a/plugin/addons/godot_ai/clients/_manual_command.gd
+++ b/plugin/addons/godot_ai/clients/_manual_command.gd
@@ -60,7 +60,7 @@ static func _toml_header(client: McpClient) -> String:
 	var parts := client.toml_section_path
 	if parts.size() < 2:
 		return "[%s]" % ".".join(parts)
-	var section := ".".join(McpClient._array_from_packed(_packed_slice(parts, 0, parts.size() - 1)))
+	var section := ".".join(McpClient._array_from_packed(McpClient._packed_slice(parts, 0, parts.size() - 1)))
 	var name := parts[parts.size() - 1]
 	return "[%s.\"%s\"]" % [section, name]
 
@@ -98,10 +98,3 @@ static func _format_value(value: Variant) -> String:
 	if value == null:
 		return "null"
 	return str(value)
-
-
-static func _packed_slice(packed: PackedStringArray, from: int, to: int) -> PackedStringArray:
-	var out := PackedStringArray()
-	for i in range(from, to):
-		out.append(packed[i])
-	return out

--- a/plugin/addons/godot_ai/clients/_manual_command.gd.uid
+++ b/plugin/addons/godot_ai/clients/_manual_command.gd.uid
@@ -1,0 +1,1 @@
+uid://ct1wmgfk408x0

--- a/plugin/addons/godot_ai/clients/_toml_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_toml_strategy.gd
@@ -146,7 +146,7 @@ static func _primary_header(client: McpClient) -> String:
 	var parts := client.toml_section_path
 	if parts.size() < 2:
 		return "[%s]" % ".".join(parts)
-	var section := ".".join(_packed_slice(parts, 0, parts.size() - 1))
+	var section := ".".join(McpClient._packed_slice(parts, 0, parts.size() - 1))
 	var name := parts[parts.size() - 1]
 	return "[%s.\"%s\"]" % [section, name]
 
@@ -183,10 +183,3 @@ static func _find_section(lines: Array[String], headers: Array[String]) -> Dicti
 					break
 			return {"start": i, "end": end}
 	return {}
-
-
-static func _packed_slice(packed: PackedStringArray, from: int, to: int) -> PackedStringArray:
-	var out := PackedStringArray()
-	for i in range(from, to):
-		out.append(packed[i])
-	return out

--- a/plugin/addons/godot_ai/clients/_toml_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_toml_strategy.gd
@@ -2,8 +2,9 @@
 class_name McpTomlStrategy
 extends RefCounted
 
-## Minimal TOML upsert: replace or insert one [section."name"] block produced by
-## `client.toml_body_builder`. Generalized from the original Codex-only logic.
+## Minimal TOML upsert: replace or insert one [section."name"] block whose body
+## comes from substituting `{url}` in `client.toml_body_template`. No
+## descriptor-supplied Callables — see `_base.gd`.
 
 
 static func configure(client: McpClient, _server_name: String, server_url: String) -> Dictionary:
@@ -14,10 +15,10 @@ static func configure(client: McpClient, _server_name: String, server_url: Strin
 	var read := _read_or_init(path)
 	if not read["ok"]:
 		return {"status": "error", "message": "Refusing to overwrite %s: %s. Fix or move the file, then re-run Configure." % [path, read["error"]]}
-	if not client.toml_body_builder.is_valid():
-		return McpClient.stale_callable_status(client)
+	if client.toml_body_template.is_empty():
+		return {"status": "error", "message": "%s descriptor missing toml_body_template" % client.display_name}
 	var lines: Array[String] = _split_lines(String(read["data"]))
-	var body: PackedStringArray = client.toml_body_builder.call(server_url)
+	var body: PackedStringArray = format_body(client.toml_body_template, server_url)
 
 	var section := _find_section(lines, _all_headers(client))
 	var header := _primary_header(client)
@@ -98,6 +99,14 @@ static func remove(client: McpClient, _server_name: String) -> Dictionary:
 	if not McpAtomicWrite.write(path, "\n".join(output)):
 		return {"status": "error", "message": "Cannot write to %s" % path}
 	return {"status": "ok", "message": "%s configuration removed" % client.display_name}
+
+
+## Substitute `{url}` in every body-template line.
+static func format_body(template: PackedStringArray, server_url: String) -> PackedStringArray:
+	var out := PackedStringArray()
+	for line in template:
+		out.append(String(line).replace("{url}", server_url))
+	return out
 
 
 # --- helpers --------------------------------------------------------------

--- a/plugin/addons/godot_ai/clients/antigravity.gd
+++ b/plugin/addons/godot_ai/clients/antigravity.gd
@@ -13,8 +13,5 @@ func _init() -> void:
 	}
 	server_key_path = PackedStringArray(["mcpServers"])
 	entry_url_field = "serverUrl"
-	entry_builder = func(_name: String, url: String) -> Dictionary:
-		return {"serverUrl": url, "disabled": false}
+	entry_extra_fields = {"disabled": false}
 	detect_paths = PackedStringArray(path_template.values())
-	manual_command_builder = func(name: String, url: String, path: String) -> String:
-		return "Edit %s and add under \"mcpServers\":\n  \"%s\": { \"serverUrl\": \"%s\", \"disabled\": false }" % [path, name, url]

--- a/plugin/addons/godot_ai/clients/antigravity.gd
+++ b/plugin/addons/godot_ai/clients/antigravity.gd
@@ -13,5 +13,7 @@ func _init() -> void:
 	}
 	server_key_path = PackedStringArray(["mcpServers"])
 	entry_url_field = "serverUrl"
-	entry_extra_fields = {"disabled": false}
+	## `disabled` is user-state (they may have flipped the entry off in the
+	## UI); seeded on first Configure but preserved across reconfigure.
+	entry_initial_fields = {"disabled": false}
 	detect_paths = PackedStringArray(path_template.values())

--- a/plugin/addons/godot_ai/clients/cherry_studio.gd
+++ b/plugin/addons/godot_ai/clients/cherry_studio.gd
@@ -13,8 +13,5 @@ func _init() -> void:
 		"linux": "$XDG_CONFIG_HOME/CherryStudio/mcp_servers.json",
 	}
 	server_key_path = PackedStringArray(["mcpServers"])
-	entry_builder = func(_name: String, url: String) -> Dictionary:
-		return {"type": "streamableHttp", "url": url, "isActive": true}
+	entry_extra_fields = {"type": "streamableHttp", "isActive": true}
 	detect_paths = PackedStringArray(path_template.values())
-	manual_command_builder = func(name: String, url: String, path: String) -> String:
-		return "Edit %s and add under \"mcpServers\":\n  \"%s\": { \"type\": \"streamableHttp\", \"url\": \"%s\", \"isActive\": true }" % [path, name, url]

--- a/plugin/addons/godot_ai/clients/cherry_studio.gd
+++ b/plugin/addons/godot_ai/clients/cherry_studio.gd
@@ -13,5 +13,8 @@ func _init() -> void:
 		"linux": "$XDG_CONFIG_HOME/CherryStudio/mcp_servers.json",
 	}
 	server_key_path = PackedStringArray(["mcpServers"])
-	entry_extra_fields = {"type": "streamableHttp", "isActive": true}
+	entry_extra_fields = {"type": "streamableHttp"}
+	## `isActive` is user-state (they may have toggled the server off in the UI).
+	## Seed on first Configure but preserve across reconfigure.
+	entry_initial_fields = {"isActive": true}
 	detect_paths = PackedStringArray(path_template.values())

--- a/plugin/addons/godot_ai/clients/claude_code.gd
+++ b/plugin/addons/godot_ai/clients/claude_code.gd
@@ -8,22 +8,8 @@ func _init() -> void:
 	config_type = "cli"
 	doc_url = "https://docs.anthropic.com/en/docs/claude-code"
 	cli_names = PackedStringArray(["claude", "claude.exe"] if OS.get_name() == "Windows" else ["claude"])
-	cli_register_args = func(name: String, url: String) -> Array[String]:
-		return ["mcp", "add", "--scope", "user", "--transport", "http", name, url]
-	cli_unregister_args = func(name: String) -> Array[String]:
-		return ["mcp", "remove", name]
-	cli_status_check = func(cli: String, name: String, url: String) -> McpClient.Status:
-		var output: Array = []
-		var exit_code := OS.execute(cli, ["mcp", "list"], output, true)
-		if exit_code != 0 or output.is_empty():
-			return McpClient.Status.NOT_CONFIGURED
-		var text: String = output[0]
-		if text.find(name) < 0:
-			return McpClient.Status.NOT_CONFIGURED
-		## Server registered, but pointing somewhere else — drift after a
-		## port change. Surface as mismatch so the dock offers Reconfigure.
-		if text.find(url) < 0:
-			return McpClient.Status.CONFIGURED_MISMATCH
-		return McpClient.Status.CONFIGURED
-	manual_command_builder = func(name: String, url: String, _path: String) -> String:
-		return "claude mcp add --scope user --transport http %s %s" % [name, url]
+	cli_register_template = PackedStringArray(
+		["mcp", "add", "--scope", "user", "--transport", "http", "{name}", "{url}"]
+	)
+	cli_unregister_template = PackedStringArray(["mcp", "remove", "{name}"])
+	cli_status_args = PackedStringArray(["mcp", "list"])

--- a/plugin/addons/godot_ai/clients/claude_desktop.gd
+++ b/plugin/addons/godot_ai/clients/claude_desktop.gd
@@ -17,18 +17,8 @@ func _init() -> void:
 		"linux": "$XDG_CONFIG_HOME/Claude/claude_desktop_config.json",
 	}
 	server_key_path = PackedStringArray(["mcpServers"])
-	entry_builder = func(_name: String, url: String) -> Dictionary:
-		return {"command": McpClient.resolve_uvx_path(), "args": McpClient.mcp_proxy_bridge_args(url)}
-	verify_entry = func(entry: Dictionary, url: String) -> bool:
-		# Accept both the bridge form we write and a future url-style entry.
-		if entry.get("url", "") == url:
-			return true
-		var cmd: String = entry.get("command", "")
-		var uvx_like := cmd.get_file() == "uvx" or cmd.get_file() == "uvx.exe"
-		var args = entry.get("args", [])
-		return uvx_like and args is Array and args.has(url)
+	## "flat" bridge: `{"command": "<uvx>", "args": [...]}`. The default
+	## verifier ALSO accepts a future url-style entry (Claude Desktop has
+	## been tolerant of both forms since the npx→uvx bridge migration).
+	entry_uvx_bridge = "flat"
 	detect_paths = PackedStringArray(path_template.values())
-	manual_command_builder = func(name: String, url: String, path: String) -> String:
-		var uvx := McpClient.resolve_uvx_path()
-		var proxy_arg := "mcp-proxy==" + McpClient.MCP_PROXY_VERSION
-		return "Edit %s and add under \"mcpServers\":\n  \"%s\": { \"command\": \"%s\", \"args\": [\"%s\", \"--transport\", \"streamablehttp\", \"%s\"] }" % [path, name, uvx, proxy_arg, url]

--- a/plugin/addons/godot_ai/clients/claude_desktop.gd
+++ b/plugin/addons/godot_ai/clients/claude_desktop.gd
@@ -17,8 +17,8 @@ func _init() -> void:
 		"linux": "$XDG_CONFIG_HOME/Claude/claude_desktop_config.json",
 	}
 	server_key_path = PackedStringArray(["mcpServers"])
-	## "flat" bridge: `{"command": "<uvx>", "args": [...]}`. The default
+	## FLAT bridge: `{"command": "<uvx>", "args": [...]}`. The default
 	## verifier ALSO accepts a future url-style entry (Claude Desktop has
 	## been tolerant of both forms since the npx→uvx bridge migration).
-	entry_uvx_bridge = "flat"
+	entry_uvx_bridge = McpClient.UvxBridge.FLAT
 	detect_paths = PackedStringArray(path_template.values())

--- a/plugin/addons/godot_ai/clients/cline.gd
+++ b/plugin/addons/godot_ai/clients/cline.gd
@@ -21,5 +21,9 @@ func _init() -> void:
 	## the type explicitly. Cline's schema uses "streamableHttp" (camelCase,
 	## see src/services/mcp/schemas.ts in the cline repo) — distinct from
 	## Roo's "streamable-http" string. Parallel to the Roo fix in #190.
-	entry_extra_fields = {"type": "streamableHttp", "disabled": false, "autoApprove": []}
+	entry_extra_fields = {"type": "streamableHttp"}
+	## `disabled` and `autoApprove` are user-state (they may have flipped the
+	## entry off, or auto-approved specific tools). Seed on first Configure
+	## but preserve across reconfigure — see `entry_initial_fields` in `_base.gd`.
+	entry_initial_fields = {"disabled": false, "autoApprove": []}
 	detect_paths = PackedStringArray(path_template.values())

--- a/plugin/addons/godot_ai/clients/cline.gd
+++ b/plugin/addons/godot_ai/clients/cline.gd
@@ -21,13 +21,5 @@ func _init() -> void:
 	## the type explicitly. Cline's schema uses "streamableHttp" (camelCase,
 	## see src/services/mcp/schemas.ts in the cline repo) — distinct from
 	## Roo's "streamable-http" string. Parallel to the Roo fix in #190.
-	entry_builder = func(_name: String, url: String) -> Dictionary:
-		return {"type": "streamableHttp", "url": url, "disabled": false, "autoApprove": []}
-	## Flag pre-fix entries (correct URL, missing or wrong "type") as drift so
-	## upgrading users get nudged to re-configure rather than silently keeping
-	## the broken SSE-default entry.
-	verify_entry = func(entry: Dictionary, url: String) -> bool:
-		return entry.get("url", "") == url and entry.get("type", "") == "streamableHttp"
+	entry_extra_fields = {"type": "streamableHttp", "disabled": false, "autoApprove": []}
 	detect_paths = PackedStringArray(path_template.values())
-	manual_command_builder = func(name: String, url: String, path: String) -> String:
-		return "Edit %s and add under \"mcpServers\":\n  \"%s\": { \"type\": \"streamableHttp\", \"url\": \"%s\", \"disabled\": false, \"autoApprove\": [] }" % [path, name, url]

--- a/plugin/addons/godot_ai/clients/codex.gd
+++ b/plugin/addons/godot_ai/clients/codex.gd
@@ -11,11 +11,8 @@ func _init() -> void:
 	toml_section_path = PackedStringArray(["mcp_servers", "godot-ai"])
 	# Older Codex builds used the unquoted form with underscore-substituted ids.
 	toml_legacy_section_aliases = PackedStringArray(["mcp_servers.godot_ai"])
-	toml_body_builder = func(url: String) -> PackedStringArray:
-		return PackedStringArray([
-			"url = \"%s\"" % url,
-			"enabled = true",
-		])
+	toml_body_template = PackedStringArray([
+		"url = \"{url}\"",
+		"enabled = true",
+	])
 	detect_paths = PackedStringArray(path_template.values())
-	manual_command_builder = func(name: String, url: String, path: String) -> String:
-		return "Edit %s and add:\n  [mcp_servers.\"%s\"]\n  url = \"%s\"\n  enabled = true" % [path, name, url]

--- a/plugin/addons/godot_ai/clients/cursor.gd
+++ b/plugin/addons/godot_ai/clients/cursor.gd
@@ -9,8 +9,4 @@ func _init() -> void:
 	doc_url = "https://docs.cursor.com/context/model-context-protocol"
 	path_template = {"unix": "~/.cursor/mcp.json", "windows": "$USERPROFILE/.cursor/mcp.json"}
 	server_key_path = PackedStringArray(["mcpServers"])
-	entry_builder = func(_name: String, url: String) -> Dictionary:
-		return {"url": url}
 	detect_paths = PackedStringArray(path_template.values())
-	manual_command_builder = func(name: String, url: String, path: String) -> String:
-		return "Edit %s and add under \"mcpServers\":\n  \"%s\": { \"url\": \"%s\" }" % [path, name, url]

--- a/plugin/addons/godot_ai/clients/gemini_cli.gd
+++ b/plugin/addons/godot_ai/clients/gemini_cli.gd
@@ -13,8 +13,4 @@ func _init() -> void:
 	}
 	server_key_path = PackedStringArray(["mcpServers"])
 	entry_url_field = "httpUrl"
-	entry_builder = func(_name: String, url: String) -> Dictionary:
-		return {"httpUrl": url}
 	detect_paths = PackedStringArray(path_template.values())
-	manual_command_builder = func(name: String, url: String, path: String) -> String:
-		return "Edit %s and add under \"mcpServers\":\n  \"%s\": { \"httpUrl\": \"%s\" }" % [path, name, url]

--- a/plugin/addons/godot_ai/clients/kilo_code.gd
+++ b/plugin/addons/godot_ai/clients/kilo_code.gd
@@ -16,13 +16,5 @@ func _init() -> void:
 	## Kilo Code (like Roo) defaults a typeless entry to SSE transport, which
 	## returns HTTP 400 against our streamable-http endpoint on `/mcp`. Pin
 	## the type explicitly. Parallel to the Roo fix in #190.
-	entry_builder = func(_name: String, url: String) -> Dictionary:
-		return {"type": "streamable-http", "url": url, "disabled": false, "alwaysAllow": []}
-	## Flag pre-fix entries (correct URL, missing or wrong "type") as drift so
-	## upgrading users get nudged to re-configure rather than silently keeping
-	## the broken SSE-default entry.
-	verify_entry = func(entry: Dictionary, url: String) -> bool:
-		return entry.get("url", "") == url and entry.get("type", "") == "streamable-http"
+	entry_extra_fields = {"type": "streamable-http", "disabled": false, "alwaysAllow": []}
 	detect_paths = PackedStringArray(path_template.values())
-	manual_command_builder = func(name: String, url: String, path: String) -> String:
-		return "Edit %s and add under \"mcpServers\":\n  \"%s\": { \"type\": \"streamable-http\", \"url\": \"%s\", \"disabled\": false, \"alwaysAllow\": [] }" % [path, name, url]

--- a/plugin/addons/godot_ai/clients/kilo_code.gd
+++ b/plugin/addons/godot_ai/clients/kilo_code.gd
@@ -16,5 +16,9 @@ func _init() -> void:
 	## Kilo Code (like Roo) defaults a typeless entry to SSE transport, which
 	## returns HTTP 400 against our streamable-http endpoint on `/mcp`. Pin
 	## the type explicitly. Parallel to the Roo fix in #190.
-	entry_extra_fields = {"type": "streamable-http", "disabled": false, "alwaysAllow": []}
+	entry_extra_fields = {"type": "streamable-http"}
+	## `disabled` and `alwaysAllow` are user-state (they may have flipped the
+	## entry off, or auto-approved specific tools). Seed on first Configure
+	## but preserve across reconfigure — see `entry_initial_fields` in `_base.gd`.
+	entry_initial_fields = {"disabled": false, "alwaysAllow": []}
 	detect_paths = PackedStringArray(path_template.values())

--- a/plugin/addons/godot_ai/clients/kiro.gd
+++ b/plugin/addons/godot_ai/clients/kiro.gd
@@ -12,8 +12,5 @@ func _init() -> void:
 		"windows": "$USERPROFILE/.kiro/settings/mcp.json",
 	}
 	server_key_path = PackedStringArray(["mcpServers"])
-	entry_builder = func(_name: String, url: String) -> Dictionary:
-		return {"url": url, "disabled": false}
+	entry_extra_fields = {"disabled": false}
 	detect_paths = PackedStringArray(path_template.values())
-	manual_command_builder = func(name: String, url: String, path: String) -> String:
-		return "Edit %s and add under \"mcpServers\":\n  \"%s\": { \"url\": \"%s\", \"disabled\": false }" % [path, name, url]

--- a/plugin/addons/godot_ai/clients/kiro.gd
+++ b/plugin/addons/godot_ai/clients/kiro.gd
@@ -12,5 +12,6 @@ func _init() -> void:
 		"windows": "$USERPROFILE/.kiro/settings/mcp.json",
 	}
 	server_key_path = PackedStringArray(["mcpServers"])
-	entry_extra_fields = {"disabled": false}
+	## `disabled` is user-state — preserved across reconfigure.
+	entry_initial_fields = {"disabled": false}
 	detect_paths = PackedStringArray(path_template.values())

--- a/plugin/addons/godot_ai/clients/opencode.gd
+++ b/plugin/addons/godot_ai/clients/opencode.gd
@@ -15,8 +15,5 @@ func _init() -> void:
 		"windows": "$HOME/.config/opencode/opencode.json",
 	}
 	server_key_path = PackedStringArray(["mcp"])
-	entry_builder = func(_name: String, url: String) -> Dictionary:
-		return {"type": "remote", "url": url, "enabled": true}
+	entry_extra_fields = {"type": "remote", "enabled": true}
 	detect_paths = PackedStringArray(path_template.values())
-	manual_command_builder = func(name: String, url: String, path: String) -> String:
-		return "Edit %s and add under \"mcp\":\n  \"%s\": { \"type\": \"remote\", \"url\": \"%s\", \"enabled\": true }" % [path, name, url]

--- a/plugin/addons/godot_ai/clients/opencode.gd
+++ b/plugin/addons/godot_ai/clients/opencode.gd
@@ -15,5 +15,7 @@ func _init() -> void:
 		"windows": "$HOME/.config/opencode/opencode.json",
 	}
 	server_key_path = PackedStringArray(["mcp"])
-	entry_extra_fields = {"type": "remote", "enabled": true}
+	entry_extra_fields = {"type": "remote"}
+	## `enabled` is user-state (they may have toggled the server off).
+	entry_initial_fields = {"enabled": true}
 	detect_paths = PackedStringArray(path_template.values())

--- a/plugin/addons/godot_ai/clients/qwen_code.gd
+++ b/plugin/addons/godot_ai/clients/qwen_code.gd
@@ -13,8 +13,4 @@ func _init() -> void:
 	}
 	server_key_path = PackedStringArray(["mcpServers"])
 	entry_url_field = "httpUrl"
-	entry_builder = func(_name: String, url: String) -> Dictionary:
-		return {"httpUrl": url}
 	detect_paths = PackedStringArray(path_template.values())
-	manual_command_builder = func(name: String, url: String, path: String) -> String:
-		return "Edit %s and add under \"mcpServers\":\n  \"%s\": { \"httpUrl\": \"%s\" }" % [path, name, url]

--- a/plugin/addons/godot_ai/clients/roo_code.gd
+++ b/plugin/addons/godot_ai/clients/roo_code.gd
@@ -19,5 +19,11 @@ func _init() -> void:
 	## recommended remote transport). See issue #189. The default verifier
 	## requires every entry_extra_fields key to match, so a pre-#189 typeless
 	## entry surfaces as drift instead of silently passing as configured.
-	entry_extra_fields = {"type": "streamable-http", "disabled": false, "alwaysAllow": []}
+	entry_extra_fields = {"type": "streamable-http"}
+	## `disabled` and `alwaysAllow` are user-state (they may have flipped the
+	## entry off, or auto-approved specific tools like `session_manage`).
+	## Seed on first Configure but preserve across reconfigure — without this
+	## split, the Configure-All-Mismatched sweep silently wipes the user's
+	## auto-approval list every time the type pin or URL drifts.
+	entry_initial_fields = {"disabled": false, "alwaysAllow": []}
 	detect_paths = PackedStringArray(path_template.values())

--- a/plugin/addons/godot_ai/clients/roo_code.gd
+++ b/plugin/addons/godot_ai/clients/roo_code.gd
@@ -16,15 +16,8 @@ func _init() -> void:
 	## Roo defaults an entry with no "type" to SSE transport — which returns
 	## HTTP 400 against our streamable-http endpoint on `/mcp`. Pin the type
 	## explicitly so Roo negotiates streamable-http (the current MCP spec's
-	## recommended remote transport). See issue #189.
-	entry_builder = func(_name: String, url: String) -> Dictionary:
-		return {"type": "streamable-http", "url": url, "disabled": false, "alwaysAllow": []}
-	## Flag pre-#189 entries (correct URL, missing or wrong "type") as drift so
-	## the dock nudges the user to re-configure after upgrading. Without this,
-	## the URL-only default verifier says CONFIGURED and the broken SSE
-	## negotiation is invisible until Roo fails at connect time.
-	verify_entry = func(entry: Dictionary, url: String) -> bool:
-		return entry.get("url", "") == url and entry.get("type", "") == "streamable-http"
+	## recommended remote transport). See issue #189. The default verifier
+	## requires every entry_extra_fields key to match, so a pre-#189 typeless
+	## entry surfaces as drift instead of silently passing as configured.
+	entry_extra_fields = {"type": "streamable-http", "disabled": false, "alwaysAllow": []}
 	detect_paths = PackedStringArray(path_template.values())
-	manual_command_builder = func(name: String, url: String, path: String) -> String:
-		return "Edit %s and add under \"mcpServers\":\n  \"%s\": { \"type\": \"streamable-http\", \"url\": \"%s\", \"disabled\": false, \"alwaysAllow\": [] }" % [path, name, url]

--- a/plugin/addons/godot_ai/clients/trae.gd
+++ b/plugin/addons/godot_ai/clients/trae.gd
@@ -13,8 +13,4 @@ func _init() -> void:
 		"linux": "$XDG_CONFIG_HOME/Trae/User/mcp.json",
 	}
 	server_key_path = PackedStringArray(["mcpServers"])
-	entry_builder = func(_name: String, url: String) -> Dictionary:
-		return {"url": url}
 	detect_paths = PackedStringArray(path_template.values())
-	manual_command_builder = func(name: String, url: String, path: String) -> String:
-		return "Edit %s and add under \"mcpServers\":\n  \"%s\": { \"url\": \"%s\" }" % [path, name, url]

--- a/plugin/addons/godot_ai/clients/vscode.gd
+++ b/plugin/addons/godot_ai/clients/vscode.gd
@@ -16,8 +16,5 @@ func _init() -> void:
 		"linux": "$XDG_CONFIG_HOME/Code/User/mcp.json",
 	}
 	server_key_path = PackedStringArray(["servers"])
-	entry_builder = func(_name: String, url: String) -> Dictionary:
-		return {"type": "http", "url": url}
+	entry_extra_fields = {"type": "http"}
 	detect_paths = PackedStringArray(path_template.values())
-	manual_command_builder = func(name: String, url: String, path: String) -> String:
-		return "Edit %s and add under \"servers\":\n  \"%s\": { \"type\": \"http\", \"url\": \"%s\" }" % [path, name, url]

--- a/plugin/addons/godot_ai/clients/vscode_insiders.gd
+++ b/plugin/addons/godot_ai/clients/vscode_insiders.gd
@@ -13,8 +13,5 @@ func _init() -> void:
 		"linux": "$XDG_CONFIG_HOME/Code - Insiders/User/mcp.json",
 	}
 	server_key_path = PackedStringArray(["servers"])
-	entry_builder = func(_name: String, url: String) -> Dictionary:
-		return {"type": "http", "url": url}
+	entry_extra_fields = {"type": "http"}
 	detect_paths = PackedStringArray(path_template.values())
-	manual_command_builder = func(name: String, url: String, path: String) -> String:
-		return "Edit %s and add under \"servers\":\n  \"%s\": { \"type\": \"http\", \"url\": \"%s\" }" % [path, name, url]

--- a/plugin/addons/godot_ai/clients/windsurf.gd
+++ b/plugin/addons/godot_ai/clients/windsurf.gd
@@ -13,8 +13,4 @@ func _init() -> void:
 	}
 	server_key_path = PackedStringArray(["mcpServers"])
 	entry_url_field = "serverUrl"
-	entry_builder = func(_name: String, url: String) -> Dictionary:
-		return {"serverUrl": url}
 	detect_paths = PackedStringArray(path_template.values())
-	manual_command_builder = func(name: String, url: String, path: String) -> String:
-		return "Edit %s and add under \"mcpServers\":\n  \"%s\": { \"serverUrl\": \"%s\" }" % [path, name, url]

--- a/plugin/addons/godot_ai/clients/zed.gd
+++ b/plugin/addons/godot_ai/clients/zed.gd
@@ -17,19 +17,8 @@ func _init() -> void:
 		"windows": "$APPDATA/Zed/settings.json",
 	}
 	server_key_path = PackedStringArray(["context_servers"])
-	entry_builder = func(_name: String, url: String) -> Dictionary:
-		return {
-			"command": {"path": McpClient.resolve_uvx_path(), "args": McpClient.mcp_proxy_bridge_args(url)},
-			"settings": {},
-		}
-	verify_entry = func(entry: Dictionary, url: String) -> bool:
-		var cmd = entry.get("command", {})
-		if not (cmd is Dictionary):
-			return false
-		var args = cmd.get("args", [])
-		return args is Array and args.has(url)
+	## "nested" bridge: `{"command": {"path": <uvx>, "args": [...]}, "settings": {}}`.
+	## Verifier requires the bridge form (no url-style fallback) — Zed has
+	## never spoken HTTP natively.
+	entry_uvx_bridge = "nested"
 	detect_paths = PackedStringArray(path_template.values())
-	manual_command_builder = func(name: String, url: String, path: String) -> String:
-		var uvx := McpClient.resolve_uvx_path()
-		var proxy_arg := "mcp-proxy==" + McpClient.MCP_PROXY_VERSION
-		return "Edit %s and add under \"context_servers\":\n  \"%s\": { \"command\": { \"path\": \"%s\", \"args\": [\"%s\", \"--transport\", \"streamablehttp\", \"%s\"] }, \"settings\": {} }" % [path, name, uvx, proxy_arg, url]

--- a/plugin/addons/godot_ai/clients/zed.gd
+++ b/plugin/addons/godot_ai/clients/zed.gd
@@ -17,8 +17,8 @@ func _init() -> void:
 		"windows": "$APPDATA/Zed/settings.json",
 	}
 	server_key_path = PackedStringArray(["context_servers"])
-	## "nested" bridge: `{"command": {"path": <uvx>, "args": [...]}, "settings": {}}`.
+	## NESTED bridge: `{"command": {"path": <uvx>, "args": [...]}, "settings": {}}`.
 	## Verifier requires the bridge form (no url-style fallback) — Zed has
 	## never spoken HTTP natively.
-	entry_uvx_bridge = "nested"
+	entry_uvx_bridge = McpClient.UvxBridge.NESTED
 	detect_paths = PackedStringArray(path_template.values())

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -1267,6 +1267,81 @@ func test_kilo_code_verify_flags_pre_fix_typeless_entry_as_drift() -> void:
 	assert_false(McpJsonStrategy.verify_entry(c, url_drift, "http://x"), "URL drift must still register as drift")
 
 
+# ----- entry_initial_fields: user-state preservation across reconfigure -----
+
+func test_verify_entry_ignores_initial_field_drift() -> void:
+	## Default verifier must NOT compare `entry_initial_fields` keys: those are
+	## user-state (auto-approval lists, `disabled` toggles) that the user is
+	## expected to mutate after the initial Configure. A user with a customised
+	## `alwaysAllow` array must not be flagged as drift — otherwise the dock's
+	## Configure-All-Mismatched sweep silently overwrites their state.
+	var c := McpClientRegistry.get_by_id("roo_code")
+	var customised := {
+		"type": "streamable-http",
+		"url": "http://x",
+		"disabled": false,
+		"alwaysAllow": ["session_manage", "node_create"],  # ← user-added
+	}
+	assert_true(McpJsonStrategy.verify_entry(c, customised, "http://x"),
+		"User-customised alwaysAllow must verify as CONFIGURED, not drift")
+	var disabled_by_user := {
+		"type": "streamable-http",
+		"url": "http://x",
+		"disabled": true,  # ← user disabled the entry
+		"alwaysAllow": [],
+	}
+	assert_true(McpJsonStrategy.verify_entry(c, disabled_by_user, "http://x"),
+		"User-disabled entry must verify as CONFIGURED — they explicitly turned it off")
+
+
+func test_build_entry_preserves_existing_initial_fields() -> void:
+	## Reconfigure must not overwrite user-mutable state with descriptor
+	## defaults. The strategy passes the existing entry to `build_entry`; this
+	## test locks in that contract by simulating a reconfigure on an entry the
+	## user has customised.
+	var c := McpClientRegistry.get_by_id("roo_code")
+	var existing := {
+		"type": "streamable-http",
+		"url": "http://old:8000/mcp",
+		"disabled": true,
+		"alwaysAllow": ["session_manage", "node_create"],
+	}
+	var rebuilt := McpJsonStrategy.build_entry(c, "http://new:8001/mcp", existing)
+	assert_eq(rebuilt.get("url"), "http://new:8001/mcp", "URL must be force-updated to current server_url")
+	assert_eq(rebuilt.get("type"), "streamable-http", "type pin must be force-set from entry_extra_fields")
+	assert_eq(rebuilt.get("disabled"), true,
+		"existing `disabled: true` must survive — user explicitly turned the entry off")
+	assert_eq(rebuilt.get("alwaysAllow"), ["session_manage", "node_create"],
+		"existing alwaysAllow array must survive — wiping it would silently revoke user auto-approvals")
+
+
+func test_build_entry_seeds_initial_fields_when_absent() -> void:
+	## First-time Configure (no existing entry) must populate initial defaults
+	## so the dock surfaces a fully-formed entry — same shape as pre-split.
+	var c := McpClientRegistry.get_by_id("roo_code")
+	var fresh := McpJsonStrategy.build_entry(c, "http://x")  # existing = null
+	assert_eq(fresh.get("type"), "streamable-http", "type pin must be set on fresh entries")
+	assert_eq(fresh.get("disabled"), false, "initial `disabled: false` must seed on fresh entries")
+	assert_eq(fresh.get("alwaysAllow"), [], "initial `alwaysAllow: []` must seed on fresh entries")
+
+
+func test_build_entry_force_overwrites_drifted_required_fields() -> void:
+	## A user (or upstream) entry with a wrong `type` value gets corrected on
+	## reconfigure — the type pin is in `entry_extra_fields` precisely because
+	## a wrong value breaks transport negotiation. User-state preservation
+	## must not extend to broken transport pins.
+	var c := McpClientRegistry.get_by_id("roo_code")
+	var legacy_sse := {
+		"type": "sse",  # ← wrong, broken transport
+		"url": "http://old/mcp",
+		"disabled": false,
+		"alwaysAllow": ["session_manage"],
+	}
+	var rebuilt := McpJsonStrategy.build_entry(c, "http://new/mcp", legacy_sse)
+	assert_eq(rebuilt.get("type"), "streamable-http", "type pin must overwrite legacy SSE")
+	assert_eq(rebuilt.get("alwaysAllow"), ["session_manage"], "user state still preserved across the type fix")
+
+
 func test_opencode_client_uses_home_config_on_windows() -> void:
 	## Regression: OpenCode reads its MCP config from
 	## ~/.config/opencode/opencode.json on ALL platforms (verified via

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -131,6 +131,43 @@ func test_every_client_has_manual_command() -> void:
 		assert_true(not cmd.is_empty(), "%s missing manual command" % client_id)
 
 
+func test_manual_command_escapes_backslashes_in_paths() -> void:
+	## Regression: `_format_value` used to interpolate strings with bare `"..."`
+	## quoting, so a Windows uvx path like `C:\Users\foo\uvx.exe` rendered as
+	## `"C:\Users\foo\uvx.exe"` — invalid JSON, unsafe to paste into a config
+	## file. The fix routes leaf strings through `JSON.stringify`, which
+	## escapes backslashes / quotes / newlines per the JSON spec.
+	##
+	## Build a synthetic flat-bridge client with a path containing every
+	## hazardous char so the inline JSON the manual command emits parses
+	## back without errors.
+	var client := McpClient.new()
+	client.id = "manual_escape_test"
+	client.display_name = "Escape Test"
+	client.config_type = "json"
+	client.path_template = {"darwin": "/tmp/m.json", "windows": "/tmp/m.json", "linux": "/tmp/m.json", "unix": "/tmp/m.json"}
+	client.server_key_path = PackedStringArray(["mcpServers"])
+	client.entry_extra_fields = {
+		"command": "C:\\Users\\foo bar\\uvx.exe",
+		"hint": "say \"hello\"\nworld",
+	}
+
+	var manual := McpManualCommand.build(client, "godot-ai", "http://x", "/tmp/m.json")
+	# Extract the JSON object body — everything from the first `{` after the
+	# entry key onwards to the matching trailing `}`.
+	var first_brace := manual.find("{")
+	assert_gt(first_brace, 0, "manual command should contain a JSON-ish entry")
+	var entry_text := manual.substr(first_brace)
+	var parsed = JSON.parse_string(entry_text)
+	assert_true(
+		parsed is Dictionary,
+		"manual-command entry must be valid JSON; got: %s" % entry_text,
+	)
+	assert_eq(parsed.get("command"), "C:\\Users\\foo bar\\uvx.exe")
+	assert_eq(parsed.get("hint"), "say \"hello\"\nworld")
+	assert_eq(parsed.get("url"), "http://x")
+
+
 # ----- server launch mode -----
 
 

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -97,10 +97,32 @@ func test_descriptors_are_data_only() -> void:
 				continue
 			var prop_name: String = prop.name
 			var value = client.get(prop_name)
-			assert_false(
-				value is Callable,
-				"%s.%s is a Callable — descriptors must be data-only (issue #229)" % [client.id, prop_name],
+			var crumb: String = _find_callable(value, "%s.%s" % [client.id, prop_name])
+			assert_true(
+				crumb.is_empty(),
+				"%s — descriptors must be data-only (issue #229)" % crumb,
 			)
+
+
+## Recursively walk a Variant looking for a Callable — top-level OR nested
+## inside a Dictionary / Array. Returns the breadcrumb path of the offending
+## field (e.g. "claude_desktop.entry_extra_fields[\"hook\"]") on hit, or "" on
+## clean. Catches `entry_extra_fields = {"hook": Callable()}`-style sneaks
+## that a top-level type check would miss.
+func _find_callable(value: Variant, breadcrumb: String) -> String:
+	if value is Callable:
+		return breadcrumb
+	if value is Dictionary:
+		for k in value:
+			var hit := _find_callable(value[k], "%s[%s]" % [breadcrumb, JSON.stringify(k)])
+			if not hit.is_empty():
+				return hit
+	elif value is Array:
+		for i in value.size():
+			var hit := _find_callable(value[i], "%s[%d]" % [breadcrumb, i])
+			if not hit.is_empty():
+				return hit
+	return ""
 
 
 func test_every_client_has_manual_command() -> void:
@@ -773,7 +795,7 @@ func test_json_strategy_drift_with_bridge_entry() -> void:
 	client.config_type = "json"
 	client.path_template = {"darwin": path, "windows": path, "linux": path, "unix": path}
 	client.server_key_path = PackedStringArray(["mcpServers"])
-	client.entry_uvx_bridge = "flat"
+	client.entry_uvx_bridge = McpClient.UvxBridge.FLAT
 
 	McpJsonStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
 	assert_eq(
@@ -1050,7 +1072,7 @@ func test_gemini_cli_entry_uses_httpUrl() -> void:
 
 func test_claude_desktop_bridges_via_uvx() -> void:
 	var c := McpClientRegistry.get_by_id("claude_desktop")
-	assert_eq(c.entry_uvx_bridge, "flat", "claude_desktop must declare flat uvx bridge")
+	assert_eq(c.entry_uvx_bridge, McpClient.UvxBridge.FLAT, "claude_desktop must declare FLAT uvx bridge")
 	var entry := McpJsonStrategy.build_entry(c, "http://x")
 	_assert_uvx_command(entry.get("command", ""))
 	_assert_mcp_proxy_bridge_args(entry.get("args", []), "http://x")
@@ -1077,7 +1099,7 @@ func test_claude_desktop_verify_entry_accepts_future_url_form() -> void:
 
 func test_zed_bridges_via_uvx() -> void:
 	var c := McpClientRegistry.get_by_id("zed")
-	assert_eq(c.entry_uvx_bridge, "nested", "zed must declare nested uvx bridge")
+	assert_eq(c.entry_uvx_bridge, McpClient.UvxBridge.NESTED, "zed must declare NESTED uvx bridge")
 	var entry := McpJsonStrategy.build_entry(c, "http://x")
 	var cmd = entry.get("command", {})
 	assert_true(cmd is Dictionary, "Zed entry.command must be a Dictionary (path+args shape)")

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -65,11 +65,42 @@ func test_every_client_has_required_fields() -> void:
 		assert_true(not client.display_name.is_empty(), "%s missing display_name" % client.id)
 		assert_contains(["json", "toml", "cli"], client.config_type, "%s has unexpected config_type %s" % [client.id, client.config_type])
 		if client.config_type == "json":
-			assert_true(client.entry_builder.is_valid(), "%s json client missing entry_builder" % client.id)
 			assert_gt(client.server_key_path.size(), 0, "%s missing server_key_path" % client.id)
 		elif client.config_type == "cli":
 			assert_gt(client.cli_names.size(), 0, "%s cli client missing cli_names" % client.id)
-			assert_true(client.cli_register_args.is_valid(), "%s cli client missing cli_register_args" % client.id)
+			assert_gt(client.cli_register_template.size(), 0, "%s cli client missing cli_register_template" % client.id)
+		elif client.config_type == "toml":
+			assert_gt(client.toml_section_path.size(), 0, "%s toml client missing toml_section_path" % client.id)
+			assert_gt(client.toml_body_template.size(), 0, "%s toml client missing toml_body_template" % client.id)
+
+
+func test_descriptors_are_data_only() -> void:
+	## #229 race-surface guard: every shipped descriptor must be pure data.
+	## A worker thread walking a Callable on a hot-reloadable per-client `.gd`
+	## file is what blew up in the issue — when the bytecode swaps under the
+	## running thread, the IP walks off a cliff (Opcode: 0, Bad address
+	## index, signal 11). Removing all Callable-typed fields on descriptors
+	## reduces the worker's GDScript-IP exposure to the strategy files alone,
+	## which churn far less. It also makes #192's stale-Callable workaround
+	## obsolete: nothing to go stale.
+	##
+	## If this test fails, you almost certainly added a Callable field to
+	## either McpClient (`_base.gd`) or one of the per-client descriptors.
+	## Move the logic into the matching strategy and supply declarative data
+	## (PackedStringArray template, Dictionary, scalar) on the descriptor
+	## instead. See `_base.gd` doc-comment for the rationale.
+	for client in McpClientRegistry.all():
+		var props := client.get_property_list()
+		for prop in props:
+			# Skip script/internal properties — only inspect user-defined fields.
+			if (prop.usage & PROPERTY_USAGE_SCRIPT_VARIABLE) == 0:
+				continue
+			var prop_name: String = prop.name
+			var value = client.get(prop_name)
+			assert_false(
+				value is Callable,
+				"%s.%s is a Callable — descriptors must be data-only (issue #229)" % [client.id, prop_name],
+			)
 
 
 func test_every_client_has_manual_command() -> void:
@@ -729,12 +760,11 @@ func test_json_strategy_distinguishes_missing_entry_from_url_drift() -> void:
 	)
 
 
-func test_json_strategy_drift_with_verify_entry_callable() -> void:
-	## Clients with a custom `verify_entry` (Zed, Claude Desktop) take a
-	## different path through `check_status` than the default url-field
-	## comparison. Both must emit CONFIGURED_MISMATCH for drift, not
-	## NOT_CONFIGURED — the dock contract is the same regardless of how
-	## the check is wired.
+func test_json_strategy_drift_with_bridge_entry() -> void:
+	## Bridge clients (Claude Desktop "flat", Zed "nested") run through a
+	## different verify path in `_json_strategy.verify_entry` than the
+	## default url-field comparison. Drift must still surface as
+	## CONFIGURED_MISMATCH, not NOT_CONFIGURED — dock contract is the same.
 	var path := _scratch_dir.path_join("verify_drift.json")
 	_remove_if_exists(path)
 	var client := McpClient.new()
@@ -743,77 +773,13 @@ func test_json_strategy_drift_with_verify_entry_callable() -> void:
 	client.config_type = "json"
 	client.path_template = {"darwin": path, "windows": path, "linux": path, "unix": path}
 	client.server_key_path = PackedStringArray(["mcpServers"])
-	client.entry_builder = func(_n: String, u: String) -> Dictionary:
-		return {"command": {"path": "npx", "args": ["-y", "mcp-remote", u]}}
-	client.verify_entry = func(entry: Dictionary, u: String) -> bool:
-		var args = entry.get("command", {}).get("args", [])
-		return args is Array and args.has(u)
+	client.entry_uvx_bridge = "flat"
 
 	McpJsonStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
 	assert_eq(
 		McpJsonStrategy.check_status(client, "godot-ai", "http://127.0.0.1:9000/mcp"),
 		McpClient.Status.CONFIGURED_MISMATCH,
 	)
-
-
-## #192 — Lambdas captured in McpClient._init() reference the descriptor
-## instance; toggling the plugin off/on in Project Settings frees the
-## instance and leaves the registry holding stale Callables that crash hard
-## the moment they're invoked. A default-constructed Callable is the closest
-## stand-in we can build in a test — both stale and unset report
-## `is_valid() == false`. The strategies must short-circuit with the shared
-## restart-the-editor message instead of dereferencing the invalid call.
-
-func test_json_strategy_returns_clean_error_when_entry_builder_callable_is_stale() -> void:
-	var path := _scratch_dir.path_join("stale_entry_builder.json")
-	_remove_if_exists(path)
-	var client := _make_test_json_client(path)
-	client.entry_builder = Callable()
-
-	var result := McpJsonStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
-	_assert_stale_callable_error(result, client)
-	assert_false(FileAccess.file_exists(path), "Strategy must not write the config file when the callable is stale")
-
-
-func test_toml_strategy_returns_clean_error_when_body_builder_callable_is_stale() -> void:
-	var path := _scratch_dir.path_join("stale_toml_body.toml")
-	_remove_if_exists(path)
-	var client := _make_test_toml_client(path)
-	client.toml_body_builder = Callable()
-
-	var result := McpTomlStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
-	_assert_stale_callable_error(result, client)
-	assert_false(FileAccess.file_exists(path), "Strategy must not write the config file when the callable is stale")
-
-
-func test_cli_strategy_returns_clean_error_when_register_args_callable_is_stale() -> void:
-	## The strategy resolves the CLI binary before invoking the Callable;
-	## point at `sh` / `cmd.exe` so the resolver succeeds on every test host
-	## and the guard is the line under test.
-	var client := McpClient.new()
-	client.id = "stale_cli_test"
-	client.display_name = "Stale CLI Test"
-	client.config_type = "cli"
-	client.cli_names = PackedStringArray(["cmd.exe"] if OS.get_name() == "Windows" else ["sh"])
-	client.cli_register_args = Callable()
-
-	var result := McpCliStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
-	_assert_stale_callable_error(result, client)
-
-
-func test_cli_strategy_remove_returns_clean_error_when_unregister_args_callable_is_stale() -> void:
-	## remove() had a pre-existing guard with a different message; after #192
-	## it now routes through stale_callable_status alongside configure(). Same
-	## crash hazard, same recovery — keep the dock-facing wording uniform.
-	var client := McpClient.new()
-	client.id = "stale_cli_remove_test"
-	client.display_name = "Stale CLI Remove Test"
-	client.config_type = "cli"
-	client.cli_names = PackedStringArray(["cmd.exe"] if OS.get_name() == "Windows" else ["sh"])
-	client.cli_unregister_args = Callable()
-
-	var result := McpCliStrategy.remove(client, "godot-ai")
-	_assert_stale_callable_error(result, client)
 
 
 func test_json_strategy_supports_nested_key_path() -> void:
@@ -826,8 +792,7 @@ func test_json_strategy_supports_nested_key_path() -> void:
 	client.path_template = {"darwin": path, "windows": path, "linux": path, "unix": path}
 	# Mirror OpenCode's `mcp.<name>` shape.
 	client.server_key_path = PackedStringArray(["mcp"])
-	client.entry_builder = func(_n: String, u: String) -> Dictionary:
-		return {"type": "remote", "url": u}
+	client.entry_extra_fields = {"type": "remote"}
 
 	var result := McpJsonStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
 	assert_eq(result.get("status"), "ok")
@@ -1066,26 +1031,27 @@ func test_handler_status_returns_array_of_clients() -> void:
 
 func test_cursor_entry_uses_url() -> void:
 	var c := McpClientRegistry.get_by_id("cursor")
-	var entry: Dictionary = c.entry_builder.call("godot-ai", "http://x")
+	var entry := McpJsonStrategy.build_entry(c, "http://x")
 	assert_eq(entry.get("url", ""), "http://x")
 
 
 func test_antigravity_entry_uses_serverUrl() -> void:
 	var c := McpClientRegistry.get_by_id("antigravity")
-	var entry: Dictionary = c.entry_builder.call("godot-ai", "http://x")
+	var entry := McpJsonStrategy.build_entry(c, "http://x")
 	assert_eq(entry.get("serverUrl", ""), "http://x")
 	assert_eq(entry.get("disabled", true), false)
 
 
 func test_gemini_cli_entry_uses_httpUrl() -> void:
 	var c := McpClientRegistry.get_by_id("gemini_cli")
-	var entry: Dictionary = c.entry_builder.call("godot-ai", "http://x")
+	var entry := McpJsonStrategy.build_entry(c, "http://x")
 	assert_eq(entry.get("httpUrl", ""), "http://x")
 
 
 func test_claude_desktop_bridges_via_uvx() -> void:
 	var c := McpClientRegistry.get_by_id("claude_desktop")
-	var entry: Dictionary = c.entry_builder.call("godot-ai", "http://x")
+	assert_eq(c.entry_uvx_bridge, "flat", "claude_desktop must declare flat uvx bridge")
+	var entry := McpJsonStrategy.build_entry(c, "http://x")
 	_assert_uvx_command(entry.get("command", ""))
 	_assert_mcp_proxy_bridge_args(entry.get("args", []), "http://x")
 
@@ -1093,15 +1059,26 @@ func test_claude_desktop_bridges_via_uvx() -> void:
 func test_claude_desktop_verify_entry_accepts_uvx_form() -> void:
 	## Drift-detection: once we've written the new uvx entry, check_status
 	## must round-trip it as CONFIGURED (not MISMATCH). Guards against a
-	## verify_entry that still only recognises the old npx/mcp-remote shape.
+	## verifier that still only recognises the old npx/mcp-remote shape.
 	var c := McpClientRegistry.get_by_id("claude_desktop")
-	var entry: Dictionary = c.entry_builder.call("godot-ai", "http://x")
-	assert_true(c.verify_entry.call(entry, "http://x"), "uvx entry should verify as a match")
+	var entry := McpJsonStrategy.build_entry(c, "http://x")
+	assert_true(McpJsonStrategy.verify_entry(c, entry, "http://x"), "uvx entry should verify as a match")
+
+
+func test_claude_desktop_verify_entry_accepts_future_url_form() -> void:
+	## Tolerance preserved from the pre-refactor verifier: a hypothetical
+	## future Claude Desktop that speaks HTTP natively would write a plain
+	## `{"url": "..."}` entry. The flat-bridge verifier must accept that
+	## shape too so we don't downgrade-classify it as drift.
+	var c := McpClientRegistry.get_by_id("claude_desktop")
+	var future_entry := {"url": "http://x"}
+	assert_true(McpJsonStrategy.verify_entry(c, future_entry, "http://x"), "future url-style entry should verify")
 
 
 func test_zed_bridges_via_uvx() -> void:
 	var c := McpClientRegistry.get_by_id("zed")
-	var entry: Dictionary = c.entry_builder.call("godot-ai", "http://x")
+	assert_eq(c.entry_uvx_bridge, "nested", "zed must declare nested uvx bridge")
+	var entry := McpJsonStrategy.build_entry(c, "http://x")
 	var cmd = entry.get("command", {})
 	assert_true(cmd is Dictionary, "Zed entry.command must be a Dictionary (path+args shape)")
 	_assert_uvx_command(cmd.get("path", ""))
@@ -1109,11 +1086,11 @@ func test_zed_bridges_via_uvx() -> void:
 
 
 func test_zed_verify_entry_accepts_uvx_form() -> void:
-	## Parity with claude_desktop drift-detection test — if Zed's entry_builder
-	## changes but verify_entry isn't updated in lock-step, this catches it.
+	## Parity with claude_desktop drift-detection test — if Zed's entry shape
+	## changes but the verifier isn't updated in lock-step, this catches it.
 	var c := McpClientRegistry.get_by_id("zed")
-	var entry: Dictionary = c.entry_builder.call("godot-ai", "http://x")
-	assert_true(c.verify_entry.call(entry, "http://x"), "uvx entry should verify as a match")
+	var entry := McpJsonStrategy.build_entry(c, "http://x")
+	assert_true(McpJsonStrategy.verify_entry(c, entry, "http://x"), "uvx entry should verify as a match")
 
 
 func test_mcp_proxy_bridge_args_pins_version() -> void:
@@ -1138,7 +1115,7 @@ func test_vscode_uses_servers_key_with_type_http() -> void:
 	var c := McpClientRegistry.get_by_id("vscode")
 	assert_eq(c.server_key_path.size(), 1)
 	assert_eq(c.server_key_path[0], "servers")
-	var entry: Dictionary = c.entry_builder.call("godot-ai", "http://x")
+	var entry := McpJsonStrategy.build_entry(c, "http://x")
 	assert_eq(entry.get("type", ""), "http")
 	assert_eq(entry.get("url", ""), "http://x")
 
@@ -1149,28 +1126,28 @@ func test_roo_code_pins_streamable_http_transport() -> void:
 	## The entry and the manual-command string must both pin the type so the
 	## out-of-the-box config negotiates the right transport.
 	var c := McpClientRegistry.get_by_id("roo_code")
-	var entry: Dictionary = c.entry_builder.call("godot-ai", "http://x")
+	var entry := McpJsonStrategy.build_entry(c, "http://x")
 	assert_eq(entry.get("type", ""), "streamable-http")
 	assert_eq(entry.get("url", ""), "http://x")
-	var manual: String = c.manual_command_builder.call("godot-ai", "http://x", "/tmp/roo.json")
+	var manual := McpManualCommand.build(c, "godot-ai", "http://x", "/tmp/roo.json")
 	assert_contains(manual, "\"type\": \"streamable-http\"")
 
 
 func test_roo_code_verify_flags_pre_189_typeless_entry_as_drift() -> void:
 	## Users who configured Roo before the #189 fix have a correct URL but no
 	## "type" field — the URL-only default verifier would report CONFIGURED and
-	## hide the broken SSE negotiation. verify_entry must treat a missing/wrong
-	## type as drift so the dock prompts them to re-configure.
+	## hide the broken SSE negotiation. The default verifier (deep-equal of
+	## entry_extra_fields) treats a missing/wrong type as drift so the dock
+	## prompts them to re-configure.
 	var c := McpClientRegistry.get_by_id("roo_code")
-	assert_true(c.verify_entry.is_valid(), "roo_code must supply verify_entry")
-	var current: Dictionary = c.entry_builder.call("godot-ai", "http://x")
-	assert_true(c.verify_entry.call(current, "http://x"), "current entry must verify")
+	var current := McpJsonStrategy.build_entry(c, "http://x")
+	assert_true(McpJsonStrategy.verify_entry(c, current, "http://x"), "current entry must verify")
 	var legacy_typeless := {"url": "http://x", "disabled": false, "alwaysAllow": []}
-	assert_false(c.verify_entry.call(legacy_typeless, "http://x"), "pre-#189 typeless entry must register as drift")
+	assert_false(McpJsonStrategy.verify_entry(c, legacy_typeless, "http://x"), "pre-#189 typeless entry must register as drift")
 	var legacy_sse := {"type": "sse", "url": "http://x", "disabled": false, "alwaysAllow": []}
-	assert_false(c.verify_entry.call(legacy_sse, "http://x"), "explicit sse entry must register as drift")
+	assert_false(McpJsonStrategy.verify_entry(c, legacy_sse, "http://x"), "explicit sse entry must register as drift")
 	var url_drift := {"type": "streamable-http", "url": "http://other", "disabled": false, "alwaysAllow": []}
-	assert_false(c.verify_entry.call(url_drift, "http://x"), "URL drift must still register as drift")
+	assert_false(McpJsonStrategy.verify_entry(c, url_drift, "http://x"), "URL drift must still register as drift")
 
 
 func test_cline_pins_streamable_http_transport() -> void:
@@ -1179,30 +1156,29 @@ func test_cline_pins_streamable_http_transport() -> void:
 	## HTTP 400. Cline's schema accepts "streamableHttp" (camelCase) — distinct
 	## from Roo's "streamable-http" — per src/services/mcp/schemas.ts upstream.
 	var c := McpClientRegistry.get_by_id("cline")
-	var entry: Dictionary = c.entry_builder.call("godot-ai", "http://x")
+	var entry := McpJsonStrategy.build_entry(c, "http://x")
 	assert_eq(entry.get("type", ""), "streamableHttp")
 	assert_eq(entry.get("url", ""), "http://x")
-	var manual: String = c.manual_command_builder.call("godot-ai", "http://x", "/tmp/cline.json")
+	var manual := McpManualCommand.build(c, "godot-ai", "http://x", "/tmp/cline.json")
 	assert_contains(manual, "\"type\": \"streamableHttp\"")
 
 
 func test_cline_verify_flags_pre_fix_typeless_entry_as_drift() -> void:
 	## Users who configured Cline before this fix have a correct URL but no
 	## "type" field — the URL-only default verifier would report CONFIGURED and
-	## hide the broken SSE negotiation. verify_entry must treat a missing/wrong
-	## type as drift so the dock prompts them to re-configure.
+	## hide the broken SSE negotiation. The default verifier deep-equals every
+	## entry_extra_fields key, so a missing/wrong type registers as drift.
 	var c := McpClientRegistry.get_by_id("cline")
-	assert_true(c.verify_entry.is_valid(), "cline must supply verify_entry")
-	var current: Dictionary = c.entry_builder.call("godot-ai", "http://x")
-	assert_true(c.verify_entry.call(current, "http://x"), "current entry must verify")
+	var current := McpJsonStrategy.build_entry(c, "http://x")
+	assert_true(McpJsonStrategy.verify_entry(c, current, "http://x"), "current entry must verify")
 	var legacy_typeless := {"url": "http://x", "disabled": false, "autoApprove": []}
-	assert_false(c.verify_entry.call(legacy_typeless, "http://x"), "pre-fix typeless entry must register as drift")
+	assert_false(McpJsonStrategy.verify_entry(c, legacy_typeless, "http://x"), "pre-fix typeless entry must register as drift")
 	var legacy_sse := {"type": "sse", "url": "http://x", "disabled": false, "autoApprove": []}
-	assert_false(c.verify_entry.call(legacy_sse, "http://x"), "explicit sse entry must register as drift")
+	assert_false(McpJsonStrategy.verify_entry(c, legacy_sse, "http://x"), "explicit sse entry must register as drift")
 	var wrong_case := {"type": "streamable-http", "url": "http://x", "disabled": false, "autoApprove": []}
-	assert_false(c.verify_entry.call(wrong_case, "http://x"), "Roo's kebab-case 'streamable-http' must register as drift in Cline (Cline accepts only 'streamableHttp')")
+	assert_false(McpJsonStrategy.verify_entry(c, wrong_case, "http://x"), "Roo's kebab-case 'streamable-http' must register as drift in Cline (Cline accepts only 'streamableHttp')")
 	var url_drift := {"type": "streamableHttp", "url": "http://other", "disabled": false, "autoApprove": []}
-	assert_false(c.verify_entry.call(url_drift, "http://x"), "URL drift must still register as drift")
+	assert_false(McpJsonStrategy.verify_entry(c, url_drift, "http://x"), "URL drift must still register as drift")
 
 
 func test_kilo_code_pins_streamable_http_transport() -> void:
@@ -1210,26 +1186,26 @@ func test_kilo_code_pins_streamable_http_transport() -> void:
 	## and its McpHub.ts validates against {"stdio", "sse", "streamable-http"}
 	## — same kebab-case spelling as Roo, distinct from Cline's camelCase.
 	var c := McpClientRegistry.get_by_id("kilo_code")
-	var entry: Dictionary = c.entry_builder.call("godot-ai", "http://x")
+	var entry := McpJsonStrategy.build_entry(c, "http://x")
 	assert_eq(entry.get("type", ""), "streamable-http")
 	assert_eq(entry.get("url", ""), "http://x")
-	var manual: String = c.manual_command_builder.call("godot-ai", "http://x", "/tmp/kilo.json")
+	var manual := McpManualCommand.build(c, "godot-ai", "http://x", "/tmp/kilo.json")
 	assert_contains(manual, "\"type\": \"streamable-http\"")
 
 
 func test_kilo_code_verify_flags_pre_fix_typeless_entry_as_drift() -> void:
-	## Pre-fix Kilo entries have a correct URL but no "type" field. verify_entry
-	## must flag them as drift so the dock prompts a re-configure.
+	## Pre-fix Kilo entries have a correct URL but no "type" field. The
+	## default verifier (deep-equal of entry_extra_fields) flags them as
+	## drift so the dock prompts a re-configure.
 	var c := McpClientRegistry.get_by_id("kilo_code")
-	assert_true(c.verify_entry.is_valid(), "kilo_code must supply verify_entry")
-	var current: Dictionary = c.entry_builder.call("godot-ai", "http://x")
-	assert_true(c.verify_entry.call(current, "http://x"), "current entry must verify")
+	var current := McpJsonStrategy.build_entry(c, "http://x")
+	assert_true(McpJsonStrategy.verify_entry(c, current, "http://x"), "current entry must verify")
 	var legacy_typeless := {"url": "http://x", "disabled": false, "alwaysAllow": []}
-	assert_false(c.verify_entry.call(legacy_typeless, "http://x"), "pre-fix typeless entry must register as drift")
+	assert_false(McpJsonStrategy.verify_entry(c, legacy_typeless, "http://x"), "pre-fix typeless entry must register as drift")
 	var legacy_sse := {"type": "sse", "url": "http://x", "disabled": false, "alwaysAllow": []}
-	assert_false(c.verify_entry.call(legacy_sse, "http://x"), "explicit sse entry must register as drift")
+	assert_false(McpJsonStrategy.verify_entry(c, legacy_sse, "http://x"), "explicit sse entry must register as drift")
 	var url_drift := {"type": "streamable-http", "url": "http://other", "disabled": false, "alwaysAllow": []}
-	assert_false(c.verify_entry.call(url_drift, "http://x"), "URL drift must still register as drift")
+	assert_false(McpJsonStrategy.verify_entry(c, url_drift, "http://x"), "URL drift must still register as drift")
 
 
 func test_opencode_client_uses_home_config_on_windows() -> void:
@@ -1284,13 +1260,6 @@ func _assert_mcp_proxy_bridge_args(args: Variant, expected_url: String) -> void:
 	assert_contains(args, expected_url)
 
 
-func _assert_stale_callable_error(result: Dictionary, client: McpClient) -> void:
-	assert_eq(result.get("status"), "error")
-	var msg: String = result.get("message", "")
-	assert_contains(msg, client.display_name, "stale-callable error must name the client, got: %s" % msg)
-	assert_contains(msg, "restart the editor", "stale-callable error must suggest editor restart, got: %s" % msg)
-
-
 func _make_test_json_client(path: String) -> McpClient:
 	var c := McpClient.new()
 	c.id = "json_test"
@@ -1298,8 +1267,9 @@ func _make_test_json_client(path: String) -> McpClient:
 	c.config_type = "json"
 	c.path_template = {"darwin": path, "windows": path, "linux": path, "unix": path}
 	c.server_key_path = PackedStringArray(["mcpServers"])
-	c.entry_builder = func(_n: String, u: String) -> Dictionary:
-		return {"url": u}
+	# entry_url_field defaults to "url"; entry_extra_fields stays empty
+	# → strategy synthesises `{"url": <url>}`, matching the pre-refactor
+	# entry_builder lambda.
 	return c
 
 
@@ -1310,8 +1280,7 @@ func _make_test_toml_client(path: String) -> McpClient:
 	c.config_type = "toml"
 	c.path_template = {"darwin": path, "windows": path, "linux": path, "unix": path}
 	c.toml_section_path = PackedStringArray(["mcp_servers", "godot-ai"])
-	c.toml_body_builder = func(u: String) -> PackedStringArray:
-		return PackedStringArray(["url = \"%s\"" % u, "enabled = true"])
+	c.toml_body_template = PackedStringArray(["url = \"{url}\"", "enabled = true"])
 	return c
 
 


### PR DESCRIPTION
Closes #229. Implements **option 4** from [the empirical-confirmation comment](https://github.com/hi-godot/godot-ai/issues/229#issuecomment-4323327346) — the deepest-but-cleanest fix the issue documented.

## Root cause (confirmed via real smoke test)

The issue commenter ruled out `is_scanning()` + one-shot `filesystem_changed` gates: the script-reload phase fires *after* `filesystem_changed`, so any guard hung off that signal sees the editor as "settled" while bytecode is still being swapped. With no public signal that brackets the reload phase, the only way to neutralise the race is to remove the worker's exposure to hot-reloadable per-client GDScript entirely.

The race surface today is `_cli_strategy.check_status` → `client.cli_status_check.call(...)` (and the parallel sites for `verify_entry` / `entry_builder` etc.) — every one of those Callables lives on a `clients/<name>.gd` script that gets hot-reloaded on disk-mtime change.

## The deep clean

Per-client descriptors are now **pure data**, as `_base.gd:6` always claimed they were ("Subclasses set fields in `_init()`; they should not contain control flow"). All seven Callable fields are gone:

| Removed Callable | Replaced with |
|---|---|
| `entry_builder` | `entry_url_field` + `entry_extra_fields: Dictionary` (default {}) |
| `verify_entry` | Default verifier deep-equals every `entry_extra_fields` key (catches Cline/Roo/Kilo type-drift verbatim) |
| `cli_register_args` | `cli_register_template: PackedStringArray` with `{name}`/`{url}` tokens |
| `cli_unregister_args` | `cli_unregister_template: PackedStringArray` |
| `cli_status_check` | `cli_status_args: PackedStringArray` (logic moved into `_cli_strategy.check_status`) |
| `toml_body_builder` | `toml_body_template: PackedStringArray` with `{url}` token |
| `manual_command_builder` | New `_manual_command.gd` synthesises the string from declarative data |

Bridge clients (Claude Desktop, Zed) declare `entry_uvx_bridge = "flat"` or `"nested"`; the strategy composes the uvx + mcp-proxy command shape. Claude Desktop's tolerance for a future url-style entry survives via the strategy's `verify_entry` default for `flat` bridge.

`McpClient.stale_callable_status` (the #192 workaround) is also deleted — with no descriptor-supplied Callables, there's nothing to go stale on plugin disable+enable.

## Real smoke test

Round-tripped live against this checkout via MCP `client_manage`:

- **cursor** (non-bridge JSON) → writes `{"url": "..."}` byte-equivalent to pre-refactor; configure → status (CONFIGURED) → remove all green
- **claude_desktop** (flat bridge) → writes pinned `uvx + mcp-proxy==0.11.0` entry under `mcpServers`
- **codex** (TOML) → writes `[mcp_servers."godot-ai"]\nurl = "..."\nenabled = true`

The verify-after-write contract holds end-to-end (any drift between strategy claim and on-disk state would have downgraded the response to error).

## Test surface

- **891/905 GDScript tests pass, 0 failures** (14 pre-existing skips). Net –2 from baseline:
  - removed 4 `..._stale_callable_..` tests (workaround no longer exists)
  - rewrote `verify_entry_callable` test as the bridge-form check
  - added `test_descriptors_are_data_only` — race-surface guard that walks every registered descriptor's properties and fails fast if any field is a Callable. Re-introducing a lambda anywhere in `clients/*.gd` will fail the suite with a pointer back to this issue.
  - added `test_claude_desktop_verify_entry_accepts_future_url_form` — locks in the flat-bridge tolerance the old verifier had baked in.
- **633 pytest tests still green.**
- **ruff clean.**

## Test plan

- [ ] CI: ruff + pytest (Linux/macOS/Windows × py3.11/3.13)
- [ ] CI: GDScript test suite via `script/ci-godot-tests` on all three OSes
- [ ] Manual: open `test_project/` in a real editor, run Configure on Cursor / Claude Desktop / Codex / Claude Code, verify the on-disk entry matches what the pre-refactor build wrote
- [ ] Manual: with the editor open, `git checkout -- plugin/addons/godot_ai/clients/claude_code.gd` and `editor_reload_plugin` — should no longer SEGV (this is the original issue's repro)

https://claude.ai/code/session_01XFeA5y2dKwHmUNJx6cnAfq

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFeA5y2dKwHmUNJx6cnAfq)_