### PR TITLE
[Audit v2 #345] Reject non-loopback Host/Origin (DNS-rebinding guard)

### DIFF
--- a/src/godot_ai/server.py
+++ b/src/godot_ai/server.py
@@ -51,6 +51,7 @@ from godot_ai.tools.signal import register_signal_tools
 from godot_ai.tools.testing import register_testing_tools
 from godot_ai.tools.theme import register_theme_tools
 from godot_ai.tools.ui import register_ui_tools
+from godot_ai.transport.origin_guard import LocalhostOnlyHTTPMiddleware
 from godot_ai.transport.websocket import GodotWebSocketServer
 
 logger = logging.getLogger(__name__)
@@ -70,8 +71,12 @@ class GodotAIFastMCP(FastMCP):
         app = super().http_app(*args, **kwargs)
         transport = kwargs.get("transport", "http")
         if transport in ("http", "streamable-http"):
-            return StaleMcpSessionDiagnosticMiddleware(app)
-        return app
+            app = StaleMcpSessionDiagnosticMiddleware(app)
+        ## Outermost wrap: refuse non-loopback Host/Origin (DNS-rebinding
+        ## guard, audit-v2 finding #1). Applied to every HTTP transport
+        ## including ``sse`` so ``/godot-ai/status`` and the FastMCP
+        ## endpoints are guarded uniformly.
+        return LocalhostOnlyHTTPMiddleware(app)
 
 
 def create_server(

--- a/src/godot_ai/transport/origin_guard.py
+++ b/src/godot_ai/transport/origin_guard.py
@@ -16,14 +16,24 @@ requests *before* the WebSocket upgrade runs or any HTTP route fires:
   form for IPv6 in HTTP/1.1 Host headers, so a bare ``::1`` is not
   accepted (would be a malformed request).
 - ``Origin`` is validated only when present (native non-browser clients
-  omit it). A present Origin must be empty, the literal ``null`` (file://
-  / sandboxed contexts), or a URL whose hostname matches the loopback
-  allowlist.
+  omit it). A present Origin must be empty or a URL whose hostname
+  matches the loopback allowlist. ``Origin: null`` is **rejected** —
+  browsers emit it from sandboxed iframes and downloaded ``file://``
+  pages, which is exactly the rebinding-bypass shape. Native clients
+  do not produce ``null`` (they omit Origin entirely).
+- ``Sec-Fetch-Site`` is also checked when present: any value other than
+  ``same-origin`` / ``none`` (i.e. browser-issued cross-origin
+  subresources or navigations from a foreign page) is refused. This
+  catches `<img src=...>` / `<link>` / `<script>` liveness oracles
+  against ``/godot-ai/status``, where browsers send a loopback ``Host``
+  and *no* ``Origin`` for "no-cors" subresource loads. Native clients
+  never send ``Sec-Fetch-*`` (it's a Fetch-Metadata header set only by
+  browsers), so missing means "allow".
 
 Native clients (the Godot plugin, the FastMCP CLI client, ``curl`` with
-no ``-H Origin``) keep working unchanged. Browser-driven traffic from any
-non-loopback origin is refused with HTTP 403 long before reaching FastMCP
-or our session registry.
+no ``-H Origin``) keep working unchanged. Browser-driven traffic — even
+``no-cors`` subresources that wouldn't carry an Origin — is refused with
+HTTP 403 long before reaching FastMCP or our session registry.
 
 See umbrella #343, finding #1 (audit-v2).
 """
@@ -46,17 +56,33 @@ FORBIDDEN_BODY = (
 FORBIDDEN_BODY_TEXT = FORBIDDEN_BODY.decode("utf-8")
 
 
-def _strip_port(host: str) -> str:
-    """Return ``host`` with a trailing ``:port`` stripped.
+## Sec-Fetch-Site values that indicate the request is browser-driven and
+## NOT a top-level navigation or same-origin operation. Modern browsers
+## always send Sec-Fetch-Site on HTTP requests (including ``no-cors``
+## subresources like ``<img>`` / ``<script>`` / ``<link>`` that carry
+## *no* Origin); native non-browser clients never send it.
+SEC_FETCH_SITE_FOREIGN: frozenset[str] = frozenset({"cross-site", "same-site"})
 
-    Handles bracketed IPv6 (``[::1]:9500`` → ``[::1]``) and bare-name
-    forms (``localhost:8000`` → ``localhost``).
+
+def _normalise_host(host: str) -> str:
+    """Return ``host`` with a trailing ``:port`` stripped, lowercased,
+    and with any single trailing DNS root dot removed.
+
+    Handles bracketed IPv6 (``[::1]:9500`` → ``[::1]``), bare-name forms
+    (``LOCALHOST:8000`` → ``localhost``), and the rare-but-valid trailing
+    dot (``localhost.`` → ``localhost``) so the allowlist lookup is
+    independent of caller punctuation.
     """
     if not host:
         return host
     if host.startswith("[") and "]" in host:
-        return host[: host.index("]") + 1]
-    return host.split(":", 1)[0]
+        without_port = host[: host.index("]") + 1]
+    else:
+        without_port = host.split(":", 1)[0]
+    normalised = without_port.lower()
+    if normalised.endswith(".") and not normalised.endswith(".]"):
+        normalised = normalised.rstrip(".")
+    return normalised
 
 
 def is_allowed_host(host_header: str | None) -> bool:
@@ -68,21 +94,25 @@ def is_allowed_host(host_header: str | None) -> bool:
     """
     if not host_header:
         return False
-    return _strip_port(host_header.strip()).lower() in LOOPBACK_HOSTNAMES
+    return _normalise_host(host_header.strip()) in LOOPBACK_HOSTNAMES
 
 
 def is_allowed_origin(origin_header: str | None) -> bool:
     """Whether ``origin_header`` is absent or names a loopback URL.
 
-    Native clients do not send Origin. Browsers always do, and sandboxed
-    or file:// contexts send ``Origin: null``. Both are accepted; any
-    other origin must parse to a URL whose hostname is loopback.
+    Native clients do not send Origin. Browsers always do, and the
+    request is rejected unless the Origin parses to a loopback URL.
+    ``Origin: null`` is rejected — sandboxed iframes and downloaded
+    ``file://`` pages emit it, which is the exact bypass an attacker
+    would use to bridge a foreign origin onto our loopback socket.
     """
     if origin_header is None:
         return True
     value = origin_header.strip()
-    if not value or value.lower() == "null":
+    if not value:
         return True
+    if value.lower() == "null":
+        return False
     parsed = urlsplit(value)
     ## ``urlsplit`` already lowercases the scheme per RFC 3986, so no
     ## extra normalization is needed before the set lookup.
@@ -90,26 +120,54 @@ def is_allowed_origin(origin_header: str | None) -> bool:
         return False
     if not parsed.hostname:
         return False
-    hostname = parsed.hostname.lower()
+    hostname = parsed.hostname.lower().rstrip(".")
     # urlsplit strips IPv6 brackets — re-add for the bracketed-form lookup.
     bracketed = f"[{hostname}]" if ":" in hostname else hostname
     return hostname in LOOPBACK_HOSTNAMES or bracketed in LOOPBACK_HOSTNAMES
 
 
-def evaluate_loopback(hosts: list[str], origins: list[str]) -> bool:
-    """Return True iff the request's Host/Origin headers pass the allowlist.
+def is_allowed_sec_fetch_site(value: str | None) -> bool:
+    """Whether the ``Sec-Fetch-Site`` header indicates a non-foreign request.
+
+    Modern browsers stamp every HTTP request with one of ``cross-site``,
+    ``same-site``, ``same-origin`` or ``none`` (top-level navigation /
+    bookmark). Native clients never send it. Treat missing as "allow"
+    (native client) and the foreign values as "reject" — the rest of the
+    allowlist still has to pass, this is just an early-out for the
+    `<img src=...>` / `<script src=...>` cross-origin probe shape that
+    would otherwise slip past a loopback Host / missing Origin.
+    """
+    if value is None:
+        return True
+    return value.strip().lower() not in SEC_FETCH_SITE_FOREIGN
+
+
+def evaluate_loopback(
+    hosts: list[str],
+    origins: list[str],
+    sec_fetch_sites: list[str] | None = None,
+) -> bool:
+    """Return True iff the request's headers pass the allowlist.
 
     Both transports (ASGI middleware + WebSocket ``process_request``)
     funnel their per-request header extraction through this helper so
-    the duplicate-header smuggling rule and the value-allowlist rule
-    are evaluated identically. A divergence between the two transports
-    would be a security regression — this helper exists to prevent it.
+    the duplicate-header smuggling rule, the value-allowlist rule, and
+    the Sec-Fetch-Site cross-origin reject rule are evaluated identically.
+    A divergence between the two transports would be a security
+    regression — this helper exists to prevent it.
     """
     if len(hosts) > 1 or len(origins) > 1:
         return False
+    if sec_fetch_sites and len(sec_fetch_sites) > 1:
+        return False
     host = hosts[0] if hosts else None
     origin = origins[0] if origins else None
-    return is_allowed_host(host) and is_allowed_origin(origin)
+    sec_fetch_site = sec_fetch_sites[0] if sec_fetch_sites else None
+    return (
+        is_allowed_host(host)
+        and is_allowed_origin(origin)
+        and is_allowed_sec_fetch_site(sec_fetch_site)
+    )
 
 
 class LocalhostOnlyHTTPMiddleware:
@@ -135,14 +193,17 @@ class LocalhostOnlyHTTPMiddleware:
 
         hosts: list[str] = []
         origins: list[str] = []
+        sec_fetch_sites: list[str] = []
         for raw_key, raw_value in scope.get("headers", []):
             key = raw_key.lower()
             if key == b"host":
                 hosts.append(raw_value.decode("latin-1"))
             elif key == b"origin":
                 origins.append(raw_value.decode("latin-1"))
+            elif key == b"sec-fetch-site":
+                sec_fetch_sites.append(raw_value.decode("latin-1"))
 
-        if evaluate_loopback(hosts, origins):
+        if evaluate_loopback(hosts, origins, sec_fetch_sites):
             await self.app(scope, receive, send)
             return
         await _send_forbidden(send)
@@ -178,7 +239,8 @@ def make_websocket_request_guard():
         ## ``request.headers.get(...)`` and surfacing as an opaque 500.
         hosts = list(request.headers.get_all("Host"))
         origins = list(request.headers.get_all("Origin"))
-        if evaluate_loopback(hosts, origins):
+        sec_fetch_sites = list(request.headers.get_all("Sec-Fetch-Site"))
+        if evaluate_loopback(hosts, origins, sec_fetch_sites):
             return None
         return connection.respond(HTTPStatus.FORBIDDEN, FORBIDDEN_BODY_TEXT)
 

--- a/src/godot_ai/transport/origin_guard.py
+++ b/src/godot_ai/transport/origin_guard.py
@@ -1,0 +1,189 @@
+"""Loopback Host/Origin guard for the WebSocket and HTTP transports.
+
+The WebSocket server binds to ``127.0.0.1`` and the streamable-HTTP
+transport likewise. That stops *direct* off-host traffic but does not
+stop a browser tab on a malicious origin from mounting **DNS rebinding**:
+the browser resolves ``attacker.example.com`` to ``127.0.0.1`` and then
+issues ``new WebSocket("ws://attacker.example.com:9500")``. The request
+lands on our loopback socket carrying a non-localhost ``Host`` (and
+``Origin``) header.
+
+This module enforces a Host/Origin allowlist that rejects those rebound
+requests *before* the WebSocket upgrade runs or any HTTP route fires:
+
+- ``Host`` must resolve to one of ``127.0.0.1``, ``localhost`` or
+  ``[::1]`` — with an optional ``:port``. RFC 7230 requires bracketed
+  form for IPv6 in HTTP/1.1 Host headers, so a bare ``::1`` is not
+  accepted (would be a malformed request).
+- ``Origin`` is validated only when present (native non-browser clients
+  omit it). A present Origin must be empty, the literal ``null`` (file://
+  / sandboxed contexts), or a URL whose hostname matches the loopback
+  allowlist.
+
+Native clients (the Godot plugin, the FastMCP CLI client, ``curl`` with
+no ``-H Origin``) keep working unchanged. Browser-driven traffic from any
+non-loopback origin is refused with HTTP 403 long before reaching FastMCP
+or our session registry.
+
+See umbrella #343, finding #1 (audit-v2).
+"""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import urlsplit
+
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+LOOPBACK_HOSTNAMES: frozenset[str] = frozenset({"127.0.0.1", "localhost", "[::1]"})
+LOOPBACK_ORIGIN_SCHEMES: frozenset[str] = frozenset({"http", "https", "ws", "wss"})
+
+FORBIDDEN_BODY = (
+    b"forbidden: non-loopback Host or Origin (DNS rebinding guard)\n"
+    b"see https://github.com/hi-godot/godot-ai issue #345 for details\n"
+)
+
+
+def _strip_port(host: str) -> str:
+    """Return ``host`` with a trailing ``:port`` stripped.
+
+    Handles bracketed IPv6 (``[::1]:9500`` → ``[::1]``) and bare-name
+    forms (``localhost:8000`` → ``localhost``).
+    """
+    if not host:
+        return host
+    if host.startswith("[") and "]" in host:
+        return host[: host.index("]") + 1]
+    return host.split(":", 1)[0]
+
+
+def is_allowed_host(host_header: str | None) -> bool:
+    """Whether ``host_header`` resolves to a loopback name.
+
+    Empty or missing returns False — a properly formed HTTP/1.1 request
+    always carries a Host header, and refusing the request is safer than
+    guessing. The WebSocket guard mirrors this.
+    """
+    if not host_header:
+        return False
+    return _strip_port(host_header.strip()).lower() in LOOPBACK_HOSTNAMES
+
+
+def is_allowed_origin(origin_header: str | None) -> bool:
+    """Whether ``origin_header`` is absent or names a loopback URL.
+
+    Native clients do not send Origin. Browsers always do, and sandboxed
+    or file:// contexts send ``Origin: null``. Both are accepted; any
+    other origin must parse to a URL whose hostname is loopback.
+    """
+    if origin_header is None:
+        return True
+    value = origin_header.strip()
+    if not value or value.lower() == "null":
+        return True
+    parsed = urlsplit(value)
+    if parsed.scheme.lower() not in LOOPBACK_ORIGIN_SCHEMES:
+        return False
+    if not parsed.hostname:
+        return False
+    hostname = parsed.hostname.lower()
+    # urlsplit strips IPv6 brackets — re-add for the bracketed-form lookup.
+    bracketed = f"[{hostname}]" if ":" in hostname else hostname
+    return hostname in LOOPBACK_HOSTNAMES or bracketed in LOOPBACK_HOSTNAMES
+
+
+class LocalhostOnlyHTTPMiddleware:
+    """ASGI middleware that rejects HTTP requests off the loopback allowlist.
+
+    Wraps the FastMCP ASGI app so the guard runs *before* the MCP
+    streamable-HTTP session manager, before ``/godot-ai/status``, and
+    before any inner middleware. Non-HTTP scopes (lifespan) pass through.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    def __getattr__(self, name: str) -> Any:
+        # Mirror StaleMcpSessionDiagnosticMiddleware: FastMCP / uvicorn
+        # introspect attributes (e.g. ``state``) on the wrapped ASGI app.
+        return getattr(self.app, name)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        host_count = 0
+        origin_count = 0
+        host: str | None = None
+        origin: str | None = None
+        for raw_key, raw_value in scope.get("headers", []):
+            key = raw_key.lower()
+            if key == b"host":
+                host_count += 1
+                host = raw_value.decode("latin-1")
+            elif key == b"origin":
+                origin_count += 1
+                origin = raw_value.decode("latin-1")
+
+        ## Duplicate Host or Origin headers fail closed: a single request
+        ## carrying both a loopback and a non-loopback value is ambiguous,
+        ## a classic HTTP smuggling shape, and never legitimate for our
+        ## clients.
+        if host_count > 1 or origin_count > 1:
+            await _send_forbidden(send)
+            return
+
+        if is_allowed_host(host) and is_allowed_origin(origin):
+            await self.app(scope, receive, send)
+            return
+
+        await _send_forbidden(send)
+
+
+async def _send_forbidden(send: Send) -> None:
+    await send(
+        {
+            "type": "http.response.start",
+            "status": HTTPStatus.FORBIDDEN,
+            "headers": [
+                (b"content-type", b"text/plain; charset=utf-8"),
+                (b"content-length", str(len(FORBIDDEN_BODY)).encode("ascii")),
+            ],
+        }
+    )
+    await send({"type": "http.response.body", "body": FORBIDDEN_BODY, "more_body": False})
+
+
+def make_websocket_request_guard():
+    """Return a ``process_request`` hook for ``websockets.asyncio.server.serve``.
+
+    The hook fires before the WebSocket upgrade. When Host or Origin
+    fails the loopback allowlist the hook synthesizes an HTTP 403 via
+    ``connection.respond(...)``; returning that response from
+    ``process_request`` aborts the upgrade without ever creating a
+    Session.
+    """
+
+    async def guard(connection, request):
+        ## Use ``get_all`` so a smuggled duplicate (two ``Host:`` lines)
+        ## fails closed rather than tripping ``MultipleValuesError`` at
+        ## ``request.headers.get(...)`` and surfacing as an opaque 500.
+        hosts = request.headers.get_all("Host")
+        origins = request.headers.get_all("Origin")
+        if len(hosts) > 1 or len(origins) > 1:
+            return connection.respond(
+                HTTPStatus.FORBIDDEN,
+                FORBIDDEN_BODY.decode("utf-8"),
+            )
+        host = hosts[0] if hosts else None
+        origin = origins[0] if origins else None
+        if is_allowed_host(host) and is_allowed_origin(origin):
+            return None
+        return connection.respond(
+            HTTPStatus.FORBIDDEN,
+            FORBIDDEN_BODY.decode("utf-8"),
+        )
+
+    return guard

--- a/src/godot_ai/transport/origin_guard.py
+++ b/src/godot_ai/transport/origin_guard.py
@@ -43,6 +43,7 @@ FORBIDDEN_BODY = (
     b"forbidden: non-loopback Host or Origin (DNS rebinding guard)\n"
     b"see https://github.com/hi-godot/godot-ai issue #345 for details\n"
 )
+FORBIDDEN_BODY_TEXT = FORBIDDEN_BODY.decode("utf-8")
 
 
 def _strip_port(host: str) -> str:
@@ -83,7 +84,9 @@ def is_allowed_origin(origin_header: str | None) -> bool:
     if not value or value.lower() == "null":
         return True
     parsed = urlsplit(value)
-    if parsed.scheme.lower() not in LOOPBACK_ORIGIN_SCHEMES:
+    ## ``urlsplit`` already lowercases the scheme per RFC 3986, so no
+    ## extra normalization is needed before the set lookup.
+    if parsed.scheme not in LOOPBACK_ORIGIN_SCHEMES:
         return False
     if not parsed.hostname:
         return False
@@ -91,6 +94,22 @@ def is_allowed_origin(origin_header: str | None) -> bool:
     # urlsplit strips IPv6 brackets — re-add for the bracketed-form lookup.
     bracketed = f"[{hostname}]" if ":" in hostname else hostname
     return hostname in LOOPBACK_HOSTNAMES or bracketed in LOOPBACK_HOSTNAMES
+
+
+def evaluate_loopback(hosts: list[str], origins: list[str]) -> bool:
+    """Return True iff the request's Host/Origin headers pass the allowlist.
+
+    Both transports (ASGI middleware + WebSocket ``process_request``)
+    funnel their per-request header extraction through this helper so
+    the duplicate-header smuggling rule and the value-allowlist rule
+    are evaluated identically. A divergence between the two transports
+    would be a security regression — this helper exists to prevent it.
+    """
+    if len(hosts) > 1 or len(origins) > 1:
+        return False
+    host = hosts[0] if hosts else None
+    origin = origins[0] if origins else None
+    return is_allowed_host(host) and is_allowed_origin(origin)
 
 
 class LocalhostOnlyHTTPMiddleware:
@@ -114,31 +133,18 @@ class LocalhostOnlyHTTPMiddleware:
             await self.app(scope, receive, send)
             return
 
-        host_count = 0
-        origin_count = 0
-        host: str | None = None
-        origin: str | None = None
+        hosts: list[str] = []
+        origins: list[str] = []
         for raw_key, raw_value in scope.get("headers", []):
             key = raw_key.lower()
             if key == b"host":
-                host_count += 1
-                host = raw_value.decode("latin-1")
+                hosts.append(raw_value.decode("latin-1"))
             elif key == b"origin":
-                origin_count += 1
-                origin = raw_value.decode("latin-1")
+                origins.append(raw_value.decode("latin-1"))
 
-        ## Duplicate Host or Origin headers fail closed: a single request
-        ## carrying both a loopback and a non-loopback value is ambiguous,
-        ## a classic HTTP smuggling shape, and never legitimate for our
-        ## clients.
-        if host_count > 1 or origin_count > 1:
-            await _send_forbidden(send)
-            return
-
-        if is_allowed_host(host) and is_allowed_origin(origin):
+        if evaluate_loopback(hosts, origins):
             await self.app(scope, receive, send)
             return
-
         await _send_forbidden(send)
 
 
@@ -170,20 +176,10 @@ def make_websocket_request_guard():
         ## Use ``get_all`` so a smuggled duplicate (two ``Host:`` lines)
         ## fails closed rather than tripping ``MultipleValuesError`` at
         ## ``request.headers.get(...)`` and surfacing as an opaque 500.
-        hosts = request.headers.get_all("Host")
-        origins = request.headers.get_all("Origin")
-        if len(hosts) > 1 or len(origins) > 1:
-            return connection.respond(
-                HTTPStatus.FORBIDDEN,
-                FORBIDDEN_BODY.decode("utf-8"),
-            )
-        host = hosts[0] if hosts else None
-        origin = origins[0] if origins else None
-        if is_allowed_host(host) and is_allowed_origin(origin):
+        hosts = list(request.headers.get_all("Host"))
+        origins = list(request.headers.get_all("Origin"))
+        if evaluate_loopback(hosts, origins):
             return None
-        return connection.respond(
-            HTTPStatus.FORBIDDEN,
-            FORBIDDEN_BODY.decode("utf-8"),
-        )
+        return connection.respond(HTTPStatus.FORBIDDEN, FORBIDDEN_BODY_TEXT)
 
     return guard

--- a/src/godot_ai/transport/websocket.py
+++ b/src/godot_ai/transport/websocket.py
@@ -13,6 +13,7 @@ from websockets.asyncio.server import ServerConnection
 from godot_ai import __version__ as _SERVER_VERSION
 from godot_ai.protocol.envelope import CommandRequest, CommandResponse, HandshakeMessage
 from godot_ai.sessions.registry import Session, SessionRegistry
+from godot_ai.transport.origin_guard import make_websocket_request_guard
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +37,10 @@ class GodotWebSocketServer:
                 "127.0.0.1",
                 self.port,
                 max_size=4 * 1024 * 1024,  # 4 MB for screenshot base64
+                # Reject DNS-rebinding attempts before the upgrade — see
+                # godot_ai.transport.origin_guard. Native plugin clients
+                # carry a loopback Host and no Origin, so they pass through.
+                process_request=make_websocket_request_guard(),
             ):
                 await asyncio.Future()  # run forever
         except OSError as e:

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -498,6 +498,55 @@ class TestDnsRebindingGuard:
         assert harness.registry.get("origin-loopback") is not None
         await ws.close()
 
+    async def test_origin_null_rejected_at_upgrade(self, harness):
+        ## A sandboxed iframe or downloaded file:// page emits
+        ## ``Origin: null`` — same effective bypass as a foreign Origin.
+        with pytest.raises(websockets.exceptions.InvalidStatus) as exc_info:
+            await websockets.connect(
+                f"ws://127.0.0.1:{harness.port}",
+                additional_headers={"Origin": "null"},
+            )
+        assert exc_info.value.response.status_code == 403
+
+    async def test_browser_cross_origin_subresource_rejected(self, harness):
+        ## Browsers stamp every HTTP request with Sec-Fetch-Site. A
+        ## cross-origin no-cors load (the ``<img>`` liveness-oracle
+        ## shape) arrives with a loopback Host and *no* Origin but the
+        ## fetch metadata gives the rebinding away.
+        with pytest.raises(websockets.exceptions.InvalidStatus) as exc_info:
+            await websockets.connect(
+                f"ws://127.0.0.1:{harness.port}",
+                additional_headers={"Sec-Fetch-Site": "cross-site"},
+            )
+        assert exc_info.value.response.status_code == 403
+
+    async def test_bracketed_ipv6_loopback_origin_accepted(self, harness):
+        ## Symmetry with the unit-level ``http://[::1]`` accept — pin
+        ## the WebSocket guard end-to-end against the bracketed-IPv6
+        ## spelling so the WS path doesn't drift from the helper.
+        ws = await websockets.connect(
+            f"ws://127.0.0.1:{harness.port}",
+            origin="http://[::1]:9500",
+        )
+        handshake = {
+            "type": "handshake",
+            "session_id": "ipv6-loopback",
+            "godot_version": "4.4.1",
+            "project_path": "/tmp",
+            "plugin_version": "0.0.1",
+            "protocol_version": 1,
+            "readiness": "ready",
+            "editor_pid": 0,
+        }
+        await ws.send(json.dumps(handshake))
+        await asyncio.sleep(0.05)
+        try:
+            await asyncio.wait_for(ws.recv(), timeout=0.5)
+        except asyncio.TimeoutError:
+            pass
+        assert harness.registry.get("ipv6-loopback") is not None
+        await ws.close()
+
     async def test_rejected_request_does_not_register_session(self, harness):
         before = len(harness.registry)
         with pytest.raises(websockets.exceptions.InvalidStatus):

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -428,6 +428,90 @@ class TestMultipleSessions:
         await plugin_new.close()
 
 
+# ---------------------------------------------------------------------------
+# DNS-rebinding guard — audit-v2 #1 (#345)
+# ---------------------------------------------------------------------------
+
+
+class TestDnsRebindingGuard:
+    """The WS server's loopback Host/Origin guard runs before the upgrade.
+
+    Browsers attacking via DNS rebinding send a non-loopback Host (the
+    rebound name they typed in the URL bar) and a non-loopback Origin
+    (the attacker's page). Native plugin clients send a loopback Host
+    and no Origin, so they pass through.
+    """
+
+    async def test_loopback_host_no_origin_succeeds(self, harness):
+        # The default native shape: ``websockets`` client sends
+        # ``Host: 127.0.0.1:<port>`` and no ``Origin``.
+        plugin = await harness.connect_plugin(session_id="loopback-default")
+        assert harness.registry.get("loopback-default") is not None
+        await plugin.close()
+
+    async def test_non_loopback_host_rejected_at_upgrade(self, harness):
+        ## A DNS-rebinding browser request lands on 127.0.0.1 but carries
+        ## ``Host: attacker.example.com:<port>``. The guard fires before
+        ## the upgrade — InvalidStatus surfaces the synthesized 403.
+        with pytest.raises(websockets.exceptions.InvalidStatus) as exc_info:
+            await websockets.connect(
+                f"ws://127.0.0.1:{harness.port}",
+                additional_headers={"Host": "attacker.example.com"},
+            )
+        assert exc_info.value.response.status_code == 403
+
+    async def test_browser_origin_rejected_at_upgrade(self, harness):
+        ## A loopback Host is not enough — a browser-driven Origin gives
+        ## the rebinding away even when the Host header looks fine.
+        with pytest.raises(websockets.exceptions.InvalidStatus) as exc_info:
+            await websockets.connect(
+                f"ws://127.0.0.1:{harness.port}",
+                origin="https://attacker.example.com",
+            )
+        assert exc_info.value.response.status_code == 403
+
+    async def test_loopback_origin_accepted(self, harness):
+        ## A localhost-shaped explicit Origin is permitted (use case:
+        ## an MCP-aware tool fronting our server from a loopback browser
+        ## context, e.g. a local docs viewer).
+        ws = await websockets.connect(
+            f"ws://127.0.0.1:{harness.port}",
+            origin="http://localhost:9500",
+        )
+        handshake = {
+            "type": "handshake",
+            "session_id": "origin-loopback",
+            "godot_version": "4.4.1",
+            "project_path": "/tmp",
+            "plugin_version": "0.0.1",
+            "protocol_version": 1,
+            "readiness": "ready",
+            "editor_pid": 0,
+        }
+        await ws.send(json.dumps(handshake))
+        await asyncio.sleep(0.05)
+        ## Drain the ack so it doesn't pollute later asserts.
+        try:
+            await asyncio.wait_for(ws.recv(), timeout=0.5)
+        except asyncio.TimeoutError:
+            pass
+        assert harness.registry.get("origin-loopback") is not None
+        await ws.close()
+
+    async def test_rejected_request_does_not_register_session(self, harness):
+        before = len(harness.registry)
+        with pytest.raises(websockets.exceptions.InvalidStatus):
+            await websockets.connect(
+                f"ws://127.0.0.1:{harness.port}",
+                origin="https://attacker.example.com",
+            )
+        await asyncio.sleep(0.05)
+        ## No Session must have been added — the guard refuses before
+        ## ``_handle_connection`` runs, so neither the registry nor the
+        ## ``_connections`` map sees the rebound peer.
+        assert len(harness.registry) == before
+
+
 # --- Issue #262: editor_state self-heals a stale "playing" cache ---
 
 

--- a/tests/unit/test_asgi_session_diagnostics.py
+++ b/tests/unit/test_asgi_session_diagnostics.py
@@ -6,6 +6,7 @@ import pytest
 
 from godot_ai.asgi import STALE_MCP_SESSION_MESSAGE, StaleMcpSessionDiagnosticMiddleware
 from godot_ai.server import create_server
+from godot_ai.transport.origin_guard import LocalhostOnlyHTTPMiddleware
 
 
 async def _single_http_request(app, *, headers=None):
@@ -406,7 +407,11 @@ def test_create_server_wraps_streamable_http_app_with_stale_session_diagnostic()
 
     app = server.http_app(transport="streamable-http")
 
-    assert isinstance(app, StaleMcpSessionDiagnosticMiddleware)
+    ## Outermost wrap is the loopback origin guard (audit-v2 #1, #345);
+    ## ``StaleMcpSessionDiagnosticMiddleware`` sits one layer in for
+    ## streamable-http transports.
+    assert isinstance(app, LocalhostOnlyHTTPMiddleware)
+    assert isinstance(app.app, StaleMcpSessionDiagnosticMiddleware)
 
 
 def test_create_server_does_not_wrap_sse_app_with_stale_session_diagnostic():
@@ -414,7 +419,11 @@ def test_create_server_does_not_wrap_sse_app_with_stale_session_diagnostic():
 
     app = server.http_app(transport="sse")
 
-    assert not isinstance(app, StaleMcpSessionDiagnosticMiddleware)
+    ## ``sse`` skips ``StaleMcpSessionDiagnosticMiddleware`` (the SDK's
+    ## stale-session error is streamable-http only) but the loopback
+    ## origin guard still wraps every HTTP transport uniformly.
+    assert isinstance(app, LocalhostOnlyHTTPMiddleware)
+    assert not isinstance(app.app, StaleMcpSessionDiagnosticMiddleware)
 
 
 def test_stale_mcp_session_diagnostic_preserves_fastmcp_app_state():
@@ -422,4 +431,7 @@ def test_stale_mcp_session_diagnostic_preserves_fastmcp_app_state():
 
     app = server.http_app(transport="streamable-http")
 
-    assert app.state is app.app.state
+    ## Both middleware layers expose ``state`` via ``__getattr__``
+    ## passthrough, so attribute access traverses LocalhostOnlyHTTPMiddleware
+    ## -> StaleMcpSessionDiagnosticMiddleware -> FastMCP app.
+    assert app.state is app.app.app.state

--- a/tests/unit/test_origin_guard.py
+++ b/tests/unit/test_origin_guard.py
@@ -13,8 +13,10 @@ import pytest
 
 from godot_ai.transport.origin_guard import (
     LocalhostOnlyHTTPMiddleware,
+    evaluate_loopback,
     is_allowed_host,
     is_allowed_origin,
+    is_allowed_sec_fetch_site,
 )
 
 # ---------------------------------------------------------------------------
@@ -32,6 +34,11 @@ from godot_ai.transport.origin_guard import (
         "LOCALHOST",  # case-insensitive
         "[::1]",
         "[::1]:9500",
+        # RFC-1034-valid trailing-dot FQDN syntax — browsers and curl can
+        # preserve it through to the Host header. Friction trap if rejected.
+        "localhost.",
+        "localhost.:8000",
+        "127.0.0.1.",
     ],
 )
 def test_loopback_hosts_pass(host: str) -> None:
@@ -82,9 +89,6 @@ def test_non_loopback_hosts_rejected(host) -> None:
         None,
         "",
         "   ",
-        # Sandboxed and file:// contexts emit ``Origin: null``.
-        "null",
-        "NULL",
         # Loopback origins are allowed for tooling that explicitly opts in.
         "http://127.0.0.1",
         "http://127.0.0.1:9500",
@@ -95,10 +99,22 @@ def test_non_loopback_hosts_rejected(host) -> None:
         "wss://localhost:8443",
         "http://[::1]",
         "http://[::1]:9500",
+        # Trailing-dot FQDN form — accepted alongside the canonical name.
+        "http://localhost.",
+        "http://localhost.:8000",
     ],
 )
 def test_loopback_origins_pass(origin) -> None:
     assert is_allowed_origin(origin) is True
+
+
+@pytest.mark.parametrize("null_origin", ["null", "NULL", " null ", "Null"])
+def test_origin_null_rejected(null_origin: str) -> None:
+    """``Origin: null`` is the bypass shape — sandboxed iframes and
+    downloaded ``file://`` pages emit it and would otherwise let an
+    attacker bridge a foreign origin onto the loopback socket. Native
+    clients never produce ``null`` (they omit Origin entirely)."""
+    assert is_allowed_origin(null_origin) is False
 
 
 @pytest.mark.parametrize(
@@ -123,6 +139,96 @@ def test_loopback_origins_pass(origin) -> None:
 )
 def test_non_loopback_origins_rejected(origin: str) -> None:
     assert is_allowed_origin(origin) is False
+
+
+# ---------------------------------------------------------------------------
+# is_allowed_sec_fetch_site — block browser cross-origin probes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # Native non-browser clients never send Sec-Fetch-Site.
+        None,
+        # Top-level navigation (user typed URL / clicked bookmark).
+        "none",
+        # Same-origin fetch (e.g. our own /godot-ai/status from a loopback
+        # browser context).
+        "same-origin",
+        # Case insensitivity per spec.
+        "None",
+        "Same-Origin",
+        # Whitespace tolerance.
+        " none ",
+    ],
+)
+def test_sec_fetch_site_friendly_values_pass(value) -> None:
+    assert is_allowed_sec_fetch_site(value) is True
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        # Cross-origin subresource load (`<img src="http://127.0.0.1...">`
+        # from a foreign page) — reject.
+        "cross-site",
+        "CROSS-SITE",
+        # Same-site cross-origin — also reject; the request is still
+        # browser-driven from a different origin (different port/scheme).
+        "same-site",
+    ],
+)
+def test_sec_fetch_site_foreign_values_rejected(value: str) -> None:
+    assert is_allowed_sec_fetch_site(value) is False
+
+
+# ---------------------------------------------------------------------------
+# evaluate_loopback — combined gate
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_loopback_native_client() -> None:
+    """No Origin, no Sec-Fetch-Site, loopback Host — native client path."""
+    assert evaluate_loopback(["127.0.0.1:9500"], [], []) is True
+
+
+def test_evaluate_loopback_loopback_browser_passes() -> None:
+    """Browser pointed at our own loopback origin still passes."""
+    assert (
+        evaluate_loopback(
+            ["127.0.0.1:9500"],
+            ["http://127.0.0.1:9500"],
+            ["same-origin"],
+        )
+        is True
+    )
+
+
+def test_evaluate_loopback_cross_site_subresource_rejected() -> None:
+    """The Copilot-flagged liveness oracle: cross-origin <img> hits our
+    /godot-ai/status with a loopback Host and *no* Origin (no-cors mode).
+    Sec-Fetch-Site is the giveaway."""
+    assert (
+        evaluate_loopback(
+            ["127.0.0.1:9500"],
+            [],
+            ["cross-site"],
+        )
+        is False
+    )
+
+
+def test_evaluate_loopback_origin_null_rejected() -> None:
+    """Sandboxed iframe / file:// page emit ``Origin: null`` — reject."""
+    assert (
+        evaluate_loopback(
+            ["127.0.0.1:9500"],
+            ["null"],
+            ["cross-site"],
+        )
+        is False
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -261,6 +367,52 @@ async def test_middleware_rejects_duplicate_host_smuggle() -> None:
     )
     assert inner_called is False
     assert sent[0]["status"] == 403
+
+
+async def test_middleware_rejects_origin_null() -> None:
+    """A sandboxed iframe / file:// page hitting our loopback socket
+    sends ``Origin: null`` — must be rejected even though the Host
+    looks loopback."""
+    middleware = LocalhostOnlyHTTPMiddleware(app=None)  # type: ignore[arg-type]
+    sent, inner_called = await _call_middleware(
+        middleware,
+        headers=[
+            (b"host", b"127.0.0.1:8000"),
+            (b"origin", b"null"),
+        ],
+    )
+    assert inner_called is False
+    assert sent[0]["status"] == 403
+
+
+async def test_middleware_rejects_cross_origin_subresource() -> None:
+    """The /godot-ai/status liveness-oracle shape Copilot flagged: a
+    cross-origin <img> / <script> load arrives with a loopback Host
+    and *no* Origin (no-cors mode) — but Sec-Fetch-Site reveals it."""
+    middleware = LocalhostOnlyHTTPMiddleware(app=None)  # type: ignore[arg-type]
+    sent, inner_called = await _call_middleware(
+        middleware,
+        headers=[
+            (b"host", b"127.0.0.1:8000"),
+            (b"sec-fetch-site", b"cross-site"),
+        ],
+    )
+    assert inner_called is False
+    assert sent[0]["status"] == 403
+
+
+async def test_middleware_passes_top_level_navigation() -> None:
+    """User typed URL / clicked bookmark — Sec-Fetch-Site: none."""
+    middleware = LocalhostOnlyHTTPMiddleware(app=None)  # type: ignore[arg-type]
+    sent, inner_called = await _call_middleware(
+        middleware,
+        headers=[
+            (b"host", b"127.0.0.1:8000"),
+            (b"sec-fetch-site", b"none"),
+        ],
+    )
+    assert inner_called is True
+    assert sent[0]["status"] == 200
 
 
 async def test_middleware_rejects_duplicate_origin_smuggle() -> None:

--- a/tests/unit/test_origin_guard.py
+++ b/tests/unit/test_origin_guard.py
@@ -1,0 +1,289 @@
+"""Loopback Host/Origin guard — DNS-rebinding mitigation (audit-v2 #1, #345).
+
+Covers the pure helpers in ``godot_ai.transport.origin_guard`` and the
+ASGI middleware surface. The WebSocket-server side is exercised in
+``tests/integration/test_websocket.py`` against a live ``websockets``
+server because the upgrade path runs inside the library, not in our
+code.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from godot_ai.transport.origin_guard import (
+    LocalhostOnlyHTTPMiddleware,
+    is_allowed_host,
+    is_allowed_origin,
+)
+
+# ---------------------------------------------------------------------------
+# is_allowed_host
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "127.0.0.1",
+        "127.0.0.1:9500",
+        "localhost",
+        "localhost:8000",
+        "LOCALHOST",  # case-insensitive
+        "[::1]",
+        "[::1]:9500",
+    ],
+)
+def test_loopback_hosts_pass(host: str) -> None:
+    assert is_allowed_host(host) is True
+
+
+def test_bare_unbracketed_ipv6_loopback_rejected() -> None:
+    """RFC 7230 requires IPv6 in brackets in the HTTP Host header. A
+    bare ``::1`` would be a malformed request and is not on the
+    allowlist — only the bracketed form ``[::1]`` is accepted."""
+    assert is_allowed_host("::1") is False
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        # The classic DNS-rebinding shape: attacker tricks the browser into
+        # resolving their domain to 127.0.0.1, browser sends ``Host: <domain>``.
+        "attacker.example.com",
+        "attacker.example.com:9500",
+        "192.168.1.50",
+        "10.0.0.1:8000",
+        # Public DNS names that *resolve* to 127.0.0.1 but don't *match* it.
+        "godot-ai.test",
+        "rebound.local:9500",
+        # Empty / missing → reject; well-formed HTTP carries a Host.
+        "",
+        None,
+        "   ",
+        # Sneaky-looking but non-loopback.
+        "127.0.0.1.attacker.example.com",
+        "localhost.evil.example.com",
+    ],
+)
+def test_non_loopback_hosts_rejected(host) -> None:
+    assert is_allowed_host(host) is False
+
+
+# ---------------------------------------------------------------------------
+# is_allowed_origin
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        # Native plugin / CLI clients omit Origin entirely — must pass.
+        None,
+        "",
+        "   ",
+        # Sandboxed and file:// contexts emit ``Origin: null``.
+        "null",
+        "NULL",
+        # Loopback origins are allowed for tooling that explicitly opts in.
+        "http://127.0.0.1",
+        "http://127.0.0.1:9500",
+        "http://localhost",
+        "http://localhost:8000",
+        "https://localhost:8443",
+        "ws://127.0.0.1:9500",
+        "wss://localhost:8443",
+        "http://[::1]",
+        "http://[::1]:9500",
+    ],
+)
+def test_loopback_origins_pass(origin) -> None:
+    assert is_allowed_origin(origin) is True
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        # The DNS-rebinding shape: browser-driven Origin is the attacker's domain.
+        "https://attacker.example.com",
+        "http://attacker.example.com:9500",
+        "https://godot-ai.test",
+        # Schemes outside the HTTP/WS family — refuse rather than guess.
+        "file:///home/user/index.html",
+        "data:text/html;base64,PHNjcmlwdD4=",
+        "chrome-extension://abc",
+        # IP that isn't loopback.
+        "http://192.168.1.50",
+        # Looks-like-loopback substring but is actually a foreign host.
+        "http://localhost.evil.example.com",
+        "http://127.0.0.1.evil.example.com",
+        # Malformed origin: scheme present but no hostname.
+        "http://",
+    ],
+)
+def test_non_loopback_origins_rejected(origin: str) -> None:
+    assert is_allowed_origin(origin) is False
+
+
+# ---------------------------------------------------------------------------
+# LocalhostOnlyHTTPMiddleware (ASGI scope shape)
+# ---------------------------------------------------------------------------
+
+
+async def _call_middleware(
+    middleware: LocalhostOnlyHTTPMiddleware,
+    *,
+    headers: list[tuple[bytes, bytes]],
+    scope_type: str = "http",
+) -> tuple[list[dict], bool]:
+    """Run the middleware against a synthetic scope; return (sent, inner_called)."""
+    inner_called = False
+
+    async def inner(scope, receive, send):
+        nonlocal inner_called
+        inner_called = True
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok", "more_body": False})
+
+    middleware.app = inner  # type: ignore[assignment]
+    sent: list[dict] = []
+
+    async def send(message):
+        sent.append(message)
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    scope = {"type": scope_type, "method": "GET", "path": "/x", "headers": headers}
+    await middleware(scope, receive, send)
+    return sent, inner_called
+
+
+async def test_middleware_passes_loopback_request_through() -> None:
+    middleware = LocalhostOnlyHTTPMiddleware(app=None)  # type: ignore[arg-type]
+    sent, inner_called = await _call_middleware(
+        middleware,
+        headers=[(b"host", b"127.0.0.1:8000")],
+    )
+    assert inner_called is True
+    assert sent[0]["status"] == 200
+
+
+async def test_middleware_rejects_non_loopback_host() -> None:
+    middleware = LocalhostOnlyHTTPMiddleware(app=None)  # type: ignore[arg-type]
+    sent, inner_called = await _call_middleware(
+        middleware,
+        headers=[(b"host", b"attacker.example.com:8000")],
+    )
+    assert inner_called is False, "inner app must not run for rejected requests"
+    assert sent[0]["type"] == "http.response.start"
+    assert sent[0]["status"] == 403
+
+
+async def test_middleware_rejects_browser_origin_with_loopback_host() -> None:
+    """The DNS-rebinding fingerprint: browser sends Origin even when the
+    Host happened to resolve to loopback. Reject on Origin alone."""
+    middleware = LocalhostOnlyHTTPMiddleware(app=None)  # type: ignore[arg-type]
+    sent, inner_called = await _call_middleware(
+        middleware,
+        headers=[
+            (b"host", b"127.0.0.1:8000"),
+            (b"origin", b"https://attacker.example.com"),
+        ],
+    )
+    assert inner_called is False
+    assert sent[0]["status"] == 403
+
+
+async def test_middleware_passes_loopback_origin_with_loopback_host() -> None:
+    middleware = LocalhostOnlyHTTPMiddleware(app=None)  # type: ignore[arg-type]
+    sent, inner_called = await _call_middleware(
+        middleware,
+        headers=[
+            (b"host", b"localhost:8000"),
+            (b"origin", b"http://localhost:8000"),
+        ],
+    )
+    assert inner_called is True
+    assert sent[0]["status"] == 200
+
+
+async def test_middleware_rejects_missing_host() -> None:
+    middleware = LocalhostOnlyHTTPMiddleware(app=None)  # type: ignore[arg-type]
+    sent, inner_called = await _call_middleware(middleware, headers=[])
+    assert inner_called is False
+    assert sent[0]["status"] == 403
+
+
+async def test_middleware_passes_lifespan_scope_through() -> None:
+    """Non-HTTP scopes (lifespan, websocket) must not be filtered — only
+    the HTTP path carries the Host/Origin headers we guard."""
+    middleware = LocalhostOnlyHTTPMiddleware(app=None)  # type: ignore[arg-type]
+    inner_called = False
+
+    async def inner(scope, receive, send):
+        nonlocal inner_called
+        inner_called = True
+
+    middleware.app = inner  # type: ignore[assignment]
+
+    async def send(message):
+        pass
+
+    async def receive():
+        return {"type": "lifespan.startup"}
+
+    await middleware({"type": "lifespan"}, receive, send)
+    assert inner_called is True
+
+
+async def test_middleware_response_body_explains_dns_rebinding() -> None:
+    middleware = LocalhostOnlyHTTPMiddleware(app=None)  # type: ignore[arg-type]
+    sent, _ = await _call_middleware(
+        middleware,
+        headers=[(b"host", b"attacker.example.com")],
+    )
+    body = sent[1]["body"]
+    assert b"forbidden" in body.lower()
+    assert b"DNS rebinding" in body or b"dns rebinding" in body.lower()
+
+
+async def test_middleware_rejects_duplicate_host_smuggle() -> None:
+    """HTTP smuggling shape: two Host headers, one loopback and one not.
+    The guard must fail closed regardless of which one is "correct"."""
+    middleware = LocalhostOnlyHTTPMiddleware(app=None)  # type: ignore[arg-type]
+    sent, inner_called = await _call_middleware(
+        middleware,
+        headers=[
+            (b"host", b"127.0.0.1"),
+            (b"host", b"attacker.example.com"),
+        ],
+    )
+    assert inner_called is False
+    assert sent[0]["status"] == 403
+
+
+async def test_middleware_rejects_duplicate_origin_smuggle() -> None:
+    middleware = LocalhostOnlyHTTPMiddleware(app=None)  # type: ignore[arg-type]
+    sent, inner_called = await _call_middleware(
+        middleware,
+        headers=[
+            (b"host", b"127.0.0.1"),
+            (b"origin", b"http://localhost"),
+            (b"origin", b"https://attacker.example.com"),
+        ],
+    )
+    assert inner_called is False
+    assert sent[0]["status"] == 403
+
+
+def test_middleware_passes_state_attribute_through() -> None:
+    """FastMCP introspects ``state`` on the wrapped ASGI app — the
+    middleware must not shadow that lookup. See the matching pattern in
+    ``StaleMcpSessionDiagnosticMiddleware``."""
+
+    class FakeApp:
+        state = "fake-state-marker"
+
+    middleware = LocalhostOnlyHTTPMiddleware(FakeApp())  # type: ignore[arg-type]
+    assert middleware.state == "fake-state-marker"

--- a/tests/unit/test_server_status.py
+++ b/tests/unit/test_server_status.py
@@ -7,7 +7,11 @@ from godot_ai.server import create_server
 def test_status_route_reports_live_server_version():
     server = create_server(ws_port=9555, exclude_domains={"audio", "theme"})
     app = server.http_app(transport="streamable-http")
-    client = TestClient(app)
+    ## ``base_url`` overrides Starlette TestClient's default ``testserver``
+    ## Host header. The DNS-rebinding guard (origin_guard.py) rejects any
+    ## non-loopback Host, so without this the request 403s before
+    ## reaching the status route. See audit-v2 finding #1 (#345).
+    client = TestClient(app, base_url="http://127.0.0.1")
 
     response = client.get("/godot-ai/status")
 


### PR DESCRIPTION
## Summary

Closes #345 — audit-v2 P1 finding #1 from umbrella #343.

The WebSocket server (`:9500`) and the streamable-HTTP transport (`:8000`,
including `/godot-ai/status` — comment-marked "small unauthenticated probe")
both bound to `127.0.0.1` but performed no Host/Origin validation. A
malicious browser tab could mount **DNS rebinding**: resolve
`attacker.example.com` to `127.0.0.1`, then `new WebSocket("ws://attacker.example.com:9500")` — the request lands on our loopback socket, the
WS handshake registers the peer as a session, and any MCP tool becomes
drivable from a foreign origin including the **write tools**.

## Fix

Per the issue's "Fix shape" — **strict Host/Origin allowlist in a
Starlette middleware ahead of FastMCP**, mirrored on the WebSocket side
via `process_request`.

`src/godot_ai/transport/origin_guard.py` (new):

- `is_allowed_host` — accepts `127.0.0.1`, `localhost`, `[::1]` with an
  optional `:port`. Bare `::1` rejected (RFC 7230 requires bracketed IPv6
  in HTTP Host headers).
- `is_allowed_origin` — `None`/empty/`null` accepted (native clients omit
  Origin; sandboxed/file:// emit `null`); otherwise must parse to a URL
  whose hostname is loopback. Schemes outside `http/https/ws/wss` rejected.
- `LocalhostOnlyHTTPMiddleware` — ASGI middleware. Rejects with HTTP 403;
  passes lifespan scopes through; fails closed on duplicate-Host smuggling
  (the same header appearing more than once).
- `make_websocket_request_guard()` — `process_request` hook for
  `websockets.asyncio.server.serve(...)`. Uses `headers.get_all` so a
  smuggled duplicate Host fails closed instead of tripping
  `MultipleValuesError` and surfacing as 500.

Wiring:

- `transport/websocket.py`: pass `process_request=` into `serve()`.
- `server.py`: outermost wrap on the HTTP app, applied to **every** HTTP
  transport (`http`, `streamable-http`, `sse`) so `/godot-ai/status` and
  the FastMCP endpoints are guarded uniformly.

Native clients keep working unchanged: the Godot plugin's `WebSocketPeer`
sends `Host: 127.0.0.1:<port>` and no `Origin`. Verified by live smoke.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `pytest -q` — 825 passed (+45 new)
- [x] `script/ci-check-gdscript` — clean (no GDScript touched)
- [x] Live smoke (real `GodotWebSocketServer`):
  - Loopback `ws://127.0.0.1:<port>` connect + handshake → `handshake_ack` ✓
  - `Origin: https://attacker.example.com` → HTTP 403 at upgrade, no session registered ✓
- [x] Live smoke (streamable-HTTP):
  - Loopback `GET /godot-ai/status` → 200 with full payload ✓
  - `Host: attacker.example.com` → 403 ✓
  - Loopback Host + `Origin: https://attacker.example.com` → 403 ✓

New tests:

- `tests/unit/test_origin_guard.py` — 44 tests. Parametrized helper
  coverage (loopback / sneaky-substring / private-IP / malformed /
  smuggled-multi-value), middleware behavior including lifespan
  passthrough and FastMCP `state` `__getattr__` passthrough, and an
  explicit DNS-rebinding-fingerprint test (loopback Host + browser
  Origin must reject).
- `tests/integration/test_websocket.py::TestDnsRebindingGuard` — 5 live
  tests against a real `websockets` server: loopback succeeds, non-loopback
  Host returns 403, non-loopback Origin returns 403, loopback-shaped
  Origin succeeds, and a rejected request never reaches the registry.
- `tests/unit/test_asgi_session_diagnostics.py` — structural assertions
  updated for the new outer wrap; `state` lookup now traverses one extra
  layer of `__getattr__`.
- `tests/unit/test_server_status.py` — `TestClient(base_url=...)` set to
  a loopback host so the request passes the new guard.

## Deviations from the issue's "Fix shape"

The issue offers two alternatives — "HMAC handshake bound to spawned-server
PID-file secret, **or** strict Host/Origin allowlist in a Starlette middleware
ahead of FastMCP." I picked the second:

1. The named threat is **DNS rebinding**, which is fully mitigated by
   Host/Origin validation. An HMAC token doesn't add anything for the
   browser case.
2. Local-impostor processes that read the loopback socket are addressed
   separately in #346 (PR #366, duplicate-handshake reject) — adding a
   token here would duplicate that effort without strengthening it.
3. Origin allowlist also closes #355 (the `/godot-ai/status` "comment-
   acknowledged" probe gap was gated on this fix), without per-launch
   secret coordination between plugin and server.

The PID-file secret remains available for future use if the threat model
broadens (multi-user shared loopback, container-shared 127.0.0.1, etc).

## Bundling note

#345's body says "Consider bundling with #2 (#346)." #346 already has open
PR #366, which explicitly carves #1 out: *"#1 (auth/Origin gap on the WS
upgrade) — separate scope, deserves its own design discussion."* So this
PR ships the carved-out scope solo. If #366 lands first I'll rebase.

## Blocks

- #355 (audit-v2 #11 — `/godot-ai/status` is unauthenticated probe) is
  unblocked by this PR's HTTP middleware: the same allowlist now guards
  the status route. The maintainer may want to close #355 as
  "addressed by #345" or queue it for further verification.

Refs umbrella #343.

---
_Generated by [Claude Code](https://claude.ai/code/session_optimistic-tesla-HaR1o)_