### PR TITLE
test: skip POSIX pid liveness checks on Windows

### DIFF
--- a/tests/unit/test_orphan_reaper.py
+++ b/tests/unit/test_orphan_reaper.py
@@ -12,6 +12,11 @@ import pytest
 from godot_ai import orphan_reaper
 from godot_ai.orphan_reaper import pid_alive, should_arm_reaper, watch_owner
 
+POSIX_ONLY_PID_ALIVE = pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="pid_alive is POSIX-only; orphan reaper is disabled on Windows",
+)
+
 
 def test_should_arm_requires_valid_pid():
     assert should_arm_reaper(None) is False
@@ -33,6 +38,7 @@ def test_should_arm_false_on_windows(monkeypatch):
     assert should_arm_reaper(1234) is False
 
 
+@POSIX_ONLY_PID_ALIVE
 def test_pid_alive_for_self():
     assert pid_alive(os.getpid()) is True
 
@@ -51,6 +57,7 @@ def test_pid_alive_raises_on_windows(monkeypatch):
         pid_alive(12345)
 
 
+@POSIX_ONLY_PID_ALIVE
 def test_pid_alive_false_for_dead_process():
     proc = subprocess.Popen([sys.executable, "-c", "pass"])
     proc.wait()


### PR DESCRIPTION
Fixes #570.

`pid_alive()` is intentionally POSIX-only. On Windows, the orphan reaper is disabled by `should_arm_reaper()`, and `pid_alive()` raises rather than risk using Windows `os.kill()` semantics incorrectly.

This PR marks only the two direct `pid_alive()` liveness tests as POSIX-only on Windows:
- `test_pid_alive_for_self`
- `test_pid_alive_false_for_dead_process`

The explicit Windows behavior test is unchanged, so we still assert that `pid_alive()` raises on Windows by design. This is a test-scope fix only; it does not add Windows orphan-reaper support or a Windows process liveness probe.

**Validation**
- `uv run ruff check tests/unit/test_orphan_reaper.py`
- `uv run pytest -q tests/unit/test_orphan_reaper.py` → `10 passed, 2 skipped`
- `uv run pytest -q` → `1165 passed, 11 skipped`
- `git diff --check`