### PR TITLE
fix(dock): drain refresh-thread on plugin tear-down (orphan-Thread-GC, follow-up to #228/#230)

### DIFF
--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -172,11 +172,25 @@ func _process(_delta: float) -> void:
 
 
 func _exit_tree() -> void:
+	## Block on any in-flight refresh worker before letting the dock leave the
+	## tree. The plugin disable path (editor_reload_plugin, Project Settings
+	## toggle) reloads the McpDock script class — which wipes the static
+	## `_orphaned_client_status_refresh_threads`, GCs the Thread objects mid-
+	## execution, and triggers `~Thread … destroyed without its completion
+	## having been realized` plus GDScript VM corruption (Opcode: 0, IP-bounds
+	## errors, intermittent SIGSEGV). Probes finish in well under a second
+	## under normal conditions; if a CLI probe genuinely hung, the runtime
+	## timeout path (`_abandon_client_status_refresh_thread`) has already
+	## moved that thread into the orphan list, so we drain it here too.
 	_client_status_refresh_shutdown_requested = true
 	_client_status_refresh_generation += 1
 	if _client_status_refresh_thread != null:
-		_orphaned_client_status_refresh_threads.append(_client_status_refresh_thread)
+		_client_status_refresh_thread.wait_to_finish()
 		_client_status_refresh_thread = null
+	for thread in _orphaned_client_status_refresh_threads:
+		if thread != null:
+			thread.wait_to_finish()
+	_orphaned_client_status_refresh_threads.clear()
 	_client_status_refresh_in_flight = false
 	_client_status_refresh_pending = false
 	_client_status_refresh_pending_force = false

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -182,6 +182,11 @@ func _exit_tree() -> void:
 	## under normal conditions; if a CLI probe genuinely hung, the runtime
 	## timeout path (`_abandon_client_status_refresh_thread`) has already
 	## moved that thread into the orphan list, so we drain it here too.
+	##
+	## `wait_to_finish` is unbounded by design: GDScript's Thread API has no
+	## timeout, and a polling/abandon fallback would just re-introduce the
+	## GC-mid-execution crash this fix exists to prevent. Blocking the editor
+	## briefly on plugin-reload is strictly better than the SIGSEGV.
 	_client_status_refresh_shutdown_requested = true
 	_client_status_refresh_generation += 1
 	if _client_status_refresh_thread != null:

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -157,6 +157,25 @@ func test_refresh_cooldown_helper_only_blocks_automatic_refreshes() -> void:
 		"No completed refresh means no cooldown")
 
 
+func test_exit_tree_drains_orphaned_refresh_threads() -> void:
+	## Regression for the static-var orphan bug surfaced on the plugin disable
+	## path (editor_reload_plugin, Project Settings toggle): the McpDock
+	## script class is itself reloaded, which wipes
+	## `_orphaned_client_status_refresh_threads` and GCs any Thread still in
+	## it mid-execution → `~Thread … destroyed without its completion having
+	## been realized` plus GDScript VM corruption (Opcode: 0, IP-bounds
+	## errors, intermittent SIGSEGV). `_exit_tree` must drain the orphan list
+	## synchronously before returning, so no GDScript work straddles the
+	## script-class reload boundary.
+	var t := Thread.new()
+	var err := t.start(func() -> int: return 42)
+	assert_eq(err, OK, "Test fixture failed to start thread")
+	McpDockScript._orphaned_client_status_refresh_threads.append(t)
+	_dock._exit_tree()
+	assert_true(McpDockScript._orphaned_client_status_refresh_threads.is_empty(),
+		"_exit_tree must clear the orphan list synchronously after waiting on each thread")
+
+
 ## Shared fixture for the three version-label tests. Inject a Label + Button
 ## + Connection onto the dock so the pure refresh logic can be exercised
 ## without depending on whether the test environment resolves as user mode


### PR DESCRIPTION
## Summary

Follow-up to #228, retargeted onto post-#230 main. Fixes the editor crash that surfaces during the plugin disable path (`editor_reload_plugin`, Project Settings toggle) — orthogonal to the descriptor hot-reload race that #230 already addressed.

## The bug

PR #228 orphans the in-flight client-status refresh `Thread` to `static var _orphaned_client_status_refresh_threads` and relies on the dock's `_process()` loop to `wait_to_finish` it later. That breaks on plugin disable: the `McpDock` script class is itself reloaded, which **wipes the static var and GCs the Thread objects mid-execution**, triggering:

```
WARNING: A Thread object is being destroyed without its completion having been realized.
   at: ~Thread (drivers/apple/thread_apple.cpp:136)
ERROR: Condition ' (ip + 7 + _pointer_size) > _code_size ' is true. Breaking..
SCRIPT ERROR: Internal script error! Opcode: 0
```

…plus intermittent `SIGSEGV` (the corrupted IP sometimes lands on a valid address, sometimes doesn't). Witnessed live on this checkout while smoke-testing #230 — my on-disk `clients/*.gd` edits triggered Godot's filesystem hot-reload while a worker was mid-probe, the static-var orphan list got wiped on script-class reload, and the running thread's destructor fired with `is_alive()` true → C++ stack ending in `Thread::_start_func` → segfault.

#230 makes the worker's call chain immune to bytecode corruption (no per-client Callables to swap). This PR closes the second leg: ensures no Thread straddles the script-class reload boundary in the first place.

## The fix

`_exit_tree` now drains the active and orphaned refresh threads synchronously via `wait_to_finish()`, so the dock can't leave the tree (and the script class can't reload) while a worker is still running:

```gdscript
if _client_status_refresh_thread != null:
    _client_status_refresh_thread.wait_to_finish()
    _client_status_refresh_thread = null
for thread in _orphaned_client_status_refresh_threads:
    if thread != null:
        thread.wait_to_finish()
_orphaned_client_status_refresh_threads.clear()
```

Probes finish in well under a second under normal conditions; if a CLI probe genuinely hung, the runtime timeout path (`_abandon_client_status_refresh_thread`) has already moved that thread into the orphan list, and we drain it here too. Orthogonal to #230's per-call-chain fix.

## Why a separate PR

#230's fix and this one address different races:

| Race | Trigger | Fix |
|---|---|---|
| Worker executes per-client Callable while `clients/<name>.gd` hot-reloads on disk | `git checkout`, IDE save, self-update | #230: descriptors are pure data |
| Worker is still running when `_exit_tree` orphans it; static var GCs the Thread mid-execution | `editor_reload_plugin`, Project Settings toggle | This PR: `wait_to_finish` synchronously |

Both are needed for full safety on top of #228. With only #230, every `editor_reload_plugin` still risks the orphan-Thread-GC trip — the user just witnessed it.

## Repro (against current main, before this fix)

1. Open the editor with the plugin loaded.
2. Call `editor_reload_plugin` (or toggle the plugin in Project Settings).
3. Editor stdout shows the `~Thread … destroyed without its completion` warning + `Opcode: 0` script errors. Sometimes segfaults on the next reload, sometimes survives with corrupted GDScript state.

## Validation

- Cherry-picked clean from the original `fix/exit-tree-thread-drain` branch onto current `main` (post-#230)
- 910/913 GDScript tests pass (3 pre-existing skips, 0 fail), including the new `test_exit_tree_drains_orphaned_refresh_threads` regression test
- 641/641 pytest pass, ruff clean
- 5x rapid `editor_reload_plugin` calls before the fix → "destroyed without its completion" warning + segfault on first reload
- Same calls after the fix → 0 thread warnings, 0 script errors, 0 segfaults; editor stable across 11 reloads in the smoke session

## Test plan

- [ ] CI: ruff + pytest (Linux/macOS/Windows × py3.11/3.13)
- [ ] CI: GDScript test suite via `script/ci-godot-tests` on all three OSes
- [ ] Manual: open `test_project/` in a real editor, trigger `editor_reload_plugin` 3-5 times in quick succession — should produce no `~Thread destroyed without completion` warnings in stdout
