### PR TITLE
[codex] Adapt #309 self-update parse fix for beta

### DIFF
--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -49,6 +49,8 @@ const GameLogBuffer := preload("res://addons/godot_ai/utils/game_log_buffer.gd")
 const EditorLogBuffer := preload("res://addons/godot_ai/utils/editor_log_buffer.gd")
 const Dock := preload("res://addons/godot_ai/mcp_dock.gd")
 const DebuggerPlugin := preload("res://addons/godot_ai/debugger/mcp_debugger_plugin.gd")
+const ClientConfigurator := preload("res://addons/godot_ai/client_configurator.gd")
+const WindowsPortReservation := preload("res://addons/godot_ai/utils/windows_port_reservation.gd")
 
 ## Handlers — preloaded as consts instead of registered via `class_name` so
 ## they don't pollute the project-wide global scope. A user project that
@@ -86,7 +88,7 @@ const ControlDrawRecipeHandler := preload("res://addons/godot_ai/handlers/contro
 ## Windows where `OS.kill` on the uvx launcher doesn't take the Python
 ## child with it, and the scrape was the only path to the real PID.
 ## See issue for #154-era Windows update friction.
-## Re-export of McpPortResolver.SERVER_PID_FILE so the spawn flags, the
+## Re-export of PortResolver.SERVER_PID_FILE so the spawn flags, the
 ## resolver, and characterization tests share one source of truth.
 const SERVER_PID_FILE := PortResolver.SERVER_PID_FILE
 
@@ -114,27 +116,34 @@ const STARTUP_TRACE_COUNTER_NAMES := [
 ## Untyped on purpose — see policy below. Type fences move to handler `_init`
 ## sites that take typed parameters.
 ##
-## Self-update parse-hazard policy: `plugin.gd` MUST NOT reference any
-## plugin-defined `class_name` (`Mcp*`) by name — neither as a type
-## annotation (`var x: McpFoo`) nor as a constructor (`McpFoo.new()`).
-## Both forms resolve through Godot's global class_name registry at parse
-## time. During an in-place self-update, `set_plugin_enabled(false)` re-
-## parses `plugin.gd` against the freshly-extracted addon tree before the
-## registry has scanned the new files; a reference to a class whose
-## inheritance or class_name siblings changed in the new release fails to
-## resolve, the plugin enters a degraded state, and the follow-up
-## `_exit_tree` cascade crashes (see #242, #244).
+## Self-update parse-hazard policy: plugin entry-load code MUST NOT
+## reference any plugin-defined `class_name` (`Mcp*`) by name — neither
+## as a type annotation (`var x: McpFoo`), nor as a constructor
+## (`McpFoo.new()`), nor as any other member access (`McpFoo.CONST`,
+## `McpFoo.static_method()`). Every form resolves through Godot's global
+## class_name registry at parse time. During an in-place self-update,
+## `set_plugin_enabled(false)` re-parses `plugin.gd` against the freshly-
+## extracted addon tree before the registry has scanned the new files; a
+## reference to a class whose inheritance or class_name siblings changed
+## in the new release fails to resolve, the plugin enters a degraded
+## state, and the follow-up `_exit_tree` cascade crashes (see #242,
+## #244). Static-var initializers are the most dangerous form because
+## they execute at script-load: `static var _x := McpFoo.BAR` aborts the
+## parse before `_enter_tree` runs.
 ##
 ## The mitigation is two-part:
 ##   (1) Field declarations are untyped (this block).
-##   (2) Constructor sites use script-local `const X := preload("res://...")`
-##       aliases declared at the top of the file (e.g. `Connection`,
-##       `Dispatcher`, `LogBuffer`, …). `preload(...)` resolves the script
-##       by path at script-load, never consulting the global registry, so
-##       the parse stays clean across releases regardless of how the
-##       referenced class's `extends` chain or sibling class_names change.
+##   (2) Every other reference site uses script-local
+##       `const X := preload("res://...")` aliases declared at the top of
+##       the file (e.g. `Connection`, `Dispatcher`, `LogBuffer`,
+##       `ClientConfigurator`, `WindowsPortReservation`, …) — for
+##       constructors, constants, and static methods alike. `preload(...)`
+##       resolves the script by path at script-load, never consulting the
+##       global registry, so the parse stays clean across releases
+##       regardless of how the referenced class's `extends` chain or
+##       sibling class_names change.
 ##
-## `tests/unit/test_plugin_self_update_safety.py` locks both halves in.
+## `tests/unit/test_plugin_self_update_safety.py` locks these forms in.
 ##
 ## `_editor_logger` was already untyped because its script extends Godot
 ## 4.5+'s Logger class and is loaded via `load()` so the plugin still parses
@@ -156,7 +165,7 @@ var _debugger_plugin
 ## `utils/server_lifecycle.gd`.
 var _lifecycle
 static var _server_started_this_session := false  # guard against re-entrant spawns
-static var _resolved_ws_port := McpClientConfigurator.DEFAULT_WS_PORT
+static var _resolved_ws_port := ClientConfigurator.DEFAULT_WS_PORT
 
 ## Server-watch timer lives on the plugin because it's a Node — the
 ## manager is RefCounted and can't host children.
@@ -189,7 +198,7 @@ func _enter_tree() -> void:
 	## Register port overrides before spawn so `http_port()` / `ws_port()`
 	## return the user's configured values (if any) when `_start_server`
 	## builds the CLI args.
-	McpClientConfigurator.ensure_settings_registered()
+	ClientConfigurator.ensure_settings_registered()
 	_startup_trace_phase("settings_registered")
 
 	_log_buffer = LogBuffer.new()
@@ -547,12 +556,12 @@ func _ensure_game_helper_autoload() -> void:
 
 
 func _startup_trace_begin() -> void:
-	_startup_trace_enabled = McpClientConfigurator.startup_trace_enabled()
+	_startup_trace_enabled = ClientConfigurator.startup_trace_enabled()
 	if not _startup_trace_enabled:
 		return
 	_startup_trace_start_ms = Time.get_ticks_msec()
 	_startup_trace_last_ms = _startup_trace_start_ms
-	_startup_trace_netsh_start_count = McpWindowsPortReservation.netsh_query_count()
+	_startup_trace_netsh_start_count = WindowsPortReservation.netsh_query_count()
 	_startup_trace_counters.clear()
 	for counter in STARTUP_TRACE_COUNTER_NAMES:
 		_startup_trace_counters[counter] = 0
@@ -560,8 +569,8 @@ func _startup_trace_begin() -> void:
 		"MCP startup trace | begin platform=%s http_port=%d ws_port=%d"
 		% [
 			OS.get_name(),
-			McpClientConfigurator.http_port(),
-			McpClientConfigurator.ws_port(),
+			ClientConfigurator.http_port(),
+			ClientConfigurator.ws_port(),
 		]
 	)
 
@@ -588,7 +597,7 @@ func _startup_trace_finish(path: String) -> void:
 		return
 	var now := Time.get_ticks_msec()
 	_startup_trace_counters["netsh"] = (
-		McpWindowsPortReservation.netsh_query_count() - _startup_trace_netsh_start_count
+		WindowsPortReservation.netsh_query_count() - _startup_trace_netsh_start_count
 	)
 	print(
 		"MCP startup trace | done path=%s total_ms=%d counters=%s"
@@ -861,7 +870,7 @@ func _check_server_health() -> void:
 func _should_retry_with_refresh() -> bool:
 	return _retry_with_refresh_allowed(
 		_lifecycle._refresh_retried,
-		McpClientConfigurator.get_server_launch_mode(),
+		ClientConfigurator.get_server_launch_mode(),
 		_read_pid_file(),
 	)
 
@@ -902,8 +911,8 @@ func _set_resolved_ws_port(port: int) -> void:
 
 func _resolve_ws_port() -> int:
 	return PortResolver.resolve_ws_port(
-		McpClientConfigurator.ws_port(),
-		McpClientConfigurator.MAX_PORT,
+		ClientConfigurator.ws_port(),
+		ClientConfigurator.MAX_PORT,
 		_log_buffer,
 	)
 
@@ -931,7 +940,7 @@ static func _resolve_ws_port_from_output(
 	return PortResolver.resolve_ws_port_from_output(
 		configured_port,
 		netsh_output,
-		McpClientConfigurator.MAX_PORT,
+		ClientConfigurator.MAX_PORT,
 		span,
 	)
 
@@ -1138,7 +1147,7 @@ static func _build_server_flags(port: int, ws_port: int) -> Array[String]:
 	## least one domain to drop. Skipping the empty case keeps spawns
 	## compatible with older (pre-1.4.2) servers that don't know the flag —
 	## relevant during staggered plugin/server upgrades in user-mode installs.
-	var excluded := McpClientConfigurator.excluded_domains()
+	var excluded := ClientConfigurator.excluded_domains()
 	if not excluded.is_empty():
 		flags.append("--exclude-domains")
 		flags.append(excluded)
@@ -1404,7 +1413,7 @@ func start_dev_server() -> void:
 	## worktree's Python. See #84.
 	_stop_server()
 	get_tree().create_timer(0.5).timeout.connect(func():
-		var server_cmd := McpClientConfigurator.get_server_command()
+		var server_cmd := ClientConfigurator.get_server_command()
 		if server_cmd.is_empty():
 			push_warning("MCP | could not find server command for dev server")
 			return
@@ -1415,12 +1424,12 @@ func start_dev_server() -> void:
 		inner_args.assign(server_cmd.slice(1))
 		inner_args.append_array([
 			"--transport", "streamable-http",
-			"--port", str(McpClientConfigurator.http_port()),
+			"--port", str(ClientConfigurator.http_port()),
 			"--ws-port", str(_resolved_ws_port),
 			"--reload",
 		])
 
-		var worktree_src := McpClientConfigurator.find_worktree_src_dir(ProjectSettings.globalize_path("res://"))
+		var worktree_src := ClientConfigurator.find_worktree_src_dir(ProjectSettings.globalize_path("res://"))
 		var prev_pythonpath := OS.get_environment("PYTHONPATH")
 		if not worktree_src.is_empty():
 			var sep := ";" if OS.get_name() == "Windows" else ":"
@@ -1455,7 +1464,7 @@ func stop_dev_server() -> void:
 		_stop_server()
 		return
 	var output: Array = []
-	var port := McpClientConfigurator.http_port()
+	var port := ClientConfigurator.http_port()
 	if OS.get_name() == "Windows":
 		var killed := _kill_processes_and_windows_spawn_children(_find_all_pids_on_port(port))
 		if not killed.is_empty():
@@ -1512,7 +1521,7 @@ func _find_windows_spawn_children(parent_pids: Array[int]) -> Array[int]:
 
 func is_dev_server_running() -> bool:
 	## Returns true if a server is running on the HTTP port that we didn't start as managed.
-	return _lifecycle.get_server_pid() <= 0 and _is_port_in_use(McpClientConfigurator.http_port())
+	return _lifecycle.get_server_pid() <= 0 and _is_port_in_use(ClientConfigurator.http_port())
 
 
 func has_managed_server() -> bool:

--- a/plugin/addons/godot_ai/utils/port_resolver.gd
+++ b/plugin/addons/godot_ai/utils/port_resolver.gd
@@ -9,6 +9,7 @@ extends RefCounted
 ## Canonical pid-file path. plugin.gd::SERVER_PID_FILE re-exports this so
 ## external readers and tests can use either name.
 const SERVER_PID_FILE := "user://godot_ai_server.pid"
+const WindowsPortReservation := preload("res://addons/godot_ai/utils/windows_port_reservation.gd")
 
 
 static func can_bind_local_port(port: int) -> bool:
@@ -264,7 +265,7 @@ static func wait_for_port_free(port: int, timeout_s: float) -> void:
 ## `log_buffer` is a duck-typed sink (`log(String)`) that gets the
 ## remap notice so users see why the port shifted.
 static func resolve_ws_port(configured: int, max_port: int, log_buffer = null) -> int:
-	var resolved := McpWindowsPortReservation.suggest_non_excluded_port(
+	var resolved := WindowsPortReservation.suggest_non_excluded_port(
 		configured,
 		2048,
 		max_port
@@ -301,7 +302,7 @@ static func resolve_ws_port_from_output(
 	max_port: int,
 	span: int = 2048
 ) -> int:
-	return McpWindowsPortReservation.suggest_non_excluded_port_from_output(
+	return WindowsPortReservation.suggest_non_excluded_port_from_output(
 		netsh_output,
 		configured_port,
 		span,

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -19,6 +19,9 @@ extends RefCounted
 var _host
 
 const UvCacheCleanup := preload("res://addons/godot_ai/utils/uv_cache_cleanup.gd")
+const ClientConfigurator := preload("res://addons/godot_ai/client_configurator.gd")
+const PortResolver := preload("res://addons/godot_ai/utils/port_resolver.gd")
+const WindowsPortReservation := preload("res://addons/godot_ai/utils/windows_port_reservation.gd")
 const McpServerStateScript := preload("res://addons/godot_ai/utils/mcp_server_state.gd")
 const McpStartupPathScript := preload("res://addons/godot_ai/utils/mcp_startup_path.gd")
 const McpAdoptionLabelScript := preload("res://addons/godot_ai/utils/mcp_adoption_label.gd")
@@ -198,7 +201,7 @@ func get_version_check():
 func _resolve_expected_version(supplied: String) -> String:
 	if not supplied.is_empty():
 		return supplied
-	return McpClientConfigurator.get_plugin_version()
+	return ClientConfigurator.get_plugin_version()
 
 
 ## Called by McpServerVersionCheck when handshake_ack carries a version
@@ -208,10 +211,10 @@ func handle_server_version_verified(expected_version: String, version: String) -
 	_server_actual_version = version
 	var expected := _resolve_expected_version(expected_version)
 	_server_expected_version = expected
-	var compatibility := McpServerLifecycleManager._server_version_compatibility(
+	var compatibility := _server_version_compatibility(
 		version,
 		expected,
-		McpClientConfigurator.is_dev_checkout()
+		ClientConfigurator.is_dev_checkout()
 	)
 	if compatibility.get("compatible", false):
 		_can_recover_incompatible = false
@@ -230,7 +233,7 @@ func handle_server_version_verified(expected_version: String, version: String) -
 		_host._update_process_enabled()
 		return
 	var live := {"version": version, "status_code": 200, "name": "godot-ai"}
-	_set_incompatible_server(live, expected, McpClientConfigurator.http_port())
+	_set_incompatible_server(live, expected, ClientConfigurator.http_port())
 	if _host._connection != null:
 		_host._connection.connect_blocked = true
 		_host._connection.connect_block_reason = _server_status_message
@@ -242,7 +245,7 @@ func handle_server_version_unverified(expected_version: String) -> void:
 	var expected := _resolve_expected_version(expected_version)
 	_server_expected_version = expected
 	var live := {"version": "", "status_code": 0, "error": "missing_handshake_ack"}
-	_set_incompatible_server(live, expected, McpClientConfigurator.http_port())
+	_set_incompatible_server(live, expected, ClientConfigurator.http_port())
 	if _host._connection != null:
 		_host._connection.connect_blocked = true
 		_host._connection.connect_block_reason = _server_status_message
@@ -377,16 +380,16 @@ func start_server() -> void:
 
 	_refresh_retried = false
 
-	var port := McpClientConfigurator.http_port()
-	var ws_port := McpClientConfigurator.ws_port()
-	var current_version := McpClientConfigurator.get_plugin_version()
+	var port := ClientConfigurator.http_port()
+	var ws_port := ClientConfigurator.ws_port()
+	var current_version := ClientConfigurator.get_plugin_version()
 	_server_expected_version = current_version
 
 	if bool(_host._is_port_in_use(port)):
 		var record: Dictionary = _host._read_managed_server_record()
 		var record_version := str(record.get("version", ""))
 		var record_ws_port := int(record.get("ws_port", 0))
-		_host._set_resolved_ws_port(McpPortResolver.resolved_ws_port_for_existing_server(
+		_host._set_resolved_ws_port(PortResolver.resolved_ws_port_for_existing_server(
 			record_ws_port,
 			record_version,
 			current_version,
@@ -401,7 +404,7 @@ func start_server() -> void:
 			current_version,
 			live_ws_port,
 			ws_port,
-			McpClientConfigurator.is_dev_checkout()
+			ClientConfigurator.is_dev_checkout()
 		)
 		if compatibility.get("compatible", false):
 			_server_actual_name = "godot-ai"
@@ -446,7 +449,7 @@ func start_server() -> void:
 	ws_port = _host._resolved_ws_port
 
 	_host._startup_trace_count("server_command_discovery")
-	var server_cmd := McpClientConfigurator.get_server_command()
+	var server_cmd := ClientConfigurator.get_server_command()
 	if server_cmd.is_empty():
 		set_terminal_diagnosis(McpServerStateScript.NO_COMMAND)
 		_startup_path = McpStartupPathScript.NO_COMMAND
@@ -465,7 +468,7 @@ func start_server() -> void:
 	## Proactive Windows port-reservation check (#146) — bind would
 	## fail silently with WinError 10013 inside a Hyper-V / WSL2 /
 	## Docker exclusion range; netstat shows nothing.
-	if McpWindowsPortReservation.is_port_excluded(port):
+	if WindowsPortReservation.is_port_excluded(port):
 		_host._server_started_this_session = true
 		set_terminal_diagnosis(McpServerStateScript.PORT_EXCLUDED)
 		_startup_path = McpStartupPathScript.RESERVED
@@ -500,11 +503,11 @@ func check_server_health() -> void:
 		_host._stop_server_watch()
 		return
 	var elapsed := Time.get_ticks_msec() - int(_server_spawn_ms)
-	var real_pid := McpPortResolver.read_pid_file()
+	var real_pid := PortResolver.read_pid_file()
 	var spawn_pid := int(_server_pid)
-	if real_pid > 0 and real_pid != spawn_pid and McpPortResolver.pid_alive(real_pid):
+	if real_pid > 0 and real_pid != spawn_pid and PortResolver.pid_alive(real_pid):
 		_server_pid = real_pid
-	elif not McpPortResolver.pid_alive(spawn_pid):
+	elif not PortResolver.pid_alive(spawn_pid):
 		if elapsed >= int(_host.SPAWN_GRACE_MS) and not McpServerStateScript.is_terminal_diagnosis(_server_state):
 			if bool(_host._should_retry_with_refresh()):
 				_refresh_retried = true
@@ -526,13 +529,13 @@ func check_server_health() -> void:
 ## fresh publish ~10 min — #172). One-shot per session via _refresh_retried.
 func respawn_with_refresh() -> void:
 	_host._startup_trace_count("server_command_discovery")
-	var server_cmd := McpClientConfigurator.get_server_command(true)
+	var server_cmd := ClientConfigurator.get_server_command(true)
 	if server_cmd.is_empty():
 		return
 	var cmd: String = server_cmd[0]
 	var args: Array[String] = []
 	args.assign(server_cmd.slice(1))
-	args.append_array(_host._build_server_flags(McpClientConfigurator.http_port(), int(_host._resolved_ws_port)))
+	args.append_array(_host._build_server_flags(ClientConfigurator.http_port(), int(_host._resolved_ws_port)))
 	_host._clear_pid_file()
 	_host._log_buffer.log("retrying with --refresh (PyPI index may be stale)")
 	_server_pid = OS.create_process(cmd, args)
@@ -540,7 +543,7 @@ func respawn_with_refresh() -> void:
 	if spawn_pid > 0:
 		_server_spawn_ms = Time.get_ticks_msec()
 		_server_exit_ms = 0
-		var current_version := McpClientConfigurator.get_plugin_version()
+		var current_version := ClientConfigurator.get_plugin_version()
 		_host._write_managed_server_record(spawn_pid, current_version)
 		print("MCP | retried server (PID %d, v%s): %s %s" % [spawn_pid, current_version, cmd, " ".join(args)])
 	else:
@@ -622,7 +625,7 @@ func stop_server() -> void:
 	## Kill the tracked PID AND the real Python PID — they differ for the
 	## uvx tier (the launcher exits before its child) and on Windows
 	## `OS.kill` is `TerminateProcess` which doesn't walk the child tree.
-	var port := McpClientConfigurator.http_port()
+	var port := ClientConfigurator.http_port()
 	var killed: Array = []
 	var candidates: Array[int] = [int(_server_pid)]
 	var real_pid := int(_host._find_managed_pid(port))
@@ -651,10 +654,10 @@ func stop_server() -> void:
 func prepare_for_update_reload() -> void:
 	stop_server()
 	_host._server_started_this_session = false
-	if McpClientConfigurator.is_dev_checkout():
+	if ClientConfigurator.is_dev_checkout():
 		return
 
-	var port := McpClientConfigurator.http_port()
+	var port := ClientConfigurator.http_port()
 	if not bool(_host._is_port_in_use(port)):
 		return
 
@@ -680,7 +683,7 @@ func prepare_for_update_reload() -> void:
 func can_recover_incompatible_server() -> bool:
 	if _server_state != McpServerStateScript.INCOMPATIBLE:
 		return false
-	var port := McpClientConfigurator.http_port()
+	var port := ClientConfigurator.http_port()
 	if not bool(_host._is_port_in_use(port)):
 		return false
 	var proof: Dictionary = _host._evaluate_recovery_port_occupant_proof(port)
@@ -691,7 +694,7 @@ func recover_incompatible_server() -> bool:
 	if _server_state != McpServerStateScript.INCOMPATIBLE:
 		return false
 
-	var port := McpClientConfigurator.http_port()
+	var port := ClientConfigurator.http_port()
 	var proof: Dictionary = _host._evaluate_recovery_port_occupant_proof(port)
 	var targets: Array[int] = []
 	targets.assign(proof.get("pids", []))
@@ -758,9 +761,9 @@ func reset_for_force_restart() -> void:
 func force_restart_server() -> void:
 	if not can_restart_managed_server():
 		push_warning("MCP | refusing to kill server on port %d without managed-server ownership proof"
-			% McpClientConfigurator.http_port())
+			% ClientConfigurator.http_port())
 		return
-	var port := McpClientConfigurator.http_port()
+	var port := ClientConfigurator.http_port()
 	## Kill every LISTENER on the port, not just the first one. A dev
 	## server run via `uvicorn --reload` owns port 8000 through both a
 	## reloader parent AND a worker child — killing only one (or zero,
@@ -775,7 +778,7 @@ func force_restart_server() -> void:
 		transition_state(McpServerStateScript.UNINITIALIZED)
 		_set_incompatible_server(
 			_host._probe_live_server_status_for_port(port),
-			McpClientConfigurator.get_plugin_version(),
+			ClientConfigurator.get_plugin_version(),
 			port
 		)
 		return

--- a/plugin/addons/godot_ai/utils/update_manager.gd
+++ b/plugin/addons/godot_ai/utils/update_manager.gd
@@ -22,6 +22,7 @@ const RELEASES_URL := (
 const RELEASES_PAGE := "https://github.com/hi-godot/godot-ai/releases/latest"
 const UPDATE_TEMP_DIR := "user://godot_ai_update/"
 const UPDATE_TEMP_ZIP := "user://godot_ai_update/update.zip"
+const ClientConfigurator := preload("res://addons/godot_ai/client_configurator.gd")
 
 ## Emitted after `check_for_updates()` resolves a newer remote version.
 ## Payload mirrors the Dictionary returned by `parse_releases_response`:
@@ -69,7 +70,7 @@ func setup(plugin, dock) -> void:
 ## `_install_zip` still gates on the physical symlink check so a forced-
 ## user mode can never clobber source.
 func check_for_updates() -> void:
-	if McpClientConfigurator.is_dev_checkout():
+	if ClientConfigurator.is_dev_checkout():
 		return
 	if _http_request == null:
 		_http_request = HTTPRequest.new()
@@ -169,7 +170,7 @@ static func parse_releases_response(
 	if tag.is_empty():
 		return out
 	var remote_version := tag.trim_prefix("v")
-	var local_version := McpClientConfigurator.get_plugin_version()
+	var local_version := ClientConfigurator.get_plugin_version()
 	if not _is_newer(remote_version, local_version):
 		return out
 
@@ -181,7 +182,7 @@ static func parse_releases_response(
 			url = String(asset_dict.get("browser_download_url", ""))
 			break
 
-	var forced := McpClientConfigurator.mode_override() == "user"
+	var forced := ClientConfigurator.mode_override() == "user"
 	var label_text := "Update available: v%s" % remote_version
 	if forced:
 		## Forced-user mode (dropdown or env) is the only way the banner
@@ -253,7 +254,7 @@ func _install_zip() -> void:
 	## Symlinked addons dir means an extract would clobber canonical
 	## `plugin/` source through the link. Symlink detection is independent
 	## of the mode override: even forced-user aborts here. See #116.
-	if McpClientConfigurator.addons_dir_is_symlink():
+	if ClientConfigurator.addons_dir_is_symlink():
 		install_state_changed.emit({
 			"button_text": "Dev checkout — update via git",
 			"button_disabled": true,

--- a/tests/unit/test_plugin_self_update_safety.py
+++ b/tests/unit/test_plugin_self_update_safety.py
@@ -1,4 +1,4 @@
-"""Lock the self-update parse-hazard policy on plugin entry-load scripts.
+"""Lock the self-update parse-hazard policy on targeted plugin-load scripts.
 
 Issue #242 surfaced as `v2.1.1 → v2.1.2` SIGABRT during in-place self-update:
 v2.1.2's `plugin.gd` declared `var _editor_log_buffer: EditorLogBuffer` —
@@ -9,7 +9,7 @@ registered in the global table → `plugin.gd` parse fails → plugin enters
 a degraded state → the follow-up `_exit_tree` cascade crashes.
 
 Issue #244 is the defense-in-depth follow-up: any name reference from
-plugin entry-load code to a plugin-defined `Mcp*` class is the same
+plugin load-path code to a plugin-defined `Mcp*` class is the same
 latent hazard. The hazard has three syntactic forms, all of which
 resolve through the global class_name registry at parse time:
 
@@ -25,7 +25,7 @@ stable, a future refactor that changes one class's `extends` chain or
 adds a sibling class_name file re-trips the bug — and review won't
 catch it because the named references *look* idiomatic.
 
-The structurally correct answer is "entry-load code does NOT name
+The structurally correct answer is "plugin load-path code does NOT name
 plugin classes directly." Field types fall through to the runtime
 parameter checks at handler `_init` sites that take typed parameters
 (see e.g. `McpEditorHandler._init`'s typed
@@ -38,9 +38,11 @@ Constructors, constants, and static methods go through script-local
 at script-load and never consults the registry.
 
 This test enforces the existing typed-var / constructor policy on
-`plugin.gd`, and the new member-access policy on the beta entry-load
-surface touched by the PR #309 adaptation. Offenders fail with a
-paste-over-ready list.
+`plugin.gd`, and the new constructor / member-access policy on the
+targeted beta load surface touched by the PR #309 adaptation. It does
+not claim the full transitive `plugin.gd` preload graph is clean yet;
+that broader cleanup belongs with the ongoing #297 decomposition work.
+Offenders fail with a paste-over-ready list.
 """
 
 from __future__ import annotations
@@ -53,12 +55,10 @@ PLUGIN_ROOT = REPO_ROOT / "plugin" / "addons" / "godot_ai"
 PLUGIN_GD = PLUGIN_ROOT / "plugin.gd"
 
 # Beta #297 moved plugin-owned startup/update work into these scripts.
-# They are parsed on the plugin-load path before the self-update scan can
-# refresh the global class_name registry, so the direct `McpFoo.member`
-# hazard is locked here alongside plugin.gd. This is intentionally the
-# targeted PR #309 adaptation surface, not a broad cleanup of every dock,
-# handler, or client strategy reference in the addon.
-ENTRY_LOAD_MEMBER_ACCESS_FILES = (
+# This is intentionally the targeted PR #309 adaptation surface, not a
+# broad cleanup of every direct/transitive preload such as the dock,
+# handlers, connection, or client strategy scripts.
+TARGETED_LOAD_SURFACE_FILES = (
     PLUGIN_GD,
     PLUGIN_ROOT / "utils" / "server_lifecycle.gd",
     PLUGIN_ROOT / "utils" / "port_resolver.gd",
@@ -152,22 +152,55 @@ def test_plugin_gd_does_not_construct_via_class_name() -> None:
     )
 
 
-def test_entry_load_scripts_do_not_access_members_via_class_name() -> None:
-    """Entry-load scripts must not access `McpFoo.X` directly.
+def test_targeted_load_scripts_do_not_construct_via_class_name() -> None:
+    """Targeted load-path scripts must not call `McpFoo.new(...)`.
+
+    The existing constructor test predates the beta #297 extractions and
+    only scans `plugin.gd`. Keep the same guard on the manager scripts
+    this PR touches so future changes do not reintroduce constructor
+    lookups into the targeted startup/update surface.
+    """
+
+    mcp_classes = _registered_mcp_class_names()
+    constructor = re.compile(r"\b(Mcp\w+)\.new\s*\(")
+    offenders: list[str] = []
+
+    for gd_file in TARGETED_LOAD_SURFACE_FILES:
+        source = _strip_gdscript_comments(gd_file.read_text())
+        for match in constructor.finditer(source):
+            type_name = match.group(1)
+            if type_name not in mcp_classes:
+                continue
+            line_no = source.count("\n", 0, match.start()) + 1
+            rel_path = gd_file.relative_to(REPO_ROOT)
+            offenders.append(f"{rel_path}:{line_no}: {type_name}.new")
+
+    assert not offenders, (
+        "Targeted load-path scripts must not invoke plugin-class "
+        "constructors by class_name (self-update parse hazard, issues "
+        "#242 / #244). Add a script-local "
+        '`const Foo := preload("res://addons/godot_ai/...")` alias and '
+        "call `Foo.new(...)` instead. Offending references: "
+        f"{sorted(set(offenders))}"
+    )
+
+
+def test_targeted_load_scripts_do_not_access_members_via_class_name() -> None:
+    """Targeted load-path scripts must not access `McpFoo.X` directly.
 
     This is the third syntactic form of the parse hazard. Identifier
     resolution for `McpFoo` happens at parse time even when only its
     members are used, so `McpFoo.SOME_CONST` and
     `McpFoo.static_method()` must route through script-local
     `preload(...)` aliases. `McpFoo.new()` is skipped here because the
-    existing constructor test owns that offender list for `plugin.gd`.
+    targeted constructor test owns that offender list.
     """
 
     mcp_classes = _registered_mcp_class_names()
     member_access = re.compile(r"\b(Mcp\w+)\.(\w+)")
     offenders: list[str] = []
 
-    for gd_file in ENTRY_LOAD_MEMBER_ACCESS_FILES:
+    for gd_file in TARGETED_LOAD_SURFACE_FILES:
         source = _strip_gdscript_comments(gd_file.read_text())
         for match in member_access.finditer(source):
             type_name, member = match.group(1), match.group(2)
@@ -180,10 +213,11 @@ def test_entry_load_scripts_do_not_access_members_via_class_name() -> None:
             offenders.append(f"{rel_path}:{line_no}: {type_name}.{member}")
 
     assert not offenders, (
-        "Entry-load scripts must not access plugin-class constants or "
-        "static methods via class_name (self-update parse hazard, issues "
-        "#242 / #244). Static-var initializers are the most dangerous "
-        "form: a failed lookup aborts the parse before _enter_tree. Add a "
+        "Targeted load-path scripts must not access plugin-class "
+        "constants or static methods via class_name (self-update parse "
+        "hazard, issues #242 / #244). Static-var initializers are the "
+        "most dangerous form: a failed lookup aborts the parse before "
+        "_enter_tree. Add a "
         'script-local `const Foo := preload("res://addons/godot_ai/...")` '
         "alias and call `Foo.X` instead. Offending references: "
         f"{sorted(set(offenders))}"

--- a/tests/unit/test_plugin_self_update_safety.py
+++ b/tests/unit/test_plugin_self_update_safety.py
@@ -1,4 +1,4 @@
-"""Lock the self-update parse-hazard policy on `plugin.gd`.
+"""Lock the self-update parse-hazard policy on plugin entry-load scripts.
 
 Issue #242 surfaced as `v2.1.1 → v2.1.2` SIGABRT during in-place self-update:
 v2.1.2's `plugin.gd` declared `var _editor_log_buffer: EditorLogBuffer` —
@@ -9,29 +9,38 @@ registered in the global table → `plugin.gd` parse fails → plugin enters
 a degraded state → the follow-up `_exit_tree` cascade crashes.
 
 Issue #244 is the defense-in-depth follow-up: any name reference from
-`plugin.gd` to a plugin-defined `Mcp*` class is the same latent hazard,
-in either form — `var x: McpFoo` (typed-var) or `McpFoo.new()` (named
-constructor). Both resolve through the global class_name registry at
-parse time. Even if today's inheritance is stable, a future refactor
-that changes one class's `extends` chain or adds a sibling class_name
-file re-trips the bug — and review won't catch it because the named
-references *look* idiomatic.
+plugin entry-load code to a plugin-defined `Mcp*` class is the same
+latent hazard. The hazard has three syntactic forms, all of which
+resolve through the global class_name registry at parse time:
 
-The structurally correct answer is "`plugin.gd` does NOT name plugin
-classes — neither for types nor for instantiation." Field types fall
-through to the runtime parameter checks at handler `_init` sites that
-take typed parameters (see e.g. `McpEditorHandler._init`'s typed
+    var x: McpFoo                  # typed-var
+    McpFoo.new()                   # constructor
+    McpFoo.SOME_CONST              # constant / static-method access
+
+The third form is especially risky in a static-var initializer:
+`static var _x := McpFoo.BAR` runs at script-load, so a failed lookup
+aborts the parse before `_enter_tree` runs and surfaces as Godot's
+"Unable to load addon script" warning. Even if today's inheritance is
+stable, a future refactor that changes one class's `extends` chain or
+adds a sibling class_name file re-trips the bug — and review won't
+catch it because the named references *look* idiomatic.
+
+The structurally correct answer is "entry-load code does NOT name
+plugin classes directly." Field types fall through to the runtime
+parameter checks at handler `_init` sites that take typed parameters
+(see e.g. `McpEditorHandler._init`'s typed
 `editor_log_buffer: McpEditorLogBuffer` parameter — the type fence still
 fires, just at the call site at runtime, not at `plugin.gd`'s parse).
-Constructors go through script-local `const X := preload("res://...")`
-aliases declared at the top of `plugin.gd` (e.g. `Connection`,
-`Dispatcher`, `LogBuffer`); `preload(...)` resolves the script by path
+Constructors, constants, and static methods go through script-local
+`const X := preload("res://...")` aliases (e.g. `Connection`,
+`Dispatcher`, `LogBuffer`, `ClientConfigurator`,
+`WindowsPortReservation`); `preload(...)` resolves the script by path
 at script-load and never consults the registry.
 
-This test enforces both halves of the policy. Adding either
-`var _foo: McpAnything` or a literal `McpAnything.new()` call to
-`plugin.gd` will fail here with a paste-over-ready offender list so the
-next contributor doesn't silently re-introduce the hazard.
+This test enforces the existing typed-var / constructor policy on
+`plugin.gd`, and the new member-access policy on the beta entry-load
+surface touched by the PR #309 adaptation. Offenders fail with a
+paste-over-ready list.
 """
 
 from __future__ import annotations
@@ -39,8 +48,22 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-PLUGIN_ROOT = Path(__file__).resolve().parents[2] / "plugin" / "addons" / "godot_ai"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_ROOT = REPO_ROOT / "plugin" / "addons" / "godot_ai"
 PLUGIN_GD = PLUGIN_ROOT / "plugin.gd"
+
+# Beta #297 moved plugin-owned startup/update work into these scripts.
+# They are parsed on the plugin-load path before the self-update scan can
+# refresh the global class_name registry, so the direct `McpFoo.member`
+# hazard is locked here alongside plugin.gd. This is intentionally the
+# targeted PR #309 adaptation surface, not a broad cleanup of every dock,
+# handler, or client strategy reference in the addon.
+ENTRY_LOAD_MEMBER_ACCESS_FILES = (
+    PLUGIN_GD,
+    PLUGIN_ROOT / "utils" / "server_lifecycle.gd",
+    PLUGIN_ROOT / "utils" / "port_resolver.gd",
+    PLUGIN_ROOT / "utils" / "update_manager.gd",
+)
 
 
 def _registered_mcp_class_names() -> set[str]:
@@ -129,12 +152,51 @@ def test_plugin_gd_does_not_construct_via_class_name() -> None:
     )
 
 
+def test_entry_load_scripts_do_not_access_members_via_class_name() -> None:
+    """Entry-load scripts must not access `McpFoo.X` directly.
+
+    This is the third syntactic form of the parse hazard. Identifier
+    resolution for `McpFoo` happens at parse time even when only its
+    members are used, so `McpFoo.SOME_CONST` and
+    `McpFoo.static_method()` must route through script-local
+    `preload(...)` aliases. `McpFoo.new()` is skipped here because the
+    existing constructor test owns that offender list for `plugin.gd`.
+    """
+
+    mcp_classes = _registered_mcp_class_names()
+    member_access = re.compile(r"\b(Mcp\w+)\.(\w+)")
+    offenders: list[str] = []
+
+    for gd_file in ENTRY_LOAD_MEMBER_ACCESS_FILES:
+        source = _strip_gdscript_comments(gd_file.read_text())
+        for match in member_access.finditer(source):
+            type_name, member = match.group(1), match.group(2)
+            if type_name not in mcp_classes:
+                continue
+            if member == "new":
+                continue
+            line_no = source.count("\n", 0, match.start()) + 1
+            rel_path = gd_file.relative_to(REPO_ROOT)
+            offenders.append(f"{rel_path}:{line_no}: {type_name}.{member}")
+
+    assert not offenders, (
+        "Entry-load scripts must not access plugin-class constants or "
+        "static methods via class_name (self-update parse hazard, issues "
+        "#242 / #244). Static-var initializers are the most dangerous "
+        "form: a failed lookup aborts the parse before _enter_tree. Add a "
+        'script-local `const Foo := preload("res://addons/godot_ai/...")` '
+        "alias and call `Foo.X` instead. Offending references: "
+        f"{sorted(set(offenders))}"
+    )
+
+
 def test_plugin_gd_documents_the_untyped_policy() -> None:
     """The policy comment must stay near the field declarations.
 
-    A future contributor must understand WHY the fields are untyped (and
-    why constructors go through preload-aliased consts) or they will
-    "fix" the apparent oversight and re-introduce the hazard.
+    A future contributor must understand WHY the fields are untyped and
+    why constructors/constants/static methods go through preload-aliased
+    consts, or they will "fix" the apparent oversight and re-introduce
+    the hazard.
     """
 
     source = PLUGIN_GD.read_text()
@@ -149,8 +211,14 @@ def test_plugin_gd_documents_the_untyped_policy() -> None:
         "future readers can find the full context."
     )
     assert "preload" in source.lower(), (
-        "The policy comment must explain that constructors go through "
+        "The policy comment must explain that direct references go through "
         "preload-aliased consts — without that half, a future contributor "
-        "may untype a field but still write `McpFoo.new()`, leaving the "
-        "parse-time class_name lookup in place."
+        "may untype a field but still write `McpFoo.new()` or "
+        "`McpFoo.CONST`, leaving the parse-time class_name lookup in place."
+    )
+    assert "static-var" in source.lower() or "static var" in source.lower(), (
+        "The policy comment must call out static-var initializers as the "
+        "worst case, so a future contributor doesn't add "
+        "`static var _x := McpFoo.BAR` and reproduce the load-time parse "
+        "failure."
     )


### PR DESCRIPTION
## Summary

Supersedes and adapts #309 for the `beta` branch. #309 is conceptually still correct, but it targets `main` and predates the #297 beta refactors from #307, #308, and #310.

This keeps the current beta state model intact (`McpServerState`, `McpServerLifecycleManager`, and the new `McpUpdateManager`) and does not resurrect `McpSpawnState`.

## Changes

- Added script-local preload aliases for plugin entry-load code that needs static constants or methods from plugin-defined `class_name Mcp*` scripts.
- Replaced executable direct `McpClientConfigurator.*`, `McpWindowsPortReservation.*`, and beta manager-scope `McpPortResolver.*` references in the targeted load surface with aliases.
- Covered the beta entry-load manager surface now involved in plugin load/update paths: `plugin.gd`, `server_lifecycle.gd`, `port_resolver.gd`, and `update_manager.gd`.
- Updated `tests/unit/test_plugin_self_update_safety.py` to document the third parse-hazard form, `McpFoo.<member>`, and fail on direct member access for registered plugin `class_name McpFoo` while leaving `McpFoo.new()` to the existing constructor test.

## Why

During self-update, Godot can parse plugin entry-load scripts before the refreshed addon tree has been scanned into the global `class_name` registry. Direct dotted references like `McpFoo.CONST`, `McpFoo.static_method()`, or `static var _x := McpFoo.BAR` can therefore fail at parse/script-load time the same way typed fields and direct constructors did.

## Validation

- `pytest -q tests/unit/test_plugin_self_update_safety.py`
- `pytest -q tests/unit/test_dock_cli_timeout.py tests/unit/test_editor_focus_refocus.py tests/unit/test_self_update_orphan_recovery.py tests/unit/test_self_update_smoke_harness.py`
- `script/ci-check-gdscript`
- `rg 'Mcp(ClientConfigurator|WindowsPortReservation)\.' plugin/addons/godot_ai/plugin.gd plugin/addons/godot_ai/utils/server_lifecycle.gd plugin/addons/godot_ai/utils/port_resolver.gd` returned no matches.
