### PR TITLE
Strict version match + reload-shape pidfile proof fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,69 @@ jobs:
           echo "===== godot-import.log (last 200 lines) ====="
           tail -n 200 godot-import.log || echo "(log not found)"
 
+  # Verifies the plugin's automatic kill+respawn flow when port 8000 is held
+  # by a stale godot-ai server (different version). The unit tests in
+  # test_plugin_lifecycle.gd mock every OS interaction; this is the only
+  # automated job that exercises the real per-OS branded-kill machinery
+  # (PowerShell on Windows, /proc on Linux, ps on macOS). Replaces the
+  # manual operator runs of `script/manual-orphan-test`.
+  stale-server-smoke:
+    name: Stale server smoke / ${{ matrix.label }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: Linux
+          - os: macos-latest
+            label: macOS
+          - os: windows-latest
+            label: Windows
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build plugin link
+        shell: bash
+        run: bash script/verify-worktree
+
+      - uses: chickensoft-games/setup-godot@v2
+        with:
+          version: 4.6.2
+          use-dotnet: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Import and validate GDScript
+        shell: bash
+        timeout-minutes: 3
+        run: |
+          godot --headless --path test_project --import > godot-import.log 2>&1 || true
+          bash script/ci-check-gdscript godot-import.log
+
+      - name: Run stale-server smoke
+        shell: bash
+        timeout-minutes: 3
+        run: python script/ci-stale-server-smoke --log-dir .
+
+      - name: Dump editor log on failure
+        if: failure()
+        shell: bash
+        run: |
+          echo "===== godot-stale-smoke.log (last 500 lines) ====="
+          tail -n 500 godot-stale-smoke.log || echo "(log not found)"
+          echo "===== godot-import.log (last 200 lines) ====="
+          tail -n 200 godot-import.log || echo "(log not found)"
+
   # Separate job from godot-tests: the capture smoke test needs a real
   # rendering driver (null RenderingDevice in --headless produces empty
   # framebuffers) and a display server. Linux uses xvfb-run; macOS and

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -779,13 +779,8 @@ func _update_status() -> void:
 		status_text = "Restarting server..."
 		status_color = COLOR_AMBER
 	elif connected:
-		if bool(server_status.get("dev_version_mismatch_allowed", false)):
-			var actual := str(server_status.get("actual_version", ""))
-			status_text = "Connected (dev server v%s)" % actual if not actual.is_empty() else "Connected (dev server)"
-			status_color = COLOR_AMBER
-		else:
-			status_text = "Connected"
-			status_color = Color.GREEN
+		status_text = "Connected"
+		status_color = Color.GREEN
 	elif state == ServerStateScript.CRASHED:
 		var exit_ms: int = server_status.get("exit_ms", 0)
 		status_text = "Server exited after %.1fs" % (exit_ms / 1000.0)
@@ -1183,27 +1178,22 @@ func _refresh_server_version_label(server_status: Dictionary = {}) -> void:
 		text = "godot-ai == %s" % server_ver
 		color = Color.GREEN
 	else:
-		var dev_allowed := bool(server_status.get("dev_version_mismatch_allowed", false))
-		if dev_allowed:
-			text = "godot-ai == %s  (plugin %s, dev)" % [server_ver, expected_ver]
-			color = COLOR_AMBER
-		else:
-			text = "godot-ai == %s  (expected %s)" % [server_ver, expected_ver]
-			var is_incompatible: bool = state == ServerStateScript.INCOMPATIBLE
-			color = Color.RED if is_incompatible else COLOR_AMBER
-			var has_managed_proof: bool = (
-				_plugin != null
-				and _plugin.has_method("can_restart_managed_server")
-				and _plugin.can_restart_managed_server()
-			)
-			var can_recover: bool = bool(server_status.get("can_recover_incompatible", false))
-			show_restart = (
-				(not is_incompatible and has_managed_proof)
-				## Recoverable incompatible servers get the primary action in
-				## the top error panel. Duplicating it in Setup made the UI
-				## look like it had multiple restart paths.
-				or (is_incompatible and can_recover and _crash_restart_btn == null)
-			)
+		text = "godot-ai == %s  (expected %s)" % [server_ver, expected_ver]
+		var is_incompatible: bool = state == ServerStateScript.INCOMPATIBLE
+		color = Color.RED if is_incompatible else COLOR_AMBER
+		var has_managed_proof: bool = (
+			_plugin != null
+			and _plugin.has_method("can_restart_managed_server")
+			and _plugin.can_restart_managed_server()
+		)
+		var can_recover: bool = bool(server_status.get("can_recover_incompatible", false))
+		show_restart = (
+			(not is_incompatible and has_managed_proof)
+			## Recoverable incompatible servers get the primary action in
+			## the top error panel. Duplicating it in Setup made the UI
+			## look like it had multiple restart paths.
+			or (is_incompatible and can_recover and _crash_restart_btn == null)
+		)
 	if text == _last_rendered_server_text:
 		_setup_server_label.add_theme_color_override("font_color", color)
 		_update_restart_button(show_restart)

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -657,10 +657,10 @@ static func _incompatible_server_message(
 
 
 static func _server_version_compatibility(
-	actual_version: String, expected_version: String, is_dev_checkout: bool
+	actual_version: String, expected_version: String
 ) -> Dictionary:
 	return ServerLifecycleManager._server_version_compatibility(
-		actual_version, expected_version, is_dev_checkout
+		actual_version, expected_version
 	)
 
 
@@ -669,10 +669,9 @@ static func _server_status_compatibility(
 	expected_version: String,
 	actual_ws_port: int,
 	expected_ws_port: int,
-	is_dev_checkout: bool,
 ) -> Dictionary:
 	return ServerLifecycleManager._server_status_compatibility(
-		actual_version, expected_version, actual_ws_port, expected_ws_port, is_dev_checkout
+		actual_version, expected_version, actual_ws_port, expected_ws_port
 	)
 
 
@@ -1099,18 +1098,26 @@ func _recover_strong_port_occupant(port: int, wait_s: float, pre_kill_live: Dict
 func _legacy_pidfile_kill_targets(_port: int, listener_pids: Array[int]) -> Array[int]:
 	var targets: Array[int] = []
 	var pidfile_pid := _read_pid_file_for_proof()
-	var pidfile_alive := _pid_alive_for_proof(pidfile_pid)
-	var pidfile_branded := _pid_cmdline_is_godot_ai_for_proof(pidfile_pid)
 	if pidfile_pid <= 1 or pidfile_pid == OS.get_process_id():
 		return targets
-	if not listener_pids.has(pidfile_pid) or not pidfile_alive:
-		return targets
-	if not pidfile_branded:
+	## An alive, branded pid-file PID is sufficient ownership proof. Under
+	## `uvicorn --reload` the reloader writes the pid-file but a child worker
+	## binds the port, so `listener_pids` never contains the reloader PID.
+	## Requiring `listener_pids.has(pidfile_pid)` here used to silently skip
+	## the kill path for the entire reload-shaped server family. The branded
+	## listener loop below still does the per-PID brand check so we never
+	## kill an unrelated process that happens to share the port.
+	if not _pid_alive_for_proof(pidfile_pid) or not _pid_cmdline_is_godot_ai_for_proof(pidfile_pid):
 		return targets
 
 	for pid in listener_pids:
 		if pid > 1 and pid != OS.get_process_id() and _pid_cmdline_is_godot_ai_for_proof(pid):
 			targets.append(pid)
+	## Also kill the reloader/launcher itself when it isn't already a listener.
+	## Without this, `--reload` workers would be killed but their parent would
+	## immediately respawn a replacement and the port would never free.
+	if not targets.has(pidfile_pid):
+		targets.append(pidfile_pid)
 	return targets
 
 

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -1111,7 +1111,13 @@ func _legacy_pidfile_kill_targets(_port: int, listener_pids: Array[int]) -> Arra
 		return targets
 
 	for pid in listener_pids:
-		if pid > 1 and pid != OS.get_process_id() and _pid_cmdline_is_godot_ai_for_proof(pid):
+		if pid <= 1 or pid == OS.get_process_id():
+			continue
+		## Reuse the brand result already proven above when this listener is
+		## the same PID as the pidfile — saves a parent-chain walk and a
+		## shell-out (PowerShell on Windows, /proc on Linux, ps on macOS) per
+		## startup proof evaluation.
+		if pid == pidfile_pid or _pid_cmdline_is_godot_ai_for_proof(pid):
 			targets.append(pid)
 	## Also kill the reloader/launcher itself when it isn't already a listener.
 	## Without this, `--reload` workers would be killed but their parent would

--- a/plugin/addons/godot_ai/utils/mcp_server_state.gd
+++ b/plugin/addons/godot_ai/utils/mcp_server_state.gd
@@ -6,9 +6,9 @@ extends RefCounted
 ## lifecycle. Single source of truth — supersedes the boolean-flag thicket
 ## (`_server_started_this_session`, `_awaiting_server_version`,
 ## `_server_version_deadline_ms`, `_connection_blocked`,
-## `_can_recover_incompatible`, `_server_dev_version_mismatch_allowed`,
-## `_refresh_retried`, `_adoption_watch_deadline_ms`) and the older
-## terminal-only McpSpawnState string union.
+## `_can_recover_incompatible`, `_refresh_retried`,
+## `_adoption_watch_deadline_ms`) and the older terminal-only
+## McpSpawnState string union.
 ##
 ## The integer values matter — they're what `get_server_status()`
 ## surfaces, what the dock pattern-matches on, and what the test suites

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -46,7 +46,6 @@ var _server_actual_name: String = ""
 
 ## Diagnostic + recovery flags surfaced to the dock via `get_status()`.
 var _server_status_message: String = ""
-var _server_dev_version_mismatch_allowed: bool = false
 var _can_recover_incompatible: bool = false
 var _connection_blocked: bool = false
 
@@ -87,7 +86,6 @@ func get_status_dict() -> Dictionary:
 		"actual_version": _server_actual_version,
 		"expected_version": _server_expected_version,
 		"message": _server_status_message,
-		"dev_version_mismatch_allowed": _server_dev_version_mismatch_allowed,
 		"can_recover_incompatible": _can_recover_incompatible,
 		"connection_blocked": _connection_blocked,
 	}
@@ -215,21 +213,9 @@ func handle_server_version_verified(expected_version: String, version: String) -
 	_server_actual_version = version
 	var expected := _resolve_expected_version(expected_version)
 	_server_expected_version = expected
-	var compatibility := _server_version_compatibility(
-		version,
-		expected,
-		ClientConfigurator.is_dev_checkout()
-	)
+	var compatibility := _server_version_compatibility(version, expected)
 	if compatibility.get("compatible", false):
 		_can_recover_incompatible = false
-		_server_dev_version_mismatch_allowed = bool(
-			compatibility.get("dev_mismatch_allowed", false)
-		)
-		if _server_dev_version_mismatch_allowed:
-			_server_status_message = (
-				"Using dev server v%s with plugin v%s "
-				+ "(dev checkout version mismatch allowed)."
-			) % [version, expected]
 		## Foreign-port and post-spawn handshakes both clear to READY
 		## on a successful handshake. Late re-arms from READY also land
 		## here and self-confirm.
@@ -259,18 +245,22 @@ func handle_server_version_unverified(expected_version: String) -> void:
 
 # ---- Compatibility / version helpers (pure) ---------------------------
 
+## Plugin and server speak a single, version-coupled protocol — new commands
+## and response fields are added together. Treating dev-mode mismatches as
+## "compatible" silently adopts a stale server whose code may differ from the
+## live source tree (e.g. another worktree on a different branch holding
+## port 8000). Strict match in all modes routes mismatches through
+## `recover_strong_port_occupant`, which kills the branded port-holder and
+## lets `start_server` spawn fresh against the current source.
 static func _server_version_compatibility(
 	actual_version: String,
-	expected_version: String,
-	is_dev_checkout: bool
+	expected_version: String
 ) -> Dictionary:
 	if actual_version.is_empty():
-		return {"compatible": false, "reason": "unknown", "dev_mismatch_allowed": false}
+		return {"compatible": false, "reason": "unknown"}
 	if actual_version == expected_version:
-		return {"compatible": true, "reason": "exact", "dev_mismatch_allowed": false}
-	if is_dev_checkout:
-		return {"compatible": true, "reason": "dev_mismatch", "dev_mismatch_allowed": true}
-	return {"compatible": false, "reason": "version_mismatch", "dev_mismatch_allowed": false}
+		return {"compatible": true, "reason": "exact"}
+	return {"compatible": false, "reason": "version_mismatch"}
 
 
 static func _server_status_compatibility(
@@ -278,17 +268,12 @@ static func _server_status_compatibility(
 	expected_version: String,
 	actual_ws_port: int,
 	expected_ws_port: int,
-	is_dev_checkout: bool,
 ) -> Dictionary:
-	var version_result := _server_version_compatibility(
-		actual_version,
-		expected_version,
-		is_dev_checkout
-	)
+	var version_result := _server_version_compatibility(actual_version, expected_version)
 	if not bool(version_result.get("compatible", false)):
 		return version_result
 	if actual_ws_port != expected_ws_port:
-		return {"compatible": false, "reason": "ws_port_mismatch", "dev_mismatch_allowed": false}
+		return {"compatible": false, "reason": "ws_port_mismatch"}
 	return version_result
 
 
@@ -308,7 +293,6 @@ func _set_incompatible_server(live: Dictionary, expected_version: String, port: 
 	_server_expected_version = expected_version
 	_server_actual_name = str(live.get("name", ""))
 	_server_actual_version = _live_version_for_message(live)
-	_server_dev_version_mismatch_allowed = false
 	_server_status_message = _incompatible_server_message(
 		live, expected_version, port, int(_host._resolved_ws_port)
 	)
@@ -442,18 +426,11 @@ func start_server() -> void:
 			current_version,
 			live_ws_port,
 			ws_port,
-			ClientConfigurator.is_dev_checkout()
 		)
 		if compatibility.get("compatible", false):
 			_server_actual_name = "godot-ai"
 			_server_actual_version = live_version
 			_can_recover_incompatible = false
-			_server_dev_version_mismatch_allowed = bool(compatibility.get("dev_mismatch_allowed", false))
-			if bool(_server_dev_version_mismatch_allowed):
-				_server_status_message = (
-					"Using dev server v%s on WS port %d with plugin v%s "
-					+ "(dev checkout version mismatch allowed)."
-				) % [str(_server_actual_version), live_ws_port, current_version]
 			var owner := int(_host._find_managed_pid(port))
 			var owner_label := adopt_compatible_server(record_version, current_version, owner)
 			_host._server_started_this_session = true

--- a/script/ci-stale-server-smoke
+++ b/script/ci-stale-server-smoke
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Live smoke: plugin kills a stale port-8000 server and respawns its own.
+
+Plants a synthetic godot-ai server simulator (different version) on port 8000,
+launches Godot headless against test_project/, and asserts that the plugin's
+`recover_strong_port_occupant` path observably:
+
+  1. Detects the version mismatch.
+  2. Logs `MCP | strong proof: <name>`.
+  3. Logs `MCP | killed pids [...]`.
+  4. Spawns its own server (`/godot-ai/status` reports the plugin version).
+  5. The simulator PID is gone.
+
+Backfills the automated coverage gap: the unit tests in test_plugin_lifecycle.gd
+mock all OS interactions, and `script/manual-orphan-test` exercises the real
+kill path but is a manual operator helper. This script runs the same path in CI
+on every OS, so a regression in the per-OS kill / cmdline-brand machinery is
+caught before merge.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+TEST_PROJECT = ROOT / "test_project"
+PROJECT_NAME = "MCP Test Project"
+PORT = 8000
+WS_PORT = 9500
+STALE_VERSION = "0.0.0-stale"
+STATUS_URL = f"http://127.0.0.1:{PORT}/godot-ai/status"
+EXPECTED_PROOF_NAMES = ("managed_record", "pidfile_listener", "status_matches_record")
+
+
+SIM_SOURCE = '''\
+"""Stale godot-ai server simulator for ci-stale-server-smoke."""
+import argparse
+import json
+import os
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+ap = argparse.ArgumentParser()
+ap.add_argument("--transport", default="streamable-http")
+ap.add_argument("--port", type=int, default=8000)
+ap.add_argument("--ws-port", type=int, default=9500)
+ap.add_argument("--pid-file", required=True)
+ap.add_argument("--fake-version", default="0.0.0-stale")
+args, _ = ap.parse_known_args()
+
+os.makedirs(os.path.dirname(args.pid_file), exist_ok=True)
+with open(args.pid_file, "w", encoding="utf-8") as f:
+    f.write(str(os.getpid()))
+
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a, **kw):  # silence
+        pass
+
+    def do_GET(self):
+        if self.path == "/godot-ai/status":
+            body = json.dumps({
+                "name": "godot-ai",
+                "version": args.fake_version,
+                "ws_port": args.ws_port,
+            }).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        self.send_response(404)
+        self.end_headers()
+
+
+print(f"stale-sim pid={os.getpid()} listening on :{args.port}", flush=True)
+ThreadingHTTPServer(("127.0.0.1", args.port), H).serve_forever()
+'''
+
+
+class SmokeError(RuntimeError):
+    pass
+
+
+def godot_user_data_dir() -> Path:
+    """The directory Godot uses for `user://` under PROJECT_NAME on this OS."""
+    system = platform.system()
+    if system == "Darwin":
+        return Path.home() / "Library" / "Application Support" / "Godot" / "app_userdata" / PROJECT_NAME
+    if system == "Windows":
+        return Path(os.environ["APPDATA"]) / "Godot" / "app_userdata" / PROJECT_NAME
+    return Path.home() / ".local" / "share" / "godot" / "app_userdata" / PROJECT_NAME
+
+
+def write_sim(workdir: Path) -> Path:
+    pkg = workdir / "godot_ai"
+    pkg.mkdir(parents=True, exist_ok=True)
+    (pkg / "__init__.py").write_text("")
+    (pkg / "__main__.py").write_text(SIM_SOURCE)
+    return workdir
+
+
+def extract_version(payload: dict) -> str:
+    """Mirror plugin.gd::_extract_server_version: try server_version first,
+    then version. The real server emits server_version; the sim emits version."""
+    return str(payload.get("server_version") or payload.get("version") or "")
+
+
+def wait_for_status(version: str | None, timeout_s: float) -> dict:
+    """Poll /godot-ai/status until it returns the expected version (or any
+    JSON if version is None). Returns the parsed payload."""
+    deadline = time.monotonic() + timeout_s
+    last_err: str | None = None
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(STATUS_URL, timeout=2) as r:
+                payload = json.loads(r.read().decode())
+                found = extract_version(payload)
+                if version is None or found == version:
+                    return payload
+                last_err = f"version={found!r} (waiting for {version!r})"
+        except (urllib.error.URLError, ConnectionError, TimeoutError) as e:
+            last_err = str(e)
+        time.sleep(0.5)
+    raise SmokeError(f"status endpoint did not match within {timeout_s}s: {last_err}")
+
+
+def wait_for_log_lines(log_path: Path, needles: list[str], timeout_s: float) -> dict[str, str]:
+    """Tail `log_path` until every needle matches at least one line. Returns
+    a {needle: matched_line} dict."""
+    found: dict[str, str] = {}
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if log_path.exists():
+            for line in log_path.read_text(errors="replace").splitlines():
+                for needle in needles:
+                    if needle in found:
+                        continue
+                    if needle in line:
+                        found[needle] = line
+            if len(found) == len(needles):
+                return found
+        time.sleep(0.5)
+    missing = [n for n in needles if n not in found]
+    raise SmokeError(f"never saw log lines: {missing!r}. found: {list(found.keys())!r}")
+
+
+def pid_alive(pid: int) -> bool:
+    if platform.system() == "Windows":
+        out = subprocess.run(
+            ["tasklist", "/FI", f"PID eq {pid}", "/FO", "CSV", "/NH"],
+            capture_output=True, text=True, check=False,
+        )
+        return str(pid) in out.stdout
+    try:
+        os.kill(pid, 0)
+        return True
+    except (OSError, ProcessLookupError):
+        return False
+
+
+def find_godot() -> str:
+    for candidate in (os.environ.get("GODOT_BIN"), "godot", "Godot"):
+        if not candidate:
+            continue
+        if shutil.which(candidate):
+            return candidate
+    raise SmokeError("godot not on PATH (set GODOT_BIN)")
+
+
+def find_plugin_version() -> str:
+    cfg = ROOT / "plugin" / "addons" / "godot_ai" / "plugin.cfg"
+    for line in cfg.read_text().splitlines():
+        if line.startswith("version="):
+            return line.split("=", 1)[1].strip().strip('"')
+    raise SmokeError(f"could not find version= in {cfg}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--log-dir", default=".", help="Where to write godot-stale-smoke.log")
+    ap.add_argument("--timeout", type=float, default=45.0)
+    args = ap.parse_args()
+
+    log_dir = Path(args.log_dir).resolve()
+    log_dir.mkdir(parents=True, exist_ok=True)
+    editor_log = log_dir / "godot-stale-smoke.log"
+
+    godot = find_godot()
+    plugin_version = find_plugin_version()
+    user_dir = godot_user_data_dir()
+    user_dir.mkdir(parents=True, exist_ok=True)
+    pidfile = user_dir / "godot_ai_server.pid"
+
+    print(f"godot={godot}")
+    print(f"plugin version={plugin_version}")
+    print(f"user data dir={user_dir}")
+    print(f"pidfile={pidfile}")
+
+    # Pre-clean: stale pidfile / managed record from a prior run would route
+    # the plugin through a different proof tier than the one we're targeting.
+    if pidfile.exists():
+        pidfile.unlink()
+
+    sim: subprocess.Popen | None = None
+    godot_proc: subprocess.Popen | None = None
+    workdir = Path(tempfile.mkdtemp(prefix="stale-sim-"))
+    try:
+        write_sim(workdir)
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(workdir) + os.pathsep + env.get("PYTHONPATH", "")
+        sim_cmd = [
+            sys.executable, "-m", "godot_ai",
+            "--transport", "streamable-http",
+            "--port", str(PORT),
+            "--ws-port", str(WS_PORT),
+            "--pid-file", str(pidfile),
+            "--fake-version", STALE_VERSION,
+        ]
+        print(f"starting stale sim: {' '.join(sim_cmd)}")
+        sim = subprocess.Popen(sim_cmd, env=env)
+        sim_pid = sim.pid
+        print(f"sim pid={sim_pid}")
+
+        sim_status = wait_for_status(STALE_VERSION, timeout_s=10.0)
+        print(f"sim status confirmed: {sim_status}")
+
+        editor_log.write_text("")
+        log_fh = editor_log.open("ab")
+        try:
+            godot_env = os.environ.copy()
+            godot_env["GODOT_AI_ALLOW_HEADLESS"] = "1"
+            godot_cmd = [godot, "--headless", "--path", str(TEST_PROJECT), "--editor"]
+            print(f"launching godot: {' '.join(godot_cmd)}")
+            godot_proc = subprocess.Popen(godot_cmd, env=godot_env, stdout=log_fh, stderr=log_fh)
+
+            proof_needle = "MCP | strong proof:"
+            kill_needle = "MCP | killed pids"
+            print(f"waiting up to {args.timeout}s for kill+respawn log lines...")
+            matched = wait_for_log_lines(editor_log, [proof_needle, kill_needle], args.timeout)
+            print(f"saw: {matched[proof_needle]!r}")
+            print(f"saw: {matched[kill_needle]!r}")
+
+            proof_line = matched[proof_needle]
+            if not any(name in proof_line for name in EXPECTED_PROOF_NAMES):
+                raise SmokeError(
+                    f"proof line did not name a strong-proof tier: {proof_line!r}; "
+                    f"expected one of {EXPECTED_PROOF_NAMES}"
+                )
+
+            print(f"verifying respawned server reports plugin version {plugin_version}...")
+            fresh = wait_for_status(plugin_version, timeout_s=20.0)
+            print(f"fresh server status: {fresh}")
+
+            if pid_alive(sim_pid):
+                raise SmokeError(f"sim pid {sim_pid} is still alive after kill+respawn")
+            print(f"sim pid {sim_pid} is gone, as expected")
+        finally:
+            log_fh.close()
+
+        print("PASS: stale-server kill+respawn smoke")
+        return 0
+    except SmokeError as e:
+        print(f"FAIL: {e}", file=sys.stderr)
+        if editor_log.exists():
+            print("===== editor log (last 200 lines) =====", file=sys.stderr)
+            tail = editor_log.read_text(errors="replace").splitlines()[-200:]
+            print("\n".join(tail), file=sys.stderr)
+        return 1
+    finally:
+        if godot_proc is not None and godot_proc.poll() is None:
+            print(f"terminating godot pid={godot_proc.pid}")
+            if platform.system() == "Windows":
+                godot_proc.terminate()
+            else:
+                godot_proc.send_signal(signal.SIGTERM)
+            try:
+                godot_proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                godot_proc.kill()
+        if sim is not None and sim.poll() is None:
+            print(f"terminating sim pid={sim.pid}")
+            sim.terminate()
+            try:
+                sim.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                sim.kill()
+        shutil.rmtree(workdir, ignore_errors=True)
+        # Clear pidfile that may have been left by the respawned server, so
+        # adjacent CI steps see a clean state.
+        if pidfile.exists():
+            pidfile.unlink()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/script/ci-stale-server-smoke
+++ b/script/ci-stale-server-smoke
@@ -125,7 +125,7 @@ def discover_user_dir(godot: str) -> Path:
     `user://godot_ai_server.pid` via Godot's own resolution, so we must
     write the pidfile to the *exact* same place."""
     helper = TEST_PROJECT / "_smoke_get_user_dir.gd"
-    helper.write_text(DISCOVER_USER_DIR_GD)
+    helper.write_text(DISCOVER_USER_DIR_GD, encoding="utf-8")
     try:
         result = subprocess.run(
             [godot, "--headless", "--path", str(TEST_PROJECT),
@@ -146,8 +146,11 @@ def discover_user_dir(godot: str) -> Path:
 def write_sim(workdir: Path) -> Path:
     pkg = workdir / "godot_ai"
     pkg.mkdir(parents=True, exist_ok=True)
-    (pkg / "__init__.py").write_text("")
-    (pkg / "__main__.py").write_text(SIM_SOURCE)
+    # Explicit UTF-8 — Path.write_text defaults to locale encoding (cp1252 on
+    # Windows), which would mangle non-ASCII chars in docstrings into bytes
+    # the child Python (reading source as UTF-8) rejects with SyntaxError.
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (pkg / "__main__.py").write_text(SIM_SOURCE, encoding="utf-8")
     return workdir
 
 

--- a/script/ci-stale-server-smoke
+++ b/script/ci-stale-server-smoke
@@ -36,12 +36,21 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 TEST_PROJECT = ROOT / "test_project"
-PROJECT_NAME = "MCP Test Project"
 PORT = 8000
 WS_PORT = 9500
 STALE_VERSION = "0.0.0-stale"
 STATUS_URL = f"http://127.0.0.1:{PORT}/godot-ai/status"
 EXPECTED_PROOF_NAMES = ("managed_record", "pidfile_listener", "status_matches_record")
+LOG_LINES_TIMEOUT = 60.0
+FRESH_STATUS_TIMEOUT = 30.0
+
+DISCOVER_USER_DIR_GD = '''\
+extends SceneTree
+
+func _initialize() -> void:
+\tprint("USER_DATA_DIR=" + OS.get_user_data_dir())
+\tquit()
+'''
 
 
 SIM_SOURCE = '''\
@@ -94,14 +103,28 @@ class SmokeError(RuntimeError):
     pass
 
 
-def godot_user_data_dir() -> Path:
-    """The directory Godot uses for `user://` under PROJECT_NAME on this OS."""
-    system = platform.system()
-    if system == "Darwin":
-        return Path.home() / "Library" / "Application Support" / "Godot" / "app_userdata" / PROJECT_NAME
-    if system == "Windows":
-        return Path(os.environ["APPDATA"]) / "Godot" / "app_userdata" / PROJECT_NAME
-    return Path.home() / ".local" / "share" / "godot" / "app_userdata" / PROJECT_NAME
+def discover_user_dir(godot: str) -> Path:
+    """Ask Godot itself for `OS.get_user_data_dir()`. More reliable than
+    re-deriving the per-OS convention by hand — the plugin reads
+    `user://godot_ai_server.pid` via Godot's own resolution, so we must
+    write the pidfile to the *exact* same place."""
+    helper = TEST_PROJECT / "_smoke_get_user_dir.gd"
+    helper.write_text(DISCOVER_USER_DIR_GD)
+    try:
+        result = subprocess.run(
+            [godot, "--headless", "--path", str(TEST_PROJECT),
+             "--script", "res://_smoke_get_user_dir.gd"],
+            capture_output=True, text=True, timeout=60, check=False,
+        )
+        for line in result.stdout.splitlines():
+            if line.startswith("USER_DATA_DIR="):
+                return Path(line[len("USER_DATA_DIR="):].strip())
+        raise SmokeError(
+            f"discover_user_dir: no marker line in Godot output.\n"
+            f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+        )
+    finally:
+        helper.unlink(missing_ok=True)
 
 
 def write_sim(workdir: Path) -> Path:
@@ -200,13 +223,17 @@ def main() -> int:
 
     godot = find_godot()
     plugin_version = find_plugin_version()
-    user_dir = godot_user_data_dir()
+
+    godot_ai_path = shutil.which("godot-ai") or "(not on PATH)"
+    print(f"godot={godot}")
+    print(f"godot-ai={godot_ai_path}")
+    print(f"plugin version={plugin_version}")
+
+    print("discovering Godot user data dir...")
+    user_dir = discover_user_dir(godot)
+    print(f"user data dir={user_dir}")
     user_dir.mkdir(parents=True, exist_ok=True)
     pidfile = user_dir / "godot_ai_server.pid"
-
-    print(f"godot={godot}")
-    print(f"plugin version={plugin_version}")
-    print(f"user data dir={user_dir}")
     print(f"pidfile={pidfile}")
 
     # Pre-clean: stale pidfile / managed record from a prior run would route
@@ -248,8 +275,9 @@ def main() -> int:
 
             proof_needle = "MCP | strong proof:"
             kill_needle = "MCP | killed pids"
-            print(f"waiting up to {args.timeout}s for kill+respawn log lines...")
-            matched = wait_for_log_lines(editor_log, [proof_needle, kill_needle], args.timeout)
+            log_timeout = max(args.timeout, LOG_LINES_TIMEOUT)
+            print(f"waiting up to {log_timeout}s for kill+respawn log lines...")
+            matched = wait_for_log_lines(editor_log, [proof_needle, kill_needle], log_timeout)
             print(f"saw: {matched[proof_needle]!r}")
             print(f"saw: {matched[kill_needle]!r}")
 
@@ -260,8 +288,9 @@ def main() -> int:
                     f"expected one of {EXPECTED_PROOF_NAMES}"
                 )
 
-            print(f"verifying respawned server reports plugin version {plugin_version}...")
-            fresh = wait_for_status(plugin_version, timeout_s=20.0)
+            print(f"verifying respawned server reports plugin version {plugin_version} "
+                  f"(timeout {FRESH_STATUS_TIMEOUT}s)...")
+            fresh = wait_for_status(plugin_version, timeout_s=FRESH_STATUS_TIMEOUT)
             print(f"fresh server status: {fresh}")
 
             if pid_alive(sim_pid):
@@ -274,8 +303,24 @@ def main() -> int:
         return 0
     except SmokeError as e:
         print(f"FAIL: {e}", file=sys.stderr)
+        print(f"===== user data dir state ({user_dir}) =====", file=sys.stderr)
+        if user_dir.exists():
+            for entry in sorted(user_dir.iterdir()):
+                marker = "[pidfile]" if entry.name == "godot_ai_server.pid" else ""
+                print(f"  {entry.name} {marker}", file=sys.stderr)
+                if entry.name == "godot_ai_server.pid":
+                    try:
+                        print(f"    contents: {entry.read_text().strip()!r}", file=sys.stderr)
+                    except OSError as oe:
+                        print(f"    read error: {oe}", file=sys.stderr)
+        else:
+            print("  (user dir does not exist)", file=sys.stderr)
+        print(f"===== MCP-tagged log lines =====", file=sys.stderr)
         if editor_log.exists():
-            print("===== editor log (last 200 lines) =====", file=sys.stderr)
+            for line in editor_log.read_text(errors="replace").splitlines():
+                if "MCP " in line or "godot_ai" in line or "godot-ai" in line:
+                    print(f"  {line}", file=sys.stderr)
+            print(f"===== editor log (last 200 lines) =====", file=sys.stderr)
             tail = editor_log.read_text(errors="replace").splitlines()[-200:]
             print("\n".join(tail), file=sys.stderr)
         return 1

--- a/script/ci-stale-server-smoke
+++ b/script/ci-stale-server-smoke
@@ -59,6 +59,7 @@ import argparse
 import json
 import os
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from socketserver import TCPServer
 
 ap = argparse.ArgumentParser()
 ap.add_argument("--transport", default="streamable-http")
@@ -94,9 +95,21 @@ class H(BaseHTTPRequestHandler):
         self.end_headers()
 
 
+class FastBindServer(ThreadingHTTPServer):
+    """Skip HTTPServer's reverse-DNS lookup. The stock server_bind calls
+    socket.getfqdn(host) to set self.server_name — on macOS CI runners
+    with no PTR for 127.0.0.1 and unreachable upstream DNS, that hangs
+    ~30s before falling back. We don't need server_name; route by path."""
+    def server_bind(self):
+        TCPServer.server_bind(self)
+        host, port = self.server_address[:2]
+        self.server_name = host
+        self.server_port = port
+
+
 # Bind FIRST so the "listening" print isn't a lie — the smoke polls
 # /godot-ai/status immediately after seeing it.
-server = ThreadingHTTPServer(("127.0.0.1", args.port), H)
+server = FastBindServer(("127.0.0.1", args.port), H)
 print(f"stale-sim pid={os.getpid()} listening on :{args.port}", flush=True)
 server.serve_forever()
 '''

--- a/script/ci-stale-server-smoke
+++ b/script/ci-stale-server-smoke
@@ -144,12 +144,23 @@ def extract_version(payload: dict) -> str:
     return str(payload.get("server_version") or payload.get("version") or "")
 
 
-def wait_for_status(version: str | None, timeout_s: float) -> dict:
+def wait_for_status(
+    version: str | None,
+    timeout_s: float,
+    sim: subprocess.Popen | None = None,
+) -> dict:
     """Poll /godot-ai/status until it returns the expected version (or any
-    JSON if version is None). Returns the parsed payload."""
+    JSON if version is None). Returns the parsed payload. When `sim` is
+    given, fail fast if it dies — there's no point waiting 30s for a port
+    nobody is bound to anymore."""
     deadline = time.monotonic() + timeout_s
     last_err: str | None = None
     while time.monotonic() < deadline:
+        if sim is not None and sim.poll() is not None:
+            raise SmokeError(
+                f"stale sim died early (exit {sim.returncode}) while waiting "
+                f"for status; last urlopen error: {last_err!r}"
+            )
         try:
             with urllib.request.urlopen(STATUS_URL, timeout=2) as r:
                 payload = json.loads(r.read().decode())
@@ -250,6 +261,7 @@ def main() -> int:
     log_dir = Path(args.log_dir).resolve()
     log_dir.mkdir(parents=True, exist_ok=True)
     editor_log = log_dir / "godot-stale-smoke.log"
+    sim_log = log_dir / "stale-sim.log"
 
     godot = find_godot()
     plugin_version = find_plugin_version()
@@ -287,11 +299,12 @@ def main() -> int:
             "--fake-version", STALE_VERSION,
         ]
         print(f"starting stale sim: {' '.join(sim_cmd)}")
-        sim = subprocess.Popen(sim_cmd, env=env)
+        sim_log_fh = sim_log.open("wb")
+        sim = subprocess.Popen(sim_cmd, env=env, stdout=sim_log_fh, stderr=subprocess.STDOUT)
         sim_pid = sim.pid
-        print(f"sim pid={sim_pid}")
+        print(f"sim pid={sim_pid}, sim log={sim_log}")
 
-        sim_status = wait_for_status(STALE_VERSION, timeout_s=30.0)
+        sim_status = wait_for_status(STALE_VERSION, timeout_s=30.0, sim=sim)
         print(f"sim status confirmed: {sim_status}")
 
         editor_log.write_text("")
@@ -340,6 +353,15 @@ def main() -> int:
         return 0
     except SmokeError as e:
         print(f"FAIL: {e}", file=sys.stderr)
+        print(f"===== stale sim stdout/stderr ({sim_log}) =====", file=sys.stderr)
+        if sim_log.exists():
+            content = sim_log.read_text(errors="replace")
+            if content.strip():
+                print(content, file=sys.stderr)
+            else:
+                print("(empty — sim produced no output before terminating)", file=sys.stderr)
+        else:
+            print("(sim log not created)", file=sys.stderr)
         print(f"===== user data dir state ({user_dir}) =====", file=sys.stderr)
         if user_dir.exists():
             for entry in sorted(user_dir.iterdir()):

--- a/script/ci-stale-server-smoke
+++ b/script/ci-stale-server-smoke
@@ -94,8 +94,11 @@ class H(BaseHTTPRequestHandler):
         self.end_headers()
 
 
+# Bind FIRST so the "listening" print isn't a lie — the smoke polls
+# /godot-ai/status immediately after seeing it.
+server = ThreadingHTTPServer(("127.0.0.1", args.port), H)
 print(f"stale-sim pid={os.getpid()} listening on :{args.port}", flush=True)
-ThreadingHTTPServer(("127.0.0.1", args.port), H).serve_forever()
+server.serve_forever()
 '''
 
 
@@ -180,27 +183,54 @@ def wait_for_log_lines(log_path: Path, needles: list[str], timeout_s: float) -> 
     raise SmokeError(f"never saw log lines: {missing!r}. found: {list(found.keys())!r}")
 
 
-def pid_alive(pid: int) -> bool:
-    if platform.system() == "Windows":
-        out = subprocess.run(
-            ["tasklist", "/FI", f"PID eq {pid}", "/FO", "CSV", "/NH"],
-            capture_output=True, text=True, check=False,
-        )
-        return str(pid) in out.stdout
-    try:
-        os.kill(pid, 0)
-        return True
-    except (OSError, ProcessLookupError):
-        return False
+def child_is_alive(proc: subprocess.Popen) -> bool:
+    """Reap the child via Popen.poll() before answering. A naive
+    `os.kill(pid, 0)` check returns True for unreaped zombies — so when
+    the plugin kills the sim externally, the sim becomes a zombie under
+    our smoke (its parent) and the cheap signal-zero probe lies. poll()
+    issues waitpid and clears the zombie, giving us an honest answer."""
+    return proc.poll() is None
 
 
 def find_godot() -> str:
-    for candidate in (os.environ.get("GODOT_BIN"), "godot", "Godot"):
+    """Locate the Godot binary. shutil.which is fine on POSIX, but on
+    Windows the chickensoft action sometimes registers godot via a
+    name that PATHEXT/which logic doesn't find from Python (it works
+    from bash because bash uses its own resolution). Fall back to the
+    OS-native `where`/`which` shell command which mirrors what bash
+    sees."""
+    candidates = [
+        os.environ.get("GODOT_BIN"),
+        os.environ.get("GODOT4_BIN"),
+        "godot",
+        "Godot",
+    ]
+    for candidate in candidates:
         if not candidate:
             continue
-        if shutil.which(candidate):
+        resolved = shutil.which(candidate)
+        if resolved:
+            print(f"find_godot: shutil.which({candidate!r}) -> {resolved}")
             return candidate
-    raise SmokeError("godot not on PATH (set GODOT_BIN)")
+
+    cmd = "where" if platform.system() == "Windows" else "which"
+    for name in ("godot", "Godot"):
+        try:
+            out = subprocess.run(
+                [cmd, name], capture_output=True, text=True, timeout=10, check=False
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            continue
+        if out.returncode == 0 and out.stdout.strip():
+            resolved = out.stdout.strip().splitlines()[0]
+            print(f"find_godot: {cmd} {name} -> {resolved}")
+            return resolved
+
+    path = os.environ.get("PATH", "")
+    raise SmokeError(
+        f"godot not on PATH (set GODOT_BIN). Tried {candidates!r} via "
+        f"shutil.which and `{cmd}`. PATH={path!r}"
+    )
 
 
 def find_plugin_version() -> str:
@@ -261,7 +291,7 @@ def main() -> int:
         sim_pid = sim.pid
         print(f"sim pid={sim_pid}")
 
-        sim_status = wait_for_status(STALE_VERSION, timeout_s=10.0)
+        sim_status = wait_for_status(STALE_VERSION, timeout_s=30.0)
         print(f"sim status confirmed: {sim_status}")
 
         editor_log.write_text("")
@@ -293,9 +323,16 @@ def main() -> int:
             fresh = wait_for_status(plugin_version, timeout_s=FRESH_STATUS_TIMEOUT)
             print(f"fresh server status: {fresh}")
 
-            if pid_alive(sim_pid):
+            # Give the plugin's kill a moment to land + reap. The plugin's
+            # `_kill_processes_and_windows_spawn_children` returns once the
+            # signal is sent; the sim process may still be in flight here.
+            for _ in range(20):
+                if not child_is_alive(sim):
+                    break
+                time.sleep(0.25)
+            if child_is_alive(sim):
                 raise SmokeError(f"sim pid {sim_pid} is still alive after kill+respawn")
-            print(f"sim pid {sim_pid} is gone, as expected")
+            print(f"sim pid {sim_pid} is gone (exit={sim.returncode}), as expected")
         finally:
             log_fh.close()
 

--- a/script/manual-orphan-test
+++ b/script/manual-orphan-test
@@ -684,33 +684,18 @@ Launch the editor with console logging:
     "\$GODOT" --editor --path "\$PROJECT" 2>&1 | tee /tmp/mcp-editor.log
     tail -f /tmp/mcp-editor.log | grep -E 'MCP \\||godot[_-]ai'
 
-## Dev checkout: force user mode for version-mismatch scenarios
+## Dev checkout: strict version match in all modes
 
-Scenarios 1, 2, 3, and 5 deliberately pin the simulator to a version that
-does NOT match the plugin, and expect the plugin to treat the occupant as
-incompatible. In a dev checkout (a clone next to a \`.venv\`)
-\`McpClientConfigurator.is_dev_checkout()\` returns true, and
-\`_server_version_compatibility\` then returns \`{compatible: true,
-dev_mismatch_allowed: true}\` regardless of version — so the plugin happily
-adopts the simulator and the proof log lines never fire. The heuristic
-checks \`.venv/bin/python\` on POSIX and \`.venv/Scripts/python.exe\` on
-Windows (\`client_configurator.gd::_find_venv_python\`), so a Windows
-source checkout is also affected.
-
-Before launching Godot for these scenarios from a dev checkout, force user
-mode in one of two ways:
-
-- Set the env var on the launch line. POSIX:
-
-      GODOT_AI_MODE=user "\$GODOT" --editor --path "\$PROJECT" 2>&1 | tee /tmp/mcp-editor.log
-
-  PowerShell (set in the same shell before \`&\`-launching Godot):
-
-      \$env:GODOT_AI_MODE = "user"
-      & "C:\\path\\to\\Godot.exe" --editor --path "$project_win"
-
-- Or open the dock's "Mode override" dropdown (visible when Developer mode
-  is on) and pick "Force user".
+Scenarios 1, 2, 3, and 5 pin the simulator to a version that does NOT match
+the plugin and expect the plugin to treat the occupant as incompatible. As
+of the strict-version-match change, this is the behavior in both dev and
+user modes — \`_server_version_compatibility\` only returns compatible on
+an exact match. Earlier versions of this matrix asked you to set
+\`GODOT_AI_MODE=user\` from a dev checkout to bypass a lenient dev-mode
+branch; that branch is gone, so no override is needed for the
+version-mismatch scenarios. \`GODOT_AI_MODE\` and the dock's Mode override
+still control update-check behavior (whether the yellow Update banner can
+appear).
 
 The dock dropdown persists as the EditorSetting \`godot_ai/mode_override\`
 and **wins over the env var** — \`mode_override()\` reads the EditorSetting
@@ -767,9 +752,6 @@ Use PowerShell. This tests the legacy-pidfile proof tier that motivated the PR.
 
     Get-NetTCPConnection -LocalPort 8000
     Get-CimInstance Win32_Process -Filter ("ProcessId=" + \$sim.Id) | Select ProcessId,CommandLine
-    # Dev checkout: force user mode (see "Dev checkout" section above).
-    # Skip the next line on a non-dev install.
-    \$env:GODOT_AI_MODE = "user"
     & "C:\\path\\to\\Godot.exe" --editor --path "$project_win"
 
 Pass criteria:
@@ -820,9 +802,9 @@ Close Godot and add or replace these lines in \$EDITOR_SETTINGS:
     godot_ai/managed_server_version = "2.1.0"
     godot_ai/managed_server_ws_port = 9500
 
-Then launch (dev checkout: force user mode — see "Dev checkout" section above):
+Then launch:
 
-    GODOT_AI_MODE=user "\$GODOT" --editor --path "\$PROJECT" 2>&1 | tee /tmp/mcp-editor.log
+    "\$GODOT" --editor --path "\$PROJECT" 2>&1 | tee /tmp/mcp-editor.log
 
 Pass criteria:
 
@@ -861,9 +843,9 @@ scenario 7).
     SIM_PID=\$!
     ps -ww -p \$SIM_PID -o args=
 
-Then launch (dev checkout: force user mode — see "Dev checkout" section above):
+Then launch:
 
-    GODOT_AI_MODE=user "\$GODOT" --editor --path "\$PROJECT" 2>&1 | tee /tmp/mcp-editor.log
+    "\$GODOT" --editor --path "\$PROJECT" 2>&1 | tee /tmp/mcp-editor.log
 
 Initial pass criteria:
 

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -289,8 +289,8 @@ func test_get_server_status_shape_is_stable() -> void:
 
 
 func test_server_status_compatibility_requires_matching_ws_port() -> void:
-	var ok := GodotAiPlugin._server_status_compatibility("2.2.0", "2.2.0", 9500, 9500, false)
-	var wrong_ws := GodotAiPlugin._server_status_compatibility("2.2.0", "2.2.0", 9600, 9500, false)
+	var ok := GodotAiPlugin._server_status_compatibility("2.2.0", "2.2.0", 9500, 9500)
+	var wrong_ws := GodotAiPlugin._server_status_compatibility("2.2.0", "2.2.0", 9600, 9500)
 	assert_true(bool(ok.get("compatible", false)), "matching version + WS port must be compatible")
 	assert_false(
 		bool(wrong_ws.get("compatible", true)),
@@ -517,6 +517,47 @@ func test_legacy_pidfile_proof_returns_all_branded_listener_pids() -> void:
 	var pids: Array[int] = []
 	pids.assign(proof.get("pids", []))
 	assert_eq(pids, [11111, 22222] as Array[int])
+
+
+func test_legacy_pidfile_proof_accepts_reloader_shape() -> void:
+	## `uvicorn --reload` writes the pid-file from the reloader/launcher PID
+	## but the worker child binds the port — so the pidfile PID is alive +
+	## branded yet absent from `listener_pids`. Before the fix, the proof
+	## helper bailed unconditionally for this shape, leaving the plugin
+	## unable to recycle a stuck dev server. The fix accepts the proof and
+	## adds both the branded worker AND the branded reloader PID to the
+	## kill targets so the reloader can't immediately respawn a replacement.
+	var plugin := _ProofPlugin.new()
+	plugin.listener_pids = [22222] as Array[int]  # worker, not reloader
+	plugin.pid_file_pid = 11111  # reloader, not a listener
+	plugin.alive_pids = [11111, 22222] as Array[int]
+	plugin.branded_pids = [11111, 22222] as Array[int]
+
+	var targets := plugin._legacy_pidfile_kill_targets(TEST_PORT, plugin.listener_pids)
+	plugin.free()
+
+	assert_eq(
+		targets, [22222, 11111] as Array[int],
+		"branded worker first (listener loop), then branded reloader (pidfile pid)"
+	)
+
+
+func test_legacy_pidfile_proof_rejects_unbranded_pidfile_pid() -> void:
+	## A stale pidfile PID can outlive its original process and the kernel
+	## may recycle it for an unrelated branded-or-not process. The brand
+	## check on the pidfile PID is the load-bearing guard — without it,
+	## a stale pidfile alone could authorize killing a branded listener
+	## that doesn't belong to us.
+	var plugin := _ProofPlugin.new()
+	plugin.listener_pids = [22222] as Array[int]
+	plugin.pid_file_pid = 11111
+	plugin.alive_pids = [11111, 22222] as Array[int]
+	plugin.branded_pids = [22222] as Array[int]  # listener branded, pidfile NOT
+
+	var targets := plugin._legacy_pidfile_kill_targets(TEST_PORT, plugin.listener_pids)
+	plugin.free()
+
+	assert_true(targets.is_empty(), "unbranded pidfile PID must not authorize any kill")
 
 
 func test_strong_proof_accepts_status_matching_managed_record_version() -> void:
@@ -767,7 +808,7 @@ func test_stale_ws_port_does_not_authorize_killing_external_server() -> void:
 	## Step 2: with the freshly-resolved expected port, a live current
 	## server passes compatibility — the precondition for adoption.
 	var compatibility := GodotAiPlugin._server_status_compatibility(
-		CURRENT, CURRENT, LIVE_CURRENT_WS, resolved, false
+		CURRENT, CURRENT, LIVE_CURRENT_WS, resolved
 	)
 	assert_true(
 		bool(compatibility.get("compatible", false)),
@@ -804,22 +845,28 @@ func test_matching_compatible_adoption_keeps_managed_ownership() -> void:
 	assert_true(can_restart, "managed adoption must keep restart authorization")
 
 
-func test_server_version_compatibility_requires_exact_match_in_release_mode() -> void:
-	var exact := GodotAiPlugin._server_version_compatibility("2.2.0", "2.2.0", false)
-	var old := GodotAiPlugin._server_version_compatibility("1.2.10", "2.2.0", false)
-	var unknown := GodotAiPlugin._server_version_compatibility("", "2.2.0", false)
-	assert_true(bool(exact.get("compatible", false)), "exact release version must be compatible")
-	assert_false(bool(old.get("compatible", true)), "old release server must be incompatible")
+func test_server_version_compatibility_requires_exact_match() -> void:
+	var exact := GodotAiPlugin._server_version_compatibility("2.2.0", "2.2.0")
+	var old := GodotAiPlugin._server_version_compatibility("1.2.10", "2.2.0")
+	var unknown := GodotAiPlugin._server_version_compatibility("", "2.2.0")
+	assert_true(bool(exact.get("compatible", false)), "exact version must be compatible")
+	assert_false(bool(old.get("compatible", true)), "old server must be incompatible")
 	assert_false(bool(unknown.get("compatible", true)), "unknown live version must be incompatible")
+	assert_eq(old.get("reason", ""), "version_mismatch")
+	assert_eq(unknown.get("reason", ""), "unknown")
 
 
-func test_server_version_compatibility_allows_visible_dev_mismatch() -> void:
-	var result := GodotAiPlugin._server_version_compatibility("2.2.0-dev", "2.2.0", true)
-	assert_true(bool(result.get("compatible", false)), "dev checkout may reuse a mismatched dev server")
-	assert_true(
-		bool(result.get("dev_mismatch_allowed", false)),
-		"dev mismatch must be flagged so the dock can render it visibly"
+func test_server_version_compatibility_rejects_dev_mismatch() -> void:
+	## Plugin and server speak one version-coupled protocol. Tolerating a
+	## dev-mode mismatch silently adopts a stale server (e.g. a sibling
+	## worktree's). Mismatch must route through `recover_strong_port_occupant`
+	## instead.
+	var result := GodotAiPlugin._server_version_compatibility("2.2.0-dev", "2.2.0")
+	assert_false(
+		bool(result.get("compatible", true)),
+		"dev-mode mismatch must be incompatible so startup can kill+respawn"
 	)
+	assert_eq(result.get("reason", ""), "version_mismatch")
 
 
 func test_incompatible_server_message_names_actual_version_when_discoverable() -> void:


### PR DESCRIPTION
## Summary

Two scoped server-lifecycle fixes that work together so dev-mode version mismatches recover (kill + respawn) instead of silently sitting on a stale server. Follow-up from the PR #459 discussion.

### 1. `_legacy_pidfile_kill_targets` accepts the reload-shape proof

Under `uvicorn --reload` the reloader writes the pid-file but a child worker binds the port, so the pid-file PID is alive + branded yet absent from `listener_pids`. The old `listener_pids.has(pidfile_pid)` gate bailed for that whole family of process layouts. The fix:

- Drop the `listener_pids.has(pidfile_pid)` requirement — alive + branded is sufficient ownership proof.
- The per-listener brand check in the existing loop still keeps unrelated processes safe.
- Add the reloader PID itself to the kill set so a worker kill can't be immediately respawned by its parent.

### 2. `_server_version_compatibility` is strict in all modes

Plugin and server speak a single, version-coupled protocol — new commands and response fields are added together. The dev-mode "compatible with `dev_mismatch_allowed`" branch quietly adopted a stale port-holder (e.g. a sibling worktree's server, or a server stuck on an older bump) and left the agent talking to a server whose code didn't match the source tree.

- Strict match in all modes. Mismatches route through the existing `recover_strong_port_occupant` path in `start_server`, which kills the branded port-holder (now including the reload shape from #1) and lets `start_server` spawn fresh against the current source.
- If proof can't be obtained, the existing INCOMPATIBLE banner + Restart Server button remains the safe fallback — no blind kills.

### Why proof is still needed

The handshake proves the listener is godot-ai, but doesn't hand us a PID. We still need to map port → PIDs to kill, and the existing proof system answers both (port-lookup + brand verification) in one shot. Reusing `recover_strong_port_occupant` keeps that defense.

### Cleanup

Drops the now-dead `_server_dev_version_mismatch_allowed` state, the `dev_version_mismatch_allowed` status field, and the two dock UI branches that consumed it (amber "Connected (dev server)" status). Updates `manual-orphan-test` docs that asked operators to set `GODOT_AI_MODE=user` in dev checkouts to exercise version-mismatch scenarios — strict mode means no override is needed.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `pytest -v` — 1083 passed, 2 skipped
- [ ] Open `test_project/` in Godot, `test_run` — verify all GDScript tests pass including the three new ones
- [ ] Live smoke: launch with a port-8000 `uvicorn --reload` running an older `__version__`, confirm plugin auto-recovers (kill + respawn) instead of adopting silently
- [ ] Live smoke (negative): launch against a non-godot occupant on port 8000, confirm plugin shows INCOMPATIBLE banner and doesn't kill blindly
- [ ] `script/local-self-update-smoke` (the self-update path is in user mode by default and not affected by the dev-mode change; including for safety)

### New GDScript tests

- `test_legacy_pidfile_proof_accepts_reloader_shape` — pid-file PID alive + branded but not in listener_pids; expects both reloader and branded worker in kill targets.
- `test_legacy_pidfile_proof_rejects_unbranded_pidfile_pid` — stale pidfile PID with no brand can't authorize killing branded listeners.
- `test_server_version_compatibility_rejects_dev_mismatch` — dev mode no longer adopts a mismatched server; reason is `version_mismatch`.

## Notes

- Independent from PR #459 (test/lint follow-ups) — this branch is rooted on `main` at `bc36034`.
- The `is_dev_checkout` parameter is dropped from `_server_version_compatibility` and `_server_status_compatibility` since it no longer changes behavior. Callers and tests are updated in lockstep.

https://claude.ai/code/session_01BYp6r2tkh6voSSjD8nBwxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYp6r2tkh6voSSjD8nBwxW)_