### PR TITLE
Fix manual-orphan-test scenarios 3/5 dev-mode bypass; drop scenario 4 (closes #279)

### DIFF
--- a/script/manual-orphan-test
+++ b/script/manual-orphan-test
@@ -543,9 +543,11 @@ PY
 
 print_instructions() {
     local orphan_pp status_pp orphan_pwsh_pp status_pwsh_pp posix_orphan_pp posix_status_pp
-    local posix_project posix_repo repo_win project_win
+    local posix_project posix_repo repo_win project_win plugin_version
     orphan_pp="$(pythonpath_for_shell "$ORPHAN_ROOT")"
     status_pp="$(pythonpath_for_shell "$STATUS_ROOT")"
+    plugin_version="$(sed -n 's/^version="\([^"]*\)"/\1/p' "$repo_root/plugin/addons/godot_ai/plugin.cfg" | head -n 1)"
+    plugin_version="${plugin_version:-unknown}"
     if is_windows_bash; then
         orphan_pwsh_pp="$(to_windows_path "$ORPHAN_ROOT")"
         status_pwsh_pp="$(to_windows_path "$STATUS_ROOT")"
@@ -684,27 +686,44 @@ Launch the editor with console logging:
 
 ## Dev checkout: force user mode for version-mismatch scenarios
 
-Scenarios 3 and 5 deliberately pin the simulator to a version that does NOT
-match the plugin (e.g. v2.1.0 vs the current plugin), and expect the plugin
-to treat the occupant as incompatible. In a dev checkout (a clone next to a
-\`.venv\`) \`McpClientConfigurator.is_dev_checkout()\` returns true, and
+Scenarios 1, 2, 3, and 5 deliberately pin the simulator to a version that
+does NOT match the plugin, and expect the plugin to treat the occupant as
+incompatible. In a dev checkout (a clone next to a \`.venv\`)
+\`McpClientConfigurator.is_dev_checkout()\` returns true, and
 \`_server_version_compatibility\` then returns \`{compatible: true,
 dev_mismatch_allowed: true}\` regardless of version — so the plugin happily
-adopts the simulator and the proof log lines never fire.
+adopts the simulator and the proof log lines never fire. The heuristic
+checks \`.venv/bin/python\` on POSIX and \`.venv/Scripts/python.exe\` on
+Windows (\`client_configurator.gd::_find_venv_python\`), so a Windows
+source checkout is also affected.
 
-Before launching Godot for scenarios 3 and 5 from a dev checkout, force user
+Before launching Godot for these scenarios from a dev checkout, force user
 mode in one of two ways:
 
-- Set the env var on the launch line:
+- Set the env var on the launch line. POSIX:
 
       GODOT_AI_MODE=user "\$GODOT" --editor --path "\$PROJECT" 2>&1 | tee /tmp/mcp-editor.log
+
+  PowerShell (set in the same shell before \`&\`-launching Godot):
+
+      \$env:GODOT_AI_MODE = "user"
+      & "C:\\path\\to\\Godot.exe" --editor --path "$project_win"
 
 - Or open the dock's "Mode override" dropdown (visible when Developer mode
   is on) and pick "Force user".
 
-Scenarios 1, 2, 6, and 7 don't need this — they either run on Windows
-(unaffected by the POSIX-only \`.venv\` heuristic) or already exercise paths
-that bypass the dev-mode bypass.
+The dock dropdown persists as the EditorSetting \`godot_ai/mode_override\`
+and **wins over the env var** — \`mode_override()\` reads the EditorSetting
+first, and only falls back to \`GODOT_AI_MODE\` when the dropdown is
+"Auto"/unset. If you previously left the dropdown on "Force dev" or
+"Force user", the env var on the launch line will silently do nothing.
+Either set the dropdown back to "Auto" via the dock UI before relaunching,
+or close Godot and remove the \`godot_ai/mode_override = "..."\` line from
+\$EDITOR_SETTINGS (POSIX) / editor_settings-4.6.tres (Windows).
+
+Scenarios 6 and 7 don't need user mode forced — scenario 6's occupant is
+not godot-ai (no version is even returned), and scenario 7 deliberately
+exercises the compatible-adoption path so dev-mode is harmless there.
 
 ## Scenario 1: Windows v2.2.0 orphan recovery
 
@@ -748,6 +767,9 @@ Use PowerShell. This tests the legacy-pidfile proof tier that motivated the PR.
 
     Get-NetTCPConnection -LocalPort 8000
     Get-CimInstance Win32_Process -Filter ("ProcessId=" + \$sim.Id) | Select ProcessId,CommandLine
+    # Dev checkout: force user mode (see "Dev checkout" section above).
+    # Skip the next line on a non-dev install.
+    \$env:GODOT_AI_MODE = "user"
     & "C:\\path\\to\\Godot.exe" --editor --path "$project_win"
 
 Pass criteria:
@@ -901,10 +923,14 @@ Windows simulator equivalent for a compatible external current server:
     \$psi.FileName = \$python
     \$psi.UseShellExecute = \$false
     \$psi.Environment["PYTHONPATH"] = "$status_pwsh_pp"
-    foreach (\$arg in @("-m","http_status_only","--port","8000","--ws-port","9500","--fake-version","2.2.3")) {
+    foreach (\$arg in @("-m","http_status_only","--port","8000","--ws-port","9500","--fake-version","$plugin_version")) {
       [void]\$psi.ArgumentList.Add(\$arg)
     }
     \$server = [System.Diagnostics.Process]::Start(\$psi)
+
+The \`--fake-version\` value is read from \`plugin/addons/godot_ai/plugin.cfg\`
+on each \`script/manual-orphan-test instructions\` run so this scenario
+genuinely exercises compatible adoption against the current plugin.
 
 Pass criteria:
 

--- a/script/manual-orphan-test
+++ b/script/manual-orphan-test
@@ -138,7 +138,6 @@ write_orphan_sim() {
 import argparse
 import json
 import os
-import signal
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 ap = argparse.ArgumentParser()
@@ -156,23 +155,12 @@ ap.add_argument(
     default="godot-ai",
     help="name in /godot-ai/status; 'none' drops the endpoint",
 )
-ap.add_argument(
-    "--ignore-sigterm",
-    action="store_true",
-    help="trap SIGTERM so kill -15 fails (failed-kill scenario)",
-)
 args = ap.parse_args()
 
 if args.pid_file and args.pid_file.lower() != "none":
     os.makedirs(os.path.dirname(args.pid_file), exist_ok=True)
     with open(args.pid_file, "w", encoding="utf-8") as f:
         f.write(str(os.getpid()))
-
-if args.ignore_sigterm:
-    signal.signal(
-        signal.SIGTERM,
-        lambda *a: print("simulator: ignoring SIGTERM", flush=True),
-    )
 
 
 class H(BaseHTTPRequestHandler):
@@ -694,6 +682,30 @@ Launch the editor with console logging:
     "\$GODOT" --editor --path "\$PROJECT" 2>&1 | tee /tmp/mcp-editor.log
     tail -f /tmp/mcp-editor.log | grep -E 'MCP \\||godot[_-]ai'
 
+## Dev checkout: force user mode for version-mismatch scenarios
+
+Scenarios 3 and 5 deliberately pin the simulator to a version that does NOT
+match the plugin (e.g. v2.1.0 vs the current plugin), and expect the plugin
+to treat the occupant as incompatible. In a dev checkout (a clone next to a
+\`.venv\`) \`McpClientConfigurator.is_dev_checkout()\` returns true, and
+\`_server_version_compatibility\` then returns \`{compatible: true,
+dev_mismatch_allowed: true}\` regardless of version — so the plugin happily
+adopts the simulator and the proof log lines never fire.
+
+Before launching Godot for scenarios 3 and 5 from a dev checkout, force user
+mode in one of two ways:
+
+- Set the env var on the launch line:
+
+      GODOT_AI_MODE=user "\$GODOT" --editor --path "\$PROJECT" 2>&1 | tee /tmp/mcp-editor.log
+
+- Or open the dock's "Mode override" dropdown (visible when Developer mode
+  is on) and pick "Force user".
+
+Scenarios 1, 2, 6, and 7 don't need this — they either run on Windows
+(unaffected by the POSIX-only \`.venv\` heuristic) or already exercise paths
+that bypass the dev-mode bypass.
+
 ## Scenario 1: Windows v2.2.0 orphan recovery
 
 Use PowerShell. This tests the legacy-pidfile proof tier that motivated the PR.
@@ -786,9 +798,9 @@ Close Godot and add or replace these lines in \$EDITOR_SETTINGS:
     godot_ai/managed_server_version = "2.1.0"
     godot_ai/managed_server_ws_port = 9500
 
-Then launch:
+Then launch (dev checkout: force user mode — see "Dev checkout" section above):
 
-    "\$GODOT" --editor --path "\$PROJECT" 2>&1 | tee /tmp/mcp-editor.log
+    GODOT_AI_MODE=user "\$GODOT" --editor --path "\$PROJECT" 2>&1 | tee /tmp/mcp-editor.log
 
 Pass criteria:
 
@@ -797,46 +809,39 @@ Pass criteria:
 - Port 8000 now has a different PID.
 - Dock is green with no Restart button.
 
-## Scenario 4: Failed-kill preservation (POSIX only)
+## Failed-kill preservation: covered by GDScript tests, not the manual matrix
 
-Use Linux/macOS for this scenario unless you add a Windows-specific way to make
-taskkill fail. The simulator's --ignore-sigterm only exercises the POSIX
-OS.kill/SIGTERM path.
+The "kill returns success but the port stays held, so the plugin must preserve
+the managed record and refuse to spawn a replacement" invariant used to live
+here as scenario 4 with a \`--ignore-sigterm\` simulator. That scenario could
+not actually exercise the path on POSIX: Godot's \`OS.kill(pid)\` on POSIX
+sends SIGKILL (\`drivers/unix/os_unix.cpp\`), and a SIGTERM trap is irrelevant
+against SIGKILL — the kill always succeeded and the matrix was lying to
+operators.
 
-Use the same managed record as scenario 3, but start the simulator with
---ignore-sigterm:
-
-    PYTHONPATH="$posix_orphan_pp" python3 -m godot_ai \\
-      --transport streamable-http --port 8000 --ws-port 9500 \\
-      --pid-file "\$PIDFILE" --fake-version 2.1.0 \\
-      --ignore-sigterm &
-    SIM_PID=\$!
-
-Pass criteria:
-
-- Console shows kill failure or "port 8000 still in use".
-- Dock shows the incompatible-server banner.
-- "\$PIDFILE" still contains \$SIM_PID.
-- The managed-server settings still show the old version.
-- No new server spawned; port 8000 is still held by \$SIM_PID.
-
-Cleanup:
-
-    kill -KILL \$SIM_PID
+The invariant is fully covered by
+\`test_project/tests/test_plugin_lifecycle.gd::test_drift_kill_preserves_record_and_does_not_spawn_when_port_stays_held\`,
+which drives the same \`_recover_strong_port_occupant\` branch via in-process
+plugin stubs.
 
 ## Scenario 5: Status-name-only occupant safety
 
 This proves auto-kill is not triggered when the only evidence is a status
-endpoint returning name=godot-ai.
+endpoint returning name=godot-ai. Use a deliberately-mismatched
+\`--fake-version\` so a dev checkout in user mode treats the occupant as
+incompatible (matching versions would be a compatible-adoption test, see
+scenario 7).
 
     rm -f "\$PIDFILE"
     # Close Godot, then remove godot_ai/managed_server_* from \$EDITOR_SETTINGS.
 
-    PYTHONPATH="$posix_status_pp" python3 -m http_status_only &
+    PYTHONPATH="$posix_status_pp" python3 -m http_status_only --fake-version 2.1.0 &
     SIM_PID=\$!
     ps -ww -p \$SIM_PID -o args=
 
-    "\$GODOT" --editor --path "\$PROJECT" 2>&1 | tee /tmp/mcp-editor.log
+Then launch (dev checkout: force user mode — see "Dev checkout" section above):
+
+    GODOT_AI_MODE=user "\$GODOT" --editor --path "\$PROJECT" 2>&1 | tee /tmp/mcp-editor.log
 
 Initial pass criteria:
 
@@ -911,8 +916,8 @@ Pass criteria:
 
 ## Recommended order
 
-Run 6 and 5 first to prove unrelated processes are not killed. Then run 3, 1,
-4, and finally 2 and 7 as sanity sweeps.
+Run 6 and 5 first to prove unrelated processes are not killed. Then run 3 and
+1, and finally 2 and 7 as sanity sweeps.
 
 If a scenario fails, capture:
 


### PR DESCRIPTION
## Summary

Bundle of two test-harness fixes from #279, both in `script/manual-orphan-test`:

- **Finding 1 — scenarios 3/5 silently assumed user mode on POSIX dev checkouts.** With `.venv` adjacent, `McpClientConfigurator.is_dev_checkout()` is true and `_server_version_compatibility` returns `{compatible: true, dev_mismatch_allowed: true}` for any fake-version, so the plugin adopted the simulator instead of treating it as incompatible. The `MCP | strong proof: managed_record` / `MCP | proof: status_name` log lines (and scenario 5's yellow-Restart UX) never fired. Add a new "Dev checkout: force user mode for version-mismatch scenarios" callout, inline `GODOT_AI_MODE=user` on the scenario 3 and 5 launch commands, and pin scenario 5's status-only sim to `--fake-version 2.1.0` so it's a deliberate mismatch decoupled from "current plugin happens to be 2.x.y".

- **Finding 2 — scenario 4 couldn't trigger the failed-kill preservation path on POSIX.** Godot's `OS.kill(pid)` uses SIGKILL on POSIX (`drivers/unix/os_unix.cpp::OS_Unix::kill`), so the simulator's `--ignore-sigterm` SIGTERM trap was irrelevant — the kill always succeeded and the matrix was lying to operators. Drop the scenario; the invariant is fully covered by `test_drift_kill_preserves_record_and_does_not_spawn_when_port_stays_held` in `test_project/tests/test_plugin_lifecycle.gd`, which drives the same `_recover_strong_port_occupant` branch via in-process stubs. Also retire the now-dead `--ignore-sigterm` argparse arg, signal handler, and `signal` import from the orphan sim heredoc.

Net change: `script/manual-orphan-test` only, +48/−43 lines.

## Test plan

- [x] `bash -n script/manual-orphan-test` — syntax clean
- [x] `script/manual-orphan-test instructions` — renders correctly with new "Dev checkout" section, fixed scenarios 3 + 5, scenario 4 replaced by GDScript-test pointer, "Recommended order" updated
- [x] `script/manual-orphan-test setup` — regenerates orphan sim with no `signal` import / no `--ignore-sigterm` flag
- [x] Smoke-launched the regenerated orphan sim (`PYTHONPATH=/tmp/orphan-sim python -m godot_ai --fake-version 2.1.0 …`): status endpoint serves correctly, pidfile written, no crashes
- [x] Smoke-launched the status-only sim with `--fake-version 2.1.0` (scenario 5's new flag): `{"name": "godot-ai", "version": "2.1.0", "ws_port": 9500}`
- [x] `ruff check src/ tests/` — all checks passed
- [x] `pytest -q` — 719 passed
- [x] `script/ci-check-gdscript` — all GDScript files OK
- [x] Live Godot editor (xvfb) + MCP `test_run` — 1029/1032 passed, 0 failed
- [x] Live MCP `editor_state` against the running editor — `readiness=ready`

Closes #279.

https://claude.ai/code/session_011DDzmPFRjpjAuxh7oiw3TP

---
_Generated by [Claude Code](https://claude.ai/code/session_011DDzmPFRjpjAuxh7oiw3TP)_