### PR TITLE
Fix game_logger.gd parse failure on fresh-project headless launches

### DIFF
--- a/plugin/addons/godot_ai/runtime/game_logger.gd
+++ b/plugin/addons/godot_ai/runtime/game_logger.gd
@@ -17,6 +17,16 @@ extends Logger
 ## and the host (game_helper.gd) flushes once per frame from the main
 ## thread, where EngineDebugger.send_message is safe to call.
 
+## `McpLogBacktrace` is published as a `class_name` on log_backtrace.gd, but a
+## freshly-launched game subprocess (no prior editor scan; e.g. CI launching
+## `--headless --path`) hits this autoload before the global class_name table
+## is populated, and parsing this script fails with
+## "Identifier 'McpLogBacktrace' not declared in the current scope". Using
+## `const preload` resolves the path at parse time and is independent of the
+## class_name registry — matches the project convention in CLAUDE.md
+## ("Internals … skip class_name entirely and load via const preload").
+const _LogBacktrace := preload("res://addons/godot_ai/utils/log_backtrace.gd")
+
 var _pending: Array = []
 var _mutex := Mutex.new()
 
@@ -41,7 +51,7 @@ func _log_error(
 	## location has nowhere structured to land for the game side, so we
 	## inline it into `text`. editor_logger keeps the resolved fields
 	## as structured columns instead.
-	var resolved := McpLogBacktrace.resolve_error(
+	var resolved := _LogBacktrace.resolve_error(
 		function, file, line, code, rationale, error_type, script_backtraces,
 	)
 	var loc := ""

--- a/tests/unit/test_game_logger_no_class_name_lookup.py
+++ b/tests/unit/test_game_logger_no_class_name_lookup.py
@@ -1,0 +1,56 @@
+"""Source-pin: game_logger.gd must not depend on the McpLogBacktrace
+class_name being globally registered.
+
+A freshly-launched game subprocess (no prior editor scan; e.g. CI launching
+`--headless --path` on a fresh worktree) hits the `game_helper.gd` autoload
+before the global class_name table is populated. If `game_logger.gd`
+references `McpLogBacktrace.resolve_error(...)` by its class_name, parsing
+that script fails with:
+
+    SCRIPT ERROR: Parse Error: Identifier "McpLogBacktrace" not declared in
+    the current scope.
+    at: GDScript::reload (res://addons/godot_ai/runtime/game_logger.gd:44)
+
+…and the entire game-side log-bridge fails to load. This breaks `print()`
+/ `printerr()` ferrying back to the editor for any user whose first launch
+of the project is headless (CI, fleet smoke).
+
+Fix: `const _LogBacktrace := preload("res://addons/godot_ai/utils/log_backtrace.gd")`
+in game_logger.gd, then call `_LogBacktrace.resolve_error(...)`. The path is
+resolved at parse time and is independent of the class_name registry.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[2] / "plugin" / "addons" / "godot_ai"
+GAME_LOGGER = PLUGIN_ROOT / "runtime" / "game_logger.gd"
+
+
+def test_game_logger_preloads_log_backtrace_by_path() -> None:
+    """The script must `const preload` log_backtrace.gd."""
+    source = GAME_LOGGER.read_text(encoding="utf-8")
+    assert 'preload("res://addons/godot_ai/utils/log_backtrace.gd")' in source, (
+        "game_logger.gd must `const`-preload log_backtrace.gd by path. "
+        "Relying on the McpLogBacktrace class_name fails when this script "
+        "is parsed in a game subprocess before the global class_name table "
+        "is populated (fresh-project headless launch)."
+    )
+
+
+def test_game_logger_does_not_reference_log_backtrace_class_name() -> None:
+    """No `McpLogBacktrace.` call sites — those re-introduce the bug."""
+    source = GAME_LOGGER.read_text(encoding="utf-8")
+    # Comments referencing the class name are fine (and the comment above the
+    # preload const explains the rationale). Code references — anywhere a
+    # `McpLogBacktrace.` method call could land — are not.
+    for lineno, raw in enumerate(source.splitlines(), start=1):
+        # Strip GDScript line comments (## or #) before the check so the
+        # rationale comment doesn't trip this assertion.
+        code = raw.split("#", 1)[0]
+        assert "McpLogBacktrace." not in code, (
+            f"game_logger.gd:{lineno} references `McpLogBacktrace.` in code: "
+            f"{raw.strip()!r}. Use the `_LogBacktrace` preload const instead — "
+            "see the rationale in the file's header comment."
+        )


### PR DESCRIPTION
## Summary

- Switch `game_logger.gd` from the `McpLogBacktrace` class_name lookup to a `const preload` of `log_backtrace.gd` by path.
- The `class_name` declaration on `log_backtrace.gd` is preserved (compatibility surface; matches CLAUDE.md "Never delete a published class_name declaration").
- Source-pin test prevents the bug from being reintroduced.

## Bug

A freshly-launched Godot project running headless (CI, fresh worktree, anywhere the editor hasn't scanned yet) hits the `game_helper.gd` autoload before the global class_name table is populated. Parsing `game_logger.gd` then fails:

```
SCRIPT ERROR: Parse Error: Identifier "McpLogBacktrace" not declared in the current scope.
          at: GDScript::reload (res://addons/godot_ai/runtime/game_logger.gd:44)
          GDScript backtrace (most recent call first):
              [0] _ready (res://addons/godot_ai/runtime/game_helper.gd:62)
SCRIPT ERROR: Parse Error: Cannot infer the type of "resolved" variable because the value doesn't have a set type.
ERROR: Failed to load script "res://addons/godot_ai/runtime/game_logger.gd" with error "Parse error".
SCRIPT ERROR: Invalid call. Nonexistent function 'new' in base 'GDScript'.
          at: _ready (res://addons/godot_ai/runtime/game_helper.gd:64)
```

…and the whole game-side log bridge fails to load. `print()` / `printerr()` in user game code no longer ferry back to the editor.

## Reproducer

```bash
git worktree add /tmp/fresh-worktree main
/Applications/Godot_mono.app/Contents/MacOS/Godot --headless --path /tmp/fresh-worktree/test_project --quit-after 15 2>&1 | grep -E "McpLogBacktrace|Failed to load"
```

Before this PR: 4 parse errors. After: clean.

The bug doesn't surface when the editor has scanned the project first because the class_name cache exists in `.godot/global_script_class_cache.cfg` by then — that's why most users haven't hit it.

## Approach

`McpLogBacktrace` is used as a static-method namespace in `game_logger.gd`, not as a type annotation. Per the project convention in CLAUDE.md:

> Internals only used inside the plugin (handlers, presets/values, test stubs) skip `class_name` entirely and load via `const X := preload("res://addons/godot_ai/...")` from `plugin.gd` and consumers.

So the local fix is to switch this one call site to a `const preload`. Path resolution then happens at parse time, independent of the class_name registry.

I left `editor_logger.gd` alone — it runs in the editor process where the class_name cache is populated before autoloads load, so it doesn't hit this failure mode in practice. Don't over-refactor what isn't broken.

## Test plan

- [x] `pytest tests/unit/test_game_logger_no_class_name_lookup.py -v` — 2 new source-pin assertions pass.
- [x] `pytest -q tests/unit` — 744 passed, 2 skipped.
- [x] `ruff check src/ tests/` — clean.
- [x] Reproducer above: fresh-worktree headless launch — clean (was 4 errors before).
