### PR TITLE
[codex] Fix self-update orphan server recovery

### DIFF
--- a/plugin/addons/godot_ai/handlers/camera_handler.gd
+++ b/plugin/addons/godot_ai/handlers/camera_handler.gd
@@ -283,7 +283,7 @@ func configure(params: Dictionary) -> Dictionary:
 			if prop_name in _NODE_TRANSFORM_KEYS:
 				msg += (
 					". Transforms live on the Node, not on the camera config — "
-					+ "use node_set_property(path=%s, properties={\"%s\": ...})" % [node_path, prop_name]
+					+ "use node_set_property(path=%s, property=\"%s\", value=...)" % [node_path, prop_name]
 				)
 			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, msg)
 		if prop_name == "current":

--- a/plugin/addons/godot_ai/handlers/camera_handler.gd
+++ b/plugin/addons/godot_ai/handlers/camera_handler.gd
@@ -57,6 +57,14 @@ const _KEYS_3D := [
 	"current",
 ]
 
+# Transform-shaped keys live on Node2D / Node3D, not in the camera-specific
+# schema — rejecting them without a hint sends agents searching for the wrong
+# tool.
+const _NODE_TRANSFORM_KEYS := [
+	"position", "rotation", "scale", "transform",
+	"global_position", "global_rotation", "global_scale", "global_transform",
+]
+
 const _DAMPING_MARGIN_KEYS := ["left", "top", "right", "bottom"]
 const _CURRENT_SETTLE_ATTEMPTS := 3
 const _CURRENT_SETTLE_DELAY_MSEC := 2
@@ -269,12 +277,15 @@ func configure(params: Dictionary) -> Dictionary:
 	for property in properties:
 		var prop_name: String = String(property)
 		if not (prop_name in valid_keys):
-			return McpErrorCodes.make(
-				McpErrorCodes.INVALID_PARAMS,
-				"Property '%s' not valid for %s. Valid: %s" % [
-					prop_name, _VALID_TYPES[type_str], ", ".join(valid_keys)
-				]
-			)
+			var msg := "Property '%s' not valid for %s. Valid: %s" % [
+				prop_name, _VALID_TYPES[type_str], ", ".join(valid_keys)
+			]
+			if prop_name in _NODE_TRANSFORM_KEYS:
+				msg += (
+					". Transforms live on the Node, not on the camera config — "
+					+ "use node_set_property(path=%s, properties={\"%s\": ...})" % [node_path, prop_name]
+				)
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, msg)
 		if prop_name == "current":
 			current_request = bool(properties[prop_name])
 			continue

--- a/plugin/addons/godot_ai/handlers/physics_shape_handler.gd
+++ b/plugin/addons/godot_ai/handlers/physics_shape_handler.gd
@@ -53,12 +53,10 @@ func autofit(params: Dictionary) -> Dictionary:
 	var source_path: String = params.get("source_path", "")
 	var source: Node = null
 	if source_path.is_empty():
-		source = _find_bounds_sibling(node, is_3d)
-		if source == null:
-			return McpErrorCodes.make(
-				McpErrorCodes.INVALID_PARAMS,
-				"No visual sibling found to measure — pass source_path explicitly (e.g. a MeshInstance3D or Sprite2D)"
-			)
+		var search := _find_bounds_visual(node, is_3d, scene_root)
+		if search.has("error"):
+			return search.error
+		source = search.source
 	else:
 		source = McpScenePath.resolve(source_path, scene_root)
 		if source == null:
@@ -133,21 +131,71 @@ func autofit(params: Dictionary) -> Dictionary:
 	}
 
 
-## Find the first sibling of `collision_node` that provides bounds we can
-## measure. For 3D: any VisualInstance3D (MeshInstance3D, CSGShape3D, etc.).
-## For 2D: Sprite2D or TextureRect with an item rect.
-static func _find_bounds_sibling(collision_node: Node, is_3d: bool) -> Node:
+## Returns `{source: Node}` on success, `{error: <error dict>}` on failure.
+## Ambiguous tier-2 matches put candidate scene paths in
+## `error.data.candidates` so callers can pick one explicitly.
+static func _find_bounds_visual(collision_node: Node, is_3d: bool, scene_root: Node) -> Dictionary:
 	var parent := collision_node.get_parent()
 	if parent == null:
-		return null
-	for sibling in parent.get_children():
-		if sibling == collision_node:
+		return {"error": _no_visual_error(is_3d)}
+
+	# Tier 1: direct siblings of the collision shape. Uses the broad
+	# VisualInstance3D filter for backwards compatibility — callers who put
+	# the visual directly next to the collision picked it on purpose.
+	var siblings := _measurable_visuals(parent.get_children(), collision_node, is_3d, false)
+	if not siblings.is_empty():
+		return {"source": siblings[0]}
+
+	# Tier 2: parent siblings (uncles). Tighten the filter to
+	# GeometryInstance3D so we don't auto-pick a Light3D / DirectionalLight3D
+	# as a collision source. Auto-pick only when unambiguous; surface
+	# multiple candidates so the agent chooses.
+	var grandparent := parent.get_parent()
+	if grandparent == null:
+		return {"error": _no_visual_error(is_3d)}
+	var uncles := _measurable_visuals(grandparent.get_children(), parent, is_3d, true)
+	if uncles.size() == 1:
+		return {"source": uncles[0]}
+	if uncles.size() > 1:
+		var paths: Array[String] = []
+		for n in uncles:
+			paths.append(McpScenePath.from_node(n, scene_root))
+		var msg := "Multiple visual candidates near %s — pass source_path explicitly. Candidates: %s" % [
+			McpScenePath.from_node(collision_node, scene_root),
+			", ".join(paths),
+		]
+		var err := McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, msg)
+		err["error"]["data"] = {"candidates": paths}
+		return {"error": err}
+	return {"error": _no_visual_error(is_3d)}
+
+
+## Filter `nodes` for ones we can measure as a collision source. When
+## `strict` is true (tier 2 / uncles) only GeometryInstance3D counts in 3D —
+## avoids picking up lights as accidental sources. 2D filter is already
+## narrow enough that strictness doesn't change behavior.
+static func _measurable_visuals(nodes: Array, exclude: Node, is_3d: bool, strict: bool) -> Array[Node]:
+	var out: Array[Node] = []
+	for n in nodes:
+		if n == exclude:
 			continue
-		if is_3d and sibling is VisualInstance3D:
-			return sibling
-		if not is_3d and (sibling is Sprite2D or sibling is TextureRect):
-			return sibling
-	return null
+		if is_3d:
+			if strict:
+				if n is GeometryInstance3D:
+					out.append(n)
+			elif n is VisualInstance3D:
+				out.append(n)
+		elif n is Sprite2D or n is TextureRect:
+			out.append(n)
+	return out
+
+
+static func _no_visual_error(is_3d: bool) -> Dictionary:
+	var hint := "MeshInstance3D" if is_3d else "Sprite2D"
+	return McpErrorCodes.make(
+		McpErrorCodes.INVALID_PARAMS,
+		"No visual found near collision shape — searched siblings and parent-siblings. Pass source_path explicitly (e.g. a %s)" % hint,
+	)
 
 
 ## Measure the visual bounds of `source`. Returns {aabb: AABB} for 3D or

--- a/plugin/addons/godot_ai/handlers/script_handler.gd
+++ b/plugin/addons/godot_ai/handlers/script_handler.gd
@@ -4,10 +4,17 @@ extends RefCounted
 ## Handles script creation, reading, attaching, detaching, and symbol inspection.
 
 var _undo_redo: EditorUndoRedoManager
+var _connection: McpConnection
+
+# Bounded settle window for `ResourceLoader.exists(path)` after `scan()` so that
+# an agent calling create_script -> attach_script back-to-back doesn't race the
+# editor's import pipeline (#261). Polled once per frame.
+const _IMPORT_SETTLE_MAX_FRAMES := 300  # ~5s at 60fps; bails out and replies anyway.
 
 
-func _init(undo_redo: EditorUndoRedoManager) -> void:
+func _init(undo_redo: EditorUndoRedoManager, connection: McpConnection = null) -> void:
 	_undo_redo = undo_redo
+	_connection = connection
 
 
 func create_script(params: Dictionary) -> Dictionary:
@@ -51,7 +58,36 @@ func create_script(params: Dictionary) -> Dictionary:
 	# `.gd.uid` is the sidecar Godot generates on scan; list both so the caller
 	# can rm the full set in one go.
 	McpResourceIO.attach_cleanup_hint(data, existed_before, [path, path + ".uid"])
+
+	# scan() is async — ResourceLoader.exists(path) returns false until Godot's
+	# filesystem pipeline finishes. If we reply now, an immediate attach_script
+	# races and 404s (#261). Defer the response until the resource is visible
+	# (or a bounded timeout elapses). For freshly-created files we wait; on
+	# overwrite the resource was already known to ResourceLoader, so reply now.
+	var request_id: String = params.get("_request_id", "")
+	if not existed_before and _connection != null and not request_id.is_empty():
+		_finish_create_script_deferred(request_id, path, data)
+		return McpDispatcher.DEFERRED_RESPONSE
+
+	# Synchronous fallback: batch_execute (no request_id) and unit-test contexts
+	# (no connection) get the immediate reply that the previous behaviour gave.
 	return {"data": data}
+
+
+func _finish_create_script_deferred(request_id: String, path: String, data: Dictionary) -> void:
+	var tree := _connection.get_tree()
+	var frames := 0
+	while frames < _IMPORT_SETTLE_MAX_FRAMES and not ResourceLoader.exists(path):
+		await tree.process_frame
+		frames += 1
+	# If the plugin tears down (_exit_tree frees _connection) during the await,
+	# is_instance_valid() goes false and we drop the response silently — the
+	# server's request timeout will surface the failure to the caller.
+	if not is_instance_valid(_connection):
+		return
+	var payload := data.duplicate()
+	payload["import_settled"] = frames < _IMPORT_SETTLE_MAX_FRAMES
+	_connection.send_deferred_response(request_id, {"data": payload})
 
 
 func read_script(params: Dictionary) -> Dictionary:

--- a/plugin/addons/godot_ai/handlers/ui_handler.gd
+++ b/plugin/addons/godot_ai/handlers/ui_handler.gd
@@ -88,9 +88,12 @@ func set_anchor_preset(params: Dictionary) -> Dictionary:
 	if node == null:
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, McpScenePath.format_node_error(node_path, scene_root))
 	if not node is Control:
+		var got_class: String = node.get_class()
 		return McpErrorCodes.make(
 			McpErrorCodes.INVALID_PARAMS,
-			"Node %s is not a Control (got %s)" % [node_path, node.get_class()]
+			"Node %s is not a Control (got %s)%s" % [
+				node_path, got_class, _canvas_layer_overlay_hint(got_class)
+			]
 		)
 
 	var control := node as Control
@@ -307,7 +310,12 @@ func _build_subtree(spec: Dictionary) -> Dictionary:
 				return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "theme path must point to a Theme resource: %s" % theme_path)
 			if not node is Control and not node is Window:
 				node.free()
-				return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "theme can only be set on Control / Window (got %s)" % node_type)
+				return McpErrorCodes.make(
+					McpErrorCodes.INVALID_PARAMS,
+					"theme can only be set on Control / Window (got %s)%s" % [
+						node_type, _canvas_layer_overlay_hint(node_type)
+					]
+				)
 			node.theme = theme_res as Theme
 
 	# Anchor preset — applied before children so children inherit sensible anchors.
@@ -318,7 +326,12 @@ func _build_subtree(spec: Dictionary) -> Dictionary:
 			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Unknown anchor_preset: %s" % preset_name)
 		if not node is Control:
 			node.free()
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "anchor_preset requires a Control (got %s)" % node_type)
+			return McpErrorCodes.make(
+				McpErrorCodes.INVALID_PARAMS,
+				"anchor_preset requires a Control (got %s)%s" % [
+					node_type, _canvas_layer_overlay_hint(node_type)
+				]
+			)
 		var preset_value: int = _PRESETS[preset_name]
 		var margin: int = int(spec.get("anchor_margin", 0))
 		(node as Control).set_anchors_and_offsets_preset(preset_value, Control.PRESET_MODE_MINSIZE, margin)
@@ -500,3 +513,16 @@ static func _coerce_for_type(value: Variant, prop_type: int) -> Dictionary:
 				return {"ok": true, "value": NodePath(value)}
 			return {"ok": false}
 	return {"ok": true, "value": value}
+
+
+# CanvasLayer is the canonical HUD parent but isn't a Control, so applying
+# Control-only properties (theme, anchor_preset) to it is a common mistake.
+# The recovery shape is always the same: nest a Control child under the layer.
+static func _canvas_layer_overlay_hint(node_class: String) -> String:
+	if node_class != "CanvasLayer":
+		return ""
+	return (
+		". CanvasLayer is not a Control — add a Control (e.g. Panel or Control "
+		+ "with anchor_preset=full_rect) as its child and apply theme / "
+		+ "anchor_preset to that overlay."
+	)

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -1046,12 +1046,17 @@ func _refresh_server_version_label() -> void:
 			color = COLOR_AMBER
 		else:
 			text = "godot-ai == %s  (expected %s)" % [server_ver, expected_ver]
-			color = Color.RED if server_status.get("state", "") == McpSpawnState.INCOMPATIBLE_SERVER else COLOR_AMBER
-			show_restart = (
-				server_status.get("state", "") != McpSpawnState.INCOMPATIBLE_SERVER
-				and _plugin != null
+			var is_incompatible: bool = server_status.get("state", "") == McpSpawnState.INCOMPATIBLE_SERVER
+			color = Color.RED if is_incompatible else COLOR_AMBER
+			var has_managed_proof: bool = (
+				_plugin != null
 				and _plugin.has_method("can_restart_managed_server")
 				and _plugin.can_restart_managed_server()
+			)
+			var can_recover: bool = bool(server_status.get("can_recover_incompatible", false))
+			show_restart = (
+				(not is_incompatible and has_managed_proof)
+				or (is_incompatible and can_recover)
 			)
 	if text == _last_rendered_server_text:
 		_setup_server_label.add_theme_color_override("font_color", color)
@@ -1066,7 +1071,17 @@ func _refresh_server_version_label() -> void:
 
 
 func _on_restart_stale_server() -> void:
-	if _plugin != null and _plugin.has_method("force_restart_server"):
+	if _plugin == null:
+		return
+	var status: Dictionary = (
+		_plugin.get_server_status()
+		if _plugin.has_method("get_server_status")
+		else {}
+	)
+	if str(status.get("state", "")) == McpSpawnState.INCOMPATIBLE_SERVER:
+		if _plugin.has_method("recover_incompatible_server"):
+			_plugin.recover_incompatible_server()
+	elif _plugin.has_method("force_restart_server"):
 		_plugin.force_restart_server()
 
 

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -116,8 +116,10 @@ var _refresh_retried: bool = false
 var _adoption_watch_deadline_ms: int = 0
 var _server_expected_version := ""
 var _server_actual_version := ""
+var _server_actual_name := ""
 var _server_status_message := ""
 var _server_dev_version_mismatch_allowed := false
+var _can_recover_incompatible := false
 var _connection_blocked := false
 var _awaiting_server_version := false
 var _server_version_deadline_ms: int = 0
@@ -489,7 +491,7 @@ func _start_server() -> void:
 			_resolve_ws_port()
 		))
 		ws_port = _resolved_ws_port
-		var live := _probe_live_server_status(port)
+		var live := _probe_live_server_status_for_port(port)
 		var live_version := _verified_status_version(live)
 		var live_ws_port := _verified_status_ws_port(live)
 		var compatibility := _server_status_compatibility(
@@ -500,7 +502,9 @@ func _start_server() -> void:
 			McpClientConfigurator.is_dev_checkout()
 		)
 		if compatibility.get("compatible", false):
+			_server_actual_name = "godot-ai"
 			_server_actual_version = live_version
+			_can_recover_incompatible = false
 			_server_dev_version_mismatch_allowed = bool(compatibility.get("dev_mismatch_allowed", false))
 			if _server_dev_version_mismatch_allowed:
 				_server_status_message = (
@@ -519,16 +523,28 @@ func _start_server() -> void:
 			return
 		if _managed_record_has_version_drift(record_version, current_version):
 			## Version drift — our server but the plugin moved on. Kill
-			## the port owner (not the stale launcher PID) and respawn
-			## to match the current plugin version.
+			## the proved managed occupant and respawn only after the port
+			## is actually free. A stale record by itself is not enough to
+			## kill the process currently holding the port.
 			print("MCP | managed server v%s does not match plugin v%s, restarting"
 				% [record_version, current_version])
-			var owner := _find_managed_pid(port)
-			if owner > 0:
-				OS.kill(owner)
+			var proof := _evaluate_strong_port_occupant_proof(port)
+			var targets: Array[int] = []
+			targets.assign(proof.get("pids", []))
+			if targets.is_empty():
+				_server_started_this_session = true
+				_set_incompatible_server(live, current_version, port)
+				push_warning(_server_status_message)
+				return
+			_kill_processes_and_windows_spawn_children(targets)
+			_wait_for_port_free(port, 3.0)
+			if _is_port_in_use(port):
+				_server_started_this_session = true
+				_set_incompatible_server(_probe_live_server_status_for_port(port), current_version, port)
+				push_warning(_server_status_message)
+				return
 			_clear_managed_server_record()
 			_clear_pid_file()
-			_wait_for_port_free(port, 3.0)
 			## Fall through to spawn.
 		else:
 			## No recorded version drift and the live status probe did not
@@ -605,9 +621,12 @@ func _set_incompatible_server(live: Dictionary, expected_version: String, port: 
 	_spawn_state = McpSpawnState.INCOMPATIBLE_SERVER
 	_connection_blocked = true
 	_server_expected_version = expected_version
+	_server_actual_name = str(live.get("name", ""))
 	_server_actual_version = _live_version_for_message(live)
 	_server_dev_version_mismatch_allowed = false
 	_server_status_message = _incompatible_server_message(live, expected_version, port, _resolved_ws_port)
+	var proof := _evaluate_recovery_port_occupant_proof(port)
+	_can_recover_incompatible = not str(proof.get("proof", "")).is_empty()
 	_refresh_dock_client_statuses()
 
 
@@ -706,7 +725,9 @@ static func _probe_live_server_status(port: int, timeout_ms: int = SERVER_STATUS
 	var body := PackedByteArray()
 	while true:
 		var status := client.get_status()
-		if status == HTTPClient.STATUS_REQUESTING or status == HTTPClient.STATUS_BODY:
+		if status == HTTPClient.STATUS_REQUESTING:
+			client.poll()
+		elif status == HTTPClient.STATUS_BODY:
 			client.poll()
 			var chunk := client.read_response_body_chunk()
 			if chunk.size() > 0:
@@ -736,6 +757,10 @@ static func _probe_live_server_status(port: int, timeout_ms: int = SERVER_STATUS
 	return result
 
 
+func _probe_live_server_status_for_port(port: int) -> Dictionary:
+	return _probe_live_server_status(port)
+
+
 static func _extract_server_version(payload: Dictionary) -> String:
 	var version := str(payload.get("server_version", ""))
 	if version.is_empty():
@@ -743,14 +768,18 @@ static func _extract_server_version(payload: Dictionary) -> String:
 	return version
 
 
+static func _live_status_identifies_godot_ai(live: Dictionary) -> bool:
+	return str(live.get("name", "")) == "godot-ai"
+
+
 static func _verified_status_version(live: Dictionary) -> String:
-	if str(live.get("name", "")) != "godot-ai":
+	if not _live_status_identifies_godot_ai(live):
 		return ""
 	return str(live.get("version", ""))
 
 
 static func _verified_status_ws_port(live: Dictionary) -> int:
-	if str(live.get("name", "")) != "godot-ai":
+	if not _live_status_identifies_godot_ai(live):
 		return 0
 	return int(live.get("ws_port", 0))
 
@@ -843,6 +872,7 @@ func _on_connection_established() -> void:
 func _on_server_version_verified(version: String) -> void:
 	_awaiting_server_version = false
 	_server_version_deadline_ms = 0
+	_server_actual_name = "godot-ai"
 	_server_actual_version = version
 	var expected := _server_expected_version
 	if expected.is_empty():
@@ -854,6 +884,7 @@ func _on_server_version_verified(version: String) -> void:
 		McpClientConfigurator.is_dev_checkout()
 	)
 	if compatibility.get("compatible", false):
+		_can_recover_incompatible = false
 		_server_dev_version_mismatch_allowed = bool(compatibility.get("dev_mismatch_allowed", false))
 		if _server_dev_version_mismatch_allowed:
 			_server_status_message = (
@@ -1021,10 +1052,12 @@ func get_server_status() -> Dictionary:
 	return {
 		"state": _spawn_state,
 		"exit_ms": _server_exit_ms,
+		"actual_name": _server_actual_name,
 		"actual_version": _server_actual_version,
 		"expected_version": _server_expected_version,
 		"message": _server_status_message,
 		"dev_version_mismatch_allowed": _server_dev_version_mismatch_allowed,
+		"can_recover_incompatible": _can_recover_incompatible,
 		"connection_blocked": _connection_blocked,
 	}
 
@@ -1092,6 +1125,8 @@ static func _resolve_ws_port_from_output(
 func _is_port_in_use(port: int) -> bool:
 	var output: Array = []
 	if OS.get_name() == "Windows":
+		if not _find_listener_pids_windows(port).is_empty():
+			return true
 		var exit_code := OS.execute("netstat", ["-ano"], output, true)
 		if exit_code == 0 and output.size() > 0:
 			return _parse_windows_netstat_listening(str(output[0]), port)
@@ -1115,6 +1150,9 @@ func _is_port_in_use(port: int) -> bool:
 func _find_pid_on_port(port: int) -> int:
 	var output: Array = []
 	if OS.get_name() == "Windows":
+		var listener_pids := _find_listener_pids_windows(port)
+		if not listener_pids.is_empty():
+			return listener_pids[0]
 		var exit_code := OS.execute("netstat", ["-ano"], output, true)
 		if exit_code != 0 or output.is_empty():
 			return 0
@@ -1138,6 +1176,9 @@ func _find_pid_on_port(port: int) -> int:
 ## listener rows for the same port, so collect every matching row there too.
 func _find_all_pids_on_port(port: int) -> Array[int]:
 	if OS.get_name() == "Windows":
+		var listener_pids := _find_listener_pids_windows(port)
+		if not listener_pids.is_empty():
+			return listener_pids
 		var output: Array = []
 		var exit_code := OS.execute("netstat", ["-ano"], output, true)
 		if exit_code != 0 or output.is_empty():
@@ -1150,6 +1191,33 @@ func _find_all_pids_on_port(port: int) -> Array[int]:
 		var empty: Array[int] = []
 		return empty
 	return _parse_lsof_pids(str(output[0]))
+
+
+static func _find_listener_pids_windows(port: int) -> Array[int]:
+	var script := (
+		"Get-NetTCPConnection -LocalPort %d -State Listen "
+		+ "-ErrorAction SilentlyContinue | "
+		+ "Select-Object -ExpandProperty OwningProcess"
+	) % port
+	var output: Array = []
+	var exit_code := OS.execute(
+		"powershell.exe",
+		["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script],
+		output,
+		true
+	)
+	return _windows_listener_pids_from_execute_result(exit_code, output)
+
+
+static func _windows_listener_pids_from_execute_result(exit_code: int, output: Array) -> Array[int]:
+	var empty: Array[int] = []
+	if exit_code == 0 and not output.is_empty():
+		return _parse_pid_lines(str(output[0]))
+	return empty
+
+
+static func _windows_listener_execute_result_in_use(exit_code: int, output: Array) -> bool:
+	return not _windows_listener_pids_from_execute_result(exit_code, output).is_empty()
 
 
 ## Pure-parser for the `lsof -ti...` output shape: zero or more newline-
@@ -1188,6 +1256,75 @@ func _find_managed_pid(port: int) -> int:
 	if pid > 0 and _pid_alive(pid):
 		return pid
 	return _find_pid_on_port(port)
+
+
+func _evaluate_strong_port_occupant_proof(port: int) -> Dictionary:
+	var result := {"proof": "", "pids": []}
+	var listener_pids := _find_all_pids_on_port(port)
+	if listener_pids.is_empty():
+		return result
+
+	var record := _read_managed_server_record()
+	var record_pid := int(record.get("pid", 0))
+	var record_version := str(record.get("version", ""))
+
+	if record_pid > 1 and record_pid != OS.get_process_id():
+		if listener_pids.has(record_pid) and _pid_alive_for_proof(record_pid):
+			return {"proof": "managed_record", "pids": [record_pid]}
+
+	var legacy_targets := _legacy_pidfile_kill_targets(port, listener_pids)
+	if not legacy_targets.is_empty():
+		return {"proof": "pidfile_listener", "pids": legacy_targets}
+
+	var live := _probe_live_server_status_for_port(port)
+	if (
+		_live_status_identifies_godot_ai(live)
+		and not record_version.is_empty()
+		and str(live.get("version", "")) == record_version
+	):
+		return {"proof": "status_matches_record", "pids": listener_pids}
+
+	return result
+
+
+func _evaluate_recovery_port_occupant_proof(port: int) -> Dictionary:
+	var proof := _evaluate_strong_port_occupant_proof(port)
+	if not str(proof.get("proof", "")).is_empty():
+		return proof
+
+	var live := _probe_live_server_status_for_port(port)
+	if _live_status_identifies_godot_ai(live):
+		return {"proof": "status_name", "pids": _find_all_pids_on_port(port)}
+
+	return {"proof": "", "pids": []}
+
+
+func _legacy_pidfile_kill_targets(_port: int, listener_pids: Array[int]) -> Array[int]:
+	var targets: Array[int] = []
+	var pidfile_pid := _read_pid_file_for_proof()
+	if pidfile_pid <= 1 or pidfile_pid == OS.get_process_id():
+		return targets
+	if not listener_pids.has(pidfile_pid) or not _pid_alive_for_proof(pidfile_pid):
+		return targets
+	if not _pid_cmdline_is_godot_ai_for_proof(pidfile_pid):
+		return targets
+
+	for pid in listener_pids:
+		if pid > 1 and pid != OS.get_process_id() and _pid_cmdline_is_godot_ai_for_proof(pid):
+			targets.append(pid)
+	return targets
+
+
+func _read_pid_file_for_proof() -> int:
+	return _read_pid_file()
+
+
+func _pid_alive_for_proof(pid: int) -> bool:
+	return _pid_alive(pid)
+
+
+func _pid_cmdline_is_godot_ai_for_proof(pid: int) -> bool:
+	return _pid_cmdline_is_godot_ai(pid)
 
 
 ## Parse the LISTENING line for `port` in a Windows `netstat -ano`
@@ -1354,6 +1491,36 @@ static func _build_server_flags(port: int, ws_port: int) -> Array[String]:
 	return flags
 
 
+func _pid_cmdline_is_godot_ai(pid: int) -> bool:
+	if OS.get_name() != "Windows":
+		return true
+	return _commandline_is_godot_ai_server(_windows_pid_commandline(pid))
+
+
+static func _commandline_is_godot_ai_server(cmd: String) -> bool:
+	var lower := cmd.to_lower()
+	var has_brand := lower.find("godot-ai") >= 0 or lower.find("godot_ai") >= 0
+	var has_flag := lower.find("--pid-file") >= 0 or lower.find("--transport") >= 0
+	return has_brand and has_flag
+
+
+func _windows_pid_commandline(pid: int) -> String:
+	var output: Array = []
+	var script := (
+		"Get-CimInstance Win32_Process -Filter \"ProcessId = %d\" | "
+		+ "Select-Object -ExpandProperty CommandLine"
+	) % pid
+	var exit_code := OS.execute(
+		"powershell.exe",
+		["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script],
+		output,
+		true
+	)
+	if exit_code != 0 or output.is_empty():
+		return ""
+	return str(output[0])
+
+
 ## True if the given PID corresponds to a live (non-zombie) process.
 ## POSIX uses `ps -o stat=` (see inline comment for the zombie rationale);
 ## Windows uses `tasklist`. Called by `_start_server` to distinguish a live
@@ -1448,9 +1615,29 @@ func _clear_managed_server_record() -> void:
 func prepare_for_update_reload() -> void:
 	_stop_server()
 	_server_started_this_session = false
+	if McpClientConfigurator.is_dev_checkout():
+		return
+
+	var port := McpClientConfigurator.http_port()
+	if not _is_port_in_use(port):
+		return
+
+	var proof := _evaluate_strong_port_occupant_proof(port)
+	var targets: Array[int] = []
+	targets.assign(proof.get("pids", []))
+	if targets.is_empty():
+		return
+
+	_kill_processes_and_windows_spawn_children(targets)
+	_wait_for_port_free(port, 3.0)
+	if not _is_port_in_use(port):
+		_clear_managed_server_record()
+		_clear_pid_file()
 
 
 func _adopt_compatible_server(record_version: String, current_version: String, owner: int) -> String:
+	_server_actual_name = "godot-ai"
+	_can_recover_incompatible = false
 	if record_version == current_version and owner > 0:
 		_server_pid = owner
 		_write_managed_server_record(owner, current_version)
@@ -1485,6 +1672,47 @@ func install_downloaded_update(zip_path: String, temp_dir: String, source_dock: 
 	runner.start(zip_path, temp_dir, detached_dock)
 
 
+func can_recover_incompatible_server() -> bool:
+	if _spawn_state != McpSpawnState.INCOMPATIBLE_SERVER:
+		return false
+	var port := McpClientConfigurator.http_port()
+	if not _is_port_in_use(port):
+		return false
+	var proof := _evaluate_recovery_port_occupant_proof(port)
+	return not str(proof.get("proof", "")).is_empty()
+
+
+func recover_incompatible_server() -> bool:
+	if _spawn_state != McpSpawnState.INCOMPATIBLE_SERVER:
+		return false
+
+	var port := McpClientConfigurator.http_port()
+	var proof := _evaluate_recovery_port_occupant_proof(port)
+	var targets: Array[int] = []
+	targets.assign(proof.get("pids", []))
+	if targets.is_empty():
+		return false
+
+	_kill_processes_and_windows_spawn_children(targets)
+	_wait_for_port_free(port, 5.0)
+	if _is_port_in_use(port):
+		return false
+
+	UvCacheCleanup.purge_stale_builds()
+	_clear_managed_server_record()
+	_clear_pid_file()
+	_spawn_state = McpSpawnState.OK
+	_connection_blocked = false
+	_server_status_message = ""
+	_server_actual_version = ""
+	_server_actual_name = ""
+	_can_recover_incompatible = false
+	_server_started_this_session = false
+	_server_pid = -1
+	_start_server()
+	return true
+
+
 ## Kill whichever process is holding `http_port()` right now — by resolving
 ## the port-owning PID via pid-file / netstat / lsof, independent of whether
 ## we ever set `_server_pid` — then clear ownership state and respawn via
@@ -1505,15 +1733,22 @@ func force_restart_server() -> void:
 	## if the single-pid parse fell over on multi-line lsof output) leaves
 	## the other holding the port past `_wait_for_port_free`'s window.
 	_kill_processes_and_windows_spawn_children(_find_all_pids_on_port(port))
-	_clear_managed_server_record()
-	_clear_pid_file()
 	_wait_for_port_free(port, 5.0)
+	if _is_port_in_use(port):
+		_set_incompatible_server(
+			_probe_live_server_status_for_port(port),
+			McpClientConfigurator.get_plugin_version(),
+			port
+		)
+		return
 	## Same rationale as `_stop_server`: the server child python just
 	## released its `pydantic_core` mapping, so this is the only window in
 	## which the hard-linked copies under `builds-v0\.tmp*` are deletable.
 	## Sweep before respawning so the upcoming `uvx mcp-proxy` build doesn't
 	## inherit the same cleanup-failure path that triggered the restart.
 	UvCacheCleanup.purge_stale_builds()
+	_clear_managed_server_record()
+	_clear_pid_file()
 	_server_started_this_session = false
 	_server_pid = -1
 	_start_server()

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -159,7 +159,7 @@ func _enter_tree() -> void:
 	var node_handler := NodeHandler.new(get_undo_redo())
 	var project_handler := ProjectHandler.new(_connection)
 	var client_handler := ClientHandler.new()
-	var script_handler := ScriptHandler.new(get_undo_redo())
+	var script_handler := ScriptHandler.new(get_undo_redo(), _connection)
 	var resource_handler := ResourceHandler.new(get_undo_redo())
 	var filesystem_handler := FilesystemHandler.new()
 	var signal_handler := SignalHandler.new(get_undo_redo())

--- a/plugin/addons/godot_ai/utils/uv_cache_cleanup.gd.uid
+++ b/plugin/addons/godot_ai/utils/uv_cache_cleanup.gd.uid
@@ -1,0 +1,1 @@
+uid://d33ukg65qf7q0

--- a/src/godot_ai/handlers/_readiness.py
+++ b/src/godot_ai/handlers/_readiness.py
@@ -14,6 +14,29 @@ _READINESS_INFO: dict[str, tuple[str, bool]] = {
     "playing": ("Editor is in play mode — call project_stop to stop the game, then retry", False),
 }
 
+# Every readiness value the plugin can emit. Derived from the blocking-state
+# table plus "ready" / "no_scene" so the canonical list can't drift. Used by
+# handlers that copy a live readiness snapshot (editor_state's response,
+# project_stop's readiness_after) onto session.readiness — guards against
+# the plugin inventing an unknown state and the cache trusting it.
+KNOWN_READINESS: frozenset[str] = frozenset(_READINESS_INFO) | {"ready", "no_scene"}
+
+
+def sync_readiness_from_snapshot(runtime: Runtime, value: object) -> bool:
+    """Copy an authoritative readiness snapshot onto the active session.
+
+    Used by handlers that receive a live readiness from the plugin
+    (`editor_state`'s reply, `project_stop`'s `readiness_after`). Returns
+    True if the cache was updated, False if there's no active session or
+    the snapshot wasn't a recognized readiness value (forward-compat: a
+    newer plugin sending an unknown state is ignored, not propagated).
+    """
+    session = runtime.get_active_session()
+    if session is None or value not in KNOWN_READINESS:
+        return False
+    session.readiness = value  # type: ignore[assignment]
+    return True
+
 
 def require_writable(runtime: Runtime) -> None:
     """Check that the active session is in a writable state.

--- a/src/godot_ai/handlers/editor.py
+++ b/src/godot_ai/handlers/editor.py
@@ -9,7 +9,7 @@ import logging
 from fastmcp.tools.base import Image as McpImage
 from mcp.types import TextContent
 
-from godot_ai.handlers._readiness import require_writable
+from godot_ai.handlers._readiness import require_writable, sync_readiness_from_snapshot
 from godot_ai.runtime.interface import Runtime
 from godot_ai.sessions.registry import Session
 from godot_ai.tools._pagination import paginate
@@ -18,7 +18,26 @@ logger = logging.getLogger(__name__)
 
 
 async def editor_state(runtime: Runtime) -> dict:
-    return await runtime.send_command("get_editor_state")
+    """Read live editor state and self-heal the session readiness cache.
+
+    The plugin emits ``readiness_changed`` events when ``_check_state_changes``
+    notices a transition, but ``_process`` is paused around save/play frames
+    (see ``McpConnection.pause_processing``), so the event can lag actual state
+    by one or more ticks. During that window the server's ``session.readiness``
+    cache stays at the previous value and a write call gated by
+    ``require_writable`` is rejected even though the editor is already
+    writeable. Issue #262 reproduced exactly that with an ``editor_state ->
+    scene_save`` sequence: editor_state returned ``is_playing: false`` while
+    the cache still said ``playing``, blocking the save.
+
+    The plugin's ``get_editor_state`` reads ``EditorInterface.is_playing_scene``
+    and ``McpConnection.get_readiness`` directly, so its ``readiness`` field is
+    authoritative. Copy it onto the session so a subsequent ``require_writable``
+    can't disagree with the value the agent just observed.
+    """
+    result = await runtime.send_command("get_editor_state")
+    sync_readiness_from_snapshot(runtime, result.get("readiness"))
+    return result
 
 
 async def editor_selection_get(runtime: Runtime) -> dict:

--- a/src/godot_ai/handlers/project.py
+++ b/src/godot_ai/handlers/project.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-from godot_ai.handlers._readiness import require_writable
+from godot_ai.handlers._readiness import require_writable, sync_readiness_from_snapshot
 from godot_ai.runtime.interface import Runtime
-
-_KNOWN_READINESS = frozenset({"ready", "importing", "playing", "no_scene"})
 
 COMMON_SETTINGS = [
     "application/config/name",
@@ -57,13 +55,11 @@ async def project_stop(runtime: Runtime) -> dict:
     EDITOR_NOT_READY.
     """
     result = await runtime.send_command("stop_project")
-    session = runtime.get_active_session()
-    if session is None:
+    if sync_readiness_from_snapshot(runtime, result.get("readiness_after")):
         return result
 
-    readiness_after = result.get("readiness_after")
-    if readiness_after in _KNOWN_READINESS:
-        session.readiness = readiness_after
+    session = runtime.get_active_session()
+    if session is None:
         return result
 
     loop = asyncio.get_running_loop()

--- a/src/godot_ai/tools/camera.py
+++ b/src/godot_ai/tools/camera.py
@@ -23,9 +23,12 @@ Ops:
         Create a Camera2D ("2d") or Camera3D ("3d"). When make_current=True,
         unmarks previously current cameras of the same class in one undo.
   • configure(camera_path, properties)
-        Batch-set properties. Class-aware. Enum-by-name (projection,
-        keep_aspect, anchor_mode, doppler_tracking, process_callback).
-        Vector2 dict coercion for zoom/offset.
+        Batch-set camera-specific properties (zoom, fov, projection, smoothing,
+        drag, limits …). Class-aware. Enum-by-name (projection, keep_aspect,
+        anchor_mode, doppler_tracking, process_callback). Vector2 dict
+        coercion for zoom/offset. Transforms (position, rotation, scale,
+        transform, global_*) live on the Node — set those via
+        node_set_property, not here.
   • set_limits_2d(camera_path, left?, right?, top?, bottom?, smoothed?)
         Set Camera2D bounds. Pass only the edges to change.
   • set_damping_2d(camera_path, position_speed?, rotation_speed?,

--- a/src/godot_ai/tools/editor.py
+++ b/src/godot_ai/tools/editor.py
@@ -46,6 +46,12 @@ def register_editor_tools(mcp: FastMCP, *, include_non_core: bool = True) -> Non
         Also reachable as ``editor_manage(op="state")`` (same handler) for clients
         that prefer a single rolled-up tool.
 
+        Side effect: refreshes the server's session readiness cache from the
+        live editor reply. Useful as a recovery step after a write call is
+        rejected as ``EDITOR_NOT_READY (state=playing)`` when you already know
+        the game has stopped — calling ``editor_state`` once syncs the cache
+        and the next write proceeds. Issue #262.
+
         Args:
             session_id: Optional Godot session to target. Empty = active session.
         """

--- a/src/godot_ai/tools/resource.py
+++ b/src/godot_ai/tools/resource.py
@@ -45,8 +45,11 @@ Ops:
         Build Environment + Sky chain. Presets: default | clear | sunset
         | night | fog. Either assign to a WorldEnvironment node or save .tres.
   • physics_shape_autofit(path, source_path="", shape_type="")
-        Size a CollisionShape2D/3D to a sibling visual's bounds. Auto-creates
-        the concrete Shape subclass if needed.
+        Size a CollisionShape2D/3D to a nearby visual's bounds. Searches
+        direct siblings then parent-siblings (handles nested
+        Body→Collision layouts). Ambiguous matches return candidate paths
+        in error.data.candidates. Auto-creates the concrete Shape subclass
+        if needed.
   • gradient_texture_create(stops, width=256, height=1, fill="linear",
                               path="", property="", resource_path="",
                               overwrite=False)

--- a/src/godot_ai/tools/ui.py
+++ b/src/godot_ai/tools/ui.py
@@ -22,6 +22,9 @@ Ops:
         center_bottom | center | left_wide | top_wide | right_wide |
         bottom_wide | vcenter_wide | hcenter_wide | full_rect.
         resize_mode: minsize | keep_width | keep_height | keep_size.
+        Target must be a Control. CanvasLayer is the canonical HUD parent
+        but is not a Control — put a Control child under the CanvasLayer and
+        apply the preset to that overlay.
   • set_text(path, text)
         Set text on a Label/Button/LineEdit/TextEdit/RichTextLabel.
   • build_layout(tree, parent_path="")
@@ -32,6 +35,9 @@ Ops:
         container spacing live under `theme_override_constants/<name>` —
         e.g. `{"theme_override_constants/separation": 8}` on a
         VBoxContainer, not `{"separation": 8}` (which errors).
+        `theme` and `anchor_preset` require a Control / Window — for a HUD,
+        nest a Control under a CanvasLayer and apply them to the Control
+        child, not the layer itself.
   • draw_recipe(path, ops, clear_existing=True)
         Attach a declarative list of vector _draw() ops to a Control —
         radar sweeps, gauges, corner brackets, crosshairs, waveforms.

--- a/test_project/tests/test_camera.gd
+++ b/test_project/tests/test_camera.gd
@@ -190,6 +190,25 @@ func test_configure_empty_dict() -> void:
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 
 
+func test_configure_transform_key_suggests_node_set_property() -> void:
+	# Transform-shaped keys live on the Node, not in the camera config schema.
+	# Rejecting them must point at node_set_property explicitly — otherwise
+	# an agent falls back to fuzzy-matching the listed camera keys.
+	var r := _create("RejectPos", "3d")
+	if r.is_empty():
+		assert_true(false, "No scene open")
+		return
+	for bad_key in ["position", "rotation", "scale", "transform", "global_position"]:
+		var result := _handler.configure({
+			"camera_path": r.data.path,
+			"properties": {bad_key: 0},
+		})
+		assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+		assert_contains(result.error.message, "node_set_property",
+			"Rejecting camera_configure(%s) should suggest node_set_property" % bad_key)
+		assert_contains(result.error.message, bad_key)
+
+
 func test_configure_current_sibling_unmark_single_undo() -> void:
 	var first := _create("UndoFirst", "2d", true)
 	if first.is_empty():

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -8,6 +8,26 @@ extends McpTestSuite
 const McpDockScript = preload("res://addons/godot_ai/mcp_dock.gd")
 const GodotAiPlugin := preload("res://addons/godot_ai/plugin.gd")
 
+class _RestartDispatchPlugin extends GodotAiPlugin:
+	var status: Dictionary = {}
+	var can_restart := false
+	var force_restart_calls := 0
+	var recover_calls := 0
+
+	func get_server_status() -> Dictionary:
+		return status.duplicate()
+
+	func can_restart_managed_server() -> bool:
+		return can_restart
+
+	func force_restart_server() -> void:
+		force_restart_calls += 1
+
+	func recover_incompatible_server() -> bool:
+		recover_calls += 1
+		return true
+
+
 var _dock: Node
 
 
@@ -116,8 +136,12 @@ func test_incompatible_server_marks_clients_unhealthy() -> void:
 	## server with an incompatible tool surface. The dock must not show green
 	## client rows while the plugin has blocked server adoption.
 	_dock._build_ui()
-	var plugin := GodotAiPlugin.new()
-	plugin._set_incompatible_server({"version": "1.2.10"}, "2.2.0", 8000)
+	var plugin := _RestartDispatchPlugin.new()
+	plugin.status = {
+		"state": McpSpawnState.INCOMPATIBLE_SERVER,
+		"message": "Port 8000 is occupied by godot-ai server v1.2.10; plugin expects v2.2.0.",
+		"connection_blocked": true,
+	}
 	_dock._plugin = plugin
 
 	var any_id := McpClientConfigurator.client_ids()[0]
@@ -357,6 +381,58 @@ func test_server_version_label_repaints_color_when_state_changes_without_text_ch
 	_dock._plugin = null
 	plugin.free()
 	_cleanup_server_row(conn)
+
+
+func test_server_version_label_shows_restart_for_recoverable_incompatible_server() -> void:
+	var conn := _seed_server_row("1.2.3-stale-for-test")
+	var plugin := _RestartDispatchPlugin.new()
+	plugin.status = {
+		"state": McpSpawnState.INCOMPATIBLE_SERVER,
+		"actual_version": "1.2.3-stale-for-test",
+		"expected_version": "2.2.0",
+		"can_recover_incompatible": true,
+	}
+	_dock._plugin = plugin
+
+	_dock._refresh_server_version_label()
+	assert_true(
+		_dock._version_restart_btn.visible,
+		"recoverable incompatible godot-ai server should offer the user-confirmed restart"
+	)
+
+	_dock._plugin = null
+	plugin.free()
+	_cleanup_server_row(conn)
+
+
+func test_restart_dispatches_incompatible_state_to_recovery() -> void:
+	var plugin := _RestartDispatchPlugin.new()
+	plugin.status = {"state": McpSpawnState.INCOMPATIBLE_SERVER}
+	_dock._plugin = plugin
+
+	_dock._on_restart_stale_server()
+	var recover_calls := plugin.recover_calls
+	var restart_calls := plugin.force_restart_calls
+	_dock._plugin = null
+	plugin.free()
+
+	assert_eq(recover_calls, 1)
+	assert_eq(restart_calls, 0)
+
+
+func test_restart_dispatches_non_incompatible_state_to_force_restart() -> void:
+	var plugin := _RestartDispatchPlugin.new()
+	plugin.status = {"state": McpSpawnState.OK}
+	_dock._plugin = plugin
+
+	_dock._on_restart_stale_server()
+	var recover_calls := plugin.recover_calls
+	var restart_calls := plugin.force_restart_calls
+	_dock._plugin = null
+	plugin.free()
+
+	assert_eq(recover_calls, 0)
+	assert_eq(restart_calls, 1)
 
 
 func test_dev_checkout_tooltip_exposes_symlink_target() -> void:

--- a/test_project/tests/test_netstat_parser.gd
+++ b/test_project/tests/test_netstat_parser.gd
@@ -170,6 +170,21 @@ func test_parse_pid_lines_ignores_noise_and_deduplicates() -> void:
 	assert_eq(pids[1], 40064)
 
 
+func test_powershell_listener_output_parses_pid_lines() -> void:
+	var pids := GodotAiPlugin._windows_listener_pids_from_execute_result(
+		0,
+		["19088\r\n40064\r\n19088\r\n"]
+	)
+	assert_eq(pids.size(), 2)
+	assert_eq(pids[0], 19088)
+	assert_eq(pids[1], 40064)
+
+
+func test_powershell_listener_output_empty_means_no_listener() -> void:
+	assert_false(GodotAiPlugin._windows_listener_execute_result_in_use(0, [""]))
+	assert_false(GodotAiPlugin._windows_listener_execute_result_in_use(1, ["19088"]))
+
+
 # ----- pid-file round trip -----
 
 func test_read_pid_file_missing_returns_zero() -> void:

--- a/test_project/tests/test_physics_shape.gd
+++ b/test_project/tests/test_physics_shape.gd
@@ -240,15 +240,22 @@ func test_autofit_2d_rectangle() -> void:
 # ----- source auto-detection -----
 
 func test_autofit_no_sibling_visual_errors() -> void:
-	# Wrap in a fresh Node3D so the scene root's other children don't leak
-	# in as sibling candidates.
+	# Two-level nesting so neither tier-1 (direct siblings) nor tier-2
+	# (parent siblings / uncles) leaks in scene-root-level visuals — e.g.
+	# a `ReloadTestCube` left over from `script/ci-reload-test`, which
+	# otherwise becomes an uncle of LonelyCollision and makes autofit
+	# return data instead of the expected error.
 	var scene_root := EditorInterface.get_edited_scene_root()
 	if scene_root == null:
 		skip("No scene root")
 		return
+	var outer := Node3D.new()
+	outer.name = "IsolatedCollisionOuter"
+	scene_root.add_child(outer)
+	outer.set_owner(scene_root)
 	var isolated := Node3D.new()
 	isolated.name = "IsolatedCollisionHost"
-	scene_root.add_child(isolated)
+	outer.add_child(isolated)
 	isolated.set_owner(scene_root)
 	var col := CollisionShape3D.new()
 	col.name = "LonelyCollision"
@@ -257,7 +264,7 @@ func test_autofit_no_sibling_visual_errors() -> void:
 	var result := _handler.autofit({"path": col.get_path()})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 	assert_contains(result.error.message, "source_path")
-	_remove_node(isolated)
+	_remove_node(outer)
 
 
 func test_autofit_explicit_source_path() -> void:

--- a/test_project/tests/test_physics_shape.gd
+++ b/test_project/tests/test_physics_shape.gd
@@ -79,6 +79,42 @@ func _remove_node(node: Node) -> void:
 	node.queue_free()
 
 
+## Build the issue-#263 nested layout under a fresh container:
+##   Container
+##     <visual_name>(MeshInstance3D, BoxMesh size=mesh_size)*  (one per entry)
+##     Body(StaticBody3D)
+##       Collision(CollisionShape3D)
+## Returns {container, visuals: Array[MeshInstance3D], body, collision} or
+## {} when no scene root is open.
+func _add_nested_body_3d(container_name: String, visuals: Array) -> Dictionary:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return {}
+	var container := Node3D.new()
+	container.name = container_name
+	scene_root.add_child(container)
+	container.set_owner(scene_root)
+	var visual_nodes: Array[Node] = []
+	for v in visuals:
+		var mesh := MeshInstance3D.new()
+		mesh.name = v.name
+		var box := BoxMesh.new()
+		box.size = v.size
+		mesh.mesh = box
+		container.add_child(mesh)
+		mesh.set_owner(scene_root)
+		visual_nodes.append(mesh)
+	var body := StaticBody3D.new()
+	body.name = "Body"
+	container.add_child(body)
+	body.set_owner(scene_root)
+	var col := CollisionShape3D.new()
+	col.name = "Collision"
+	body.add_child(col)
+	col.set_owner(scene_root)
+	return {"container": container, "visuals": visual_nodes, "body": body, "collision": col}
+
+
 # ----- validation errors -----
 
 func test_autofit_missing_path() -> void:
@@ -236,6 +272,101 @@ func test_autofit_explicit_source_path() -> void:
 	assert_has_key(result, "data")
 	assert_eq(parts.collision.shape.size.x, 5.0)
 	_remove_node(parts.body)
+
+
+# ----- nested layout: visual is a parent-sibling, not a direct sibling -----
+
+func test_autofit_3d_finds_uncle_mesh_in_nested_body_layout() -> void:
+	# Issue #263: visual is a sibling of the body, not of the collision shape.
+	var parts := _add_nested_body_3d("TestNestedAutofit3D", [{"name": "Visual", "size": Vector3(7, 3, 5)}])
+	if parts.is_empty():
+		skip("No scene root")
+		return
+	var result := _handler.autofit({"path": parts.collision.get_path()})
+	assert_has_key(result, "data")
+	assert_eq(result.data.shape_class, "BoxShape3D")
+	assert_true(parts.collision.shape is BoxShape3D)
+	assert_eq(parts.collision.shape.size.x, 7.0)
+	assert_eq(parts.collision.shape.size.y, 3.0)
+	assert_eq(parts.collision.shape.size.z, 5.0)
+	assert_true(result.data.source_path.ends_with("/Visual"), "source_path should resolve to the uncle visual")
+	_remove_node(parts.container)
+
+
+func test_autofit_3d_ambiguous_uncles_lists_candidates() -> void:
+	# Two measurable uncles → no auto-pick; error must list candidate
+	# scene paths in error.data.candidates so the agent can pick one.
+	var parts := _add_nested_body_3d("TestAmbiguousAutofit3D", [
+		{"name": "VisualA", "size": Vector3(1, 1, 1)},
+		{"name": "VisualB", "size": Vector3(1, 1, 1)},
+	])
+	if parts.is_empty():
+		skip("No scene root")
+		return
+	var result := _handler.autofit({"path": parts.collision.get_path()})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "Multiple visual candidates")
+	assert_contains(result.error.message, "source_path")
+	assert_has_key(result.error, "data")
+	var candidates: Array = result.error.data.get("candidates", [])
+	assert_eq(candidates.size(), 2)
+	var joined := ", ".join(candidates)
+	assert_true(joined.contains("/VisualA"), "candidates should include VisualA path")
+	assert_true(joined.contains("/VisualB"), "candidates should include VisualB path")
+	_remove_node(parts.container)
+
+
+func test_autofit_3d_uncle_search_skips_lights() -> void:
+	# Tier 2 must reject Light3D — DirectionalLight3D extends
+	# VisualInstance3D and would silently produce a huge collider. The
+	# stricter GeometryInstance3D filter is what prevents it.
+	var parts := _add_nested_body_3d("TestLightOnlyAutofit3D", [])
+	if parts.is_empty():
+		skip("No scene root")
+		return
+	var light := OmniLight3D.new()
+	light.name = "OnlyLight"
+	parts.container.add_child(light)
+	light.set_owner(EditorInterface.get_edited_scene_root())
+	var result := _handler.autofit({"path": parts.collision.get_path()})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "source_path")
+	_remove_node(parts.container)
+
+
+func test_autofit_2d_finds_uncle_sprite_in_nested_body_layout() -> void:
+	# 2D variant of the nested-body layout from issue #263.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root")
+		return
+	var container := Node2D.new()
+	container.name = "TestNestedAutofit2D"
+	scene_root.add_child(container)
+	container.set_owner(scene_root)
+	var sprite := Sprite2D.new()
+	sprite.name = "Visual"
+	var img := Image.create(40, 24, false, Image.FORMAT_RGBA8)
+	img.fill(Color.WHITE)
+	sprite.texture = ImageTexture.create_from_image(img)
+	container.add_child(sprite)
+	sprite.set_owner(scene_root)
+	var body := StaticBody2D.new()
+	body.name = "Body"
+	container.add_child(body)
+	body.set_owner(scene_root)
+	var col := CollisionShape2D.new()
+	col.name = "Collision"
+	body.add_child(col)
+	col.set_owner(scene_root)
+
+	var result := _handler.autofit({"path": col.get_path()})
+	assert_has_key(result, "data")
+	assert_true(col.shape is RectangleShape2D)
+	assert_eq(col.shape.size.x, 40.0)
+	assert_eq(col.shape.size.y, 24.0)
+	assert_true(result.data.source_path.ends_with("/Visual"))
+	_remove_node(container)
 
 
 # ----- regression: capsule silent clamp (height >= 2*radius) -----

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -15,6 +15,59 @@ class _RefreshDock extends McpDock:
 		refresh_calls += 1
 
 
+class _ProofPlugin extends GodotAiPlugin:
+	var listener_pids: Array[int] = []
+	var managed_record := {"pid": 0, "version": "", "ws_port": 0}
+	var live_status := {"name": "", "version": "", "ws_port": 0, "status_code": 0}
+	var alive_pids: Array[int] = []
+	var pid_file_pid := 0
+	var branded_pids: Array[int] = []
+	var port_in_use := false
+	var port_in_use_sequence: Array[bool] = []
+	var killed_targets: Array[int] = []
+	var cleared_record_calls := 0
+	var waited_calls := 0
+
+	func _find_all_pids_on_port(_port: int) -> Array[int]:
+		var pids: Array[int] = []
+		pids.assign(listener_pids)
+		return pids
+
+	func _read_managed_server_record() -> Dictionary:
+		return managed_record.duplicate()
+
+	func _read_pid_file_for_proof() -> int:
+		return pid_file_pid
+
+	func _pid_alive_for_proof(pid: int) -> bool:
+		return alive_pids.has(pid)
+
+	func _pid_cmdline_is_godot_ai_for_proof(pid: int) -> bool:
+		return branded_pids.has(pid)
+
+	func _probe_live_server_status_for_port(_port: int) -> Dictionary:
+		return live_status.duplicate()
+
+	func _is_port_in_use(_port: int) -> bool:
+		if not port_in_use_sequence.is_empty():
+			return bool(port_in_use_sequence.pop_front())
+		return port_in_use
+
+	func _kill_processes_and_windows_spawn_children(pids: Array[int]) -> Array[int]:
+		for pid in pids:
+			if not killed_targets.has(pid):
+				killed_targets.append(pid)
+		var killed: Array[int] = []
+		killed.assign(pids)
+		return killed
+
+	func _wait_for_port_free(_port: int, _timeout_s: float) -> void:
+		waited_calls += 1
+
+	func _clear_managed_server_record() -> void:
+		cleared_record_calls += 1
+
+
 ## Test port high enough to almost never collide with real services and
 ## distinct from the plugin's configured http_port() so the stop-finalize tests
 ## don't interact with a developer's running managed server.
@@ -196,9 +249,11 @@ func test_get_server_status_shape_is_stable() -> void:
 	plugin.free()
 	assert_has_key(status, "state")
 	assert_has_key(status, "exit_ms")
+	assert_has_key(status, "actual_name")
 	assert_has_key(status, "actual_version")
 	assert_has_key(status, "expected_version")
 	assert_has_key(status, "message")
+	assert_has_key(status, "can_recover_incompatible")
 	assert_has_key(status, "connection_blocked")
 
 
@@ -226,6 +281,114 @@ func test_managed_record_restart_requires_recorded_version_drift() -> void:
 		GodotAiPlugin._managed_record_has_version_drift("", "2.2.0"),
 		"missing managed record must not authorize restart"
 	)
+
+
+func test_commandline_fingerprint_is_case_insensitive_and_requires_flag() -> void:
+	assert_true(
+		GodotAiPlugin._commandline_is_godot_ai_server(
+			"C:/Python/python.exe -m GODOT_AI --TRANSPORT streamable-http"
+		),
+		"brand and management flag should match case-insensitively"
+	)
+	assert_true(
+		GodotAiPlugin._commandline_is_godot_ai_server(
+			"C:/Python/python.exe -m godot-ai --pid-file C:/tmp/godot_ai_server.pid"
+		),
+		"hyphenated brand plus pid-file flag should identify the server"
+	)
+	assert_false(
+		GodotAiPlugin._commandline_is_godot_ai_server("C:/Python/python.exe -m godot_ai"),
+		"brand alone is not enough ownership proof"
+	)
+
+
+func test_strong_proof_accepts_live_managed_record_pid() -> void:
+	var plugin := _ProofPlugin.new()
+	plugin.listener_pids = [24680] as Array[int]
+	plugin.managed_record = {"pid": 24680, "version": "2.1.0", "ws_port": 9500}
+	plugin.alive_pids = [24680] as Array[int]
+
+	var proof := plugin._evaluate_strong_port_occupant_proof(TEST_PORT)
+	plugin.free()
+
+	assert_eq(proof.get("proof", ""), "managed_record")
+	var pids: Array[int] = []
+	pids.assign(proof.get("pids", []))
+	assert_eq(pids, [24680] as Array[int])
+
+
+func test_legacy_pidfile_proof_returns_all_branded_listener_pids() -> void:
+	var plugin := _ProofPlugin.new()
+	plugin.listener_pids = [11111, 22222, 33333] as Array[int]
+	plugin.pid_file_pid = 11111
+	plugin.alive_pids = [11111] as Array[int]
+	plugin.branded_pids = [11111, 22222] as Array[int]
+
+	var targets := plugin._legacy_pidfile_kill_targets(TEST_PORT, plugin.listener_pids)
+	var proof := plugin._evaluate_strong_port_occupant_proof(TEST_PORT)
+	plugin.free()
+
+	assert_eq(targets, [11111, 22222] as Array[int])
+	assert_eq(proof.get("proof", ""), "pidfile_listener")
+	var pids: Array[int] = []
+	pids.assign(proof.get("pids", []))
+	assert_eq(pids, [11111, 22222] as Array[int])
+
+
+func test_strong_proof_accepts_status_matching_managed_record_version() -> void:
+	var plugin := _ProofPlugin.new()
+	plugin.listener_pids = [13579] as Array[int]
+	plugin.managed_record = {"pid": 0, "version": "2.1.0", "ws_port": 9500}
+	plugin.live_status = {"name": "godot-ai", "version": "2.1.0", "ws_port": 9500, "status_code": 200}
+
+	var proof := plugin._evaluate_strong_port_occupant_proof(TEST_PORT)
+	plugin.free()
+
+	assert_eq(proof.get("proof", ""), "status_matches_record")
+	var pids: Array[int] = []
+	pids.assign(proof.get("pids", []))
+	assert_eq(pids, [13579] as Array[int])
+
+
+func test_strong_proof_rejects_status_name_only() -> void:
+	var plugin := _ProofPlugin.new()
+	plugin.listener_pids = [13579] as Array[int]
+	plugin.managed_record = {"pid": 0, "version": "", "ws_port": 0}
+	plugin.live_status = {"name": "godot-ai", "version": "2.1.0", "ws_port": 9500, "status_code": 200}
+
+	var proof := plugin._evaluate_strong_port_occupant_proof(TEST_PORT)
+	plugin.free()
+
+	assert_eq(proof.get("proof", ""), "")
+	var pids: Array[int] = []
+	pids.assign(proof.get("pids", []))
+	assert_true(pids.is_empty())
+
+
+func test_recovery_proof_accepts_status_name_only() -> void:
+	var plugin := _ProofPlugin.new()
+	plugin.listener_pids = [13579] as Array[int]
+	plugin.live_status = {"name": "godot-ai", "version": "2.1.0", "ws_port": 9500, "status_code": 200}
+
+	var proof := plugin._evaluate_recovery_port_occupant_proof(TEST_PORT)
+	plugin.free()
+
+	assert_eq(proof.get("proof", ""), "status_name")
+	var pids: Array[int] = []
+	pids.assign(proof.get("pids", []))
+	assert_eq(pids, [13579] as Array[int])
+
+
+func test_can_recover_incompatible_server_requires_state_and_recovery_proof() -> void:
+	var plugin := _ProofPlugin.new()
+	plugin.port_in_use = true
+	plugin.listener_pids = [13579] as Array[int]
+	plugin.live_status = {"name": "godot-ai", "version": "2.1.0", "ws_port": 9500, "status_code": 200}
+
+	assert_false(plugin.can_recover_incompatible_server(), "OK state must not expose recovery")
+	plugin._spawn_state = McpSpawnState.INCOMPATIBLE_SERVER
+	assert_true(plugin.can_recover_incompatible_server(), "status-name proof should allow clicked recovery")
+	plugin.free()
 
 
 func test_external_compatible_adoption_clears_stale_managed_record() -> void:
@@ -415,7 +578,7 @@ func test_incompatible_server_message_names_ws_port_mismatch() -> void:
 
 
 func test_incompatible_transition_refreshes_dock_client_statuses() -> void:
-	var plugin := GodotAiPlugin.new()
+	var plugin := _ProofPlugin.new()
 	var dock := _RefreshDock.new()
 	plugin._dock = dock
 	plugin._set_incompatible_server({"version": "1.2.10"}, "2.2.0", 8000)
@@ -424,6 +587,98 @@ func test_incompatible_transition_refreshes_dock_client_statuses() -> void:
 	plugin.free()
 
 	assert_eq(calls, 1, "late incompatible transition must resweep dock client status")
+
+
+func test_incompatible_status_exposes_actual_name_and_recovery_flag() -> void:
+	var plugin := _ProofPlugin.new()
+	plugin.listener_pids = [24680] as Array[int]
+	plugin.live_status = {"name": "godot-ai", "version": "1.2.10", "ws_port": 9500, "status_code": 200}
+	plugin._set_incompatible_server(plugin.live_status, "2.2.0", TEST_PORT)
+	var status := plugin.get_server_status()
+	plugin.free()
+
+	assert_eq(status.get("actual_name", ""), "godot-ai")
+	assert_true(bool(status.get("can_recover_incompatible", false)))
+
+
+func test_drift_kill_without_strong_targets_sets_incompatible_and_preserves_record() -> void:
+	var plugin := _ProofPlugin.new()
+	plugin.port_in_use_sequence = [true] as Array[bool]
+	plugin.listener_pids = [24680] as Array[int]
+	plugin.managed_record = {"pid": 0, "version": "old-managed-for-test", "ws_port": 9500}
+	plugin.live_status = {"name": "other-server", "version": "old-managed-for-test", "ws_port": 9500, "status_code": 200}
+
+	plugin._start_server()
+	var status := plugin.get_server_status()
+	var killed := plugin.killed_targets.duplicate()
+	var clear_calls := plugin.cleared_record_calls
+	var server_pid := plugin._server_pid
+	plugin.free()
+
+	assert_eq(status.get("state", ""), McpSpawnState.INCOMPATIBLE_SERVER)
+	assert_true(killed.is_empty(), "drift branch must not kill without strong proof")
+	assert_eq(clear_calls, 0, "failed drift proof must preserve the managed record")
+	assert_eq(server_pid, -1, "drift branch must not spawn into a port with no strong kill target")
+
+
+func test_drift_kill_preserves_record_and_does_not_spawn_when_port_stays_held() -> void:
+	var plugin := _ProofPlugin.new()
+	plugin.port_in_use_sequence = [true, true] as Array[bool]
+	plugin.listener_pids = [24680] as Array[int]
+	plugin.managed_record = {"pid": 24680, "version": "old-managed-for-test", "ws_port": 9500}
+	plugin.alive_pids = [24680] as Array[int]
+	plugin.live_status = {"name": "other-server", "version": "old-managed-for-test", "ws_port": 9500, "status_code": 200}
+
+	plugin._start_server()
+	var status := plugin.get_server_status()
+	var killed := plugin.killed_targets.duplicate()
+	var clear_calls := plugin.cleared_record_calls
+	var server_pid := plugin._server_pid
+	plugin.free()
+
+	assert_eq(status.get("state", ""), McpSpawnState.INCOMPATIBLE_SERVER)
+	assert_eq(killed, [24680] as Array[int])
+	assert_eq(clear_calls, 0, "held port after kill must preserve the managed record")
+	assert_eq(server_pid, -1, "drift branch must not spawn while the port is still held")
+
+
+func test_force_restart_preserves_record_when_port_remains_held() -> void:
+	var plugin := _ProofPlugin.new()
+	plugin.port_in_use = true
+	plugin.listener_pids = [24680] as Array[int]
+	plugin.managed_record = {"pid": 24680, "version": "old-managed-for-test", "ws_port": 9500}
+	plugin.live_status = {"name": "other-server", "version": "old-managed-for-test", "ws_port": 9500, "status_code": 200}
+
+	plugin.force_restart_server()
+	var status := plugin.get_server_status()
+	var killed := plugin.killed_targets.duplicate()
+	var clear_calls := plugin.cleared_record_calls
+	plugin.free()
+
+	assert_eq(status.get("state", ""), McpSpawnState.INCOMPATIBLE_SERVER)
+	assert_eq(killed, [24680] as Array[int])
+	assert_eq(clear_calls, 0, "force restart must not clear ownership while the port is still held")
+
+
+func test_recover_incompatible_returns_false_and_leaves_state_when_port_remains_held() -> void:
+	var plugin := _ProofPlugin.new()
+	plugin._spawn_state = McpSpawnState.INCOMPATIBLE_SERVER
+	plugin._connection_blocked = true
+	plugin.port_in_use = true
+	plugin.listener_pids = [24680] as Array[int]
+	plugin.live_status = {"name": "godot-ai", "version": "1.2.10", "ws_port": 9500, "status_code": 200}
+
+	var ok := plugin.recover_incompatible_server()
+	var status := plugin.get_server_status()
+	var killed := plugin.killed_targets.duplicate()
+	var clear_calls := plugin.cleared_record_calls
+	plugin.free()
+
+	assert_false(ok, "recovery click must report failure when the kill did not free the port")
+	assert_eq(status.get("state", ""), McpSpawnState.INCOMPATIBLE_SERVER)
+	assert_true(bool(status.get("connection_blocked", false)))
+	assert_eq(killed, [24680] as Array[int])
+	assert_eq(clear_calls, 0, "failed recovery must preserve record/pid-file state")
 
 
 func test_connection_established_waits_for_version_before_clearing_foreign_port() -> void:

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -468,11 +468,32 @@ func test_verified_matching_server_clears_foreign_port() -> void:
 
 
 func test_verified_old_server_becomes_incompatible_and_blocks_connection() -> void:
+	## Force user-mode for the duration of this test so the dev-checkout
+	## heuristic — which silently treats any version mismatch as compatible
+	## when run from a `.venv`-adjacent worktree — can't make 1.2.10 look
+	## OK against an expected 2.2.0. Without this the test is non-
+	## deterministic across CI runners and dev machines.
+	var prior_setting: Variant = null
+	var es := EditorInterface.get_editor_settings()
+	if es != null and es.has_setting(McpClientConfigurator.MODE_OVERRIDE_SETTING):
+		prior_setting = es.get_setting(McpClientConfigurator.MODE_OVERRIDE_SETTING)
+	var prior_env := OS.get_environment("GODOT_AI_MODE")
+	if es != null:
+		es.set_setting(McpClientConfigurator.MODE_OVERRIDE_SETTING, "user")
+	OS.set_environment("GODOT_AI_MODE", "user")
+
 	var plugin := GodotAiPlugin.new()
 	plugin._server_expected_version = "2.2.0"
 	plugin._on_server_version_verified("1.2.10")
 	var status := plugin.get_server_status()
 	plugin.free()
+
+	if es != null:
+		es.set_setting(McpClientConfigurator.MODE_OVERRIDE_SETTING, prior_setting if prior_setting != null else "")
+	if prior_env.is_empty():
+		OS.unset_environment("GODOT_AI_MODE")
+	else:
+		OS.set_environment("GODOT_AI_MODE", prior_env)
 
 	assert_eq(status.get("state", ""), McpSpawnState.INCOMPATIBLE_SERVER)
 	assert_eq(status.get("actual_version", ""), "1.2.10")

--- a/test_project/tests/test_ui.gd
+++ b/test_project/tests/test_ui.gd
@@ -161,6 +161,27 @@ func test_set_anchor_preset_non_control_node() -> void:
 	assert_contains(result.error.message, "not a Control")
 
 
+func test_set_anchor_preset_canvas_layer_suggests_control_overlay() -> void:
+	# Applying anchor_preset directly to a CanvasLayer is the common HUD-shaped
+	# mistake. A bare "not a Control" rejection isn't actionable — the error
+	# must spell out the Control-child overlay fix.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root — is a scene open?")
+		return
+	var layer := CanvasLayer.new()
+	layer.name = "TestUiCanvasLayer"
+	scene_root.add_child(layer)
+	layer.owner = scene_root
+	var path := "/" + scene_root.name + "/TestUiCanvasLayer"
+	var result := _handler.set_anchor_preset({"path": path, "preset": "full_rect"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "CanvasLayer")
+	assert_contains(result.error.message, "Control")
+	scene_root.remove_child(layer)
+	layer.queue_free()
+
+
 # ----- undo -----
 
 func test_set_anchor_preset_is_undoable() -> void:
@@ -406,6 +427,32 @@ func test_build_layout_rejects_anchor_preset_on_non_control() -> void:
 		"tree": {"type": "Node", "anchor_preset": "center"}
 	})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_build_layout_anchor_preset_on_canvas_layer_suggests_control_overlay() -> void:
+	# build_layout({type: CanvasLayer, anchor_preset: ...}) is the common
+	# HUD-shaped mistake. Reject with the Control-child fix spelled out.
+	var result := _handler.build_layout({
+		"tree": {"type": "CanvasLayer", "anchor_preset": "full_rect"}
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "CanvasLayer")
+	assert_contains(result.error.message, "Control")
+
+
+func test_build_layout_theme_on_canvas_layer_suggests_control_overlay() -> void:
+	# Same shape but for the `theme` field — must reject with the same hint.
+	var theme_path := "res://tests/_mcp_test_canvas_layer_theme.tres"
+	ResourceSaver.save(Theme.new(), theme_path)
+	var result := _handler.build_layout({
+		"tree": {"type": "CanvasLayer", "theme": theme_path}
+	})
+	# Clean up before asserting so a failed assert can't leak the .tres.
+	if FileAccess.file_exists(theme_path):
+		DirAccess.remove_absolute(theme_path)
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "CanvasLayer")
+	assert_contains(result.error.message, "Control")
 
 
 func test_build_layout_is_undoable() -> void:

--- a/test_project/tests/test_uv_cache_cleanup.gd.uid
+++ b/test_project/tests/test_uv_cache_cleanup.gd.uid
@@ -1,0 +1,1 @@
+uid://daqohh6qyfnbu

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -10,6 +10,9 @@ import websockets
 
 from godot_ai import __version__ as _SERVER_VERSION
 from godot_ai.godot_client.client import GodotClient, GodotCommandError
+from godot_ai.handlers import editor as editor_handlers
+from godot_ai.handlers import scene as scene_handlers
+from godot_ai.runtime.direct import DirectRuntime
 
 # ---------------------------------------------------------------------------
 # Handshake
@@ -287,3 +290,83 @@ class TestMultipleSessions:
         assert harness.registry.get("keep-a") is None
         assert harness.registry.get("keep-b") is not None
         await plugin_b.close()
+
+
+# --- Issue #262: editor_state self-heals a stale "playing" cache ---
+
+
+class TestEditorStateSelfHeal:
+    async def test_editor_state_then_scene_save_no_stale_playing_block(self, harness):
+        plugin = await harness.connect_plugin(session_id="sh-1", readiness="playing")
+        client = GodotClient(harness.server, harness.registry)
+        runtime = DirectRuntime(registry=harness.registry, client=client)
+        session = harness.registry.get("sh-1")
+        assert session.readiness == "playing"
+
+        async def mock_plugin_loop():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "get_editor_state"
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "godot_version": "4.4.1",
+                    "project_name": "p",
+                    "current_scene": "res://main.tscn",
+                    "is_playing": False,
+                    "readiness": "ready",
+                },
+            )
+            # Without the self-heal the runtime never reaches save_scene —
+            # require_writable raises EDITOR_NOT_READY against the stale
+            # "playing" cache before send_command runs. Receiving the
+            # save_scene command is the test.
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "save_scene"
+            await plugin.send_response(
+                cmd["request_id"],
+                {"path": "res://main.tscn", "undoable": False},
+            )
+
+        task = asyncio.create_task(mock_plugin_loop())
+        try:
+            state = await editor_handlers.editor_state(runtime)
+            assert state["readiness"] == "ready"
+            assert session.readiness == "ready"
+            saved = await scene_handlers.scene_save(runtime)
+            assert saved["path"] == "res://main.tscn"
+        finally:
+            await asyncio.wait_for(task, timeout=2.0)
+            await plugin.close()
+
+    async def test_editor_state_promotes_cache_to_playing_when_truly_playing(self, harness):
+        """Self-heal is bidirectional — a stale 'ready' cache also reconciles
+        so the next write correctly blocks instead of slipping through."""
+        plugin = await harness.connect_plugin(session_id="sh-2", readiness="ready")
+        client = GodotClient(harness.server, harness.registry)
+        runtime = DirectRuntime(registry=harness.registry, client=client)
+        session = harness.registry.get("sh-2")
+        assert session.readiness == "ready"
+
+        async def mock_plugin():
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "godot_version": "4.4.1",
+                    "project_name": "p",
+                    "current_scene": "res://main.tscn",
+                    "is_playing": True,
+                    "readiness": "playing",
+                },
+            )
+
+        task = asyncio.create_task(mock_plugin())
+        try:
+            await editor_handlers.editor_state(runtime)
+            assert session.readiness == "playing"
+            with pytest.raises(GodotCommandError) as exc_info:
+                await scene_handlers.scene_save(runtime)
+            assert exc_info.value.code == "EDITOR_NOT_READY"
+        finally:
+            await asyncio.wait_for(task, timeout=2.0)
+            await plugin.close()

--- a/tests/unit/test_gdscript_no_adjacent_string_concat.py
+++ b/tests/unit/test_gdscript_no_adjacent_string_concat.py
@@ -1,0 +1,213 @@
+"""Lint: GDScript does not support Python-style implicit adjacent-string concat.
+
+Hit three times in recent PRs (#236, twice in #243): the pattern looks fine to
+anyone with Python muscle memory, but lands as a parse error in GDScript:
+
+    assert_false(cond,
+        "first half - "
+        "second half")          # parse error in GDScript
+
+The CI `--import` log scan in `script/ci-check-gdscript` does catch this — but
+only after a push round-trip, and only if the failed file actually loads. This
+test runs at `pytest` time and walks every `.gd` file under `plugin/` and
+`test_project/tests/`, so the regression is caught locally before the commit.
+
+The detector is a small purpose-built tokenizer (no third-party dependency):
+it tracks paren/bracket depth and flags any two string literals that appear
+back-to-back inside `()` / `[]` / `{}` with only whitespace and comments
+between them. It deliberately does not flag adjacent strings outside parens
+(e.g. consecutive `match` cases) because GDScript newlines end statements
+there, so adjacency is not a parse hazard.
+
+See issue #246.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCAN_ROOTS = (
+    REPO_ROOT / "plugin" / "addons" / "godot_ai",
+    REPO_ROOT / "test_project" / "tests",
+)
+
+
+def _find_adjacent_string_pairs(text: str) -> list[tuple[tuple[int, int], tuple[int, int]]]:
+    """Return ((prev_line, prev_col), (cur_line, cur_col)) for each offending pair.
+
+    A pair is only reported when both string literals occur with paren/bracket
+    depth > 0 — outside parens, GDScript ends the statement at the newline and
+    adjacent strings are independent expressions, not a concat hazard.
+    """
+    n = len(text)
+    i = 0
+    prev_string_loc: tuple[int, int] | None = None
+    paren_depth = 0
+    hits: list[tuple[tuple[int, int], tuple[int, int]]] = []
+
+    def loc(pos: int) -> tuple[int, int]:
+        line = text.count("\n", 0, pos) + 1
+        col = pos - (text.rfind("\n", 0, pos) + 1) + 1
+        return line, col
+
+    while i < n:
+        c = text[i]
+        if c in " \t\r\n":
+            i += 1
+            continue
+        if c == "#":
+            while i < n and text[i] != "\n":
+                i += 1
+            continue
+        if c in "([{":
+            paren_depth += 1
+            prev_string_loc = None
+            i += 1
+            continue
+        if c in ")]}":
+            # Clamp at 0 so the lint stays useful on partially-edited / malformed
+            # files instead of underflowing into a negative depth that would
+            # silently disable the in-parens check for the rest of the file.
+            paren_depth = max(0, paren_depth - 1)
+            prev_string_loc = None
+            i += 1
+            continue
+        # GDScript string prefixes: r"..." (raw), &"..." (StringName),
+        # ^"..." (NodePath). The prefix char must be immediately followed by
+        # an opening quote — otherwise it is just an identifier starting with
+        # that letter (e.g. `return`, `range`).
+        prefix_len = 0
+        if c in ("r", "&", "^") and i + 1 < n and text[i + 1] in ('"', "'"):
+            prefix_len = 1
+        q_start = i + prefix_len
+        if q_start < n and text[q_start] in ('"', "'"):
+            q = text[q_start]
+            if text[q_start : q_start + 3] == q * 3:
+                # Triple-quoted strings do not honor backslash-escaping for the
+                # closing quote in GDScript, so a plain `find` is sufficient.
+                end = text.find(q * 3, q_start + 3)
+                end = (end + 3) if end != -1 else n
+            else:
+                j = q_start + 1
+                while j < n:
+                    ch = text[j]
+                    if ch == "\\":
+                        j += 2
+                        continue
+                    if ch == q:
+                        j += 1
+                        break
+                    if ch == "\n":
+                        # Unterminated single-line string; stop tokenizing this
+                        # span without crashing the lint pass.
+                        break
+                    j += 1
+                end = j
+            tok_loc = loc(i)
+            if prev_string_loc is not None and paren_depth > 0:
+                hits.append((prev_string_loc, tok_loc))
+            prev_string_loc = tok_loc
+            i = end
+            continue
+        prev_string_loc = None
+        i += 1
+
+    return hits
+
+
+def test_no_python_style_adjacent_string_concat_in_gdscript() -> None:
+    """No `.gd` file may contain two string literals adjacent inside parens.
+
+    Acceptance criterion from issue #246: a structural scan that runs at lint
+    time (i.e. in `pytest`) and points at the offending file:line pair, so the
+    contributor sees the bug before pushing — not after CI's `--import` round-
+    trip flags it.
+    """
+    offenders: list[str] = []
+    for root in SCAN_ROOTS:
+        assert root.exists(), f"Lint root does not exist: {root}"
+        for path in sorted(root.rglob("*.gd")):
+            text = path.read_text(encoding="utf-8")
+            for prev, cur in _find_adjacent_string_pairs(text):
+                rel = path.relative_to(REPO_ROOT)
+                offenders.append(
+                    f"{rel}:{cur[0]}:{cur[1]}  (string at line {prev[0]} is "
+                    f"adjacent to string at line {cur[0]} inside a parenthesised "
+                    f"expression — GDScript parse error)"
+                )
+
+    assert not offenders, (
+        "GDScript does not support Python-style implicit adjacent-string "
+        "concat. Use explicit `+` or merge the literals onto one line.\n"
+        "Offenders:\n  " + "\n  ".join(offenders)
+    )
+
+
+# --- detector self-tests: pin the tokenizer's behavior so a future refactor
+# cannot quietly weaken the lint into a no-op (which is how a "lint added but
+# not actually firing" regression slips through). ---
+
+
+def test_detector_flags_canonical_multiline_bug_pattern() -> None:
+    """The exact shape from PR #236 must be detected."""
+    src = (
+        "assert_false(cond,\n"
+        '    "first half - "\n'
+        '    "second half")\n'
+    )
+    hits = _find_adjacent_string_pairs(src)
+    assert len(hits) == 1, f"expected 1 hit, got {hits}"
+    (prev_line, _), (cur_line, _) = hits[0]
+    assert prev_line == 2 and cur_line == 3
+
+
+def test_detector_flags_same_line_adjacent_strings() -> None:
+    """A single-line `foo("a" "b")` is also a parse error and must be flagged."""
+    assert _find_adjacent_string_pairs('foo("a" "b")') != []
+
+
+def test_detector_ignores_explicit_plus_concat() -> None:
+    """Explicit `+` between strings is the supported form and must not flag."""
+    src = 'foo("a" +\n    "b")\n'
+    assert _find_adjacent_string_pairs(src) == []
+
+
+def test_detector_ignores_comma_separated_args() -> None:
+    """Two string args separated by `,` are independent — not a concat hazard."""
+    src = 'foo("a",\n    "b")\n'
+    assert _find_adjacent_string_pairs(src) == []
+
+
+def test_detector_ignores_match_block_adjacent_cases() -> None:
+    """Adjacent `match` cases share no expression context and must not flag.
+
+    `_path_template.gd::_os_key` is the in-tree shape this guards: consecutive
+    `"darwin": / "windows":` cases sit at paren_depth=0, so the tokenizer must
+    not treat them as a parenthesised concat pair.
+    """
+    src = (
+        "match OS.get_name():\n"
+        '    "macOS":\n'
+        '        return "darwin"\n'
+        '    "Windows":\n'
+        '        return "windows"\n'
+    )
+    assert _find_adjacent_string_pairs(src) == []
+
+
+def test_detector_handles_triple_quoted_strings_with_embedded_quotes() -> None:
+    """Triple-quoted strings can contain `"`; the tokenizer must not desync."""
+    src = 'var s := """hello "world" again"""\n'
+    assert _find_adjacent_string_pairs(src) == []
+
+
+def test_detector_does_not_treat_return_as_a_string_prefix() -> None:
+    """`return "x"` starts with `r`; `r` is a string-prefix only before a quote."""
+    src = 'func f() -> String:\n    return "x"\n'
+    assert _find_adjacent_string_pairs(src) == []
+
+
+def test_detector_flags_prefixed_adjacent_strings() -> None:
+    """`r"a" "b"` inside a call is still a hazard."""
+    assert _find_adjacent_string_pairs('foo(r"a"\n    "b")') != []

--- a/tests/unit/test_readiness.py
+++ b/tests/unit/test_readiness.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import pytest
 
 from godot_ai.godot_client.client import GodotCommandError
-from godot_ai.handlers._readiness import require_writable
+from godot_ai.handlers import editor as editor_handlers
+from godot_ai.handlers._readiness import KNOWN_READINESS, require_writable
 from godot_ai.protocol.errors import ErrorCode
 from godot_ai.runtime.direct import DirectRuntime
 from godot_ai.sessions.registry import Session, SessionRegistry
@@ -84,3 +85,106 @@ def test_session_readiness_defaults_to_ready():
         plugin_version="0.0.1",
     )
     assert session.readiness == "ready"
+
+
+# --- editor_state self-heal — issue #262 ---
+
+
+class _EditorStateClient:
+    """Stub plugin that only handles get_editor_state.
+
+    `readiness=None` means "omit the field from the response" — older plugins
+    pre-dating the readiness self-heal don't emit it.
+    """
+
+    def __init__(self, readiness: str | None):
+        self._readiness = readiness
+
+    async def send(
+        self,
+        command: str,
+        params: dict | None = None,
+        session_id: str | None = None,
+        timeout: float = 5.0,
+    ) -> dict:
+        if command != "get_editor_state":
+            raise AssertionError(f"unexpected command: {command}")
+        payload: dict = {
+            "current_scene": "res://main.tscn",
+            "project_name": "p",
+            "is_playing": self._readiness == "playing",
+            "godot_version": "4.4.1",
+        }
+        if self._readiness is not None:
+            payload["readiness"] = self._readiness
+        return payload
+
+
+def _runtime_for_self_heal(
+    cached: str, plugin_reports: str | None
+) -> tuple[DirectRuntime, Session]:
+    session = _make_session(cached)
+    registry = SessionRegistry()
+    registry.register(session)
+    runtime = DirectRuntime(registry=registry, client=_EditorStateClient(plugin_reports))
+    return runtime, session
+
+
+async def test_editor_state_overwrites_stale_playing_cache():
+    runtime, session = _runtime_for_self_heal(cached="playing", plugin_reports="ready")
+
+    result = await editor_handlers.editor_state(runtime)
+
+    assert result["readiness"] == "ready"
+    assert session.readiness == "ready"
+    # Followup require_writable now sees the refreshed cache and lets the
+    # caller through. This is the critical end-to-end invariant — without
+    # it, editor_state -> scene_save still fails with the stale cache.
+    require_writable(runtime)
+
+
+async def test_editor_state_syncs_playing_when_truly_playing():
+    """Self-heal is bidirectional — a stale 'ready' cache must also reconcile
+    so the next write correctly blocks instead of slipping through."""
+    runtime, session = _runtime_for_self_heal(cached="ready", plugin_reports="playing")
+
+    await editor_handlers.editor_state(runtime)
+
+    assert session.readiness == "playing"
+    with pytest.raises(GodotCommandError):
+        require_writable(runtime)
+
+
+async def test_editor_state_ignores_missing_readiness_field():
+    """Older plugins that omit readiness must not blank the cache."""
+    runtime, session = _runtime_for_self_heal(cached="ready", plugin_reports=None)
+
+    await editor_handlers.editor_state(runtime)
+
+    assert session.readiness == "ready"
+
+
+async def test_editor_state_ignores_unknown_readiness_field():
+    """Pinning this case lets a future plugin add new readiness values
+    without a forward-compat refactor; the server keeps the prior value
+    until the Python KNOWN_READINESS set is widened to match."""
+    runtime, session = _runtime_for_self_heal(cached="ready", plugin_reports="bogus_state")
+
+    await editor_handlers.editor_state(runtime)
+
+    assert session.readiness == "ready"
+
+
+async def test_editor_state_no_session_is_no_op():
+    runtime = DirectRuntime(registry=SessionRegistry(), client=_EditorStateClient("ready"))
+
+    result = await editor_handlers.editor_state(runtime)
+
+    assert result["readiness"] == "ready"
+
+
+def test_known_readiness_covers_all_states_handlers_emit():
+    """Lock the canonical readiness set so contributors don't drift the
+    plugin and server states out of sync. The plugin's get_readiness emits
+    exactly these values today (see connection.gd::get_readiness)."""
+    assert KNOWN_READINESS == frozenset({"ready", "importing", "playing", "no_scene"})

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -140,6 +140,7 @@ class StubClient:
                 "project_name": "TestProject",
                 "is_playing": False,
                 "godot_version": "4.4.1",
+                "readiness": "ready",
             }
         if command == "get_selection":
             return {"selected": ["/Main/Camera3D"]}

--- a/tests/unit/test_script_create_import_settle.py
+++ b/tests/unit/test_script_create_import_settle.py
@@ -1,0 +1,106 @@
+"""Source-structure regression tests for the create_script -> attach_script
+import-settle fix (issue #261).
+
+Without this guard, an agent that calls `script_create` followed immediately
+by `script_attach` for the same `.gd` file races the editor's filesystem
+scan: `ResourceLoader.exists(path)` can return false while Godot is still
+recognising the new resource. The fix is to defer the `script_create`
+response until either the resource is visible or a bounded settle window
+elapses, so a successful response means an immediate `script_attach` will
+succeed.
+
+These tests pin the structure so a future refactor can't silently regress
+the guarantee.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[2] / "plugin" / "addons" / "godot_ai"
+SCRIPT_HANDLER = PLUGIN_ROOT / "handlers" / "script_handler.gd"
+PLUGIN_GD = PLUGIN_ROOT / "plugin.gd"
+
+
+def test_script_handler_holds_connection_for_deferred_replies() -> None:
+    """ScriptHandler needs an McpConnection ref to push the deferred response."""
+    source = SCRIPT_HANDLER.read_text()
+
+    assert "var _connection: McpConnection" in source, (
+        "ScriptHandler must hold an McpConnection so create_script can defer "
+        "its reply until the editor's filesystem scan settles. Without this "
+        "field a fresh script_create -> script_attach pair races the import "
+        "pipeline (issue #261)."
+    )
+    # _init must accept the connection. Default null keeps batch_execute and
+    # unit-test contexts working on the synchronous fallback path.
+    expected_init = (
+        "func _init(undo_redo: EditorUndoRedoManager, "
+        "connection: McpConnection = null)"
+    )
+    assert expected_init in source, (
+        "ScriptHandler._init must accept the connection as an optional "
+        "second parameter so test contexts can keep using the sync fallback."
+    )
+
+
+def test_create_script_defers_for_freshly_created_files() -> None:
+    """The new-file path returns DEFERRED_RESPONSE; existing-file path replies sync."""
+    source = SCRIPT_HANDLER.read_text()
+
+    # The deferred handoff must be guarded by `not existed_before` so that
+    # overwriting an already-known resource still returns immediately —
+    # ResourceLoader already knows it, no scan to wait for.
+    assert "not existed_before and _connection != null and not request_id.is_empty()" in source, (
+        "create_script must only defer when the file was newly created AND a "
+        "connection is available AND a request_id is present. Overwrites and "
+        "batch_execute / unit-test contexts must keep the synchronous reply."
+    )
+    assert "return McpDispatcher.DEFERRED_RESPONSE" in source, (
+        "create_script must return the DEFERRED_RESPONSE sentinel on the "
+        "deferred path so the dispatcher skips auto-sending the reply."
+    )
+
+
+def test_finish_create_script_deferred_polls_resourceloader_with_bounded_loop() -> None:
+    """The settle loop must be bounded and check ResourceLoader.exists each frame."""
+    source = SCRIPT_HANDLER.read_text()
+
+    # The bounded counter prevents an indefinite hang if the editor's
+    # filesystem pipeline never reports the new resource.
+    assert "_IMPORT_SETTLE_MAX_FRAMES" in source, (
+        "The deferred loop must use a named bounded-frame constant so the "
+        "wait can't run forever if the filesystem scan stalls."
+    )
+    deferred_block = source.split("func _finish_create_script_deferred", 1)[1]
+    assert "ResourceLoader.exists(path)" in deferred_block, (
+        "The deferred loop must poll ResourceLoader.exists(path) — that's "
+        "the precise check script_attach uses, so settling on it gives the "
+        "guarantee #261 wants."
+    )
+    assert "await tree.process_frame" in deferred_block, (
+        "The deferred loop must yield via process_frame between polls so the "
+        "editor can actually run the import pipeline between checks."
+    )
+    # The reply must use send_deferred_response with a {"data": ...} payload.
+    assert "_connection.send_deferred_response(request_id" in deferred_block, (
+        "After settling, the handler must push the response over the "
+        "connection's send_deferred_response — the dispatcher won't do it."
+    )
+    # Match the project_handler.stop_project pattern: drop the response if
+    # the plugin tore down during the await.
+    assert "is_instance_valid(_connection)" in deferred_block, (
+        "If _exit_tree fires during the await the connection is freed; the "
+        "deferred reply must check is_instance_valid and bail silently."
+    )
+
+
+def test_plugin_gd_passes_connection_to_script_handler() -> None:
+    """plugin.gd must wire _connection into ScriptHandler — the field is null otherwise."""
+    source = PLUGIN_GD.read_text()
+
+    assert "ScriptHandler.new(get_undo_redo(), _connection)" in source, (
+        "plugin.gd must construct ScriptHandler with the connection so the "
+        "deferred-reply path is reachable in production. Without this, every "
+        "create_script falls back to the synchronous reply and #261 returns."
+    )


### PR DESCRIPTION
## Summary

This PR fixes the managed server lifecycle around self-update so an old `godot-ai` server cannot survive on the HTTP port and block the updated plugin from starting a compatible server.

The safety model is cross-platform: automatic cleanup now requires strong ownership proof, records and pid files are preserved unless the port is actually released, and the plugin never falls through to spawn while the port remains held. The Windows-specific part is the listener discovery path, which now uses PowerShell first so PID lookup does not depend on localized `netstat` output.

## Root Cause

The old lifecycle paths could clear managed-server records or continue startup after a failed kill attempt. On Windows, listener PID discovery depended on parsing `netstat`, which is fragile under localization. For legacy v2.2.0 servers, the plugin also needed a deterministic recovery path because those servers write `user://godot_ai_server.pid` but do not expose `/godot-ai/status`.

## Changes

- Add PowerShell-first Windows listener PID lookup with netstat fallback coverage retained.
- Replace boolean ownership checks with proof dictionaries that carry proof kind and target PIDs.
- Add strong proof tiers for managed record, legacy pidfile listener, and status matching the managed record version.
- Keep status-name-only identity out of automatic kill paths; allow it only for user-click recovery.
- Preserve managed records and pid files when a kill fails or the port remains held.
- Block spawn fall-through while the HTTP port is still occupied.
- Add incompatible-server recovery status fields and recovery APIs.
- Update the dock so Restart is shown for recoverable incompatible servers and dispatches to recovery instead of force restart.
- Add lifecycle, dock, and listener parser tests for the new proof and recovery behavior.

## Validation Run

- `git diff --check`
- `ruff check src/ tests/`
- `pytest -v` - 697 passed
- Godot headless import: `Godot --headless --path test_project --import`
- `bash script/ci-godot-tests` - 994/1008 passed, 0 failed

## Approval Test Plan

Automated checks to keep in the approval gate:

- Run `ruff check src/ tests/` and `pytest -v`.
- Run the Godot import and `bash script/ci-godot-tests` on a machine with Godot available.
- Confirm the proof tests cover managed-record proof, v2.2-style pidfile listener proof, status-version match proof, strong rejection of status-name-only proof, and recovery acceptance of status-name-only proof.
- Confirm the lifecycle tests prove drift kill with no strong targets sets incompatible, preserves the record, and does not spawn.
- Confirm the lifecycle tests prove a failed drift kill keeps the record and pid file intact and does not spawn into the held port.
- Confirm the lifecycle tests prove `force_restart_server()` preserves the record when the port stays held.
- Confirm the lifecycle tests prove `recover_incompatible_server()` returns false and leaves incompatible state intact when the port stays held.
- Confirm the dock tests prove Restart is visible only when `can_recover_incompatible=true`, and dispatch goes to `recover_incompatible_server()` for incompatible state and `force_restart_server()` otherwise.
- Confirm Windows listener tests prove PowerShell PID output parsing and netstat fallback coverage.
- Confirm command-line fingerprint tests prove case-insensitive `godot-ai` or `godot_ai` matching and require a server flag such as `--pid-file` or `--transport`.

Manual regression matrix for the original orphaned-server failure:

1. Windows v2.2.0 orphan recovery
   - Start a v2.2.0 managed server that writes `user://godot_ai_server.pid` and does not expose `/godot-ai/status`.
   - Install or reload the updated plugin.
   - Verify the old pidfile PID is a listener on the configured HTTP port and has a `godot-ai` or `godot_ai` branded command line with a server flag.
   - Verify self-update cleanup kills all branded listener PIDs on that port, waits for the port to become free, clears the record and pid file only after release, and starts exactly one new compatible server.
   - Verify Task Manager or PowerShell no longer shows the old PID or its spawned child listener.

2. Windows localized shell safety
   - On a non-English Windows locale, repeat listener detection while a server is listening.
   - Verify PowerShell `Get-NetTCPConnection` finds the listener PID even if `netstat` text would be localized.
   - Temporarily make PowerShell lookup return no PID or fail, then verify the netstat fallback path still works where possible.

3. Cross-platform managed drift cleanup
   - On macOS and Linux, start an older managed server with a valid managed record whose version differs from the plugin version.
   - Reload the plugin.
   - Verify automatic kill occurs only when strong proof exists, the port is confirmed free before record cleanup, and the new server is spawned only after the port is free.

4. Failed-kill preservation
   - Simulate or force a listener that cannot be killed, or immediately rebind the port during cleanup.
   - Trigger drift cleanup and force restart.
   - Verify the managed record and pid file remain present, the plugin enters incompatible-server state, and no replacement server is spawned into the held port.

5. Status-name-only occupant safety
   - Put a process on the configured port whose `/godot-ai/status` returns `name=godot-ai` but has no matching managed record or pidfile proof.
   - Trigger update reload or drift startup.
   - Verify the plugin does not automatically kill it.
   - Verify the incompatible banner appears with recovery only when identity proof is present.
   - Click Restart and verify user-confirmed recovery can kill the occupant; if the port remains held, verify recovery returns false and the banner/state remain.

6. Non-godot occupant safety
   - Bind the configured port with an unrelated local service.
   - Trigger plugin startup, update reload, force restart, and recovery attempts.
   - Verify no automatic kill occurs, no raw port sweep occurs, and the plugin reports incompatible or blocked state without clearing managed records prematurely.

7. Compatible adoption sanity
   - Start a compatible managed server on the configured port.
   - Reload the plugin.
   - Verify the plugin adopts it, sets `actual_name` to `godot-ai`, clears `can_recover_incompatible`, and does not show the recovery Restart path.