### PR TITLE
fix: use update_file() instead of full scan() on single-file writes (prevents EditorFileSystem global-class SIGABRT)

### DIFF
--- a/plugin/addons/godot_ai/handlers/filesystem_handler.gd
+++ b/plugin/addons/godot_ai/handlers/filesystem_handler.gd
@@ -57,8 +57,13 @@ func write_file(params: Dictionary) -> Dictionary:
 	file.store_string(content)
 	file.close()
 
-	# Trigger reimport so the editor recognises the new/changed file
-	EditorInterface.get_resource_filesystem().scan()
+	# Single-file register, not a full scan() — a scan() per write stacks
+	# filesystem WorkerThreadPool tasks under concurrent writes and can SIGABRT
+	# in the global-class update (see dsarno/godot#6 and create_script in
+	# script_handler.gd). update_file() is what reimport()/material/theme use.
+	var efs := EditorInterface.get_resource_filesystem()
+	if efs != null:
+		efs.update_file(path)
 
 	var data := {
 		"path": path,

--- a/plugin/addons/godot_ai/handlers/script_handler.gd
+++ b/plugin/addons/godot_ai/handlers/script_handler.gd
@@ -50,8 +50,16 @@ func create_script(params: Dictionary) -> Dictionary:
 	file.store_string(content)
 	file.close()
 
-	# Trigger reimport so the editor recognises the new file
-	EditorInterface.get_resource_filesystem().scan()
+	# Register just this file with the editor instead of a full recursive
+	# scan(). A scan() per write stacks `update_scripts_classes` /
+	# `update_script_paths_documentation` WorkerThreadPool tasks under concurrent
+	# script creation ("Task ... already exists" / "!tasks.has(p_task)"), which
+	# races the global-class registry and can SIGABRT in
+	# ScriptServer::remove_global_class_by_path (see dsarno/godot#6).
+	# update_file() is the single-file path the rest of the plugin already uses.
+	var efs := EditorInterface.get_resource_filesystem()
+	if efs != null:
+		efs.update_file(path)
 
 	var data := {
 		"path": path,
@@ -206,7 +214,10 @@ func patch_script(params: Dictionary) -> Dictionary:
 	write.store_string(new_content)
 	write.close()
 
-	EditorInterface.get_resource_filesystem().scan()
+	# Single-file register, not a full scan() — see create_script (dsarno/godot#6).
+	var efs := EditorInterface.get_resource_filesystem()
+	if efs != null:
+		efs.update_file(path)
 
 	return {
 		"data": {


### PR DESCRIPTION
## Problem

`script_create`, `script_patch`, and filesystem `write_text` each triggered a **full recursive `EditorInterface.get_resource_filesystem().scan()`** per write. Under concurrent file creation (multiple MCP clients, or a stress run), these scans stack — the editor re-enqueues the `update_scripts_classes` / `update_script_paths_documentation` WorkerThreadPool tasks while a previous scan is still pending:

```
ERROR: Task 'update_scripts_classes' already exists.
ERROR: Task 'update_script_paths_documentation' already exists.
ERROR: Condition "!tasks.has(p_task)" is true.
```

…leaving the global-class registry inconsistent. The next idle filesystem scan can then **SIGABRT in `ScriptServer::remove_global_class_by_path()`** — a hard editor crash:

```
SIGABRT → abort
  ScriptServer::remove_global_class_by_path(String const&)
  EditorFileSystem::_register_global_class_script(...)
  EditorFileSystem::_update_script_classes()
  EditorFileSystem::_update_scan_actions()
  EditorFileSystem::_notification(int)
```

Engine-side record of the underlying abort: `dsarno/godot#6`.

## Fix

Switch all three sites to `EditorFileSystem.update_file(path)` — the single-file registration call **the rest of the plugin already uses** (material/theme handlers, filesystem `reimport`, `resource_io`). It registers just the written file without the recursive scan-action batch, so the duplicate-task race can't occur. It's also cheaper than a full project rescan per write.

## Validation (concurrency stress harness)

| | full `scan()` (before) | `update_file()` (after) |
|---|---|---|
| `Task ... already exists` / `!tasks.has(p_task)` | 5 + 5 per run | **0** |
| SIGABRT | intermittent (3 crash reports) | none across heavier runs |

- `create` → immediate `attach` still settles (`import_settled=true`) — **#261 import-settle behaviour preserved**.
- GDScript `script` (38) + `filesystem` (16) suites pass; Python import-settle (6) + script/filesystem unit tests (67) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)