### PR TITLE
[Audit v2 #3] Reject res:// path traversal in script + filesystem write tools

### DIFF
--- a/plugin/addons/godot_ai/handlers/filesystem_handler.gd
+++ b/plugin/addons/godot_ai/handlers/filesystem_handler.gd
@@ -7,11 +7,9 @@ extends RefCounted
 func read_file(params: Dictionary) -> Dictionary:
 	var path: String = params.get("path", "")
 
-	if path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: path")
-
-	if not path.begins_with("res://"):
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Path must start with res://")
+	var path_err := McpPathValidator.validate_resource_path(path)
+	if not path_err.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, path_err)
 
 	if not FileAccess.file_exists(path):
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "File not found: %s" % path)
@@ -37,11 +35,9 @@ func write_file(params: Dictionary) -> Dictionary:
 	var path: String = params.get("path", "")
 	var content: String = params.get("content", "")
 
-	if path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: path")
-
-	if not path.begins_with("res://"):
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Path must start with res://")
+	var path_err := McpPathValidator.validate_resource_path(path)
+	if not path_err.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, path_err)
 
 	# Ensure parent directory exists
 	var dir_path := path.get_base_dir()
@@ -87,8 +83,9 @@ func reimport(params: Dictionary) -> Dictionary:
 
 	for path_variant in paths:
 		var path: String = str(path_variant)
-		if not path.begins_with("res://"):
-			not_found.append("%s (must start with res://)" % path)
+		var path_err := McpPathValidator.validate_resource_path(path)
+		if not path_err.is_empty():
+			not_found.append("%s (%s)" % [path, path_err])
 			continue
 		if not FileAccess.file_exists(path):
 			not_found.append("%s (file does not exist)" % path)

--- a/plugin/addons/godot_ai/handlers/script_handler.gd
+++ b/plugin/addons/godot_ai/handlers/script_handler.gd
@@ -25,11 +25,9 @@ func create_script(params: Dictionary) -> Dictionary:
 	var path: String = params.get("path", "")
 	var content: String = params.get("content", "")
 
-	if path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: path")
-
-	if not path.begins_with("res://"):
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Path must start with res://")
+	var path_err := McpPathValidator.validate_resource_path(path)
+	if not path_err.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, path_err)
 
 	if not path.ends_with(".gd"):
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Path must end with .gd")
@@ -116,11 +114,9 @@ func _finish_create_script_deferred(request_id: String, path: String, data: Dict
 func read_script(params: Dictionary) -> Dictionary:
 	var path: String = params.get("path", "")
 
-	if path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: path")
-
-	if not path.begins_with("res://"):
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Path must start with res://")
+	var path_err := McpPathValidator.validate_resource_path(path)
+	if not path_err.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, path_err)
 
 	if not FileAccess.file_exists(path):
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "File not found: %s" % path)
@@ -148,14 +144,13 @@ func patch_script(params: Dictionary) -> Dictionary:
 	var new_text: String = params.get("new_text", "")
 	var replace_all: bool = params.get("replace_all", false)
 
-	if path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: path")
+	var path_err := McpPathValidator.validate_resource_path(path)
+	if not path_err.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, path_err)
 	if not "old_text" in params:
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: old_text")
 	if not "new_text" in params:
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: new_text")
-	if not path.begins_with("res://"):
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Path must start with res://")
 	if not path.ends_with(".gd"):
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Path must end with .gd (use filesystem_write_text for other text files)")
 	if old_text.is_empty():
@@ -283,11 +278,9 @@ func detach_script(params: Dictionary) -> Dictionary:
 func find_symbols(params: Dictionary) -> Dictionary:
 	var path: String = params.get("path", "")
 
-	if path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: path")
-
-	if not path.begins_with("res://"):
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Path must start with res://")
+	var path_err := McpPathValidator.validate_resource_path(path)
+	if not path_err.is_empty():
+		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, path_err)
 
 	if not FileAccess.file_exists(path):
 		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "File not found: %s" % path)

--- a/plugin/addons/godot_ai/utils/path_validator.gd
+++ b/plugin/addons/godot_ai/utils/path_validator.gd
@@ -20,6 +20,20 @@ extends RefCounted
 ##      that simplify_path collapses but the substring check might miss)
 
 
+# Cached project root. `ProjectSettings.globalize_path("res://")` is stable
+# across the editor's lifetime — caching avoids redundant resolution on every
+# call. Matters most for `reimport`, which loops the validator over each path
+# in a batch. Lazy-init on first call so static-load timing can't see a
+# half-initialised ProjectSettings.
+static var _cached_res_root: String = ""
+
+
+static func _res_root() -> String:
+	if _cached_res_root.is_empty():
+		_cached_res_root = ProjectSettings.globalize_path("res://").simplify_path()
+	return _cached_res_root
+
+
 ## Returns "" when the path is a safe `res://`-rooted reference inside the
 ## project root. Returns a human-readable error message otherwise; callers
 ## wrap it with `McpErrorCodes.make(INVALID_PARAMS, ...)`.
@@ -31,7 +45,7 @@ static func validate_resource_path(path: String) -> String:
 	if ".." in path:
 		return "Path must not contain '..' (path traversal not allowed)"
 	var globalized := ProjectSettings.globalize_path(path).simplify_path()
-	var res_root := ProjectSettings.globalize_path("res://").simplify_path()
+	var res_root := _res_root()
 	# Append a separator so `/proj_evil/...` can't pretend to be inside
 	# `/proj` via prefix match. `globalized == res_root` covers `path == "res://"`.
 	if globalized != res_root and not globalized.begins_with(res_root + "/"):

--- a/plugin/addons/godot_ai/utils/path_validator.gd
+++ b/plugin/addons/godot_ai/utils/path_validator.gd
@@ -1,0 +1,39 @@
+@tool
+class_name McpPathValidator
+extends RefCounted
+
+## Validates `res://`-rooted paths against directory-traversal escape.
+##
+## Issue #347 (audit-v2 #3): handlers were accepting `res://../etc/passwd.gd`
+## because the only check was `path.begins_with("res://")`. LLM-driven path
+## generation (prompt injection, agent typos, untrusted issue/PR text in
+## context) can produce traversal payloads for the write tools that produce
+## arbitrary disk content (`script_create`, `filesystem_write_text`,
+## `patch_script`) and for the matching reads (info disclosure surface).
+##
+## Layered checks:
+##   1. non-empty
+##   2. begins with `res://`
+##   3. no `..` substring (cheap, catches every common traversal payload)
+##   4. globalize → simplify → verify still under the project root
+##      (defence-in-depth against URL-encoded or otherwise sneaky shapes
+##      that simplify_path collapses but the substring check might miss)
+
+
+## Returns "" when the path is a safe `res://`-rooted reference inside the
+## project root. Returns a human-readable error message otherwise; callers
+## wrap it with `McpErrorCodes.make(INVALID_PARAMS, ...)`.
+static func validate_resource_path(path: String) -> String:
+	if path.is_empty():
+		return "Missing required param: path"
+	if not path.begins_with("res://"):
+		return "Path must start with res://"
+	if ".." in path:
+		return "Path must not contain '..' (path traversal not allowed)"
+	var globalized := ProjectSettings.globalize_path(path).simplify_path()
+	var res_root := ProjectSettings.globalize_path("res://").simplify_path()
+	# Append a separator so `/proj_evil/...` can't pretend to be inside
+	# `/proj` via prefix match. `globalized == res_root` covers `path == "res://"`.
+	if globalized != res_root and not globalized.begins_with(res_root + "/"):
+		return "Path must resolve under res:// root"
+	return ""

--- a/plugin/addons/godot_ai/utils/path_validator.gd.uid
+++ b/plugin/addons/godot_ai/utils/path_validator.gd.uid
@@ -1,0 +1,1 @@
+uid://blxntmd65ljyu

--- a/test_project/tests/test_filesystem.gd
+++ b/test_project/tests/test_filesystem.gd
@@ -59,6 +59,13 @@ func test_read_file_not_found() -> void:
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 
 
+func test_read_file_rejects_traversal_path() -> void:
+	## Issue #347: traversal in read_file is the file-disclosure primitive.
+	var result := _handler.read_file({"path": "res://../etc/passwd"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "..")
+
+
 # ----- write_file -----
 
 func test_write_file_basic() -> void:
@@ -105,6 +112,17 @@ func test_write_file_invalid_prefix() -> void:
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 
 
+func test_write_file_rejects_traversal_path() -> void:
+	## Issue #347: the actual arbitrary-disk-write primitive.
+	var result := _handler.write_file({
+		"path": "res://../etc/passwd",
+		"content": "owned\n",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "..")
+	assert_false(FileAccess.file_exists("res://../etc/passwd"), "traversal must not write to disk")
+
+
 # ----- reimport -----
 
 func test_reimport_missing_paths() -> void:
@@ -139,3 +157,12 @@ func test_reimport_invalid_prefix() -> void:
 	assert_has_key(result, "data")
 	assert_eq(result.data.reimported_count, 0)
 	assert_eq(result.data.not_found_count, 1)
+
+
+func test_reimport_rejects_traversal_path() -> void:
+	## Issue #347: per-path validation in the loop must catch traversal too.
+	var result := _handler.reimport({"paths": ["res://../etc/passwd"]})
+	assert_has_key(result, "data")
+	assert_eq(result.data.reimported_count, 0)
+	assert_eq(result.data.not_found_count, 1)
+	assert_contains(result.data.not_found[0], "..")

--- a/test_project/tests/test_filesystem.gd
+++ b/test_project/tests/test_filesystem.gd
@@ -114,13 +114,19 @@ func test_write_file_invalid_prefix() -> void:
 
 func test_write_file_rejects_traversal_path() -> void:
 	## Issue #347: the actual arbitrary-disk-write primitive.
+	## Use a synthetic target so a Unix host's pre-existing /etc/* doesn't
+	## false-positive the disk-state assertion below. If a regression let
+	## the write through, the file would land one dir above the project at
+	## `<project_parent>/__mcp_traversal_test_target__`, which never
+	## exists in a clean tree.
+	var traversal_path := "res://../__mcp_traversal_test_target__.txt"
 	var result := _handler.write_file({
-		"path": "res://../etc/passwd",
+		"path": traversal_path,
 		"content": "owned\n",
 	})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 	assert_contains(result.error.message, "..")
-	assert_false(FileAccess.file_exists("res://../etc/passwd"), "traversal must not write to disk")
+	assert_false(FileAccess.file_exists(traversal_path), "traversal must not write to disk")
 
 
 # ----- reimport -----

--- a/test_project/tests/test_path_validator.gd
+++ b/test_project/tests/test_path_validator.gd
@@ -79,13 +79,18 @@ func test_rejects_dotdot_in_filename() -> void:
 	assert_false(err.is_empty(), "literal '..' anywhere in path must be rejected")
 
 
-# ----- defence in depth (boundary check beyond the substring guard) -----
+# ----- boundary check (defence in depth past the substring guard) -----
 
-func test_rejects_path_resolving_outside_root() -> void:
-	## Direct traversal is caught by the substring guard. This test exercises
-	## the globalize_path → simplify_path → boundary verification — if a
-	## future encoding bypass slips past the substring check, this layer
-	## still rejects.
-	## Sanity: validate_resource_path on something we know simplifies safely.
+func test_well_formed_nested_path_passes_boundary_check() -> void:
+	## Sanity: a path with no `..` substring still has to clear the
+	## globalize_path → simplify_path → boundary check. This pins the safe
+	## path so a regression in the boundary comparison (e.g. trailing-slash
+	## handling) couldn't silently reject legitimate paths.
+	##
+	## Direct traversal payloads can't reach the boundary check — they're
+	## caught by the `..` substring rejection above — so there's no
+	## non-`..` traversal payload to assert rejection on. The boundary
+	## check exists as defence-in-depth for any future encoding-bypass
+	## that smuggles a `..` past the substring guard.
 	var safe := McpPathValidator.validate_resource_path("res://addons/godot_ai")
 	assert_eq(safe, "", "well-formed nested path must validate")

--- a/test_project/tests/test_path_validator.gd
+++ b/test_project/tests/test_path_validator.gd
@@ -1,0 +1,91 @@
+@tool
+extends McpTestSuite
+
+## Tests for McpPathValidator — the resource-path traversal guard shared by
+## script_handler and filesystem_handler. Issue #347 (audit-v2 #3): paths
+## like `res://../etc/passwd.gd` were passing the bare prefix check.
+
+
+func suite_name() -> String:
+	return "path_validator"
+
+
+# ----- happy path -----
+
+func test_valid_simple_path_returns_empty() -> void:
+	assert_eq(McpPathValidator.validate_resource_path("res://main.tscn"), "")
+
+
+func test_valid_nested_path_returns_empty() -> void:
+	assert_eq(McpPathValidator.validate_resource_path("res://addons/godot_ai/plugin.gd"), "")
+
+
+func test_valid_root_path_returns_empty() -> void:
+	## "res://" itself has no traversal and resolves exactly to the project
+	## root, so the validator must not reject it on the boundary check.
+	assert_eq(McpPathValidator.validate_resource_path("res://"), "")
+
+
+# ----- empty + prefix -----
+
+func test_empty_path_rejected() -> void:
+	var err := McpPathValidator.validate_resource_path("")
+	assert_false(err.is_empty(), "empty path must report an error")
+	assert_contains(err, "Missing required param")
+
+
+func test_missing_prefix_rejected() -> void:
+	var err := McpPathValidator.validate_resource_path("/tmp/foo.gd")
+	assert_false(err.is_empty(), "absolute path without res:// must be rejected")
+	assert_contains(err, "res://")
+
+
+func test_user_prefix_rejected() -> void:
+	## user:// is a valid Godot scheme but it's outside the project — agents
+	## must not be able to write to user:// via the same handlers (they have
+	## different lifecycle and permission semantics).
+	var err := McpPathValidator.validate_resource_path("user://save.dat")
+	assert_false(err.is_empty(), "user:// path must be rejected")
+	assert_contains(err, "res://")
+
+
+# ----- traversal regressions (the actual security guard) -----
+
+func test_rejects_dotdot_at_root() -> void:
+	## The exact attack shape called out in issue #347.
+	var err := McpPathValidator.validate_resource_path("res://../etc/passwd.gd")
+	assert_false(err.is_empty(), "res://../etc/passwd.gd must be rejected")
+	assert_contains(err, "..")
+
+
+func test_rejects_dotdot_nested() -> void:
+	var err := McpPathValidator.validate_resource_path("res://addons/../../etc/passwd")
+	assert_false(err.is_empty(), "nested traversal must be rejected")
+	assert_contains(err, "..")
+
+
+func test_rejects_deep_dotdot_chain() -> void:
+	## Defence in depth: even if a payload chains through legitimate-looking
+	## subdirectories first, the substring check fires.
+	var err := McpPathValidator.validate_resource_path("res://addons/godot_ai/../../../etc/passwd.gd")
+	assert_false(err.is_empty(), "deep traversal chain must be rejected")
+
+
+func test_rejects_dotdot_in_filename() -> void:
+	## Per the audit's fix shape: reject any path containing `..`. A filename
+	## like `my..backup.json` is unusual enough that we accept the false-
+	## positive cost in exchange for a simpler, shorter security boundary.
+	var err := McpPathValidator.validate_resource_path("res://data/my..backup.json")
+	assert_false(err.is_empty(), "literal '..' anywhere in path must be rejected")
+
+
+# ----- defence in depth (boundary check beyond the substring guard) -----
+
+func test_rejects_path_resolving_outside_root() -> void:
+	## Direct traversal is caught by the substring guard. This test exercises
+	## the globalize_path → simplify_path → boundary verification — if a
+	## future encoding bypass slips past the substring check, this layer
+	## still rejects.
+	## Sanity: validate_resource_path on something we know simplifies safely.
+	var safe := McpPathValidator.validate_resource_path("res://addons/godot_ai")
+	assert_eq(safe, "", "well-formed nested path must validate")

--- a/test_project/tests/test_path_validator.gd.uid
+++ b/test_project/tests/test_path_validator.gd.uid
@@ -1,0 +1,1 @@
+uid://03e3vouyp30v

--- a/test_project/tests/test_script.gd
+++ b/test_project/tests/test_script.gd
@@ -106,6 +106,18 @@ func test_create_script_wrong_extension() -> void:
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 
 
+func test_create_script_rejects_traversal_path() -> void:
+	## Issue #347: `res://../etc/passwd.gd` previously passed the prefix check.
+	var result := _handler.create_script({
+		"path": "res://../etc/passwd.gd",
+		"content": "extends Node\n",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "..")
+	## Defence: confirm the file was NOT written outside the project.
+	assert_false(FileAccess.file_exists("res://../etc/passwd.gd"), "traversal must not write to disk")
+
+
 # ----- patch_script -----
 
 func test_patch_script_basic() -> void:
@@ -222,6 +234,18 @@ func test_patch_script_invalid_prefix() -> void:
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 
 
+func test_patch_script_rejects_traversal_path() -> void:
+	## Issue #347 regression: traversal must be caught before the file is
+	## opened for read or write.
+	var result := _handler.patch_script({
+		"path": "res://../etc/passwd.gd",
+		"old_text": "x",
+		"new_text": "y",
+	})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "..")
+
+
 # ----- read_script -----
 
 func test_read_script_basic() -> void:
@@ -246,6 +270,13 @@ func test_read_script_invalid_prefix() -> void:
 func test_read_script_not_found() -> void:
 	var result := _handler.read_script({"path": "res://nonexistent_script.gd"})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_read_script_rejects_traversal_path() -> void:
+	## Issue #347: read_script must not become a file-disclosure primitive.
+	var result := _handler.read_script({"path": "res://../etc/passwd.gd"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "..")
 
 
 # ----- attach_script -----
@@ -378,3 +409,10 @@ func test_find_symbols_invalid_prefix() -> void:
 func test_find_symbols_not_found() -> void:
 	var result := _handler.find_symbols({"path": "res://nonexistent_script.gd"})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+
+
+func test_find_symbols_rejects_traversal_path() -> void:
+	## Issue #347: find_symbols also reads file content; same disclosure surface.
+	var result := _handler.find_symbols({"path": "res://../etc/passwd.gd"})
+	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "..")

--- a/test_project/tests/test_script.gd
+++ b/test_project/tests/test_script.gd
@@ -108,14 +108,18 @@ func test_create_script_wrong_extension() -> void:
 
 func test_create_script_rejects_traversal_path() -> void:
 	## Issue #347: `res://../etc/passwd.gd` previously passed the prefix check.
+	## Use a synthetic target so a host with a pre-existing
+	## `<project_parent>/etc/passwd.gd` couldn't false-positive the disk
+	## assertion. The synthetic name never exists in a clean tree.
+	var traversal_path := "res://../__mcp_traversal_test_target__.gd"
 	var result := _handler.create_script({
-		"path": "res://../etc/passwd.gd",
+		"path": traversal_path,
 		"content": "extends Node\n",
 	})
 	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
 	assert_contains(result.error.message, "..")
 	## Defence: confirm the file was NOT written outside the project.
-	assert_false(FileAccess.file_exists("res://../etc/passwd.gd"), "traversal must not write to disk")
+	assert_false(FileAccess.file_exists(traversal_path), "traversal must not write to disk")
 
 
 # ----- patch_script -----

--- a/tests/unit/test_path_traversal_guard.py
+++ b/tests/unit/test_path_traversal_guard.py
@@ -36,21 +36,29 @@ def test_path_validator_declares_class_name() -> None:
 
 
 def test_path_validator_implements_layered_checks() -> None:
-    """The validator must implement all four layers from issue #347's fix shape:
-    non-empty, res:// prefix, no `..` substring, and globalize-simplify boundary check.
+    """The validator must implement every layer from issue #347's fix shape:
+    non-empty, res:// prefix, no `..` substring, globalize-simplify
+    normalisation, and boundary verification against the project root.
 
     Each layer catches a different escape vector — losing any of them silently
     weakens the security boundary without a single test failing on a single bad input.
     """
     source = PATH_VALIDATOR.read_text()
-    # 1) prefix check
+    # 1) non-empty guard — without this, an empty path silently passes the
+    # prefix check (since "".begins_with("res://") is false, the prefix
+    # error fires, but the message would name the wrong layer).
+    assert "is_empty()" in source, (
+        "validator must reject empty paths explicitly so the error message "
+        "names the missing-param layer rather than the prefix layer."
+    )
+    # 2) prefix check
     assert 'begins_with("res://")' in source, "validator must check res:// prefix"
-    # 2) literal `..` substring rejection — the cheap defence-in-depth layer
+    # 3) literal `..` substring rejection — the cheap defence-in-depth layer
     assert '".." in path' in source, "validator must reject any path containing '..'"
-    # 3) globalize → simplify normalisation
+    # 4) globalize → simplify normalisation
     assert "ProjectSettings.globalize_path" in source
     assert "simplify_path()" in source
-    # 4) boundary verification against the project root
+    # 5) boundary verification against the project root
     assert "res_root" in source, (
         "validator must compare the simplified globalised path against the "
         "simplified project root — a missing boundary check lets encoded "

--- a/tests/unit/test_path_traversal_guard.py
+++ b/tests/unit/test_path_traversal_guard.py
@@ -1,0 +1,99 @@
+"""Source-structure regression tests for the path-traversal fix (issue #347, audit-v2 #3).
+
+Before this fix, `script_handler.gd` and `filesystem_handler.gd` validated
+resource paths only with `path.begins_with("res://")`, which accepts payloads
+like `res://../etc/passwd.gd`. The fix adds `McpPathValidator` and replaces
+every prefix-check call site in the named handlers with a validator call
+that additionally rejects `..` substrings and boundary-violating paths.
+
+These tests pin the structure so a future refactor can't silently
+reintroduce the bare `begins_with("res://")` pattern in the affected
+handlers (where every `path` originates from agent input and lands at a
+real disk write or read).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[2] / "plugin" / "addons" / "godot_ai"
+PATH_VALIDATOR = PLUGIN_ROOT / "utils" / "path_validator.gd"
+SCRIPT_HANDLER = PLUGIN_ROOT / "handlers" / "script_handler.gd"
+FILESYSTEM_HANDLER = PLUGIN_ROOT / "handlers" / "filesystem_handler.gd"
+
+
+def test_path_validator_file_exists() -> None:
+    assert PATH_VALIDATOR.exists(), (
+        "McpPathValidator must live at utils/path_validator.gd — handlers "
+        "depend on the project-wide class_name to delegate path validation."
+    )
+
+
+def test_path_validator_declares_class_name() -> None:
+    """Project-wide class_name lets handlers reference McpPathValidator without preload."""
+    source = PATH_VALIDATOR.read_text()
+    assert "class_name McpPathValidator" in source
+
+
+def test_path_validator_implements_layered_checks() -> None:
+    """The validator must implement all four layers from issue #347's fix shape:
+    non-empty, res:// prefix, no `..` substring, and globalize-simplify boundary check.
+
+    Each layer catches a different escape vector — losing any of them silently
+    weakens the security boundary without a single test failing on a single bad input.
+    """
+    source = PATH_VALIDATOR.read_text()
+    # 1) prefix check
+    assert 'begins_with("res://")' in source, "validator must check res:// prefix"
+    # 2) literal `..` substring rejection — the cheap defence-in-depth layer
+    assert '".." in path' in source, "validator must reject any path containing '..'"
+    # 3) globalize → simplify normalisation
+    assert "ProjectSettings.globalize_path" in source
+    assert "simplify_path()" in source
+    # 4) boundary verification against the project root
+    assert "res_root" in source, (
+        "validator must compare the simplified globalised path against the "
+        "simplified project root — a missing boundary check lets encoded "
+        "traversal payloads through even after `..` substring rejection."
+    )
+
+
+def test_script_handler_uses_path_validator_at_every_entry_point() -> None:
+    """Every handler entry that takes a `path` param must delegate to McpPathValidator.
+
+    Drift here is a security regression — if a future change re-inlines the
+    bare prefix check, agent input flows back into the file write/read
+    primitives without the `..` and boundary guards.
+    """
+    source = SCRIPT_HANDLER.read_text()
+    # No bare prefix check remains in this file.
+    assert 'begins_with("res://")' not in source, (
+        'script_handler.gd must not contain bare `begins_with("res://")` '
+        "checks — replace with McpPathValidator.validate_resource_path."
+    )
+    # Each listed entry point (issue #347) calls the validator.
+    for func_name in ("create_script", "read_script", "patch_script", "find_symbols"):
+        assert f"func {func_name}" in source, f"{func_name} missing from script_handler"
+    # The validator helper is referenced — surface area covers all four entry
+    # points; counting calls catches a partial revert.
+    validator_calls = source.count("McpPathValidator.validate_resource_path")
+    assert validator_calls >= 4, (
+        f"script_handler.gd should call McpPathValidator.validate_resource_path "
+        f"at least 4 times (create_script, read_script, patch_script, find_symbols); "
+        f"found {validator_calls}"
+    )
+
+
+def test_filesystem_handler_uses_path_validator_at_every_entry_point() -> None:
+    source = FILESYSTEM_HANDLER.read_text()
+    assert 'begins_with("res://")' not in source, (
+        'filesystem_handler.gd must not contain bare `begins_with("res://")` '
+        "checks — replace with McpPathValidator.validate_resource_path."
+    )
+    for func_name in ("read_file", "write_file", "reimport"):
+        assert f"func {func_name}" in source
+    validator_calls = source.count("McpPathValidator.validate_resource_path")
+    assert validator_calls >= 3, (
+        f"filesystem_handler.gd should call McpPathValidator.validate_resource_path "
+        f"at least 3 times (read_file, write_file, reimport); found {validator_calls}"
+    )


### PR DESCRIPTION
## Summary

Closes #347 — audit-v2 P1 finding #3 from umbrella #343.

`script_handler.gd` and `filesystem_handler.gd` validated agent-supplied
paths only with `path.begins_with("res://")`. That accepts payloads like
`res://../etc/passwd.gd`; whether Godot rejects them depends on platform/
version. Combined with LLM-driven path generation (prompt injection,
agent typos, untrusted issue/PR text in context), this is a real escape
vector for the only write tools that produce arbitrary disk content
(`script_create`, `filesystem_write_text`, `patch_script`) and for the
matching reads (info-disclosure surface).

## Fix

Adds `plugin/addons/godot_ai/utils/path_validator.gd` →
`McpPathValidator.validate_resource_path(path)` with the four layers
called for in the issue's fix shape:

1. non-empty
2. `path.begins_with("res://")`
3. no `..` substring (cheap defence-in-depth)
4. `ProjectSettings.globalize_path(path).simplify_path()` must still
   resolve under `globalize_path("res://").simplify_path()` (boundary
   verification with trailing-slash handling so `/proj_evil/...` can't
   pretend to be inside `/proj`)

Migrates every prefix-check call site named in #347:

- `script_handler.gd` lines 31 / 122 / 157 / 289 →
  `create_script`, `read_script`, `patch_script`, `find_symbols`
- `filesystem_handler.gd` lines 13 / 43 / 90 →
  `read_file`, `write_file`, `reimport` (per-path inside the loop)

No bare `begins_with("res://")` remains in either handler.

## Tests

- `test_project/tests/test_path_validator.gd` — McpTestSuite covering
  happy path, prefix variants (`user://` rejected), and four traversal
  shapes including the exact `res://../etc/passwd.gd` payload from the
  audit body.
- `test_project/tests/test_script.gd` / `test_filesystem.gd` — per-
  handler regression tests asserting `INVALID_PARAMS` on the traversal
  payload at every entry point. The two write tests also assert no
  file landed on disk outside the project root.
- `tests/unit/test_path_traversal_guard.py` — source-structure pytest
  (5 tests) pinning the validator's existence, all four required check
  layers, and the absence of bare `begins_with("res://")` patterns in
  the affected handlers. Drift here would silently weaken the security
  boundary without any single behavioural test catching it.

## Test plan

- [x] `ruff check src/ tests/` clean
- [x] `ruff format` applied to the new test file (other files have
      pre-existing format drift on beta — not touched)
- [x] `pytest -q` — 772 passed (5 new)
- [x] `script/ci-check-gdscript` — all GDScript files OK (the new
      validator + test suite parse cleanly)
- [ ] Live editor `test_run` via MCP — not feasible from this sandboxed
      CLI session (the running godot is `--headless` without the
      `GODOT_AI_ALLOW_HEADLESS=1` override, so the plugin returns
      early). The Godot CI matrix (Linux + macOS + Windows) will
      exercise the new `path_validator` suite and the new handler
      regression tests on PR.

## Scope

Per the audit prompt's "One audit finding == one PR" rule, only the
seven sites named in #347 are migrated. Other handlers
(`scene_handler.gd`, `theme_handler.gd`, `resource_handler.gd`,
`autoload_handler.gd`, `material_handler.gd`, `audio_handler.gd`,
`ui_handler.gd`, `node_handler.gd`) still carry the bare
`begins_with("res://")` pattern; if a future audit finding promotes
them, the validator is already there to delegate to.

Blocks #355 (audit-v2 #11) only inasmuch as #355 references finding #1
(WebSocket auth/Origin) — independent of this PR.

Part of #343.

https://claude.ai/code/session_01LYwesbn3B7LzLvcV2mPQTV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LYwesbn3B7LzLvcV2mPQTV)_