### PR TITLE
camera: track logical current to make camera_get deterministic

### DIFF
--- a/plugin/addons/godot_ai/handlers/camera_handler.gd
+++ b/plugin/addons/godot_ai/handlers/camera_handler.gd
@@ -182,6 +182,13 @@ static func _logical_current_camera(scene_root: Node, type_str: String = "") -> 
 
 
 
+static func _is_logical_current(scene_root: Node, cam: Node) -> bool:
+	if scene_root == null or cam == null:
+		return false
+	var logical := _logical_current_camera(scene_root, _camera_type_str(cam))
+	return logical != null and logical == cam
+
+
 # Register a current=true switch on `node` in the open undo action,
 # unmarking previously-current siblings of the same class so a single
 # Ctrl-Z reverts the whole switch.
@@ -795,9 +802,10 @@ func get_camera(params: Dictionary) -> Dictionary:
 	var keys: Array = _KEYS_2D if type_str == "2d" else _KEYS_3D
 	var prop_types := _property_type_map(node)
 	var props: Dictionary = {}
+	var is_current_effective := _is_effective_current(node) or _is_logical_current(scene_root, node)
 	for key in keys:
 		if key == "current":
-			props[key] = _is_effective_current(node)
+			props[key] = is_current_effective
 			continue
 		if prop_types.has(key):
 			props[key] = CameraValues.serialize(node.get(key))
@@ -807,7 +815,7 @@ func get_camera(params: Dictionary) -> Dictionary:
 			"path": McpScenePath.from_node(node, scene_root),
 			"type": type_str,
 			"class": node.get_class(),
-			"current": _is_effective_current(node),
+			"current": is_current_effective,
 			"properties": props,
 			"resolved_via": resolved_via,
 		}
@@ -825,12 +833,15 @@ func list_cameras(_params: Dictionary) -> Dictionary:
 
 	var cams := _list_cameras_in_scene(scene_root, "")
 	var out: Array[Dictionary] = []
+	var logical_2d := _logical_current_camera(scene_root, "2d")
+	var logical_3d := _logical_current_camera(scene_root, "3d")
 	for cam in cams:
+		var logical_current := logical_2d if cam is Camera2D else logical_3d if cam is Camera3D else null
 		out.append({
 			"path": McpScenePath.from_node(cam, scene_root),
 			"class": cam.get_class(),
 			"type": _camera_type_str(cam),
-			"current": _is_effective_current(cam) or _logical_current_camera(scene_root, _camera_type_str(cam)) == cam,
+			"current": _is_effective_current(cam) or (logical_current != null and logical_current == cam),
 		})
 	return {"data": {"cameras": out}}
 

--- a/plugin/addons/godot_ai/handlers/camera_handler.gd
+++ b/plugin/addons/godot_ai/handlers/camera_handler.gd
@@ -68,6 +68,8 @@ const _NODE_TRANSFORM_KEYS := [
 const _DAMPING_MARGIN_KEYS := ["left", "top", "right", "bottom"]
 const _CURRENT_SETTLE_ATTEMPTS := 8
 const _CURRENT_SETTLE_DELAY_MSEC := 10
+const _LOGICAL_CURRENT_2D_META := "godot_ai/logical_current_2d"
+const _LOGICAL_CURRENT_3D_META := "godot_ai/logical_current_3d"
 
 
 var _undo_redo: EditorUndoRedoManager
@@ -111,6 +113,73 @@ static func _is_effective_current(cam: Node) -> bool:
 		var viewport_3d := cam.get_viewport()
 		return viewport_3d != null and viewport_3d.get_camera_3d() == cam
 	return false
+
+static func _logical_meta_key_for(cam: Node) -> String:
+	if cam is Camera2D:
+		return _LOGICAL_CURRENT_2D_META
+	if cam is Camera3D:
+		return _LOGICAL_CURRENT_3D_META
+	return ""
+
+
+static func _set_logical_current(cam: Node) -> void:
+	if cam == null or not is_instance_valid(cam) or not cam.is_inside_tree():
+		return
+	var key := _logical_meta_key_for(cam)
+	if key.is_empty():
+		return
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return
+	if not scene_root.is_ancestor_of(cam):
+		return
+	scene_root.set_meta(key, McpScenePath.from_node(cam, scene_root))
+
+
+static func _clear_logical_current(cam: Node) -> void:
+	if cam == null:
+		return
+	var key := _logical_meta_key_for(cam)
+	if key.is_empty():
+		return
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null or not scene_root.has_meta(key):
+		return
+	var existing_path := String(scene_root.get_meta(key, ""))
+	var current_path := ""
+	if is_instance_valid(cam) and cam.is_inside_tree() and scene_root.is_ancestor_of(cam):
+		current_path = McpScenePath.from_node(cam, scene_root)
+	if existing_path == current_path:
+		scene_root.remove_meta(key)
+
+
+static func _logical_current_camera(scene_root: Node, type_str: String = "") -> Node:
+	if scene_root == null:
+		return null
+	var keys: Array[String] = []
+	if type_str == "2d":
+		keys = [_LOGICAL_CURRENT_2D_META]
+	elif type_str == "3d":
+		keys = [_LOGICAL_CURRENT_3D_META]
+	else:
+		keys = [_LOGICAL_CURRENT_2D_META, _LOGICAL_CURRENT_3D_META]
+	for key in keys:
+		if not scene_root.has_meta(key):
+			continue
+		var path := String(scene_root.get_meta(key, ""))
+		if path.is_empty():
+			continue
+		var node := McpScenePath.resolve(path, scene_root)
+		if node == null:
+			scene_root.remove_meta(key)
+			continue
+		if not _is_camera(node):
+			scene_root.remove_meta(key)
+			continue
+		if type_str.is_empty() or _camera_type_str(node) == type_str:
+			return node
+	return null
+
 
 
 # Register a current=true switch on `node` in the open undo action,
@@ -166,6 +235,7 @@ func _add_make_current_to_action(node: Node, type_str: String, scene_root: Node)
 func _apply_make_current(cam: Node) -> void:
 	if cam == null or not is_instance_valid(cam) or not cam.is_inside_tree():
 		return
+	_set_logical_current(cam)
 	for attempt in range(_CURRENT_SETTLE_ATTEMPTS):
 		cam.make_current()
 		_force_camera_refresh(cam)
@@ -247,6 +317,7 @@ func _nudge_camera_2d_current(target: Node) -> void:
 func _apply_clear_current(cam: Node) -> void:
 	if cam == null or not is_instance_valid(cam) or not cam.is_inside_tree():
 		return
+	_clear_logical_current(cam)
 	for attempt in range(_CURRENT_SETTLE_ATTEMPTS):
 		if not _is_current(cam):
 			return
@@ -679,8 +750,12 @@ func get_camera(params: Dictionary) -> Dictionary:
 		# viewport slot has switched; falling through to "first" during that
 		# window makes camera_get("") nondeterministic.
 		var all_cams := _list_cameras_in_scene(scene_root, "")
+		var logical_current := _logical_current_camera(scene_root)
+		if logical_current != null and all_cams.has(logical_current):
+			node = logical_current
+			resolved_via = "current"
 		var viewport_current := _viewport_current_camera(scene_root)
-		if viewport_current != null and all_cams.has(viewport_current):
+		if node == null and viewport_current != null and all_cams.has(viewport_current):
 			node = viewport_current
 			resolved_via = "current"
 		for cam in all_cams:
@@ -755,7 +830,7 @@ func list_cameras(_params: Dictionary) -> Dictionary:
 			"path": McpScenePath.from_node(cam, scene_root),
 			"class": cam.get_class(),
 			"type": _camera_type_str(cam),
-			"current": _is_current(cam),
+			"current": _is_effective_current(cam) or _logical_current_camera(scene_root, _camera_type_str(cam)) == cam,
 		})
 	return {"data": {"cameras": out}}
 


### PR DESCRIPTION
### Motivation
- Headless CI shows nondeterministic `camera_get("")`/current-camera resolution because `Camera2D.is_current()` and `Viewport.get_camera_*()` can lag after create/undo/reload, causing flaky tests (Issue #301). 
- The intent is to provide a deterministic MCP-facing notion of “current camera” that is updated inside the same undo/redo callbacks that call `make_current()`/`clear_current()` so tests and tools do not depend solely on transient viewport timing.

### Description
- Added per-scene-root metadata keys `"godot_ai/logical_current_2d"` and `"godot_ai/logical_current_3d"` and helper functions ` _logical_meta_key_for`, `_set_logical_current`, `_clear_logical_current`, and `_logical_current_camera` to read/write and self-heal stale entries. (file: `plugin/addons/godot_ai/handlers/camera_handler.gd`)
- Updated `_apply_make_current` to call `_set_logical_current(cam)` and `_apply_clear_current` to call `_clear_logical_current(cam)` so logical marker updates occur inside the same do/undo callbacks as the real viewport operations. 
- Changed `get_camera` selection order to prefer the logical current first, then the viewport current, then `is_current()` scanning, and finally fall back to the first camera; and updated `list_cameras` to consider the logical marker when reporting `current`.
- Preserved existing bounded settling/force-refresh logic so the change is a deterministic metadata-backed fallback rather than a replacement of `make_current()`/`clear_current()` behavior.

### Testing
- Ran `pytest -q tests/unit/test_runtime_handlers.py -k "camera_get_empty_path or camera_list_handler"` in the environment, but the run failed with `ModuleNotFoundError: No module named 'websockets'` so unit tests could not complete. 
- No other automated tests were executed in this environment; the change includes self-healing metadata behavior to avoid stale entries during test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f819133798832781713424d18b0054)