### PR TITLE
Update auto-config for Zed and remove nested enum option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,7 +296,7 @@ The plugin auto-configures 19+ MCP clients via a registry + strategy system in
   `serverUrl`, Gemini's `httpUrl`); `entry_extra_fields` adds verbatim keys
   (Roo's `type: streamable-http`, OpenCode's `enabled: true`); `entry_uvx_bridge`
   composes the stdio→HTTP bridge shape for stdio-only clients (Claude Desktop's
-  `flat`, Zed's `nested`).
+  `flat`).
 - `_manual_command.gd` — synthesizes the dock's "Run this manually" string
   from the same declarative fields. No per-client builders.
 - `_path_template.gd` — expands `~`, `$HOME`, `$APPDATA`, `$XDG_CONFIG_HOME`,

--- a/plugin/addons/godot_ai/clients/_base.gd
+++ b/plugin/addons/godot_ai/clients/_base.gd
@@ -83,12 +83,10 @@ var entry_initial_fields: Dictionary = {}
 ##             ...entry_initial_fields (only for new entries)}`
 ##   FLAT    — Claude Desktop shape: `{"command": <uvx>, "args": [...bridge...]}`
 ##             Verifier ALSO accepts a future url-style entry.
-##   NESTED  — Zed shape: `{"command": {"path": <uvx>, "args": [...]}, "settings": {}}`
-##             Verifier requires the bridge form (no url-style fallback).
 ##
 ## Enum (vs. String) so a typo in a descriptor fails at parse time instead of
 ## silently falling through `match` to the non-bridge path.
-enum UvxBridge { NONE, FLAT, NESTED }
+enum UvxBridge { NONE, FLAT }
 var entry_uvx_bridge: UvxBridge = UvxBridge.NONE
 
 ## Paths whose existence implies the user has this client installed.
@@ -152,7 +150,7 @@ static func _packed_slice(packed: PackedStringArray, from: int, to: int) -> Pack
 	return out
 
 
-# ----- stdio→http bridge helpers (Claude Desktop, Zed) --------------------
+# ---------- stdio→http bridge helpers (Claude Desktop) --------------------
 
 ## Pinned mcp-proxy release used by every stdio-only client's bridge. uvx's
 ## cache key is version-specific, so pinning guarantees all users run the
@@ -162,8 +160,8 @@ static func _packed_slice(packed: PackedStringArray, from: int, to: int) -> Pack
 const MCP_PROXY_VERSION := "0.11.0"
 
 
-## Resolve `uvx` to an absolute path. GUI-launched apps (Claude Desktop,
-## Zed) often run with a minimal PATH that excludes ~/.local/bin on macOS /
+## Resolve `uvx` to an absolute path. GUI-launched apps (Claude Desktop)
+## often run with a minimal PATH that excludes ~/.local/bin on macOS /
 ## Linux, so a bare "uvx" string in the config would fail at spawn time
 ## with the same "Server disconnected" symptom we're trying to cure. The
 ## shared three-tier McpCliFinder covers the well-known install dirs;

--- a/plugin/addons/godot_ai/clients/_json_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_json_strategy.gd
@@ -71,7 +71,7 @@ static func remove(client: McpClient, server_name: String) -> Dictionary:
 ## `entry_extra_fields` key force-set (the verified type pins) and every
 ## `entry_initial_fields` key set ONLY when absent (preserves user state
 ## like `alwaysAllow`/`autoApprove` arrays). For bridge clients (Claude
-## Desktop, Zed) it composes the uvx + mcp-proxy command shape unconditionally
+## Desktop) it composes the uvx + mcp-proxy command shape unconditionally
 ## — the bridge form has no user-mutable surface.
 static func build_entry(client: McpClient, server_url: String, existing: Variant = null) -> Dictionary:
 	match client.entry_uvx_bridge:
@@ -80,15 +80,6 @@ static func build_entry(client: McpClient, server_url: String, existing: Variant
 				"command": McpClient.resolve_uvx_path(),
 				"args": McpClient.mcp_proxy_bridge_args(server_url),
 				"env": _merge_bridge_env(existing),
-			}
-		McpClient.UvxBridge.NESTED:
-			return {
-				"command": {
-					"path": McpClient.resolve_uvx_path(),
-					"args": McpClient.mcp_proxy_bridge_args(server_url),
-				},
-				"env": _merge_bridge_env(existing),
-				"settings": {},
 			}
 	var entry: Dictionary = (existing as Dictionary).duplicate() if existing is Dictionary else {}
 	entry[client.entry_url_field] = server_url
@@ -118,16 +109,6 @@ static func verify_entry(client: McpClient, entry: Dictionary, server_url: Strin
 			if not (cmd is String and _command_is_uvx_like(cmd as String)):
 				return false
 			if not _bridge_args_are_valid(entry.get("args", []), server_url):
-				return false
-			return _bridge_env_matches(entry)
-		McpClient.UvxBridge.NESTED:
-			var cmd_obj = entry.get("command", {})
-			if not (cmd_obj is Dictionary):
-				return false
-			var npath = cmd_obj.get("path", "")
-			if not (npath is String and _command_is_uvx_like(npath as String)):
-				return false
-			if not _bridge_args_are_valid(cmd_obj.get("args", []), server_url):
 				return false
 			return _bridge_env_matches(entry)
 	if entry.get(client.entry_url_field, "") != server_url:
@@ -175,9 +156,9 @@ static func _merge_bridge_env(existing: Variant) -> Dictionary:
 
 
 ## Basename match for `uvx` / `uvx.exe`, accepting both the bare-name
-## fallback and an absolute path resolved by `McpCliFinder`. Shared by the
-## FLAT and NESTED bridge verifiers — the only place we ever inspect a
-## stored bridge command/path.
+## fallback and an absolute path resolved by `McpCliFinder`. Used by the
+## FLAT bridge verifier — the only place we ever inspect a stored bridge
+## command/path.
 static func _command_is_uvx_like(cmd: String) -> bool:
 	var basename := cmd.get_file()
 	return basename == "uvx" or basename == "uvx.exe"

--- a/plugin/addons/godot_ai/clients/zed.gd
+++ b/plugin/addons/godot_ai/clients/zed.gd
@@ -1,9 +1,8 @@
 @tool
 extends McpClient
 
-## Zed registers MCP servers under `context_servers.<name>` and only speaks
-## stdio, so we bridge through `uvx mcp-proxy --transport streamablehttp <url>`
-## like Claude Desktop. `uvx` is already a plugin prereq.
+## Zed registers MCP servers under `context_servers.<name>` and supports both
+## stdio and streamable http transports.
 
 
 func _init() -> void:
@@ -17,8 +16,4 @@ func _init() -> void:
 		"windows": "$APPDATA/Zed/settings.json",
 	}
 	server_key_path = PackedStringArray(["context_servers"])
-	## NESTED bridge: `{"command": {"path": <uvx>, "args": [...]}, "settings": {}}`.
-	## Verifier requires the bridge form (no url-style fallback) — Zed has
-	## never spoken HTTP natively.
-	entry_uvx_bridge = McpClient.UvxBridge.NESTED
 	detect_paths = PackedStringArray(path_template.values())

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -834,10 +834,9 @@ func test_json_strategy_distinguishes_missing_entry_from_url_drift() -> void:
 
 
 func test_json_strategy_drift_with_bridge_entry() -> void:
-	## Bridge clients (Claude Desktop "flat", Zed "nested") run through a
-	## different verify path in `_json_strategy.verify_entry` than the
-	## default url-field comparison. Drift must still surface as
-	## CONFIGURED_MISMATCH, not NOT_CONFIGURED — dock contract is the same.
+	## Bridge clients (Claude Desktop "flat") run through a different verify path in
+	## `_json_strategy.verify_entry` than the default url-field comparison. Drift must still
+	## surface as CONFIGURED_MISMATCH, not NOT_CONFIGURED — dock contract is the same.
 	var path := _scratch_dir.path_join("verify_drift.json")
 	_remove_if_exists(path)
 	var client := McpClient.new()
@@ -1466,22 +1465,6 @@ func test_claude_desktop_verify_flags_wrong_transport_as_drift() -> void:
 	assert_false(McpJsonStrategy.verify_entry(c, non_uvx_command, "http://x"), "non-uvx command must register as drift")
 
 
-func test_zed_verify_flags_non_uvx_command_path_as_drift() -> void:
-	## Parallel to claude_desktop's strict-verify: NESTED form must validate
-	## command.path too. A Zed entry pointing at the wrong binary will still
-	## "have the URL in args" but won't actually launch the bridge.
-	var c := McpClientRegistry.get_by_id("zed")
-	var bad_path := {
-		"command": {
-			"path": "/usr/bin/python",
-			"args": McpClient.mcp_proxy_bridge_args("http://x"),
-		},
-		"env": McpClient.bridge_env_for_uvx(),
-		"settings": {},
-	}
-	assert_false(McpJsonStrategy.verify_entry(c, bad_path, "http://x"), "non-uvx command.path must register as drift")
-
-
 func test_claude_desktop_verify_entry_accepts_future_url_form() -> void:
 	## Tolerance preserved from the pre-refactor verifier: a hypothetical
 	## future Claude Desktop that speaks HTTP natively would write a plain
@@ -1492,36 +1475,10 @@ func test_claude_desktop_verify_entry_accepts_future_url_form() -> void:
 	assert_true(McpJsonStrategy.verify_entry(c, future_entry, "http://x"), "future url-style entry should verify")
 
 
-func test_zed_bridges_via_uvx() -> void:
-	var c := McpClientRegistry.get_by_id("zed")
-	assert_eq(c.entry_uvx_bridge, McpClient.UvxBridge.NESTED, "zed must declare NESTED uvx bridge")
-	var entry := McpJsonStrategy.build_entry(c, "http://x")
-	var cmd = entry.get("command", {})
-	assert_true(cmd is Dictionary, "Zed entry.command must be a Dictionary (path+args shape)")
-	_assert_uvx_command(cmd.get("path", ""))
-	_assert_mcp_proxy_bridge_args(cmd.get("args", []), "http://x")
-	_assert_bridge_env_pin(entry)
-
-
-func test_zed_verify_entry_accepts_uvx_form() -> void:
-	## Parity with claude_desktop drift-detection test — if Zed's entry shape
-	## changes but the verifier isn't updated in lock-step, this catches it.
+func test_zed_uses_url() -> void:
 	var c := McpClientRegistry.get_by_id("zed")
 	var entry := McpJsonStrategy.build_entry(c, "http://x")
-	assert_true(McpJsonStrategy.verify_entry(c, entry, "http://x"), "uvx entry should verify as a match")
-
-
-func test_zed_verify_flags_pre_uv_link_mode_entry_as_drift() -> void:
-	## Same UV_LINK_MODE=copy pin as claude_desktop, in NESTED shape.
-	var c := McpClientRegistry.get_by_id("zed")
-	var legacy_no_env := {
-		"command": {
-			"path": "uvx",
-			"args": McpClient.mcp_proxy_bridge_args("http://x"),
-		},
-		"settings": {},
-	}
-	assert_false(McpJsonStrategy.verify_entry(c, legacy_no_env, "http://x"), "pre-fix Zed entry without env must register as drift")
+	assert_eq(entry.get("url", ""), "http://x")
 
 
 func test_mcp_proxy_bridge_args_pins_version() -> void:


### PR DESCRIPTION
Zed supports both stdio and http transports for mcp so the following config works:
```
"godot-ai": {
    "url": "http://127.0.0.1:8000/mcp"
}
```
but godot-ai wants it to be:
```
"godot-ai": {
    "command": {
        "args": [
	        "mcp-proxy==0.11.0",
	        "--transport",
	        "streamablehttp",
	        "http://127.0.0.1:8000/mcp"
        ],
        "path": "/opt/homebrew/bin/uvx"
        },
        "env": {
        "UV_LINK_MODE": "copy"
        },
        "settings": {}
    }
}
```
With this config, Zed warns about deprecated options and can automatically convert the nested format to the flat format also used by Claude Code:

<img width="854" height="50" alt="Screenshot 2026-05-12 at 11 30 55 AM" src="https://github.com/user-attachments/assets/e005c4ce-38df-4d80-8956-9673be62fe1a" />

The two tools continue to battle back and forth over the format of the entry.

This PR changes the Zed client to use the url directly and avoid the bridge entirely. Since the Zed client was the only user of the `UvxBridge.NESTED` option, this also removes that enum entry and the config entry builder/validator.

Since Zed only recently hit 1.0 and has supported both the flat stdio and http transport style configs for a little while, I think it's fine to only support the url form here. However if it's desirable I can change it to validate the flat format in addition to the url format, even if the url format is default/preferred.

This change was manually tested against a godot project.