### PR TITLE
Fix #450: rename release zip's top-level LICENSE so install doesn't clobber user files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,32 +87,40 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Build plugin ZIP
-        # Ship `addons/` + `LICENSE` at the zip's top level. The multi-top
-        # shape matters: Godot's AssetLib install dialog defaults "Ignore
-        # asset root" to CHECKED whenever it detects a single top-level
-        # folder, which would strip `addons/` and drop `godot_ai/` at
+        # Ship `addons/` + `godot-ai-LICENSE.txt` at the zip's top level. The
+        # multi-top shape matters: Godot's AssetLib install dialog defaults
+        # "Ignore asset root" to CHECKED whenever it detects a single top-
+        # level folder, which would strip `addons/` and drop `godot_ai/` at
         # res:// — outside the plugin path and outside the addons-warning
         # exclusion. With two top-level entries, Godot doesn't offer the
         # strip option, so files land as-archived at res://addons/godot_ai/
         # regardless of any user-toggled preference.
+        #
+        # The second top-level entry is namespaced (`godot-ai-LICENSE.txt`)
+        # rather than a bare `LICENSE`. A bare `LICENSE` lands at
+        # `res://LICENSE` on install and silently overwrites the user's own
+        # project LICENSE file — issue #450. The namespaced name preserves
+        # the AssetLib trick without clobbering anything in a typical project.
+        # The canonical addon-scoped license still ships at
+        # `addons/godot_ai/LICENSE` for in-tree consumers.
         run: |
           mkdir -p staging/addons
           cp -r plugin/addons/godot_ai staging/addons/
-          cp LICENSE staging/
+          cp LICENSE staging/godot-ai-LICENSE.txt
           cd staging
           # `-D` strips zero-byte directory entries. The 2.2.x/2.3.0 self-
           # update runner has an over-strict safety check that flags the
           # bare `addons/godot_ai/` directory entry as unsafe and aborts
           # the extract. Stripping directory entries lets those installs
           # successfully self-update to a fixed runner.
-          zip -D -r ../godot-ai-plugin.zip addons/ LICENSE
+          zip -D -r ../godot-ai-plugin.zip addons/ godot-ai-LICENSE.txt
 
       - name: Verify zip structure
         run: |
           # unzip -Z1 lists only entry names, one per line, no header/footer
           tops=$(unzip -Z1 godot-ai-plugin.zip | awk -F/ '{print $1}' | sort -u | tr '\n' ' ' | sed 's/ $//')
-          if [ "$tops" != "LICENSE addons" ]; then
-            echo "ERROR: expected top-level entries 'LICENSE addons' in zip, got:" >&2
+          if [ "$tops" != "addons godot-ai-LICENSE.txt" ]; then
+            echo "ERROR: expected top-level entries 'addons godot-ai-LICENSE.txt' in zip, got:" >&2
             echo "  $tops" >&2
             exit 1
           fi
@@ -120,8 +128,15 @@ jobs:
             echo "ERROR: plugin.cfg not at expected path addons/godot_ai/plugin.cfg" >&2
             exit 1
           fi
-          if ! unzip -Z1 godot-ai-plugin.zip | grep -qx 'LICENSE'; then
-            echo "ERROR: LICENSE not present at zip root" >&2
+          if ! unzip -Z1 godot-ai-plugin.zip | grep -qx 'godot-ai-LICENSE.txt'; then
+            echo "ERROR: godot-ai-LICENSE.txt not present at zip root" >&2
+            exit 1
+          fi
+          # Guard against the issue-#450 regression: a bare `LICENSE` at zip
+          # root would silently overwrite the installing project's own
+          # LICENSE on AssetLib install.
+          if unzip -Z1 godot-ai-plugin.zip | grep -qx 'LICENSE'; then
+            echo "ERROR: zip contains bare 'LICENSE' at root — would clobber user project LICENSE on install (see #450)" >&2
             exit 1
           fi
           # Hard-fail if the zip contains zero-byte directory entries (paths
@@ -144,7 +159,7 @@ jobs:
             unzip -Z1 godot-ai-plugin.zip | grep ' 2\.' >&2
             exit 1
           fi
-          echo "Zip structure verified: addons/godot_ai/... + LICENSE (multi-top)"
+          echo "Zip structure verified: addons/godot_ai/... + godot-ai-LICENSE.txt (multi-top)"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3

--- a/tests/unit/test_release_zip_shape.py
+++ b/tests/unit/test_release_zip_shape.py
@@ -1,0 +1,62 @@
+"""Pin the release-zip contract enforced by `.github/workflows/release.yml`.
+
+This test exists to keep two invariants from regressing in CI's
+`build-plugin-zip` step, both motivated by issue #450:
+
+  1. The zip's second top-level entry is `godot-ai-LICENSE.txt`, not a
+     bare `LICENSE`. A bare `LICENSE` lands at `res://LICENSE` on
+     AssetLib install and silently overwrites the user's own project
+     LICENSE file.
+
+  2. The multi-top-level shape (`addons/` + a sibling file) is preserved.
+     A single-top-folder zip lets AssetLib's "Ignore asset root" toggle
+     strip the `addons/` prefix and drop `godot_ai/` outside the
+     plugin path.
+
+We assert against the workflow YAML text directly so a casual edit (e.g.
+"clean up the rename, just call it LICENSE again") trips this test before
+shipping a release that would clobber user files.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "release.yml"
+
+
+@pytest.fixture(scope="module")
+def workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_release_zip_uses_namespaced_license_filename(workflow_text: str) -> None:
+    assert "godot-ai-LICENSE.txt" in workflow_text, (
+        "release.yml should ship LICENSE under the namespaced name "
+        "godot-ai-LICENSE.txt — see issue #450."
+    )
+
+
+def test_release_zip_does_not_pack_bare_license_at_root(workflow_text: str) -> None:
+    # The `zip` invocation must not include a bare `LICENSE` argument at
+    # the top level. We look for the specific `zip -D -r ... LICENSE`
+    # shape the workflow uses; substring-matching `LICENSE` alone would
+    # false-positive on the namespaced filename.
+    forbidden = "../godot-ai-plugin.zip addons/ LICENSE"
+    assert forbidden not in workflow_text, (
+        "release.yml must not pack a bare `LICENSE` at zip root — that "
+        "clobbers the installing project's own LICENSE file (issue #450)."
+    )
+
+
+def test_release_zip_preserves_multi_top_shape(workflow_text: str) -> None:
+    # The whole point of having a sibling file alongside `addons/` is to
+    # keep AssetLib from offering the "Ignore asset root" strip option.
+    # If a future cleanup drops the sibling entirely, the strip
+    # regression returns.
+    assert "addons/ godot-ai-LICENSE.txt" in workflow_text, (
+        "release.yml must keep the multi-top-level zip shape so "
+        "AssetLib doesn't strip the `addons/` prefix on install."
+    )

--- a/tests/unit/test_self_update_rescue_contract.py
+++ b/tests/unit/test_self_update_rescue_contract.py
@@ -38,7 +38,7 @@ _REAL_FILES: tuple[tuple[str, bytes], ...] = (
     ("addons/godot_ai/plugin.cfg", b'[plugin]\nname="godot-ai"\n'),
     ("addons/godot_ai/plugin.gd", b"@tool\nextends EditorPlugin\n"),
     ("addons/godot_ai/utils/example.gd", b"extends RefCounted\n"),
-    ("LICENSE", b"MIT\n"),
+    ("godot-ai-LICENSE.txt", b"MIT\n"),
 )
 
 # Directory entries an unstripped `zip -r` (without `-D`) would emit. Note


### PR DESCRIPTION
## Summary

Fixes #450. AssetLib install of the plugin currently silently overwrites the user's own `res://LICENSE` with our MIT license — the release zip ships `LICENSE` at the zip root, and AssetLib extracts it as-archived to `res://LICENSE`.

The bare `LICENSE` at zip root was deliberate: it's the second top-level entry that defeats AssetLib's "Ignore asset root" auto-strip heuristic (single-top-folder zips lose their first segment, which would drop `godot_ai/` outside `addons/`). Fix is to keep the multi-top shape but rename the sibling entry to a namespaced filename that can't realistically collide with anything in a user project.

## Changes

- `.github/workflows/release.yml`: rename top-level `LICENSE` → `godot-ai-LICENSE.txt` in both the `zip` invocation and the verify step. Add a guard that fails the build if a bare `LICENSE` ever reappears at zip root. Update the multi-top docstring to call out the #450 rationale.
- `tests/unit/test_self_update_rescue_contract.py`: update the fixture's representative non-addons entry to match the new filename. (Doesn't affect the rescue logic — the rescue test cares about directory entries, not the LICENSE name — but keeps the fixture aligned with the real release shape.)
- `tests/unit/test_release_zip_shape.py` (new): pin three invariants against the workflow YAML — uses the namespaced filename, never packs a bare `LICENSE` at root, and preserves the multi-top shape so AssetLib doesn't strip `addons/`.

The canonical addon-scoped license still ships at `addons/godot_ai/LICENSE`. The self-update path is unaffected — `update_reload_runner.gd::_is_safe_zip_addon_file` already gates on the `addons/godot_ai/` prefix and skips any other top-level entry.

## Test plan

- [x] `pytest tests/unit/ -x -q` → 789 passed
- [x] `ruff check tests/unit/test_release_zip_shape.py tests/unit/test_self_update_rescue_contract.py` → clean
- [x] Local zip-build smoke (`mkdir staging && cp LICENSE staging/godot-ai-LICENSE.txt && zip -D -r ...`): top-level entries are exactly `addons godot-ai-LICENSE.txt`, `plugin.cfg` lands at `addons/godot_ai/plugin.cfg`, no bare `LICENSE` present.
- [ ] On next release tag, confirm the published `godot-ai-plugin.zip` has the new shape, then test-install into a project that already has its own `LICENSE` and verify the file is untouched.

Note for existing installs: this only changes the release-zip shape going forward. Users who already installed the plugin and saw their project `LICENSE` overwritten will need to restore their own LICENSE from git history. Worth a callout in the next release notes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8Kkjean5iX8323Vvk2RPP)_