### PR TITLE
Fix node_set_property silent zero-fill on Packed*Array properties

### DIFF
--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -547,6 +547,22 @@ static func _check_coerced(value: Variant, target_type: int, prefix: String = ""
 			ok = value is Vector3
 		TYPE_COLOR:
 			ok = value is Color
+		TYPE_PACKED_VECTOR2_ARRAY:
+			ok = value is PackedVector2Array
+		TYPE_PACKED_VECTOR3_ARRAY:
+			ok = value is PackedVector3Array
+		TYPE_PACKED_COLOR_ARRAY:
+			ok = value is PackedColorArray
+		TYPE_PACKED_INT32_ARRAY:
+			ok = value is PackedInt32Array
+		TYPE_PACKED_INT64_ARRAY:
+			ok = value is PackedInt64Array
+		TYPE_PACKED_FLOAT32_ARRAY:
+			ok = value is PackedFloat32Array
+		TYPE_PACKED_FLOAT64_ARRAY:
+			ok = value is PackedFloat64Array
+		TYPE_PACKED_STRING_ARRAY:
+			ok = value is PackedStringArray
 		_:
 			return null
 	if ok:
@@ -564,8 +580,22 @@ static func _check_coerced(value: Variant, target_type: int, prefix: String = ""
 
 
 ## Build a "{\"x\":1,...}" hint string from the canonical key constants
-## so adding a key (e.g. Vector4) only touches VECTORN_KEYS.
+## so adding a key (e.g. Vector4) only touches VECTORN_KEYS. Packed*Array
+## targets short-circuit to a literal list-shaped hint.
 static func _shape_hint(target_type: int) -> String:
+	match target_type:
+		TYPE_PACKED_VECTOR2_ARRAY:
+			return "[{\"x\":0,\"y\":0}, ...]"
+		TYPE_PACKED_VECTOR3_ARRAY:
+			return "[{\"x\":0,\"y\":0,\"z\":0}, ...]"
+		TYPE_PACKED_COLOR_ARRAY:
+			return "[{\"r\":0,\"g\":0,\"b\":0,\"a\":1}, ...]"
+		TYPE_PACKED_INT32_ARRAY, TYPE_PACKED_INT64_ARRAY:
+			return "[int, ...]"
+		TYPE_PACKED_FLOAT32_ARRAY, TYPE_PACKED_FLOAT64_ARRAY:
+			return "[float, ...]"
+		TYPE_PACKED_STRING_ARRAY:
+			return "[\"...\"]"
 	var keys: Array[String] = []
 	match target_type:
 		TYPE_VECTOR2: keys = VECTOR2_KEYS
@@ -656,6 +686,70 @@ static func _coerce_value(value: Variant, target_type: int) -> Variant:
 		TYPE_DICTIONARY:
 			if value is Dictionary:
 				return value
+		TYPE_PACKED_VECTOR2_ARRAY:
+			if value is Array:
+				var out := PackedVector2Array()
+				for item in value:
+					if item is Vector2:
+						out.append(item)
+					elif item is Dictionary and item.has_all(VECTOR2_KEYS):
+						out.append(Vector2(item["x"], item["y"]))
+					else:
+						return value  # leave for _check_coerced to flag
+				return out
+		TYPE_PACKED_VECTOR3_ARRAY:
+			if value is Array:
+				var out := PackedVector3Array()
+				for item in value:
+					if item is Vector3:
+						out.append(item)
+					elif item is Dictionary and item.has_all(VECTOR3_KEYS):
+						out.append(Vector3(item["x"], item["y"], item["z"]))
+					else:
+						return value
+				return out
+		TYPE_PACKED_COLOR_ARRAY:
+			if value is Array:
+				var out := PackedColorArray()
+				for item in value:
+					if item is Color:
+						out.append(item)
+					elif item is Dictionary and item.has_all(COLOR_KEYS):
+						out.append(Color(item["r"], item["g"], item["b"], item.get("a", 1.0)))
+					elif item is String:
+						out.append(Color(item))
+					else:
+						return value
+				return out
+		TYPE_PACKED_INT32_ARRAY, TYPE_PACKED_INT64_ARRAY:
+			if value is Array:
+				var out: Variant = PackedInt32Array() if target_type == TYPE_PACKED_INT32_ARRAY else PackedInt64Array()
+				for item in value:
+					if item is int or item is float:
+						out.append(int(item))
+					else:
+						return value
+				return out
+		TYPE_PACKED_FLOAT32_ARRAY, TYPE_PACKED_FLOAT64_ARRAY:
+			if value is Array:
+				var out: Variant = PackedFloat32Array() if target_type == TYPE_PACKED_FLOAT32_ARRAY else PackedFloat64Array()
+				for item in value:
+					if item is float or item is int:
+						out.append(float(item))
+					else:
+						return value
+				return out
+		TYPE_PACKED_STRING_ARRAY:
+			if value is Array:
+				var out := PackedStringArray()
+				for item in value:
+					if item is String:
+						out.append(item)
+					else:
+						return value
+				return out
+		# PackedByteArray intentionally unhandled — needs design decision
+		# (base64 string vs. raw int list); JSON has no native byte type.
 	return value
 
 

--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -570,9 +570,13 @@ static func _check_coerced(value: Variant, target_type: int, prefix: String = ""
 	var dict_err := _check_dict_coerce_failed(value, target_type)
 	if dict_err != null:
 		return ErrorCodes.prefix_message(dict_err, prefix)
+	## Wording stays neutral on shape — `_shape_hint` already produces a
+	## dict-shaped string for Vector2/3/Color and a list-shaped one for
+	## the Packed*Array slots. The old "expected a dict like [...]" phrasing
+	## read self-contradictory for packed targets (PR #424 review).
 	var err := ErrorCodes.make(
 		ErrorCodes.WRONG_TYPE,
-		"Cannot coerce %s to %s; expected a dict like %s" % [
+		"Cannot coerce %s to %s; expected %s" % [
 			type_string(typeof(value)), type_string(target_type), _shape_hint(target_type),
 		],
 	)
@@ -595,7 +599,7 @@ static func _shape_hint(target_type: int) -> String:
 		TYPE_PACKED_FLOAT32_ARRAY, TYPE_PACKED_FLOAT64_ARRAY:
 			return "[float, ...]"
 		TYPE_PACKED_STRING_ARRAY:
-			return "[\"...\"]"
+			return "[\"...\", ...]"
 	var keys: Array[String] = []
 	match target_type:
 		TYPE_VECTOR2: keys = VECTOR2_KEYS

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -705,7 +705,7 @@ func test_shape_hint_packed_arrays() -> void:
 	assert_eq(NodeHandler._shape_hint(TYPE_PACKED_INT64_ARRAY), "[int, ...]")
 	assert_eq(NodeHandler._shape_hint(TYPE_PACKED_FLOAT32_ARRAY), "[float, ...]")
 	assert_eq(NodeHandler._shape_hint(TYPE_PACKED_FLOAT64_ARRAY), "[float, ...]")
-	assert_eq(NodeHandler._shape_hint(TYPE_PACKED_STRING_ARRAY), "[\"...\"]")
+	assert_eq(NodeHandler._shape_hint(TYPE_PACKED_STRING_ARRAY), "[\"...\", ...]")
 
 
 func test_check_coerced_array_vector3_returns_wrong_type() -> void:
@@ -718,6 +718,14 @@ func test_check_coerced_array_vector3_returns_wrong_type() -> void:
 	assert_eq(coerce_err.error.code, ErrorCodes.WRONG_TYPE)
 	assert_contains(coerce_err.error.message, "Vector3")
 	assert_contains(coerce_err.error.message, "Array")  # names the received type
+	## PR #424 follow-up: the message used to read "expected a dict like %s",
+	## which was self-contradictory once `_shape_hint` learned to return
+	## list-shaped hints for Packed*Array targets. Pin the new wording so a
+	## future revert can't reintroduce the inconsistency unnoticed.
+	assert_false(
+		String(coerce_err.error.message).contains("a dict like"),
+		"Message must drop the 'a dict like' phrasing — _shape_hint already encodes shape",
+	)
 
 
 func test_check_coerced_noop_for_non_compound_target() -> void:

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -462,6 +462,252 @@ func test_set_property_color_rejects_array_input() -> void:
 	assert_true(editor_undo(_undo_redo), "undo create should succeed")
 
 
+# ----- #429 — Packed*Array dict-coercion (silent zero-fill bug) -----
+
+func test_set_property_polygon2d_polygon_round_trip() -> void:
+	## Bug repro: setting a PackedVector2Array property (Polygon2D.polygon)
+	## with [{x,y}, ...] used to fall through _coerce_value unchanged.
+	## Godot's implicit Array → PackedVector2Array then per-element failed
+	## Dictionary → Vector2 and silently produced 6 × Vector2.ZERO. Must
+	## now coerce each dict and store the supplied vertices.
+	_handler.create_node({"type": "Polygon2D", "name": "_McpTestPoly", "parent_path": "/Main"})
+	var result := _handler.set_property({
+		"path": "/Main/_McpTestPoly",
+		"property": "polygon",
+		"value": [
+			{"x": -104, "y": -40},
+			{"x":  -32, "y": -16},
+			{"x":    0, "y": -72},
+			{"x":   32, "y": -16},
+			{"x":  112, "y": -40},
+			{"x":    0, "y":  64},
+		],
+	})
+	assert_has_key(result, "data")
+	assert_true(result.data.undoable)
+
+	## Assert on the stored Variant — count-only checks would silently pass
+	## against the zero-fill failure mode.
+	var node := EditorInterface.get_edited_scene_root().get_node("_McpTestPoly") as Polygon2D
+	assert_eq(node.polygon.size(), 6)
+	assert_true(node.polygon is PackedVector2Array, "stored value must be PackedVector2Array")
+	assert_eq(node.polygon[0], Vector2(-104, -40))
+	assert_eq(node.polygon[2], Vector2(0, -72))
+	assert_eq(node.polygon[5], Vector2(0, 64))
+	assert_true(editor_undo(_undo_redo), "undo set should succeed")
+	assert_true(editor_undo(_undo_redo), "undo create should succeed")
+
+
+func test_set_property_polygon2d_uv_round_trip() -> void:
+	## Same coercion path, different PackedVector2Array slot.
+	_handler.create_node({"type": "Polygon2D", "name": "_McpTestUv", "parent_path": "/Main"})
+	var result := _handler.set_property({
+		"path": "/Main/_McpTestUv",
+		"property": "uv",
+		"value": [
+			{"x": 0, "y": 0},
+			{"x": 1, "y": 0},
+			{"x": 1, "y": 1},
+			{"x": 0, "y": 1},
+		],
+	})
+	assert_has_key(result, "data")
+	var node := EditorInterface.get_edited_scene_root().get_node("_McpTestUv") as Polygon2D
+	assert_eq(node.uv.size(), 4)
+	assert_true(node.uv is PackedVector2Array)
+	assert_eq(node.uv[2], Vector2(1, 1))
+	assert_true(editor_undo(_undo_redo), "undo set should succeed")
+	assert_true(editor_undo(_undo_redo), "undo create should succeed")
+
+
+func test_set_property_packed_color_array_round_trip_dict_shape() -> void:
+	## PackedColorArray accepts both [{r,g,b,a}, ...] and ["#rrggbb", ...].
+	_handler.create_node({"type": "Polygon2D", "name": "_McpTestVColDict", "parent_path": "/Main"})
+	var result := _handler.set_property({
+		"path": "/Main/_McpTestVColDict",
+		"property": "vertex_colors",
+		"value": [
+			{"r": 1, "g": 0, "b": 0, "a": 1},
+			{"r": 0, "g": 1, "b": 0, "a": 0.5},
+			{"r": 0, "g": 0, "b": 1},
+		],
+	})
+	assert_has_key(result, "data")
+	var node := EditorInterface.get_edited_scene_root().get_node("_McpTestVColDict") as Polygon2D
+	assert_eq(node.vertex_colors.size(), 3)
+	assert_true(node.vertex_colors is PackedColorArray)
+	assert_eq(node.vertex_colors[0], Color(1, 0, 0, 1))
+	assert_eq(node.vertex_colors[1], Color(0, 1, 0, 0.5))
+	# Alpha defaults to 1 when omitted.
+	assert_eq(node.vertex_colors[2], Color(0, 0, 1, 1))
+	assert_true(editor_undo(_undo_redo), "undo set should succeed")
+	assert_true(editor_undo(_undo_redo), "undo create should succeed")
+
+
+func test_set_property_packed_color_array_round_trip_hex_string() -> void:
+	_handler.create_node({"type": "Polygon2D", "name": "_McpTestVColStr", "parent_path": "/Main"})
+	var result := _handler.set_property({
+		"path": "/Main/_McpTestVColStr",
+		"property": "vertex_colors",
+		"value": ["#ff0000", "#00ff00", "#0000ff"],
+	})
+	assert_has_key(result, "data")
+	var node := EditorInterface.get_edited_scene_root().get_node("_McpTestVColStr") as Polygon2D
+	assert_eq(node.vertex_colors.size(), 3)
+	assert_true(node.vertex_colors is PackedColorArray)
+	assert_eq(node.vertex_colors[0], Color(1, 0, 0, 1))
+	assert_eq(node.vertex_colors[2], Color(0, 0, 1, 1))
+	assert_true(editor_undo(_undo_redo), "undo set should succeed")
+	assert_true(editor_undo(_undo_redo), "undo create should succeed")
+
+
+func test_set_property_packed_vector2_array_rejects_flat_list() -> void:
+	## A flat [x, y, x, y, ...] list is an easy mistake; must error rather
+	## than silently zero-fill every element.
+	_handler.create_node({"type": "Polygon2D", "name": "_McpTestFlat", "parent_path": "/Main"})
+	var node := EditorInterface.get_edited_scene_root().get_node("_McpTestFlat") as Polygon2D
+	var original := node.polygon
+
+	var result := _handler.set_property({
+		"path": "/Main/_McpTestFlat",
+		"property": "polygon",
+		"value": [-104, -40, 0, -72, 32, -16],
+	})
+	assert_is_error(result, ErrorCodes.WRONG_TYPE)
+	assert_contains(result.error.message, "PackedVector2Array")
+	## Property must be untouched on rejection.
+	assert_eq(node.polygon, original, "polygon must be unchanged after rejected coerce")
+	assert_true(editor_undo(_undo_redo), "undo create should succeed")
+
+
+func test_set_property_packed_vector2_array_rejects_mixed_shapes() -> void:
+	## Mixing dict items with non-dict items must also fail rather than
+	## partial-zero-fill the unrecognized elements.
+	_handler.create_node({"type": "Polygon2D", "name": "_McpTestMixed", "parent_path": "/Main"})
+	var node := EditorInterface.get_edited_scene_root().get_node("_McpTestMixed") as Polygon2D
+	var original := node.polygon
+
+	var result := _handler.set_property({
+		"path": "/Main/_McpTestMixed",
+		"property": "polygon",
+		"value": [{"x": 1, "y": 2}, "garbage", {"x": 3, "y": 4}],
+	})
+	assert_is_error(result, ErrorCodes.WRONG_TYPE)
+	assert_eq(node.polygon, original, "polygon must be unchanged after rejected coerce")
+	assert_true(editor_undo(_undo_redo), "undo create should succeed")
+
+
+func test_coerce_packed_vector2_array_from_dict_list() -> void:
+	## Unit-level coverage on the static helper.
+	var coerced = NodeHandler._coerce_value(
+		[{"x": 1, "y": 2}, {"x": 3, "y": 4}],
+		TYPE_PACKED_VECTOR2_ARRAY,
+	)
+	assert_true(coerced is PackedVector2Array)
+	assert_eq(coerced.size(), 2)
+	assert_eq(coerced[0], Vector2(1, 2))
+	assert_eq(coerced[1], Vector2(3, 4))
+
+
+func test_coerce_packed_vector2_array_accepts_vector2_items() -> void:
+	## Internal callers may already have Vector2 values — passing through
+	## should not double-construct.
+	var coerced = NodeHandler._coerce_value(
+		[Vector2(1, 2), Vector2(3, 4)],
+		TYPE_PACKED_VECTOR2_ARRAY,
+	)
+	assert_true(coerced is PackedVector2Array)
+	assert_eq(coerced[1], Vector2(3, 4))
+
+
+func test_coerce_packed_vector3_array_from_dict_list() -> void:
+	var coerced = NodeHandler._coerce_value(
+		[{"x": 1, "y": 2, "z": 3}],
+		TYPE_PACKED_VECTOR3_ARRAY,
+	)
+	assert_true(coerced is PackedVector3Array)
+	assert_eq(coerced[0], Vector3(1, 2, 3))
+
+
+func test_coerce_packed_color_array_from_string() -> void:
+	var coerced = NodeHandler._coerce_value(["#ff0000", "#00ff00"], TYPE_PACKED_COLOR_ARRAY)
+	assert_true(coerced is PackedColorArray)
+	assert_eq(coerced[0], Color(1, 0, 0, 1))
+
+
+func test_coerce_packed_int32_array_from_numeric_list() -> void:
+	var coerced = NodeHandler._coerce_value([1, 2.0, 3], TYPE_PACKED_INT32_ARRAY)
+	assert_true(coerced is PackedInt32Array)
+	assert_eq(coerced.size(), 3)
+	assert_eq(coerced[1], 2)
+
+
+func test_coerce_packed_int64_array_from_numeric_list() -> void:
+	var coerced = NodeHandler._coerce_value([10, 20], TYPE_PACKED_INT64_ARRAY)
+	assert_true(coerced is PackedInt64Array)
+	assert_eq(coerced[0], 10)
+
+
+func test_coerce_packed_float32_array_from_numeric_list() -> void:
+	var coerced = NodeHandler._coerce_value([1, 2.5, 3], TYPE_PACKED_FLOAT32_ARRAY)
+	assert_true(coerced is PackedFloat32Array)
+	assert_eq(coerced.size(), 3)
+	assert_true(is_equal_approx(coerced[1], 2.5))
+
+
+func test_coerce_packed_float64_array_from_numeric_list() -> void:
+	var coerced = NodeHandler._coerce_value([1.5, 2.5], TYPE_PACKED_FLOAT64_ARRAY)
+	assert_true(coerced is PackedFloat64Array)
+
+
+func test_coerce_packed_string_array_from_string_list() -> void:
+	var coerced = NodeHandler._coerce_value(["a", "bb", "ccc"], TYPE_PACKED_STRING_ARRAY)
+	assert_true(coerced is PackedStringArray)
+	assert_eq(coerced[1], "bb")
+
+
+func test_coerce_packed_vector2_array_passes_through_on_bad_item() -> void:
+	## Contract: _coerce_value returns input unchanged on shape failure so
+	## the typed error comes from _check_coerced. A flat numeric list is a
+	## non-coercible Array.
+	var coerced = NodeHandler._coerce_value([-1, -2, 0, -3], TYPE_PACKED_VECTOR2_ARRAY)
+	assert_true(coerced is Array, "Bad-shape input must pass through unchanged")
+	assert_false(coerced is PackedVector2Array)
+
+
+func test_check_coerced_array_packed_vector2_returns_wrong_type() -> void:
+	## When _coerce_value passes through a bad Array, _check_coerced must
+	## flag it as WRONG_TYPE rather than letting it reach Godot's setter.
+	var coerce_err: Variant = NodeHandler._check_coerced([1, 2, 3], TYPE_PACKED_VECTOR2_ARRAY)
+	assert_true(coerce_err is Dictionary)
+	assert_eq(coerce_err.error.code, ErrorCodes.WRONG_TYPE)
+	assert_contains(coerce_err.error.message, "PackedVector2Array")
+	assert_contains(coerce_err.error.message, "Array")
+
+
+func test_check_coerced_passes_correct_packed_arrays() -> void:
+	## Right-typed packed arrays must pass through (return null).
+	assert_eq(NodeHandler._check_coerced(PackedVector2Array(), TYPE_PACKED_VECTOR2_ARRAY), null)
+	assert_eq(NodeHandler._check_coerced(PackedVector3Array(), TYPE_PACKED_VECTOR3_ARRAY), null)
+	assert_eq(NodeHandler._check_coerced(PackedColorArray(), TYPE_PACKED_COLOR_ARRAY), null)
+	assert_eq(NodeHandler._check_coerced(PackedInt32Array(), TYPE_PACKED_INT32_ARRAY), null)
+	assert_eq(NodeHandler._check_coerced(PackedFloat32Array(), TYPE_PACKED_FLOAT32_ARRAY), null)
+	assert_eq(NodeHandler._check_coerced(PackedStringArray(), TYPE_PACKED_STRING_ARRAY), null)
+
+
+func test_shape_hint_packed_arrays() -> void:
+	## The hint string is what agents read after a WRONG_TYPE — make sure
+	## each new packed type returns a list-shaped hint, not a dict.
+	assert_eq(NodeHandler._shape_hint(TYPE_PACKED_VECTOR2_ARRAY), "[{\"x\":0,\"y\":0}, ...]")
+	assert_eq(NodeHandler._shape_hint(TYPE_PACKED_VECTOR3_ARRAY), "[{\"x\":0,\"y\":0,\"z\":0}, ...]")
+	assert_eq(NodeHandler._shape_hint(TYPE_PACKED_COLOR_ARRAY), "[{\"r\":0,\"g\":0,\"b\":0,\"a\":1}, ...]")
+	assert_eq(NodeHandler._shape_hint(TYPE_PACKED_INT32_ARRAY), "[int, ...]")
+	assert_eq(NodeHandler._shape_hint(TYPE_PACKED_INT64_ARRAY), "[int, ...]")
+	assert_eq(NodeHandler._shape_hint(TYPE_PACKED_FLOAT32_ARRAY), "[float, ...]")
+	assert_eq(NodeHandler._shape_hint(TYPE_PACKED_FLOAT64_ARRAY), "[float, ...]")
+	assert_eq(NodeHandler._shape_hint(TYPE_PACKED_STRING_ARRAY), "[\"...\"]")
+
+
 func test_check_coerced_array_vector3_returns_wrong_type() -> void:
 	## Direct unit check on the helper — no scene needed. Pins the
 	## error shape so the message format change in #191 stays bisect-friendly.


### PR DESCRIPTION
**Summary**

node_set_property accepts a JSON array of typed elements for Packed*Array properties (e.g. polygon / uv on Polygon2D and CollisionPolygon2D, points on Line2D, custom @export var foo: PackedVector2Array), but the value is never coerced into the target Packed type. Godot's implicit Array → Packed*Array conversion then falls back to zero-filling each element, with no error returned. The agent sees a success response containing the zeroed array.

**Reproduction**

// tool: node_set_property
{
  "path": "/Root/CollisionPolygon2D",
  "property": "polygon",
  "value": [
    {"x": -104, "y": -40},
    {"x":  -32, "y": -16},
    {"x":    0, "y": -72},
    {"x":   32, "y": -16},
    {"x":  112, "y": -40},
    {"x":    0, "y":  64}
  ]
}
Expected: polygon set to those 6 vertices, or a typed error if the format is wrong.
Actual: polygon set to 6 × Vector2(0, 0). Tool returns success.

Variant: passing a flat list [-104, -40, -32, -16, 0, -72, ...] produces 12 × Vector2(0, 0) — each scalar becomes a separate zero vector.

**Root cause**

Two coupled gaps in node_handler.gd:

_coerce_value has explicit cases for TYPE_VECTOR2 / VECTOR3 / COLOR / BOOL / INT / FLOAT / STRING_NAME / NODE_PATH / OBJECT / ARRAY / DICTIONARY but no case for any TYPE_PACKED_*_ARRAY. The JSON Array[Dictionary] passes through unchanged.

_check_coerced only validates Vector2/Vector3/Color shape after coercion. For other target types it return null ("not a compound target — let Godot's setter handle it"). The uncoerced Array[Dictionary] is then forwarded to Godot, which fails per-element Dictionary → Vector2 and silently fills Vector2.ZERO.

The Godot-side zero-fill behavior is documented and not the bug — the plugin should have coerced or rejected before reaching the setter. The current asymmetry between Vector2/3/Color (handled) and PackedVector2/3Array (not handled) is what makes this bite silently.

**Impact**
The failure mode is the worst kind: silent data loss with a success return. The response's value field reflects the post-set state (node.get(property)), so the agent sees the zeroed array and may "self-correct" by escalating to a flat numeric array — which fails the same way with more zeros, looking like it's making things worse.

Affected properties include essentially anything geometric edited through MCP: Polygon2D.polygon / uv, CollisionPolygon2D.polygon, Line2D.points, NavigationPolygon outlines, MultiMesh.colors, any user-defined @export var x: Packed*Array.