### PR TITLE
docs(stormtest): Windows/cross-platform pathing heads-up (stacked on #510)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,6 +288,8 @@ SS_URL=http://127.0.0.1:8010/mcp .venv/bin/python script/stormtest.py  # target 
 
 To stress a *branch's* code (plugin + server), point a Godot editor at that worktree's `test_project/` and serve its `src/` via `script/serve-this-worktree` (external server, so `editor_reload_plugin` exercises reload without killing the server), then run stormtest against it. A full JSON snapshot lands in `$TMPDIR/stormtest_report.json` (override with `SS_REPORT`), flushed every few seconds so a crash/kill still leaves data. A small `EDITOR_NOT_READY` / `NODE_NOT_FOUND` / `CONNECTION` error rate is expected noise under concurrency + reloads — watch instead for the process dying, a reload that never recovers, or one op with pathological error/latency.
 
+On Windows, a reads-dominant run (`SS_RELOAD=0`) works, but **reload churn (`SS_RELOAD=1`, the default) currently wedges the harness** and the external-server mitigation doesn't apply (`serve-this-worktree` is bash-only; a hand-started external `--reload` server gets killed by the reload). The editor itself survives reloads — only the harness hangs. Use `.venv\Scripts\python.exe` and note `$TMPDIR` is `%TEMP%`. See the "Windows / cross-platform notes" callout in `docs/STRESS_TESTING.md` (issues #513 / #514; resilience tracked in #509).
+
 **Guardrails built into the test runner:**
 - **Zero-assertion detection**: Tests that complete with 0 assertions are flagged as failures ("Test completed with 0 assertions — likely skipped its logic"). This catches tests that silently `return` before asserting anything.
 - **Resilient discovery**: If a `.gd` file fails to load (parse error, duplicate method, wrong base class), the rest of the suites still run and the failing files are reported in `load_errors`.

--- a/docs/STRESS_TESTING.md
+++ b/docs/STRESS_TESTING.md
@@ -63,6 +63,43 @@ SS_RELOAD=0 SS_WORKERS=4 SS_WAVES=3 .venv/bin/python script/stormtest.py
 SS_URL=http://127.0.0.1:8010/mcp .venv/bin/python script/stormtest.py
 ```
 
+### Windows / cross-platform notes
+
+> ⚠️ **Running on Windows? Reads/writes work; reload churn does not (yet).**
+>
+> **Concurrent reads/writes are fine.** The harness *logic* is platform-agnostic:
+> the in-editor scratch paths (`res://_stormtest/…`) use Godot's virtual
+> filesystem, and the report path goes through `tempfile.gettempdir()` /
+> `os.path.join`, so both resolve correctly on every OS. A reads-dominant run
+> (`SS_RELOAD=0`) is clean on Windows.
+>
+> **Reload churn (`SS_RELOAD=1`, the default) currently does NOT work on Windows**
+> — two independent problems, both tracked:
+> - Against a plugin-managed server, the first `editor_reload_plugin` **wedges the
+>   harness**: the asyncio loop stalls past `CALL_TIMEOUT` when the server is
+>   killed mid-reload under concurrent load. The *editor* survives fine (it
+>   reloads and re-registers a new session) — only the harness hangs. See
+>   [#513](https://github.com/hi-godot/godot-ai/issues/513).
+> - The "run the server externally" mitigation **also fails on Windows**:
+>   `script/serve-this-worktree` is bash-only (no PowerShell port, and it never
+>   passes `--ws-port`), and even a hand-started external `--reload` server gets
+>   **killed by the reload** (`_stop_server` takes down the port owner with no
+>   respawn). See [#514](https://github.com/hi-godot/godot-ai/issues/514).
+>
+>   Until those land, validate reload survival on Windows with a *single-threaded*
+>   reload loop (reload → reconnect → confirm a new `session_id`) rather than the
+>   concurrent churn mode.
+>
+> **Invocation also differs (POSIX → Windows):**
+> - **venv interpreter** — use `.venv\Scripts\python.exe`, not `.venv/bin/python`.
+> - **`$TMPDIR`** in the examples is POSIX; the report lands in the platform temp
+>   dir (`%TEMP%` on Windows). Pass an explicit `SS_REPORT=…` for a known
+>   location, and prefer forward slashes (Python accepts them on Windows and they
+>   dodge backslash-escaping surprises).
+>
+> Making the tooling resilient enough to drop this heads-up is tracked in
+> [#509](https://github.com/hi-godot/godot-ai/issues/509).
+
 ### Knobs (env)
 
 | Var | Default | Meaning |


### PR DESCRIPTION
## Summary

Adds a **Windows / cross-platform pathing heads-up** for `stormtest` — a docs callout in `docs/STRESS_TESTING.md` plus a one-line pointer in `AGENTS.md`. No code changes.

The harness *logic* is already platform-agnostic (in-editor `res://_stormtest/…` scratch paths use Godot's virtual filesystem; the host-side report path goes through `tempfile.gettempdir()` / `os.path.join`). What's POSIX-only is the **invocation** — so the note flags, for agents running it on Windows:

- venv interpreter: `.venv\Scripts\python.exe`, not `.venv/bin/python`
- `script/serve-this-worktree` is bash → Git Bash / WSL, or start the `--reload` server by hand
- `$TMPDIR` → `%TEMP%`, with a forward-slash tip for an explicit `SS_REPORT`

The note advertises its own removal once the runner is made resilient, tracked in #509.

## ⚠️ Stacked on #510 — merge after it

`docs/STRESS_TESTING.md` and the AGENTS.md stress section are introduced by **#510** (the stormtest harness), which isn't on `main` yet. This branch is based on `test/stormtest-harness`, so **until #510 merges this PR's diff will also show #510's harness files**; once #510 lands in `main`, the diff here collapses to just the ~23-line note. Please **merge #510 first, then this.**

Context: this is the rescued note from the now-closed integration branch #506 — kept off #510 itself to leave that PR clean, per request.

https://claude.ai/code/session_01Jq5X4ivngAf1N6r5UX2BVw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jq5X4ivngAf1N6r5UX2BVw)_