### PR TITLE
Extend self-update preload aliases to PR 9 load scripts

### DIFF
--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -16,6 +16,15 @@ extends RefCounted
 ## To add a new client: drop a file in clients/, then preload it in
 ## clients/_registry.gd. No edits required here.
 
+const Client := preload("res://addons/godot_ai/clients/_base.gd")
+const ClientRegistry := preload("res://addons/godot_ai/clients/_registry.gd")
+const JsonStrategy := preload("res://addons/godot_ai/clients/_json_strategy.gd")
+const TomlStrategy := preload("res://addons/godot_ai/clients/_toml_strategy.gd")
+const CliStrategy := preload("res://addons/godot_ai/clients/_cli_strategy.gd")
+const ManualCommand := preload("res://addons/godot_ai/clients/_manual_command.gd")
+const CliFinder := preload("res://addons/godot_ai/clients/_cli_finder.gd")
+const WindowsPortReservation := preload("res://addons/godot_ai/utils/windows_port_reservation.gd")
+
 const SERVER_NAME := "godot-ai"
 
 ## Fallback ports. Live port selection goes through `http_port()` / `ws_port()`,
@@ -139,21 +148,21 @@ static func excluded_domains() -> String:
 ## clamped candidate.
 static func suggest_free_port(start: int, span: int = 2048) -> int:
 	var candidate := clampi(start, MIN_PORT, MAX_PORT - span + 1)
-	return McpWindowsPortReservation.suggest_non_excluded_port(candidate, span, MAX_PORT)
+	return WindowsPortReservation.suggest_non_excluded_port(candidate, span, MAX_PORT)
 
 
 # --- Client operations (string id) ---------------------------------------
 
 static func client_ids() -> PackedStringArray:
-	return McpClientRegistry.ids()
+	return ClientRegistry.ids()
 
 
 static func has_client(id: String) -> bool:
-	return McpClientRegistry.has_id(id)
+	return ClientRegistry.has_id(id)
 
 
 static func client_display_name(id: String) -> String:
-	var c := McpClientRegistry.get_by_id(id)
+	var c := ClientRegistry.get_by_id(id)
 	return c.display_name if c != null else id
 
 
@@ -162,7 +171,7 @@ static func client_display_name(id: String) -> String:
 ## Empty defaults to the live server URL — appropriate for MCP-tool callers
 ## that always run on main.
 static func configure(id: String, url: String = "") -> Dictionary:
-	var client := McpClientRegistry.get_by_id(id)
+	var client := ClientRegistry.get_by_id(id)
 	if client == null:
 		return {"status": "error", "message": "Unknown client: %s" % id}
 	## Capture `url` once so a port flip in EditorSettings between write and
@@ -176,25 +185,25 @@ static func configure(id: String, url: String = "") -> Dictionary:
 	## because the user's installed client is reading a different file than
 	## `path_template` resolves to (issue #201). Re-read the live state and
 	## surface a clear error before the dock reports a bogus green dot.
-	return _verify_post_state(client, result, McpClient.Status.CONFIGURED, url, "configure")
+	return _verify_post_state(client, result, Client.Status.CONFIGURED, url, "configure")
 
 
-static func check_status(id: String) -> McpClient.Status:
-	var client := McpClientRegistry.get_by_id(id)
+static func check_status(id: String) -> Client.Status:
+	var client := ClientRegistry.get_by_id(id)
 	if client == null:
-		return McpClient.Status.NOT_CONFIGURED
+		return Client.Status.NOT_CONFIGURED
 	return _dispatch_check_status(client, http_url())
 
 
-static func check_status_for_url(id: String, url: String) -> McpClient.Status:
-	var client := McpClientRegistry.get_by_id(id)
+static func check_status_for_url(id: String, url: String) -> Client.Status:
+	var client := ClientRegistry.get_by_id(id)
 	if client == null:
-		return McpClient.Status.NOT_CONFIGURED
+		return Client.Status.NOT_CONFIGURED
 	return _dispatch_check_status(client, url)
 
 
-static func check_status_for_url_with_cli_path(id: String, url: String, cli_path: String) -> McpClient.Status:
-	return check_status_details_for_url_with_cli_path(id, url, cli_path).get("status", McpClient.Status.NOT_CONFIGURED)
+static func check_status_for_url_with_cli_path(id: String, url: String, cli_path: String) -> Client.Status:
+	return check_status_details_for_url_with_cli_path(id, url, cli_path).get("status", Client.Status.NOT_CONFIGURED)
 
 
 ## Detailed variant used by the dock refresh worker. Returns
@@ -203,22 +212,22 @@ static func check_status_for_url_with_cli_path(id: String, url: String, cli_path
 ## NOT_CONFIGURED. Callers that only need the status can use the simpler
 ## helper above.
 static func check_status_details_for_url_with_cli_path(id: String, url: String, cli_path: String) -> Dictionary:
-	var client := McpClientRegistry.get_by_id(id)
+	var client := ClientRegistry.get_by_id(id)
 	if client == null:
-		return {"status": McpClient.Status.NOT_CONFIGURED, "error_msg": ""}
+		return {"status": Client.Status.NOT_CONFIGURED, "error_msg": ""}
 	if client.config_type == "cli" and cli_path.is_empty():
-		return {"status": McpClient.Status.NOT_CONFIGURED, "error_msg": ""}
+		return {"status": Client.Status.NOT_CONFIGURED, "error_msg": ""}
 	return _dispatch_check_status_with_cli_path_details(client, url, cli_path)
 
 
 static func client_status_probe_snapshot(id: String) -> Dictionary:
-	var client := McpClientRegistry.get_by_id(id)
+	var client := ClientRegistry.get_by_id(id)
 	if client == null:
 		return {}
 	var cli_path := ""
 	var installed := false
 	if client.config_type == "cli":
-		cli_path = McpCliStrategy.resolve_cli_path(client)
+		cli_path = CliStrategy.resolve_cli_path(client)
 		installed = not cli_path.is_empty()
 	else:
 		installed = client.is_installed()
@@ -229,58 +238,58 @@ static func client_status_probe_snapshot(id: String) -> Dictionary:
 ## `configure()` above for why. The url is only used to format the
 ## verify-after-write diagnostic message; the remove itself doesn't need it.
 static func remove(id: String, url: String = "") -> Dictionary:
-	var client := McpClientRegistry.get_by_id(id)
+	var client := ClientRegistry.get_by_id(id)
 	if client == null:
 		return {"status": "error", "message": "Unknown client: %s" % id}
 	if url.is_empty():
 		url = http_url()
 	var result := _dispatch_remove(client)
-	return _verify_post_state(client, result, McpClient.Status.NOT_CONFIGURED, url, "remove")
+	return _verify_post_state(client, result, Client.Status.NOT_CONFIGURED, url, "remove")
 
 
 # --- Strategy dispatch + verify (testable seam) --------------------------
 
-static func _dispatch_configure(client: McpClient, url: String) -> Dictionary:
+static func _dispatch_configure(client: Client, url: String) -> Dictionary:
 	match client.config_type:
 		"json":
-			return McpJsonStrategy.configure(client, SERVER_NAME, url)
+			return JsonStrategy.configure(client, SERVER_NAME, url)
 		"toml":
-			return McpTomlStrategy.configure(client, SERVER_NAME, url)
+			return TomlStrategy.configure(client, SERVER_NAME, url)
 		"cli":
-			return McpCliStrategy.configure(client, SERVER_NAME, url)
+			return CliStrategy.configure(client, SERVER_NAME, url)
 	return {"status": "error", "message": "Unknown config_type for %s: %s" % [client.id, client.config_type]}
 
 
-static func _dispatch_remove(client: McpClient) -> Dictionary:
+static func _dispatch_remove(client: Client) -> Dictionary:
 	match client.config_type:
 		"json":
-			return McpJsonStrategy.remove(client, SERVER_NAME)
+			return JsonStrategy.remove(client, SERVER_NAME)
 		"toml":
-			return McpTomlStrategy.remove(client, SERVER_NAME)
+			return TomlStrategy.remove(client, SERVER_NAME)
 		"cli":
-			return McpCliStrategy.remove(client, SERVER_NAME)
+			return CliStrategy.remove(client, SERVER_NAME)
 	return {"status": "error", "message": "Unknown config_type for %s: %s" % [client.id, client.config_type]}
 
 
-static func _dispatch_check_status(client: McpClient, url: String) -> McpClient.Status:
+static func _dispatch_check_status(client: Client, url: String) -> Client.Status:
 	return _dispatch_check_status_with_cli_path(client, url, "")
 
 
-static func _dispatch_check_status_with_cli_path(client: McpClient, url: String, cli_path: String) -> McpClient.Status:
-	return _dispatch_check_status_with_cli_path_details(client, url, cli_path).get("status", McpClient.Status.NOT_CONFIGURED)
+static func _dispatch_check_status_with_cli_path(client: Client, url: String, cli_path: String) -> Client.Status:
+	return _dispatch_check_status_with_cli_path_details(client, url, cli_path).get("status", Client.Status.NOT_CONFIGURED)
 
 
-static func _dispatch_check_status_with_cli_path_details(client: McpClient, url: String, cli_path: String) -> Dictionary:
+static func _dispatch_check_status_with_cli_path_details(client: Client, url: String, cli_path: String) -> Dictionary:
 	match client.config_type:
 		"json":
-			return {"status": McpJsonStrategy.check_status(client, SERVER_NAME, url), "error_msg": ""}
+			return {"status": JsonStrategy.check_status(client, SERVER_NAME, url), "error_msg": ""}
 		"toml":
-			return {"status": McpTomlStrategy.check_status(client, SERVER_NAME, url), "error_msg": ""}
+			return {"status": TomlStrategy.check_status(client, SERVER_NAME, url), "error_msg": ""}
 		"cli":
 			if cli_path.is_empty():
-				return McpCliStrategy.check_status_details(client, SERVER_NAME, url, McpCliStrategy.resolve_cli_path(client))
-			return McpCliStrategy.check_status_details(client, SERVER_NAME, url, cli_path)
-	return {"status": McpClient.Status.NOT_CONFIGURED, "error_msg": ""}
+				return CliStrategy.check_status_details(client, SERVER_NAME, url, CliStrategy.resolve_cli_path(client))
+			return CliStrategy.check_status_details(client, SERVER_NAME, url, cli_path)
+	return {"status": Client.Status.NOT_CONFIGURED, "error_msg": ""}
 
 
 ## After a configure/remove returns ok, re-read the live status. If it doesn't
@@ -288,9 +297,9 @@ static func _dispatch_check_status_with_cli_path_details(client: McpClient, url:
 ## status and the resolved config path so the user can self-diagnose. The
 ## strategy's own error path is left untouched — already actionable.
 static func _verify_post_state(
-	client: McpClient,
+	client: Client,
 	result: Dictionary,
-	expected: McpClient.Status,
+	expected: Client.Status,
 	url: String,
 	action: String,
 ) -> Dictionary:
@@ -305,21 +314,21 @@ static func _verify_post_state(
 		"status": "error",
 		"message": "%s reported %s ok but verification still reads %s (expected %s).%s" % [
 			client.display_name, action,
-			McpClient.status_label(actual), McpClient.status_label(expected),
+			Client.status_label(actual), Client.status_label(expected),
 			path_hint,
 		],
 	}
 
 
 static func manual_command(id: String) -> String:
-	var client := McpClientRegistry.get_by_id(id)
+	var client := ClientRegistry.get_by_id(id)
 	if client == null:
 		return ""
-	return McpManualCommand.build(client, SERVER_NAME, http_url(), client.resolved_config_path())
+	return ManualCommand.build(client, SERVER_NAME, http_url(), client.resolved_config_path())
 
 
 static func is_installed(id: String) -> bool:
-	var client := McpClientRegistry.get_by_id(id)
+	var client := ClientRegistry.get_by_id(id)
 	return client != null and client.is_installed()
 
 
@@ -460,7 +469,7 @@ static func get_server_launch_mode() -> String:
 
 
 static func find_uvx() -> String:
-	return McpCliFinder.find(_uvx_cli_names())
+	return CliFinder.find(_uvx_cli_names())
 
 
 static func _uvx_cli_names() -> Array[String]:
@@ -469,7 +478,7 @@ static func _uvx_cli_names() -> Array[String]:
 	return names
 
 
-## Drop the `McpCliFinder` cache for the platform-specific uvx binary
+## Drop the `CliFinder` cache for the platform-specific uvx binary
 ## name. Pairs with `invalidate_uv_version_cache()` so the dock's
 ## `_on_install_uv` can refresh both caches with one call each. The
 ## OS-specific name matters: Windows caches under `uvx.exe`, every
@@ -478,7 +487,7 @@ static func _uvx_cli_names() -> Array[String]:
 ## dock would keep showing "uv: not found" for the rest of the session.
 static func invalidate_uvx_cli_cache() -> void:
 	for name in _uvx_cli_names():
-		McpCliFinder.invalidate(name)
+		CliFinder.invalidate(name)
 
 
 static var _uv_version_cache: String = ""
@@ -495,7 +504,7 @@ static var _uv_version_searched: bool = false
 ## Invalidate via `invalidate_uv_version_cache()` when the user
 ## installs / reinstalls uv via the dock so the next refresh reflects
 ## the new install. The dock's `_on_install_uv` calls this alongside
-## `McpCliFinder.invalidate("uvx")` to clear both the path cache and
+## `CliFinder.invalidate("uvx")` to clear both the path cache and
 ## the version cache in one place.
 static func check_uv_version() -> String:
 	if _uv_version_searched:

--- a/plugin/addons/godot_ai/connection.gd
+++ b/plugin/addons/godot_ai/connection.gd
@@ -14,12 +14,14 @@ const RECONNECT_LOG_EVERY_N_ATTEMPTS := 10
 ## responses get a compact structured error when that can still be sent;
 ## state events report failure so their callers can retry on a later tick.
 const OUTBOUND_BUFFER_LIMIT_BYTES := 4 * 1024 * 1024
+const ClientConfigurator := preload("res://addons/godot_ai/client_configurator.gd")
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
 
 var _peer := WebSocketPeer.new()
 ## Set by plugin.gd after resolving the configured WebSocket port once for the
 ## server spawn. Reconnects reuse this cached value so they keep dialing the
 ## same port the Python server was asked to bind.
-var ws_port := McpClientConfigurator.DEFAULT_WS_PORT
+var ws_port := ClientConfigurator.DEFAULT_WS_PORT
 var _url := ""
 var _connected := false
 var _reconnect_attempt := 0
@@ -31,8 +33,8 @@ var _session_id := ""
 ## must treat empty as "unknown, don't raise a false alarm".
 var server_version := ""
 
-var dispatcher: McpDispatcher
-var log_buffer: McpLogBuffer
+var dispatcher
+var log_buffer
 ## Set by plugin.gd when the HTTP port is occupied by an incompatible or
 ## unverified server. Keeping the Connection node alive lets handlers and the
 ## dock share one object, but no WebSocket is opened to the wrong server.
@@ -205,11 +207,11 @@ func _send_handshake() -> void:
 		"session_id": _session_id,
 		"godot_version": Engine.get_version_info().get("string", "unknown"),
 		"project_path": ProjectSettings.globalize_path("res://"),
-		"plugin_version": McpClientConfigurator.get_plugin_version(),
+		"plugin_version": ClientConfigurator.get_plugin_version(),
 		"protocol_version": 1,
 		"readiness": _last_readiness,
 		"editor_pid": OS.get_process_id(),
-		"server_launch_mode": McpClientConfigurator.get_server_launch_mode(),
+		"server_launch_mode": ClientConfigurator.get_server_launch_mode(),
 	})
 
 
@@ -373,7 +375,7 @@ static func _make_backpressure_error(
 		"status": "error",
 		"data": {},
 		"error": {
-			"code": McpErrorCodes.INTERNAL_ERROR,
+			"code": ErrorCodes.INTERNAL_ERROR,
 			"message": (
 				"Outbound WebSocket buffer is full; dropped response before queueing "
 				+ "more data. Retry with a smaller payload (for screenshots, lower "

--- a/plugin/addons/godot_ai/dispatcher.gd
+++ b/plugin/addons/godot_ai/dispatcher.gd
@@ -8,7 +8,7 @@ extends RefCounted
 var _command_queue: Array[Dictionary] = []
 var _handlers: Dictionary = {}  # command_name -> Callable
 var _pending_deferred: Dictionary = {}  # request_id -> {command, started_ms, timeout_ms}
-var _log_buffer: McpLogBuffer
+var _log_buffer
 var mcp_logging := true
 var deferred_timeout_overrides_ms: Dictionary = {}
 
@@ -18,6 +18,7 @@ const DEFERRED_TIMEOUT_MS_BY_COMMAND := {
 	"stop_project": 4500,
 	"take_screenshot": 30000,
 }
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
 
 
 func _init(log_buffer: McpLogBuffer) -> void:
@@ -44,7 +45,7 @@ func clear() -> void:
 ## error dict if the command is not registered. Used by batch_execute.
 func dispatch_direct(command: String, params: Dictionary) -> Dictionary:
 	if not _handlers.has(command):
-		return McpErrorCodes.make(McpErrorCodes.UNKNOWN_COMMAND, "Unknown command: %s" % command)
+		return ErrorCodes.make(ErrorCodes.UNKNOWN_COMMAND, "Unknown command: %s" % command)
 	return _call_handler(command, params)
 
 
@@ -147,7 +148,7 @@ func _dispatch(cmd: Dictionary) -> Dictionary:
 	if _handlers.has(command):
 		result = _call_handler(command, params)
 	else:
-		result = McpErrorCodes.make(McpErrorCodes.UNKNOWN_COMMAND, "Unknown command: %s" % command)
+		result = ErrorCodes.make(ErrorCodes.UNKNOWN_COMMAND, "Unknown command: %s" % command)
 
 	if result.get("_deferred", false):
 		_register_deferred(request_id, command)
@@ -201,7 +202,7 @@ func _call_handler(command: String, params: Dictionary) -> Dictionary:
 				"[error] %s -> malformed result; args=%s; backtrace=%s"
 				% [command, args_json, compact_backtrace]
 			)
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, msg)
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, msg)
 	return result
 
 
@@ -234,8 +235,8 @@ func _collect_deferred_timeouts() -> Array[Dictionary]:
 			continue
 		_pending_deferred.erase(request_id)
 		var command: String = entry.get("command", "")
-		var response := McpErrorCodes.make(
-			McpErrorCodes.DEFERRED_TIMEOUT,
+		var response := ErrorCodes.make(
+			ErrorCodes.DEFERRED_TIMEOUT,
 			"Deferred response for '%s' timed out after %dms" % [command, timeout_ms]
 		)
 		response["request_id"] = request_id

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -7,11 +7,18 @@ extends VBoxContainer
 const ServerStateScript := preload("res://addons/godot_ai/utils/mcp_server_state.gd")
 const ClientRefreshStateScript := preload("res://addons/godot_ai/utils/mcp_client_refresh_state.gd")
 const UpdateManagerScript := preload("res://addons/godot_ai/utils/update_manager.gd")
+const Client := preload("res://addons/godot_ai/clients/_base.gd")
+const ClientConfigurator := preload("res://addons/godot_ai/client_configurator.gd")
+const ClientRegistry := preload("res://addons/godot_ai/clients/_registry.gd")
+const JsonStrategy := preload("res://addons/godot_ai/clients/_json_strategy.gd")
+const TomlStrategy := preload("res://addons/godot_ai/clients/_toml_strategy.gd")
+const CliStrategy := preload("res://addons/godot_ai/clients/_cli_strategy.gd")
+const ToolCatalog := preload("res://addons/godot_ai/tool_catalog.gd")
 
 const DEV_MODE_SETTING := "godot_ai/dev_mode"
 ## Index ↔ persisted-value mapping for the mode-override dropdown. The array
 ## index is the OptionButton item id; the string is what's written to the
-## EditorSetting and read by `McpClientConfigurator.mode_override()`.
+## EditorSetting and read by `ClientConfigurator.mode_override()`.
 const MODE_OVERRIDE_VALUES := ["", "user", "dev"]
 const MODE_OVERRIDE_LABELS := ["Auto", "Force user", "Force dev"]
 const CLIENT_STATUS_REFRESH_COOLDOWN_MSEC := 15 * 1000
@@ -24,8 +31,8 @@ static var COLOR_HEADER := Color(0.95, 0.95, 0.95)
 ## doesn't have to find every literal.
 static var COLOR_AMBER := Color(1.0, 0.75, 0.25)
 
-var _connection: McpConnection
-var _log_buffer: McpLogBuffer
+var _connection
+var _log_buffer
 var _plugin: EditorPlugin
 
 # Always visible
@@ -291,7 +298,7 @@ func _drain_client_action_workers() -> void:
 		if not row.is_empty():
 			_apply_row_status(
 				String(client_id),
-				row.get("status", McpClient.Status.NOT_CONFIGURED),
+				row.get("status", Client.Status.NOT_CONFIGURED),
 				""
 			)
 	_client_action_threads.clear()
@@ -601,7 +608,7 @@ func _build_ui() -> void:
 	_client_grid.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	clients_scroll.add_child(_client_grid)
 
-	for client_id in McpClientConfigurator.client_ids():
+	for client_id in ClientConfigurator.client_ids():
 		_build_client_row(client_id)
 
 	_build_tools_tab(tabs)
@@ -676,7 +683,7 @@ func _build_client_row(client_id: String) -> void:
 	row.add_child(dot_center)
 
 	var name_label := Label.new()
-	name_label.text = McpClientConfigurator.client_display_name(client_id)
+	name_label.text = ClientConfigurator.client_display_name(client_id)
 	name_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	## Long error messages from `_verify_post_state` (e.g. "reported remove ok
 	## but verification still reads configured…") used to push the Retry /
@@ -726,7 +733,7 @@ func _build_client_row(client_id: String) -> void:
 
 	_client_rows[client_id] = {
 		"dot": dot,
-		"status": McpClient.Status.NOT_CONFIGURED,
+		"status": Client.Status.NOT_CONFIGURED,
 		"name_label": name_label,
 		"configure_btn": configure_btn,
 		"remove_btn": remove_btn,
@@ -738,7 +745,7 @@ func _build_client_row(client_id: String) -> void:
 # --- Status updates ---
 
 func _update_status() -> void:
-	var connected := _connection.is_connected
+	var connected: bool = _connection.is_connected
 	## During plugin self-update there's a brief window where this dock
 	## script is already the new version (Godot hot-reloads scripts on
 	## file change) but `_plugin` is still the old `EditorPlugin` instance
@@ -777,13 +784,13 @@ func _update_status() -> void:
 		status_text = "Server exited after %.1fs" % (exit_ms / 1000.0)
 		status_color = Color.RED
 	elif state == ServerStateScript.PORT_EXCLUDED:
-		status_text = "Port %d reserved by Windows" % McpClientConfigurator.http_port()
+		status_text = "Port %d reserved by Windows" % ClientConfigurator.http_port()
 		status_color = Color.RED
 	elif state == ServerStateScript.INCOMPATIBLE:
-		status_text = "Incompatible server on port %d" % McpClientConfigurator.http_port()
+		status_text = "Incompatible server on port %d" % ClientConfigurator.http_port()
 		status_color = Color.RED
 	elif state == ServerStateScript.FOREIGN_PORT:
-		status_text = "Port %d held by another process" % McpClientConfigurator.http_port()
+		status_text = "Port %d held by another process" % ClientConfigurator.http_port()
 		status_color = Color.RED
 	elif state == ServerStateScript.NO_COMMAND:
 		status_text = "No server command found"
@@ -800,7 +807,7 @@ func _update_status() -> void:
 	_update_crash_panel(server_status)
 	_refresh_server_version_label(server_status)
 
-	var changed := connected != _last_connected or status_text != _last_status_text
+	var changed: bool = connected != _last_connected or status_text != _last_status_text
 	if not changed:
 		return
 	_last_connected = connected
@@ -853,15 +860,15 @@ func _update_crash_panel(server_status: Dictionary) -> void:
 		## Seed the SpinBox with a suggested non-reserved port each time
 		## the panel surfaces. Idempotent when the user already has a
 		## good candidate queued up.
-		_port_picker_spinbox.value = McpClientConfigurator.suggest_free_port(
-			McpClientConfigurator.http_port() + 1
+		_port_picker_spinbox.value = ClientConfigurator.suggest_free_port(
+			ClientConfigurator.http_port() + 1
 		)
 
 
 static func _crash_body_for_state(state: int, server_status: Dictionary = {}) -> String:
 	## Single sentence per state. The top status label already names the
 	## problem; don't repeat it here. This copy answers "what do I do?".
-	var port := McpClientConfigurator.http_port()
+	var port := ClientConfigurator.http_port()
 	match state:
 		ServerStateScript.PORT_EXCLUDED:
 			return "Windows (Hyper-V / WSL2 / Docker) reserved port %d. Pick a free port or try `net stop winnat; net start winnat` in an admin shell." % port
@@ -870,7 +877,7 @@ static func _crash_body_for_state(state: int, server_status: Dictionary = {}) ->
 			if bool(server_status.get("can_recover_incompatible", false)):
 				var expected := str(server_status.get("expected_version", ""))
 				if expected.is_empty():
-					expected = McpClientConfigurator.get_plugin_version()
+					expected = ClientConfigurator.get_plugin_version()
 				if not message.is_empty():
 					return "%s Click Restart Server below to replace it with godot-ai v%s." % [message, expected]
 				return "Port %d is occupied by an older godot-ai server. Click Restart Server below to replace it with godot-ai v%s." % [port, expected]
@@ -884,8 +891,8 @@ static func _crash_body_for_state(state: int, server_status: Dictionary = {}) ->
 			## means PyPI hasn't propagated this version yet (~10 min after
 			## publish). `_start_server` already tried `--refresh` once, so
 			## the next realistic move is to wait and reload.
-			if McpClientConfigurator.get_server_launch_mode() == "uvx":
-				var version := McpClientConfigurator.get_plugin_version()
+			if ClientConfigurator.get_server_launch_mode() == "uvx":
+				var version := ClientConfigurator.get_plugin_version()
 				return "The server exited before the WebSocket handshake, even after a `uvx --refresh` retry. If this is a brand-new release, PyPI's index may still be propagating (~10 min). Wait a moment and click Reload Plugin to retry, or check Godot's output log for Python's traceback. Target: godot-ai==%s." % version
 			return "The server exited before the WebSocket handshake. Check Godot's output log (bottom panel) for Python's traceback."
 		ServerStateScript.NO_COMMAND:
@@ -903,10 +910,10 @@ func _build_port_picker_section() -> void:
 	picker_row.add_theme_constant_override("separation", 6)
 
 	_port_picker_spinbox = SpinBox.new()
-	_port_picker_spinbox.min_value = McpClientConfigurator.MIN_PORT
-	_port_picker_spinbox.max_value = McpClientConfigurator.MAX_PORT
+	_port_picker_spinbox.min_value = ClientConfigurator.MIN_PORT
+	_port_picker_spinbox.max_value = ClientConfigurator.MAX_PORT
 	_port_picker_spinbox.step = 1
-	_port_picker_spinbox.value = McpClientConfigurator.http_port()
+	_port_picker_spinbox.value = ClientConfigurator.http_port()
 	_port_picker_spinbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	picker_row.add_child(_port_picker_spinbox)
 
@@ -925,11 +932,11 @@ func _build_port_picker_section() -> void:
 
 func _on_apply_new_port() -> void:
 	var new_port: int = int(_port_picker_spinbox.value)
-	if new_port < McpClientConfigurator.MIN_PORT or new_port > McpClientConfigurator.MAX_PORT:
+	if new_port < ClientConfigurator.MIN_PORT or new_port > ClientConfigurator.MAX_PORT:
 		return
 	var es := EditorInterface.get_editor_settings()
 	if es != null:
-		es.set_setting(McpClientConfigurator.SETTING_HTTP_PORT, new_port)
+		es.set_setting(ClientConfigurator.SETTING_HTTP_PORT, new_port)
 	## Every saved client config now points at the old port. Re-sweep so the
 	## drift banner appears in the same frame the user committed the change —
 	## the plugin reload below will run a second sweep on its own first paint,
@@ -944,21 +951,21 @@ func _on_apply_new_port() -> void:
 func _refresh_server_label() -> void:
 	if _server_label == null:
 		return
-	var ws_port := McpClientConfigurator.ws_port()
+	var ws_port := ClientConfigurator.ws_port()
 	if _plugin != null and _plugin.has_method("get_resolved_ws_port"):
 		ws_port = int(_plugin.get_resolved_ws_port())
-	_server_label.text = "WS: %d  HTTP: %d" % [ws_port, McpClientConfigurator.http_port()]
+	_server_label.text = "WS: %d  HTTP: %d" % [ws_port, ClientConfigurator.http_port()]
 
 
 func _update_log() -> void:
 	if _log_buffer == null:
 		return
-	var count := _log_buffer.total_count()
+	var count: int = _log_buffer.total_count()
 	if count == _last_log_count:
 		return
 
 	# Append only new lines
-	var new_lines := _log_buffer.get_recent(count - _last_log_count)
+	var new_lines: Array[String] = _log_buffer.get_recent(count - _last_log_count)
 	for line in new_lines:
 		_log_display.add_text(line + "\n")
 	_last_log_count = count
@@ -995,16 +1002,16 @@ func _apply_dev_mode_visibility() -> void:
 
 	# Setup section: visible in dev mode, OR in user mode when uv is missing
 	# (so users can install uv from the dock).
-	var is_dev := McpClientConfigurator.is_dev_checkout()
-	var uv_missing := not is_dev and McpClientConfigurator.check_uv_version().is_empty()
+	var is_dev := ClientConfigurator.is_dev_checkout()
+	var uv_missing := not is_dev and ClientConfigurator.check_uv_version().is_empty()
 	_setup_section.visible = dev or uv_missing
 
 
 func _mode_override_index_from_setting() -> int:
 	var es := EditorInterface.get_editor_settings()
-	if es == null or not es.has_setting(McpClientConfigurator.MODE_OVERRIDE_SETTING):
+	if es == null or not es.has_setting(ClientConfigurator.MODE_OVERRIDE_SETTING):
 		return 0
-	var v := str(es.get_setting(McpClientConfigurator.MODE_OVERRIDE_SETTING)).strip_edges().to_lower()
+	var v := str(es.get_setting(ClientConfigurator.MODE_OVERRIDE_SETTING)).strip_edges().to_lower()
 	return maxi(MODE_OVERRIDE_VALUES.find(v), 0)
 
 
@@ -1032,7 +1039,7 @@ func _on_mode_override_selected(index: int) -> void:
 	var value: String = MODE_OVERRIDE_VALUES[index] if index >= 0 and index < MODE_OVERRIDE_VALUES.size() else ""
 	var es := EditorInterface.get_editor_settings()
 	if es != null:
-		es.set_setting(McpClientConfigurator.MODE_OVERRIDE_SETTING, value)
+		es.set_setting(ClientConfigurator.MODE_OVERRIDE_SETTING, value)
 	_refresh_install_mode_ui()
 	## Cancel any in-flight startup check before firing a new one, otherwise
 	## the next `request()` returns ERR_BUSY and the dropdown flip silently
@@ -1066,7 +1073,7 @@ func _on_reload_plugin() -> void:
 func _refresh_server_version_label(server_status: Dictionary = {}) -> void:
 	if _setup_server_label == null:
 		return
-	var plugin_ver := McpClientConfigurator.get_plugin_version()
+	var plugin_ver := ClientConfigurator.get_plugin_version()
 	if server_status.is_empty():
 		## Re-fetch only when called outside `_update_status`'s frame
 		## (e.g. from `_apply_new_port`, `_on_restart_*`). Inside the
@@ -1077,7 +1084,7 @@ func _refresh_server_version_label(server_status: Dictionary = {}) -> void:
 			if _plugin != null and _plugin.has_method("get_server_status")
 			else {}
 		)
-	var server_ver := _connection.server_version if _connection != null else ""
+	var server_ver: String = _connection.server_version if _connection != null else ""
 	if server_ver.is_empty():
 		server_ver = str(server_status.get("actual_version", ""))
 	var expected_ver := str(server_status.get("expected_version", ""))
@@ -1202,7 +1209,7 @@ func _refresh_setup_status() -> void:
 		child.queue_free()
 	_dev_server_btn = null
 
-	var is_dev := McpClientConfigurator.is_dev_checkout()
+	var is_dev := ClientConfigurator.is_dev_checkout()
 	if is_dev:
 		_setup_container.add_child(_make_status_row("Mode", "Dev (venv)", Color.CYAN))
 		_dev_server_btn = Button.new()
@@ -1213,7 +1220,7 @@ func _refresh_setup_status() -> void:
 		return
 
 	# User mode — check for uv
-	var uv_version := McpClientConfigurator.check_uv_version()
+	var uv_version := ClientConfigurator.check_uv_version()
 	if not uv_version.is_empty():
 		_setup_container.add_child(_make_status_row("uv", uv_version, Color.GREEN))
 		## Build the Server row with a placeholder label we can update every
@@ -1233,7 +1240,7 @@ func _refresh_setup_status() -> void:
 		server_row.add_child(_setup_server_label)
 		_version_restart_btn = Button.new()
 		_version_restart_btn.text = "Restart"
-		_version_restart_btn.tooltip_text = "Kill the server on port %d and respawn with the plugin's bundled version" % McpClientConfigurator.http_port()
+		_version_restart_btn.tooltip_text = "Kill the server on port %d and respawn with the plugin's bundled version" % ClientConfigurator.http_port()
 		_version_restart_btn.pressed.connect(_on_restart_stale_server)
 		_version_restart_btn.visible = false
 		server_row.add_child(_version_restart_btn)
@@ -1249,13 +1256,13 @@ func _refresh_setup_status() -> void:
 
 
 func _install_mode_text() -> String:
-	if McpClientConfigurator.is_dev_checkout():
+	if ClientConfigurator.is_dev_checkout():
 		return "Install: dev checkout — update via git pull"
-	return "Install: v%s" % McpClientConfigurator.get_plugin_version()
+	return "Install: v%s" % ClientConfigurator.get_plugin_version()
 
 
 func _install_mode_tooltip() -> String:
-	if not McpClientConfigurator.is_dev_checkout():
+	if not ClientConfigurator.is_dev_checkout():
 		return "Plugin installed from a release ZIP, Asset Library, or source copy. Update button in this dock downloads the latest GitHub release."
 	var target := _resolve_plugin_symlink_target()
 	if target.is_empty():
@@ -1298,7 +1305,7 @@ func _make_status_row(label_text: String, value_text: String, value_color: Color
 ## label and tooltip. Factored out so tests can cover all three states without
 ## spinning up a real server or plugin.
 static func _dev_server_btn_state(has_managed: bool, dev_running: bool) -> Dictionary:
-	var port := McpClientConfigurator.http_port()
+	var port := ClientConfigurator.http_port()
 	if has_managed:
 		return {
 			"text": "Switch to dev mode (--reload)",
@@ -1356,8 +1363,8 @@ func _on_install_uv() -> void:
 	## the CLI-finder cache key is `uvx.exe` — invalidating just `"uvx"`
 	## would leave the cache stale and the dock would keep showing
 	## "uv: not found" for the rest of the session.
-	McpClientConfigurator.invalidate_uvx_cli_cache()
-	McpClientConfigurator.invalidate_uv_version_cache()
+	ClientConfigurator.invalidate_uvx_cli_cache()
+	ClientConfigurator.invalidate_uv_version_cache()
 	_refresh_setup_status.call_deferred()
 
 
@@ -1365,7 +1372,7 @@ func _on_install_uv() -> void:
 
 func _on_configure_client(client_id: String) -> void:
 	if _server_blocks_client_health():
-		_apply_row_status(client_id, McpClient.Status.ERROR, _server_blocked_client_message())
+		_apply_row_status(client_id, Client.Status.ERROR, _server_blocked_client_message())
 		_refresh_clients_summary()
 		return
 	_dispatch_client_action(client_id, "configure")
@@ -1377,8 +1384,8 @@ func _on_remove_client(client_id: String) -> void:
 
 ## Spawn a worker thread for Configure / Remove so a hung CLI can't lock
 ## the editor (issue #239). The action verbs are: "configure" → calls
-## `McpClientConfigurator.configure`; "remove" → calls
-## `McpClientConfigurator.remove`. Both routes shell out to the per-client
+## `ClientConfigurator.configure`; "remove" → calls
+## `ClientConfigurator.remove`. Both routes shell out to the per-client
 ## CLI via `McpCliExec.run`, which is wall-clock-bounded.
 ##
 ## Per-row in-flight rules:
@@ -1406,7 +1413,7 @@ func _dispatch_client_action(client_id: String, action: String) -> void:
 	## The status-refresh worker uses the same pattern — see
 	## `_perform_initial_client_status_refresh` and
 	## `_request_client_status_refresh`.
-	var server_url := McpClientConfigurator.http_url()
+	var server_url := ClientConfigurator.http_url()
 	var generation := int(_client_action_generations.get(client_id, 0)) + 1
 	_client_action_generations[client_id] = generation
 	var thread := Thread.new()
@@ -1417,16 +1424,16 @@ func _dispatch_client_action(client_id: String, action: String) -> void:
 	if err != OK:
 		_client_action_threads.erase(client_id)
 		_finalize_action_buttons(client_id)
-		_apply_row_status(client_id, McpClient.Status.ERROR, "couldn't start worker thread")
+		_apply_row_status(client_id, Client.Status.ERROR, "couldn't start worker thread")
 		_refresh_clients_summary()
 
 
 func _run_client_action_worker(client_id: String, action: String, server_url: String, generation: int) -> void:
 	var result: Dictionary
 	if action == "remove":
-		result = McpClientConfigurator.remove(client_id, server_url)
+		result = ClientConfigurator.remove(client_id, server_url)
 	else:
-		result = McpClientConfigurator.configure(client_id, server_url)
+		result = ClientConfigurator.configure(client_id, server_url)
 	if _refresh_state != ClientRefreshStateScript.SHUTTING_DOWN:
 		call_deferred("_apply_client_action_result", client_id, action, result, generation)
 
@@ -1443,18 +1450,18 @@ func _apply_client_action_result(client_id: String, action: String, result: Dict
 		_client_action_threads.erase(client_id)
 	_finalize_action_buttons(client_id)
 	if _server_blocks_client_health():
-		_apply_row_status(client_id, McpClient.Status.ERROR, _server_blocked_client_message())
+		_apply_row_status(client_id, Client.Status.ERROR, _server_blocked_client_message())
 		_refresh_clients_summary()
 		return
 
-	var success_status := McpClient.Status.NOT_CONFIGURED if action == "remove" else McpClient.Status.CONFIGURED
+	var success_status := Client.Status.NOT_CONFIGURED if action == "remove" else Client.Status.CONFIGURED
 	if result.get("status") == "ok":
 		_apply_row_status(client_id, success_status)
 		var row: Dictionary = _client_rows.get(client_id, {})
 		if not row.is_empty():
 			(row["manual_panel"] as VBoxContainer).visible = false
 	else:
-		_apply_row_status(client_id, McpClient.Status.ERROR, str(result.get("message", "failed")))
+		_apply_row_status(client_id, Client.Status.ERROR, str(result.get("message", "failed")))
 		if action == "configure":
 			_show_manual_command_for(client_id)
 	_refresh_clients_summary()
@@ -1505,14 +1512,14 @@ func _on_refresh_clients_pressed() -> void:
 func _on_configure_all_clients() -> void:
 	if _server_blocks_client_health():
 		for client_id in _client_rows:
-			_apply_row_status(String(client_id), McpClient.Status.ERROR, _server_blocked_client_message())
+			_apply_row_status(String(client_id), Client.Status.ERROR, _server_blocked_client_message())
 		_refresh_clients_summary()
 		return
 	if ClientRefreshStateScript.has_worker_alive(_refresh_state):
 		return
 	for client_id in _client_rows:
-		var status: McpClient.Status = _client_rows[client_id].get("status", McpClient.Status.NOT_CONFIGURED)
-		if status == McpClient.Status.CONFIGURED:
+		var status: Client.Status = _client_rows[client_id].get("status", Client.Status.NOT_CONFIGURED)
+		if status == Client.Status.CONFIGURED:
 			continue
 		_on_configure_client(String(client_id))
 	_refresh_clients_summary()
@@ -1619,16 +1626,16 @@ func _build_tools_tab(tabs: TabContainer) -> void:
 	core_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	core_row.add_child(core_label)
 	var core_count := Label.new()
-	core_count.text = "%d tools" % McpToolCatalog.CORE_TOOLS.size()
+	core_count.text = "%d tools" % ToolCatalog.CORE_TOOLS.size()
 	core_count.add_theme_color_override("font_color", COLOR_MUTED)
 	core_row.add_child(core_count)
-	core_row.tooltip_text = ", ".join(McpToolCatalog.CORE_TOOLS)
+	core_row.tooltip_text = ", ".join(ToolCatalog.CORE_TOOLS)
 	grid.add_child(core_row)
 
 	grid.add_child(HSeparator.new())
 
 	_tools_domain_checkboxes.clear()
-	for entry in McpToolCatalog.DOMAINS:
+	for entry in ToolCatalog.DOMAINS:
 		_build_tools_domain_row(grid, entry)
 
 	tools_tab.add_child(HSeparator.new())
@@ -1701,7 +1708,7 @@ func _reset_tools_pending_from_setting() -> void:
 	## Unknown domain names in the setting (e.g. from an older plugin
 	## version) are silently dropped — matches the Python side's
 	## warn-and-continue behavior when it sees an unknown name.
-	var saved_raw := McpClientConfigurator.excluded_domains()
+	var saved_raw := ClientConfigurator.excluded_domains()
 	var saved := PackedStringArray()
 	if not saved_raw.is_empty():
 		for part in saved_raw.split(","):
@@ -1733,8 +1740,8 @@ func _on_tools_domain_toggled(pressed: bool, domain_id: String) -> void:
 func _refresh_tools_ui_state() -> void:
 	if _tools_count_label == null:
 		return
-	var enabled := McpToolCatalog.enabled_tool_count(_tools_pending_excluded)
-	var total := McpToolCatalog.total_tool_count()
+	var enabled := ToolCatalog.enabled_tool_count(_tools_pending_excluded)
+	var total := ToolCatalog.total_tool_count()
 	_tools_count_label.text = "%d / %d" % [enabled, total]
 	var dirty := _tools_pending_excluded != _tools_saved_excluded
 	_tools_dirty_warning.visible = dirty
@@ -1749,10 +1756,10 @@ func _refresh_tools_ui_state() -> void:
 
 
 func _on_tools_apply() -> void:
-	var canonical_excluded := McpToolCatalog.canonical(_tools_pending_excluded)
+	var canonical_excluded := ToolCatalog.canonical(_tools_pending_excluded)
 	var es := EditorInterface.get_editor_settings()
 	if es != null:
-		es.set_setting(McpClientConfigurator.SETTING_EXCLUDED_DOMAINS, canonical_excluded)
+		es.set_setting(ClientConfigurator.SETTING_EXCLUDED_DOMAINS, canonical_excluded)
 	_tools_saved_excluded = _tools_pending_excluded.duplicate()
 	_refresh_tools_ui_state()
 	## Plugin reload respawns the server with the new `--exclude-domains`
@@ -1794,10 +1801,10 @@ func _refresh_clients_summary() -> void:
 	var configured := 0
 	var mismatched_ids: Array[String] = []
 	for client_id in _client_rows:
-		var status: McpClient.Status = _client_rows[client_id].get("status", McpClient.Status.NOT_CONFIGURED)
-		if status == McpClient.Status.CONFIGURED:
+		var status: Client.Status = _client_rows[client_id].get("status", Client.Status.NOT_CONFIGURED)
+		if status == Client.Status.CONFIGURED:
 			configured += 1
-		elif status == McpClient.Status.CONFIGURED_MISMATCH:
+		elif status == Client.Status.CONFIGURED_MISMATCH:
 			mismatched_ids.append(client_id)
 	var text := "%d / %d configured" % [configured, _client_rows.size()]
 	if mismatched_ids.size() > 0:
@@ -1818,7 +1825,7 @@ func _show_manual_command_for(client_id: String) -> void:
 	var row: Dictionary = _client_rows.get(client_id, {})
 	if row.is_empty():
 		return
-	var cmd := McpClientConfigurator.manual_command(client_id)
+	var cmd := ClientConfigurator.manual_command(client_id)
 	if cmd.is_empty():
 		row["manual_panel"].visible = false
 		return
@@ -1839,7 +1846,7 @@ func _refresh_all_client_statuses() -> void:
 	## main thread.
 	if _server_blocks_client_health():
 		for client_id in _client_rows:
-			_apply_row_status(String(client_id), McpClient.Status.ERROR, _server_blocked_client_message())
+			_apply_row_status(String(client_id), Client.Status.ERROR, _server_blocked_client_message())
 		_refresh_clients_summary()
 		return
 	_request_client_status_refresh(true)
@@ -1950,18 +1957,18 @@ func _perform_initial_client_status_refresh() -> void:
 
 	if _server_blocks_client_health():
 		for client_id in _client_rows:
-			_apply_row_status(String(client_id), McpClient.Status.ERROR, _server_blocked_client_message())
+			_apply_row_status(String(client_id), Client.Status.ERROR, _server_blocked_client_message())
 		_refresh_clients_summary()
 		return
 
 	_warm_strategy_bytecode()
 
 	var generation := _begin_client_status_refresh_run()
-	var server_url := McpClientConfigurator.http_url()
+	var server_url := ClientConfigurator.http_url()
 	var all_probes: Array[Dictionary] = []
 
 	for client_id in _client_rows:
-		var probe := McpClientConfigurator.client_status_probe_snapshot(String(client_id))
+		var probe := ClientConfigurator.client_status_probe_snapshot(String(client_id))
 		if probe.is_empty():
 			continue
 		all_probes.append(probe)
@@ -1989,14 +1996,14 @@ func _perform_initial_client_status_refresh() -> void:
 ## itself. See `_perform_initial_client_status_refresh` for context and
 ## #233 / #235 for the SIGABRT this exists to prevent.
 func _warm_strategy_bytecode() -> void:
-	var ids := McpClientConfigurator.client_ids()
+	var ids := ClientConfigurator.client_ids()
 	if ids.is_empty():
 		return
-	var any_client := McpClientRegistry.get_by_id(String(ids[0]))
+	var any_client := ClientRegistry.get_by_id(String(ids[0]))
 	if any_client != null:
-		McpJsonStrategy.verify_entry(any_client, {}, "")
-	McpTomlStrategy.format_body(PackedStringArray(), "")
-	McpCliStrategy.format_args(PackedStringArray(), "", "")
+		JsonStrategy.verify_entry(any_client, {}, "")
+	TomlStrategy.format_body(PackedStringArray(), "")
+	CliStrategy.format_args(PackedStringArray(), "", "")
 
 
 func _begin_client_status_refresh_run() -> int:
@@ -2029,7 +2036,7 @@ func _request_client_status_refresh(force: bool = false) -> bool:
 	## background worker's result is applied on the main thread.
 	if _server_blocks_client_health():
 		for client_id in _client_rows:
-			_apply_row_status(String(client_id), McpClient.Status.ERROR, _server_blocked_client_message())
+			_apply_row_status(String(client_id), Client.Status.ERROR, _server_blocked_client_message())
 		_refresh_clients_summary()
 		return false
 	if _is_self_update_in_progress():
@@ -2071,8 +2078,8 @@ func _request_client_status_refresh(force: bool = false) -> bool:
 
 	var client_probes: Array[Dictionary] = []
 	for client_id in _client_rows:
-		client_probes.append(McpClientConfigurator.client_status_probe_snapshot(String(client_id)))
-	var server_url := McpClientConfigurator.http_url()
+		client_probes.append(ClientConfigurator.client_status_probe_snapshot(String(client_id)))
+	var server_url := ClientConfigurator.http_url()
 
 	var generation := _begin_client_status_refresh_run()
 	_client_status_refresh_thread = Thread.new()
@@ -2138,14 +2145,14 @@ func _run_client_status_refresh_worker(client_probes: Array[Dictionary], server_
 		var client_id := String(probe.get("id", ""))
 		if client_id.is_empty():
 			continue
-		var details := McpClientConfigurator.check_status_details_for_url_with_cli_path(
+		var details := ClientConfigurator.check_status_details_for_url_with_cli_path(
 			client_id,
 			server_url,
 			String(probe.get("cli_path", ""))
 		)
 		var installed := bool(probe.get("installed", false))
 		results[client_id] = {
-			"status": details.get("status", McpClient.Status.NOT_CONFIGURED),
+			"status": details.get("status", Client.Status.NOT_CONFIGURED),
 			"installed": installed,
 			"error_msg": details.get("error_msg", ""),
 		}
@@ -2161,7 +2168,7 @@ func _apply_client_status_refresh_results(results: Dictionary, generation: int) 
 		_client_status_refresh_thread = null
 	if _server_blocks_client_health():
 		for client_id in _client_rows:
-			_apply_row_status(String(client_id), McpClient.Status.ERROR, _server_blocked_client_message())
+			_apply_row_status(String(client_id), Client.Status.ERROR, _server_blocked_client_message())
 		_finalize_completed_refresh()
 		return
 
@@ -2175,7 +2182,7 @@ func _apply_client_status_refresh_results(results: Dictionary, generation: int) 
 		var result: Dictionary = results[client_id]
 		_apply_row_status(
 			String(client_id),
-			result.get("status", McpClient.Status.NOT_CONFIGURED),
+			result.get("status", Client.Status.NOT_CONFIGURED),
 			str(result.get("error_msg", "")),
 			result.get("installed", false)
 		)
@@ -2221,7 +2228,7 @@ func _refresh_drift_banner(mismatched_ids: Array[String]) -> void:
 		return
 	var names: Array[String] = []
 	for id in mismatched_ids:
-		names.append(McpClientConfigurator.client_display_name(id))
+		names.append(ClientConfigurator.client_display_name(id))
 	## Active server URL is already shown on the WS:/HTTP: line above the
 	## Clients section, so it doesn't need to repeat here. Lead with the
 	## client names — that's the only thing the user can act on.
@@ -2245,7 +2252,7 @@ func _on_reconfigure_mismatched() -> void:
 
 func _apply_row_status(
 	client_id: String,
-	status: McpClient.Status,
+	status: Client.Status,
 	error_msg: String = "",
 	installed_override: Variant = null,
 ) -> void:
@@ -2257,20 +2264,20 @@ func _apply_row_status(
 	var configure_btn: Button = row["configure_btn"]
 	var remove_btn: Button = row["remove_btn"]
 	var name_label: Label = row["name_label"]
-	var base_name := McpClientConfigurator.client_display_name(client_id)
+	var base_name := ClientConfigurator.client_display_name(client_id)
 	match status:
-		McpClient.Status.CONFIGURED:
+		Client.Status.CONFIGURED:
 			dot.color = Color.GREEN
 			configure_btn.text = "Reconfigure"
 			remove_btn.visible = true
 			name_label.text = base_name
-		McpClient.Status.NOT_CONFIGURED:
+		Client.Status.NOT_CONFIGURED:
 			dot.color = COLOR_MUTED
 			configure_btn.text = "Configure"
 			remove_btn.visible = false
-			var installed: bool = installed_override if installed_override != null else McpClientConfigurator.is_installed(client_id)
+			var installed: bool = installed_override if installed_override != null else ClientConfigurator.is_installed(client_id)
 			name_label.text = base_name if installed else "%s  (not detected)" % base_name
-		McpClient.Status.CONFIGURED_MISMATCH:
+		Client.Status.CONFIGURED_MISMATCH:
 			## Amber matches the dock-level drift banner so a glance at the
 			## row + the banner read as the same condition.
 			dot.color = COLOR_AMBER

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -100,7 +100,7 @@ var _server_restart_in_progress := false
 var _last_mismatched_ids: Array[String] = []
 var _client_status_refresh_thread: Thread
 ## Single source of truth for the refresh-sweep state machine. See
-## `McpClientRefreshState` for the transition table. Replaces the
+## `ClientRefreshStateScript` for the transition table. Replaces the
 ## previously scattered booleans (`_in_flight`, `_timed_out`,
 ## `_deferred_until_filesystem_ready`, `_shutdown_requested`).
 var _refresh_state: int = ClientRefreshStateScript.IDLE
@@ -764,7 +764,7 @@ func _update_status() -> void:
 		connected = false
 
 	## One `match`/`elif` chain, one source of truth. Adding a new
-	## spawn outcome = one `McpServerState` constant + one arm here +
+	## spawn outcome = one `ServerStateScript` constant + one arm here +
 	## one body string in `_crash_body_for_state`.
 	var status_text: String
 	var status_color: Color

--- a/tests/unit/test_deferred_timeout_contract.py
+++ b/tests/unit/test_deferred_timeout_contract.py
@@ -18,5 +18,6 @@ def test_deferred_timeout_error_code_registered_on_both_sides() -> None:
 def test_dispatcher_tracks_deferred_ids_and_emits_timeout_error() -> None:
     source = (PLUGIN_ROOT / "dispatcher.gd").read_text()
     assert "_pending_deferred" in source
-    assert "McpErrorCodes.DEFERRED_TIMEOUT" in source
+    assert 'const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")' in source
+    assert "ErrorCodes.DEFERRED_TIMEOUT" in source
     assert "complete_deferred_response" in source

--- a/tests/unit/test_editor_focus_refocus.py
+++ b/tests/unit/test_editor_focus_refocus.py
@@ -28,7 +28,7 @@ def test_client_status_refresh_runs_on_background_thread_and_applies_deferred() 
 
     assert "var _client_status_refresh_thread: Thread" in source
     assert "_client_status_refresh_thread.start" in source
-    assert "McpClientConfigurator.check_status" in source
+    assert "ClientConfigurator.check_status" in source
     assert 'call_deferred("_apply_client_status_refresh_results' in source
 
 
@@ -133,15 +133,15 @@ def test_initial_paint_warms_worker_call_graph_before_threading() -> None:
     )
 
     warm_block = get_func_block(source, "func _warm_strategy_bytecode() -> void:")
-    assert "McpJsonStrategy." in warm_block, (
-        "_warm_strategy_bytecode must dereference McpJsonStrategy so the "
+    assert "JsonStrategy." in warm_block, (
+        "_warm_strategy_bytecode must dereference JsonStrategy so the "
         "worker can't race the JSON strategy's lazy bytecode swap."
     )
-    assert "McpTomlStrategy." in warm_block, (
-        "_warm_strategy_bytecode must dereference McpTomlStrategy."
+    assert "TomlStrategy." in warm_block, (
+        "_warm_strategy_bytecode must dereference TomlStrategy."
     )
-    assert "McpCliStrategy." in warm_block, (
-        "_warm_strategy_bytecode must dereference McpCliStrategy."
+    assert "CliStrategy." in warm_block, (
+        "_warm_strategy_bytecode must dereference CliStrategy."
     )
     assert "FileAccess" not in warm_block and "OS.execute" not in warm_block, (
         "_warm_strategy_bytecode must stay pure-memory — no disk, no "
@@ -557,13 +557,13 @@ def test_check_uv_version_caches_for_session() -> None:
 
     dock_source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
     install_block = get_func_block(dock_source, "func _on_install_uv() -> void:")
-    assert "McpClientConfigurator.invalidate_uvx_cli_cache()" in install_block, (
+    assert "ClientConfigurator.invalidate_uvx_cli_cache()" in install_block, (
         "_on_install_uv must invalidate the CLI-path cache via the "
         "configurator helper (which knows the OS-specific binary name). "
-        'A direct `McpCliFinder.invalidate("uvx")` would leave the '
+        'A direct `CliFinder.invalidate("uvx")` would leave the '
         "Windows cache stale — Windows caches under `uvx.exe`."
     )
-    assert "McpClientConfigurator.invalidate_uv_version_cache()" in install_block, (
+    assert "ClientConfigurator.invalidate_uv_version_cache()" in install_block, (
         "_on_install_uv must invalidate the version cache too — without "
         "this, the dock's setup status keeps showing 'uv: not found' "
         "after a successful install."
@@ -586,7 +586,7 @@ def test_configure_all_uses_cached_status_not_dot_color() -> None:
     source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
     block = get_func_block(source, "func _on_configure_all_clients() -> void:")
 
-    assert 'get("status", McpClient.Status.NOT_CONFIGURED)' in block
+    assert 'get("status", Client.Status.NOT_CONFIGURED)' in block
     assert "dot.color" not in block
 
 

--- a/tests/unit/test_plugin_self_update_safety.py
+++ b/tests/unit/test_plugin_self_update_safety.py
@@ -55,14 +55,18 @@ PLUGIN_ROOT = REPO_ROOT / "plugin" / "addons" / "godot_ai"
 PLUGIN_GD = PLUGIN_ROOT / "plugin.gd"
 
 # Beta #297 moved plugin-owned startup/update work into these scripts.
-# This is intentionally the targeted PR #309 adaptation surface, not a
-# broad cleanup of every direct/transitive preload such as the dock,
-# handlers, connection, or client strategy scripts.
+# This is intentionally the targeted PR #309 adaptation surface plus the
+# PR 9 depth-1 infrastructure follow-up, not a broad cleanup of every
+# direct/transitive preload such as handlers or client strategy scripts.
 TARGETED_LOAD_SURFACE_FILES = (
     PLUGIN_GD,
     PLUGIN_ROOT / "utils" / "server_lifecycle.gd",
     PLUGIN_ROOT / "utils" / "port_resolver.gd",
     PLUGIN_ROOT / "utils" / "update_manager.gd",
+    PLUGIN_ROOT / "connection.gd",
+    PLUGIN_ROOT / "dispatcher.gd",
+    PLUGIN_ROOT / "mcp_dock.gd",
+    PLUGIN_ROOT / "client_configurator.gd",
 )
 
 
@@ -91,14 +95,13 @@ def _strip_gdscript_comments(source: str) -> str:
     return re.sub(r"#.*$", "", source, flags=re.MULTILINE)
 
 
-def test_plugin_gd_has_no_typed_field_against_plugin_class_names() -> None:
-    """`plugin.gd` field declarations must not type-bind to any `Mcp*` class.
+def test_targeted_load_scripts_have_no_typed_fields_against_plugin_class_names() -> None:
+    """Targeted load-path field declarations must not type-bind to `Mcp*`.
 
     See module docstring for the parse-hazard mechanism. Untype the field;
     keep the type fence on handler `_init` parameters.
     """
 
-    source = PLUGIN_GD.read_text()
     mcp_classes = _registered_mcp_class_names()
     assert mcp_classes, (
         "Sanity check: expected to find Mcp* class_name declarations in the addon tree"
@@ -109,14 +112,20 @@ def test_plugin_gd_has_no_typed_field_against_plugin_class_names() -> None:
     # vars inside functions, which the parser resolves lazily and which
     # are not part of the parse-time hazard.
     typed_field = re.compile(r"^var\s+(\w+)\s*:\s*(Mcp\w+)\b", re.MULTILINE)
-    offenders: list[tuple[str, str]] = []
-    for match in typed_field.finditer(source):
-        field_name, type_name = match.group(1), match.group(2)
-        if type_name in mcp_classes:
-            offenders.append((field_name, type_name))
+    offenders: list[str] = []
+
+    for gd_file in TARGETED_LOAD_SURFACE_FILES:
+        source = _strip_gdscript_comments(gd_file.read_text())
+        for match in typed_field.finditer(source):
+            field_name, type_name = match.group(1), match.group(2)
+            if type_name not in mcp_classes:
+                continue
+            line_no = source.count("\n", 0, match.start()) + 1
+            rel_path = gd_file.relative_to(REPO_ROOT)
+            offenders.append(f"{rel_path}:{line_no}: var {field_name}: {type_name}")
 
     assert not offenders, (
-        "plugin.gd must not declare typed fields against plugin class_names "
+        "Targeted load-path scripts must not declare typed fields against plugin class_names "
         "(self-update parse hazard, issues #242 / #244). Untype the field "
         "and rely on the typed handler `_init` parameters for the type "
         f"fence. Offending declarations: {offenders}"


### PR DESCRIPTION
## Summary

Base: `beta`.

This extends the self-update parse-hazard preload-alias policy from PR #312 to the next four depth-1 infrastructure scripts from the issue #297 roadmap comment: https://github.com/hi-godot/godot-ai/issues/297#issuecomment-4373410003.

PR #313 was already landed on `beta` before this branch was created.

Covered scripts only:

- `plugin/addons/godot_ai/connection.gd`
- `plugin/addons/godot_ai/dispatcher.gd`
- `plugin/addons/godot_ai/mcp_dock.gd`
- `plugin/addons/godot_ai/client_configurator.gd`

This keeps the scope narrow to the PR 9 next ring. `_meta_tool.py` JSON-string coercion, finding #8 from #297, is deferred to PR 10+ / remaining cleanup.

## Context

This follows the parse-hazard context from #242 and #244, where plugin load-path code must not type-bind or member-access plugin-defined `class_name Mcp*` symbols through Godot's global class registry during self-update reload.

The policy being extended is PR #312: use script-local `preload(...)` aliases for constructors, constants, enums, and static methods, and untype parse-sensitive top-level fields that bind to plugin `Mcp*` classes.

## Changes

- Added local preload aliases in the four PR 9 files.
- Untyped targeted top-level fields that referenced plugin `Mcp*` classes.
- Routed constructor, enum, constant, and static-method references through local aliases.
- Kept runtime type fences where practical, including `_init(...)` / `setup(...)` parameters.
- Used alias-based enum/script types in `client_configurator.gd` where Godot accepts them.
- Expanded `tests/unit/test_plugin_self_update_safety.py` to cover the four PR 9 targeted files without broadening to the full transitive graph.
- Updated static source tests that intentionally assert the alias form.

## Test Plan

- `ruff check src/ tests/`
- `pytest -v`
- `pytest -q tests/unit/test_plugin_self_update_safety.py`
- `script/ci-check-gdscript`
- `script/local-self-update-smoke --no-launch` with a fresh project dir; the default temp dir refused reuse due to a stale marker from a previous run
- `script/ci-reload-test` in the CI-style topology with an external MCP server adopted by the plugin
- `script/ci-godot-tests` live against this branch's `test_project`