### PR TITLE
Quiet plugin ring-buffer console echo during test runs

### DIFF
--- a/plugin/addons/godot_ai/testing/test_runner.gd
+++ b/plugin/addons/godot_ai/testing/test_runner.gd
@@ -75,6 +75,14 @@ func run_suites(suites: Array, suite_filter: String = "", test_filter: String = 
 	_results.clear()
 	var start := Time.get_ticks_msec()
 
+	## Silence the plugin's ring-buffer console echo while tests run. Negative-
+	## path suites deliberately fill the ring with 500 lines and log malformed-
+	## result errors; echoing all of that buries an all-green run in scary
+	## console output. The ring contents tests assert on are untouched, and
+	## the flag is restored after the run so live logging resumes.
+	var _prev_console_echo := McpLogBuffer.console_echo
+	McpLogBuffer.console_echo = false
+
 	for suite: McpTestSuite in suites:
 		if not suite_filter.is_empty() and suite.suite_name() != suite_filter:
 			continue
@@ -117,6 +125,7 @@ func run_suites(suites: Array, suite_filter: String = "", test_filter: String = 
 			_cleanup_leaked_nodes(scene_root, before_children)
 
 	_last_run_ms = Time.get_ticks_msec() - start
+	McpLogBuffer.console_echo = _prev_console_echo
 	return get_results(verbose)
 
 

--- a/plugin/addons/godot_ai/utils/log_buffer.gd
+++ b/plugin/addons/godot_ai/utils/log_buffer.gd
@@ -6,6 +6,15 @@ extends RefCounted
 
 const MAX_LINES := 500
 
+## When false, `log()` still records into the ring buffer but does not echo the
+## line to the Godot console. The test runner flips this off for the duration
+## of a run so negative-path suites (which intentionally drive a 500-line ring
+## fill and malformed-result error logging) don't bury an all-green run in
+## console noise. Ring *contents* — what tests assert on via `get_recent()` /
+## `total_logged()` — are unaffected. Engine-level C++ errors raised by
+## negative-path tests are not routed through here and still surface.
+static var console_echo := true
+
 var _lines: Array[String] = []
 ## Monotonic count of every line ever passed to `log()` since the last
 ## `clear()`. Distinct from `_lines.size()`, which is bounded at MAX_LINES.
@@ -19,7 +28,8 @@ var enabled := true
 
 func log(msg: String) -> void:
 	var line := "MCP | %s" % msg
-	print(line)
+	if enabled and console_echo:
+		print(line)
 	_lines.append(line)
 	if _lines.size() > MAX_LINES:
 		_lines = _lines.slice(-MAX_LINES)

--- a/test_project/tests/test_log_buffer.gd
+++ b/test_project/tests/test_log_buffer.gd
@@ -1,0 +1,47 @@
+@tool
+extends McpTestSuite
+
+## Coverage for McpLogBuffer's console-echo gating. The ring buffer must keep
+## recording lines (so content-asserting tests stay valid) whether or not the
+## console echo is muted — the test runner mutes it for the whole run.
+
+const McpLogBufferScript := preload("res://addons/godot_ai/utils/log_buffer.gd")
+
+
+func suite_name() -> String:
+	return "log_buffer"
+
+
+## NOTE: there is intentionally no "console_echo defaults to true" test — the
+## test runner sets it false for the duration of every run, so the flag is
+## never true mid-run. The production default lives in the declaration
+## (`static var console_echo := true`) and the runner restores the prior value
+## on exit.
+
+
+func test_log_records_to_ring_when_echo_muted() -> void:
+	var prev: bool = McpLogBufferScript.console_echo
+	McpLogBufferScript.console_echo = false
+	var buffer = McpLogBufferScript.new()
+	buffer.log("quiet line a")
+	buffer.log("quiet line b")
+	McpLogBufferScript.console_echo = prev
+
+	## Muting the console must not drop ring entries — the contract that lets
+	## negative-path tests assert on buffer contents during a muted run.
+	assert_eq(buffer.total_logged(), 2, "both lines recorded despite muted echo")
+	var recent: Array = buffer.get_recent(10)
+	assert_eq(recent.size(), 2, "ring holds both muted lines")
+	assert_true(String(recent[-1]).ends_with("quiet line b"), "last line preserved verbatim")
+
+
+func test_per_instance_enabled_gates_recording_independently() -> void:
+	## `enabled` gates the console print per instance; recording still happens.
+	var prev: bool = McpLogBufferScript.console_echo
+	McpLogBufferScript.console_echo = false
+	var buffer = McpLogBufferScript.new()
+	buffer.enabled = false
+	buffer.log("still recorded")
+	McpLogBufferScript.console_echo = prev
+
+	assert_eq(buffer.total_logged(), 1, "line recorded even with enabled=false")

--- a/test_project/tests/test_log_buffer.gd.uid
+++ b/test_project/tests/test_log_buffer.gd.uid
@@ -1,0 +1,1 @@
+uid://6rrmdcq3mjsr


### PR DESCRIPTION
## Problem

A clean, all-green `test_run` printed **thousands** of alarming lines — making a passing run look broken. The bulk:

- ~500 `MCP | filler N` lines from the log-ring bound test (`test_dock`),
- per-test dispatcher `[recv]`/`[send]` chatter, and
- `[error] ... malformed result` lines from negative-path suites (e.g. `test_dispatcher`) that deliberately drive failures.

## Fix

`McpLogBuffer.log()` echoed every line to the Godot console **unconditionally** (the existing `enabled` field was never consulted). Now:

- The console `print` is gated on `enabled and console_echo`. The **ring buffer still records every line**, so tests that assert on buffer contents via `get_recent()` / `total_logged()` are unaffected.
- A new static `console_echo` (default `true`, so production logging is unchanged) is flipped **off by the test runner for the duration of a run** and restored afterward.

## Scope / non-goals

- **Engine-level C++ errors** (JSON parse failures, `get_node()` from outside the active tree, etc.) that negative-path tests intentionally trigger are **not** routed through our logger and still surface — that's inherent and out of scope.
- The 33 raw `print("MCP | ...")` calls in the update/lifecycle paths are left as-is (real diagnostics, not buffer-routed). Trimming those is a possible follow-up.

## Verification

Live on Godot 4.6.3 (`test_run` via the live editor):

| Metric | Before | After |
|---|---|---|
| `MCP | filler` lines during a run | ~500 | **0** |
| dispatcher `[error]` lines | 2 | **0** |
| total editor-console lines for a run | thousands | ~400 |

- GDScript suite: **0 failures** (new `log_buffer` suite asserts the ring still records under a muted echo; a brittle "defaults true" test was intentionally omitted since the runner mutes the flag mid-run).
- **0 parse errors** on Godot 4.6.3 and 4.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
