### PR TITLE
[Audit v2 #352] Auto-promote sole survivor on active-session disconnect

### DIFF
--- a/src/godot_ai/sessions/registry.py
+++ b/src/godot_ai/sessions/registry.py
@@ -112,18 +112,29 @@ class SessionRegistry:
                 future.set_result(session)
 
     def unregister(self, session_id: str) -> None:
-        ## Do NOT silently promote another session to active when the active
-        ## one disconnects. Promoting by insertion order means a crash or
-        ## editor_quit on the user's working editor would route subsequent
-        ## commands to whichever editor happened to connect first — the
-        ## "routing by registration order" bug. Clear active instead; the
-        ## next register() or an explicit session_activate will set it.
-        should_log = False
+        ## Active-session promotion policy on disconnect:
+        ## - n>=2 survivors: do NOT auto-promote — picking by insertion order
+        ##   would route the user's commands to whichever editor happened to
+        ##   connect first ("routing by registration order" bug). Caller must
+        ##   session_activate explicitly.
+        ## - n=1 survivor (audit-v2 #8): the only safe single-editor path —
+        ##   promote it with a warning so an agent on the solo-user setup
+        ##   doesn't see opaque "no active session" errors after an editor
+        ##   crash. Ambiguity-by-order can't apply with one survivor.
+        ## - n=0: keep cleared; nothing to promote.
         self._sessions.pop(session_id, None)
-        if self._active_session_id == session_id:
-            self._active_session_id = None
-            should_log = True
-        if should_log:
+        if self._active_session_id != session_id:
+            return
+        self._active_session_id = None
+        if len(self._sessions) == 1:
+            survivor_id = next(iter(self._sessions))
+            self._active_session_id = survivor_id
+            logger.warning(
+                "Active session %s disconnected; auto-promoting sole survivor %s",
+                session_id[:8],
+                survivor_id[:8],
+            )
+        else:
             logger.info(
                 "Active session %s disconnected; no active session until next register/activate",
                 session_id[:8],

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -481,6 +481,32 @@ class TestMultipleSessions:
         assert harness.registry.get("keep-b") is not None
         await plugin_b.close()
 
+    async def test_active_disconnect_with_one_survivor_auto_promotes(self, harness):
+        ## audit-v2 #8: solo-user case. Two editors connect; the user runs
+        ## session_activate on B; A's editor crashes. Pre-fix, every
+        ## subsequent tool call would fail with "no active session" until
+        ## the agent guessed to call session_activate. Now B is auto-
+        ## promoted on A's disconnect.
+        plugin_a = await harness.connect_plugin(session_id="failover-a")
+        plugin_b = await harness.connect_plugin(session_id="failover-b")
+        ## A connected first → A is active. Make A explicitly active so
+        ## the test's preconditions don't depend on registration order
+        ## (registration-order semantics are tested elsewhere).
+        harness.registry.set_active("failover-a")
+        assert harness.registry.active_session_id == "failover-a"
+
+        await plugin_a.close()
+        for _ in range(20):
+            if harness.registry.get("failover-a") is None:
+                break
+            await asyncio.sleep(0.05)
+        assert harness.registry.get("failover-a") is None
+
+        ## B is the only survivor — must be auto-promoted.
+        assert harness.registry.active_session_id == "failover-b"
+        assert harness.registry.get_active().session_id == "failover-b"
+        await plugin_b.close()
+
     async def test_disconnect_reconnect_handshake_then_first_command(self, harness):
         plugin_old = await harness.connect_plugin(session_id="reconnect-old")
         assert harness.registry.active_session_id == "reconnect-old"

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -482,15 +482,15 @@ class TestMultipleSessions:
         await plugin_b.close()
 
     async def test_active_disconnect_with_one_survivor_auto_promotes(self, harness):
-        ## audit-v2 #8: solo-user case. Two editors connect; the user runs
-        ## session_activate on B; A's editor crashes. Pre-fix, every
-        ## subsequent tool call would fail with "no active session" until
-        ## the agent guessed to call session_activate. Now B is auto-
-        ## promoted on A's disconnect.
+        ## audit-v2 #8: solo-user case. Two editors are connected with A
+        ## active; A's editor crashes, leaving B as sole survivor. Pre-fix,
+        ## every subsequent tool call would fail with "no active session"
+        ## until the agent guessed to call session_activate. Now B is
+        ## auto-promoted on A's disconnect.
         plugin_a = await harness.connect_plugin(session_id="failover-a")
         plugin_b = await harness.connect_plugin(session_id="failover-b")
-        ## A connected first → A is active. Make A explicitly active so
-        ## the test's preconditions don't depend on registration order
+        ## A connected first → A is active. Pin A explicitly so the test's
+        ## preconditions don't depend on registration order
         ## (registration-order semantics are tested elsewhere).
         harness.registry.set_active("failover-a")
         assert harness.registry.active_session_id == "failover-a"

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -1450,9 +1450,25 @@ async def test_reload_plugin_pins_target_session_when_multiple_connected():
     assert runtime.active_session_id == "session-b-new"
 
 
-def test_unregister_active_session_clears_active_not_promotes_first():
-    """Disconnect of the active session must not silently promote another
-    session — that's the 'first-registered wins' routing footgun."""
+def test_unregister_active_with_multiple_survivors_clears_active():
+    """Disconnect of the active session with ≥2 survivors must not silently
+    promote another — that's the 'first-registered wins' routing footgun."""
+    registry = SessionRegistry()
+    registry.register(_make_session("session-a"))
+    registry.register(_make_session("session-b"))
+    registry.register(_make_session("session-c"))
+    registry.set_active("session-b")
+
+    registry.unregister("session-b")
+
+    assert registry.active_session_id is None
+    assert registry.get_active() is None
+
+
+def test_unregister_active_with_one_survivor_promotes_it():
+    """audit-v2 #8: at n=1-survivor the order ambiguity disappears, so
+    promote the survivor — solo-user agents would otherwise see opaque
+    'no active session' errors after a crash."""
     registry = SessionRegistry()
     registry.register(_make_session("session-a"))
     registry.register(_make_session("session-b"))
@@ -1460,8 +1476,8 @@ def test_unregister_active_session_clears_active_not_promotes_first():
 
     registry.unregister("session-b")
 
-    assert registry.active_session_id is None
-    assert registry.get_active() is None
+    assert registry.active_session_id == "session-a"
+    assert registry.get_active().session_id == "session-a"
 
 
 def test_unregister_non_active_session_leaves_active_unchanged():

--- a/tests/unit/test_session_registry.py
+++ b/tests/unit/test_session_registry.py
@@ -41,17 +41,36 @@ class TestSessionRegistry:
 
         assert reg.active_session_id == "a"
 
-    def test_unregister_active_clears_active(self):
-        ## Disconnect of the active session must NOT silently promote another
-        ## session to active — that would route commands to whichever session
-        ## was registered first, which is the 'multi-instance routing' bug.
+    def test_unregister_active_with_multiple_survivors_clears_active(self, caplog):
+        ## With ≥2 survivors after unregister, picking one by insertion order
+        ## would route commands to whichever editor connected first — the
+        ## 'routing by registration order' footgun. Stay cleared until the
+        ## caller picks via session_activate.
         reg = SessionRegistry()
         reg.register(_make_session("a"))
         reg.register(_make_session("b"))
-        reg.unregister("a")
+        reg.register(_make_session("c"))
+        with caplog.at_level("INFO", logger="godot_ai.sessions.registry"):
+            reg.unregister("a")
 
         assert reg.active_session_id is None
+        assert len(reg) == 2
+        assert any("no active session until next register/activate" in m for m in caplog.messages)
+
+    def test_unregister_active_with_one_survivor_promotes_it(self, caplog):
+        ## audit-v2 #8: the n=1-survivor case is unambiguous — one editor
+        ## left, no ordering footgun. Auto-promote so a solo-user agent
+        ## doesn't see opaque "no active session" errors after a crash.
+        reg = SessionRegistry()
+        reg.register(_make_session("a"))
+        reg.register(_make_session("b"))
+        with caplog.at_level("WARNING", logger="godot_ai.sessions.registry"):
+            reg.unregister("a")
+
+        assert reg.active_session_id == "b"
+        assert reg.get_active().session_id == "b"
         assert len(reg) == 1
+        assert any("auto-promoting sole survivor" in m for m in caplog.messages)
 
     def test_unregister_non_active_leaves_active(self):
         reg = SessionRegistry()


### PR DESCRIPTION
## Summary

Closes audit-v2 finding #8 (#352): `SessionRegistry.unregister()` now auto-promotes the sole surviving session when the active one disconnects, eliminating the opaque "no active session" error agents hit after a solo-user editor crash.

The "no auto-promotion" rule was correct when ≥2 sessions remain — picking by insertion order would route the user's commands to whichever editor connected first (the registration-order routing footgun) — but it was wrong for the common single-editor case. Now `unregister()` branches on survivor count:

- **n=0** (last session): keep cleared. Same as before.
- **n=1** (sole survivor): auto-promote with a `WARNING` log naming both IDs. Order ambiguity can't apply with one survivor.
- **n≥2**: keep cleared with the existing `INFO` log. Caller must `session_activate` explicitly. Same as before.

Diff: +91 / −19 across one src + three test files.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check` on touched files — clean
- [x] `pytest -q` — **875 passed** (3 net new tests)
- [x] `script/ci-check-gdscript` — All GDScript files OK
- [x] Existing tests updated:
  - `test_session_registry.py::TestSessionRegistry::test_unregister_active_clears_active` → split into `test_unregister_active_with_multiple_survivors_clears_active` (3 sessions, n≥2 case) and `test_unregister_active_with_one_survivor_promotes_it` (n=1 case, asserts promotion + WARNING log)
  - `test_runtime_handlers.py::test_unregister_active_session_clears_active_not_promotes_first` → same split
- [x] New integration test: `TestMultipleSessions::test_active_disconnect_with_one_survivor_auto_promotes` drives the promotion through the real WS lifecycle (two `harness.connect_plugin()` calls, A set active, A's WS closes, assert `registry.active_session_id == "failover-b"` after the disconnect settles)
- [x] Existing `test_unregister_last_clears_active` (n=0 case), `test_unregister_non_active_leaves_active`, `test_disconnect_reconnect_handshake_then_first_command` all still pass — n=0 and "non-active disconnects" are unaffected
- [x] Live editor `test_run` skipped — pure Python in-memory state-machine change, no GDScript or transport-protocol edits

## Deviations from "Fix shape"

None. The issue called for "when exactly one session remains and active was just cleared, auto-promote with a logged warning. The wrong-routing-by-registration-order bug only fires when ≥2 sessions exist, so the n=1 case is safe." That's the implementation.

## Cross-references

Closes #352
Umbrella: #343 (next reliability sweep)

https://claude.ai/code/session_01ERwAhFK6CEZLRigwK1iC2k

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERwAhFK6CEZLRigwK1iC2k)_