### PR TITLE
Self-heal session readiness from editor_state replies (#262)

### DIFF
--- a/plugin/addons/godot_ai/utils/uv_cache_cleanup.gd.uid
+++ b/plugin/addons/godot_ai/utils/uv_cache_cleanup.gd.uid
@@ -1,0 +1,1 @@
+uid://d33ukg65qf7q0

--- a/src/godot_ai/handlers/_readiness.py
+++ b/src/godot_ai/handlers/_readiness.py
@@ -14,6 +14,29 @@ _READINESS_INFO: dict[str, tuple[str, bool]] = {
     "playing": ("Editor is in play mode — call project_stop to stop the game, then retry", False),
 }
 
+# Every readiness value the plugin can emit. Derived from the blocking-state
+# table plus "ready" / "no_scene" so the canonical list can't drift. Used by
+# handlers that copy a live readiness snapshot (editor_state's response,
+# project_stop's readiness_after) onto session.readiness — guards against
+# the plugin inventing an unknown state and the cache trusting it.
+KNOWN_READINESS: frozenset[str] = frozenset(_READINESS_INFO) | {"ready", "no_scene"}
+
+
+def sync_readiness_from_snapshot(runtime: Runtime, value: object) -> bool:
+    """Copy an authoritative readiness snapshot onto the active session.
+
+    Used by handlers that receive a live readiness from the plugin
+    (`editor_state`'s reply, `project_stop`'s `readiness_after`). Returns
+    True if the cache was updated, False if there's no active session or
+    the snapshot wasn't a recognized readiness value (forward-compat: a
+    newer plugin sending an unknown state is ignored, not propagated).
+    """
+    session = runtime.get_active_session()
+    if session is None or value not in KNOWN_READINESS:
+        return False
+    session.readiness = value  # type: ignore[assignment]
+    return True
+
 
 def require_writable(runtime: Runtime) -> None:
     """Check that the active session is in a writable state.

--- a/src/godot_ai/handlers/editor.py
+++ b/src/godot_ai/handlers/editor.py
@@ -9,7 +9,7 @@ import logging
 from fastmcp.tools.base import Image as McpImage
 from mcp.types import TextContent
 
-from godot_ai.handlers._readiness import require_writable
+from godot_ai.handlers._readiness import require_writable, sync_readiness_from_snapshot
 from godot_ai.runtime.interface import Runtime
 from godot_ai.sessions.registry import Session
 from godot_ai.tools._pagination import paginate
@@ -18,7 +18,26 @@ logger = logging.getLogger(__name__)
 
 
 async def editor_state(runtime: Runtime) -> dict:
-    return await runtime.send_command("get_editor_state")
+    """Read live editor state and self-heal the session readiness cache.
+
+    The plugin emits ``readiness_changed`` events when ``_check_state_changes``
+    notices a transition, but ``_process`` is paused around save/play frames
+    (see ``McpConnection.pause_processing``), so the event can lag actual state
+    by one or more ticks. During that window the server's ``session.readiness``
+    cache stays at the previous value and a write call gated by
+    ``require_writable`` is rejected even though the editor is already
+    writeable. Issue #262 reproduced exactly that with an ``editor_state ->
+    scene_save`` sequence: editor_state returned ``is_playing: false`` while
+    the cache still said ``playing``, blocking the save.
+
+    The plugin's ``get_editor_state`` reads ``EditorInterface.is_playing_scene``
+    and ``McpConnection.get_readiness`` directly, so its ``readiness`` field is
+    authoritative. Copy it onto the session so a subsequent ``require_writable``
+    can't disagree with the value the agent just observed.
+    """
+    result = await runtime.send_command("get_editor_state")
+    sync_readiness_from_snapshot(runtime, result.get("readiness"))
+    return result
 
 
 async def editor_selection_get(runtime: Runtime) -> dict:

--- a/src/godot_ai/handlers/project.py
+++ b/src/godot_ai/handlers/project.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-from godot_ai.handlers._readiness import require_writable
+from godot_ai.handlers._readiness import require_writable, sync_readiness_from_snapshot
 from godot_ai.runtime.interface import Runtime
-
-_KNOWN_READINESS = frozenset({"ready", "importing", "playing", "no_scene"})
 
 COMMON_SETTINGS = [
     "application/config/name",
@@ -57,13 +55,11 @@ async def project_stop(runtime: Runtime) -> dict:
     EDITOR_NOT_READY.
     """
     result = await runtime.send_command("stop_project")
-    session = runtime.get_active_session()
-    if session is None:
+    if sync_readiness_from_snapshot(runtime, result.get("readiness_after")):
         return result
 
-    readiness_after = result.get("readiness_after")
-    if readiness_after in _KNOWN_READINESS:
-        session.readiness = readiness_after
+    session = runtime.get_active_session()
+    if session is None:
         return result
 
     loop = asyncio.get_running_loop()

--- a/src/godot_ai/tools/editor.py
+++ b/src/godot_ai/tools/editor.py
@@ -46,6 +46,12 @@ def register_editor_tools(mcp: FastMCP, *, include_non_core: bool = True) -> Non
         Also reachable as ``editor_manage(op="state")`` (same handler) for clients
         that prefer a single rolled-up tool.
 
+        Side effect: refreshes the server's session readiness cache from the
+        live editor reply. Useful as a recovery step after a write call is
+        rejected as ``EDITOR_NOT_READY (state=playing)`` when you already know
+        the game has stopped — calling ``editor_state`` once syncs the cache
+        and the next write proceeds. Issue #262.
+
         Args:
             session_id: Optional Godot session to target. Empty = active session.
         """

--- a/test_project/tests/test_uv_cache_cleanup.gd.uid
+++ b/test_project/tests/test_uv_cache_cleanup.gd.uid
@@ -1,0 +1,1 @@
+uid://daqohh6qyfnbu

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -10,6 +10,9 @@ import websockets
 
 from godot_ai import __version__ as _SERVER_VERSION
 from godot_ai.godot_client.client import GodotClient, GodotCommandError
+from godot_ai.handlers import editor as editor_handlers
+from godot_ai.handlers import scene as scene_handlers
+from godot_ai.runtime.direct import DirectRuntime
 
 # ---------------------------------------------------------------------------
 # Handshake
@@ -287,3 +290,83 @@ class TestMultipleSessions:
         assert harness.registry.get("keep-a") is None
         assert harness.registry.get("keep-b") is not None
         await plugin_b.close()
+
+
+# --- Issue #262: editor_state self-heals a stale "playing" cache ---
+
+
+class TestEditorStateSelfHeal:
+    async def test_editor_state_then_scene_save_no_stale_playing_block(self, harness):
+        plugin = await harness.connect_plugin(session_id="sh-1", readiness="playing")
+        client = GodotClient(harness.server, harness.registry)
+        runtime = DirectRuntime(registry=harness.registry, client=client)
+        session = harness.registry.get("sh-1")
+        assert session.readiness == "playing"
+
+        async def mock_plugin_loop():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "get_editor_state"
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "godot_version": "4.4.1",
+                    "project_name": "p",
+                    "current_scene": "res://main.tscn",
+                    "is_playing": False,
+                    "readiness": "ready",
+                },
+            )
+            # Without the self-heal the runtime never reaches save_scene —
+            # require_writable raises EDITOR_NOT_READY against the stale
+            # "playing" cache before send_command runs. Receiving the
+            # save_scene command is the test.
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "save_scene"
+            await plugin.send_response(
+                cmd["request_id"],
+                {"path": "res://main.tscn", "undoable": False},
+            )
+
+        task = asyncio.create_task(mock_plugin_loop())
+        try:
+            state = await editor_handlers.editor_state(runtime)
+            assert state["readiness"] == "ready"
+            assert session.readiness == "ready"
+            saved = await scene_handlers.scene_save(runtime)
+            assert saved["path"] == "res://main.tscn"
+        finally:
+            await asyncio.wait_for(task, timeout=2.0)
+            await plugin.close()
+
+    async def test_editor_state_promotes_cache_to_playing_when_truly_playing(self, harness):
+        """Self-heal is bidirectional — a stale 'ready' cache also reconciles
+        so the next write correctly blocks instead of slipping through."""
+        plugin = await harness.connect_plugin(session_id="sh-2", readiness="ready")
+        client = GodotClient(harness.server, harness.registry)
+        runtime = DirectRuntime(registry=harness.registry, client=client)
+        session = harness.registry.get("sh-2")
+        assert session.readiness == "ready"
+
+        async def mock_plugin():
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "godot_version": "4.4.1",
+                    "project_name": "p",
+                    "current_scene": "res://main.tscn",
+                    "is_playing": True,
+                    "readiness": "playing",
+                },
+            )
+
+        task = asyncio.create_task(mock_plugin())
+        try:
+            await editor_handlers.editor_state(runtime)
+            assert session.readiness == "playing"
+            with pytest.raises(GodotCommandError) as exc_info:
+                await scene_handlers.scene_save(runtime)
+            assert exc_info.value.code == "EDITOR_NOT_READY"
+        finally:
+            await asyncio.wait_for(task, timeout=2.0)
+            await plugin.close()

--- a/tests/unit/test_readiness.py
+++ b/tests/unit/test_readiness.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import pytest
 
 from godot_ai.godot_client.client import GodotCommandError
-from godot_ai.handlers._readiness import require_writable
+from godot_ai.handlers import editor as editor_handlers
+from godot_ai.handlers._readiness import KNOWN_READINESS, require_writable
 from godot_ai.protocol.errors import ErrorCode
 from godot_ai.runtime.direct import DirectRuntime
 from godot_ai.sessions.registry import Session, SessionRegistry
@@ -84,3 +85,106 @@ def test_session_readiness_defaults_to_ready():
         plugin_version="0.0.1",
     )
     assert session.readiness == "ready"
+
+
+# --- editor_state self-heal — issue #262 ---
+
+
+class _EditorStateClient:
+    """Stub plugin that only handles get_editor_state.
+
+    `readiness=None` means "omit the field from the response" — older plugins
+    pre-dating the readiness self-heal don't emit it.
+    """
+
+    def __init__(self, readiness: str | None):
+        self._readiness = readiness
+
+    async def send(
+        self,
+        command: str,
+        params: dict | None = None,
+        session_id: str | None = None,
+        timeout: float = 5.0,
+    ) -> dict:
+        if command != "get_editor_state":
+            raise AssertionError(f"unexpected command: {command}")
+        payload: dict = {
+            "current_scene": "res://main.tscn",
+            "project_name": "p",
+            "is_playing": self._readiness == "playing",
+            "godot_version": "4.4.1",
+        }
+        if self._readiness is not None:
+            payload["readiness"] = self._readiness
+        return payload
+
+
+def _runtime_for_self_heal(
+    cached: str, plugin_reports: str | None
+) -> tuple[DirectRuntime, Session]:
+    session = _make_session(cached)
+    registry = SessionRegistry()
+    registry.register(session)
+    runtime = DirectRuntime(registry=registry, client=_EditorStateClient(plugin_reports))
+    return runtime, session
+
+
+async def test_editor_state_overwrites_stale_playing_cache():
+    runtime, session = _runtime_for_self_heal(cached="playing", plugin_reports="ready")
+
+    result = await editor_handlers.editor_state(runtime)
+
+    assert result["readiness"] == "ready"
+    assert session.readiness == "ready"
+    # Followup require_writable now sees the refreshed cache and lets the
+    # caller through. This is the critical end-to-end invariant — without
+    # it, editor_state -> scene_save still fails with the stale cache.
+    require_writable(runtime)
+
+
+async def test_editor_state_syncs_playing_when_truly_playing():
+    """Self-heal is bidirectional — a stale 'ready' cache must also reconcile
+    so the next write correctly blocks instead of slipping through."""
+    runtime, session = _runtime_for_self_heal(cached="ready", plugin_reports="playing")
+
+    await editor_handlers.editor_state(runtime)
+
+    assert session.readiness == "playing"
+    with pytest.raises(GodotCommandError):
+        require_writable(runtime)
+
+
+async def test_editor_state_ignores_missing_readiness_field():
+    """Older plugins that omit readiness must not blank the cache."""
+    runtime, session = _runtime_for_self_heal(cached="ready", plugin_reports=None)
+
+    await editor_handlers.editor_state(runtime)
+
+    assert session.readiness == "ready"
+
+
+async def test_editor_state_ignores_unknown_readiness_field():
+    """Pinning this case lets a future plugin add new readiness values
+    without a forward-compat refactor; the server keeps the prior value
+    until the Python KNOWN_READINESS set is widened to match."""
+    runtime, session = _runtime_for_self_heal(cached="ready", plugin_reports="bogus_state")
+
+    await editor_handlers.editor_state(runtime)
+
+    assert session.readiness == "ready"
+
+
+async def test_editor_state_no_session_is_no_op():
+    runtime = DirectRuntime(registry=SessionRegistry(), client=_EditorStateClient("ready"))
+
+    result = await editor_handlers.editor_state(runtime)
+
+    assert result["readiness"] == "ready"
+
+
+def test_known_readiness_covers_all_states_handlers_emit():
+    """Lock the canonical readiness set so contributors don't drift the
+    plugin and server states out of sync. The plugin's get_readiness emits
+    exactly these values today (see connection.gd::get_readiness)."""
+    assert KNOWN_READINESS == frozenset({"ready", "importing", "playing", "no_scene"})

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -140,6 +140,7 @@ class StubClient:
                 "project_name": "TestProject",
                 "is_playing": False,
                 "godot_version": "4.4.1",
+                "readiness": "ready",
             }
         if command == "get_selection":
             return {"selected": ["/Main/Camera3D"]}


### PR DESCRIPTION
## Summary

Closes #262.

The plugin's `readiness_changed` event lags actual editor state when `_process` is paused around save/play frames (`McpConnection.pause_processing` is set during `save_scene` and the play-call autosave preview). During that window the server's `session.readiness` cache stays at the previous value and `require_writable` rejects a write that the live editor would accept. The friction-log scenario reproduced exactly that: an `editor_state -> scene_save` sequence where `editor_state` returned `is_playing: false` while the cache still said `playing`, blocking the save.

The plugin's `get_editor_state` reads `EditorInterface.is_playing_scene` and `McpConnection.get_readiness` directly, so its `readiness` field is authoritative. `editor_state` now copies that value onto `session.readiness` so a subsequent `require_writable` can't disagree with the value the agent just observed.

### Refactor: shared `sync_readiness_from_snapshot()` helper

`project_stop` already had the same shape — it copies `readiness_after` from the deferred reply onto the session. Extracted both call sites into one helper in `handlers/_readiness.py`:

```python
def sync_readiness_from_snapshot(runtime: Runtime, value: object) -> bool:
    session = runtime.get_active_session()
    if session is None or value not in KNOWN_READINESS:
        return False
    session.readiness = value
    return True
```

`KNOWN_READINESS` is now derived from the existing `_READINESS_INFO` table plus `{"ready", "no_scene"}` so the canonical state list can't drift — pinned by `test_known_readiness_covers_all_states_handlers_emit`. The duplicated `_KNOWN_READINESS` constant in `project.py` is gone.

### Why self-heal here is sufficient for #262

The issue's exact scenario is `editor_state -> scene_save`. With self-heal, the agent's `editor_state` call refreshes the cache before any subsequent write is gated. The acceptance criterion ("a stop -> editor_state -> scene_save sequence does not produce contradictory `not playing` / `Editor is in play mode` results") is met without changing `require_writable`'s signature or touching 102 callsites across the handler tree.

A future PR could add an async live-state verify inside `require_writable` for the case where an agent doesn't call `editor_state` between an external Stop (UI button) and a write — but that's a wider change with its own trade-offs and not on the critical path for the friction reported here.

### Tool description update

`editor_state`'s docstring (in `tools/editor.py`) now spells out the side effect so schema-aware MCP clients see the recovery path:

> Side effect: refreshes the server's session readiness cache from the live editor reply. Useful as a recovery step after a write call is rejected as `EDITOR_NOT_READY (state=playing)` when you already know the game has stopped — calling `editor_state` once syncs the cache and the next write proceeds.

The resource form (`godot://editor/state`) inherits the self-heal automatically — same handler.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `pytest -q` — **673/673 passed** (+8 new tests: 6 unit + 2 integration)
- [x] `script/ci-check-gdscript` — no parse errors
- [x] GDScript suite via `script/ci-godot-tests` — 967/968 passed; 1 pre-existing failure (`plugin_lifecycle.test_verified_old_server_becomes_incompatible_and_blocks_connection`) is the same flake noted on PRs #265, #266, #267, #268, unrelated.
- [x] **Live MCP smoke against headless Godot 4.6.2** — both tool form (`editor_state`) and resource form (`godot://editor/state`) successfully self-heal `session.readiness`. Verified by inspecting `session_manage(op="list")` before and after each call: the live `readiness` field equals the server cache. `editor_state -> scene_save` succeeds end-to-end.

New tests:
- `tests/unit/test_readiness.py` — 6 self-heal unit tests:
  - `test_editor_state_overwrites_stale_playing_cache`
  - `test_editor_state_syncs_playing_when_truly_playing` (bidirectional)
  - `test_editor_state_ignores_missing_readiness_field` (forward-compat with older plugins)
  - `test_editor_state_ignores_unknown_readiness_field` (forward-compat with newer plugins)
  - `test_editor_state_no_session_is_no_op`
  - `test_known_readiness_covers_all_states_handlers_emit` (drift-protection pin)
- `tests/integration/test_websocket.py::TestEditorStateSelfHeal` — 2 end-to-end tests over the real WebSocket harness, both bidirectional.

## Triage notes

Open issue triage at the start of this session (no friction-log entries since 2026-04-19):

- #264 → already in flight (PR #265). Skipped.
- #263 → already in flight (PR #268). Skipped.
- #261 → already in flight (PR #266). Skipped.
- #246 → already in flight (PR #267). Skipped.
- #244 → defense-in-depth follow-up; needs an architectural decision (untype all vs lint-only). Deferred.
- #262 → this PR.

No suitable bundle (4 of 6 open issues already had in-flight PRs; #244 needs design discussion). #262 was the larger bisect-friendly issue still up for grabs.

https://claude.ai/code/session_01Dad6kbc9uHDv7uBqGigZY4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dad6kbc9uHDv7uBqGigZY4)_