### PR TITLE
Fix MegaSmoke lifecycle recovery regressions

### DIFF
--- a/docs/friction-log.md
+++ b/docs/friction-log.md
@@ -12,6 +12,178 @@ edges that aren't necessarily code bugs.
 
 ---
 
+## 2026-05-04 — MegaSmoke beta (`origin/beta` 767220a)
+
+Live operator-driven smoke run against PR 11-inclusive beta
+(`767220a`, "PR 11: Document and pin FastMCP middleware order (#14) +
+closing docs sweep (#317)"). Started 2026-05-04 13:46:01 PDT on macOS.
+
+Scope: issue #297 audit refactor stack, PR 11 middleware-order contract,
+high-traffic MCP tools, reload/self-update paths, multi-session routing,
+middleware edge cases, and real editor/game-process behavior.
+
+### Baseline gates
+
+| Gate | Status | Notes |
+| --- | --- | --- |
+| `ruff check src/ tests/` | pass | All checks passed. |
+| `pytest -v` | pass | Sandbox run blocked localhost connects with `PermissionError: [Errno 1]`; rerun with socket permission passed, 768 passed in 35.38s. |
+| `script/ci-check-gdscript` | pass | Headless import completed; all GDScript files OK. |
+| MCP `test_run` | pass | Live `test-project@43b6`: 1132 passed, 0 failed, 5 skipped across 44 suites in 4265 ms. |
+| `script/ci-reload-test` | fail | Created `/Main/ReloadTestCube`, then `editor_reload_plugin` returned empty SSE; external `script/serve-this-worktree` server was killed/replaced by plugin-managed server. Test node cleaned up manually. |
+| `script/ci-game-capture-smoke` | pass with workaround | Direct shebang failed because system Python lacked `PIL`; rerun with `.venv/bin/python` passed, 1920x1080 game PNG quadrants OK. |
+| `script/local-self-update-smoke --no-launch` | pass with workaround | Default temp path refused as unsafe stale fixture; explicit `/private/tmp/godot-ai-megasmoke-self-update-smoke` prepared v2.3.2 -> v2.3.3 fixture. |
+| interactive `script/local-self-update-smoke` + Update click | pass after harness patch | Initial managed-server run passed the core safety checks but then exposed a version-mismatch recovery loop, logged below. Managed-server rerun on `codex/megasmoke-results-harness-fix` at 14:27 PDT passed with plugin v2.3.3, server `godot-ai==2.3.2`, temp update dir consumed, no new `.ips`, managed server stopped, and no server/plugin version mismatch reported. Separate foreign/orphan lifecycle scenarios are not covered by this harness rerun. |
+| `script/manual-orphan-test setup` + macOS live matrix | pass after patches | Prepared `/tmp/orphan-sim` and `/tmp/sim-statusonly`. Compatible external adoption passed; managed drift cleanup passed; IPv4 non-godot control passed; default macOS IPv6 non-godot occupant initially failed, then passed after the branch lifecycle patch. Status-name-only Restart-click initially recovered the backend but left the dock in Restarting; after the SPAWNING-unblock patch, rerun passed and the dock turned green. |
+
+### Live MCP scenario
+
+Corrected disposable session: `godot-ai-megasmoke-live@e913`,
+`/private/tmp/godot-ai-megasmoke-live/`.
+
+Covered: scene create/save, node create/properties/groups, hierarchy reads,
+script create/read/attach, signal connect/list, input map action/binding,
+autoload add/list, UI text/anchors, theme create/apply, material preset +
+readback, particle main/process + readback, camera current/readback, audio
+playback properties, resource creation/search, filesystem write/reimport,
+batch rollback, project run/stop with `autosave=false`, game screenshot,
+viewport coverage screenshot, plugin/game/all logs, and middleware edge cases.
+
+Middleware checks: stringified `params` decoded; `task_progress` stripped;
+JSON-shaped string stayed a string for a `String` param; malformed JSON
+fell through to Pydantic dict validation; misspelled manage op returned
+suggestions; batch unknown-command preserved `error.data.suggestions`.
+
+Correction: an initial live-tool attempt accidentally targeted
+`test_project@c4af`. All resulting `test_project` artifacts were removed
+and tracked scene diffs were restored before the corrected disposable run.
+
+### Friction items
+
+#### bug — self-update Restart Server respawns the old server package after plugin advances
+
+- Timestamp: 2026-05-04 13:57:54 PDT
+- Phase: interactive self-update / recovery path.
+- Exact operator action: run `script/local-self-update-smoke --project-dir /private/tmp/godot-ai-megasmoke-self-update-smoke`, click Update, then click Restart Server after the dock reports plugin install v2.3.3 but server v2.3.2.
+- Observed result: dock stayed at `Restarting server...`; localhost status on port 18000 continued to report `{"name":"godot-ai","server_version":"2.3.2","ws_port":19500}`. Harness output showed the restart spawned `/Users/davidsarno/.local/bin/uvx --from godot-ai==2.3.2 godot-ai ...` even though the updated plugin expected v2.3.3.
+- Expected result: Restart Server should replace the incompatible server with the version the plugin expects, or the dock should not promise replacement with v2.3.3 when the configured command still pins 2.3.2.
+- Repro notes: the harness patches the vNext plugin to 2.3.3 while `next_server_version` defaults to the base server version. After Update, the mismatch is correctly detected, but recovery reuses the stale `godot-ai==2.3.2` command.
+- Severity: high for recovery UX; the main self-update safety checks passed, but the advertised recovery action wedges.
+- Workaround: close the disposable editor to let the harness finish; for a real run, manually update the server command/package pin before restarting.
+- Suspected component: self-update smoke fixture command patching / `McpServerLifecycleManager.force_restart_server` command selection after plugin version advance.
+- Follow-up: branch `codex/megasmoke-results-harness-fix` patches the smoke fixture to override the lifecycle manager's expected server-version seam instead of the stale `plugin.gd` call site, and the harness now fails result processing if a server/plugin version mismatch is reported. Focused unit coverage added in `tests/unit/test_self_update_smoke_harness.py`. Managed-server interactive rerun at 14:27 PDT passed: the dock stayed connected with install v2.3.3 and server `godot-ai==2.3.2`, and the harness printed `PASS: no server/plugin version mismatch reported`. This does not replace the separate foreign/orphan lifecycle matrix.
+
+#### bug — non-godot IPv6 port occupant is ignored on startup and killed on shutdown
+
+- Timestamp: 2026-05-04 14:34 PDT
+- Phase: manual orphan/foreign lifecycle matrix / scenario 6 non-godot occupant safety.
+- Exact operator action: start `python3 -m http.server 8000` on macOS, then launch `GODOT_AI_MODE=user /Applications/Godot_mono.app/Contents/MacOS/Godot --editor --quit-after 600 --path test_project`.
+- Observed result: Python reported `Serving HTTP on :: port 8000`. The plugin still printed `MCP | started server (PID 58665, v2.3.2)` on `127.0.0.1:8000`, connected successfully, and on editor shutdown printed `MCP | stopped server (PID [58666, 58574])`. The temporary `http.server` session then exited; its only request log was a `POST /mcp` returning 501.
+- Expected result: non-godot occupant safety should block adoption/spawn, show a warning without a Restart button, avoid kill logs, and leave the original `http.server` listener alive.
+- Repro notes: macOS/Python bound the default `http.server` to IPv6 `* :8000`, while the Godot AI server later bound IPv4 `127.0.0.1:8000`. Startup port detection did not treat the IPv6 listener as blocking, but shutdown process discovery included both the godot-ai worker and unrelated Python listener.
+- Severity: release-blocking lifecycle safety bug; a plugin-owned stop path killed an unrelated non-godot process on the same configured HTTP port.
+- Workaround: bind test occupants explicitly to `127.0.0.1` for now when continuing the matrix, but the product should not kill unrelated IPv6 listeners.
+- Suspected component: `McpServerLifecycleManager.start_server` port-in-use check vs `_find_all_pids_on_port` / `_stop_server` ownership filtering mismatch for IPv4/IPv6 listeners.
+- Control run: `python3 -m http.server 8000 --bind 127.0.0.1` behaved correctly: startup printed `MCP | proof: (none)` plus an unverified-server warning, did not spawn godot-ai, did not kill on editor exit, and left the Python listener alive until manually stopped.
+- Follow-up: branch `codex/megasmoke-results-harness-fix` now confirms POSIX port occupancy with `lsof` even when the IPv4 bind probe succeeds, and filters managed/dev stop kill candidates to godot-ai-branded command lines. Rerun at 15:52 PDT with default `python3 -m http.server 8000` passed: Godot printed `MCP | proof: (none)` and the unverified-server warning, did not spawn godot-ai, left port 9500 unused, and the IPv6 Python listener remained alive until manually stopped.
+
+#### bug — status-name-only Restart-click recovers backend but dock can stay in Restarting
+
+- Timestamp: 2026-05-04 15:15 PDT
+- Phase: manual orphan/foreign lifecycle matrix / scenario 5 status-name-only occupant safety.
+- Exact operator action: start `PYTHONPATH=/tmp/sim-statusonly python3 -m http_status_only --port 18100 --ws-port 19600 --fake-version 2.1.0`, temporarily set Godot AI ports to 18100/19600, launch `GODOT_AI_MODE=user /Applications/Godot_mono.app/Contents/MacOS/Godot --editor --path test_project`, then click Restart Server.
+- Observed result: initial diagnosis passed: `MCP | proof: status_name` and the dock showed fake server v2.1.0 vs expected v2.3.2. After clicking Restart Server, backend recovery also succeeded: Godot printed `MCP | killed pids [35436] on port 18100`, spawned `godot-ai==2.3.2`, and `/godot-ai/status` returned `{"server_version":"2.3.2","ws_port":19600}`. The dock, however, stayed in `Restarting server...` and did not reconnect within ~30 seconds.
+- Expected result: after the replacement server starts, the connection should unblock, reconnect, verify the v2.3.2 handshake, clear `_server_restart_in_progress`, and turn the dock green.
+- Repro notes: the backend path is good; the stale UI appears to come from `_resume_connection_after_recovery()` requiring lifecycle state READY even though `recover_incompatible_server()` leaves the replacement in SPAWNING until the WebSocket handshake can make it READY.
+- Severity: high for recovery UX; not data-loss, but the advertised Restart Server action appears wedged after doing the backend work.
+- Workaround: close/reopen or reload the editor after backend recovery; the replacement server is already running.
+- Suspected component: dock/client refresh state after `recover_incompatible_server()` / `_resume_connection_after_recovery()` SPAWNING gate.
+- Follow-up: branch `codex/megasmoke-results-harness-fix` now unblocks the connection while recovery is in SPAWNING and adds `test_recovery_resume_unblocks_connection_while_spawn_is_in_flight`. Rerun on temporary ports 18100/19600 passed: click printed `MCP | proof: status_name`, killed fake PID 45265, spawned `godot-ai==2.3.2`, logged reconnect attempts, then `MCP | connected to server`; the dock turned green and `/godot-ai/status` reported v2.3.2 with WS 19600.
+
+#### pass — compatible external adoption and managed drift cleanup
+
+- Timestamp: 2026-05-04 14:58 PDT
+- Phase: manual orphan/foreign lifecycle matrix / scenarios 7 and 3.
+- Exact operator actions: for compatible adoption, run `script/serve-this-worktree`, verify `/godot-ai/status` reports v2.3.2 on ports 8000/9500, then launch Godot with `--quit-after 600`. For managed drift, run `/tmp/orphan-sim` fake godot-ai v2.1.0, seed `godot_ai/managed_server_pid`, `godot_ai/managed_server_version`, and `godot_ai/managed_server_ws_port` in EditorSettings, then launch Godot with `GODOT_AI_MODE=user --quit-after 800`.
+- Observed result: compatible adoption printed `MCP | adopted external server owner_pid=60323 (live v2.3.2, WS 9500, plugin v2.3.2)`, left the managed record cleared, and did not kill the external server on editor exit. Managed drift printed `MCP | managed server v2.1.0 does not match plugin v2.3.2, restarting`, `MCP | strong proof: managed_record`, `MCP | killed pids [61190] on port 8000`, then started a fresh v2.3.2 server and connected.
+- Expected result: same.
+- Repro notes: final preflight after restoring EditorSettings showed managed-server record cleared and no listeners on ports 8000/9500.
+- Severity: pass.
+- Workaround: none.
+- Suspected component: lifecycle manager adoption/recovery paths behaved as expected for these cases.
+
+#### bug — `script_create` can time out while the file is successfully created
+
+- Timestamp: 2026-05-04 14:06 PDT
+- Phase: corrected disposable live scenario / script creation.
+- Exact tool call: `script_create(path="res://mega_smoke/mega_smoke_controller.gd", content=...)` against `godot-ai-megasmoke-live@e913`.
+- Observed result: MCP returned `DEFERRED_TIMEOUT` after 4505 ms, but `filesystem_manage(op="search")` found the script immediately afterward and `script_manage(op="read")` returned the full expected source.
+- Expected result: either success once the file/import settles, or a retryable timeout that does not look like a failed mutation when the mutation already committed.
+- Repro notes: happened during live creation of a new GDScript under `res://mega_smoke/`; editor readiness was `ready` after the timeout.
+- Severity: medium; can cause duplicate retries or false failure reports.
+- Workaround: after `DEFERRED_TIMEOUT`, poll `editor_state` and read/search the target file before retrying.
+- Suspected component: script create deferred import-settle timeout / response completion.
+
+#### bug — `particle_get` returns ok while emitting editor out-of-bounds errors for unused draw passes
+
+- Timestamp: 2026-05-04 14:11 PDT
+- Phase: corrected disposable live scenario / particle readback.
+- Exact tool call: `particle_manage(op="get", params={"node_path":"/MegaSmoke/Sparks"})`.
+- Observed result: MCP returned a normal `particle_get` response, but the Godot console emitted three errors: `Index p_pass = 1/2/3 is out of bounds (draw_passes.size() = 1)` with backtrace at `res://addons/godot_ai/handlers/particle_handler.gd:538`.
+- Expected result: readback should only inspect configured draw passes, or should guard missing draw passes without emitting editor errors.
+- Repro notes: create a default `GPUParticles3D`, set main/process properties, then call `particle_get`. The response listed four draw-pass slots even though the particle node only had one draw pass allocated.
+- Severity: medium; silent success with red editor errors can hide handler defects and pollute editor logs.
+- Workaround: ignore the extra editor errors for now; avoid using `particle_get` as a clean-log assertion until fixed.
+- Suspected component: `ParticleHandler.get_particle` draw-pass loop bounds.
+
+#### test gap — destructive live smoke initially targeted `test_project`
+
+- Timestamp: 2026-05-04 13:58 PDT
+- Phase: live MCP scenario / session routing.
+- Exact tool calls: `scene_manage(op="create", path="res://mega_smoke/mega_smoke.tscn")` and follow-up node/material/script operations were initially sent to `test-project@c4af`.
+- Observed result: `test_project/mega_smoke/` was created and Godot autosaved tracked scenes during adjacent smoke scripts. The operator caught the wrong project before the run continued.
+- Expected result: destructive live smoke should refuse to run unless the active or pinned session path is a disposable project, not the repo `test_project`.
+- Repro notes: `session_manage(op="list")` showed only `test_project` after the initial self-update project was on a different port; the run should have stopped there and launched a disposable project before live mutations.
+- Severity: medium as a process/test gap; no lasting data loss in this run. `test_project/mega_smoke/` was removed and tracked `test_project/main.tscn` / `capture_smoke.tscn` were restored to `HEAD`.
+- Workaround: gate destructive smoke with an explicit project-path assertion and exact `session_id` before any write.
+- Suspected component: MegaSmoke operator checklist / missing preflight guard.
+
+#### friction — default self-update smoke temp dir refused as stale/non-generated fixture
+
+- Timestamp: 2026-05-04 13:48:37 PDT
+- Phase: baseline gates / self-update fixture preparation.
+- Exact operator action: `script/local-self-update-smoke --no-launch`
+- Observed result: harness exited with `FAIL: /private/var/folders/y4/xqc3mdfd76ggjxd9gx3vbly00000gp/T/godot-ai-self-update-smoke has a smoke marker but does not look generated. Pass --project-dir elsewhere or --force.`
+- Expected result: either prepare the default disposable fixture or provide a one-command safe fallback for stale generated fixture dirs.
+- Repro notes: run the no-launch harness on this macOS host while the default temp dir already contains `.godot-ai-self-update-smoke/marker.txt` but the project does not satisfy `is_generated_smoke_project`.
+- Severity: low; no data loss and guard is intentionally conservative.
+- Workaround: rerun with an explicit disposable path, `script/local-self-update-smoke --no-launch --project-dir /private/tmp/godot-ai-megasmoke-self-update-smoke`.
+- Suspected component: `script/local-self-update-smoke` stale fixture UX / cleanup guidance.
+
+#### bug — `editor_reload_plugin` kills external dev server when a stale managed-server record still matches
+
+- Timestamp: 2026-05-04 13:51:04 PDT
+- Phase: baseline gates / reload lifecycle.
+- Exact operator action: start `script/serve-this-worktree` on port 8000, confirm editor reconnects, then run `script/ci-reload-test`.
+- Observed result: `script/ci-reload-test` created `/Main/ReloadTestCube`, then `editor_reload_plugin` produced no SSE data. The external dev-server terminal exited, and port 8000 was immediately owned by a new Godot-child process: `python -m godot_ai --transport streamable-http --port 8000 --ws-port 9500 --pid-file .../godot_ai_server.pid`.
+- Expected result: `editor_reload_plugin` should return `status="reloaded"` with a new session id while the externally-started MCP server remains alive.
+- Repro notes: the editor had previously spawned a managed server with version 2.3.2. Starting `script/serve-this-worktree` replaced that listener, but the persisted managed-server record still matched the plugin version. On reload, lifecycle adoption classified the external owner as managed and `_exit_tree` killed the port listener, severing the in-flight HTTP response.
+- Severity: high / release-blocking until triaged; this is a reload-path stale ownership failure and turns a documented external-server prerequisite into a silent transport drop.
+- Workaround: likely clear the managed-server record and pid-file before adopting a manually-started dev server, or launch from a clean editor settings state. Not verified in this run.
+- Suspected component: `McpServerLifecycleManager.adopt_compatible_server` / `_stop_server` ownership classification for external servers when `record_version == current_version`.
+
+#### friction — game capture smoke shebang uses system Python without Pillow
+
+- Timestamp: 2026-05-04 13:53:05 PDT
+- Phase: baseline gates / game capture smoke.
+- Exact operator action: `script/ci-game-capture-smoke`
+- Observed result: immediate `ModuleNotFoundError: No module named 'PIL'` before any MCP/Godot interaction.
+- Expected result: script runs in the repo's dependency environment or prints the required invocation.
+- Repro notes: this host's `python3` resolves to `/opt/homebrew/opt/python@3.14/bin/python3.14`; the repo `.venv/bin/python` has Pillow 12.2.0.
+- Severity: low; environment-only and easy workaround.
+- Workaround: `.venv/bin/python script/ci-game-capture-smoke`
+- Suspected component: `script/ci-game-capture-smoke` interpreter/dependency UX.
+
 ## 2026-04-19 — Smoking PR #78 (`logs_read source=game`)
 
 Smoking PR #78 (`claude/add-game-logs-capture-gtE27`) against a live editor

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -949,6 +949,12 @@ static func _resolve_ws_port_from_output(
 ## counter increment and the `_ProofPlugin` override hook on the plugin.
 func _is_port_in_use(port: int) -> bool:
 	if PortResolver.can_bind_local_port(port):
+		## POSIX can still have an IPv6 wildcard listener on this port
+		## even when an IPv4 loopback bind succeeds. Confirm through
+		## lsof so startup and kill-path discovery agree.
+		if OS.get_name() != "Windows":
+			_startup_trace_count("lsof")
+			return PortResolver.is_port_in_use_via_scrape(port)
 		return false
 	if OS.get_name() == "Windows":
 		_startup_trace_count("netstat")
@@ -1374,7 +1380,14 @@ func can_recover_incompatible_server() -> bool:
 func _resume_connection_after_recovery() -> void:
 	if _connection == null:
 		return
-	if not ServerStateScript.is_healthy(_lifecycle.get_state()) or _lifecycle.is_connection_blocked():
+	var state: int = _lifecycle.get_state()
+	if (
+		_lifecycle.is_connection_blocked()
+		or (
+			state != ServerStateScript.SPAWNING
+			and state != ServerStateScript.READY
+		)
+	):
 		return
 	_connection.connect_blocked = false
 	_connection.connect_block_reason = ""
@@ -1463,16 +1476,15 @@ func stop_dev_server() -> void:
 		# We have a managed server — use normal stop
 		_stop_server()
 		return
-	var output: Array = []
 	var port := ClientConfigurator.http_port()
-	if OS.get_name() == "Windows":
-		var killed := _kill_processes_and_windows_spawn_children(_find_all_pids_on_port(port))
-		if not killed.is_empty():
-			print("MCP | stopped dev server on port %d" % port)
-	else:
-		var exit_code := OS.execute("bash", ["-c", "lsof -ti:%d -sTCP:LISTEN | xargs kill 2>/dev/null" % port], output, true)
-		if exit_code == 0:
-			print("MCP | stopped dev server on port %d" % port)
+	var candidates: Array[int] = []
+	for pid in _find_all_pids_on_port(port):
+		var candidate := int(pid)
+		if _pid_cmdline_is_godot_ai(candidate):
+			candidates.append(candidate)
+	var killed := _kill_processes_and_windows_spawn_children(candidates)
+	if not killed.is_empty():
+		print("MCP | stopped dev server on port %d" % port)
 
 
 func _kill_processes_and_windows_spawn_children(pids: Array[int]) -> Array[int]:

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -1532,8 +1532,14 @@ func _find_windows_spawn_children(parent_pids: Array[int]) -> Array[int]:
 
 
 func is_dev_server_running() -> bool:
-	## Returns true if a server is running on the HTTP port that we didn't start as managed.
-	return _lifecycle.get_server_pid() <= 0 and _is_port_in_use(ClientConfigurator.http_port())
+	## Returns true if a branded dev server is running on the HTTP port
+	## that we didn't start as managed.
+	if _lifecycle.get_server_pid() > 0:
+		return false
+	for pid in _find_all_pids_on_port(ClientConfigurator.http_port()):
+		if _pid_cmdline_is_godot_ai(int(pid)):
+			return true
+	return false
 
 
 func has_managed_server() -> bool:

--- a/plugin/addons/godot_ai/utils/port_resolver.gd
+++ b/plugin/addons/godot_ai/utils/port_resolver.gd
@@ -27,6 +27,11 @@ static func can_bind_local_port(port: int) -> bool:
 ## after their own `can_bind_local_port` probe.
 static func is_port_in_use(port: int) -> bool:
 	if can_bind_local_port(port):
+		## On POSIX, an IPv6 wildcard listener can coexist with a
+		## successful 127.0.0.1 bind probe. Confirm with lsof so startup
+		## sees the same listener set that shutdown/recovery would see.
+		if OS.get_name() != "Windows":
+			return is_port_in_use_via_scrape(port)
 		return false
 	return is_port_in_use_via_scrape(port)
 

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -633,7 +633,10 @@ func stop_server() -> void:
 	var killed: Array = []
 	var candidates: Array[int] = [int(_server_pid)]
 	var real_pid := int(_host._find_managed_pid(port))
-	if real_pid > 0:
+	if real_pid > 0 and (
+		candidates.has(real_pid)
+		or _host._pid_cmdline_is_godot_ai_for_proof(real_pid)
+	):
 		candidates.append(real_pid)
 	var listener_pids: Array = _host._find_all_pids_on_port(port)
 	for pid in listener_pids:

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -201,6 +201,10 @@ func get_version_check():
 func _resolve_expected_version(supplied: String) -> String:
 	if not supplied.is_empty():
 		return supplied
+	return _expected_server_version()
+
+
+func _expected_server_version() -> String:
 	return ClientConfigurator.get_plugin_version()
 
 
@@ -382,7 +386,7 @@ func start_server() -> void:
 
 	var port := ClientConfigurator.http_port()
 	var ws_port := ClientConfigurator.ws_port()
-	var current_version := ClientConfigurator.get_plugin_version()
+	var current_version := _expected_server_version()
 	_server_expected_version = current_version
 
 	if bool(_host._is_port_in_use(port)):
@@ -543,7 +547,7 @@ func respawn_with_refresh() -> void:
 	if spawn_pid > 0:
 		_server_spawn_ms = Time.get_ticks_msec()
 		_server_exit_ms = 0
-		var current_version := ClientConfigurator.get_plugin_version()
+		var current_version := _expected_server_version()
 		_host._write_managed_server_record(spawn_pid, current_version)
 		print("MCP | retried server (PID %d, v%s): %s %s" % [spawn_pid, current_version, cmd, " ".join(args)])
 	else:
@@ -633,7 +637,11 @@ func stop_server() -> void:
 		candidates.append(real_pid)
 	var listener_pids: Array = _host._find_all_pids_on_port(port)
 	for pid in listener_pids:
-		candidates.append(int(pid))
+		var listener_pid := int(pid)
+		if candidates.has(listener_pid):
+			candidates.append(listener_pid)
+		elif _host._pid_cmdline_is_godot_ai_for_proof(listener_pid):
+			candidates.append(listener_pid)
 	killed = _host._kill_processes_and_windows_spawn_children(candidates)
 	if not killed.is_empty():
 		print("MCP | stopped server (PID %s)" % str(killed))
@@ -778,7 +786,7 @@ func force_restart_server() -> void:
 		transition_state(McpServerStateScript.UNINITIALIZED)
 		_set_incompatible_server(
 			_host._probe_live_server_status_for_port(port),
-			ClientConfigurator.get_plugin_version(),
+			_expected_server_version(),
 			port
 		)
 		return

--- a/script/local-self-update-smoke
+++ b/script/local-self-update-smoke
@@ -306,7 +306,9 @@ def patch_fixture_plugin(
     patch_port_isolation(addon_dir / "client_configurator.gd", http_port, ws_port)
     patch_server_package_pin(addon_dir / "client_configurator.gd", server_version)
     patch_managed_record_isolation(addon_dir / "plugin.gd")
-    patch_expected_server_version(addon_dir / "plugin.gd", server_version)
+    patch_lifecycle_expected_server_version(
+        addon_dir / "utils" / "server_lifecycle.gd", server_version
+    )
     if force_local_update:
         # Update flow lives on McpUpdateManager; the dock keeps only
         # the visible banner UI.
@@ -421,23 +423,32 @@ def patch_managed_record_isolation(path: Path) -> None:
     path.write_text(text, encoding="utf-8")
 
 
-def patch_expected_server_version(path: Path, server_version: str) -> None:
+def patch_lifecycle_expected_server_version(path: Path, server_version: str) -> None:
     text = path.read_text(encoding="utf-8")
-    marker = "const MANAGED_SERVER_VERSION_SETTING := "
+    marker = 'const ClientConfigurator := preload("res://addons/godot_ai/client_configurator.gd")'
     line_start = text.find(marker)
     if line_start < 0:
-        raise HarnessError(f"Could not find MANAGED_SERVER_VERSION_SETTING in {path}")
+        raise HarnessError(f"Could not find ClientConfigurator preload in {path}")
     line_end = text.find("\n", line_start)
     if line_end < 0:
-        raise HarnessError(f"Could not find MANAGED_SERVER_VERSION_SETTING line end in {path}")
+        raise HarnessError(f"Could not find ClientConfigurator preload line end in {path}")
     text = (
         text[: line_end + 1]
         + f'const SELF_UPDATE_SMOKE_EXPECTED_SERVER_VERSION := "{server_version}"\n'
         + text[line_end + 1 :]
     )
-    text = text.replace(
-        "McpClientConfigurator.get_plugin_version()",
-        "SELF_UPDATE_SMOKE_EXPECTED_SERVER_VERSION",
+    text = replace_once(
+        path,
+        text,
+        (
+            "func _expected_server_version() -> String:\n"
+            "\treturn ClientConfigurator.get_plugin_version()"
+        ),
+        (
+            "func _expected_server_version() -> String:\n"
+            "\treturn SELF_UPDATE_SMOKE_EXPECTED_SERVER_VERSION"
+        ),
+        "_expected_server_version",
     )
     path.write_text(text, encoding="utf-8")
 
@@ -818,7 +829,10 @@ def verify_post_run(
         print("PASS: vNext _exit_tree trigger did not run during the update window")
 
     if smoke_adopted_existing_server_before_update(lines):
-        print("FAIL: smoke fixture adopted an existing server before update; clear the smoke ports first")
+        print(
+            "FAIL: smoke fixture adopted an existing server before update; "
+            "clear the smoke ports first"
+        )
         ok = False
     elif smoke_started_own_server_before_update(lines):
         print("PASS: smoke fixture started its own server before update")
@@ -831,6 +845,12 @@ def verify_post_run(
     else:
         print("FAIL: self-update did not stop a managed smoke server")
         ok = False
+
+    if smoke_reported_server_version_mismatch(lines):
+        print("FAIL: smoke fixture reported a server/plugin version mismatch")
+        ok = False
+    else:
+        print("PASS: no server/plugin version mismatch reported")
 
     new_reports = new_diagnostic_reports(baseline, started)
     if new_reports:
@@ -893,6 +913,13 @@ def smoke_stopped_server_during_update(lines: list[str]) -> bool:
         if "MCP | stopped server" in line:
             return True
     return False
+
+
+def smoke_reported_server_version_mismatch(lines: list[str]) -> bool:
+    return any(
+        "is occupied by godot-ai server v" in line and "plugin expects v" in line
+        for line in lines
+    )
 
 
 def smoke_lines_before_update(lines: list[str]) -> list[str]:

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -1193,6 +1193,29 @@ func test_parse_lsof_pids_ignores_non_numeric_lines() -> void:
 	assert_eq(pids[0], 32696)
 
 
+func test_dev_server_detection_ignores_unbranded_port_listener() -> void:
+	var plugin := _ProofPlugin.new()
+	plugin.listener_pids = [24680] as Array[int]
+	plugin.port_in_use = true
+
+	var detected := plugin.is_dev_server_running()
+	plugin.free()
+
+	assert_false(detected)
+
+
+func test_dev_server_detection_accepts_branded_port_listener() -> void:
+	var plugin := _ProofPlugin.new()
+	plugin.listener_pids = [24680] as Array[int]
+	plugin.branded_pids = [24680] as Array[int]
+	plugin.port_in_use = true
+
+	var detected := plugin.is_dev_server_running()
+	plugin.free()
+
+	assert_true(detected)
+
+
 ## --- Live-status threading ------------------------------------------
 ##
 ## `_start_server` probes once at the top of the spawn body and threads

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -46,6 +46,9 @@ class _ProofPlugin extends GodotAiPlugin:
 	func _pid_cmdline_is_godot_ai_for_proof(pid: int) -> bool:
 		return branded_pids.has(pid)
 
+	func _pid_cmdline_is_godot_ai(pid: int) -> bool:
+		return branded_pids.has(pid)
+
 	func _probe_live_server_status_for_port(_port: int) -> Dictionary:
 		probe_calls += 1
 		return live_status.duplicate()
@@ -203,6 +206,23 @@ func test_finalize_stop_preserves_state_when_port_still_in_use() -> void:
 		FileAccess.file_exists(GodotAiPlugin.SERVER_PID_FILE),
 		"pid-file must be preserved so next _find_managed_pid has the deterministic hint"
 	)
+
+
+func test_stop_dev_server_only_kills_godot_ai_listeners() -> void:
+	## `stop_dev_server` used to shell out to `lsof | xargs kill`, which
+	## swept unrelated listeners that happened to share the configured HTTP
+	## port. It must filter by the same godot-ai command-line proof used by
+	## the managed lifecycle stop path.
+	var plugin := _ProofPlugin.new()
+	plugin.listener_pids = [11111, 22222] as Array[int]
+	plugin.branded_pids = [22222] as Array[int]
+
+	plugin.stop_dev_server()
+	var killed := plugin.killed_targets.duplicate()
+	plugin.free()
+
+	assert_eq(killed.size(), 1)
+	assert_eq(killed[0], 22222)
 
 
 # ----- spawn state machine -----
@@ -928,6 +948,34 @@ func test_recover_incompatible_returns_false_and_leaves_state_when_port_remains_
 	assert_true(bool(status.get("connection_blocked", false)))
 	assert_eq(killed, [24680] as Array[int])
 	assert_eq(clear_calls, 0, "failed recovery must preserve record/pid-file state")
+
+
+func test_recovery_resume_unblocks_connection_while_spawn_is_in_flight() -> void:
+	## Recovery click kills the incompatible occupant and starts a fresh
+	## server, leaving lifecycle state at SPAWNING until the WebSocket
+	## handshake verifies the version. The connection must be unblocked
+	## during SPAWNING, otherwise the dock sits forever at "Restarting".
+	var plugin := GodotAiPlugin.new()
+	var conn := McpConnection.new()
+	conn.connect_blocked = true
+	conn.connect_block_reason = "incompatible"
+	conn.server_version = "1.2.10"
+	plugin._connection = conn
+	plugin._lifecycle._server_state = McpServerState.SPAWNING
+	plugin._lifecycle._connection_blocked = false
+
+	plugin._resume_connection_after_recovery()
+	var blocked := conn.connect_blocked
+	var reason := conn.connect_block_reason
+	var version := conn.server_version
+	var awaiting: bool = plugin._lifecycle.is_awaiting_server_version()
+	conn.free()
+	plugin.free()
+
+	assert_false(blocked)
+	assert_eq(reason, "")
+	assert_eq(version, "")
+	assert_true(awaiting)
 
 
 func test_connection_established_waits_for_version_before_clearing_foreign_port() -> void:

--- a/test_project/tests/test_port_resolver.gd
+++ b/test_project/tests/test_port_resolver.gd
@@ -85,6 +85,13 @@ func test_is_port_in_use_checks_os_listeners_after_bind_probe_on_posix() -> void
 		skip("python http.server did not bind test port")
 		return
 
+	var bind_still_succeeds := McpPortResolver.can_bind_local_port(port)
+	if not bind_still_succeeds:
+		OS.kill(pid)
+		McpPortResolver.wait_for_port_free(port, 2.0)
+		skip("python http.server also held IPv4 loopback; POSIX fallback precondition unavailable")
+		return
+
 	var detected := McpPortResolver.is_port_in_use(port)
 	OS.kill(pid)
 	McpPortResolver.wait_for_port_free(port, 2.0)

--- a/test_project/tests/test_port_resolver.gd
+++ b/test_project/tests/test_port_resolver.gd
@@ -53,6 +53,45 @@ func test_can_bind_local_port_returns_false_when_held() -> void:
 	assert_false(got_bind)
 
 
+func test_is_port_in_use_checks_os_listeners_after_bind_probe_on_posix() -> void:
+	if OS.get_name() == "Windows":
+		skip("POSIX-only lsof confirmation")
+		return
+	var python_check: Array = []
+	if OS.execute("python3", ["--version"], python_check, true) != 0:
+		skip("python3 is unavailable for live listener smoke")
+		return
+
+	var port := 51249
+	var probe := TCPServer.new()
+	if probe.listen(port, "127.0.0.1") != OK:
+		skip("port %d is already held on this host" % port)
+		return
+	probe.stop()
+
+	var pid := OS.create_process("python3", ["-m", "http.server", str(port)])
+	if pid <= 0:
+		skip("could not start python http.server")
+		return
+
+	var listener_seen := false
+	for _i in range(20):
+		OS.delay_msec(100)
+		if not McpPortResolver.find_all_pids_on_port(port).is_empty():
+			listener_seen = true
+			break
+	if not listener_seen:
+		OS.kill(pid)
+		skip("python http.server did not bind test port")
+		return
+
+	var detected := McpPortResolver.is_port_in_use(port)
+	OS.kill(pid)
+	McpPortResolver.wait_for_port_free(port, 2.0)
+
+	assert_true(detected)
+
+
 func test_pid_alive_rejects_sentinel_pids() -> void:
 	assert_false(McpPortResolver.pid_alive(0))
 	assert_false(McpPortResolver.pid_alive(-1))

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -191,7 +191,7 @@ func test_stop_aggregates_launcher_pidfile_and_branded_listener_pids() -> void:
 	var host := _ManagerHostStub.new()
 	host.managed_pid_lookup = 22222
 	host.listener_pids = [33333] as Array[int]
-	host.branded_pids = [33333] as Array[int]
+	host.branded_pids = [22222, 33333] as Array[int]
 	var manager := McpServerLifecycleManagerScript.new(host)
 	manager._server_pid = 11111
 
@@ -203,6 +203,24 @@ func test_stop_aggregates_launcher_pidfile_and_branded_listener_pids() -> void:
 	assert_true(killed.has(11111))
 	assert_true(killed.has(22222))
 	assert_true(killed.has(33333))
+
+
+func test_stop_does_not_trust_unbranded_managed_pid_fallback() -> void:
+	## `_find_managed_pid` falls back to a port scrape when the pid-file is
+	## stale or missing. That fallback is only proof when the PID is branded.
+	var host := _ManagerHostStub.new()
+	host.managed_pid_lookup = 22222
+	host.listener_pids = [22222] as Array[int]
+	var manager := McpServerLifecycleManagerScript.new(host)
+	manager._server_pid = 11111
+
+	manager.stop_server()
+	var killed := host.killed_targets.duplicate()
+	host.free()
+
+	assert_eq(killed.size(), 1)
+	assert_true(killed.has(11111))
+	assert_false(killed.has(22222))
 
 
 func test_stop_does_not_kill_unbranded_port_listeners() -> void:

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -22,6 +22,7 @@ class _ManagerHostStub extends GodotAiPlugin:
 	var managed_record := {"pid": 0, "version": "", "ws_port": 0}
 	var live_status := {"name": "", "version": "", "ws_port": 0, "status_code": 0}
 	var alive_pids: Array[int] = []
+	var branded_pids: Array[int] = []
 	var pid_file_pid := 0
 	var managed_pid_lookup := 0
 	var port_in_use := false
@@ -44,6 +45,9 @@ class _ManagerHostStub extends GodotAiPlugin:
 
 	func _pid_alive_for_proof(pid: int) -> bool:
 		return alive_pids.has(pid)
+
+	func _pid_cmdline_is_godot_ai_for_proof(pid: int) -> bool:
+		return branded_pids.has(pid)
 
 	func _probe_live_server_status_for_port(_port: int) -> Dictionary:
 		return live_status.duplicate()
@@ -181,12 +185,13 @@ func test_stop_short_circuits_when_no_pid() -> void:
 	assert_true(killed.is_empty())
 
 
-func test_stop_aggregates_launcher_pidfile_and_listener_pids() -> void:
+func test_stop_aggregates_launcher_pidfile_and_branded_listener_pids() -> void:
 	## uvx leaks the launcher early on Windows; the real Python child
 	## must still get killed. Coverage for Copilot review #5.
 	var host := _ManagerHostStub.new()
 	host.managed_pid_lookup = 22222
 	host.listener_pids = [33333] as Array[int]
+	host.branded_pids = [33333] as Array[int]
 	var manager := McpServerLifecycleManagerScript.new(host)
 	manager._server_pid = 11111
 
@@ -198,6 +203,24 @@ func test_stop_aggregates_launcher_pidfile_and_listener_pids() -> void:
 	assert_true(killed.has(11111))
 	assert_true(killed.has(22222))
 	assert_true(killed.has(33333))
+
+
+func test_stop_does_not_kill_unbranded_port_listeners() -> void:
+	## A POSIX IPv6 wildcard listener can show up in the same lsof query
+	## as our managed IPv4 server. Stop must never sweep unrelated PIDs
+	## just because they share the configured HTTP port.
+	var host := _ManagerHostStub.new()
+	host.listener_pids = [33333] as Array[int]
+	var manager := McpServerLifecycleManagerScript.new(host)
+	manager._server_pid = 11111
+
+	manager.stop_server()
+	var killed := host.killed_targets.duplicate()
+	host.free()
+
+	assert_eq(killed.size(), 1)
+	assert_true(killed.has(11111))
+	assert_false(killed.has(33333))
 
 
 func test_stop_invokes_finalize_for_record_cleanup() -> void:

--- a/tests/unit/test_self_update_orphan_recovery.py
+++ b/tests/unit/test_self_update_orphan_recovery.py
@@ -43,7 +43,8 @@ def test_recover_incompatible_success_unblocks_existing_connection() -> None:
     # Manager-side: respawn happens here, after the kill drains.
     assert "start_server()" in lifecycle_recover_block
 
-    assert "ServerStateScript.is_healthy(_lifecycle.get_state())" in resume_block
+    assert "state != ServerStateScript.SPAWNING" in resume_block
+    assert "state != ServerStateScript.READY" in resume_block
     assert "_lifecycle.is_connection_blocked()" in resume_block
     assert "_connection.connect_blocked = false" in resume_block
     assert '_connection.connect_block_reason = ""' in resume_block

--- a/tests/unit/test_self_update_smoke_harness.py
+++ b/tests/unit/test_self_update_smoke_harness.py
@@ -77,8 +77,13 @@ def test_self_update_smoke_harness_prepares_fixture(tmp_path: Path) -> None:
 
     base_plugin = (project / "addons" / "godot_ai" / "plugin.gd").read_text()
     assert "godot_ai_self_update_smoke/managed_server_pid" in base_plugin
-    assert 'const SELF_UPDATE_SMOKE_EXPECTED_SERVER_VERSION := "2.2.0"' in base_plugin
-    assert "McpClientConfigurator.get_plugin_version()" not in base_plugin
+
+    base_lifecycle = (
+        project / "addons" / "godot_ai" / "utils" / "server_lifecycle.gd"
+    ).read_text()
+    assert 'const SELF_UPDATE_SMOKE_EXPECTED_SERVER_VERSION := "2.2.0"' in base_lifecycle
+    assert "func _expected_server_version() -> String:" in base_lifecycle
+    assert "return SELF_UPDATE_SMOKE_EXPECTED_SERVER_VERSION" in base_lifecycle
 
     zip_path = project / "self_update_smoke" / "godot-ai-plugin-vnext.zip"
     assert zip_path.exists()
@@ -94,6 +99,7 @@ def test_self_update_smoke_harness_prepares_fixture(tmp_path: Path) -> None:
         vnext_manager = zf.read("addons/godot_ai/utils/update_manager.gd").decode()
         vnext_configurator = zf.read("addons/godot_ai/client_configurator.gd").decode()
         vnext_plugin = zf.read("addons/godot_ai/plugin.gd").decode()
+        vnext_lifecycle = zf.read("addons/godot_ai/utils/server_lifecycle.gd").decode()
         vnext_base = zf.read("addons/godot_ai/utils/self_update_smoke_base.gd").decode()
         vnext_child = zf.read("addons/godot_ai/utils/self_update_smoke_child.gd").decode()
 
@@ -118,8 +124,9 @@ def test_self_update_smoke_harness_prepares_fixture(tmp_path: Path) -> None:
     assert "static func ensure_settings_registered() -> void:" in vnext_configurator
     assert "static func _register_port_setting(" in vnext_configurator
     assert "godot_ai_self_update_smoke/managed_server_pid" in vnext_plugin
-    assert 'const SELF_UPDATE_SMOKE_EXPECTED_SERVER_VERSION := "2.2.0"' in vnext_plugin
-    assert "McpClientConfigurator.get_plugin_version()" not in vnext_plugin
+    assert 'const SELF_UPDATE_SMOKE_EXPECTED_SERVER_VERSION := "2.2.0"' in vnext_lifecycle
+    assert "func _expected_server_version() -> String:" in vnext_lifecycle
+    assert "return SELF_UPDATE_SMOKE_EXPECTED_SERVER_VERSION" in vnext_lifecycle
 
 
 def test_self_update_smoke_log_verifier_rejects_external_adoption() -> None:
@@ -147,6 +154,37 @@ def test_self_update_smoke_log_verifier_requires_managed_stop_after_staging() ->
     assert smoke.smoke_started_own_server_before_update(lines)
     assert not smoke.smoke_adopted_existing_server_before_update(lines)
     assert not smoke.smoke_stopped_server_during_update(lines)
+
+
+def test_self_update_smoke_log_verifier_rejects_version_mismatch() -> None:
+    smoke = load_smoke_script()
+    lines = [
+        "MCP | started server (PID 123, v2.2.0): godot-ai",
+        "MCP | self-update smoke: staged local zip /tmp/update.zip",
+        "MCP | stopped server (PID [123])",
+        "MCP | update runner enabling new plugin",
+        "MCP | plugin loaded",
+        (
+            "MCP | Port 18000 is occupied by godot-ai server v2.2.0; "
+            "plugin expects v2.2.1. Stop the old server or change both HTTP and WS ports."
+        ),
+    ]
+
+    assert smoke.smoke_reported_server_version_mismatch(lines)
+
+
+def test_self_update_smoke_log_verifier_accepts_matching_versions() -> None:
+    smoke = load_smoke_script()
+    lines = [
+        "MCP | started server (PID 123, v2.2.0): godot-ai",
+        "MCP | self-update smoke: staged local zip /tmp/update.zip",
+        "MCP | stopped server (PID [123])",
+        "MCP | update runner enabling new plugin",
+        "MCP | started server (PID 456, v2.2.0): godot-ai",
+        "MCP | plugin loaded",
+    ]
+
+    assert not smoke.smoke_reported_server_version_mismatch(lines)
 
 
 def test_self_update_smoke_harness_refuses_unmarked_existing_dir(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Fix local self-update smoke harness expected-version patching after lifecycle extraction.
- Fix POSIX IPv6/default-bind port occupant handling and avoid killing unbranded listeners during server stop paths.
- Fix recoverable incompatible-server Restart flow so the dock reconnects while the replacement server is still SPAWNING.
- Address PR feedback by making dev-mode detection require a branded godot-ai listener and by guarding the managed-pid fallback used during stop.
- Record MegaSmoke beta results and follow-up findings in docs/friction-log.md.

## Verification
- ruff check src/ tests/ script/local-self-update-smoke
- pytest -q
- script/ci-check-gdscript
- script/local-self-update-smoke --no-launch
- interactive script/local-self-update-smoke + Update click: passed after harness patch
- live non-godot default macOS IPv6 occupant rerun: passed after lifecycle patch
- status-name-only Restart Server rerun on temp ports 18100/19600: passed after SPAWNING unblock patch
- live script/ci-godot-tests: 1128/1144 passed, 0 failed after PR feedback fixes

## MegaSmoke Scope Notes
This PR closes the release-blocking lifecycle/self-update issues found during MegaSmoke. The broader 30-60 minute regular tool-call stress loop was not completed here and should be run as a separate follow-up round.

## Windows Agent Instructions Before Merge
Run from this PR branch on Windows with all Godot instances closed first:

```powershell
git checkout codex/megasmoke-results-harness-fix
git status --short
python -m ruff check src tests script/local-self-update-smoke
python -m pytest -q
$env:GODOT_BIN = "C:\path\to\Godot.exe"
script\ci-check-gdscript
python script/local-self-update-smoke --godot "C:\path\to\Godot.exe" --project-dir "$env:TEMP\godot-ai-self-update-smoke-pr"
```

For the interactive self-update smoke: click Update in the Godot AI dock, wait for the update runner and plugin loaded messages, confirm the editor stays alive and reconnects, then close Godot normally.

Then run:

```powershell
script\manual-orphan-test setup
script\manual-orphan-test preflight
script\manual-orphan-test instructions
```

Exercise the Windows-relevant scenarios from the printed matrix: scenario 1, scenario 2, scenario 3, scenario 5, scenario 6, and scenario 7. Capture Godot console output, manual-orphan-test preflight, port ownership, and git diff --stat for any failure.
