### PR TITLE
Detect bare-key TOML sections in _toml_strategy to fix codex duplicate-key error

### DIFF
--- a/plugin/addons/godot_ai/clients/_toml_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_toml_strategy.gd
@@ -81,11 +81,17 @@ static func remove(client: McpClient, _server_name: String) -> Dictionary:
 		return {"status": "error", "message": "Refusing to rewrite %s: %s." % [path, read["error"]]}
 	var lines: Array[String] = _split_lines(String(read["data"]))
 	var headers := _all_headers(client)
+	## Subtables in the namespace (e.g. [mcp_servers.godot-ai.tools.session_list]
+	## that codex users add to set per-tool approval_mode) must be removed
+	## too. Leaving them behind keeps `mcp_servers.godot-ai` implicitly
+	## defined, so a later configure that writes [mcp_servers."godot-ai"]
+	## produces a duplicate-key TOML error.
+	var subtable_prefixes := _subtable_prefixes(headers)
 
 	var output: Array[String] = []
 	var i := 0
 	while i < lines.size():
-		if _matches_any_header(lines[i], headers):
+		if _matches_any_header(lines[i], headers) or _matches_subtable_prefix(lines[i], subtable_prefixes):
 			i += 1
 			while i < lines.size():
 				var nt := lines[i].strip_edges()
@@ -189,6 +195,36 @@ static func _is_bare_key(s: String) -> bool:
 		if not (alpha or digit or dash_or_under):
 			return false
 	return true
+
+
+## Subtable prefixes derived from each header in `headers`. Strips the
+## closing `]` and appends `.` so a header `[a.b]` becomes the prefix
+## `[a.b.` — matching subtables `[a.b.<rest>]` but NOT siblings like
+## `[a.b-other]` (next char must be a dot, not anything bare-key-valid).
+static func _subtable_prefixes(headers: Array[String]) -> Array[String]:
+	var out: Array[String] = []
+	for h in headers:
+		if h.length() > 2 and h.ends_with("]"):
+			out.append(h.substr(0, h.length() - 1) + ".")
+	return out
+
+
+## Mirror of `_matches_any_header` for subtable prefixes — line must
+## start with `[a.b.` and have a closing `]` followed only by whitespace
+## or a comment.
+static func _matches_subtable_prefix(line: String, prefixes: Array[String]) -> bool:
+	var trimmed := line.strip_edges()
+	for p in prefixes:
+		if not trimmed.begins_with(p):
+			continue
+		var rest := trimmed.substr(p.length())
+		var bracket := rest.find("]")
+		if bracket < 0:
+			continue
+		var remainder := rest.substr(bracket + 1).strip_edges()
+		if remainder.is_empty() or remainder.begins_with("#"):
+			return true
+	return false
 
 
 ## Exact-header match. We cannot use a simple prefix check because

--- a/plugin/addons/godot_ai/clients/_toml_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_toml_strategy.gd
@@ -152,10 +152,43 @@ static func _primary_header(client: McpClient) -> String:
 
 
 static func _all_headers(client: McpClient) -> Array[String]:
-	var out: Array[String] = [_primary_header(client)]
+	var primary := _primary_header(client)
+	var out: Array[String] = [primary]
+	## TOML accepts bare keys ([A-Za-z0-9_-]+) unquoted in section headers,
+	## so [mcp_servers.godot-ai] is a valid hand-written form of the same
+	## logical key we emit as [mcp_servers."godot-ai"]. Match both during
+	## reconfigure / status / remove or a hand-edited (or older-plugin)
+	## bare-key file gets a duplicate quoted section appended that breaks
+	## the user's TOML parser.
+	var bare := _bare_key_header(client)
+	if not bare.is_empty() and bare != primary:
+		out.append(bare)
 	for legacy in client.toml_legacy_section_aliases:
 		out.append("[%s]" % legacy)
 	return out
+
+
+static func _bare_key_header(client: McpClient) -> String:
+	var parts := client.toml_section_path
+	if parts.is_empty():
+		return ""
+	for p in parts:
+		if not _is_bare_key(String(p)):
+			return ""
+	return "[%s]" % ".".join(parts)
+
+
+static func _is_bare_key(s: String) -> bool:
+	if s.is_empty():
+		return false
+	for i in range(s.length()):
+		var c := s.unicode_at(i)
+		var alpha := (c >= 65 and c <= 90) or (c >= 97 and c <= 122)
+		var digit := c >= 48 and c <= 57
+		var dash_or_under := c == 45 or c == 95  # '-' or '_'
+		if not (alpha or digit or dash_or_under):
+			return false
+	return true
 
 
 ## Exact-header match. We cannot use a simple prefix check because

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -980,14 +980,32 @@ func test_toml_strategy_detects_bare_key_section_no_duplicate_on_reconfigure() -
 	assert_contains(content, "[mcp_servers.godot-ai.tools.session_list]")
 	assert_contains(content, "approval_mode = \"approve\"")
 
-	## remove must also clean the bare-key form (was a silent no-op).
+	## remove must clean the bare-key form (was a silent no-op) AND the
+	## subtables under the namespace. Leaving subtables behind would
+	## keep mcp_servers.godot-ai implicitly defined, so a later
+	## configure rewriting [mcp_servers."godot-ai"] produces a
+	## duplicate-key TOML error — the same shape the original bug took.
 	var removed := McpTomlStrategy.remove(client, "godot-ai")
 	assert_eq(removed.get("status"), "ok")
 	var after_remove := FileAccess.open(path, FileAccess.READ).get_as_text()
 	assert_eq(after_remove.count("[mcp_servers.godot-ai]\n"), 0,
-		"remove must clean the bare-key section:\n%s" % after_remove)
+		"remove must clean the bare-key parent section:\n%s" % after_remove)
 	assert_eq(after_remove.count("[mcp_servers.\"godot-ai\"]\n"), 0,
-		"remove must clean the quoted-key section:\n%s" % after_remove)
+		"remove must clean the quoted-key parent section:\n%s" % after_remove)
+	assert_eq(after_remove.count("[mcp_servers.godot-ai.tools.session_list]"), 0,
+		"remove must clean subtables in the namespace:\n%s" % after_remove)
+	assert_eq(after_remove.count("approval_mode"), 0,
+		"subtable bodies must be removed too:\n%s" % after_remove)
+
+	## Round-trip: configure-after-remove must produce a clean,
+	## parseable file with exactly one godot-ai section.
+	var reconfigure := McpTomlStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+	assert_eq(reconfigure.get("status"), "ok")
+	var final_content := FileAccess.open(path, FileAccess.READ).get_as_text()
+	var final_bare := final_content.count("[mcp_servers.godot-ai]\n")
+	var final_quoted := final_content.count("[mcp_servers.\"godot-ai\"]\n")
+	assert_eq(final_bare + final_quoted, 1,
+		"configure-after-remove must produce exactly one godot-ai section (bare=%d quoted=%d):\n%s" % [final_bare, final_quoted, final_content])
 
 
 # ----- configure/remove verify-after-write (#201) -----

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -933,6 +933,63 @@ func test_toml_strategy_preserves_other_sections() -> void:
 	assert_contains(content, "[mcp_servers.\"godot-ai\"]")
 
 
+func test_toml_strategy_detects_bare_key_section_no_duplicate_on_reconfigure() -> void:
+	## Regression for the codex duplicate-key bug. TOML accepts bare keys
+	## [A-Za-z0-9_-]+ unquoted, so a hand-written or older-plugin
+	## [mcp_servers.godot-ai] section refers to the same logical key as
+	## the quoted [mcp_servers."godot-ai"] we emit. Reconfigure must
+	## update the bare-key section in place — appending a duplicate
+	## quoted section makes the file fail to parse.
+	var path := _scratch_dir.path_join("bare_key_codex.toml")
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	f.store_string(
+		"[mcp_servers.godot-ai]\n" +
+		"url = \"http://127.0.0.1:7000/mcp\"\n" +
+		"enabled = true\n" +
+		"\n" +
+		"[mcp_servers.godot-ai.tools.session_list]\n" +
+		"approval_mode = \"approve\"\n"
+	)
+	f.close()
+
+	var client := _make_test_toml_client(path)
+
+	## check_status must recognise the bare-key form (was reporting
+	## NOT_CONFIGURED, masking that an entry already existed).
+	assert_eq(
+		McpTomlStrategy.check_status(client, "godot-ai", "http://127.0.0.1:8000/mcp"),
+		McpClient.Status.CONFIGURED_MISMATCH,
+		"bare-key section must be detected by check_status"
+	)
+
+	## configure must update the bare-key section in place. After the
+	## write there must be exactly one godot-ai section header (counting
+	## both bare and quoted forms) — anything else is the duplicate that
+	## breaks the user's TOML parser.
+	var result := McpTomlStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+	assert_eq(result.get("status"), "ok")
+
+	var content := FileAccess.open(path, FileAccess.READ).get_as_text()
+	var bare_count := content.count("[mcp_servers.godot-ai]\n")
+	var quoted_count := content.count("[mcp_servers.\"godot-ai\"]\n")
+	assert_eq(bare_count + quoted_count, 1,
+		"exactly one godot-ai section must exist after reconfigure (bare=%d quoted=%d):\n%s" % [bare_count, quoted_count, content])
+
+	## The user's nested subtable customisation must survive — the
+	## strategy only owns the matched section, not its children.
+	assert_contains(content, "[mcp_servers.godot-ai.tools.session_list]")
+	assert_contains(content, "approval_mode = \"approve\"")
+
+	## remove must also clean the bare-key form (was a silent no-op).
+	var removed := McpTomlStrategy.remove(client, "godot-ai")
+	assert_eq(removed.get("status"), "ok")
+	var after_remove := FileAccess.open(path, FileAccess.READ).get_as_text()
+	assert_eq(after_remove.count("[mcp_servers.godot-ai]\n"), 0,
+		"remove must clean the bare-key section:\n%s" % after_remove)
+	assert_eq(after_remove.count("[mcp_servers.\"godot-ai\"]\n"), 0,
+		"remove must clean the quoted-key section:\n%s" % after_remove)
+
+
 # ----- configure/remove verify-after-write (#201) -----
 #
 # A strategy returning `status: ok` is necessary but not sufficient — a write


### PR DESCRIPTION
## Summary

When a user's TOML file has a bare-key section like `[mcp_servers.godot-ai]` (valid TOML — bare keys allow `[A-Za-z0-9_-]+`), `McpTomlStrategy._all_headers` only considered the quoted form `[mcp_servers."godot-ai"]` that `_primary_header` always emits. `_find_section` returned empty, `configure` fell through to the append-at-end path, and the resulting file had two godot-ai sections. Codex's TOML parser rejects that with `duplicate key`:

```
Error loading config.toml:
~/.codex/config.toml:99:14: duplicate key
   |
99 | [mcp_servers."godot-ai"]
   |              ^^^^^^^^^^
```

Same root cause also made `check_status` report `NOT_CONFIGURED` for bare-key files (the dock looked like the client was unconfigured even when an entry existed), and made `remove` a silent no-op.

## Fix

- Add `_bare_key_header` / `_is_bare_key` helpers in [plugin/addons/godot_ai/clients/_toml_strategy.gd](plugin/addons/godot_ai/clients/_toml_strategy.gd:154).
- Include the bare form in `_all_headers` when every segment of `toml_section_path` matches the bare-key character class.
- `_primary_header` is unchanged — new writes keep emitting the quoted form, so existing quoted-form files don't churn. The matcher just tolerates either spelling.

## Reproduction (pre-fix)

1. Hand-edit `~/.codex/config.toml` to add `[mcp_servers.godot-ai]\nurl = "..."\nenabled = true` (bare-key form).
2. Click **Reconfigure** on the Codex row in the godot-ai dock.
3. Open the file — there are now two `godot-ai` sections (one bare, one quoted). `codex` errors on launch.

## Test plan

- [x] `pytest -v` — 733 / 733 green (Python tests unaffected; included as a smoke check).
- [ ] GDScript clients suite — covered by the new `test_toml_strategy_detects_bare_key_section_no_duplicate_on_reconfigure`. The test fixtures the codex shape (bare-key parent section + nested `.tools.session_list` subtable that a user might add to set `approval_mode = "approve"`) and asserts:
  - `check_status` returns `CONFIGURED_MISMATCH` instead of `NOT_CONFIGURED`.
  - `configure` updates the section in place — exactly one `godot-ai` section header in the resulting file (counting both spellings).
  - The user's nested subtable customisation survives.
  - `remove` cleans the bare-key form (was a silent no-op).
