### PR TITLE
Rename Kimi Code CLI display name to Kimi Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ covers:
 
 Codex, Cursor, Windsurf, VS Code, VS Code Insiders, Zed, Gemini CLI, Cline,
 Kilo Code, Roo Code, Kiro, Trae, Cherry Studio, OpenCode, Qwen Code,
-Kimi Code CLI.
+Kimi Code.
 
 </details>
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -83,7 +83,7 @@ Adjacent reference docs:
 
 See [Packaging & Distribution](packaging-distribution.md) for full detail. The short version:
 
-- [x] clean install docs for Claude Code, Claude Desktop, Codex, and Antigravity (README + dock auto-configure with manual fallback for 19 clients including Cursor, Cline, Roo Code, Kilo, OpenCode, Zed, Windsurf, VS Code/Insiders, Trae, Kiro, Gemini CLI, Cherry Studio, Qwen Code, Kimi Code CLI)
+- [x] clean install docs for Claude Code, Claude Desktop, Codex, and Antigravity (README + dock auto-configure with manual fallback for 19 clients including Cursor, Cline, Roo Code, Kilo, OpenCode, Zed, Windsurf, VS Code/Insiders, Trae, Kiro, Gemini CLI, Cherry Studio, Qwen Code, Kimi Code)
 - [x] PyPI / `uvx` path works reliably — automated via `bump-and-release.yml`; live on PyPI as `godot-ai`; `uvx --from godot-ai~=VERSION godot-ai` is the canonical user-install command. Stdio-only clients (Claude Desktop, Zed) bridge through `uvx mcp-proxy`. Stale-index retries (`--refresh`) and cache priming on self-update prevent flaky first-run failures.
 - [ ] desktop binary path is real, not aspirational
 - [x] plugin is downloadable from the Godot AssetLib — live as [asset/5050](https://godotengine.org/asset-library/asset/5050) and on the new [Godot Asset Store](https://store.godotengine.org/asset/dlight/godot-ai/); release ZIP workflow ships `godot-ai-plugin.zip` via GitHub Releases; dock self-update banner offers one-click upgrades that survive without an editor restart (`update_reload_runner.gd` handoff). Local self-update smoke (`script/local-self-update-smoke`) is the regression gate.

--- a/plugin/addons/godot_ai/clients/_cli_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_cli_strategy.gd
@@ -20,7 +20,7 @@ const _STATUS_TIMEOUT_MS := 6000
 static func configure(client: McpClient, server_name: String, server_url: String) -> Dictionary:
 	var cli := _resolve_cli(client)
 	if cli.is_empty():
-		return {"status": "error", "message": "%s CLI not found" % client.display_name}
+		return {"status": "error", "message": "%s not found" % client.display_name}
 
 	# Best-effort prior cleanup so re-configure is idempotent. Bounded to
 	# the same budget — a hung unregister shouldn't block the configure
@@ -41,7 +41,7 @@ static func configure(client: McpClient, server_name: String, server_url: String
 			],
 		}
 	if result.get("spawn_failed", false):
-		return {"status": "error", "message": "Failed to spawn %s CLI" % client.display_name}
+		return {"status": "error", "message": "Failed to spawn %s" % client.display_name}
 	if int(result.get("exit_code", -1)) == 0:
 		return {"status": "ok", "message": "%s configured (HTTP: %s)" % [client.display_name, server_url]}
 	## `claude mcp add` writes its real failure diagnostics to stderr, so
@@ -103,7 +103,7 @@ static func _status_details(status: McpClient.Status, error_msg: String = "") ->
 static func remove(client: McpClient, server_name: String) -> Dictionary:
 	var cli := _resolve_cli(client)
 	if cli.is_empty():
-		return {"status": "error", "message": "%s CLI not found" % client.display_name}
+		return {"status": "error", "message": "%s not found" % client.display_name}
 	if client.cli_unregister_template.is_empty():
 		return {"status": "error", "message": "%s descriptor missing cli_unregister_template" % client.display_name}
 	var args := _format_args(client.cli_unregister_template, server_name, "")
@@ -116,7 +116,7 @@ static func remove(client: McpClient, server_name: String) -> Dictionary:
 			],
 		}
 	if result.get("spawn_failed", false):
-		return {"status": "error", "message": "Failed to spawn %s CLI" % client.display_name}
+		return {"status": "error", "message": "Failed to spawn %s" % client.display_name}
 	if int(result.get("exit_code", -1)) == 0:
 		return {"status": "ok", "message": "%s configuration removed" % client.display_name}
 	## `claude mcp add` writes its real failure diagnostics to stderr, so

--- a/plugin/addons/godot_ai/clients/kimi_code.gd
+++ b/plugin/addons/godot_ai/clients/kimi_code.gd
@@ -4,7 +4,7 @@ extends McpClient
 
 func _init() -> void:
 	id = "kimi_code"
-	display_name = "Kimi Code CLI"
+	display_name = "Kimi Code"
 	config_type = "cli"
 	doc_url = "https://moonshotai.github.io/kimi-cli/"
 	cli_names = PackedStringArray(["kimi", "kimi.exe"] if OS.get_name() == "Windows" else ["kimi"])

--- a/plugin/addons/godot_ai/clients/kimi_code.gd.uid
+++ b/plugin/addons/godot_ai/clients/kimi_code.gd.uid
@@ -1,0 +1,1 @@
+uid://d2whd6a5fofhg


### PR DESCRIPTION
## Summary
- Drop the redundant "CLI" suffix from the Kimi client's `display_name`
- Fix the dock status that rendered "Kimi Code CLI CLI not found" when the `kimi` binary wasn't on PATH (the cli strategy appends " CLI not found" using the display name)
- Match the convention of every other CLI client in the registry (Claude Code, Codex, Qwen Code, etc.)

Follow-up to #396.

## Test plan
- [x] Visually confirmed in dock: status now reads "Kimi Code — Kimi Code not found" instead of "Kimi Code CLI CLI not found"
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)