### PR TITLE
Make script_handler deferred completion static to survive handler GC

### DIFF
--- a/plugin/addons/godot_ai/handlers/script_handler.gd
+++ b/plugin/addons/godot_ai/handlers/script_handler.gd
@@ -73,7 +73,7 @@ func create_script(params: Dictionary) -> Dictionary:
 	# overwrite the resource was already known to ResourceLoader, so reply now.
 	var request_id: String = params.get("_request_id", "")
 	if not existed_before and _connection != null and not request_id.is_empty():
-		_finish_create_script_deferred(request_id, path, data)
+		_finish_create_script_deferred(_connection, request_id, path, data)
 		return McpDispatcher.DEFERRED_RESPONSE
 
 	# Synchronous fallback: batch_execute (no request_id) and unit-test contexts
@@ -81,8 +81,25 @@ func create_script(params: Dictionary) -> Dictionary:
 	return {"data": data}
 
 
-func _finish_create_script_deferred(request_id: String, path: String, data: Dictionary) -> void:
-	var tree := _connection.get_tree()
+# `static` is load-bearing: the deferred completion captures no `self`, so the
+# coroutine survives even if the ScriptHandler RefCounted is freed mid-await.
+# Under concurrent script_create storms with editor_reload_plugin fired during
+# the burst, the handler instance is otherwise GC'd between `await` and resume,
+# producing "Resumed function '_finish_create_script_deferred()' after await,
+# but class instance is gone" errors and dropping the response. Keep this
+# function static and parameterise everything it needs explicitly — do not
+# reference instance state.
+static func _finish_create_script_deferred(
+	connection: McpConnection,
+	request_id: String,
+	path: String,
+	data: Dictionary,
+) -> void:
+	if not is_instance_valid(connection):
+		return
+	var tree := connection.get_tree()
+	if tree == null:
+		return
 	var deadline_ms := Time.get_ticks_msec() + _IMPORT_SETTLE_MAX_MSEC
 	# Let _dispatch() return DEFERRED_RESPONSE and register the request before
 	# this coroutine can send a committed result. ResourceLoader.exists(path)
@@ -100,17 +117,17 @@ func _finish_create_script_deferred(request_id: String, path: String, data: Dict
 	):
 		await tree.process_frame
 		frames += 1
-	# If the plugin tears down (_exit_tree frees _connection) during the await,
-	# is_instance_valid() goes false and we drop the response silently — the
-	# server's request timeout will surface the failure to the caller.
-	if not is_instance_valid(_connection):
+	# If the plugin tears down (_exit_tree frees the connection) during the
+	# await, is_instance_valid() goes false and we drop the response silently —
+	# the server's request timeout will surface the failure to the caller.
+	if not is_instance_valid(connection):
 		return
 	var payload := data.duplicate()
 	var settled := ResourceLoader.exists(path)
 	payload["import_settled"] = settled
 	payload["import_settle"] = "settled" if settled else "timeout"
 	payload["import_pending"] = not settled
-	_connection.send_deferred_response(request_id, {"data": payload})
+	connection.send_deferred_response(request_id, {"data": payload})
 
 
 func read_script(params: Dictionary) -> Dictionary:

--- a/test_project/tests/test_script.gd
+++ b/test_project/tests/test_script.gd
@@ -76,6 +76,28 @@ func test_create_script_basic() -> void:
 	DirAccess.remove_absolute(path)
 
 
+func test_finish_create_script_deferred_is_static_and_handles_null_connection() -> void:
+	## Under stress (many concurrent script_create + editor_reload_plugin
+	## mid-burst) the ScriptHandler RefCounted was being freed mid-await of
+	## _finish_create_script_deferred, producing "Resumed function ... after
+	## await, but class instance is gone" errors and dropping the response.
+	## The fix is to make the deferred completion a `static` function so the
+	## coroutine doesn't capture self.
+	##
+	## Calling the function directly via the Script resource exercises both
+	## guarantees in one go: if the function isn't `static`, the parser
+	## rejects this call site ("Cannot call non-static function ... directly,
+	## make an instance instead") and the whole test file fails to load. If
+	## it IS static, the null-connection branch must bail without awaiting or
+	## sending a deferred response — the safety net for teardown-time callers.
+	##
+	## The Python source-pin in tests/unit/test_script_create_import_settle.py
+	## also asserts the `static func` declaration at the source-text level.
+	var ScriptHandlerScript := preload("res://addons/godot_ai/handlers/script_handler.gd")
+	ScriptHandlerScript._finish_create_script_deferred(null, "req-x", "res://nope.gd", {})
+	assert_true(true, "Static call with null connection must not raise")
+
+
 func test_create_script_overwrite_omits_cleanup_hint() -> void:
 	## On overwrite the caller already had the file on disk; cleanup.rm would
 	## point them at user content, not just scratch — so the field is omitted.

--- a/tests/unit/test_script_create_import_settle.py
+++ b/tests/unit/test_script_create_import_settle.py
@@ -77,7 +77,7 @@ def test_finish_create_script_deferred_polls_resourceloader_with_bounded_loop() 
         "timeout, a committed file can still surface to callers as "
         "DEFERRED_TIMEOUT."
     )
-    deferred_block = get_func_block(source, "func _finish_create_script_deferred")
+    deferred_block = get_func_block(source, "static func _finish_create_script_deferred")
     assert "var deadline_ms := Time.get_ticks_msec() + _IMPORT_SETTLE_MAX_MSEC" in deferred_block
     assert "Time.get_ticks_msec() < deadline_ms" in deferred_block
     assert "ResourceLoader.exists(path)" in deferred_block, (
@@ -97,15 +97,16 @@ def test_finish_create_script_deferred_polls_resourceloader_with_bounded_loop() 
         "window and a committed write can still hit the dispatcher timeout (#324)."
     )
     # The reply must use send_deferred_response with a {"data": ...} payload.
-    assert "_connection.send_deferred_response(request_id" in deferred_block, (
+    assert "connection.send_deferred_response(request_id" in deferred_block, (
         "After settling, the handler must push the response over the "
         "connection's send_deferred_response — the dispatcher won't do it."
     )
     assert 'payload["import_settle"] = "settled" if settled else "timeout"' in deferred_block
     assert 'payload["import_pending"] = not settled' in deferred_block
     # Match the project_handler.stop_project pattern: drop the response if
-    # the plugin tore down during the await.
-    assert "is_instance_valid(_connection)" in deferred_block, (
+    # the plugin tore down during the await. The static refactor passes
+    # `connection` explicitly instead of relying on `self._connection`.
+    assert "is_instance_valid(connection)" in deferred_block, (
         "If _exit_tree fires during the await the connection is freed; the "
         "deferred reply must check is_instance_valid and bail silently."
     )
@@ -121,7 +122,7 @@ def test_create_script_reports_committed_status_even_when_import_wait_times_out(
         "plain safe retry."
     )
     assert '"import_settle": "already_known" if existed_before else "not_waited"' in source
-    deferred_block = get_func_block(source, "func _finish_create_script_deferred")
+    deferred_block = get_func_block(source, "static func _finish_create_script_deferred")
     assert 'payload["import_settle"] = "settled" if settled else "timeout"' in deferred_block, (
         "Deferred completion must distinguish import success from import-settle "
         "timeout while still returning a success payload for the committed file."
@@ -129,6 +130,38 @@ def test_create_script_reports_committed_status_even_when_import_wait_times_out(
     assert 'payload["import_pending"] = not settled' in deferred_block, (
         "When import settling times out, callers need an explicit import_pending "
         "flag instead of interpreting a transport timeout as write failure."
+    )
+
+
+def test_finish_create_script_deferred_is_static() -> None:
+    """Source-pin: the deferred completion must be a `static func`.
+
+    Under concurrent script_create storms (e.g. /tmp/shitstorm2.py) combined
+    with editor_reload_plugin firing during the burst, the ScriptHandler
+    RefCounted was being freed mid-await, producing "Resumed function
+    '_finish_create_script_deferred()' after await, but class instance is
+    gone" and dropping the deferred response. The fix is to declare the
+    coroutine `static` so it captures no `self` reference, surviving handler
+    GC. This source check prevents a silent revert.
+    """
+    source = SCRIPT_HANDLER.read_text(encoding="utf-8")
+    assert "static func _finish_create_script_deferred(" in source, (
+        "_finish_create_script_deferred must be declared `static` so the "
+        "deferred coroutine doesn't capture self. Without this, a handler "
+        "freed mid-await produces 'class instance is gone' errors and drops "
+        "the response."
+    )
+    # And the connection must be passed in explicitly, not pulled from self.
+    assert "connection: McpConnection," in source, (
+        "The static function must take the connection as an explicit "
+        "parameter — referencing self._connection would re-introduce the "
+        "implicit `self` capture the static refactor avoids."
+    )
+    # The caller in create_script must thread _connection through.
+    assert "_finish_create_script_deferred(_connection, request_id, path, data)" in source, (
+        "create_script must pass `_connection` explicitly to the static "
+        "deferred completion. A bare call with no args would silently "
+        "regress to depending on instance state."
     )
 
 


### PR DESCRIPTION
## Summary

- Make `_finish_create_script_deferred` a `static` function so the deferred coroutine doesn't capture `self`. The handler RefCounted can now be freed mid-await without producing "Resumed function ... after await, but class instance is gone" errors that drop the response.
- Pass `_connection` explicitly into the static function; add a null-connection guard at the top so teardown-time callers bail cleanly.
- Source-pin Python tests + a live GDScript regression test guard the refactor against silent revert.

## Background

A stress harness (20x concurrent `script_create` writing `.gd` files with `class_name` declarations, plus `filesystem_write_text` rewrites, `resource_create` saves, and `editor_reload_plugin` / `test_run` fired mid-burst) reproducibly spammed:

```
ERROR: Resumed function '_finish_create_script_deferred()' after await,
but class instance is gone.
At script: res://addons/godot_ai/handlers/script_handler.gd:94
```

Root cause: under concurrent `script_create` pressure + plugin reload, the `ScriptHandler` RefCounted is GC'd between `await tree.process_frame` and the coroutine's resumption. The defensive `is_instance_valid(_connection)` check downstream of the await never executes — Godot's coroutine machinery aborts because `self` is gone, not just `_connection`. The deferred reply is dropped and the dispatcher eventually times the request out, even though the file was committed to disk.

## Approach

Three options were on the table:

1. Hold a strong reference to the handler in `McpDispatcher._pending_deferred` for the lifetime of the request.
2. Stash a self-reference in a dispatcher-owned dict.
3. Eliminate the `self` dependency entirely.

**(3) is cleanest** — no dispatcher changes, no refcount juggling, and naturally handles plugin teardown (the coroutine sees `is_instance_valid(connection) == false` and bails silently). The function now references only its parameters and script-level `const`s.

## Test plan

- [x] `pytest tests/unit/test_script_create_import_settle.py -v` — all 6 source-pin assertions pass (1 new, 5 updated to track the `connection` parameter rename).
- [x] `pytest -q tests/unit` — 743 passed, 2 skipped, 0 failures.
- [x] `ruff check src/ tests/` — clean.
- [x] Godot headless import — no parse errors on the refactored script.
- [ ] Live editor: run the stress harness and confirm the "Resumed function ... after await" pattern no longer appears in the Godot log. (Crash itself is an engine reentrance bug filed separately upstream; this PR only addresses the plugin-side noise.)
- [ ] `test_run suite=script` against a live editor — exercises both new regression tests.

## Scope

This PR fixes only the await-leak. The underlying engine crash (recursive `EditorFileSystem::_update_script_classes` via `ProgressDialog::task_step` reentrance during mass concurrent `.gd` writes) is a Godot bug that needs to be filed upstream and is out of scope here.
