### PR TITLE
Fix Windows "Could not create child process" for npm-installed CLIs

### DIFF
--- a/plugin/addons/godot_ai/clients/_cli_exec.gd
+++ b/plugin/addons/godot_ai/clients/_cli_exec.gd
@@ -45,7 +45,24 @@ static func run(
 	if exe.is_empty():
 		return _spawn_failed_result()
 
-	var info := OS.execute_with_pipe(exe, args)
+	var spawn_exe := exe
+	var spawn_args := args
+	if OS.get_name() == "Windows":
+		var lower := exe.to_lower()
+		if lower.ends_with(".cmd") or lower.ends_with(".bat"):
+			## CreateProcessW can't launch `.cmd` / `.bat` scripts on its
+			## own — they're cmd.exe input, not PE binaries. Without this
+			## wrap, the moment `McpCliFinder` resolves a Node-style shim
+			## (npm's `claude.cmd`, pnpm's wrappers, …) the next
+			## `OS.execute_with_pipe` surfaces "Could not create child
+			## process: <path> ..." in Godot's output log (#251). Passing
+			## `exe` as a separate argv element keeps spaces in the path
+			## quoted by Godot's standard quoter — no manual escaping.
+			spawn_exe = "cmd.exe"
+			spawn_args = ["/c", exe]
+			spawn_args.append_array(args)
+
+	var info := OS.execute_with_pipe(spawn_exe, spawn_args)
 	if info.is_empty():
 		return _spawn_failed_result()
 

--- a/plugin/addons/godot_ai/clients/_cli_finder.gd
+++ b/plugin/addons/godot_ai/clients/_cli_finder.gd
@@ -94,10 +94,46 @@ static func _resolve(exe_name: String) -> String:
 	var output: Array = []
 	var exit_code := OS.execute(lookup, [exe_name], output, true)
 	if exit_code == 0 and output.size() > 0:
-		var found: String = output[0].strip_edges().split("\n")[0].strip_edges()
+		var lines := PackedStringArray(output[0].split("\n"))
+		var found := _pick_best_path(lines) if is_windows else lines[0].strip_edges()
 		if not found.is_empty():
 			return found
 	return ""
+
+
+## Executable extensions Windows' CreateProcessW can launch from a path
+## (after the cmd.exe wrap in `_cli_exec.gd`). Order is preference: `.exe`
+## is a native PE binary; `.cmd` / `.bat` go through the shell; `.com` is
+## the legacy COM-format executable that some shims still ship.
+const _WINDOWS_EXEC_EXTS := [".exe", ".cmd", ".bat", ".com"]
+
+
+## Pick the best path from `where` output on Windows.
+##
+## npm-installed Node CLIs ship as BOTH `<dir>/<name>` (a POSIX bash shim
+## for WSL / Git Bash users) AND `<dir>/<name>.cmd` (the actual Windows
+## wrapper). `where <name>` lists both. CreateProcessW — the underlying
+## syscall behind `OS.execute_with_pipe` — refuses to launch the
+## extensionless POSIX shim, surfacing as
+## `ERROR: Could not create child process: "...\claude" mcp list`
+## in Godot's output log (#251). Picking a path with a real executable
+## extension dodges that entirely.
+##
+## Falls back to the first non-empty line when no entry has a recognised
+## extension, so we never come up empty when `where` returned *something*.
+static func _pick_best_path(lines: PackedStringArray) -> String:
+	var fallback := ""
+	for raw in lines:
+		var line := raw.strip_edges()
+		if line.is_empty():
+			continue
+		if fallback.is_empty():
+			fallback = line
+		var lower := line.to_lower()
+		for ext in _WINDOWS_EXEC_EXTS:
+			if lower.ends_with(ext):
+				return line
+	return fallback
 
 
 static func _well_known_dirs() -> Array[String]:

--- a/plugin/addons/godot_ai/clients/_cli_finder.gd
+++ b/plugin/addons/godot_ai/clients/_cli_finder.gd
@@ -119,21 +119,24 @@ const _WINDOWS_EXEC_EXTS := [".exe", ".cmd", ".bat", ".com"]
 ## in Godot's output log (#251). Picking a path with a real executable
 ## extension dodges that entirely.
 ##
-## Falls back to the first non-empty line when no entry has a recognised
+## Extension scan is the OUTER loop so the order in `_WINDOWS_EXEC_EXTS`
+## drives preference — `.exe` wins over `.cmd` even when the `.cmd` shows
+## up first in `where` output (one fewer process per shell-out). Falls
+## back to the first non-empty line when no entry has a recognised
 ## extension, so we never come up empty when `where` returned *something*.
 static func _pick_best_path(lines: PackedStringArray) -> String:
-	var fallback := ""
+	var stripped := PackedStringArray()
 	for raw in lines:
 		var line := raw.strip_edges()
-		if line.is_empty():
-			continue
-		if fallback.is_empty():
-			fallback = line
-		var lower := line.to_lower()
-		for ext in _WINDOWS_EXEC_EXTS:
-			if lower.ends_with(ext):
-				return line
-	return fallback
+		if not line.is_empty():
+			stripped.append(line)
+	if stripped.is_empty():
+		return ""
+	for ext in _WINDOWS_EXEC_EXTS:
+		for candidate in stripped:
+			if candidate.to_lower().ends_with(ext):
+				return candidate
+	return stripped[0]
 
 
 static func _well_known_dirs() -> Array[String]:

--- a/test_project/tests/test_cli_exec.gd
+++ b/test_project/tests/test_cli_exec.gd
@@ -113,6 +113,36 @@ func test_run_kills_subprocess_when_budget_expires() -> void:
 		"Timeout kill must return within ~budget+poll, not wait for sleep to finish (elapsed=%dms)" % elapsed_msec)
 
 
+func test_run_wraps_cmd_files_through_cmd_exe_on_windows() -> void:
+	## Regression for #251: `McpCliFinder` resolving a Node-style CLI to
+	## its `.cmd` wrapper used to trip CreateProcessW with
+	## `ERROR: Could not create child process: <path> ...`.
+	## `McpCliExec.run` now wraps `.cmd` paths via `cmd.exe /c`, so the
+	## wrapper actually runs and we capture its stdout.
+	if OS.get_name() != "Windows":
+		skip(".cmd shell-out is Windows-only; the wrap path is a no-op elsewhere")
+		return
+	var script_path := OS.get_user_data_dir().path_join("mcp_cli_exec_smoke.cmd")
+	var f := FileAccess.open(script_path, FileAccess.WRITE)
+	assert_true(f != null, "Should be able to write a temp .cmd fixture under user://")
+	if f == null:
+		return
+	## `@echo off` keeps `claude.cmd`-style banners from polluting stdout —
+	## the assertion below only cares that our explicit token came through.
+	f.store_string("@echo off\r\necho cli-exec-cmd-token %1\r\n")
+	f.close()
+	var result := McpCliExec.run(script_path, ["arg-from-mcp"], 5000)
+	assert_false(bool(result.get("spawn_failed", false)),
+		".cmd files must spawn successfully via the cmd.exe wrap")
+	assert_false(bool(result.get("timed_out", false)),
+		"echo-only .cmd finishes well inside 5s")
+	assert_eq(int(result.get("exit_code", -1)), 0,
+		".cmd should exit 0 on success")
+	assert_contains(str(result.get("stdout", "")), "cli-exec-cmd-token arg-from-mcp",
+		"Captured stdout must include the echoed token and forwarded arg")
+	DirAccess.remove_absolute(script_path)
+
+
 func _stderr_fixture_command(exit_code: int) -> Dictionary:
 	if OS.get_name() == "Windows":
 		return {

--- a/test_project/tests/test_cli_finder.gd
+++ b/test_project/tests/test_cli_finder.gd
@@ -1,0 +1,90 @@
+@tool
+extends McpTestSuite
+
+## Tests for McpCliFinder, focused on the Windows path-picking rule that
+## stops `OS.execute_with_pipe` from surfacing "Could not create child
+## process" against npm-installed POSIX shims (#251).
+##
+## `find()` end-to-end depends on the host's PATH and well-known dirs, so
+## the routing logic is covered indirectly through `test_clients.gd`. Here
+## we pin the pure helper (`_pick_best_path`) on every platform so the rule
+## doesn't quietly regress on a CI runner that lacks any npm-installed CLI.
+
+
+func suite_name() -> String:
+	return "cli_finder"
+
+
+func test_pick_best_path_prefers_cmd_over_extensionless() -> void:
+	## The npm-on-Windows reproducer: `where claude` lists the bash shim
+	## first (no extension) and the `.cmd` wrapper after. Picking the
+	## extensionless one is what produces
+	## `ERROR: Could not create child process: "...\claude" mcp list`.
+	var lines := PackedStringArray([
+		"C:\\Program Files\\nodejs\\claude",
+		"C:\\Program Files\\nodejs\\claude.cmd",
+		"C:\\Program Files\\nodejs\\claude.ps1",
+	])
+	var picked: String = McpCliFinder._pick_best_path(lines)
+	assert_eq(picked, "C:\\Program Files\\nodejs\\claude.cmd",
+		"Must skip the extensionless POSIX shim and pick the .cmd wrapper")
+
+
+func test_pick_best_path_prefers_exe_over_cmd() -> void:
+	## Native `.exe` is always preferable to a `.cmd` shell wrapper — same
+	## work, one fewer process. Order is independent of where the entries
+	## appear in `where` output, since the helper scans every line before
+	## falling back.
+	var lines := PackedStringArray([
+		"C:\\Users\\u\\AppData\\Local\\npm\\tool.cmd",
+		"C:\\Users\\u\\AppData\\Local\\npm\\tool.exe",
+	])
+	var picked: String = McpCliFinder._pick_best_path(lines)
+	assert_eq(picked, "C:\\Users\\u\\AppData\\Local\\npm\\tool.exe",
+		"`.exe` should win over `.cmd` when both are listed")
+
+
+func test_pick_best_path_strips_carriage_returns() -> void:
+	## `where` on Windows emits CRLF line endings — `strip_edges()` has to
+	## eat the `\r` before the extension check or every line looks like it
+	## ends in `\r` and falls through to the fallback branch.
+	var lines := PackedStringArray([
+		"C:\\Program Files\\nodejs\\claude\r",
+		"C:\\Program Files\\nodejs\\claude.cmd\r",
+	])
+	var picked: String = McpCliFinder._pick_best_path(lines)
+	assert_eq(picked, "C:\\Program Files\\nodejs\\claude.cmd",
+		"CRLF line endings must not defeat the extension check")
+
+
+func test_pick_best_path_falls_back_when_nothing_qualifies() -> void:
+	## If `where` somehow returned only extensionless or unrecognised
+	## entries, return *something* rather than empty — the caller can still
+	## try to spawn it and surface a clearer error than "no CLI found".
+	var lines := PackedStringArray([
+		"C:\\custom\\bin\\tool",
+		"C:\\other\\tool.weird",
+	])
+	var picked: String = McpCliFinder._pick_best_path(lines)
+	assert_eq(picked, "C:\\custom\\bin\\tool",
+		"With no recognised extension, fall back to the first non-empty line")
+
+
+func test_pick_best_path_skips_blank_lines() -> void:
+	## `where` sometimes leaves a trailing blank line in its output;
+	## splitting by "\n" surfaces it as an empty entry. The helper must
+	## skip blanks for both the fallback and the extension scan.
+	var lines := PackedStringArray([
+		"",
+		"   ",
+		"C:\\bin\\tool.cmd",
+	])
+	var picked: String = McpCliFinder._pick_best_path(lines)
+	assert_eq(picked, "C:\\bin\\tool.cmd",
+		"Blank entries must not be returned as the fallback")
+
+
+func test_pick_best_path_empty_input_returns_empty() -> void:
+	var picked: String = McpCliFinder._pick_best_path(PackedStringArray())
+	assert_eq(picked, "",
+		"No input lines must yield an empty string, not a synthetic path")

--- a/test_project/tests/test_cli_finder.gd.uid
+++ b/test_project/tests/test_cli_finder.gd.uid
@@ -1,0 +1,1 @@
+uid://cqf7m8jx3p4l1


### PR DESCRIPTION
## Summary

Fixes the Discord report:

> `ERROR: Could not create child process: "C:\Program Files\nodejs\claude" mcp list`

### Root cause

npm-on-Windows installs `claude` as **two** files in `C:\Program Files\nodejs\`:
- `claude` — a POSIX bash shim for Git Bash / WSL users (no extension)
- `claude.cmd` — the actual Windows batch wrapper

`where claude` lists both, extensionless first. `McpCliFinder._resolve` was taking `output[0].split("\n")[0]` and handing the bash shim to `OS.execute_with_pipe`, which goes through `CreateProcessW`. CreateProcessW refuses to launch the extensionless shim and surfaces the "Could not create child process" line in Godot's output log. Every dock client-status probe (`claude mcp list`, configure, remove) tripped this.

A side effect users notice: the troubleshooting prompt under "server exited before WebSocket handshake" tells them to check Godot's output for Python's traceback, and the very loud `claude` error sits right there, so it gets attributed to the server-spawn problem even though it doesn't actually crash the server.

### Fix (two layers, on purpose)

1. **`_cli_finder.gd`** — on Windows, prefer paths ending in `.exe` / `.cmd` / `.bat` / `.com` over extensionless entries in `where` output. Falls back to the first non-empty line so a host returning only an extensionless match still gets something to try.
2. **`_cli_exec.gd`** — on Windows, wrap `.cmd` / `.bat` invocations as `cmd.exe /c <exe> <args>`. CreateProcessW won't launch shell scripts on its own; this defends against future resolvers handing back a `.cmd` path directly.

Both layers are needed: layer 1 stops the bug at resolution time; layer 2 guarantees a `.cmd` that arrives through any other path still spawns correctly.

## Test plan

- [x] `pytest -v` — 904 passed (no Python-side changes; sanity check only)
- [x] `ruff check src/ tests/` — clean
- [ ] Open `test_project/` in Godot on a Windows host with npm-installed `claude`
  - [ ] `test_run suite=cli_finder` — `_pick_best_path` invariants pass (npm reproducer, `.exe` > `.cmd`, CRLF endings, fallback, blanks, empty input)
  - [ ] `test_run suite=cli_exec` — the new Windows `.cmd` smoke captures stdout through the `cmd.exe` wrap; existing Unix-side tests still pass
  - [ ] Dock client status row for Claude Code shows CONFIGURED / NOT_CONFIGURED instead of the spawn-failed state; Godot output log is free of the "Could not create child process" line
- [ ] Open `test_project/` in Godot on macOS or Linux
  - [ ] `test_run suite=cli_finder` — extension preference rules are platform-pure and still pass (no host PATH dependency)
  - [ ] `test_run suite=cli_exec` — the new Windows-only smoke is skipped; rest is unchanged

https://claude.ai/code/session_01C5WkB2x3RmUCmhzdnYzEes

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5WkB2x3RmUCmhzdnYzEes)_