### PR TITLE
Capture exact GDScript write diagnostics

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -49,12 +49,13 @@ user-facing UI, so the default leaves it untouched.
 editor import step and include per-write diagnostics in their response:
 `diagnostics` (array of structured editor-style entries), `diagnostics_scope`
 (`"this_file"`), `diagnostics_status` (`"checked"` or `"partial"` if the scoped
-log window overflowed), and `diagnostics_detail`. `diagnostics_detail` is
-`"log_capture"` when entries came from the editor log capture window,
-`"fallback"` when `GDScript.reload()` failed but Godot did not expose structured
-log details for the ephemeral script, and `"none"` when no diagnostics were
-reported. Fallback diagnostics still prove the content failed validation, but
-their line number is a best-effort hint marked with `details.fallback_line`.
+validation log window overflowed), and `diagnostics_detail`.
+`diagnostics_detail` is `"log_capture"` when Godot 4.5+'s Logger API supplied
+real parse diagnostics for the written file, `"fallback"` when validation failed
+but Logger details were unavailable (for example on Godot < 4.5), and `"none"`
+when no diagnostics were reported. Fallback diagnostics still prove the content
+failed validation, but their line number is a best-effort hint marked with
+`details.fallback_line`.
 
 ## Domain rollups (`<domain>_manage`)
 

--- a/plugin/addons/godot_ai/handlers/script_handler.gd
+++ b/plugin/addons/godot_ai/handlers/script_handler.gd
@@ -3,12 +3,12 @@ extends RefCounted
 
 const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
 const DiagnosticsCapture := preload("res://addons/godot_ai/utils/diagnostics_capture.gd")
+const LoggerLoader := preload("res://addons/godot_ai/runtime/logger_loader.gd")
 
 ## Handles script creation, reading, attaching, detaching, and symbol inspection.
 
 var _undo_redo: EditorUndoRedoManager
 var _connection: McpConnection
-var _editor_log_buffer: McpEditorLogBuffer
 
 # Bounded settle window for `ResourceLoader.exists(path)` after `scan()` so
 # that an agent calling create_script -> attach_script back-to-back doesn't
@@ -20,10 +20,9 @@ const _IMPORT_SETTLE_MAX_FRAMES := 300
 const _IMPORT_SETTLE_MAX_MSEC := 3500
 
 
-func _init(undo_redo: EditorUndoRedoManager, connection: McpConnection = null, editor_log_buffer: McpEditorLogBuffer = null) -> void:
+func _init(undo_redo: EditorUndoRedoManager, connection: McpConnection = null) -> void:
 	_undo_redo = undo_redo
 	_connection = connection
-	_editor_log_buffer = editor_log_buffer
 
 
 func create_script(params: Dictionary) -> Dictionary:
@@ -171,19 +170,23 @@ func read_script(params: Dictionary) -> Dictionary:
 
 
 func _attach_gdscript_diagnostics(data: Dictionary, path: String, content: String) -> void:
-	var capture := DiagnosticsCapture.capture_this_file(_editor_log_buffer, path, func() -> Dictionary:
-		return _validate_gdscript_source(content)
-	)
-	var diagnostics: Array = capture.get("diagnostics", [])
-	var validation: Dictionary = capture.get("action", {})
-	var diagnostics_detail: String = capture.get("diagnostics_detail", "none")
+	var validation := _validate_gdscript_source(content)
+	var diagnostics: Array = []
+	var diagnostics_detail := "none"
+	var diagnostics_status := "checked"
+
+	if not validation.get("ok", true):
+		var capture := _capture_gdscript_load_diagnostics(path)
+		diagnostics = capture.get("diagnostics", [])
+		diagnostics_detail = capture.get("diagnostics_detail", "none")
+		diagnostics_status = capture.get("diagnostics_status", "checked")
 	if not validation.get("ok", true) and diagnostics.is_empty():
 		diagnostics.append(_fallback_gdscript_diagnostic(path, validation.get("error_code", FAILED), content))
 		diagnostics_detail = "fallback"
 	data["diagnostics"] = diagnostics
 	data["diagnostics_detail"] = diagnostics_detail
-	data["diagnostics_scope"] = capture.get("diagnostics_scope", "this_file")
-	data["diagnostics_status"] = capture.get("diagnostics_status", "checked")
+	data["diagnostics_scope"] = "this_file"
+	data["diagnostics_status"] = diagnostics_status
 
 
 static func _validate_gdscript_source(content: String) -> Dictionary:
@@ -198,6 +201,35 @@ static func _validate_gdscript_source(content: String) -> Dictionary:
 	return {
 		"ok": err == OK,
 		"error_code": err,
+	}
+
+
+static func _capture_gdscript_load_diagnostics(path: String) -> Dictionary:
+	if not (ClassDB.class_exists("Logger") and OS.has_method("add_logger") and OS.has_method("remove_logger")):
+		return _empty_diagnostics_capture()
+	var logger_script := LoggerLoader.build(LoggerLoader.VALIDATION_LOGGER_PATH)
+	if logger_script == null:
+		return _empty_diagnostics_capture()
+	var buffer := McpEditorLogBuffer.new()
+	var logger = logger_script.new(buffer)
+	var capture := DiagnosticsCapture.capture_this_file(buffer, path, func() -> Dictionary:
+		OS.call("add_logger", logger)
+		# ResourceLoader.load() reports parse failure instead of throwing, and
+		# a failed GDScript parse does not execute user code; remove immediately
+		# after the synchronous load to keep the private capture window tiny.
+		ResourceLoader.load(path, "", ResourceLoader.CACHE_MODE_IGNORE)
+		OS.call("remove_logger", logger)
+		return {}
+	)
+	return capture
+
+
+static func _empty_diagnostics_capture() -> Dictionary:
+	return {
+		"diagnostics": [],
+		"diagnostics_detail": "none",
+		"diagnostics_scope": "this_file",
+		"diagnostics_status": "checked",
 	}
 
 

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -242,7 +242,7 @@ func _enter_tree() -> void:
 	var node_handler := NodeHandler.new(get_undo_redo())
 	var project_handler := ProjectHandler.new(_connection, _debugger_plugin)
 	var client_handler := ClientHandler.new()
-	var script_handler := ScriptHandler.new(get_undo_redo(), _connection, _editor_log_buffer)
+	var script_handler := ScriptHandler.new(get_undo_redo(), _connection)
 	var resource_handler := ResourceHandler.new(get_undo_redo(), _connection)
 	var api_handler := ApiHandler.new()
 	var filesystem_handler := FilesystemHandler.new()

--- a/plugin/addons/godot_ai/runtime/logger_loader.gd
+++ b/plugin/addons/godot_ai/runtime/logger_loader.gd
@@ -25,6 +25,7 @@ extends RefCounted
 
 const EDITOR_LOGGER_PATH := "res://addons/godot_ai/runtime/loggers/editor_logger.gd"
 const GAME_LOGGER_PATH := "res://addons/godot_ai/runtime/loggers/game_logger.gd"
+const VALIDATION_LOGGER_PATH := "res://addons/godot_ai/runtime/loggers/validation_logger.gd"
 
 
 ## Compile a `.gdignore`'d logger script from its on-disk source. Returns the

--- a/plugin/addons/godot_ai/runtime/loggers/validation_logger.gd
+++ b/plugin/addons/godot_ai/runtime/loggers/validation_logger.gd
@@ -1,0 +1,43 @@
+@tool
+extends Logger
+
+## Short-lived Logger used only for per-write validation loads.
+##
+## Unlike editor_logger.gd this deliberately has no addon feedback-loop filter:
+## the caller attaches it around one ResourceLoader.load() call, reads its
+## private buffer, and immediately removes it. The shared editor logger should
+## still drop these validation-load errors so logs_read(source="editor") stays
+## clean.
+
+const _LogBacktrace := preload("res://addons/godot_ai/utils/log_backtrace.gd")
+
+var _buffer
+
+
+func _init(buffer = null) -> void:
+	_buffer = buffer
+
+
+func _log_error(
+	function: String,
+	file: String,
+	line: int,
+	code: String,
+	rationale: String,
+	_editor_notify: bool,
+	error_type: int,
+	script_backtraces: Array,
+) -> void:
+	if _buffer == null:
+		return
+	var resolved := _LogBacktrace.resolve_error(
+		function,
+		file,
+		line,
+		code,
+		rationale,
+		error_type,
+		script_backtraces,
+	)
+	var details: Dictionary = resolved.get("details", {})
+	_buffer.append(resolved.level, resolved.message, resolved.path, resolved.line, resolved.function, details)

--- a/plugin/addons/godot_ai/utils/diagnostics_capture.gd
+++ b/plugin/addons/godot_ai/utils/diagnostics_capture.gd
@@ -2,22 +2,22 @@
 class_name McpDiagnosticsCapture
 extends RefCounted
 
-## Small helper for scoped editor-log capture windows. Callers snapshot the
-## editor log cursor, perform a deliberate validation action, then only report
-## new diagnostics that can belong to the target file.
+## Small helper for scoped validation-log capture windows. Callers snapshot a
+## private log cursor, perform a deliberate validation action, then only report
+## new diagnostics whose original source location is the target file.
 
 
-static func capture_this_file(editor_log_buffer: McpEditorLogBuffer, target_path: String, action: Callable) -> Dictionary:
+static func capture_this_file(log_buffer: McpEditorLogBuffer, target_path: String, action: Callable) -> Dictionary:
 	var cursor := 0
-	if editor_log_buffer != null:
-		cursor = editor_log_buffer.appended_total()
+	if log_buffer != null:
+		cursor = log_buffer.appended_total()
 
 	var action_result = action.call()
 	var diagnostics: Array[Dictionary] = []
 	var truncated := false
 
-	if editor_log_buffer != null:
-		var captured: Dictionary = editor_log_buffer.get_since(cursor)
+	if log_buffer != null:
+		var captured: Dictionary = log_buffer.get_since(cursor)
 		truncated = captured.get("truncated", false)
 		diagnostics = _diagnostics_for_target(captured.get("entries", []), target_path)
 
@@ -43,88 +43,24 @@ static func _diagnostics_for_target(entries: Array, target_path: String) -> Arra
 
 
 static func _entry_matches_target(entry: Dictionary, target_path: String) -> bool:
-	var path := str(entry.get("path", ""))
-	## Ephemeral GDScript reloads report synthetic `gdscript://...` paths, and
-	## some logger events have no path at all. Accept pathless/ephemeral entries
-	## only when their structured details do not point at a different concrete
-	## file; otherwise we would rewrite an unrelated diagnostic onto target_path.
-	if path == target_path:
-		return true
-	if path.is_empty() or _is_ephemeral_gdscript_path(path):
-		return not _details_conflict_with_target(entry.get("details", {}), target_path)
-	return false
+	var source := _source_location(entry)
+	return str(source.get("path", "")) == target_path
 
 
 static func _normalize_entry(entry: Dictionary, target_path: String) -> Dictionary:
 	var normalized := entry.duplicate(true)
-	if _should_rewrite_path(str(normalized.get("path", "")), target_path):
-		normalized["path"] = target_path
+	var source := _source_location(entry)
+	normalized["path"] = str(source.get("path", target_path))
+	normalized["line"] = int(source.get("line", normalized.get("line", 0)))
+	normalized["function"] = str(source.get("function", normalized.get("function", "")))
 	if normalized.has("details") and normalized.details is Dictionary:
-		normalized["details"] = _normalize_details(normalized.details, target_path)
+		normalized["details"] = normalized.details.duplicate(true)
 	return normalized
 
 
-static func _normalize_details(details: Dictionary, target_path: String) -> Dictionary:
-	var normalized := details.duplicate(true)
-	for key in ["source", "resolved"]:
-		if normalized.get(key) is Dictionary:
-			var location: Dictionary = normalized[key]
-			if _should_rewrite_path(str(location.get("path", "")), target_path):
-				location["path"] = target_path
-			normalized[key] = location
-	if normalized.get("frames") is Array:
-		normalized["frames"] = _normalize_location_array(normalized.frames, target_path)
-	if normalized.get("children") is Array:
-		normalized["children"] = _normalize_location_array(normalized.children, target_path)
-	return normalized
-
-
-static func _normalize_location_array(items: Array, target_path: String) -> Array:
-	var out := []
-	for item in items:
-		if item is Dictionary:
-			var normalized: Dictionary = item.duplicate(true)
-			if _should_rewrite_path(str(normalized.get("path", "")), target_path):
-				normalized["path"] = target_path
-			out.append(normalized)
-		else:
-			out.append(item)
-	return out
-
-
-static func _should_rewrite_path(path: String, _target_path: String) -> bool:
-	return path.is_empty() or _is_ephemeral_gdscript_path(path)
-
-
-static func _is_ephemeral_gdscript_path(path: String) -> bool:
-	return path.begins_with("gdscript://")
-
-
-static func _details_conflict_with_target(details_value, target_path: String) -> bool:
-	if not details_value is Dictionary:
-		return false
-	var details: Dictionary = details_value
-	for key in ["source", "resolved"]:
-		if _location_conflicts_with_target(details.get(key), target_path):
-			return true
-	if _locations_conflict_with_target(details.get("frames"), target_path):
-		return true
-	if _locations_conflict_with_target(details.get("children"), target_path):
-		return true
-	return false
-
-
-static func _locations_conflict_with_target(items, target_path: String) -> bool:
-	if not items is Array:
-		return false
-	for item in items:
-		if _location_conflicts_with_target(item, target_path):
-			return true
-	return false
-
-
-static func _location_conflicts_with_target(location_value, target_path: String) -> bool:
-	if not location_value is Dictionary:
-		return false
-	var path := str(location_value.get("path", ""))
-	return not path.is_empty() and not _is_ephemeral_gdscript_path(path) and path != target_path
+static func _source_location(entry: Dictionary) -> Dictionary:
+	if entry.get("details") is Dictionary:
+		var details: Dictionary = entry.details
+		if details.get("source") is Dictionary:
+			return details.source
+	return {}

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -1112,13 +1112,13 @@ func test_editor_log_buffer_get_since_reports_clear_truncation() -> void:
 
 # ----- Diagnostics capture -----
 
-func test_diagnostics_capture_rewrites_ephemeral_gdscript_paths() -> void:
+func test_diagnostics_capture_uses_details_source_for_target_match() -> void:
 	var buf := McpEditorLogBuffer.new()
 	var target := "res://scripts/player.gd"
 	var result := DiagnosticsCapture.capture_this_file(buf, target, func() -> Dictionary:
-		buf.append("error", "Parse Error: Expected statement", "gdscript://12345.gd", 7, "GDScript::reload", {
-			"source": {"path": "gdscript://12345.gd", "line": 7},
-			"frames": [{"path": "gdscript://12345.gd", "line": 7, "function": "GDScript::reload"}],
+		buf.append("error", "Parse Error: Expected statement", "res://addons/godot_ai/handlers/script_handler.gd", 55, "_validate", {
+			"source": {"path": target, "line": 7, "function": "GDScript::reload"},
+			"resolved": {"path": "res://addons/godot_ai/handlers/script_handler.gd", "line": 55, "function": "_validate"},
 		})
 		return {"ok": false, "error_code": ERR_PARSE_ERROR}
 	)
@@ -1129,8 +1129,33 @@ func test_diagnostics_capture_rewrites_ephemeral_gdscript_paths() -> void:
 	assert_eq(result.diagnostics.size(), 1)
 	assert_eq(result.diagnostics[0].path, target)
 	assert_eq(result.diagnostics[0].line, 7)
+	assert_eq(result.diagnostics[0].function, "GDScript::reload")
 	assert_eq(result.diagnostics[0].details.source.path, target)
-	assert_eq(result.diagnostics[0].details.frames[0].path, target)
+	assert_eq(result.diagnostics[0].details.resolved.path, "res://addons/godot_ai/handlers/script_handler.gd")
+
+
+func test_diagnostics_capture_excludes_load_wrapper_and_keeps_multiple_parse_errors() -> void:
+	var buf := McpEditorLogBuffer.new()
+	var target := "res://scripts/player.gd"
+	var result := DiagnosticsCapture.capture_this_file(buf, target, func() -> Dictionary:
+		buf.append("error", "Parse Error: first", "res://addons/godot_ai/handlers/script_handler.gd", 40, "_validate", {
+			"source": {"path": target, "line": 4, "function": "GDScript::reload"},
+		})
+		buf.append("error", "Failed to load script \"res://scripts/player.gd\" with error \"Parse error\".", "res://addons/godot_ai/handlers/script_handler.gd", 40, "_validate", {
+			"source": {"path": "modules/gdscript/gdscript.cpp", "line": 2907, "function": "load"},
+		})
+		buf.append("error", "Parse Error: second", "res://addons/godot_ai/handlers/script_handler.gd", 40, "_validate", {
+			"source": {"path": target, "line": 8, "function": "GDScript::reload"},
+		})
+		return {"ok": false, "error_code": ERR_PARSE_ERROR}
+	)
+
+	assert_eq(result.diagnostics_detail, "log_capture")
+	assert_eq(result.diagnostics.size(), 2)
+	assert_eq(result.diagnostics[0].text, "Parse Error: first")
+	assert_eq(result.diagnostics[0].line, 4)
+	assert_eq(result.diagnostics[1].text, "Parse Error: second")
+	assert_eq(result.diagnostics[1].line, 8)
 
 
 func test_diagnostics_capture_rejects_pathless_entries_for_other_files() -> void:
@@ -1154,7 +1179,9 @@ func test_diagnostics_capture_reports_partial_when_window_overflows() -> void:
 	var target := "res://scripts/storm.gd"
 	var result := DiagnosticsCapture.capture_this_file(buf, target, func() -> Dictionary:
 		for i in range(cap + 2):
-			buf.append("error", "storm %d" % i, target, i)
+			buf.append("error", "storm %d" % i, "res://addons/godot_ai/handlers/script_handler.gd", i, "_validate", {
+				"source": {"path": target, "line": i, "function": "GDScript::reload"},
+			})
 		return {"ok": false, "error_code": ERR_PARSE_ERROR}
 	)
 

--- a/test_project/tests/test_script.gd
+++ b/test_project/tests/test_script.gd
@@ -5,15 +5,11 @@ const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
 
 const NodeHandler := preload("res://addons/godot_ai/handlers/node_handler.gd")
 const ScriptHandler := preload("res://addons/godot_ai/handlers/script_handler.gd")
-const _LoggerLoader := preload("res://addons/godot_ai/runtime/logger_loader.gd")
 
 ## Tests for ScriptHandler — script creation, reading, attach/detach, and symbol inspection.
 
 var _handler: ScriptHandler
-var _handler_with_logs: ScriptHandler
-var _editor_log_buffer: McpEditorLogBuffer
 var _undo_redo: EditorUndoRedoManager
-var _attached_test_logger = null
 
 const TEST_SCRIPT_PATH := "res://tests/_mcp_test_script.gd"
 const TEST_SCRIPT_CONTENT := """class_name _McpTestScript
@@ -45,8 +41,6 @@ func suite_name() -> String:
 func suite_setup(ctx: Dictionary) -> void:
 	_undo_redo = ctx.get("undo_redo")
 	_handler = ScriptHandler.new(_undo_redo)
-	_editor_log_buffer = McpEditorLogBuffer.new()
-	_handler_with_logs = ScriptHandler.new(_undo_redo, null, _editor_log_buffer)
 	# Create a test script file for read/symbol tests
 	var file := FileAccess.open(TEST_SCRIPT_PATH, FileAccess.WRITE)
 	if file:
@@ -55,7 +49,6 @@ func suite_setup(ctx: Dictionary) -> void:
 
 
 func suite_teardown() -> void:
-	_detach_test_logger()
 	# Clean up test script file
 	if FileAccess.file_exists(TEST_SCRIPT_PATH):
 		DirAccess.remove_absolute(TEST_SCRIPT_PATH)
@@ -90,7 +83,9 @@ func test_create_script_basic() -> void:
 	DirAccess.remove_absolute(path)
 
 
-func test_create_script_reports_fallback_diagnostics_without_log_buffer() -> void:
+func test_create_script_reports_log_capture_diagnostics_with_real_line() -> void:
+	if skip_on_godot_lt("4.5", "Logger subclass only exists on Godot 4.5+"):
+		return
 	var path := "res://tests/_mcp_test_invalid_create.gd"
 	var content := "extends Node\n\nfunc _ready() -> void:\n\tif\n\tpass\n"
 	var result := _handler.create_script({"path": path, "content": content})
@@ -99,67 +94,35 @@ func test_create_script_reports_fallback_diagnostics_without_log_buffer() -> voi
 	assert_eq(result.data.committed, true)
 	assert_eq(result.data.diagnostics_scope, "this_file")
 	assert_eq(result.data.diagnostics_status, "checked")
-	assert_eq(result.data.diagnostics_detail, "fallback")
+	assert_eq(result.data.diagnostics_detail, "log_capture")
 	assert_gt(result.data.diagnostics.size(), 0, "Invalid GDScript should report diagnostics")
 	assert_eq(result.data.diagnostics[0].path, path)
-	assert_eq(result.data.diagnostics[0].line, 5)
+	assert_eq(result.data.diagnostics[0].line, 4)
 	assert_eq(result.data.diagnostics[0].level, "error")
-	assert_eq(result.data.diagnostics[0].details.fallback_line, true)
+	assert_contains(result.data.diagnostics[0].text, "Parse Error")
+	assert_false(result.data.diagnostics[0].details.has("fallback_line"), "Real capture must not use fallback line guesses")
+	assert_eq(result.data.diagnostics[0].details.source.path, path)
+	assert_eq(result.data.diagnostics[0].details.source.line, 4)
 	assert_true(FileAccess.file_exists(path), "Invalid content is still written so the agent can fix it")
 	DirAccess.remove_absolute(path)
 
 
-func test_create_script_with_log_buffer_falls_back_when_ephemeral_reload_is_not_logged() -> void:
-	## Empirical guard for the real chain. Godot 4.6 prints ephemeral
-	## GDScript.reload() parse errors to stderr with a gdscript:// path, but
-	## they do not pass through OS.add_logger into McpEditorLogBuffer. Keep the
-	## response honest: validation is checked, detail fidelity is fallback.
-	if skip_on_godot_lt("4.5", "Logger subclass only exists on Godot 4.5+"):
+func test_create_script_reports_fallback_diagnostics_without_logger() -> void:
+	if ClassDB.class_exists("Logger"):
+		skip("Fallback branch is exercised on Godot versions without Logger")
 		return
-	if not OS.has_method("add_logger"):
-		skip("Logger API is unavailable")
-		return
-	var logger_script := _LoggerLoader.build(_LoggerLoader.EDITOR_LOGGER_PATH)
-	assert_true(logger_script != null, "Editor logger script should compile on Godot 4.5+")
-	if logger_script == null:
-		return
-	_attached_test_logger = logger_script.new(_editor_log_buffer)
-	var path := "res://tests/_mcp_test_invalid_create_logged.gd"
+	var path := "res://tests/_mcp_test_invalid_create_no_logger.gd"
 	var content := "extends Node\n\nfunc _ready() -> void:\n\tif\n\tpass\n"
-	_editor_log_buffer.clear()
-	OS.call("add_logger", _attached_test_logger)
-	var result := _handler_with_logs.create_script({"path": path, "content": content})
-	_detach_test_logger()
+	var result := _handler.create_script({"path": path, "content": content})
 	assert_has_key(result, "data")
 	assert_eq(result.data.diagnostics_scope, "this_file")
 	assert_eq(result.data.diagnostics_status, "checked")
 	assert_eq(result.data.diagnostics_detail, "fallback")
-	assert_eq(_count_ephemeral_reload_parse_errors(_editor_log_buffer.get_recent(20)), 0, "Ephemeral reload parse errors are not logger-captured")
 	assert_gt(result.data.diagnostics.size(), 0)
 	assert_eq(result.data.diagnostics[0].path, path)
+	assert_eq(result.data.diagnostics[0].line, 5)
 	assert_eq(result.data.diagnostics[0].details.fallback_line, true)
 	DirAccess.remove_absolute(path)
-
-
-func _count_ephemeral_reload_parse_errors(entries: Array[Dictionary]) -> int:
-	var count := 0
-	for entry in entries:
-		var path := str(entry.get("path", ""))
-		var text := str(entry.get("text", ""))
-		var function := str(entry.get("function", ""))
-		if (
-			(path.is_empty() or path.begins_with("gdscript://"))
-			and text.find("Parse Error") != -1
-			and function.find("GDScript") != -1
-		):
-			count += 1
-	return count
-
-
-func _detach_test_logger() -> void:
-	if _attached_test_logger != null and OS.has_method("remove_logger"):
-		OS.call("remove_logger", _attached_test_logger)
-	_attached_test_logger = null
 
 
 func test_finish_create_script_deferred_is_static_and_handles_null_connection() -> void:
@@ -261,7 +224,9 @@ func test_patch_script_basic() -> void:
 	DirAccess.remove_absolute(path)
 
 
-func test_patch_script_reports_fallback_diagnostics_without_log_buffer() -> void:
+func test_patch_script_reports_log_capture_diagnostics_with_real_line() -> void:
+	if skip_on_godot_lt("4.5", "Logger subclass only exists on Godot 4.5+"):
+		return
 	var path := "res://tests/_mcp_test_invalid_patch.gd"
 	var original := "extends Node\n\nfunc _ready() -> void:\n\tpass\n\tprint(\"after\")\n"
 	var file := FileAccess.open(path, FileAccess.WRITE)
@@ -278,17 +243,47 @@ func test_patch_script_reports_fallback_diagnostics_without_log_buffer() -> void
 	assert_eq(result.data.replacements, 1)
 	assert_eq(result.data.diagnostics_scope, "this_file")
 	assert_eq(result.data.diagnostics_status, "checked")
-	assert_eq(result.data.diagnostics_detail, "fallback")
+	assert_eq(result.data.diagnostics_detail, "log_capture")
 	assert_gt(result.data.diagnostics.size(), 0, "Invalid patched GDScript should report diagnostics")
 	assert_eq(result.data.diagnostics[0].path, path)
-	assert_eq(result.data.diagnostics[0].line, 5)
+	assert_eq(result.data.diagnostics[0].line, 4)
 	assert_eq(result.data.diagnostics[0].level, "error")
-	assert_eq(result.data.diagnostics[0].details.fallback_line, true)
+	assert_contains(result.data.diagnostics[0].text, "Parse Error")
+	assert_false(result.data.diagnostics[0].details.has("fallback_line"), "Real capture must not use fallback line guesses")
+	assert_eq(result.data.diagnostics[0].details.source.path, path)
+	assert_eq(result.data.diagnostics[0].details.source.line, 4)
 
 	var read := FileAccess.open(path, FileAccess.READ)
 	var new_content := read.get_as_text()
 	read.close()
 	assert_contains(new_content, "if")
+	DirAccess.remove_absolute(path)
+
+
+func test_patch_script_reports_fallback_diagnostics_without_logger() -> void:
+	if ClassDB.class_exists("Logger"):
+		skip("Fallback branch is exercised on Godot versions without Logger")
+		return
+	var path := "res://tests/_mcp_test_invalid_patch_no_logger.gd"
+	var original := "extends Node\n\nfunc _ready() -> void:\n\tpass\n\tprint(\"after\")\n"
+	var file := FileAccess.open(path, FileAccess.WRITE)
+	file.store_string(original)
+	file.close()
+
+	var result := _handler.patch_script({
+		"path": path,
+		"old_text": "pass",
+		"new_text": "if",
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.path, path)
+	assert_eq(result.data.diagnostics_scope, "this_file")
+	assert_eq(result.data.diagnostics_status, "checked")
+	assert_eq(result.data.diagnostics_detail, "fallback")
+	assert_gt(result.data.diagnostics.size(), 0)
+	assert_eq(result.data.diagnostics[0].path, path)
+	assert_eq(result.data.diagnostics[0].line, 5)
+	assert_eq(result.data.diagnostics[0].details.fallback_line, true)
 	DirAccess.remove_absolute(path)
 
 

--- a/test_project/tests/test_script.gd
+++ b/test_project/tests/test_script.gd
@@ -5,11 +5,13 @@ const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
 
 const NodeHandler := preload("res://addons/godot_ai/handlers/node_handler.gd")
 const ScriptHandler := preload("res://addons/godot_ai/handlers/script_handler.gd")
+const _LoggerLoader := preload("res://addons/godot_ai/runtime/logger_loader.gd")
 
 ## Tests for ScriptHandler — script creation, reading, attach/detach, and symbol inspection.
 
 var _handler: ScriptHandler
 var _undo_redo: EditorUndoRedoManager
+var _attached_shared_logger = null
 
 const TEST_SCRIPT_PATH := "res://tests/_mcp_test_script.gd"
 const TEST_SCRIPT_CONTENT := """class_name _McpTestScript
@@ -49,6 +51,7 @@ func suite_setup(ctx: Dictionary) -> void:
 
 
 func suite_teardown() -> void:
+	_detach_shared_editor_logger()
 	# Clean up test script file
 	if FileAccess.file_exists(TEST_SCRIPT_PATH):
 		DirAccess.remove_absolute(TEST_SCRIPT_PATH)
@@ -107,6 +110,23 @@ func test_create_script_reports_log_capture_diagnostics_with_real_line() -> void
 	DirAccess.remove_absolute(path)
 
 
+func test_create_script_validation_does_not_pollute_shared_editor_log() -> void:
+	var shared_buf := McpEditorLogBuffer.new()
+	if not _attach_shared_editor_logger(shared_buf):
+		return
+	var path := "res://tests/_mcp_test_invalid_create_shared_log.gd"
+	var content := "extends Node\n\nfunc _ready() -> void:\n\tif\n\tpass\n"
+	var cursor := shared_buf.appended_total()
+	var result := _handler.create_script({"path": path, "content": content})
+	_detach_shared_editor_logger()
+
+	assert_has_key(result, "data")
+	assert_eq(result.data.diagnostics_detail, "log_capture")
+	var captured := shared_buf.get_since(cursor)
+	assert_eq(captured.entries.size(), 0, "Validation load diagnostics must not leak into the shared editor log")
+	DirAccess.remove_absolute(path)
+
+
 func test_create_script_reports_fallback_diagnostics_without_logger() -> void:
 	if ClassDB.class_exists("Logger"):
 		skip("Fallback branch is exercised on Godot versions without Logger")
@@ -123,6 +143,28 @@ func test_create_script_reports_fallback_diagnostics_without_logger() -> void:
 	assert_eq(result.data.diagnostics[0].line, 5)
 	assert_eq(result.data.diagnostics[0].details.fallback_line, true)
 	DirAccess.remove_absolute(path)
+
+
+func _attach_shared_editor_logger(buffer: McpEditorLogBuffer) -> bool:
+	_detach_shared_editor_logger()
+	if skip_on_godot_lt("4.5", "Logger subclass only exists on Godot 4.5+"):
+		return false
+	if not OS.has_method("add_logger") or not OS.has_method("remove_logger"):
+		skip("Logger API is unavailable")
+		return false
+	var logger_script := _LoggerLoader.build(_LoggerLoader.EDITOR_LOGGER_PATH)
+	assert_true(logger_script != null, "Editor logger script should compile on Godot 4.5+")
+	if logger_script == null:
+		return false
+	_attached_shared_logger = logger_script.new(buffer)
+	OS.call("add_logger", _attached_shared_logger)
+	return true
+
+
+func _detach_shared_editor_logger() -> void:
+	if _attached_shared_logger != null and OS.has_method("remove_logger"):
+		OS.call("remove_logger", _attached_shared_logger)
+	_attached_shared_logger = null
 
 
 func test_finish_create_script_deferred_is_static_and_handles_null_connection() -> void:
@@ -257,6 +299,31 @@ func test_patch_script_reports_log_capture_diagnostics_with_real_line() -> void:
 	var new_content := read.get_as_text()
 	read.close()
 	assert_contains(new_content, "if")
+	DirAccess.remove_absolute(path)
+
+
+func test_patch_script_validation_does_not_pollute_shared_editor_log() -> void:
+	var shared_buf := McpEditorLogBuffer.new()
+	if not _attach_shared_editor_logger(shared_buf):
+		return
+	var path := "res://tests/_mcp_test_invalid_patch_shared_log.gd"
+	var original := "extends Node\n\nfunc _ready() -> void:\n\tpass\n\tprint(\"after\")\n"
+	var file := FileAccess.open(path, FileAccess.WRITE)
+	file.store_string(original)
+	file.close()
+
+	var cursor := shared_buf.appended_total()
+	var result := _handler.patch_script({
+		"path": path,
+		"old_text": "pass",
+		"new_text": "if",
+	})
+	_detach_shared_editor_logger()
+
+	assert_has_key(result, "data")
+	assert_eq(result.data.diagnostics_detail, "log_capture")
+	var captured := shared_buf.get_since(cursor)
+	assert_eq(captured.entries.size(), 0, "Validation load diagnostics must not leak into the shared editor log")
 	DirAccess.remove_absolute(path)
 
 

--- a/tests/unit/test_script_create_import_settle.py
+++ b/tests/unit/test_script_create_import_settle.py
@@ -36,10 +36,7 @@ def test_script_handler_holds_connection_for_deferred_replies() -> None:
     )
     # _init must accept the connection. Default null keeps batch_execute and
     # unit-test contexts working on the synchronous fallback path.
-    expected_init = (
-        "func _init(undo_redo: EditorUndoRedoManager, connection: McpConnection = null, "
-        "editor_log_buffer: McpEditorLogBuffer = null)"
-    )
+    expected_init = "func _init(undo_redo: EditorUndoRedoManager, connection: McpConnection = null)"
     assert expected_init in source, (
         "ScriptHandler._init must accept the connection as an optional "
         "second parameter so test contexts can keep using the sync fallback."
@@ -172,7 +169,7 @@ def test_plugin_gd_passes_connection_to_script_handler() -> None:
     """plugin.gd must wire _connection into ScriptHandler — the field is null otherwise."""
     source = PLUGIN_GD.read_text(encoding="utf-8")
 
-    assert "ScriptHandler.new(get_undo_redo(), _connection, _editor_log_buffer)" in source, (
+    assert "ScriptHandler.new(get_undo_redo(), _connection)" in source, (
         "plugin.gd must construct ScriptHandler with the connection so the "
         "deferred-reply path is reachable in production. Without this, every "
         "create_script falls back to the synchronous reply and #261 returns."


### PR DESCRIPTION
## Summary

This follows up on #557 / #556 by upgrading `.gd` write diagnostics from best-effort fallback lines to real parser diagnostics when Godot’s Logger API is available.

#556 added inline diagnostics for `script_create` and `script_patch`, but invalid GDScript usually reported `diagnostics_detail: "fallback"` because ephemeral `GDScript.reload()` errors do not flow through the editor logger. That fallback proves the content failed validation, but its line number is only a guess.

This PR keeps the cheap ephemeral `reload()` validity gate, then adds a second step only when that gate fails:

1. Attach a short-lived private validation logger.
2. Call `ResourceLoader.load(path, "", ResourceLoader.CACHE_MODE_IGNORE)`.
3. Remove the logger immediately.
4. Match captured diagnostics by `details.source.path == target`.
5. Return the real parse message and line as `diagnostics_detail: "log_capture"`.

This works for both `script_create` and `script_patch`.

## Why this approach

I spiked the `update_file()` / deferred-settle route first, but it produced no logger-visible parse diagnostics, even after polling up to 10 seconds. `update_file()` registers the file but does not appear to trigger the logger-visible reparse needed for exact lines.

`ResourceLoader.load(path, "", ResourceLoader.CACHE_MODE_IGNORE)` did produce the needed diagnostics synchronously:

- The real target path is in `details.source.path`.
- The real error line is in `details.source.line`.
- The diagnostic is available immediately after `load()` returns.
- The patch/preloaded-file case did not produce resource-path collision noise.

The top-level log entry path points at the caller/backtrace location, so this PR intentionally pivots matching and normalization to `details.source`.

## Notes

This does not fully resolve #557 item 2. The implementation still uses ephemeral `GDScript.reload()` as the cheap validity gate, so the static-initializer side-effect surface for clean-compiling content remains. The heavier `ResourceLoader.load(..., CACHE_MODE_IGNORE)` path only runs after the content is already known invalid.

## Verification

- `uv run pytest tests\unit\test_script_create_import_settle.py`
- Godot headless import
- `test_run suite="script"`
- `test_run suite="editor"`
- `git diff --check`