### PR TITLE
Pause WebSocket pump around ResourceSaver.save (closes #288)

### DIFF
--- a/plugin/addons/godot_ai/handlers/curve_handler.gd
+++ b/plugin/addons/godot_ai/handlers/curve_handler.gd
@@ -11,10 +11,12 @@ extends RefCounted
 const NodeHandler := preload("res://addons/godot_ai/handlers/node_handler.gd")
 
 var _undo_redo: EditorUndoRedoManager
+var _connection: McpConnection
 
 
-func _init(undo_redo: EditorUndoRedoManager) -> void:
+func _init(undo_redo: EditorUndoRedoManager, connection: McpConnection = null) -> void:
 	_undo_redo = undo_redo
+	_connection = connection
 
 
 func set_points(params: Dictionary) -> Dictionary:
@@ -100,7 +102,7 @@ func set_points(params: Dictionary) -> Dictionary:
 			"curve_class": curve.get_class(),
 			"point_count": new_snapshot.size(),
 			"reason": "File save is persistent; edit the .tres file manually to revert",
-		})
+		}, _connection)
 
 	# Inline (node-attached) path: swap the curve property so the action lands
 	# cleanly in scene history, mirroring the resource-swap pattern used by

--- a/plugin/addons/godot_ai/handlers/environment_handler.gd
+++ b/plugin/addons/godot_ai/handlers/environment_handler.gd
@@ -8,10 +8,12 @@ extends RefCounted
 const ResourceHandler := preload("res://addons/godot_ai/handlers/resource_handler.gd")
 
 var _undo_redo: EditorUndoRedoManager
+var _connection: McpConnection
 
 
-func _init(undo_redo: EditorUndoRedoManager) -> void:
+func _init(undo_redo: EditorUndoRedoManager, connection: McpConnection = null) -> void:
 	_undo_redo = undo_redo
+	_connection = connection
 
 
 const _PRESETS := {
@@ -152,4 +154,4 @@ func _assign_environment(env: Environment, sky: Sky, sky_material: ProceduralSky
 func _save_environment(env: Environment, _sky: Sky, _sky_material: ProceduralSkyMaterial, resource_path: String, overwrite: bool, preset: String) -> Dictionary:
 	return McpResourceIO.save_to_disk(env, resource_path, overwrite, "Environment", {
 		"preset": preset,
-	})
+	}, _connection)

--- a/plugin/addons/godot_ai/handlers/resource_handler.gd
+++ b/plugin/addons/godot_ai/handlers/resource_handler.gd
@@ -6,10 +6,12 @@ extends RefCounted
 const NodeHandler := preload("res://addons/godot_ai/handlers/node_handler.gd")
 
 var _undo_redo: EditorUndoRedoManager
+var _connection: McpConnection
 
 
-func _init(undo_redo: EditorUndoRedoManager) -> void:
+func _init(undo_redo: EditorUndoRedoManager, connection: McpConnection = null) -> void:
 	_undo_redo = undo_redo
+	_connection = connection
 
 
 func search_resources(params: Dictionary) -> Dictionary:
@@ -340,7 +342,7 @@ func _save_created_resource(res: Resource, type_str: String, resource_path: Stri
 		"type": type_str,
 		"resource_class": res.get_class(),
 		"properties_applied": applied_count,
-	})
+	}, _connection)
 
 
 ## Introspect a Resource class — return its editor-visible properties, parent,

--- a/plugin/addons/godot_ai/handlers/texture_handler.gd
+++ b/plugin/addons/godot_ai/handlers/texture_handler.gd
@@ -8,10 +8,12 @@ extends RefCounted
 const NodeHandler := preload("res://addons/godot_ai/handlers/node_handler.gd")
 
 var _undo_redo: EditorUndoRedoManager
+var _connection: McpConnection
 
 
-func _init(undo_redo: EditorUndoRedoManager) -> void:
+func _init(undo_redo: EditorUndoRedoManager, connection: McpConnection = null) -> void:
 	_undo_redo = undo_redo
+	_connection = connection
 
 
 const _FILL_MODES := {
@@ -145,7 +147,7 @@ func _finalize(tex: Resource, sub_resources: Array, params: Dictionary, label: S
 	var overwrite: bool = params.get("overwrite", false)
 
 	if not resource_path.is_empty():
-		return McpResourceIO.save_to_disk(tex, resource_path, overwrite, label, extra)
+		return McpResourceIO.save_to_disk(tex, resource_path, overwrite, label, extra, _connection)
 	return _assign_texture(tex, sub_resources, node_path, property, label, extra)
 
 

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -187,7 +187,7 @@ func _enter_tree() -> void:
 	var project_handler := ProjectHandler.new(_connection)
 	var client_handler := ClientHandler.new()
 	var script_handler := ScriptHandler.new(get_undo_redo(), _connection)
-	var resource_handler := ResourceHandler.new(get_undo_redo())
+	var resource_handler := ResourceHandler.new(get_undo_redo(), _connection)
 	var filesystem_handler := FilesystemHandler.new()
 	var signal_handler := SignalHandler.new(get_undo_redo())
 	var autoload_handler := AutoloadHandler.new()
@@ -202,9 +202,9 @@ func _enter_tree() -> void:
 	var camera_handler := CameraHandler.new(get_undo_redo())
 	var audio_handler := AudioHandler.new(get_undo_redo())
 	var physics_shape_handler := PhysicsShapeHandler.new(get_undo_redo())
-	var environment_handler := EnvironmentHandler.new(get_undo_redo())
-	var texture_handler := TextureHandler.new(get_undo_redo())
-	var curve_handler := CurveHandler.new(get_undo_redo())
+	var environment_handler := EnvironmentHandler.new(get_undo_redo(), _connection)
+	var texture_handler := TextureHandler.new(get_undo_redo(), _connection)
+	var curve_handler := CurveHandler.new(get_undo_redo(), _connection)
 	var control_draw_recipe_handler := ControlDrawRecipeHandler.new(get_undo_redo())
 	_handlers = [editor_handler, scene_handler, node_handler, project_handler, client_handler, script_handler, resource_handler, filesystem_handler, signal_handler, autoload_handler, input_handler, test_handler, batch_handler, ui_handler, theme_handler, animation_handler, material_handler, particle_handler, camera_handler, audio_handler, physics_shape_handler, environment_handler, texture_handler, curve_handler, control_draw_recipe_handler]
 

--- a/plugin/addons/godot_ai/utils/resource_io.gd
+++ b/plugin/addons/godot_ai/utils/resource_io.gd
@@ -48,9 +48,27 @@ static func validate_home(params: Dictionary, require_property: bool = true) -> 
 ## a `reason` key in `extra_fields` overrides the default — useful for
 ## tools that edit existing files rather than creating fresh ones.
 ##
+## `pause_target` should be the handler's `McpConnection`. When supplied,
+## `pause_processing` is flipped on around `ResourceSaver.save()` so the
+## dispatcher's WebSocket pump can't re-enter while Godot pumps
+## `Main::iteration()` for the resource-save's progress UI / script-class
+## update task. Without this guard a queued command landing during the
+## save can trigger another `save_to_disk` that tries to add the same
+## `update_scripts_classes` editor task — "Task already exists" → null
+## deref → SIGSEGV. Same family of bug as godotengine/godot#118545 and
+## the same mitigation as `SceneHandler`'s `save_scene*` wraps. See
+## issue #288.
+##
 ## Returns either an error dict or a {"data": {...}} success dict — ready
 ## for the handler to return directly.
-static func save_to_disk(res: Resource, resource_path: String, overwrite: bool, label: String, extra_fields: Dictionary = {}) -> Dictionary:
+static func save_to_disk(
+	res: Resource,
+	resource_path: String,
+	overwrite: bool,
+	label: String,
+	extra_fields: Dictionary = {},
+	pause_target: McpConnection = null,
+) -> Dictionary:
 	if not resource_path.begins_with("res://"):
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "resource_path must start with res://")
 
@@ -69,7 +87,11 @@ static func save_to_disk(res: Resource, resource_path: String, overwrite: bool, 
 			"Failed to create directory %s: %s" % [dir_path, error_string(mkdir_err)]
 		)
 
+	if pause_target != null:
+		pause_target.pause_processing = true
 	var save_err := ResourceSaver.save(res, resource_path)
+	if pause_target != null:
+		pause_target.pause_processing = false
 	if save_err != OK:
 		return McpErrorCodes.make(
 			McpErrorCodes.INTERNAL_ERROR,

--- a/tests/unit/test_resource_save_pause_processing.py
+++ b/tests/unit/test_resource_save_pause_processing.py
@@ -1,0 +1,151 @@
+"""Regression test for #288 — re-entrant ResourceSaver.save crash.
+
+`ResourceSaver.save()` can pump `Main::iteration()` while it scans for
+script-class changes. If `McpConnection._process()` runs during that pump,
+the dispatcher re-enters and may dispatch another command that also calls
+`save_to_disk` -> tries to add the same `update_scripts_classes` editor
+task -> "Task already exists" -> null deref -> SIGSEGV. Same family as
+godotengine/godot#118545.
+
+Mitigation mirrors the pattern `SceneHandler` / `ProjectHandler` already
+use around `EditorInterface.save_scene*` and `play_*scene*`: flip
+`McpConnection.pause_processing = true` while the editor pumps, so the
+WebSocket pump short-circuits in `_process` (`connection.gd:55-57`).
+
+The structural assertions below lock the wrap into place. If a future
+refactor drops `pause_target` from `save_to_disk` or stops threading
+`_connection` through any of the four resource-saving handlers, the test
+fails with a pointer to this file.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[2] / "plugin" / "addons" / "godot_ai"
+
+
+def _func_block(source: str, marker: str) -> str:
+    """Slice everything from `marker` until the next top-level `func` /
+    `static func` declaration. Tolerates blank lines inside the body that
+    a naive `split("\n\n")` would cut on.
+    """
+    rest = source.split(marker, 1)[1]
+    cuts = []
+    for needle in ("\nfunc ", "\nstatic func "):
+        idx = rest.find(needle)
+        if idx >= 0:
+            cuts.append(idx)
+    if not cuts:
+        return rest
+    return rest[: min(cuts)]
+
+
+def test_save_to_disk_takes_pause_target() -> None:
+    source = (PLUGIN_ROOT / "utils" / "resource_io.gd").read_text()
+    block = _func_block(source, "static func save_to_disk(")
+    assert "pause_target: McpConnection" in block, (
+        "save_to_disk must accept a McpConnection so the WebSocket pump "
+        "can be paused while ResourceSaver.save() runs. Without this, a "
+        "queued command landing during the editor's progress-UI pump "
+        "re-enters the dispatcher and crashes Godot. See #288."
+    )
+    assert "pause_target.pause_processing = true" in block, (
+        "Before the ResourceSaver.save() call, save_to_disk must flip "
+        "pause_processing on. Otherwise the re-entrancy mitigation isn't "
+        "in effect."
+    )
+    assert "pause_target.pause_processing = false" in block, (
+        "After the ResourceSaver.save() call, save_to_disk must flip "
+        "pause_processing back off, otherwise the dispatcher stays silent "
+        "for the rest of the session."
+    )
+
+    # Order: pause -> save -> unpause. A naive refactor that re-orders
+    # these would silently neuter the guard.
+    pause_idx = block.index("pause_target.pause_processing = true")
+    save_idx = block.index("ResourceSaver.save(res, resource_path)")
+    unpause_idx = block.index("pause_target.pause_processing = false")
+    assert pause_idx < save_idx < unpause_idx, (
+        f"Order must be pause -> save -> unpause, got "
+        f"pause={pause_idx}, save={save_idx}, unpause={unpause_idx}"
+    )
+
+
+def test_resource_handler_threads_connection_to_save() -> None:
+    source = (PLUGIN_ROOT / "handlers" / "resource_handler.gd").read_text()
+    assert "var _connection: McpConnection" in source, (
+        "ResourceHandler must hold a McpConnection ref to thread into "
+        "save_to_disk. See #288."
+    )
+    assert "_init(undo_redo: EditorUndoRedoManager, connection: McpConnection" in source, (
+        "ResourceHandler._init must accept a McpConnection — the existing "
+        "pattern from SceneHandler / ProjectHandler. plugin.gd passes it."
+    )
+    save_block = _func_block(source, "func _save_created_resource")
+    assert "_connection)" in save_block or "_connection," in save_block, (
+        "_save_created_resource must pass _connection to "
+        "McpResourceIO.save_to_disk. Otherwise the pause guard is a no-op "
+        "for create_resource calls."
+    )
+
+
+def test_curve_handler_threads_connection_to_save() -> None:
+    source = (PLUGIN_ROOT / "handlers" / "curve_handler.gd").read_text()
+    assert "var _connection: McpConnection" in source
+    assert "_init(undo_redo: EditorUndoRedoManager, connection: McpConnection" in source
+    set_points_block = _func_block(source, "func set_points")
+    assert "save_to_disk(" in set_points_block
+    # Slice from save_to_disk( through the next return / line break out of
+    # the call. _connection must appear in that range.
+    after_save = set_points_block.split("save_to_disk(", 1)[1].split("\n\n", 1)[0]
+    assert "_connection" in after_save, (
+        "curve_handler.set_points must pass _connection to save_to_disk "
+        "for the pause guard to take effect. See #288."
+    )
+
+
+def test_environment_handler_threads_connection_to_save() -> None:
+    source = (PLUGIN_ROOT / "handlers" / "environment_handler.gd").read_text()
+    assert "var _connection: McpConnection" in source
+    assert "_init(undo_redo: EditorUndoRedoManager, connection: McpConnection" in source
+    save_block = _func_block(source, "func _save_environment")
+    assert "_connection)" in save_block or "_connection," in save_block, (
+        "_save_environment must thread _connection to save_to_disk. See #288."
+    )
+
+
+def test_texture_handler_threads_connection_to_save() -> None:
+    source = (PLUGIN_ROOT / "handlers" / "texture_handler.gd").read_text()
+    assert "var _connection: McpConnection" in source
+    assert "_init(undo_redo: EditorUndoRedoManager, connection: McpConnection" in source
+    # The save call lives inside _save_or_assign_texture in this handler;
+    # locate the save_to_disk call and assert _connection is in the args.
+    save_idx = source.index("McpResourceIO.save_to_disk(tex,")
+    save_call = source[save_idx : source.index(")", save_idx) + 1]
+    assert "_connection" in save_call, (
+        "texture_handler must pass _connection to save_to_disk. See #288."
+    )
+
+
+def test_plugin_passes_connection_to_resource_handlers() -> None:
+    source = (PLUGIN_ROOT / "plugin.gd").read_text()
+    # All four resource-saving handlers must be constructed with _connection,
+    # otherwise the pause guard inside save_to_disk silently no-ops.
+    for handler in ("ResourceHandler", "EnvironmentHandler", "TextureHandler", "CurveHandler"):
+        assert f"{handler}.new(get_undo_redo(), _connection)" in source, (
+            f"plugin.gd must construct {handler} with _connection. Without "
+            f"the connection ref, save_to_disk's pause guard can't fire and "
+            f"the editor crashes under load. See #288."
+        )
+
+
+def test_scene_handler_pause_pattern_still_present_for_reference() -> None:
+    """The SceneHandler pattern is the precedent for the resource-save fix.
+
+    If this test ever fails, the resource-save fix is now an orphan
+    pattern and the issue #288 fix should be re-evaluated.
+    """
+    source = (PLUGIN_ROOT / "handlers" / "scene_handler.gd").read_text()
+    assert "_connection.pause_processing = true" in source
+    assert "_connection.pause_processing = false" in source


### PR DESCRIPTION
Closes #288.

## Summary

`ResourceSaver.save()` can pump `Main::iteration()` while the editor scans for script-class changes (the `update_scripts_classes` task's progress UI). If `McpConnection._process()` runs during that pump, the dispatcher re-enters and may dispatch another command that also calls `save_to_disk` — which tries to add the same `update_scripts_classes` editor task. Godot logs `Task already exists`, then null-derefs → SIGSEGV. Same family as [godotengine/godot#118545](https://github.com/godotengine/godot/issues/118545), surfaced during interactive smoke for #287 (full crash analysis in #288).

## Approach

`SceneHandler` and `ProjectHandler` already work around the same pattern by flipping `_connection.pause_processing = true` around `save_scene*` / `play_*scene*` calls. `_process` short-circuits on that flag so the WebSocket pump doesn't re-enter while Godot is pumping its own main loop.

This PR applies the same wrap to `resource_io.save_to_disk`:

- New optional `pause_target: McpConnection = null` parameter on `save_to_disk`. When supplied, `pause_processing` is flipped on around the `ResourceSaver.save()` call only.
- Four resource-saving handlers (`ResourceHandler`, `CurveHandler`, `EnvironmentHandler`, `TextureHandler`) now take a `McpConnection` in their constructors (`null` default preserves existing test/instantiation patterns) and thread it into `save_to_disk`.
- `plugin.gd` passes `_connection` at each construction site.

Pause window is narrow (just the `ResourceSaver.save()` call itself, not the whole helper) so the dispatcher only stalls for the actual editor pump, not for path validation / mkdir / response building.

## Verification

**Reproduction on `main`** (Linux, xvfb-run, Godot 4.6.2):
- `test_run` via MCP → SIGSEGV ~halfway through the suite, on the boundary between `test_resource` and `test_curve` where `create_resource` and `curve_set_points` rapid-fire saves.

**After this PR**:
```
PASSED=1029 FAILED=0 SKIPPED=3 TOTAL=1032 duration_ms=4660
```

Editor PID stays the same throughout. The `update_scripts_classes` task collision is gone.

## Tests

`tests/unit/test_resource_save_pause_processing.py` — seven structural assertions:

| Test | Asserts |
|---|---|
| `test_save_to_disk_takes_pause_target` | `save_to_disk` signature accepts `pause_target: McpConnection`, flips the flag on/off, ordering is pause → save → unpause |
| `test_resource_handler_threads_connection_to_save` | `ResourceHandler._init` takes a connection, `_save_created_resource` passes it |
| `test_curve_handler_threads_connection_to_save` | Same for `CurveHandler.set_points` |
| `test_environment_handler_threads_connection_to_save` | Same for `EnvironmentHandler._save_environment` |
| `test_texture_handler_threads_connection_to_save` | Same for `TextureHandler` |
| `test_plugin_passes_connection_to_resource_handlers` | `plugin.gd` constructs all four handlers with `_connection` |
| `test_scene_handler_pause_pattern_still_present_for_reference` | The precedent pattern in `SceneHandler` hasn't been removed |

A future refactor that drops the wrap from any of these call sites fails the test with a pointer to this file and #288.

## Test plan

- [x] `ruff check src/ tests/` clean
- [x] `pytest -v` (699 passed — was 692, +7 new structural tests)
- [x] `bash script/ci-check-gdscript` — all GDScript files OK
- [x] **Repro on Linux (xvfb-run): full `test_run` completed (1029 / 0 / 3) — was crashing on `main`**
- [ ] Windows interactive smoke (`test_run` via MCP) — best done locally per @dsarno's offer to hand off
- [ ] Live smoke: each of `create_resource`, `curve_set_points`, `environment_create`, `gradient_texture_create`, `noise_texture_create` works for both inline assignment and the `resource_path=res://...` save path

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vr39Q5d8TyLd2CGq2nYoAp)_