### PR TITLE
Gate in-editor self-update off on Godot < 4.4 (#475)

### DIFF
--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -487,6 +487,12 @@ func _build_ui() -> void:
 	_update_label = Label.new()
 	_update_label.add_theme_font_size_override("font_size", 15)
 	_update_label.add_theme_color_override("font_color", Color(1.0, 0.85, 0.3))
+	## Wrap long banner text (e.g. the < 4.4 manual-update guidance) instead
+	## of letting a single line stretch the whole dock wide. The dock is a
+	## fixed-width side panel, so constrain horizontally and wrap.
+	_update_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_update_label.size_flags_horizontal = Control.SIZE_FILL
+	_update_label.custom_minimum_size = Vector2(0, 0)
 	_update_banner.add_child(_update_label)
 
 	var update_btn_row := HBoxContainer.new()

--- a/plugin/addons/godot_ai/utils/update_manager.gd
+++ b/plugin/addons/godot_ai/utils/update_manager.gd
@@ -122,6 +122,21 @@ static func _version_can_self_update(major: int, minor: int) -> bool:
 	return major > 4 or (major == 4 and minor >= 4)
 
 
+## Banner guidance for the gated (< 4.4) path. Shown up-front at check time
+## (with the available version) and again on click, so the user understands
+## the manual-update flow before they press anything. Single source of truth
+## so check-time and click-time text never drift.
+static func _manual_update_label(version: String) -> String:
+	var prefix := "Update available"
+	if not version.is_empty():
+		prefix = "Update v%s available" % version
+	return (
+		prefix
+		+ " — in-editor update needs Godot 4.4+. Open the download page, then "
+		+ "replace addons/godot_ai/ manually and relaunch."
+	)
+
+
 ## Driven by the dock's Update button. On Godot < 4.4 (see `_can_self_update`)
 ## the in-editor install is disabled — we open the release page for a manual
 ## download instead, never entering the extract pipeline that crashes those
@@ -132,14 +147,12 @@ static func _version_can_self_update(major: int, minor: int) -> bool:
 func start_install() -> void:
 	if not _can_self_update():
 		OS.shell_open(RELEASES_PAGE)
+		## Keep the up-front guidance label (already shown since check time);
+		## just confirm the page opened and lock the button.
 		install_state_changed.emit({
 			"button_text": "Opened download page",
 			"button_disabled": true,
-			"label_text": (
-				"Update available — in-editor update needs Godot 4.4+. "
-				+ "Download the new addon and replace addons/godot_ai/ manually, "
-				+ "then relaunch Godot."
-			),
+			"label_text": _manual_update_label(""),
 		})
 		return
 
@@ -268,11 +281,14 @@ func _on_update_check_completed(
 		return
 	_latest_download_url = String(parsed.get("download_url", ""))
 	update_check_completed.emit(parsed)
-	## On engines that can't self-update (Godot < 4.4, #475), relabel the
-	## button up-front so the user knows clicking opens a download page
-	## rather than running an in-editor update.
+	## On engines that can't self-update (Godot < 4.4, #475), surface the
+	## full manual-update guidance AND relabel the button up-front — before
+	## any click — so the user knows what the button does and why.
 	if not _can_self_update():
-		install_state_changed.emit({"button_text": "Open download page"})
+		install_state_changed.emit({
+			"button_text": "Open download page",
+			"label_text": _manual_update_label(String(parsed.get("version", ""))),
+		})
 
 
 func _on_download_completed(

--- a/plugin/addons/godot_ai/utils/update_manager.gd
+++ b/plugin/addons/godot_ai/utils/update_manager.gd
@@ -103,11 +103,46 @@ func clear_pending_download() -> void:
 	_latest_download_url = ""
 
 
-## Driven by the dock's Update button. With no resolved download URL —
-## either the check never completed, or the release didn't ship a
-## matching asset — falls back to opening the release page. Otherwise
-## kicks off the download → extract → reload pipeline.
+## True when the running Godot can self-update in place. Godot < 4.4 takes
+## the `_install_zip_inline` extract-then-restart path, and that engine's
+## stricter `GDScript::reload()` (`!p_keep_state && has_instances` ->
+## `ERR_ALREADY_IN_USE`) turns the extract-over-live-scripts into a reload
+## error flood plus a SIGSEGV in `EditorDockManager::remove_dock` /
+## `SceneTree::finalize` on the restart/quit (#475). So on < 4.4 we don't
+## run the in-editor pipeline at all — the user updates manually.
+## Guards `major` too so a future Godot 5.x (minor 0) isn't misclassified.
+func _can_self_update() -> bool:
+	var v := Engine.get_version_info()
+	return _version_can_self_update(int(v.get("major", 0)), int(v.get("minor", 0)))
+
+
+## Pure version predicate, split out so it's testable without faking the
+## running engine. In-editor self-update needs Godot >= 4.4.
+static func _version_can_self_update(major: int, minor: int) -> bool:
+	return major > 4 or (major == 4 and minor >= 4)
+
+
+## Driven by the dock's Update button. On Godot < 4.4 (see `_can_self_update`)
+## the in-editor install is disabled — we open the release page for a manual
+## download instead, never entering the extract pipeline that crashes those
+## engines. With no resolved download URL — either the check never completed,
+## or the release didn't ship a matching asset — also falls back to opening
+## the release page. Otherwise kicks off the download → extract → reload
+## pipeline.
 func start_install() -> void:
+	if not _can_self_update():
+		OS.shell_open(RELEASES_PAGE)
+		install_state_changed.emit({
+			"button_text": "Opened download page",
+			"button_disabled": true,
+			"label_text": (
+				"Update available — in-editor update needs Godot 4.4+. "
+				+ "Download the new addon and replace addons/godot_ai/ manually, "
+				+ "then relaunch Godot."
+			),
+		})
+		return
+
 	if _latest_download_url.is_empty():
 		OS.shell_open(RELEASES_PAGE)
 		return
@@ -233,6 +268,11 @@ func _on_update_check_completed(
 		return
 	_latest_download_url = String(parsed.get("download_url", ""))
 	update_check_completed.emit(parsed)
+	## On engines that can't self-update (Godot < 4.4, #475), relabel the
+	## button up-front so the user knows clicking opens a download page
+	## rather than running an in-editor update.
+	if not _can_self_update():
+		install_state_changed.emit({"button_text": "Open download page"})
 
 
 func _on_download_completed(

--- a/plugin/addons/godot_ai/utils/update_manager.gd
+++ b/plugin/addons/godot_ai/utils/update_manager.gd
@@ -146,14 +146,20 @@ static func _manual_update_label(version: String) -> String:
 ## pipeline.
 func start_install() -> void:
 	if not _can_self_update():
-		OS.shell_open(RELEASES_PAGE)
-		## Keep the up-front guidance label (already shown since check time);
-		## just confirm the page opened and lock the button.
-		install_state_changed.emit({
-			"button_text": "Opened download page",
-			"button_disabled": true,
-			"label_text": _manual_update_label(""),
-		})
+		## Only claim success + lock the button if the browser actually opened.
+		## On failure (no handler, headless) keep the button enabled so the
+		## user can retry. Either way, leave the version-bearing guidance label
+		## from check time in place — don't re-emit label_text.
+		if OS.shell_open(RELEASES_PAGE) == OK:
+			install_state_changed.emit({
+				"button_text": "Opened download page",
+				"button_disabled": true,
+			})
+		else:
+			install_state_changed.emit({
+				"button_text": "Couldn't open browser — retry",
+				"button_disabled": false,
+			})
 		return
 
 	if _latest_download_url.is_empty():

--- a/plugin/addons/godot_ai/utils/update_manager.gd
+++ b/plugin/addons/godot_ai/utils/update_manager.gd
@@ -340,7 +340,11 @@ func _install_zip() -> void:
 		_plugin != null
 		and _plugin.has_method("install_downloaded_update")
 	)
-	if int(version.get("minor", 0)) >= 4 and has_runner:
+	## Same major-aware predicate as the _can_self_update() gate, so a future
+	## Godot 5.x (minor 0) takes the runner path the gate promised — not the
+	## pre-4.4 inline extract. A bare `minor >= 4` here would route 5.0 to the
+	## crash-prone inline path even though the gate let it in.
+	if _version_can_self_update(int(version.get("major", 0)), int(version.get("minor", 0))) and has_runner:
 		install_state_changed.emit({"button_text": "Reloading..."})
 		## Runner takes over: plugin tears down, runner extracts + scans +
 		## re-enables. `install_downloaded_update` calls
@@ -393,7 +397,7 @@ func _install_zip_inline(version: Dictionary) -> void:
 	if _plugin != null and _plugin.has_method("prepare_for_update_reload"):
 		_plugin.prepare_for_update_reload()
 
-	if int(version.get("minor", 0)) >= 4:
+	if _version_can_self_update(int(version.get("major", 0)), int(version.get("minor", 0))):
 		install_state_changed.emit({"button_text": "Scanning..."})
 		## Filesystem scan must complete before plugin reload — otherwise
 		## plugin.gd re-parses against a ClassDB that hasn't seen the new

--- a/test_project/tests/test_update_manager.gd
+++ b/test_project/tests/test_update_manager.gd
@@ -23,6 +23,28 @@ func suite_name() -> String:
 	return "update_manager"
 
 
+# ---- _version_can_self_update (pure / static, #475 gate) ---------------
+
+func test_version_can_self_update_false_below_4_4() -> void:
+	## Godot < 4.4 takes the extract-then-restart path that crashes (#475),
+	## so the in-editor self-update is gated off on those engines.
+	assert_false(McpUpdateManagerScript._version_can_self_update(4, 3),
+		"4.3 must be gated (in-editor self-update disabled)")
+	assert_false(McpUpdateManagerScript._version_can_self_update(4, 0),
+		"4.0 must be gated")
+	assert_false(McpUpdateManagerScript._version_can_self_update(3, 9),
+		"a hypothetical 3.x must be gated")
+
+
+func test_version_can_self_update_true_at_and_above_4_4() -> void:
+	assert_true(McpUpdateManagerScript._version_can_self_update(4, 4),
+		"4.4 is the first engine that can self-update in place")
+	assert_true(McpUpdateManagerScript._version_can_self_update(4, 6),
+		"4.6 can self-update")
+	assert_true(McpUpdateManagerScript._version_can_self_update(5, 0),
+		"a future 5.0 (minor 0) must not be misclassified by the minor check")
+
+
 # ---- parse_releases_response (pure / static) ---------------------------
 
 func _make_body(json_str: String) -> PackedByteArray:

--- a/test_project/tests/test_update_manager.gd
+++ b/test_project/tests/test_update_manager.gd
@@ -45,6 +45,24 @@ func test_version_can_self_update_true_at_and_above_4_4() -> void:
 		"a future 5.0 (minor 0) must not be misclassified by the minor check")
 
 
+func test_manual_update_label_includes_version_and_guidance() -> void:
+	## Shown up-front on < 4.4 (before any click) so the user understands the
+	## manual-update flow. Must name the version and the 4.4+ requirement.
+	var with_v := McpUpdateManagerScript._manual_update_label("2.5.7")
+	assert_contains(with_v, "2.5.7", "label must name the available version")
+	assert_contains(with_v, "Godot 4.4+", "label must state the engine requirement")
+	assert_contains(with_v, "addons/godot_ai/", "label must point at the manual-swap path")
+
+
+func test_manual_update_label_omits_version_when_unknown() -> void:
+	## On the click path the version isn't re-threaded; the label degrades to
+	## a generic "Update available" without a stray "v" token.
+	var no_v := McpUpdateManagerScript._manual_update_label("")
+	assert_contains(no_v, "Update available", "generic label must still lead with 'Update available'")
+	assert_false(no_v.contains(" v"), "no version token when version is empty")
+	assert_contains(no_v, "Godot 4.4+", "label must still state the engine requirement")
+
+
 # ---- parse_releases_response (pure / static) ---------------------------
 
 func _make_body(json_str: String) -> PackedByteArray:


### PR DESCRIPTION
## Summary

Fixes #475. On Godot < 4.4 the in-editor self-update extracts new scripts over the live editor, which collides with that engine's stricter `GDScript::reload()` (`!p_keep_state && has_instances` → `ERR_ALREADY_IN_USE`) — producing a reload-error flood and a SIGSEGV in `EditorDockManager::remove_dock` / `SceneTree::finalize` on the restart/quit. Approaches to make the in-place flow safe on 4.3 were disproven (see #475 thread).

This **gates the in-editor update off on < 4.4** rather than trying to fix the unfixable path:

- `start_install()` on a gated engine opens the GitHub releases page (`OS.shell_open`) and shows *"in-editor update needs Godot 4.4+ — download the new addon and replace `addons/godot_ai/` manually, then relaunch"*, and **returns before the extract pipeline**.
- The update banner button is relabeled **"Open download page"** at check time so the action is honest before the click.
- **4.4+ is unchanged** — real in-place update via `update_reload_runner`.
- Version logic is a pure static `_version_can_self_update(major, minor)` (testable without faking the engine; `major`-guarded so a future 5.x minor-0 isn't misclassified).

## Verification (e2e on real engines)

Disposable standalone fixtures at v2.5.6 vs the real v2.5.7 release:

- **Godot 4.3** (the ironclad case): clicking the gated button opens the release page + manual message; **0 extract, 0 `ERR_ALREADY_IN_USE`, 0 crash**; a subsequent **Cmd-Q exits cleanly with no new crash report**. Only the two benign `extends Logger` parse errors remain (cosmetic on < 4.5).
- **Godot 4.6** (regression): gate does **not** fire; real in-place update runs end-to-end (**2.5.6 → 2.5.7** via `update_reload_runner`), 0 errors, 0 crash.
- **Unit**: GDScript tests pin the predicate (4.3/4.0/3.x → false; 4.4/4.6/5.0 → true); full `update_manager` suite green (14/14).

## Test plan
- [x] GDScript `update_manager` suite green incl. new `_version_can_self_update` tests
- [x] ruff + pytest green (gate is GDScript-only)
- [x] 4.3 e2e: gated, no extract/crash, clean quit
- [x] 4.6 e2e: in-place update still works (gate inert)
- [ ] CI green across Linux (4.6.2 + 4.3) / macOS / Windows

## Follow-up
The two benign `extends Logger` parse errors on < 4.5 are still cosmetically present (tracked separately) — not addressed here.
