### PR TITLE
fix(game_eval): cap eval readiness wait below the server command timeout (#500)

### DIFF
--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -34,10 +34,12 @@ const GAME_READY_WAIT_SEC := 20.0
 ## issuing a game_eval. This is deliberately MUCH shorter than the 20s
 ## screenshot wait above: the eval path's total editor-side budget is this wait
 ## plus the 10s eval backstop (request_game_eval's timeout_sec), and that total
-## MUST stay below the server-side game_eval command timeout (15s, see
-## handlers/editor.py::game_eval / dispatcher.gd's 15000ms game_eval budget).
+## MUST stay below the 15s game_eval timeout enforced at two layers: the Python
+## server's send_command budget (src/godot_ai/handlers/editor.py::game_eval) and
+## this plugin's own deferred budget (dispatcher.gd's 15000ms game_eval entry,
+## editor/plugin-side — not server-side). Either firing produces the opaque tail.
 ## With the 20s screenshot wait, a not-yet-ready game made the editor poll past
-## the 15s server deadline, so the server gave up first with an opaque
+## the 15s deadline, so the server gave up first with an opaque
 ## ~15s TimeoutError instead of the actionable "Is the game actually running?"
 ## error below ever reaching the client (#500's residual TimeoutError bucket).
 ## 3s wait + 10s backstop = 13s, comfortably under the 15s server timeout, so
@@ -432,7 +434,7 @@ func _wait_then_eval(
 		await tree.process_frame
 	if not is_game_capture_ready():
 		_send_error(connection, request_id, ErrorCodes.INTERNAL_ERROR,
-			"Game-side autoload never registered its debugger capture within %ds. Is the game actually running? Start it with project_run / the editor's Play button, then retry." % int(EVAL_READY_WAIT_SEC))
+			"Game-side autoload never registered its debugger capture within %ds. Is the game actually running? Start it with project_run / the editor's Play button, then retry. If it IS running, check Project Settings → Autoload for _mcp_game_helper (added automatically when the plugin is enabled)." % int(EVAL_READY_WAIT_SEC))
 		return
 	_send_eval(tree, code, request_id, connection, timeout_sec)
 

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -432,7 +432,7 @@ func _wait_then_eval(
 		await tree.process_frame
 	if not is_game_capture_ready():
 		_send_error(connection, request_id, ErrorCodes.INTERNAL_ERROR,
-			"Game-side autoload never registered its debugger capture within %ds. Is the game actually running? Start it with play_scene / the editor's Play button, then retry." % int(EVAL_READY_WAIT_SEC))
+			"Game-side autoload never registered its debugger capture within %ds. Is the game actually running? Start it with project_run / the editor's Play button, then retry." % int(EVAL_READY_WAIT_SEC))
 		return
 	_send_eval(tree, code, request_id, connection, timeout_sec)
 

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -30,6 +30,21 @@ const DEFAULT_TIMEOUT_SEC := 8.0
 ## silent black hole. On CI the game subprocess has been observed
 ## taking ~15s to boot + register.
 const GAME_READY_WAIT_SEC := 20.0
+## #500: how long to wait for the game-side autoload to beacon mcp:hello before
+## issuing a game_eval. This is deliberately MUCH shorter than the 20s
+## screenshot wait above: the eval path's total editor-side budget is this wait
+## plus the 10s eval backstop (request_game_eval's timeout_sec), and that total
+## MUST stay below the server-side game_eval command timeout (15s, see
+## handlers/editor.py::game_eval / dispatcher.gd's 15000ms game_eval budget).
+## With the 20s screenshot wait, a not-yet-ready game made the editor poll past
+## the 15s server deadline, so the server gave up first with an opaque
+## ~15s TimeoutError instead of the actionable "Is the game actually running?"
+## error below ever reaching the client (#500's residual TimeoutError bucket).
+## 3s wait + 10s backstop = 13s, comfortably under the 15s server timeout, so
+## the actionable error always wins. A game launched moments before the eval
+## still has the 3s grace to register; if it needs longer, the user gets a fast,
+## clear "is it running?" rather than a 15s hang.
+const EVAL_READY_WAIT_SEC := 3.0
 ## #490: how long to wait for the game's mcp:eval_compiled beacon before
 ## concluding the eval source failed to compile. A parse error aborts the
 ## game-side handler before it can reply, so without this we'd wait the
@@ -370,6 +385,13 @@ func _clear_pending(request_id: String) -> void:
 ## and its message (the timeout_callable below) is intentionally generic. Drop
 ## timeout_sec at/below 8s and it pre-empts the game's actionable "Eval
 ## exceeded 8s" message — see the TIMEOUT ORDERING note on EVAL_TIMEOUT_SEC.
+##
+## #500: the *not-ready* path adds EVAL_READY_WAIT_SEC (3s) on top of this 10s
+## backstop. That sum (13s) must also stay below the dispatcher/server 15s
+## budget, or a not-yet-ready game makes the server time out opaquely before
+## the editor's actionable error returns — which is exactly the residual ~15s
+## TimeoutError bucket #500 tracked down. Keep EVAL_READY_WAIT_SEC + timeout_sec
+## < 15s if you tune either.
 func request_game_eval(
 	code: String,
 	request_id: String,
@@ -402,12 +424,15 @@ func _wait_then_eval(
 	connection: McpConnection,
 	timeout_sec: float,
 ) -> void:
-	var deadline := Time.get_ticks_msec() + int(GAME_READY_WAIT_SEC * 1000.0)
+	## #500: eval uses EVAL_READY_WAIT_SEC (not the 20s GAME_READY_WAIT_SEC) so
+	## the not-ready path returns its actionable error before the 15s server-side
+	## command timeout fires an opaque TimeoutError. See EVAL_READY_WAIT_SEC.
+	var deadline := Time.get_ticks_msec() + int(EVAL_READY_WAIT_SEC * 1000.0)
 	while not is_game_capture_ready() and Time.get_ticks_msec() < deadline:
 		await tree.process_frame
 	if not is_game_capture_ready():
 		_send_error(connection, request_id, ErrorCodes.INTERNAL_ERROR,
-			"Game-side autoload never registered its debugger capture within %ds. Is the game actually running?" % int(GAME_READY_WAIT_SEC))
+			"Game-side autoload never registered its debugger capture within %ds. Is the game actually running? Start it with play_scene / the editor's Play button, then retry." % int(EVAL_READY_WAIT_SEC))
 		return
 	_send_eval(tree, code, request_id, connection, timeout_sec)
 


### PR DESCRIPTION
## Summary

Addresses the residual **`TimeoutError` ~15s** bucket in #500 (the larger of the two long-timeout slices the telemetry flagged post-2.5.10).

### Root cause

The `game_eval` editor-side path (`mcp_debugger_plugin.gd::request_game_eval` → `_wait_then_eval`) reused `GAME_READY_WAIT_SEC = 20.0` — a wait tuned for the **screenshot** path, where a freshly launched game subprocess can take ~15s to boot and render a first frame.

But the eval path's total editor-side budget is `ready_wait + eval_backstop (10s)`, and the **server-side `game_eval` command timeout is 15s** (`handlers/editor.py::game_eval`, mirrored by the dispatcher's 15000 ms `game_eval` budget). With a 20s readiness wait, a game that isn't running/ready makes the editor poll *past* the 15s server deadline, so the server gives up first with an **opaque `TimeoutError`** — the editor's actionable "Is the game actually running?" error never reaches the client.

This matches #500's hypothesis exactly: a hang path where "the eval request never reaches `game_helper.gd`, or no game is running," so only the outer server-side timeout catches it.

### Fix

Give eval its own `EVAL_READY_WAIT_SEC = 3.0` instead of inheriting the 20s screenshot wait:

- **Editor-side worst case is now 3s + 10s backstop = 13s**, comfortably under the 15s server timeout, so the fast, actionable error always wins the race instead of an opaque 15s `TimeoutError`.
- A game launched moments before the eval still has a 3s grace to register its `mcp:hello`; if it needs longer, the user gets a fast "is it running? start it and retry" message rather than a 15s hang.
- The 20s `GAME_READY_WAIT_SEC` is unchanged for the screenshot path (which genuinely needs the longer boot window and whose 8s send timeout sits differently).

The TIMEOUT ORDERING comments are updated to document the new invariant: `EVAL_READY_WAIT_SEC + eval backstop < server command timeout`.

### Scope / notes

- **The `INTERNAL_ERROR` ~10s bucket** in #500 is the editor-side eval backstop firing on a genuinely stuck/frozen eval (e.g. a backgrounded play-in-editor game with a frozen idle loop, or an infinite loop). That path is already *actionable* (it returns the "compiled and started running but never returned… likely an infinite loop or never-firing await" message), so this PR leaves it as-is — the opaque `TimeoutError` bucket was the higher-value target.
- `game_command` (`_wait_then_game_command`) shares the same 20s-wait-vs-15s-command-timeout relationship and could get the same treatment, but it isn't in #500's telemetry, so I've kept this change scoped to `game_eval`. Happy to extend if desired.
- Final confirmation against the telemetry logs (which path each residual failure took) is still the issue's investigative ask and needs the maintainers' data — this PR closes the most likely opaque-timeout path.

## Testing

- `script/ci-check-gdscript` → **All GDScript files OK** (parse-clean on the import pass).
- Behavioral change is timing-only; logic paths (ready check, send, backstop, grace timer) are unchanged.

https://claude.ai/code/session_01Jq5X4ivngAf1N6r5UX2BVw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jq5X4ivngAf1N6r5UX2BVw)_