### PR TITLE
Fix self-update ZIP backslash test on Windows

### DIFF
--- a/tests/integration/_self_update_fixture.py
+++ b/tests/integration/_self_update_fixture.py
@@ -279,13 +279,14 @@ def extract_addon_from_zip(zip_path: Path, target_addon: Path) -> None:
         for info in zf.infolist():
             if not info.filename.startswith("addons/godot_ai/") or info.is_dir():
                 continue
+            raw_filename = getattr(info, "orig_filename", info.filename)
             # ZIP spec uses POSIX-style forward-slash separators; parsing the
             # member name as PurePosixPath stops a Windows host from
             # reinterpreting an entry like "addons/godot_ai/C:evil.txt" as a
             # drive component (which would make `target_addon / rel` discard
             # the prefix and write outside the fixture).
-            if "\\" in info.filename:
-                raise ValueError(f"Refusing unsafe zip entry {info.filename!r}: contains backslash")
+            if "\\" in raw_filename or "\\" in info.filename:
+                raise ValueError(f"Refusing unsafe zip entry {raw_filename!r}: contains backslash")
             rel = PurePosixPath(info.filename).relative_to("addons/godot_ai")
             if rel.is_absolute() or any(part in ("", ".", "..") for part in rel.parts):
                 raise ValueError(

--- a/tests/unit/test_self_update_fixture_extract.py
+++ b/tests/unit/test_self_update_fixture_extract.py
@@ -24,6 +24,25 @@ def _write_zip(path: Path, members: dict[str, bytes]) -> None:
             zf.writestr(name, data)
 
 
+def _write_zip_with_raw_member_name(
+    path: Path,
+    normalized_name: str,
+    raw_name: str,
+    data: bytes,
+) -> None:
+    assert len(normalized_name) == len(raw_name)
+    _write_zip(
+        path,
+        {
+            "addons/godot_ai/plugin.cfg": b"[plugin]\nname=ok\n",
+            normalized_name: data,
+        },
+    )
+    path.write_bytes(
+        path.read_bytes().replace(normalized_name.encode("ascii"), raw_name.encode("ascii"))
+    )
+
+
 def test_clean_zip_extracts_files_to_target(tmp_path: Path) -> None:
     zip_path = tmp_path / "good.zip"
     _write_zip(
@@ -54,12 +73,11 @@ def test_parent_traversal_entry_is_rejected(tmp_path: Path) -> None:
 
 def test_backslash_in_entry_name_is_rejected(tmp_path: Path) -> None:
     zip_path = tmp_path / "bad.zip"
-    _write_zip(
+    _write_zip_with_raw_member_name(
         zip_path,
-        {
-            "addons/godot_ai/plugin.cfg": b"[plugin]\nname=ok\n",
-            "addons/godot_ai/sub\\windows-style.gd": b"oops",
-        },
+        "addons/godot_ai/sub/windows-style.gd",
+        "addons/godot_ai/sub\\windows-style.gd",
+        b"oops",
     )
     with pytest.raises(ValueError, match="contains backslash"):
         extract_addon_from_zip(zip_path, tmp_path / "target")

--- a/tests/unit/test_self_update_fixture_extract.py
+++ b/tests/unit/test_self_update_fixture_extract.py
@@ -38,9 +38,25 @@ def _write_zip_with_raw_member_name(
             normalized_name: data,
         },
     )
-    path.write_bytes(
-        path.read_bytes().replace(normalized_name.encode("ascii"), raw_name.encode("ascii"))
+    normalized_name_bytes = normalized_name.encode("ascii")
+    raw_name_bytes = raw_name.encode("ascii")
+    original_bytes = path.read_bytes()
+    mutated_bytes = original_bytes.replace(normalized_name_bytes, raw_name_bytes)
+
+    assert mutated_bytes != original_bytes, (
+        "failed to inject raw ZIP member name: normalized member name bytes were "
+        "not found in archive"
     )
+    assert raw_name_bytes in mutated_bytes, (
+        "failed to inject raw ZIP member name: mutated archive does not contain "
+        "the expected raw member name bytes"
+    )
+    assert normalized_name_bytes not in mutated_bytes, (
+        "failed to inject raw ZIP member name: archive still contains the "
+        "normalized member name bytes after mutation"
+    )
+
+    path.write_bytes(mutated_bytes)
 
 
 def test_clean_zip_extracts_files_to_target(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fixes #469.

- Update the self-update ZIP fixture test so it creates a raw backslash archive entry on Windows.
- Check `ZipInfo.orig_filename` as well as `filename`, since Python normalizes `filename` on Windows.

## Tests

- [x] `uv run pytest tests/unit/test_self_update_fixture_extract.py -v`
- [x] `uv run ruff check tests/unit/test_self_update_fixture_extract.py tests/integration/_self_update_fixture.py`