### PR TITLE
Implement and refactor HTTP proxy support in update manager

### DIFF
--- a/plugin/addons/godot_ai/utils/update_manager.gd
+++ b/plugin/addons/godot_ai/utils/update_manager.gd
@@ -86,6 +86,7 @@ func check_for_updates() -> void:
 		_http_request = HTTPRequest.new()
 		_http_request.request_completed.connect(_on_update_check_completed)
 		add_child(_http_request)
+	_with_editor_http_proxy(_http_request)
 	_http_request.request(RELEASES_URL, ["Accept: application/vnd.github+json"])
 
 
@@ -181,6 +182,7 @@ func start_install() -> void:
 	_download_request.max_redirects = 10
 	_download_request.request_completed.connect(_on_download_completed)
 	add_child(_download_request)
+	_with_editor_http_proxy(_download_request)
 	var err := _download_request.request(_latest_download_url)
 	if err != OK:
 		## `request_completed` never fires when `request()` itself errors,
@@ -441,3 +443,11 @@ func _reload_after_update() -> void:
 func _drain_dock_workers() -> void:
 	if _dock != null and _dock.has_method("prepare_for_self_update_drain"):
 		_dock.prepare_for_self_update_drain()
+
+
+func _with_editor_http_proxy(request: HTTPRequest) -> void:
+	var editor_settings = EditorInterface.get_editor_settings()
+	if editor_settings.get_setting("network/http_proxy/host") and editor_settings.get_setting("network/http_proxy/host"):
+		request.set_http_proxy(editor_settings.get_setting("network/http_proxy/host"), int(editor_settings.get_setting("network/http_proxy/host")))
+		request.set_https_proxy(editor_settings.get_setting("network/http_proxy/host"), int(editor_settings.get_setting("network/http_proxy/host")))
+

--- a/plugin/addons/godot_ai/utils/update_manager.gd
+++ b/plugin/addons/godot_ai/utils/update_manager.gd
@@ -446,8 +446,19 @@ func _drain_dock_workers() -> void:
 
 
 func _with_editor_http_proxy(request: HTTPRequest) -> void:
-	var editor_settings = EditorInterface.get_editor_settings()
-	if editor_settings.get_setting("network/http_proxy/host") and editor_settings.get_setting("network/http_proxy/host"):
-		request.set_http_proxy(editor_settings.get_setting("network/http_proxy/host"), int(editor_settings.get_setting("network/http_proxy/host")))
-		request.set_https_proxy(editor_settings.get_setting("network/http_proxy/host"), int(editor_settings.get_setting("network/http_proxy/host")))
+	var es := EditorInterface.get_editor_settings()
+ 	if es == null:
+ 		return
+ 	var host := ""
+ 	var port := 0
+ 	if es.has_setting("network/http_proxy/host"):
+ 		host = str(es.get_setting("network/http_proxy/host")).strip_edges()
+ 	if es.has_setting("network/http_proxy/port"):
+ 		port = int(es.get_setting("network/http_proxy/port"))
+ 	## Always apply (even when host/port are empty) so reused HTTPRequest
+ 	## instances don’t keep a stale proxy after the user clears settings.
+ 	if request.has_method("set_http_proxy"):
+ 		request.call("set_http_proxy", host, port)
+ 	if request.has_method("set_https_proxy"):
+ 		request.call("set_https_proxy", host, port)
 


### PR DESCRIPTION
This pull request improves the update manager's handling of HTTP proxy settings in the Godot AI plugin. It introduces a helper function to automatically apply the editor's HTTP and HTTPS proxy settings to all HTTP requests made during update checks and installations, ensuring correct network behavior in environments with proxy requirements.

Network proxy support:

* Added a new `_with_editor_http_proxy` function in `update_manager.gd` to read the editor's proxy settings and apply them to `HTTPRequest` instances before making network requests.
* Updated `check_for_updates()` and `start_install()` to call `_with_editor_http_proxy` on their respective HTTP request objects, ensuring all update-related network traffic respects the user's proxy configuration. [[1]](diffhunk://#diff-26a76f0af6eb69c25621dcf0f0f9acb8567ae83b34958c424e7f11a866330101R89) [[2]](diffhunk://#diff-26a76f0af6eb69c25621dcf0f0f9acb8567ae83b34958c424e7f11a866330101R185)