### PR TITLE
fix(runtime): look up EditorInterface by name so exported builds parse game_helper.gd autoload

### DIFF
--- a/plugin/addons/godot_ai/runtime/game_helper.gd
+++ b/plugin/addons/godot_ai/runtime/game_helper.gd
@@ -430,7 +430,15 @@ func _current_scene_root() -> Node:
 		return null
 	var scene_root := tree.current_scene
 	if scene_root == null and Engine.is_editor_hint():
-		scene_root = EditorInterface.get_edited_scene_root()
+		# Look the editor singleton up by name rather than referencing the bare
+		# `EditorInterface` identifier: that identifier is compiled out of export
+		# templates, so the GDScript parser rejects it ("Identifier
+		# "EditorInterface" not declared in the current scope") in an exported
+		# build even though `Engine.is_editor_hint()` would never run it there.
+		# That parse failure stops this autoload from loading in every export.
+		var editor := Engine.get_singleton(&"EditorInterface")
+		if editor:
+			scene_root = editor.get_edited_scene_root()
 	return scene_root
 
 

--- a/tests/unit/test_game_helper_no_editor_interface_identifier.py
+++ b/tests/unit/test_game_helper_no_editor_interface_identifier.py
@@ -1,0 +1,70 @@
+"""Source-pin: game_helper.gd must not reference the bare `EditorInterface`
+identifier, which is compiled out of export templates.
+
+`game_helper.gd` is registered as the `_mcp_game_helper` autoload, so it is
+loaded (and parsed) in every game process — including exported release builds.
+The bare `EditorInterface` singleton only exists in the editor; it is compiled
+out of export templates. A bare reference is rejected by the GDScript parser at
+load time in an exported build, even when the reference is guarded at runtime
+by `Engine.is_editor_hint()` (the guard never runs because parsing fails first):
+
+    SCRIPT ERROR: Parse Error: Identifier "EditorInterface" not declared in
+    the current scope.
+       at: GDScript::reload (res://addons/godot_ai/runtime/game_helper.gd:...)
+    ERROR: Failed to instantiate an autoload, script 'game_helper.gd' does not
+    inherit from 'Node'.
+
+…which stops the autoload from loading in every exported build and cascades
+into misleading downstream errors in the user's own scripts. The file's own
+header docstring states it "silently sits idle ... (e.g. exported release
+builds)", so the bare identifier contradicts the intended behavior.
+
+Fix: reach the singleton by string name so the identifier never reaches the
+parser — `Engine.get_singleton(&"EditorInterface")` — then call
+`get_edited_scene_root()` on the returned object.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[2] / "plugin" / "addons" / "godot_ai"
+GAME_HELPER = PLUGIN_ROOT / "runtime" / "game_helper.gd"
+
+
+def test_game_helper_does_not_reference_editor_interface_identifier() -> None:
+    """No bare `EditorInterface` reference in code — it breaks export parsing.
+
+    A *bare identifier* reference (`EditorInterface.method(...)` or
+    `EditorInterface` used as a value) is what the export-template parser
+    rejects. The string-literal form inside `Engine.get_singleton(...)` is
+    fine, so the check strips comments and double-quoted strings first.
+    """
+    source = GAME_HELPER.read_text(encoding="utf-8")
+    for lineno, raw in enumerate(source.splitlines(), start=1):
+        # Strip GDScript line comments (## or #) so the rationale comment
+        # (which names the identifier) doesn't trip this.
+        code = raw.split("#", 1)[0]
+        # Strip double-quoted strings so the `&"EditorInterface"` string-name
+        # argument to Engine.get_singleton(...) is not flagged — only a bare
+        # identifier reaches the parser as a symbol.
+        code = re.sub(r'"[^"]*"', '""', code)
+        assert "EditorInterface" not in code, (
+            f"game_helper.gd:{lineno} references the bare `EditorInterface` "
+            f"identifier in code: {raw.strip()!r}. This autoload loads in "
+            "exported builds, where `EditorInterface` is compiled out and the "
+            'parser rejects it. Use `Engine.get_singleton(&"EditorInterface")` '
+            "instead — see the rationale in the call site's comment."
+        )
+
+
+def test_game_helper_uses_get_singleton_for_editor_interface() -> None:
+    """The export-safe lookup must be present."""
+    source = GAME_HELPER.read_text(encoding="utf-8")
+    assert 'Engine.get_singleton(&"EditorInterface")' in source, (
+        "game_helper.gd must reach the editor singleton via "
+        'Engine.get_singleton(&"EditorInterface"). Referencing the bare '
+        "`EditorInterface` identifier fails to parse in exported builds, where "
+        "the singleton is compiled out of the export template."
+    )


### PR DESCRIPTION
Fixes #561.

## Problem

`game_helper.gd` is registered as the `_mcp_game_helper` autoload, so it is parsed in exported builds (see 561)

## Fix

Reach the singleton by string name so only a string literal reaches the parser:

```gdscript
	if scene_root == null and Engine.is_editor_hint():
		var editor := Engine.get_singleton(&"EditorInterface")
		if editor:
			scene_root = editor.get_edited_scene_root()
	return scene_root
```

The `is_editor_hint()` guard still gates the actual editor call in the editor process. Same class of latent-parse bug as the existing `game_logger.gd` / `McpLogBacktrace` fix.

## Testing

- Added `tests/unit/test_game_helper_no_editor_interface_identifier.py`, a source-pin test mirroring `tests/unit/test_game_logger_no_class_name_lookup.py`: it fails if a bare `EditorInterface` identifier reappears in code, and requires the `Engine.get_singleton(&"EditorInterface")` form. Verified it passes against the fixed source and fails against the pre-fix source.
- `ruff check` / `ruff format --check` clean on the new test.
- Verified working in the editor and in a Web export (Godot 4.6.3 stable).
