### PR TITLE
[Audit v2 #362] Cache meta-tool dynamic Literal via functools.cache

### DIFF
--- a/src/godot_ai/tools/_meta_tool.py
+++ b/src/godot_ai/tools/_meta_tool.py
@@ -50,10 +50,8 @@ MANAGE_TOOL_OPS: dict[str, tuple[str, ...]] = {}
 
 @functools.cache
 def _op_literal_for(op_names: frozenset[str]) -> Any:
-    ## Sorting yields a deterministic Literal arg order so the cache key
-    ## (a frozenset, order-independent) maps to a stable type — and any
-    ## error message Pydantic emits ("must be one of …") stays consistent
-    ## across registrations of the same op set.
+    ## Sort because the cache key is a frozenset (orderless); a stable arg
+    ## order keeps Pydantic's "Input should be …" error message consistent.
     return Literal[tuple(sorted(op_names))]  # type: ignore[valid-type]
 
 

--- a/src/godot_ai/tools/_meta_tool.py
+++ b/src/godot_ai/tools/_meta_tool.py
@@ -48,6 +48,15 @@ OpHandler = Callable[..., Awaitable[dict] | dict]
 MANAGE_TOOL_OPS: dict[str, tuple[str, ...]] = {}
 
 
+@functools.cache
+def _op_literal_for(op_names: frozenset[str]) -> Any:
+    ## Sorting yields a deterministic Literal arg order so the cache key
+    ## (a frozenset, order-independent) maps to a stable type — and any
+    ## error message Pydantic emits ("must be one of …") stays consistent
+    ## across registrations of the same op set.
+    return Literal[tuple(sorted(op_names))]  # type: ignore[valid-type]
+
+
 def register_manage_tool(
     mcp: FastMCP,
     *,
@@ -75,7 +84,7 @@ def register_manage_tool(
         raise ValueError(f"register_manage_tool: ops cannot be empty (tool {tool_name!r})")
 
     MANAGE_TOOL_OPS[tool_name] = tuple(ops.keys())
-    op_literal = Literal[tuple(ops.keys())]  # type: ignore[valid-type]
+    op_literal = _op_literal_for(frozenset(ops.keys()))
 
     async def manage(ctx: Context, op, params=None, session_id="") -> dict:
         runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)

--- a/tests/unit/test_meta_tool.py
+++ b/tests/unit/test_meta_tool.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, get_args
 from unittest.mock import AsyncMock
 
 import pytest
@@ -11,6 +11,7 @@ from fastmcp import FastMCP
 from godot_ai.godot_client.client import GodotCommandError
 from godot_ai.protocol.errors import ErrorCode
 from godot_ai.tools._meta_tool import (
+    _op_literal_for,
     dispatch_manage_op,
     register_manage_tool,
 )
@@ -62,6 +63,31 @@ def test_register_rejects_empty_ops():
     mcp = FastMCP("test")
     with pytest.raises(ValueError, match="ops cannot be empty"):
         register_manage_tool(mcp, tool_name="x_manage", description="x", ops={})
+
+
+# ---------------------------------------------------------------------------
+# Op-literal memoization (Audit v2 #18 / #362)
+# ---------------------------------------------------------------------------
+
+
+def test_op_literal_for_returns_same_object_for_equal_op_sets():
+    ## Two registrations with the same op names — even in different insertion
+    ## orders — must share one Literal so Pydantic doesn't rebuild equivalent
+    ## schema fragments per domain.
+    a = _op_literal_for(frozenset({"create", "delete", "rename"}))
+    b = _op_literal_for(frozenset({"rename", "create", "delete"}))
+    assert a is b
+
+
+def test_op_literal_for_returns_distinct_object_for_different_op_sets():
+    a = _op_literal_for(frozenset({"create", "delete"}))
+    b = _op_literal_for(frozenset({"create", "delete", "rename"}))
+    assert a is not b
+
+
+def test_op_literal_for_args_are_sorted_for_determinism():
+    literal = _op_literal_for(frozenset({"zeta", "alpha", "mu"}))
+    assert get_args(literal) == ("alpha", "mu", "zeta")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Memoize the `<domain>_manage` op `Literal` via a new `_op_literal_for(frozenset(ops.keys()))` helper decorated with `functools.cache`, so equivalent registrations share one Literal instead of rebuilding it per `register_manage_tool` call.
- Sort the cached Literal args inside the helper so the cache key (a frozenset, order-independent) maps to a stable type — Pydantic's "Input should be 'a', 'b', …" error stays consistent across registrations.
- Faithful to the issue's "Fix shape": no other behavior change.

## Test plan
- [x] `ruff check src/godot_ai/tools/_meta_tool.py tests/unit/test_meta_tool.py` (clean)
- [x] `ruff format --check` (clean for both touched files; pre-existing format warnings on 4 unrelated files left alone)
- [x] `pytest -v` — 881 passed, including new tests:
  - `test_op_literal_for_returns_same_object_for_equal_op_sets` (verifies frozenset memoization)
  - `test_op_literal_for_returns_distinct_object_for_different_op_sets`
  - `test_op_literal_for_args_are_sorted_for_determinism`
- [x] `script/ci-check-gdscript` (pass)
- [x] No GDScript or write-tool surface touched, so no Godot live-smoke needed.

Closes #362
Refs #343

---
_Generated by [Claude Code](https://claude.ai/code/session_01BL8ftPeGHALe7WZ6rYUXzo)_