### PR TITLE
Add screenshot-testing recipe doc + local game-capture diagnostic

### DIFF
--- a/docs/screenshot-testing.md
+++ b/docs/screenshot-testing.md
@@ -19,14 +19,15 @@ answer when the thing you want to see only exists in the *running* game.
 ## Recipe: testing a runtime UI option (e.g. main menu)
 
 ```
-1. editor_state                     -> confirm session, current_scene, readiness="ready"
-2. project_run(mode="current",      -> autosave=False so MCP scene mutations stay in memory
+1. editor_state                              -> confirm session, current_scene, readiness="ready"
+2. project_run(mode="current",               -> autosave=False so MCP scene mutations stay in memory
               autosave=False)
-3. poll editor_state every ~500ms   -> wait until is_playing=true AND game_capture_ready=true
-4. (interact: input_send / node_set_property / call_method as needed)
-5. editor_screenshot(source="game", -> request the capture
+3. poll editor_state every ~500ms            -> wait until is_playing=true AND game_capture_ready=true
+4. (interact via available write tools as    -> e.g. node_set_property, batch_execute,
+    needed for the scenario being tested)       ui_manage, theme_manage
+5. editor_screenshot(source="game",          -> request the capture
                      max_resolution=1280)
-6. project_stop                     -> always stop the run when done
+6. project_manage(op="stop")                 -> always stop the run when done
 ```
 
 `game_capture_ready` is the deterministic readiness signal — it flips true
@@ -73,8 +74,9 @@ sleep-and-pray; poll this field.
     `_ready` errored before reaching the `mcp:hello` send (check `logs_read
     source="game"`).
 - Worked once, fails on second attempt within the same play cycle?
-  → Did you `project_stop` and forget to `project_run` again? Each new run
-    rotates a token; the readiness flag is reset on `begin_game_run()`.
+  → Did you `project_manage(op="stop")` and forget to `project_run` again?
+    Each new run rotates a token; the readiness flag is reset on
+    `begin_game_run()`.
 
 ## Things to prefer over screenshots, when possible
 

--- a/docs/screenshot-testing.md
+++ b/docs/screenshot-testing.md
@@ -1,0 +1,106 @@
+# Screenshot-driven testing
+
+Notes for AI agents (and humans) on getting `editor_screenshot` to work the
+first time, instead of looping through "autoload never registered its debugger
+capture within 20s" timeouts.
+
+## Pick the right `source`
+
+| Goal | `source` | Notes |
+|------|----------|-------|
+| Verify in-editor UI / inspector / dock layout | `viewport` | Captures the editor's 2D view directly — no debugger bridge, always works. |
+| Verify a 3D scene framing as the editor camera sees it | `viewport` | Same path, no game subprocess required. |
+| Verify a running game's framebuffer (menus that exist at runtime, gameplay state, particle effects, runtime UI animations) | `game` | Requires the game subprocess + `_mcp_game_helper` autoload + a `project_run`-driven play cycle. |
+| Verify a specific `Camera3D` view without playing | `cinematic` (where supported) | Doesn't require Play. |
+
+**Default to `viewport` when in doubt.** `source="game"` is only the right
+answer when the thing you want to see only exists in the *running* game.
+
+## Recipe: testing a runtime UI option (e.g. main menu)
+
+```
+1. editor_state                     -> confirm session, current_scene, readiness="ready"
+2. project_run(mode="current",      -> autosave=False so MCP scene mutations stay in memory
+              autosave=False)
+3. poll editor_state every ~500ms   -> wait until is_playing=true AND game_capture_ready=true
+4. (interact: input_send / node_set_property / call_method as needed)
+5. editor_screenshot(source="game", -> request the capture
+                     max_resolution=1280)
+6. project_stop                     -> always stop the run when done
+```
+
+`game_capture_ready` is the deterministic readiness signal — it flips true
+*only* after the game-side autoload's `mcp:hello` beacon arrives, which means
+the debugger channel is wired up and `mcp:take_screenshot` will land. Do not
+sleep-and-pray; poll this field.
+
+## Pre-flight checklist (when `source="game"` keeps timing out)
+
+1. **Is `_mcp_game_helper` actually in the project's autoload list?**
+   - Open `Project Settings → Autoload`, or grep `project.godot` for
+     `_mcp_game_helper="*res://addons/godot_ai/runtime/game_helper.gd"`.
+   - If missing: disable + re-enable the Godot AI plugin in Project Settings →
+     Plugins. Re-enabling fires `_ensure_game_helper_autoload()` which writes
+     the entry and persists it via `ProjectSettings.save()`.
+2. **Was the game launched via `project_run`?**
+   - `editor_screenshot(source="game")` requires `_game_run_active=true` on
+     the editor side, which is only set by `project_run`. F5-from-keyboard
+     plays the game but `mcp:hello` from that play cycle is *explicitly
+     ignored*, and you will time out.
+3. **Is the right session active?**
+   - Multi-editor / multi-worktree setups: call `session_activate` (or pass
+     `session_id` per call) so the screenshot routes to the editor whose game
+     is actually running.
+4. **Did the game subprocess actually boot?**
+   - Look at the Godot Output panel for
+     `[godot_ai game_helper] registered mcp capture (debugger active=true, logger=true)`.
+     If that line never prints, the autoload didn't run. If
+     `debugger active=false`, you're in a headless / custom-main-loop /
+     exported build where the debugger channel is off.
+5. **Did the game crash during boot?**
+   - `logs_read` (or `logs_read source="game"`) surfaces any `print`/error
+     output the game emitted before dying. A crashed game can never beacon.
+
+## Decision tree for the timeout error
+
+`Game-side autoload never registered its debugger capture within 20s`:
+
+- `is_playing` was **false** when you called `editor_screenshot`?
+  → The game wasn't running. Call `project_run` first and poll readiness.
+- `is_playing=true` but `game_capture_ready` stayed **false**?
+  → Either the autoload isn't in `project.godot` (item 1 above), or the
+    project was launched outside `project_run` (item 2), or the game's
+    `_ready` errored before reaching the `mcp:hello` send (check `logs_read
+    source="game"`).
+- Worked once, fails on second attempt within the same play cycle?
+  → Did you `project_stop` and forget to `project_run` again? Each new run
+    rotates a token; the readiness flag is reset on `begin_game_run()`.
+
+## Things to prefer over screenshots, when possible
+
+Screenshots are the slowest, flakiest assertion surface — they require
+rendering, encoding, and a live debugger bridge, and any of those can fail
+intermittently. When you can, assert on **state** instead of pixels:
+
+- `node_get_properties` to read the actual visible/visibility/text/etc. of a
+  Control after the menu opens.
+- `print()` from the game's `_pressed()` handler — game prints are forwarded
+  back over `mcp:log_batch` and surface in `logs_read source="game"`. The AI
+  can grep for `"menu_opened"` instead of trying to OCR a screenshot.
+- `node_find` with a query like "find a Control named MainMenu that's
+  visible" — gives a yes/no without ever rendering.
+
+Reach for `source="game"` screenshots when the assertion is genuinely
+visual (layout, colors, particle bursts, animation poses) and skip them
+when state inspection would do.
+
+## Reproducing the timeout deterministically
+
+`script/local-game-capture-diag` (developer-facing, runs against your local
+editor) walks through the full bridge end-to-end against the currently-open
+scene and prints diagnostics on failure. Use it when you can't tell whether
+the bug is in your project, in the plugin, or in the AI's calling pattern.
+
+`script/ci-game-capture-smoke` is the CI equivalent — it requires the
+fixture scene `test_project/capture_smoke.tscn` and asserts pixel colors at
+known coordinates.

--- a/script/local-game-capture-diag
+++ b/script/local-game-capture-diag
@@ -12,9 +12,13 @@ currently open). Walks the full bridge:
     4. (if --run is passed) call project_run(mode="current", autosave=False)
        and poll editor_state until is_playing=true AND game_capture_ready=true
     5. call editor_screenshot(source="game") and print PNG dimensions +
-       byte size — does NOT assert on pixel colors, so it works against
-       any scene
+       byte size (dimensions parsed from the PNG IHDR chunk) — does NOT
+       assert on pixel colors, so it works against any scene
     6. on any failure, dump recent plugin logs
+
+Pass --session <hint> to pin tool calls to a specific Godot editor when
+multiple are connected (the same routing problem the doc calls out as a
+common cause of capture timeouts).
 
 Use this when you're staring at a "Game-side autoload never registered its
 debugger capture within 20s" timeout and need to figure out which step broke.
@@ -179,6 +183,19 @@ def _print_autoload_section(url: str, sid: str) -> bool:
     return found
 
 
+def _png_dimensions(png: bytes) -> tuple[int, int] | None:
+    ## PNG layout: 8-byte signature, then IHDR chunk:
+    ##   bytes 8-11   chunk length (always 13 for IHDR)
+    ##   bytes 12-15  type ("IHDR")
+    ##   bytes 16-19  width (big-endian uint32)
+    ##   bytes 20-23  height (big-endian uint32)
+    if len(png) < 24 or png[:8] != b"\x89PNG\r\n\x1a\n" or png[12:16] != b"IHDR":
+        return None
+    width = int.from_bytes(png[16:20], "big")
+    height = int.from_bytes(png[20:24], "big")
+    return width, height
+
+
 def _wait_for_capture_ready(url: str, sid: str, timeout: float = 30.0) -> dict:
     deadline = time.monotonic() + timeout
     last: dict = {}
@@ -226,7 +243,16 @@ def main() -> int:
     parser.add_argument(
         "--keep-running",
         action="store_true",
-        help="Skip project_stop on exit (default is to stop the run we started).",
+        help="Skip the project_manage(op='stop') call on exit (default is to "
+        "stop the run we started).",
+    )
+    parser.add_argument(
+        "--session",
+        default=None,
+        help="Pin all tool calls to the Godot editor matching this hint "
+        "(exact session_id or substring of project name / path / id). "
+        "Calls session_activate before everything else; print the chosen "
+        "session. Useful when multiple editors are connected.",
     )
     args = parser.parse_args()
 
@@ -242,7 +268,23 @@ def main() -> int:
             file=sys.stderr,
         )
         return 2
-    print(f"Session: {sess.get('active_session_id') or sess}")
+    print(f"Sessions registered: count={sess.get('count')} "
+          f"active={sess.get('active_session_id')}")
+
+    if args.session:
+        try:
+            activated = _tool_call(
+                args.url, sid, "session_activate", {"session_id": args.session}, 50
+            )
+            chosen = (
+                activated.get("session_id")
+                or activated.get("data", {}).get("session_id")
+                or activated
+            )
+            print(f"  --session pinned: {chosen}")
+        except Exception as exc:
+            print(f"\nFAIL: --session activate '{args.session}' raised: {exc}")
+            return 1
 
     autoload_ok = _print_autoload_section(args.url, sid)
 
@@ -332,7 +374,12 @@ def main() -> int:
             return 1
 
         png = base64.b64decode(image_b64)
-        print(f"  PNG returned: {len(png)} bytes")
+        dims = _png_dimensions(png)
+        if dims is None:
+            print(f"  PNG returned: {len(png)} bytes (dimensions: malformed header)")
+        else:
+            w, h = dims
+            print(f"  PNG returned: {w}x{h}, {len(png)} bytes")
         if len(png) < 256:
             print("\nFAIL: PNG payload suspiciously small.")
             return 1
@@ -341,9 +388,14 @@ def main() -> int:
     finally:
         if we_started_run and not args.keep_running:
             try:
-                _tool_call(args.url, sid, "project_stop", {}, 999, timeout=10)
+                _tool_call(
+                    args.url, sid, "project_manage", {"op": "stop"}, 999, timeout=10
+                )
             except Exception as exc:
-                print(f"(cleanup) project_stop failed: {exc}", file=sys.stderr)
+                print(
+                    f"(cleanup) project_manage(op='stop') failed: {exc}",
+                    file=sys.stderr,
+                )
 
 
 if __name__ == "__main__":

--- a/script/local-game-capture-diag
+++ b/script/local-game-capture-diag
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+"""
+Local end-to-end diagnostic for editor_screenshot(source="game").
+
+Runs against an already-running Godot editor + plugin (whatever scene is
+currently open). Walks the full bridge:
+
+    1. connect to the MCP server (default http://127.0.0.1:8000/mcp)
+    2. confirm a Godot session is registered
+    3. dump autoload state + project.godot [autoload] section so you can
+       eyeball whether _mcp_game_helper is actually persisted to disk
+    4. (if --run is passed) call project_run(mode="current", autosave=False)
+       and poll editor_state until is_playing=true AND game_capture_ready=true
+    5. call editor_screenshot(source="game") and print PNG dimensions +
+       byte size — does NOT assert on pixel colors, so it works against
+       any scene
+    6. on any failure, dump recent plugin logs
+
+Use this when you're staring at a "Game-side autoload never registered its
+debugger capture within 20s" timeout and need to figure out which step broke.
+For a stricter pixel-check smoke against a fixture scene, see
+script/ci-game-capture-smoke.
+
+Exit codes:
+    0  bridge worked end-to-end (or readiness verified with --no-screenshot)
+    1  diagnostic failure — preceded by printed reason
+    2  setup failure (could not connect / no session registered)
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+DEFAULT_URL = os.environ.get("MCP_SERVER_URL", "http://127.0.0.1:8000/mcp")
+HEADERS = {
+    "Content-Type": "application/json",
+    "Accept": "application/json, text/event-stream",
+}
+
+
+def _post(url: str, session_id: str | None, body: dict, timeout: float = 10.0) -> dict:
+    headers = dict(HEADERS)
+    if session_id:
+        headers["Mcp-Session-Id"] = session_id
+    req = urllib.request.Request(
+        url, data=json.dumps(body).encode("utf-8"), headers=headers, method="POST"
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        raw = resp.read().decode("utf-8")
+        new_session = resp.headers.get("mcp-session-id")
+    result: dict = {"_session_id": new_session, "_raw": raw}
+    for line in raw.splitlines():
+        if line.startswith("data: "):
+            result.update(json.loads(line[6:]))
+            break
+    else:
+        try:
+            result.update(json.loads(raw))
+        except json.JSONDecodeError:
+            pass
+    return result
+
+
+def _tool_call(
+    url: str, session_id: str, name: str, args: dict, request_id: int, timeout: float = 30.0
+) -> dict:
+    body = {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": "tools/call",
+        "params": {"name": name, "arguments": args},
+    }
+    resp = _post(url, session_id, body, timeout=timeout)
+    result = resp.get("result", {})
+    sc = result.get("structuredContent")
+    if sc:
+        return sc
+    for block in result.get("content") or []:
+        if block.get("type") == "text":
+            try:
+                return json.loads(block["text"])
+            except json.JSONDecodeError:
+                return {"_text": block["text"]}
+    return {"_raw": resp.get("_raw", "")}
+
+
+def _initialize(url: str) -> str:
+    body = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-03-26",
+            "capabilities": {},
+            "clientInfo": {"name": "local-game-capture-diag", "version": "1.0"},
+        },
+    }
+    resp = _post(url, None, body)
+    sid = resp.get("_session_id")
+    if not sid:
+        raise RuntimeError(f"No Mcp-Session-Id returned. Raw: {resp.get('_raw', '')[:300]}")
+    _post(url, sid, {"jsonrpc": "2.0", "method": "notifications/initialized"})
+    return sid
+
+
+def _wait_for_session(url: str, sid: str, timeout: float = 15.0) -> dict:
+    deadline = time.monotonic() + timeout
+    last: dict = {}
+    while time.monotonic() < deadline:
+        last = _tool_call(url, sid, "session_manage", {"op": "list"}, 2)
+        if last.get("count", 0) > 0:
+            return last
+        time.sleep(1.0)
+    raise RuntimeError(f"No Godot session registered within {timeout}s. Last response: {last}")
+
+
+def _print_autoload_section(url: str, sid: str) -> bool:
+    """Return True if _mcp_game_helper is present in the autoload list."""
+    found = False
+    print("\n[1/3] Autoload list (from autoload_manage):")
+    try:
+        autoloads = _tool_call(url, sid, "autoload_manage", {"op": "list"}, 100)
+        items = autoloads.get("autoloads") or autoloads.get("data", {}).get("autoloads") or []
+        if not items:
+            print("  (autoload_manage returned no entries — payload was:")
+            print(f"   {json.dumps(autoloads, indent=2)[:400]})")
+        for entry in items:
+            name = entry.get("name") if isinstance(entry, dict) else str(entry)
+            path = entry.get("path") if isinstance(entry, dict) else ""
+            marker = " <-- target" if name == "_mcp_game_helper" else ""
+            print(f"  - {name}: {path}{marker}")
+            if name == "_mcp_game_helper":
+                found = True
+    except Exception as exc:
+        print(f"  autoload_manage failed: {exc}")
+
+    print("\n[2/3] [autoload] section in project.godot on disk:")
+    try:
+        proj = _tool_call(
+            url,
+            sid,
+            "filesystem_manage",
+            {"op": "read_text", "params": {"path": "res://project.godot"}},
+            101,
+        )
+        text = proj.get("content") or proj.get("data", {}).get("content", "")
+        in_section = False
+        any_lines = False
+        for line in text.splitlines():
+            if line.startswith("[autoload]"):
+                in_section = True
+                print(f"    {line}")
+                any_lines = True
+                continue
+            if in_section and line.startswith("["):
+                in_section = False
+            if in_section:
+                print(f"    {line}")
+                any_lines = True
+                if "_mcp_game_helper" in line:
+                    found = True
+        if not any_lines:
+            print("    (no [autoload] section in project.godot)")
+    except Exception as exc:
+        print(f"  filesystem_manage read_text failed: {exc}")
+
+    if not found:
+        print(
+            "\n  HINT: _mcp_game_helper is missing. Disable + re-enable the Godot AI\n"
+            "  plugin in Project Settings → Plugins to recreate it."
+        )
+    return found
+
+
+def _wait_for_capture_ready(url: str, sid: str, timeout: float = 30.0) -> dict:
+    deadline = time.monotonic() + timeout
+    last: dict = {}
+    while time.monotonic() < deadline:
+        last = _tool_call(url, sid, "editor_state", {}, 200)
+        if last.get("is_playing") and last.get("game_capture_ready"):
+            return last
+        time.sleep(0.5)
+    return last
+
+
+def _dump_recent_logs(url: str, sid: str) -> None:
+    print("\nRecent plugin logs (last 30 lines):")
+    try:
+        logs = _tool_call(url, sid, "logs_read", {"count": 30}, 900)
+        lines = logs.get("lines") or logs.get("data", {}).get("lines", [])
+        for line in lines:
+            print(f"    {line}")
+    except Exception as exc:
+        print(f"    logs_read failed: {exc}")
+    print("\nRecent game logs (last 30 lines):")
+    try:
+        logs = _tool_call(url, sid, "logs_read", {"source": "game", "count": 30}, 901)
+        lines = logs.get("lines") or logs.get("data", {}).get("lines", [])
+        for line in lines:
+            print(f"    {line}")
+    except Exception as exc:
+        print(f"    logs_read source=game failed: {exc}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--url", default=DEFAULT_URL, help="MCP server URL")
+    parser.add_argument(
+        "--run",
+        action="store_true",
+        help="Call project_run(mode='current', autosave=False) before screenshotting. "
+        "Without this flag, the script assumes you've already started the game.",
+    )
+    parser.add_argument(
+        "--no-screenshot",
+        action="store_true",
+        help="Stop after readiness check — don't actually take the screenshot.",
+    )
+    parser.add_argument(
+        "--keep-running",
+        action="store_true",
+        help="Skip project_stop on exit (default is to stop the run we started).",
+    )
+    args = parser.parse_args()
+
+    print(f"Connecting to {args.url}")
+    try:
+        sid = _initialize(args.url)
+        sess = _wait_for_session(args.url, sid)
+    except (urllib.error.URLError, RuntimeError) as exc:
+        print(f"\nSetup failed: {exc}", file=sys.stderr)
+        print(
+            "Is the Godot editor open with the plugin enabled?\n"
+            "Is the MCP server running on the expected port?",
+            file=sys.stderr,
+        )
+        return 2
+    print(f"Session: {sess.get('active_session_id') or sess}")
+
+    autoload_ok = _print_autoload_section(args.url, sid)
+
+    we_started_run = False
+    try:
+        print("\n[3/3] Readiness:")
+        state = _tool_call(args.url, sid, "editor_state", {}, 300)
+        print(
+            f"  is_playing={state.get('is_playing')} "
+            f"game_capture_ready={state.get('game_capture_ready')} "
+            f"readiness={state.get('readiness')}"
+        )
+
+        if args.run and not state.get("is_playing"):
+            print("  --run set; calling project_run(mode='current', autosave=False)")
+            _tool_call(
+                args.url,
+                sid,
+                "project_run",
+                {"mode": "current", "autosave": False},
+                301,
+                timeout=20,
+            )
+            we_started_run = True
+
+        if not state.get("is_playing") and not args.run:
+            print(
+                "\nGame is not running. Either pass --run to have this script start it,\n"
+                "or start it yourself via project_run (NOT F5 — F5 plays don't register\n"
+                "for editor_screenshot source='game')."
+            )
+            return 1
+
+        ready = _wait_for_capture_ready(args.url, sid)
+        if not ready.get("game_capture_ready"):
+            print("\nFAIL: game_capture_ready stayed false.")
+            print(f"  is_playing={ready.get('is_playing')}")
+            print(f"  readiness={ready.get('readiness')}")
+            print(f"  autoload registered={autoload_ok}")
+            print(
+                "\n  This is the same condition that produces the 'autoload never\n"
+                "  registered its debugger capture within 20s' timeout. The most\n"
+                "  common causes:"
+            )
+            print("    - autoload missing from project.godot (see above)")
+            print("    - game launched outside project_run (manual F5)")
+            print("    - game crashed before reaching the mcp:hello beacon")
+            _dump_recent_logs(args.url, sid)
+            return 1
+        print("  game_capture_ready=true — bridge is up.")
+
+        if args.no_screenshot:
+            return 0
+
+        print("\nCalling editor_screenshot(source='game', include_image=True)")
+        body = {
+            "jsonrpc": "2.0",
+            "id": 400,
+            "method": "tools/call",
+            "params": {
+                "name": "editor_screenshot",
+                "arguments": {
+                    "source": "game",
+                    "include_image": True,
+                    "max_resolution": 1280,
+                },
+            },
+        }
+        resp = _post(args.url, sid, body, timeout=25)
+        raw = resp.get("_raw", "")
+        image_b64 = None
+        for line in raw.splitlines():
+            if not line.startswith("data: "):
+                continue
+            data = json.loads(line[6:])
+            for block in data.get("result", {}).get("content", []):
+                if block.get("type") == "image":
+                    image_b64 = block.get("data")
+                    break
+            if image_b64:
+                break
+
+        if not image_b64:
+            print("\nFAIL: no image block in response.")
+            print(f"  Raw (first 500 bytes): {raw[:500]}")
+            _dump_recent_logs(args.url, sid)
+            return 1
+
+        png = base64.b64decode(image_b64)
+        print(f"  PNG returned: {len(png)} bytes")
+        if len(png) < 256:
+            print("\nFAIL: PNG payload suspiciously small.")
+            return 1
+        print("\nPASS: end-to-end game capture bridge works.")
+        return 0
+    finally:
+        if we_started_run and not args.keep_running:
+            try:
+                _tool_call(args.url, sid, "project_stop", {}, 999, timeout=10)
+            except Exception as exc:
+                print(f"(cleanup) project_stop failed: {exc}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Context

Surfaced by a user who kept hitting

```
INTERNAL_ERROR: Game-side autoload never registered its debugger capture within 20s.
Is the game actually running? Check Project Settings → Autoload for _mcp_game_helper.
```

while having an AI client test a runtime UI option (a new main-menu entry).
The 20s timeout in `mcp_debugger_plugin.gd:202-204` fires whenever the
editor sends `mcp:take_screenshot` but never sees `mcp:hello` from the
game-side autoload — and there are several sharp edges that make AI agents
hit it repeatedly:

- `mcp:hello` is *only* honored when `_game_run_active=true`, i.e. when the
  current play cycle was started by `project_run`. Manual F5 plays beacon
  is explicitly ignored (`mcp_debugger_plugin.gd:113-116`), so any AI that
  reaches for `editor_screenshot(source="game")` without first calling
  `project_run` will time out.
- `editor_state` already exposes `game_capture_ready` (set by `_setup_session`
  / `begin_game_run` and flipped true on `mcp:hello`), but agents don't
  always know to poll it — they sleep instead, miss the window, and time out.
- The pre-flight question "is `_mcp_game_helper` actually persisted to
  `project.godot`?" requires either eyeballing the file or calling
  `autoload_manage(op="list")`, which agents skip.
- Multi-editor / multi-worktree setups can land the screenshot tool call on
  a session whose game isn't running.

## Changes

**`docs/screenshot-testing.md`** — agent-facing recipe:
- `source` selection table (when to use `viewport` vs `game` vs `cinematic`).
- The canonical recipe: `project_run(autosave=False)` → poll
  `editor_state.game_capture_ready` → `editor_screenshot(source="game")` →
  `project_stop`.
- Pre-flight checklist for the timeout + a decision tree by symptom.
- Notes on preferring state assertions (`node_get_properties`, `print()`
  from the game forwarded over `mcp:log_batch`) when the assertion isn't
  truly visual — screenshots are the slowest, flakiest assertion surface.

**`script/local-game-capture-diag`** — developer-facing companion to the
existing `script/ci-game-capture-smoke`:
- Works against whatever scene is currently open (no `capture_smoke.tscn`
  fixture required) so it's usable for "is this broken in MY project?".
- Dumps the in-memory autoload list (`autoload_manage`) AND the on-disk
  `[autoload]` section of `project.godot` (`filesystem_manage` read_text)
  before touching the game, so the autoload-missing case is visible.
- Polls `game_capture_ready` deterministically — same readiness signal the
  CI smoke uses, no sleep-and-pray.
- On failure, dumps recent plugin logs and game logs (`logs_read` and
  `logs_read source="game"`) so a crashed boot vs. a missing autoload vs.
  a wrong session is distinguishable.
- `--run` / `--no-screenshot` / `--keep-running` flags for the common
  diagnostic shapes.

## Test plan
- [ ] `python3 -c "import ast; ast.parse(open('script/local-game-capture-diag').read())"` — done locally
- [ ] `ruff check script/local-game-capture-diag` — done locally
- [ ] `script/local-game-capture-diag --help` renders argparse correctly — done locally
- [ ] Run `script/local-game-capture-diag --run` against an open editor on a project with `_mcp_game_helper` registered → expect `PASS: end-to-end game capture bridge works.`
- [ ] Remove `_mcp_game_helper` from `project.godot` and rerun → expect the autoload-missing path to print the project.godot section with the entry absent and the actionable HINT.
- [ ] Skim `docs/screenshot-testing.md` rendered on GitHub for formatting.

No code paths in `src/` or `plugin/` change — this is docs + a diagnostic
script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015WMRKQXqd55GDuiaJb1m2E)_