### PR TITLE
docs: add Linux package-manager uv install options (#464)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@
 - [uv](https://docs.astral.sh/uv/) (for the Python server):
   - **macOS / Linux:** `curl -LsSf https://astral.sh/uv/install.sh | sh`
   - **Windows (PowerShell):** `powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"`
+  - **Prefer your package manager?** `uv` is a popular open-source tool packaged in
+    most distro repos, so you don't have to pipe a script from the web:
+    - **Arch:** `sudo pacman -S uv`
+    - **Debian / Ubuntu:** `sudo apt install uv` (older releases: `pipx install uv` or the script above)
+    - **Fedora:** `sudo dnf install uv`
+    - **macOS (Homebrew):** `brew install uv`
   - Other options: [uv install docs](https://docs.astral.sh/uv/getting-started/installation/)
 - An MCP client ([Claude Code](https://docs.anthropic.com/en/docs/claude-code) | [Codex](https://openai.com/index/codex/) | [Antigravity](https://www.antigravity.dev/))
 


### PR DESCRIPTION
## Summary

Closes #464.

The Prerequisites section only offered the `curl … | sh` / PowerShell `irm | iex` install scripts for `uv`. As the reporter noted, being told to pipe a script from a site that renders blank in a browser feels sketchy — and it's the kind of "just run this" step many users either skip or run uneasily.

`uv` is a popular open-source tool packaged in most distro repos, so this adds package-manager alternatives so users can install it from a source they already trust (and get automatic updates via their package manager):

- **Arch:** `sudo pacman -S uv`
- **Debian / Ubuntu:** `sudo apt install uv` (older releases: `pipx install uv` or the script)
- **Fedora:** `sudo dnf install uv`
- **macOS (Homebrew):** `brew install uv`

The existing script commands and the upstream install-docs link are kept unchanged.

## Testing

Docs-only change. No code paths touched.

https://claude.ai/code/session_01Jq5X4ivngAf1N6r5UX2BVw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jq5X4ivngAf1N6r5UX2BVw)_