### PR TITLE
Defer script_create reply until ResourceLoader sees the new file (#261)

### DIFF
--- a/plugin/addons/godot_ai/handlers/script_handler.gd
+++ b/plugin/addons/godot_ai/handlers/script_handler.gd
@@ -4,10 +4,17 @@ extends RefCounted
 ## Handles script creation, reading, attaching, detaching, and symbol inspection.
 
 var _undo_redo: EditorUndoRedoManager
+var _connection: McpConnection
+
+# Bounded settle window for `ResourceLoader.exists(path)` after `scan()` so that
+# an agent calling create_script -> attach_script back-to-back doesn't race the
+# editor's import pipeline (#261). Polled once per frame.
+const _IMPORT_SETTLE_MAX_FRAMES := 300  # ~5s at 60fps; bails out and replies anyway.
 
 
-func _init(undo_redo: EditorUndoRedoManager) -> void:
+func _init(undo_redo: EditorUndoRedoManager, connection: McpConnection = null) -> void:
 	_undo_redo = undo_redo
+	_connection = connection
 
 
 func create_script(params: Dictionary) -> Dictionary:
@@ -51,7 +58,36 @@ func create_script(params: Dictionary) -> Dictionary:
 	# `.gd.uid` is the sidecar Godot generates on scan; list both so the caller
 	# can rm the full set in one go.
 	McpResourceIO.attach_cleanup_hint(data, existed_before, [path, path + ".uid"])
+
+	# scan() is async — ResourceLoader.exists(path) returns false until Godot's
+	# filesystem pipeline finishes. If we reply now, an immediate attach_script
+	# races and 404s (#261). Defer the response until the resource is visible
+	# (or a bounded timeout elapses). For freshly-created files we wait; on
+	# overwrite the resource was already known to ResourceLoader, so reply now.
+	var request_id: String = params.get("_request_id", "")
+	if not existed_before and _connection != null and not request_id.is_empty():
+		_finish_create_script_deferred(request_id, path, data)
+		return McpDispatcher.DEFERRED_RESPONSE
+
+	# Synchronous fallback: batch_execute (no request_id) and unit-test contexts
+	# (no connection) get the immediate reply that the previous behaviour gave.
 	return {"data": data}
+
+
+func _finish_create_script_deferred(request_id: String, path: String, data: Dictionary) -> void:
+	var tree := _connection.get_tree()
+	var frames := 0
+	while frames < _IMPORT_SETTLE_MAX_FRAMES and not ResourceLoader.exists(path):
+		await tree.process_frame
+		frames += 1
+	# If the plugin tears down (_exit_tree frees _connection) during the await,
+	# is_instance_valid() goes false and we drop the response silently — the
+	# server's request timeout will surface the failure to the caller.
+	if not is_instance_valid(_connection):
+		return
+	var payload := data.duplicate()
+	payload["import_settled"] = frames < _IMPORT_SETTLE_MAX_FRAMES
+	_connection.send_deferred_response(request_id, {"data": payload})
 
 
 func read_script(params: Dictionary) -> Dictionary:

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -159,7 +159,7 @@ func _enter_tree() -> void:
 	var node_handler := NodeHandler.new(get_undo_redo())
 	var project_handler := ProjectHandler.new(_connection)
 	var client_handler := ClientHandler.new()
-	var script_handler := ScriptHandler.new(get_undo_redo())
+	var script_handler := ScriptHandler.new(get_undo_redo(), _connection)
 	var resource_handler := ResourceHandler.new(get_undo_redo())
 	var filesystem_handler := FilesystemHandler.new()
 	var signal_handler := SignalHandler.new(get_undo_redo())

--- a/plugin/addons/godot_ai/utils/uv_cache_cleanup.gd.uid
+++ b/plugin/addons/godot_ai/utils/uv_cache_cleanup.gd.uid
@@ -1,0 +1,1 @@
+uid://d33ukg65qf7q0

--- a/test_project/tests/test_uv_cache_cleanup.gd.uid
+++ b/test_project/tests/test_uv_cache_cleanup.gd.uid
@@ -1,0 +1,1 @@
+uid://daqohh6qyfnbu

--- a/tests/unit/test_script_create_import_settle.py
+++ b/tests/unit/test_script_create_import_settle.py
@@ -1,0 +1,106 @@
+"""Source-structure regression tests for the create_script -> attach_script
+import-settle fix (issue #261).
+
+Without this guard, an agent that calls `script_create` followed immediately
+by `script_attach` for the same `.gd` file races the editor's filesystem
+scan: `ResourceLoader.exists(path)` can return false while Godot is still
+recognising the new resource. The fix is to defer the `script_create`
+response until either the resource is visible or a bounded settle window
+elapses, so a successful response means an immediate `script_attach` will
+succeed.
+
+These tests pin the structure so a future refactor can't silently regress
+the guarantee.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[2] / "plugin" / "addons" / "godot_ai"
+SCRIPT_HANDLER = PLUGIN_ROOT / "handlers" / "script_handler.gd"
+PLUGIN_GD = PLUGIN_ROOT / "plugin.gd"
+
+
+def test_script_handler_holds_connection_for_deferred_replies() -> None:
+    """ScriptHandler needs an McpConnection ref to push the deferred response."""
+    source = SCRIPT_HANDLER.read_text()
+
+    assert "var _connection: McpConnection" in source, (
+        "ScriptHandler must hold an McpConnection so create_script can defer "
+        "its reply until the editor's filesystem scan settles. Without this "
+        "field a fresh script_create -> script_attach pair races the import "
+        "pipeline (issue #261)."
+    )
+    # _init must accept the connection. Default null keeps batch_execute and
+    # unit-test contexts working on the synchronous fallback path.
+    expected_init = (
+        "func _init(undo_redo: EditorUndoRedoManager, "
+        "connection: McpConnection = null)"
+    )
+    assert expected_init in source, (
+        "ScriptHandler._init must accept the connection as an optional "
+        "second parameter so test contexts can keep using the sync fallback."
+    )
+
+
+def test_create_script_defers_for_freshly_created_files() -> None:
+    """The new-file path returns DEFERRED_RESPONSE; existing-file path replies sync."""
+    source = SCRIPT_HANDLER.read_text()
+
+    # The deferred handoff must be guarded by `not existed_before` so that
+    # overwriting an already-known resource still returns immediately —
+    # ResourceLoader already knows it, no scan to wait for.
+    assert "not existed_before and _connection != null and not request_id.is_empty()" in source, (
+        "create_script must only defer when the file was newly created AND a "
+        "connection is available AND a request_id is present. Overwrites and "
+        "batch_execute / unit-test contexts must keep the synchronous reply."
+    )
+    assert "return McpDispatcher.DEFERRED_RESPONSE" in source, (
+        "create_script must return the DEFERRED_RESPONSE sentinel on the "
+        "deferred path so the dispatcher skips auto-sending the reply."
+    )
+
+
+def test_finish_create_script_deferred_polls_resourceloader_with_bounded_loop() -> None:
+    """The settle loop must be bounded and check ResourceLoader.exists each frame."""
+    source = SCRIPT_HANDLER.read_text()
+
+    # The bounded counter prevents an indefinite hang if the editor's
+    # filesystem pipeline never reports the new resource.
+    assert "_IMPORT_SETTLE_MAX_FRAMES" in source, (
+        "The deferred loop must use a named bounded-frame constant so the "
+        "wait can't run forever if the filesystem scan stalls."
+    )
+    deferred_block = source.split("func _finish_create_script_deferred", 1)[1]
+    assert "ResourceLoader.exists(path)" in deferred_block, (
+        "The deferred loop must poll ResourceLoader.exists(path) — that's "
+        "the precise check script_attach uses, so settling on it gives the "
+        "guarantee #261 wants."
+    )
+    assert "await tree.process_frame" in deferred_block, (
+        "The deferred loop must yield via process_frame between polls so the "
+        "editor can actually run the import pipeline between checks."
+    )
+    # The reply must use send_deferred_response with a {"data": ...} payload.
+    assert "_connection.send_deferred_response(request_id" in deferred_block, (
+        "After settling, the handler must push the response over the "
+        "connection's send_deferred_response — the dispatcher won't do it."
+    )
+    # Match the project_handler.stop_project pattern: drop the response if
+    # the plugin tore down during the await.
+    assert "is_instance_valid(_connection)" in deferred_block, (
+        "If _exit_tree fires during the await the connection is freed; the "
+        "deferred reply must check is_instance_valid and bail silently."
+    )
+
+
+def test_plugin_gd_passes_connection_to_script_handler() -> None:
+    """plugin.gd must wire _connection into ScriptHandler — the field is null otherwise."""
+    source = PLUGIN_GD.read_text()
+
+    assert "ScriptHandler.new(get_undo_redo(), _connection)" in source, (
+        "plugin.gd must construct ScriptHandler with the connection so the "
+        "deferred-reply path is reachable in production. Without this, every "
+        "create_script falls back to the synchronous reply and #261 returns."
+    )


### PR DESCRIPTION
## Summary

Closes #261. A back-to-back `script_create` → `script_attach` for a fresh `.gd` file races Godot's filesystem-scan pipeline: `EditorInterface.get_resource_filesystem().scan()` is async, `ResourceLoader.exists(path)` returns false during the import window, and `script_attach` 404s until the editor catches up. Per the friction log, the workaround was a client-side sleep + retry.

The fix uses the existing deferred-response pattern (mirroring `ProjectHandler._finish_stop_project_deferred`) to poll `ResourceLoader.exists(path)` once per frame after `scan()`, capped at `_IMPORT_SETTLE_MAX_FRAMES = 300` (~5s at 60fps). Only the new-file path defers — overwrite, `batch_execute` (no `request_id`), and unit-test contexts (no connection) keep the synchronous reply, so this is purely additive for production agents.

A successful `script_create` response now also carries `import_settled: bool` so callers can tell whether the resource was visible by reply time or whether the wait timed out.

## Why polling instead of awaiting `filesystem_changed`

The signal fires once per scan and may not coincide with the moment `ResourceLoader.exists()` flips true for a specific path. Polling the precise check `script_attach` uses is the cleanest invariant — settle on the same predicate the consumer reads. `ResourceLoader.exists()` is an O(1) cache lookup, and the wait yields via `await tree.process_frame` so the import pipeline gets CPU between polls. The 300-frame cap also bounds the wait if the FS pipeline ever stalls, instead of leaving the request stuck on a signal that never arrives.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `pytest -q` — 669/669 passed (+4 new structural tests)
- [x] `script/ci-check-gdscript` — no parse errors
- [x] GDScript suite via `script/ci-godot-tests` — 968/983 passed; 1 pre-existing failure (`plugin_lifecycle.test_verified_old_server_becomes_incompatible_and_blocks_connection`) is the same flake noted on PR #265, unrelated to this change.
- [x] **Live MCP smoke against headless Godot 4.6.2**, exercising the exact #261 scenario:
  1. `script_create({"path": "res://_smoke_261_*.gd", "content": "extends Node3D\n…"})` → returned in 21ms with `import_settled: true`. Under the old code this would reply immediately with `undoable: false` and no settle guarantee.
  2. **Immediately** `script_attach({"path": "/Main", "script_path": "res://_smoke_261_*.gd"})` with no client-side sleep → succeeded with `undoable: true, had_previous_script: false`. This is the call that used to 404.

New tests:
- `tests/unit/test_script_create_import_settle.py` — 4 structural pytest tests pinning the deferred-response shape (connection field, init signature, fresh-file guard, polling-loop with bounded counter, plugin.gd wiring) so a future refactor can't silently regress the guarantee.

https://claude.ai/code/session_01A1aWK1EW1qgVhNL93eGPkh

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1aWK1EW1qgVhNL93eGPkh)_
