### PR TITLE
fix(dock): wall-clock timeout + off-main worker for CLI client probes

### DIFF
--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -169,12 +169,21 @@ static func check_status_for_url(id: String, url: String) -> McpClient.Status:
 
 
 static func check_status_for_url_with_cli_path(id: String, url: String, cli_path: String) -> McpClient.Status:
+	return check_status_details_for_url_with_cli_path(id, url, cli_path).get("status", McpClient.Status.NOT_CONFIGURED)
+
+
+## Detailed variant used by the dock refresh worker. Returns
+## `{"status": Status, "error_msg": String}` so the worker can surface
+## "probe timed out" on the row instead of silently flipping it to
+## NOT_CONFIGURED. Callers that only need the status can use the simpler
+## helper above.
+static func check_status_details_for_url_with_cli_path(id: String, url: String, cli_path: String) -> Dictionary:
 	var client := McpClientRegistry.get_by_id(id)
 	if client == null:
-		return McpClient.Status.NOT_CONFIGURED
+		return {"status": McpClient.Status.NOT_CONFIGURED, "error_msg": ""}
 	if client.config_type == "cli" and cli_path.is_empty():
-		return McpClient.Status.NOT_CONFIGURED
-	return _dispatch_check_status_with_cli_path(client, url, cli_path)
+		return {"status": McpClient.Status.NOT_CONFIGURED, "error_msg": ""}
+	return _dispatch_check_status_with_cli_path_details(client, url, cli_path)
 
 
 static func client_status_probe_snapshot(id: String) -> Dictionary:
@@ -229,16 +238,20 @@ static func _dispatch_check_status(client: McpClient, url: String) -> McpClient.
 
 
 static func _dispatch_check_status_with_cli_path(client: McpClient, url: String, cli_path: String) -> McpClient.Status:
+	return _dispatch_check_status_with_cli_path_details(client, url, cli_path).get("status", McpClient.Status.NOT_CONFIGURED)
+
+
+static func _dispatch_check_status_with_cli_path_details(client: McpClient, url: String, cli_path: String) -> Dictionary:
 	match client.config_type:
 		"json":
-			return McpJsonStrategy.check_status(client, SERVER_NAME, url)
+			return {"status": McpJsonStrategy.check_status(client, SERVER_NAME, url), "error_msg": ""}
 		"toml":
-			return McpTomlStrategy.check_status(client, SERVER_NAME, url)
+			return {"status": McpTomlStrategy.check_status(client, SERVER_NAME, url), "error_msg": ""}
 		"cli":
 			if cli_path.is_empty():
-				return McpCliStrategy.check_status(client, SERVER_NAME, url)
-			return McpCliStrategy.check_status_with_cli_path(client, SERVER_NAME, url, cli_path)
-	return McpClient.Status.NOT_CONFIGURED
+				return McpCliStrategy.check_status_details(client, SERVER_NAME, url, McpCliStrategy.resolve_cli_path(client))
+			return McpCliStrategy.check_status_details(client, SERVER_NAME, url, cli_path)
+	return {"status": McpClient.Status.NOT_CONFIGURED, "error_msg": ""}
 
 
 ## After a configure/remove returns ok, re-read the live status. If it doesn't

--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -137,14 +137,19 @@ static func client_display_name(id: String) -> String:
 	return c.display_name if c != null else id
 
 
-static func configure(id: String) -> Dictionary:
+## Pass an explicit `url` when calling from a worker thread: `http_url()`
+## reads `EditorInterface.get_editor_settings()`, which is main-thread-only.
+## Empty defaults to the live server URL — appropriate for MCP-tool callers
+## that always run on main.
+static func configure(id: String, url: String = "") -> Dictionary:
 	var client := McpClientRegistry.get_by_id(id)
 	if client == null:
 		return {"status": "error", "message": "Unknown client: %s" % id}
 	## Capture `url` once so a port flip in EditorSettings between write and
 	## verify can't trigger a spurious CONFIGURED_MISMATCH against an entry
 	## that just landed correctly.
-	var url := http_url()
+	if url.is_empty():
+		url = http_url()
 	var result := _dispatch_configure(client, url)
 	## Trust-but-verify: a strategy may report ok and have actually written the
 	## file, yet the entry is missing/stale on the read-back path — most often
@@ -200,11 +205,15 @@ static func client_status_probe_snapshot(id: String) -> Dictionary:
 	return {"id": id, "cli_path": cli_path, "installed": installed}
 
 
-static func remove(id: String) -> Dictionary:
+## Pass an explicit `url` when calling from a worker thread — see
+## `configure()` above for why. The url is only used to format the
+## verify-after-write diagnostic message; the remove itself doesn't need it.
+static func remove(id: String, url: String = "") -> Dictionary:
 	var client := McpClientRegistry.get_by_id(id)
 	if client == null:
 		return {"status": "error", "message": "Unknown client: %s" % id}
-	var url := http_url()
+	if url.is_empty():
+		url = http_url()
 	var result := _dispatch_remove(client)
 	return _verify_post_state(client, result, McpClient.Status.NOT_CONFIGURED, url, "remove")
 

--- a/plugin/addons/godot_ai/clients/_cli_exec.gd
+++ b/plugin/addons/godot_ai/clients/_cli_exec.gd
@@ -1,0 +1,86 @@
+@tool
+class_name McpCliExec
+extends RefCounted
+
+## Wall-clock-bounded CLI invocation. Every dock shell-out to a per-client
+## CLI (`claude mcp list`, `claude mcp add ...`, etc.) goes through here so
+## a hung subprocess can't trap the calling thread forever.
+##
+## Without the timeout, a contended `claude mcp list` has been observed to
+## hang for 6+ minutes (issues #238, #239) — wedging the dock's status
+## refresh worker, and on the Configure / Remove paths the editor main
+## thread itself.
+##
+## Why poll/kill instead of `OS.execute(..., true)`: GDScript can't
+## interrupt a blocking `OS.execute`, so a hung CLI takes its caller's
+## thread with it. `OS.execute_with_pipe` returns immediately with a PID;
+## we drive the wait ourselves and `OS.kill` the orphan if budget
+## expires. CLI registry commands have bounded output (a few hundred
+## bytes), so we don't bother draining the pipe during the poll loop —
+## the kernel buffer absorbs it.
+##
+## Returns a Dictionary with:
+##   exit_code:    process exit code (0 = success). -1 on timeout / spawn failure.
+##   stdout:       captured stdout+stderr text. May be partial on timeout.
+##   timed_out:    true if we killed the process at the wall-clock budget.
+##   spawn_failed: true if `OS.execute_with_pipe` didn't return a usable PID.
+
+const DEFAULT_TIMEOUT_MS := 8000
+const _POLL_INTERVAL_MS := 50
+
+
+static func run(exe: String, args: Array, timeout_ms: int = DEFAULT_TIMEOUT_MS) -> Dictionary:
+	if exe.is_empty():
+		return _spawn_failed_result()
+
+	var info := OS.execute_with_pipe(exe, args)
+	if info.is_empty():
+		return _spawn_failed_result()
+
+	var pid: int = int(info.get("pid", -1))
+	var stdio: Variant = info.get("stdio", null)
+	var stderr_pipe: Variant = info.get("stderr", null)
+	if pid <= 0:
+		_close_pipes(stdio, stderr_pipe)
+		return _spawn_failed_result()
+
+	var deadline := Time.get_ticks_msec() + maxi(timeout_ms, _POLL_INTERVAL_MS)
+	while OS.is_process_running(pid):
+		if Time.get_ticks_msec() >= deadline:
+			OS.kill(pid)
+			_close_pipes(stdio, stderr_pipe)
+			return {
+				"exit_code": -1,
+				"stdout": "",
+				"timed_out": true,
+				"spawn_failed": false,
+			}
+		OS.delay_msec(_POLL_INTERVAL_MS)
+
+	var stdout := ""
+	if stdio is FileAccess:
+		stdout = (stdio as FileAccess).get_as_text()
+	_close_pipes(stdio, stderr_pipe)
+
+	return {
+		"exit_code": OS.get_process_exit_code(pid),
+		"stdout": stdout,
+		"timed_out": false,
+		"spawn_failed": false,
+	}
+
+
+static func _spawn_failed_result() -> Dictionary:
+	return {
+		"exit_code": -1,
+		"stdout": "",
+		"timed_out": false,
+		"spawn_failed": true,
+	}
+
+
+static func _close_pipes(stdio: Variant, stderr_pipe: Variant) -> void:
+	if stdio is FileAccess:
+		(stdio as FileAccess).close()
+	if stderr_pipe is FileAccess:
+		(stderr_pipe as FileAccess).close()

--- a/plugin/addons/godot_ai/clients/_cli_exec.gd
+++ b/plugin/addons/godot_ai/clients/_cli_exec.gd
@@ -21,7 +21,13 @@ extends RefCounted
 ##
 ## Returns a Dictionary with:
 ##   exit_code:    process exit code (0 = success). -1 on timeout / spawn failure.
-##   stdout:       captured stdout+stderr text. May be partial on timeout.
+##   stdout:       captured stdout text. May be partial on timeout.
+##   stderr:       captured stderr text. May be partial on timeout.
+##   output:       stdout + (newline + stderr if non-empty). Convenience for
+##                 the common case of "show whatever the CLI said when it
+##                 failed" — `claude mcp add` writes its real diagnostics to
+##                 stderr, so callers that only read `stdout` would surface
+##                 a generic "exit code 1" instead.
 ##   timed_out:    true if we killed the process at the wall-clock budget.
 ##   spawn_failed: true if `OS.execute_with_pipe` didn't return a usable PID.
 
@@ -47,24 +53,32 @@ static func run(exe: String, args: Array, timeout_ms: int = DEFAULT_TIMEOUT_MS) 
 	var deadline := Time.get_ticks_msec() + maxi(timeout_ms, _POLL_INTERVAL_MS)
 	while OS.is_process_running(pid):
 		if Time.get_ticks_msec() >= deadline:
+			## Read whatever made it to the pipes before we kill the
+			## process — partial output beats blank "timed out" when the
+			## CLI was emitting useful diagnostics on its way to hanging.
+			var partial_stdout := _drain_pipe(stdio)
+			var partial_stderr := _drain_pipe(stderr_pipe)
 			OS.kill(pid)
 			_close_pipes(stdio, stderr_pipe)
 			return {
 				"exit_code": -1,
-				"stdout": "",
+				"stdout": partial_stdout,
+				"stderr": partial_stderr,
+				"output": _join_streams(partial_stdout, partial_stderr),
 				"timed_out": true,
 				"spawn_failed": false,
 			}
 		OS.delay_msec(_POLL_INTERVAL_MS)
 
-	var stdout := ""
-	if stdio is FileAccess:
-		stdout = (stdio as FileAccess).get_as_text()
+	var stdout := _drain_pipe(stdio)
+	var stderr_text := _drain_pipe(stderr_pipe)
 	_close_pipes(stdio, stderr_pipe)
 
 	return {
 		"exit_code": OS.get_process_exit_code(pid),
 		"stdout": stdout,
+		"stderr": stderr_text,
+		"output": _join_streams(stdout, stderr_text),
 		"timed_out": false,
 		"spawn_failed": false,
 	}
@@ -74,9 +88,29 @@ static func _spawn_failed_result() -> Dictionary:
 	return {
 		"exit_code": -1,
 		"stdout": "",
+		"stderr": "",
+		"output": "",
 		"timed_out": false,
 		"spawn_failed": true,
 	}
+
+
+static func _drain_pipe(pipe: Variant) -> String:
+	if pipe is FileAccess:
+		return (pipe as FileAccess).get_as_text()
+	return ""
+
+
+static func _join_streams(stdout: String, stderr_text: String) -> String:
+	## Most CLIs write their actionable diagnostics to one stream or the
+	## other, never both — so concatenation gives "the message" without
+	## the caller having to guess which key to read. Newline-separate so
+	## callers that grep don't see two lines run together.
+	if stderr_text.is_empty():
+		return stdout
+	if stdout.is_empty():
+		return stderr_text
+	return "%s\n%s" % [stdout, stderr_text]
 
 
 static func _close_pipes(stdio: Variant, stderr_pipe: Variant) -> void:

--- a/plugin/addons/godot_ai/clients/_cli_exec.gd.uid
+++ b/plugin/addons/godot_ai/clients/_cli_exec.gd.uid
@@ -1,0 +1,1 @@
+uid://dhoe3ypkhm12v

--- a/plugin/addons/godot_ai/clients/_cli_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_cli_strategy.gd
@@ -6,6 +6,15 @@ extends RefCounted
 ## `claude mcp add`). Reads `cli_register_template` / `cli_unregister_template`
 ## / `cli_status_args` from the descriptor and substitutes `{name}` / `{url}`
 ## tokens. No descriptor-supplied Callables — see `_base.gd` for why.
+##
+## Every shell-out goes through `McpCliExec.run`, which wraps the call in a
+## wall-clock timeout. A hung CLI (e.g. `claude mcp list` under
+## inter-Claude-Code contention) gets killed at the budget instead of
+## locking up the caller forever — see issues #238 / #239.
+
+const _CONFIGURE_TIMEOUT_MS := 10000
+const _REMOVE_TIMEOUT_MS := 10000
+const _STATUS_TIMEOUT_MS := 6000
 
 
 static func configure(client: McpClient, server_name: String, server_url: String) -> Dictionary:
@@ -13,19 +22,30 @@ static func configure(client: McpClient, server_name: String, server_url: String
 	if cli.is_empty():
 		return {"status": "error", "message": "%s CLI not found" % client.display_name}
 
-	# Best-effort prior cleanup so re-configure is idempotent.
+	# Best-effort prior cleanup so re-configure is idempotent. Bounded to
+	# the same budget — a hung unregister shouldn't block the configure
+	# that follows.
 	if not client.cli_unregister_template.is_empty():
 		var pre_args := _format_args(client.cli_unregister_template, server_name, server_url)
-		OS.execute(cli, pre_args, [], true)
+		McpCliExec.run(cli, pre_args, _REMOVE_TIMEOUT_MS)
 
 	if client.cli_register_template.is_empty():
 		return {"status": "error", "message": "%s descriptor missing cli_register_template" % client.display_name}
 	var args := _format_args(client.cli_register_template, server_name, server_url)
-	var output: Array = []
-	var exit_code := OS.execute(cli, args, output, true)
-	if exit_code == 0:
+	var result := McpCliExec.run(cli, args, _CONFIGURE_TIMEOUT_MS)
+	if result.get("timed_out", false):
+		return {
+			"status": "error",
+			"message": "Configure %s timed out after %ds — see 'Run this manually' below to retry by hand" % [
+				client.display_name, _CONFIGURE_TIMEOUT_MS / 1000,
+			],
+		}
+	if result.get("spawn_failed", false):
+		return {"status": "error", "message": "Failed to spawn %s CLI" % client.display_name}
+	if int(result.get("exit_code", -1)) == 0:
 		return {"status": "ok", "message": "%s configured (HTTP: %s)" % [client.display_name, server_url]}
-	var err: String = output[0].strip_edges() if output.size() > 0 else "exit code %d" % exit_code
+	var stdout := str(result.get("stdout", "")).strip_edges()
+	var err := stdout if not stdout.is_empty() else "exit code %d" % int(result.get("exit_code", -1))
 	return {"status": "error", "message": "Failed to configure %s: %s" % [client.display_name, err]}
 
 
@@ -38,22 +58,38 @@ static func check_status(client: McpClient, server_name: String, server_url: Str
 
 
 static func check_status_with_cli_path(client: McpClient, server_name: String, server_url: String, cli: String) -> McpClient.Status:
+	return check_status_details(client, server_name, server_url, cli).get("status", McpClient.Status.NOT_CONFIGURED)
+
+
+## Detailed variant used by the dock's refresh worker so it can surface a
+## "probe timed out" badge on the affected row instead of silently
+## conflating the timeout with NOT_CONFIGURED. Returns
+## `{"status": Status, "error_msg": String}`. The caller plumbs
+## `error_msg` straight into `_apply_row_status`.
+static func check_status_details(client: McpClient, server_name: String, server_url: String, cli: String) -> Dictionary:
 	if cli.is_empty():
-		return McpClient.Status.NOT_CONFIGURED
+		return _status_details(McpClient.Status.NOT_CONFIGURED)
 	if client.cli_status_args.is_empty():
-		return McpClient.Status.NOT_CONFIGURED
-	var output: Array = []
-	var exit_code := OS.execute(cli, McpClient._array_from_packed(client.cli_status_args), output, true)
-	if exit_code != 0 or output.is_empty():
-		return McpClient.Status.NOT_CONFIGURED
-	var text: String = output[0]
+		return _status_details(McpClient.Status.NOT_CONFIGURED)
+	var result := McpCliExec.run(cli, McpClient._array_from_packed(client.cli_status_args), _STATUS_TIMEOUT_MS)
+	if result.get("timed_out", false):
+		return _status_details(McpClient.Status.ERROR, "probe timed out")
+	if result.get("spawn_failed", false):
+		return _status_details(McpClient.Status.NOT_CONFIGURED)
+	if int(result.get("exit_code", -1)) != 0:
+		return _status_details(McpClient.Status.NOT_CONFIGURED)
+	var text := str(result.get("stdout", ""))
 	if text.find(server_name) < 0:
-		return McpClient.Status.NOT_CONFIGURED
+		return _status_details(McpClient.Status.NOT_CONFIGURED)
 	## Server registered, but pointing somewhere else — drift after a
 	## port change. Surface as mismatch so the dock offers Reconfigure.
 	if text.find(server_url) < 0:
-		return McpClient.Status.CONFIGURED_MISMATCH
-	return McpClient.Status.CONFIGURED
+		return _status_details(McpClient.Status.CONFIGURED_MISMATCH)
+	return _status_details(McpClient.Status.CONFIGURED)
+
+
+static func _status_details(status: McpClient.Status, error_msg: String = "") -> Dictionary:
+	return {"status": status, "error_msg": error_msg}
 
 
 static func remove(client: McpClient, server_name: String) -> Dictionary:
@@ -63,11 +99,20 @@ static func remove(client: McpClient, server_name: String) -> Dictionary:
 	if client.cli_unregister_template.is_empty():
 		return {"status": "error", "message": "%s descriptor missing cli_unregister_template" % client.display_name}
 	var args := _format_args(client.cli_unregister_template, server_name, "")
-	var output: Array = []
-	var exit_code := OS.execute(cli, args, output, true)
-	if exit_code == 0:
+	var result := McpCliExec.run(cli, args, _REMOVE_TIMEOUT_MS)
+	if result.get("timed_out", false):
+		return {
+			"status": "error",
+			"message": "Remove %s timed out after %ds — see 'Run this manually' below to retry by hand" % [
+				client.display_name, _REMOVE_TIMEOUT_MS / 1000,
+			],
+		}
+	if result.get("spawn_failed", false):
+		return {"status": "error", "message": "Failed to spawn %s CLI" % client.display_name}
+	if int(result.get("exit_code", -1)) == 0:
 		return {"status": "ok", "message": "%s configuration removed" % client.display_name}
-	var err: String = output[0].strip_edges() if output.size() > 0 else "exit code %d" % exit_code
+	var stdout := str(result.get("stdout", "")).strip_edges()
+	var err := stdout if not stdout.is_empty() else "exit code %d" % int(result.get("exit_code", -1))
 	return {"status": "error", "message": "Failed to remove %s: %s" % [client.display_name, err]}
 
 

--- a/plugin/addons/godot_ai/clients/_cli_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_cli_strategy.gd
@@ -44,8 +44,11 @@ static func configure(client: McpClient, server_name: String, server_url: String
 		return {"status": "error", "message": "Failed to spawn %s CLI" % client.display_name}
 	if int(result.get("exit_code", -1)) == 0:
 		return {"status": "ok", "message": "%s configured (HTTP: %s)" % [client.display_name, server_url]}
-	var stdout := str(result.get("stdout", "")).strip_edges()
-	var err := stdout if not stdout.is_empty() else "exit code %d" % int(result.get("exit_code", -1))
+	## `claude mcp add` writes its real failure diagnostics to stderr, so
+	## prefer `output` (stdout + stderr) over `stdout` alone — otherwise
+	## the user sees "exit code 1" instead of the actual error.
+	var combined := str(result.get("output", "")).strip_edges()
+	var err := combined if not combined.is_empty() else "exit code %d" % int(result.get("exit_code", -1))
 	return {"status": "error", "message": "Failed to configure %s: %s" % [client.display_name, err]}
 
 
@@ -111,8 +114,11 @@ static func remove(client: McpClient, server_name: String) -> Dictionary:
 		return {"status": "error", "message": "Failed to spawn %s CLI" % client.display_name}
 	if int(result.get("exit_code", -1)) == 0:
 		return {"status": "ok", "message": "%s configuration removed" % client.display_name}
-	var stdout := str(result.get("stdout", "")).strip_edges()
-	var err := stdout if not stdout.is_empty() else "exit code %d" % int(result.get("exit_code", -1))
+	## `claude mcp add` writes its real failure diagnostics to stderr, so
+	## prefer `output` (stdout + stderr) over `stdout` alone — otherwise
+	## the user sees "exit code 1" instead of the actual error.
+	var combined := str(result.get("output", "")).strip_edges()
+	var err := combined if not combined.is_empty() else "exit code %d" % int(result.get("exit_code", -1))
 	return {"status": "error", "message": "Failed to remove %s: %s" % [client.display_name, err]}
 
 

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -113,9 +113,15 @@ static var _orphaned_client_status_refresh_threads: Array[Thread] = []
 ## Per-client (not single-slot) so Configure-all can fan out — the
 ## workers are independent, only the row UI is shared, and McpCliExec
 ## bounds the wall-clock for each.
+##
+## No orphan-thread list (unlike the refresh worker): action threads
+## never get abandoned mid-flight. McpCliExec's wall-clock budget caps
+## the worst case at ~10s, so the `_exit_tree` / `_install_update` drain
+## blocks briefly and finishes — there's no path that "gives up" on an
+## action thread the way `_abandon_client_status_refresh_thread` does
+## for the refresh worker.
 var _client_action_threads: Dictionary = {}
 var _client_action_generations: Dictionary = {}
-static var _orphaned_client_action_threads: Array[Thread] = []
 
 # Dev-mode only
 var _dev_section: VBoxContainer
@@ -185,7 +191,6 @@ func _process(_delta: float) -> void:
 	if _connection == null:
 		return
 	_prune_orphaned_client_status_refresh_threads()
-	_prune_orphaned_client_action_threads()
 	_check_client_status_refresh_timeout()
 	_update_status()
 	if _log_section.visible:
@@ -239,26 +244,32 @@ func _drain_client_action_workers() -> void:
 	## `~Thread … destroyed without its completion having been realized` →
 	## VM corruption. Bounded by `McpCliExec` wall-clock budgets, so the
 	## worst case is a ~10s blocking drain, vs. an unbounded SIGSEGV.
+	##
+	## Generation-bumped per-row so any pending `call_deferred(
+	## "_apply_client_action_result")` from a worker that finished after we
+	## started draining detects the generation mismatch and short-circuits
+	## without touching freed UI state.
+	##
+	## After draining, restore the row UI for any in-flight rows: bare
+	## `_client_action_threads.clear()` would leave the dock stuck showing
+	## "Configuring…" / "Removing…" with disabled buttons forever — a
+	## user-visible failure mode for the install-update bail-out branch
+	## (zip extract failure clears `_self_update_in_progress` and the dock
+	## stays alive).
 	for client_id in _client_action_threads.keys():
 		var t: Thread = _client_action_threads[client_id]
 		if t != null:
 			t.wait_to_finish()
+		_client_action_generations[client_id] = int(_client_action_generations.get(client_id, 0)) + 1
+		_finalize_action_buttons(String(client_id))
+		var row: Dictionary = _client_rows.get(String(client_id), {})
+		if not row.is_empty():
+			_apply_row_status(
+				String(client_id),
+				row.get("status", McpClient.Status.NOT_CONFIGURED),
+				""
+			)
 	_client_action_threads.clear()
-	_client_action_generations.clear()
-	for thread in _orphaned_client_action_threads:
-		if thread != null:
-			thread.wait_to_finish()
-	_orphaned_client_action_threads.clear()
-
-
-func _prune_orphaned_client_action_threads() -> void:
-	for i in range(_orphaned_client_action_threads.size() - 1, -1, -1):
-		var thread := _orphaned_client_action_threads[i]
-		if thread == null:
-			_orphaned_client_action_threads.remove_at(i)
-		elif not thread.is_alive():
-			thread.wait_to_finish()
-			_orphaned_client_action_threads.remove_at(i)
 
 
 func _notification(what: int) -> void:
@@ -1213,12 +1224,18 @@ func _dispatch_client_action(client_id: String, action: String) -> void:
 		return
 
 	_set_row_action_in_flight(client_id, action)
+	## Snapshot `server_url` on main: `http_url()` reads
+	## `EditorInterface.get_editor_settings()`, which is main-thread-only.
+	## The status-refresh worker uses the same pattern — see
+	## `_perform_initial_client_status_refresh` and
+	## `_request_client_status_refresh`.
+	var server_url := McpClientConfigurator.http_url()
 	var generation := int(_client_action_generations.get(client_id, 0)) + 1
 	_client_action_generations[client_id] = generation
 	var thread := Thread.new()
 	_client_action_threads[client_id] = thread
 	var err := thread.start(
-		Callable(self, "_run_client_action_worker").bind(client_id, action, generation)
+		Callable(self, "_run_client_action_worker").bind(client_id, action, server_url, generation)
 	)
 	if err != OK:
 		_client_action_threads.erase(client_id)
@@ -1227,12 +1244,12 @@ func _dispatch_client_action(client_id: String, action: String) -> void:
 		_refresh_clients_summary()
 
 
-func _run_client_action_worker(client_id: String, action: String, generation: int) -> void:
+func _run_client_action_worker(client_id: String, action: String, server_url: String, generation: int) -> void:
 	var result: Dictionary
 	if action == "remove":
-		result = McpClientConfigurator.remove(client_id)
+		result = McpClientConfigurator.remove(client_id, server_url)
 	else:
-		result = McpClientConfigurator.configure(client_id)
+		result = McpClientConfigurator.configure(client_id, server_url)
 	if not _client_status_refresh_shutdown_requested:
 		call_deferred("_apply_client_action_result", client_id, action, result, generation)
 

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -103,6 +103,20 @@ var _client_status_refresh_timed_out := false
 var _self_update_in_progress := false
 static var _orphaned_client_status_refresh_threads: Array[Thread] = []
 
+## Per-row worker state for Configure / Remove. Issue #239: shelling out
+## to a hung CLI on main hangs the editor. We dispatch each click to its
+## own thread (one slot per client) and apply the result via call_deferred
+## once the subprocess returns or the wall-clock budget in McpCliExec
+## kicks in. The buttons stay disabled while the slot is busy so the user
+## can't queue a re-click on the same row.
+##
+## Per-client (not single-slot) so Configure-all can fan out — the
+## workers are independent, only the row UI is shared, and McpCliExec
+## bounds the wall-clock for each.
+var _client_action_threads: Dictionary = {}
+var _client_action_generations: Dictionary = {}
+static var _orphaned_client_action_threads: Array[Thread] = []
+
 # Dev-mode only
 var _dev_section: VBoxContainer
 var _server_label: Label
@@ -171,6 +185,7 @@ func _process(_delta: float) -> void:
 	if _connection == null:
 		return
 	_prune_orphaned_client_status_refresh_threads()
+	_prune_orphaned_client_action_threads()
 	_check_client_status_refresh_timeout()
 	_update_status()
 	if _log_section.visible:
@@ -195,6 +210,7 @@ func _exit_tree() -> void:
 	## briefly on plugin-reload is strictly better than the SIGSEGV.
 	_client_status_refresh_shutdown_requested = true
 	_drain_client_status_refresh_workers()
+	_drain_client_action_workers()
 
 
 func _drain_client_status_refresh_workers() -> void:
@@ -214,6 +230,35 @@ func _drain_client_status_refresh_workers() -> void:
 	_client_status_refresh_in_flight = false
 	_client_status_refresh_pending = false
 	_client_status_refresh_pending_force = false
+
+
+func _drain_client_action_workers() -> void:
+	## Same drain semantics as the refresh worker (see comment above): the
+	## plugin disable / install-update path reloads our script class, so any
+	## live Thread must finish before its slot is GC'd or we hit
+	## `~Thread … destroyed without its completion having been realized` →
+	## VM corruption. Bounded by `McpCliExec` wall-clock budgets, so the
+	## worst case is a ~10s blocking drain, vs. an unbounded SIGSEGV.
+	for client_id in _client_action_threads.keys():
+		var t: Thread = _client_action_threads[client_id]
+		if t != null:
+			t.wait_to_finish()
+	_client_action_threads.clear()
+	_client_action_generations.clear()
+	for thread in _orphaned_client_action_threads:
+		if thread != null:
+			thread.wait_to_finish()
+	_orphaned_client_action_threads.clear()
+
+
+func _prune_orphaned_client_action_threads() -> void:
+	for i in range(_orphaned_client_action_threads.size() - 1, -1, -1):
+		var thread := _orphaned_client_action_threads[i]
+		if thread == null:
+			_orphaned_client_action_threads.remove_at(i)
+		elif not thread.is_alive():
+			thread.wait_to_finish()
+			_orphaned_client_action_threads.remove_at(i)
 
 
 func _notification(what: int) -> void:
@@ -588,6 +633,15 @@ func _build_client_row(client_id: String) -> void:
 	var name_label := Label.new()
 	name_label.text = McpClientConfigurator.client_display_name(client_id)
 	name_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	## Long error messages from `_verify_post_state` (e.g. "reported remove ok
+	## but verification still reads configured…") used to push the Retry /
+	## Configure button off-screen — the row's Label wanted its full text
+	## width as minimum size, so the buttons got squeezed out. Wrap onto
+	## multiple lines instead so the row keeps its right edge stable and
+	## the buttons remain visible; the user can also read the whole message
+	## without resizing the window.
+	name_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	name_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
 	row.add_child(name_label)
 
 	var configure_btn := Button.new()
@@ -1126,24 +1180,124 @@ func _on_install_uv() -> void:
 # --- Client section ---
 
 func _on_configure_client(client_id: String) -> void:
-	var result := McpClientConfigurator.configure(client_id)
-	if result.get("status") == "ok":
-		_apply_row_status(client_id, McpClient.Status.CONFIGURED)
-		_client_rows[client_id]["manual_panel"].visible = false
-	else:
-		_apply_row_status(client_id, McpClient.Status.ERROR, str(result.get("message", "failed")))
-		_show_manual_command_for(client_id)
-	_refresh_clients_summary()
+	_dispatch_client_action(client_id, "configure")
 
 
 func _on_remove_client(client_id: String) -> void:
-	var result := McpClientConfigurator.remove(client_id)
+	_dispatch_client_action(client_id, "remove")
+
+
+## Spawn a worker thread for Configure / Remove so a hung CLI can't lock
+## the editor (issue #239). The action verbs are: "configure" → calls
+## `McpClientConfigurator.configure`; "remove" → calls
+## `McpClientConfigurator.remove`. Both routes shell out to the per-client
+## CLI via `McpCliExec.run`, which is wall-clock-bounded.
+##
+## Per-row in-flight rules:
+##   - One worker at a time per client (the row's slot).
+##   - Both buttons disabled while the slot is busy — prevents a
+##     double-click queueing a stale Configure on top of a still-running
+##     Remove.
+##   - The dot turns amber and the row label gets a "Configuring…" /
+##     "Removing…" suffix so the user can see the click was registered.
+func _dispatch_client_action(client_id: String, action: String) -> void:
+	if _self_update_in_progress:
+		## Same gate as the refresh worker — the install window overwrites
+		## plugin scripts on disk, and a worker mid-call into them would
+		## SIGABRT in `GDScriptFunction::call`. See `_install_update`.
+		return
+	if _client_action_threads.has(client_id):
+		return
+	var row: Dictionary = _client_rows.get(client_id, {})
+	if row.is_empty():
+		return
+
+	_set_row_action_in_flight(client_id, action)
+	var generation := int(_client_action_generations.get(client_id, 0)) + 1
+	_client_action_generations[client_id] = generation
+	var thread := Thread.new()
+	_client_action_threads[client_id] = thread
+	var err := thread.start(
+		Callable(self, "_run_client_action_worker").bind(client_id, action, generation)
+	)
+	if err != OK:
+		_client_action_threads.erase(client_id)
+		_finalize_action_buttons(client_id)
+		_apply_row_status(client_id, McpClient.Status.ERROR, "couldn't start worker thread")
+		_refresh_clients_summary()
+
+
+func _run_client_action_worker(client_id: String, action: String, generation: int) -> void:
+	var result: Dictionary
+	if action == "remove":
+		result = McpClientConfigurator.remove(client_id)
+	else:
+		result = McpClientConfigurator.configure(client_id)
+	if not _client_status_refresh_shutdown_requested:
+		call_deferred("_apply_client_action_result", client_id, action, result, generation)
+
+
+func _apply_client_action_result(client_id: String, action: String, result: Dictionary, generation: int) -> void:
+	if int(_client_action_generations.get(client_id, 0)) != generation:
+		return
+	if _client_status_refresh_shutdown_requested:
+		return
+	if _client_action_threads.has(client_id):
+		var t: Thread = _client_action_threads[client_id]
+		if t != null:
+			t.wait_to_finish()
+		_client_action_threads.erase(client_id)
+	_finalize_action_buttons(client_id)
+
+	var success_status := McpClient.Status.NOT_CONFIGURED if action == "remove" else McpClient.Status.CONFIGURED
 	if result.get("status") == "ok":
-		_apply_row_status(client_id, McpClient.Status.NOT_CONFIGURED)
-		_client_rows[client_id]["manual_panel"].visible = false
+		_apply_row_status(client_id, success_status)
+		var row: Dictionary = _client_rows.get(client_id, {})
+		if not row.is_empty():
+			(row["manual_panel"] as VBoxContainer).visible = false
 	else:
 		_apply_row_status(client_id, McpClient.Status.ERROR, str(result.get("message", "failed")))
+		if action == "configure":
+			_show_manual_command_for(client_id)
 	_refresh_clients_summary()
+
+
+## In-flight visual: rewrite the verb onto the button the user just
+## clicked ("Configuring…" / "Removing…") so the feedback lands where
+## their attention already is. Don't pollute the row label — that'd
+## clobber any drift hint ("URL out of date") still relevant to the row.
+## The dot turns amber so the row reads as "busy" at a glance, not as
+## green (premature success) or red (premature failure). Both buttons
+## go disabled so a double-click or second action can't queue stale
+## work behind the in-flight worker.
+func _set_row_action_in_flight(client_id: String, action: String) -> void:
+	var row: Dictionary = _client_rows.get(client_id, {})
+	if row.is_empty():
+		return
+	var configure_btn: Button = row["configure_btn"]
+	var remove_btn: Button = row["remove_btn"]
+	configure_btn.disabled = true
+	remove_btn.disabled = true
+	if action == "remove":
+		remove_btn.text = "Removing…"
+	else:
+		configure_btn.text = "Configuring…"
+	(row["dot"] as ColorRect).color = COLOR_AMBER
+
+
+## Re-enable both buttons and reset their text back to canonical labels.
+## `_apply_row_status` sets `configure_btn.text` per the resulting
+## Status (Configure / Reconfigure / Retry), so we only need to reset
+## `remove_btn.text` here — its sibling visibility toggle already
+## handles whether to show it at all.
+func _finalize_action_buttons(client_id: String) -> void:
+	var row: Dictionary = _client_rows.get(client_id, {})
+	if row.is_empty():
+		return
+	(row["configure_btn"] as Button).disabled = false
+	var remove_btn: Button = row["remove_btn"]
+	remove_btn.disabled = false
+	remove_btn.text = "Remove"
 
 
 func _on_refresh_clients_pressed() -> void:
@@ -1676,13 +1830,17 @@ func _run_client_status_refresh_worker(client_probes: Array[Dictionary], server_
 		var client_id := String(probe.get("id", ""))
 		if client_id.is_empty():
 			continue
-		var status := McpClientConfigurator.check_status_for_url_with_cli_path(
+		var details := McpClientConfigurator.check_status_details_for_url_with_cli_path(
 			client_id,
 			server_url,
 			String(probe.get("cli_path", ""))
 		)
 		var installed := bool(probe.get("installed", false))
-		results[client_id] = {"status": status, "installed": installed}
+		results[client_id] = {
+			"status": details.get("status", McpClient.Status.NOT_CONFIGURED),
+			"installed": installed,
+			"error_msg": details.get("error_msg", ""),
+		}
 	if not _client_status_refresh_shutdown_requested:
 		call_deferred("_apply_client_status_refresh_results", results, generation)
 
@@ -1695,11 +1853,17 @@ func _apply_client_status_refresh_results(results: Dictionary, generation: int) 
 		_client_status_refresh_thread = null
 
 	for client_id in results:
+		## Skip rows whose Configure / Remove worker is still running so the
+		## status refresh doesn't overwrite the "Configuring…" / "Removing…"
+		## badge with a stale dot color. The action's own completion handler
+		## will repaint the row when it lands.
+		if _client_action_threads.has(String(client_id)):
+			continue
 		var result: Dictionary = results[client_id]
 		_apply_row_status(
 			String(client_id),
 			result.get("status", McpClient.Status.NOT_CONFIGURED),
-			"",
+			str(result.get("error_msg", "")),
 			result.get("installed", false)
 		)
 	_finalize_completed_refresh()
@@ -1908,6 +2072,7 @@ func _install_update() -> void:
 	## so every spawn path is gated.
 	_self_update_in_progress = true
 	_drain_client_status_refresh_workers()
+	_drain_client_action_workers()
 
 	var zip_path := ProjectSettings.globalize_path(UPDATE_TEMP_ZIP)
 	var install_base := ProjectSettings.globalize_path("res://")

--- a/test_project/tests/test_cli_exec.gd
+++ b/test_project/tests/test_cli_exec.gd
@@ -1,0 +1,77 @@
+@tool
+extends McpTestSuite
+
+## Tests for the wall-clock-bounded CLI helper that backs every dock
+## shell-out (issues #238 / #239 — a hung `claude mcp list` was wedging
+## the worker thread for 6+ minutes; the Configure / Remove paths had the
+## same root cause exposed on main).
+
+
+func suite_name() -> String:
+	return "cli_exec"
+
+
+func test_run_returns_spawn_failed_for_empty_exe() -> void:
+	## Empty `exe` is the cheap pre-flight check before we hand anything
+	## to the OS. Asserting the dict shape here so callers in
+	## `_cli_strategy.gd` can rely on the four keys without optional-key
+	## defensiveness at every call site.
+	var result := McpCliExec.run("", [])
+	assert_true(bool(result.get("spawn_failed", false)),
+		"Empty exe must short-circuit as spawn_failed=true")
+	assert_false(bool(result.get("timed_out", false)),
+		"Spawn failure is not a timeout")
+	assert_eq(int(result.get("exit_code", 0)), -1,
+		"Spawn failure must surface exit_code=-1 so callers don't read it as success")
+	assert_eq(str(result.get("stdout", "x")), "",
+		"Spawn failure must return empty stdout")
+
+
+func test_run_captures_stdout_and_zero_exit_on_quick_command() -> void:
+	## End-to-end: spawn `echo hello`, wait for it, capture stdout.
+	## Skipped on Windows because the host's `echo` lives inside cmd.exe
+	## and isn't reachable as a standalone exe via OS.execute_with_pipe.
+	if OS.get_name() == "Windows":
+		skip("echo is a cmd.exe builtin on Windows; covered by the Unix path")
+		return
+	var echo := "/bin/echo"
+	if not FileAccess.file_exists(echo):
+		echo = "/usr/bin/echo"
+	if not FileAccess.file_exists(echo):
+		skip("No /bin/echo or /usr/bin/echo on this host")
+		return
+	var result := McpCliExec.run(echo, ["hello-from-mcpcliexec"], 5000)
+	assert_false(bool(result.get("spawn_failed", false)),
+		"echo should spawn successfully on POSIX")
+	assert_false(bool(result.get("timed_out", false)),
+		"echo finishes well inside a 5s budget")
+	assert_eq(int(result.get("exit_code", -1)), 0,
+		"echo exits 0 on success")
+	assert_contains(str(result.get("stdout", "")), "hello-from-mcpcliexec",
+		"Captured stdout must include the echoed token")
+
+
+func test_run_kills_subprocess_when_budget_expires() -> void:
+	## The headline behavior: a hung CLI no longer hangs the editor.
+	## Spawn `sleep 5` with a 200ms budget — McpCliExec should kill it
+	## and return timed_out=true. The whole assertion path must complete
+	## in well under 5s; if it doesn't, the kill regressed and the test
+	## suite itself surfaces the same wedge the issue describes.
+	if OS.get_name() == "Windows":
+		skip("Windows lacks `sleep` as a standalone exe; cover via Unix")
+		return
+	var sleep_exe := "/bin/sleep"
+	if not FileAccess.file_exists(sleep_exe):
+		sleep_exe = "/usr/bin/sleep"
+	if not FileAccess.file_exists(sleep_exe):
+		skip("No /bin/sleep or /usr/bin/sleep on this host")
+		return
+	var started_msec := Time.get_ticks_msec()
+	var result := McpCliExec.run(sleep_exe, ["5"], 200)
+	var elapsed_msec := Time.get_ticks_msec() - started_msec
+	assert_true(bool(result.get("timed_out", false)),
+		"sleep 5 with 200ms budget must surface timed_out=true")
+	assert_eq(int(result.get("exit_code", 0)), -1,
+		"timed_out runs must report exit_code=-1 — never a real exit code")
+	assert_true(elapsed_msec < 3000,
+		"Timeout kill must return within ~budget+poll, not wait for sleep to finish (elapsed=%dms)" % elapsed_msec)

--- a/test_project/tests/test_cli_exec.gd.uid
+++ b/test_project/tests/test_cli_exec.gd.uid
@@ -1,0 +1,1 @@
+uid://d1namym0b05rt

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -330,3 +330,149 @@ func test_crashed_body_mentions_pypi_propagation_on_uvx_tier() -> void:
 		assert_contains(body, "Reload Plugin", "uvx-tier body should direct the user to the retry action")
 	else:
 		assert_contains(body, "output log", "Non-uvx body should still point at Godot's traceback")
+
+
+# --- Configure / Remove run off-thread (issue #239) ----------------------
+
+func _first_client_id() -> String:
+	var ids := McpClientConfigurator.client_ids()
+	if ids.is_empty():
+		return ""
+	return ids[0]
+
+
+func test_set_row_action_in_flight_disables_both_buttons_and_marks_amber() -> void:
+	## Issue #239 surface: clicking Configure on a CLI client used to
+	## block main on `OS.execute`. The new flow dispatches to a worker;
+	## while the worker is in flight the row must look "busy" so the
+	## user doesn't assume nothing happened and click again. The verb
+	## lands on the button the user clicked — not the name label —
+	## otherwise a long row error message would compete with the badge
+	## for the same horizontal space.
+	_dock._build_ui()
+	var any_id := _first_client_id()
+	if any_id.is_empty():
+		skip("No clients registered")
+		return
+	_dock._set_row_action_in_flight(any_id, "configure")
+	var row: Dictionary = _dock._client_rows[any_id]
+	assert_true((row["configure_btn"] as Button).disabled,
+		"Configure button must be disabled while worker is in flight")
+	assert_true((row["remove_btn"] as Button).disabled,
+		"Remove button must also be disabled — a click during in-flight could queue stale work")
+	assert_eq((row["dot"] as ColorRect).color, McpDockScript.COLOR_AMBER,
+		"Dot turns amber so the row reads as 'busy', not green/red")
+	assert_contains((row["configure_btn"] as Button).text, "Configuring",
+		"Configure-in-flight verb must land on the configure button itself")
+
+
+func test_set_row_action_in_flight_uses_removing_label_for_remove_action() -> void:
+	## The verb must track the action — Configuring/Removing — otherwise a
+	## Remove click silently shows "Configuring…" and the user thinks they
+	## hit the wrong button. We also verify the configure button's text
+	## stays untouched so the two states don't overlap.
+	_dock._build_ui()
+	var any_id := _first_client_id()
+	if any_id.is_empty():
+		skip("No clients registered")
+		return
+	_dock._set_row_action_in_flight(any_id, "remove")
+	var row: Dictionary = _dock._client_rows[any_id]
+	assert_contains((row["remove_btn"] as Button).text, "Removing",
+		"Remove action must show 'Removing…' on the remove button itself")
+	assert_false(str((row["configure_btn"] as Button).text).contains("Removing"),
+		"Configure button must not be tagged with the Remove verb")
+
+
+func test_finalize_action_buttons_reenables_after_in_flight() -> void:
+	_dock._build_ui()
+	var any_id := _first_client_id()
+	if any_id.is_empty():
+		skip("No clients registered")
+		return
+	_dock._set_row_action_in_flight(any_id, "configure")
+	_dock._finalize_action_buttons(any_id)
+	var row: Dictionary = _dock._client_rows[any_id]
+	assert_false((row["configure_btn"] as Button).disabled,
+		"Configure button must re-enable after the worker resolves")
+	assert_false((row["remove_btn"] as Button).disabled,
+		"Remove button must re-enable too")
+
+
+func test_dispatch_client_action_short_circuits_during_self_update() -> void:
+	## Same gate the refresh worker honors: while `_install_update` is
+	## overwriting plugin scripts on disk, spawning a worker that walks
+	## into `_cli_strategy.gd` mid-bytecode-swap SIGABRTs the editor.
+	_dock._build_ui()
+	var any_id := _first_client_id()
+	if any_id.is_empty():
+		skip("No clients registered")
+		return
+	_dock._self_update_in_progress = true
+	_dock._dispatch_client_action(any_id, "configure")
+	assert_false(_dock._client_action_threads.has(any_id),
+		"No worker thread must be created while self-update is in progress")
+	_dock._self_update_in_progress = false
+
+
+func test_dispatch_client_action_noop_when_slot_already_in_flight() -> void:
+	## Double-click guard: a second click while the first worker is still
+	## running must not start a second thread on the same row. Without
+	## this, the row's button/label state would race between the two
+	## workers' deferred callbacks.
+	_dock._build_ui()
+	var any_id := _first_client_id()
+	if any_id.is_empty():
+		skip("No clients registered")
+		return
+	## Plant a sentinel in the slot so the dispatch sees it as in-flight
+	## without us having to actually spawn (and then drain) a real
+	## subprocess. Cleared in teardown so we don't leak the entry.
+	var sentinel := Thread.new()
+	_dock._client_action_threads[any_id] = sentinel
+	_dock._dispatch_client_action(any_id, "configure")
+	assert_eq(_dock._client_action_threads[any_id], sentinel,
+		"Dispatch must leave the existing slot untouched while in flight")
+	_dock._client_action_threads.erase(any_id)
+
+
+func test_apply_status_refresh_results_skips_rows_with_in_flight_action() -> void:
+	## Race scenario: user clicks Configure (worker thread starts), then
+	## focus-out/focus-in fires while the worker is still running. The
+	## refresh worker returns a stale "NOT_CONFIGURED" snapshot; if we
+	## let it through, the in-flight "Configuring…" badge gets clobbered.
+	_dock._build_ui()
+	var any_id := _first_client_id()
+	if any_id.is_empty():
+		skip("No clients registered")
+		return
+	_dock._set_row_action_in_flight(any_id, "configure")
+	_dock._client_action_threads[any_id] = Thread.new()
+	_dock._client_status_refresh_generation = 1
+	var results := {
+		any_id: {
+			"status": McpClient.Status.NOT_CONFIGURED,
+			"installed": true,
+			"error_msg": "",
+		}
+	}
+	_dock._apply_client_status_refresh_results(results, 1)
+	var row: Dictionary = _dock._client_rows[any_id]
+	assert_contains((row["configure_btn"] as Button).text, "Configuring",
+		"In-flight Configuring badge on the button must survive a concurrent refresh result")
+	assert_eq((row["dot"] as ColorRect).color, McpDockScript.COLOR_AMBER,
+		"Dot must stay amber while the action worker hasn't completed")
+	_dock._client_action_threads.erase(any_id)
+
+
+func test_drain_client_action_workers_clears_dictionaries() -> void:
+	## `_install_update` calls this drain before extracting the release
+	## zip, same reason as the refresh worker drain — a worker mid-call
+	## into a half-overwritten script SIGABRTs the editor.
+	_dock._client_action_threads["sentinel-id"] = null
+	_dock._client_action_generations["sentinel-id"] = 7
+	_dock._drain_client_action_workers()
+	assert_true(_dock._client_action_threads.is_empty(),
+		"Drain must empty the action-thread map")
+	assert_true(_dock._client_action_generations.is_empty(),
+		"Drain must also clear generation tokens so a follow-up dispatch starts fresh")

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -465,14 +465,43 @@ func test_apply_status_refresh_results_skips_rows_with_in_flight_action() -> voi
 	_dock._client_action_threads.erase(any_id)
 
 
-func test_drain_client_action_workers_clears_dictionaries() -> void:
+func test_drain_client_action_workers_clears_threads_and_bumps_generation() -> void:
 	## `_install_update` calls this drain before extracting the release
 	## zip, same reason as the refresh worker drain — a worker mid-call
-	## into a half-overwritten script SIGABRTs the editor.
+	## into a half-overwritten script SIGABRTs the editor. The drain
+	## bumps generation per-row so any pending `call_deferred(
+	## "_apply_client_action_result")` from a worker that finished after
+	## the drain detects the mismatch and short-circuits before touching
+	## restored UI state.
 	_dock._client_action_threads["sentinel-id"] = null
 	_dock._client_action_generations["sentinel-id"] = 7
 	_dock._drain_client_action_workers()
 	assert_true(_dock._client_action_threads.is_empty(),
-		"Drain must empty the action-thread map")
-	assert_true(_dock._client_action_generations.is_empty(),
-		"Drain must also clear generation tokens so a follow-up dispatch starts fresh")
+		"Drain must empty the action-thread map so a follow-up dispatch starts fresh")
+	assert_eq(int(_dock._client_action_generations.get("sentinel-id", 0)), 8,
+		"Drain must bump generation so any late call_deferred from the drained worker is rejected as stale")
+
+
+func test_drain_client_action_workers_restores_in_flight_row_buttons() -> void:
+	## Issue #239 follow-up: `_install_update` has a bail-out branch (zip
+	## extract failure) that clears `_self_update_in_progress` and leaves
+	## the dock alive. Without restoring the row UI in the drain, an
+	## in-flight Configure / Remove would leave the buttons disabled and
+	## the active button stuck on "Configuring…" / "Removing…" forever
+	## because `_apply_client_action_result` never runs after we erase
+	## the thread slot.
+	_dock._build_ui()
+	var any_id := _first_client_id()
+	if any_id.is_empty():
+		skip("No clients registered")
+		return
+	_dock._set_row_action_in_flight(any_id, "configure")
+	_dock._client_action_threads[any_id] = null
+	_dock._drain_client_action_workers()
+	var row: Dictionary = _dock._client_rows[any_id]
+	assert_false((row["configure_btn"] as Button).disabled,
+		"Drain must re-enable the configure button so the user can retry")
+	assert_false((row["remove_btn"] as Button).disabled,
+		"Drain must re-enable the remove button too")
+	assert_false(str((row["configure_btn"] as Button).text).contains("Configuring"),
+		"Drain must clear the in-flight badge from the configure button")

--- a/tests/unit/test_dock_cli_timeout.py
+++ b/tests/unit/test_dock_cli_timeout.py
@@ -1,0 +1,160 @@
+"""Source-structure regression tests for the wall-clock-bounded CLI fix.
+
+Issues #238 / #239: a hung `claude mcp list` was wedging the dock's
+status refresh worker for 6+ minutes; the Configure / Remove buttons hit
+the same root cause on the editor main thread. The fix is layered:
+
+1. `McpCliExec.run` wraps every shell-out in an `OS.execute_with_pipe` +
+   poll/`OS.kill` loop with a hard wall-clock budget.
+2. `McpCliStrategy` uses the helper from configure / remove / status —
+   no direct `OS.execute(..., true)` call survives.
+3. The dock dispatches Configure / Remove to a per-row worker thread
+   instead of running on main, with the existing in-flight UI pattern
+   already used by status refresh.
+
+These tests lock the structure in so a future "simplify" pass can't
+silently regress either issue.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[2] / "plugin" / "addons" / "godot_ai"
+
+
+def test_cli_strategy_routes_every_shell_out_through_mcpcliexec() -> None:
+    """No bare OS.execute survives in _cli_strategy.gd."""
+
+    cli_source = (PLUGIN_ROOT / "clients" / "_cli_strategy.gd").read_text()
+
+    # The whole point of the refactor: every CLI invocation must go
+    # through the bounded helper. A bare OS.execute slipping back in
+    # would re-introduce the hang.
+    assert "OS.execute(" not in cli_source, (
+        "OS.execute(...) must not appear in _cli_strategy.gd — every "
+        "shell-out should go through McpCliExec.run for the wall-clock "
+        "timeout. See issues #238 / #239."
+    )
+    # The replacement should be present in all three call sites
+    # (configure, remove, status check) at minimum.
+    assert cli_source.count("McpCliExec.run(") >= 3, (
+        "Configure, Remove, and check_status_details must each call "
+        "McpCliExec.run — fewer call sites means at least one CLI path "
+        "is still synchronous."
+    )
+
+
+def test_cli_exec_helper_uses_pipe_spawn_and_poll_kill() -> None:
+    """The helper must spawn detached and kill on timeout — not a blocking OS.execute."""
+
+    helper_source = (PLUGIN_ROOT / "clients" / "_cli_exec.gd").read_text()
+
+    # Pipe-based spawn returns a PID we can poll on. A blocking
+    # OS.execute(..., true) here would just relocate the original hang.
+    assert "OS.execute_with_pipe(" in helper_source
+    assert "OS.is_process_running(" in helper_source
+    assert "OS.kill(" in helper_source
+    # Sanity-check the return shape so callers can rely on the four keys.
+    for key in ("exit_code", "stdout", "timed_out", "spawn_failed"):
+        assert f'"{key}"' in helper_source, (
+            f"Helper must populate the '{key}' key — callers in "
+            "_cli_strategy.gd dispatch on it."
+        )
+
+
+def test_cli_strategy_surfaces_timeout_in_configure_and_remove_messages() -> None:
+    """A timeout must produce a user-actionable error, not a cryptic exit code."""
+
+    cli_source = (PLUGIN_ROOT / "clients" / "_cli_strategy.gd").read_text()
+
+    # The dock surfaces these strings in its row-error label and "Run
+    # this manually" panel. Drift here means the user sees "exit code
+    # -1" instead of "timed out — retry by hand."
+    assert "Configure" in cli_source and "timed out" in cli_source
+    assert "Remove" in cli_source
+    # The probe path uses a different label ("probe timed out") because
+    # the worker plumbs it into the row's error_msg slot, not into a
+    # configure result. Guarding this prevents an over-eager unifier
+    # from collapsing the two phrasings and breaking the row UI.
+    assert "probe timed out" in cli_source
+
+
+def test_dock_dispatches_configure_and_remove_to_worker_thread() -> None:
+    """Issue #239: the Configure / Remove buttons must not block main."""
+
+    dock_source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+
+    # The dispatch funnel must exist and route the click into a worker.
+    assert "func _dispatch_client_action(" in dock_source
+    assert "Thread.new()" in dock_source
+    # The deferred apply lives on main; the worker only does the
+    # blocking call and a call_deferred handoff.
+    assert "call_deferred(\"_apply_client_action_result\"" in dock_source
+    assert "func _run_client_action_worker(" in dock_source
+    # The two button handlers should NOT call McpClientConfigurator
+    # directly — that would re-introduce the main-thread block. They
+    # forward to the dispatcher.
+    on_configure = dock_source.split(
+        "func _on_configure_client(client_id: String) -> void:", 1
+    )[1].split("\n\nfunc ", 1)[0]
+    on_remove = dock_source.split(
+        "func _on_remove_client(client_id: String) -> void:", 1
+    )[1].split("\n\nfunc ", 1)[0]
+    assert "_dispatch_client_action(" in on_configure
+    assert "_dispatch_client_action(" in on_remove
+    assert "McpClientConfigurator.configure(" not in on_configure, (
+        "Configure handler must dispatch to a worker, not call the "
+        "configurator inline (issue #239)."
+    )
+    assert "McpClientConfigurator.remove(" not in on_remove, (
+        "Remove handler must dispatch to a worker, not call the "
+        "configurator inline (issue #239)."
+    )
+
+
+def test_dock_drains_action_workers_during_install_update_and_exit_tree() -> None:
+    """Worker drain must cover both shutdown paths — same reason as the refresh worker."""
+
+    dock_source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+
+    # Both `_exit_tree` and `_install_update` must drain or we hit
+    # `~Thread … destroyed without its completion having been realized`
+    # → VM corruption, same as #232.
+    exit_block = dock_source.split("func _exit_tree() -> void:", 1)[1].split(
+        "\n\nfunc ", 1
+    )[0]
+    install_block = dock_source.split("func _install_update() -> void:", 1)[1].split(
+        "\n\nfunc ", 1
+    )[0]
+    assert "_drain_client_action_workers()" in exit_block
+    assert "_drain_client_action_workers()" in install_block
+
+
+def test_dock_action_dispatch_gates_on_self_update_in_progress() -> None:
+    """The same gate the refresh worker honors must protect Configure / Remove."""
+
+    dock_source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+    block = dock_source.split("func _dispatch_client_action(", 1)[1].split(
+        "\n\nfunc ", 1
+    )[0]
+    assert "_self_update_in_progress" in block, (
+        "Configure / Remove dispatch must short-circuit during the "
+        "install-update window — a worker mid-call into a half-overwritten "
+        "_cli_strategy.gd SIGABRTs (same root cause as the refresh-worker "
+        "gate in #235)."
+    )
+
+
+def test_status_refresh_apply_skips_rows_with_in_flight_action() -> None:
+    """A concurrent refresh result must not stomp the 'Configuring…' badge."""
+
+    dock_source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+    apply_block = dock_source.split(
+        "func _apply_client_status_refresh_results(", 1
+    )[1].split("\n\nfunc ", 1)[0]
+    assert "_client_action_threads.has(" in apply_block, (
+        "Refresh-result apply must skip rows whose action worker is "
+        "still running — otherwise focus-in lands a stale snapshot on "
+        "top of the in-flight badge."
+    )

--- a/tests/unit/test_editor_focus_refocus.py
+++ b/tests/unit/test_editor_focus_refocus.py
@@ -220,7 +220,10 @@ def test_worker_uses_main_thread_probe_snapshot_for_cli_paths() -> None:
     )[0]
 
     assert "client_status_probe_snapshot" in dock_source
-    assert "check_status_for_url_with_cli_path" in worker_block
+    # Worker uses the details variant so probe timeouts (issue #238) can
+    # surface as "probe timed out" on the row instead of being silently
+    # conflated with NOT_CONFIGURED.
+    assert "check_status_details_for_url_with_cli_path" in worker_block
     assert "McpClientConfigurator.is_installed" not in worker_block
     assert "resolve_cli_path" in configurator_source
     assert "check_status_with_cli_path" in cli_source


### PR DESCRIPTION
## Summary

Closes #238 and #239 — both stem from the same root cause: synchronous `OS.execute(..., true)` calls against per-client CLIs (`claude mcp list`, `claude mcp add`, etc.) with no wall-clock budget. Under contention the call hangs indefinitely, wedging the status refresh worker (#238) or the editor main thread (#239).

- **`McpCliExec.run`** wraps every CLI shell-out in `OS.execute_with_pipe` + poll/`OS.kill`. A hung subprocess gets killed at its budget instead of trapping the caller. Configure / Remove use 10 s; status probes use 6 s.
- **`McpCliStrategy`** routes configure / remove / status through the helper — no bare `OS.execute` survives.
- **Dock Configure / Remove** dispatch to a per-row worker thread (mirroring the existing status-refresh worker pattern from #228 / #232 / #235). While in flight, both buttons disable and the clicked button's text becomes "Configuring…" / "Removing…". Drained on `_exit_tree` and at the start of `_install_update`.
- **Probe timeouts** surface as `error_msg="probe timed out"` on the affected row instead of being silently flipped to `NOT_CONFIGURED`.
- **Long error messages** (e.g. `_verify_post_state` "reported remove ok but verification still reads configured…") used to push the Retry button off-screen — the row label now `AUTOWRAP_WORD_SMART`s onto multiple lines so buttons stay visible without resizing the window.

## Test plan

- [x] `pytest -q` — 651 passed (16 in the new + impacted unit tests, including a `test_dock_cli_timeout.py` that locks in source-structure invariants).
- [x] `ruff check src/ tests/` — clean.
- [x] `test_run` against a freshly-launched editor on this branch — 945 passed, 0 failed across 36 suites.
  - `cli_exec` suite (3 tests) verifies real subprocess spawn + kill on timeout (`/bin/sleep 5` with 200 ms budget returns within ~250 ms).
  - `dock` suite gained 7 new tests covering button disable/enable, in-flight badge placement on the active button, self-update gate, in-flight slot deduplication, drain helpers, and the in-flight refresh-result skip.
- [ ] Live: click Remove on a configured CLI client and confirm (a) the editor stays responsive while the worker runs, (b) the "Removing…" badge lands on the Remove button itself, (c) if `_verify_post_state` reports a long error, the row label wraps and the Retry button stays visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
