### PR TITLE
Implement game_eval feature 

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -55,7 +55,7 @@ Calls take the form:
 | `node_manage` | `get_children`, `get_groups`, `delete`, `duplicate`, `rename`, `move`, `reparent`, `add_to_group`, `remove_from_group` |
 | `script_manage` | `read`, `detach`, `find_symbols` |
 | `project_manage` | `stop`, `settings_get`, `settings_set` |
-| `editor_manage` | `state`, `selection_get`, `selection_set`, `monitors_get`, `quit`, `logs_clear` |
+| `editor_manage` | `state`, `selection_get`, `selection_set`, `monitors_get`, `quit`, `logs_clear`, `game_eval` |
 | `session_manage` | `list` |
 | `test_manage` | `results_get` |
 | `animation_manage` | `player_create`, `delete`, `validate`, `add_property_track`, `add_method_track`, `set_autoplay`, `play`, `stop`, `list`, `get`, `create_simple`, `preset_fade`, `preset_slide`, `preset_shake`, `preset_pulse` |

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -390,7 +390,7 @@ func _send_eval(
 		if conn == null or not is_instance_valid(conn):
 			return
 		_send_error(conn, request_id, ErrorCodes.INTERNAL_ERROR,
-			"Game eval timed out after %.0fs. Eval code may be stuck in an infinite loop or await." % timeout_sec)
+			"Game eval timed out after %.0fs — eval code may be stuck in an infinite loop / await, OR triggered a GDScript runtime error that halted execution before responding. Check logs_read(source='game') for push_error/runtime errors from this run." % timeout_sec)
 		if _log_buffer:
 			_log_buffer.log("[debug] !! eval timeout (%s)" % request_id)
 	timer.timeout.connect(timeout_callable)
@@ -420,9 +420,10 @@ func _on_eval_response(data: Array) -> void:
 		return
 
 	var result_json: String = data[1] if data.size() > 1 else "null"
+	var parsed = JSON.parse_string(result_json)
 	connection.send_deferred_response(request_id, {
 		"data": {
-			"result": result_json,
+			"result": parsed if parsed != null else result_json,
 			"source": "game",
 		}
 	})

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -134,6 +134,12 @@ func _capture(message: String, data: Array, _session_id: int) -> bool:
 			elif _log_buffer:
 				_log_buffer.log("[debug] <- mcp:hello from game_helper")
 			return true
+		"mcp:eval_response":
+			_on_eval_response(data)
+			return true
+		"mcp:eval_error":
+			_on_eval_error(data)
+			return true
 	return false
 
 
@@ -315,3 +321,127 @@ func _clear_pending(request_id: String) -> void:
 	if timer != null and timer.timeout.is_connected(cb):
 		timer.timeout.disconnect(cb)
 	_pending.erase(request_id)
+
+
+## --- game_eval: execute arbitrary GDScript in the running game ---
+
+func request_game_eval(
+	code: String,
+	request_id: String,
+	connection: McpConnection,
+	timeout_sec: float = 10.0,
+) -> void:
+	if request_id.is_empty():
+		push_warning("MCP debugger: eval request missing request_id")
+		return
+
+	var tree := Engine.get_main_loop() as SceneTree
+	if tree == null:
+		_send_error(connection, request_id, ErrorCodes.INTERNAL_ERROR,
+			"Editor main loop is not a SceneTree — cannot schedule eval")
+		return
+
+	if is_game_capture_ready():
+		_send_eval(tree, code, request_id, connection, timeout_sec)
+		return
+
+	if _log_buffer:
+		_log_buffer.log("[debug] waiting for game_helper hello before eval (%s)" % request_id)
+	_wait_then_eval(tree, code, request_id, connection, timeout_sec)
+
+
+func _wait_then_eval(
+	tree: SceneTree,
+	code: String,
+	request_id: String,
+	connection: McpConnection,
+	timeout_sec: float,
+) -> void:
+	var deadline := Time.get_ticks_msec() + int(GAME_READY_WAIT_SEC * 1000.0)
+	while not is_game_capture_ready() and Time.get_ticks_msec() < deadline:
+		await tree.process_frame
+	if not is_game_capture_ready():
+		_send_error(connection, request_id, ErrorCodes.INTERNAL_ERROR,
+			"Game-side autoload never registered its debugger capture within %ds. Is the game actually running?" % int(GAME_READY_WAIT_SEC))
+		return
+	_send_eval(tree, code, request_id, connection, timeout_sec)
+
+
+func _send_eval(
+	tree: SceneTree,
+	code: String,
+	request_id: String,
+	connection: McpConnection,
+	timeout_sec: float,
+) -> void:
+	var session: EditorDebuggerSession = _first_active_session()
+	if session == null:
+		_send_error(connection, request_id, ErrorCodes.INTERNAL_ERROR,
+			"No active debugger session — is the game actually running?")
+		return
+
+	var timer: SceneTreeTimer = tree.create_timer(timeout_sec)
+	var timeout_callable := func() -> void:
+		var pending_entry = _pending.get(request_id)
+		if pending_entry == null:
+			return
+		_pending.erase(request_id)
+		var conn: McpConnection = pending_entry.connection
+		if conn == null or not is_instance_valid(conn):
+			return
+		_send_error(conn, request_id, ErrorCodes.INTERNAL_ERROR,
+			"Game eval timed out after %.0fs. Eval code may be stuck in an infinite loop or await." % timeout_sec)
+		if _log_buffer:
+			_log_buffer.log("[debug] !! eval timeout (%s)" % request_id)
+	timer.timeout.connect(timeout_callable)
+	_pending[request_id] = {
+		"connection": connection,
+		"timer": timer,
+		"timeout_callable": timeout_callable,
+	}
+
+	session.send_message("mcp:eval", [request_id, code])
+	if _log_buffer:
+		_log_buffer.log("[debug] -> mcp:eval (%s)" % request_id)
+
+
+func _on_eval_response(data: Array) -> void:
+	if data.size() < 2:
+		push_warning("MCP debugger: malformed eval response (expected 2 fields, got %d)" % data.size())
+		return
+	var request_id: String = data[0]
+	var pending_entry = _pending.get(request_id)
+	if pending_entry == null:
+		return
+	_clear_pending(request_id)
+
+	var connection: McpConnection = pending_entry.connection
+	if connection == null or not is_instance_valid(connection):
+		return
+
+	var result_json: String = data[1] if data.size() > 1 else "null"
+	connection.send_deferred_response(request_id, {
+		"data": {
+			"result": result_json,
+			"source": "game",
+		}
+	})
+	if _log_buffer:
+		_log_buffer.log("[debug] <- mcp:eval_response (%s)" % request_id)
+
+
+func _on_eval_error(data: Array) -> void:
+	if data.size() < 2:
+		return
+	var request_id: String = data[0]
+	var message: String = data[1]
+	var pending_entry = _pending.get(request_id)
+	if pending_entry == null:
+		return
+	_clear_pending(request_id)
+	var connection: McpConnection = pending_entry.connection
+	if connection == null or not is_instance_valid(connection):
+		return
+	_send_error(connection, request_id, ErrorCodes.INTERNAL_ERROR, message)
+	if _log_buffer:
+		_log_buffer.log("[debug] <- mcp:eval_error (%s): %s" % [request_id, message])

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -420,10 +420,11 @@ func _on_eval_response(data: Array) -> void:
 		return
 
 	var result_json: String = data[1] if data.size() > 1 else "null"
-	var parsed = JSON.parse_string(result_json)
+	var json := JSON.new()
+	var parse_err := json.parse(result_json)
 	connection.send_deferred_response(request_id, {
 		"data": {
-			"result": parsed if parsed != null else result_json,
+			"result": json.data if parse_err == OK else result_json,
 			"source": "game",
 		}
 	})

--- a/plugin/addons/godot_ai/dispatcher.gd
+++ b/plugin/addons/godot_ai/dispatcher.gd
@@ -17,6 +17,7 @@ const DEFERRED_TIMEOUT_MS_BY_COMMAND := {
 	"create_script": 4500,
 	"stop_project": 4500,
 	"take_screenshot": 30000,
+	"game_eval": 15000,
 }
 const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
 

--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -678,7 +678,7 @@ func quit_editor(_params: Dictionary) -> Dictionary:
 func game_eval(params: Dictionary) -> Dictionary:
 	var code: String = params.get("code", "")
 	if code.is_empty():
-		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, "code is required")
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "code is required")
 
 	if _debugger_plugin == null or _connection == null:
 		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR,

--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -673,3 +673,25 @@ func quit_editor(_params: Dictionary) -> Dictionary:
 	## Defer the quit so the response is sent back before the editor exits.
 	EditorInterface.get_base_control().get_tree().call_deferred("quit")
 	return {"data": {"status": "quitting", "message": "Editor quit initiated"}}
+
+
+func game_eval(params: Dictionary) -> Dictionary:
+	var code: String = params.get("code", "")
+	if code.is_empty():
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, "code is required")
+
+	if _debugger_plugin == null or _connection == null:
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR,
+			"Debugger bridge unavailable — plugin may not be fully initialised")
+
+	if not EditorInterface.is_playing_scene():
+		return ErrorCodes.make(ErrorCodes.EDITOR_NOT_READY,
+			"Game is not running — start the project first")
+
+	var request_id: String = params.get("_request_id", "")
+	if request_id.is_empty():
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR,
+			"Missing request_id — cannot correlate deferred response")
+
+	_debugger_plugin.request_game_eval(code, request_id, _connection)
+	return McpDispatcher.DEFERRED_RESPONSE

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -279,6 +279,7 @@ func _enter_tree() -> void:
 	_dispatcher.register("get_performance_monitors", editor_handler.get_performance_monitors)
 	_dispatcher.register("reload_plugin", editor_handler.reload_plugin)
 	_dispatcher.register("quit_editor", editor_handler.quit_editor)
+	_dispatcher.register("game_eval", editor_handler.game_eval)
 	_dispatcher.register("get_project_setting", project_handler.get_project_setting)
 	_dispatcher.register("set_project_setting", project_handler.set_project_setting)
 	_dispatcher.register("run_project", project_handler.run_project)

--- a/plugin/addons/godot_ai/runtime/game_helper.gd
+++ b/plugin/addons/godot_ai/runtime/game_helper.gd
@@ -114,6 +114,9 @@ func _on_debug_message(message: String, data: Array) -> bool:
 		"take_screenshot":
 			_handle_take_screenshot(data)
 			return true
+		"eval":
+			_handle_eval(data)
+			return true
 	return false
 
 
@@ -162,3 +165,172 @@ func _handle_take_screenshot(data: Array) -> void:
 
 func _reply_error(request_id: String, message: String) -> void:
 	EngineDebugger.send_message("mcp:screenshot_error", [request_id, message])
+
+
+## --- game_eval: execute arbitrary GDScript in the running game ---
+
+func _handle_eval(data: Array) -> void:
+	var request_id: String = data[0] if data.size() > 0 else ""
+	var code: String = data[1] if data.size() > 1 else ""
+
+	if code.is_empty():
+		EngineDebugger.send_message("mcp:eval_error", [request_id, "No code provided"])
+		return
+
+	## Wrap user code so we can capture a return value.
+	## Uses await so user code can use `await` internally.
+	var script_source := (
+		"extends Node\n"
+		+ "func execute():\n"
+		+ "\tvar __result = null\n"
+		+ "\t__result = await _run()\n"
+		+ "\treturn __result\n\n"
+		+ "func _run():\n"
+		+ _indent_eval_code(code)
+	)
+
+	var script: GDScript = GDScript.new()
+	script.source_code = script_source
+	var err: int = script.reload()
+	if err != OK:
+		EngineDebugger.send_message("mcp:eval_error",
+			[request_id, "Failed to compile GDScript (error %d). Check syntax." % err])
+		return
+
+	var temp_node := Node.new()
+	temp_node.set_script(script)
+	temp_node.process_mode = Node.PROCESS_MODE_ALWAYS
+	add_child(temp_node)
+
+	var result = null
+	if temp_node.has_method("execute"):
+		result = await temp_node.execute()
+
+	temp_node.queue_free()
+	EngineDebugger.send_message("mcp:eval_response",
+		[request_id, JSON.stringify(_variant_to_json(result))])
+
+
+func _indent_eval_code(code: String) -> String:
+	var lines: PackedStringArray = code.split("\n")
+	var out := ""
+	for line in lines:
+		out += "\t" + line + "\n"
+	return out
+
+
+## Serialize any Godot Variant to a JSON-safe dictionary/array/primitive.
+## Ported from godot-mcp's mcp_interaction_server.gd.
+func _variant_to_json(value: Variant) -> Variant:
+	if value == null:
+		return null
+	if value is bool or value is int or value is float or value is String:
+		return value
+	if value is Vector2:
+		return {"x": value.x, "y": value.y}
+	if value is Vector3:
+		return {"x": value.x, "y": value.y, "z": value.z}
+	if value is Vector4:
+		return {"x": value.x, "y": value.y, "z": value.z, "w": value.w}
+	if value is Vector2i:
+		return {"x": value.x, "y": value.y}
+	if value is Vector3i:
+		return {"x": value.x, "y": value.y, "z": value.z}
+	if value is Vector4i:
+		return {"x": value.x, "y": value.y, "z": value.z, "w": value.w}
+	if value is Color:
+		return {"r": value.r, "g": value.g, "b": value.b, "a": value.a}
+	if value is Quaternion:
+		return {"x": value.x, "y": value.y, "z": value.z, "w": value.w}
+	if value is Basis:
+		return {
+			"x": _variant_to_json(value.x),
+			"y": _variant_to_json(value.y),
+			"z": _variant_to_json(value.z),
+		}
+	if value is Transform3D:
+		return {
+			"basis": _variant_to_json(value.basis),
+			"origin": _variant_to_json(value.origin),
+		}
+	if value is Transform2D:
+		return {
+			"x": _variant_to_json(value.x),
+			"y": _variant_to_json(value.y),
+			"origin": _variant_to_json(value.origin),
+		}
+	if value is Rect2:
+		return {
+			"position": _variant_to_json(value.position),
+			"size": _variant_to_json(value.size),
+		}
+	if value is Rect2i:
+		return {
+			"position": _variant_to_json(value.position),
+			"size": _variant_to_json(value.size),
+		}
+	if value is AABB:
+		return {
+			"position": _variant_to_json(value.position),
+			"size": _variant_to_json(value.size),
+		}
+	if value is NodePath or value is StringName:
+		return str(value)
+	if value is Plane:
+		return {
+			"normal": _variant_to_json(value.normal),
+			"d": value.d,
+		}
+	if value is Projection:
+		return {
+			"x": _variant_to_json(value.x),
+			"y": _variant_to_json(value.y),
+			"z": _variant_to_json(value.z),
+			"w": _variant_to_json(value.w),
+		}
+	## Packed arrays
+	if value is PackedByteArray:
+		var arr: Array = []
+		for item in value: arr.append(item)
+		return arr
+	if value is PackedInt32Array or value is PackedInt64Array:
+		var arr: Array = []
+		for item in value: arr.append(item)
+		return arr
+	if value is PackedFloat32Array or value is PackedFloat64Array:
+		var arr: Array = []
+		for item in value: arr.append(item)
+		return arr
+	if value is PackedStringArray:
+		var arr: Array = []
+		for item in value: arr.append(item)
+		return arr
+	if value is PackedVector2Array:
+		var arr: Array = []
+		for item in value: arr.append({"x": item.x, "y": item.y})
+		return arr
+	if value is PackedVector3Array:
+		var arr: Array = []
+		for item in value: arr.append({"x": item.x, "y": item.y, "z": item.z})
+		return arr
+	if value is PackedVector4Array:
+		var arr: Array = []
+		for item in value: arr.append({"x": item.x, "y": item.y, "z": item.z, "w": item.w})
+		return arr
+	if value is PackedColorArray:
+		var arr: Array = []
+		for item in value: arr.append({"r": item.r, "g": item.g, "b": item.b, "a": item.a})
+		return arr
+	## Generic arrays and dictionaries — recurse
+	if value is Array:
+		var arr: Array = []
+		for item in value:
+			arr.append(_variant_to_json(item))
+		return arr
+	if value is Dictionary:
+		var dict: Dictionary = {}
+		for key in value.keys():
+			dict[str(key)] = _variant_to_json(value[key])
+		return dict
+	## Fallback: string representation
+	return str(value)

--- a/src/godot_ai/handlers/editor.py
+++ b/src/godot_ai/handlers/editor.py
@@ -338,3 +338,10 @@ async def selection_resource_data(runtime: DirectRuntime) -> dict:
 
 async def logs_resource_data(runtime: DirectRuntime) -> dict:
     return await runtime.send_command("get_logs", {"count": 100})
+
+
+async def game_eval(runtime: DirectRuntime, code: str) -> dict:
+    """Execute GDScript in the running game. Use 'return' for values."""
+    return await runtime.send_command(
+        "game_eval", {"code": code}, timeout=15.0
+    )

--- a/src/godot_ai/handlers/editor.py
+++ b/src/godot_ai/handlers/editor.py
@@ -341,7 +341,11 @@ async def logs_resource_data(runtime: DirectRuntime) -> dict:
 
 
 async def game_eval(runtime: DirectRuntime, code: str) -> dict:
-    """Execute GDScript in the running game. Use 'return' for values."""
+    """Execute GDScript in the running game. Use 'return' for values.
+
+    Runtime errors in the eval code are not caught — if eval times out,
+    check ``logs_read(source='game')`` for push_error output.
+    """
     return await runtime.send_command(
         "game_eval", {"code": code}, timeout=15.0
     )

--- a/src/godot_ai/tools/editor.py
+++ b/src/godot_ai/tools/editor.py
@@ -196,6 +196,7 @@ def register_editor_tools(mcp: FastMCP, *, include_non_core: bool = True) -> Non
             "monitors_get": editor_handlers.performance_monitors_get,
             "quit": editor_handlers.editor_quit,
             "logs_clear": editor_handlers.logs_clear,
+            "game_eval": editor_handlers.game_eval,
         },
         read_resource_forms={
             "state": "godot://editor/state",
@@ -206,5 +207,6 @@ def register_editor_tools(mcp: FastMCP, *, include_non_core: bool = True) -> Non
             ## has a resource counterpart.
             "quit": None,
             "logs_clear": None,
+            "game_eval": None,
         },
     )

--- a/src/godot_ai/tools/editor.py
+++ b/src/godot_ai/tools/editor.py
@@ -15,7 +15,7 @@ from godot_ai.tools import DEFER_META
 from godot_ai.tools._meta_tool import register_manage_tool
 
 _DESCRIPTION = """\
-Editor selection, performance monitors, quit, log clearing.
+Editor selection, performance monitors, quit, log clearing, game eval.
 
 Resource forms (prefer for active-session reads):
   godot://editor/state, godot://selection/current, godot://performance
@@ -34,7 +34,11 @@ Ops:
         Gracefully quit the Godot editor on next frame.
   • logs_clear()
         Clear the MCP log buffer. Returns lines_cleared.
-"""
+  • game_eval(code)
+        Execute GDScript in the running game with return values. Uses
+        'await' so user code can await internally. Runtime errors are not
+        caught — if eval times out, check logs_read(source='game') for
+        push_error output."""
 
 
 def register_editor_tools(mcp: FastMCP, *, include_non_core: bool = True) -> None:

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -1272,4 +1272,32 @@ func test_game_logger_falls_back_to_original_file_when_no_backtrace() -> void:
 	var pending: Array = logger.drain()
 	assert_eq(pending.size(), 1)
 	assert_contains(pending[0][1], "res://foo.gd:42", "Fallback path:line should appear when no backtrace is present")
+
+
+# ----- game_eval -----
+
+func test_game_eval_missing_code_returns_error() -> void:
+	var result := _handler.game_eval({})
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
+
+
+func test_game_eval_without_debugger_plugin_returns_error() -> void:
+	## _handler is constructed without a debugger plugin in suite_setup,
+	## so game_eval should return INTERNAL_ERROR.
+	var result := _handler.game_eval({"code": "return 42"})
+	assert_is_error(result, ErrorCodes.INTERNAL_ERROR)
+
+
+func test_game_eval_silently_drops_unknown_eval_response() -> void:
+	## _on_eval_response for an unknown request_id must silently drop
+	## without crashing (same pattern as screenshot_error_unknown_request).
+	var plugin := McpDebuggerPlugin.new()
+	plugin._on_eval_response(["unknown-id", "42"])
+	assert_true(true, "No crash when replying to unknown eval request_id")
+
+
+func test_game_eval_silently_drops_unknown_eval_error() -> void:
+	var plugin := McpDebuggerPlugin.new()
+	plugin._on_eval_error(["unknown-id", "some error"])
+	assert_true(true, "No crash when replying to unknown eval request_id")
 	assert_contains(pending[0][1], "my_func", "Fallback function name should appear when no backtrace is present")

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -1300,4 +1300,3 @@ func test_game_eval_silently_drops_unknown_eval_error() -> void:
 	var plugin := McpDebuggerPlugin.new()
 	plugin._on_eval_error(["unknown-id", "some error"])
 	assert_true(true, "No crash when replying to unknown eval request_id")
-	assert_contains(pending[0][1], "my_func", "Fallback function name should appear when no backtrace is present")

--- a/tests/unit/test_game_eval.py
+++ b/tests/unit/test_game_eval.py
@@ -1,6 +1,7 @@
 """Tests for the game_eval handler."""
 
 import pytest
+
 from godot_ai.handlers import editor as editor_handlers
 from godot_ai.runtime.direct import DirectRuntime
 from godot_ai.sessions.registry import SessionRegistry

--- a/tests/unit/test_game_eval.py
+++ b/tests/unit/test_game_eval.py
@@ -1,0 +1,54 @@
+"""Tests for the game_eval handler."""
+
+import pytest
+from godot_ai.handlers import editor as editor_handlers
+from godot_ai.runtime.direct import DirectRuntime
+from godot_ai.sessions.registry import SessionRegistry
+
+
+class _StubGameEvalClient:
+    """Records send() calls and returns canned game_eval responses."""
+
+    def __init__(self, *, eval_result: dict | None = None):
+        self.calls: list[dict] = []
+        self._eval_result = eval_result or {"data": {"result": "42", "source": "game"}}
+
+    async def send(self, command: str, params: dict | None = None,
+                   session_id: str | None = None, timeout: float = 5.0) -> dict:
+        self.calls.append({
+            "command": command, "params": params,
+            "session_id": session_id, "timeout": timeout,
+        })
+        if command == "game_eval":
+            return self._eval_result
+        return {"data": {}}
+
+
+@pytest.mark.asyncio
+async def test_game_eval_dispatches_command():
+    client = _StubGameEvalClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await editor_handlers.game_eval(runtime, code="return 42")
+    assert client.calls[-1]["command"] == "game_eval"
+    assert client.calls[-1]["params"] == {"code": "return 42"}
+    assert result["data"]["result"] == "42"
+    assert result["data"]["source"] == "game"
+
+
+@pytest.mark.asyncio
+async def test_game_eval_uses_custom_timeout():
+    client = _StubGameEvalClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    await editor_handlers.game_eval(runtime, code="return 1")
+    assert client.calls[-1]["timeout"] == 15.0
+
+
+@pytest.mark.asyncio
+async def test_game_eval_passes_code_verbatim():
+    client = _StubGameEvalClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    await editor_handlers.game_eval(
+        runtime,
+        code="return get_tree().root.name"
+    )
+    assert client.calls[-1]["params"]["code"] == "return get_tree().root.name"


### PR DESCRIPTION
Reuses the existing EngineDebugger bridge (same channel as screenshots).

Editor sends mcp:eval via debugger to game_helper autoload, which wraps

user code in a temp Node, executes it, serializes the return value with

_variant_to_json (Vector2/3/4, Color, Transform, Rect, AABB, packed

arrays, nested dicts/arrays), and returns the result.

- game_helper.gd: _handle_eval, _variant_to_json, _indent_eval_code
- mcp_debugger_plugin.gd: request_game_eval, response capture, 10s timeout
- editor_handler.gd: game_eval handler (DEFERRED_RESPONSE pattern)
- plugin.gd: dispatcher registration
- dispatcher.gd: 15s deferred timeout
- handlers/editor.py: Python async handler wrapper
- tools/editor.py: editor_manage op registration