### PR TITLE
docs: add get_ui_elements to game_manage rollup inventory (#481 follow-up)

### DIFF
--- a/.claude/skills/godot-ai/skill.md
+++ b/.claude/skills/godot-ai/skill.md
@@ -185,7 +185,7 @@ When adding a new verb, prefer adding it as an op on the domain's existing `regi
 | `signal_manage` | `list`, `connect`, `disconnect` |
 | `autoload_manage` | `list`, `add`, `remove` |
 | `input_map_manage` | `list`, `add_action`, `remove_action`, `bind_event` |
-| `game_manage` | `get_scene_tree`, `get_node_info`, `input_key`, `input_mouse`, `input_gamepad`, `input_state` (running-game inspection + synthetic input; routed to the game process via `game_eval` / `game_command`) |
+| `game_manage` | `get_scene_tree`, `get_node_info`, `get_ui_elements`, `input_key`, `input_mouse`, `input_gamepad`, `input_state` (running-game inspection + synthetic input; routed to the game process via `game_eval` / `game_command`) |
 | `test_manage` | `results_get` |
 | `ui_manage` | `set_anchor_preset`, `set_text`, `build_layout`, `draw_recipe` |
 | `theme_manage` | `create`, `set_color`, `set_constant`, `set_font_size`, `set_stylebox_flat`, `apply` |


### PR DESCRIPTION
Adds the get_ui_elements op to the game_manage rollup row in .claude/skills/godot-ai/skill.md — #481 added the op + updated docs/TOOLS.md but missed the skill inventory table. Closes the doc-sync item from #484.

Docs only; no code change.