### PR TITLE
Clean focused suite editor errors

### DIFF
--- a/plugin/addons/godot_ai/handlers/material_handler.gd
+++ b/plugin/addons/godot_ai/handlers/material_handler.gd
@@ -539,12 +539,19 @@ func apply_preset(params: Dictionary) -> Dictionary:
 
 	if not node_path.is_empty() and path.is_empty():
 		# Inline
-		return apply_to_node({
+		var inline_result := apply_to_node({
 			"node_path": node_path,
 			"type": type_str,
 			"params": preset_params,
 			"slot": params.get("slot", "override"),
 		})
+		if inline_result.has("data"):
+			inline_result.data["preset"] = preset_name
+			inline_result.data["assigned"] = true
+			inline_result.data["path"] = ""
+			inline_result.data["saved_to_disk"] = false
+			inline_result.data["reason"] = "Inline material assigned to node"
+		return inline_result
 
 	# Save-to-disk path.
 	var existed_before := FileAccess.file_exists(path)

--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -214,10 +214,14 @@ func set_property(params: Dictionary) -> Dictionary:
 		if json.parse(value) == OK and json.data is Dictionary and (json.data as Dictionary).has("__class__"):
 			value = json.data
 
-	if target_type == TYPE_OBJECT and value is String:
+	var nil_resource_string: bool = target_type == TYPE_NIL and (value == "" or (value is String and value.begins_with("res://")))
+	var resource_string_value: bool = value is String and (target_type == TYPE_OBJECT or nil_resource_string)
+	if resource_string_value:
 		if value == "":
 			value = null
 		else:
+			if not ResourceLoader.exists(value):
+				return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Resource not found: %s" % value)
 			var loaded := ResourceLoader.load(value)
 			if loaded == null:
 				return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Resource not found: %s" % value)

--- a/plugin/addons/godot_ai/handlers/particle_handler.gd
+++ b/plugin/addons/godot_ai/handlers/particle_handler.gd
@@ -533,7 +533,8 @@ func get_particle(params: Dictionary) -> Dictionary:
 
 	var draw_passes: Array[Dictionary] = []
 	if node is GPUParticles3D:
-		for i in range(1, 5):
+		var active_draw_pass_count: int = min(int(node.draw_passes), 4)
+		for i in range(1, active_draw_pass_count + 1):
 			var prop_name := "draw_pass_%d" % i
 			var m: Mesh = node.get(prop_name) as Mesh
 			draw_passes.append({

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -83,7 +83,7 @@ func test_drift_banner_hidden_when_no_mismatched_clients() -> void:
 	## and become noise. See #166.
 	_dock._build_ui()
 	assert_false(_dock._drift_banner.visible, "Banner must default to hidden")
-	_dock._refresh_drift_banner([])
+	_dock._refresh_drift_banner([] as Array[String])
 	assert_false(_dock._drift_banner.visible, "Empty mismatched list must keep banner hidden")
 
 
@@ -345,7 +345,8 @@ func test_server_version_label_green_when_server_matches_plugin() -> void:
 	_dock._refresh_server_version_label()
 	assert_eq(_dock._setup_server_label.text, "godot-ai == %s" % plugin_ver,
 		"Match: label omits the '(plugin X)' suffix since there's no drift to flag")
-	var color: Color = _dock._setup_server_label.get_theme_color_override("font_color")
+	assert_true(_dock._setup_server_label.has_theme_color_override("font_color"))
+	var color: Color = _dock._setup_server_label.get_theme_color("font_color")
 	assert_true(color == Color.GREEN,
 		"Matched version must render green, got %s" % str(color))
 	assert_false(_dock._version_restart_btn.visible,
@@ -366,8 +367,9 @@ func test_server_version_label_amber_without_restart_when_ownership_unproven() -
 		"Mismatch must show the actual server version, not the plugin's")
 	assert_contains(_dock._setup_server_label.text, plugin_ver,
 		"Mismatch must show the plugin version alongside so the drift is visible at a glance")
+	assert_true(_dock._setup_server_label.has_theme_color_override("font_color"))
 	assert_eq(
-		_dock._setup_server_label.get_theme_color_override("font_color"),
+		_dock._setup_server_label.get_theme_color("font_color"),
 		McpDockScript.COLOR_AMBER,
 		"Mismatch must render amber, matching the drift banner's color"
 	)

--- a/test_project/tests/test_ui.gd
+++ b/test_project/tests/test_ui.gd
@@ -517,9 +517,9 @@ func test_build_layout_theme_override_color() -> void:
 	var label: Label = scene_root.find_child("TestOverrideColor", true, false)
 	assert_true(label != null, "Label should exist")
 	assert_true(label.has_theme_color_override("font_color"), "Color override should be set")
-	# Read back via the *_override getter (not the fallback get_theme_color)
-	# so we're asserting on the stored Variant, not on any theme fallback path.
-	var stored: Color = label.get_theme_color_override("font_color")
+	# Godot 4.6 no longer exposes get_theme_*_override. After has_*_override,
+	# the regular getter resolves the stored override.
+	var stored: Color = label.get_theme_color("font_color")
 	assert_eq(stored.r, 1.0)
 	assert_eq(stored.g, 0.0)
 	assert_eq(stored.b, 0.0)
@@ -546,8 +546,7 @@ func test_build_layout_theme_override_constant() -> void:
 	var vbox := scene_root.find_child("TestOverrideConst", true, false) as VBoxContainer
 	assert_true(vbox != null, "VBoxContainer should exist")
 	assert_true(vbox.has_theme_constant_override("separation"), "Constant override should be set")
-	# Read back via *_override getter — asserts the stored int, not a fallback.
-	assert_eq(vbox.get_theme_constant_override("separation"), 20)
+	assert_eq(vbox.get_theme_constant("separation"), 20)
 	vbox.get_parent().remove_child(vbox)
 	vbox.queue_free()
 
@@ -571,8 +570,7 @@ func test_build_layout_theme_override_font_size() -> void:
 	var label := scene_root.find_child("TestOverrideFontSize", true, false) as Label
 	assert_true(label != null, "Label should exist")
 	assert_true(label.has_theme_font_size_override("font_size"), "Font size override should be set")
-	# Read back via *_override getter.
-	assert_eq(label.get_theme_font_size_override("font_size"), 32)
+	assert_eq(label.get_theme_font_size("font_size"), 32)
 	label.get_parent().remove_child(label)
 	label.queue_free()
 
@@ -604,7 +602,7 @@ func test_build_layout_theme_override_stylebox() -> void:
 	var panel := scene_root.find_child("TestOverrideStyle", true, false) as Panel
 	assert_true(panel != null, "Panel should exist")
 	assert_true(panel.has_theme_stylebox_override("panel"), "Stylebox override should be set")
-	var stored: StyleBox = panel.get_theme_stylebox_override("panel")
+	var stored: StyleBox = panel.get_theme_stylebox("panel")
 	assert_true(stored is StyleBoxFlat, "Stored override is a StyleBoxFlat")
 	assert_eq((stored as StyleBoxFlat).bg_color, Color(0.1, 0.2, 0.3, 1.0))
 	# Cleanup.


### PR DESCRIPTION
## Summary
- return preset metadata for inline material presets so material tests do not emit invalid dictionary access errors
- avoid ResourceLoader.load on known-missing res:// strings and only inspect active particle draw-pass slots
- update UI/dock tests for Godot 4.6 theme override getter behavior and typed array expectations

## Verification
- script/ci-check-gdscript
- pytest -q (771 passed)
- test_run(suite="material") + logs_read(source="editor") empty
- test_run(suite="node") + logs_read(source="editor") empty
- test_run(suite="particle") + logs_read(source="editor") empty
- test_run(suite="ui") + logs_read(source="editor") empty
- test_run(suite="dock") + logs_read(source="editor") empty

Fixes #326