### PR TITLE
[codex] fix(dock): reload self-update from detached runner

### DIFF
--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -95,6 +95,8 @@ var _client_status_refresh_started_msec: int = 0
 var _client_status_refresh_generation: int = 0
 var _client_status_refresh_shutdown_requested := false
 var _client_status_refresh_timed_out := false
+var _client_status_refresh_deferred_until_filesystem_ready := false
+var _client_status_refresh_deferred_force := false
 ## Set for the duration of `_install_update` — extract-overwrite of plugin
 ## scripts on disk would crash any worker mid-`GDScriptFunction::call`
 ## (confirmed via SIGABRT in `VBoxContainer(McpDock)::_run_client_status_refresh_worker`).
@@ -192,6 +194,7 @@ func _process(_delta: float) -> void:
 		return
 	_prune_orphaned_client_status_refresh_threads()
 	_check_client_status_refresh_timeout()
+	_retry_deferred_client_status_refresh()
 	_update_status()
 	if _log_section.visible:
 		_update_log()
@@ -1728,6 +1731,9 @@ func _perform_initial_client_status_refresh() -> void:
 		return
 	if _self_update_in_progress:
 		return
+	if _is_editor_filesystem_busy():
+		_defer_client_status_refresh_until_filesystem_ready(false)
+		return
 	if _client_status_refresh_in_flight:
 		return
 
@@ -1821,6 +1827,10 @@ func _request_client_status_refresh(force: bool = false) -> bool:
 		return false
 	if _client_rows.is_empty():
 		return false
+	if _is_editor_filesystem_busy():
+		if force:
+			_defer_client_status_refresh_until_filesystem_ready(force)
+		return false
 
 	var client_probes: Array[Dictionary] = []
 	for client_id in _client_rows:
@@ -1839,6 +1849,36 @@ func _request_client_status_refresh(force: bool = false) -> bool:
 		_refresh_clients_summary()
 		return false
 	return true
+
+
+func _is_editor_filesystem_busy() -> bool:
+	var fs := EditorInterface.get_resource_filesystem()
+	return fs != null and fs.is_scanning()
+
+
+func _defer_client_status_refresh_until_filesystem_ready(force: bool) -> void:
+	## Godot can still be reparsing/reloading plugin scripts while the editor
+	## filesystem is busy. Do not spawn a worker into that window: the worker
+	## can call plugin GDScript while the main thread is reloading it, which
+	## crashes in `GDScriptFunction::call`.
+	_client_status_refresh_deferred_until_filesystem_ready = true
+	_client_status_refresh_deferred_force = _client_status_refresh_deferred_force or force
+
+
+func _retry_deferred_client_status_refresh() -> void:
+	if not _client_status_refresh_deferred_until_filesystem_ready:
+		return
+	if _self_update_in_progress or _client_status_refresh_shutdown_requested:
+		return
+	if _client_status_refresh_in_flight:
+		return
+	if _is_editor_filesystem_busy():
+		return
+
+	var force := _client_status_refresh_deferred_force
+	_client_status_refresh_deferred_until_filesystem_ready = false
+	_client_status_refresh_deferred_force = false
+	_request_client_status_refresh(force)
 
 
 func _run_client_status_refresh_worker(client_probes: Array[Dictionary], server_url: String, generation: int) -> void:

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -97,6 +97,7 @@ var _client_status_refresh_shutdown_requested := false
 var _client_status_refresh_timed_out := false
 var _client_status_refresh_deferred_until_filesystem_ready := false
 var _client_status_refresh_deferred_force := false
+var _client_status_refresh_deferred_initial := false
 ## Set for the duration of `_install_update` — extract-overwrite of plugin
 ## scripts on disk would crash any worker mid-`GDScriptFunction::call`
 ## (confirmed via SIGABRT in `VBoxContainer(McpDock)::_run_client_status_refresh_worker`).
@@ -1732,7 +1733,7 @@ func _perform_initial_client_status_refresh() -> void:
 	if _self_update_in_progress:
 		return
 	if _is_editor_filesystem_busy():
-		_defer_client_status_refresh_until_filesystem_ready(false)
+		_defer_initial_client_status_refresh_until_filesystem_ready()
 		return
 	if _client_status_refresh_in_flight:
 		return
@@ -1856,6 +1857,11 @@ func _is_editor_filesystem_busy() -> bool:
 	return fs != null and fs.is_scanning()
 
 
+func _defer_initial_client_status_refresh_until_filesystem_ready() -> void:
+	_client_status_refresh_deferred_until_filesystem_ready = true
+	_client_status_refresh_deferred_initial = true
+
+
 func _defer_client_status_refresh_until_filesystem_ready(force: bool) -> void:
 	## Godot can still be reparsing/reloading plugin scripts while the editor
 	## filesystem is busy. Do not spawn a worker into that window: the worker
@@ -1875,10 +1881,15 @@ func _retry_deferred_client_status_refresh() -> void:
 	if _is_editor_filesystem_busy():
 		return
 
+	var initial := _client_status_refresh_deferred_initial
 	var force := _client_status_refresh_deferred_force
 	_client_status_refresh_deferred_until_filesystem_ready = false
 	_client_status_refresh_deferred_force = false
-	_request_client_status_refresh(force)
+	_client_status_refresh_deferred_initial = false
+	if initial:
+		_perform_initial_client_status_refresh()
+	else:
+		_request_client_status_refresh(force)
 
 
 func _run_client_status_refresh_worker(client_probes: Array[Dictionary], server_url: String, generation: int) -> void:

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -2091,6 +2091,12 @@ func _install_update() -> void:
 	_drain_client_status_refresh_workers()
 	_drain_client_action_workers()
 
+	var version := Engine.get_version_info()
+	if version.get("minor", 0) >= 4 and _plugin != null and _plugin.has_method("install_downloaded_update"):
+		_update_btn.text = "Reloading..."
+		_plugin.install_downloaded_update(UPDATE_TEMP_ZIP, UPDATE_TEMP_DIR, self)
+		return
+
 	var zip_path := ProjectSettings.globalize_path(UPDATE_TEMP_ZIP)
 	var install_base := ProjectSettings.globalize_path("res://")
 
@@ -2139,7 +2145,6 @@ func _install_update() -> void:
 	# Godot 4.4+ handles plugin reload safely. On 4.3 and older, toggling
 	# the plugin off/on can cause re-entrant server spawns, so we ask the
 	# user to restart the editor instead.
-	var version := Engine.get_version_info()
 	if version.get("minor", 0) >= 4:
 		_update_btn.text = "Scanning..."
 		## Before reloading the plugin we MUST wait for Godot's filesystem

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -1033,6 +1033,7 @@ func install_downloaded_update(zip_path: String, temp_dir: String, source_dock: 
 		_dock = null
 	elif source_dock != null and is_instance_valid(source_dock):
 		detached_dock = source_dock
+		remove_control_from_docks(source_dock)
 
 	var runner = UPDATE_RELOAD_RUNNER_SCRIPT.new()
 	var parent: Node = EditorInterface.get_base_control()

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -16,6 +16,7 @@ const EDITOR_LOGGER_PATH := "res://addons/godot_ai/runtime/editor_logger.gd"
 ## and manage a server it didn't spawn itself. See #135.
 const MANAGED_SERVER_PID_SETTING := "godot_ai/managed_server_pid"
 const MANAGED_SERVER_VERSION_SETTING := "godot_ai/managed_server_version"
+const UPDATE_RELOAD_RUNNER_SCRIPT := preload("res://addons/godot_ai/update_reload_runner.gd")
 
 ## The Python server writes its own PID here on startup (passed as
 ## `--pid-file`) and unlinks on clean exit. Deterministic replacement
@@ -1016,6 +1017,29 @@ func _clear_managed_server_record() -> void:
 func prepare_for_update_reload() -> void:
 	_stop_server()
 	_server_started_this_session = false
+
+
+## Hand the self-update over to a tiny runner that is not owned by this
+## EditorPlugin. The runner keeps the editor process alive, but disables this
+## plugin before extracting/scanning the new scripts so every plugin-owned
+## instance tears down on pre-update bytecode and pre-update field storage.
+func install_downloaded_update(zip_path: String, temp_dir: String, source_dock: Control) -> void:
+	prepare_for_update_reload()
+
+	var detached_dock = null
+	if _dock != null and is_instance_valid(_dock):
+		detached_dock = _dock
+		remove_control_from_docks(_dock)
+		_dock = null
+	elif source_dock != null and is_instance_valid(source_dock):
+		detached_dock = source_dock
+
+	var runner = UPDATE_RELOAD_RUNNER_SCRIPT.new()
+	var parent: Node = EditorInterface.get_base_control()
+	if parent == null:
+		parent = get_tree().root
+	parent.add_child(runner)
+	runner.start(zip_path, temp_dir, detached_dock)
 
 
 ## Kill whichever process is holding `http_port()` right now — by resolving

--- a/plugin/addons/godot_ai/update_reload_runner.gd
+++ b/plugin/addons/godot_ai/update_reload_runner.gd
@@ -102,10 +102,25 @@ func _extract_update() -> bool:
 			var dir := file_path.get_base_dir()
 			DirAccess.make_dir_recursive_absolute(install_base.path_join(dir))
 			var content := reader.read_file(file_path)
-			var f := FileAccess.open(install_base.path_join(file_path), FileAccess.WRITE)
-			if f != null:
-				f.store_buffer(content)
-				f.close()
+			var target_path := install_base.path_join(file_path)
+			var f := FileAccess.open(target_path, FileAccess.WRITE)
+			if f == null:
+				print("MCP | update extract failed: could not write %s (error %d)" % [
+					target_path,
+					FileAccess.get_open_error(),
+				])
+				reader.close()
+				return false
+			f.store_buffer(content)
+			var write_error := f.get_error()
+			f.close()
+			if write_error != OK:
+				print("MCP | update extract failed: write error %d for %s" % [
+					write_error,
+					target_path,
+				])
+				reader.close()
+				return false
 
 	reader.close()
 	return true

--- a/plugin/addons/godot_ai/update_reload_runner.gd
+++ b/plugin/addons/godot_ai/update_reload_runner.gd
@@ -13,7 +13,6 @@ const PLUGIN_CFG_PATH := "res://addons/godot_ai/plugin.cfg"
 const PRE_DISABLE_DRAIN_FRAMES := 8
 const POST_DISABLE_DRAIN_FRAMES := 2
 const POST_ENABLE_FREE_FRAMES := 8
-const FILESYSTEM_SCAN_TIMEOUT_FRAMES := 300
 
 var _zip_path := ""
 var _temp_dir := ""
@@ -22,7 +21,6 @@ var _started := false
 var _next_step := ""
 var _frames_remaining := 0
 var _waiting_for_scan := false
-var _scan_timeout_frames := 0
 
 
 func start(zip_path: String, temp_dir: String, detached_dock) -> void:
@@ -36,12 +34,6 @@ func start(zip_path: String, temp_dir: String, detached_dock) -> void:
 
 
 func _process(_delta: float) -> void:
-	if _waiting_for_scan:
-		_scan_timeout_frames -= 1
-		if _scan_timeout_frames <= 0:
-			_finish_scan_wait()
-		return
-
 	if _frames_remaining <= 0:
 		set_process(false)
 		return
@@ -86,11 +78,9 @@ func _start_filesystem_scan() -> void:
 		return
 
 	_waiting_for_scan = true
-	_scan_timeout_frames = FILESYSTEM_SCAN_TIMEOUT_FRAMES
 	if not fs.filesystem_changed.is_connected(_on_filesystem_changed):
 		fs.filesystem_changed.connect(_on_filesystem_changed, CONNECT_ONE_SHOT)
 	fs.scan()
-	set_process(true)
 
 
 func _extract_update() -> bool:

--- a/plugin/addons/godot_ai/update_reload_runner.gd
+++ b/plugin/addons/godot_ai/update_reload_runner.gd
@@ -1,0 +1,155 @@
+@tool
+extends Node
+
+## Runs the self-update after the visible plugin has handed off control.
+##
+## This node is deliberately tiny and not parented under the EditorPlugin:
+## it survives `set_plugin_enabled(false)`, extracts the downloaded release,
+## waits for Godot's filesystem scan, then enables the plugin again. The old
+## dock is detached before this runner starts, kept alive while deferred
+## Callables drain, and freed only after the new plugin instance is loaded.
+
+const PLUGIN_CFG_PATH := "res://addons/godot_ai/plugin.cfg"
+const PRE_DISABLE_DRAIN_FRAMES := 8
+const POST_DISABLE_DRAIN_FRAMES := 2
+const POST_ENABLE_FREE_FRAMES := 8
+const FILESYSTEM_SCAN_TIMEOUT_FRAMES := 300
+
+var _zip_path := ""
+var _temp_dir := ""
+var _detached_dock = null
+var _started := false
+var _next_step := ""
+var _frames_remaining := 0
+var _waiting_for_scan := false
+var _scan_timeout_frames := 0
+
+
+func start(zip_path: String, temp_dir: String, detached_dock) -> void:
+	if _started:
+		return
+	_started = true
+	_zip_path = zip_path
+	_temp_dir = temp_dir
+	_detached_dock = detached_dock
+	_wait_frames(PRE_DISABLE_DRAIN_FRAMES, "_disable_old_plugin")
+
+
+func _process(_delta: float) -> void:
+	if _waiting_for_scan:
+		_scan_timeout_frames -= 1
+		if _scan_timeout_frames <= 0:
+			_finish_scan_wait()
+		return
+
+	if _frames_remaining <= 0:
+		set_process(false)
+		return
+
+	_frames_remaining -= 1
+	if _frames_remaining <= 0:
+		var step := _next_step
+		_next_step = ""
+		set_process(false)
+		call(step)
+
+
+func _wait_frames(frame_count: int, next_step: String) -> void:
+	_next_step = next_step
+	_frames_remaining = max(1, frame_count)
+	set_process(true)
+
+
+func _disable_old_plugin() -> void:
+	## Disable before writing or scanning new scripts. This avoids both the
+	## Dict/Array field-storage hot-reload crash (#245) and cached handler
+	## constructor shape mismatches (#247) for plugin-owned instances.
+	print("MCP | update runner disabling old plugin")
+	EditorInterface.set_plugin_enabled(PLUGIN_CFG_PATH, false)
+	_wait_frames(POST_DISABLE_DRAIN_FRAMES, "_extract_and_scan")
+
+
+func _extract_and_scan() -> void:
+	if not _extract_update():
+		EditorInterface.set_plugin_enabled(PLUGIN_CFG_PATH, true)
+		_wait_frames(POST_ENABLE_FREE_FRAMES, "_cleanup_and_finish")
+		return
+
+	_cleanup_update_temp()
+	_start_filesystem_scan()
+
+
+func _start_filesystem_scan() -> void:
+	var fs := EditorInterface.get_resource_filesystem()
+	if fs == null:
+		_enable_new_plugin.call_deferred()
+		return
+
+	_waiting_for_scan = true
+	_scan_timeout_frames = FILESYSTEM_SCAN_TIMEOUT_FRAMES
+	if not fs.filesystem_changed.is_connected(_on_filesystem_changed):
+		fs.filesystem_changed.connect(_on_filesystem_changed, CONNECT_ONE_SHOT)
+	fs.scan()
+	set_process(true)
+
+
+func _extract_update() -> bool:
+	var zip_path := ProjectSettings.globalize_path(_zip_path)
+	var install_base := ProjectSettings.globalize_path("res://")
+
+	var reader := ZIPReader.new()
+	if reader.open(zip_path) != OK:
+		print("MCP | update extract failed: could not open %s" % zip_path)
+		return false
+
+	var files := reader.get_files()
+	for file_path in files:
+		if not file_path.begins_with("addons/godot_ai/"):
+			continue
+		if file_path.ends_with("/"):
+			DirAccess.make_dir_recursive_absolute(install_base.path_join(file_path))
+		else:
+			var dir := file_path.get_base_dir()
+			DirAccess.make_dir_recursive_absolute(install_base.path_join(dir))
+			var content := reader.read_file(file_path)
+			var f := FileAccess.open(install_base.path_join(file_path), FileAccess.WRITE)
+			if f != null:
+				f.store_buffer(content)
+				f.close()
+
+	reader.close()
+	return true
+
+
+func _cleanup_update_temp() -> void:
+	DirAccess.remove_absolute(ProjectSettings.globalize_path(_zip_path))
+	DirAccess.remove_absolute(ProjectSettings.globalize_path(_temp_dir))
+
+
+func _on_filesystem_changed() -> void:
+	_finish_scan_wait()
+
+
+func _finish_scan_wait() -> void:
+	if not _waiting_for_scan:
+		return
+	_waiting_for_scan = false
+	set_process(false)
+	_enable_new_plugin.call_deferred()
+
+
+func _enable_new_plugin() -> void:
+	print("MCP | update runner enabling new plugin")
+	EditorInterface.set_plugin_enabled(PLUGIN_CFG_PATH, true)
+	_wait_frames(POST_ENABLE_FREE_FRAMES, "_cleanup_and_finish")
+
+
+func _cleanup_and_finish() -> void:
+	_cleanup_detached_dock()
+	queue_free()
+
+
+func _cleanup_detached_dock() -> void:
+	if _detached_dock != null and is_instance_valid(_detached_dock):
+		_detached_dock.queue_free()
+	_detached_dock = null

--- a/plugin/addons/godot_ai/update_reload_runner.gd.uid
+++ b/plugin/addons/godot_ai/update_reload_runner.gd.uid
@@ -1,0 +1,1 @@
+uid://cu6c75n3x2pik

--- a/tests/unit/test_editor_focus_refocus.py
+++ b/tests/unit/test_editor_focus_refocus.py
@@ -133,6 +133,7 @@ def test_client_status_refresh_defers_while_editor_filesystem_is_busy() -> None:
 
     assert "var _client_status_refresh_deferred_until_filesystem_ready := false" in source
     assert "var _client_status_refresh_deferred_force := false" in source
+    assert "var _client_status_refresh_deferred_initial := false" in source
 
     process_block = source.split("func _process(_delta: float) -> void:", 1)[
         1
@@ -146,7 +147,7 @@ def test_client_status_refresh_defers_while_editor_filesystem_is_busy() -> None:
         "func _request_client_status_refresh(force: bool = false) -> bool:", 1
     )[1].split("\n\nfunc ", 1)[0]
     assert "_is_editor_filesystem_busy()" in init_block
-    assert "_defer_client_status_refresh_until_filesystem_ready(" in init_block
+    assert "_defer_initial_client_status_refresh_until_filesystem_ready()" in init_block
 
     assert "_is_editor_filesystem_busy()" in request_block
     busy_request_block = request_block.split("if _is_editor_filesystem_busy():", 1)[
@@ -155,6 +156,12 @@ def test_client_status_refresh_defers_while_editor_filesystem_is_busy() -> None:
     assert "if force:" in busy_request_block
     assert "_defer_client_status_refresh_until_filesystem_ready(force)" in busy_request_block
     assert busy_request_block.index("if force:") < busy_request_block.index("return false")
+
+    initial_defer_block = source.split(
+        "func _defer_initial_client_status_refresh_until_filesystem_ready() -> void:", 1
+    )[1].split("\n\nfunc ", 1)[0]
+    assert "_client_status_refresh_deferred_until_filesystem_ready = true" in initial_defer_block
+    assert "_client_status_refresh_deferred_initial = true" in initial_defer_block
 
 
 def test_focus_refresh_is_opportunistic_while_editor_filesystem_is_busy() -> None:
@@ -177,8 +184,8 @@ def test_focus_refresh_is_opportunistic_while_editor_filesystem_is_busy() -> Non
     assert "check_status" not in focus_block
 
 
-def test_deferred_refresh_replays_through_async_request_path_only() -> None:
-    """Queued manual/initial refreshes should not reintroduce PR #228's sync sweep."""
+def test_deferred_manual_refresh_replays_through_async_request_path_only() -> None:
+    """Queued manual refreshes should not reintroduce PR #228's sync sweep."""
 
     source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
     retry_block = source.split("func _retry_deferred_client_status_refresh() -> void:", 1)[
@@ -192,11 +199,31 @@ def test_deferred_refresh_replays_through_async_request_path_only() -> None:
         assert "client_status_probe_snapshot(" not in block
         assert "check_status" not in block
 
+    assert "_client_status_refresh_deferred_initial = false" in retry_block
+    assert "else:" in retry_block
+    assert "_request_client_status_refresh(force)" in retry_block
+
     busy_block = source.split("func _is_editor_filesystem_busy() -> bool:", 1)[
         1
     ].split("\n\nfunc ", 1)[0]
     assert "EditorInterface.get_resource_filesystem()" in busy_block
     assert "fs.is_scanning()" in busy_block
+
+
+def test_deferred_initial_refresh_replays_warmup_path() -> None:
+    """Scan-delayed initial paint must preserve #235's main-thread warm-up."""
+
+    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+    retry_block = source.split("func _retry_deferred_client_status_refresh() -> void:", 1)[
+        1
+    ].split("\n\nfunc ", 1)[0]
+
+    assert "var initial := _client_status_refresh_deferred_initial" in retry_block
+    assert "if initial:" in retry_block
+    assert "_perform_initial_client_status_refresh()" in retry_block
+    assert retry_block.index("if initial:") < retry_block.index(
+        "_request_client_status_refresh(force)"
+    )
 
 
 def test_install_update_drains_workers_and_blocks_spawning_before_extract() -> None:
@@ -302,6 +329,7 @@ def test_self_update_runner_disables_old_plugin_before_extract_and_scan() -> Non
     )[1].split("\n\nfunc ", 1)[0]
     assert "prepare_for_update_reload()" in handoff_block
     assert "remove_control_from_docks(_dock)" in handoff_block
+    assert "remove_control_from_docks(source_dock)" in handoff_block
     assert "_dock = null" in handoff_block
     assert "runner.start(zip_path, temp_dir, detached_dock)" in handoff_block
 
@@ -352,6 +380,14 @@ def test_self_update_runner_disables_old_plugin_before_extract_and_scan() -> Non
     ].split("\n\nfunc ", 1)[0]
     assert "_cleanup_detached_dock()" in cleanup_block
     assert "queue_free()" in cleanup_block
+
+    extract_update_block = runner_source.split("func _extract_update() -> bool:", 1)[
+        1
+    ].split("\n\nfunc ", 1)[0]
+    assert "FileAccess.get_open_error()" in extract_update_block
+    assert "var write_error := f.get_error()" in extract_update_block
+    assert "return false" in extract_update_block
+
     assert "OS.create_process" not in runner_source
     assert "get_tree().quit" not in runner_source
     assert "await " not in runner_source, (

--- a/tests/unit/test_editor_focus_refocus.py
+++ b/tests/unit/test_editor_focus_refocus.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 PLUGIN_ROOT = Path(__file__).resolve().parents[2] / "plugin" / "addons" / "godot_ai"
@@ -158,6 +159,7 @@ def test_install_update_drains_workers_and_blocks_spawning_before_extract() -> N
 
     flag_set_idx = install_block.find("_self_update_in_progress = true")
     drain_idx = install_block.find("_drain_client_status_refresh_workers()")
+    handoff_idx = install_block.find("install_downloaded_update")
     first_write_idx = install_block.find("f.store_buffer(content)")
     symlink_return_idx = install_block.find("addons_dir_is_symlink()")
 
@@ -173,7 +175,7 @@ def test_install_update_drains_workers_and_blocks_spawning_before_extract() -> N
     )
     assert first_write_idx > 0, (
         "Test fixture broken: could not locate the extract-write site "
-        "(`f.store_buffer(content)`) inside `_install_update`."
+        "(`f.store_buffer(content)`) inside `_install_update`'s legacy path."
     )
     assert symlink_return_idx > 0, (
         "Test fixture broken: could not locate the symlink-safety check."
@@ -188,6 +190,12 @@ def test_install_update_drains_workers_and_blocks_spawning_before_extract() -> N
     assert drain_idx < first_write_idx, (
         "Drain must complete before any file write. Otherwise an in-flight "
         "worker can race the overwrite of the script it's mid-call into."
+    )
+    assert drain_idx < handoff_idx < first_write_idx, (
+        "The normal Godot 4.4+ path must hand off to the update runner after "
+        "the worker drain but before the legacy in-dock extract loop. The "
+        "runner disables the old plugin before extraction so plugin-owned "
+        "instances do not hot-reload in place."
     )
 
     request_block = source.split(
@@ -206,6 +214,81 @@ def test_install_update_drains_workers_and_blocks_spawning_before_extract() -> N
         "_perform_initial_client_status_refresh must also short-circuit on "
         "the self-update flag — defensive even though the new dock instance "
         "wouldn't normally see this flag set."
+    )
+
+
+def test_self_update_runner_disables_old_plugin_before_extract_and_scan() -> None:
+    """The in-place update workaround depends on this exact order (#245/#247)."""
+
+    plugin_source = (PLUGIN_ROOT / "plugin.gd").read_text()
+    runner_source = (PLUGIN_ROOT / "update_reload_runner.gd").read_text()
+
+    assert "UPDATE_RELOAD_RUNNER_SCRIPT" in plugin_source
+    handoff_block = plugin_source.split(
+        "func install_downloaded_update(", 1
+    )[1].split("\n\nfunc ", 1)[0]
+    assert "prepare_for_update_reload()" in handoff_block
+    assert "remove_control_from_docks(_dock)" in handoff_block
+    assert "_dock = null" in handoff_block
+    assert "runner.start(zip_path, temp_dir, detached_dock)" in handoff_block
+
+    assert '_wait_frames(PRE_DISABLE_DRAIN_FRAMES, "_disable_old_plugin")' in runner_source
+
+    disable_block = runner_source.split("func _disable_old_plugin() -> void:", 1)[
+        1
+    ].split("\n\nfunc ", 1)[0]
+    assert 'set_plugin_enabled(PLUGIN_CFG_PATH, false)' in disable_block
+    assert '_wait_frames(POST_DISABLE_DRAIN_FRAMES, "_extract_and_scan")' in disable_block
+
+    extract_block = runner_source.split("func _extract_and_scan() -> void:", 1)[
+        1
+    ].split("\n\nfunc ", 1)[0]
+    assert "_extract_update()" in extract_block
+    assert "_cleanup_update_temp()" in extract_block
+    assert "_start_filesystem_scan()" in extract_block
+
+    scan_block = runner_source.split("func _start_filesystem_scan() -> void:", 1)[
+        1
+    ].split("\n\nfunc ", 1)[0]
+    assert "fs.filesystem_changed.connect(_on_filesystem_changed, CONNECT_ONE_SHOT)" in scan_block
+    assert "fs.scan()" in scan_block
+    assert "set_process(true)" in scan_block
+
+    finish_block = runner_source.split("func _finish_scan_wait() -> void:", 1)[
+        1
+    ].split("\n\nfunc ", 1)[0]
+    assert "_enable_new_plugin.call_deferred()" in finish_block
+
+    enable_block = runner_source.split("func _enable_new_plugin() -> void:", 1)[
+        1
+    ].split("\n\nfunc ", 1)[0]
+    assert 'set_plugin_enabled(PLUGIN_CFG_PATH, true)' in enable_block
+    assert '_wait_frames(POST_ENABLE_FREE_FRAMES, "_cleanup_and_finish")' in enable_block
+
+    cleanup_block = runner_source.split("func _cleanup_and_finish() -> void:", 1)[
+        1
+    ].split("\n\nfunc ", 1)[0]
+    assert "_cleanup_detached_dock()" in cleanup_block
+    assert "queue_free()" in cleanup_block
+    assert "OS.create_process" not in runner_source
+    assert "get_tree().quit" not in runner_source
+    assert "await " not in runner_source, (
+        "The runner script is itself under addons/godot_ai, so fs.scan() can "
+        "hot-reload it. It must not suspend with await across that reload; "
+        "use _process/signal callbacks instead."
+    )
+
+
+def test_self_update_runner_does_not_introduce_typed_variant_storage_hazards() -> None:
+    """The runner is the only plugin-owned script instance expected to survive scan."""
+
+    runner_source = (PLUGIN_ROOT / "update_reload_runner.gd").read_text()
+    risky_field = re.compile(r"^\s*var\s+\w+\s*:\s*(?:Dictionary|Array)(?:\[|[\s=])", re.M)
+
+    assert risky_field.search(runner_source) is None, (
+        "Do not add typed Dictionary/Array fields to update_reload_runner.gd. "
+        "That instance intentionally survives fs.scan() and would recreate "
+        "the #245 NIL-storage crash class."
     )
 
 

--- a/tests/unit/test_editor_focus_refocus.py
+++ b/tests/unit/test_editor_focus_refocus.py
@@ -126,6 +126,79 @@ def test_initial_paint_warms_worker_call_graph_before_threading() -> None:
     )
 
 
+def test_client_status_refresh_defers_while_editor_filesystem_is_busy() -> None:
+    """Refresh workers must not race Godot's script reload/documentation pass."""
+
+    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+
+    assert "var _client_status_refresh_deferred_until_filesystem_ready := false" in source
+    assert "var _client_status_refresh_deferred_force := false" in source
+
+    process_block = source.split("func _process(_delta: float) -> void:", 1)[
+        1
+    ].split("\n\nfunc ", 1)[0]
+    assert "_retry_deferred_client_status_refresh()" in process_block
+
+    init_block = source.split(
+        "func _perform_initial_client_status_refresh() -> void:", 1
+    )[1].split("\n\nfunc ", 1)[0]
+    request_block = source.split(
+        "func _request_client_status_refresh(force: bool = false) -> bool:", 1
+    )[1].split("\n\nfunc ", 1)[0]
+    assert "_is_editor_filesystem_busy()" in init_block
+    assert "_defer_client_status_refresh_until_filesystem_ready(" in init_block
+
+    assert "_is_editor_filesystem_busy()" in request_block
+    busy_request_block = request_block.split("if _is_editor_filesystem_busy():", 1)[
+        1
+    ].split("\n\n", 1)[0]
+    assert "if force:" in busy_request_block
+    assert "_defer_client_status_refresh_until_filesystem_ready(force)" in busy_request_block
+    assert busy_request_block.index("if force:") < busy_request_block.index("return false")
+
+
+def test_focus_refresh_is_opportunistic_while_editor_filesystem_is_busy() -> None:
+    """Focus-in status refresh should never be treated as important editor work."""
+
+    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+    focus_block = _focus_in_block(source)
+    request_block = source.split(
+        "func _request_client_status_refresh(force: bool = false) -> bool:", 1
+    )[1].split("\n\nfunc ", 1)[0]
+    busy_request_block = request_block.split("if _is_editor_filesystem_busy():", 1)[
+        1
+    ].split("\n\n", 1)[0]
+
+    assert "_request_client_status_refresh(false)" in focus_block
+    assert "_defer_client_status_refresh_until_filesystem_ready(force)" in busy_request_block
+    assert "if force:" in busy_request_block
+    assert "_refresh_all_client_statuses" not in focus_block
+    assert "client_status_probe_snapshot(" not in focus_block
+    assert "check_status" not in focus_block
+
+
+def test_deferred_refresh_replays_through_async_request_path_only() -> None:
+    """Queued manual/initial refreshes should not reintroduce PR #228's sync sweep."""
+
+    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+    retry_block = source.split("func _retry_deferred_client_status_refresh() -> void:", 1)[
+        1
+    ].split("\n\nfunc ", 1)[0]
+
+    for block in (retry_block,):
+        assert "_is_editor_filesystem_busy()" in block
+        assert "_request_client_status_refresh(force)" in block
+        assert "_refresh_all_client_statuses" not in block
+        assert "client_status_probe_snapshot(" not in block
+        assert "check_status" not in block
+
+    busy_block = source.split("func _is_editor_filesystem_busy() -> bool:", 1)[
+        1
+    ].split("\n\nfunc ", 1)[0]
+    assert "EditorInterface.get_resource_filesystem()" in busy_block
+    assert "fs.is_scanning()" in busy_block
+
+
 def test_install_update_drains_workers_and_blocks_spawning_before_extract() -> None:
     """Self-update must drain in-flight workers + block new ones before any file write.
 
@@ -252,7 +325,16 @@ def test_self_update_runner_disables_old_plugin_before_extract_and_scan() -> Non
     ].split("\n\nfunc ", 1)[0]
     assert "fs.filesystem_changed.connect(_on_filesystem_changed, CONNECT_ONE_SHOT)" in scan_block
     assert "fs.scan()" in scan_block
-    assert "set_process(true)" in scan_block
+    assert "FILESYSTEM_SCAN_TIMEOUT" not in runner_source
+    assert "_scan_timeout" not in runner_source
+    process_block = runner_source.split("func _process(_delta: float) -> void:", 1)[
+        1
+    ].split("\n\nfunc ", 1)[0]
+    assert "_finish_scan_wait()" not in process_block, (
+        "Do not treat a frame-count timeout as filesystem-scan completion. "
+        "Re-enabling before `filesystem_changed` can parse plugin.gd before "
+        "Godot has registered newly extracted class_name scripts."
+    )
 
     finish_block = runner_source.split("func _finish_scan_wait() -> void:", 1)[
         1


### PR DESCRIPTION
## Summary
- hand off downloaded self-updates from `McpDock` to a detached update runner before any extraction writes
- synchronously remove the live dock from editor docks so its `_exit_tree` runs on pre-update bytecode, then disable the old plugin before extraction and filesystem scan
- re-enable the plugin after scan and lazily `queue_free` the orphaned old dock after deferred callbacks have drained
- add static guard tests for ordering, no restart calls, no `await` across hot-reload, and no typed `Dictionary`/`Array` fields on the runner

## Why
Godot 4.6.2 can hot-reload a live script instance with newly added typed `Dictionary`/`Array` storage left as NIL. In the v(N) -> v(N+1) self-update path, that made the old `McpDock` execute new `_exit_tree` bytecode against old storage and crash in `Dictionary.keys()`. This path avoids keeping plugin-owned instances alive across the scan.

Fixes #245. Refs #242 and #247.

## Validation
- `pytest -q`
- `ruff check src tests`
- `godot --headless --path test_project --import` with no parse/load errors in the import log
- PR CI: https://github.com/hi-godot/godot-ai/actions/runs/25067331195 passed, including cross-platform Godot 4.6.2 reload smoke on Linux, macOS, and Windows
- interactive smoke: Godot 4.6.2 mono, `~/Documents/godot-ai-pr249-smoke`, synthetic `2.1.3-test` update adding `_vnp1_trigger_dict: Dictionary = {}`; clicked Update; no crash and no new `.ips`; console saw runner disable old plugin, old plugin unload, runner enable new plugin, and new plugin load. The `[v(N+1) _exit_tree]` trigger only ran later on manual editor shutdown and returned 0 entries from `.keys()`.

## Forensic synthetic note
The dedicated #245 synthetic forensic workflow from PR #249 is not part of this implementation PR. I ran it separately on temporary branch `tmp/forensic-issue-245-run`, based on this PR head plus only the forensic workflow/docs: https://github.com/hi-godot/godot-ai/actions/runs/25067538231.

That run intentionally exercises the upstream Godot bug, not the godot-ai self-update workaround. It still reports `RESULT: CRASH (Dictionary::keys on null _p)` on Linux, macOS, and Windows, with `inst.get('injected_dict'): typeof=0 value=<null>` before the crash. That confirms the engine bug still exists; the plugin fix avoids keeping godot-ai plugin-owned instances alive across the hot-reload boundary.