### PR TITLE
Dedup $HOME fallback to _home() + add mocked-env test for USERPROFILE path

### DIFF
--- a/plugin/addons/godot_ai/clients/_path_template.gd
+++ b/plugin/addons/godot_ai/clients/_path_template.gd
@@ -40,7 +40,7 @@ static func expand(template: String) -> String:
 			if value.is_empty() and var_name == "LOCALAPPDATA":
 				value = _home().path_join("AppData/Local")
 			if value.is_empty() and var_name == "HOME":
-				value = OS.get_environment("USERPROFILE")
+				value = _home()
 			out = out.replace(token, value)
 	return out
 

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -1520,14 +1520,22 @@ func test_path_template_expand_home_falls_back_to_userprofile() -> void:
 	var saved_userprofile := OS.get_environment("USERPROFILE")
 	var fake_userprofile := "/tmp/godot-ai-test-userprofile"
 
-	OS.set_environment("HOME", "")
+	OS.unset_environment("HOME")
 	OS.set_environment("USERPROFILE", fake_userprofile)
 	var via_dollar := McpPathTemplate.expand("$HOME/foo")
 	var via_tilde := McpPathTemplate.expand("~/foo")
-	# Restore before asserting so a failure can't leak a poisoned HOME
-	# into the rest of the test run.
-	OS.set_environment("HOME", saved_home)
-	OS.set_environment("USERPROFILE", saved_userprofile)
+	# Restore before asserting so a failure can't leak into later tests.
+	# Mirror the unset-when-saved-was-empty pattern used by the
+	# GODOT_AI_MODE tests above — `set_environment(var, "")` would
+	# define a new empty-valued env var rather than leave it unset.
+	if saved_home.is_empty():
+		OS.unset_environment("HOME")
+	else:
+		OS.set_environment("HOME", saved_home)
+	if saved_userprofile.is_empty():
+		OS.unset_environment("USERPROFILE")
+	else:
+		OS.set_environment("USERPROFILE", saved_userprofile)
 
 	assert_eq(via_dollar, fake_userprofile.path_join("foo"),
 		"$HOME must fall back to USERPROFILE when HOME is unset")

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -1509,6 +1509,34 @@ func test_opencode_client_uses_home_config_on_windows() -> void:
 	assert_eq(resolved, home.path_join(".config/opencode/opencode.json"))
 
 
+func test_path_template_expand_home_falls_back_to_userprofile() -> void:
+	## Defensive coverage for the Windows fallback: when HOME is unset (a
+	## stock Windows install), $HOME and ~ must both resolve via _home()'s
+	## USERPROFILE fallback. The existing OpenCode descriptor test never
+	## hits this branch on GitHub Actions Windows runners because GHA
+	## injects HOME — explicitly mock the env so the fallback path is
+	## exercised on every CI platform.
+	var saved_home := OS.get_environment("HOME")
+	var saved_userprofile := OS.get_environment("USERPROFILE")
+	var fake_userprofile := "/tmp/godot-ai-test-userprofile"
+
+	OS.set_environment("HOME", "")
+	OS.set_environment("USERPROFILE", fake_userprofile)
+	var via_dollar := McpPathTemplate.expand("$HOME/foo")
+	var via_tilde := McpPathTemplate.expand("~/foo")
+	# Restore before asserting so a failure can't leak a poisoned HOME
+	# into the rest of the test run.
+	OS.set_environment("HOME", saved_home)
+	OS.set_environment("USERPROFILE", saved_userprofile)
+
+	assert_eq(via_dollar, fake_userprofile.path_join("foo"),
+		"$HOME must fall back to USERPROFILE when HOME is unset")
+	assert_eq(via_tilde, fake_userprofile.path_join("foo"),
+		"~ must fall back to USERPROFILE when HOME is unset")
+	assert_eq(via_dollar, via_tilde,
+		"$HOME and ~ must resolve identically — both go through _home()")
+
+
 # ----- helpers -----
 
 func _assert_uvx_command(cmd: Variant) -> void:


### PR DESCRIPTION
Follow-up to #318 addressing two Copilot review points.

## Summary

- **Dedup**: route the `$HOME` fallback through `_home()` instead of a parallel `OS.get_environment("USERPROFILE")` lookup. `~` and `$HOME` now share one resolver, so a future change to home-directory logic can't make them drift apart.
- **Test**: add a focused regression that explicitly clears `HOME` and sets `USERPROFILE` to a known value, then runs both `$HOME/foo` and `~/foo` through `expand()`. The existing OpenCode descriptor test never hit the fallback on GitHub Actions Windows runners (GHA injects `HOME`), so the new branch was effectively untested in CI.

## Test plan

- [x] `pytest -v` — 733 / 733 green
- [ ] GDScript clients suite — verified by CI on all three OSes (the new test mocks env vars, so it exercises the fallback regardless of the host's `HOME`/`USERPROFILE` state)
