### PR TITLE
Add game_manage runtime inspection and input tools

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -65,6 +65,7 @@ Calls take the form:
 | `camera_manage` | `create`, `configure`, `set_limits_2d`, `set_damping_2d`, `follow_2d`, `get`, `list`, `apply_preset` |
 | `signal_manage` | `list`, `connect`, `disconnect` |
 | `input_map_manage` | `list`, `add_action`, `remove_action`, `bind_event` |
+| `game_manage` | `get_scene_tree`, `get_node_info`, `input_key`, `input_mouse`, `input_gamepad`, `input_state` |
 | `autoload_manage` | `list`, `add`, `remove` |
 | `filesystem_manage` | `read_text`, `write_text`, `reimport`, `search` |
 | `theme_manage` | `create`, `set_color`, `set_constant`, `set_font_size`, `set_stylebox_flat`, `apply` |

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -140,6 +140,12 @@ func _capture(message: String, data: Array, _session_id: int) -> bool:
 		"mcp:eval_error":
 			_on_eval_error(data)
 			return true
+		"mcp:game_command_response":
+			_on_game_command_response(data)
+			return true
+		"mcp:game_command_error":
+			_on_game_command_error(data)
+			return true
 	return false
 
 
@@ -447,3 +453,129 @@ func _on_eval_error(data: Array) -> void:
 	_send_error(connection, request_id, ErrorCodes.INTERNAL_ERROR, message)
 	if _log_buffer:
 		_log_buffer.log("[debug] <- mcp:eval_error (%s): %s" % [request_id, message])
+
+
+## --- game_command: curated runtime game operations ---
+
+func request_game_command(
+	op: String,
+	params: Dictionary,
+	request_id: String,
+	connection: McpConnection,
+	timeout_sec: float = 10.0,
+) -> void:
+	if request_id.is_empty():
+		push_warning("MCP debugger: game command request missing request_id")
+		return
+
+	var tree := Engine.get_main_loop() as SceneTree
+	if tree == null:
+		_send_error(connection, request_id, ErrorCodes.INTERNAL_ERROR,
+			"Editor main loop is not a SceneTree — cannot schedule game command")
+		return
+
+	if is_game_capture_ready():
+		_send_game_command(tree, op, params, request_id, connection, timeout_sec)
+		return
+
+	if _log_buffer:
+		_log_buffer.log("[debug] waiting for game_helper hello before game_command (%s)" % request_id)
+	_wait_then_game_command(tree, op, params, request_id, connection, timeout_sec)
+
+
+func _wait_then_game_command(
+	tree: SceneTree,
+	op: String,
+	params: Dictionary,
+	request_id: String,
+	connection: McpConnection,
+	timeout_sec: float,
+) -> void:
+	var deadline := Time.get_ticks_msec() + int(GAME_READY_WAIT_SEC * 1000.0)
+	while not is_game_capture_ready() and Time.get_ticks_msec() < deadline:
+		await tree.process_frame
+	if not is_game_capture_ready():
+		_send_error(connection, request_id, ErrorCodes.INTERNAL_ERROR,
+			"Game-side autoload never registered its debugger capture within %ds. Is the game actually running?" % int(GAME_READY_WAIT_SEC))
+		return
+	_send_game_command(tree, op, params, request_id, connection, timeout_sec)
+
+
+func _send_game_command(
+	tree: SceneTree,
+	op: String,
+	params: Dictionary,
+	request_id: String,
+	connection: McpConnection,
+	timeout_sec: float,
+) -> void:
+	var session: EditorDebuggerSession = _first_active_session()
+	if session == null:
+		_send_error(connection, request_id, ErrorCodes.INTERNAL_ERROR,
+			"No active debugger session — is the game actually running?")
+		return
+
+	var timer: SceneTreeTimer = tree.create_timer(timeout_sec)
+	var timeout_callable := func() -> void:
+		var pending_entry = _pending.get(request_id)
+		if pending_entry == null:
+			return
+		_pending.erase(request_id)
+		var conn: McpConnection = pending_entry.connection
+		if conn == null or not is_instance_valid(conn):
+			return
+		_send_error(conn, request_id, ErrorCodes.INTERNAL_ERROR,
+			"Game command '%s' timed out after %.0fs" % [op, timeout_sec])
+		if _log_buffer:
+			_log_buffer.log("[debug] !! game_command timeout (%s)" % request_id)
+	timer.timeout.connect(timeout_callable)
+	_pending[request_id] = {
+		"connection": connection,
+		"timer": timer,
+		"timeout_callable": timeout_callable,
+	}
+
+	session.send_message("mcp:game_command", [request_id, op, JSON.stringify(params)])
+	if _log_buffer:
+		_log_buffer.log("[debug] -> mcp:game_command %s (%s)" % [op, request_id])
+
+
+func _on_game_command_response(data: Array) -> void:
+	if data.size() < 2:
+		push_warning("MCP debugger: malformed game_command response (expected 2 fields, got %d)" % data.size())
+		return
+	var request_id: String = data[0]
+	var pending_entry = _pending.get(request_id)
+	if pending_entry == null:
+		return
+	_clear_pending(request_id)
+
+	var connection: McpConnection = pending_entry.connection
+	if connection == null or not is_instance_valid(connection):
+		return
+
+	var result_json: String = data[1] if data.size() > 1 else "{}"
+	var json := JSON.new()
+	var parse_err := json.parse(result_json)
+	connection.send_deferred_response(request_id, {
+		"data": json.data if parse_err == OK else {"source": "game", "result": result_json}
+	})
+	if _log_buffer:
+		_log_buffer.log("[debug] <- mcp:game_command_response (%s)" % request_id)
+
+
+func _on_game_command_error(data: Array) -> void:
+	if data.size() < 2:
+		return
+	var request_id: String = data[0]
+	var message: String = data[1]
+	var pending_entry = _pending.get(request_id)
+	if pending_entry == null:
+		return
+	_clear_pending(request_id)
+	var connection: McpConnection = pending_entry.connection
+	if connection == null or not is_instance_valid(connection):
+		return
+	_send_error(connection, request_id, ErrorCodes.INTERNAL_ERROR, message)
+	if _log_buffer:
+		_log_buffer.log("[debug] <- mcp:game_command_error (%s): %s" % [request_id, message])

--- a/plugin/addons/godot_ai/dispatcher.gd
+++ b/plugin/addons/godot_ai/dispatcher.gd
@@ -18,6 +18,7 @@ const DEFERRED_TIMEOUT_MS_BY_COMMAND := {
 	"stop_project": 4500,
 	"take_screenshot": 30000,
 	"game_eval": 15000,
+	"game_command": 15000,
 }
 const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
 

--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -798,3 +798,26 @@ func game_eval(params: Dictionary) -> Dictionary:
 
 	_debugger_plugin.request_game_eval(code, request_id, _connection)
 	return McpDispatcher.DEFERRED_RESPONSE
+
+
+func game_command(params: Dictionary) -> Dictionary:
+	var op: String = str(params.get("op", ""))
+	if op.is_empty():
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "op is required")
+
+	if _debugger_plugin == null or _connection == null:
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR,
+			"Debugger bridge unavailable — plugin may not be fully initialised")
+
+	if not EditorInterface.is_playing_scene():
+		return ErrorCodes.make(ErrorCodes.EDITOR_NOT_READY,
+			"Game is not running — start the project first")
+
+	var request_id: String = params.get("_request_id", "")
+	if request_id.is_empty():
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR,
+			"Missing request_id — cannot correlate deferred response")
+
+	var command_params: Dictionary = params.get("params", {})
+	_debugger_plugin.request_game_command(op, command_params, request_id, _connection)
+	return McpDispatcher.DEFERRED_RESPONSE

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -280,6 +280,7 @@ func _enter_tree() -> void:
 	_dispatcher.register("reload_plugin", editor_handler.reload_plugin)
 	_dispatcher.register("quit_editor", editor_handler.quit_editor)
 	_dispatcher.register("game_eval", editor_handler.game_eval)
+	_dispatcher.register("game_command", editor_handler.game_command)
 	_dispatcher.register("get_project_setting", project_handler.get_project_setting)
 	_dispatcher.register("set_project_setting", project_handler.set_project_setting)
 	_dispatcher.register("run_project", project_handler.run_project)

--- a/plugin/addons/godot_ai/runtime/game_helper.gd
+++ b/plugin/addons/godot_ai/runtime/game_helper.gd
@@ -378,9 +378,13 @@ func _game_input_state(params: Dictionary) -> Dictionary:
 
 
 func _dict_to_vector2(value: Variant) -> Vector2:
+	var viewport := get_viewport()
+	var fallback := viewport.get_mouse_position() if viewport != null else Vector2.ZERO
 	if value is Dictionary:
-		return Vector2(float(value.get("x", 0.0)), float(value.get("y", 0.0)))
-	return Vector2.ZERO
+		if value.is_empty() or (not value.has("x") and not value.has("y")):
+			return fallback
+		return Vector2(float(value.get("x", fallback.x)), float(value.get("y", fallback.y)))
+	return fallback
 
 
 func _mouse_button_index(name: String) -> int:

--- a/plugin/addons/godot_ai/runtime/game_helper.gd
+++ b/plugin/addons/godot_ai/runtime/game_helper.gd
@@ -117,6 +117,9 @@ func _on_debug_message(message: String, data: Array) -> bool:
 		"eval":
 			_handle_eval(data)
 			return true
+		"game_command":
+			_handle_game_command(data)
+			return true
 	return false
 
 
@@ -165,6 +168,232 @@ func _handle_take_screenshot(data: Array) -> void:
 
 func _reply_error(request_id: String, message: String) -> void:
 	EngineDebugger.send_message("mcp:screenshot_error", [request_id, message])
+
+
+## --- game_command: curated runtime inspection and input ---
+
+func _handle_game_command(data: Array) -> void:
+	var request_id: String = data[0] if data.size() > 0 else ""
+	var op: String = data[1] if data.size() > 1 else ""
+	var params_json: String = data[2] if data.size() > 2 else "{}"
+
+	if request_id.is_empty():
+		return
+	if op.is_empty():
+		_reply_game_command_error(request_id, "No op provided")
+		return
+
+	var json := JSON.new()
+	var parse_err := json.parse(params_json)
+	if parse_err != OK or not (json.data is Dictionary):
+		_reply_game_command_error(request_id, "Invalid params JSON")
+		return
+
+	var result: Dictionary
+	match op:
+		"get_scene_tree":
+			result = _game_get_scene_tree(json.data)
+		"get_node_info":
+			result = _game_get_node_info(json.data)
+		"input_key":
+			result = _game_input_key(json.data)
+		"input_mouse":
+			result = _game_input_mouse(json.data)
+		"input_gamepad":
+			result = _game_input_gamepad(json.data)
+		"input_state":
+			result = _game_input_state(json.data)
+		_:
+			_reply_game_command_error(request_id, "Unknown game op: %s" % op)
+			return
+
+	result["source"] = "game"
+	result["op"] = op
+	EngineDebugger.send_message("mcp:game_command_response",
+		[request_id, JSON.stringify(_variant_to_json(result))])
+
+
+func _reply_game_command_error(request_id: String, message: String) -> void:
+	EngineDebugger.send_message("mcp:game_command_error", [request_id, message])
+
+
+func _game_get_scene_tree(params: Dictionary) -> Dictionary:
+	var depth := maxi(0, int(params.get("depth", 10)))
+	var root := _resolve_runtime_node(str(params.get("root_path", "")))
+	if root == null:
+		return {"root": "", "nodes": [], "total_count": 0, "not_found": params.get("root_path", "")}
+
+	var nodes: Array[Dictionary] = []
+	_collect_runtime_nodes(root, 0, depth, nodes)
+	return {
+		"root": _runtime_path(root),
+		"nodes": nodes,
+		"total_count": nodes.size(),
+	}
+
+
+func _collect_runtime_nodes(node: Node, current_depth: int, max_depth: int, out: Array[Dictionary]) -> void:
+	out.append({
+		"name": node.name,
+		"type": node.get_class(),
+		"path": _runtime_path(node),
+		"children_count": node.get_child_count(),
+	})
+	if current_depth >= max_depth:
+		return
+	for child in node.get_children():
+		if child is Node:
+			_collect_runtime_nodes(child, current_depth + 1, max_depth, out)
+
+
+func _game_get_node_info(params: Dictionary) -> Dictionary:
+	var path := str(params.get("path", ""))
+	var node := _resolve_runtime_node(path)
+	if node == null:
+		return {"path": path, "found": false}
+
+	var info := {
+		"path": _runtime_path(node),
+		"name": node.name,
+		"type": node.get_class(),
+		"children_count": node.get_child_count(),
+		"groups": node.get_groups(),
+		"found": true,
+	}
+	if bool(params.get("include_properties", true)):
+		info["properties"] = _runtime_node_properties(node)
+	return info
+
+
+func _runtime_node_properties(node: Node) -> Dictionary:
+	var props := {}
+	for p in node.get_property_list():
+		var name := str(p.get("name", ""))
+		var usage := int(p.get("usage", 0))
+		if name.is_empty() or (usage & PROPERTY_USAGE_EDITOR) == 0:
+			continue
+		props[name] = _variant_to_json(node.get(name))
+	return props
+
+
+func _resolve_runtime_node(path: String) -> Node:
+	var scene_root := get_tree().current_scene
+	if scene_root == null:
+		return null
+	if path.is_empty() or path == "/":
+		return scene_root
+
+	if path.begins_with("/root/"):
+		return get_tree().root.get_node_or_null(path.trim_prefix("/root/"))
+
+	var scene_path := path.trim_prefix("/")
+	if scene_path == str(scene_root.name):
+		return scene_root
+	var prefix := str(scene_root.name) + "/"
+	if scene_path.begins_with(prefix):
+		scene_path = scene_path.substr(prefix.length())
+	return scene_root.get_node_or_null(scene_path)
+
+
+func _runtime_path(node: Node) -> String:
+	var scene_root := get_tree().current_scene
+	if scene_root == null:
+		return str(node.get_path())
+	if node == scene_root:
+		return "/" + str(scene_root.name)
+	return "/" + str(scene_root.name) + "/" + str(scene_root.get_path_to(node))
+
+
+func _game_input_key(params: Dictionary) -> Dictionary:
+	var key_name := str(params.get("key", ""))
+	var keycode := OS.find_keycode_from_string(key_name)
+	if keycode == KEY_NONE:
+		return {"sent": false, "error": "Unknown key: %s" % key_name}
+	var ev := InputEventKey.new()
+	ev.keycode = keycode
+	ev.physical_keycode = keycode
+	ev.pressed = bool(params.get("pressed", true))
+	ev.echo = bool(params.get("echo", false))
+	Input.parse_input_event(ev)
+	return {"sent": true, "key": key_name, "pressed": ev.pressed}
+
+
+func _game_input_mouse(params: Dictionary) -> Dictionary:
+	var event := str(params.get("event", "button"))
+	var pos := _dict_to_vector2(params.get("position", {}))
+	match event:
+		"motion":
+			var motion := InputEventMouseMotion.new()
+			motion.position = pos
+			motion.global_position = pos
+			Input.parse_input_event(motion)
+			return {"sent": true, "event": "motion", "position": _variant_to_json(pos)}
+		"button":
+			var button_event := InputEventMouseButton.new()
+			button_event.position = pos
+			button_event.global_position = pos
+			button_event.button_index = _mouse_button_index(str(params.get("button", "left")))
+			button_event.pressed = bool(params.get("pressed", true))
+			Input.parse_input_event(button_event)
+			return {
+				"sent": true,
+				"event": "button",
+				"button": params.get("button", "left"),
+				"pressed": button_event.pressed,
+				"position": _variant_to_json(pos),
+			}
+	return {"sent": false, "error": "Invalid mouse event: %s" % event}
+
+
+func _game_input_gamepad(params: Dictionary) -> Dictionary:
+	var device := int(params.get("device", 0))
+	var control := str(params.get("control", "button"))
+	match control:
+		"button":
+			var button := InputEventJoypadButton.new()
+			button.device = device
+			button.button_index = int(params.get("index", 0))
+			button.pressed = bool(params.get("pressed", true))
+			Input.parse_input_event(button)
+			return {"sent": true, "control": "button", "device": device, "index": button.button_index, "pressed": button.pressed}
+		"axis":
+			var axis := InputEventJoypadMotion.new()
+			axis.device = device
+			axis.axis = int(params.get("index", 0))
+			axis.axis_value = float(params.get("value", 0.0))
+			Input.parse_input_event(axis)
+			return {"sent": true, "control": "axis", "device": device, "index": axis.axis, "value": axis.axis_value}
+	return {"sent": false, "error": "Invalid gamepad control: %s" % control}
+
+
+func _game_input_state(params: Dictionary) -> Dictionary:
+	var actions: Array = params.get("actions", [])
+	if actions.is_empty():
+		actions = InputMap.get_actions()
+	var states := {}
+	for action in actions:
+		var name := str(action)
+		states[name] = Input.is_action_pressed(name)
+	return {"actions": states}
+
+
+func _dict_to_vector2(value: Variant) -> Vector2:
+	if value is Dictionary:
+		return Vector2(float(value.get("x", 0.0)), float(value.get("y", 0.0)))
+	return Vector2.ZERO
+
+
+func _mouse_button_index(name: String) -> int:
+	match name:
+		"right":
+			return MOUSE_BUTTON_RIGHT
+		"middle":
+			return MOUSE_BUTTON_MIDDLE
+		"wheel_up":
+			return MOUSE_BUTTON_WHEEL_UP
+		"wheel_down":
+			return MOUSE_BUTTON_WHEEL_DOWN
+	return MOUSE_BUTTON_LEFT
 
 
 ## --- game_eval: execute arbitrary GDScript in the running game ---

--- a/plugin/addons/godot_ai/tool_catalog.gd
+++ b/plugin/addons/godot_ai/tool_catalog.gd
@@ -37,6 +37,7 @@ const DOMAINS := [
 	{"id": "client", "label": "client", "count": 1, "tools": ["client_manage"]},
 	{"id": "editor", "label": "editor", "count": 4, "tools": ["editor_manage", "editor_reload_plugin", "editor_screenshot", "logs_read"]},
 	{"id": "filesystem", "label": "filesystem", "count": 1, "tools": ["filesystem_manage"]},
+	{"id": "game", "label": "game", "count": 1, "tools": ["game_manage"]},
 	{"id": "input_map", "label": "input_map", "count": 1, "tools": ["input_map_manage"]},
 	{"id": "material", "label": "material", "count": 1, "tools": ["material_manage"]},
 	{"id": "node", "label": "node", "count": 4, "tools": ["node_create", "node_find", "node_manage", "node_set_property"]},

--- a/src/godot_ai/handlers/game.py
+++ b/src/godot_ai/handlers/game.py
@@ -1,0 +1,99 @@
+"""Shared handlers for runtime game tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from godot_ai.runtime.direct import DirectRuntime
+
+GAME_COMMAND_TIMEOUT_SEC = 15.0
+
+
+async def _game_command(runtime: DirectRuntime, op: str, params: dict[str, Any]) -> dict:
+    return await runtime.send_command(
+        "game_command",
+        {"op": op, "params": params},
+        timeout=GAME_COMMAND_TIMEOUT_SEC,
+    )
+
+
+async def game_get_scene_tree(
+    runtime: DirectRuntime,
+    depth: int = 10,
+    root_path: str = "",
+) -> dict:
+    params: dict[str, Any] = {"depth": depth}
+    if root_path:
+        params["root_path"] = root_path
+    return await _game_command(runtime, "get_scene_tree", params)
+
+
+async def game_get_node_info(
+    runtime: DirectRuntime,
+    path: str,
+    include_properties: bool = True,
+) -> dict:
+    return await _game_command(
+        runtime,
+        "get_node_info",
+        {"path": path, "include_properties": include_properties},
+    )
+
+
+async def game_input_key(
+    runtime: DirectRuntime,
+    key: str,
+    pressed: bool = True,
+    echo: bool = False,
+) -> dict:
+    return await _game_command(
+        runtime,
+        "input_key",
+        {"key": key, "pressed": pressed, "echo": echo},
+    )
+
+
+async def game_input_mouse(
+    runtime: DirectRuntime,
+    event: str,
+    position: dict[str, Any] | None = None,
+    button: str = "left",
+    pressed: bool = True,
+) -> dict:
+    params: dict[str, Any] = {
+        "event": event,
+        "position": position or {},
+        "button": button,
+        "pressed": pressed,
+    }
+    return await _game_command(runtime, "input_mouse", params)
+
+
+async def game_input_gamepad(
+    runtime: DirectRuntime,
+    device: int = 0,
+    control: str = "button",
+    index: int = 0,
+    pressed: bool = True,
+    value: float = 0.0,
+) -> dict:
+    params: dict[str, Any] = {
+        "device": device,
+        "control": control,
+        "index": index,
+    }
+    if control == "axis":
+        params["value"] = value
+    else:
+        params["pressed"] = pressed
+    return await _game_command(runtime, "input_gamepad", params)
+
+
+async def game_input_state(
+    runtime: DirectRuntime,
+    actions: list[str] | None = None,
+) -> dict:
+    params: dict[str, Any] = {}
+    if actions is not None:
+        params["actions"] = actions
+    return await _game_command(runtime, "input_state", params)

--- a/src/godot_ai/server.py
+++ b/src/godot_ai/server.py
@@ -49,6 +49,7 @@ from godot_ai.tools.camera import register_camera_tools
 from godot_ai.tools.client import register_client_tools
 from godot_ai.tools.editor import register_editor_tools
 from godot_ai.tools.filesystem import register_filesystem_tools
+from godot_ai.tools.game import register_game_tools
 from godot_ai.tools.input_map import register_input_map_tools
 from godot_ai.tools.material import register_material_tools
 from godot_ai.tools.node import register_node_tools
@@ -194,6 +195,8 @@ def create_server(
             "                   follow_2d, get, list, apply_preset\n"
             "  signal_manage    list, connect, disconnect\n"
             "  input_map_manage list, add_action, remove_action, bind_event\n"
+            "  game_manage      get_scene_tree, get_node_info, input_key,\n"
+            "                   input_mouse, input_gamepad, input_state\n"
             "  autoload_manage  list, add, remove\n"
             "  filesystem_manage read_text, write_text, reimport, search\n"
             "  theme_manage     create, set_color, set_constant, set_font_size,\n"
@@ -315,6 +318,8 @@ def create_server(
         register_autoload_tools(mcp)
     if "input_map" not in exclude:
         register_input_map_tools(mcp)
+    if "game" not in exclude:
+        register_game_tools(mcp)
     if "testing" not in exclude:
         register_testing_tools(mcp)
     if "batch" not in exclude:

--- a/src/godot_ai/tools/domains.py
+++ b/src/godot_ai/tools/domains.py
@@ -38,6 +38,7 @@ DOMAINS: tuple[str, ...] = (
     "signal",
     "autoload",
     "input_map",
+    "game",
     "testing",
     "batch",
     "ui",

--- a/src/godot_ai/tools/game.py
+++ b/src/godot_ai/tools/game.py
@@ -1,0 +1,54 @@
+"""MCP tools for runtime game inspection and input."""
+
+from __future__ import annotations
+
+from fastmcp import FastMCP
+
+from godot_ai.handlers import game as game_handlers
+from godot_ai.tools._meta_tool import register_manage_tool
+
+_DESCRIPTION = """\
+Runtime game inspection and input simulation.
+
+These ops target the running game process through Godot's EngineDebugger
+bridge. Start the project first with project_run and poll editor_state until
+game_capture_ready=true.
+
+Ops:
+  - get_scene_tree(depth=10, root_path="")
+        Inspect the running scene tree. root_path accepts an absolute runtime
+        path or a scene-relative path rooted at the current scene.
+  - get_node_info(path, include_properties=True)
+        Inspect one running node's metadata and optional property snapshot.
+  - input_key(key, pressed=True, echo=False)
+        Send a key press/release to the running game.
+  - input_mouse(event, position=None, button="left", pressed=True)
+        Send a mouse motion or button event. event: "motion" | "button".
+  - input_gamepad(device=0, control="button", index=0, pressed=True, value=0.0)
+        Send a joypad button or axis event. control: "button" | "axis".
+  - input_state(actions=None)
+        Read current action pressed states. Empty actions = all project actions."""
+
+
+def register_game_tools(mcp: FastMCP) -> None:
+    register_manage_tool(
+        mcp,
+        tool_name="game_manage",
+        description=_DESCRIPTION,
+        ops={
+            "get_scene_tree": game_handlers.game_get_scene_tree,
+            "get_node_info": game_handlers.game_get_node_info,
+            "input_key": game_handlers.game_input_key,
+            "input_mouse": game_handlers.game_input_mouse,
+            "input_gamepad": game_handlers.game_input_gamepad,
+            "input_state": game_handlers.game_input_state,
+        },
+        read_resource_forms={
+            "get_scene_tree": None,
+            "get_node_info": None,
+            "input_key": None,
+            "input_mouse": None,
+            "input_gamepad": None,
+            "input_state": None,
+        },
+    )

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -128,6 +128,26 @@ func test_screenshot_game_not_playing() -> void:
 	assert_is_error(result)
 
 
+# ----- game_command -----
+
+func test_game_command_missing_op() -> void:
+	var result := _handler.game_command({})
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
+
+
+func test_game_command_not_playing() -> void:
+	var plugin := McpDebuggerPlugin.new()
+	var handler := EditorHandler.new(McpLogBuffer.new(), McpConnection.new(), plugin)
+	var result := handler.game_command({"op": "get_scene_tree"})
+	assert_is_error(result, ErrorCodes.EDITOR_NOT_READY)
+
+
+func test_debugger_plugin_game_command_response_unknown_request() -> void:
+	var plugin := McpDebuggerPlugin.new()
+	plugin._on_game_command_response(["unknown-id", "{\"ok\":true}"])
+	assert_true(true, "Unknown responses should be ignored without crashing")
+
+
 # ----- viewport_screenshot_precheck (#456: stop returning INTERNAL_ERROR on 2D) -----
 
 func test_viewport_precheck_passes_for_node3d_root() -> void:

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -1453,6 +1453,20 @@ async def test_game_input_gamepad_sends_game_command():
     }
 
 
+async def test_game_input_gamepad_axis_sends_value_not_pressed():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+
+    await game_handlers.game_input_gamepad(
+        runtime, device=2, control="axis", index=1, value=0.5
+    )
+
+    params = client.calls[-1]["params"]["params"]
+    assert client.calls[-1]["params"]["op"] == "input_gamepad"
+    assert params == {"device": 2, "control": "axis", "index": 1, "value": 0.5}
+    assert "pressed" not in params
+
+
 async def test_game_input_state_sends_game_command():
     client = StubClient()
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -18,6 +18,7 @@ from godot_ai.handlers import curve as curve_handlers
 from godot_ai.handlers import editor as editor_handlers
 from godot_ai.handlers import environment as environment_handlers
 from godot_ai.handlers import filesystem as filesystem_handlers
+from godot_ai.handlers import game as game_handlers
 from godot_ai.handlers import input_map as input_map_handlers
 from godot_ai.handlers import material as material_handlers
 from godot_ai.handlers import node as node_handlers
@@ -130,6 +131,12 @@ class StubClient:
                     "dropped_count": 0,
                 }
             return {"lines": [f"line {i}" for i in range(6)]}
+        if command == "game_command":
+            return {
+                "source": "game",
+                "op": params.get("op", ""),
+                "params": params.get("params", {}),
+            }
         if command == "get_project_setting":
             key = params["key"] if params else ""
             return {"key": key, "value": f"value:{key}"}
@@ -1366,6 +1373,96 @@ async def test_logs_read_handler_plugin_normalizes_structured_payload():
     result = await editor_handlers.logs_read(runtime, count=10)
 
     assert result["lines"] == ["structured 0", "structured 1"]
+
+
+# ---------------------------------------------------------------------------
+# Runtime game handler tests
+# ---------------------------------------------------------------------------
+
+
+async def test_game_get_scene_tree_sends_game_command():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+
+    result = await game_handlers.game_get_scene_tree(runtime, depth=4, root_path="/Main")
+
+    assert result["source"] == "game"
+    assert result["op"] == "get_scene_tree"
+    assert client.calls[-1]["command"] == "game_command"
+    assert client.calls[-1]["params"] == {
+        "op": "get_scene_tree",
+        "params": {"depth": 4, "root_path": "/Main"},
+    }
+    assert client.calls[-1]["timeout"] == game_handlers.GAME_COMMAND_TIMEOUT_SEC
+
+
+async def test_game_get_node_info_sends_game_command():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+
+    await game_handlers.game_get_node_info(runtime, path="/Main/Player")
+
+    assert client.calls[-1]["params"] == {
+        "op": "get_node_info",
+        "params": {"path": "/Main/Player", "include_properties": True},
+    }
+
+
+async def test_game_input_key_sends_game_command():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+
+    await game_handlers.game_input_key(runtime, key="Space", pressed=True, echo=False)
+
+    assert client.calls[-1]["params"] == {
+        "op": "input_key",
+        "params": {"key": "Space", "pressed": True, "echo": False},
+    }
+
+
+async def test_game_input_mouse_sends_game_command():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+
+    await game_handlers.game_input_mouse(
+        runtime, event="button", position={"x": 10, "y": 20}, button="left", pressed=True
+    )
+
+    assert client.calls[-1]["params"] == {
+        "op": "input_mouse",
+        "params": {
+            "event": "button",
+            "position": {"x": 10, "y": 20},
+            "button": "left",
+            "pressed": True,
+        },
+    }
+
+
+async def test_game_input_gamepad_sends_game_command():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+
+    await game_handlers.game_input_gamepad(
+        runtime, device=1, control="button", index=0, pressed=True
+    )
+
+    assert client.calls[-1]["params"] == {
+        "op": "input_gamepad",
+        "params": {"device": 1, "control": "button", "index": 0, "pressed": True},
+    }
+
+
+async def test_game_input_state_sends_game_command():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+
+    await game_handlers.game_input_state(runtime, actions=["ui_accept"])
+
+    assert client.calls[-1]["params"] == {
+        "op": "input_state",
+        "params": {"actions": ["ui_accept"]},
+    }
 
 
 async def test_project_settings_resource_collects_results():


### PR DESCRIPTION
Fixes #466.

This is also related to the broader discussion in #462, but intentionally keeps the scope to the curated runtime inspection/input surface.

## Summary

- Add a new `game_manage` domain for running-game inspection and input simulation.
- Route runtime game commands through the existing editor debugger bridge and `_mcp_game_helper` autoload.
- Support `get_scene_tree`, `get_node_info`, `input_key`, `input_mouse`, `input_gamepad`, and `input_state`.

## Tests

- [x] `uv run ruff check src tests`
- [x] `uv run pytest tests/unit/test_runtime_handlers.py -k "game_"`
- [x] `uv run pytest tests/unit/test_tool_domains.py tests/unit/test_resource_form_lint.py tests/unit/test_deferred_timeout_contract.py`
- [x] Godot headless GDScript import: `All GDScript files OK`
- [x] Targeted Godot editor tests: `editor` suite `game_command` tests passed
- [x] Live runtime smoke:
  - `game_manage.get_scene_tree` returned `/Main`
  - `game_manage.get_node_info` returned `/Main` as `Node3D`
  - `game_manage.input_state` returned action state
  - `game_manage.input_key` Space down/up returned `sent: true`
- [x] Full Godot suite with `HOME=$USERPROFILE`: `1303 passed`, `24 skipped`, `0 failed`