### PR TITLE
harden(protocol): bound + charset-constrain the handshake session_id

### DIFF
--- a/src/godot_ai/protocol/envelope.py
+++ b/src/godot_ai/protocol/envelope.py
@@ -46,7 +46,12 @@ class HandshakeMessage(BaseModel):
     """Initial handshake sent by the Godot plugin on connection."""
 
     type: str = "handshake"
-    session_id: str
+    ## Bounded + charset-constrained: the plugin always produces "<slug>@<4hex>"
+    ## (slug is [a-z0-9-]; see connection.gd::_make_session_id), so this only
+    ## rejects a malformed or non-plugin peer. The value is used as a registry
+    ## key, logged, and hashed into telemetry, so an unbounded/arbitrary string
+    ## from an untrusted WS client shouldn't flow downstream unchecked (#527).
+    session_id: str = Field(pattern=r"^[A-Za-z0-9._@-]{1,128}$")
     godot_version: str
     project_path: str
     plugin_version: str

--- a/tests/unit/test_protocol.py
+++ b/tests/unit/test_protocol.py
@@ -2,6 +2,9 @@
 
 import json
 
+import pytest
+from pydantic import ValidationError
+
 from godot_ai.protocol.envelope import (
     CommandRequest,
     CommandResponse,
@@ -134,3 +137,34 @@ class TestHandshakeMessage:
             }
         )
         assert msg.server_launch_mode == "dev_venv"
+
+    def test_canonical_session_id_accepted(self):
+        ## The plugin's "<slug>@<4hex>" form must validate (connection.gd).
+        msg = HandshakeMessage(
+            session_id="my-game@a3f2",
+            godot_version="4.4.1",
+            project_path="/tmp/project",
+            plugin_version="0.0.1",
+        )
+        assert msg.session_id == "my-game@a3f2"
+
+    @pytest.mark.parametrize(
+        "bad_id",
+        [
+            "",  # empty
+            "has space",  # whitespace
+            "a/b/../etc",  # path separators / traversal shape
+            "x" * 129,  # over the 128 bound
+            "emoji😀",  # non-ASCII control/payload
+        ],
+    )
+    def test_malformed_session_id_rejected(self, bad_id):
+        ## An untrusted WS peer can't register an arbitrary/oversized id that
+        ## then flows into the registry key, logs, and telemetry hash (#527).
+        with pytest.raises(ValidationError):
+            HandshakeMessage(
+                session_id=bad_id,
+                godot_version="4.4.1",
+                project_path="/tmp/project",
+                plugin_version="0.0.1",
+            )


### PR DESCRIPTION
Wave 2 hardening — review finding **ST-4** ([#527](https://github.com/hi-godot/godot-ai/issues/527)).

The WebSocket handshake accepted an unbounded, arbitrary `session_id` from the peer, then used it as a registry key, logged it, and hashed it into telemetry. The plugin only ever produces `<slug>@<4hex>` (slug is `[a-z0-9-]`, see `connection.gd::_make_session_id`), so a `^[A-Za-z0-9._@-]{1,128}$` pattern rejects only malformed/non-plugin clients while accepting every legitimate id. A bad id now fails at the Pydantic boundary instead of populating the registry.

## Test
- `tests/unit/test_protocol.py`: canonical `slug@hex` accepted; empty / whitespace / path-separator / over-128 / non-ASCII rejected.
- Full handshake/transport/integration suite (403) green; ruff clean.

Closes #527.

🤖 Generated with [Claude Code](https://claude.com/claude-code)