### PR TITLE
camera: address review feedback on logical-current bookkeeping (#305)

### DIFF
--- a/plugin/addons/godot_ai/handlers/camera_handler.gd
+++ b/plugin/addons/godot_ai/handlers/camera_handler.gd
@@ -182,6 +182,13 @@ static func _logical_current_camera(scene_root: Node, type_str: String = "") -> 
 
 
 
+static func _is_logical_current(scene_root: Node, cam: Node) -> bool:
+	if scene_root == null or cam == null:
+		return false
+	var logical := _logical_current_camera(scene_root, _camera_type_str(cam))
+	return logical != null and logical == cam
+
+
 # Register a current=true switch on `node` in the open undo action,
 # unmarking previously-current siblings of the same class so a single
 # Ctrl-Z reverts the whole switch.
@@ -795,9 +802,10 @@ func get_camera(params: Dictionary) -> Dictionary:
 	var keys: Array = _KEYS_2D if type_str == "2d" else _KEYS_3D
 	var prop_types := _property_type_map(node)
 	var props: Dictionary = {}
+	var is_current_effective := _is_effective_current(node) or _is_logical_current(scene_root, node)
 	for key in keys:
 		if key == "current":
-			props[key] = _is_effective_current(node)
+			props[key] = is_current_effective
 			continue
 		if prop_types.has(key):
 			props[key] = CameraValues.serialize(node.get(key))
@@ -807,7 +815,7 @@ func get_camera(params: Dictionary) -> Dictionary:
 			"path": McpScenePath.from_node(node, scene_root),
 			"type": type_str,
 			"class": node.get_class(),
-			"current": _is_effective_current(node),
+			"current": is_current_effective,
 			"properties": props,
 			"resolved_via": resolved_via,
 		}
@@ -825,12 +833,15 @@ func list_cameras(_params: Dictionary) -> Dictionary:
 
 	var cams := _list_cameras_in_scene(scene_root, "")
 	var out: Array[Dictionary] = []
+	var logical_2d := _logical_current_camera(scene_root, "2d")
+	var logical_3d := _logical_current_camera(scene_root, "3d")
 	for cam in cams:
+		var logical_current := logical_2d if cam is Camera2D else logical_3d if cam is Camera3D else null
 		out.append({
 			"path": McpScenePath.from_node(cam, scene_root),
 			"class": cam.get_class(),
 			"type": _camera_type_str(cam),
-			"current": _is_effective_current(cam) or _logical_current_camera(scene_root, _camera_type_str(cam)) == cam,
+			"current": _is_effective_current(cam) or (logical_current != null and logical_current == cam),
 		})
 	return {"data": {"cameras": out}}
 

--- a/plugin/addons/godot_ai/handlers/camera_handler.gd
+++ b/plugin/addons/godot_ai/handlers/camera_handler.gd
@@ -68,6 +68,8 @@ const _NODE_TRANSFORM_KEYS := [
 const _DAMPING_MARGIN_KEYS := ["left", "top", "right", "bottom"]
 const _CURRENT_SETTLE_ATTEMPTS := 8
 const _CURRENT_SETTLE_DELAY_MSEC := 10
+const _LOGICAL_CURRENT_2D_META := "godot_ai/logical_current_2d"
+const _LOGICAL_CURRENT_3D_META := "godot_ai/logical_current_3d"
 
 
 var _undo_redo: EditorUndoRedoManager
@@ -111,6 +113,73 @@ static func _is_effective_current(cam: Node) -> bool:
 		var viewport_3d := cam.get_viewport()
 		return viewport_3d != null and viewport_3d.get_camera_3d() == cam
 	return false
+
+static func _logical_meta_key_for(cam: Node) -> String:
+	if cam is Camera2D:
+		return _LOGICAL_CURRENT_2D_META
+	if cam is Camera3D:
+		return _LOGICAL_CURRENT_3D_META
+	return ""
+
+
+static func _set_logical_current(cam: Node) -> void:
+	if cam == null or not is_instance_valid(cam) or not cam.is_inside_tree():
+		return
+	var key := _logical_meta_key_for(cam)
+	if key.is_empty():
+		return
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return
+	if not scene_root.is_ancestor_of(cam):
+		return
+	scene_root.set_meta(key, McpScenePath.from_node(cam, scene_root))
+
+
+static func _clear_logical_current(cam: Node) -> void:
+	if cam == null:
+		return
+	var key := _logical_meta_key_for(cam)
+	if key.is_empty():
+		return
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null or not scene_root.has_meta(key):
+		return
+	var existing_path := String(scene_root.get_meta(key, ""))
+	var current_path := ""
+	if is_instance_valid(cam) and cam.is_inside_tree() and scene_root.is_ancestor_of(cam):
+		current_path = McpScenePath.from_node(cam, scene_root)
+	if existing_path == current_path:
+		scene_root.remove_meta(key)
+
+
+static func _logical_current_camera(scene_root: Node, type_str: String = "") -> Node:
+	if scene_root == null:
+		return null
+	var keys: Array[String] = []
+	if type_str == "2d":
+		keys = [_LOGICAL_CURRENT_2D_META]
+	elif type_str == "3d":
+		keys = [_LOGICAL_CURRENT_3D_META]
+	else:
+		keys = [_LOGICAL_CURRENT_2D_META, _LOGICAL_CURRENT_3D_META]
+	for key in keys:
+		if not scene_root.has_meta(key):
+			continue
+		var path := String(scene_root.get_meta(key, ""))
+		if path.is_empty():
+			continue
+		var node := McpScenePath.resolve(path, scene_root)
+		if node == null:
+			scene_root.remove_meta(key)
+			continue
+		if not _is_camera(node):
+			scene_root.remove_meta(key)
+			continue
+		if type_str.is_empty() or _camera_type_str(node) == type_str:
+			return node
+	return null
+
 
 
 # Register a current=true switch on `node` in the open undo action,
@@ -166,6 +235,7 @@ func _add_make_current_to_action(node: Node, type_str: String, scene_root: Node)
 func _apply_make_current(cam: Node) -> void:
 	if cam == null or not is_instance_valid(cam) or not cam.is_inside_tree():
 		return
+	_set_logical_current(cam)
 	for attempt in range(_CURRENT_SETTLE_ATTEMPTS):
 		cam.make_current()
 		_force_camera_refresh(cam)
@@ -247,6 +317,7 @@ func _nudge_camera_2d_current(target: Node) -> void:
 func _apply_clear_current(cam: Node) -> void:
 	if cam == null or not is_instance_valid(cam) or not cam.is_inside_tree():
 		return
+	_clear_logical_current(cam)
 	for attempt in range(_CURRENT_SETTLE_ATTEMPTS):
 		if not _is_current(cam):
 			return
@@ -679,8 +750,12 @@ func get_camera(params: Dictionary) -> Dictionary:
 		# viewport slot has switched; falling through to "first" during that
 		# window makes camera_get("") nondeterministic.
 		var all_cams := _list_cameras_in_scene(scene_root, "")
+		var logical_current := _logical_current_camera(scene_root)
+		if logical_current != null and all_cams.has(logical_current):
+			node = logical_current
+			resolved_via = "current"
 		var viewport_current := _viewport_current_camera(scene_root)
-		if viewport_current != null and all_cams.has(viewport_current):
+		if node == null and viewport_current != null and all_cams.has(viewport_current):
 			node = viewport_current
 			resolved_via = "current"
 		for cam in all_cams:
@@ -755,7 +830,7 @@ func list_cameras(_params: Dictionary) -> Dictionary:
 			"path": McpScenePath.from_node(cam, scene_root),
 			"class": cam.get_class(),
 			"type": _camera_type_str(cam),
-			"current": _is_current(cam),
+			"current": _is_effective_current(cam) or _logical_current_camera(scene_root, _camera_type_str(cam)) == cam,
 		})
 	return {"data": {"cameras": out}}
 

--- a/plugin/addons/godot_ai/handlers/camera_handler.gd
+++ b/plugin/addons/godot_ai/handlers/camera_handler.gd
@@ -68,11 +68,19 @@ const _NODE_TRANSFORM_KEYS := [
 const _DAMPING_MARGIN_KEYS := ["left", "top", "right", "bottom"]
 const _CURRENT_SETTLE_ATTEMPTS := 8
 const _CURRENT_SETTLE_DELAY_MSEC := 10
-const _LOGICAL_CURRENT_2D_META := "godot_ai/logical_current_2d"
-const _LOGICAL_CURRENT_3D_META := "godot_ai/logical_current_3d"
 
 
 var _undo_redo: EditorUndoRedoManager
+
+# Per-scene logical-current bookkeeping. Keys are scene-root InstanceIDs;
+# values are { "2d": NodePath-as-String, "3d": NodePath-as-String } with
+# missing keys meaning "no logical current for that class."
+#
+# Stored on the handler instance (NOT as Node metadata on the scene root)
+# because set_meta() persists into the .tscn on save, contaminating user
+# scene files with MCP-internal sidecar state that lingers across reloads
+# and travels in commits.
+var _logical_current: Dictionary = {}
 
 
 func _init(undo_redo: EditorUndoRedoManager) -> void:
@@ -114,79 +122,123 @@ static func _is_effective_current(cam: Node) -> bool:
 		return viewport_3d != null and viewport_3d.get_camera_3d() == cam
 	return false
 
-static func _logical_meta_key_for(cam: Node) -> String:
-	if cam is Camera2D:
-		return _LOGICAL_CURRENT_2D_META
-	if cam is Camera3D:
-		return _LOGICAL_CURRENT_3D_META
-	return ""
 
+# Logical-current bookkeeping. Updated from inside _apply_make_current /
+# _apply_clear_current so DO and UNDO callables stamp the same logical
+# slot they touch in the viewport. Reads consult the logical slot first
+# and treat it as authoritative when set — the viewport read is the
+# fallback for "MCP never touched this scene's cameras."
 
-static func _set_logical_current(cam: Node) -> void:
+func _set_logical_current(cam: Node) -> void:
 	if cam == null or not is_instance_valid(cam) or not cam.is_inside_tree():
 		return
-	var key := _logical_meta_key_for(cam)
-	if key.is_empty():
+	var type_str := _camera_type_str(cam)
+	if type_str.is_empty():
+		return
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null or not scene_root.is_ancestor_of(cam):
+		return
+	var slot: Dictionary = _logical_current.get(scene_root.get_instance_id(), {})
+	slot[type_str] = McpScenePath.from_node(cam, scene_root)
+	_logical_current[scene_root.get_instance_id()] = slot
+
+
+func _clear_logical_current(cam: Node) -> void:
+	if cam == null:
+		return
+	var type_str := _camera_type_str(cam)
+	if type_str.is_empty():
 		return
 	var scene_root := EditorInterface.get_edited_scene_root()
 	if scene_root == null:
 		return
-	if not scene_root.is_ancestor_of(cam):
+	var key := scene_root.get_instance_id()
+	if not _logical_current.has(key):
 		return
-	scene_root.set_meta(key, McpScenePath.from_node(cam, scene_root))
-
-
-static func _clear_logical_current(cam: Node) -> void:
-	if cam == null:
+	var slot: Dictionary = _logical_current[key]
+	if not slot.has(type_str):
 		return
-	var key := _logical_meta_key_for(cam)
-	if key.is_empty():
-		return
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null or not scene_root.has_meta(key):
-		return
-	var existing_path := String(scene_root.get_meta(key, ""))
+	# Only clear if the logical slot still points at this camera; otherwise
+	# a later make_current already took the slot and we'd stomp it.
 	var current_path := ""
 	if is_instance_valid(cam) and cam.is_inside_tree() and scene_root.is_ancestor_of(cam):
 		current_path = McpScenePath.from_node(cam, scene_root)
-	if existing_path == current_path:
-		scene_root.remove_meta(key)
+	if String(slot[type_str]) == current_path:
+		slot.erase(type_str)
+		if slot.is_empty():
+			_logical_current.erase(key)
+		else:
+			_logical_current[key] = slot
 
 
-static func _logical_current_camera(scene_root: Node, type_str: String = "") -> Node:
+func _logical_current_camera(scene_root: Node, type_str: String = "") -> Node:
 	if scene_root == null:
 		return null
-	var keys: Array[String] = []
-	if type_str == "2d":
-		keys = [_LOGICAL_CURRENT_2D_META]
-	elif type_str == "3d":
-		keys = [_LOGICAL_CURRENT_3D_META]
+	var key := scene_root.get_instance_id()
+	if not _logical_current.has(key):
+		return null
+	var slot: Dictionary = _logical_current[key]
+	var types: Array[String] = []
+	if type_str == "2d" or type_str == "3d":
+		types = [type_str]
 	else:
-		keys = [_LOGICAL_CURRENT_2D_META, _LOGICAL_CURRENT_3D_META]
-	for key in keys:
-		if not scene_root.has_meta(key):
+		types = ["2d", "3d"]
+	for t in types:
+		if not slot.has(t):
 			continue
-		var path := String(scene_root.get_meta(key, ""))
+		var path := String(slot[t])
 		if path.is_empty():
+			slot.erase(t)
 			continue
 		var node := McpScenePath.resolve(path, scene_root)
-		if node == null:
-			scene_root.remove_meta(key)
+		if node == null or not _is_camera(node) or _camera_type_str(node) != t:
+			slot.erase(t)
 			continue
-		if not _is_camera(node):
-			scene_root.remove_meta(key)
-			continue
-		if type_str.is_empty() or _camera_type_str(node) == type_str:
-			return node
+		return node
+	if slot.is_empty():
+		_logical_current.erase(key)
+	else:
+		_logical_current[key] = slot
 	return null
 
 
-
-static func _is_logical_current(scene_root: Node, cam: Node) -> bool:
+func _is_logical_current(scene_root: Node, cam: Node) -> bool:
 	if scene_root == null or cam == null:
 		return false
 	var logical := _logical_current_camera(scene_root, _camera_type_str(cam))
 	return logical != null and logical == cam
+
+
+# Authoritative answer for "is `cam` the current camera of its class?"
+#
+# When a logical marker exists for the camera's class, it is the single
+# source of truth — only the marker's referenced camera reports current,
+# every other camera of that class reports false even if the viewport
+# slot still points at one of them (the headless-CI lag in #140 / #278 /
+# #301). Without a logical marker, fall through to the viewport read so
+# scenes MCP never touched still answer correctly.
+func _resolve_current(scene_root: Node, cam: Node) -> bool:
+	if scene_root == null or cam == null:
+		return false
+	var logical := _logical_current_camera(scene_root, _camera_type_str(cam))
+	if logical != null:
+		return logical == cam
+	return _is_effective_current(cam)
+
+
+# list_cameras pre-fetches the per-class logical pointers once; this
+# variant takes those pointers to avoid an O(n²) walk over the meta
+# bookkeeping for each camera in the scene.
+func _resolve_current_with_logicals(cam: Node, logical_2d: Node, logical_3d: Node) -> bool:
+	if cam == null:
+		return false
+	if cam is Camera2D:
+		if logical_2d != null:
+			return logical_2d == cam
+	elif cam is Camera3D:
+		if logical_3d != null:
+			return logical_3d == cam
+	return _is_effective_current(cam)
 
 
 # Register a current=true switch on `node` in the open undo action,
@@ -243,11 +295,19 @@ func _apply_make_current(cam: Node) -> void:
 	if cam == null or not is_instance_valid(cam) or not cam.is_inside_tree():
 		return
 	_set_logical_current(cam)
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var type_str := _camera_type_str(cam)
 	for attempt in range(_CURRENT_SETTLE_ATTEMPTS):
 		cam.make_current()
 		_force_camera_refresh(cam)
+		# Godot's make_current is supposed to atomically displace siblings,
+		# but on macOS headless the displaced camera occasionally still
+		# answers is_current() == true after this returns (#140 / #278 / #301).
+		# Sweep same-class siblings and clear any that lag.
+		_force_clear_other_currents(cam, type_str, scene_root)
 		if not _is_current_settled(cam):
 			_displace_stale_camera_2d(cam)
+			_force_clear_other_currents(cam, type_str, scene_root)
 		var waited_this_attempt := false
 		if _is_current_settled(cam):
 			if not (cam is Camera2D):
@@ -255,10 +315,38 @@ func _apply_make_current(cam: Node) -> void:
 			OS.delay_msec(_CURRENT_SETTLE_DELAY_MSEC)
 			waited_this_attempt = true
 			_force_camera_refresh(cam)
+			_force_clear_other_currents(cam, type_str, scene_root)
 			if _is_current_settled(cam):
 				return
 		if attempt < _CURRENT_SETTLE_ATTEMPTS - 1 and not waited_this_attempt:
 			OS.delay_msec(_CURRENT_SETTLE_DELAY_MSEC)
+
+
+# Walk same-class siblings and force-clear any that still report is_current().
+# Best-effort: clear_current errors when called on a non-current camera, so
+# guard. Camera2D's clear_current path also flushes the viewport slot, which
+# is the one we actually care about settling for #301.
+func _force_clear_other_currents(target: Node, type_str: String, scene_root: Node) -> void:
+	if scene_root == null or type_str.is_empty():
+		return
+	for sibling in _list_cameras_in_scene(scene_root, type_str):
+		if sibling == target:
+			continue
+		if not is_instance_valid(sibling) or not sibling.is_inside_tree():
+			continue
+		if not _is_current(sibling):
+			# Even if is_current() reports false, the viewport slot can
+			# still point at this sibling on macOS — re-make target to
+			# take it back. Cheap (idempotent) when the slot is fine.
+			if sibling is Camera2D:
+				var vp_other: Viewport = (sibling as Camera2D).get_viewport()
+				if vp_other != null and vp_other.get_camera_2d() == sibling:
+					target.make_current()
+					_force_camera_refresh(target)
+			continue
+		sibling.clear_current()
+		if sibling is Camera2D:
+			(sibling as Camera2D).force_update_scroll()
 
 
 # Call after commit_action() whenever the action registered a make_current DO.
@@ -326,14 +414,39 @@ func _apply_clear_current(cam: Node) -> void:
 		return
 	_clear_logical_current(cam)
 	for attempt in range(_CURRENT_SETTLE_ATTEMPTS):
-		if not _is_current(cam):
+		if _is_clear_settled(cam):
 			return
-		cam.clear_current()
-		_force_camera_refresh(cam)
-		if not _is_current(cam):
+		if _is_current(cam):
+			cam.clear_current()
+			_force_camera_refresh(cam)
+		# Camera2D-only: is_current() may answer false while the viewport
+		# slot still points at cam. Toggle enabled to force the viewport
+		# to release, then restore.
+		if cam is Camera2D:
+			var vp := cam.get_viewport()
+			if vp != null and vp.get_camera_2d() == cam:
+				var was_enabled := (cam as Camera2D).enabled
+				if was_enabled:
+					(cam as Camera2D).enabled = false
+				_force_camera_refresh(cam)
+				if was_enabled:
+					(cam as Camera2D).enabled = true
+		if _is_clear_settled(cam):
 			return
 		if attempt < _CURRENT_SETTLE_ATTEMPTS - 1:
 			OS.delay_msec(_CURRENT_SETTLE_DELAY_MSEC)
+
+
+func _is_clear_settled(cam: Node) -> bool:
+	if cam == null:
+		return true
+	if _is_current(cam):
+		return false
+	if cam is Camera2D:
+		var vp := cam.get_viewport()
+		if vp != null and vp.get_camera_2d() == cam:
+			return false
+	return true
 
 
 # ============================================================================
@@ -802,7 +915,7 @@ func get_camera(params: Dictionary) -> Dictionary:
 	var keys: Array = _KEYS_2D if type_str == "2d" else _KEYS_3D
 	var prop_types := _property_type_map(node)
 	var props: Dictionary = {}
-	var is_current_effective := _is_effective_current(node) or _is_logical_current(scene_root, node)
+	var is_current_effective := _resolve_current(scene_root, node)
 	for key in keys:
 		if key == "current":
 			props[key] = is_current_effective
@@ -836,12 +949,11 @@ func list_cameras(_params: Dictionary) -> Dictionary:
 	var logical_2d := _logical_current_camera(scene_root, "2d")
 	var logical_3d := _logical_current_camera(scene_root, "3d")
 	for cam in cams:
-		var logical_current := logical_2d if cam is Camera2D else logical_3d if cam is Camera3D else null
 		out.append({
 			"path": McpScenePath.from_node(cam, scene_root),
 			"class": cam.get_class(),
 			"type": _camera_type_str(cam),
-			"current": _is_effective_current(cam) or (logical_current != null and logical_current == cam),
+			"current": _resolve_current_with_logicals(cam, logical_2d, logical_3d),
 		})
 	return {"data": {"cameras": out}}
 

--- a/test_project/tests/test_camera.gd
+++ b/test_project/tests/test_camera.gd
@@ -635,6 +635,112 @@ func test_list_enumerates_2d_and_3d() -> void:
 
 
 # ============================================================================
+# logical-current determinism (#301)
+# ============================================================================
+
+# After configure({current: true}) followed by undo, the MCP read layer
+# must report the original current camera deterministically — even if
+# the viewport slot is still racing under us. This is the read-path
+# guarantee #305 was after.
+func test_configure_current_undo_mcp_reads_are_deterministic() -> void:
+	var first := _create("DetFirst", "2d", true)
+	if first.is_empty():
+		assert_true(false, "No scene open")
+		return
+	var second := _create("DetSecond", "2d", false)
+
+	var result := _handler.configure({
+		"camera_path": second.data.path,
+		"properties": {"current": true},
+	})
+	assert_has_key(result, "data")
+
+	# After flipping current to second, MCP reads must agree on second.
+	var got_second := _handler.get_camera({"camera_path": ""})
+	assert_eq(got_second.data.path, second.data.path,
+		"camera_get('') should resolve to second after configure(current=true)")
+	assert_eq(got_second.data.current, true)
+
+	assert_true(editor_undo(_undo_redo), "editor_undo returned false")
+
+	# Logical marker is authoritative — only first reports current.
+	var got_first := _handler.get_camera({"camera_path": ""})
+	assert_eq(got_first.data.path, first.data.path,
+		"camera_get('') should resolve to first after undo")
+	assert_eq(got_first.data.current, true)
+
+	var listed := _handler.list_cameras({})
+	var current_paths: Array = []
+	for entry in listed.data.cameras:
+		if bool(entry.current):
+			current_paths.append(entry.path)
+	assert_eq(current_paths.size(), 1,
+		"Exactly one Camera2D should report current after undo, got %s" % [current_paths])
+	assert_eq(current_paths[0], first.data.path,
+		"list_cameras should report first as current after undo, got %s" % [current_paths])
+
+	# Per-path get_camera must agree with the list view — not OR-stack
+	# logical with a still-laggy viewport for second.
+	var second_view := _handler.get_camera({"camera_path": second.data.path})
+	assert_eq(second_view.data.current, false,
+		"camera_get(second) must report current=false after undo")
+
+
+# Logical-current state must live on the handler, NOT as Node metadata
+# on the scene root, because set_meta() persists into .tscn on save.
+# Regression guard: walk the scene root's metadata after a make_current
+# round-trip and assert no godot_ai/* keys leaked there.
+func test_logical_current_does_not_pollute_scene_root_metadata() -> void:
+	var first := _create("MetaProbeFirst", "2d", true)
+	if first.is_empty():
+		assert_true(false, "No scene open")
+		return
+	var second := _create("MetaProbeSecond", "2d", false)
+	var _r := _handler.configure({
+		"camera_path": second.data.path,
+		"properties": {"current": true},
+	})
+	assert_true(editor_undo(_undo_redo))
+
+	var scene_root := EditorInterface.get_edited_scene_root()
+	for meta_key in scene_root.get_meta_list():
+		assert_false(String(meta_key).begins_with("godot_ai/"),
+			"Scene root metadata polluted with MCP key '%s' — would persist into .tscn on save"
+				% [meta_key])
+
+
+# Two cameras must never both report current=true for the same class,
+# even during the headless-CI race window where the viewport lags.
+# Construct the scenario, then verify list_cameras invariant directly.
+func test_list_cameras_never_reports_two_current_per_class() -> void:
+	var first := _create("InvFirst", "2d", true)
+	if first.is_empty():
+		assert_true(false, "No scene open")
+		return
+	var second := _create("InvSecond", "2d", false)
+	var _r := _handler.configure({
+		"camera_path": second.data.path,
+		"properties": {"current": true},
+	})
+	assert_true(editor_undo(_undo_redo))
+
+	var listed := _handler.list_cameras({})
+	var twod_currents := 0
+	var threed_currents := 0
+	for entry in listed.data.cameras:
+		if not bool(entry.current):
+			continue
+		if String(entry.type) == "2d":
+			twod_currents += 1
+		elif String(entry.type) == "3d":
+			threed_currents += 1
+	assert_true(twod_currents <= 1,
+		"At most one Camera2D may be current; got %d" % twod_currents)
+	assert_true(threed_currents <= 1,
+		"At most one Camera3D may be current; got %d" % threed_currents)
+
+
+# ============================================================================
 # camera_apply_preset
 # ============================================================================
 


### PR DESCRIPTION
Builds on #305 to address the remaining review feedback. Branch is based on #305's HEAD, so the diff against `beta` includes #305's two commits plus the follow-up below.

## What's fixed vs. #305

### Blocker — `list_cameras` could report two cameras as current at once
`current` was OR'ing `_is_effective_current(cam)` with the logical marker. During the post-undo viewport-lag race, **First** (logical match, viewport=lagging) and **Second** (viewport still points here) both came out `true`, violating the per-class single-current invariant.

Replaced with `_resolve_current` (and a list-loop variant `_resolve_current_with_logicals` to keep the per-camera lookup O(1) inside the list walk): when a logical marker exists for the camera's class, it is the **single** source of truth — only the marker's referenced camera reports current. Without a logical marker, fall through to the viewport read so scenes MCP never touched still answer correctly.

### Concern — scene file pollution from `Node.set_meta`
`set_meta()` on the edited scene root persists into the `.tscn` on save, contaminating user scene files with `metadata/godot_ai/logical_current_2d` / `_3d` sidecar keys that live beyond MCP and travel in commits.

Moved the bookkeeping onto the handler instance, keyed by `scene_root.get_instance_id()` → `{ "2d": path, "3d": path }`. Same self-heal semantics (stale entries get removed when `_logical_current_camera` resolves a missing/wrong-type node), but nothing serializes.

### Concern — root-cause attempt for the post-undo `is_current()` lag
The original PR papered over read-side symptoms but `Camera2D.is_current()` (which the existing `test_configure_current_sibling_unmark_single_undo` asserts on directly) was untouched. Two strengthening passes:

- `_apply_make_current` now calls `_force_clear_other_currents(target, type, scene_root)` after `make_current` and after the displace-stale path. It walks same-class siblings and explicitly `clear_current()`s any that still answer `is_current()=true` — the macOS-headless symptom from #140 / #278 / #301 that `_displace_stale_camera_2d` was missing.
- `_apply_clear_current` now polls `_is_clear_settled` (checks both `is_current()` *and* `viewport.get_camera_2d() != cam`) and, when the viewport slot lags, toggles `enabled` off/on as an escape hatch.

I don't have macOS-headless to repro the #301 flake locally, so this is best-effort defense in depth on top of the metadata-backed read determinism — not a guaranteed fix to the existing `is_current()` assertion.

### Style
Triple-blank-line separator collapsed.

## Tests added (`test_project/tests/test_camera.gd`)

- `test_configure_current_undo_mcp_reads_are_deterministic` — runs the exact #301 scenario (configure Second to current, then undo) and asserts through `camera_get` and `list_cameras` that exactly one camera reports current and it's First. This is the read-path determinism guarantee #305 was actually after.
- `test_logical_current_does_not_pollute_scene_root_metadata` — regression guard. Walks the scene root's `get_meta_list()` after a make_current undo round-trip and fails if any `godot_ai/*` key appears.
- `test_list_cameras_never_reports_two_current_per_class` — guards the invariant the OR semantics broke.

The pre-existing `test_configure_current_sibling_unmark_single_undo` is unchanged. If the strengthened `_apply_make_current` doesn't fully eliminate the macOS race, that test may continue to flake — that's a separate, longer-running issue (and arguably an upstream Godot timing bug). The MCP read layer is now deterministic regardless.

## Verification

- `ruff check src/ tests/ plugin/` — clean
- `pytest -q` — 744 passed
- `script/ci-check-gdscript` — All GDScript files OK
- GDScript test suite: not run locally (this sandbox can't host an editor + MCP server pair); CI on this PR will run it.

Closes #305 if merged in its place.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XvbAXa2c4r6aQyYKYPbXre)_