### PR TITLE
Extend #316 engine-state-lag gate to all headless DisplayServers

### DIFF
--- a/test_project/tests/test_camera.gd
+++ b/test_project/tests/test_camera.gd
@@ -237,17 +237,18 @@ func _camera_current_diag(cam: Node, expected: bool, attempts: int, elapsed_msec
 	]
 
 
-# Issue #316 gate. After 12+ fix attempts, the Camera2D `make_current` →
-# `Viewport.camera_2d` slot propagation still occasionally lags in headless
-# mode (originally observed on macOS, then on Windows after PR #380's
-# diagnostic landed — same handler-agrees / engine-disagrees signature, same
-# `viewport_camera=<none>` end state). The handler-side logical bookkeeping
-# (#311) stays correct in that race — only the engine-side viewport slot
-# doesn't catch up. Per the issue's acceptance criterion #2, the headless
-# failure is gated when the handler view agrees with the expectation: skip
-# with the full diagnostic so the next investigator still sees the state
-# divergence, but don't fail the build for a known upstream race we can't
-# close at the plugin level.
+# Issue #316 gate. After 12+ fix attempts, `Camera2D.make_current()` →
+# `Viewport.camera_2d` (and the same dispatch for Camera3D →
+# `Viewport.camera_3d`, exercised by `test_make_current_does_not_cross_classes`)
+# still occasionally lags in headless mode (originally observed on macOS,
+# then on Windows after PR #380's diagnostic landed — same handler-agrees /
+# engine-disagrees signature, same `viewport_camera=<none>` end state). The
+# handler-side logical bookkeeping (#311) stays correct in that race — only
+# the engine-side viewport slot doesn't catch up. Per the issue's acceptance
+# criterion #2, the headless failure is gated when the handler view agrees
+# with the expectation: skip with the full diagnostic so the next
+# investigator still sees the state divergence, but don't fail the build for
+# a known upstream race we can't close at the plugin level.
 #
 # Deliberately scoped to headless DisplayServer only — Linux CI runs under
 # xvfb with a real display server, and a developer running the suite in a
@@ -256,7 +257,10 @@ func _camera_current_diag(cam: Node, expected: bool, attempts: int, elapsed_msec
 # `_handler_logical_current_matches` guard further ensures we only skip when
 # the handler explicitly agrees — a handler-level regression still fails.
 func _is_headless() -> bool:
-	return DisplayServer.get_name() == "headless"
+	# Lowercased to match `plugin.gd::_mcp_disabled_for_headless` convention —
+	# Godot 4.x reports "headless" lowercase but normalize defensively in case
+	# a future build returns "Headless".
+	return DisplayServer.get_name().to_lower() == "headless"
 
 
 func _handler_logical_current_matches(cam: Node, expected: bool) -> bool:
@@ -272,7 +276,7 @@ func _handler_logical_current_matches(cam: Node, expected: bool) -> bool:
 	var scene_root := EditorInterface.get_edited_scene_root()
 	if scene_root == null or not scene_root.is_ancestor_of(cam):
 		return false
-	var type_str := "2d" if cam is Camera2D else ("3d" if cam is Camera3D else "")
+	var type_str := CameraHandler._camera_type_str(cam)
 	if type_str.is_empty():
 		return false
 	var marker: Node = _handler.peek_logical_current(scene_root, type_str)
@@ -299,9 +303,9 @@ func _skip_if_headless_engine_lag(cam: Node, expected: bool, report: Dictionary,
 		return false
 	if not _handler_logical_current_matches(cam, expected):
 		return false
-	# The relevant viewport slot depends on camera class — `_handler_logical_current_matches`
-	# already validated cam is a Camera2D or Camera3D in tree.
-	var slot_name := "Viewport.camera_3d" if cam is Camera3D else "Viewport.camera_2d"
+	# `_handler_logical_current_matches` already validated cam is a Camera2D or
+	# Camera3D in tree, so `_camera_type_str` returns "2d"/"3d" non-empty here.
+	var slot_name := "Viewport.camera_%s" % CameraHandler._camera_type_str(cam)
 	var msg := (
 		"Engine-state lag on headless DisplayServer (#316): handler logical "
 		+ "state matches expected current=%s but %s slot didn't propagate "

--- a/test_project/tests/test_camera.gd
+++ b/test_project/tests/test_camera.gd
@@ -238,19 +238,25 @@ func _camera_current_diag(cam: Node, expected: bool, attempts: int, elapsed_msec
 
 
 # Issue #316 gate. After 12+ fix attempts, the Camera2D `make_current` →
-# `Viewport.camera_2d` slot propagation still occasionally lags on macOS
-# headless (the test polls 200ms, observed up to ~600ms in the wild). The
-# handler-side logical bookkeeping (#311) stays correct in that race — only
-# the engine-side viewport slot doesn't catch up. Per the issue's acceptance
-# criterion #2, the macOS-only failure is gated when the handler view agrees
-# with the expectation: skip with the full diagnostic so the next investigator
-# still sees the state divergence, but don't fail the build for a known
-# upstream race we can't close at the plugin level.
+# `Viewport.camera_2d` slot propagation still occasionally lags in headless
+# mode (originally observed on macOS, then on Windows after PR #380's
+# diagnostic landed — same handler-agrees / engine-disagrees signature, same
+# `viewport_camera=<none>` end state). The handler-side logical bookkeeping
+# (#311) stays correct in that race — only the engine-side viewport slot
+# doesn't catch up. Per the issue's acceptance criterion #2, the headless
+# failure is gated when the handler view agrees with the expectation: skip
+# with the full diagnostic so the next investigator still sees the state
+# divergence, but don't fail the build for a known upstream race we can't
+# close at the plugin level.
 #
-# This deliberately does NOT skip on Linux/Windows or when the handler view
-# also disagrees — those would represent real regressions and must fail.
-func _is_macos_headless() -> bool:
-	return OS.has_feature("macos") and DisplayServer.get_name() == "headless"
+# Deliberately scoped to headless DisplayServer only — Linux CI runs under
+# xvfb with a real display server, and a developer running the suite in a
+# windowed editor sees a real display server too. A failure on a non-headless
+# platform would represent a real regression and must fail. The
+# `_handler_logical_current_matches` guard further ensures we only skip when
+# the handler explicitly agrees — a handler-level regression still fails.
+func _is_headless() -> bool:
+	return DisplayServer.get_name() == "headless"
 
 
 func _handler_logical_current_matches(cam: Node, expected: bool) -> bool:
@@ -281,15 +287,15 @@ func _handler_logical_current_matches(cam: Node, expected: bool) -> bool:
 	return marker != cam
 
 
-# Returns true and calls skip() when the test should bail out on a macOS-
-# headless engine-state lag the handler already agrees was settled correctly.
-# Returns false when the caller should proceed to its direct assertions —
-# either the wait succeeded, we're not on macOS headless, or the handler
-# also disagrees (real regression).
-func _skip_if_macos_engine_lag(cam: Node, expected: bool, report: Dictionary, label: String) -> bool:
+# Returns true and calls skip() when the test should bail out on a headless
+# engine-state lag the handler already agrees was settled correctly. Returns
+# false when the caller should proceed to its direct assertions — either the
+# wait succeeded, we're not on headless, or the handler also disagrees (real
+# regression).
+func _skip_if_headless_engine_lag(cam: Node, expected: bool, report: Dictionary, label: String) -> bool:
 	if report.settled:
 		return false
-	if not _is_macos_headless():
+	if not _is_headless():
 		return false
 	if not _handler_logical_current_matches(cam, expected):
 		return false
@@ -297,9 +303,9 @@ func _skip_if_macos_engine_lag(cam: Node, expected: bool, report: Dictionary, la
 	# already validated cam is a Camera2D or Camera3D in tree.
 	var slot_name := "Viewport.camera_3d" if cam is Camera3D else "Viewport.camera_2d"
 	var msg := (
-		"Engine-state lag on macOS headless (#316): handler logical state "
-		+ "matches expected current=%s but %s slot didn't "
-		+ "propagate within the wait budget. %s — %s"
+		"Engine-state lag on headless DisplayServer (#316): handler logical "
+		+ "state matches expected current=%s but %s slot didn't propagate "
+		+ "within the wait budget. %s — %s"
 	) % [expected, slot_name, label, report.message]
 	skip(msg)
 	return true
@@ -355,11 +361,11 @@ func test_create_with_make_current_unmarks_sibling() -> void:
 	assert_true(first_node != null, "First camera should resolve from %s" % first.data.path)
 	assert_true(second_node != null, "Second camera should resolve from %s" % second.data.path)
 	var second_current := _wait_for_camera_current_report(second_node, true)
-	if _skip_if_macos_engine_lag(second_node, true, second_current, "second after create"):
+	if _skip_if_headless_engine_lag(second_node, true, second_current, "second after create"):
 		return
 	assert_true(second_current.settled, second_current.message)
 	var first_not_current := _wait_for_camera_current_report(first_node, false)
-	if _skip_if_macos_engine_lag(first_node, false, first_not_current, "first unmarked after sibling create"):
+	if _skip_if_headless_engine_lag(first_node, false, first_not_current, "first unmarked after sibling create"):
 		return
 	assert_true(first_not_current.settled, first_not_current.message)
 	assert_eq(second_node.is_current(), true, "Direct is_current mismatch after wait succeeded. %s" % _camera_current_diag(second_node, true, second_current.attempts, second_current.elapsed_msec))
@@ -376,11 +382,11 @@ func test_make_current_does_not_cross_classes() -> void:
 	var n2 := McpScenePath.resolve(cam2d.data.path, scene_root) as Camera2D
 	var n3 := McpScenePath.resolve(cam3d.data.path, scene_root) as Camera3D
 	var cam2_current := _wait_for_camera_current_report(n2, true)
-	if _skip_if_macos_engine_lag(n2, true, cam2_current, "Camera2D after Camera3D create"):
+	if _skip_if_headless_engine_lag(n2, true, cam2_current, "Camera2D after Camera3D create"):
 		return
 	assert_true(cam2_current.settled, cam2_current.message)
 	var cam3_current := _wait_for_camera_current_report(n3, true)
-	if _skip_if_macos_engine_lag(n3, true, cam3_current, "Camera3D after create"):
+	if _skip_if_headless_engine_lag(n3, true, cam3_current, "Camera3D after create"):
 		return
 	assert_true(cam3_current.settled, cam3_current.message)
 	assert_eq(n2.is_current(), true, "Camera2D current should not be touched when Camera3D becomes current. %s" % _camera_current_diag(n2, true, cam2_current.attempts, cam2_current.elapsed_msec))
@@ -483,11 +489,11 @@ func test_configure_current_sibling_unmark_single_undo() -> void:
 	})
 	assert_has_key(result, "data")
 	var forward_second_current := _wait_for_camera_current_report(second_node, true)
-	if _skip_if_macos_engine_lag(second_node, true, forward_second_current, "forward configure: second"):
+	if _skip_if_headless_engine_lag(second_node, true, forward_second_current, "forward configure: second"):
 		return
 	assert_true(forward_second_current.settled, forward_second_current.message)
 	var forward_first_not_current := _wait_for_camera_current_report(first_node, false)
-	if _skip_if_macos_engine_lag(first_node, false, forward_first_not_current, "forward configure: first unmarked"):
+	if _skip_if_headless_engine_lag(first_node, false, forward_first_not_current, "forward configure: first unmarked"):
 		return
 	assert_true(forward_first_not_current.settled, forward_first_not_current.message)
 	assert_eq(second_node.is_current(), true, "Direct is_current mismatch after forward configure wait succeeded. %s" % _camera_current_diag(second_node, true, forward_second_current.attempts, forward_second_current.elapsed_msec))
@@ -501,11 +507,11 @@ func test_configure_current_sibling_unmark_single_undo() -> void:
 	# Diagnostic detail if this ever regresses (#316): report viewport state,
 	# direct Camera current state, handler/logical current reads, and wait budget.
 	var undo_second_not_current := _wait_for_camera_current_report(second_node, false)
-	if _skip_if_macos_engine_lag(second_node, false, undo_second_not_current, "post-undo: second unmarked"):
+	if _skip_if_headless_engine_lag(second_node, false, undo_second_not_current, "post-undo: second unmarked"):
 		return
 	assert_true(undo_second_not_current.settled, undo_second_not_current.message)
 	var undo_first_current := _wait_for_camera_current_report(first_node, true)
-	if _skip_if_macos_engine_lag(first_node, true, undo_first_current, "post-undo: first restored"):
+	if _skip_if_headless_engine_lag(first_node, true, undo_first_current, "post-undo: first restored"):
 		return
 	assert_true(undo_first_current.settled, undo_first_current.message)
 	assert_eq(second_node.is_current(), false, "After undo second should not be current. %s" % _camera_current_diag(second_node, false, undo_second_not_current.attempts, undo_second_not_current.elapsed_msec))


### PR DESCRIPTION
## Summary

PR #380's diagnostic landed on Windows in [run 25401381687](https://github.com/hi-godot/godot-ai/actions/runs/25401381687/job/74501570928) with **the same handler-agrees / engine-disagrees signature** the macOS-only gate was already built for:

```
camera=TwoDim path=/Main/TwoDim class=Camera2D in_tree=true
node_is_current=false
viewport_camera=<none>
viewport_matches=false
handler_current=true
handler_empty_path=/Main/TwoDim current=true
cam_viewport_id=55499033714 scene_root_viewport_id=55499033714
cam_viewport_matches_scene=true
```

`cam_viewport_matches_scene=true` rules out the reload-churn / stale-viewport theory. Engine-source trace (full writeup on [#316](https://github.com/hi-godot/godot-ai/issues/316)) confirms Camera3D operations cannot legally touch the camera_2d slot, so this is the same engine-state lag we already gate on macOS — just on Windows now too.

## What changes

- `_is_macos_headless()` → `_is_headless()` (drops `OS.has_feature("macos")` check)
- `_skip_if_macos_engine_lag()` → `_skip_if_headless_engine_lag()`
- Skip message: "on macOS headless" → "on headless DisplayServer"
- Comment block at [test_camera.gd:240-258](test_project/tests/test_camera.gd:240) rewritten to document the broader scope and explicitly call out Linux's `xvfb-run` keeping it outside the gate

## Why this is safe

- **Linux CI runs under `xvfb-run`** ([.github/workflows/ci.yml:253-254](.github/workflows/ci.yml#L253)) — `DisplayServer.get_name()` returns the X11 display server name, not `"headless"`. Linux stays outside the gate, so a Linux regression still fails.
- **A developer running the suite windowed** sees a real display server too — same exclusion.
- **The `_handler_logical_current_matches` guard is unchanged** — the gate only fires when the handler explicitly recorded the expected logical state. A handler-level regression (handler also wrong) still fails loudly.
- The same gate has been live on macOS-headless since #372 with no false positives.

## What this PR explicitly does NOT do

- **Does not fix the underlying engine-state lag.** Filed as a separate deep-dive issue ([#388](https://github.com/hi-godot/godot-ai/issues/388)). The two most plausible root-cause hypotheses (`_apply_make_current` settle loop never landing, or `_nudge_camera_2d_current`'s `enabled=false/true` cycle leaving a transient null) need instrumented runs to disambiguate, which doesn't fit in this PR.
- **Does not extend to non-headless platforms.** Linux/macOS/Windows windowed runs still fail loudly on this signature.

## Test plan

- [x] `pytest -v tests/` from the worktree — 892 passed
- [x] `ruff check src/ tests/` — clean
- [x] grep confirms no stale `_is_macos_headless` / `_skip_if_macos_engine_lag` references
- [ ] CI: `Godot tests / macOS` — happy-path passes, gate-fire path still produces same diagnostic
- [ ] CI: `Godot tests / Windows` — happy-path passes, next flake of this signature now skips with diagnostic instead of failing
- [ ] CI: `Godot tests / Linux` — unchanged behavior (xvfb means non-headless, gate doesn't fire)

🤖 Generated with [Claude Code](https://claude.com/claude-code)