### PR TITLE
Guard McpScenePath.from_node against foreign nodes (#297, PR 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: CI
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [main, beta]
   pull_request:
-    branches: [main]
+    branches: [main, beta]
 
 jobs:
   python-tests:

--- a/plugin/addons/godot_ai/utils/scene_path.gd
+++ b/plugin/addons/godot_ai/utils/scene_path.gd
@@ -7,11 +7,20 @@ extends RefCounted
 
 
 ## Return a clean path relative to the scene root (e.g. /Main/Camera3D).
+##
+## Returns "" when `node` is not the scene root and not a descendant of it.
+## Without the ancestry guard, `scene_root.get_path_to(foreign)` returns an
+## empty NodePath (with a Godot warning), which then concatenates into a
+## plausible-looking but invalid string like "/Main/" — every consumer trusts
+## the path and the failure surfaces as a confusing downstream error rather
+## than an "unknown node" signal.
 static func from_node(node: Node, scene_root: Node) -> String:
 	if scene_root == null or node == null:
 		return ""
 	if node == scene_root:
 		return "/" + scene_root.name
+	if not scene_root.is_ancestor_of(node):
+		return ""
 	var relative := scene_root.get_path_to(node)
 	return "/" + scene_root.name + "/" + str(relative)
 

--- a/plugin/addons/godot_ai/utils/scene_path.gd
+++ b/plugin/addons/godot_ai/utils/scene_path.gd
@@ -7,13 +7,9 @@ extends RefCounted
 
 
 ## Return a clean path relative to the scene root (e.g. /Main/Camera3D).
-##
-## Returns "" when `node` is not the scene root and not a descendant of it.
-## Without the ancestry guard, `scene_root.get_path_to(foreign)` returns an
-## empty NodePath (with a Godot warning), which then concatenates into a
-## plausible-looking but invalid string like "/Main/" — every consumer trusts
-## the path and the failure surfaces as a confusing downstream error rather
-## than an "unknown node" signal.
+## Returns "" when `node` is not the scene root or a descendant of it —
+## without the ancestry guard, get_path_to() returns an empty NodePath that
+## concatenates into a plausible-looking but invalid "/Main/".
 static func from_node(node: Node, scene_root: Node) -> String:
 	if scene_root == null or node == null:
 		return ""

--- a/test_project/tests/test_scene_path.gd
+++ b/test_project/tests/test_scene_path.gd
@@ -63,10 +63,6 @@ func test_from_node_null_scene_root_returns_empty_string() -> void:
 
 
 func test_from_node_orphan_node_returns_empty_string() -> void:
-	## A node not parented anywhere is not an ancestor of scene_root. Without
-	## the is_ancestor_of guard, get_path_to() returns an empty NodePath and
-	## from_node would produce "/Main/" — a plausible-looking string that
-	## resolves to nothing. Issue #297 audit finding #4.
 	var root := _make_tree()
 	var orphan := Node.new()
 	orphan.name = "Orphan"
@@ -76,9 +72,6 @@ func test_from_node_orphan_node_returns_empty_string() -> void:
 
 
 func test_from_node_foreign_tree_returns_empty_string() -> void:
-	## Node lives in a sibling tree to scene_root. Same hazard as the orphan
-	## case but more representative of the real-world bug: handlers passing
-	## nodes from instanced sub-scenes or foreign trees.
 	var root := _make_tree()
 	var other_root := Node.new()
 	other_root.name = "OtherRoot"
@@ -91,8 +84,6 @@ func test_from_node_foreign_tree_returns_empty_string() -> void:
 
 
 func test_from_node_ancestor_of_scene_root_returns_empty_string() -> void:
-	## scene_root's parent is not a descendant of scene_root. is_ancestor_of
-	## must reject upward lookups too, not just sideways/foreign ones.
 	var root := _make_tree()
 	var parent := Node.new()
 	parent.name = "Parent"

--- a/test_project/tests/test_scene_path.gd
+++ b/test_project/tests/test_scene_path.gd
@@ -28,6 +28,79 @@ func _make_tree() -> Node:
 	return main
 
 
+# ----- from_node: clean path formatting -----
+
+func test_from_node_scene_root_returns_root_prefix() -> void:
+	var root := _make_tree()
+	assert_eq(McpScenePath.from_node(root, root), "/Main")
+	root.queue_free()
+
+
+func test_from_node_direct_child_returns_root_prefixed_path() -> void:
+	var root := _make_tree()
+	var cam := root.get_node("Camera3D")
+	assert_eq(McpScenePath.from_node(cam, root), "/Main/Camera3D")
+	root.queue_free()
+
+
+func test_from_node_nested_descendant_returns_full_path() -> void:
+	var root := _make_tree()
+	var ground := root.get_node("World/Ground")
+	assert_eq(McpScenePath.from_node(ground, root), "/Main/World/Ground")
+	root.queue_free()
+
+
+func test_from_node_null_node_returns_empty_string() -> void:
+	var root := _make_tree()
+	assert_eq(McpScenePath.from_node(null, root), "")
+	root.queue_free()
+
+
+func test_from_node_null_scene_root_returns_empty_string() -> void:
+	var n := Node.new()
+	assert_eq(McpScenePath.from_node(n, null), "")
+	n.free()
+
+
+func test_from_node_orphan_node_returns_empty_string() -> void:
+	## A node not parented anywhere is not an ancestor of scene_root. Without
+	## the is_ancestor_of guard, get_path_to() returns an empty NodePath and
+	## from_node would produce "/Main/" — a plausible-looking string that
+	## resolves to nothing. Issue #297 audit finding #4.
+	var root := _make_tree()
+	var orphan := Node.new()
+	orphan.name = "Orphan"
+	assert_eq(McpScenePath.from_node(orphan, root), "")
+	orphan.free()
+	root.queue_free()
+
+
+func test_from_node_foreign_tree_returns_empty_string() -> void:
+	## Node lives in a sibling tree to scene_root. Same hazard as the orphan
+	## case but more representative of the real-world bug: handlers passing
+	## nodes from instanced sub-scenes or foreign trees.
+	var root := _make_tree()
+	var other_root := Node.new()
+	other_root.name = "OtherRoot"
+	var foreign := Node.new()
+	foreign.name = "Foreign"
+	other_root.add_child(foreign)
+	assert_eq(McpScenePath.from_node(foreign, root), "")
+	other_root.queue_free()
+	root.queue_free()
+
+
+func test_from_node_ancestor_of_scene_root_returns_empty_string() -> void:
+	## scene_root's parent is not a descendant of scene_root. is_ancestor_of
+	## must reject upward lookups too, not just sideways/foreign ones.
+	var root := _make_tree()
+	var parent := Node.new()
+	parent.name = "Parent"
+	parent.add_child(root)
+	assert_eq(McpScenePath.from_node(parent, root), "")
+	parent.queue_free()
+
+
 # ----- resolve: existing canonical forms -----
 
 func test_resolve_root_prefix_returns_scene_root() -> void:


### PR DESCRIPTION
Base: `beta`

First implementation PR in the audit roadmap (#297). Addresses finding **#4 / P0** — `McpScenePath.from_node` silently producing wrong paths for foreign nodes.

## Summary

- Add `scene_root.is_ancestor_of(node)` guard in `McpScenePath.from_node` so foreign / orphan / sibling-tree nodes return `""` instead of a plausible-but-broken path like `/Main/`.
- Add 8 regression tests in `test_scene_path.gd` covering: scene root, direct child, nested descendant, null node, null scene_root, orphan node, foreign tree, and ancestor-of-scene-root.

## Why

`scene_root.get_path_to(foreign)` returns an empty `NodePath` (with a Godot warning) when the node isn't a descendant. Concatenating that into `"/" + scene_root.name + "/" + str(relative)` produced `"/Main/"` — a string every consumer trusted, but that resolves to nothing. The failure mode looked like an ordinary downstream tool bug instead of "you handed me a foreign node," so it was very hard to triage.

The fix is a one-line `is_ancestor_of` check; the bulk of the diff is the regression coverage so the bug stays fixed across future refactors of the broader scene-path / handler layer.

## Roadmap status

- PR 0 (create `beta` from `main`) — done before this PR (branch already on origin).
- PR 1 (this PR) — scene path ancestry guard.
- PR 2 (next) — update/config data-loss safeguards (findings #9, #10).

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `pytest -q` — 722 passed
- [x] GDScript `test_run suite=scene_path` against real Godot 4.6.2 editor — **30/30 passed, 0 failed** (8 new `from_node` tests included)
- [x] Full GDScript handler suite (`script/ci-godot-tests`) — 1026/1040 passed, 0 failed (14 environment-skips)
- [ ] Reviewer: in an open editor, call `scene_get_hierarchy` on a scene that contains an instanced sub-scene and confirm child paths still look correct (no regression on the happy path)

https://claude.ai/code/session_01SsicZcqm4Am9owyFkowNRS