### PR TITLE
Harden ZIP extractor against Windows drive-letter and backslash entries

### DIFF
--- a/tests/integration/_self_update_fixture.py
+++ b/tests/integration/_self_update_fixture.py
@@ -5,7 +5,7 @@ import shutil
 import subprocess
 import zipfile
 from importlib.machinery import SourceFileLoader
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from types import ModuleType
 
 import pytest
@@ -274,17 +274,37 @@ def assert_no_update_parse_errors(log: str) -> None:
 
 def extract_addon_from_zip(zip_path: Path, target_addon: Path) -> None:
     target_addon.mkdir(parents=True)
+    target_resolved = target_addon.resolve()
     with zipfile.ZipFile(zip_path) as zf:
         for info in zf.infolist():
             if not info.filename.startswith("addons/godot_ai/") or info.is_dir():
                 continue
-            rel = Path(info.filename).relative_to("addons/godot_ai")
+            # ZIP spec uses POSIX-style forward-slash separators; parsing the
+            # member name as PurePosixPath stops a Windows host from
+            # reinterpreting an entry like "addons/godot_ai/C:evil.txt" as a
+            # drive component (which would make `target_addon / rel` discard
+            # the prefix and write outside the fixture).
+            if "\\" in info.filename:
+                raise ValueError(
+                    f"Refusing unsafe zip entry {info.filename!r}: contains backslash"
+                )
+            rel = PurePosixPath(info.filename).relative_to("addons/godot_ai")
             if rel.is_absolute() or any(part in ("", ".", "..") for part in rel.parts):
                 raise ValueError(
                     f"Refusing unsafe zip entry {info.filename!r}: relative path "
                     f"{rel!s} contains absolute or traversal segments"
                 )
-            out = target_addon / rel
+            out = target_addon.joinpath(*rel.parts)
+            # Belt-and-suspenders containment: if the resolved output path
+            # would escape target_addon (e.g. an OS-specific path-parsing
+            # quirk we didn't anticipate), refuse the entry.
+            candidate = out if out.exists() else target_resolved / Path(*rel.parts)
+            resolved = candidate.resolve()
+            if not resolved.is_relative_to(target_resolved):
+                raise ValueError(
+                    f"Refusing unsafe zip entry {info.filename!r}: resolved "
+                    f"output {resolved!s} escapes target {target_resolved!s}"
+                )
             out.parent.mkdir(parents=True, exist_ok=True)
             out.write_bytes(zf.read(info.filename))
 

--- a/tests/unit/test_self_update_fixture_extract.py
+++ b/tests/unit/test_self_update_fixture_extract.py
@@ -1,0 +1,91 @@
+"""Unit tests for `tests/integration/_self_update_fixture.py::extract_addon_from_zip`.
+
+The helper extracts release-zip entries into a fixture directory before the
+integration tests in `tests/integration/test_self_update_*.py` exercise the
+update flow. The runtime installer (`update_reload_runner.gd`) rejects unsafe
+zip entries via `_is_safe_zip_addon_file()`; this helper mirrors that
+defense in Python so a crafted/corrupt release zip can't escape the fixture
+sandbox on developer machines or CI runners.
+"""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from tests.integration._self_update_fixture import extract_addon_from_zip
+
+
+def _write_zip(path: Path, members: dict[str, bytes]) -> None:
+    with zipfile.ZipFile(path, "w") as zf:
+        for name, data in members.items():
+            zf.writestr(name, data)
+
+
+def test_clean_zip_extracts_files_to_target(tmp_path: Path) -> None:
+    zip_path = tmp_path / "good.zip"
+    _write_zip(
+        zip_path,
+        {
+            "addons/godot_ai/plugin.cfg": b"[plugin]\nname=ok\n",
+            "addons/godot_ai/sub/file.gd": b"pass",
+        },
+    )
+    target = tmp_path / "target"
+    extract_addon_from_zip(zip_path, target)
+    assert (target / "plugin.cfg").read_bytes().startswith(b"[plugin]")
+    assert (target / "sub" / "file.gd").read_bytes() == b"pass"
+
+
+def test_parent_traversal_entry_is_rejected(tmp_path: Path) -> None:
+    zip_path = tmp_path / "bad.zip"
+    _write_zip(
+        zip_path,
+        {
+            "addons/godot_ai/plugin.cfg": b"[plugin]\nname=ok\n",
+            "addons/godot_ai/../../escape.txt": b"escape",
+        },
+    )
+    with pytest.raises(ValueError, match="absolute or traversal segments"):
+        extract_addon_from_zip(zip_path, tmp_path / "target")
+
+
+def test_backslash_in_entry_name_is_rejected(tmp_path: Path) -> None:
+    zip_path = tmp_path / "bad.zip"
+    _write_zip(
+        zip_path,
+        {
+            "addons/godot_ai/plugin.cfg": b"[plugin]\nname=ok\n",
+            "addons/godot_ai/sub\\windows-style.gd": b"oops",
+        },
+    )
+    with pytest.raises(ValueError, match="contains backslash"):
+        extract_addon_from_zip(zip_path, tmp_path / "target")
+
+
+def test_directory_entries_are_skipped(tmp_path: Path) -> None:
+    zip_path = tmp_path / "dirs.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("addons/godot_ai/sub/", b"")
+        zf.writestr("addons/godot_ai/plugin.cfg", b"[plugin]\nname=ok\n")
+    target = tmp_path / "target"
+    extract_addon_from_zip(zip_path, target)
+    assert (target / "plugin.cfg").is_file()
+    assert not (target / "sub").exists()
+
+
+def test_entries_outside_addon_prefix_are_skipped(tmp_path: Path) -> None:
+    zip_path = tmp_path / "mixed.zip"
+    _write_zip(
+        zip_path,
+        {
+            "addons/godot_ai/plugin.cfg": b"[plugin]\nname=ok\n",
+            "README.md": b"not an addon file",
+            "other/thing.txt": b"also not",
+        },
+    )
+    target = tmp_path / "target"
+    extract_addon_from_zip(zip_path, target)
+    assert sorted(p.name for p in target.iterdir()) == ["plugin.cfg"]


### PR DESCRIPTION
## Summary

Mini follow-up: the Windows-hardening fix I pushed to PR #427 in response to Copilot's review (`9afcdc7`) didn't make it into the squash-merge — #427 was merged on its earlier head (`20702f9`), so the hardening never landed on either branch.

This PR cherry-picks just that commit onto beta. After it merges, beta has the hardening; the next beta→main cycle carries it forward to main.

## What's in this PR

Single commit cherry-picked from `claude/sync-main-to-beta-final-jcvhf`. No new code beyond what was reviewed on #427:

- **`tests/integration/_self_update_fixture.py`** (~16 lines): three-pronged hardening to `extract_addon_from_zip`
  - Parse zip member names as `PurePosixPath` (ZIP spec is POSIX-style with `/`) so Windows host pathlib doesn't reinterpret drive-letter syntax (e.g. `addons/godot_ai/C:evil.txt`)
  - Reject any literal backslash in `info.filename`, mirroring `update_reload_runner.gd::_is_safe_zip_addon_file()`
  - Belt-and-suspenders containment check: `resolved.is_relative_to(target_resolved)` on the final output path
- **`tests/unit/test_self_update_fixture_extract.py`** (new, 5 cases): clean-zip happy path, parent-traversal rejection, backslash rejection, zip-directory entries skipped, entries outside `addons/godot_ai/` prefix skipped

## Test plan

- [x] `ruff check tests/` — clean
- [x] `pytest tests/unit/test_self_update_fixture_extract.py -q` — 5/5 pass
- [ ] Full CI matrix on the cherry-pick

## Why this is a mini PR

Once #427 merged on the pre-hardening head, the cleanest recovery is a tiny isolated PR rather than another big sync. Single commit, no merge conflicts to worry about, fast review.

https://claude.ai/code/session_01VgXf3Lqv2ypt36g6EqpRYg

---
_Generated by [Claude Code](https://claude.ai/code/session_01VgXf3Lqv2ypt36g6EqpRYg)_