### PR TITLE
Support rich environment sky payloads

### DIFF
--- a/plugin/addons/godot_ai/handlers/environment_handler.gd
+++ b/plugin/addons/godot_ai/handlers/environment_handler.gd
@@ -46,7 +46,27 @@ func create_environment(params: Dictionary) -> Dictionary:
 		)
 
 	var preset_config: Dictionary = _PRESETS[preset]
-	var want_sky: bool = sky_param if sky_param != null else preset_config.sky
+	var want_sky: bool = preset_config.sky
+	var sky_properties: Dictionary = {}
+	if sky_param != null:
+		if sky_param is bool:
+			want_sky = sky_param
+		elif sky_param is Dictionary:
+			var sky_config: Dictionary = (sky_param as Dictionary).duplicate()
+			var material_type: String = String(sky_config.get("sky_material", "procedural")).to_lower()
+			if material_type != "procedural":
+				return McpErrorCodes.make(
+					McpErrorCodes.INVALID_PARAMS,
+					"sky.sky_material must be 'procedural' when sky is a dictionary"
+				)
+			sky_config.erase("sky_material")
+			sky_properties = sky_config
+			want_sky = true
+		else:
+			return McpErrorCodes.make(
+				McpErrorCodes.INVALID_PARAMS,
+				"sky must be a bool, null, or dictionary of ProceduralSkyMaterial properties"
+			)
 
 	var env := Environment.new()
 	var sky: Sky = null
@@ -61,6 +81,10 @@ func create_environment(params: Dictionary) -> Dictionary:
 		env.background_mode = Environment.BG_CLEAR_COLOR
 
 	_apply_preset(env, sky_material, preset)
+	if not sky_properties.is_empty():
+		var sky_apply_err := ResourceHandler._apply_resource_properties(sky_material, sky_properties)
+		if sky_apply_err != null:
+			return sky_apply_err
 	if preset_config.fog:
 		env.volumetric_fog_enabled = true
 		env.volumetric_fog_density = 0.03

--- a/src/godot_ai/handlers/environment.py
+++ b/src/godot_ai/handlers/environment.py
@@ -12,7 +12,7 @@ async def environment_create(
     path: str = "",
     preset: str = "default",
     properties: dict | None = None,
-    sky: bool | None = None,
+    sky: bool | dict | None = None,
     resource_path: str = "",
     overwrite: bool = False,
 ) -> dict:

--- a/src/godot_ai/tools/resource.py
+++ b/src/godot_ai/tools/resource.py
@@ -43,7 +43,9 @@ Ops:
   • environment_create(path="", preset="default", properties=None,
                         sky=None, resource_path="", overwrite=False)
         Build Environment + Sky chain. Presets: default | clear | sunset
-        | night | fog. Either assign to a WorldEnvironment node or save .tres.
+        | night | fog. sky may be bool or a procedural sky dict such as
+        {"sky_material": "procedural", "sky_top_color": "#0f172a"}.
+        Either assign to a WorldEnvironment node or save .tres.
   • physics_shape_autofit(path, source_path="", shape_type="")
         Size a CollisionShape2D/3D to a nearby visual's bounds. Searches
         direct siblings then parent-siblings (handles nested

--- a/test_project/tests/test_environment.gd
+++ b/test_project/tests/test_environment.gd
@@ -139,6 +139,50 @@ func test_create_sky_false_skips_sky_chain() -> void:
 	_remove_node(we)
 
 
+func test_create_rich_sky_payload_applies_procedural_material_properties() -> void:
+	var we := _add_world_env("TestEnvRichSky")
+	if we == null:
+		skip("No scene root")
+		return
+	var result := _handler.create_environment({
+		"path": we.get_path(),
+		"preset": "night",
+		"properties": {"ambient_light_energy": 0.35},
+		"sky": {
+			"sky_material": "procedural",
+			"sky_top_color": "#0f172a",
+			"sky_horizon_color": "#334155",
+		},
+	})
+	assert_has_key(result, "data")
+	assert_true(result.data.sky_created)
+	assert_true(is_equal_approx(we.environment.ambient_light_energy, 0.35))
+	var mat: ProceduralSkyMaterial = we.environment.sky.sky_material
+	assert_true(mat.sky_top_color.is_equal_approx(Color.from_string("#0f172a", Color.MAGENTA)))
+	assert_true(mat.sky_horizon_color.is_equal_approx(Color.from_string("#334155", Color.MAGENTA)))
+	_remove_node(we)
+
+
+func test_create_invalid_sky_shape_errors() -> void:
+	var result := _handler.create_environment({
+		"path": "/Main/World",
+		"preset": "night",
+		"sky": ["procedural"],
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "sky")
+
+
+func test_create_unsupported_sky_material_errors() -> void:
+	var result := _handler.create_environment({
+		"path": "/Main/World",
+		"preset": "night",
+		"sky": {"sky_material": "panorama"},
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "sky_material")
+
+
 func test_create_properties_override_preset() -> void:
 	var we := _add_world_env("TestEnvOverride")
 	if we == null:

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -2473,6 +2473,30 @@ async def test_environment_create_save_handler():
     }
 
 
+async def test_environment_create_forwards_rich_sky_dict():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    sky = {
+        "sky_material": "procedural",
+        "sky_top_color": "#0f172a",
+        "sky_horizon_color": "#334155",
+    }
+    result = await environment_handlers.environment_create(
+        runtime,
+        path="/Main/World",
+        preset="night",
+        properties={"ambient_light_energy": 0.35},
+        sky=sky,
+    )
+    assert result["undoable"] is True
+    assert client.calls[-1]["params"] == {
+        "preset": "night",
+        "path": "/Main/World",
+        "properties": {"ambient_light_energy": 0.35},
+        "sky": sky,
+    }
+
+
 async def test_environment_create_requires_writable():
     from godot_ai.godot_client.client import GodotCommandError
     from godot_ai.sessions.registry import Session


### PR DESCRIPTION
## Summary
- accept procedural sky dictionaries in environment_create and apply them to ProceduralSkyMaterial
- reject invalid sky shapes and unsupported sky_material values with INVALID_PARAMS
- document/forward rich sky payloads through the Python resource tool wrapper

Fixes #325

## Verification
- script/ci-check-gdscript
- pytest -q tests/unit/test_runtime_handlers.py -k environment_create
- focused live MCP test_run suite=environment: 14 passed, 0 failed