### PR TITLE
[codex] Gate managed restart on version drift

### DIFF
--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -437,7 +437,8 @@ func _start_server() -> void:
 	## launcher that has long since exited. See #135 and #137.
 	##
 	##   port free                            -> spawn fresh, record PID
-	##   port in use, record.version matches  -> adopt the port owner
+	##   port in use, record.version matches
+	##        + live verification passes       -> adopt the port owner
 	##                                              (self-heals stale PID)
 	##   port in use, record.version drifts   -> kill port owner + respawn
 	##                                              (fixes cold-start drift
@@ -458,6 +459,7 @@ func _start_server() -> void:
 
 	if _is_port_in_use(port):
 		var record := _read_managed_server_record()
+		var record_version := str(record.get("version", ""))
 		var live := _probe_live_server_status(port)
 		var live_version := _verified_status_version(live)
 		var live_ws_port := _verified_status_ws_port(live)
@@ -481,7 +483,7 @@ func _start_server() -> void:
 			## its PID. Otherwise reuse the external/dev server without
 			## recording ownership, so plugin unloads never kill it.
 			var owner := _find_managed_pid(port)
-			if record.version == current_version and owner > 0:
+			if record_version == current_version and owner > 0:
 				_server_pid = owner
 				_write_managed_server_record(owner, current_version)
 			_server_started_this_session = true
@@ -489,12 +491,12 @@ func _start_server() -> void:
 			print("MCP | adopted %s server (PID %d, live v%s, WS %d, plugin v%s)"
 				% [owner_label, _server_pid, _server_actual_version, live_ws_port, current_version])
 			return
-		if not record.version.is_empty():
+		if _managed_record_has_version_drift(record_version, current_version):
 			## Version drift — our server but the plugin moved on. Kill
 			## the port owner (not the stale launcher PID) and respawn
 			## to match the current plugin version.
 			print("MCP | managed server v%s does not match plugin v%s, restarting"
-				% [record.version, current_version])
+				% [record_version, current_version])
 			var owner := _find_managed_pid(port)
 			if owner > 0:
 				OS.kill(owner)
@@ -503,11 +505,11 @@ func _start_server() -> void:
 			_wait_for_port_free(port, 3.0)
 			## Fall through to spawn.
 		else:
-			## No record claiming this port and the live status probe did
-			## not verify an exact/current-compatible godot-ai server. Do
-			## not open the WebSocket: an old server can accept the plugin
-			## session while still exposing an incompatible HTTP/MCP tool
-			## surface to clients such as Antigravity.
+			## No recorded version drift and the live status probe did not
+			## verify an exact/current-compatible godot-ai server. A stale
+			## matching record alone is not enough ownership proof to kill
+			## the current port owner, and opening the WebSocket could route
+			## clients to an incompatible HTTP/MCP tool surface.
 			_server_started_this_session = true
 			_set_incompatible_server(live, current_version, port)
 			push_warning(_server_status_message)
@@ -634,6 +636,10 @@ static func _server_status_compatibility(
 	if actual_ws_port != expected_ws_port:
 		return {"compatible": false, "reason": "ws_port_mismatch", "dev_mismatch_allowed": false}
 	return version_result
+
+
+static func _managed_record_has_version_drift(record_version: String, current_version: String) -> bool:
+	return not record_version.is_empty() and record_version != current_version
 
 
 static func _probe_live_server_status(port: int, timeout_ms: int = SERVER_STATUS_PROBE_TIMEOUT_MS) -> Dictionary:

--- a/script/local-self-update-smoke
+++ b/script/local-self-update-smoke
@@ -76,9 +76,17 @@ def parse_args() -> argparse.Namespace:
         "--server-version",
         default="",
         help=(
-            "Published godot-ai Python package version for the smoke fixture "
-            "(default: base version). Keeps synthetic vNext plugin.cfg values "
-            "from trying to install a fake PyPI package."
+            "Published godot-ai Python package version for the base smoke fixture "
+            "(default: base version)."
+        ),
+    )
+    parser.add_argument(
+        "--next-server-version",
+        default="",
+        help=(
+            "Published godot-ai Python package version for the vNext fixture "
+            "(default: --server-version). Use with --base-version/--next-version "
+            "to smoke old-to-current server replacement."
         ),
     )
     parser.add_argument(
@@ -113,6 +121,7 @@ def main() -> int:
         base_version = args.base_version or read_plugin_version(PLUGIN_ROOT / "plugin.cfg")
         next_version = args.next_version or bump_patch_version(base_version)
         server_version = args.server_version or base_version
+        next_server_version = args.next_server_version or server_version
         baseline = diagnostic_reports_snapshot()
 
         prepare_project(
@@ -120,6 +129,7 @@ def main() -> int:
             base_version=base_version,
             next_version=next_version,
             server_version=server_version,
+            next_server_version=next_server_version,
             http_port=args.http_port,
             ws_port=args.ws_port,
             force=args.force,
@@ -131,6 +141,7 @@ def main() -> int:
             base_version,
             next_version,
             server_version,
+            next_server_version,
             baseline,
         )
 
@@ -167,6 +178,7 @@ def prepare_project(
     base_version: str,
     next_version: str,
     server_version: str,
+    next_server_version: str,
     http_port: int,
     ws_port: int,
     force: bool,
@@ -199,7 +211,7 @@ def prepare_project(
     patch_fixture_plugin(
         vnext_root,
         version=next_version,
-        server_version=server_version,
+        server_version=next_server_version,
         http_port=http_port,
         ws_port=ws_port,
         force_local_update=False,
@@ -584,6 +596,7 @@ def print_instructions(
     base_version: str,
     next_version: str,
     server_version: str,
+    next_server_version: str,
     baseline: set[Path],
 ) -> None:
     latest = max(baseline, key=lambda path: path.stat().st_mtime, default=None)
@@ -592,7 +605,8 @@ def print_instructions(
     print(f"  project:      {project_dir}")
     print(f"  base version: {base_version}")
     print(f"  next version: {next_version}")
-    print(f"  server pkg:   godot-ai=={server_version}")
+    print(f"  base server:  godot-ai=={server_version}")
+    print(f"  next server:  godot-ai=={next_server_version}")
     print(f"  local zip:    {project_dir / SMOKE_DIR / SMOKE_ZIP_NAME}")
     if latest is not None:
         print(f"  latest .ips:  {latest}")

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -211,6 +211,21 @@ func test_server_status_compatibility_requires_matching_ws_port() -> void:
 	assert_eq(wrong_ws.get("reason", ""), "ws_port_mismatch")
 
 
+func test_managed_record_restart_requires_recorded_version_drift() -> void:
+	assert_true(
+		GodotAiPlugin._managed_record_has_version_drift("2.1.0", "2.2.0"),
+		"older managed record must still authorize update restart"
+	)
+	assert_false(
+		GodotAiPlugin._managed_record_has_version_drift("2.2.0", "2.2.0"),
+		"matching managed record must not authorize killing an unverified port owner"
+	)
+	assert_false(
+		GodotAiPlugin._managed_record_has_version_drift("", "2.2.0"),
+		"missing managed record must not authorize restart"
+	)
+
+
 func test_server_version_compatibility_requires_exact_match_in_release_mode() -> void:
 	var exact := GodotAiPlugin._server_version_compatibility("2.2.0", "2.2.0", false)
 	var old := GodotAiPlugin._server_version_compatibility("1.2.10", "2.2.0", false)


### PR DESCRIPTION
## Summary
- restart managed occupied ports only when the recorded server version actually differs from the plugin version
- block matching-record but unverified/wrong-WS live servers as incompatible instead of killing the port owner
- let the self-update smoke pin base and vNext server packages separately so old-to-current replacement can be tested explicitly

## Verification
- ruff check src tests script/local-self-update-smoke
- pytest -q
- PATH="/Applications/Godot_mono.app/Contents/MacOS:$PATH" bash script/ci-check-gdscript
- focused MCP/Godot plugin_lifecycle suite: 28 passed
- live self-update smoke: base plugin/server 1.2.10 -> next plugin/server 2.2.0 on isolated ports 18132/19632; old server stopped, new server started, reconnect succeeded, post-run checks passed