### PR TITLE
Address Copilot review on #408: post-await guard + ellipsis consistency

### DIFF
--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -1355,10 +1355,14 @@ func _on_dev_stop_pressed() -> void:
 
 
 func _perform_dev_restart_after_feedback() -> void:
-	## Brief paint cycle so the user sees "Restarting…" before the
+	## Brief paint cycle so the user sees "Restarting..." before the
 	## blocking _wait_for_port_free freezes the editor for up to 5s.
 	await get_tree().create_timer(0.15).timeout
-	if _plugin != null:
+	## Re-check has_method post-await — a self-update mixed-state window
+	## could swap _plugin's script class while we were sleeping, leaving
+	## the old reference pointing at a class that no longer carries the
+	## new method. Same #168 guard pattern as _update_dev_section_buttons.
+	if _plugin != null and _plugin.has_method("force_restart_or_start_dev_server"):
 		_plugin.force_restart_or_start_dev_server()
 	## start_dev_server's spawn happens via a 0.5s SceneTree timer; give
 	## it time to land plus a buffer for the WS reconnect before clearing
@@ -1385,8 +1389,8 @@ func _update_dev_section_buttons() -> void:
 	if _dev_primary_btn != null:
 		if _server_restart_in_progress:
 			_dev_primary_btn.disabled = true
-			_dev_primary_btn.text = "Restarting…"
-			_dev_primary_btn.tooltip_text = "Killing the current server and respawning…"
+			_dev_primary_btn.text = "Restarting..."
+			_dev_primary_btn.tooltip_text = "Killing the current server and respawning..."
 		else:
 			var primary_state := _dev_primary_btn_state(has_managed, dev_running)
 			_dev_primary_btn.disabled = false


### PR DESCRIPTION
## Summary

Single-commit follow-up to address Copilot's two findings on [#408](https://github.com/hi-godot/godot-ai/pull/408), which merged before the fix landed:

1. **Post-`await` guard in `_perform_dev_restart_after_feedback`.** The 0.15s `await` between flag-set and dispatch is a window where a self-update mixed-state could swap `_plugin`'s script class. Re-check `_plugin.has_method("force_restart_or_start_dev_server")` after the `await`, mirroring the `#168` guard pattern used elsewhere in the dock.

2. **Ellipsis consistency.** The dev primary button used `"Restarting…"` (Unicode ellipsis) while the rest of the dock — `_crash_restart_btn`, `_version_restart_btn`, the status-text `"Restarting server..."` — uses `"Restarting..."` (three ASCII dots). Standardise on the three-dot form for the dev primary's label and tooltip.

Tests assert on the substring `"Restarting"` so they're unaffected.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `pytest -q` — 899 passed
- [x] `godot --headless --import` — no GDScript parse errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
