### PR TITLE
PR 11: Document and pin FastMCP middleware order (#14) + closing docs sweep

### DIFF
--- a/.claude/skills/godot-ai/skill.md
+++ b/.claude/skills/godot-ai/skill.md
@@ -14,7 +14,7 @@ globs:
   - `server.py` — entrypoint, lifespan, tool registration, `--exclude-domains` support
   - `tools/` — MCP tool modules (session, editor, scene, node, project, script, resource, filesystem, signal, autoload, input_map, testing, batch, client, ui, theme, animation, material, particle, camera, audio) + `_meta_tool.py` (`register_manage_tool` rollup factory)
   - `resources/` — `godot://...` read-only URIs (sessions, editor, project, nodes, scripts, scenes, library)
-  - `middleware/` — `StripClientWrapperKwargs`, `ParseStringifiedParams`, `HintOpTypoOnManage`
+  - `middleware/` — `PreserveGodotCommandErrorData`, `StripClientWrapperKwargs`, `ParseStringifiedParams`, `HintOpTypoOnManage` (registration order is load-bearing — see the docstring above the `mcp.add_middleware(...)` calls in `server.py` and `tests/unit/test_server_middleware_order.py`)
   - `handlers/` — shared sync handlers using `DirectRuntime`; `_readiness.py` gates writes
   - `runtime/direct.py` — `DirectRuntime`, the in-process runtime adapter
   - `transport/websocket.py` — WebSocket server for Godot plugin

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ AI Client → MCP (stdio/sse/streamable-http) → Python FastMCP server → WebS
 - **`batch_execute` uses plugin command names, not MCP tool names**: The MCP tool `node_create` dispatches the plugin command `create_node`. Inside `batch_execute`'s `commands[].command` field, use the plugin name (`create_node`), not the MCP name (`node_create`). Inside a `<domain>_manage` op, the same rule applies — `node_manage(op="delete", params={...})` delegates to the plugin's `delete_node`, not `node_delete`. The Python handlers in `src/godot_ai/handlers/` are the authoritative map — each handler calls `runtime.send_command("<plugin_cmd>", ...)`. When `batch_execute` receives an unknown plugin command, the GDScript dispatcher returns `INVALID_PARAMS` with fuzzy `data.suggestions`. Inside a `<domain>_manage` rollup, op-name validation happens earlier — at the FastMCP/Pydantic schema boundary, since `op` is typed `Literal[...]` of the registered op names. A misspelling like `theme_manage(op="set_colour")` surfaces as a Pydantic `literal_error` whose message lists the valid alternatives ("Input should be 'create', 'set_color', …"), not a structured `data.suggestions` payload. The meta-tool's own `difflib`-based fallback in `dispatch_manage_op` only fires when the call somehow bypasses Pydantic (e.g. a future internal direct-dispatch caller).
 - **Session IDs**: format is `<project-slug>@<4hex>` (e.g. `godot-ai@a3f2`). The slug is derived from the project directory name so agents can recognize which editor they're targeting; the hex suffix disambiguates same-project twins. Server treats the ID as an opaque key.
 - **Per-call session routing**: every Godot-talking tool accepts an optional `session_id` parameter. Empty (the default) resolves to the global active session. When supplied, that single call targets that session — `require_writable` and every handler inside the call see the pinned session, not the active one. Use this when multiple AI clients share one MCP server. For `<domain>_manage` rollups, `session_id` is a sibling of `op` and `params` (top-level), *not* nested inside `params`. Resources (`godot://...`) still resolve via the active session.
+- **FastMCP middleware order is load-bearing**: `src/godot_ai/server.py` registers, in this order, `PreserveGodotCommandErrorData → StripClientWrapperKwargs → ParseStringifiedParams → HintOpTypoOnManage`. FastMCP composes the chain via `reversed(self.middleware)`, so first-added is **outermost** (sees response last) and last-added is **innermost** (sees response first). The four positions are reasoned out in the docstring above the `mcp.add_middleware(...)` calls in `server.py`; the order is locked by `tests/unit/test_server_middleware_order.py`. Adding new middleware: read that docstring, decide the position, update both the docstring and the test in lockstep.
 
 ## Worktrees
 
@@ -183,7 +184,7 @@ The harness creates a disposable project with a physical addon copy, stages a sy
 
 ### Python tests
 ```bash
-pytest -v                    # 686 unit + integration tests
+pytest -v                    # 757 unit + integration tests
 ```
 
 ### Godot-side tests

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -1,6 +1,6 @@
 # Godot AI — Working Plan
 
-*Updated 2026-04-29 (audio_*, ui_set_text, animation_preset_*, resource_create, control_draw_recipe shipped; tool surface collapsed to ~39 via `<domain>_manage` rollups)*
+*Updated 2026-05-04 (audit cleanup PRs #298–#315 + PR 11 landed on `beta`: scene-path ancestry guard, update/config data-loss safeguards, lifecycle reliability, characterization tests, plugin.gd extraction, state-model cleanup, UpdateManager extraction, Runtime Protocol deletion, narrowed meta-tool JSON coercion, self-update preload-alias hardening, locked FastMCP middleware order)*
 
 This is the current working plan for Godot AI. It focuses on active and upcoming work only.
 
@@ -75,7 +75,7 @@ Adjacent reference docs:
 - [x] batch execution is shipped with a clear contract
 - [x] multi-instance routing works in practice
 - [x] `script.patch` decision is made (shipped: anchor-based replace)
-- [x] test coverage and smoke coverage increase where the new runtime loop needs it (686 Python + 991 GDScript = 1677 total)
+- [x] test coverage and smoke coverage increase where the new runtime loop needs it (757 Python + 991+ GDScript)
 
 ---
 

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -1,6 +1,6 @@
 # Godot AI — Plugin Architecture
 
-*Updated 2026-04-29 (refresh file-structure tree, server-side modules, session metadata, and handshake JSON to match shipped code; add `<domain>_manage` rollups + resources + middleware to server responsibilities)*
+*Updated 2026-05-04 (add `PreserveGodotCommandErrorData` to the middleware list and note registration-order is load-bearing; previous: refresh file-structure tree, server-side modules, session metadata, and handshake JSON to match shipped code; add `<domain>_manage` rollups + resources + middleware to server responsibilities)*
 
 This document is the architecture reference for the Godot-side plugin and the server-to-plugin interaction model.
 
@@ -49,7 +49,7 @@ That includes:
 - the rolled-up tool surface — ~15 named verbs plus per-domain `<domain>_manage` tools wired by `tools/_meta_tool.py::register_manage_tool`, which builds a dynamic `Literal[...]` op enum so schema-aware clients see every op
 - read-only `godot://...` MCP resources (sessions, editor state, scenes, nodes, scripts, project, materials, performance, test results) that mirror the cheap reads and don't count against tool-cap budgets
 - per-call session routing — every Godot-talking tool accepts an optional `session_id`, bound at the `DirectRuntime` boundary so `require_writable` and downstream handlers see the pinned session, not the active one
-- middleware that smooths over client quirks: `StripClientWrapperKwargs` (Cline's `task_progress`), `ParseStringifiedParams` (clients that auto-stringify nested params for `_manage` calls), `HintOpTypoOnManage` (rewrites Pydantic `literal_error` with a `difflib`-derived "Did you mean" hint)
+- middleware that smooths over client quirks and shapes error responses: `PreserveGodotCommandErrorData` (outermost — packages `GodotCommandError` with structured `error.data` so candidate-path / suggestion payloads survive), `StripClientWrapperKwargs` (Cline's `task_progress`), `ParseStringifiedParams` (clients that auto-stringify nested params for `_manage` calls), `HintOpTypoOnManage` (innermost — rewrites Pydantic `literal_error` with a `difflib`-derived "Did you mean" hint). Order is load-bearing and locked by `tests/unit/test_server_middleware_order.py`; rationale lives in the docstring above the `mcp.add_middleware(...)` calls in `server.py`.
 - session registry and active-session resolution, with `<project-slug>@<4hex>` IDs and substring/path matching in `session_activate`
 - request validation and structured error mapping (`protocol/errors.py`)
 - job tracking for long-running operations and the deferred-response pattern for replies that flow back over a different channel (game capture)
@@ -121,7 +121,7 @@ The server-side counterparts live in:
 - `src/godot_ai/handlers/` — shared sync handlers; `_readiness.py` gates writes; `_target.py` resolves nodes
 - `src/godot_ai/tools/` — MCP tool wrappers per domain + `_meta_tool.py::register_manage_tool` rollup factory + `domains.py` (CI-paired with `tool_catalog.gd`)
 - `src/godot_ai/resources/` — read-only `godot://...` URI handlers
-- `src/godot_ai/middleware/` — `StripClientWrapperKwargs`, `ParseStringifiedParams`, `HintOpTypoOnManage`
+- `src/godot_ai/middleware/` — `PreserveGodotCommandErrorData`, `StripClientWrapperKwargs`, `ParseStringifiedParams`, `HintOpTypoOnManage` (registration order is load-bearing — see `server.py` docstring + `tests/unit/test_server_middleware_order.py`)
 - `src/godot_ai/protocol/` — envelope types and error codes (kept in sync with `utils/error_codes.gd`)
 
 ---

--- a/src/godot_ai/server.py
+++ b/src/godot_ai/server.py
@@ -162,22 +162,44 @@ def create_server(
         lifespan=_lifespan,
     )
 
-    ## Keep plugin-provided error.data (e.g. candidate paths) visible on MCP
-    ## tool error responses instead of collapsing it into plain text.
+    ## Middleware registration order is load-bearing — do not reorder
+    ## without reading the rationale below. Locked by
+    ## ``tests/unit/test_server_middleware_order.py``.
+    ##
+    ## FastMCP composes the chain by iterating ``reversed(self.middleware)``
+    ## (see ``fastmcp/server/server.py::_run_middleware``), so the
+    ## **first-added** middleware is the **outermost** wrap (runs first on
+    ## request, last on response) and the **last-added** is the **innermost**
+    ## (runs last on request, first on response). Each layer below is placed
+    ## where it is for a specific reason:
+    ##
+    ## 1. ``PreserveGodotCommandErrorData`` — outermost on the response
+    ##    side. Catches ``GodotCommandError`` raised from any inner layer
+    ##    (handlers, plugin client, validation) and packages structured
+    ##    ``error.data`` (e.g. plugin-provided candidate paths) into the
+    ##    MCP tool result. Must be outermost so no inner middleware can
+    ##    collapse the structured payload into plain text before this
+    ##    catches it.
+    ##
+    ## 2. ``StripClientWrapperKwargs`` — early on the request side. Removes
+    ##    known client-injected wrapper kwargs (e.g. Cline's
+    ##    ``task_progress``) before any inner layer or Pydantic strict-mode
+    ##    schema sees them. See #193.
+    ##
+    ## 3. ``ParseStringifiedParams`` — request-side, after wrapper-stripping
+    ##    and before Pydantic. JSON-decodes a stringified ``params`` slot on
+    ##    ``<domain>_manage`` calls so the strict-mode schema sees the dict
+    ##    the client meant to send. Must run before Pydantic (which lives
+    ##    below all middleware in the FastMCP tool layer). See #206.
+    ##
+    ## 4. ``HintOpTypoOnManage`` — innermost on the response side. Catches
+    ##    Pydantic ``ValidationError`` for ``op`` literal_error and rewrites
+    ##    it with a ``difflib``-derived "Did you mean…" hint. Must be
+    ##    innermost on response so it sees Pydantic's raw ``ValidationError``
+    ##    before any outer middleware reshapes or wraps it. See #211.
     mcp.add_middleware(PreserveGodotCommandErrorData())
-
-    ## Tolerate known client-injected wrapper kwargs (Cline's task_progress,
-    ## etc.) so strict pydantic schemas don't reject every call. See #193.
     mcp.add_middleware(StripClientWrapperKwargs())
-
-    ## Decode stringified ``params`` on ``<domain>_manage`` calls before
-    ## strict-mode Pydantic rejects them. Some clients (Cline) auto-serialize
-    ## nested objects. See #206.
     mcp.add_middleware(ParseStringifiedParams())
-
-    ## Rewrite Pydantic literal_error on ``<domain>_manage`` op typos with a
-    ## ``difflib``-derived "Did you mean" hint, since op typos are the most
-    ## common rollup-misuse pattern. See #211.
     mcp.add_middleware(HintOpTypoOnManage())
 
     exclude = set(exclude_domains or ())

--- a/tests/unit/test_server_middleware_order.py
+++ b/tests/unit/test_server_middleware_order.py
@@ -1,0 +1,53 @@
+"""Lock the registration order of FastMCP middleware in ``create_server()``.
+
+Closes #297 finding #14: middleware order in ``server.py`` is load-bearing
+but was previously undocumented and unenforced. The matching docstring lives
+above the ``mcp.add_middleware(...)`` calls in ``src/godot_ai/server.py``
+and explains the reasoning. This test pins the order so a reorder fails CI
+with a clear diff.
+
+Why runtime introspection rather than source-text:
+``mcp.middleware`` is the authoritative ordered list FastMCP iterates when
+composing the chain (``fastmcp/server/server.py::_run_middleware`` calls
+``reversed(self.middleware)``). Source-text would be a weaker, drift-prone
+check — a refactor that moved registration into a helper would silently
+break it without changing observable behavior.
+"""
+
+from __future__ import annotations
+
+from godot_ai.server import create_server
+
+EXPECTED_ORDER: tuple[str, ...] = (
+    "PreserveGodotCommandErrorData",
+    "StripClientWrapperKwargs",
+    "ParseStringifiedParams",
+    "HintOpTypoOnManage",
+)
+
+
+def test_godot_ai_middleware_registered_in_documented_order() -> None:
+    """First-added is outermost; reorder fails with the actual list named.
+
+    Filters ``mcp.middleware`` to entries whose class lives in
+    ``godot_ai.middleware.*``. FastMCP itself adds internal middleware
+    (e.g. ``DereferenceRefsMiddleware`` — see ``fastmcp/server/server.py``
+    around the ``DereferenceRefsMiddleware`` append in ``__init__``); the
+    filter keeps this test resilient to FastMCP version bumps that change
+    or extend the internal set without affecting the godot_ai chain.
+    """
+    mcp = create_server()
+    actual = tuple(
+        type(m).__name__
+        for m in mcp.middleware
+        if type(m).__module__.startswith("godot_ai.middleware")
+    )
+    assert actual == EXPECTED_ORDER, (
+        "godot_ai middleware registration order drifted.\n"
+        f"  expected: {list(EXPECTED_ORDER)}\n"
+        f"  actual:   {list(actual)}\n"
+        "If you intentionally reordered, update the docstring above the "
+        "mcp.add_middleware(...) calls in src/godot_ai/server.py and "
+        "update EXPECTED_ORDER here in lockstep — the order is load-bearing "
+        "(see the rationale block in server.py)."
+    )

--- a/tests/unit/test_server_middleware_order.py
+++ b/tests/unit/test_server_middleware_order.py
@@ -12,40 +12,50 @@ composing the chain (``fastmcp/server/server.py::_run_middleware`` calls
 ``reversed(self.middleware)``). Source-text would be a weaker, drift-prone
 check — a refactor that moved registration into a helper would silently
 break it without changing observable behavior.
+
+Why class identities rather than name strings: importing the classes
+directly hard-fails at module load if a middleware is renamed or deleted,
+which is louder and earlier than a runtime assertion against a name string.
+It also lets the godot_ai-vs-FastMCP-internal split be expressed by an
+identity-set membership test rather than a stringly-typed module-prefix
+filter.
 """
 
 from __future__ import annotations
 
+from godot_ai.middleware import (
+    HintOpTypoOnManage,
+    ParseStringifiedParams,
+    PreserveGodotCommandErrorData,
+    StripClientWrapperKwargs,
+)
 from godot_ai.server import create_server
 
-EXPECTED_ORDER: tuple[str, ...] = (
-    "PreserveGodotCommandErrorData",
-    "StripClientWrapperKwargs",
-    "ParseStringifiedParams",
-    "HintOpTypoOnManage",
+EXPECTED_ORDER: tuple[type, ...] = (
+    PreserveGodotCommandErrorData,
+    StripClientWrapperKwargs,
+    ParseStringifiedParams,
+    HintOpTypoOnManage,
 )
 
 
 def test_godot_ai_middleware_registered_in_documented_order() -> None:
     """First-added is outermost; reorder fails with the actual list named.
 
-    Filters ``mcp.middleware`` to entries whose class lives in
-    ``godot_ai.middleware.*``. FastMCP itself adds internal middleware
+    Filters ``mcp.middleware`` to entries whose class is one of the four
+    godot_ai middleware classes. FastMCP itself adds internal middleware
     (e.g. ``DereferenceRefsMiddleware`` — see ``fastmcp/server/server.py``
     around the ``DereferenceRefsMiddleware`` append in ``__init__``); the
-    filter keeps this test resilient to FastMCP version bumps that change
-    or extend the internal set without affecting the godot_ai chain.
+    identity-set filter excludes them without depending on a stringly-typed
+    module prefix.
     """
     mcp = create_server()
-    actual = tuple(
-        type(m).__name__
-        for m in mcp.middleware
-        if type(m).__module__.startswith("godot_ai.middleware")
-    )
+    expected_set = set(EXPECTED_ORDER)
+    actual = tuple(type(m) for m in mcp.middleware if type(m) in expected_set)
     assert actual == EXPECTED_ORDER, (
         "godot_ai middleware registration order drifted.\n"
-        f"  expected: {list(EXPECTED_ORDER)}\n"
-        f"  actual:   {list(actual)}\n"
+        f"  expected: {[c.__name__ for c in EXPECTED_ORDER]}\n"
+        f"  actual:   {[c.__name__ for c in actual]}\n"
         "If you intentionally reordered, update the docstring above the "
         "mcp.add_middleware(...) calls in src/godot_ai/server.py and "
         "update EXPECTED_ORDER here in lockstep — the order is load-bearing "


### PR DESCRIPTION
## Summary

Base: `beta`. Closes audit finding **#14** from #297. This is the **final PR of the architecture-audit cleanup batch** (PRs 1–10 already on `beta`).

### Code change — pin middleware order

`src/godot_ai/server.py`'s four `mcp.add_middleware(...)` calls are reordering-sensitive. The four scattered single-line comments above each call gave no clue about the FastMCP composition rule or why a contributor adding a fifth middleware should think twice.

This PR:

- Replaces those scattered comments with **one consolidated rationale block** above the four calls. The block states the FastMCP composition rule (`reversed(self.middleware)` → first-added is outermost) and gives one paragraph per layer explaining why its position is load-bearing:
  1. `PreserveGodotCommandErrorData` — outermost on response, so structured `error.data` survives every inner layer.
  2. `StripClientWrapperKwargs` — early on request, so wrapper kwargs (Cline `task_progress`) never reach Pydantic.
  3. `ParseStringifiedParams` — request-side, before Pydantic strict-mode validation of `*_manage` rollups.
  4. `HintOpTypoOnManage` — innermost on response, so it sees Pydantic's raw `ValidationError` before any outer layer reshapes it.
- Adds `tests/unit/test_server_middleware_order.py` to lock the order via runtime introspection of `mcp.middleware`. The test imports the four godot_ai middleware classes directly and asserts the live registration order via identity-set membership — this hard-fails at module-import time if any middleware class is renamed or deleted, and excludes FastMCP-internal middleware (e.g. `DereferenceRefsMiddleware`) without depending on a stringly-typed module-prefix filter.

**No behavior change.** The four call sites stay in the same order; no middleware classes were modified. Failure message names the offending class so a reorder gets an immediate diff.

### Closing docs sweep

Per user direction, this PR closes the audit-cleanup batch with a docs reconciliation alongside the code:

- **`CLAUDE.md`** — new "FastMCP middleware order is load-bearing" entry in Key conventions, with a pointer to the rationale block + lock test. Documented Python test count bumped 686 → 757.
- **`.claude/skills/godot-ai/skill.md`** — adds the missing `PreserveGodotCommandErrorData` to the middleware inventory (was listing only three of four — drift caught by this sweep). Notes ordering is locked.
- **`docs/plugin-architecture.md`** — same drift fix in two middleware lists, plus a one-line ordering note. "Updated" date bumped.
- **`docs/implementation-plan.md`** — "Updated" line refreshed to call out the audit batch landing on `beta`. Python test count bumped 686 → 757.

## Test plan

- [x] `ruff check src/ tests/` (clean)
- [x] `.venv/bin/python -m pytest -q` (757 passed)
- [x] `.venv/bin/python -m pytest tests/unit/test_server_middleware_order.py -v` (1 passed)
- [x] CI green on all 11 jobs (Python 3.11 / 3.13, Release smoke + Godot tests + Game capture smoke on Linux/macOS/Windows). First run had one flake on `camera.test_create_with_make_current_unmarks_sibling` (`Godot tests / macOS`) — same family as #316 (4th recurrence in that ticket); rerun all green. PR 11 has zero camera/GDScript changes, so a real regression is mechanically impossible.

No GDScript edits → live `test_run` skipped per CLAUDE.md "Pre-commit smoke test" rules.
No self-update edits → `script/local-self-update-smoke` skipped per CLAUDE.md "Self-update" trigger list.

## Out of scope

- Changing the actual registration order — this PR locks; any future reshuffle is a separate, intentional change.
- Adding new middleware.
- Other audit-finding cleanups — #12 (error-code parity contract test), #13 (animation_handler split), debugger timer leak, CLI finder cache invalidation, structured `ci-check-gdscript` exit, `setup-dev.ps1` uv parity, broader self-update preload-alias depth-2+ work. These remain open under #297 PR 11+ for any future agent.