### PR TITLE
fix(dock): pre-detach dock from self-update to dodge hot-reload Dict-NIL crash (#245)

### DIFF
--- a/.github/workflows/forensic-issue-245.yml
+++ b/.github/workflows/forensic-issue-245.yml
@@ -1,0 +1,85 @@
+name: Forensic / issue-245 dictionary hot-reload
+
+# Manual one-shot to verify the macOS-only "newly-injected typed Dictionary
+# field stays NIL after hot-reload" bug across Linux, macOS, and Windows
+# Godot 4.6.2-stable runners. Triggered via workflow_dispatch only.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  synthetic:
+    name: Synthetic / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: chickensoft-games/setup-godot@v2
+        with:
+          version: 4.6.2
+          use-dotnet: false
+
+      - name: Run synthetic dictionary-injection test (Linux/macOS)
+        if: matrix.os != 'windows-latest'
+        shell: bash
+        run: |
+          set +e
+          godot --headless --editor \
+            --path docs/forensic/issue-245/repro-dictinject \
+            --quit-after 1500 > /tmp/synthetic.log 2>&1
+          rc=$?
+          echo "::group::Full Godot output"
+          cat /tmp/synthetic.log
+          echo "::endgroup::"
+          echo "exit code: $rc"
+          echo
+          echo "===== Verdict ====="
+          if grep -q "post-reload property names" /tmp/synthetic.log; then
+            grep "post-reload property names" /tmp/synthetic.log
+          fi
+          if grep -q "inst.get('injected_dict')" /tmp/synthetic.log; then
+            grep "inst.get('injected_dict')" /tmp/synthetic.log
+          fi
+          if grep -q "Program crashed with signal" /tmp/synthetic.log; then
+            echo "RESULT: CRASH (Dictionary::keys on null _p)"
+          elif grep -q "DONE — no SIGABRT" /tmp/synthetic.log; then
+            echo "RESULT: OK (no crash, hot-reload initialized field correctly)"
+          else
+            echo "RESULT: INDETERMINATE (test did not complete normally; rc=$rc)"
+          fi
+
+      - name: Run synthetic dictionary-injection test (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          $log = "$env:TEMP\synthetic.log"
+          # `godot.exe` is on PATH after setup-godot
+          & godot --headless --editor `
+            --path docs/forensic/issue-245/repro-dictinject `
+            --quit-after 1500 *> $log
+          $rc = $LASTEXITCODE
+          Write-Host "::group::Full Godot output"
+          Get-Content $log
+          Write-Host "::endgroup::"
+          Write-Host "exit code: $rc"
+          Write-Host ""
+          Write-Host "===== Verdict ====="
+          $content = Get-Content $log -Raw
+          if ($content -match "post-reload property names: .*") {
+            Write-Host $matches[0]
+          }
+          if ($content -match "inst\.get\('injected_dict'\): .*") {
+            Write-Host $matches[0]
+          }
+          if ($content -match "Program crashed with signal") {
+            Write-Host "RESULT: CRASH (Dictionary::keys on null _p)"
+          } elseif ($content -match "DONE — no SIGABRT") {
+            Write-Host "RESULT: OK (no crash, hot-reload initialized field correctly)"
+          } else {
+            Write-Host "RESULT: INDETERMINATE (test did not complete normally; rc=$rc)"
+          }

--- a/.github/workflows/forensic-issue-245.yml
+++ b/.github/workflows/forensic-issue-245.yml
@@ -6,6 +6,12 @@ name: Forensic / issue-245 dictionary hot-reload
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - dlight/wizardly-payne-37369d
+    paths:
+      - .github/workflows/forensic-issue-245.yml
+      - docs/forensic/issue-245/**
 
 jobs:
   synthetic:

--- a/.github/workflows/forensic-issue-245.yml
+++ b/.github/workflows/forensic-issue-245.yml
@@ -1,8 +1,9 @@
 name: Forensic / issue-245 dictionary hot-reload
 
-# Manual one-shot to verify the macOS-only "newly-injected typed Dictionary
-# field stays NIL after hot-reload" bug across Linux, macOS, and Windows
-# Godot 4.6.2-stable runners. Triggered via workflow_dispatch only.
+# Manual one-shot to verify the "newly-introduced typed Dictionary field
+# stays NIL after hot-reload" bug across Linux, macOS, and Windows Godot
+# 4.6.2-stable runners. Initial macOS run from a Mac confirmed the crash;
+# this workflow checks Linux + Windows + a second macOS for completeness.
 
 on:
   workflow_dispatch:
@@ -30,62 +31,30 @@ jobs:
           version: 4.6.2
           use-dotnet: false
 
-      - name: Run synthetic dictionary-injection test (Linux/macOS)
-        if: matrix.os != 'windows-latest'
+      - name: Run synthetic dictionary-injection test
         shell: bash
         run: |
           set +e
           godot --headless --editor \
             --path docs/forensic/issue-245/repro-dictinject \
-            --quit-after 1500 > /tmp/synthetic.log 2>&1
+            --quit-after 1500 > synthetic.log 2>&1
           rc=$?
           echo "::group::Full Godot output"
-          cat /tmp/synthetic.log
+          cat synthetic.log
           echo "::endgroup::"
           echo "exit code: $rc"
           echo
           echo "===== Verdict ====="
-          if grep -q "post-reload property names" /tmp/synthetic.log; then
-            grep "post-reload property names" /tmp/synthetic.log
+          if grep -q "post-reload property names" synthetic.log; then
+            grep "post-reload property names" synthetic.log
           fi
-          if grep -q "inst.get('injected_dict')" /tmp/synthetic.log; then
-            grep "inst.get('injected_dict')" /tmp/synthetic.log
+          if grep -q "inst.get('injected_dict')" synthetic.log; then
+            grep "inst.get('injected_dict')" synthetic.log
           fi
-          if grep -q "Program crashed with signal" /tmp/synthetic.log; then
+          if grep -q "Program crashed with signal" synthetic.log; then
             echo "RESULT: CRASH (Dictionary::keys on null _p)"
-          elif grep -q "DONE — no SIGABRT" /tmp/synthetic.log; then
+          elif grep -q "DONE — no SIGABRT" synthetic.log; then
             echo "RESULT: OK (no crash, hot-reload initialized field correctly)"
           else
             echo "RESULT: INDETERMINATE (test did not complete normally; rc=$rc)"
           fi
-
-      - name: Run synthetic dictionary-injection test (Windows)
-        if: matrix.os == 'windows-latest'
-        shell: pwsh
-        run: |
-          $log = "$env:TEMP\synthetic.log"
-          # `godot.exe` is on PATH after setup-godot
-          & godot --headless --editor `
-            --path docs/forensic/issue-245/repro-dictinject `
-            --quit-after 1500 *> $log
-          $rc = $LASTEXITCODE
-          Write-Host "::group::Full Godot output"
-          Get-Content $log
-          Write-Host "::endgroup::"
-          Write-Host "exit code: $rc"
-          Write-Host ""
-          Write-Host "===== Verdict ====="
-          $content = Get-Content $log -Raw
-          if ($content -match "post-reload property names: .*") {
-            Write-Host $matches[0]
-          }
-          if ($content -match "inst\.get\('injected_dict'\): .*") {
-            Write-Host $matches[0]
-          }
-          if ($content -match "Program crashed with signal") {
-            Write-Host "RESULT: CRASH (Dictionary::keys on null _p)"
-          } elseif ($content -match "DONE — no SIGABRT") {
-            Write-Host "RESULT: OK (no crash, hot-reload initialized field correctly)"
-          } else {
-            Write-Host "RESULT: INDETERMINATE (test did not complete normally; rc=$rc)"
-          }

--- a/docs/forensic/issue-245/repro-dictinject/addons/repro/plugin.cfg
+++ b/docs/forensic/issue-245/repro-dictinject/addons/repro/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="Repro DictInject"
+description="Synthetic test for Dictionary hot-reload field injection bug (#245)"
+author="dsarno"
+version="0.1"
+script="plugin.gd"

--- a/docs/forensic/issue-245/repro-dictinject/addons/repro/plugin.gd
+++ b/docs/forensic/issue-245/repro-dictinject/addons/repro/plugin.gd
@@ -1,0 +1,121 @@
+@tool
+extends EditorPlugin
+
+# Synthetic test for #245: macOS Godot 4.6.2-mono leaves a newly-injected
+# Dictionary field with null _p after hot-reloading the script class on a
+# live instance. Models the v2.1.1 → v2.1.2 self-update path of godot-ai.
+#
+# Sequence on _enter_tree (deferred so editor is fully booted):
+#   1) stage repro_v1.gd content into res://repro.gd
+#   2) construct an instance of v1
+#   3) overwrite res://repro.gd with v2 content (adds Dictionary field)
+#   4) trigger filesystem rescan + script reload
+#   5) read instance.injected_dict.keys() — bug fires here
+
+var _instance: RefCounted
+
+
+func _enter_tree() -> void:
+	print("[repro] _enter_tree — scheduling test")
+	get_tree().create_timer(2.0).timeout.connect(_step_1_stage_v1)
+
+
+func _exit_tree() -> void:
+	pass
+
+
+func _read_text(p: String) -> String:
+	var f := FileAccess.open(p, FileAccess.READ)
+	if f == null:
+		print("[repro] FAIL: cannot read %s" % p)
+		return ""
+	var s := f.get_as_text()
+	f.close()
+	return s
+
+
+func _write_text(p: String, content: String) -> void:
+	var f := FileAccess.open(p, FileAccess.WRITE)
+	if f == null:
+		print("[repro] FAIL: cannot open %s for write" % p)
+		return
+	f.store_string(content)
+	f.close()
+
+
+func _step_1_stage_v1() -> void:
+	print("[repro] step 1: stage v1 at res://repro.gd")
+	var v1: String = _read_text("res://repro_v1.gd")
+	_write_text("res://repro.gd", v1)
+	EditorInterface.get_resource_filesystem().scan()
+	get_tree().create_timer(2.0).timeout.connect(_step_2_construct_v1)
+
+
+func _step_2_construct_v1() -> void:
+	print("[repro] step 2: construct v1 instance")
+	var script_v1: GDScript = load("res://repro.gd") as GDScript
+	if script_v1 == null:
+		print("[repro] FAIL: v1 class did not load")
+		return
+	_instance = script_v1.new()
+	if _instance == null:
+		print("[repro] FAIL: v1 instance is null")
+		return
+	print("[repro] v1 instance: %s" % _instance)
+	var s: Variant = _instance.call("say")
+	print("[repro] v1 .say() -> %s" % str(s))
+	var prop_names: Array[String] = []
+	for p in _instance.get_property_list():
+		prop_names.append(p["name"])
+	print("[repro] v1 property names: %s" % str(prop_names))
+	get_tree().create_timer(1.0).timeout.connect(_step_3_overwrite_to_v2)
+
+
+func _step_3_overwrite_to_v2() -> void:
+	print("[repro] step 3: overwrite res://repro.gd with v2 (adds Dictionary field)")
+	var v2: String = _read_text("res://repro_v2.gd")
+	_write_text("res://repro.gd", v2)
+	EditorInterface.get_resource_filesystem().scan()
+	get_tree().create_timer(3.0).timeout.connect(_step_4_force_reload)
+
+
+func _step_4_force_reload() -> void:
+	print("[repro] step 4: force script reload + reimport")
+	EditorInterface.get_resource_filesystem().reimport_files(PackedStringArray(["res://repro.gd"]))
+	get_tree().create_timer(2.0).timeout.connect(_step_5_probe)
+
+
+func _step_5_probe() -> void:
+	print("[repro] step 5: probe instance after hot-reload")
+	if _instance == null:
+		print("[repro] FAIL: instance was GC'd")
+		_quit_with(1)
+		return
+	var prop_names: Array[String] = []
+	for p in _instance.get_property_list():
+		prop_names.append(p["name"])
+	print("[repro] post-reload property names: %s" % str(prop_names))
+
+	var v: Variant = _instance.get("injected_dict")
+	print("[repro] inst.get('injected_dict'): typeof=%d value=%s" % [typeof(v), str(v)])
+
+	if typeof(v) == TYPE_DICTIONARY:
+		var d: Dictionary = v
+		print("[repro] is Dictionary; calling .keys()...")
+		# THIS is where the bug would crash (Dictionary::keys on null _p)
+		var k: Array = d.keys()
+		print("[repro] .keys() returned %s (size=%d)" % [str(k), k.size()])
+	else:
+		print("[repro] field is not Dictionary; type=%d" % typeof(v))
+
+	# Call the v2 .say() method which itself does injected_dict.keys()
+	print("[repro] calling inst.say() (v2 body)...")
+	var msg: Variant = _instance.call("say")
+	print("[repro] inst.say() -> %s" % str(msg))
+
+	print("[repro] DONE — no SIGABRT. Bug did NOT reproduce in synthetic.")
+	_quit_with(0)
+
+
+func _quit_with(code: int) -> void:
+	get_tree().create_timer(0.5).timeout.connect(func(): get_tree().quit(code))

--- a/docs/forensic/issue-245/repro-dictinject/addons/repro/plugin.gd.uid
+++ b/docs/forensic/issue-245/repro-dictinject/addons/repro/plugin.gd.uid
@@ -1,0 +1,1 @@
+uid://fkcshrjxd5cs

--- a/docs/forensic/issue-245/repro-dictinject/main.tscn
+++ b/docs/forensic/issue-245/repro-dictinject/main.tscn
@@ -1,0 +1,3 @@
+[gd_scene format=3 uid="uid://b00000000000y"]
+
+[node name="Main" type="Node"]

--- a/docs/forensic/issue-245/repro-dictinject/project.godot
+++ b/docs/forensic/issue-245/repro-dictinject/project.godot
@@ -1,0 +1,13 @@
+; Engine configuration file for synthetic Dictionary-injection hot-reload test.
+
+config_version=5
+
+[application]
+
+config/name="repro-dictinject"
+config/features=PackedStringArray("4.6")
+run/main_scene="res://main.tscn"
+
+[editor_plugins]
+
+enabled=PackedStringArray("res://addons/repro/plugin.cfg")

--- a/docs/forensic/issue-245/repro-dictinject/repro_v1.gd
+++ b/docs/forensic/issue-245/repro-dictinject/repro_v1.gd
@@ -1,0 +1,5 @@
+class_name Repro
+extends RefCounted
+
+func say() -> String:
+	return "v1: no injected_dict field"

--- a/docs/forensic/issue-245/repro-dictinject/repro_v1.gd.uid
+++ b/docs/forensic/issue-245/repro-dictinject/repro_v1.gd.uid
@@ -1,0 +1,1 @@
+uid://dylc8rkmwoca3

--- a/docs/forensic/issue-245/repro-dictinject/repro_v2.gd
+++ b/docs/forensic/issue-245/repro-dictinject/repro_v2.gd
@@ -1,0 +1,7 @@
+class_name Repro
+extends RefCounted
+
+var injected_dict: Dictionary = {}
+
+func say() -> String:
+	return "v2: injected_dict.keys() = %s" % str(injected_dict.keys())

--- a/docs/forensic/issue-245/repro-dictinject/repro_v2.gd.uid
+++ b/docs/forensic/issue-245/repro-dictinject/repro_v2.gd.uid
@@ -1,0 +1,1 @@
+uid://b2iks11w20k8c

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -2142,20 +2142,30 @@ func _install_update() -> void:
 	var version := Engine.get_version_info()
 	if version.get("minor", 0) >= 4:
 		_update_btn.text = "Scanning..."
-		## Before reloading the plugin we MUST wait for Godot's filesystem
-		## scanner to see the newly-extracted files. Otherwise plugin.gd
-		## re-parses and its `class_name` references (GameLogBuffer,
-		## McpDebuggerPlugin, …) resolve against a ClassDB that hasn't
-		## picked up the new files yet — parse errors, dock tears down,
-		## plugin reports "enabled" with no UI. See issue #127.
-		var fs := EditorInterface.get_resource_filesystem()
-		if fs != null:
-			fs.filesystem_changed.connect(_on_filesystem_scanned_for_update, CONNECT_ONE_SHOT)
-			fs.scan()
+		## Hand off to the plugin to (a) free THIS dock instance while we
+		## still own pre-update bytecode that matches our field shape, and
+		## (b) drive the filesystem-scan + `set_plugin_enabled` cycle from
+		## the plugin side. Without (a), the post-scan hot-reload pairs
+		## the new dock bytecode with our pre-update field storage; new
+		## typed Dictionary fields land as `Variant::NIL` instead of `{}`,
+		## and the new `_exit_tree`'s `<dict>.keys()` SIGSEGVs cross-OS.
+		## See #245 for the forensic trail and the cross-platform CI run.
+		##
+		## `detach_dock_for_update` was added in v2.1.3. The fallback
+		## arm preserves the v2.1.2 in-place reload behaviour for the
+		## (unreachable, defensive) case where `_plugin` doesn't expose
+		## the new method — same crash hazard, same UX as before.
+		if _plugin != null and _plugin.has_method("detach_dock_for_update"):
+			_plugin.detach_dock_for_update()
 		else:
-			## Fallback: no filesystem accessor — defer and hope (matches
-			## the pre-#127 behaviour).
-			_reload_after_update.call_deferred()
+			var fs := EditorInterface.get_resource_filesystem()
+			if fs != null:
+				fs.filesystem_changed.connect(_on_filesystem_scanned_for_update, CONNECT_ONE_SHOT)
+				fs.scan()
+			else:
+				## Fallback: no filesystem accessor — defer and hope
+				## (matches the pre-#127 behaviour).
+				_reload_after_update.call_deferred()
 	else:
 		## Pre-4.4 Godot: no plugin reload, dock stays alive on the new files.
 		## Clear the install flag so refreshes resume on the OLD dock instance
@@ -2167,6 +2177,9 @@ func _install_update() -> void:
 		_update_label.add_theme_color_override("font_color", Color.GREEN)
 
 
+## Legacy fallback used only when `_plugin.detach_dock_for_update`
+## isn't available. v2.1.3+ routes through plugin.detach_dock_for_update
+## instead — see #245.
 func _on_filesystem_scanned_for_update() -> void:
 	_update_btn.text = "Reloading..."
 	_reload_after_update.call_deferred()

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -1018,6 +1018,73 @@ func prepare_for_update_reload() -> void:
 	_server_started_this_session = false
 
 
+## Tear down the live McpDock instance and drive the post-extract scan +
+## set_plugin_enabled cycle from the plugin instead of from the dock.
+##
+## Why this isn't done from the dock itself: at the moment the filesystem
+## scan completes and the script class for `mcp_dock.gd` hot-reloads,
+## any McpDock instance that survives gets its existing storage paired
+## with the new bytecode. New typed fields the new version declared
+## (e.g. `var _client_action_threads: Dictionary = {}`) come through
+## with `Variant::NIL` storage instead of running their `= {}`
+## initializer — confirmed cross-platform on Godot 4.6.2-stable
+## (ubuntu-latest, macos-latest, windows-latest) per #245's CI run. The
+## new bytecode then reads those fields as Dictionary in `_exit_tree`
+## (e.g. `_client_action_threads.keys()`) and SIGSEGVs in
+## `Dictionary::keys()` against a null `_p`. That's #242.
+##
+## Freeing the dock here, on pre-update bytecode that matches the
+## pre-update field shape, makes its `_exit_tree` cascade run cleanly
+## against fields it actually owns. The subsequent `set_plugin_enabled`
+## cycle finds `_dock == null` and skips the dock teardown branch in
+## `plugin._exit_tree`. When the plugin re-enables, `_enter_tree` builds
+## a fresh dock under the new class — every field initialized via its
+## declared default, no NIL storage, no crash.
+##
+## This protects v(N) → v(N+1) upgrades. It cannot retroactively fix
+## v(N-1) users hitting `_install_update` without this method, since the
+## currently-running `_install_update` is the one that decides whether
+## to call this. v2.1.1 and v2.1.2 → next-release upgrades will still
+## hit the original crash via the old code path; documented in release
+## notes alongside this fix.
+func detach_dock_for_update() -> void:
+	if _dock != null and is_instance_valid(_dock):
+		remove_control_from_docks(_dock)
+		_dock.queue_free()
+		_dock = null
+
+	## Mirror the dock's prior post-extract sequence: wait for Godot's
+	## filesystem scanner to see the newly-extracted files before we
+	## toggle the plugin off, otherwise plugin.gd re-parses against a
+	## ClassDB that hasn't ingested the new class_name'd scripts yet
+	## (issue #127). Use ONE_SHOT so reconnects on subsequent updates
+	## don't pile up.
+	var fs := EditorInterface.get_resource_filesystem()
+	if fs != null:
+		fs.filesystem_changed.connect(_on_filesystem_scanned_post_extract, CONNECT_ONE_SHOT)
+		fs.scan()
+	else:
+		_reload_after_extract.call_deferred()
+
+
+func _on_filesystem_scanned_post_extract() -> void:
+	_reload_after_extract.call_deferred()
+
+
+## Toggle the plugin off→on to load the freshly-extracted scripts.
+## Lives on plugin.gd (not the dock) because the dock instance has been
+## freed by `detach_dock_for_update` by this point. The plugin instance
+## itself survives the hot-reload of `plugin.gd`'s class — but its
+## existing fields are nullable references (`_connection`,
+## `_log_buffer`, `_dock`, …), each guarded with `if _xxx:` in
+## `_exit_tree`. None of them are typed Dictionary/Array fields read
+## via builtin methods, so the same NIL-storage hazard that crashed
+## the dock doesn't fire here.
+func _reload_after_extract() -> void:
+	EditorInterface.set_plugin_enabled("res://addons/godot_ai/plugin.cfg", false)
+	EditorInterface.set_plugin_enabled("res://addons/godot_ai/plugin.cfg", true)
+
+
 ## Kill whichever process is holding `http_port()` right now — by resolving
 ## the port-owning PID via pid-file / netstat / lsof, independent of whether
 ## we ever set `_server_pid` — then clear ownership state and respawn via


### PR DESCRIPTION
## Summary

- Pre-detaches the McpDock instance during `_install_update` so it never runs hot-reloaded `_exit_tree` bytecode against pre-update field storage. Closes [#245](https://github.com/hi-godot/godot-ai/issues/245) for v(N) → v(N+1) upgrades from this release forward.
- Adds a forensic synthetic repro (`docs/forensic/issue-245/repro-dictinject/`) and a one-shot CI workflow (`.github/workflows/forensic-issue-245.yml`) that reproduces the underlying Godot 4.6.2 hot-reload bug on Linux + macOS + Windows runners. CI run: [25061868538](https://github.com/hi-godot/godot-ai/actions/runs/25061868538).
- Filed upstream Godot bug at [dsarno/godot#1](https://github.com/dsarno/godot/issues/1).

## What this fixes

The original SIGABRT in [#242](https://github.com/hi-godot/godot-ai/issues/242) (Project Boost v2.1.1 → v2.1.2 self-update) traces to a Godot 4.6.2 script-hot-reload bug: when a script class hot-reloads on a live instance and the new version declares a new typed `Dictionary` field with `= {}`, the field's backing storage is left as `Variant::NIL` instead of running the declared initializer. The new bytecode then reads it as `Dictionary` (e.g. `.keys()`) and dereferences a null `_p` → SIGSEGV in `Dictionary::keys() const + 52`. **Confirmed cross-platform** on Godot 4.6.2-stable per the CI grid above (not macOS-only as the first forensic comment claimed; corrected on [#245](https://github.com/hi-godot/godot-ai/issues/245#issuecomment-4336713248)).

In v2.1.2 the trigger field was `var _client_action_threads: Dictionary = {}` newly introduced in `mcp_dock.gd`, read via `_drain_client_action_workers()` from `_exit_tree`. Any future plugin update that adds a new typed Dictionary or Array field used in `_exit_tree`'s reach has the same hazard.

## What this doesn't fix

- **v2.1.1 / v2.1.2 → v2.1.3 upgrades** still hit the original crash, because the running v2.1.1 / v2.1.2 `_install_update` doesn't have `detach_dock_for_update`. From v2.1.3 onwards the in-place upgrade path is safe. Affected users on v2.1.1 / v2.1.2 need to reinstall the plugin manually one time. Will document in the v2.1.3 release notes.
- [#247](https://github.com/hi-godot/godot-ai/issues/247) (`EditorHandler.new(5 args)` against cached 4-arg `_init` after hot-reload) is a different layer of the same upgrade window — script-class cache rather than instance-field cache. Not addressed here; tracked as a follow-up.

## How the fix works

Pre-update: while we still own bytecode that matches the dock's pre-update field shape, free the McpDock instance before triggering the filesystem rescan.

```
v(N) bytecode running:
   _install_update(): extract zip
   _install_update(): _plugin.detach_dock_for_update()
                       └─ remove_control_from_docks(_dock)  ← runs _exit_tree on
                          _dock.queue_free()                  v(N) bytecode against
                          _dock = null                        v(N) field shape ✓
                       └─ filesystem_changed.connect(...)
                       └─ fs.scan()
[hot-reload happens here — McpDock class swaps to v(N+1), but no instance
 to crash; plugin instance survives, but its _exit_tree reads only nullable
 refs guarded by `if _xxx:`, no Dictionary/Array fields read via builtin]
   _on_filesystem_scanned_post_extract():
     _reload_after_extract():
       set_plugin_enabled(false)  ← plugin._exit_tree: _dock is null, skips dock
       set_plugin_enabled(true)   ← plugin._enter_tree: builds fresh dock under
                                    v(N+1) class, every field initialized cleanly
```

## Test plan

- [x] `pytest -x` (608 tests pass)
- [x] `ruff check src/ tests/` (clean)
- [x] `godot --headless --path test_project --import` (no parse errors on edited files)
- [x] Cross-platform synthetic CI ([forensic workflow](https://github.com/hi-godot/godot-ai/actions/runs/25061868538)) demonstrates the underlying Godot bug on all three OSes
- [ ] Full CI matrix on this PR (will run when opened)
- [ ] Manual end-to-end smoke: build a v(N) zip from current main, install, click Update with a v(N+1) zip that introduces a new typed Dictionary field, verify no crash and dock recreates

## Closes / refs

- Closes [#245](https://github.com/hi-godot/godot-ai/issues/245)
- Refs [#242](https://github.com/hi-godot/godot-ai/issues/242), [#247](https://github.com/hi-godot/godot-ai/issues/247)
- Upstream: [dsarno/godot#1](https://github.com/dsarno/godot/issues/1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
