### PR TITLE
docs(ui_build_layout): clarify separation lives under theme_override_constants

### DIFF
--- a/src/godot_ai/tools/ui.py
+++ b/src/godot_ai/tools/ui.py
@@ -28,6 +28,10 @@ Ops:
         Atomically build a UI subtree from a nested spec
         ({type, name?, properties?, anchor_preset?, anchor_margin?, theme?,
         children?}). Validates everything before mutating.
+        `properties` is direct node properties only. Theme constants like
+        container spacing live under `theme_override_constants/<name>` —
+        e.g. `{"theme_override_constants/separation": 8}` on a
+        VBoxContainer, not `{"separation": 8}` (which errors).
   • draw_recipe(path, ops, clear_existing=True)
         Attach a declarative list of vector _draw() ops to a Control —
         radar sweeps, gauges, corner brackets, crosshairs, waveforms.

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -3173,7 +3173,7 @@ async def test_ui_build_layout_handler_forwards_tree_and_parent():
     tree = {
         "type": "VBoxContainer",
         "name": "PauseMenu",
-        "properties": {"separation": 16},
+        "properties": {"theme_override_constants/separation": 16},
         "children": [{"type": "Label", "properties": {"text": "Paused"}}],
     }
     result = await ui_handlers.ui_build_layout(runtime, tree=tree, parent_path="/Main/HUD")


### PR DESCRIPTION
## Summary
- Add a concise note + negative example to `ui_build_layout`'s op description: `{"separation": N}` errors because `separation` is a Godot theme constant, not a direct property — use `theme_override_constants/separation` instead.
- Swap the same misleading shape out of the stub-forwarding unit test so test data no longer documents a shape that errors at runtime.

## Test plan
- [x] `pytest -q` — 660 passing
- [x] Live `test_run suite=ui test_name=theme_override_constant` — 1/1, confirms the recommended form works against the editor (`test_ui.gd::test_build_layout_theme_override_constant`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
