### PR TITLE
[Audit v2 #354] Surface FAILED_MIXED self-update state in editor_state + dock

### DIFF
--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -3,6 +3,8 @@ extends RefCounted
 
 ## Handles editor state, selection, log, screenshot, and performance commands.
 
+const UpdateMixedState := preload("res://addons/godot_ai/utils/update_mixed_state.gd")
+
 var _log_buffer: McpLogBuffer
 var _connection: McpConnection
 var _debugger_plugin: McpDebuggerPlugin
@@ -20,19 +22,26 @@ func _init(log_buffer: McpLogBuffer, connection: McpConnection = null, debugger_
 
 func get_editor_state(_params: Dictionary) -> Dictionary:
 	var scene_root := EditorInterface.get_edited_scene_root()
-	return {
-		"data": {
-			"godot_version": Engine.get_version_info().get("string", "unknown"),
-			"project_name": ProjectSettings.get_setting("application/config/name", ""),
-			"current_scene": scene_root.scene_file_path if scene_root else "",
-			"is_playing": EditorInterface.is_playing_scene(),
-			"readiness": McpConnection.get_readiness(),
-			## True once the game subprocess autoload has beaconed mcp:hello;
-			## false between Play→Stop cycles. Lets capture-source=game callers
-			## poll for a real ready signal instead of guessing with sleep().
-			"game_capture_ready": _debugger_plugin != null and _debugger_plugin.is_game_capture_ready(),
-		}
+	var data := {
+		"godot_version": Engine.get_version_info().get("string", "unknown"),
+		"project_name": ProjectSettings.get_setting("application/config/name", ""),
+		"current_scene": scene_root.scene_file_path if scene_root else "",
+		"is_playing": EditorInterface.is_playing_scene(),
+		"readiness": McpConnection.get_readiness(),
+		## True once the game subprocess autoload has beaconed mcp:hello;
+		## false between Play→Stop cycles. Lets capture-source=game callers
+		## poll for a real ready signal instead of guessing with sleep().
+		"game_capture_ready": _debugger_plugin != null and _debugger_plugin.is_game_capture_ready(),
 	}
+	## Half-installed addon tree from a failed self-update rollback. When
+	## non-empty, the agent / dock paint the operator-facing recovery copy
+	## from `update_mixed_state.gd::diagnose`. Field omitted when the
+	## addons tree is clean so editor_state's normal payload stays small.
+	## See issue #354 / audit-v2 #10.
+	var mixed_state := UpdateMixedState.diagnose()
+	if not mixed_state.is_empty():
+		data["mixed_state"] = mixed_state
+	return {"data": data}
 
 
 func get_selection(_params: Dictionary) -> Dictionary:

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -7,6 +7,7 @@ extends VBoxContainer
 const ServerStateScript := preload("res://addons/godot_ai/utils/mcp_server_state.gd")
 const ClientRefreshStateScript := preload("res://addons/godot_ai/utils/mcp_client_refresh_state.gd")
 const UpdateManagerScript := preload("res://addons/godot_ai/utils/update_manager.gd")
+const UpdateMixedStateScript := preload("res://addons/godot_ai/utils/update_mixed_state.gd")
 const Client := preload("res://addons/godot_ai/clients/_base.gd")
 const ClientConfigurator := preload("res://addons/godot_ai/client_configurator.gd")
 const ClientRegistry := preload("res://addons/godot_ai/clients/_registry.gd")
@@ -189,6 +190,16 @@ const STARTUP_GRACE_MSEC := 60 * 1000
 var _update_banner: VBoxContainer
 var _update_label: Label
 var _update_btn: Button
+
+# Mixed-state banner — surfaces when `addons/godot_ai/` contains
+# `*.update_backup` files left by a self-update whose rollback failed
+# (`UpdateReloadRunner.InstallStatus.FAILED_MIXED`). Without this banner
+# the user sees "plugin won't start" with no actionable context, re-runs
+# the update, and compounds the mismatch (issue #354 / audit-v2 #10).
+var _mixed_state_banner: VBoxContainer
+var _mixed_state_label: RichTextLabel
+var _mixed_state_files: RichTextLabel
+var _mixed_state_rescan_btn: Button
 
 
 func setup(connection: McpConnection, log_buffer: McpLogBuffer, plugin: EditorPlugin) -> void:
@@ -428,6 +439,9 @@ func _build_ui() -> void:
 
 	_crash_panel.add_child(HSeparator.new())
 	add_child(_crash_panel)
+
+	_build_mixed_state_banner()
+	_refresh_mixed_state_banner()
 
 	# --- Update banner (top of dock, hidden until check finds a newer version) ---
 	_update_banner = VBoxContainer.new()
@@ -899,6 +913,70 @@ static func _crash_body_for_state(state: int, server_status: Dictionary = {}) ->
 			return "No godot-ai server found. Install `uv` via the Setup panel above, or run `pip install godot-ai`."
 		_:
 			return ""
+
+
+## Build the mixed-state banner. Hidden until `_refresh_mixed_state_banner`
+## confirms `*.update_backup` files exist in the addons tree. Mirrors the
+## issue #354 fix shape: structured, agent-readable diagnostic that survives
+## a normal editor restart so the user can act on it instead of re-running
+## the update.
+func _build_mixed_state_banner() -> void:
+	_mixed_state_banner = VBoxContainer.new()
+	_mixed_state_banner.add_theme_constant_override("separation", 4)
+	_mixed_state_banner.visible = false
+
+	_mixed_state_label = RichTextLabel.new()
+	_mixed_state_label.bbcode_enabled = false
+	_mixed_state_label.fit_content = true
+	_mixed_state_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_mixed_state_label.selection_enabled = true
+	_mixed_state_label.scroll_active = false
+	_mixed_state_label.add_theme_color_override("default_color", Color.RED)
+	_mixed_state_banner.add_child(_mixed_state_label)
+
+	_mixed_state_files = RichTextLabel.new()
+	_mixed_state_files.bbcode_enabled = false
+	_mixed_state_files.fit_content = true
+	_mixed_state_files.autowrap_mode = TextServer.AUTOWRAP_OFF
+	_mixed_state_files.selection_enabled = true
+	_mixed_state_files.scroll_active = true
+	_mixed_state_files.custom_minimum_size = Vector2(0, 90)
+	_mixed_state_files.add_theme_color_override("default_color", COLOR_AMBER)
+	_mixed_state_banner.add_child(_mixed_state_files)
+
+	_mixed_state_rescan_btn = Button.new()
+	_mixed_state_rescan_btn.text = "Re-scan"
+	_mixed_state_rescan_btn.tooltip_text = (
+		"Scan addons/godot_ai/ for *.update_backup files again."
+		+ " Click after restoring the addon manually to dismiss this banner."
+	)
+	_mixed_state_rescan_btn.pressed.connect(_refresh_mixed_state_banner)
+	_mixed_state_banner.add_child(_mixed_state_rescan_btn)
+
+	_mixed_state_banner.add_child(HSeparator.new())
+	add_child(_mixed_state_banner)
+
+
+func _refresh_mixed_state_banner() -> void:
+	if _mixed_state_banner == null:
+		return
+	var diag := UpdateMixedStateScript.diagnose()
+	if diag.is_empty():
+		_mixed_state_banner.visible = false
+		return
+	_mixed_state_banner.visible = true
+	_mixed_state_label.clear()
+	_mixed_state_label.add_text(String(diag.get("message", "")))
+	_mixed_state_files.clear()
+	var backup_files: Array = diag.get("backup_files", [])
+	for path in backup_files:
+		_mixed_state_files.add_text(String(path))
+		_mixed_state_files.newline()
+	if bool(diag.get("truncated", false)):
+		_mixed_state_files.add_text(
+			"… (list truncated at %d entries)" % UpdateMixedStateScript.MAX_BACKUP_RESULTS
+		)
+		_mixed_state_files.newline()
 
 
 func _build_port_picker_section() -> void:

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -197,7 +197,7 @@ var _update_btn: Button
 # the user sees "plugin won't start" with no actionable context, re-runs
 # the update, and compounds the mismatch (issue #354 / audit-v2 #10).
 var _mixed_state_banner: VBoxContainer
-var _mixed_state_label: RichTextLabel
+var _mixed_state_label: Label
 var _mixed_state_files: RichTextLabel
 var _mixed_state_rescan_btn: Button
 
@@ -925,13 +925,10 @@ func _build_mixed_state_banner() -> void:
 	_mixed_state_banner.add_theme_constant_override("separation", 4)
 	_mixed_state_banner.visible = false
 
-	_mixed_state_label = RichTextLabel.new()
-	_mixed_state_label.bbcode_enabled = false
-	_mixed_state_label.fit_content = true
+	_mixed_state_label = Label.new()
 	_mixed_state_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	_mixed_state_label.selection_enabled = true
-	_mixed_state_label.scroll_active = false
-	_mixed_state_label.add_theme_color_override("default_color", Color.RED)
+	_mixed_state_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_mixed_state_label.add_theme_color_override("font_color", Color.RED)
 	_mixed_state_banner.add_child(_mixed_state_label)
 
 	_mixed_state_files = RichTextLabel.new()
@@ -976,11 +973,13 @@ func _apply_mixed_state_banner_diagnostic(diag: Dictionary) -> void:
 		_mixed_state_banner.visible = false
 		return
 	_mixed_state_banner.visible = true
-	_mixed_state_label.clear()
-	_mixed_state_label.add_text(diag.get("message", ""))
+	## `Dictionary.get(...)` returns Variant; Label.text is typed String.
+	## Explicit cast keeps the type contract honest and dodges some Godot
+	## 4.x point-release quirks around Variant→typed-property assignment.
+	_mixed_state_label.text = String(diag.get("message", ""))
 	_mixed_state_files.clear()
 	for path in diag.get("backup_files", []):
-		_mixed_state_files.add_text(path)
+		_mixed_state_files.add_text(String(path))
 		_mixed_state_files.newline()
 	if bool(diag.get("truncated", false)):
 		_mixed_state_files.add_text(

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -950,27 +950,37 @@ func _build_mixed_state_banner() -> void:
 		"Scan addons/godot_ai/ for *.update_backup files again."
 		+ " Click after restoring the addon manually to dismiss this banner."
 	)
-	_mixed_state_rescan_btn.pressed.connect(_refresh_mixed_state_banner)
+	_mixed_state_rescan_btn.pressed.connect(func(): _refresh_mixed_state_banner(true))
 	_mixed_state_banner.add_child(_mixed_state_rescan_btn)
 
 	_mixed_state_banner.add_child(HSeparator.new())
 	add_child(_mixed_state_banner)
 
 
-func _refresh_mixed_state_banner() -> void:
+func _refresh_mixed_state_banner(force: bool = false) -> void:
+	## Re-scan button passes `force=true` to bypass the scanner's TTL
+	## cache so a manual fix is reflected immediately.
+	_apply_mixed_state_banner_diagnostic(UpdateMixedStateScript.diagnose(
+		UpdateMixedStateScript.ADDON_DIR, force
+	))
+
+
+## Render seam exposed for testing — the GDScript test suite drives this
+## directly with synthetic diagnostics so dock banner contracts can be
+## pinned without polluting the real `addons/godot_ai/` tree with backup
+## files. Callers from production go through `_refresh_mixed_state_banner`.
+func _apply_mixed_state_banner_diagnostic(diag: Dictionary) -> void:
 	if _mixed_state_banner == null:
 		return
-	var diag := UpdateMixedStateScript.diagnose()
 	if diag.is_empty():
 		_mixed_state_banner.visible = false
 		return
 	_mixed_state_banner.visible = true
 	_mixed_state_label.clear()
-	_mixed_state_label.add_text(String(diag.get("message", "")))
+	_mixed_state_label.add_text(diag.get("message", ""))
 	_mixed_state_files.clear()
-	var backup_files: Array = diag.get("backup_files", [])
-	for path in backup_files:
-		_mixed_state_files.add_text(String(path))
+	for path in diag.get("backup_files", []):
+		_mixed_state_files.add_text(path)
 		_mixed_state_files.newline()
 	if bool(diag.get("truncated", false)):
 		_mixed_state_files.add_text(

--- a/plugin/addons/godot_ai/utils/update_mixed_state.gd
+++ b/plugin/addons/godot_ai/utils/update_mixed_state.gd
@@ -1,0 +1,81 @@
+@tool
+extends RefCounted
+
+## Scanner that detects whether `addons/godot_ai/` is in a half-installed
+## state left behind by a self-update whose rollback couldn't restore the
+## previous addon contents (`UpdateReloadRunner.InstallStatus.FAILED_MIXED`).
+##
+## Without this surface the user sees "plugin won't start" with no actionable
+## context, re-runs the update, and compounds the mismatch (issue #354 /
+## audit-v2 #10). The dock paints a banner from `diagnose()` and
+## `editor_handler.gd::get_editor_state` includes the same Dictionary so an
+## MCP agent can see and report the state.
+
+const ADDON_DIR := "res://addons/godot_ai/"
+const BACKUP_SUFFIX := ".update_backup"
+## Cap so a runaway addons tree (someone parented the wrong dir, an old
+## crashed install left thousands of artifacts) can't blow the
+## `editor_state` payload size or freeze the editor on first paint.
+const MAX_BACKUP_RESULTS := 200
+
+
+## Walk `dir` recursively and return every `res://`-relative path that ends
+## in `.update_backup`, sorted ascending. Empty when the addons tree is
+## clean. Truncates at `MAX_BACKUP_RESULTS` — the truncation flag is exposed
+## via `diagnose()`.
+static func find_backups(dir: String = ADDON_DIR) -> Array:
+	var results: Array = []
+	if not DirAccess.dir_exists_absolute(ProjectSettings.globalize_path(dir)):
+		return results
+	var stack: Array = [dir]
+	while not stack.is_empty():
+		if results.size() >= MAX_BACKUP_RESULTS:
+			break
+		var current: String = stack.pop_back()
+		var d := DirAccess.open(current)
+		if d == null:
+			continue
+		d.list_dir_begin()
+		while true:
+			var entry := d.get_next()
+			if entry.is_empty():
+				break
+			if entry == "." or entry == "..":
+				continue
+			var full := current.path_join(entry)
+			if d.current_is_dir():
+				stack.append(full)
+			elif entry.ends_with(BACKUP_SUFFIX):
+				results.append(full)
+				if results.size() >= MAX_BACKUP_RESULTS:
+					break
+		d.list_dir_end()
+	results.sort()
+	return results
+
+
+## Build the structured diagnostic Dictionary surfaced via `editor_state`
+## and the dock banner. Empty Dictionary when the addons tree is clean —
+## callers gate banner visibility / response field on `is_empty()`.
+##
+## Returned shape:
+##   addon_dir: String        ## "res://addons/godot_ai/"
+##   backup_files: Array[String]
+##   backup_count: int
+##   truncated: bool          ## true when the cap was hit
+##   message: String          ## one-sentence operator hint
+static func diagnose(dir: String = ADDON_DIR) -> Dictionary:
+	var backups := find_backups(dir)
+	if backups.is_empty():
+		return {}
+	return {
+		"addon_dir": dir,
+		"backup_files": backups,
+		"backup_count": backups.size(),
+		"truncated": backups.size() >= MAX_BACKUP_RESULTS,
+		"message": (
+			"Self-update rollback failed; addons/godot_ai/ contains a mix of"
+			+ " old and new files. Restore the addon from your VCS or a fresh"
+			+ " release ZIP, then delete the listed *.update_backup files."
+		),
+	}

--- a/plugin/addons/godot_ai/utils/update_mixed_state.gd
+++ b/plugin/addons/godot_ai/utils/update_mixed_state.gd
@@ -11,30 +11,53 @@ extends RefCounted
 ## `editor_handler.gd::get_editor_state` includes the same Dictionary so an
 ## MCP agent can see and report the state.
 
+const UpdateReloadRunner := preload("res://addons/godot_ai/update_reload_runner.gd")
+
 const ADDON_DIR := "res://addons/godot_ai/"
-const BACKUP_SUFFIX := ".update_backup"
+## Single source of truth for the suffix lives on the producer
+## (`UpdateReloadRunner._install_zip_file`); aliasing here so the scanner
+## can never drift from what the runner actually writes.
+const BACKUP_SUFFIX := UpdateReloadRunner.INSTALL_BACKUP_SUFFIX
 ## Cap so a runaway addons tree (someone parented the wrong dir, an old
 ## crashed install left thousands of artifacts) can't blow the
 ## `editor_state` payload size or freeze the editor on first paint.
 const MAX_BACKUP_RESULTS := 200
+## TTL for the `diagnose()` cache. `editor_state` is one of the highest-
+## traffic MCP tools (agents poll it constantly) and a recursive
+## `DirAccess` walk on every call would put I/O on the 4ms `_process()`
+## budget. Mixed-state is rare and persistent across editor restarts, so
+## a few seconds of staleness is acceptable; the dock's Re-scan button
+## bypasses the cache via `force=true` for immediate feedback.
+const CACHE_TTL_MSEC := 5000
+
+static var _cache_value: Dictionary = {}
+static var _cache_timestamp_msec: int = -1
 
 
 ## Walk `dir` recursively and return every `res://`-relative path that ends
-## in `.update_backup`, sorted ascending. Empty when the addons tree is
-## clean. Truncates at `MAX_BACKUP_RESULTS` — the truncation flag is exposed
-## via `diagnose()`.
+## in `.update_backup`, sorted ascending. Truncates at `MAX_BACKUP_RESULTS`
+## — the truncation flag is exposed via `diagnose()`.
+##
+## Walk order is deterministic: entries within each directory are sorted
+## alphabetically, subdirs pushed reverse-sorted so DFS pops them in
+## ascending order. Without this two scans of the same mixed tree could
+## return different 200-file slices when truncation kicks in (Godot's
+## `list_dir` order isn't guaranteed stable across filesystems).
 static func find_backups(dir: String = ADDON_DIR) -> Array:
 	var results: Array = []
-	if not DirAccess.dir_exists_absolute(ProjectSettings.globalize_path(dir)):
-		return results
 	var stack: Array = [dir]
 	while not stack.is_empty():
 		if results.size() >= MAX_BACKUP_RESULTS:
 			break
 		var current: String = stack.pop_back()
 		var d := DirAccess.open(current)
+		## Missing dir, permission error, or unreadable junction — skip
+		## silently. A missing addons dir is the bare-clone case; mid-walk
+		## errors stay quiet so a single permission glitch can't block the
+		## diagnostic the rest of the scan would have produced.
 		if d == null:
 			continue
+		var entries: Array = []
 		d.list_dir_begin()
 		while true:
 			var entry := d.get_next()
@@ -42,40 +65,77 @@ static func find_backups(dir: String = ADDON_DIR) -> Array:
 				break
 			if entry == "." or entry == "..":
 				continue
-			var full := current.path_join(entry)
-			if d.current_is_dir():
-				stack.append(full)
-			elif entry.ends_with(BACKUP_SUFFIX):
-				results.append(full)
-				if results.size() >= MAX_BACKUP_RESULTS:
-					break
+			entries.append({"name": entry, "is_dir": d.current_is_dir()})
 		d.list_dir_end()
+		entries.sort_custom(func(a, b): return a["name"] < b["name"])
+		## Push subdirs reverse-sorted so the next outer iteration pops
+		## them in ascending order — see method docstring for why this
+		## determinism matters for the truncated case.
+		for i in range(entries.size() - 1, -1, -1):
+			var entry: Dictionary = entries[i]
+			if entry["is_dir"]:
+				stack.append(current.path_join(entry["name"]))
+		for entry in entries:
+			if entry["is_dir"]:
+				continue
+			if not String(entry["name"]).ends_with(BACKUP_SUFFIX):
+				continue
+			results.append(current.path_join(entry["name"]))
+			if results.size() >= MAX_BACKUP_RESULTS:
+				break
 	results.sort()
 	return results
 
 
 ## Build the structured diagnostic Dictionary surfaced via `editor_state`
-## and the dock banner. Empty Dictionary when the addons tree is clean —
-## callers gate banner visibility / response field on `is_empty()`.
+## and the dock banner. Empty when the addons tree is clean — callers
+## gate banner visibility / response field on `is_empty()`.
 ##
-## Returned shape:
-##   addon_dir: String        ## "res://addons/godot_ai/"
-##   backup_files: Array[String]
-##   backup_count: int
-##   truncated: bool          ## true when the cap was hit
-##   message: String          ## one-sentence operator hint
-static func diagnose(dir: String = ADDON_DIR) -> Dictionary:
+## Cached for `CACHE_TTL_MSEC` when scanning the default `ADDON_DIR` so
+## per-`editor_state` polls don't re-walk the addons tree every frame.
+## Tests passing a custom `dir` always see a fresh scan (cache only
+## tracks the production path). `force=true` bypasses the cache — used
+## by the dock's Re-scan button so a manual fix is reflected immediately.
+static func diagnose(dir: String = ADDON_DIR, force: bool = false) -> Dictionary:
+	var use_cache := dir == ADDON_DIR and not force
+	if use_cache and _cache_timestamp_msec >= 0:
+		if Time.get_ticks_msec() - _cache_timestamp_msec < CACHE_TTL_MSEC:
+			return _cache_value.duplicate(true)
+
 	var backups := find_backups(dir)
-	if backups.is_empty():
-		return {}
-	return {
-		"addon_dir": dir,
-		"backup_files": backups,
-		"backup_count": backups.size(),
-		"truncated": backups.size() >= MAX_BACKUP_RESULTS,
-		"message": (
-			"Self-update rollback failed; addons/godot_ai/ contains a mix of"
-			+ " old and new files. Restore the addon from your VCS or a fresh"
-			+ " release ZIP, then delete the listed *.update_backup files."
-		),
-	}
+	var result: Dictionary = {}
+	if not backups.is_empty():
+		## Most commonly produced by `_rollback_paths_written` returning
+		## FAILED_MIXED, but `_finalize_install_success` removes backups on
+		## a best-effort basis so a successful install can also leave them
+		## behind if the cleanup `remove_absolute` hit a permission error.
+		## The recovery action — delete the *.update_backup files — is the
+		## same in both cases, so the message acknowledges both
+		## possibilities rather than asserting the alarming one.
+		result = {
+			"addon_dir": dir,
+			"backup_files": backups,
+			"backup_count": backups.size(),
+			"truncated": backups.size() >= MAX_BACKUP_RESULTS,
+			"message": (
+				"Found .update_backup files in addons/godot_ai/. This usually"
+				+ " means a self-update rollback couldn't restore the previous"
+				+ " addon contents (FAILED_MIXED) — the plugin may load a mix"
+				+ " of old and new files. Restore the addon from your VCS or a"
+				+ " fresh release ZIP, then delete the listed *.update_backup"
+				+ " files. If the plugin runs without issues these are likely"
+				+ " stale from a successful install and safe to delete."
+			),
+		}
+	if use_cache:
+		_cache_value = result.duplicate(true)
+		_cache_timestamp_msec = Time.get_ticks_msec()
+	return result
+
+
+## Reset the `diagnose()` cache. Tests that flip the addons-tree state
+## between calls use this to avoid TTL-bound flakiness; the dock's
+## Re-scan button uses `force=true` instead.
+static func clear_cache() -> void:
+	_cache_value = {}
+	_cache_timestamp_msec = -1

--- a/plugin/addons/godot_ai/utils/update_mixed_state.gd.uid
+++ b/plugin/addons/godot_ai/utils/update_mixed_state.gd.uid
@@ -1,0 +1,1 @@
+uid://dd5rti52vgs71

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -125,6 +125,93 @@ func test_drift_banner_no_op_when_mismatched_set_unchanged() -> void:
 	assert_true(_dock._drift_label.text != first_text, "Different set must produce different text")
 
 
+func test_mixed_state_banner_hidden_in_clean_addons_tree() -> void:
+	## The dock builds the mixed-state banner during `_build_ui` and seeds
+	## it from `UpdateMixedState.diagnose()`. In test_project's tree the
+	## addons dir has no `.update_backup` files, so the banner must default
+	## to hidden. Without this guard a future regression that always shows
+	## the banner would only surface when a real FAILED_MIXED state landed.
+	_dock._build_ui()
+	assert_true(_dock._mixed_state_banner != null, "Banner must be constructed by _build_ui")
+	assert_false(
+		_dock._mixed_state_banner.visible,
+		"Clean addons tree must keep the mixed-state banner hidden",
+	)
+
+
+func test_mixed_state_banner_renders_synthetic_diagnostic() -> void:
+	## Drive the render seam with a fake diagnostic so the banner contract
+	## (visibility + label text + file list) is pinned without polluting
+	## the real `addons/godot_ai/` tree with `.update_backup` files. This
+	## covers Copilot's "dock banner is untested" finding on PR #382.
+	_dock._build_ui()
+	var fake_diag := {
+		"addon_dir": "res://addons/godot_ai/",
+		"backup_files": [
+			"res://addons/godot_ai/handlers/scene_handler.gd.update_backup",
+			"res://addons/godot_ai/plugin.gd.update_backup",
+		],
+		"backup_count": 2,
+		"truncated": false,
+		"message": "Fake diagnostic for test_mixed_state_banner_renders_synthetic_diagnostic",
+	}
+	_dock._apply_mixed_state_banner_diagnostic(fake_diag)
+	assert_true(_dock._mixed_state_banner.visible, "Non-empty diagnostic must show banner")
+	assert_contains(
+		_dock._mixed_state_label.text,
+		"Fake diagnostic for test_mixed_state_banner_renders_synthetic_diagnostic",
+		"Banner must surface the diagnostic message verbatim",
+	)
+	assert_contains(
+		_dock._mixed_state_files.text,
+		"plugin.gd.update_backup",
+		"Banner must list each backup file path so the operator can act on them",
+	)
+
+
+func test_mixed_state_banner_re_hides_when_diagnostic_empties() -> void:
+	## The Re-scan button calls `_refresh_mixed_state_banner(true)` which
+	## eventually feeds the apply seam an empty Dict when the addons tree
+	## has been restored. Pin that the banner correctly hides when applied
+	## with `{}` so the button delivers the dismissal it advertises.
+	_dock._build_ui()
+	_dock._apply_mixed_state_banner_diagnostic({
+		"addon_dir": "res://addons/godot_ai/",
+		"backup_files": ["res://addons/godot_ai/foo.gd.update_backup"],
+		"backup_count": 1,
+		"truncated": false,
+		"message": "show me",
+	})
+	assert_true(_dock._mixed_state_banner.visible, "Precondition: banner must be visible")
+	_dock._apply_mixed_state_banner_diagnostic({})
+	assert_false(
+		_dock._mixed_state_banner.visible,
+		"Empty diagnostic must hide the banner — the Re-scan dismissal path",
+	)
+
+
+func test_mixed_state_banner_renders_truncated_hint() -> void:
+	## When the scanner caps results, the dock must surface that the list
+	## isn't exhaustive — otherwise a power user with a runaway tree thinks
+	## they only have N backups when there might be more. The truncation
+	## hint references the canonical MAX_BACKUP_RESULTS so the message
+	## stays accurate if the cap moves.
+	_dock._build_ui()
+	_dock._apply_mixed_state_banner_diagnostic({
+		"addon_dir": "res://addons/godot_ai/",
+		"backup_files": ["res://addons/godot_ai/x.gd.update_backup"],
+		"backup_count": 200,
+		"truncated": true,
+		"message": "lots of backups",
+	})
+	assert_true(_dock._mixed_state_banner.visible)
+	assert_contains(
+		_dock._mixed_state_files.text,
+		"truncated",
+		"truncated=true must produce the cap-hit hint in the file list",
+	)
+
+
 func test_apply_row_status_renders_mismatch_as_amber_with_url_hint() -> void:
 	## The row UI is the per-client mirror of the dock-level banner —
 	## amber dot + "URL out of date" suffix on the name label so a

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -162,8 +162,11 @@ func test_mixed_state_banner_renders_synthetic_diagnostic() -> void:
 		"Fake diagnostic for test_mixed_state_banner_renders_synthetic_diagnostic",
 		"Banner must surface the diagnostic message verbatim",
 	)
+	## RichTextLabel.text reflects the BBCode source, not the rendered
+	## content added via `add_text()` — assert via `get_parsed_text()`
+	## which returns the visible text concatenation.
 	assert_contains(
-		_dock._mixed_state_files.text,
+		_dock._mixed_state_files.get_parsed_text(),
 		"plugin.gd.update_backup",
 		"Banner must list each backup file path so the operator can act on them",
 	)
@@ -206,7 +209,7 @@ func test_mixed_state_banner_renders_truncated_hint() -> void:
 	})
 	assert_true(_dock._mixed_state_banner.visible)
 	assert_contains(
-		_dock._mixed_state_files.text,
+		_dock._mixed_state_files.get_parsed_text(),
 		"truncated",
 		"truncated=true must produce the cap-hit hint in the file list",
 	)

--- a/test_project/tests/test_update_mixed_state.gd
+++ b/test_project/tests/test_update_mixed_state.gd
@@ -26,10 +26,14 @@ func suite_setup(_ctx: Dictionary) -> void:
 func teardown() -> void:
 	_clean_scratch_dir()
 	DirAccess.make_dir_recursive_absolute(_scratch_dir)
+	## Static cache survives across tests; clear so a prior run's stale
+	## production-path scan can't bleed into the next case.
+	UpdateMixedState.clear_cache()
 
 
 func suite_teardown() -> void:
 	_clean_scratch_dir()
+	UpdateMixedState.clear_cache()
 
 
 func _clean_scratch_dir() -> void:
@@ -151,10 +155,81 @@ func test_diagnose_carries_structured_fields() -> void:
 	assert_has_key(diag, "truncated")
 	assert_eq(false, bool(diag["truncated"]), "two entries are well below the cap")
 	assert_has_key(diag, "message")
+	var message: String = diag["message"]
 	assert_true(
-		String(diag["message"]).contains("addons/godot_ai/"),
+		message.contains("addons/godot_ai/"),
 		"message should name the addons dir so the operator knows where to look",
 	)
+	assert_true(
+		message.contains("FAILED_MIXED"),
+		"message should name the FAILED_MIXED state so a searching agent can correlate",
+	)
+	## The scanner can't tell FAILED_MIXED from "successful install whose
+	## best-effort cleanup hit a permission error" — both leave
+	## .update_backup files. Pin that the message acknowledges the
+	## ambiguity so the dock copy doesn't lie to users in the latter case.
+	assert_true(
+		message.contains("safe to delete") or message.contains("stale"),
+		"message should acknowledge the stale-backup case as well as FAILED_MIXED",
+	)
+
+
+func test_find_backups_walk_is_deterministic_when_truncated() -> void:
+	## Truncation cap is rare in practice but when it kicks in two scans of
+	## the same tree must return the same 200-file slice — otherwise the
+	## "diff cleanly across calls" property breaks. Pin this by creating
+	## enough files to overflow the cap and asserting the result is stable
+	## across repeated invocations.
+	var max_results: int = UpdateMixedState.MAX_BACKUP_RESULTS
+	var overflow_count := max_results + 25
+	for i in range(overflow_count):
+		_make_file(
+			_scratch_dir.path_join(
+				"sub_%02d/file_%04d.gd%s"
+				% [i % 4, i, UpdateMixedState.BACKUP_SUFFIX]
+			),
+			"vN content %d" % i,
+		)
+	var first := UpdateMixedState.find_backups(_scratch_dir)
+	var second := UpdateMixedState.find_backups(_scratch_dir)
+	assert_eq(max_results, first.size(), "first scan should hit cap")
+	assert_eq(max_results, second.size(), "second scan should hit cap")
+	assert_eq(first, second, "two scans of the same tree must return the same slice")
+
+
+func test_diagnose_caches_repeated_default_dir_calls() -> void:
+	## `editor_state` is one of the most-called MCP tools and runs the
+	## scanner on every poll. Pin that a second call within the TTL is a
+	## cache hit by mutating the addons tree between calls and verifying
+	## the cached result wins until clear_cache() forces a re-scan.
+	UpdateMixedState.clear_cache()
+	## First call: production ADDON_DIR, no force, populates cache.
+	var first := UpdateMixedState.diagnose()
+	## In the test_project tree this should be empty (no .update_backup
+	## files present); we just need a cached snapshot to compare against.
+	assert_true(first.is_empty(), "test_project tree must be clean for this test to drive the cache")
+	## Second call: still cached (within 5s TTL), returns the same Dict.
+	var second := UpdateMixedState.diagnose()
+	assert_eq(first, second, "second call within TTL must hit cache")
+	## clear_cache() forces the next call to re-scan.
+	UpdateMixedState.clear_cache()
+	var third := UpdateMixedState.diagnose()
+	assert_eq(first, third, "post-clear scan returns the same clean result")
+
+
+func test_diagnose_force_bypasses_cache() -> void:
+	## Re-scan button uses `force=true` so a manual fix is reflected
+	## without waiting for the TTL. Pin that force re-runs the walk even
+	## with a fresh cache populated by a normal call.
+	UpdateMixedState.clear_cache()
+	var cached := UpdateMixedState.diagnose()
+	assert_true(cached.is_empty(), "test_project tree must be clean")
+	## With force=true the scanner must not return the cached value — it
+	## must re-walk. The result is still empty here (clean tree) but the
+	## contract is that the walk happened. We assert force returns the
+	## same empty Dict shape.
+	var forced := UpdateMixedState.diagnose(UpdateMixedState.ADDON_DIR, true)
+	assert_eq(cached, forced, "forced re-scan returns the same shape on a clean tree")
 
 
 func test_find_backups_caps_results_at_max() -> void:

--- a/test_project/tests/test_update_mixed_state.gd
+++ b/test_project/tests/test_update_mixed_state.gd
@@ -1,0 +1,176 @@
+@tool
+extends McpTestSuite
+
+## Tests for `update_mixed_state.gd` — the scanner that surfaces the
+## half-installed addon-tree diagnostic in `editor_state` and the dock
+## (issue #354 / audit-v2 #10).
+##
+## Cases run against a scratch dir under `user://` so the tests never
+## touch the real addons tree or rely on its current contents.
+
+const UpdateMixedState := preload("res://addons/godot_ai/utils/update_mixed_state.gd")
+
+var _scratch_dir: String
+
+
+func suite_name() -> String:
+	return "update_mixed_state"
+
+
+func suite_setup(_ctx: Dictionary) -> void:
+	_scratch_dir = OS.get_user_data_dir().path_join("mcp_update_mixed_state_tests")
+	_clean_scratch_dir()
+	DirAccess.make_dir_recursive_absolute(_scratch_dir)
+
+
+func teardown() -> void:
+	_clean_scratch_dir()
+	DirAccess.make_dir_recursive_absolute(_scratch_dir)
+
+
+func suite_teardown() -> void:
+	_clean_scratch_dir()
+
+
+func _clean_scratch_dir() -> void:
+	if not DirAccess.dir_exists_absolute(_scratch_dir):
+		return
+	var dirs_to_walk := [_scratch_dir]
+	var all_dirs := []
+	while not dirs_to_walk.is_empty():
+		var cur: String = dirs_to_walk.pop_back()
+		all_dirs.append(cur)
+		for sub in DirAccess.get_directories_at(cur):
+			dirs_to_walk.append(cur.path_join(sub))
+	all_dirs.reverse()
+	for d in all_dirs:
+		for f in DirAccess.get_files_at(d):
+			DirAccess.remove_absolute(d.path_join(f))
+		if d != _scratch_dir:
+			DirAccess.remove_absolute(d)
+
+
+func _make_file(path: String, content: String) -> void:
+	DirAccess.make_dir_recursive_absolute(path.get_base_dir())
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	f.store_string(content)
+	f.close()
+
+
+func test_find_backups_empty_when_dir_clean() -> void:
+	_make_file(_scratch_dir.path_join("plugin.gd"), "extends Node")
+	_make_file(_scratch_dir.path_join("handlers/scene_handler.gd"), "extends RefCounted")
+	var backups := UpdateMixedState.find_backups(_scratch_dir)
+	assert_eq(0, backups.size(), "clean dir should produce no backup matches")
+
+
+func test_find_backups_detects_top_level() -> void:
+	## A FAILED_MIXED rollback typically leaves backup snapshots next to the
+	## file that couldn't be restored. Pin that the scanner finds them at the
+	## top level of the addons tree.
+	_make_file(_scratch_dir.path_join("plugin.gd"), "vN+1 content")
+	_make_file(
+		_scratch_dir.path_join("plugin.gd" + UpdateMixedState.BACKUP_SUFFIX),
+		"vN content",
+	)
+	var backups := UpdateMixedState.find_backups(_scratch_dir)
+	assert_eq(1, backups.size(), "should find exactly one backup")
+	assert_true(
+		String(backups[0]).ends_with("plugin.gd" + UpdateMixedState.BACKUP_SUFFIX),
+		"path should point at the .update_backup snapshot",
+	)
+
+
+func test_find_backups_recurses_subdirectories() -> void:
+	## Backups can land anywhere in the addon tree (handlers/, utils/,
+	## clients/, etc.). Pin recursive walk.
+	_make_file(
+		_scratch_dir.path_join("handlers/scene_handler.gd" + UpdateMixedState.BACKUP_SUFFIX),
+		"vN scene handler",
+	)
+	_make_file(
+		_scratch_dir.path_join(
+			"utils/log_buffer.gd" + UpdateMixedState.BACKUP_SUFFIX
+		),
+		"vN log buffer",
+	)
+	_make_file(_scratch_dir.path_join("clients/_base.gd"), "vN+1 client base")
+	var backups := UpdateMixedState.find_backups(_scratch_dir)
+	assert_eq(2, backups.size(), "recursion should pick up both nested backups")
+	## Sorted output is part of the contract — agents diffing two scans
+	## shouldn't see spurious churn from filesystem walk order.
+	assert_true(String(backups[0]) < String(backups[1]), "results must be sorted ascending")
+
+
+func test_find_backups_ignores_non_backup_files() -> void:
+	## The .uid sidecars next to every .gd, plus ordinary .tscn/.cfg files,
+	## must not register as MIXED-state evidence.
+	_make_file(_scratch_dir.path_join("plugin.cfg"), "[plugin]")
+	_make_file(_scratch_dir.path_join("plugin.gd.uid"), "uid=abc")
+	_make_file(_scratch_dir.path_join("foo.tres"), "[res]")
+	var backups := UpdateMixedState.find_backups(_scratch_dir)
+	assert_eq(0, backups.size(), "non-.update_backup files must not match")
+
+
+func test_find_backups_returns_empty_for_missing_dir() -> void:
+	## A hypothetical bare clone where addons/godot_ai/ doesn't exist (or
+	## was removed) shouldn't crash the scanner.
+	var nonexistent := _scratch_dir.path_join("does_not_exist")
+	assert_false(
+		DirAccess.dir_exists_absolute(nonexistent),
+		"precondition: nonexistent dir must really not exist",
+	)
+	var backups := UpdateMixedState.find_backups(nonexistent)
+	assert_eq(0, backups.size(), "missing dir must return empty list, not error")
+
+
+func test_diagnose_empty_when_clean() -> void:
+	_make_file(_scratch_dir.path_join("plugin.gd"), "extends Node")
+	var diag := UpdateMixedState.diagnose(_scratch_dir)
+	assert_true(diag.is_empty(), "clean addons tree must produce empty diagnose() Dictionary")
+
+
+func test_diagnose_carries_structured_fields() -> void:
+	## editor_state's contract is that the field is a structured Dictionary
+	## with addon_dir / backup_files / backup_count / truncated / message
+	## keys — pin every one so a future field rename can't silently drop one.
+	_make_file(
+		_scratch_dir.path_join("foo.gd" + UpdateMixedState.BACKUP_SUFFIX), "vN foo"
+	)
+	_make_file(
+		_scratch_dir.path_join("bar.gd" + UpdateMixedState.BACKUP_SUFFIX), "vN bar"
+	)
+	var diag := UpdateMixedState.diagnose(_scratch_dir)
+	assert_false(diag.is_empty(), "non-clean tree must produce non-empty Dictionary")
+	assert_has_key(diag, "addon_dir")
+	assert_eq(_scratch_dir, diag["addon_dir"], "addon_dir should round-trip the scanned path")
+	assert_has_key(diag, "backup_files")
+	assert_eq(2, (diag["backup_files"] as Array).size(), "backup_files lists every match")
+	assert_has_key(diag, "backup_count")
+	assert_eq(2, int(diag["backup_count"]), "backup_count mirrors the array size")
+	assert_has_key(diag, "truncated")
+	assert_eq(false, bool(diag["truncated"]), "two entries are well below the cap")
+	assert_has_key(diag, "message")
+	assert_true(
+		String(diag["message"]).contains("addons/godot_ai/"),
+		"message should name the addons dir so the operator knows where to look",
+	)
+
+
+func test_find_backups_caps_results_at_max() -> void:
+	## A pathological install that left thousands of backup files (e.g. an
+	## old crashed install loop) shouldn't blow up the editor_state response
+	## or freeze the dock paint. The cap must be honored and the truncated
+	## flag set so the operator knows there's more than what's shown.
+	var max_results: int = UpdateMixedState.MAX_BACKUP_RESULTS
+	var overflow_count := max_results + 5
+	for i in range(overflow_count):
+		_make_file(
+			_scratch_dir.path_join("file_%04d.gd%s" % [i, UpdateMixedState.BACKUP_SUFFIX]),
+			"vN content %d" % i,
+		)
+	var backups := UpdateMixedState.find_backups(_scratch_dir)
+	assert_eq(max_results, backups.size(), "result list must respect MAX_BACKUP_RESULTS cap")
+	var diag := UpdateMixedState.diagnose(_scratch_dir)
+	assert_eq(true, bool(diag["truncated"]), "diagnose() must flag truncation when the cap is hit")
+	assert_eq(max_results, int(diag["backup_count"]), "backup_count reflects what was returned, not what existed on disk")

--- a/test_project/tests/test_update_mixed_state.gd.uid
+++ b/test_project/tests/test_update_mixed_state.gd.uid
@@ -1,0 +1,1 @@
+uid://dni74dv3tnnrp

--- a/tests/unit/test_editor_state_mixed_state.py
+++ b/tests/unit/test_editor_state_mixed_state.py
@@ -1,0 +1,132 @@
+"""Unit tests for the FAILED_MIXED self-update diagnostic in `editor_state`.
+
+The plugin's `update_mixed_state.gd` scanner attaches a structured
+`mixed_state` Dictionary to the GDScript `get_editor_state` response when
+`addons/godot_ai/` contains `*.update_backup` files left behind by a
+self-update whose rollback couldn't restore the previous addon contents
+(`UpdateReloadRunner.InstallStatus.FAILED_MIXED`). These tests pin the
+Python-side passthrough so an MCP agent observing the field can rely on
+its presence and shape without having to probe the plugin directly.
+
+See issue #354 / audit-v2 #10. The GDScript scanner itself is exercised
+by `test_project/tests/test_update_mixed_state.gd`.
+"""
+
+from __future__ import annotations
+
+from godot_ai.handlers import editor as editor_handlers
+from godot_ai.runtime.direct import DirectRuntime
+from godot_ai.sessions.registry import Session, SessionRegistry
+
+
+class _EditorStateClient:
+    """Stub plugin that returns whatever payload the test injects."""
+
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    async def send(
+        self,
+        command: str,
+        params: dict | None = None,
+        session_id: str | None = None,
+        timeout: float = 5.0,
+    ) -> dict:
+        if command != "get_editor_state":
+            raise AssertionError(f"unexpected command: {command}")
+        return dict(self._payload)
+
+
+def _runtime_with_payload(payload: dict) -> DirectRuntime:
+    session = Session(
+        session_id="test-001",
+        godot_version="4.4.1",
+        project_path="/tmp/test",
+        plugin_version="0.0.1",
+        readiness="ready",
+    )
+    registry = SessionRegistry()
+    registry.register(session)
+    return DirectRuntime(registry=registry, client=_EditorStateClient(payload))
+
+
+_BASE_PAYLOAD: dict = {
+    "godot_version": "4.4.1",
+    "project_name": "p",
+    "current_scene": "res://main.tscn",
+    "is_playing": False,
+    "readiness": "ready",
+    "game_capture_ready": False,
+}
+
+
+async def test_editor_state_omits_mixed_state_when_clean():
+    """When the addons tree has no `.update_backup` files, the plugin
+    omits the `mixed_state` key entirely. The Python handler must not
+    invent it — agents distinguish "clean" vs "MIXED" on key presence."""
+    runtime = _runtime_with_payload(_BASE_PAYLOAD)
+
+    result = await editor_handlers.editor_state(runtime)
+
+    assert "mixed_state" not in result, (
+        "mixed_state must be absent when the plugin reports a clean tree"
+    )
+
+
+async def test_editor_state_passes_through_mixed_state_diagnostic():
+    """When the plugin reports a half-installed addon tree, the Python
+    handler must surface every field of the structured diagnostic so an
+    MCP agent (or the dock crash banner consumer) can render it."""
+    mixed = {
+        "addon_dir": "res://addons/godot_ai/",
+        "backup_files": [
+            "res://addons/godot_ai/handlers/scene_handler.gd.update_backup",
+            "res://addons/godot_ai/plugin.gd.update_backup",
+        ],
+        "backup_count": 2,
+        "truncated": False,
+        "message": (
+            "Self-update rollback failed; addons/godot_ai/ contains a mix"
+            " of old and new files. Restore the addon from your VCS or a"
+            " fresh release ZIP, then delete the listed *.update_backup"
+            " files."
+        ),
+    }
+    payload = dict(_BASE_PAYLOAD)
+    payload["mixed_state"] = mixed
+    runtime = _runtime_with_payload(payload)
+
+    result = await editor_handlers.editor_state(runtime)
+
+    assert result.get("mixed_state") == mixed, (
+        "Python handler must pass through the GDScript scanner's mixed_state Dictionary unchanged"
+    )
+    ## Spot-check structural keys so a future field rename in the
+    ## scanner can't silently drop one downstream.
+    surfaced = result["mixed_state"]
+    assert surfaced["addon_dir"] == "res://addons/godot_ai/"
+    assert len(surfaced["backup_files"]) == 2
+    assert surfaced["backup_count"] == 2
+    assert surfaced["truncated"] is False
+    assert "addons/godot_ai/" in surfaced["message"]
+
+
+async def test_editor_state_passes_through_truncated_mixed_state():
+    """A pathological install that left thousands of backups gets capped
+    by the scanner. Pin that the truncated flag still passes through so
+    the agent knows the list isn't exhaustive."""
+    mixed = {
+        "addon_dir": "res://addons/godot_ai/",
+        "backup_files": [f"res://addons/godot_ai/file_{i}.gd.update_backup" for i in range(200)],
+        "backup_count": 200,
+        "truncated": True,
+        "message": "Self-update rollback failed; addons/godot_ai/ ...",
+    }
+    payload = dict(_BASE_PAYLOAD)
+    payload["mixed_state"] = mixed
+    runtime = _runtime_with_payload(payload)
+
+    result = await editor_handlers.editor_state(runtime)
+
+    assert result["mixed_state"]["truncated"] is True
+    assert len(result["mixed_state"]["backup_files"]) == 200


### PR DESCRIPTION
## Summary

Closes audit-v2 finding #10 (#354): when self-update's runner reports `InstallStatus.FAILED_MIXED` (rollback couldn't restore the previous addon contents), the runner correctly refuses to re-enable the plugin — but the half-installed state was previously invisible to both MCP agents and the dock. Users saw "plugin won't start," re-ran the update, and compounded the mismatch.

This PR adds a structured "addon dir is in MIXED state, here are the `.update_backup` files" diagnostic in two places:

- **MCP `editor_state`** — adds a `mixed_state` field with `addon_dir`, `backup_files`, `backup_count`, `truncated`, and `message`. The field is **omitted entirely** when the addons tree is clean, so agents distinguish "MIXED" vs "clean" on key presence and the normal payload stays small.
- **Dock banner** — a separate red/amber banner (independent of the spawn-failure crash panel) listing the leftover `*.update_backup` paths plus a **Re-scan** button so the user can dismiss the banner after restoring the addon manually from VCS or a fresh release ZIP.

## Design

Both surfaces consume the same scanner — `plugin/addons/godot_ai/utils/update_mixed_state.gd`:

- Walks `res://addons/godot_ai/` recursively for files ending in `.update_backup`.
- Caps results at `MAX_BACKUP_RESULTS = 200`; on hit, sets `truncated: true` so an agent reading `editor_state` knows the list isn't exhaustive.
- Returns an empty `Dictionary` when the tree is clean (callers gate on `is_empty()`).
- Sorted output so two consecutive scans diff cleanly.
- **No marker file**: `.update_backup` files on disk ARE the evidence. This is resilient to a runner crash that happens before a hypothetical marker write — and it works automatically across editor restarts (which is the realistic case here, since by the time `FAILED_MIXED` lands the plugin has already been disabled and the dock detached).

`editor_handler.gd::get_editor_state` calls `UpdateMixedState.diagnose()` and adds the `mixed_state` field only when non-empty. `mcp_dock.gd` builds a new banner during `_build_ui` and refreshes it once on dock construction (`_refresh_mixed_state_banner`), with the same helper bound to the **Re-scan** button.

The runner itself is unchanged. This PR is a pure read-side surface for a state the runner already produces correctly.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — my new test file reformatted; everything else clean
- [x] `pytest -q` — **878 passed**
- [x] `script/ci-check-gdscript` — All GDScript files OK
- [x] New Python tests in `tests/unit/test_editor_state_mixed_state.py`:
  - `test_editor_state_omits_mixed_state_when_clean` — clean addons tree → field absent
  - `test_editor_state_passes_through_mixed_state_diagnostic` — MIXED → every field surfaces unchanged (`addon_dir`, `backup_files`, `backup_count`, `truncated`, `message`)
  - `test_editor_state_passes_through_truncated_mixed_state` — `truncated: true` survives the passthrough
- [x] New GDScript tests in `test_project/tests/test_update_mixed_state.gd`:
  - `test_find_backups_empty_when_dir_clean`
  - `test_find_backups_detects_top_level`
  - `test_find_backups_recurses_subdirectories` — also asserts sorted output
  - `test_find_backups_ignores_non_backup_files` — `.uid`, `.tres`, `.cfg` etc. don't match
  - `test_find_backups_returns_empty_for_missing_dir` — bare clone won't crash the scanner
  - `test_diagnose_empty_when_clean`
  - `test_diagnose_carries_structured_fields` — pins every key on the contract
  - `test_find_backups_caps_results_at_max` — pathological 1000s-of-backups scenario won't blow up `editor_state`

## Interactive smoke (`script/local-self-update-smoke`) — NOT run from this session

Per CLAUDE.md, changes that touch `mcp_dock.gd` "update check/download/install paths" or `update_reload_runner.gd` trigger the interactive harness. This PR touches `mcp_dock.gd` only to **add** a separate banner (in `_build_ui`) that **reads** addons-tree state — none of the update check / download / install paths change. `update_reload_runner.gd` is untouched. The runner's `FAILED_MIXED` semantics are exactly as #297 / `_rollback_paths_written` left them.

That said, the interactive harness is not runnable from this CI session (requires a real Godot editor and manual click). Mitigations:

1. **The change is purely additive.** Clean addons tree → scanner returns `{}` → banner stays hidden → `editor_state` payload unchanged. Existing happy-path smoke output is byte-identical to pre-PR.
2. **The MIXED-state branch is unit-tested in isolation.** The eight GDScript tests drive the scanner against a scratch dir under `user://`, so we exercise every diagnostic field and the truncation path without needing to corrupt a real addons dir.
3. **The Python passthrough has its own coverage** — three unit tests pin clean / MIXED / truncated.

**Recommendation for @dsarno**: please run `script/local-self-update-smoke` locally before merging if you want belt-and-suspenders verification. The new banner construction is on the happy path of `_build_ui`, but it consults disk via `DirAccess` — worth a sanity check that it doesn't add visible latency to the dock paint.

## Deviations from "Fix shape"

None. The issue called for "a structured 'addon dir is in MIXED state, here are the `.update_backup` files' diagnostic in the dock crash panel and `editor_state`." Implemented as a separate banner (rather than mutating the existing `_crash_panel`) because the spawn-failure crash panel is keyed off `ServerStateScript` and `is_terminal_diagnosis` — orthogonal to addon-tree state. The MIXED banner can show concurrent with a healthy server, and a healthy server can run alongside MIXED-state addon files.

## Cross-references

Closes #354
Umbrella: #343 (audit-v2 reliability sweep — adjacent to #353 / #345 / #349 / #351 / #352)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbW6sEKTKiVvanWoy19LoG)_