### PR TITLE
[Audit v2 #360] Extract LogViewer + PortPickerPanel from mcp_dock.gd

### DIFF
--- a/plugin/addons/godot_ai/dock_panels/log_viewer.gd
+++ b/plugin/addons/godot_ai/dock_panels/log_viewer.gd
@@ -17,12 +17,17 @@ var _log_toggle: CheckButton
 var _last_log_count := 0
 
 
+## Build the UI synchronously here so callers (and detached-tree tests that
+## instantiate the dock with `McpDockScript.new()` and never enter the tree)
+## can interact with the panel's controls right after `setup()`. Mirrors the
+## pre-extraction inline-build behavior that test_dock.gd relies on.
+##
+## Idempotent: `_log_display == null` covers an unlikely double-`setup()` call
+## without rebuilding (which would orphan the prior controls).
 func setup(log_buffer: McpLogBuffer) -> void:
 	_log_buffer = log_buffer
-
-
-func _ready() -> void:
-	_build_ui()
+	if _log_display == null:
+		_build_ui()
 
 
 func _build_ui() -> void:

--- a/plugin/addons/godot_ai/dock_panels/log_viewer.gd
+++ b/plugin/addons/godot_ai/dock_panels/log_viewer.gd
@@ -2,24 +2,23 @@
 extends VBoxContainer
 
 ## Dock subpanel — renders the MCP request/response log buffer. Owns its own
-## UI subtree and the line-count cursor; the dock provides the buffer +
-## connection at setup() time and calls tick() each frame the panel is visible.
+## UI subtree, the line-count cursor, and the display-visibility toggle. Emits
+## `logging_enabled_changed` so the dock can route the flag onto the
+## connection dispatcher without the panel knowing the routing exists.
 ##
 ## Extracted from mcp_dock.gd as part of audit-v2 #360 — see the comment at
 ## the top of mcp_dock.gd for the broader extraction story.
 
-const COLOR_HEADER := Color(0.95, 0.95, 0.95)
+signal logging_enabled_changed(enabled: bool)
 
-var _log_buffer
-var _connection
+var _log_buffer: McpLogBuffer
 var _log_display: RichTextLabel
 var _log_toggle: CheckButton
 var _last_log_count := 0
 
 
-func setup(log_buffer, connection) -> void:
+func setup(log_buffer: McpLogBuffer) -> void:
 	_log_buffer = log_buffer
-	_connection = connection
 
 
 func _ready() -> void:
@@ -31,7 +30,7 @@ func _build_ui() -> void:
 	add_child(HSeparator.new())
 
 	var log_header_row := HBoxContainer.new()
-	var log_header := _make_header("MCP Log")
+	var log_header := McpDock._make_header("MCP Log")
 	log_header.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	log_header_row.add_child(log_header)
 
@@ -67,14 +66,5 @@ func tick() -> void:
 
 
 func _on_log_toggled(enabled: bool) -> void:
-	if _connection and _connection.dispatcher:
-		_connection.dispatcher.mcp_logging = enabled
 	_log_display.visible = enabled
-
-
-static func _make_header(text: String) -> Label:
-	var label := Label.new()
-	label.text = text
-	label.add_theme_font_size_override("font_size", 18)
-	label.add_theme_color_override("font_color", COLOR_HEADER)
-	return label
+	logging_enabled_changed.emit(enabled)

--- a/plugin/addons/godot_ai/dock_panels/log_viewer.gd
+++ b/plugin/addons/godot_ai/dock_panels/log_viewer.gd
@@ -1,0 +1,80 @@
+@tool
+extends VBoxContainer
+
+## Dock subpanel — renders the MCP request/response log buffer. Owns its own
+## UI subtree and the line-count cursor; the dock provides the buffer +
+## connection at setup() time and calls tick() each frame the panel is visible.
+##
+## Extracted from mcp_dock.gd as part of audit-v2 #360 — see the comment at
+## the top of mcp_dock.gd for the broader extraction story.
+
+const COLOR_HEADER := Color(0.95, 0.95, 0.95)
+
+var _log_buffer
+var _connection
+var _log_display: RichTextLabel
+var _log_toggle: CheckButton
+var _last_log_count := 0
+
+
+func setup(log_buffer, connection) -> void:
+	_log_buffer = log_buffer
+	_connection = connection
+
+
+func _ready() -> void:
+	_build_ui()
+
+
+func _build_ui() -> void:
+	size_flags_vertical = Control.SIZE_EXPAND_FILL
+	add_child(HSeparator.new())
+
+	var log_header_row := HBoxContainer.new()
+	var log_header := _make_header("MCP Log")
+	log_header.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	log_header_row.add_child(log_header)
+
+	_log_toggle = CheckButton.new()
+	_log_toggle.text = "Log"
+	_log_toggle.button_pressed = true
+	_log_toggle.toggled.connect(_on_log_toggled)
+	log_header_row.add_child(_log_toggle)
+
+	add_child(log_header_row)
+
+	_log_display = RichTextLabel.new()
+	_log_display.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	_log_display.custom_minimum_size = Vector2(0, 120)
+	_log_display.scroll_following = true
+	_log_display.bbcode_enabled = false
+	_log_display.selection_enabled = true
+	add_child(_log_display)
+
+
+## Called from McpDock._process when the panel is visible. Appends any new
+## log lines since the last tick.
+func tick() -> void:
+	if _log_buffer == null or _log_display == null:
+		return
+	var count: int = _log_buffer.total_count()
+	if count == _last_log_count:
+		return
+	var new_lines: Array[String] = _log_buffer.get_recent(count - _last_log_count)
+	for line in new_lines:
+		_log_display.add_text(line + "\n")
+	_last_log_count = count
+
+
+func _on_log_toggled(enabled: bool) -> void:
+	if _connection and _connection.dispatcher:
+		_connection.dispatcher.mcp_logging = enabled
+	_log_display.visible = enabled
+
+
+static func _make_header(text: String) -> Label:
+	var label := Label.new()
+	label.text = text
+	label.add_theme_font_size_override("font_size", 18)
+	label.add_theme_color_override("font_color", COLOR_HEADER)
+	return label

--- a/plugin/addons/godot_ai/dock_panels/log_viewer.gd.uid
+++ b/plugin/addons/godot_ai/dock_panels/log_viewer.gd.uid
@@ -1,0 +1,1 @@
+uid://cr5nbnd6vj3b8

--- a/plugin/addons/godot_ai/dock_panels/port_picker_panel.gd
+++ b/plugin/addons/godot_ai/dock_panels/port_picker_panel.gd
@@ -16,8 +16,16 @@ signal port_apply_requested(new_port: int)
 var _spinbox: SpinBox
 
 
-func _ready() -> void:
-	_build_ui()
+## Build the UI synchronously here so callers (and detached-tree tests that
+## instantiate the dock with `McpDockScript.new()` and never enter the tree)
+## can interact with the panel's controls right after `setup()`. Mirrors the
+## pre-extraction inline-build behavior that test_dock.gd relies on.
+##
+## Idempotent: `_spinbox == null` covers an unlikely double-`setup()` call
+## without rebuilding (which would orphan the prior controls).
+func setup() -> void:
+	if _spinbox == null:
+		_build_ui()
 
 
 func _build_ui() -> void:

--- a/plugin/addons/godot_ai/dock_panels/port_picker_panel.gd
+++ b/plugin/addons/godot_ai/dock_panels/port_picker_panel.gd
@@ -1,0 +1,65 @@
+@tool
+extends VBoxContainer
+
+## Dock subpanel — port-change escape hatch surfaced inside the spawn-failure
+## crash panel when the HTTP port is contested (PORT_EXCLUDED, FOREIGN_PORT).
+## Emits `port_apply_requested(new_port)` after range-validation; the dock
+## handles writing the EditorSetting and reloading the plugin.
+##
+## Extracted from mcp_dock.gd as part of audit-v2 #360 — see the comment at
+## the top of mcp_dock.gd for the broader extraction story.
+
+const ClientConfigurator := preload("res://addons/godot_ai/client_configurator.gd")
+
+signal port_apply_requested(new_port: int)
+
+var _spinbox: SpinBox
+
+
+func _ready() -> void:
+	_build_ui()
+
+
+func _build_ui() -> void:
+	add_theme_constant_override("separation", 4)
+	visible = false
+
+	var picker_row := HBoxContainer.new()
+	picker_row.add_theme_constant_override("separation", 6)
+
+	_spinbox = SpinBox.new()
+	_spinbox.min_value = ClientConfigurator.MIN_PORT
+	_spinbox.max_value = ClientConfigurator.MAX_PORT
+	_spinbox.step = 1
+	_spinbox.value = ClientConfigurator.http_port()
+	_spinbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	picker_row.add_child(_spinbox)
+
+	var apply_btn := Button.new()
+	apply_btn.text = "Apply + Reload"
+	apply_btn.tooltip_text = (
+		"Saves godot_ai/http_port to Editor Settings and reloads the plugin so"
+		+ " the server spawns on the new port."
+	)
+	apply_btn.pressed.connect(_on_apply_pressed)
+	picker_row.add_child(apply_btn)
+
+	add_child(picker_row)
+
+
+## Seed the spinbox with a suggested non-reserved port. Idempotent — the dock
+## calls this each time the panel becomes visible so a stale value from a
+## previous spawn-failure doesn't carry over.
+func seed_suggested_port() -> void:
+	if _spinbox == null:
+		return
+	_spinbox.value = ClientConfigurator.suggest_free_port(
+		ClientConfigurator.http_port() + 1
+	)
+
+
+func _on_apply_pressed() -> void:
+	var new_port: int = int(_spinbox.value)
+	if new_port < ClientConfigurator.MIN_PORT or new_port > ClientConfigurator.MAX_PORT:
+		return
+	port_apply_requested.emit(new_port)

--- a/plugin/addons/godot_ai/dock_panels/port_picker_panel.gd.uid
+++ b/plugin/addons/godot_ai/dock_panels/port_picker_panel.gd.uid
@@ -1,0 +1,1 @@
+uid://hlggbo1q65eq

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -174,7 +174,7 @@ var _mode_override_btn: OptionButton
 var _setup_section: VBoxContainer
 var _setup_container: VBoxContainer
 var _dev_server_btn: Button
-var _log_viewer  # log_viewer.gd — VBoxContainer subtree, owns log buffer cursor + display
+var _log_viewer: LogViewerScript
 
 var _last_connected := false
 var _last_status_text := ""
@@ -191,7 +191,7 @@ var _crash_reload_btn: Button
 ## cause is port contention (PORT_EXCLUDED or FOREIGN_PORT). The dock writes
 ## the EditorSetting and reloads the plugin in response to the panel's
 ## `port_apply_requested` signal.
-var _port_picker_panel  # port_picker_panel.gd — VBoxContainer subtree
+var _port_picker_panel: PortPickerPanelScript
 ## Last status Dict rendered into the panel — used to skip re-population
 ## when nothing changed, which would otherwise reset the user's scroll
 ## position on every frame. GDScript Dicts compare by value with `==`.
@@ -664,7 +664,8 @@ func _build_ui() -> void:
 
 	# --- Log section (dev-only) ---
 	_log_viewer = LogViewerScript.new()
-	_log_viewer.setup(_log_buffer, _connection)
+	_log_viewer.setup(_log_buffer)
+	_log_viewer.logging_enabled_changed.connect(_on_log_logging_enabled_changed)
 	add_child(_log_viewer)
 
 	# Apply initial dev-mode visibility
@@ -673,7 +674,9 @@ func _build_ui() -> void:
 	_perform_initial_client_status_refresh()
 
 
-func _make_header(text: String) -> Label:
+## Static so `dock_panels/*.gd` subpanels can call it via `McpDock._make_header(...)`
+## without re-declaring identical helpers + COLOR_HEADER constants.
+static func _make_header(text: String) -> Label:
 	var label := Label.new()
 	label.text = text
 	label.add_theme_font_size_override("font_size", 18)
@@ -981,6 +984,13 @@ func _apply_mixed_state_banner_diagnostic(diag: Dictionary) -> void:
 			"… (list truncated at %d entries)" % UpdateMixedStateScript.MAX_BACKUP_RESULTS
 		)
 		_mixed_state_files.newline()
+
+
+## Signal handler for the extracted LogViewer — the panel owns its own
+## display visibility, the dock owns dispatcher logging routing.
+func _on_log_logging_enabled_changed(enabled: bool) -> void:
+	if _connection and _connection.dispatcher:
+		_connection.dispatcher.mcp_logging = enabled
 
 
 ## Signal handler for the extracted PortPickerPanel — the panel range-validates

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -437,6 +437,7 @@ func _build_ui() -> void:
 	_crash_panel.add_child(_crash_output)
 
 	_port_picker_panel = PortPickerPanelScript.new()
+	_port_picker_panel.setup()
 	_port_picker_panel.port_apply_requested.connect(_on_port_apply_requested)
 	_crash_panel.add_child(_port_picker_panel)
 

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -3,6 +3,26 @@ class_name McpDock
 extends VBoxContainer
 
 ## Editor dock panel showing MCP connection status, client config, and command log.
+##
+## Audit-v2 #360 partial extraction. Two cohesive subpanels live in
+## res://addons/godot_ai/dock_panels/:
+##   - log_viewer.gd: MCP request/response log (dev-mode only).
+##   - port_picker_panel.gd: spawn-failure escape hatch nested in the crash panel.
+##
+## The audit also called for ServerStatusPanel and ClientRowController
+## extractions; those were *deliberately deferred*. Their UI scatters across
+## the dock layout (status icon at top, crash panel mid, setup section lower;
+## client rows + drift banner + scroll grid spread similarly), so a clean
+## extract-by-panel needs either visible UI reorganization or a coordinator-
+## Node pattern with property-accessor façades on McpDock that re-tangle the
+## very state they claim to move.
+##
+## A future refactor probably wants extract-by-concern instead — e.g.
+## `utils/mcp_async_refresh_state_machine.gd` owning the IDLE → RUNNING →
+## RUNNING_TIMED_OUT → DEFERRED_FOR_FILESYSTEM → SHUTTING_DOWN transitions
+## and pending-flag triplet, `utils/mcp_client_action_dispatcher.gd` owning
+## the per-row Configure/Remove worker pool. The dock would keep UI
+## construction and lose the state-machine ownership. See issue #360.
 
 const ServerStateScript := preload("res://addons/godot_ai/utils/mcp_server_state.gd")
 const ClientRefreshStateScript := preload("res://addons/godot_ai/utils/mcp_client_refresh_state.gd")
@@ -15,6 +35,8 @@ const JsonStrategy := preload("res://addons/godot_ai/clients/_json_strategy.gd")
 const TomlStrategy := preload("res://addons/godot_ai/clients/_toml_strategy.gd")
 const CliStrategy := preload("res://addons/godot_ai/clients/_cli_strategy.gd")
 const ToolCatalog := preload("res://addons/godot_ai/tool_catalog.gd")
+const LogViewerScript := preload("res://addons/godot_ai/dock_panels/log_viewer.gd")
+const PortPickerPanelScript := preload("res://addons/godot_ai/dock_panels/port_picker_panel.gd")
 
 const DEV_MODE_SETTING := "godot_ai/dev_mode"
 ## Index ↔ persisted-value mapping for the mode-override dropdown. The array
@@ -152,11 +174,8 @@ var _mode_override_btn: OptionButton
 var _setup_section: VBoxContainer
 var _setup_container: VBoxContainer
 var _dev_server_btn: Button
-var _log_section: VBoxContainer
-var _log_display: RichTextLabel
-var _log_toggle: CheckButton
+var _log_viewer  # log_viewer.gd — VBoxContainer subtree, owns log buffer cursor + display
 
-var _last_log_count := 0
 var _last_connected := false
 var _last_status_text := ""
 var _startup_grace_until_msec: int = 0
@@ -168,12 +187,11 @@ var _crash_panel: VBoxContainer
 var _crash_output: RichTextLabel
 var _crash_restart_btn: Button
 var _crash_reload_btn: Button
-## Port-picker escape hatch — visible inside the panel when the root
-## cause is port contention (PORT_EXCLUDED or FOREIGN_PORT). Applies a
-## new `godot_ai/http_port` value and reloads the plugin so the spawn
-## retries with the new port.
-var _port_picker_section: VBoxContainer
-var _port_picker_spinbox: SpinBox
+## Port-picker escape hatch — visible inside the crash panel when the root
+## cause is port contention (PORT_EXCLUDED or FOREIGN_PORT). The dock writes
+## the EditorSetting and reloads the plugin in response to the panel's
+## `port_apply_requested` signal.
+var _port_picker_panel  # port_picker_panel.gd — VBoxContainer subtree
 ## Last status Dict rendered into the panel — used to skip re-population
 ## when nothing changed, which would otherwise reset the user's scroll
 ## position on every frame. GDScript Dicts compare by value with `==`.
@@ -220,8 +238,8 @@ func _process(_delta: float) -> void:
 	_check_client_status_refresh_timeout()
 	_retry_deferred_client_status_refresh()
 	_update_status()
-	if _log_section.visible:
-		_update_log()
+	if _log_viewer != null and _log_viewer.visible:
+		_log_viewer.tick()
 
 
 func _exit_tree() -> void:
@@ -418,7 +436,9 @@ func _build_ui() -> void:
 	_crash_output.fit_content = true
 	_crash_panel.add_child(_crash_output)
 
-	_build_port_picker_section()
+	_port_picker_panel = PortPickerPanelScript.new()
+	_port_picker_panel.port_apply_requested.connect(_on_port_apply_requested)
+	_crash_panel.add_child(_port_picker_panel)
 
 	_crash_restart_btn = Button.new()
 	_crash_restart_btn.text = "Restart Server"
@@ -643,32 +663,9 @@ func _build_ui() -> void:
 	add_child(dev_toggle_row)
 
 	# --- Log section (dev-only) ---
-	_log_section = VBoxContainer.new()
-	_log_section.size_flags_vertical = Control.SIZE_EXPAND_FILL
-	add_child(_log_section)
-
-	_log_section.add_child(HSeparator.new())
-
-	var log_header_row := HBoxContainer.new()
-	var log_header := _make_header("MCP Log")
-	log_header.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	log_header_row.add_child(log_header)
-
-	_log_toggle = CheckButton.new()
-	_log_toggle.text = "Log"
-	_log_toggle.button_pressed = true
-	_log_toggle.toggled.connect(_on_log_toggled)
-	log_header_row.add_child(_log_toggle)
-
-	_log_section.add_child(log_header_row)
-
-	_log_display = RichTextLabel.new()
-	_log_display.size_flags_vertical = Control.SIZE_EXPAND_FILL
-	_log_display.custom_minimum_size = Vector2(0, 120)
-	_log_display.scroll_following = true
-	_log_display.bbcode_enabled = false
-	_log_display.selection_enabled = true
-	_log_section.add_child(_log_display)
+	_log_viewer = LogViewerScript.new()
+	_log_viewer.setup(_log_buffer, _connection)
+	add_child(_log_viewer)
 
 	# Apply initial dev-mode visibility
 	_apply_dev_mode_visibility()
@@ -869,14 +866,12 @@ func _update_crash_panel(server_status: Dictionary) -> void:
 		state == ServerStateScript.PORT_EXCLUDED
 		or state == ServerStateScript.FOREIGN_PORT
 	)
-	_port_picker_section.visible = port_picker_visible
+	_port_picker_panel.visible = port_picker_visible
 	if port_picker_visible:
-		## Seed the SpinBox with a suggested non-reserved port each time
-		## the panel surfaces. Idempotent when the user already has a
-		## good candidate queued up.
-		_port_picker_spinbox.value = ClientConfigurator.suggest_free_port(
-			ClientConfigurator.http_port() + 1
-		)
+		## Seed the spinbox with a suggested non-reserved port each time the
+		## panel surfaces. Idempotent when the user already has a good
+		## candidate queued up.
+		_port_picker_panel.seed_suggested_port()
 
 
 static func _crash_body_for_state(state: int, server_status: Dictionary = {}) -> String:
@@ -988,39 +983,10 @@ func _apply_mixed_state_banner_diagnostic(diag: Dictionary) -> void:
 		_mixed_state_files.newline()
 
 
-func _build_port_picker_section() -> void:
-	_port_picker_section = VBoxContainer.new()
-	_port_picker_section.add_theme_constant_override("separation", 4)
-	_port_picker_section.visible = false
-
-	var picker_row := HBoxContainer.new()
-	picker_row.add_theme_constant_override("separation", 6)
-
-	_port_picker_spinbox = SpinBox.new()
-	_port_picker_spinbox.min_value = ClientConfigurator.MIN_PORT
-	_port_picker_spinbox.max_value = ClientConfigurator.MAX_PORT
-	_port_picker_spinbox.step = 1
-	_port_picker_spinbox.value = ClientConfigurator.http_port()
-	_port_picker_spinbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	picker_row.add_child(_port_picker_spinbox)
-
-	var apply_btn := Button.new()
-	apply_btn.text = "Apply + Reload"
-	apply_btn.tooltip_text = (
-		"Saves godot_ai/http_port to Editor Settings and reloads the plugin so"
-		+ " the server spawns on the new port."
-	)
-	apply_btn.pressed.connect(_on_apply_new_port)
-	picker_row.add_child(apply_btn)
-
-	_port_picker_section.add_child(picker_row)
-	_crash_panel.add_child(_port_picker_section)
-
-
-func _on_apply_new_port() -> void:
-	var new_port: int = int(_port_picker_spinbox.value)
-	if new_port < ClientConfigurator.MIN_PORT or new_port > ClientConfigurator.MAX_PORT:
-		return
+## Signal handler for the extracted PortPickerPanel — the panel range-validates
+## the spinbox value before emitting, so we just write the EditorSetting and
+## reload the plugin here.
+func _on_port_apply_requested(new_port: int) -> void:
 	var es := EditorInterface.get_editor_settings()
 	if es != null:
 		es.set_setting(ClientConfigurator.SETTING_HTTP_PORT, new_port)
@@ -1042,20 +1008,6 @@ func _refresh_server_label() -> void:
 	if _plugin != null and _plugin.has_method("get_resolved_ws_port"):
 		ws_port = int(_plugin.get_resolved_ws_port())
 	_server_label.text = "WS: %d  HTTP: %d" % [ws_port, ClientConfigurator.http_port()]
-
-
-func _update_log() -> void:
-	if _log_buffer == null:
-		return
-	var count: int = _log_buffer.total_count()
-	if count == _last_log_count:
-		return
-
-	# Append only new lines
-	var new_lines: Array[String] = _log_buffer.get_recent(count - _last_log_count)
-	for line in new_lines:
-		_log_display.add_text(line + "\n")
-	_last_log_count = count
 
 
 # --- Dev mode persistence ---
@@ -1085,7 +1037,8 @@ func _on_dev_mode_toggled(enabled: bool) -> void:
 func _apply_dev_mode_visibility() -> void:
 	var dev := _dev_mode_toggle.button_pressed
 	_dev_section.visible = dev
-	_log_section.visible = dev
+	if _log_viewer != null:
+		_log_viewer.visible = dev
 
 	# Setup section: visible in dev mode, OR in user mode when uv is missing
 	# (so users can install uv from the dock).
@@ -1279,12 +1232,6 @@ func _dispatch_stale_server_restart() -> bool:
 		_plugin.force_restart_server()
 		return true
 	return false
-
-
-func _on_log_toggled(enabled: bool) -> void:
-	if _connection and _connection.dispatcher:
-		_connection.dispatcher.mcp_logging = enabled
-	_log_display.visible = enabled
 
 
 # --- Setup section ---

--- a/script/local-self-update-smoke
+++ b/script/local-self-update-smoke
@@ -564,12 +564,13 @@ def patch_vnext_hot_reload_trigger(path: Path) -> None:
     """Inject a typed Dict + Array onto McpDock so the vNext hot-reload
     actually exercises the field-storage crash class (issue #245).
 
-    Anchored to a stable plain field (`_last_log_count`) — anchoring to
+    Anchored to a stable plain field (`_last_connected`) — anchoring to
     a recently-moved field would silently miss the regression rather
-    than failing loudly.
+    than failing loudly. (`_last_log_count` moved into the LogViewer
+    subpanel as part of audit-v2 #360 and is no longer on McpDock.)
     """
     text = path.read_text(encoding="utf-8")
-    field_marker = "var _last_log_count := 0\n"
+    field_marker = "var _last_connected := false\n"
     if field_marker not in text:
         raise HarnessError(f"Could not find self-update field marker in {path}")
     text = text.replace(

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -7,6 +7,8 @@ extends McpTestSuite
 
 const McpDockScript = preload("res://addons/godot_ai/mcp_dock.gd")
 const GodotAiPlugin := preload("res://addons/godot_ai/plugin.gd")
+const PortPickerPanelScript = preload("res://addons/godot_ai/dock_panels/port_picker_panel.gd")
+const LogViewerScript = preload("res://addons/godot_ai/dock_panels/log_viewer.gd")
 
 ## Stub for the dock's `_update_manager` slot. Tests that want to fake
 ## "self-update mid-install" inject one of these so the dock's
@@ -787,3 +789,77 @@ func test_incompatible_server_hides_http_only_port_picker() -> void:
 	})
 	assert_true(_dock._crash_panel.visible, "diagnostic panel still shows")
 	assert_false(_dock._port_picker_panel.visible, "HTTP-only picker must stay hidden")
+
+
+# --- Signal-emit contracts on the audit-v2 #360 extracted subpanels ---
+# These pin the new panel boundary: panels emit; dock owns side effects.
+
+## Spies for the two panels' signals. Inner-class pattern matches the
+## `_RestartDispatchPlugin` spy at the top of this file — multi-line
+## lambdas with closure-captured locals don't reliably evaluate the body
+## under the test runner, so a typed receiver is the safe form.
+class _PortApplySpy:
+	var captured: Array[int] = []
+	func on_apply(new_port: int) -> void:
+		captured.append(new_port)
+
+
+class _LogToggleSpy:
+	var captured: Array[bool] = []
+	func on_toggle(enabled: bool) -> void:
+		captured.append(enabled)
+
+
+func test_port_picker_panel_emits_apply_requested_for_in_range_port() -> void:
+	## The panel is the gatekeeper for `EditorInterface.set_setting` — invalid
+	## ports must never reach the dock's handler. In-range values must.
+	## Instantiate the panel in isolation: going through the dock's wiring
+	## would fire the connected `_on_port_apply_requested` handler, which
+	## reloads the plugin (`set_plugin_enabled(false/true)`) and tears down
+	## the test runner mid-suite.
+	var panel := PortPickerPanelScript.new()
+	panel.setup()
+	var spy := _PortApplySpy.new()
+	panel.port_apply_requested.connect(spy.on_apply)
+	panel._spinbox.value = 9000
+	panel._on_apply_pressed()
+	assert_eq(spy.captured.size(), 1, "in-range port must emit exactly once")
+	assert_eq(spy.captured[0], 9000, "emitted port must match the spinbox value")
+	panel.free()
+
+
+func test_port_picker_panel_skips_emit_for_out_of_range_port() -> void:
+	## SpinBox.value is clamped by min_value/max_value at the UI layer,
+	## but the panel re-validates before emitting because programmatic
+	## sets (or future re-bindings) can bypass the clamp. The dock relies
+	## on this guard, so pin it. Same isolation rationale as the test above.
+	var panel := PortPickerPanelScript.new()
+	panel.setup()
+	var spy := _PortApplySpy.new()
+	panel.port_apply_requested.connect(spy.on_apply)
+	## Bypass the SpinBox clamp by writing the raw `value` field after
+	## relaxing min_value — covers a future regression where the panel's
+	## clamp is the only line of defense (e.g. someone replaces SpinBox
+	## with a free-form input).
+	panel._spinbox.min_value = 0
+	panel._spinbox.value = 0
+	panel._on_apply_pressed()
+	assert_eq(spy.captured.size(), 0, "out-of-range port must not emit")
+	panel.free()
+
+
+func test_log_viewer_emits_logging_enabled_changed_on_toggle() -> void:
+	## The dock routes this signal to `_connection.dispatcher.mcp_logging`.
+	## If LogViewer stops emitting, MCP request/response logging silently
+	## stays whatever it was — easy to regress, hard to spot.
+	## Instantiate in isolation to keep the test focused on the panel's
+	## emit contract (and consistent with the port-picker tests above).
+	var panel := LogViewerScript.new()
+	panel.setup(null)  # buffer not exercised — only signal emission is under test
+	var spy := _LogToggleSpy.new()
+	panel.logging_enabled_changed.connect(spy.on_toggle)
+	panel._on_log_toggled(false)
+	panel._on_log_toggled(true)
+	assert_eq(spy.captured, [false, true] as Array[bool],
+		"toggle must emit each state change exactly once, in order")
+	panel.free()

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -786,4 +786,4 @@ func test_incompatible_server_hides_http_only_port_picker() -> void:
 		"message": "Port 8000 is occupied by godot-ai server v1.2.10",
 	})
 	assert_true(_dock._crash_panel.visible, "diagnostic panel still shows")
-	assert_false(_dock._port_picker_section.visible, "HTTP-only picker must stay hidden")
+	assert_false(_dock._port_picker_panel.visible, "HTTP-only picker must stay hidden")


### PR DESCRIPTION
## Summary

Audit-v2 #360 partial extraction. Two cohesive Control subtrees move out of `mcp_dock.gd` into `plugin/addons/godot_ai/dock_panels/`:

- **`log_viewer.gd`** owns `_log_section` / `_log_display` / `_log_toggle` / `_last_log_count` and the `tick()` + `_on_log_toggled` methods. The dock's `_process` now calls `_log_viewer.tick()` instead of an inline `_update_log` helper, and `_apply_dev_mode_visibility` flips `_log_viewer.visible` directly.
- **`port_picker_panel.gd`** owns `_port_picker_section` / `_port_picker_spinbox`, range-validates, and emits `port_apply_requested(int)`. The dock listens, writes the EditorSetting, refreshes client status, and reloads the plugin. `seed_suggested_port()` is exposed for `_update_crash_panel` to call when the picker becomes visible.

`mcp_dock.gd`: 2424 → 2371 LOC (-53). Two new files, 80 + 65 LOC.

## Scope decision (read first)

The audit's "Natural extractions" listed four panels — `LogViewer`, `PortPickerPanel`, `ServerStatusPanel`, `ClientRowController`. **Only the first two ship in this PR.** The other two were deliberately deferred. A long-form note now sits at the top of `mcp_dock.gd` so the next contributor doesn't redo the analysis from scratch:

```
## A future refactor probably wants extract-by-concern instead — e.g.
## `utils/mcp_async_refresh_state_machine.gd` owning the IDLE → RUNNING →
## RUNNING_TIMED_OUT → DEFERRED_FOR_FILESYSTEM → SHUTTING_DOWN transitions
## and pending-flag triplet, `utils/mcp_client_action_dispatcher.gd` owning
## the per-row Configure/Remove worker pool. The dock would keep UI
## construction and lose the state-machine ownership. See issue #360.
```

The reasoning, in short: `ServerStatusPanel` and `ClientRowController` UI scatters across the dock layout (status icon at top, crash panel mid, setup section lower; client rows + drift banner + scroll grid spread similarly). A clean extract-by-panel needs either visible UI reorganization (out of scope for an internal refactor) or a coordinator-Node pattern with property-accessor façades on `McpDock` that re-tangle the very state they claim to move. The full discussion is on issue #360 (decision-thread comment 4384050064).

I'll file a follow-up issue for the deferred extract-by-concern work once this lands.

## Side-effect: smoke harness anchor

`script/local-self-update-smoke` injected its vNext field-storage trigger after `var _last_log_count := 0` — which moved into LogViewer. The harness comment explicitly predicted this:

```
Anchored to a stable plain field (`_last_log_count`) — anchoring to
a recently-moved field would silently miss the regression rather
than failing loudly.
```

The loud failure fired on this PR's pytest run (`test_self_update_smoke_harness_prepares_fixture` failed cleanly with `Could not find self-update field marker`). Anchor migrated to `var _last_connected := false` with an updated comment so the next field move is guided the same way.

## Test plan

- [x] `ruff check src/ tests/` — All checks passed
- [x] `pytest -q` — **892 passed**
- [x] `script/ci-check-gdscript` — All GDScript files OK
- [x] Headless GDScript `test_run` via MCP (`GODOT_AI_ALLOW_HEADLESS=1`) — **1211/1227 passed, 0 failed** (16 pre-existing macOS-headless camera-current skips)
- [x] No interactive `script/local-self-update-smoke` needed — the smoke-trigger paths in `mcp_dock.gd` (update banner, `_check_for_updates`, `_on_download_completed`, `_install_update`, etc.) were intentionally **not touched**. CLAUDE.md's smoke-gate trigger covers "update check/download/install paths"; this PR doesn't move any of that.

## Test migration

One line in `test_project/tests/test_dock.gd:789` — `_dock._port_picker_section` → `_dock._port_picker_panel`. Zero migrations elsewhere in `test_dock.gd` (no test pokes log internals; the picker test was the only state read).

## Cross-references

Closes #360 (partial — the deferred work tracked separately)
Umbrella: #343
Builds on the dock-panels directory pattern; preloads via `const`, no `class_name` (matches `clients/_*.gd` convention)

https://claude.ai/code/session_01B8h9tYowSrjvzUA1hEc1KC

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8h9tYowSrjvzUA1hEc1KC)_