### PR TITLE
Migrate last camera make_current test to #335 diagnostic pattern (#316)

### DIFF
--- a/test_project/tests/test_camera.gd
+++ b/test_project/tests/test_camera.gd
@@ -372,10 +372,16 @@ func test_make_current_does_not_cross_classes() -> void:
 	var scene_root := EditorInterface.get_edited_scene_root()
 	var n2 := McpScenePath.resolve(cam2d.data.path, scene_root) as Camera2D
 	var n3 := McpScenePath.resolve(cam3d.data.path, scene_root) as Camera3D
-	assert_true(_wait_for_camera_current(n2, true))
-	assert_true(_wait_for_camera_current(n3, true))
-	assert_eq(n2.is_current(), true, "Camera2D current should not be touched when Camera3D becomes current")
-	assert_eq(n3.is_current(), true)
+	var cam2_current := _wait_for_camera_current_report(n2, true)
+	if _skip_if_macos_engine_lag(n2, true, cam2_current, "Camera2D after Camera3D create"):
+		return
+	assert_true(cam2_current.settled, cam2_current.message)
+	var cam3_current := _wait_for_camera_current_report(n3, true)
+	if _skip_if_macos_engine_lag(n3, true, cam3_current, "Camera3D after create"):
+		return
+	assert_true(cam3_current.settled, cam3_current.message)
+	assert_eq(n2.is_current(), true, "Camera2D current should not be touched when Camera3D becomes current. %s" % _camera_current_diag(n2, true, cam2_current.attempts, cam2_current.elapsed_msec))
+	assert_eq(n3.is_current(), true, "Direct is_current mismatch after wait succeeded. %s" % _camera_current_diag(n3, true, cam3_current.attempts, cam3_current.elapsed_msec))
 
 
 # ============================================================================

--- a/test_project/tests/test_camera.gd
+++ b/test_project/tests/test_camera.gd
@@ -293,11 +293,14 @@ func _skip_if_macos_engine_lag(cam: Node, expected: bool, report: Dictionary, la
 		return false
 	if not _handler_logical_current_matches(cam, expected):
 		return false
+	# The relevant viewport slot depends on camera class — `_handler_logical_current_matches`
+	# already validated cam is a Camera2D or Camera3D in tree.
+	var slot_name := "Viewport.camera_3d" if cam is Camera3D else "Viewport.camera_2d"
 	var msg := (
 		"Engine-state lag on macOS headless (#316): handler logical state "
-		+ "matches expected current=%s but Viewport.camera_2d slot didn't "
+		+ "matches expected current=%s but %s slot didn't "
 		+ "propagate within the wait budget. %s — %s"
-	) % [expected, label, report.message]
+	) % [expected, slot_name, label, report.message]
 	skip(msg)
 	return true
 


### PR DESCRIPTION
## Summary

- Migrate `test_make_current_does_not_cross_classes` ([test_project/tests/test_camera.gd:366-378](https://github.com/hi-godot/godot-ai/blob/beta/test_project/tests/test_camera.gd#L366-L378)) to the diagnostic pattern PR #335 already applied to its two siblings — third test in the family, last bare `assert_true(_wait_for_camera_current(...))` call site.
- Closes the hygiene gap surfaced by [#316](https://github.com/hi-godot/godot-ai/issues/316)'s newest recurrence ([run 25394799329 / Windows](https://github.com/hi-godot/godot-ai/actions/runs/25394799329/job/74478548920)) — the failure currently emits only "Expected true" with no camera identity, viewport state, or handler-vs-engine comparison.
- Same shape as the existing two migrated tests: `_wait_for_camera_current_report` → `_skip_if_macos_engine_lag` → `assert_true(report.settled, report.message)`. Trailing direct-`is_current()` checks now also carry `_camera_current_diag(...)` for the wait-passed-but-direct-check-failed regression case.

## What this PR explicitly does NOT do

- **Does not extend the macOS-only gate to Windows.** That decision needs the rich-diagnostic output from a real Windows recurrence first to confirm the handler-agrees-engine-lags signature actually applies cross-platform. Without that data, extending the gate would be guessing.
- Does not touch handler code (`camera_handler.gd`). The PR #311 / #372 work on the handler side stays correct in observed failures.
- Does not modify other unmessage'd `assert_true` calls in the file (FP comparisons, undoable-flag checks, null guards) — those are deterministic, not flake-prone, and belong in a separate cosmetic PR.

## Test plan

- [x] `pytest -v tests/` from the worktree — 883 passed
- [x] `ruff check src/ tests/` — clean
- [ ] CI: `Godot tests / macOS` — happy path passes (the migration only changes failure-mode diagnostics, not success behavior)
- [ ] CI: `Godot tests / Windows` — happy path passes
- [ ] CI: `Godot tests / Linux` — happy path passes
- [ ] **Real verification deferred**: the next time this test flakes in CI, the failure log will carry `Timed out waiting for camera current=true after N attempts/Xms. camera_state expected_current=true … camera=… viewport_camera=… handler_current=… cam_viewport_id=… cam_viewport_matches_scene=…` instead of the bare "Expected true" — that's where the value of this PR shows up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
