### PR TITLE
Fix #435: KeyError 'op' at startup on some Python/Pydantic combos

### DIFF
--- a/src/godot_ai/telemetry.py
+++ b/src/godot_ai/telemetry.py
@@ -713,6 +713,7 @@ def _instrument(
                 _emit(start, False, sub, sid, err)
                 raise
 
+        _expose_wrapped_surface(_async_wrapper, func)
         return _async_wrapper
 
     @functools.wraps(func)
@@ -730,7 +731,30 @@ def _instrument(
             _emit(start, False, sub, sid, err)
             raise
 
+    _expose_wrapped_surface(_sync_wrapper, func)
     return _sync_wrapper
+
+
+def _expose_wrapped_surface(wrapper: Callable[..., Any], func: Callable[..., Any]) -> None:
+    ## FastMCP's schema generator (``without_injected_parameters`` →
+    ## ``typing.get_type_hints`` → Pydantic ``TypeAdapter``) inspects the
+    ## wrapper's own ``__signature__`` / ``__annotations__`` rather than
+    ## chasing ``__wrapped__`` consistently. On the Python / Pydantic
+    ## combos that surface issue #435, the chain returns a ``type_hints``
+    ## dict missing the ``op`` key for ``<domain>_manage`` rollups,
+    ## crashing schema build at server startup with ``KeyError: 'op'``.
+    ##
+    ## ``functools.wraps`` already assigns ``__annotations__`` to the
+    ## wrapped dict, but does not synthesize ``__signature__``. Re-assign
+    ## a *fresh* dict copy of ``__annotations__`` (so a downstream
+    ## consumer mutating it can't corrupt the underlying handler's dict)
+    ## and pin ``__signature__`` to the real signature so callers don't
+    ## have to follow ``__wrapped__``.
+    try:
+        wrapper.__signature__ = inspect.signature(func)  # type: ignore[attr-defined]
+    except (TypeError, ValueError):
+        pass
+    wrapper.__annotations__ = dict(getattr(func, "__annotations__", {}))
 
 
 def telemetry_tool(tool_name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:

--- a/tests/unit/test_telemetry_decorator.py
+++ b/tests/unit/test_telemetry_decorator.py
@@ -292,3 +292,54 @@ class TestInstallFastmcpWraps:
         _wait_for(sent, 0, timeout=0.3)
 
         assert sent == []
+
+    def test_manage_tool_schema_builds_through_wrap(self, isolated_collector) -> None:
+        """Issue #435 regression: ``<domain>_manage`` rollups have their
+        ``op`` annotation set post-hoc to a dynamically-built ``Literal[...]``
+        (see ``_meta_tool.py`` rationale). When the telemetry wrap put a
+        ``functools.wraps``-decorated wrapper between FastMCP and the closure,
+        FastMCP's ``without_injected_parameters`` → Pydantic schema build
+        crashed with ``KeyError: 'op'`` on some Python / Pydantic combos
+        because the wrapper's own ``__annotations__`` / ``__globals__`` lost
+        the dynamic ``Literal``. The fix pins ``__signature__`` and a fresh
+        ``__annotations__`` copy on the instrumented wrapper so FastMCP can
+        introspect it directly.
+
+        This test reproduces the failing path: register a manage tool through
+        an ``install_fastmcp_wraps``-wrapped FastMCP and force schema
+        generation by listing tools. Pre-fix this raised ``KeyError: 'op'``.
+        """
+        from fastmcp import FastMCP
+
+        from godot_ai.tools._meta_tool import register_manage_tool
+
+        mcp = FastMCP("test")
+        tel.install_fastmcp_wraps(mcp)
+
+        async def op_a(runtime, **_kwargs):  # type: ignore[no-untyped-def]
+            return {"ok": True}
+
+        async def op_b(runtime, **_kwargs):  # type: ignore[no-untyped-def]
+            return {"ok": True}
+
+        register_manage_tool(
+            mcp,
+            tool_name="test_manage",
+            description="test manage rollup",
+            ops={"alpha": op_a, "beta": op_b},
+        )
+
+        ## Forcing tool list materializes the Pydantic schema for every
+        ## registered tool — that's the call that exploded in #435.
+        tools = asyncio.run(mcp.list_tools())
+        names = {t.name for t in tools}
+        assert "test_manage" in names
+
+        test_manage = next(t for t in tools if t.name == "test_manage")
+        schema = test_manage.parameters or {}
+        ## Schema must enumerate the op literal — proves Pydantic saw the
+        ## ``op`` annotation rather than skipping or defaulting it.
+        op_schema = schema.get("properties", {}).get("op", {})
+        assert op_schema.get("enum") == ["alpha", "beta"], (
+            f"op enum missing or wrong; got schema={op_schema!r}"
+        )


### PR DESCRIPTION
Fixes #435.

## Root cause

The telemetry wrap added in #431 puts a `functools.wraps`-decorated `*args, **kwargs` wrapper between FastMCP and every registered tool. For `<domain>_manage` rollups, the underlying `manage` closure has its `__annotations__` set post-hoc to a dynamically-built `Literal[...]` (the `op` enum) — see the rationale at `_meta_tool.py:142-145`.

On some Python / Pydantic combos (reproduced by two users on Windows 11 + Python 3.13 + Pydantic 2.13.4), FastMCP's `without_injected_parameters` → `typing.get_type_hints` → Pydantic `TypeAdapter` chain loses the `op` annotation when introspecting the wrapped function. Pydantic's `_arguments_schema` sees `op` in `inspect.signature(...)` (via `__wrapped__`) but not in `type_hints`, and crashes with `KeyError: 'op'` at server startup — before the first MCP request, before the lifespan even completes — so the editor sees the spawned `uvx` process die within the 5s grace window with no surfaced traceback.

The traceback that finally pinned this down (full chain in #435):

```
File ".../godot_ai/telemetry.py", line 794, in _apply
    return original(*decorator_args, **decorator_kwargs)(inst)
...
File ".../fastmcp/tools/function_parsing.py", line 201, in from_function
    input_type_adapter = get_cached_typeadapter(wrapper_fn)
...
File ".../pydantic/_internal/_generate_schema.py", line 2005, in _arguments_schema
    annotation = type_hints[name]
                 ~~~~~~~~~~^^^^^^
KeyError: 'op'
```

## Fix

Pin `wrapper.__signature__` to the wrapped function's signature and re-assign a fresh dict copy of `wrapper.__annotations__` so FastMCP can introspect the wrapper directly instead of chasing `__wrapped__` through `typing.get_type_hints`. Same defensive pattern `_meta_tool.py:146` already uses to bypass `from __future__ import annotations` forward-ref resolution — the wrap inherits whatever invariants the underlying closure already has.

## Regression test

`test_manage_tool_schema_builds_through_wrap` exercises the exact failing path: register a manage tool through `install_fastmcp_wraps` and force schema materialization via `list_tools()`. Asserts the `op` enum survives into the JSON schema. Pre-fix, this crashes with `KeyError: 'op'` on affected Python/Pydantic combos.

## Test plan

- [x] `pytest tests/unit/` — 741 passed locally on Python 3.11 + 3.13
- [x] Lint clean (`ruff check`)
- [x] Schema build for all 39 tools incl. all 20 `<domain>_manage` rollups works on Python 3.13
- [ ] Verify with #435 reporters once merged & 2.5.2 published
- [ ] Live smoke against `test_project/` (CI Godot tests cover the runtime path)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ec3xeSTwM2W6i5W2e1AUYR)_