### PR TITLE
Dev-section follow-ups: Restarting… feedback + consolidate buttons + parent-walk

### DIFF
--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -173,11 +173,15 @@ var _reload_btn: Button
 var _mode_override_btn: OptionButton
 var _setup_section: VBoxContainer
 var _setup_container: VBoxContainer
-var _dev_server_btn: Button
-## Same-version Python edits get adopted as compatible, so neither the
-## drift nor the crash Restart button surfaces — this is the unconditional
-## kick contributors need to pick up source changes without a version bump.
-var _dev_restart_btn: Button
+## Primary dev-section button — always (re)starts a `--reload` dev server.
+## Same-version Python edits get adopted as compatible by the lifecycle, so
+## neither the drift nor the crash Restart button surfaces; this is the
+## unconditional kick contributors need to pick up source changes without
+## a version bump.
+var _dev_primary_btn: Button
+## Small "✕" affordance next to the primary — stops the dev server without
+## spawning a replacement. Disabled when no dev server is running.
+var _dev_stop_btn: Button
 var _log_viewer: LogViewerScript
 
 var _last_connected := false
@@ -1256,24 +1260,31 @@ func _refresh_setup_status() -> void:
 		return
 	for child in _setup_container.get_children():
 		child.queue_free()
-	_dev_server_btn = null
-	_dev_restart_btn = null
+	_dev_primary_btn = null
+	_dev_stop_btn = null
 
 	var is_dev := ClientConfigurator.is_dev_checkout()
 	if is_dev:
 		_setup_container.add_child(_make_status_row("Mode", "Dev (venv)", Color.CYAN))
-		_dev_server_btn = Button.new()
-		_dev_server_btn.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-		_dev_server_btn.pressed.connect(_on_dev_server_pressed)
-		_update_dev_server_btn()
-		_setup_container.add_child(_dev_server_btn)
 
-		_dev_restart_btn = Button.new()
-		_dev_restart_btn.text = "Restart Server"
-		_dev_restart_btn.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-		_dev_restart_btn.pressed.connect(_on_dev_restart_pressed)
-		_update_dev_restart_btn()
-		_setup_container.add_child(_dev_restart_btn)
+		var btn_row := HBoxContainer.new()
+		btn_row.add_theme_constant_override("separation", 4)
+		btn_row.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+
+		_dev_primary_btn = Button.new()
+		_dev_primary_btn.text = "Restart Dev Server"
+		_dev_primary_btn.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		_dev_primary_btn.pressed.connect(_on_dev_primary_pressed)
+		btn_row.add_child(_dev_primary_btn)
+
+		_dev_stop_btn = Button.new()
+		_dev_stop_btn.text = "✕"
+		_dev_stop_btn.tooltip_text = "Stop the dev server without spawning a replacement."
+		_dev_stop_btn.pressed.connect(_on_dev_stop_pressed)
+		btn_row.add_child(_dev_stop_btn)
+
+		_setup_container.add_child(btn_row)
+		_update_dev_section_buttons()
 		return
 
 	# User mode — check for uv
@@ -1358,102 +1369,56 @@ func _make_status_row(label_text: String, value_text: String, value_color: Color
 	return row
 
 
-## Pure helper — given the two independent server states, return the button
-## label and tooltip. Factored out so tests can cover all three states without
-## spinning up a real server or plugin.
-static func _dev_server_btn_state(has_managed: bool, dev_running: bool) -> Dictionary:
-	var port := ClientConfigurator.http_port()
-	if has_managed:
-		return {
-			"text": "Switch to dev mode (--reload)",
-			"tooltip": "Stops the plugin's managed server and replaces it with a --reload dev server on port %d. The dev server auto-restarts when you edit Python sources." % port,
-		}
-	if dev_running:
-		return {
-			"text": "Exit dev mode",
-			"tooltip": "Stops the external dev server on port %d so the plugin's managed server can take over on next reload." % port,
-		}
-	return {
-		"text": "Start dev server",
-		"tooltip": "Spawns a --reload dev server on port %d. Auto-restarts when you edit Python sources." % port,
-	}
-
-
-func _update_dev_server_btn() -> void:
-	if _dev_server_btn == null:
-		return
-	if _plugin == null:
-		return
-	## Defensive guard against the self-update mixed-state window — see the
-	## comment in `_update_status` for the full story. Same #168.
-	if not (_plugin.has_method("has_managed_server") and _plugin.has_method("is_dev_server_running")):
-		return
-	var state := _dev_server_btn_state(_plugin.has_managed_server(), _plugin.is_dev_server_running())
-	_dev_server_btn.text = state["text"]
-	_dev_server_btn.tooltip_text = state["tooltip"]
-
-
-func _on_dev_server_pressed() -> void:
-	if _plugin == null:
-		return
-	if _plugin.has_managed_server():
-		# Managed server running — swap it for a --reload dev server.
-		# start_dev_server() calls _stop_server() internally before spawning.
-		_plugin.start_dev_server()
-	elif _plugin.is_dev_server_running():
-		_plugin.stop_dev_server()
-	else:
-		_plugin.start_dev_server()
-	_update_dev_section_buttons.call_deferred()
-
-
-## Pure helper for the Restart Server button — enabled iff something is
-## running on the HTTP port we can kick. Static so `test_dock_dev_server_btn`
-## can cover the truth table without a real plugin.
-static func _restart_server_btn_state(has_managed: bool, dev_running: bool) -> Dictionary:
+## Pure helper for the primary "Restart Dev Server" button. Always enabled
+## (clicking with nothing running just spawns fresh); tooltip adapts to
+## whether a kill+respawn or fresh spawn is what'll happen.
+static func _dev_primary_btn_state(has_managed: bool, dev_running: bool) -> Dictionary:
 	var port := ClientConfigurator.http_port()
 	if has_managed or dev_running:
 		return {
-			"enabled": true,
+			"text": "Restart Dev Server",
 			"tooltip": (
-				"Kill the server on port %d and respawn from current source, "
-				+ "preserving managed vs --reload mode. Use this to pick up "
-				+ "Python server-source changes that don't bump the version."
+				"Kill the server on port %d and start a fresh --reload dev server. "
+				+ "Use this to pick up Python source changes that don't bump the version."
 			) % port,
 		}
 	return {
-		"enabled": false,
-		"tooltip": "No godot-ai server is running on port %d." % port,
+		"text": "Start Dev Server",
+		"tooltip": "Spawn a --reload dev server on port %d. Auto-restarts when you edit Python sources." % port,
 	}
 
 
-func _update_dev_restart_btn() -> void:
-	if _dev_restart_btn == null:
-		return
-	if _plugin == null:
-		return
-	## See _update_dev_server_btn — same #168 self-update mixed-state guard.
-	if not (_plugin.has_method("has_managed_server") and _plugin.has_method("is_dev_server_running")):
-		return
-	var state := _restart_server_btn_state(_plugin.has_managed_server(), _plugin.is_dev_server_running())
-	_dev_restart_btn.disabled = not state["enabled"]
-	_dev_restart_btn.tooltip_text = state["tooltip"]
+## Pure helper for the small "✕" stop button — only enabled when a dev
+## server is actually running. Stops without respawning; intentionally
+## never targets a managed server (that's the lifecycle's responsibility).
+static func _dev_stop_btn_state(dev_running: bool) -> Dictionary:
+	if dev_running:
+		return {"enabled": true, "tooltip": "Stop the dev server without spawning a replacement."}
+	return {"enabled": false, "tooltip": "No --reload dev server to stop."}
 
 
-func _on_dev_restart_pressed() -> void:
+func _on_dev_primary_pressed() -> void:
 	if _plugin == null or _server_restart_in_progress:
 		return
-	if not _plugin.has_method("force_restart_server_preserving_mode"):
+	if not _plugin.has_method("force_restart_or_start_dev_server"):
 		return
 	_server_restart_in_progress = true
 	_update_dev_section_buttons()
 	if not is_inside_tree():
 		## Test path — no scene tree means no timer; run synchronously
 		## so suite assertions see the dispatch without `await`.
-		_plugin.force_restart_server_preserving_mode()
+		_plugin.force_restart_or_start_dev_server()
 		_server_restart_in_progress = false
 		return
 	call_deferred("_perform_dev_restart_after_feedback")
+
+
+func _on_dev_stop_pressed() -> void:
+	if _plugin == null:
+		return
+	if _plugin.has_method("stop_dev_server"):
+		_plugin.stop_dev_server()
+	_update_dev_section_buttons.call_deferred()
 
 
 func _perform_dev_restart_after_feedback() -> void:
@@ -1461,7 +1426,7 @@ func _perform_dev_restart_after_feedback() -> void:
 	## blocking _wait_for_port_free freezes the editor for up to 5s.
 	await get_tree().create_timer(0.15).timeout
 	if _plugin != null:
-		_plugin.force_restart_server_preserving_mode()
+		_plugin.force_restart_or_start_dev_server()
 	## start_dev_server's spawn happens via a 0.5s SceneTree timer; give
 	## it time to land plus a buffer for the WS reconnect before clearing
 	## the busy state. The unconditional clear matches sibling restart
@@ -1484,20 +1449,20 @@ func _update_dev_section_buttons() -> void:
 		return
 	var has_managed: bool = _plugin.has_managed_server()
 	var dev_running: bool = _plugin.is_dev_server_running()
-	if _dev_server_btn != null:
-		var server_state := _dev_server_btn_state(has_managed, dev_running)
-		_dev_server_btn.text = server_state["text"]
-		_dev_server_btn.tooltip_text = server_state["tooltip"]
-	if _dev_restart_btn != null:
+	if _dev_primary_btn != null:
 		if _server_restart_in_progress:
-			_dev_restart_btn.disabled = true
-			_dev_restart_btn.text = "Restarting…"
-			_dev_restart_btn.tooltip_text = "Killing the current server and respawning…"
+			_dev_primary_btn.disabled = true
+			_dev_primary_btn.text = "Restarting…"
+			_dev_primary_btn.tooltip_text = "Killing the current server and respawning…"
 		else:
-			var restart_state := _restart_server_btn_state(has_managed, dev_running)
-			_dev_restart_btn.disabled = not restart_state["enabled"]
-			_dev_restart_btn.text = "Restart Server"
-			_dev_restart_btn.tooltip_text = restart_state["tooltip"]
+			var primary_state := _dev_primary_btn_state(has_managed, dev_running)
+			_dev_primary_btn.disabled = false
+			_dev_primary_btn.text = primary_state["text"]
+			_dev_primary_btn.tooltip_text = primary_state["tooltip"]
+	if _dev_stop_btn != null:
+		var stop_state := _dev_stop_btn_state(dev_running)
+		_dev_stop_btn.disabled = (not stop_state["enabled"]) or _server_restart_in_progress
+		_dev_stop_btn.tooltip_text = stop_state["tooltip"]
 
 
 func _on_install_uv() -> void:

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -1441,11 +1441,35 @@ func _update_dev_restart_btn() -> void:
 
 
 func _on_dev_restart_pressed() -> void:
-	if _plugin == null:
+	if _plugin == null or _server_restart_in_progress:
 		return
-	if _plugin.has_method("force_restart_server_preserving_mode"):
+	if not _plugin.has_method("force_restart_server_preserving_mode"):
+		return
+	_server_restart_in_progress = true
+	_update_dev_section_buttons()
+	if not is_inside_tree():
+		## Test path — no scene tree means no timer; run synchronously
+		## so suite assertions see the dispatch without `await`.
 		_plugin.force_restart_server_preserving_mode()
-	_update_dev_section_buttons.call_deferred()
+		_server_restart_in_progress = false
+		return
+	call_deferred("_perform_dev_restart_after_feedback")
+
+
+func _perform_dev_restart_after_feedback() -> void:
+	## Brief paint cycle so the user sees "Restarting…" before the
+	## blocking _wait_for_port_free freezes the editor for up to 5s.
+	await get_tree().create_timer(0.15).timeout
+	if _plugin != null:
+		_plugin.force_restart_server_preserving_mode()
+	## start_dev_server's spawn happens via a 0.5s SceneTree timer; give
+	## it time to land plus a buffer for the WS reconnect before clearing
+	## the busy state. The unconditional clear matches sibling restart
+	## buttons — overshoot is fine because subsequent _update_status calls
+	## refresh the button against live plugin state.
+	await get_tree().create_timer(2.0).timeout
+	_server_restart_in_progress = false
+	_update_dev_section_buttons()
 
 
 ## Single-scan refresh of every dev-section button state. Both buttons
@@ -1465,9 +1489,15 @@ func _update_dev_section_buttons() -> void:
 		_dev_server_btn.text = server_state["text"]
 		_dev_server_btn.tooltip_text = server_state["tooltip"]
 	if _dev_restart_btn != null:
-		var restart_state := _restart_server_btn_state(has_managed, dev_running)
-		_dev_restart_btn.disabled = not restart_state["enabled"]
-		_dev_restart_btn.tooltip_text = restart_state["tooltip"]
+		if _server_restart_in_progress:
+			_dev_restart_btn.disabled = true
+			_dev_restart_btn.text = "Restarting…"
+			_dev_restart_btn.tooltip_text = "Killing the current server and respawning…"
+		else:
+			var restart_state := _restart_server_btn_state(has_managed, dev_running)
+			_dev_restart_btn.disabled = not restart_state["enabled"]
+			_dev_restart_btn.text = "Restart Server"
+			_dev_restart_btn.tooltip_text = restart_state["tooltip"]
 
 
 func _on_install_uv() -> void:

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -39,11 +39,6 @@ const LogViewerScript := preload("res://addons/godot_ai/dock_panels/log_viewer.g
 const PortPickerPanelScript := preload("res://addons/godot_ai/dock_panels/port_picker_panel.gd")
 
 const DEV_MODE_SETTING := "godot_ai/dev_mode"
-## Index ↔ persisted-value mapping for the mode-override dropdown. The array
-## index is the OptionButton item id; the string is what's written to the
-## EditorSetting and read by `ClientConfigurator.mode_override()`.
-const MODE_OVERRIDE_VALUES := ["", "user", "dev"]
-const MODE_OVERRIDE_LABELS := ["Auto", "Force user", "Force dev"]
 const CLIENT_STATUS_REFRESH_COOLDOWN_MSEC := 15 * 1000
 const CLIENT_STATUS_REFRESH_TIMEOUT_MSEC := 30 * 1000
 static var COLOR_MUTED := Color(0.7, 0.7, 0.7)
@@ -170,7 +165,6 @@ var _client_action_generations: Dictionary = {}
 var _dev_section: VBoxContainer
 var _server_label: Label
 var _reload_btn: Button
-var _mode_override_btn: OptionButton
 var _setup_section: VBoxContainer
 var _setup_container: VBoxContainer
 ## Primary dev-section button — always (re)starts a `--reload` dev server.
@@ -530,23 +524,6 @@ func _build_ui() -> void:
 	btn_row.add_child(_reload_btn)
 
 	_dev_section.add_child(btn_row)
-
-	# Dev-only override for testing the update-banner flow; persisted via EditorSettings.
-	var mode_row := HBoxContainer.new()
-	mode_row.add_theme_constant_override("separation", 6)
-	var mode_label := Label.new()
-	mode_label.text = "Mode override"
-	mode_label.tooltip_text = "Force dev or user mode for testing the update flow. Normally leave on Auto. GODOT_AI_MODE env var is the fallback when this is Auto."
-	mode_row.add_child(mode_label)
-	_mode_override_btn = OptionButton.new()
-	_mode_override_btn.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	for i in MODE_OVERRIDE_LABELS.size():
-		_mode_override_btn.add_item(MODE_OVERRIDE_LABELS[i], i)
-	_mode_override_btn.tooltip_text = mode_label.tooltip_text
-	_mode_override_btn.select(_mode_override_index_from_setting())
-	_mode_override_btn.item_selected.connect(_on_mode_override_selected)
-	mode_row.add_child(_mode_override_btn)
-	_dev_section.add_child(mode_row)
 
 	# --- Setup section (dev-only or when uv missing) ---
 	_setup_section = VBoxContainer.new()
@@ -1064,50 +1041,6 @@ func _apply_dev_mode_visibility() -> void:
 	var is_dev := ClientConfigurator.is_dev_checkout()
 	var uv_missing := not is_dev and ClientConfigurator.check_uv_version().is_empty()
 	_setup_section.visible = dev or uv_missing
-
-
-func _mode_override_index_from_setting() -> int:
-	var es := EditorInterface.get_editor_settings()
-	if es == null or not es.has_setting(ClientConfigurator.MODE_OVERRIDE_SETTING):
-		return 0
-	var v := str(es.get_setting(ClientConfigurator.MODE_OVERRIDE_SETTING)).strip_edges().to_lower()
-	return maxi(MODE_OVERRIDE_VALUES.find(v), 0)
-
-
-## Called whenever `is_dev_checkout()`'s answer could have changed — repaints
-## the install label/tooltip, rebuilds the setup container (Mode row, Dev
-## Server button vs uv status), and clears any stale update banner so a
-## fresh check paints over a clean slate. The Update button state is reset
-## too: a prior install attempt may have left it disabled with text like
-## "Dev checkout — update via git" or "Extract failed"; without this reset,
-## flipping the dropdown and re-checking would re-open the banner with the
-## stale button text.
-func _refresh_install_mode_ui() -> void:
-	_install_label.text = _install_mode_text()
-	_install_label.tooltip_text = _install_mode_tooltip()
-	_refresh_setup_status()
-	_update_banner.visible = false
-	if _update_manager != null:
-		_update_manager.clear_pending_download()
-	if _update_btn != null:
-		_update_btn.text = "Update"
-		_update_btn.disabled = false
-
-
-func _on_mode_override_selected(index: int) -> void:
-	var value: String = MODE_OVERRIDE_VALUES[index] if index >= 0 and index < MODE_OVERRIDE_VALUES.size() else ""
-	var es := EditorInterface.get_editor_settings()
-	if es != null:
-		es.set_setting(ClientConfigurator.MODE_OVERRIDE_SETTING, value)
-	_refresh_install_mode_ui()
-	## Cancel any in-flight startup check before firing a new one, otherwise
-	## the next `request()` returns ERR_BUSY and the dropdown flip silently
-	## fails to re-check. `call_deferred` lets the cancel settle before the
-	## new request goes out.
-	if _update_manager != null:
-		_update_manager.cancel_check()
-		_update_manager.check_for_updates.call_deferred()
-	print("MCP | mode override -> %s" % (value if value else "auto"))
 
 
 # --- Button handlers ---

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -1168,14 +1168,42 @@ static func _build_server_flags(port: int, ws_port: int) -> Array[String]:
 ## conservatively return false — better to surface incompatible-server and
 ## let the user click Restart than to kill the wrong process.
 func _pid_cmdline_is_godot_ai(pid: int) -> bool:
+	## Walks up the parent chain so a uvicorn `--reload` worker whose
+	## cmdline is just `multiprocessing.spawn` still matches when its
+	## parent reloader carries the godot_ai brand. Bound the walk so a
+	## hypothetical loop or runaway PPID can't stall the editor.
+	var current := pid
+	for _i in range(5):
+		if current <= 1:
+			return false
+		var cmd := ""
+		if OS.get_name() == "Windows":
+			cmd = _windows_pid_commandline(current)
+		else:
+			cmd = _posix_pid_commandline(current)
+		if _commandline_is_godot_ai_server(cmd):
+			return true
+		current = _pid_parent(current)
+	return false
+
+
+func _pid_parent(pid: int) -> int:
 	if pid <= 1:
-		return false
-	var cmd := ""
+		return 0
 	if OS.get_name() == "Windows":
-		cmd = _windows_pid_commandline(pid)
-	else:
-		cmd = _posix_pid_commandline(pid)
-	return _commandline_is_godot_ai_server(cmd)
+		var output: Array = []
+		var script := (
+			"Get-CimInstance Win32_Process -Filter 'ProcessId = %d' | "
+			+ "Select-Object -ExpandProperty ParentProcessId"
+		) % pid
+		_startup_trace_count("powershell")
+		if _execute_windows_powershell(script, output) != 0 or output.is_empty():
+			return 0
+		return int(str(output[0]).strip_edges())
+	var output_posix: Array = []
+	if OS.execute("ps", ["-o", "ppid=", "-p", str(pid)], output_posix, true) != 0 or output_posix.is_empty():
+		return 0
+	return int(str(output_posix[0]).strip_edges())
 
 
 static func _commandline_is_godot_ai_server(cmd: String) -> bool:

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -1414,21 +1414,19 @@ func force_restart_server() -> void:
 
 
 ## Single entry point for the dock's primary "Restart Dev Server" button.
-## Kills whatever godot-ai server is currently on the HTTP port (managed,
-## adopted, or already-dev) and lands in `--reload` mode. Same-version
-## Python edits get adopted as compatible by the lifecycle's start_server
-## arm, so reloading the plugin won't pick them up — this is the explicit
-## "kill and respawn from current source" path. Returns true if a kill
-## happened, false if we just spawned fresh.
+## The user clicking Restart is explicit consent to take over the HTTP port,
+## so this is aggressive: any PID holding the port gets killed (managed,
+## branded-dev, or orphan multiprocessing.spawn workers whose parent died
+## so brand detection misses them). After the port frees we spawn a fresh
+## --reload dev server. Returns true if a kill happened, false if the port
+## was already free and we just spawned.
 func force_restart_or_start_dev_server() -> bool:
 	var port := ClientConfigurator.http_port()
 	var killed := false
 	if has_managed_server():
 		_lifecycle.reset_for_force_restart()
+	if _is_port_in_use(port):
 		_kill_processes_and_windows_spawn_children(_find_all_pids_on_port(port))
-		killed = true
-	elif is_dev_server_running():
-		stop_dev_server()
 		killed = true
 	if killed:
 		## OS.kill returns synchronously but uvicorn's listener can take

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -1413,26 +1413,31 @@ func force_restart_server() -> void:
 	_lifecycle.force_restart_server()
 
 
-## Same-version Python edits get adopted as compatible by the lifecycle's
-## start_server arm, so reloading or relaunching just re-adopts the stale
-## process. This is the "kill whatever's there and respawn from current
-## source" path the dock's Restart Server button hits, preserving managed
-## vs --reload mode.
-func force_restart_server_preserving_mode() -> bool:
+## Single entry point for the dock's primary "Restart Dev Server" button.
+## Kills whatever godot-ai server is currently on the HTTP port (managed,
+## adopted, or already-dev) and lands in `--reload` mode. Same-version
+## Python edits get adopted as compatible by the lifecycle's start_server
+## arm, so reloading the plugin won't pick them up — this is the explicit
+## "kill and respawn from current source" path. Returns true if a kill
+## happened, false if we just spawned fresh.
+func force_restart_or_start_dev_server() -> bool:
+	var port := ClientConfigurator.http_port()
+	var killed := false
 	if has_managed_server():
-		_lifecycle.force_restart_server()
-		return true
-	if is_dev_server_running():
+		_lifecycle.reset_for_force_restart()
+		_kill_processes_and_windows_spawn_children(_find_all_pids_on_port(port))
+		killed = true
+	elif is_dev_server_running():
 		stop_dev_server()
-		## OS.kill returns synchronously but the listener can take longer
-		## to release the port — without this wait, start_dev_server's
-		## fixed 500ms timer races the old uvicorn shutdown and the new
-		## --reload spawn fails to bind. Mirrors the managed path's wait
-		## inside _lifecycle.force_restart_server.
-		_wait_for_port_free(ClientConfigurator.http_port(), 5.0)
-		start_dev_server()
-		return true
-	return false
+		killed = true
+	if killed:
+		## OS.kill returns synchronously but uvicorn's listener can take
+		## longer to release the port. Without this wait, start_dev_server's
+		## fixed 500ms timer races the old shutdown and the new --reload
+		## spawn fails to bind.
+		_wait_for_port_free(port, 5.0)
+	start_dev_server()
+	return killed
 
 
 func start_dev_server() -> void:

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -1059,3 +1059,32 @@ func test_restart_server_btn_enabled_when_managed_running() -> void:
 	assert_false(disabled, "Managed server running must enable the button")
 	assert_contains(tooltip, "current source",
 		"Tooltip must explain the button picks up source changes")
+
+
+func test_restart_server_btn_shows_restarting_state_during_dispatch() -> void:
+	## Without "Restarting…" feedback, the user sees a 5s editor freeze
+	## (from _wait_for_port_free) with no acknowledgement of their click.
+	## The flag is set before dispatch and cleared after the spawn timer.
+	var plugin := _RestartDispatchPlugin.new()
+	plugin.has_managed = true
+	_seed_dev_restart_btn(plugin)
+	_dock._dev_restart_btn.text = "Restart Server"
+
+	_dock._server_restart_in_progress = true
+	_dock._update_dev_section_buttons()
+	var mid_text: String = _dock._dev_restart_btn.text
+	var mid_disabled: bool = _dock._dev_restart_btn.disabled
+
+	_dock._server_restart_in_progress = false
+	_dock._update_dev_section_buttons()
+	var post_text: String = _dock._dev_restart_btn.text
+	var post_disabled: bool = _dock._dev_restart_btn.disabled
+
+	_cleanup_dev_restart_btn(plugin)
+	assert_contains(mid_text, "Restarting",
+		"In-flight click must replace label with Restarting…")
+	assert_true(mid_disabled, "In-flight click must disable the button")
+	assert_eq(post_text, "Restart Server",
+		"Once the flag clears, label reverts to Restart Server")
+	assert_false(post_disabled,
+		"Cleared flag with managed server still up must re-enable the button")

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -25,7 +25,8 @@ class _RestartDispatchPlugin extends GodotAiPlugin:
 	var can_restart := false
 	var force_restart_calls := 0
 	var recover_calls := 0
-	var preserve_mode_calls := 0
+	var primary_calls := 0
+	var stop_calls := 0
 	var has_managed := false
 	var dev_running := false
 
@@ -48,9 +49,13 @@ class _RestartDispatchPlugin extends GodotAiPlugin:
 	func is_dev_server_running() -> bool:
 		return dev_running
 
-	func force_restart_server_preserving_mode() -> bool:
-		preserve_mode_calls += 1
+	func force_restart_or_start_dev_server() -> bool:
+		primary_calls += 1
 		return has_managed or dev_running
+
+	func stop_dev_server() -> void:
+		stop_calls += 1
+		dev_running = false
 
 
 var _dock: Node
@@ -962,28 +967,30 @@ func test_log_viewer_tick_keeps_painting_after_buffer_caps_at_max_lines() -> voi
 	panel.free()
 
 
-# --- Restart Server button (dev-mode) -----------------------------------
+# --- Dev-section primary + stop buttons ---------------------------------
 
-func test_restart_server_btn_rendered_in_dev_checkout() -> void:
-	## The button only makes sense for contributors editing Python source —
-	## live in the Setup section's dev branch alongside `_dev_server_btn`.
-	## In a non-dev checkout (release install) the branch isn't entered and
-	## the button must not appear; we skip rather than fake the env.
+func test_dev_buttons_rendered_in_dev_checkout() -> void:
+	## Dev checkout's Setup section gets the primary "Restart Dev Server"
+	## button + the small "✕" stop affordance side-by-side. In a non-dev
+	## checkout (release install) the branch isn't entered and neither
+	## button appears; we skip rather than fake the env.
 	if not McpClientConfigurator.is_dev_checkout():
 		skip("only meaningful in dev checkout")
 		return
 	_dock._build_ui()
 	_dock._refresh_setup_status()
-	assert_true(_dock._dev_restart_btn != null,
-		"Dev checkout must render the Restart Server button in the Setup section")
-	assert_eq(_dock._dev_restart_btn.text, "Restart Server")
+	assert_true(_dock._dev_primary_btn != null,
+		"Dev checkout must render the primary button in the Setup section")
+	assert_true(_dock._dev_stop_btn != null,
+		"Dev checkout must render the stop button alongside the primary")
+	assert_eq(_dock._dev_stop_btn.text, "✕",
+		"Stop button uses the compact ✕ glyph")
 
 
-func test_restart_server_btn_visibility_follows_dev_mode_toggle() -> void:
-	## The button lives inside `_setup_section`, whose visibility is driven
-	## by `_apply_dev_mode_visibility`. With Developer mode off in a dev
-	## checkout the section hides — taking the button with it — which is the
-	## "ON + dev checkout" gate the task requires.
+func test_dev_buttons_visibility_follows_dev_mode_toggle() -> void:
+	## Buttons live inside `_setup_section`, whose visibility is driven by
+	## `_apply_dev_mode_visibility`. With Developer mode off in a dev
+	## checkout the section hides — taking both buttons with it.
 	if not McpClientConfigurator.is_dev_checkout():
 		skip("only meaningful in dev checkout")
 		return
@@ -993,98 +1000,138 @@ func test_restart_server_btn_visibility_follows_dev_mode_toggle() -> void:
 	_dock._refresh_setup_status()
 	assert_true(_dock._setup_section.visible,
 		"precondition: dev toggle on must show the Setup section")
-	assert_true(_dock._dev_restart_btn != null,
-		"Restart Server button must be in the Setup section when dev toggle is on")
+	assert_true(_dock._dev_primary_btn != null,
+		"Primary button must be in the Setup section when dev toggle is on")
+	assert_true(_dock._dev_stop_btn != null,
+		"Stop button must be in the Setup section when dev toggle is on")
 
 	_dock._dev_mode_toggle.button_pressed = false
 	_dock._apply_dev_mode_visibility()
-	## In dev checkout with toggle off, the section hides but its children
-	## (including the button) remain in the tree — the gate is the section's
-	## visibility, not whether the button was constructed.
 	assert_false(_dock._setup_section.visible,
-		"dev toggle off must hide the Setup section, hiding the Restart Server button")
+		"dev toggle off must hide the Setup section, hiding both dev buttons")
 
 
 ## Mirrors `_seed_server_row` / `_cleanup_server_row`: stand up just enough
-## of the dock for the per-frame restart-button helpers to run without a
-## full `_build_ui` pass.
-func _seed_dev_restart_btn(plugin: _RestartDispatchPlugin) -> void:
+## of the dock for the per-frame button helpers to run without a full
+## `_build_ui` pass.
+func _seed_dev_buttons(plugin: _RestartDispatchPlugin) -> void:
 	_dock._plugin = plugin
-	_dock._dev_restart_btn = Button.new()
+	_dock._dev_primary_btn = Button.new()
+	_dock._dev_stop_btn = Button.new()
 
 
-func _cleanup_dev_restart_btn(plugin: _RestartDispatchPlugin) -> void:
-	_dock._dev_restart_btn.free()
-	_dock._dev_restart_btn = null
+func _cleanup_dev_buttons(plugin: _RestartDispatchPlugin) -> void:
+	_dock._dev_primary_btn.free()
+	_dock._dev_primary_btn = null
+	_dock._dev_stop_btn.free()
+	_dock._dev_stop_btn = null
 	_dock._plugin = null
 	plugin.free()
 
 
-func test_restart_server_btn_dispatches_to_force_restart_preserving_mode() -> void:
+func test_primary_btn_dispatches_to_force_restart_or_start() -> void:
 	var plugin := _RestartDispatchPlugin.new()
 	plugin.has_managed = true
-	_seed_dev_restart_btn(plugin)
+	_seed_dev_buttons(plugin)
 
-	_dock._on_dev_restart_pressed()
-	var calls: int = plugin.preserve_mode_calls
+	_dock._on_dev_primary_pressed()
+	var calls: int = plugin.primary_calls
 
-	_cleanup_dev_restart_btn(plugin)
+	_cleanup_dev_buttons(plugin)
 	assert_eq(calls, 1,
-		"Click must call force_restart_server_preserving_mode exactly once")
+		"Click must call force_restart_or_start_dev_server exactly once")
 
 
-func test_restart_server_btn_disabled_when_nothing_running() -> void:
+func test_stop_btn_dispatches_to_stop_dev_server() -> void:
 	var plugin := _RestartDispatchPlugin.new()
-	_seed_dev_restart_btn(plugin)
+	plugin.dev_running = true
+	_seed_dev_buttons(plugin)
 
-	_dock._update_dev_restart_btn()
-	var disabled: bool = _dock._dev_restart_btn.disabled
-	var tooltip: String = _dock._dev_restart_btn.tooltip_text
+	_dock._on_dev_stop_pressed()
+	var calls: int = plugin.stop_calls
 
-	_cleanup_dev_restart_btn(plugin)
-	assert_true(disabled, "No server running must disable the button")
-	assert_contains(tooltip, "No godot-ai server is running")
+	_cleanup_dev_buttons(plugin)
+	assert_eq(calls, 1, "Stop click must call stop_dev_server exactly once")
 
 
-func test_restart_server_btn_enabled_when_managed_running() -> void:
+func test_primary_btn_label_when_nothing_running() -> void:
+	## Per-frame refresh must reflect the live plugin state. With nothing
+	## running, the primary button is enabled (a click spawns fresh) and
+	## reads "Start Dev Server".
+	var plugin := _RestartDispatchPlugin.new()
+	_seed_dev_buttons(plugin)
+
+	_dock._update_dev_section_buttons()
+	var primary_text: String = _dock._dev_primary_btn.text
+	var primary_disabled: bool = _dock._dev_primary_btn.disabled
+	var stop_disabled: bool = _dock._dev_stop_btn.disabled
+
+	_cleanup_dev_buttons(plugin)
+	assert_eq(primary_text, "Start Dev Server")
+	assert_false(primary_disabled,
+		"Primary stays enabled even with nothing running — click spawns fresh")
+	assert_true(stop_disabled,
+		"Stop has no target when nothing's running — must be disabled")
+
+
+func test_primary_btn_label_when_managed_running() -> void:
 	var plugin := _RestartDispatchPlugin.new()
 	plugin.has_managed = true
-	_seed_dev_restart_btn(plugin)
+	_seed_dev_buttons(plugin)
 
-	_dock._update_dev_restart_btn()
-	var disabled: bool = _dock._dev_restart_btn.disabled
-	var tooltip: String = _dock._dev_restart_btn.tooltip_text
+	_dock._update_dev_section_buttons()
+	var primary_text: String = _dock._dev_primary_btn.text
+	var stop_disabled: bool = _dock._dev_stop_btn.disabled
 
-	_cleanup_dev_restart_btn(plugin)
-	assert_false(disabled, "Managed server running must enable the button")
-	assert_contains(tooltip, "current source",
-		"Tooltip must explain the button picks up source changes")
+	_cleanup_dev_buttons(plugin)
+	assert_eq(primary_text, "Restart Dev Server",
+		"Managed running means click will kill+respawn — label says Restart")
+	assert_true(stop_disabled,
+		"Stop button intentionally never targets the managed server")
 
 
-func test_restart_server_btn_shows_restarting_state_during_dispatch() -> void:
+func test_primary_btn_label_when_dev_running() -> void:
+	var plugin := _RestartDispatchPlugin.new()
+	plugin.dev_running = true
+	_seed_dev_buttons(plugin)
+
+	_dock._update_dev_section_buttons()
+	var primary_text: String = _dock._dev_primary_btn.text
+	var stop_disabled: bool = _dock._dev_stop_btn.disabled
+
+	_cleanup_dev_buttons(plugin)
+	assert_eq(primary_text, "Restart Dev Server")
+	assert_false(stop_disabled,
+		"Dev server running means Stop has a target — must be enabled")
+
+
+func test_primary_btn_shows_restarting_state_during_dispatch() -> void:
 	## Without "Restarting…" feedback, the user sees a 5s editor freeze
 	## (from _wait_for_port_free) with no acknowledgement of their click.
 	## The flag is set before dispatch and cleared after the spawn timer.
 	var plugin := _RestartDispatchPlugin.new()
 	plugin.has_managed = true
-	_seed_dev_restart_btn(plugin)
-	_dock._dev_restart_btn.text = "Restart Server"
+	_seed_dev_buttons(plugin)
+	_dock._dev_primary_btn.text = "Restart Dev Server"
 
 	_dock._server_restart_in_progress = true
 	_dock._update_dev_section_buttons()
-	var mid_text: String = _dock._dev_restart_btn.text
-	var mid_disabled: bool = _dock._dev_restart_btn.disabled
+	var mid_text: String = _dock._dev_primary_btn.text
+	var mid_disabled: bool = _dock._dev_primary_btn.disabled
+	var stop_disabled_during: bool = _dock._dev_stop_btn.disabled
 
 	_dock._server_restart_in_progress = false
 	_dock._update_dev_section_buttons()
-	var post_text: String = _dock._dev_restart_btn.text
-	var post_disabled: bool = _dock._dev_restart_btn.disabled
+	var post_text: String = _dock._dev_primary_btn.text
+	var post_disabled: bool = _dock._dev_primary_btn.disabled
 
-	_cleanup_dev_restart_btn(plugin)
+	_cleanup_dev_buttons(plugin)
 	assert_contains(mid_text, "Restarting",
 		"In-flight click must replace label with Restarting…")
-	assert_true(mid_disabled, "In-flight click must disable the button")
-	assert_eq(post_text, "Restart Server",
-		"Once the flag clears, label reverts to Restart Server")
+	assert_true(mid_disabled, "In-flight click must disable the primary button")
+	assert_true(stop_disabled_during,
+		"Stop must also disable while a restart is in flight")
+	assert_eq(post_text, "Restart Dev Server",
+		"Once the flag clears, primary label reverts")
 	assert_false(post_disabled,
-		"Cleared flag with managed server still up must re-enable the button")
+		"Cleared flag with managed server still up must re-enable the primary")

--- a/test_project/tests/test_dock_dev_server_btn.gd
+++ b/test_project/tests/test_dock_dev_server_btn.gd
@@ -1,12 +1,11 @@
 @tool
 extends McpTestSuite
 
-## Tests for McpDock._dev_server_btn_state — the three-state label/tooltip
-## for the dev-server toggle button. Before this fix, the button only keyed
-## on is_dev_server_running() (which returns false when the plugin's own
-## managed server is up), so it said "Start Dev Server" while actually
-## replacing the managed server with a --reload one. See Windows friction
-## from #159/#147 live testing.
+## Truth-table tests for McpDock's static dev-section button helpers:
+##  - `_dev_primary_btn_state(has_managed, dev_running)` — adapts the
+##    "Restart Dev Server" / "Start Dev Server" label + tooltip.
+##  - `_dev_stop_btn_state(dev_running)` — gates the "✕" stop affordance.
+## Static helpers so the truth table can be verified without a real plugin.
 
 const McpDockScript = preload("res://addons/godot_ai/mcp_dock.gd")
 
@@ -15,54 +14,51 @@ func suite_name() -> String:
 	return "dock_dev_server_btn"
 
 
-func test_state_managed_server_running() -> void:
-	var state: Dictionary = McpDockScript._dev_server_btn_state(true, false)
-	assert_contains(state["text"], "Switch to dev mode", "Managed-running state must not say 'Start'")
-	assert_contains(state["tooltip"], "replaces it", "Tooltip must disclose that the managed server is replaced")
+# --- _dev_primary_btn_state ---------------------------------------------
+
+func test_primary_label_says_restart_when_managed_running() -> void:
+	var state: Dictionary = McpDockScript._dev_primary_btn_state(true, false)
+	assert_eq(state["text"], "Restart Dev Server",
+		"Managed running means click will kill+respawn — label says Restart")
+	assert_contains(state["tooltip"], "Kill",
+		"Tooltip discloses the kill+respawn action")
 
 
-func test_state_foreign_dev_server_running() -> void:
-	var state: Dictionary = McpDockScript._dev_server_btn_state(false, true)
-	assert_contains(state["text"], "Exit dev mode")
-	assert_contains(state["tooltip"], "external dev server")
+func test_primary_label_says_restart_when_dev_running() -> void:
+	var state: Dictionary = McpDockScript._dev_primary_btn_state(false, true)
+	assert_eq(state["text"], "Restart Dev Server",
+		"Dev server running means click will kill+respawn — label says Restart")
+	assert_contains(state["tooltip"], "Kill")
 
 
-func test_state_nothing_running() -> void:
-	var state: Dictionary = McpDockScript._dev_server_btn_state(false, false)
-	assert_eq(state["text"], "Start dev server")
-	assert_contains(state["tooltip"], "--reload")
+func test_primary_label_says_start_when_nothing_running() -> void:
+	var state: Dictionary = McpDockScript._dev_primary_btn_state(false, false)
+	assert_eq(state["text"], "Start Dev Server",
+		"Nothing running means click is a fresh spawn — label adapts to Start")
+	assert_contains(state["tooltip"], "--reload",
+		"Tooltip explains the dev-server flavor")
 
 
-func test_state_both_true_prefers_managed() -> void:
-	## Defensive: if both signals are somehow true (shouldn't happen given the
-	## is_dev_server_running() definition — it requires _server_pid <= 0 — but
-	## don't let the UI lie if it does). Managed wins, so clicking swaps rather
-	## than claiming to "exit" a dev server that the user's managed server
-	## would actually replace.
-	var state: Dictionary = McpDockScript._dev_server_btn_state(true, true)
-	assert_contains(state["text"], "Switch to dev mode")
+func test_primary_label_prefers_restart_when_both_signals_true() -> void:
+	## Defensive: is_dev_server_running()'s definition makes this combo
+	## impossible (it requires _server_pid <= 0), but if it ever lands the
+	## UI must read as Restart, not Start.
+	var state: Dictionary = McpDockScript._dev_primary_btn_state(true, true)
+	assert_eq(state["text"], "Restart Dev Server")
 
 
-## --- _restart_server_btn_state -----------------------------------------
+# --- _dev_stop_btn_state ------------------------------------------------
 
-func test_restart_btn_enabled_when_managed_server_running() -> void:
-	var state: Dictionary = McpDockScript._restart_server_btn_state(true, false)
+func test_stop_btn_enabled_when_dev_running() -> void:
+	var state: Dictionary = McpDockScript._dev_stop_btn_state(true)
 	assert_eq(state["enabled"], true,
-		"Managed server running must enable the Restart Server button")
-	assert_contains(state["tooltip"], "current source",
-		"Tooltip must explain the button picks up source changes")
+		"Stop button enables only when there's a dev server to kill")
+	assert_contains(state["tooltip"], "Stop")
 
 
-func test_restart_btn_enabled_when_dev_server_running() -> void:
-	var state: Dictionary = McpDockScript._restart_server_btn_state(false, true)
-	assert_eq(state["enabled"], true,
-		"External --reload dev server running must enable the Restart Server button")
-	assert_contains(state["tooltip"], "current source")
-
-
-func test_restart_btn_disabled_when_nothing_running() -> void:
-	var state: Dictionary = McpDockScript._restart_server_btn_state(false, false)
+func test_stop_btn_disabled_when_no_dev_server() -> void:
+	var state: Dictionary = McpDockScript._dev_stop_btn_state(false)
 	assert_eq(state["enabled"], false,
-		"With no godot-ai server on the port, the button must be disabled")
-	assert_contains(state["tooltip"], "No godot-ai server is running",
-		"Disabled tooltip must explain why so the user isn't left guessing")
+		"No dev server means nothing to stop — button stays disabled")
+	assert_contains(state["tooltip"], "No --reload",
+		"Tooltip explains why so the user isn't left guessing")


### PR DESCRIPTION
## Summary

Follow-up to [#406](https://github.com/hi-godot/godot-ai/pull/406), based on live testing feedback after that PR merged. Four commits on top of beta:

1. **Show "Restarting…" feedback while a restart is in flight.** Without this the user clicks Restart and sees a 5s editor freeze (from `_wait_for_port_free`) with no acknowledgement. Mirrors the existing `_crash_restart_btn` / `_version_restart_btn` pattern: set `_server_restart_in_progress` on click, dispatch via `call_deferred` + 0.15s paint window, clear after the spawn lands. `_update_dev_section_buttons` shows "Restarting…" disabled while the flag is set.

2. **Consolidate the dev-section to one primary "Restart Dev Server" + small "✕" stop button.** Drops the previous `_dev_server_btn` (3-state Switch / Exit / Start toggle) and the disabled-when-nothing-running second Restart button. Primary's label adapts: "Start Dev Server" when nothing's running, "Restart Dev Server" otherwise. Click always lands in `--reload` mode. ✕ stops without respawning.

3. **Aggressive port takeover in `force_restart_or_start_dev_server`.** The user clicking Restart is explicit consent to take over `:8000`, so the kill arm now runs whenever `_is_port_in_use(port)` is true — covers orphaned `multiprocessing.spawn` uvicorn workers whose parent reloader died and brand detection misses.

4. **Parent-walk in `_pid_cmdline_is_godot_ai` + drop dock mode-override dropdown + delete a stale debug test file.**
   - The newly-spawned `--reload` server's LISTEN holder is the multiprocessing worker (no `godot_ai` brand on its own cmdline). Walks up to depth 5 so a worker whose parent reloader IS branded gets recognised. Adds `_pid_parent` (POSIX `ps -o ppid=`, Windows PowerShell CIM).
   - The "Mode override" dropdown in the dev section advertised toggling between local-repo and installed-ZIP plugin versions but didn't actually do that. Drops the UI; the `GODOT_AI_MODE` env var still works (and is still tested).

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `pytest -q` — 899 passed
- [x] `godot --headless --import` — no GDScript parse errors
- [x] GDScript suites against live worktree editor: 51 dock + 6 dock_dev_server_btn + 91 clients all pass
- [x] Live click smoke: orphan worker on :8000 → click Restart Dev Server → "Restarting…" → orphan killed → fresh `--reload` server PID 7629 spawned (confirmed via `lsof`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
