### PR TITLE
feat(logs): logs_read(source=editor) + share helpers with game logger (#231)

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -29,7 +29,7 @@ not the MCP tool names.
 | `script_create` / `script_attach` / `script_patch` | Create, attach, anchor-edit GDScript files |
 | `project_run` | Play the project (autosave persists in-memory MCP edits unless `autosave=False`) |
 | `test_run` | Run GDScript test suites in the editor |
-| `logs_read` | Read plugin / game / combined log buffers (game source needs `_mcp_game_helper` autoload) |
+| `logs_read` | Read plugin / game / editor / combined log buffers. `source="editor"` surfaces parse errors + @tool/EditorPlugin runtime errors + push_error/push_warning (Godot 4.5+, filtered to user .gd/.cs) — use this when the editor's Output panel shows red lines but `logs_read` returned nothing |
 | `editor_screenshot` | Capture editor viewport, cinematic camera, or running game framebuffer |
 | `editor_reload_plugin` | Reload the plugin and wait for reconnect (server must be external) |
 | `animation_create` | Create an Animation clip (auto-creates AnimationPlayer + library if missing) |

--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -8,13 +8,15 @@ var _log_buffer: McpLogBuffer
 var _connection: Connection
 var _debugger_plugin: McpDebuggerPlugin
 var _game_log_buffer: GameLogBuffer
+var _editor_log_buffer: EditorLogBuffer
 
 
-func _init(log_buffer: McpLogBuffer, connection: Connection = null, debugger_plugin: McpDebuggerPlugin = null, game_log_buffer: GameLogBuffer = null) -> void:
+func _init(log_buffer: McpLogBuffer, connection: Connection = null, debugger_plugin: McpDebuggerPlugin = null, game_log_buffer: GameLogBuffer = null, editor_log_buffer: EditorLogBuffer = null) -> void:
 	_log_buffer = log_buffer
 	_connection = connection
 	_debugger_plugin = debugger_plugin
 	_game_log_buffer = game_log_buffer
+	_editor_log_buffer = editor_log_buffer
 
 
 func get_editor_state(_params: Dictionary) -> Dictionary:
@@ -43,7 +45,7 @@ func get_selection(_params: Dictionary) -> Dictionary:
 	return {"data": {"selected_paths": paths, "count": paths.size()}}
 
 
-const VALID_LOG_SOURCES := ["plugin", "game", "all"]
+const VALID_LOG_SOURCES := ["plugin", "game", "editor", "all"]
 
 
 func get_logs(params: Dictionary) -> Dictionary:
@@ -56,7 +58,7 @@ func get_logs(params: Dictionary) -> Dictionary:
 	if not source in VALID_LOG_SOURCES:
 		return McpErrorCodes.make(
 			McpErrorCodes.INVALID_PARAMS,
-			"Invalid source '%s' — use 'plugin', 'game', or 'all'" % source,
+			"Invalid source '%s' — use 'plugin', 'game', 'editor', or 'all'" % source,
 		)
 
 	match source:
@@ -64,6 +66,8 @@ func get_logs(params: Dictionary) -> Dictionary:
 			return _get_plugin_logs(count, offset)
 		"game":
 			return _get_game_logs(count, offset)
+		"editor":
+			return _get_editor_logs(count, offset)
 		"all":
 			return _get_all_logs(count, offset)
 	return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Unreachable")
@@ -115,14 +119,49 @@ func _get_game_logs(count: int, offset: int) -> Dictionary:
 	}
 
 
+func _get_editor_logs(count: int, offset: int) -> Dictionary:
+	## Editor-process script errors (parse errors, @tool runtime errors,
+	## EditorPlugin errors, push_error/push_warning). Captured by
+	## editor_logger.gd via OS.add_logger and gated on Godot 4.5+; on older
+	## engines or before plugin enable the buffer is null/empty and we
+	## return an empty page so callers can poll unconditionally.
+	if _editor_log_buffer == null:
+		return {
+			"data": {
+				"source": "editor",
+				"lines": [],
+				"total_count": 0,
+				"returned_count": 0,
+				"offset": offset,
+				"dropped_count": 0,
+			}
+		}
+	var page := _editor_log_buffer.get_range(offset, count)
+	return {
+		"data": {
+			"source": "editor",
+			"lines": page,
+			"total_count": _editor_log_buffer.total_count(),
+			"returned_count": page.size(),
+			"offset": offset,
+			"dropped_count": _editor_log_buffer.dropped_count(),
+		}
+	}
+
+
 func _get_all_logs(count: int, offset: int) -> Dictionary:
 	## Plugin lines have no timestamp, so we can't merge chronologically.
-	## Concatenate plugin then game and apply the offset/count window over
-	## the combined list. The per-line `source` field tells callers where
-	## each entry came from.
+	## Concatenate plugin → editor → game and apply the offset/count window
+	## over the combined list. The per-line `source` field tells callers
+	## where each entry came from. Editor goes between plugin and game so
+	## script errors stay grouped near the plugin recv/send traffic that
+	## triggered them, with game runtime logs at the end.
 	var combined: Array[Dictionary] = []
 	for line in _log_buffer.get_recent(_log_buffer.total_count()):
 		combined.append({"source": "plugin", "level": "info", "text": line})
+	if _editor_log_buffer != null:
+		for entry in _editor_log_buffer.get_range(0, _editor_log_buffer.total_count()):
+			combined.append(entry)
 	if _game_log_buffer != null:
 		for entry in _game_log_buffer.get_range(0, _game_log_buffer.total_count()):
 			combined.append(entry)
@@ -135,6 +174,8 @@ func _get_all_logs(count: int, offset: int) -> Dictionary:
 	if _game_log_buffer != null:
 		run_id = _game_log_buffer.run_id()
 		dropped = _game_log_buffer.dropped_count()
+	if _editor_log_buffer != null:
+		dropped += _editor_log_buffer.dropped_count()
 	return {
 		"data": {
 			"source": "all",

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -4,6 +4,13 @@ extends EditorPlugin
 const GAME_HELPER_AUTOLOAD_NAME := "_mcp_game_helper"
 const GAME_HELPER_AUTOLOAD_PATH := "res://addons/godot_ai/runtime/game_helper.gd"
 
+## Editor-process Logger subclass — captures parse errors, @tool runtime
+## errors, and push_error/push_warning so the LLM can read them via
+## `logs_read(source="editor")`. Loaded dynamically because
+## `extends Logger` requires Godot 4.5+; gating on ClassDB at registration
+## time keeps the plugin loadable on 4.4. See issue #231.
+const EDITOR_LOGGER_PATH := "res://addons/godot_ai/runtime/editor_logger.gd"
+
 ## EditorSettings keys used to remember which server process the plugin
 ## spawned — survives editor restarts, lets a later editor session adopt
 ## and manage a server it didn't spawn itself. See #135.
@@ -32,6 +39,11 @@ var _connection: Connection
 var _dispatcher: McpDispatcher
 var _log_buffer: McpLogBuffer
 var _game_log_buffer: GameLogBuffer
+var _editor_log_buffer: EditorLogBuffer
+## Untyped — script extends Godot 4.5+'s Logger class, loaded via load() so
+## the plugin still parses on 4.4. Null on Godot < 4.5 or before
+## `_attach_editor_logger` runs; "attached" state IS exactly "non-null".
+var _editor_logger
 var _dock: McpDock
 var _server_pid := -1
 var _handlers: Array = []  # prevent GC of RefCounted handlers
@@ -77,6 +89,8 @@ func _enter_tree() -> void:
 
 	_log_buffer = McpLogBuffer.new()
 	_game_log_buffer = GameLogBuffer.new()
+	_editor_log_buffer = EditorLogBuffer.new()
+	_attach_editor_logger()
 	_dispatcher = McpDispatcher.new(_log_buffer)
 
 	_connection = Connection.new()
@@ -86,7 +100,7 @@ func _enter_tree() -> void:
 	add_debugger_plugin(_debugger_plugin)
 	_ensure_game_helper_autoload()
 
-	var editor_handler := EditorHandler.new(_log_buffer, _connection, _debugger_plugin, _game_log_buffer)
+	var editor_handler := EditorHandler.new(_log_buffer, _connection, _debugger_plugin, _game_log_buffer, _editor_log_buffer)
 	var scene_handler := SceneHandler.new(_connection)
 	var node_handler := NodeHandler.new(get_undo_redo())
 	var project_handler := ProjectHandler.new(_connection)
@@ -282,9 +296,16 @@ func _exit_tree() -> void:
 		remove_debugger_plugin(_debugger_plugin)
 		_debugger_plugin = null
 
+	## Detach the editor logger BEFORE nulling the buffer. After remove_logger
+	## returns, Godot guarantees no further virtual calls — so the logger's
+	## next access to `_buffer` (if any in flight) lands on a still-live
+	## ref-counted buffer, not a freed one.
+	_detach_editor_logger()
+
 	_dispatcher = null
 	_log_buffer = null
 	_game_log_buffer = null
+	_editor_log_buffer = null
 
 	_stop_server()
 	## Symmetric with prepare_for_update_reload: the static guard persists
@@ -295,6 +316,36 @@ func _exit_tree() -> void:
 	## deterministic, nothing is left to adopt and the reload hangs.
 	_server_started_this_session = false
 	print("MCP | plugin unloaded")
+
+
+## Attach editor_logger.gd as a Godot logger so editor-process script
+## errors (parse errors, @tool runtime errors, EditorPlugin errors,
+## push_error/push_warning) flow into _editor_log_buffer for
+## logs_read(source="editor"). Logger subclassing is 4.5+ only; the
+## ClassDB gate keeps the plugin loadable on 4.4 with no-op editor logs
+## (the buffer stays empty, logs_read returns no entries).
+##
+## Limitation called out in the issue: parse errors fired *before* the
+## plugin's _enter_tree (e.g. during the editor's initial filesystem
+## scan, or for scripts that fail on first project open) happen before
+## add_logger is called and are not captured. There's no public API to
+## drain the editor's already-emitted error history; rescanning the
+## file would re-emit them but at the cost of disrupting the user's
+## editing state, so we accept the gap.
+func _attach_editor_logger() -> void:
+	if not (ClassDB.class_exists("Logger") and OS.has_method("add_logger")):
+		return
+	var logger_script := load(EDITOR_LOGGER_PATH)
+	if logger_script == null:
+		return
+	_editor_logger = logger_script.new(_editor_log_buffer)
+	OS.call("add_logger", _editor_logger)
+
+
+func _detach_editor_logger() -> void:
+	if _editor_logger != null and OS.has_method("remove_logger"):
+		OS.call("remove_logger", _editor_logger)
+	_editor_logger = null
 
 
 ## Register the game-side autoload on plugin enable. Runs the helper inside

--- a/plugin/addons/godot_ai/runtime/editor_logger.gd
+++ b/plugin/addons/godot_ai/runtime/editor_logger.gd
@@ -50,12 +50,13 @@ func _log_error(
 	error_type: int,
 	script_backtraces: Array,
 ) -> void:
-	## LogBacktrace.resolve_error coalesces the per-virtual-arg shape
-	## (level mapping, rationale-vs-code fallback, backtrace-driven source
-	## remap) so editor_logger and game_logger don't drift on their own
-	## copies of those rules. Filtering is editor-only — game_logger keeps
-	## everything — so we apply it here against the resolved path.
 	if _buffer == null:
+		return
+	## Cheap reject for the firehose: when `file` is already non-user (the
+	## bulk of editor-internal C++ chatter) and there's no backtrace to
+	## remap from, the resolved path can only stay non-user — drop without
+	## paying for resolve_error's call frame + dict allocation.
+	if not _is_user_script(file) and script_backtraces.is_empty():
 		return
 	var resolved := LogBacktrace.resolve_error(
 		function, file, line, code, rationale, error_type, script_backtraces,

--- a/plugin/addons/godot_ai/runtime/editor_logger.gd
+++ b/plugin/addons/godot_ai/runtime/editor_logger.gd
@@ -1,0 +1,88 @@
+@tool
+extends Logger
+
+## Editor-process Logger subclass.
+##
+## NOTE: deliberately no `class_name` — `extends Logger` requires the Logger
+## class which Godot only exposes from 4.5+. plugin.gd loads this script
+## dynamically via load() after gating on
+## ClassDB.class_exists("Logger"), so the script never gets parsed on
+## older engines. Registered via OS.add_logger() from plugin.gd::_enter_tree
+## so we can intercept editor-process script errors — parse errors, @tool
+## runtime errors, EditorPlugin errors, push_error/push_warning — and
+## surface them via `logs_read(source="editor")`. Without this, the LLM
+## sees nothing in `logs_read` while the same errors show in red lines in
+## Godot's Output panel.
+##
+## Why only `_log_error` and not `_log_message`:
+## `_log_message(msg, error)` covers print() and printerr(), which is the
+## firehose path — running editors print thousands of internal info lines
+## a session. The issue (#231) explicitly asks to filter so the buffer
+## isn't drowned. Errors and warnings flow through `_log_error` (parse
+## errors, push_error/push_warning, runtime errors), which is what
+## debugging callers actually need. If we discover @tool printerr() is a
+## valuable source later, _log_message can be added behind the same filter.
+##
+## Logger virtuals can be called from any thread (e.g. async script
+## loaders push parse errors off the main thread). EditorLogBuffer is
+## mutex-protected so we can append directly without an intermediate queue.
+
+const ADDON_PATH_MARKER := "/addons/godot_ai/"
+
+## EditorLogBuffer — untyped because this script is loaded dynamically and
+## EditorLogBuffer's class_name isn't yet registered on the parser at the
+## time `extends Logger` resolves. Constructor-injected so the hot path
+## doesn't need a per-call null check.
+var _buffer
+
+
+func _init(buffer = null) -> void:
+	_buffer = buffer
+
+
+func _log_error(
+	function: String,
+	file: String,
+	line: int,
+	code: String,
+	rationale: String,
+	_editor_notify: bool,
+	error_type: int,
+	script_backtraces: Array,
+) -> void:
+	## LogBacktrace.resolve_error coalesces the per-virtual-arg shape
+	## (level mapping, rationale-vs-code fallback, backtrace-driven source
+	## remap) so editor_logger and game_logger don't drift on their own
+	## copies of those rules. Filtering is editor-only — game_logger keeps
+	## everything — so we apply it here against the resolved path.
+	if _buffer == null:
+		return
+	var resolved := LogBacktrace.resolve_error(
+		function, file, line, code, rationale, error_type, script_backtraces,
+	)
+	if not _is_user_script(resolved.path):
+		return
+	if _is_in_godot_ai_addon(resolved.path):
+		return
+	_buffer.append(resolved.level, resolved.message, resolved.path, resolved.line, resolved.function)
+
+
+## Predicate broken out so tests can drive the path-filter logic without
+## constructing real Logger calls.
+static func _is_user_script(path: String) -> bool:
+	if path.is_empty():
+		return false
+	## Match .gd / .cs (case-insensitively to handle .GD on case-insensitive
+	## filesystems). C# scripts compile elsewhere but the parser path can
+	## still surface .cs files for assembly load failures.
+	var lower := path.to_lower()
+	return lower.ends_with(".gd") or lower.ends_with(".cs")
+
+
+## Path-substring check works for both `res://addons/godot_ai/foo.gd` and
+## globalized absolute paths (`/Users/.../addons/godot_ai/foo.gd`) that
+## Godot can also report depending on where the error originated.
+static func _is_in_godot_ai_addon(path: String) -> bool:
+	if path.begins_with("res://addons/godot_ai/"):
+		return true
+	return path.find(ADDON_PATH_MARKER) >= 0

--- a/plugin/addons/godot_ai/runtime/editor_logger.gd.uid
+++ b/plugin/addons/godot_ai/runtime/editor_logger.gd.uid
@@ -1,0 +1,1 @@
+uid://cfanpykurwnvh

--- a/plugin/addons/godot_ai/runtime/game_logger.gd
+++ b/plugin/addons/godot_ai/runtime/game_logger.gd
@@ -37,34 +37,22 @@ func _log_error(
 	error_type: int,
 	script_backtraces: Array,
 ) -> void:
-	## error_type: 0 = ERROR (push_error), 1 = WARNING (push_warning),
-	## 2 = SCRIPT, 3 = SHADER. Map warnings to "warn" so callers can filter
-	## without consulting the enum.
-	##
-	## Single-arg push_error("msg") / push_warning("msg") stores the user's
-	## string in `code` and leaves `rationale` empty; the two-arg form
-	## push_error(code, rationale) populates both. Fall back to `code` when
-	## `rationale` is missing — otherwise the user's message is silently lost.
-	##
-	## `file`/`line` for push_error/push_warning point into Godot's own C++
-	## source (core/variant/variant_utility.cpp). Prefer the first frame of
-	## `script_backtraces` so the capture shows the caller's GDScript location.
-	var level := "warn" if error_type == 1 else "error"
-	var message := rationale if not rationale.is_empty() else code
-	var src_file := file
-	var src_line := line
-	var src_function := function
-	for bt in script_backtraces:
-		if bt != null and bt.get_frame_count() > 0:
-			src_file = bt.get_frame_file(0)
-			src_line = bt.get_frame_line(0)
-			src_function = bt.get_frame_function(0)
-			break
+	## LogBacktrace.resolve_error coalesces the per-virtual-arg shape
+	## (level mapping, rationale-vs-code fallback, backtrace-driven source
+	## remap) — the same logic editor_logger needs. Format `loc` from the
+	## resolved fields so the queued text carries a human-readable source
+	## suffix; editor_logger uses the structured fields directly instead.
+	var resolved := LogBacktrace.resolve_error(
+		function, file, line, code, rationale, error_type, script_backtraces,
+	)
+	var src_file: String = resolved.path
+	var src_line: int = resolved.line
+	var src_function: String = resolved.function
 	var loc := ""
 	if not src_file.is_empty():
 		loc = "%s:%d @ %s" % [src_file, src_line, src_function] if not src_function.is_empty() else "%s:%d" % [src_file, src_line]
-	var text := "%s (%s)" % [message, loc] if not loc.is_empty() else message
-	_append(level, text)
+	var text: String = "%s (%s)" % [resolved.message, loc] if not loc.is_empty() else resolved.message
+	_append(resolved.level, text)
 
 
 func _append(level: String, text: String) -> void:

--- a/plugin/addons/godot_ai/runtime/game_logger.gd
+++ b/plugin/addons/godot_ai/runtime/game_logger.gd
@@ -37,20 +37,16 @@ func _log_error(
 	error_type: int,
 	script_backtraces: Array,
 ) -> void:
-	## LogBacktrace.resolve_error coalesces the per-virtual-arg shape
-	## (level mapping, rationale-vs-code fallback, backtrace-driven source
-	## remap) — the same logic editor_logger needs. Format `loc` from the
-	## resolved fields so the queued text carries a human-readable source
-	## suffix; editor_logger uses the structured fields directly instead.
+	## EngineDebugger's payload shape is `[level, text]` — the source
+	## location has nowhere structured to land for the game side, so we
+	## inline it into `text`. editor_logger keeps the resolved fields
+	## as structured columns instead.
 	var resolved := LogBacktrace.resolve_error(
 		function, file, line, code, rationale, error_type, script_backtraces,
 	)
-	var src_file: String = resolved.path
-	var src_line: int = resolved.line
-	var src_function: String = resolved.function
 	var loc := ""
-	if not src_file.is_empty():
-		loc = "%s:%d @ %s" % [src_file, src_line, src_function] if not src_function.is_empty() else "%s:%d" % [src_file, src_line]
+	if not resolved.path.is_empty():
+		loc = "%s:%d @ %s" % [resolved.path, resolved.line, resolved.function] if not resolved.function.is_empty() else "%s:%d" % [resolved.path, resolved.line]
 	var text: String = "%s (%s)" % [resolved.message, loc] if not loc.is_empty() else resolved.message
 	_append(resolved.level, text)
 

--- a/plugin/addons/godot_ai/testing/stub_backtrace.gd
+++ b/plugin/addons/godot_ai/testing/stub_backtrace.gd
@@ -1,0 +1,40 @@
+@tool
+class_name StubBacktrace
+extends RefCounted
+
+## Minimal duck-typed stand-in for Godot's built-in `ScriptBacktrace`
+## class (the type of `script_backtraces[i]` entries inside `_log_error`).
+## Mirrors the getter surface `_log_error`'s `script_backtraces` argument
+## exposes (`get_frame_count` + per-frame file/line/function), so test
+## suites for `editor_logger` and `game_logger` can exercise the
+## backtrace-remapping path without a live script execution — Godot
+## doesn't expose a constructor for the real ScriptBacktrace.
+##
+## Single-frame is enough: both loggers only consult `script_backtraces[0]`'s
+## frame 0 (via `LogBacktrace.resolve_error`).
+
+var _file: String
+var _line: int
+var _function: String
+
+
+func _init(file: String, line: int, function: String) -> void:
+	_file = file
+	_line = line
+	_function = function
+
+
+func get_frame_count() -> int:
+	return 1
+
+
+func get_frame_file(_idx: int) -> String:
+	return _file
+
+
+func get_frame_line(_idx: int) -> int:
+	return _line
+
+
+func get_frame_function(_idx: int) -> String:
+	return _function

--- a/plugin/addons/godot_ai/testing/stub_backtrace.gd
+++ b/plugin/addons/godot_ai/testing/stub_backtrace.gd
@@ -10,8 +10,8 @@ extends RefCounted
 ## backtrace-remapping path without a live script execution — Godot
 ## doesn't expose a constructor for the real ScriptBacktrace.
 ##
-## Single-frame is enough: both loggers only consult `script_backtraces[0]`'s
-## frame 0 (via `LogBacktrace.resolve_error`).
+## Single-frame is enough: both loggers only consult the first non-empty
+## frame of `script_backtraces` (via `LogBacktrace.resolve_error`).
 
 var _file: String
 var _line: int

--- a/plugin/addons/godot_ai/testing/stub_backtrace.gd.uid
+++ b/plugin/addons/godot_ai/testing/stub_backtrace.gd.uid
@@ -1,0 +1,1 @@
+uid://d2xpmw5kvtjr7

--- a/plugin/addons/godot_ai/utils/editor_log_buffer.gd
+++ b/plugin/addons/godot_ai/utils/editor_log_buffer.gd
@@ -57,7 +57,7 @@ func get_recent(count: int) -> Array[Dictionary]:
 	## Single-lock so the size we compute `start` from can't race against
 	## a concurrent append between the size read and the slice copy.
 	_mutex.lock()
-	var size := _storage.size()
+	var size := _total_count_unlocked()
 	var start := maxi(0, size - count)
 	var out := _get_range_unlocked(start, size - start)
 	_mutex.unlock()
@@ -66,21 +66,21 @@ func get_recent(count: int) -> Array[Dictionary]:
 
 func total_count() -> int:
 	_mutex.lock()
-	var n := _storage.size()
+	var n := _total_count_unlocked()
 	_mutex.unlock()
 	return n
 
 
 func dropped_count() -> int:
 	_mutex.lock()
-	var n := _dropped_count
+	var n := _dropped_count_unlocked()
 	_mutex.unlock()
 	return n
 
 
 func clear() -> int:
 	_mutex.lock()
-	var n := _storage.size()
+	var n := _total_count_unlocked()
 	_clear_storage()
 	_mutex.unlock()
 	return n

--- a/plugin/addons/godot_ai/utils/editor_log_buffer.gd
+++ b/plugin/addons/godot_ai/utils/editor_log_buffer.gd
@@ -1,0 +1,86 @@
+@tool
+class_name EditorLogBuffer
+extends StructuredLogRing
+
+## Ring buffer for editor-process script errors and warnings (parse errors,
+## @tool runtime errors, EditorPlugin errors, push_error/push_warning) captured
+## by editor_logger.gd's Logger subclass.
+##
+## Smaller cap than GameLogBuffer (500 vs 2000) — the editor only emits errors,
+## not the full println firehose a game can produce. No run_id rotation: editor
+## errors persist across project_run cycles (they're about *editing* state, not
+## about the playing game).
+##
+## Mutex-protected because Logger virtuals can fire from any thread (e.g.
+## async script-loader threads emitting parse errors), and the buffer is
+## read on the main thread by EditorHandler.get_logs. Each public method
+## wraps the base ring's lockless helpers in `_mutex.lock()/unlock()` —
+## the base stays lockless so GameLogBuffer's hot path doesn't pay an
+## unused mutex cost.
+##
+## Entry shape: {source: "editor", level: "info"|"warn"|"error",
+##   text, path, line, function} — `path/line/function` may be empty/zero
+## when the source location wasn't recoverable (e.g. printerr from a
+## thread without a script context).
+
+const MAX_LINES := 500
+
+var _mutex := Mutex.new()
+
+
+func _init() -> void:
+	super._init(MAX_LINES)
+
+
+func append(level: String, text: String, path: String = "", line: int = 0, function: String = "") -> void:
+	var entry := {
+		"source": "editor",
+		"level": _coerce_level(level),
+		"text": text,
+		"path": path,
+		"line": line,
+		"function": function,
+	}
+	_mutex.lock()
+	_append_entry(entry)
+	_mutex.unlock()
+
+
+func get_range(offset: int, count: int) -> Array[Dictionary]:
+	_mutex.lock()
+	var out := _get_range_unlocked(offset, count)
+	_mutex.unlock()
+	return out
+
+
+func get_recent(count: int) -> Array[Dictionary]:
+	## Single-lock so the size we compute `start` from can't race against
+	## a concurrent append between the size read and the slice copy.
+	_mutex.lock()
+	var size := _storage.size()
+	var start := maxi(0, size - count)
+	var out := _get_range_unlocked(start, size - start)
+	_mutex.unlock()
+	return out
+
+
+func total_count() -> int:
+	_mutex.lock()
+	var n := _storage.size()
+	_mutex.unlock()
+	return n
+
+
+func dropped_count() -> int:
+	_mutex.lock()
+	var n := _dropped_count
+	_mutex.unlock()
+	return n
+
+
+func clear() -> int:
+	_mutex.lock()
+	var n := _storage.size()
+	_clear_storage()
+	_mutex.unlock()
+	return n

--- a/plugin/addons/godot_ai/utils/editor_log_buffer.gd.uid
+++ b/plugin/addons/godot_ai/utils/editor_log_buffer.gd.uid
@@ -1,0 +1,1 @@
+uid://b6ynms0856hhq

--- a/plugin/addons/godot_ai/utils/game_log_buffer.gd
+++ b/plugin/addons/godot_ai/utils/game_log_buffer.gd
@@ -1,94 +1,43 @@
 @tool
 class_name GameLogBuffer
-extends RefCounted
+extends StructuredLogRing
 
 ## Ring buffer for game-process log lines (print, push_warning, push_error)
 ## ferried back from the playing game over the EngineDebugger channel.
 ##
-## Larger cap than McpLogBuffer because games can be noisy. Each entry is a
-## structured dict so callers can filter by level. `run_id` rotates each time
-## clear_for_new_run() fires (called on the game's mcp:hello boot beacon),
-## giving agents a stable cursor for "lines since this play started".
+## Larger cap than EditorLogBuffer because games can be noisy. `run_id`
+## rotates each time clear_for_new_run() fires (called on the game's
+## mcp:hello boot beacon), giving agents a stable cursor for "lines since
+## this play started".
 ##
-## Implemented as a head-indexed circular buffer: `_storage` stays at most
-## MAX_LINES long, and once full, new appends overwrite the oldest slot at
-## `_head`. This keeps append O(1) on overflow — the previous `slice()`
-## approach reallocated the full retained array on every drop, which a very
-## chatty game would pay for thousands of times per second.
+## Single-threaded — game_helper.gd drains its logger from `_process` and
+## calls `append` from the main thread, so this subclass can use the base
+## ring's lockless reads/writes directly.
 
 const MAX_LINES := 2000
-const VALID_LEVELS := ["info", "warn", "error"]
 
-var _storage: Array[Dictionary] = []
-## Next write position within `_storage`. While filling (before first
-## wrap) equals `_storage.size()`; once full, points at the oldest entry
-## (the one about to be overwritten).
-var _head := 0
 var _run_id := ""
-var _dropped_count := 0
+
+
+func _init() -> void:
+	super._init(MAX_LINES)
 
 
 func append(level: String, text: String) -> void:
-	## Coerce unknown levels to "info" so a misbehaving sender can't poison
-	## downstream filters with arbitrary strings.
-	var safe_level := level if level in VALID_LEVELS else "info"
-	var entry := {"source": "game", "level": safe_level, "text": text}
-	if _storage.size() < MAX_LINES:
-		_storage.append(entry)
-		_head = _storage.size() % MAX_LINES
-		return
-	## Full — overwrite oldest in place, advance head, count the drop.
-	_storage[_head] = entry
-	_head = (_head + 1) % MAX_LINES
-	_dropped_count += 1
-
-
-func get_range(offset: int, count: int) -> Array[Dictionary]:
-	var size := _storage.size()
-	var start := maxi(0, offset)
-	var stop := mini(size, start + count)
-	var out: Array[Dictionary] = []
-	for i in range(start, stop):
-		out.append(_storage[_logical_to_physical(i)])
-	return out
-
-
-func get_recent(count: int) -> Array[Dictionary]:
-	var size := _storage.size()
-	var start := maxi(0, size - count)
-	return get_range(start, size - start)
+	_append_entry({"source": "game", "level": _coerce_level(level), "text": text})
 
 
 ## Rotate the run identifier and drop all buffered entries. Called when the
 ## game-side autoload sends its mcp:hello beacon, marking a fresh play cycle.
 ## Returns the new run_id.
 func clear_for_new_run() -> String:
-	_storage.clear()
-	_head = 0
-	_dropped_count = 0
+	_clear_storage()
 	_run_id = _generate_run_id()
 	return _run_id
 
 
-func total_count() -> int:
-	return _storage.size()
-
-
 func run_id() -> String:
 	return _run_id
-
-
-func dropped_count() -> int:
-	return _dropped_count
-
-
-## Translate a logical index (0 = oldest retained) to a physical
-## `_storage` slot. Before the first wrap, storage-order is
-## logical-order. After wrapping, the oldest entry lives at `_head`.
-func _logical_to_physical(logical: int) -> int:
-	if _storage.size() < MAX_LINES:
-		return logical
-	return (_head + logical) % MAX_LINES
 
 
 static func _generate_run_id() -> String:

--- a/plugin/addons/godot_ai/utils/log_backtrace.gd
+++ b/plugin/addons/godot_ai/utils/log_backtrace.gd
@@ -1,0 +1,63 @@
+@tool
+class_name LogBacktrace
+extends RefCounted
+
+## Helpers for interpreting Godot's `_log_error` virtual arguments.
+## (Named `LogBacktrace`, not `ScriptBacktrace`, because Godot 4.5+ ships
+## a built-in `ScriptBacktrace` class — the type of `script_backtraces[i]`
+## entries — and class_name'ing ours the same would collide.)
+##
+## Both `editor_logger.gd` and `game_logger.gd` need to:
+##   - Map `error_type` (0=ERROR, 1=WARNING, 2=SCRIPT, 3=SHADER) to a
+##     two-bucket "error" / "warn" string so callers can filter without
+##     consulting the enum.
+##   - Fall back to `code` when `rationale` is empty — single-arg
+##     `push_error("msg")` leaves rationale empty and stuffs the user's
+##     string into `code`; without the fallback the user message is
+##     silently lost. The two-arg form `push_error(code, rationale)`
+##     populates both and rationale wins.
+##   - Remap the source location to the first frame of `script_backtraces[0]`
+##     when present. `push_error` / `push_warning` always report
+##     `file=core/variant/variant_utility.cpp`; the actual user GDScript
+##     caller is in the backtrace.
+##
+## Centralising the rules keeps the next push_error semantics shift
+## (already happened once between 4.5 and 4.6, see PR #78) a one-place
+## fix instead of a two-place hunt.
+
+
+## Coalesce the per-virtual-arg shape Godot hands `_log_error` into a
+## flat record. Always walks `script_backtraces` for the first non-empty
+## frame; loggers that need to filter by source path call this first and
+## then check the resolved `path` field.
+##
+## Returns: `{level, message, path, line, function}`
+##   - `level`: "error" or "warn" (warn iff `error_type == 1`).
+##   - `message`: `rationale` when non-empty, else `code`.
+##   - `path` / `line` / `function`: first backtrace frame when one is
+##     available; otherwise the original `file` / `line` / `function`.
+static func resolve_error(
+	function: String,
+	file: String,
+	line: int,
+	code: String,
+	rationale: String,
+	error_type: int,
+	script_backtraces: Array,
+) -> Dictionary:
+	var src_file := file
+	var src_line := line
+	var src_function := function
+	for bt in script_backtraces:
+		if bt != null and bt.get_frame_count() > 0:
+			src_file = bt.get_frame_file(0)
+			src_line = bt.get_frame_line(0)
+			src_function = bt.get_frame_function(0)
+			break
+	return {
+		"level": "warn" if error_type == 1 else "error",
+		"message": rationale if not rationale.is_empty() else code,
+		"path": src_file,
+		"line": src_line,
+		"function": src_function,
+	}

--- a/plugin/addons/godot_ai/utils/log_backtrace.gd
+++ b/plugin/addons/godot_ai/utils/log_backtrace.gd
@@ -3,9 +3,10 @@ class_name LogBacktrace
 extends RefCounted
 
 ## Helpers for interpreting Godot's `_log_error` virtual arguments.
-## (Named `LogBacktrace`, not `ScriptBacktrace`, because Godot 4.5+ ships
-## a built-in `ScriptBacktrace` class — the type of `script_backtraces[i]`
-## entries — and class_name'ing ours the same would collide.)
+## (Named `LogBacktrace`, not `ScriptBacktrace`: Godot ships a built-in
+## `ScriptBacktrace` class — the type of `script_backtraces[i]` entries
+## — so class_name'ing ours the same would collide. Verified against
+## the engine's `--doctool` output in 4.6.)
 ##
 ## Both `editor_logger.gd` and `game_logger.gd` need to:
 ##   - Map `error_type` (0=ERROR, 1=WARNING, 2=SCRIPT, 3=SHADER) to a
@@ -48,6 +49,9 @@ static func resolve_error(
 	var src_file := file
 	var src_line := line
 	var src_function := function
+	## First non-empty frame wins, not just `script_backtraces[0]` —
+	## chained errors can leave the leading entry empty with the actual
+	## user frame in `script_backtraces[1]`.
 	for bt in script_backtraces:
 		if bt != null and bt.get_frame_count() > 0:
 			src_file = bt.get_frame_file(0)

--- a/plugin/addons/godot_ai/utils/log_backtrace.gd.uid
+++ b/plugin/addons/godot_ai/utils/log_backtrace.gd.uid
@@ -1,0 +1,1 @@
+uid://b8t9kznr2pqxa

--- a/plugin/addons/godot_ai/utils/structured_log_ring.gd
+++ b/plugin/addons/godot_ai/utils/structured_log_ring.gd
@@ -72,12 +72,23 @@ func get_recent(count: int) -> Array[Dictionary]:
 	return _get_range_unlocked(start, size - start)
 
 
-func total_count() -> int:
+## Lockless accessors. Subclasses with a mutex use these under their lock
+## so the field reads stay encapsulated in the base instead of leaking
+## `_storage` / `_dropped_count` reach-through into the subclass.
+func _total_count_unlocked() -> int:
 	return _storage.size()
 
 
-func dropped_count() -> int:
+func _dropped_count_unlocked() -> int:
 	return _dropped_count
+
+
+func total_count() -> int:
+	return _total_count_unlocked()
+
+
+func dropped_count() -> int:
+	return _dropped_count_unlocked()
 
 
 ## Translate a logical index (0 = oldest retained) to a physical

--- a/plugin/addons/godot_ai/utils/structured_log_ring.gd
+++ b/plugin/addons/godot_ai/utils/structured_log_ring.gd
@@ -1,0 +1,104 @@
+@tool
+class_name StructuredLogRing
+extends RefCounted
+
+## Head-indexed circular buffer of structured log entries shared by
+## game_log_buffer and editor_log_buffer.
+##
+## Once `_max_lines` (set in subclass `_init`) is reached, new appends
+## overwrite the oldest slot at `_head`, keeping append O(1) on overflow
+## — the previous slice() approach reallocated the full retained array
+## on every drop, which a chatty game would pay for thousands of times
+## per second.
+##
+## Lockless. Subclasses needing thread-safety (editor_log_buffer is
+## written from any thread a Godot Logger virtual can fire on) wrap each
+## public method with their own Mutex around the `_*_unlocked` helpers.
+## Keeping the base lockless means the hot game-side path (single thread,
+## called from _process) doesn't pay an unused mutex cost.
+##
+## Entry shape is owned by subclasses — `_append_entry` takes a
+## ready-built Dictionary so each buffer can carry the fields it needs
+## (game: `source/level/text`; editor: adds `path/line/function`).
+
+const VALID_LEVELS := ["info", "warn", "error"]
+
+var _max_lines: int
+var _storage: Array[Dictionary] = []
+## Next write position within `_storage`. While filling (before first
+## wrap) equals `_storage.size()`; once full, points at the oldest entry
+## (the one about to be overwritten).
+var _head := 0
+var _dropped_count := 0
+
+
+func _init(max_lines: int) -> void:
+	_max_lines = max_lines
+
+
+## Append `entry` to the ring, evicting the oldest slot when full.
+## Subclasses build the dict with their per-source shape and pass it in.
+func _append_entry(entry: Dictionary) -> void:
+	if _storage.size() < _max_lines:
+		_storage.append(entry)
+		_head = _storage.size() % _max_lines
+		return
+	## Full — overwrite oldest in place, advance head, count the drop.
+	_storage[_head] = entry
+	_head = (_head + 1) % _max_lines
+	_dropped_count += 1
+
+
+## Lockless slice. Subclasses with a mutex wrap their `get_range` /
+## `get_recent` overrides around this; the lockless base implementations
+## of those public methods just delegate here.
+func _get_range_unlocked(offset: int, count: int) -> Array[Dictionary]:
+	var size := _storage.size()
+	var start := maxi(0, offset)
+	var stop := mini(size, start + count)
+	var out: Array[Dictionary] = []
+	for i in range(start, stop):
+		out.append(_storage[_logical_to_physical(i)])
+	return out
+
+
+func get_range(offset: int, count: int) -> Array[Dictionary]:
+	return _get_range_unlocked(offset, count)
+
+
+func get_recent(count: int) -> Array[Dictionary]:
+	var size := _storage.size()
+	var start := maxi(0, size - count)
+	return _get_range_unlocked(start, size - start)
+
+
+func total_count() -> int:
+	return _storage.size()
+
+
+func dropped_count() -> int:
+	return _dropped_count
+
+
+## Translate a logical index (0 = oldest retained) to a physical
+## `_storage` slot. Before the first wrap, storage-order is logical-
+## order. After wrapping, the oldest entry lives at `_head`.
+func _logical_to_physical(logical: int) -> int:
+	if _storage.size() < _max_lines:
+		return logical
+	return (_head + logical) % _max_lines
+
+
+## Reset the ring to empty. Subclasses with a mutex wrap this with their
+## lock; subclasses that surface `clear` to callers (EditorLogBuffer)
+## return the prior size from their wrapper.
+func _clear_storage() -> void:
+	_storage.clear()
+	_head = 0
+	_dropped_count = 0
+
+
+## Coerce unknown levels to "info" so a misbehaving sender can't poison
+## downstream filters with arbitrary strings.
+static func _coerce_level(level: String) -> String:
+	return level if level in VALID_LEVELS else "info"

--- a/plugin/addons/godot_ai/utils/structured_log_ring.gd.uid
+++ b/plugin/addons/godot_ai/utils/structured_log_ring.gd.uid
@@ -1,0 +1,1 @@
+uid://c4yh3jqfn6dwe

--- a/src/godot_ai/handlers/editor.py
+++ b/src/godot_ai/handlers/editor.py
@@ -142,7 +142,7 @@ async def logs_clear(runtime: Runtime) -> dict:
     return await runtime.send_command("clear_logs")
 
 
-_VALID_LOG_SOURCES = ("plugin", "game", "all")
+_VALID_LOG_SOURCES = ("plugin", "game", "editor", "all")
 
 
 async def logs_read(
@@ -153,7 +153,7 @@ async def logs_read(
     since_run_id: str = "",
 ) -> dict:
     if source not in _VALID_LOG_SOURCES:
-        raise ValueError(f"Invalid source '{source}' — use 'plugin', 'game', or 'all'")
+        raise ValueError(f"Invalid source '{source}' — use 'plugin', 'game', 'editor', or 'all'")
 
     if source == "plugin":
         ## Backward-compatible shape: callers asking for the default

--- a/src/godot_ai/tools/editor.py
+++ b/src/godot_ai/tools/editor.py
@@ -64,7 +64,7 @@ def register_editor_tools(mcp: FastMCP, *, include_non_core: bool = True) -> Non
         since_run_id: str = "",
         session_id: str = "",
     ) -> dict:
-        """Read recent log lines from the Godot editor or running game.
+        """Read recent log lines from the Godot editor, plugin, or running game.
 
         Resource form: ``godot://logs/recent`` — prefer for active-session reads.
 
@@ -74,15 +74,24 @@ def register_editor_tools(mcp: FastMCP, *, include_non_core: bool = True) -> Non
           via ``_mcp_game_helper`` autoload (Godot 4.5+). Buffer 2000, clears
           on each ``project_run``. Entries: {source, level, text}; response
           carries run_id, is_running, dropped_count.
-        - "all": plugin lines first, then game lines (with source per entry).
+        - "editor": editor-process script errors — parse errors, @tool/
+          EditorPlugin runtime errors, push_error/push_warning (Godot 4.5+).
+          Use when the editor's Output panel shows red lines but other
+          sources turned up nothing. Buffer 500, persists across
+          ``project_run``. Entries: {source, level, text, path, line,
+          function}. Filtered to .gd/.cs in the user project;
+          addons/godot_ai/ dropped. Errors fired before plugin enable are
+          not captured.
+        - "all": plugin → editor → game lines (with source per entry).
 
         Tail pattern: poll with offset=N + since_run_id=R. ``stale_run_id: true``
         means the buffer has rotated; reset offset to 0 and capture new run_id.
+        ``run_id`` is empty for ``source="editor"`` (editor logs don't rotate).
 
         Args:
             count: Max lines to return. Default 50.
             offset: Lines to skip. Default 0.
-            source: "plugin" | "game" | "all". Default "plugin".
+            source: "plugin" | "game" | "editor" | "all". Default "plugin".
             since_run_id: Stale-detection token from a previous response.
             session_id: Optional Godot session to target. Empty = active session.
         """

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -695,6 +695,315 @@ func test_get_logs_source_all_includes_both_streams() -> void:
 	assert_eq(result.data.lines[2].text, "game-c")
 
 
+# ----- EditorLogBuffer (issue #231) -----
+
+func test_editor_log_buffer_append_and_get_range() -> void:
+	var buf := EditorLogBuffer.new()
+	buf.append("error", "Parse Error", "res://broken.gd", 12, "")
+	buf.append("warn", "deprecation", "res://foo.gd", 4, "_ready")
+	var entries := buf.get_range(0, 10)
+	assert_eq(entries.size(), 2)
+	assert_eq(entries[0].source, "editor")
+	assert_eq(entries[0].level, "error")
+	assert_eq(entries[0].text, "Parse Error")
+	assert_eq(entries[0].path, "res://broken.gd")
+	assert_eq(entries[0].line, 12)
+	assert_eq(entries[1].level, "warn")
+	assert_eq(entries[1].function, "_ready")
+	assert_eq(buf.total_count(), 2)
+
+
+func test_editor_log_buffer_unknown_level_coerces_to_info() -> void:
+	var buf := EditorLogBuffer.new()
+	buf.append("fatal", "huh")
+	assert_eq(buf.get_range(0, 1)[0].level, "info", "Unknown level should coerce to info")
+
+
+func test_editor_log_buffer_missing_fields_default_to_empty() -> void:
+	## A logger that omits structured fields (e.g. printerr without script
+	## context) should still produce a well-formed entry — callers iterating
+	## response shape never KeyError.
+	var buf := EditorLogBuffer.new()
+	buf.append("error", "bare")
+	var e := buf.get_range(0, 1)[0]
+	assert_eq(e.path, "")
+	assert_eq(e.line, 0)
+	assert_eq(e.function, "")
+
+
+func test_editor_log_buffer_ring_evicts_and_tracks_dropped() -> void:
+	var buf := EditorLogBuffer.new()
+	var cap := EditorLogBuffer.MAX_LINES
+	for i in range(cap + 7):
+		buf.append("error", "n %d" % i, "res://x.gd", i)
+	assert_eq(buf.total_count(), cap, "Buffer should cap at MAX_LINES")
+	assert_eq(buf.dropped_count(), 7, "Should record 7 evictions")
+	## Oldest 7 dropped: first remaining entry should be index 7.
+	var first := buf.get_range(0, 1)
+	assert_eq(first[0].text, "n 7")
+
+
+func test_editor_log_buffer_clear_resets_counts() -> void:
+	var buf := EditorLogBuffer.new()
+	for i in range(5):
+		buf.append("error", "n %d" % i)
+	var cleared := buf.clear()
+	assert_eq(cleared, 5, "clear() should report cleared count")
+	assert_eq(buf.total_count(), 0)
+	assert_eq(buf.dropped_count(), 0)
+
+
+# ----- get_logs source="editor" routing (issue #231) -----
+
+func test_get_logs_source_editor_empty_when_no_buffer() -> void:
+	## Plugin started without an editor buffer (e.g. Godot 4.4 where the
+	## logger never attached) should still answer the source — empty page,
+	## no crash — so `logs_read(source="editor")` is unconditionally safe
+	## to call.
+	var handler := EditorHandler.new(McpLogBuffer.new())
+	var result := handler.get_logs({"source": "editor", "count": 10})
+	assert_has_key(result, "data")
+	assert_eq(result.data.source, "editor")
+	assert_eq(result.data.lines.size(), 0)
+	assert_eq(result.data.total_count, 0)
+	assert_eq(result.data.dropped_count, 0)
+
+
+func test_get_logs_source_editor_returns_buffered_entries() -> void:
+	var ed_buf := EditorLogBuffer.new()
+	ed_buf.append("error", "Parse Error: Expected statement", "res://broken.gd", 17, "")
+	ed_buf.append("warn", "Integer division", "res://math.gd", 3, "_compute")
+	var handler := EditorHandler.new(McpLogBuffer.new(), null, null, null, ed_buf)
+	var result := handler.get_logs({"source": "editor", "count": 10})
+	assert_eq(result.data.source, "editor")
+	assert_eq(result.data.lines.size(), 2)
+	assert_eq(result.data.lines[0].text, "Parse Error: Expected statement")
+	assert_eq(result.data.lines[0].path, "res://broken.gd")
+	assert_eq(result.data.lines[0].line, 17)
+	assert_eq(result.data.lines[1].level, "warn")
+	assert_eq(result.data.lines[1].function, "_compute")
+
+
+func test_get_logs_source_editor_offset_applies() -> void:
+	var ed_buf := EditorLogBuffer.new()
+	for i in range(5):
+		ed_buf.append("error", "e %d" % i, "res://x.gd", i)
+	var handler := EditorHandler.new(McpLogBuffer.new(), null, null, null, ed_buf)
+	var result := handler.get_logs({"source": "editor", "count": 2, "offset": 2})
+	assert_eq(result.data.returned_count, 2)
+	assert_eq(result.data.lines[0].text, "e 2")
+	assert_eq(result.data.lines[1].text, "e 3")
+	assert_eq(result.data.offset, 2)
+	assert_eq(result.data.total_count, 5)
+
+
+func test_get_logs_source_all_includes_editor_between_plugin_and_game() -> void:
+	var plugin_buf := McpLogBuffer.new()
+	plugin_buf.log("plugin-a")
+	var ed_buf := EditorLogBuffer.new()
+	ed_buf.append("error", "parse err", "res://x.gd", 1, "")
+	var game_buf := GameLogBuffer.new()
+	game_buf.append("info", "game-runtime")
+	var handler := EditorHandler.new(plugin_buf, null, null, game_buf, ed_buf)
+	var result := handler.get_logs({"source": "all", "count": 10})
+	assert_eq(result.data.lines.size(), 3)
+	## Order: plugin → editor → game.
+	assert_eq(result.data.lines[0].source, "plugin")
+	assert_eq(result.data.lines[1].source, "editor")
+	assert_eq(result.data.lines[1].text, "parse err")
+	assert_eq(result.data.lines[2].source, "game")
+
+
+func test_get_logs_source_all_dropped_count_includes_editor() -> void:
+	## The dropped_count surfaced by source="all" should aggregate across
+	## both ring buffers so a caller polling for "are we losing entries"
+	## doesn't have to read each source separately.
+	var ed_buf := EditorLogBuffer.new()
+	for i in range(EditorLogBuffer.MAX_LINES + 3):
+		ed_buf.append("error", "x %d" % i)
+	var game_buf := GameLogBuffer.new()
+	for i in range(GameLogBuffer.MAX_LINES + 4):
+		game_buf.append("info", "g %d" % i)
+	var handler := EditorHandler.new(McpLogBuffer.new(), null, null, game_buf, ed_buf)
+	var result := handler.get_logs({"source": "all", "count": 1})
+	assert_eq(result.data.dropped_count, 7, "Editor (3) + game (4) drops should sum")
+
+
+func test_get_logs_source_invalid_message_lists_editor() -> void:
+	## After adding the new source, the validator's error message should
+	## list it so users see a complete option set in their typo correction.
+	var handler := EditorHandler.new(McpLogBuffer.new())
+	var result := handler.get_logs({"source": "bogus"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "editor")
+
+
+# ----- EditorLogger filtering (issue #231) -----
+
+const _EDITOR_LOGGER_PATH := "res://addons/godot_ai/runtime/editor_logger.gd"
+
+
+func test_editor_logger_captures_user_script_parse_error() -> void:
+	## Simulate Godot's parser firing _log_error with the offending .gd
+	## file as `file`. The buffer should receive a structured entry with
+	## the path/line/level so the LLM can navigate straight to the bug.
+	if not ClassDB.class_exists("Logger"):
+		skip("Logger class requires Godot 4.5+")
+		return
+	var ed_buf := EditorLogBuffer.new()
+	var logger = load(_EDITOR_LOGGER_PATH).new(ed_buf)
+	logger._log_error(
+		"_parse",
+		"res://broken.gd",
+		42,
+		"Parse Error: Expected statement, got 'EOF' instead.",
+		"",
+		false,
+		2,  ## SCRIPT
+		[],
+	)
+	var entries := ed_buf.get_range(0, 10)
+	assert_eq(entries.size(), 1, "User script parse error should be captured")
+	assert_eq(entries[0].level, "error")
+	assert_eq(entries[0].path, "res://broken.gd")
+	assert_eq(entries[0].line, 42)
+	assert_contains(entries[0].text, "Parse Error")
+
+
+func test_editor_logger_warn_error_type_maps_to_warn_level() -> void:
+	if not ClassDB.class_exists("Logger"):
+		skip("Logger class requires Godot 4.5+")
+		return
+	var ed_buf := EditorLogBuffer.new()
+	var logger = load(_EDITOR_LOGGER_PATH).new(ed_buf)
+	logger._log_error("_run", "res://x.gd", 3, "deprecated", "", false, 1, [])
+	var entries := ed_buf.get_range(0, 10)
+	assert_eq(entries.size(), 1)
+	assert_eq(entries[0].level, "warn")
+
+
+func test_editor_logger_drops_internal_godot_cpp_noise() -> void:
+	## Errors that originate in Godot's C++ code with no script backtrace
+	## (e.g. "scene/main/scene_tree.cpp" warnings) should be filtered —
+	## otherwise the editor's normal startup chatter buries the parse
+	## errors callers actually want.
+	if not ClassDB.class_exists("Logger"):
+		skip("Logger class requires Godot 4.5+")
+		return
+	var ed_buf := EditorLogBuffer.new()
+	var logger = load(_EDITOR_LOGGER_PATH).new(ed_buf)
+	logger._log_error("foo", "scene/main/scene_tree.cpp", 1234, "noise", "", false, 0, [])
+	assert_eq(ed_buf.total_count(), 0, "C++-source errors with no script backtrace should be filtered")
+
+
+func test_editor_logger_drops_godot_ai_addon_to_avoid_feedback_loop() -> void:
+	## We push_warning ourselves from plugin.gd. Capturing those would
+	## amplify on every reload and pollute the buffer the dock reads.
+	if not ClassDB.class_exists("Logger"):
+		skip("Logger class requires Godot 4.5+")
+		return
+	var ed_buf := EditorLogBuffer.new()
+	var logger = load(_EDITOR_LOGGER_PATH).new(ed_buf)
+	logger._log_error("_start_server", "res://addons/godot_ai/plugin.gd", 100, "self-noise", "", false, 1, [])
+	assert_eq(ed_buf.total_count(), 0, "addons/godot_ai/ paths should be filtered")
+
+
+func test_editor_logger_uses_script_backtrace_for_push_error() -> void:
+	## push_error/push_warning fire with file=core/variant/variant_utility.cpp;
+	## the actual user location lives in the first script_backtrace frame.
+	## Without this remapping, every push_error from user code would be
+	## filtered as C++ noise.
+	if not ClassDB.class_exists("Logger"):
+		skip("Logger class requires Godot 4.5+")
+		return
+	var ed_buf := EditorLogBuffer.new()
+	var logger = load(_EDITOR_LOGGER_PATH).new(ed_buf)
+
+	## Build a stub backtrace object with the same getter shape Godot
+	## passes via _log_error. ScriptBacktrace can't be constructed in
+	## tests, so a minimal duck-typed stub stands in.
+	var bt := StubBacktrace.new("res://user_tool.gd", 17, "_handle_event")
+	logger._log_error(
+		"push_error",
+		"core/variant/variant_utility.cpp",
+		1000,
+		"user-flagged-bug",
+		"",
+		false,
+		0,
+		[bt],
+	)
+	var entries := ed_buf.get_range(0, 10)
+	assert_eq(entries.size(), 1, "push_error from user code should be captured via backtrace")
+	assert_eq(entries[0].path, "res://user_tool.gd")
+	assert_eq(entries[0].line, 17)
+	assert_eq(entries[0].function, "_handle_event")
+	assert_contains(entries[0].text, "user-flagged-bug")
+
+
+func test_editor_logger_drops_push_error_from_plugin_via_backtrace() -> void:
+	## A push_warning called from inside addons/godot_ai/ should be filtered
+	## even though file points at variant_utility.cpp — the backtrace gives
+	## us the real source path, and that's the path we filter on.
+	if not ClassDB.class_exists("Logger"):
+		skip("Logger class requires Godot 4.5+")
+		return
+	var ed_buf := EditorLogBuffer.new()
+	var logger = load(_EDITOR_LOGGER_PATH).new(ed_buf)
+	var bt := StubBacktrace.new("res://addons/godot_ai/plugin.gd", 50, "_attach_editor_logger")
+	logger._log_error(
+		"push_warning",
+		"core/variant/variant_utility.cpp",
+		1000,
+		"internal noise",
+		"",
+		false,
+		1,
+		[bt],
+	)
+	assert_eq(ed_buf.total_count(), 0, "Backtrace inside godot_ai addon should still filter")
+
+
+func test_editor_logger_no_op_when_buffer_unset() -> void:
+	## Defensive: instantiated without a buffer (the default), the logger
+	## must silently no-op rather than crash. Covers the brief window
+	## during plugin shutdown after `_detach_editor_logger` has run but a
+	## stray Logger virtual is still in flight.
+	if not ClassDB.class_exists("Logger"):
+		skip("Logger class requires Godot 4.5+")
+		return
+	var logger = load(_EDITOR_LOGGER_PATH).new()
+	logger._log_error("f", "res://x.gd", 1, "msg", "", false, 0, [])
+	assert_true(true, "No crash when buffer is null")
+
+
+func test_editor_logger_is_user_script_predicate() -> void:
+	## Static helper — script `extends Logger` so it only parses on
+	## Godot 4.5+. Skip on older where load() returns null.
+	if not ClassDB.class_exists("Logger"):
+		skip("Logger class requires Godot 4.5+")
+		return
+	var script = load(_EDITOR_LOGGER_PATH)
+	assert_true(script._is_user_script("res://foo.gd"))
+	assert_true(script._is_user_script("res://Bar.cs"))
+	assert_true(script._is_user_script("/abs/path/foo.gd"))
+	assert_true(script._is_user_script("foo.GD"), "Case-insensitive .gd match")
+	assert_false(script._is_user_script(""))
+	assert_false(script._is_user_script("scene/main/scene_tree.cpp"))
+	assert_false(script._is_user_script("res://image.png"))
+
+
+func test_editor_logger_is_in_godot_ai_addon_predicate() -> void:
+	if not ClassDB.class_exists("Logger"):
+		skip("Logger class requires Godot 4.5+")
+		return
+	var script = load(_EDITOR_LOGGER_PATH)
+	assert_true(script._is_in_godot_ai_addon("res://addons/godot_ai/plugin.gd"))
+	assert_true(script._is_in_godot_ai_addon("/abs/project/addons/godot_ai/handler.gd"))
+	assert_false(script._is_in_godot_ai_addon("res://user_script.gd"))
+	assert_false(script._is_in_godot_ai_addon("res://addons/other_plugin/foo.gd"))
+
+
 # ----- McpDebuggerPlugin: log batch capture (issue #73) -----
 
 func test_debugger_plugin_log_batch_appends_to_buffer() -> void:
@@ -787,3 +1096,48 @@ func test_game_logger_printerr_routes_to_error_level() -> void:
 	assert_eq(pending[0][1], "oops")
 	assert_eq(pending[1][0], "info")
 	assert_eq(pending[1][1], "hi")
+
+
+func test_game_logger_uses_script_backtrace_for_push_error() -> void:
+	## push_error from game-side .gd lands with file=variant_utility.cpp;
+	## the queued text must report the user's GDScript location (from the
+	## first backtrace frame), not the C++ wrapper. Mirrors the
+	## editor_logger backtrace-remap test — game_logger went uncovered
+	## until the LogBacktrace.resolve_error extraction.
+	if not ClassDB.class_exists("Logger"):
+		skip("Logger class requires Godot 4.5+")
+		return
+	var logger = load(_GAME_LOGGER_PATH).new()
+	var bt := StubBacktrace.new("res://player.gd", 88, "_take_damage")
+	logger._log_error(
+		"push_error",
+		"core/variant/variant_utility.cpp",
+		1000,
+		"hp went negative",
+		"",
+		false,
+		0,
+		[bt],
+	)
+	var pending: Array = logger.drain()
+	assert_eq(pending.size(), 1)
+	assert_eq(pending[0][0], "error")
+	assert_contains(pending[0][1], "hp went negative")
+	assert_contains(pending[0][1], "res://player.gd:88", "Backtrace path:line should land in the formatted text")
+	assert_contains(pending[0][1], "_take_damage", "Backtrace function should land in the formatted text")
+	assert_true(not pending[0][1].contains("variant_utility.cpp"), "C++ wrapper path should be replaced by the backtrace")
+
+
+func test_game_logger_falls_back_to_original_file_when_no_backtrace() -> void:
+	## A two-arg push_error from a real .gd file (rationale-form) reports
+	## file=res://foo.gd directly with no backtrace; the formatted loc
+	## suffix should still appear so users can navigate to the source.
+	if not ClassDB.class_exists("Logger"):
+		skip("Logger class requires Godot 4.5+")
+		return
+	var logger = load(_GAME_LOGGER_PATH).new()
+	logger._log_error("my_func", "res://foo.gd", 42, "ERR_CODE", "detailed reason", false, 0, [])
+	var pending: Array = logger.drain()
+	assert_eq(pending.size(), 1)
+	assert_contains(pending[0][1], "res://foo.gd:42", "Fallback path:line should appear when no backtrace is present")
+	assert_contains(pending[0][1], "my_func", "Fallback function name should appear when no backtrace is present")

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -390,6 +390,58 @@ class TestLogsReadTool:
         assert data["lines"] == []
         assert data["run_id"] == "rNEW"
 
+    async def test_source_editor_returns_structured_script_errors(self, mcp_stack):
+        client, plugin = mcp_stack
+        entries = [
+            {
+                "source": "editor",
+                "level": "error",
+                "text": "Parse Error: Expected statement, got 'EOF' instead.",
+                "path": "res://broken.gd",
+                "line": 12,
+                "function": "",
+            },
+            {
+                "source": "editor",
+                "level": "warn",
+                "text": "Integer division: 5 / 2",
+                "path": "res://math.gd",
+                "line": 4,
+                "function": "_compute",
+            },
+        ]
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "get_logs"
+            assert cmd["params"]["source"] == "editor"
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "source": "editor",
+                    "lines": entries,
+                    "total_count": 2,
+                    "returned_count": 2,
+                    "offset": 0,
+                    "dropped_count": 0,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool("logs_read", {"source": "editor"})
+        await task
+
+        data = result.data
+        assert data["source"] == "editor"
+        assert data["lines"] == entries
+        ## run_id and is_running are absent in the plugin payload but the
+        ## tool fills them with empty defaults so the response schema stays
+        ## stable across sources.
+        assert data["run_id"] == ""
+        assert data["is_running"] is False
+        assert data["dropped_count"] == 0
+        assert data["stale_run_id"] is False
+
 
 # ---------------------------------------------------------------------------
 # node_find

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -75,15 +75,46 @@ class StubClient:
                     "is_running": True,
                     "dropped_count": 0,
                 }
+            if source == "editor":
+                req_offset = int(params_dict.get("offset", 0))
+                req_count = int(params_dict.get("count", 50))
+                all_entries = [
+                    {
+                        "source": "editor",
+                        "level": "error",
+                        "text": f"editor err {i}",
+                        "path": f"res://script_{i}.gd",
+                        "line": 10 + i,
+                        "function": "_ready",
+                    }
+                    for i in range(3)
+                ]
+                page = all_entries[req_offset : req_offset + req_count]
+                return {
+                    "source": "editor",
+                    "lines": page,
+                    "total_count": len(all_entries),
+                    "returned_count": len(page),
+                    "offset": req_offset,
+                    "dropped_count": 0,
+                }
             if source == "all":
                 return {
                     "source": "all",
                     "lines": [
                         {"source": "plugin", "level": "info", "text": "p0"},
+                        {
+                            "source": "editor",
+                            "level": "error",
+                            "text": "ed-err",
+                            "path": "res://foo.gd",
+                            "line": 7,
+                            "function": "_init",
+                        },
                         {"source": "game", "level": "warn", "text": "g0"},
                     ],
-                    "total_count": 2,
-                    "returned_count": 2,
+                    "total_count": 3,
+                    "returned_count": 3,
                     "offset": 0,
                     "run_id": "rstub",
                     "is_running": True,
@@ -1249,10 +1280,54 @@ async def test_logs_read_handler_source_all_returns_structured():
     result = await editor_handlers.logs_read(runtime, source="all")
 
     assert result["source"] == "all"
-    assert result["lines"][0]["source"] == "plugin"
-    assert result["lines"][1]["source"] == "game"
-    assert result["lines"][1]["level"] == "warn"
+    sources = [entry["source"] for entry in result["lines"]]
+    assert sources == ["plugin", "editor", "game"]
+    assert result["lines"][1]["level"] == "error"
+    assert result["lines"][1]["path"] == "res://foo.gd"
+    assert result["lines"][2]["level"] == "warn"
     assert result["run_id"] == "rstub"
+
+
+async def test_logs_read_handler_source_editor_passes_through():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+
+    result = await editor_handlers.logs_read(runtime, count=2, offset=1, source="editor")
+
+    last_call = client.calls[-1]
+    assert last_call["command"] == "get_logs"
+    assert last_call["params"] == {"count": 2, "offset": 1, "source": "editor"}
+
+    assert result["source"] == "editor"
+    assert result["lines"] == [
+        {
+            "source": "editor",
+            "level": "error",
+            "text": "editor err 1",
+            "path": "res://script_1.gd",
+            "line": 11,
+            "function": "_ready",
+        },
+        {
+            "source": "editor",
+            "level": "error",
+            "text": "editor err 2",
+            "path": "res://script_2.gd",
+            "line": 12,
+            "function": "_ready",
+        },
+    ]
+    assert result["total_count"] == 3
+    assert result["returned_count"] == 2
+    assert result["offset"] == 1
+    assert result["limit"] == 2
+    assert result["dropped_count"] == 0
+    ## Editor logs don't rotate (no run_id) — but the response shape stays
+    ## consistent with game/all so dashboards don't have to special-case.
+    assert result["run_id"] == ""
+    assert result["is_running"] is False
+    assert result["stale_run_id"] is False
+    assert result["has_more"] is False
 
 
 async def test_logs_read_handler_plugin_normalizes_structured_payload():


### PR DESCRIPTION
## Summary

- Adds `logs_read(source="editor")` so parse errors, `@tool` / EditorPlugin runtime errors, and editor-side `push_error` / `push_warning` reach the LLM with structured `{path, line, function}` (closes #231).
- Extracts `LogBacktrace.resolve_error()` and `StructuredLogRing` so the editor pair and the game pair share their substantive plumbing instead of carrying two near-identical copies of the rationale-vs-code semantics, the `variant_utility.cpp` source remap, and the head-indexed eviction math.
- Moves `StubBacktrace` from a private inner class in `test_editor.gd` to `plugin/addons/godot_ai/testing/`, lifts game_logger out of its no-backtrace-coverage gap with two new tests.

Supersedes the WIP that lived in the `pensive-curran-7e7828` worktree — that branch can be discarded.

## What changed

**New files:**
- `plugin/addons/godot_ai/runtime/editor_logger.gd` — Logger subclass; gated on 4.5+; filters to user `.gd`/`.cs`, drops `addons/godot_ai/` to avoid feedback loops.
- `plugin/addons/godot_ai/utils/editor_log_buffer.gd` — 500-line ring, mutex-wrapped, no `run_id` (editor errors persist across `project_run`).
- `plugin/addons/godot_ai/utils/log_backtrace.gd` — `LogBacktrace.resolve_error()` returns `{level, message, path, line, function}`. Single source of truth for level mapping, rationale fallback, and backtrace-driven source remap.
- `plugin/addons/godot_ai/utils/structured_log_ring.gd` — base class for the head-indexed circular buffer plus eviction math. Lockless; subclasses needing thread-safety wrap with their own mutex.
- `plugin/addons/godot_ai/testing/stub_backtrace.gd` — duck-typed `ScriptBacktrace` stand-in shared by editor + game logger tests.

**Refactored:**
- `game_logger.gd` and `editor_logger.gd` both call `LogBacktrace.resolve_error(...)`. game_logger formats a `loc` suffix from the resolved fields; editor_logger applies its `_is_user_script` / `_is_in_godot_ai_addon` filter against `resolved.path` and writes the structured entry.
- `game_log_buffer.gd` (47 lines, was 99) and `editor_log_buffer.gd` (86 lines, was 122) both `extends StructuredLogRing`. Each subclass keeps `const MAX_LINES`, passes it via `super._init(MAX_LINES)`, and owns only its per-source entry shape (and, for the editor, the mutex wrapping).

**Naming:** the helper class is `LogBacktrace`, not `ScriptBacktrace` — Godot 4.5+ ships a built-in `ScriptBacktrace` (the type of `script_backtraces[i]` entries inside `_log_error`), so class_name'ing ours the same name would collide.

## Test plan

- [x] `pytest -q` — 644 passed
- [x] `Godot --headless --path test_project --import` — no parse / script errors; all five class_name'd types register in the global class cache
- [x] `test_run` via the live editor at this worktree — **935 / 938 passed** (3 pre-existing skips, 0 failures)
- [x] `editor` suite specifically — 79 / 81 passed (2 pre-existing cinematic skips)
- [x] Live smoke: wrote a broken `.gd` (deliberate parse error), called `filesystem_manage(op="reimport")`, then `logs_read(source="editor")` — parse error landed in the buffer with `{path: "res://...", line: 4, function: "GDScript::reload", level: "error", text: "Parse Error: Expected expression for variable initial value after \"=\"."}`.
- [x] `ruff check src/ tests/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
