### PR TITLE
Add PR4 characterization tests

### DIFF
--- a/test_project/tests/test_connection.gd
+++ b/test_project/tests/test_connection.gd
@@ -264,6 +264,65 @@ func test_pause_processing_property_preserves_nested_pause_semantics() -> void:
 	conn.free()
 
 
+# ----- pause depth across disconnect/reconnect -----
+#
+# Issue #297 PR 4 checklist: "Connection lifecycle round-trip — disconnect
+# -> reconnect -> handshake -> first command, with pause/resume interleaved."
+# `_clear_on_disconnect` is the choke point that runs once per drop. It
+# resets per-server state (server_version, pending deferred responses) but
+# MUST NOT touch `_pause_depth`: pauses are owned by handlers (e.g.
+# ResourceSaver mid-save in `utils/resource_io.gd`, scene save in
+# `scene_handler.gd`). Clearing them on a socket drop would let the next
+# `_process` tick resume polling while the editor is still in a re-entrant
+# save window — the exact hazard #289 fixed.
+
+
+func test_clear_on_disconnect_preserves_pause_depth() -> void:
+	var conn := McpConnection.new()
+	conn.pause()
+	conn.pause()
+	assert_eq(conn.pause_depth(), 2, "precondition: nested pause depth=2")
+
+	conn._clear_on_disconnect()
+
+	assert_eq(
+		conn.pause_depth(), 2,
+		"disconnect must leave handler-held pauses intact",
+	)
+	assert_true(
+		conn.pause_processing,
+		"_process must keep skipping the WebSocket poll while a save still owns the pause",
+	)
+	conn.resume()
+	conn.resume()
+	assert_eq(conn.pause_depth(), 0, "balanced resume drains depth to zero after a disconnect")
+	conn.free()
+
+
+func test_pause_resume_balances_across_repeated_reconnect_cycles() -> void:
+	## Disconnect/reconnect cycles call `_clear_on_disconnect` once per
+	## drop. Multiple cycles plus pause/resume calls interleaved between
+	## them must still balance — depth is the source of truth and only
+	## explicit resumes drain it.
+	var conn := McpConnection.new()
+
+	conn.pause()  # handler A acquires pause before any drop
+	conn._clear_on_disconnect()  # cycle 1: server drops underneath A
+	conn.pause()  # handler B starts mid-disconnect (e.g. queued save)
+	conn._clear_on_disconnect()  # cycle 2: a second drop while B is mid-save
+	assert_eq(
+		conn.pause_depth(), 2,
+		"both handler-held pauses must survive back-to-back drops",
+	)
+
+	conn.resume()  # handler B finishes
+	assert_true(conn.pause_processing, "A's pause still gates polling")
+	conn.resume()  # handler A finishes
+	assert_eq(conn.pause_depth(), 0)
+	assert_false(conn.pause_processing, "polling resumes only after every paired resume")
+	conn.free()
+
+
 # ----- outbound backpressure -----
 
 

--- a/test_project/tests/test_dispatcher.gd
+++ b/test_project/tests/test_dispatcher.gd
@@ -205,3 +205,28 @@ func test_deferred_completion_removes_pending_entry() -> void:
 		d.complete_deferred_response("req-ok"),
 		"late duplicate deferred responses should be rejected",
 	)
+
+
+# ----- deferred response path -----
+
+func test_tick_suppresses_deferred_response_and_threads_request_id() -> void:
+	var d := _make_dispatcher()
+	d.mcp_logging = false
+	var seen := {}
+	d.register("deferred_command", func(p):
+		seen["request_id"] = p.get("_request_id", "")
+		return McpDispatcher.DEFERRED_RESPONSE
+	)
+
+	var params := {"value": 42}
+	d.enqueue({
+		"request_id": "req-deferred-1",
+		"command": "deferred_command",
+		"params": params,
+	})
+
+	var responses := d.tick()
+	assert_eq(responses.size(), 0, "Deferred handlers must not get an immediate auto-response")
+	assert_eq(seen.get("request_id", ""), "req-deferred-1")
+	assert_false(params.has("_request_id"), "Dispatcher internals must not mutate queued params")
+	assert_eq(d.tick().size(), 0, "Deferred command should be drained from the queue")

--- a/test_project/tests/test_project.gd
+++ b/test_project/tests/test_project.gd
@@ -140,6 +140,18 @@ func test_run_project_invalid_mode() -> void:
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 
 
+func test_run_project_invalid_mode_restores_connection_pause() -> void:
+	var conn := McpConnection.new()
+	var handler := ProjectHandler.new(conn)
+	assert_false(conn.pause_processing, "precondition: connection processing starts unpaused")
+
+	var result := handler.run_project({"mode": "invalid_mode"})
+
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_false(conn.pause_processing, "validation errors must not leave processing paused")
+	conn.free()
+
+
 func test_run_project_custom_missing_scene() -> void:
 	var result := _handler.run_project({"mode": "custom"})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)

--- a/test_project/tests/test_update_reload_runner.gd
+++ b/test_project/tests/test_update_reload_runner.gd
@@ -12,6 +12,7 @@ extends McpTestSuite
 ## to re-enable the plugin against.
 
 const UpdateReloadRunner := preload("res://addons/godot_ai/update_reload_runner.gd")
+const PROBE_PREFIX := "__update_runner_probe_"
 
 var _scratch_dir: String
 
@@ -24,9 +25,15 @@ func suite_setup(_ctx: Dictionary) -> void:
 	_scratch_dir = OS.get_user_data_dir().path_join("mcp_update_reload_runner_tests")
 	_clean_scratch_dir()
 	DirAccess.make_dir_recursive_absolute(_scratch_dir)
+	_cleanup_probe_files()
+
+
+func teardown() -> void:
+	_cleanup_probe_files()
 
 
 func suite_teardown() -> void:
+	_cleanup_probe_files()
 	_clean_scratch_dir()
 
 
@@ -69,6 +76,15 @@ func _new_runner():
 	# Runner extends Node; we don't add it to the tree because the rollback
 	# code path doesn't need _process(). free() in teardown.
 	return UpdateReloadRunner.new()
+
+
+func _cleanup_probe_files() -> void:
+	var addon_dir := ProjectSettings.globalize_path("res://addons/godot_ai")
+	if not DirAccess.dir_exists_absolute(addon_dir):
+		return
+	for f in DirAccess.get_files_at(addon_dir):
+		if String(f).begins_with(PROBE_PREFIX):
+			DirAccess.remove_absolute(addon_dir.path_join(f))
 
 
 # ----- _rollback_paths_written -----
@@ -282,6 +298,42 @@ func _stage_release_zip(zip_path: String, files: Dictionary) -> void:
 		assert_eq(packer.write_file(String(files[rel_path]).to_utf8_buffer()), OK)
 		assert_eq(packer.close_file(), OK)
 	assert_eq(packer.close(), OK)
+
+
+func test_manifest_accepts_release_zip_and_installs_new_files() -> void:
+	## Lower-level non-interactive self-update success path: a valid release
+	## zip is accepted, existing addon files are classified separately, and
+	## the first-stage new-file install writes the expected content.
+	var probe_name := "%s%d.txt" % [PROBE_PREFIX, Time.get_ticks_usec()]
+	var probe_entry := "addons/godot_ai/%s" % probe_name
+	var zip_path := _scratch_dir.path_join("update_success.zip")
+	_stage_release_zip(
+		zip_path,
+		{
+			"addons/godot_ai/plugin.cfg": "[plugin]\nname=\"Godot AI\"\n",
+			"addons/godot_ai/plugin.gd": "extends EditorPlugin\n",
+			probe_entry: "probe content\n",
+		},
+	)
+
+	var runner = _new_runner()
+	runner._zip_path = zip_path
+	assert_true(
+		runner._read_update_manifest(),
+		"release zip with plugin.cfg and plugin.gd must be accepted",
+	)
+	assert_contains(runner._existing_file_paths, "addons/godot_ai/plugin.cfg")
+	assert_contains(runner._existing_file_paths, "addons/godot_ai/plugin.gd")
+	assert_contains(runner._new_file_paths, probe_entry)
+
+	assert_eq(
+		runner._install_zip_paths(runner._new_file_paths),
+		UpdateReloadRunner.InstallStatus.OK,
+		"new files should install from zip",
+	)
+	var target_path := ProjectSettings.globalize_path("res://addons/godot_ai/%s" % probe_name)
+	assert_eq(_read_file(target_path), "probe content\n")
+	runner.free()
 
 
 func test_install_zip_file_creates_backup_for_existing_target() -> void:

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -3336,6 +3336,49 @@ class TestPerCallSessionRouting:
         finally:
             await plugin_b.close()
 
+    async def test_concurrent_read_and_write_route_to_target_sessions(self, mcp_stack):
+        client, plugin_a = mcp_stack
+        plugin_b = await self._connect_second_plugin("proj-b@0002")
+        try:
+            async def respond_a():
+                cmd = await plugin_a.recv_command()
+                assert cmd["command"] == "get_open_scenes"
+                await plugin_a.send_response(
+                    cmd["request_id"],
+                    {"scenes": ["res://from_a.tscn"], "current": "res://from_a.tscn"},
+                )
+
+            async def respond_b():
+                cmd = await plugin_b.recv_command()
+                assert cmd["command"] == "create_node"
+                assert cmd["params"] == {"type": "Node3D", "name": "FromB", "parent_path": ""}
+                await plugin_b.send_response(
+                    cmd["request_id"],
+                    {"path": "/Main/FromB", "type": "Node3D", "undoable": True},
+                )
+
+            responders = [asyncio.create_task(respond_a()), asyncio.create_task(respond_b())]
+            read_result, write_result = await asyncio.gather(
+                client.call_tool(
+                    "scene_manage",
+                    {"op": "get_roots", "params": {}, "session_id": "mcp-test"},
+                ),
+                client.call_tool(
+                    "node_create",
+                    {
+                        "type": "Node3D",
+                        "name": "FromB",
+                        "session_id": "proj-b@0002",
+                    },
+                ),
+            )
+            await asyncio.gather(*responders)
+
+            assert read_result.data["current"] == "res://from_a.tscn"
+            assert write_result.data["path"] == "/Main/FromB"
+        finally:
+            await plugin_b.close()
+
     async def test_session_id_respects_target_readiness(self, mcp_stack):
         client, plugin_a = mcp_stack
         ## Active session (plugin_a/mcp-test) is ready; plugin_b is playing.

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -170,6 +170,45 @@ class TestCommandRoundTrip:
         assert r2 == {"cmd": "second"}
         await plugin.close()
 
+    async def test_concurrent_commands_route_to_explicit_sessions(self, harness):
+        """A read and a write in flight at the same time stay on their target sessions."""
+        plugin_a = await harness.connect_plugin(session_id="route-a")
+        plugin_b = await harness.connect_plugin(session_id="route-b")
+        client = GodotClient(harness.server, harness.registry)
+
+        async def respond_a():
+            cmd = await plugin_a.recv_command()
+            assert cmd["command"] == "get_open_scenes"
+            await plugin_a.send_response(
+                cmd["request_id"],
+                {"scenes": ["res://from_a.tscn"], "current": "res://from_a.tscn"},
+            )
+
+        async def respond_b():
+            cmd = await plugin_b.recv_command()
+            assert cmd["command"] == "create_node"
+            assert cmd["params"] == {"type": "Node3D", "name": "FromB"}
+            await plugin_b.send_response(
+                cmd["request_id"],
+                {"path": "/Main/FromB", "type": "Node3D", "undoable": True},
+            )
+
+        handler_tasks = [asyncio.create_task(respond_a()), asyncio.create_task(respond_b())]
+        read_result, write_result = await asyncio.gather(
+            client.send("get_open_scenes", session_id="route-a"),
+            client.send(
+                "create_node",
+                params={"type": "Node3D", "name": "FromB"},
+                session_id="route-b",
+            ),
+        )
+        await asyncio.gather(*handler_tasks)
+
+        assert read_result["current"] == "res://from_a.tscn"
+        assert write_result["path"] == "/Main/FromB"
+        await plugin_a.close()
+        await plugin_b.close()
+
 
 # ---------------------------------------------------------------------------
 # Error handling
@@ -264,6 +303,22 @@ class TestErrors:
         assert exc_info.value.data["command"] == "deferred_never_replies"
         await plugin.close()
 
+    async def test_timeout_removes_pending_request_and_ignores_late_reply(self, harness):
+        plugin = await harness.connect_plugin()
+        client = GodotClient(harness.server, harness.registry)
+
+        with pytest.raises(TimeoutError):
+            await client.send("slow_command", timeout=0.05)
+
+        assert harness.server._pending == {}
+
+        cmd = await plugin.recv_command()
+        await plugin.send_response(cmd["request_id"], {"arrived": "late"})
+        await asyncio.sleep(0.05)
+
+        assert harness.server._pending == {}
+        await plugin.close()
+
 
 # ---------------------------------------------------------------------------
 # Events
@@ -340,6 +395,37 @@ class TestMultipleSessions:
         assert harness.registry.get("keep-a") is None
         assert harness.registry.get("keep-b") is not None
         await plugin_b.close()
+
+    async def test_disconnect_reconnect_handshake_then_first_command(self, harness):
+        plugin_old = await harness.connect_plugin(session_id="reconnect-old")
+        assert harness.registry.active_session_id == "reconnect-old"
+
+        await plugin_old.close()
+        for _ in range(20):
+            if harness.registry.get("reconnect-old") is None:
+                break
+            await asyncio.sleep(0.05)
+        assert harness.registry.get("reconnect-old") is None
+        assert harness.registry.active_session_id is None
+
+        plugin_new = await harness.connect_plugin(session_id="reconnect-new")
+        assert harness.registry.active_session_id == "reconnect-new"
+        client = GodotClient(harness.server, harness.registry)
+
+        async def respond_new():
+            cmd = await plugin_new.recv_command()
+            assert cmd["command"] == "get_editor_state"
+            await plugin_new.send_response(
+                cmd["request_id"],
+                {"project_name": "AfterReconnect", "godot_version": "4.4.1"},
+            )
+
+        handler_task = asyncio.create_task(respond_new())
+        result = await client.send("get_editor_state")
+        await handler_task
+
+        assert result["project_name"] == "AfterReconnect"
+        await plugin_new.close()
 
 
 # --- Issue #262: editor_state self-heals a stale "playing" cache ---


### PR DESCRIPTION
## Summary
- Add concurrency coverage for explicit multi-session command/tool routing.
- Characterize reconnect -> handshake -> first command and timeout/late-reply behavior.
- Add GDScript characterization for deferred request-id threading, pause restoration, and the lower-level self-update success path.

## Notes
- Full interactive self-update smoke remains covered by script/local-self-update-smoke; this PR adds the narrow non-interactive lower-level success-path test instead.
- #299 already covers config preservation/success paths, so this PR leaves that beta coverage intact rather than duplicating it.

## Validation
- uv run --extra dev pytest -p no:cacheprovider tests/integration/test_websocket.py tests/integration/test_mcp_tools.py::TestPerCallSessionRouting -q
- uv run --extra dev ruff check tests/integration/test_websocket.py tests/integration/test_mcp_tools.py
- Godot 4.6.2 headless import/parse: exit 0, only known Windows certificate/editor-settings warnings
- Focused Godot suites: dispatcher targeted test 1/1, project targeted test 1/1, update_reload_runner 10/10
