### PR TITLE
Flush CliFinder cache on force-refresh (#297 deferred)

### DIFF
--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -490,6 +490,16 @@ static func invalidate_uvx_cli_cache() -> void:
 		CliFinder.invalidate(name)
 
 
+## Drop the entire `CliFinder` cache. Called by the dock's manual Refresh
+## button so a freshly-installed CLI (claude, codex, gemini, …) gets
+## detected without an editor restart. Per-CLI invalidation
+## (`invalidate_uvx_cli_cache`) is preferred when the dock knows which
+## binary changed; this catch-all fits the user-clicked-Refresh case
+## where any CLI may have been installed since the last sweep.
+static func invalidate_cli_cache() -> void:
+	CliFinder.invalidate()
+
+
 static var _uv_version_cache: String = ""
 static var _uv_version_searched: bool = false
 

--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -490,12 +490,19 @@ static func invalidate_uvx_cli_cache() -> void:
 		CliFinder.invalidate(name)
 
 
-## Drop the entire `CliFinder` cache. Called by the dock's manual Refresh
-## button so a freshly-installed CLI (claude, codex, gemini, …) gets
-## detected without an editor restart. Per-CLI invalidation
-## (`invalidate_uvx_cli_cache`) is preferred when the dock knows which
-## binary changed; this catch-all fits the user-clicked-Refresh case
-## where any CLI may have been installed since the last sweep.
+## Drop the entire `CliFinder` cache. Called from any explicit-user-action
+## refresh path (`force=true` in `_request_client_status_refresh` — manual
+## Refresh button, popup-open, compat wrapper, future external API) so a
+## freshly-installed CLI (claude, codex, gemini, …) gets detected without
+## an editor restart. Per-CLI invalidation (`invalidate_uvx_cli_cache`) is
+## preferred when the dock knows which binary changed; this catch-all
+## handles the "any CLI may have been installed since the last sweep" case.
+##
+## Thread safety: `CliFinder.invalidate()` guards `_cache` / `_searched`
+## with a mutex so it can race safely against worker threads calling
+## `find()` from `_run_client_action_worker`. The mutex is held only
+## across the dictionary clear, never across `OS.execute`, so this call
+## can never block the main thread on a subprocess.
 static func invalidate_cli_cache() -> void:
 	CliFinder.invalidate()
 

--- a/plugin/addons/godot_ai/clients/_cli_finder.gd
+++ b/plugin/addons/godot_ai/clients/_cli_finder.gd
@@ -8,8 +8,19 @@ extends RefCounted
 ##   2. Login shell lookup (`bash -lc 'command -v <exe>'`) — picks up .zshrc / .bashrc
 ##   3. Plain `which` / `where` against the inherited PATH
 ## Caches per-exe so repeated dock refreshes don't fork a shell every frame.
+##
+## Thread safety: `find()` runs on action-worker threads
+## (`_run_client_action_worker` in `mcp_dock.gd`), and `invalidate()` runs on
+## the main thread (manual Refresh path). Godot `Dictionary` is not safe for
+## concurrent mutation, so `_cache` / `_searched` access is guarded by
+## `_mutex`. The mutex is held only across dictionary read/write — the slow
+## `_resolve()` path (FileAccess + `OS.execute`) runs unlocked, so a
+## main-thread `invalidate()` can never block on a worker's subprocess.
+## Two workers racing the same exe both call `_resolve()` and both write
+## back the same answer; that's wasted work, not corruption.
 
 
+static var _mutex: Mutex = Mutex.new()
 static var _cache: Dictionary = {}  # exe_name -> resolved path (or "")
 static var _searched: Dictionary = {}
 
@@ -26,20 +37,33 @@ static func find(exe_names: Array[String]) -> String:
 
 ## Drop cache for one exe (call after the user installs / reinstalls).
 static func invalidate(exe_name: String = "") -> void:
+	_mutex.lock()
 	if exe_name.is_empty():
 		_cache.clear()
 		_searched.clear()
 	else:
 		_cache.erase(exe_name)
 		_searched.erase(exe_name)
+	_mutex.unlock()
 
 
 static func _find_one(exe_name: String) -> String:
-	if _searched.get(exe_name, false):
-		return _cache.get(exe_name, "")
+	_mutex.lock()
+	var already_searched: bool = _searched.get(exe_name, false)
+	var cached: String = _cache.get(exe_name, "")
+	_mutex.unlock()
+	if already_searched:
+		return cached
+	# `_resolve()` does FileAccess + `OS.execute` (forks `bash -lc` /
+	# `which`), which can take 100ms-1s. Holding the mutex across that
+	# would let a concurrent `invalidate()` on the main thread freeze the
+	# editor for the duration of the subprocess — which defeats the whole
+	# point of running CLI lookup off the main thread.
 	var hit := _resolve(exe_name)
+	_mutex.lock()
 	_cache[exe_name] = hit
 	_searched[exe_name] = true
+	_mutex.unlock()
 	return hit
 
 

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -2067,6 +2067,16 @@ func _request_client_status_refresh(force: bool = false) -> bool:
 			_defer_client_status_refresh_until_filesystem_ready(force)
 		return false
 
+	## Manual refresh (any `force=true` path: button click, popup open,
+	## external API caller) implies "may have installed a CLI since the
+	## last sweep" — flush CliFinder so freshly-installed binaries get
+	## re-detected. Focus-in (`force=false`) stays cached so the cheap
+	## case stays cheap. Per-CLI invalidation
+	## (`invalidate_uvx_cli_cache`) still pairs with specific events
+	## like `_on_install_uv` where the binary name is known.
+	if force:
+		ClientConfigurator.invalidate_cli_cache()
+
 	## Force the bytecode swap on the same scripts the worker will reach
 	## into — same #233/#235 guard `_perform_initial_*` already had.
 	## Without this, a manual refresh dispatched before the initial sweep

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -173,6 +173,18 @@ func test_manual_command_escapes_backslashes_in_paths() -> void:
 # ----- server launch mode -----
 
 
+func test_invalidate_cli_cache_clears_all_entries() -> void:
+	McpCliFinder.invalidate()
+	var miss := McpCliFinder.find(["mcp_test_definitely_no_such_cli_xyz"])
+	assert_eq(miss, "")
+	assert_true(McpCliFinder._searched.size() > 0)
+
+	McpClientConfigurator.invalidate_cli_cache()
+
+	assert_eq(McpCliFinder._cache.size(), 0)
+	assert_eq(McpCliFinder._searched.size(), 0, "Without dropping _searched, the next find() short-circuits on the stale negative")
+
+
 func test_server_launch_mode_returns_known_string() -> void:
 	## get_server_launch_mode() powers the handshake field agents read to
 	## detect plugin/server version drift. Always returns one of four

--- a/tests/unit/test_editor_focus_refocus.py
+++ b/tests/unit/test_editor_focus_refocus.py
@@ -616,6 +616,62 @@ def test_force_refresh_invalidates_cli_finder_cache() -> None:
     )
 
 
+def test_cli_finder_cache_is_mutex_guarded() -> None:
+    """`CliFinder.find()` runs on action-worker threads
+    (`_run_client_action_worker` in `mcp_dock.gd`) and `invalidate()` runs on
+    the main thread (force-refresh path). Godot `Dictionary` is not safe for
+    concurrent mutation, so `_cache` / `_searched` access must be guarded by
+    a `Mutex`. The mutex must NOT be held across `_resolve()` (which forks
+    `bash -lc` / `which` and can take 100ms-1s) — otherwise a main-thread
+    `invalidate()` blocks the editor on a worker's subprocess, defeating
+    the off-main-thread CLI-lookup design.
+    """
+
+    source = (PLUGIN_ROOT / "clients" / "_cli_finder.gd").read_text()
+
+    assert re.search(r"static var _mutex: Mutex = Mutex\.new\(\)", source), (
+        "CliFinder must declare `static var _mutex: Mutex = Mutex.new()` so "
+        "concurrent find()/invalidate() calls don't race the shared "
+        "_cache / _searched dictionaries."
+    )
+
+    invalidate_block = get_func_block(
+        source, "static func invalidate(exe_name: String = \"\") -> void:"
+    )
+    assert "_mutex.lock()" in invalidate_block and "_mutex.unlock()" in invalidate_block, (
+        "invalidate() must hold _mutex around the dict clear/erase so it "
+        "can race safely against worker-thread find() calls."
+    )
+
+    find_one_block = get_func_block(source, "static func _find_one(exe_name: String) -> String:")
+    # Lock + unlock pattern must appear at least twice: once around the
+    # cache read, once around the cache writeback. _resolve() must run
+    # outside any lock — the lock/unlock count therefore tells us the
+    # critical sections aren't accidentally fused into a single span that
+    # encloses the subprocess fork.
+    assert find_one_block.count("_mutex.lock()") >= 2, (
+        "_find_one() must lock _mutex separately around the read and the "
+        "writeback so _resolve() (which forks bash) runs unlocked."
+    )
+    assert find_one_block.count("_mutex.unlock()") >= 2, (
+        "_find_one() must release _mutex before calling _resolve(), "
+        "otherwise a main-thread invalidate() blocks on the subprocess."
+    )
+    # Hard guarantee: no `_resolve(` call sandwiched between a lock and the
+    # next unlock. Search for the resolve call and check the surrounding
+    # context.
+    resolve_idx = find_one_block.index("_resolve(")
+    preceding = find_one_block[:resolve_idx]
+    last_lock = preceding.rfind("_mutex.lock()")
+    last_unlock = preceding.rfind("_mutex.unlock()")
+    assert last_unlock > last_lock, (
+        "_resolve() must be called with _mutex unlocked. Holding the lock "
+        "across the subprocess fork would let invalidate() freeze the main "
+        "thread for the duration of `bash -lc` / `which` — exactly the "
+        "main-thread blocking the off-thread design exists to avoid."
+    )
+
+
 def test_configure_all_uses_cached_status_not_dot_color() -> None:
     """Configure-all must not make correctness decisions from stale UI colors."""
 

--- a/tests/unit/test_editor_focus_refocus.py
+++ b/tests/unit/test_editor_focus_refocus.py
@@ -580,6 +580,42 @@ def test_check_uv_version_caches_for_session() -> None:
     )
 
 
+def test_force_refresh_invalidates_cli_finder_cache() -> None:
+    """Force-refresh (manual button, popup open, any explicit-user callsite)
+    flushes CliFinder so a freshly-installed CLI is re-detected without an
+    editor restart. Focus-in (`force=false`) keeps the cache.
+    """
+
+    configurator_source = (PLUGIN_ROOT / "client_configurator.gd").read_text()
+    invalidator_block = get_func_block(
+        configurator_source, "static func invalidate_cli_cache() -> void:"
+    )
+    assert "CliFinder.invalidate()" in invalidator_block, (
+        "Facade must call no-arg CliFinder.invalidate() to drop every "
+        "cached entry (positive and negative)."
+    )
+
+    dock_source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+    request_block = get_func_block(
+        dock_source,
+        "func _request_client_status_refresh(force: bool = false) -> bool:",
+    )
+    assert re.search(
+        r"if force:\s+ClientConfigurator\.invalidate_cli_cache\(\)",
+        request_block,
+    ), (
+        "_request_client_status_refresh must flush CliFinder when "
+        "force=true so manual refresh, popup-open, and every other "
+        "explicit-user-action callsite re-detects newly-installed CLIs."
+    )
+
+    focus_in_block = _focus_in_block(dock_source)
+    assert "invalidate_cli_cache" not in focus_in_block, (
+        "Focus-in must NOT flush — focus fires dozens of times per "
+        "session and would re-fork `which` / `bash -lc` every time."
+    )
+
+
 def test_configure_all_uses_cached_status_not_dot_color() -> None:
     """Configure-all must not make correctness decisions from stale UI colors."""
 


### PR DESCRIPTION
## Summary

Base: `beta`. Closes the "CLI finder cache never invalidates" deferred audit finding from #297 — fits the same pattern as #338 (#12 contract test) and #339 (debugger timer leak): pick one finding, do it well, no bundling. Triage: the only other open issues (#303, #328, #316) already have active PRs (#336, #337, #335 merged for #316's diagnostic gap).

### What it does

`McpCliFinder.find()` is the three-tier CLI lookup (well-known dirs → `bash -lc 'command -v'` → `which`/`where`) used to detect installed clients (claude, codex, gemini, …). Once a binary was resolved or missed, the result was pinned for the editor session. So if a user installed `claude` in a terminal mid-session and clicked the dock's Refresh button, the row kept reporting "not installed" until they restarted Godot.

The fix wires `ClientConfigurator.invalidate_cli_cache()` (a new no-arg facade over `CliFinder.invalidate()`) into `_request_client_status_refresh(force)` so **every** explicit-user-action callsite shares one flush site:

- `_on_refresh_clients_pressed` — manual Refresh button
- `_on_open_clients_window` — popup open
- `_refresh_all_client_statuses` — compat wrapper marked "treat as manual refresh"

Focus-in cooldown refresh (`force=false`) deliberately keeps the cache — focus fires dozens of times per session and would otherwise re-fork `which` / `bash -lc` each time, defeating the cache. Per-CLI helpers like `invalidate_uvx_cli_cache` stay alongside for event-driven cases (`_on_install_uv` knows the binary name).

The flush sits after every early-return guard (`_server_blocks_client_health`, `_self_update_in_progress`, in-flight worker, cooldown, filesystem busy) and before `Thread.start()`, so it can't race the worker. The `has_worker_alive` early-return prevents flushing while a thread reads `_cache`/`_searched`. Filesystem-busy / cooldown paths preserve `_pending_force`, so the deferred dispatcher eventually flushes once the gate opens.

### Verification

- `ruff check src/ tests/` — clean
- `pytest -q` — 763 passed
- `script/ci-check-gdscript` — clean
- Live MCP `test_run suite=clients` against a headless Godot 4.6.2 editor — 82/82 passed, 0 failed
  - New `clients.test_invalidate_cli_cache_clears_all_entries` runs with 4 asserts (verbose results confirmed)
- Live MCP full `test_run` — 1138/1154 passed, 0 failed (16 skipped — environment-gated)

### /simplify pass

Three review agents reviewed the diff:

- **Applied (reuse, substantive)**: original draft only flushed at `_on_refresh_clients_pressed`. Two other force=true callsites (`_on_open_clients_window`, `_refresh_all_client_statuses` — both documented as user-action equivalents) suffered the same stale-miss bug. Folded the flush into `_request_client_status_refresh(force)` so every force=true entry point invalidates from one place; the `force` arg is already exactly the "user-driven, bypass cooldown" signal.
- **Applied (quality)**: dropped narration comment from `_on_refresh_clients_pressed` (now a one-line delegate). Trimmed Python contract test docstring + assertion messages from paragraph-length to one-sentence each. Trimmed inline GDScript test docstring; assertion messages now only carry the load-bearing one (`_searched` not dropped → next find() short-circuits on stale negative).
- **Skipped (efficiency)**: agent found nothing to fix — manual refresh is user-initiated, the ~5-entry `Dictionary.clear()` is in the noise behind the worker's `OS.execute` round-trips, and gating on `_searched.size() > 0` would just add a branch for a nanosecond's saving.

### /review pass

Independent correctness review (verdict: SHIP) confirmed:

- Concurrency: flush sits before `Thread.start()`; `has_worker_alive` early-return prevents flushing while a worker holds the cache; deferred paths preserve `_pending_force`.
- All three force=true callsites are explicit-user / external-API paths — none should opt out.
- Test reaching into `_cache` / `_searched` underscored statics is acceptable: same-plugin internal class, asserting on observable state is stronger than a `cache_size()` shim that would only exist for tests.
- Comment weight on the new gate is justified — the WHY (focus-in fork cost) and relationship to per-CLI invalidator are non-obvious.
- Test hygiene: 4 load-bearing asserts, no zero-assertion path, no `assert_has_key` without value check, no bare `return`.
- **Applied (review nit)**: changed Python lock-test from literal-string match (`"if force:\n\t\tClientConfigurator..."`) to regex match (`r"if force:\s+ClientConfigurator\.invalidate_cli_cache\(\)"`) so a future GDScript reformat that touches indentation doesn't false-fail the contract.

## Out of scope

This is the **CLI finder cache invalidation slice only.** Other deferred-outside-audit items in #297 remain open: animation_handler split #13, structured `ci-check-gdscript` exit, `setup-dev.ps1` uv parity (likely already done — both scripts have uv handling now, worth a verification PR), structured dispatcher diagnostics, broader self-update preload-alias depth-2+ work. Each is a separate PR — they don't bundle naturally because they touch different layers and concerns (per #338 / #339's framing).

Closes audit deferred-item "CLI finder cache invalidation" from #297.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2ZL6fnxqNszddJPm8axpr)_