### PR TITLE
Add Kimi Code CLI client support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,7 +246,7 @@ current working tree's `test_project/`.
 
 ## Client configuration
 
-The plugin auto-configures 18+ MCP clients via a registry + strategy system in
+The plugin auto-configures 19+ MCP clients via a registry + strategy system in
 `plugin/addons/godot_ai/clients/`:
 
 - `_base.gd` — `McpClient` descriptor (data only: id, display_name, config_type,

--- a/README.md
+++ b/README.md
@@ -74,10 +74,11 @@ covers:
 - **Claude Code**, **Claude Desktop**, **Antigravity**
 
 <details>
-<summary><strong>…and 15+ more clients</strong></summary>
+<summary><strong>…and 16+ more clients</strong></summary>
 
 Codex, Cursor, Windsurf, VS Code, VS Code Insiders, Zed, Gemini CLI, Cline,
-Kilo Code, Roo Code, Kiro, Trae, Cherry Studio, OpenCode, Qwen Code.
+Kilo Code, Roo Code, Kiro, Trae, Cherry Studio, OpenCode, Qwen Code,
+Kimi Code CLI.
 
 </details>
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -83,7 +83,7 @@ Adjacent reference docs:
 
 See [Packaging & Distribution](packaging-distribution.md) for full detail. The short version:
 
-- [x] clean install docs for Claude Code, Claude Desktop, Codex, and Antigravity (README + dock auto-configure with manual fallback for 18 clients including Cursor, Cline, Roo Code, Kilo, OpenCode, Zed, Windsurf, VS Code/Insiders, Trae, Kiro, Gemini CLI, Cherry Studio, Qwen Code)
+- [x] clean install docs for Claude Code, Claude Desktop, Codex, and Antigravity (README + dock auto-configure with manual fallback for 19 clients including Cursor, Cline, Roo Code, Kilo, OpenCode, Zed, Windsurf, VS Code/Insiders, Trae, Kiro, Gemini CLI, Cherry Studio, Qwen Code, Kimi Code CLI)
 - [x] PyPI / `uvx` path works reliably — automated via `bump-and-release.yml`; live on PyPI as `godot-ai`; `uvx --from godot-ai~=VERSION godot-ai` is the canonical user-install command. Stdio-only clients (Claude Desktop, Zed) bridge through `uvx mcp-proxy`. Stale-index retries (`--refresh`) and cache priming on self-update prevent flaky first-run failures.
 - [ ] desktop binary path is real, not aspirational
 - [x] plugin is downloadable from the Godot AssetLib — live as [asset/5050](https://godotengine.org/asset-library/asset/5050) and on the new [Godot Asset Store](https://store.godotengine.org/asset/dlight/godot-ai/); release ZIP workflow ships `godot-ai-plugin.zip` via GitHub Releases; dock self-update banner offers one-click upgrades that survive without an editor restart (`update_reload_runner.gd` handoff). Local self-update smoke (`script/local-self-update-smoke`) is the regression gate.

--- a/plugin/addons/godot_ai/clients/_registry.gd
+++ b/plugin/addons/godot_ai/clients/_registry.gd
@@ -24,6 +24,7 @@ const _CLIENT_SCRIPTS := [
 	preload("res://addons/godot_ai/clients/cherry_studio.gd"),
 	preload("res://addons/godot_ai/clients/opencode.gd"),
 	preload("res://addons/godot_ai/clients/qwen_code.gd"),
+	preload("res://addons/godot_ai/clients/kimi_code.gd"),
 ]
 
 static var _instances: Array[McpClient] = []

--- a/plugin/addons/godot_ai/clients/kimi_code.gd
+++ b/plugin/addons/godot_ai/clients/kimi_code.gd
@@ -1,0 +1,15 @@
+@tool
+extends McpClient
+
+
+func _init() -> void:
+	id = "kimi_code"
+	display_name = "Kimi Code CLI"
+	config_type = "cli"
+	doc_url = "https://moonshotai.github.io/kimi-cli/"
+	cli_names = PackedStringArray(["kimi", "kimi.exe"] if OS.get_name() == "Windows" else ["kimi"])
+	cli_register_template = PackedStringArray(
+		["mcp", "add", "--transport", "http", "{name}", "{url}"]
+	)
+	cli_unregister_template = PackedStringArray(["mcp", "remove", "{name}"])
+	cli_status_args = PackedStringArray(["mcp", "list"])


### PR DESCRIPTION
This PR adds auto-configuration support for [Kimi Code CLI](https://moonshotai.github.io/kimi-cli/) as an MCP client.

Changes:
- New client descriptor `kimi_code.gd` using the CLI strategy
- Registers `kimi mcp add/remove/list` commands for dock integration
- Updates README and docs to reflect the expanded client list

Kimi Code CLI uses the same HTTP transport pattern as Claude Code, so it slots into the existing CLI strategy without any new infrastructure.