### PR TITLE
Fix project_manage(op="stop") INVALID_PARAMS — 87 installs hit it daily

### DIFF
--- a/plugin/addons/godot_ai/handlers/project_handler.gd
+++ b/plugin/addons/godot_ai/handlers/project_handler.gd
@@ -75,8 +75,22 @@ func set_project_setting(params: Dictionary) -> Dictionary:
 func run_project(params: Dictionary) -> Dictionary:
 	var mode: String = params.get("mode", "main")
 	var autosave: bool = params.get("autosave", true)
+	# Idempotent: a project that's already running satisfies the caller's intent.
+	# Returning INVALID_PARAMS here punished agents that legitimately called run
+	# to ensure the project is playing (87+ installs/day hit the matching
+	# stop-not-running case in telemetry). Surface state via was_already_running
+	# so a caller wanting a *different* scene can detect and stop+restart.
 	if EditorInterface.is_playing_scene():
-		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, "Project is already running")
+		return {
+			"data": {
+				"mode": mode,
+				"scene": params.get("scene", ""),
+				"autosave": autosave,
+				"was_already_running": true,
+				"undoable": false,
+				"reason": "Project was already running; no action taken",
+			}
+		}
 
 	var validation_error: Variant = null
 	if mode == "custom":
@@ -133,6 +147,7 @@ func run_project(params: Dictionary) -> Dictionary:
 			"mode": mode,
 			"scene": params.get("scene", ""),
 			"autosave": autosave,
+			"was_already_running": false,
 			"undoable": false,
 			"reason": "Play/stop is a runtime action",
 		}
@@ -140,8 +155,19 @@ func run_project(params: Dictionary) -> Dictionary:
 
 
 func stop_project(params: Dictionary) -> Dictionary:
+	# Idempotent: a project that's already stopped satisfies the caller's intent.
+	# Returning INVALID_PARAMS here was the largest single source of fleet-wide
+	# project_manage failures (87 installs/24h). was_running=false lets callers
+	# distinguish a no-op stop from one that actually halted a running session.
 	if not EditorInterface.is_playing_scene():
-		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, "Project is not running")
+		return {
+			"data": {
+				"stopped": true,
+				"was_running": false,
+				"undoable": false,
+				"reason": "Project was not running; no action taken",
+			}
+		}
 
 	if _debugger_plugin != null:
 		_debugger_plugin.end_game_run()
@@ -161,6 +187,7 @@ func stop_project(params: Dictionary) -> Dictionary:
 	return {
 		"data": {
 			"stopped": true,
+			"was_running": true,
 			"undoable": false,
 			"reason": "Play/stop is a runtime action",
 		}
@@ -181,6 +208,7 @@ func _finish_stop_project_deferred(request_id: String) -> void:
 	_connection.send_deferred_response(request_id, {
 		"data": {
 			"stopped": true,
+			"was_running": true,
 			"undoable": false,
 			"reason": "Play/stop is a runtime action",
 			"readiness_after": McpConnection.get_readiness(),

--- a/src/godot_ai/tools/_meta_tool.py
+++ b/src/godot_ai/tools/_meta_tool.py
@@ -362,8 +362,54 @@ async def dispatch_manage_op(
             result = await result
         return result
     except TypeError as exc:
+        ## When a caller passes a key the handler doesn't accept (a common LLM
+        ## failure mode: invented kwargs like ``force=True`` on ``stop``,
+        ## ``session_id`` nested inside ``params``), the bare TypeError text
+        ## reads like an internal error. Surface the handler's accepted-key set
+        ## and the unexpected key (if Pydantic-style detectable) so the agent
+        ## can self-correct without a second round-trip.
+        signature, _ = _handler_meta(handler)
+        accepted: list[str] = []
+        if signature is not None:
+            ## The first positional is always the runtime — skip by position
+            ## rather than name (handlers in tests use ``rt``; real handlers
+            ## use ``runtime``).
+            params_iter = iter(signature.parameters.items())
+            next(params_iter, None)
+            accepted = [
+                name
+                for name, param in params_iter
+                if param.kind
+                in (
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    inspect.Parameter.KEYWORD_ONLY,
+                )
+            ]
+        received = list(call_params.keys())
+        ## When we can't introspect the handler signature, leave unexpected empty
+        ## so the hint reads as the bare TypeError (no false claims about keys).
+        if signature is None:
+            unexpected = []
+        else:
+            unexpected = [k for k in received if k not in accepted]
+        hint = f"{tool_name}.{op}: {exc}"
+        if signature is not None:
+            accepted_label = ", ".join(repr(k) for k in accepted) if accepted else "(none)"
+            if unexpected:
+                hint += (
+                    f". Unexpected param(s): {', '.join(repr(k) for k in unexpected)}. "
+                    f"Accepted params for op {op!r}: {accepted_label}"
+                )
+            else:
+                hint += f". Accepted params for op {op!r}: {accepted_label}"
         raise GodotCommandError(
             code=ErrorCode.INVALID_PARAMS,
-            message=f"{tool_name}.{op}: {exc}",
-            data={"tool": tool_name, "op": op, "received": list(call_params.keys())},
+            message=hint,
+            data={
+                "tool": tool_name,
+                "op": op,
+                "received": received,
+                "accepted": accepted,
+                "unexpected": unexpected,
+            },
         ) from exc

--- a/src/godot_ai/tools/project.py
+++ b/src/godot_ai/tools/project.py
@@ -21,7 +21,13 @@ Resource form: ``godot://project/info`` and ``godot://project/settings``
 
 Ops:
   • stop()
-        Stop the running project (game). Errors if not running.
+        Stop the running project (game). Takes no params — call as
+        ``project_manage(op="stop")`` or with ``params={}``. Idempotent:
+        succeeds with ``was_running=false`` if the project isn't running.
+        Do NOT pass extra fields like ``force`` or ``reason`` inside
+        ``params`` — only the registered keys are accepted (here, none).
+        For multi-editor setups, pass ``session_id`` as a sibling of
+        ``op``/``params``, not inside ``params``.
   • settings_get(key)
         Read a ProjectSettings key (e.g. "application/config/name").
   • settings_set(key, value)
@@ -44,6 +50,10 @@ def register_project_tools(mcp: FastMCP) -> None:
         - "main": Run the project's main scene (default).
         - "current": Run the currently open scene.
         - "custom": Run a specific scene (requires ``scene``).
+
+        Idempotent: if the project is already running, returns success with
+        ``data.was_already_running=true`` (no scene switch). To switch scenes,
+        call ``project_manage(op="stop")`` first, then ``project_run`` again.
 
         Args:
             mode: "main" | "current" | "custom". Default "main".

--- a/test_project/tests/test_project.gd
+++ b/test_project/tests/test_project.gd
@@ -198,6 +198,20 @@ func test_run_project_autosave_false_restores_editor_setting() -> void:
 
 # ----- stop_project -----
 
-func test_stop_project_rejects_when_not_playing() -> void:
+func test_stop_project_idempotent_when_not_playing() -> void:
+	## Telemetry: 87 unique installs/day hit INVALID_PARAMS on
+	## project_manage(op="stop") because the plugin rejected stop-when-not-running.
+	## Calling stop to ensure the project is stopped is a valid intent; the
+	## handler now returns success with was_running=false instead of erroring.
 	var result := _handler.stop_project({})
-	assert_is_error(result)
+	assert_has_key(result, "data")
+	assert_has_key(result.data, "stopped")
+	assert_eq(result.data.stopped, true)
+	assert_has_key(result.data, "was_running")
+	assert_eq(result.data.was_running, false)
+
+
+## NOTE: run_project's was_already_running branch can't be exercised here —
+## actually starting playback from the editor test runner would re-enter the
+## test loop. End-to-end coverage of that branch lives in the Python integration
+## tests. The success/validation paths are covered by the run_project tests above.

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -2890,6 +2890,74 @@ class TestProjectStopTool:
         assert not result.is_error
         assert result.data["stopped"] is True
 
+    async def test_stop_with_omitted_params(self, mcp_stack):
+        """Bare ``project_manage(op="stop")`` — the most common shape.
+
+        Telemetry shows 87 unique installs/24h hit INVALID_PARAMS on this op.
+        The dispatch layer must accept a missing ``params`` field and forward
+        an empty call to the plugin without error.
+        """
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "stop_project"
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "stopped": True,
+                    "was_running": False,
+                    "undoable": False,
+                    "reason": "Project was not running; no action taken",
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool("project_manage", {"op": "stop"})
+        await task
+
+        assert not result.is_error
+        assert result.data["stopped"] is True
+        assert result.data["was_running"] is False
+
+    async def test_stop_with_stringified_params(self, mcp_stack):
+        """Some MCP clients stringify ``params`` — middleware must JSON-decode."""
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "stop_project"
+            await plugin.send_response(
+                cmd["request_id"],
+                {"stopped": True, "was_running": True, "undoable": False},
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool("project_manage", {"op": "stop", "params": "{}"})
+        await task
+
+        assert not result.is_error
+
+    async def test_stop_rejects_extra_keys_with_helpful_hint(self, mcp_stack):
+        """Invented kwargs like ``force=True`` must surface the accepted set.
+
+        Before this fix, the response was a bare ``TypeError`` text wrapped as
+        INVALID_PARAMS — agents couldn't tell which key was wrong. Now the
+        error names the unexpected key(s) and the accepted set (here, none).
+        """
+        client, _ = mcp_stack
+
+        result = await client.call_tool(
+            "project_manage",
+            {"op": "stop", "params": {"force": True}},
+            raise_on_error=False,
+        )
+        assert result.is_error
+        text = str(result.content)
+        assert "Unexpected param(s)" in text
+        assert "'force'" in text
+        assert "Accepted params for op 'stop'" in text
+
 
 # ---------------------------------------------------------------------------
 # editor_screenshot

--- a/tests/unit/test_meta_tool.py
+++ b/tests/unit/test_meta_tool.py
@@ -342,6 +342,65 @@ async def test_dispatch_wraps_extra_param_typeerror():
     assert exc.value.data["received"] == ["extra"]
 
 
+@pytest.mark.asyncio
+async def test_dispatch_extra_param_hint_lists_unexpected_and_accepted():
+    """A no-arg op called with extra keys must surface both lists.
+
+    Regression for the fleet-wide project_manage(op="stop") confusion: LLMs
+    invent kwargs like force=True. The error must name the offending key and
+    the (empty) set of accepted keys so the agent can self-correct.
+    """
+
+    async def no_params(rt):
+        del rt
+        return {}
+
+    with pytest.raises(GodotCommandError) as exc:
+        await dispatch_manage_op(
+            ops={"stop": no_params},
+            tool_name="project_manage",
+            runtime=None,
+            op="stop",
+            params={"force": True, "reason": "user"},
+        )
+
+    err = exc.value
+    assert err.code == ErrorCode.INVALID_PARAMS
+    assert "Unexpected param(s)" in err.message
+    assert "'force'" in err.message
+    assert "'reason'" in err.message
+    assert "Accepted params for op 'stop'" in err.message
+    assert err.data["accepted"] == []
+    assert err.data["unexpected"] == ["force", "reason"]
+    assert err.data["received"] == ["force", "reason"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_extra_param_hint_lists_handler_kwargs():
+    """Op with several accepted kwargs surfaces those in the hint."""
+
+    async def with_kwargs(rt, mode="main", scene="", autosave=True):
+        del rt, mode, scene, autosave
+        return {}
+
+    with pytest.raises(GodotCommandError) as exc:
+        await dispatch_manage_op(
+            ops={"run": with_kwargs},
+            tool_name="project_manage",
+            runtime=None,
+            op="run",
+            params={"mode": "main", "bogus": 1},
+        )
+
+    err = exc.value
+    assert "'bogus'" in err.message
+    assert "'mode'" in err.message
+    assert "'scene'" in err.message
+    assert "'autosave'" in err.message
+    assert err.data["accepted"] == ["mode", "scene", "autosave"]
+    assert err.data["unexpected"] == ["bogus"]
+
+
 # ---------------------------------------------------------------------------
 # JSON-string coercion
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -3070,6 +3070,51 @@ async def test_project_stop_handler():
     assert client.calls[-1]["command"] == "stop_project"
 
 
+async def test_project_stop_handler_passes_through_idempotent_payload():
+    """Idempotent-stop path (was_running=false) flows through the Python wrapper
+    untouched. Regression for the fleet-wide INVALID_PARAMS pattern: 87 unique
+    installs/24h hit the old "Project is not running" error. The plugin now
+    returns success; the Python handler must not re-wrap it as an error.
+    """
+
+    class IdempotentStopClient(StubClient):
+        async def send(self, command, params=None, session_id=None, timeout=5.0):
+            self.calls.append({"command": command, "params": params})
+            return {
+                "stopped": True,
+                "was_running": False,
+                "undoable": False,
+                "reason": "Project was not running; no action taken",
+            }
+
+    client = IdempotentStopClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await project_handlers.project_stop(runtime)
+    assert result["stopped"] is True
+    assert result["was_running"] is False
+
+
+async def test_project_run_handler_passes_through_already_running_payload():
+    """Idempotent-run path (was_already_running=true) flows through unchanged."""
+
+    class AlreadyRunningClient(StubClient):
+        async def send(self, command, params=None, session_id=None, timeout=5.0):
+            self.calls.append({"command": command, "params": params})
+            return {
+                "mode": (params or {}).get("mode", "main"),
+                "scene": "",
+                "autosave": True,
+                "was_already_running": True,
+                "undoable": False,
+            }
+
+    client = AlreadyRunningClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await project_handlers.project_run(runtime)
+    assert result["was_already_running"] is True
+    assert result["mode"] == "main"
+
+
 # ---------------------------------------------------------------------------
 # Performance monitor handler tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Telemetry shows `project_manage(op="stop")` returning `INVALID_PARAMS` on **87 unique installs / 311 hits in 24h**, persisting across every plugin version released (2.5.0, 2.5.2, 2.5.3, 2.5.4, 2.5.6). The closely-related `project_run` shows the same shape: **78 installs / 168 hits**. Since telemetry only captures the error code, the rejection reason had to be reproduced from code reading.

**Root cause (not what the analysis brief speculated):** the plugin returns `INVALID_PARAMS` for state mismatches that aren't parameter problems at all — `"Project is not running"` on stop and `"Project is already running"` on run. Agents calling these ops to ensure the project is in the desired state were rejected for what is actually valid intent.

## What changed

**Plugin — `plugin/addons/godot_ai/handlers/project_handler.gd`**
- `stop_project`: when not playing, return success with `data.was_running = false` instead of `INVALID_PARAMS`. Stop is idempotent — the caller wanted the project stopped, and it is.
- `run_project`: when already playing, return success with `data.was_already_running = true` so a caller wanting a different scene can detect this and stop+restart.

**Dispatcher — `src/godot_ai/tools/_meta_tool.py`**
- The TypeError → INVALID_PARAMS path in `dispatch_manage_op` now surfaces the offending unexpected key and the handler's accepted-key set in both the error message and `data`. Before, the message was the bare Python TypeError text, which didn't tell agents which key to drop. This catches the secondary failure mode (LLMs inventing `force=True`, `reason=...`, or nesting `session_id` inside `params`).

**Tool description — `src/godot_ai/tools/project.py`**
- `_DESCRIPTION` for `stop`: spells out that it takes no params, that it's idempotent, and that `session_id` is a top-level sibling of `op`/`params`, not nested inside.
- `project_run` docstring: notes idempotence and how to switch scenes.

## Tests

- `tests/unit/test_meta_tool.py`: new tests for the unexpected/accepted-key hint, including the no-arg-op shape that's the immediate `stop` analogue.
- `tests/unit/test_runtime_handlers.py`: new tests that the idempotent payloads (`was_running=false`, `was_already_running=true`) flow through the Python handlers unchanged.
- `tests/integration/test_mcp_tools.py`: new tests under `TestProjectStopTool` covering bare `op="stop"` with no `params`, stringified `params="{}"`, and the rejection-with-hint path for extra keys.
- `test_project/tests/test_project.gd`: updated `test_stop_project_rejects_when_not_playing` → `test_stop_project_idempotent_when_not_playing` to lock in the new shape.

Lint clean; 1077 passing pytests (up from 1072).

## Live smoke

Not run. The only Godot editor currently on `:8000` belongs to another active session on a different worktree (`xenodochial-bhabha-e45d73`, plugin 2.5.6), and serving this worktree's Python on the same port would disrupt it. Per the analysis brief, telemetry verification (the recurring `INVALID_PARAMS` rate on `project_manage(op="stop")` and `project_run` dropping after release) is the post-release check.

## Out of scope, flagged for follow-up

- I did not survey other `<domain>_manage` ops for similar state-mismatch-as-INVALID_PARAMS patterns. Worth a quick audit.
- I did not extend the F-006 circuit breaker, touch transport, or change any unrelated domain.

## Telemetry source

Analysis brief authored against the dashboard reading from BigQuery at the time of writing.

## Test plan

- [x] `ruff check src/ tests/` clean
- [x] `pytest -v` — 1077 passed (was 1072)
- [x] New tests for idempotent payloads and extra-kwarg hint
- [ ] Live smoke deferred — see note above

🤖 Generated with [Claude Code](https://claude.com/claude-code)