### PR TITLE
Fix XDG fallback test when HOME is unset

### DIFF
--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -679,7 +679,9 @@ func test_path_template_expands_home() -> void:
 func test_path_template_xdg_fallback() -> void:
 	var home := OS.get_environment("HOME")
 	if home.is_empty():
-		assert_true(false, "HOME not set")
+		home = OS.get_environment("USERPROFILE")
+	if home.is_empty():
+		assert_true(false, "HOME / USERPROFILE not set in test environment")
 		return
 	var resolved := McpPathTemplate.expand("$XDG_CONFIG_HOME/foo")
 	# Either uses XDG_CONFIG_HOME if set, or falls back to ~/.config


### PR DESCRIPTION
## Summary

Fixes #467.

- Update `clients.test_path_template_xdg_fallback` to fall back to `USERPROFILE` when `HOME` is unset.
- Keep the test aligned with `McpPathTemplate._home()` behavior.

## Tests

- [x] `test_run suite=clients test_name=test_path_template_xdg_fallback`
- [x] `test_run suite=clients`
- [x] Full Godot suite with `HOME` unset