### PR TITLE
[codex] Fix self-update hot reload reliability

### DIFF
--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -1051,6 +1051,7 @@ func _refresh_server_version_label() -> void:
 				and _plugin.can_restart_managed_server()
 			)
 	if text == _last_rendered_server_text:
+		_setup_server_label.add_theme_color_override("font_color", color)
 		if _version_restart_btn != null and _version_restart_btn.visible != show_restart:
 			_version_restart_btn.visible = show_restart
 		return

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -483,11 +483,8 @@ func _start_server() -> void:
 			## its PID. Otherwise reuse the external/dev server without
 			## recording ownership, so plugin unloads never kill it.
 			var owner := _find_managed_pid(port)
-			if record_version == current_version and owner > 0:
-				_server_pid = owner
-				_write_managed_server_record(owner, current_version)
+			var owner_label := _adopt_compatible_server(record_version, current_version, owner)
 			_server_started_this_session = true
-			var owner_label := "managed" if _server_pid > 0 else "external"
 			print("MCP | adopted %s server (PID %d, live v%s, WS %d, plugin v%s)"
 				% [owner_label, _server_pid, _server_actual_version, live_ws_port, current_version])
 			return
@@ -1323,6 +1320,17 @@ func _clear_managed_server_record() -> void:
 func prepare_for_update_reload() -> void:
 	_stop_server()
 	_server_started_this_session = false
+
+
+func _adopt_compatible_server(record_version: String, current_version: String, owner: int) -> String:
+	if record_version == current_version and owner > 0:
+		_server_pid = owner
+		_write_managed_server_record(owner, current_version)
+		return "managed"
+	_server_pid = -1
+	_clear_managed_server_record()
+	_clear_pid_file()
+	return "external"
 
 
 ## Hand the self-update over to a tiny runner that is not owned by this

--- a/plugin/addons/godot_ai/update_reload_runner.gd
+++ b/plugin/addons/godot_ai/update_reload_runner.gd
@@ -13,6 +13,9 @@ const PLUGIN_CFG_PATH := "res://addons/godot_ai/plugin.cfg"
 const PRE_DISABLE_DRAIN_FRAMES := 8
 const POST_DISABLE_DRAIN_FRAMES := 2
 const POST_ENABLE_FREE_FRAMES := 8
+const INSTALL_BASE_PATH := "res://"
+const ZIP_ADDON_PREFIX := "addons/godot_ai/"
+const TEMP_FILE_SUFFIX := ".godot_ai_update_tmp"
 
 var _zip_path := ""
 var _temp_dir := ""
@@ -21,6 +24,11 @@ var _started := false
 var _next_step := ""
 var _frames_remaining := 0
 var _waiting_for_scan := false
+var _scan_next_step := ""
+## Keep Array fields untyped: this runner survives fs.scan() during update,
+## and typed Variant storage is part of the hot-reload crash class.
+var _new_file_paths = []
+var _existing_file_paths = []
 
 
 func start(zip_path: String, temp_dir: String, detached_dock) -> void:
@@ -62,67 +70,163 @@ func _disable_old_plugin() -> void:
 
 
 func _extract_and_scan() -> void:
-	if not _extract_update():
+	if not _read_update_manifest():
 		EditorInterface.set_plugin_enabled(PLUGIN_CFG_PATH, true)
 		_wait_frames(POST_ENABLE_FREE_FRAMES, "_cleanup_and_finish")
 		return
 
-	_cleanup_update_temp()
-	_start_filesystem_scan()
+	if not _install_zip_paths(_new_file_paths):
+		EditorInterface.set_plugin_enabled(PLUGIN_CFG_PATH, true)
+		_wait_frames(POST_ENABLE_FREE_FRAMES, "_cleanup_and_finish")
+		return
+
+	if _new_file_paths.is_empty():
+		_install_existing_files_and_scan.call_deferred()
+	else:
+		## Register newly added class_name/base scripts while all old plugin
+		## files are still intact. Updating plugin.gd or handler preloads
+		## before this scan can make Godot parse a new dependency graph
+		## before its new global classes exist.
+		_start_filesystem_scan("_install_existing_files_and_scan")
 
 
-func _start_filesystem_scan() -> void:
+func _start_filesystem_scan(next_step: String = "_enable_new_plugin") -> void:
 	var fs := EditorInterface.get_resource_filesystem()
+	var deferred_step := next_step if not next_step.is_empty() else "_enable_new_plugin"
 	if fs == null:
-		_enable_new_plugin.call_deferred()
+		call_deferred(deferred_step)
 		return
 
 	_waiting_for_scan = true
+	_scan_next_step = deferred_step
 	if not fs.filesystem_changed.is_connected(_on_filesystem_changed):
 		fs.filesystem_changed.connect(_on_filesystem_changed, CONNECT_ONE_SHOT)
 	fs.scan()
 
 
-func _extract_update() -> bool:
+func _read_update_manifest() -> bool:
 	var zip_path := ProjectSettings.globalize_path(_zip_path)
-	var install_base := ProjectSettings.globalize_path("res://")
+	var install_base := ProjectSettings.globalize_path(INSTALL_BASE_PATH)
 
 	var reader := ZIPReader.new()
 	if reader.open(zip_path) != OK:
 		print("MCP | update extract failed: could not open %s" % zip_path)
 		return false
 
+	_new_file_paths.clear()
+	_existing_file_paths.clear()
+	var has_plugin_cfg := false
+	var has_plugin_script := false
 	var files := reader.get_files()
 	for file_path in files:
-		if not file_path.begins_with("addons/godot_ai/"):
+		if not file_path.begins_with(ZIP_ADDON_PREFIX):
 			continue
-		if file_path.ends_with("/"):
-			DirAccess.make_dir_recursive_absolute(install_base.path_join(file_path))
+		if not _is_safe_zip_addon_file(file_path):
+			print("MCP | update extract failed: unsafe zip path %s" % file_path)
+			reader.close()
+			return false
+		var rel_path := file_path.trim_prefix(ZIP_ADDON_PREFIX)
+		if rel_path.is_empty() or file_path.ends_with("/"):
+			continue
+		if rel_path == "plugin.cfg":
+			has_plugin_cfg = true
+		elif rel_path == "plugin.gd":
+			has_plugin_script = true
+		var target_path := install_base.path_join(file_path)
+		if FileAccess.file_exists(target_path):
+			_existing_file_paths.append(file_path)
 		else:
-			var dir := file_path.get_base_dir()
-			DirAccess.make_dir_recursive_absolute(install_base.path_join(dir))
-			var content := reader.read_file(file_path)
-			var target_path := install_base.path_join(file_path)
-			var f := FileAccess.open(target_path, FileAccess.WRITE)
-			if f == null:
-				print("MCP | update extract failed: could not write %s (error %d)" % [
-					target_path,
-					FileAccess.get_open_error(),
-				])
-				reader.close()
-				return false
-			f.store_buffer(content)
-			var write_error := f.get_error()
-			f.close()
-			if write_error != OK:
-				print("MCP | update extract failed: write error %d for %s" % [
-					write_error,
-					target_path,
-				])
-				reader.close()
-				return false
-
+			_new_file_paths.append(file_path)
 	reader.close()
+	if not has_plugin_cfg:
+		print("MCP | update extract failed: zip is missing plugin.cfg")
+		return false
+	if not has_plugin_script:
+		print("MCP | update extract failed: zip is missing plugin.gd")
+		return false
+	return true
+
+
+func _install_existing_files_and_scan() -> void:
+	if not _install_zip_paths(_existing_file_paths):
+		EditorInterface.set_plugin_enabled(PLUGIN_CFG_PATH, true)
+		_wait_frames(POST_ENABLE_FREE_FRAMES, "_cleanup_and_finish")
+		return
+
+	_cleanup_update_temp()
+	_start_filesystem_scan("_enable_new_plugin")
+
+
+func _is_safe_zip_addon_file(file_path: String) -> bool:
+	if file_path.is_absolute_path() or file_path.contains("\\"):
+		return false
+	if not file_path.begins_with(ZIP_ADDON_PREFIX):
+		return false
+	var rel_path := file_path.trim_prefix(ZIP_ADDON_PREFIX)
+	if rel_path.is_empty() or rel_path.ends_with("/"):
+		return false
+	for segment in rel_path.split("/", true):
+		if segment.is_empty() or segment == "." or segment == "..":
+			return false
+	return true
+
+
+func _install_zip_paths(paths: Array) -> bool:
+	if paths.is_empty():
+		return true
+
+	var zip_path := ProjectSettings.globalize_path(_zip_path)
+	var reader := ZIPReader.new()
+	if reader.open(zip_path) != OK:
+		print("MCP | update extract failed: could not reopen %s" % zip_path)
+		return false
+
+	for file_path in paths:
+		if not _install_zip_file(reader, String(file_path)):
+			reader.close()
+			return false
+	reader.close()
+	return true
+
+
+func _install_zip_file(reader: ZIPReader, file_path: String) -> bool:
+	var install_base := ProjectSettings.globalize_path(INSTALL_BASE_PATH)
+	var target_path := install_base.path_join(file_path)
+	var dir := target_path.get_base_dir()
+	if DirAccess.make_dir_recursive_absolute(dir) != OK:
+		print("MCP | update extract failed: could not create %s" % dir)
+		return false
+
+	var temp_path := target_path + TEMP_FILE_SUFFIX
+	DirAccess.remove_absolute(temp_path)
+	var content := reader.read_file(file_path)
+	var f := FileAccess.open(temp_path, FileAccess.WRITE)
+	if f == null:
+		print("MCP | update extract failed: could not write %s (error %d)" % [
+			temp_path,
+			FileAccess.get_open_error(),
+		])
+		return false
+	f.store_buffer(content)
+	var write_error := f.get_error()
+	f.close()
+	if write_error != OK:
+		print("MCP | update extract failed: write error %d for %s" % [
+			write_error,
+			temp_path,
+		])
+		DirAccess.remove_absolute(temp_path)
+		return false
+
+	if DirAccess.rename_absolute(temp_path, target_path) != OK:
+		## POSIX and APFS replace atomically. Some filesystems reject
+		## rename-over-existing; keep a fallback so the update can still
+		## proceed, but the common path never exposes a truncated target.
+		DirAccess.remove_absolute(target_path)
+		if DirAccess.rename_absolute(temp_path, target_path) != OK:
+			DirAccess.remove_absolute(temp_path)
+			print("MCP | update extract failed: could not replace %s" % target_path)
+			return false
 	return true
 
 
@@ -139,8 +243,12 @@ func _finish_scan_wait() -> void:
 	if not _waiting_for_scan:
 		return
 	_waiting_for_scan = false
+	var next_step := _scan_next_step
+	_scan_next_step = ""
 	set_process(false)
-	_enable_new_plugin.call_deferred()
+	if next_step.is_empty():
+		next_step = "_enable_new_plugin"
+	call_deferred(next_step)
 
 
 func _enable_new_plugin() -> void:

--- a/script/ci-check-gdscript
+++ b/script/ci-check-gdscript
@@ -22,7 +22,8 @@ else
 fi
 
 # Check for parse errors in the import output.
-ERRORS=$(grep -ciE "SCRIPT ERROR|Parse Error|Failed to load script" "$IMPORT_LOG" 2>/dev/null || echo "0")
+ERRORS=$(grep -ciE "SCRIPT ERROR|Parse Error|Failed to load script" "$IMPORT_LOG" 2>/dev/null || true)
+ERRORS="${ERRORS:-0}"
 
 if [ "$ERRORS" -gt 0 ]; then
   echo "GDScript parse errors found:"

--- a/script/local-self-update-smoke
+++ b/script/local-self-update-smoke
@@ -3,8 +3,9 @@
 
 This harness creates a disposable Godot project with a physical
 addons/godot_ai directory, patches that fixture only, and stages a synthetic
-v(N+1) plugin ZIP that adds a typed Dict/Array hot-reload trigger. The
-operator still performs the one step that matters: click Update in the dock.
+v(N+1) plugin ZIP that adds a typed Dict/Array hot-reload trigger plus a new
+class_name dependency chain. The operator still performs the one step that
+matters: click Update in the dock.
 """
 
 from __future__ import annotations
@@ -218,6 +219,7 @@ def prepare_project(
         next_version=next_version,
     )
     patch_vnext_hot_reload_trigger(vnext_root / "mcp_dock.gd")
+    patch_vnext_topology_change(vnext_root)
 
     zip_path = project_dir / SMOKE_DIR / SMOKE_ZIP_NAME
     zip_path.parent.mkdir()
@@ -304,6 +306,7 @@ def patch_fixture_plugin(
     patch_port_isolation(addon_dir / "client_configurator.gd", http_port, ws_port)
     patch_server_package_pin(addon_dir / "client_configurator.gd", server_version)
     patch_managed_record_isolation(addon_dir / "plugin.gd")
+    patch_expected_server_version(addon_dir / "plugin.gd", server_version)
     if force_local_update:
         patch_local_update_banner(addon_dir / "mcp_dock.gd", next_version)
 
@@ -414,6 +417,27 @@ def patch_managed_record_isolation(path: Path) -> None:
     path.write_text(text, encoding="utf-8")
 
 
+def patch_expected_server_version(path: Path, server_version: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    marker = "const MANAGED_SERVER_VERSION_SETTING := "
+    line_start = text.find(marker)
+    if line_start < 0:
+        raise HarnessError(f"Could not find MANAGED_SERVER_VERSION_SETTING in {path}")
+    line_end = text.find("\n", line_start)
+    if line_end < 0:
+        raise HarnessError(f"Could not find MANAGED_SERVER_VERSION_SETTING line end in {path}")
+    text = (
+        text[: line_end + 1]
+        + f'const SELF_UPDATE_SMOKE_EXPECTED_SERVER_VERSION := "{server_version}"\n'
+        + text[line_end + 1 :]
+    )
+    text = text.replace(
+        "McpClientConfigurator.get_plugin_version()",
+        "SELF_UPDATE_SMOKE_EXPECTED_SERVER_VERSION",
+    )
+    path.write_text(text, encoding="utf-8")
+
+
 def patch_local_update_banner(path: Path, next_version: str) -> None:
     text = path.read_text(encoding="utf-8")
     text = replace_once(
@@ -519,6 +543,50 @@ def patch_vnext_hot_reload_trigger(path: Path) -> None:
         1,
     )
     path.write_text(text, encoding="utf-8")
+
+
+def patch_vnext_topology_change(addon_dir: Path) -> None:
+    utils_dir = addon_dir / "utils"
+    base_path = utils_dir / "self_update_smoke_base.gd"
+    child_path = utils_dir / "self_update_smoke_child.gd"
+    base_path.write_text(
+        """@tool
+class_name McpSelfUpdateSmokeBase
+extends RefCounted
+
+
+func marker() -> String:
+\treturn "base"
+""",
+        encoding="utf-8",
+    )
+    child_path.write_text(
+        """@tool
+class_name McpSelfUpdateSmokeChild
+extends McpSelfUpdateSmokeBase
+
+
+func marker() -> String:
+\treturn "child:" + super.marker()
+""",
+        encoding="utf-8",
+    )
+
+    dock_path = addon_dir / "mcp_dock.gd"
+    text = dock_path.read_text(encoding="utf-8")
+    marker = 'const UPDATE_TEMP_ZIP := "user://godot_ai_update/update.zip"\n'
+    text = replace_once(
+        dock_path,
+        text,
+        marker,
+        (
+            marker
+            + "const SelfUpdateSmokeChild := preload("
+            + '"res://addons/godot_ai/utils/self_update_smoke_child.gd")\n'
+        ),
+        "self-update smoke topology preload",
+    )
+    dock_path.write_text(text, encoding="utf-8")
 
 
 def replace_function(text: str, signature: str, replacement: str) -> str:
@@ -694,6 +762,21 @@ def verify_post_run(
     else:
         print("PASS: vNext _exit_tree trigger did not run during the update window")
 
+    if smoke_adopted_existing_server_before_update(lines):
+        print("FAIL: smoke fixture adopted an existing server before update; clear the smoke ports first")
+        ok = False
+    elif smoke_started_own_server_before_update(lines):
+        print("PASS: smoke fixture started its own server before update")
+    else:
+        print("FAIL: smoke fixture did not start its own server before update")
+        ok = False
+
+    if smoke_stopped_server_during_update(lines):
+        print("PASS: self-update stopped the managed smoke server")
+    else:
+        print("FAIL: self-update did not stop a managed smoke server")
+        ok = False
+
     new_reports = new_diagnostic_reports(baseline, started)
     if new_reports:
         print("FAIL: new Godot crash reports:")
@@ -724,6 +807,46 @@ def vnext_exit_tree_during_update(lines: list[str]) -> bool:
         if staged and SMOKE_TRIGGER_LOG in line and not new_plugin_loaded:
             return True
     return False
+
+
+def smoke_started_own_server_before_update(lines: list[str]) -> bool:
+    return any("MCP | started server" in line for line in smoke_lines_before_update(lines))
+
+
+def smoke_adopted_existing_server_before_update(lines: list[str]) -> bool:
+    external_signals = (
+        "MCP | adopted external server",
+        "MCP | foreign server already running",
+        "foreign server already running",
+    )
+    return any(
+        any(signal in line for signal in external_signals)
+        for line in smoke_lines_before_update(lines)
+    )
+
+
+def smoke_stopped_server_during_update(lines: list[str]) -> bool:
+    staged = False
+    for line in lines:
+        if "MCP | self-update smoke: staged local zip" in line:
+            staged = True
+            continue
+        if not staged:
+            continue
+        if "MCP | update runner enabling new plugin" in line:
+            return False
+        if "MCP | stopped server" in line:
+            return True
+    return False
+
+
+def smoke_lines_before_update(lines: list[str]) -> list[str]:
+    before: list[str] = []
+    for line in lines:
+        if "MCP | self-update smoke: staged local zip" in line:
+            break
+        before.append(line)
+    return before
 
 
 def print_new_reports(baseline: set[Path], started: float) -> None:

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -10,6 +10,16 @@ const GodotAiPlugin := preload("res://addons/godot_ai/plugin.gd")
 
 var _dock: Node
 
+class _ServerStatusPlugin extends EditorPlugin:
+	var status: Dictionary = {}
+	var restart_allowed := false
+
+	func get_server_status() -> Dictionary:
+		return status
+
+	func can_restart_managed_server() -> bool:
+		return restart_allowed
+
 
 func suite_name() -> String:
 	return "dock"
@@ -324,6 +334,40 @@ func test_server_version_label_amber_without_restart_when_ownership_unproven() -
 		"Mismatch must render amber, matching the drift banner's color"
 	)
 	assert_false(_dock._version_restart_btn.visible, "Restart button requires ownership proof")
+	_cleanup_server_row(conn)
+
+
+func test_server_version_label_repaints_color_when_state_changes_without_text_change() -> void:
+	## The label text for "server vX, expected vY" is identical before and
+	## after the plugin marks the server incompatible; the color must still
+	## repaint from amber to red so the blocked state is visible.
+	var conn := _seed_server_row("1.2.3-stale-for-test")
+	var plugin := _ServerStatusPlugin.new()
+	plugin.status = {
+		"actual_version": "1.2.3-stale-for-test",
+		"expected_version": "2.2.0",
+		"state": McpSpawnState.OK,
+	}
+	_dock._plugin = plugin
+
+	_dock._refresh_server_version_label()
+	assert_eq(
+		_dock._setup_server_label.get_theme_color_override("font_color"),
+		McpDockScript.COLOR_AMBER,
+		"precondition: mismatch starts amber while not blocked"
+	)
+
+	plugin.status["state"] = McpSpawnState.INCOMPATIBLE_SERVER
+	_dock._refresh_server_version_label()
+	assert_eq(
+		_dock._setup_server_label.get_theme_color_override("font_color"),
+		Color.RED,
+		"same label text must repaint red when state becomes incompatible"
+	)
+	assert_false(_dock._version_restart_btn.visible, "incompatible state must hide Restart")
+
+	_dock._plugin = null
+	plugin.free()
 	_cleanup_server_row(conn)
 
 

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -10,16 +10,6 @@ const GodotAiPlugin := preload("res://addons/godot_ai/plugin.gd")
 
 var _dock: Node
 
-class _ServerStatusPlugin extends EditorPlugin:
-	var status: Dictionary = {}
-	var restart_allowed := false
-
-	func get_server_status() -> Dictionary:
-		return status
-
-	func can_restart_managed_server() -> bool:
-		return restart_allowed
-
 
 func suite_name() -> String:
 	return "dock"
@@ -342,25 +332,23 @@ func test_server_version_label_repaints_color_when_state_changes_without_text_ch
 	## after the plugin marks the server incompatible; the color must still
 	## repaint from amber to red so the blocked state is visible.
 	var conn := _seed_server_row("1.2.3-stale-for-test")
-	var plugin := _ServerStatusPlugin.new()
-	plugin.status = {
-		"actual_version": "1.2.3-stale-for-test",
-		"expected_version": "2.2.0",
-		"state": McpSpawnState.OK,
-	}
+	var plugin := GodotAiPlugin.new()
+	plugin._server_actual_version = "1.2.3-stale-for-test"
+	plugin._server_expected_version = "2.2.0"
+	plugin._spawn_state = McpSpawnState.OK
 	_dock._plugin = plugin
 
 	_dock._refresh_server_version_label()
 	assert_eq(
-		_dock._setup_server_label.get_theme_color_override("font_color"),
+		_dock._setup_server_label.get_theme_color("font_color"),
 		McpDockScript.COLOR_AMBER,
 		"precondition: mismatch starts amber while not blocked"
 	)
 
-	plugin.status["state"] = McpSpawnState.INCOMPATIBLE_SERVER
+	plugin._spawn_state = McpSpawnState.INCOMPATIBLE_SERVER
 	_dock._refresh_server_version_label()
 	assert_eq(
-		_dock._setup_server_label.get_theme_color_override("font_color"),
+		_dock._setup_server_label.get_theme_color("font_color"),
 		Color.RED,
 		"same label text must repaint red when state becomes incompatible"
 	)

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -226,6 +226,46 @@ func test_managed_record_restart_requires_recorded_version_drift() -> void:
 	)
 
 
+func test_external_compatible_adoption_clears_stale_managed_record() -> void:
+	## If a live compatible server is verified but its managed record does
+	## not match the current plugin version, the plugin treats it as external.
+	## That must also clear the stale record; otherwise later restart paths
+	## would treat the old record as ownership proof and kill the external
+	## process.
+	_seed_managed_record(11111, "2.1.0")
+	_seed_pid_file(11111)
+	var plugin := GodotAiPlugin.new()
+
+	var owner_label := plugin._adopt_compatible_server("2.1.0", "2.2.0", 22222)
+	var can_restart := plugin.can_restart_managed_server()
+	var server_pid := plugin._server_pid
+	plugin.free()
+
+	assert_eq(owner_label, "external")
+	assert_eq(server_pid, -1, "external adoption must not keep a managed PID")
+	assert_eq(_read_record_version(), "", "stale managed record must be cleared")
+	assert_false(
+		FileAccess.file_exists(GodotAiPlugin.SERVER_PID_FILE),
+		"stale pid-file must be cleared with the stale record"
+	)
+	assert_false(can_restart, "external adoption must not authorize managed restart")
+
+
+func test_matching_compatible_adoption_keeps_managed_ownership() -> void:
+	_seed_managed_record(11111, "2.2.0")
+	var plugin := GodotAiPlugin.new()
+
+	var owner_label := plugin._adopt_compatible_server("2.2.0", "2.2.0", 22222)
+	var can_restart := plugin.can_restart_managed_server()
+	var server_pid := plugin._server_pid
+	plugin.free()
+
+	assert_eq(owner_label, "managed")
+	assert_eq(server_pid, 22222)
+	assert_eq(_read_record_version(), "2.2.0")
+	assert_true(can_restart, "managed adoption must keep restart authorization")
+
+
 func test_server_version_compatibility_requires_exact_match_in_release_mode() -> void:
 	var exact := GodotAiPlugin._server_version_compatibility("2.2.0", "2.2.0", false)
 	var old := GodotAiPlugin._server_version_compatibility("1.2.10", "2.2.0", false)

--- a/tests/unit/test_editor_focus_refocus.py
+++ b/tests/unit/test_editor_focus_refocus.py
@@ -318,7 +318,7 @@ def test_install_update_drains_workers_and_blocks_spawning_before_extract() -> N
 
 
 def test_self_update_runner_disables_old_plugin_before_extract_and_scan() -> None:
-    """The in-place update workaround depends on this exact order (#245/#247)."""
+    """The in-process update path must never expose a half-written addon tree."""
 
     plugin_source = (PLUGIN_ROOT / "plugin.gd").read_text()
     runner_source = (PLUGIN_ROOT / "update_reload_runner.gd").read_text()
@@ -344,13 +344,25 @@ def test_self_update_runner_disables_old_plugin_before_extract_and_scan() -> Non
     extract_block = runner_source.split("func _extract_and_scan() -> void:", 1)[
         1
     ].split("\n\nfunc ", 1)[0]
-    assert "_extract_update()" in extract_block
-    assert "_cleanup_update_temp()" in extract_block
-    assert "_start_filesystem_scan()" in extract_block
+    assert "_read_update_manifest()" in extract_block
+    assert "_install_zip_paths(_new_file_paths)" in extract_block
+    assert '_start_filesystem_scan("_install_existing_files_and_scan")' in extract_block
+    assert "_install_existing_files_and_scan.call_deferred()" in extract_block
 
-    scan_block = runner_source.split("func _start_filesystem_scan() -> void:", 1)[
+    assert "INSTALL_BASE_PATH" in runner_source
+    assert "TEMP_FILE_SUFFIX" in runner_source
+    assert "ZIP_ADDON_PREFIX" in runner_source
+    assert "STAGING_DIR_NAME" not in runner_source
+    assert "rename_absolute(live_path, backup_path)" not in runner_source
+
+    scan_block = runner_source.split("func _start_filesystem_scan", 1)[
         1
     ].split("\n\nfunc ", 1)[0]
+    assert (
+        'var deferred_step := next_step if not next_step.is_empty() else "_enable_new_plugin"'
+        in scan_block
+    )
+    assert "call_deferred(deferred_step)" in scan_block
     assert "fs.filesystem_changed.connect(_on_filesystem_changed, CONNECT_ONE_SHOT)" in scan_block
     assert "fs.scan()" in scan_block
     assert "FILESYSTEM_SCAN_TIMEOUT" not in runner_source
@@ -367,7 +379,8 @@ def test_self_update_runner_disables_old_plugin_before_extract_and_scan() -> Non
     finish_block = runner_source.split("func _finish_scan_wait() -> void:", 1)[
         1
     ].split("\n\nfunc ", 1)[0]
-    assert "_enable_new_plugin.call_deferred()" in finish_block
+    assert 'next_step = "_enable_new_plugin"' in finish_block
+    assert "call_deferred(next_step)" in finish_block
 
     enable_block = runner_source.split("func _enable_new_plugin() -> void:", 1)[
         1
@@ -381,12 +394,42 @@ def test_self_update_runner_disables_old_plugin_before_extract_and_scan() -> Non
     assert "_cleanup_detached_dock()" in cleanup_block
     assert "queue_free()" in cleanup_block
 
-    extract_update_block = runner_source.split("func _extract_update() -> bool:", 1)[
+    manifest_block = runner_source.split("func _read_update_manifest() -> bool:", 1)[
         1
     ].split("\n\nfunc ", 1)[0]
-    assert "FileAccess.get_open_error()" in extract_update_block
-    assert "var write_error := f.get_error()" in extract_update_block
-    assert "return false" in extract_update_block
+    assert "_is_safe_zip_addon_file(file_path)" in manifest_block
+    assert "unsafe zip path" in manifest_block
+    assert "_new_file_paths.clear()" in manifest_block
+    assert "_existing_file_paths.clear()" in manifest_block
+    assert "_new_file_paths.append(file_path)" in manifest_block
+    assert "_existing_file_paths.append(file_path)" in manifest_block
+    assert "FileAccess.file_exists(target_path)" in manifest_block
+    assert "zip is missing plugin.cfg" in manifest_block
+    assert "zip is missing plugin.gd" in manifest_block
+
+    existing_block = runner_source.split("func _install_existing_files_and_scan() -> void:", 1)[
+        1
+    ].split("\n\nfunc ", 1)[0]
+    assert "_install_zip_paths(_existing_file_paths)" in existing_block
+    assert "_cleanup_update_temp()" in existing_block
+    assert '_start_filesystem_scan("_enable_new_plugin")' in existing_block
+
+    safe_path_block = runner_source.split("func _is_safe_zip_addon_file(", 1)[
+        1
+    ].split("\n\nfunc ", 1)[0]
+    assert "file_path.is_absolute_path()" in safe_path_block
+    assert 'file_path.contains("\\\\")' in safe_path_block
+    assert 'segment == ".."' in safe_path_block
+    assert "segment.is_empty()" in safe_path_block
+
+    install_file_block = runner_source.split("func _install_zip_file(", 1)[1].split(
+        "\n\nfunc ", 1
+    )[0]
+    assert "var temp_path := target_path + TEMP_FILE_SUFFIX" in install_file_block
+    assert "FileAccess.open(temp_path, FileAccess.WRITE)" in install_file_block
+    assert "DirAccess.rename_absolute(temp_path, target_path)" in install_file_block
+    assert "FileAccess.open(target_path, FileAccess.WRITE)" not in install_file_block
+    assert "DirAccess.remove_absolute(target_path)" in install_file_block
 
     assert "OS.create_process" not in runner_source
     assert "get_tree().quit" not in runner_source

--- a/tests/unit/test_self_update_smoke_harness.py
+++ b/tests/unit/test_self_update_smoke_harness.py
@@ -5,10 +5,20 @@ from __future__ import annotations
 import subprocess
 import sys
 import zipfile
+from importlib.machinery import SourceFileLoader
 from pathlib import Path
+from types import ModuleType
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "script" / "local-self-update-smoke"
+
+
+def load_smoke_script() -> ModuleType:
+    loader = SourceFileLoader("local_self_update_smoke", str(SCRIPT))
+    module = ModuleType(loader.name)
+    module.__file__ = str(SCRIPT)
+    loader.exec_module(module)
+    return module
 
 
 def test_self_update_smoke_harness_prepares_fixture(tmp_path: Path) -> None:
@@ -60,6 +70,8 @@ def test_self_update_smoke_harness_prepares_fixture(tmp_path: Path) -> None:
 
     base_plugin = (project / "addons" / "godot_ai" / "plugin.gd").read_text()
     assert "godot_ai_self_update_smoke/managed_server_pid" in base_plugin
+    assert 'const SELF_UPDATE_SMOKE_EXPECTED_SERVER_VERSION := "2.2.0"' in base_plugin
+    assert "McpClientConfigurator.get_plugin_version()" not in base_plugin
 
     zip_path = project / "self_update_smoke" / "godot-ai-plugin-vnext.zip"
     assert zip_path.exists()
@@ -67,16 +79,24 @@ def test_self_update_smoke_harness_prepares_fixture(tmp_path: Path) -> None:
         names = set(zf.namelist())
         assert "addons/godot_ai/plugin.cfg" in names
         assert "addons/godot_ai/mcp_dock.gd" in names
+        assert "addons/godot_ai/utils/self_update_smoke_base.gd" in names
+        assert "addons/godot_ai/utils/self_update_smoke_child.gd" in names
         vnext_cfg = zf.read("addons/godot_ai/plugin.cfg").decode()
         vnext_dock = zf.read("addons/godot_ai/mcp_dock.gd").decode()
         vnext_configurator = zf.read("addons/godot_ai/client_configurator.gd").decode()
         vnext_plugin = zf.read("addons/godot_ai/plugin.gd").decode()
+        vnext_base = zf.read("addons/godot_ai/utils/self_update_smoke_base.gd").decode()
+        vnext_child = zf.read("addons/godot_ai/utils/self_update_smoke_child.gd").decode()
 
     assert 'version="2.2.1-self-update-smoke"' in vnext_cfg
     assert "smoke://local-prestaged" not in vnext_dock
     assert 'var _self_update_smoke_trigger: Dictionary = {"armed": true}' in vnext_dock
     assert 'var _self_update_smoke_array_trigger: Array[String] = ["armed"]' in vnext_dock
     assert "MCP | [self-update-smoke vnext _exit_tree]" in vnext_dock
+    assert "SelfUpdateSmokeChild" in vnext_dock
+    assert "class_name McpSelfUpdateSmokeBase" in vnext_base
+    assert "class_name McpSelfUpdateSmokeChild" in vnext_child
+    assert "extends McpSelfUpdateSmokeBase" in vnext_child
     assert "const DEFAULT_HTTP_PORT := 18000" in vnext_configurator
     assert 'const SELF_UPDATE_SMOKE_SERVER_VERSION := "2.2.0"' in vnext_configurator
     assert 'godot-ai==%s" % version' in vnext_configurator
@@ -86,6 +106,35 @@ def test_self_update_smoke_harness_prepares_fixture(tmp_path: Path) -> None:
     assert "static func ensure_settings_registered() -> void:" in vnext_configurator
     assert "static func _register_port_setting(" in vnext_configurator
     assert "godot_ai_self_update_smoke/managed_server_pid" in vnext_plugin
+    assert 'const SELF_UPDATE_SMOKE_EXPECTED_SERVER_VERSION := "2.2.0"' in vnext_plugin
+    assert "McpClientConfigurator.get_plugin_version()" not in vnext_plugin
+
+
+def test_self_update_smoke_log_verifier_rejects_external_adoption() -> None:
+    smoke = load_smoke_script()
+    lines = [
+        "MCP | foreign server already running on port 18000, using existing",
+        "MCP | self-update smoke: staged local zip /tmp/update.zip",
+        "MCP | stopped server (PID [123])",
+        "MCP | update runner enabling new plugin",
+    ]
+
+    assert smoke.smoke_adopted_existing_server_before_update(lines)
+    assert not smoke.smoke_started_own_server_before_update(lines)
+    assert smoke.smoke_stopped_server_during_update(lines)
+
+
+def test_self_update_smoke_log_verifier_requires_managed_stop_after_staging() -> None:
+    smoke = load_smoke_script()
+    lines = [
+        "MCP | started server (PID 123, v2.2.1): godot-ai",
+        "MCP | self-update smoke: staged local zip /tmp/update.zip",
+        "MCP | update runner enabling new plugin",
+    ]
+
+    assert smoke.smoke_started_own_server_before_update(lines)
+    assert not smoke.smoke_adopted_existing_server_before_update(lines)
+    assert not smoke.smoke_stopped_server_during_update(lines)
 
 
 def test_self_update_smoke_harness_refuses_unmarked_existing_dir(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fixes the in-editor self-update path so future plugin updates can hot-reload more reliably without requiring an editor restart.

- Installs new ZIP entries first, scans them, then atomically replaces existing addon files before the final scan and plugin re-enable.
- Adds manifest validation and unsafe ZIP member rejection before mutating the addon tree.
- Preserves managed-server safety by clearing stale ownership metadata when adopting compatible external servers.
- Fixes the dock server-version label cache so same-text state changes repaint the correct severity color.
- Strengthens the local self-update smoke fixture with a new class_name dependency chain and checks that the smoke server is started, stopped, and not externally adopted.

## Root Cause

Godot can parse the updated plugin graph while self-update is still replacing files. When vNext introduces new class_name scripts or preload dependencies, overwriting existing consumers before the new files are present and scanned can leave the editor in a mixed script graph with cascading parse/load errors.

## Validation

- `ruff check`
- `pytest -q` (`676 passed`)
- `script/ci-check-gdscript`
- `python3 script/local-self-update-smoke --force` live interactive smoke on Godot 4.6.2 Mono

Smoke result: plugin advanced from `2.2.1` to synthetic `2.2.2`, the managed smoke server was stopped and restarted, the plugin reloaded in-process, no parse-error cascade appeared, no new Godot `.ips` crash report was created, and smoke ports `18000/19500` were clear afterward.