### PR TITLE
Fix telemetry privacy boundaries

### DIFF
--- a/src/godot_ai/telemetry.py
+++ b/src/godot_ai/telemetry.py
@@ -655,6 +655,20 @@ def _extract_session_id(args: tuple[Any, ...], kwargs: dict[str, Any]) -> str | 
     return None
 
 
+def _safe_exception_category(exc: Exception) -> str:
+    """Return a telemetry-safe error category without exception details.
+
+    ``GodotCommandError.__str__`` includes plugin-provided ``error.data``;
+    other exception messages can include user input or project paths. The
+    decorator only needs a stable category for aggregate failure counts.
+    """
+    if exc.__class__.__name__ == "GodotCommandError":
+        code = getattr(exc, "code", None)
+        if code:
+            return str(code)
+    return exc.__class__.__name__
+
+
 def _instrument(
     func: Callable[..., Any],
     *,
@@ -691,7 +705,7 @@ def _instrument(
                 _emit(start, True, sub, sid, None)
                 return result
             except Exception as exc:
-                err = str(exc)
+                err = _safe_exception_category(exc)
                 _emit(start, False, sub, sid, err)
                 raise
 
@@ -708,7 +722,7 @@ def _instrument(
             _emit(start, True, sub, sid, None)
             return result
         except Exception as exc:
-            err = str(exc)
+            err = _safe_exception_category(exc)
             _emit(start, False, sub, sid, err)
             raise
 

--- a/src/godot_ai/telemetry.py
+++ b/src/godot_ai/telemetry.py
@@ -45,6 +45,7 @@ from urllib.parse import urlparse
 import httpx
 
 from godot_ai import __version__ as _PACKAGE_VERSION
+from godot_ai.protocol.errors import ErrorCode
 
 logger = logging.getLogger("godot-ai-telemetry")
 
@@ -664,8 +665,11 @@ def _safe_exception_category(exc: Exception) -> str:
     """
     if exc.__class__.__name__ == "GodotCommandError":
         code = getattr(exc, "code", None)
-        if code:
+        if code in {member.value for member in ErrorCode}:
             return str(code)
+        if isinstance(code, ErrorCode):
+            return code.value
+        return "GodotCommandError"
     return exc.__class__.__name__
 
 

--- a/src/godot_ai/transport/websocket.py
+++ b/src/godot_ai/transport/websocket.py
@@ -6,6 +6,7 @@ import asyncio
 import errno
 import json
 import logging
+import re
 from typing import Any
 
 import websockets
@@ -51,12 +52,12 @@ _SELF_UPDATE_STATUSES: frozenset[str] = frozenset(
 )
 _PLUGIN_RELOAD_SOURCES: frozenset[str] = frozenset({"dock_button", "mcp_tool", "unknown"})
 _DEV_SERVER_ACTIONS: frozenset[str] = frozenset({"start", "stop", "unknown"})
-_PLUGIN_EVENT_ERROR_MAX = 200
+_VERSION_TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$")
 
 
-def _truncate_text(value: Any, limit: int) -> str:
+def _safe_version_token(value: Any) -> str:
     text = str(value)
-    return text if len(text) <= limit else text[:limit]
+    return text if _VERSION_TOKEN_RE.fullmatch(text) else "unknown"
 
 
 def _sanitized_plugin_event_data(name: str, data: dict[str, Any]) -> dict[str, Any]:
@@ -76,11 +77,11 @@ def _sanitized_plugin_event_data(name: str, data: dict[str, Any]) -> dict[str, A
         status = str(data.get("status", "unknown"))
         sanitized["status"] = status if status in _SELF_UPDATE_STATUSES else "unknown"
         if "from_version" in data:
-            sanitized["from_version"] = str(data["from_version"])
+            sanitized["from_version"] = _safe_version_token(data["from_version"])
         if "to_version" in data:
-            sanitized["to_version"] = str(data["to_version"])
+            sanitized["to_version"] = _safe_version_token(data["to_version"])
         if "error" in data:
-            sanitized["error"] = _truncate_text(data["error"], _PLUGIN_EVENT_ERROR_MAX)
+            sanitized["error"] = "reported"
     elif name == "plugin_reload":
         success = data.get("success")
         if isinstance(success, bool):
@@ -88,7 +89,7 @@ def _sanitized_plugin_event_data(name: str, data: dict[str, Any]) -> dict[str, A
         source = str(data.get("source", "unknown"))
         sanitized["source"] = source if source in _PLUGIN_RELOAD_SOURCES else "unknown"
         if "error" in data:
-            sanitized["error"] = _truncate_text(data["error"], _PLUGIN_EVENT_ERROR_MAX)
+            sanitized["error"] = "reported"
     elif name == "dev_server_toggle":
         action = str(data.get("action", "unknown"))
         sanitized["action"] = action if action in _DEV_SERVER_ACTIONS else "unknown"

--- a/src/godot_ai/transport/websocket.py
+++ b/src/godot_ai/transport/websocket.py
@@ -46,6 +46,55 @@ _PLUGIN_EVENT_NAMES: frozenset[str] = frozenset(
         "dev_server_toggle",
     }
 )
+_SELF_UPDATE_STATUSES: frozenset[str] = frozenset(
+    {"success", "failed_clean", "failed_mixed", "unknown"}
+)
+_PLUGIN_RELOAD_SOURCES: frozenset[str] = frozenset({"dock_button", "mcp_tool", "unknown"})
+_DEV_SERVER_ACTIONS: frozenset[str] = frozenset({"start", "stop", "unknown"})
+_PLUGIN_EVENT_ERROR_MAX = 200
+
+
+def _truncate_text(value: Any, limit: int) -> str:
+    text = str(value)
+    return text if len(text) <= limit else text[:limit]
+
+
+def _sanitized_plugin_event_data(name: str, data: dict[str, Any]) -> dict[str, Any]:
+    """Return the server-side telemetry schema for a plugin event.
+
+    The plugin has its own allowlist, but a local peer with a valid session
+    can still submit arbitrary data. Keep this as the final outbound
+    telemetry boundary: known event name in, canonical safe fields out.
+    """
+    sanitized: dict[str, Any] = {}
+
+    if name == "dock_startup":
+        developer_mode = data.get("developer_mode")
+        if isinstance(developer_mode, bool):
+            sanitized["developer_mode"] = developer_mode
+    elif name == "self_update":
+        status = str(data.get("status", "unknown"))
+        sanitized["status"] = status if status in _SELF_UPDATE_STATUSES else "unknown"
+        if "from_version" in data:
+            sanitized["from_version"] = str(data["from_version"])
+        if "to_version" in data:
+            sanitized["to_version"] = str(data["to_version"])
+        if "error" in data:
+            sanitized["error"] = _truncate_text(data["error"], _PLUGIN_EVENT_ERROR_MAX)
+    elif name == "plugin_reload":
+        success = data.get("success")
+        if isinstance(success, bool):
+            sanitized["success"] = success
+        source = str(data.get("source", "unknown"))
+        sanitized["source"] = source if source in _PLUGIN_RELOAD_SOURCES else "unknown"
+        if "error" in data:
+            sanitized["error"] = _truncate_text(data["error"], _PLUGIN_EVENT_ERROR_MAX)
+    elif name == "dev_server_toggle":
+        action = str(data.get("action", "unknown"))
+        sanitized["action"] = action if action in _DEV_SERVER_ACTIONS else "unknown"
+
+    sanitized["event_name"] = name
+    return sanitized
 
 
 class GodotWebSocketServer:
@@ -200,18 +249,15 @@ class GodotWebSocketServer:
                 logger.info("Session %s: readiness -> %s", session_id[:8], session.readiness)
             elif event == "plugin_event":
                 ## Plugin-side events (self-update outcome, dock startup,
-                ## reload). The plugin owns the allowlist on the emit side;
-                ## here we only validate envelope shape and forward.
+                ## reload). The plugin owns the allowlist on the emit side,
+                ## but the server is the outbound telemetry trust boundary:
+                ## validate the envelope and project it into per-event safe
+                ## fields before forwarding.
                 payload = PluginTelemetryEvent.model_validate(event_data)
                 if payload.name in _PLUGIN_EVENT_NAMES:
-                    ## ``payload.name`` must win over any ``event_name`` key
-                    ## hidden inside ``payload.data`` — otherwise a malformed
-                    ## plugin event (or hijacked WS) could spoof the recorded
-                    ## event name past the allowlist. Spreading data first,
-                    ## then setting event_name, makes that override impossible.
                     record_telemetry(
                         RecordType.PLUGIN_EVENT,
-                        {**payload.data, "event_name": payload.name},
+                        _sanitized_plugin_event_data(payload.name, payload.data),
                         session_id=session_id,
                     )
                 else:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -24,10 +24,16 @@ from godot_ai import telemetry as tel
 def isolated_data_dir(monkeypatch, tmp_path: Path) -> Path:
     """Force ``TelemetryConfig._get_data_directory`` into a tmp_path,
     drop any inherited opt-out env vars (CI workflows / conftest.py
-    set them globally), and reset the module-level collector
-    singleton before and after the test."""
+    set them globally), force an invalid endpoint so unmocked sends
+    cannot reach production, and reset the module-level collector
+    singleton before and after the test.
+
+    Tests that assert endpoint resolution can still override or delete
+    ``GODOT_AI_TELEMETRY_ENDPOINT`` after this fixture is active.
+    """
     monkeypatch.delenv("GODOT_AI_DISABLE_TELEMETRY", raising=False)
     monkeypatch.delenv("DISABLE_TELEMETRY", raising=False)
+    monkeypatch.setenv("GODOT_AI_TELEMETRY_ENDPOINT", "ftp://test-leak-guard.invalid/")
     monkeypatch.setattr(tel.TelemetryConfig, "_get_data_directory", lambda self: tmp_path)
     tel.reset_telemetry()
     yield tmp_path

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -74,17 +74,30 @@ class TestHashSessionId:
 
 class TestTelemetryConfig:
     def test_default_enabled_uses_baked_in_endpoint(
-        self, clean_env, isolated_data_dir
+        self, monkeypatch, clean_env, isolated_data_dir
     ) -> None:
         """A fresh install with no env overrides should resolve to the
         baked-in production endpoint so the binary actually reports.
         Regression test for "telemetry on by default" — empty default
         endpoint used to mean zero traffic even when enabled."""
+        monkeypatch.delenv("GODOT_AI_TELEMETRY_ENDPOINT", raising=False)
         config = tel.TelemetryConfig()
         assert config.enabled is True
         assert config.endpoint == tel.TelemetryConfig.DEFAULT_ENDPOINT
         ## The bake-in must be a real https URL, not the empty string.
         assert config.endpoint.startswith("https://")
+
+    def test_isolated_fixture_uses_invalid_endpoint_leak_guard(
+        self, clean_env, isolated_data_dir
+    ) -> None:
+        """Unit tests remove opt-out to exercise enabled telemetry.
+
+        The shared fixture must still prevent an unmocked background
+        worker from POSTing to the baked-in production endpoint.
+        """
+        config = tel.TelemetryConfig()
+        assert config.enabled is True
+        assert config.endpoint == ""
 
     @pytest.mark.parametrize("var", ["GODOT_AI_DISABLE_TELEMETRY", "DISABLE_TELEMETRY"])
     def test_opt_out_via_env(self, monkeypatch, clean_env, isolated_data_dir, var: str) -> None:

--- a/tests/unit/test_telemetry_decorator.py
+++ b/tests/unit/test_telemetry_decorator.py
@@ -92,6 +92,25 @@ class TestTelemetryToolSync:
         assert "secret-project" not in rec.data["error"]
         assert "candidate" not in rec.data["error"]
 
+    def test_replaces_unknown_godot_command_error_code(self, isolated_collector) -> None:
+        _, sent = isolated_collector
+
+        @tel.telemetry_tool("my_tool")
+        def my_tool() -> None:
+            raise GodotCommandError(
+                code="res://secret-project/error-code",
+                message="Missing res://secret-project/player.gd",
+            )
+
+        with pytest.raises(GodotCommandError):
+            my_tool()
+        _wait_for(sent, 1)
+
+        rec = sent[0]
+        assert rec.data["success"] is False
+        assert rec.data["error"] == "GodotCommandError"
+        assert "secret-project" not in rec.data["error"]
+
     def test_extracts_op_as_sub_action(self, isolated_collector) -> None:
         _, sent = isolated_collector
 
@@ -118,7 +137,7 @@ class TestTelemetryToolSync:
         assert sent[0].session_id.endswith("@a3f2")
         assert "my-game" not in sent[0].session_id
 
-    def test_truncates_long_error(self, isolated_collector) -> None:
+    def test_records_class_name_for_long_error_message(self, isolated_collector) -> None:
         _, sent = isolated_collector
         long_msg = "x" * 500
 

--- a/tests/unit/test_telemetry_decorator.py
+++ b/tests/unit/test_telemetry_decorator.py
@@ -13,6 +13,7 @@ import asyncio
 import pytest
 
 from godot_ai import telemetry as tel
+from godot_ai.godot_client.client import GodotCommandError
 
 
 @pytest.fixture
@@ -67,7 +68,29 @@ class TestTelemetryToolSync:
 
         rec = sent[0]
         assert rec.data["success"] is False
-        assert rec.data["error"] == "boom"
+        assert rec.data["error"] == "ValueError"
+        assert "boom" not in rec.data["error"]
+
+    def test_records_godot_command_error_code_without_data(self, isolated_collector) -> None:
+        _, sent = isolated_collector
+
+        @tel.telemetry_tool("my_tool")
+        def my_tool() -> None:
+            raise GodotCommandError(
+                code="RESOURCE_NOT_FOUND",
+                message="Missing res://secret-project/player.gd",
+                data={"candidate": "res://secret-project/player_backup.gd"},
+            )
+
+        with pytest.raises(GodotCommandError):
+            my_tool()
+        _wait_for(sent, 1)
+
+        rec = sent[0]
+        assert rec.data["success"] is False
+        assert rec.data["error"] == "RESOURCE_NOT_FOUND"
+        assert "secret-project" not in rec.data["error"]
+        assert "candidate" not in rec.data["error"]
 
     def test_extracts_op_as_sub_action(self, isolated_collector) -> None:
         _, sent = isolated_collector
@@ -107,7 +130,7 @@ class TestTelemetryToolSync:
             x()
         _wait_for(sent, 1)
 
-        assert len(sent[0].data["error"]) == 200
+        assert sent[0].data["error"] == "RuntimeError"
 
 
 class TestTelemetryToolAsync:
@@ -137,7 +160,8 @@ class TestTelemetryToolAsync:
         _wait_for(sent, 1)
 
         assert sent[0].data["success"] is False
-        assert sent[0].data["error"] == "async boom"
+        assert sent[0].data["error"] == "RuntimeError"
+        assert "async boom" not in sent[0].data["error"]
 
 
 class TestTelemetryResource:
@@ -155,6 +179,23 @@ class TestTelemetryResource:
         assert rec.record_type is tel.RecordType.RESOURCE_RETRIEVAL
         assert rec.data["resource_name"] == "my_resource"
         assert rec.data["success"] is True
+
+    def test_resource_failure_records_class_name_not_message(self, isolated_collector) -> None:
+        _, sent = isolated_collector
+
+        @tel.telemetry_resource("my_resource")
+        def reader() -> dict:
+            raise ConnectionError("project path /Users/alice/private-game disappeared")
+
+        with pytest.raises(ConnectionError):
+            reader()
+        _wait_for(sent, 1)
+
+        rec = sent[0]
+        assert rec.record_type is tel.RecordType.RESOURCE_RETRIEVAL
+        assert rec.data["success"] is False
+        assert rec.data["error"] == "ConnectionError"
+        assert "private-game" not in rec.data["error"]
 
 
 class TestDecoratorNeverRaises:

--- a/tests/unit/test_telemetry_integration.py
+++ b/tests/unit/test_telemetry_integration.py
@@ -304,7 +304,7 @@ class TestPluginEventAllowlist:
             "source": "dock_button",
         }
 
-    def test_malformed_payload_values_are_replaced_or_truncated(self, captured) -> None:
+    def test_malformed_payload_values_are_replaced_safely(self, captured) -> None:
         from godot_ai.transport import websocket as ws_mod
 
         reg = SessionRegistry()
@@ -328,9 +328,9 @@ class TestPluginEventAllowlist:
                     "name": "self_update",
                     "data": {
                         "status": "res://unexpected",
-                        "from_version": 1,
-                        "to_version": None,
-                        "error": "x" * 250,
+                        "from_version": "1.2.3",
+                        "to_version": "res://private-game/addons/godot_ai",
+                        "error": "/Users/alice/private-game/full editor log",
                         "logs": "full editor log",
                     },
                 },
@@ -343,10 +343,52 @@ class TestPluginEventAllowlist:
         rec = plugin_events[0]
         assert rec.data["event_name"] == "self_update"
         assert rec.data["status"] == "unknown"
-        assert rec.data["from_version"] == "1"
-        assert rec.data["to_version"] == "None"
-        assert rec.data["error"] == "x" * 200
+        assert rec.data["from_version"] == "1.2.3"
+        assert rec.data["to_version"] == "unknown"
+        assert rec.data["error"] == "reported"
+        assert all("private-game" not in str(value) for value in rec.data.values())
         assert "logs" not in rec.data
+
+    def test_plugin_reload_error_message_is_replaced(self, captured) -> None:
+        from godot_ai.transport import websocket as ws_mod
+
+        reg = SessionRegistry()
+        session = Session(
+            session_id="demo@a3f2",
+            godot_version="4.4.1",
+            project_path="/tmp/demo",
+            plugin_version="0.0.1",
+        )
+        reg.register(session)
+        captured.clear()
+
+        stub = types.SimpleNamespace(registry=reg)
+        ws_mod.GodotWebSocketServer._handle_event(
+            stub,  # type: ignore[arg-type]
+            "demo@a3f2",
+            {
+                "type": "event",
+                "event": "plugin_event",
+                "data": {
+                    "name": "plugin_reload",
+                    "data": {
+                        "success": False,
+                        "source": "mcp_tool",
+                        "error": "failed reading /Users/alice/private-game/plugin.gd",
+                    },
+                },
+            },
+        )
+        _wait_for(captured, 1)
+
+        plugin_events = [r for r in captured if r.record_type is tel.RecordType.PLUGIN_EVENT]
+        assert len(plugin_events) == 1
+        assert plugin_events[0].data == {
+            "event_name": "plugin_reload",
+            "success": False,
+            "source": "mcp_tool",
+            "error": "reported",
+        }
 
     def test_plugin_reload_and_dev_server_enums_default_unknown(self, captured) -> None:
         from godot_ai.transport import websocket as ws_mod

--- a/tests/unit/test_telemetry_integration.py
+++ b/tests/unit/test_telemetry_integration.py
@@ -261,7 +261,131 @@ class TestPluginEventAllowlist:
         plugin_events = [r for r in captured if r.record_type is tel.RecordType.PLUGIN_EVENT]
         assert len(plugin_events) == 1
         assert plugin_events[0].data["event_name"] == "dock_startup"
-        assert plugin_events[0].data["other"] == 1
+        assert "other" not in plugin_events[0].data
+
+    def test_payload_unknown_fields_are_dropped(self, captured) -> None:
+        from godot_ai.transport import websocket as ws_mod
+
+        reg = SessionRegistry()
+        session = Session(
+            session_id="demo@a3f2",
+            godot_version="4.4.1",
+            project_path="/tmp/demo",
+            plugin_version="0.0.1",
+        )
+        reg.register(session)
+        captured.clear()
+
+        stub = types.SimpleNamespace(registry=reg)
+        ws_mod.GodotWebSocketServer._handle_event(
+            stub,  # type: ignore[arg-type]
+            "demo@a3f2",
+            {
+                "type": "event",
+                "event": "plugin_event",
+                "data": {
+                    "name": "plugin_reload",
+                    "data": {
+                        "success": True,
+                        "source": "dock_button",
+                        "project_path": "/Users/alice/private-game",
+                        "event_name": "FAKE_OVERRIDE",
+                    },
+                },
+            },
+        )
+        _wait_for(captured, 1)
+
+        plugin_events = [r for r in captured if r.record_type is tel.RecordType.PLUGIN_EVENT]
+        assert len(plugin_events) == 1
+        assert plugin_events[0].data == {
+            "event_name": "plugin_reload",
+            "success": True,
+            "source": "dock_button",
+        }
+
+    def test_malformed_payload_values_are_replaced_or_truncated(self, captured) -> None:
+        from godot_ai.transport import websocket as ws_mod
+
+        reg = SessionRegistry()
+        session = Session(
+            session_id="demo@a3f2",
+            godot_version="4.4.1",
+            project_path="/tmp/demo",
+            plugin_version="0.0.1",
+        )
+        reg.register(session)
+        captured.clear()
+
+        stub = types.SimpleNamespace(registry=reg)
+        ws_mod.GodotWebSocketServer._handle_event(
+            stub,  # type: ignore[arg-type]
+            "demo@a3f2",
+            {
+                "type": "event",
+                "event": "plugin_event",
+                "data": {
+                    "name": "self_update",
+                    "data": {
+                        "status": "res://unexpected",
+                        "from_version": 1,
+                        "to_version": None,
+                        "error": "x" * 250,
+                        "logs": "full editor log",
+                    },
+                },
+            },
+        )
+        _wait_for(captured, 1)
+
+        plugin_events = [r for r in captured if r.record_type is tel.RecordType.PLUGIN_EVENT]
+        assert len(plugin_events) == 1
+        rec = plugin_events[0]
+        assert rec.data["event_name"] == "self_update"
+        assert rec.data["status"] == "unknown"
+        assert rec.data["from_version"] == "1"
+        assert rec.data["to_version"] == "None"
+        assert rec.data["error"] == "x" * 200
+        assert "logs" not in rec.data
+
+    def test_plugin_reload_and_dev_server_enums_default_unknown(self, captured) -> None:
+        from godot_ai.transport import websocket as ws_mod
+
+        reg = SessionRegistry()
+        session = Session(
+            session_id="demo@a3f2",
+            godot_version="4.4.1",
+            project_path="/tmp/demo",
+            plugin_version="0.0.1",
+        )
+        reg.register(session)
+        captured.clear()
+
+        stub = types.SimpleNamespace(registry=reg)
+        for name, data in (
+            ("plugin_reload", {"success": "yes", "source": "shell"}),
+            ("dev_server_toggle", {"action": "restart"}),
+        ):
+            ws_mod.GodotWebSocketServer._handle_event(
+                stub,  # type: ignore[arg-type]
+                "demo@a3f2",
+                {
+                    "type": "event",
+                    "event": "plugin_event",
+                    "data": {"name": name, "data": data},
+                },
+            )
+        _wait_for(captured, 2)
+
+        plugin_events = [r for r in captured if r.record_type is tel.RecordType.PLUGIN_EVENT]
+        assert plugin_events[0].data == {
+            "event_name": "plugin_reload",
+            "source": "unknown",
+        }
+        assert plugin_events[1].data == {
+            "event_name": "dev_server_toggle",
+            "action": "unknown",
+        }
 
     def test_unknown_event_dropped(self, captured) -> None:
         from godot_ai.transport import websocket as ws_mod


### PR DESCRIPTION
## Summary
- record only safe failure categories in telemetry decorators: GodotCommandError code or exception class name
- sanitize plugin_event payloads server-side with per-event allowlists and canonical event_name
- guard unit telemetry fixtures from accidentally posting to the production endpoint

## Tests
- pytest -q tests/unit/test_telemetry.py tests/unit/test_telemetry_send.py tests/unit/test_telemetry_integration.py tests/unit/test_telemetry_decorator.py
- pytest -q tests/unit
- ruff check tests/unit/conftest.py tests/unit/test_telemetry.py src/godot_ai/telemetry.py src/godot_ai/transport/websocket.py tests/unit/test_telemetry_decorator.py tests/unit/test_telemetry_integration.py