### PR TITLE
Add joy axis input map binding

### DIFF
--- a/plugin/addons/godot_ai/handlers/input_handler.gd
+++ b/plugin/addons/godot_ai/handlers/input_handler.gd
@@ -194,8 +194,16 @@ func _create_event(event_type: String, params: Dictionary):
 			var ev := InputEventJoypadButton.new()
 			ev.button_index = int(params.get("button", 0))
 			return ev
+		"joy_axis":
+			if not params.has("axis"):
+				return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM,
+					"event_type='joy_axis' requires axis (JoyAxis index, e.g. 0=left stick X, 1=left stick Y).")
+			var ev := InputEventJoypadMotion.new()
+			ev.axis = int(params.get("axis", 0))
+			ev.axis_value = float(params.get("axis_value", 1.0))
+			return ev
 	return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE,
-		"Unsupported event_type: '%s'. Use 'key', 'mouse_button', or 'joy_button'." % event_type)
+		"Unsupported event_type: '%s'. Use 'key', 'mouse_button', 'joy_button', or 'joy_axis'." % event_type)
 
 
 func _serialize_event(event: InputEvent) -> Dictionary:

--- a/plugin/addons/godot_ai/handlers/input_handler.gd
+++ b/plugin/addons/godot_ai/handlers/input_handler.gd
@@ -195,11 +195,30 @@ func _create_event(event_type: String, params: Dictionary):
 			ev.button_index = int(params.get("button", 0))
 			return ev
 		"joy_axis":
-			if not params.has("axis"):
+			var axis_param = params.get("axis", null)
+			if axis_param == null:
 				return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM,
 					"event_type='joy_axis' requires axis (JoyAxis index, e.g. 0=left stick X, 1=left stick Y).")
+			var axis: int
+			match typeof(axis_param):
+				TYPE_INT:
+					axis = axis_param
+				TYPE_FLOAT:
+					if axis_param != floor(axis_param):
+						return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE,
+							"joy_axis axis must be an integer JoyAxis index (got %s)." % str(axis_param))
+					axis = int(axis_param)
+				TYPE_STRING:
+					var axis_text := str(axis_param)
+					if not axis_text.is_valid_int():
+						return ErrorCodes.make(ErrorCodes.WRONG_TYPE,
+							"joy_axis axis must be an integer JoyAxis index (got '%s')." % axis_text)
+					axis = int(axis_text)
+				_:
+					return ErrorCodes.make(ErrorCodes.WRONG_TYPE,
+						"joy_axis axis must be an integer JoyAxis index (got %s)." % type_string(typeof(axis_param)))
 			var ev := InputEventJoypadMotion.new()
-			ev.axis = int(params.get("axis", 0))
+			ev.axis = axis
 			ev.axis_value = float(params.get("axis_value", 1.0))
 			return ev
 	return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE,

--- a/src/godot_ai/tools/input_map.py
+++ b/src/godot_ai/tools/input_map.py
@@ -30,10 +30,12 @@ Ops:
   • remove_action(action)
         Remove an action and all its event bindings.
   • bind_event(action, event_type, keycode="", ctrl=False, alt=False,
-                shift=False, meta=False, button=None)
+                shift=False, meta=False, button=None, axis=None,
+                axis_value=1.0)
         Bind a key/mouse/gamepad event to an action. The action must
         already exist (call ``add_action`` first). ``event_type`` is
-        ``"key"`` | ``"mouse_button"`` | ``"joy_button"``.
+        ``"key"`` | ``"mouse_button"`` | ``"joy_button"`` |
+        ``"joy_axis"``.
           - ``key``: ``keycode`` is a Godot keycode *name string* like
             ``"A"``, ``"Space"``, ``"Enter"``, ``"Escape"``, ``"F1"``,
             ``"Left"`` — not an integer and not ``KEY_*``. Modifier
@@ -42,6 +44,8 @@ Ops:
             3=middle, 4=wheel up, 5=wheel down.
           - ``joy_button``: ``button`` is the ``JoyButton`` index
             (e.g. 0=A/Cross, 1=B/Circle).
+          - ``joy_axis``: ``axis`` is the ``JoyAxis`` index and
+            ``axis_value`` is the direction/value, usually -1.0 or 1.0.
 """
 
 

--- a/test_project/tests/test_input.gd
+++ b/test_project/tests/test_input.gd
@@ -209,6 +209,16 @@ func test_bind_event_mouse_button_zero_button() -> void:
 	_handler.remove_action({"action": TEST_ACTION})
 
 
+func test_bind_event_joy_axis_missing_axis() -> void:
+	_handler.add_action({"action": TEST_ACTION})
+	var result := _handler.bind_event({
+		"action": TEST_ACTION,
+		"event_type": "joy_axis",
+	})
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
+	_handler.remove_action({"action": TEST_ACTION})
+
+
 func test_bind_event_unknown_action_message_suggests_add_action() -> void:
 	## The error string should point the caller at the fix so they don't loop.
 	var result := _handler.bind_event({
@@ -231,4 +241,21 @@ func test_bind_key_event() -> void:
 	assert_eq(result.data.action, TEST_ACTION)
 	assert_has_key(result.data, "event")
 	assert_eq(result.data.event.type, "key")
+	_handler.remove_action({"action": TEST_ACTION})
+
+
+func test_bind_joy_axis_event() -> void:
+	_handler.add_action({"action": TEST_ACTION})
+	var result := _handler.bind_event({
+		"action": TEST_ACTION,
+		"event_type": "joy_axis",
+		"axis": JOY_AXIS_LEFT_X,
+		"axis_value": -1.0,
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.action, TEST_ACTION)
+	assert_has_key(result.data, "event")
+	assert_eq(result.data.event.type, "joy_axis")
+	assert_eq(result.data.event.axis, JOY_AXIS_LEFT_X)
+	assert_eq(result.data.event.axis_value, -1.0)
 	_handler.remove_action({"action": TEST_ACTION})

--- a/test_project/tests/test_input.gd
+++ b/test_project/tests/test_input.gd
@@ -219,6 +219,17 @@ func test_bind_event_joy_axis_missing_axis() -> void:
 	_handler.remove_action({"action": TEST_ACTION})
 
 
+func test_bind_event_joy_axis_null_axis() -> void:
+	_handler.add_action({"action": TEST_ACTION})
+	var result := _handler.bind_event({
+		"action": TEST_ACTION,
+		"event_type": "joy_axis",
+		"axis": null,
+	})
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
+	_handler.remove_action({"action": TEST_ACTION})
+
+
 func test_bind_event_unknown_action_message_suggests_add_action() -> void:
 	## The error string should point the caller at the fix so they don't loop.
 	var result := _handler.bind_event({


### PR DESCRIPTION
## Summary

Fixes #465 by adding support for binding joystick axis events through `input_map_manage(op=bind_event)`.

- Add `event_type=joy_axis` support in the GDScript input handler by creating `InputEventJoypadMotion`.
- Require `axis` and accept optional `axis_value` (default `1.0`).
- Update MCP tool docs to advertise `joy_axis` alongside key, mouse button, and joy button bindings.
- Add GDScript coverage for missing `axis` and successful axis binding.

## Verification

- Red check before implementation: focused `input` suite failed on `test_bind_joy_axis_event` because `joy_axis` returned an error instead of data.
- `test_run suite=input`: 22/22 passed, 0 failed.
- `python -m ruff check src/godot_ai/tools/input_map.py`: passed.
- `git diff --check`: passed.