### PR TITLE
Surface editor error context in log reads

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -29,10 +29,16 @@ not the MCP tool names.
 | `script_create` / `script_attach` / `script_patch` | Create, attach, anchor-edit GDScript files |
 | `project_run` | Play the project (autosave persists in-memory MCP edits unless `autosave=False`) |
 | `test_run` | Run GDScript test suites in the editor |
-| `logs_read` | Read plugin / game / editor / combined log buffers. `source="editor"` surfaces parse errors + @tool/EditorPlugin runtime errors + push_error/push_warning (Godot 4.5+, filtered to user .gd/.cs) — use this when the editor's Output panel shows red lines but `logs_read` returned nothing |
+| `logs_read` | Read plugin / game / editor / combined log buffers. `source="editor"` surfaces parse errors, GDScript reload warnings, @tool/EditorPlugin runtime errors, push_error/push_warning, and visible Debugger dock Errors-tab rows — use this when the editor's Output or Debugger Errors panel shows red/yellow rows |
 | `editor_screenshot` | Capture editor viewport, cinematic camera, or running game framebuffer |
 | `editor_reload_plugin` | Reload the plugin and wait for reconnect (server must be external) |
 | `animation_create` | Create an Animation clip (auto-creates AnimationPlayer + library if missing) |
+
+`logs_read` also accepts `include_details=true` for `source="editor"`,
+`source="game"`, and `source="all"`. Detailed entries include the original
+Godot `_log_error` code/rationale when available, error type, resolved source
+location, and stack/error-tree context corresponding to the Debugger dock's
+Errors tab.
 
 ## Domain rollups (`<domain>_manage`)
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -40,6 +40,11 @@ Godot `_log_error` code/rationale when available, error type, resolved source
 location, and stack/error-tree context corresponding to the Debugger dock's
 Errors tab.
 
+`editor_manage(op="logs_clear")` accepts `clear_debugger_errors=true` to also
+clear the Debugger dock's visible Errors-tab rows (routed through the panel's
+own Clear path so the tab badge and counters reset). The Errors panel is
+user-facing UI, so the default leaves it untouched.
+
 ## Domain rollups (`<domain>_manage`)
 
 Each rollup is a single MCP tool dispatched by `op` name + `params` dict.

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -192,14 +192,24 @@ func _capture(message: String, data: Array, session_id: int) -> bool:
 func _on_log_batch(data: Array) -> void:
 	if _game_log_buffer == null:
 		return
-	## data layout: [[[level, text], [level, text], ...]]
+	## data layout: [[[level, text, details?], ...]]
 	if data.is_empty() or not (data[0] is Array):
 		return
 	var entries: Array = data[0]
 	for entry in entries:
+		if entry is Dictionary:
+			var dict_details: Dictionary = {}
+			var raw_dict_details = entry.get("details", {})
+			if raw_dict_details is Dictionary:
+				dict_details = raw_dict_details
+			_game_log_buffer.append(str(entry.get("level", "info")), str(entry.get("text", "")), dict_details)
+			continue
 		if not (entry is Array) or entry.size() < 2:
 			continue
-		_game_log_buffer.append(str(entry[0]), str(entry[1]))
+		var details: Dictionary = {}
+		if entry.size() > 2 and entry[2] is Dictionary:
+			details = entry[2]
+		_game_log_buffer.append(str(entry[0]), str(entry[1]), details)
 
 
 ## Request a game-process framebuffer capture over the debugger channel.

--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -14,6 +14,7 @@ var _debugger_plugin: McpDebuggerPlugin
 var _game_log_buffer: McpGameLogBuffer
 var _editor_log_buffer: McpEditorLogBuffer
 var _debugger_errors_root: Node
+var _debugger_search_root_cache: Node
 
 
 func _init(log_buffer: McpLogBuffer, connection: McpConnection = null, debugger_plugin: McpDebuggerPlugin = null, game_log_buffer: McpGameLogBuffer = null, editor_log_buffer: McpEditorLogBuffer = null, debugger_errors_root: Node = null) -> void:
@@ -196,12 +197,17 @@ func _get_all_logs(count: int, offset: int, include_details: bool) -> Dictionary
 
 
 func _entries_for_response(entries: Array[Dictionary], include_details: bool) -> Array[Dictionary]:
+	## Compact responses only drop the top-level "details" key, so a shallow
+	## copy is enough; the deep copy is reserved for the opt-in details path
+	## where nested dicts leave the buffer.
 	var out: Array[Dictionary] = []
 	for entry in entries:
-		var copy: Dictionary = entry.duplicate(true)
-		if not include_details:
+		if include_details:
+			out.append(entry.duplicate(true))
+		else:
+			var copy: Dictionary = entry.duplicate(false)
 			copy.erase("details")
-		out.append(copy)
+			out.append(copy)
 	return out
 
 
@@ -217,21 +223,55 @@ func _collect_editor_log_entries() -> Array[Dictionary]:
 
 
 func _read_debugger_error_entries() -> Array[Dictionary]:
-	if _debugger_plugin == null and _debugger_errors_root == null:
-		return []
-	var root: Node = _debugger_errors_root
-	if root == null:
-		root = EditorInterface.get_base_control()
-	if root == null:
-		return []
-	var trees: Array[Tree] = []
-	_collect_debugger_error_trees(root, trees)
 	var entries: Array[Dictionary] = []
-	for tree in trees:
+	for tree in _locate_debugger_error_trees():
 		for entry in _entries_from_debugger_error_tree(tree):
 			if not _has_equivalent_log_entry(entries, entry):
 				entries.append(entry)
 	return entries
+
+
+func _locate_debugger_error_trees() -> Array[Tree]:
+	var trees: Array[Tree] = []
+	if _debugger_plugin == null and _debugger_errors_root == null:
+		return trees
+	var root: Node = _debugger_errors_root
+	if root == null:
+		root = _debugger_search_root()
+	if root == null:
+		return trees
+	_collect_debugger_error_trees(root, trees)
+	return trees
+
+
+func _debugger_search_root() -> Node:
+	## logs_read is a polling tool, so per-call discovery must not recurse the
+	## entire editor UI. EditorDebuggerNode is the bottom-panel container that
+	## owns every ScriptEditorDebugger session tab and lives for the editor's
+	## lifetime — find it once from the base control, then scan only its
+	## subtree on later calls. The error Trees themselves can't be cached:
+	## they are identified by their content, and an emptied tree is
+	## indistinguishable from any other Tree.
+	if is_instance_valid(_debugger_search_root_cache):
+		return _debugger_search_root_cache
+	_debugger_search_root_cache = null
+	var base := EditorInterface.get_base_control()
+	if base == null:
+		return null
+	_debugger_search_root_cache = _find_first_of_class(base, "EditorDebuggerNode")
+	if _debugger_search_root_cache == null:
+		return base
+	return _debugger_search_root_cache
+
+
+static func _find_first_of_class(node: Node, klass: String) -> Node:
+	if node.get_class() == klass:
+		return node
+	for child in node.get_children():
+		var found := _find_first_of_class(child, klass)
+		if found != null:
+			return found
+	return null
 
 
 static func _collect_debugger_error_trees(node: Node, out: Array[Tree]) -> void:
@@ -284,23 +324,15 @@ static func _entry_from_debugger_error_item(item: TreeItem) -> Dictionary:
 
 static func _details_from_debugger_error_item(item: TreeItem, loc: Dictionary, function: String) -> Dictionary:
 	var children: Array[Dictionary] = []
-	var frames: Array[Dictionary] = []
 	var child := item.get_first_child()
 	while child != null:
 		var child_loc := _location_from_metadata(child.get_metadata(0))
-		var child_entry := {
+		children.append({
 			"label": child.get_text(0),
 			"text": child.get_text(1),
 			"path": str(child_loc.get("path", "")),
 			"line": int(child_loc.get("line", 0)),
-		}
-		children.append(child_entry)
-		if _is_stack_trace_item(child, child_loc):
-			frames.append({
-				"path": child_entry.path,
-				"line": child_entry.line,
-				"function": _function_from_frame_text(child_entry.text),
-			})
+		})
 		child = child.get_next()
 	return {
 		"debugger_tab": "Errors",
@@ -318,7 +350,7 @@ static func _details_from_debugger_error_item(item: TreeItem, loc: Dictionary, f
 			"function": function,
 		},
 		"children": children,
-		"frames": frames,
+		"frames": _frames_from_error_children(children),
 	}
 
 
@@ -326,10 +358,39 @@ static func _is_debugger_error_item(item: TreeItem) -> bool:
 	return item.has_meta("_is_warning") or item.has_meta("_is_error")
 
 
-static func _is_stack_trace_item(item: TreeItem, loc: Dictionary) -> bool:
-	if str(item.get_text(0)).find("Stack Trace") >= 0:
-		return true
-	return not str(loc.get("path", "")).is_empty() and not item.get_parent().has_meta("_is_warning") and not item.get_parent().has_meta("_is_error")
+## ScriptEditorDebugger lays out an error item's children flat, in order: an
+## optional "<X Error>" row, one "<X Source>" row, then one row per stack
+## frame. Only frame 0 carries the "<Stack Trace>" label (TTR-translated);
+## later frames have an empty label. Every frame row carries [path, line]
+## metadata, but so can the Error/Source rows, so metadata alone can't
+## identify frames — the frame run has to be found first.
+static func _frames_from_error_children(children: Array[Dictionary]) -> Array[Dictionary]:
+	var start := -1
+	for i in children.size():
+		if str(children[i].label).contains("Stack Trace"):
+			start = i
+			break
+	if start < 0:
+		## Non-English editor locale: the "<Stack Trace>" label is translated.
+		## Frames past the first are the only rows with an empty label and a
+		## real location; back up one row to recover the labeled first frame
+		## (rows before the frame run always have a non-empty label).
+		for i in children.size():
+			if str(children[i].label).is_empty() and not str(children[i].path).is_empty():
+				start = maxi(i - 1, 0)
+				break
+	if start < 0:
+		return []
+	var frames: Array[Dictionary] = []
+	for i in range(start, children.size()):
+		if str(children[i].path).is_empty():
+			continue
+		frames.append({
+			"path": children[i].path,
+			"line": children[i].line,
+			"function": _function_from_frame_text(children[i].text),
+		})
+	return frames
 
 
 static func _location_from_metadata(meta: Variant) -> Dictionary:
@@ -912,33 +973,49 @@ func get_performance_monitors(params: Dictionary) -> Dictionary:
 	}
 
 
-func clear_logs(_params: Dictionary) -> Dictionary:
+func clear_logs(params: Dictionary) -> Dictionary:
 	var count := _log_buffer.total_count()
 	_log_buffer.clear()
-	var debugger_errors_cleared := _clear_debugger_error_trees()
-	return {
-		"data": {
-			"cleared_count": count,
-			"debugger_errors_cleared": debugger_errors_cleared,
-		}
-	}
+	var data := {"cleared_count": count}
+	## The Debugger Errors panel is user-visible editor UI, not an MCP-owned
+	## buffer — wiping it stays behind an explicit opt-in.
+	if bool(params.get("clear_debugger_errors", false)):
+		data["debugger_errors_cleared"] = _clear_debugger_error_trees()
+	return {"data": data}
 
 
 func _clear_debugger_error_trees() -> int:
-	if _debugger_plugin == null and _debugger_errors_root == null:
-		return 0
-	var root: Node = _debugger_errors_root
-	if root == null:
-		root = EditorInterface.get_base_control()
-	if root == null:
-		return 0
-	var trees: Array[Tree] = []
-	_collect_debugger_error_trees(root, trees)
 	var cleared := 0
-	for tree in trees:
+	for tree in _locate_debugger_error_trees():
 		cleared += _entries_from_debugger_error_tree(tree).size()
-		tree.clear()
+		if not _press_debugger_clear_button(tree):
+			## No Clear button near this tree (synthetic roots in tests).
+			## A raw clear is acceptable there; the real panel always routes
+			## through the button below.
+			tree.clear()
 	return cleared
+
+
+## Clear via ScriptEditorDebugger's own Clear button so the engine runs
+## _clear_errors_list() — clearing the Tree directly leaves error_count/
+## warning_count, the "Errors (N)" tab badge, the errors_cleared signal, and
+## the toolbar button states out of sync with the emptied tree. The button is
+## identified by its pressed-connection target, not its (translated) label.
+static func _press_debugger_clear_button(tree: Tree) -> bool:
+	var parent := tree.get_parent()
+	if parent == null:
+		return false
+	var stack: Array[Node] = [parent]
+	while not stack.is_empty():
+		var node: Node = stack.pop_back()
+		if node is BaseButton:
+			for conn in node.get_signal_connection_list("pressed"):
+				if str(conn.get("callable", "")).contains("_clear_errors_list"):
+					node.emit_signal("pressed")
+					return true
+		for child in node.get_children():
+			stack.push_back(child)
+	return false
 
 
 func reload_plugin(_params: Dictionary) -> Dictionary:

--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -13,14 +13,16 @@ var _connection: McpConnection
 var _debugger_plugin: McpDebuggerPlugin
 var _game_log_buffer: McpGameLogBuffer
 var _editor_log_buffer: McpEditorLogBuffer
+var _debugger_errors_root: Node
 
 
-func _init(log_buffer: McpLogBuffer, connection: McpConnection = null, debugger_plugin: McpDebuggerPlugin = null, game_log_buffer: McpGameLogBuffer = null, editor_log_buffer: McpEditorLogBuffer = null) -> void:
+func _init(log_buffer: McpLogBuffer, connection: McpConnection = null, debugger_plugin: McpDebuggerPlugin = null, game_log_buffer: McpGameLogBuffer = null, editor_log_buffer: McpEditorLogBuffer = null, debugger_errors_root: Node = null) -> void:
 	_log_buffer = log_buffer
 	_connection = connection
 	_debugger_plugin = debugger_plugin
 	_game_log_buffer = game_log_buffer
 	_editor_log_buffer = editor_log_buffer
+	_debugger_errors_root = debugger_errors_root
 
 
 func get_editor_state(_params: Dictionary) -> Dictionary:
@@ -66,6 +68,7 @@ func get_logs(params: Dictionary) -> Dictionary:
 	var count: int = maxi(0, int(params.get("count", 50)))
 	var offset: int = maxi(0, int(params.get("offset", 0)))
 	var source: String = str(params.get("source", "plugin"))
+	var include_details: bool = bool(params.get("include_details", false))
 	if not source in VALID_LOG_SOURCES:
 		return ErrorCodes.make(
 			ErrorCodes.VALUE_OUT_OF_RANGE,
@@ -76,11 +79,11 @@ func get_logs(params: Dictionary) -> Dictionary:
 		"plugin":
 			return _get_plugin_logs(count, offset)
 		"game":
-			return _get_game_logs(count, offset)
+			return _get_game_logs(count, offset, include_details)
 		"editor":
-			return _get_editor_logs(count, offset)
+			return _get_editor_logs(count, offset, include_details)
 		"all":
-			return _get_all_logs(count, offset)
+			return _get_all_logs(count, offset, include_details)
 	return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Unreachable")
 
 
@@ -101,7 +104,7 @@ func _get_plugin_logs(count: int, offset: int) -> Dictionary:
 	}
 
 
-func _get_game_logs(count: int, offset: int) -> Dictionary:
+func _get_game_logs(count: int, offset: int, include_details: bool) -> Dictionary:
 	if _game_log_buffer == null:
 		return {
 			"data": {
@@ -115,7 +118,7 @@ func _get_game_logs(count: int, offset: int) -> Dictionary:
 				"dropped_count": 0,
 			}
 		}
-	var page := _game_log_buffer.get_range(offset, count)
+	var page := _entries_for_response(_game_log_buffer.get_range(offset, count), include_details)
 	return {
 		"data": {
 			"source": "game",
@@ -130,37 +133,28 @@ func _get_game_logs(count: int, offset: int) -> Dictionary:
 	}
 
 
-func _get_editor_logs(count: int, offset: int) -> Dictionary:
+func _get_editor_logs(count: int, offset: int, include_details: bool) -> Dictionary:
 	## Editor-process script errors (parse errors, @tool runtime errors,
 	## EditorPlugin errors, push_error/push_warning). Captured by
 	## editor_logger.gd via OS.add_logger and gated on Godot 4.5+; on older
-	## engines or before plugin enable the buffer is null/empty and we
-	## return an empty page so callers can poll unconditionally.
-	if _editor_log_buffer == null:
-		return {
-			"data": {
-				"source": "editor",
-				"lines": [],
-				"total_count": 0,
-				"returned_count": 0,
-				"offset": offset,
-				"dropped_count": 0,
-			}
-		}
-	var page := _editor_log_buffer.get_range(offset, count)
+	## engines the buffer can be null. Godot also sends GDScript reload
+	## warnings/errors straight to the Debugger dock's Errors tab; those do
+	## not flow through OS.add_logger, so merge the visible tree rows here.
+	var all_entries := _collect_editor_log_entries()
+	var page := _entries_for_response(_slice_entries(all_entries, offset, count), include_details)
 	return {
 		"data": {
 			"source": "editor",
 			"lines": page,
-			"total_count": _editor_log_buffer.total_count(),
+			"total_count": all_entries.size(),
 			"returned_count": page.size(),
 			"offset": offset,
-			"dropped_count": _editor_log_buffer.dropped_count(),
+			"dropped_count": _editor_log_buffer.dropped_count() if _editor_log_buffer != null else 0,
 		}
 	}
 
 
-func _get_all_logs(count: int, offset: int) -> Dictionary:
+func _get_all_logs(count: int, offset: int, include_details: bool) -> Dictionary:
 	## Plugin lines have no timestamp, so we can't merge chronologically.
 	## Concatenate plugin → editor → game and apply the offset/count window
 	## over the combined list. The per-line `source` field tells callers
@@ -170,9 +164,8 @@ func _get_all_logs(count: int, offset: int) -> Dictionary:
 	var combined: Array[Dictionary] = []
 	for line in _log_buffer.get_recent(_log_buffer.total_count()):
 		combined.append({"source": "plugin", "level": "info", "text": line})
-	if _editor_log_buffer != null:
-		for entry in _editor_log_buffer.get_range(0, _editor_log_buffer.total_count()):
-			combined.append(entry)
+	for entry in _collect_editor_log_entries():
+		combined.append(entry)
 	if _game_log_buffer != null:
 		for entry in _game_log_buffer.get_range(0, _game_log_buffer.total_count()):
 			combined.append(entry)
@@ -180,6 +173,7 @@ func _get_all_logs(count: int, offset: int) -> Dictionary:
 	var page: Array[Dictionary] = []
 	for i in range(mini(offset, combined.size()), stop):
 		page.append(combined[i])
+	page = _entries_for_response(page, include_details)
 	var run_id := ""
 	var dropped := 0
 	if _game_log_buffer != null:
@@ -199,6 +193,191 @@ func _get_all_logs(count: int, offset: int) -> Dictionary:
 			"dropped_count": dropped,
 		}
 	}
+
+
+func _entries_for_response(entries: Array[Dictionary], include_details: bool) -> Array[Dictionary]:
+	var out: Array[Dictionary] = []
+	for entry in entries:
+		var copy: Dictionary = entry.duplicate(true)
+		if not include_details:
+			copy.erase("details")
+		out.append(copy)
+	return out
+
+
+func _collect_editor_log_entries() -> Array[Dictionary]:
+	var entries: Array[Dictionary] = []
+	if _editor_log_buffer != null:
+		for entry in _editor_log_buffer.get_range(0, _editor_log_buffer.total_count()):
+			entries.append(entry)
+	for entry in _read_debugger_error_entries():
+		if not _has_equivalent_log_entry(entries, entry):
+			entries.append(entry)
+	return entries
+
+
+func _read_debugger_error_entries() -> Array[Dictionary]:
+	if _debugger_plugin == null and _debugger_errors_root == null:
+		return []
+	var root: Node = _debugger_errors_root
+	if root == null:
+		root = EditorInterface.get_base_control()
+	if root == null:
+		return []
+	var trees: Array[Tree] = []
+	_collect_debugger_error_trees(root, trees)
+	var entries: Array[Dictionary] = []
+	for tree in trees:
+		for entry in _entries_from_debugger_error_tree(tree):
+			if not _has_equivalent_log_entry(entries, entry):
+				entries.append(entry)
+	return entries
+
+
+static func _collect_debugger_error_trees(node: Node, out: Array[Tree]) -> void:
+	if node is Tree and _tree_has_debugger_errors(node as Tree):
+		out.append(node as Tree)
+	for child in node.get_children():
+		if child is Node:
+			_collect_debugger_error_trees(child as Node, out)
+
+
+static func _tree_has_debugger_errors(tree: Tree) -> bool:
+	var root := tree.get_root()
+	if root == null:
+		return false
+	var item := root.get_first_child()
+	while item != null:
+		if _is_debugger_error_item(item):
+			return true
+		item = item.get_next()
+	return false
+
+
+static func _entries_from_debugger_error_tree(tree: Tree) -> Array[Dictionary]:
+	var entries: Array[Dictionary] = []
+	var root := tree.get_root()
+	if root == null:
+		return entries
+	var item := root.get_first_child()
+	while item != null:
+		if _is_debugger_error_item(item):
+			entries.append(_entry_from_debugger_error_item(item))
+		item = item.get_next()
+	return entries
+
+
+static func _entry_from_debugger_error_item(item: TreeItem) -> Dictionary:
+	var title := item.get_text(1)
+	var loc := _location_from_metadata(item.get_metadata(0))
+	var function := _function_from_title(title)
+	return {
+		"source": "editor",
+		"level": "warn" if item.has_meta("_is_warning") else "error",
+		"text": title,
+		"path": str(loc.get("path", "")),
+		"line": int(loc.get("line", 0)),
+		"function": function,
+		"details": _details_from_debugger_error_item(item, loc, function),
+	}
+
+
+static func _details_from_debugger_error_item(item: TreeItem, loc: Dictionary, function: String) -> Dictionary:
+	var children: Array[Dictionary] = []
+	var frames: Array[Dictionary] = []
+	var child := item.get_first_child()
+	while child != null:
+		var child_loc := _location_from_metadata(child.get_metadata(0))
+		var child_entry := {
+			"label": child.get_text(0),
+			"text": child.get_text(1),
+			"path": str(child_loc.get("path", "")),
+			"line": int(child_loc.get("line", 0)),
+		}
+		children.append(child_entry)
+		if _is_stack_trace_item(child, child_loc):
+			frames.append({
+				"path": child_entry.path,
+				"line": child_entry.line,
+				"function": _function_from_frame_text(child_entry.text),
+			})
+		child = child.get_next()
+	return {
+		"debugger_tab": "Errors",
+		"time": item.get_text(0),
+		"message": item.get_text(1),
+		"error_type_name": "warning" if item.has_meta("_is_warning") else "error",
+		"source": {
+			"path": str(loc.get("path", "")),
+			"line": int(loc.get("line", 0)),
+			"function": function,
+		},
+		"resolved": {
+			"path": str(loc.get("path", "")),
+			"line": int(loc.get("line", 0)),
+			"function": function,
+		},
+		"children": children,
+		"frames": frames,
+	}
+
+
+static func _is_debugger_error_item(item: TreeItem) -> bool:
+	return item.has_meta("_is_warning") or item.has_meta("_is_error")
+
+
+static func _is_stack_trace_item(item: TreeItem, loc: Dictionary) -> bool:
+	if str(item.get_text(0)).find("Stack Trace") >= 0:
+		return true
+	return not str(loc.get("path", "")).is_empty() and not item.get_parent().has_meta("_is_warning") and not item.get_parent().has_meta("_is_error")
+
+
+static func _location_from_metadata(meta: Variant) -> Dictionary:
+	if meta is Array and meta.size() >= 2:
+		return {"path": str(meta[0]), "line": int(meta[1])}
+	return {"path": "", "line": 0}
+
+
+static func _function_from_title(title: String) -> String:
+	var colon := title.find(": ")
+	if colon <= 0:
+		return ""
+	return title.substr(0, colon)
+
+
+static func _function_from_frame_text(text: String) -> String:
+	var marker := text.find(" @ ")
+	if marker < 0:
+		return ""
+	var fn := text.substr(marker + 3).strip_edges()
+	if fn.ends_with("()"):
+		fn = fn.substr(0, fn.length() - 2)
+	return fn
+
+
+static func _slice_entries(entries: Array[Dictionary], offset: int, count: int) -> Array[Dictionary]:
+	var page: Array[Dictionary] = []
+	var stop := mini(entries.size(), offset + count)
+	for i in range(mini(offset, entries.size()), stop):
+		page.append(entries[i])
+	return page
+
+
+static func _has_equivalent_log_entry(entries: Array[Dictionary], candidate: Dictionary) -> bool:
+	var key := _log_entry_key(candidate)
+	for entry in entries:
+		if _log_entry_key(entry) == key:
+			return true
+	return false
+
+
+static func _log_entry_key(entry: Dictionary) -> String:
+	return "%s|%s|%s|%s" % [
+		str(entry.get("level", "")),
+		str(entry.get("text", "")),
+		str(entry.get("path", "")),
+		str(entry.get("line", 0)),
+	]
 
 
 ## Map of human-readable monitor names to Performance.Monitor enum values.
@@ -736,11 +915,30 @@ func get_performance_monitors(params: Dictionary) -> Dictionary:
 func clear_logs(_params: Dictionary) -> Dictionary:
 	var count := _log_buffer.total_count()
 	_log_buffer.clear()
+	var debugger_errors_cleared := _clear_debugger_error_trees()
 	return {
 		"data": {
 			"cleared_count": count,
+			"debugger_errors_cleared": debugger_errors_cleared,
 		}
 	}
+
+
+func _clear_debugger_error_trees() -> int:
+	if _debugger_plugin == null and _debugger_errors_root == null:
+		return 0
+	var root: Node = _debugger_errors_root
+	if root == null:
+		root = EditorInterface.get_base_control()
+	if root == null:
+		return 0
+	var trees: Array[Tree] = []
+	_collect_debugger_error_trees(root, trees)
+	var cleared := 0
+	for tree in trees:
+		cleared += _entries_from_debugger_error_tree(tree).size()
+		tree.clear()
+	return cleared
 
 
 func reload_plugin(_params: Dictionary) -> Dictionary:

--- a/plugin/addons/godot_ai/runtime/loggers/editor_logger.gd
+++ b/plugin/addons/godot_ai/runtime/loggers/editor_logger.gd
@@ -82,11 +82,25 @@ func _log_error(
 		resolved.path = message_res_path
 		resolved.line = 0
 		resolved.function = function
+		_update_resolved_details(resolved)
 	if _is_in_godot_ai_addon(resolved.path):
 		return
 	if not message_res_path.is_empty() and _is_in_godot_ai_addon(message_res_path):
 		return
-	_buffer.append(resolved.level, resolved.message, resolved.path, resolved.line, resolved.function)
+	var details: Dictionary = resolved.get("details", {})
+	_buffer.append(resolved.level, resolved.message, resolved.path, resolved.line, resolved.function, details)
+
+
+static func _update_resolved_details(resolved: Dictionary) -> void:
+	var details: Dictionary = resolved.get("details", {})
+	if details.is_empty():
+		return
+	details["resolved"] = {
+		"path": resolved.get("path", ""),
+		"line": resolved.get("line", 0),
+		"function": resolved.get("function", ""),
+	}
+	resolved["details"] = details
 
 
 ## Predicate broken out so tests can drive the path-filter logic without

--- a/plugin/addons/godot_ai/runtime/loggers/game_logger.gd
+++ b/plugin/addons/godot_ai/runtime/loggers/game_logger.gd
@@ -75,7 +75,8 @@ func _log_error(
 	if not resolved.path.is_empty():
 		loc = "%s:%d @ %s" % [resolved.path, resolved.line, resolved.function] if not resolved.function.is_empty() else "%s:%d" % [resolved.path, resolved.line]
 	var text: String = "%s (%s)" % [resolved.message, loc] if not loc.is_empty() else resolved.message
-	_append(resolved.level, text)
+	var details: Dictionary = resolved.get("details", {})
+	_append(resolved.level, text, details)
 	if error_type == _ERROR_TYPE_SCRIPT:
 		## Collect every function name in the first non-empty backtrace so
 		## game_helper can match its eval's uniquely named wrapper function.
@@ -93,9 +94,12 @@ func _log_error(
 		_mutex.unlock()
 
 
-func _append(level: String, text: String) -> void:
+func _append(level: String, text: String, details: Dictionary = {}) -> void:
 	_mutex.lock()
-	_pending.append([level, text])
+	if details.is_empty():
+		_pending.append([level, text])
+	else:
+		_pending.append([level, text, details.duplicate(true)])
 	_mutex.unlock()
 
 

--- a/plugin/addons/godot_ai/testing/stub_backtrace.gd
+++ b/plugin/addons/godot_ai/testing/stub_backtrace.gd
@@ -9,31 +9,30 @@ extends RefCounted
 ## backtrace-remapping path without a live script execution — Godot
 ## doesn't expose a constructor for the real ScriptBacktrace.
 ##
-## Single-frame is enough: both loggers only consult the first non-empty
-## frame of `script_backtraces` (via `McpLogBacktrace.resolve_error`).
+## Defaults to a single frame for existing tests, but can carry multiple
+## frames so detail payload tests can verify full stack preservation.
 
-var _file: String
-var _line: int
-var _function: String
+var _frames: Array[Dictionary] = []
 
 
-func _init(file: String, line: int, function: String) -> void:
-	_file = file
-	_line = line
-	_function = function
+func _init(file: String, line: int, function: String, frames: Array[Dictionary] = []) -> void:
+	if frames.is_empty():
+		_frames = [{"path": file, "line": line, "function": function}]
+	else:
+		_frames = frames
 
 
 func get_frame_count() -> int:
-	return 1
+	return _frames.size()
 
 
-func get_frame_file(_idx: int) -> String:
-	return _file
+func get_frame_file(idx: int) -> String:
+	return str(_frames[idx].get("path", ""))
 
 
-func get_frame_line(_idx: int) -> int:
-	return _line
+func get_frame_line(idx: int) -> int:
+	return int(_frames[idx].get("line", 0))
 
 
-func get_frame_function(_idx: int) -> String:
-	return _function
+func get_frame_function(idx: int) -> String:
+	return str(_frames[idx].get("function", ""))

--- a/plugin/addons/godot_ai/utils/editor_log_buffer.gd
+++ b/plugin/addons/godot_ai/utils/editor_log_buffer.gd
@@ -32,7 +32,7 @@ func _init() -> void:
 	super._init(MAX_LINES)
 
 
-func append(level: String, text: String, path: String = "", line: int = 0, function: String = "") -> void:
+func append(level: String, text: String, path: String = "", line: int = 0, function: String = "", details: Dictionary = {}) -> void:
 	var entry := {
 		"source": "editor",
 		"level": _coerce_level(level),
@@ -41,6 +41,8 @@ func append(level: String, text: String, path: String = "", line: int = 0, funct
 		"line": line,
 		"function": function,
 	}
+	if not details.is_empty():
+		entry["details"] = details.duplicate(true)
 	_mutex.lock()
 	_append_entry(entry)
 	_mutex.unlock()

--- a/plugin/addons/godot_ai/utils/game_log_buffer.gd
+++ b/plugin/addons/godot_ai/utils/game_log_buffer.gd
@@ -23,8 +23,11 @@ func _init() -> void:
 	super._init(MAX_LINES)
 
 
-func append(level: String, text: String) -> void:
-	_append_entry({"source": "game", "level": _coerce_level(level), "text": text})
+func append(level: String, text: String, details: Dictionary = {}) -> void:
+	var entry := {"source": "game", "level": _coerce_level(level), "text": text}
+	if not details.is_empty():
+		entry["details"] = details.duplicate(true)
+	_append_entry(entry)
 
 
 ## Rotate the run identifier and drop all buffered entries. Called when the

--- a/plugin/addons/godot_ai/utils/log_backtrace.gd
+++ b/plugin/addons/godot_ai/utils/log_backtrace.gd
@@ -32,11 +32,21 @@ extends RefCounted
 ## frame; loggers that need to filter by source path call this first and
 ## then check the resolved `path` field.
 ##
-## Returns: `{level, message, path, line, function}`
+## Returns: `{level, message, path, line, function, details}`
 ##   - `level`: "error" or "warn" (warn iff `error_type == 1`).
 ##   - `message`: `rationale` when non-empty, else `code`.
 ##   - `path` / `line` / `function`: first backtrace frame when one is
 ##     available; otherwise the original `file` / `line` / `function`.
+##   - `details`: original `_log_error` fields plus the first non-empty
+##     backtrace as frames, mirroring the debugger Errors tab context.
+const ERROR_TYPE_NAMES := {
+	0: "error",
+	1: "warning",
+	2: "script",
+	3: "shader",
+}
+
+
 static func resolve_error(
 	function: String,
 	file: String,
@@ -49,19 +59,55 @@ static func resolve_error(
 	var src_file := file
 	var src_line := line
 	var src_function := function
+	var frames: Array[Dictionary] = []
 	## First non-empty frame wins, not just `script_backtraces[0]` —
 	## chained errors can leave the leading entry empty with the actual
 	## user frame in `script_backtraces[1]`.
 	for bt in script_backtraces:
 		if bt != null and bt.get_frame_count() > 0:
-			src_file = bt.get_frame_file(0)
-			src_line = bt.get_frame_line(0)
-			src_function = bt.get_frame_function(0)
+			frames = _frames_from_backtrace(bt)
+			src_file = str(frames[0].get("path", ""))
+			src_line = int(frames[0].get("line", 0))
+			src_function = str(frames[0].get("function", ""))
 			break
+	var message := rationale if not rationale.is_empty() else code
 	return {
 		"level": "warn" if error_type == 1 else "error",
-		"message": rationale if not rationale.is_empty() else code,
+		"message": message,
 		"path": src_file,
 		"line": src_line,
 		"function": src_function,
+		"details": {
+			"message": message,
+			"code": code,
+			"rationale": rationale,
+			"error_type": error_type,
+			"error_type_name": _error_type_name(error_type),
+			"source": {
+				"path": file,
+				"line": line,
+				"function": function,
+			},
+			"resolved": {
+				"path": src_file,
+				"line": src_line,
+				"function": src_function,
+			},
+			"frames": frames,
+		},
 	}
+
+
+static func _frames_from_backtrace(bt) -> Array[Dictionary]:
+	var frames: Array[Dictionary] = []
+	for i in bt.get_frame_count():
+		frames.append({
+			"path": bt.get_frame_file(i),
+			"line": bt.get_frame_line(i),
+			"function": bt.get_frame_function(i),
+		})
+	return frames
+
+
+static func _error_type_name(error_type: int) -> String:
+	return str(ERROR_TYPE_NAMES.get(error_type, "unknown"))

--- a/src/godot_ai/handlers/editor.py
+++ b/src/godot_ai/handlers/editor.py
@@ -196,6 +196,7 @@ async def logs_read(
     offset: int = 0,
     source: str = "plugin",
     since_run_id: str = "",
+    include_details: bool = False,
 ) -> dict:
     if source not in _VALID_LOG_SOURCES:
         raise ValueError(f"Invalid source '{source}' — use 'plugin', 'game', 'editor', or 'all'")
@@ -219,11 +220,15 @@ async def logs_read(
                 flat.append(str(entry))
         return paginate(flat, offset, count, key="lines")
 
-    ## game / all: ask the plugin to apply offset+count itself so the
+    ## game / editor / all: ask the plugin to apply offset+count itself so the
     ## ring buffer's run_id, dropped_count, and is_running stay
     ## authoritative on the editor side.
+    params = {"count": count, "offset": offset, "source": source}
+    if include_details:
+        params["include_details"] = True
     result = await runtime.send_command(
-        "get_logs", {"count": count, "offset": offset, "source": source}
+        "get_logs",
+        params,
     )
     run_id = result.get("run_id", "")
     if since_run_id and run_id and run_id != since_run_id:

--- a/src/godot_ai/handlers/editor.py
+++ b/src/godot_ai/handlers/editor.py
@@ -183,8 +183,11 @@ async def performance_monitors_get(
     return await runtime.send_command("get_performance_monitors", params)
 
 
-async def logs_clear(runtime: DirectRuntime) -> dict:
-    return await runtime.send_command("clear_logs")
+async def logs_clear(runtime: DirectRuntime, clear_debugger_errors: bool = False) -> dict:
+    params: dict = {}
+    if clear_debugger_errors:
+        params["clear_debugger_errors"] = True
+    return await runtime.send_command("clear_logs", params)
 
 
 _VALID_LOG_SOURCES = ("plugin", "game", "editor", "all")

--- a/src/godot_ai/tools/editor.py
+++ b/src/godot_ai/tools/editor.py
@@ -76,6 +76,7 @@ def register_editor_tools(mcp: FastMCP, *, include_non_core: bool = True) -> Non
         offset: int = 0,
         source: str = "plugin",
         since_run_id: str = "",
+        include_details: bool = False,
         session_id: str = "",
     ) -> dict:
         """Read recent log lines from the Godot editor, plugin, or running game.
@@ -88,25 +89,32 @@ def register_editor_tools(mcp: FastMCP, *, include_non_core: bool = True) -> Non
           via ``_mcp_game_helper`` autoload (Godot 4.5+). Buffer 2000, clears
           on each ``project_run``. Entries: {source, level, text}; response
           carries run_id, is_running, dropped_count.
-        - "editor": editor-process script errors — parse errors, @tool/
-          EditorPlugin runtime errors, push_error/push_warning (Godot 4.5+).
-          Use when the editor's Output panel shows red lines but other
-          sources turned up nothing. Buffer 500, persists across
-          ``project_run``. Entries: {source, level, text, path, line,
-          function}. Filtered to .gd/.cs in the user project;
-          addons/godot_ai/ dropped. Errors fired before plugin enable are
-          not captured.
+        - "editor": editor-process script errors and the Debugger dock's
+          visible Errors-tab rows — parse errors, GDScript reload warnings,
+          @tool/EditorPlugin runtime errors, push_error/push_warning.
+          Logger-backed entries require Godot 4.5+; Errors-tab rows are read
+          from the editor UI when available. Use when the editor Output or
+          Debugger Errors panel shows red/yellow rows but other sources turned
+          up nothing. Buffer 500 for logger-backed entries; Debugger rows are
+          live UI state. Entries: {source, level, text, path, line, function}.
+          Filtered to .gd/.cs in the user project for Logger-backed entries;
+          addons/godot_ai/ dropped. Logger entries fired before plugin enable
+          are not captured.
         - "all": plugin → editor → game lines (with source per entry).
 
         Tail pattern: poll with offset=N + since_run_id=R. ``stale_run_id: true``
         means the buffer has rotated; reset offset to 0 and capture new run_id.
         ``run_id`` is empty for ``source="editor"`` (editor logs don't rotate).
+        Set ``include_details=True`` for Errors-tab style metadata on game/editor
+        entries: original code/rationale, error type, resolved source, and
+        stack frames. Default false preserves compact responses.
 
         Args:
             count: Max lines to return. Default 50.
             offset: Lines to skip. Default 0.
             source: "plugin" | "game" | "editor" | "all". Default "plugin".
             since_run_id: Stale-detection token from a previous response.
+            include_details: Include rich error metadata for game/editor entries.
             session_id: Optional Godot session to target. Empty = active session.
         """
         runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
@@ -116,6 +124,7 @@ def register_editor_tools(mcp: FastMCP, *, include_non_core: bool = True) -> Non
             offset=offset,
             source=source,
             since_run_id=since_run_id,
+            include_details=include_details,
         )
 
     @mcp.tool(output_schema=None, meta=DEFER_META)

--- a/src/godot_ai/tools/editor.py
+++ b/src/godot_ai/tools/editor.py
@@ -32,8 +32,11 @@ Ops:
         a list of monitor names to filter; None returns everything.
   • quit()
         Gracefully quit the Godot editor on next frame.
-  • logs_clear()
-        Clear the MCP log buffer. Returns lines_cleared.
+  • logs_clear(clear_debugger_errors=False)
+        Clear the MCP log buffer. Returns cleared_count. Pass
+        clear_debugger_errors=True to also clear the Debugger dock's
+        visible Errors-tab rows (user-facing UI, so opt-in only); the
+        response then includes debugger_errors_cleared.
   • game_eval(code)
         Execute GDScript in the running game with return values. Uses
         'await' so user code can await internally. Errors return fast and

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -114,6 +114,16 @@ func test_clear_logs_empties_buffer() -> void:
 	assert_eq(buf.total_count(), 0)
 
 
+func test_clear_logs_clears_debugger_errors_tree() -> void:
+	var tree := _make_debugger_errors_tree()
+	var handler := EditorHandler.new(McpLogBuffer.new(), null, McpDebuggerPlugin.new(), null, null, tree)
+	var result := handler.clear_logs({})
+	assert_eq(result.data.cleared_count, 0)
+	assert_eq(result.data.debugger_errors_cleared, 2)
+	var logs := handler.get_logs({"source": "editor", "count": 10})
+	assert_eq(logs.data.total_count, 0)
+
+
 # ----- get_performance_monitors -----
 
 # ----- take_screenshot -----
@@ -687,6 +697,18 @@ func test_game_log_buffer_unknown_level_coerces_to_info() -> void:
 	assert_eq(entries[0].level, "info", "Unknown level should coerce to info")
 
 
+func test_game_log_buffer_preserves_details() -> void:
+	var buf := McpGameLogBuffer.new()
+	buf.append("error", "boom", {
+		"code": "boom",
+		"frames": [{"path": "res://player.gd", "line": 8, "function": "_ready"}],
+	})
+	var entries := buf.get_range(0, 10)
+	assert_has_key(entries[0], "details")
+	assert_eq(entries[0].details.code, "boom")
+	assert_eq(entries[0].details.frames[0].path, "res://player.gd")
+
+
 func test_game_log_buffer_ring_evicts_and_tracks_dropped() -> void:
 	var buf := McpGameLogBuffer.new()
 	var cap := McpGameLogBuffer.MAX_LINES
@@ -821,15 +843,40 @@ func test_get_logs_source_game_empty_when_no_buffer() -> void:
 func test_get_logs_source_game_returns_buffered_entries() -> void:
 	var game_buf := McpGameLogBuffer.new()
 	game_buf.clear_for_new_run()
-	game_buf.append("info", "spawned 12 blocks")
+	game_buf.append("info", "spawned 12 blocks", {"code": "spawned"})
 	game_buf.append("error", "null deref")
 	var handler := EditorHandler.new(McpLogBuffer.new(), null, null, game_buf)
 	var result := handler.get_logs({"source": "game", "count": 10})
 	assert_eq(result.data.source, "game")
 	assert_eq(result.data.lines.size(), 2)
 	assert_eq(result.data.lines[0].text, "spawned 12 blocks")
+	assert_false(result.data.lines[0].has("details"), "Details are opt-in")
 	assert_eq(result.data.lines[1].level, "error")
 	assert_ne(result.data.run_id, "", "run_id should be set after clear_for_new_run")
+
+
+func test_get_logs_include_details_returns_buffered_metadata() -> void:
+	var game_buf := McpGameLogBuffer.new()
+	game_buf.append("error", "game boom", {
+		"code": "ERR_GAME",
+		"frames": [{"path": "res://game.gd", "line": 5, "function": "_tick"}],
+	})
+	var ed_buf := McpEditorLogBuffer.new()
+	ed_buf.append("error", "editor boom", "res://tool.gd", 9, "_run", {
+		"code": "ERR_EDITOR",
+		"frames": [{"path": "res://tool.gd", "line": 9, "function": "_run"}],
+	})
+	var handler := EditorHandler.new(McpLogBuffer.new(), null, null, game_buf, ed_buf)
+
+	var compact := handler.get_logs({"source": "all", "count": 10})
+	assert_false(compact.data.lines[0].has("details"), "Compact all-source logs strip details")
+	assert_false(compact.data.lines[1].has("details"), "Compact all-source logs strip details")
+
+	var detailed := handler.get_logs({"source": "all", "count": 10, "include_details": true})
+	assert_eq(detailed.data.lines[0].details.code, "ERR_EDITOR")
+	assert_eq(detailed.data.lines[0].details.frames[0].path, "res://tool.gd")
+	assert_eq(detailed.data.lines[1].details.code, "ERR_GAME")
+	assert_eq(detailed.data.lines[1].details.frames[0].function, "_tick")
 
 
 func test_get_logs_source_game_offset_applies() -> void:
@@ -899,6 +946,18 @@ func test_editor_log_buffer_missing_fields_default_to_empty() -> void:
 	assert_eq(e.function, "")
 
 
+func test_editor_log_buffer_preserves_details() -> void:
+	var buf := McpEditorLogBuffer.new()
+	buf.append("error", "Parse Error", "res://broken.gd", 12, "", {
+		"code": "Parse Error",
+		"frames": [{"path": "res://broken.gd", "line": 12, "function": ""}],
+	})
+	var e := buf.get_range(0, 1)[0]
+	assert_has_key(e, "details")
+	assert_eq(e.details.code, "Parse Error")
+	assert_eq(e.details.frames[0].line, 12)
+
+
 func test_editor_log_buffer_ring_evicts_and_tracks_dropped() -> void:
 	var buf := McpEditorLogBuffer.new()
 	var cap := McpEditorLogBuffer.MAX_LINES
@@ -950,6 +1009,52 @@ func test_get_logs_source_editor_returns_buffered_entries() -> void:
 	assert_eq(result.data.lines[0].line, 17)
 	assert_eq(result.data.lines[1].level, "warn")
 	assert_eq(result.data.lines[1].function, "_compute")
+
+
+func test_get_logs_source_editor_reads_debugger_errors_tree() -> void:
+	var tree := _make_debugger_errors_tree()
+	var handler := EditorHandler.new(McpLogBuffer.new(), null, McpDebuggerPlugin.new(), null, null, tree)
+	var result := handler.get_logs({"source": "editor", "count": 10})
+	assert_eq(result.data.source, "editor")
+	assert_eq(result.data.total_count, 2)
+	assert_eq(result.data.lines[0].level, "warn")
+	assert_eq(result.data.lines[0].text, "GDScript::reload: The variable \"hash\" has the same name as a built-in function.")
+	assert_eq(result.data.lines[0].path, "res://scripts/player.gd")
+	assert_eq(result.data.lines[0].line, 21)
+	assert_eq(result.data.lines[0].function, "GDScript::reload")
+	assert_eq(result.data.lines[1].level, "error")
+	assert_eq(result.data.lines[1].path, "res://scripts/broken.gd")
+
+
+func test_get_logs_source_editor_details_include_debugger_errors_children() -> void:
+	var tree := _make_debugger_errors_tree()
+	var handler := EditorHandler.new(McpLogBuffer.new(), null, McpDebuggerPlugin.new(), null, null, tree)
+	var result := handler.get_logs({"source": "editor", "count": 1, "include_details": true})
+	var details: Dictionary = result.data.lines[0].details
+	assert_eq(details.debugger_tab, "Errors")
+	assert_eq(details.time, "0:00:00:776")
+	assert_eq(details.source.path, "res://scripts/player.gd")
+	assert_eq(details.children[0].label, "<GDScript Error>")
+	assert_eq(details.children[1].label, "<GDScript Source>")
+	assert_eq(details.frames[0].path, "res://scripts/player.gd")
+	assert_eq(details.frames[0].function, "_ready")
+
+
+func test_get_logs_source_editor_dedupes_debugger_errors_tree() -> void:
+	var ed_buf := McpEditorLogBuffer.new()
+	ed_buf.append(
+		"warn",
+		"GDScript::reload: The variable \"hash\" has the same name as a built-in function.",
+		"res://scripts/player.gd",
+		21,
+		"GDScript::reload",
+	)
+	var tree := _make_debugger_errors_tree()
+	var handler := EditorHandler.new(McpLogBuffer.new(), null, McpDebuggerPlugin.new(), null, ed_buf, tree)
+	var result := handler.get_logs({"source": "editor", "count": 10})
+	assert_eq(result.data.total_count, 2, "duplicate debugger row should not repeat the buffered warning")
+	assert_eq(result.data.lines[0].text, "GDScript::reload: The variable \"hash\" has the same name as a built-in function.")
+	assert_eq(result.data.lines[1].text, "Parse Error: Expected statement")
 
 
 func test_get_logs_source_editor_offset_applies() -> void:
@@ -1004,6 +1109,58 @@ func test_get_logs_source_invalid_message_lists_editor() -> void:
 	var result := handler.get_logs({"source": "bogus"})
 	assert_is_error(result)
 	assert_contains(result.error.message, "editor")
+
+
+func _make_debugger_errors_tree() -> Tree:
+	var tree := Tree.new()
+	tree.set_columns(2)
+	tree.set_hide_root(true)
+	var root := tree.create_item()
+
+	var warning := tree.create_item(root)
+	warning.set_meta("_is_warning", true)
+	warning.set_text(0, "0:00:00:776")
+	warning.set_text(1, "GDScript::reload: The variable \"hash\" has the same name as a built-in function.")
+	warning.set_metadata(0, ["res://scripts/player.gd", 21])
+	var warning_condition := tree.create_item(warning)
+	warning_condition.set_text(0, "<GDScript Error>")
+	warning_condition.set_text(1, "BUILTIN_SHADOWED")
+	var warning_source := tree.create_item(warning)
+	warning_source.set_text(0, "<GDScript Source>")
+	warning_source.set_text(1, "player.gd:21 @ GDScript::reload()")
+	warning_source.set_metadata(0, ["res://scripts/player.gd", 21])
+	var warning_frame := tree.create_item(warning)
+	warning_frame.set_text(0, "<Stack Trace>")
+	warning_frame.set_text(1, "res://scripts/player.gd:21 @ _ready()")
+	warning_frame.set_metadata(0, ["res://scripts/player.gd", 21])
+
+	var error := tree.create_item(root)
+	error.set_meta("_is_error", true)
+	error.set_text(0, "0:00:00:790")
+	error.set_text(1, "Parse Error: Expected statement")
+	error.set_metadata(0, ["res://scripts/broken.gd", 12])
+	return tree
+
+
+func test_log_backtrace_resolve_error_preserves_all_frames() -> void:
+	var bt := StubBacktrace.new("", 0, "", [
+		{"path": "res://player.gd", "line": 44, "function": "_take_damage"},
+		{"path": "res://main.gd", "line": 12, "function": "_ready"},
+	])
+	var resolved := McpLogBacktrace.resolve_error(
+		"push_error",
+		"core/variant/variant_utility.cpp",
+		1000,
+		"hp went negative",
+		"",
+		2,
+		[bt],
+	)
+	assert_eq(resolved.path, "res://player.gd")
+	assert_eq(resolved.details.error_type_name, "script")
+	assert_eq(resolved.details.source.path, "core/variant/variant_utility.cpp")
+	assert_eq(resolved.details.frames.size(), 2)
+	assert_eq(resolved.details.frames[1].function, "_ready")
 
 
 # ----- EditorLogger filtering (issue #231) -----
@@ -1154,6 +1311,10 @@ func test_editor_logger_uses_script_backtrace_for_push_error() -> void:
 	assert_eq(entries[0].line, 17)
 	assert_eq(entries[0].function, "_handle_event")
 	assert_contains(entries[0].text, "user-flagged-bug")
+	assert_eq(entries[0].details.error_type_name, "error")
+	assert_eq(entries[0].details.source.path, "core/variant/variant_utility.cpp")
+	assert_eq(entries[0].details.resolved.path, "res://user_tool.gd")
+	assert_eq(entries[0].details.frames[0].function, "_handle_event")
 
 
 func test_editor_logger_drops_push_error_from_plugin_via_backtrace() -> void:
@@ -1249,6 +1410,23 @@ func test_debugger_plugin_log_batch_appends_to_buffer() -> void:
 	var entries := game_buf.get_range(0, 10)
 	assert_eq(entries[0].text, "alpha")
 	assert_eq(entries[1].level, "error")
+
+
+func test_debugger_plugin_log_batch_preserves_details() -> void:
+	var game_buf := McpGameLogBuffer.new()
+	var plugin := McpDebuggerPlugin.new(null, game_buf)
+	plugin._capture("mcp:log_batch", [[
+		["error", "boom", {
+			"code": "ERR",
+			"frames": [{"path": "res://game.gd", "line": 21, "function": "_ready"}],
+		}],
+		{"level": "warn", "text": "dict-entry", "details": {"code": "WARN"}},
+	]], 0)
+	var entries := game_buf.get_range(0, 10)
+	assert_eq(entries.size(), 2)
+	assert_eq(entries[0].details.frames[0].path, "res://game.gd")
+	assert_eq(entries[1].level, "warn")
+	assert_eq(entries[1].details.code, "WARN")
 
 
 func test_debugger_plugin_hello_rotates_run_id() -> void:
@@ -1394,6 +1572,10 @@ func test_game_logger_uses_script_backtrace_for_push_error() -> void:
 	assert_contains(pending[0][1], "res://player.gd:88", "Backtrace path:line should land in the formatted text")
 	assert_contains(pending[0][1], "_take_damage", "Backtrace function should land in the formatted text")
 	assert_true(not pending[0][1].contains("variant_utility.cpp"), "C++ wrapper path should be replaced by the backtrace")
+	assert_eq(pending[0].size(), 3, "Runtime log batches carry optional details")
+	assert_eq(pending[0][2].source.path, "core/variant/variant_utility.cpp")
+	assert_eq(pending[0][2].resolved.path, "res://player.gd")
+	assert_eq(pending[0][2].frames[0].line, 88)
 
 
 func test_game_logger_falls_back_to_original_file_when_no_backtrace() -> void:

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -114,14 +114,60 @@ func test_clear_logs_empties_buffer() -> void:
 	assert_eq(buf.total_count(), 0)
 
 
-func test_clear_logs_clears_debugger_errors_tree() -> void:
+func test_clear_logs_leaves_debugger_errors_tree_by_default() -> void:
 	var tree := _make_debugger_errors_tree()
 	var handler := EditorHandler.new(McpLogBuffer.new(), null, McpDebuggerPlugin.new(), null, null, tree)
 	var result := handler.clear_logs({})
 	assert_eq(result.data.cleared_count, 0)
+	assert_false(result.data.has("debugger_errors_cleared"), "Errors-tab clear is opt-in")
+	var logs := handler.get_logs({"source": "editor", "count": 10})
+	assert_eq(logs.data.total_count, 2, "Visible Errors rows must survive a default clear_logs")
+	tree.free()
+
+
+func test_clear_logs_clears_debugger_errors_tree_on_opt_in() -> void:
+	var tree := _make_debugger_errors_tree()
+	var handler := EditorHandler.new(McpLogBuffer.new(), null, McpDebuggerPlugin.new(), null, null, tree)
+	var result := handler.clear_logs({"clear_debugger_errors": true})
+	assert_eq(result.data.cleared_count, 0)
 	assert_eq(result.data.debugger_errors_cleared, 2)
 	var logs := handler.get_logs({"source": "editor", "count": 10})
 	assert_eq(logs.data.total_count, 0)
+	tree.free()
+
+
+class DebuggerClearStub:
+	extends RefCounted
+	var tree: Tree
+	var pressed_count := 0
+
+	func _clear_errors_list() -> void:
+		pressed_count += 1
+		tree.clear()
+
+
+func test_clear_logs_routes_through_debugger_clear_button() -> void:
+	## The real Errors panel must be cleared via its own Clear button so the
+	## engine resets error_count/warning_count, the tab badge, and button
+	## states — model the panel as button + tree under one container and
+	## assert the button's pressed path ran instead of a raw Tree.clear().
+	var panel := VBoxContainer.new()
+	var toolbar := HBoxContainer.new()
+	panel.add_child(toolbar)
+	var clear_button := Button.new()
+	toolbar.add_child(clear_button)
+	var tree := _make_debugger_errors_tree()
+	panel.add_child(tree)
+	var stub := DebuggerClearStub.new()
+	stub.tree = tree
+	clear_button.pressed.connect(stub._clear_errors_list)
+
+	var handler := EditorHandler.new(McpLogBuffer.new(), null, McpDebuggerPlugin.new(), null, null, panel)
+	var result := handler.clear_logs({"clear_debugger_errors": true})
+	assert_eq(result.data.debugger_errors_cleared, 2)
+	assert_eq(stub.pressed_count, 1, "Clear must go through the panel's own Clear button")
+	assert_true(tree.get_root() == null, "Button handler should have emptied the tree")
+	panel.free()
 
 
 # ----- get_performance_monitors -----
@@ -1036,8 +1082,48 @@ func test_get_logs_source_editor_details_include_debugger_errors_children() -> v
 	assert_eq(details.source.path, "res://scripts/player.gd")
 	assert_eq(details.children[0].label, "<GDScript Error>")
 	assert_eq(details.children[1].label, "<GDScript Source>")
+	assert_eq(details.frames.size(), 2, "Every stack row must land in frames, not just the labeled first one")
 	assert_eq(details.frames[0].path, "res://scripts/player.gd")
 	assert_eq(details.frames[0].function, "_ready")
+	assert_eq(details.frames[1].path, "res://scripts/main.gd")
+	assert_eq(details.frames[1].line, 12)
+	assert_eq(details.frames[1].function, "_start")
+	tree.free()
+
+
+func test_get_logs_details_frames_survive_translated_stack_trace_label() -> void:
+	## The "<Stack Trace>" label is TTR-translated, so frame detection must
+	## not depend on the English text: frames past the first are the only
+	## rows with an empty label and a real location, and the row before the
+	## first of those is the labeled first frame.
+	var tree := Tree.new()
+	tree.set_columns(2)
+	tree.set_hide_root(true)
+	var root := tree.create_item()
+	var error := tree.create_item(root)
+	error.set_meta("_is_error", true)
+	error.set_text(0, "0:00:01:002")
+	error.set_text(1, "_ready: boom")
+	error.set_metadata(0, ["res://scripts/player.gd", 8])
+	var source := tree.create_item(error)
+	source.set_text(0, "<GDScript-Quelle>")
+	source.set_text(1, "player.gd:8 @ _ready()")
+	source.set_metadata(0, ["res://scripts/player.gd", 8])
+	var frame_0 := tree.create_item(error)
+	frame_0.set_text(0, "<Stapelverfolgung>")
+	frame_0.set_text(1, "player.gd:8 @ _ready()")
+	frame_0.set_metadata(0, ["res://scripts/player.gd", 8])
+	var frame_1 := tree.create_item(error)
+	frame_1.set_text(1, "main.gd:3 @ _init()")
+	frame_1.set_metadata(0, ["res://scripts/main.gd", 3])
+
+	var handler := EditorHandler.new(McpLogBuffer.new(), null, McpDebuggerPlugin.new(), null, null, tree)
+	var result := handler.get_logs({"source": "editor", "count": 1, "include_details": true})
+	var frames: Array = result.data.lines[0].details.frames
+	assert_eq(frames.size(), 2)
+	assert_eq(frames[0].function, "_ready")
+	assert_eq(frames[1].function, "_init")
+	tree.free()
 
 
 func test_get_logs_source_editor_dedupes_debugger_errors_tree() -> void:
@@ -1111,6 +1197,11 @@ func test_get_logs_source_invalid_message_lists_editor() -> void:
 	assert_contains(result.error.message, "editor")
 
 
+## Mirrors ScriptEditorDebugger's real Errors-tab layout (verified against
+## script_editor_debugger.cpp on 4.3 and 4.6): children of an error item are
+## flat — optional "<X Error>" row, one "<X Source>" row, then one row per
+## stack frame. Only frame 0 carries the "<Stack Trace>" label; later frames
+## have an empty label. Frame text uses the file *name*, not the res:// path.
 func _make_debugger_errors_tree() -> Tree:
 	var tree := Tree.new()
 	tree.set_columns(2)
@@ -1125,14 +1216,18 @@ func _make_debugger_errors_tree() -> Tree:
 	var warning_condition := tree.create_item(warning)
 	warning_condition.set_text(0, "<GDScript Error>")
 	warning_condition.set_text(1, "BUILTIN_SHADOWED")
+	warning_condition.set_metadata(0, ["res://scripts/player.gd", 21])
 	var warning_source := tree.create_item(warning)
 	warning_source.set_text(0, "<GDScript Source>")
 	warning_source.set_text(1, "player.gd:21 @ GDScript::reload()")
 	warning_source.set_metadata(0, ["res://scripts/player.gd", 21])
 	var warning_frame := tree.create_item(warning)
 	warning_frame.set_text(0, "<Stack Trace>")
-	warning_frame.set_text(1, "res://scripts/player.gd:21 @ _ready()")
+	warning_frame.set_text(1, "player.gd:21 @ _ready()")
 	warning_frame.set_metadata(0, ["res://scripts/player.gd", 21])
+	var warning_frame_2 := tree.create_item(warning)
+	warning_frame_2.set_text(1, "main.gd:12 @ _start()")
+	warning_frame_2.set_metadata(0, ["res://scripts/main.gd", 12])
 
 	var error := tree.create_item(root)
 	error.set_meta("_is_error", true)

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -442,6 +442,80 @@ class TestLogsReadTool:
         assert data["dropped_count"] == 0
         assert data["stale_run_id"] is False
 
+    async def test_include_details_returns_errors_tab_context(self, mcp_stack):
+        client, plugin = mcp_stack
+        entries = [
+            {
+                "source": "editor",
+                "level": "error",
+                "text": "Invalid get index 'hp' on base Nil.",
+                "path": "res://player.gd",
+                "line": 44,
+                "function": "_take_damage",
+                "details": {
+                    "code": "Invalid get index 'hp' on base Nil.",
+                    "rationale": "",
+                    "error_type": 2,
+                    "error_type_name": "script",
+                    "source": {
+                        "path": "core/variant/variant_utility.cpp",
+                        "line": 1000,
+                        "function": "push_error",
+                    },
+                    "resolved": {
+                        "path": "res://player.gd",
+                        "line": 44,
+                        "function": "_take_damage",
+                    },
+                    "frames": [
+                        {
+                            "path": "res://player.gd",
+                            "line": 44,
+                            "function": "_take_damage",
+                        },
+                        {
+                            "path": "res://main.gd",
+                            "line": 12,
+                            "function": "_ready",
+                        },
+                    ],
+                },
+            }
+        ]
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "get_logs"
+            assert cmd["params"] == {
+                "count": 50,
+                "offset": 0,
+                "source": "editor",
+                "include_details": True,
+            }
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "source": "editor",
+                    "lines": entries,
+                    "total_count": 1,
+                    "returned_count": 1,
+                    "offset": 0,
+                    "dropped_count": 0,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "logs_read",
+            {"source": "editor", "include_details": True},
+        )
+        await task
+
+        data = result.data
+        assert data["lines"] == entries
+        assert data["lines"][0]["details"]["resolved"]["path"] == "res://player.gd"
+        assert data["lines"][0]["details"]["frames"][1]["function"] == "_ready"
+
 
 # ---------------------------------------------------------------------------
 # node_find

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -2849,6 +2849,27 @@ class TestLogsClearTool:
         assert not result.is_error
         assert result.data["cleared_count"] == 12
 
+    async def test_clear_debugger_errors_opt_in_forwards(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "clear_logs"
+            assert cmd["params"]["clear_debugger_errors"] is True
+            await plugin.send_response(
+                cmd["request_id"], {"cleared_count": 3, "debugger_errors_cleared": 2}
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "editor_manage",
+            {"op": "logs_clear", "params": {"clear_debugger_errors": True}},
+        )
+        await task
+
+        assert not result.is_error
+        assert result.data["debugger_errors_cleared"] == 2
+
 
 # ---------------------------------------------------------------------------
 # project_run / project_stop

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -1543,9 +1543,7 @@ async def test_game_input_gamepad_axis_sends_value_not_pressed():
     client = StubClient()
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)
 
-    await game_handlers.game_input_gamepad(
-        runtime, device=2, control="axis", index=1, value=0.5
-    )
+    await game_handlers.game_input_gamepad(runtime, device=2, control="axis", index=1, value=0.5)
 
     params = client.calls[-1]["params"]["params"]
     assert client.calls[-1]["params"]["op"] == "input_gamepad"
@@ -3206,6 +3204,15 @@ async def test_logs_clear_handler():
     result = await editor_handlers.logs_clear(runtime)
     assert result["cleared_count"] == 5
     assert client.calls[-1]["command"] == "clear_logs"
+    assert client.calls[-1]["params"] == {}
+
+
+async def test_logs_clear_handler_passes_clear_debugger_errors_opt_in():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    await editor_handlers.logs_clear(runtime, clear_debugger_errors=True)
+    assert client.calls[-1]["command"] == "clear_logs"
+    assert client.calls[-1]["params"] == {"clear_debugger_errors": True}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -68,12 +68,24 @@ class StubClient:
         if command == "get_logs":
             params_dict = params or {}
             source = params_dict.get("source", "plugin")
+            include_details = bool(params_dict.get("include_details", False))
             if source == "game":
                 req_offset = int(params_dict.get("offset", 0))
                 req_count = int(params_dict.get("count", 50))
                 all_entries = [
                     {"source": "game", "level": "info", "text": f"game {i}"} for i in range(5)
                 ]
+                if include_details:
+                    for entry in all_entries:
+                        entry["details"] = {
+                            "code": entry["text"],
+                            "rationale": "",
+                            "error_type": 0,
+                            "error_type_name": "error",
+                            "source": {"path": "", "line": 0, "function": ""},
+                            "resolved": {"path": "", "line": 0, "function": ""},
+                            "frames": [],
+                        }
                 page = all_entries[req_offset : req_offset + req_count]
                 return {
                     "source": "game",
@@ -99,6 +111,31 @@ class StubClient:
                     }
                     for i in range(3)
                 ]
+                if include_details:
+                    for entry in all_entries:
+                        entry["details"] = {
+                            "code": entry["text"],
+                            "rationale": "",
+                            "error_type": 2,
+                            "error_type_name": "script",
+                            "source": {
+                                "path": "core/variant/variant_utility.cpp",
+                                "line": 1000,
+                                "function": "push_error",
+                            },
+                            "resolved": {
+                                "path": entry["path"],
+                                "line": entry["line"],
+                                "function": entry["function"],
+                            },
+                            "frames": [
+                                {
+                                    "path": entry["path"],
+                                    "line": entry["line"],
+                                    "function": entry["function"],
+                                }
+                            ],
+                        }
                 page = all_entries[req_offset : req_offset + req_count]
                 return {
                     "source": "editor",
@@ -1345,6 +1382,30 @@ async def test_logs_read_handler_source_editor_passes_through():
     assert result["is_running"] is False
     assert result["stale_run_id"] is False
     assert result["has_more"] is False
+
+
+async def test_logs_read_handler_include_details_passes_through():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+
+    result = await editor_handlers.logs_read(
+        runtime,
+        count=1,
+        offset=0,
+        source="editor",
+        include_details=True,
+    )
+
+    last_call = client.calls[-1]
+    assert last_call["command"] == "get_logs"
+    assert last_call["params"] == {
+        "count": 1,
+        "offset": 0,
+        "source": "editor",
+        "include_details": True,
+    }
+    assert result["lines"][0]["details"]["error_type_name"] == "script"
+    assert result["lines"][0]["details"]["frames"][0]["path"] == "res://script_0.gd"
 
 
 async def test_logs_read_handler_plugin_normalizes_structured_payload():


### PR DESCRIPTION
Editor and game logs now preserve structured error details, read visible Debugger Errors rows through logs_read, and clear those rows from clear_logs. Compact responses remain the default; callers opt into rich metadata with include_details.
