### PR TITLE
[codex] Fix self-update orphan server recovery

### DIFF
--- a/plugin/addons/godot_ai/clients/_cli_exec.gd
+++ b/plugin/addons/godot_ai/clients/_cli_exec.gd
@@ -22,7 +22,8 @@ extends RefCounted
 ## Returns a Dictionary with:
 ##   exit_code:    process exit code (0 = success). -1 on timeout / spawn failure.
 ##   stdout:       captured stdout text. May be partial on timeout.
-##   stderr:       captured stderr text. May be partial on timeout.
+##   stderr:       captured stderr text. May be partial on timeout. Empty when
+##                 `capture_stderr` is false.
 ##   output:       stdout + (newline + stderr if non-empty). Convenience for
 ##                 the common case of "show whatever the CLI said when it
 ##                 failed" — `claude mcp add` writes its real diagnostics to
@@ -35,7 +36,12 @@ const DEFAULT_TIMEOUT_MS := 8000
 const _POLL_INTERVAL_MS := 50
 
 
-static func run(exe: String, args: Array, timeout_ms: int = DEFAULT_TIMEOUT_MS) -> Dictionary:
+static func run(
+	exe: String,
+	args: Array,
+	timeout_ms: int = DEFAULT_TIMEOUT_MS,
+	capture_stderr: bool = true
+) -> Dictionary:
 	if exe.is_empty():
 		return _spawn_failed_result()
 
@@ -57,7 +63,7 @@ static func run(exe: String, args: Array, timeout_ms: int = DEFAULT_TIMEOUT_MS) 
 			## process — partial output beats blank "timed out" when the
 			## CLI was emitting useful diagnostics on its way to hanging.
 			var partial_stdout := _drain_pipe(stdio)
-			var partial_stderr := _drain_pipe(stderr_pipe)
+			var partial_stderr := _drain_pipe(stderr_pipe) if capture_stderr else ""
 			OS.kill(pid)
 			_close_pipes(stdio, stderr_pipe)
 			return {
@@ -71,7 +77,7 @@ static func run(exe: String, args: Array, timeout_ms: int = DEFAULT_TIMEOUT_MS) 
 		OS.delay_msec(_POLL_INTERVAL_MS)
 
 	var stdout := _drain_pipe(stdio)
-	var stderr_text := _drain_pipe(stderr_pipe)
+	var stderr_text := _drain_pipe(stderr_pipe) if capture_stderr else ""
 	_close_pipes(stdio, stderr_pipe)
 
 	return {

--- a/plugin/addons/godot_ai/clients/_cli_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_cli_strategy.gd
@@ -74,7 +74,12 @@ static func check_status_details(client: McpClient, server_name: String, server_
 		return _status_details(McpClient.Status.NOT_CONFIGURED)
 	if client.cli_status_args.is_empty():
 		return _status_details(McpClient.Status.NOT_CONFIGURED)
-	var result := McpCliExec.run(cli, McpClient._array_from_packed(client.cli_status_args), _STATUS_TIMEOUT_MS)
+	var result := McpCliExec.run(
+		cli,
+		McpClient._array_from_packed(client.cli_status_args),
+		_STATUS_TIMEOUT_MS,
+		false
+	)
 	if result.get("timed_out", false):
 		return _status_details(McpClient.Status.ERROR, "probe timed out")
 	if result.get("spawn_failed", false):

--- a/plugin/addons/godot_ai/handlers/script_handler.gd
+++ b/plugin/addons/godot_ai/handlers/script_handler.gd
@@ -6,10 +6,12 @@ extends RefCounted
 var _undo_redo: EditorUndoRedoManager
 var _connection: McpConnection
 
-# Bounded settle window for `ResourceLoader.exists(path)` after `scan()` so that
-# an agent calling create_script -> attach_script back-to-back doesn't race the
-# editor's import pipeline (#261). Polled once per frame.
-const _IMPORT_SETTLE_MAX_FRAMES := 300  # ~5s at 60fps; bails out and replies anyway.
+# Bounded settle window for `ResourceLoader.exists(path)` after `scan()` so
+# that an agent calling create_script -> attach_script back-to-back doesn't
+# race the editor's import pipeline (#261). Polled once per frame, with an
+# elapsed-time cap below the Python client's default 5s command timeout.
+const _IMPORT_SETTLE_MAX_FRAMES := 300
+const _IMPORT_SETTLE_MAX_MSEC := 4500
 
 
 func _init(undo_redo: EditorUndoRedoManager, connection: McpConnection = null) -> void:
@@ -77,7 +79,12 @@ func create_script(params: Dictionary) -> Dictionary:
 func _finish_create_script_deferred(request_id: String, path: String, data: Dictionary) -> void:
 	var tree := _connection.get_tree()
 	var frames := 0
-	while frames < _IMPORT_SETTLE_MAX_FRAMES and not ResourceLoader.exists(path):
+	var deadline_ms := Time.get_ticks_msec() + _IMPORT_SETTLE_MAX_MSEC
+	while (
+		frames < _IMPORT_SETTLE_MAX_FRAMES
+		and Time.get_ticks_msec() < deadline_ms
+		and not ResourceLoader.exists(path)
+	):
 		await tree.process_frame
 		frames += 1
 	# If the plugin tears down (_exit_tree frees _connection) during the await,
@@ -86,7 +93,7 @@ func _finish_create_script_deferred(request_id: String, path: String, data: Dict
 	if not is_instance_valid(_connection):
 		return
 	var payload := data.duplicate()
-	payload["import_settled"] = frames < _IMPORT_SETTLE_MAX_FRAMES
+	payload["import_settled"] = ResourceLoader.exists(path)
 	_connection.send_deferred_response(request_id, {"data": payload})
 
 

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -1046,12 +1046,17 @@ func _refresh_server_version_label() -> void:
 			color = COLOR_AMBER
 		else:
 			text = "godot-ai == %s  (expected %s)" % [server_ver, expected_ver]
-			color = Color.RED if server_status.get("state", "") == McpSpawnState.INCOMPATIBLE_SERVER else COLOR_AMBER
-			show_restart = (
-				server_status.get("state", "") != McpSpawnState.INCOMPATIBLE_SERVER
-				and _plugin != null
+			var is_incompatible: bool = server_status.get("state", "") == McpSpawnState.INCOMPATIBLE_SERVER
+			color = Color.RED if is_incompatible else COLOR_AMBER
+			var has_managed_proof: bool = (
+				_plugin != null
 				and _plugin.has_method("can_restart_managed_server")
 				and _plugin.can_restart_managed_server()
+			)
+			var can_recover: bool = bool(server_status.get("can_recover_incompatible", false))
+			show_restart = (
+				(not is_incompatible and has_managed_proof)
+				or (is_incompatible and can_recover)
 			)
 	if text == _last_rendered_server_text:
 		_setup_server_label.add_theme_color_override("font_color", color)
@@ -1066,7 +1071,17 @@ func _refresh_server_version_label() -> void:
 
 
 func _on_restart_stale_server() -> void:
-	if _plugin != null and _plugin.has_method("force_restart_server"):
+	if _plugin == null:
+		return
+	var status: Dictionary = (
+		_plugin.get_server_status()
+		if _plugin.has_method("get_server_status")
+		else {}
+	)
+	if str(status.get("state", "")) == McpSpawnState.INCOMPATIBLE_SERVER:
+		if _plugin.has_method("recover_incompatible_server"):
+			_plugin.recover_incompatible_server()
+	elif _plugin.has_method("force_restart_server"):
 		_plugin.force_restart_server()
 
 

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -79,6 +79,7 @@ var _last_rendered_server_text: String = ""
 ## `McpConnection.server_version` drifts from the plugin version. Hidden
 ## in the match case so the UI stays calm.
 var _version_restart_btn: Button
+var _server_restart_in_progress := false
 ## Sorted snapshot of the most recent mismatched-client set. Powers two things:
 ## (a) the Reconfigure button reuses this list instead of re-running
 ## `check_status` per row (saves ~18 filesystem reads per click), and
@@ -129,7 +130,6 @@ var _client_action_generations: Dictionary = {}
 # Dev-mode only
 var _dev_section: VBoxContainer
 var _server_label: Label
-var _reconnect_btn: Button
 var _reload_btn: Button
 var _mode_override_btn: OptionButton
 var _setup_section: VBoxContainer
@@ -149,6 +149,8 @@ var _startup_grace_until_msec: int = 0
 # booleans. See `_crash_body_for_state`.
 var _crash_panel: VBoxContainer
 var _crash_output: RichTextLabel
+var _crash_restart_btn: Button
+var _crash_reload_btn: Button
 ## Port-picker escape hatch — visible inside the panel when the root
 ## cause is port contention (PORT_EXCLUDED or FOREIGN_PORT). Applies a
 ## new `godot_ai/http_port` value and reloads the plugin so the spawn
@@ -381,11 +383,22 @@ func _build_ui() -> void:
 
 	_build_port_picker_section()
 
-	var crash_retry := Button.new()
-	crash_retry.text = "Reload Plugin"
-	crash_retry.tooltip_text = "Re-run the spawn after fixing the underlying issue"
-	crash_retry.pressed.connect(_on_reload_plugin)
-	_crash_panel.add_child(crash_retry)
+	_crash_restart_btn = Button.new()
+	_crash_restart_btn.text = "Restart Server"
+	_crash_restart_btn.tooltip_text = "Stop the old server on this port and start the bundled godot-ai server"
+	_crash_restart_btn.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_crash_restart_btn.add_theme_color_override("font_color", Color.WHITE)
+	_crash_restart_btn.add_theme_color_override("font_hover_color", Color.WHITE)
+	_crash_restart_btn.add_theme_color_override("font_pressed_color", Color.WHITE)
+	_crash_restart_btn.pressed.connect(_on_restart_stale_server)
+	_crash_restart_btn.visible = false
+	_crash_panel.add_child(_crash_restart_btn)
+
+	_crash_reload_btn = Button.new()
+	_crash_reload_btn.text = "Reload Plugin"
+	_crash_reload_btn.tooltip_text = "Re-run the spawn after fixing the underlying issue"
+	_crash_reload_btn.pressed.connect(_on_reload_plugin)
+	_crash_panel.add_child(_crash_reload_btn)
 
 	_crash_panel.add_child(HSeparator.new())
 	add_child(_crash_panel)
@@ -424,7 +437,7 @@ func _build_ui() -> void:
 	add_child(_http_request)
 	_check_for_updates.call_deferred()
 
-	# --- Dev-only connection extras (server label + reconnect/reload buttons) ---
+	# --- Dev-only connection extras (server label + reload button) ---
 	_dev_section = VBoxContainer.new()
 	_dev_section.add_theme_constant_override("separation", 6)
 	add_child(_dev_section)
@@ -437,14 +450,9 @@ func _build_ui() -> void:
 	var btn_row := HBoxContainer.new()
 	btn_row.add_theme_constant_override("separation", 6)
 
-	_reconnect_btn = Button.new()
-	_reconnect_btn.text = "Reconnect"
-	_reconnect_btn.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	_reconnect_btn.pressed.connect(_on_reconnect)
-	btn_row.add_child(_reconnect_btn)
-
 	_reload_btn = Button.new()
-	_reload_btn.text = "Reload Plugin"
+	_reload_btn.text = "Dev: Reload Plugin"
+	_reload_btn.tooltip_text = "Developer utility: reload the GDScript plugin. This does not restart or replace the server."
 	_reload_btn.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	_reload_btn.pressed.connect(_on_reload_plugin)
 	btn_row.add_child(_reload_btn)
@@ -731,7 +739,10 @@ func _update_status() -> void:
 	## one body string in `_crash_body_for_state`.
 	var status_text: String
 	var status_color: Color
-	if connected:
+	if _server_restart_in_progress:
+		status_text = "Restarting server..."
+		status_color = COLOR_AMBER
+	elif connected:
 		if bool(server_status.get("dev_version_mismatch_allowed", false)):
 			var actual := str(server_status.get("actual_version", ""))
 			status_text = "Connected (dev server v%s)" % actual if not actual.is_empty() else "Connected (dev server)"
@@ -797,6 +808,19 @@ func _update_crash_panel(server_status: Dictionary) -> void:
 	_crash_panel.visible = true
 	_crash_output.clear()
 	_crash_output.add_text(_crash_body_for_state(state, server_status))
+	var show_recovery_restart := (
+		state == McpSpawnState.INCOMPATIBLE_SERVER
+		and bool(server_status.get("can_recover_incompatible", false))
+	)
+	if _crash_restart_btn != null:
+		_crash_restart_btn.visible = show_recovery_restart
+		_crash_restart_btn.disabled = _server_restart_in_progress
+		_crash_restart_btn.text = "Restarting..." if _server_restart_in_progress else "Restart Server"
+	if _crash_reload_btn != null:
+		_crash_reload_btn.visible = (
+			not show_recovery_restart
+			and state != McpSpawnState.INCOMPATIBLE_SERVER
+		)
 
 	var port_picker_visible := (
 		state == McpSpawnState.PORT_EXCLUDED
@@ -821,6 +845,13 @@ static func _crash_body_for_state(state: String, server_status: Dictionary = {})
 			return "Windows (Hyper-V / WSL2 / Docker) reserved port %d. Pick a free port or try `net stop winnat; net start winnat` in an admin shell." % port
 		McpSpawnState.INCOMPATIBLE_SERVER:
 			var message := str(server_status.get("message", ""))
+			if bool(server_status.get("can_recover_incompatible", false)):
+				var expected := str(server_status.get("expected_version", ""))
+				if expected.is_empty():
+					expected = McpClientConfigurator.get_plugin_version()
+				if not message.is_empty():
+					return "%s Click Restart Server below to replace it with godot-ai v%s." % [message, expected]
+				return "Port %d is occupied by an older godot-ai server. Click Restart Server below to replace it with godot-ai v%s." % [port, expected]
 			if not message.is_empty():
 				return message
 			return "Port %d is occupied by an incompatible server. Stop it or change both HTTP and WS ports." % port
@@ -915,7 +946,7 @@ func _update_log() -> void:
 
 func _load_dev_mode() -> bool:
 	# Default OFF for every install (including dev checkouts). Contributors
-	# who want the extra diagnostic UI (Reload Plugin, Reconnect, MCP log
+	# who want the extra diagnostic UI (Reload Plugin, MCP log
 	# panel, Start/Stop Dev Server) can flip the toggle once — editor
 	# settings persist across sessions.
 	var es := EditorInterface.get_editor_settings()
@@ -998,12 +1029,6 @@ func _on_reload_plugin() -> void:
 	EditorInterface.set_plugin_enabled("res://addons/godot_ai/plugin.cfg", true)
 
 
-func _on_reconnect() -> void:
-	if _connection:
-		_connection.disconnect_from_server()
-		_connection._attempt_reconnect()
-
-
 ## Setup-section "Server" row: always report the TRUE running server
 ## version (from the handshake_ack) rather than the plugin's expected
 ## version, and highlight the mismatch so self-update drift is visible
@@ -1030,10 +1055,20 @@ func _refresh_server_version_label() -> void:
 	var expected_ver := str(server_status.get("expected_version", ""))
 	if expected_ver.is_empty():
 		expected_ver = plugin_ver
+	var state: String = str(server_status.get("state", McpSpawnState.OK))
+	if _server_restart_in_progress and (
+		server_ver == expected_ver
+		or (state != McpSpawnState.OK and state != McpSpawnState.INCOMPATIBLE_SERVER)
+	):
+		_server_restart_in_progress = false
 	var text: String
 	var color: Color
 	var show_restart := false
-	if server_ver.is_empty():
+	if _server_restart_in_progress:
+		text = "restarting server..."
+		color = COLOR_AMBER
+		show_restart = true
+	elif server_ver.is_empty():
 		text = "checking live version (expected godot-ai == %s)" % expected_ver
 		color = COLOR_MUTED
 	elif server_ver == expected_ver:
@@ -1046,7 +1081,7 @@ func _refresh_server_version_label() -> void:
 			color = COLOR_AMBER
 		else:
 			text = "godot-ai == %s  (expected %s)" % [server_ver, expected_ver]
-			var is_incompatible: bool = server_status.get("state", "") == McpSpawnState.INCOMPATIBLE_SERVER
+			var is_incompatible: bool = state == McpSpawnState.INCOMPATIBLE_SERVER
 			color = Color.RED if is_incompatible else COLOR_AMBER
 			var has_managed_proof: bool = (
 				_plugin != null
@@ -1056,33 +1091,62 @@ func _refresh_server_version_label() -> void:
 			var can_recover: bool = bool(server_status.get("can_recover_incompatible", false))
 			show_restart = (
 				(not is_incompatible and has_managed_proof)
-				or (is_incompatible and can_recover)
+				## Recoverable incompatible servers get the primary action in
+				## the top error panel. Duplicating it in Setup made the UI
+				## look like it had multiple restart paths.
+				or (is_incompatible and can_recover and _crash_restart_btn == null)
 			)
 	if text == _last_rendered_server_text:
 		_setup_server_label.add_theme_color_override("font_color", color)
-		if _version_restart_btn != null and _version_restart_btn.visible != show_restart:
-			_version_restart_btn.visible = show_restart
+		_update_restart_button(show_restart)
 		return
 	_last_rendered_server_text = text
 	_setup_server_label.text = text
 	_setup_server_label.add_theme_color_override("font_color", color)
+	_update_restart_button(show_restart)
+
+
+func _update_restart_button(visible: bool) -> void:
 	if _version_restart_btn != null:
-		_version_restart_btn.visible = show_restart
+		_version_restart_btn.visible = visible
+		_version_restart_btn.disabled = _server_restart_in_progress
+		_version_restart_btn.text = "Restarting..." if _server_restart_in_progress else "Restart"
+	if _crash_restart_btn != null:
+		_crash_restart_btn.disabled = _server_restart_in_progress
+		_crash_restart_btn.text = "Restarting..." if _server_restart_in_progress else "Restart Server"
 
 
 func _on_restart_stale_server() -> void:
+	if _plugin == null or _server_restart_in_progress:
+		return
+	_server_restart_in_progress = true
+	_last_rendered_server_text = ""
+	_refresh_server_version_label()
+	call_deferred("_restart_stale_server_after_feedback")
+
+
+func _restart_stale_server_after_feedback() -> void:
+	await get_tree().create_timer(0.15).timeout
 	if _plugin == null:
+		_server_restart_in_progress = false
+		_refresh_server_version_label()
 		return
 	var status: Dictionary = (
 		_plugin.get_server_status()
 		if _plugin.has_method("get_server_status")
 		else {}
 	)
+	var started := false
 	if str(status.get("state", "")) == McpSpawnState.INCOMPATIBLE_SERVER:
 		if _plugin.has_method("recover_incompatible_server"):
-			_plugin.recover_incompatible_server()
+			started = bool(_plugin.recover_incompatible_server())
 	elif _plugin.has_method("force_restart_server"):
 		_plugin.force_restart_server()
+		started = true
+	if not started:
+		_server_restart_in_progress = false
+		_last_rendered_server_text = ""
+		_refresh_server_version_label()
 
 
 func _on_log_toggled(enabled: bool) -> void:

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -1122,31 +1122,38 @@ func _on_restart_stale_server() -> void:
 	_server_restart_in_progress = true
 	_last_rendered_server_text = ""
 	_refresh_server_version_label()
+	if not is_inside_tree():
+		_dispatch_stale_server_restart()
+		_server_restart_in_progress = false
+		_last_rendered_server_text = ""
+		_refresh_server_version_label()
+		return
 	call_deferred("_restart_stale_server_after_feedback")
 
 
 func _restart_stale_server_after_feedback() -> void:
 	await get_tree().create_timer(0.15).timeout
-	if _plugin == null:
+	if not _dispatch_stale_server_restart():
 		_server_restart_in_progress = false
+		_last_rendered_server_text = ""
 		_refresh_server_version_label()
-		return
+
+
+func _dispatch_stale_server_restart() -> bool:
+	if _plugin == null:
+		return false
 	var status: Dictionary = (
 		_plugin.get_server_status()
 		if _plugin.has_method("get_server_status")
 		else {}
 	)
-	var started := false
 	if str(status.get("state", "")) == McpSpawnState.INCOMPATIBLE_SERVER:
 		if _plugin.has_method("recover_incompatible_server"):
-			started = bool(_plugin.recover_incompatible_server())
+			return bool(_plugin.recover_incompatible_server())
 	elif _plugin.has_method("force_restart_server"):
 		_plugin.force_restart_server()
-		started = true
-	if not started:
-		_server_restart_in_progress = false
-		_last_rendered_server_text = ""
-		_refresh_server_version_label()
+		return true
+	return false
 
 
 func _on_log_toggled(enabled: bool) -> void:

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -575,34 +575,24 @@ func _start_server() -> void:
 			## kill the process currently holding the port.
 			print("MCP | managed server v%s does not match plugin v%s, restarting"
 				% [record_version, current_version])
-			var proof := _evaluate_strong_port_occupant_proof(port)
-			var targets: Array[int] = []
-			targets.assign(proof.get("pids", []))
-			if targets.is_empty():
-				_server_started_this_session = true
-				_set_incompatible_server(live, current_version, port)
-				push_warning(_server_status_message)
-				return
-			_kill_processes_and_windows_spawn_children(targets)
-			_wait_for_port_free(port, 3.0)
-			if _is_port_in_use(port):
+			if not _recover_strong_port_occupant(port, 3.0):
 				_server_started_this_session = true
 				_set_incompatible_server(_probe_live_server_status_for_port(port), current_version, port)
 				push_warning(_server_status_message)
 				return
-			_clear_managed_server_record()
-			_clear_pid_file()
 			## Fall through to spawn.
 		else:
-			## No recorded version drift and the live status probe did not
-			## verify an exact/current-compatible godot-ai server. A stale
-			## matching record alone is not enough ownership proof to kill
-			## the current port owner, and opening the WebSocket could route
-			## clients to an incompatible HTTP/MCP tool surface.
-			_server_started_this_session = true
-			_set_incompatible_server(live, current_version, port)
-			push_warning(_server_status_message)
-			return
+			if not _recover_strong_port_occupant(port, 3.0):
+				## No recorded version drift and the live status probe did not
+				## verify an exact/current-compatible godot-ai server. A stale
+				## matching record alone is not enough ownership proof to kill
+				## the current port owner, and opening the WebSocket could route
+				## clients to an incompatible HTTP/MCP tool surface.
+				_server_started_this_session = true
+				_set_incompatible_server(live, current_version, port)
+				push_warning(_server_status_message)
+				return
+			## Fall through to spawn.
 
 	_set_resolved_ws_port(_resolve_ws_port())
 	ws_port = _resolved_ws_port
@@ -673,7 +663,9 @@ func _set_incompatible_server(live: Dictionary, expected_version: String, port: 
 	_server_dev_version_mismatch_allowed = false
 	_server_status_message = _incompatible_server_message(live, expected_version, port, _resolved_ws_port)
 	var proof := _evaluate_recovery_port_occupant_proof(port)
-	_can_recover_incompatible = not str(proof.get("proof", "")).is_empty()
+	var proof_name := str(proof.get("proof", ""))
+	_can_recover_incompatible = not proof_name.is_empty()
+	print("MCP | proof: %s" % (proof_name if _can_recover_incompatible else "(none)"))
 	_refresh_dock_client_statuses()
 
 
@@ -1247,13 +1239,30 @@ static func _find_listener_pids_windows(port: int) -> Array[int]:
 		+ "Select-Object -ExpandProperty OwningProcess"
 	) % port
 	var output: Array = []
-	var exit_code := OS.execute(
-		"powershell.exe",
-		["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script],
-		output,
-		true
-	)
+	var exit_code := _execute_windows_powershell(script, output)
 	return _windows_listener_pids_from_execute_result(exit_code, output)
+
+
+static func _execute_windows_powershell(script: String, output: Array) -> int:
+	var args := ["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script]
+	for exe in _windows_powershell_candidates():
+		output.clear()
+		var exit_code := OS.execute(exe, args, output, true)
+		if exit_code == 0:
+			return exit_code
+	return -1
+
+
+static func _windows_powershell_candidates() -> Array[String]:
+	var candidates: Array[String] = []
+	var system_root := OS.get_environment("SystemRoot")
+	if system_root.is_empty():
+		system_root = "C:/Windows"
+	system_root = system_root.replace("\\", "/").trim_suffix("/")
+	candidates.append(system_root + "/System32/WindowsPowerShell/v1.0/powershell.exe")
+	candidates.append("powershell.exe")
+	candidates.append("pwsh.exe")
+	return candidates
 
 
 static func _windows_listener_pids_from_execute_result(exit_code: int, output: Array) -> Array[int]:
@@ -1346,14 +1355,36 @@ func _evaluate_recovery_port_occupant_proof(port: int) -> Dictionary:
 	return {"proof": "", "pids": []}
 
 
+func _recover_strong_port_occupant(port: int, wait_s: float) -> bool:
+	var proof := _evaluate_strong_port_occupant_proof(port)
+	var targets: Array[int] = []
+	targets.assign(proof.get("pids", []))
+	if targets.is_empty():
+		return false
+
+	print("MCP | strong proof: %s" % str(proof.get("proof", "")))
+	var killed := _kill_processes_and_windows_spawn_children(targets)
+	if not killed.is_empty():
+		print("MCP | killed pids %s on port %d" % [str(killed), port])
+	_wait_for_port_free(port, wait_s)
+	if _is_port_in_use(port):
+		return false
+
+	_clear_managed_server_record()
+	_clear_pid_file()
+	return true
+
+
 func _legacy_pidfile_kill_targets(_port: int, listener_pids: Array[int]) -> Array[int]:
 	var targets: Array[int] = []
 	var pidfile_pid := _read_pid_file_for_proof()
+	var pidfile_alive := _pid_alive_for_proof(pidfile_pid)
+	var pidfile_branded := _pid_cmdline_is_godot_ai_for_proof(pidfile_pid)
 	if pidfile_pid <= 1 or pidfile_pid == OS.get_process_id():
 		return targets
-	if not listener_pids.has(pidfile_pid) or not _pid_alive_for_proof(pidfile_pid):
+	if not listener_pids.has(pidfile_pid) or not pidfile_alive:
 		return targets
-	if not _pid_cmdline_is_godot_ai_for_proof(pidfile_pid):
+	if not pidfile_branded:
 		return targets
 
 	for pid in listener_pids:
@@ -1584,15 +1615,10 @@ static func _strip_pidfile_value(cmd: String) -> String:
 func _windows_pid_commandline(pid: int) -> String:
 	var output: Array = []
 	var script := (
-		"Get-CimInstance Win32_Process -Filter \"ProcessId = %d\" | "
+		"Get-CimInstance Win32_Process -Filter 'ProcessId = %d' | "
 		+ "Select-Object -ExpandProperty CommandLine"
 	) % pid
-	var exit_code := OS.execute(
-		"powershell.exe",
-		["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script],
-		output,
-		true
-	)
+	var exit_code := _execute_windows_powershell(script, output)
 	if exit_code != 0 or output.is_empty():
 		return ""
 	return str(output[0])
@@ -1826,8 +1852,11 @@ func recover_incompatible_server() -> bool:
 	targets.assign(proof.get("pids", []))
 	if targets.is_empty():
 		return false
+	print("MCP | proof: %s" % str(proof.get("proof", "")))
 
-	_kill_processes_and_windows_spawn_children(targets)
+	var killed := _kill_processes_and_windows_spawn_children(targets)
+	if not killed.is_empty():
+		print("MCP | killed pids %s on port %d" % [str(killed), port])
 	_wait_for_port_free(port, 5.0)
 	if _is_port_in_use(port):
 		return false
@@ -1998,12 +2027,7 @@ func _find_windows_spawn_children(parent_pids: Array[int]) -> Array[int]:
 			+ "Where-Object { $_.CommandLine -like '*spawn_main(parent_pid=%d*' } | "
 			+ "ForEach-Object { $_.ProcessId }"
 		) % parent_pid
-		var exit_code := OS.execute(
-			"powershell.exe",
-			["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script],
-			output,
-			true
-		)
+		var exit_code := _execute_windows_powershell(script, output)
 		if exit_code != 0 or output.is_empty():
 			continue
 		for pid in _parse_pid_lines(str(output[0])):

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -1729,6 +1729,18 @@ func can_recover_incompatible_server() -> bool:
 	return not str(proof.get("proof", "")).is_empty()
 
 
+func _resume_connection_after_recovery() -> void:
+	if _connection == null:
+		return
+	if _spawn_state != McpSpawnState.OK or _connection_blocked:
+		return
+	_connection.connect_blocked = false
+	_connection.connect_block_reason = ""
+	_connection.server_version = ""
+	_connection.set_process(true)
+	_arm_server_version_check()
+
+
 func recover_incompatible_server() -> bool:
 	if _spawn_state != McpSpawnState.INCOMPATIBLE_SERVER:
 		return false
@@ -1757,6 +1769,7 @@ func recover_incompatible_server() -> bool:
 	_server_started_this_session = false
 	_server_pid = -1
 	_start_server()
+	_resume_connection_after_recovery()
 	return true
 
 

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -1538,17 +1538,47 @@ static func _build_server_flags(port: int, ws_port: int) -> Array[String]:
 	return flags
 
 
+## Returns true only when we can prove `pid`'s command line carries the
+## `godot-ai` brand AND a server flag (`--pid-file` / `--transport`). Used by
+## automatic kill paths (`_legacy_pidfile_kill_targets`) so a stale pidfile
+## whose PID has been recycled by an unrelated listener can't hand us a
+## kill target. If the OS lookup fails or returns an empty cmdline we
+## conservatively return false — better to surface incompatible-server and
+## let the user click Restart than to kill the wrong process.
 func _pid_cmdline_is_godot_ai(pid: int) -> bool:
-	if OS.get_name() != "Windows":
-		return true
-	return _commandline_is_godot_ai_server(_windows_pid_commandline(pid))
+	if pid <= 1:
+		return false
+	var cmd := ""
+	if OS.get_name() == "Windows":
+		cmd = _windows_pid_commandline(pid)
+	else:
+		cmd = _posix_pid_commandline(pid)
+	return _commandline_is_godot_ai_server(cmd)
 
 
 static func _commandline_is_godot_ai_server(cmd: String) -> bool:
+	if cmd.is_empty():
+		return false
 	var lower := cmd.to_lower()
-	var has_brand := lower.find("godot-ai") >= 0 or lower.find("godot_ai") >= 0
+	## The server is invoked with `--pid-file <user>/godot_ai_server.pid`,
+	## so the path itself contains "godot_ai". A naive substring brand
+	## search would falsely match an unrelated process whose cmdline
+	## happens to reference a similarly-named pidfile path. Strip the
+	## value (but leave the bare flag for the has_flag check) before
+	## brand matching.
+	var brand_search := _strip_pidfile_value(lower)
+	var has_brand := brand_search.find("godot-ai") >= 0 or brand_search.find("godot_ai") >= 0
 	var has_flag := lower.find("--pid-file") >= 0 or lower.find("--transport") >= 0
 	return has_brand and has_flag
+
+
+static func _strip_pidfile_value(cmd: String) -> String:
+	var rx := RegEx.new()
+	## Match `--pid-file=<token>` and `--pid-file <token>`; keep the bare
+	## flag so the flag-presence check still succeeds for a real server.
+	if rx.compile("--pid-file(?:=|\\s+)\\S+") != OK:
+		return cmd
+	return rx.sub(cmd, "--pid-file ", true)
 
 
 func _windows_pid_commandline(pid: int) -> String:
@@ -1566,6 +1596,51 @@ func _windows_pid_commandline(pid: int) -> String:
 	if exit_code != 0 or output.is_empty():
 		return ""
 	return str(output[0])
+
+
+## POSIX command-line lookup. Linux exposes `/proc/<pid>/cmdline` as
+## NUL-separated argv — read it directly so we avoid a `ps` fork on Linux
+## and get the full argv rather than the truncated/quoted form some `ps`
+## builds emit. Falls back to `ps -ww -p <pid> -o args=` on macOS / *BSD,
+## which lack a Linux-style `/proc/<pid>/cmdline`. Returns "" on failure
+## so callers conservatively reject the PID rather than killing it blind.
+func _posix_pid_commandline(pid: int) -> String:
+	var proc_path := "/proc/%d/cmdline" % pid
+	if FileAccess.file_exists(proc_path):
+		var f := FileAccess.open(proc_path, FileAccess.READ)
+		if f != null:
+			## procfs pseudo-files report length 0 (the kernel generates
+			## content on read). `get_length()` therefore returns 0 and
+			## `get_buffer(0)` reads nothing. Read in chunks until EOF
+			## instead. Cap at ARG_MAX-class bound so a hypothetically
+			## misbehaving file can never stall the editor frame.
+			var bytes := PackedByteArray()
+			var max_bytes := 1 << 20  # 1 MiB
+			while bytes.size() < max_bytes:
+				var chunk := f.get_buffer(4096)
+				if chunk.is_empty():
+					break
+				bytes.append_array(chunk)
+				if f.eof_reached():
+					break
+			f.close()
+			## /proc cmdline is NUL-separated argv; convert NULs to spaces
+			## so the substring fingerprint matches the same way it does on
+			## the Windows path. Empty (kernel threads, exited processes)
+			## bubbles up as "" via the strip below.
+			for i in range(bytes.size()):
+				if bytes[i] == 0:
+					bytes[i] = 0x20
+			return bytes.get_string_from_utf8().strip_edges()
+	## `-ww` removes ps's column-width truncation so trailing flags like
+	## --pid-file / --transport aren't dropped from the args= field.
+	## Both procps (Linux) and BSD ps (macOS / *BSD) accept the
+	## double-w form.
+	var output: Array = []
+	var exit_code := OS.execute("ps", ["-ww", "-p", str(pid), "-o", "args="], output, true)
+	if exit_code != 0 or output.is_empty():
+		return ""
+	return str(output[0]).strip_edges()
 
 
 ## True if the given PID corresponds to a live (non-zombie) process.

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -565,8 +565,14 @@ func _start_server() -> void:
 			var owner := _find_managed_pid(port)
 			var owner_label := _adopt_compatible_server(record_version, current_version, owner)
 			_server_started_this_session = true
-			print("MCP | adopted %s server (PID %d, live v%s, WS %d, plugin v%s)"
-				% [owner_label, _server_pid, _server_actual_version, live_ws_port, current_version])
+			print(_compatible_adoption_log_message(
+				owner_label,
+				_server_pid,
+				owner,
+				_server_actual_version,
+				live_ws_port,
+				current_version
+			))
 			return
 		if _managed_record_has_version_drift(record_version, current_version):
 			## Version drift — our server but the plugin moved on. Kill
@@ -1794,6 +1800,29 @@ func _adopt_compatible_server(record_version: String, current_version: String, o
 	_clear_managed_server_record()
 	_clear_pid_file()
 	return "external"
+
+
+static func _compatible_adoption_log_message(
+	owner_label: String,
+	owned_pid: int,
+	observed_owner_pid: int,
+	live_version: String,
+	live_ws_port: int,
+	current_version: String
+) -> String:
+	if owner_label == "managed":
+		return "MCP | adopted managed server (PID %d, live v%s, WS %d, plugin v%s)" % [
+			owned_pid,
+			live_version,
+			live_ws_port,
+			current_version
+		]
+	return "MCP | adopted external server owner_pid=%d (live v%s, WS %d, plugin v%s)" % [
+		observed_owner_pid,
+		live_version,
+		live_ws_port,
+		current_version
+	]
 
 
 ## Hand the self-update over to a tiny runner that is not owned by this

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -116,8 +116,10 @@ var _refresh_retried: bool = false
 var _adoption_watch_deadline_ms: int = 0
 var _server_expected_version := ""
 var _server_actual_version := ""
+var _server_actual_name := ""
 var _server_status_message := ""
 var _server_dev_version_mismatch_allowed := false
+var _can_recover_incompatible := false
 var _connection_blocked := false
 var _awaiting_server_version := false
 var _server_version_deadline_ms: int = 0
@@ -536,7 +538,7 @@ func _start_server() -> void:
 			_resolve_ws_port()
 		))
 		ws_port = _resolved_ws_port
-		var live := _probe_live_server_status(port)
+		var live := _probe_live_server_status_for_port(port)
 		var live_version := _verified_status_version(live)
 		var live_ws_port := _verified_status_ws_port(live)
 		var compatibility := _server_status_compatibility(
@@ -547,7 +549,9 @@ func _start_server() -> void:
 			McpClientConfigurator.is_dev_checkout()
 		)
 		if compatibility.get("compatible", false):
+			_server_actual_name = "godot-ai"
 			_server_actual_version = live_version
+			_can_recover_incompatible = false
 			_server_dev_version_mismatch_allowed = bool(compatibility.get("dev_mismatch_allowed", false))
 			if _server_dev_version_mismatch_allowed:
 				_server_status_message = (
@@ -566,16 +570,28 @@ func _start_server() -> void:
 			return
 		if _managed_record_has_version_drift(record_version, current_version):
 			## Version drift — our server but the plugin moved on. Kill
-			## the port owner (not the stale launcher PID) and respawn
-			## to match the current plugin version.
+			## the proved managed occupant and respawn only after the port
+			## is actually free. A stale record by itself is not enough to
+			## kill the process currently holding the port.
 			print("MCP | managed server v%s does not match plugin v%s, restarting"
 				% [record_version, current_version])
-			var owner := _find_managed_pid(port)
-			if owner > 0:
-				OS.kill(owner)
+			var proof := _evaluate_strong_port_occupant_proof(port)
+			var targets: Array[int] = []
+			targets.assign(proof.get("pids", []))
+			if targets.is_empty():
+				_server_started_this_session = true
+				_set_incompatible_server(live, current_version, port)
+				push_warning(_server_status_message)
+				return
+			_kill_processes_and_windows_spawn_children(targets)
+			_wait_for_port_free(port, 3.0)
+			if _is_port_in_use(port):
+				_server_started_this_session = true
+				_set_incompatible_server(_probe_live_server_status_for_port(port), current_version, port)
+				push_warning(_server_status_message)
+				return
 			_clear_managed_server_record()
 			_clear_pid_file()
-			_wait_for_port_free(port, 3.0)
 			## Fall through to spawn.
 		else:
 			## No recorded version drift and the live status probe did not
@@ -652,9 +668,12 @@ func _set_incompatible_server(live: Dictionary, expected_version: String, port: 
 	_spawn_state = McpSpawnState.INCOMPATIBLE_SERVER
 	_connection_blocked = true
 	_server_expected_version = expected_version
+	_server_actual_name = str(live.get("name", ""))
 	_server_actual_version = _live_version_for_message(live)
 	_server_dev_version_mismatch_allowed = false
 	_server_status_message = _incompatible_server_message(live, expected_version, port, _resolved_ws_port)
+	var proof := _evaluate_recovery_port_occupant_proof(port)
+	_can_recover_incompatible = not str(proof.get("proof", "")).is_empty()
 	_refresh_dock_client_statuses()
 
 
@@ -753,7 +772,9 @@ static func _probe_live_server_status(port: int, timeout_ms: int = SERVER_STATUS
 	var body := PackedByteArray()
 	while true:
 		var status := client.get_status()
-		if status == HTTPClient.STATUS_REQUESTING or status == HTTPClient.STATUS_BODY:
+		if status == HTTPClient.STATUS_REQUESTING:
+			client.poll()
+		elif status == HTTPClient.STATUS_BODY:
 			client.poll()
 			var chunk := client.read_response_body_chunk()
 			if chunk.size() > 0:
@@ -783,6 +804,10 @@ static func _probe_live_server_status(port: int, timeout_ms: int = SERVER_STATUS
 	return result
 
 
+func _probe_live_server_status_for_port(port: int) -> Dictionary:
+	return _probe_live_server_status(port)
+
+
 static func _extract_server_version(payload: Dictionary) -> String:
 	var version := str(payload.get("server_version", ""))
 	if version.is_empty():
@@ -790,14 +815,18 @@ static func _extract_server_version(payload: Dictionary) -> String:
 	return version
 
 
+static func _live_status_identifies_godot_ai(live: Dictionary) -> bool:
+	return str(live.get("name", "")) == "godot-ai"
+
+
 static func _verified_status_version(live: Dictionary) -> String:
-	if str(live.get("name", "")) != "godot-ai":
+	if not _live_status_identifies_godot_ai(live):
 		return ""
 	return str(live.get("version", ""))
 
 
 static func _verified_status_ws_port(live: Dictionary) -> int:
-	if str(live.get("name", "")) != "godot-ai":
+	if not _live_status_identifies_godot_ai(live):
 		return 0
 	return int(live.get("ws_port", 0))
 
@@ -890,6 +919,7 @@ func _on_connection_established() -> void:
 func _on_server_version_verified(version: String) -> void:
 	_awaiting_server_version = false
 	_server_version_deadline_ms = 0
+	_server_actual_name = "godot-ai"
 	_server_actual_version = version
 	var expected := _server_expected_version
 	if expected.is_empty():
@@ -901,6 +931,7 @@ func _on_server_version_verified(version: String) -> void:
 		McpClientConfigurator.is_dev_checkout()
 	)
 	if compatibility.get("compatible", false):
+		_can_recover_incompatible = false
 		_server_dev_version_mismatch_allowed = bool(compatibility.get("dev_mismatch_allowed", false))
 		if _server_dev_version_mismatch_allowed:
 			_server_status_message = (
@@ -1068,10 +1099,12 @@ func get_server_status() -> Dictionary:
 	return {
 		"state": _spawn_state,
 		"exit_ms": _server_exit_ms,
+		"actual_name": _server_actual_name,
 		"actual_version": _server_actual_version,
 		"expected_version": _server_expected_version,
 		"message": _server_status_message,
 		"dev_version_mismatch_allowed": _server_dev_version_mismatch_allowed,
+		"can_recover_incompatible": _can_recover_incompatible,
 		"connection_blocked": _connection_blocked,
 	}
 
@@ -1139,6 +1172,8 @@ static func _resolve_ws_port_from_output(
 func _is_port_in_use(port: int) -> bool:
 	var output: Array = []
 	if OS.get_name() == "Windows":
+		if not _find_listener_pids_windows(port).is_empty():
+			return true
 		var exit_code := OS.execute("netstat", ["-ano"], output, true)
 		if exit_code == 0 and output.size() > 0:
 			return _parse_windows_netstat_listening(str(output[0]), port)
@@ -1162,6 +1197,9 @@ func _is_port_in_use(port: int) -> bool:
 func _find_pid_on_port(port: int) -> int:
 	var output: Array = []
 	if OS.get_name() == "Windows":
+		var listener_pids := _find_listener_pids_windows(port)
+		if not listener_pids.is_empty():
+			return listener_pids[0]
 		var exit_code := OS.execute("netstat", ["-ano"], output, true)
 		if exit_code != 0 or output.is_empty():
 			return 0
@@ -1185,6 +1223,9 @@ func _find_pid_on_port(port: int) -> int:
 ## listener rows for the same port, so collect every matching row there too.
 func _find_all_pids_on_port(port: int) -> Array[int]:
 	if OS.get_name() == "Windows":
+		var listener_pids := _find_listener_pids_windows(port)
+		if not listener_pids.is_empty():
+			return listener_pids
 		var output: Array = []
 		var exit_code := OS.execute("netstat", ["-ano"], output, true)
 		if exit_code != 0 or output.is_empty():
@@ -1197,6 +1238,33 @@ func _find_all_pids_on_port(port: int) -> Array[int]:
 		var empty: Array[int] = []
 		return empty
 	return _parse_lsof_pids(str(output[0]))
+
+
+static func _find_listener_pids_windows(port: int) -> Array[int]:
+	var script := (
+		"Get-NetTCPConnection -LocalPort %d -State Listen "
+		+ "-ErrorAction SilentlyContinue | "
+		+ "Select-Object -ExpandProperty OwningProcess"
+	) % port
+	var output: Array = []
+	var exit_code := OS.execute(
+		"powershell.exe",
+		["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script],
+		output,
+		true
+	)
+	return _windows_listener_pids_from_execute_result(exit_code, output)
+
+
+static func _windows_listener_pids_from_execute_result(exit_code: int, output: Array) -> Array[int]:
+	var empty: Array[int] = []
+	if exit_code == 0 and not output.is_empty():
+		return _parse_pid_lines(str(output[0]))
+	return empty
+
+
+static func _windows_listener_execute_result_in_use(exit_code: int, output: Array) -> bool:
+	return not _windows_listener_pids_from_execute_result(exit_code, output).is_empty()
 
 
 ## Pure-parser for the `lsof -ti...` output shape: zero or more newline-
@@ -1235,6 +1303,75 @@ func _find_managed_pid(port: int) -> int:
 	if pid > 0 and _pid_alive(pid):
 		return pid
 	return _find_pid_on_port(port)
+
+
+func _evaluate_strong_port_occupant_proof(port: int) -> Dictionary:
+	var result := {"proof": "", "pids": []}
+	var listener_pids := _find_all_pids_on_port(port)
+	if listener_pids.is_empty():
+		return result
+
+	var record := _read_managed_server_record()
+	var record_pid := int(record.get("pid", 0))
+	var record_version := str(record.get("version", ""))
+
+	if record_pid > 1 and record_pid != OS.get_process_id():
+		if listener_pids.has(record_pid) and _pid_alive_for_proof(record_pid):
+			return {"proof": "managed_record", "pids": [record_pid]}
+
+	var legacy_targets := _legacy_pidfile_kill_targets(port, listener_pids)
+	if not legacy_targets.is_empty():
+		return {"proof": "pidfile_listener", "pids": legacy_targets}
+
+	var live := _probe_live_server_status_for_port(port)
+	if (
+		_live_status_identifies_godot_ai(live)
+		and not record_version.is_empty()
+		and str(live.get("version", "")) == record_version
+	):
+		return {"proof": "status_matches_record", "pids": listener_pids}
+
+	return result
+
+
+func _evaluate_recovery_port_occupant_proof(port: int) -> Dictionary:
+	var proof := _evaluate_strong_port_occupant_proof(port)
+	if not str(proof.get("proof", "")).is_empty():
+		return proof
+
+	var live := _probe_live_server_status_for_port(port)
+	if _live_status_identifies_godot_ai(live):
+		return {"proof": "status_name", "pids": _find_all_pids_on_port(port)}
+
+	return {"proof": "", "pids": []}
+
+
+func _legacy_pidfile_kill_targets(_port: int, listener_pids: Array[int]) -> Array[int]:
+	var targets: Array[int] = []
+	var pidfile_pid := _read_pid_file_for_proof()
+	if pidfile_pid <= 1 or pidfile_pid == OS.get_process_id():
+		return targets
+	if not listener_pids.has(pidfile_pid) or not _pid_alive_for_proof(pidfile_pid):
+		return targets
+	if not _pid_cmdline_is_godot_ai_for_proof(pidfile_pid):
+		return targets
+
+	for pid in listener_pids:
+		if pid > 1 and pid != OS.get_process_id() and _pid_cmdline_is_godot_ai_for_proof(pid):
+			targets.append(pid)
+	return targets
+
+
+func _read_pid_file_for_proof() -> int:
+	return _read_pid_file()
+
+
+func _pid_alive_for_proof(pid: int) -> bool:
+	return _pid_alive(pid)
+
+
+func _pid_cmdline_is_godot_ai_for_proof(pid: int) -> bool:
+	return _pid_cmdline_is_godot_ai(pid)
 
 
 ## Parse the LISTENING line for `port` in a Windows `netstat -ano`
@@ -1401,6 +1538,36 @@ static func _build_server_flags(port: int, ws_port: int) -> Array[String]:
 	return flags
 
 
+func _pid_cmdline_is_godot_ai(pid: int) -> bool:
+	if OS.get_name() != "Windows":
+		return true
+	return _commandline_is_godot_ai_server(_windows_pid_commandline(pid))
+
+
+static func _commandline_is_godot_ai_server(cmd: String) -> bool:
+	var lower := cmd.to_lower()
+	var has_brand := lower.find("godot-ai") >= 0 or lower.find("godot_ai") >= 0
+	var has_flag := lower.find("--pid-file") >= 0 or lower.find("--transport") >= 0
+	return has_brand and has_flag
+
+
+func _windows_pid_commandline(pid: int) -> String:
+	var output: Array = []
+	var script := (
+		"Get-CimInstance Win32_Process -Filter \"ProcessId = %d\" | "
+		+ "Select-Object -ExpandProperty CommandLine"
+	) % pid
+	var exit_code := OS.execute(
+		"powershell.exe",
+		["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script],
+		output,
+		true
+	)
+	if exit_code != 0 or output.is_empty():
+		return ""
+	return str(output[0])
+
+
 ## True if the given PID corresponds to a live (non-zombie) process.
 ## POSIX uses `ps -o stat=` (see inline comment for the zombie rationale);
 ## Windows uses `tasklist`. Called by `_start_server` to distinguish a live
@@ -1495,9 +1662,29 @@ func _clear_managed_server_record() -> void:
 func prepare_for_update_reload() -> void:
 	_stop_server()
 	_server_started_this_session = false
+	if McpClientConfigurator.is_dev_checkout():
+		return
+
+	var port := McpClientConfigurator.http_port()
+	if not _is_port_in_use(port):
+		return
+
+	var proof := _evaluate_strong_port_occupant_proof(port)
+	var targets: Array[int] = []
+	targets.assign(proof.get("pids", []))
+	if targets.is_empty():
+		return
+
+	_kill_processes_and_windows_spawn_children(targets)
+	_wait_for_port_free(port, 3.0)
+	if not _is_port_in_use(port):
+		_clear_managed_server_record()
+		_clear_pid_file()
 
 
 func _adopt_compatible_server(record_version: String, current_version: String, owner: int) -> String:
+	_server_actual_name = "godot-ai"
+	_can_recover_incompatible = false
 	if record_version == current_version and owner > 0:
 		_server_pid = owner
 		_write_managed_server_record(owner, current_version)
@@ -1532,6 +1719,47 @@ func install_downloaded_update(zip_path: String, temp_dir: String, source_dock: 
 	runner.start(zip_path, temp_dir, detached_dock)
 
 
+func can_recover_incompatible_server() -> bool:
+	if _spawn_state != McpSpawnState.INCOMPATIBLE_SERVER:
+		return false
+	var port := McpClientConfigurator.http_port()
+	if not _is_port_in_use(port):
+		return false
+	var proof := _evaluate_recovery_port_occupant_proof(port)
+	return not str(proof.get("proof", "")).is_empty()
+
+
+func recover_incompatible_server() -> bool:
+	if _spawn_state != McpSpawnState.INCOMPATIBLE_SERVER:
+		return false
+
+	var port := McpClientConfigurator.http_port()
+	var proof := _evaluate_recovery_port_occupant_proof(port)
+	var targets: Array[int] = []
+	targets.assign(proof.get("pids", []))
+	if targets.is_empty():
+		return false
+
+	_kill_processes_and_windows_spawn_children(targets)
+	_wait_for_port_free(port, 5.0)
+	if _is_port_in_use(port):
+		return false
+
+	UvCacheCleanup.purge_stale_builds()
+	_clear_managed_server_record()
+	_clear_pid_file()
+	_spawn_state = McpSpawnState.OK
+	_connection_blocked = false
+	_server_status_message = ""
+	_server_actual_version = ""
+	_server_actual_name = ""
+	_can_recover_incompatible = false
+	_server_started_this_session = false
+	_server_pid = -1
+	_start_server()
+	return true
+
+
 ## Kill whichever process is holding `http_port()` right now — by resolving
 ## the port-owning PID via pid-file / netstat / lsof, independent of whether
 ## we ever set `_server_pid` — then clear ownership state and respawn via
@@ -1552,15 +1780,22 @@ func force_restart_server() -> void:
 	## if the single-pid parse fell over on multi-line lsof output) leaves
 	## the other holding the port past `_wait_for_port_free`'s window.
 	_kill_processes_and_windows_spawn_children(_find_all_pids_on_port(port))
-	_clear_managed_server_record()
-	_clear_pid_file()
 	_wait_for_port_free(port, 5.0)
+	if _is_port_in_use(port):
+		_set_incompatible_server(
+			_probe_live_server_status_for_port(port),
+			McpClientConfigurator.get_plugin_version(),
+			port
+		)
+		return
 	## Same rationale as `_stop_server`: the server child python just
 	## released its `pydantic_core` mapping, so this is the only window in
 	## which the hard-linked copies under `builds-v0\.tmp*` are deletable.
 	## Sweep before respawning so the upcoming `uvx mcp-proxy` build doesn't
 	## inherit the same cleanup-failure path that triggered the restart.
 	UvCacheCleanup.purge_stale_builds()
+	_clear_managed_server_record()
+	_clear_pid_file()
 	_server_started_this_session = false
 	_server_pid = -1
 	_start_server()

--- a/script/manual-orphan-test
+++ b/script/manual-orphan-test
@@ -1,0 +1,981 @@
+#!/usr/bin/env bash
+# Prepare local fake-server modules and print the manual proof matrix for
+# orphan/foreign MCP server recovery. This is intentionally a manual helper:
+# it does not edit Godot EditorSettings, kill real listeners, or launch Godot.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+
+is_windows_bash() {
+    case "$(uname -s 2>/dev/null || echo unknown)" in
+        MINGW*|MSYS*|CYGWIN*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+default_orphan_root() {
+    if is_windows_bash; then
+        if command -v cygpath >/dev/null 2>&1; then
+            cygpath -u 'C:\tmp\orphan-sim'
+        else
+            printf '%s\n' '/c/tmp/orphan-sim'
+        fi
+    else
+        printf '%s\n' '/tmp/orphan-sim'
+    fi
+}
+
+default_status_root() {
+    if is_windows_bash; then
+        if command -v cygpath >/dev/null 2>&1; then
+            cygpath -u 'C:\tmp\sim-statusonly'
+        else
+            printf '%s\n' '/c/tmp/sim-statusonly'
+        fi
+    else
+        printf '%s\n' '/tmp/sim-statusonly'
+    fi
+}
+
+ORPHAN_ROOT="${ORPHAN_SIM_ROOT:-$(default_orphan_root)}"
+STATUS_ROOT="${STATUS_ONLY_SIM_ROOT:-$(default_status_root)}"
+SANITY_SIM_PID=""
+SANITY_OLD_PYTHONPATH=""
+SANITY_OLD_PYTHONPATH_SET=0
+SANITY_PIDFILE=""
+SANITY_OLD_PIDFILE_CONTENT=""
+SANITY_OLD_PIDFILE_EXISTS=0
+
+to_windows_path() {
+    if command -v cygpath >/dev/null 2>&1; then
+        cygpath -w "$1"
+    else
+        printf '%s' "$1"
+    fi
+}
+
+to_bash_path() {
+    local path="$1"
+    if is_windows_bash && command -v cygpath >/dev/null 2>&1; then
+        cygpath -u "$path"
+    else
+        printf '%s' "$path"
+    fi
+}
+
+pythonpath_for_shell() {
+    local path="$1"
+    if is_windows_bash; then
+        to_windows_path "$path"
+    else
+        printf '%s' "$path"
+    fi
+}
+
+main_worktree_root() {
+    local common_dir
+    common_dir="$(git -C "$repo_root" rev-parse --git-common-dir 2>/dev/null || true)"
+    if [ -z "$common_dir" ]; then
+        return 1
+    fi
+    if [[ "$common_dir" != /* && ! "$common_dir" =~ ^[A-Za-z]:[\\/] ]]; then
+        common_dir="$repo_root/$common_dir"
+    fi
+    common_dir="$(cd "$common_dir" 2>/dev/null && pwd || true)"
+    if [ -z "$common_dir" ]; then
+        return 1
+    fi
+    dirname "$common_dir"
+}
+
+find_python() {
+    if [ -n "${PYTHON:-}" ]; then
+        printf '%s\n' "$PYTHON"
+        return 0
+    fi
+    if [ -x "$repo_root/.venv/Scripts/python.exe" ]; then
+        printf '%s\n' "$repo_root/.venv/Scripts/python.exe"
+        return 0
+    fi
+    if [ -x "$repo_root/.venv/bin/python" ]; then
+        printf '%s\n' "$repo_root/.venv/bin/python"
+        return 0
+    fi
+    local main_root
+    main_root="$(main_worktree_root || true)"
+    if [ -n "$main_root" ] && [ "$main_root" != "$repo_root" ]; then
+        if [ -x "$main_root/.venv/Scripts/python.exe" ]; then
+            printf '%s\n' "$main_root/.venv/Scripts/python.exe"
+            return 0
+        fi
+        if [ -x "$main_root/.venv/bin/python" ]; then
+            printf '%s\n' "$main_root/.venv/bin/python"
+            return 0
+        fi
+    fi
+    if command -v python3 >/dev/null 2>&1; then
+        command -v python3
+        return 0
+    fi
+    if command -v python >/dev/null 2>&1; then
+        command -v python
+        return 0
+    fi
+    if command -v py >/dev/null 2>&1; then
+        command -v py
+        return 0
+    fi
+    echo "error: neither python3 nor python was found on PATH" >&2
+    return 1
+}
+
+write_orphan_sim() {
+    mkdir -p "$ORPHAN_ROOT/godot_ai"
+    : > "$ORPHAN_ROOT/godot_ai/__init__.py"
+    cat > "$ORPHAN_ROOT/godot_ai/__main__.py" <<'PY'
+"""Minimal orphan godot-ai server simulator for manual PR verification."""
+import argparse
+import json
+import os
+import signal
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+ap = argparse.ArgumentParser()
+ap.add_argument("--transport", default="streamable-http")
+ap.add_argument("--port", type=int, default=8000)
+ap.add_argument("--ws-port", type=int, default=9500)
+ap.add_argument("--pid-file", required=True)
+ap.add_argument(
+    "--fake-version",
+    default="2.2.0",
+    help="value returned in /godot-ai/status; use 'none' to drop version",
+)
+ap.add_argument(
+    "--fake-name",
+    default="godot-ai",
+    help="name in /godot-ai/status; 'none' drops the endpoint",
+)
+ap.add_argument(
+    "--ignore-sigterm",
+    action="store_true",
+    help="trap SIGTERM so kill -15 fails (failed-kill scenario)",
+)
+args = ap.parse_args()
+
+if args.pid_file and args.pid_file.lower() != "none":
+    os.makedirs(os.path.dirname(args.pid_file), exist_ok=True)
+    with open(args.pid_file, "w", encoding="utf-8") as f:
+        f.write(str(os.getpid()))
+
+if args.ignore_sigterm:
+    signal.signal(
+        signal.SIGTERM,
+        lambda *a: print("simulator: ignoring SIGTERM", flush=True),
+    )
+
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a, **kw):
+        pass
+
+    def do_GET(self):
+        if self.path == "/godot-ai/status" and args.fake_name.lower() != "none":
+            payload = {
+                "name": args.fake_name,
+                "version": args.fake_version,
+                "ws_port": args.ws_port,
+            }
+            body = json.dumps(payload).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        self.send_response(404)
+        self.end_headers()
+
+
+print(f"simulator pid={os.getpid()} listening on :{args.port}", flush=True)
+ThreadingHTTPServer(("127.0.0.1", args.port), H).serve_forever()
+PY
+}
+
+write_status_only_sim() {
+    mkdir -p "$STATUS_ROOT/http_status_only"
+    : > "$STATUS_ROOT/http_status_only/__init__.py"
+    cat > "$STATUS_ROOT/http_status_only/__main__.py" <<'PY'
+import argparse
+import json
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+ap = argparse.ArgumentParser()
+ap.add_argument("--port", type=int, default=8000)
+ap.add_argument("--fake-version", default="2.2.0")
+ap.add_argument("--ws-port", type=int, default=9500)
+args = ap.parse_args()
+
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a, **kw):
+        pass
+
+    def do_GET(self):
+        body = json.dumps(
+            {
+                "name": "godot-ai",
+                "version": args.fake_version,
+                "ws_port": args.ws_port,
+            }
+        ).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+ThreadingHTTPServer(("127.0.0.1", args.port), H).serve_forever()
+PY
+}
+
+setup_sims() {
+    write_orphan_sim
+    write_status_only_sim
+    echo "Prepared orphan simulator:"
+    echo "  Bash path:       $ORPHAN_ROOT"
+    echo "  PYTHONPATH:      $(pythonpath_for_shell "$ORPHAN_ROOT")"
+    echo
+    echo "Prepared status-only simulator:"
+    echo "  Bash path:       $STATUS_ROOT"
+    echo "  PYTHONPATH:      $(pythonpath_for_shell "$STATUS_ROOT")"
+    if is_windows_bash; then
+        echo
+        echo "PowerShell paths:"
+        echo "  orphan sim:      $(to_windows_path "$ORPHAN_ROOT")"
+        echo "  status-only sim: $(to_windows_path "$STATUS_ROOT")"
+    fi
+}
+
+editor_settings_candidates() {
+    if is_windows_bash; then
+        local appdata
+        appdata="$(powershell.exe -NoProfile -Command '[Environment]::GetFolderPath("ApplicationData")' 2>/dev/null | tr -d '\r' || true)"
+        if [ -n "$appdata" ]; then
+            printf '%s\n' \
+                "$appdata\\Godot\\editor_settings-4.6.tres" \
+                "$appdata\\Godot\\editor_settings-4.5.tres" \
+                "$appdata\\Godot\\editor_settings-4.tres"
+        else
+            printf '%s\n' \
+                '$env:APPDATA\Godot\editor_settings-4.6.tres' \
+                '$env:APPDATA\Godot\editor_settings-4.5.tres' \
+                '$env:APPDATA\Godot\editor_settings-4.tres'
+        fi
+    else
+        printf '%s\n' \
+            "$HOME/.config/godot/editor_settings-4.6.tres" \
+            "$HOME/.config/godot/editor_settings-4.5.tres" \
+            "$HOME/.config/godot/editor_settings-4.tres" \
+            "$HOME/Library/Application Support/Godot/editor_settings-4.6.tres" \
+            "$HOME/Library/Application Support/Godot/editor_settings-4.5.tres" \
+            "$HOME/Library/Application Support/Godot/editor_settings-4.tres"
+    fi
+}
+
+active_editor_settings() {
+    local candidate bash_path
+    while IFS= read -r candidate; do
+        bash_path="$(to_bash_path "$candidate")"
+        if [ -f "$bash_path" ]; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done < <(editor_settings_candidates)
+    return 1
+}
+
+print_editor_settings_preflight() {
+    echo "EditorSettings candidates:"
+    local candidate bash_path marker
+    while IFS= read -r candidate; do
+        bash_path="$(to_bash_path "$candidate")"
+        marker="missing"
+        if [ -f "$bash_path" ]; then
+            marker="exists"
+        fi
+        echo "  [$marker] $candidate"
+    done < <(editor_settings_candidates)
+
+    local active active_bash
+    if active="$(active_editor_settings)"; then
+        active_bash="$(to_bash_path "$active")"
+        echo
+        echo "Active EditorSettings:"
+        echo "  $active"
+        echo "godot_ai settings:"
+        if ! grep -E 'godot_ai/(http_port|ws_port|managed_server_(pid|version|ws_port))' "$active_bash" 2>/dev/null | sed 's/^/  /'; then
+            echo "  (none found; defaults are http_port=8000 and ws_port=9500)"
+        fi
+    else
+        echo
+        echo "Active EditorSettings: not found"
+        echo "  Start Godot once, then re-run preflight."
+    fi
+}
+
+print_port_8000_preflight() {
+    echo "Port 8000 listener:"
+    if is_windows_bash; then
+        powershell.exe -NoProfile -Command '
+$conn = Get-NetTCPConnection -LocalPort 8000 -State Listen -ErrorAction SilentlyContinue | Select-Object -First 1
+if ($null -eq $conn) {
+  "  none"
+  exit 0
+}
+$pidValue = [int]$conn.OwningProcess
+"  pid=$pidValue"
+$proc = Get-CimInstance Win32_Process -Filter ("ProcessId=" + $pidValue)
+if ($null -ne $proc -and $proc.CommandLine) {
+  "  command=$($proc.CommandLine)"
+} else {
+  "  command=(unavailable)"
+}
+' 2>/dev/null | tr -d '\r' || echo "  unavailable"
+    elif command -v lsof >/dev/null 2>&1; then
+        local pids
+        pids="$(lsof -ti:8000 -sTCP:LISTEN 2>/dev/null || true)"
+        if [ -z "$pids" ]; then
+            echo "  none"
+            return
+        fi
+        local pid
+        while IFS= read -r pid; do
+            [ -z "$pid" ] && continue
+            echo "  pid=$pid"
+            if ps -ww -p "$pid" -o args= >/dev/null 2>&1; then
+                ps -ww -p "$pid" -o args= | sed 's/^/  command=/'
+            else
+                echo "  command=(unavailable)"
+            fi
+        done <<< "$pids"
+    else
+        echo "  lsof unavailable"
+    fi
+}
+
+print_checkout_preflight() {
+    local version git_head
+    version="$(sed -n 's/^version="\([^"]*\)"/\1/p' "$repo_root/plugin/addons/godot_ai/plugin.cfg" | head -n 1)"
+    git_head="$(git -C "$repo_root" rev-parse --short HEAD 2>/dev/null || true)"
+    echo "Checkout:"
+    echo "  repo:    $repo_root"
+    echo "  git:     ${git_head:-unavailable}"
+    echo "  plugin:  ${version:-unknown}"
+    echo "Proof symbols:"
+    local plugin_gd="$repo_root/plugin/addons/godot_ai/plugin.gd"
+    local sym marker
+    for sym in \
+        'MCP | strong proof:' \
+        'MCP | proof:' \
+        'MCP | killed pids' \
+        'managed_record' \
+        'pidfile_listener' \
+        'status_name'
+    do
+        marker="missing"
+        if grep -Fq "$sym" "$plugin_gd"; then
+            marker="present"
+        fi
+        echo "  [$marker] $sym"
+    done
+}
+
+print_preflight() {
+    echo "# manual-orphan-test preflight"
+    echo
+    print_checkout_preflight
+    echo
+    print_editor_settings_preflight
+    echo
+    print_port_8000_preflight
+    echo
+    echo "Simulator roots:"
+    echo "  orphan sim:      $ORPHAN_ROOT"
+    echo "  status-only sim: $STATUS_ROOT"
+}
+
+print_paths() {
+    cat <<EOF
+Repository:
+  $repo_root
+
+Simulator roots:
+  orphan sim:      $ORPHAN_ROOT
+  status-only sim: $STATUS_ROOT
+
+Python import paths for this shell:
+  orphan sim:      $(pythonpath_for_shell "$ORPHAN_ROOT")
+  status-only sim: $(pythonpath_for_shell "$STATUS_ROOT")
+EOF
+    if is_windows_bash; then
+        cat <<EOF
+
+PowerShell import paths:
+  orphan sim:      $(to_windows_path "$ORPHAN_ROOT")
+  status-only sim: $(to_windows_path "$STATUS_ROOT")
+EOF
+    fi
+}
+
+port_8000_in_use() {
+    if is_windows_bash; then
+        powershell.exe -NoProfile -Command 'if (Get-NetTCPConnection -LocalPort 8000 -State Listen -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }' >/dev/null 2>&1
+        return $?
+    fi
+    if command -v lsof >/dev/null 2>&1; then
+        lsof -ti:8000 -sTCP:LISTEN >/dev/null 2>&1
+        return $?
+    fi
+    return 1
+}
+
+run_sanity() {
+    setup_sims
+    echo
+    print_preflight
+    echo
+    if port_8000_in_use; then
+        echo "error: port 8000 is already in use; free it before running sanity" >&2
+        return 1
+    fi
+
+    local py
+    py="$(find_python)"
+    local pidfile="$HOME/.local/share/godot/app_userdata/MCP Test Project/godot_ai_server.pid"
+    if is_windows_bash; then
+        local appdata
+        appdata="$(powershell.exe -NoProfile -Command '[Environment]::GetFolderPath("ApplicationData")' 2>/dev/null | tr -d '\r' || true)"
+        if [ -n "$appdata" ]; then
+            pidfile="$(to_bash_path "$appdata\\Godot\\app_userdata\\MCP Test Project\\godot_ai_server.pid")"
+        fi
+    fi
+    mkdir -p "$(dirname "$pidfile")"
+    SANITY_PIDFILE="$pidfile"
+    SANITY_OLD_PIDFILE_CONTENT=""
+    SANITY_OLD_PIDFILE_EXISTS=0
+    if [ -f "$pidfile" ]; then
+        SANITY_OLD_PIDFILE_CONTENT="$(cat "$pidfile" 2>/dev/null || true)"
+        SANITY_OLD_PIDFILE_EXISTS=1
+    fi
+    local sim_pythonpath
+    sim_pythonpath="$(pythonpath_for_shell "$ORPHAN_ROOT")"
+    local old_pythonpath="${PYTHONPATH:-}"
+    SANITY_OLD_PYTHONPATH="$old_pythonpath"
+    if [ -n "${PYTHONPATH+x}" ]; then
+        SANITY_OLD_PYTHONPATH_SET=1
+    else
+        SANITY_OLD_PYTHONPATH_SET=0
+    fi
+    local sep=":"
+    if is_windows_bash; then
+        sep=";"
+    fi
+    if [ -n "$old_pythonpath" ]; then
+        export PYTHONPATH="$sim_pythonpath$sep$old_pythonpath"
+    else
+        export PYTHONPATH="$sim_pythonpath"
+    fi
+
+    cleanup() {
+        if [ -n "${SANITY_SIM_PID:-}" ]; then
+            kill "$SANITY_SIM_PID" >/dev/null 2>&1 || true
+            wait "$SANITY_SIM_PID" >/dev/null 2>&1 || true
+            SANITY_SIM_PID=""
+        fi
+        if [ "${SANITY_PIDFILE:-}" != "" ] && [ "$SANITY_OLD_PIDFILE_EXISTS" = "1" ]; then
+            printf '%s' "$SANITY_OLD_PIDFILE_CONTENT" > "$SANITY_PIDFILE"
+        else
+            rm -f "${SANITY_PIDFILE:-}"
+        fi
+        SANITY_PIDFILE=""
+        SANITY_OLD_PIDFILE_CONTENT=""
+        SANITY_OLD_PIDFILE_EXISTS=0
+        if [ "${SANITY_OLD_PYTHONPATH_SET:-0}" = "1" ]; then
+            export PYTHONPATH="$SANITY_OLD_PYTHONPATH"
+        else
+            unset PYTHONPATH
+        fi
+    }
+    trap cleanup EXIT
+
+    "$py" -m godot_ai \
+        --transport streamable-http \
+        --port 8000 \
+        --ws-port 9500 \
+        --pid-file "$pidfile" \
+        --fake-version 2.2.0 &
+    SANITY_SIM_PID=$!
+    sleep 0.7
+
+    echo
+    echo "Status endpoint:"
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsS http://127.0.0.1:8000/godot-ai/status | "$py" -m json.tool
+    else
+        "$py" - <<'PY'
+import json
+from urllib.request import urlopen
+
+with urlopen("http://127.0.0.1:8000/godot-ai/status", timeout=2) as r:
+    print(json.dumps(json.loads(r.read()), indent=4))
+PY
+    fi
+
+    echo
+    echo "Simulator command line:"
+    local inspect_pid="$SANITY_SIM_PID"
+    local pid_from_file=""
+    if [ -f "$pidfile" ]; then
+        pid_from_file="$(tr -d '[:space:]' < "$pidfile" || true)"
+        if [[ "$pid_from_file" =~ ^[0-9]+$ ]]; then
+            inspect_pid="$pid_from_file"
+        fi
+    fi
+    if ps -p "$inspect_pid" -o args= >/dev/null 2>&1; then
+        ps -p "$inspect_pid" -o args=
+    elif is_windows_bash && command -v powershell.exe >/dev/null 2>&1; then
+        powershell.exe -NoProfile -Command "\$p = Get-CimInstance Win32_Process -Filter 'ProcessId=$inspect_pid'; if (\$p) { \$p.CommandLine } else { exit 1 }"
+    else
+        echo "ps command-line inspection is unavailable in this shell."
+        echo "Expected fingerprint: godot_ai --transport ... --pid-file ..."
+    fi
+}
+
+print_instructions() {
+    local orphan_pp status_pp orphan_pwsh_pp status_pwsh_pp posix_orphan_pp posix_status_pp
+    local posix_project posix_repo repo_win project_win
+    orphan_pp="$(pythonpath_for_shell "$ORPHAN_ROOT")"
+    status_pp="$(pythonpath_for_shell "$STATUS_ROOT")"
+    if is_windows_bash; then
+        orphan_pwsh_pp="$(to_windows_path "$ORPHAN_ROOT")"
+        status_pwsh_pp="$(to_windows_path "$STATUS_ROOT")"
+        posix_orphan_pp="/tmp/orphan-sim"
+        posix_status_pp="/tmp/sim-statusonly"
+        posix_repo="\$HOME/godot-ai"
+        posix_project="\$HOME/godot-ai/test_project"
+        repo_win="$(to_windows_path "$repo_root")"
+    else
+        orphan_pwsh_pp='C:\tmp\orphan-sim'
+        status_pwsh_pp='C:\tmp\sim-statusonly'
+        posix_orphan_pp="$orphan_pp"
+        posix_status_pp="$status_pp"
+        posix_repo="$repo_root"
+        posix_project="$repo_root/test_project"
+        repo_win='C:\path\to\godot-ai'
+    fi
+    project_win="$repo_win\\test_project"
+
+    cat <<EOF
+# Manual orphan/foreign server proof tests
+
+Run these before the scenarios:
+
+    script/manual-orphan-test setup
+    script/manual-orphan-test preflight
+
+This prepares two fake modules:
+
+    orphan godot_ai module:      $ORPHAN_ROOT
+    status-only occupant module: $STATUS_ROOT
+
+The preflight prints:
+
+- candidate Godot EditorSettings files, including editor_settings-4.6.tres
+- current godot_ai/http_port, godot_ai/ws_port, and managed-server keys
+- current port-8000 listener PID and command line
+- checkout commit, plugin version, and proof-symbol presence
+
+These recipes assume the PR branch emits proof-tier log lines such as:
+
+    MCP | port 8000 in use, evaluating proof...
+    MCP | strong proof: managed_record
+    MCP | strong proof: pidfile_listener
+    MCP | proof: status_name
+    MCP | killed pids [...]
+    MCP | incompatible server detected
+    MCP | spawned managed server pid=...
+
+The helper does not edit EditorSettings. Close Godot before manually editing
+editor_settings-4.6.tres or editor_settings-4.tres.
+
+## Safe reset checklist
+
+Before each scenario, back up EditorSettings and put the ports back to the
+baseline expected by the matrix:
+
+PowerShell:
+
+    \$edCandidates = @(
+      "\$env:APPDATA\\Godot\\editor_settings-4.6.tres",
+      "\$env:APPDATA\\Godot\\editor_settings-4.5.tres",
+      "\$env:APPDATA\\Godot\\editor_settings-4.tres"
+    )
+    \$ed = \$edCandidates | Where-Object { Test-Path -LiteralPath \$_ } | Select-Object -First 1
+    if (-not \$ed) { throw "No Godot editor_settings-4*.tres found under APPDATA\\Godot" }
+    Copy-Item -LiteralPath \$ed -Destination ("\$ed.bak-" + (Get-Date -Format yyyyMMdd-HHmmss))
+    Select-String -LiteralPath \$ed -Pattern 'godot_ai/(http_port|ws_port|managed_server_)'
+
+Then edit \$ed so these lines are present exactly once:
+
+    godot_ai/http_port = 8000
+    godot_ai/ws_port = 9500
+
+For scenarios that require a clean ownership record, remove or zero:
+
+    godot_ai/managed_server_pid
+    godot_ai/managed_server_version
+    godot_ai/managed_server_ws_port
+
+And remove the pidfile when the scenario says "clean record":
+
+    Remove-Item -LiteralPath "\$env:APPDATA\\Godot\\app_userdata\\MCP Test Project\\godot_ai_server.pid" -ErrorAction SilentlyContinue
+
+POSIX:
+
+    EDITOR_SETTINGS="\$HOME/.config/godot/editor_settings-4.6.tres"
+    [ -f "\$EDITOR_SETTINGS" ] || EDITOR_SETTINGS="\$HOME/.config/godot/editor_settings-4.tres"
+    cp "\$EDITOR_SETTINGS" "\$EDITOR_SETTINGS.bak-\$(date +%Y%m%d-%H%M%S)"
+    grep -E 'godot_ai/(http_port|ws_port|managed_server_)' "\$EDITOR_SETTINGS" || true
+
+Launching Godot may dirty test_project/project.godot. After each scenario:
+
+    git -C "$posix_repo" diff --stat
+
+On Windows:
+
+    git -C "$repo_win" diff --stat
+
+## Quick simulator sanity check
+
+Port 8000 must be free:
+
+    PYTHON_BIN="\${PYTHON:-python3}"
+    PYTHONPATH="$orphan_pp" "\$PYTHON_BIN" -m godot_ai \\
+      --transport streamable-http --port 8000 --ws-port 9500 \\
+      --pid-file "\$HOME/.local/share/godot/app_userdata/MCP Test Project/godot_ai_server.pid" \\
+      --fake-version 2.2.0 &
+    SIM_PID=\$!
+    sleep 0.5
+    curl -s http://127.0.0.1:8000/godot-ai/status | "\$PYTHON_BIN" -m json.tool
+    ps -ww -p \$SIM_PID -o args=
+    kill \$SIM_PID
+
+Expected: JSON includes name=godot-ai and version=2.2.0. The command line
+contains "godot_ai --transport ... --pid-file ...".
+
+## Common POSIX paths
+
+    USER_DIR_LINUX="\$HOME/.local/share/godot/app_userdata/MCP Test Project"
+    USER_DIR_MAC="\$HOME/Library/Application Support/Godot/app_userdata/MCP Test Project"
+    USER_DIR="\$USER_DIR_LINUX"
+    PIDFILE="\$USER_DIR/godot_ai_server.pid"
+
+    EDITOR_SETTINGS_LINUX="\$HOME/.config/godot/editor_settings-4.6.tres"
+    EDITOR_SETTINGS_MAC="\$HOME/Library/Application Support/Godot/editor_settings-4.6.tres"
+    EDITOR_SETTINGS="\$EDITOR_SETTINGS_LINUX"
+
+    GODOT="/Applications/Godot_mono.app/Contents/MacOS/Godot"
+    PROJECT="$posix_project"
+
+Launch the editor with console logging:
+
+    "\$GODOT" --editor --path "\$PROJECT" 2>&1 | tee /tmp/mcp-editor.log
+    tail -f /tmp/mcp-editor.log | grep -E 'MCP \\||godot[_-]ai'
+
+## Scenario 1: Windows v2.2.0 orphan recovery
+
+Use PowerShell. This tests the legacy-pidfile proof tier that motivated the PR.
+
+    \$edCandidates = @(
+      "\$env:APPDATA\\Godot\\editor_settings-4.6.tres",
+      "\$env:APPDATA\\Godot\\editor_settings-4.5.tres",
+      "\$env:APPDATA\\Godot\\editor_settings-4.tres"
+    )
+    \$ed = \$edCandidates | Where-Object { Test-Path -LiteralPath \$_ } | Select-Object -First 1
+    Copy-Item -LiteralPath \$ed -Destination ("\$ed.bak-" + (Get-Date -Format yyyyMMdd-HHmmss))
+    # Close Godot, set godot_ai/http_port=8000 and godot_ai/ws_port=9500.
+    # Remove or zero:
+    # godot_ai/managed_server_pid
+    # godot_ai/managed_server_version
+    # godot_ai/managed_server_ws_port
+
+    Get-NetTCPConnection -LocalPort 8000 -ErrorAction SilentlyContinue
+
+    \$repo = "$repo_win"
+    \$python = Join-Path \$repo ".venv\\Scripts\\python.exe"
+    if (!(Test-Path -LiteralPath \$python)) { \$python = "python" }
+    \$pidfile = "\$env:APPDATA\\Godot\\app_userdata\\MCP Test Project\\godot_ai_server.pid"
+    New-Item -Force -ItemType Directory (Split-Path \$pidfile) | Out-Null
+
+    \$psi = [System.Diagnostics.ProcessStartInfo]::new()
+    \$psi.FileName = \$python
+    \$psi.UseShellExecute = \$false
+    \$psi.Environment["PYTHONPATH"] = "$orphan_pwsh_pp"
+    foreach (\$arg in @(
+      "-m","godot_ai",
+      "--transport","streamable-http",
+      "--port","8000",
+      "--ws-port","9500",
+      "--pid-file",\$pidfile,
+      "--fake-version","2.2.0"
+    )) { [void]\$psi.ArgumentList.Add(\$arg) }
+    \$sim = [System.Diagnostics.Process]::Start(\$psi)
+    \$sim.Id
+
+    Get-NetTCPConnection -LocalPort 8000
+    Get-CimInstance Win32_Process -Filter ("ProcessId=" + \$sim.Id) | Select ProcessId,CommandLine
+    & "C:\\path\\to\\Godot.exe" --editor --path "$project_win"
+
+Pass criteria:
+
+- Console shows "MCP | strong proof: pidfile_listener".
+- Console shows "MCP | killed pids [<simulator_pid>]".
+- Port 8000 has a new PID, not the simulator PID.
+- Pidfile contents equal the new server PID.
+- Dock is green with no Restart button.
+- The old simulator process no longer exists.
+
+## Scenario 2: Windows localized shell safety
+
+Use PowerShell and repeat the scenario 1 pidfile-only orphan path after changing
+UI culture:
+
+    \$savedCulture = [System.Threading.Thread]::CurrentThread.CurrentUICulture
+    [System.Threading.Thread]::CurrentThread.CurrentUICulture =
+      [System.Globalization.CultureInfo]::GetCultureInfo("ja-JP")
+    try {
+      # Repeat scenario 1 from the ProcessStartInfo simulator launch onward.
+    } finally {
+      [System.Threading.Thread]::CurrentThread.CurrentUICulture = \$savedCulture
+    }
+
+Pass criteria: same as scenario 1. The PowerShell-first listener lookup must not
+depend on localized netstat text.
+
+Optional netstat fallback check: on a disposable admin machine, temporarily make
+powershell.exe unavailable and repeat. Skip this on a normal workstation; renaming
+system binaries is high risk.
+
+## Scenario 3: Cross-platform managed drift cleanup
+
+This tests the managed_record proof tier.
+
+    PYTHONPATH="$posix_orphan_pp" python3 -m godot_ai \\
+      --transport streamable-http --port 8000 --ws-port 9500 \\
+      --pid-file "\$PIDFILE" --fake-version 2.1.0 &
+    SIM_PID=\$!
+    sleep 0.5
+
+Close Godot and add or replace these lines in \$EDITOR_SETTINGS:
+
+    godot_ai/http_port = 8000
+    godot_ai/ws_port = 9500
+    godot_ai/managed_server_pid = <SIM_PID>
+    godot_ai/managed_server_version = "2.1.0"
+    godot_ai/managed_server_ws_port = 9500
+
+Then launch:
+
+    "\$GODOT" --editor --path "\$PROJECT" 2>&1 | tee /tmp/mcp-editor.log
+
+Pass criteria:
+
+- Console shows "MCP | strong proof: managed_record".
+- Console shows "MCP | killed pids [\$SIM_PID]".
+- Port 8000 now has a different PID.
+- Dock is green with no Restart button.
+
+## Scenario 4: Failed-kill preservation (POSIX only)
+
+Use Linux/macOS for this scenario unless you add a Windows-specific way to make
+taskkill fail. The simulator's --ignore-sigterm only exercises the POSIX
+OS.kill/SIGTERM path.
+
+Use the same managed record as scenario 3, but start the simulator with
+--ignore-sigterm:
+
+    PYTHONPATH="$posix_orphan_pp" python3 -m godot_ai \\
+      --transport streamable-http --port 8000 --ws-port 9500 \\
+      --pid-file "\$PIDFILE" --fake-version 2.1.0 \\
+      --ignore-sigterm &
+    SIM_PID=\$!
+
+Pass criteria:
+
+- Console shows kill failure or "port 8000 still in use".
+- Dock shows the incompatible-server banner.
+- "\$PIDFILE" still contains \$SIM_PID.
+- The managed-server settings still show the old version.
+- No new server spawned; port 8000 is still held by \$SIM_PID.
+
+Cleanup:
+
+    kill -KILL \$SIM_PID
+
+## Scenario 5: Status-name-only occupant safety
+
+This proves auto-kill is not triggered when the only evidence is a status
+endpoint returning name=godot-ai.
+
+    rm -f "\$PIDFILE"
+    # Close Godot, then remove godot_ai/managed_server_* from \$EDITOR_SETTINGS.
+
+    PYTHONPATH="$posix_status_pp" python3 -m http_status_only &
+    SIM_PID=\$!
+    ps -ww -p \$SIM_PID -o args=
+
+    "\$GODOT" --editor --path "\$PROJECT" 2>&1 | tee /tmp/mcp-editor.log
+
+Initial pass criteria:
+
+- Console shows "MCP | proof: status_name".
+- Console shows incompatible server with recoverable=true or equivalent.
+- No "killed pids" line appears.
+- Dock is yellow and includes a Restart button.
+- Port 8000 is still held by \$SIM_PID.
+
+After clicking Restart in the dock:
+
+- Console shows "MCP | killed pids [\$SIM_PID]".
+- Port 8000 has a new listener.
+- Dock turns green.
+
+## Scenario 6: Non-godot occupant safety
+
+    rm -f "\$PIDFILE"
+    # Close Godot, then remove godot_ai/managed_server_* from \$EDITOR_SETTINGS.
+
+    python3 -m http.server 8000 &
+    SIM_PID=\$!
+
+    "\$GODOT" --editor --path "\$PROJECT" 2>&1 | tee /tmp/mcp-editor.log
+
+Pass criteria:
+
+- Console shows proof "(none)" or incompatible_server recoverable=false.
+- Dock shows a warning without a Restart button.
+- No "killed pids" line appears.
+- Port 8000 is still held by the http.server PID.
+
+Cleanup:
+
+    kill \$SIM_PID
+
+## Scenario 7: Compatible adoption sanity
+
+Start the real current-version server outside the editor:
+
+    cd "$posix_repo"
+    script/serve-this-worktree &
+    SERVER_PID=\$!
+    sleep 1
+    curl -s http://127.0.0.1:8000/godot-ai/status
+
+    "\$GODOT" --editor --path "\$PROJECT" 2>&1 | tee /tmp/mcp-editor.log
+
+Windows simulator equivalent for a compatible external current server:
+
+    \$repo = "$repo_win"
+    \$python = Join-Path \$repo ".venv\\Scripts\\python.exe"
+    if (!(Test-Path -LiteralPath \$python)) { \$python = "python" }
+    \$pidfile = "\$env:APPDATA\\Godot\\app_userdata\\MCP Test Project\\godot_ai_server.pid"
+
+    \$psi = [System.Diagnostics.ProcessStartInfo]::new()
+    \$psi.FileName = \$python
+    \$psi.UseShellExecute = \$false
+    \$psi.Environment["PYTHONPATH"] = "$status_pwsh_pp"
+    foreach (\$arg in @("-m","http_status_only","--port","8000","--ws-port","9500","--fake-version","2.2.3")) {
+      [void]\$psi.ArgumentList.Add(\$arg)
+    }
+    \$server = [System.Diagnostics.Process]::Start(\$psi)
+
+Pass criteria:
+
+- Console shows the plugin adopted the existing compatible server.
+- External adoption logs the observed owner PID, while managed ownership remains unset.
+- Dock is green with no banner and no Restart button.
+- Port 8000 is still held by \$SERVER_PID or \$server.Id.
+- Dock status includes actual_name=godot-ai.
+
+## Recommended order
+
+Run 6 and 5 first to prove unrelated processes are not killed. Then run 3, 1,
+4, and finally 2 and 7 as sanity sweeps.
+
+If a scenario fails, capture:
+
+- /tmp/mcp-editor.log
+- contents of \$PIDFILE
+- grep godot_ai/managed_server "\$EDITOR_SETTINGS"
+- script/manual-orphan-test preflight
+- git diff --stat
+EOF
+}
+
+usage() {
+    cat <<'EOF'
+Usage: script/manual-orphan-test [command]
+
+Commands:
+  setup         Write the fake godot_ai and status-only simulator packages.
+  instructions Print the manual scenario matrix.
+  sanity       Run a short orphan simulator status/cmdline check on port 8000.
+  paths        Print the resolved simulator paths.
+  preflight    Print EditorSettings, port-listener, version, and proof checks.
+  help         Show this help.
+
+Default: setup, then print instructions.
+
+Environment:
+  ORPHAN_SIM_ROOT       Override the fake godot_ai package root.
+  STATUS_ONLY_SIM_ROOT  Override the fake status-only package root.
+  PYTHON                Python executable for sanity checks.
+EOF
+}
+
+main() {
+    local cmd="${1:-default}"
+    case "$cmd" in
+        default)
+            setup_sims
+            echo
+            print_instructions
+            ;;
+        setup)
+            setup_sims
+            ;;
+        instructions|print)
+            print_instructions
+            ;;
+        sanity)
+            run_sanity
+            ;;
+        paths)
+            print_paths
+            ;;
+        preflight)
+            print_preflight
+            ;;
+        help|-h|--help)
+            usage
+            ;;
+        *)
+            usage >&2
+            exit 2
+            ;;
+    esac
+}
+
+main "$@"

--- a/src/godot_ai/godot_client/client.py
+++ b/src/godot_ai/godot_client/client.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from fastmcp.exceptions import FastMCPError
+
 from godot_ai.protocol.errors import ErrorCode
 from godot_ai.sessions.registry import SessionRegistry
 from godot_ai.transport.websocket import GodotWebSocketServer
@@ -12,7 +14,7 @@ from godot_ai.transport.websocket import GodotWebSocketServer
 logger = logging.getLogger(__name__)
 
 
-class GodotCommandError(Exception):
+class GodotCommandError(FastMCPError):
     """Raised when a Godot plugin command returns an error response."""
 
     def __init__(
@@ -29,6 +31,9 @@ class GodotCommandError(Exception):
             super().__init__(f"{code}: {message}{suffix}")
         else:
             super().__init__(f"{code}: {message}")
+
+    def to_payload(self) -> dict[str, Any]:
+        return {"code": self.code, "message": self.message, "data": self.data}
 
 
 class GodotClient:
@@ -80,6 +85,7 @@ class GodotClient:
             raise GodotCommandError(
                 code=error.code if error else "UNKNOWN",
                 message=error.message if error else "Unknown error",
+                data=error.data if error else {},
             )
 
         return response.data

--- a/src/godot_ai/middleware/__init__.py
+++ b/src/godot_ai/middleware/__init__.py
@@ -6,6 +6,7 @@ from godot_ai.middleware.client_wrapper_kwargs import (
     CLIENT_WRAPPER_KWARGS,
     StripClientWrapperKwargs,
 )
+from godot_ai.middleware.godot_command_error import PreserveGodotCommandErrorData
 from godot_ai.middleware.op_typo_hint import HintOpTypoOnManage
 from godot_ai.middleware.parse_stringified_params import ParseStringifiedParams
 
@@ -13,5 +14,6 @@ __all__ = [
     "CLIENT_WRAPPER_KWARGS",
     "HintOpTypoOnManage",
     "ParseStringifiedParams",
+    "PreserveGodotCommandErrorData",
     "StripClientWrapperKwargs",
 ]

--- a/src/godot_ai/middleware/godot_command_error.py
+++ b/src/godot_ai/middleware/godot_command_error.py
@@ -1,0 +1,38 @@
+"""Preserve structured Godot command errors in MCP tool responses."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
+from fastmcp.tools.base import ToolResult
+from mcp.types import CallToolRequestParams, CallToolResult, TextContent
+
+from godot_ai.godot_client.client import GodotCommandError
+
+
+class GodotCommandErrorToolResult(ToolResult):
+    """ToolResult variant that can mark the MCP response as an error."""
+
+    def to_mcp_result(self) -> CallToolResult:
+        return CallToolResult(
+            content=self.content,
+            structuredContent=self.structured_content,
+            isError=True,
+        )
+
+
+class PreserveGodotCommandErrorData(Middleware):
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[CallToolRequestParams],
+        call_next: CallNext[CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        try:
+            return await call_next(context)
+        except GodotCommandError as exc:
+            error_payload: dict[str, Any] = exc.to_payload()
+            return GodotCommandErrorToolResult(
+                content=[TextContent(type="text", text=str(exc))],
+                structured_content={"error": error_payload},
+            )

--- a/src/godot_ai/protocol/envelope.py
+++ b/src/godot_ai/protocol/envelope.py
@@ -30,6 +30,7 @@ class ErrorDetail(BaseModel):
 
     code: str
     message: str
+    data: dict[str, Any] = Field(default_factory=dict)
 
 
 class HandshakeMessage(BaseModel):

--- a/src/godot_ai/server.py
+++ b/src/godot_ai/server.py
@@ -19,6 +19,7 @@ from godot_ai.godot_client.client import GodotClient
 from godot_ai.middleware import (
     HintOpTypoOnManage,
     ParseStringifiedParams,
+    PreserveGodotCommandErrorData,
     StripClientWrapperKwargs,
 )
 from godot_ai.resources.editor import register_editor_resources
@@ -160,6 +161,10 @@ def create_server(
         ),
         lifespan=_lifespan,
     )
+
+    ## Keep plugin-provided error.data (e.g. candidate paths) visible on MCP
+    ## tool error responses instead of collapsing it into plain text.
+    mcp.add_middleware(PreserveGodotCommandErrorData())
 
     ## Tolerate known client-injected wrapper kwargs (Cline's task_progress,
     ## etc.) so strict pydantic schemas don't reject every call. See #193.

--- a/test_project/tests/test_cli_exec.gd
+++ b/test_project/tests/test_cli_exec.gd
@@ -51,6 +51,42 @@ func test_run_captures_stdout_and_zero_exit_on_quick_command() -> void:
 		"Captured stdout must include the echoed token")
 
 
+func test_run_captures_stderr_by_default() -> void:
+	var fixture := _stderr_fixture_command(7)
+	if fixture.is_empty():
+		skip("No shell available for stderr fixture")
+		return
+	var result := McpCliExec.run(
+		fixture["exe"],
+		fixture["args"],
+		5000
+	)
+	assert_eq(int(result.get("exit_code", 0)), 7)
+	assert_contains(str(result.get("stdout", "")), "stdout-token")
+	assert_contains(str(result.get("stderr", "")), "stderr-token")
+	assert_contains(str(result.get("output", "")), "stderr-token")
+
+
+func test_run_can_skip_stderr_capture_for_status_probe() -> void:
+	var fixture := _stderr_fixture_command(0)
+	if fixture.is_empty():
+		skip("No shell available for stderr fixture")
+		return
+	var result := McpCliExec.run(
+		fixture["exe"],
+		fixture["args"],
+		5000,
+		false
+	)
+	assert_eq(int(result.get("exit_code", -1)), 0)
+	assert_contains(str(result.get("stdout", "")), "stdout-token")
+	assert_eq(str(result.get("stderr", "")), "")
+	assert_false(
+		str(result.get("output", "")).find("stderr-token") >= 0,
+		"status probes skip stderr drain to avoid expected empty-pipe noise"
+	)
+
+
 func test_run_kills_subprocess_when_budget_expires() -> void:
 	## The headline behavior: a hung CLI no longer hangs the editor.
 	## Spawn `sleep 5` with a 200ms budget — McpCliExec should kill it
@@ -75,3 +111,32 @@ func test_run_kills_subprocess_when_budget_expires() -> void:
 		"timed_out runs must report exit_code=-1 — never a real exit code")
 	assert_true(elapsed_msec < 3000,
 		"Timeout kill must return within ~budget+poll, not wait for sleep to finish (elapsed=%dms)" % elapsed_msec)
+
+
+func _stderr_fixture_command(exit_code: int) -> Dictionary:
+	if OS.get_name() == "Windows":
+		return {
+			"exe": "cmd.exe",
+			"args": [
+				"/c",
+				"echo stdout-token & echo stderr-token 1>&2 & exit /b %d" % exit_code
+			]
+		}
+	var shell := _find_posix_shell()
+	if shell.is_empty():
+		return {}
+	return {
+		"exe": shell,
+		"args": [
+			"-c",
+			"printf 'stdout-token'; printf 'stderr-token' >&2; exit %d" % exit_code
+		]
+	}
+
+
+func _find_posix_shell() -> String:
+	if FileAccess.file_exists("/bin/sh"):
+		return "/bin/sh"
+	if FileAccess.file_exists("/usr/bin/sh"):
+		return "/usr/bin/sh"
+	return ""

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -8,6 +8,26 @@ extends McpTestSuite
 const McpDockScript = preload("res://addons/godot_ai/mcp_dock.gd")
 const GodotAiPlugin := preload("res://addons/godot_ai/plugin.gd")
 
+class _RestartDispatchPlugin extends GodotAiPlugin:
+	var status: Dictionary = {}
+	var can_restart := false
+	var force_restart_calls := 0
+	var recover_calls := 0
+
+	func get_server_status() -> Dictionary:
+		return status.duplicate()
+
+	func can_restart_managed_server() -> bool:
+		return can_restart
+
+	func force_restart_server() -> void:
+		force_restart_calls += 1
+
+	func recover_incompatible_server() -> bool:
+		recover_calls += 1
+		return true
+
+
 var _dock: Node
 
 
@@ -116,8 +136,12 @@ func test_incompatible_server_marks_clients_unhealthy() -> void:
 	## server with an incompatible tool surface. The dock must not show green
 	## client rows while the plugin has blocked server adoption.
 	_dock._build_ui()
-	var plugin := GodotAiPlugin.new()
-	plugin._set_incompatible_server({"version": "1.2.10"}, "2.2.0", 8000)
+	var plugin := _RestartDispatchPlugin.new()
+	plugin.status = {
+		"state": McpSpawnState.INCOMPATIBLE_SERVER,
+		"message": "Port 8000 is occupied by godot-ai server v1.2.10; plugin expects v2.2.0.",
+		"connection_blocked": true,
+	}
 	_dock._plugin = plugin
 
 	var any_id := McpClientConfigurator.client_ids()[0]
@@ -357,6 +381,58 @@ func test_server_version_label_repaints_color_when_state_changes_without_text_ch
 	_dock._plugin = null
 	plugin.free()
 	_cleanup_server_row(conn)
+
+
+func test_server_version_label_shows_restart_for_recoverable_incompatible_server() -> void:
+	var conn := _seed_server_row("1.2.3-stale-for-test")
+	var plugin := _RestartDispatchPlugin.new()
+	plugin.status = {
+		"state": McpSpawnState.INCOMPATIBLE_SERVER,
+		"actual_version": "1.2.3-stale-for-test",
+		"expected_version": "2.2.0",
+		"can_recover_incompatible": true,
+	}
+	_dock._plugin = plugin
+
+	_dock._refresh_server_version_label()
+	assert_true(
+		_dock._version_restart_btn.visible,
+		"recoverable incompatible godot-ai server should offer the user-confirmed restart"
+	)
+
+	_dock._plugin = null
+	plugin.free()
+	_cleanup_server_row(conn)
+
+
+func test_restart_dispatches_incompatible_state_to_recovery() -> void:
+	var plugin := _RestartDispatchPlugin.new()
+	plugin.status = {"state": McpSpawnState.INCOMPATIBLE_SERVER}
+	_dock._plugin = plugin
+
+	_dock._on_restart_stale_server()
+	var recover_calls := plugin.recover_calls
+	var restart_calls := plugin.force_restart_calls
+	_dock._plugin = null
+	plugin.free()
+
+	assert_eq(recover_calls, 1)
+	assert_eq(restart_calls, 0)
+
+
+func test_restart_dispatches_non_incompatible_state_to_force_restart() -> void:
+	var plugin := _RestartDispatchPlugin.new()
+	plugin.status = {"state": McpSpawnState.OK}
+	_dock._plugin = plugin
+
+	_dock._on_restart_stale_server()
+	var recover_calls := plugin.recover_calls
+	var restart_calls := plugin.force_restart_calls
+	_dock._plugin = null
+	plugin.free()
+
+	assert_eq(recover_calls, 0)
+	assert_eq(restart_calls, 1)
 
 
 func test_dev_checkout_tooltip_exposes_symlink_target() -> void:

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -281,6 +281,9 @@ func test_drain_helper_does_not_poison_shutdown_flag() -> void:
 ## or dev checkout (the user-mode Server row is what owns these handles in
 ## production — see `_refresh_setup_status`).
 func _seed_server_row(server_ver: String) -> McpConnection:
+	_dock._plugin = null
+	_dock._server_restart_in_progress = false
+	_dock._crash_restart_btn = null
 	var conn := McpConnection.new()
 	_dock._connection = conn
 	_dock._setup_server_label = Label.new()

--- a/test_project/tests/test_netstat_parser.gd
+++ b/test_project/tests/test_netstat_parser.gd
@@ -170,6 +170,21 @@ func test_parse_pid_lines_ignores_noise_and_deduplicates() -> void:
 	assert_eq(pids[1], 40064)
 
 
+func test_powershell_listener_output_parses_pid_lines() -> void:
+	var pids := GodotAiPlugin._windows_listener_pids_from_execute_result(
+		0,
+		["19088\r\n40064\r\n19088\r\n"]
+	)
+	assert_eq(pids.size(), 2)
+	assert_eq(pids[0], 19088)
+	assert_eq(pids[1], 40064)
+
+
+func test_powershell_listener_output_empty_means_no_listener() -> void:
+	assert_false(GodotAiPlugin._windows_listener_execute_result_in_use(0, [""]))
+	assert_false(GodotAiPlugin._windows_listener_execute_result_in_use(1, ["19088"]))
+
+
 # ----- pid-file round trip -----
 
 func test_read_pid_file_missing_returns_zero() -> void:

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -300,6 +300,159 @@ func test_commandline_fingerprint_is_case_insensitive_and_requires_flag() -> voi
 		GodotAiPlugin._commandline_is_godot_ai_server("C:/Python/python.exe -m godot_ai"),
 		"brand alone is not enough ownership proof"
 	)
+	assert_false(
+		GodotAiPlugin._commandline_is_godot_ai_server(""),
+		"empty cmdline (lookup failure) must never be accepted as proof"
+	)
+
+
+func test_commandline_fingerprint_ignores_brand_in_pidfile_path() -> void:
+	## Regression: the pidfile path itself is `<user>/godot_ai_server.pid`,
+	## so a substring brand search would falsely match an unrelated process
+	## that happens to reference a similarly-named pidfile. The brand must
+	## come from somewhere outside the --pid-file value.
+	assert_false(
+		GodotAiPlugin._commandline_is_godot_ai_server(
+			"someprogram --pid-file /var/run/godot_ai_server.pid --transport tcp"
+		),
+		"brand in pidfile path alone must not satisfy ownership proof"
+	)
+	assert_false(
+		GodotAiPlugin._commandline_is_godot_ai_server(
+			"someprogram --pid-file=/var/run/godot_ai_server.pid --transport tcp"
+		),
+		"--pid-file=<value> form must also strip the path before brand search"
+	)
+	assert_true(
+		GodotAiPlugin._commandline_is_godot_ai_server(
+			"/usr/bin/python -m godot_ai --transport streamable-http --pid-file /tmp/godot_ai_server.pid"
+		),
+		"real server invocation has brand outside the pidfile value, must still match"
+	)
+
+
+func test_strip_pidfile_value_handles_space_and_equals_forms() -> void:
+	## Whitespace form: keep the bare flag, drop the value.
+	assert_eq(
+		GodotAiPlugin._strip_pidfile_value("foo --pid-file /tmp/x.pid bar"),
+		"foo --pid-file  bar"
+	)
+	## Equals form: same outcome.
+	assert_eq(
+		GodotAiPlugin._strip_pidfile_value("foo --pid-file=/tmp/x.pid bar"),
+		"foo --pid-file  bar"
+	)
+	## No --pid-file flag: returned unchanged.
+	assert_eq(
+		GodotAiPlugin._strip_pidfile_value("foo --transport tcp"),
+		"foo --transport tcp"
+	)
+
+
+func test_pid_cmdline_rejects_sentinel_pids() -> void:
+	## Init/PID 1 and pid 0 must never be considered candidates for kill.
+	## A stale pidfile that somehow contains 0 or 1 has to bail before any
+	## OS lookup, otherwise we'd risk targeting init on POSIX.
+	var plugin := GodotAiPlugin.new()
+	assert_false(plugin._pid_cmdline_is_godot_ai(0), "pid 0 must never match")
+	assert_false(plugin._pid_cmdline_is_godot_ai(1), "pid 1 (init) must never match")
+	plugin.free()
+
+
+func test_posix_pid_commandline_reads_procfs_despite_zero_length() -> void:
+	## procfs pseudo-files (/proc/<pid>/cmdline) report length 0 even though
+	## they have content. If we sized the read by `get_length()` we'd get
+	## an empty string back and the legacy pidfile proof would silently
+	## fail on Linux. Verify the chunked-read path actually returns data
+	## for a known-live PID (the editor itself).
+	if not FileAccess.file_exists("/proc/self/cmdline"):
+		skip("/proc not available — Linux-only test")
+		return
+	var plugin := GodotAiPlugin.new()
+	var cmd := plugin._posix_pid_commandline(OS.get_process_id())
+	plugin.free()
+	assert_false(
+		cmd.is_empty(),
+		"chunked read must return non-empty cmdline for the editor's own PID"
+	)
+	## The editor cmdline must contain the Godot binary path; this also
+	## confirms NUL-to-space conversion produced a usable string.
+	assert_true(
+		cmd.to_lower().find("godot") >= 0,
+		"editor cmdline should contain 'godot' substring, got: %s" % cmd
+	)
+
+
+func test_pid_cmdline_rejects_unrelated_local_pid() -> void:
+	## Regression for the cross-platform pidfile-proof bug: previously the
+	## non-Windows path returned true unconditionally, so a stale pidfile
+	## whose PID had been recycled by an unrelated listener could be accepted
+	## as a kill target. Now the function must actually inspect the cmdline.
+	## The current Godot editor process is a convenient stand-in for an
+	## "unrelated" PID — its cmdline contains no `--pid-file` / `--transport`
+	## flags, so the brand+flag fingerprint must reject it.
+	if OS.get_name() == "Windows":
+		skip("POSIX-only path: Windows uses PowerShell, exercised elsewhere")
+		return
+	var plugin := GodotAiPlugin.new()
+	var godot_pid := OS.get_process_id()
+	var matches := plugin._pid_cmdline_is_godot_ai(godot_pid)
+	plugin.free()
+	assert_false(
+		matches,
+		"editor PID's cmdline lacks --pid-file/--transport, must not match godot-ai server fingerprint"
+	)
+
+
+class _RealCmdlinePlugin extends GodotAiPlugin:
+	## Exercises the real `_pid_cmdline_is_godot_ai` inside the kill-target
+	## path. Mocks the pidfile / liveness lookups but lets the cmdline
+	## fingerprint flow through to the OS-specific reader (`/proc` on Linux,
+	## `ps` on macOS/*BSD, PowerShell on Windows). Regression coverage for
+	## the bug where the POSIX path returned true unconditionally.
+	var listener_pids: Array[int] = []
+	var pid_file_pid := 0
+	var alive_pids: Array[int] = []
+
+	func _read_pid_file_for_proof() -> int:
+		return pid_file_pid
+
+	func _pid_alive_for_proof(pid: int) -> bool:
+		return alive_pids.has(pid)
+
+
+func test_legacy_pidfile_kill_targets_requires_real_brand_proof() -> void:
+	## Spawn a benign child (`sleep`) so we have an unrelated live PID we
+	## can plant in the pidfile slot. Without the fix, `_legacy_pidfile_kill_targets`
+	## would return [child_pid] on POSIX because the cmdline check returned
+	## true unconditionally. With the fix, the child's cmdline (no
+	## --pid-file / --transport) is rejected and no kill targets are produced.
+	if OS.get_name() == "Windows":
+		skip("POSIX-only regression: Windows path covered by netstat parser tests")
+		return
+	var sleep_path := "/bin/sleep"
+	if not FileAccess.file_exists(sleep_path):
+		sleep_path = "/usr/bin/sleep"
+		if not FileAccess.file_exists(sleep_path):
+			skip("sleep(1) not available on this host")
+			return
+	var child_pid := OS.create_process(sleep_path, ["30"])
+	if child_pid <= 0:
+		skip("OS.create_process unavailable in this test environment")
+		return
+	var plugin := _RealCmdlinePlugin.new()
+	plugin.listener_pids = [child_pid] as Array[int]
+	plugin.pid_file_pid = child_pid
+	plugin.alive_pids = [child_pid] as Array[int]
+
+	var targets := plugin._legacy_pidfile_kill_targets(TEST_PORT, plugin.listener_pids)
+	plugin.free()
+	OS.kill(child_pid)
+
+	assert_true(
+		targets.is_empty(),
+		"unrelated live PID in pidfile must not produce kill targets without brand+flag cmdline proof"
+	)
 
 
 func test_strong_proof_accepts_live_managed_record_pid() -> void:

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -532,6 +532,63 @@ func test_recovery_proof_accepts_status_name_only() -> void:
 	assert_eq(pids, [13579] as Array[int])
 
 
+func test_strong_recovery_kills_pidfile_listener_when_port_frees() -> void:
+	var plugin := _ProofPlugin.new()
+	plugin.listener_pids = [11111] as Array[int]
+	plugin.pid_file_pid = 11111
+	plugin.alive_pids = [11111] as Array[int]
+	plugin.branded_pids = [11111] as Array[int]
+	plugin.port_in_use_sequence = [false] as Array[bool]
+
+	var ok := plugin._recover_strong_port_occupant(TEST_PORT, 0.1)
+	var killed := plugin.killed_targets.duplicate()
+	var waited_calls := plugin.waited_calls
+	var clear_calls := plugin.cleared_record_calls
+	plugin.free()
+
+	assert_true(ok, "strong pidfile proof should recover when the port frees")
+	assert_eq(killed, [11111] as Array[int])
+	assert_eq(waited_calls, 1)
+	assert_eq(clear_calls, 1, "successful recovery must clear stale managed state")
+
+
+func test_strong_recovery_preserves_state_when_port_stays_held() -> void:
+	var plugin := _ProofPlugin.new()
+	plugin.listener_pids = [11111] as Array[int]
+	plugin.pid_file_pid = 11111
+	plugin.alive_pids = [11111] as Array[int]
+	plugin.branded_pids = [11111] as Array[int]
+	plugin.port_in_use_sequence = [true] as Array[bool]
+
+	var ok := plugin._recover_strong_port_occupant(TEST_PORT, 0.1)
+	var killed := plugin.killed_targets.duplicate()
+	var waited_calls := plugin.waited_calls
+	var clear_calls := plugin.cleared_record_calls
+	plugin.free()
+
+	assert_false(ok, "recovery must fail when the port stays held")
+	assert_eq(killed, [11111] as Array[int])
+	assert_eq(waited_calls, 1)
+	assert_eq(clear_calls, 0, "failed recovery must preserve stale ownership state")
+
+
+func test_strong_recovery_rejects_status_name_only() -> void:
+	var plugin := _ProofPlugin.new()
+	plugin.listener_pids = [13579] as Array[int]
+	plugin.live_status = {"name": "godot-ai", "version": "2.1.0", "ws_port": 9500, "status_code": 200}
+
+	var ok := plugin._recover_strong_port_occupant(TEST_PORT, 0.1)
+	var killed := plugin.killed_targets.duplicate()
+	var waited_calls := plugin.waited_calls
+	var clear_calls := plugin.cleared_record_calls
+	plugin.free()
+
+	assert_false(ok, "status_name proof is recoverable by click, not by automatic startup kill")
+	assert_true(killed.is_empty())
+	assert_eq(waited_calls, 0)
+	assert_eq(clear_calls, 0)
+
+
 func test_can_recover_incompatible_server_requires_state_and_recovery_proof() -> void:
 	var plugin := _ProofPlugin.new()
 	plugin.port_in_use = true

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -15,6 +15,59 @@ class _RefreshDock extends McpDock:
 		refresh_calls += 1
 
 
+class _ProofPlugin extends GodotAiPlugin:
+	var listener_pids: Array[int] = []
+	var managed_record := {"pid": 0, "version": "", "ws_port": 0}
+	var live_status := {"name": "", "version": "", "ws_port": 0, "status_code": 0}
+	var alive_pids: Array[int] = []
+	var pid_file_pid := 0
+	var branded_pids: Array[int] = []
+	var port_in_use := false
+	var port_in_use_sequence: Array[bool] = []
+	var killed_targets: Array[int] = []
+	var cleared_record_calls := 0
+	var waited_calls := 0
+
+	func _find_all_pids_on_port(_port: int) -> Array[int]:
+		var pids: Array[int] = []
+		pids.assign(listener_pids)
+		return pids
+
+	func _read_managed_server_record() -> Dictionary:
+		return managed_record.duplicate()
+
+	func _read_pid_file_for_proof() -> int:
+		return pid_file_pid
+
+	func _pid_alive_for_proof(pid: int) -> bool:
+		return alive_pids.has(pid)
+
+	func _pid_cmdline_is_godot_ai_for_proof(pid: int) -> bool:
+		return branded_pids.has(pid)
+
+	func _probe_live_server_status_for_port(_port: int) -> Dictionary:
+		return live_status.duplicate()
+
+	func _is_port_in_use(_port: int) -> bool:
+		if not port_in_use_sequence.is_empty():
+			return bool(port_in_use_sequence.pop_front())
+		return port_in_use
+
+	func _kill_processes_and_windows_spawn_children(pids: Array[int]) -> Array[int]:
+		for pid in pids:
+			if not killed_targets.has(pid):
+				killed_targets.append(pid)
+		var killed: Array[int] = []
+		killed.assign(pids)
+		return killed
+
+	func _wait_for_port_free(_port: int, _timeout_s: float) -> void:
+		waited_calls += 1
+
+	func _clear_managed_server_record() -> void:
+		cleared_record_calls += 1
+
+
 ## Test port high enough to almost never collide with real services and
 ## distinct from the plugin's configured http_port() so the stop-finalize tests
 ## don't interact with a developer's running managed server.
@@ -196,9 +249,11 @@ func test_get_server_status_shape_is_stable() -> void:
 	plugin.free()
 	assert_has_key(status, "state")
 	assert_has_key(status, "exit_ms")
+	assert_has_key(status, "actual_name")
 	assert_has_key(status, "actual_version")
 	assert_has_key(status, "expected_version")
 	assert_has_key(status, "message")
+	assert_has_key(status, "can_recover_incompatible")
 	assert_has_key(status, "connection_blocked")
 
 
@@ -226,6 +281,114 @@ func test_managed_record_restart_requires_recorded_version_drift() -> void:
 		GodotAiPlugin._managed_record_has_version_drift("", "2.2.0"),
 		"missing managed record must not authorize restart"
 	)
+
+
+func test_commandline_fingerprint_is_case_insensitive_and_requires_flag() -> void:
+	assert_true(
+		GodotAiPlugin._commandline_is_godot_ai_server(
+			"C:/Python/python.exe -m GODOT_AI --TRANSPORT streamable-http"
+		),
+		"brand and management flag should match case-insensitively"
+	)
+	assert_true(
+		GodotAiPlugin._commandline_is_godot_ai_server(
+			"C:/Python/python.exe -m godot-ai --pid-file C:/tmp/godot_ai_server.pid"
+		),
+		"hyphenated brand plus pid-file flag should identify the server"
+	)
+	assert_false(
+		GodotAiPlugin._commandline_is_godot_ai_server("C:/Python/python.exe -m godot_ai"),
+		"brand alone is not enough ownership proof"
+	)
+
+
+func test_strong_proof_accepts_live_managed_record_pid() -> void:
+	var plugin := _ProofPlugin.new()
+	plugin.listener_pids = [24680] as Array[int]
+	plugin.managed_record = {"pid": 24680, "version": "2.1.0", "ws_port": 9500}
+	plugin.alive_pids = [24680] as Array[int]
+
+	var proof := plugin._evaluate_strong_port_occupant_proof(TEST_PORT)
+	plugin.free()
+
+	assert_eq(proof.get("proof", ""), "managed_record")
+	var pids: Array[int] = []
+	pids.assign(proof.get("pids", []))
+	assert_eq(pids, [24680] as Array[int])
+
+
+func test_legacy_pidfile_proof_returns_all_branded_listener_pids() -> void:
+	var plugin := _ProofPlugin.new()
+	plugin.listener_pids = [11111, 22222, 33333] as Array[int]
+	plugin.pid_file_pid = 11111
+	plugin.alive_pids = [11111] as Array[int]
+	plugin.branded_pids = [11111, 22222] as Array[int]
+
+	var targets := plugin._legacy_pidfile_kill_targets(TEST_PORT, plugin.listener_pids)
+	var proof := plugin._evaluate_strong_port_occupant_proof(TEST_PORT)
+	plugin.free()
+
+	assert_eq(targets, [11111, 22222] as Array[int])
+	assert_eq(proof.get("proof", ""), "pidfile_listener")
+	var pids: Array[int] = []
+	pids.assign(proof.get("pids", []))
+	assert_eq(pids, [11111, 22222] as Array[int])
+
+
+func test_strong_proof_accepts_status_matching_managed_record_version() -> void:
+	var plugin := _ProofPlugin.new()
+	plugin.listener_pids = [13579] as Array[int]
+	plugin.managed_record = {"pid": 0, "version": "2.1.0", "ws_port": 9500}
+	plugin.live_status = {"name": "godot-ai", "version": "2.1.0", "ws_port": 9500, "status_code": 200}
+
+	var proof := plugin._evaluate_strong_port_occupant_proof(TEST_PORT)
+	plugin.free()
+
+	assert_eq(proof.get("proof", ""), "status_matches_record")
+	var pids: Array[int] = []
+	pids.assign(proof.get("pids", []))
+	assert_eq(pids, [13579] as Array[int])
+
+
+func test_strong_proof_rejects_status_name_only() -> void:
+	var plugin := _ProofPlugin.new()
+	plugin.listener_pids = [13579] as Array[int]
+	plugin.managed_record = {"pid": 0, "version": "", "ws_port": 0}
+	plugin.live_status = {"name": "godot-ai", "version": "2.1.0", "ws_port": 9500, "status_code": 200}
+
+	var proof := plugin._evaluate_strong_port_occupant_proof(TEST_PORT)
+	plugin.free()
+
+	assert_eq(proof.get("proof", ""), "")
+	var pids: Array[int] = []
+	pids.assign(proof.get("pids", []))
+	assert_true(pids.is_empty())
+
+
+func test_recovery_proof_accepts_status_name_only() -> void:
+	var plugin := _ProofPlugin.new()
+	plugin.listener_pids = [13579] as Array[int]
+	plugin.live_status = {"name": "godot-ai", "version": "2.1.0", "ws_port": 9500, "status_code": 200}
+
+	var proof := plugin._evaluate_recovery_port_occupant_proof(TEST_PORT)
+	plugin.free()
+
+	assert_eq(proof.get("proof", ""), "status_name")
+	var pids: Array[int] = []
+	pids.assign(proof.get("pids", []))
+	assert_eq(pids, [13579] as Array[int])
+
+
+func test_can_recover_incompatible_server_requires_state_and_recovery_proof() -> void:
+	var plugin := _ProofPlugin.new()
+	plugin.port_in_use = true
+	plugin.listener_pids = [13579] as Array[int]
+	plugin.live_status = {"name": "godot-ai", "version": "2.1.0", "ws_port": 9500, "status_code": 200}
+
+	assert_false(plugin.can_recover_incompatible_server(), "OK state must not expose recovery")
+	plugin._spawn_state = McpSpawnState.INCOMPATIBLE_SERVER
+	assert_true(plugin.can_recover_incompatible_server(), "status-name proof should allow clicked recovery")
+	plugin.free()
 
 
 func test_external_compatible_adoption_clears_stale_managed_record() -> void:
@@ -415,7 +578,7 @@ func test_incompatible_server_message_names_ws_port_mismatch() -> void:
 
 
 func test_incompatible_transition_refreshes_dock_client_statuses() -> void:
-	var plugin := GodotAiPlugin.new()
+	var plugin := _ProofPlugin.new()
 	var dock := _RefreshDock.new()
 	plugin._dock = dock
 	plugin._set_incompatible_server({"version": "1.2.10"}, "2.2.0", 8000)
@@ -424,6 +587,98 @@ func test_incompatible_transition_refreshes_dock_client_statuses() -> void:
 	plugin.free()
 
 	assert_eq(calls, 1, "late incompatible transition must resweep dock client status")
+
+
+func test_incompatible_status_exposes_actual_name_and_recovery_flag() -> void:
+	var plugin := _ProofPlugin.new()
+	plugin.listener_pids = [24680] as Array[int]
+	plugin.live_status = {"name": "godot-ai", "version": "1.2.10", "ws_port": 9500, "status_code": 200}
+	plugin._set_incompatible_server(plugin.live_status, "2.2.0", TEST_PORT)
+	var status := plugin.get_server_status()
+	plugin.free()
+
+	assert_eq(status.get("actual_name", ""), "godot-ai")
+	assert_true(bool(status.get("can_recover_incompatible", false)))
+
+
+func test_drift_kill_without_strong_targets_sets_incompatible_and_preserves_record() -> void:
+	var plugin := _ProofPlugin.new()
+	plugin.port_in_use_sequence = [true] as Array[bool]
+	plugin.listener_pids = [24680] as Array[int]
+	plugin.managed_record = {"pid": 0, "version": "old-managed-for-test", "ws_port": 9500}
+	plugin.live_status = {"name": "other-server", "version": "old-managed-for-test", "ws_port": 9500, "status_code": 200}
+
+	plugin._start_server()
+	var status := plugin.get_server_status()
+	var killed := plugin.killed_targets.duplicate()
+	var clear_calls := plugin.cleared_record_calls
+	var server_pid := plugin._server_pid
+	plugin.free()
+
+	assert_eq(status.get("state", ""), McpSpawnState.INCOMPATIBLE_SERVER)
+	assert_true(killed.is_empty(), "drift branch must not kill without strong proof")
+	assert_eq(clear_calls, 0, "failed drift proof must preserve the managed record")
+	assert_eq(server_pid, -1, "drift branch must not spawn into a port with no strong kill target")
+
+
+func test_drift_kill_preserves_record_and_does_not_spawn_when_port_stays_held() -> void:
+	var plugin := _ProofPlugin.new()
+	plugin.port_in_use_sequence = [true, true] as Array[bool]
+	plugin.listener_pids = [24680] as Array[int]
+	plugin.managed_record = {"pid": 24680, "version": "old-managed-for-test", "ws_port": 9500}
+	plugin.alive_pids = [24680] as Array[int]
+	plugin.live_status = {"name": "other-server", "version": "old-managed-for-test", "ws_port": 9500, "status_code": 200}
+
+	plugin._start_server()
+	var status := plugin.get_server_status()
+	var killed := plugin.killed_targets.duplicate()
+	var clear_calls := plugin.cleared_record_calls
+	var server_pid := plugin._server_pid
+	plugin.free()
+
+	assert_eq(status.get("state", ""), McpSpawnState.INCOMPATIBLE_SERVER)
+	assert_eq(killed, [24680] as Array[int])
+	assert_eq(clear_calls, 0, "held port after kill must preserve the managed record")
+	assert_eq(server_pid, -1, "drift branch must not spawn while the port is still held")
+
+
+func test_force_restart_preserves_record_when_port_remains_held() -> void:
+	var plugin := _ProofPlugin.new()
+	plugin.port_in_use = true
+	plugin.listener_pids = [24680] as Array[int]
+	plugin.managed_record = {"pid": 24680, "version": "old-managed-for-test", "ws_port": 9500}
+	plugin.live_status = {"name": "other-server", "version": "old-managed-for-test", "ws_port": 9500, "status_code": 200}
+
+	plugin.force_restart_server()
+	var status := plugin.get_server_status()
+	var killed := plugin.killed_targets.duplicate()
+	var clear_calls := plugin.cleared_record_calls
+	plugin.free()
+
+	assert_eq(status.get("state", ""), McpSpawnState.INCOMPATIBLE_SERVER)
+	assert_eq(killed, [24680] as Array[int])
+	assert_eq(clear_calls, 0, "force restart must not clear ownership while the port is still held")
+
+
+func test_recover_incompatible_returns_false_and_leaves_state_when_port_remains_held() -> void:
+	var plugin := _ProofPlugin.new()
+	plugin._spawn_state = McpSpawnState.INCOMPATIBLE_SERVER
+	plugin._connection_blocked = true
+	plugin.port_in_use = true
+	plugin.listener_pids = [24680] as Array[int]
+	plugin.live_status = {"name": "godot-ai", "version": "1.2.10", "ws_port": 9500, "status_code": 200}
+
+	var ok := plugin.recover_incompatible_server()
+	var status := plugin.get_server_status()
+	var killed := plugin.killed_targets.duplicate()
+	var clear_calls := plugin.cleared_record_calls
+	plugin.free()
+
+	assert_false(ok, "recovery click must report failure when the kill did not free the port")
+	assert_eq(status.get("state", ""), McpSpawnState.INCOMPATIBLE_SERVER)
+	assert_true(bool(status.get("connection_blocked", false)))
+	assert_eq(killed, [24680] as Array[int])
+	assert_eq(clear_calls, 0, "failed recovery must preserve record/pid-file state")
 
 
 func test_connection_established_waits_for_version_before_clearing_foreign_port() -> void:

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -626,6 +626,34 @@ func test_external_compatible_adoption_clears_stale_managed_record() -> void:
 	assert_false(can_restart, "external adoption must not authorize managed restart")
 
 
+func test_external_compatible_adoption_log_reports_observed_owner() -> void:
+	var message := GodotAiPlugin._compatible_adoption_log_message(
+		"external",
+		-1,
+		22222,
+		"2.2.3",
+		9500,
+		"2.2.3"
+	)
+	assert_contains(message, "adopted external server owner_pid=22222")
+	assert_false(
+		message.find("PID -1") >= 0,
+		"external adoption log must not report the intentionally unowned _server_pid"
+	)
+
+
+func test_managed_compatible_adoption_log_reports_owned_pid() -> void:
+	var message := GodotAiPlugin._compatible_adoption_log_message(
+		"managed",
+		22222,
+		22222,
+		"2.2.3",
+		9500,
+		"2.2.3"
+	)
+	assert_contains(message, "adopted managed server (PID 22222")
+
+
 func test_resolved_ws_port_drops_stale_record_value() -> void:
 	## Regression for the cached-ws-port + stale-ownership interaction.
 	## Setup mirrors the bad shape from the field:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,12 +28,18 @@ class MockGodotPlugin:
         msg = {"request_id": request_id, "status": status, "data": data}
         await self.ws.send(json.dumps(msg))
 
-    async def send_error(self, request_id: str, code: str, message: str) -> None:
+    async def send_error(
+        self,
+        request_id: str,
+        code: str,
+        message: str,
+        data: dict | None = None,
+    ) -> None:
         msg = {
             "request_id": request_id,
             "status": "error",
             "data": {},
-            "error": {"code": code, "message": message},
+            "error": {"code": code, "message": message, "data": data or {}},
         }
         await self.ws.send(json.dumps(msg))
 

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -2079,6 +2079,37 @@ class TestPhysicsShapeAutofitTool:
         assert result.data["shape_created"] is True
         assert result.data["size"]["x"] == 2.0
 
+    async def test_ambiguous_visual_candidates_preserved_in_structured_error(
+        self, mcp_stack
+    ):
+        client, plugin = mcp_stack
+        candidates = ["/Main/VisualA", "/Main/VisualB"]
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "physics_shape_autofit"
+            await plugin.send_error(
+                cmd["request_id"],
+                "INVALID_PARAMS",
+                "Multiple visual candidates near /Main/Body/Collision",
+                data={"candidates": candidates},
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "resource_manage",
+            {
+                "op": "physics_shape_autofit",
+                "params": {"path": "/Main/Body/Collision"},
+            },
+            raise_on_error=False,
+        )
+        await task
+
+        assert result.is_error
+        assert result.structured_content["error"]["code"] == "INVALID_PARAMS"
+        assert result.structured_content["error"]["data"]["candidates"] == candidates
+
 
 # ---------------------------------------------------------------------------
 # filesystem_read_text

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -194,6 +194,29 @@ class TestErrors:
         assert "/Missing/Node" in exc_info.value.message
         await plugin.close()
 
+    async def test_plugin_error_preserves_structured_data(self, harness):
+        plugin = await harness.connect_plugin()
+        client = GodotClient(harness.server, harness.registry)
+        candidates = ["/Main/VisualA", "/Main/VisualB"]
+
+        async def mock_handler():
+            cmd = await plugin.recv_command()
+            await plugin.send_error(
+                cmd["request_id"],
+                "INVALID_PARAMS",
+                "Multiple visual candidates near /Main/Body/Collision",
+                data={"candidates": candidates},
+            )
+
+        handler_task = asyncio.create_task(mock_handler())
+        with pytest.raises(GodotCommandError) as exc_info:
+            await client.send("physics_shape_autofit")
+        await handler_task
+
+        assert exc_info.value.code == "INVALID_PARAMS"
+        assert exc_info.value.data["candidates"] == candidates
+        await plugin.close()
+
     async def test_send_to_no_active_session_raises(self, harness):
         client = GodotClient(harness.server, harness.registry)
         with pytest.raises(ConnectionError, match="No active Godot session"):

--- a/tests/unit/test_protocol.py
+++ b/tests/unit/test_protocol.py
@@ -44,10 +44,24 @@ class TestCommandResponse:
         resp = CommandResponse(
             request_id="abc123",
             status="error",
-            error=ErrorDetail(code="NODE_NOT_FOUND", message="Not found"),
+            error=ErrorDetail(
+                code="NODE_NOT_FOUND",
+                message="Not found",
+                data={"path": "/Missing/Node"},
+            ),
         )
         assert resp.status == "error"
         assert resp.error.code == "NODE_NOT_FOUND"
+        assert resp.error.data == {"path": "/Missing/Node"}
+
+    def test_error_response_defaults_data_to_empty_dict(self):
+        resp = CommandResponse(
+            request_id="abc123",
+            status="error",
+            error=ErrorDetail(code="NODE_NOT_FOUND", message="Not found"),
+        )
+        assert resp.error is not None
+        assert resp.error.data == {}
 
     def test_roundtrip_json(self):
         resp = CommandResponse(

--- a/tests/unit/test_script_create_import_settle.py
+++ b/tests/unit/test_script_create_import_settle.py
@@ -72,7 +72,16 @@ def test_finish_create_script_deferred_polls_resourceloader_with_bounded_loop() 
         "The deferred loop must use a named bounded-frame constant so the "
         "wait can't run forever if the filesystem scan stalls."
     )
+    assert "_IMPORT_SETTLE_MAX_MSEC := 4500" in source, (
+        "The deferred loop must also be capped below the Python client's "
+        "default 5s send timeout. A pure 300-frame cap can exceed 5s on a "
+        "slow editor frame rate."
+    )
     deferred_block = source.split("func _finish_create_script_deferred", 1)[1]
+    assert "var deadline_ms := Time.get_ticks_msec() + _IMPORT_SETTLE_MAX_MSEC" in (
+        deferred_block
+    )
+    assert "Time.get_ticks_msec() < deadline_ms" in deferred_block
     assert "ResourceLoader.exists(path)" in deferred_block, (
         "The deferred loop must poll ResourceLoader.exists(path) — that's "
         "the precise check script_attach uses, so settling on it gives the "

--- a/tests/unit/test_self_update_orphan_recovery.py
+++ b/tests/unit/test_self_update_orphan_recovery.py
@@ -1,0 +1,52 @@
+"""Source-structure regression tests for self-update orphan recovery."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+PLUGIN_GD = (
+    Path(__file__).resolve().parents[2] / "plugin" / "addons" / "godot_ai" / "plugin.gd"
+)
+
+
+def _func_block(source: str, signature: str) -> str:
+    return source.split(signature, 1)[1].split("\n\nfunc ", 1)[0]
+
+
+def test_recover_incompatible_success_unblocks_existing_connection() -> None:
+    source = PLUGIN_GD.read_text()
+    recover_block = _func_block(source, "func recover_incompatible_server() -> bool:")
+    resume_block = _func_block(source, "func _resume_connection_after_recovery() -> void:")
+
+    assert "_start_server()" in recover_block
+    assert "_resume_connection_after_recovery()" in recover_block
+    assert recover_block.index("_start_server()") < recover_block.index(
+        "_resume_connection_after_recovery()"
+    )
+
+    assert "_spawn_state != McpSpawnState.OK or _connection_blocked" in resume_block
+    assert "_connection.connect_blocked = false" in resume_block
+    assert '_connection.connect_block_reason = ""' in resume_block
+    assert '_connection.server_version = ""' in resume_block
+    assert "_connection.set_process(true)" in resume_block
+    assert "_arm_server_version_check()" in resume_block
+
+
+def test_status_probe_reads_response_body_only_after_headers() -> None:
+    source = PLUGIN_GD.read_text()
+    probe_block = _func_block(
+        source,
+        "static func _probe_live_server_status(port: int, timeout_ms: int = "
+        "SERVER_STATUS_PROBE_TIMEOUT_MS) -> Dictionary:",
+    )
+    response_loop = probe_block.split("while true:", 1)[1].split("var response_code", 1)[0]
+    requesting_branch = response_loop.split(
+        "if status == HTTPClient.STATUS_REQUESTING:", 1
+    )[1].split("elif status == HTTPClient.STATUS_BODY:", 1)[0]
+    body_branch = response_loop.split("elif status == HTTPClient.STATUS_BODY:", 1)[1].split(
+        "elif status == HTTPClient.STATUS_CONNECTED:", 1
+    )[0]
+
+    assert "client.poll()" in requesting_branch
+    assert "read_response_body_chunk" not in requesting_branch
+    assert "read_response_body_chunk" in body_branch


### PR DESCRIPTION
## Summary

This PR fixes managed server lifecycle around self-update so an old `godot-ai` server cannot survive on the configured HTTP port and block the updated plugin from starting a compatible server.

The safety model is cross-platform: automatic cleanup now requires strong ownership proof, records and pid files are preserved unless the port is actually released, and the plugin never falls through to spawn while the port remains held. The Windows-specific part is listener discovery, which now uses PowerShell first so PID lookup does not depend on localized `netstat` output.

## Root Cause

The old lifecycle paths could clear managed-server records or continue startup after a failed kill attempt. On Windows, listener PID discovery depended on parsing `netstat`, which is fragile under localization. For legacy v2.2.0 servers, the plugin also needed a deterministic recovery path because those servers write `user://godot_ai_server.pid` but do not expose `/godot-ai/status`.

## Changes

- Add PowerShell-first Windows listener PID lookup with netstat fallback coverage retained.
- Replace boolean ownership checks with proof dictionaries that carry proof kind and target PIDs.
- Add strong proof tiers for managed record, legacy pidfile listener, and status matching the managed record version.
- Keep status-name-only identity out of automatic kill paths; allow it only for user-click recovery.
- Preserve managed records and pid files when a kill fails or the port remains held.
- Block spawn fall-through while the HTTP port is still occupied.
- Add incompatible-server recovery status fields and recovery APIs.
- Update the dock so Restart is shown for recoverable incompatible servers and dispatches to recovery instead of force restart.
- Add lifecycle, dock, and listener parser tests for the new proof and recovery behavior.

## Validation Run

- `git diff --check origin/main...HEAD`
- `ruff check src/ tests/`
- `pytest -v` - 697 passed
- Godot headless import: `Godot --headless --path test_project --import`
- `bash script/ci-godot-tests` against the clean-branch editor session - 1008/1011 passed, 0 failed

## Approval Test Plan

Automated checks to keep in the approval gate:

- Run `ruff check src/ tests/` and `pytest -v`.
- Run the Godot import and `bash script/ci-godot-tests` on a machine with Godot available.
- Confirm the proof tests cover managed-record proof, v2.2-style pidfile listener proof, status-version match proof, strong rejection of status-name-only proof, and recovery acceptance of status-name-only proof.
- Confirm the lifecycle tests prove drift kill with no strong targets sets incompatible, preserves the record, and does not spawn.
- Confirm the lifecycle tests prove a failed drift kill keeps the record and pid file intact and does not spawn into the held port.
- Confirm the lifecycle tests prove `force_restart_server()` preserves the record when the port stays held.
- Confirm the lifecycle tests prove `recover_incompatible_server()` returns false and leaves incompatible state intact when the port stays held.
- Confirm the dock tests prove Restart is visible only when `can_recover_incompatible=true`, and dispatch goes to `recover_incompatible_server()` for incompatible state and `force_restart_server()` otherwise.
- Confirm Windows listener tests prove PowerShell PID output parsing and netstat fallback coverage.
- Confirm command-line fingerprint tests prove case-insensitive `godot-ai` or `godot_ai` matching and require a server flag such as `--pid-file` or `--transport`.

Manual regression matrix for the original orphaned-server failure:

1. Windows v2.2.0 orphan recovery
   - Start a v2.2.0 managed server that writes `user://godot_ai_server.pid` and does not expose `/godot-ai/status`.
   - Install or reload the updated plugin.
   - Verify the old pidfile PID is a listener on the configured HTTP port and has a `godot-ai` or `godot_ai` branded command line with a server flag.
   - Verify self-update cleanup kills all branded listener PIDs on that port, waits for the port to become free, clears the record and pid file only after release, and starts exactly one new compatible server.
   - Verify Task Manager or PowerShell no longer shows the old PID or its spawned child listener.

2. Windows localized shell safety
   - On a non-English Windows locale, repeat listener detection while a server is listening.
   - Verify PowerShell `Get-NetTCPConnection` finds the listener PID even if `netstat` text would be localized.
   - Temporarily make PowerShell lookup return no PID or fail, then verify the netstat fallback path still works where possible.

3. Cross-platform managed drift cleanup
   - On macOS and Linux, start an older managed server with a valid managed record whose version differs from the plugin version.
   - Reload the plugin.
   - Verify automatic kill occurs only when strong proof exists, the port is confirmed free before record cleanup, and the new server is spawned only after the port is free.

4. Failed-kill preservation
   - Simulate or force a listener that cannot be killed, or immediately rebind the port during cleanup.
   - Trigger drift cleanup and force restart.
   - Verify the managed record and pid file remain present, the plugin enters incompatible-server state, and no replacement server is spawned into the held port.

5. Status-name-only occupant safety
   - Put a process on the configured port whose `/godot-ai/status` returns `name=godot-ai` but has no matching managed record or pidfile proof.
   - Trigger update reload or drift startup.
   - Verify the plugin does not automatically kill it.
   - Verify the incompatible banner appears with recovery only when identity proof is present.
   - Click Restart and verify user-confirmed recovery can kill the occupant; if the port remains held, verify recovery returns false and the banner/state remain.

6. Non-godot occupant safety
   - Bind the configured port with an unrelated local service.
   - Trigger plugin startup, update reload, force restart, and recovery attempts.
   - Verify no automatic kill occurs, no raw port sweep occurs, and the plugin reports incompatible or blocked state without clearing managed records prematurely.

7. Compatible adoption sanity
   - Start a compatible managed server on the configured port.
   - Reload the plugin.
   - Verify the plugin adopts it, sets `actual_name` to `godot-ai`, clears `can_recover_incompatible`, and does not show the recovery Restart path.