### PR TITLE
Suggest recovery shapes when camera/UI rejections look transform/HUD-shaped

### DIFF
--- a/plugin/addons/godot_ai/handlers/camera_handler.gd
+++ b/plugin/addons/godot_ai/handlers/camera_handler.gd
@@ -283,7 +283,7 @@ func configure(params: Dictionary) -> Dictionary:
 			if prop_name in _NODE_TRANSFORM_KEYS:
 				msg += (
 					". Transforms live on the Node, not on the camera config — "
-					+ "use node_set_property(path=%s, properties={\"%s\": ...})" % [node_path, prop_name]
+					+ "use node_set_property(path=%s, property=\"%s\", value=...)" % [node_path, prop_name]
 				)
 			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, msg)
 		if prop_name == "current":

--- a/plugin/addons/godot_ai/handlers/camera_handler.gd
+++ b/plugin/addons/godot_ai/handlers/camera_handler.gd
@@ -57,6 +57,14 @@ const _KEYS_3D := [
 	"current",
 ]
 
+# Transform-shaped keys live on Node2D / Node3D, not in the camera-specific
+# schema — rejecting them without a hint sends agents searching for the wrong
+# tool.
+const _NODE_TRANSFORM_KEYS := [
+	"position", "rotation", "scale", "transform",
+	"global_position", "global_rotation", "global_scale", "global_transform",
+]
+
 const _DAMPING_MARGIN_KEYS := ["left", "top", "right", "bottom"]
 const _CURRENT_SETTLE_ATTEMPTS := 3
 const _CURRENT_SETTLE_DELAY_MSEC := 2
@@ -269,12 +277,15 @@ func configure(params: Dictionary) -> Dictionary:
 	for property in properties:
 		var prop_name: String = String(property)
 		if not (prop_name in valid_keys):
-			return McpErrorCodes.make(
-				McpErrorCodes.INVALID_PARAMS,
-				"Property '%s' not valid for %s. Valid: %s" % [
-					prop_name, _VALID_TYPES[type_str], ", ".join(valid_keys)
-				]
-			)
+			var msg := "Property '%s' not valid for %s. Valid: %s" % [
+				prop_name, _VALID_TYPES[type_str], ", ".join(valid_keys)
+			]
+			if prop_name in _NODE_TRANSFORM_KEYS:
+				msg += (
+					". Transforms live on the Node, not on the camera config — "
+					+ "use node_set_property(path=%s, properties={\"%s\": ...})" % [node_path, prop_name]
+				)
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, msg)
 		if prop_name == "current":
 			current_request = bool(properties[prop_name])
 			continue

--- a/plugin/addons/godot_ai/handlers/ui_handler.gd
+++ b/plugin/addons/godot_ai/handlers/ui_handler.gd
@@ -88,9 +88,12 @@ func set_anchor_preset(params: Dictionary) -> Dictionary:
 	if node == null:
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, McpScenePath.format_node_error(node_path, scene_root))
 	if not node is Control:
+		var got_class: String = node.get_class()
 		return McpErrorCodes.make(
 			McpErrorCodes.INVALID_PARAMS,
-			"Node %s is not a Control (got %s)" % [node_path, node.get_class()]
+			"Node %s is not a Control (got %s)%s" % [
+				node_path, got_class, _canvas_layer_overlay_hint(got_class)
+			]
 		)
 
 	var control := node as Control
@@ -307,7 +310,12 @@ func _build_subtree(spec: Dictionary) -> Dictionary:
 				return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "theme path must point to a Theme resource: %s" % theme_path)
 			if not node is Control and not node is Window:
 				node.free()
-				return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "theme can only be set on Control / Window (got %s)" % node_type)
+				return McpErrorCodes.make(
+					McpErrorCodes.INVALID_PARAMS,
+					"theme can only be set on Control / Window (got %s)%s" % [
+						node_type, _canvas_layer_overlay_hint(node_type)
+					]
+				)
 			node.theme = theme_res as Theme
 
 	# Anchor preset — applied before children so children inherit sensible anchors.
@@ -318,7 +326,12 @@ func _build_subtree(spec: Dictionary) -> Dictionary:
 			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Unknown anchor_preset: %s" % preset_name)
 		if not node is Control:
 			node.free()
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "anchor_preset requires a Control (got %s)" % node_type)
+			return McpErrorCodes.make(
+				McpErrorCodes.INVALID_PARAMS,
+				"anchor_preset requires a Control (got %s)%s" % [
+					node_type, _canvas_layer_overlay_hint(node_type)
+				]
+			)
 		var preset_value: int = _PRESETS[preset_name]
 		var margin: int = int(spec.get("anchor_margin", 0))
 		(node as Control).set_anchors_and_offsets_preset(preset_value, Control.PRESET_MODE_MINSIZE, margin)
@@ -500,3 +513,16 @@ static func _coerce_for_type(value: Variant, prop_type: int) -> Dictionary:
 				return {"ok": true, "value": NodePath(value)}
 			return {"ok": false}
 	return {"ok": true, "value": value}
+
+
+# CanvasLayer is the canonical HUD parent but isn't a Control, so applying
+# Control-only properties (theme, anchor_preset) to it is a common mistake.
+# The recovery shape is always the same: nest a Control child under the layer.
+static func _canvas_layer_overlay_hint(node_class: String) -> String:
+	if node_class != "CanvasLayer":
+		return ""
+	return (
+		". CanvasLayer is not a Control — add a Control (e.g. Panel or Control "
+		+ "with anchor_preset=full_rect) as its child and apply theme / "
+		+ "anchor_preset to that overlay."
+	)

--- a/plugin/addons/godot_ai/utils/uv_cache_cleanup.gd.uid
+++ b/plugin/addons/godot_ai/utils/uv_cache_cleanup.gd.uid
@@ -1,0 +1,1 @@
+uid://d33ukg65qf7q0

--- a/src/godot_ai/tools/camera.py
+++ b/src/godot_ai/tools/camera.py
@@ -23,9 +23,12 @@ Ops:
         Create a Camera2D ("2d") or Camera3D ("3d"). When make_current=True,
         unmarks previously current cameras of the same class in one undo.
   • configure(camera_path, properties)
-        Batch-set properties. Class-aware. Enum-by-name (projection,
-        keep_aspect, anchor_mode, doppler_tracking, process_callback).
-        Vector2 dict coercion for zoom/offset.
+        Batch-set camera-specific properties (zoom, fov, projection, smoothing,
+        drag, limits …). Class-aware. Enum-by-name (projection, keep_aspect,
+        anchor_mode, doppler_tracking, process_callback). Vector2 dict
+        coercion for zoom/offset. Transforms (position, rotation, scale,
+        transform, global_*) live on the Node — set those via
+        node_set_property, not here.
   • set_limits_2d(camera_path, left?, right?, top?, bottom?, smoothed?)
         Set Camera2D bounds. Pass only the edges to change.
   • set_damping_2d(camera_path, position_speed?, rotation_speed?,

--- a/src/godot_ai/tools/ui.py
+++ b/src/godot_ai/tools/ui.py
@@ -22,6 +22,9 @@ Ops:
         center_bottom | center | left_wide | top_wide | right_wide |
         bottom_wide | vcenter_wide | hcenter_wide | full_rect.
         resize_mode: minsize | keep_width | keep_height | keep_size.
+        Target must be a Control. CanvasLayer is the canonical HUD parent
+        but is not a Control — put a Control child under the CanvasLayer and
+        apply the preset to that overlay.
   • set_text(path, text)
         Set text on a Label/Button/LineEdit/TextEdit/RichTextLabel.
   • build_layout(tree, parent_path="")
@@ -32,6 +35,9 @@ Ops:
         container spacing live under `theme_override_constants/<name>` —
         e.g. `{"theme_override_constants/separation": 8}` on a
         VBoxContainer, not `{"separation": 8}` (which errors).
+        `theme` and `anchor_preset` require a Control / Window — for a HUD,
+        nest a Control under a CanvasLayer and apply them to the Control
+        child, not the layer itself.
   • draw_recipe(path, ops, clear_existing=True)
         Attach a declarative list of vector _draw() ops to a Control —
         radar sweeps, gauges, corner brackets, crosshairs, waveforms.

--- a/test_project/tests/test_camera.gd
+++ b/test_project/tests/test_camera.gd
@@ -190,6 +190,25 @@ func test_configure_empty_dict() -> void:
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 
 
+func test_configure_transform_key_suggests_node_set_property() -> void:
+	# Transform-shaped keys live on the Node, not in the camera config schema.
+	# Rejecting them must point at node_set_property explicitly — otherwise
+	# an agent falls back to fuzzy-matching the listed camera keys.
+	var r := _create("RejectPos", "3d")
+	if r.is_empty():
+		assert_true(false, "No scene open")
+		return
+	for bad_key in ["position", "rotation", "scale", "transform", "global_position"]:
+		var result := _handler.configure({
+			"camera_path": r.data.path,
+			"properties": {bad_key: 0},
+		})
+		assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+		assert_contains(result.error.message, "node_set_property",
+			"Rejecting camera_configure(%s) should suggest node_set_property" % bad_key)
+		assert_contains(result.error.message, bad_key)
+
+
 func test_configure_current_sibling_unmark_single_undo() -> void:
 	var first := _create("UndoFirst", "2d", true)
 	if first.is_empty():

--- a/test_project/tests/test_ui.gd
+++ b/test_project/tests/test_ui.gd
@@ -161,6 +161,27 @@ func test_set_anchor_preset_non_control_node() -> void:
 	assert_contains(result.error.message, "not a Control")
 
 
+func test_set_anchor_preset_canvas_layer_suggests_control_overlay() -> void:
+	# Applying anchor_preset directly to a CanvasLayer is the common HUD-shaped
+	# mistake. A bare "not a Control" rejection isn't actionable — the error
+	# must spell out the Control-child overlay fix.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root — is a scene open?")
+		return
+	var layer := CanvasLayer.new()
+	layer.name = "TestUiCanvasLayer"
+	scene_root.add_child(layer)
+	layer.owner = scene_root
+	var path := "/" + scene_root.name + "/TestUiCanvasLayer"
+	var result := _handler.set_anchor_preset({"path": path, "preset": "full_rect"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "CanvasLayer")
+	assert_contains(result.error.message, "Control")
+	scene_root.remove_child(layer)
+	layer.queue_free()
+
+
 # ----- undo -----
 
 func test_set_anchor_preset_is_undoable() -> void:
@@ -406,6 +427,32 @@ func test_build_layout_rejects_anchor_preset_on_non_control() -> void:
 		"tree": {"type": "Node", "anchor_preset": "center"}
 	})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_build_layout_anchor_preset_on_canvas_layer_suggests_control_overlay() -> void:
+	# build_layout({type: CanvasLayer, anchor_preset: ...}) is the common
+	# HUD-shaped mistake. Reject with the Control-child fix spelled out.
+	var result := _handler.build_layout({
+		"tree": {"type": "CanvasLayer", "anchor_preset": "full_rect"}
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "CanvasLayer")
+	assert_contains(result.error.message, "Control")
+
+
+func test_build_layout_theme_on_canvas_layer_suggests_control_overlay() -> void:
+	# Same shape but for the `theme` field — must reject with the same hint.
+	var theme_path := "res://tests/_mcp_test_canvas_layer_theme.tres"
+	ResourceSaver.save(Theme.new(), theme_path)
+	var result := _handler.build_layout({
+		"tree": {"type": "CanvasLayer", "theme": theme_path}
+	})
+	# Clean up before asserting so a failed assert can't leak the .tres.
+	if FileAccess.file_exists(theme_path):
+		DirAccess.remove_absolute(theme_path)
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "CanvasLayer")
+	assert_contains(result.error.message, "Control")
 
 
 func test_build_layout_is_undoable() -> void:

--- a/test_project/tests/test_uv_cache_cleanup.gd.uid
+++ b/test_project/tests/test_uv_cache_cleanup.gd.uid
@@ -1,0 +1,1 @@
+uid://daqohh6qyfnbu


### PR DESCRIPTION
## Summary

Closes #264. Three additive error-message improvements + matching tool-description text. Pure error-string changes (and tool description text); no protocol or behavior change.

- **camera_configure**: when an agent passes a transform-shaped key (`position` / `rotation` / `scale` / `transform` / `global_*`), the rejection now appends a sentence pointing at `node_set_property`. Without the hint, agents fuzzy-match the listed camera keys and pick wrong.
- **ui_set_anchor_preset** and **ui_build_layout** (theme + anchor_preset): three non-Control rejection paths now share one `_canvas_layer_overlay_hint(node_class)` helper. When the offending node is a `CanvasLayer`, the error spells out the recovery — nest a `Control` child under the layer and apply `theme` / `anchor_preset` to that overlay. CanvasLayer is the canonical HUD parent but isn't a Control, so a bare "not a Control" rejection isn't actionable.
- **Tool descriptions** for `camera_manage.configure`, `ui_manage.set_anchor_preset`, and `ui_manage.build_layout` mirror the runtime hints so schema-aware clients see the guidance up front.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `pytest -q` — 665/665 passed
- [x] GDScript suite via `script/ci-godot-tests` — 972/987 passed; 4 new tests pass; 1 pre-existing failure (`plugin_lifecycle.test_verified_old_server_becomes_incompatible_and_blocks_connection`) reproduces on clean `main` and is unrelated.
- [x] Live MCP smoke against headless Godot 4.6.2:
  - `camera_manage(op="configure", properties={"position": ...})` → returns the new `node_set_property` hint inline.
  - `ui_manage(op="set_anchor_preset", path=/Main/HudLayer)` on a `CanvasLayer` → returns the Control-child overlay hint.
  - `ui_manage(op="build_layout", tree={type: "CanvasLayer", anchor_preset: "full_rect"})` → returns the same hint.

New GDScript tests:
- `camera.test_configure_transform_key_suggests_node_set_property`
- `ui.test_set_anchor_preset_canvas_layer_suggests_control_overlay`
- `ui.test_build_layout_anchor_preset_on_canvas_layer_suggests_control_overlay`
- `ui.test_build_layout_theme_on_canvas_layer_suggests_control_overlay`

https://claude.ai/code/session_01BWT7uJTcFie9ho6LNQkas4

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWT7uJTcFie9ho6LNQkas4)_