### PR TITLE
verify-worktree: don't accept a stale real dir as a valid link on POSIX

### DIFF
--- a/script/verify-worktree
+++ b/script/verify-worktree
@@ -38,6 +38,16 @@ fi
 link="test_project/addons/godot_ai"
 expected_target_abs="$repo_root/plugin/addons/godot_ai"
 
+# Are we on Windows? Junctions appear as plain directories to bash, so the
+# "is it a directory?" fallback below is only meaningful there. On macOS/Linux
+# a non-symlink directory at $link is a stale real copy (e.g. left by a
+# self-update smoke test or botched checkout) holding OUTDATED plugin code —
+# it must be treated as broken and replaced with the symlink, never accepted.
+is_windows=0
+case "${OS:-}${OSTYPE:-}" in
+    *Windows_NT*|*msys*|*cygwin*) is_windows=1 ;;
+esac
+
 link_ok=0
 if [ -L "$link" ]; then
     # POSIX symlink — resolve and compare
@@ -45,9 +55,12 @@ if [ -L "$link" ]; then
     if [ "$resolved" = "$expected_target_abs" ]; then
         link_ok=1
     fi
-elif [ -d "$link" ]; then
-    # Could be a Windows junction. Compare contents via plugin.gd presence.
-    # On Windows, junctions appear as directories to bash.
+elif [ "$is_windows" = "1" ] && [ -d "$link" ]; then
+    # On Windows, directory junctions appear as plain directories to bash and
+    # can't be told apart from real dirs the way `-L` distinguishes symlinks.
+    # Accept a junction-shaped dir via plugin.gd presence. (Not reachable on
+    # macOS/Linux: there, a real dir here is a stale copy and falls through to
+    # the rm -rf + recreate path below.)
     if [ -f "$link/plugin.gd" ]; then
         link_ok=1
     fi

--- a/tests/unit/test_verify_worktree_link.py
+++ b/tests/unit/test_verify_worktree_link.py
@@ -47,7 +47,7 @@ def _make_sandbox(tmp_path: Path) -> Path:
     (root / "script").mkdir(parents=True)
     (root / "plugin" / "addons" / "godot_ai").mkdir(parents=True)
     (root / "plugin" / "addons" / "godot_ai" / "plugin.gd").write_text(
-        "# canonical plugin source\n"
+        "# canonical plugin source\n", encoding="utf-8"
     )
     (root / "test_project" / "addons").mkdir(parents=True)
 
@@ -72,7 +72,7 @@ def test_stale_real_dir_is_repaired_to_symlink(tmp_path: Path) -> None:
 
     # Stale real-dir copy holding OUTDATED plugin code.
     link.mkdir()
-    (link / "plugin.gd").write_text("# OUTDATED stale copy\n")
+    (link / "plugin.gd").write_text("# OUTDATED stale copy\n", encoding="utf-8")
 
     result = _run(root)
 
@@ -80,7 +80,7 @@ def test_stale_real_dir_is_repaired_to_symlink(tmp_path: Path) -> None:
     assert link.is_symlink(), "stale real dir should have been replaced with a symlink"
     assert link.resolve() == (root / "plugin" / "addons" / "godot_ai").resolve()
     # And it now resolves to the canonical (not the stale) plugin.gd.
-    assert (link / "plugin.gd").read_text() == "# canonical plugin source\n"
+    assert (link / "plugin.gd").read_text(encoding="utf-8") == "# canonical plugin source\n"
 
 
 def test_healthy_symlink_is_left_intact(tmp_path: Path) -> None:

--- a/tests/unit/test_verify_worktree_link.py
+++ b/tests/unit/test_verify_worktree_link.py
@@ -1,0 +1,123 @@
+"""Behavioral test for ``script/verify-worktree`` Invariant-2 link repair.
+
+The ``test_project/addons/godot_ai`` link is supposed to be a symlink into this
+worktree's ``plugin/addons/godot_ai`` (or, on Windows, a directory junction).
+
+Regression guarded here: on macOS/Linux a *stale real directory* at the link
+path (a full copy of an old plugin, e.g. left behind by a self-update smoke
+test or a botched checkout) used to satisfy the script's ``-d`` +
+``plugin.gd``-exists fallback — that branch is only meant to accept genuine
+Windows directory junctions, which appear as plain dirs to bash. The script
+printed ``[ok]`` and exited 0 without repairing, so a developer/agent silently
+tested OUTDATED plugin source. The fix gates the ``-d`` fallback to Windows
+only; on POSIX a non-symlink directory is treated as broken and replaced with
+the symlink.
+
+Driven against a throwaway sandbox repo (a copy of the script + a minimal
+``plugin/`` tree) so the real worktree's link is never touched. POSIX-only —
+the bug and its fix are about the POSIX path; the Windows junction branch can't
+be exercised from bash on this platform.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VERIFY_SCRIPT = REPO_ROOT / "script" / "verify-worktree"
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt",
+    reason="POSIX symlink-repair path; Windows uses the junction branch.",
+)
+
+
+def _make_sandbox(tmp_path: Path) -> Path:
+    """Build a minimal repo where verify-worktree can run self-contained.
+
+    The script does ``cd "$(dirname "$0")/.."`` then operates on
+    ``plugin/`` and ``test_project/addons/godot_ai`` relative to that root.
+    """
+    root = tmp_path / "sandbox"
+    (root / "script").mkdir(parents=True)
+    (root / "plugin" / "addons" / "godot_ai").mkdir(parents=True)
+    (root / "plugin" / "addons" / "godot_ai" / "plugin.gd").write_text(
+        "# canonical plugin source\n"
+    )
+    (root / "test_project" / "addons").mkdir(parents=True)
+
+    script_copy = root / "script" / "verify-worktree"
+    shutil.copy2(VERIFY_SCRIPT, script_copy)
+    script_copy.chmod(0o755)
+    return root
+
+
+def _run(root: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(root / "script" / "verify-worktree")],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_stale_real_dir_is_repaired_to_symlink(tmp_path: Path) -> None:
+    """A stale real directory (not a symlink) must be replaced, not accepted."""
+    root = _make_sandbox(tmp_path)
+    link = root / "test_project" / "addons" / "godot_ai"
+
+    # Stale real-dir copy holding OUTDATED plugin code.
+    link.mkdir()
+    (link / "plugin.gd").write_text("# OUTDATED stale copy\n")
+
+    result = _run(root)
+
+    assert result.returncode == 0, result.stderr
+    assert link.is_symlink(), "stale real dir should have been replaced with a symlink"
+    assert link.resolve() == (root / "plugin" / "addons" / "godot_ai").resolve()
+    # And it now resolves to the canonical (not the stale) plugin.gd.
+    assert (link / "plugin.gd").read_text() == "# canonical plugin source\n"
+
+
+def test_healthy_symlink_is_left_intact(tmp_path: Path) -> None:
+    """An already-correct symlink passes without being recreated."""
+    root = _make_sandbox(tmp_path)
+    link = root / "test_project" / "addons" / "godot_ai"
+    link.symlink_to(Path("../../plugin/addons/godot_ai"))
+
+    result = _run(root)
+
+    assert result.returncode == 0, result.stderr
+    assert "[ok]" in result.stdout
+    assert link.is_symlink()
+    assert link.resolve() == (root / "plugin" / "addons" / "godot_ai").resolve()
+
+
+def test_missing_link_is_created(tmp_path: Path) -> None:
+    """No link at all → create the symlink."""
+    root = _make_sandbox(tmp_path)
+    link = root / "test_project" / "addons" / "godot_ai"
+
+    result = _run(root)
+
+    assert result.returncode == 0, result.stderr
+    assert link.is_symlink()
+    assert link.resolve() == (root / "plugin" / "addons" / "godot_ai").resolve()
+
+
+def test_wrong_symlink_target_is_repaired(tmp_path: Path) -> None:
+    """A symlink pointing somewhere else is repaired to the canonical target."""
+    root = _make_sandbox(tmp_path)
+    link = root / "test_project" / "addons" / "godot_ai"
+    (root / "elsewhere").mkdir()
+    link.symlink_to(Path("../../elsewhere"))
+
+    result = _run(root)
+
+    assert result.returncode == 0, result.stderr
+    assert link.is_symlink()
+    assert link.resolve() == (root / "plugin" / "addons" / "godot_ai").resolve()


### PR DESCRIPTION
## Problem

`script/verify-worktree`'s Invariant-2 check has a macOS/Linux blind spot. The link `test_project/addons/godot_ai` should be a symlink into this worktree's `plugin/addons/godot_ai` (or, on Windows, a directory junction).

The `elif [ -d "$link" ]` fallback was meant **only** to accept genuine Windows directory junctions, which appear as plain dirs to bash. But on macOS/Linux it also matched a **stale real directory** — a full copy of an old plugin left behind by a self-update smoke test or a botched checkout. The script saw `plugin.gd` inside it, printed `[ok]`, and exited 0 **without repairing** — so a developer/agent silently tested OUTDATED plugin source. Hit in practice: a stale copy lacked a branch's `game_helper.gd` fix while `[ok]` was printed.

## Fix

Gate the `-d` fallback to Windows only, reusing the same `${OS}`/`${OSTYPE}` detection the script already uses for link creation. On POSIX, a non-symlink directory now falls through to the existing `rm -rf "$link"` + recreate-symlink path. Windows junction support (junctions look like plain dirs to bash, matched via `plugin.gd` presence) is unchanged.

## Tests

New `tests/unit/test_verify_worktree_link.py` drives the script against a throwaway sandbox repo (the real worktree's link is never touched), POSIX-only:

- **stale real dir → repaired to symlink** (the regression; also asserts it now resolves to the *canonical* `plugin.gd`, not the stale copy)
- healthy symlink left intact (`[ok]`, idempotent)
- missing link created
- wrong-target symlink repaired

All 4 pass; `ruff check` clean; `bash -n` syntax-ok.

### Manual repro

```bash
cd ~/godot-ai
rm -rf test_project/addons/godot_ai
mkdir -p test_project/addons/godot_ai
touch test_project/addons/godot_ai/plugin.gd
script/verify-worktree          # before: [ok] (BUG). after: recreates the symlink.
ls -ld test_project/addons/godot_ai   # confirms it's a symlink again
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
