### PR TITLE
Return committed script_create results before import timeout

### DIFF
--- a/plugin/addons/godot_ai/handlers/script_handler.gd
+++ b/plugin/addons/godot_ai/handlers/script_handler.gd
@@ -9,9 +9,11 @@ var _connection: McpConnection
 # Bounded settle window for `ResourceLoader.exists(path)` after `scan()` so
 # that an agent calling create_script -> attach_script back-to-back doesn't
 # race the editor's import pipeline (#261). Polled once per frame, with an
-# elapsed-time cap below the Python client's default 5s command timeout.
+# elapsed-time cap below the dispatcher's create_script deferred timeout. If
+# import is still not visible at the cap, we still return committed=true
+# instead of letting the already-written file surface as DEFERRED_TIMEOUT.
 const _IMPORT_SETTLE_MAX_FRAMES := 300
-const _IMPORT_SETTLE_MAX_MSEC := 4500
+const _IMPORT_SETTLE_MAX_MSEC := 3500
 
 
 func _init(undo_redo: EditorUndoRedoManager, connection: McpConnection = null) -> void:
@@ -54,6 +56,9 @@ func create_script(params: Dictionary) -> Dictionary:
 	var data := {
 		"path": path,
 		"size": content.length(),
+		"committed": true,
+		"import_settled": existed_before,
+		"import_settle": "already_known" if existed_before else "not_waited",
 		"undoable": false,
 		"reason": "File system operations cannot be undone via editor undo",
 	}
@@ -78,8 +83,16 @@ func create_script(params: Dictionary) -> Dictionary:
 
 func _finish_create_script_deferred(request_id: String, path: String, data: Dictionary) -> void:
 	var tree := _connection.get_tree()
-	var frames := 0
 	var deadline_ms := Time.get_ticks_msec() + _IMPORT_SETTLE_MAX_MSEC
+	# Let _dispatch() return DEFERRED_RESPONSE and register the request before
+	# this coroutine can send a committed result. ResourceLoader.exists(path)
+	# may already be true on fast imports; without this handoff the connection
+	# treats the response as late/unregistered and drops it, then the dispatcher
+	# times out a file that was already written (#324). The deadline starts
+	# before this await so a slow handoff frame is counted against the bounded
+	# settle window.
+	await tree.process_frame
+	var frames := 0
 	while (
 		frames < _IMPORT_SETTLE_MAX_FRAMES
 		and Time.get_ticks_msec() < deadline_ms
@@ -93,7 +106,10 @@ func _finish_create_script_deferred(request_id: String, path: String, data: Dict
 	if not is_instance_valid(_connection):
 		return
 	var payload := data.duplicate()
-	payload["import_settled"] = ResourceLoader.exists(path)
+	var settled := ResourceLoader.exists(path)
+	payload["import_settled"] = settled
+	payload["import_settle"] = "settled" if settled else "timeout"
+	payload["import_pending"] = not settled
 	_connection.send_deferred_response(request_id, {"data": payload})
 
 

--- a/test_project/tests/test_script.gd
+++ b/test_project/tests/test_script.gd
@@ -58,6 +58,9 @@ func test_create_script_basic() -> void:
 	assert_has_key(result, "data")
 	assert_eq(result.data.path, path)
 	assert_eq(result.data.size, content.length())
+	assert_eq(result.data.committed, true)
+	assert_eq(result.data.import_settled, false)
+	assert_eq(result.data.import_settle, "not_waited")
 	assert_false(result.data.undoable, "File write should not be undoable")
 	# Verify file was actually written
 	assert_true(FileAccess.file_exists(path), "Script file should exist")
@@ -81,6 +84,9 @@ func test_create_script_overwrite_omits_cleanup_hint() -> void:
 	first.close()
 	var result := _handler.create_script({"path": path, "content": "extends Node\n# v2\n"})
 	assert_has_key(result, "data")
+	assert_eq(result.data.committed, true)
+	assert_eq(result.data.import_settled, true)
+	assert_eq(result.data.import_settle, "already_known")
 	assert_false(result.data.has("cleanup"), "Overwrite must not emit a cleanup hint")
 	DirAccess.remove_absolute(path)
 

--- a/tests/unit/test_script_create_import_settle.py
+++ b/tests/unit/test_script_create_import_settle.py
@@ -71,10 +71,11 @@ def test_finish_create_script_deferred_polls_resourceloader_with_bounded_loop() 
         "The deferred loop must use a named bounded-frame constant so the "
         "wait can't run forever if the filesystem scan stalls."
     )
-    assert "_IMPORT_SETTLE_MAX_MSEC := 4500" in source, (
-        "The deferred loop must also be capped below the Python client's "
-        "default 5s send timeout. A pure 300-frame cap can exceed 5s on a "
-        "slow editor frame rate."
+    assert "_IMPORT_SETTLE_MAX_MSEC := 3500" in source, (
+        "The deferred loop must be capped well below the dispatcher's "
+        "create_script deferred timeout. If this window reaches the dispatcher "
+        "timeout, a committed file can still surface to callers as "
+        "DEFERRED_TIMEOUT."
     )
     deferred_block = get_func_block(source, "func _finish_create_script_deferred")
     assert "var deadline_ms := Time.get_ticks_msec() + _IMPORT_SETTLE_MAX_MSEC" in deferred_block
@@ -88,16 +89,47 @@ def test_finish_create_script_deferred_polls_resourceloader_with_bounded_loop() 
         "The deferred loop must yield via process_frame between polls so the "
         "editor can actually run the import pipeline between checks."
     )
+    assert (
+        deferred_block.find("var deadline_ms := Time.get_ticks_msec() + _IMPORT_SETTLE_MAX_MSEC")
+        < deferred_block.find("await tree.process_frame")
+    ), (
+        "The deferred coroutine must start its deadline before the registration "
+        "handoff await. Otherwise a slow first frame is outside the bounded "
+        "window and a committed write can still hit the dispatcher timeout (#324)."
+    )
     # The reply must use send_deferred_response with a {"data": ...} payload.
     assert "_connection.send_deferred_response(request_id" in deferred_block, (
         "After settling, the handler must push the response over the "
         "connection's send_deferred_response — the dispatcher won't do it."
     )
+    assert 'payload["import_settle"] = "settled" if settled else "timeout"' in deferred_block
+    assert 'payload["import_pending"] = not settled' in deferred_block
     # Match the project_handler.stop_project pattern: drop the response if
     # the plugin tore down during the await.
     assert "is_instance_valid(_connection)" in deferred_block, (
         "If _exit_tree fires during the await the connection is freed; the "
         "deferred reply must check is_instance_valid and bail silently."
+    )
+
+
+def test_create_script_reports_committed_status_even_when_import_wait_times_out() -> None:
+    """A committed file must not be indistinguishable from a failed mutation."""
+    source = SCRIPT_HANDLER.read_text()
+
+    assert '"committed": true' in source, (
+        "create_script writes the file before waiting for ResourceLoader; the "
+        "response must expose committed=true so callers know retrying is not a "
+        "plain safe retry."
+    )
+    assert '"import_settle": "already_known" if existed_before else "not_waited"' in source
+    deferred_block = get_func_block(source, "func _finish_create_script_deferred")
+    assert 'payload["import_settle"] = "settled" if settled else "timeout"' in deferred_block, (
+        "Deferred completion must distinguish import success from import-settle "
+        "timeout while still returning a success payload for the committed file."
+    )
+    assert 'payload["import_pending"] = not settled' in deferred_block, (
+        "When import settling times out, callers need an explicit import_pending "
+        "flag instead of interpreting a transport timeout as write failure."
     )
 
 


### PR DESCRIPTION
## Summary
- avoid dropping fast deferred script_create replies before dispatcher registration
- return explicit committed/import-settle status for script_create results
- keep import settling bounded below the dispatcher timeout so committed writes do not surface as DEFERRED_TIMEOUT

## Verification
- script/ci-check-gdscript
- pytest -q tests/unit/test_script_create_import_settle.py tests/unit/test_runtime_handlers.py::test_script_create_handler
- live MCP script_create probe returned success with committed=true and import_settle=settled instead of DEFERRED_TIMEOUT
- focused Godot test_run suite=script passed 33/33

Fixes #324