### PR TITLE
Fix #393: editor_reload_plugin returns pre-flight ack on plugin-managed servers

### DIFF
--- a/src/godot_ai/handlers/editor.py
+++ b/src/godot_ai/handlers/editor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 import logging
@@ -9,6 +10,7 @@ import logging
 from fastmcp.tools.base import Image as McpImage
 from mcp.types import TextContent
 
+from godot_ai import runtime_info
 from godot_ai.handlers._readiness import require_writable, sync_readiness_from_snapshot
 from godot_ai.runtime.direct import DirectRuntime
 from godot_ai.tools._pagination import paginate
@@ -17,6 +19,13 @@ logger = logging.getLogger(__name__)
 
 SCREENSHOT_TIMEOUT_SEC = 15.0
 GAME_SCREENSHOT_TIMEOUT_SEC = 35.0
+
+## Brief delay between handing the structured pre-flight ack back to
+## FastMCP and firing `reload_plugin` over the WebSocket on the
+## plugin-managed path. Gives the HTTP/SSE response a chance to flush
+## before the plugin tears down our own process. Tests override this
+## to 0 so they don't wait. See `editor_reload_plugin` below.
+PLUGIN_MANAGED_RELOAD_DELAY_SEC = 0.5
 
 
 async def editor_state(runtime: DirectRuntime) -> dict:
@@ -248,6 +257,27 @@ async def editor_reload_plugin(runtime: DirectRuntime) -> dict:
     if active is None:
         raise ConnectionError("No active Godot session")
     old_id = active.session_id
+
+    if runtime_info.is_plugin_managed():
+        ## Plugin-managed server: the reload will kill our own process
+        ## before any sync `wait_for_session` result can reach the
+        ## caller (issue #393). Hand the structured ack back to FastMCP
+        ## now so the HTTP response flushes, then dispatch the reload
+        ## command from a background task. `new_session_id` is dropped
+        ## from this shape because it lives in the *next* server's
+        ## registry, which this process can never see.
+        asyncio.create_task(_dispatch_reload_async(runtime, old_id))
+        return {
+            "status": "reload_initiated",
+            "transport_will_drop": True,
+            "old_session_id": old_id,
+            "guidance": (
+                "Server is plugin-managed; the WebSocket transport will drop "
+                "as part of the reload. Reconnect, then call "
+                "session_manage(op='list') to find the new session_id."
+            ),
+        }
+
     known_ids = {session.session_id for session in runtime.list_sessions()}
 
     try:
@@ -270,6 +300,17 @@ async def editor_reload_plugin(runtime: DirectRuntime) -> dict:
         "old_session_id": old_id,
         "new_session_id": new_session.session_id,
     }
+
+
+async def _dispatch_reload_async(runtime: DirectRuntime, old_id: str) -> None:
+    if PLUGIN_MANAGED_RELOAD_DELAY_SEC > 0:
+        await asyncio.sleep(PLUGIN_MANAGED_RELOAD_DELAY_SEC)
+    try:
+        await runtime.send_command("reload_plugin", session_id=old_id, timeout=2.0)
+    except (ConnectionError, TimeoutError) as exc:
+        logger.debug("Expected disconnect during plugin-managed reload: %s", exc)
+    except Exception:
+        logger.exception("Unexpected error dispatching plugin-managed reload")
 
 
 async def editor_quit(runtime: DirectRuntime) -> dict:

--- a/src/godot_ai/handlers/editor.py
+++ b/src/godot_ai/handlers/editor.py
@@ -27,6 +27,14 @@ GAME_SCREENSHOT_TIMEOUT_SEC = 35.0
 ## to 0 so they don't wait. See `editor_reload_plugin` below.
 PLUGIN_MANAGED_RELOAD_DELAY_SEC = 0.5
 
+## Strong references to in-flight `_dispatch_reload_async` tasks. The
+## event loop only holds weak references to tasks created via
+## `create_task`, so without this set a GC cycle landing during the
+## post-ack delay could collect the task and silently skip the WS
+## reload command — leaving the caller with a "reload_initiated" ack
+## but no actual reload. A done-callback removes the task on exit.
+_pending_reload_tasks: set[asyncio.Task] = set()
+
 
 async def editor_state(runtime: DirectRuntime) -> dict:
     """Read live editor state and self-heal the session readiness cache.
@@ -266,7 +274,9 @@ async def editor_reload_plugin(runtime: DirectRuntime) -> dict:
         ## command from a background task. `new_session_id` is dropped
         ## from this shape because it lives in the *next* server's
         ## registry, which this process can never see.
-        asyncio.create_task(_dispatch_reload_async(runtime, old_id))
+        task = asyncio.create_task(_dispatch_reload_async(runtime, old_id))
+        _pending_reload_tasks.add(task)
+        task.add_done_callback(_pending_reload_tasks.discard)
         return {
             "status": "reload_initiated",
             "transport_will_drop": True,

--- a/src/godot_ai/runtime_info.py
+++ b/src/godot_ai/runtime_info.py
@@ -27,6 +27,11 @@ def install_pid_file(path: str | os.PathLike[str] | None) -> Path | None:
     """
     global _PID_FILE_PATH
     if not path:
+        ## A subsequent install_pid_file(None) — e.g. a programmatic
+        ## caller dropping plugin-managed mode — must reset the flag,
+        ## otherwise `is_plugin_managed()` would stay True against the
+        ## docstring's "caller did not pass --pid-file" semantics.
+        _PID_FILE_PATH = None
         return None
 
     pid_path = Path(path).expanduser()

--- a/src/godot_ai/runtime_info.py
+++ b/src/godot_ai/runtime_info.py
@@ -14,6 +14,8 @@ import atexit
 import os
 from pathlib import Path
 
+_PID_FILE_PATH: Path | None = None
+
 
 def install_pid_file(path: str | os.PathLike[str] | None) -> Path | None:
     """Write `os.getpid()` to `path` and register an atexit unlink.
@@ -23,12 +25,14 @@ def install_pid_file(path: str | os.PathLike[str] | None) -> Path | None:
     to the caller — we'd rather surface a broken install than silently
     continue with the plugin unable to find our PID.
     """
+    global _PID_FILE_PATH
     if not path:
         return None
 
     pid_path = Path(path).expanduser()
     pid_path.parent.mkdir(parents=True, exist_ok=True)
     pid_path.write_text(f"{os.getpid()}\n", encoding="utf-8")
+    _PID_FILE_PATH = pid_path
 
     def _cleanup() -> None:
         ## Only unlink if the file still holds *our* PID. Prevents a
@@ -46,3 +50,15 @@ def install_pid_file(path: str | os.PathLike[str] | None) -> Path | None:
 
     atexit.register(_cleanup)
     return pid_path
+
+
+def is_plugin_managed() -> bool:
+    """True when this server was spawned by the Godot plugin.
+
+    The plugin always passes `--pid-file <path>` when it spawns the
+    Python server (see `plugin/addons/godot_ai/utils/server_lifecycle.gd`),
+    and an externally launched `python -m godot_ai` does not. So a
+    recorded pid-file path is a reliable signal that calling
+    `editor_reload_plugin` will kill our own process.
+    """
+    return _PID_FILE_PATH is not None

--- a/src/godot_ai/tools/editor.py
+++ b/src/godot_ai/tools/editor.py
@@ -162,14 +162,22 @@ def register_editor_tools(mcp: FastMCP, *, include_non_core: bool = True) -> Non
 
     @mcp.tool(meta=DEFER_META)
     async def editor_reload_plugin(ctx: Context, session_id: str = "") -> dict:
-        """Reload the Godot editor plugin and wait for reconnect.
+        """Reload the Godot editor plugin.
 
-        Disables and re-enables the plugin on the next frame. Waits for the
-        new session to connect before returning.
+        Disables and re-enables the plugin on the next frame. The response
+        shape depends on whether this MCP server was spawned by the plugin
+        or launched externally:
 
-        Requires the MCP server to be running externally (not started by the
-        plugin). Start with: ``python -m godot_ai --transport streamable-http
-        --port 8000 --reload``.
+        - **Plugin-managed (default install)**: returns a pre-flight ack
+          ``{status: "reload_initiated", transport_will_drop: true,
+          old_session_id, guidance}`` immediately. The reload kills this
+          server, so the WebSocket transport drops; reconnect and call
+          ``session_manage(op="list")`` to find the new session_id.
+
+        - **Externally launched** (e.g. ``python -m godot_ai --transport
+          streamable-http --port 8000 --reload``): waits for the new
+          session to register and returns
+          ``{status: "reloaded", old_session_id, new_session_id}``.
 
         Args:
             session_id: Optional Godot session to target. Empty = active session.

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -1068,6 +1068,38 @@ class TestReloadPluginTool:
         assert result.data["new_session_id"] == "reloaded-session"
         await new_ws.close()
 
+    async def test_plugin_managed_returns_preflight_ack(self, mcp_stack, monkeypatch, tmp_path):
+        """Issue #393: when the server is plugin-managed, the structured
+        ack must come back to the caller — and only AFTER it lands on the
+        wire does the WS reload command fire from a background task."""
+        from godot_ai import runtime_info
+        from godot_ai.handlers import editor as editor_handlers
+
+        monkeypatch.setattr(runtime_info, "_PID_FILE_PATH", tmp_path / "fake.pid")
+        monkeypatch.setattr(editor_handlers, "PLUGIN_MANAGED_RELOAD_DELAY_SEC", 0)
+
+        client, plugin = mcp_stack
+        result = await client.call_tool("editor_reload_plugin", {})
+
+        assert result.data["status"] == "reload_initiated"
+        assert result.data["transport_will_drop"] is True
+        assert result.data["old_session_id"] == "mcp-test"
+        assert "session_manage" in result.data["guidance"]
+        ## A pre-flight ack must NOT carry a new_session_id field — the
+        ## new session lives in the next server's registry, which this
+        ## process can never observe.
+        assert "new_session_id" not in result.data
+
+        ## The background dispatch fires reload_plugin over the WS after
+        ## the ack returns. Drain it so the test confirms the async half
+        ## completed too.
+        cmd = await plugin.recv_command(timeout=2.0)
+        assert cmd["command"] == "reload_plugin"
+        await plugin.send_response(
+            cmd["request_id"],
+            {"status": "reloading", "message": "Plugin reload initiated"},
+        )
+
 
 # ---------------------------------------------------------------------------
 # session_list / session_activate

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -1070,13 +1070,17 @@ class TestReloadPluginTool:
 
     async def test_plugin_managed_returns_preflight_ack(self, mcp_stack, monkeypatch, tmp_path):
         """Issue #393: when the server is plugin-managed, the structured
-        ack must come back to the caller — and only AFTER it lands on the
-        wire does the WS reload command fire from a background task."""
+        ack must come back to the caller AND the WS reload command must
+        only fire afterward, from the background task. Use a small but
+        observable delay so the ordering assertion isn't relying on
+        scheduler luck — peeking the WS immediately after `call_tool()`
+        returns must time out, then the command lands once the delay
+        elapses."""
         from godot_ai import runtime_info
         from godot_ai.handlers import editor as editor_handlers
 
         monkeypatch.setattr(runtime_info, "_PID_FILE_PATH", tmp_path / "fake.pid")
-        monkeypatch.setattr(editor_handlers, "PLUGIN_MANAGED_RELOAD_DELAY_SEC", 0)
+        monkeypatch.setattr(editor_handlers, "PLUGIN_MANAGED_RELOAD_DELAY_SEC", 0.05)
 
         client, plugin = mcp_stack
         result = await client.call_tool("editor_reload_plugin", {})
@@ -1092,9 +1096,13 @@ class TestReloadPluginTool:
         ## process can never observe.
         assert "new_session_id" not in result.data
 
-        ## The background dispatch fires reload_plugin over the WS after
-        ## the ack returns. Drain it so the test confirms the async half
-        ## completed too.
+        ## Ordering check: the background task is still inside its
+        ## PLUGIN_MANAGED_RELOAD_DELAY_SEC sleep, so no command should be
+        ## visible on the WS yet. A short-timeout peek must error.
+        with pytest.raises(asyncio.TimeoutError):
+            await plugin.recv_command(timeout=0.005)
+
+        ## After the delay elapses, the reload command lands on the WS.
         cmd = await plugin.recv_command(timeout=2.0)
         assert cmd["command"] == "reload_plugin"
         await plugin.send_response(

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -1084,7 +1084,9 @@ class TestReloadPluginTool:
         assert result.data["status"] == "reload_initiated"
         assert result.data["transport_will_drop"] is True
         assert result.data["old_session_id"] == "mcp-test"
-        assert "session_manage" in result.data["guidance"]
+        guidance = result.data["guidance"]
+        assert guidance.startswith("Server is plugin-managed;")
+        assert "session_manage(op='list')" in guidance
         ## A pre-flight ack must NOT carry a new_session_id field — the
         ## new session lives in the next server's registry, which this
         ## process can never observe.

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -1460,6 +1460,9 @@ def plugin_managed_mode(monkeypatch, tmp_path):
     fires immediately on the next event-loop tick."""
     monkeypatch.setattr(runtime_info, "_PID_FILE_PATH", tmp_path / "fake.pid")
     monkeypatch.setattr(editor_handlers, "PLUGIN_MANAGED_RELOAD_DELAY_SEC", 0)
+    ## A leftover task from a prior test would make the retention assertions
+    ## here ambiguous; clear the set so we're measuring this test's task only.
+    editor_handlers._pending_reload_tasks.clear()
 
 
 async def test_reload_plugin_returns_preflight_ack_when_plugin_managed(
@@ -1490,6 +1493,12 @@ async def test_reload_plugin_returns_preflight_ack_when_plugin_managed(
     ## point of the pre-flight ack is that the structured response gets
     ## back to the caller before the server tears itself down.
     assert not [c for c in stub.calls if c["command"] == "reload_plugin"]
+    ## A strong reference to the background task must be retained — the
+    ## event loop only weakrefs tasks, so without this the GC could collect
+    ## the task during the post-ack delay and silently skip the reload.
+    assert len(editor_handlers._pending_reload_tasks) == 1
+    ## Drain so the task doesn't leak into the next test.
+    await asyncio.gather(*editor_handlers._pending_reload_tasks)
 
 
 async def test_reload_plugin_dispatches_reload_async_when_plugin_managed(
@@ -1506,10 +1515,13 @@ async def test_reload_plugin_dispatches_reload_async_when_plugin_managed(
     result = await editor_handlers.editor_reload_plugin(runtime)
     assert result["status"] == "reload_initiated"
 
-    ## Drain the create_task'd background reload — a single yield with a
-    ## small budget gives it room to schedule and complete its (mocked) WS
-    ## send. The stub returns synchronously, so this is comfortably enough.
-    await asyncio.sleep(0.01)
+    ## Await the task by reference rather than `sleep(N)` — synchronizes
+    ## on actual completion, not a timing budget that could miss on a
+    ## loaded CI runner.
+    await asyncio.gather(*editor_handlers._pending_reload_tasks)
+    ## And the done-callback must have removed it from the retention set
+    ## so successive reloads don't pile up.
+    assert editor_handlers._pending_reload_tasks == set()
 
     reload_calls = [c for c in stub.calls if c["command"] == "reload_plugin"]
     assert len(reload_calls) == 1
@@ -1536,9 +1548,10 @@ async def test_reload_plugin_async_dispatch_swallows_disconnect_errors(
     result = await editor_handlers.editor_reload_plugin(runtime)
     assert result["status"] == "reload_initiated"
 
-    ## Drain the background task; if it raised an unhandled exception
-    ## this loop tick would surface it.
-    await asyncio.sleep(0.01)
+    ## Drain the background task by reference; if it raised an unhandled
+    ## exception (TimeoutError counted as expected) `gather` would surface
+    ## it here.
+    await asyncio.gather(*editor_handlers._pending_reload_tasks)
 
 
 async def test_reload_plugin_external_path_unchanged_when_not_plugin_managed():

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import pathlib
 
 import pytest
 
@@ -1455,16 +1454,16 @@ async def test_reload_plugin_pins_target_session_when_multiple_connected():
 
 
 @pytest.fixture
-def plugin_managed_runtime(monkeypatch):
+def plugin_managed_mode(monkeypatch, tmp_path):
     """Pretend the server was spawned by the plugin (--pid-file present),
     and zero out the post-ack delay so the background reload dispatch
     fires immediately on the next event-loop tick."""
-    monkeypatch.setattr(runtime_info, "_PID_FILE_PATH", pathlib.Path("/tmp/fake.pid"))
+    monkeypatch.setattr(runtime_info, "_PID_FILE_PATH", tmp_path / "fake.pid")
     monkeypatch.setattr(editor_handlers, "PLUGIN_MANAGED_RELOAD_DELAY_SEC", 0)
 
 
 async def test_reload_plugin_returns_preflight_ack_when_plugin_managed(
-    plugin_managed_runtime,
+    plugin_managed_mode,
 ):
     """Issue #393: when our own server was spawned by the plugin, the
     reload kills us before any sync `wait_for_session` could deliver a
@@ -1494,11 +1493,11 @@ async def test_reload_plugin_returns_preflight_ack_when_plugin_managed(
 
 
 async def test_reload_plugin_dispatches_reload_async_when_plugin_managed(
-    plugin_managed_runtime,
+    plugin_managed_mode,
 ):
     """The pre-flight ack returns first; the WS reload command then fires
     from a background task. Verify both halves: the ack returns synchronously
-    and the reload command lands on the wire after one event-loop yield."""
+    and the reload command lands on the wire after the loop runs the task."""
     registry = SessionRegistry()
     registry.register(_make_session("old-session"))
     stub = ReloadStubClient(registry=registry, new_session_id="new-session")
@@ -1507,9 +1506,10 @@ async def test_reload_plugin_dispatches_reload_async_when_plugin_managed(
     result = await editor_handlers.editor_reload_plugin(runtime)
     assert result["status"] == "reload_initiated"
 
-    ## Yield once to drain the background task scheduled by create_task.
-    await asyncio.sleep(0)
-    await asyncio.sleep(0)
+    ## Drain the create_task'd background reload — a single yield with a
+    ## small budget gives it room to schedule and complete its (mocked) WS
+    ## send. The stub returns synchronously, so this is comfortably enough.
+    await asyncio.sleep(0.01)
 
     reload_calls = [c for c in stub.calls if c["command"] == "reload_plugin"]
     assert len(reload_calls) == 1
@@ -1519,7 +1519,7 @@ async def test_reload_plugin_dispatches_reload_async_when_plugin_managed(
 
 
 async def test_reload_plugin_async_dispatch_swallows_disconnect_errors(
-    plugin_managed_runtime,
+    plugin_managed_mode,
 ):
     """The plugin tearing down our server is the *expected* side effect
     of reload_plugin, so a Connection/Timeout error from the WS send in
@@ -1538,8 +1538,7 @@ async def test_reload_plugin_async_dispatch_swallows_disconnect_errors(
 
     ## Drain the background task; if it raised an unhandled exception
     ## this loop tick would surface it.
-    await asyncio.sleep(0)
-    await asyncio.sleep(0)
+    await asyncio.sleep(0.01)
 
 
 async def test_reload_plugin_external_path_unchanged_when_not_plugin_managed():

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
+import pathlib
+
 import pytest
 
+from godot_ai import runtime_info
 from godot_ai.handlers import animation as animation_handlers
 from godot_ai.handlers import audio as audio_handlers
 from godot_ai.handlers import autoload as autoload_handlers
@@ -1448,6 +1452,114 @@ async def test_reload_plugin_pins_target_session_when_multiple_connected():
     assert result["old_session_id"] == "session-b"
     assert result["new_session_id"] == "session-b-new"
     assert runtime.active_session_id == "session-b-new"
+
+
+@pytest.fixture
+def plugin_managed_runtime(monkeypatch):
+    """Pretend the server was spawned by the plugin (--pid-file present),
+    and zero out the post-ack delay so the background reload dispatch
+    fires immediately on the next event-loop tick."""
+    monkeypatch.setattr(runtime_info, "_PID_FILE_PATH", pathlib.Path("/tmp/fake.pid"))
+    monkeypatch.setattr(editor_handlers, "PLUGIN_MANAGED_RELOAD_DELAY_SEC", 0)
+
+
+async def test_reload_plugin_returns_preflight_ack_when_plugin_managed(
+    plugin_managed_runtime,
+):
+    """Issue #393: when our own server was spawned by the plugin, the
+    reload kills us before any sync `wait_for_session` could deliver a
+    payload. Hand back a structured ack immediately and dispatch the
+    actual reload async."""
+    registry = SessionRegistry()
+    registry.register(_make_session("old-session"))
+    stub = ReloadStubClient(registry=registry, new_session_id="new-session")
+    runtime = DirectRuntime(registry=registry, client=stub)
+
+    result = await editor_handlers.editor_reload_plugin(runtime)
+
+    assert result == {
+        "status": "reload_initiated",
+        "transport_will_drop": True,
+        "old_session_id": "old-session",
+        "guidance": (
+            "Server is plugin-managed; the WebSocket transport will drop "
+            "as part of the reload. Reconnect, then call "
+            "session_manage(op='list') to find the new session_id."
+        ),
+    }
+    ## The reload command itself must NOT have left the wire yet — the
+    ## point of the pre-flight ack is that the structured response gets
+    ## back to the caller before the server tears itself down.
+    assert not [c for c in stub.calls if c["command"] == "reload_plugin"]
+
+
+async def test_reload_plugin_dispatches_reload_async_when_plugin_managed(
+    plugin_managed_runtime,
+):
+    """The pre-flight ack returns first; the WS reload command then fires
+    from a background task. Verify both halves: the ack returns synchronously
+    and the reload command lands on the wire after one event-loop yield."""
+    registry = SessionRegistry()
+    registry.register(_make_session("old-session"))
+    stub = ReloadStubClient(registry=registry, new_session_id="new-session")
+    runtime = DirectRuntime(registry=registry, client=stub)
+
+    result = await editor_handlers.editor_reload_plugin(runtime)
+    assert result["status"] == "reload_initiated"
+
+    ## Yield once to drain the background task scheduled by create_task.
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    reload_calls = [c for c in stub.calls if c["command"] == "reload_plugin"]
+    assert len(reload_calls) == 1
+    assert reload_calls[0]["session_id"] == "old-session", (
+        "Async reload dispatch must still pin to the original active id"
+    )
+
+
+async def test_reload_plugin_async_dispatch_swallows_disconnect_errors(
+    plugin_managed_runtime,
+):
+    """The plugin tearing down our server is the *expected* side effect
+    of reload_plugin, so a Connection/Timeout error from the WS send in
+    the background task must not surface as an unhandled task exception."""
+    registry = SessionRegistry()
+    registry.register(_make_session("old-session"))
+    stub = ReloadStubClient(
+        registry=registry,
+        new_session_id="new-session",
+        raise_timeout=True,
+    )
+    runtime = DirectRuntime(registry=registry, client=stub)
+
+    result = await editor_handlers.editor_reload_plugin(runtime)
+    assert result["status"] == "reload_initiated"
+
+    ## Drain the background task; if it raised an unhandled exception
+    ## this loop tick would surface it.
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+
+async def test_reload_plugin_external_path_unchanged_when_not_plugin_managed():
+    """The pid-file isn't set by default, so external-server callers keep
+    the current sync `wait_for_session` shape that returns new_session_id."""
+    assert not runtime_info.is_plugin_managed()
+    registry = SessionRegistry()
+    registry.register(_make_session("old-session"))
+    runtime = DirectRuntime(
+        registry=registry,
+        client=ReloadStubClient(registry=registry, new_session_id="new-session"),
+    )
+
+    result = await editor_handlers.editor_reload_plugin(runtime)
+
+    assert result == {
+        "status": "reloaded",
+        "old_session_id": "old-session",
+        "new_session_id": "new-session",
+    }
 
 
 def test_unregister_active_with_multiple_survivors_clears_active():

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -1554,6 +1554,52 @@ async def test_reload_plugin_async_dispatch_swallows_disconnect_errors(
     await asyncio.gather(*editor_handlers._pending_reload_tasks)
 
 
+async def test_dispatch_reload_async_swallows_unexpected_errors(plugin_managed_mode):
+    """The generic `except Exception` fallback must keep an unexpected
+    error from a misbehaving WS send out of the asyncio loop's unhandled
+    task path. Direct-await of `_dispatch_reload_async` — without the
+    catch this `await` would re-raise the RuntimeError."""
+    registry = SessionRegistry()
+    registry.register(_make_session("old-session"))
+
+    class RaisingClient:
+        async def send(self, *args, **kwargs):
+            raise RuntimeError("simulated unexpected failure")
+
+    runtime = DirectRuntime(registry=registry, client=RaisingClient())
+
+    await editor_handlers._dispatch_reload_async(runtime, "old-session")
+
+
+async def test_dispatch_reload_async_honors_delay(monkeypatch):
+    """The `PLUGIN_MANAGED_RELOAD_DELAY_SEC > 0` branch must actually
+    sleep before firing the WS command — that's the whole reason the
+    delay exists (give the HTTP/SSE response time to flush)."""
+    monkeypatch.setattr(editor_handlers, "PLUGIN_MANAGED_RELOAD_DELAY_SEC", 0.05)
+    registry = SessionRegistry()
+    registry.register(_make_session("old-session"))
+    stub = ReloadStubClient(registry=registry, new_session_id="new-session")
+    runtime = DirectRuntime(registry=registry, client=stub)
+
+    sleep_calls: list[float] = []
+    real_sleep = asyncio.sleep
+
+    async def recording_sleep(delay, *args, **kwargs):
+        sleep_calls.append(delay)
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", recording_sleep)
+
+    await editor_handlers._dispatch_reload_async(runtime, "old-session")
+
+    assert 0.05 in sleep_calls, (
+        "_dispatch_reload_async must sleep for PLUGIN_MANAGED_RELOAD_DELAY_SEC "
+        "before firing the reload command"
+    )
+    reload_calls = [c for c in stub.calls if c["command"] == "reload_plugin"]
+    assert len(reload_calls) == 1
+
+
 async def test_reload_plugin_external_path_unchanged_when_not_plugin_managed():
     """The pid-file isn't set by default, so external-server callers keep
     the current sync `wait_for_session` shape that returns new_session_id."""

--- a/tests/unit/test_runtime_info.py
+++ b/tests/unit/test_runtime_info.py
@@ -52,7 +52,8 @@ def test_install_pid_file_none_is_noop(_unregister_atexit):
 def test_is_plugin_managed_tracks_pid_file_install(tmp_path, _unregister_atexit):
     """`is_plugin_managed()` is the editor_reload_plugin handler's signal
     that calling reload will kill its own server process (issue #393).
-    It must flip True only after `install_pid_file` actually wrote a file."""
+    It must flip True only after `install_pid_file` actually wrote a file,
+    and flip back when a subsequent install_pid_file(None) drops the path."""
     assert is_plugin_managed() is False
 
     install_pid_file(None)
@@ -60,6 +61,11 @@ def test_is_plugin_managed_tracks_pid_file_install(tmp_path, _unregister_atexit)
 
     install_pid_file(tmp_path / "server.pid")
     assert is_plugin_managed() is True
+
+    ## A later install_pid_file(None) (e.g. a programmatic caller
+    ## leaving plugin-managed mode) must flip the flag back to False.
+    install_pid_file(None)
+    assert is_plugin_managed() is False
 
 
 def test_install_pid_file_creates_parent_dir(tmp_path, _unregister_atexit):

--- a/tests/unit/test_runtime_info.py
+++ b/tests/unit/test_runtime_info.py
@@ -6,15 +6,20 @@ from pathlib import Path
 
 import pytest
 
-from godot_ai.runtime_info import install_pid_file
+from godot_ai import runtime_info
+from godot_ai.runtime_info import install_pid_file, is_plugin_managed
 
 
 @pytest.fixture
 def _unregister_atexit(monkeypatch):
     """Capture atexit handlers registered during install_pid_file so the
-    test can invoke them explicitly and unregister them cleanly.
+    test can invoke them explicitly and unregister them cleanly. Also
+    snapshots and restores the module-level _PID_FILE_PATH so a test
+    that calls install_pid_file doesn't leak plugin-managed mode into
+    other tests in the suite.
     """
     registered: list = []
+    saved_path = runtime_info._PID_FILE_PATH
 
     real_register = atexit.register
 
@@ -26,6 +31,7 @@ def _unregister_atexit(monkeypatch):
     yield registered
     for fn, _args, _kwargs in registered:
         atexit.unregister(fn)
+    runtime_info._PID_FILE_PATH = saved_path
 
 
 def test_install_pid_file_writes_pid(tmp_path, _unregister_atexit):
@@ -41,6 +47,19 @@ def test_install_pid_file_none_is_noop(_unregister_atexit):
     assert install_pid_file(None) is None
     assert install_pid_file("") is None
     assert _unregister_atexit == []
+
+
+def test_is_plugin_managed_tracks_pid_file_install(tmp_path, _unregister_atexit):
+    """`is_plugin_managed()` is the editor_reload_plugin handler's signal
+    that calling reload will kill its own server process (issue #393).
+    It must flip True only after `install_pid_file` actually wrote a file."""
+    assert is_plugin_managed() is False
+
+    install_pid_file(None)
+    assert is_plugin_managed() is False
+
+    install_pid_file(tmp_path / "server.pid")
+    assert is_plugin_managed() is True
 
 
 def test_install_pid_file_creates_parent_dir(tmp_path, _unregister_atexit):


### PR DESCRIPTION
## Summary

Fixes the `editor_reload_plugin` "session expired" return on plugin-managed servers. Branches by mode:

- **Plugin-managed (default install)**: detect via the existing `--pid-file` arg (the plugin always passes it when it spawns the server). Return a structured pre-flight ack — `{status: "reload_initiated", transport_will_drop: true, old_session_id, guidance}` — immediately, then dispatch `reload_plugin` over the WS from a background task after a brief delay so the HTTP/SSE response flushes before the plugin tears the server down. `new_session_id` is dropped from this shape because the new session lives in the *next* server's registry, which the dying process can never observe.
- **Externally launched**: behavior unchanged — the existing sync `wait_for_session` path still returns `{status: "reloaded", old_session_id, new_session_id}`.

Updates the tool docstring (it was incorrectly claiming the tool only works against an external server — both modes work; the difference is just the response shape).

Closes #393.

## Test plan

- [x] `ruff check src/ tests/` + `ruff format --check src/ tests/`
- [x] `pytest -q` — 905 passed
- [x] `script/ci-check-gdscript` — all GDScript files OK
- [x] New unit tests cover: pre-flight ack shape, async dispatch fires the WS command, disconnect/timeout from the background send is swallowed, external-server path unchanged
- [x] New integration test: `editor_reload_plugin` via FastMCP returns the structured ack with `transport_will_drop: true` AND the WS reload command lands on the mock plugin afterward
- [ ] Live-smoke against a running editor — Godot crashed during this session and could not be relaunched. The integration test exercises the full FastMCP→handler→WS pipeline with a real WebSocket and a mock plugin, but a manual smoke against a real plugin-managed server is still recommended before merge.

## Notes

The async dispatch uses `asyncio.create_task` plus a 0.5s delay (`PLUGIN_MANAGED_RELOAD_DELAY_SEC`, overridable in tests) to give the HTTP response time to leave the socket before the plugin's `_exit_tree` SIGTERMs the server. Errors from the background send are logged and swallowed — a `ConnectionError` / `TimeoutError` there is the *expected* shape of "the plugin killed our process, mission accomplished."

---
_Generated by [Claude Code](https://claude.ai/code/session_012qrpMD3xwJYYXRsGYjgNgq)_