### PR TITLE
Fix stale game capture readiness between project runs

### DIFF
--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -36,10 +36,14 @@ var _game_log_buffer: McpGameLogBuffer
 var _pending: Dictionary = {}
 
 ## Flipped true when the game-side autoload sends its "mcp:hello" boot
-## beacon on _ready. Reset when the debugger session drops (game stop).
-## Guards request_game_screenshot so we never send into a debugger
-## channel whose receiving capture hasn't been registered yet.
+## beacon for the current project_run. Reset as soon as a new run is
+## requested, before Godot has attached the fresh debugger session, so
+## editor_state cannot leak readiness from the previous game process.
 var _game_ready := false
+var _game_run_token := 0
+var _ready_run_token := -1
+var _game_session_id := -1
+var _game_run_active := false
 signal game_ready
 
 
@@ -61,8 +65,31 @@ func _has_capture(prefix: String) -> bool:
 ## Do NOT log here: add_debugger_plugin() triggers this virtual before
 ## plugin.gd's _enter_tree logs "plugin loaded", and ci-reload-test
 ## asserts "plugin loaded" is the first line after a plugin reload.
-func _setup_session(_session_id: int) -> void:
+func _setup_session(session_id: int) -> void:
 	_game_ready = false
+	_ready_run_token = -1
+	_game_session_id = session_id
+
+
+func begin_game_run() -> void:
+	_game_run_token += 1
+	_game_run_active = true
+	_game_ready = false
+	_ready_run_token = -1
+	_game_session_id = -1
+	if _log_buffer:
+		_log_buffer.log("[debug] game capture pending run token %d" % _game_run_token)
+
+
+func end_game_run() -> void:
+	_game_run_active = false
+	_game_ready = false
+	_ready_run_token = -1
+	_game_session_id = -1
+
+
+func is_game_capture_ready() -> bool:
+	return _game_run_active and _game_ready and _ready_run_token == _game_run_token
 
 
 func _capture(message: String, data: Array, _session_id: int) -> bool:
@@ -78,6 +105,14 @@ func _capture(message: String, data: Array, _session_id: int) -> bool:
 			_on_log_batch(data)
 			return true
 		"mcp:hello":
+			if not _game_run_active:
+				if _log_buffer:
+					_log_buffer.log("[debug] ignored mcp:hello with no active game run")
+				return true
+			if _game_session_id != -1 and _session_id != _game_session_id:
+				if _log_buffer:
+					_log_buffer.log("[debug] ignored stale mcp:hello from debugger session %d (current %d)" % [_session_id, _game_session_id])
+				return true
 			## Boot beacon from the game-side autoload. Tells us the
 			## game has registered its "mcp" capture and is safe to send
 			## take_screenshot to — before this, Godot's debugger would
@@ -85,6 +120,7 @@ func _capture(message: String, data: Array, _session_id: int) -> bool:
 			## cycle: rotate the game-log buffer so each run starts
 			## clean and gets a new run_id.
 			_game_ready = true
+			_ready_run_token = _game_run_token
 			game_ready.emit()
 			if _game_log_buffer:
 				var run_id := _game_log_buffer.clear_for_new_run()
@@ -132,7 +168,7 @@ func request_game_screenshot(
 			"Editor main loop is not a SceneTree — cannot schedule capture")
 		return
 
-	if _game_ready:
+	if is_game_capture_ready():
 		_send_take_screenshot(tree, request_id, max_resolution, connection, timeout_sec)
 		return
 
@@ -156,9 +192,9 @@ func _wait_then_send(
 	timeout_sec: float,
 ) -> void:
 	var deadline := Time.get_ticks_msec() + int(GAME_READY_WAIT_SEC * 1000.0)
-	while not _game_ready and Time.get_ticks_msec() < deadline:
+	while not is_game_capture_ready() and Time.get_ticks_msec() < deadline:
 		await tree.process_frame
-	if not _game_ready:
+	if not is_game_capture_ready():
 		_send_error(connection, request_id, McpErrorCodes.INTERNAL_ERROR,
 			"Game-side autoload never registered its debugger capture within %ds. Is the game actually running? Check Project Settings → Autoload for _mcp_game_helper." % int(GAME_READY_WAIT_SEC))
 		return

--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -30,7 +30,7 @@ func get_editor_state(_params: Dictionary) -> Dictionary:
 			## True once the game subprocess autoload has beaconed mcp:hello;
 			## false between Play→Stop cycles. Lets capture-source=game callers
 			## poll for a real ready signal instead of guessing with sleep().
-			"game_capture_ready": _debugger_plugin != null and _debugger_plugin._game_ready,
+			"game_capture_ready": _debugger_plugin != null and _debugger_plugin.is_game_capture_ready(),
 		}
 	}
 

--- a/plugin/addons/godot_ai/handlers/project_handler.gd
+++ b/plugin/addons/godot_ai/handlers/project_handler.gd
@@ -6,10 +6,12 @@ extends RefCounted
 const NodeHandler := preload("res://addons/godot_ai/handlers/node_handler.gd")
 
 var _connection: McpConnection
+var _debugger_plugin
 
 
-func _init(connection: McpConnection = null) -> void:
+func _init(connection: McpConnection = null, debugger_plugin = null) -> void:
 	_connection = connection
+	_debugger_plugin = debugger_plugin
 
 
 func get_project_setting(params: Dictionary) -> Dictionary:
@@ -74,6 +76,16 @@ func run_project(params: Dictionary) -> Dictionary:
 	if EditorInterface.is_playing_scene():
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Project is already running")
 
+	var validation_error: Variant = null
+	if mode == "custom":
+		var custom_scene: String = params.get("scene", "")
+		if custom_scene.is_empty():
+			validation_error = McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: scene (required when mode='custom')")
+	elif mode != "main" and mode != "current":
+		validation_error = McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Invalid mode '%s' — use 'main', 'current', or 'custom'" % mode)
+	if validation_error != null:
+		return validation_error
+
 	# play_*_scene internally triggers try_autosave() → _save_scene_with_preview()
 	# which renders a preview thumbnail and calls frame processing. If our
 	# WebSocket connection's _process() re-enters during that render, the
@@ -96,7 +108,9 @@ func run_project(params: Dictionary) -> Dictionary:
 		editor_settings.set_setting(autosave_key, false)
 		restore_setting = true
 
-	var validation_error: Variant = null
+	if _debugger_plugin != null:
+		_debugger_plugin.begin_game_run()
+
 	match mode:
 		"main":
 			EditorInterface.play_main_scene()
@@ -104,21 +118,13 @@ func run_project(params: Dictionary) -> Dictionary:
 			EditorInterface.play_current_scene()
 		"custom":
 			var scene_path: String = params.get("scene", "")
-			if scene_path.is_empty():
-				validation_error = McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: scene (required when mode='custom')")
-			else:
-				EditorInterface.play_custom_scene(scene_path)
-		_:
-			validation_error = McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Invalid mode '%s' — use 'main', 'current', or 'custom'" % mode)
+			EditorInterface.play_custom_scene(scene_path)
 
 	if restore_setting:
 		editor_settings.set_setting(autosave_key, prior_autosave)
 
 	if _connection:
 		_connection.pause_processing = false
-
-	if validation_error != null:
-		return validation_error
 
 	return {
 		"data": {
@@ -135,6 +141,8 @@ func stop_project(params: Dictionary) -> Dictionary:
 	if not EditorInterface.is_playing_scene():
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Project is not running")
 
+	if _debugger_plugin != null:
+		_debugger_plugin.end_game_run()
 	EditorInterface.stop_playing_scene()
 
 	# stop_playing_scene() is async — is_playing_scene() only flips to false on

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -229,7 +229,7 @@ func _enter_tree() -> void:
 	var editor_handler := EditorHandler.new(_log_buffer, _connection, _debugger_plugin, _game_log_buffer, _editor_log_buffer)
 	var scene_handler := SceneHandler.new(_connection)
 	var node_handler := NodeHandler.new(get_undo_redo())
-	var project_handler := ProjectHandler.new(_connection)
+	var project_handler := ProjectHandler.new(_connection, _debugger_plugin)
 	var client_handler := ClientHandler.new()
 	var script_handler := ScriptHandler.new(get_undo_redo(), _connection)
 	var resource_handler := ResourceHandler.new(get_undo_redo(), _connection)

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -58,9 +58,14 @@ func test_editor_state_game_capture_ready_tracks_debugger_plugin_flag() -> void:
 	var handler := EditorHandler.new(McpLogBuffer.new(), null, plugin)
 	var result := handler.get_editor_state({})
 	assert_eq(result.data.game_capture_ready, false, "starts false before mcp:hello")
-	plugin._game_ready = true
+	plugin.begin_game_run()
+	plugin._setup_session(101)
+	plugin._capture("mcp:hello", [], 101)
 	result = handler.get_editor_state({})
 	assert_eq(result.data.game_capture_ready, true, "flips true once beacon arrives")
+	plugin.begin_game_run()
+	result = handler.get_editor_state({})
+	assert_eq(result.data.game_capture_ready, false, "new project_run clears stale readiness immediately")
 
 
 # ----- get_selection -----
@@ -1026,9 +1031,43 @@ func test_debugger_plugin_hello_rotates_run_id() -> void:
 	var game_buf := McpGameLogBuffer.new()
 	game_buf.append("info", "stale from previous run")
 	var plugin := McpDebuggerPlugin.new(null, game_buf)
+	plugin.begin_game_run()
 	plugin._capture("mcp:hello", [], 0)
 	assert_eq(game_buf.total_count(), 0, "hello should clear the game buffer")
 	assert_ne(game_buf.run_id(), "", "hello should set a run_id")
+
+
+func test_debugger_plugin_readiness_is_scoped_to_current_run() -> void:
+	var plugin := McpDebuggerPlugin.new()
+	plugin.begin_game_run()
+	plugin._setup_session(11)
+	plugin._capture("mcp:hello", [], 11)
+	assert_true(plugin.is_game_capture_ready(), "hello for active run should mark capture ready")
+
+	plugin.begin_game_run()
+	assert_false(plugin.is_game_capture_ready(), "starting the next run must clear stale readiness")
+	plugin._game_ready = true
+	assert_false(plugin.is_game_capture_ready(), "raw ready flag without current run token is stale")
+	plugin._capture("mcp:hello", [], -1)
+	assert_true(plugin.is_game_capture_ready(), "hello without a session still readies active direct-test run")
+	plugin.end_game_run()
+	assert_false(plugin.is_game_capture_ready(), "stopping the run clears capture readiness")
+	plugin._capture("mcp:hello", [], -1)
+	assert_false(plugin.is_game_capture_ready(), "late hello after stop must not restore readiness")
+
+
+func test_debugger_plugin_ignores_hello_from_stale_session() -> void:
+	var game_buf := McpGameLogBuffer.new()
+	var plugin := McpDebuggerPlugin.new(null, game_buf)
+	plugin.begin_game_run()
+	plugin._setup_session(22)
+	plugin._capture("mcp:hello", [], 21)
+	assert_false(plugin.is_game_capture_ready(), "hello from an old debugger session must not ready current run")
+	assert_eq(game_buf.run_id(), "", "stale hello must not rotate logs for current run")
+
+	plugin._capture("mcp:hello", [], 22)
+	assert_true(plugin.is_game_capture_ready(), "hello from current session should ready capture")
+	assert_ne(game_buf.run_id(), "", "current hello rotates run logs")
 
 
 func test_debugger_plugin_log_batch_no_buffer_is_safe() -> void:

--- a/test_project/tests/test_project.gd
+++ b/test_project/tests/test_project.gd
@@ -152,6 +152,16 @@ func test_run_project_invalid_mode_restores_connection_pause() -> void:
 	conn.free()
 
 
+func test_run_project_validation_error_does_not_rotate_capture_run() -> void:
+	var plugin := McpDebuggerPlugin.new()
+	var handler := ProjectHandler.new(null, plugin)
+
+	var result := handler.run_project({"mode": "invalid_mode"})
+
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_eq(plugin._game_run_token, 0, "invalid runs must not clear or advance game capture readiness")
+
+
 func test_run_project_custom_missing_scene() -> void:
 	var result := _handler.run_project({"mode": "custom"})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)


### PR DESCRIPTION
## Summary

Fixes stale game capture readiness leaking across Play/Stop cycles.

`begin_game_run()` now clears any previous `mcp:hello` readiness before starting a new play session and advances a scoped run token. `mcp:hello` only marks the current run/session ready, `editor_state.game_capture_ready` reads through `is_game_capture_ready()`, and `project_manage(op="stop")` clears readiness through `end_game_run()`.

Fixes #323.

## Validation

- `script/ci-check-gdscript`
- `.venv/bin/python -m pytest tests/unit/test_runtime_handlers.py -k "project_run_handler or editor_screenshot_handler"`
- Disposable-project MCP smoke under `/private/tmp/godot-ai-*`, not `test_project`:
  - active session path confirmed as the disposable project
  - opened `res://capture_smoke.tscn`
  - repeated 5x `project_run(mode="current")` -> `editor_screenshot(source="game")` -> `project_manage(op="stop")`
  - each screenshot returned `source="game"` at `1920x1080`
  - plugin logs confirmed fresh run tokens 1 through 5, each followed by a fresh `mcp:hello`
  - post-stop `editor_state` confirmed `is_playing=false` and `game_capture_ready=false`
- `test_run(suite="editor")`: 81 passed, 2 skipped
- `test_run(suite="project")`: 20 passed
