### PR TITLE
Fix #398: alias shared classes via non-Mcp* preload consts on parse-hazard load surface

### DIFF
--- a/plugin/addons/godot_ai/dock_panels/log_viewer.gd
+++ b/plugin/addons/godot_ai/dock_panels/log_viewer.gd
@@ -11,15 +11,11 @@ extends VBoxContainer
 
 signal logging_enabled_changed(enabled: bool)
 
-## `Dock` const name intentionally does NOT match `mcp_dock.gd`'s global
-## `class_name` (`McpDock`). See `_node_validator.gd` for the full
-## self-update parse-hazard rationale (#398).
 const Dock := preload("res://addons/godot_ai/mcp_dock.gd")
 
-## `_log_buffer` is intentionally untyped: a `: McpLogBuffer` field
-## annotation resolves through the class_name registry at script-load,
-## tripping the same parse hazard. The type fence stays on the
-## `setup(log_buffer: McpLogBuffer)` parameter, resolved at call time.
+## Untyped: a `: McpLogBuffer` annotation hits the class_name registry at
+## script-load and trips the self-update parse hazard (#398). The type fence
+## stays on the `setup(log_buffer: McpLogBuffer)` parameter.
 var _log_buffer
 var _log_display: RichTextLabel
 var _log_toggle: CheckButton

--- a/plugin/addons/godot_ai/dock_panels/log_viewer.gd
+++ b/plugin/addons/godot_ai/dock_panels/log_viewer.gd
@@ -11,7 +11,18 @@ extends VBoxContainer
 
 signal logging_enabled_changed(enabled: bool)
 
-var _log_buffer: McpLogBuffer
+## Self-update parse-hazard policy: this script is on the plugin's load
+## surface (preloaded as a const from `mcp_dock.gd`). Field declarations
+## must NOT type-bind to plugin `class_name` types like `McpLogBuffer` —
+## the parser resolves those through the global class_name registry at
+## script-load time, which during the disable→extract→enable window holds
+## the cached pre-update class object. The type fence stays on the
+## `setup(log_buffer: McpLogBuffer)` parameter, which is resolved at call
+## time. The `Dock` const aliases `mcp_dock.gd` under a non-`Mcp*` name
+## for the same reason — see `_node_validator.gd` and #398.
+const Dock := preload("res://addons/godot_ai/mcp_dock.gd")
+
+var _log_buffer
 var _log_display: RichTextLabel
 var _log_toggle: CheckButton
 ## Last `McpLogBuffer.total_logged()` value painted into the display. Tracking
@@ -39,7 +50,7 @@ func _build_ui() -> void:
 	add_child(HSeparator.new())
 
 	var log_header_row := HBoxContainer.new()
-	var log_header := McpDock._make_header("MCP Log")
+	var log_header := Dock._make_header("MCP Log")
 	log_header.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	log_header_row.add_child(log_header)
 

--- a/plugin/addons/godot_ai/dock_panels/log_viewer.gd
+++ b/plugin/addons/godot_ai/dock_panels/log_viewer.gd
@@ -11,17 +11,15 @@ extends VBoxContainer
 
 signal logging_enabled_changed(enabled: bool)
 
-## Self-update parse-hazard policy: this script is on the plugin's load
-## surface (preloaded as a const from `mcp_dock.gd`). Field declarations
-## must NOT type-bind to plugin `class_name` types like `McpLogBuffer` —
-## the parser resolves those through the global class_name registry at
-## script-load time, which during the disable→extract→enable window holds
-## the cached pre-update class object. The type fence stays on the
-## `setup(log_buffer: McpLogBuffer)` parameter, which is resolved at call
-## time. The `Dock` const aliases `mcp_dock.gd` under a non-`Mcp*` name
-## for the same reason — see `_node_validator.gd` and #398.
+## `Dock` const name intentionally does NOT match `mcp_dock.gd`'s global
+## `class_name` (`McpDock`). See `_node_validator.gd` for the full
+## self-update parse-hazard rationale (#398).
 const Dock := preload("res://addons/godot_ai/mcp_dock.gd")
 
+## `_log_buffer` is intentionally untyped: a `: McpLogBuffer` field
+## annotation resolves through the class_name registry at script-load,
+## tripping the same parse hazard. The type fence stays on the
+## `setup(log_buffer: McpLogBuffer)` parameter, resolved at call time.
 var _log_buffer
 var _log_display: RichTextLabel
 var _log_toggle: CheckButton

--- a/plugin/addons/godot_ai/handlers/_node_validator.gd
+++ b/plugin/addons/godot_ai/handlers/_node_validator.gd
@@ -9,8 +9,18 @@ extends RefCounted
 ## audit-v2 #20 (issue #364). Uses the audit-v2 #21 (issue #365) error
 ## vocabulary.
 
-const McpScenePath = preload("res://addons/godot_ai/utils/scene_path.gd")
-const McpErrorCodes = preload("res://addons/godot_ai/utils/error_codes.gd")
+## Local const names intentionally do NOT match the global `class_name`
+## of the preloaded scripts. When a script-local `const X = preload(...)`
+## shadows a global `class_name X`, GDScript still resolves bare `X.MEMBER`
+## references through the class_name registry — which during the
+## self-update disable→extract→enable window holds the cached pre-update
+## script object. New members added to those classes (e.g. audit-v2 #21's
+## extra error codes) appear missing on the cached object, so the parser
+## raises `Cannot find member ...` and refuses to load this script. Aliasing
+## under a non-`Mcp*` name routes the lookup through the local const's
+## preload-by-path resolution and avoids the registry entirely. See #398.
+const ScenePath := preload("res://addons/godot_ai/utils/scene_path.gd")
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
 
 
 ## Resolve a scene-relative path to the live Node, or return a structured
@@ -37,28 +47,28 @@ static func resolve_or_error(
 	scene_file: String = "",
 ) -> Dictionary:
 	if node_path.is_empty():
-		return McpErrorCodes.make(
-			McpErrorCodes.MISSING_REQUIRED_PARAM,
+		return ErrorCodes.make(
+			ErrorCodes.MISSING_REQUIRED_PARAM,
 			"Missing required param: %s" % param_name,
 		)
-	var scene_check := McpScenePath.require_edited_scene(scene_file)
+	var scene_check := ScenePath.require_edited_scene(scene_file)
 	if scene_check.has("error"):
 		return scene_check
 	var scene_root: Node = scene_check.node
-	var node := McpScenePath.resolve(node_path, scene_root)
+	var node := ScenePath.resolve(node_path, scene_root)
 	if node == null:
-		return McpErrorCodes.make(
-			McpErrorCodes.NODE_NOT_FOUND,
-			McpScenePath.format_node_error(node_path, scene_root),
+		return ErrorCodes.make(
+			ErrorCodes.NODE_NOT_FOUND,
+			ScenePath.format_node_error(node_path, scene_root),
 		)
 	return {"node": node, "scene_root": scene_root, "path": node_path}
 
 
 ## When the caller needs the scene root but no specific node yet — e.g.
 ## handlers that walk children or filter by group. Returns either
-## `{"scene_root": Node}` or a `McpErrorCodes.make(...)` error dict.
+## `{"scene_root": Node}` or a `ErrorCodes.make(...)` error dict.
 static func require_scene_or_error(scene_file: String = "") -> Dictionary:
-	var scene_check := McpScenePath.require_edited_scene(scene_file)
+	var scene_check := ScenePath.require_edited_scene(scene_file)
 	if scene_check.has("error"):
 		return scene_check
 	return {"scene_root": scene_check.node}

--- a/plugin/addons/godot_ai/handlers/_node_validator.gd
+++ b/plugin/addons/godot_ai/handlers/_node_validator.gd
@@ -66,7 +66,7 @@ static func resolve_or_error(
 
 ## When the caller needs the scene root but no specific node yet — e.g.
 ## handlers that walk children or filter by group. Returns either
-## `{"scene_root": Node}` or a `ErrorCodes.make(...)` error dict.
+## `{"scene_root": Node}` or a `McpErrorCodes.make(...)` error dict.
 static func require_scene_or_error(scene_file: String = "") -> Dictionary:
 	var scene_check := ScenePath.require_edited_scene(scene_file)
 	if scene_check.has("error"):

--- a/plugin/addons/godot_ai/handlers/_node_validator.gd
+++ b/plugin/addons/godot_ai/handlers/_node_validator.gd
@@ -66,7 +66,7 @@ static func resolve_or_error(
 
 ## When the caller needs the scene root but no specific node yet — e.g.
 ## handlers that walk children or filter by group. Returns either
-## `{"scene_root": Node}` or a `McpErrorCodes.make(...)` error dict.
+## `{"scene_root": Node}` or an `ErrorCodes.make(...)` error dict.
 static func require_scene_or_error(scene_file: String = "") -> Dictionary:
 	var scene_check := ScenePath.require_edited_scene(scene_file)
 	if scene_check.has("error"):

--- a/plugin/addons/godot_ai/handlers/animation_presets.gd
+++ b/plugin/addons/godot_ai/handlers/animation_presets.gd
@@ -17,6 +17,11 @@ extends RefCounted
 
 
 const AnimationValues := preload("res://addons/godot_ai/handlers/animation_values.gd")
+## Local const names intentionally do NOT match the global `class_name` of the
+## preloaded scripts (`McpErrorCodes`, `McpScenePath`). See `_node_validator.gd`
+## for the full self-update parse-hazard rationale (#398).
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+const ScenePath := preload("res://addons/godot_ai/utils/scene_path.gd")
 
 
 var _handler_weak: WeakRef
@@ -43,18 +48,18 @@ func preset_fade(params: Dictionary) -> Dictionary:
 	var overwrite: bool = params.get("overwrite", false)
 
 	if player_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
 	if target_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: target_path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: target_path")
 	if mode != "in" and mode != "out":
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE,
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE,
 			"Invalid mode '%s'. Valid: 'in', 'out'" % mode)
 	if duration <= 0.0:
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "'duration' must be > 0")
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "'duration' must be > 0")
 
 	var handler = _h()
 	if handler == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "AnimationHandler not available")
+		return ErrorCodes.make(ErrorCodes.EDITOR_NOT_READY, "AnimationHandler not available")
 	var resolved: Dictionary = handler._resolve_player(player_path)
 	if resolved.has("error"):
 		return resolved
@@ -78,7 +83,7 @@ func preset_fade(params: Dictionary) -> Dictionary:
 			has_modulate = true
 			break
 	if not has_modulate:
-		return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE,
+		return ErrorCodes.make(ErrorCodes.WRONG_TYPE,
 			"Target '%s' (class %s) has no 'modulate' property — fade requires a CanvasItem, Control, Node2D, or Sprite3D"
 			% [target_path, target.get_class()])
 
@@ -88,7 +93,7 @@ func preset_fade(params: Dictionary) -> Dictionary:
 	var old_anim: Animation = null
 	if library.has_animation(anim_name):
 		if not overwrite:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+			return ErrorCodes.make(ErrorCodes.INVALID_PARAMS,
 				"Animation '%s' already exists. Pass overwrite=true or delete it first." % anim_name)
 		old_anim = library.get_animation(anim_name)
 
@@ -138,21 +143,21 @@ func preset_slide(params: Dictionary) -> Dictionary:
 	var overwrite: bool = params.get("overwrite", false)
 
 	if player_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
 	if target_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: target_path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: target_path")
 	if not ["left", "right", "up", "down"].has(direction):
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE,
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE,
 			"Invalid direction '%s'. Valid: 'left', 'right', 'up', 'down'" % direction)
 	if mode != "in" and mode != "out":
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE,
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE,
 			"Invalid mode '%s'. Valid: 'in', 'out'" % mode)
 	if duration <= 0.0:
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "'duration' must be > 0")
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "'duration' must be > 0")
 
 	var handler = _h()
 	if handler == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "AnimationHandler not available")
+		return ErrorCodes.make(ErrorCodes.EDITOR_NOT_READY, "AnimationHandler not available")
 	var resolved: Dictionary = handler._resolve_player(player_path)
 	if resolved.has("error"):
 		return resolved
@@ -174,7 +179,7 @@ func preset_slide(params: Dictionary) -> Dictionary:
 	var default_distance: float = 1.0 if kind == "3d" else 100.0
 	var distance: float = float(params.get("distance", default_distance))
 	if distance == 0.0:
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "'distance' must be non-zero")
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "'distance' must be non-zero")
 
 	var offset: Variant = _direction_offset(kind, direction, distance)
 	var current_pos: Variant = target.position
@@ -193,7 +198,7 @@ func preset_slide(params: Dictionary) -> Dictionary:
 	var old_anim: Animation = null
 	if library.has_animation(anim_name):
 		if not overwrite:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+			return ErrorCodes.make(ErrorCodes.INVALID_PARAMS,
 				"Animation '%s' already exists. Pass overwrite=true or delete it first." % anim_name)
 		old_anim = library.get_animation(anim_name)
 
@@ -242,17 +247,17 @@ func preset_shake(params: Dictionary) -> Dictionary:
 	var overwrite: bool = params.get("overwrite", false)
 
 	if player_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
 	if target_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: target_path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: target_path")
 	if duration <= 0.0:
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "'duration' must be > 0")
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "'duration' must be > 0")
 	if frequency <= 0.0:
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "'frequency' must be > 0")
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "'frequency' must be > 0")
 
 	var handler = _h()
 	if handler == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "AnimationHandler not available")
+		return ErrorCodes.make(ErrorCodes.EDITOR_NOT_READY, "AnimationHandler not available")
 	var resolved: Dictionary = handler._resolve_player(player_path)
 	if resolved.has("error"):
 		return resolved
@@ -273,7 +278,7 @@ func preset_shake(params: Dictionary) -> Dictionary:
 	var default_intensity: float = 0.1 if kind == "3d" else 10.0
 	var intensity: float = float(params.get("intensity", default_intensity))
 	if intensity <= 0.0:
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "'intensity' must be > 0")
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "'intensity' must be > 0")
 
 	if anim_name.is_empty():
 		anim_name = "shake"
@@ -281,7 +286,7 @@ func preset_shake(params: Dictionary) -> Dictionary:
 	var old_anim: Animation = null
 	if library.has_animation(anim_name):
 		if not overwrite:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+			return ErrorCodes.make(ErrorCodes.INVALID_PARAMS,
 				"Animation '%s' already exists. Pass overwrite=true or delete it first." % anim_name)
 		old_anim = library.get_animation(anim_name)
 
@@ -354,19 +359,19 @@ func preset_pulse(params: Dictionary) -> Dictionary:
 	var overwrite: bool = params.get("overwrite", false)
 
 	if player_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
 	if target_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: target_path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: target_path")
 	if duration <= 0.0:
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "'duration' must be > 0")
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "'duration' must be > 0")
 	if from_scale <= 0.0:
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "'from_scale' must be > 0")
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "'from_scale' must be > 0")
 	if to_scale <= 0.0:
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "'to_scale' must be > 0")
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "'to_scale' must be > 0")
 
 	var handler = _h()
 	if handler == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "AnimationHandler not available")
+		return ErrorCodes.make(ErrorCodes.EDITOR_NOT_READY, "AnimationHandler not available")
 	var resolved: Dictionary = handler._resolve_player(player_path)
 	if resolved.has("error"):
 		return resolved
@@ -389,7 +394,7 @@ func preset_pulse(params: Dictionary) -> Dictionary:
 	var old_anim: Animation = null
 	if library.has_animation(anim_name):
 		if not overwrite:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+			return ErrorCodes.make(ErrorCodes.INVALID_PARAMS,
 				"Animation '%s' already exists. Pass overwrite=true or delete it first." % anim_name)
 		old_anim = library.get_animation(anim_name)
 
@@ -440,7 +445,7 @@ func preset_pulse(params: Dictionary) -> Dictionary:
 ## Resolve a preset target node and classify its transform kind.
 ##
 ## Accepts two `target_path` shapes:
-##   * Scene-absolute (starts with "/") — resolved through `McpScenePath.resolve`,
+##   * Scene-absolute (starts with "/") — resolved through `ScenePath.resolve`,
 ##     matching the convention used by every other scene-mutating tool. Targets
 ##     outside the player's `root_node` subtree are converted to `..`-prefixed
 ##     paths via `root_node.get_path_to(target)`, mirroring what the relative
@@ -459,7 +464,7 @@ func preset_pulse(params: Dictionary) -> Dictionary:
 func _resolve_preset_target(player: AnimationPlayer, target_path: String) -> Dictionary:
 	var root_node := AnimationValues.player_root_node(player)
 	if root_node == null:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS,
 			"AnimationPlayer at %s has no resolvable root_node (is the scene open?)" % str(player.get_path()))
 
 	var target: Node = null
@@ -467,12 +472,12 @@ func _resolve_preset_target(player: AnimationPlayer, target_path: String) -> Dic
 	if target_path.begins_with("/"):
 		var scene_root := EditorInterface.get_edited_scene_root()
 		if scene_root == null:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+			return ErrorCodes.make(ErrorCodes.INVALID_PARAMS,
 				"Cannot resolve scene-absolute target_path '%s': no scene open" % target_path)
-		target = McpScenePath.resolve(target_path, scene_root)
+		target = ScenePath.resolve(target_path, scene_root)
 		if target == null:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
-				McpScenePath.format_node_error(target_path, scene_root))
+			return ErrorCodes.make(ErrorCodes.INVALID_PARAMS,
+				ScenePath.format_node_error(target_path, scene_root))
 		# Convert to a root_node-relative path. For targets outside the
 		# subtree this yields a `..`-prefixed path, matching what the
 		# relative form already accepts (root_node.get_node_or_null
@@ -486,9 +491,9 @@ func _resolve_preset_target(player: AnimationPlayer, target_path: String) -> Dic
 			# path; use the clean scene-relative form so the hint is
 			# actionable.
 			var scene_root := EditorInterface.get_edited_scene_root()
-			var root_hint := McpScenePath.from_node(root_node, scene_root) if scene_root != null else str(root_node.name)
+			var root_hint := ScenePath.from_node(root_node, scene_root) if scene_root != null else str(root_node.name)
 			var abs_example := "/%s/path/to/target" % scene_root.name if scene_root != null else "/SceneRoot/path/to/target"
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+			return ErrorCodes.make(ErrorCodes.INVALID_PARAMS,
 				("Target node not found at '%s' (resolved relative to AnimationPlayer's root_node '%s'). "
 				+ "Pass a path relative to root_node (e.g. \"path/to/target\") or a scene-absolute path (e.g. \"%s\").")
 				% [target_path, root_hint, abs_example])
@@ -501,7 +506,7 @@ func _resolve_preset_target(player: AnimationPlayer, target_path: String) -> Dic
 	elif target is Node3D:
 		kind = "3d"
 	else:
-		return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE,
+		return ErrorCodes.make(ErrorCodes.WRONG_TYPE,
 			"Target '%s' must be a Control, Node2D, or Node3D (got %s)" % [target_path, target.get_class()])
 	return {"node": target, "kind": kind, "track_path_root": track_path_root}
 

--- a/plugin/addons/godot_ai/handlers/animation_presets.gd
+++ b/plugin/addons/godot_ai/handlers/animation_presets.gd
@@ -17,9 +17,6 @@ extends RefCounted
 
 
 const AnimationValues := preload("res://addons/godot_ai/handlers/animation_values.gd")
-## Local const names intentionally do NOT match the global `class_name` of the
-## preloaded scripts (`McpErrorCodes`, `McpScenePath`). See `_node_validator.gd`
-## for the full self-update parse-hazard rationale (#398).
 const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
 const ScenePath := preload("res://addons/godot_ai/utils/scene_path.gd")
 

--- a/plugin/addons/godot_ai/handlers/animation_values.gd
+++ b/plugin/addons/godot_ai/handlers/animation_values.gd
@@ -17,6 +17,13 @@ extends RefCounted
 ## error — matches the dispatcher already being torn down at that point.
 
 
+## Local const names intentionally do NOT match the global `class_name` of the
+## preloaded scripts (`McpErrorCodes`, `McpPropertyErrors`). See
+## `_node_validator.gd` for the full self-update parse-hazard rationale (#398).
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+const PropertyErrors := preload("res://addons/godot_ai/handlers/_property_errors.gd")
+
+
 const _NAMED_TRANSITIONS := {
 	"linear": 1.0,
 	"ease_in": 2.0,
@@ -58,11 +65,11 @@ func list_animations(params: Dictionary) -> Dictionary:
 	var player_path: String = params.get("player_path", "")
 
 	if player_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
 
 	var handler = _h()
 	if handler == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "AnimationHandler not available")
+		return ErrorCodes.make(ErrorCodes.EDITOR_NOT_READY, "AnimationHandler not available")
 	var resolved: Dictionary = handler._resolve_player_read(player_path)
 	if resolved.has("error"):
 		return resolved
@@ -99,13 +106,13 @@ func get_animation(params: Dictionary) -> Dictionary:
 	var anim_name: String = params.get("animation_name", "")
 
 	if player_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
 	if anim_name.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: animation_name")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: animation_name")
 
 	var handler = _h()
 	if handler == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "AnimationHandler not available")
+		return ErrorCodes.make(ErrorCodes.EDITOR_NOT_READY, "AnimationHandler not available")
 	var resolved: Dictionary = handler._resolve_player_read(player_path)
 	if resolved.has("error"):
 		return resolved
@@ -158,20 +165,20 @@ func validate_animation(params: Dictionary) -> Dictionary:
 	var anim_name: String = params.get("animation_name", "")
 
 	if player_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
 	if anim_name.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: animation_name")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: animation_name")
 
 	var handler = _h()
 	if handler == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "AnimationHandler not available")
+		return ErrorCodes.make(ErrorCodes.EDITOR_NOT_READY, "AnimationHandler not available")
 	var resolved: Dictionary = handler._resolve_player_read(player_path)
 	if resolved.has("error"):
 		return resolved
 	var player: AnimationPlayer = resolved.player
 
 	if not player.has_animation(anim_name):
-		return McpErrorCodes.make(McpErrorCodes.PROPERTY_NOT_ON_CLASS,
+		return ErrorCodes.make(ErrorCodes.PROPERTY_NOT_ON_CLASS,
 			"Animation '%s' not found on player at %s" % [anim_name, player_path])
 
 	var anim: Animation = player.get_animation(anim_name)
@@ -321,7 +328,7 @@ static func resolve_track_prop_context(track_path: String, player: AnimationPlay
 	# the raw value here produces garbage keyframes at playback time.
 	return {"error":
 		"%s (target path: '%s')" %
-		[McpPropertyErrors.build_message(target, prop_base), node_part]}
+		[PropertyErrors.build_message(target, prop_base), node_part]}
 
 
 ## Map a `property:sub` subpath to its scalar component type. Returns

--- a/plugin/addons/godot_ai/handlers/animation_values.gd
+++ b/plugin/addons/godot_ai/handlers/animation_values.gd
@@ -17,9 +17,6 @@ extends RefCounted
 ## error — matches the dispatcher already being torn down at that point.
 
 
-## Local const names intentionally do NOT match the global `class_name` of the
-## preloaded scripts (`McpErrorCodes`, `McpPropertyErrors`). See
-## `_node_validator.gd` for the full self-update parse-hazard rationale (#398).
 const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
 const PropertyErrors := preload("res://addons/godot_ai/handlers/_property_errors.gd")
 

--- a/plugin/addons/godot_ai/utils/update_mixed_state.gd
+++ b/plugin/addons/godot_ai/utils/update_mixed_state.gd
@@ -11,13 +11,18 @@ extends RefCounted
 ## `editor_handler.gd::get_editor_state` includes the same Dictionary so an
 ## MCP agent can see and report the state.
 
-const UpdateReloadRunner := preload("res://addons/godot_ai/update_reload_runner.gd")
-
 const ADDON_DIR := "res://addons/godot_ai/"
 ## Single source of truth for the suffix lives on the producer
-## (`UpdateReloadRunner._install_zip_file`); aliasing here so the scanner
-## can never drift from what the runner actually writes.
-const BACKUP_SUFFIX := UpdateReloadRunner.INSTALL_BACKUP_SUFFIX
+## (`update_reload_runner.gd::INSTALL_BACKUP_SUFFIX`). Inlined as a literal
+## here rather than aliased via `UpdateReloadRunner.INSTALL_BACKUP_SUFFIX`
+## because module-level const initializers run at script-load time, and
+## during the self-update disable→extract→enable window the runner
+## script's cached parsed form may not yet expose new constants — the
+## aliased lookup raises `Cannot find member ...` and refuses to load
+## this whole script. The Python lint
+## `test_update_backup_suffix_stays_in_sync` asserts the two literals
+## match so the anti-drift guarantee holds. See #398.
+const BACKUP_SUFFIX := ".update_backup"
 ## Cap so a runaway addons tree (someone parented the wrong dir, an old
 ## crashed install left thousands of artifacts) can't blow the
 ## `editor_state` payload size or freeze the editor on first paint.

--- a/plugin/addons/godot_ai/utils/update_mixed_state.gd
+++ b/plugin/addons/godot_ai/utils/update_mixed_state.gd
@@ -12,16 +12,10 @@ extends RefCounted
 ## MCP agent can see and report the state.
 
 const ADDON_DIR := "res://addons/godot_ai/"
-## Single source of truth for the suffix lives on the producer
-## (`update_reload_runner.gd::INSTALL_BACKUP_SUFFIX`). Inlined as a literal
-## here rather than aliased via `UpdateReloadRunner.INSTALL_BACKUP_SUFFIX`
-## because module-level const initializers run at script-load time, and
-## during the self-update disable→extract→enable window the runner
-## script's cached parsed form may not yet expose new constants — the
-## aliased lookup raises `Cannot find member ...` and refuses to load
-## this whole script. The Python lint
-## `test_update_backup_suffix_stays_in_sync` asserts the two literals
-## match so the anti-drift guarantee holds. See #398.
+## Producer is `update_reload_runner.gd::INSTALL_BACKUP_SUFFIX`. Inlined as a
+## literal — not aliased — because module-level const initializers run at
+## script-load and the alias re-introduces the self-update parse hazard
+## (#398). `test_update_backup_suffix_stays_in_sync` guards against drift.
 const BACKUP_SUFFIX := ".update_backup"
 ## Cap so a runaway addons tree (someone parented the wrong dir, an old
 ## crashed install left thousands of artifacts) can't blow the

--- a/tests/unit/test_plugin_self_update_safety.py
+++ b/tests/unit/test_plugin_self_update_safety.py
@@ -245,15 +245,9 @@ def test_targeted_load_scripts_do_not_access_members_via_class_name() -> None:
 
 
 def test_update_backup_suffix_stays_in_sync() -> None:
-    """`update_mixed_state.gd::BACKUP_SUFFIX` must equal the producer's value.
+    """Build-time anti-drift guard for `update_mixed_state.gd::BACKUP_SUFFIX`.
 
-    `update_mixed_state.gd` previously aliased the suffix from
-    `update_reload_runner.gd::INSTALL_BACKUP_SUFFIX` via a module-level
-    const initializer. That site failed to load during a real self-update
-    when a parse-cache lag left the runner's new constants invisible
-    (issue #398). The fix inlines the literal in `update_mixed_state.gd`
-    so script-load doesn't depend on the runner's cached form. This test
-    replaces the runtime-aliasing anti-drift guard with a build-time one.
+    Replaces the runtime alias removed for #398 — see `update_mixed_state.gd`.
     """
 
     runner = (PLUGIN_ROOT / "update_reload_runner.gd").read_text(encoding="utf-8")

--- a/tests/unit/test_plugin_self_update_safety.py
+++ b/tests/unit/test_plugin_self_update_safety.py
@@ -58,15 +58,26 @@ PLUGIN_GD = PLUGIN_ROOT / "plugin.gd"
 # This is intentionally the targeted PR #309 adaptation surface plus the
 # PR 9 depth-1 infrastructure follow-up, not a broad cleanup of every
 # direct/transitive preload such as handlers or client strategy scripts.
+#
+# Issue #398 extended the list to the five files that emitted parse
+# errors during a real `v2.3.2 → v2.4.0` self-update — the audit-v2
+# regression that landed new `class_name` members behind bare-class_name
+# references. The structurally correct expansion (deny-by-default across
+# the whole load surface) is tracked in #399.
 TARGETED_LOAD_SURFACE_FILES = (
     PLUGIN_GD,
     PLUGIN_ROOT / "utils" / "server_lifecycle.gd",
     PLUGIN_ROOT / "utils" / "port_resolver.gd",
     PLUGIN_ROOT / "utils" / "update_manager.gd",
+    PLUGIN_ROOT / "utils" / "update_mixed_state.gd",
     PLUGIN_ROOT / "connection.gd",
     PLUGIN_ROOT / "dispatcher.gd",
     PLUGIN_ROOT / "mcp_dock.gd",
     PLUGIN_ROOT / "client_configurator.gd",
+    PLUGIN_ROOT / "dock_panels" / "log_viewer.gd",
+    PLUGIN_ROOT / "handlers" / "_node_validator.gd",
+    PLUGIN_ROOT / "handlers" / "animation_presets.gd",
+    PLUGIN_ROOT / "handlers" / "animation_values.gd",
 )
 
 
@@ -230,6 +241,52 @@ def test_targeted_load_scripts_do_not_access_members_via_class_name() -> None:
         'script-local `const Foo := preload("res://addons/godot_ai/...")` '
         "alias and call `Foo.X` instead. Offending references: "
         f"{sorted(set(offenders))}"
+    )
+
+
+def test_update_backup_suffix_stays_in_sync() -> None:
+    """`update_mixed_state.gd::BACKUP_SUFFIX` must equal the producer's value.
+
+    `update_mixed_state.gd` previously aliased the suffix from
+    `update_reload_runner.gd::INSTALL_BACKUP_SUFFIX` via a module-level
+    const initializer. That site failed to load during a real self-update
+    when a parse-cache lag left the runner's new constants invisible
+    (issue #398). The fix inlines the literal in `update_mixed_state.gd`
+    so script-load doesn't depend on the runner's cached form. This test
+    replaces the runtime-aliasing anti-drift guard with a build-time one.
+    """
+
+    runner = (PLUGIN_ROOT / "update_reload_runner.gd").read_text(encoding="utf-8")
+    scanner = (PLUGIN_ROOT / "utils" / "update_mixed_state.gd").read_text(encoding="utf-8")
+
+    runner_match = re.search(
+        r'^const\s+INSTALL_BACKUP_SUFFIX\s*:=\s*"([^"]+)"',
+        runner,
+        re.MULTILINE,
+    )
+    assert runner_match, (
+        'update_reload_runner.gd must declare `const INSTALL_BACKUP_SUFFIX := "..."` '
+        "as the authoritative producer of the backup-file suffix."
+    )
+
+    scanner_match = re.search(
+        r'^const\s+BACKUP_SUFFIX\s*:=\s*"([^"]+)"',
+        scanner,
+        re.MULTILINE,
+    )
+    assert scanner_match, (
+        'update_mixed_state.gd must declare `const BACKUP_SUFFIX := "..."` as a '
+        "string literal — aliasing via `UpdateReloadRunner.INSTALL_BACKUP_SUFFIX` "
+        "re-introduces the self-update parse hazard (issue #398)."
+    )
+
+    assert runner_match.group(1) == scanner_match.group(1), (
+        "update_mixed_state.gd::BACKUP_SUFFIX "
+        f"({scanner_match.group(1)!r}) drifted from the producer "
+        f"update_reload_runner.gd::INSTALL_BACKUP_SUFFIX "
+        f"({runner_match.group(1)!r}). Update both literals in lockstep — they "
+        "describe the same on-disk suffix, but the scanner's value is inlined "
+        "to avoid the parse hazard fixed in #398."
     )
 
 


### PR DESCRIPTION
## Summary

The `v2.3.2 → v2.4.0` self-update emitted ~30 transient `Parse Error` lines from five files that referenced new audit-v2 members (`McpErrorCodes.MISSING_REQUIRED_PARAM` and friends, `McpDock._make_header`, `UpdateReloadRunner.INSTALL_BACKUP_SUFFIX`) via bare class_name during the disable→extract→enable window. The new plugin loaded fine afterward, but the affected scripts were unloaded *during* the window — anything `_enter_tree` touched in them silently no-oped.

The fix ports the existing `connection.gd` / `dispatcher.gd` mitigation pattern into the five files: alias each shared class via a `const X := preload(...)` local const whose name does **not** shadow the global `class_name`, so GDScript routes the lookup through the local-const preload-by-path resolution rather than the registry (which during the parse window holds the cached pre-update class object).

`utils/update_mixed_state.gd:20` couldn't take that pattern — the const initializer ran at script-load and would still hit the cache when `update_reload_runner.gd`'s new constants weren't yet visible. Inlined the literal `.update_backup` instead and added a Python lint that asserts the literal stays in lockstep with the producer's `INSTALL_BACKUP_SUFFIX`.

Also extends `TARGETED_LOAD_SURFACE_FILES` to cover the five files so the existing typed-field / constructor / member-access lints prevent the same shape from recurring on this surface. The broader deny-by-default inversion across the whole load surface is tracked in #399.

Closes #398.

## Files changed

- `plugin/addons/godot_ai/handlers/_node_validator.gd` — rename local const aliases `McpScenePath`/`McpErrorCodes` → `ScenePath`/`ErrorCodes`; add a comment block explaining the parse-hazard rationale that other handlers cite.
- `plugin/addons/godot_ai/handlers/animation_presets.gd` — add `ErrorCodes` and `ScenePath` preload aliases; rename ~70 bare-class_name references.
- `plugin/addons/godot_ai/handlers/animation_values.gd` — add `ErrorCodes` and `PropertyErrors` preload aliases; rename ~20 bare-class_name references.
- `plugin/addons/godot_ai/dock_panels/log_viewer.gd` — add `Dock` preload alias for `mcp_dock.gd`; untype `_log_buffer` field (type fence stays on the `setup(log_buffer: McpLogBuffer)` parameter).
- `plugin/addons/godot_ai/utils/update_mixed_state.gd` — drop the `UpdateReloadRunner` preload alias; inline `BACKUP_SUFFIX := ".update_backup"` literal with anti-drift Python regression test.
- `tests/unit/test_plugin_self_update_safety.py` — extend `TARGETED_LOAD_SURFACE_FILES` to cover the five files; add `test_update_backup_suffix_stays_in_sync`.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `pytest -v` — 899 passed (includes the new `test_update_backup_suffix_stays_in_sync` and the extended targeted-load lints over the new files)
- [x] `script/ci-check-gdscript` — `All GDScript files OK`
- [ ] **Live editor smoke** — out of reach for this daemon run; CI's `Godot tests` (Linux/macOS/Windows) covers the GDScript handler tests, and `script/local-self-update-smoke` is the right next step for end-to-end verification of the install/extract path before a release. Recommended for maintainer before merging since `update_mixed_state.gd` sits on the install path.

## Out of scope (per #399)

- Inverting the lint to deny-by-default across the addon tree.
- Sweeping the other ~30 `handlers/*.gd` files that still reference shared classes by bare class_name. They aren't currently failing because v2.4.0 didn't add new members behind their references; #399 tracks the structurally correct fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A18upuweDXBQBg6juM9KWp)_