### PR TITLE
Add per-session circuit breaker for editor-bridge transport failures (F-006)

### DIFF
--- a/src/godot_ai/godot_client/circuit_breaker.py
+++ b/src/godot_ai/godot_client/circuit_breaker.py
@@ -1,0 +1,152 @@
+"""Per-session circuit breaker for editor-bridge transport failures.
+
+Background — F-006 (telemetry-driven). When the WebSocket bridge to a
+Godot editor goes unresponsive (editor crashed, plugin reload mid-flight,
+network hiccup), tool calls fail with ``TimeoutError`` (~5–120s) or
+``ConnectionError`` (~0ms). LLM clients with no built-in backoff
+hot-retry these, generating death-spirals — one observed install
+sustained ~200 errors/min for 7 minutes (≈1,400 failures) with no
+self-correction.
+
+This module's job is to give those clients a clear "back off" signal.
+After ``threshold`` consecutive transport failures on a given session,
+the breaker opens for an exponentially-growing window. While open,
+``check_open`` returns the remaining backoff in milliseconds; the
+caller short-circuits with a structured ``PLUGIN_DISCONNECTED`` error
+carrying ``retry_after_ms`` so the next would-be hot-retry is instead
+told exactly when to try again.
+
+State persists across reconnects intentionally — a flapping editor
+that briefly returns only to fail again should escalate the backoff,
+not reset it. The canonical reset signal is a *successful* command
+call; that's the only thing that proves the bridge actually works.
+
+Threading: all callers run on the single asyncio event loop driving
+the WS transport, so the dict is mutated without locking (same model
+as ``SessionRegistry``).
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Callable
+
+## Sentinel key for the "no active session" failure path — the LLM is
+## hammering without a session at all (death-spiral source #1 in the
+## F-006 finding). Tracked independently from per-session circuits so a
+## working session B can't be poisoned by a hammering no-session client.
+_NO_SESSION_KEY = "__no_session__"
+
+
+@dataclass
+class _CircuitState:
+    consecutive_failures: int = 0
+    open_until_monotonic: float = 0.0
+    next_open_ms: int = 0  # filled in by tracker on first use
+    last_failure_kind: str = ""
+
+
+class EditorBridgeCircuitBreaker:
+    """Per-session circuit breaker for editor-bridge transport failures.
+
+    Defaults (5 failures → 1s..30s exponential) chosen so a single
+    transient blip (one timeout) never trips the breaker, but a
+    sustained hot-retry storm is short-circuited well before it can
+    saturate the dashboard.
+    """
+
+    def __init__(
+        self,
+        threshold: int = 5,
+        initial_open_ms: int = 1000,
+        max_open_ms: int = 30_000,
+        *,
+        time_fn: Callable[[], float] | None = None,
+    ):
+        if threshold < 1:
+            raise ValueError("threshold must be >= 1")
+        if initial_open_ms <= 0:
+            raise ValueError("initial_open_ms must be > 0")
+        if max_open_ms < initial_open_ms:
+            raise ValueError("max_open_ms must be >= initial_open_ms")
+        self._threshold = threshold
+        self._initial_open_ms = initial_open_ms
+        self._max_open_ms = max_open_ms
+        self._time = time_fn or time.monotonic
+        self._states: dict[str, _CircuitState] = {}
+
+    @staticmethod
+    def _key(session_id: str | None) -> str:
+        return session_id if session_id else _NO_SESSION_KEY
+
+    def _state(self, session_id: str | None) -> _CircuitState:
+        key = self._key(session_id)
+        state = self._states.get(key)
+        if state is None:
+            state = _CircuitState(next_open_ms=self._initial_open_ms)
+            self._states[key] = state
+        return state
+
+    def check_open(self, session_id: str | None) -> int | None:
+        """If the circuit is open for ``session_id``, return remaining ms.
+
+        Returns ``None`` if the circuit is closed (either never opened
+        or the open window has elapsed). The returned ms count is the
+        ``retry_after_ms`` hint to surface to the caller.
+        """
+        state = self._states.get(self._key(session_id))
+        if state is None or state.open_until_monotonic == 0.0:
+            return None
+        now = self._time()
+        if now >= state.open_until_monotonic:
+            return None
+        return max(1, int((state.open_until_monotonic - now) * 1000))
+
+    def record_failure(
+        self,
+        session_id: str | None,
+        *,
+        kind: str = "",
+    ) -> bool:
+        """Record a transport failure. Returns True if this call opened the circuit.
+
+        ``kind`` is a short tag for the failure category (e.g.
+        ``"TimeoutError"``, ``"no_session"``) used for diagnostic
+        payloads only — never user input, so no sanitization needed.
+        """
+        state = self._state(session_id)
+        state.consecutive_failures += 1
+        if kind:
+            state.last_failure_kind = kind
+        if state.consecutive_failures < self._threshold:
+            return False
+        was_open = state.open_until_monotonic > self._time()
+        state.open_until_monotonic = self._time() + state.next_open_ms / 1000.0
+        state.next_open_ms = min(state.next_open_ms * 2, self._max_open_ms)
+        return not was_open
+
+    def record_success(self, session_id: str | None) -> None:
+        """A successful command — the bridge works. Reset state.
+
+        Also clears the ``_NO_SESSION_KEY`` state, because a successful
+        per-session call proves there IS an active session, fixing the
+        condition the no-session circuit was guarding against.
+        """
+        self._states.pop(self._key(session_id), None)
+        if session_id:
+            self._states.pop(_NO_SESSION_KEY, None)
+
+    def snapshot(self, session_id: str | None) -> dict[str, int | bool | str]:
+        """Diagnostic snapshot for inclusion in error payloads."""
+        state = self._states.get(self._key(session_id))
+        if state is None:
+            return {"consecutive_failures": 0, "circuit_open": False}
+        is_open = state.open_until_monotonic > self._time()
+        snap: dict[str, int | bool | str] = {
+            "consecutive_failures": state.consecutive_failures,
+            "circuit_open": is_open,
+        }
+        if state.last_failure_kind:
+            snap["last_failure_kind"] = state.last_failure_kind
+        return snap

--- a/src/godot_ai/godot_client/client.py
+++ b/src/godot_ai/godot_client/client.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from fastmcp.exceptions import FastMCPError
 
+from godot_ai.godot_client.circuit_breaker import EditorBridgeCircuitBreaker
 from godot_ai.protocol.errors import ErrorCode
 from godot_ai.sessions.registry import SessionRegistry
 from godot_ai.transport.websocket import GodotWebSocketServer
@@ -39,9 +40,57 @@ class GodotCommandError(FastMCPError):
 class GodotClient:
     """High-level client for interacting with connected Godot editors."""
 
-    def __init__(self, ws_server: GodotWebSocketServer, registry: SessionRegistry):
+    def __init__(
+        self,
+        ws_server: GodotWebSocketServer,
+        registry: SessionRegistry,
+        circuit_breaker: EditorBridgeCircuitBreaker | None = None,
+    ):
         self.ws_server = ws_server
         self.registry = registry
+        ## F-006: stop death-spiral hot retries from melting the bridge.
+        ## Defaults: 5 consecutive transport failures opens for 1s, doubles
+        ## per re-open up to 30s. While open, the next call short-circuits
+        ## with PLUGIN_DISCONNECTED + retry_after_ms so retrying clients
+        ## get a clear back-off signal instead of another bare TimeoutError.
+        self._circuit = circuit_breaker or EditorBridgeCircuitBreaker()
+
+    @property
+    def circuit_breaker(self) -> EditorBridgeCircuitBreaker:
+        return self._circuit
+
+    def _raise_if_circuit_open(self, session_id: str | None) -> None:
+        retry_after_ms = self._circuit.check_open(session_id)
+        if retry_after_ms is None:
+            return
+        snapshot = self._circuit.snapshot(session_id)
+        raise GodotCommandError(
+            code=ErrorCode.PLUGIN_DISCONNECTED,
+            message=(
+                "Editor-bridge circuit is open after repeated transport failures — "
+                f"retry in {retry_after_ms}ms"
+            ),
+            data={
+                "retryable": True,
+                "retry_after_ms": retry_after_ms,
+                "circuit_open": True,
+                **snapshot,
+            },
+        )
+
+    def _record_failure(self, session_id: str | None, kind: str) -> None:
+        opened = self._circuit.record_failure(session_id, kind=kind)
+        if opened:
+            ## Log once on each closed→open transition so operators can
+            ## grep for the death-spiral entry point. Subsequent
+            ## short-circuited calls don't log to avoid amplifying the
+            ## spiral we're trying to dampen.
+            logger.warning(
+                "Editor-bridge circuit OPEN for session %s (kind=%s, snapshot=%s)",
+                (session_id or "<no-session>")[:16],
+                kind,
+                self._circuit.snapshot(session_id),
+            )
 
     async def send(
         self,
@@ -54,10 +103,20 @@ class GodotClient:
 
         If session_id is None, uses the active session.
         Raises GodotCommandError if the plugin returns an error.
+        Raises GodotCommandError(PLUGIN_DISCONNECTED) when the per-session
+        transport circuit is open (death-spiral protection — see
+        ``EditorBridgeCircuitBreaker``).
         """
+        ## Resolve the active session first so the circuit check below
+        ## keys on a concrete session_id when possible. The no-session
+        ## sentinel is only used when there genuinely is no session —
+        ## otherwise a once-tripped no-session circuit would falsely
+        ## block calls against an editor that has since come back up.
         if session_id is None:
             session = self.registry.get_active()
             if session is None:
+                self._raise_if_circuit_open(None)
+                self._record_failure(None, kind="no_active_session")
                 raise ConnectionError("No active Godot session")
             session_id = session.session_id
             if len(self.registry) > 1:
@@ -68,17 +127,29 @@ class GodotClient:
                     len(self.registry),
                 )
 
+        self._raise_if_circuit_open(session_id)
+
         if self.registry.get(session_id) is None:
+            self._record_failure(session_id, kind="session_not_found")
             raise ConnectionError(
                 f"Session {session_id} not found. Error code: {ErrorCode.SESSION_NOT_FOUND}"
             )
 
-        response = await self.ws_server.send_command(
-            session_id=session_id,
-            command=command,
-            params=params,
-            timeout=timeout,
-        )
+        try:
+            response = await self.ws_server.send_command(
+                session_id=session_id,
+                command=command,
+                params=params,
+                timeout=timeout,
+            )
+        except (ConnectionError, TimeoutError) as exc:
+            self._record_failure(session_id, kind=type(exc).__name__)
+            raise
+
+        ## A bridge round-trip completed (even if the plugin returned an
+        ## error response — that's the plugin saying "no" to a valid
+        ## command, not a transport failure). Reset the circuit.
+        self._circuit.record_success(session_id)
 
         if response.status == "error":
             error = response.error

--- a/tests/unit/test_circuit_breaker.py
+++ b/tests/unit/test_circuit_breaker.py
@@ -1,0 +1,181 @@
+"""Unit tests for EditorBridgeCircuitBreaker (F-006 death-spiral guard)."""
+
+from __future__ import annotations
+
+import pytest
+
+from godot_ai.godot_client.circuit_breaker import EditorBridgeCircuitBreaker
+
+
+class _FakeClock:
+    """Deterministic monotonic clock for circuit-breaker timing tests."""
+
+    def __init__(self, start: float = 1000.0):
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+@pytest.fixture
+def clock() -> _FakeClock:
+    return _FakeClock()
+
+
+@pytest.fixture
+def cb(clock: _FakeClock) -> EditorBridgeCircuitBreaker:
+    return EditorBridgeCircuitBreaker(
+        threshold=5,
+        initial_open_ms=1000,
+        max_open_ms=30_000,
+        time_fn=clock,
+    )
+
+
+class TestThresholdAndOpen:
+    def test_closed_when_no_failures(self, cb: EditorBridgeCircuitBreaker) -> None:
+        assert cb.check_open("sess-a") is None
+        assert cb.snapshot("sess-a") == {"consecutive_failures": 0, "circuit_open": False}
+
+    def test_does_not_open_before_threshold(self, cb: EditorBridgeCircuitBreaker) -> None:
+        for _ in range(4):
+            opened = cb.record_failure("sess-a", kind="TimeoutError")
+            assert opened is False
+        assert cb.check_open("sess-a") is None
+        assert cb.snapshot("sess-a")["circuit_open"] is False
+
+    def test_opens_on_threshold_failure(self, cb: EditorBridgeCircuitBreaker) -> None:
+        for _ in range(4):
+            cb.record_failure("sess-a", kind="TimeoutError")
+        ## 5th failure trips the breaker.
+        opened = cb.record_failure("sess-a", kind="TimeoutError")
+        assert opened is True
+        remaining = cb.check_open("sess-a")
+        assert remaining is not None
+        assert 900 <= remaining <= 1000  # ~1000ms window
+
+    def test_check_open_returns_none_after_window_elapses(
+        self, cb: EditorBridgeCircuitBreaker, clock: _FakeClock
+    ) -> None:
+        for _ in range(5):
+            cb.record_failure("sess-a", kind="TimeoutError")
+        assert cb.check_open("sess-a") is not None
+        clock.advance(1.5)
+        assert cb.check_open("sess-a") is None
+
+
+class TestRecovery:
+    def test_success_resets_count_and_circuit(
+        self, cb: EditorBridgeCircuitBreaker, clock: _FakeClock
+    ) -> None:
+        for _ in range(5):
+            cb.record_failure("sess-a", kind="TimeoutError")
+        clock.advance(1.5)  # let the window elapse
+        cb.record_success("sess-a")
+        ## After success, the count starts fresh — five more failures
+        ## are needed to re-open.
+        for _ in range(4):
+            assert cb.record_failure("sess-a", kind="TimeoutError") is False
+        assert cb.check_open("sess-a") is None
+        assert cb.record_failure("sess-a", kind="TimeoutError") is True
+
+    def test_success_on_a_real_session_clears_no_session_circuit(
+        self, cb: EditorBridgeCircuitBreaker
+    ) -> None:
+        ## The death-spiral source #1 is "no active session" hammering.
+        ## Once a real session comes up and serves a call, the global
+        ## no-session circuit should also clear.
+        for _ in range(5):
+            cb.record_failure(None, kind="no_active_session")
+        assert cb.check_open(None) is not None
+        cb.record_success("sess-a")
+        assert cb.check_open(None) is None
+
+
+class TestEscalation:
+    def test_backoff_doubles_on_reopen(
+        self, cb: EditorBridgeCircuitBreaker, clock: _FakeClock
+    ) -> None:
+        for _ in range(5):
+            cb.record_failure("sess-a", kind="TimeoutError")
+        first = cb.check_open("sess-a")
+        assert first is not None and 900 <= first <= 1000
+
+        clock.advance(1.5)
+        ## Single extra failure while count is above threshold immediately
+        ## triggers another open with doubled window.
+        opened_again = cb.record_failure("sess-a", kind="TimeoutError")
+        assert opened_again is True
+        second = cb.check_open("sess-a")
+        assert second is not None and 1900 <= second <= 2000
+
+    def test_backoff_caps_at_max(self, clock: _FakeClock) -> None:
+        cb = EditorBridgeCircuitBreaker(
+            threshold=1, initial_open_ms=10_000, max_open_ms=15_000, time_fn=clock
+        )
+        cb.record_failure("sess-a", kind="TimeoutError")
+        assert cb.check_open("sess-a") == pytest.approx(10_000, abs=20)
+        clock.advance(11.0)
+        cb.record_failure("sess-a", kind="TimeoutError")
+        ## next_open_ms would be 20_000 but is clamped to 15_000.
+        capped = cb.check_open("sess-a")
+        assert capped is not None and 14_000 <= capped <= 15_000
+
+
+class TestPerSessionIsolation:
+    def test_sessions_track_independently(self, cb: EditorBridgeCircuitBreaker) -> None:
+        for _ in range(5):
+            cb.record_failure("sess-a", kind="TimeoutError")
+        ## sess-b is unaffected.
+        assert cb.check_open("sess-b") is None
+        cb.record_success("sess-b")
+        ## And sess-a's open state survives sess-b's reset.
+        assert cb.check_open("sess-a") is not None
+
+    def test_no_session_key_isolated_from_real_sessions(
+        self, cb: EditorBridgeCircuitBreaker
+    ) -> None:
+        for _ in range(5):
+            cb.record_failure(None, kind="no_active_session")
+        assert cb.check_open(None) is not None
+        assert cb.check_open("sess-a") is None
+
+
+class TestSnapshot:
+    def test_snapshot_includes_failure_kind(self, cb: EditorBridgeCircuitBreaker) -> None:
+        cb.record_failure("sess-a", kind="TimeoutError")
+        snap = cb.snapshot("sess-a")
+        assert snap["consecutive_failures"] == 1
+        assert snap["circuit_open"] is False
+        assert snap["last_failure_kind"] == "TimeoutError"
+
+    def test_snapshot_with_kind_overwritten(self, cb: EditorBridgeCircuitBreaker) -> None:
+        cb.record_failure("sess-a", kind="TimeoutError")
+        cb.record_failure("sess-a", kind="ConnectionError")
+        assert cb.snapshot("sess-a")["last_failure_kind"] == "ConnectionError"
+
+    def test_snapshot_reflects_open_state(
+        self, cb: EditorBridgeCircuitBreaker, clock: _FakeClock
+    ) -> None:
+        for _ in range(5):
+            cb.record_failure("sess-a", kind="TimeoutError")
+        assert cb.snapshot("sess-a")["circuit_open"] is True
+        clock.advance(1.5)
+        assert cb.snapshot("sess-a")["circuit_open"] is False
+
+
+class TestValidation:
+    def test_threshold_must_be_at_least_one(self) -> None:
+        with pytest.raises(ValueError, match="threshold"):
+            EditorBridgeCircuitBreaker(threshold=0)
+
+    def test_initial_open_must_be_positive(self) -> None:
+        with pytest.raises(ValueError, match="initial_open_ms"):
+            EditorBridgeCircuitBreaker(initial_open_ms=0)
+
+    def test_max_must_be_at_least_initial(self) -> None:
+        with pytest.raises(ValueError, match="max_open_ms"):
+            EditorBridgeCircuitBreaker(initial_open_ms=2000, max_open_ms=1000)

--- a/tests/unit/test_godot_client_circuit_breaker.py
+++ b/tests/unit/test_godot_client_circuit_breaker.py
@@ -1,0 +1,312 @@
+"""GodotClient ↔ circuit breaker wiring (F-006 death-spiral guard).
+
+Exercises the integration between ``GodotClient.send`` and
+``EditorBridgeCircuitBreaker`` using a stubbed WebSocket server, so the
+tests don't depend on real port binding (and so the suite stays fast).
+The tracker's own state machine is covered by
+``test_circuit_breaker.py`` — the tests here are about the wiring:
+
+* every transport-error path increments the counter
+* a plugin-level error response does NOT increment the counter
+* a successful round-trip clears the counter
+* once the circuit is open, calls short-circuit with PLUGIN_DISCONNECTED
+  carrying a retry_after_ms hint
+* per-session and "no active session" circuits stay isolated
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from godot_ai.godot_client.circuit_breaker import EditorBridgeCircuitBreaker
+from godot_ai.godot_client.client import GodotClient, GodotCommandError
+from godot_ai.protocol.envelope import CommandResponse, ErrorDetail
+from godot_ai.sessions.registry import Session, SessionRegistry
+
+
+class _FakeClock:
+    def __init__(self, start: float = 1000.0):
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class _StubWsServer:
+    """Minimal stand-in for ``GodotWebSocketServer.send_command``.
+
+    The script is a list of (command_filter, action) pairs: each ``send_command``
+    call consumes the first script entry whose ``command_filter`` matches the
+    request. ``action`` is either:
+
+    * an ``Exception`` instance — raised as if transport failed
+    * a ``dict`` — returned wrapped in a ``CommandResponse(status="ok", data=…)``
+    * an ``ErrorDetail`` — returned as ``CommandResponse(status="error", error=…)``
+
+    ``recorded_calls`` lets tests assert what actually reached the wire.
+    """
+
+    def __init__(self) -> None:
+        self.script: list[tuple[str | None, Exception | dict | ErrorDetail]] = []
+        self.recorded_calls: list[tuple[str, str]] = []  # (command, session_id)
+
+    def queue(self, action, *, command: str | None = None) -> None:
+        self.script.append((command, action))
+
+    async def send_command(
+        self,
+        session_id: str,
+        command: str,
+        params=None,
+        timeout: float = 5.0,
+    ) -> CommandResponse:
+        self.recorded_calls.append((command, session_id))
+        if not self.script:
+            raise AssertionError(f"unexpected send_command({command!r}) — script exhausted")
+        ## Find first matching entry by command filter (None matches anything).
+        for idx, (filter_cmd, action) in enumerate(self.script):
+            if filter_cmd is None or filter_cmd == command:
+                self.script.pop(idx)
+                break
+        else:
+            raise AssertionError(
+                f"no script entry for command {command!r}; remaining: {self.script!r}"
+            )
+        if isinstance(action, Exception):
+            raise action
+        if isinstance(action, ErrorDetail):
+            return CommandResponse(request_id="r", status="error", data={}, error=action)
+        return CommandResponse(request_id="r", status="ok", data=action)
+
+
+def _make_registry(*session_ids: str, active: str | None = None) -> SessionRegistry:
+    registry = SessionRegistry()
+    for sid in session_ids:
+        registry.register(
+            Session(
+                session_id=sid,
+                godot_version="4.4.1",
+                project_path="/tmp/test",
+                plugin_version="0.0.1",
+            )
+        )
+    if active is not None:
+        registry.set_active(active)
+    return registry
+
+
+def _client(registry, *, threshold: int = 3, initial_open_ms: int = 1000):
+    ws = _StubWsServer()
+    breaker = EditorBridgeCircuitBreaker(
+        threshold=threshold,
+        initial_open_ms=initial_open_ms,
+        max_open_ms=30_000,
+        time_fn=_FakeClock(),
+    )
+    return GodotClient(ws, registry, circuit_breaker=breaker), ws, breaker
+
+
+class TestPreThresholdBehavior:
+    """Below the threshold, bare exceptions still propagate (back-compat)."""
+
+    async def test_first_no_session_failures_raise_connection_error(self) -> None:
+        client, _, breaker = _client(_make_registry(), threshold=3)
+        for _ in range(2):
+            with pytest.raises(ConnectionError, match="No active Godot session"):
+                await client.send("anything")
+        assert breaker.check_open(None) is None
+        assert breaker.snapshot(None)["consecutive_failures"] == 2
+
+    async def test_first_session_not_found_failures_raise_connection_error(self) -> None:
+        client, _, breaker = _client(_make_registry(), threshold=3)
+        for _ in range(2):
+            with pytest.raises(ConnectionError, match="not found"):
+                await client.send("anything", session_id="ghost")
+        assert breaker.check_open("ghost") is None
+
+    async def test_first_transport_timeout_raises_bare_timeout(self) -> None:
+        client, ws, breaker = _client(_make_registry("sess", active="sess"), threshold=3)
+        for _ in range(2):
+            ws.queue(TimeoutError("boom"))
+            with pytest.raises(TimeoutError):
+                await client.send("slow", session_id="sess")
+        assert breaker.snapshot("sess")["consecutive_failures"] == 2
+        assert breaker.check_open("sess") is None
+
+
+class TestCircuitOpens:
+    async def test_no_session_threshold_opens_circuit(self) -> None:
+        client, _, breaker = _client(_make_registry(), threshold=3)
+        for _ in range(3):
+            with pytest.raises(ConnectionError):
+                await client.send("anything")
+        ## Threshold reached on the 3rd failure — the 4th call short-circuits.
+        with pytest.raises(GodotCommandError) as exc_info:
+            await client.send("anything")
+        assert exc_info.value.code == "PLUGIN_DISCONNECTED"
+        data = exc_info.value.data
+        assert data["circuit_open"] is True
+        assert data["retryable"] is True
+        assert data["retry_after_ms"] > 0
+        assert data["last_failure_kind"] == "no_active_session"
+        assert "retry in" in exc_info.value.message
+
+    async def test_session_not_found_threshold_opens_circuit_keyed_by_session(self) -> None:
+        client, _, breaker = _client(_make_registry(), threshold=3)
+        for _ in range(3):
+            with pytest.raises(ConnectionError):
+                await client.send("anything", session_id="ghost")
+        with pytest.raises(GodotCommandError) as exc_info:
+            await client.send("anything", session_id="ghost")
+        assert exc_info.value.code == "PLUGIN_DISCONNECTED"
+        assert exc_info.value.data["last_failure_kind"] == "session_not_found"
+
+    async def test_transport_timeout_threshold_opens_circuit(self) -> None:
+        client, ws, _ = _client(_make_registry("sess", active="sess"), threshold=3)
+        for _ in range(3):
+            ws.queue(TimeoutError("nope"))
+            with pytest.raises(TimeoutError):
+                await client.send("slow", session_id="sess")
+        ## 4th call short-circuits before any transport work.
+        before_len = len(ws.recorded_calls)
+        with pytest.raises(GodotCommandError) as exc_info:
+            await client.send("slow", session_id="sess")
+        assert exc_info.value.code == "PLUGIN_DISCONNECTED"
+        assert exc_info.value.data["last_failure_kind"] == "TimeoutError"
+        ## The circuit-open path must not have hit transport.
+        assert len(ws.recorded_calls) == before_len
+
+    async def test_transport_connection_error_threshold_opens_circuit(self) -> None:
+        client, ws, _ = _client(_make_registry("sess", active="sess"), threshold=3)
+        for _ in range(3):
+            ws.queue(ConnectionError("ws dropped"))
+            with pytest.raises(ConnectionError):
+                await client.send("ping", session_id="sess")
+        with pytest.raises(GodotCommandError) as exc_info:
+            await client.send("ping", session_id="sess")
+        assert exc_info.value.code == "PLUGIN_DISCONNECTED"
+        assert exc_info.value.data["last_failure_kind"] == "ConnectionError"
+
+
+class TestCircuitDoesNotOpen:
+    async def test_plugin_error_response_does_not_count_as_transport_failure(self) -> None:
+        ## F-006 rationale: a plugin-side error (NODE_NOT_FOUND, etc.) is a
+        ## *successful* bridge round-trip — the transport works, the request
+        ## was answered. Such errors must NOT increment the breaker or it
+        ## would slam shut on any tool getting a normal validation error.
+        client, ws, breaker = _client(_make_registry("sess", active="sess"), threshold=3)
+        for _ in range(5):
+            ws.queue(ErrorDetail(code="NODE_NOT_FOUND", message="/Missing"))
+            with pytest.raises(GodotCommandError) as exc_info:
+                await client.send("get_node", session_id="sess")
+            assert exc_info.value.code == "NODE_NOT_FOUND"
+        snap = breaker.snapshot("sess")
+        assert snap["circuit_open"] is False
+        assert snap["consecutive_failures"] == 0
+
+
+class TestReset:
+    async def test_successful_call_resets_counter(self) -> None:
+        client, ws, breaker = _client(_make_registry("sess", active="sess"), threshold=3)
+        for _ in range(2):
+            ws.queue(TimeoutError("nope"))
+            with pytest.raises(TimeoutError):
+                await client.send("slow", session_id="sess")
+        ws.queue({"ok": True})
+        result = await client.send("ping", session_id="sess")
+        assert result == {"ok": True}
+        assert breaker.snapshot("sess")["consecutive_failures"] == 0
+
+        ## Fresh threshold countdown.
+        for _ in range(2):
+            ws.queue(TimeoutError("nope"))
+            with pytest.raises(TimeoutError):
+                await client.send("slow", session_id="sess")
+        assert breaker.check_open("sess") is None
+
+    async def test_per_session_success_clears_no_session_circuit(self) -> None:
+        ## After a "no active session" death-spiral, the first successful
+        ## per-session call must also clear the global no-session circuit.
+        client, ws, breaker = _client(_make_registry(), threshold=3)
+        for _ in range(3):
+            with pytest.raises(ConnectionError):
+                await client.send("anything")
+        assert breaker.check_open(None) is not None
+
+        ## Register a session and serve one call.
+        client.registry.register(
+            Session(
+                session_id="late",
+                godot_version="4.4.1",
+                project_path="/tmp/late",
+                plugin_version="0.0.1",
+            )
+        )
+        ws.queue({"ok": True})
+        result = await client.send("ping")  # uses active session "late"
+        assert result == {"ok": True}
+        assert breaker.check_open(None) is None
+
+
+class TestPerSessionIsolation:
+    async def test_failing_session_does_not_affect_healthy_session(self) -> None:
+        registry = _make_registry("good", active="good")
+        client, ws, breaker = _client(registry, threshold=3)
+        ## Trip the circuit on a missing pinned session.
+        for _ in range(3):
+            with pytest.raises(ConnectionError):
+                await client.send("anything", session_id="ghost")
+        with pytest.raises(GodotCommandError):
+            await client.send("anything", session_id="ghost")
+        ## "good" session is still untouched.
+        assert breaker.check_open("good") is None
+        ws.queue({"alive": True})
+        result = await client.send("ping", session_id="good")
+        assert result == {"alive": True}
+
+
+class TestErrorPayloadShape:
+    async def test_payload_carries_actionable_fields(self) -> None:
+        client, _, _ = _client(_make_registry(), threshold=3)
+        for _ in range(3):
+            with pytest.raises(ConnectionError):
+                await client.send("anything")
+        with pytest.raises(GodotCommandError) as exc_info:
+            await client.send("anything")
+
+        err = exc_info.value
+        assert err.code == "PLUGIN_DISCONNECTED"
+        assert err.data["retryable"] is True
+        assert isinstance(err.data["retry_after_ms"], int)
+        assert err.data["retry_after_ms"] >= 1
+        assert err.data["circuit_open"] is True
+        assert err.data["consecutive_failures"] >= 3
+
+        ## Payload is JSON-serializable (no Exception objects or Enums) so it
+        ## flows through MCP without surprises.
+        payload = err.to_payload()
+        import json
+
+        json.dumps(payload)  # no TypeError
+
+
+class TestSettingsViaConstructor:
+    async def test_default_threshold_does_not_open_until_5_failures(self) -> None:
+        ## Pin the production default — the docstring claims threshold=5.
+        client = GodotClient(
+            _StubWsServer(),
+            _make_registry(),
+            # default breaker
+        )
+        for _ in range(4):
+            with pytest.raises(ConnectionError):
+                await client.send("anything")
+        assert client.circuit_breaker.check_open(None) is None
+        with pytest.raises(ConnectionError):
+            await client.send("anything")  # 5th — trips
+        with pytest.raises(GodotCommandError) as exc_info:
+            await client.send("anything")  # 6th — short-circuits
+        assert exc_info.value.code == "PLUGIN_DISCONNECTED"


### PR DESCRIPTION
## Summary

Addresses telemetry finding **F-006** (MCP transport errors — editor-bridge connectivity): 57/57 UUIDs hit `TimeoutError`/`ConnectionError` over 14d (1,263 lifetime events), and one install death-spiraled at ~200 errors/min for 7 minutes against a dead bridge with no client-side back-off. The finding's recommendation was a server-side circuit-open / Retry-After signal once transport failures saturate.

- `EditorBridgeCircuitBreaker` (new module) tracks per-session transport failures with exponential backoff (1s base, 30s cap).
- `GodotClient.send()` opens the circuit after 5 consecutive transport failures across all four paths (no active session, session-not-found, ws `ConnectionError`, ws `TimeoutError`) and short-circuits subsequent calls with `GodotCommandError(PLUGIN_DISCONNECTED, data={retry_after_ms, retryable, circuit_open, consecutive_failures, last_failure_kind})`.
- Plugin-side error responses (`NODE_NOT_FOUND`, etc.) are *not* counted as transport failures — those are successful round-trips where the plugin just said "no". A successful call resets the breaker state.
- Pre-threshold behavior is unchanged: the first 4 transport failures still raise bare `TimeoutError`/`ConnectionError`, so existing handlers (`editor_reload_plugin`) that catch those keep working for the legitimate one-shot disconnect case.

## Design notes

- **State persists across reconnects intentionally** — a flapping editor that briefly returns only to fail again should escalate the backoff, not reset it. The canonical reset signal is a *successful* call.
- **Active-session resolution happens before circuit check** when no `session_id` is passed, so a once-tripped no-session circuit doesn't falsely block calls against an editor that has since come back up.
- **Per-session isolation** — a failing session A can't poison a healthy session B. The "no-session" sentinel key is independent of any per-session circuit.

## Test plan

- [x] `ruff check src/ tests/` clean
- [x] `ruff format` clean
- [x] `pytest tests/` — 1054 passed, 4 skipped (was 1025 + 2 skipped pre-change → 29 new tests, no regressions)
  - 16 tracker-state tests in `tests/unit/test_circuit_breaker.py` (threshold, recovery, escalation, isolation, validation)
  - 13 wiring tests in `tests/unit/test_godot_client_circuit_breaker.py` (each failure path opens the circuit, plugin errors don't count, success resets, per-session isolation, payload shape, default threshold = 5)
- [x] Existing `tests/integration/test_websocket.py` (50 tests) still passes — no regressions to pre-existing transport-error tests

## Telemetry follow-up

After merge + release, run from `~/godot-ai-telemetry-ingest/`:

```bash
ops/finding-status F-006 verifying --pr <this PR url> --fix-version <released ver>
```

The F-006 BigQuery predicate (`error LIKE 'TimeoutError%' OR error LIKE 'ConnectionError%'`) should drop because the hot-retry tail gets short-circuited; a new `error = "PLUGIN_DISCONNECTED"` cohort will appear in the standard error breakdown carrying the `retry_after_ms` hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
