### PR TITLE
fix(plugin, dock): unbreak self-update across new-class_name releases (#242)

### DIFF
--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -2168,6 +2168,34 @@ func _install_update() -> void:
 
 
 func _on_filesystem_scanned_for_update() -> void:
+	## Belt-and-suspenders: verify the new release's plugin.gd actually parses
+	## before we fire `set_plugin_enabled(false/true)`. If the new release adds
+	## a class_name'd file that's referenced by a typed-var declaration in
+	## plugin.gd (or its transitive dependencies), GDScript's parser can fail
+	## to resolve the new class_name during hot-reload — `plugin.gd` then
+	## fails to compile and the v2.1.x plugin enters a degraded state. The
+	## subsequent `_exit_tree` cascade has been observed to SIGABRT in the
+	## wild (#242).
+	##
+	## `ResourceLoader.load` returns `null` when a script has a parse error,
+	## so a single load is enough to detect the hazard. On failure, fall back
+	## to the same "Restart editor to apply" surface the pre-Godot-4.4 path
+	## already uses — the user manually restarts, picks up the new files
+	## fresh from disk, and dodges the in-place reload entirely.
+	##
+	## The check itself is cheap (the script's already in the editor's cache
+	## post-`fs.scan()`) and only runs once per update install.
+	if ResourceLoader.load("res://addons/godot_ai/plugin.gd") == null:
+		_self_update_in_progress = false
+		_update_btn.text = "Restart editor to apply"
+		_update_btn.disabled = true
+		_update_label.text = (
+			"Updated! Restart the editor to apply — auto-reload skipped because "
+			"the new release added a script class plugin.gd parses against "
+			"(safe-mode fallback, see #242)."
+		)
+		_update_label.add_theme_color_override("font_color", Color.GREEN)
+		return
 	_update_btn.text = "Reloading..."
 	_reload_after_update.call_deferred()
 

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -2189,11 +2189,7 @@ func _on_filesystem_scanned_for_update() -> void:
 		_self_update_in_progress = false
 		_update_btn.text = "Restart editor to apply"
 		_update_btn.disabled = true
-		_update_label.text = (
-			"Updated! Restart the editor to apply — auto-reload skipped because "
-			"the new release added a script class plugin.gd parses against "
-			"(safe-mode fallback, see #242)."
-		)
+		_update_label.text = "Updated! Restart the editor to apply — auto-reload skipped (safe-mode fallback, see #242)."
 		_update_label.add_theme_color_override("font_color", Color.GREEN)
 		return
 	_update_btn.text = "Reloading..."

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -38,8 +38,22 @@ const SPAWN_GRACE_MS := 5 * 1000
 var _connection: Connection
 var _dispatcher: McpDispatcher
 var _log_buffer: McpLogBuffer
-var _game_log_buffer: GameLogBuffer
-var _editor_log_buffer: EditorLogBuffer
+## Untyped — `GameLogBuffer` and `EditorLogBuffer` are class_names whose
+## inheritance chain has changed between releases (v2.1.2 refactored both to
+## extend `StructuredLogRing`, a class_name that didn't exist in v2.1.1).
+## A typed declaration here is a self-update hazard: when `_install_update`
+## extracts the new release's files and `fs.scan()` triggers script reload,
+## the parser hits these typed-vars before the new dependent class_names
+## are registered in the global table → plugin.gd parse error → v2.1.x
+## plugin fails to load → set_plugin_enabled(false)'s _exit_tree cascade
+## fires on a degraded dock instance → SIGABRT. See #242.
+##
+## Same lesson as the existing `_editor_logger` field below: untyped + load
+## via `preload()` at construction time. The `preload()` is resolved at
+## script-load and doesn't need the global class_name registry to be ahead
+## of plugin.gd's parse, breaking the chicken-and-egg.
+var _game_log_buffer
+var _editor_log_buffer
 ## Untyped — script extends Godot 4.5+'s Logger class, loaded via load() so
 ## the plugin still parses on 4.4. Null on Godot < 4.5 or before
 ## `_attach_editor_logger` runs; "attached" state IS exactly "non-null".
@@ -88,8 +102,10 @@ func _enter_tree() -> void:
 	_start_server()
 
 	_log_buffer = McpLogBuffer.new()
-	_game_log_buffer = GameLogBuffer.new()
-	_editor_log_buffer = EditorLogBuffer.new()
+	## See the `_game_log_buffer` / `_editor_log_buffer` declaration comment
+	## above for why these go through `preload()` instead of `ClassName.new()`.
+	_game_log_buffer = preload("res://addons/godot_ai/utils/game_log_buffer.gd").new()
+	_editor_log_buffer = preload("res://addons/godot_ai/utils/editor_log_buffer.gd").new()
 	_attach_editor_logger()
 	_dispatcher = McpDispatcher.new(_log_buffer)
 

--- a/tests/unit/test_editor_focus_refocus.py
+++ b/tests/unit/test_editor_focus_refocus.py
@@ -209,6 +209,112 @@ def test_install_update_drains_workers_and_blocks_spawning_before_extract() -> N
     )
 
 
+def test_plugin_gd_avoids_typed_class_name_for_log_buffers() -> None:
+    """plugin.gd's `_game_log_buffer` / `_editor_log_buffer` must be untyped (#242).
+
+    Hot-reload during self-update parses the new release's plugin.gd before
+    its dependent class_name'd files are guaranteed to be in the global class
+    table. A typed declaration like `var _editor_log_buffer: EditorLogBuffer`
+    fails to resolve when `EditorLogBuffer` is a class_name added in this
+    release (and similarly for `GameLogBuffer` when its `extends` chain
+    changes to reference a new class_name).
+
+    Failed plugin.gd parse → degraded plugin state → set_plugin_enabled(false)
+    fires _exit_tree on a half-broken dock → SIGABRT in the user's wild
+    (issue #242, observed on v2.1.1 → v2.1.2).
+
+    Lock the untyped pattern so a future contributor doesn't "fix" the
+    apparent oversight by re-typing the field. The runtime parameter checks
+    on EditorHandler / GameLogger callees still enforce the type fence —
+    the typing just moves from plugin.gd's parse to the call site's runtime
+    check, breaking the chicken-and-egg with class_name registration order.
+
+    Same lesson as the existing untyped `_editor_logger` pattern.
+    """
+
+    plugin_source = (PLUGIN_ROOT / "plugin.gd").read_text()
+
+    # Find the var declarations. Allow whitespace around `var`.
+    forbidden_decls = (
+        "var _game_log_buffer: GameLogBuffer",
+        "var _editor_log_buffer: EditorLogBuffer",
+    )
+    for forbidden in forbidden_decls:
+        assert forbidden not in plugin_source, (
+            f"plugin.gd must not declare `{forbidden}` — typed-var declarations "
+            "against class_names that may be added or refactored in future "
+            "releases break self-update hot-reload (#242). Use untyped + "
+            "`preload()` instead, like the existing `_editor_logger` field."
+        )
+
+    # And confirm the corresponding preload sites exist (preload-resolved
+    # construction doesn't require the global class_name registry to be
+    # ahead of plugin.gd's parse).
+    assert 'preload("res://addons/godot_ai/utils/game_log_buffer.gd").new()' in plugin_source, (
+        "plugin.gd must construct `_game_log_buffer` via "
+        "`preload(...).new()` — the path-based load resolves at "
+        "script-load time without needing GameLogBuffer's class_name "
+        "registered first."
+    )
+    assert 'preload("res://addons/godot_ai/utils/editor_log_buffer.gd").new()' in plugin_source, (
+        "plugin.gd must construct `_editor_log_buffer` via "
+        "`preload(...).new()` — same reason as above for EditorLogBuffer."
+    )
+
+
+def test_install_update_falls_back_on_plugin_parse_failure() -> None:
+    """`_on_filesystem_scanned_for_update` must verify plugin.gd parses before reload (#242).
+
+    Even with the untyped-log-buffer fix, future releases could introduce
+    other parse hazards (renamed `class_name`s, removed inheritance bases,
+    refactored cross-class references). The install flow's belt-and-suspenders
+    is to load the new plugin.gd via `ResourceLoader.load` after `fs.scan()`
+    completes; `null` return = parse error = bail out of the in-place reload
+    and fall back to the same "Restart editor to apply" message the
+    pre-Godot-4.4 path uses.
+
+    This avoids exercising `set_plugin_enabled(false/true)`'s _exit_tree
+    cascade against a degraded plugin instance — the observed crash mode
+    in #242.
+    """
+
+    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+    block = source.split(
+        "func _on_filesystem_scanned_for_update() -> void:", 1
+    )[1].split("\n\nfunc ", 1)[0]
+
+    assert 'ResourceLoader.load("res://addons/godot_ai/plugin.gd")' in block, (
+        "_on_filesystem_scanned_for_update must verify the new plugin.gd "
+        "parses (via ResourceLoader.load) before triggering "
+        "_reload_after_update. Without this gate, a parse error in the new "
+        "release leaves the v2.1.x plugin in a degraded state when "
+        "set_plugin_enabled(false) fires its _exit_tree cascade. See #242."
+    )
+    assert "_self_update_in_progress = false" in block, (
+        "On parse failure, the install flag must be cleared so the dock "
+        "instance can resume normal refresh once the user restarts the "
+        "editor manually (matching the pre-Godot-4.4 fallback path)."
+    )
+    assert "Restart the editor" in block, (
+        "On parse failure, surface the same 'Restart the editor to apply' "
+        "user-facing message that the pre-Godot-4.4 path already uses. "
+        "That message is a known-good fallback path."
+    )
+
+    # Also confirm the bail-out happens BEFORE _reload_after_update is queued.
+    parse_check_idx = block.find('ResourceLoader.load("res://addons/godot_ai/plugin.gd")')
+    reload_call_idx = block.find("_reload_after_update.call_deferred()")
+    assert parse_check_idx > 0 and reload_call_idx > 0, (
+        "Test fixture broken: expected both ResourceLoader.load and "
+        "_reload_after_update.call_deferred in the function body."
+    )
+    assert parse_check_idx < reload_call_idx, (
+        "Parse check must run BEFORE the deferred reload call — a parse "
+        "failure must short-circuit and not fall through into the in-place "
+        "set_plugin_enabled cycle."
+    )
+
+
 def test_worker_uses_main_thread_probe_snapshot_for_cli_paths() -> None:
     """CLI path discovery caches should not be mutated from the refresh worker."""
 


### PR DESCRIPTION
## Summary

Closes [#242](https://github.com/hi-godot/godot-ai/issues/242).

The `v2.1.1 → v2.1.2` in-place self-update SIGABRT'd in `_propagate_exit_tree` → `Dictionary::keys()` for users in the wild (Project Boost). Root cause: v2.1.2's `plugin.gd:42` declared `var _editor_log_buffer: EditorLogBuffer` — a typed-var against a brand-new `class_name` introduced by [#240](https://github.com/hi-godot/godot-ai/pull/240). During `_install_update`'s extract → `fs.scan()` cycle, the parser hits that typed-var BEFORE `EditorLogBuffer`'s class_name has been registered in the global table → `plugin.gd` parse fails → v2.1.x plugin enters a degraded state → the follow-up `set_plugin_enabled(false)` fires its `_exit_tree` cascade against that degraded instance → crash downstream.

`GameLogBuffer`'s `extends` chain also changed in v2.1.2 to inherit from `StructuredLogRing` (also new), giving the four-error chain we observed in the repro:

```
SCRIPT ERROR: Could not parse global class "GameLogBuffer"
SCRIPT ERROR: Could not find type "EditorLogBuffer" in the current scope (plugin.gd:42)
SCRIPT ERROR: Could not resolve class "GameLogBuffer", because of a parser error
SCRIPT ERROR: Identifier "EditorLogBuffer" not declared in the current scope (plugin.gd:92)
```

## Two-part fix

### Fix 1 — untype `_game_log_buffer` and `_editor_log_buffer` in plugin.gd

Same lesson as the existing untyped `_editor_logger` field: typed declarations in `plugin.gd` against class_names whose inheritance or new class_name siblings can change between releases are self-update hazards. Untyped + `preload(...).new()` resolves at script-load time without needing the global class_name registry to be ahead of `plugin.gd`'s parse.

The runtime parameter checks on `EditorHandler._init`'s typed `editor_log_buffer: EditorLogBuffer` parameter still enforce the type fence — we just move it from `plugin.gd`'s parse to the call site's runtime check, breaking the chicken-and-egg.

### Fix 2 — parse-check fallback in `_on_filesystem_scanned_for_update`

Belt-and-suspenders for the next time someone introduces a parse hazard we don't catch in review. Before triggering `_reload_after_update`, load the new `plugin.gd` via `ResourceLoader.load`. `null` return = parse error → bail out to the same "Restart editor to apply" surface the pre-Godot-4.4 path already uses. User manually restarts, picks up the new files fresh from disk, dodges the in-place reload entirely.

## Tests

Two new structural tests in `tests/unit/test_editor_focus_refocus.py`:

- `test_plugin_gd_avoids_typed_class_name_for_log_buffers` — locks the untyped+preload pattern (so a future contributor "fixing" the apparent oversight by re-typing the field will fail CI).
- `test_install_update_falls_back_on_plugin_parse_failure` — locks the parse-check + bail-out: `ResourceLoader.load` gate, install flag cleared, "Restart editor" message, AND the parse check happens *before* `_reload_after_update.call_deferred()`.

All 653 Python tests pass locally. ruff clean.

## What this does NOT close

- **Users currently on v2.1.1**: this fix lands in v2.1.3+ and protects v2.1.x → v2.1.x+1 transitions where v2.1.x has the fix. Users on v2.1.1 hitting #242 still need to manually reinstall (download zip from Releases, extract over `addons/godot_ai/`, restart editor).
- **Direct identification of the crashing dock child** in #242's `Dictionary::keys()` SIGABRT: the crash is downstream of the parse failure plus Project-Boost-specific dock state. Eliminating the parse failure eliminates the conditions for the crash, so it's fixed transitively. The exact dock child remains an open thread on #242 if some other crash signature later needs it.
- **Broader untyping of every class_name field in plugin.gd** (defense-in-depth against future regressions): filed as a separate follow-up for evaluation.

## Test plan

- [x] `pytest` — 653 passed locally
- [x] `ruff check plugin/ tests/` — clean
- [ ] CI passes (will populate)
- [ ] Live smoke verifying the parse-check fallback fires when a hand-crafted "broken" plugin.gd is dropped in (next session — not blocking merge given structural tests cover the path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
