### PR TITLE
Verify POSIX cmdline before accepting pidfile kill targets (#275 feedback)

### DIFF
--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -1538,13 +1538,27 @@ static func _build_server_flags(port: int, ws_port: int) -> Array[String]:
 	return flags
 
 
+## Returns true only when we can prove `pid`'s command line carries the
+## `godot-ai` brand AND a server flag (`--pid-file` / `--transport`). Used by
+## automatic kill paths (`_legacy_pidfile_kill_targets`) so a stale pidfile
+## whose PID has been recycled by an unrelated listener can't hand us a
+## kill target. If the OS lookup fails or returns an empty cmdline we
+## conservatively return false — better to surface incompatible-server and
+## let the user click Restart than to kill the wrong process.
 func _pid_cmdline_is_godot_ai(pid: int) -> bool:
-	if OS.get_name() != "Windows":
-		return true
-	return _commandline_is_godot_ai_server(_windows_pid_commandline(pid))
+	if pid <= 1:
+		return false
+	var cmd := ""
+	if OS.get_name() == "Windows":
+		cmd = _windows_pid_commandline(pid)
+	else:
+		cmd = _posix_pid_commandline(pid)
+	return _commandline_is_godot_ai_server(cmd)
 
 
 static func _commandline_is_godot_ai_server(cmd: String) -> bool:
+	if cmd.is_empty():
+		return false
 	var lower := cmd.to_lower()
 	var has_brand := lower.find("godot-ai") >= 0 or lower.find("godot_ai") >= 0
 	var has_flag := lower.find("--pid-file") >= 0 or lower.find("--transport") >= 0
@@ -1566,6 +1580,34 @@ func _windows_pid_commandline(pid: int) -> String:
 	if exit_code != 0 or output.is_empty():
 		return ""
 	return str(output[0])
+
+
+## POSIX command-line lookup. Linux exposes `/proc/<pid>/cmdline` as
+## NUL-separated argv — read it directly so we avoid a `ps` fork on Linux
+## and get the full argv rather than the truncated/quoted form some `ps`
+## builds emit. Falls back to `ps -p <pid> -o args=` on macOS / *BSD,
+## which lack a Linux-style `/proc/<pid>/cmdline`. Returns "" on failure
+## so callers conservatively reject the PID rather than killing it blind.
+func _posix_pid_commandline(pid: int) -> String:
+	var proc_path := "/proc/%d/cmdline" % pid
+	if FileAccess.file_exists(proc_path):
+		var f := FileAccess.open(proc_path, FileAccess.READ)
+		if f != null:
+			var bytes := f.get_buffer(int(f.get_length()))
+			f.close()
+			## /proc cmdline is NUL-separated argv; convert NULs to spaces
+			## so the substring fingerprint matches the same way it does on
+			## the Windows path. Empty (kernel threads, exited processes)
+			## bubbles up as "" via the strip below.
+			for i in range(bytes.size()):
+				if bytes[i] == 0:
+					bytes[i] = 0x20
+			return bytes.get_string_from_utf8().strip_edges()
+	var output: Array = []
+	var exit_code := OS.execute("ps", ["-p", str(pid), "-o", "args="], output, true)
+	if exit_code != 0 or output.is_empty():
+		return ""
+	return str(output[0]).strip_edges()
 
 
 ## True if the given PID corresponds to a live (non-zombie) process.

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -1560,9 +1560,25 @@ static func _commandline_is_godot_ai_server(cmd: String) -> bool:
 	if cmd.is_empty():
 		return false
 	var lower := cmd.to_lower()
-	var has_brand := lower.find("godot-ai") >= 0 or lower.find("godot_ai") >= 0
+	## The server is invoked with `--pid-file <user>/godot_ai_server.pid`,
+	## so the path itself contains "godot_ai". A naive substring brand
+	## search would falsely match an unrelated process whose cmdline
+	## happens to reference a similarly-named pidfile path. Strip the
+	## value (but leave the bare flag for the has_flag check) before
+	## brand matching.
+	var brand_search := _strip_pidfile_value(lower)
+	var has_brand := brand_search.find("godot-ai") >= 0 or brand_search.find("godot_ai") >= 0
 	var has_flag := lower.find("--pid-file") >= 0 or lower.find("--transport") >= 0
 	return has_brand and has_flag
+
+
+static func _strip_pidfile_value(cmd: String) -> String:
+	var rx := RegEx.new()
+	## Match `--pid-file=<token>` and `--pid-file <token>`; keep the bare
+	## flag so the flag-presence check still succeeds for a real server.
+	if rx.compile("--pid-file(?:=|\\s+)\\S+") != OK:
+		return cmd
+	return rx.sub(cmd, "--pid-file ", true)
 
 
 func _windows_pid_commandline(pid: int) -> String:
@@ -1585,7 +1601,7 @@ func _windows_pid_commandline(pid: int) -> String:
 ## POSIX command-line lookup. Linux exposes `/proc/<pid>/cmdline` as
 ## NUL-separated argv — read it directly so we avoid a `ps` fork on Linux
 ## and get the full argv rather than the truncated/quoted form some `ps`
-## builds emit. Falls back to `ps -p <pid> -o args=` on macOS / *BSD,
+## builds emit. Falls back to `ps -ww -p <pid> -o args=` on macOS / *BSD,
 ## which lack a Linux-style `/proc/<pid>/cmdline`. Returns "" on failure
 ## so callers conservatively reject the PID rather than killing it blind.
 func _posix_pid_commandline(pid: int) -> String:
@@ -1593,7 +1609,20 @@ func _posix_pid_commandline(pid: int) -> String:
 	if FileAccess.file_exists(proc_path):
 		var f := FileAccess.open(proc_path, FileAccess.READ)
 		if f != null:
-			var bytes := f.get_buffer(int(f.get_length()))
+			## procfs pseudo-files report length 0 (the kernel generates
+			## content on read). `get_length()` therefore returns 0 and
+			## `get_buffer(0)` reads nothing. Read in chunks until EOF
+			## instead. Cap at ARG_MAX-class bound so a hypothetically
+			## misbehaving file can never stall the editor frame.
+			var bytes := PackedByteArray()
+			var max_bytes := 1 << 20  # 1 MiB
+			while bytes.size() < max_bytes:
+				var chunk := f.get_buffer(4096)
+				if chunk.is_empty():
+					break
+				bytes.append_array(chunk)
+				if f.eof_reached():
+					break
 			f.close()
 			## /proc cmdline is NUL-separated argv; convert NULs to spaces
 			## so the substring fingerprint matches the same way it does on
@@ -1603,8 +1632,12 @@ func _posix_pid_commandline(pid: int) -> String:
 				if bytes[i] == 0:
 					bytes[i] = 0x20
 			return bytes.get_string_from_utf8().strip_edges()
+	## `-ww` removes ps's column-width truncation so trailing flags like
+	## --pid-file / --transport aren't dropped from the args= field.
+	## Both procps (Linux) and BSD ps (macOS / *BSD) accept the
+	## double-w form.
 	var output: Array = []
-	var exit_code := OS.execute("ps", ["-p", str(pid), "-o", "args="], output, true)
+	var exit_code := OS.execute("ps", ["-ww", "-p", str(pid), "-o", "args="], output, true)
 	if exit_code != 0 or output.is_empty():
 		return ""
 	return str(output[0]).strip_edges()

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -306,6 +306,49 @@ func test_commandline_fingerprint_is_case_insensitive_and_requires_flag() -> voi
 	)
 
 
+func test_commandline_fingerprint_ignores_brand_in_pidfile_path() -> void:
+	## Regression: the pidfile path itself is `<user>/godot_ai_server.pid`,
+	## so a substring brand search would falsely match an unrelated process
+	## that happens to reference a similarly-named pidfile. The brand must
+	## come from somewhere outside the --pid-file value.
+	assert_false(
+		GodotAiPlugin._commandline_is_godot_ai_server(
+			"someprogram --pid-file /var/run/godot_ai_server.pid --transport tcp"
+		),
+		"brand in pidfile path alone must not satisfy ownership proof"
+	)
+	assert_false(
+		GodotAiPlugin._commandline_is_godot_ai_server(
+			"someprogram --pid-file=/var/run/godot_ai_server.pid --transport tcp"
+		),
+		"--pid-file=<value> form must also strip the path before brand search"
+	)
+	assert_true(
+		GodotAiPlugin._commandline_is_godot_ai_server(
+			"/usr/bin/python -m godot_ai --transport streamable-http --pid-file /tmp/godot_ai_server.pid"
+		),
+		"real server invocation has brand outside the pidfile value, must still match"
+	)
+
+
+func test_strip_pidfile_value_handles_space_and_equals_forms() -> void:
+	## Whitespace form: keep the bare flag, drop the value.
+	assert_eq(
+		GodotAiPlugin._strip_pidfile_value("foo --pid-file /tmp/x.pid bar"),
+		"foo --pid-file  bar"
+	)
+	## Equals form: same outcome.
+	assert_eq(
+		GodotAiPlugin._strip_pidfile_value("foo --pid-file=/tmp/x.pid bar"),
+		"foo --pid-file  bar"
+	)
+	## No --pid-file flag: returned unchanged.
+	assert_eq(
+		GodotAiPlugin._strip_pidfile_value("foo --transport tcp"),
+		"foo --transport tcp"
+	)
+
+
 func test_pid_cmdline_rejects_sentinel_pids() -> void:
 	## Init/PID 1 and pid 0 must never be considered candidates for kill.
 	## A stale pidfile that somehow contains 0 or 1 has to bail before any
@@ -314,6 +357,30 @@ func test_pid_cmdline_rejects_sentinel_pids() -> void:
 	assert_false(plugin._pid_cmdline_is_godot_ai(0), "pid 0 must never match")
 	assert_false(plugin._pid_cmdline_is_godot_ai(1), "pid 1 (init) must never match")
 	plugin.free()
+
+
+func test_posix_pid_commandline_reads_procfs_despite_zero_length() -> void:
+	## procfs pseudo-files (/proc/<pid>/cmdline) report length 0 even though
+	## they have content. If we sized the read by `get_length()` we'd get
+	## an empty string back and the legacy pidfile proof would silently
+	## fail on Linux. Verify the chunked-read path actually returns data
+	## for a known-live PID (the editor itself).
+	if not FileAccess.file_exists("/proc/self/cmdline"):
+		skip("/proc not available — Linux-only test")
+		return
+	var plugin := GodotAiPlugin.new()
+	var cmd := plugin._posix_pid_commandline(OS.get_process_id())
+	plugin.free()
+	assert_false(
+		cmd.is_empty(),
+		"chunked read must return non-empty cmdline for the editor's own PID"
+	)
+	## The editor cmdline must contain the Godot binary path; this also
+	## confirms NUL-to-space conversion produced a usable string.
+	assert_true(
+		cmd.to_lower().find("godot") >= 0,
+		"editor cmdline should contain 'godot' substring, got: %s" % cmd
+	)
 
 
 func test_pid_cmdline_rejects_unrelated_local_pid() -> void:

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -300,6 +300,92 @@ func test_commandline_fingerprint_is_case_insensitive_and_requires_flag() -> voi
 		GodotAiPlugin._commandline_is_godot_ai_server("C:/Python/python.exe -m godot_ai"),
 		"brand alone is not enough ownership proof"
 	)
+	assert_false(
+		GodotAiPlugin._commandline_is_godot_ai_server(""),
+		"empty cmdline (lookup failure) must never be accepted as proof"
+	)
+
+
+func test_pid_cmdline_rejects_sentinel_pids() -> void:
+	## Init/PID 1 and pid 0 must never be considered candidates for kill.
+	## A stale pidfile that somehow contains 0 or 1 has to bail before any
+	## OS lookup, otherwise we'd risk targeting init on POSIX.
+	var plugin := GodotAiPlugin.new()
+	assert_false(plugin._pid_cmdline_is_godot_ai(0), "pid 0 must never match")
+	assert_false(plugin._pid_cmdline_is_godot_ai(1), "pid 1 (init) must never match")
+	plugin.free()
+
+
+func test_pid_cmdline_rejects_unrelated_local_pid() -> void:
+	## Regression for the cross-platform pidfile-proof bug: previously the
+	## non-Windows path returned true unconditionally, so a stale pidfile
+	## whose PID had been recycled by an unrelated listener could be accepted
+	## as a kill target. Now the function must actually inspect the cmdline.
+	## The current Godot editor process is a convenient stand-in for an
+	## "unrelated" PID — its cmdline contains no `--pid-file` / `--transport`
+	## flags, so the brand+flag fingerprint must reject it.
+	if OS.get_name() == "Windows":
+		skip("POSIX-only path: Windows uses PowerShell, exercised elsewhere")
+		return
+	var plugin := GodotAiPlugin.new()
+	var godot_pid := OS.get_process_id()
+	var matches := plugin._pid_cmdline_is_godot_ai(godot_pid)
+	plugin.free()
+	assert_false(
+		matches,
+		"editor PID's cmdline lacks --pid-file/--transport, must not match godot-ai server fingerprint"
+	)
+
+
+class _RealCmdlinePlugin extends GodotAiPlugin:
+	## Exercises the real `_pid_cmdline_is_godot_ai` inside the kill-target
+	## path. Mocks the pidfile / liveness lookups but lets the cmdline
+	## fingerprint flow through to the OS-specific reader (`/proc` on Linux,
+	## `ps` on macOS/*BSD, PowerShell on Windows). Regression coverage for
+	## the bug where the POSIX path returned true unconditionally.
+	var listener_pids: Array[int] = []
+	var pid_file_pid := 0
+	var alive_pids: Array[int] = []
+
+	func _read_pid_file_for_proof() -> int:
+		return pid_file_pid
+
+	func _pid_alive_for_proof(pid: int) -> bool:
+		return alive_pids.has(pid)
+
+
+func test_legacy_pidfile_kill_targets_requires_real_brand_proof() -> void:
+	## Spawn a benign child (`sleep`) so we have an unrelated live PID we
+	## can plant in the pidfile slot. Without the fix, `_legacy_pidfile_kill_targets`
+	## would return [child_pid] on POSIX because the cmdline check returned
+	## true unconditionally. With the fix, the child's cmdline (no
+	## --pid-file / --transport) is rejected and no kill targets are produced.
+	if OS.get_name() == "Windows":
+		skip("POSIX-only regression: Windows path covered by netstat parser tests")
+		return
+	var sleep_path := "/bin/sleep"
+	if not FileAccess.file_exists(sleep_path):
+		sleep_path = "/usr/bin/sleep"
+		if not FileAccess.file_exists(sleep_path):
+			skip("sleep(1) not available on this host")
+			return
+	var child_pid := OS.create_process(sleep_path, ["30"])
+	if child_pid <= 0:
+		skip("OS.create_process unavailable in this test environment")
+		return
+	var plugin := _RealCmdlinePlugin.new()
+	plugin.listener_pids = [child_pid] as Array[int]
+	plugin.pid_file_pid = child_pid
+	plugin.alive_pids = [child_pid] as Array[int]
+
+	var targets := plugin._legacy_pidfile_kill_targets(TEST_PORT, plugin.listener_pids)
+	plugin.free()
+	OS.kill(child_pid)
+
+	assert_true(
+		targets.is_empty(),
+		"unrelated live PID in pidfile must not produce kill targets without brand+flag cmdline proof"
+	)
 
 
 func test_strong_proof_accepts_live_managed_record_pid() -> void:


### PR DESCRIPTION
## Summary

Addresses the Copilot review on #275 ([discussion](https://github.com/hi-godot/godot-ai/pull/275#discussion_r3165734378)): `_pid_cmdline_is_godot_ai()` returned `true` unconditionally on non-Windows, so `_legacy_pidfile_kill_targets()` would accept any live pidfile PID and then sweep every listener on the configured HTTP port without verifying it was actually a `godot-ai` server. A stale pidfile whose PID had been recycled by an unrelated listener could feed the cleanup path a wrong kill target.

## Changes

- `plugin.gd`: add `_posix_pid_commandline()` — reads `/proc/<pid>/cmdline` directly on Linux (NUL-separated argv → space-joined for substring matching), falls back to `ps -p <pid> -o args=` on macOS / *BSD. Failures return `""`, which the brand+flag fingerprint rejects, so the plugin prefers landing in incompatible-server state (user can click Restart) over a wrong-process kill.
- `_pid_cmdline_is_godot_ai()`: sentinel-PID guard (pid `<= 1` short-circuits before any OS lookup so init/PID 1 can never be a kill target).
- `_commandline_is_godot_ai_server()`: rejects empty input explicitly so a downstream lookup-failure can't silently fall through.

## Tests

`test_project/tests/test_plugin_lifecycle.gd`:

- `test_pid_cmdline_rejects_sentinel_pids` — pid 0 and pid 1 always rejected.
- `test_pid_cmdline_rejects_unrelated_local_pid` — calls the real lookup against the editor's own PID; its cmdline lacks `--pid-file`/`--transport`, so the fingerprint correctly rejects it. (POSIX-only.)
- `test_legacy_pidfile_kill_targets_requires_real_brand_proof` — spawns a benign `sleep` child, plants its PID in the pidfile slot, asserts `_legacy_pidfile_kill_targets()` returns no targets. Without the fix this would have returned `[child_pid]`. (POSIX-only; cleans up the child.)
- Empty-cmdline rejection added to the existing fingerprint test.

## Validation

- `ruff check src/ tests/` — clean.
- `pytest -q` — 691 passed.
- `bash script/ci-check-gdscript` — all GDScript files OK.

This PR targets `codex/self-update-orphan-recovery` so it can be merged into #275 before that PR lands on `main`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Sgp6JjiWFLVmcAkgt3x1Wq)_