### PR TITLE
fix(game_eval): carve the not-ready path out into EVAL_GAME_NOT_READY (#518)

### DIFF
--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -438,7 +438,7 @@ func _wait_then_eval(
 		## and caller-actionable; classifying it apart from the opaque 10s hang
 		## keeps the INTERNAL_ERROR telemetry bucket meaning "the eval truly hung".
 		_send_error(connection, request_id, ErrorCodes.EVAL_GAME_NOT_READY,
-			"Game-side autoload never registered its debugger capture within %ds. Is the game actually running? Start it with project_run / the editor's Play button, then retry. If it IS running, check Project Settings → Autoload for _mcp_game_helper (added automatically when the plugin is enabled)." % int(EVAL_READY_WAIT_SEC))
+			"Game-side capture didn't register within %ds. The play session is already running, so the game is most likely still booting — wait a moment and retry. If it persists, the _mcp_game_helper autoload is missing or disabled (Project Settings → Autoload; added automatically when the plugin is enabled), or the game uses a custom main loop." % int(EVAL_READY_WAIT_SEC))
 		return
 	_send_eval(tree, code, request_id, connection, timeout_sec)
 
@@ -452,10 +452,11 @@ func _send_eval(
 ) -> void:
 	var session: EditorDebuggerSession = _first_active_session()
 	if session == null:
-		## #518: same not-ready condition as _wait_then_eval (capture reported
-		## ready but no live debugger session), so the same caller-actionable code.
+		## #518: capture reported ready but the debugger session is no longer live
+		## (the game just stopped / is restarting) — a not-ready race, so the same
+		## caller-actionable EVAL_GAME_NOT_READY rather than the opaque hang bucket.
 		_send_error(connection, request_id, ErrorCodes.EVAL_GAME_NOT_READY,
-			"No active debugger session — is the game actually running?")
+			"Game-side capture registered but its debugger session is no longer active — the game likely just stopped or is restarting. Confirm it's running and retry.")
 		return
 
 	var timer: SceneTreeTimer = tree.create_timer(timeout_sec)

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -433,7 +433,11 @@ func _wait_then_eval(
 	while not is_game_capture_ready() and Time.get_ticks_msec() < deadline:
 		await tree.process_frame
 	if not is_game_capture_ready():
-		_send_error(connection, request_id, ErrorCodes.INTERNAL_ERROR,
+		## #518: EVAL_GAME_NOT_READY (not INTERNAL_ERROR) — the play session is up
+		## but the game-side capture didn't register within the short wait. Fast
+		## and caller-actionable; classifying it apart from the opaque 10s hang
+		## keeps the INTERNAL_ERROR telemetry bucket meaning "the eval truly hung".
+		_send_error(connection, request_id, ErrorCodes.EVAL_GAME_NOT_READY,
 			"Game-side autoload never registered its debugger capture within %ds. Is the game actually running? Start it with project_run / the editor's Play button, then retry. If it IS running, check Project Settings → Autoload for _mcp_game_helper (added automatically when the plugin is enabled)." % int(EVAL_READY_WAIT_SEC))
 		return
 	_send_eval(tree, code, request_id, connection, timeout_sec)
@@ -448,7 +452,9 @@ func _send_eval(
 ) -> void:
 	var session: EditorDebuggerSession = _first_active_session()
 	if session == null:
-		_send_error(connection, request_id, ErrorCodes.INTERNAL_ERROR,
+		## #518: same not-ready condition as _wait_then_eval (capture reported
+		## ready but no live debugger session), so the same caller-actionable code.
+		_send_error(connection, request_id, ErrorCodes.EVAL_GAME_NOT_READY,
 			"No active debugger session — is the game actually running?")
 		return
 

--- a/plugin/addons/godot_ai/utils/error_codes.gd
+++ b/plugin/addons/godot_ai/utils/error_codes.gd
@@ -29,6 +29,15 @@ const DEFERRED_TIMEOUT := "DEFERRED_TIMEOUT"
 # game_eval failure codes (#490) — keep in sync with protocol/errors.py
 const EVAL_COMPILE_ERROR := "EVAL_COMPILE_ERROR"
 const EVAL_RUNTIME_ERROR := "EVAL_RUNTIME_ERROR"
+## #518: the play session is up (EditorInterface.is_playing_scene() is true, so
+## editor_handler's EDITOR_NOT_READY "game is not running" gate already passed)
+## but the game-side _mcp_game_helper autoload never registered its debugger
+## capture within EVAL_READY_WAIT_SEC. Carved out of INTERNAL_ERROR so this
+## boot-window / missing-autoload race stops masquerading as the opaque "eval
+## hung" 10s timeout in telemetry — the same split #490 made for compile/runtime
+## errors. NOT a hang: it fires fast (~3s) and is caller-actionable (let the game
+## finish booting and retry, or check the autoload is enabled).
+const EVAL_GAME_NOT_READY := "EVAL_GAME_NOT_READY"
 ## audit-v2 #21 (issue #365): finer-grained codes carved out of the 471
 ## INVALID_PARAMS sites so agents can distinguish recoverable input
 ## errors from structural ones. INVALID_PARAMS stays for genuinely

--- a/src/godot_ai/handlers/editor.py
+++ b/src/godot_ai/handlers/editor.py
@@ -345,10 +345,13 @@ async def game_eval(runtime: DirectRuntime, code: str) -> dict:
 
     Errors come back fast and actionable (#490): a syntax/parse error returns
     ``EVAL_COMPILE_ERROR`` and a runtime error returns ``EVAL_RUNTIME_ERROR``
-    with the real message and resolved line, instead of a generic timeout. A
-    genuine infinite loop / never-firing await still hits the timeout. Note
-    that ``await`` (timers, signals, frames) only progresses while the game
-    window is focused; a backgrounded play-in-editor game has a frozen idle
-    loop, so an awaiting eval reads as a timeout until the game is focused.
+    with the real message and resolved line, instead of a generic timeout.
+    ``EVAL_GAME_NOT_READY`` (#518) means the play session is up but the
+    game-side capture hasn't registered yet — let the game finish launching and
+    retry, or check the ``_mcp_game_helper`` autoload is enabled. A genuine
+    infinite loop / never-firing await still hits the timeout. Note that
+    ``await`` (timers, signals, frames) only progresses while the game window is
+    focused; a backgrounded play-in-editor game has a frozen idle loop, so an
+    awaiting eval reads as a timeout until the game is focused.
     """
     return await runtime.send_command("game_eval", {"code": code}, timeout=15.0)

--- a/src/godot_ai/protocol/errors.py
+++ b/src/godot_ai/protocol/errors.py
@@ -18,6 +18,12 @@ class ErrorCode(StrEnum):
     # actionable reply. Keep in sync with utils/error_codes.gd.
     EVAL_COMPILE_ERROR = "EVAL_COMPILE_ERROR"
     EVAL_RUNTIME_ERROR = "EVAL_RUNTIME_ERROR"
+    # #518: the play session is up but the game-side autoload never registered
+    # its debugger capture within the readiness wait (boot-window race, worst on
+    # Windows, or a missing/disabled autoload). Carved out of INTERNAL_ERROR so
+    # this fast (~3s), caller-actionable failure stops being counted as the
+    # opaque "eval hung" 10s timeout. Keep in sync with utils/error_codes.gd.
+    EVAL_GAME_NOT_READY = "EVAL_GAME_NOT_READY"
     ## audit-v2 #21 (issue #365): finer-grained codes carved out of the
     ## 471 INVALID_PARAMS sites so agents can distinguish recoverable
     ## input errors from structural ones. INVALID_PARAMS stays for

--- a/src/godot_ai/tools/editor.py
+++ b/src/godot_ai/tools/editor.py
@@ -39,8 +39,9 @@ Ops:
         'await' so user code can await internally. Errors return fast and
         actionable: EVAL_COMPILE_ERROR for a syntax/parse error,
         EVAL_RUNTIME_ERROR (with the real message + line) for a runtime
-        error; a genuine infinite loop / never-firing await still times out.
-        'await' only progresses while the game window is focused."""
+        error; EVAL_GAME_NOT_READY if the game is still launching (retry
+        once it's up); a genuine infinite loop / never-firing await still
+        times out. 'await' only progresses while the game window is focused."""
 
 
 def register_editor_tools(mcp: FastMCP, *, include_non_core: bool = True) -> None:

--- a/src/godot_ai/tools/editor.py
+++ b/src/godot_ai/tools/editor.py
@@ -39,8 +39,9 @@ Ops:
         'await' so user code can await internally. Errors return fast and
         actionable: EVAL_COMPILE_ERROR for a syntax/parse error,
         EVAL_RUNTIME_ERROR (with the real message + line) for a runtime
-        error; EVAL_GAME_NOT_READY if the game is still launching (retry
-        once it's up); a genuine infinite loop / never-firing await still
+        error; EVAL_GAME_NOT_READY if the game isn't ready yet — still
+        launching (retry once it's up) or the _mcp_game_helper autoload is
+        missing/disabled; a genuine infinite loop / never-firing await still
         times out. 'await' only progresses while the game window is focused."""
 
 

--- a/test_project/tests/test_game_eval_errors.gd
+++ b/test_project/tests/test_game_eval_errors.gd
@@ -406,14 +406,16 @@ func test_send_eval_without_active_session_replies_game_not_ready() -> void:
 		skip("No SceneTree available")
 		return
 	var plugin := McpDebuggerPlugin.new()
-	var conn := _StubConnection.new()
-	plugin._send_eval(tree, "return 1", "rid-no-session", conn, 10.0)
-	if conn.captured.is_empty():
-		## A live debugger session is present (e.g. a game running under this
-		## editor), so the no-session branch wasn't exercised — don't false-fail.
-		conn.free()
+	## Gate BEFORE calling _send_eval: a bare plugin normally has no session, but
+	## if one were present _send_eval would take its live path (arm timers, send a
+	## real mcp:eval into the running game). Skip first so the test never has side
+	## effects in that case rather than bailing after the fact.
+	if plugin._first_active_session() != null:
 		skip("an active debugger session is present; no-session branch not exercised")
 		return
+	var conn := _StubConnection.new()
+	plugin._send_eval(tree, "return 1", "rid-no-session", conn, 10.0)
+	assert_eq(conn.captured.size(), 1, "exactly one deferred reply is sent")
 	assert_eq(conn.captured[0]["payload"]["error"]["code"], ErrorCodes.EVAL_GAME_NOT_READY,
 		"no active debugger session replies with EVAL_GAME_NOT_READY, not INTERNAL_ERROR")
 	conn.free()

--- a/test_project/tests/test_game_eval_errors.gd
+++ b/test_project/tests/test_game_eval_errors.gd
@@ -394,3 +394,26 @@ func test_eval_grace_noop_when_already_compiled() -> void:
 	assert_true(plugin._pending.has(rid), "a compiled eval is untouched by the grace timer")
 	assert_eq(conn.captured.size(), 0, "no compile error for a compiled eval")
 	conn.free()
+
+
+func test_send_eval_without_active_session_replies_game_not_ready() -> void:
+	## #518: with no live debugger session, _send_eval replies with the
+	## caller-actionable EVAL_GAME_NOT_READY rather than the opaque INTERNAL_ERROR
+	## that the telemetry bucket now reserves for a genuine ~10s eval hang. (The
+	## no-session branch returns before touching `tree`, so a bare plugin is safe.)
+	var tree := Engine.get_main_loop() as SceneTree
+	if tree == null:
+		skip("No SceneTree available")
+		return
+	var plugin := McpDebuggerPlugin.new()
+	var conn := _StubConnection.new()
+	plugin._send_eval(tree, "return 1", "rid-no-session", conn, 10.0)
+	if conn.captured.is_empty():
+		## A live debugger session is present (e.g. a game running under this
+		## editor), so the no-session branch wasn't exercised — don't false-fail.
+		conn.free()
+		skip("an active debugger session is present; no-session branch not exercised")
+		return
+	assert_eq(conn.captured[0]["payload"]["error"]["code"], ErrorCodes.EVAL_GAME_NOT_READY,
+		"no active debugger session replies with EVAL_GAME_NOT_READY, not INTERNAL_ERROR")
+	conn.free()

--- a/tests/unit/test_game_eval.py
+++ b/tests/unit/test_game_eval.py
@@ -67,9 +67,12 @@ async def test_game_eval_passes_code_verbatim():
 
 
 def test_eval_error_codes_exist():
-    """The two codes the plugin emits for fast game_eval failures."""
+    """The codes the plugin emits for fast game_eval failures."""
     assert ErrorCode.EVAL_COMPILE_ERROR == "EVAL_COMPILE_ERROR"
     assert ErrorCode.EVAL_RUNTIME_ERROR == "EVAL_RUNTIME_ERROR"
+    # #518: the play-session-up-but-capture-not-ready race, carved out of
+    # INTERNAL_ERROR so it stops being counted as a genuine eval hang.
+    assert ErrorCode.EVAL_GAME_NOT_READY == "EVAL_GAME_NOT_READY"
 
 
 class _RaisingGameEvalClient:


### PR DESCRIPTION
## What this is

[#518](https://github.com/hi-godot/godot-ai/issues/518) reports the opaque
`INTERNAL_ERROR` on `editor_manage(game_eval)` "regressing" 1.42% (2.5.10) →
6.15% (2.6.0). I split the bucket by `duration_ms` (telemetry stores latency,
not the message) and **it is not a regression of the #487/#488 opaque hang** —
it's a thin-baseline cohort artifact plus a #500 reclassification. This PR fixes
the one real, high-confidence problem: the not-ready failure is mis-coded as
`INTERNAL_ERROR`, so it masquerades as the opaque hang.

## The data (INTERNAL_ERROR split by latency)

| ver | game_eval | INTERNAL_ERROR | ~3s (#500 not-ready) | ~10s hang (#487 kind) | TimeoutError |
|---|---|---|---|---|---|
| 2.5.10 | 1,561 | 1.41% | 0 | **21 (1.35%)** | 46 |
| 2.5.13 | 11,142 | 3.23% | 5 | **325 (2.92%)** | 330 |
| 2.6.0 | 4,659 | 6.29% | **151 (3.24%)** | **131 (2.81%)** | 3 |

- **Genuine ~10s hang is flat** (2.92% → 2.81%). The within-install rise was one
  pathological install (`2db6f78c`, 15% hang rate, 42% of all 2.6.0 hangs);
  excluding it, 2.78% → 2.70%.
- **2.5.10→2.5.13 step is a cohort artifact** — zero runtime code changed
  between those tags; the "1.42%" baseline was 9 installs / 1,561 calls.
- **2.6.0 jump is #500**: capping the readiness wait at 3s converted ~15s
  `TimeoutError`s into fast ~3s `INTERNAL_ERROR`s (`TimeoutError` collapsed
  330 → 3). Same code, different (faster, actionable) failure.

## The change

A dedicated `EVAL_GAME_NOT_READY` code — the same split #490/#491 made for
compile/runtime errors, and the issue's own Suggested Action #2. It reclassifies
the two debugger-plugin not-ready sites (`_wait_then_eval` readiness-wait expiry
and `_send_eval`'s no-session branch). The condition is specifically *"the play
session is up (`editor_handler`'s `is_playing_scene()` gate already passed) but
the game-side capture never registered within the wait"* — a boot-window race
(worst on Windows) or a missing/disabled `_mcp_game_helper` autoload.

**This relabels; it does not change eval timing or reduce failures.** Opaque
`INTERNAL_ERROR` drops ~6.3% → ~2.8% by definition and once again means "the eval
truly hung"; the not-ready volume becomes its own measurable, caller-side bucket.
No timing machinery touched — the `game_command` / screenshot not-ready paths are
intentionally left as-is.

## What I deliberately did **not** do

Chase the residual ~2.8% hang floor or widen #500's 3s wait. The floor is the
inherent backgrounded-game idle-freeze limit, and the 3s wait is bounded by the
15s server ceiling — moving it would mean raising the whole timeout ladder for
partial benefit. That's the half-measure to avoid.

## Validation

- ✅ `ruff` clean
- ✅ Python unit suite: **854 passed, 2 skipped** (incl. new `EVAL_GAME_NOT_READY` assertion)
- ✅ GDScript `--import` parse-check: **0 errors**
- ⏳ GDScript behavioral test (`test_send_eval_without_active_session_replies_game_not_ready`) — validated by CI's `ci-godot-tests` job (needs the editor harness; couldn't run locally)

Refs #518. After this ships, mark finding **F-009** verifying and confirm the
opaque-`INTERNAL_ERROR` rate drops in 2.6.x telemetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
