### PR TITLE
Implement #399 Step 2: drop class_name from McpErrorCodes

### DIFF
--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -2,6 +2,8 @@
 class_name McpDebuggerPlugin
 extends EditorDebuggerPlugin
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Editor-side half of the game-process capture bridge.
 ##
 ## The game-side counterpart (`plugin/addons/godot_ai/runtime/game_helper.gd`,
@@ -167,7 +169,7 @@ func request_game_screenshot(
 
 	var tree := Engine.get_main_loop() as SceneTree
 	if tree == null:
-		_send_error(connection, request_id, McpErrorCodes.INTERNAL_ERROR,
+		_send_error(connection, request_id, ErrorCodes.INTERNAL_ERROR,
 			"Editor main loop is not a SceneTree — cannot schedule capture")
 		return
 
@@ -198,7 +200,7 @@ func _wait_then_send(
 	while not is_game_capture_ready() and Time.get_ticks_msec() < deadline:
 		await tree.process_frame
 	if not is_game_capture_ready():
-		_send_error(connection, request_id, McpErrorCodes.INTERNAL_ERROR,
+		_send_error(connection, request_id, ErrorCodes.INTERNAL_ERROR,
 			"Game-side autoload never registered its debugger capture within %ds. Is the game actually running? Check Project Settings → Autoload for _mcp_game_helper." % int(GAME_READY_WAIT_SEC))
 		return
 	_send_take_screenshot(tree, request_id, max_resolution, connection, timeout_sec)
@@ -215,7 +217,7 @@ func _send_take_screenshot(
 ) -> void:
 	var session: EditorDebuggerSession = _first_active_session()
 	if session == null:
-		_send_error(connection, request_id, McpErrorCodes.INTERNAL_ERROR,
+		_send_error(connection, request_id, ErrorCodes.INTERNAL_ERROR,
 			"No active debugger session — is the game actually running and started from this editor?")
 		return
 
@@ -282,7 +284,7 @@ func _on_screenshot_error(data: Array) -> void:
 	var connection: McpConnection = pending.connection
 	if connection == null or not is_instance_valid(connection):
 		return
-	_send_error(connection, request_id, McpErrorCodes.INTERNAL_ERROR, message)
+	_send_error(connection, request_id, ErrorCodes.INTERNAL_ERROR, message)
 
 
 func _on_timeout(request_id: String) -> void:
@@ -293,7 +295,7 @@ func _on_timeout(request_id: String) -> void:
 	var connection: McpConnection = pending.connection
 	if connection == null or not is_instance_valid(connection):
 		return
-	_send_error(connection, request_id, McpErrorCodes.INTERNAL_ERROR,
+	_send_error(connection, request_id, ErrorCodes.INTERNAL_ERROR,
 		"Game screenshot timed out. The running game must include the _mcp_game_helper autoload (added automatically when the plugin is enabled — check Project Settings → Autoload). If the autoload is missing, re-enable the plugin and relaunch the game. For headless or custom-main-loop builds, use source='viewport' instead.")
 	if _log_buffer:
 		_log_buffer.log("[debug] !! screenshot timeout (%s)" % request_id)
@@ -302,7 +304,7 @@ func _on_timeout(request_id: String) -> void:
 func _send_error(connection: McpConnection, request_id: String, code: String, message: String) -> void:
 	if connection == null or not is_instance_valid(connection):
 		return
-	var err := McpErrorCodes.make(code, message)
+	var err := ErrorCodes.make(code, message)
 	connection.send_deferred_response(request_id, err)
 
 

--- a/plugin/addons/godot_ai/handlers/_node_validator.gd
+++ b/plugin/addons/godot_ai/handlers/_node_validator.gd
@@ -27,7 +27,7 @@ const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
 ## error dict.
 ##
 ## Success shape: `{"node": Node, "scene_root": Node, "path": String}`.
-## Error shape: matches `McpErrorCodes.make(...)` so callers can
+## Error shape: matches `ErrorCodes.make(...)` so callers can
 ## `return resolved` to propagate.
 ##
 ## Errors (in order checked):

--- a/plugin/addons/godot_ai/handlers/_param_validators.gd
+++ b/plugin/addons/godot_ai/handlers/_param_validators.gd
@@ -2,6 +2,8 @@
 class_name McpParamValidators
 extends RefCounted
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Type-check a JSON-decoded param Variant before assigning it into a typed
 ## GDScript local. The dispatcher only catches handler crashes as an opaque
 ## "malformed result" (issue #210), so a typed assignment like
@@ -18,8 +20,8 @@ static func require_string(name: String, value: Variant) -> Variant:
 	var t := typeof(value)
 	if t == TYPE_STRING or t == TYPE_STRING_NAME:
 		return null
-	return McpErrorCodes.make(
-		McpErrorCodes.WRONG_TYPE,
+	return ErrorCodes.make(
+		ErrorCodes.WRONG_TYPE,
 		"Param '%s' must be a String, got %s" % [name, type_string(t)],
 	)
 
@@ -30,8 +32,8 @@ static func require_string(name: String, value: Variant) -> Variant:
 static func require_int(name: String, value: Variant) -> Variant:
 	if typeof(value) == TYPE_INT:
 		return null
-	return McpErrorCodes.make(
-		McpErrorCodes.WRONG_TYPE,
+	return ErrorCodes.make(
+		ErrorCodes.WRONG_TYPE,
 		"Param '%s' must be an int, got %s" % [name, type_string(typeof(value))],
 	)
 
@@ -40,7 +42,7 @@ static func require_int(name: String, value: Variant) -> Variant:
 static func require_bool(name: String, value: Variant) -> Variant:
 	if typeof(value) == TYPE_BOOL:
 		return null
-	return McpErrorCodes.make(
-		McpErrorCodes.WRONG_TYPE,
+	return ErrorCodes.make(
+		ErrorCodes.WRONG_TYPE,
 		"Param '%s' must be a bool, got %s" % [name, type_string(typeof(value))],
 	)

--- a/plugin/addons/godot_ai/handlers/animation_handler.gd
+++ b/plugin/addons/godot_ai/handlers/animation_handler.gd
@@ -1,6 +1,8 @@
 @tool
 extends RefCounted
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Handles AnimationPlayer authoring: creating players, animations, tracks,
 ## keyframes, autoplay, and dev-ergonomics playback.
 ##
@@ -59,7 +61,7 @@ func create_player(params: Dictionary) -> Dictionary:
 	if not parent_path.is_empty():
 		parent = McpScenePath.resolve(parent_path, scene_root)
 		if parent == null:
-			return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_parent_error(parent_path, scene_root))
+			return ErrorCodes.make(ErrorCodes.NODE_NOT_FOUND, McpScenePath.format_parent_error(parent_path, scene_root))
 
 	var player := AnimationPlayer.new()
 	if not node_name.is_empty():
@@ -98,14 +100,14 @@ func create_animation(params: Dictionary) -> Dictionary:
 	var loop_mode_str: String = params.get("loop_mode", "none")
 
 	if player_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
 	if anim_name.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: name")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: name")
 	if length <= 0.0:
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "length must be > 0 (got %s)" % length)
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "length must be > 0 (got %s)" % length)
 
 	if not _LOOP_MODES.has(loop_mode_str):
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE,
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE,
 			"Invalid loop_mode '%s'. Valid: %s" % [loop_mode_str, ", ".join(_LOOP_MODES.keys())])
 
 	var resolved := _resolve_player(player_path, true)
@@ -124,7 +126,7 @@ func create_animation(params: Dictionary) -> Dictionary:
 	var old_anim: Animation = null
 	if library.has_animation(anim_name):
 		if not overwrite:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+			return ErrorCodes.make(ErrorCodes.INVALID_PARAMS,
 				"Animation '%s' already exists. Pass overwrite=true or delete it first." % anim_name)
 		old_anim = library.get_animation(anim_name)
 
@@ -159,9 +161,9 @@ func delete_animation(params: Dictionary) -> Dictionary:
 	var anim_name: String = params.get("animation_name", "")
 
 	if player_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
 	if anim_name.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: animation_name")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: animation_name")
 
 	var resolved := _resolve_player(player_path)
 	if resolved.has("error"):
@@ -211,20 +213,20 @@ func add_property_track(params: Dictionary) -> Dictionary:
 	var interp_str: String = params.get("interpolation", "linear")
 
 	if player_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
 	if anim_name.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: animation_name")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: animation_name")
 	if track_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM,
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM,
 			"Missing required param: track_path (format: 'NodeName:property', e.g. 'Panel:modulate')")
 	if not track_path.contains(":"):
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS,
 			"track_path must include ':property' suffix (e.g. 'Panel:modulate', '.:position')")
 	if not _INTERP_MODES.has(interp_str):
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE,
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE,
 			"Invalid interpolation '%s'. Valid: %s" % [interp_str, ", ".join(_INTERP_MODES.keys())])
 	if typeof(keyframes) != TYPE_ARRAY or keyframes.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "keyframes must be a non-empty array")
+		return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "keyframes must be a non-empty array")
 
 	var resolved := _resolve_player(player_path)
 	if resolved.has("error"):
@@ -242,18 +244,18 @@ func add_property_track(params: Dictionary) -> Dictionary:
 	# get_property_list() per keyframe.
 	var ctx := AnimationValues.resolve_track_prop_context(track_path, player)
 	if ctx.has("error"):
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, ctx.error)
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, ctx.error)
 	var coerced_keyframes: Array = []
 	for kf in keyframes:
 		if typeof(kf) != TYPE_DICTIONARY:
-			return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "Each keyframe must be a dictionary")
+			return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "Each keyframe must be a dictionary")
 		if not "time" in kf:
-			return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Each keyframe must have a 'time' field")
+			return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Each keyframe must have a 'time' field")
 		if not "value" in kf:
-			return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Each keyframe must have a 'value' field")
+			return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Each keyframe must have a 'value' field")
 		var coerce_result := AnimationValues.coerce_with_context(kf.get("value"), ctx)
 		if coerce_result.has("error"):
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, coerce_result.error)
+			return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, coerce_result.error)
 		coerced_keyframes.append({
 			"time": kf.get("time"),
 			"value": coerce_result.ok,
@@ -310,30 +312,30 @@ func add_method_track(params: Dictionary) -> Dictionary:
 	var keyframes = params.get("keyframes", [])
 
 	if player_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
 	if anim_name.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: animation_name")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: animation_name")
 	if target_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: target_node_path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: target_node_path")
 	if target_path.contains(":"):
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS,
 			"target_node_path is a bare NodePath without ':property' (got '%s'). " % target_path +
 			"Method name goes in each keyframe's 'method' field, not the path.")
 	if typeof(keyframes) != TYPE_ARRAY or keyframes.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "keyframes must be a non-empty array")
+		return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "keyframes must be a non-empty array")
 
 	for kf in keyframes:
 		if typeof(kf) != TYPE_DICTIONARY:
-			return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "Each keyframe must be a dictionary")
+			return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "Each keyframe must be a dictionary")
 		if not "time" in kf:
-			return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Each keyframe must have a 'time' field")
+			return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Each keyframe must have a 'time' field")
 		if not "method" in kf:
-			return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Each keyframe must have a 'method' field")
+			return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Each keyframe must have a 'method' field")
 		var method_field = kf.get("method")
 		if typeof(method_field) != TYPE_STRING or (method_field as String).is_empty():
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "'method' must be a non-empty string")
+			return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, "'method' must be a non-empty string")
 		if kf.has("args") and typeof(kf.get("args")) != TYPE_ARRAY:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+			return ErrorCodes.make(ErrorCodes.INVALID_PARAMS,
 				"'args' must be an array if provided (got %s)" % type_string(typeof(kf.get("args"))))
 
 	var resolved := _resolve_player(player_path)
@@ -392,7 +394,7 @@ func set_autoplay(params: Dictionary) -> Dictionary:
 	var anim_name: String = params.get("animation_name", "")
 
 	if player_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
 
 	var resolved := _resolve_player(player_path)
 	if resolved.has("error"):
@@ -401,7 +403,7 @@ func set_autoplay(params: Dictionary) -> Dictionary:
 
 	# Allow empty string to clear autoplay; otherwise validate the name exists.
 	if not anim_name.is_empty() and not player.has_animation(anim_name):
-		return McpErrorCodes.make(McpErrorCodes.PROPERTY_NOT_ON_CLASS,
+		return ErrorCodes.make(ErrorCodes.PROPERTY_NOT_ON_CLASS,
 			"Animation '%s' not found on player at %s" % [anim_name, player_path])
 
 	var old_autoplay: String = player.autoplay
@@ -431,7 +433,7 @@ func play(params: Dictionary) -> Dictionary:
 	var anim_name: String = params.get("animation_name", "")
 
 	if player_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
 
 	var resolved := _resolve_player(player_path)
 	if resolved.has("error"):
@@ -439,7 +441,7 @@ func play(params: Dictionary) -> Dictionary:
 	var player: AnimationPlayer = resolved.player
 
 	if not anim_name.is_empty() and not player.has_animation(anim_name):
-		return McpErrorCodes.make(McpErrorCodes.PROPERTY_NOT_ON_CLASS,
+		return ErrorCodes.make(ErrorCodes.PROPERTY_NOT_ON_CLASS,
 			"Animation '%s' not found on player at %s" % [anim_name, player_path])
 
 	player.play(anim_name)
@@ -462,7 +464,7 @@ func stop(params: Dictionary) -> Dictionary:
 	var player_path: String = params.get("player_path", "")
 
 	if player_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
 
 	var resolved := _resolve_player(player_path)
 	if resolved.has("error"):
@@ -491,30 +493,30 @@ func create_simple(params: Dictionary) -> Dictionary:
 	var loop_mode_str: String = params.get("loop_mode", "none")
 
 	if player_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
 	if anim_name.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: name")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: name")
 	if typeof(tweens) != TYPE_ARRAY or tweens.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "tweens must be a non-empty array")
+		return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "tweens must be a non-empty array")
 	if not _LOOP_MODES.has(loop_mode_str):
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE,
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE,
 			"Invalid loop_mode '%s'. Valid: %s" % [loop_mode_str, ", ".join(_LOOP_MODES.keys())])
 
 	# Validate all tween specs before touching the scene.
 	var seen_paths := {}
 	for spec in tweens:
 		if typeof(spec) != TYPE_DICTIONARY:
-			return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "Each tween spec must be a dictionary")
+			return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "Each tween spec must be a dictionary")
 		for field in ["target", "property", "from", "to", "duration"]:
 			if not field in spec:
-				return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM,
+				return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM,
 					"Each tween spec must have '%s'" % field)
 		if float(spec.get("duration", 0.0)) <= 0.0:
-			return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE,
+			return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE,
 				"tween 'duration' must be > 0")
 		var dup_key: String = str(spec.target) + ":" + str(spec.property)
 		if seen_paths.has(dup_key):
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+			return ErrorCodes.make(ErrorCodes.INVALID_PARAMS,
 				"Duplicate tween target '%s' — merge keyframes into a single track " % dup_key +
 				"via animation_add_property_track instead of two separate tweens.")
 		seen_paths[dup_key] = true
@@ -526,7 +528,7 @@ func create_simple(params: Dictionary) -> Dictionary:
 	if has_length:
 		computed_length = float(params.get("length"))
 		if computed_length <= 0.0:
-			return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE,
+			return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE,
 				"'length' must be > 0 when provided (got %s)" % str(params.get("length")))
 	else:
 		for spec in tweens:
@@ -554,7 +556,7 @@ func create_simple(params: Dictionary) -> Dictionary:
 		if not overwrite:
 			if created_player:
 				player.queue_free()
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+			return ErrorCodes.make(ErrorCodes.INVALID_PARAMS,
 				"Animation '%s' already exists. Pass overwrite=true or delete it first." % anim_name)
 		old_anim = library.get_animation(anim_name)
 
@@ -575,12 +577,12 @@ func create_simple(params: Dictionary) -> Dictionary:
 		if from_result.has("error"):
 			if created_player:
 				player.queue_free()
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "tween '%s': %s" % [track_path, from_result.error])
+			return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, "tween '%s': %s" % [track_path, from_result.error])
 		var to_result := AnimationValues.coerce_value_for_track(spec.get("to"), track_path, player, coerce_root)
 		if to_result.has("error"):
 			if created_player:
 				player.queue_free()
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "tween '%s': %s" % [track_path, to_result.error])
+			return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, "tween '%s': %s" % [track_path, to_result.error])
 		per_track_keyframes.append({
 			"track_path": track_path,
 			"keyframes": [
@@ -734,10 +736,10 @@ func _resolve_player(player_path: String, create_if_missing: bool = false) -> Di
 	var node := McpScenePath.resolve(player_path, scene_root)
 	if node == null:
 		if not create_if_missing:
-			return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_node_error(player_path, scene_root))
+			return ErrorCodes.make(ErrorCodes.NODE_NOT_FOUND, McpScenePath.format_node_error(player_path, scene_root))
 		return _instantiate_player(player_path, scene_root)
 	if not node is AnimationPlayer:
-		return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE,
+		return ErrorCodes.make(ErrorCodes.WRONG_TYPE,
 			"Node at %s is not an AnimationPlayer (got %s)" % [player_path, node.get_class()])
 	var player := node as AnimationPlayer
 	var lib: AnimationLibrary = null
@@ -760,7 +762,7 @@ func _instantiate_player(player_path: String, scene_root: Node) -> Dictionary:
 		parent_path = player_path.substr(0, slash)
 		player_name = player_path.substr(slash + 1)
 	if player_name.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS,
 			"Cannot auto-create AnimationPlayer: player_path '%s' has no leaf name" % player_path)
 	var parent: Node
 	if parent_path.is_empty():
@@ -768,7 +770,7 @@ func _instantiate_player(player_path: String, scene_root: Node) -> Dictionary:
 	else:
 		parent = McpScenePath.resolve(parent_path, scene_root)
 	if parent == null:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS,
 			"Cannot auto-create AnimationPlayer at %s: %s" % [
 				player_path, McpScenePath.format_parent_error(parent_path, scene_root)])
 	var new_player := AnimationPlayer.new()
@@ -809,7 +811,7 @@ func _resolve_or_create_player(player_path: String) -> Dictionary:
 	var parent_path := player_path.get_base_dir()
 	var new_name := player_path.get_file()
 	if new_name.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE,
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE,
 			"Invalid player_path (no node name): %s" % player_path)
 	var parent: Node
 	if parent_path.is_empty() or parent_path == "/":
@@ -817,7 +819,7 @@ func _resolve_or_create_player(player_path: String) -> Dictionary:
 	else:
 		parent = McpScenePath.resolve(parent_path, scene_root)
 		if parent == null:
-			return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND,
+			return ErrorCodes.make(ErrorCodes.NODE_NOT_FOUND,
 				"Node not found: %s (and its parent %s also does not exist — create the parent first)" %
 				[player_path, parent_path])
 	var new_player := AnimationPlayer.new()
@@ -837,7 +839,7 @@ func _resolve_player_read(player_path: String) -> Dictionary:
 		return resolved
 	var node: Node = resolved.node
 	if not node is AnimationPlayer:
-		return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE,
+		return ErrorCodes.make(ErrorCodes.WRONG_TYPE,
 			"Node at %s is not an AnimationPlayer (got %s)" % [player_path, node.get_class()])
 	return {"player": node as AnimationPlayer}
 
@@ -847,7 +849,7 @@ func _resolve_player_read(player_path: String) -> Dictionary:
 ## as returned by `list_animations` for non-default libraries.
 func _resolve_animation(player: AnimationPlayer, anim_name: String) -> Dictionary:
 	if not player.has_animation(anim_name):
-		return McpErrorCodes.make(McpErrorCodes.PROPERTY_NOT_ON_CLASS,
+		return ErrorCodes.make(ErrorCodes.PROPERTY_NOT_ON_CLASS,
 			"Animation '%s' not found on player. Available: %s" % [
 				anim_name,
 				", ".join(Array(player.get_animation_list()))
@@ -867,4 +869,4 @@ func _resolve_animation(player: AnimationPlayer, anim_name: String) -> Dictionar
 		if lib2.has_animation(anim_name):
 			return {"animation": lib2.get_animation(anim_name), "library": lib2, "library_key": lib_name}
 	# Fallback — shouldn't happen if has_animation returned true.
-	return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Animation found by player but not in any library")
+	return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Animation found by player but not in any library")

--- a/plugin/addons/godot_ai/handlers/audio_handler.gd
+++ b/plugin/addons/godot_ai/handlers/audio_handler.gd
@@ -1,6 +1,8 @@
 @tool
 extends RefCounted
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Handles AudioStreamPlayer / 2D / 3D authoring — node creation, stream
 ## assignment, playback-property edits, and real editor preview playback.
 ##
@@ -45,8 +47,8 @@ func create_player(params: Dictionary) -> Dictionary:
 	var type_str: String = params.get("type", "1d")
 
 	if not _VALID_TYPES.has(type_str):
-		return McpErrorCodes.make(
-			McpErrorCodes.VALUE_OUT_OF_RANGE,
+		return ErrorCodes.make(
+			ErrorCodes.VALUE_OUT_OF_RANGE,
 			"Invalid audio player type '%s'. Valid: %s" % [type_str, ", ".join(_VALID_TYPES.keys())]
 		)
 
@@ -59,11 +61,11 @@ func create_player(params: Dictionary) -> Dictionary:
 	if not parent_path.is_empty():
 		parent = McpScenePath.resolve(parent_path, scene_root)
 		if parent == null:
-			return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_parent_error(parent_path, scene_root))
+			return ErrorCodes.make(ErrorCodes.NODE_NOT_FOUND, McpScenePath.format_parent_error(parent_path, scene_root))
 
 	var node := _instantiate_player(type_str)
 	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to instantiate audio player")
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to instantiate audio player")
 	if not node_name.is_empty():
 		node.name = node_name
 
@@ -95,9 +97,9 @@ func set_stream(params: Dictionary) -> Dictionary:
 	var stream_path: String = params.get("stream_path", "")
 
 	if player_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
 	if stream_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: stream_path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: stream_path")
 
 	var resolved := _resolve_player(player_path)
 	if resolved.has("error"):
@@ -105,13 +107,13 @@ func set_stream(params: Dictionary) -> Dictionary:
 	var player: Node = resolved.player
 
 	if not ResourceLoader.exists(stream_path):
-		return McpErrorCodes.make(McpErrorCodes.RESOURCE_NOT_FOUND, "AudioStream not found: %s" % stream_path)
+		return ErrorCodes.make(ErrorCodes.RESOURCE_NOT_FOUND, "AudioStream not found: %s" % stream_path)
 	var loaded := ResourceLoader.load(stream_path)
 	if loaded == null:
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to load AudioStream: %s" % stream_path)
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to load AudioStream: %s" % stream_path)
 	if not (loaded is AudioStream):
-		return McpErrorCodes.make(
-			McpErrorCodes.WRONG_TYPE,
+		return ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
 			"Resource at %s is not an AudioStream (got %s)" % [stream_path, loaded.get_class()]
 		)
 
@@ -140,7 +142,7 @@ func set_stream(params: Dictionary) -> Dictionary:
 func set_playback(params: Dictionary) -> Dictionary:
 	var player_path: String = params.get("player_path", "")
 	if player_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
 
 	var resolved := _resolve_player(player_path)
 	if resolved.has("error"):
@@ -154,8 +156,8 @@ func set_playback(params: Dictionary) -> Dictionary:
 			var value = params.get(key)
 			var coerced = _coerce_playback_value(value, expected_type)
 			if coerced == null:
-				return McpErrorCodes.make(
-					McpErrorCodes.INVALID_PARAMS,
+				return ErrorCodes.make(
+					ErrorCodes.INVALID_PARAMS,
 					"Invalid value for %s: expected %s, got %s" % [
 						key, type_string(expected_type), type_string(typeof(value))
 					]
@@ -163,8 +165,8 @@ func set_playback(params: Dictionary) -> Dictionary:
 			updates[key] = coerced
 
 	if updates.is_empty():
-		return McpErrorCodes.make(
-			McpErrorCodes.MISSING_REQUIRED_PARAM,
+		return ErrorCodes.make(
+			ErrorCodes.MISSING_REQUIRED_PARAM,
 			"At least one of %s is required" % ", ".join(_PLAYBACK_KEYS.keys())
 		)
 
@@ -197,7 +199,7 @@ func play(params: Dictionary) -> Dictionary:
 	var from_position: float = float(params.get("from_position", 0.0))
 
 	if player_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
 
 	var resolved := _resolve_player(player_path)
 	if resolved.has("error"):
@@ -205,8 +207,8 @@ func play(params: Dictionary) -> Dictionary:
 	var player: Node = resolved.player
 
 	if player.stream == null:
-		return McpErrorCodes.make(
-			McpErrorCodes.MISSING_REQUIRED_PARAM,
+		return ErrorCodes.make(
+			ErrorCodes.MISSING_REQUIRED_PARAM,
 			"Player has no stream assigned — call audio_player_set_stream first"
 		)
 
@@ -230,7 +232,7 @@ func play(params: Dictionary) -> Dictionary:
 func stop(params: Dictionary) -> Dictionary:
 	var player_path: String = params.get("player_path", "")
 	if player_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: player_path")
 
 	var resolved := _resolve_player(player_path)
 	if resolved.has("error"):
@@ -258,11 +260,11 @@ func list_streams(params: Dictionary) -> Dictionary:
 	var include_duration: bool = bool(params.get("include_duration", true))
 
 	if not root.begins_with("res://"):
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "root must start with res://")
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "root must start with res://")
 
 	var efs := EditorInterface.get_resource_filesystem()
 	if efs == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "EditorFileSystem not available")
+		return ErrorCodes.make(ErrorCodes.EDITOR_NOT_READY, "EditorFileSystem not available")
 
 	var results: Array[Dictionary] = []
 	var start_dir := efs.get_filesystem_path(root)
@@ -328,8 +330,8 @@ func _resolve_player(player_path: String) -> Dictionary:
 		or node is AudioStreamPlayer2D \
 		or node is AudioStreamPlayer3D
 	if not is_player:
-		return McpErrorCodes.make(
-			McpErrorCodes.WRONG_TYPE,
+		return ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
 			"Node at %s is not an AudioStreamPlayer/2D/3D (got %s)" % [player_path, node.get_class()]
 		)
 	return {"player": node}

--- a/plugin/addons/godot_ai/handlers/autoload_handler.gd
+++ b/plugin/addons/godot_ai/handlers/autoload_handler.gd
@@ -1,6 +1,8 @@
 @tool
 extends RefCounted
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Handles autoload listing, adding, and removing via ProjectSettings.
 
 
@@ -28,17 +30,17 @@ func add_autoload(params: Dictionary) -> Dictionary:
 	var singleton: bool = params.get("singleton", true)
 
 	if name.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: name")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: name")
 	if path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
 	if not path.begins_with("res://"):
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "Path must start with res:// (got: %s)" % path)
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "Path must start with res:// (got: %s)" % path)
 	if not FileAccess.file_exists(path):
-		return McpErrorCodes.make(McpErrorCodes.RESOURCE_NOT_FOUND, "File not found: %s" % path)
+		return ErrorCodes.make(ErrorCodes.RESOURCE_NOT_FOUND, "File not found: %s" % path)
 
 	var key := "autoload/%s" % name
 	if ProjectSettings.has_setting(key):
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Autoload '%s' already exists" % name)
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, "Autoload '%s' already exists" % name)
 
 	var value := ("*" if singleton else "") + path
 	ProjectSettings.set_setting(key, value)
@@ -47,7 +49,7 @@ func add_autoload(params: Dictionary) -> Dictionary:
 	var err := ProjectSettings.save()
 	if err != OK:
 		ProjectSettings.clear(key)
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR,
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR,
 			"Failed to save project settings while adding autoload '%s': %s (error %d)" % [name, error_string(err), err])
 
 	return {
@@ -64,18 +66,18 @@ func add_autoload(params: Dictionary) -> Dictionary:
 func remove_autoload(params: Dictionary) -> Dictionary:
 	var name: String = params.get("name", "")
 	if name.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: name")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: name")
 
 	var key := "autoload/%s" % name
 	if not ProjectSettings.has_setting(key):
-		return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, "Autoload '%s' not found" % name)
+		return ErrorCodes.make(ErrorCodes.NODE_NOT_FOUND, "Autoload '%s' not found" % name)
 
 	var old_value: String = ProjectSettings.get_setting(key, "")
 	ProjectSettings.clear(key)
 	var err := ProjectSettings.save()
 	if err != OK:
 		ProjectSettings.set_setting(key, old_value)
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR,
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR,
 			"Failed to save project settings while removing autoload '%s': %s (error %d)" % [name, error_string(err), err])
 
 	return {

--- a/plugin/addons/godot_ai/handlers/batch_handler.gd
+++ b/plugin/addons/godot_ai/handlers/batch_handler.gd
@@ -1,6 +1,8 @@
 @tool
 extends RefCounted
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Executes a list of sub-commands through the dispatcher with stop-on-first-error
 ## semantics. When undo=true (default), any successful sub-commands are rolled
 ## back via the scene's UndoRedo history if a later sub-command fails.
@@ -19,21 +21,21 @@ func _init(dispatcher: McpDispatcher, undo_redo: EditorUndoRedoManager) -> void:
 func batch_execute(params: Dictionary) -> Dictionary:
 	var commands = params.get("commands", null)
 	if typeof(commands) != TYPE_ARRAY:
-		return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "commands must be a list")
+		return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "commands must be a list")
 	if commands.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "commands must not be empty")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "commands must not be empty")
 
 	var undo: bool = params.get("undo", true)
 
 	for idx in range(commands.size()):
 		var item = commands[idx]
 		if typeof(item) != TYPE_DICTIONARY:
-			return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "commands[%d] must be a dict" % idx)
+			return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "commands[%d] must be a dict" % idx)
 		var cmd_name: String = item.get("command", "")
 		if cmd_name.is_empty():
-			return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "commands[%d] missing 'command' field" % idx)
+			return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "commands[%d] missing 'command' field" % idx)
 		if cmd_name in FORBIDDEN_SUBCOMMANDS:
-			return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "commands[%d]: '%s' is not allowed as a sub-command" % [idx, cmd_name])
+			return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "commands[%d]: '%s' is not allowed as a sub-command" % [idx, cmd_name])
 		if not _dispatcher.has_command(cmd_name):
 			return _unknown_command_error(idx, cmd_name)
 
@@ -106,7 +108,7 @@ func _unknown_command_error(idx: int, cmd_name: String) -> Dictionary:
 	var msg := "commands[%d]: unknown plugin command '%s'. batch_execute expects plugin command names (e.g. 'create_node'), not MCP tool names (e.g. 'node_create')." % [idx, cmd_name]
 	if not suggestions.is_empty():
 		msg += " Did you mean: %s?" % ", ".join(suggestions)
-	var err := McpErrorCodes.make(McpErrorCodes.UNKNOWN_COMMAND, msg)
+	var err := ErrorCodes.make(ErrorCodes.UNKNOWN_COMMAND, msg)
 	err["error"]["data"] = {"suggestions": suggestions}
 	return err
 

--- a/plugin/addons/godot_ai/handlers/camera_handler.gd
+++ b/plugin/addons/godot_ai/handlers/camera_handler.gd
@@ -1,6 +1,8 @@
 @tool
 extends RefCounted
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Handles Camera2D / Camera3D authoring — create, configure, bounds, damping,
 ## node-parent-based follow, presets.
 ##
@@ -472,8 +474,8 @@ func create_camera(params: Dictionary) -> Dictionary:
 	var make_current: bool = bool(params.get("make_current", false))
 
 	if not _VALID_TYPES.has(type_str):
-		return McpErrorCodes.make(
-			McpErrorCodes.VALUE_OUT_OF_RANGE,
+		return ErrorCodes.make(
+			ErrorCodes.VALUE_OUT_OF_RANGE,
 			"Invalid camera type '%s'. Valid: %s" % [type_str, ", ".join(_VALID_TYPES.keys())]
 		)
 
@@ -486,11 +488,11 @@ func create_camera(params: Dictionary) -> Dictionary:
 	if not parent_path.is_empty():
 		parent = McpScenePath.resolve(parent_path, scene_root)
 		if parent == null:
-			return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_parent_error(parent_path, scene_root))
+			return ErrorCodes.make(ErrorCodes.NODE_NOT_FOUND, McpScenePath.format_parent_error(parent_path, scene_root))
 
 	var node := _instantiate_camera(type_str)
 	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to instantiate camera")
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to instantiate camera")
 	if not node_name.is_empty():
 		node.name = node_name
 
@@ -538,7 +540,7 @@ func configure(params: Dictionary) -> Dictionary:
 
 	var properties: Dictionary = params.get("properties", {})
 	if properties.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "properties dict is empty")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "properties dict is empty")
 
 	var valid_keys: Array = _KEYS_2D if type_str == "2d" else _KEYS_3D
 	var prop_types := _property_type_map(node)
@@ -558,19 +560,19 @@ func configure(params: Dictionary) -> Dictionary:
 					". Transforms live on the Node, not on the camera config — "
 					+ "use node_set_property(path=%s, property=\"%s\", value=...)" % [node_path, prop_name]
 				)
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, msg)
+			return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, msg)
 		if prop_name == "current":
 			current_request = bool(properties[prop_name])
 			continue
 		var prop_type: int = prop_types.get(prop_name, TYPE_NIL)
 		if prop_type == TYPE_NIL:
-			return McpErrorCodes.make(
-				McpErrorCodes.PROPERTY_NOT_ON_CLASS,
+			return ErrorCodes.make(
+				ErrorCodes.PROPERTY_NOT_ON_CLASS,
 				"Property '%s' not present on %s" % [prop_name, node.get_class()]
 			)
 		var coerce_result := CameraValues.coerce(prop_name, properties[prop_name], prop_type)
 		if not coerce_result.ok:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, String(coerce_result.error))
+			return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, String(coerce_result.error))
 		coerced[prop_name] = coerce_result.value
 		old_values[prop_name] = node.get(prop_name)
 
@@ -629,8 +631,8 @@ func set_limits_2d(params: Dictionary) -> Dictionary:
 	var type_str: String = resolved.type
 
 	if type_str != "2d":
-		return McpErrorCodes.make(
-			McpErrorCodes.WRONG_TYPE,
+		return ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
 			"camera_set_limits_2d requires a Camera2D (got %s)" % node.get_class()
 		)
 
@@ -655,8 +657,8 @@ func set_limits_2d(params: Dictionary) -> Dictionary:
 		old_values["limit_smoothed"] = node.get("limit_smoothed")
 
 	if applied.is_empty():
-		return McpErrorCodes.make(
-			McpErrorCodes.MISSING_REQUIRED_PARAM,
+		return ErrorCodes.make(
+			ErrorCodes.MISSING_REQUIRED_PARAM,
 			"No limits specified; provide at least one of left, right, top, bottom, smoothed"
 		)
 
@@ -693,8 +695,8 @@ func set_damping_2d(params: Dictionary) -> Dictionary:
 	var type_str: String = resolved.type
 
 	if type_str != "2d":
-		return McpErrorCodes.make(
-			McpErrorCodes.WRONG_TYPE,
+		return ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
 			"camera_set_damping_2d requires a Camera2D (got %s)" % node.get_class()
 		)
 
@@ -733,8 +735,8 @@ func set_damping_2d(params: Dictionary) -> Dictionary:
 	var margins_v = params.get("drag_margins")
 	if margins_v != null:
 		if not (margins_v is Dictionary):
-			return McpErrorCodes.make(
-				McpErrorCodes.WRONG_TYPE,
+			return ErrorCodes.make(
+				ErrorCodes.WRONG_TYPE,
 				"drag_margins must be a dict with optional keys left/top/right/bottom"
 			)
 		var margins: Dictionary = margins_v
@@ -744,8 +746,8 @@ func set_damping_2d(params: Dictionary) -> Dictionary:
 				continue
 			var v := float(margin_v)
 			if v < 0.0 or v > 1.0:
-				return McpErrorCodes.make(
-					McpErrorCodes.INVALID_PARAMS,
+				return ErrorCodes.make(
+					ErrorCodes.INVALID_PARAMS,
 					"drag_margins.%s must be in [0, 1] (got %s)" % [edge, v]
 				)
 			var prop_name: String = "drag_%s_margin" % edge
@@ -753,8 +755,8 @@ func set_damping_2d(params: Dictionary) -> Dictionary:
 			old_values[prop_name] = node.get(prop_name)
 
 	if applied.is_empty():
-		return McpErrorCodes.make(
-			McpErrorCodes.MISSING_REQUIRED_PARAM,
+		return ErrorCodes.make(
+			ErrorCodes.MISSING_REQUIRED_PARAM,
 			"No damping params specified; provide at least one of position_speed, rotation_speed, drag_margins, drag_horizontal_enabled, drag_vertical_enabled"
 		)
 
@@ -788,30 +790,30 @@ func follow_2d(params: Dictionary) -> Dictionary:
 	var scene_root: Node = resolved.scene_root
 
 	if type_str != "2d":
-		return McpErrorCodes.make(
-			McpErrorCodes.WRONG_TYPE,
+		return ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
 			"camera_follow_2d requires a Camera2D (got %s)" % node.get_class()
 		)
 
 	var target_path: String = params.get("target_path", "")
 	if target_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: target_path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: target_path")
 	var target := McpScenePath.resolve(target_path, scene_root)
 	if target == null:
-		return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, "Target not found: %s" % target_path)
+		return ErrorCodes.make(ErrorCodes.NODE_NOT_FOUND, "Target not found: %s" % target_path)
 	if not (target is Node2D) and target != scene_root:
-		return McpErrorCodes.make(
-			McpErrorCodes.WRONG_TYPE,
+		return ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
 			"Follow target must be a Node2D (got %s)" % target.get_class()
 		)
 	if target == node:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Camera cannot follow itself")
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, "Camera cannot follow itself")
 	if target.is_ancestor_of(node) and node.get_parent() != target:
 		# A non-parent ancestor — still valid to reparent under (direct parent).
 		pass
 	if node.is_ancestor_of(target):
-		return McpErrorCodes.make(
-			McpErrorCodes.INVALID_PARAMS,
+		return ErrorCodes.make(
+			ErrorCodes.INVALID_PARAMS,
 			"Cannot follow a descendant of the camera"
 		)
 
@@ -905,10 +907,10 @@ func get_camera(params: Dictionary) -> Dictionary:
 	else:
 		node = McpScenePath.resolve(camera_path, scene_root)
 		if node == null:
-			return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_node_error(camera_path, scene_root))
+			return ErrorCodes.make(ErrorCodes.NODE_NOT_FOUND, McpScenePath.format_node_error(camera_path, scene_root))
 		if not _is_camera(node):
-			return McpErrorCodes.make(
-				McpErrorCodes.WRONG_TYPE,
+			return ErrorCodes.make(
+				ErrorCodes.WRONG_TYPE,
 				"Node %s is not a camera (got %s)" % [camera_path, node.get_class()]
 			)
 		resolved_via = "path"
@@ -980,13 +982,13 @@ func list_cameras(_params: Dictionary) -> Dictionary:
 func apply_preset(params: Dictionary) -> Dictionary:
 	var preset_name: String = params.get("preset", "")
 	if preset_name.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: preset")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: preset")
 
 	var overrides: Dictionary = params.get("overrides", {})
 	var blueprint = CameraPresets.build(preset_name, overrides)
 	if blueprint == null:
-		return McpErrorCodes.make(
-			McpErrorCodes.VALUE_OUT_OF_RANGE,
+		return ErrorCodes.make(
+			ErrorCodes.VALUE_OUT_OF_RANGE,
 			"Unknown preset '%s'. Valid: %s" % [preset_name, ", ".join(CameraPresets.list_presets())]
 		)
 
@@ -997,8 +999,8 @@ func apply_preset(params: Dictionary) -> Dictionary:
 	if node_name.is_empty():
 		node_name = preset_name.capitalize()
 	if not _VALID_TYPES.has(type_str):
-		return McpErrorCodes.make(
-			McpErrorCodes.VALUE_OUT_OF_RANGE,
+		return ErrorCodes.make(
+			ErrorCodes.VALUE_OUT_OF_RANGE,
 			"Invalid camera type '%s'. Valid: %s" % [type_str, ", ".join(_VALID_TYPES.keys())]
 		)
 
@@ -1011,7 +1013,7 @@ func apply_preset(params: Dictionary) -> Dictionary:
 	if not parent_path.is_empty():
 		parent = McpScenePath.resolve(parent_path, scene_root)
 		if parent == null:
-			return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_parent_error(parent_path, scene_root))
+			return ErrorCodes.make(ErrorCodes.NODE_NOT_FOUND, McpScenePath.format_parent_error(parent_path, scene_root))
 
 	var node := _instantiate_camera(type_str)
 	node.name = node_name
@@ -1033,7 +1035,7 @@ func apply_preset(params: Dictionary) -> Dictionary:
 			continue
 		var coerce_result := CameraValues.coerce(prop_name, preset_props[prop_name], prop_type)
 		if not coerce_result.ok:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, String(coerce_result.error))
+			return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, String(coerce_result.error))
 		node.set(prop_name, coerce_result.value)
 		applied.append(prop_name)
 
@@ -1101,8 +1103,8 @@ func _resolve_camera(params: Dictionary) -> Dictionary:
 	var node_path: String = resolved.path
 	var scene_root: Node = resolved.scene_root
 	if not _is_camera(node):
-		return McpErrorCodes.make(
-			McpErrorCodes.WRONG_TYPE,
+		return ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
 			"Node %s is not a camera (got %s)" % [node_path, node.get_class()]
 		)
 	return {

--- a/plugin/addons/godot_ai/handlers/client_handler.gd
+++ b/plugin/addons/godot_ai/handlers/client_handler.gd
@@ -1,6 +1,8 @@
 @tool
 extends RefCounted
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Handles MCP client configuration commands.
 
 
@@ -8,10 +10,10 @@ func configure_client(params: Dictionary) -> Dictionary:
 	var client_id: String = params.get("client", "")
 	if not McpClientConfigurator.has_client(client_id):
 		var valid := ", ".join(McpClientConfigurator.client_ids())
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "Unknown client: %s. Use one of: %s" % [client_id, valid])
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "Unknown client: %s. Use one of: %s" % [client_id, valid])
 	var result := McpClientConfigurator.configure(client_id)
 	if result.get("status") == "error":
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR,
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR,
 			result.get("message", "Configuration failed for '%s'" % client_id))
 	return {"data": result}
 
@@ -20,10 +22,10 @@ func remove_client(params: Dictionary) -> Dictionary:
 	var client_id: String = params.get("client", "")
 	if not McpClientConfigurator.has_client(client_id):
 		var valid := ", ".join(McpClientConfigurator.client_ids())
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "Unknown client: %s. Use one of: %s" % [client_id, valid])
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "Unknown client: %s. Use one of: %s" % [client_id, valid])
 	var result := McpClientConfigurator.remove(client_id)
 	if result.get("status") == "error":
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR,
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR,
 			result.get("message", "Removal failed for '%s'" % client_id))
 	return {"data": result}
 

--- a/plugin/addons/godot_ai/handlers/control_draw_recipe_handler.gd
+++ b/plugin/addons/godot_ai/handlers/control_draw_recipe_handler.gd
@@ -1,6 +1,8 @@
 @tool
 extends RefCounted
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Handles the control_draw_recipe MCP command. Attaches a shared DrawRecipe
 ## script to a Control and stores the caller's ordered draw ops in node
 ## metadata under "_ops". The DrawRecipe script dispatches each op to a
@@ -23,9 +25,9 @@ func control_draw_recipe(params: Dictionary) -> Dictionary:
 	var clear_existing: bool = bool(params.get("clear_existing", true))
 
 	if path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
 	if typeof(ops_raw) != TYPE_ARRAY:
-		return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "ops must be an Array")
+		return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "ops must be an Array")
 
 	var _resolved := McpNodeValidator.resolve_or_error(path, "path")
 	if _resolved.has("error"):
@@ -33,8 +35,8 @@ func control_draw_recipe(params: Dictionary) -> Dictionary:
 	var node: Node = _resolved.node
 	var scene_root: Node = _resolved.scene_root
 	if not node is Control:
-		return McpErrorCodes.make(
-			McpErrorCodes.WRONG_TYPE,
+		return ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
 			"control_draw_recipe requires a Control node, got %s" % node.get_class()
 		)
 
@@ -46,8 +48,8 @@ func control_draw_recipe(params: Dictionary) -> Dictionary:
 	var old_script: Variant = node.get_script()
 	if old_script != null and old_script != DRAW_RECIPE_SCRIPT:
 		if not clear_existing:
-			return McpErrorCodes.make(
-				McpErrorCodes.INVALID_PARAMS,
+			return ErrorCodes.make(
+				ErrorCodes.INVALID_PARAMS,
 				(
 					"Node %s already has a script. Pass clear_existing=true to replace."
 					% path
@@ -95,8 +97,8 @@ func _coerce_ops(ops: Array) -> Dictionary:
 	for i in ops.size():
 		var op: Variant = ops[i]
 		if typeof(op) != TYPE_DICTIONARY:
-			return McpErrorCodes.make(
-				McpErrorCodes.WRONG_TYPE, "ops[%d] must be a dictionary" % i
+			return ErrorCodes.make(
+				ErrorCodes.WRONG_TYPE, "ops[%d] must be a dictionary" % i
 			)
 		var coerced := _coerce_single_op(op, i)
 		if coerced.has("error"):
@@ -108,8 +110,8 @@ func _coerce_ops(ops: Array) -> Dictionary:
 func _coerce_single_op(op: Dictionary, idx: int) -> Dictionary:
 	var draw_type: String = op.get("draw", "")
 	if draw_type.is_empty():
-		return McpErrorCodes.make(
-			McpErrorCodes.MISSING_REQUIRED_PARAM, "ops[%d]: missing 'draw' field" % idx
+		return ErrorCodes.make(
+			ErrorCodes.MISSING_REQUIRED_PARAM, "ops[%d]: missing 'draw' field" % idx
 		)
 	match draw_type:
 		"line":
@@ -126,8 +128,8 @@ func _coerce_single_op(op: Dictionary, idx: int) -> Dictionary:
 			return _coerce_polyline_or_polygon(op, idx, "polygon")
 		"string":
 			return _coerce_string(op, idx)
-	return McpErrorCodes.make(
-		McpErrorCodes.VALUE_OUT_OF_RANGE,
+	return ErrorCodes.make(
+		ErrorCodes.VALUE_OUT_OF_RANGE,
 		"ops[%d]: unknown draw type '%s'" % [idx, draw_type]
 	)
 
@@ -135,8 +137,8 @@ func _coerce_single_op(op: Dictionary, idx: int) -> Dictionary:
 func _require_fields(op: Dictionary, idx: int, kind: String, fields: Array) -> Dictionary:
 	for f in fields:
 		if not op.has(f):
-			return McpErrorCodes.make(
-				McpErrorCodes.INVALID_PARAMS,
+			return ErrorCodes.make(
+				ErrorCodes.INVALID_PARAMS,
 				"ops[%d] (%s): missing '%s'" % [idx, kind, f]
 			)
 	return {}
@@ -146,8 +148,8 @@ func _coerce_typed(value: Variant, prop_type: int, idx: int, kind: String, field
 	var r := UiHandler._coerce_for_type(value, prop_type)
 	if r.ok:
 		return {"ok": true, "value": r.value}
-	return McpErrorCodes.make(
-		McpErrorCodes.VALUE_OUT_OF_RANGE, "ops[%d] (%s): invalid '%s'" % [idx, kind, field]
+	return ErrorCodes.make(
+		ErrorCodes.VALUE_OUT_OF_RANGE, "ops[%d] (%s): invalid '%s'" % [idx, kind, field]
 	)
 
 
@@ -242,20 +244,20 @@ func _coerce_circle(op: Dictionary, idx: int) -> Dictionary:
 
 func _coerce_polyline_or_polygon(op: Dictionary, idx: int, kind: String) -> Dictionary:
 	if not op.has("points"):
-		return McpErrorCodes.make(
-			McpErrorCodes.MISSING_REQUIRED_PARAM, "ops[%d] (%s): missing 'points'" % [idx, kind]
+		return ErrorCodes.make(
+			ErrorCodes.MISSING_REQUIRED_PARAM, "ops[%d] (%s): missing 'points'" % [idx, kind]
 		)
 	if typeof(op.points) != TYPE_ARRAY:
-		return McpErrorCodes.make(
-			McpErrorCodes.WRONG_TYPE,
+		return ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
 			"ops[%d] (%s): 'points' must be an Array" % [idx, kind]
 		)
 	var points := PackedVector2Array()
 	for j in op.points.size():
 		var p := UiHandler._coerce_for_type(op.points[j], TYPE_VECTOR2)
 		if not p.ok:
-			return McpErrorCodes.make(
-				McpErrorCodes.INVALID_PARAMS,
+			return ErrorCodes.make(
+				ErrorCodes.INVALID_PARAMS,
 				"ops[%d] (%s): points[%d] invalid" % [idx, kind, j]
 			)
 		points.append(p.value)
@@ -264,16 +266,16 @@ func _coerce_polyline_or_polygon(op: Dictionary, idx: int, kind: String) -> Dict
 
 	if op.has("colors"):
 		if typeof(op.colors) != TYPE_ARRAY:
-			return McpErrorCodes.make(
-				McpErrorCodes.INVALID_PARAMS,
+			return ErrorCodes.make(
+				ErrorCodes.INVALID_PARAMS,
 				"ops[%d] (%s): 'colors' must be an Array" % [idx, kind]
 			)
 		var colors := PackedColorArray()
 		for k in op.colors.size():
 			var ck := UiHandler._coerce_for_type(op.colors[k], TYPE_COLOR)
 			if not ck.ok:
-				return McpErrorCodes.make(
-					McpErrorCodes.INVALID_PARAMS,
+				return ErrorCodes.make(
+					ErrorCodes.INVALID_PARAMS,
 					"ops[%d] (%s): colors[%d] invalid" % [idx, kind, k]
 				)
 			colors.append(ck.value)
@@ -281,13 +283,13 @@ func _coerce_polyline_or_polygon(op: Dictionary, idx: int, kind: String) -> Dict
 	elif op.has("color"):
 		var c := UiHandler._coerce_for_type(op.color, TYPE_COLOR)
 		if not c.ok:
-			return McpErrorCodes.make(
-				McpErrorCodes.VALUE_OUT_OF_RANGE, "ops[%d] (%s): invalid 'color'" % [idx, kind]
+			return ErrorCodes.make(
+				ErrorCodes.VALUE_OUT_OF_RANGE, "ops[%d] (%s): invalid 'color'" % [idx, kind]
 			)
 		out["color"] = c.value
 	else:
-		return McpErrorCodes.make(
-			McpErrorCodes.MISSING_REQUIRED_PARAM,
+		return ErrorCodes.make(
+			ErrorCodes.MISSING_REQUIRED_PARAM,
 			"ops[%d] (%s): missing 'color' or 'colors'" % [idx, kind]
 		)
 

--- a/plugin/addons/godot_ai/handlers/curve_handler.gd
+++ b/plugin/addons/godot_ai/handlers/curve_handler.gd
@@ -1,6 +1,8 @@
 @tool
 extends RefCounted
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Replaces all points on a Curve / Curve2D / Curve3D resource. The point
 ## list shape depends on resource type (see `set_points` for the schemas).
 ##
@@ -30,14 +32,14 @@ func set_points(params: Dictionary) -> Dictionary:
 		return home_err
 	var has_file_target := not resource_path.is_empty()
 	if not (new_points is Array):
-		return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "points must be an array")
+		return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "points must be an array")
 
 	var curve: Resource
 	var node: Node = null
 	var curve_created := false
 	if has_file_target:
 		if not ResourceLoader.exists(resource_path):
-			return McpErrorCodes.make(McpErrorCodes.RESOURCE_NOT_FOUND, "Resource not found: %s" % resource_path)
+			return ErrorCodes.make(ErrorCodes.RESOURCE_NOT_FOUND, "Resource not found: %s" % resource_path)
 		# ResourceLoader.load() returns Godot's cached Resource. Duplicate
 		# before mutating so: (a) open scenes holding a reference to this
 		# .tres don't silently see the new points outside any undo action,
@@ -48,8 +50,8 @@ func set_points(params: Dictionary) -> Dictionary:
 		# on the response line below would crash the plugin.
 		var loaded_curve: Resource = ResourceLoader.load(resource_path)
 		if loaded_curve == null:
-			return McpErrorCodes.make(
-				McpErrorCodes.INTERNAL_ERROR,
+			return ErrorCodes.make(
+				ErrorCodes.INTERNAL_ERROR,
 				"Failed to load curve from %s (file exists but load returned null — may be corrupt)" % resource_path
 			)
 		curve = loaded_curve.duplicate()
@@ -60,10 +62,10 @@ func set_points(params: Dictionary) -> Dictionary:
 		var scene_root: Node = _scene_check.scene_root
 		node = McpScenePath.resolve(node_path, scene_root)
 		if node == null:
-			return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_node_error(node_path, scene_root))
+			return ErrorCodes.make(ErrorCodes.NODE_NOT_FOUND, McpScenePath.format_node_error(node_path, scene_root))
 		if not (property in node):
-			return McpErrorCodes.make(
-				McpErrorCodes.PROPERTY_NOT_ON_CLASS,
+			return ErrorCodes.make(
+				ErrorCodes.PROPERTY_NOT_ON_CLASS,
 				"Property '%s' not found on %s" % [property, node.get_class()]
 			)
 		curve = node.get(property)
@@ -74,18 +76,18 @@ func set_points(params: Dictionary) -> Dictionary:
 		if curve == null:
 			var inferred := _infer_curve_class(node, property)
 			if inferred.is_empty():
-				return McpErrorCodes.make(
-					McpErrorCodes.INVALID_PARAMS,
+				return ErrorCodes.make(
+					ErrorCodes.INVALID_PARAMS,
 					"Curve slot on %s.%s is null and the Curve class can't be inferred from the property hint — create one first with resource_create (type=Curve3D/Curve2D/Curve)" % [node.get_class(), property]
 				)
 			curve = ClassDB.instantiate(inferred)
 			if curve == null:
-				return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to instantiate %s" % inferred)
+				return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to instantiate %s" % inferred)
 			curve_created = true
 
 	if not (curve is Curve or curve is Curve2D or curve is Curve3D):
-		return McpErrorCodes.make(
-			McpErrorCodes.WRONG_TYPE,
+		return ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
 			"Resource is %s — must be Curve, Curve2D, or Curve3D" % curve.get_class()
 		)
 
@@ -161,8 +163,8 @@ static func _coerce_points(curve: Resource, points: Array) -> Dictionary:
 		for i in range(points.size()):
 			var p = points[i]
 			if not (p is Dictionary) or not p.has("offset") or not p.has("value"):
-				return {"error": McpErrorCodes.make(
-					McpErrorCodes.INVALID_PARAMS,
+				return {"error": ErrorCodes.make(
+					ErrorCodes.INVALID_PARAMS,
 					"Curve points[%d] must be {offset, value, [left_tangent, right_tangent]}" % i
 				)}
 			snapshot.append({
@@ -176,8 +178,8 @@ static func _coerce_points(curve: Resource, points: Array) -> Dictionary:
 		for i in range(points.size()):
 			var p2 = points[i]
 			if not (p2 is Dictionary) or not p2.has("position"):
-				return {"error": McpErrorCodes.make(
-					McpErrorCodes.INVALID_PARAMS,
+				return {"error": ErrorCodes.make(
+					ErrorCodes.INVALID_PARAMS,
 					"Curve2D points[%d] must have 'position' (and optional 'in', 'out')" % i
 				)}
 			var axes2 := {
@@ -198,8 +200,8 @@ static func _coerce_points(curve: Resource, points: Array) -> Dictionary:
 		for i in range(points.size()):
 			var p3 = points[i]
 			if not (p3 is Dictionary) or not p3.has("position"):
-				return {"error": McpErrorCodes.make(
-					McpErrorCodes.INVALID_PARAMS,
+				return {"error": ErrorCodes.make(
+					ErrorCodes.INVALID_PARAMS,
 					"Curve3D points[%d] must have 'position' (and optional 'in', 'out', 'tilt')" % i
 				)}
 			var axes3 := {

--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -1,6 +1,8 @@
 @tool
 extends RefCounted
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Handles editor state, selection, log, screenshot, and performance commands.
 
 const UpdateMixedState := preload("res://addons/godot_ai/utils/update_mixed_state.gd")
@@ -64,8 +66,8 @@ func get_logs(params: Dictionary) -> Dictionary:
 	var offset: int = maxi(0, int(params.get("offset", 0)))
 	var source: String = str(params.get("source", "plugin"))
 	if not source in VALID_LOG_SOURCES:
-		return McpErrorCodes.make(
-			McpErrorCodes.VALUE_OUT_OF_RANGE,
+		return ErrorCodes.make(
+			ErrorCodes.VALUE_OUT_OF_RANGE,
 			"Invalid source '%s' — use 'plugin', 'game', 'editor', or 'all'" % source,
 		)
 
@@ -78,7 +80,7 @@ func get_logs(params: Dictionary) -> Dictionary:
 			return _get_editor_logs(count, offset)
 		"all":
 			return _get_all_logs(count, offset)
-	return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Unreachable")
+	return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Unreachable")
 
 
 func _get_plugin_logs(count: int, offset: int) -> Dictionary:
@@ -275,10 +277,10 @@ func take_screenshot(params: Dictionary) -> Dictionary:
 		"viewport":
 			viewport = EditorInterface.get_editor_viewport_3d()
 			if viewport == null:
-				return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No 3D viewport available")
+				return ErrorCodes.make(ErrorCodes.EDITOR_NOT_READY, "No 3D viewport available")
 		"game":
 			if not EditorInterface.is_playing_scene():
-				return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Game is not running — use source='viewport' or start the project first")
+				return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, "Game is not running — use source='viewport' or start the project first")
 			## The game is always a separate OS process (embedded mode just
 			## reparents its window into the editor). Reach the framebuffer
 			## via the debugger channel: the `_mcp_game_helper` autoload
@@ -286,16 +288,16 @@ func take_screenshot(params: Dictionary) -> Dictionary:
 			## McpDebuggerPlugin pushes the response back through our
 			## WebSocket with the same request_id via McpConnection.send_deferred_response.
 			if _debugger_plugin == null or _connection == null:
-				return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Debugger bridge unavailable — plugin may not be fully initialised")
+				return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Debugger bridge unavailable — plugin may not be fully initialised")
 			var request_id: String = params.get("_request_id", "")
 			if request_id.is_empty():
-				return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Missing request_id — cannot correlate deferred response")
+				return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Missing request_id — cannot correlate deferred response")
 			_debugger_plugin.request_game_screenshot(request_id, max_resolution, _connection)
 			return McpDispatcher.DEFERRED_RESPONSE
 		"cinematic":
 			return _take_cinematic_screenshot(max_resolution)
 		_:
-			return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "Invalid source '%s' — use 'viewport', 'cinematic', or 'game'" % source)
+			return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "Invalid source '%s' — use 'viewport', 'cinematic', or 'game'" % source)
 
 	## Handle view_target: temporarily reposition the editor's own camera to
 	## frame one or more target nodes, force a render, capture, then restore.
@@ -328,11 +330,11 @@ func take_screenshot(params: Dictionary) -> Dictionary:
 				targets.append(node as Node3D)
 
 		if targets.is_empty():
-			return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, "No valid Node3D targets found: %s" % ", ".join(not_found))
+			return ErrorCodes.make(ErrorCodes.NODE_NOT_FOUND, "No valid Node3D targets found: %s" % ", ".join(not_found))
 
 		var cam := viewport.get_camera_3d()
 		if cam == null:
-			return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No camera in 3D viewport")
+			return ErrorCodes.make(ErrorCodes.EDITOR_NOT_READY, "No camera in 3D viewport")
 
 		## Merge AABBs from all targets
 		var combined_aabb := _get_visual_aabb(targets[0])
@@ -382,7 +384,7 @@ func take_screenshot(params: Dictionary) -> Dictionary:
 			## Consistent with single-shot path: error if no frames rendered
 			## (e.g. headless mode where force_draw produces no output).
 			if images.is_empty():
-				return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Coverage sweep rendered no images")
+				return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Coverage sweep rendered no images")
 
 			var aabb_center := combined_aabb.get_center()
 			var aabb_size := combined_aabb.size
@@ -420,7 +422,7 @@ func take_screenshot(params: Dictionary) -> Dictionary:
 		RenderingServer.camera_set_transform(cam_rid, saved_xform)
 
 		if image == null or image.is_empty():
-			return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Framed viewport rendered an empty image")
+			return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Framed viewport rendered an empty image")
 
 		var result := _finalize_image(image, "viewport", max_resolution)
 		result.data["view_target"] = view_target
@@ -442,7 +444,7 @@ func take_screenshot(params: Dictionary) -> Dictionary:
 	var image: Image = viewport.get_texture().get_image()
 
 	if image == null or image.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to capture image from %s" % source)
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to capture image from %s" % source)
 
 	return _finalize_image(image, source, max_resolution)
 
@@ -459,8 +461,8 @@ func _take_cinematic_screenshot(max_resolution: int) -> Dictionary:
 
 	var scene_camera := _find_current_camera_3d(scene_root)
 	if scene_camera == null:
-		return McpErrorCodes.make(
-			McpErrorCodes.NODE_NOT_FOUND,
+		return ErrorCodes.make(
+			ErrorCodes.NODE_NOT_FOUND,
 			"No current Camera3D in scene — mark a Camera3D as `current` or add one to the scene",
 		)
 
@@ -504,7 +506,7 @@ func _take_cinematic_screenshot(max_resolution: int) -> Dictionary:
 	sub_vp.queue_free()
 
 	if image == null or image.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Cinematic render produced an empty image")
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Cinematic render produced an empty image")
 
 	var result := _finalize_image(image, "cinematic", max_resolution)
 	result.data["camera_path"] = McpScenePath.from_node(scene_camera, scene_root)

--- a/plugin/addons/godot_ai/handlers/environment_handler.gd
+++ b/plugin/addons/godot_ai/handlers/environment_handler.gd
@@ -1,6 +1,8 @@
 @tool
 extends RefCounted
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Creates an Environment (+ optional Sky + ProceduralSkyMaterial) chain and
 ## either assigns it to a WorldEnvironment node or saves it to a .tres file.
 ## Bundles sub-resource creation + assignment in a single undo action.
@@ -40,8 +42,8 @@ func create_environment(params: Dictionary) -> Dictionary:
 		return home_err
 
 	if not _PRESETS.has(preset):
-		return McpErrorCodes.make(
-			McpErrorCodes.VALUE_OUT_OF_RANGE,
+		return ErrorCodes.make(
+			ErrorCodes.VALUE_OUT_OF_RANGE,
 			"Invalid preset '%s'. Valid: %s" % [preset, ", ".join(_PRESETS.keys())]
 		)
 
@@ -55,16 +57,16 @@ func create_environment(params: Dictionary) -> Dictionary:
 			var sky_config: Dictionary = (sky_param as Dictionary).duplicate()
 			var material_type: String = String(sky_config.get("sky_material", "procedural")).to_lower()
 			if material_type != "procedural":
-				return McpErrorCodes.make(
-					McpErrorCodes.INVALID_PARAMS,
+				return ErrorCodes.make(
+					ErrorCodes.INVALID_PARAMS,
 					"sky.sky_material must be 'procedural' when sky is a dictionary"
 				)
 			sky_config.erase("sky_material")
 			sky_properties = sky_config
 			want_sky = true
 		else:
-			return McpErrorCodes.make(
-				McpErrorCodes.WRONG_TYPE,
+			return ErrorCodes.make(
+				ErrorCodes.WRONG_TYPE,
 				"sky must be a bool, null, or dictionary of ProceduralSkyMaterial properties"
 			)
 
@@ -145,8 +147,8 @@ func _assign_environment(env: Environment, sky: Sky, sky_material: ProceduralSky
 	var node: Node = _resolved.node
 	var scene_root: Node = _resolved.scene_root
 	if not (node is WorldEnvironment):
-		return McpErrorCodes.make(
-			McpErrorCodes.WRONG_TYPE,
+		return ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
 			"Node at %s is %s — must be WorldEnvironment" % [node_path, node.get_class()]
 		)
 

--- a/plugin/addons/godot_ai/handlers/filesystem_handler.gd
+++ b/plugin/addons/godot_ai/handlers/filesystem_handler.gd
@@ -1,6 +1,8 @@
 @tool
 extends RefCounted
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Handles file read/write operations and reimport within the Godot project.
 
 
@@ -9,14 +11,14 @@ func read_file(params: Dictionary) -> Dictionary:
 
 	var path_err := McpPathValidator.validate_resource_path(path)
 	if not path_err.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, path_err)
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, path_err)
 
 	if not FileAccess.file_exists(path):
-		return McpErrorCodes.make(McpErrorCodes.RESOURCE_NOT_FOUND, "File not found: %s" % path)
+		return ErrorCodes.make(ErrorCodes.RESOURCE_NOT_FOUND, "File not found: %s" % path)
 
 	var file := FileAccess.open(path, FileAccess.READ)
 	if file == null:
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to open file: %s" % path)
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to open file: %s" % path)
 
 	var content := file.get_as_text()
 	file.close()
@@ -37,20 +39,20 @@ func write_file(params: Dictionary) -> Dictionary:
 
 	var path_err := McpPathValidator.validate_resource_path(path)
 	if not path_err.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, path_err)
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, path_err)
 
 	# Ensure parent directory exists
 	var dir_path := path.get_base_dir()
 	if not DirAccess.dir_exists_absolute(dir_path):
 		var err := DirAccess.make_dir_recursive_absolute(dir_path)
 		if err != OK:
-			return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to create directory: %s" % dir_path)
+			return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to create directory: %s" % dir_path)
 
 	var existed_before := FileAccess.file_exists(path)
 
 	var file := FileAccess.open(path, FileAccess.WRITE)
 	if file == null:
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to open file for writing: %s" % path)
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to open file for writing: %s" % path)
 
 	file.store_string(content)
 	file.close()
@@ -72,11 +74,11 @@ func reimport(params: Dictionary) -> Dictionary:
 	var paths: Array = params.get("paths", [])
 
 	if paths.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: paths (non-empty array)")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: paths (non-empty array)")
 
 	var efs := EditorInterface.get_resource_filesystem()
 	if efs == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "EditorFileSystem not available")
+		return ErrorCodes.make(ErrorCodes.EDITOR_NOT_READY, "EditorFileSystem not available")
 
 	var reimported: Array[String] = []
 	var not_found: Array[String] = []

--- a/plugin/addons/godot_ai/handlers/input_handler.gd
+++ b/plugin/addons/godot_ai/handlers/input_handler.gd
@@ -1,6 +1,8 @@
 @tool
 extends RefCounted
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Handles input action listing, creation, removal, and event binding.
 ## Actions are persisted via ProjectSettings so they survive editor restarts.
 
@@ -50,10 +52,10 @@ func add_action(params: Dictionary) -> Dictionary:
 	var deadzone: float = params.get("deadzone", 0.5)
 
 	if action.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: action")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: action")
 
 	if InputMap.has_action(action):
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Action '%s' already exists" % action)
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, "Action '%s' already exists" % action)
 
 	InputMap.add_action(action, deadzone)
 
@@ -66,7 +68,7 @@ func add_action(params: Dictionary) -> Dictionary:
 	if err != OK:
 		InputMap.erase_action(action)
 		ProjectSettings.clear(key)
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR,
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR,
 			"Failed to save project settings while adding action '%s': %s (error %d)" % [action, error_string(err), err])
 
 	return {
@@ -82,10 +84,10 @@ func add_action(params: Dictionary) -> Dictionary:
 func remove_action(params: Dictionary) -> Dictionary:
 	var action: String = params.get("action", "")
 	if action.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: action")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: action")
 
 	if not InputMap.has_action(action):
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "Action '%s' not found" % action)
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "Action '%s' not found" % action)
 
 	var key := "input/%s" % action
 	var old_setting = ProjectSettings.get_setting(key) if ProjectSettings.has_setting(key) else null
@@ -102,7 +104,7 @@ func remove_action(params: Dictionary) -> Dictionary:
 					if ev is InputEvent:
 						InputMap.action_add_event(action, ev)
 			ProjectSettings.set_setting(key, old_setting)
-			return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR,
+			return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR,
 				"Failed to save project settings while removing action '%s': %s (error %d)" % [action, error_string(err), err])
 
 	return {
@@ -120,23 +122,23 @@ func bind_event(params: Dictionary) -> Dictionary:
 	var event_type: String = params.get("event_type", "")
 
 	if action.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: action")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: action")
 	if event_type.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: event_type")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: event_type")
 
 	if not InputMap.has_action(action):
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "Action '%s' not found" % action)
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "Action '%s' not found" % action)
 
 	var event: InputEvent = _create_event(event_type, params)
 	if event == null:
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "Unsupported event_type: %s (use key, mouse_button, or joy_button)" % event_type)
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "Unsupported event_type: %s (use key, mouse_button, or joy_button)" % event_type)
 
 	InputMap.action_add_event(action, event)
 
 	var err := _save_action_events(action)
 	if err != OK:
 		InputMap.action_erase_event(action, event)
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR,
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR,
 			"Failed to save project settings while binding event to action '%s': %s (error %d)" % [action, error_string(err), err])
 
 	return {

--- a/plugin/addons/godot_ai/handlers/material_handler.gd
+++ b/plugin/addons/godot_ai/handlers/material_handler.gd
@@ -1,6 +1,8 @@
 @tool
 extends RefCounted
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Handles Material authoring: creating .tres files, setting BaseMaterial3D
 ## properties / shader uniforms, assigning to nodes, high-level presets.
 ##
@@ -43,47 +45,47 @@ func create_material(params: Dictionary) -> Dictionary:
 		return err
 
 	if not _TYPE_TO_CLASS.has(type_str):
-		return McpErrorCodes.make(
-			McpErrorCodes.VALUE_OUT_OF_RANGE,
+		return ErrorCodes.make(
+			ErrorCodes.VALUE_OUT_OF_RANGE,
 			"Invalid material type '%s'. Valid: %s" % [type_str, ", ".join(_TYPE_TO_CLASS.keys())]
 		)
 
 	var existed_before := FileAccess.file_exists(path)
 	if existed_before and not overwrite:
-		return McpErrorCodes.make(
-			McpErrorCodes.INVALID_PARAMS,
+		return ErrorCodes.make(
+			ErrorCodes.INVALID_PARAMS,
 			"Material already exists at %s (pass overwrite=true to replace)" % path
 		)
 
 	var mat := _instantiate_material(type_str)
 	if mat == null:
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to instantiate material")
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to instantiate material")
 
 	if type_str == "shader":
 		if shader_path.is_empty():
-			return McpErrorCodes.make(
-				McpErrorCodes.INVALID_PARAMS,
+			return ErrorCodes.make(
+				ErrorCodes.INVALID_PARAMS,
 				"ShaderMaterial requires shader_path (res:// path to a .gdshader)"
 			)
 		if not ResourceLoader.exists(shader_path):
-			return McpErrorCodes.make(McpErrorCodes.RESOURCE_NOT_FOUND, "Shader not found: %s" % shader_path)
+			return ErrorCodes.make(ErrorCodes.RESOURCE_NOT_FOUND, "Shader not found: %s" % shader_path)
 		var shader_res := ResourceLoader.load(shader_path)
 		if not (shader_res is Shader):
-			return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "Resource at %s is not a Shader" % shader_path)
+			return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "Resource at %s is not a Shader" % shader_path)
 		(mat as ShaderMaterial).shader = shader_res
 
 	var dir_path := path.get_base_dir()
 	var mkdir_err := DirAccess.make_dir_recursive_absolute(dir_path)
 	if mkdir_err != OK and mkdir_err != ERR_ALREADY_EXISTS:
-		return McpErrorCodes.make(
-			McpErrorCodes.INTERNAL_ERROR,
+		return ErrorCodes.make(
+			ErrorCodes.INTERNAL_ERROR,
 			"Failed to create directory: %s (error %d)" % [dir_path, mkdir_err]
 		)
 
 	var save_err := ResourceSaver.save(mat, path)
 	if save_err != OK:
-		return McpErrorCodes.make(
-			McpErrorCodes.INTERNAL_ERROR,
+		return ErrorCodes.make(
+			ErrorCodes.INTERNAL_ERROR,
 			"Failed to save material to %s (error %d)" % [path, save_err]
 		)
 
@@ -117,10 +119,10 @@ func set_param(params: Dictionary) -> Dictionary:
 
 	var property: String = params.get("param", "")
 	if property.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: param")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: param")
 
 	if not ("value" in params):
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: value")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: value")
 
 	var raw_value = params.get("value")
 
@@ -134,14 +136,14 @@ func set_param(params: Dictionary) -> Dictionary:
 			prop_type = prop.get("type", TYPE_NIL)
 			break
 	if not property_exists:
-		return McpErrorCodes.make(
-			McpErrorCodes.PROPERTY_NOT_ON_CLASS,
+		return ErrorCodes.make(
+			ErrorCodes.PROPERTY_NOT_ON_CLASS,
 			McpPropertyErrors.build_message(mat, property)
 		)
 
 	var coerced := MaterialValues.coerce_material_value(property, raw_value, prop_type)
 	if not coerced.ok:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, String(coerced.error))
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, String(coerced.error))
 	var new_value = coerced.value
 
 	var old_value = mat.get(property)
@@ -174,36 +176,36 @@ func set_shader_param(params: Dictionary) -> Dictionary:
 	var mat_path: String = load_result.path
 
 	if not (mat is ShaderMaterial):
-		return McpErrorCodes.make(
-			McpErrorCodes.WRONG_TYPE,
+		return ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
 			"Material at %s is %s, not ShaderMaterial" % [mat_path, mat.get_class()]
 		)
 	var shader_mat := mat as ShaderMaterial
 	if shader_mat.shader == null:
-		return McpErrorCodes.make(
-			McpErrorCodes.WRONG_TYPE,
+		return ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
 			"ShaderMaterial at %s has no shader assigned" % mat_path
 		)
 
 	var param_name: String = params.get("param", "")
 	if param_name.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: param")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: param")
 
 	if not ("value" in params):
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: value")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: value")
 
 	# Verify the uniform exists in the shader.
 	var uniform_type := _shader_uniform_type(shader_mat.shader, param_name)
 	if uniform_type == TYPE_NIL:
-		return McpErrorCodes.make(
-			McpErrorCodes.PROPERTY_NOT_ON_CLASS,
+		return ErrorCodes.make(
+			ErrorCodes.PROPERTY_NOT_ON_CLASS,
 			"Shader uniform '%s' not declared on shader at %s" % [param_name, shader_mat.shader.resource_path]
 		)
 
 	var raw_value = params.get("value")
 	var coerced := MaterialValues.coerce_material_value(param_name, raw_value, uniform_type)
 	if not coerced.ok:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, String(coerced.error))
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, String(coerced.error))
 	var new_value = coerced.value
 
 	var old_value = shader_mat.get_shader_parameter(param_name)
@@ -296,11 +298,11 @@ func list_materials(params: Dictionary) -> Dictionary:
 	var type_filter: String = params.get("type", "")
 
 	if not root.begins_with("res://"):
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "root must start with res://")
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "root must start with res://")
 
 	var efs := EditorInterface.get_resource_filesystem()
 	if efs == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "EditorFileSystem not available")
+		return ErrorCodes.make(ErrorCodes.EDITOR_NOT_READY, "EditorFileSystem not available")
 
 	var results: Array[Dictionary] = []
 	var start_dir := efs.get_filesystem_path(root)
@@ -342,7 +344,7 @@ func _scan_materials(dir: EditorFileSystemDirectory, type_filter: String, root: 
 func assign_material(params: Dictionary) -> Dictionary:
 	var node_path: String = params.get("node_path", "")
 	if node_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: node_path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: node_path")
 
 	var _resolved := McpNodeValidator.resolve_or_error(node_path, "node_path")
 	if _resolved.has("error"):
@@ -369,30 +371,30 @@ func assign_material(params: Dictionary) -> Dictionary:
 				# We'd need to create a new file here — refuse; callers should
 				# use material_create first or omit resource_path to get an
 				# inline material.
-				return McpErrorCodes.make(
-					McpErrorCodes.RESOURCE_NOT_FOUND,
+				return ErrorCodes.make(
+					ErrorCodes.RESOURCE_NOT_FOUND,
 					"Resource not found: %s. Create it first with material_create or omit resource_path for an inline material." % resource_path
 				)
-			return McpErrorCodes.make(McpErrorCodes.RESOURCE_NOT_FOUND, "Resource not found: %s" % resource_path)
+			return ErrorCodes.make(ErrorCodes.RESOURCE_NOT_FOUND, "Resource not found: %s" % resource_path)
 		var loaded := ResourceLoader.load(resource_path)
 		if not (loaded is Material):
 			var loaded_class := "null"
 			if loaded != null:
 				loaded_class = loaded.get_class()
-			return McpErrorCodes.make(
-				McpErrorCodes.WRONG_TYPE,
+			return ErrorCodes.make(
+				ErrorCodes.WRONG_TYPE,
 				"Resource at %s is not a Material (got %s)" % [resource_path, loaded_class]
 			)
 		mat = loaded
 	else:
 		if not create_if_missing:
-			return McpErrorCodes.make(
-				McpErrorCodes.INVALID_PARAMS,
+			return ErrorCodes.make(
+				ErrorCodes.INVALID_PARAMS,
 				"Missing resource_path (pass create_if_missing=true to create a new inline material)"
 			)
 		if not _TYPE_TO_CLASS.has(type_str):
-			return McpErrorCodes.make(
-				McpErrorCodes.VALUE_OUT_OF_RANGE,
+			return ErrorCodes.make(
+				ErrorCodes.VALUE_OUT_OF_RANGE,
 				"Invalid material type '%s'" % type_str
 			)
 		mat = _instantiate_material(type_str)
@@ -427,12 +429,12 @@ func assign_material(params: Dictionary) -> Dictionary:
 func apply_to_node(params: Dictionary) -> Dictionary:
 	var node_path: String = params.get("node_path", "")
 	if node_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: node_path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: node_path")
 
 	var type_str: String = params.get("type", "standard")
 	if not _TYPE_TO_CLASS.has(type_str):
-		return McpErrorCodes.make(
-			McpErrorCodes.VALUE_OUT_OF_RANGE,
+		return ErrorCodes.make(
+			ErrorCodes.VALUE_OUT_OF_RANGE,
 			"Invalid material type '%s'. Valid: %s" % [type_str, ", ".join(_TYPE_TO_CLASS.keys())]
 		)
 
@@ -467,10 +469,10 @@ func apply_to_node(params: Dictionary) -> Dictionary:
 		var dir_path := save_to.get_base_dir()
 		var mkdir_err := DirAccess.make_dir_recursive_absolute(dir_path)
 		if mkdir_err != OK and mkdir_err != ERR_ALREADY_EXISTS:
-			return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to create directory: %s" % dir_path)
+			return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to create directory: %s" % dir_path)
 		var save_err := ResourceSaver.save(mat, save_to)
 		if save_err != OK:
-			return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to save material to %s (error %d)" % [save_to, save_err])
+			return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to save material to %s (error %d)" % [save_to, save_err])
 		var efs := EditorInterface.get_resource_filesystem()
 		if efs != null:
 			efs.update_file(save_to)
@@ -507,13 +509,13 @@ func apply_to_node(params: Dictionary) -> Dictionary:
 func apply_preset(params: Dictionary) -> Dictionary:
 	var preset_name: String = params.get("preset", "")
 	if preset_name.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: preset")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: preset")
 
 	var overrides: Dictionary = params.get("overrides", {})
 	var blueprint = MaterialPresets.build(preset_name, overrides)
 	if blueprint == null:
-		return McpErrorCodes.make(
-			McpErrorCodes.VALUE_OUT_OF_RANGE,
+		return ErrorCodes.make(
+			ErrorCodes.VALUE_OUT_OF_RANGE,
 			"Unknown preset '%s'. Valid: %s" % [preset_name, ", ".join(MaterialPresets.list())]
 		)
 
@@ -524,8 +526,8 @@ func apply_preset(params: Dictionary) -> Dictionary:
 	var node_path: String = params.get("node_path", "")
 
 	if path.is_empty() and node_path.is_empty():
-		return McpErrorCodes.make(
-			McpErrorCodes.MISSING_REQUIRED_PARAM,
+		return ErrorCodes.make(
+			ErrorCodes.MISSING_REQUIRED_PARAM,
 			"Pass at least one of: path (save to disk), node_path (assign to node)"
 		)
 
@@ -552,8 +554,8 @@ func apply_preset(params: Dictionary) -> Dictionary:
 	# Save-to-disk path.
 	var existed_before := FileAccess.file_exists(path)
 	if existed_before and not params.get("overwrite", false):
-		return McpErrorCodes.make(
-			McpErrorCodes.INVALID_PARAMS,
+		return ErrorCodes.make(
+			ErrorCodes.INVALID_PARAMS,
 			"Material already exists at %s (pass overwrite=true to replace)" % path
 		)
 
@@ -570,11 +572,11 @@ func apply_preset(params: Dictionary) -> Dictionary:
 	var dir_path := path.get_base_dir()
 	var mkdir_err := DirAccess.make_dir_recursive_absolute(dir_path)
 	if mkdir_err != OK and mkdir_err != ERR_ALREADY_EXISTS:
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to create directory: %s" % dir_path)
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to create directory: %s" % dir_path)
 
 	var save_err := ResourceSaver.save(mat, path)
 	if save_err != OK:
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to save material: %s" % path)
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to save material: %s" % path)
 
 	var efs := EditorInterface.get_resource_filesystem()
 	if efs != null:
@@ -660,17 +662,17 @@ static func _reverse_type_map() -> Dictionary:
 
 static func _validate_material_path(path: String, param_name: String) -> Variant:
 	if path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: %s" % param_name)
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: %s" % param_name)
 	if not path.begins_with("res://"):
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "%s must start with res:// (got %s)" % [param_name, path])
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, "%s must start with res:// (got %s)" % [param_name, path])
 	var has_suffix := false
 	for s in _SUPPORTED_SUFFIXES:
 		if path.ends_with(s):
 			has_suffix = true
 			break
 	if not has_suffix:
-		return McpErrorCodes.make(
-			McpErrorCodes.VALUE_OUT_OF_RANGE,
+		return ErrorCodes.make(
+			ErrorCodes.VALUE_OUT_OF_RANGE,
 			"%s must end with one of %s (got %s)" % [param_name, ", ".join(_SUPPORTED_SUFFIXES), path]
 		)
 	return null
@@ -681,10 +683,10 @@ func _load_material_from_path(path: String) -> Dictionary:
 	if err != null:
 		return err
 	if not ResourceLoader.exists(path):
-		return McpErrorCodes.make(McpErrorCodes.RESOURCE_NOT_FOUND, "Material not found: %s" % path)
+		return ErrorCodes.make(ErrorCodes.RESOURCE_NOT_FOUND, "Material not found: %s" % path)
 	var res := ResourceLoader.load(path)
 	if res == null or not (res is Material):
-		return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "Resource at %s is not a Material" % path)
+		return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "Resource at %s is not a Material" % path)
 	return {"material": res, "path": path}
 
 
@@ -698,44 +700,44 @@ func _resolve_slot_property(node: Node, slot: String) -> Dictionary:
 			return {"property": "material"}
 		if node is GPUParticles3D or node is GPUParticles2D or node is CPUParticles3D or node is CPUParticles2D:
 			return {"property": "material_override"} if node is GeometryInstance3D else {"property": "material"}
-		return McpErrorCodes.make(
-			McpErrorCodes.PROPERTY_NOT_ON_CLASS,
+		return ErrorCodes.make(
+			ErrorCodes.PROPERTY_NOT_ON_CLASS,
 			"Slot 'override' not supported on %s" % node.get_class()
 		)
 	if slot == "canvas":
 		if node is CanvasItem:
 			return {"property": "material"}
-		return McpErrorCodes.make(
-			McpErrorCodes.WRONG_TYPE,
+		return ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
 			"Slot 'canvas' requires a CanvasItem (got %s)" % node.get_class()
 		)
 	if slot == "process":
 		if node is GPUParticles3D or node is GPUParticles2D:
 			return {"property": "process_material"}
-		return McpErrorCodes.make(
-			McpErrorCodes.WRONG_TYPE,
+		return ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
 			"Slot 'process' requires a GPUParticles2D/3D (got %s)" % node.get_class()
 		)
 	if slot.begins_with("surface_"):
 		if not (node is MeshInstance3D):
-			return McpErrorCodes.make(
-				McpErrorCodes.WRONG_TYPE,
+			return ErrorCodes.make(
+				ErrorCodes.WRONG_TYPE,
 				"Slot '%s' requires a MeshInstance3D (got %s)" % [slot, node.get_class()]
 			)
 		var idx_str := slot.substr(len("surface_"))
 		if not idx_str.is_valid_int():
-			return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "Invalid surface slot: %s" % slot)
+			return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "Invalid surface slot: %s" % slot)
 		var idx := int(idx_str)
 		var mi := node as MeshInstance3D
 		var surf_count := mi.mesh.get_surface_count() if mi.mesh != null else 0
 		if idx < 0 or idx >= surf_count:
-			return McpErrorCodes.make(
-				McpErrorCodes.INVALID_PARAMS,
+			return ErrorCodes.make(
+				ErrorCodes.INVALID_PARAMS,
 				"Surface index %d out of range (mesh has %d surfaces)" % [idx, surf_count]
 			)
 		return {"property": "surface_material_override/%d" % idx}
-	return McpErrorCodes.make(
-		McpErrorCodes.VALUE_OUT_OF_RANGE,
+	return ErrorCodes.make(
+		ErrorCodes.VALUE_OUT_OF_RANGE,
 		"Unknown slot '%s'. Valid: override, canvas, process, surface_N" % slot
 	)
 
@@ -751,13 +753,13 @@ func _apply_one_param_on_instance(mat: Material, property: String, raw_value: Va
 			prop_type = prop.get("type", TYPE_NIL)
 			break
 	if not property_exists:
-		return McpErrorCodes.make(
-			McpErrorCodes.PROPERTY_NOT_ON_CLASS,
+		return ErrorCodes.make(
+			ErrorCodes.PROPERTY_NOT_ON_CLASS,
 			McpPropertyErrors.build_message(mat, property)
 		)
 	var coerced := MaterialValues.coerce_material_value(property, raw_value, prop_type)
 	if not coerced.ok:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, String(coerced.error))
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, String(coerced.error))
 	mat.set(property, coerced.value)
 	return null
 

--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -1,6 +1,8 @@
 @tool
 extends RefCounted
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Handles node creation and manipulation with undo/redo support.
 
 const ResourceHandler := preload("res://addons/godot_ai/handlers/resource_handler.gd")
@@ -27,7 +29,7 @@ func create_node(params: Dictionary) -> Dictionary:
 	if not parent_path.is_empty():
 		parent = McpScenePath.resolve(parent_path, scene_root)
 		if parent == null:
-			return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_parent_error(parent_path, scene_root))
+			return ErrorCodes.make(ErrorCodes.NODE_NOT_FOUND, McpScenePath.format_parent_error(parent_path, scene_root))
 
 	var new_node: Node
 
@@ -38,26 +40,26 @@ func create_node(params: Dictionary) -> Dictionary:
 		# an exploded subtree). Descendants remain owned by their sub-scene;
 		# setting their owner to our scene_root would break the instance link.
 		if not scene_path.begins_with("res://"):
-			return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "scene_path must start with res://")
+			return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "scene_path must start with res://")
 		if not ResourceLoader.exists(scene_path):
-			return McpErrorCodes.make(McpErrorCodes.RESOURCE_NOT_FOUND, "Scene not found: %s" % scene_path)
+			return ErrorCodes.make(ErrorCodes.RESOURCE_NOT_FOUND, "Scene not found: %s" % scene_path)
 		var packed_scene = ResourceLoader.load(scene_path)
 		if packed_scene == null or not packed_scene is PackedScene:
-			return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "Resource at %s is not a PackedScene" % scene_path)
+			return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "Resource at %s is not a PackedScene" % scene_path)
 		new_node = packed_scene.instantiate(PackedScene.GEN_EDIT_STATE_INSTANCE)
 		if new_node == null:
-			return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to instantiate scene: %s" % scene_path)
+			return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to instantiate scene: %s" % scene_path)
 	else:
 		# ClassDB path — create by type.
 		if node_type.is_empty():
-			return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: type (or provide scene_path)")
+			return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: type (or provide scene_path)")
 		if not ClassDB.class_exists(node_type):
-			return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "Unknown node type: %s" % node_type)
+			return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "Unknown node type: %s" % node_type)
 		if not ClassDB.is_parent_class(node_type, "Node"):
-			return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "%s is not a Node type" % node_type)
+			return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "%s is not a Node type" % node_type)
 		new_node = ClassDB.instantiate(node_type)
 		if new_node == null:
-			return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to instantiate %s" % node_type)
+			return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to instantiate %s" % node_type)
 
 	if not node_name.is_empty():
 		new_node.name = node_name
@@ -122,11 +124,11 @@ func reparent_node(params: Dictionary) -> Dictionary:
 
 	var new_parent_path: String = params.get("new_parent", "")
 	if new_parent_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: new_parent")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: new_parent")
 
 	var new_parent := McpScenePath.resolve(new_parent_path, scene_root)
 	if new_parent == null:
-		return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_parent_error(new_parent_path, scene_root))
+		return ErrorCodes.make(ErrorCodes.NODE_NOT_FOUND, McpScenePath.format_parent_error(new_parent_path, scene_root))
 
 	var root_err := _reject_if_scene_root(node, scene_root, "reparent")
 	if root_err != null:
@@ -140,7 +142,7 @@ func reparent_node(params: Dictionary) -> Dictionary:
 	# the opposite question — whether we were trying to move a node to one of
 	# its own ancestors — which is a perfectly valid operation. See issue #121.
 	if node == new_parent or node.is_ancestor_of(new_parent):
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Cannot reparent a node to itself or its descendant")
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, "Cannot reparent a node to itself or its descendant")
 
 	var old_parent := node.get_parent()
 	var old_idx := node.get_index()
@@ -180,10 +182,10 @@ func set_property(params: Dictionary) -> Dictionary:
 
 	var property: String = params.get("property", "")
 	if property.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: property")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: property")
 
 	if not "value" in params:
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: value")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: value")
 
 	var value = params.get("value")
 
@@ -195,7 +197,7 @@ func set_property(params: Dictionary) -> Dictionary:
 			prop_type = prop.get("type", TYPE_NIL)
 			break
 	if not found:
-		return McpErrorCodes.make(McpErrorCodes.PROPERTY_NOT_ON_CLASS, McpPropertyErrors.build_message(node, property))
+		return ErrorCodes.make(ErrorCodes.PROPERTY_NOT_ON_CLASS, McpPropertyErrors.build_message(node, property))
 
 	var old_value = node.get(property)
 	# Prefer declared property type; fall back to runtime type for dynamic props
@@ -221,10 +223,10 @@ func set_property(params: Dictionary) -> Dictionary:
 			value = null
 		else:
 			if not ResourceLoader.exists(value):
-				return McpErrorCodes.make(McpErrorCodes.RESOURCE_NOT_FOUND, "Resource not found: %s" % value)
+				return ErrorCodes.make(ErrorCodes.RESOURCE_NOT_FOUND, "Resource not found: %s" % value)
 			var loaded := ResourceLoader.load(value)
 			if loaded == null:
-				return McpErrorCodes.make(McpErrorCodes.RESOURCE_NOT_FOUND, "Resource not found: %s" % value)
+				return ErrorCodes.make(ErrorCodes.RESOURCE_NOT_FOUND, "Resource not found: %s" % value)
 			value = loaded
 	elif target_type == TYPE_OBJECT and value is Dictionary and value.has("__class__"):
 		# Shortcut: {"__class__": "BoxMesh", "size": {...}} instantiates a
@@ -237,8 +239,8 @@ func set_property(params: Dictionary) -> Dictionary:
 			return class_err
 		var instance := ClassDB.instantiate(type_str)
 		if instance == null or not (instance is Resource):
-			return McpErrorCodes.make(
-				McpErrorCodes.INTERNAL_ERROR,
+			return ErrorCodes.make(
+				ErrorCodes.INTERNAL_ERROR,
 				"Failed to instantiate %s as a Resource" % type_str
 			)
 		var res: Resource = instance
@@ -287,7 +289,7 @@ func rename_node(params: Dictionary) -> Dictionary:
 
 	var new_name: String = params.get("new_name", "")
 	if new_name.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: new_name")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: new_name")
 
 	## The scene root's name is baked into the .tscn serialization and is
 	## referenced by every NodePath that starts with `/<root>` (AnimationPlayer
@@ -295,10 +297,10 @@ func rename_node(params: Dictionary) -> Dictionary:
 	## Renaming it silently breaks those references. The MCP tool's docstring
 	## has always promised "Cannot rename the scene root" — enforce it. #122
 	if node == scene_root:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Cannot rename the scene root")
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, "Cannot rename the scene root")
 
 	if new_name.validate_node_name() != new_name:
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "Invalid characters in name: %s" % new_name)
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "Invalid characters in name: %s" % new_name)
 
 	var old_name := String(node.name)
 	if old_name == new_name:
@@ -316,7 +318,7 @@ func rename_node(params: Dictionary) -> Dictionary:
 	var parent := node.get_parent()
 	for sibling in parent.get_children():
 		if sibling != node and String(sibling.name) == new_name:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "A sibling already has the name '%s'" % new_name)
+			return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, "A sibling already has the name '%s'" % new_name)
 
 	_undo_redo.create_action("MCP: Rename %s to %s" % [old_name, new_name])
 	_undo_redo.add_do_property(node, "name", new_name)
@@ -349,7 +351,7 @@ func duplicate_node(params: Dictionary) -> Dictionary:
 	var parent := node.get_parent()
 	var dup: Node = node.duplicate()
 	if dup == null:
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to duplicate node")
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to duplicate node")
 
 	# Apply optional name
 	var new_name: String = params.get("name", "")
@@ -390,7 +392,7 @@ func move_node(params: Dictionary) -> Dictionary:
 		return root_err
 
 	if not "index" in params:
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: index")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: index")
 
 	var new_index: int = params.get("index", 0)
 	var parent := node.get_parent()
@@ -398,7 +400,7 @@ func move_node(params: Dictionary) -> Dictionary:
 	var sibling_count := parent.get_child_count()
 
 	if new_index < 0 or new_index >= sibling_count:
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "Index %d out of range (0..%d)" % [new_index, sibling_count - 1])
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "Index %d out of range (0..%d)" % [new_index, sibling_count - 1])
 
 	_undo_redo.create_action("MCP: Move %s to index %d" % [node.name, new_index])
 	_undo_redo.add_do_method(parent, "move_child", node, new_index)
@@ -428,7 +430,7 @@ func add_to_group(params: Dictionary) -> Dictionary:
 		return type_err
 	var group := String(group_value)
 	if group.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: group")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: group")
 
 	if node.is_in_group(group):
 		return {"data": {"path": node_path, "group": group, "already_member": true, "undoable": false, "reason": "No change made"}}
@@ -460,7 +462,7 @@ func remove_from_group(params: Dictionary) -> Dictionary:
 		return type_err
 	var group := String(group_value)
 	if group.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: group")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: group")
 
 	if not node.is_in_group(group):
 		return {"data": {"path": node_path, "group": group, "not_member": true, "undoable": false, "reason": "Node not in group"}}
@@ -551,14 +553,14 @@ static func _check_coerced(value: Variant, target_type: int, prefix: String = ""
 		return null
 	var dict_err := _check_dict_coerce_failed(value, target_type)
 	if dict_err != null:
-		return McpErrorCodes.prefix_message(dict_err, prefix)
-	var err := McpErrorCodes.make(
-		McpErrorCodes.WRONG_TYPE,
+		return ErrorCodes.prefix_message(dict_err, prefix)
+	var err := ErrorCodes.make(
+		ErrorCodes.WRONG_TYPE,
 		"Cannot coerce %s to %s; expected a dict like %s" % [
 			type_string(typeof(value)), type_string(target_type), _shape_hint(target_type),
 		],
 	)
-	return McpErrorCodes.prefix_message(err, prefix)
+	return ErrorCodes.prefix_message(err, prefix)
 
 
 ## Build a "{\"x\":1,...}" hint string from the canonical key constants
@@ -598,8 +600,8 @@ static func _check_dict_coerce_failed(value: Variant, target_type: int) -> Varia
 		_:
 			return null
 	var got_keys: Array = (value as Dictionary).keys()
-	return McpErrorCodes.make(
-		McpErrorCodes.WRONG_TYPE,
+	return ErrorCodes.make(
+		ErrorCodes.WRONG_TYPE,
 		"Cannot coerce dict to %s: expected keys %s; got %s" % [type_name, str(expected), str(got_keys)]
 	)
 
@@ -749,7 +751,7 @@ func _resolve_node(params: Dictionary) -> Dictionary:
 ## dict with "Cannot <op> the scene root", or null if `node` is not the root.
 static func _reject_if_scene_root(node: Node, scene_root: Node, op: String) -> Variant:
 	if node == scene_root:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Cannot %s the scene root" % op)
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, "Cannot %s the scene root" % op)
 	return null
 
 

--- a/plugin/addons/godot_ai/handlers/particle_handler.gd
+++ b/plugin/addons/godot_ai/handlers/particle_handler.gd
@@ -1,6 +1,8 @@
 @tool
 extends RefCounted
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Handles particle emitter authoring (GPU + CPU, 2D + 3D).
 ##
 ## All write operations bundle node creation and sub-resource spawns
@@ -49,8 +51,8 @@ func create_particle(params: Dictionary) -> Dictionary:
 	var type_str: String = params.get("type", "gpu_3d")
 
 	if not _VALID_TYPES.has(type_str):
-		return McpErrorCodes.make(
-			McpErrorCodes.VALUE_OUT_OF_RANGE,
+		return ErrorCodes.make(
+			ErrorCodes.VALUE_OUT_OF_RANGE,
 			"Invalid particle type '%s'. Valid: %s" % [type_str, ", ".join(_VALID_TYPES.keys())]
 		)
 
@@ -63,11 +65,11 @@ func create_particle(params: Dictionary) -> Dictionary:
 	if not parent_path.is_empty():
 		parent = McpScenePath.resolve(parent_path, scene_root)
 		if parent == null:
-			return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_parent_error(parent_path, scene_root))
+			return ErrorCodes.make(ErrorCodes.NODE_NOT_FOUND, McpScenePath.format_parent_error(parent_path, scene_root))
 
 	var node := _instantiate_particle(type_str)
 	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to instantiate particle node")
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to instantiate particle node")
 	if not node_name.is_empty():
 		node.name = node_name
 
@@ -135,26 +137,26 @@ func set_main(params: Dictionary) -> Dictionary:
 
 	var properties: Dictionary = params.get("properties", {})
 	if properties.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "properties dict is empty")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "properties dict is empty")
 
 	var coerced: Dictionary = {}
 	var old_values: Dictionary = {}
 	for property in properties:
 		var prop_name: String = String(property)
 		if not (prop_name in _MAIN_KEYS):
-			return McpErrorCodes.make(
-				McpErrorCodes.INVALID_PARAMS,
+			return ErrorCodes.make(
+				ErrorCodes.INVALID_PARAMS,
 				"Unknown main property '%s'. Valid: %s" % [prop_name, ", ".join(_MAIN_KEYS)]
 			)
 		var prop_type := _node_property_type(node, prop_name)
 		if prop_type == TYPE_NIL:
-			return McpErrorCodes.make(
-				McpErrorCodes.PROPERTY_NOT_ON_CLASS,
+			return ErrorCodes.make(
+				ErrorCodes.PROPERTY_NOT_ON_CLASS,
 				"Property '%s' not present on %s" % [prop_name, node.get_class()]
 			)
 		var coerce_result := ParticleValues.coerce(prop_name, properties[prop_name], prop_type)
 		if not coerce_result.ok:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, String(coerce_result.error))
+			return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, String(coerce_result.error))
 		coerced[prop_name] = coerce_result.value
 		old_values[prop_name] = node.get(prop_name)
 
@@ -193,7 +195,7 @@ func set_process(params: Dictionary) -> Dictionary:
 
 	var properties: Dictionary = params.get("properties", {})
 	if properties.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "properties dict is empty")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "properties dict is empty")
 
 	# GPU: work through process_material; CPU: properties live on node directly.
 	if node is GPUParticles3D or node is GPUParticles2D:
@@ -214,13 +216,13 @@ func _set_process_gpu(node: Node, node_path: String, properties: Dictionary) -> 
 		var prop_name: String = String(property)
 		var prop_type := _object_property_type(mat, prop_name)
 		if prop_type == TYPE_NIL:
-			return McpErrorCodes.make(
-				McpErrorCodes.PROPERTY_NOT_ON_CLASS,
+			return ErrorCodes.make(
+				ErrorCodes.PROPERTY_NOT_ON_CLASS,
 				"Property '%s' not present on ParticleProcessMaterial" % prop_name
 			)
 		var coerce_result := ParticleValues.coerce(prop_name, properties[prop_name], prop_type)
 		if not coerce_result.ok:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, String(coerce_result.error))
+			return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, String(coerce_result.error))
 		coerced[prop_name] = coerce_result.value
 
 	_undo_redo.create_action("MCP: Set particle process on %s" % node.name)
@@ -271,13 +273,13 @@ func _set_process_cpu(node: Node, node_path: String, properties: Dictionary) -> 
 		var prop_name: String = aliases.get(String(property), String(property))
 		var prop_type := _node_property_type(node, prop_name)
 		if prop_type == TYPE_NIL:
-			return McpErrorCodes.make(
-				McpErrorCodes.PROPERTY_NOT_ON_CLASS,
+			return ErrorCodes.make(
+				ErrorCodes.PROPERTY_NOT_ON_CLASS,
 				"Property '%s' not present on %s" % [prop_name, node.get_class()]
 			)
 		var coerce_result := ParticleValues.coerce(prop_name, properties[property], prop_type)
 		if not coerce_result.ok:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, String(coerce_result.error))
+			return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, String(coerce_result.error))
 		coerced[prop_name] = coerce_result.value
 		old_values[prop_name] = node.get(prop_name)
 
@@ -326,12 +328,12 @@ func set_draw_pass(params: Dictionary) -> Dictionary:
 		return _set_draw_pass_cpu_3d(node, node_path, mesh_path, material_path)
 	if node is GPUParticles2D or node is CPUParticles2D:
 		return _set_draw_pass_2d(node, node_path, texture_path)
-	return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "Node %s is not a particle node" % node.get_class())
+	return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "Node %s is not a particle node" % node.get_class())
 
 
 func _set_draw_pass_gpu_3d(node: GPUParticles3D, node_path: String, pass_idx: int, mesh_path: String, material_path: String) -> Dictionary:
 	if pass_idx < 1 or pass_idx > 4:
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "pass must be 1..4 (got %d)" % pass_idx)
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "pass must be 1..4 (got %d)" % pass_idx)
 
 	var mesh: Mesh = null
 	var mesh_created := false
@@ -343,10 +345,10 @@ func _set_draw_pass_gpu_3d(node: GPUParticles3D, node_path: String, pass_idx: in
 		existing_mesh = node.get(property_name) as Mesh
 	if not mesh_path.is_empty():
 		if not ResourceLoader.exists(mesh_path):
-			return McpErrorCodes.make(McpErrorCodes.RESOURCE_NOT_FOUND, "Mesh not found: %s" % mesh_path)
+			return ErrorCodes.make(ErrorCodes.RESOURCE_NOT_FOUND, "Mesh not found: %s" % mesh_path)
 		var loaded := ResourceLoader.load(mesh_path)
 		if not (loaded is Mesh):
-			return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "Resource at %s is not a Mesh" % mesh_path)
+			return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "Resource at %s is not a Mesh" % mesh_path)
 		mesh = loaded
 	else:
 		if existing_mesh == null:
@@ -359,10 +361,10 @@ func _set_draw_pass_gpu_3d(node: GPUParticles3D, node_path: String, pass_idx: in
 	var material: Material = null
 	if not material_path.is_empty():
 		if not ResourceLoader.exists(material_path):
-			return McpErrorCodes.make(McpErrorCodes.RESOURCE_NOT_FOUND, "Material not found: %s" % material_path)
+			return ErrorCodes.make(ErrorCodes.RESOURCE_NOT_FOUND, "Material not found: %s" % material_path)
 		var loaded_mat := ResourceLoader.load(material_path)
 		if not (loaded_mat is Material):
-			return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "Resource at %s is not a Material" % material_path)
+			return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "Resource at %s is not a Material" % material_path)
 		material = loaded_mat
 
 	var old_draw_passes: int = int(node.draw_passes)
@@ -403,26 +405,26 @@ func _set_draw_pass_gpu_3d(node: GPUParticles3D, node_path: String, pass_idx: in
 
 func _set_draw_pass_cpu_3d(node: CPUParticles3D, node_path: String, mesh_path: String, material_path: String) -> Dictionary:
 	if mesh_path.is_empty() and material_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "CPUParticles3D requires mesh or material param")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "CPUParticles3D requires mesh or material param")
 
 	var mesh: Mesh = node.mesh
 	var old_mesh: Mesh = mesh
 	if not mesh_path.is_empty():
 		if not ResourceLoader.exists(mesh_path):
-			return McpErrorCodes.make(McpErrorCodes.RESOURCE_NOT_FOUND, "Mesh not found: %s" % mesh_path)
+			return ErrorCodes.make(ErrorCodes.RESOURCE_NOT_FOUND, "Mesh not found: %s" % mesh_path)
 		var loaded := ResourceLoader.load(mesh_path)
 		if not (loaded is Mesh):
-			return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "Resource at %s is not a Mesh" % mesh_path)
+			return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "Resource at %s is not a Mesh" % mesh_path)
 		mesh = loaded
 
 	var material: Material = null
 	var old_material: Material = node.material_override
 	if not material_path.is_empty():
 		if not ResourceLoader.exists(material_path):
-			return McpErrorCodes.make(McpErrorCodes.RESOURCE_NOT_FOUND, "Material not found: %s" % material_path)
+			return ErrorCodes.make(ErrorCodes.RESOURCE_NOT_FOUND, "Material not found: %s" % material_path)
 		var loaded_mat := ResourceLoader.load(material_path)
 		if not (loaded_mat is Material):
-			return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "Resource at %s is not a Material" % material_path)
+			return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "Resource at %s is not a Material" % material_path)
 		material = loaded_mat
 
 	_undo_redo.create_action("MCP: Set CPU particle draw on %s" % node.name)
@@ -447,12 +449,12 @@ func _set_draw_pass_cpu_3d(node: CPUParticles3D, node_path: String, mesh_path: S
 
 func _set_draw_pass_2d(node: Node, node_path: String, texture_path: String) -> Dictionary:
 	if texture_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "2D particles require texture param")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "2D particles require texture param")
 	if not ResourceLoader.exists(texture_path):
-		return McpErrorCodes.make(McpErrorCodes.RESOURCE_NOT_FOUND, "Texture not found: %s" % texture_path)
+		return ErrorCodes.make(ErrorCodes.RESOURCE_NOT_FOUND, "Texture not found: %s" % texture_path)
 	var tex := ResourceLoader.load(texture_path)
 	if not (tex is Texture2D):
-		return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "Resource at %s is not a Texture2D" % texture_path)
+		return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "Resource at %s is not a Texture2D" % texture_path)
 
 	var old_texture: Texture2D = node.get("texture")
 
@@ -569,13 +571,13 @@ func get_particle(params: Dictionary) -> Dictionary:
 func apply_preset(params: Dictionary) -> Dictionary:
 	var preset_name: String = params.get("preset", "")
 	if preset_name.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: preset")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: preset")
 
 	var overrides: Dictionary = params.get("overrides", {})
 	var blueprint = ParticlePresets.build(preset_name, overrides)
 	if blueprint == null:
-		return McpErrorCodes.make(
-			McpErrorCodes.VALUE_OUT_OF_RANGE,
+		return ErrorCodes.make(
+			ErrorCodes.VALUE_OUT_OF_RANGE,
 			"Unknown preset '%s'. Valid: %s" % [preset_name, ", ".join(ParticlePresets.list())]
 		)
 
@@ -585,8 +587,8 @@ func apply_preset(params: Dictionary) -> Dictionary:
 	if node_name.is_empty():
 		node_name = preset_name.capitalize()
 	if not _VALID_TYPES.has(type_str):
-		return McpErrorCodes.make(
-			McpErrorCodes.VALUE_OUT_OF_RANGE,
+		return ErrorCodes.make(
+			ErrorCodes.VALUE_OUT_OF_RANGE,
 			"Invalid particle type '%s'. Valid: %s" % [type_str, ", ".join(_VALID_TYPES.keys())]
 		)
 
@@ -599,7 +601,7 @@ func apply_preset(params: Dictionary) -> Dictionary:
 	if not parent_path.is_empty():
 		parent = McpScenePath.resolve(parent_path, scene_root)
 		if parent == null:
-			return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_parent_error(parent_path, scene_root))
+			return ErrorCodes.make(ErrorCodes.NODE_NOT_FOUND, McpScenePath.format_parent_error(parent_path, scene_root))
 
 	var node := _instantiate_particle(type_str)
 	node.name = node_name
@@ -639,7 +641,7 @@ func apply_preset(params: Dictionary) -> Dictionary:
 			continue  # Silently skip: not all main keys apply to all types.
 		var coerce_result := ParticleValues.coerce(prop_name, main_values[prop_name], prop_type)
 		if not coerce_result.ok:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, String(coerce_result.error))
+			return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, String(coerce_result.error))
 		node.set(prop_name, coerce_result.value)
 		applied_main.append(prop_name)
 
@@ -652,7 +654,7 @@ func apply_preset(params: Dictionary) -> Dictionary:
 			continue  # Silently skip: preset property doesn't apply to this variant.
 		var coerce_result := ParticleValues.coerce(prop_name, process_values[prop_name], prop_type)
 		if not coerce_result.ok:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, String(coerce_result.error))
+			return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, String(coerce_result.error))
 		process_target.set(prop_name, coerce_result.value)
 		applied_process.append(prop_name)
 
@@ -718,8 +720,8 @@ func _resolve_particle(params: Dictionary) -> Dictionary:
 	var is_particle := node is GPUParticles3D or node is GPUParticles2D \
 		or node is CPUParticles3D or node is CPUParticles2D
 	if not is_particle:
-		return McpErrorCodes.make(
-			McpErrorCodes.WRONG_TYPE,
+		return ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
 			"Node %s is not a particle node (got %s)" % [node_path, node.get_class()]
 		)
 	return {"node": node, "path": node_path}

--- a/plugin/addons/godot_ai/handlers/physics_shape_handler.gd
+++ b/plugin/addons/godot_ai/handlers/physics_shape_handler.gd
@@ -1,6 +1,8 @@
 @tool
 extends RefCounted
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Sizes a CollisionShape2D/CollisionShape3D to match a visual sibling's
 ## bounds. Auto-creates the concrete Shape subclass when the slot is empty
 ## or the requested type differs — bundling creation and sizing in a single
@@ -32,7 +34,7 @@ const _SHAPE_2D_CLASSES := {
 func autofit(params: Dictionary) -> Dictionary:
 	var node_path: String = params.get("path", "")
 	if node_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
 
 	var _resolved := McpNodeValidator.resolve_or_error(node_path, "node_path")
 	if _resolved.has("error"):
@@ -43,8 +45,8 @@ func autofit(params: Dictionary) -> Dictionary:
 	var is_3d := node is CollisionShape3D
 	var is_2d := node is CollisionShape2D
 	if not (is_3d or is_2d):
-		return McpErrorCodes.make(
-			McpErrorCodes.WRONG_TYPE,
+		return ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
 			"Node at %s is %s — must be CollisionShape3D or CollisionShape2D" % [node_path, node.get_class()]
 		)
 
@@ -58,7 +60,7 @@ func autofit(params: Dictionary) -> Dictionary:
 	else:
 		source = McpScenePath.resolve(source_path, scene_root)
 		if source == null:
-			return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, "Source node not found: %s" % source_path)
+			return ErrorCodes.make(ErrorCodes.NODE_NOT_FOUND, "Source node not found: %s" % source_path)
 
 	var shape_type: String = params.get("shape_type", "box" if is_3d else "rectangle")
 	var type_map := _SHAPE_3D_CLASSES if is_3d else _SHAPE_2D_CLASSES
@@ -74,8 +76,8 @@ func autofit(params: Dictionary) -> Dictionary:
 		var valid_pairs: Array[String] = []
 		for short_form in type_map:
 			valid_pairs.append("%s (%s)" % [short_form, type_map[short_form]])
-		return McpErrorCodes.make(
-			McpErrorCodes.VALUE_OUT_OF_RANGE,
+		return ErrorCodes.make(
+			ErrorCodes.VALUE_OUT_OF_RANGE,
 			"Invalid shape_type '%s' for %s. Valid: %s" % [shape_type, node.get_class(), ", ".join(valid_pairs)]
 		)
 	var shape_class: String = type_map[shape_type]
@@ -104,7 +106,7 @@ func autofit(params: Dictionary) -> Dictionary:
 	if needs_new_shape:
 		var instance := ClassDB.instantiate(shape_class)
 		if instance == null:
-			return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to instantiate %s" % shape_class)
+			return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to instantiate %s" % shape_class)
 		target_shape = instance
 	else:
 		target_shape = existing_shape if is_3d else existing_shape_2d
@@ -173,7 +175,7 @@ static func _find_bounds_visual(collision_node: Node, is_3d: bool, scene_root: N
 			McpScenePath.from_node(collision_node, scene_root),
 			", ".join(paths),
 		]
-		var err := McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, msg)
+		var err := ErrorCodes.make(ErrorCodes.INVALID_PARAMS, msg)
 		err["error"]["data"] = {"candidates": paths}
 		return {"error": err}
 	return {"error": _no_visual_error(is_3d)}
@@ -201,8 +203,8 @@ static func _measurable_visuals(nodes: Array, exclude: Node, is_3d: bool, strict
 
 static func _no_visual_error(is_3d: bool) -> Dictionary:
 	var hint := "MeshInstance3D" if is_3d else "Sprite2D"
-	return McpErrorCodes.make(
-		McpErrorCodes.INVALID_PARAMS,
+	return ErrorCodes.make(
+		ErrorCodes.INVALID_PARAMS,
 		"No visual found near collision shape — searched siblings and parent-siblings. Pass source_path explicitly (e.g. a %s)" % hint,
 	)
 
@@ -222,8 +224,8 @@ static func _measure_bounds(source: Node, is_3d: bool) -> Dictionary:
 			aabb.position = aabb.position * scale_3d
 			aabb.size = aabb.size * scale_3d
 			return {"aabb": aabb}
-		return {"error": McpErrorCodes.make(
-			McpErrorCodes.WRONG_TYPE,
+		return {"error": ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
 			"Source %s has no measurable 3D bounds (must be VisualInstance3D subclass)" % source.get_class()
 		)}
 	# 2D
@@ -245,13 +247,13 @@ static func _measure_bounds(source: Node, is_3d: bool) -> Dictionary:
 			if tr.texture != null:
 				tr_size = tr.texture.get_size() * tr.scale
 			else:
-				return {"error": McpErrorCodes.make(
-					McpErrorCodes.INVALID_PARAMS,
+				return {"error": ErrorCodes.make(
+					ErrorCodes.INVALID_PARAMS,
 					"TextureRect at %s has zero layout size and no texture to fall back to — autofit would produce a zero-sized shape" % source.name
 				)}
 		return {"rect": Rect2(Vector2.ZERO, tr_size)}
-	return {"error": McpErrorCodes.make(
-		McpErrorCodes.WRONG_TYPE,
+	return {"error": ErrorCodes.make(
+		ErrorCodes.WRONG_TYPE,
 		"Source %s has no measurable 2D bounds (must be Sprite2D or TextureRect)" % source.get_class()
 	)}
 

--- a/plugin/addons/godot_ai/handlers/project_handler.gd
+++ b/plugin/addons/godot_ai/handlers/project_handler.gd
@@ -1,6 +1,8 @@
 @tool
 extends RefCounted
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Handles project settings and filesystem search commands.
 
 const NodeHandler := preload("res://addons/godot_ai/handlers/node_handler.gd")
@@ -17,10 +19,10 @@ func _init(connection: McpConnection = null, debugger_plugin = null) -> void:
 func get_project_setting(params: Dictionary) -> Dictionary:
 	var key: String = params.get("key", "")
 	if key.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: key")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: key")
 
 	if not ProjectSettings.has_setting(key):
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "Setting not found: %s" % key)
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "Setting not found: %s" % key)
 
 	var value = ProjectSettings.get_setting(key)
 	return {
@@ -35,10 +37,10 @@ func get_project_setting(params: Dictionary) -> Dictionary:
 func set_project_setting(params: Dictionary) -> Dictionary:
 	var key: String = params.get("key", "")
 	if key.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: key")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: key")
 
 	if not params.has("value"):
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: value")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: value")
 
 	var value = params.get("value")
 	var had_setting := ProjectSettings.has_setting(key)
@@ -56,7 +58,7 @@ func set_project_setting(params: Dictionary) -> Dictionary:
 			ProjectSettings.set_setting(key, old_value)
 		else:
 			ProjectSettings.clear(key)
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to save project settings (error %d)" % err)
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to save project settings (error %d)" % err)
 
 	return {
 		"data": {
@@ -74,15 +76,15 @@ func run_project(params: Dictionary) -> Dictionary:
 	var mode: String = params.get("mode", "main")
 	var autosave: bool = params.get("autosave", true)
 	if EditorInterface.is_playing_scene():
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Project is already running")
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, "Project is already running")
 
 	var validation_error: Variant = null
 	if mode == "custom":
 		var custom_scene: String = params.get("scene", "")
 		if custom_scene.is_empty():
-			validation_error = McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: scene (required when mode='custom')")
+			validation_error = ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: scene (required when mode='custom')")
 	elif mode != "main" and mode != "current":
-		validation_error = McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "Invalid mode '%s' — use 'main', 'current', or 'custom'" % mode)
+		validation_error = ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "Invalid mode '%s' — use 'main', 'current', or 'custom'" % mode)
 	if validation_error != null:
 		return validation_error
 
@@ -139,7 +141,7 @@ func run_project(params: Dictionary) -> Dictionary:
 
 func stop_project(params: Dictionary) -> Dictionary:
 	if not EditorInterface.is_playing_scene():
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Project is not running")
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, "Project is not running")
 
 	if _debugger_plugin != null:
 		_debugger_plugin.end_game_run()
@@ -192,11 +194,11 @@ func search_filesystem(params: Dictionary) -> Dictionary:
 	var path_filter: String = params.get("path", "")
 
 	if name_filter.is_empty() and type_filter.is_empty() and path_filter.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "At least one filter (name, type, path) is required")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "At least one filter (name, type, path) is required")
 
 	var efs := EditorInterface.get_resource_filesystem()
 	if efs == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "EditorFileSystem not available")
+		return ErrorCodes.make(ErrorCodes.EDITOR_NOT_READY, "EditorFileSystem not available")
 
 	var results: Array[Dictionary] = []
 	_scan_directory(efs.get_filesystem(), name_filter, type_filter, path_filter, results)

--- a/plugin/addons/godot_ai/handlers/resource_handler.gd
+++ b/plugin/addons/godot_ai/handlers/resource_handler.gd
@@ -1,6 +1,8 @@
 @tool
 extends RefCounted
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Handles resource search, inspection, and assignment to nodes.
 
 const NodeHandler := preload("res://addons/godot_ai/handlers/node_handler.gd")
@@ -19,11 +21,11 @@ func search_resources(params: Dictionary) -> Dictionary:
 	var path_filter: String = params.get("path", "")
 
 	if type_filter.is_empty() and path_filter.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "At least one filter (type, path) is required")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "At least one filter (type, path) is required")
 
 	var efs := EditorInterface.get_resource_filesystem()
 	if efs == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "EditorFileSystem not available")
+		return ErrorCodes.make(ErrorCodes.EDITOR_NOT_READY, "EditorFileSystem not available")
 
 	var results: Array[Dictionary] = []
 	_scan_resources(efs.get_filesystem(), type_filter, path_filter, results)
@@ -60,17 +62,17 @@ func load_resource(params: Dictionary) -> Dictionary:
 	var path: String = params.get("path", "")
 
 	if path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
 
 	if not path.begins_with("res://"):
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "Path must start with res://")
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "Path must start with res://")
 
 	if not ResourceLoader.exists(path):
-		return McpErrorCodes.make(McpErrorCodes.RESOURCE_NOT_FOUND, "Resource not found: %s" % path)
+		return ErrorCodes.make(ErrorCodes.RESOURCE_NOT_FOUND, "Resource not found: %s" % path)
 
 	var res: Resource = load(path)
 	if res == null:
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to load resource: %s" % path)
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to load resource: %s" % path)
 
 	var properties: Array[Dictionary] = []
 	for prop in res.get_property_list():
@@ -102,13 +104,13 @@ func assign_resource(params: Dictionary) -> Dictionary:
 	var resource_path: String = params.get("resource_path", "")
 
 	if node_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
 
 	if property.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: property")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: property")
 
 	if resource_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: resource_path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: resource_path")
 
 	var _resolved := McpNodeValidator.resolve_or_error(node_path, "node_path")
 	if _resolved.has("error"):
@@ -123,14 +125,14 @@ func assign_resource(params: Dictionary) -> Dictionary:
 			found = true
 			break
 	if not found:
-		return McpErrorCodes.make(McpErrorCodes.PROPERTY_NOT_ON_CLASS, McpPropertyErrors.build_message(node, property))
+		return ErrorCodes.make(ErrorCodes.PROPERTY_NOT_ON_CLASS, McpPropertyErrors.build_message(node, property))
 
 	if not ResourceLoader.exists(resource_path):
-		return McpErrorCodes.make(McpErrorCodes.RESOURCE_NOT_FOUND, "Resource not found: %s" % resource_path)
+		return ErrorCodes.make(ErrorCodes.RESOURCE_NOT_FOUND, "Resource not found: %s" % resource_path)
 
 	var res: Resource = load(resource_path)
 	if res == null:
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to load resource: %s" % resource_path)
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to load resource: %s" % resource_path)
 
 	var old_value = node.get(property)
 
@@ -157,7 +159,7 @@ func assign_resource(params: Dictionary) -> Dictionary:
 func create_resource(params: Dictionary) -> Dictionary:
 	var type_str: String = params.get("type", "")
 	if type_str.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: type")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: type")
 
 	var properties: Dictionary = params.get("properties", {})
 	var node_path: String = params.get("path", "")
@@ -176,10 +178,10 @@ func create_resource(params: Dictionary) -> Dictionary:
 
 	var instance := ClassDB.instantiate(type_str)
 	if instance == null:
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to instantiate %s" % type_str)
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to instantiate %s" % type_str)
 	if not (instance is Resource):
-		return McpErrorCodes.make(
-			McpErrorCodes.INTERNAL_ERROR,
+		return ErrorCodes.make(
+			ErrorCodes.INTERNAL_ERROR,
 			"Instantiated %s but result is not a Resource (got %s)" % [type_str, instance.get_class()]
 		)
 	var res: Resource = instance
@@ -198,21 +200,21 @@ func create_resource(params: Dictionary) -> Dictionary:
 ## instantiate. Returns an error dict on failure, or null on success.
 static func _validate_resource_class(type_str: String) -> Variant:
 	if not ClassDB.class_exists(type_str):
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "Unknown resource type: %s" % type_str)
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "Unknown resource type: %s" % type_str)
 	if ClassDB.is_parent_class(type_str, "Node"):
-		return McpErrorCodes.make(
-			McpErrorCodes.WRONG_TYPE,
+		return ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
 			"%s is a Node type, not a Resource — use node_create instead" % type_str
 		)
 	if not ClassDB.is_parent_class(type_str, "Resource"):
 		var parent := ClassDB.get_parent_class(type_str)
-		return McpErrorCodes.make(
-			McpErrorCodes.WRONG_TYPE,
+		return ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
 			"%s is not a Resource type (extends %s)" % [type_str, parent]
 		)
 	if not ClassDB.can_instantiate(type_str):
-		return McpErrorCodes.make(
-			McpErrorCodes.WRONG_TYPE,
+		return ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
 			"%s is abstract and cannot be instantiated — use a concrete subclass (e.g. BoxMesh, BoxShape3D, StyleBoxFlat)" % type_str
 		)
 	return null
@@ -232,8 +234,8 @@ static func _apply_resource_properties(res: Resource, properties: Dictionary) ->
 				if prop.get("usage", 0) & PROPERTY_USAGE_EDITOR:
 					valid.append(prop.name)
 			valid.sort()
-			var err := McpErrorCodes.make(
-				McpErrorCodes.PROPERTY_NOT_ON_CLASS,
+			var err := ErrorCodes.make(
+				ErrorCodes.PROPERTY_NOT_ON_CLASS,
 				"Property '%s' not found on %s. Call resource_get_info('%s') to list available properties." % [key, res.get_class(), res.get_class()]
 			)
 			err["error"]["data"] = {"valid_properties": valid}
@@ -248,8 +250,8 @@ static func _apply_resource_properties(res: Resource, properties: Dictionary) ->
 			else:
 				var loaded := ResourceLoader.load(v)
 				if loaded == null:
-					return McpErrorCodes.make(
-						McpErrorCodes.INVALID_PARAMS,
+					return ErrorCodes.make(
+						ErrorCodes.INVALID_PARAMS,
 						"Resource not found at path '%s' for property '%s'" % [v, key]
 					)
 				v = loaded
@@ -264,8 +266,8 @@ static func _apply_resource_properties(res: Resource, properties: Dictionary) ->
 				return class_err
 			var sub_instance := ClassDB.instantiate(sub_type)
 			if sub_instance == null or not (sub_instance is Resource):
-				return McpErrorCodes.make(
-					McpErrorCodes.INTERNAL_ERROR,
+				return ErrorCodes.make(
+					ErrorCodes.INTERNAL_ERROR,
 					"Failed to instantiate %s as a Resource for property '%s'" % [sub_type, key]
 				)
 			var sub_res: Resource = sub_instance
@@ -303,13 +305,13 @@ func _assign_created_resource(res: Resource, type_str: String, node_path: String
 			prop_type = prop.get("type", TYPE_NIL)
 			break
 	if not found:
-		return McpErrorCodes.make(
-			McpErrorCodes.PROPERTY_NOT_ON_CLASS,
+		return ErrorCodes.make(
+			ErrorCodes.PROPERTY_NOT_ON_CLASS,
 			"Property '%s' not found on %s" % [property, node.get_class()]
 		)
 	if prop_type != TYPE_NIL and prop_type != TYPE_OBJECT:
-		return McpErrorCodes.make(
-			McpErrorCodes.PROPERTY_NOT_ON_CLASS,
+		return ErrorCodes.make(
+			ErrorCodes.PROPERTY_NOT_ON_CLASS,
 			"Property '%s' on %s is not an Object slot (type %s)" % [property, node.get_class(), type_string(prop_type)]
 		)
 
@@ -347,19 +349,19 @@ func _save_created_resource(res: Resource, type_str: String, resource_path: Stri
 func get_resource_info(params: Dictionary) -> Dictionary:
 	var type_str: String = params.get("type", "")
 	if type_str.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: type")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: type")
 
 	if not ClassDB.class_exists(type_str):
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "Unknown resource type: %s" % type_str)
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "Unknown resource type: %s" % type_str)
 	if ClassDB.is_parent_class(type_str, "Node"):
-		return McpErrorCodes.make(
-			McpErrorCodes.WRONG_TYPE,
+		return ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
 			"%s is a Node type, not a Resource — use node_* tools for node introspection" % type_str
 		)
 	if not ClassDB.is_parent_class(type_str, "Resource") and type_str != "Resource":
 		var parent := ClassDB.get_parent_class(type_str)
-		return McpErrorCodes.make(
-			McpErrorCodes.WRONG_TYPE,
+		return ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
 			"%s is not a Resource type (extends %s)" % [type_str, parent]
 		)
 

--- a/plugin/addons/godot_ai/handlers/scene_handler.gd
+++ b/plugin/addons/godot_ai/handlers/scene_handler.gd
@@ -1,6 +1,8 @@
 @tool
 extends RefCounted
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Handles scene tree reading and node search.
 
 var _connection: McpConnection
@@ -42,7 +44,7 @@ func find_nodes(params: Dictionary) -> Dictionary:
 	var group_filter: String = params.get("group", "")
 
 	if name_filter.is_empty() and type_filter.is_empty() and group_filter.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "At least one filter (name, type, group) is required")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "At least one filter (name, type, group) is required")
 
 	var _scene_check := McpNodeValidator.require_scene_or_error()
 	if _scene_check.has("error"):
@@ -86,29 +88,29 @@ func create_scene(params: Dictionary) -> Dictionary:
 	var path: String = params.get("path", "")
 
 	if path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
 
 	if not path.begins_with("res://"):
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "Path must start with res://")
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "Path must start with res://")
 
 	if not path.ends_with(".tscn") and not path.ends_with(".scn"):
 		path += ".tscn"
 
 	if not ClassDB.class_exists(root_type):
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "Unknown node type: %s" % root_type)
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "Unknown node type: %s" % root_type)
 	if not ClassDB.is_parent_class(root_type, "Node"):
-		return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "%s is not a Node type" % root_type)
+		return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "%s is not a Node type" % root_type)
 
 	# Ensure parent directory exists
 	var dir_path := path.get_base_dir()
 	if not DirAccess.dir_exists_absolute(dir_path):
 		var err := DirAccess.make_dir_recursive_absolute(dir_path)
 		if err != OK:
-			return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to create directory: %s" % dir_path)
+			return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to create directory: %s" % dir_path)
 
 	var root: Node = ClassDB.instantiate(root_type)
 	if root == null:
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to instantiate %s" % root_type)
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to instantiate %s" % root_type)
 
 	var root_name: String = params.get("root_name", "")
 	if root_name.is_empty():
@@ -127,7 +129,7 @@ func create_scene(params: Dictionary) -> Dictionary:
 		_connection.pause_processing = false
 
 	if err != OK:
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to save scene: %s" % error_string(err))
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to save scene: %s" % error_string(err))
 
 	return {
 		"data": {
@@ -144,10 +146,10 @@ func create_scene(params: Dictionary) -> Dictionary:
 func open_scene(params: Dictionary) -> Dictionary:
 	var path: String = params.get("path", "")
 	if path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
 
 	if not ResourceLoader.exists(path):
-		return McpErrorCodes.make(McpErrorCodes.RESOURCE_NOT_FOUND, "Scene not found: %s" % path)
+		return ErrorCodes.make(ErrorCodes.RESOURCE_NOT_FOUND, "Scene not found: %s" % path)
 
 	EditorInterface.open_scene_from_path(path)
 
@@ -171,8 +173,8 @@ func save_scene(_params: Dictionary) -> Dictionary:
 
 	var path := scene_root.scene_file_path
 	if path.is_empty():
-		return McpErrorCodes.make(
-			McpErrorCodes.INVALID_PARAMS,
+		return ErrorCodes.make(
+			ErrorCodes.INVALID_PARAMS,
 			"Current scene has never been saved; call scene_manage(op='save_as') with a res://... path ending in .tscn or .scn."
 		)
 
@@ -183,7 +185,7 @@ func save_scene(_params: Dictionary) -> Dictionary:
 		_connection.pause_processing = false
 
 	if err != OK:
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to save scene: %s" % error_string(err))
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to save scene: %s" % error_string(err))
 
 	return {
 		"data": {
@@ -198,10 +200,10 @@ func save_scene(_params: Dictionary) -> Dictionary:
 func save_scene_as(params: Dictionary) -> Dictionary:
 	var path: String = params.get("path", "")
 	if path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
 
 	if not path.begins_with("res://"):
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "Path must start with res://")
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "Path must start with res://")
 
 	if not path.ends_with(".tscn") and not path.ends_with(".scn"):
 		path += ".tscn"
@@ -216,7 +218,7 @@ func save_scene_as(params: Dictionary) -> Dictionary:
 	if not DirAccess.dir_exists_absolute(dir_path):
 		var err := DirAccess.make_dir_recursive_absolute(dir_path)
 		if err != OK:
-			return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to create directory: %s" % dir_path)
+			return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to create directory: %s" % dir_path)
 
 	if _connection:
 		_connection.pause_processing = true

--- a/plugin/addons/godot_ai/handlers/script_handler.gd
+++ b/plugin/addons/godot_ai/handlers/script_handler.gd
@@ -1,6 +1,8 @@
 @tool
 extends RefCounted
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Handles script creation, reading, attaching, detaching, and symbol inspection.
 
 var _undo_redo: EditorUndoRedoManager
@@ -27,23 +29,23 @@ func create_script(params: Dictionary) -> Dictionary:
 
 	var path_err := McpPathValidator.validate_resource_path(path)
 	if not path_err.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, path_err)
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, path_err)
 
 	if not path.ends_with(".gd"):
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "Path must end with .gd")
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "Path must end with .gd")
 
 	# Ensure parent directory exists
 	var dir_path := path.get_base_dir()
 	if not DirAccess.dir_exists_absolute(dir_path):
 		var err := DirAccess.make_dir_recursive_absolute(dir_path)
 		if err != OK:
-			return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to create directory: %s" % dir_path)
+			return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to create directory: %s" % dir_path)
 
 	var existed_before := FileAccess.file_exists(path)
 
 	var file := FileAccess.open(path, FileAccess.WRITE)
 	if file == null:
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to open file for writing: %s" % path)
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to open file for writing: %s" % path)
 
 	file.store_string(content)
 	file.close()
@@ -116,14 +118,14 @@ func read_script(params: Dictionary) -> Dictionary:
 
 	var path_err := McpPathValidator.validate_resource_path(path)
 	if not path_err.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, path_err)
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, path_err)
 
 	if not FileAccess.file_exists(path):
-		return McpErrorCodes.make(McpErrorCodes.RESOURCE_NOT_FOUND, "File not found: %s" % path)
+		return ErrorCodes.make(ErrorCodes.RESOURCE_NOT_FOUND, "File not found: %s" % path)
 
 	var file := FileAccess.open(path, FileAccess.READ)
 	if file == null:
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to open file: %s" % path)
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to open file: %s" % path)
 
 	var content := file.get_as_text()
 	file.close()
@@ -146,28 +148,28 @@ func patch_script(params: Dictionary) -> Dictionary:
 
 	var path_err := McpPathValidator.validate_resource_path(path)
 	if not path_err.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, path_err)
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, path_err)
 	if not "old_text" in params:
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: old_text")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: old_text")
 	if not "new_text" in params:
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: new_text")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: new_text")
 	if not path.ends_with(".gd"):
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "Path must end with .gd (use filesystem_write_text for other text files)")
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "Path must end with .gd (use filesystem_write_text for other text files)")
 	if old_text.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "old_text must not be empty")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "old_text must not be empty")
 
 	var read := FileAccess.open(path, FileAccess.READ)
 	if read == null:
-		return McpErrorCodes.make(McpErrorCodes.RESOURCE_NOT_FOUND, "File not found or unreadable: %s" % path)
+		return ErrorCodes.make(ErrorCodes.RESOURCE_NOT_FOUND, "File not found or unreadable: %s" % path)
 	var content := read.get_as_text()
 	read.close()
 
 	var match_count := content.count(old_text)
 	if match_count == 0:
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "old_text not found in %s" % path)
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, "old_text not found in %s" % path)
 	if match_count > 1 and not replace_all:
-		return McpErrorCodes.make(
-			McpErrorCodes.INVALID_PARAMS,
+		return ErrorCodes.make(
+			ErrorCodes.INVALID_PARAMS,
 			"old_text matches %d times; pass replace_all=true or provide a more specific snippet" % match_count,
 		)
 
@@ -183,7 +185,7 @@ func patch_script(params: Dictionary) -> Dictionary:
 
 	var write := FileAccess.open(path, FileAccess.WRITE)
 	if write == null:
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to open file for writing: %s" % path)
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to open file for writing: %s" % path)
 	write.store_string(new_content)
 	write.close()
 
@@ -206,10 +208,10 @@ func attach_script(params: Dictionary) -> Dictionary:
 	var script_path: String = params.get("script_path", "")
 
 	if node_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
 
 	if script_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: script_path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: script_path")
 
 	var _resolved := McpNodeValidator.resolve_or_error(node_path, "node_path")
 	if _resolved.has("error"):
@@ -218,11 +220,11 @@ func attach_script(params: Dictionary) -> Dictionary:
 	var scene_root: Node = _resolved.scene_root
 
 	if not ResourceLoader.exists(script_path):
-		return McpErrorCodes.make(McpErrorCodes.RESOURCE_NOT_FOUND, "Script not found: %s" % script_path)
+		return ErrorCodes.make(ErrorCodes.RESOURCE_NOT_FOUND, "Script not found: %s" % script_path)
 
 	var script: Script = load(script_path)
 	if script == null:
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to load script: %s" % script_path)
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to load script: %s" % script_path)
 
 	var old_script: Script = node.get_script()
 
@@ -245,7 +247,7 @@ func detach_script(params: Dictionary) -> Dictionary:
 	var node_path: String = params.get("path", "")
 
 	if node_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
 
 	var _resolved := McpNodeValidator.resolve_or_error(node_path, "node_path")
 	if _resolved.has("error"):
@@ -276,14 +278,14 @@ func find_symbols(params: Dictionary) -> Dictionary:
 
 	var path_err := McpPathValidator.validate_resource_path(path)
 	if not path_err.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, path_err)
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, path_err)
 
 	if not FileAccess.file_exists(path):
-		return McpErrorCodes.make(McpErrorCodes.RESOURCE_NOT_FOUND, "File not found: %s" % path)
+		return ErrorCodes.make(ErrorCodes.RESOURCE_NOT_FOUND, "File not found: %s" % path)
 
 	var file := FileAccess.open(path, FileAccess.READ)
 	if file == null:
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to open file: %s" % path)
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to open file: %s" % path)
 
 	var content := file.get_as_text()
 	file.close()

--- a/plugin/addons/godot_ai/handlers/signal_handler.gd
+++ b/plugin/addons/godot_ai/handlers/signal_handler.gd
@@ -1,6 +1,8 @@
 @tool
 extends RefCounted
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Handles signal listing, connecting, and disconnecting on scene nodes.
 
 var _undo_redo: EditorUndoRedoManager
@@ -13,7 +15,7 @@ func _init(undo_redo: EditorUndoRedoManager) -> void:
 func list_signals(params: Dictionary) -> Dictionary:
 	var path: String = params.get("path", "")
 	if path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
 
 	var _resolved := McpNodeValidator.resolve_or_error(path, "path")
 	if _resolved.has("error"):
@@ -140,14 +142,14 @@ func connect_signal(params: Dictionary) -> Dictionary:
 	var scene_root: Node = resolved.scene_root
 
 	if not source.has_signal(signal_name):
-		return McpErrorCodes.make(McpErrorCodes.PROPERTY_NOT_ON_CLASS, "Signal '%s' not found on %s" % [signal_name, params.path])
+		return ErrorCodes.make(ErrorCodes.PROPERTY_NOT_ON_CLASS, "Signal '%s' not found on %s" % [signal_name, params.path])
 
 	if not target.has_method(method):
-		return McpErrorCodes.make(McpErrorCodes.PROPERTY_NOT_ON_CLASS, "Method '%s' not found on %s" % [method, params.target])
+		return ErrorCodes.make(ErrorCodes.PROPERTY_NOT_ON_CLASS, "Method '%s' not found on %s" % [method, params.target])
 
 	var callable := Callable(target, method)
 	if source.is_connected(signal_name, callable):
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Signal '%s' already connected to %s.%s" % [signal_name, params.target, method])
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, "Signal '%s' already connected to %s.%s" % [signal_name, params.target, method])
 
 	_undo_redo.create_action("MCP: Connect signal %s" % signal_name)
 	_undo_redo.add_do_method(source, "connect", signal_name, callable)
@@ -170,7 +172,7 @@ func disconnect_signal(params: Dictionary) -> Dictionary:
 
 	var callable := Callable(target, method)
 	if not source.is_connected(signal_name, callable):
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Signal '%s' is not connected to %s.%s" % [signal_name, params.target, method])
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, "Signal '%s' is not connected to %s.%s" % [signal_name, params.target, method])
 
 	_undo_redo.create_action("MCP: Disconnect signal %s" % signal_name)
 	_undo_redo.add_do_method(source, "disconnect", signal_name, callable)
@@ -183,7 +185,7 @@ func disconnect_signal(params: Dictionary) -> Dictionary:
 func _resolve_signal_params(params: Dictionary) -> Dictionary:
 	for key in ["path", "signal", "target", "method"]:
 		if params.get(key, "").is_empty():
-			return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: %s" % key)
+			return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: %s" % key)
 
 	var _scene_check := McpNodeValidator.require_scene_or_error()
 	if _scene_check.has("error"):
@@ -229,13 +231,13 @@ func _resolve_node_or_autoload(path: String, scene_root: Node, role: String) -> 
 			var live := (tree as SceneTree).root.get_node_or_null(name)
 			if live != null:
 				return {"node": live}
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS,
 			"%s '%s' is a declared autoload but isn't instantiated in the editor. " % [role, name] +
 			"Most autoloads are runtime-only; edit-time signal connection isn't supported for them. " +
 			"Connect it from a script attached to the scene using @onready + connect(), " +
 			"or enable editor-instancing for this autoload in Project Settings > Autoload.")
 
-	return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND,
+	return ErrorCodes.make(ErrorCodes.NODE_NOT_FOUND,
 		"%s node not found: %s (not in scene tree or autoloads)" % [role, path])
 
 

--- a/plugin/addons/godot_ai/handlers/texture_handler.gd
+++ b/plugin/addons/godot_ai/handlers/texture_handler.gd
@@ -1,6 +1,8 @@
 @tool
 extends RefCounted
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Creates procedural textures — GradientTexture2D (wrapping a Gradient)
 ## and NoiseTexture2D (wrapping a FastNoiseLite). Assigns to a node slot
 ## (undoable, bundles sub-resources) or saves to a .tres file.
@@ -43,13 +45,13 @@ func create_gradient_texture(params: Dictionary) -> Dictionary:
 	var fill: String = params.get("fill", "linear")
 
 	if stops.size() < 2:
-		return McpErrorCodes.make(
-			McpErrorCodes.VALUE_OUT_OF_RANGE,
+		return ErrorCodes.make(
+			ErrorCodes.VALUE_OUT_OF_RANGE,
 			"gradient_texture_create requires at least 2 stops, got %d" % stops.size()
 		)
 	if not _FILL_MODES.has(fill):
-		return McpErrorCodes.make(
-			McpErrorCodes.VALUE_OUT_OF_RANGE,
+		return ErrorCodes.make(
+			ErrorCodes.VALUE_OUT_OF_RANGE,
 			"Invalid fill '%s'. Valid: %s" % [fill, ", ".join(_FILL_MODES.keys())]
 		)
 
@@ -63,13 +65,13 @@ func create_gradient_texture(params: Dictionary) -> Dictionary:
 	for i in range(stops.size()):
 		var stop = stops[i]
 		if not stop is Dictionary:
-			return McpErrorCodes.make(
-				McpErrorCodes.WRONG_TYPE,
+			return ErrorCodes.make(
+				ErrorCodes.WRONG_TYPE,
 				"stops[%d] must be a dict with 'offset' and 'color' keys" % i
 			)
 		if not stop.has("offset") or not stop.has("color"):
-			return McpErrorCodes.make(
-				McpErrorCodes.INVALID_PARAMS,
+			return ErrorCodes.make(
+				ErrorCodes.INVALID_PARAMS,
 				"stops[%d] missing 'offset' or 'color' key" % i
 			)
 		offsets.append(float(stop["offset"]))
@@ -108,8 +110,8 @@ func create_noise_texture(params: Dictionary) -> Dictionary:
 	var fractal_octaves: int = params.get("fractal_octaves", 0)  # 0 = leave default
 
 	if not _NOISE_TYPES.has(noise_type):
-		return McpErrorCodes.make(
-			McpErrorCodes.VALUE_OUT_OF_RANGE,
+		return ErrorCodes.make(
+			ErrorCodes.VALUE_OUT_OF_RANGE,
 			"Invalid noise_type '%s'. Valid: %s" % [noise_type, ", ".join(_NOISE_TYPES.keys())]
 		)
 
@@ -166,13 +168,13 @@ func _assign_texture(tex: Resource, sub_resources: Array, node_path: String, pro
 			prop_type = prop.get("type", TYPE_NIL)
 			break
 	if not found:
-		return McpErrorCodes.make(
-			McpErrorCodes.PROPERTY_NOT_ON_CLASS,
+		return ErrorCodes.make(
+			ErrorCodes.PROPERTY_NOT_ON_CLASS,
 			"Property '%s' not found on %s" % [property, node.get_class()]
 		)
 	if prop_type != TYPE_NIL and prop_type != TYPE_OBJECT:
-		return McpErrorCodes.make(
-			McpErrorCodes.PROPERTY_NOT_ON_CLASS,
+		return ErrorCodes.make(
+			ErrorCodes.PROPERTY_NOT_ON_CLASS,
 			"Property '%s' on %s is not an Object slot" % [property, node.get_class()]
 		)
 

--- a/plugin/addons/godot_ai/handlers/theme_handler.gd
+++ b/plugin/addons/godot_ai/handlers/theme_handler.gd
@@ -1,6 +1,8 @@
 @tool
 extends RefCounted
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Handles Theme resource authoring: creating, modifying color/constant/font-size/
 ## stylebox slots, and applying a theme to a Control subtree.
 ##
@@ -34,8 +36,8 @@ func create_theme(params: Dictionary) -> Dictionary:
 	# report `overwritten` accurately (after save the file always exists).
 	var existed_before := FileAccess.file_exists(path)
 	if existed_before and not overwrite:
-		return McpErrorCodes.make(
-			McpErrorCodes.INVALID_PARAMS,
+		return ErrorCodes.make(
+			ErrorCodes.INVALID_PARAMS,
 			"Theme already exists at %s (pass overwrite=true to replace)" % path
 		)
 
@@ -44,16 +46,16 @@ func create_theme(params: Dictionary) -> Dictionary:
 	var dir_path := path.get_base_dir()
 	var mkdir_err := DirAccess.make_dir_recursive_absolute(dir_path)
 	if mkdir_err != OK and mkdir_err != ERR_ALREADY_EXISTS:
-		return McpErrorCodes.make(
-			McpErrorCodes.INTERNAL_ERROR,
+		return ErrorCodes.make(
+			ErrorCodes.INTERNAL_ERROR,
 			"Failed to create directory: %s (error %d)" % [dir_path, mkdir_err]
 		)
 
 	var theme := Theme.new()
 	var save_err := ResourceSaver.save(theme, path)
 	if save_err != OK:
-		return McpErrorCodes.make(
-			McpErrorCodes.INTERNAL_ERROR,
+		return ErrorCodes.make(
+			ErrorCodes.INTERNAL_ERROR,
 			"Failed to save theme to %s: %s (error %d)" % [path, error_string(save_err), save_err]
 		)
 
@@ -120,24 +122,24 @@ func _set_scalar(
 
 	var class_name_param: String = params.get("class_name", "")
 	if class_name_param.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: class_name")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: class_name")
 
 	var name: String = params.get("name", "")
 	if name.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: name")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: name")
 
 	if not "value" in params:
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: value")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: value")
 
 	var raw_value = params.get("value")
 	if raw_value == null:
-		return McpErrorCodes.make(
-			McpErrorCodes.VALUE_OUT_OF_RANGE,
+		return ErrorCodes.make(
+			ErrorCodes.VALUE_OUT_OF_RANGE,
 			"Invalid %s value: null (pass a concrete value; use the appropriate clear command to remove a slot)" % kind
 		)
 	var parsed = parser.call(raw_value)
 	if parsed == null:
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE,
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE,
 			"Invalid %s value: %s (%s)" % [kind, raw_value, _COLOR_HINT])
 
 	var had_before: bool = has_fn.call(theme, name, class_name_param)
@@ -208,22 +210,22 @@ func set_stylebox_flat(params: Dictionary) -> Dictionary:
 
 	var class_name_param: String = params.get("class_name", "")
 	if class_name_param.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: class_name")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: class_name")
 
 	var name: String = params.get("name", "")
 	if name.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: name")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: name")
 
 	var sb := StyleBoxFlat.new()
 	if params.has("bg_color"):
 		var bg := _parse_color(params.bg_color)
 		if bg == null:
-			return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "Invalid bg_color: %s (%s)" % [str(params.bg_color), _COLOR_HINT])
+			return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "Invalid bg_color: %s (%s)" % [str(params.bg_color), _COLOR_HINT])
 		sb.bg_color = bg
 	if params.has("border_color"):
 		var bc := _parse_color(params.border_color)
 		if bc == null:
-			return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "Invalid border_color: %s (%s)" % [str(params.border_color), _COLOR_HINT])
+			return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "Invalid border_color: %s (%s)" % [str(params.border_color), _COLOR_HINT])
 		sb.border_color = bc
 
 	# border: {all, top, bottom, left, right} — int widths
@@ -233,7 +235,7 @@ func set_stylebox_flat(params: Dictionary) -> Dictionary:
 			"border_width_",
 			TYPE_INT)
 		if err != "":
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, err)
+			return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, err)
 
 	# corners: {all, top_left, top_right, bottom_left, bottom_right} — int radii
 	if params.has("corners"):
@@ -242,7 +244,7 @@ func set_stylebox_flat(params: Dictionary) -> Dictionary:
 			"corner_radius_",
 			TYPE_INT)
 		if err2 != "":
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, err2)
+			return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, err2)
 
 	# margins: {all, top, bottom, left, right} — float padding
 	if params.has("margins"):
@@ -251,22 +253,22 @@ func set_stylebox_flat(params: Dictionary) -> Dictionary:
 			"content_margin_",
 			TYPE_FLOAT)
 		if err3 != "":
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, err3)
+			return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, err3)
 
 	# shadow: {color, size, offset_x, offset_y}
 	if params.has("shadow"):
 		if typeof(params.shadow) != TYPE_DICTIONARY:
-			return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "'shadow' must be a dict with color/size/offset_x/offset_y")
+			return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, "'shadow' must be a dict with color/size/offset_x/offset_y")
 		var shadow: Dictionary = params.shadow
 		var allowed_shadow_keys := {"color": true, "size": true, "offset_x": true, "offset_y": true}
 		for k in shadow.keys():
 			if not allowed_shadow_keys.has(k):
-				return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+				return ErrorCodes.make(ErrorCodes.INVALID_PARAMS,
 					"Unknown key in 'shadow': %s (valid: color, size, offset_x, offset_y)" % k)
 		if shadow.has("color"):
 			var sc := _parse_color(shadow.color)
 			if sc == null:
-				return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS,
+				return ErrorCodes.make(ErrorCodes.INVALID_PARAMS,
 					"Invalid shadow.color: %s (%s)" % [str(shadow.color), _COLOR_HINT])
 			sb.shadow_color = sc
 		if shadow.has("size"):
@@ -374,7 +376,7 @@ func _clear_stylebox(theme_path: String, name: String, class_name_param: String)
 func apply_theme(params: Dictionary) -> Dictionary:
 	var node_path: String = params.get("node_path", "")
 	if node_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: node_path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: node_path")
 
 	var theme_path: String = params.get("theme_path", "")
 	var theme: Theme = null
@@ -383,10 +385,10 @@ func apply_theme(params: Dictionary) -> Dictionary:
 		if path_err != null:
 			return path_err
 		if not ResourceLoader.exists(theme_path):
-			return McpErrorCodes.make(McpErrorCodes.RESOURCE_NOT_FOUND, "Theme not found: %s" % theme_path)
+			return ErrorCodes.make(ErrorCodes.RESOURCE_NOT_FOUND, "Theme not found: %s" % theme_path)
 		theme = ResourceLoader.load(theme_path)
 		if theme == null or not theme is Theme:
-			return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "Resource at %s is not a Theme" % theme_path)
+			return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "Resource at %s is not a Theme" % theme_path)
 
 	var _resolved := McpNodeValidator.resolve_or_error(node_path, "node_path")
 	if _resolved.has("error"):
@@ -394,8 +396,8 @@ func apply_theme(params: Dictionary) -> Dictionary:
 	var node: Node = _resolved.node
 	var scene_root: Node = _resolved.scene_root
 	if not node is Control and not node is Window:
-		return McpErrorCodes.make(
-			McpErrorCodes.WRONG_TYPE,
+		return ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
 			"Node %s is not a Control or Window (got %s)" % [node_path, node.get_class()]
 		)
 
@@ -425,24 +427,24 @@ func _load_theme_from_params(params: Dictionary) -> Dictionary:
 	if err != null:
 		return err
 	if not ResourceLoader.exists(theme_path):
-		return McpErrorCodes.make(McpErrorCodes.RESOURCE_NOT_FOUND, "Theme not found: %s" % theme_path)
+		return ErrorCodes.make(ErrorCodes.RESOURCE_NOT_FOUND, "Theme not found: %s" % theme_path)
 	var theme: Theme = ResourceLoader.load(theme_path)
 	if theme == null or not theme is Theme:
-		return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "Resource at %s is not a Theme" % theme_path)
+		return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "Resource at %s is not a Theme" % theme_path)
 	return {"theme": theme, "path": theme_path}
 
 
 static func _validate_res_path(path: String, required_suffix: String, param_name: String = "theme_path") -> Variant:
 	if path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: %s" % param_name)
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: %s" % param_name)
 	if not path.begins_with("res://"):
-		return McpErrorCodes.make(
-			McpErrorCodes.VALUE_OUT_OF_RANGE,
+		return ErrorCodes.make(
+			ErrorCodes.VALUE_OUT_OF_RANGE,
 			"%s must start with res:// (got %s)" % [param_name, path]
 		)
 	if not path.ends_with(required_suffix):
-		return McpErrorCodes.make(
-			McpErrorCodes.VALUE_OUT_OF_RANGE,
+		return ErrorCodes.make(
+			ErrorCodes.VALUE_OUT_OF_RANGE,
 			"%s must end with %s (got %s)" % [param_name, required_suffix, path]
 		)
 	return null

--- a/plugin/addons/godot_ai/handlers/ui_handler.gd
+++ b/plugin/addons/godot_ai/handlers/ui_handler.gd
@@ -1,6 +1,8 @@
 @tool
 extends RefCounted
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Handles UI-specific (Control) layout helpers: anchor presets, etc.
 ##
 ## Anchors/offsets are the worst part of Control layout to set one-property-at-a-time.
@@ -56,16 +58,16 @@ func _init(undo_redo: EditorUndoRedoManager) -> void:
 func set_anchor_preset(params: Dictionary) -> Dictionary:
 	var node_path: String = params.get("path", "")
 	if node_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
 
 	var preset_name: String = str(params.get("preset", "")).to_lower()
 	if preset_name.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: preset")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: preset")
 	if not _PRESETS.has(preset_name):
 		var names := _PRESETS.keys()
 		names.sort()
-		return McpErrorCodes.make(
-			McpErrorCodes.VALUE_OUT_OF_RANGE,
+		return ErrorCodes.make(
+			ErrorCodes.VALUE_OUT_OF_RANGE,
 			"Unknown preset '%s'. Valid: %s" % [preset_name, ", ".join(names)]
 		)
 
@@ -73,8 +75,8 @@ func set_anchor_preset(params: Dictionary) -> Dictionary:
 	if not _RESIZE_MODES.has(resize_mode_name):
 		var names := _RESIZE_MODES.keys()
 		names.sort()
-		return McpErrorCodes.make(
-			McpErrorCodes.VALUE_OUT_OF_RANGE,
+		return ErrorCodes.make(
+			ErrorCodes.VALUE_OUT_OF_RANGE,
 			"Unknown resize_mode '%s'. Valid: %s" % [resize_mode_name, ", ".join(names)]
 		)
 
@@ -87,8 +89,8 @@ func set_anchor_preset(params: Dictionary) -> Dictionary:
 	var scene_root: Node = _resolved.scene_root
 	if not node is Control:
 		var got_class: String = node.get_class()
-		return McpErrorCodes.make(
-			McpErrorCodes.WRONG_TYPE,
+		return ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
 			"Node %s is not a Control (got %s)%s" % [
 				node_path, got_class, _canvas_layer_overlay_hint(got_class)
 			]
@@ -143,13 +145,13 @@ func set_anchor_preset(params: Dictionary) -> Dictionary:
 func set_text(params: Dictionary) -> Dictionary:
 	var node_path: String = params.get("path", "")
 	if node_path.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
 
 	if not params.has("text"):
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: text")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: text")
 	var text_value: Variant = params["text"]
 	if typeof(text_value) != TYPE_STRING:
-		return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "text must be a string")
+		return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "text must be a string")
 
 	var _resolved := McpNodeValidator.resolve_or_error(node_path, "node_path")
 	if _resolved.has("error"):
@@ -158,8 +160,8 @@ func set_text(params: Dictionary) -> Dictionary:
 	var scene_root: Node = _resolved.scene_root
 	var node_type := node.get_class()
 	if not node is Control:
-		return McpErrorCodes.make(
-			McpErrorCodes.WRONG_TYPE,
+		return ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
 			"Node %s is not a Control (got %s)" % [node_path, node_type]
 		)
 	# Scan get_property_list() (matches set_property / _apply_property in this
@@ -174,13 +176,13 @@ func set_text(params: Dictionary) -> Dictionary:
 			text_prop_type = prop.get("type", TYPE_NIL)
 			break
 	if not has_text:
-		return McpErrorCodes.make(
-			McpErrorCodes.PROPERTY_NOT_ON_CLASS,
+		return ErrorCodes.make(
+			ErrorCodes.PROPERTY_NOT_ON_CLASS,
 			"Control %s has no 'text' property (got %s)" % [node_path, node_type]
 		)
 	if text_prop_type != TYPE_STRING:
-		return McpErrorCodes.make(
-			McpErrorCodes.PROPERTY_NOT_ON_CLASS,
+		return ErrorCodes.make(
+			ErrorCodes.PROPERTY_NOT_ON_CLASS,
 			"Control %s has a non-string 'text' property (got %s)" % [node_path, node_type]
 		)
 
@@ -220,9 +222,9 @@ func set_text(params: Dictionary) -> Dictionary:
 func build_layout(params: Dictionary) -> Dictionary:
 	var tree = params.get("tree")
 	if not params.has("tree"):
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: tree")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: tree")
 	if typeof(tree) != TYPE_DICTIONARY:
-		return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "tree must be a dictionary")
+		return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "tree must be a dictionary")
 
 	var _scene_check := McpNodeValidator.require_scene_or_error()
 	if _scene_check.has("error"):
@@ -234,7 +236,7 @@ func build_layout(params: Dictionary) -> Dictionary:
 	if not parent_path.is_empty() and parent_path != "/":
 		parent = McpScenePath.resolve(parent_path, scene_root)
 		if parent == null:
-			return McpErrorCodes.make(McpErrorCodes.NODE_NOT_FOUND, McpScenePath.format_parent_error(parent_path, scene_root))
+			return ErrorCodes.make(ErrorCodes.NODE_NOT_FOUND, McpScenePath.format_parent_error(parent_path, scene_root))
 
 	# Validate + build in memory first; if anything fails, free and bail.
 	var built := _build_subtree(tree)
@@ -266,15 +268,15 @@ func build_layout(params: Dictionary) -> Dictionary:
 func _build_subtree(spec: Dictionary) -> Dictionary:
 	var node_type: String = spec.get("type", "")
 	if node_type.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.MISSING_REQUIRED_PARAM, "Every layout node requires a 'type'")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Every layout node requires a 'type'")
 	if not ClassDB.class_exists(node_type):
-		return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "Unknown type: %s" % node_type)
+		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "Unknown type: %s" % node_type)
 	if not ClassDB.is_parent_class(node_type, "Node"):
-		return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "%s is not a Node type" % node_type)
+		return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "%s is not a Node type" % node_type)
 
 	var node: Node = ClassDB.instantiate(node_type)
 	if node == null:
-		return McpErrorCodes.make(McpErrorCodes.INTERNAL_ERROR, "Failed to instantiate %s" % node_type)
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to instantiate %s" % node_type)
 
 	var node_name: String = spec.get("name", "")
 	if not node_name.is_empty():
@@ -285,7 +287,7 @@ func _build_subtree(spec: Dictionary) -> Dictionary:
 		var props = spec.get("properties")
 		if typeof(props) != TYPE_DICTIONARY:
 			node.free()
-			return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "properties must be a dictionary")
+			return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "properties must be a dictionary")
 		for key in props:
 			var value = props[key]
 			var apply_err := _apply_property(node, str(key), value)
@@ -299,18 +301,18 @@ func _build_subtree(spec: Dictionary) -> Dictionary:
 		if not theme_path.is_empty():
 			if not theme_path.begins_with("res://"):
 				node.free()
-				return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "theme must be a res:// path")
+				return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "theme must be a res:// path")
 			if not ResourceLoader.exists(theme_path):
 				node.free()
-				return McpErrorCodes.make(McpErrorCodes.RESOURCE_NOT_FOUND, "Theme not found: %s" % theme_path)
+				return ErrorCodes.make(ErrorCodes.RESOURCE_NOT_FOUND, "Theme not found: %s" % theme_path)
 			var theme_res: Resource = ResourceLoader.load(theme_path)
 			if theme_res == null or not theme_res is Theme:
 				node.free()
-				return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "theme path must point to a Theme resource: %s" % theme_path)
+				return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "theme path must point to a Theme resource: %s" % theme_path)
 			if not node is Control and not node is Window:
 				node.free()
-				return McpErrorCodes.make(
-					McpErrorCodes.INVALID_PARAMS,
+				return ErrorCodes.make(
+					ErrorCodes.INVALID_PARAMS,
 					"theme can only be set on Control / Window (got %s)%s" % [
 						node_type, _canvas_layer_overlay_hint(node_type)
 					]
@@ -322,11 +324,11 @@ func _build_subtree(spec: Dictionary) -> Dictionary:
 		var preset_name: String = str(spec.get("anchor_preset", "")).to_lower()
 		if not _PRESETS.has(preset_name):
 			node.free()
-			return McpErrorCodes.make(McpErrorCodes.VALUE_OUT_OF_RANGE, "Unknown anchor_preset: %s" % preset_name)
+			return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "Unknown anchor_preset: %s" % preset_name)
 		if not node is Control:
 			node.free()
-			return McpErrorCodes.make(
-				McpErrorCodes.INVALID_PARAMS,
+			return ErrorCodes.make(
+				ErrorCodes.INVALID_PARAMS,
 				"anchor_preset requires a Control (got %s)%s" % [
 					node_type, _canvas_layer_overlay_hint(node_type)
 				]
@@ -340,11 +342,11 @@ func _build_subtree(spec: Dictionary) -> Dictionary:
 		var children = spec.get("children")
 		if typeof(children) != TYPE_ARRAY:
 			node.free()
-			return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "children must be an array")
+			return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "children must be an array")
 		for child_spec in children:
 			if typeof(child_spec) != TYPE_DICTIONARY:
 				node.free()
-				return McpErrorCodes.make(McpErrorCodes.WRONG_TYPE, "each child must be a dictionary")
+				return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "each child must be a dictionary")
 			var child_result := _build_subtree(child_spec)
 			if child_result.has("error"):
 				node.free()
@@ -388,8 +390,8 @@ func _apply_property(node: Node, prop: String, value: Variant) -> Variant:
 	for prefix in _THEME_OVERRIDE_MAP:
 		if prop.begins_with(prefix):
 			if not node is Control:
-				return McpErrorCodes.make(
-					McpErrorCodes.INVALID_PARAMS,
+				return ErrorCodes.make(
+					ErrorCodes.INVALID_PARAMS,
 					"theme_override_* requires a Control node (got %s)" % node.get_class()
 				)
 			var override_name := prop.substr(prefix.length())
@@ -401,21 +403,21 @@ func _apply_property(node: Node, prop: String, value: Variant) -> Variant:
 				if value is String and value.begins_with("res://"):
 					var res := ResourceLoader.load(value)
 					if res == null or not res is StyleBox:
-						return McpErrorCodes.make(
-							McpErrorCodes.INVALID_PARAMS,
+						return ErrorCodes.make(
+							ErrorCodes.INVALID_PARAMS,
 							"Style resource not found or not a StyleBox: %s" % value
 						)
 					node.call(info.add, override_name, res)
 				else:
-					return McpErrorCodes.make(
-						McpErrorCodes.INVALID_PARAMS,
+					return ErrorCodes.make(
+						ErrorCodes.INVALID_PARAMS,
 						"theme_override_styles/ expects a res:// path to a StyleBox"
 					)
 			else:
 				var coercion := _coerce_for_type(value, coerce_type)
 				if not coercion.ok:
-					return McpErrorCodes.make(
-						McpErrorCodes.WRONG_TYPE,
+					return ErrorCodes.make(
+						ErrorCodes.WRONG_TYPE,
 						"Cannot coerce '%s' for %s" % [value, prop]
 					)
 				node.call(info.add, override_name, coercion.value)
@@ -429,15 +431,15 @@ func _apply_property(node: Node, prop: String, value: Variant) -> Variant:
 			prop_type = p.get("type", TYPE_NIL)
 			break
 	if not found:
-		return McpErrorCodes.make(
-			McpErrorCodes.PROPERTY_NOT_ON_CLASS,
+		return ErrorCodes.make(
+			ErrorCodes.PROPERTY_NOT_ON_CLASS,
 			McpPropertyErrors.build_message(node, prop)
 		)
 
 	var coercion := _coerce_for_type(value, prop_type)
 	if not coercion.ok:
-		return McpErrorCodes.make(
-			McpErrorCodes.WRONG_TYPE,
+		return ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
 			"Property '%s' on %s expects type %s (cannot coerce %s)" % [
 				prop, node.get_class(), type_string(prop_type), value
 			]

--- a/plugin/addons/godot_ai/utils/error_codes.gd
+++ b/plugin/addons/godot_ai/utils/error_codes.gd
@@ -1,5 +1,4 @@
 @tool
-class_name McpErrorCodes
 extends RefCounted
 
 ## Error code constants shared across handlers. Mirrors protocol/errors.py.

--- a/plugin/addons/godot_ai/utils/path_validator.gd
+++ b/plugin/addons/godot_ai/utils/path_validator.gd
@@ -2,6 +2,8 @@
 class_name McpPathValidator
 extends RefCounted
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Validates `res://`-rooted paths against directory-traversal escape.
 ##
 ## Issue #347 (audit-v2 #3): handlers were accepting `res://../etc/passwd.gd`
@@ -36,7 +38,7 @@ static func _res_root() -> String:
 
 ## Returns "" when the path is a safe `res://`-rooted reference inside the
 ## project root. Returns a human-readable error message otherwise; callers
-## wrap it with `McpErrorCodes.make(INVALID_PARAMS, ...)`.
+## wrap it with `ErrorCodes.make(INVALID_PARAMS, ...)`.
 static func validate_resource_path(path: String) -> String:
 	if path.is_empty():
 		return "Missing required param: path"

--- a/plugin/addons/godot_ai/utils/resource_io.gd
+++ b/plugin/addons/godot_ai/utils/resource_io.gd
@@ -2,6 +2,8 @@
 class_name McpResourceIO
 extends RefCounted
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Shared helpers for "save a Resource to .tres" and the mutually-exclusive
 ## path-vs-resource_path param validation that every resource-authoring
 ## handler needs. Extracted to remove 4-way duplication across
@@ -26,12 +28,12 @@ static func validate_home(params: Dictionary, require_property: bool = true) -> 
 
 	if has_node_target and has_file_target:
 		var both_msg := "Provide either path+property or resource_path, not both" if require_property else "Provide either path or resource_path, not both"
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, both_msg)
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, both_msg)
 	if not has_node_target and not has_file_target:
 		var none_msg := "Must provide either path+property (assign inline) or resource_path (save .tres)" if require_property else "Must provide either path or resource_path"
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, none_msg)
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, none_msg)
 	if require_property and has_node_target and property.is_empty():
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "Missing required param: property (required when path is given)")
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, "Missing required param: property (required when path is given)")
 	return null
 
 
@@ -70,20 +72,20 @@ static func save_to_disk(
 	pause_target: McpConnection = null,
 ) -> Dictionary:
 	if not resource_path.begins_with("res://"):
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "resource_path must start with res://")
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, "resource_path must start with res://")
 
 	var existed_before := FileAccess.file_exists(resource_path)
 	if existed_before and not overwrite:
-		return McpErrorCodes.make(
-			McpErrorCodes.INVALID_PARAMS,
+		return ErrorCodes.make(
+			ErrorCodes.INVALID_PARAMS,
 			"%s already exists at %s (pass overwrite=true to replace)" % [label, resource_path]
 		)
 
 	var dir_path := resource_path.get_base_dir()
 	var mkdir_err := DirAccess.make_dir_recursive_absolute(dir_path)
 	if mkdir_err != OK and mkdir_err != ERR_ALREADY_EXISTS:
-		return McpErrorCodes.make(
-			McpErrorCodes.INTERNAL_ERROR,
+		return ErrorCodes.make(
+			ErrorCodes.INTERNAL_ERROR,
 			"Failed to create directory %s: %s" % [dir_path, error_string(mkdir_err)]
 		)
 
@@ -93,8 +95,8 @@ static func save_to_disk(
 	if pause_target != null:
 		pause_target.pause_processing = false
 	if save_err != OK:
-		return McpErrorCodes.make(
-			McpErrorCodes.INTERNAL_ERROR,
+		return ErrorCodes.make(
+			ErrorCodes.INTERNAL_ERROR,
 			"Failed to save %s to %s: %s" % [label, resource_path, error_string(save_err)]
 		)
 

--- a/plugin/addons/godot_ai/utils/scene_path.gd
+++ b/plugin/addons/godot_ai/utils/scene_path.gd
@@ -2,6 +2,8 @@
 class_name McpScenePath
 extends RefCounted
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Utility for converting between Godot internal node paths and clean
 ## scene-relative paths like /Main/Camera3D.
 
@@ -68,15 +70,15 @@ static func resolve(scene_path: String, scene_root: Node) -> Node:
 ## caller can re-open the right scene.
 ##
 ## Shape on success: {"node": <scene_root>}. Shape on error matches
-## `McpErrorCodes.make()` so callers can propagate the result directly.
+## `ErrorCodes.make()` so callers can propagate the result directly.
 static func require_edited_scene(expected_scene_file: String) -> Dictionary:
 	var root := EditorInterface.get_edited_scene_root()
 	if root == null:
-		return McpErrorCodes.make(McpErrorCodes.EDITOR_NOT_READY, "No scene open")
+		return ErrorCodes.make(ErrorCodes.EDITOR_NOT_READY, "No scene open")
 	if not expected_scene_file.is_empty() and root.scene_file_path != expected_scene_file:
 		var actual := root.scene_file_path if not root.scene_file_path.is_empty() else "<unsaved>"
-		return McpErrorCodes.make(
-			McpErrorCodes.EDITED_SCENE_MISMATCH,
+		return ErrorCodes.make(
+			ErrorCodes.EDITED_SCENE_MISMATCH,
 			(
 				"Expected edited scene \"%s\" but \"%s\" is active. "
 				+ "Call scene_open(\"%s\") first, or omit scene_file to target the active scene."

--- a/test_project/tests/test_animation.gd
+++ b/test_project/tests/test_animation.gd
@@ -1,6 +1,8 @@
 @tool
 extends McpTestSuite
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 const AnimationHandler := preload("res://addons/godot_ai/handlers/animation_handler.gd")
 
 ## Tests for AnimationHandler — AnimationPlayer authoring.
@@ -174,7 +176,7 @@ func test_animation_create_rejects_invalid_loop_mode() -> void:
 		"length": 1.0,
 		"loop_mode": "bogus",
 	})
-	assert_is_error(result, McpErrorCodes.VALUE_OUT_OF_RANGE)
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
 	assert_contains(result.error.message, "loop_mode")
 	_remove_node(player_path)
 
@@ -284,7 +286,7 @@ func test_add_property_track_rejects_missing_property() -> void:
 		"track_path": ".:modulate",
 		"keyframes": [{"time": 0.0, "value": {"r": 1.0, "g": 0.0, "b": 0.0}}],
 	})
-	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_is_error(result, ErrorCodes.INVALID_PARAMS)
 	assert_contains(result.error.message, "not found")
 	_remove_node(player_path)
 
@@ -1010,7 +1012,7 @@ func test_create_simple_rejects_wrong_type_even_when_auto_create_enabled() -> vo
 			 "from": {"x": 0}, "to": {"x": 1}, "duration": 1.0},
 		],
 	})
-	assert_is_error(result, McpErrorCodes.WRONG_TYPE)
+	assert_is_error(result, ErrorCodes.WRONG_TYPE)
 	assert_contains(result.error.message, "not an AnimationPlayer")
 	_remove_node("/" + scene_root.name + "/Decoy86")
 
@@ -1656,7 +1658,7 @@ func test_preset_fade_invalid_mode() -> void:
 		"target_path": "FadeBadMode",
 		"mode": "wobble",
 	})
-	assert_is_error(result, McpErrorCodes.VALUE_OUT_OF_RANGE)
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
 	_remove_node(player_path)
 	_remove_node("/" + scene_root.name + "/FadeBadMode")
 
@@ -1957,7 +1959,7 @@ func test_preset_fade_missing_target() -> void:
 		"target_path": "NoSuchNode",
 		"mode": "in",
 	})
-	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_is_error(result, ErrorCodes.INVALID_PARAMS)
 	# Error must teach both supported path conventions so callers can pick the
 	# right one without spelunking docs (issue #328).
 	var msg := String(result.error.message)

--- a/test_project/tests/test_audio.gd
+++ b/test_project/tests/test_audio.gd
@@ -1,6 +1,8 @@
 @tool
 extends McpTestSuite
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 const AudioHandler := preload("res://addons/godot_ai/handlers/audio_handler.gd")
 
 ## Tests for AudioHandler — AudioStreamPlayer / 2D / 3D node authoring,
@@ -132,7 +134,7 @@ func test_create_invalid_type() -> void:
 		"name": "BadType",
 		"type": "gpu_3d",
 	})
-	assert_is_error(result, McpErrorCodes.VALUE_OUT_OF_RANGE)
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
 
 
 func test_create_missing_parent() -> void:
@@ -179,7 +181,7 @@ func test_set_stream_missing_resource() -> void:
 		"player_path": r.data.path,
 		"stream_path": "res://does_not_exist.ogg",
 	})
-	assert_is_error(result, McpErrorCodes.RESOURCE_NOT_FOUND)
+	assert_is_error(result, ErrorCodes.RESOURCE_NOT_FOUND)
 
 
 func test_set_stream_wrong_type() -> void:
@@ -192,7 +194,7 @@ func test_set_stream_wrong_type() -> void:
 		"player_path": r.data.path,
 		"stream_path": "res://tests/test_audio.gd",
 	})
-	assert_is_error(result, McpErrorCodes.WRONG_TYPE)
+	assert_is_error(result, ErrorCodes.WRONG_TYPE)
 
 
 func test_set_stream_empty_path() -> void:
@@ -337,12 +339,12 @@ func test_play_and_stop_roundtrip() -> void:
 
 func test_play_missing_player_path() -> void:
 	var result := _handler.play({})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_stop_missing_player_path() -> void:
 	var result := _handler.stop({})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 # ============================================================================

--- a/test_project/tests/test_autoload.gd
+++ b/test_project/tests/test_autoload.gd
@@ -1,6 +1,8 @@
 @tool
 extends McpTestSuite
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 const AutoloadHandler := preload("res://addons/godot_ai/handlers/autoload_handler.gd")
 
 ## Tests for AutoloadHandler — autoload listing, adding, and removing.
@@ -38,12 +40,12 @@ func test_list_autoloads() -> void:
 
 func test_add_autoload_missing_name() -> void:
 	var result := _handler.add_autoload({})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_add_autoload_missing_path() -> void:
 	var result := _handler.add_autoload({"name": TEST_AUTOLOAD_NAME})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_add_autoload_invalid_path_prefix() -> void:
@@ -51,7 +53,7 @@ func test_add_autoload_invalid_path_prefix() -> void:
 		"name": TEST_AUTOLOAD_NAME,
 		"path": "/absolute/path/evil.gd",
 	})
-	assert_is_error(result, McpErrorCodes.VALUE_OUT_OF_RANGE)
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
 
 
 func test_add_autoload_user_path_rejected() -> void:
@@ -115,7 +117,7 @@ func test_add_autoload_duplicate() -> void:
 
 func test_remove_autoload_missing_name() -> void:
 	var result := _handler.remove_autoload({})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_remove_autoload_not_found() -> void:

--- a/test_project/tests/test_batch.gd
+++ b/test_project/tests/test_batch.gd
@@ -1,6 +1,8 @@
 @tool
 extends McpTestSuite
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 const BatchHandler := preload("res://addons/godot_ai/handlers/batch_handler.gd")
 const NodeHandler := preload("res://addons/godot_ai/handlers/node_handler.gd")
 
@@ -32,7 +34,7 @@ func suite_setup(ctx: Dictionary) -> void:
 		return {"data": {"undoable": false}})
 	_dispatcher.register("_fail_pure", func(_p: Dictionary) -> Dictionary:
 		_call_log.append("_fail_pure")
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "forced failure"))
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, "forced failure"))
 
 	_handler = BatchHandler.new(_dispatcher, _undo_redo)
 
@@ -69,14 +71,14 @@ func test_rejects_non_dict_item() -> void:
 
 func test_rejects_unknown_subcommand() -> void:
 	var result := _handler.batch_execute({"commands": [{"command": "does_not_exist"}]})
-	assert_is_error(result, McpErrorCodes.UNKNOWN_COMMAND)
+	assert_is_error(result, ErrorCodes.UNKNOWN_COMMAND)
 
 
 func test_unknown_command_error_mentions_plugin_names() -> void:
 	# Simulates the common mistake: passing MCP tool name "node_create"
 	# instead of the plugin command "create_node".
 	var result := _handler.batch_execute({"commands": [{"command": "node_create"}]})
-	assert_is_error(result, McpErrorCodes.UNKNOWN_COMMAND)
+	assert_is_error(result, ErrorCodes.UNKNOWN_COMMAND)
 	var msg: String = result.error.message
 	assert_contains(msg, "plugin command names", "error should explain naming convention")
 	assert_contains(msg, "create_node", "error should suggest the correct plugin name")
@@ -84,7 +86,7 @@ func test_unknown_command_error_mentions_plugin_names() -> void:
 
 func test_unknown_command_populates_suggestions_field() -> void:
 	var result := _handler.batch_execute({"commands": [{"command": "node_create"}]})
-	assert_is_error(result, McpErrorCodes.UNKNOWN_COMMAND)
+	assert_is_error(result, ErrorCodes.UNKNOWN_COMMAND)
 	assert_has_key(result.error, "data")
 	assert_has_key(result.error.data, "suggestions")
 	var suggestions: Array = result.error.data.suggestions
@@ -95,7 +97,7 @@ func test_unknown_command_populates_suggestions_field() -> void:
 func test_unknown_command_empty_suggestions_when_no_match() -> void:
 	# Pure gibberish should still error cleanly, with suggestions empty or low-similarity.
 	var result := _handler.batch_execute({"commands": [{"command": "zzzqqqxxx_totally_bogus"}]})
-	assert_is_error(result, McpErrorCodes.UNKNOWN_COMMAND)
+	assert_is_error(result, ErrorCodes.UNKNOWN_COMMAND)
 	assert_has_key(result.error, "data")
 	assert_has_key(result.error.data, "suggestions")
 	# Array may be empty — the contract is just that the key exists and is an Array.

--- a/test_project/tests/test_camera.gd
+++ b/test_project/tests/test_camera.gd
@@ -1,6 +1,8 @@
 @tool
 extends McpTestSuite
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 const CameraHandler := preload("res://addons/godot_ai/handlers/camera_handler.gd")
 
 ## Tests for CameraHandler — Camera2D/Camera3D authoring, configure,
@@ -350,7 +352,7 @@ func test_create_invalid_type() -> void:
 		"name": "BadType",
 		"type": "nonsense",
 	})
-	assert_is_error(result, McpErrorCodes.VALUE_OUT_OF_RANGE)
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
 
 
 func test_create_with_make_current_unmarks_sibling() -> void:
@@ -634,7 +636,7 @@ func test_set_damping_2d_margin_out_of_range() -> void:
 		"camera_path": r.data.path,
 		"drag_margins": {"left": 1.5},
 	})
-	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_is_error(result, ErrorCodes.INVALID_PARAMS)
 
 
 func test_set_damping_2d_errors_on_3d() -> void:

--- a/test_project/tests/test_connection.gd
+++ b/test_project/tests/test_connection.gd
@@ -1,6 +1,8 @@
 @tool
 extends McpTestSuite
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Tests for McpConnection._make_session_id / _slugify — session ID format.
 
 
@@ -345,7 +347,7 @@ func test_outbound_backpressure_limit_rejects_payload_that_would_overflow() -> v
 func test_backpressure_error_is_structured_and_actionable() -> void:
 	var err := McpConnection._make_backpressure_error("rid-1", 100, 200)
 	assert_eq(err.request_id, "rid-1")
-	assert_is_error(err, McpErrorCodes.INTERNAL_ERROR)
+	assert_is_error(err, ErrorCodes.INTERNAL_ERROR)
 	assert_has_key(err.error, "data")
 	assert_eq(err.error.data.buffered_bytes, 100)
 	assert_eq(err.error.data.message_bytes, 200)

--- a/test_project/tests/test_control_draw_recipe.gd
+++ b/test_project/tests/test_control_draw_recipe.gd
@@ -1,6 +1,8 @@
 @tool
 extends McpTestSuite
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 const ControlDrawRecipeHandler := preload("res://addons/godot_ai/handlers/control_draw_recipe_handler.gd")
 
 ## Live-editor tests for ControlDrawRecipeHandler — control_draw_recipe command.
@@ -283,17 +285,17 @@ func test_undo_preserves_prior_meta() -> void:
 
 func test_missing_path_errors() -> void:
 	var result := _handler.control_draw_recipe({"ops": []})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_non_array_ops_errors() -> void:
 	var result := _handler.control_draw_recipe({"path": "/Main", "ops": "nope"})
-	assert_is_error(result, McpErrorCodes.WRONG_TYPE)
+	assert_is_error(result, ErrorCodes.WRONG_TYPE)
 
 
 func test_node_not_found_errors() -> void:
 	var result := _handler.control_draw_recipe({"path": "/Bogus/Path", "ops": []})
-	assert_is_error(result, McpErrorCodes.NODE_NOT_FOUND)
+	assert_is_error(result, ErrorCodes.NODE_NOT_FOUND)
 
 
 func test_non_control_rejected() -> void:
@@ -323,7 +325,7 @@ func test_missing_required_op_field_errors() -> void:
 	var result := _handler.control_draw_recipe(
 		{"path": path, "ops": [{"draw": "line", "from": [0, 0], "color": "red"}]}
 	)
-	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_is_error(result, ErrorCodes.INVALID_PARAMS)
 	assert_contains(result.error.message, "'to'")
 	var scene_root := EditorInterface.get_edited_scene_root()
 	var node := McpScenePath.resolve(path, scene_root)

--- a/test_project/tests/test_curve.gd
+++ b/test_project/tests/test_curve.gd
@@ -1,6 +1,8 @@
 @tool
 extends McpTestSuite
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 const CurveHandler := preload("res://addons/godot_ai/handlers/curve_handler.gd")
 
 ## Tests for CurveHandler — set points on Curve/Curve2D/Curve3D resources.
@@ -72,7 +74,7 @@ func test_set_points_missing_property() -> void:
 		"points": [],
 		"path": "/Main/Path3D",
 	})
-	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_is_error(result, ErrorCodes.INVALID_PARAMS)
 
 
 func test_set_points_wrong_resource_type() -> void:

--- a/test_project/tests/test_dispatcher.gd
+++ b/test_project/tests/test_dispatcher.gd
@@ -1,6 +1,8 @@
 @tool
 extends McpTestSuite
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Tests for McpDispatcher — specifically the crash-detection guardrail
 ## that catches handlers returning malformed results (null, empty dict,
 ## or dicts missing both "data" and "error" keys).
@@ -21,7 +23,7 @@ func test_dispatch_direct_converts_empty_dict_to_internal_error() -> void:
 	d.mcp_logging = false
 	d.register("returns_empty", func(_p): return {})
 	var result := d.dispatch_direct("returns_empty", {})
-	assert_is_error(result, McpErrorCodes.INTERNAL_ERROR)
+	assert_is_error(result, ErrorCodes.INTERNAL_ERROR)
 	assert_contains(result.error.message, "returns_empty")
 	assert_contains(result.error.message, "malformed result")
 
@@ -33,7 +35,7 @@ func test_dispatch_direct_converts_null_result_to_internal_error() -> void:
 	## this ends up looking the same as the empty-dict case — still flagged.
 	d.register("returns_null", func(_p): return {})
 	var result := d.dispatch_direct("returns_null", {})
-	assert_is_error(result, McpErrorCodes.INTERNAL_ERROR)
+	assert_is_error(result, ErrorCodes.INTERNAL_ERROR)
 
 
 func test_dispatch_direct_rejects_dict_missing_data_and_error_keys() -> void:
@@ -43,7 +45,7 @@ func test_dispatch_direct_rejects_dict_missing_data_and_error_keys() -> void:
 	d.mcp_logging = false
 	d.register("malformed", func(_p): return {"foo": "bar", "baz": 42})
 	var result := d.dispatch_direct("malformed", {})
-	assert_is_error(result, McpErrorCodes.INTERNAL_ERROR)
+	assert_is_error(result, ErrorCodes.INTERNAL_ERROR)
 	assert_contains(result.error.message, "malformed")
 
 
@@ -60,7 +62,7 @@ func test_dispatch_direct_accepts_error_key() -> void:
 	var d := _make_dispatcher()
 	d.mcp_logging = false
 	d.register("good_error", func(_p):
-		return McpErrorCodes.make(McpErrorCodes.INVALID_PARAMS, "bad input"))
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, "bad input"))
 	var result := d.dispatch_direct("good_error", {})
 	assert_is_error(result)
 	assert_eq(result.error.message, "bad input")
@@ -70,7 +72,7 @@ func test_dispatch_direct_unknown_command_unchanged() -> void:
 	var d := _make_dispatcher()
 	d.mcp_logging = false
 	var result := d.dispatch_direct("never_registered", {})
-	assert_is_error(result, McpErrorCodes.UNKNOWN_COMMAND)
+	assert_is_error(result, ErrorCodes.UNKNOWN_COMMAND)
 
 
 # ----- malformed-result error surfaces args + writes to log buffer (#210) -----
@@ -84,7 +86,7 @@ func test_malformed_result_message_includes_received_args() -> void:
 	d.mcp_logging = false
 	d.register("crashy", func(_p): return {})
 	var result := d.dispatch_direct("crashy", {"path": "/Main", "group": ["a", "b"]})
-	assert_is_error(result, McpErrorCodes.INTERNAL_ERROR)
+	assert_is_error(result, ErrorCodes.INTERNAL_ERROR)
 	assert_contains(result.error.message, "crashy")
 	assert_contains(result.error.message, "/Main")
 	assert_contains(result.error.message, "group")
@@ -98,7 +100,7 @@ func test_malformed_result_message_strips_internal_request_id() -> void:
 	d.mcp_logging = false
 	d.register("crashy", func(_p): return {})
 	var result := d.dispatch_direct("crashy", {"_request_id": "secret-rid-123"})
-	assert_is_error(result, McpErrorCodes.INTERNAL_ERROR)
+	assert_is_error(result, ErrorCodes.INTERNAL_ERROR)
 	assert_true(
 		result.error.message.find("secret-rid-123") == -1,
 		"_request_id must not appear in the user-facing error message",
@@ -132,7 +134,7 @@ func test_malformed_result_log_includes_non_empty_backtrace() -> void:
 	d.mcp_logging = true
 	d.register("crashy", func(_p): return {})
 	var result := d.dispatch_direct("crashy", {"path": "/Main"})
-	assert_is_error(result, McpErrorCodes.INTERNAL_ERROR)
+	assert_is_error(result, ErrorCodes.INTERNAL_ERROR)
 	assert_contains(result.error.message, "Backtrace:")
 
 	var lines := buf.get_recent(20)
@@ -154,7 +156,7 @@ func test_malformed_result_truncates_long_args() -> void:
 	for i in range(200):
 		big += "x"
 	var result := d.dispatch_direct("crashy", {"blob": big + big + big})
-	assert_is_error(result, McpErrorCodes.INTERNAL_ERROR)
+	assert_is_error(result, ErrorCodes.INTERNAL_ERROR)
 	assert_contains(result.error.message, "...")
 
 
@@ -183,7 +185,7 @@ func test_deferred_response_times_out_and_cleans_pending_entry() -> void:
 
 	assert_eq(responses.size(), 1, "deferred timeout should produce one local error")
 	assert_eq(responses[0].request_id, "req-timeout")
-	assert_is_error(responses[0], McpErrorCodes.DEFERRED_TIMEOUT)
+	assert_is_error(responses[0], ErrorCodes.DEFERRED_TIMEOUT)
 	assert_eq(d.pending_deferred_count(), 0, "timeout should clean the pending entry")
 
 

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -1,6 +1,8 @@
 @tool
 extends McpTestSuite
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 const EditorHandler := preload("res://addons/godot_ai/handlers/editor_handler.gd")
 const StubBacktrace := preload("res://addons/godot_ai/testing/stub_backtrace.gd")
 
@@ -118,7 +120,7 @@ func test_clear_logs_empties_buffer() -> void:
 
 func test_screenshot_invalid_source() -> void:
 	var result := _handler.take_screenshot({"source": "invalid"})
-	assert_is_error(result, McpErrorCodes.VALUE_OUT_OF_RANGE)
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
 
 
 func test_screenshot_game_not_playing() -> void:
@@ -171,7 +173,7 @@ func test_debugger_plugin_clear_pending_disconnects_timer() -> void:
 
 func test_screenshot_view_target_not_found() -> void:
 	var result := _handler.take_screenshot({"source": "viewport", "view_target": "/Main/NonExistent"})
-	assert_is_error(result, McpErrorCodes.NODE_NOT_FOUND)
+	assert_is_error(result, ErrorCodes.NODE_NOT_FOUND)
 
 
 func test_screenshot_view_target_all_invalid_comma() -> void:

--- a/test_project/tests/test_environment.gd
+++ b/test_project/tests/test_environment.gd
@@ -1,6 +1,8 @@
 @tool
 extends McpTestSuite
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 const EnvironmentHandler := preload("res://addons/godot_ai/handlers/environment_handler.gd")
 
 ## Tests for EnvironmentHandler — create Environment + Sky + SkyMaterial.
@@ -57,7 +59,7 @@ func test_create_invalid_preset() -> void:
 		"path": "/Main/World",
 		"preset": "zapruder",
 	})
-	assert_is_error(result, McpErrorCodes.VALUE_OUT_OF_RANGE)
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
 
 
 func test_create_target_not_world_environment() -> void:

--- a/test_project/tests/test_filesystem.gd
+++ b/test_project/tests/test_filesystem.gd
@@ -1,6 +1,8 @@
 @tool
 extends McpTestSuite
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 const FilesystemHandler := preload("res://addons/godot_ai/handlers/filesystem_handler.gd")
 
 ## Tests for FilesystemHandler — file read/write and reimport.
@@ -46,7 +48,7 @@ func test_read_file_basic() -> void:
 
 func test_read_file_missing_path() -> void:
 	var result := _handler.read_file({})
-	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_is_error(result, ErrorCodes.INVALID_PARAMS)
 
 
 func test_read_file_invalid_prefix() -> void:
@@ -56,7 +58,7 @@ func test_read_file_invalid_prefix() -> void:
 
 func test_read_file_not_found() -> void:
 	var result := _handler.read_file({"path": "res://nonexistent_file.txt"})
-	assert_is_error(result, McpErrorCodes.RESOURCE_NOT_FOUND)
+	assert_is_error(result, ErrorCodes.RESOURCE_NOT_FOUND)
 
 
 func test_read_file_rejects_traversal_path() -> void:
@@ -104,7 +106,7 @@ func test_write_file_overwrite_omits_cleanup_hint() -> void:
 
 func test_write_file_missing_path() -> void:
 	var result := _handler.write_file({"content": "hello"})
-	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_is_error(result, ErrorCodes.INVALID_PARAMS)
 
 
 func test_write_file_invalid_prefix() -> void:
@@ -133,7 +135,7 @@ func test_write_file_rejects_traversal_path() -> void:
 
 func test_reimport_missing_paths() -> void:
 	var result := _handler.reimport({})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_reimport_empty_paths() -> void:

--- a/test_project/tests/test_input.gd
+++ b/test_project/tests/test_input.gd
@@ -1,6 +1,8 @@
 @tool
 extends McpTestSuite
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 const InputHandler := preload("res://addons/godot_ai/handlers/input_handler.gd")
 
 ## Tests for InputHandler — input action listing, adding, removing, binding.
@@ -74,7 +76,7 @@ func test_list_actions_hides_editor_internal_namespaces() -> void:
 
 func test_add_action_missing_name() -> void:
 	var result := _handler.add_action({})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_add_and_remove_action() -> void:
@@ -103,7 +105,7 @@ func test_add_action_duplicate() -> void:
 
 func test_remove_action_missing_name() -> void:
 	var result := _handler.remove_action({})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_remove_action_not_found() -> void:
@@ -115,10 +117,10 @@ func test_remove_action_not_found() -> void:
 
 func test_bind_event_missing_params() -> void:
 	var result := _handler.bind_event({})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 	result = _handler.bind_event({"action": TEST_ACTION})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_bind_event_unknown_action() -> void:

--- a/test_project/tests/test_material.gd
+++ b/test_project/tests/test_material.gd
@@ -1,6 +1,8 @@
 @tool
 extends McpTestSuite
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 const MaterialHandler := preload("res://addons/godot_ai/handlers/material_handler.gd")
 
 ## Tests for MaterialHandler — StandardMaterial3D, ORM, CanvasItemMaterial,
@@ -94,7 +96,7 @@ func test_create_canvas_item() -> void:
 
 func test_create_invalid_type() -> void:
 	var result := _handler.create_material({"path": TEST_MATERIAL_PATH, "type": "nonsense"})
-	assert_is_error(result, McpErrorCodes.VALUE_OUT_OF_RANGE)
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
 
 
 func test_create_requires_res_path() -> void:
@@ -220,7 +222,7 @@ func test_set_param_unknown_property() -> void:
 		"param": "does_not_exist",
 		"value": 1.0,
 	})
-	assert_is_error(result, McpErrorCodes.PROPERTY_NOT_ON_CLASS)
+	assert_is_error(result, ErrorCodes.PROPERTY_NOT_ON_CLASS)
 
 
 func test_set_param_material_not_found() -> void:
@@ -238,7 +240,7 @@ func test_set_param_missing_value() -> void:
 		"path": TEST_MATERIAL_PATH,
 		"param": "metallic",
 	})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 # ============================================================================
@@ -393,7 +395,7 @@ func test_assign_surface_index_out_of_range() -> void:
 		"resource_path": TEST_MATERIAL_PATH,
 		"slot": "surface_99",
 	})
-	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_is_error(result, ErrorCodes.INVALID_PARAMS)
 	_remove_node(node)
 
 
@@ -403,7 +405,7 @@ func test_assign_node_not_found() -> void:
 		"node_path": "/DoesNotExist",
 		"resource_path": TEST_MATERIAL_PATH,
 	})
-	assert_is_error(result, McpErrorCodes.NODE_NOT_FOUND)
+	assert_is_error(result, ErrorCodes.NODE_NOT_FOUND)
 
 
 # ============================================================================
@@ -443,7 +445,7 @@ func test_apply_to_node_invalid_type() -> void:
 		"type": "garbage",
 		"params": {},
 	})
-	assert_is_error(result, McpErrorCodes.VALUE_OUT_OF_RANGE)
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
 	_remove_node(node)
 
 

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -1,6 +1,8 @@
 @tool
 extends McpTestSuite
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 const NodeHandler := preload("res://addons/godot_ai/handlers/node_handler.gd")
 
 ## Tests for NodeHandler — node reads and writes.
@@ -59,12 +61,12 @@ func test_get_children_includes_metadata() -> void:
 
 func test_get_children_invalid_path() -> void:
 	var result := _handler.get_children({"path": "/Main/DoesNotExist"})
-	assert_is_error(result, McpErrorCodes.NODE_NOT_FOUND)
+	assert_is_error(result, ErrorCodes.NODE_NOT_FOUND)
 
 
 func test_get_children_missing_path() -> void:
 	var result := _handler.get_children({})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 # ----- get_node_properties -----
@@ -96,12 +98,12 @@ func test_get_properties_has_value_and_type() -> void:
 
 func test_get_properties_invalid_path() -> void:
 	var result := _handler.get_node_properties({"path": "/Main/Nope"})
-	assert_is_error(result, McpErrorCodes.NODE_NOT_FOUND)
+	assert_is_error(result, ErrorCodes.NODE_NOT_FOUND)
 
 
 func test_get_properties_missing_path() -> void:
 	var result := _handler.get_node_properties({})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 # ----- get_groups -----
@@ -115,7 +117,7 @@ func test_get_groups_returns_array() -> void:
 
 func test_get_groups_invalid_path() -> void:
 	var result := _handler.get_groups({"path": "/Main/Missing"})
-	assert_is_error(result, McpErrorCodes.NODE_NOT_FOUND)
+	assert_is_error(result, ErrorCodes.NODE_NOT_FOUND)
 
 
 # ----- create_node -----
@@ -136,12 +138,12 @@ func test_create_node_basic() -> void:
 
 func test_create_node_invalid_type() -> void:
 	var result := _handler.create_node({"type": "NotARealNodeType"})
-	assert_is_error(result, McpErrorCodes.VALUE_OUT_OF_RANGE)
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
 
 
 func test_create_node_missing_type() -> void:
 	var result := _handler.create_node({})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_create_node_non_node_type() -> void:
@@ -169,7 +171,7 @@ func test_create_node_parent_not_found_error_names_convention() -> void:
 		"type": "Node3D",
 		"parent_path": "/SomeBogusPath",
 	})
-	assert_is_error(result, McpErrorCodes.NODE_NOT_FOUND)
+	assert_is_error(result, ErrorCodes.NODE_NOT_FOUND)
 	assert_contains(result.error.message, "relative to the edited scene root")
 	assert_contains(result.error.message, "Scene root is")
 
@@ -195,12 +197,12 @@ func test_delete_node_scene_root() -> void:
 
 func test_delete_node_invalid_path() -> void:
 	var result := _handler.delete_node({"path": "/Main/DoesNotExist"})
-	assert_is_error(result, McpErrorCodes.NODE_NOT_FOUND)
+	assert_is_error(result, ErrorCodes.NODE_NOT_FOUND)
 
 
 func test_delete_node_missing_path() -> void:
 	var result := _handler.delete_node({})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 # ----- reparent_node -----
@@ -212,7 +214,7 @@ func test_reparent_scene_root() -> void:
 
 func test_reparent_missing_new_parent() -> void:
 	var result := _handler.reparent_node({"path": "/Main/Camera3D"})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_reparent_to_self() -> void:
@@ -314,12 +316,12 @@ func test_set_property_float() -> void:
 
 func test_set_property_missing_property() -> void:
 	var result := _handler.set_property({"path": "/Main/Camera3D", "value": 10})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_set_property_missing_value() -> void:
 	var result := _handler.set_property({"path": "/Main/Camera3D", "property": "fov"})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_set_property_vector3_accepts_valid_dict() -> void:
@@ -467,7 +469,7 @@ func test_check_coerced_array_vector3_returns_wrong_type() -> void:
 	## coerce to a typed Variant slot is a type mismatch.
 	var coerce_err: Variant = NodeHandler._check_coerced([1, 2, 3], TYPE_VECTOR3)
 	assert_true(coerce_err is Dictionary, "Non-coerced Array input must produce an error dict")
-	assert_eq(coerce_err.error.code, McpErrorCodes.WRONG_TYPE)
+	assert_eq(coerce_err.error.code, ErrorCodes.WRONG_TYPE)
 	assert_contains(coerce_err.error.message, "Vector3")
 	assert_contains(coerce_err.error.message, "Array")  # names the received type
 
@@ -531,7 +533,7 @@ func test_set_property_resource_not_found() -> void:
 		"property": "environment",
 		"value": "res://does/not/exist.tres",
 	})
-	assert_is_error(result, McpErrorCodes.RESOURCE_NOT_FOUND)
+	assert_is_error(result, ErrorCodes.RESOURCE_NOT_FOUND)
 
 
 func test_set_property_resource_null_clears() -> void:
@@ -980,7 +982,7 @@ func test_rename_node_scene_root_rejected() -> void:
 
 func test_rename_node_missing_name() -> void:
 	var result := _handler.rename_node({"path": "/Main/Camera3D"})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_rename_node_invalid_characters() -> void:
@@ -1014,7 +1016,7 @@ func test_rename_node_invalid_path() -> void:
 		"path": "/Main/Nope",
 		"new_name": "NewName",
 	})
-	assert_is_error(result, McpErrorCodes.NODE_NOT_FOUND)
+	assert_is_error(result, ErrorCodes.NODE_NOT_FOUND)
 
 
 # ----- duplicate_node -----
@@ -1039,7 +1041,7 @@ func test_duplicate_scene_root() -> void:
 
 func test_duplicate_node_invalid_path() -> void:
 	var result := _handler.duplicate_node({"path": "/Main/NoSuchNode"})
-	assert_is_error(result, McpErrorCodes.NODE_NOT_FOUND)
+	assert_is_error(result, ErrorCodes.NODE_NOT_FOUND)
 
 
 # ----- move_node -----
@@ -1051,12 +1053,12 @@ func test_move_node_scene_root() -> void:
 
 func test_move_node_missing_index() -> void:
 	var result := _handler.move_node({"path": "/Main/Camera3D"})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_move_node_out_of_range() -> void:
 	var result := _handler.move_node({"path": "/Main/Camera3D", "index": 999})
-	assert_is_error(result, McpErrorCodes.VALUE_OUT_OF_RANGE)
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
 
 
 # ----- add_to_group / remove_from_group -----
@@ -1081,7 +1083,7 @@ func test_add_to_group() -> void:
 
 func test_add_to_group_missing_group() -> void:
 	var result := _handler.add_to_group({"path": "/Main/Camera3D"})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_remove_from_group_not_member() -> void:
@@ -1095,7 +1097,7 @@ func test_remove_from_group_not_member() -> void:
 
 func test_remove_from_group_missing_group() -> void:
 	var result := _handler.remove_from_group({"path": "/Main/Camera3D"})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_add_to_group_rejects_array_value() -> void:
@@ -1306,7 +1308,7 @@ func test_create_node_scene_file_mismatch_blocks_mutation() -> void:
 		"type": "Node",
 		"scene_file": "res://does/not/match.tscn",
 	})
-	assert_is_error(result, McpErrorCodes.EDITED_SCENE_MISMATCH)
+	assert_is_error(result, ErrorCodes.EDITED_SCENE_MISMATCH)
 
 
 func test_resolve_node_scene_file_mismatch_blocks_mutation() -> void:
@@ -1317,7 +1319,7 @@ func test_resolve_node_scene_file_mismatch_blocks_mutation() -> void:
 		"new_name": "ShouldNotRename",
 		"scene_file": "res://does/not/match.tscn",
 	})
-	assert_is_error(result, McpErrorCodes.EDITED_SCENE_MISMATCH)
+	assert_is_error(result, ErrorCodes.EDITED_SCENE_MISMATCH)
 	## And it did NOT actually rename — the original node stays put.
 	var cam := EditorInterface.get_edited_scene_root().get_node_or_null("Camera3D")
 	assert_ne(cam, null, "Camera3D must still exist under the original name")

--- a/test_project/tests/test_node_validator.gd
+++ b/test_project/tests/test_node_validator.gd
@@ -1,6 +1,8 @@
 @tool
 extends McpTestSuite
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Tests for McpNodeValidator (audit-v2 #20 / issue #364) — the shared
 ## resolve-or-error helper that subsumed the 38+ inline EDITOR_NOT_READY +
 ## NODE_NOT_FOUND blocks across handlers.
@@ -17,7 +19,7 @@ func suite_name() -> String:
 
 func test_resolve_or_error_missing_path_emits_missing_required_param() -> void:
 	var result := McpNodeValidator.resolve_or_error("")
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 	assert_contains(result.error.message, "path")
 
 
@@ -26,13 +28,13 @@ func test_resolve_or_error_uses_param_name_in_missing_message() -> void:
 	## error message must echo the caller's name so agents see the same
 	## param name they sent.
 	var result := McpNodeValidator.resolve_or_error("", "player_path")
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 	assert_contains(result.error.message, "player_path")
 
 
 func test_resolve_or_error_unresolvable_path_emits_node_not_found() -> void:
 	var result := McpNodeValidator.resolve_or_error("/Main/__definitely_nonexistent__")
-	assert_is_error(result, McpErrorCodes.NODE_NOT_FOUND)
+	assert_is_error(result, ErrorCodes.NODE_NOT_FOUND)
 
 
 # ----- resolve_or_error: success paths -----
@@ -70,10 +72,10 @@ func test_require_scene_or_error_returns_scene_root_when_open() -> void:
 # ----- error dict shape parity -----
 
 
-func test_error_dicts_match_McpErrorCodes_make_shape() -> void:
+func test_error_dicts_match_ErrorCodes_make_shape() -> void:
 	## The handler call sites do `if resolved.has("error"): return resolved`
 	## — that propagation only works if the error dict shape matches what
-	## `McpErrorCodes.make()` produces. Pin the contract here so a refactor
+	## `ErrorCodes.make()` produces. Pin the contract here so a refactor
 	## can't subtly change the error envelope.
 	var missing := McpNodeValidator.resolve_or_error("")
 	assert_has_key(missing, "status")

--- a/test_project/tests/test_particle.gd
+++ b/test_project/tests/test_particle.gd
@@ -1,6 +1,8 @@
 @tool
 extends McpTestSuite
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 const ParticleHandler := preload("res://addons/godot_ai/handlers/particle_handler.gd")
 
 ## Tests for ParticleHandler — GPUParticles3D/2D, CPUParticles3D/2D,
@@ -107,7 +109,7 @@ func test_create_invalid_type() -> void:
 		"name": "BadType",
 		"type": "nonsense",
 	})
-	assert_is_error(result, McpErrorCodes.VALUE_OUT_OF_RANGE)
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
 
 
 func test_create_attaches_process_material_to_gpu() -> void:
@@ -158,7 +160,7 @@ func test_set_main_unknown_property() -> void:
 		"node_path": r.data.path,
 		"properties": {"nonsense_prop": 1},
 	})
-	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_is_error(result, ErrorCodes.INVALID_PARAMS)
 
 
 func test_set_main_empty_dict() -> void:
@@ -297,7 +299,7 @@ func test_set_process_invalid_color_ramp() -> void:
 		"node_path": r.data.path,
 		"properties": {"color_ramp": {"no_stops_key": []}},
 	})
-	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_is_error(result, ErrorCodes.INVALID_PARAMS)
 
 
 # ============================================================================
@@ -549,4 +551,4 @@ func test_apply_preset_invalid_type() -> void:
 		"preset": "fire",
 		"type": "gpu_5d",
 	})
-	assert_is_error(result, McpErrorCodes.VALUE_OUT_OF_RANGE)
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)

--- a/test_project/tests/test_physics_shape.gd
+++ b/test_project/tests/test_physics_shape.gd
@@ -1,6 +1,8 @@
 @tool
 extends McpTestSuite
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 const PhysicsShapeHandler := preload("res://addons/godot_ai/handlers/physics_shape_handler.gd")
 
 ## Tests for PhysicsShapeHandler — autofit CollisionShape* to sibling bounds.
@@ -119,12 +121,12 @@ func _add_nested_body_3d(container_name: String, visuals: Array) -> Dictionary:
 
 func test_autofit_missing_path() -> void:
 	var result := _handler.autofit({})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_autofit_node_not_found() -> void:
 	var result := _handler.autofit({"path": "/Main/NopeNotHere"})
-	assert_is_error(result, McpErrorCodes.NODE_NOT_FOUND)
+	assert_is_error(result, ErrorCodes.NODE_NOT_FOUND)
 
 
 func test_autofit_node_is_not_collision_shape() -> void:
@@ -142,7 +144,7 @@ func test_autofit_invalid_shape_type_for_3d() -> void:
 		"path": parts.collision.get_path(),
 		"shape_type": "rectangle",  # 2D-only type used in 3D context
 	})
-	assert_is_error(result, McpErrorCodes.VALUE_OUT_OF_RANGE)
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
 	_remove_node(parts.body)
 
 
@@ -199,7 +201,7 @@ func test_autofit_3d_rejects_2d_class_name() -> void:
 		"path": parts.collision.get_path(),
 		"shape_type": "RectangleShape2D",
 	})
-	assert_is_error(result, McpErrorCodes.VALUE_OUT_OF_RANGE)
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
 	# Error message lists both short and class-name forms so the next
 	# attempt can pick a valid one.
 	assert_contains(result.error.message, "BoxShape3D")
@@ -216,7 +218,7 @@ func test_autofit_3d_rejects_unknown_class_name() -> void:
 		"path": parts.collision.get_path(),
 		"shape_type": "TotallyMadeUpShape3D",
 	})
-	assert_is_error(result, McpErrorCodes.VALUE_OUT_OF_RANGE)
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
 	_remove_node(parts.body)
 
 

--- a/test_project/tests/test_project.gd
+++ b/test_project/tests/test_project.gd
@@ -1,6 +1,8 @@
 @tool
 extends McpTestSuite
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 const ProjectHandler := preload("res://addons/godot_ai/handlers/project_handler.gd")
 
 ## Tests for ProjectHandler — project settings and filesystem search.
@@ -29,7 +31,7 @@ func test_get_project_setting_returns_value() -> void:
 
 func test_get_project_setting_missing_key() -> void:
 	var result := _handler.get_project_setting({})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_get_project_setting_unknown_key() -> void:
@@ -85,12 +87,12 @@ func test_set_project_setting_preserves_int_type() -> void:
 
 func test_set_project_setting_missing_key() -> void:
 	var result := _handler.set_project_setting({})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_set_project_setting_missing_value() -> void:
 	var result := _handler.set_project_setting({"key": "application/config/name"})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 # ----- search_filesystem -----
@@ -137,7 +139,7 @@ func test_search_filesystem_no_results() -> void:
 
 func test_run_project_invalid_mode() -> void:
 	var result := _handler.run_project({"mode": "invalid_mode"})
-	assert_is_error(result, McpErrorCodes.VALUE_OUT_OF_RANGE)
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
 
 
 func test_run_project_invalid_mode_restores_connection_pause() -> void:
@@ -147,7 +149,7 @@ func test_run_project_invalid_mode_restores_connection_pause() -> void:
 
 	var result := handler.run_project({"mode": "invalid_mode"})
 
-	assert_is_error(result, McpErrorCodes.VALUE_OUT_OF_RANGE)
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
 	assert_false(conn.pause_processing, "validation errors must not leave processing paused")
 	conn.free()
 
@@ -164,7 +166,7 @@ func test_run_project_validation_error_does_not_rotate_capture_run() -> void:
 
 func test_run_project_custom_missing_scene() -> void:
 	var result := _handler.run_project({"mode": "custom"})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_run_project_custom_empty_scene() -> void:

--- a/test_project/tests/test_resource.gd
+++ b/test_project/tests/test_resource.gd
@@ -1,6 +1,8 @@
 @tool
 extends McpTestSuite
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 const ResourceHandler := preload("res://addons/godot_ai/handlers/resource_handler.gd")
 
 ## Tests for ResourceHandler — resource search, load, and assign.
@@ -22,7 +24,7 @@ func suite_setup(ctx: Dictionary) -> void:
 
 func test_search_resources_missing_filters() -> void:
 	var result := _handler.search_resources({})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_search_resources_by_path() -> void:
@@ -46,7 +48,7 @@ func test_search_resources_by_type() -> void:
 
 func test_load_resource_missing_path() -> void:
 	var result := _handler.load_resource({})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_load_resource_invalid_prefix() -> void:
@@ -56,7 +58,7 @@ func test_load_resource_invalid_prefix() -> void:
 
 func test_load_resource_not_found() -> void:
 	var result := _handler.load_resource({"path": "res://nonexistent.tres"})
-	assert_is_error(result, McpErrorCodes.RESOURCE_NOT_FOUND)
+	assert_is_error(result, ErrorCodes.RESOURCE_NOT_FOUND)
 
 
 func test_load_resource_scene() -> void:
@@ -71,17 +73,17 @@ func test_load_resource_scene() -> void:
 
 func test_assign_resource_missing_path() -> void:
 	var result := _handler.assign_resource({"property": "mesh", "resource_path": "res://foo.tres"})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_assign_resource_missing_property() -> void:
 	var result := _handler.assign_resource({"path": "/Main/Camera3D", "resource_path": "res://foo.tres"})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_assign_resource_missing_resource_path() -> void:
 	var result := _handler.assign_resource({"path": "/Main/Camera3D", "property": "mesh"})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_assign_resource_node_not_found() -> void:
@@ -90,7 +92,7 @@ func test_assign_resource_node_not_found() -> void:
 		"property": "mesh",
 		"resource_path": "res://main.tscn",
 	})
-	assert_is_error(result, McpErrorCodes.NODE_NOT_FOUND)
+	assert_is_error(result, ErrorCodes.NODE_NOT_FOUND)
 
 
 func test_assign_resource_property_not_found() -> void:
@@ -141,7 +143,7 @@ func test_assign_resource_resource_not_found() -> void:
 		"property": "environment",
 		"resource_path": "res://nonexistent.tres",
 	})
-	assert_is_error(result, McpErrorCodes.RESOURCE_NOT_FOUND)
+	assert_is_error(result, ErrorCodes.RESOURCE_NOT_FOUND)
 
 
 # ----- create_resource -----
@@ -167,7 +169,7 @@ func _remove_node(node: Node) -> void:
 
 func test_create_resource_missing_type() -> void:
 	var result := _handler.create_resource({"path": "/Main/Foo", "property": "mesh"})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 	assert_contains(result.error.message, "type")
 
 
@@ -300,7 +302,7 @@ func test_create_resource_unknown_property_in_properties_dict() -> void:
 		"property": "mesh",
 		"properties": {"not_a_real_field": 42},
 	})
-	assert_is_error(result, McpErrorCodes.PROPERTY_NOT_ON_CLASS)
+	assert_is_error(result, ErrorCodes.PROPERTY_NOT_ON_CLASS)
 	# Error should enrich with valid_properties so the caller can recover without a round-trip.
 	assert_has_key(result.error, "data")
 	assert_has_key(result.error.data, "valid_properties")
@@ -315,12 +317,12 @@ func test_create_resource_unknown_property_in_properties_dict() -> void:
 
 func test_get_resource_info_missing_type() -> void:
 	var result := _handler.get_resource_info({})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_get_resource_info_unknown_type() -> void:
 	var result := _handler.get_resource_info({"type": "DefinitelyNotAClass_xyz"})
-	assert_is_error(result, McpErrorCodes.VALUE_OUT_OF_RANGE)
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
 	assert_contains(result.error.message, "Unknown resource type")
 
 

--- a/test_project/tests/test_scene.gd
+++ b/test_project/tests/test_scene.gd
@@ -1,6 +1,8 @@
 @tool
 extends McpTestSuite
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 const SceneHandler := preload("res://addons/godot_ai/handlers/scene_handler.gd")
 
 ## Tests for SceneHandler — scene tree reading and node search.
@@ -151,7 +153,7 @@ func test_find_nonexistent_type_returns_empty() -> void:
 
 func test_create_scene_missing_path() -> void:
 	var result := _handler.create_scene({})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_create_scene_invalid_root_type() -> void:
@@ -166,14 +168,14 @@ func test_create_scene_non_node_root_type() -> void:
 
 func test_create_scene_invalid_path_prefix() -> void:
 	var result := _handler.create_scene({"path": "/tmp/scene.tscn"})
-	assert_is_error(result, McpErrorCodes.VALUE_OUT_OF_RANGE)
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
 
 
 # ----- open_scene (validation only — opening scenes triggers UI that blocks test runner) -----
 
 func test_open_scene_missing_path() -> void:
 	var result := _handler.open_scene({})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_open_scene_nonexistent() -> void:
@@ -257,9 +259,9 @@ func test_save_scene_as_supports_never_saved_scene() -> void:
 
 func test_save_scene_as_missing_path() -> void:
 	var result := _handler.save_scene_as({})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_save_scene_as_invalid_path_prefix() -> void:
 	var result := _handler.save_scene_as({"path": "/tmp/bad.tscn"})
-	assert_is_error(result, McpErrorCodes.VALUE_OUT_OF_RANGE)
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)

--- a/test_project/tests/test_scene_path.gd
+++ b/test_project/tests/test_scene_path.gd
@@ -1,6 +1,8 @@
 @tool
 extends McpTestSuite
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 ## Tests for McpScenePath — the path resolver/formatter shared by every
 ## scene-mutating handler. Uses a freestanding Node tree (no dependency
 ## on the edited scene) so behavior is deterministic.
@@ -293,7 +295,7 @@ func test_require_edited_scene_mismatch_returns_structured_error() -> void:
 	## A non-empty expected that doesn't match the active scene must fail with
 	## EDITED_SCENE_MISMATCH, not silently target the wrong scene.
 	var result := McpScenePath.require_edited_scene("res://this/does/not/match.tscn")
-	assert_is_error(result, McpErrorCodes.EDITED_SCENE_MISMATCH)
+	assert_is_error(result, ErrorCodes.EDITED_SCENE_MISMATCH)
 	## Message must name both the expected and the active scene so the caller
 	## can diagnose drift without another call.
 	var active := EditorInterface.get_edited_scene_root().scene_file_path

--- a/test_project/tests/test_script.gd
+++ b/test_project/tests/test_script.gd
@@ -1,6 +1,8 @@
 @tool
 extends McpTestSuite
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 const NodeHandler := preload("res://addons/godot_ai/handlers/node_handler.gd")
 const ScriptHandler := preload("res://addons/godot_ai/handlers/script_handler.gd")
 
@@ -93,7 +95,7 @@ func test_create_script_overwrite_omits_cleanup_hint() -> void:
 
 func test_create_script_missing_path() -> void:
 	var result := _handler.create_script({"content": "extends Node\n"})
-	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_is_error(result, ErrorCodes.INVALID_PARAMS)
 
 
 func test_create_script_invalid_prefix() -> void:
@@ -200,7 +202,7 @@ func test_patch_script_missing_old_text() -> void:
 		"path": TEST_SCRIPT_PATH,
 		"new_text": "x",
 	})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_patch_script_non_gd_extension_rejected() -> void:
@@ -226,7 +228,7 @@ func test_patch_script_file_not_found() -> void:
 		"old_text": "x",
 		"new_text": "y",
 	})
-	assert_is_error(result, McpErrorCodes.RESOURCE_NOT_FOUND)
+	assert_is_error(result, ErrorCodes.RESOURCE_NOT_FOUND)
 
 
 func test_patch_script_invalid_prefix() -> void:
@@ -263,7 +265,7 @@ func test_read_script_basic() -> void:
 
 func test_read_script_missing_path() -> void:
 	var result := _handler.read_script({})
-	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_is_error(result, ErrorCodes.INVALID_PARAMS)
 
 
 func test_read_script_invalid_prefix() -> void:
@@ -313,12 +315,12 @@ func test_attach_script_basic() -> void:
 
 func test_attach_script_missing_path() -> void:
 	var result := _handler.attach_script({"script_path": TEST_SCRIPT_PATH})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_attach_script_missing_script_path() -> void:
 	var result := _handler.attach_script({"path": "/Main/Camera3D"})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_attach_script_node_not_found() -> void:
@@ -326,7 +328,7 @@ func test_attach_script_node_not_found() -> void:
 		"path": "/Main/DoesNotExist",
 		"script_path": TEST_SCRIPT_PATH,
 	})
-	assert_is_error(result, McpErrorCodes.NODE_NOT_FOUND)
+	assert_is_error(result, ErrorCodes.NODE_NOT_FOUND)
 
 
 func test_attach_script_not_found() -> void:
@@ -355,12 +357,12 @@ func test_detach_script_no_script() -> void:
 
 func test_detach_script_missing_path() -> void:
 	var result := _handler.detach_script({})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_detach_script_node_not_found() -> void:
 	var result := _handler.detach_script({"path": "/Main/DoesNotExist"})
-	assert_is_error(result, McpErrorCodes.NODE_NOT_FOUND)
+	assert_is_error(result, ErrorCodes.NODE_NOT_FOUND)
 
 
 # ----- find_symbols -----
@@ -402,7 +404,7 @@ func test_find_symbols_exports() -> void:
 
 func test_find_symbols_missing_path() -> void:
 	var result := _handler.find_symbols({})
-	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_is_error(result, ErrorCodes.INVALID_PARAMS)
 
 
 func test_find_symbols_invalid_prefix() -> void:

--- a/test_project/tests/test_signal.gd
+++ b/test_project/tests/test_signal.gd
@@ -1,6 +1,8 @@
 @tool
 extends McpTestSuite
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 const SignalHandler := preload("res://addons/godot_ai/handlers/signal_handler.gd")
 
 ## Tests for SignalHandler — signal listing, connecting, and disconnecting.
@@ -35,7 +37,7 @@ func test_list_signals_returns_signals() -> void:
 
 func test_list_signals_missing_path() -> void:
 	var result := _handler.list_signals({})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_list_signals_unknown_node() -> void:
@@ -211,16 +213,16 @@ func test_format_target_path_uses_absolute_for_non_descendants() -> void:
 
 func test_connect_signal_missing_params() -> void:
 	var result := _handler.connect_signal({})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 	result = _handler.connect_signal({"path": "/Main"})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 	result = _handler.connect_signal({"path": "/Main", "signal": "ready"})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 	result = _handler.connect_signal({"path": "/Main", "signal": "ready", "target": "/Main"})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_connect_signal_unknown_source() -> void:
@@ -237,7 +239,7 @@ func test_connect_signal_unknown_source() -> void:
 
 func test_disconnect_signal_missing_params() -> void:
 	var result := _handler.disconnect_signal({})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_disconnect_signal_not_connected() -> void:

--- a/test_project/tests/test_texture.gd
+++ b/test_project/tests/test_texture.gd
@@ -1,6 +1,8 @@
 @tool
 extends McpTestSuite
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 const TextureHandler := preload("res://addons/godot_ai/handlers/texture_handler.gd")
 
 ## Tests for TextureHandler — GradientTexture2D + NoiseTexture2D creation.
@@ -80,7 +82,7 @@ func test_gradient_stop_missing_keys() -> void:
 		"path": "/Main/Line",
 		"property": "texture",
 	})
-	assert_is_error(result, McpErrorCodes.INVALID_PARAMS)
+	assert_is_error(result, ErrorCodes.INVALID_PARAMS)
 
 
 func test_gradient_stop_wrong_shape_color_reports_keys() -> void:
@@ -116,7 +118,7 @@ func test_gradient_stop_non_dict_non_string_color_is_rejected() -> void:
 		"path": "/Main/Line",
 		"property": "texture",
 	})
-	assert_is_error(result, McpErrorCodes.WRONG_TYPE)
+	assert_is_error(result, ErrorCodes.WRONG_TYPE)
 	assert_contains(result.error.message, "stops[0].color")
 
 
@@ -184,7 +186,7 @@ func test_noise_invalid_type() -> void:
 		"path": "/Main/Foo",
 		"property": "texture",
 	})
-	assert_is_error(result, McpErrorCodes.VALUE_OUT_OF_RANGE)
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
 
 
 func test_noise_assigns_typed_chain() -> void:

--- a/test_project/tests/test_theme.gd
+++ b/test_project/tests/test_theme.gd
@@ -1,6 +1,8 @@
 @tool
 extends McpTestSuite
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 const ThemeHandler := preload("res://addons/godot_ai/handlers/theme_handler.gd")
 
 ## Tests for ThemeHandler — Theme resource authoring.
@@ -113,7 +115,7 @@ func test_theme_set_color_missing_theme_path() -> void:
 		"name": "font_color",
 		"value": "#ff0000",
 	})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_theme_set_color_missing_class_name() -> void:
@@ -359,7 +361,7 @@ func test_create_theme_overwritten_flag_tracks_pre_save_state() -> void:
 func test_create_theme_missing_path_names_param_correctly() -> void:
 	# Error message should name `path`, not `theme_path`, for theme_create.
 	var result := _handler.create_theme({})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 	assert_contains(result.error.message, "path")
 	# Make sure it's NOT using the default "theme_path" label.
 	assert_true(result.error.message.find("theme_path") == -1, "Error should say 'path', not 'theme_path'")

--- a/test_project/tests/test_ui.gd
+++ b/test_project/tests/test_ui.gd
@@ -1,6 +1,8 @@
 @tool
 extends McpTestSuite
 
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
 const UiHandler := preload("res://addons/godot_ai/handlers/ui_handler.gd")
 
 ## Tests for UiHandler — Control layout helpers (anchor presets).
@@ -104,7 +106,7 @@ func test_set_anchor_preset_keep_size_mode() -> void:
 
 func test_set_anchor_preset_missing_path() -> void:
 	var result := _handler.set_anchor_preset({"preset": "full_rect"})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_set_anchor_preset_missing_preset() -> void:
@@ -113,7 +115,7 @@ func test_set_anchor_preset_missing_preset() -> void:
 		skip("Scene not ready — _add_control returned empty path")
 		return
 	var result := _handler.set_anchor_preset({"path": path})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 	_remove_control(path)
 
 
@@ -265,7 +267,7 @@ func test_set_text_replaces_existing_text() -> void:
 
 func test_set_text_missing_path() -> void:
 	var result := _handler.set_text({"text": "hi"})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_set_text_missing_text() -> void:
@@ -285,7 +287,7 @@ func test_set_text_rejects_non_string_value() -> void:
 		skip("Scene not ready — _add_control returned empty path")
 		return
 	var result := _handler.set_text({"path": path, "text": 42})
-	assert_is_error(result, McpErrorCodes.WRONG_TYPE)
+	assert_is_error(result, ErrorCodes.WRONG_TYPE)
 	_remove_control(path)
 
 
@@ -369,7 +371,7 @@ func test_build_layout_creates_simple_tree() -> void:
 
 func test_build_layout_rejects_unknown_type() -> void:
 	var result := _handler.build_layout({"tree": {"type": "NotARealClass"}})
-	assert_is_error(result, McpErrorCodes.VALUE_OUT_OF_RANGE)
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
 
 
 func test_build_layout_rejects_non_node_type() -> void:
@@ -380,7 +382,7 @@ func test_build_layout_rejects_non_node_type() -> void:
 
 func test_build_layout_rejects_missing_type() -> void:
 	var result := _handler.build_layout({"tree": {"name": "NoType"}})
-	assert_is_error(result, McpErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
 
 
 func test_build_layout_rejects_unknown_property() -> void:
@@ -388,7 +390,7 @@ func test_build_layout_rejects_unknown_property() -> void:
 	var result := _handler.build_layout({
 		"tree": {"type": "Label", "properties": {"bogus_prop": 1}}
 	})
-	assert_is_error(result, McpErrorCodes.PROPERTY_NOT_ON_CLASS)
+	assert_is_error(result, ErrorCodes.PROPERTY_NOT_ON_CLASS)
 
 
 func test_build_layout_rejects_bad_parent_path() -> void:

--- a/tests/unit/test_plugin_self_update_safety.py
+++ b/tests/unit/test_plugin_self_update_safety.py
@@ -88,7 +88,7 @@ OFF_LOAD_SURFACE = frozenset(
 # that a regression slipped through review.
 #
 # End state: 0. Steps 2 and 3 of #399 drive this down.
-BASELINE_VIOLATION_COUNT = 1254
+BASELINE_VIOLATION_COUNT = 306
 
 
 Kind = Literal["typed_field", "typed_annotation", "constructor", "member_access"]


### PR DESCRIPTION
## Summary

Step 2 of #399. Removes `class_name McpErrorCodes` from
`plugin/addons/godot_ai/utils/error_codes.gd` and routes every
consumer through a script-local
`const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")`
alias — the same pattern #398 introduced for `McpScenePath` /
`McpErrorCodes` in five files, applied at the source by dropping
the `class_name` declaration entirely.

This eliminates `McpErrorCodes.*` member-access hazards across the
entire load surface in one pass.

## Impact on the deny-by-default ratchet

`tests/unit/test_plugin_self_update_safety.py::BASELINE_VIOLATION_COUNT`:

- **Before:** 1254
- **After:** 306
- **Delta:** -948 sites

End state target is 0; future steps drive the remaining 306 down by
applying the same pattern to other `Mcp*` classes.

## Files touched

- 32 files under `plugin/addons/godot_ai/` (handlers, utils, debugger,
  including `error_codes.gd` itself)
- 27 files under `test_project/tests/`
- `tests/unit/test_plugin_self_update_safety.py` (baseline lowered)

Self-references inside `error_codes.gd` needed no alias — they resolve
through lexical scope, not the class_name registry.

## Judgment calls

- **Comments and docstrings:** updated to use `ErrorCodes.X` for
  grep-ability, per the CLAUDE.md note that future readers grepping
  `ErrorCodes.MISSING_REQUIRED_PARAM` should find both code and docs.
- **Test files under `test_project/tests/`:** converted for consistency
  even though they're outside `OFF_LOAD_SURFACE`'s scan path. One test
  function name `test_error_dicts_match_McpErrorCodes_make_shape` was
  renamed to `_match_ErrorCodes_make_shape` for the same reason.
- **Python files (`src/godot_ai/protocol/errors.py` and friends):** left
  alone — they're not affected by the GDScript class_name registry.

## How verified

- `ruff check tests/ src/` — clean
- `ruff format --check tests/ src/` — clean
- `pytest -v`: 915 passed (Python suite)
- `pytest tests/unit/test_plugin_self_update_safety.py -v`: 3 passed
  (after baseline update)
- Godot editor parse (`--editor --quit-after 5`): clean — no
  `SCRIPT ERROR` / `Parse Error` introduced
- **Live-smoke** in a Godot editor launched on this worktree's
  `test_project/` (session `test-project@def1`):
  - `editor_state` → `ready`
  - `test_run` → 1241 passed, 0 failed, 5 skipped, 47 suites
  - Triggered an error path via
    `node_get_properties path=/NonExistent/Bogus` — got back
    `NODE_NOT_FOUND` with the right code, confirming the alias
    resolves at runtime.

## Test plan

- [x] Python lint/format clean
- [x] Python pytest suite green (915 passed)
- [x] Self-update safety ratchet test green at new baseline (306)
- [x] Godot editor parses with no new errors
- [x] GDScript test runner: 0 failures across 47 suites
- [x] Error code path exercised end-to-end via a real MCP tool call

Refs: #399

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>