### PR TITLE
add Godot 4.7 row and harden input device IDs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,9 @@ jobs:
           - os: windows-latest
             label: Windows
             godot-version: "4.6.2"
+          - os: ubuntu-latest
+            label: Linux (Godot 4.7)
+            godot-version: "4.7.0"
           ## 4.3 Linux canary — README advertises "Godot 4.3+" support and
           ## #476's parse-cascade regression went unnoticed for 24 days
           ## because every CI run was on 4.6.2. Phase 1 of #477: one cheap

--- a/plugin/addons/godot_ai/handlers/input_handler.gd
+++ b/plugin/addons/godot_ai/handlers/input_handler.gd
@@ -175,6 +175,7 @@ func _create_event(event_type: String, params: Dictionary):
 			ev.alt_pressed = params.get("alt", false)
 			ev.shift_pressed = params.get("shift", false)
 			ev.meta_pressed = params.get("meta", false)
+			ev.device = -1
 			return ev
 		"mouse_button":
 			if not params.has("button"):
@@ -186,6 +187,7 @@ func _create_event(event_type: String, params: Dictionary):
 					"mouse_button button must be > 0 (got %d). Use 1=left, 2=right, 3=middle, 4=wheel up, 5=wheel down." % button)
 			var ev := InputEventMouseButton.new()
 			ev.button_index = button
+			ev.device = -1
 			return ev
 		"joy_button":
 			if not params.has("button"):

--- a/test_project/tests/test_input.gd
+++ b/test_project/tests/test_input.gd
@@ -255,6 +255,64 @@ func test_bind_key_event() -> void:
 	_handler.remove_action({"action": TEST_ACTION})
 
 
+func test_bind_key_event_matches_all_keyboard_devices() -> void:
+	_handler.add_action({"action": TEST_ACTION})
+	var result := _handler.bind_event({
+		"action": TEST_ACTION,
+		"event_type": "key",
+		"keycode": "Space",
+	})
+	assert_has_key(result, "data")
+
+	var events := InputMap.action_get_events(TEST_ACTION)
+	assert_eq(events.size(), 1)
+	var stored_event = events[0]
+	assert_true(stored_event is InputEventKey)
+	assert_eq(stored_event.device, -1)
+
+	var default_device_event := InputEventKey.new()
+	default_device_event.keycode = KEY_SPACE
+	default_device_event.pressed = true
+	assert_true(InputMap.event_is_action(default_device_event, TEST_ACTION))
+
+	var explicit_device_event := InputEventKey.new()
+	explicit_device_event.keycode = KEY_SPACE
+	explicit_device_event.device = 1
+	explicit_device_event.pressed = true
+	assert_true(InputMap.event_is_action(explicit_device_event, TEST_ACTION))
+
+	_handler.remove_action({"action": TEST_ACTION})
+
+
+func test_bind_mouse_button_event_matches_all_mouse_devices() -> void:
+	_handler.add_action({"action": TEST_ACTION})
+	var result := _handler.bind_event({
+		"action": TEST_ACTION,
+		"event_type": "mouse_button",
+		"button": MOUSE_BUTTON_LEFT,
+	})
+	assert_has_key(result, "data")
+
+	var events := InputMap.action_get_events(TEST_ACTION)
+	assert_eq(events.size(), 1)
+	var stored_event = events[0]
+	assert_true(stored_event is InputEventMouseButton)
+	assert_eq(stored_event.device, -1)
+
+	var default_device_event := InputEventMouseButton.new()
+	default_device_event.button_index = MOUSE_BUTTON_LEFT
+	default_device_event.pressed = true
+	assert_true(InputMap.event_is_action(default_device_event, TEST_ACTION))
+
+	var explicit_device_event := InputEventMouseButton.new()
+	explicit_device_event.button_index = MOUSE_BUTTON_LEFT
+	explicit_device_event.device = 1
+	explicit_device_event.pressed = true
+	assert_true(InputMap.event_is_action(explicit_device_event, TEST_ACTION))
+
+	_handler.remove_action({"action": TEST_ACTION})
+
+
 func test_bind_joy_axis_event() -> void:
 	_handler.add_action({"action": TEST_ACTION})
 	var result := _handler.bind_event({

--- a/test_project/tests/test_script.gd
+++ b/test_project/tests/test_script.gd
@@ -101,7 +101,7 @@ func test_create_script_reports_log_capture_diagnostics_with_real_line() -> void
 	assert_eq(result.data.diagnostics_scope, "this_file")
 	assert_eq(result.data.diagnostics_status, "checked")
 	assert_eq(result.data.diagnostics_detail, "log_capture")
-	assert_gt(result.data.diagnostics.size(), 0, "Invalid GDScript should report diagnostics")
+	assert_eq(result.data.diagnostics.size(), 1, "Invalid GDScript should report one diagnostic")
 	assert_eq(result.data.diagnostics[0].path, path)
 	assert_eq(result.data.diagnostics[0].line, 4)
 	assert_eq(result.data.diagnostics[0].level, "error")
@@ -126,6 +126,7 @@ func test_create_script_validation_does_not_pollute_shared_editor_log() -> void:
 
 	assert_has_key(result, "data")
 	assert_eq(result.data.diagnostics_detail, "log_capture")
+	assert_eq(result.data.diagnostics.size(), 1, "Invalid GDScript should report one diagnostic")
 	var captured := shared_buf.get_since(cursor)
 	assert_eq(captured.entries.size(), 0, "Validation load diagnostics must not leak into the shared editor log")
 	DirAccess.remove_absolute(path)
@@ -300,7 +301,7 @@ func test_patch_script_reports_log_capture_diagnostics_with_real_line() -> void:
 	assert_eq(result.data.diagnostics_scope, "this_file")
 	assert_eq(result.data.diagnostics_status, "checked")
 	assert_eq(result.data.diagnostics_detail, "log_capture")
-	assert_gt(result.data.diagnostics.size(), 0, "Invalid patched GDScript should report diagnostics")
+	assert_eq(result.data.diagnostics.size(), 1, "Invalid patched GDScript should report one diagnostic")
 	assert_eq(result.data.diagnostics[0].path, path)
 	assert_eq(result.data.diagnostics[0].line, 4)
 	assert_eq(result.data.diagnostics[0].level, "error")
@@ -337,6 +338,7 @@ func test_patch_script_validation_does_not_pollute_shared_editor_log() -> void:
 
 	assert_has_key(result, "data")
 	assert_eq(result.data.diagnostics_detail, "log_capture")
+	assert_eq(result.data.diagnostics.size(), 1, "Invalid patched GDScript should report one diagnostic")
 	var captured := shared_buf.get_since(cursor)
 	assert_eq(captured.entries.size(), 0, "Validation load diagnostics must not leak into the shared editor log")
 	DirAccess.remove_absolute(path)

--- a/test_project/tests/test_script.gd
+++ b/test_project/tests/test_script.gd
@@ -172,7 +172,10 @@ func _detach_shared_editor_logger() -> void:
 
 
 func _expect_invalid_if_parse_errors() -> void:
-	# Godot emits this diagnostic twice: once for gdscript:// validation and once for the res:// file load.
+	# Godot 4.7 adds one more logger-visible copy of this parse diagnostic.
+	# Expect the maximum seen across supported engines; older versions tolerate
+	# extra expectations for errors that are never emitted.
+	expect_script_error_containing(INVALID_IF_PARSE_ERROR)
 	expect_script_error_containing(INVALID_IF_PARSE_ERROR)
 	expect_script_error_containing(INVALID_IF_PARSE_ERROR)
 


### PR DESCRIPTION
**Description**
This is the first Godot 4.7 adoption PR. It adds 4.7 as a CI signal without promoting it to the primary supported/tested version yet.

Changes:
- Add a Linux Godot `4.7.0` row to the `godot-tests` matrix.
- Keep the existing 4.6.2 primary rows and the 4.3 canary unchanged.
- Set synthesized keyboard and mouse InputMap bindings to `device = -1` so they match events from any keyboard/mouse device under Godot 4.7’s new device-ID behavior.
- Leave joypad bindings unchanged because joypad events already use explicit device IDs.
- Add regression tests that assert both the stored device value and real `InputMap.event_is_action(...)` matching behavior.
- Pin invalid-write diagnostic tests to exactly one returned diagnostic, guarding against duplicate user-facing diagnostics on 4.7.

Validation:
- Live Godot 4.7 full `test_run`: `1426 passed, 21 skipped`
- `test_run suite="script"`: `42 passed, 2 skipped`
- `script/ci-check-gdscript`: passed
- `ruff check src/ tests/`: passed
- `git diff --check`: passed