### PR TITLE
Validate scene_save for never-saved scenes

### DIFF
--- a/plugin/addons/godot_ai/handlers/scene_handler.gd
+++ b/plugin/addons/godot_ai/handlers/scene_handler.gd
@@ -4,6 +4,8 @@ extends RefCounted
 ## Handles scene tree reading and node search.
 
 var _connection: McpConnection
+var _save_scene_callable: Callable = Callable()
+var _save_scene_as_callable: Callable = Callable()
 
 
 func _init(connection: McpConnection = null) -> void:
@@ -165,9 +167,16 @@ func save_scene(_params: Dictionary) -> Dictionary:
 	if scene_root == null:
 		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
 
+	var path := scene_root.scene_file_path
+	if path.is_empty():
+		return McpErrorCodes.make(
+			McpErrorCodes.INVALID_PARAMS,
+			"Current scene has never been saved; call scene_save_as or scene_manage(op='save_as') with a res://...tscn path."
+		)
+
 	if _connection:
 		_connection.pause_processing = true
-	var err := EditorInterface.save_scene()
+	var err := _save_current_scene()
 	if _connection:
 		_connection.pause_processing = false
 
@@ -176,7 +185,7 @@ func save_scene(_params: Dictionary) -> Dictionary:
 
 	return {
 		"data": {
-			"path": scene_root.scene_file_path,
+			"path": path,
 			"undoable": false,
 			"reason": "File save cannot be undone via editor undo",
 		}
@@ -208,7 +217,7 @@ func save_scene_as(params: Dictionary) -> Dictionary:
 
 	if _connection:
 		_connection.pause_processing = true
-	EditorInterface.save_scene_as(path)
+	_save_current_scene_as(path)
 	if _connection:
 		_connection.pause_processing = false
 
@@ -219,6 +228,19 @@ func save_scene_as(params: Dictionary) -> Dictionary:
 			"reason": "File save cannot be undone via editor undo",
 		}
 	}
+
+
+func _save_current_scene() -> int:
+	if _save_scene_callable.is_valid():
+		return int(_save_scene_callable.call())
+	return EditorInterface.save_scene()
+
+
+func _save_current_scene_as(path: String) -> void:
+	if _save_scene_as_callable.is_valid():
+		_save_scene_as_callable.call(path)
+		return
+	EditorInterface.save_scene_as(path)
 
 
 func _walk_tree(node: Node, out: Array[Dictionary], depth: int, max_depth: int, scene_root: Node) -> void:

--- a/plugin/addons/godot_ai/handlers/scene_handler.gd
+++ b/plugin/addons/godot_ai/handlers/scene_handler.gd
@@ -171,7 +171,7 @@ func save_scene(_params: Dictionary) -> Dictionary:
 	if path.is_empty():
 		return McpErrorCodes.make(
 			McpErrorCodes.INVALID_PARAMS,
-			"Current scene has never been saved; call scene_save_as or scene_manage(op='save_as') with a res://...tscn path."
+			"Current scene has never been saved; call scene_manage(op='save_as') with a res://... path ending in .tscn or .scn."
 		)
 
 	if _connection:

--- a/test_project/tests/test_scene.gd
+++ b/test_project/tests/test_scene.gd
@@ -14,6 +14,21 @@ const SceneHandler := preload("res://addons/godot_ai/handlers/scene_handler.gd")
 
 var _handler: SceneHandler
 
+class SaveSpy:
+	extends RefCounted
+
+	var save_called := false
+	var save_as_called := false
+	var save_as_path := ""
+
+	func save_scene() -> int:
+		save_called = true
+		return OK
+
+	func save_scene_as(path: String) -> void:
+		save_as_called = true
+		save_as_path = path
+
 
 func suite_name() -> String:
 	return "scene"
@@ -167,6 +182,73 @@ func test_open_scene_nonexistent() -> void:
 
 
 # ----- save_scene / save_scene_as (validation only — save triggers modal dialog) -----
+
+func test_save_scene_never_saved_returns_actionable_validation_error() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene open")
+		return
+
+	var original_path := scene_root.scene_file_path
+	var spy := SaveSpy.new()
+	_handler._save_scene_callable = spy.save_scene
+	scene_root.scene_file_path = ""
+
+	var result := _handler.save_scene({})
+
+	scene_root.scene_file_path = original_path
+	_handler._save_scene_callable = Callable()
+
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_false(spy.save_called, "scene_save must not call EditorInterface.save_scene() without a scene path")
+	assert_contains(result.error.message, "scene_save_as")
+	assert_contains(result.error.message, "scene_manage(op='save_as')")
+	assert_contains(result.error.message, "res://...tscn")
+
+
+func test_save_scene_succeeds_for_saved_scene() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene open")
+		return
+	if scene_root.scene_file_path.is_empty():
+		skip("Current scene has no path")
+		return
+
+	var spy := SaveSpy.new()
+	_handler._save_scene_callable = spy.save_scene
+
+	var result := _handler.save_scene({})
+
+	_handler._save_scene_callable = Callable()
+
+	assert_has_key(result, "data")
+	assert_true(spy.save_called, "scene_save should save when the scene already has a path")
+	assert_eq(result.data.path, scene_root.scene_file_path)
+
+
+func test_save_scene_as_supports_never_saved_scene() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene open")
+		return
+
+	var original_path := scene_root.scene_file_path
+	var spy := SaveSpy.new()
+	var path := "res://tmp/mcp_scene_save_as_from_unsaved.tscn"
+	_handler._save_scene_as_callable = spy.save_scene_as
+	scene_root.scene_file_path = ""
+
+	var result := _handler.save_scene_as({"path": path})
+
+	scene_root.scene_file_path = original_path
+	_handler._save_scene_as_callable = Callable()
+
+	assert_has_key(result, "data")
+	assert_true(spy.save_as_called, "scene_save_as should remain available for scenes without a path")
+	assert_eq(spy.save_as_path, path)
+	assert_eq(result.data.path, path)
+
 
 func test_save_scene_as_missing_path() -> void:
 	var result := _handler.save_scene_as({})

--- a/test_project/tests/test_scene.gd
+++ b/test_project/tests/test_scene.gd
@@ -201,9 +201,14 @@ func test_save_scene_never_saved_returns_actionable_validation_error() -> void:
 
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 	assert_false(spy.save_called, "scene_save must not call EditorInterface.save_scene() without a scene path")
-	assert_contains(result.error.message, "scene_save_as")
+	# Recovery hint must point at the published MCP tool surface
+	# (scene_manage(op='save_as')), not a non-existent `scene_save_as`
+	# top-level tool. Hint must also acknowledge both supported scene
+	# extensions (.tscn and .scn) since save_scene_as accepts either.
 	assert_contains(result.error.message, "scene_manage(op='save_as')")
-	assert_contains(result.error.message, "res://...tscn")
+	assert_contains(result.error.message, "res://")
+	assert_contains(result.error.message, ".tscn")
+	assert_contains(result.error.message, ".scn")
 
 
 func test_save_scene_succeeds_for_saved_scene() -> void:


### PR DESCRIPTION
## Summary
- return INVALID_PARAMS before calling Godot's pathless scene save when the edited scene has no file path
- keep scene_save_as as the supported save path for never-saved scenes
- add focused scene handler coverage for unsaved save, saved save, and save_as behavior

## Verification
- script/ci-check-gdscript
- live MCP test_run suite=scene: 24 passed, 0 failed

Fixes #303