### PR TITLE
[codex] Fix camera current undo capture

### DIFF
--- a/plugin/addons/godot_ai/handlers/camera_handler.gd
+++ b/plugin/addons/godot_ai/handlers/camera_handler.gd
@@ -276,7 +276,7 @@ func _add_make_current_to_action(node: Node, type_str: String, scene_root: Node)
 	for cam in _list_cameras_in_scene(scene_root, type_str):
 		if cam == node:
 			continue
-		if _is_current(cam):
+		if _resolve_current(scene_root, cam):
 			prev_current = cam
 			break
 	_undo_redo.add_do_method(self, "_apply_make_current", node)
@@ -571,7 +571,7 @@ func configure(params: Dictionary) -> Dictionary:
 	var verify_current_after := false
 	if current_request != null:
 		var want_on: bool = bool(current_request)
-		var was_on: bool = _is_current(node)
+		var was_on: bool = _resolve_current(scene_root, node)
 		if want_on and not was_on:
 			_add_make_current_to_action(node, type_str, scene_root)
 			verify_current_after = true

--- a/tests/unit/test_camera_current_contract.py
+++ b/tests/unit/test_camera_current_contract.py
@@ -1,0 +1,44 @@
+"""Source-level contracts for Camera2D current-state flake guards."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.unit._gdscript_text import get_func_block
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[2] / "plugin" / "addons" / "godot_ai"
+CAMERA_HANDLER_PATH = PLUGIN_ROOT / "handlers" / "camera_handler.gd"
+
+
+def test_current_switch_undo_captures_logical_or_effective_current() -> None:
+    """The undo action must restore the logical/viewport current camera.
+
+    Headless editor CI has repeatedly observed Camera2D.is_current() and the
+    viewport camera slot disagreeing for a short window. On current beta, the
+    handler also keeps logical-current bookkeeping. If current-switch undo
+    captures the previous camera using only is_current(), it can miss the real
+    current camera and record "clear new camera" instead of "make old camera
+    current", leaving the new camera active after undo.
+    """
+
+    source = CAMERA_HANDLER_PATH.read_text()
+    switch_block = get_func_block(
+        source,
+        "func _add_make_current_to_action(node: Node, type_str: String, scene_root: Node) -> void:",
+    )
+    assert "_resolve_current(scene_root, cam)" in switch_block
+    assert "if _is_current(cam):" not in switch_block
+
+
+def test_configure_current_false_uses_authoritative_current_guard() -> None:
+    source = CAMERA_HANDLER_PATH.read_text()
+    configure_block = get_func_block(source, "func configure(params: Dictionary) -> Dictionary:")
+    assert "var was_on: bool = _resolve_current(scene_root, node)" in configure_block
+
+
+def test_camera_reads_still_route_through_logical_current_resolvers() -> None:
+    source = CAMERA_HANDLER_PATH.read_text()
+    get_block = get_func_block(source, "func get_camera(params: Dictionary) -> Dictionary:")
+    list_block = get_func_block(source, "func list_cameras(_params: Dictionary) -> Dictionary:")
+    assert "_resolve_current(scene_root, node)" in get_block
+    assert "_resolve_current_with_logicals(cam, logical_2d, logical_3d)" in list_block


### PR DESCRIPTION
## Summary

Fixes the remaining Camera2D current/undo flake by making current-switch undo capture use the handler's authoritative `_resolve_current(...)` path instead of raw `is_current()`.

## Root Cause

On headless CI, Godot can briefly disagree between `Camera2D.is_current()` and the viewport/logical current camera. Beta already has logical-current bookkeeping for camera read paths, but `_add_make_current_to_action()` still captured the previous current camera with raw `is_current()`. In that lag window, undo could record "clear new camera" instead of "make old camera current," leaving the new camera active after undo.

## Changes

- Use `_resolve_current(scene_root, cam)` when capturing the previous current camera for current-switch undo.
- Use `_resolve_current(scene_root, node)` when deciding whether `camera_configure({current: ...})` is a no-op.
- Add source-level regression contracts to pin the authoritative-current paths.

## Validation

- `pytest -q tests/unit/test_camera_current_contract.py`
- `ruff check tests/unit/test_camera_current_contract.py`
- `script/ci-check-gdscript`
- `script/ci-godot-tests` -> `1110/1125 passed, 0 failed`