### PR TITLE
Harden WebSocket transport: pending-Future leak + duplicate-ID handshake reject

### DIFF
--- a/src/godot_ai/transport/websocket.py
+++ b/src/godot_ai/transport/websocket.py
@@ -20,6 +20,11 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_PORT = 9500
 
+## RFC 6455 reserves 4000-4999 for application-defined close codes; we use
+## 4001 to flag a handshake rejected for duplicate session_id so a debugging
+## peer can distinguish it from a normal close.
+_CLOSE_CODE_DUPLICATE_SESSION = 4001
+
 
 class GodotWebSocketServer:
     """Accepts connections from Godot editor plugins and routes commands."""
@@ -61,6 +66,23 @@ class GodotWebSocketServer:
             raw = await asyncio.wait_for(ws.recv(), timeout=10.0)
             data = json.loads(raw)
             handshake = HandshakeMessage.model_validate(data)
+
+            ## Reject duplicate session_id while the first peer is live —
+            ## otherwise the second handshake silently overwrites the
+            ## routing map (duplicate-ID hijack).
+            existing = self.registry.get(handshake.session_id)
+            if existing is not None:
+                logger.warning(
+                    "Rejecting duplicate handshake for session %s (existing pid=%s, project=%s)",
+                    handshake.session_id,
+                    existing.editor_pid,
+                    existing.project_path,
+                )
+                await ws.close(
+                    code=_CLOSE_CODE_DUPLICATE_SESSION,
+                    reason="session id already registered",
+                )
+                return
 
             session_id = handshake.session_id
             session = Session(
@@ -159,12 +181,16 @@ class GodotWebSocketServer:
         future: asyncio.Future[CommandResponse] = asyncio.get_running_loop().create_future()
         self._pending[request.request_id] = future
 
-        await ws.send(request.model_dump_json())
-
+        ## Always pop on exit — the response receiver in _handle_connection
+        ## pops on the happy path, so this is a no-op there; on `ws.send`
+        ## raise / TimeoutError / cancellation it prevents Futures leaking
+        ## into _pending forever.
         try:
+            await ws.send(request.model_dump_json())
             return await asyncio.wait_for(future, timeout=timeout)
         except asyncio.TimeoutError:
-            self._pending.pop(request.request_id, None)
             raise TimeoutError(
                 f"Command {command} timed out after {timeout}s on session {session_id}"
             )
+        finally:
+            self._pending.pop(request.request_id, None)

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -2067,9 +2067,7 @@ class TestPhysicsShapeAutofitTool:
         assert result.data["shape_created"] is True
         assert result.data["size"]["x"] == 2.0
 
-    async def test_ambiguous_visual_candidates_preserved_in_structured_error(
-        self, mcp_stack
-    ):
+    async def test_ambiguous_visual_candidates_preserved_in_structured_error(self, mcp_stack):
         client, plugin = mcp_stack
         candidates = ["/Main/VisualA", "/Main/VisualB"]
 
@@ -3328,6 +3326,7 @@ class TestPerCallSessionRouting:
         client, plugin_a = mcp_stack
         plugin_b = await self._connect_second_plugin("proj-b@0002")
         try:
+
             async def respond_a():
                 cmd = await plugin_a.recv_command()
                 assert cmd["command"] == "get_open_scenes"

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -561,6 +561,127 @@ class TestDnsRebindingGuard:
         assert len(harness.registry) == before
 
 
+# ---------------------------------------------------------------------------
+# Duplicate-ID handshake hardening (#343 finding #2)
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicateHandshake:
+    async def test_duplicate_session_id_handshake_is_rejected(self, harness):
+        ## Without rejection, a second handshake with the same session_id
+        ## silently overwrites both `_connections[session_id]` and the
+        ## registry entry — routing every subsequent command to the
+        ## attacker. session_id is `<slug>@<4hex>` so 16 bits of suffix is
+        ## locally guessable. Reject keeps the first peer authoritative.
+        first = await harness.connect_plugin(session_id="dup-target")
+        original_session = harness.registry.get("dup-target")
+        assert original_session is not None
+        original_pid = original_session.editor_pid
+
+        ## Hand-roll the second handshake so we observe the close on the
+        ## wire — `connect_plugin()` would assert on the missing ack.
+        ws2 = await websockets.connect(f"ws://127.0.0.1:{harness.port}")
+        await ws2.send(
+            json.dumps(
+                {
+                    "type": "handshake",
+                    "session_id": "dup-target",
+                    "godot_version": "4.4.1",
+                    "project_path": "/tmp/attacker",
+                    "plugin_version": "0.0.1",
+                    "protocol_version": 1,
+                    "readiness": "ready",
+                    "editor_pid": 9999,
+                }
+            )
+        )
+
+        ## Server should close us before sending an ack. Drain until the WS
+        ## reports closed; recv() will raise ConnectionClosed.
+        with pytest.raises(websockets.ConnectionClosed):
+            await asyncio.wait_for(ws2.recv(), timeout=2.0)
+
+        ## Original session must still be live and unaffected.
+        live = harness.registry.get("dup-target")
+        assert live is original_session, "registry entry was overwritten by duplicate"
+        assert live.editor_pid == original_pid
+        assert live.project_path != "/tmp/attacker"
+
+        ## Round-trip a command through the original to prove its WS is
+        ## still wired to the routing map (regression: silent overwrite
+        ## also hijacks `_connections[session_id]`).
+        client = GodotClient(harness.server, harness.registry)
+
+        async def mock_handler():
+            cmd = await first.recv_command()
+            await first.send_response(cmd["request_id"], {"alive": True})
+
+        handler = asyncio.create_task(mock_handler())
+        result = await client.send("ping", session_id="dup-target")
+        await handler
+        assert result == {"alive": True}
+
+        await first.close()
+
+    async def test_reconnect_after_clean_disconnect_succeeds(self, harness):
+        ## The reject must not break the legitimate plugin reconnect path
+        ## (e.g. after `editor_reload_plugin`): close → unregister →
+        ## fresh connect with the same session_id should succeed because
+        ## the registry entry has already been removed.
+        first = await harness.connect_plugin(session_id="reconnect-1")
+        await first.close()
+        await asyncio.sleep(0.1)  # let server process disconnect
+        assert harness.registry.get("reconnect-1") is None
+
+        second = await harness.connect_plugin(session_id="reconnect-1")
+        assert harness.registry.get("reconnect-1") is not None
+        await second.close()
+
+
+# ---------------------------------------------------------------------------
+# send_command pending-Future leak (#343 finding #5)
+# ---------------------------------------------------------------------------
+
+
+class TestPendingFutureCleanup:
+    async def test_timeout_pops_pending_entry(self, harness):
+        ## TimeoutError path always cleared the pending dict; this test
+        ## pins that behavior so a future refactor doesn't regress it.
+        plugin = await harness.connect_plugin(session_id="leak-timeout")
+        client = GodotClient(harness.server, harness.registry)
+
+        with pytest.raises(TimeoutError):
+            await client.send("never_responded", timeout=0.1)
+
+        assert harness.server._pending == {}, "TimeoutError should not leave entries in _pending"
+        await plugin.close()
+
+    async def test_send_failure_pops_pending_entry(self, harness):
+        ## If `ws.send` raises (e.g. ConnectionClosed mid-send), the
+        ## pending Future was previously leaked into `_pending` forever.
+        ## Force the failure by replacing the connection's send with one
+        ## that raises after the pending entry has been registered.
+        plugin = await harness.connect_plugin(session_id="leak-send")
+
+        ws = harness.server._connections["leak-send"]
+        boom = ConnectionError("simulated mid-send transport error")
+
+        async def raising_send(_payload: str) -> None:
+            raise boom
+
+        ws.send = raising_send  # type: ignore[assignment]
+
+        with pytest.raises(ConnectionError):
+            await harness.server.send_command(
+                session_id="leak-send",
+                command="will_fail",
+                timeout=1.0,
+            )
+
+        assert harness.server._pending == {}, "send-time exception must not leak _pending entries"
+        await plugin.close()
+
+
 # --- Issue #262: editor_state self-heals a stale "playing" cache ---
 
 

--- a/tests/unit/test_gdscript_no_adjacent_string_concat.py
+++ b/tests/unit/test_gdscript_no_adjacent_string_concat.py
@@ -151,11 +151,7 @@ def test_no_python_style_adjacent_string_concat_in_gdscript() -> None:
 
 def test_detector_flags_canonical_multiline_bug_pattern() -> None:
     """The exact shape from PR #236 must be detected."""
-    src = (
-        "assert_false(cond,\n"
-        '    "first half - "\n'
-        '    "second half")\n'
-    )
+    src = 'assert_false(cond,\n    "first half - "\n    "second half")\n'
     hits = _find_adjacent_string_pairs(src)
     assert len(hits) == 1, f"expected 1 hit, got {hits}"
     (prev_line, _), (cur_line, _) = hits[0]


### PR DESCRIPTION
## Summary

Two small audit-v2 hardening fixes from #343 in `src/godot_ai/transport/websocket.py`. Each is independently scoped and pinned by a regression test; bundled because they're tightly themed (transport-layer hardening, ~30 LOC of code).

Closes findings **#2** and **#5** of #343.

> **Note:** Originally also covered finding **#4** (errno portability), but that landed separately via PR #373 (`8e3a812`) while this PR was being prepared. Rebased; my errno changes are gone, my redundant errno test is deleted, and the umbrella issue (#343) is being updated to reflect what's already in beta.

## Fixes

### #5 (P2) — `send_command` pending-Future leak

`send_command` registered `self._pending[request.request_id] = future` then awaited `ws.send(...)`. If `ws.send` raised (`ConnectionClosed` mid-send, transport error, cancellation), the pending entry was never popped and the dict grew unbounded under churn. Wrapped the send + wait in `try/finally: self._pending.pop(...)`; the response receiver still pops on the happy path so the finally is a no-op there.

### #2 (P1) — Duplicate-ID handshake hijack

`_handle_connection` registered the inbound peer with `session_id = handshake.session_id`, silently overwriting both the registry entry and `_connections[session_id]` when the same ID was already present. session_id format is `<slug>@<4hex>` — 16 bits of suffix is locally guessable, so any local peer could hijack an active session by sending a handshake with the same ID; subsequent MCP commands would route to the impostor.

Now `_handle_connection` checks `registry.get(handshake.session_id)` and rejects with WebSocket close code `4001` (RFC 6455 application-defined range) plus a structured warning log naming the existing peer's PID and project. Legitimate plugin reconnect after `editor_reload_plugin` first triggers `ConnectionClosed` → `unregister`, so the new connect still lands cleanly — pinned by `test_reconnect_after_clean_disconnect_succeeds`.

## Tests

New in `tests/integration/test_websocket.py`:
- `TestDuplicateHandshake` — pins both the reject path and the legitimate-reconnect path.
- `TestPendingFutureCleanup` — pins both the timeout-pop and the send-raise pop behaviors (the latter monkey-patches `ws.send` to force a synthetic `ConnectionError` after the pending entry is registered).

Drive-by: also includes a small `ruff format` cleanup to two pre-existing test files (`test_mcp_tools.py`, `test_gdscript_no_adjacent_string_concat.py`) so format-check stays green on the touched-area files. Pure whitespace.

Existing on `beta`: 783 passed.

## Live smoke

Spawned a real Godot 4.6.2 editor against `test_project/`, opened `main.tscn`, ran via the streamable-HTTP MCP transport:

- `editor_state` → `readiness=ready` ✓
- `test_run` → **1037/1040 passed, 0 failed** ✓
- Duplicate-ID handshake against the live session's own ID → server closed the WS with code **4001** and reason `'session id already registered'` ✓
- `editor_state` after the rejected hijack → still `readiness=ready` (original session unaffected) ✓
- Server log: `Rejecting duplicate handshake for session test-project@307e (existing pid=21071, project=/home/user/godot-ai/test_project/)` ✓

## What's NOT closed

See the status comment on #343 for the full follow-up list. Big remaining items: #1 (auth/Origin gap), #7 (Pydantic-validate WS events), #16/17 (refactors). Bundleable next sweep: #8 + #11 + #12.

## Test plan

- [x] `ruff check src/ tests/` clean
- [x] `ruff format --check` clean for the touched-area files
- [x] `pytest -q` — 783 passed
- [x] Live MCP `test_run` against Godot 4.6.2 editor — 1037/1040 passed, 0 failed
- [x] Live duplicate-ID handshake reject smoke — 4001 close received, original session unaffected

https://claude.ai/code/session_016ijmCD5S6QfwJGJcc5Wirp