### PR TITLE
Migrate 52 test sites off broken `_undo_redo.undo()`; add lint + handler pin (closes #290)

### DIFF
--- a/plugin/addons/godot_ai/handlers/animation_handler.gd
+++ b/plugin/addons/godot_ai/handlers/animation_handler.gd
@@ -251,7 +251,7 @@ func add_property_track(params: Dictionary) -> Dictionary:
 			"transition": kf.get("transition", "linear"),
 		})
 
-	_undo_redo.create_action("MCP: Add property track %s to %s" % [track_path, anim_name])
+	_create_scene_pinned_action("MCP: Add property track %s to %s" % [track_path, anim_name])
 	_undo_redo.add_do_method(self, "_do_add_property_track", anim, track_path, interp_str, coerced_keyframes)
 	# Undo locates the track by (path, type) at undo time rather than caching
 	# an index captured at do time. Cached indices go stale if any other track
@@ -337,7 +337,7 @@ func add_method_track(params: Dictionary) -> Dictionary:
 		return anim_resolved
 	var anim: Animation = anim_resolved.animation
 
-	_undo_redo.create_action("MCP: Add method track %s to %s" % [target_path, anim_name])
+	_create_scene_pinned_action("MCP: Add method track %s to %s" % [target_path, anim_name])
 	_undo_redo.add_do_method(self, "_do_add_method_track", anim, target_path, keyframes)
 	# Undo locates the track by (path, type) at undo time — see add_property_track.
 	_undo_redo.add_undo_method(self, "_undo_remove_track_by_path", anim, target_path, Animation.TYPE_METHOD)
@@ -1261,6 +1261,20 @@ func _commit_animation_add(
 		_undo_redo.add_undo_method(library, "remove_animation", anim_name)
 	_undo_redo.add_do_reference(anim)
 	_undo_redo.commit_action()
+
+
+## Open a `create_action` pinned to the edited scene's history.
+##
+## Without an explicit context, `add_do_method(self, ...)` against a
+## RefCounted handler lands in GLOBAL_HISTORY while sibling actions whose
+## first do-target is a Resource (e.g. AnimationLibrary) land in the scene's
+## history. Mismatched histories make the test-side `editor_undo` helper
+## (walks scene first) undo the wrong action, and break batch_handler's
+## rollback. Mirrors `camera_handler.gd`'s identical pinning rationale.
+func _create_scene_pinned_action(action_label: String) -> void:
+	_undo_redo.create_action(
+		action_label, UndoRedo.MERGE_DISABLE, EditorInterface.get_edited_scene_root(),
+	)
 
 
 # ============================================================================

--- a/test_project/tests/test_animation.gd
+++ b/test_project/tests/test_animation.gd
@@ -29,14 +29,21 @@ func suite_teardown() -> void:
 
 ## Add an AnimationPlayer to the scene root and return its path.
 ## Caller is responsible for removing the node in teardown.
+##
+## Adds the node directly (not via `_handler.create_player`) so the fixture
+## doesn't push a setup action onto the undo stack — keeping the test's
+## `editor_undo` calls focused on the one action under test. Mirrors the
+## `_add_mesh_instance` pattern in `test_resource.gd`.
 func _add_player(player_name: String = "TestAnimPlayer") -> String:
 	var scene_root := EditorInterface.get_edited_scene_root()
 	if scene_root == null:
 		return ""
-	var result := _handler.create_player({"parent_path": "/" + scene_root.name, "name": player_name})
-	if result.has("error"):
-		return ""
-	return result.data.path
+	var player := AnimationPlayer.new()
+	player.name = player_name
+	player.add_animation_library("", AnimationLibrary.new())
+	scene_root.add_child(player)
+	player.set_owner(scene_root)
+	return "/" + scene_root.name + "/" + player_name
 
 
 func _remove_node(path: String) -> void:
@@ -96,7 +103,7 @@ func test_player_create_is_undoable() -> void:
 	})
 	assert_has_key(result, "data")
 	assert_eq(scene_root.get_child_count(), before_count + 1)
-	_undo_redo.undo()
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 	assert_eq(scene_root.get_child_count(), before_count, "Undo should remove the player")
 
 
@@ -182,9 +189,9 @@ func test_animation_create_is_undoable() -> void:
 
 	_handler.create_animation({"player_path": player_path, "name": "fade", "length": 0.3})
 	assert_true(player.has_animation("fade"), "Animation should exist after create")
-	_undo_redo.undo()
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 	assert_true(not player.has_animation("fade"), "Undo should remove animation")
-	_undo_redo.redo()
+	assert_true(editor_redo(_undo_redo), "redo should succeed")
 	assert_true(player.has_animation("fade"), "Redo should restore animation")
 	_remove_node(player_path)
 
@@ -258,7 +265,7 @@ func test_add_property_track_is_undoable() -> void:
 		"keyframes": [{"time": 0.0, "value": true}, {"time": 1.0, "value": false}],
 	})
 	assert_eq(anim.get_track_count(), 1)
-	_undo_redo.undo()
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 	assert_eq(anim.get_track_count(), 0, "Undo should remove the track")
 	_remove_node(player_path)
 
@@ -314,12 +321,12 @@ func test_add_property_track_undo_survives_interleaving() -> void:
 	assert_eq(anim.get_track_count(), 2, "After track B")
 
 	# Undo B — should remove scale, leaving position.
-	_undo_redo.undo()
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 	assert_eq(anim.get_track_count(), 1, "Undo B leaves one track")
 	assert_eq(anim.track_get_path(0), NodePath(".:position"), "Remaining track is position, not scale")
 
 	# Undo A — should remove position.
-	_undo_redo.undo()
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 	assert_eq(anim.get_track_count(), 0, "Undo A leaves no tracks")
 
 	_remove_node(player_path)
@@ -843,9 +850,9 @@ func test_create_simple_is_undoable() -> void:
 		],
 	})
 	assert_true(player.has_animation("pulse"))
-	_undo_redo.undo()
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 	assert_true(not player.has_animation("pulse"), "Undo should remove the composed animation")
-	_undo_redo.redo()
+	assert_true(editor_redo(_undo_redo), "redo should succeed")
 	assert_true(player.has_animation("pulse"), "Redo should restore the composed animation")
 	_remove_node(player_path)
 
@@ -905,13 +912,13 @@ func test_create_animation_auto_attaches_default_library() -> void:
 	assert_true(player.has_animation("idle"))
 
 	# Undo should remove both the animation AND the library.
-	_undo_redo.undo()
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 	assert_true(not player.has_animation("idle"))
 	assert_true(not player.has_animation_library(""),
 		"undo should also remove the auto-created library")
 
 	# Redo should restore both.
-	_undo_redo.redo()
+	assert_true(editor_redo(_undo_redo), "redo should succeed")
 	assert_true(player.has_animation_library(""))
 	assert_true(player.has_animation("idle"))
 
@@ -939,7 +946,7 @@ func test_create_simple_auto_attaches_default_library() -> void:
 	assert_true(result.data.library_created)
 	assert_true(player.has_animation("slide"))
 
-	_undo_redo.undo()
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 	assert_true(not player.has_animation_library(""))
 	_remove_node(path)
 
@@ -978,7 +985,7 @@ func test_create_simple_auto_creates_animation_player() -> void:
 	assert_true((created as AnimationPlayer).has_animation("bob"))
 
 	# Single Ctrl-Z rolls back everything.
-	_undo_redo.undo()
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 	assert_true(McpScenePath.resolve(player_path, scene_root) == null,
 		"undo should remove the auto-created AnimationPlayer from the scene")
 
@@ -1086,12 +1093,12 @@ func test_create_animation_auto_create_is_undoable() -> void:
 	assert_eq(result.data.animation_player_created, true)
 
 	# Undo: player AND animation should both vanish in one action.
-	_undo_redo.undo()
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 	assert_true(McpScenePath.resolve(player_path, scene_root) == null,
 		"undo should remove the auto-created player")
 
 	# Redo: player and animation come back.
-	_undo_redo.redo()
+	assert_true(editor_redo(_undo_redo), "redo should succeed")
 	var player := McpScenePath.resolve(player_path, scene_root) as AnimationPlayer
 	assert_true(player != null, "redo should restore the player")
 	assert_true(player.has_animation("idle"), "redo should restore the animation")
@@ -1343,7 +1350,7 @@ func test_delete_animation_basic() -> void:
 		assert_true(anim.name != "to_delete", "Deleted anim should not appear")
 
 	# Undo should restore it.
-	_undo_redo.undo()
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 	var list_after := _handler.list_animations({"player_path": player_path})
 	var found := false
 	for anim in list_after.data.animations:
@@ -1380,7 +1387,7 @@ func test_delete_animation_in_non_default_library() -> void:
 	assert_false(player.has_animation("moves/idle"), "Animation removed from non-default library")
 
 	# Undo restores it.
-	_undo_redo.undo()
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 	assert_true(player.has_animation("moves/idle"), "Undo restored library-qualified animation")
 
 	_remove_node(player_path)

--- a/test_project/tests/test_camera.gd
+++ b/test_project/tests/test_camera.gd
@@ -463,7 +463,7 @@ func test_follow_2d_undo_restores_parent() -> void:
 	})
 	assert_eq(cam.get_parent(), target)
 
-	_undo_redo.undo()
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 	assert_eq(cam.get_parent(), original_parent, "Undo should restore original parent")
 	# Refresh the _created_paths entry since the path changed after reparent/undo.
 	_created_paths = [McpScenePath.from_node(cam, scene_root)]

--- a/test_project/tests/test_control_draw_recipe.gd
+++ b/test_project/tests/test_control_draw_recipe.gd
@@ -242,11 +242,11 @@ func test_undo_reverts_clean_node() -> void:
 	assert_true(node.has_meta("_ops"))
 	assert_true(node.get_script() == DRAW_RECIPE_SCRIPT)
 
-	_undo_redo.undo()
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 	assert_false(node.has_meta("_ops"), "undo should remove _ops meta")
 	assert_true(node.get_script() == null, "undo should remove the script")
 
-	_undo_redo.redo()
+	assert_true(editor_redo(_undo_redo), "redo should succeed")
 	assert_true(node.has_meta("_ops"), "redo re-applies meta")
 	assert_true(node.get_script() == DRAW_RECIPE_SCRIPT, "redo re-attaches script")
 	_remove_control(path)
@@ -271,7 +271,7 @@ func test_undo_preserves_prior_meta() -> void:
 	var after_b: Array = node.get_meta("_ops")
 	assert_eq(after_b[0].radius, 2.0)
 
-	_undo_redo.undo()
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 	var restored: Array = node.get_meta("_ops")
 	assert_eq(restored[0].radius, 1.0, "undo should restore prior _ops meta")
 	assert_true(node.get_script() == DRAW_RECIPE_SCRIPT, "script still attached")

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -131,7 +131,7 @@ func test_create_node_basic() -> void:
 	assert_eq(result.data.type, "Node3D")
 	assert_true(result.data.undoable, "Create should be undoable")
 	## Clean up via undo (reverses the create action)
-	_undo_redo.undo()
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 
 
 func test_create_node_invalid_type() -> void:
@@ -159,7 +159,7 @@ func test_create_node_accepts_root_alias_for_parent_path() -> void:
 	})
 	assert_has_key(result, "data")
 	assert_eq(result.data.parent_path, "/Main", "should resolve to scene root")
-	_undo_redo.undo()
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 
 
 func test_create_node_parent_not_found_error_names_convention() -> void:
@@ -309,7 +309,7 @@ func test_set_property_float() -> void:
 	assert_eq(result.data.property, "fov")
 	assert_true(result.data.undoable, "Set property should be undoable")
 	## Restore via undo
-	_undo_redo.undo()
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 
 
 func test_set_property_missing_property() -> void:
@@ -336,8 +336,8 @@ func test_set_property_vector3_accepts_valid_dict() -> void:
 	assert_true(result.data.undoable)
 	var node := EditorInterface.get_edited_scene_root().get_node("_McpTestV3") as Node3D
 	assert_eq(node.position, Vector3(1, 2, 3))
-	_undo_redo.undo()  # undo set
-	_undo_redo.undo()  # undo create
+	assert_true(editor_undo(_undo_redo), "undo set should succeed")
+	assert_true(editor_undo(_undo_redo), "undo create should succeed")
 
 
 func test_set_property_vector3_rejects_color_shaped_dict() -> void:
@@ -358,7 +358,7 @@ func test_set_property_vector3_rejects_color_shaped_dict() -> void:
 	assert_contains(result.error.message, "Vector3")
 
 	assert_eq(node.position, original, "Position must be unchanged after a rejected coerce")
-	_undo_redo.undo()  # undo create
+	assert_true(editor_undo(_undo_redo), "undo create should succeed")
 
 
 func test_set_property_vector3_rejects_partial_dict() -> void:
@@ -372,7 +372,7 @@ func test_set_property_vector3_rejects_partial_dict() -> void:
 		"value": {"x": 1},  # missing y, z
 	})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
-	_undo_redo.undo()  # undo create
+	assert_true(editor_undo(_undo_redo), "undo create should succeed")
 
 
 func test_set_property_color_rejects_vector3_shaped_dict() -> void:
@@ -405,7 +405,7 @@ func test_set_property_vector3_rejects_array_input() -> void:
 	## Read back the stored Variant — the silent-zero failure mode would
 	## leave the node at (0,0,0) even though the response said "error".
 	assert_eq(node.position, original, "Position must be unchanged after rejected array coerce")
-	_undo_redo.undo()  # undo create
+	assert_true(editor_undo(_undo_redo), "undo create should succeed")
 
 
 func test_set_property_vector3_rejects_json_string_input() -> void:
@@ -423,7 +423,7 @@ func test_set_property_vector3_rejects_json_string_input() -> void:
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 	assert_contains(result.error.message, "Vector3")
 	assert_eq(node.position, original, "Position must be unchanged after rejected string coerce")
-	_undo_redo.undo()  # undo create
+	assert_true(editor_undo(_undo_redo), "undo create should succeed")
 
 
 func test_set_property_vector2_rejects_array_input() -> void:
@@ -440,7 +440,7 @@ func test_set_property_vector2_rejects_array_input() -> void:
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 	assert_contains(result.error.message, "Vector2")
 	assert_eq(node.position, original, "Position must be unchanged after rejected array coerce")
-	_undo_redo.undo()  # undo create
+	assert_true(editor_undo(_undo_redo), "undo create should succeed")
 
 
 func test_set_property_color_rejects_array_input() -> void:
@@ -457,7 +457,7 @@ func test_set_property_color_rejects_array_input() -> void:
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 	assert_contains(result.error.message, "Color")
 	assert_eq(node.modulate, original, "Modulate must be unchanged after rejected array coerce")
-	_undo_redo.undo()  # undo create
+	assert_true(editor_undo(_undo_redo), "undo create should succeed")
 
 
 func test_check_coerced_array_vector3_returns_invalid_params() -> void:
@@ -519,8 +519,8 @@ func test_set_property_resource_path() -> void:
 	assert_has_key(result, "data")
 	assert_eq(result.data.value, TEST_MATERIAL_PATH)
 	assert_true(result.data.undoable)
-	_undo_redo.undo()  # undo assign
-	_undo_redo.undo()  # undo create
+	assert_true(editor_undo(_undo_redo), "undo assign should succeed")
+	assert_true(editor_undo(_undo_redo), "undo create should succeed")
 
 
 func test_set_property_resource_not_found() -> void:
@@ -550,9 +550,9 @@ func test_set_property_resource_null_clears() -> void:
 	})
 	assert_has_key(result, "data")
 	assert_eq(result.data.value, null)
-	_undo_redo.undo()
-	_undo_redo.undo()
-	_undo_redo.undo()
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 
 
 func test_set_property_node_path() -> void:
@@ -568,8 +568,8 @@ func test_set_property_node_path() -> void:
 	})
 	assert_has_key(result, "data")
 	assert_eq(result.data.value, "../Camera3D")
-	_undo_redo.undo()
-	_undo_redo.undo()
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 
 
 func test_set_property_nonexistent_property() -> void:
@@ -947,8 +947,8 @@ func test_rename_node_basic() -> void:
 	assert_eq(result.data.name, target_name)
 	assert_eq(result.data.old_name, created_name)
 	assert_true(result.data.undoable)
-	_undo_redo.undo()
-	_undo_redo.undo()
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 
 
 func test_rename_node_scene_root_rejected() -> void:
@@ -1027,7 +1027,7 @@ func test_duplicate_node_basic() -> void:
 	assert_eq(result.data.type, "Camera3D")
 	assert_true(result.data.undoable)
 	## Clean up via undo
-	_undo_redo.undo()
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 
 
 func test_duplicate_scene_root() -> void:
@@ -1074,7 +1074,7 @@ func test_add_to_group() -> void:
 	assert_eq(result.data.group, "_mcp_test_group")
 	assert_true(result.data.undoable)
 	## Clean up via undo
-	_undo_redo.undo()
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 
 
 func test_add_to_group_missing_group() -> void:
@@ -1139,7 +1139,7 @@ func test_add_to_group_accepts_string_name_value() -> void:
 	assert_has_key(result, "data")
 	assert_eq(result.data.group, "_mcp_test_sn_group")
 	assert_true(result.data.undoable)
-	_undo_redo.undo()
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 
 
 # ----- set_selection -----
@@ -1256,11 +1256,11 @@ func test_create_node_scene_path_undo_redo() -> void:
 	_handler.create_node({"scene_path": tmp_path, "name": "UndoInstance"})
 	assert_eq(scene_root.get_child_count(), before + 1, "Instance added")
 
-	_undo_redo.undo()
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 	assert_eq(scene_root.get_child_count(), before, "Undo removes the instance")
 	assert_true(scene_root.find_child("UndoInstance", false, false) == null, "No node after undo")
 
-	_undo_redo.redo()
+	assert_true(editor_redo(_undo_redo), "redo should succeed")
 	assert_eq(scene_root.get_child_count(), before + 1, "Redo restores the instance")
 	var restored: Node = scene_root.find_child("UndoInstance", false, false)
 	assert_true(restored != null, "Instance back after redo")
@@ -1330,6 +1330,6 @@ func test_create_node_scene_file_matching_active_scene_passes() -> void:
 	})
 	assert_has_key(result, "data")
 	## Undo so we don't leak test state into downstream tests.
-	_undo_redo.undo()
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 
 

--- a/test_project/tests/test_script.gd
+++ b/test_project/tests/test_script.gd
@@ -266,8 +266,8 @@ func test_attach_script_basic() -> void:
 	assert_true(result.data.undoable)
 
 	# Clean up: undo attach then undo create
-	_undo_redo.undo()
-	_undo_redo.undo()
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 
 
 func test_attach_script_missing_path() -> void:
@@ -309,7 +309,7 @@ func test_detach_script_no_script() -> void:
 	assert_false(result.data.had_script)
 
 	# Clean up
-	_undo_redo.undo()
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 
 
 func test_detach_script_missing_path() -> void:

--- a/test_project/tests/test_ui.gd
+++ b/test_project/tests/test_ui.gd
@@ -195,7 +195,7 @@ func test_set_anchor_preset_is_undoable() -> void:
 	var before_right := ctl.anchor_right
 	_handler.set_anchor_preset({"path": path, "preset": "full_rect"})
 	assert_eq(ctl.anchor_right, 1.0, "Apply should change anchor_right")
-	_undo_redo.undo()
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 	assert_eq(ctl.anchor_left, before_left, "Undo should restore anchor_left")
 	assert_eq(ctl.anchor_right, before_right, "Undo should restore anchor_right")
 	_remove_control(path)
@@ -329,7 +329,7 @@ func test_set_text_is_undoable() -> void:
 		return
 	_handler.set_text({"path": path, "text": "after"})
 	assert_eq(label.text, "after", "Apply should change text")
-	_undo_redo.undo()
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 	assert_eq(label.text, "before", "Undo should restore prior text")
 	_remove_control(path)
 
@@ -467,7 +467,7 @@ func test_build_layout_is_undoable() -> void:
 	})
 	assert_has_key(result, "data")
 	assert_eq(scene_root.get_child_count(), before_count + 1)
-	_undo_redo.undo()
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
 	assert_eq(scene_root.get_child_count(), before_count, "Undo should remove the whole built tree")
 
 

--- a/tests/unit/test_no_direct_undo_redo_in_gdscript_tests.py
+++ b/tests/unit/test_no_direct_undo_redo_in_gdscript_tests.py
@@ -1,0 +1,156 @@
+"""Lint: GDScript tests must not call ``_undo_redo.undo()`` / ``.redo()`` directly.
+
+Issue #290 — ``EditorUndoRedoManager.undo()`` does not exist in Godot 4.x.
+Calling it logs a ``SCRIPT ERROR: Invalid call. Nonexistent function 'undo' in
+base 'EditorUndoRedoManager'.`` to the editor output and silently returns
+``null`` — the test then asserts on whichever post-undo state happens to match
+the do-state, masking handler regressions in the undo/redo path.
+
+The supported pattern is the helper on ``McpTestSuite``::
+
+    assert_true(editor_undo(_undo_redo), "<reason> undo should succeed")
+
+which walks both the scene history and ``GLOBAL_HISTORY``, calls ``.undo()``
+on the underlying ``UndoRedo``, and returns whether anything was actually
+undone (so a no-op surfaces as a real test failure).
+
+This lint runs at ``pytest`` time so the bad pattern can't sneak back in via a
+new test file. The structural sweep that fixed the existing 52 sites lives in
+the same PR (#290).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GDSCRIPT_TESTS = REPO_ROOT / "test_project" / "tests"
+
+# ``_undo_redo.undo()`` or ``_undo_redo.redo()`` as a real call — not bare
+# ``_undo_redo.undo`` (a method reference) and not the same identifier appearing
+# inside a comment or a string. The check below strips those out before the
+# regex runs.
+_BAD_CALL = re.compile(r"\b_undo_redo\s*\.\s*(?:undo|redo)\s*\(")
+
+
+def _strip_comments_and_strings(text: str) -> str:
+    """Return ``text`` with line comments and string literals blanked out.
+
+    GDScript line comments start at ``#`` and run to end-of-line. Strings come
+    in single-line ``"..."`` / ``'...'`` form (with backslash escaping) and in
+    triple-quoted form (single or double quote, repeated three times).
+    Replacing them with same-length whitespace preserves line and column
+    numbers so reported locations stay accurate.
+    """
+    out: list[str] = []
+    n = len(text)
+    i = 0
+    while i < n:
+        ch = text[i]
+        if ch == "#":
+            j = text.find("\n", i)
+            if j == -1:
+                j = n
+            out.append(" " * (j - i))
+            i = j
+            continue
+        if ch in ('"', "'"):
+            triple = text[i : i + 3]
+            if triple == ch * 3:
+                end = text.find(ch * 3, i + 3)
+                end = (end + 3) if end != -1 else n
+            else:
+                j = i + 1
+                while j < n:
+                    c = text[j]
+                    if c == "\\":
+                        j += 2
+                        continue
+                    if c == ch or c == "\n":
+                        j += 1
+                        break
+                    j += 1
+                end = j
+            # Preserve any embedded newlines so line numbers match.
+            span = text[i:end]
+            out.append("".join(c if c == "\n" else " " for c in span))
+            i = end
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def _find_offenders(text: str) -> list[tuple[int, int, str]]:
+    """Return ``(line, col, snippet)`` for each direct undo/redo call site."""
+    stripped = _strip_comments_and_strings(text)
+    hits: list[tuple[int, int, str]] = []
+    for m in _BAD_CALL.finditer(stripped):
+        pos = m.start()
+        line = text.count("\n", 0, pos) + 1
+        col = pos - (text.rfind("\n", 0, pos) + 1) + 1
+        # Use the original text for the snippet so the user sees what they wrote.
+        line_start = text.rfind("\n", 0, pos) + 1
+        line_end = text.find("\n", pos)
+        if line_end == -1:
+            line_end = len(text)
+        hits.append((line, col, text[line_start:line_end].rstrip()))
+    return hits
+
+
+def test_no_direct_undo_redo_calls_in_gdscript_tests() -> None:
+    """No ``test_*.gd`` file may call ``_undo_redo.undo()`` / ``.redo()`` directly."""
+    offenders: list[str] = []
+    assert GDSCRIPT_TESTS.exists(), f"Test root does not exist: {GDSCRIPT_TESTS}"
+    for path in sorted(GDSCRIPT_TESTS.rglob("*.gd")):
+        text = path.read_text(encoding="utf-8")
+        for line, col, snippet in _find_offenders(text):
+            rel = path.relative_to(REPO_ROOT)
+            offenders.append(f"{rel}:{line}:{col}  {snippet}")
+
+    assert not offenders, (
+        "EditorUndoRedoManager.undo()/redo() do not exist in Godot 4.x. Use "
+        '`assert_true(editor_undo(_undo_redo), "... should succeed")` (or '
+        "`editor_redo`) from McpTestSuite — see issue #290.\nOffenders:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+# --- detector self-tests: pin the lint's behavior so a refactor cannot quietly
+# weaken it into a no-op (the same trap covered in #246's adjacent-string lint). ---
+
+
+def test_detector_flags_canonical_bad_call() -> None:
+    src = "func test_x():\n\t_undo_redo.undo()\n"
+    assert [h[0] for h in _find_offenders(src)] == [2]
+
+
+def test_detector_flags_redo_call() -> None:
+    assert _find_offenders("\t_undo_redo.redo()\n") != []
+
+
+def test_detector_ignores_helper_call() -> None:
+    src = '\tassert_true(editor_undo(_undo_redo), "msg")\n'
+    assert _find_offenders(src) == []
+
+
+def test_detector_ignores_method_reference() -> None:
+    """``_undo_redo.undo`` (no parens) is a Callable reference, not a call."""
+    src = "\tvar fn := _undo_redo.undo\n"
+    assert _find_offenders(src) == []
+
+
+def test_detector_ignores_call_inside_comment() -> None:
+    src = "\t## historical: _undo_redo.undo() used to be the cleanup pattern\n"
+    assert _find_offenders(src) == []
+
+
+def test_detector_ignores_call_inside_string_literal() -> None:
+    src = '\tprint("avoid _undo_redo.undo() in tests")\n'
+    assert _find_offenders(src) == []
+
+
+def test_detector_ignores_call_inside_triple_quoted_string() -> None:
+    src = '\tvar doc := """example: _undo_redo.undo() bad"""\n'
+    assert _find_offenders(src) == []


### PR DESCRIPTION
## Summary

Closes #290.

`EditorUndoRedoManager.undo()` / `.redo()` don't exist in Godot 4.x — direct
calls log `SCRIPT ERROR: Invalid call. Nonexistent function 'undo' in base
'EditorUndoRedoManager'.` and abort the test before any post-undo assertion
can fire. The test still counts as a pass (one assertion ran, none failed),
silently masking real regressions in handler undo paths.

This PR fixes 52 such call sites and adds a structural lint to keep the
pattern from coming back. Per-file commits for bisect-friendliness:

1. **Pin animation track-add actions to scene history.** Without an explicit
   context, `add_do_method(self, ...)` against a RefCounted handler lands in
   `GLOBAL_HISTORY` while sibling `create_animation` actions land in scene
   history. The `editor_undo` helper walks scene first, so a track-add
   followed by `editor_undo` would undo the wrong action. New
   `_create_scene_pinned_action()` helper mirrors `camera_handler.gd`'s
   established pattern.
2. **`test_animation.gd`:** migrate 16 sites; rework `_add_player` to add the
   AnimationPlayer directly (matching `_add_mesh_instance` in
   `test_resource.gd`) so fixture setup doesn't push a setup action onto the
   undo stack.
3. **`test_node.gd`:** migrate 26 sites; inline `# undo set` / `# undo create`
   comments fold into the assertion message.
4. **`test_ui` / `test_camera` / `test_control_draw_recipe` / `test_script`:**
   migrate the remaining 10 sites.
5. **Add lint:** new `tests/unit/test_no_direct_undo_redo_in_gdscript_tests.py`
   blanks comments + string literals before regex-matching, so docstring /
   `print()` references don't trip it. Mirrors
   `test_gdscript_no_adjacent_string_concat.py`'s tokenizer-self-test pattern
   so a future refactor can't quietly weaken the lint into a no-op.

After the migration, two animation tests (`test_add_property_track_is_undoable`
and `test_add_property_track_undo_survives_interleaving`) actually run their
post-undo assertions for the first time — going from 1 silent assertion to 3
and 7 real ones. The handler pin is what lets them pass.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `pytest -v` — 707 pass (was 686; +8 new lint self-tests + the migration
      sweep doesn't touch any Python tests)
- [x] Live Godot 4.6.2 (headless with `GODOT_AI_ALLOW_HEADLESS=1`) +
      `script/ci-godot-tests` — **1018/1032 pass, 0 failed**. The two formerly-
      silent tests now run 3 and 7 assertions respectively.
- [x] Live MCP smoke: `animation_player_create` →
      `animation_create(name="fade")` → `animation_add_property_track(track=".:visible",
      keyframes=[{0,true},{0.3,false}])` → `animation_get` confirms the track
      lands with both keyframes typed correctly. Pin doesn't affect the
      user-visible behavior.

## Files

- `plugin/addons/godot_ai/handlers/animation_handler.gd` — pin + helper
  (+16 / -2)
- `test_project/tests/test_animation.gd` — 16 migrations + `_add_player` direct
  add (+27 / -20)
- `test_project/tests/test_node.gd` — 26 migrations (+26 / -26)
- `test_project/tests/test_ui.gd` — 3 migrations
- `test_project/tests/test_control_draw_recipe.gd` — 3 migrations
- `test_project/tests/test_script.gd` — 3 migrations
- `test_project/tests/test_camera.gd` — 1 migration
- `tests/unit/test_no_direct_undo_redo_in_gdscript_tests.py` — new lint with
  8 detector self-tests (+156)

https://claude.ai/code/session_01JipA3yvdbjL78d4j7h48cW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JipA3yvdbjL78d4j7h48cW)_