### PR TITLE
[Audit v2 #351] Pydantic-validate WebSocket event payloads

### DIFF
--- a/src/godot_ai/protocol/envelope.py
+++ b/src/godot_ai/protocol/envelope.py
@@ -50,3 +50,22 @@ class HandshakeMessage(BaseModel):
     ## server — distinguishable from a live detection that returned
     ## "unknown" only by plugin_version.
     server_launch_mode: str = "unknown"
+
+
+## State events emitted by the plugin's _check_state_changes() poller. Each
+## carries one typed string field. Validating them on receive prevents a
+## malformed event (or a hijacked WS) from setting non-string values on the
+## Session, which then ship to MCP clients verbatim via Session.to_dict().
+## See audit-v2 finding #7 (issue #351).
+
+
+class SceneChangedEvent(BaseModel):
+    current_scene: str = ""
+
+
+class PlayStateChangedEvent(BaseModel):
+    play_state: str = "stopped"
+
+
+class ReadinessChangedEvent(BaseModel):
+    readiness: str = "ready"

--- a/src/godot_ai/transport/websocket.py
+++ b/src/godot_ai/transport/websocket.py
@@ -9,10 +9,18 @@ import logging
 from typing import Any
 
 import websockets
+from pydantic import ValidationError
 from websockets.asyncio.server import ServerConnection
 
 from godot_ai import __version__ as _SERVER_VERSION
-from godot_ai.protocol.envelope import CommandRequest, CommandResponse, HandshakeMessage
+from godot_ai.protocol.envelope import (
+    CommandRequest,
+    CommandResponse,
+    HandshakeMessage,
+    PlayStateChangedEvent,
+    ReadinessChangedEvent,
+    SceneChangedEvent,
+)
 from godot_ai.sessions.registry import Session, SessionRegistry
 from godot_ai.transport.origin_guard import make_websocket_request_guard
 
@@ -156,15 +164,33 @@ class GodotWebSocketServer:
         if session is None:
             return
 
-        if event == "scene_changed":
-            session.current_scene = event_data.get("current_scene", "")
-            logger.info("Session %s: scene changed to %s", session_id[:8], session.current_scene)
-        elif event == "play_state_changed":
-            session.play_state = event_data.get("play_state", "stopped")
-            logger.info("Session %s: play state -> %s", session_id[:8], session.play_state)
-        elif event == "readiness_changed":
-            session.readiness = event_data.get("readiness", "ready")
-            logger.info("Session %s: readiness -> %s", session_id[:8], session.readiness)
+        ## Validate the payload before assigning to typed Session fields —
+        ## a malformed plugin event (or hijacked WS) used to ship non-string
+        ## values straight through to MCP clients via Session.to_dict()
+        ## (audit-v2 #7). On ValidationError we drop the event with a
+        ## warning rather than corrupt the cached session state.
+        try:
+            if event == "scene_changed":
+                payload = SceneChangedEvent.model_validate(event_data)
+                session.current_scene = payload.current_scene
+                logger.info(
+                    "Session %s: scene changed to %s", session_id[:8], session.current_scene
+                )
+            elif event == "play_state_changed":
+                payload = PlayStateChangedEvent.model_validate(event_data)
+                session.play_state = payload.play_state
+                logger.info("Session %s: play state -> %s", session_id[:8], session.play_state)
+            elif event == "readiness_changed":
+                payload = ReadinessChangedEvent.model_validate(event_data)
+                session.readiness = payload.readiness
+                logger.info("Session %s: readiness -> %s", session_id[:8], session.readiness)
+        except ValidationError as exc:
+            logger.warning(
+                "Dropping malformed %s event from session %s: %s",
+                event,
+                session_id[:8],
+                exc.errors(include_url=False, include_context=False, include_input=False),
+            )
 
     async def send_command(
         self,

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -360,6 +360,91 @@ class TestEvents:
 
 
 # ---------------------------------------------------------------------------
+# Event payload validation (audit-v2 #7 / issue #351)
+# ---------------------------------------------------------------------------
+
+
+class TestEventValidation:
+    ## Pre-fix, _handle_event blindly assigned event_data.get(...) to typed
+    ## Session fields, so a malformed plugin event (or hijacked WS) shipped
+    ## non-string values verbatim to MCP clients via Session.to_dict(). Now
+    ## the payloads are Pydantic-validated and dropped on ValidationError.
+
+    async def test_scene_changed_with_non_string_payload_is_dropped(self, harness, caplog):
+        plugin = await harness.connect_plugin(session_id="evt-bad-scene")
+        session = harness.registry.get("evt-bad-scene")
+        baseline_scene = session.current_scene
+
+        with caplog.at_level("WARNING", logger="godot_ai.transport.websocket"):
+            await plugin.send_event("scene_changed", {"current_scene": 12345})
+            await asyncio.sleep(0.05)
+
+        assert session.current_scene == baseline_scene, (
+            "current_scene must not be overwritten with a non-string"
+        )
+        assert any("Dropping malformed scene_changed" in m for m in caplog.messages), (
+            "expected warning log naming the dropped event"
+        )
+        await plugin.close()
+
+    async def test_play_state_changed_with_non_string_payload_is_dropped(self, harness, caplog):
+        plugin = await harness.connect_plugin(session_id="evt-bad-play")
+        session = harness.registry.get("evt-bad-play")
+        baseline_play = session.play_state
+
+        with caplog.at_level("WARNING", logger="godot_ai.transport.websocket"):
+            await plugin.send_event("play_state_changed", {"play_state": ["running"]})
+            await asyncio.sleep(0.05)
+
+        assert session.play_state == baseline_play
+        assert any("Dropping malformed play_state_changed" in m for m in caplog.messages)
+        await plugin.close()
+
+    async def test_readiness_changed_with_non_string_payload_is_dropped(self, harness, caplog):
+        plugin = await harness.connect_plugin(session_id="evt-bad-ready")
+        session = harness.registry.get("evt-bad-ready")
+        baseline_ready = session.readiness
+
+        with caplog.at_level("WARNING", logger="godot_ai.transport.websocket"):
+            await plugin.send_event("readiness_changed", {"readiness": {"nested": "obj"}})
+            await asyncio.sleep(0.05)
+
+        assert session.readiness == baseline_ready
+        assert any("Dropping malformed readiness_changed" in m for m in caplog.messages)
+        await plugin.close()
+
+    async def test_unknown_event_type_is_silently_ignored(self, harness):
+        ## Forward-compat: a future plugin might emit an event type the
+        ## current server doesn't know yet. The handler should ignore it
+        ## without raising or mutating session state.
+        plugin = await harness.connect_plugin(session_id="evt-unknown")
+        session = harness.registry.get("evt-unknown")
+        before = (session.current_scene, session.play_state, session.readiness)
+
+        await plugin.send_event("future_event", {"foo": "bar"})
+        await asyncio.sleep(0.05)
+
+        assert (session.current_scene, session.play_state, session.readiness) == before
+        await plugin.close()
+
+    async def test_valid_event_after_malformed_one_still_applies(self, harness, caplog):
+        ## Regression guard: dropping a malformed payload must not poison
+        ## the connection — the next valid event for the same session
+        ## should still update the typed field.
+        plugin = await harness.connect_plugin(session_id="evt-recover")
+        session = harness.registry.get("evt-recover")
+
+        with caplog.at_level("WARNING", logger="godot_ai.transport.websocket"):
+            await plugin.send_event("readiness_changed", {"readiness": 42})
+            await asyncio.sleep(0.05)
+
+        await plugin.send_event("readiness_changed", {"readiness": "importing"})
+        await asyncio.sleep(0.05)
+        assert session.readiness == "importing"
+        await plugin.close()
+
+
+# ---------------------------------------------------------------------------
 # Multiple sessions
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes the audit-v2 #7 finding from #343: WebSocket event payloads are now Pydantic-validated before they touch typed `Session` fields.

`_handle_event` previously did `event_data.get(...)` blind assignment — `HandshakeMessage` and `CommandResponse` were validated, but the three plugin-emitted state events (`scene_changed`, `play_state_changed`, `readiness_changed`) weren't. A malformed plugin event (or a hijacked WS via the surface #345 / #346 covered) put non-string values straight into `Session.current_scene` / `play_state` / `readiness`, which then shipped to MCP clients verbatim through `Session.to_dict()`.

## Fix

- New Pydantic models in `src/godot_ai/protocol/envelope.py`: `SceneChangedEvent`, `PlayStateChangedEvent`, `ReadinessChangedEvent`. Each carries one typed string field; defaults match the old `.get(default)` shape so a missing key still falls through to the same safe value the caller had been assigning.
- `_handle_event` runs each known event payload through `model_validate()` inside a `try` block. On `ValidationError` the event is dropped with a structured warning log naming the event type + session prefix — the typed `Session` field stays at its current value rather than being corrupted.
- Unknown event types remain silently ignored (forward-compat for future plugin versions).

Diff is small: +140 / −10 across the three files.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check` on touched files — clean
- [x] `pytest -q` — **872 passed** (5 new in `TestEventValidation`)
- [x] `script/ci-check-gdscript` — All GDScript files OK
- [x] New regression tests (`tests/integration/test_websocket.py::TestEventValidation`):
  - `test_scene_changed_with_non_string_payload_is_dropped` — sends `{"current_scene": 12345}`, asserts the typed field is unchanged + the warning was logged
  - `test_play_state_changed_with_non_string_payload_is_dropped` — sends a list payload
  - `test_readiness_changed_with_non_string_payload_is_dropped` — sends a nested dict
  - `test_unknown_event_type_is_silently_ignored` — forward-compat: unknown event names don't raise or mutate state
  - `test_valid_event_after_malformed_one_still_applies` — recovery: a valid event after a dropped one still updates the typed field on the same connection
- [x] Existing `TestEvents` (3 tests covering the happy path) still passes
- [x] Live editor `test_run` skipped — pure Python transport-layer change, no GDScript or handler edits

## Deviations from "Fix shape"

None. The issue called for "add `SceneChangedEvent`, `PlayStateChangedEvent`, `ReadinessChangedEvent` Pydantic models in `protocol/envelope.py`; validate in `_handle_event`." That's the diff.

## Cross-references

Closes #351
Umbrella: #343 (next reliability sweep — adjacent to #345 / #346 / #349 transport-hardening landings)

https://claude.ai/code/session_01ERwAhFK6CEZLRigwK1iC2k

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERwAhFK6CEZLRigwK1iC2k)_