### PR TITLE
[codex] Block stale foreign MCP server adoption

### DIFF
--- a/plugin/addons/godot_ai/connection.gd
+++ b/plugin/addons/godot_ai/connection.gd
@@ -28,6 +28,12 @@ var server_version := ""
 
 var dispatcher: McpDispatcher
 var log_buffer: McpLogBuffer
+## Set by plugin.gd when the HTTP port is occupied by an incompatible or
+## unverified server. Keeping the Connection node alive lets handlers and the
+## dock share one object, but no WebSocket is opened to the wrong server.
+var connect_blocked := false
+var connect_block_reason := ""
+var _blocked_notice_logged := false
 ## Set to true to skip _process() during operations like save_scene
 ## that may trigger re-entrant frame processing.
 var pause_processing := false
@@ -39,6 +45,10 @@ func _ready() -> void:
 	## Increase outbound buffer for large messages (e.g. screenshot base64).
 	## Default is 64 KB; screenshots can be several MB.
 	_peer.outbound_buffer_size = 4 * 1024 * 1024  # 4 MB
+	if connect_blocked:
+		_log_blocked_notice_once()
+		set_process(false)
+		return
 	_connect_to_server()
 	_hook_editor_signals()
 
@@ -119,6 +129,10 @@ func _connect_to_server() -> void:
 
 
 func _attempt_reconnect() -> void:
+	if connect_blocked:
+		_log_blocked_notice_once()
+		set_process(false)
+		return
 	var delay := _reconnect_delay_for_attempt(_reconnect_attempt)
 	_reconnect_attempt += 1
 	_reconnect_timer = delay
@@ -147,6 +161,14 @@ static func _should_log_reconnect_attempt(attempt_number: int) -> bool:
 		attempt_number <= RECONNECT_VERBOSE_ATTEMPTS
 		or attempt_number % RECONNECT_LOG_EVERY_N_ATTEMPTS == 0
 	)
+
+
+func _log_blocked_notice_once() -> void:
+	if _blocked_notice_logged:
+		return
+	_blocked_notice_logged = true
+	if log_buffer and not connect_block_reason.is_empty():
+		log_buffer.log(connect_block_reason)
 
 
 func _send_handshake() -> void:

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -723,6 +723,8 @@ func _update_status() -> void:
 		else {}
 	)
 	var state: String = server_status.get("state", McpSpawnState.OK)
+	if state == McpSpawnState.INCOMPATIBLE_SERVER:
+		connected = false
 
 	## One `match`/`elif` chain, one source of truth. Adding a new
 	## spawn outcome = one `McpSpawnState` constant + one arm here +
@@ -730,14 +732,22 @@ func _update_status() -> void:
 	var status_text: String
 	var status_color: Color
 	if connected:
-		status_text = "Connected"
-		status_color = Color.GREEN
+		if bool(server_status.get("dev_version_mismatch_allowed", false)):
+			var actual := str(server_status.get("actual_version", ""))
+			status_text = "Connected (dev server v%s)" % actual if not actual.is_empty() else "Connected (dev server)"
+			status_color = COLOR_AMBER
+		else:
+			status_text = "Connected"
+			status_color = Color.GREEN
 	elif state == McpSpawnState.CRASHED:
 		var exit_ms: int = server_status.get("exit_ms", 0)
 		status_text = "Server exited after %.1fs" % (exit_ms / 1000.0)
 		status_color = Color.RED
 	elif state == McpSpawnState.PORT_EXCLUDED:
 		status_text = "Port %d reserved by Windows" % McpClientConfigurator.http_port()
+		status_color = Color.RED
+	elif state == McpSpawnState.INCOMPATIBLE_SERVER:
+		status_text = "Incompatible server on port %d" % McpClientConfigurator.http_port()
 		status_color = Color.RED
 	elif state == McpSpawnState.FOREIGN_PORT:
 		status_text = "Port %d held by another process" % McpClientConfigurator.http_port()
@@ -770,8 +780,10 @@ func _update_status() -> void:
 
 ## Render the diagnostic panel body for a given spawn state. The top
 ## status label already names the problem; this answers "what do I do?".
-## Panel shows for any non-OK state; picker shows when the root cause
-## is port contention (same escape applies to PORT_EXCLUDED + FOREIGN_PORT).
+## Panel shows for any non-OK state; picker shows only when moving the HTTP
+## port alone is a valid recovery. Incompatible godot-ai servers commonly
+## hold both HTTP and WS ports, so their message points to Editor Settings
+## instead of offering the HTTP-only quick picker.
 func _update_crash_panel(server_status: Dictionary) -> void:
 	var state: String = server_status.get("state", McpSpawnState.OK)
 	if state == McpSpawnState.OK:
@@ -784,9 +796,12 @@ func _update_crash_panel(server_status: Dictionary) -> void:
 	_last_server_status = server_status.duplicate()
 	_crash_panel.visible = true
 	_crash_output.clear()
-	_crash_output.add_text(_crash_body_for_state(state))
+	_crash_output.add_text(_crash_body_for_state(state, server_status))
 
-	var port_picker_visible := state == McpSpawnState.PORT_EXCLUDED or state == McpSpawnState.FOREIGN_PORT
+	var port_picker_visible := (
+		state == McpSpawnState.PORT_EXCLUDED
+		or state == McpSpawnState.FOREIGN_PORT
+	)
 	_port_picker_section.visible = port_picker_visible
 	if port_picker_visible:
 		## Seed the SpinBox with a suggested non-reserved port each time
@@ -797,13 +812,18 @@ func _update_crash_panel(server_status: Dictionary) -> void:
 		)
 
 
-static func _crash_body_for_state(state: String) -> String:
+static func _crash_body_for_state(state: String, server_status: Dictionary = {}) -> String:
 	## Single sentence per state. The top status label already names the
 	## problem; don't repeat it here. This copy answers "what do I do?".
 	var port := McpClientConfigurator.http_port()
 	match state:
 		McpSpawnState.PORT_EXCLUDED:
 			return "Windows (Hyper-V / WSL2 / Docker) reserved port %d. Pick a free port or try `net stop winnat; net start winnat` in an admin shell." % port
+		McpSpawnState.INCOMPATIBLE_SERVER:
+			var message := str(server_status.get("message", ""))
+			if not message.is_empty():
+				return message
+			return "Port %d is occupied by an incompatible server. Stop it or change both HTTP and WS ports." % port
 		McpSpawnState.FOREIGN_PORT:
 			return "Another process is already bound to port %d. Pick a free port or stop the other process." % port
 		McpSpawnState.CRASHED:
@@ -986,31 +1006,50 @@ func _on_reconnect() -> void:
 ## version, and highlight the mismatch so self-update drift is visible
 ## at a glance instead of silently masked by a green label.
 ##
-## Three render states, keyed off `McpConnection.server_version`:
-## - empty (pre-ack or older server): show plugin's expected version,
-##   muted, no Restart button
+## Render states, keyed off live version metadata:
+## - empty (pre-ack): show the expected version only as an unverified target
 ## - matches plugin: show it green, no Restart button
-## - diverges from plugin: show it amber, append "(plugin X)", show
-##   Restart button so the user can kill the stale occupant and respawn
-##   without restarting the editor
+## - dev mismatch: show amber with an explicit dev marker
+## - release mismatch: show actual vs expected; only surface Restart when the
+##   plugin has ownership proof for the process
 func _refresh_server_version_label() -> void:
 	if _setup_server_label == null:
 		return
 	var plugin_ver := McpClientConfigurator.get_plugin_version()
+	var server_status: Dictionary = (
+		_plugin.get_server_status()
+		if _plugin != null and _plugin.has_method("get_server_status")
+		else {}
+	)
 	var server_ver := _connection.server_version if _connection != null else ""
+	if server_ver.is_empty():
+		server_ver = str(server_status.get("actual_version", ""))
+	var expected_ver := str(server_status.get("expected_version", ""))
+	if expected_ver.is_empty():
+		expected_ver = plugin_ver
 	var text: String
 	var color: Color
 	var show_restart := false
 	if server_ver.is_empty():
-		text = "godot-ai == %s" % plugin_ver
+		text = "checking live version (expected godot-ai == %s)" % expected_ver
 		color = COLOR_MUTED
-	elif server_ver == plugin_ver:
+	elif server_ver == expected_ver:
 		text = "godot-ai == %s" % server_ver
 		color = Color.GREEN
 	else:
-		text = "godot-ai == %s  (plugin %s)" % [server_ver, plugin_ver]
-		color = COLOR_AMBER
-		show_restart = true
+		var dev_allowed := bool(server_status.get("dev_version_mismatch_allowed", false))
+		if dev_allowed:
+			text = "godot-ai == %s  (plugin %s, dev)" % [server_ver, expected_ver]
+			color = COLOR_AMBER
+		else:
+			text = "godot-ai == %s  (expected %s)" % [server_ver, expected_ver]
+			color = Color.RED if server_status.get("state", "") == McpSpawnState.INCOMPATIBLE_SERVER else COLOR_AMBER
+			show_restart = (
+				server_status.get("state", "") != McpSpawnState.INCOMPATIBLE_SERVER
+				and _plugin != null
+				and _plugin.has_method("can_restart_managed_server")
+				and _plugin.can_restart_managed_server()
+			)
 	if text == _last_rendered_server_text:
 		if _version_restart_btn != null and _version_restart_btn.visible != show_restart:
 			_version_restart_btn.visible = show_restart
@@ -1195,6 +1234,10 @@ func _on_install_uv() -> void:
 # --- Client section ---
 
 func _on_configure_client(client_id: String) -> void:
+	if _server_blocks_client_health():
+		_apply_row_status(client_id, McpClient.Status.ERROR, _server_blocked_client_message())
+		_refresh_clients_summary()
+		return
 	_dispatch_client_action(client_id, "configure")
 
 
@@ -1269,6 +1312,10 @@ func _apply_client_action_result(client_id: String, action: String, result: Dict
 			t.wait_to_finish()
 		_client_action_threads.erase(client_id)
 	_finalize_action_buttons(client_id)
+	if _server_blocks_client_health():
+		_apply_row_status(client_id, McpClient.Status.ERROR, _server_blocked_client_message())
+		_refresh_clients_summary()
+		return
 
 	var success_status := McpClient.Status.NOT_CONFIGURED if action == "remove" else McpClient.Status.CONFIGURED
 	if result.get("status") == "ok":
@@ -1326,6 +1373,11 @@ func _on_refresh_clients_pressed() -> void:
 
 
 func _on_configure_all_clients() -> void:
+	if _server_blocks_client_health():
+		for client_id in _client_rows:
+			_apply_row_status(String(client_id), McpClient.Status.ERROR, _server_blocked_client_message())
+		_refresh_clients_summary()
+		return
 	if _client_status_refresh_in_flight:
 		return
 	for client_id in _client_rows:
@@ -1651,6 +1703,11 @@ func _refresh_all_client_statuses() -> void:
 	## Compatibility wrapper for older explicit call sites. Treat this as a manual
 	## refresh: it bypasses focus-in cooldown but still runs probes off the editor
 	## main thread.
+	if _server_blocks_client_health():
+		for client_id in _client_rows:
+			_apply_row_status(String(client_id), McpClient.Status.ERROR, _server_blocked_client_message())
+		_refresh_clients_summary()
+		return
 	_request_client_status_refresh(true)
 
 
@@ -1738,6 +1795,12 @@ func _perform_initial_client_status_refresh() -> void:
 	if _client_status_refresh_in_flight:
 		return
 
+	if _server_blocks_client_health():
+		for client_id in _client_rows:
+			_apply_row_status(String(client_id), McpClient.Status.ERROR, _server_blocked_client_message())
+		_refresh_clients_summary()
+		return
+
 	var generation := _begin_client_status_refresh_run()
 	var server_url := McpClientConfigurator.http_url()
 	var deferred_cli_probes: Array[Dictionary] = []
@@ -1806,6 +1869,11 @@ func _request_client_status_refresh(force: bool = false) -> bool:
 	## Stale-while-refreshing: do not clear dots, summary, or the drift banner
 	## when a refresh is requested. The existing UI remains visible until the
 	## background worker's result is applied on the main thread.
+	if _server_blocks_client_health():
+		for client_id in _client_rows:
+			_apply_row_status(String(client_id), McpClient.Status.ERROR, _server_blocked_client_message())
+		_refresh_clients_summary()
+		return false
 	if _self_update_in_progress:
 		## Self-update is overwriting plugin scripts on disk; spawning a worker
 		## now would crash it inside `GDScriptFunction::call` once the bytecode
@@ -1919,6 +1987,11 @@ func _apply_client_status_refresh_results(results: Dictionary, generation: int) 
 	if _client_status_refresh_thread != null:
 		_client_status_refresh_thread.wait_to_finish()
 		_client_status_refresh_thread = null
+	if _server_blocks_client_health():
+		for client_id in _client_rows:
+			_apply_row_status(String(client_id), McpClient.Status.ERROR, _server_blocked_client_message())
+		_finalize_completed_refresh()
+		return
 
 	for client_id in results:
 		## Skip rows whose Configure / Remove worker is still running so the
@@ -1941,6 +2014,21 @@ func _apply_client_status_refresh_results(results: Dictionary, generation: int) 
 		_client_status_refresh_pending = false
 		_client_status_refresh_pending_force = false
 		_request_client_status_refresh(pending_force)
+
+
+func _server_blocks_client_health() -> bool:
+	if _plugin == null or not _plugin.has_method("get_server_status"):
+		return false
+	var status: Dictionary = _plugin.get_server_status()
+	return status.get("state", McpSpawnState.OK) == McpSpawnState.INCOMPATIBLE_SERVER
+
+
+func _server_blocked_client_message() -> String:
+	if _plugin == null or not _plugin.has_method("get_server_status"):
+		return "server incompatible"
+	var status: Dictionary = _plugin.get_server_status()
+	var message := str(status.get("message", ""))
+	return message if not message.is_empty() else "server incompatible"
 
 
 func _refresh_drift_banner(mismatched_ids: Array[String]) -> void:

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -65,6 +65,9 @@ const SERVER_WATCH_MS := 30 * 1000
 ## a spawn a crash until this window elapses so the watch loop has time to
 ## observe either the pid-file (dev venv) or the port listening (uvx).
 const SPAWN_GRACE_MS := 5 * 1000
+const SERVER_STATUS_PATH := "/godot-ai/status"
+const SERVER_STATUS_PROBE_TIMEOUT_MS := 800
+const SERVER_HANDSHAKE_VERSION_TIMEOUT_MS := 5 * 1000
 
 var _connection: McpConnection
 var _dispatcher: McpDispatcher
@@ -103,6 +106,13 @@ var _refresh_retried: bool = false
 ## Bounded deadline for `_watch_for_adoption_confirmation`. Zero when
 ## disarmed. See that function's docstring.
 var _adoption_watch_deadline_ms: int = 0
+var _server_expected_version := ""
+var _server_actual_version := ""
+var _server_status_message := ""
+var _server_dev_version_mismatch_allowed := false
+var _connection_blocked := false
+var _awaiting_server_version := false
+var _server_version_deadline_ms: int = 0
 
 
 func _enter_tree() -> void:
@@ -126,6 +136,10 @@ func _enter_tree() -> void:
 
 	_connection = McpConnection.new()
 	_connection.log_buffer = _log_buffer
+	_connection.connect_blocked = _connection_blocked
+	_connection.connect_block_reason = _server_status_message
+	if not _connection_blocked and _spawn_state == McpSpawnState.OK:
+		_arm_server_version_check()
 
 	_debugger_plugin = McpDebuggerPlugin.new(_log_buffer, _game_log_buffer)
 	add_debugger_plugin(_debugger_plugin)
@@ -428,7 +442,7 @@ func _start_server() -> void:
 	##   port in use, record.version drifts   -> kill port owner + respawn
 	##                                              (fixes cold-start drift
 	##                                              from manual file replace)
-	##   port in use, no matching record      -> foreign server, leave alone
+	##   port in use, no verified live match  -> block adoption + warn
 	if _server_started_this_session:
 		## Guard against re-entrant spawns (e.g. plugin reload during update).
 		## The static flag persists across disable/enable cycles within the
@@ -440,20 +454,40 @@ func _start_server() -> void:
 	var port := McpClientConfigurator.http_port()
 	var ws_port := McpClientConfigurator.ws_port()
 	var current_version := McpClientConfigurator.get_plugin_version()
+	_server_expected_version = current_version
 
 	if _is_port_in_use(port):
 		var record := _read_managed_server_record()
-		if record.version == current_version:
-			## Version matches — this port is owned by a server we spawned
-			## at some point. Adopt the live port owner, ignoring any stale
-			## launcher PID that may still be in the record. Self-heal the
-			## record so next session's adopt can fast-path.
+		var live := _probe_live_server_status(port)
+		var live_version := _verified_status_version(live)
+		var live_ws_port := _verified_status_ws_port(live)
+		var compatibility := _server_status_compatibility(
+			live_version,
+			current_version,
+			live_ws_port,
+			ws_port,
+			McpClientConfigurator.is_dev_checkout()
+		)
+		if compatibility.get("compatible", false):
+			_server_actual_version = live_version
+			_server_dev_version_mismatch_allowed = bool(compatibility.get("dev_mismatch_allowed", false))
+			if _server_dev_version_mismatch_allowed:
+				_server_status_message = (
+					"Using dev server v%s on WS port %d with plugin v%s "
+					+ "(dev checkout version mismatch allowed)."
+				) % [_server_actual_version, live_ws_port, current_version]
+			## Version verified — this port speaks current-compatible godot-ai.
+			## If the managed record matches, adopt ownership and self-heal
+			## its PID. Otherwise reuse the external/dev server without
+			## recording ownership, so plugin unloads never kill it.
 			var owner := _find_managed_pid(port)
-			if owner > 0:
+			if record.version == current_version and owner > 0:
 				_server_pid = owner
 				_write_managed_server_record(owner, current_version)
 			_server_started_this_session = true
-			print("MCP | adopted managed server (PID %d, v%s)" % [_server_pid, current_version])
+			var owner_label := "managed" if _server_pid > 0 else "external"
+			print("MCP | adopted %s server (PID %d, live v%s, WS %d, plugin v%s)"
+				% [owner_label, _server_pid, _server_actual_version, live_ws_port, current_version])
 			return
 		if not record.version.is_empty():
 			## Version drift — our server but the plugin moved on. Kill
@@ -469,17 +503,14 @@ func _start_server() -> void:
 			_wait_for_port_free(port, 3.0)
 			## Fall through to spawn.
 		else:
-			## No record claiming this port. Could be a non-MCP process
-			## (the handshake will never succeed → user sees FOREIGN_PORT
-			## and picks a different port) OR another editor's MCP server
-			## whose managed-record we just don't have locally — in which
-			## case our WebSocket WILL open and the diagnostic would be a
-			## lie. Flag FOREIGN_PORT preemptively, and arm a one-shot
-			## watcher that clears it if adoption actually succeeds.
+			## No record claiming this port and the live status probe did
+			## not verify an exact/current-compatible godot-ai server. Do
+			## not open the WebSocket: an old server can accept the plugin
+			## session while still exposing an incompatible HTTP/MCP tool
+			## surface to clients such as Antigravity.
 			_server_started_this_session = true
-			_set_spawn_state(McpSpawnState.FOREIGN_PORT)
-			_watch_for_adoption_confirmation()
-			print("MCP | foreign server already running on port %d, using existing" % port)
+			_set_incompatible_server(live, current_version, port)
+			push_warning(_server_status_message)
 			return
 
 	var server_cmd := McpClientConfigurator.get_server_command()
@@ -539,6 +570,173 @@ func _start_server() -> void:
 		push_warning("MCP | failed to start server")
 
 
+func _set_incompatible_server(live: Dictionary, expected_version: String, port: int) -> void:
+	_spawn_state = McpSpawnState.INCOMPATIBLE_SERVER
+	_connection_blocked = true
+	_server_expected_version = expected_version
+	_server_actual_version = _live_version_for_message(live)
+	_server_dev_version_mismatch_allowed = false
+	_server_status_message = _incompatible_server_message(live, expected_version, port)
+	_refresh_dock_client_statuses()
+
+
+static func _incompatible_server_message(live: Dictionary, expected_version: String, port: int) -> String:
+	var version := _live_version_for_message(live)
+	var actual_ws_port := _live_ws_port_for_message(live)
+	var expected_ws_port := McpClientConfigurator.ws_port()
+	if not version.is_empty():
+		if actual_ws_port > 0 and actual_ws_port != expected_ws_port:
+			return (
+				"Port %d is occupied by godot-ai server v%s using WS port %d; "
+				+ "plugin expects v%s with WS port %d. Stop the old server or "
+				+ "change both HTTP and WS ports."
+			) % [port, version, actual_ws_port, expected_version, expected_ws_port]
+		return (
+			"Port %d is occupied by godot-ai server v%s; plugin expects v%s. "
+			+ "Stop the old server or change both HTTP and WS ports."
+		) % [port, version, expected_version]
+	var status_code := int(live.get("status_code", 0))
+	if status_code > 0:
+		return (
+			"Port %d is occupied by an unverified server (status endpoint returned HTTP %d); "
+			+ "plugin expects godot-ai v%s. Stop the other server or change both HTTP and WS ports."
+		) % [port, status_code, expected_version]
+	return (
+		"Port %d is occupied by another process; plugin expects godot-ai v%s. "
+		+ "Stop the other process or change both HTTP and WS ports."
+	) % [port, expected_version]
+
+
+static func _server_version_compatibility(actual_version: String, expected_version: String, is_dev_checkout: bool) -> Dictionary:
+	if actual_version.is_empty():
+		return {"compatible": false, "reason": "unknown", "dev_mismatch_allowed": false}
+	if actual_version == expected_version:
+		return {"compatible": true, "reason": "exact", "dev_mismatch_allowed": false}
+	if is_dev_checkout:
+		return {"compatible": true, "reason": "dev_mismatch", "dev_mismatch_allowed": true}
+	return {"compatible": false, "reason": "version_mismatch", "dev_mismatch_allowed": false}
+
+
+static func _server_status_compatibility(
+	actual_version: String,
+	expected_version: String,
+	actual_ws_port: int,
+	expected_ws_port: int,
+	is_dev_checkout: bool,
+) -> Dictionary:
+	var version_result := _server_version_compatibility(
+		actual_version,
+		expected_version,
+		is_dev_checkout
+	)
+	if not bool(version_result.get("compatible", false)):
+		return version_result
+	if actual_ws_port != expected_ws_port:
+		return {"compatible": false, "reason": "ws_port_mismatch", "dev_mismatch_allowed": false}
+	return version_result
+
+
+static func _probe_live_server_status(port: int, timeout_ms: int = SERVER_STATUS_PROBE_TIMEOUT_MS) -> Dictionary:
+	var result := {
+		"reachable": false,
+		"version": "",
+		"name": "",
+		"ws_port": 0,
+		"status_code": 0,
+		"error": "",
+	}
+	var client := HTTPClient.new()
+	var err := client.connect_to_host("127.0.0.1", port)
+	if err != OK:
+		result["error"] = "connect_%d" % err
+		return result
+	var deadline := Time.get_ticks_msec() + timeout_ms
+	while client.get_status() == HTTPClient.STATUS_RESOLVING or client.get_status() == HTTPClient.STATUS_CONNECTING:
+		client.poll()
+		if Time.get_ticks_msec() >= deadline:
+			result["error"] = "connect_timeout"
+			return result
+		OS.delay_msec(10)
+	if client.get_status() != HTTPClient.STATUS_CONNECTED:
+		result["error"] = "connect_status_%d" % client.get_status()
+		return result
+	err = client.request(HTTPClient.METHOD_GET, SERVER_STATUS_PATH, ["Accept: application/json"])
+	if err != OK:
+		result["error"] = "request_%d" % err
+		return result
+	var body := PackedByteArray()
+	while true:
+		var status := client.get_status()
+		if status == HTTPClient.STATUS_REQUESTING or status == HTTPClient.STATUS_BODY:
+			client.poll()
+			var chunk := client.read_response_body_chunk()
+			if chunk.size() > 0:
+				body.append_array(chunk)
+		elif status == HTTPClient.STATUS_CONNECTED:
+			break
+		else:
+			result["error"] = "response_status_%d" % status
+			return result
+		if Time.get_ticks_msec() >= deadline:
+			result["error"] = "response_timeout"
+			return result
+		OS.delay_msec(10)
+	var response_code := client.get_response_code()
+	result["status_code"] = response_code
+	if response_code != 200:
+		result["error"] = "http_%d" % response_code
+		return result
+	var parsed = JSON.parse_string(body.get_string_from_utf8())
+	if not (parsed is Dictionary):
+		result["error"] = "invalid_json"
+		return result
+	result["reachable"] = true
+	result["name"] = str(parsed.get("name", ""))
+	result["version"] = _extract_server_version(parsed)
+	result["ws_port"] = int(parsed.get("ws_port", 0))
+	return result
+
+
+static func _extract_server_version(payload: Dictionary) -> String:
+	var version := str(payload.get("server_version", ""))
+	if version.is_empty():
+		version = str(payload.get("version", ""))
+	return version
+
+
+static func _verified_status_version(live: Dictionary) -> String:
+	if str(live.get("name", "")) != "godot-ai":
+		return ""
+	return str(live.get("version", ""))
+
+
+static func _verified_status_ws_port(live: Dictionary) -> int:
+	if str(live.get("name", "")) != "godot-ai":
+		return 0
+	return int(live.get("ws_port", 0))
+
+
+static func _live_version_for_message(live: Dictionary) -> String:
+	if live.has("name") and str(live.get("name", "")) != "godot-ai":
+		return ""
+	return str(live.get("version", ""))
+
+
+static func _live_ws_port_for_message(live: Dictionary) -> int:
+	if live.has("name") and str(live.get("name", "")) != "godot-ai":
+		return 0
+	return int(live.get("ws_port", 0))
+
+
+func _refresh_dock_client_statuses() -> bool:
+	if _dock == null:
+		return false
+	if not _dock.has_method("_refresh_all_client_statuses"):
+		return false
+	_dock.call("_refresh_all_client_statuses")
+	return true
+
+
 ## Record a non-OK spawn outcome. First writer wins: once a specific
 ## diagnosis lands (e.g. PORT_EXCLUDED during the proactive check),
 ## later fallback paths (e.g. CRASHED from the watch loop) don't
@@ -564,31 +762,92 @@ func _set_spawn_state(state: String) -> void:
 ## every shipped McpConnection), so upgrades stay hot-reloadable.
 ##
 ## The watch self-disarms after SPAWN_GRACE_MS so per-frame cost drops
-## back to zero even if the foreign occupant never opens a WebSocket.
+## back to zero if it is ever armed by a legacy adoption path.
 func _watch_for_adoption_confirmation() -> void:
 	_adoption_watch_deadline_ms = Time.get_ticks_msec() + SPAWN_GRACE_MS
-	set_process(true)
+	_update_process_enabled()
+
+
+func _arm_server_version_check() -> void:
+	_awaiting_server_version = true
+	_server_version_deadline_ms = 0
+	_update_process_enabled()
+
+
+func _update_process_enabled() -> void:
+	set_process(_adoption_watch_deadline_ms > 0 or _awaiting_server_version)
 
 
 func _process(_delta: float) -> void:
-	if _connection != null and _connection.is_connected:
-		_on_connection_established()
+	var now := Time.get_ticks_msec()
+	if _awaiting_server_version:
+		if _connection != null and _connection.is_connected:
+			if _server_version_deadline_ms == 0:
+				_server_version_deadline_ms = now + SERVER_HANDSHAKE_VERSION_TIMEOUT_MS
+			if not _connection.server_version.is_empty():
+				_on_server_version_verified(_connection.server_version)
+			elif now >= _server_version_deadline_ms:
+				_on_server_version_unverified()
+	if _adoption_watch_deadline_ms > 0 and now >= _adoption_watch_deadline_ms:
 		_adoption_watch_deadline_ms = 0
-		set_process(false)
-		return
-	if Time.get_ticks_msec() >= _adoption_watch_deadline_ms:
-		_adoption_watch_deadline_ms = 0
-		set_process(false)
+	_update_process_enabled()
 
 
-## Bypasses `_set_spawn_state`'s first-writer-wins guard: the WebSocket
-## opening proves the occupant is a compatible MCP server (another
-## editor's session), so the preemptive FOREIGN_PORT diagnostic was a
-## false alarm and the dock shouldn't render the banner next to the
-## green "Connected" dot.
+## A WebSocket opening only proves the occupant speaks enough of the editor
+## protocol to accept a session. Compatibility is decided by the server
+## version in `handshake_ack`, so this only arms that check.
 func _on_connection_established() -> void:
 	if _spawn_state == McpSpawnState.FOREIGN_PORT:
-		_spawn_state = McpSpawnState.OK
+		_arm_server_version_check()
+
+
+func _on_server_version_verified(version: String) -> void:
+	_awaiting_server_version = false
+	_server_version_deadline_ms = 0
+	_server_actual_version = version
+	var expected := _server_expected_version
+	if expected.is_empty():
+		expected = McpClientConfigurator.get_plugin_version()
+		_server_expected_version = expected
+	var compatibility := _server_version_compatibility(
+		version,
+		expected,
+		McpClientConfigurator.is_dev_checkout()
+	)
+	if compatibility.get("compatible", false):
+		_server_dev_version_mismatch_allowed = bool(compatibility.get("dev_mismatch_allowed", false))
+		if _server_dev_version_mismatch_allowed:
+			_server_status_message = (
+				"Using dev server v%s with plugin v%s (dev checkout version mismatch allowed)."
+				% [version, expected]
+			)
+		if _spawn_state == McpSpawnState.FOREIGN_PORT:
+			_spawn_state = McpSpawnState.OK
+		_update_process_enabled()
+		return
+	var live := {"version": version, "status_code": 200, "name": "godot-ai"}
+	_set_incompatible_server(live, expected, McpClientConfigurator.http_port())
+	if _connection != null:
+		_connection.connect_blocked = true
+		_connection.connect_block_reason = _server_status_message
+		_connection.disconnect_from_server()
+	_update_process_enabled()
+
+
+func _on_server_version_unverified() -> void:
+	_awaiting_server_version = false
+	_server_version_deadline_ms = 0
+	var expected := _server_expected_version
+	if expected.is_empty():
+		expected = McpClientConfigurator.get_plugin_version()
+		_server_expected_version = expected
+	var live := {"version": "", "status_code": 0, "error": "missing_handshake_ack"}
+	_set_incompatible_server(live, expected, McpClientConfigurator.http_port())
+	if _connection != null:
+		_connection.connect_blocked = true
+		_connection.connect_block_reason = _server_status_message
+		_connection.disconnect_from_server()
+	_update_process_enabled()
 
 
 ## Start a 1s-tick timer that watches the spawned server for up to
@@ -635,6 +894,9 @@ func _check_server_health() -> void:
 				return
 			_server_exit_ms = elapsed
 			_set_spawn_state(McpSpawnState.CRASHED)
+			_awaiting_server_version = false
+			_server_version_deadline_ms = 0
+			_update_process_enabled()
 			_log_buffer.log("server exited after %dms — see Godot output log" % _server_exit_ms)
 			_stop_server_watch()
 		return
@@ -704,6 +966,9 @@ func _respawn_with_refresh() -> void:
 		## from a real crash, so surface CRASHED immediately rather than
 		## looping. `_refresh_retried` is already true so we won't try again.
 		_set_spawn_state(McpSpawnState.CRASHED)
+		_awaiting_server_version = false
+		_server_version_deadline_ms = 0
+		_update_process_enabled()
 		_log_buffer.log("refresh retry failed to spawn — see Godot output log")
 		_stop_server_watch()
 
@@ -717,6 +982,11 @@ func get_server_status() -> Dictionary:
 	return {
 		"state": _spawn_state,
 		"exit_ms": _server_exit_ms,
+		"actual_version": _server_actual_version,
+		"expected_version": _server_expected_version,
+		"message": _server_status_message,
+		"dev_version_mismatch_allowed": _server_dev_version_mismatch_allowed,
+		"connection_blocked": _connection_blocked,
 	}
 
 
@@ -1082,6 +1352,10 @@ func install_downloaded_update(zip_path: String, temp_dir: String, source_dock: 
 ## this, `_stop_server` early-returns on `_server_pid <= 0` and the old
 ## server outlives every plugin reload.
 func force_restart_server() -> void:
+	if not can_restart_managed_server():
+		push_warning("MCP | refusing to kill server on port %d without managed-server ownership proof"
+			% McpClientConfigurator.http_port())
+		return
 	var port := McpClientConfigurator.http_port()
 	## Kill every LISTENER on the port, not just the first one. A dev
 	## server run via `uvicorn --reload` owns port 8000 through both a
@@ -1181,3 +1455,13 @@ func is_dev_server_running() -> bool:
 func has_managed_server() -> bool:
 	## Returns true if the plugin is currently managing a server process it spawned.
 	return _server_pid > 0
+
+
+func can_restart_managed_server() -> bool:
+	## Restart is allowed only when we have ownership proof. A live PID
+	## means this plugin spawned/adopted a managed server; a non-empty
+	## managed record is the cross-session proof used by the drift branch.
+	if _server_pid > 0:
+		return true
+	var record := _read_managed_server_record()
+	return not str(record.get("version", "")).is_empty()

--- a/plugin/addons/godot_ai/utils/mcp_spawn_state.gd
+++ b/plugin/addons/godot_ai/utils/mcp_spawn_state.gd
@@ -30,6 +30,11 @@ const PORT_EXCLUDED := "port_excluded"
 ## PORT_EXCLUDED, just a different root cause.
 const FOREIGN_PORT := "foreign_port"
 
+## HTTP port is held by a godot-ai server or MCP-looking process whose
+## live version could not be verified as compatible with this plugin.
+## The plugin must not silently adopt it or mark client setup healthy.
+const INCOMPATIBLE_SERVER := "incompatible_server"
+
 ## Our spawned process exited inside the startup grace window. Python
 ## stdout/stderr went to Godot's output log (no pipe capture), so the
 ## dock points the user there instead of rendering empty output.

--- a/src/godot_ai/server.py
+++ b/src/godot_ai/server.py
@@ -10,7 +10,10 @@ from dataclasses import dataclass
 from typing import Any
 
 from fastmcp import FastMCP
+from starlette.requests import Request
+from starlette.responses import JSONResponse
 
+from godot_ai import __version__ as _SERVER_VERSION
 from godot_ai.asgi import StaleMcpSessionDiagnosticMiddleware
 from godot_ai.godot_client.client import GodotClient
 from godot_ai.middleware import (
@@ -175,6 +178,19 @@ def create_server(
     exclude = set(exclude_domains or ())
     if exclude:
         logger.info("Excluding tool domains: %s", ", ".join(sorted(exclude)))
+
+    @mcp.custom_route("/godot-ai/status", methods=["GET"], include_in_schema=False)
+    async def godot_ai_status(_request: Request) -> JSONResponse:
+        """Small unauthenticated probe used by the editor before reusing a port."""
+        return JSONResponse(
+            {
+                "name": "godot-ai",
+                "server_version": _SERVER_VERSION,
+                "ws_port": ws_port,
+                "tool_surface": "rollup",
+                "exclude_domains": sorted(exclude),
+            }
+        )
 
     ## Core-bearing domains: always registered. ``include_non_core=False`` keeps
     ## only the core tool alive when the user excluded that domain.

--- a/test_project/tests/test_connection.gd
+++ b/test_project/tests/test_connection.gd
@@ -173,3 +173,23 @@ func test_reconnect_logging_throttles_later_attempts() -> void:
 		McpConnection._should_log_reconnect_attempt(20),
 		"attempt 20 should log periodic progress",
 	)
+
+
+func test_blocked_connection_logs_once_and_stops_reconnect_loop() -> void:
+	## Regression from the stale-server live smoke: blocked adoption logged the
+	## actionable warning every reconnect tick because `_attempt_reconnect`
+	## returned before resetting the timer. A blocked connection should surface
+	## one clear message and then stop processing until the plugin is reloaded.
+	var conn := McpConnection.new()
+	var buffer := McpLogBuffer.new()
+	conn.log_buffer = buffer
+	conn.connect_blocked = true
+	conn.connect_block_reason = "blocked for test"
+
+	conn._attempt_reconnect()
+	conn._attempt_reconnect()
+
+	assert_eq(buffer.total_count(), 1, "blocked reconnect must log once, not every tick")
+	assert_eq(buffer.get_recent(1)[0], "MCP | blocked for test")
+	assert_false(conn.is_processing(), "blocked reconnect must stop Connection processing")
+	conn.free()

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -6,6 +6,7 @@ extends McpTestSuite
 ## whatever mode the current test environment is actually running in.
 
 const McpDockScript = preload("res://addons/godot_ai/mcp_dock.gd")
+const GodotAiPlugin := preload("res://addons/godot_ai/plugin.gd")
 
 var _dock: Node
 
@@ -108,6 +109,28 @@ func test_apply_row_status_renders_mismatch_as_amber_with_url_hint() -> void:
 		"Mismatched row must label itself so the user reads it as drift")
 	assert_eq((row["configure_btn"] as Button).text, "Reconfigure",
 		"Mismatched rows offer the same Reconfigure action as the banner")
+
+
+func test_incompatible_server_marks_clients_unhealthy() -> void:
+	## URL-only client checks are not enough when the URL points at an old
+	## server with an incompatible tool surface. The dock must not show green
+	## client rows while the plugin has blocked server adoption.
+	_dock._build_ui()
+	var plugin := GodotAiPlugin.new()
+	plugin._set_incompatible_server({"version": "1.2.10"}, "2.2.0", 8000)
+	_dock._plugin = plugin
+
+	var any_id := McpClientConfigurator.client_ids()[0]
+	_dock._refresh_all_client_statuses()
+	var row: Dictionary = _dock._client_rows[any_id]
+	var dot: ColorRect = row["dot"]
+	assert_eq(dot.color, Color.RED, "Blocked incompatible server must render client rows red")
+	assert_contains(
+		(row["name_label"] as Label).text,
+		"Port 8000 is occupied by godot-ai server v1.2.10",
+		"Client row must explain the live server mismatch instead of looking healthy"
+	)
+	plugin.free()
 
 
 func test_drift_banner_clears_after_per_row_reconfigure() -> void:
@@ -253,13 +276,16 @@ func _cleanup_server_row(conn: McpConnection) -> void:
 
 
 func test_server_version_label_muted_when_ack_not_received() -> void:
-	## Pre-ack (connection just opened, or older server that doesn't send
-	## handshake_ack): show the plugin's expected version muted. Nothing to
-	## flag yet and no Restart button — we don't know what's actually running.
+	## Pre-ack: show the expected version only as an unverified target.
+	## The row must not state "godot-ai == <plugin>" as a fact until the
+	## live server has reported that exact version.
 	var conn := _seed_server_row("")
 	_dock._refresh_server_version_label()
 	var plugin_ver := McpClientConfigurator.get_plugin_version()
-	assert_eq(_dock._setup_server_label.text, "godot-ai == %s" % plugin_ver)
+	assert_eq(
+		_dock._setup_server_label.text,
+		"checking live version (expected godot-ai == %s)" % plugin_ver
+	)
 	assert_false(_dock._version_restart_btn.visible, "Restart button stays hidden pre-ack")
 	_cleanup_server_row(conn)
 
@@ -279,12 +305,12 @@ func test_server_version_label_green_when_server_matches_plugin() -> void:
 	_cleanup_server_row(conn)
 
 
-func test_server_version_label_amber_with_restart_on_mismatch() -> void:
+func test_server_version_label_amber_without_restart_when_ownership_unproven() -> void:
 	## The money test: the bug scenario. Plugin is v1.4.2 but connected to
 	## a v1.3.3 server (common after self-update when a foreign-adopted
-	## server outlives the plugin upgrade). Label must expose both versions
-	## and the Restart button must surface. Regression guard — without
-	## this, the dock silently masks the drift and the user has no signal.
+	## server outlives the plugin upgrade). Label must expose both versions.
+	## The Restart button stays hidden without plugin-provided ownership proof
+	## so the dock does not offer to kill an arbitrary foreign process.
 	var conn := _seed_server_row("1.2.3-stale-for-test")
 	_dock._refresh_server_version_label()
 	var plugin_ver := McpClientConfigurator.get_plugin_version()
@@ -297,7 +323,7 @@ func test_server_version_label_amber_with_restart_on_mismatch() -> void:
 		McpDockScript.COLOR_AMBER,
 		"Mismatch must render amber, matching the drift banner's color"
 	)
-	assert_true(_dock._version_restart_btn.visible, "Restart button must surface on mismatch")
+	assert_false(_dock._version_restart_btn.visible, "Restart button requires ownership proof")
 	_cleanup_server_row(conn)
 
 
@@ -505,3 +531,26 @@ func test_drain_client_action_workers_restores_in_flight_row_buttons() -> void:
 		"Drain must re-enable the remove button too")
 	assert_false(str((row["configure_btn"] as Button).text).contains("Configuring"),
 		"Drain must clear the in-flight badge from the configure button")
+
+
+func test_incompatible_server_body_uses_actionable_message() -> void:
+	var body := McpDockScript._crash_body_for_state(
+		McpSpawnState.INCOMPATIBLE_SERVER,
+		{"message": "Port 8000 is occupied by godot-ai server v1.2.10; plugin expects v2.2.0. Stop the old server or change both HTTP and WS ports."},
+	)
+	assert_contains(body, "godot-ai server v1.2.10")
+	assert_contains(body, "plugin expects v2.2.0")
+	assert_contains(body, "change both HTTP and WS ports")
+
+
+func test_incompatible_server_hides_http_only_port_picker() -> void:
+	## Incompatible godot-ai servers commonly hold both HTTP and WS ports.
+	## The quick picker only changes HTTP, so showing it here advertises a
+	## partial recovery path that can leave the editor disconnected.
+	_dock._build_ui()
+	_dock._update_crash_panel({
+		"state": McpSpawnState.INCOMPATIBLE_SERVER,
+		"message": "Port 8000 is occupied by godot-ai server v1.2.10",
+	})
+	assert_true(_dock._crash_panel.visible, "diagnostic panel still shows")
+	assert_false(_dock._port_picker_section.visible, "HTTP-only picker must stay hidden")

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -9,6 +9,12 @@ extends McpTestSuite
 
 const GodotAiPlugin := preload("res://addons/godot_ai/plugin.gd")
 
+class _RefreshDock extends McpDock:
+	var refresh_calls := 0
+	func _refresh_all_client_statuses() -> void:
+		refresh_calls += 1
+
+
 ## Test port high enough to almost never collide with real services and
 ## distinct from the plugin's configured http_port() so the stop-finalize tests
 ## don't interact with a developer's running managed server.
@@ -188,17 +194,80 @@ func test_get_server_status_shape_is_stable() -> void:
 	plugin.free()
 	assert_has_key(status, "state")
 	assert_has_key(status, "exit_ms")
+	assert_has_key(status, "actual_version")
+	assert_has_key(status, "expected_version")
+	assert_has_key(status, "message")
+	assert_has_key(status, "connection_blocked")
 
 
-func test_connection_established_clears_foreign_port() -> void:
-	## User-visible regression: on editor restart when a previous session's
-	## server is still on port 8000, `_start_server` hits the "no matching
-	## managed-server record" branch and preemptively sets FOREIGN_PORT.
-	## If the occupant happens to speak MCP (the common case — it's another
-	## editor's server), the WebSocket still connects and the dock ends up
-	## showing both "Connected" (green dot) and "Another process is already
-	## bound to port 8000" (warning banner). `_on_connection_established`
-	## must clear FOREIGN_PORT once the connection actually opens.
+func test_server_status_compatibility_requires_matching_ws_port() -> void:
+	var ok := GodotAiPlugin._server_status_compatibility("2.2.0", "2.2.0", 9500, 9500, false)
+	var wrong_ws := GodotAiPlugin._server_status_compatibility("2.2.0", "2.2.0", 9600, 9500, false)
+	assert_true(bool(ok.get("compatible", false)), "matching version + WS port must be compatible")
+	assert_false(
+		bool(wrong_ws.get("compatible", true)),
+		"same-version server on the wrong WS port must not be adopted"
+	)
+	assert_eq(wrong_ws.get("reason", ""), "ws_port_mismatch")
+
+
+func test_server_version_compatibility_requires_exact_match_in_release_mode() -> void:
+	var exact := GodotAiPlugin._server_version_compatibility("2.2.0", "2.2.0", false)
+	var old := GodotAiPlugin._server_version_compatibility("1.2.10", "2.2.0", false)
+	var unknown := GodotAiPlugin._server_version_compatibility("", "2.2.0", false)
+	assert_true(bool(exact.get("compatible", false)), "exact release version must be compatible")
+	assert_false(bool(old.get("compatible", true)), "old release server must be incompatible")
+	assert_false(bool(unknown.get("compatible", true)), "unknown live version must be incompatible")
+
+
+func test_server_version_compatibility_allows_visible_dev_mismatch() -> void:
+	var result := GodotAiPlugin._server_version_compatibility("2.2.0-dev", "2.2.0", true)
+	assert_true(bool(result.get("compatible", false)), "dev checkout may reuse a mismatched dev server")
+	assert_true(
+		bool(result.get("dev_mismatch_allowed", false)),
+		"dev mismatch must be flagged so the dock can render it visibly"
+	)
+
+
+func test_incompatible_server_message_names_actual_version_when_discoverable() -> void:
+	var message := GodotAiPlugin._incompatible_server_message(
+		{"version": "1.2.10"},
+		"2.2.0",
+		8000,
+	)
+	assert_contains(message, "Port 8000 is occupied by godot-ai server v1.2.10")
+	assert_contains(message, "plugin expects v2.2.0")
+	assert_contains(message, "change both HTTP and WS ports")
+
+
+func test_incompatible_server_message_names_ws_port_mismatch() -> void:
+	var message := GodotAiPlugin._incompatible_server_message(
+		{"name": "godot-ai", "version": "2.2.0", "ws_port": 9600},
+		"2.2.0",
+		8000,
+	)
+	assert_contains(message, "using WS port 9600")
+	assert_contains(message, "with WS port %d" % McpClientConfigurator.ws_port())
+	assert_contains(message, "change both HTTP and WS ports")
+
+
+func test_incompatible_transition_refreshes_dock_client_statuses() -> void:
+	var plugin := GodotAiPlugin.new()
+	var dock := _RefreshDock.new()
+	plugin._dock = dock
+	plugin._set_incompatible_server({"version": "1.2.10"}, "2.2.0", 8000)
+	var calls := dock.refresh_calls
+	dock.free()
+	plugin.free()
+
+	assert_eq(calls, 1, "late incompatible transition must resweep dock client status")
+
+
+func test_connection_established_waits_for_version_before_clearing_foreign_port() -> void:
+	## A WebSocket opening is not enough proof anymore: old pre-rollup
+	## servers accept the plugin session while still exposing an incompatible
+	## HTTP/MCP tool surface. FOREIGN_PORT only clears after the live server
+	## version is verified.
 	_seed_managed_record(99999, "other-version")
 	var plugin := GodotAiPlugin.new()
 	plugin._set_spawn_state(McpSpawnState.FOREIGN_PORT)
@@ -210,12 +279,45 @@ func test_connection_established_clears_foreign_port() -> void:
 
 	plugin._on_connection_established()
 	var state: String = plugin.get_server_status().get("state", "")
+	var awaiting := plugin._awaiting_server_version
 	plugin.free()
 
 	assert_eq(
 		state,
-		McpSpawnState.OK,
-		"successful adoption (WebSocket opened) must clear FOREIGN_PORT diagnostic"
+		McpSpawnState.FOREIGN_PORT,
+		"opening the WebSocket must not clear FOREIGN_PORT before version verification"
+	)
+	assert_true(awaiting, "connection establishment must arm the server-version check")
+
+
+func test_verified_matching_server_clears_foreign_port() -> void:
+	var plugin := GodotAiPlugin.new()
+	var plugin_ver := McpClientConfigurator.get_plugin_version()
+	plugin._server_expected_version = plugin_ver
+	plugin._set_spawn_state(McpSpawnState.FOREIGN_PORT)
+	plugin._on_server_version_verified(plugin_ver)
+	var status := plugin.get_server_status()
+	plugin.free()
+
+	assert_eq(status.get("state", ""), McpSpawnState.OK)
+	assert_eq(status.get("actual_version", ""), plugin_ver)
+	assert_false(bool(status.get("connection_blocked", true)))
+
+
+func test_verified_old_server_becomes_incompatible_and_blocks_connection() -> void:
+	var plugin := GodotAiPlugin.new()
+	plugin._server_expected_version = "2.2.0"
+	plugin._on_server_version_verified("1.2.10")
+	var status := plugin.get_server_status()
+	plugin.free()
+
+	assert_eq(status.get("state", ""), McpSpawnState.INCOMPATIBLE_SERVER)
+	assert_eq(status.get("actual_version", ""), "1.2.10")
+	assert_true(bool(status.get("connection_blocked", false)))
+	assert_contains(
+		str(status.get("message", "")),
+		"Port %d is occupied by godot-ai server v1.2.10; plugin expects v2.2.0"
+			% McpClientConfigurator.http_port(),
 	)
 
 
@@ -261,30 +363,30 @@ func test_watch_for_adoption_confirmation_arms_bounded_deadline() -> void:
 	)
 
 
-func test_process_clears_foreign_port_on_successful_connection() -> void:
+func test_process_clears_foreign_port_after_matching_version_ack() -> void:
 	## Integration test for the full adoption-confirm loop:
 	## `_watch_for_adoption_confirmation` arms the deadline + `_process`,
-	## then `_process` reads `_connection.is_connected` each frame. The
-	## previous two tests exercise each half in isolation; this one wires
-	## them together with a real McpConnection whose `_connected` we flip.
-	## Without this, a refactor that broke the `is_connected` check in
-	## `_process` (e.g. reading the wrong property) would slip through.
+	## then `_process` waits for McpConnection.server_version. Mere connection
+	## is insufficient; a matching ack is what authorizes adoption.
 	var plugin := GodotAiPlugin.new()
 	var conn := McpConnection.new()
 	plugin._connection = conn
+	plugin._server_expected_version = McpClientConfigurator.get_plugin_version()
 	plugin._set_spawn_state(McpSpawnState.FOREIGN_PORT)
 	plugin._watch_for_adoption_confirmation()
+	plugin._arm_server_version_check()
 	assert_true(plugin._adoption_watch_deadline_ms > 0, "precondition: watcher armed")
 
 	conn._connected = true  # simulate WebSocket STATE_OPEN transition
+	conn.server_version = plugin._server_expected_version
 	plugin._process(0.0)
 	var state: String = plugin.get_server_status().get("state", "")
 	var deadline := plugin._adoption_watch_deadline_ms
 	conn.free()
 	plugin.free()
 
-	assert_eq(state, McpSpawnState.OK, "_process must clear FOREIGN_PORT on first connect")
-	assert_eq(deadline, 0, "_process must disarm the deadline on successful adoption")
+	assert_eq(state, McpSpawnState.OK, "_process must clear FOREIGN_PORT after version match")
+	assert_true(deadline > 0, "adoption deadline is independent of version verification")
 
 
 func test_process_self_disarms_after_deadline_without_connect() -> void:

--- a/tests/unit/test_server_status.py
+++ b/tests/unit/test_server_status.py
@@ -1,0 +1,21 @@
+from starlette.testclient import TestClient
+
+from godot_ai import __version__
+from godot_ai.server import create_server
+
+
+def test_status_route_reports_live_server_version():
+    server = create_server(ws_port=9555, exclude_domains={"audio", "theme"})
+    app = server.http_app(transport="streamable-http")
+    client = TestClient(app)
+
+    response = client.get("/godot-ai/status")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "name": "godot-ai",
+        "server_version": __version__,
+        "ws_port": 9555,
+        "tool_surface": "rollup",
+        "exclude_domains": ["audio", "theme"],
+    }


### PR DESCRIPTION
## Summary

Fixes the stale foreign MCP server adoption path where the Godot plugin could report a healthy install while clients were routed to an older incompatible server already bound to the HTTP port.

Changes include:
- add a live `/godot-ai/status` probe exposing actual server version, WS port, tool surface, and excluded domains
- require occupied HTTP ports to verify compatible `godot-ai` version and matching WS port before reuse
- block WebSocket connection and client health when the live server is incompatible or unverified
- make dock status/version text distinguish expected install from verified live server
- hide the HTTP-only port picker for incompatible `godot-ai` conflicts because stale servers often also own WS
- preserve managed-server replacement only when ownership proof exists, while keeping compatible external/dev reuse visible

## Validation

- `ruff check src tests`
- `pytest -q` (`672 passed`)
- `git diff --cached --check`
- actual stale-server smoke on isolated ports using cached `godot-ai 1.2.10`:
  - old server exposed 125 tools
  - `/godot-ai/status` returned 404
  - plugin v2.2.0 logged incompatible/unverified server warning
  - no Godot session registered before or after plugin load
  - no `connected to server` / no adoption

## Notes

Unrelated local changes in the original checkout, including the concurrent camera handler work, were not included in this branch.