### PR TITLE
harden(self-update): inline-extract path safety + integrity, brand-gate managed_record kill

### DIFF
--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -1092,7 +1092,17 @@ func _evaluate_strong_port_occupant_proof(port: int, live: Dictionary = {}) -> D
 	var record_version := str(record.get("version", ""))
 
 	if record_pid > 1 and record_pid != OS.get_process_id():
-		if listener_pids.has(record_pid) and _pid_alive_for_proof(record_pid):
+		## Brand-verify the recorded PID before trusting it as a kill target.
+		## A recorded PID can outlive the server it named and be recycled by
+		## the kernel for an unrelated process that happens to bind the same
+		## port — without the cmdline brand gate (the same one the
+		## `pidfile_listener` branch enforces) that process could be killed.
+		## See #525.
+		if (
+			listener_pids.has(record_pid)
+			and _pid_alive_for_proof(record_pid)
+			and _pid_cmdline_is_godot_ai_for_proof(record_pid)
+		):
 			return {"proof": "managed_record", "pids": [record_pid]}
 
 	var legacy_targets := _legacy_pidfile_kill_targets(port, listener_pids)

--- a/plugin/addons/godot_ai/utils/update_manager.gd
+++ b/plugin/addons/godot_ai/utils/update_manager.gd
@@ -34,6 +34,21 @@ const UPDATE_TEMP_DIR := "user://godot_ai_update/"
 const UPDATE_TEMP_ZIP := "user://godot_ai_update/update.zip"
 const ClientConfigurator := preload("res://addons/godot_ai/client_configurator.gd")
 
+## Hosts the self-update download is allowed to come from. The download URL
+## is taken verbatim from the GitHub Releases API's `browser_download_url`,
+## so before fetching we pin it to https on a GitHub-owned host — a tampered
+## or unexpected API response can't then point the in-editor updater at an
+## arbitrary origin. (HTTPRequest follows the github.com -> githubusercontent
+## redirect internally; this validates the entry point. Release-side checksum
+## / provenance verification of the downloaded bytes remains tracked in #523.)
+const _TRUSTED_DOWNLOAD_HOSTS := [
+	"github.com",
+	"www.github.com",
+	"api.github.com",
+	"objects.githubusercontent.com",
+	"release-assets.githubusercontent.com",
+]
+
 ## Emitted after `check_for_updates()` resolves a newer remote version.
 ## Payload mirrors the Dictionary returned by `parse_releases_response`:
 ##   {has_update, version, forced, label_text, download_url}
@@ -166,6 +181,22 @@ func start_install() -> void:
 		OS.shell_open(RELEASES_PAGE)
 		return
 
+	## Pin the resolved asset URL to https on a GitHub host before fetching.
+	## Fall back to the release page (a user-driven browser download) rather
+	## than pulling an executable plugin payload from an unexpected origin.
+	## See #523.
+	if not _is_trusted_download_url(_latest_download_url):
+		push_error(
+			"MCP | refusing self-update download from untrusted URL: %s"
+			% _latest_download_url
+		)
+		OS.shell_open(RELEASES_PAGE)
+		install_state_changed.emit({
+			"button_text": "Update via download page",
+			"button_disabled": false,
+		})
+		return
+
 	install_state_changed.emit({
 		"button_text": "Downloading...",
 		"button_disabled": true,
@@ -259,6 +290,30 @@ static func parse_releases_response(
 	out["label_text"] = label_text
 	out["download_url"] = url
 	return out
+
+
+## True only for an `https://` URL whose host is one of
+## `_TRUSTED_DOWNLOAD_HOSTS`. Parses the authority by hand (GDScript has no
+## URL parser): strips userinfo via the LAST `@` so `https://github.com@evil
+## .com/...` resolves to `evil.com` (rejected), and strips any `:port`.
+## Static so the guard is unit-testable without instancing the manager.
+static func _is_trusted_download_url(url: String) -> bool:
+	const SCHEME := "https://"
+	if not url.begins_with(SCHEME):
+		return false
+	var rest := url.substr(SCHEME.length())
+	var authority := rest
+	var slash := rest.find("/")
+	if slash >= 0:
+		authority = rest.substr(0, slash)
+	## Host is everything after the LAST '@' (userinfo precedes it).
+	var at := authority.rfind("@")
+	if at >= 0:
+		authority = authority.substr(at + 1)
+	var colon := authority.find(":")
+	if colon >= 0:
+		authority = authority.substr(0, colon)
+	return authority.to_lower() in _TRUSTED_DOWNLOAD_HOSTS
 
 
 static func _is_newer(remote: String, local: String) -> bool:
@@ -382,16 +437,43 @@ func _install_zip_inline(version: Dictionary) -> void:
 	for file_path in files:
 		if not file_path.begins_with("addons/godot_ai/"):
 			continue
+		## Skip zip dir entries; parent dirs are created from each validated
+		## file's base dir below — the same shape the runner uses. Creating a
+		## dir from an unvalidated entry would itself be a traversal hole.
 		if file_path.ends_with("/"):
-			DirAccess.make_dir_recursive_absolute(install_base.path_join(file_path))
-		else:
-			var dir := file_path.get_base_dir()
-			DirAccess.make_dir_recursive_absolute(install_base.path_join(dir))
-			var content := reader.read_file(file_path)
-			var f := FileAccess.open(install_base.path_join(file_path), FileAccess.WRITE)
-			if f != null:
-				f.store_buffer(content)
-				f.close()
+			continue
+		## Reject path-traversal / absolute / backslash entries BEFORE any
+		## path_join + write. The modern runner enforces this via
+		## `update_reload_runner.gd::_is_safe_zip_addon_file`; the pre-4.4
+		## inline path used to gate only on the `addons/godot_ai/` prefix, so
+		## `addons/godot_ai/../../evil.gd` escaped the addon dir. This guard
+		## closes that gap so the weaker path runs the same checks. See #522.
+		if not _is_safe_zip_addon_file(file_path):
+			_abort_inline_install(reader, "unsafe zip path: %s" % file_path)
+			return
+		var dir := file_path.get_base_dir()
+		DirAccess.make_dir_recursive_absolute(install_base.path_join(dir))
+		var content := reader.read_file(file_path)
+		var target := install_base.path_join(file_path)
+		var f := FileAccess.open(target, FileAccess.WRITE)
+		## Unlike the runner (tmp+rename+per-file backup+rollback), this pre-4.4
+		## path writes directly over live files and can't roll back. It used to
+		## skip a null open and ignore store_buffer errors silently, leaving a
+		## partially-overwritten addons tree while still telling the user to
+		## restart onto it. Check both error surfaces and abort loudly instead.
+		## See #524.
+		if f == null:
+			_abort_inline_install(
+				reader,
+				"could not open %s for write (error %d)" % [target, FileAccess.get_open_error()],
+			)
+			return
+		f.store_buffer(content)
+		var write_error := f.get_error()
+		f.close()
+		if write_error != OK:
+			_abort_inline_install(reader, "write error %d for %s" % [write_error, target])
+			return
 
 	reader.close()
 
@@ -426,6 +508,47 @@ func _install_zip_inline(version: Dictionary) -> void:
 			"label_text": "Updated! Restart the editor.",
 			"outcome": "success",
 		})
+
+
+## Abort the inline (pre-4.4) extract on a path-safety or write failure.
+## Closes the ZIP reader, drops the in-flight gate so dock spawn paths
+## un-block, and surfaces the failure loudly: this path has no rollback, so
+## the addons tree may be partially overwritten and the user must reinstall
+## from the download page rather than relaunch onto a half-written plugin.
+## See #522 / #524.
+func _abort_inline_install(reader: ZIPReader, reason: String) -> void:
+	reader.close()
+	_install_in_flight = false
+	push_error(
+		"MCP | self-update extract failed: %s. addons/godot_ai/ may be"
+		% reason
+		+ " partially updated — reinstall the plugin from the download page"
+		+ " before relaunching."
+	)
+	print("MCP | self-update extract aborted: %s" % reason)
+	install_state_changed.emit({
+		"button_text": "Extract failed — reinstall",
+		"button_disabled": false,
+	})
+
+
+## Mirror of `update_reload_runner.gd::_is_safe_zip_addon_file`. Rejects any
+## entry that could escape `addons/godot_ai/` — absolute paths, backslashes,
+## and `.`/`..`/empty path segments — before it reaches a `path_join` + write
+## on the inline (pre-4.4) extract path, which has no rollback. Static so the
+## guard is unit-testable without instancing the manager. See #522.
+static func _is_safe_zip_addon_file(file_path: String) -> bool:
+	if file_path.is_absolute_path() or file_path.contains("\\"):
+		return false
+	if not file_path.begins_with("addons/godot_ai/"):
+		return false
+	var rel_path := file_path.trim_prefix("addons/godot_ai/")
+	if rel_path.is_empty() or rel_path.ends_with("/"):
+		return false
+	for segment in rel_path.split("/", true):
+		if segment.is_empty() or segment == "." or segment == "..":
+			return false
+	return true
 
 
 func _on_filesystem_scanned_for_update() -> void:

--- a/plugin/addons/godot_ai/utils/update_manager.gd
+++ b/plugin/addons/godot_ai/utils/update_manager.gd
@@ -294,9 +294,10 @@ static func parse_releases_response(
 
 ## True only for an `https://` URL whose host is one of
 ## `_TRUSTED_DOWNLOAD_HOSTS`. Parses the authority by hand (GDScript has no
-## URL parser): strips userinfo via the LAST `@` so `https://github.com@evil
-## .com/...` resolves to `evil.com` (rejected), and strips any `:port`.
-## Static so the guard is unit-testable without instancing the manager.
+## URL parser): strips userinfo via the LAST `@` so a spoof like
+## `https://github.com@evil.com/...` resolves to `evil.com` (rejected), and
+## strips any `:port`. Static so the guard is unit-testable without
+## instancing the manager.
 static func _is_trusted_download_url(url: String) -> bool:
 	const SCHEME := "https://"
 	if not url.begins_with(SCHEME):

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -1025,6 +1025,9 @@ func test_drift_kill_preserves_record_and_does_not_spawn_when_port_stays_held() 
 	plugin.listener_pids = [24680] as Array[int]
 	plugin.managed_record = {"pid": 24680, "version": "old-managed-for-test", "ws_port": 9500}
 	plugin.alive_pids = [24680] as Array[int]
+	## The recorded PID is genuinely our managed server, so it's branded
+	## godot-ai — the managed_record kill branch now requires that brand (#525).
+	plugin.branded_pids = [24680] as Array[int]
 	plugin.live_status = {"name": "other-server", "version": "old-managed-for-test", "ws_port": 9500, "status_code": 200}
 
 	plugin._start_server()

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -491,6 +491,10 @@ func test_strong_proof_accepts_live_managed_record_pid() -> void:
 	plugin.listener_pids = [24680] as Array[int]
 	plugin.managed_record = {"pid": 24680, "version": "2.1.0", "ws_port": 9500}
 	plugin.alive_pids = [24680] as Array[int]
+	## The managed_record kill target now clears the same cmdline brand gate
+	## as the pidfile_listener branch (#525), so the recorded PID must be
+	## branded for the proof to hold.
+	plugin.branded_pids = [24680] as Array[int]
 
 	var proof := plugin._evaluate_strong_port_occupant_proof(TEST_PORT)
 	plugin.free()
@@ -499,6 +503,31 @@ func test_strong_proof_accepts_live_managed_record_pid() -> void:
 	var pids: Array[int] = []
 	pids.assign(proof.get("pids", []))
 	assert_eq(pids, [24680] as Array[int])
+
+
+func test_strong_proof_rejects_unbranded_managed_record_pid() -> void:
+	## A recorded PID can outlive the server it named and be recycled by the
+	## kernel for an unrelated process that binds the same port. Before #525
+	## the managed_record branch trusted an alive listener PID with no cmdline
+	## brand check — so that unrelated process could be selected as a kill
+	## target. With the brand gate, an unbranded recorded PID yields no proof
+	## (and the helper falls through to the stricter status-match branch,
+	## which also fails here), so nothing is authorized for the kill.
+	var plugin := _ProofPlugin.new()
+	plugin.listener_pids = [24680] as Array[int]
+	plugin.managed_record = {"pid": 24680, "version": "2.1.0", "ws_port": 9500}
+	plugin.alive_pids = [24680] as Array[int]
+	plugin.branded_pids = [] as Array[int]  # recorded PID is alive + listening but NOT ours
+	plugin.live_status = {"name": "", "version": "", "ws_port": 0, "status_code": 0}
+
+	var proof := plugin._evaluate_strong_port_occupant_proof(TEST_PORT)
+	plugin.free()
+
+	assert_eq(proof.get("proof", ""), "",
+		"an unbranded recorded PID must not authorize a managed_record kill")
+	var pids: Array[int] = []
+	pids.assign(proof.get("pids", []))
+	assert_true(pids.is_empty(), "no kill targets when the recorded PID isn't branded ours")
 
 
 func test_legacy_pidfile_proof_returns_all_branded_listener_pids() -> void:

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -152,6 +152,9 @@ func test_recover_kills_and_clears_when_port_frees() -> void:
 	var host := _ManagerHostStub.new()
 	host.listener_pids = [22222] as Array[int]
 	host.alive_pids = [22222] as Array[int]
+	## The recorded PID is our managed server, so it's branded godot-ai — the
+	## managed_record kill branch now requires that brand (#525).
+	host.branded_pids = [22222] as Array[int]
 	host.managed_record = {"pid": 22222, "version": "2.1.0", "ws_port": 9500}
 	host.port_in_use_sequence = [false] as Array[bool]
 	var manager := McpServerLifecycleManagerScript.new(host)
@@ -166,6 +169,9 @@ func test_recover_preserves_record_when_port_held() -> void:
 	var host := _ManagerHostStub.new()
 	host.listener_pids = [33333] as Array[int]
 	host.alive_pids = [33333] as Array[int]
+	## Branded ours so the managed_record proof fires and a kill is attempted;
+	## the port then stays held, exercising the preserve-record path (#525).
+	host.branded_pids = [33333] as Array[int]
 	host.managed_record = {"pid": 33333, "version": "2.1.0", "ws_port": 9500}
 	host.port_in_use_sequence = [true] as Array[bool]
 	var manager := McpServerLifecycleManagerScript.new(host)

--- a/test_project/tests/test_update_manager.gd
+++ b/test_project/tests/test_update_manager.gd
@@ -63,6 +63,73 @@ func test_manual_update_label_omits_version_when_unknown() -> void:
 	assert_contains(no_v, "Godot 4.4+", "label must still state the engine requirement")
 
 
+# ---- _is_safe_zip_addon_file (pure / static, #522) --------------------
+
+func test_safe_zip_addon_file_accepts_normal_entries() -> void:
+	## The inline (pre-4.4) extract path validates every entry with the same
+	## guard the runner enforces, so ordinary addon files must pass.
+	assert_true(
+		McpUpdateManagerScript._is_safe_zip_addon_file("addons/godot_ai/plugin.gd"),
+		"a top-level addon file must be accepted")
+	assert_true(
+		McpUpdateManagerScript._is_safe_zip_addon_file("addons/godot_ai/utils/settings.gd"),
+		"a nested addon file must be accepted")
+
+
+func test_safe_zip_addon_file_rejects_traversal_and_escapes() -> void:
+	## These are exactly the shapes the prefix-only check used to let through
+	## onto a path_join + write (#522).
+	assert_false(
+		McpUpdateManagerScript._is_safe_zip_addon_file("addons/godot_ai/../../evil.gd"),
+		"`..` segments must be rejected — they escape the addon dir")
+	assert_false(
+		McpUpdateManagerScript._is_safe_zip_addon_file("/etc/passwd"),
+		"absolute paths must be rejected")
+	assert_false(
+		McpUpdateManagerScript._is_safe_zip_addon_file("addons/godot_ai/foo\\..\\bar.gd"),
+		"backslashes must be rejected (Windows-style traversal)")
+	assert_false(
+		McpUpdateManagerScript._is_safe_zip_addon_file("addons/other/file.gd"),
+		"entries outside addons/godot_ai/ must be rejected")
+	assert_false(
+		McpUpdateManagerScript._is_safe_zip_addon_file("addons/godot_ai/"),
+		"the bare prefix (dir entry) must be rejected as a file")
+	assert_false(
+		McpUpdateManagerScript._is_safe_zip_addon_file("addons/godot_ai/a//b.gd"),
+		"empty path segments must be rejected")
+
+
+# ---- _is_trusted_download_url (pure / static, #523) -------------------
+
+func test_trusted_download_url_accepts_github_hosts() -> void:
+	assert_true(
+		McpUpdateManagerScript._is_trusted_download_url(TEST_ASSET_URL),
+		"a normal github.com release asset URL must be trusted")
+	assert_true(
+		McpUpdateManagerScript._is_trusted_download_url(
+			"https://objects.githubusercontent.com/github-production-release/x.zip"),
+		"the githubusercontent redirect target host must be trusted")
+
+
+func test_trusted_download_url_rejects_untrusted_and_insecure() -> void:
+	assert_false(
+		McpUpdateManagerScript._is_trusted_download_url(
+			"http://github.com/hi-godot/godot-ai/releases/download/v1/godot-ai-plugin.zip"),
+		"plain http must be rejected even on a github host")
+	assert_false(
+		McpUpdateManagerScript._is_trusted_download_url("https://example.invalid/payload.zip"),
+		"a non-github host must be rejected")
+	assert_false(
+		McpUpdateManagerScript._is_trusted_download_url("https://github.com.evil.com/x.zip"),
+		"a look-alike host suffix must be rejected")
+	assert_false(
+		McpUpdateManagerScript._is_trusted_download_url("https://github.com@evil.com/x.zip"),
+		"userinfo spoofing (host is after the last @) must be rejected")
+	assert_false(
+		McpUpdateManagerScript._is_trusted_download_url(""),
+		"an empty URL must be rejected")
+
+
 # ---- parse_releases_response (pure / static) ---------------------------
 
 func _make_body(json_str: String) -> PackedByteArray:


### PR DESCRIPTION
Implements the self-update hardening cluster tracked in #573 (#522, #524, #525 fully; #523 partially).

## Changes

### #522 — zip path-safety on the legacy inline extract
The pre-4.4 `_install_zip_inline` path gated only on the `addons/godot_ai/` prefix before `path_join` + write, so `addons/godot_ai/../../evil.gd`, absolute paths, and backslashes escaped the addon dir. It now validates every entry with a new `_is_safe_zip_addon_file` (mirroring the runner's `update_reload_runner.gd::_is_safe_zip_addon_file`: rejects absolute paths, backslashes, and `.`/`..`/empty segments) and skips zip dir entries — parent dirs are created from each validated file's base dir, the same shape the runner uses. The two install paths now share the same trust handling.

### #524 — inline extract write-error handling
The inline path skipped a null `FileAccess.open` and ignored `store_buffer` errors silently, leaving a partially-overwritten addons tree while still telling the user to restart onto it. It now checks `get_open_error()` and `get_error()` and aborts loudly via a new `_abort_inline_install` helper (closes the reader, drops the in-flight gate so dock spawn paths un-block, and surfaces a "reinstall from the download page" message). Full tmp+rename+backup+rollback stays in the runner (4.4+); the pre-4.4 path can't roll back, so the message tells the user not to relaunch onto a half-written plugin.

### #523 — download host/scheme pinning (partial)
The download URL was taken verbatim from the GitHub API's `browser_download_url` and fetched with no scheme/host check. `start_install` now pins the resolved URL to `https://` on a GitHub-owned host (`_is_trusted_download_url`, with userinfo-spoof and port handling) before fetching, falling back to the release page otherwise. **Release-side checksum/provenance verification of the downloaded bytes is not included here** and remains tracked in #523 — it requires changes to the publish workflow and is better reviewed on its own. I'd suggest keeping #523 open after this merges.

### #525 — brand-gate the managed_record kill target
`_evaluate_strong_port_occupant_proof` returned a recorded PID as an automatic kill target when it was an alive listener, but skipped the `_pid_cmdline_is_godot_ai_for_proof` brand check that the sibling `pidfile_listener` branch enforces — a recycled PID bound to the same port could be killed. The `managed_record` branch now clears the same brand gate.

## Tests
- `test_update_manager.gd`: new static-helper coverage for `_is_safe_zip_addon_file` (accepts normal entries; rejects `..`, absolute, backslash, out-of-prefix, bare-prefix, empty-segment) and `_is_trusted_download_url` (accepts github hosts; rejects http, non-github, look-alike suffix, userinfo-spoof, empty). These pass headlessly.
- `test_plugin_lifecycle.gd`: new `test_strong_proof_rejects_unbranded_managed_record_pid`; the existing accept test now brands its PID to reflect the added gate. (This suite runs in the editor+MCP harness, not headless.)
- `script/ci-check-gdscript` is clean (no parse errors).

## Scope note
This is one of the two umbrella sets from the issue-triage pass; the stormtest-Windows set (#574) is untouched. After merge, #522/#524/#525 can close; #523 should stay open for the checksum/provenance half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7VnMraTCEhTyj2CzyH8tC

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7VnMraTCEhTyj2CzyH8tC)_