### PR TITLE
Tighten 7 tests that passed without verifying behavior

### DIFF
--- a/test_project/tests/test_animation.gd
+++ b/test_project/tests/test_animation.gd
@@ -578,6 +578,7 @@ func test_add_property_track_transition_raw_float() -> void:
 	var v1 = anim.track_get_key_value(0, 1)
 	assert_true(v0 is Vector3, "from value must coerce to Vector3, not stay as Dict")
 	assert_true(v1 is Vector3, "to value must coerce to Vector3, not stay as Dict")
+	assert_eq(v0.x, 0.0)
 	assert_eq(v1.x, 100.0)
 	assert_true(abs(anim.track_get_key_transition(0, 0) - 3.0) < 0.0001,
 		"raw-float transition should be stored on key 0")

--- a/test_project/tests/test_animation.gd
+++ b/test_project/tests/test_animation.gd
@@ -569,6 +569,20 @@ func test_add_property_track_transition_raw_float() -> void:
 		],
 	})
 	assert_has_key(result, "data")
+	# Read back the stored keyframes so a broken dict→Vector3 coercion or a
+	# silently-dropped transition can't pass this test.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var player := McpScenePath.resolve(player_path, scene_root) as AnimationPlayer
+	var anim: Animation = player.get_animation("anim")
+	var v0 = anim.track_get_key_value(0, 0)
+	var v1 = anim.track_get_key_value(0, 1)
+	assert_true(v0 is Vector3, "from value must coerce to Vector3, not stay as Dict")
+	assert_true(v1 is Vector3, "to value must coerce to Vector3, not stay as Dict")
+	assert_eq(v1.x, 100.0)
+	assert_true(abs(anim.track_get_key_transition(0, 0) - 3.0) < 0.0001,
+		"raw-float transition should be stored on key 0")
+	assert_true(abs(anim.track_get_key_transition(0, 1) - 3.0) < 0.0001,
+		"raw-float transition should be stored on key 1")
 	_remove_node(player_path)
 
 

--- a/test_project/tests/test_material.gd
+++ b/test_project/tests/test_material.gd
@@ -119,6 +119,10 @@ func test_create_overwrite_allowed() -> void:
 	_make_material()
 	var result := _handler.create_material({"path": TEST_MATERIAL_PATH, "overwrite": true})
 	assert_has_key(result, "data")
+	assert_eq(result.data.overwritten, true,
+		"overwritten flag must reflect the pre-existing file")
+	assert_true(FileAccess.file_exists(TEST_MATERIAL_PATH),
+		"material file should still exist after overwrite")
 
 
 func test_create_shader_requires_shader_path() -> void:
@@ -179,6 +183,9 @@ func test_set_param_bool() -> void:
 		"value": true,
 	})
 	assert_has_key(result, "data")
+	var mat: Material = ResourceLoader.load(TEST_MATERIAL_PATH)
+	assert_eq(mat.get("emission_enabled"), true,
+		"emission_enabled should be stored as the bool we passed")
 
 
 func test_set_param_transparency_enum_by_name() -> void:

--- a/test_project/tests/test_theme.gd
+++ b/test_project/tests/test_theme.gd
@@ -109,6 +109,7 @@ func test_theme_set_color_accepts_dict() -> void:
 	assert_true(abs(c.r - 0.5) < 0.01)
 	assert_true(abs(c.g - 0.3) < 0.01)
 	assert_true(abs(c.b - 0.1) < 0.01)
+	assert_true(abs(c.a - 1.0) < 0.01)
 
 
 func test_theme_set_color_rejects_garbage_string() -> void:

--- a/test_project/tests/test_theme.gd
+++ b/test_project/tests/test_theme.gd
@@ -65,6 +65,10 @@ func test_create_theme_overwrite_allowed() -> void:
 	_make_theme()
 	var result := _handler.create_theme({"path": TEST_THEME_PATH, "overwrite": true})
 	assert_has_key(result, "data")
+	assert_eq(result.data.overwritten, true,
+		"overwritten flag must reflect the pre-existing file")
+	assert_true(FileAccess.file_exists(TEST_THEME_PATH),
+		"theme file should still exist after overwrite")
 
 
 # ----- theme_set_color -----
@@ -96,6 +100,15 @@ func test_theme_set_color_accepts_dict() -> void:
 		"value": {"r": 0.5, "g": 0.3, "b": 0.1, "a": 1.0},
 	})
 	assert_has_key(result, "data")
+	# Read back from disk so a missing dict→Color coercion can't pass by
+	# returning a successful envelope while storing a raw Dict.
+	var theme: Theme = ResourceLoader.load(TEST_THEME_PATH)
+	assert_true(theme.has_color("font_color", "Label"))
+	var c := theme.get_color("font_color", "Label")
+	assert_true(c is Color, "Stored value must be a Color, not a raw Dict")
+	assert_true(abs(c.r - 0.5) < 0.01)
+	assert_true(abs(c.g - 0.3) < 0.01)
+	assert_true(abs(c.b - 0.1) < 0.01)
 
 
 func test_theme_set_color_rejects_garbage_string() -> void:

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -4869,6 +4869,8 @@ async def test_audio_list_handler_is_read_only():
 
 async def test_audio_player_create_blocks_when_not_writable():
     """audio_player_create requires a writable session (uses require_writable)."""
+    from godot_ai.godot_client.client import GodotCommandError
+
     client = StubClient()
     client.live_readiness = "playing"
     session = Session(
@@ -4881,7 +4883,7 @@ async def test_audio_player_create_blocks_when_not_writable():
     registry = SessionRegistry()
     registry.register(session)
     runtime = DirectRuntime(registry=registry, client=client)
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(GodotCommandError) as exc_info:
         await audio_handlers.audio_player_create(runtime, parent_path="/Main")
     assert "play mode" in str(exc_info.value).lower()
     ## The gate fires one `get_editor_state` probe to confirm the cache

--- a/tests/unit/test_self_update_smoke_harness.py
+++ b/tests/unit/test_self_update_smoke_harness.py
@@ -224,7 +224,9 @@ def test_v240_preflight_passes_when_both_files_present(tmp_path: Path) -> None:
         tmp_path,
         present=("utils/server_lifecycle.gd", "utils/update_manager.gd"),
     )
-    smoke._require_v240_plus_addon_shape(addon, "2.4.0")
+    # Validator returns None on success and raises HarnessError otherwise; the
+    # assertion both documents intent and trips the runner's zero-assertion guard.
+    assert smoke._require_v240_plus_addon_shape(addon, "2.4.0") is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Audit of the test suites (Python + GDScript) surfaced **7 tests** whose assertions did not actually pin down the behavior they claimed to test — they would have stayed green under regressions in the code paths they exercise. Five matched the "counts instead of stored Variants" / `assert_has_key` weakness called out in `CLAUDE.md`'s test-hygiene checklist; two were Python-side cousins (overly broad `pytest.raises(Exception)` and a zero-assertion test).

### GDScript fixes

- **`test_theme.gd::test_theme_set_color_accepts_dict`** — only checked the response envelope. Now reloads the theme and asserts the stored value is a `Color` with the right channels, so a missing dict→Color coercion can't pass.
- **`test_theme.gd::test_create_theme_overwrite_allowed`** and **`test_material.gd::test_create_overwrite_allowed`** — now assert `overwritten=true` on the response and that the target file still exists, instead of just confirming the call returned `data`.
- **`test_material.gd::test_set_param_bool`** — now reads `emission_enabled` back off the loaded material (matching the read-back pattern its float and color siblings already use).
- **`test_animation.gd::test_add_property_track_transition_raw_float`** — now reads the stored keyframes and asserts both that the dict values coerced to `Vector3` and that the raw-float `transition` landed on each key. The prior version would pass even if either silently no-oped.

### Python fixes

- **`test_runtime_handlers.py::test_audio_player_create_blocks_when_not_writable`** — was catching bare `Exception`, which would mask unrelated bugs. Narrowed to `GodotCommandError` to match the surrounding readiness-gate tests.
- **`test_self_update_smoke_harness.py::test_v240_preflight_passes_when_both_files_present`** — had zero assertions; it called the validator and returned. Added `assert smoke._require_v240_plus_addon_shape(...) is None` so the runner's zero-assertion guard has something to verify and the intent is documented.

### Notes — wider patterns observed (not fixed here)

- ~200 calls to `assert_is_error(result)` across the GDScript suite omit the expected error code (vs ~153 that supply one). That accepts *any* error as success, including unrelated bugs. Worth fixing in tests whose names claim a specific failure (e.g. `test_create_node_non_node_type`) but is too large to bundle into this PR.
- The `editor_undo(_undo_redo)` calls flagged at `test_node.gd:283, 298, 928` are cleanup-only undos with no post-undo assertion, so they don't violate the CLAUDE.md rule. Left as-is.
- `test_ui.gd:524/551/575/607` use the non-`_override` theme getters but are gated on `has_theme_*_override(...)` first, which guards against the silent-fallback failure mode. Godot 4.6 dropped the `_override` getter variants, per the inline comment. Left as-is.

## Test plan

- [x] `ruff check tests/unit/test_runtime_handlers.py tests/unit/test_self_update_smoke_harness.py` — clean
- [x] `pytest tests/unit/test_runtime_handlers.py tests/unit/test_self_update_smoke_harness.py -q` — 263 passed
- [ ] GDScript test runner (`test_run` via MCP) — to be exercised when CI picks up the branch / a reviewer runs the editor; the edits are syntactic-mirror copies of patterns already used elsewhere in the same files

https://claude.ai/code/session_01H8CLhwuNUA4NoEZ4neJk78

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8CLhwuNUA4NoEZ4neJk78)_