### PR TITLE
Fix telemetry data dir platform tests on Windows

### DIFF
--- a/src/godot_ai/telemetry.py
+++ b/src/godot_ai/telemetry.py
@@ -232,12 +232,12 @@ class TelemetryConfig:
     @staticmethod
     def _resolve_data_directory() -> Path:
         """Resolve data directory path without creating it."""
-        if os.name == "nt":  # Windows
-            base = Path(os.environ.get("APPDATA", str(Path.home() / "AppData" / "Roaming")))
+        if sys.platform.startswith("win"):  # Windows
+            base = Path(os.environ.get("APPDATA") or str(Path.home() / "AppData" / "Roaming"))
         elif sys.platform == "darwin":
             base = Path.home() / "Library" / "Application Support"
         else:
-            base = Path(os.environ.get("XDG_DATA_HOME", str(Path.home() / ".local" / "share")))
+            base = Path(os.environ.get("XDG_DATA_HOME") or str(Path.home() / ".local" / "share"))
         return base / "godot-ai"
 
     @staticmethod

--- a/tests/unit/test_telemetry_platform.py
+++ b/tests/unit/test_telemetry_platform.py
@@ -54,7 +54,7 @@ class TestResolveDataDirectory:
             def home():
                 return MockPath("/home/test")
 
-        with patch("godot_ai.telemetry.os.name", "nt"):
+        with patch("godot_ai.telemetry.sys.platform", "win32"):
             with patch("godot_ai.telemetry.Path", MockPath):
                 result = tel.TelemetryConfig._resolve_data_directory()
         assert result.name == "godot-ai"
@@ -63,8 +63,9 @@ class TestResolveDataDirectory:
     def test_windows_fallback_to_home(self, monkeypatch, clean_env) -> None:
         """Windows falls back to user's home if APPDATA is unset."""
         monkeypatch.setenv("APPDATA", "")
-        with patch("godot_ai.telemetry.Path.home", return_value=Path("C:\\Users\\Test")):
-            result = tel.TelemetryConfig._resolve_data_directory()
+        with patch("godot_ai.telemetry.sys.platform", "win32"):
+            with patch("godot_ai.telemetry.Path.home", return_value=Path("C:\\Users\\Test")):
+                result = tel.TelemetryConfig._resolve_data_directory()
         assert "godot-ai" in str(result)
         assert "Test" in str(result)
 
@@ -81,7 +82,7 @@ class TestResolveDataDirectory:
         with patch("godot_ai.telemetry.sys.platform", "linux"):
             monkeypatch.setenv("XDG_DATA_HOME", "/custom/data")
             result = tel.TelemetryConfig._resolve_data_directory()
-        assert str(result) == "/custom/data/godot-ai"
+        assert str(result).replace("\\", "/") == "/custom/data/godot-ai"
 
     def test_linux_fallback_to_home(self, monkeypatch, clean_env) -> None:
         """Linux falls back to ~/.local/share when XDG_DATA_HOME unset."""


### PR DESCRIPTION
## Summary

Fixes #468.

- Use `sys.platform` consistently when resolving telemetry data directories.
- Treat empty `APPDATA` and `XDG_DATA_HOME` like unset values.
- Update telemetry platform tests so mocked platform behavior is consistent on Windows.

## Tests

- [x] `uv run pytest tests/unit/test_telemetry_platform.py -v`
- [x] `uv run ruff check src/godot_ai/telemetry.py tests/unit/test_telemetry_platform.py`