### PR TITLE
fix(dock): defer first auto-refresh past GDScript hot-reload settle (#233)

### DIFF
--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -12,15 +12,11 @@ const MODE_OVERRIDE_VALUES := ["", "user", "dev"]
 const MODE_OVERRIDE_LABELS := ["Auto", "Force user", "Force dev"]
 const CLIENT_STATUS_REFRESH_COOLDOWN_MSEC := 15 * 1000
 const CLIENT_STATUS_REFRESH_TIMEOUT_MSEC := 30 * 1000
-## Delay before the very first auto-refresh fires after `_build_ui`. Godot's
-## lazy GDScript hot-reload of `addons/godot_ai/*.gd` doesn't fully settle by
-## the time the new dock is in the tree on the self-update path
-## (`_install_update` extracts a new release zip then toggles
-## `set_plugin_enabled`). Worker walking into a strategy whose bytecode is
-## mid-swap aborts the editor (KERN_INVALID_ADDRESS / SIGABRT, see #233).
-## 1.5s is comfortable margin past typical settle (<500ms empirically) while
-## still feeling instant in the dock.
-const CLIENT_STATUS_REFRESH_INITIAL_DELAY_SEC := 1.5
+## Delay before the very first auto-refresh fires after `_build_ui` —
+## settle margin past Godot's lazy GDScript hot-reload of plugin scripts
+## on the self-update path. Empirical settle is <500ms; 1500 is 3× margin.
+## See issue #233.
+const CLIENT_STATUS_REFRESH_INITIAL_DELAY_MSEC := 1500
 static var COLOR_MUTED := Color(0.7, 0.7, 0.7)
 static var COLOR_HEADER := Color(0.95, 0.95, 0.95)
 ## Used for "in-progress" / "stale, action needed" UI: the startup-grace
@@ -1525,18 +1521,11 @@ func _prune_orphaned_client_status_refresh_threads() -> void:
 
 func _schedule_initial_client_status_refresh() -> void:
 	## Defer the first auto-refresh past Godot's lazy GDScript hot-reload
-	## window. On the self-update path (`_install_update` extracts a release
-	## zip over `addons/godot_ai/`, then toggles `set_plugin_enabled`), the
-	## new dock spawns its first worker while strategy GDScript bytecode is
-	## still being swapped on the main thread. The worker walks into
-	## `_json_strategy.check_status` / `client_configurator.*` mid-swap and
-	## aborts (`KERN_INVALID_ADDRESS` / SIGABRT, see issue #233). Filesystem
-	## signals like `is_scanning()` / `filesystem_changed` flip back to false
-	## before the bytecode swap completes, so a signal-based gate doesn't
-	## bracket the race; a timer does. `NOTIFICATION_APPLICATION_FOCUS_IN`
-	## also won't fire — the editor is already focused when the user clicks
-	## Update and stays focused through the reload.
-	await get_tree().create_timer(CLIENT_STATUS_REFRESH_INITIAL_DELAY_SEC).timeout
+	## window — racing it segfaults the editor on the self-update path.
+	## Filesystem signals don't bracket the race (they fire before bytecode
+	## swap completes) and FOCUS_IN doesn't fire on in-place plugin reload,
+	## so a fixed-delay timer is the only mechanism that works. See #233.
+	await get_tree().create_timer(CLIENT_STATUS_REFRESH_INITIAL_DELAY_MSEC / 1000.0).timeout
 	if _client_status_refresh_shutdown_requested:
 		return
 	if not is_inside_tree():

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -1525,7 +1525,15 @@ func _schedule_initial_client_status_refresh() -> void:
 	## Filesystem signals don't bracket the race (they fire before bytecode
 	## swap completes) and FOCUS_IN doesn't fire on in-place plugin reload,
 	## so a fixed-delay timer is the only mechanism that works. See #233.
-	await get_tree().create_timer(CLIENT_STATUS_REFRESH_INITIAL_DELAY_MSEC / 1000.0).timeout
+	## (Tracked in #235; this is the interim heuristic stopgap.)
+	## Pre-await `get_tree()` capture: GDScript tests instantiate the dock
+	## via `McpDockScript.new()` without adding to the tree, so `get_tree()`
+	## is null and `null.create_timer(...)` would error. Bail cleanly when
+	## not in tree — the deferred refresh is a no-op outside the editor.
+	var tree := get_tree()
+	if tree == null or not is_inside_tree():
+		return
+	await tree.create_timer(CLIENT_STATUS_REFRESH_INITIAL_DELAY_MSEC / 1000.0).timeout
 	if _client_status_refresh_shutdown_requested:
 		return
 	if not is_inside_tree():

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -12,6 +12,15 @@ const MODE_OVERRIDE_VALUES := ["", "user", "dev"]
 const MODE_OVERRIDE_LABELS := ["Auto", "Force user", "Force dev"]
 const CLIENT_STATUS_REFRESH_COOLDOWN_MSEC := 15 * 1000
 const CLIENT_STATUS_REFRESH_TIMEOUT_MSEC := 30 * 1000
+## Delay before the very first auto-refresh fires after `_build_ui`. Godot's
+## lazy GDScript hot-reload of `addons/godot_ai/*.gd` doesn't fully settle by
+## the time the new dock is in the tree on the self-update path
+## (`_install_update` extracts a new release zip then toggles
+## `set_plugin_enabled`). Worker walking into a strategy whose bytecode is
+## mid-swap aborts the editor (KERN_INVALID_ADDRESS / SIGABRT, see #233).
+## 1.5s is comfortable margin past typical settle (<500ms empirically) while
+## still feeling instant in the dock.
+const CLIENT_STATUS_REFRESH_INITIAL_DELAY_SEC := 1.5
 static var COLOR_MUTED := Color(0.7, 0.7, 0.7)
 static var COLOR_HEADER := Color(0.95, 0.95, 0.95)
 ## Used for "in-progress" / "stale, action needed" UI: the startup-grace
@@ -547,7 +556,7 @@ func _build_ui() -> void:
 	# Apply initial dev-mode visibility
 	_apply_dev_mode_visibility()
 	_refresh_setup_status.call_deferred()
-	_request_client_status_refresh.call_deferred(true)
+	_schedule_initial_client_status_refresh()
 
 
 func _make_header(text: String) -> Label:
@@ -1512,6 +1521,27 @@ func _prune_orphaned_client_status_refresh_threads() -> void:
 		elif not thread.is_alive():
 			thread.wait_to_finish()
 			_orphaned_client_status_refresh_threads.remove_at(i)
+
+
+func _schedule_initial_client_status_refresh() -> void:
+	## Defer the first auto-refresh past Godot's lazy GDScript hot-reload
+	## window. On the self-update path (`_install_update` extracts a release
+	## zip over `addons/godot_ai/`, then toggles `set_plugin_enabled`), the
+	## new dock spawns its first worker while strategy GDScript bytecode is
+	## still being swapped on the main thread. The worker walks into
+	## `_json_strategy.check_status` / `client_configurator.*` mid-swap and
+	## aborts (`KERN_INVALID_ADDRESS` / SIGABRT, see issue #233). Filesystem
+	## signals like `is_scanning()` / `filesystem_changed` flip back to false
+	## before the bytecode swap completes, so a signal-based gate doesn't
+	## bracket the race; a timer does. `NOTIFICATION_APPLICATION_FOCUS_IN`
+	## also won't fire — the editor is already focused when the user clicks
+	## Update and stays focused through the reload.
+	await get_tree().create_timer(CLIENT_STATUS_REFRESH_INITIAL_DELAY_SEC).timeout
+	if _client_status_refresh_shutdown_requested:
+		return
+	if not is_inside_tree():
+		return
+	_request_client_status_refresh(true)
 
 
 func _request_client_status_refresh(force: bool = false) -> bool:

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -157,6 +157,19 @@ func test_refresh_cooldown_helper_only_blocks_automatic_refreshes() -> void:
 		"No completed refresh means no cooldown")
 
 
+func test_initial_refresh_delay_is_past_typical_hot_reload_settle() -> void:
+	## Regression for #233: the self-update path extracts a fresh release zip
+	## over `addons/godot_ai/` then toggles `set_plugin_enabled`. The new
+	## dock's first auto-refresh worker must NOT fire while Godot is still
+	## hot-reloading strategy bytecode (`_json_strategy`, `client_configurator`,
+	## …) — the worker walks into a script mid-swap and aborts the editor
+	## (KERN_INVALID_ADDRESS / SIGABRT). The initial-delay constant is the
+	## settle margin; locking it in keeps a future "0-delay would be snappier"
+	## refactor from re-introducing the crash.
+	assert_true(McpDockScript.CLIENT_STATUS_REFRESH_INITIAL_DELAY_SEC >= 1.0,
+		"Initial refresh delay must be at least 1s — empirical hot-reload settle")
+
+
 func test_exit_tree_drains_orphaned_refresh_threads() -> void:
 	## Regression for the static-var orphan bug surfaced on the plugin disable
 	## path (editor_reload_plugin, Project Settings toggle): the McpDock

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -158,15 +158,9 @@ func test_refresh_cooldown_helper_only_blocks_automatic_refreshes() -> void:
 
 
 func test_initial_refresh_delay_is_past_typical_hot_reload_settle() -> void:
-	## Regression for #233: the self-update path extracts a fresh release zip
-	## over `addons/godot_ai/` then toggles `set_plugin_enabled`. The new
-	## dock's first auto-refresh worker must NOT fire while Godot is still
-	## hot-reloading strategy bytecode (`_json_strategy`, `client_configurator`,
-	## …) — the worker walks into a script mid-swap and aborts the editor
-	## (KERN_INVALID_ADDRESS / SIGABRT). The initial-delay constant is the
-	## settle margin; locking it in keeps a future "0-delay would be snappier"
-	## refactor from re-introducing the crash.
-	assert_true(McpDockScript.CLIENT_STATUS_REFRESH_INITIAL_DELAY_SEC >= 1.0,
+	## Regression for #233 — locks the settle margin so a "0-delay would be
+	## snappier" refactor can't silently re-introduce the self-update crash.
+	assert_true(McpDockScript.CLIENT_STATUS_REFRESH_INITIAL_DELAY_MSEC >= 1000,
 		"Initial refresh delay must be at least 1s — empirical hot-reload settle")
 
 

--- a/tests/unit/test_editor_focus_refocus.py
+++ b/tests/unit/test_editor_focus_refocus.py
@@ -51,12 +51,31 @@ def test_clients_window_open_requests_nonblocking_refresh() -> None:
 
 
 def test_initial_paint_requests_async_status_refresh() -> None:
-    """Cold editor open should still populate client dots without waiting for focus-in."""
+    """Cold editor open should still populate client dots without waiting for focus-in.
+
+    The refresh is deferred past Godot's GDScript hot-reload settle window (issue
+    #233 — self-update path crashes if the worker fires while strategy bytecode
+    is mid-swap), but ``_schedule_initial_client_status_refresh`` ultimately calls
+    ``_request_client_status_refresh(true)`` so the dock populates without
+    requiring a focus-in event. Locking in the call site here so a future
+    refactor doesn't accidentally drop the auto-spawn entirely.
+    """
 
     source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
     build_block = source.split("func _build_ui() -> void:", 1)[1].split("\n\nfunc ", 1)[0]
+    assert "_schedule_initial_client_status_refresh()" in build_block, (
+        "_build_ui must schedule the initial refresh"
+    )
 
-    assert "_request_client_status_refresh.call_deferred(true)" in build_block
+    helper_block = source.split(
+        "func _schedule_initial_client_status_refresh() -> void:", 1
+    )[1].split("\n\nfunc ", 1)[0]
+    assert "_request_client_status_refresh(true)" in helper_block, (
+        "Helper must ultimately call the force-refresh path"
+    )
+    assert "CLIENT_STATUS_REFRESH_INITIAL_DELAY_SEC" in helper_block, (
+        "Helper must defer past hot-reload settle window"
+    )
 
 
 def test_worker_uses_main_thread_probe_snapshot_for_cli_paths() -> None:

--- a/tests/unit/test_editor_focus_refocus.py
+++ b/tests/unit/test_editor_focus_refocus.py
@@ -51,14 +51,10 @@ def test_clients_window_open_requests_nonblocking_refresh() -> None:
 
 
 def test_initial_paint_requests_async_status_refresh() -> None:
-    """Cold editor open should still populate client dots without waiting for focus-in.
+    """Cold editor open populates client dots via the deferred helper (#233).
 
-    The refresh is deferred past Godot's GDScript hot-reload settle window (issue
-    #233 — self-update path crashes if the worker fires while strategy bytecode
-    is mid-swap), but ``_schedule_initial_client_status_refresh`` ultimately calls
-    ``_request_client_status_refresh(true)`` so the dock populates without
-    requiring a focus-in event. Locking in the call site here so a future
-    refactor doesn't accidentally drop the auto-spawn entirely.
+    Asserts the call chain end-to-end so a future refactor can't accidentally
+    drop the auto-spawn or remove the hot-reload settle delay.
     """
 
     source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
@@ -73,7 +69,7 @@ def test_initial_paint_requests_async_status_refresh() -> None:
     assert "_request_client_status_refresh(true)" in helper_block, (
         "Helper must ultimately call the force-refresh path"
     )
-    assert "CLIENT_STATUS_REFRESH_INITIAL_DELAY_SEC" in helper_block, (
+    assert "CLIENT_STATUS_REFRESH_INITIAL_DELAY_MSEC" in helper_block, (
         "Helper must defer past hot-reload settle window"
     )
 


### PR DESCRIPTION
## Summary

**Interim heuristic stopgap** for #233 — editor crashes (`SIGABRT` in worker thread) on the dock's self-update path immediately after the new plugin loads. Reproduced in the wild minutes after v2.1.0 was tagged: real user updated v2.0.1 → v2.1.0, install completed, editor died with:

```
Exception: EXC_BAD_ACCESS / SIGABRT
Subtype:   KERN_INVALID_ADDRESS at 0x18
Thread:    VBoxContainer(McpDock)::_run_client_status_refresh_worker
Stack:     Thread::_start_func
           → CallableCustomBind::call
           → 4× nested GDScriptFunction::call
           → __abort
```

> ⚠️ **Caveat (not bulletproof):** the 1.5s delay is empirical, not derived from any Godot signal that confirms hot-reload completion. On a slow CI runner, a larger plugin tree, or a future Godot version that changes hot-reload timing, this race could resurface. **A deterministic fix is tracked in #235** (investigate `EditorFileSystem.script_classes_updated`, fall back to sync first refresh on main thread, or refactor strategies to share no GDScript state with the worker). This PR ships the timer-based fix because:
> - The observed crash repros at 100% on the affected user path
> - Every hour without a fix risks more user crashes
> - Investigating + verifying a deterministic gate takes meaningful effort
> - The timer is a defensible interim that takes us from 100% crash rate to "no observed crashes on tested systems"

## Root cause

The self-update flow extracts a release zip over `addons/godot_ai/` then toggles `set_plugin_enabled(false/true)`. Godot's GDScript hot-reload of the just-overwritten files is **lazy** — class registration runs to completion before enable returns, but bytecode replacement of arbitrary referenced scripts happens as those scripts are first dereferenced post-reload. The new dock's `_build_ui` was firing the auto-refresh worker via `call_deferred(true)` (next idle frame), and the worker walks deep into `_json_strategy.check_status` / `client_configurator.*` — exactly the scripts still mid-swap.

This is the residual leg of #229 that #230 and #232 didn't close:

| PR | Side | What it fixed |
|---|---|---|
| #230 | both | Per-client `clients/<name>.gd` Callables → data-only |
| #232 | **disable** | Worker draining via `_exit_tree.wait_to_finish` |
| **this** | **enable** | New worker spawn deferred past hot-reload settle |

## Fix

Replace the immediate `_request_client_status_refresh.call_deferred(true)` in `_build_ui` with a 1500ms timer-deferred call. Empirical settle is <500ms; 1500ms is 3× margin.

```gdscript
func _schedule_initial_client_status_refresh() -> void:
    await get_tree().create_timer(CLIENT_STATUS_REFRESH_INITIAL_DELAY_MSEC / 1000.0).timeout
    if _client_status_refresh_shutdown_requested:
        return
    if not is_inside_tree():
        return
    _request_client_status_refresh(true)
```

## Why a signal-based gate wasn't used (yet)

- `is_scanning()` / `filesystem_changed` flip back to false **before** the bytecode swap completes — confirmed empirically in [#229's discussion](https://github.com/hi-godot/godot-ai/issues/229#issuecomment-4323327346).
- `NOTIFICATION_APPLICATION_FOCUS_IN` doesn't fire on plugin reload (editor stays focused through the toggle), so dropping the auto-spawn entirely would leave the dock unpopulated.
- `EditorFileSystem.script_classes_updated` is the most promising deterministic signal but is **unverified** to bracket the hot-reload window — see #235 for the investigation plan.

A timer is the only mechanism that actually works in observed conditions today. #235 tracks replacing it.

## Test surface

- **Updated** Python test `test_initial_paint_requests_async_status_refresh` — locks in the new contract: `_build_ui` must call the helper, which must reference the delay constant and ultimately call `_request_client_status_refresh(true)`.
- **Added** GDScript regression test `test_initial_refresh_delay_is_past_typical_hot_reload_settle` — asserts the constant is ≥1000ms so a "0-delay would be snappier" refactor can't silently re-introduce the crash.
- 911/914 GDScript suite, 652 pytest, ruff clean.

## Test plan

- [ ] CI: pytest + ruff (Linux/macOS/Windows × py3.11/3.13)
- [ ] CI: GDScript suite via `script/ci-godot-tests` on all three OSes
- [ ] Manual: install pre-#233 plugin (e.g. v2.1.0), trigger an in-place update via the dock — should now complete without crash. The dock briefly shows cached state for ~1.5s before the dots refresh.

## Follow-up
- **#235** tracks the deterministic replacement for this timer-based fix.
