### PR TITLE
[Audit v2 #364] Extract resolve-or-error helper; migrate 38+ duplicate sites

### DIFF
--- a/plugin/addons/godot_ai/handlers/_node_validator.gd
+++ b/plugin/addons/godot_ai/handlers/_node_validator.gd
@@ -1,0 +1,64 @@
+@tool
+class_name McpNodeValidator
+extends RefCounted
+
+## Shared resolve-or-error helper that subsumes the 38+ sites where
+## handlers each rolled their own "is the editor ready, does the path
+## resolve, otherwise return EDITOR_NOT_READY / NODE_NOT_FOUND" guard.
+##
+## audit-v2 #20 (issue #364). Uses the audit-v2 #21 (issue #365) error
+## vocabulary.
+
+const McpScenePath = preload("res://addons/godot_ai/utils/scene_path.gd")
+const McpErrorCodes = preload("res://addons/godot_ai/utils/error_codes.gd")
+
+
+## Resolve a scene-relative path to the live Node, or return a structured
+## error dict.
+##
+## Success shape: `{"node": Node, "scene_root": Node, "path": String}`.
+## Error shape: matches `McpErrorCodes.make(...)` so callers can
+## `return resolved` to propagate.
+##
+## Errors (in order checked):
+##   - `MISSING_REQUIRED_PARAM`: `node_path` is empty
+##   - `EDITOR_NOT_READY`: no scene open
+##   - `EDITED_SCENE_MISMATCH`: caller pinned `scene_file` and the open
+##     scene's path doesn't match
+##   - `NODE_NOT_FOUND`: `node_path` doesn't resolve under the scene root
+##
+## `param_name` is the agent-facing name reported in the
+## `MISSING_REQUIRED_PARAM` message — handlers pass "node_path",
+## "player_path", "target_path", etc. so the error reads like the
+## hand-written messages it replaces.
+static func resolve_or_error(
+	node_path: String,
+	param_name: String = "path",
+	scene_file: String = "",
+) -> Dictionary:
+	if node_path.is_empty():
+		return McpErrorCodes.make(
+			McpErrorCodes.MISSING_REQUIRED_PARAM,
+			"Missing required param: %s" % param_name,
+		)
+	var scene_check := McpScenePath.require_edited_scene(scene_file)
+	if scene_check.has("error"):
+		return scene_check
+	var scene_root: Node = scene_check.node
+	var node := McpScenePath.resolve(node_path, scene_root)
+	if node == null:
+		return McpErrorCodes.make(
+			McpErrorCodes.NODE_NOT_FOUND,
+			McpScenePath.format_node_error(node_path, scene_root),
+		)
+	return {"node": node, "scene_root": scene_root, "path": node_path}
+
+
+## When the caller needs the scene root but no specific node yet — e.g.
+## handlers that walk children or filter by group. Returns either
+## `{"scene_root": Node}` or a `McpErrorCodes.make(...)` error dict.
+static func require_scene_or_error(scene_file: String = "") -> Dictionary:
+	var scene_check := McpScenePath.require_edited_scene(scene_file)
+	if scene_check.has("error"):
+		return scene_check
+	return {"scene_root": scene_check.node}

--- a/plugin/addons/godot_ai/handlers/_node_validator.gd.uid
+++ b/plugin/addons/godot_ai/handlers/_node_validator.gd.uid
@@ -1,0 +1,1 @@
+uid://dn75jifad0ghx

--- a/plugin/addons/godot_ai/handlers/animation_handler.gd
+++ b/plugin/addons/godot_ai/handlers/animation_handler.gd
@@ -50,9 +50,10 @@ func create_player(params: Dictionary) -> Dictionary:
 	var parent_path: String = params.get("parent_path", "")
 	var node_name: String = params.get("name", "AnimationPlayer")
 
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+	var _scene_check := McpNodeValidator.require_scene_or_error()
+	if _scene_check.has("error"):
+		return _scene_check
+	var scene_root: Node = _scene_check.scene_root
 
 	var parent: Node = scene_root
 	if not parent_path.is_empty():
@@ -726,9 +727,10 @@ func _create_scene_pinned_action(action_label: String) -> void:
 ## If the resolved node exists but isn't an AnimationPlayer, that's still an
 ## error — we don't clobber an existing node of a different type.
 func _resolve_player(player_path: String, create_if_missing: bool = false) -> Dictionary:
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+	var _scene_check := McpNodeValidator.require_scene_or_error()
+	if _scene_check.has("error"):
+		return _scene_check
+	var scene_root: Node = _scene_check.scene_root
 	var node := McpScenePath.resolve(player_path, scene_root)
 	if node == null:
 		if not create_if_missing:
@@ -790,9 +792,10 @@ func _instantiate_player(player_path: String, scene_root: Node) -> Dictionary:
 ## staged. If the node exists but isn't an AnimationPlayer, errors exactly
 ## like `_resolve_player` — that's a genuine type mismatch, not a missing node.
 func _resolve_or_create_player(player_path: String) -> Dictionary:
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+	var _scene_check := McpNodeValidator.require_scene_or_error()
+	if _scene_check.has("error"):
+		return _scene_check
+	var scene_root: Node = _scene_check.scene_root
 	if McpScenePath.resolve(player_path, scene_root) != null:
 		# Node exists — delegate so the type-mismatch error stays identical
 		# to _resolve_player's.
@@ -829,12 +832,10 @@ func _resolve_or_create_player(player_path: String) -> Dictionary:
 
 ## Resolve for read operations (no library requirement).
 func _resolve_player_read(player_path: String) -> Dictionary:
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
-	var node := McpScenePath.resolve(player_path, scene_root)
-	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_node_error(player_path, scene_root))
+	var resolved := McpNodeValidator.resolve_or_error(player_path, "player_path")
+	if resolved.has("error"):
+		return resolved
+	var node: Node = resolved.node
 	if not node is AnimationPlayer:
 		return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE,
 			"Node at %s is not an AnimationPlayer (got %s)" % [player_path, node.get_class()])

--- a/plugin/addons/godot_ai/handlers/audio_handler.gd
+++ b/plugin/addons/godot_ai/handlers/audio_handler.gd
@@ -50,9 +50,10 @@ func create_player(params: Dictionary) -> Dictionary:
 			"Invalid audio player type '%s'. Valid: %s" % [type_str, ", ".join(_VALID_TYPES.keys())]
 		)
 
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+	var _scene_check := McpNodeValidator.require_scene_or_error()
+	if _scene_check.has("error"):
+		return _scene_check
+	var scene_root: Node = _scene_check.scene_root
 
 	var parent: Node = scene_root
 	if not parent_path.is_empty():
@@ -319,12 +320,10 @@ static func _instantiate_player(type_str: String) -> Node:
 
 
 func _resolve_player(player_path: String) -> Dictionary:
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
-	var node := McpScenePath.resolve(player_path, scene_root)
-	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_node_error(player_path, scene_root))
+	var resolved := McpNodeValidator.resolve_or_error(player_path, "player_path")
+	if resolved.has("error"):
+		return resolved
+	var node: Node = resolved.node
 	var is_player := node is AudioStreamPlayer \
 		or node is AudioStreamPlayer2D \
 		or node is AudioStreamPlayer3D

--- a/plugin/addons/godot_ai/handlers/camera_handler.gd
+++ b/plugin/addons/godot_ai/handlers/camera_handler.gd
@@ -477,9 +477,10 @@ func create_camera(params: Dictionary) -> Dictionary:
 			"Invalid camera type '%s'. Valid: %s" % [type_str, ", ".join(_VALID_TYPES.keys())]
 		)
 
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+	var _scene_check := McpNodeValidator.require_scene_or_error()
+	if _scene_check.has("error"):
+		return _scene_check
+	var scene_root: Node = _scene_check.scene_root
 
 	var parent: Node = scene_root
 	if not parent_path.is_empty():
@@ -869,9 +870,10 @@ func follow_2d(params: Dictionary) -> Dictionary:
 # ============================================================================
 
 func get_camera(params: Dictionary) -> Dictionary:
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+	var _scene_check := McpNodeValidator.require_scene_or_error()
+	if _scene_check.has("error"):
+		return _scene_check
+	var scene_root: Node = _scene_check.scene_root
 
 	var camera_path: String = params.get("camera_path", "")
 	var node: Node = null
@@ -952,9 +954,10 @@ func get_camera(params: Dictionary) -> Dictionary:
 # ============================================================================
 
 func list_cameras(_params: Dictionary) -> Dictionary:
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+	var _scene_check := McpNodeValidator.require_scene_or_error()
+	if _scene_check.has("error"):
+		return _scene_check
+	var scene_root: Node = _scene_check.scene_root
 
 	var cams := _list_cameras_in_scene(scene_root, "")
 	var out: Array[Dictionary] = []
@@ -999,9 +1002,10 @@ func apply_preset(params: Dictionary) -> Dictionary:
 			"Invalid camera type '%s'. Valid: %s" % [type_str, ", ".join(_VALID_TYPES.keys())]
 		)
 
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+	var _scene_check := McpNodeValidator.require_scene_or_error()
+	if _scene_check.has("error"):
+		return _scene_check
+	var scene_root: Node = _scene_check.scene_root
 
 	var parent: Node = scene_root
 	if not parent_path.is_empty():
@@ -1088,15 +1092,14 @@ static func _camera_type_str(node: Node) -> String:
 
 
 func _resolve_camera(params: Dictionary) -> Dictionary:
-	var node_path: String = params.get("camera_path", "")
-	if node_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: camera_path")
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
-	var node := McpScenePath.resolve(node_path, scene_root)
-	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_node_error(node_path, scene_root))
+	var resolved := McpNodeValidator.resolve_or_error(
+		params.get("camera_path", ""), "camera_path",
+	)
+	if resolved.has("error"):
+		return resolved
+	var node: Node = resolved.node
+	var node_path: String = resolved.path
+	var scene_root: Node = resolved.scene_root
 	if not _is_camera(node):
 		return McpErrorCodes.make(
 			McpErrorCodes.WRONG_TYPE,

--- a/plugin/addons/godot_ai/handlers/control_draw_recipe_handler.gd
+++ b/plugin/addons/godot_ai/handlers/control_draw_recipe_handler.gd
@@ -27,13 +27,11 @@ func control_draw_recipe(params: Dictionary) -> Dictionary:
 	if typeof(ops_raw) != TYPE_ARRAY:
 		return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "ops must be an Array")
 
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
-
-	var node := McpScenePath.resolve(path, scene_root)
-	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_node_error(path, scene_root))
+	var _resolved := McpNodeValidator.resolve_or_error(path, "path")
+	if _resolved.has("error"):
+		return _resolved
+	var node: Node = _resolved.node
+	var scene_root: Node = _resolved.scene_root
 	if not node is Control:
 		return McpErrorCodes.make(
 			McpErrorCodes.WRONG_TYPE,

--- a/plugin/addons/godot_ai/handlers/curve_handler.gd
+++ b/plugin/addons/godot_ai/handlers/curve_handler.gd
@@ -54,9 +54,10 @@ func set_points(params: Dictionary) -> Dictionary:
 			)
 		curve = loaded_curve.duplicate()
 	else:
-		var scene_root := EditorInterface.get_edited_scene_root()
-		if scene_root == null:
-			return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+		var _scene_check := McpNodeValidator.require_scene_or_error()
+		if _scene_check.has("error"):
+			return _scene_check
+		var scene_root: Node = _scene_check.scene_root
 		node = McpScenePath.resolve(node_path, scene_root)
 		if node == null:
 			return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_node_error(node_path, scene_root))

--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -300,9 +300,10 @@ func take_screenshot(params: Dictionary) -> Dictionary:
 	## Handle view_target: temporarily reposition the editor's own camera to
 	## frame one or more target nodes, force a render, capture, then restore.
 	if not view_target.is_empty() and source == "viewport":
-		var scene_root := EditorInterface.get_edited_scene_root()
-		if scene_root == null:
-			return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+		var _scene_check := McpNodeValidator.require_scene_or_error()
+		if _scene_check.has("error"):
+			return _scene_check
+		var scene_root: Node = _scene_check.scene_root
 
 		## Parse comma-separated paths, deduplicate
 		var raw_paths := view_target.split(",")
@@ -451,9 +452,10 @@ func take_screenshot(params: Dictionary) -> Dictionary:
 ## throwaway SubViewport, so the output has no editor gizmos, selection
 ## outlines, or grid lines.
 func _take_cinematic_screenshot(max_resolution: int) -> Dictionary:
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+	var _scene_check := McpNodeValidator.require_scene_or_error()
+	if _scene_check.has("error"):
+		return _scene_check
+	var scene_root: Node = _scene_check.scene_root
 
 	var scene_camera := _find_current_camera_3d(scene_root)
 	if scene_camera == null:

--- a/plugin/addons/godot_ai/handlers/environment_handler.gd
+++ b/plugin/addons/godot_ai/handlers/environment_handler.gd
@@ -139,13 +139,11 @@ static func _apply_preset(env: Environment, sky_material: ProceduralSkyMaterial,
 
 
 func _assign_environment(env: Environment, sky: Sky, sky_material: ProceduralSkyMaterial, node_path: String, preset: String) -> Dictionary:
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
-
-	var node := McpScenePath.resolve(node_path, scene_root)
-	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_node_error(node_path, scene_root))
+	var _resolved := McpNodeValidator.resolve_or_error(node_path, "node_path")
+	if _resolved.has("error"):
+		return _resolved
+	var node: Node = _resolved.node
+	var scene_root: Node = _resolved.scene_root
 	if not (node is WorldEnvironment):
 		return McpErrorCodes.make(
 			McpErrorCodes.WRONG_TYPE,

--- a/plugin/addons/godot_ai/handlers/material_handler.gd
+++ b/plugin/addons/godot_ai/handlers/material_handler.gd
@@ -344,13 +344,11 @@ func assign_material(params: Dictionary) -> Dictionary:
 	if node_path.is_empty():
 		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: node_path")
 
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
-
-	var node := McpScenePath.resolve(node_path, scene_root)
-	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_node_error(node_path, scene_root))
+	var _resolved := McpNodeValidator.resolve_or_error(node_path, "node_path")
+	if _resolved.has("error"):
+		return _resolved
+	var node: Node = _resolved.node
+	var scene_root: Node = _resolved.scene_root
 
 	var slot: String = params.get("slot", "override")
 	var resource_path: String = params.get("resource_path", "")
@@ -438,13 +436,11 @@ func apply_to_node(params: Dictionary) -> Dictionary:
 			"Invalid material type '%s'. Valid: %s" % [type_str, ", ".join(_TYPE_TO_CLASS.keys())]
 		)
 
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
-
-	var node := McpScenePath.resolve(node_path, scene_root)
-	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_node_error(node_path, scene_root))
+	var _resolved := McpNodeValidator.resolve_or_error(node_path, "node_path")
+	if _resolved.has("error"):
+		return _resolved
+	var node: Node = _resolved.node
+	var scene_root: Node = _resolved.scene_root
 
 	var slot: String = params.get("slot", "override")
 	var slot_result := _resolve_slot_property(node, slot)
@@ -586,12 +582,11 @@ func apply_preset(params: Dictionary) -> Dictionary:
 
 	var assigned := false
 	if not node_path.is_empty():
-		var scene_root := EditorInterface.get_edited_scene_root()
-		if scene_root == null:
-			return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
-		var node := McpScenePath.resolve(node_path, scene_root)
-		if node == null:
-			return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_node_error(node_path, scene_root))
+		var _resolved := McpNodeValidator.resolve_or_error(node_path, "node_path")
+		if _resolved.has("error"):
+			return _resolved
+		var node: Node = _resolved.node
+		var scene_root: Node = _resolved.scene_root
 		var slot_result := _resolve_slot_property(node, params.get("slot", "override"))
 		if slot_result.has("error"):
 			return slot_result

--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -481,9 +481,10 @@ func remove_from_group(params: Dictionary) -> Dictionary:
 
 func set_selection(params: Dictionary) -> Dictionary:
 	var paths: Array = params.get("paths", [])
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+	var _scene_check := McpNodeValidator.require_scene_or_error()
+	if _scene_check.has("error"):
+		return _scene_check
+	var scene_root: Node = _scene_check.scene_root
 
 	var selection := EditorInterface.get_selection()
 	selection.clear()
@@ -736,19 +737,12 @@ func get_groups(params: Dictionary) -> Dictionary:
 
 
 ## Validate path param, resolve to node. Returns dict with node/path/scene_root
-## on success, or an error dict (has "error" key) on failure.
+## on success, or an error dict (has "error" key) on failure. Thin wrapper
+## around the shared `McpNodeValidator.resolve_or_error` helper (audit-v2 #20).
 func _resolve_node(params: Dictionary) -> Dictionary:
-	var node_path: String = params.get("path", "")
-	if node_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
-	var scene_check := McpScenePath.require_edited_scene(params.get("scene_file", ""))
-	if scene_check.has("error"):
-		return scene_check
-	var scene_root: Node = scene_check.node
-	var node := McpScenePath.resolve(node_path, scene_root)
-	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_node_error(node_path, scene_root))
-	return {"node": node, "path": node_path, "scene_root": scene_root}
+	return McpNodeValidator.resolve_or_error(
+		params.get("path", ""), "path", params.get("scene_file", ""),
+	)
 
 
 ## Reject operations targeting the scene root. Returns an INVALID_PARAMS error

--- a/plugin/addons/godot_ai/handlers/particle_handler.gd
+++ b/plugin/addons/godot_ai/handlers/particle_handler.gd
@@ -54,9 +54,10 @@ func create_particle(params: Dictionary) -> Dictionary:
 			"Invalid particle type '%s'. Valid: %s" % [type_str, ", ".join(_VALID_TYPES.keys())]
 		)
 
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+	var _scene_check := McpNodeValidator.require_scene_or_error()
+	if _scene_check.has("error"):
+		return _scene_check
+	var scene_root: Node = _scene_check.scene_root
 
 	var parent: Node = scene_root
 	if not parent_path.is_empty():
@@ -589,9 +590,10 @@ func apply_preset(params: Dictionary) -> Dictionary:
 			"Invalid particle type '%s'. Valid: %s" % [type_str, ", ".join(_VALID_TYPES.keys())]
 		)
 
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+	var _scene_check := McpNodeValidator.require_scene_or_error()
+	if _scene_check.has("error"):
+		return _scene_check
+	var scene_root: Node = _scene_check.scene_root
 
 	var parent: Node = scene_root
 	if not parent_path.is_empty():
@@ -706,15 +708,13 @@ static func _instantiate_particle(type_str: String) -> Node:
 
 
 func _resolve_particle(params: Dictionary) -> Dictionary:
-	var node_path: String = params.get("node_path", "")
-	if node_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: node_path")
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
-	var node := McpScenePath.resolve(node_path, scene_root)
-	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_node_error(node_path, scene_root))
+	var resolved := McpNodeValidator.resolve_or_error(
+		params.get("node_path", ""), "node_path",
+	)
+	if resolved.has("error"):
+		return resolved
+	var node: Node = resolved.node
+	var node_path: String = resolved.path
 	var is_particle := node is GPUParticles3D or node is GPUParticles2D \
 		or node is CPUParticles3D or node is CPUParticles2D
 	if not is_particle:

--- a/plugin/addons/godot_ai/handlers/physics_shape_handler.gd
+++ b/plugin/addons/godot_ai/handlers/physics_shape_handler.gd
@@ -34,13 +34,11 @@ func autofit(params: Dictionary) -> Dictionary:
 	if node_path.is_empty():
 		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
 
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
-
-	var node := McpScenePath.resolve(node_path, scene_root)
-	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_node_error(node_path, scene_root))
+	var _resolved := McpNodeValidator.resolve_or_error(node_path, "node_path")
+	if _resolved.has("error"):
+		return _resolved
+	var node: Node = _resolved.node
+	var scene_root: Node = _resolved.scene_root
 
 	var is_3d := node is CollisionShape3D
 	var is_2d := node is CollisionShape2D

--- a/plugin/addons/godot_ai/handlers/resource_handler.gd
+++ b/plugin/addons/godot_ai/handlers/resource_handler.gd
@@ -110,13 +110,11 @@ func assign_resource(params: Dictionary) -> Dictionary:
 	if resource_path.is_empty():
 		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: resource_path")
 
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
-
-	var node := McpScenePath.resolve(node_path, scene_root)
-	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_node_error(node_path, scene_root))
+	var _resolved := McpNodeValidator.resolve_or_error(node_path, "node_path")
+	if _resolved.has("error"):
+		return _resolved
+	var node: Node = _resolved.node
+	var scene_root: Node = _resolved.scene_root
 
 	# Verify property exists
 	var found := false
@@ -291,13 +289,11 @@ static func _apply_resource_properties(res: Resource, properties: Dictionary) ->
 
 
 func _assign_created_resource(res: Resource, type_str: String, node_path: String, property: String, applied_count: int) -> Dictionary:
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
-
-	var node := McpScenePath.resolve(node_path, scene_root)
-	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_node_error(node_path, scene_root))
+	var _resolved := McpNodeValidator.resolve_or_error(node_path, "node_path")
+	if _resolved.has("error"):
+		return _resolved
+	var node: Node = _resolved.node
+	var scene_root: Node = _resolved.scene_root
 
 	var found := false
 	var prop_type: int = TYPE_NIL

--- a/plugin/addons/godot_ai/handlers/scene_handler.gd
+++ b/plugin/addons/godot_ai/handlers/scene_handler.gd
@@ -44,9 +44,10 @@ func find_nodes(params: Dictionary) -> Dictionary:
 	if name_filter.is_empty() and type_filter.is_empty() and group_filter.is_empty():
 		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "At least one filter (name, type, group) is required")
 
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+	var _scene_check := McpNodeValidator.require_scene_or_error()
+	if _scene_check.has("error"):
+		return _scene_check
+	var scene_root: Node = _scene_check.scene_root
 
 	var results: Array[Dictionary] = []
 	_find_recursive(scene_root, scene_root, name_filter, type_filter, group_filter, results)
@@ -163,9 +164,10 @@ func open_scene(params: Dictionary) -> Dictionary:
 ## Pauses WebSocket processing during save to prevent re-entrant _process()
 ## calls during EditorNode::_save_scene_with_preview's thumbnail render.
 func save_scene(_params: Dictionary) -> Dictionary:
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+	var _scene_check := McpNodeValidator.require_scene_or_error()
+	if _scene_check.has("error"):
+		return _scene_check
+	var scene_root: Node = _scene_check.scene_root
 
 	var path := scene_root.scene_file_path
 	if path.is_empty():
@@ -204,9 +206,10 @@ func save_scene_as(params: Dictionary) -> Dictionary:
 	if not path.ends_with(".tscn") and not path.ends_with(".scn"):
 		path += ".tscn"
 
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+	var _scene_check := McpNodeValidator.require_scene_or_error()
+	if _scene_check.has("error"):
+		return _scene_check
+	var scene_root: Node = _scene_check.scene_root
 
 	# Ensure parent directory exists
 	var dir_path := path.get_base_dir()

--- a/plugin/addons/godot_ai/handlers/script_handler.gd
+++ b/plugin/addons/godot_ai/handlers/script_handler.gd
@@ -211,13 +211,11 @@ func attach_script(params: Dictionary) -> Dictionary:
 	if script_path.is_empty():
 		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: script_path")
 
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
-
-	var node := McpScenePath.resolve(node_path, scene_root)
-	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_node_error(node_path, scene_root))
+	var _resolved := McpNodeValidator.resolve_or_error(node_path, "node_path")
+	if _resolved.has("error"):
+		return _resolved
+	var node: Node = _resolved.node
+	var scene_root: Node = _resolved.scene_root
 
 	if not ResourceLoader.exists(script_path):
 		return McpErrorCodes.make(McpErrorCodes.RESOURCE_NOT_FOUND, "Script not found: %s" % script_path)
@@ -249,13 +247,11 @@ func detach_script(params: Dictionary) -> Dictionary:
 	if node_path.is_empty():
 		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
 
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
-
-	var node := McpScenePath.resolve(node_path, scene_root)
-	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_node_error(node_path, scene_root))
+	var _resolved := McpNodeValidator.resolve_or_error(node_path, "node_path")
+	if _resolved.has("error"):
+		return _resolved
+	var node: Node = _resolved.node
+	var scene_root: Node = _resolved.scene_root
 
 	var old_script: Script = node.get_script()
 	if old_script == null:

--- a/plugin/addons/godot_ai/handlers/signal_handler.gd
+++ b/plugin/addons/godot_ai/handlers/signal_handler.gd
@@ -15,13 +15,11 @@ func list_signals(params: Dictionary) -> Dictionary:
 	if path.is_empty():
 		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
 
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
-
-	var node := McpScenePath.resolve(path, scene_root)
-	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_node_error(path, scene_root))
+	var _resolved := McpNodeValidator.resolve_or_error(path, "path")
+	if _resolved.has("error"):
+		return _resolved
+	var node: Node = _resolved.node
+	var scene_root: Node = _resolved.scene_root
 
 	## Default: hide editor-internal connections (SceneTreeEditor observers
 	## live on every scene node and would otherwise dominate the response).
@@ -187,9 +185,10 @@ func _resolve_signal_params(params: Dictionary) -> Dictionary:
 		if params.get(key, "").is_empty():
 			return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: %s" % key)
 
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+	var _scene_check := McpNodeValidator.require_scene_or_error()
+	if _scene_check.has("error"):
+		return _scene_check
+	var scene_root: Node = _scene_check.scene_root
 
 	var source_result := _resolve_node_or_autoload(params.path, scene_root, "Source")
 	if source_result.has("error"):

--- a/plugin/addons/godot_ai/handlers/texture_handler.gd
+++ b/plugin/addons/godot_ai/handlers/texture_handler.gd
@@ -152,12 +152,11 @@ func _finalize(tex: Resource, sub_resources: Array, params: Dictionary, label: S
 
 
 func _assign_texture(tex: Resource, sub_resources: Array, node_path: String, property: String, label: String, extra: Dictionary) -> Dictionary:
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
-	var node := McpScenePath.resolve(node_path, scene_root)
-	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_node_error(node_path, scene_root))
+	var _resolved := McpNodeValidator.resolve_or_error(node_path, "node_path")
+	if _resolved.has("error"):
+		return _resolved
+	var node: Node = _resolved.node
+	var scene_root: Node = _resolved.scene_root
 
 	var found := false
 	var prop_type: int = TYPE_NIL

--- a/plugin/addons/godot_ai/handlers/theme_handler.gd
+++ b/plugin/addons/godot_ai/handlers/theme_handler.gd
@@ -388,13 +388,11 @@ func apply_theme(params: Dictionary) -> Dictionary:
 		if theme == null or not theme is Theme:
 			return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "Resource at %s is not a Theme" % theme_path)
 
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
-
-	var node := McpScenePath.resolve(node_path, scene_root)
-	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_node_error(node_path, scene_root))
+	var _resolved := McpNodeValidator.resolve_or_error(node_path, "node_path")
+	if _resolved.has("error"):
+		return _resolved
+	var node: Node = _resolved.node
+	var scene_root: Node = _resolved.scene_root
 	if not node is Control and not node is Window:
 		return McpErrorCodes.make(
 			McpErrorCodes.WRONG_TYPE,

--- a/plugin/addons/godot_ai/handlers/ui_handler.gd
+++ b/plugin/addons/godot_ai/handlers/ui_handler.gd
@@ -80,13 +80,11 @@ func set_anchor_preset(params: Dictionary) -> Dictionary:
 
 	var margin: int = int(params.get("margin", 0))
 
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
-
-	var node := McpScenePath.resolve(node_path, scene_root)
-	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_node_error(node_path, scene_root))
+	var _resolved := McpNodeValidator.resolve_or_error(node_path, "node_path")
+	if _resolved.has("error"):
+		return _resolved
+	var node: Node = _resolved.node
+	var scene_root: Node = _resolved.scene_root
 	if not node is Control:
 		var got_class: String = node.get_class()
 		return McpErrorCodes.make(
@@ -153,13 +151,11 @@ func set_text(params: Dictionary) -> Dictionary:
 	if typeof(text_value) != TYPE_STRING:
 		return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "text must be a string")
 
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
-
-	var node := McpScenePath.resolve(node_path, scene_root)
-	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_node_error(node_path, scene_root))
+	var _resolved := McpNodeValidator.resolve_or_error(node_path, "node_path")
+	if _resolved.has("error"):
+		return _resolved
+	var node: Node = _resolved.node
+	var scene_root: Node = _resolved.scene_root
 	var node_type := node.get_class()
 	if not node is Control:
 		return McpErrorCodes.make(
@@ -228,9 +224,10 @@ func build_layout(params: Dictionary) -> Dictionary:
 	if typeof(tree) != TYPE_DICTIONARY:
 		return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "tree must be a dictionary")
 
-	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+	var _scene_check := McpNodeValidator.require_scene_or_error()
+	if _scene_check.has("error"):
+		return _scene_check
+	var scene_root: Node = _scene_check.scene_root
 
 	var parent_path: String = params.get("parent_path", "")
 	var parent: Node = scene_root

--- a/test_project/tests/test_node_validator.gd
+++ b/test_project/tests/test_node_validator.gd
@@ -1,0 +1,90 @@
+@tool
+extends McpTestSuite
+
+## Tests for McpNodeValidator (audit-v2 #20 / issue #364) — the shared
+## resolve-or-error helper that subsumed the 38+ inline EDITOR_NOT_READY +
+## NODE_NOT_FOUND blocks across handlers.
+
+const McpNodeValidator := preload("res://addons/godot_ai/handlers/_node_validator.gd")
+
+
+func suite_name() -> String:
+	return "node_validator"
+
+
+# ----- resolve_or_error: error paths -----
+
+
+func test_resolve_or_error_missing_path_emits_missing_required_param() -> void:
+	var result := McpNodeValidator.resolve_or_error("")
+	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_contains(result.error.message, "path")
+
+
+func test_resolve_or_error_uses_param_name_in_missing_message() -> void:
+	## Handlers pass "player_path" / "node_path" / "camera_path" — the
+	## error message must echo the caller's name so agents see the same
+	## param name they sent.
+	var result := McpNodeValidator.resolve_or_error("", "player_path")
+	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_contains(result.error.message, "player_path")
+
+
+func test_resolve_or_error_unresolvable_path_emits_node_not_found() -> void:
+	var result := McpNodeValidator.resolve_or_error("/Main/__definitely_nonexistent__")
+	assert_is_error(result, McpErrorCodes.NODE_NOT_FOUND)
+
+
+# ----- resolve_or_error: success paths -----
+
+
+func test_resolve_or_error_resolves_root_path() -> void:
+	var result := McpNodeValidator.resolve_or_error("/Main")
+	assert_has_key(result, "node")
+	assert_has_key(result, "scene_root")
+	assert_has_key(result, "path")
+	assert_eq(result.path, "/Main")
+	assert_true(result.node is Node, "node field must be a Node")
+	assert_eq(result.node, result.scene_root, "/Main IS the scene root")
+
+
+func test_resolve_or_error_resolves_descendant_path() -> void:
+	var result := McpNodeValidator.resolve_or_error("/Main/Camera3D")
+	assert_has_key(result, "node")
+	assert_eq(result.path, "/Main/Camera3D")
+	assert_eq(String(result.node.name), "Camera3D")
+	assert_true(result.node is Camera3D, "node must be the Camera3D")
+	assert_ne(result.node, result.scene_root, "descendant != scene_root")
+
+
+# ----- require_scene_or_error -----
+
+
+func test_require_scene_or_error_returns_scene_root_when_open() -> void:
+	## In CI the test runner ensures main.tscn is the open scene.
+	var result := McpNodeValidator.require_scene_or_error()
+	assert_has_key(result, "scene_root")
+	assert_true(result.scene_root is Node, "scene_root must be a Node")
+
+
+# ----- error dict shape parity -----
+
+
+func test_error_dicts_match_McpErrorCodes_make_shape() -> void:
+	## The handler call sites do `if resolved.has("error"): return resolved`
+	## — that propagation only works if the error dict shape matches what
+	## `McpErrorCodes.make()` produces. Pin the contract here so a refactor
+	## can't subtly change the error envelope.
+	var missing := McpNodeValidator.resolve_or_error("")
+	assert_has_key(missing, "status")
+	assert_eq(missing.status, "error")
+	assert_has_key(missing, "error")
+	assert_has_key(missing.error, "code")
+	assert_has_key(missing.error, "message")
+
+	var not_found := McpNodeValidator.resolve_or_error("/Main/nope_nope_nope")
+	assert_has_key(not_found, "status")
+	assert_eq(not_found.status, "error")
+	assert_has_key(not_found, "error")
+	assert_has_key(not_found.error, "code")
+	assert_has_key(not_found.error, "message")

--- a/test_project/tests/test_node_validator.gd.uid
+++ b/test_project/tests/test_node_validator.gd.uid
@@ -1,0 +1,1 @@
+uid://c81rlv5w7agp5


### PR DESCRIPTION
## Summary

Closes audit-v2 #20 (#364): the same six lines for "validate path, fetch the edited scene, resolve to a node, otherwise return `EDITOR_NOT_READY` / `NODE_NOT_FOUND`" were repeated **38+ times across 18 handlers**. This PR extracts the shared helper and migrates every site.

## New helper

`plugin/addons/godot_ai/handlers/_node_validator.gd`:

```gdscript
class_name McpNodeValidator

static func resolve_or_error(
    node_path: String,
    param_name: String = "path",
    scene_file: String = "",
) -> Dictionary
# Success: {"node": Node, "scene_root": Node, "path": String}
# Errors:  MISSING_REQUIRED_PARAM | EDITOR_NOT_READY | EDITED_SCENE_MISMATCH | NODE_NOT_FOUND

static func require_scene_or_error(scene_file: String = "") -> Dictionary
# Success: {"scene_root": Node}
# (For sites that need only the scene root, no specific node yet.)
```

The error dict shape matches `McpErrorCodes.make()` so handlers can `return resolved` to propagate verbatim. Uses the audit-v2 #21 (#365) error vocabulary throughout (the helper's design is a direct beneficiary of the freshly-landed taxonomy).

## Migration

- **4 handler-local resolvers** (`audio._resolve_player`, `animation._resolve_player_read`, `camera._resolve_camera`, `particle._resolve_particle`, `node._resolve_node`) → now thin wrappers calling `McpNodeValidator`. Each kept its handler-specific type-check (e.g. `is AnimationPlayer`, `is Camera*`) which sits cleanly after the shared resolve.
- **13 Pattern A inline blocks** (path → node + handler-specific guard) → `McpNodeValidator.resolve_or_error(path, "param_name")`. Mechanical rewrite via `/tmp/migrate_patterns.py`.
- **19 Pattern B inline blocks** (scene-root only, no specific path) → `McpNodeValidator.require_scene_or_error()`.

After: **0 inline `EDITOR_NOT_READY` "No scene open" sites remain in `handlers/`** (was 38).

## Tests

`test_project/tests/test_node_validator.gd` (new, 7 tests):

- `test_resolve_or_error_missing_path_emits_missing_required_param` — empty path → `MISSING_REQUIRED_PARAM`
- `test_resolve_or_error_uses_param_name_in_missing_message` — caller's param name (`player_path`, `camera_path`, etc.) appears in the error message
- `test_resolve_or_error_unresolvable_path_emits_node_not_found` — bogus path → `NODE_NOT_FOUND`
- `test_resolve_or_error_resolves_root_path` — `/Main` → scene root (success path)
- `test_resolve_or_error_resolves_descendant_path` — `/Main/Camera3D` → Camera3D
- `test_require_scene_or_error_returns_scene_root_when_open`
- `test_error_dicts_match_McpErrorCodes_make_shape` — pins the error envelope contract so a refactor can't subtly change the shape and silently break every `return resolved` propagation

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `pytest -q` — **892 passed**
- [x] `script/ci-check-gdscript` — All GDScript files OK
- [x] **Local end-to-end Godot test_run**: `godot --headless --editor` with `GODOT_AI_ALLOW_HEADLESS=1` + MCP `test_run`: **1211/1227 passed, 0 failed** (1227 = 1220 prior baseline + 7 new in `test_node_validator`). 16 skipped are pre-existing macOS-headless camera-current cases.
- [x] No interactive smoke required — handler refactor only, no `update_reload_runner.gd` / `mcp_dock.gd` paths touched.

## Diff shape

22 files changed, 335 insertions, 202 deletions. The helper file (~70 LOC) plus tests account for the additions; handlers net-shrunk by ~23 LOC and the duplicated validation logic now has one source of truth.

## Cross-references

Closes #364
Unblocks #360 (`mcp_dock.gd` extraction) and #361 (animation_handler split) — the audit umbrella's soft-prereq chain
Built on #365 (just-landed error vocabulary) — uses `MISSING_REQUIRED_PARAM`, `NODE_NOT_FOUND`, `EDITOR_NOT_READY`, `EDITED_SCENE_MISMATCH` directly
Umbrella: #343

https://claude.ai/code/session_01ERwAhFK6CEZLRigwK1iC2k

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERwAhFK6CEZLRigwK1iC2k)_