### PR TITLE
Add GDScript write diagnostics

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -45,6 +45,17 @@ clear the Debugger dock's visible Errors-tab rows (routed through the panel's
 own Clear path so the tab badge and counters reset). The Errors panel is
 user-facing UI, so the default leaves it untouched.
 
+`script_create` and `script_patch` validate written `.gd` content before the
+editor import step and include per-write diagnostics in their response:
+`diagnostics` (array of structured editor-style entries), `diagnostics_scope`
+(`"this_file"`), `diagnostics_status` (`"checked"` or `"partial"` if the scoped
+log window overflowed), and `diagnostics_detail`. `diagnostics_detail` is
+`"log_capture"` when entries came from the editor log capture window,
+`"fallback"` when `GDScript.reload()` failed but Godot did not expose structured
+log details for the ephemeral script, and `"none"` when no diagnostics were
+reported. Fallback diagnostics still prove the content failed validation, but
+their line number is a best-effort hint marked with `details.fallback_line`.
+
 ## Domain rollups (`<domain>_manage`)
 
 Each rollup is a single MCP tool dispatched by `op` name + `params` dict.

--- a/plugin/addons/godot_ai/handlers/script_handler.gd
+++ b/plugin/addons/godot_ai/handlers/script_handler.gd
@@ -2,11 +2,13 @@
 extends RefCounted
 
 const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+const DiagnosticsCapture := preload("res://addons/godot_ai/utils/diagnostics_capture.gd")
 
 ## Handles script creation, reading, attaching, detaching, and symbol inspection.
 
 var _undo_redo: EditorUndoRedoManager
 var _connection: McpConnection
+var _editor_log_buffer: McpEditorLogBuffer
 
 # Bounded settle window for `ResourceLoader.exists(path)` after `scan()` so
 # that an agent calling create_script -> attach_script back-to-back doesn't
@@ -18,9 +20,10 @@ const _IMPORT_SETTLE_MAX_FRAMES := 300
 const _IMPORT_SETTLE_MAX_MSEC := 3500
 
 
-func _init(undo_redo: EditorUndoRedoManager, connection: McpConnection = null) -> void:
+func _init(undo_redo: EditorUndoRedoManager, connection: McpConnection = null, editor_log_buffer: McpEditorLogBuffer = null) -> void:
 	_undo_redo = undo_redo
 	_connection = connection
+	_editor_log_buffer = editor_log_buffer
 
 
 func create_script(params: Dictionary) -> Dictionary:
@@ -50,6 +53,17 @@ func create_script(params: Dictionary) -> Dictionary:
 	file.store_string(content)
 	file.close()
 
+	var data := {
+		"path": path,
+		"size": content.length(),
+		"committed": true,
+		"import_settled": existed_before,
+		"import_settle": "already_known" if existed_before else "not_waited",
+		"undoable": false,
+		"reason": "File system operations cannot be undone via editor undo",
+	}
+	_attach_gdscript_diagnostics(data, path, content)
+
 	# Register just this file with the editor instead of a full recursive
 	# scan(). A scan() per write stacks `update_scripts_classes` /
 	# `update_script_paths_documentation` WorkerThreadPool tasks under concurrent
@@ -61,15 +75,6 @@ func create_script(params: Dictionary) -> Dictionary:
 	if efs != null:
 		efs.update_file(path)
 
-	var data := {
-		"path": path,
-		"size": content.length(),
-		"committed": true,
-		"import_settled": existed_before,
-		"import_settle": "already_known" if existed_before else "not_waited",
-		"undoable": false,
-		"reason": "File system operations cannot be undone via editor undo",
-	}
 	# `.gd.uid` is the sidecar Godot generates on scan; list both so the caller
 	# can rm the full set in one go.
 	McpResourceIO.attach_cleanup_hint(data, existed_before, [path, path + ".uid"])
@@ -165,6 +170,66 @@ func read_script(params: Dictionary) -> Dictionary:
 	}
 
 
+func _attach_gdscript_diagnostics(data: Dictionary, path: String, content: String) -> void:
+	var capture := DiagnosticsCapture.capture_this_file(_editor_log_buffer, path, func() -> Dictionary:
+		return _validate_gdscript_source(content)
+	)
+	var diagnostics: Array = capture.get("diagnostics", [])
+	var validation: Dictionary = capture.get("action", {})
+	var diagnostics_detail: String = capture.get("diagnostics_detail", "none")
+	if not validation.get("ok", true) and diagnostics.is_empty():
+		diagnostics.append(_fallback_gdscript_diagnostic(path, validation.get("error_code", FAILED), content))
+		diagnostics_detail = "fallback"
+	data["diagnostics"] = diagnostics
+	data["diagnostics_detail"] = diagnostics_detail
+	data["diagnostics_scope"] = capture.get("diagnostics_scope", "this_file")
+	data["diagnostics_status"] = capture.get("diagnostics_status", "checked")
+
+
+static func _validate_gdscript_source(content: String) -> Dictionary:
+	var script := GDScript.new()
+	script.source_code = content
+	## Keep validation off the live cached resource: assigning resource_path to
+	## this ephemeral Script can collide with loaded instances. reload() still
+	## performs normal GDScript analysis, including static initializer work, so
+	## this check is intentionally scoped to `.gd` writes where the editor would
+	## compile the file on scan anyway.
+	var err := script.reload()
+	return {
+		"ok": err == OK,
+		"error_code": err,
+	}
+
+
+static func _fallback_gdscript_diagnostic(path: String, error_code: int, content: String) -> Dictionary:
+	var line := _fallback_gdscript_error_line(content)
+	return {
+		"source": "editor",
+		"level": "error",
+		"text": "GDScript reload failed with error code %d." % error_code,
+		"path": path,
+		"line": line,
+		"function": "GDScript::reload",
+		"details": {
+			"code": "gdscript_reload_failed",
+			"error_code": error_code,
+			"fallback_line": true,
+			"source": {
+				"path": path,
+				"line": line,
+			},
+		},
+	}
+
+
+static func _fallback_gdscript_error_line(content: String) -> int:
+	var lines := content.split("\n")
+	for i in range(lines.size() - 1, -1, -1):
+		if not str(lines[i]).strip_edges().is_empty():
+			return i + 1
+	return 1
+
+
 func patch_script(params: Dictionary) -> Dictionary:
 	var path: String = params.get("path", "")
 	var old_text: String = params.get("old_text", "")
@@ -214,21 +279,22 @@ func patch_script(params: Dictionary) -> Dictionary:
 	write.store_string(new_content)
 	write.close()
 
+	var data := {
+		"path": path,
+		"replacements": replacements,
+		"size": new_content.length(),
+		"old_size": content.length(),
+		"undoable": false,
+		"reason": "File system operations cannot be undone via editor undo",
+	}
+	_attach_gdscript_diagnostics(data, path, new_content)
+
 	# Single-file register, not a full scan() — see create_script (dsarno/godot#6).
 	var efs := EditorInterface.get_resource_filesystem()
 	if efs != null:
 		efs.update_file(path)
 
-	return {
-		"data": {
-			"path": path,
-			"replacements": replacements,
-			"size": new_content.length(),
-			"old_size": content.length(),
-			"undoable": false,
-			"reason": "File system operations cannot be undone via editor undo",
-		}
-	}
+	return {"data": data}
 
 
 func attach_script(params: Dictionary) -> Dictionary:

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -242,7 +242,7 @@ func _enter_tree() -> void:
 	var node_handler := NodeHandler.new(get_undo_redo())
 	var project_handler := ProjectHandler.new(_connection, _debugger_plugin)
 	var client_handler := ClientHandler.new()
-	var script_handler := ScriptHandler.new(get_undo_redo(), _connection)
+	var script_handler := ScriptHandler.new(get_undo_redo(), _connection, _editor_log_buffer)
 	var resource_handler := ResourceHandler.new(get_undo_redo(), _connection)
 	var api_handler := ApiHandler.new()
 	var filesystem_handler := FilesystemHandler.new()

--- a/plugin/addons/godot_ai/utils/diagnostics_capture.gd
+++ b/plugin/addons/godot_ai/utils/diagnostics_capture.gd
@@ -45,11 +45,14 @@ static func _diagnostics_for_target(entries: Array, target_path: String) -> Arra
 static func _entry_matches_target(entry: Dictionary, target_path: String) -> bool:
 	var path := str(entry.get("path", ""))
 	## Ephemeral GDScript reloads report synthetic `gdscript://...` paths, and
-	## some logger events have no path at all. Accepting empty paths is a small
-	## residual misattribution risk for concurrent pathless editor errors, but
-	## the cursor window is deliberately narrow and this is the only way to keep
-	## pathless validation diagnostics from being dropped.
-	return path == target_path or path.is_empty() or _is_ephemeral_gdscript_path(path)
+	## some logger events have no path at all. Accept pathless/ephemeral entries
+	## only when their structured details do not point at a different concrete
+	## file; otherwise we would rewrite an unrelated diagnostic onto target_path.
+	if path == target_path:
+		return true
+	if path.is_empty() or _is_ephemeral_gdscript_path(path):
+		return not _details_conflict_with_target(entry.get("details", {}), target_path)
+	return false
 
 
 static func _normalize_entry(entry: Dictionary, target_path: String) -> Dictionary:
@@ -95,3 +98,33 @@ static func _should_rewrite_path(path: String, _target_path: String) -> bool:
 
 static func _is_ephemeral_gdscript_path(path: String) -> bool:
 	return path.begins_with("gdscript://")
+
+
+static func _details_conflict_with_target(details_value, target_path: String) -> bool:
+	if not details_value is Dictionary:
+		return false
+	var details: Dictionary = details_value
+	for key in ["source", "resolved"]:
+		if _location_conflicts_with_target(details.get(key), target_path):
+			return true
+	if _locations_conflict_with_target(details.get("frames"), target_path):
+		return true
+	if _locations_conflict_with_target(details.get("children"), target_path):
+		return true
+	return false
+
+
+static func _locations_conflict_with_target(items, target_path: String) -> bool:
+	if not items is Array:
+		return false
+	for item in items:
+		if _location_conflicts_with_target(item, target_path):
+			return true
+	return false
+
+
+static func _location_conflicts_with_target(location_value, target_path: String) -> bool:
+	if not location_value is Dictionary:
+		return false
+	var path := str(location_value.get("path", ""))
+	return not path.is_empty() and not _is_ephemeral_gdscript_path(path) and path != target_path

--- a/plugin/addons/godot_ai/utils/diagnostics_capture.gd
+++ b/plugin/addons/godot_ai/utils/diagnostics_capture.gd
@@ -1,0 +1,97 @@
+@tool
+class_name McpDiagnosticsCapture
+extends RefCounted
+
+## Small helper for scoped editor-log capture windows. Callers snapshot the
+## editor log cursor, perform a deliberate validation action, then only report
+## new diagnostics that can belong to the target file.
+
+
+static func capture_this_file(editor_log_buffer: McpEditorLogBuffer, target_path: String, action: Callable) -> Dictionary:
+	var cursor := 0
+	if editor_log_buffer != null:
+		cursor = editor_log_buffer.appended_total()
+
+	var action_result = action.call()
+	var diagnostics: Array[Dictionary] = []
+	var truncated := false
+
+	if editor_log_buffer != null:
+		var captured: Dictionary = editor_log_buffer.get_since(cursor)
+		truncated = captured.get("truncated", false)
+		diagnostics = _diagnostics_for_target(captured.get("entries", []), target_path)
+
+	return {
+		"action": action_result if action_result is Dictionary else {},
+		"diagnostics": diagnostics,
+		"diagnostics_detail": "log_capture" if not diagnostics.is_empty() else "none",
+		"diagnostics_scope": "this_file",
+		"diagnostics_status": "partial" if truncated else "checked",
+	}
+
+
+static func _diagnostics_for_target(entries: Array, target_path: String) -> Array[Dictionary]:
+	var out: Array[Dictionary] = []
+	for raw_entry in entries:
+		if not raw_entry is Dictionary:
+			continue
+		var entry: Dictionary = raw_entry
+		if not _entry_matches_target(entry, target_path):
+			continue
+		out.append(_normalize_entry(entry, target_path))
+	return out
+
+
+static func _entry_matches_target(entry: Dictionary, target_path: String) -> bool:
+	var path := str(entry.get("path", ""))
+	## Ephemeral GDScript reloads report synthetic `gdscript://...` paths, and
+	## some logger events have no path at all. Accepting empty paths is a small
+	## residual misattribution risk for concurrent pathless editor errors, but
+	## the cursor window is deliberately narrow and this is the only way to keep
+	## pathless validation diagnostics from being dropped.
+	return path == target_path or path.is_empty() or _is_ephemeral_gdscript_path(path)
+
+
+static func _normalize_entry(entry: Dictionary, target_path: String) -> Dictionary:
+	var normalized := entry.duplicate(true)
+	if _should_rewrite_path(str(normalized.get("path", "")), target_path):
+		normalized["path"] = target_path
+	if normalized.has("details") and normalized.details is Dictionary:
+		normalized["details"] = _normalize_details(normalized.details, target_path)
+	return normalized
+
+
+static func _normalize_details(details: Dictionary, target_path: String) -> Dictionary:
+	var normalized := details.duplicate(true)
+	for key in ["source", "resolved"]:
+		if normalized.get(key) is Dictionary:
+			var location: Dictionary = normalized[key]
+			if _should_rewrite_path(str(location.get("path", "")), target_path):
+				location["path"] = target_path
+			normalized[key] = location
+	if normalized.get("frames") is Array:
+		normalized["frames"] = _normalize_location_array(normalized.frames, target_path)
+	if normalized.get("children") is Array:
+		normalized["children"] = _normalize_location_array(normalized.children, target_path)
+	return normalized
+
+
+static func _normalize_location_array(items: Array, target_path: String) -> Array:
+	var out := []
+	for item in items:
+		if item is Dictionary:
+			var normalized: Dictionary = item.duplicate(true)
+			if _should_rewrite_path(str(normalized.get("path", "")), target_path):
+				normalized["path"] = target_path
+			out.append(normalized)
+		else:
+			out.append(item)
+	return out
+
+
+static func _should_rewrite_path(path: String, _target_path: String) -> bool:
+	return path.is_empty() or _is_ephemeral_gdscript_path(path)
+
+
+static func _is_ephemeral_gdscript_path(path: String) -> bool:
+	return path.begins_with("gdscript://")

--- a/plugin/addons/godot_ai/utils/diagnostics_capture.gd.uid
+++ b/plugin/addons/godot_ai/utils/diagnostics_capture.gd.uid
@@ -1,0 +1,1 @@
+uid://b3npxxpuobbc2

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -1133,6 +1133,21 @@ func test_diagnostics_capture_rewrites_ephemeral_gdscript_paths() -> void:
 	assert_eq(result.diagnostics[0].details.frames[0].path, target)
 
 
+func test_diagnostics_capture_rejects_pathless_entries_for_other_files() -> void:
+	var buf := McpEditorLogBuffer.new()
+	var target := "res://scripts/player.gd"
+	var result := DiagnosticsCapture.capture_this_file(buf, target, func() -> Dictionary:
+		buf.append("error", "unrelated parse error", "", 0, "", {
+			"source": {"path": "res://scripts/other.gd", "line": 12},
+			"frames": [{"path": "res://scripts/other.gd", "line": 12, "function": "_ready"}],
+		})
+		return {"ok": false, "error_code": ERR_PARSE_ERROR}
+	)
+
+	assert_eq(result.diagnostics_detail, "none")
+	assert_eq(result.diagnostics, [])
+
+
 func test_diagnostics_capture_reports_partial_when_window_overflows() -> void:
 	var buf := McpEditorLogBuffer.new()
 	var cap := McpEditorLogBuffer.MAX_LINES

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -3,6 +3,7 @@ extends McpTestSuite
 
 const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
 
+const DiagnosticsCapture := preload("res://addons/godot_ai/utils/diagnostics_capture.gd")
 const EditorHandler := preload("res://addons/godot_ai/handlers/editor_handler.gd")
 const StubBacktrace := preload("res://addons/godot_ai/testing/stub_backtrace.gd")
 
@@ -1107,6 +1108,46 @@ func test_editor_log_buffer_get_since_reports_clear_truncation() -> void:
 	assert_eq(result.entries[0].text, "after-clear")
 	assert_eq(result.oldest_cursor, 5)
 	assert_eq(result.next_cursor, 6)
+
+
+# ----- Diagnostics capture -----
+
+func test_diagnostics_capture_rewrites_ephemeral_gdscript_paths() -> void:
+	var buf := McpEditorLogBuffer.new()
+	var target := "res://scripts/player.gd"
+	var result := DiagnosticsCapture.capture_this_file(buf, target, func() -> Dictionary:
+		buf.append("error", "Parse Error: Expected statement", "gdscript://12345.gd", 7, "GDScript::reload", {
+			"source": {"path": "gdscript://12345.gd", "line": 7},
+			"frames": [{"path": "gdscript://12345.gd", "line": 7, "function": "GDScript::reload"}],
+		})
+		return {"ok": false, "error_code": ERR_PARSE_ERROR}
+	)
+
+	assert_eq(result.diagnostics_scope, "this_file")
+	assert_eq(result.diagnostics_status, "checked")
+	assert_eq(result.diagnostics_detail, "log_capture")
+	assert_eq(result.diagnostics.size(), 1)
+	assert_eq(result.diagnostics[0].path, target)
+	assert_eq(result.diagnostics[0].line, 7)
+	assert_eq(result.diagnostics[0].details.source.path, target)
+	assert_eq(result.diagnostics[0].details.frames[0].path, target)
+
+
+func test_diagnostics_capture_reports_partial_when_window_overflows() -> void:
+	var buf := McpEditorLogBuffer.new()
+	var cap := McpEditorLogBuffer.MAX_LINES
+	var target := "res://scripts/storm.gd"
+	var result := DiagnosticsCapture.capture_this_file(buf, target, func() -> Dictionary:
+		for i in range(cap + 2):
+			buf.append("error", "storm %d" % i, target, i)
+		return {"ok": false, "error_code": ERR_PARSE_ERROR}
+	)
+
+	assert_eq(result.diagnostics_status, "partial")
+	assert_eq(result.diagnostics_detail, "log_capture")
+	assert_eq(result.diagnostics_scope, "this_file")
+	assert_eq(result.diagnostics.size(), cap)
+	assert_eq(result.diagnostics[0].text, "storm 2")
 
 
 # ----- get_logs source="editor" routing (issue #231) -----

--- a/test_project/tests/test_script.gd
+++ b/test_project/tests/test_script.gd
@@ -116,6 +116,9 @@ func test_create_script_with_log_buffer_falls_back_when_ephemeral_reload_is_not_
 	## response honest: validation is checked, detail fidelity is fallback.
 	if skip_on_godot_lt("4.5", "Logger subclass only exists on Godot 4.5+"):
 		return
+	if not OS.has_method("add_logger"):
+		skip("Logger API is unavailable")
+		return
 	var logger_script := _LoggerLoader.build(_LoggerLoader.EDITOR_LOGGER_PATH)
 	assert_true(logger_script != null, "Editor logger script should compile on Godot 4.5+")
 	if logger_script == null:
@@ -316,7 +319,7 @@ func test_patch_script_ambiguous_match_without_replace_all() -> void:
 
 func test_patch_script_replace_all() -> void:
 	var path := "res://tests/_mcp_test_patch_all.gd"
-	var original := "foo()\nfoo()\nfoo()\n"
+	var original := "extends Node\n\n# foo\n# foo\n# foo\n"
 	var file := FileAccess.open(path, FileAccess.WRITE)
 	file.store_string(original)
 	file.close()
@@ -333,7 +336,7 @@ func test_patch_script_replace_all() -> void:
 	var read := FileAccess.open(path, FileAccess.READ)
 	var new_content := read.get_as_text()
 	read.close()
-	assert_eq(new_content, "bar()\nbar()\nbar()\n")
+	assert_eq(new_content, "extends Node\n\n# bar\n# bar\n# bar\n")
 	DirAccess.remove_absolute(path)
 
 

--- a/test_project/tests/test_script.gd
+++ b/test_project/tests/test_script.gd
@@ -5,11 +5,15 @@ const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
 
 const NodeHandler := preload("res://addons/godot_ai/handlers/node_handler.gd")
 const ScriptHandler := preload("res://addons/godot_ai/handlers/script_handler.gd")
+const _LoggerLoader := preload("res://addons/godot_ai/runtime/logger_loader.gd")
 
 ## Tests for ScriptHandler — script creation, reading, attach/detach, and symbol inspection.
 
 var _handler: ScriptHandler
+var _handler_with_logs: ScriptHandler
+var _editor_log_buffer: McpEditorLogBuffer
 var _undo_redo: EditorUndoRedoManager
+var _attached_test_logger = null
 
 const TEST_SCRIPT_PATH := "res://tests/_mcp_test_script.gd"
 const TEST_SCRIPT_CONTENT := """class_name _McpTestScript
@@ -41,6 +45,8 @@ func suite_name() -> String:
 func suite_setup(ctx: Dictionary) -> void:
 	_undo_redo = ctx.get("undo_redo")
 	_handler = ScriptHandler.new(_undo_redo)
+	_editor_log_buffer = McpEditorLogBuffer.new()
+	_handler_with_logs = ScriptHandler.new(_undo_redo, null, _editor_log_buffer)
 	# Create a test script file for read/symbol tests
 	var file := FileAccess.open(TEST_SCRIPT_PATH, FileAccess.WRITE)
 	if file:
@@ -49,6 +55,7 @@ func suite_setup(ctx: Dictionary) -> void:
 
 
 func suite_teardown() -> void:
+	_detach_test_logger()
 	# Clean up test script file
 	if FileAccess.file_exists(TEST_SCRIPT_PATH):
 		DirAccess.remove_absolute(TEST_SCRIPT_PATH)
@@ -66,6 +73,10 @@ func test_create_script_basic() -> void:
 	assert_eq(result.data.committed, true)
 	assert_eq(result.data.import_settled, false)
 	assert_eq(result.data.import_settle, "not_waited")
+	assert_eq(result.data.diagnostics_scope, "this_file")
+	assert_eq(result.data.diagnostics_status, "checked")
+	assert_eq(result.data.diagnostics_detail, "none")
+	assert_eq(result.data.diagnostics, [])
 	assert_false(result.data.undoable, "File write should not be undoable")
 	# Verify file was actually written
 	assert_true(FileAccess.file_exists(path), "Script file should exist")
@@ -77,6 +88,75 @@ func test_create_script_basic() -> void:
 	assert_eq(result.data.cleanup.rm, [path, path + ".uid"])
 	# Clean up
 	DirAccess.remove_absolute(path)
+
+
+func test_create_script_reports_fallback_diagnostics_without_log_buffer() -> void:
+	var path := "res://tests/_mcp_test_invalid_create.gd"
+	var content := "extends Node\n\nfunc _ready() -> void:\n\tif\n\tpass\n"
+	var result := _handler.create_script({"path": path, "content": content})
+	assert_has_key(result, "data")
+	assert_eq(result.data.path, path)
+	assert_eq(result.data.committed, true)
+	assert_eq(result.data.diagnostics_scope, "this_file")
+	assert_eq(result.data.diagnostics_status, "checked")
+	assert_eq(result.data.diagnostics_detail, "fallback")
+	assert_gt(result.data.diagnostics.size(), 0, "Invalid GDScript should report diagnostics")
+	assert_eq(result.data.diagnostics[0].path, path)
+	assert_eq(result.data.diagnostics[0].line, 5)
+	assert_eq(result.data.diagnostics[0].level, "error")
+	assert_eq(result.data.diagnostics[0].details.fallback_line, true)
+	assert_true(FileAccess.file_exists(path), "Invalid content is still written so the agent can fix it")
+	DirAccess.remove_absolute(path)
+
+
+func test_create_script_with_log_buffer_falls_back_when_ephemeral_reload_is_not_logged() -> void:
+	## Empirical guard for the real chain. Godot 4.6 prints ephemeral
+	## GDScript.reload() parse errors to stderr with a gdscript:// path, but
+	## they do not pass through OS.add_logger into McpEditorLogBuffer. Keep the
+	## response honest: validation is checked, detail fidelity is fallback.
+	if skip_on_godot_lt("4.5", "Logger subclass only exists on Godot 4.5+"):
+		return
+	var logger_script := _LoggerLoader.build(_LoggerLoader.EDITOR_LOGGER_PATH)
+	assert_true(logger_script != null, "Editor logger script should compile on Godot 4.5+")
+	if logger_script == null:
+		return
+	_attached_test_logger = logger_script.new(_editor_log_buffer)
+	var path := "res://tests/_mcp_test_invalid_create_logged.gd"
+	var content := "extends Node\n\nfunc _ready() -> void:\n\tif\n\tpass\n"
+	_editor_log_buffer.clear()
+	OS.call("add_logger", _attached_test_logger)
+	var result := _handler_with_logs.create_script({"path": path, "content": content})
+	_detach_test_logger()
+	assert_has_key(result, "data")
+	assert_eq(result.data.diagnostics_scope, "this_file")
+	assert_eq(result.data.diagnostics_status, "checked")
+	assert_eq(result.data.diagnostics_detail, "fallback")
+	assert_eq(_count_ephemeral_reload_parse_errors(_editor_log_buffer.get_recent(20)), 0, "Ephemeral reload parse errors are not logger-captured")
+	assert_gt(result.data.diagnostics.size(), 0)
+	assert_eq(result.data.diagnostics[0].path, path)
+	assert_eq(result.data.diagnostics[0].details.fallback_line, true)
+	DirAccess.remove_absolute(path)
+
+
+func _count_ephemeral_reload_parse_errors(entries: Array[Dictionary]) -> int:
+	var count := 0
+	for entry in entries:
+		var path := str(entry.get("path", ""))
+		var text := str(entry.get("text", ""))
+		var function := str(entry.get("function", ""))
+		if (
+			(path.is_empty() or path.begins_with("gdscript://"))
+			and text.find("Parse Error") != -1
+			and function.find("GDScript") != -1
+		):
+			count += 1
+	return count
+
+
+func _detach_test_logger() -> void:
+	if _attached_test_logger != null and OS.has_method("remove_logger"):
+		OS.call("remove_logger", _attached_test_logger)
+	_attached_test_logger = null
 
 
 func test_finish_create_script_deferred_is_static_and_handles_null_connection() -> void:
@@ -165,12 +245,47 @@ func test_patch_script_basic() -> void:
 	})
 	assert_has_key(result, "data")
 	assert_eq(result.data.replacements, 1)
+	assert_eq(result.data.diagnostics_scope, "this_file")
+	assert_eq(result.data.diagnostics_status, "checked")
+	assert_eq(result.data.diagnostics_detail, "none")
+	assert_eq(result.data.diagnostics, [])
 	assert_false(result.data.undoable)
 
 	var read := FileAccess.open(path, FileAccess.READ)
 	var new_content := read.get_as_text()
 	read.close()
 	assert_contains(new_content, "speed = 10")
+	DirAccess.remove_absolute(path)
+
+
+func test_patch_script_reports_fallback_diagnostics_without_log_buffer() -> void:
+	var path := "res://tests/_mcp_test_invalid_patch.gd"
+	var original := "extends Node\n\nfunc _ready() -> void:\n\tpass\n\tprint(\"after\")\n"
+	var file := FileAccess.open(path, FileAccess.WRITE)
+	file.store_string(original)
+	file.close()
+
+	var result := _handler.patch_script({
+		"path": path,
+		"old_text": "pass",
+		"new_text": "if",
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.path, path)
+	assert_eq(result.data.replacements, 1)
+	assert_eq(result.data.diagnostics_scope, "this_file")
+	assert_eq(result.data.diagnostics_status, "checked")
+	assert_eq(result.data.diagnostics_detail, "fallback")
+	assert_gt(result.data.diagnostics.size(), 0, "Invalid patched GDScript should report diagnostics")
+	assert_eq(result.data.diagnostics[0].path, path)
+	assert_eq(result.data.diagnostics[0].line, 5)
+	assert_eq(result.data.diagnostics[0].level, "error")
+	assert_eq(result.data.diagnostics[0].details.fallback_line, true)
+
+	var read := FileAccess.open(path, FileAccess.READ)
+	var new_content := read.get_as_text()
+	read.close()
+	assert_contains(new_content, "if")
 	DirAccess.remove_absolute(path)
 
 

--- a/tests/unit/test_script_create_import_settle.py
+++ b/tests/unit/test_script_create_import_settle.py
@@ -36,7 +36,10 @@ def test_script_handler_holds_connection_for_deferred_replies() -> None:
     )
     # _init must accept the connection. Default null keeps batch_execute and
     # unit-test contexts working on the synchronous fallback path.
-    expected_init = "func _init(undo_redo: EditorUndoRedoManager, connection: McpConnection = null)"
+    expected_init = (
+        "func _init(undo_redo: EditorUndoRedoManager, connection: McpConnection = null, "
+        "editor_log_buffer: McpEditorLogBuffer = null)"
+    )
     assert expected_init in source, (
         "ScriptHandler._init must accept the connection as an optional "
         "second parameter so test contexts can keep using the sync fallback."
@@ -169,7 +172,7 @@ def test_plugin_gd_passes_connection_to_script_handler() -> None:
     """plugin.gd must wire _connection into ScriptHandler — the field is null otherwise."""
     source = PLUGIN_GD.read_text(encoding="utf-8")
 
-    assert "ScriptHandler.new(get_undo_redo(), _connection)" in source, (
+    assert "ScriptHandler.new(get_undo_redo(), _connection, _editor_log_buffer)" in source, (
         "plugin.gd must construct ScriptHandler with the connection so the "
         "deferred-reply path is reachable in production. Without this, every "
         "create_script falls back to the synchronous reply and #261 returns."


### PR DESCRIPTION
## Summary

This PR adds inline GDScript diagnostics to `script_create` and `script_patch`.

Before this change, these tools could successfully write invalid `.gd` files and return `committed: true`; the caller only found out later by running the project or manually reading editor logs. Now each write validates the GDScript content immediately and includes diagnostics in the tool response.

This gives agents a faster feedback loop: write a script, see whether it parses, and fix it before moving on.

## What Changed

- Added a shared diagnostics capture helper.
- `script_create` and `script_patch` now validate `.gd` content with an ephemeral `GDScript` instance.
- Responses now include:
  - `diagnostics`
  - `diagnostics_scope`
  - `diagnostics_status`
  - `diagnostics_detail`
- Diagnostics are scoped to the file being written.
- If the editor log capture window overflows, the response reports `diagnostics_status: "partial"`.
- If Godot reports only the reload error code and does not expose structured log details for the ephemeral script, the response still includes a fallback diagnostic.

## Important Note

On current Godot versions tested here, ephemeral `GDScript.reload()` parse errors do not flow through the editor `Logger` hook into `McpEditorLogBuffer`. Because of that, invalid `.gd` writes currently return `diagnostics_detail: "fallback"`.

That fallback still proves the written content failed validation, but its line number is only a best-effort hint and is marked with `details.fallback_line: true`.

The path to exact line numbers is a follow-up: capture the editor’s real import/scan parse errors after `update_file()` settles, especially for `script_create`, which already has a deferred response path.

## Tests

- Added tests for diagnostics capture path normalization and overflow behavior.
- Added script handler tests for clean writes, invalid writes, fallback diagnostics, and the live logger-backed canary.
- Updated source contract tests for the new `ScriptHandler` constructor wiring.
- Added logger cleanup backstop so the live logger test cannot leak a logger into later suites.

Verified locally:

- Godot import passed
- `test_run suite="script"` passed
- `test_run suite="editor"` passed
- `tests/unit/test_script_create_import_settle.py` passed
- Python unit suite passed earlier on this branch
- `git diff --check` clean