### PR TITLE
[#509] Cross-platform stormtest + serve-this-worktree pathing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ AI Client → MCP (stdio/sse/streamable-http) → Python FastMCP server → WebS
   - `integration/` — WebSocket server + mock Godot plugin, MCP tools, rollups
 - `script/` — dev and CI scripts
   - `setup-dev` / `setup-dev.ps1` / `verify-worktree` — dev environment + worktree health
-  - `serve-this-worktree` / `open-godot-here` — point dev server / editor at the current worktree
+  - `serve-this-worktree` (bash) / `serve-this-worktree.py` (cross-platform) / `open-godot-here` — point dev server / editor at the current worktree
   - `local-self-update-smoke` — interactive local fixture for self-update changes
   - `ci-start-server`, `ci-godot-tests`, `ci-reload-test`, `ci-quit-test`, `ci-check-gdscript` — CI scripts
   - `ci-find-regression-range` — helper for identifying CI regression windows
@@ -93,7 +93,7 @@ Assistant sessions may run in git worktrees. Claude Code commonly uses `.claude/
 
 - **File paths**: Your working directory is the worktree, not the repo root. Files you create live in that worktree.
 - **Godot editor**: The editor runs against a specific worktree's `test_project/`. The plugin is symlinked from that worktree's `plugin/` directory. Check `session_list` — the `project_path` field tells you which worktree the editor is using.
-- **Dev server**: The plugin-managed server (auto-spawned on editor start, no `--reload`) uses the root repo's `.venv` and `src/`. Python code changes in a worktree won't take effect there unless the root repo also has them. Two ways to serve the worktree's own Python source: (a) click **Start Dev Server** in the dock — it walks up from `res://` to find a sibling `src/godot_ai/` and auto-sets `PYTHONPATH` to that tree's `src/` before spawning `--reload`; (b) run `script/serve-this-worktree` from a terminal for the same effect outside the editor.
+- **Dev server**: The plugin-managed server (auto-spawned on editor start, no `--reload`) uses the root repo's `.venv` and `src/`. Python code changes in a worktree won't take effect there unless the root repo also has them. Two ways to serve the worktree's own Python source: (a) click **Start Dev Server** in the dock — it walks up from `res://` to find a sibling `src/godot_ai/` and auto-sets `PYTHONPATH` to that tree's `src/` before spawning `--reload`; (b) run `script/serve-this-worktree` (POSIX) or `python script/serve-this-worktree.py` (any OS) from a terminal for the same effect outside the editor.
 - **Passing info between sessions**: When writing prompts, handoff notes, or file references intended for another session, **always include the full worktree path** or specify the worktree name. Relative paths like `docs/friction-log.md` are ambiguous — a different session may be in a different worktree or on `main`. Use the absolute path.
 - **Merging**: Worktree branches must be merged to `main` and pulled into other worktrees for changes to propagate. The plugin symlink means GDScript changes propagate within the same worktree immediately, but not across worktrees.
 
@@ -280,15 +280,18 @@ Test suites extend `McpTestSuite` (assertion methods: `assert_true`, `assert_eq`
 `stormtest` opens many concurrent MCP clients and fires rapid, randomized tool calls across **every** domain at a live editor, with periodic `editor_reload_plugin` churn mixed in. It's a robustness test, not a correctness test: it answers "does the editor + plugin + WebSocket dispatcher + server survive sustained concurrent abuse and reload cycles without crashing?" and surfaces per-tool latency/error hot-spots. Use it after changes to the dispatcher, transport, readiness gating, session routing, or the reload/handoff path. Full reference: `docs/STRESS_TESTING.md`.
 
 ```bash
-.venv/bin/python script/stormtest.py                       # ≈ 1000 calls, with reload churn
-SS_WORKERS=12 SS_WAVES=30 .venv/bin/python script/stormtest.py   # brutal ≈ 9000 calls
-SS_RELOAD=0 .venv/bin/python script/stormtest.py           # reads-only smoke, no reloads
-SS_URL=http://127.0.0.1:8010/mcp .venv/bin/python script/stormtest.py  # target another stack
+python script/stormtest.py                       # ≈ 1000 calls, with reload churn
+SS_WORKERS=12 SS_WAVES=30 python script/stormtest.py   # brutal ≈ 9000 calls
+SS_RELOAD=0 python script/stormtest.py           # reads-only smoke, no reloads
+SS_URL=http://127.0.0.1:8010/mcp python script/stormtest.py  # target another stack
 ```
 
-To stress a *branch's* code (plugin + server), point a Godot editor at that worktree's `test_project/` and serve its `src/` via `script/serve-this-worktree` (external server, so `editor_reload_plugin` exercises reload without killing the server), then run stormtest against it. A full JSON snapshot lands in `$TMPDIR/stormtest_report.json` (override with `SS_REPORT`), flushed every few seconds so a crash/kill still leaves data. A small `EDITOR_NOT_READY` / `NODE_NOT_FOUND` / `CONNECTION` error rate is expected noise under concurrency + reloads — watch instead for the process dying, a reload that never recovers, or one op with pathological error/latency.
+(`python script/stormtest.py` re-execs into the project `.venv` on every OS;
+`SS_NO_REEXEC=1` opts out.)
 
-On Windows, a reads-dominant run (`SS_RELOAD=0`) works, but **reload churn (`SS_RELOAD=1`, the default) currently wedges the harness** and the external-server mitigation doesn't apply (`serve-this-worktree` is bash-only; a hand-started external `--reload` server gets killed by the reload). The editor itself survives reloads — only the harness hangs. Use `.venv\Scripts\python.exe` and note `$TMPDIR` is `%TEMP%`. See the "Windows / cross-platform notes" callout in `docs/STRESS_TESTING.md` (issues #513 / #514; resilience tracked in #509).
+To stress a *branch's* code (plugin + server), point a Godot editor at that worktree's `test_project/` and serve its `src/` via `script/serve-this-worktree` (POSIX) or `python script/serve-this-worktree.py` (any OS) — an external server, so `editor_reload_plugin` exercises reload without killing the server — then run stormtest against it. A full JSON snapshot lands in `$TMPDIR/stormtest_report.json` (override with `SS_REPORT`), flushed every few seconds so a crash/kill still leaves data. A small `EDITOR_NOT_READY` / `NODE_NOT_FOUND` / `CONNECTION` error rate is expected noise under concurrency + reloads — watch instead for the process dying, a reload that never recovers, or one op with pathological error/latency.
+
+On Windows, `python script/stormtest.py` re-execs into the `.venv` automatically (no `.venv\Scripts\python.exe` step) and `python script/serve-this-worktree.py` serves a worktree without bash. A reads-dominant run (`SS_RELOAD=0`) works, but **reload churn (`SS_RELOAD=1`, the default) still wedges the harness** and a hand-started external `--reload` server still gets killed by the reload. The editor itself survives reloads — only the harness hangs; note `$TMPDIR` is `%TEMP%`. See the "Windows / cross-platform notes" callout in `docs/STRESS_TESTING.md` (issues #513 / #514).
 
 **Guardrails built into the test runner:**
 - **Zero-assertion detection**: Tests that complete with 0 assertions are flagged as failures ("Test completed with 0 assertions — likely skipped its logic"). This catches tests that silently `return` before asserting anything.

--- a/docs/STRESS_TESTING.md
+++ b/docs/STRESS_TESTING.md
@@ -44,28 +44,41 @@ under load and across the disable→extract→enable reload window.
 
 ## Running
 
-The target editor's MCP server must be reachable (default `:8000`). For a true
-test of a branch's code, point the editor at that branch's worktree and serve
-that worktree's `src/` (see `script/serve-this-worktree`), so both the GDScript
-plugin and the Python server are the code under test.
+The target editor's MCP server must be reachable (default `:8000`). `python
+script/stormtest.py` works on every OS — it re-execs into the project `.venv`
+automatically, so there's no `.venv/bin/python` vs `.venv\Scripts\python.exe`
+split (override with `SS_NO_REEXEC=1`). For a true test of a branch's code,
+point the editor at that branch's worktree and serve that worktree's `src/`
+(`python script/serve-this-worktree.py`, or `script/serve-this-worktree` on
+POSIX), so both the GDScript plugin and the Python server are the code under
+test.
 
 ```bash
 # default ≈ 1000 calls, with reload churn, against localhost:8000
-.venv/bin/python script/stormtest.py
+python script/stormtest.py
 
 # brutal ≈ 9000 calls
-SS_WORKERS=12 SS_WAVES=30 .venv/bin/python script/stormtest.py
+SS_WORKERS=12 SS_WAVES=30 python script/stormtest.py
 
 # reads-only smoke, no reloads
-SS_RELOAD=0 SS_WORKERS=4 SS_WAVES=3 .venv/bin/python script/stormtest.py
+SS_RELOAD=0 SS_WORKERS=4 SS_WAVES=3 python script/stormtest.py
 
 # target a server on another port / host
-SS_URL=http://127.0.0.1:8010/mcp .venv/bin/python script/stormtest.py
+SS_URL=http://127.0.0.1:8010/mcp python script/stormtest.py
 ```
 
 ### Windows / cross-platform notes
 
 > ⚠️ **Running on Windows? Reads/writes work; reload churn does not (yet).**
+>
+> **Invocation is now identical on every OS.** `python script/stormtest.py`
+> re-execs into the project `.venv` automatically (override with
+> `SS_NO_REEXEC=1`), and `python script/serve-this-worktree.py` is a
+> cross-platform (no-`bash`/no-`lsof`) way to serve a worktree's `src/` with
+> `--reload` — extra args like `--ws-port` pass straight through. The report
+> still lands in the platform temp dir (`%TEMP%` on Windows); pass an explicit
+> `SS_REPORT=…` for a known location, and prefer forward slashes (Python accepts
+> them on Windows and they dodge backslash-escaping surprises).
 >
 > **Concurrent reads/writes are fine.** The harness *logic* is platform-agnostic:
 > the in-editor scratch paths (`res://_stormtest/…`) use Godot's virtual
@@ -73,32 +86,22 @@ SS_URL=http://127.0.0.1:8010/mcp .venv/bin/python script/stormtest.py
 > `os.path.join`, so both resolve correctly on every OS. A reads-dominant run
 > (`SS_RELOAD=0`) is clean on Windows.
 >
-> **Reload churn (`SS_RELOAD=1`, the default) currently does NOT work on Windows**
-> — two independent problems, both tracked:
+> **Reload churn (`SS_RELOAD=1`, the default) still does NOT work on Windows** —
+> two independent problems, both tracked, and *not* addressed by the pathing work
+> above:
 > - Against a plugin-managed server, the first `editor_reload_plugin` **wedges the
 >   harness**: the asyncio loop stalls past `CALL_TIMEOUT` when the server is
 >   killed mid-reload under concurrent load. The *editor* survives fine (it
 >   reloads and re-registers a new session) — only the harness hangs. See
 >   [#513](https://github.com/hi-godot/godot-ai/issues/513).
-> - The "run the server externally" mitigation **also fails on Windows**:
->   `script/serve-this-worktree` is bash-only (no PowerShell port, and it never
->   passes `--ws-port`), and even a hand-started external `--reload` server gets
->   **killed by the reload** (`_stop_server` takes down the port owner with no
->   respawn). See [#514](https://github.com/hi-godot/godot-ai/issues/514).
+> - The "run the server externally" mitigation still doesn't fully hold: even a
+>   correctly-launched external `--reload` server gets **killed by the reload**
+>   (`_stop_server` takes down the port owner with no respawn). See
+>   [#514](https://github.com/hi-godot/godot-ai/issues/514).
 >
 >   Until those land, validate reload survival on Windows with a *single-threaded*
 >   reload loop (reload → reconnect → confirm a new `session_id`) rather than the
 >   concurrent churn mode.
->
-> **Invocation also differs (POSIX → Windows):**
-> - **venv interpreter** — use `.venv\Scripts\python.exe`, not `.venv/bin/python`.
-> - **`$TMPDIR`** in the examples is POSIX; the report lands in the platform temp
->   dir (`%TEMP%` on Windows). Pass an explicit `SS_REPORT=…` for a known
->   location, and prefer forward slashes (Python accepts them on Windows and they
->   dodge backslash-escaping surprises).
->
-> Making the tooling resilient enough to drop this heads-up is tracked in
-> [#509](https://github.com/hi-godot/godot-ai/issues/509).
 
 ### Knobs (env)
 
@@ -146,6 +149,7 @@ comes back** (managed-server-killed; recovery time unbounded), or one op with a
 **pathologically high error rate or latency** that points at a real regression.
 
 > If the target server is plugin-managed (auto-spawned), a reload may kill it
-> and not return — run the server **externally** (e.g. `serve-this-worktree`,
-> which uses `--reload`) so `editor_reload_plugin` exercises the plugin reload
-> without taking the server down with it.
+> and not return — run the server **externally** (`python
+> script/serve-this-worktree.py`, or `script/serve-this-worktree` on POSIX; both
+> use `--reload`) so `editor_reload_plugin` exercises the plugin reload without
+> taking the server down with it.

--- a/docs/STRESS_TESTING.md
+++ b/docs/STRESS_TESTING.md
@@ -80,6 +80,11 @@ SS_URL=http://127.0.0.1:8010/mcp python script/stormtest.py
 > `SS_REPORT=…` for a known location, and prefer forward slashes (Python accepts
 > them on Windows and they dodge backslash-escaping surprises).
 >
+> The `SS_*` knob examples below use the POSIX `SS_FOO=… python …` inline-env
+> prefix, which PowerShell doesn't parse. In PowerShell, set the var first:
+> `$env:SS_RELOAD=0; python script/stormtest.py` (clear it afterward with
+> `Remove-Item Env:\SS_RELOAD`).
+>
 > **Concurrent reads/writes are fine.** The harness *logic* is platform-agnostic:
 > the in-editor scratch paths (`res://_stormtest/…`) use Godot's virtual
 > filesystem, and the report path goes through `tempfile.gettempdir()` /

--- a/script/_dev_env.py
+++ b/script/_dev_env.py
@@ -126,28 +126,30 @@ def extract_port(argv: list[str], default: int = 8000) -> tuple[int, list[str]]:
 
     Returns ``(port, remaining_args)`` with the port flag removed, so the caller
     can pass the port explicitly (and free it) without duplicating the flag.
+    Raises ``ValueError`` on a missing or non-integer value — fail fast rather
+    than silently fall back to ``default`` and start on the wrong port.
     """
     port = default
     rest: list[str] = []
     i = 0
     while i < len(argv):
         arg = argv[i]
-        if arg == "--port" and i + 1 < len(argv):
-            try:
-                port = int(argv[i + 1])
-            except ValueError:
-                pass
+        if arg == "--port":
+            if i + 1 >= len(argv):
+                raise ValueError("--port requires an integer value")
+            value = argv[i + 1]
             i += 2
-            continue
-        if arg.startswith("--port="):
-            try:
-                port = int(arg.split("=", 1)[1])
-            except ValueError:
-                pass
+        elif arg.startswith("--port="):
+            value = arg.split("=", 1)[1]
+            i += 1
+        else:
+            rest.append(arg)
             i += 1
             continue
-        rest.append(arg)
-        i += 1
+        try:
+            port = int(value)
+        except ValueError:
+            raise ValueError(f"--port value must be an integer, got {value!r}") from None
     return port, rest
 
 

--- a/script/_dev_env.py
+++ b/script/_dev_env.py
@@ -152,13 +152,8 @@ def extract_port(argv: list[str], default: int = 8000) -> tuple[int, list[str]]:
 
 
 def parse_lsof_pids(output: str) -> list[int]:
-    """PIDs from ``lsof -ti`` output (one PID per line), de-duplicated."""
-    pids: list[int] = []
-    for token in output.split():
-        token = token.strip()
-        if token.isdigit() and int(token) not in pids:
-            pids.append(int(token))
-    return pids
+    """PIDs from ``lsof -ti`` output (one PID per line), de-duplicated in order."""
+    return list(dict.fromkeys(int(tok) for tok in output.split() if tok.isdigit()))
 
 
 def parse_netstat_pids(output: str, port: int) -> list[int]:
@@ -169,13 +164,11 @@ def parse_netstat_pids(output: str, port: int) -> list[int]:
         parts = line.split()
         if len(parts) < 5 or "LISTENING" not in parts:
             continue
-        local = parts[1]  # e.g. 0.0.0.0:8000 or [::]:8000
-        if not local.endswith(needle):
+        if not parts[1].endswith(needle):  # local addr, e.g. 0.0.0.0:8000 or [::]:8000
             continue
-        pid = parts[-1]
-        if pid.isdigit() and int(pid) not in pids:
-            pids.append(int(pid))
-    return pids
+        if parts[-1].isdigit():
+            pids.append(int(parts[-1]))
+    return list(dict.fromkeys(pids))
 
 
 def _port_listening(port: int) -> bool:

--- a/script/_dev_env.py
+++ b/script/_dev_env.py
@@ -172,9 +172,17 @@ def parse_netstat_pids(output: str, port: int) -> list[int]:
 
 
 def _port_listening(port: int) -> bool:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.settimeout(0.5)
-        return sock.connect_ex(("127.0.0.1", port)) == 0
+    # Check both families: a dev server (esp. on Windows, where sockets are
+    # commonly IPv6-only — see #511) may be bound to ::1 rather than 127.0.0.1.
+    for family, host in ((socket.AF_INET, "127.0.0.1"), (socket.AF_INET6, "::1")):
+        try:
+            with socket.socket(family, socket.SOCK_STREAM) as sock:
+                sock.settimeout(0.5)
+                if sock.connect_ex((host, port)) == 0:
+                    return True
+        except OSError:
+            continue
+    return False
 
 
 def _listener_pids(port: int) -> list[int]:

--- a/script/_dev_env.py
+++ b/script/_dev_env.py
@@ -1,0 +1,228 @@
+"""Shared cross-platform helpers for the dev scripts (stormtest, serve-this-worktree).
+
+POSIX/Windows differences — the venv interpreter layout (``bin/python`` vs
+``Scripts\\python.exe``) and port freeing (``lsof`` vs ``netstat``/``taskkill``)
+— are resolved here so the *documented* commands are identical on every OS and
+no script carries a hard ``bash``/``lsof`` dependency. See issue #509.
+
+stdlib-only and side-effect-free on import, so it is safe to import from a test
+or before a script re-execs into the venv.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+# --------------------------------------------------------------------------- #
+# venv interpreter resolution
+# --------------------------------------------------------------------------- #
+def venv_python(venv_dir: Path, *, windows: bool | None = None) -> Path:
+    """Interpreter path inside ``venv_dir`` for the target OS.
+
+    ``windows`` defaults to the current platform; pass it explicitly to resolve
+    the other layout (used by tests so the Windows branch is covered on POSIX CI).
+    """
+    if windows is None:
+        windows = os.name == "nt"
+    if windows:
+        return venv_dir / "Scripts" / "python.exe"
+    return venv_dir / "bin" / "python"
+
+
+def _git(args: list[str], cwd: Path) -> str | None:
+    """Run a read-only git command, returning trimmed stdout or ``None`` on error."""
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(cwd), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return out.stdout.strip() or None
+
+
+def worktree_root(start: Path | None = None) -> Path:
+    """Top of the current git worktree; falls back to this file's repo root."""
+    start = start or Path.cwd()
+    top = _git(["rev-parse", "--show-toplevel"], start)
+    if top:
+        return Path(top)
+    # script/_dev_env.py -> repo root
+    return Path(__file__).resolve().parent.parent
+
+
+def _root_from_common_dir(worktree: Path, common_dir: str) -> Path:
+    """Parent of the git common dir (the main repo that owns the shared .venv)."""
+    common = Path(common_dir)
+    if not common.is_absolute():
+        common = (worktree / common).resolve()
+    return common.parent
+
+
+def root_repo(worktree: Path | None = None) -> Path:
+    """Main repo dir holding the shared ``.venv`` (handles git worktrees).
+
+    In a worktree the ``.venv`` lives in the main checkout, not the worktree, so
+    ``git rev-parse --git-common-dir`` (whose parent is the main repo) is used to
+    find it. On the main checkout this collapses to the worktree itself.
+    """
+    wt = worktree or worktree_root()
+    common = _git(["rev-parse", "--git-common-dir"], wt)
+    if common:
+        return _root_from_common_dir(wt, common)
+    return wt
+
+
+def worktree_src(worktree: Path | None = None) -> Path:
+    """The ``src/`` directory of the given (or current) worktree."""
+    return (worktree or worktree_root()) / "src"
+
+
+def find_venv_python(worktree: Path | None = None) -> Path | None:
+    """Locate the checkout's venv interpreter, or ``None`` if it doesn't exist."""
+    candidate = venv_python(root_repo(worktree) / ".venv")
+    return candidate if candidate.exists() else None
+
+
+def reexec_into_venv(*, guard_env: str, opt_out_env: str | None = None) -> None:
+    """Re-exec the current script under the project venv interpreter.
+
+    No-op when: the venv is absent, we're already running it, ``guard_env`` is
+    set (re-exec already happened, so we never loop), or ``opt_out_env`` is set.
+    Lets a script's documented invocation be ``python <script>`` on every OS — it
+    hops into the venv itself instead of the caller naming ``bin/python`` vs
+    ``Scripts\\python.exe``.
+    """
+    if os.environ.get(guard_env):
+        return
+    if opt_out_env and os.environ.get(opt_out_env):
+        return
+    target = find_venv_python()
+    if target is None:
+        return
+    try:
+        if target.resolve() == Path(sys.executable).resolve():
+            return
+    except OSError:
+        return
+    os.environ[guard_env] = "1"
+    os.execv(str(target), [str(target), *sys.argv])
+
+
+# --------------------------------------------------------------------------- #
+# port freeing (replace a plugin-spawned server instead of stacking on it)
+# --------------------------------------------------------------------------- #
+def extract_port(argv: list[str], default: int = 8000) -> tuple[int, list[str]]:
+    """Pull ``--port N`` / ``--port=N`` out of ``argv``.
+
+    Returns ``(port, remaining_args)`` with the port flag removed, so the caller
+    can pass the port explicitly (and free it) without duplicating the flag.
+    """
+    port = default
+    rest: list[str] = []
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg == "--port" and i + 1 < len(argv):
+            try:
+                port = int(argv[i + 1])
+            except ValueError:
+                pass
+            i += 2
+            continue
+        if arg.startswith("--port="):
+            try:
+                port = int(arg.split("=", 1)[1])
+            except ValueError:
+                pass
+            i += 1
+            continue
+        rest.append(arg)
+        i += 1
+    return port, rest
+
+
+def parse_lsof_pids(output: str) -> list[int]:
+    """PIDs from ``lsof -ti`` output (one PID per line), de-duplicated."""
+    pids: list[int] = []
+    for token in output.split():
+        token = token.strip()
+        if token.isdigit() and int(token) not in pids:
+            pids.append(int(token))
+    return pids
+
+
+def parse_netstat_pids(output: str, port: int) -> list[int]:
+    """Listener PIDs for ``port`` from Windows ``netstat -ano`` output."""
+    needle = f":{port}"
+    pids: list[int] = []
+    for line in output.splitlines():
+        parts = line.split()
+        if len(parts) < 5 or "LISTENING" not in parts:
+            continue
+        local = parts[1]  # e.g. 0.0.0.0:8000 or [::]:8000
+        if not local.endswith(needle):
+            continue
+        pid = parts[-1]
+        if pid.isdigit() and int(pid) not in pids:
+            pids.append(int(pid))
+    return pids
+
+
+def _port_listening(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(0.5)
+        return sock.connect_ex(("127.0.0.1", port)) == 0
+
+
+def _listener_pids(port: int) -> list[int]:
+    try:
+        if os.name == "nt":
+            out = subprocess.run(
+                ["netstat", "-ano", "-p", "tcp"],
+                capture_output=True,
+                text=True,
+            ).stdout
+            return parse_netstat_pids(out, port)
+        out = subprocess.run(
+            ["lsof", "-ti", f"tcp:{port}", "-sTCP:LISTEN"],
+            capture_output=True,
+            text=True,
+        ).stdout
+        return parse_lsof_pids(out)
+    except (OSError, subprocess.SubprocessError):
+        return []
+
+
+def _kill_pid(pid: int) -> None:
+    try:
+        if os.name == "nt":
+            subprocess.run(["taskkill", "/F", "/PID", str(pid)], capture_output=True)
+        else:
+            os.kill(pid, signal.SIGTERM)
+    except (OSError, subprocess.SubprocessError):
+        pass
+
+
+def free_port(port: int) -> None:
+    """Best-effort: stop any process currently listening on ``port``.
+
+    Cross-platform replacement for the bash ``lsof | xargs kill`` dance. Silent
+    and non-fatal if the port is free or the listener can't be identified.
+    """
+    if not _port_listening(port):
+        return
+    print(f"Stopping existing listener on port {port}")
+    for pid in _listener_pids(port):
+        _kill_pid(pid)
+    # Give the socket a moment to release before the caller binds it.
+    time.sleep(1)

--- a/script/serve-this-worktree.py
+++ b/script/serve-this-worktree.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+r"""Serve the MCP dev server from *this worktree's* ``src/godot_ai`` (cross-platform).
+
+A non-bash companion to ``script/serve-this-worktree`` so the worktree dev-server
+flow works on Windows too (no ``bash``/``lsof`` dependency). It resolves this
+worktree's ``src/``, the root repo's shared ``.venv`` interpreter (``bin/python``
+on POSIX, ``Scripts\python.exe`` on Windows), frees the target port if a server
+is already squatting on it, prepends ``src/`` to ``PYTHONPATH`` and execs
+``python -m godot_ai --transport streamable-http --port <p> --reload``.
+
+Extra args pass straight through to the module, so a non-default WebSocket port
+works too::
+
+    python script/serve-this-worktree.py --port 18130 --ws-port 19630
+
+See issue #509.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# Make script/ importable so the shared dev-env helpers resolve regardless of cwd.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _dev_env import (  # noqa: E402
+    extract_port,
+    find_venv_python,
+    free_port,
+    worktree_root,
+    worktree_src,
+)
+
+
+def main(argv: list[str]) -> int:
+    worktree = worktree_root()
+    src = worktree_src(worktree)
+    if not src.is_dir():
+        print(f"error: {src} not found", file=sys.stderr)
+        return 1
+
+    venv_py = find_venv_python(worktree)
+    if venv_py is None:
+        print(
+            "error: project .venv interpreter not found — run script/setup-dev "
+            "(or script/setup-dev.ps1) in the root repo first",
+            file=sys.stderr,
+        )
+        return 1
+
+    port, passthrough = extract_port(argv, default=8000)
+    # Free the port so we replace any plugin-spawned server rather than stack on it.
+    free_port(port)
+
+    env = dict(os.environ)
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = str(src) + (os.pathsep + existing if existing else "")
+
+    print(f"Serving worktree: {worktree}")
+    print(f"Using venv:       {venv_py}")
+    print(f"PYTHONPATH:       {src}")
+
+    cmd = [
+        str(venv_py),
+        "-m",
+        "godot_ai",
+        "--transport",
+        "streamable-http",
+        "--port",
+        str(port),
+        "--reload",
+        *passthrough,
+    ]
+    os.execve(str(venv_py), cmd, env)
+    return 0  # unreachable; execve replaces the process
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/script/serve-this-worktree.py
+++ b/script/serve-this-worktree.py
@@ -50,7 +50,11 @@ def main(argv: list[str]) -> int:
         )
         return 1
 
-    port, passthrough = extract_port(argv, default=8000)
+    try:
+        port, passthrough = extract_port(argv, default=8000)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
     # Free the port so we replace any plugin-spawned server rather than stack on it.
     free_port(port)
 

--- a/script/stormtest.py
+++ b/script/stormtest.py
@@ -21,9 +21,10 @@ A full JSON snapshot is flushed to stormtest_report.json every few seconds so
 a crash or kill still leaves analyzable data (latency p50/p95/max + per-op
 error codes).
 
-Run against a running editor whose MCP server is on :8000:
+Run against a running editor whose MCP server is on :8000 (works on every OS —
+the script re-execs into the project .venv automatically):
 
-    .venv/bin/python script/stormtest.py
+    python script/stormtest.py
 
 Knobs (all env-overridable):
     SS_WORKERS   parallel client connections           (default 8)
@@ -45,11 +46,25 @@ import json
 import os
 import random
 import signal
+import sys
 import tempfile
 import time
 from collections import Counter, defaultdict
+from pathlib import Path
 
-from fastmcp import Client
+# Make script/ importable so the shared dev-env helpers resolve regardless of cwd.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+# Hop into the project venv interpreter before importing third-party deps, so the
+# documented command (`python script/stormtest.py`) is identical on every OS — no
+# `.venv/bin/python` vs `.venv\Scripts\python.exe` split. Opt out with
+# SS_NO_REEXEC=1. See issue #509.
+if __name__ == "__main__":
+    from _dev_env import reexec_into_venv
+
+    reexec_into_venv(guard_env="_SS_VENV_REEXEC", opt_out_env="SS_NO_REEXEC")
+
+from fastmcp import Client  # noqa: E402
 
 URL = os.environ.get("SS_URL", "http://127.0.0.1:8000/mcp")
 

--- a/tests/unit/test_dev_env.py
+++ b/tests/unit/test_dev_env.py
@@ -1,0 +1,175 @@
+"""Unit tests for ``script/_dev_env.py`` — cross-platform dev-script helpers (#509).
+
+Covers the platform-branching logic (venv interpreter layout, port parsing) and
+the venv re-exec decision so the Windows path is exercised on a POSIX CI runner
+without needing a Windows host.
+"""
+
+from __future__ import annotations
+
+import py_compile
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_DIR = REPO_ROOT / "script"
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import _dev_env  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# venv interpreter layout
+# --------------------------------------------------------------------------- #
+def test_venv_python_posix():
+    # Explicit windows flag keeps the global os.name (and pathlib's flavour) untouched.
+    assert _dev_env.venv_python(Path("/proj/.venv"), windows=False) == Path(
+        "/proj/.venv/bin/python"
+    )
+
+
+def test_venv_python_windows():
+    result = _dev_env.venv_python(Path("/proj/.venv"), windows=True)
+    assert result.parts[-3:] == (".venv", "Scripts", "python.exe")
+
+
+def test_find_venv_python_present(monkeypatch, tmp_path):
+    # find_venv_python resolves the layout for the host it runs on.
+    exe = _dev_env.venv_python(tmp_path / ".venv")
+    exe.parent.mkdir(parents=True)
+    exe.write_text("")
+    monkeypatch.setattr(_dev_env, "root_repo", lambda worktree=None: tmp_path)
+    assert _dev_env.find_venv_python() == exe
+
+
+def test_find_venv_python_absent(monkeypatch, tmp_path):
+    monkeypatch.setattr(_dev_env, "root_repo", lambda worktree=None: tmp_path)
+    assert _dev_env.find_venv_python() is None
+
+
+# --------------------------------------------------------------------------- #
+# worktree / root-repo resolution
+# --------------------------------------------------------------------------- #
+def test_root_from_common_dir_absolute(tmp_path):
+    common = tmp_path / "main-repo" / ".git"
+    assert _dev_env._root_from_common_dir(tmp_path, str(common)) == tmp_path / "main-repo"
+
+
+def test_root_from_common_dir_relative(tmp_path):
+    worktree = tmp_path / "wt"
+    (worktree / ".git").mkdir(parents=True)
+    # A bare ".git" relative to the worktree resolves the root back to the worktree.
+    assert _dev_env._root_from_common_dir(worktree, ".git") == worktree
+
+
+def test_worktree_src():
+    assert _dev_env.worktree_src(Path("/foo/bar")) == Path("/foo/bar/src")
+
+
+# --------------------------------------------------------------------------- #
+# arg / output parsing
+# --------------------------------------------------------------------------- #
+def test_extract_port_space_separated():
+    port, rest = _dev_env.extract_port(["--port", "18130", "--ws-port", "19630"])
+    assert port == 18130
+    assert rest == ["--ws-port", "19630"]
+
+
+def test_extract_port_equals():
+    port, rest = _dev_env.extract_port(["--port=8010", "--reload-extra"])
+    assert port == 8010
+    assert rest == ["--reload-extra"]
+
+
+def test_extract_port_default_when_absent():
+    port, rest = _dev_env.extract_port(["--ws-port", "9000"])
+    assert port == 8000
+    assert rest == ["--ws-port", "9000"]
+
+
+def test_parse_lsof_pids():
+    assert _dev_env.parse_lsof_pids("1234\n5678\n1234\n") == [1234, 5678]
+    assert _dev_env.parse_lsof_pids("") == []
+
+
+def test_parse_netstat_pids():
+    out = (
+        "  Proto  Local Address          Foreign Address        State           PID\n"
+        "  TCP    0.0.0.0:8000           0.0.0.0:0              LISTENING       4321\n"
+        "  TCP    127.0.0.1:9500         0.0.0.0:0              LISTENING       9999\n"
+        "  TCP    [::]:8000              [::]:0                 LISTENING       4321\n"
+        "  TCP    0.0.0.0:8000           1.2.3.4:55555          ESTABLISHED     1111\n"
+    )
+    assert _dev_env.parse_netstat_pids(out, 8000) == [4321]
+    assert _dev_env.parse_netstat_pids(out, 9500) == [9999]
+    assert _dev_env.parse_netstat_pids(out, 1234) == []
+
+
+# --------------------------------------------------------------------------- #
+# venv re-exec decision
+# --------------------------------------------------------------------------- #
+def test_reexec_noop_when_guard_set(monkeypatch):
+    monkeypatch.setenv("GUARD_X", "1")
+    calls = []
+    monkeypatch.setattr(_dev_env.os, "execv", lambda *a: calls.append(a))
+    _dev_env.reexec_into_venv(guard_env="GUARD_X")
+    assert calls == []
+
+
+def test_reexec_noop_when_opt_out(monkeypatch):
+    monkeypatch.delenv("GUARD_Y", raising=False)
+    monkeypatch.setenv("OPT_OUT", "1")
+    calls = []
+    monkeypatch.setattr(_dev_env.os, "execv", lambda *a: calls.append(a))
+    _dev_env.reexec_into_venv(guard_env="GUARD_Y", opt_out_env="OPT_OUT")
+    assert calls == []
+
+
+def test_reexec_noop_when_no_venv(monkeypatch):
+    monkeypatch.delenv("GUARD_Z", raising=False)
+    monkeypatch.setattr(_dev_env, "find_venv_python", lambda worktree=None: None)
+    calls = []
+    monkeypatch.setattr(_dev_env.os, "execv", lambda *a: calls.append(a))
+    _dev_env.reexec_into_venv(guard_env="GUARD_Z")
+    assert calls == []
+
+
+def test_reexec_noop_when_already_in_venv(monkeypatch):
+    monkeypatch.delenv("GUARD_W", raising=False)
+    monkeypatch.setattr(_dev_env, "find_venv_python", lambda worktree=None: Path(sys.executable))
+    calls = []
+    monkeypatch.setattr(_dev_env.os, "execv", lambda *a: calls.append(a))
+    _dev_env.reexec_into_venv(guard_env="GUARD_W")
+    assert calls == []
+
+
+def test_reexec_execs_into_venv(monkeypatch, tmp_path):
+    monkeypatch.delenv("GUARD_V", raising=False)
+    fake_python = tmp_path / "python"
+    fake_python.write_text("")
+    monkeypatch.setattr(_dev_env, "find_venv_python", lambda worktree=None: fake_python)
+    monkeypatch.setattr(_dev_env.sys, "argv", ["script/stormtest.py", "--flag"])
+    captured = {}
+
+    def fake_execv(path, args):
+        captured["path"] = path
+        captured["args"] = args
+
+    monkeypatch.setattr(_dev_env.os, "execv", fake_execv)
+    try:
+        _dev_env.reexec_into_venv(guard_env="GUARD_V")
+        assert captured["path"] == str(fake_python)
+        assert captured["args"] == [str(fake_python), "script/stormtest.py", "--flag"]
+        # Guard is set so a re-execed process won't loop.
+        assert _dev_env.os.environ.get("GUARD_V") == "1"
+    finally:
+        _dev_env.os.environ.pop("GUARD_V", None)
+
+
+# --------------------------------------------------------------------------- #
+# scripts parse cleanly
+# --------------------------------------------------------------------------- #
+def test_dev_scripts_compile():
+    for name in ("_dev_env.py", "stormtest.py", "serve-this-worktree.py"):
+        py_compile.compile(str(SCRIPT_DIR / name), doraise=True)

--- a/tests/unit/test_dev_env.py
+++ b/tests/unit/test_dev_env.py
@@ -11,6 +11,8 @@ import py_compile
 import sys
 from pathlib import Path
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_DIR = REPO_ROOT / "script"
 if str(SCRIPT_DIR) not in sys.path:
@@ -86,6 +88,21 @@ def test_extract_port_default_when_absent():
     port, rest = _dev_env.extract_port(["--ws-port", "9000"])
     assert port == 8000
     assert rest == ["--ws-port", "9000"]
+
+
+def test_extract_port_missing_value_raises():
+    with pytest.raises(ValueError, match="requires an integer"):
+        _dev_env.extract_port(["--ws-port", "9000", "--port"])
+
+
+def test_extract_port_non_integer_raises():
+    with pytest.raises(ValueError, match="must be an integer"):
+        _dev_env.extract_port(["--port", "80O0"])
+
+
+def test_extract_port_non_integer_equals_raises():
+    with pytest.raises(ValueError, match="must be an integer"):
+        _dev_env.extract_port(["--port="])
 
 
 def test_parse_lsof_pids():

--- a/tests/unit/test_dev_env.py
+++ b/tests/unit/test_dev_env.py
@@ -168,6 +168,19 @@ def test_reexec_execs_into_venv(monkeypatch, tmp_path):
 
 
 # --------------------------------------------------------------------------- #
+# port listening probe
+# --------------------------------------------------------------------------- #
+def test_port_listening_detects_bound_socket():
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as srv:
+        srv.bind(("127.0.0.1", 0))
+        srv.listen(1)
+        port = srv.getsockname()[1]
+        assert _dev_env._port_listening(port) is True
+
+
+# --------------------------------------------------------------------------- #
 # scripts parse cleanly
 # --------------------------------------------------------------------------- #
 def test_dev_scripts_compile():


### PR DESCRIPTION
## Summary

Makes the `stormtest` invocation surface platform-agnostic so a Windows agent can copy-paste one command and run, removing the POSIX-only steps (`.venv/bin/python`, bash-only `serve-this-worktree`) called out in #509.

- **`script/_dev_env.py`** — new, stdlib-only, import-safe shared helpers: venv interpreter resolution (`bin/python` vs `Scripts\python.exe`), git worktree/root-repo resolution, a venv re-exec decision, and cross-platform port freeing (`lsof` vs `netstat`/`taskkill`).
- **`script/stormtest.py`** — re-execs into the project `.venv` on launch, so `python script/stormtest.py` works identically on every OS. Opt out with `SS_NO_REEXEC=1`.
- **`script/serve-this-worktree.py`** — new cross-platform (no `bash`/`lsof`) companion to the bash `serve-this-worktree`; extra args (e.g. `--ws-port`) pass straight through. The bash script is retained for POSIX.
- Host-side path construction in the harness already goes through `tempfile.gettempdir()` / `os.path.join` — audited and confirmed resilient; only the invocation surface needed work (issue item 3).
- **`docs/STRESS_TESTING.md`** + **`AGENTS.md`** — document the OS-agnostic commands and trim the invocation/serve-script parts of the Windows heads-up.

## Test plan

- [x] `ruff check` + `ruff format --check` on all changed/new files — clean.
- [x] `pytest -q` full suite — 1158 passed, 2 skipped.
- [x] `tests/unit/test_dev_env.py` (new, 18 tests) — venv layout for **both** OSes (Windows branch exercised on POSIX via an explicit flag, no global `os.name` flip), worktree/root-repo resolution, `--port` extraction, `lsof`/`netstat` PID parsing, the re-exec decision (no-op when already in-venv / guarded / opted-out / no venv; execs otherwise), and a `py_compile` smoke of all three scripts.
- [x] `script/ci-check-gdscript` — "All GDScript files OK" (no GDScript touched; run for safety).
- [x] Manual smoke: `find_venv_python()` resolves the real `.venv`; `serve-this-worktree.py` resolves worktree `src/` + venv and parses args; re-exec is a no-op when already running the venv interpreter.
- n/a Live-editor `test_run` / self-update / write-tool-undo smokes — this change is Python tooling + docs only; it touches no plugin/GDScript, self-update, or write-tool code.

## Deviations / notes

- **PR base is `main`, not `beta`.** `origin/beta` is currently stale (v2.4.4 era, `9c95fda`) and mid-reset (cf. `archive/beta-pre-reset-20260531`, `claude/merge-main-into-beta-*`); it does **not** contain `script/stormtest.py` (#510) or `docs/STRESS_TESTING.md` (#512) — the very files #509 targets. Basing on `beta` would produce a ~1000-line bogus diff re-introducing #510/#512. `main` is the live branch (v2.5.13) and the state #509 references, so this PR targets it. Happy to retarget if a different integration branch is preferred.
- **Scope vs. #513/#514.** This PR resolves #509's invocation/pathing item only. The Windows **reload-churn** wedge (#513) and #514's `_stop_server` kill-on-reload **product decision** are out of scope and intentionally left documented as open caveats — they are not pathing problems. The new `serve-this-worktree.py` does incidentally give Windows a non-bash serve path (overlapping #514's Problem 1), but does not change any reload/kill behavior.

Closes #509


---
_Generated by [Claude Code](https://claude.ai/code/session_01FAB4kCYfQNGP4LQTVbPRTM)_