### PR TITLE
Sanitize Discord webhook URL; don't fail release on Discord post

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,6 +182,13 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_CHANGELOG_WEBHOOK }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Strip any whitespace/newlines from the secret. `gh secret set`
+          # captures a trailing newline if the value was piped/pasted with
+          # one, which makes curl reject the URL with "(3) Malformed input to
+          # a URL function". A webhook URL contains no internal whitespace, so
+          # stripping all whitespace is safe and fixes contaminated secrets
+          # regardless of how they were set.
+          DISCORD_WEBHOOK=$(printf '%s' "$DISCORD_WEBHOOK" | tr -d '[:space:]')
           if [ -z "$DISCORD_WEBHOOK" ]; then
             echo "DISCORD_CHANGELOG_WEBHOOK not set — skipping changelog post."
             exit 0
@@ -208,6 +215,12 @@ jobs:
                  color: 5793266
                } ]
              }')
-          curl -fsS -H "Content-Type: application/json" \
-            -X POST -d "$payload" "$DISCORD_WEBHOOK"
-          echo "Posted changelog for $tag to Discord."
+          # The changelog post is non-essential: the release already shipped
+          # before this step. A Discord outage or a bad webhook must not turn
+          # a successful release red — log a warning annotation and exit 0.
+          if curl -fsS --retry 3 --retry-delay 2 -H "Content-Type: application/json" \
+               -X POST -d "$payload" "$DISCORD_WEBHOOK"; then
+            echo "Posted changelog for $tag to Discord."
+          else
+            echo "::warning::Discord changelog post for $tag failed (release itself is unaffected)."
+          fi


### PR DESCRIPTION
## What

Fixes the changelog-to-Discord step that failed on its first real release with:

```
curl: (3) URL rejected: Malformed input to a URL function
```

## Cause

The `DISCORD_CHANGELOG_WEBHOOK` secret carries a **trailing newline** — `gh secret set` keeps it when the value is pasted/piped with a newline. curl rejects the resulting URL as malformed. (Our local smoke test wrote the URL with `printf '%s'`, no newline, so it worked — the secret didn't get that treatment.)

## Fix

- **Strip all whitespace** from the webhook value before use. A webhook URL has no internal whitespace, so this is safe and repairs the already-contaminated secret without needing it re-set.
- **Make the post non-fatal**: the release ships *before* this step runs, so a Discord failure now logs a `::warning::` annotation and exits 0 instead of turning a green release red. Adds `curl --retry 3` for transient blips.

## Note

The release that surfaced this (the run linked from the failure) shipped fine — only the changelog post was skipped. That one version's note can be posted manually if desired; all future releases post automatically once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
