### PR TITLE
Add viewport-id fields to camera current-state diagnostic (#316 follow-up)

### DIFF
--- a/test_project/tests/test_camera.gd
+++ b/test_project/tests/test_camera.gd
@@ -158,6 +158,20 @@ func _camera_current_diag(cam: Node, expected: bool, attempts: int, elapsed_msec
 	var viewport_matches := false
 	var handler_current: Variant = "<unavailable>"
 	var handler_empty_path := "<unavailable>"
+	## Viewport identity captured so a post-reload-churn failure can prove
+	## whether `cam.get_viewport()` still points at the live edited-scene
+	## viewport or at a stale one from a previous editor lifecycle. If
+	## `cam_viewport_id` differs from `scene_root_viewport_id`, every
+	## `make_current()` lands on a viewport the engine's current-camera
+	## tracking has already moved past — see #316 comment thread for the
+	## reload-related theory this field exists to confirm.
+	var cam_viewport_id: Variant = "<unavailable>"
+	var scene_root_viewport_id: Variant = "<unavailable>"
+	var cam_viewport_matches_scene: Variant = "<unavailable>"
+	if scene_root != null:
+		var scene_viewport := scene_root.get_viewport()
+		if scene_viewport != null:
+			scene_root_viewport_id = scene_viewport.get_instance_id()
 	if cam != null and is_instance_valid(cam):
 		cam_name = String(cam.name)
 		cam_class = cam.get_class()
@@ -166,24 +180,29 @@ func _camera_current_diag(cam: Node, expected: bool, attempts: int, elapsed_msec
 			cam_path = McpScenePath.from_node(cam, scene_root)
 		if cam.has_method("is_current"):
 			node_is_current = bool(cam.is_current())
+		var cam_viewport: Viewport = null
 		if cam is Camera2D:
-			var viewport_2d := cam.get_viewport()
-			if viewport_2d != null:
-				var viewport_cam_2d := viewport_2d.get_camera_2d()
+			cam_viewport = cam.get_viewport()
+			if cam_viewport != null:
+				var viewport_cam_2d := cam_viewport.get_camera_2d()
 				viewport_matches = viewport_cam_2d == cam
 				if viewport_cam_2d != null and scene_root != null and scene_root.is_ancestor_of(viewport_cam_2d):
 					viewport_cam_path = McpScenePath.from_node(viewport_cam_2d, scene_root)
 				elif viewport_cam_2d != null:
 					viewport_cam_path = str(viewport_cam_2d)
 		elif cam is Camera3D:
-			var viewport_3d := cam.get_viewport()
-			if viewport_3d != null:
-				var viewport_cam_3d := viewport_3d.get_camera_3d()
+			cam_viewport = cam.get_viewport()
+			if cam_viewport != null:
+				var viewport_cam_3d := cam_viewport.get_camera_3d()
 				viewport_matches = viewport_cam_3d == cam
 				if viewport_cam_3d != null and scene_root != null and scene_root.is_ancestor_of(viewport_cam_3d):
 					viewport_cam_path = McpScenePath.from_node(viewport_cam_3d, scene_root)
 				elif viewport_cam_3d != null:
 					viewport_cam_path = str(viewport_cam_3d)
+		if cam_viewport != null:
+			cam_viewport_id = cam_viewport.get_instance_id()
+			if scene_root_viewport_id is int:
+				cam_viewport_matches_scene = (cam_viewport_id == scene_root_viewport_id)
 		if cam_path != "<null>":
 			var per_path := _handler.get_camera({"camera_path": cam_path})
 			if per_path.has("data"):
@@ -197,7 +216,8 @@ func _camera_current_diag(cam: Node, expected: bool, attempts: int, elapsed_msec
 	return (
 		"camera_state expected_current=%s attempts=%d elapsed_msec=%d "
 		+ "camera=%s path=%s class=%s in_tree=%s node_is_current=%s "
-		+ "viewport_camera=%s viewport_matches=%s handler_current=%s handler_empty_path=%s"
+		+ "viewport_camera=%s viewport_matches=%s handler_current=%s handler_empty_path=%s "
+		+ "cam_viewport_id=%s scene_root_viewport_id=%s cam_viewport_matches_scene=%s"
 	) % [
 		expected,
 		attempts,
@@ -211,6 +231,9 @@ func _camera_current_diag(cam: Node, expected: bool, attempts: int, elapsed_msec
 		viewport_matches,
 		handler_current,
 		handler_empty_path,
+		cam_viewport_id,
+		scene_root_viewport_id,
+		cam_viewport_matches_scene,
 	]
 
 


### PR DESCRIPTION
## Summary

Follow-up to #335. The first post-#335 informative recurrence on #316 ([reload-smoke `test_create_with_make_current_unmarks_sibling`](https://github.com/hi-godot/godot-ai/issues/316#issuecomment-4379126244)) showed `viewport_camera=<none>` while every handler-side field reported the expected state — i.e. the engine's viewport had no active camera at all, not the wrong one. The leading hypothesis from that analysis is that after reload churn `cam.get_viewport()` may still point at a viewport the engine's current-camera tracking has already retired.

This PR teaches `_camera_current_diag` to capture three more fields so the next recurrence can confirm or rule out the stale-viewport theory without a follow-up patch.

## What changes

`test_project/tests/test_camera.gd::_camera_current_diag` gains three trailing fields appended to the existing `camera_state ...` payload:

| Field | Source | What it tells us |
| --- | --- | --- |
| `cam_viewport_id` | `cam.get_viewport().get_instance_id()` | Which viewport the camera node currently references |
| `scene_root_viewport_id` | `EditorInterface.get_edited_scene_root().get_viewport().get_instance_id()` | Which viewport the live edited scene is on |
| `cam_viewport_matches_scene` | `bool` of the comparison | Whether the camera's viewport reference is fresh |

All three default to `<unavailable>` so the format string is tolerant of camera-freed / no-scene-open paths (matching the existing `<null>` / `<missing>` convention).

## How to read the next failure

- **`cam_viewport_matches_scene=false`** → camera holds a stale viewport reference from a previous editor lifecycle. `make_current()` is landing on a viewport the engine has retired; fix is to re-resolve the viewport on every wait poll instead of caching it.
- **`cam_viewport_matches_scene=true`** → `make_current()` itself isn't propagating inside the wait window. Next probe is Godot's `Viewport.set_camera_2d` source path — likely a `_make_current` frame-ordering issue specific to macOS headless after a reload barrage.

Either way, the next #316 recurrence resolves the open hypothesis without a third diagnostic round-trip.

## Scope

Pure-diagnostic change: no production code touched, no assertion logic moved, no test renamed. The format string just appends three fields. Same shape as #335.

## Verification

- `script/ci-check-gdscript` — clean
- The diff only adds string fields to a diagnostic helper, so no Python suite changes; the helper is only invoked on assertion failure.

Refs #316.

https://claude.ai/code/session_01DwmN9ouQq88KnabiW42y2C

---
_Generated by [Claude Code](https://claude.ai/code/session_01DwmN9ouQq88KnabiW42y2C)_