### PR TITLE
Ignore .claude/worktrees/ in repo gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,10 @@ export_presets.cfg
 *.swo
 *~
 
+# Claude Code worktrees (per-session checkouts under .claude/worktrees/)
+# — .claude/settings.json, hooks/, skills/ are tracked; worktrees/ is local-only.
+.claude/worktrees/
+
 # OS
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
## Summary

- `.claude/worktrees/` (per-session Claude Code worktrees) was untracked but not ignored, which caused branch switches in the main checkout to be blocked with "uncommitted changes" until the user manually stashed.
- `.claude/settings.json`, `.claude/hooks/`, and `.claude/skills/` stay tracked — only the local worktree checkouts are excluded.

## Test plan

- [x] `git status` clean in main checkout after pulling this change
- [x] Other tracked `.claude/` files unaffected (`git ls-files .claude/` still shows hooks, settings, skills)

🤖 Generated with [Claude Code](https://claude.com/claude-code)