### PR TITLE
[Audit v2 #346+#349] WS hardening: duplicate-ID reject + send_command leak

### DIFF
--- a/src/godot_ai/transport/websocket.py
+++ b/src/godot_ai/transport/websocket.py
@@ -20,6 +20,11 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_PORT = 9500
 
+## RFC 6455 reserves 4000-4999 for application-defined close codes; we use
+## 4001 to flag a handshake rejected for duplicate session_id so a debugging
+## peer can distinguish it from a normal close.
+_CLOSE_CODE_DUPLICATE_SESSION = 4001
+
 
 class GodotWebSocketServer:
     """Accepts connections from Godot editor plugins and routes commands."""
@@ -61,6 +66,23 @@ class GodotWebSocketServer:
             raw = await asyncio.wait_for(ws.recv(), timeout=10.0)
             data = json.loads(raw)
             handshake = HandshakeMessage.model_validate(data)
+
+            ## Reject duplicate session_id while the first peer is live —
+            ## otherwise the second handshake silently overwrites the
+            ## routing map, hijacking command delivery (audit-v2 #2).
+            existing = self.registry.get(handshake.session_id)
+            if existing is not None:
+                logger.warning(
+                    "Rejecting duplicate handshake for session %s (existing pid=%s, project=%s)",
+                    handshake.session_id,
+                    existing.editor_pid,
+                    existing.project_path,
+                )
+                await ws.close(
+                    code=_CLOSE_CODE_DUPLICATE_SESSION,
+                    reason="session id already registered",
+                )
+                return
 
             session_id = handshake.session_id
             session = Session(
@@ -159,12 +181,16 @@ class GodotWebSocketServer:
         future: asyncio.Future[CommandResponse] = asyncio.get_running_loop().create_future()
         self._pending[request.request_id] = future
 
-        await ws.send(request.model_dump_json())
-
+        ## Always pop on exit — the response receiver in _handle_connection
+        ## pops on the happy path, so this is a no-op there; on `ws.send`
+        ## raise / TimeoutError / cancellation it prevents Futures leaking
+        ## into _pending forever (audit-v2 #5).
         try:
+            await ws.send(request.model_dump_json())
             return await asyncio.wait_for(future, timeout=timeout)
         except asyncio.TimeoutError:
-            self._pending.pop(request.request_id, None)
             raise TimeoutError(
                 f"Command {command} timed out after {timeout}s on session {session_id}"
             )
+        finally:
+            self._pending.pop(request.request_id, None)

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -639,3 +639,129 @@ class TestEditorStateSelfHeal:
         finally:
             await asyncio.wait_for(task, timeout=2.0)
             await plugin.close()
+
+
+# ---------------------------------------------------------------------------
+# Duplicate-ID handshake hardening (audit-v2 #2 / issue #346)
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicateHandshake:
+    async def test_duplicate_session_id_handshake_is_rejected(self, harness):
+        ## Without rejection, a second handshake with the same session_id
+        ## silently overwrites both `_connections[session_id]` and the
+        ## registry entry — routing every subsequent command to the
+        ## attacker. session_id is `<slug>@<4hex>` so 16 bits of suffix is
+        ## locally guessable. Reject keeps the first peer authoritative.
+        first = await harness.connect_plugin(session_id="dup-target")
+        original_session = harness.registry.get("dup-target")
+        assert original_session is not None
+        original_pid = original_session.editor_pid
+
+        ## Hand-roll the second handshake so we observe the close on the
+        ## wire — `connect_plugin()` would assert on the missing ack.
+        ws2 = await websockets.connect(f"ws://127.0.0.1:{harness.port}")
+        await ws2.send(
+            json.dumps(
+                {
+                    "type": "handshake",
+                    "session_id": "dup-target",
+                    "godot_version": "4.4.1",
+                    "project_path": "/tmp/attacker",
+                    "plugin_version": "0.0.1",
+                    "protocol_version": 1,
+                    "readiness": "ready",
+                    "editor_pid": 9999,
+                }
+            )
+        )
+
+        ## Server should close us before sending an ack. Drain until the WS
+        ## reports closed; recv() will raise ConnectionClosed.
+        with pytest.raises(websockets.ConnectionClosed):
+            await asyncio.wait_for(ws2.recv(), timeout=2.0)
+
+        ## Original session must still be live and unaffected.
+        live = harness.registry.get("dup-target")
+        assert live is original_session, "registry entry was overwritten by duplicate"
+        assert live.editor_pid == original_pid
+        assert live.project_path != "/tmp/attacker"
+
+        ## Round-trip a command through the original to prove its WS is
+        ## still wired to the routing map (regression: silent overwrite
+        ## also hijacks `_connections[session_id]`).
+        from godot_ai.godot_client.client import GodotClient
+
+        client = GodotClient(harness.server, harness.registry)
+
+        async def mock_handler():
+            cmd = await first.recv_command()
+            await first.send_response(cmd["request_id"], {"alive": True})
+
+        handler = asyncio.create_task(mock_handler())
+        result = await client.send("ping", session_id="dup-target")
+        await handler
+        assert result == {"alive": True}
+
+        await first.close()
+
+    async def test_reconnect_after_clean_disconnect_succeeds(self, harness):
+        ## The reject must not break the legitimate plugin reconnect path
+        ## (e.g. after `editor_reload_plugin`): close → unregister →
+        ## fresh connect with the same session_id should succeed because
+        ## the registry entry has already been removed.
+        first = await harness.connect_plugin(session_id="reconnect-1")
+        await first.close()
+        await asyncio.sleep(0.1)  # let server process disconnect
+        assert harness.registry.get("reconnect-1") is None
+
+        second = await harness.connect_plugin(session_id="reconnect-1")
+        assert harness.registry.get("reconnect-1") is not None
+        await second.close()
+
+
+# ---------------------------------------------------------------------------
+# send_command pending-Future leak (audit-v2 #5 / issue #349)
+# ---------------------------------------------------------------------------
+
+
+class TestPendingFutureCleanup:
+    async def test_timeout_pops_pending_entry(self, harness):
+        ## TimeoutError path always cleared the pending dict; this test
+        ## pins that behavior so a future refactor doesn't regress it.
+        plugin = await harness.connect_plugin(session_id="leak-timeout")
+
+        with pytest.raises(TimeoutError):
+            await harness.server.send_command(
+                session_id="leak-timeout",
+                command="never_responded",
+                timeout=0.1,
+            )
+
+        assert harness.server._pending == {}, "TimeoutError should not leave entries in _pending"
+        await plugin.close()
+
+    async def test_send_failure_pops_pending_entry(self, harness):
+        ## If `ws.send` raises (e.g. ConnectionClosed mid-send), the
+        ## pending Future was previously leaked into `_pending` forever.
+        ## Force the failure by replacing the connection's send with one
+        ## that raises after the pending entry has been registered.
+        plugin = await harness.connect_plugin(session_id="leak-send")
+
+        ws = harness.server._connections["leak-send"]
+        boom = ConnectionError("simulated mid-send transport error")
+
+        async def raising_send(_payload: str) -> None:
+            raise boom
+
+        ws.send = raising_send  # type: ignore[assignment]
+
+        with pytest.raises(ConnectionError):
+            await harness.server.send_command(
+                session_id="leak-send",
+                command="will_fail",
+                timeout=1.0,
+            )
+
+        assert harness.server._pending == {}, "send-time exception must not leak _pending entries"
+        await plugin.close()


### PR DESCRIPTION
## Summary

Two transport-layer audit fixes in `src/godot_ai/transport/websocket.py`. Cribbed from abandoned PR #366 (which targeted `main`); this re-targets `beta` per the maintainer's bundle direction in #346 / #349. The #348 (errno) portion of #366 already shipped via PR #373 and is omitted here.

- **#346 (P1, security)** — duplicate-ID handshake hijack: a second handshake with the same `session_id` previously overwrote both `_sessions[id]` and `_connections[id]` silently, so a local peer could brute-force the 16-bit hex suffix and steal command routing. Now rejects with WS close code 4001 + warning log naming the existing peer's pid/project. Legitimate reconnect after `editor_reload_plugin` is unaffected — `ConnectionClosed → unregister` happens before the new connect, so the slot is free.
- **#349 (P2, reliability)** — `send_command` Future leak: `ws.send` raising mid-call left the registered Future stranded in `_pending` forever. Wrapped the `send + wait_for` in `try/finally` that always pops. Happy path still pops via the response receiver, so the finally pop is a no-op there.

## Test plan

- [x] `ruff check src/ tests/` — passes (the 6 unrelated unformatted files were already that way on `beta`)
- [x] `ruff format --check` on changed files (`src/godot_ai/transport/websocket.py`, `tests/integration/test_websocket.py`) — clean
- [x] `pytest -v` — 867 passed
- [x] `script/ci-check-gdscript` — all GDScript files OK
- [x] New regression tests:
  - `TestDuplicateHandshake::test_duplicate_session_id_handshake_is_rejected` — attack-shape regression: round-trips a command through the original WS after the duplicate is rejected to prove the routing map wasn't hijacked
  - `TestDuplicateHandshake::test_reconnect_after_clean_disconnect_succeeds` — guards the legitimate reconnect-after-`editor_reload_plugin` path
  - `TestPendingFutureCleanup::test_timeout_pops_pending_entry` — pins the existing timeout-pop behavior so the refactor doesn't regress it
  - `TestPendingFutureCleanup::test_send_failure_pops_pending_entry` — covers the new send-time-exception path that was previously leaking
- [x] Live editor `test_run` skipped — diff is Python-only (transport layer), no GDScript or handler changes. PR #366 already live-smoked an identical diff against Godot 4.6 (1037/1040 GDScript suite green).

## Deviations from "Fix shape"

None. #346's fix shape called for "reject the second handshake with a warning log naming the colliding peer" — implemented. #349's fix shape called for "try/finally pattern that pops on any non-success path" — implemented.

## Cross-references

Closes #346
Closes #349
Umbrella: #343
Bundled per [maintainer comment on #346](https://github.com/hi-godot/godot-ai/issues/346#issuecomment-4381736212).

https://claude.ai/code/session_01ERwAhFK6CEZLRigwK1iC2k

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERwAhFK6CEZLRigwK1iC2k)_