### PR TITLE
Followup changes for https://github.com/hi-godot/godot-ai/pull/446

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -18,7 +18,8 @@ goes, and how to opt out. All telemetry code is open source and lives in
 - **Non-blocking**: events go through a bounded in-process queue and a
   single daemon worker. Telemetry failures never propagate to tool
   callers.
-- **Easy opt-out**: one environment variable. See "Opting out" below.
+- **Easy opt-out**: Respects opt-out via environment variable or through
+  in-editor settings menu. See "Opting out" below.
 
 ## What we collect
 
@@ -83,7 +84,7 @@ export GODOT_AI_DISABLE_TELEMETRY=true
 export DISABLE_TELEMETRY=true
 ```
 
-If either of the above environment variables are enabled, the opt-out is
+If either of the above environment variables is enabled, the opt-out is
 saved to Godot's editor settings and will persist between runs. Similarly,
 if an environment variable is explicitly set and disabled, that will be
 persisted to the editor settings.
@@ -93,12 +94,11 @@ startup.
 
 ### Effect
 
-On opt-out (whether via UI or env var): the collector enters disabled
-mode. No records are enqueued, no UUID is generated, no worker thread is
-spawned, and no data directory is created. Existing local telemetry
-files (`customer_uuid.txt`, `milestones.json`) are deleted on the next
-server startup. The plugin-side helper honors the same variables and
-stops buffering events. Opt-out is fully side-effect-free.
+On opt-out, the collector enters disabled mode. No records are enqueued,
+no UUID is generated, no worker thread is spawned, and no data directory
+is created. Existing local telemetry files (`customer_uuid.txt`,
+`milestones.json`) are deleted on the next server startup. The plugin-side
+helper honors the same variables and stops buffering events.
 
 ## Endpoint configuration
 

--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -34,25 +34,16 @@ const SERVER_NAME := "godot-ai"
 ## the Windows-reservation diagnostics this is the escape hatch for.
 const DEFAULT_HTTP_PORT := 8000
 const DEFAULT_WS_PORT := 9500
-const SETTING_HTTP_PORT := "godot_ai/http_port"
-const SETTING_WS_PORT := "godot_ai/ws_port"
-const SETTING_STARTUP_TRACE := "godot_ai/log_startup_timing"
 const STARTUP_TRACE_ENV := "GODOT_AI_STARTUP_TRACE"
 const MIN_PORT := 1024
 const MAX_PORT := 65535
-
-## Comma-separated list of tool domains to drop from the server at spawn
-## time. Maps 1:1 onto the `--exclude-domains` CLI flag. Set via the dock's
-## "Tools" tab; a change requires a server restart (the dock handles this
-## by triggering a plugin reload). Unknown names are warned about on the
-## Python side and skipped, so an EditorSetting left over from a previous
-## plugin version can't wedge the spawn.
-const SETTING_EXCLUDED_DOMAINS := "godot_ai/excluded_domains"
+const SETTING_WS_PORT := "godot_ai/ws_port"
+const SETTING_STARTUP_TRACE := "godot_ai/log_startup_timing"
 
 
 ## Active HTTP port: user override (if in range) or `DEFAULT_HTTP_PORT`.
 static func http_port() -> int:
-	return _read_port_setting(SETTING_HTTP_PORT, DEFAULT_HTTP_PORT)
+	return _read_port_setting(McpSettings.SETTING_HTTP_PORT, DEFAULT_HTTP_PORT)
 
 
 ## Active WebSocket port: user override (if in range) or `DEFAULT_WS_PORT`.
@@ -83,7 +74,7 @@ static func ensure_settings_registered() -> void:
 	var es := EditorInterface.get_editor_settings()
 	if es == null:
 		return
-	_register_port_setting(es, SETTING_HTTP_PORT, DEFAULT_HTTP_PORT)
+	_register_port_setting(es, McpSettings.SETTING_HTTP_PORT, DEFAULT_HTTP_PORT)
 	_register_port_setting(es, SETTING_WS_PORT, DEFAULT_WS_PORT)
 	_register_bool_setting(es, SETTING_STARTUP_TRACE, false)
 
@@ -128,9 +119,9 @@ static func startup_trace_enabled() -> bool:
 ## `--exclude-domains` don't see an empty argument.
 static func excluded_domains() -> String:
 	var es := EditorInterface.get_editor_settings()
-	if es == null or not es.has_setting(SETTING_EXCLUDED_DOMAINS):
+	if es == null or not es.has_setting(McpSettings.SETTING_EXCLUDED_DOMAINS):
 		return ""
-	var raw := str(es.get_setting(SETTING_EXCLUDED_DOMAINS))
+	var raw := str(es.get_setting(McpSettings.SETTING_EXCLUDED_DOMAINS))
 	var parts := PackedStringArray()
 	for p in raw.split(","):
 		var t := p.strip_edges()

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -595,7 +595,8 @@ func _build_ui() -> void:
 
 	_clients_window = Window.new()
 	_clients_window.title = "MCP Clients & Settings"
-	_clients_window.min_size = Vector2i(Vector2i(560, 460) * EditorInterface.get_editor_scale())
+	## `Vector2i * float` yields Vector2; wrap the result back to Vector2i.
+	_clients_window.min_size = Vector2i(Vector2(560, 460) * EditorInterface.get_editor_scale())
 	_clients_window.visible = false
 	_clients_window.close_requested.connect(_on_clients_window_close_requested)
 	add_child(_clients_window)

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -381,12 +381,12 @@ func _on_redock() -> void:
 
 
 func _build_margin_container(margin: int = 12) -> MarginContainer:
-	var marginContainer := MarginContainer.new()
-	marginContainer.add_theme_constant_override("margin_left", margin)
-	marginContainer.add_theme_constant_override("margin_right", margin)
-	marginContainer.add_theme_constant_override("margin_top", margin)
-	marginContainer.add_theme_constant_override("margin_bottom", margin)
-	return marginContainer
+	var margin_container := MarginContainer.new()
+	margin_container.add_theme_constant_override("margin_left", margin)
+	margin_container.add_theme_constant_override("margin_right", margin)
+	margin_container.add_theme_constant_override("margin_top", margin)
+	margin_container.add_theme_constant_override("margin_bottom", margin)
+	return margin_container
 
 
 func _build_ui() -> void:
@@ -571,7 +571,7 @@ func _build_ui() -> void:
 
 	var clients_open_btn := Button.new()
 	clients_open_btn.text = "Clients & Settings"
-	clients_open_btn.tooltip_text = "Open the MCP settings window — configure AI clients or disable tool domains to fit under a client's hard tool-count cap (e.g. Antigravity's 100)."
+	clients_open_btn.tooltip_text = "Open the MCP settings window — configure AI clients, choose telemetry preferences, or disable tool domains to fit under a client's hard tool-count cap (e.g. Antigravity's 100)."
 	clients_open_btn.pressed.connect(_on_open_clients_window)
 	clients_row.add_child(clients_open_btn)
 
@@ -595,7 +595,7 @@ func _build_ui() -> void:
 
 	_clients_window = Window.new()
 	_clients_window.title = "MCP Clients & Settings"
-	_clients_window.min_size = Vector2i(560, 460) * EditorInterface.get_editor_scale()
+	_clients_window.min_size = Vector2i(Vector2i(560, 460) * EditorInterface.get_editor_scale())
 	_clients_window.visible = false
 	_clients_window.close_requested.connect(_on_clients_window_close_requested)
 	add_child(_clients_window)
@@ -991,7 +991,7 @@ func _on_log_logging_enabled_changed(enabled: bool) -> void:
 func _on_port_apply_requested(new_port: int) -> void:
 	var es := EditorInterface.get_editor_settings()
 	if es != null:
-		es.set_setting(ClientConfigurator.SETTING_HTTP_PORT, new_port)
+		es.set_setting(McpSettings.SETTING_HTTP_PORT, new_port)
 	## Every saved client config now points at the old port. Re-sweep so the
 	## drift banner appears in the same frame the user committed the change —
 	## the plugin reload below will run a second sweep on its own first paint,
@@ -1015,19 +1015,13 @@ func _refresh_server_label() -> void:
 # --- Telemetry setting persistence ---
 
 
-func _env_truthy(var_name: String) -> bool:
-	var val: String = OS.get_environment(var_name).strip_edges().to_lower()
-	return val in ["1", "true", "yes", "on"]
-
-
 ## Returns true if GODOT_AI_DISABLE_TELEMETRY or DISABLE_TELEMETRY is set
 ## to a truthy value, false if either is set and non-truthy, null if neither
 ## env var is present at all.
 func _is_telemetry_disabled_via_env() -> Variant:
-	var disabled: bool = _env_truthy("GODOT_AI_DISABLE_TELEMETRY") or _env_truthy("DISABLE_TELEMETRY")
-	if OS.has_environment("GODOT_AI_DISABLE_TELEMETRY") or OS.has_environment("DISABLE_TELEMETRY"):
-		return disabled
-	return null
+	if not (OS.has_environment("GODOT_AI_DISABLE_TELEMETRY") or OS.has_environment("DISABLE_TELEMETRY")):
+		return null
+	return McpSettings.env_truthy("GODOT_AI_DISABLE_TELEMETRY") or McpSettings.env_truthy("DISABLE_TELEMETRY")
 
 
 ## Reads the telemetry preference, applying env-var override when present.
@@ -1044,15 +1038,15 @@ func _load_telemetry_setting() -> void:
 		## the env var honour the last-set value.
 		enabled = not bool(env_disabled)
 		if es != null:
-			es.set_setting("godot_ai/telemetry_enabled", enabled)
+			es.set_setting(McpSettings.SETTING_TELEMETRY_ENABLED, enabled)
 	else:
 		## No env var: read (or create) the EditorSettings key.
-		if es != null and es.has_setting("godot_ai/telemetry_enabled"):
-			enabled = bool(es.get_setting("godot_ai/telemetry_enabled"))
+		if es != null and es.has_setting(McpSettings.SETTING_TELEMETRY_ENABLED):
+			enabled = bool(es.get_setting(McpSettings.SETTING_TELEMETRY_ENABLED))
 		else:
 			enabled = true
 			if es != null:
-				es.set_setting("godot_ai/telemetry_enabled", true)
+				es.set_setting(McpSettings.SETTING_TELEMETRY_ENABLED, true)
 
 	_telemetry_pending_enabled = enabled
 	_telemetry_saved_enabled = enabled
@@ -1117,7 +1111,7 @@ func _apply_dev_mode_visibility() -> void:
 # --- Button handlers ---
 
 
-func _do_plugin_reload():
+func _do_plugin_reload() -> void:
 	EditorInterface.set_plugin_enabled("res://addons/godot_ai/plugin.cfg", false)
 	EditorInterface.set_plugin_enabled("res://addons/godot_ai/plugin.cfg", true)
 
@@ -1920,14 +1914,14 @@ func _on_tools_apply() -> void:
 	var canonical_excluded := ToolCatalog.canonical(_tools_pending_excluded)
 	var es := EditorInterface.get_editor_settings()
 	if es != null:
-		es.set_setting(ClientConfigurator.SETTING_EXCLUDED_DOMAINS, canonical_excluded)
-		es.set_setting("godot_ai/telemetry_enabled", _telemetry_pending_enabled)
+		es.set_setting(McpSettings.SETTING_EXCLUDED_DOMAINS, canonical_excluded)
+		es.set_setting(McpSettings.SETTING_TELEMETRY_ENABLED, _telemetry_pending_enabled)
 	_tools_saved_excluded = _tools_pending_excluded.duplicate()
 	_telemetry_saved_enabled = _telemetry_pending_enabled
 	_refresh_tools_ui_state()
-	## Plugin reload respawns the server with the new `--exclude-domains`
-	## flag (see `plugin.gd::_build_server_flags`). Mirrors the port-change
-	## Apply flow.
+	## Plugin reload respawns the server with the new `--exclude-domains` flag
+	## (see `plugin.gd::_build_server_flags`) and telemetry option. Mirrors the
+	## port-change Apply flow.
 	_on_reload_plugin()
 
 

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -534,7 +534,7 @@ static func _mcp_disabled_for_headless_launch() -> bool:
 
 
 static func _mcp_disabled_for_headless(args: PackedStringArray, display_name: String, allow_value: String) -> bool:
-	if _env_truthy(allow_value):
+	if McpSettings.truthy(allow_value):
 		return false
 	return _args_request_headless(args) or display_name.to_lower() == "headless"
 
@@ -551,12 +551,6 @@ static func _args_request_headless(args: PackedStringArray) -> bool:
 	return false
 
 
-static func _env_truthy(value: String) -> bool:
-	match value.strip_edges().to_lower():
-		"1", "true", "yes", "on":
-			return true
-		_:
-			return false
 
 
 func _disable_plugin() -> void:
@@ -1538,7 +1532,10 @@ func start_dev_server() -> void:
 			var new_pp := worktree_src if prev_pythonpath.is_empty() else worktree_src + sep + prev_pythonpath
 			OS.set_environment("PYTHONPATH", new_pp)
 
+		var injected_telemetry: bool = _lifecycle._inject_telemetry_env()
 		var pid := OS.create_process(cmd, inner_args)
+		if injected_telemetry:
+			OS.unset_environment("GODOT_AI_DISABLE_TELEMETRY")
 
 		## Restore PYTHONPATH immediately — the spawned child has already
 		## copied the env, so the editor's own process state returns to

--- a/plugin/addons/godot_ai/telemetry.gd
+++ b/plugin/addons/godot_ai/telemetry.gd
@@ -8,11 +8,16 @@
 ## and the bounded-queue worker stay in one place (Python), not
 ## duplicated in GDScript.
 ##
-## Opt-out: honors `GODOT_AI_DISABLE_TELEMETRY` and `DISABLE_TELEMETRY`
-## environment variables on the GDScript side too, so events are never
-## buffered (let alone sent) when the operator opts out — useful when
-## a tester wants to confirm the disable flag is effective before any
-## handshake has happened.
+## Opt-out options priority:
+##   1. `GODOT_AI_DISABLE_TELEMETRY` / `DISABLE_TELEMETRY` env vars —
+##      checked first so CI / operators can force-disable without touching
+##      EditorSettings.
+##   2. The `godot_ai/telemetry_enabled` EditorSetting — set through the
+## 		mcp dock and persisted between sessions.
+##
+## When telemetry is disabled, events are never buffered or sent. If an env
+## var is explicitly set to a non-truthy value, telemetry is enabled even if
+## the editor setting is false.
 ##
 ## Buffering: events recorded before the WebSocket is connected go into
 ## a small bounded buffer and flush on the next `record_event` call once
@@ -83,7 +88,7 @@ var _pending: Array = []  # of {name: String, data: Dictionary}
 
 func _init(connection) -> void:
 	_connection = connection
-	_disabled = _resolve_disabled()
+	_disabled = not McpSettings.telemetry_enabled()
 	## Subscribe to ``connection_state_changed`` so events buffered before
 	## the WebSocket handshake (e.g. ``record_dock_startup`` from
 	## ``plugin._enter_tree``) actually leave the editor. Without this,
@@ -93,17 +98,6 @@ func _init(connection) -> void:
 	if _connection != null and _connection.has_signal("connection_state_changed"):
 		_connection.connection_state_changed.connect(_on_connection_state_changed)
 
-static func _truthy(value: String) -> bool:
-	## Match ``plugin.gd::_env_truthy`` semantics — ``strip_edges()`` so
-	## a stray ``" true "`` from shell quoting still parses as truthy.
-	return value.strip_edges().to_lower() in ["1", "true", "yes", "on"]
-
-static func _resolve_disabled() -> bool:
-	if _truthy(OS.get_environment("GODOT_AI_DISABLE_TELEMETRY")):
-		return true
-	if _truthy(OS.get_environment("DISABLE_TELEMETRY")):
-		return true
-	return false
 
 func record_event(name: String, data: Dictionary = {}) -> void:
 	if _disabled:

--- a/plugin/addons/godot_ai/telemetry.gd
+++ b/plugin/addons/godot_ai/telemetry.gd
@@ -13,7 +13,7 @@
 ##      checked first so CI / operators can force-disable without touching
 ##      EditorSettings.
 ##   2. The `godot_ai/telemetry_enabled` EditorSetting — set through the
-## 		mcp dock and persisted between sessions.
+##      MCP dock and persisted between sessions.
 ##
 ## When telemetry is disabled, events are never buffered or sent. If an env
 ## var is explicitly set to a non-truthy value, telemetry is enabled even if

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -391,15 +391,12 @@ static func _live_package_path_for_message(live: Dictionary) -> String:
 ## "godot_ai/telemetry_enabled" is set to false. Returns true if the var was
 ## injected so the caller can unset it after spawning.
 func _inject_telemetry_env() -> bool:
+	## Guard: if the user or CI already set an env var (even to "false"), leave
+	## it alone. McpSettings.telemetry_enabled() only reads the EditorSetting
+	## when no env var overrides are present.
 	if OS.has_environment("GODOT_AI_DISABLE_TELEMETRY") or OS.has_environment("DISABLE_TELEMETRY"):
 		return false
-	var es := EditorInterface.get_editor_settings()
-	var telemetry_enabled: bool = (
-		bool(es.get_setting("godot_ai/telemetry_enabled"))
-		if es != null and es.has_setting("godot_ai/telemetry_enabled")
-		else true
-	)
-	if not telemetry_enabled:
+	if not McpSettings.telemetry_enabled():
 		OS.set_environment("GODOT_AI_DISABLE_TELEMETRY", "true")
 		return true
 	return false

--- a/plugin/addons/godot_ai/utils/settings.gd
+++ b/plugin/addons/godot_ai/utils/settings.gd
@@ -1,0 +1,39 @@
+@tool
+class_name McpSettings
+extends RefCounted
+
+## Shared EditorSettings key constants for the godot_ai/* namespace.
+##
+## Centralised here so lightweight files (e.g. telemetry.gd) can reference
+## settings keys without pulling in the full client_configurator.gd dep tree.
+## All keys must keep their raw string values stable across releases because
+## they are persisted in the user's editor_settings-4.tres.
+
+const SETTING_HTTP_PORT := "godot_ai/http_port"
+## Comma-separated list of tool domains excluded from the server at spawn time.
+const SETTING_EXCLUDED_DOMAINS := "godot_ai/excluded_domains"
+const SETTING_TELEMETRY_ENABLED := "godot_ai/telemetry_enabled"
+
+
+## Returns true if the string value is truthy
+## ("1", "true", "yes", "on", case-insensitive, whitespace-trimmed).
+static func truthy(value: String) -> bool:
+	return value.strip_edges().to_lower() in ["1", "true", "yes", "on"]
+
+
+## Returns true if the named environment variable is set to a truthy value.
+static func env_truthy(var_name: String) -> bool:
+	return truthy(OS.get_environment(var_name))
+
+
+## Returns true if telemetry should be active, checking in priority order:
+##   1. GODOT_AI_DISABLE_TELEMETRY / DISABLE_TELEMETRY env vars
+##   2. The godot_ai/telemetry_enabled EditorSetting written by the dock UI
+## Defaults to true when neither source has set a preference.
+static func telemetry_enabled() -> bool:
+	if env_truthy("GODOT_AI_DISABLE_TELEMETRY") or env_truthy("DISABLE_TELEMETRY"):
+		return false
+	var es := EditorInterface.get_editor_settings()
+	if es != null and es.has_setting(SETTING_TELEMETRY_ENABLED):
+		return bool(es.get_setting(SETTING_TELEMETRY_ENABLED))
+	return true

--- a/plugin/addons/godot_ai/utils/settings.gd.uid
+++ b/plugin/addons/godot_ai/utils/settings.gd.uid
@@ -1,0 +1,1 @@
+uid://pefrtofs7ijw

--- a/script/local-self-update-smoke
+++ b/script/local-self-update-smoke
@@ -396,7 +396,12 @@ def patch_fixture_plugin(
     # fire as the documented historical constraint).
     _require_v240_plus_addon_shape(addon_dir, version)
     patch_plugin_cfg(addon_dir / "plugin.cfg", version)
-    patch_port_isolation(addon_dir / "client_configurator.gd", http_port, ws_port)
+    patch_port_isolation(
+        addon_dir / "client_configurator.gd",
+        addon_dir / "utils" / "settings.gd",
+        http_port,
+        ws_port,
+    )
     patch_server_package_pin(addon_dir / "client_configurator.gd", server_version)
     patch_managed_record_isolation(addon_dir / "plugin.gd")
     patch_lifecycle_expected_server_version(
@@ -451,42 +456,50 @@ def patch_plugin_cfg(path: Path, version: str) -> None:
     path.write_text(text, encoding="utf-8")
 
 
-def patch_port_isolation(path: Path, http_port: int, ws_port: int) -> None:
-    text = path.read_text(encoding="utf-8")
+def patch_port_isolation(
+    configurator_path: Path, settings_path: Path, http_port: int, ws_port: int
+) -> None:
+    # SETTING_HTTP_PORT and SETTING_EXCLUDED_DOMAINS live in utils/settings.gd.
+    stext = settings_path.read_text(encoding="utf-8")
+    stext = replace_once(
+        settings_path,
+        stext,
+        'const SETTING_HTTP_PORT := "godot_ai/http_port"',
+        'const SETTING_HTTP_PORT := "godot_ai_self_update_smoke/http_port"',
+        "SETTING_HTTP_PORT",
+    )
+    stext = replace_once(
+        settings_path,
+        stext,
+        'const SETTING_EXCLUDED_DOMAINS := "godot_ai/excluded_domains"',
+        'const SETTING_EXCLUDED_DOMAINS := "godot_ai_self_update_smoke/excluded_domains"',
+        "SETTING_EXCLUDED_DOMAINS",
+    )
+    settings_path.write_text(stext, encoding="utf-8")
+
+    # DEFAULT_HTTP_PORT, DEFAULT_WS_PORT, SETTING_WS_PORT, and
+    # _read_port_setting all remain in client_configurator.gd.
+    text = configurator_path.read_text(encoding="utf-8")
     text = subn_once(
-        path,
+        configurator_path,
         text,
         r"const DEFAULT_HTTP_PORT := \d+",
         f"const DEFAULT_HTTP_PORT := {http_port}",
         "DEFAULT_HTTP_PORT",
     )
     text = subn_once(
-        path,
+        configurator_path,
         text,
         r"const DEFAULT_WS_PORT := \d+",
         f"const DEFAULT_WS_PORT := {ws_port}",
         "DEFAULT_WS_PORT",
     )
     text = replace_once(
-        path,
-        text,
-        'const SETTING_HTTP_PORT := "godot_ai/http_port"',
-        'const SETTING_HTTP_PORT := "godot_ai_self_update_smoke/http_port"',
-        "SETTING_HTTP_PORT",
-    )
-    text = replace_once(
-        path,
+        configurator_path,
         text,
         'const SETTING_WS_PORT := "godot_ai/ws_port"',
         'const SETTING_WS_PORT := "godot_ai_self_update_smoke/ws_port"',
         "SETTING_WS_PORT",
-    )
-    text = replace_once(
-        path,
-        text,
-        'const SETTING_EXCLUDED_DOMAINS := "godot_ai/excluded_domains"',
-        'const SETTING_EXCLUDED_DOMAINS := "godot_ai_self_update_smoke/excluded_domains"',
-        "SETTING_EXCLUDED_DOMAINS",
     )
     text = replace_function(
         text,
@@ -496,7 +509,7 @@ def patch_port_isolation(path: Path, http_port: int, ws_port: int) -> None:
 \t## global EditorSettings. Keep its ports deterministic and fixture-local.
 \treturn default_port""",
     )
-    path.write_text(text, encoding="utf-8")
+    configurator_path.write_text(text, encoding="utf-8")
 
 
 def patch_server_package_pin(path: Path, server_version: str) -> None:

--- a/src/godot_ai/telemetry.py
+++ b/src/godot_ai/telemetry.py
@@ -138,9 +138,9 @@ class TelemetryConfig:
     overrides the default for self-hosters and during smoke testing.
 
     Privacy posture matches the docs in ``docs/TELEMETRY.md``: only
-    anonymous, slug-hashed identifiers leave the process, and the
-    collector is fully side-effect-free when disabled (no UUID
-    generated, no worker thread, no data directory created).
+    anonymous, slug-hashed identifiers leave the process. If telemetry
+    is disabled, any existing local files are cleaned up, no UUID is
+    generated, and no worker thread is created.
     """
 
     ## Production telemetry endpoint baked in so installs without an
@@ -277,17 +277,13 @@ class TelemetryCollector:
         self._customer_uuid: str | None = None
         self._milestones: dict[str, dict[str, Any]] = {}
         self._lock = threading.Lock()
+        ## When telemetry is disabled, this queue is unused as documented
+        ## in docs/TELEMETRY.md.
         self._queue: queue.Queue[TelemetryRecord] = queue.Queue(maxsize=self.QUEUE_MAXSIZE)
         self._shutdown = False
         ## One-shot guard for the "endpoint unset" debug log in _send so a
         ## flood of dequeued records doesn't flood logs at debug level.
         self._endpoint_unset_logged = False
-        ## When disabled (env opt-out), make construction fully
-        ## side-effect-free: no UUID generated, no milestones loaded,
-        ## no worker thread. ``record`` / ``record_milestone`` already
-        ## short-circuit on ``config.enabled``, so the empty queue and
-        ## dormant worker are harmless. This is the contract documented
-        ## in docs/TELEMETRY.md.
         self._worker: threading.Thread | None = None
         ## Reusable httpx client. Built lazily on first send so a never-
         ## sending session (empty endpoint) doesn't pay the setup cost,
@@ -543,8 +539,7 @@ def is_telemetry_enabled() -> bool:
 
     Callers may want to check the opt-out flag without paying for
     collector construction (which generates a UUID and creates the data
-    directory). Reading the env vars directly preserves the
-    side-effect-free contract of opt-out.
+    directory).
     """
     return not TelemetryConfig._is_disabled_via_env()
 

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -30,8 +30,8 @@ func suite_setup(_ctx: Dictionary) -> void:
 	DirAccess.make_dir_recursive_absolute(_scratch_dir)
 	var es := EditorInterface.get_editor_settings()
 	if es != null:
-		if es.has_setting(McpClientConfigurator.SETTING_HTTP_PORT):
-			_saved_http_port = es.get_setting(McpClientConfigurator.SETTING_HTTP_PORT)
+		if es.has_setting(McpSettings.SETTING_HTTP_PORT):
+			_saved_http_port = es.get_setting(McpSettings.SETTING_HTTP_PORT)
 		if es.has_setting(McpClientConfigurator.SETTING_WS_PORT):
 			_saved_ws_port = es.get_setting(McpClientConfigurator.SETTING_WS_PORT)
 
@@ -603,7 +603,7 @@ func test_http_port_reads_configured_value() -> void:
 	_clear_port_settings()
 	var es := EditorInterface.get_editor_settings()
 	assert_true(es != null, "EditorSettings unavailable")
-	es.set_setting(McpClientConfigurator.SETTING_HTTP_PORT, 8123)
+	es.set_setting(McpSettings.SETTING_HTTP_PORT, 8123)
 	assert_eq(McpClientConfigurator.http_port(), 8123)
 	_clear_port_settings()
 
@@ -615,9 +615,9 @@ func test_http_port_rejects_out_of_range() -> void:
 	_clear_port_settings()
 	var es := EditorInterface.get_editor_settings()
 	assert_true(es != null, "EditorSettings unavailable")
-	es.set_setting(McpClientConfigurator.SETTING_HTTP_PORT, 80)
+	es.set_setting(McpSettings.SETTING_HTTP_PORT, 80)
 	assert_eq(McpClientConfigurator.http_port(), McpClientConfigurator.DEFAULT_HTTP_PORT)
-	es.set_setting(McpClientConfigurator.SETTING_HTTP_PORT, 70000)
+	es.set_setting(McpSettings.SETTING_HTTP_PORT, 70000)
 	assert_eq(McpClientConfigurator.http_port(), McpClientConfigurator.DEFAULT_HTTP_PORT)
 	_clear_port_settings()
 
@@ -654,7 +654,7 @@ func test_http_url_uses_current_http_port() -> void:
 	_clear_port_settings()
 	var es := EditorInterface.get_editor_settings()
 	assert_true(es != null, "EditorSettings unavailable")
-	es.set_setting(McpClientConfigurator.SETTING_HTTP_PORT, 8321)
+	es.set_setting(McpSettings.SETTING_HTTP_PORT, 8321)
 	assert_eq(McpClientConfigurator.http_url(), "http://127.0.0.1:8321/mcp")
 	_clear_port_settings()
 	assert_eq(
@@ -1857,7 +1857,7 @@ func _clear_port_settings() -> void:
 	var es := EditorInterface.get_editor_settings()
 	if es == null:
 		return
-	es.set_setting(McpClientConfigurator.SETTING_HTTP_PORT, McpClientConfigurator.DEFAULT_HTTP_PORT)
+	es.set_setting(McpSettings.SETTING_HTTP_PORT, McpClientConfigurator.DEFAULT_HTTP_PORT)
 	es.set_setting(McpClientConfigurator.SETTING_WS_PORT, McpClientConfigurator.DEFAULT_WS_PORT)
 
 
@@ -1866,9 +1866,9 @@ func _restore_port_settings() -> void:
 	if es == null:
 		return
 	if _saved_http_port == null:
-		es.set_setting(McpClientConfigurator.SETTING_HTTP_PORT, McpClientConfigurator.DEFAULT_HTTP_PORT)
+		es.set_setting(McpSettings.SETTING_HTTP_PORT, McpClientConfigurator.DEFAULT_HTTP_PORT)
 	else:
-		es.set_setting(McpClientConfigurator.SETTING_HTTP_PORT, _saved_http_port)
+		es.set_setting(McpSettings.SETTING_HTTP_PORT, _saved_http_port)
 	if _saved_ws_port == null:
 		es.set_setting(McpClientConfigurator.SETTING_WS_PORT, McpClientConfigurator.DEFAULT_WS_PORT)
 	else:

--- a/test_project/tests/test_plugin_telemetry.gd
+++ b/test_project/tests/test_plugin_telemetry.gd
@@ -28,11 +28,80 @@ class StubConnection extends RefCounted:
 		connection_state_changed.emit(is_open)
 
 
+const _TENV1 := "GODOT_AI_DISABLE_TELEMETRY"
+const _TENV2 := "DISABLE_TELEMETRY"
+
+var _saved_tenv1: Variant = null
+var _saved_tenv2: Variant = null
+var _had_telemetry_setting: bool = false
+var _saved_telemetry_setting: Variant = null
+
+
 func suite_name() -> String:
 	return "plugin_telemetry"
 
 
+func suite_setup(_ctx: Dictionary) -> void:
+	_saved_tenv1 = OS.get_environment(_TENV1) if OS.has_environment(_TENV1) else null
+	_saved_tenv2 = OS.get_environment(_TENV2) if OS.has_environment(_TENV2) else null
+	var es := EditorInterface.get_editor_settings()
+	_had_telemetry_setting = es.has_setting(McpSettings.SETTING_TELEMETRY_ENABLED)
+	if _had_telemetry_setting:
+		_saved_telemetry_setting = es.get_setting(McpSettings.SETTING_TELEMETRY_ENABLED)
+
+
+func suite_teardown() -> void:
+	_restore_tenv(_TENV1, _saved_tenv1)
+	_restore_tenv(_TENV2, _saved_tenv2)
+	var es := EditorInterface.get_editor_settings()
+	if not _had_telemetry_setting:
+		if es.has_setting(McpSettings.SETTING_TELEMETRY_ENABLED):
+			es.set_setting(McpSettings.SETTING_TELEMETRY_ENABLED, null)
+	else:
+		es.set_setting(McpSettings.SETTING_TELEMETRY_ENABLED, _saved_telemetry_setting)
+
+
+func _restore_tenv(name: String, saved: Variant) -> void:
+	if saved == null:
+		OS.unset_environment(name)
+	else:
+		OS.set_environment(name, str(saved))
+
+
+func _clear_telemetry_env_vars() -> void:
+	OS.unset_environment(_TENV1)
+	OS.unset_environment(_TENV2)
+
+
 # ----- opt-out -----
+
+func test_disabled_when_editor_setting_is_false() -> void:
+	## Regression guard for the UI opt-out / plugin-reload race:
+	## _inject_telemetry_env unsets GODOT_AI_DISABLE_TELEMETRY right after
+	## OS.create_process, so the new plugin instance's Telemetry constructor
+	## must fall back to the persisted EditorSetting instead of re-enabling.
+	_clear_telemetry_env_vars()
+	EditorInterface.get_editor_settings().set_setting(
+		McpSettings.SETTING_TELEMETRY_ENABLED, false
+	)
+	var conn := StubConnection.new()
+	var t := Telemetry.new(conn)
+	var is_disabled := t._disabled
+	assert_true(is_disabled,
+		"telemetry must be disabled when EditorSetting is false and no env var is set")
+
+
+func test_enabled_when_editor_setting_is_true() -> void:
+	_clear_telemetry_env_vars()
+	EditorInterface.get_editor_settings().set_setting(
+		McpSettings.SETTING_TELEMETRY_ENABLED, true
+	)
+	var conn := StubConnection.new()
+	var t := Telemetry.new(conn)
+	var is_disabled := t._disabled
+	assert_false(is_disabled,
+		"telemetry must be enabled when EditorSetting is true and no env var is set")
+
 
 func test_disabled_drops_event_without_send() -> void:
 	var conn := StubConnection.new()

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -84,9 +84,49 @@ class _ManagerHostStub extends GodotAiPlugin:
 
 const TEST_PORT := 65431
 
+const _TENV1 := "GODOT_AI_DISABLE_TELEMETRY"
+const _TENV2 := "DISABLE_TELEMETRY"
+
+var _saved_tenv1: Variant = null
+var _saved_tenv2: Variant = null
+var _had_telemetry_setting: bool = false
+var _saved_telemetry_setting: Variant = null
+
 
 func suite_name() -> String:
 	return "server_lifecycle"
+
+
+func suite_setup(_ctx: Dictionary) -> void:
+	_saved_tenv1 = OS.get_environment(_TENV1) if OS.has_environment(_TENV1) else null
+	_saved_tenv2 = OS.get_environment(_TENV2) if OS.has_environment(_TENV2) else null
+	var es := EditorInterface.get_editor_settings()
+	_had_telemetry_setting = es.has_setting(McpSettings.SETTING_TELEMETRY_ENABLED)
+	if _had_telemetry_setting:
+		_saved_telemetry_setting = es.get_setting(McpSettings.SETTING_TELEMETRY_ENABLED)
+
+
+func suite_teardown() -> void:
+	_restore_tenv(_TENV1, _saved_tenv1)
+	_restore_tenv(_TENV2, _saved_tenv2)
+	var es := EditorInterface.get_editor_settings()
+	if not _had_telemetry_setting:
+		if es.has_setting(McpSettings.SETTING_TELEMETRY_ENABLED):
+			es.set_setting(McpSettings.SETTING_TELEMETRY_ENABLED, null)
+	else:
+		es.set_setting(McpSettings.SETTING_TELEMETRY_ENABLED, _saved_telemetry_setting)
+
+
+func _restore_tenv(name: String, saved: Variant) -> void:
+	if saved == null:
+		OS.unset_environment(name)
+	else:
+		OS.set_environment(name, str(saved))
+
+
+func _clear_telemetry_env_vars() -> void:
+	OS.unset_environment(_TENV1)
+	OS.unset_environment(_TENV2)
 
 
 # ----- seam wiring -----------------------------------------------------
@@ -305,3 +345,94 @@ func test_prepare_for_update_reload_clears_spawn_guard() -> void:
 ## respawn_with_refresh is covered by script/ci-reload-test (10 reload
 ## iterations + full test suite). Stubbing McpClientConfigurator's
 ## get_server_command at this layer would re-implement config resolution.
+
+
+# ----- _inject_telemetry_env -------------------------------------------
+
+func test_inject_sets_env_when_telemetry_disabled_in_settings() -> void:
+	_clear_telemetry_env_vars()
+	EditorInterface.get_editor_settings().set_setting(
+		McpSettings.SETTING_TELEMETRY_ENABLED, false
+	)
+	var host := _ManagerHostStub.new()
+	var manager := McpServerLifecycleManagerScript.new(host)
+
+	var injected := manager._inject_telemetry_env()
+	var env_present := OS.has_environment(_TENV1)
+	if injected:
+		OS.unset_environment(_TENV1)
+	host.free()
+
+	assert_true(injected, "_inject_telemetry_env must return true when it sets the var")
+	assert_true(env_present, "GODOT_AI_DISABLE_TELEMETRY must be set in process env for the spawn")
+
+
+func test_inject_env_is_unset_after_caller_restores() -> void:
+	## Regression guard: start_server / respawn_with_refresh unset the var
+	## immediately after OS.create_process. Verify the restore pattern works
+	## so a future refactor can't silently leak the flag into later spawns.
+	_clear_telemetry_env_vars()
+	EditorInterface.get_editor_settings().set_setting(
+		McpSettings.SETTING_TELEMETRY_ENABLED, false
+	)
+	var host := _ManagerHostStub.new()
+	var manager := McpServerLifecycleManagerScript.new(host)
+
+	var injected := manager._inject_telemetry_env()
+	if injected:
+		OS.unset_environment(_TENV1)  ## mirrors what start_server / respawn_with_refresh do
+	var env_present_after := OS.has_environment(_TENV1)
+	host.free()
+
+	assert_false(env_present_after, "editor process env must be clean after the spawn-window restore")
+
+
+func test_inject_skips_when_setting_is_true() -> void:
+	_clear_telemetry_env_vars()
+	EditorInterface.get_editor_settings().set_setting(
+		McpSettings.SETTING_TELEMETRY_ENABLED, true
+	)
+	var host := _ManagerHostStub.new()
+	var manager := McpServerLifecycleManagerScript.new(host)
+
+	var injected := manager._inject_telemetry_env()
+	var env_present := OS.has_environment(_TENV1)
+	if injected:
+		OS.unset_environment(_TENV1)
+	host.free()
+
+	assert_false(injected, "must not inject when telemetry is enabled")
+	assert_false(env_present, "GODOT_AI_DISABLE_TELEMETRY must not be set when telemetry is enabled")
+
+
+func test_inject_skips_when_godot_ai_disable_telemetry_already_present() -> void:
+	## Env var already set by the user / CI — must not double-inject or
+	## report it as injected (which would cause the caller to unset it on
+	## cleanup, removing the user's own setting).
+	OS.set_environment(_TENV1, "true")
+	OS.unset_environment(_TENV2)
+	EditorInterface.get_editor_settings().set_setting(
+		McpSettings.SETTING_TELEMETRY_ENABLED, false
+	)
+	var host := _ManagerHostStub.new()
+	var manager := McpServerLifecycleManagerScript.new(host)
+
+	var injected := manager._inject_telemetry_env()
+	host.free()
+
+	assert_false(injected, "must not inject when GODOT_AI_DISABLE_TELEMETRY is already in env")
+
+
+func test_inject_skips_when_disable_telemetry_already_present() -> void:
+	OS.unset_environment(_TENV1)
+	OS.set_environment(_TENV2, "1")
+	EditorInterface.get_editor_settings().set_setting(
+		McpSettings.SETTING_TELEMETRY_ENABLED, false
+	)
+	var host := _ManagerHostStub.new()
+	var manager := McpServerLifecycleManagerScript.new(host)
+
+	var injected := manager._inject_telemetry_env()
+	host.free()
+
+	assert_false(injected, "must not inject when DISABLE_TELEMETRY is already in env")

--- a/test_project/tests/test_telemetry_setting.gd
+++ b/test_project/tests/test_telemetry_setting.gd
@@ -38,11 +38,9 @@ func test_setting_defaults_true_when_absent() -> void:
 	## Simulate what _load_telemetry_setting does on first run: if absent, write true.
 	var es := EditorInterface.get_editor_settings()
 	## Clear any existing value so we can test the absent-setting path.
+	## NB: Passing null to set_setting is the intended way to unset editor settings in Godot 3/4.
 	if es.has_setting(McpSettings.SETTING_TELEMETRY_ENABLED):
 		es.set_setting(McpSettings.SETTING_TELEMETRY_ENABLED, null)
-	## After clearing, check absence — note: set_setting(null) may or may not
-	## remove the key depending on Godot version. Work around: skip directly to
-	## the init logic assertion.
 	if not es.has_setting(McpSettings.SETTING_TELEMETRY_ENABLED):
 		es.set_setting(McpSettings.SETTING_TELEMETRY_ENABLED, true)
 	assert_true(bool(es.get_setting(McpSettings.SETTING_TELEMETRY_ENABLED)), "absent setting should resolve to true after first-run init")

--- a/test_project/tests/test_telemetry_setting.gd
+++ b/test_project/tests/test_telemetry_setting.gd
@@ -2,14 +2,12 @@
 extends McpTestSuite
 
 ## Tests that the EditorSettings key "godot_ai/telemetry_enabled" can be read
-## and written correctly. This is the storage-layer check written before the
-## UI code exists.
+## and written correctly. This suite covers the storage-layer behavior
+## independently of any telemetry UI.
 
 func suite_name() -> String:
 	return "telemetry_setting"
 
-
-const SETTING_KEY := "godot_ai/telemetry_enabled"
 
 ## Instance var to preserve the real setting value across setup/teardown.
 var _original_value: Variant = null
@@ -19,9 +17,9 @@ var _had_setting: bool = false
 func suite_setup(_ctx: Dictionary) -> void:
 	## Preserve whatever the real setting is before tests mutate it.
 	var es := EditorInterface.get_editor_settings()
-	_had_setting = es.has_setting(SETTING_KEY)
+	_had_setting = es.has_setting(McpSettings.SETTING_TELEMETRY_ENABLED)
 	if _had_setting:
-		_original_value = es.get_setting(SETTING_KEY)
+		_original_value = es.get_setting(McpSettings.SETTING_TELEMETRY_ENABLED)
 
 
 func suite_teardown() -> void:
@@ -29,42 +27,42 @@ func suite_teardown() -> void:
 	var es := EditorInterface.get_editor_settings()
 	if not _had_setting:
 		## Setting didn't exist before tests ran — remove it if we added it.
-		## EditorSettings has no erase_setting; setting to null removes it in Godot 4.
-		if es.has_setting(SETTING_KEY):
-			es.set_setting(SETTING_KEY, null)
+		## NB: Passing null to set_setting is the intended way to unset editor settings in Godot 3/4.
+		if es.has_setting(McpSettings.SETTING_TELEMETRY_ENABLED):
+			es.set_setting(McpSettings.SETTING_TELEMETRY_ENABLED, null)
 	else:
-		es.set_setting(SETTING_KEY, _original_value)
+		es.set_setting(McpSettings.SETTING_TELEMETRY_ENABLED, _original_value)
 
 
 func test_setting_defaults_true_when_absent() -> void:
 	## Simulate what _load_telemetry_setting does on first run: if absent, write true.
 	var es := EditorInterface.get_editor_settings()
 	## Clear any existing value so we can test the absent-setting path.
-	if es.has_setting(SETTING_KEY):
-		es.set_setting(SETTING_KEY, null)
+	if es.has_setting(McpSettings.SETTING_TELEMETRY_ENABLED):
+		es.set_setting(McpSettings.SETTING_TELEMETRY_ENABLED, null)
 	## After clearing, check absence — note: set_setting(null) may or may not
 	## remove the key depending on Godot version. Work around: skip directly to
 	## the init logic assertion.
-	if not es.has_setting(SETTING_KEY):
-		es.set_setting(SETTING_KEY, true)
-	assert_true(bool(es.get_setting(SETTING_KEY)), "absent setting should resolve to true after first-run init")
+	if not es.has_setting(McpSettings.SETTING_TELEMETRY_ENABLED):
+		es.set_setting(McpSettings.SETTING_TELEMETRY_ENABLED, true)
+	assert_true(bool(es.get_setting(McpSettings.SETTING_TELEMETRY_ENABLED)), "absent setting should resolve to true after first-run init")
 
 
 func test_setting_persists_false() -> void:
 	var es := EditorInterface.get_editor_settings()
-	es.set_setting(SETTING_KEY, false)
-	assert_true(not bool(es.get_setting(SETTING_KEY)), "false should persist")
+	es.set_setting(McpSettings.SETTING_TELEMETRY_ENABLED, false)
+	assert_true(not bool(es.get_setting(McpSettings.SETTING_TELEMETRY_ENABLED)), "false should persist")
 
 
 func test_setting_persists_true() -> void:
 	var es := EditorInterface.get_editor_settings()
-	es.set_setting(SETTING_KEY, true)
-	assert_true(bool(es.get_setting(SETTING_KEY)), "true should persist")
+	es.set_setting(McpSettings.SETTING_TELEMETRY_ENABLED, true)
+	assert_true(bool(es.get_setting(McpSettings.SETTING_TELEMETRY_ENABLED)), "true should persist")
 
 
 func test_setting_roundtrip_false_then_true() -> void:
 	var es := EditorInterface.get_editor_settings()
-	es.set_setting(SETTING_KEY, false)
-	assert_false(bool(es.get_setting(SETTING_KEY)), "write false then read back false")
-	es.set_setting(SETTING_KEY, true)
-	assert_true(bool(es.get_setting(SETTING_KEY)), "write true then read back true")
+	es.set_setting(McpSettings.SETTING_TELEMETRY_ENABLED, false)
+	assert_false(bool(es.get_setting(McpSettings.SETTING_TELEMETRY_ENABLED)), "write false then read back false")
+	es.set_setting(McpSettings.SETTING_TELEMETRY_ENABLED, true)
+	assert_true(bool(es.get_setting(McpSettings.SETTING_TELEMETRY_ENABLED)), "write true then read back true")

--- a/test_project/tests/test_telemetry_toggle.gd
+++ b/test_project/tests/test_telemetry_toggle.gd
@@ -1,0 +1,101 @@
+@tool
+extends McpTestSuite
+
+## Tests that the telemetry CheckButton in McpDock reflects env-var state.
+## We instantiate McpDock directly (without adding it to the scene tree, so
+## _ready() never fires) and inject a bare CheckButton into _telemetry_toggle
+## before calling _load_telemetry_setting(), which is the method that drives
+## the toggle's disabled state.
+
+func suite_name() -> String:
+	return "telemetry_toggle"
+
+
+const _ENV1 := "GODOT_AI_DISABLE_TELEMETRY"
+const _ENV2 := "DISABLE_TELEMETRY"
+
+var _saved_env1: Variant = null
+var _saved_env2: Variant = null
+var _had_setting: bool = false
+var _saved_setting: Variant = null
+
+
+func suite_setup(_ctx: Dictionary) -> void:
+	_saved_env1 = OS.get_environment(_ENV1) if OS.has_environment(_ENV1) else null
+	_saved_env2 = OS.get_environment(_ENV2) if OS.has_environment(_ENV2) else null
+	var es := EditorInterface.get_editor_settings()
+	_had_setting = es.has_setting(McpSettings.SETTING_TELEMETRY_ENABLED)
+	if _had_setting:
+		_saved_setting = es.get_setting(McpSettings.SETTING_TELEMETRY_ENABLED)
+
+
+func suite_teardown() -> void:
+	_restore_env(_ENV1, _saved_env1)
+	_restore_env(_ENV2, _saved_env2)
+	var es := EditorInterface.get_editor_settings()
+	if not _had_setting:
+		if es.has_setting(McpSettings.SETTING_TELEMETRY_ENABLED):
+			## Setting didn't exist before tests ran — remove it if we added it.
+			## NB: Passing null to set_setting is the intended way to unset editor settings in Godot 3/4.
+			es.set_setting(McpSettings.SETTING_TELEMETRY_ENABLED, null)
+	else:
+		es.set_setting(McpSettings.SETTING_TELEMETRY_ENABLED, _saved_setting)
+
+
+func _restore_env(name: String, saved: Variant) -> void:
+	if saved == null:
+		OS.unset_environment(name)
+	else:
+		OS.set_environment(name, str(saved))
+
+
+func _clear_env_vars() -> void:
+	OS.unset_environment(_ENV1)
+	OS.unset_environment(_ENV2)
+
+
+## Returns [dock, toggle] with the toggle already wired in.
+## Caller must free both after the test.
+func _make_dock_with_toggle() -> Array:
+	var dock := McpDock.new()
+	var toggle := CheckButton.new()
+	dock._telemetry_toggle = toggle
+	return [dock, toggle]
+
+
+func test_toggle_disabled_when_godot_ai_disable_telemetry_set() -> void:
+	_clear_env_vars()
+	OS.set_environment(_ENV1, "true")
+	var pair := _make_dock_with_toggle()
+	var dock: McpDock = pair[0]
+	var toggle: CheckButton = pair[1]
+	dock._load_telemetry_setting()
+	var disabled := toggle.disabled
+	toggle.free()
+	dock.free()
+	assert_true(disabled, "toggle must be disabled when GODOT_AI_DISABLE_TELEMETRY=true")
+
+
+func test_toggle_disabled_when_disable_telemetry_set() -> void:
+	_clear_env_vars()
+	OS.set_environment(_ENV2, "1")
+	var pair := _make_dock_with_toggle()
+	var dock: McpDock = pair[0]
+	var toggle: CheckButton = pair[1]
+	dock._load_telemetry_setting()
+	var disabled := toggle.disabled
+	toggle.free()
+	dock.free()
+	assert_true(disabled, "toggle must be disabled when DISABLE_TELEMETRY=1")
+
+
+func test_toggle_enabled_when_no_env_var() -> void:
+	_clear_env_vars()
+	var pair := _make_dock_with_toggle()
+	var dock: McpDock = pair[0]
+	var toggle: CheckButton = pair[1]
+	dock._load_telemetry_setting()
+	var disabled := toggle.disabled
+	toggle.free()
+	dock.free()
+	assert_false(disabled, "toggle must not be disabled when no env var is set")

--- a/test_project/tests/test_telemetry_toggle.gd.uid
+++ b/test_project/tests/test_telemetry_toggle.gd.uid
@@ -1,0 +1,1 @@
+uid://isocaoqntc7e

--- a/tests/unit/test_self_update_smoke_harness.py
+++ b/tests/unit/test_self_update_smoke_harness.py
@@ -71,10 +71,14 @@ def test_self_update_smoke_harness_prepares_fixture(tmp_path: Path) -> None:
     assert "const DEFAULT_WS_PORT := 19500" in base_configurator
     assert 'const SELF_UPDATE_SMOKE_SERVER_VERSION := "2.2.0"' in base_configurator
     assert "var version := SELF_UPDATE_SMOKE_SERVER_VERSION" in base_configurator
-    assert "godot_ai_self_update_smoke/excluded_domains" in base_configurator
     assert "return default_port" in base_configurator
     assert "static func ensure_settings_registered() -> void:" in base_configurator
     assert "static func _register_port_setting(" in base_configurator
+
+    base_settings = (project / "addons" / "godot_ai" / "utils" / "settings.gd").read_text(
+        encoding="utf-8"
+    )
+    assert "godot_ai_self_update_smoke/excluded_domains" in base_settings
 
     base_plugin = (project / "addons" / "godot_ai" / "plugin.gd").read_text(encoding="utf-8")
     assert "godot_ai_self_update_smoke/managed_server_pid" in base_plugin
@@ -99,6 +103,7 @@ def test_self_update_smoke_harness_prepares_fixture(tmp_path: Path) -> None:
         vnext_dock = zf.read("addons/godot_ai/mcp_dock.gd").decode()
         vnext_manager = zf.read("addons/godot_ai/utils/update_manager.gd").decode()
         vnext_configurator = zf.read("addons/godot_ai/client_configurator.gd").decode()
+        vnext_settings = zf.read("addons/godot_ai/utils/settings.gd").decode()
         vnext_plugin = zf.read("addons/godot_ai/plugin.gd").decode()
         vnext_lifecycle = zf.read("addons/godot_ai/utils/server_lifecycle.gd").decode()
         vnext_base = zf.read("addons/godot_ai/utils/self_update_smoke_base.gd").decode()
@@ -120,10 +125,10 @@ def test_self_update_smoke_harness_prepares_fixture(tmp_path: Path) -> None:
     assert 'const SELF_UPDATE_SMOKE_SERVER_VERSION := "2.2.0"' in vnext_configurator
     assert 'godot-ai==%s" % version' in vnext_configurator
     assert "var version := SELF_UPDATE_SMOKE_SERVER_VERSION" in vnext_configurator
-    assert "godot_ai_self_update_smoke/excluded_domains" in vnext_configurator
     assert "return default_port" in vnext_configurator
     assert "static func ensure_settings_registered() -> void:" in vnext_configurator
     assert "static func _register_port_setting(" in vnext_configurator
+    assert "godot_ai_self_update_smoke/excluded_domains" in vnext_settings
     assert "godot_ai_self_update_smoke/managed_server_pid" in vnext_plugin
     assert 'const SELF_UPDATE_SMOKE_EXPECTED_SERVER_VERSION := "2.2.0"' in vnext_lifecycle
     assert "func _expected_server_version() -> String:" in vnext_lifecycle

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -175,9 +175,11 @@ class TestTelemetryConfigCleanup:
         assert config.enabled is False
 
     def test_cleanup_logs_warning_on_oserror(
-        self, monkeypatch, clean_env, isolated_data_dir: Path
+        self, monkeypatch, clean_env, isolated_data_dir: Path, caplog
     ) -> None:
         """A deletion failure logs a warning and does not propagate."""
+        import logging
+
         monkeypatch.setenv("GODOT_AI_DISABLE_TELEMETRY", "true")
         uuid_file = isolated_data_dir / "customer_uuid.txt"
         uuid_file.write_text("fake-uuid")
@@ -186,9 +188,14 @@ class TestTelemetryConfigCleanup:
             raise OSError("permission denied")
 
         monkeypatch.setattr(type(uuid_file), "unlink", _bad_unlink)
-        # Should complete without raising:
-        config = tel.TelemetryConfig()
+        # Should complete without raising and must emit a warning:
+        with caplog.at_level(logging.WARNING, logger="godot_ai.telemetry"):
+            config = tel.TelemetryConfig()
         assert config.enabled is False
+        expected_err = "Could not remove telemetry file customer_uuid.txt"
+        assert any(
+            r.levelno == logging.WARNING and expected_err in r.message for r in caplog.records
+        ), f"Expected warning about customer_uuid.txt, got: {caplog.records}"
 
 
 # --- TelemetryCollector --------------------------------------------------


### PR DESCRIPTION
This is a grab bag of changes following up on the copilot review of https://github.com/hi-godot/godot-ai/pull/446. Many of the changes are test additions, comment changes, or md changes. Common setting constants used between modules and helpers are moved to `plugin/addons/godot_ai/utils/settings.gd`.