### PR TITLE
Implement #399 Step 1: deny-by-default self-update parse-hazard lint

### DIFF
--- a/tests/unit/test_plugin_self_update_safety.py
+++ b/tests/unit/test_plugin_self_update_safety.py
@@ -1,48 +1,62 @@
-"""Lock the self-update parse-hazard policy on targeted plugin-load scripts.
+"""Lock the self-update parse-hazard policy across the plugin load surface.
 
-Issue #242 surfaced as `v2.1.1 → v2.1.2` SIGABRT during in-place self-update:
-v2.1.2's `plugin.gd` declared `var _editor_log_buffer: EditorLogBuffer` —
-a typed-var against a brand-new `class_name` introduced in the same
-release. During `_install_update`'s extract → `set_plugin_enabled(false)`
-path the parser hits the typed-var BEFORE the new class_name has been
-registered in the global table → `plugin.gd` parse fails → plugin enters
-a degraded state → the follow-up `_exit_tree` cascade crashes.
+Issue #242 surfaced as `v2.1.1 -> v2.1.2` SIGABRT during in-place
+self-update: v2.1.2's `plugin.gd` declared `var _editor_log_buffer:
+EditorLogBuffer` -- a typed-var against a brand-new `class_name`
+introduced in the same release. During `_install_update`'s extract ->
+`set_plugin_enabled(false)` path the parser hits the typed-var BEFORE the
+new class_name has been registered in the global table -> `plugin.gd`
+parse fails -> plugin enters a degraded state -> the follow-up
+`_exit_tree` cascade crashes.
 
 Issue #244 is the defense-in-depth follow-up: any name reference from
-plugin load-path code to a plugin-defined `Mcp*` class is the same
-latent hazard. The hazard has three syntactic forms, all of which
-resolve through the global class_name registry at parse time:
+plugin load-path code to a plugin-defined `Mcp*` class is the same latent
+hazard. The hazard has four syntactic forms, all of which resolve through
+the global class_name registry at parse time:
 
-    var x: McpFoo                  # typed-var
+    var x: McpFoo                  # typed-var (top-level field)
+    func f(x: McpFoo):             # typed-parameter
     McpFoo.new()                   # constructor
-    McpFoo.SOME_CONST              # constant / static-method access
+    McpFoo.SOME_CONST              # constant access
+    McpFoo.some_method(...)        # static-method access
 
-The third form is especially risky in a static-var initializer:
+The constant/method form is especially risky in a static-var initializer:
 `static var _x := McpFoo.BAR` runs at script-load, so a failed lookup
 aborts the parse before `_enter_tree` runs and surfaces as Godot's
-"Unable to load addon script" warning. Even if today's inheritance is
-stable, a future refactor that changes one class's `extends` chain or
-adds a sibling class_name file re-trips the bug — and review won't
-catch it because the named references *look* idiomatic.
+"Unable to load addon script" warning.
 
 The structurally correct answer is "plugin load-path code does NOT name
 plugin classes directly." Field types fall through to the runtime
 parameter checks at handler `_init` sites that take typed parameters
 (see e.g. `McpEditorHandler._init`'s typed
-`editor_log_buffer: McpEditorLogBuffer` parameter — the type fence still
+`editor_log_buffer: McpEditorLogBuffer` parameter -- the type fence still
 fires, just at the call site at runtime, not at `plugin.gd`'s parse).
 Constructors, constants, and static methods go through script-local
 `const X := preload("res://...")` aliases (e.g. `Connection`,
-`Dispatcher`, `LogBuffer`, `ClientConfigurator`,
-`WindowsPortReservation`); `preload(...)` resolves the script by path
-at script-load and never consults the registry.
+`Dispatcher`, `LogBuffer`); `preload(...)` resolves the script by path at
+script-load and never consults the registry.
 
-This test enforces the existing typed-var / constructor policy on
-`plugin.gd`, and the new constructor / member-access policy on the
-targeted beta load surface touched by the PR #309 adaptation. It does
-not claim the full transitive `plugin.gd` preload graph is clean yet;
-that broader cleanup belongs with the ongoing #297 decomposition work.
-Offenders fail with a paste-over-ready list.
+## Layered enforcement
+
+Issue #399 inverted the original targeted-allowlist approach to
+deny-by-default. The audit data (`script/audit-self-update-load-surface`,
+since absorbed here) showed that 97 of 102 `.gd` files in the addon tree
+are reachable from `plugin.gd`'s preload + `class_name` graph; only 5 are
+genuinely off the load surface (game-side or test-only). A targeted
+allowlist for the other 92 was tracking ~13% of the actual hazard surface.
+
+This module therefore enforces the policy as a single deny-by-default
+scan over the entire addon tree (minus the 5 off-surface files). The
+violation count is ratcheted via `BASELINE_VIOLATION_COUNT`: the test
+fails when the count climbs above the baseline (regression) AND when it
+drops below (developer must lower the baseline so the fix is locked in).
+The end state is `BASELINE_VIOLATION_COUNT == 0`, achieved across the
+remaining steps of #399.
+
+The original targeted-allowlist tests are removed -- the deny-by-default
+scan strictly subsumes them. `plugin.gd` and the previously-allowlisted
+files are still scanned, just as part of the full closure rather than a
+hand-maintained subset.
 """
 
 from __future__ import annotations
@@ -54,40 +68,66 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 PLUGIN_ROOT = REPO_ROOT / "plugin" / "addons" / "godot_ai"
 PLUGIN_GD = PLUGIN_ROOT / "plugin.gd"
 
-# Beta #297 moved plugin-owned startup/update work into these scripts.
-# This is intentionally the targeted PR #309 adaptation surface plus the
-# PR 9 depth-1 infrastructure follow-up, not a broad cleanup of every
-# direct/transitive preload such as handlers or client strategy scripts.
+# The five `.gd` files that are genuinely off the self-update load
+# surface, per the #399 audit. Each is either game-side (runs in the
+# game subprocess, not the editor process where self-update happens) or
+# test-only (loaded by the test runner, not by `plugin.gd`'s preload
+# graph). Bare `Mcp*` references in these files cannot trip the
+# self-update parse hazard because their parse never overlaps the
+# disable -> extract -> enable window in the editor.
 #
-# Issue #398 extended the list to the five files that emitted parse
-# errors during a real `v2.3.2 → v2.4.0` self-update — the audit-v2
-# regression that landed new `class_name` members behind bare-class_name
-# references. The structurally correct expansion (deny-by-default across
-# the whole load surface) is tracked in #399.
-TARGETED_LOAD_SURFACE_FILES = (
-    PLUGIN_GD,
-    PLUGIN_ROOT / "utils" / "server_lifecycle.gd",
-    PLUGIN_ROOT / "utils" / "port_resolver.gd",
-    PLUGIN_ROOT / "utils" / "update_manager.gd",
-    PLUGIN_ROOT / "utils" / "update_mixed_state.gd",
-    PLUGIN_ROOT / "connection.gd",
-    PLUGIN_ROOT / "dispatcher.gd",
-    PLUGIN_ROOT / "mcp_dock.gd",
-    PLUGIN_ROOT / "client_configurator.gd",
-    PLUGIN_ROOT / "dock_panels" / "log_viewer.gd",
-    PLUGIN_ROOT / "handlers" / "_node_validator.gd",
-    PLUGIN_ROOT / "handlers" / "animation_presets.gd",
-    PLUGIN_ROOT / "handlers" / "animation_values.gd",
+# Keep this list short and stable -- it is the single deny-by-default
+# escape hatch. Any new entry needs a concrete justification (the file
+# is provably outside the editor-process load graph) and a comment
+# below recording why.
+OFF_LOAD_SURFACE = frozenset(
+    {
+        # Game subprocess: spawned by play-in-editor, parsed by the game
+        # binary, not the editor's plugin loader.
+        "runtime/editor_logger.gd",
+        "runtime/game_helper.gd",
+        "runtime/game_logger.gd",
+        # Test-only: loaded by the GDScript test runner, never by
+        # plugin.gd's preload graph or the global class_name registry
+        # consulted at editor parse time.
+        "testing/stub_backtrace.gd",
+        "utils/log_backtrace.gd",
+    }
 )
+
+# Ratchet target for the deny-by-default scan. Recorded against
+# `origin/beta` at the time #399 Step 1 landed. Lower this when fixes
+# land; raising it requires explicit justification and is the signal
+# that a regression slipped through review.
+#
+# End state: 0. Steps 2 and 3 of #399 drive this down.
+BASELINE_VIOLATION_COUNT = 1258
+
+
+_CLASS_NAME_RE = re.compile(r"^class_name\s+(Mcp\w+)\s*$", re.MULTILINE)
+# Top-level typed-var fields. Anchored to start-of-line; locals inside
+# functions are resolved lazily and don't participate in the parse-time
+# hazard.
+_TYPED_FIELD_RE = re.compile(r"^\s*(?:static\s+)?var\s+\w+\s*:\s*(Mcp\w+)\b", re.MULTILINE)
+# Any `name: McpFoo` typed annotation (parameters, locals with type, etc.).
+# Note this overlaps with TYPED_FIELD_RE for top-level vars -- both
+# patterns count, mirroring the audit script's accounting so the baseline
+# is a stable reproducible number.
+_TYPED_PARAM_RE = re.compile(r"\b\w+\s*:\s*(Mcp\w+)\b")
+_CONSTRUCTOR_RE = re.compile(r"\b(Mcp\w+)\s*\.\s*new\s*\(")
+# Member access: any identifier after `Mcp*.`, not just uppercase consts.
+# The earlier audit only matched `[A-Z_]+` and missed method calls -- a
+# `Mcp*.method()` invocation has the exact same parse-time class_name
+# lookup as `Mcp*.CONST`. Constructors are excluded (they have their own
+# bucket above) so a single site doesn't double-count.
+_MEMBER_ACCESS_RE = re.compile(r"\b(Mcp\w+)\s*\.\s*(\w+)\b")
 
 
 def _registered_mcp_class_names() -> set[str]:
     """Every `class_name McpFoo` declared anywhere in the addon tree."""
-
-    pattern = re.compile(r"^class_name\s+(Mcp\w+)\s*$", re.MULTILINE)
     found: set[str] = set()
     for gd_file in PLUGIN_ROOT.rglob("*.gd"):
-        found.update(pattern.findall(gd_file.read_text(encoding="utf-8")))
+        found.update(_CLASS_NAME_RE.findall(gd_file.read_text(encoding="utf-8")))
     return found
 
 
@@ -96,160 +136,134 @@ def _strip_gdscript_comments(source: str) -> str:
 
     The parse hazard only fires for executable references; comments that
     happen to mention `McpConnection` or include `class_name McpFoo` in
-    explanatory prose are not parsed as identifiers and must not trip the
-    lint. Anchored on `#` start so we don't break legitimate code that
-    happens to contain a `#` inside a string literal — `plugin.gd` has
-    none today, and adding one would already be a code-smell worth
-    flagging.
+    explanatory prose are not parsed as identifiers and must not trip
+    the lint.
     """
-
     return re.sub(r"#.*$", "", source, flags=re.MULTILINE)
 
 
-def test_targeted_load_scripts_have_no_typed_fields_against_plugin_class_names() -> None:
-    """Targeted load-path field declarations must not type-bind to `Mcp*`.
+def _scan_file(gd_file: Path, registered: set[str]) -> list[tuple[int, str, str]]:
+    """Return `(line_no, kind, identifier)` tuples for offending sites.
 
-    See module docstring for the parse-hazard mechanism. Untype the field;
-    keep the type fence on handler `_init` parameters.
+    A file's own declared `class_name` is excluded from `registered`
+    locally, since a class can safely reference its own constants and
+    static methods (they resolve through `self`'s script, not the global
+    registry).
     """
+    raw = gd_file.read_text(encoding="utf-8")
+    src = _strip_gdscript_comments(raw)
+    own = set(_CLASS_NAME_RE.findall(src))
+    in_scope = registered - own
 
-    mcp_classes = _registered_mcp_class_names()
-    assert mcp_classes, (
+    offenders: list[tuple[int, str, str]] = []
+
+    def _add(match: re.Match[str], kind: str, ident: str) -> None:
+        line_no = src.count("\n", 0, match.start()) + 1
+        offenders.append((line_no, kind, ident))
+
+    for match in _TYPED_FIELD_RE.finditer(src):
+        name = match.group(1)
+        if name in in_scope:
+            _add(match, "typed_field", f"var: {name}")
+
+    for match in _TYPED_PARAM_RE.finditer(src):
+        name = match.group(1)
+        if name in in_scope:
+            _add(match, "typed_param", f": {name}")
+
+    for match in _CONSTRUCTOR_RE.finditer(src):
+        name = match.group(1)
+        if name in in_scope:
+            _add(match, "constructor", f"{name}.new")
+
+    for match in _MEMBER_ACCESS_RE.finditer(src):
+        name, member = match.group(1), match.group(2)
+        if member == "new":
+            continue  # owned by constructor bucket above
+        if name in in_scope:
+            _add(match, "member_access", f"{name}.{member}")
+
+    return offenders
+
+
+def _load_surface_files() -> list[Path]:
+    """All `.gd` under the addon tree, minus the off-surface opt-outs."""
+    files: list[Path] = []
+    for gd in PLUGIN_ROOT.rglob("*.gd"):
+        rel = gd.relative_to(PLUGIN_ROOT).as_posix()
+        if rel in OFF_LOAD_SURFACE:
+            continue
+        files.append(gd)
+    return sorted(files)
+
+
+def test_self_update_parse_hazard_baseline_ratchet() -> None:
+    """Deny-by-default lint of the self-update load surface (#399).
+
+    Scans every `.gd` under `plugin/addons/godot_ai/` (minus
+    `OFF_LOAD_SURFACE`) for the four syntactic forms of the
+    parse-hazard: typed-var, typed-param, `Mcp*.new(...)`, and
+    `Mcp*.<identifier>` member access. Total violations must be
+    `<= BASELINE_VIOLATION_COUNT`.
+
+    When the count rises, the failure prints a paste-over-ready offender
+    list -- the regression is somewhere in those new lines.
+
+    When the count drops, the failure asks the developer to lower
+    `BASELINE_VIOLATION_COUNT` to the new value. This is the ratchet:
+    fixes get locked in so they cannot silently regress later.
+
+    End state: `BASELINE_VIOLATION_COUNT == 0`.
+    """
+    registered = _registered_mcp_class_names()
+    assert registered, (
         "Sanity check: expected to find Mcp* class_name declarations in the addon tree"
     )
 
-    # Match top-level `var _foo: McpBar` (with or without trailing `=` /
-    # ` # comment`). Anchored to start-of-line so we don't catch local
-    # vars inside functions, which the parser resolves lazily and which
-    # are not part of the parse-time hazard.
-    typed_field = re.compile(r"^var\s+(\w+)\s*:\s*(Mcp\w+)\b", re.MULTILINE)
-    offenders: list[str] = []
+    all_offenders: list[tuple[Path, int, str, str]] = []
+    for gd_file in _load_surface_files():
+        for line_no, kind, ident in _scan_file(gd_file, registered):
+            all_offenders.append((gd_file, line_no, kind, ident))
 
-    for gd_file in TARGETED_LOAD_SURFACE_FILES:
-        source = _strip_gdscript_comments(gd_file.read_text(encoding="utf-8"))
-        for match in typed_field.finditer(source):
-            field_name, type_name = match.group(1), match.group(2)
-            if type_name not in mcp_classes:
-                continue
-            line_no = source.count("\n", 0, match.start()) + 1
-            rel_path = gd_file.relative_to(REPO_ROOT)
-            offenders.append(f"{rel_path}:{line_no}: var {field_name}: {type_name}")
+    total = len(all_offenders)
 
-    assert not offenders, (
-        "Targeted load-path scripts must not declare typed fields against plugin class_names "
-        "(self-update parse hazard, issues #242 / #244). Untype the field "
-        "and rely on the typed handler `_init` parameters for the type "
-        f"fence. Offending declarations: {offenders}"
-    )
+    if total > BASELINE_VIOLATION_COUNT:
+        all_offenders.sort(key=lambda t: (t[0].relative_to(REPO_ROOT).as_posix(), t[1]))
+        lines = [
+            f"  {p.relative_to(REPO_ROOT).as_posix()}:{ln}: {kind}: {ident}"
+            for p, ln, kind, ident in all_offenders
+        ]
+        listing = "\n".join(lines)
+        raise AssertionError(
+            f"Self-update parse-hazard violations regressed: {total} sites "
+            f"(baseline {BASELINE_VIOLATION_COUNT}). New bare `Mcp*` "
+            "references slipped into the addon load surface. Either route "
+            "the reference through a script-local `const X := preload("
+            '"res://addons/godot_ai/...")` alias, or (only if the file is '
+            "provably off the editor-process load graph) add it to "
+            "OFF_LOAD_SURFACE with justification.\n\n"
+            "Issues: #242 / #244 / #399.\n\n"
+            f"All {total} offending sites:\n{listing}"
+        )
 
-
-def test_plugin_gd_does_not_construct_via_class_name() -> None:
-    """`plugin.gd` must not call `McpFoo.new(...)` on any plugin class.
-
-    Constructor references resolve through the global class_name
-    registry at parse time, so they participate in the same self-update
-    parse hazard as typed-var declarations (#242 / #244). Use a script-
-    local `const Foo := preload("res://addons/godot_ai/...")` alias
-    declared at the top of `plugin.gd` and call `Foo.new(...)` instead.
-    """
-
-    source = _strip_gdscript_comments(PLUGIN_GD.read_text(encoding="utf-8"))
-    mcp_classes = _registered_mcp_class_names()
-
-    constructor = re.compile(r"\b(Mcp\w+)\.new\s*\(")
-    offenders: list[str] = []
-    for match in constructor.finditer(source):
-        type_name = match.group(1)
-        if type_name in mcp_classes:
-            offenders.append(type_name)
-
-    assert not offenders, (
-        "plugin.gd must not invoke plugin-class constructors by class_name "
-        "(self-update parse hazard, issues #242 / #244). Add a script-local "
-        '`const Foo := preload("res://addons/godot_ai/...")` alias at the '
-        "top of plugin.gd and call `Foo.new(...)` instead. Offending "
-        f"references: {sorted(set(offenders))}"
-    )
-
-
-def test_targeted_load_scripts_do_not_construct_via_class_name() -> None:
-    """Targeted load-path scripts must not call `McpFoo.new(...)`.
-
-    The existing constructor test predates the beta #297 extractions and
-    only scans `plugin.gd`. Keep the same guard on the manager scripts
-    this PR touches so future changes do not reintroduce constructor
-    lookups into the targeted startup/update surface.
-    """
-
-    mcp_classes = _registered_mcp_class_names()
-    constructor = re.compile(r"\b(Mcp\w+)\.new\s*\(")
-    offenders: list[str] = []
-
-    for gd_file in TARGETED_LOAD_SURFACE_FILES:
-        source = _strip_gdscript_comments(gd_file.read_text(encoding="utf-8"))
-        for match in constructor.finditer(source):
-            type_name = match.group(1)
-            if type_name not in mcp_classes:
-                continue
-            line_no = source.count("\n", 0, match.start()) + 1
-            rel_path = gd_file.relative_to(REPO_ROOT)
-            offenders.append(f"{rel_path}:{line_no}: {type_name}.new")
-
-    assert not offenders, (
-        "Targeted load-path scripts must not invoke plugin-class "
-        "constructors by class_name (self-update parse hazard, issues "
-        "#242 / #244). Add a script-local "
-        '`const Foo := preload("res://addons/godot_ai/...")` alias and '
-        "call `Foo.new(...)` instead. Offending references: "
-        f"{sorted(set(offenders))}"
-    )
-
-
-def test_targeted_load_scripts_do_not_access_members_via_class_name() -> None:
-    """Targeted load-path scripts must not access `McpFoo.X` directly.
-
-    This is the third syntactic form of the parse hazard. Identifier
-    resolution for `McpFoo` happens at parse time even when only its
-    members are used, so `McpFoo.SOME_CONST` and
-    `McpFoo.static_method()` must route through script-local
-    `preload(...)` aliases. `McpFoo.new()` is skipped here because the
-    targeted constructor test owns that offender list.
-    """
-
-    mcp_classes = _registered_mcp_class_names()
-    member_access = re.compile(r"\b(Mcp\w+)\.(\w+)")
-    offenders: list[str] = []
-
-    for gd_file in TARGETED_LOAD_SURFACE_FILES:
-        source = _strip_gdscript_comments(gd_file.read_text(encoding="utf-8"))
-        for match in member_access.finditer(source):
-            type_name, member = match.group(1), match.group(2)
-            if type_name not in mcp_classes:
-                continue
-            if member == "new":
-                continue
-            line_no = source.count("\n", 0, match.start()) + 1
-            rel_path = gd_file.relative_to(REPO_ROOT)
-            offenders.append(f"{rel_path}:{line_no}: {type_name}.{member}")
-
-    assert not offenders, (
-        "Targeted load-path scripts must not access plugin-class "
-        "constants or static methods via class_name (self-update parse "
-        "hazard, issues #242 / #244). Static-var initializers are the "
-        "most dangerous form: a failed lookup aborts the parse before "
-        "_enter_tree. Add a "
-        'script-local `const Foo := preload("res://addons/godot_ai/...")` '
-        "alias and call `Foo.X` instead. Offending references: "
-        f"{sorted(set(offenders))}"
-    )
+    if total < BASELINE_VIOLATION_COUNT:
+        raise AssertionError(
+            "Self-update parse-hazard violation count dropped from "
+            f"{BASELINE_VIOLATION_COUNT} to {total}. Lower "
+            "BASELINE_VIOLATION_COUNT in this file to "
+            f"{total} to lock in the improvement -- otherwise the next "
+            "regression that re-adds these sites will pass under the "
+            "old baseline. End state is 0; we ratchet there one PR at a "
+            "time (#399 Step 2 onward)."
+        )
 
 
 def test_update_backup_suffix_stays_in_sync() -> None:
     """Build-time anti-drift guard for `update_mixed_state.gd::BACKUP_SUFFIX`.
 
-    Replaces the runtime alias removed for #398 — see `update_mixed_state.gd`.
+    Replaces the runtime alias removed for #398 -- see
+    `update_mixed_state.gd`.
     """
-
     runner = (PLUGIN_ROOT / "update_reload_runner.gd").read_text(encoding="utf-8")
     scanner = (PLUGIN_ROOT / "utils" / "update_mixed_state.gd").read_text(encoding="utf-8")
 
@@ -270,7 +284,7 @@ def test_update_backup_suffix_stays_in_sync() -> None:
     )
     assert scanner_match, (
         'update_mixed_state.gd must declare `const BACKUP_SUFFIX := "..."` as a '
-        "string literal — aliasing via `UpdateReloadRunner.INSTALL_BACKUP_SUFFIX` "
+        "string literal -- aliasing via `UpdateReloadRunner.INSTALL_BACKUP_SUFFIX` "
         "re-introduces the self-update parse hazard (issue #398)."
     )
 
@@ -278,7 +292,7 @@ def test_update_backup_suffix_stays_in_sync() -> None:
         "update_mixed_state.gd::BACKUP_SUFFIX "
         f"({scanner_match.group(1)!r}) drifted from the producer "
         f"update_reload_runner.gd::INSTALL_BACKUP_SUFFIX "
-        f"({runner_match.group(1)!r}). Update both literals in lockstep — they "
+        f"({runner_match.group(1)!r}). Update both literals in lockstep -- they "
         "describe the same on-disk suffix, but the scanner's value is inlined "
         "to avoid the parse hazard fixed in #398."
     )
@@ -292,7 +306,6 @@ def test_plugin_gd_documents_the_untyped_policy() -> None:
     consts, or they will "fix" the apparent oversight and re-introduce
     the hazard.
     """
-
     source = PLUGIN_GD.read_text(encoding="utf-8")
     assert "Self-update parse-hazard policy" in source, (
         "plugin.gd must keep an explanatory comment near the untyped "
@@ -306,7 +319,7 @@ def test_plugin_gd_documents_the_untyped_policy() -> None:
     )
     assert "preload" in source.lower(), (
         "The policy comment must explain that direct references go through "
-        "preload-aliased consts — without that half, a future contributor "
+        "preload-aliased consts -- without that half, a future contributor "
         "may untype a field but still write `McpFoo.new()` or "
         "`McpFoo.CONST`, leaving the parse-time class_name lookup in place."
     )

--- a/tests/unit/test_plugin_self_update_safety.py
+++ b/tests/unit/test_plugin_self_update_safety.py
@@ -36,33 +36,20 @@ Constructors, constants, and static methods go through script-local
 `Dispatcher`, `LogBuffer`); `preload(...)` resolves the script by path at
 script-load and never consults the registry.
 
-## Layered enforcement
+## Enforcement (#399)
 
-Issue #399 inverted the original targeted-allowlist approach to
-deny-by-default. The audit data (`script/audit-self-update-load-surface`,
-since absorbed here) showed that 97 of 102 `.gd` files in the addon tree
-are reachable from `plugin.gd`'s preload + `class_name` graph; only 5 are
-genuinely off the load surface (game-side or test-only). A targeted
-allowlist for the other 92 was tracking ~13% of the actual hazard surface.
-
-This module therefore enforces the policy as a single deny-by-default
-scan over the entire addon tree (minus the 5 off-surface files). The
-violation count is ratcheted via `BASELINE_VIOLATION_COUNT`: the test
-fails when the count climbs above the baseline (regression) AND when it
-drops below (developer must lower the baseline so the fix is locked in).
-The end state is `BASELINE_VIOLATION_COUNT == 0`, achieved across the
-remaining steps of #399.
-
-The original targeted-allowlist tests are removed -- the deny-by-default
-scan strictly subsumes them. `plugin.gd` and the previously-allowlisted
-files are still scanned, just as part of the full closure rather than a
-hand-maintained subset.
+A single deny-by-default scan over every `.gd` under the addon tree
+minus `OFF_LOAD_SURFACE`. The violation count is ratcheted via
+`BASELINE_VIOLATION_COUNT`: regressions raise it (test fails with
+offender list); fixes lower it (test fails until the constant is
+updated, so improvements lock in). End state is 0.
 """
 
 from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import Literal
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PLUGIN_ROOT = REPO_ROOT / "plugin" / "addons" / "godot_ai"
@@ -104,97 +91,93 @@ OFF_LOAD_SURFACE = frozenset(
 BASELINE_VIOLATION_COUNT = 1258
 
 
+Kind = Literal["typed_field", "typed_annotation", "constructor", "member_access"]
+
 _CLASS_NAME_RE = re.compile(r"^class_name\s+(Mcp\w+)\s*$", re.MULTILINE)
 # Top-level typed-var fields. Anchored to start-of-line; locals inside
 # functions are resolved lazily and don't participate in the parse-time
 # hazard.
 _TYPED_FIELD_RE = re.compile(r"^\s*(?:static\s+)?var\s+\w+\s*:\s*(Mcp\w+)\b", re.MULTILINE)
-# Any `name: McpFoo` typed annotation (parameters, locals with type, etc.).
-# Note this overlaps with TYPED_FIELD_RE for top-level vars -- both
-# patterns count, mirroring the audit script's accounting so the baseline
-# is a stable reproducible number.
-_TYPED_PARAM_RE = re.compile(r"\b\w+\s*:\s*(Mcp\w+)\b")
+# Any `name: McpFoo` annotation (params, top-level fields, typed locals).
+# Intentionally overlaps `_TYPED_FIELD_RE` for top-level vars: a single
+# typed field counts in both buckets, matching the original audit's
+# accounting so the baseline is a stable reproducible number rather
+# than a deduplicated one.
+_TYPED_ANNOTATION_RE = re.compile(r"\b\w+\s*:\s*(Mcp\w+)\b")
 _CONSTRUCTOR_RE = re.compile(r"\b(Mcp\w+)\s*\.\s*new\s*\(")
-# Member access: any identifier after `Mcp*.`, not just uppercase consts.
-# The earlier audit only matched `[A-Z_]+` and missed method calls -- a
-# `Mcp*.method()` invocation has the exact same parse-time class_name
-# lookup as `Mcp*.CONST`. Constructors are excluded (they have their own
-# bucket above) so a single site doesn't double-count.
+# Any identifier after `Mcp*.`. `Mcp*.method()` hits the same
+# parse-time class_name lookup as `Mcp*.CONST`. `.new` matches the
+# constructor pattern above and is filtered out so single sites
+# don't double-count.
 _MEMBER_ACCESS_RE = re.compile(r"\b(Mcp\w+)\s*\.\s*(\w+)\b")
 
-
-def _registered_mcp_class_names() -> set[str]:
-    """Every `class_name McpFoo` declared anywhere in the addon tree."""
-    found: set[str] = set()
-    for gd_file in PLUGIN_ROOT.rglob("*.gd"):
-        found.update(_CLASS_NAME_RE.findall(gd_file.read_text(encoding="utf-8")))
-    return found
+_PASSES: tuple[tuple[re.Pattern[str], Kind], ...] = (
+    (_TYPED_FIELD_RE, "typed_field"),
+    (_TYPED_ANNOTATION_RE, "typed_annotation"),
+    (_CONSTRUCTOR_RE, "constructor"),
+    (_MEMBER_ACCESS_RE, "member_access"),
+)
 
 
 def _strip_gdscript_comments(source: str) -> str:
     """Remove `## ...` doc comments and `# ...` line comments.
 
-    The parse hazard only fires for executable references; comments that
-    happen to mention `McpConnection` or include `class_name McpFoo` in
-    explanatory prose are not parsed as identifiers and must not trip
-    the lint.
+    The parse hazard only fires for executable references; mentions of
+    `McpConnection` or `class_name McpFoo` in explanatory prose must
+    not trip the lint.
     """
     return re.sub(r"#.*$", "", source, flags=re.MULTILINE)
 
 
-def _scan_file(gd_file: Path, registered: set[str]) -> list[tuple[int, str, str]]:
-    """Return `(line_no, kind, identifier)` tuples for offending sites.
+def _format_ident(kind: Kind, match: re.Match[str]) -> str | None:
+    """Render an offender's identifier, or None to skip the match."""
+    name = match.group(1)
+    if kind == "typed_field":
+        return f"var: {name}"
+    if kind == "typed_annotation":
+        return f": {name}"
+    if kind == "constructor":
+        return f"{name}.new"
+    member = match.group(2)
+    if member == "new":
+        return None  # owned by the constructor pass
+    return f"{name}.{member}"
 
-    A file's own declared `class_name` is excluded from `registered`
-    locally, since a class can safely reference its own constants and
-    static methods (they resolve through `self`'s script, not the global
-    registry).
+
+def _scan_load_surface() -> tuple[set[str], list[tuple[Path, int, Kind, str]]]:
+    """Walk the load surface in one pass.
+
+    Returns the set of `Mcp*` class names declared anywhere in the addon
+    tree (for sanity-check assertions) and the list of offending sites
+    across the load surface. A file's own `class_name` is excluded from
+    in-scope lookups, since a class can safely reference its own
+    constants and static methods.
     """
-    raw = gd_file.read_text(encoding="utf-8")
-    src = _strip_gdscript_comments(raw)
-    own = set(_CLASS_NAME_RE.findall(src))
-    in_scope = registered - own
+    registered: set[str] = set()
+    surface_sources: list[tuple[Path, str, set[str]]] = []
 
-    offenders: list[tuple[int, str, str]] = []
-
-    def _add(match: re.Match[str], kind: str, ident: str) -> None:
-        line_no = src.count("\n", 0, match.start()) + 1
-        offenders.append((line_no, kind, ident))
-
-    for match in _TYPED_FIELD_RE.finditer(src):
-        name = match.group(1)
-        if name in in_scope:
-            _add(match, "typed_field", f"var: {name}")
-
-    for match in _TYPED_PARAM_RE.finditer(src):
-        name = match.group(1)
-        if name in in_scope:
-            _add(match, "typed_param", f": {name}")
-
-    for match in _CONSTRUCTOR_RE.finditer(src):
-        name = match.group(1)
-        if name in in_scope:
-            _add(match, "constructor", f"{name}.new")
-
-    for match in _MEMBER_ACCESS_RE.finditer(src):
-        name, member = match.group(1), match.group(2)
-        if member == "new":
-            continue  # owned by constructor bucket above
-        if name in in_scope:
-            _add(match, "member_access", f"{name}.{member}")
-
-    return offenders
-
-
-def _load_surface_files() -> list[Path]:
-    """All `.gd` under the addon tree, minus the off-surface opt-outs."""
-    files: list[Path] = []
-    for gd in PLUGIN_ROOT.rglob("*.gd"):
-        rel = gd.relative_to(PLUGIN_ROOT).as_posix()
-        if rel in OFF_LOAD_SURFACE:
+    for gd in sorted(PLUGIN_ROOT.rglob("*.gd")):
+        raw = gd.read_text(encoding="utf-8")
+        own = set(_CLASS_NAME_RE.findall(raw))
+        registered |= own
+        if gd.relative_to(PLUGIN_ROOT).as_posix() in OFF_LOAD_SURFACE:
             continue
-        files.append(gd)
-    return sorted(files)
+        surface_sources.append((gd, _strip_gdscript_comments(raw), own))
+
+    offenders: list[tuple[Path, int, Kind, str]] = []
+    for path, src, own in surface_sources:
+        in_scope = registered - own
+        for pattern, kind in _PASSES:
+            for match in pattern.finditer(src):
+                if match.group(1) not in in_scope:
+                    continue
+                ident = _format_ident(kind, match)
+                if ident is None:
+                    continue
+                line_no = src.count("\n", 0, match.start()) + 1
+                offenders.append((path, line_no, kind, ident))
+
+    return registered, offenders
 
 
 def test_self_update_parse_hazard_baseline_ratchet() -> None:
@@ -215,15 +198,10 @@ def test_self_update_parse_hazard_baseline_ratchet() -> None:
 
     End state: `BASELINE_VIOLATION_COUNT == 0`.
     """
-    registered = _registered_mcp_class_names()
+    registered, all_offenders = _scan_load_surface()
     assert registered, (
         "Sanity check: expected to find Mcp* class_name declarations in the addon tree"
     )
-
-    all_offenders: list[tuple[Path, int, str, str]] = []
-    for gd_file in _load_surface_files():
-        for line_no, kind, ident in _scan_file(gd_file, registered):
-            all_offenders.append((gd_file, line_no, kind, ident))
 
     total = len(all_offenders)
 

--- a/tests/unit/test_plugin_self_update_safety.py
+++ b/tests/unit/test_plugin_self_update_safety.py
@@ -88,21 +88,23 @@ OFF_LOAD_SURFACE = frozenset(
 # that a regression slipped through review.
 #
 # End state: 0. Steps 2 and 3 of #399 drive this down.
-BASELINE_VIOLATION_COUNT = 1258
+BASELINE_VIOLATION_COUNT = 1254
 
 
 Kind = Literal["typed_field", "typed_annotation", "constructor", "member_access"]
 
 _CLASS_NAME_RE = re.compile(r"^class_name\s+(Mcp\w+)\s*$", re.MULTILINE)
-# Top-level typed-var fields. Anchored to start-of-line; locals inside
-# functions are resolved lazily and don't participate in the parse-time
-# hazard.
-_TYPED_FIELD_RE = re.compile(r"^\s*(?:static\s+)?var\s+\w+\s*:\s*(Mcp\w+)\b", re.MULTILINE)
-# Any `name: McpFoo` annotation (params, top-level fields, typed locals).
-# Intentionally overlaps `_TYPED_FIELD_RE` for top-level vars: a single
-# typed field counts in both buckets, matching the original audit's
-# accounting so the baseline is a stable reproducible number rather
-# than a deduplicated one.
+# Top-level typed-var fields: `(static )?var name: McpFoo` at column 0.
+# Indented `var` declarations inside function bodies are still flagged
+# by `_TYPED_ANNOTATION_RE` below; this pass is the dedicated counter
+# for top-level fields specifically (the worst case, since they parse
+# at script-load).
+_TYPED_FIELD_RE = re.compile(r"^(?:static\s+)?var\s+\w+\s*:\s*(Mcp\w+)\b", re.MULTILINE)
+# Any `name: McpFoo` annotation (parameters, typed locals, indented
+# fields, return types). Intentionally overlaps `_TYPED_FIELD_RE` for
+# top-level fields so a single offender counts in both buckets --
+# matches the original audit's accounting and keeps the baseline a
+# stable reproducible number.
 _TYPED_ANNOTATION_RE = re.compile(r"\b\w+\s*:\s*(Mcp\w+)\b")
 _CONSTRUCTOR_RE = re.compile(r"\b(Mcp\w+)\s*\.\s*new\s*\(")
 # Any identifier after `Mcp*.`. `Mcp*.method()` hits the same
@@ -120,13 +122,54 @@ _PASSES: tuple[tuple[re.Pattern[str], Kind], ...] = (
 
 
 def _strip_gdscript_comments(source: str) -> str:
-    """Remove `## ...` doc comments and `# ...` line comments.
+    """Remove `# ...` line comments while preserving string literals.
 
-    The parse hazard only fires for executable references; mentions of
-    `McpConnection` or `class_name McpFoo` in explanatory prose must
-    not trip the lint.
+    A naive `re.sub(r"#.*$", ...)` truncates lines like
+    `remainder.begins_with("#")`, which can shift the violation count
+    when an offender appears later on the same line. This walks
+    character by character, recognising GDScript single, triple, and
+    prefixed (raw `r`, StringName `&`, NodePath `^`) string forms, and
+    only treats `#` as a comment when outside a string. Newlines are
+    preserved so line numbers in offender messages stay accurate.
     """
-    return re.sub(r"#.*$", "", source, flags=re.MULTILINE)
+    out: list[str] = []
+    n = len(source)
+    i = 0
+    while i < n:
+        c = source[i]
+        if c == "#":
+            while i < n and source[i] != "\n":
+                i += 1
+            continue
+        prefix_len = 0
+        if c in ("r", "&", "^") and i + 1 < n and source[i + 1] in ('"', "'"):
+            prefix_len = 1
+        q_start = i + prefix_len
+        if q_start < n and source[q_start] in ('"', "'"):
+            q = source[q_start]
+            if source[q_start : q_start + 3] == q * 3:
+                end = source.find(q * 3, q_start + 3)
+                end = (end + 3) if end != -1 else n
+            else:
+                j = q_start + 1
+                while j < n:
+                    ch = source[j]
+                    if ch == "\\":
+                        j += 2
+                        continue
+                    if ch == q:
+                        j += 1
+                        break
+                    if ch == "\n":
+                        break  # unterminated string; bail without crashing
+                    j += 1
+                end = j
+            out.append(source[i:end])
+            i = end
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
 
 
 def _format_ident(kind: Kind, match: re.Match[str]) -> str | None:


### PR DESCRIPTION
## Summary

Implements Step 1 of #399: invert `tests/unit/test_plugin_self_update_safety.py` from a 13-file targeted allowlist to a deny-by-default ratcheting lint.

- Scans every `.gd` under `plugin/addons/godot_ai/`, minus a hardcoded 5-file `OFF_LOAD_SURFACE` set (3 game-side runtime helpers, 2 test-only utilities -- documented in-place with the rationale that each is provably outside the editor-process load graph).
- Detects all four syntactic forms of the parse-hazard: typed-var, typed-param, `Mcp*.new(...)`, and `Mcp*.<identifier>` member access.
- Single test asserts `total <= BASELINE_VIOLATION_COUNT`. On regression, prints a paste-over-ready offender list. On improvement, demands the developer lower the baseline -- this is the ratchet, locking fixes in.

## Recorded baseline

`BASELINE_VIOLATION_COUNT = 1258`, recorded against `origin/beta` at PR open. End state is 0, driven down by Steps 2-3 of #399.

This is **higher** than the ~600 figure cited in #399 because the original audit script's `STATIC_ACCESS_RE` only matched `Mcp*.[A-Z_]+` (uppercase constants). A `Mcp*.method()` invocation hits the exact same parse-time class_name registry lookup as `Mcp*.CONST`, so the test extends the regex to all identifiers after `Mcp*.`. The recorded baseline reflects the true hazard surface.

## Judgment calls

- **Deleted the existing targeted-allowlist tests** (`test_targeted_load_scripts_have_no_typed_fields_against_plugin_class_names`, `test_plugin_gd_does_not_construct_via_class_name`, `test_targeted_load_scripts_do_not_construct_via_class_name`, `test_targeted_load_scripts_do_not_access_members_via_class_name`). Each was a strict subset of the new deny-by-default scan over a hand-maintained 13-file list. With the closure-wide scan in place, those files are still covered -- just as part of the full surface, not a parallel zero-tolerance bucket. Keeping both would have created two failure messages for the same offender, with the targeted version going stale as the allowlist diverged from reality.
- **Kept the two non-scan tests** (`test_update_backup_suffix_stays_in_sync` and `test_plugin_gd_documents_the_untyped_policy`). Neither overlaps with the parse-hazard scan; they enforce the literal-suffix anti-drift guard from #398 and the in-source policy comment that prevents future contributors from "fixing" the apparent oversight.
- **Extended the member-access regex to all identifiers** (not just uppercase). This raised the baseline from the audit's reported ~600 to 1258, but the under-counted method calls were a real coverage gap -- shipping the deny-by-default lint with the same blind spot would have left a class of regressions invisible to the ratchet.

## Closure of #410

`script/audit-self-update-load-surface` is deleted in this PR -- its logic now lives inside the test. PR #410 should be closed as absorbed.

After this PR merges, run:

```bash
gh pr comment 410 --repo hi-godot/godot-ai --body "Absorbed into #<this-PR-number>; the audit logic now lives in tests/unit/test_plugin_self_update_safety.py with extended coverage."
gh pr close 410 --repo hi-godot/godot-ai
```

(I cannot close #410 from inside this PR's body / from this branch; leaving as a manual follow-up.)

## How to verify locally

1. Clean checkout of this branch, then `pytest tests/unit/test_plugin_self_update_safety.py -v` -- 3 tests pass with baseline 1258.
2. Add a synthetic `var x: McpErrorCodes` to any handler not already at the limit (e.g. `signal_handler.gd`); rerun the test. Should fail with `regressed: 1260 sites (baseline 1258)` and the new line listed.
3. Lower `BASELINE_VIOLATION_COUNT` by 1 in the test file. Should fail with the "lower the baseline" message asking you to set it to 1258.
4. Revert both, confirm 3 tests pass.

## Test plan

- [x] `pytest tests/unit/test_plugin_self_update_safety.py -v` passes with baseline 1258
- [x] Full `pytest -q` passes (915 tests, no regressions)
- [x] `ruff check tests/` clean
- [x] `ruff format tests/` clean
- [x] Synthetic-violation injection raises the count and fails with offender listing
- [x] Lowered-baseline experiment fails with the ratchet-down message

Out of scope (and intentionally not done): fixing any of the 1258 violations. Step 1 is observation-only; Steps 2-3 of #399 do the fixing.

Refs: #242, #244, #398, #399. Absorbs #410.
