### PR TITLE
fix(self-update): skip zip directory entries before safety check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,12 @@ jobs:
           cp -r plugin/addons/godot_ai staging/addons/
           cp LICENSE staging/
           cd staging
-          zip -r ../godot-ai-plugin.zip addons/ LICENSE
+          # `-D` strips zero-byte directory entries. The 2.2.x/2.3.0 self-
+          # update runner has an over-strict safety check that flags the
+          # bare `addons/godot_ai/` directory entry as unsafe and aborts
+          # the extract. Stripping directory entries lets those installs
+          # successfully self-update to a fixed runner.
+          zip -D -r ../godot-ai-plugin.zip addons/ LICENSE
 
       - name: Verify zip structure
         run: |

--- a/plugin/addons/godot_ai/update_reload_runner.gd
+++ b/plugin/addons/godot_ai/update_reload_runner.gd
@@ -121,13 +121,17 @@ func _read_update_manifest() -> bool:
 	for file_path in files:
 		if not file_path.begins_with(ZIP_ADDON_PREFIX):
 			continue
+		var rel_path := file_path.trim_prefix(ZIP_ADDON_PREFIX)
+		## `zip -r` (used by release.yml) emits zero-byte directory entries
+		## like `addons/godot_ai/`. Skip those before the safety check; the
+		## empty-segment guard in `_is_safe_zip_addon_file` would otherwise
+		## flag the bare prefix as unsafe and abort the extract.
+		if rel_path.is_empty() or file_path.ends_with("/"):
+			continue
 		if not _is_safe_zip_addon_file(file_path):
 			print("MCP | update extract failed: unsafe zip path %s" % file_path)
 			reader.close()
 			return false
-		var rel_path := file_path.trim_prefix(ZIP_ADDON_PREFIX)
-		if rel_path.is_empty() or file_path.ends_with("/"):
-			continue
 		if rel_path == "plugin.cfg":
 			has_plugin_cfg = true
 		elif rel_path == "plugin.gd":

--- a/plugin/addons/godot_ai/update_reload_runner.gd
+++ b/plugin/addons/godot_ai/update_reload_runner.gd
@@ -122,10 +122,13 @@ func _read_update_manifest() -> bool:
 		if not file_path.begins_with(ZIP_ADDON_PREFIX):
 			continue
 		var rel_path := file_path.trim_prefix(ZIP_ADDON_PREFIX)
-		## `zip -r` (used by release.yml) emits zero-byte directory entries
-		## like `addons/godot_ai/`. Skip those before the safety check; the
+		## Many zip builders (`zip -r` without `-D`, AssetLib uploads, hand-
+		## built archives) emit zero-byte directory entries like
+		## `addons/godot_ai/`. Skip those before the safety check; the
 		## empty-segment guard in `_is_safe_zip_addon_file` would otherwise
-		## flag the bare prefix as unsafe and abort the extract.
+		## flag the bare prefix as unsafe and abort the extract. Current
+		## release.yml passes `-D` to strip them, but installed runners must
+		## still tolerate older or manually built zips.
 		if rel_path.is_empty() or file_path.ends_with("/"):
 			continue
 		if not _is_safe_zip_addon_file(file_path):

--- a/script/local-self-update-smoke
+++ b/script/local-self-update-smoke
@@ -633,10 +633,12 @@ def subn_once(path: Path, text: str, pattern: str, replacement: str, label: str)
 
 
 def create_plugin_zip(vnext_addon: Path, zip_path: Path) -> None:
-    # Mirror release.yml (`zip -r addons/ LICENSE`): include zero-byte
-    # directory entries so the install path sees the same shape on smoke
-    # and on real releases. The bare `addons/godot_ai/` entry is exactly
-    # what tripped the install safety check in 2.3.0.
+    # Include zero-byte directory entries (the shape `zip -r` produces
+    # without `-D`, also typical of AssetLib uploads and hand-built
+    # archives). Current release.yml strips them via `zip -D`, but the
+    # smoke must still exercise the directory-entry path: that's what
+    # tripped the 2.2.x/2.3.0 install safety check, and the runner has
+    # to keep handling it correctly for older or manually built zips.
     with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
         zf.writestr("addons/", "")
         zf.writestr("addons/godot_ai/", "")

--- a/script/local-self-update-smoke
+++ b/script/local-self-update-smoke
@@ -633,12 +633,23 @@ def subn_once(path: Path, text: str, pattern: str, replacement: str, label: str)
 
 
 def create_plugin_zip(vnext_addon: Path, zip_path: Path) -> None:
+    ## Mirror release.yml (`zip -r addons/ LICENSE`): include zero-byte
+    ## directory entries so the install path sees the same shape on smoke
+    ## and on real releases. The bare `addons/godot_ai/` entry is exactly
+    ## what tripped the install safety check in 2.3.0.
     with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("addons/", "")
+        zf.writestr("addons/godot_ai/", "")
+        seen_dirs: set[Path] = set()
         for path in sorted(vnext_addon.rglob("*")):
-            if path.is_dir():
-                continue
             rel = path.relative_to(vnext_addon)
-            zf.write(path, Path("addons") / "godot_ai" / rel)
+            if path.is_dir():
+                dir_arcname = Path("addons") / "godot_ai" / rel
+                if dir_arcname not in seen_dirs:
+                    zf.writestr(dir_arcname.as_posix() + "/", "")
+                    seen_dirs.add(dir_arcname)
+                continue
+            zf.write(path, (Path("addons") / "godot_ai" / rel).as_posix())
 
 
 def diagnostic_reports_snapshot() -> set[Path]:

--- a/script/local-self-update-smoke
+++ b/script/local-self-update-smoke
@@ -633,23 +633,20 @@ def subn_once(path: Path, text: str, pattern: str, replacement: str, label: str)
 
 
 def create_plugin_zip(vnext_addon: Path, zip_path: Path) -> None:
-    ## Mirror release.yml (`zip -r addons/ LICENSE`): include zero-byte
-    ## directory entries so the install path sees the same shape on smoke
-    ## and on real releases. The bare `addons/godot_ai/` entry is exactly
-    ## what tripped the install safety check in 2.3.0.
+    # Mirror release.yml (`zip -r addons/ LICENSE`): include zero-byte
+    # directory entries so the install path sees the same shape on smoke
+    # and on real releases. The bare `addons/godot_ai/` entry is exactly
+    # what tripped the install safety check in 2.3.0.
     with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
         zf.writestr("addons/", "")
         zf.writestr("addons/godot_ai/", "")
-        seen_dirs: set[Path] = set()
         for path in sorted(vnext_addon.rglob("*")):
             rel = path.relative_to(vnext_addon)
+            arcname = (Path("addons") / "godot_ai" / rel).as_posix()
             if path.is_dir():
-                dir_arcname = Path("addons") / "godot_ai" / rel
-                if dir_arcname not in seen_dirs:
-                    zf.writestr(dir_arcname.as_posix() + "/", "")
-                    seen_dirs.add(dir_arcname)
-                continue
-            zf.write(path, (Path("addons") / "godot_ai" / rel).as_posix())
+                zf.writestr(arcname + "/", "")
+            else:
+                zf.write(path, arcname)
 
 
 def diagnostic_reports_snapshot() -> set[Path]:

--- a/tests/unit/test_editor_focus_refocus.py
+++ b/tests/unit/test_editor_focus_refocus.py
@@ -406,9 +406,11 @@ def test_self_update_runner_disables_old_plugin_before_extract_and_scan() -> Non
     assert "FileAccess.file_exists(target_path)" in manifest_block
     assert "zip is missing plugin.cfg" in manifest_block
     assert "zip is missing plugin.gd" in manifest_block
-    dir_skip_idx = manifest_block.index('rel_path.is_empty() or file_path.ends_with("/")')
-    safe_call_idx = manifest_block.index("_is_safe_zip_addon_file(file_path)")
-    assert dir_skip_idx < safe_call_idx, (
+    dir_skip = 'rel_path.is_empty() or file_path.ends_with("/")'
+    assert dir_skip in manifest_block
+    assert manifest_block.index(dir_skip) < manifest_block.index(
+        "_is_safe_zip_addon_file(file_path)"
+    ), (
         "Skip zero-byte directory entries (rel_path empty or trailing slash) "
         "BEFORE the _is_safe_zip_addon_file check. `zip -r` (used by "
         "release.yml) emits a bare `addons/godot_ai/` directory entry; the "

--- a/tests/unit/test_editor_focus_refocus.py
+++ b/tests/unit/test_editor_focus_refocus.py
@@ -412,10 +412,11 @@ def test_self_update_runner_disables_old_plugin_before_extract_and_scan() -> Non
         "_is_safe_zip_addon_file(file_path)"
     ), (
         "Skip zero-byte directory entries (rel_path empty or trailing slash) "
-        "BEFORE the _is_safe_zip_addon_file check. `zip -r` (used by "
-        "release.yml) emits a bare `addons/godot_ai/` directory entry; the "
-        "safety guard treats an empty rel_path as unsafe and aborts the "
-        "extract, breaking self-update from any release zip."
+        "BEFORE the _is_safe_zip_addon_file check. Zips without `zip -D` "
+        "(older release artifacts, AssetLib uploads, hand-built archives) "
+        "include a bare `addons/godot_ai/` directory entry; the safety "
+        "guard treats its empty rel_path as unsafe and aborts the extract, "
+        "breaking self-update for any user whose installed runner sees one."
     )
 
     existing_block = runner_source.split("func _install_existing_files_and_scan() -> void:", 1)[

--- a/tests/unit/test_editor_focus_refocus.py
+++ b/tests/unit/test_editor_focus_refocus.py
@@ -406,6 +406,15 @@ def test_self_update_runner_disables_old_plugin_before_extract_and_scan() -> Non
     assert "FileAccess.file_exists(target_path)" in manifest_block
     assert "zip is missing plugin.cfg" in manifest_block
     assert "zip is missing plugin.gd" in manifest_block
+    dir_skip_idx = manifest_block.index('rel_path.is_empty() or file_path.ends_with("/")')
+    safe_call_idx = manifest_block.index("_is_safe_zip_addon_file(file_path)")
+    assert dir_skip_idx < safe_call_idx, (
+        "Skip zero-byte directory entries (rel_path empty or trailing slash) "
+        "BEFORE the _is_safe_zip_addon_file check. `zip -r` (used by "
+        "release.yml) emits a bare `addons/godot_ai/` directory entry; the "
+        "safety guard treats an empty rel_path as unsafe and aborts the "
+        "extract, breaking self-update from any release zip."
+    )
 
     existing_block = runner_source.split("func _install_existing_files_and_scan() -> void:", 1)[
         1


### PR DESCRIPTION
## Summary
- Self-update from 2.2.x → 2.3.0 fails with `MCP | update extract failed: unsafe zip path addons/godot_ai/` and silently rolls back to 2.2.3. Plugin remains usable; just stuck on the old version.
- Root cause: 1ced6a6's new `_is_safe_zip_addon_file` guard runs before the existing trailing-slash skip in `_read_update_manifest`. When `zip -r addons/ LICENSE` (release.yml) emits the standard zero-byte `addons/godot_ai/` directory entry, the guard sees an empty rel_path → returns false → entire extract aborts on the very first directory entry.
- The local self-update smoke harness didn't catch this because `script/local-self-update-smoke::create_plugin_zip` skips directories on the way in (`if path.is_dir(): continue`), so its synthetic zips have no directory entries — divergent shape from real CI release zips.

## Changes
- **`update_reload_runner.gd`**: skip directory entries before the safety check.
- **`script/local-self-update-smoke`**: include zero-byte directory entries in the synthetic vNext zip so the smoke fixture mirrors the real release zip shape. Also force POSIX arc names so it reproduces correctly on Windows (where the original `zf.write(path, Path(...))` would emit backslash arcnames that the runner's `\` guard would *also* reject).
- **`tests/unit/test_editor_focus_refocus.py`**: assert the directory-skip lives before the safety check in source order. Stops a future refactor from regressing this.
- **`.github/workflows/release.yml`**: build release zips with `zip -D` to strip directory entries. This is the **rescue** for users already on 2.2.x/2.3.0 — their installed (broken) runner is what extracts the next zip, so the next zip itself has to dodge their broken guard. Without this, the only escape from a 2.2.x install is a manual download-and-extract.

## Recommend
- Cut **v2.3.1** as soon as this lands so the rescue zip is published. Existing 2.2.x/2.3.0 users will then be able to self-update via the dock button into the fixed runner.

## Test plan
- [x] `pytest tests/unit -x -q` (440 passed)
- [x] Source-text test enforces ordering of directory-skip before safety check
- [ ] After merge & v2.3.1 release: install 2.2.3 from a dev checkout (or use the smoke harness), let the dock offer 2.3.1, click Update, confirm the editor stays alive, the version advances to 2.3.1, and the next 2.3.x update from there also works.
- [ ] Run `script/local-self-update-smoke` — now exercises the directory-entry path and would have caught this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)