### PR TITLE
Fix: Added static types to iterators in game_logger.gd

### DIFF
--- a/plugin/addons/godot_ai/runtime/loggers/game_logger.gd
+++ b/plugin/addons/godot_ai/runtime/loggers/game_logger.gd
@@ -81,9 +81,9 @@ func _log_error(
 		## Collect every function name in the first non-empty backtrace so
 		## game_helper can match its eval's uniquely named wrapper function.
 		var funcs := PackedStringArray()
-		for bt in script_backtraces:
+		for bt:ScriptBacktrace in script_backtraces:
 			if bt != null and bt.get_frame_count() > 0:
-				for i in bt.get_frame_count():
+				for i:int in bt.get_frame_count():
 					funcs.append(bt.get_frame_function(i))
 				break
 		_mutex.lock()

--- a/plugin/addons/godot_ai/runtime/loggers/game_logger.gd
+++ b/plugin/addons/godot_ai/runtime/loggers/game_logger.gd
@@ -71,27 +71,27 @@ func _log_error(
 	var resolved := _LogBacktrace.resolve_error(
 		function, file, line, code, rationale, error_type, script_backtraces,
 	)
-var loc := ""
-    if not resolved.path.is_empty():
-        loc = "%s:%d @ %s" % [resolved.path, resolved.line, resolved.function] if not resolved.function.is_empty() else "%s:%d" % [resolved.path, resolved.line]
-    var text: String = "%s (%s)" % [resolved.message, loc] if not loc.is_empty() else resolved.message
-    var details: Dictionary = resolved.get("details", {})
-    _append(resolved.level, text, details)
-    if error_type == _ERROR_TYPE_SCRIPT:
-        ## Collect every function name in the first non-empty backtrace so
-        ## game_helper can match its eval's uniquely named wrapper function.
-        var funcs := PackedStringArray()
-        for bt: RefCounted in script_backtraces:
-            if bt != null and bt.get_frame_count() > 0:
-                for i: int in bt.get_frame_count():
-                    funcs.append(bt.get_frame_function(i))
-                break
-        _mutex.lock()
-        _script_error_seq += 1
-        _recent_script_errors.append({"seq": _script_error_seq, "text": text, "funcs": funcs})
-        if _recent_script_errors.size() > _MAX_RECENT_SCRIPT_ERRORS:
-            _recent_script_errors.remove_at(0)
-        _mutex.unlock()
+	var loc := ""
+	if not resolved.path.is_empty():
+		loc = "%s:%d @ %s" % [resolved.path, resolved.line, resolved.function] if not resolved.function.is_empty() else "%s:%d" % [resolved.path, resolved.line]
+	var text: String = "%s (%s)" % [resolved.message, loc] if not loc.is_empty() else resolved.message
+	var details: Dictionary = resolved.get("details", {})
+	_append(resolved.level, text, details)
+	if error_type == _ERROR_TYPE_SCRIPT:
+		## Collect every function name in the first non-empty backtrace so
+		## game_helper can match its eval's uniquely named wrapper function.
+		var funcs := PackedStringArray()
+		for bt: RefCounted in script_backtraces:
+			if bt != null and bt.get_frame_count() > 0:
+				for i: int in bt.get_frame_count():
+					funcs.append(bt.get_frame_function(i))
+				break
+		_mutex.lock()
+		_script_error_seq += 1
+		_recent_script_errors.append({"seq": _script_error_seq, "text": text, "funcs": funcs})
+		if _recent_script_errors.size() > _MAX_RECENT_SCRIPT_ERRORS:
+			_recent_script_errors.remove_at(0)
+		_mutex.unlock()
 
 
 func _append(level: String, text: String, details: Dictionary = {}) -> void:

--- a/plugin/addons/godot_ai/runtime/loggers/game_logger.gd
+++ b/plugin/addons/godot_ai/runtime/loggers/game_logger.gd
@@ -71,27 +71,27 @@ func _log_error(
 	var resolved := _LogBacktrace.resolve_error(
 		function, file, line, code, rationale, error_type, script_backtraces,
 	)
-	var loc := ""
-	if not resolved.path.is_empty():
-		loc = "%s:%d @ %s" % [resolved.path, resolved.line, resolved.function] if not resolved.function.is_empty() else "%s:%d" % [resolved.path, resolved.line]
-	var text: String = "%s (%s)" % [resolved.message, loc] if not loc.is_empty() else resolved.message
-	var details: Dictionary = resolved.get("details", {})
-	_append(resolved.level, text, details)
-	if error_type == _ERROR_TYPE_SCRIPT:
-		## Collect every function name in the first non-empty backtrace so
-		## game_helper can match its eval's uniquely named wrapper function.
-		var funcs := PackedStringArray()
-		for bt: RefCounted in script_backtraces:
-    		if bt != null and bt.get_frame_count() > 0:
-        		for i: int in bt.get_frame_count():
-					funcs.append(bt.get_frame_function(i))
-				break
-		_mutex.lock()
-		_script_error_seq += 1
-		_recent_script_errors.append({"seq": _script_error_seq, "text": text, "funcs": funcs})
-		if _recent_script_errors.size() > _MAX_RECENT_SCRIPT_ERRORS:
-			_recent_script_errors.remove_at(0)
-		_mutex.unlock()
+var loc := ""
+    if not resolved.path.is_empty():
+        loc = "%s:%d @ %s" % [resolved.path, resolved.line, resolved.function] if not resolved.function.is_empty() else "%s:%d" % [resolved.path, resolved.line]
+    var text: String = "%s (%s)" % [resolved.message, loc] if not loc.is_empty() else resolved.message
+    var details: Dictionary = resolved.get("details", {})
+    _append(resolved.level, text, details)
+    if error_type == _ERROR_TYPE_SCRIPT:
+        ## Collect every function name in the first non-empty backtrace so
+        ## game_helper can match its eval's uniquely named wrapper function.
+        var funcs := PackedStringArray()
+        for bt: RefCounted in script_backtraces:
+            if bt != null and bt.get_frame_count() > 0:
+                for i: int in bt.get_frame_count():
+                    funcs.append(bt.get_frame_function(i))
+                break
+        _mutex.lock()
+        _script_error_seq += 1
+        _recent_script_errors.append({"seq": _script_error_seq, "text": text, "funcs": funcs})
+        if _recent_script_errors.size() > _MAX_RECENT_SCRIPT_ERRORS:
+            _recent_script_errors.remove_at(0)
+        _mutex.unlock()
 
 
 func _append(level: String, text: String, details: Dictionary = {}) -> void:

--- a/plugin/addons/godot_ai/runtime/loggers/game_logger.gd
+++ b/plugin/addons/godot_ai/runtime/loggers/game_logger.gd
@@ -81,9 +81,9 @@ func _log_error(
 		## Collect every function name in the first non-empty backtrace so
 		## game_helper can match its eval's uniquely named wrapper function.
 		var funcs := PackedStringArray()
-		for bt:ScriptBacktrace in script_backtraces:
-			if bt != null and bt.get_frame_count() > 0:
-				for i:int in bt.get_frame_count():
+		for bt: RefCounted in script_backtraces:
+    		if bt != null and bt.get_frame_count() > 0:
+        		for i: int in bt.get_frame_count():
 					funcs.append(bt.get_frame_function(i))
 				break
 		_mutex.lock()


### PR DESCRIPTION
My Godot setup enforces strict typing (untyped_iterator treated as an Error). Because game_logger.gd is compiled dynamically into memory, it gets a virtual gdscript:// path. This means it isn't protected by the exclude_addons folder filter, causing the engine to block compilation for the whole project. Adding explicit types to the loop iterators fixes the crash!