### PR TITLE
[Audit v2 #363] Lint enforces every meta-tool read op declares a resource form

### DIFF
--- a/src/godot_ai/tools/_meta_tool.py
+++ b/src/godot_ai/tools/_meta_tool.py
@@ -47,6 +47,17 @@ OpHandler = Callable[..., Awaitable[dict] | dict]
 ## reverse-engineering Pydantic's human-readable error string.
 MANAGE_TOOL_OPS: dict[str, tuple[str, ...]] = {}
 
+## (tool_name -> op_name -> handler) so the resource-form lint at test time
+## can introspect each handler's source to classify it as read vs write.
+MANAGE_TOOL_HANDLERS: dict[str, dict[str, OpHandler]] = {}
+
+## (tool_name -> op_name -> URI string | None). Per-op resource declaration
+## for read ops: a URI string declares the matching ``godot://...`` resource
+## form, ``None`` is an explicit waiver acknowledging there is no resource
+## counterpart. Write ops (handlers that call ``require_writable``) are
+## exempt from this declaration; the lint enforces only read-op coverage.
+MANAGE_TOOL_RESOURCE_FORMS: dict[str, dict[str, str | None]] = {}
+
 
 @functools.cache
 def _op_literal_for(op_names: frozenset[str]) -> Any:
@@ -61,6 +72,7 @@ def register_manage_tool(
     tool_name: str,
     description: str,
     ops: dict[str, OpHandler],
+    read_resource_forms: Mapping[str, str | None] | None = None,
 ) -> None:
     """Register a `<domain>_manage` tool that dispatches by op name.
 
@@ -74,6 +86,15 @@ def register_manage_tool(
             ``runtime`` as its first arg and accepts the same keyword args
             as the underlying shared handler in ``handlers/<domain>.py``.
             The dispatcher unpacks ``params`` via ``**`` before calling.
+        read_resource_forms: Per-op declaration of the matching
+            ``godot://...`` resource URI for read ops, or ``None`` as an
+            explicit waiver when no resource counterpart exists. Keys must
+            be a subset of ``ops``. Read-vs-write classification is done
+            by ``tests/unit/test_resource_form_lint.py`` at test time
+            (handlers calling ``require_writable`` are write ops and are
+            exempt from declaration). The lint fails if a read op has
+            no entry here, or if the declared URI isn't actually
+            registered — catching both new-op drift and phantom-URI typos.
 
     Unknown ops raise ``GodotCommandError`` with ``INVALID_PARAMS`` and
     ``data.suggestions`` populated by ``difflib.get_close_matches``.
@@ -81,7 +102,31 @@ def register_manage_tool(
     if not ops:
         raise ValueError(f"register_manage_tool: ops cannot be empty (tool {tool_name!r})")
 
+    if read_resource_forms is not None:
+        unknown = set(read_resource_forms) - set(ops)
+        if unknown:
+            raise ValueError(
+                f"register_manage_tool: read_resource_forms keys "
+                f"{sorted(unknown)!r} are not in ops for {tool_name!r}"
+            )
+        for op_name, form in read_resource_forms.items():
+            if form is not None and not isinstance(form, str):
+                raise ValueError(
+                    f"register_manage_tool: read_resource_forms[{op_name!r}] "
+                    f"must be a 'godot://' URI string or None waiver "
+                    f"(got {type(form).__name__})"
+                )
+            if isinstance(form, str) and not form.startswith("godot://"):
+                raise ValueError(
+                    f"register_manage_tool: read_resource_forms[{op_name!r}] "
+                    f"URI must start with 'godot://' (got {form!r})"
+                )
+
     MANAGE_TOOL_OPS[tool_name] = tuple(ops.keys())
+    MANAGE_TOOL_HANDLERS[tool_name] = dict(ops)
+    MANAGE_TOOL_RESOURCE_FORMS[tool_name] = (
+        dict(read_resource_forms) if read_resource_forms is not None else {}
+    )
     op_literal = _op_literal_for(frozenset(ops.keys()))
 
     async def manage(ctx: Context, op, params=None, session_id="") -> dict:

--- a/src/godot_ai/tools/animation.py
+++ b/src/godot_ai/tools/animation.py
@@ -17,8 +17,6 @@ from godot_ai.tools._meta_tool import register_manage_tool
 _DESCRIPTION = """\
 AnimationPlayer authoring (player, tracks, autoplay, presets, playback).
 
-Resource form: ``godot://animations`` — prefer for active-session reads.
-
 Ops:
   • player_create(parent_path, name="AnimationPlayer")
         Create an AnimationPlayer with empty default library.
@@ -128,5 +126,15 @@ def register_animation_tools(mcp: FastMCP) -> None:
             "preset_slide": animation_handlers.animation_preset_slide,
             "preset_shake": animation_handlers.animation_preset_shake,
             "preset_pulse": animation_handlers.animation_preset_pulse,
+        },
+        read_resource_forms={
+            ## No `godot://animations` resource exists. Animation reads are
+            ## stateful (per-player, per-clip) and don't fit the single-URL
+            ## resource shape; agents fetch via the rollup ops.
+            "validate": None,
+            "play": None,
+            "stop": None,
+            "list": None,
+            "get": None,
         },
     )

--- a/src/godot_ai/tools/audio.py
+++ b/src/godot_ai/tools/audio.py
@@ -53,4 +53,10 @@ def register_audio_tools(mcp: FastMCP) -> None:
             "stop": audio_handlers.audio_stop,
             "list": audio_handlers.audio_list,
         },
+        read_resource_forms={
+            ## Audio reads are stateful and per-player; no aggregate resource.
+            "play": None,
+            "stop": None,
+            "list": None,
+        },
     )

--- a/src/godot_ai/tools/autoload.py
+++ b/src/godot_ai/tools/autoload.py
@@ -32,4 +32,7 @@ def register_autoload_tools(mcp: FastMCP) -> None:
             "add": autoload_handlers.autoload_add,
             "remove": autoload_handlers.autoload_remove,
         },
+        read_resource_forms={
+            "list": None,  ## No aggregate autoload resource yet.
+        },
     )

--- a/src/godot_ai/tools/camera.py
+++ b/src/godot_ai/tools/camera.py
@@ -65,4 +65,8 @@ def register_camera_tools(mcp: FastMCP) -> None:
             "list": camera_handlers.camera_list,
             "apply_preset": camera_handlers.camera_apply_preset,
         },
+        read_resource_forms={
+            "get": None,  ## No per-camera resource.
+            "list": None,  ## No aggregate cameras resource.
+        },
     )

--- a/src/godot_ai/tools/client.py
+++ b/src/godot_ai/tools/client.py
@@ -35,4 +35,12 @@ def register_client_tools(mcp: FastMCP) -> None:
             "configure": client_handlers.client_configure,
             "remove": client_handlers.client_remove,
         },
+        read_resource_forms={
+            ## Client ops touch local MCP-client config files (Claude Desktop,
+            ## Cursor, etc.) — they're plumbing, not Godot scene reads, and
+            ## have no `godot://` analogue.
+            "status": None,
+            "configure": None,
+            "remove": None,
+        },
     )

--- a/src/godot_ai/tools/editor.py
+++ b/src/godot_ai/tools/editor.py
@@ -189,4 +189,14 @@ def register_editor_tools(mcp: FastMCP, *, include_non_core: bool = True) -> Non
             "quit": editor_handlers.editor_quit,
             "logs_clear": editor_handlers.logs_clear,
         },
+        read_resource_forms={
+            "state": "godot://editor/state",
+            "selection_get": "godot://selection/current",
+            "monitors_get": "godot://performance",
+            ## quit is destructive but skips require_writable so a stuck
+            ## editor can still be quit; logs_clear truncates logs. Neither
+            ## has a resource counterpart.
+            "quit": None,
+            "logs_clear": None,
+        },
     )

--- a/src/godot_ai/tools/filesystem.py
+++ b/src/godot_ai/tools/filesystem.py
@@ -38,4 +38,10 @@ def register_filesystem_tools(mcp: FastMCP) -> None:
             "reimport": filesystem_handlers.filesystem_reimport,
             "search": filesystem_handlers.filesystem_search,
         },
+        read_resource_forms={
+            ## File reads/searches are per-call queries with arbitrary path
+            ## or query inputs; no fixed-URI resource shape fits.
+            "read_text": None,
+            "search": None,
+        },
     )

--- a/src/godot_ai/tools/input_map.py
+++ b/src/godot_ai/tools/input_map.py
@@ -44,4 +44,7 @@ def register_input_map_tools(mcp: FastMCP) -> None:
             "remove_action": input_map_handlers.input_map_remove_action,
             "bind_event": input_map_handlers.input_map_bind_event,
         },
+        read_resource_forms={
+            "list": "godot://input_map",
+        },
     )

--- a/src/godot_ai/tools/material.py
+++ b/src/godot_ai/tools/material.py
@@ -59,4 +59,8 @@ def register_material_tools(mcp: FastMCP) -> None:
             "apply_to_node": material_handlers.material_apply_to_node,
             "apply_preset": material_handlers.material_apply_preset,
         },
+        read_resource_forms={
+            "get": None,  ## Per-material read; no per-resource URI shape.
+            "list": "godot://materials",
+        },
     )

--- a/src/godot_ai/tools/node.py
+++ b/src/godot_ai/tools/node.py
@@ -191,4 +191,8 @@ def register_node_tools(mcp: FastMCP, *, include_non_core: bool = True) -> None:
             "add_to_group": node_handlers.node_add_to_group,
             "remove_from_group": node_handlers.node_remove_from_group,
         },
+        read_resource_forms={
+            "get_children": "godot://node/{path*}/children",
+            "get_groups": "godot://node/{path*}/groups",
+        },
     )

--- a/src/godot_ai/tools/particle.py
+++ b/src/godot_ai/tools/particle.py
@@ -52,4 +52,10 @@ def register_particle_tools(mcp: FastMCP) -> None:
             "get": particle_handlers.particle_get,
             "apply_preset": particle_handlers.particle_apply_preset,
         },
+        read_resource_forms={
+            ## restart triggers a re-emit but skips require_writable; get is
+            ## per-emitter introspection. No aggregate particles resource.
+            "restart": None,
+            "get": None,
+        },
     )

--- a/src/godot_ai/tools/project.py
+++ b/src/godot_ai/tools/project.py
@@ -67,4 +67,9 @@ def register_project_tools(mcp: FastMCP) -> None:
             "settings_get": project_handlers.project_settings_get,
             "settings_set": project_handlers.project_settings_set,
         },
+        read_resource_forms={
+            ## stop ends a play session; not a read in the URI sense.
+            "stop": None,
+            "settings_get": "godot://project/settings",
+        },
     )

--- a/src/godot_ai/tools/resource.py
+++ b/src/godot_ai/tools/resource.py
@@ -82,4 +82,11 @@ def register_resource_tools(mcp: FastMCP) -> None:
             "gradient_texture_create": texture_handlers.gradient_texture_create,
             "noise_texture_create": texture_handlers.noise_texture_create,
         },
+        read_resource_forms={
+            ## search/load/get_info take per-call queries or paths; no aggregate
+            ## resource fits the URI shape.
+            "search": None,
+            "load": None,
+            "get_info": None,
+        },
     )

--- a/src/godot_ai/tools/scene.py
+++ b/src/godot_ai/tools/scene.py
@@ -99,4 +99,10 @@ def register_scene_tools(mcp: FastMCP, *, include_non_core: bool = True) -> None
             "save_as": scene_handlers.scene_save_as,
             "get_roots": scene_handlers.scene_get_roots,
         },
+        read_resource_forms={
+            ## get_roots lists root nodes of every open scene; the
+            ## `godot://scene/current` resource only exposes the active scene
+            ## tree, so it isn't a substitute. No aggregate resource fits.
+            "get_roots": None,
+        },
     )

--- a/src/godot_ai/tools/script.py
+++ b/src/godot_ai/tools/script.py
@@ -114,4 +114,8 @@ def register_script_tools(mcp: FastMCP) -> None:
             "detach": script_handlers.script_detach,
             "find_symbols": script_handlers.script_find_symbols,
         },
+        read_resource_forms={
+            "read": "godot://script/{path*}",
+            "find_symbols": None,  ## Per-script symbol lookup; no resource form.
+        },
     )

--- a/src/godot_ai/tools/session.py
+++ b/src/godot_ai/tools/session.py
@@ -56,4 +56,7 @@ def register_session_tools(mcp: FastMCP, *, include_non_core: bool = True) -> No
         ops={
             "list": session_handlers.session_list,
         },
+        read_resource_forms={
+            "list": "godot://sessions",
+        },
     )

--- a/src/godot_ai/tools/signal.py
+++ b/src/godot_ai/tools/signal.py
@@ -35,4 +35,7 @@ def register_signal_tools(mcp: FastMCP) -> None:
             "connect": signal_handlers.signal_connect,
             "disconnect": signal_handlers.signal_disconnect,
         },
+        read_resource_forms={
+            "list": None,  ## Per-node signal listing; no aggregate resource.
+        },
     )

--- a/src/godot_ai/tools/testing.py
+++ b/src/godot_ai/tools/testing.py
@@ -66,4 +66,7 @@ def register_testing_tools(mcp: FastMCP) -> None:
         ops={
             "results_get": testing_handlers.test_results_get,
         },
+        read_resource_forms={
+            "results_get": "godot://test/results",
+        },
     )

--- a/tests/unit/test_meta_tool.py
+++ b/tests/unit/test_meta_tool.py
@@ -11,10 +11,38 @@ from fastmcp import FastMCP
 from godot_ai.godot_client.client import GodotCommandError
 from godot_ai.protocol.errors import ErrorCode
 from godot_ai.tools._meta_tool import (
+    MANAGE_TOOL_HANDLERS,
+    MANAGE_TOOL_OPS,
+    MANAGE_TOOL_RESOURCE_FORMS,
     _op_literal_for,
     dispatch_manage_op,
     register_manage_tool,
 )
+
+
+@pytest.fixture(autouse=True)
+def _restore_registries():
+    """Snapshot/restore the manage-tool registries.
+
+    Several tests below register synthetic tools (``x_manage``, ``domain_manage``,
+    etc.) directly via ``register_manage_tool`` rather than through
+    ``create_server``. Without restoration those entries leak into the
+    process-global registries and then trip ``test_resource_form_lint``,
+    which sees handlers from ``unittest.mock`` and demands declarations.
+    """
+    saved_ops = dict(MANAGE_TOOL_OPS)
+    saved_handlers = {k: dict(v) for k, v in MANAGE_TOOL_HANDLERS.items()}
+    saved_forms = {k: dict(v) for k, v in MANAGE_TOOL_RESOURCE_FORMS.items()}
+    try:
+        yield
+    finally:
+        MANAGE_TOOL_OPS.clear()
+        MANAGE_TOOL_OPS.update(saved_ops)
+        MANAGE_TOOL_HANDLERS.clear()
+        MANAGE_TOOL_HANDLERS.update(saved_handlers)
+        MANAGE_TOOL_RESOURCE_FORMS.clear()
+        MANAGE_TOOL_RESOURCE_FORMS.update(saved_forms)
+
 
 # ---------------------------------------------------------------------------
 # Schema construction
@@ -63,6 +91,57 @@ def test_register_rejects_empty_ops():
     mcp = FastMCP("test")
     with pytest.raises(ValueError, match="ops cannot be empty"):
         register_manage_tool(mcp, tool_name="x_manage", description="x", ops={})
+
+
+def test_register_rejects_resource_form_for_unknown_op():
+    mcp = FastMCP("test")
+    with pytest.raises(ValueError, match="not in ops"):
+        register_manage_tool(
+            mcp,
+            tool_name="x_manage",
+            description="x",
+            ops={"a": AsyncMock()},
+            read_resource_forms={"b": "godot://x"},  # 'b' not in ops
+        )
+
+
+def test_register_rejects_non_godot_uri_in_resource_form():
+    mcp = FastMCP("test")
+    with pytest.raises(ValueError, match="must start with 'godot://'"):
+        register_manage_tool(
+            mcp,
+            tool_name="x_manage",
+            description="x",
+            ops={"a": AsyncMock()},
+            read_resource_forms={"a": "https://example.com"},
+        )
+
+
+def test_register_rejects_non_string_non_none_value_in_resource_form():
+    mcp = FastMCP("test")
+    with pytest.raises(ValueError, match="must be a 'godot://' URI string or None"):
+        register_manage_tool(
+            mcp,
+            tool_name="x_manage",
+            description="x",
+            ops={"a": AsyncMock()},
+            read_resource_forms={"a": 42},  # type: ignore[dict-item]
+        )
+
+
+def test_register_accepts_resource_form_with_uri_and_waiver():
+    mcp = FastMCP("test")
+    handler_a = AsyncMock(return_value={})
+    handler_b = AsyncMock(return_value={})
+    register_manage_tool(
+        mcp,
+        tool_name="acceptance_manage",
+        description="x",
+        ops={"a": handler_a, "b": handler_b},
+        read_resource_forms={"a": "godot://thing", "b": None},
+    )
+    assert MANAGE_TOOL_RESOURCE_FORMS["acceptance_manage"] == {"a": "godot://thing", "b": None}
+    assert MANAGE_TOOL_HANDLERS["acceptance_manage"]["a"] is handler_a
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_resource_form_lint.py
+++ b/tests/unit/test_resource_form_lint.py
@@ -1,0 +1,191 @@
+"""Lint: every read op under a `<domain>_manage` tool must declare a resource form.
+
+The audit (#363) caught a drift hazard: when a `<domain>_manage` rollup gains
+a pure-read op, no convention required the matching `godot://...` resource
+to update in lockstep. Clients that prefer URI reads silently get stale data.
+
+This lint enforces the convention. Every op whose handler does NOT call
+`require_writable` is classified as a read op and must appear in
+`read_resource_forms` on its `register_manage_tool` call — either as a URI
+string (declaring the matching resource) or as `None` (explicit waiver
+when no resource counterpart exists). Declared URIs must resolve to an
+actually-registered resource; phantom URIs (``godot://animations`` was the
+motivating example) fail the lint too.
+
+Named ``@mcp.tool`` tools all take ``session_id`` and document their resource
+form in the docstring; they are out of scope for this lint per the audit's
+literal "handler signature doesn't take session_id" framing.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+from typing import Any
+
+import pytest
+
+from godot_ai.server import create_server
+from godot_ai.tools._meta_tool import (
+    MANAGE_TOOL_HANDLERS,
+    MANAGE_TOOL_OPS,
+    MANAGE_TOOL_RESOURCE_FORMS,
+)
+
+
+@pytest.fixture(scope="module")
+def mcp():
+    ## Triggers all tool + resource registrations, populating the manage-tool
+    ## registries this lint walks.
+    return create_server(ws_port=0)
+
+
+def _handler_calls_require_writable(handler: Any) -> bool:
+    """Return True if the handler's source contains a ``require_writable(...)`` call.
+
+    AST-based so a string literal mentioning the name (or a comment) doesn't
+    register as a call. Walks both bare (``require_writable(rt)``) and
+    attribute (``readiness.require_writable(rt)``) call shapes — the
+    latter doesn't appear in the codebase today but stays defensible.
+    """
+    try:
+        source = inspect.getsource(handler)
+    except (OSError, TypeError):
+        return False
+
+    try:
+        tree = ast.parse(textwrap.dedent(source))
+    except SyntaxError:
+        return False
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Name) and func.id == "require_writable":
+            return True
+        if isinstance(func, ast.Attribute) and func.attr == "require_writable":
+            return True
+    return False
+
+
+async def _resource_uris(mcp_server) -> set[str]:
+    """Collect all registered resource URIs and resource-template URI patterns.
+
+    Resource templates are surfaced as URI patterns (``godot://node/{path*}/properties``)
+    so a tool declaring the templated form matches the registered template
+    without needing to substitute a path.
+    """
+    uris: set[str] = set()
+
+    if hasattr(mcp_server, "list_resources"):
+        for resource in await mcp_server.list_resources():
+            uris.add(str(getattr(resource, "uri", resource)))
+    elif hasattr(mcp_server, "get_resources"):
+        for resource in await mcp_server.get_resources():
+            uris.add(str(getattr(resource, "uri", resource)))
+
+    list_templates = getattr(mcp_server, "list_resource_templates", None) or getattr(
+        mcp_server, "get_resource_templates", None
+    )
+    if list_templates is not None:
+        templates = await list_templates()
+        if isinstance(templates, dict):
+            templates = templates.values()
+        for template in templates:
+            for attr in ("uriTemplate", "uri_template", "uri"):
+                value = getattr(template, attr, None)
+                if value is not None:
+                    uris.add(str(value))
+                    break
+
+    return uris
+
+
+# ---------------------------------------------------------------------------
+# Coverage lint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_meta_tool_read_ops_declare_resource_form(mcp):
+    """Every read op under a `<domain>_manage` tool must declare a form."""
+    available_uris = await _resource_uris(mcp)
+
+    missing: list[str] = []
+    phantom: list[str] = []
+
+    for tool_name in sorted(MANAGE_TOOL_OPS):
+        forms = MANAGE_TOOL_RESOURCE_FORMS.get(tool_name, {})
+        handlers = MANAGE_TOOL_HANDLERS.get(tool_name, {})
+        for op_name in MANAGE_TOOL_OPS[tool_name]:
+            handler = handlers.get(op_name)
+            if handler is None:
+                continue
+            if _handler_calls_require_writable(handler):
+                continue  ## write op — exempt
+            if op_name not in forms:
+                source_module = getattr(handler, "__module__", "<unknown>")
+                source_name = getattr(handler, "__qualname__", repr(handler))
+                missing.append(f"  {tool_name}.{op_name}  (handler {source_module}.{source_name})")
+                continue
+            form = forms[op_name]
+            if form is not None and form not in available_uris:
+                phantom.append(f"  {tool_name}.{op_name}  declares {form!r}")
+
+    parts: list[str] = []
+    if missing:
+        parts.append(
+            "Read ops below have no entry in `read_resource_forms` on their "
+            "`register_manage_tool(...)` call. Add either a matching "
+            "`godot://...` URI string or `None` (explicit waiver). See "
+            "`tests/unit/test_resource_form_lint.py` for the convention.\n" + "\n".join(missing)
+        )
+    if phantom:
+        parts.append(
+            "Read ops below declare resource URIs that are not registered "
+            "(phantom URI). Either register the resource in "
+            "`src/godot_ai/resources/` or change the declaration to `None`.\n"
+            "Available URIs:\n"
+            + "\n".join(f"  {uri}" for uri in sorted(available_uris))
+            + "\n\nDeclarations:\n"
+            + "\n".join(phantom)
+        )
+
+    if parts:
+        pytest.fail("\n\n".join(parts))
+
+
+# ---------------------------------------------------------------------------
+# Self-tests for the require_writable detector
+# ---------------------------------------------------------------------------
+
+
+def test_detector_flags_handler_with_require_writable():
+    from godot_ai.handlers.animation import animation_player_create
+
+    assert _handler_calls_require_writable(animation_player_create) is True
+
+
+def test_detector_does_not_flag_pure_read_handler():
+    from godot_ai.handlers.animation import animation_list
+
+    assert _handler_calls_require_writable(animation_list) is False
+
+
+def test_detector_ignores_string_literal_mentioning_name():
+    def fake_handler(rt):
+        msg = "this string mentions require_writable but never calls it"
+        return {"msg": msg}
+
+    assert _handler_calls_require_writable(fake_handler) is False
+
+
+def test_detector_handles_attribute_call_shape():
+    def fake_handler(rt):
+        ns = type("NS", (), {"require_writable": staticmethod(lambda r: None)})
+        ns.require_writable(rt)
+        return {}
+
+    assert _handler_calls_require_writable(fake_handler) is True

--- a/tests/unit/test_resource_form_lint.py
+++ b/tests/unit/test_resource_form_lint.py
@@ -36,8 +36,6 @@ from godot_ai.tools._meta_tool import (
 
 @pytest.fixture(scope="module")
 def mcp():
-    ## Triggers all tool + resource registrations, populating the manage-tool
-    ## registries this lint walks.
     return create_server(ws_port=0)
 
 
@@ -124,7 +122,7 @@ async def test_meta_tool_read_ops_declare_resource_form(mcp):
             if handler is None:
                 continue
             if _handler_calls_require_writable(handler):
-                continue  ## write op — exempt
+                continue
             if op_name not in forms:
                 source_module = getattr(handler, "__module__", "<unknown>")
                 source_name = getattr(handler, "__qualname__", repr(handler))


### PR DESCRIPTION
## Summary

- Adds `read_resource_forms=` kwarg on `register_manage_tool` for per-op resource declarations (URI string or `None` waiver) and a pytest lint that walks every `<domain>_manage` rollup, classifies each op as read vs write via AST scan for `require_writable`, and fails when a read op has no declaration or declares a URI that isn't actually registered.
- Migrated all 18 existing meta-tool registrations to declare their read ops. Mapped the seven that have a counterpart (`session_manage.list` → `godot://sessions`, `editor_manage.state` → `godot://editor/state`, `editor_manage.selection_get` → `godot://selection/current`, `editor_manage.monitors_get` → `godot://performance`, `input_map_manage.list` → `godot://input_map`, `material_manage.list` → `godot://materials`, `node_manage.get_children` → `godot://node/{path*}/children`, `node_manage.get_groups` → `godot://node/{path*}/groups`, `project_manage.settings_get` → `godot://project/settings`, `script_manage.read` → `godot://script/{path*}`, `test_manage.results_get` → `godot://test/results`); the rest are explicit `None` waivers with a one-line comment justifying why no resource fits.
- Removed the phantom `Resource form: godot://animations` line from `animation_manage`'s description — that resource never existed and the lint would have caught it. Animation reads are now waivers in `read_resource_forms`.

Per the audit's literal "every read tool whose handler signature doesn't take `session_id`" framing, named `@mcp.tool` tools (which all take `session_id`) stay out of scope; they already document resources in their docstrings. The lint targets exactly the meta-tool ops, where no per-op declaration mechanism existed.

Closes #363. Part of #343.

## Test plan

- [x] `ruff check src/ tests/` — pass
- [x] `ruff format --check src/ tests/` — pass
- [x] `pytest -q` — 890 passed (including new `test_resource_form_lint.py` and 5 new validation tests in `test_meta_tool.py`)
- [x] Verified the lint actually fails when a read op is undeclared (initial run reported all 39 undeclared ops with file/handler refs, then went green after migration)
- [x] Verified the lint catches phantom URIs (rejected `godot://animations` until the description line was deleted)
- [ ] CI: Python tests (3.11, 3.13) on Linux/macOS/Windows
- [ ] CI: Godot tests Linux/macOS/Windows (this PR doesn't touch GDScript; expecting unchanged)

## Deviations

None from the audit's "Fix shape." The audit asked for `# resource_form: none` waiver syntax (comment-style) but I used a Python-native dict value (`None`) since `register_manage_tool` already takes structured kwargs — clearer at the call site and validated at registration time rather than only at lint time.

---
_Generated by [Claude Code](https://claude.ai/code/session_016YtqD5kQeeqPqv9VGH2UDA)_