### PR TITLE
Fix OpenCode auto-configure on Windows: $HOME falls back to %USERPROFILE%

### DIFF
--- a/plugin/addons/godot_ai/clients/_path_template.gd
+++ b/plugin/addons/godot_ai/clients/_path_template.gd
@@ -39,6 +39,8 @@ static func expand(template: String) -> String:
 				value = _home().path_join("AppData/Roaming")
 			if value.is_empty() and var_name == "LOCALAPPDATA":
 				value = _home().path_join("AppData/Local")
+			if value.is_empty() and var_name == "HOME":
+				value = OS.get_environment("USERPROFILE")
 			out = out.replace(token, value)
 	return out
 


### PR DESCRIPTION
## Summary

- Make `$HOME` in path templates fall back to `%USERPROFILE%` on Windows, matching what `~/` already does in the same module.
- Fixes OpenCode auto-configure on Windows, which was failing with `Cannot write to /.config/opencode/opencode.json` and `ERROR: Could not create directory: '/.config'` (admin rights don't help — the path itself is malformed at the drive root because `$HOME` substituted to empty).
- One file, two lines, no behavior change on macOS / Linux / GitHub-Actions Windows runners (all of which have `HOME` set).

## Why it slipped through

[`test_opencode_client_uses_home_config_on_windows`](https://github.com/hi-godot/godot-ai/blob/main/test_project/tests/test_clients.gd) was correctly written but passes on every CI environment because GitHub Actions Windows runners set `HOME` by default. On a stock Windows install only `USERPROFILE` is set, so the empty `$HOME` substitution surfaced for the first time in user reports.

## Test plan

- [x] `pytest -v` — 733 / 733 green
- [x] `test_run suite=clients` against macOS editor — 81 / 81 green (OpenCode regression test still passes; macOS path is unchanged because `HOME` is set)
- [ ] Windows verification (manual, by user): retry the dock's `Configure` button on the OpenCode row; expect the row to flip green and the file at `%USERPROFILE%\.config\opencode\opencode.json` to be (re)written
