### PR TITLE
CI: add Godot 4.3 Linux canary (Phase 1 of #477)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,10 +132,21 @@ jobs:
         include:
           - os: ubuntu-latest
             label: Linux
+            godot-version: "4.6.2"
           - os: macos-latest
             label: macOS
+            godot-version: "4.6.2"
           - os: windows-latest
             label: Windows
+            godot-version: "4.6.2"
+          ## 4.3 Linux canary — README advertises "Godot 4.3+" support and
+          ## #476's parse-cascade regression went unnoticed for 24 days
+          ## because every CI run was on 4.6.2. Phase 1 of #477: one cheap
+          ## Linux canary to catch the same class of regression in future.
+          ## Phase 2 (full 3-OS 4.3 coverage) is deferred.
+          - os: ubuntu-latest
+            label: Linux (Godot 4.3)
+            godot-version: "4.3.stable"
 
     steps:
       - uses: actions/checkout@v6
@@ -146,7 +157,7 @@ jobs:
 
       - uses: chickensoft-games/setup-godot@v2
         with:
-          version: 4.6.2
+          version: ${{ matrix.godot-version }}
           use-dotnet: false
 
       - name: Set up Python
@@ -187,6 +198,14 @@ jobs:
       - name: Reload smoke test
         shell: bash
         timeout-minutes: 2
+        ## On the 4.3 canary, skip only the post-churn test_run step:
+        ## GDScript exec is slow enough on 4.3 that the suite outruns
+        ## mcp_call's 30s curl timeout, even though the 10 reload
+        ## iterations themselves all pass. The reload-churn mechanism
+        ## is the regression class this smoke guards, so the canary
+        ## still has value.
+        env:
+          SKIP_POSTCHURN_TEST_RUN: ${{ matrix.godot-version == '4.3.stable' && '1' || '0' }}
         run: bash script/ci-reload-test
 
       - name: Quit smoke test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
           ## Phase 2 (full 3-OS 4.3 coverage) is deferred.
           - os: ubuntu-latest
             label: Linux (Godot 4.3)
-            godot-version: "4.3"
+            godot-version: "4.3.0"
 
     steps:
       - uses: actions/checkout@v6
@@ -205,7 +205,7 @@ jobs:
         ## is the regression class this smoke guards, so the canary
         ## still has value.
         env:
-          SKIP_POSTCHURN_TEST_RUN: ${{ matrix.godot-version == '4.3' && '1' || '0' }}
+          SKIP_POSTCHURN_TEST_RUN: ${{ matrix.godot-version == '4.3.0' && '1' || '0' }}
         run: bash script/ci-reload-test
 
       - name: Quit smoke test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,13 @@ jobs:
       - name: Import and validate GDScript
         shell: bash
         timeout-minutes: 3
+        ## On the 4.3 canary, allow the benign `extends Logger` parse
+        ## errors emitted because the `Logger` class doesn't exist
+        ## before Godot 4.5. The 4.6.2 rows leave this off so any
+        ## Logger-related parse error on engines that DO have the class
+        ## still surfaces as a real failure (per Copilot review on #478).
+        env:
+          ALLOW_LOGGER_PARSE_ERRORS: ${{ matrix.godot-version == '4.3.0' && '1' || '0' }}
         run: |
           godot --headless --path test_project --import > godot-import.log 2>&1 || true
           bash script/ci-check-gdscript godot-import.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
           ## Phase 2 (full 3-OS 4.3 coverage) is deferred.
           - os: ubuntu-latest
             label: Linux (Godot 4.3)
-            godot-version: "4.3.stable"
+            godot-version: "4.3"
 
     steps:
       - uses: actions/checkout@v6
@@ -205,7 +205,7 @@ jobs:
         ## is the regression class this smoke guards, so the canary
         ## still has value.
         env:
-          SKIP_POSTCHURN_TEST_RUN: ${{ matrix.godot-version == '4.3.stable' && '1' || '0' }}
+          SKIP_POSTCHURN_TEST_RUN: ${{ matrix.godot-version == '4.3' && '1' || '0' }}
         run: bash script/ci-reload-test
 
       - name: Quit smoke test

--- a/plugin/addons/godot_ai/testing/test_suite.gd
+++ b/plugin/addons/godot_ai/testing/test_suite.gd
@@ -93,6 +93,34 @@ func skip_suite(reason: String) -> void:
 	_suite_skipped_reason = reason
 
 
+## Mark the current test as skipped when the running Godot is older than
+## `min_version` (a "major.minor" string like "4.4"). Use for tests that
+## exercise an engine API or behavior that only exists on newer Godot.
+## Returns true when the test was skipped, so callers can `return` from
+## the test body.
+##
+## Example:
+##     func test_uses_44_only_api() -> void:
+##         if skip_on_godot_lt("4.4", "Engine.capture_script_backtraces is 4.4+"):
+##             return
+##         ...
+func skip_on_godot_lt(min_version: String, reason: String = "") -> bool:
+	var v := Engine.get_version_info()
+	var current_major := int(v.get("major", 0))
+	var current_minor := int(v.get("minor", 0))
+	var parts := min_version.split(".")
+	var want_major := int(parts[0]) if parts.size() > 0 else 0
+	var want_minor := int(parts[1]) if parts.size() > 1 else 0
+	if (
+		current_major < want_major
+		or (current_major == want_major and current_minor < want_minor)
+	):
+		var msg := reason if not reason.is_empty() else "requires Godot %s+" % min_version
+		skip(msg + " (running %d.%d)" % [current_major, current_minor])
+		return true
+	return false
+
+
 ## Trigger an undo against whichever history (scene or global) holds the most
 ## recent action. `EditorUndoRedoManager` in Godot 4.x doesn't expose `.undo()`
 ## directly — you resolve the history's underlying UndoRedo and call it there.

--- a/script/ci-check-gdscript
+++ b/script/ci-check-gdscript
@@ -22,14 +22,30 @@ else
   godot --headless --path "$PROJECT_DIR" --import > "$IMPORT_LOG" 2>&1 || true
 fi
 
-# Check for parse errors in the import output.
-ERRORS=$(grep -ciE "SCRIPT ERROR|Parse Error|Failed to load script" "$IMPORT_LOG" 2>/dev/null || true)
+# Filter known-benign parse errors out of the log before counting. On
+# Godot < 4.5, runtime/editor_logger.gd and runtime/game_logger.gd
+# `extends Logger` and the filesystem scan emits two lines for each:
+#   SCRIPT ERROR: Parse Error: Could not find base class "Logger".
+#   ERROR: Failed to load script ".../(editor|game)_logger.gd" with error "Parse error".
+# (with the file path on a separate "at:" line). The scripts are only
+# load()-ed at runtime behind a ClassDB.class_exists("Logger") gate,
+# never instanced. See the comment headers in those two files.
+FILTERED_LOG=$(mktemp)
+grep -vE \
+  -e 'Could not find base class "Logger"' \
+  -e 'Failed to load script "res://addons/godot_ai/runtime/(editor|game)_logger\.gd"' \
+  "$IMPORT_LOG" > "$FILTERED_LOG" || true
+
+# Check for parse errors in the (filtered) import output.
+ERRORS=$(grep -ciE "SCRIPT ERROR|Parse Error|Failed to load script" "$FILTERED_LOG" 2>/dev/null || true)
 ERRORS="${ERRORS:-0}"
 
 if [ "$ERRORS" -gt 0 ]; then
   echo "GDScript parse errors found:"
-  grep -iE "SCRIPT ERROR|Parse Error|Failed to load script" "$IMPORT_LOG" | sed 's/^/  /'
+  grep -iE "SCRIPT ERROR|Parse Error|Failed to load script" "$FILTERED_LOG" | sed 's/^/  /'
+  rm -f "$FILTERED_LOG"
   exit 1
 fi
 
+rm -f "$FILTERED_LOG"
 echo "All GDScript files OK"

--- a/script/ci-check-gdscript
+++ b/script/ci-check-gdscript
@@ -22,30 +22,39 @@ else
   godot --headless --path "$PROJECT_DIR" --import > "$IMPORT_LOG" 2>&1 || true
 fi
 
-# Filter known-benign parse errors out of the log before counting. On
-# Godot < 4.5, runtime/editor_logger.gd and runtime/game_logger.gd
+# On Godot < 4.5, runtime/editor_logger.gd and runtime/game_logger.gd
 # `extends Logger` and the filesystem scan emits two lines for each:
 #   SCRIPT ERROR: Parse Error: Could not find base class "Logger".
 #   ERROR: Failed to load script ".../(editor|game)_logger.gd" with error "Parse error".
 # (with the file path on a separate "at:" line). The scripts are only
 # load()-ed at runtime behind a ClassDB.class_exists("Logger") gate,
 # never instanced. See the comment headers in those two files.
-FILTERED_LOG=$(mktemp)
-grep -vE \
-  -e 'Could not find base class "Logger"' \
-  -e 'Failed to load script "res://addons/godot_ai/runtime/(editor|game)_logger\.gd"' \
-  "$IMPORT_LOG" > "$FILTERED_LOG" || true
+#
+# This filter is OPT-IN via env var: on Godot >= 4.5 (where Logger exists),
+# any Logger-related parse error WOULD be a real bug — silently filtering
+# would lose CI coverage. The 4.3 canary row in .github/workflows/ci.yml
+# sets ALLOW_LOGGER_PARSE_ERRORS=1; default is strict.
+SCAN_LOG="$IMPORT_LOG"
+FILTERED_LOG=""
+if [ "${ALLOW_LOGGER_PARSE_ERRORS:-}" = "1" ]; then
+  FILTERED_LOG=$(mktemp)
+  grep -vE \
+    -e 'Could not find base class "Logger"' \
+    -e 'Failed to load script "res://addons/godot_ai/runtime/(editor|game)_logger\.gd"' \
+    "$IMPORT_LOG" > "$FILTERED_LOG" || true
+  SCAN_LOG="$FILTERED_LOG"
+fi
 
-# Check for parse errors in the (filtered) import output.
-ERRORS=$(grep -ciE "SCRIPT ERROR|Parse Error|Failed to load script" "$FILTERED_LOG" 2>/dev/null || true)
+# Check for parse errors in the (possibly filtered) import output.
+ERRORS=$(grep -ciE "SCRIPT ERROR|Parse Error|Failed to load script" "$SCAN_LOG" 2>/dev/null || true)
 ERRORS="${ERRORS:-0}"
 
 if [ "$ERRORS" -gt 0 ]; then
   echo "GDScript parse errors found:"
-  grep -iE "SCRIPT ERROR|Parse Error|Failed to load script" "$FILTERED_LOG" | sed 's/^/  /'
-  rm -f "$FILTERED_LOG"
+  grep -iE "SCRIPT ERROR|Parse Error|Failed to load script" "$SCAN_LOG" | sed 's/^/  /'
+  [ -n "$FILTERED_LOG" ] && rm -f "$FILTERED_LOG"
   exit 1
 fi
 
-rm -f "$FILTERED_LOG"
+[ -n "$FILTERED_LOG" ] && rm -f "$FILTERED_LOG"
 echo "All GDScript files OK"

--- a/script/ci-reload-test
+++ b/script/ci-reload-test
@@ -211,6 +211,20 @@ done
 # in the post-reload-churn re-run (refs #278 / PR #296). The comma-separated
 # form is parsed by `McpTestRunner._parse_exclusions` — see
 # `plugin/addons/godot_ai/testing/test_runner.gd`.
+## SKIP_POSTCHURN_TEST_RUN escape hatch: the post-churn test_run takes
+## longer than mcp_call's 30s curl timeout on slower Godot versions
+## (observed on the 4.3 Linux canary — GDScript exec is markedly slower
+## and the test_run pushes past the timeout, returning only SSE
+## keep-alive pings). The 10 reload iterations above still validate the
+## reload-churn mechanism, which is the regression class this smoke
+## guards. Setting this env var in the CI step preserves the canary
+## without blocking on a separate post-churn timeout fix.
+if [ "${SKIP_POSTCHURN_TEST_RUN:-}" = "1" ]; then
+  echo "Skipping post-churn test_run (SKIP_POSTCHURN_TEST_RUN=1)"
+  echo "Reload smoke test passed"
+  exit 0
+fi
+
 echo "Running GDScript test suite on reloaded plugin..."
 TESTS_RESULT=$(mcp_call_or_die "test_run post-churn" test_run '{"verbose":false,"exclude_test_name":"test_configure_current_sibling_unmark_single_undo,test_get_returns_current_when_path_empty"}')
 echo "$TESTS_RESULT" | python3 -c "

--- a/test_project/tests/test_cli_exec.gd
+++ b/test_project/tests/test_cli_exec.gd
@@ -31,6 +31,8 @@ func test_run_captures_stdout_and_zero_exit_on_quick_command() -> void:
 	## End-to-end: spawn `echo hello`, wait for it, capture stdout.
 	## Skipped on Windows because the host's `echo` lives inside cmd.exe
 	## and isn't reachable as a standalone exe via OS.execute_with_pipe.
+	if skip_on_godot_lt("4.4", "OS.execute_with_pipe stdout capture differs on 4.3"):
+		return
 	if OS.get_name() == "Windows":
 		skip("echo is a cmd.exe builtin on Windows; covered by the Unix path")
 		return
@@ -52,6 +54,8 @@ func test_run_captures_stdout_and_zero_exit_on_quick_command() -> void:
 
 
 func test_run_captures_stderr_by_default() -> void:
+	if skip_on_godot_lt("4.4", "OS.execute_with_pipe exit-code encoding differs on 4.3 (1792 vs 7)"):
+		return
 	var fixture := _stderr_fixture_command(7)
 	if fixture.is_empty():
 		skip("No shell available for stderr fixture")
@@ -68,6 +72,8 @@ func test_run_captures_stderr_by_default() -> void:
 
 
 func test_run_can_skip_stderr_capture_for_status_probe() -> void:
+	if skip_on_godot_lt("4.4", "OS.execute_with_pipe stdout capture differs on 4.3"):
+		return
 	var fixture := _stderr_fixture_command(0)
 	if fixture.is_empty():
 		skip("No shell available for stderr fixture")

--- a/test_project/tests/test_dispatcher.gd
+++ b/test_project/tests/test_dispatcher.gd
@@ -129,6 +129,8 @@ func test_malformed_result_log_includes_non_empty_backtrace() -> void:
 	## GDScript failures surface to the dispatcher as malformed results, so
 	## this pins the same guard path without making the test runner depend on
 	## engine-version-specific runtime-error continuation semantics.
+	if skip_on_godot_lt("4.4", "Engine.capture_script_backtraces / get_stack() format differs on 4.3"):
+		return
 	var buf := McpLogBuffer.new()
 	var d := McpDispatcher.new(buf)
 	d.mcp_logging = true


### PR DESCRIPTION
## Summary

Implements **Phase 1 of #477**: adds a Godot 4.3 Linux canary to the CI matrix. The cheapest single entry that would have caught #476's parse-cascade regression on the day it landed instead of 24 days later.

README claims "Godot 4.3+ (4.4+ recommended)" support, but every CI run was on a hardcoded `version: 4.6.2`. This widens the lone version dimension into per-row pinning and adds one new row (`ubuntu-latest` + `4.3.stable`).

Phase 2 (full 3-OS 4.3 coverage for `Stale server smoke` and `Game capture smoke`) is deferred to a follow-up to #477 once Phase 1 has bedded in.

## Blockers handled

The four 4.3-only test failures and one validator false-positive enumerated in #477 — all addressed with the smallest possible patches.

### 1. `McpTestSuite.skip_on_godot_lt(version, reason)`

Same shape as the existing `skip()` / `skip_suite()` helpers; returns `bool` so the test body can early-return. Plumbed into the four tests that exercise 4.4+-only behavior:

- `test_cli_exec.test_run_captures_stdout_and_zero_exit_on_quick_command` — 4.3's `OS.execute_with_pipe` doesn't capture stdout the same way.
- `test_cli_exec.test_run_captures_stderr_by_default` — 4.3 returns the macOS POSIX `wait_status` (`7 << 8 = 1792`), 4.4+ normalizes to the exit code (`7`).
- `test_cli_exec.test_run_can_skip_stderr_capture_for_status_probe` — same family.
- `test_dispatcher.test_malformed_result_log_includes_non_empty_backtrace` — 4.3's `get_stack()` format differs from 4.4+'s `Engine.capture_script_backtraces()` output (which is what `_capture_compact_backtrace` produces on 4.4+).

### 2. `script/ci-check-gdscript` known-benign Logger filter

Filters two well-defined parse-error signatures out of the import log before counting failures:

- `Could not find base class "Logger"`
- `Failed to load script "res://addons/godot_ai/runtime/(editor|game)_logger\.gd"`

Documented in the script header. These two `extends Logger` files are gated by `ClassDB.class_exists("Logger")` at runtime — never instanced on < 4.5 — but Godot's filesystem scan still parses them. The header comments in [`editor_logger.gd`](plugin/addons/godot_ai/runtime/editor_logger.gd) and [`game_logger.gd`](plugin/addons/godot_ai/runtime/game_logger.gd) already describe this behavior (per #476).

### 3. `ci-reload-test` `SKIP_POSTCHURN_TEST_RUN` escape hatch

The trailing post-churn `test_run` step exceeds `mcp_call`'s 30s curl timeout on 4.3 (slower GDScript exec under the SSE response window). The 10 reload iterations themselves all pass — that's the regression class this smoke guards. The env var is set **only on the 4.3 matrix row**; 4.6+ keeps the full post-churn check.

A proper post-churn fix (longer timeout, or streaming-aware response parser) is appropriate but out of scope for this PR — it'd touch behavior on all three OS × multiple Godot versions and wants its own investigation.

## Verification

Ran the full smoke chain locally on **both** Godot 4.3.stable and Godot 4.6.2.stable.mono:

| Check | 4.3.stable | 4.6.2.mono |
|---|---|---|
| `ruff check src/ tests/` | ✅ | ✅ |
| `pytest -q` | ✅ 1088 / 4 skip | ✅ same |
| `pytest tests/integration/test_self_update_upgrade_paths.py` | ✅ | ✅ |
| `script/ci-check-gdscript` (with import log) | ✅ (filter active) | ✅ (filter inert) |
| `script/ci-godot-tests` | ✅ 1302/1341, 0 failures (was 4 failures) | ✅ 1324/1341, 0 failures (identical baseline) |
| `script/ci-reload-test` (10 reloads) | ✅ with `SKIP_POSTCHURN_TEST_RUN=1` | ✅ full post-churn |
| `script/ci-quit-test` | ✅ | ✅ |

4.6 baseline is **identical** to pre-PR (1324/1341, zero failures, full post-churn run) — no regression.

## Test plan

- [x] ruff + pytest + upgrade-paths green on both Godot versions
- [x] ci-check-gdscript filter correctly suppresses the two Logger lines on 4.3 and doesn't suppress anything on 4.6
- [x] skip_on_godot_lt returns bool; tests early-return cleanly
- [x] 1302/1341 on 4.3 (was 4 failures → now 4 skipped)
- [x] 1324/1341 on 4.6 (identical baseline)
- [x] ci-reload-test on 4.3 completes 10 reload iterations + cleanly skips post-churn
- [x] ci-reload-test on 4.6 still runs full post-churn (no behavior change)
- [ ] CI passes the new 4.3 Linux row and all three existing 4.6.2 rows

## Follow-ups

- Phase 2 of #477: full 3-OS 4.3 coverage (Stale-server + Game-capture matrices).
- Investigate `ci-reload-test`'s 30s curl timeout on slower Godot versions (the post-churn step bottleneck). Currently scope-deferred via the env-var escape hatch.
