### PR TITLE
ci: pin actions to SHAs, scope ci.yml token, add Dependabot, ignore reports

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  # Keep the SHA-pinned GitHub Actions fresh — Dependabot bumps the pin and
+  # updates the trailing version comment, so pinning doesn't mean going stale.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci(deps)"
+
+  # Python runtime + dev dependencies (pyproject.toml).
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps"

--- a/.github/workflows/bump-and-release.yml
+++ b/.github/workflows/bump-and-release.yml
@@ -32,7 +32,7 @@ jobs:
   bump:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Read current version
         id: current

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,11 @@ on:
 env:
   GODOT_AI_DISABLE_TELEMETRY: "true"
 
+## CI only reads the repo — no job here writes to it, so drop the default
+## token down to read-only (third-party actions run with this grant too).
+permissions:
+  contents: read
+
 jobs:
   python-tests:
     name: Python ${{ matrix.python-version }} / ${{ matrix.os }}
@@ -31,10 +36,10 @@ jobs:
         python-version: ["3.11", "3.13"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -52,7 +57,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
         with:
           files: ./coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -69,10 +74,10 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.13"
           cache: pip
@@ -118,7 +123,7 @@ jobs:
 
       - name: Upload build artifacts
         if: matrix.os == 'ubuntu-latest'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dist
           path: dist/
@@ -149,19 +154,19 @@ jobs:
             godot-version: "4.3.0"
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Build plugin link
         shell: bash
         run: bash script/verify-worktree
 
-      - uses: chickensoft-games/setup-godot@v2
+      - uses: chickensoft-games/setup-godot@f166999204a4f2722c6fe042fbaa3b3ea0d9c789 # v2
         with:
           version: ${{ matrix.godot-version }}
           use-dotnet: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.13"
           cache: pip
@@ -243,19 +248,19 @@ jobs:
             label: Windows
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Build plugin link
         shell: bash
         run: bash script/verify-worktree
 
-      - uses: chickensoft-games/setup-godot@v2
+      - uses: chickensoft-games/setup-godot@f166999204a4f2722c6fe042fbaa3b3ea0d9c789 # v2
         with:
           version: 4.6.2
           use-dotnet: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.13"
           cache: pip
@@ -306,13 +311,13 @@ jobs:
             label: Windows
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Build plugin link
         shell: bash
         run: bash script/verify-worktree
 
-      - uses: chickensoft-games/setup-godot@v2
+      - uses: chickensoft-games/setup-godot@f166999204a4f2722c6fe042fbaa3b3ea0d9c789 # v2
         with:
           version: 4.6.2
           use-dotnet: false
@@ -322,7 +327,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y xvfb
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.13"
           cache: pip

--- a/.github/workflows/close-issues-on-beta-merge.yml
+++ b/.github/workflows/close-issues-on-beta-merge.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Close issues referenced by closing keywords
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const body = context.payload.pull_request.body || '';

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       id-token: write  # required for PyPI OIDC
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Verify ref is a version tag
         # Guard against a manual workflow_dispatch on a branch ref (e.g.
@@ -46,7 +46,7 @@ jobs:
           fi
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.13"
 
@@ -67,7 +67,7 @@ jobs:
         run: python -m build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           # Idempotent re-runs: if this version is already on PyPI (e.g. a
           # previous run published but a downstream job failed), skip the
@@ -84,7 +84,7 @@ jobs:
     needs: publish-pypi
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Build plugin ZIP
         # Ship `addons/` + `godot-ai-LICENSE.txt` at the zip's top level. The
@@ -162,7 +162,7 @@ jobs:
           echo "Zip structure verified: addons/godot_ai/... + godot-ai-LICENSE.txt (multi-top)"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           files: godot-ai-plugin.zip
           generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,10 @@ test_project/tests/_mcp_test_*
 
 # stormtest scratch artifacts (script/stormtest.py)
 _stormtest/
+
+# Local audit / review reports (generated deliverables, not part of the repo)
+/security-audit*.html
+/robustness-review*.html
+
+# Self-update smoke-test artifact dropped into the test project
+test_project/godot-ai-LICENSE.txt


### PR DESCRIPTION
Wave 2 hardening — review findings **CI-2 / CI-3 / CI-5 / CI-7**.

- **[#540](https://github.com/hi-godot/godot-ai/issues/540)** Pin every Action to a full commit SHA with a trailing version comment. Highest-value targets: `softprops/action-gh-release` (`contents: write`) and `pypa/gh-action-pypi-publish@release/v1` (a mutable *branch* ref, `id-token: write` PyPI publish). 22 refs across 4 workflows; none left unpinned.
- **[#539](https://github.com/hi-godot/godot-ai/issues/539)** Add top-level `permissions: contents: read` to `ci.yml` (the one workflow that lacked a scope; the others already declare one).
- **[#541](https://github.com/hi-godot/godot-ai/issues/541)** Add `.github/dependabot.yml` (github-actions + pip, weekly) so the SHA pins and Python deps get update PRs.
- **[#543](https://github.com/hi-godot/godot-ai/issues/543)** `.gitignore` the generated audit/review HTML reports + self-update smoke artifact.

## Verification
All workflow YAML + dependabot.yml parse cleanly; SHAs resolved from the current tags via the GitHub API; `git check-ignore` confirms the report files are now ignored.

Closes #539, #540, #541, #543.

🤖 Generated with [Claude Code](https://claude.com/claude-code)