### PR TITLE
Harden WebSocket transport: errno portability, Future leak, duplicate-ID reject

### DIFF
--- a/src/godot_ai/transport/websocket.py
+++ b/src/godot_ai/transport/websocket.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import errno
 import json
 import logging
 from typing import Any
@@ -17,6 +18,11 @@ from godot_ai.sessions.registry import Session, SessionRegistry
 logger = logging.getLogger(__name__)
 
 DEFAULT_PORT = 9500
+
+## RFC 6455 reserves 4000-4999 for application-defined close codes; we use
+## 4001 to flag a handshake rejected for duplicate session_id so a debugging
+## peer can distinguish it from a normal close.
+_CLOSE_CODE_DUPLICATE_SESSION = 4001
 
 
 class GodotWebSocketServer:
@@ -39,7 +45,10 @@ class GodotWebSocketServer:
             ):
                 await asyncio.Future()  # run forever
         except OSError as e:
-            if e.errno == 48:  # Address already in use
+            ## EADDRINUSE differs by platform (macOS 48, Linux 98, Windows
+            ## 10048) — let the stdlib name resolve it so the friendly
+            ## branch fires everywhere.
+            if e.errno == errno.EADDRINUSE:
                 logger.warning(
                     "WebSocket port %d already in use — another server instance may be running. "
                     "MCP tools will work but the Godot plugin won't connect to this instance.",
@@ -55,6 +64,23 @@ class GodotWebSocketServer:
             raw = await asyncio.wait_for(ws.recv(), timeout=10.0)
             data = json.loads(raw)
             handshake = HandshakeMessage.model_validate(data)
+
+            ## Reject duplicate session_id while the first peer is live —
+            ## otherwise the second handshake silently overwrites the
+            ## routing map (duplicate-ID hijack).
+            existing = self.registry.get(handshake.session_id)
+            if existing is not None:
+                logger.warning(
+                    "Rejecting duplicate handshake for session %s (existing pid=%s, project=%s)",
+                    handshake.session_id,
+                    existing.editor_pid,
+                    existing.project_path,
+                )
+                await ws.close(
+                    code=_CLOSE_CODE_DUPLICATE_SESSION,
+                    reason="session id already registered",
+                )
+                return
 
             session_id = handshake.session_id
             session = Session(
@@ -153,12 +179,16 @@ class GodotWebSocketServer:
         future: asyncio.Future[CommandResponse] = asyncio.get_running_loop().create_future()
         self._pending[request.request_id] = future
 
-        await ws.send(request.model_dump_json())
-
+        ## Always pop on exit — the response receiver in _handle_connection
+        ## pops on the happy path, so this is a no-op there; on `ws.send`
+        ## raise / TimeoutError / cancellation it prevents Futures leaking
+        ## into _pending forever.
         try:
+            await ws.send(request.model_dump_json())
             return await asyncio.wait_for(future, timeout=timeout)
         except asyncio.TimeoutError:
-            self._pending.pop(request.request_id, None)
             raise TimeoutError(
                 f"Command {command} timed out after {timeout}s on session {session_id}"
             )
+        finally:
+            self._pending.pop(request.request_id, None)

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -2079,9 +2079,7 @@ class TestPhysicsShapeAutofitTool:
         assert result.data["shape_created"] is True
         assert result.data["size"]["x"] == 2.0
 
-    async def test_ambiguous_visual_candidates_preserved_in_structured_error(
-        self, mcp_stack
-    ):
+    async def test_ambiguous_visual_candidates_preserved_in_structured_error(self, mcp_stack):
         client, plugin = mcp_stack
         candidates = ["/Main/VisualA", "/Main/VisualB"]
 

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -315,6 +315,127 @@ class TestMultipleSessions:
         await plugin_b.close()
 
 
+# ---------------------------------------------------------------------------
+# Duplicate-ID handshake hardening (#343 finding #2)
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicateHandshake:
+    async def test_duplicate_session_id_handshake_is_rejected(self, harness):
+        ## Without rejection, a second handshake with the same session_id
+        ## silently overwrites both `_connections[session_id]` and the
+        ## registry entry — routing every subsequent command to the
+        ## attacker. session_id is `<slug>@<4hex>` so 16 bits of suffix is
+        ## locally guessable. Reject keeps the first peer authoritative.
+        first = await harness.connect_plugin(session_id="dup-target")
+        original_session = harness.registry.get("dup-target")
+        assert original_session is not None
+        original_pid = original_session.editor_pid
+
+        ## Hand-roll the second handshake so we observe the close on the
+        ## wire — `connect_plugin()` would assert on the missing ack.
+        ws2 = await websockets.connect(f"ws://127.0.0.1:{harness.port}")
+        await ws2.send(
+            json.dumps(
+                {
+                    "type": "handshake",
+                    "session_id": "dup-target",
+                    "godot_version": "4.4.1",
+                    "project_path": "/tmp/attacker",
+                    "plugin_version": "0.0.1",
+                    "protocol_version": 1,
+                    "readiness": "ready",
+                    "editor_pid": 9999,
+                }
+            )
+        )
+
+        ## Server should close us before sending an ack. Drain until the WS
+        ## reports closed; recv() will raise ConnectionClosed.
+        with pytest.raises(websockets.ConnectionClosed):
+            await asyncio.wait_for(ws2.recv(), timeout=2.0)
+
+        ## Original session must still be live and unaffected.
+        live = harness.registry.get("dup-target")
+        assert live is original_session, "registry entry was overwritten by duplicate"
+        assert live.editor_pid == original_pid
+        assert live.project_path != "/tmp/attacker"
+
+        ## Round-trip a command through the original to prove its WS is
+        ## still wired to the routing map (regression: silent overwrite
+        ## also hijacks `_connections[session_id]`).
+        client = GodotClient(harness.server, harness.registry)
+
+        async def mock_handler():
+            cmd = await first.recv_command()
+            await first.send_response(cmd["request_id"], {"alive": True})
+
+        handler = asyncio.create_task(mock_handler())
+        result = await client.send("ping", session_id="dup-target")
+        await handler
+        assert result == {"alive": True}
+
+        await first.close()
+
+    async def test_reconnect_after_clean_disconnect_succeeds(self, harness):
+        ## The reject must not break the legitimate plugin reconnect path
+        ## (e.g. after `editor_reload_plugin`): close → unregister →
+        ## fresh connect with the same session_id should succeed because
+        ## the registry entry has already been removed.
+        first = await harness.connect_plugin(session_id="reconnect-1")
+        await first.close()
+        await asyncio.sleep(0.1)  # let server process disconnect
+        assert harness.registry.get("reconnect-1") is None
+
+        second = await harness.connect_plugin(session_id="reconnect-1")
+        assert harness.registry.get("reconnect-1") is not None
+        await second.close()
+
+
+# ---------------------------------------------------------------------------
+# send_command pending-Future leak (#343 finding #5)
+# ---------------------------------------------------------------------------
+
+
+class TestPendingFutureCleanup:
+    async def test_timeout_pops_pending_entry(self, harness):
+        ## TimeoutError path always cleared the pending dict; this test
+        ## pins that behavior so a future refactor doesn't regress it.
+        plugin = await harness.connect_plugin(session_id="leak-timeout")
+        client = GodotClient(harness.server, harness.registry)
+
+        with pytest.raises(TimeoutError):
+            await client.send("never_responded", timeout=0.1)
+
+        assert harness.server._pending == {}, "TimeoutError should not leave entries in _pending"
+        await plugin.close()
+
+    async def test_send_failure_pops_pending_entry(self, harness):
+        ## If `ws.send` raises (e.g. ConnectionClosed mid-send), the
+        ## pending Future was previously leaked into `_pending` forever.
+        ## Force the failure by replacing the connection's send with one
+        ## that raises after the pending entry has been registered.
+        plugin = await harness.connect_plugin(session_id="leak-send")
+
+        ws = harness.server._connections["leak-send"]
+        boom = ConnectionError("simulated mid-send transport error")
+
+        async def raising_send(_payload: str) -> None:
+            raise boom
+
+        ws.send = raising_send  # type: ignore[assignment]
+
+        with pytest.raises(ConnectionError):
+            await harness.server.send_command(
+                session_id="leak-send",
+                command="will_fail",
+                timeout=1.0,
+            )
+
+        assert harness.server._pending == {}, "send-time exception must not leak _pending entries"
+        await plugin.close()
+
+
 # --- Issue #262: editor_state self-heals a stale "playing" cache ---
 
 

--- a/tests/unit/test_gdscript_no_adjacent_string_concat.py
+++ b/tests/unit/test_gdscript_no_adjacent_string_concat.py
@@ -151,11 +151,7 @@ def test_no_python_style_adjacent_string_concat_in_gdscript() -> None:
 
 def test_detector_flags_canonical_multiline_bug_pattern() -> None:
     """The exact shape from PR #236 must be detected."""
-    src = (
-        "assert_false(cond,\n"
-        '    "first half - "\n'
-        '    "second half")\n'
-    )
+    src = 'assert_false(cond,\n    "first half - "\n    "second half")\n'
     hits = _find_adjacent_string_pairs(src)
     assert len(hits) == 1, f"expected 1 hit, got {hits}"
     (prev_line, _), (cur_line, _) = hits[0]

--- a/tests/unit/test_websocket_server_lifecycle.py
+++ b/tests/unit/test_websocket_server_lifecycle.py
@@ -1,0 +1,72 @@
+"""Unit tests for GodotWebSocketServer lifecycle / boot path.
+
+Covers cross-platform errno handling in `start()` (#343 finding #4) so the
+"port in use" branch fires on Linux/Windows/macOS instead of crashing the
+WS lifespan with a generic OSError traceback.
+"""
+
+from __future__ import annotations
+
+import errno
+from unittest.mock import patch
+
+import pytest
+
+from godot_ai.sessions.registry import SessionRegistry
+from godot_ai.transport.websocket import GodotWebSocketServer
+
+
+@pytest.mark.parametrize(
+    "platform_errno",
+    [
+        pytest.param(48, id="macos_eaddrinuse_48"),
+        pytest.param(98, id="linux_eaddrinuse_98"),
+        pytest.param(10048, id="windows_wsaeaddrinuse_10048"),
+    ],
+)
+async def test_start_swallows_port_in_use_on_each_platform(caplog, platform_errno):
+    ## Pre-fix the start() check was `e.errno == 48` — only macOS matched,
+    ## so on Linux/Windows the OSError propagated and took the WS lifespan
+    ## down with a generic traceback. With `errno.EADDRINUSE` the friendly
+    ## branch fires regardless of platform — simulate by raising an OSError
+    ## carrying each platform's number; on whatever platform the test runs
+    ## the stdlib's `errno.EADDRINUSE` matches one of these and the others
+    ## should propagate. We assert the *current platform's* number is
+    ## handled gracefully.
+    if platform_errno != errno.EADDRINUSE:
+        pytest.skip(
+            f"errno {platform_errno} is not EADDRINUSE on this platform "
+            f"(EADDRINUSE={errno.EADDRINUSE}); cross-platform parity is "
+            f"covered by the other parametrizations on their native OS."
+        )
+
+    server = GodotWebSocketServer(SessionRegistry(), port=12345)
+
+    def raise_addr_in_use(*_args, **_kwargs):
+        raise OSError(platform_errno, "Address already in use")
+
+    with patch("godot_ai.transport.websocket.websockets.serve", raise_addr_in_use):
+        with caplog.at_level("WARNING", logger="godot_ai.transport.websocket"):
+            await server.start()
+
+    assert any(
+        "already in use" in rec.message and "12345" in rec.message for rec in caplog.records
+    ), "expected friendly 'port already in use' warning, got: " + repr(
+        [rec.message for rec in caplog.records]
+    )
+
+
+async def test_start_propagates_non_eaddrinuse_oserror():
+    ## Any OSError that isn't EADDRINUSE must keep raising — the friendly
+    ## branch is narrow on purpose so unrelated bind failures (permission,
+    ## bad address, …) still surface their real diagnosis.
+    server = GodotWebSocketServer(SessionRegistry(), port=12345)
+
+    def raise_perm(*_args, **_kwargs):
+        raise OSError(errno.EACCES, "Permission denied")
+
+    with patch("godot_ai.transport.websocket.websockets.serve", raise_perm):
+        with pytest.raises(OSError) as exc_info:
+            await server.start()
+
+    assert exc_info.value.errno == errno.EACCES


### PR DESCRIPTION
## Summary

Bundles three small, surgical hardening fixes from the audit-v2 umbrella (#343), all in `src/godot_ai/transport/websocket.py`. Each fix is independently scoped and pinned by a regression test; bundled because they're tightly themed (transport-layer hardening) and trivially reviewable side-by-side.

Closes findings **#2**, **#4**, and **#5** of #343.

## Fixes

### #4 (P1) — `errno.EADDRINUSE` portability

`src/godot_ai/transport/websocket.py:46` previously checked `e.errno == 48`. That number is macOS-only; Linux uses 98 and Windows 10048, so on those platforms the friendly "port already in use" branch never fired and the OSError propagated, taking the WS server lifespan down with a generic traceback. Replaced with `errno.EADDRINUSE`.

### #5 (P2) — `send_command` pending-Future leak

`send_command` registered `self._pending[request.request_id] = future` then awaited `ws.send(...)`. If `ws.send` raised (`ConnectionClosed` mid-send, transport error, cancellation), the pending entry was never popped and the dict grew unbounded under churn. Wrapped the send + wait in `try/finally: self._pending.pop(...)`; the response receiver still pops on the happy path so the finally is a no-op there.

### #2 (P1) — Duplicate-ID handshake hijack

`_handle_connection` registered the inbound peer with `session_id = handshake.session_id`, silently overwriting both the registry entry and `_connections[session_id]` when the same ID was already present. session_id format is `<slug>@<4hex>` — 16 bits of suffix is locally guessable, so any local peer could hijack an active session by sending a handshake with the same ID; subsequent MCP commands would route to the impostor.

Now `_handle_connection` checks `registry.get(handshake.session_id)` and rejects with WebSocket close code `4001` (RFC 6455 application-defined range) plus a structured warning log naming the existing peer's PID and project. Legitimate plugin reconnect after `editor_reload_plugin` first triggers `ConnectionClosed` → `unregister`, so the new connect still lands cleanly — pinned by `test_reconnect_after_clean_disconnect_succeeds`.

## Tests

New:
- `tests/unit/test_websocket_server_lifecycle.py` — parametrized errno coverage (macos 48, linux 98, windows 10048; one runs per CI host) plus a non-EADDRINUSE OSError propagation case.
- `tests/integration/test_websocket.py::TestDuplicateHandshake` — pins both the reject path and the legitimate-reconnect path.
- `tests/integration/test_websocket.py::TestPendingFutureCleanup` — pins both the timeout-pop and the send-raise pop behaviors (the latter monkey-patches `ws.send` to force a synthetic `ConnectionError` after the pending entry is registered).

Existing: 728 passed, 2 skipped (cross-platform errno parametrizations on the non-host OS).

## Live smoke

Spawned a real Godot 4.6.2 editor against `test_project/`, opened `main.tscn`, ran via the streamable-HTTP MCP transport:

- `editor_state` → `readiness=ready` ✓
- `test_run` → **1037/1040 passed, 0 failed** ✓
- Duplicate-ID handshake against the live session's own ID → server closed the WS with code **4001** and reason `'session id already registered'` ✓
- `editor_state` after the rejected hijack → still `readiness=ready` (original session unaffected) ✓
- Server log: `Rejecting duplicate handshake for session test-project@307e (existing pid=21071, project=/home/user/godot-ai/test_project/)` ✓

## What's NOT closed

- #1 (auth/Origin gap on the WS upgrade) — separate scope, deserves its own design discussion. This PR closes only the *takeover-of-existing-session* path; an unauthenticated local peer can still register a *new* session_id.
- #3 (path traversal in `script_create` / `filesystem_write_text`) — touches GDScript handlers; deserves its own PR with a regression test against `res://../etc/passwd.gd`.
- #7 (Pydantic-validate WS events) — bigger; needs new envelope models.
- #6 (drop SessionRegistry RLock) — already not in the code; no change needed.

## Test plan

- [x] `ruff check src/ tests/` clean
- [x] `ruff format --check src/ tests/` clean
- [x] `pytest -q` — 728 passed
- [x] Live MCP `test_run` against Godot 4.6.2 editor — 1037/1040 passed, 0 failed
- [x] Live duplicate-ID handshake reject smoke — 4001 close received, original session unaffected
- [x] Logged server-side warning includes existing-peer pid + project_path

https://claude.ai/code/session_016ijmCD5S6QfwJGJcc5Wirp

---
_Generated by [Claude Code](https://claude.ai/code/session_016ijmCD5S6QfwJGJcc5Wirp)_