### PR TITLE
Add telemetry toggle to gui and cleanup local files when telemetry is disabled

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -62,8 +62,18 @@ Allowlist (mirrored in `plugin/addons/godot_ai/telemetry.gd` and
 ## Opting out
 
 Telemetry is **on by default** — a fresh install posts anonymous usage
-events to the maintainers' endpoint. To opt out, set either environment
-variable to `true` / `1` / `yes` / `on`:
+events to the maintainers' endpoint. There are two ways to opt out:
+
+### Via the editor UI
+
+Open the "Clients & Settings" popup from the Godot AI dock, go to the
+"Settings" tab, and uncheck the "Telemetry" checkbox. Click "Apply &
+Restart Server" to apply the change. The preference is persisted in
+EditorSettings and survives across editor restarts.
+
+### Via environment variable
+
+Set either environment variable to `true` / `1` / `yes` / `on`:
 
 ```bash
 # Godot-AI-specific
@@ -73,10 +83,22 @@ export GODOT_AI_DISABLE_TELEMETRY=true
 export DISABLE_TELEMETRY=true
 ```
 
-Effect: the collector enters disabled mode. No records are enqueued, no
-UUID is generated, no worker thread is spawned, and no data directory
-is created. The plugin-side helper honors the same variables and stops
-buffering events. Opt-out is fully side-effect-free.
+If either of the above environment variables are enabled, the opt-out is
+saved to Godot's editor settings and will persist between runs. Similarly,
+if an environment variable is explicitly set and disabled, that will be
+persisted to the editor settings.
+
+If telemetry is disabled, any local telemetry files are removed upon server
+startup.
+
+### Effect
+
+On opt-out (whether via UI or env var): the collector enters disabled
+mode. No records are enqueued, no UUID is generated, no worker thread is
+spawned, and no data directory is created. Existing local telemetry
+files (`customer_uuid.txt`, `milestones.json`) are deleted on the next
+server startup. The plugin-side helper honors the same variables and
+stops buffering events. Opt-out is fully side-effect-free.
 
 ## Endpoint configuration
 

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -1936,6 +1936,14 @@ func _on_tools_reset() -> void:
 	for id in _tools_domain_checkboxes:
 		var chk: CheckBox = _tools_domain_checkboxes[id]
 		chk.set_pressed_no_signal(true)
+	## Restore telemetry to its default (on) too, so "Reset to defaults"
+	## consistently restores every setting on this tab. Skip when the
+	## toggle is disabled because an env var is locking the value — the
+	## env var wins, and we shouldn't create a dirty pending state the
+	## user can't apply from the UI.
+	if _telemetry_toggle != null and not _telemetry_toggle.disabled:
+		_telemetry_pending_enabled = true
+		_telemetry_toggle.set_pressed_no_signal(true)
 	_refresh_tools_ui_state()
 
 

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -65,7 +65,7 @@ var _clients_window: Window
 var _dev_mode_toggle: CheckButton
 var _install_label: Label
 
-# Tools tab (secondary window, Tab 2) — domain-exclusion UI for clients
+# Settings tab (secondary window, Tab 2) — domain-exclusion UI for clients
 # that cap total tool count (Antigravity: 100). Pending set is mutated by
 # checkbox clicks; saved set reflects what the spawned server actually
 # sees. `Apply & Restart Server` writes pending → setting and triggers a
@@ -78,6 +78,9 @@ var _tools_apply_btn: Button
 var _tools_reset_btn: Button
 var _tools_dirty_warning: Label
 var _tools_close_confirm: ConfirmationDialog
+var _telemetry_toggle: CheckButton
+var _telemetry_pending_enabled: bool = true
+var _telemetry_saved_enabled: bool = true
 
 ## Per-client UI handles, keyed by client id. Each entry holds the row's
 ## status dot, configure button, remove button, manual-command panel + text.
@@ -377,6 +380,15 @@ func _on_redock() -> void:
 		win.close_requested.emit()
 
 
+func _build_margin_container(margin: int = 12) -> MarginContainer:
+	var marginContainer := MarginContainer.new()
+	marginContainer.add_theme_constant_override("margin_left", margin)
+	marginContainer.add_theme_constant_override("margin_right", margin)
+	marginContainer.add_theme_constant_override("margin_top", margin)
+	marginContainer.add_theme_constant_override("margin_bottom", margin)
+	return marginContainer
+
+
 func _build_ui() -> void:
 	add_theme_constant_override("separation", 8)
 
@@ -558,7 +570,7 @@ func _build_ui() -> void:
 	clients_row.add_child(clients_refresh_btn)
 
 	var clients_open_btn := Button.new()
-	clients_open_btn.text = "Clients & Tools"
+	clients_open_btn.text = "Clients & Settings"
 	clients_open_btn.tooltip_text = "Open the MCP settings window — configure AI clients or disable tool domains to fit under a client's hard tool-count cap (e.g. Antigravity's 100)."
 	clients_open_btn.pressed.connect(_on_open_clients_window)
 	clients_row.add_child(clients_open_btn)
@@ -582,34 +594,27 @@ func _build_ui() -> void:
 	add_child(_drift_banner)
 
 	_clients_window = Window.new()
-	_clients_window.title = "MCP Clients & Tools"
-	_clients_window.min_size = Vector2i(560, 460)
+	_clients_window.title = "MCP Clients & Settings"
+	_clients_window.min_size = Vector2i(560, 460) * EditorInterface.get_editor_scale()
 	_clients_window.visible = false
 	_clients_window.close_requested.connect(_on_clients_window_close_requested)
 	add_child(_clients_window)
-
-	var window_margin := MarginContainer.new()
-	window_margin.anchor_right = 1.0
-	window_margin.anchor_bottom = 1.0
-	window_margin.add_theme_constant_override("margin_left", 12)
-	window_margin.add_theme_constant_override("margin_right", 12)
-	window_margin.add_theme_constant_override("margin_top", 12)
-	window_margin.add_theme_constant_override("margin_bottom", 12)
-	_clients_window.add_child(window_margin)
 
 	## Two-tab secondary window: Clients (existing per-client rows) and Tools
 	## (domain-exclusion checkboxes for clients that cap total tool count,
 	## like Antigravity at 100). Adding a third tab is one more _build_*_tab
 	## call and a set_tab_title line — no surgery on the rest of the window.
 	var tabs := TabContainer.new()
-	tabs.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	tabs.size_flags_vertical = Control.SIZE_EXPAND_FILL
-	window_margin.add_child(tabs)
+	tabs.anchor_right = 1.0
+	tabs.anchor_bottom = 1.0
+	_clients_window.add_child(tabs)
 
 	var clients_tab := VBoxContainer.new()
-	clients_tab.name = "Clients"
 	clients_tab.add_theme_constant_override("separation", 8)
-	tabs.add_child(clients_tab)
+	var clients_margin := _build_margin_container()
+	clients_margin.name = "Clients"
+	clients_margin.add_child(clients_tab)
+	tabs.add_child(clients_margin)
 
 	_client_configure_all_btn = Button.new()
 	_client_configure_all_btn.text = "Configure all"
@@ -1007,7 +1012,72 @@ func _refresh_server_label() -> void:
 	_server_label.text = "WS: %d  HTTP: %d" % [ws_port, ClientConfigurator.http_port()]
 
 
+# --- Telemetry setting persistence ---
+
+
+func _env_truthy(var_name: String) -> bool:
+	var val: String = OS.get_environment(var_name).strip_edges().to_lower()
+	return val in ["1", "true", "yes", "on"]
+
+
+## Returns true if GODOT_AI_DISABLE_TELEMETRY or DISABLE_TELEMETRY is set
+## to a truthy value, false if either is set and non-truthy, null if neither
+## env var is present at all.
+func _is_telemetry_disabled_via_env() -> Variant:
+	var disabled: bool = _env_truthy("GODOT_AI_DISABLE_TELEMETRY") or _env_truthy("DISABLE_TELEMETRY")
+	if OS.has_environment("GODOT_AI_DISABLE_TELEMETRY") or OS.has_environment("DISABLE_TELEMETRY"):
+		return disabled
+	return null
+
+
+## Reads the telemetry preference, applying env-var override when present.
+## Initialises _telemetry_pending_enabled / _telemetry_saved_enabled and
+## sets the checkbox state + locked tooltip. Call after _telemetry_toggle
+## has been created.
+func _load_telemetry_setting() -> void:
+	var es := EditorInterface.get_editor_settings()
+	var env_disabled = _is_telemetry_disabled_via_env()
+
+	var enabled: bool
+	if env_disabled != null:
+		## Env var present: resolve and save to EditorSettings so future sessions without
+		## the env var honour the last-set value.
+		enabled = not bool(env_disabled)
+		if es != null:
+			es.set_setting("godot_ai/telemetry_enabled", enabled)
+	else:
+		## No env var: read (or create) the EditorSettings key.
+		if es != null and es.has_setting("godot_ai/telemetry_enabled"):
+			enabled = bool(es.get_setting("godot_ai/telemetry_enabled"))
+		else:
+			enabled = true
+			if es != null:
+				es.set_setting("godot_ai/telemetry_enabled", true)
+
+	_telemetry_pending_enabled = enabled
+	_telemetry_saved_enabled = enabled
+
+	if _telemetry_toggle == null:
+		return
+	_telemetry_toggle.set_pressed_no_signal(enabled)
+	if env_disabled != null:
+		_telemetry_toggle.disabled = true
+		_telemetry_toggle.tooltip_text = (
+			"Telemetry is controlled by an environment variable "
+			+ "(GODOT_AI_DISABLE_TELEMETRY / DISABLE_TELEMETRY)."
+		)
+	else:
+		_telemetry_toggle.disabled = false
+		_telemetry_toggle.tooltip_text = ""
+
+
+func _on_telemetry_toggled(pressed: bool) -> void:
+	_telemetry_pending_enabled = pressed
+	_refresh_tools_ui_state()
+
+
 # --- Dev mode persistence ---
+
 
 func _load_dev_mode() -> bool:
 	# Default OFF for every install (including dev checkouts). Contributors
@@ -1046,14 +1116,22 @@ func _apply_dev_mode_visibility() -> void:
 
 # --- Button handlers ---
 
+
+func _do_plugin_reload():
+	EditorInterface.set_plugin_enabled("res://addons/godot_ai/plugin.cfg", false)
+	EditorInterface.set_plugin_enabled("res://addons/godot_ai/plugin.cfg", true)
+
+
 func _on_reload_plugin() -> void:
 	# Persist a pending plugin_reload telemetry event *before* the
 	# disable kills the live WebSocket — the new plugin's _enter_tree
 	# flushes it via `_telemetry.flush_pending_plugin_reload()`.
 	Telemetry.record_pending_plugin_reload("dock_button")
-	# Toggle plugin off/on to reload all GDScript
-	EditorInterface.set_plugin_enabled("res://addons/godot_ai/plugin.cfg", false)
-	EditorInterface.set_plugin_enabled("res://addons/godot_ai/plugin.cfg", true)
+	# Defer the toggle so any in-flight input event finishes propagating
+	# before the dock (and its Window children) leave the tree. Calling
+	# set_plugin_enabled synchronously from a button press frees the
+	# viewport mid-dispatch.
+	_do_plugin_reload.call_deferred()
 
 
 ## Setup-section "Server" row: always report the TRUE running server
@@ -1605,14 +1683,18 @@ func _on_open_clients_window() -> void:
 	_clients_window.popup_centered(Vector2i(640, 600))
 
 
+func _settings_are_dirty() -> bool:
+	return _tools_pending_excluded != _tools_saved_excluded or _telemetry_pending_enabled != _telemetry_saved_enabled
+
+
 func _on_clients_window_close_requested() -> void:
 	if _clients_window == null:
 		return
-	## If the user has checked/unchecked domains without applying, a close
-	## would silently throw the pending state away. Prompt; if they confirm
-	## discard, reset pending → saved so the window shows the persisted
+	## If the user has unapplied settings, a close would silently throw the
+	## pending state away. Prompt before discarding current options and if
+	## they confirm, reset pending → saved so the window shows the persisted
 	## state the next time they open it.
-	if _tools_pending_excluded != _tools_saved_excluded:
+	if _settings_are_dirty():
 		_show_tools_close_confirm()
 		return
 	_clients_window.hide()
@@ -1625,9 +1707,11 @@ func _build_tools_tab(tabs: TabContainer) -> void:
 	## `_reset_tools_pending_from_setting()` re-syncs checkbox state from the
 	## saved setting each time the window opens.
 	var tools_tab := VBoxContainer.new()
-	tools_tab.name = "Tools"
 	tools_tab.add_theme_constant_override("separation", 8)
-	tabs.add_child(tools_tab)
+	var tools_margin := _build_margin_container()
+	tools_margin.name = "Settings"
+	tools_margin.add_child(tools_tab)
+	tabs.add_child(tools_margin)
 
 	var intro := Label.new()
 	intro.text = (
@@ -1643,7 +1727,7 @@ func _build_tools_tab(tabs: TabContainer) -> void:
 	var count_row := HBoxContainer.new()
 	count_row.add_theme_constant_override("separation", 8)
 	var count_header := Label.new()
-	count_header.text = "Enabled:"
+	count_header.text = "Tools Enabled:"
 	count_header.add_theme_color_override("font_color", COLOR_MUTED)
 	count_row.add_child(count_header)
 	_tools_count_label = Label.new()
@@ -1698,6 +1782,19 @@ func _build_tools_tab(tabs: TabContainer) -> void:
 	_tools_domain_checkboxes.clear()
 	for entry in ToolCatalog.DOMAINS:
 		_build_tools_domain_row(grid, entry)
+
+	tools_tab.add_child(HSeparator.new())
+
+	var telemetry_row := HBoxContainer.new()
+	telemetry_row.add_theme_constant_override("separation", 8)
+	var telemetry_label := Label.new()
+	telemetry_label.text = "Telemetry"
+	telemetry_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	telemetry_row.add_child(telemetry_label)
+	_telemetry_toggle = CheckButton.new()
+	_telemetry_toggle.toggled.connect(_on_telemetry_toggled)
+	telemetry_row.add_child(_telemetry_toggle)
+	tools_tab.add_child(telemetry_row)
 
 	tools_tab.add_child(HSeparator.new())
 
@@ -1786,6 +1883,9 @@ func _reset_tools_pending_from_setting() -> void:
 		## `set_pressed_no_signal` — mutating programmatically should not
 		## fire the toggled handler, which would mutate pending back.
 		chk.set_pressed_no_signal(_tools_pending_excluded.find(id) == -1)
+	## Also reset telemetry pending state from the persisted setting.
+	if _telemetry_toggle != null:
+		_load_telemetry_setting()
 
 
 func _on_tools_domain_toggled(pressed: bool, domain_id: String) -> void:
@@ -1804,7 +1904,7 @@ func _refresh_tools_ui_state() -> void:
 	var enabled := ToolCatalog.enabled_tool_count(_tools_pending_excluded)
 	var total := ToolCatalog.total_tool_count()
 	_tools_count_label.text = "%d / %d" % [enabled, total]
-	var dirty := _tools_pending_excluded != _tools_saved_excluded
+	var dirty := _settings_are_dirty()
 	_tools_dirty_warning.visible = dirty
 	_tools_apply_btn.disabled = not dirty
 	## Color the count when the user is over Antigravity's cap — a soft
@@ -1821,7 +1921,9 @@ func _on_tools_apply() -> void:
 	var es := EditorInterface.get_editor_settings()
 	if es != null:
 		es.set_setting(ClientConfigurator.SETTING_EXCLUDED_DOMAINS, canonical_excluded)
+		es.set_setting("godot_ai/telemetry_enabled", _telemetry_pending_enabled)
 	_tools_saved_excluded = _tools_pending_excluded.duplicate()
+	_telemetry_saved_enabled = _telemetry_pending_enabled
 	_refresh_tools_ui_state()
 	## Plugin reload respawns the server with the new `--exclude-domains`
 	## flag (see `plugin.gd::_build_server_flags`). Mirrors the port-change

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -384,6 +384,27 @@ static func _live_package_path_for_message(live: Dictionary) -> String:
 
 # ---- start_server / spawn watch / respawn -----------------------------
 
+
+## Sets GODOT_AI_DISABLE_TELEMETRY in the process environment for the
+## upcoming OS.create_process call if: (a) neither GODOT_AI_DISABLE_TELEMETRY
+## nor DISABLE_TELEMETRY is already set, and (b) the EditorSettings key
+## "godot_ai/telemetry_enabled" is set to false. Returns true if the var was
+## injected so the caller can unset it after spawning.
+func _inject_telemetry_env() -> bool:
+	if OS.has_environment("GODOT_AI_DISABLE_TELEMETRY") or OS.has_environment("DISABLE_TELEMETRY"):
+		return false
+	var es := EditorInterface.get_editor_settings()
+	var telemetry_enabled: bool = (
+		bool(es.get_setting("godot_ai/telemetry_enabled"))
+		if es != null and es.has_setting("godot_ai/telemetry_enabled")
+		else true
+	)
+	if not telemetry_enabled:
+		OS.set_environment("GODOT_AI_DISABLE_TELEMETRY", "true")
+		return true
+	return false
+
+
 ## Branch table (recorded version is the "is this ours?" signal — uvx
 ## launcher PIDs go stale; #135/#137):
 ##   port free                                -> spawn fresh, record PID
@@ -495,6 +516,8 @@ func start_server() -> void:
 		push_warning("MCP | port %d is reserved by Windows (Hyper-V / WSL2 / Docker)" % port)
 		return
 
+	var injected_telemetry_env := _inject_telemetry_env()
+
 	## PYTHONPATH handling for dev checkouts: when the editor is launched
 	## against a worktree whose `src/godot_ai/__version__` differs from the
 	## root repo's editable install, the dev-venv python's `sitecustomize`
@@ -536,6 +559,9 @@ func start_server() -> void:
 			OS.unset_environment("PYTHONPATH")
 		else:
 			OS.set_environment("PYTHONPATH", prev_pythonpath)
+
+	if injected_telemetry_env:
+		OS.unset_environment("GODOT_AI_DISABLE_TELEMETRY")
 
 	if spawned_pid > 0:
 		_server_spawn_ms = Time.get_ticks_msec()
@@ -604,7 +630,10 @@ func respawn_with_refresh() -> void:
 	args.append_array(_host._build_server_flags(ClientConfigurator.http_port(), int(_host._resolved_ws_port)))
 	_host._clear_pid_file()
 	_host._log_buffer.log("retrying with --refresh (PyPI index may be stale)")
+	var injected_telemetry_env := _inject_telemetry_env()
 	_server_pid = OS.create_process(cmd, args)
+	if injected_telemetry_env:
+		OS.unset_environment("GODOT_AI_DISABLE_TELEMETRY")
 	var spawn_pid := int(_server_pid)
 	if spawn_pid > 0:
 		_server_spawn_ms = Time.get_ticks_msec()

--- a/src/godot_ai/telemetry.py
+++ b/src/godot_ai/telemetry.py
@@ -154,6 +154,7 @@ class TelemetryConfig:
 
     def __init__(self) -> None:
         self.enabled = not self._is_disabled_via_env()
+        logger.info(f"Telemetry {['disabled', 'enabled'][self.enabled]}")
         ## allow_loopback must be resolved before _resolve_endpoint(), which
         ## reads it to decide whether to accept http://127.0.0.1 endpoints.
         self.allow_loopback = self._env_truthy("GODOT_AI_TELEMETRY_ALLOW_LOOPBACK")
@@ -172,6 +173,8 @@ class TelemetryConfig:
             self.data_dir = self._get_data_directory()
             self.uuid_file = self.data_dir / "customer_uuid.txt"
             self.milestones_file = self.data_dir / "milestones.json"
+        else:
+            self._cleanup_local_files()
 
         self.session_id = str(uuid.uuid4())
 
@@ -227,19 +230,40 @@ class TelemetryConfig:
         return True
 
     @staticmethod
-    def _get_data_directory() -> Path:
+    def _resolve_data_directory() -> Path:
+        """Resolve data directory path without creating it."""
         if os.name == "nt":  # Windows
             base = Path(os.environ.get("APPDATA", str(Path.home() / "AppData" / "Roaming")))
         elif sys.platform == "darwin":
             base = Path.home() / "Library" / "Application Support"
         else:
             base = Path(os.environ.get("XDG_DATA_HOME", str(Path.home() / ".local" / "share")))
-        data_dir = base / "godot-ai"
+        return base / "godot-ai"
+
+    @staticmethod
+    def _get_data_directory() -> Path:
+        """Return data directory path, creating the directory and parent directories as needed."""
+        data_dir = TelemetryConfig._resolve_data_directory()
         try:
             data_dir.mkdir(parents=True, exist_ok=True)
         except OSError as exc:
             logger.debug("Telemetry data dir %s unwritable: %s", data_dir, exc)
         return data_dir
+
+    def _cleanup_local_files(self) -> None:
+        """Best-effort deletion of persisted telemetry files on opt-out."""
+        try:
+            data_dir = self._resolve_data_directory()
+            if not data_dir.exists():
+                return
+        except Exception:
+            return
+
+        for filename in ("customer_uuid.txt", "milestones.json"):
+            try:
+                (data_dir / filename).unlink(missing_ok=True)
+            except OSError as exc:
+                logger.warning("Could not remove telemetry file %s: %s", filename, exc)
 
 
 class TelemetryCollector:
@@ -417,9 +441,7 @@ class TelemetryCollector:
             ## drop every subsequent record silently. Without the
             ## one-shot flag, a busy session would flood debug logs.
             if not self._endpoint_unset_logged:
-                logger.debug(
-                    "Telemetry endpoint unset; dropping records (logged once)"
-                )
+                logger.debug("Telemetry endpoint unset; dropping records (logged once)")
                 self._endpoint_unset_logged = True
             return
 

--- a/test_project/tests/test_telemetry_setting.gd
+++ b/test_project/tests/test_telemetry_setting.gd
@@ -1,0 +1,70 @@
+@tool
+extends McpTestSuite
+
+## Tests that the EditorSettings key "godot_ai/telemetry_enabled" can be read
+## and written correctly. This is the storage-layer check written before the
+## UI code exists.
+
+func suite_name() -> String:
+	return "telemetry_setting"
+
+
+const SETTING_KEY := "godot_ai/telemetry_enabled"
+
+## Instance var to preserve the real setting value across setup/teardown.
+var _original_value: Variant = null
+var _had_setting: bool = false
+
+
+func suite_setup(_ctx: Dictionary) -> void:
+	## Preserve whatever the real setting is before tests mutate it.
+	var es := EditorInterface.get_editor_settings()
+	_had_setting = es.has_setting(SETTING_KEY)
+	if _had_setting:
+		_original_value = es.get_setting(SETTING_KEY)
+
+
+func suite_teardown() -> void:
+	## Restore original state so tests don't leave the editor in a changed state.
+	var es := EditorInterface.get_editor_settings()
+	if not _had_setting:
+		## Setting didn't exist before tests ran — remove it if we added it.
+		## EditorSettings has no erase_setting; setting to null removes it in Godot 4.
+		if es.has_setting(SETTING_KEY):
+			es.set_setting(SETTING_KEY, null)
+	else:
+		es.set_setting(SETTING_KEY, _original_value)
+
+
+func test_setting_defaults_true_when_absent() -> void:
+	## Simulate what _load_telemetry_setting does on first run: if absent, write true.
+	var es := EditorInterface.get_editor_settings()
+	## Clear any existing value so we can test the absent-setting path.
+	if es.has_setting(SETTING_KEY):
+		es.set_setting(SETTING_KEY, null)
+	## After clearing, check absence — note: set_setting(null) may or may not
+	## remove the key depending on Godot version. Work around: skip directly to
+	## the init logic assertion.
+	if not es.has_setting(SETTING_KEY):
+		es.set_setting(SETTING_KEY, true)
+	assert_true(bool(es.get_setting(SETTING_KEY)), "absent setting should resolve to true after first-run init")
+
+
+func test_setting_persists_false() -> void:
+	var es := EditorInterface.get_editor_settings()
+	es.set_setting(SETTING_KEY, false)
+	assert_true(not bool(es.get_setting(SETTING_KEY)), "false should persist")
+
+
+func test_setting_persists_true() -> void:
+	var es := EditorInterface.get_editor_settings()
+	es.set_setting(SETTING_KEY, true)
+	assert_true(bool(es.get_setting(SETTING_KEY)), "true should persist")
+
+
+func test_setting_roundtrip_false_then_true() -> void:
+	var es := EditorInterface.get_editor_settings()
+	es.set_setting(SETTING_KEY, false)
+	assert_false(bool(es.get_setting(SETTING_KEY)), "write false then read back false")
+	es.set_setting(SETTING_KEY, true)
+	assert_true(bool(es.get_setting(SETTING_KEY)), "write true then read back true")

--- a/test_project/tests/test_telemetry_setting.gd.uid
+++ b/test_project/tests/test_telemetry_setting.gd.uid
@@ -1,0 +1,1 @@
+uid://bmqeg1jhe47u0

--- a/tests/integration/_self_update_fixture.py
+++ b/tests/integration/_self_update_fixture.py
@@ -285,9 +285,7 @@ def extract_addon_from_zip(zip_path: Path, target_addon: Path) -> None:
             # drive component (which would make `target_addon / rel` discard
             # the prefix and write outside the fixture).
             if "\\" in info.filename:
-                raise ValueError(
-                    f"Refusing unsafe zip entry {info.filename!r}: contains backslash"
-                )
+                raise ValueError(f"Refusing unsafe zip entry {info.filename!r}: contains backslash")
             rel = PurePosixPath(info.filename).relative_to("addons/godot_ai")
             if rel.is_absolute() or any(part in ("", ".", "..") for part in rel.parts):
                 raise ValueError(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -22,8 +22,8 @@ from godot_ai import telemetry as tel
 
 @pytest.fixture
 def isolated_data_dir(monkeypatch, tmp_path: Path) -> Path:
-    """Force ``TelemetryConfig._get_data_directory`` into a tmp_path,
-    drop any inherited opt-out env vars (CI workflows / conftest.py
+    """Force ``TelemetryConfig._get_data_directory`` and ``_resolve_data_directory``
+    into a tmp_path, drop any inherited opt-out env vars (CI workflows / conftest.py
     set them globally), force an invalid endpoint so unmocked sends
     cannot reach production, and reset the module-level collector
     singleton before and after the test.
@@ -35,6 +35,11 @@ def isolated_data_dir(monkeypatch, tmp_path: Path) -> Path:
     monkeypatch.delenv("DISABLE_TELEMETRY", raising=False)
     monkeypatch.setenv("GODOT_AI_TELEMETRY_ENDPOINT", "ftp://test-leak-guard.invalid/")
     monkeypatch.setattr(tel.TelemetryConfig, "_get_data_directory", lambda self: tmp_path)
+    monkeypatch.setattr(
+        tel.TelemetryConfig,
+        "_resolve_data_directory",
+        staticmethod(lambda: tmp_path),
+    )
     tel.reset_telemetry()
     yield tmp_path
     tel.reset_telemetry()

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -145,6 +145,52 @@ class TestTelemetryConfig:
         assert tel.TelemetryConfig().timeout == tel.TelemetryConfig.DEFAULT_TIMEOUT
 
 
+class TestTelemetryConfigCleanup:
+    """TelemetryConfig deletes persisted files when telemetry is disabled."""
+
+    def test_cleanup_deletes_existing_files(
+        self, monkeypatch, clean_env, isolated_data_dir: Path
+    ) -> None:
+        """Both persisted files are removed when opt-out is active."""
+        monkeypatch.setenv("GODOT_AI_DISABLE_TELEMETRY", "true")
+        # Pre-create the files so cleanup has something to delete.
+        (isolated_data_dir / "customer_uuid.txt").write_text("fake-uuid")
+        (isolated_data_dir / "milestones.json").write_text("{}")
+
+        tel.TelemetryConfig()  # disabled path → cleanup runs
+
+        assert not (isolated_data_dir / "customer_uuid.txt").exists()
+        assert not (isolated_data_dir / "milestones.json").exists()
+
+    def test_cleanup_is_noop_when_files_absent(
+        self, monkeypatch, clean_env, isolated_data_dir: Path
+    ) -> None:
+        """No error when files don't exist (fresh opt-out)."""
+        monkeypatch.setenv("GODOT_AI_DISABLE_TELEMETRY", "true")
+        # Ensure files are absent.
+        for name in ("customer_uuid.txt", "milestones.json"):
+            (isolated_data_dir / name).unlink(missing_ok=True)
+
+        config = tel.TelemetryConfig()  # must not raise
+        assert config.enabled is False
+
+    def test_cleanup_logs_warning_on_oserror(
+        self, monkeypatch, clean_env, isolated_data_dir: Path
+    ) -> None:
+        """A deletion failure logs a warning and does not propagate."""
+        monkeypatch.setenv("GODOT_AI_DISABLE_TELEMETRY", "true")
+        uuid_file = isolated_data_dir / "customer_uuid.txt"
+        uuid_file.write_text("fake-uuid")
+
+        def _bad_unlink(self_path, missing_ok=False):  # noqa: ARG001
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(type(uuid_file), "unlink", _bad_unlink)
+        # Should complete without raising:
+        config = tel.TelemetryConfig()
+        assert config.enabled is False
+
+
 # --- TelemetryCollector --------------------------------------------------
 
 

--- a/tests/unit/test_telemetry_platform.py
+++ b/tests/unit/test_telemetry_platform.py
@@ -1,0 +1,124 @@
+"""Unit tests for platform-specific telemetry code paths.
+
+These tests intentionally avoid the isolated_data_dir fixture so they
+can exercise the real _resolve_data_directory and _cleanup_local_files
+implementations without mocking.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from godot_ai import telemetry as tel
+
+
+@pytest.fixture
+def clean_env(monkeypatch) -> None:
+    for name in (
+        "GODOT_AI_DISABLE_TELEMETRY",
+        "DISABLE_TELEMETRY",
+        "GODOT_AI_TELEMETRY_ENDPOINT",
+        "GODOT_AI_TELEMETRY_TIMEOUT",
+        "GODOT_AI_TELEMETRY_ALLOW_LOOPBACK",
+        "APPDATA",
+        "XDG_DATA_HOME",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+class TestResolveDataDirectory:
+    """Tests for the platform-specific data directory resolution."""
+
+    def test_windows_uses_appdata(self, monkeypatch, clean_env) -> None:
+        """Windows uses APPDATA environment variable."""
+        monkeypatch.setenv("APPDATA", "C:\\Users\\Test\\AppData\\Roaming")
+
+        class MockPath:
+            def __init__(self, path_str):
+                self._path = path_str
+
+            def __truediv__(self, other):
+                return MockPath(f"{self._path}/{other}")
+
+            def __str__(self):
+                return self._path
+
+            @property
+            def name(self):
+                return self._path.split("/")[-1]
+
+            @staticmethod
+            def home():
+                return MockPath("/home/test")
+
+        with patch("godot_ai.telemetry.os.name", "nt"):
+            with patch("godot_ai.telemetry.Path", MockPath):
+                result = tel.TelemetryConfig._resolve_data_directory()
+        assert result.name == "godot-ai"
+        assert "Roaming" in str(result)
+
+    def test_windows_fallback_to_home(self, monkeypatch, clean_env) -> None:
+        """Windows falls back to user's home if APPDATA is unset."""
+        monkeypatch.setenv("APPDATA", "")
+        with patch("godot_ai.telemetry.Path.home", return_value=Path("C:\\Users\\Test")):
+            result = tel.TelemetryConfig._resolve_data_directory()
+        assert "godot-ai" in str(result)
+        assert "Test" in str(result)
+
+    def test_macos_uses_library_application_support(self, monkeypatch, clean_env) -> None:
+        """macOS uses ~/Library/Application Support."""
+        with patch("godot_ai.telemetry.sys.platform", "darwin"):
+            result = tel.TelemetryConfig._resolve_data_directory()
+        assert "Library" in str(result)
+        assert "Application Support" in str(result)
+        assert result.name == "godot-ai"
+
+    def test_linux_uses_xdg_data_home(self, monkeypatch, clean_env) -> None:
+        """Linux uses XDG_DATA_HOME when set."""
+        with patch("godot_ai.telemetry.sys.platform", "linux"):
+            monkeypatch.setenv("XDG_DATA_HOME", "/custom/data")
+            result = tel.TelemetryConfig._resolve_data_directory()
+        assert str(result) == "/custom/data/godot-ai"
+
+    def test_linux_fallback_to_home(self, monkeypatch, clean_env) -> None:
+        """Linux falls back to ~/.local/share when XDG_DATA_HOME unset."""
+        with patch("godot_ai.telemetry.sys.platform", "linux"):
+            with patch("godot_ai.telemetry.Path.home", return_value=Path("/home/user")):
+                result = tel.TelemetryConfig._resolve_data_directory()
+        assert ".local" in str(result)
+        assert "share" in str(result)
+        assert "godot-ai" in str(result)
+
+
+class TestCleanupLocalFilesEdgeCases:
+    """Tests for _cleanup_local_files exception handling."""
+
+    def test_returns_early_when_resolve_raises(self, monkeypatch, clean_env) -> None:
+        """Returns early when _resolve_data_directory raises an exception."""
+        monkeypatch.setenv("GODOT_AI_DISABLE_TELEMETRY", "true")
+
+        def _raise(*args):
+            raise OSError("simulated failure")
+
+        monkeypatch.setattr(tel.TelemetryConfig, "_resolve_data_directory", _raise)
+        config = tel.TelemetryConfig()
+        assert config.enabled is False
+
+    def test_returns_early_when_data_dir_not_exists(self, monkeypatch, tmp_path: Path) -> None:
+        """Returns early when resolved data directory does not exist on disk."""
+        nonexistent = tmp_path / "nonexistent_telemetry_dir"
+
+        def mock_resolve(self):
+            return nonexistent
+
+        class MockConfig(tel.TelemetryConfig):
+            _resolve_data_directory = mock_resolve
+
+        monkeypatch.setattr(tel, "TelemetryConfig", MockConfig)
+        monkeypatch.setenv("GODOT_AI_DISABLE_TELEMETRY", "true")
+        monkeypatch.setenv("GODOT_AI_TELEMETRY_ENDPOINT", "ftp://test-leak-guard.invalid/")
+        config = tel.TelemetryConfig()
+        assert config.enabled is False

--- a/tests/unit/test_telemetry_send.py
+++ b/tests/unit/test_telemetry_send.py
@@ -69,9 +69,7 @@ class TestSendOverHttpx:
         client_cls.assert_not_called()
         collector.shutdown()
 
-    def test_empty_endpoint_logs_only_once(
-        self, clean_env, isolated_data_dir, caplog
-    ) -> None:
+    def test_empty_endpoint_logs_only_once(self, clean_env, isolated_data_dir, caplog) -> None:
         """The 'endpoint unset; dropping' debug log must fire exactly
         once even under a flood of dequeued records — otherwise a busy
         session at debug level would spam logs."""
@@ -113,9 +111,7 @@ class TestSendOverHttpx:
 
         collector.shutdown()
 
-    def test_client_is_reused_across_sends(
-        self, monkeypatch, clean_env, isolated_data_dir
-    ) -> None:
+    def test_client_is_reused_across_sends(self, monkeypatch, clean_env, isolated_data_dir) -> None:
         """``httpx.Client`` must be constructed at most once per collector
         — reusing the same instance is the whole point of caching it on
         ``self._client`` (keep-alive, warm TLS pool, lower per-record


### PR DESCRIPTION
This change primarily adds a new toggle to the configuration popup menu to control whether or not telemetry is enabled. Compared to only supporting the environment variable, this is a more user-friendly approach especially on platforms where it can be annoying to set an environment variable persistently for a gui application (such as on macos). The toggle is only enabled if neither of the two controlling env vars are set and if so, the option is provided via env var for the python subprocess. If an env var is provided by the user, that enable/disable state is persisted to editor settings and used for future launches even if the env var is omitted at that point. Additionally, the python TelemetryConfig has been changed to cleanup local files when telemetry is disabled.

A few smaller supporting changes are also included:
- "Clients & Tools" has been renamed to "Clients & Settings" as the new telemetry toggle currently is added to the bottom of the 2nd tab. Since this is the tab controlling editor-persistent settings, this seemed like the most appropriate place to add it.
- The "Clients & Settings" popup min size is now scaled by the editor scale, making it a much more reasonable size with hidpi.
- The "Clients & Settings" popup margin has been added to each tab rather than being around the entire tab container.
- `_on_reload_plugin` now defers the actual plugin reload to prevent error spam due to the plugin reloading while the triggering input event (eg, clicking "Apply && Restart Server") is still propagating through the tree

Two things to call out with the current state of this PR, which can both be changed if desired:
- There are some things in the code which ideally would've been renamed for clarity (`_get_data_directory`, `_tools_apply_btn`, etc) but I didn't want to bloat the change too much and there was some precedent (eg `_clients_window`).
- The "Reset to defaults" button still only resets tools to their default state and leaves the telemetry preference alone.

Before:

<img width="396" height="392" alt="Screenshot 2026-05-16 at 10 43 42 AM" src="https://github.com/user-attachments/assets/3d503d9c-da74-45c6-9e25-6f5ac5f49da9" />

After:

<img width="560" height="505" alt="Screenshot 2026-05-16 at 10 42 51 AM" src="https://github.com/user-attachments/assets/75158595-7b25-4e33-915d-a6e2eff35f3b" />

Parts of this PR were generated by claude code. Changes were manually tested with and without manually providing environment variables.