### PR TITLE
Capture editor ResourceLoader errors

### DIFF
--- a/plugin/addons/godot_ai/runtime/editor_logger.gd
+++ b/plugin/addons/godot_ai/runtime/editor_logger.gd
@@ -53,17 +53,26 @@ func _log_error(
 	if _buffer == null:
 		return
 	## Cheap reject for the firehose: when `file` is already non-user (the
-	## bulk of editor-internal C++ chatter) and there's no backtrace to
-	## remap from, the resolved path can only stay non-user — drop without
-	## paying for resolve_error's call frame + dict allocation.
-	if not _is_user_script(file) and script_backtraces.is_empty():
+	## bulk of editor-internal C++ chatter), there's no backtrace to remap
+	## from, and the message doesn't name a project resource, the resolved
+	## path can only stay non-user — drop without paying for resolve_error's
+	## call frame + dict allocation.
+	var message := rationale if not rationale.is_empty() else code
+	var message_res_path := _extract_user_res_path(message)
+	if not _is_user_script(file) and script_backtraces.is_empty() and message_res_path.is_empty():
 		return
 	var resolved := McpLogBacktrace.resolve_error(
 		function, file, line, code, rationale, error_type, script_backtraces,
 	)
 	if not _is_user_script(resolved.path):
-		return
+		if message_res_path.is_empty():
+			return
+		resolved.path = message_res_path
+		resolved.line = 0
+		resolved.function = function
 	if _is_in_godot_ai_addon(resolved.path):
+		return
+	if not message_res_path.is_empty() and _is_in_godot_ai_addon(message_res_path):
 		return
 	_buffer.append(resolved.level, resolved.message, resolved.path, resolved.line, resolved.function)
 
@@ -87,3 +96,30 @@ static func _is_in_godot_ai_addon(path: String) -> bool:
 	if path.begins_with("res://addons/godot_ai/"):
 		return true
 	return path.find(ADDON_PATH_MARKER) >= 0
+
+
+## Some engine-origin errors have no ScriptBacktrace even though they are
+## project-relevant, notably ResourceLoader failures:
+## `Failed loading resource: res://does/not/exist.tres.`. Capture these by
+## extracting a named `res://` path from the message while keeping editor
+## internals and this addon's own resources filtered.
+static func _extract_user_res_path(message: String) -> String:
+	var start := message.find("res://")
+	if start < 0:
+		return ""
+	var end := message.length()
+	var quote_end := message.find("'", start)
+	if quote_end >= 0:
+		end = mini(end, quote_end)
+	quote_end = message.find("\"", start)
+	if quote_end >= 0:
+		end = mini(end, quote_end)
+	quote_end = message.find("`", start)
+	if quote_end >= 0:
+		end = mini(end, quote_end)
+	var path := message.substr(start, end - start).strip_edges()
+	while not path.is_empty() and path.substr(path.length() - 1, 1) in [".", ",", ";", ":", ")"]:
+		path = path.substr(0, path.length() - 1)
+	if path.is_empty() or _is_in_godot_ai_addon(path):
+		return ""
+	return path

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -904,6 +904,53 @@ func test_editor_logger_drops_internal_godot_cpp_noise() -> void:
 	assert_eq(ed_buf.total_count(), 0, "C++-source errors with no script backtrace should be filtered")
 
 
+func test_editor_logger_captures_engine_resource_error_with_res_path() -> void:
+	## ResourceLoader failures can be emitted by engine C++ with no
+	## ScriptBacktrace even when the message names a project resource.
+	## Those red editor/terminal lines should still be visible through
+	## logs_read(source="editor").
+	if not ClassDB.class_exists("Logger"):
+		skip("Logger class requires Godot 4.5+")
+		return
+	var ed_buf := McpEditorLogBuffer.new()
+	var logger = load(_EDITOR_LOGGER_PATH).new(ed_buf)
+	logger._log_error(
+		"_load",
+		"core/io/resource_loader.cpp",
+		222,
+		"Failed loading resource: res://does/not/exist.tres.",
+		"",
+		false,
+		0,
+		[],
+	)
+	var entries := ed_buf.get_range(0, 10)
+	assert_eq(entries.size(), 1, "Engine resource errors naming res:// paths should be captured")
+	assert_eq(entries[0].path, "res://does/not/exist.tres")
+	assert_eq(entries[0].line, 0, "Engine resource errors have no recoverable script line")
+	assert_eq(entries[0].function, "_load")
+	assert_contains(entries[0].text, "Failed loading resource")
+
+
+func test_editor_logger_drops_engine_resource_error_for_godot_ai_addon() -> void:
+	if not ClassDB.class_exists("Logger"):
+		skip("Logger class requires Godot 4.5+")
+		return
+	var ed_buf := McpEditorLogBuffer.new()
+	var logger = load(_EDITOR_LOGGER_PATH).new(ed_buf)
+	logger._log_error(
+		"_load",
+		"core/io/resource_loader.cpp",
+		222,
+		"Failed loading resource: res://addons/godot_ai/missing.tres.",
+		"",
+		false,
+		0,
+		[],
+	)
+	assert_eq(ed_buf.total_count(), 0, "Engine resource errors inside addons/godot_ai/ should be filtered")
+
+
 func test_editor_logger_drops_godot_ai_addon_to_avoid_feedback_loop() -> void:
 	## We push_warning ourselves from plugin.gd. Capturing those would
 	## amplify on every reload and pollute the buffer the dock reads.
@@ -999,6 +1046,23 @@ func test_editor_logger_is_user_script_predicate() -> void:
 	assert_false(script._is_user_script(""))
 	assert_false(script._is_user_script("scene/main/scene_tree.cpp"))
 	assert_false(script._is_user_script("res://image.png"))
+
+
+func test_editor_logger_extract_user_res_path_predicate() -> void:
+	if not ClassDB.class_exists("Logger"):
+		skip("Logger class requires Godot 4.5+")
+		return
+	var script = load(_EDITOR_LOGGER_PATH)
+	assert_eq(
+		script._extract_user_res_path("Cannot open file 'res://does/not/exist.tres'."),
+		"res://does/not/exist.tres",
+	)
+	assert_eq(
+		script._extract_user_res_path("Failed loading resource: res://folder/with spaces/file.tres."),
+		"res://folder/with spaces/file.tres",
+	)
+	assert_eq(script._extract_user_res_path("Failed loading resource: res://addons/godot_ai/x.tres."), "")
+	assert_eq(script._extract_user_res_path("scene/main/scene_tree.cpp noise"), "")
 
 
 func test_editor_logger_is_in_godot_ai_addon_predicate() -> void:


### PR DESCRIPTION
## Summary
- capture engine-origin editor errors when the message names a project res:// resource path
- keep existing Godot-internal and addons/godot_ai logger filtering
- add editor logger coverage for ResourceLoader-style missing resource errors

## Verification
- script/ci-check-gdscript
- test_run suite=editor: 84 passed / 86 total, 2 expected Logger-version skips
- live probe: terminal showed the three missing ResourceLoader red errors and logs_read(source=editor) plus logs_read(source=all) returned the same three entries

Fixes #327