### PR TITLE
Fix #397: pass encoding="utf-8" to read_text() in tests/

### DIFF
--- a/tests/unit/test_audit_data_loss_safeguards.py
+++ b/tests/unit/test_audit_data_loss_safeguards.py
@@ -37,7 +37,7 @@ ATOMIC_WRITE_PATH = PLUGIN_ROOT / "clients" / "_atomic_write.gd"
 
 
 def test_runner_declares_install_status_enum() -> None:
-    source = RUNNER_PATH.read_text()
+    source = RUNNER_PATH.read_text(encoding="utf-8")
     assert "enum InstallStatus { OK, FAILED_CLEAN, FAILED_MIXED }" in source, (
         "Three-state install outcome is the contract callers depend on. "
         "FAILED_CLEAN means rollback restored the prior state; FAILED_MIXED "
@@ -48,7 +48,7 @@ def test_runner_declares_install_status_enum() -> None:
 
 
 def test_runner_tracks_paths_written_for_cross_batch_rollback() -> None:
-    source = RUNNER_PATH.read_text()
+    source = RUNNER_PATH.read_text(encoding="utf-8")
     assert "var _paths_written = []" in source, (
         "Per-file install records must accumulate across both `_new_file_paths` "
         "and `_existing_file_paths` batches so a failure in the second batch "
@@ -60,7 +60,7 @@ def test_runner_tracks_paths_written_for_cross_batch_rollback() -> None:
 
 
 def test_install_zip_paths_returns_install_status_and_drives_rollback() -> None:
-    source = RUNNER_PATH.read_text()
+    source = RUNNER_PATH.read_text(encoding="utf-8")
     paths_block = get_func_block(source, "func _install_zip_paths(")
     assert "-> int:" in source[: source.index(paths_block) + len(paths_block)]
     assert "InstallStatus.OK" in paths_block, (
@@ -78,7 +78,7 @@ def test_install_zip_paths_returns_install_status_and_drives_rollback() -> None:
 
 
 def test_install_zip_file_returns_dictionary_record_with_backup_metadata() -> None:
-    source = RUNNER_PATH.read_text()
+    source = RUNNER_PATH.read_text(encoding="utf-8")
     install_block = get_func_block(source, "func _install_zip_file(")
     assert "-> Dictionary:" in source[: source.index(install_block) + len(install_block)]
     # Backup is taken via COPY (not rename) so the original stays in place
@@ -94,7 +94,7 @@ def test_install_zip_file_returns_dictionary_record_with_backup_metadata() -> No
 
 
 def test_install_zip_file_does_not_remove_target_before_rename_attempt() -> None:
-    source = RUNNER_PATH.read_text()
+    source = RUNNER_PATH.read_text(encoding="utf-8")
     install_block = get_func_block(source, "func _install_zip_file(")
     # The first rename attempt must precede any DirAccess.remove_absolute(target_path).
     # The remove-then-rename pattern only appears INSIDE the
@@ -112,7 +112,7 @@ def test_install_zip_file_does_not_remove_target_before_rename_attempt() -> None
 
 
 def test_rollback_returns_failed_mixed_when_any_restore_fails() -> None:
-    source = RUNNER_PATH.read_text()
+    source = RUNNER_PATH.read_text(encoding="utf-8")
     rollback_block = get_func_block(source, "func _rollback_paths_written(")
     assert "-> int:" in source[: source.index(rollback_block) + len(rollback_block)]
     assert "InstallStatus.FAILED_MIXED" in rollback_block, (
@@ -138,7 +138,7 @@ def test_inner_install_restore_failure_surfaces_failed_mixed() -> None:
     its conditional set in `_install_zip_file`, and its consumption in
     `_rollback_paths_written`."""
 
-    source = RUNNER_PATH.read_text()
+    source = RUNNER_PATH.read_text(encoding="utf-8")
     # Member declaration with the protective comment.
     assert "var _restore_failed := false" in source
 
@@ -146,9 +146,7 @@ def test_inner_install_restore_failure_surfaces_failed_mixed() -> None:
     # copy actually succeeded. The pattern is: a guarded copy_absolute
     # call whose return is checked, and an `else: _restore_failed = true`.
     install_block = get_func_block(source, "func _install_zip_file(")
-    assert (
-        "DirAccess.copy_absolute(backup_path, target_path) == OK" in install_block
-    ), (
+    assert "DirAccess.copy_absolute(backup_path, target_path) == OK" in install_block, (
         "Inner restore must check the copy result before treating the "
         "restore as complete. Without this check, a failed copy followed "
         "by an unconditional backup delete strands the file and produces "
@@ -170,7 +168,7 @@ def test_inner_install_restore_failure_surfaces_failed_mixed() -> None:
 
 
 def test_handle_install_failure_refuses_to_reenable_on_mixed_state() -> None:
-    source = RUNNER_PATH.read_text()
+    source = RUNNER_PATH.read_text(encoding="utf-8")
     handler_block = get_func_block(source, "func _handle_install_failure(")
     assert "InstallStatus.FAILED_MIXED" in handler_block
     # The MIXED branch must NOT call set_plugin_enabled(true). The caller
@@ -189,7 +187,7 @@ def test_handle_install_failure_refuses_to_reenable_on_mixed_state() -> None:
 
 
 def test_extract_and_scan_routes_failure_through_handle_install_failure() -> None:
-    source = RUNNER_PATH.read_text()
+    source = RUNNER_PATH.read_text(encoding="utf-8")
     extract_block = get_func_block(source, "func _extract_and_scan() -> void:")
     assert "_install_zip_paths(_new_file_paths)" in extract_block
     assert "_handle_install_failure(status)" in extract_block, (
@@ -213,7 +211,7 @@ def test_extract_and_scan_routes_failure_through_handle_install_failure() -> Non
 def test_atomic_write_does_not_remove_target_before_swap() -> None:
     """The bug pattern: remove(path) then retry rename. Must not return."""
 
-    source = ATOMIC_WRITE_PATH.read_text()
+    source = ATOMIC_WRITE_PATH.read_text(encoding="utf-8")
     write_block = get_func_block(source, "static func write(")
     # The dangerous sequence was: rename failed -> remove(path) -> rename retry.
     # In the new code, remove(path) only happens AFTER a successful copy
@@ -237,7 +235,7 @@ def test_atomic_write_does_not_remove_target_before_swap() -> None:
 
 
 def test_atomic_write_uses_copy_then_verify_as_rename_fallback() -> None:
-    source = ATOMIC_WRITE_PATH.read_text()
+    source = ATOMIC_WRITE_PATH.read_text(encoding="utf-8")
     write_block = get_func_block(source, "static func write(")
     assert "DirAccess.copy_absolute(tmp_path, path)" in write_block, (
         "Overwrite-copy is the safe fallback when rename-over-existing is "
@@ -252,7 +250,7 @@ def test_atomic_write_uses_copy_then_verify_as_rename_fallback() -> None:
 
 
 def test_atomic_write_restores_from_backup_when_swap_fails() -> None:
-    source = ATOMIC_WRITE_PATH.read_text()
+    source = ATOMIC_WRITE_PATH.read_text(encoding="utf-8")
     write_block = get_func_block(source, "static func write(")
     assert "DirAccess.copy_absolute(path, backup_path)" in write_block, (
         "Snapshot the prior file via copy_absolute BEFORE attempting the "
@@ -272,7 +270,7 @@ def test_atomic_write_restore_does_not_remove_path_before_copy() -> None:
     only. `copy_absolute` overwrites by default, so the pre-remove was
     unnecessary AND introduced a window where `path` could disappear."""
 
-    source = ATOMIC_WRITE_PATH.read_text()
+    source = ATOMIC_WRITE_PATH.read_text(encoding="utf-8")
     write_block = get_func_block(source, "static func write(")
 
     # Locate the `if backup_made:` branch and assert it does NOT contain
@@ -296,7 +294,7 @@ def test_atomic_write_restore_does_not_remove_path_before_copy() -> None:
 
 def test_atomic_write_size_verification_uses_utf8_byte_count() -> None:
     """`store_string` writes UTF-8 bytes — verify against to_utf8_buffer().size()."""
-    source = ATOMIC_WRITE_PATH.read_text()
+    source = ATOMIC_WRITE_PATH.read_text(encoding="utf-8")
     verify_block = get_func_block(source, "static func _written_size_matches(")
     assert "content.to_utf8_buffer().size()" in verify_block, (
         "String.length() returns char count which diverges from the byte "
@@ -314,7 +312,7 @@ def test_atomic_write_clears_partial_new_file_when_no_original_existed() -> None
     "destination is in its pre-call state on failure" — for a brand-new path
     that means nothing should be on disk after the function returns false."""
 
-    source = ATOMIC_WRITE_PATH.read_text()
+    source = ATOMIC_WRITE_PATH.read_text(encoding="utf-8")
     write_block = get_func_block(source, "static func write(")
     assert "elif not had_original and FileAccess.file_exists(path):" in write_block, (
         "Failure path must clear partial bytes when no original existed. "

--- a/tests/unit/test_camera_current_contract.py
+++ b/tests/unit/test_camera_current_contract.py
@@ -21,7 +21,7 @@ def test_current_switch_undo_captures_logical_or_effective_current() -> None:
     current", leaving the new camera active after undo.
     """
 
-    source = CAMERA_HANDLER_PATH.read_text()
+    source = CAMERA_HANDLER_PATH.read_text(encoding="utf-8")
     switch_block = get_func_block(
         source,
         "func _add_make_current_to_action(node: Node, type_str: String, scene_root: Node) -> void:",
@@ -31,13 +31,13 @@ def test_current_switch_undo_captures_logical_or_effective_current() -> None:
 
 
 def test_configure_current_false_uses_authoritative_current_guard() -> None:
-    source = CAMERA_HANDLER_PATH.read_text()
+    source = CAMERA_HANDLER_PATH.read_text(encoding="utf-8")
     configure_block = get_func_block(source, "func configure(params: Dictionary) -> Dictionary:")
     assert "var was_on: bool = _resolve_current(scene_root, node)" in configure_block
 
 
 def test_camera_reads_still_route_through_logical_current_resolvers() -> None:
-    source = CAMERA_HANDLER_PATH.read_text()
+    source = CAMERA_HANDLER_PATH.read_text(encoding="utf-8")
     get_block = get_func_block(source, "func get_camera(params: Dictionary) -> Dictionary:")
     list_block = get_func_block(source, "func list_cameras(_params: Dictionary) -> Dictionary:")
     assert "_resolve_current(scene_root, node)" in get_block

--- a/tests/unit/test_deferred_timeout_contract.py
+++ b/tests/unit/test_deferred_timeout_contract.py
@@ -11,12 +11,12 @@ PLUGIN_ROOT = Path(__file__).resolve().parents[2] / "plugin" / "addons" / "godot
 
 def test_deferred_timeout_error_code_registered_on_both_sides() -> None:
     assert ErrorCode.DEFERRED_TIMEOUT == "DEFERRED_TIMEOUT"
-    gd_error_codes = (PLUGIN_ROOT / "utils" / "error_codes.gd").read_text()
+    gd_error_codes = (PLUGIN_ROOT / "utils" / "error_codes.gd").read_text(encoding="utf-8")
     assert 'const DEFERRED_TIMEOUT := "DEFERRED_TIMEOUT"' in gd_error_codes
 
 
 def test_dispatcher_tracks_deferred_ids_and_emits_timeout_error() -> None:
-    source = (PLUGIN_ROOT / "dispatcher.gd").read_text()
+    source = (PLUGIN_ROOT / "dispatcher.gd").read_text(encoding="utf-8")
     assert "_pending_deferred" in source
     assert 'const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")' in source
     assert "ErrorCodes.DEFERRED_TIMEOUT" in source

--- a/tests/unit/test_dock_cli_timeout.py
+++ b/tests/unit/test_dock_cli_timeout.py
@@ -28,7 +28,7 @@ PLUGIN_ROOT = Path(__file__).resolve().parents[2] / "plugin" / "addons" / "godot
 def test_cli_strategy_routes_every_shell_out_through_mcpcliexec() -> None:
     """No bare OS.execute survives in _cli_strategy.gd."""
 
-    cli_source = (PLUGIN_ROOT / "clients" / "_cli_strategy.gd").read_text()
+    cli_source = (PLUGIN_ROOT / "clients" / "_cli_strategy.gd").read_text(encoding="utf-8")
 
     # The whole point of the refactor: every CLI invocation must go
     # through the bounded helper. A bare OS.execute slipping back in
@@ -50,7 +50,7 @@ def test_cli_strategy_routes_every_shell_out_through_mcpcliexec() -> None:
 def test_cli_exec_helper_uses_pipe_spawn_and_poll_kill() -> None:
     """The helper must spawn detached and kill on timeout — not a blocking OS.execute."""
 
-    helper_source = (PLUGIN_ROOT / "clients" / "_cli_exec.gd").read_text()
+    helper_source = (PLUGIN_ROOT / "clients" / "_cli_exec.gd").read_text(encoding="utf-8")
 
     # Pipe-based spawn returns a PID we can poll on. A blocking
     # OS.execute(..., true) here would just relocate the original hang.
@@ -67,7 +67,7 @@ def test_cli_exec_helper_uses_pipe_spawn_and_poll_kill() -> None:
 def test_cli_strategy_surfaces_timeout_in_configure_and_remove_messages() -> None:
     """A timeout must produce a user-actionable error, not a cryptic exit code."""
 
-    cli_source = (PLUGIN_ROOT / "clients" / "_cli_strategy.gd").read_text()
+    cli_source = (PLUGIN_ROOT / "clients" / "_cli_strategy.gd").read_text(encoding="utf-8")
 
     # The dock surfaces these strings in its row-error label and "Run
     # this manually" panel. Drift here means the user sees "exit code
@@ -84,7 +84,7 @@ def test_cli_strategy_surfaces_timeout_in_configure_and_remove_messages() -> Non
 def test_dock_dispatches_configure_and_remove_to_worker_thread() -> None:
     """Issue #239: the Configure / Remove buttons must not block main."""
 
-    dock_source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+    dock_source = (PLUGIN_ROOT / "mcp_dock.gd").read_text(encoding="utf-8")
 
     # The dispatch funnel must exist and route the click into a worker.
     assert "func _dispatch_client_action(" in dock_source
@@ -114,8 +114,8 @@ def test_dock_dispatches_configure_and_remove_to_worker_thread() -> None:
 def test_dock_drains_action_workers_during_install_update_and_exit_tree() -> None:
     """Worker drain must cover both shutdown paths — same reason as the refresh worker."""
 
-    dock_source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
-    manager_source = (PLUGIN_ROOT / "utils" / "update_manager.gd").read_text()
+    dock_source = (PLUGIN_ROOT / "mcp_dock.gd").read_text(encoding="utf-8")
+    manager_source = (PLUGIN_ROOT / "utils" / "update_manager.gd").read_text(encoding="utf-8")
 
     # `_exit_tree` (dock teardown) must drain inline; the install-time
     # drain runs through `McpUpdateManager._drain_dock_workers()` which
@@ -141,7 +141,7 @@ def test_dock_drains_action_workers_during_install_update_and_exit_tree() -> Non
 def test_dock_action_dispatch_gates_on_self_update_in_progress() -> None:
     """The same gate the refresh worker honors must protect Configure / Remove."""
 
-    dock_source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+    dock_source = (PLUGIN_ROOT / "mcp_dock.gd").read_text(encoding="utf-8")
     block = get_func_block(dock_source, "func _dispatch_client_action(")
     assert "_is_self_update_in_progress" in block, (
         "Configure / Remove dispatch must short-circuit during the "
@@ -155,7 +155,7 @@ def test_dock_action_dispatch_gates_on_self_update_in_progress() -> None:
 def test_status_refresh_apply_skips_rows_with_in_flight_action() -> None:
     """A concurrent refresh result must not stomp the 'Configuring…' badge."""
 
-    dock_source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+    dock_source = (PLUGIN_ROOT / "mcp_dock.gd").read_text(encoding="utf-8")
     apply_block = get_func_block(dock_source, "func _apply_client_status_refresh_results(")
     assert "_client_action_threads.has(" in apply_block, (
         "Refresh-result apply must skip rows whose action worker is "

--- a/tests/unit/test_editor_focus_refocus.py
+++ b/tests/unit/test_editor_focus_refocus.py
@@ -13,7 +13,7 @@ PLUGIN_ROOT = Path(__file__).resolve().parents[2] / "plugin" / "addons" / "godot
 def test_focus_in_uses_async_cooled_down_refresh_instead_of_blocking_sweep() -> None:
     """Focus-in should keep automatic refresh without blocking the editor thread."""
 
-    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text(encoding="utf-8")
 
     assert "NOTIFICATION_APPLICATION_FOCUS_IN" in source
     assert "CLIENT_STATUS_REFRESH_COOLDOWN_MSEC := 15 * 1000" in source
@@ -24,7 +24,7 @@ def test_focus_in_uses_async_cooled_down_refresh_instead_of_blocking_sweep() -> 
 def test_client_status_refresh_runs_on_background_thread_and_applies_deferred() -> None:
     """Blocking client probes should run off-thread; UI updates should apply deferred."""
 
-    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text(encoding="utf-8")
 
     assert "var _client_status_refresh_thread: Thread" in source
     assert "_client_status_refresh_thread.start" in source
@@ -35,7 +35,7 @@ def test_client_status_refresh_runs_on_background_thread_and_applies_deferred() 
 def test_client_status_refresh_coalesces_and_manual_refresh_bypasses_cooldown() -> None:
     """Duplicate automatic refreshes should coalesce; manual actions stay explicit."""
 
-    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text(encoding="utf-8")
 
     assert "if ClientRefreshStateScript.has_worker_alive(_refresh_state):" in source
     assert "_client_status_refresh_pending = true" in source
@@ -46,7 +46,7 @@ def test_client_status_refresh_coalesces_and_manual_refresh_bypasses_cooldown() 
 def test_clients_window_open_requests_nonblocking_refresh() -> None:
     """Opening Clients & Tools should not schedule a deferred synchronous sweep."""
 
-    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text(encoding="utf-8")
     block = get_func_block(source, "func _on_open_clients_window() -> void:")
 
     assert "_request_client_status_refresh(" in block
@@ -88,7 +88,7 @@ def test_initial_paint_warms_worker_call_graph_before_threading() -> None:
     (regressing #228's responsiveness fix and re-blocking the cold paint).
     """
 
-    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text(encoding="utf-8")
     build_block = get_func_block(source, "func _build_ui() -> void:")
     assert "_perform_initial_client_status_refresh()" in build_block, (
         "_build_ui must call the initial-refresh helper"
@@ -137,12 +137,8 @@ def test_initial_paint_warms_worker_call_graph_before_threading() -> None:
         "_warm_strategy_bytecode must dereference JsonStrategy so the "
         "worker can't race the JSON strategy's lazy bytecode swap."
     )
-    assert "TomlStrategy." in warm_block, (
-        "_warm_strategy_bytecode must dereference TomlStrategy."
-    )
-    assert "CliStrategy." in warm_block, (
-        "_warm_strategy_bytecode must dereference CliStrategy."
-    )
+    assert "TomlStrategy." in warm_block, "_warm_strategy_bytecode must dereference TomlStrategy."
+    assert "CliStrategy." in warm_block, "_warm_strategy_bytecode must dereference CliStrategy."
     assert "FileAccess" not in warm_block and "OS.execute" not in warm_block, (
         "_warm_strategy_bytecode must stay pure-memory — no disk, no "
         "subprocess. The point is to dereference scripts cheaply, not to "
@@ -160,7 +156,7 @@ def test_initial_paint_warms_worker_call_graph_before_threading() -> None:
 def test_client_status_refresh_defers_while_editor_filesystem_is_busy() -> None:
     """Refresh workers must not race Godot's script reload/documentation pass."""
 
-    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text(encoding="utf-8")
 
     # PR 6 (#297) collapsed the deferred-* boolean cluster into the
     # McpClientRefreshState enum's DEFERRED_FOR_FILESYSTEM value, plus
@@ -199,7 +195,7 @@ def test_client_status_refresh_defers_while_editor_filesystem_is_busy() -> None:
 def test_focus_refresh_is_opportunistic_while_editor_filesystem_is_busy() -> None:
     """Focus-in status refresh should never be treated as important editor work."""
 
-    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text(encoding="utf-8")
     focus_block = _focus_in_block(source)
     request_block = get_func_block(
         source, "func _request_client_status_refresh(force: bool = false) -> bool:"
@@ -219,7 +215,7 @@ def test_focus_refresh_is_opportunistic_while_editor_filesystem_is_busy() -> Non
 def test_deferred_manual_refresh_replays_through_async_request_path_only() -> None:
     """Queued manual refreshes should not reintroduce PR #228's sync sweep."""
 
-    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text(encoding="utf-8")
     retry_block = get_func_block(source, "func _retry_deferred_client_status_refresh() -> void:")
 
     for block in (retry_block,):
@@ -241,7 +237,7 @@ def test_deferred_manual_refresh_replays_through_async_request_path_only() -> No
 def test_deferred_initial_refresh_replays_warmup_path() -> None:
     """Scan-delayed initial paint must preserve #235's main-thread warm-up."""
 
-    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text(encoding="utf-8")
     retry_block = get_func_block(source, "func _retry_deferred_client_status_refresh() -> void:")
 
     assert "var initial := _client_status_refresh_pending_initial" in retry_block
@@ -278,7 +274,7 @@ def test_install_update_drains_workers_and_blocks_spawning_before_extract() -> N
     `_is_self_update_in_progress()` which consults the manager's flag.
     """
 
-    manager_source = (PLUGIN_ROOT / "utils" / "update_manager.gd").read_text()
+    manager_source = (PLUGIN_ROOT / "utils" / "update_manager.gd").read_text(encoding="utf-8")
     install_block = get_func_block(manager_source, "func _install_zip() -> void:")
 
     flag_set_idx = install_block.find("_install_in_flight = true")
@@ -318,7 +314,7 @@ def test_install_update_drains_workers_and_blocks_spawning_before_extract() -> N
         "extraction so plugin-owned instances do not hot-reload in place."
     )
 
-    dock_source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+    dock_source = (PLUGIN_ROOT / "mcp_dock.gd").read_text(encoding="utf-8")
     request_block = get_func_block(
         dock_source, "func _request_client_status_refresh(force: bool = false) -> bool:"
     )
@@ -343,8 +339,8 @@ def test_install_update_drains_workers_and_blocks_spawning_before_extract() -> N
 def test_self_update_runner_disables_old_plugin_before_extract_and_scan() -> None:
     """The in-process update path must never expose a half-written addon tree."""
 
-    plugin_source = (PLUGIN_ROOT / "plugin.gd").read_text()
-    runner_source = (PLUGIN_ROOT / "update_reload_runner.gd").read_text()
+    plugin_source = (PLUGIN_ROOT / "plugin.gd").read_text(encoding="utf-8")
+    runner_source = (PLUGIN_ROOT / "update_reload_runner.gd").read_text(encoding="utf-8")
 
     assert "UPDATE_RELOAD_RUNNER_SCRIPT" in plugin_source
     handoff_block = get_func_block(plugin_source, "func install_downloaded_update(")
@@ -456,7 +452,7 @@ def test_self_update_runner_disables_old_plugin_before_extract_and_scan() -> Non
 def test_self_update_runner_does_not_introduce_typed_variant_storage_hazards() -> None:
     """The runner is the only plugin-owned script instance expected to survive scan."""
 
-    runner_source = (PLUGIN_ROOT / "update_reload_runner.gd").read_text()
+    runner_source = (PLUGIN_ROOT / "update_reload_runner.gd").read_text(encoding="utf-8")
     risky_field = re.compile(r"^\s*var\s+\w+\s*:\s*(?:Dictionary|Array)(?:\[|[\s=])", re.M)
 
     assert risky_field.search(runner_source) is None, (
@@ -469,9 +465,9 @@ def test_self_update_runner_does_not_introduce_typed_variant_storage_hazards() -
 def test_worker_uses_main_thread_probe_snapshot_for_cli_paths() -> None:
     """CLI path discovery caches should not be mutated from the refresh worker."""
 
-    dock_source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
-    configurator_source = (PLUGIN_ROOT / "client_configurator.gd").read_text()
-    cli_source = (PLUGIN_ROOT / "clients" / "_cli_strategy.gd").read_text()
+    dock_source = (PLUGIN_ROOT / "mcp_dock.gd").read_text(encoding="utf-8")
+    configurator_source = (PLUGIN_ROOT / "client_configurator.gd").read_text(encoding="utf-8")
+    cli_source = (PLUGIN_ROOT / "clients" / "_cli_strategy.gd").read_text(encoding="utf-8")
     worker_block = get_func_block(dock_source, "func _run_client_status_refresh_worker")
 
     assert "client_status_probe_snapshot" in dock_source
@@ -487,7 +483,7 @@ def test_worker_uses_main_thread_probe_snapshot_for_cli_paths() -> None:
 def test_refresh_timeout_can_abandon_stale_worker_results() -> None:
     """A hung CLI probe should not permanently own the refresh slot."""
 
-    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text(encoding="utf-8")
 
     assert "CLIENT_STATUS_REFRESH_TIMEOUT_MSEC := 30 * 1000" in source
     assert "_client_status_refresh_generation" in source
@@ -512,7 +508,7 @@ def test_check_uv_version_caches_for_session() -> None:
     a single explicit `invalidate_uv_version_cache()` call clears both.
     """
 
-    source = (PLUGIN_ROOT / "client_configurator.gd").read_text()
+    source = (PLUGIN_ROOT / "client_configurator.gd").read_text(encoding="utf-8")
 
     assert "static var _uv_version_cache: String" in source, (
         "Cached `uvx --version` string must be a class-level static so it "
@@ -555,7 +551,7 @@ def test_check_uv_version_caches_for_session() -> None:
         "through check_uv_version (e.g. future inspectors / debug helpers)."
     )
 
-    dock_source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+    dock_source = (PLUGIN_ROOT / "mcp_dock.gd").read_text(encoding="utf-8")
     install_block = get_func_block(dock_source, "func _on_install_uv() -> void:")
     assert "ClientConfigurator.invalidate_uvx_cli_cache()" in install_block, (
         "_on_install_uv must invalidate the CLI-path cache via the "
@@ -586,7 +582,7 @@ def test_force_refresh_invalidates_cli_finder_cache() -> None:
     editor restart. Focus-in (`force=false`) keeps the cache.
     """
 
-    configurator_source = (PLUGIN_ROOT / "client_configurator.gd").read_text()
+    configurator_source = (PLUGIN_ROOT / "client_configurator.gd").read_text(encoding="utf-8")
     invalidator_block = get_func_block(
         configurator_source, "static func invalidate_cli_cache() -> void:"
     )
@@ -595,7 +591,7 @@ def test_force_refresh_invalidates_cli_finder_cache() -> None:
         "cached entry (positive and negative)."
     )
 
-    dock_source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+    dock_source = (PLUGIN_ROOT / "mcp_dock.gd").read_text(encoding="utf-8")
     request_block = get_func_block(
         dock_source,
         "func _request_client_status_refresh(force: bool = false) -> bool:",
@@ -627,7 +623,7 @@ def test_cli_finder_cache_is_mutex_guarded() -> None:
     the off-main-thread CLI-lookup design.
     """
 
-    source = (PLUGIN_ROOT / "clients" / "_cli_finder.gd").read_text()
+    source = (PLUGIN_ROOT / "clients" / "_cli_finder.gd").read_text(encoding="utf-8")
 
     assert re.search(r"static var _mutex: Mutex = Mutex\.new\(\)", source), (
         "CliFinder must declare `static var _mutex: Mutex = Mutex.new()` so "
@@ -636,7 +632,7 @@ def test_cli_finder_cache_is_mutex_guarded() -> None:
     )
 
     invalidate_block = get_func_block(
-        source, "static func invalidate(exe_name: String = \"\") -> void:"
+        source, 'static func invalidate(exe_name: String = "") -> void:'
     )
     assert "_mutex.lock()" in invalidate_block and "_mutex.unlock()" in invalidate_block, (
         "invalidate() must hold _mutex around the dict clear/erase so it "
@@ -675,7 +671,7 @@ def test_cli_finder_cache_is_mutex_guarded() -> None:
 def test_configure_all_uses_cached_status_not_dot_color() -> None:
     """Configure-all must not make correctness decisions from stale UI colors."""
 
-    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text()
+    source = (PLUGIN_ROOT / "mcp_dock.gd").read_text(encoding="utf-8")
     block = get_func_block(source, "func _on_configure_all_clients() -> void:")
 
     assert 'get("status", Client.Status.NOT_CONFIGURED)' in block

--- a/tests/unit/test_error_code_distribution.py
+++ b/tests/unit/test_error_code_distribution.py
@@ -20,13 +20,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-HANDLERS_DIR = (
-    Path(__file__).resolve().parents[2]
-    / "plugin"
-    / "addons"
-    / "godot_ai"
-    / "handlers"
-)
+HANDLERS_DIR = Path(__file__).resolve().parents[2] / "plugin" / "addons" / "godot_ai" / "handlers"
 
 ## Post-migration baseline: 97 INVALID_PARAMS sites in plugin/handlers/.
 ## The 367 specifically-coded sites are spread across NODE_NOT_FOUND (39),
@@ -57,7 +51,7 @@ def _count_code_uses(code: str) -> int:
     pattern = re.compile(rf"\b{re.escape(code)}\b")
     total = 0
     for gd_file in HANDLERS_DIR.glob("*.gd"):
-        total += len(pattern.findall(gd_file.read_text()))
+        total += len(pattern.findall(gd_file.read_text(encoding="utf-8")))
     return total
 
 

--- a/tests/unit/test_error_code_parity.py
+++ b/tests/unit/test_error_code_parity.py
@@ -33,7 +33,7 @@ _CONST_RE = re.compile(r'^\s*const\s+([A-Z_]+)\s*:=\s*"([A-Z_]+)"\s*$', re.MULTI
 
 @functools.cache
 def _parse_gdscript_codes() -> dict[str, str]:
-    text = ERROR_CODES_GD.read_text()
+    text = ERROR_CODES_GD.read_text(encoding="utf-8")
     return dict(_CONST_RE.findall(text))
 
 

--- a/tests/unit/test_path_traversal_guard.py
+++ b/tests/unit/test_path_traversal_guard.py
@@ -31,7 +31,7 @@ def test_path_validator_file_exists() -> None:
 
 def test_path_validator_declares_class_name() -> None:
     """Project-wide class_name lets handlers reference McpPathValidator without preload."""
-    source = PATH_VALIDATOR.read_text()
+    source = PATH_VALIDATOR.read_text(encoding="utf-8")
     assert "class_name McpPathValidator" in source
 
 
@@ -43,7 +43,7 @@ def test_path_validator_implements_layered_checks() -> None:
     Each layer catches a different escape vector — losing any of them silently
     weakens the security boundary without a single test failing on a single bad input.
     """
-    source = PATH_VALIDATOR.read_text()
+    source = PATH_VALIDATOR.read_text(encoding="utf-8")
     # 1) non-empty guard — without this, an empty path silently passes the
     # prefix check (since "".begins_with("res://") is false, the prefix
     # error fires, but the message would name the wrong layer).
@@ -73,7 +73,7 @@ def test_script_handler_uses_path_validator_at_every_entry_point() -> None:
     bare prefix check, agent input flows back into the file write/read
     primitives without the `..` and boundary guards.
     """
-    source = SCRIPT_HANDLER.read_text()
+    source = SCRIPT_HANDLER.read_text(encoding="utf-8")
     # No bare prefix check remains in this file.
     assert 'begins_with("res://")' not in source, (
         'script_handler.gd must not contain bare `begins_with("res://")` '
@@ -93,7 +93,7 @@ def test_script_handler_uses_path_validator_at_every_entry_point() -> None:
 
 
 def test_filesystem_handler_uses_path_validator_at_every_entry_point() -> None:
-    source = FILESYSTEM_HANDLER.read_text()
+    source = FILESYSTEM_HANDLER.read_text(encoding="utf-8")
     assert 'begins_with("res://")' not in source, (
         'filesystem_handler.gd must not contain bare `begins_with("res://")` '
         "checks — replace with McpPathValidator.validate_resource_path."

--- a/tests/unit/test_plugin_self_update_safety.py
+++ b/tests/unit/test_plugin_self_update_safety.py
@@ -76,7 +76,7 @@ def _registered_mcp_class_names() -> set[str]:
     pattern = re.compile(r"^class_name\s+(Mcp\w+)\s*$", re.MULTILINE)
     found: set[str] = set()
     for gd_file in PLUGIN_ROOT.rglob("*.gd"):
-        found.update(pattern.findall(gd_file.read_text()))
+        found.update(pattern.findall(gd_file.read_text(encoding="utf-8")))
     return found
 
 
@@ -115,7 +115,7 @@ def test_targeted_load_scripts_have_no_typed_fields_against_plugin_class_names()
     offenders: list[str] = []
 
     for gd_file in TARGETED_LOAD_SURFACE_FILES:
-        source = _strip_gdscript_comments(gd_file.read_text())
+        source = _strip_gdscript_comments(gd_file.read_text(encoding="utf-8"))
         for match in typed_field.finditer(source):
             field_name, type_name = match.group(1), match.group(2)
             if type_name not in mcp_classes:
@@ -142,7 +142,7 @@ def test_plugin_gd_does_not_construct_via_class_name() -> None:
     declared at the top of `plugin.gd` and call `Foo.new(...)` instead.
     """
 
-    source = _strip_gdscript_comments(PLUGIN_GD.read_text())
+    source = _strip_gdscript_comments(PLUGIN_GD.read_text(encoding="utf-8"))
     mcp_classes = _registered_mcp_class_names()
 
     constructor = re.compile(r"\b(Mcp\w+)\.new\s*\(")
@@ -175,7 +175,7 @@ def test_targeted_load_scripts_do_not_construct_via_class_name() -> None:
     offenders: list[str] = []
 
     for gd_file in TARGETED_LOAD_SURFACE_FILES:
-        source = _strip_gdscript_comments(gd_file.read_text())
+        source = _strip_gdscript_comments(gd_file.read_text(encoding="utf-8"))
         for match in constructor.finditer(source):
             type_name = match.group(1)
             if type_name not in mcp_classes:
@@ -210,7 +210,7 @@ def test_targeted_load_scripts_do_not_access_members_via_class_name() -> None:
     offenders: list[str] = []
 
     for gd_file in TARGETED_LOAD_SURFACE_FILES:
-        source = _strip_gdscript_comments(gd_file.read_text())
+        source = _strip_gdscript_comments(gd_file.read_text(encoding="utf-8"))
         for match in member_access.finditer(source):
             type_name, member = match.group(1), match.group(2)
             if type_name not in mcp_classes:
@@ -242,7 +242,7 @@ def test_plugin_gd_documents_the_untyped_policy() -> None:
     the hazard.
     """
 
-    source = PLUGIN_GD.read_text()
+    source = PLUGIN_GD.read_text(encoding="utf-8")
     assert "Self-update parse-hazard policy" in source, (
         "plugin.gd must keep an explanatory comment near the untyped "
         "field declarations referencing the parse-hazard policy. Without "

--- a/tests/unit/test_read_text_encoding.py
+++ b/tests/unit/test_read_text_encoding.py
@@ -1,0 +1,55 @@
+"""Lint that `read_text()` calls in tests/ always pass `encoding=`.
+
+`Path.read_text()` with no arguments defaults to
+`locale.getpreferredencoding()`. On Windows that's cp1252, which
+raises `UnicodeDecodeError` on any non-ASCII byte in the file being
+read. Linux/macOS default to UTF-8, so the hazard is silent until a
+developer runs pytest on Windows.
+
+Issue #397 surfaced four failing tests in
+`test_plugin_self_update_safety.py` because it `rglob`-walks the
+plugin tree, and `plugin/addons/godot_ai/utils/uv_cache_cleanup.gd`
+carries a verbatim Korean Windows error message string. Other tests
+in `tests/unit/` walk plugin `.gd` files via `glob`/`rglob` or read
+specific files that could pick up non-ASCII the next time someone
+adds a foreign-language comment elsewhere.
+
+This test enforces the hygiene rule across `tests/`: every bare
+`.read_text()` call (no kwargs) is an offender. CI is Linux-only
+(issue #35) so this is the only line of defense before a Windows
+developer hits the same trap.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+TESTS_ROOT = Path(__file__).resolve().parent.parent
+REPO_ROOT = TESTS_ROOT.parent
+
+
+def test_test_files_pass_encoding_to_read_text() -> None:
+    offenders: list[str] = []
+
+    for py_file in TESTS_ROOT.rglob("*.py"):
+        tree = ast.parse(py_file.read_text(encoding="utf-8"))
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not isinstance(func, ast.Attribute) or func.attr != "read_text":
+                continue
+            if any(kw.arg == "encoding" for kw in node.keywords):
+                continue
+            rel = py_file.relative_to(REPO_ROOT)
+            offenders.append(f"{rel}:{node.lineno}")
+
+    assert not offenders, (
+        "Path.read_text() calls in tests/ must pass encoding='utf-8'. "
+        "Without it, Python falls back to locale.getpreferredencoding(), "
+        "which is cp1252 on Windows and raises UnicodeDecodeError on any "
+        "non-ASCII byte in the file (issue #397). Add encoding='utf-8'. "
+        f"Bare calls: {offenders}"
+    )

--- a/tests/unit/test_read_text_encoding.py
+++ b/tests/unit/test_read_text_encoding.py
@@ -1,55 +1,77 @@
-"""Lint that `read_text()` calls in tests/ always pass `encoding=`.
+"""Lint that `Path.read_text()` calls in tests/ pass `encoding="utf-8"`.
 
-`Path.read_text()` with no arguments defaults to
-`locale.getpreferredencoding()`. On Windows that's cp1252, which
-raises `UnicodeDecodeError` on any non-ASCII byte in the file being
-read. Linux/macOS default to UTF-8, so the hazard is silent until a
-developer runs pytest on Windows.
-
-Issue #397 surfaced four failing tests in
-`test_plugin_self_update_safety.py` because it `rglob`-walks the
-plugin tree, and `plugin/addons/godot_ai/utils/uv_cache_cleanup.gd`
-carries a verbatim Korean Windows error message string. Other tests
-in `tests/unit/` walk plugin `.gd` files via `glob`/`rglob` or read
-specific files that could pick up non-ASCII the next time someone
-adds a foreign-language comment elsewhere.
-
-This test enforces the hygiene rule across `tests/`: every bare
-`.read_text()` call (no kwargs) is an offender. CI is Linux-only
-(issue #35) so this is the only line of defense before a Windows
-developer hits the same trap.
+Without it, Python falls back to `locale.getpreferredencoding()` —
+cp1252 on Windows, which raises `UnicodeDecodeError` on any non-ASCII
+byte. CI is Linux-only (#35) so the trap is silent until a developer
+runs pytest on Windows; #397 is the surfacing recurrence.
 """
 
 from __future__ import annotations
 
 import ast
+import textwrap
 from pathlib import Path
 
-TESTS_ROOT = Path(__file__).resolve().parent.parent
-REPO_ROOT = TESTS_ROOT.parent
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TESTS_ROOT = REPO_ROOT / "tests"
+
+
+def _bare_read_text_offenders(source: str) -> list[int]:
+    """Line numbers of `.read_text()` calls in `source` that lack `encoding=`."""
+
+    tree = ast.parse(source)
+    offenders: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute) or func.attr != "read_text":
+            continue
+        if any(kw.arg == "encoding" for kw in node.keywords):
+            continue
+        offenders.append(node.lineno)
+    return offenders
 
 
 def test_test_files_pass_encoding_to_read_text() -> None:
     offenders: list[str] = []
-
     for py_file in TESTS_ROOT.rglob("*.py"):
-        tree = ast.parse(py_file.read_text(encoding="utf-8"))
-
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
-                continue
-            func = node.func
-            if not isinstance(func, ast.Attribute) or func.attr != "read_text":
-                continue
-            if any(kw.arg == "encoding" for kw in node.keywords):
-                continue
-            rel = py_file.relative_to(REPO_ROOT)
-            offenders.append(f"{rel}:{node.lineno}")
+        source = py_file.read_text(encoding="utf-8")
+        if "read_text" not in source:
+            continue
+        rel = py_file.relative_to(REPO_ROOT)
+        offenders.extend(f"{rel}:{lineno}" for lineno in _bare_read_text_offenders(source))
 
     assert not offenders, (
-        "Path.read_text() calls in tests/ must pass encoding='utf-8'. "
-        "Without it, Python falls back to locale.getpreferredencoding(), "
-        "which is cp1252 on Windows and raises UnicodeDecodeError on any "
-        "non-ASCII byte in the file (issue #397). Add encoding='utf-8'. "
-        f"Bare calls: {offenders}"
+        f"Pass encoding='utf-8' to Path.read_text() (issue #397). Bare calls: {offenders}"
     )
+
+
+# Detector self-tests — without these, a future refactor can silently turn the
+# lint into a no-op. Mirrors the pattern in `test_no_direct_undo_redo_in_gdscript_tests.py`
+# and `test_gdscript_no_adjacent_string_concat.py`.
+
+
+def test_detector_flags_bare_read_text() -> None:
+    assert _bare_read_text_offenders("Path('x').read_text()") == [1]
+
+
+def test_detector_ignores_read_text_with_encoding() -> None:
+    assert _bare_read_text_offenders('Path("x").read_text(encoding="utf-8")') == []
+
+
+def test_detector_ignores_unrelated_read_text_attr() -> None:
+    # `mcp__github__read_text(...)` and similar non-attribute calls are not
+    # what the lint targets; they're flagged only if invoked as `obj.read_text(...)`.
+    assert _bare_read_text_offenders("filesystem_read_text(path)") == []
+
+
+def test_detector_finds_multiple_in_one_file() -> None:
+    src = textwrap.dedent(
+        """
+        a = p.read_text()
+        b = q.read_text(encoding="utf-8")
+        c = r.read_text()
+        """
+    )
+    assert _bare_read_text_offenders(src) == [2, 4]

--- a/tests/unit/test_read_text_encoding.py
+++ b/tests/unit/test_read_text_encoding.py
@@ -17,7 +17,12 @@ TESTS_ROOT = REPO_ROOT / "tests"
 
 
 def _bare_read_text_offenders(source: str) -> list[int]:
-    """Line numbers of `.read_text()` calls in `source` that lack `encoding=`."""
+    """Line numbers of `.read_text()` calls in `source` that lack `encoding=`.
+
+    Matches the keyword form only. A positional `read_text("utf-8")` or
+    `**kwargs` splat is opaque to AST and would be falsely flagged; in this
+    codebase the convention is the keyword form, which keeps the lint exact.
+    """
 
     tree = ast.parse(source)
     offenders: list[int] = []

--- a/tests/unit/test_resource_save_pause_processing.py
+++ b/tests/unit/test_resource_save_pause_processing.py
@@ -28,7 +28,7 @@ PLUGIN_ROOT = Path(__file__).resolve().parents[2] / "plugin" / "addons" / "godot
 
 
 def test_save_to_disk_takes_pause_target() -> None:
-    source = (PLUGIN_ROOT / "utils" / "resource_io.gd").read_text()
+    source = (PLUGIN_ROOT / "utils" / "resource_io.gd").read_text(encoding="utf-8")
     block = get_func_block(source, "static func save_to_disk(")
     assert "pause_target: McpConnection" in block, (
         "save_to_disk must accept a McpConnection so the WebSocket pump "
@@ -59,7 +59,7 @@ def test_save_to_disk_takes_pause_target() -> None:
 
 
 def test_resource_handler_threads_connection_to_save() -> None:
-    source = (PLUGIN_ROOT / "handlers" / "resource_handler.gd").read_text()
+    source = (PLUGIN_ROOT / "handlers" / "resource_handler.gd").read_text(encoding="utf-8")
     assert "var _connection: McpConnection" in source, (
         "ResourceHandler must hold a McpConnection ref to thread into save_to_disk. See #288."
     )
@@ -76,7 +76,7 @@ def test_resource_handler_threads_connection_to_save() -> None:
 
 
 def test_curve_handler_threads_connection_to_save() -> None:
-    source = (PLUGIN_ROOT / "handlers" / "curve_handler.gd").read_text()
+    source = (PLUGIN_ROOT / "handlers" / "curve_handler.gd").read_text(encoding="utf-8")
     assert "var _connection: McpConnection" in source
     assert "_init(undo_redo: EditorUndoRedoManager, connection: McpConnection" in source
     set_points_block = get_func_block(source, "func set_points")
@@ -91,7 +91,7 @@ def test_curve_handler_threads_connection_to_save() -> None:
 
 
 def test_environment_handler_threads_connection_to_save() -> None:
-    source = (PLUGIN_ROOT / "handlers" / "environment_handler.gd").read_text()
+    source = (PLUGIN_ROOT / "handlers" / "environment_handler.gd").read_text(encoding="utf-8")
     assert "var _connection: McpConnection" in source
     assert "_init(undo_redo: EditorUndoRedoManager, connection: McpConnection" in source
     save_block = get_func_block(source, "func _save_environment")
@@ -101,7 +101,7 @@ def test_environment_handler_threads_connection_to_save() -> None:
 
 
 def test_texture_handler_threads_connection_to_save() -> None:
-    source = (PLUGIN_ROOT / "handlers" / "texture_handler.gd").read_text()
+    source = (PLUGIN_ROOT / "handlers" / "texture_handler.gd").read_text(encoding="utf-8")
     assert "var _connection: McpConnection" in source
     assert "_init(undo_redo: EditorUndoRedoManager, connection: McpConnection" in source
     # The save call lives inside _save_or_assign_texture in this handler;
@@ -114,7 +114,7 @@ def test_texture_handler_threads_connection_to_save() -> None:
 
 
 def test_plugin_passes_connection_to_resource_handlers() -> None:
-    source = (PLUGIN_ROOT / "plugin.gd").read_text()
+    source = (PLUGIN_ROOT / "plugin.gd").read_text(encoding="utf-8")
     # All four resource-saving handlers must be constructed with _connection,
     # otherwise the pause guard inside save_to_disk silently no-ops.
     for handler in ("ResourceHandler", "EnvironmentHandler", "TextureHandler", "CurveHandler"):
@@ -131,6 +131,6 @@ def test_scene_handler_pause_pattern_still_present_for_reference() -> None:
     If this test ever fails, the resource-save fix is now an orphan
     pattern and the issue #288 fix should be re-evaluated.
     """
-    source = (PLUGIN_ROOT / "handlers" / "scene_handler.gd").read_text()
+    source = (PLUGIN_ROOT / "handlers" / "scene_handler.gd").read_text(encoding="utf-8")
     assert "_connection.pause_processing = true" in source
     assert "_connection.pause_processing = false" in source

--- a/tests/unit/test_script_create_import_settle.py
+++ b/tests/unit/test_script_create_import_settle.py
@@ -26,7 +26,7 @@ PLUGIN_GD = PLUGIN_ROOT / "plugin.gd"
 
 def test_script_handler_holds_connection_for_deferred_replies() -> None:
     """ScriptHandler needs an McpConnection ref to push the deferred response."""
-    source = SCRIPT_HANDLER.read_text()
+    source = SCRIPT_HANDLER.read_text(encoding="utf-8")
 
     assert "var _connection: McpConnection" in source, (
         "ScriptHandler must hold an McpConnection so create_script can defer "
@@ -45,7 +45,7 @@ def test_script_handler_holds_connection_for_deferred_replies() -> None:
 
 def test_create_script_defers_for_freshly_created_files() -> None:
     """The new-file path returns DEFERRED_RESPONSE; existing-file path replies sync."""
-    source = SCRIPT_HANDLER.read_text()
+    source = SCRIPT_HANDLER.read_text(encoding="utf-8")
 
     # The deferred handoff must be guarded by `not existed_before` so that
     # overwriting an already-known resource still returns immediately —
@@ -63,7 +63,7 @@ def test_create_script_defers_for_freshly_created_files() -> None:
 
 def test_finish_create_script_deferred_polls_resourceloader_with_bounded_loop() -> None:
     """The settle loop must be bounded and check ResourceLoader.exists each frame."""
-    source = SCRIPT_HANDLER.read_text()
+    source = SCRIPT_HANDLER.read_text(encoding="utf-8")
 
     # The bounded counter prevents an indefinite hang if the editor's
     # filesystem pipeline never reports the new resource.
@@ -89,10 +89,9 @@ def test_finish_create_script_deferred_polls_resourceloader_with_bounded_loop() 
         "The deferred loop must yield via process_frame between polls so the "
         "editor can actually run the import pipeline between checks."
     )
-    assert (
-        deferred_block.find("var deadline_ms := Time.get_ticks_msec() + _IMPORT_SETTLE_MAX_MSEC")
-        < deferred_block.find("await tree.process_frame")
-    ), (
+    assert deferred_block.find(
+        "var deadline_ms := Time.get_ticks_msec() + _IMPORT_SETTLE_MAX_MSEC"
+    ) < deferred_block.find("await tree.process_frame"), (
         "The deferred coroutine must start its deadline before the registration "
         "handoff await. Otherwise a slow first frame is outside the bounded "
         "window and a committed write can still hit the dispatcher timeout (#324)."
@@ -114,7 +113,7 @@ def test_finish_create_script_deferred_polls_resourceloader_with_bounded_loop() 
 
 def test_create_script_reports_committed_status_even_when_import_wait_times_out() -> None:
     """A committed file must not be indistinguishable from a failed mutation."""
-    source = SCRIPT_HANDLER.read_text()
+    source = SCRIPT_HANDLER.read_text(encoding="utf-8")
 
     assert '"committed": true' in source, (
         "create_script writes the file before waiting for ResourceLoader; the "
@@ -135,7 +134,7 @@ def test_create_script_reports_committed_status_even_when_import_wait_times_out(
 
 def test_plugin_gd_passes_connection_to_script_handler() -> None:
     """plugin.gd must wire _connection into ScriptHandler — the field is null otherwise."""
-    source = PLUGIN_GD.read_text()
+    source = PLUGIN_GD.read_text(encoding="utf-8")
 
     assert "ScriptHandler.new(get_undo_redo(), _connection)" in source, (
         "plugin.gd must construct ScriptHandler with the connection so the "

--- a/tests/unit/test_self_update_orphan_recovery.py
+++ b/tests/unit/test_self_update_orphan_recovery.py
@@ -19,7 +19,7 @@ def test_recover_incompatible_success_unblocks_existing_connection() -> None:
     `McpConnection` instance.
     """
 
-    source = PLUGIN_GD.read_text()
+    source = PLUGIN_GD.read_text(encoding="utf-8")
     recover_block = get_func_block(source, "func recover_incompatible_server() -> bool:")
     resume_block = get_func_block(source, "func _resume_connection_after_recovery() -> void:")
     lifecycle_source = (
@@ -29,7 +29,7 @@ def test_recover_incompatible_success_unblocks_existing_connection() -> None:
         / "godot_ai"
         / "utils"
         / "server_lifecycle.gd"
-    ).read_text()
+    ).read_text(encoding="utf-8")
     lifecycle_recover_block = get_func_block(
         lifecycle_source, "func recover_incompatible_server() -> bool:"
     )
@@ -54,7 +54,7 @@ def test_recover_incompatible_success_unblocks_existing_connection() -> None:
 
 
 def test_status_probe_reads_response_body_only_after_headers() -> None:
-    source = PLUGIN_GD.read_text()
+    source = PLUGIN_GD.read_text(encoding="utf-8")
     probe_block = get_func_block(
         source,
         "static func _probe_live_server_status(port: int, timeout_ms: int = "

--- a/tests/unit/test_self_update_smoke_harness.py
+++ b/tests/unit/test_self_update_smoke_harness.py
@@ -46,18 +46,15 @@ def test_self_update_smoke_harness_prepares_fixture(tmp_path: Path) -> None:
     assert "click Update" in result.stdout
     assert "a new Godot*.ips" in result.stdout
 
-    base_cfg = (project / "addons" / "godot_ai" / "plugin.cfg").read_text()
+    base_cfg = (project / "addons" / "godot_ai" / "plugin.cfg").read_text(encoding="utf-8")
     assert 'version="2.2.0"' in base_cfg
 
     # The smoke patches land on the manager file; the dock keeps only
     # the visible banner UI.
-    base_manager = (
-        project / "addons" / "godot_ai" / "utils" / "update_manager.gd"
-    ).read_text()
-    assert (
-        'const SELF_UPDATE_SMOKE_DOWNLOAD_URL := "smoke://local-prestaged"'
-        in base_manager
+    base_manager = (project / "addons" / "godot_ai" / "utils" / "update_manager.gd").read_text(
+        encoding="utf-8"
     )
+    assert 'const SELF_UPDATE_SMOKE_DOWNLOAD_URL := "smoke://local-prestaged"' in base_manager
     assert (
         'const SELF_UPDATE_SMOKE_ZIP := "res://self_update_smoke/godot-ai-plugin-vnext.zip"'
         in base_manager
@@ -65,7 +62,9 @@ def test_self_update_smoke_harness_prepares_fixture(tmp_path: Path) -> None:
     assert "FileAccess.get_file_as_bytes(src)" in base_manager
     assert "user-update-path.txt" in base_manager
 
-    base_configurator = (project / "addons" / "godot_ai" / "client_configurator.gd").read_text()
+    base_configurator = (project / "addons" / "godot_ai" / "client_configurator.gd").read_text(
+        encoding="utf-8"
+    )
     assert "const DEFAULT_HTTP_PORT := 18000" in base_configurator
     assert "const DEFAULT_WS_PORT := 19500" in base_configurator
     assert 'const SELF_UPDATE_SMOKE_SERVER_VERSION := "2.2.0"' in base_configurator
@@ -75,12 +74,12 @@ def test_self_update_smoke_harness_prepares_fixture(tmp_path: Path) -> None:
     assert "static func ensure_settings_registered() -> void:" in base_configurator
     assert "static func _register_port_setting(" in base_configurator
 
-    base_plugin = (project / "addons" / "godot_ai" / "plugin.gd").read_text()
+    base_plugin = (project / "addons" / "godot_ai" / "plugin.gd").read_text(encoding="utf-8")
     assert "godot_ai_self_update_smoke/managed_server_pid" in base_plugin
 
-    base_lifecycle = (
-        project / "addons" / "godot_ai" / "utils" / "server_lifecycle.gd"
-    ).read_text()
+    base_lifecycle = (project / "addons" / "godot_ai" / "utils" / "server_lifecycle.gd").read_text(
+        encoding="utf-8"
+    )
     assert 'const SELF_UPDATE_SMOKE_EXPECTED_SERVER_VERSION := "2.2.0"' in base_lifecycle
     assert "func _expected_server_version() -> String:" in base_lifecycle
     assert "return SELF_UPDATE_SMOKE_EXPECTED_SERVER_VERSION" in base_lifecycle

--- a/tests/unit/test_tool_domains.py
+++ b/tests/unit/test_tool_domains.py
@@ -50,14 +50,14 @@ def test_runtime_protocol_is_not_reintroduced_without_injection_seam():
     for path in _SRC_ROOT.rglob("*.py"):
         if "__pycache__" in path.parts:
             continue
-        text = path.read_text()
+        text = path.read_text(encoding="utf-8")
         if "godot_ai.runtime.interface" in text or "class Runtime(Protocol)" in text:
             offenders.append(str(path.relative_to(_REPO_ROOT)))
     assert offenders == [], f"Runtime Protocol references reintroduced in: {offenders}"
 
     stale_docs = []
     for path in _RUNTIME_BOUNDARY_DOCS:
-        text = path.read_text()
+        text = path.read_text(encoding="utf-8")
         if "runtime/interface.py" in text or "`Runtime` protocol" in text:
             stale_docs.append(str(path.relative_to(_REPO_ROOT)))
     assert stale_docs == [], f"Stale Runtime Protocol references in docs: {stale_docs}"
@@ -149,7 +149,7 @@ def test_create_server_ignores_unknown_domain_names_via_set_input():
 
 def _parse_gd_catalog() -> tuple[list[str], dict[str, list[str]]]:
     """Parse tool_catalog.gd into (core_tools, {domain_id: [tool_names]})."""
-    text = _CATALOG_GD.read_text()
+    text = _CATALOG_GD.read_text(encoding="utf-8")
 
     core_match = re.search(r"const CORE_TOOLS := \[(.*?)\]", text, re.DOTALL)
     assert core_match, "CORE_TOOLS block not found in tool_catalog.gd"


### PR DESCRIPTION
## Summary

`Path.read_text()` with no arguments uses `locale.getpreferredencoding()` — cp1252 on Windows. `test_plugin_self_update_safety.py` `rglob`-walks the plugin tree and chokes on the verbatim Korean string in `plugin/addons/godot_ai/utils/uv_cache_cleanup.gd`, failing 4 tests on Windows. CI is Linux-only (#35) so the hazard was silent until a developer ran pytest on a Windows box.

This patch passes `encoding="utf-8"` to all 87 bare `.read_text()` calls across `tests/unit/`, and adds a new `tests/unit/test_read_text_encoding.py` AST lint that fails on any future bare call so the regression can't reappear.

Closes #397

## Test plan

- [x] `ruff check src/ tests/` + `ruff format --check src/ tests/` — clean
- [x] `pytest -q` — 894 passed (was 893; +1 from the new lint)
- [x] Verified the new lint fails when bare `read_text()` is reintroduced (stashed the fix on `test_plugin_self_update_safety.py`, ran the new test, got the expected offender list).
- [x] Confirmed the underlying hazard: `Path('plugin/addons/godot_ai/utils/uv_cache_cleanup.gd').read_text(encoding='cp1252')` raises `UnicodeDecodeError` on the Korean line, while `encoding='utf-8'` reads cleanly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01S3eBeuX3NpL3jSazcBUz38)_