### PR TITLE
Fix full test_run timeout budget

### DIFF
--- a/src/godot_ai/handlers/testing.py
+++ b/src/godot_ai/handlers/testing.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from godot_ai.runtime.direct import DirectRuntime
 
+TEST_RUN_TIMEOUT_SEC = 120.0
+
 
 async def test_run(
     runtime: DirectRuntime,
@@ -23,7 +25,7 @@ async def test_run(
         params["exclude_test_name"] = exclude_test_name
     if verbose:
         params["verbose"] = True
-    return await runtime.send_command("run_tests", params, timeout=30.0)
+    return await runtime.send_command("run_tests", params, timeout=TEST_RUN_TIMEOUT_SEC)
 
 
 async def test_results_get(runtime: DirectRuntime, verbose: bool = False) -> dict:

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -1834,6 +1834,14 @@ async def test_run_tests_handler_with_no_params():
     assert client.calls[-1]["params"] == {}
 
 
+async def test_run_tests_handler_uses_full_suite_timeout():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    await testing_handlers.test_run(runtime)
+    assert client.calls[-1]["timeout"] == testing_handlers.TEST_RUN_TIMEOUT_SEC
+    assert client.calls[-1]["timeout"] > 30.0
+
+
 async def test_run_tests_handler_with_suite_and_test_name():
     client = StubClient()
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)


### PR DESCRIPTION
## Summary
- increase the server-side timeout for in-editor test_run from 30s to 120s
- add a unit contract that test_run stays above the old 30s full-suite boundary

## Tests
- .venv/bin/python -m pytest tests/unit/test_runtime_handlers.py -k "run_tests_handler"
- .venv/bin/python -m pytest tests/integration/test_mcp_tools.py -k "run_tests"
- .venv/bin/python -m ruff check src/godot_ai/handlers/testing.py tests/unit/test_runtime_handlers.py
- git diff --check -- src/godot_ai/handlers/testing.py tests/unit/test_runtime_handlers.py

Fixes #322