### PR TITLE
Thread live-status snapshot through the spawn path

### DIFF
--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -655,26 +655,25 @@ func _start_server() -> void:
 			## kill the process currently holding the port.
 			print("MCP | managed server v%s does not match plugin v%s, restarting"
 				% [record_version, current_version])
-			if not _recover_strong_port_occupant(port, 3.0):
-				_server_started_this_session = true
-				_set_incompatible_server(_probe_live_server_status_for_port(port), current_version, port)
-				_startup_path = "incompatible"
-				push_warning(_server_status_message)
-				return
-			## Fall through to spawn.
-		else:
-			if not _recover_strong_port_occupant(port, 3.0):
-				## No recorded version drift and the live status probe did not
-				## verify an exact/current-compatible godot-ai server. A stale
-				## matching record alone is not enough ownership proof to kill
-				## the current port owner, and opening the WebSocket could route
-				## clients to an incompatible HTTP/MCP tool surface.
-				_server_started_this_session = true
-				_set_incompatible_server(live, current_version, port)
-				_startup_path = "incompatible"
-				push_warning(_server_status_message)
-				return
-			## Fall through to spawn.
+		## No recorded drift case: a stale matching record alone is not
+		## enough ownership proof to kill the current port owner, and
+		## opening the WebSocket could route clients to an incompatible
+		## HTTP/MCP tool surface — `_recover_strong_port_occupant` only
+		## acts on strong proof (managed_record / pidfile_listener /
+		## status_matches_record) so this branch is structurally safe.
+		##
+		## `live` is forwarded so the recovery path's proof helpers reuse
+		## the snapshot we already paid for. The kill itself invalidates
+		## that snapshot, so the failure-mode arm below re-probes before
+		## handing data to `_set_incompatible_server`.
+		if not _recover_strong_port_occupant(port, 3.0, live):
+			_server_started_this_session = true
+			var post_recovery_live := _probe_live_server_status_for_port(port)
+			_set_incompatible_server(post_recovery_live, current_version, port)
+			_startup_path = "incompatible"
+			push_warning(_server_status_message)
+			return
+		## Fall through to spawn.
 	else:
 		_startup_path = "free"
 
@@ -751,7 +750,12 @@ func _set_incompatible_server(live: Dictionary, expected_version: String, port: 
 	_server_actual_version = _live_version_for_message(live)
 	_server_dev_version_mismatch_allowed = false
 	_server_status_message = _incompatible_server_message(live, expected_version, port, _resolved_ws_port)
-	var proof := _evaluate_recovery_port_occupant_proof(port)
+	## `live` is the caller's most-current snapshot — pass it through to
+	## the recovery proof helper so it doesn't fire another probe of the
+	## same port. The `_set_incompatible_server` contract is "use exactly
+	## this live", so threading it down keeps the proof determination
+	## consistent with the diagnostic message we just built.
+	var proof := _evaluate_recovery_port_occupant_proof(port, live)
 	var proof_name := str(proof.get("proof", ""))
 	_can_recover_incompatible = not proof_name.is_empty()
 	print("MCP | proof: %s" % (proof_name if _can_recover_incompatible else "(none)"))
@@ -1420,7 +1424,16 @@ func _find_managed_pid(port: int) -> int:
 	return _find_pid_on_port(port)
 
 
-func _evaluate_strong_port_occupant_proof(port: int) -> Dictionary:
+## `live` is the result of a prior `_probe_live_server_status_for_port`
+## call that the caller already has on hand. When non-empty it short-
+## circuits the internal probe at the bottom of this helper, so a single
+## `_start_server` invocation that probes once at the top can thread the
+## same snapshot through compatibility check + recovery without paying
+## for a second ~500 ms localhost HTTPClient poll loop. Default `{}`
+## preserves the historical behavior for callers outside the spawn flow
+## (`can_recover_incompatible_server`, the dock's UI buttons), where a
+## fresh probe is the right thing.
+func _evaluate_strong_port_occupant_proof(port: int, live: Dictionary = {}) -> Dictionary:
 	var result := {"proof": "", "pids": []}
 	var listener_pids := _find_all_pids_on_port(port)
 	if listener_pids.is_empty():
@@ -1438,31 +1451,40 @@ func _evaluate_strong_port_occupant_proof(port: int) -> Dictionary:
 	if not legacy_targets.is_empty():
 		return {"proof": "pidfile_listener", "pids": legacy_targets}
 
-	var live := _probe_live_server_status_for_port(port)
+	var current_live: Dictionary = live if not live.is_empty() else _probe_live_server_status_for_port(port)
 	if (
-		_live_status_identifies_godot_ai(live)
+		_live_status_identifies_godot_ai(current_live)
 		and not record_version.is_empty()
-		and str(live.get("version", "")) == record_version
+		and str(current_live.get("version", "")) == record_version
 	):
 		return {"proof": "status_matches_record", "pids": listener_pids}
 
 	return result
 
 
-func _evaluate_recovery_port_occupant_proof(port: int) -> Dictionary:
-	var proof := _evaluate_strong_port_occupant_proof(port)
+## See `_evaluate_strong_port_occupant_proof` for the `live` contract.
+## Threads `live` through the strong-proof delegate so neither helper
+## probes when the caller already knows the port-owner status.
+func _evaluate_recovery_port_occupant_proof(port: int, live: Dictionary = {}) -> Dictionary:
+	var proof := _evaluate_strong_port_occupant_proof(port, live)
 	if not str(proof.get("proof", "")).is_empty():
 		return proof
 
-	var live := _probe_live_server_status_for_port(port)
-	if _live_status_identifies_godot_ai(live):
+	var current_live: Dictionary = live if not live.is_empty() else _probe_live_server_status_for_port(port)
+	if _live_status_identifies_godot_ai(current_live):
 		return {"proof": "status_name", "pids": _find_all_pids_on_port(port)}
 
 	return {"proof": "", "pids": []}
 
 
-func _recover_strong_port_occupant(port: int, wait_s: float) -> bool:
-	var proof := _evaluate_strong_port_occupant_proof(port)
+## `pre_kill_live` is forwarded to `_evaluate_strong_port_occupant_proof`
+## so the proof helper doesn't re-probe a port the caller already
+## probed. The kill itself invalidates that snapshot — by the time this
+## function returns, the caller must re-probe before consuming any
+## live-status data. Default `{}` lets non-startup callers (none today)
+## still use the historical fresh-probe behavior.
+func _recover_strong_port_occupant(port: int, wait_s: float, pre_kill_live: Dictionary = {}) -> bool:
+	var proof := _evaluate_strong_port_occupant_proof(port, pre_kill_live)
 	var targets: Array[int] = []
 	targets.assign(proof.get("pids", []))
 	if targets.is_empty():

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -27,6 +27,7 @@ class _ProofPlugin extends GodotAiPlugin:
 	var killed_targets: Array[int] = []
 	var cleared_record_calls := 0
 	var waited_calls := 0
+	var probe_calls := 0
 
 	func _find_all_pids_on_port(_port: int) -> Array[int]:
 		var pids: Array[int] = []
@@ -46,6 +47,7 @@ class _ProofPlugin extends GodotAiPlugin:
 		return branded_pids.has(pid)
 
 	func _probe_live_server_status_for_port(_port: int) -> Dictionary:
+		probe_calls += 1
 		return live_status.duplicate()
 
 	func _is_port_in_use(_port: int) -> bool:
@@ -1132,6 +1134,98 @@ func test_parse_lsof_pids_ignores_non_numeric_lines() -> void:
 	var pids := GodotAiPlugin._parse_lsof_pids("lsof: WARNING\n32696\n")
 	assert_eq(pids.size(), 1)
 	assert_eq(pids[0], 32696)
+
+
+## --- Live-status threading ------------------------------------------
+##
+## `_start_server` probes once at the top of the spawn body and threads
+## that snapshot through `_recover_strong_port_occupant`,
+## `_evaluate_*_port_occupant_proof`, and `_set_incompatible_server` so
+## downstream decision points reuse the result instead of re-probing.
+## Each probe costs a ~500 ms localhost HTTPClient poll loop, so a user-
+## reported occupied-port trace measured five back-to-back probes
+## dominating the dock's first-paint window.
+
+func test_strong_proof_uses_provided_live_without_probing() -> void:
+	var plugin := _ProofPlugin.new()
+	plugin.listener_pids = [13579] as Array[int]
+	plugin.managed_record = {"pid": 0, "version": "2.1.0", "ws_port": 9500}
+	var caller_live := {"name": "godot-ai", "version": "2.1.0", "ws_port": 9500, "status_code": 200}
+
+	var proof := plugin._evaluate_strong_port_occupant_proof(TEST_PORT, caller_live)
+	var probe_calls := plugin.probe_calls
+	plugin.free()
+
+	assert_eq(str(proof.get("proof", "")), "status_matches_record")
+	assert_eq(probe_calls, 0, "passing live must skip the internal probe")
+
+
+func test_strong_proof_probes_when_live_omitted() -> void:
+	var plugin := _ProofPlugin.new()
+	plugin.listener_pids = [13579] as Array[int]
+	plugin.managed_record = {"pid": 0, "version": "2.1.0", "ws_port": 9500}
+	plugin.live_status = {"name": "godot-ai", "version": "2.1.0", "ws_port": 9500, "status_code": 200}
+
+	var proof := plugin._evaluate_strong_port_occupant_proof(TEST_PORT)
+	var probe_calls := plugin.probe_calls
+	plugin.free()
+
+	assert_eq(str(proof.get("proof", "")), "status_matches_record")
+	assert_eq(probe_calls, 1, "omitting live must trigger the internal probe (preserves historical behavior)")
+
+
+func test_recovery_proof_threads_live_through_strong_call() -> void:
+	## `_evaluate_recovery_port_occupant_proof` first delegates to
+	## `_evaluate_strong_port_occupant_proof` (one probe site) and on
+	## empty proof probes again itself (second probe site). Passing
+	## `live` must skip both.
+	var plugin := _ProofPlugin.new()
+	plugin.listener_pids = [13579] as Array[int]
+	plugin.managed_record = {"pid": 0, "version": "", "ws_port": 0}
+	var caller_live := {"name": "godot-ai", "version": "2.1.0", "ws_port": 9500, "status_code": 200}
+
+	var proof := plugin._evaluate_recovery_port_occupant_proof(TEST_PORT, caller_live)
+	var probe_calls := plugin.probe_calls
+	plugin.free()
+
+	assert_eq(str(proof.get("proof", "")), "status_name", "fall-through path uses status name proof")
+	assert_eq(probe_calls, 0, "threading live must skip both internal probes")
+
+
+func test_recover_strong_port_occupant_threads_live_to_proof() -> void:
+	## `_recover_strong_port_occupant` uses `pre_kill_live` for the
+	## ownership-proof determination only. Anything after the kill must
+	## re-probe at the caller; the function itself never reuses
+	## `pre_kill_live` past `_kill_processes_and_windows_spawn_children`.
+	var plugin := _ProofPlugin.new()
+	plugin.listener_pids = [13579] as Array[int]
+	plugin.managed_record = {"pid": 13579, "version": "2.1.0", "ws_port": 9500}
+	plugin.alive_pids = [13579] as Array[int]
+	plugin.port_in_use_sequence = [false] as Array[bool]
+	var caller_live := {"name": "godot-ai", "version": "2.1.0", "ws_port": 9500, "status_code": 200}
+
+	var ok := plugin._recover_strong_port_occupant(TEST_PORT, 0.1, caller_live)
+	var probe_calls := plugin.probe_calls
+	plugin.free()
+
+	assert_true(ok, "managed-record proof should recover when the port frees")
+	assert_eq(probe_calls, 0, "_recover_strong_port_occupant must thread live to its proof helper")
+
+
+func test_set_incompatible_server_threads_live_to_recovery_proof() -> void:
+	## `_set_incompatible_server` already accepts `live`; with the
+	## refactor it forwards that snapshot to its internal recovery-proof
+	## call so the proof helper doesn't re-probe.
+	var plugin := _ProofPlugin.new()
+	plugin.listener_pids = [13579] as Array[int]
+	plugin.managed_record = {"pid": 0, "version": "", "ws_port": 0}
+	var caller_live := {"name": "godot-ai", "version": "2.1.0", "ws_port": 9500, "status_code": 200}
+
+	plugin._set_incompatible_server(caller_live, "2.3.1", TEST_PORT)
+	var probe_calls := plugin.probe_calls
+	plugin.free()
+
+	assert_eq(probe_calls, 0, "_set_incompatible_server must reuse the caller's live for its proof determination")
 
 
 func _seed_managed_record(pid: int, version: String) -> void:


### PR DESCRIPTION
## Summary

Follow-on to #285. The user's startup trace on the occupied-port path showed `http_status_probe: 5` and `phase=server_start delta_ms=2646` — five back-to-back ~500 ms HTTPClient poll loops dominating the first-paint window. This PR replaces the redundant probes with explicit data flow: probe once at the top of `_start_server`, thread the snapshot through the helpers that need it.

> **Note:** an earlier version of this PR used a per-startup probe cache (memoization). After review, that approach was rejected as treating a symptom (hidden mutable state, manual cache invalidation) rather than fixing the call graph. The current diff is the parameter-threading version.

## Approach

Each downstream helper now takes an optional `live: Dictionary = {}` and falls back to its historical fresh probe when the caller doesn't have one. This preserves behavior for non-startup callers (the dock's recover/restart buttons, `_on_server_version_*`) without any branching:

- `_evaluate_strong_port_occupant_proof(port, live={})`
- `_evaluate_recovery_port_occupant_proof(port, live={})` — threads `live` to the strong-proof delegate
- `_recover_strong_port_occupant(port, wait_s, pre_kill_live={})` — uses the snapshot for proof determination only; the kill itself invalidates it, so the function never reuses `pre_kill_live` past the kill
- `_set_incompatible_server(live, ...)` — already accepted `live`; now also forwards it to its internal `_evaluate_recovery_port_occupant_proof` call

`_start_server` becomes the orchestrator: probes once at the top, passes `live` to recovery, and re-probes unconditionally on recovery failure before handing data to `_set_incompatible_server`.

## Latent staleness bug fix (bonus)

The original no-drift branch reused the pre-recovery `live` for the failure-mode diagnostic even when `_recover_strong_port_occupant` had attempted (and failed) a kill via `legacy_pidfile_kill_targets`. After a kill the port owner can change, so the diagnostic could describe a process that no longer exists. The unified failure arm now re-probes after every recovery failure — costs one extra probe in the rare no-targets sub-case, fixes the bug structurally.

## Trace verification (Linux 4.6.2 / `python -m http.server 8000`)

| Variant | `http_status_probe` count | `server_start` phase |
|---|---|---|
| #285 baseline | 4 | 285 ms |
| **This PR** | **2** | **222 ms** |

On the user's Windows environment (~530 ms per probe) the same factor of 2 fewer probes should translate to ~**1 s saved** on the occupied-port path. In the user's drift+kill-fail scenario specifically (5 probes in their trace) the refactor collapses to 2 probes — so ~1.5 s saved on Windows for that specific path.

## Why parameter threading vs the cache approach

| | Cache (rejected) | Parameter threading (this PR) |
|---|---|---|
| `http_status_probe` (Linux baseline) | 1 | 2 |
| Hidden mutable state | yes (`_startup_probe_cache_active`) | no |
| Cache invalidation correctness | manual; one site fixed in review, others latent | n/a |
| Latent no-drift staleness bug | not addressed | **fixed** |
| API surface change | additive helper | one optional kwarg per helper, default preserves behavior |

The cache version was 1 probe faster on Linux but added hidden state and didn't fix the staleness bug. The user explicitly preferred the structural fix.

## Tests

Five new unit tests in `test_plugin_lifecycle.gd` assert the threading contract via a `probe_calls` counter on the existing `_ProofPlugin` override:

- `test_strong_proof_uses_provided_live_without_probing` — `live` short-circuits internal probe.
- `test_strong_proof_probes_when_live_omitted` — historical fall-back preserved.
- `test_recovery_proof_threads_live_through_strong_call` — `live` passes through the strong-proof delegate, both internal probe sites skipped.
- `test_recover_strong_port_occupant_threads_live_to_proof` — recovery uses `pre_kill_live` for proof determination.
- `test_set_incompatible_server_threads_live_to_recovery_proof` — diagnostic and proof determination share the same `live`.

## Test plan

- [x] `ruff check src/ tests/` clean
- [x] `pytest -v` (691 passed)
- [x] `bash script/ci-check-gdscript` — all GDScript files OK
- [x] Headless trace A/B with port 8000 occupied: 4 probes → 2 probes
- [ ] `test_run` via MCP in editor — five new unit tests pass
- [ ] Live smoke: launch editor with port 8000 occupied; confirm dock shows incompatible-server panel quickly (no multi-second hang) and the Restart Server button still works
- [ ] Live smoke: launch editor with port 8000 free; confirm clean spawned path is unchanged
- [ ] Stack on top of #285 in CI to re-run the user's headless Windows trace; expect `http_status_probe: 2`