### PR TITLE
Forward animation_handler split onto beta (#344 → beta)

### DIFF
--- a/plugin/addons/godot_ai/handlers/animation_handler.gd
+++ b/plugin/addons/godot_ai/handlers/animation_handler.gd
@@ -7,8 +7,21 @@ extends RefCounted
 ## Animations live inside an AnimationLibrary attached to an AnimationPlayer
 ## node in the scene. They save with the .tscn — no separate resource file
 ## needed. Undo callables hold direct Animation references (not paths).
+##
+## Split (issue #342, audit finding #13):
+##   - animation_presets.gd  → preset_fade / slide / shake / pulse + helpers
+##   - animation_values.gd   → animation_list / get / validate + shared
+##                             value coercion / serialization
+## Both submodules hold a WeakRef back to this handler. The handler's
+## preset_* / list / get / validate methods are thin proxies so existing
+## dispatcher registrations and test fixtures don't change.
+
+const AnimationPresets := preload("res://addons/godot_ai/handlers/animation_presets.gd")
+const AnimationValues := preload("res://addons/godot_ai/handlers/animation_values.gd")
 
 var _undo_redo: EditorUndoRedoManager
+var _presets
+var _values
 
 const _LOOP_MODES := {
 	"none": Animation.LOOP_NONE,
@@ -22,16 +35,11 @@ const _INTERP_MODES := {
 	"cubic": Animation.INTERPOLATION_CUBIC,
 }
 
-const _NAMED_TRANSITIONS := {
-	"linear": 1.0,
-	"ease_in": 2.0,
-	"ease_out": 0.5,
-	"ease_in_out": -2.0,
-}
-
 
 func _init(undo_redo: EditorUndoRedoManager) -> void:
 	_undo_redo = undo_redo
+	_presets = AnimationPresets.new(self)
+	_values = AnimationValues.new(self)
 
 
 # ============================================================================
@@ -231,7 +239,7 @@ func add_property_track(params: Dictionary) -> Dictionary:
 	# surface as INVALID_PARAMS rather than silently inserting garbage keys.
 	# Resolve the target property's type ONCE — dense clips used to re-walk
 	# get_property_list() per keyframe.
-	var ctx := _resolve_track_prop_context(track_path, player)
+	var ctx := AnimationValues.resolve_track_prop_context(track_path, player)
 	if ctx.has("error"):
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ctx.error)
 	var coerced_keyframes: Array = []
@@ -242,7 +250,7 @@ func add_property_track(params: Dictionary) -> Dictionary:
 			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Each keyframe must have a 'time' field")
 		if not "value" in kf:
 			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Each keyframe must have a 'value' field")
-		var coerce_result := _coerce_with_context(kf.get("value"), ctx)
+		var coerce_result := AnimationValues.coerce_with_context(kf.get("value"), ctx)
 		if coerce_result.has("error"):
 			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, coerce_result.error)
 		coerced_keyframes.append({
@@ -273,8 +281,8 @@ func add_property_track(params: Dictionary) -> Dictionary:
 
 ## Insert a pre-coerced track into the animation. Callers must coerce
 ## values against the target property before calling this (see
-## _coerce_value_for_track) — this method runs inside the undo do-method
-## path where error propagation isn't possible.
+## AnimationValues.coerce_value_for_track) — this method runs inside the
+## undo do-method path where error propagation isn't possible.
 func _do_add_property_track(
 	anim: Animation,
 	track_path: String,
@@ -286,7 +294,7 @@ func _do_add_property_track(
 	anim.track_set_interpolation_type(idx, _INTERP_MODES.get(interp_str, Animation.INTERPOLATION_LINEAR))
 	for kf in keyframes:
 		var t: float = float(kf.get("time", 0.0))
-		var trans: float = _parse_transition(kf.get("transition", "linear"))
+		var trans: float = AnimationValues.parse_transition(kf.get("transition", "linear"))
 		anim.track_insert_key(idx, t, kf.get("value"), trans)
 
 
@@ -472,165 +480,6 @@ func stop(params: Dictionary) -> Dictionary:
 
 
 # ============================================================================
-# animation_list  (read)
-# ============================================================================
-
-func list_animations(params: Dictionary) -> Dictionary:
-	var player_path: String = params.get("player_path", "")
-
-	if player_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: player_path")
-
-	var resolved := _resolve_player_read(player_path)
-	if resolved.has("error"):
-		return resolved
-	var player: AnimationPlayer = resolved.player
-
-	var animations: Array[Dictionary] = []
-	for lib_name in player.get_animation_library_list():
-		var lib: AnimationLibrary = player.get_animation_library(lib_name)
-		for anim_name in lib.get_animation_list():
-			var anim: Animation = lib.get_animation(anim_name)
-			var display_name: String = anim_name if lib_name == "" else "%s/%s" % [lib_name, anim_name]
-			animations.append({
-				"name": display_name,
-				"length": anim.length,
-				"loop_mode": _loop_mode_to_string(anim.loop_mode),
-				"track_count": anim.get_track_count(),
-			})
-
-	return {
-		"data": {
-			"player_path": player_path,
-			"animations": animations,
-			"count": animations.size(),
-		}
-	}
-
-
-# ============================================================================
-# animation_get  (read)
-# ============================================================================
-
-func get_animation(params: Dictionary) -> Dictionary:
-	var player_path: String = params.get("player_path", "")
-	var anim_name: String = params.get("animation_name", "")
-
-	if player_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: player_path")
-	if anim_name.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: animation_name")
-
-	var resolved := _resolve_player_read(player_path)
-	if resolved.has("error"):
-		return resolved
-	var player: AnimationPlayer = resolved.player
-
-	var anim_resolved := _resolve_animation(player, anim_name)
-	if anim_resolved.has("error"):
-		return anim_resolved
-	var anim: Animation = anim_resolved.animation
-
-	var tracks: Array[Dictionary] = []
-	for i in anim.get_track_count():
-		var track_type := anim.track_get_type(i)
-		var type_name := _track_type_to_string(track_type)
-		var keys: Array[Dictionary] = []
-		for k in anim.track_get_key_count(i):
-			var key_val = anim.track_get_key_value(i, k)
-			keys.append({
-				"time": anim.track_get_key_time(i, k),
-				"value": _serialize_value(key_val),
-				"transition": anim.track_get_key_transition(i, k),
-			})
-		tracks.append({
-			"index": i,
-			"type": type_name,
-			"path": str(anim.track_get_path(i)),
-			"interpolation": _interp_to_string(anim.track_get_interpolation_type(i)),
-			"key_count": keys.size(),
-			"keys": keys,
-		})
-
-	return {
-		"data": {
-			"player_path": player_path,
-			"name": anim_name,
-			"length": anim.length,
-			"loop_mode": _loop_mode_to_string(anim.loop_mode),
-			"track_count": anim.get_track_count(),
-			"tracks": tracks,
-		}
-	}
-
-
-# ============================================================================
-# animation_validate  (read-only)
-# ============================================================================
-
-func validate_animation(params: Dictionary) -> Dictionary:
-	var player_path: String = params.get("player_path", "")
-	var anim_name: String = params.get("animation_name", "")
-
-	if player_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: player_path")
-	if anim_name.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: animation_name")
-
-	var resolved := _resolve_player_read(player_path)
-	if resolved.has("error"):
-		return resolved
-	var player: AnimationPlayer = resolved.player
-
-	if not player.has_animation(anim_name):
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
-			"Animation '%s' not found on player at %s" % [anim_name, player_path])
-
-	var anim: Animation = player.get_animation(anim_name)
-
-	var root_node := _player_root_node(player)
-
-	var broken_tracks: Array[Dictionary] = []
-	var valid_count := 0
-
-	for i in anim.get_track_count():
-		var track_path_str := str(anim.track_get_path(i))
-		var colon := track_path_str.rfind(":")
-		var node_part: String
-		if colon >= 0:
-			node_part = track_path_str.substr(0, colon)
-		else:
-			node_part = track_path_str
-
-		var target_node: Node = null
-		if root_node != null:
-			target_node = root_node.get_node_or_null(node_part)
-
-		if target_node == null:
-			broken_tracks.append({
-				"index": i,
-				"path": track_path_str,
-				"type": _track_type_to_string(anim.track_get_type(i)),
-				"issue": "node_not_found",
-				"node_path": node_part,
-			})
-		else:
-			valid_count += 1
-
-	return {
-		"data": {
-			"player_path": player_path,
-			"animation_name": anim_name,
-			"track_count": anim.get_track_count(),
-			"valid_count": valid_count,
-			"broken_count": broken_tracks.size(),
-			"broken_tracks": broken_tracks,
-			"valid": broken_tracks.is_empty(),
-		}
-	}
-
-
-# ============================================================================
 # animation_create_simple  (composer)
 # ============================================================================
 
@@ -721,12 +570,12 @@ func create_simple(params: Dictionary) -> Dictionary:
 		var duration: float = float(spec.get("duration", 1.0))
 		var delay: float = float(spec.get("delay", 0.0))
 		var trans_str = spec.get("transition", "linear")
-		var from_result := _coerce_value_for_track(spec.get("from"), track_path, player, coerce_root)
+		var from_result := AnimationValues.coerce_value_for_track(spec.get("from"), track_path, player, coerce_root)
 		if from_result.has("error"):
 			if created_player:
 				player.queue_free()
 			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "tween '%s': %s" % [track_path, from_result.error])
-		var to_result := _coerce_value_for_track(spec.get("to"), track_path, player, coerce_root)
+		var to_result := AnimationValues.coerce_value_for_track(spec.get("to"), track_path, player, coerce_root)
 		if to_result.has("error"):
 			if created_player:
 				player.queue_free()
@@ -769,502 +618,37 @@ func create_simple(params: Dictionary) -> Dictionary:
 
 
 # ============================================================================
-# animation_preset_fade
+# Proxies — preset_* and read methods live in the submodules. Kept here so
+# the dispatcher registrations and `_handler.method(...)` test fixtures stay
+# unchanged across the split.
 # ============================================================================
 
 func preset_fade(params: Dictionary) -> Dictionary:
-	var player_path: String = params.get("player_path", "")
-	var target_path: String = params.get("target_path", "")
-	var mode: String = params.get("mode", "in")
-	var duration: float = float(params.get("duration", 0.5))
-	var anim_name: String = params.get("animation_name", "")
-	var overwrite: bool = params.get("overwrite", false)
+	return _presets.preset_fade(params)
 
-	if player_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: player_path")
-	if target_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: target_path")
-	if mode != "in" and mode != "out":
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
-			"Invalid mode '%s'. Valid: 'in', 'out'" % mode)
-	if duration <= 0.0:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "'duration' must be > 0")
-
-	var resolved := _resolve_player(player_path)
-	if resolved.has("error"):
-		return resolved
-	var player: AnimationPlayer = resolved.player
-	var library: AnimationLibrary = resolved.library
-	var created_library := false
-	if library == null:
-		library = AnimationLibrary.new()
-		created_library = true
-
-	var target_resolved := _resolve_preset_target(player, target_path)
-	if target_resolved.has("error"):
-		return target_resolved
-	var target: Node = target_resolved.node
-	var track_target: String = target_resolved.track_path_root
-
-	# Fade requires a `modulate` property (CanvasItem/Control/Node2D/Sprite3D/etc).
-	var has_modulate := false
-	for p in target.get_property_list():
-		if p.name == "modulate":
-			has_modulate = true
-			break
-	if not has_modulate:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
-			"Target '%s' (class %s) has no 'modulate' property — fade requires a CanvasItem, Control, Node2D, or Sprite3D"
-			% [target_path, target.get_class()])
-
-	if anim_name.is_empty():
-		anim_name = "fade_%s" % mode
-
-	var old_anim: Animation = null
-	if library.has_animation(anim_name):
-		if not overwrite:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
-				"Animation '%s' already exists. Pass overwrite=true or delete it first." % anim_name)
-		old_anim = library.get_animation(anim_name)
-
-	var start_a: float = 0.0 if mode == "in" else 1.0
-	var end_a: float = 1.0 if mode == "in" else 0.0
-
-	var anim := Animation.new()
-	anim.length = duration
-	anim.loop_mode = Animation.LOOP_NONE
-
-	var track_path := "%s:modulate:a" % track_target
-	_do_add_property_track(anim, track_path, "linear", [
-		{"time": 0.0, "value": start_a, "transition": "linear"},
-		{"time": duration, "value": end_a, "transition": "linear"},
-	])
-
-	_commit_animation_add(
-		"MCP: Create animation %s" % anim_name,
-		player, library, created_library, anim_name, anim, old_anim,
-	)
-
-	return {
-		"data": {
-			"player_path": player_path,
-			"animation_name": anim_name,
-			"mode": mode,
-			"length": duration,
-			"track_count": anim.get_track_count(),
-			"library_created": created_library,
-			"overwritten": old_anim != null,
-			"undoable": true,
-		}
-	}
-
-
-# ============================================================================
-# animation_preset_slide
-# ============================================================================
 
 func preset_slide(params: Dictionary) -> Dictionary:
-	var player_path: String = params.get("player_path", "")
-	var target_path: String = params.get("target_path", "")
-	var direction: String = params.get("direction", "left")
-	var mode: String = params.get("mode", "in")
-	var duration: float = float(params.get("duration", 0.4))
-	var anim_name: String = params.get("animation_name", "")
-	var overwrite: bool = params.get("overwrite", false)
+	return _presets.preset_slide(params)
 
-	if player_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: player_path")
-	if target_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: target_path")
-	if not ["left", "right", "up", "down"].has(direction):
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
-			"Invalid direction '%s'. Valid: 'left', 'right', 'up', 'down'" % direction)
-	if mode != "in" and mode != "out":
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
-			"Invalid mode '%s'. Valid: 'in', 'out'" % mode)
-	if duration <= 0.0:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "'duration' must be > 0")
-
-	var resolved := _resolve_player(player_path)
-	if resolved.has("error"):
-		return resolved
-	var player: AnimationPlayer = resolved.player
-	var library: AnimationLibrary = resolved.library
-	var created_library := false
-	if library == null:
-		library = AnimationLibrary.new()
-		created_library = true
-
-	var target_resolved := _resolve_preset_target(player, target_path)
-	if target_resolved.has("error"):
-		return target_resolved
-	var target = target_resolved.node
-	var kind: String = target_resolved.kind
-	var track_target: String = target_resolved.track_path_root
-
-	# Default distance picks 3D units vs screen pixels based on target kind.
-	var default_distance: float = 1.0 if kind == "3d" else 100.0
-	var distance: float = float(params.get("distance", default_distance))
-	if distance == 0.0:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "'distance' must be non-zero")
-
-	var offset: Variant = _direction_offset(kind, direction, distance)
-	var current_pos: Variant = target.position
-	var start_pos: Variant
-	var end_pos: Variant
-	if mode == "in":
-		start_pos = current_pos + offset
-		end_pos = current_pos
-	else:
-		start_pos = current_pos
-		end_pos = current_pos + offset
-
-	if anim_name.is_empty():
-		anim_name = "slide_%s_%s" % [mode, direction]
-
-	var old_anim: Animation = null
-	if library.has_animation(anim_name):
-		if not overwrite:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
-				"Animation '%s' already exists. Pass overwrite=true or delete it first." % anim_name)
-		old_anim = library.get_animation(anim_name)
-
-	var anim := Animation.new()
-	anim.length = duration
-	anim.loop_mode = Animation.LOOP_NONE
-
-	var track_path := "%s:position" % track_target
-	_do_add_property_track(anim, track_path, "linear", [
-		{"time": 0.0, "value": start_pos, "transition": "linear"},
-		{"time": duration, "value": end_pos, "transition": "linear"},
-	])
-
-	_commit_animation_add(
-		"MCP: Create animation %s" % anim_name,
-		player, library, created_library, anim_name, anim, old_anim,
-	)
-
-	return {
-		"data": {
-			"player_path": player_path,
-			"animation_name": anim_name,
-			"direction": direction,
-			"mode": mode,
-			"distance": distance,
-			"length": duration,
-			"track_count": anim.get_track_count(),
-			"library_created": created_library,
-			"overwritten": old_anim != null,
-			"undoable": true,
-		}
-	}
-
-
-# ============================================================================
-# animation_preset_shake
-# ============================================================================
 
 func preset_shake(params: Dictionary) -> Dictionary:
-	var player_path: String = params.get("player_path", "")
-	var target_path: String = params.get("target_path", "")
-	var duration: float = float(params.get("duration", 0.3))
-	var frequency: float = float(params.get("frequency", 30.0))
-	var rng_seed: int = int(params.get("seed", 0))
-	var anim_name: String = params.get("animation_name", "")
-	var overwrite: bool = params.get("overwrite", false)
+	return _presets.preset_shake(params)
 
-	if player_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: player_path")
-	if target_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: target_path")
-	if duration <= 0.0:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "'duration' must be > 0")
-	if frequency <= 0.0:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "'frequency' must be > 0")
-
-	var resolved := _resolve_player(player_path)
-	if resolved.has("error"):
-		return resolved
-	var player: AnimationPlayer = resolved.player
-	var library: AnimationLibrary = resolved.library
-	var created_library := false
-	if library == null:
-		library = AnimationLibrary.new()
-		created_library = true
-
-	var target_resolved := _resolve_preset_target(player, target_path)
-	if target_resolved.has("error"):
-		return target_resolved
-	var target = target_resolved.node
-	var kind: String = target_resolved.kind
-	var track_target: String = target_resolved.track_path_root
-
-	var default_intensity: float = 0.1 if kind == "3d" else 10.0
-	var intensity: float = float(params.get("intensity", default_intensity))
-	if intensity <= 0.0:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "'intensity' must be > 0")
-
-	if anim_name.is_empty():
-		anim_name = "shake"
-
-	var old_anim: Animation = null
-	if library.has_animation(anim_name):
-		if not overwrite:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
-				"Animation '%s' already exists. Pass overwrite=true or delete it first." % anim_name)
-		old_anim = library.get_animation(anim_name)
-
-	var rng := RandomNumberGenerator.new()
-	if rng_seed != 0:
-		rng.seed = rng_seed
-	else:
-		rng.randomize()
-
-	# Samples between t=0 and t=duration (exclusive); bookended by at-rest keys.
-	var sample_count: int = int(ceil(frequency * duration))
-	if sample_count < 2:
-		sample_count = 2
-
-	var current_pos: Variant = target.position
-	var kfs: Array = []
-	kfs.append({"time": 0.0, "value": current_pos, "transition": "linear"})
-	for i in range(1, sample_count):
-		var t: float = (float(i) / float(sample_count)) * duration
-		var jx: float = rng.randf_range(-intensity, intensity)
-		var jy: float = rng.randf_range(-intensity, intensity)
-		var jittered: Variant
-		if kind == "3d":
-			var jz: float = rng.randf_range(-intensity, intensity)
-			jittered = current_pos + Vector3(jx, jy, jz)
-		else:
-			jittered = current_pos + Vector2(jx, jy)
-		kfs.append({"time": t, "value": jittered, "transition": "linear"})
-	kfs.append({"time": duration, "value": current_pos, "transition": "linear"})
-
-	var anim := Animation.new()
-	anim.length = duration
-	anim.loop_mode = Animation.LOOP_NONE
-
-	var track_path := "%s:position" % track_target
-	_do_add_property_track(anim, track_path, "linear", kfs)
-
-	_commit_animation_add(
-		"MCP: Create animation %s" % anim_name,
-		player, library, created_library, anim_name, anim, old_anim,
-	)
-
-	return {
-		"data": {
-			"player_path": player_path,
-			"animation_name": anim_name,
-			"length": duration,
-			"frequency": frequency,
-			"intensity": intensity,
-			"keyframe_count": kfs.size(),
-			"track_count": anim.get_track_count(),
-			"library_created": created_library,
-			"overwritten": old_anim != null,
-			"undoable": true,
-		}
-	}
-
-
-# ============================================================================
-# animation_preset_pulse
-# ============================================================================
 
 func preset_pulse(params: Dictionary) -> Dictionary:
-	var player_path: String = params.get("player_path", "")
-	var target_path: String = params.get("target_path", "")
-	var from_scale: float = float(params.get("from_scale", 1.0))
-	var to_scale: float = float(params.get("to_scale", 1.1))
-	var duration: float = float(params.get("duration", 0.4))
-	var anim_name: String = params.get("animation_name", "")
-	var overwrite: bool = params.get("overwrite", false)
-
-	if player_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: player_path")
-	if target_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: target_path")
-	if duration <= 0.0:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "'duration' must be > 0")
-	if from_scale <= 0.0:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "'from_scale' must be > 0")
-	if to_scale <= 0.0:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "'to_scale' must be > 0")
-
-	var resolved := _resolve_player(player_path)
-	if resolved.has("error"):
-		return resolved
-	var player: AnimationPlayer = resolved.player
-	var library: AnimationLibrary = resolved.library
-	var created_library := false
-	if library == null:
-		library = AnimationLibrary.new()
-		created_library = true
-
-	var target_resolved := _resolve_preset_target(player, target_path)
-	if target_resolved.has("error"):
-		return target_resolved
-	var kind: String = target_resolved.kind
-	var track_target: String = target_resolved.track_path_root
-
-	if anim_name.is_empty():
-		anim_name = "pulse"
-
-	var old_anim: Animation = null
-	if library.has_animation(anim_name):
-		if not overwrite:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
-				"Animation '%s' already exists. Pass overwrite=true or delete it first." % anim_name)
-		old_anim = library.get_animation(anim_name)
-
-	var from_vec: Variant
-	var to_vec: Variant
-	if kind == "3d":
-		from_vec = Vector3(from_scale, from_scale, from_scale)
-		to_vec = Vector3(to_scale, to_scale, to_scale)
-	else:
-		from_vec = Vector2(from_scale, from_scale)
-		to_vec = Vector2(to_scale, to_scale)
-
-	var anim := Animation.new()
-	anim.length = duration
-	anim.loop_mode = Animation.LOOP_NONE
-
-	var track_path := "%s:scale" % track_target
-	_do_add_property_track(anim, track_path, "linear", [
-		{"time": 0.0, "value": from_vec, "transition": "linear"},
-		{"time": duration * 0.5, "value": to_vec, "transition": "linear"},
-		{"time": duration, "value": from_vec, "transition": "linear"},
-	])
-
-	_commit_animation_add(
-		"MCP: Create animation %s" % anim_name,
-		player, library, created_library, anim_name, anim, old_anim,
-	)
-
-	return {
-		"data": {
-			"player_path": player_path,
-			"animation_name": anim_name,
-			"from_scale": from_scale,
-			"to_scale": to_scale,
-			"length": duration,
-			"track_count": anim.get_track_count(),
-			"library_created": created_library,
-			"overwritten": old_anim != null,
-			"undoable": true,
-		}
-	}
+	return _presets.preset_pulse(params)
 
 
-# ============================================================================
-# Helpers — preset resolution
-# ============================================================================
-
-## Resolve the AnimationPlayer's effective `root_node` — the node animation
-## tracks resolve their paths against at playback. Honors a non-default
-## `root_node` NodePath, then falls back to `player.get_parent()` (Godot's
-## documented default behavior for `root_node = ".."`). Returns null if the
-## player isn't in the tree and has no resolvable parent.
-static func _player_root_node(player: AnimationPlayer) -> Node:
-	if not player.is_inside_tree():
-		return null
-	var rn := player.root_node
-	if rn != NodePath():
-		var resolved := player.get_node_or_null(rn)
-		if resolved != null:
-			return resolved
-	return player.get_parent()
+func list_animations(params: Dictionary) -> Dictionary:
+	return _values.list_animations(params)
 
 
-## Resolve a preset target node and classify its transform kind.
-##
-## Accepts two `target_path` shapes:
-##   * Scene-absolute (starts with "/") — resolved through `McpScenePath.resolve`,
-##     matching the convention used by every other scene-mutating tool. Targets
-##     outside the player's `root_node` subtree are converted to `..`-prefixed
-##     paths via `root_node.get_path_to(target)`, mirroring what the relative
-##     form accepts and how Godot stores track paths.
-##   * Relative — used as-is against the player's `root_node`, matching how
-##     animation tracks themselves are stored.
-##
-## Returns `{node, kind, track_path_root}` where `track_path_root` is the path
-## (relative to `root_node`) that callers should embed in the track path. For
-## scene-absolute inputs this is the converted relative path; for relative
-## inputs it equals the input. `kind` ∈ {"control", "2d", "3d"}.
-##
-## Mirrors the same root-node fallback that `_resolve_track_prop_context` uses
-## so tool inputs match how the track path will resolve at playback.
-func _resolve_preset_target(player: AnimationPlayer, target_path: String) -> Dictionary:
-	var root_node := _player_root_node(player)
-	if root_node == null:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
-			"AnimationPlayer at %s has no resolvable root_node (is the scene open?)" % str(player.get_path()))
-
-	var target: Node = null
-	var track_path_root: String = target_path
-	if target_path.begins_with("/"):
-		var scene_root := EditorInterface.get_edited_scene_root()
-		if scene_root == null:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
-				"Cannot resolve scene-absolute target_path '%s': no scene open" % target_path)
-		target = McpScenePath.resolve(target_path, scene_root)
-		if target == null:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
-				McpScenePath.format_node_error(target_path, scene_root))
-		# Convert to a root_node-relative path. For targets outside the
-		# subtree this yields a `..`-prefixed path, matching what the
-		# relative form already accepts (root_node.get_node_or_null
-		# resolves `..` segments) and what Godot's animation engine
-		# stores natively.
-		track_path_root = str(root_node.get_path_to(target))
-	else:
-		target = root_node.get_node_or_null(target_path)
-		if target == null:
-			# root_node.get_path() leaks the editor's SubViewport-wrapped
-			# path; use the clean scene-relative form so the hint is
-			# actionable.
-			var scene_root := EditorInterface.get_edited_scene_root()
-			var root_hint := McpScenePath.from_node(root_node, scene_root) if scene_root != null else str(root_node.name)
-			var abs_example := "/%s/path/to/target" % scene_root.name if scene_root != null else "/SceneRoot/path/to/target"
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
-				("Target node not found at '%s' (resolved relative to AnimationPlayer's root_node '%s'). "
-				+ "Pass a path relative to root_node (e.g. \"path/to/target\") or a scene-absolute path (e.g. \"%s\").")
-				% [target_path, root_hint, abs_example])
-
-	var kind: String
-	if target is Control:
-		kind = "control"
-	elif target is Node2D:
-		kind = "2d"
-	elif target is Node3D:
-		kind = "3d"
-	else:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
-			"Target '%s' must be a Control, Node2D, or Node3D (got %s)" % [target_path, target.get_class()])
-	return {"node": target, "kind": kind, "track_path_root": track_path_root}
+func get_animation(params: Dictionary) -> Dictionary:
+	return _values.get_animation(params)
 
 
-## Build a directional offset for slide presets.
-## Axis conventions:
-##   Control + Node2D (screen-space, y-down): left/right = ∓x, up = -y, down = +y
-##   Node3D (world-up): left/right = ∓x, up = +y, down = -y
-static func _direction_offset(kind: String, direction: String, distance: float) -> Variant:
-	if kind == "3d":
-		match direction:
-			"left": return Vector3(-distance, 0.0, 0.0)
-			"right": return Vector3(distance, 0.0, 0.0)
-			"up": return Vector3(0.0, distance, 0.0)
-			"down": return Vector3(0.0, -distance, 0.0)
-	else:
-		match direction:
-			"left": return Vector2(-distance, 0.0)
-			"right": return Vector2(distance, 0.0)
-			"up": return Vector2(0.0, -distance)
-			"down": return Vector2(0.0, distance)
-	return null
+func validate_animation(params: Dictionary) -> Dictionary:
+	return _values.validate_animation(params)
 
 
 # ============================================================================
@@ -1483,235 +867,3 @@ func _resolve_animation(player: AnimationPlayer, anim_name: String) -> Dictionar
 			return {"animation": lib2.get_animation(anim_name), "library": lib2, "library_key": lib_name}
 	# Fallback — shouldn't happen if has_animation returned true.
 	return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Animation found by player but not in any library")
-
-
-# ============================================================================
-# Helpers — value coercion
-# ============================================================================
-
-## Coerce a JSON value to match the expected Godot type for the given
-## track_path. Returns {"ok": value} or {"error": msg}.
-## Passes the raw value through when the target node isn't in the scene
-## yet (authoring-time path). Errors when the target exists but the
-## property doesn't, or when parsing a typed value (Color/Vector2/Vector3)
-## clearly fails — better to reject than silently store garbage.
-## `override_root_node` lets callers supply the root to resolve target paths
-## against when the player isn't in the tree yet (auto-create flow) — the
-## player's future parent stands in for the root the AnimationPlayer will
-## eventually use.
-static func _coerce_value_for_track(value: Variant, track_path: String, player: AnimationPlayer, override_root_node: Node = null) -> Dictionary:
-	var ctx := _resolve_track_prop_context(track_path, player, override_root_node)
-	if ctx.has("error"):
-		return {"error": ctx.error}
-	return _coerce_with_context(value, ctx)
-
-
-## Resolve a track_path's target property type once, so callers coercing many
-## keyframes avoid walking `get_property_list()` on every one. Returns:
-##   {pass_through: true}                   — no resolution / authoring-time
-##   {pass_through: false, prop_type, prop_name}  — coerce against this type
-##   {error: msg}                           — property not found on target
-##
-## Supports Godot's native NodePath subpath form `property:sub` (e.g.
-## `position:y`, `modulate:a`) — splits on the FIRST colon (node↔property
-## boundary), resolves the base property on the target, and for known
-## scalar subpaths (x/y/z/w on vectors, r/g/b/a on Color) narrows the
-## coerce target to TYPE_FLOAT so JSON numbers land as floats, not dicts.
-static func _resolve_track_prop_context(track_path: String, player: AnimationPlayer, override_root_node: Node = null) -> Dictionary:
-	var colon := track_path.find(":")
-	if colon < 0:
-		return {"pass_through": true}
-
-	var node_part := track_path.substr(0, colon)
-	var prop_full := track_path.substr(colon + 1)
-
-	# Property may include a subpath: "position:y", "modulate:a", etc.
-	var sub_colon := prop_full.find(":")
-	var prop_base := prop_full if sub_colon < 0 else prop_full.substr(0, sub_colon)
-	var prop_sub := "" if sub_colon < 0 else prop_full.substr(sub_colon + 1)
-
-	var root_node: Node = override_root_node if override_root_node != null else _player_root_node(player)
-	if root_node == null:
-		return {"pass_through": true}
-
-	var target: Node = root_node.get_node_or_null(node_part)
-	if target == null:
-		# Target node isn't in the scene yet — authoring-time path. Pass through.
-		return {"pass_through": true}
-
-	for p in target.get_property_list():
-		if p.name == prop_base:
-			var base_type: int = p.get("type", TYPE_NIL)
-			var coerce_type := base_type
-			if not prop_sub.is_empty():
-				var sub_type := _subpath_component_type(base_type, prop_sub)
-				if sub_type == TYPE_NIL:
-					# Unknown subpath component — pass through so Godot's own
-					# NodePath resolution raises at playback if it's truly bogus,
-					# rather than fabricating a coerce error for a valid-but-
-					# uncommon form (e.g. Transform3D subpaths).
-					return {"pass_through": true}
-				coerce_type = sub_type
-			return {
-				"pass_through": false,
-				"prop_type": coerce_type,
-				"prop_name": prop_full,
-			}
-
-	# Target exists but the property doesn't. Reject loudly — silently storing
-	# the raw value here produces garbage keyframes at playback time.
-	return {"error":
-		"%s (target path: '%s')" %
-		[McpPropertyErrors.build_message(target, prop_base), node_part]}
-
-
-## Component letters accepted on each aggregate base type, paired with the
-## scalar Variant type the component resolves to. A subpath like `position:y`
-## on a Vector3 maps to TYPE_FLOAT; on a Vector3i it maps to TYPE_INT.
-const _SUBPATH_COMPONENTS := {
-	TYPE_VECTOR2: ["xy", TYPE_FLOAT],
-	TYPE_VECTOR3: ["xyz", TYPE_FLOAT],
-	TYPE_VECTOR4: ["xyzw", TYPE_FLOAT],
-	TYPE_QUATERNION: ["xyzw", TYPE_FLOAT],
-	TYPE_COLOR: ["rgba", TYPE_FLOAT],
-	TYPE_VECTOR2I: ["xy", TYPE_INT],
-	TYPE_VECTOR3I: ["xyz", TYPE_INT],
-	TYPE_VECTOR4I: ["xyzw", TYPE_INT],
-}
-
-
-## Map a `property:sub` subpath to its scalar component type. Returns
-## TYPE_NIL when the base type / subkey pair isn't one we recognise —
-## callers pass-through in that case rather than mis-coerce.
-static func _subpath_component_type(base_type: int, sub: String) -> int:
-	var entry = _SUBPATH_COMPONENTS.get(base_type)
-	if entry == null or sub.length() != 1:
-		return TYPE_NIL
-	return entry[1] if (entry[0] as String).contains(sub) else TYPE_NIL
-
-
-static func _coerce_with_context(value: Variant, ctx: Dictionary) -> Dictionary:
-	if ctx.get("pass_through", false):
-		return {"ok": value}
-	return _coerce_for_type(value, ctx.prop_type, ctx.prop_name)
-
-
-## Coerce a single value to the given Godot variant type. Returns
-## {"ok": coerced} or {"error": msg}. Unknown types pass through.
-static func _coerce_for_type(value: Variant, prop_type: int, prop_name: String) -> Dictionary:
-	match prop_type:
-		TYPE_COLOR:
-			if value is Color:
-				return {"ok": value}
-			if value is String:
-				var s := value as String
-				var a := Color.from_string(s, Color(0, 0, 0, 0))
-				var b := Color.from_string(s, Color(1, 1, 1, 1))
-				if a == b:
-					return {"ok": a}
-				return {"error": "Cannot parse '%s' as Color for property '%s'" % [s, prop_name]}
-			if value is Dictionary and value.has("r") and value.has("g") and value.has("b"):
-				return {"ok": Color(float(value.r), float(value.g), float(value.b), float(value.get("a", 1.0)))}
-			return {"error": "Cannot coerce value to Color for property '%s' (expected string, {r,g,b}, or Color)" % prop_name}
-		TYPE_VECTOR2:
-			if value is Vector2:
-				return {"ok": value}
-			if value is Dictionary and value.has("x") and value.has("y"):
-				return {"ok": Vector2(float(value.x), float(value.y))}
-			if value is Array and value.size() >= 2:
-				return {"ok": Vector2(float(value[0]), float(value[1]))}
-			return {"error": "Cannot coerce value to Vector2 for property '%s' (expected {x,y}, [x,y], or Vector2)" % prop_name}
-		TYPE_VECTOR3:
-			if value is Vector3:
-				return {"ok": value}
-			if value is Dictionary and value.has("x") and value.has("y") and value.has("z"):
-				return {"ok": Vector3(float(value.x), float(value.y), float(value.z))}
-			return {"error": "Cannot coerce value to Vector3 for property '%s' (expected {x,y,z} or Vector3)" % prop_name}
-		TYPE_FLOAT:
-			if value is int or value is float:
-				return {"ok": float(value)}
-		TYPE_INT:
-			if value is float or value is int:
-				return {"ok": int(value)}
-		TYPE_BOOL:
-			if value is int or value is float or value is bool:
-				return {"ok": bool(value)}
-	return {"ok": value}
-
-
-# ============================================================================
-# Helpers — parsing + serializing
-# ============================================================================
-
-## Parse a transition value: named string or raw float.
-## Named values live in `_NAMED_TRANSITIONS` so the mapping has a single source.
-static func _parse_transition(v: Variant) -> float:
-	if v is float or v is int:
-		return float(v)
-	if v is String:
-		var key: String = (v as String).to_lower()
-		if _NAMED_TRANSITIONS.has(key):
-			return float(_NAMED_TRANSITIONS[key])
-	return 1.0
-
-
-## Map an Animation.TrackType enum to a stable string. Unknown types report
-## as "unknown" rather than being silently coerced to "method" — callers that
-## only produce value/method tracks can ignore the others; clients that want
-## to round-trip bezier/audio/etc. get an honest label to key off.
-static func _track_type_to_string(track_type: int) -> String:
-	match track_type:
-		Animation.TYPE_VALUE: return "value"
-		Animation.TYPE_METHOD: return "method"
-		Animation.TYPE_POSITION_3D: return "position_3d"
-		Animation.TYPE_ROTATION_3D: return "rotation_3d"
-		Animation.TYPE_SCALE_3D: return "scale_3d"
-		Animation.TYPE_BLEND_SHAPE: return "blend_shape"
-		Animation.TYPE_BEZIER: return "bezier"
-		Animation.TYPE_AUDIO: return "audio"
-		Animation.TYPE_ANIMATION: return "animation"
-		_: return "unknown"
-
-
-static func _loop_mode_to_string(mode: int) -> String:
-	match mode:
-		Animation.LOOP_LINEAR: return "linear"
-		Animation.LOOP_PINGPONG: return "pingpong"
-		_: return "none"
-
-
-static func _interp_to_string(mode: int) -> String:
-	match mode:
-		Animation.INTERPOLATION_NEAREST: return "nearest"
-		Animation.INTERPOLATION_CUBIC: return "cubic"
-		_: return "linear"
-
-
-## Convert a Godot Variant to a JSON-safe value.
-static func _serialize_value(value: Variant) -> Variant:
-	if value == null:
-		return null
-	match typeof(value):
-		TYPE_BOOL, TYPE_INT, TYPE_FLOAT, TYPE_STRING:
-			return value
-		TYPE_STRING_NAME:
-			return str(value)
-		TYPE_VECTOR2:
-			return {"x": value.x, "y": value.y}
-		TYPE_VECTOR3:
-			return {"x": value.x, "y": value.y, "z": value.z}
-		TYPE_COLOR:
-			return {"r": value.r, "g": value.g, "b": value.b, "a": value.a}
-		TYPE_NODE_PATH:
-			return str(value)
-		TYPE_ARRAY:
-			var arr: Array = []
-			for item in value:
-				arr.append(_serialize_value(item))
-			return arr
-		TYPE_DICTIONARY:
-			var out := {}
-			for k in value:
-				out[str(k)] = _serialize_value(value[k])
-			return out
-	return str(value)

--- a/plugin/addons/godot_ai/handlers/animation_presets.gd
+++ b/plugin/addons/godot_ai/handlers/animation_presets.gd
@@ -1,0 +1,526 @@
+@tool
+extends RefCounted
+
+## Curated motion presets for the AnimationPlayer surface.
+##
+## Each preset_* method:
+##   1. Validates params + resolves the player (auto-creating its default lib).
+##   2. Resolves the target node + classifies it as control / 2d / 3d.
+##   3. Builds a single-track Animation with shape-appropriate keyframes.
+##   4. Commits the add through the handler's shared `_commit_animation_add`
+##      so a single Ctrl-Z rolls back any auto-created library + the animation.
+##
+## Holds a WeakRef back to the AnimationHandler instance so the handler can
+## continue to own this module strongly via `_presets` without forming a
+## RefCounted cycle. Resolution / undo helpers live on the handler — keeping
+## the `_undo_redo` member single-source there avoids drift.
+
+
+const AnimationValues := preload("res://addons/godot_ai/handlers/animation_values.gd")
+
+
+var _handler_weak: WeakRef
+
+
+func _init(handler) -> void:
+	_handler_weak = weakref(handler)
+
+
+func _h():
+	return _handler_weak.get_ref()
+
+
+# ============================================================================
+# animation_preset_fade
+# ============================================================================
+
+func preset_fade(params: Dictionary) -> Dictionary:
+	var player_path: String = params.get("player_path", "")
+	var target_path: String = params.get("target_path", "")
+	var mode: String = params.get("mode", "in")
+	var duration: float = float(params.get("duration", 0.5))
+	var anim_name: String = params.get("animation_name", "")
+	var overwrite: bool = params.get("overwrite", false)
+
+	if player_path.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: player_path")
+	if target_path.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: target_path")
+	if mode != "in" and mode != "out":
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+			"Invalid mode '%s'. Valid: 'in', 'out'" % mode)
+	if duration <= 0.0:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "'duration' must be > 0")
+
+	var handler = _h()
+	if handler == null:
+		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "AnimationHandler not available")
+	var resolved: Dictionary = handler._resolve_player(player_path)
+	if resolved.has("error"):
+		return resolved
+	var player: AnimationPlayer = resolved.player
+	var library: AnimationLibrary = resolved.library
+	var created_library := false
+	if library == null:
+		library = AnimationLibrary.new()
+		created_library = true
+
+	var target_resolved := _resolve_preset_target(player, target_path)
+	if target_resolved.has("error"):
+		return target_resolved
+	var target: Node = target_resolved.node
+	var track_target: String = target_resolved.track_path_root
+
+	# Fade requires a `modulate` property (CanvasItem/Control/Node2D/Sprite3D/etc).
+	var has_modulate := false
+	for p in target.get_property_list():
+		if p.name == "modulate":
+			has_modulate = true
+			break
+	if not has_modulate:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+			"Target '%s' (class %s) has no 'modulate' property — fade requires a CanvasItem, Control, Node2D, or Sprite3D"
+			% [target_path, target.get_class()])
+
+	if anim_name.is_empty():
+		anim_name = "fade_%s" % mode
+
+	var old_anim: Animation = null
+	if library.has_animation(anim_name):
+		if not overwrite:
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+				"Animation '%s' already exists. Pass overwrite=true or delete it first." % anim_name)
+		old_anim = library.get_animation(anim_name)
+
+	var start_a: float = 0.0 if mode == "in" else 1.0
+	var end_a: float = 1.0 if mode == "in" else 0.0
+
+	var anim := Animation.new()
+	anim.length = duration
+	anim.loop_mode = Animation.LOOP_NONE
+
+	var track_path := "%s:modulate:a" % track_target
+	handler._do_add_property_track(anim, track_path, "linear", [
+		{"time": 0.0, "value": start_a, "transition": "linear"},
+		{"time": duration, "value": end_a, "transition": "linear"},
+	])
+
+	handler._commit_animation_add(
+		"MCP: Create animation %s" % anim_name,
+		player, library, created_library, anim_name, anim, old_anim,
+	)
+
+	return {
+		"data": {
+			"player_path": player_path,
+			"animation_name": anim_name,
+			"mode": mode,
+			"length": duration,
+			"track_count": anim.get_track_count(),
+			"library_created": created_library,
+			"overwritten": old_anim != null,
+			"undoable": true,
+		}
+	}
+
+
+# ============================================================================
+# animation_preset_slide
+# ============================================================================
+
+func preset_slide(params: Dictionary) -> Dictionary:
+	var player_path: String = params.get("player_path", "")
+	var target_path: String = params.get("target_path", "")
+	var direction: String = params.get("direction", "left")
+	var mode: String = params.get("mode", "in")
+	var duration: float = float(params.get("duration", 0.4))
+	var anim_name: String = params.get("animation_name", "")
+	var overwrite: bool = params.get("overwrite", false)
+
+	if player_path.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: player_path")
+	if target_path.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: target_path")
+	if not ["left", "right", "up", "down"].has(direction):
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+			"Invalid direction '%s'. Valid: 'left', 'right', 'up', 'down'" % direction)
+	if mode != "in" and mode != "out":
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+			"Invalid mode '%s'. Valid: 'in', 'out'" % mode)
+	if duration <= 0.0:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "'duration' must be > 0")
+
+	var handler = _h()
+	if handler == null:
+		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "AnimationHandler not available")
+	var resolved: Dictionary = handler._resolve_player(player_path)
+	if resolved.has("error"):
+		return resolved
+	var player: AnimationPlayer = resolved.player
+	var library: AnimationLibrary = resolved.library
+	var created_library := false
+	if library == null:
+		library = AnimationLibrary.new()
+		created_library = true
+
+	var target_resolved := _resolve_preset_target(player, target_path)
+	if target_resolved.has("error"):
+		return target_resolved
+	var target = target_resolved.node
+	var kind: String = target_resolved.kind
+	var track_target: String = target_resolved.track_path_root
+
+	# Default distance picks 3D units vs screen pixels based on target kind.
+	var default_distance: float = 1.0 if kind == "3d" else 100.0
+	var distance: float = float(params.get("distance", default_distance))
+	if distance == 0.0:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "'distance' must be non-zero")
+
+	var offset: Variant = _direction_offset(kind, direction, distance)
+	var current_pos: Variant = target.position
+	var start_pos: Variant
+	var end_pos: Variant
+	if mode == "in":
+		start_pos = current_pos + offset
+		end_pos = current_pos
+	else:
+		start_pos = current_pos
+		end_pos = current_pos + offset
+
+	if anim_name.is_empty():
+		anim_name = "slide_%s_%s" % [mode, direction]
+
+	var old_anim: Animation = null
+	if library.has_animation(anim_name):
+		if not overwrite:
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+				"Animation '%s' already exists. Pass overwrite=true or delete it first." % anim_name)
+		old_anim = library.get_animation(anim_name)
+
+	var anim := Animation.new()
+	anim.length = duration
+	anim.loop_mode = Animation.LOOP_NONE
+
+	var track_path := "%s:position" % track_target
+	handler._do_add_property_track(anim, track_path, "linear", [
+		{"time": 0.0, "value": start_pos, "transition": "linear"},
+		{"time": duration, "value": end_pos, "transition": "linear"},
+	])
+
+	handler._commit_animation_add(
+		"MCP: Create animation %s" % anim_name,
+		player, library, created_library, anim_name, anim, old_anim,
+	)
+
+	return {
+		"data": {
+			"player_path": player_path,
+			"animation_name": anim_name,
+			"direction": direction,
+			"mode": mode,
+			"distance": distance,
+			"length": duration,
+			"track_count": anim.get_track_count(),
+			"library_created": created_library,
+			"overwritten": old_anim != null,
+			"undoable": true,
+		}
+	}
+
+
+# ============================================================================
+# animation_preset_shake
+# ============================================================================
+
+func preset_shake(params: Dictionary) -> Dictionary:
+	var player_path: String = params.get("player_path", "")
+	var target_path: String = params.get("target_path", "")
+	var duration: float = float(params.get("duration", 0.3))
+	var frequency: float = float(params.get("frequency", 30.0))
+	var rng_seed: int = int(params.get("seed", 0))
+	var anim_name: String = params.get("animation_name", "")
+	var overwrite: bool = params.get("overwrite", false)
+
+	if player_path.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: player_path")
+	if target_path.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: target_path")
+	if duration <= 0.0:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "'duration' must be > 0")
+	if frequency <= 0.0:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "'frequency' must be > 0")
+
+	var handler = _h()
+	if handler == null:
+		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "AnimationHandler not available")
+	var resolved: Dictionary = handler._resolve_player(player_path)
+	if resolved.has("error"):
+		return resolved
+	var player: AnimationPlayer = resolved.player
+	var library: AnimationLibrary = resolved.library
+	var created_library := false
+	if library == null:
+		library = AnimationLibrary.new()
+		created_library = true
+
+	var target_resolved := _resolve_preset_target(player, target_path)
+	if target_resolved.has("error"):
+		return target_resolved
+	var target = target_resolved.node
+	var kind: String = target_resolved.kind
+	var track_target: String = target_resolved.track_path_root
+
+	var default_intensity: float = 0.1 if kind == "3d" else 10.0
+	var intensity: float = float(params.get("intensity", default_intensity))
+	if intensity <= 0.0:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "'intensity' must be > 0")
+
+	if anim_name.is_empty():
+		anim_name = "shake"
+
+	var old_anim: Animation = null
+	if library.has_animation(anim_name):
+		if not overwrite:
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+				"Animation '%s' already exists. Pass overwrite=true or delete it first." % anim_name)
+		old_anim = library.get_animation(anim_name)
+
+	var rng := RandomNumberGenerator.new()
+	if rng_seed != 0:
+		rng.seed = rng_seed
+	else:
+		rng.randomize()
+
+	# Samples between t=0 and t=duration (exclusive); bookended by at-rest keys.
+	var sample_count: int = int(ceil(frequency * duration))
+	if sample_count < 2:
+		sample_count = 2
+
+	var current_pos: Variant = target.position
+	var kfs: Array = []
+	kfs.append({"time": 0.0, "value": current_pos, "transition": "linear"})
+	for i in range(1, sample_count):
+		var t: float = (float(i) / float(sample_count)) * duration
+		var jx: float = rng.randf_range(-intensity, intensity)
+		var jy: float = rng.randf_range(-intensity, intensity)
+		var jittered: Variant
+		if kind == "3d":
+			var jz: float = rng.randf_range(-intensity, intensity)
+			jittered = current_pos + Vector3(jx, jy, jz)
+		else:
+			jittered = current_pos + Vector2(jx, jy)
+		kfs.append({"time": t, "value": jittered, "transition": "linear"})
+	kfs.append({"time": duration, "value": current_pos, "transition": "linear"})
+
+	var anim := Animation.new()
+	anim.length = duration
+	anim.loop_mode = Animation.LOOP_NONE
+
+	var track_path := "%s:position" % track_target
+	handler._do_add_property_track(anim, track_path, "linear", kfs)
+
+	handler._commit_animation_add(
+		"MCP: Create animation %s" % anim_name,
+		player, library, created_library, anim_name, anim, old_anim,
+	)
+
+	return {
+		"data": {
+			"player_path": player_path,
+			"animation_name": anim_name,
+			"length": duration,
+			"frequency": frequency,
+			"intensity": intensity,
+			"keyframe_count": kfs.size(),
+			"track_count": anim.get_track_count(),
+			"library_created": created_library,
+			"overwritten": old_anim != null,
+			"undoable": true,
+		}
+	}
+
+
+# ============================================================================
+# animation_preset_pulse
+# ============================================================================
+
+func preset_pulse(params: Dictionary) -> Dictionary:
+	var player_path: String = params.get("player_path", "")
+	var target_path: String = params.get("target_path", "")
+	var from_scale: float = float(params.get("from_scale", 1.0))
+	var to_scale: float = float(params.get("to_scale", 1.1))
+	var duration: float = float(params.get("duration", 0.4))
+	var anim_name: String = params.get("animation_name", "")
+	var overwrite: bool = params.get("overwrite", false)
+
+	if player_path.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: player_path")
+	if target_path.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: target_path")
+	if duration <= 0.0:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "'duration' must be > 0")
+	if from_scale <= 0.0:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "'from_scale' must be > 0")
+	if to_scale <= 0.0:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "'to_scale' must be > 0")
+
+	var handler = _h()
+	if handler == null:
+		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "AnimationHandler not available")
+	var resolved: Dictionary = handler._resolve_player(player_path)
+	if resolved.has("error"):
+		return resolved
+	var player: AnimationPlayer = resolved.player
+	var library: AnimationLibrary = resolved.library
+	var created_library := false
+	if library == null:
+		library = AnimationLibrary.new()
+		created_library = true
+
+	var target_resolved := _resolve_preset_target(player, target_path)
+	if target_resolved.has("error"):
+		return target_resolved
+	var kind: String = target_resolved.kind
+	var track_target: String = target_resolved.track_path_root
+
+	if anim_name.is_empty():
+		anim_name = "pulse"
+
+	var old_anim: Animation = null
+	if library.has_animation(anim_name):
+		if not overwrite:
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+				"Animation '%s' already exists. Pass overwrite=true or delete it first." % anim_name)
+		old_anim = library.get_animation(anim_name)
+
+	var from_vec: Variant
+	var to_vec: Variant
+	if kind == "3d":
+		from_vec = Vector3(from_scale, from_scale, from_scale)
+		to_vec = Vector3(to_scale, to_scale, to_scale)
+	else:
+		from_vec = Vector2(from_scale, from_scale)
+		to_vec = Vector2(to_scale, to_scale)
+
+	var anim := Animation.new()
+	anim.length = duration
+	anim.loop_mode = Animation.LOOP_NONE
+
+	var track_path := "%s:scale" % track_target
+	handler._do_add_property_track(anim, track_path, "linear", [
+		{"time": 0.0, "value": from_vec, "transition": "linear"},
+		{"time": duration * 0.5, "value": to_vec, "transition": "linear"},
+		{"time": duration, "value": from_vec, "transition": "linear"},
+	])
+
+	handler._commit_animation_add(
+		"MCP: Create animation %s" % anim_name,
+		player, library, created_library, anim_name, anim, old_anim,
+	)
+
+	return {
+		"data": {
+			"player_path": player_path,
+			"animation_name": anim_name,
+			"from_scale": from_scale,
+			"to_scale": to_scale,
+			"length": duration,
+			"track_count": anim.get_track_count(),
+			"library_created": created_library,
+			"overwritten": old_anim != null,
+			"undoable": true,
+		}
+	}
+
+
+# ============================================================================
+# Helpers — preset resolution
+# ============================================================================
+
+## Resolve a preset target node and classify its transform kind.
+##
+## Accepts two `target_path` shapes:
+##   * Scene-absolute (starts with "/") — resolved through `McpScenePath.resolve`,
+##     matching the convention used by every other scene-mutating tool. Targets
+##     outside the player's `root_node` subtree are converted to `..`-prefixed
+##     paths via `root_node.get_path_to(target)`, mirroring what the relative
+##     form accepts and how Godot stores track paths.
+##   * Relative — used as-is against the player's `root_node`, matching how
+##     animation tracks themselves are stored.
+##
+## Returns `{node, kind, track_path_root}` where `track_path_root` is the path
+## (relative to `root_node`) that callers should embed in the track path. For
+## scene-absolute inputs this is the converted relative path; for relative
+## inputs it equals the input. `kind` ∈ {"control", "2d", "3d"}.
+##
+## Mirrors the same root-node fallback that
+## `AnimationValues.resolve_track_prop_context` uses so tool inputs match how
+## the track path will resolve at playback.
+func _resolve_preset_target(player: AnimationPlayer, target_path: String) -> Dictionary:
+	var root_node := AnimationValues.player_root_node(player)
+	if root_node == null:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+			"AnimationPlayer at %s has no resolvable root_node (is the scene open?)" % str(player.get_path()))
+
+	var target: Node = null
+	var track_path_root: String = target_path
+	if target_path.begins_with("/"):
+		var scene_root := EditorInterface.get_edited_scene_root()
+		if scene_root == null:
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+				"Cannot resolve scene-absolute target_path '%s': no scene open" % target_path)
+		target = McpScenePath.resolve(target_path, scene_root)
+		if target == null:
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+				McpScenePath.format_node_error(target_path, scene_root))
+		# Convert to a root_node-relative path. For targets outside the
+		# subtree this yields a `..`-prefixed path, matching what the
+		# relative form already accepts (root_node.get_node_or_null
+		# resolves `..` segments) and what Godot's animation engine
+		# stores natively.
+		track_path_root = str(root_node.get_path_to(target))
+	else:
+		target = root_node.get_node_or_null(target_path)
+		if target == null:
+			# root_node.get_path() leaks the editor's SubViewport-wrapped
+			# path; use the clean scene-relative form so the hint is
+			# actionable.
+			var scene_root := EditorInterface.get_edited_scene_root()
+			var root_hint := McpScenePath.from_node(root_node, scene_root) if scene_root != null else str(root_node.name)
+			var abs_example := "/%s/path/to/target" % scene_root.name if scene_root != null else "/SceneRoot/path/to/target"
+			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+				("Target node not found at '%s' (resolved relative to AnimationPlayer's root_node '%s'). "
+				+ "Pass a path relative to root_node (e.g. \"path/to/target\") or a scene-absolute path (e.g. \"%s\").")
+				% [target_path, root_hint, abs_example])
+
+	var kind: String
+	if target is Control:
+		kind = "control"
+	elif target is Node2D:
+		kind = "2d"
+	elif target is Node3D:
+		kind = "3d"
+	else:
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+			"Target '%s' must be a Control, Node2D, or Node3D (got %s)" % [target_path, target.get_class()])
+	return {"node": target, "kind": kind, "track_path_root": track_path_root}
+
+
+## Build a directional offset for slide presets.
+## Axis conventions:
+##   Control + Node2D (screen-space, y-down): left/right = ∓x, up = -y, down = +y
+##   Node3D (world-up): left/right = ∓x, up = +y, down = -y
+static func _direction_offset(kind: String, direction: String, distance: float) -> Variant:
+	if kind == "3d":
+		match direction:
+			"left": return Vector3(-distance, 0.0, 0.0)
+			"right": return Vector3(distance, 0.0, 0.0)
+			"up": return Vector3(0.0, distance, 0.0)
+			"down": return Vector3(0.0, -distance, 0.0)
+	else:
+		match direction:
+			"left": return Vector2(-distance, 0.0)
+			"right": return Vector2(distance, 0.0)
+			"up": return Vector2(0.0, -distance)
+			"down": return Vector2(0.0, distance)
+	return null

--- a/plugin/addons/godot_ai/handlers/animation_presets.gd.uid
+++ b/plugin/addons/godot_ai/handlers/animation_presets.gd.uid
@@ -1,0 +1,1 @@
+uid://c4s3h78bwvr6w

--- a/plugin/addons/godot_ai/handlers/animation_values.gd
+++ b/plugin/addons/godot_ai/handlers/animation_values.gd
@@ -1,0 +1,454 @@
+@tool
+extends RefCounted
+
+## Read-only animation introspection + shared value-coercion / serialization.
+##
+## Holds:
+##   - Static helpers used by both the write handler (track building, simple
+##     composer) and the preset module (target/property resolution).
+##   - Instance methods that back the read MCP ops: animation_list,
+##     animation_get, animation_validate.
+##
+## The instance methods need the handler to resolve players / animations.
+## To keep that without introducing a RefCounted cycle (the handler holds a
+## strong ref to this module via `_values`), the back-pointer is a WeakRef.
+## When the handler is freed during plugin teardown, _h() returns null and
+## the (no-longer-routable) calls short-circuit to a generic editor-not-ready
+## error — matches the dispatcher already being torn down at that point.
+
+
+const _NAMED_TRANSITIONS := {
+	"linear": 1.0,
+	"ease_in": 2.0,
+	"ease_out": 0.5,
+	"ease_in_out": -2.0,
+}
+
+## Component letters accepted on each aggregate base type, paired with the
+## scalar Variant type the component resolves to. A subpath like `position:y`
+## on a Vector3 maps to TYPE_FLOAT; on a Vector3i it maps to TYPE_INT.
+const _SUBPATH_COMPONENTS := {
+	TYPE_VECTOR2: ["xy", TYPE_FLOAT],
+	TYPE_VECTOR3: ["xyz", TYPE_FLOAT],
+	TYPE_VECTOR4: ["xyzw", TYPE_FLOAT],
+	TYPE_QUATERNION: ["xyzw", TYPE_FLOAT],
+	TYPE_COLOR: ["rgba", TYPE_FLOAT],
+	TYPE_VECTOR2I: ["xy", TYPE_INT],
+	TYPE_VECTOR3I: ["xyz", TYPE_INT],
+	TYPE_VECTOR4I: ["xyzw", TYPE_INT],
+}
+
+
+var _handler_weak: WeakRef
+
+
+func _init(handler) -> void:
+	_handler_weak = weakref(handler)
+
+
+func _h():
+	return _handler_weak.get_ref()
+
+
+# ============================================================================
+# animation_list  (read)
+# ============================================================================
+
+func list_animations(params: Dictionary) -> Dictionary:
+	var player_path: String = params.get("player_path", "")
+
+	if player_path.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: player_path")
+
+	var handler = _h()
+	if handler == null:
+		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "AnimationHandler not available")
+	var resolved: Dictionary = handler._resolve_player_read(player_path)
+	if resolved.has("error"):
+		return resolved
+	var player: AnimationPlayer = resolved.player
+
+	var animations: Array[Dictionary] = []
+	for lib_name in player.get_animation_library_list():
+		var lib: AnimationLibrary = player.get_animation_library(lib_name)
+		for anim_name in lib.get_animation_list():
+			var anim: Animation = lib.get_animation(anim_name)
+			var display_name: String = anim_name if lib_name == "" else "%s/%s" % [lib_name, anim_name]
+			animations.append({
+				"name": display_name,
+				"length": anim.length,
+				"loop_mode": loop_mode_to_string(anim.loop_mode),
+				"track_count": anim.get_track_count(),
+			})
+
+	return {
+		"data": {
+			"player_path": player_path,
+			"animations": animations,
+			"count": animations.size(),
+		}
+	}
+
+
+# ============================================================================
+# animation_get  (read)
+# ============================================================================
+
+func get_animation(params: Dictionary) -> Dictionary:
+	var player_path: String = params.get("player_path", "")
+	var anim_name: String = params.get("animation_name", "")
+
+	if player_path.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: player_path")
+	if anim_name.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: animation_name")
+
+	var handler = _h()
+	if handler == null:
+		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "AnimationHandler not available")
+	var resolved: Dictionary = handler._resolve_player_read(player_path)
+	if resolved.has("error"):
+		return resolved
+	var player: AnimationPlayer = resolved.player
+
+	var anim_resolved: Dictionary = handler._resolve_animation(player, anim_name)
+	if anim_resolved.has("error"):
+		return anim_resolved
+	var anim: Animation = anim_resolved.animation
+
+	var tracks: Array[Dictionary] = []
+	for i in anim.get_track_count():
+		var track_type := anim.track_get_type(i)
+		var type_name := track_type_to_string(track_type)
+		var keys: Array[Dictionary] = []
+		for k in anim.track_get_key_count(i):
+			var key_val = anim.track_get_key_value(i, k)
+			keys.append({
+				"time": anim.track_get_key_time(i, k),
+				"value": serialize_value(key_val),
+				"transition": anim.track_get_key_transition(i, k),
+			})
+		tracks.append({
+			"index": i,
+			"type": type_name,
+			"path": str(anim.track_get_path(i)),
+			"interpolation": interp_to_string(anim.track_get_interpolation_type(i)),
+			"key_count": keys.size(),
+			"keys": keys,
+		})
+
+	return {
+		"data": {
+			"player_path": player_path,
+			"name": anim_name,
+			"length": anim.length,
+			"loop_mode": loop_mode_to_string(anim.loop_mode),
+			"track_count": anim.get_track_count(),
+			"tracks": tracks,
+		}
+	}
+
+
+# ============================================================================
+# animation_validate  (read-only)
+# ============================================================================
+
+func validate_animation(params: Dictionary) -> Dictionary:
+	var player_path: String = params.get("player_path", "")
+	var anim_name: String = params.get("animation_name", "")
+
+	if player_path.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: player_path")
+	if anim_name.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: animation_name")
+
+	var handler = _h()
+	if handler == null:
+		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "AnimationHandler not available")
+	var resolved: Dictionary = handler._resolve_player_read(player_path)
+	if resolved.has("error"):
+		return resolved
+	var player: AnimationPlayer = resolved.player
+
+	if not player.has_animation(anim_name):
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+			"Animation '%s' not found on player at %s" % [anim_name, player_path])
+
+	var anim: Animation = player.get_animation(anim_name)
+
+	var root_node := player_root_node(player)
+
+	var broken_tracks: Array[Dictionary] = []
+	var valid_count := 0
+
+	for i in anim.get_track_count():
+		var track_path_str := str(anim.track_get_path(i))
+		var colon := track_path_str.rfind(":")
+		var node_part: String
+		if colon >= 0:
+			node_part = track_path_str.substr(0, colon)
+		else:
+			node_part = track_path_str
+
+		var target_node: Node = null
+		if root_node != null:
+			target_node = root_node.get_node_or_null(node_part)
+
+		if target_node == null:
+			broken_tracks.append({
+				"index": i,
+				"path": track_path_str,
+				"type": track_type_to_string(anim.track_get_type(i)),
+				"issue": "node_not_found",
+				"node_path": node_part,
+			})
+		else:
+			valid_count += 1
+
+	return {
+		"data": {
+			"player_path": player_path,
+			"animation_name": anim_name,
+			"track_count": anim.get_track_count(),
+			"valid_count": valid_count,
+			"broken_count": broken_tracks.size(),
+			"broken_tracks": broken_tracks,
+			"valid": broken_tracks.is_empty(),
+		}
+	}
+
+
+# ============================================================================
+# Static helpers — shared with handler + presets
+# ============================================================================
+
+## Resolve the effective root node an AnimationPlayer animates against.
+## Falls back to the player's parent when the explicit root_node NodePath is
+## empty or unresolvable. Returns null when the player isn't in the tree.
+##
+## Mirrors the resolution Godot does at playback time so the validator,
+## preset target resolver, and track-property coercer all see the same root.
+static func player_root_node(player: AnimationPlayer) -> Node:
+	if not player.is_inside_tree():
+		return null
+	var rn := player.root_node
+	if rn != NodePath():
+		var n := player.get_node_or_null(rn)
+		if n != null:
+			return n
+	return player.get_parent()
+
+
+## Coerce a JSON value to match the expected Godot type for the given
+## track_path. Returns {"ok": value} or {"error": msg}.
+## Passes the raw value through when the target node isn't in the scene
+## yet (authoring-time path). Errors when the target exists but the
+## property doesn't, or when parsing a typed value (Color/Vector2/Vector3)
+## clearly fails — better to reject than silently store garbage.
+## `override_root_node` lets callers supply the root to resolve target paths
+## against when the player isn't in the tree yet (auto-create flow) — the
+## player's future parent stands in for the root the AnimationPlayer will
+## eventually use.
+static func coerce_value_for_track(value: Variant, track_path: String, player: AnimationPlayer, override_root_node: Node = null) -> Dictionary:
+	var ctx := resolve_track_prop_context(track_path, player, override_root_node)
+	if ctx.has("error"):
+		return {"error": ctx.error}
+	return coerce_with_context(value, ctx)
+
+
+## Resolve a track_path's target property type once, so callers coercing many
+## keyframes avoid walking `get_property_list()` on every one. Returns:
+##   {pass_through: true}                   — no resolution / authoring-time
+##   {pass_through: false, prop_type, prop_name}  — coerce against this type
+##   {error: msg}                           — property not found on target
+##
+## Supports Godot's native NodePath subpath form `property:sub` (e.g.
+## `position:y`, `modulate:a`) — splits on the FIRST colon (node↔property
+## boundary), resolves the base property on the target, and for known
+## scalar subpaths (x/y/z/w on vectors, r/g/b/a on Color) narrows the
+## coerce target to TYPE_FLOAT so JSON numbers land as floats, not dicts.
+static func resolve_track_prop_context(track_path: String, player: AnimationPlayer, override_root_node: Node = null) -> Dictionary:
+	var colon := track_path.find(":")
+	if colon < 0:
+		return {"pass_through": true}
+
+	var node_part := track_path.substr(0, colon)
+	var prop_full := track_path.substr(colon + 1)
+
+	# Property may include a subpath: "position:y", "modulate:a", etc.
+	var sub_colon := prop_full.find(":")
+	var prop_base := prop_full if sub_colon < 0 else prop_full.substr(0, sub_colon)
+	var prop_sub := "" if sub_colon < 0 else prop_full.substr(sub_colon + 1)
+
+	var root_node: Node = override_root_node
+	if root_node == null:
+		root_node = player_root_node(player)
+	if root_node == null:
+		return {"pass_through": true}
+
+	var target: Node = root_node.get_node_or_null(node_part)
+	if target == null:
+		# Target node isn't in the scene yet — authoring-time path. Pass through.
+		return {"pass_through": true}
+
+	for p in target.get_property_list():
+		if p.name == prop_base:
+			var base_type: int = p.get("type", TYPE_NIL)
+			var coerce_type := base_type
+			if not prop_sub.is_empty():
+				var sub_type := subpath_component_type(base_type, prop_sub)
+				if sub_type == TYPE_NIL:
+					# Unknown subpath component — pass through so Godot's own
+					# NodePath resolution raises at playback if it's truly bogus,
+					# rather than fabricating a coerce error for a valid-but-
+					# uncommon form (e.g. Transform3D subpaths).
+					return {"pass_through": true}
+				coerce_type = sub_type
+			return {
+				"pass_through": false,
+				"prop_type": coerce_type,
+				"prop_name": prop_full,
+			}
+
+	# Target exists but the property doesn't. Reject loudly — silently storing
+	# the raw value here produces garbage keyframes at playback time.
+	return {"error":
+		"%s (target path: '%s')" %
+		[McpPropertyErrors.build_message(target, prop_base), node_part]}
+
+
+## Map a `property:sub` subpath to its scalar component type. Returns
+## TYPE_NIL when the base type / subkey pair isn't one we recognise —
+## callers pass-through in that case rather than mis-coerce.
+static func subpath_component_type(base_type: int, sub: String) -> int:
+	var entry = _SUBPATH_COMPONENTS.get(base_type)
+	if entry == null or sub.length() != 1:
+		return TYPE_NIL
+	return entry[1] if (entry[0] as String).contains(sub) else TYPE_NIL
+
+
+static func coerce_with_context(value: Variant, ctx: Dictionary) -> Dictionary:
+	if ctx.get("pass_through", false):
+		return {"ok": value}
+	return coerce_for_type(value, ctx.prop_type, ctx.prop_name)
+
+
+## Coerce a single value to the given Godot variant type. Returns
+## {"ok": coerced} or {"error": msg}. Unknown types pass through.
+static func coerce_for_type(value: Variant, prop_type: int, prop_name: String) -> Dictionary:
+	match prop_type:
+		TYPE_COLOR:
+			if value is Color:
+				return {"ok": value}
+			if value is String:
+				var s := value as String
+				var a := Color.from_string(s, Color(0, 0, 0, 0))
+				var b := Color.from_string(s, Color(1, 1, 1, 1))
+				if a == b:
+					return {"ok": a}
+				return {"error": "Cannot parse '%s' as Color for property '%s'" % [s, prop_name]}
+			if value is Dictionary and value.has("r") and value.has("g") and value.has("b"):
+				return {"ok": Color(float(value.r), float(value.g), float(value.b), float(value.get("a", 1.0)))}
+			return {"error": "Cannot coerce value to Color for property '%s' (expected string, {r,g,b}, or Color)" % prop_name}
+		TYPE_VECTOR2:
+			if value is Vector2:
+				return {"ok": value}
+			if value is Dictionary and value.has("x") and value.has("y"):
+				return {"ok": Vector2(float(value.x), float(value.y))}
+			if value is Array and value.size() >= 2:
+				return {"ok": Vector2(float(value[0]), float(value[1]))}
+			return {"error": "Cannot coerce value to Vector2 for property '%s' (expected {x,y}, [x,y], or Vector2)" % prop_name}
+		TYPE_VECTOR3:
+			if value is Vector3:
+				return {"ok": value}
+			if value is Dictionary and value.has("x") and value.has("y") and value.has("z"):
+				return {"ok": Vector3(float(value.x), float(value.y), float(value.z))}
+			return {"error": "Cannot coerce value to Vector3 for property '%s' (expected {x,y,z} or Vector3)" % prop_name}
+		TYPE_FLOAT:
+			if value is int or value is float:
+				return {"ok": float(value)}
+		TYPE_INT:
+			if value is float or value is int:
+				return {"ok": int(value)}
+		TYPE_BOOL:
+			if value is int or value is float or value is bool:
+				return {"ok": bool(value)}
+	return {"ok": value}
+
+
+# ============================================================================
+# Static helpers — parsing + serializing
+# ============================================================================
+
+## Parse a transition value: named string or raw float.
+## Named values live in `_NAMED_TRANSITIONS` so the mapping has a single source.
+static func parse_transition(v: Variant) -> float:
+	if v is float or v is int:
+		return float(v)
+	if v is String:
+		var key: String = (v as String).to_lower()
+		if _NAMED_TRANSITIONS.has(key):
+			return float(_NAMED_TRANSITIONS[key])
+	return 1.0
+
+
+## Map an Animation.TrackType enum to a stable string. Unknown types report
+## as "unknown" rather than being silently coerced to "method" — callers that
+## only produce value/method tracks can ignore the others; clients that want
+## to round-trip bezier/audio/etc. get an honest label to key off.
+static func track_type_to_string(track_type: int) -> String:
+	match track_type:
+		Animation.TYPE_VALUE: return "value"
+		Animation.TYPE_METHOD: return "method"
+		Animation.TYPE_POSITION_3D: return "position_3d"
+		Animation.TYPE_ROTATION_3D: return "rotation_3d"
+		Animation.TYPE_SCALE_3D: return "scale_3d"
+		Animation.TYPE_BLEND_SHAPE: return "blend_shape"
+		Animation.TYPE_BEZIER: return "bezier"
+		Animation.TYPE_AUDIO: return "audio"
+		Animation.TYPE_ANIMATION: return "animation"
+		_: return "unknown"
+
+
+static func loop_mode_to_string(mode: int) -> String:
+	match mode:
+		Animation.LOOP_LINEAR: return "linear"
+		Animation.LOOP_PINGPONG: return "pingpong"
+		_: return "none"
+
+
+static func interp_to_string(mode: int) -> String:
+	match mode:
+		Animation.INTERPOLATION_NEAREST: return "nearest"
+		Animation.INTERPOLATION_CUBIC: return "cubic"
+		_: return "linear"
+
+
+## Convert a Godot Variant to a JSON-safe value.
+static func serialize_value(value: Variant) -> Variant:
+	if value == null:
+		return null
+	match typeof(value):
+		TYPE_BOOL, TYPE_INT, TYPE_FLOAT, TYPE_STRING:
+			return value
+		TYPE_STRING_NAME:
+			return str(value)
+		TYPE_VECTOR2:
+			return {"x": value.x, "y": value.y}
+		TYPE_VECTOR3:
+			return {"x": value.x, "y": value.y, "z": value.z}
+		TYPE_COLOR:
+			return {"r": value.r, "g": value.g, "b": value.b, "a": value.a}
+		TYPE_NODE_PATH:
+			return str(value)
+		TYPE_ARRAY:
+			var arr: Array = []
+			for item in value:
+				arr.append(serialize_value(item))
+			return arr
+		TYPE_DICTIONARY:
+			var out := {}
+			for k in value:
+				out[str(k)] = serialize_value(value[k])
+			return out
+	return str(value)

--- a/plugin/addons/godot_ai/handlers/animation_values.gd.uid
+++ b/plugin/addons/godot_ai/handlers/animation_values.gd.uid
@@ -1,0 +1,1 @@
+uid://bguta2eb8blgf


### PR DESCRIPTION
## Summary

Forwards the animation_handler split from PR #344 (which I incorrectly merged to `main` instead of `beta`) onto `beta`, so the audit-stack history stays consistent with the umbrella's branching policy in #297. The maintainer-owned `beta → main` promotion will see the same patch on both sides.

Cherry-pick of `d915c4d` (#344) onto `beta`, with a one-file conflict resolved against #337's "scene-absolute `target_path`" changes:

- `_resolve_preset_target` (now in `animation_presets.gd`) accepts both scene-absolute (`/Main/Foo`) and root_node-relative (`World/Foo`) `target_path` shapes, returns `{node, kind, track_path_root}`. Each `preset_*` consumes `track_path_root` (not the raw `target_path`) when building its track string.
- The `_player_root_node` helper #337 introduced is now `AnimationValues.player_root_node` (same logic, same call sites: `validate_animation`, `resolve_track_prop_context`, `_resolve_preset_target`).

## Why this exists separately

I merged #344 to `main` directly. Per the umbrella issue's branching policy ("All audit follow-up PRs should target `beta` by default, not `main`"), it should have flowed through `beta`. This PR keeps `beta` consistent so the eventual `beta → main` promotion isn't the first time `beta` sees the split. The patch on both branches is functionally identical — git will collapse them at promotion time.

## Validated locally

- `script/ci-check-gdscript` — clean
- `ruff check src/ tests/` — clean
- `pytest -q` — **767 passed** (vs 722 on main; beta has more tests including the 6 `test_preset_*_accepts_scene_absolute_target` cases #337 added)
- SceneTree smoke — confirms handler instantiates its submodules, WeakRef back-pointers resolve, every static helper in `AnimationValues` round-trips, `AnimationPresets._direction_offset` returns the right axis convention for 2D and 3D, all 7 proxy methods exist on the handler

## Test plan

- [ ] CI green on Linux / macOS / Windows
- [ ] `test_run suite=animation` via MCP against a live editor — full pass, including the scene-absolute-target tests added in #337

Refs #297 (audit umbrella, finding #13) — #342 (split tracker) — #344 (the version that landed on `main`).

https://claude.ai/code/session_011QxzADbf9zHwfZicjzdvCw

---
_Generated by [Claude Code](https://claude.ai/code/session_011QxzADbf9zHwfZicjzdvCw)_