### PR TITLE
Fix #446 follow-up: stop resetting telemetry toggle on "Reset to defaults"

### DIFF
--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -1932,18 +1932,15 @@ func _on_tools_apply() -> void:
 
 
 func _on_tools_reset() -> void:
+	## Resets only the tool-domain exclusions, not the telemetry toggle.
+	## Telemetry is a privacy preference users typically want to set once
+	## and have honored — flipping it back to "on" via a generic Reset
+	## button would be a surprising privacy regression. The button label
+	## is scoped to tools accordingly.
 	_tools_pending_excluded = PackedStringArray()
 	for id in _tools_domain_checkboxes:
 		var chk: CheckBox = _tools_domain_checkboxes[id]
 		chk.set_pressed_no_signal(true)
-	## Restore telemetry to its default (on) too, so "Reset to defaults"
-	## consistently restores every setting on this tab. Skip when the
-	## toggle is disabled because an env var is locking the value — the
-	## env var wins, and we shouldn't create a dirty pending state the
-	## user can't apply from the UI.
-	if _telemetry_toggle != null and not _telemetry_toggle.disabled:
-		_telemetry_pending_enabled = true
-		_telemetry_toggle.set_pressed_no_signal(true)
 	_refresh_tools_ui_state()
 
 


### PR DESCRIPTION
## Summary
- Reverts the telemetry-reset block added in `9299dbe` (the follow-up commit on #446).
- Resetting the telemetry preference via a generic "Reset to defaults" button is a privacy regression: users who turn telemetry off generally want it stayed off, not flipped back to ON every time they click Reset.
- The button's tooltip already scopes it to tool domains ("Re-enable every domain"); the implementation now matches.
- Adds an inline comment explaining the deliberate scope so a future "make Reset consistent" pass doesn't re-add it.

## Context
@a-johnston flagged this on #446 after the merge — his original PR intent left telemetry untouched on Reset, which is correct. The "make it consistent" follow-up I pushed was the wrong call. This restores the original behavior.

## Test plan
- [x] Diff is a pure deletion + comment — no parse risk
- [ ] CI green (Godot tests on Linux/macOS/Windows + Python tests + release smoke)
- [ ] Manual: open Clients & Settings → Settings, toggle Telemetry OFF, Apply, then click Reset to defaults; verify telemetry toggle stays OFF (only tool-domain checkboxes flip to enabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
