### PR TITLE
PR 10: Narrow meta-tool JSON coercion

### DIFF
--- a/src/godot_ai/tools/_meta_tool.py
+++ b/src/godot_ai/tools/_meta_tool.py
@@ -22,8 +22,9 @@ from __future__ import annotations
 import difflib
 import inspect
 import json
-from collections.abc import Awaitable, Callable
-from typing import Any, Literal
+from collections.abc import Awaitable, Callable, Mapping, MutableMapping, MutableSequence, Sequence
+from types import UnionType
+from typing import Annotated, Any, Literal, Union, get_args, get_origin, get_type_hints
 
 from fastmcp import Context, FastMCP
 
@@ -102,41 +103,140 @@ def register_manage_tool(
     mcp.tool(meta=DEFER_META)(manage)
 
 
-def _coerce_stringified_json_values(params: dict[str, Any]) -> dict[str, Any]:
-    """JSON-decode string values that look like ``[...]`` / ``{...}``.
+def _json_container_prefix(value: str) -> str:
+    stripped = value.lstrip()
+    prefix = stripped[:1]
+    return prefix if prefix in ("[", "{") else ""
 
-    Narrower scope than ``godot_ai.tools.JsonCoerced``: that pydantic
-    validator runs on every typed param regardless of shape, while this
-    function gates on the value's first non-whitespace char. The narrowing
-    is intentional — at the meta-tool layer ``params`` values are untyped,
-    and naive JSON-decoding of every string would mangle plain-string
-    args like a class name (``"BoxMesh"``) into something else.
 
-    Some MCP clients (Claude Code as of 2026-04) stringify complex-typed
-    arguments before sending; without this coercion a list-typed handler
-    arg arrives as ``str`` and the handler errors.
+def _json_container_kinds(annotation: Any) -> set[str]:
+    """Return container kinds accepted by a handler annotation."""
+    if annotation in (inspect.Parameter.empty, Any, object):
+        return set()
 
-    Returns ``params`` unchanged when nothing needs coercion (the common
-    case) so the dispatcher avoids a needless dict copy.
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+    if origin is Annotated:
+        return _json_container_kinds(args[0]) if args else set()
+    if origin in (Union, UnionType):
+        kinds: set[str] = set()
+        for arg in args:
+            if arg is type(None):
+                continue
+            kinds.update(_json_container_kinds(arg))
+        return kinds
+
+    target = origin or annotation
+    if target in (dict, Mapping, MutableMapping):
+        return {"dict"}
+    if target in (list, tuple, Sequence, MutableSequence):
+        return {"list"}
+    return set()
+
+
+def _handler_type_hints(handler: OpHandler) -> dict[str, Any]:
+    try:
+        return get_type_hints(handler)
+    except (NameError, TypeError, ValueError):
+        return {}
+
+
+def _expected_json_label(kinds: set[str]) -> str:
+    if kinds == {"list"}:
+        return "JSON array"
+    if kinds == {"dict"}:
+        return "JSON object"
+    return "JSON array or object"
+
+
+def _json_kind(value: Any) -> str:
+    if isinstance(value, list):
+        return "list"
+    if isinstance(value, dict):
+        return "dict"
+    return type(value).__name__
+
+
+def _coerce_stringified_json_values(
+    params: dict[str, Any],
+    *,
+    handler: OpHandler,
+    tool_name: str,
+    op: str,
+) -> dict[str, Any]:
+    """JSON-decode nested params only when the handler annotation expects it.
+
+    Some MCP clients stringify complex nested arguments before sending them
+    inside a manage tool's ``params`` object. Decode those compatibility
+    strings for list/dict-like handler params, but keep JSON-shaped strings
+    intact for string-typed params and leave missing/extra-argument errors to
+    the handler call below.
+
+    Returns ``params`` unchanged when nothing needs coercion (the common case).
     """
-    needs_coercion = False
-    for val in params.values():
-        if isinstance(val, str) and val[:1] in ("[", "{"):
-            needs_coercion = True
-            break
-    if not needs_coercion:
+    try:
+        signature = inspect.signature(handler)
+    except (TypeError, ValueError):
         return params
 
-    coerced: dict[str, Any] = {}
+    type_hints = _handler_type_hints(handler)
+    coerced: dict[str, Any] | None = None
+
     for key, val in params.items():
-        if isinstance(val, str) and val[:1] in ("[", "{"):
-            try:
-                coerced[key] = json.loads(val)
-                continue
-            except json.JSONDecodeError:
-                pass
-        coerced[key] = val
-    return coerced
+        if not isinstance(val, str) or not _json_container_prefix(val):
+            continue
+
+        parameter = signature.parameters.get(key)
+        if parameter is None:
+            continue
+
+        annotation = type_hints.get(key, parameter.annotation)
+        expected_kinds = _json_container_kinds(annotation)
+        if not expected_kinds:
+            continue
+
+        try:
+            decoded = json.loads(val)
+        except json.JSONDecodeError as exc:
+            expected = _expected_json_label(expected_kinds)
+            raise GodotCommandError(
+                code=ErrorCode.INVALID_PARAMS,
+                message=(
+                    f"{tool_name}.{op}: param {key!r} expects {expected}; "
+                    "received malformed JSON string"
+                ),
+                data={
+                    "tool": tool_name,
+                    "op": op,
+                    "param": key,
+                    "expected": expected,
+                    "json_error": exc.msg,
+                },
+            ) from exc
+
+        actual_kind = _json_kind(decoded)
+        if actual_kind not in expected_kinds:
+            expected = _expected_json_label(expected_kinds)
+            raise GodotCommandError(
+                code=ErrorCode.INVALID_PARAMS,
+                message=(
+                    f"{tool_name}.{op}: param {key!r} expects {expected}; "
+                    f"received JSON {actual_kind}"
+                ),
+                data={
+                    "tool": tool_name,
+                    "op": op,
+                    "param": key,
+                    "expected": expected,
+                    "actual": actual_kind,
+                },
+            )
+
+        if coerced is None:
+            coerced = dict(params)
+        coerced[key] = decoded
+
+    return params if coerced is None else coerced
 
 
 async def dispatch_manage_op(
@@ -181,7 +281,12 @@ async def dispatch_manage_op(
             data={"tool": tool_name, "op": op, "type": type(call_params).__name__},
         )
 
-    call_params = _coerce_stringified_json_values(call_params)
+    call_params = _coerce_stringified_json_values(
+        call_params,
+        handler=handler,
+        tool_name=tool_name,
+        op=op,
+    )
 
     try:
         result = handler(runtime, **call_params)

--- a/src/godot_ai/tools/_meta_tool.py
+++ b/src/godot_ai/tools/_meta_tool.py
@@ -20,6 +20,7 @@ domain registrations stay free of identity-lambda boilerplate.
 from __future__ import annotations
 
 import difflib
+import functools
 import inspect
 import json
 from collections.abc import Awaitable, Callable, Mapping, MutableMapping, MutableSequence, Sequence
@@ -103,14 +104,18 @@ def register_manage_tool(
     mcp.tool(meta=DEFER_META)(manage)
 
 
-def _json_container_prefix(value: str) -> str:
-    stripped = value.lstrip()
-    prefix = stripped[:1]
-    return prefix if prefix in ("[", "{") else ""
+def _is_json_shaped(value: str) -> bool:
+    return value.lstrip()[:1] in ("[", "{")
 
 
 def _json_container_kinds(annotation: Any) -> set[str]:
-    """Return container kinds accepted by a handler annotation."""
+    """Return container kinds accepted by a handler annotation.
+
+    An empty set means "do not coerce" — including unannotated, ``Any``, and
+    ``object`` params. This is intentional: pre-PR behavior eagerly decoded
+    every JSON-shaped string, which mangled legitimate values; post-PR we
+    only decode when the handler explicitly declares list/dict shape.
+    """
     if annotation in (inspect.Parameter.empty, Any, object):
         return set()
 
@@ -129,16 +134,29 @@ def _json_container_kinds(annotation: Any) -> set[str]:
     target = origin or annotation
     if target in (dict, Mapping, MutableMapping):
         return {"dict"}
-    if target in (list, tuple, Sequence, MutableSequence):
+    if target in (list, Sequence, MutableSequence):
         return {"list"}
     return set()
 
 
-def _handler_type_hints(handler: OpHandler) -> dict[str, Any]:
+@functools.cache
+def _handler_meta(handler: OpHandler) -> tuple[inspect.Signature | None, dict[str, Any]]:
+    """Resolve and cache ``(signature, type_hints)`` for a registered handler.
+
+    Handlers are registered once at startup and live for the lifetime of the
+    process, so an unbounded cache is safe. ``get_type_hints`` walks module
+    globals to resolve forward references — not free — and ``inspect.signature``
+    introspects defaults; both ran on every dispatch before this cache.
+    """
     try:
-        return get_type_hints(handler)
+        signature = inspect.signature(handler)
+    except (TypeError, ValueError):
+        signature = None
+    try:
+        type_hints = get_type_hints(handler)
     except (NameError, TypeError, ValueError):
-        return {}
+        type_hints = {}
+    return (signature, type_hints)
 
 
 def _expected_json_label(kinds: set[str]) -> str:
@@ -174,16 +192,14 @@ def _coerce_stringified_json_values(
 
     Returns ``params`` unchanged when nothing needs coercion (the common case).
     """
-    try:
-        signature = inspect.signature(handler)
-    except (TypeError, ValueError):
+    signature, type_hints = _handler_meta(handler)
+    if signature is None:
         return params
 
-    type_hints = _handler_type_hints(handler)
     coerced: dict[str, Any] | None = None
 
     for key, val in params.items():
-        if not isinstance(val, str) or not _json_container_prefix(val):
+        if not isinstance(val, str) or not _is_json_shaped(val):
             continue
 
         parameter = signature.parameters.get(key)

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -817,28 +817,19 @@ class TestNodeGroupTools:
 
         assert result.data["group"] == "enemies"
 
-    async def test_add_to_group_array_value_returns_invalid_params(self, mcp_stack):
-        ## #210 repro: agent passes `group` as a JSON-string-looking list. The
-        ## meta-tool layer's `_coerce_json_strings` decodes it into an Array
-        ## before the plugin sees it (recv shows `"group":["a","b"]`). Without
-        ## the GDScript-side typeof() guard added in this fix, the typed
-        ## assignment `var group: String = ...` runtime-errored and the
-        ## dispatcher surfaced an opaque INTERNAL_ERROR. With the guard, the
-        ## plugin now sends back a structured INVALID_PARAMS that names the
-        ## bad param. We mock the plugin sending the new error shape and
-        ## confirm the meta-tool surfaces it cleanly to the client.
+    async def test_add_to_group_json_shaped_string_stays_string(self, mcp_stack):
+        ## Issue #297 finding #8: nested meta-tool coercion must not decode a
+        ## JSON-shaped value for a string-typed handler param. A group named
+        ## like an array is unusual, but still a legitimate string value.
         client, plugin = mcp_stack
 
         async def respond():
             cmd = await plugin.recv_command()
             assert cmd["command"] == "add_to_group"
-            ## The coercion middleware decoded the JSON-list string into a
-            ## real array. The plugin now type-checks the value and rejects.
-            assert cmd["params"]["group"] == ["a", "b"]
-            await plugin.send_error(
+            assert cmd["params"]["group"] == '["a","b"]'
+            await plugin.send_response(
                 cmd["request_id"],
-                "INVALID_PARAMS",
-                "Param 'group' must be a String, got Array",
+                {"path": "/Main/Enemy", "group": '["a","b"]', "undoable": True},
             )
 
         task = asyncio.create_task(respond())
@@ -848,12 +839,9 @@ class TestNodeGroupTools:
                 "op": "add_to_group",
                 "params": {"path": "/Main/Enemy", "group": '["a","b"]'},
             },
-            raise_on_error=False,
         )
         await task
-        assert result.is_error
-        assert "must be a String" in str(result.content)
-        assert "group" in str(result.content)
+        assert result.data["group"] == '["a","b"]'
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_meta_tool.py
+++ b/tests/unit/test_meta_tool.py
@@ -11,7 +11,6 @@ from fastmcp import FastMCP
 from godot_ai.godot_client.client import GodotCommandError
 from godot_ai.protocol.errors import ErrorCode
 from godot_ai.tools._meta_tool import (
-    _coerce_stringified_json_values,
     dispatch_manage_op,
     register_manage_tool,
 )
@@ -196,59 +195,58 @@ async def test_dispatch_unwraps_typeerror_from_handler():
     assert exc.value.data["received"] == ["path"]
 
 
+@pytest.mark.asyncio
+async def test_dispatch_wraps_missing_param_typeerror():
+    async def needs_path(rt, path):
+        del rt, path
+        return {}
+
+    with pytest.raises(GodotCommandError) as exc:
+        await dispatch_manage_op(
+            ops={"go": needs_path},
+            tool_name="x_manage",
+            runtime=None,
+            op="go",
+            params={},
+        )
+
+    assert exc.value.code == ErrorCode.INVALID_PARAMS
+    assert "x_manage.go" in exc.value.message
+    assert "path" in exc.value.message
+    assert exc.value.data["received"] == []
+
+
+@pytest.mark.asyncio
+async def test_dispatch_wraps_extra_param_typeerror():
+    async def no_params(rt):
+        del rt
+        return {}
+
+    with pytest.raises(GodotCommandError) as exc:
+        await dispatch_manage_op(
+            ops={"go": no_params},
+            tool_name="x_manage",
+            runtime=None,
+            op="go",
+            params={"extra": "{not-json"},
+        )
+
+    assert exc.value.code == ErrorCode.INVALID_PARAMS
+    assert "x_manage.go" in exc.value.message
+    assert "extra" in exc.value.message
+    assert exc.value.data["received"] == ["extra"]
+
+
 # ---------------------------------------------------------------------------
 # JSON-string coercion
 # ---------------------------------------------------------------------------
 
 
-def test_coerce_array_string_to_list():
-    out = _coerce_stringified_json_values({"paths": '["a", "b"]'})
-    assert out["paths"] == ["a", "b"]
-
-
-def test_coerce_object_string_to_dict():
-    out = _coerce_stringified_json_values({"props": '{"x": 1, "y": 2}'})
-    assert out["props"] == {"x": 1, "y": 2}
-
-
-def test_coerce_leaves_plain_strings_untouched():
-    ## Neither value is JSON list/dict-shaped — both must pass through untouched.
-    out = _coerce_stringified_json_values({"name": "Alice", "label": "draft"})
-    assert out["name"] == "Alice"
-    assert out["label"] == "draft"
-
-
-def test_coerce_leaves_non_json_prefixed_strings_untouched():
-    out = _coerce_stringified_json_values({"q": "not-json", "n": "42"})
-    assert out["q"] == "not-json"
-    assert out["n"] == "42"  # numeric string isn't a list/dict prefix
-
-
-def test_coerce_preserves_native_types():
-    out = _coerce_stringified_json_values({"n": 1, "b": True, "lst": ["already"]})
-    assert out["n"] == 1
-    assert out["b"] is True
-    assert out["lst"] == ["already"]
-
-
-def test_coerce_only_attempts_array_or_object_prefixes():
-    ## "true" is valid JSON but not list/dict-shaped — leave alone.
-    out = _coerce_stringified_json_values({"flag": "true"})
-    assert out["flag"] == "true"
-
-
-def test_coerce_returns_input_unchanged_when_no_coercion_needed():
-    ## Fast path: no string values, no prefix matches → return same dict (not a copy).
-    params = {"n": 1, "b": True, "s": "plain", "lst": [1, 2]}
-    out = _coerce_stringified_json_values(params)
-    assert out is params
-
-
 @pytest.mark.asyncio
-async def test_dispatch_applies_coercion_before_handler():
+async def test_dispatch_coerces_stringified_list_for_list_annotated_param():
     captured: dict[str, Any] = {}
 
-    async def handler(rt, paths):
+    async def handler(rt, paths: list[str]):
         del rt
         captured["paths"] = paths
         return {}
@@ -261,3 +259,136 @@ async def test_dispatch_applies_coercion_before_handler():
         params={"paths": '["one", "two"]'},
     )
     assert captured["paths"] == ["one", "two"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_coerces_stringified_dict_for_dict_annotated_param():
+    captured: dict[str, Any] = {}
+
+    async def handler(rt, props: dict[str, Any]):
+        del rt
+        captured["props"] = props
+        return {}
+
+    await dispatch_manage_op(
+        ops={"go": handler},
+        tool_name="x_manage",
+        runtime=None,
+        op="go",
+        params={"props": '{"x": 1, "y": 2}'},
+    )
+    assert captured["props"] == {"x": 1, "y": 2}
+
+
+@pytest.mark.asyncio
+async def test_dispatch_leaves_json_shaped_string_for_str_annotated_param():
+    captured: dict[str, Any] = {}
+
+    async def handler(rt, label: str):
+        del rt
+        captured["label"] = label
+        return {}
+
+    await dispatch_manage_op(
+        ops={"go": handler},
+        tool_name="x_manage",
+        runtime=None,
+        op="go",
+        params={"label": '{"not": "decoded"}'},
+    )
+    assert captured["label"] == '{"not": "decoded"}'
+
+
+@pytest.mark.asyncio
+async def test_dispatch_rejects_malformed_json_for_list_annotated_param():
+    async def handler(rt, paths: list[str]):
+        del rt, paths
+        return {}
+
+    with pytest.raises(GodotCommandError) as exc:
+        await dispatch_manage_op(
+            ops={"go": handler},
+            tool_name="x_manage",
+            runtime=None,
+            op="go",
+            params={"paths": '["unterminated"'},
+        )
+
+    err = exc.value
+    assert err.code == ErrorCode.INVALID_PARAMS
+    assert "malformed JSON" in err.message
+    assert err.data["tool"] == "x_manage"
+    assert err.data["op"] == "go"
+    assert err.data["param"] == "paths"
+    assert err.data["expected"] == "JSON array"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_rejects_malformed_json_for_dict_annotated_param():
+    async def handler(rt, props: dict[str, Any]):
+        del rt, props
+        return {}
+
+    with pytest.raises(GodotCommandError) as exc:
+        await dispatch_manage_op(
+            ops={"go": handler},
+            tool_name="x_manage",
+            runtime=None,
+            op="go",
+            params={"props": '{"unterminated"'},
+        )
+
+    err = exc.value
+    assert err.code == ErrorCode.INVALID_PARAMS
+    assert "malformed JSON" in err.message
+    assert err.data["tool"] == "x_manage"
+    assert err.data["op"] == "go"
+    assert err.data["param"] == "props"
+    assert err.data["expected"] == "JSON object"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_rejects_wrong_json_container_for_dict_annotated_param():
+    async def handler(rt, props: dict[str, Any]):
+        del rt, props
+        return {}
+
+    with pytest.raises(GodotCommandError) as exc:
+        await dispatch_manage_op(
+            ops={"go": handler},
+            tool_name="x_manage",
+            runtime=None,
+            op="go",
+            params={"props": '["not", "an", "object"]'},
+        )
+
+    err = exc.value
+    assert err.code == ErrorCode.INVALID_PARAMS
+    assert err.data["tool"] == "x_manage"
+    assert err.data["op"] == "go"
+    assert err.data["param"] == "props"
+    assert err.data["expected"] == "JSON object"
+    assert err.data["actual"] == "list"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_preserves_native_list_and_dict_params():
+    paths = ["one", "two"]
+    props = {"x": 1}
+    captured: dict[str, Any] = {}
+
+    async def handler(rt, paths: list[str], props: dict[str, Any]):
+        del rt
+        captured["paths"] = paths
+        captured["props"] = props
+        return {}
+
+    await dispatch_manage_op(
+        ops={"go": handler},
+        tool_name="x_manage",
+        runtime=None,
+        op="go",
+        params={"paths": paths, "props": props},
+    )
+    assert captured["paths"] is paths
+    assert captured["props"] is props

--- a/tests/unit/test_meta_tool.py
+++ b/tests/unit/test_meta_tool.py
@@ -281,6 +281,28 @@ async def test_dispatch_coerces_stringified_dict_for_dict_annotated_param():
 
 
 @pytest.mark.asyncio
+async def test_dispatch_coerces_stringified_list_for_optional_list_annotated_param():
+    ## Optional[list[str]] is the most common shape for "may be omitted" list
+    ## params. The Union/UnionType branch in `_json_container_kinds` must strip
+    ## NoneType and still surface "list" so the JSON-string gets decoded.
+    captured: dict[str, Any] = {}
+
+    async def handler(rt, paths: list[str] | None = None):
+        del rt
+        captured["paths"] = paths
+        return {}
+
+    await dispatch_manage_op(
+        ops={"go": handler},
+        tool_name="x_manage",
+        runtime=None,
+        op="go",
+        params={"paths": '["one", "two"]'},
+    )
+    assert captured["paths"] == ["one", "two"]
+
+
+@pytest.mark.asyncio
 async def test_dispatch_leaves_json_shaped_string_for_str_annotated_param():
     captured: dict[str, Any] = {}
 


### PR DESCRIPTION
## Summary

Base: `beta`

Addresses issue #297 finding #8 by narrowing nested JSON-string coercion in `dispatch_manage_op()`.

The new policy is annotation-aware:

- Decode JSON-shaped nested strings only when the selected handler parameter expects a list/dict-like value.
- Preserve JSON-shaped strings unchanged when the handler parameter expects `str`.
- Raise `GodotCommandError(ErrorCode.INVALID_PARAMS)` for malformed JSON-shaped text or wrong JSON container type when the handler expects list/dict-like params, with `data` including `tool`, `op`, and `param`.
- Preserve existing handler `TypeError` wrapping for missing/extra arguments.

Compatibility is preserved for clients that stringify top-level manage `params` and for nested stringified list/dict values where the target handler annotation expects those containers.

PR 9 is being worked in parallel and this PR intentionally does not touch the GDScript self-update preload-alias scope.

## Test Plan

- [x] `ruff check src/ tests/`
- [x] `pytest -v` (`766 passed`)
- [x] `pytest -q tests/unit/test_meta_tool.py tests/unit/test_middleware_parse_stringified_params.py tests/unit/test_middleware_op_typo_hint.py` (`36 passed`)
- [x] `script/ci-check-gdscript`
- [ ] `script/ci-godot-tests` attempted locally; it found a Godot session, then exited with curl code 7 while opening `main.tscn`. A follow-up probe showed no MCP server responding on `127.0.0.1:8000`.

## Out of Scope

- PR 9 preload-alias work
- #14 middleware ordering
- #13 animation split
- Runtime Protocol work