### PR TITLE
harden(self-update): verify release checksum before extract (#523)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,10 +161,21 @@ jobs:
           fi
           echo "Zip structure verified: addons/godot_ai/... + godot-ai-LICENSE.txt (multi-top)"
 
+      - name: Generate SHA-256 checksum
+        # Sidecar checksum for the plugin's self-updater to verify the
+        # downloaded archive's integrity before extracting over live plugin
+        # code (#523). `sha256sum`'s "<hex>  <name>" format is what the plugin
+        # parses (utils/update_manager.gd::_parse_sha256_digest).
+        run: |
+          sha256sum godot-ai-plugin.zip > godot-ai-plugin.zip.sha256
+          cat godot-ai-plugin.zip.sha256
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
-          files: godot-ai-plugin.zip
+          files: |
+            godot-ai-plugin.zip
+            godot-ai-plugin.zip.sha256
           generate_release_notes: true
 
       - name: Post changelog to Discord

--- a/plugin/addons/godot_ai/utils/update_manager.gd
+++ b/plugin/addons/godot_ai/utils/update_manager.gd
@@ -68,7 +68,12 @@ var _dock
 
 var _http_request: HTTPRequest
 var _download_request: HTTPRequest
+var _verify_request: HTTPRequest
 var _latest_download_url: String = ""
+## URL of the `godot-ai-plugin.zip.sha256` sidecar asset, when the release
+## ships one. Used to verify the downloaded archive's integrity before extract
+## (#523). Empty for older releases published without a checksum sidecar.
+var _latest_checksum_url: String = ""
 
 ## Set for the duration of `_install_zip` — extract-overwrite of plugin
 ## scripts on disk would crash any worker mid-`GDScriptFunction::call`
@@ -116,6 +121,7 @@ func cancel_check() -> void:
 ## flips so a fresh check paints over a clean banner.
 func clear_pending_download() -> void:
 	_latest_download_url = ""
+	_latest_checksum_url = ""
 
 
 ## True when the running Godot can self-update in place. Godot < 4.4 takes
@@ -243,6 +249,7 @@ func is_install_in_flight() -> bool:
 ##   forced: bool                    ## mode_override() == "user" (banner-only hint)
 ##   label_text: String              ## "Update available: vX.Y.Z" + " (forced)"
 ##   download_url: String            ## matching `godot-ai-plugin.zip` asset URL
+##   checksum_url: String            ## `godot-ai-plugin.zip.sha256` asset URL ("" if absent)
 ##
 ## Static so tests drive it without instancing the manager.
 static func parse_releases_response(
@@ -254,6 +261,7 @@ static func parse_releases_response(
 		"forced": false,
 		"label_text": "",
 		"download_url": "",
+		"checksum_url": "",
 	}
 	if result != HTTPRequest.RESULT_SUCCESS or response_code != 200:
 		return out
@@ -270,12 +278,15 @@ static func parse_releases_response(
 		return out
 
 	var url := ""
+	var checksum_url := ""
 	var assets: Array = json.get("assets", [])
 	for asset in assets:
 		var asset_dict: Dictionary = asset
-		if String(asset_dict.get("name", "")) == "godot-ai-plugin.zip":
+		var asset_name := String(asset_dict.get("name", ""))
+		if asset_name == "godot-ai-plugin.zip":
 			url = String(asset_dict.get("browser_download_url", ""))
-			break
+		elif asset_name == "godot-ai-plugin.zip.sha256":
+			checksum_url = String(asset_dict.get("browser_download_url", ""))
 
 	var forced := ClientConfigurator.mode_override() == "user"
 	var label_text := "Update available: v%s" % remote_version
@@ -289,6 +300,7 @@ static func parse_releases_response(
 	out["forced"] = forced
 	out["label_text"] = label_text
 	out["download_url"] = url
+	out["checksum_url"] = checksum_url
 	return out
 
 
@@ -342,6 +354,7 @@ func _on_update_check_completed(
 	if not bool(parsed.get("has_update", false)):
 		return
 	_latest_download_url = String(parsed.get("download_url", ""))
+	_latest_checksum_url = String(parsed.get("checksum_url", ""))
 	update_check_completed.emit(parsed)
 	## On engines that can't self-update (Godot < 4.4, #475), surface the
 	## full manual-update guidance AND relabel the button up-front — before
@@ -371,9 +384,117 @@ func _on_download_completed(
 		})
 		return
 
+	# Deferred so the HTTPRequest callback returns before the next step starts.
+	_verify_then_install.call_deferred()
+
+
+# ---- Integrity verification (#523) -------------------------------------
+
+## Gate the extract on a SHA-256 match against the release's checksum sidecar.
+## TLS + host pinning already constrain where the bytes came from; this
+## verifies the bytes themselves so a tampered asset (or a compromised CDN
+## object) can't be installed over live plugin code. Releases published
+## without a `.sha256` sidecar (older versions) install without this check —
+## verify-if-present rather than hard-fail, so existing releases stay
+## updatable; the host pin still applies to the download itself.
+func _verify_then_install() -> void:
+	if _latest_checksum_url.is_empty():
+		print("MCP | no checksum published for this release; skipping integrity verification")
+		install_state_changed.emit({"button_text": "Installing..."})
+		_install_zip()
+		return
+
+	## A present-but-untrusted checksum URL is a tamper signal, not a
+	## backward-compat case — refuse rather than silently skip.
+	if not _is_trusted_download_url(_latest_checksum_url):
+		_fail_verification("checksum URL is not a trusted GitHub host")
+		return
+
+	install_state_changed.emit({"button_text": "Verifying..."})
+	if _verify_request != null:
+		_verify_request.queue_free()
+	_verify_request = HTTPRequest.new()
+	_verify_request.max_redirects = 10
+	_verify_request.request_completed.connect(_on_checksum_completed)
+	add_child(_verify_request)
+	var err := _verify_request.request(_latest_checksum_url)
+	if err != OK:
+		_verify_request.queue_free()
+		_verify_request = null
+		_fail_verification("could not request checksum (error %d)" % err)
+
+
+func _on_checksum_completed(
+	result: int,
+	response_code: int,
+	_headers: PackedStringArray,
+	body: PackedByteArray
+) -> void:
+	if _verify_request != null:
+		_verify_request.queue_free()
+		_verify_request = null
+
+	if result != HTTPRequest.RESULT_SUCCESS or response_code != 200:
+		_fail_verification("checksum download failed (result=%d code=%d)" % [result, response_code])
+		return
+
+	var expected := _parse_sha256_digest(body.get_string_from_utf8())
+	if expected.is_empty():
+		_fail_verification("malformed checksum file")
+		return
+
+	var zip_path := ProjectSettings.globalize_path(UPDATE_TEMP_ZIP)
+	var actual := FileAccess.get_sha256(zip_path).to_lower()
+	if actual.is_empty():
+		_fail_verification("could not hash the downloaded archive")
+		return
+	if actual != expected:
+		_fail_verification(
+			"checksum mismatch (expected %s…, got %s…)"
+			% [expected.substr(0, 12), actual.substr(0, 12)]
+		)
+		return
+
+	print("MCP | self-update checksum verified (sha256 %s)" % actual)
 	install_state_changed.emit({"button_text": "Installing..."})
-	# Deferred so the HTTPRequest callback returns before the extract starts.
-	_install_zip.call_deferred()
+	_install_zip()
+
+
+## Surface an integrity-check failure and drop the staged zip so the bad
+## bytes can never reach the extract path. Keeps the button enabled for retry.
+func _fail_verification(reason: String) -> void:
+	push_error(
+		"MCP | self-update integrity check failed: %s. The download was not installed."
+		% reason
+	)
+	print("MCP | self-update aborted (integrity): %s" % reason)
+	DirAccess.remove_absolute(ProjectSettings.globalize_path(UPDATE_TEMP_ZIP))
+	install_state_changed.emit({
+		"button_text": "Verification failed — retry",
+		"button_disabled": false,
+	})
+
+
+## Extract the hex digest from a `sha256sum`-style file ("<hex>  <name>") or a
+## bare digest line. Returns lowercase 64-char hex, or "" if the content isn't
+## a valid SHA-256 digest. Static so it's unit-testable. See #523.
+static func _parse_sha256_digest(text: String) -> String:
+	var trimmed := text.strip_edges()
+	if trimmed.is_empty():
+		return ""
+	## First whitespace-delimited token; `sha256sum` separates digest and
+	## filename with two spaces, so allow_empty=false collapses the run.
+	var tokens := trimmed.split(" ", false)
+	if tokens.is_empty():
+		return ""
+	var digest := String(tokens[0]).strip_edges().to_lower()
+	if digest.length() != 64:
+		return ""
+	for i in digest.length():
+		var c := digest[i]
+		if not ((c >= "0" and c <= "9") or (c >= "a" and c <= "f")):
+			return ""
+	return digest
 
 
 # ---- Install orchestration ---------------------------------------------

--- a/test_project/tests/test_update_manager.gd
+++ b/test_project/tests/test_update_manager.gd
@@ -130,6 +130,55 @@ func test_trusted_download_url_rejects_untrusted_and_insecure() -> void:
 		"an empty URL must be rejected")
 
 
+# ---- _parse_sha256_digest (pure / static, #523) ----------------------
+
+func test_parse_sha256_digest_accepts_sha256sum_line() -> void:
+	## `sha256sum godot-ai-plugin.zip` emits "<hex>  <name>"; only the digest
+	## is used.
+	var hex := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	var parsed := McpUpdateManagerScript._parse_sha256_digest(hex + "  godot-ai-plugin.zip\n")
+	assert_eq(parsed, hex, "must extract the digest from a sha256sum line")
+
+
+func test_parse_sha256_digest_accepts_bare_and_uppercase_digest() -> void:
+	var hex := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	assert_eq(McpUpdateManagerScript._parse_sha256_digest(hex), hex,
+		"a bare digest line must be accepted")
+	assert_eq(McpUpdateManagerScript._parse_sha256_digest(hex.to_upper()), hex,
+		"an uppercase digest must be normalized to lowercase")
+
+
+func test_parse_sha256_digest_rejects_malformed() -> void:
+	assert_eq(McpUpdateManagerScript._parse_sha256_digest(""), "",
+		"empty content must be rejected")
+	assert_eq(McpUpdateManagerScript._parse_sha256_digest("deadbeef"), "",
+		"a too-short digest must be rejected")
+	assert_eq(
+		McpUpdateManagerScript._parse_sha256_digest(
+			"z3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"),
+		"",
+		"a non-hex character must be rejected")
+
+
+func test_parse_sha256_digest_matches_fileaccess_hash() -> void:
+	## End-to-end: the digest the plugin parses from a sha256sum line must
+	## equal what FileAccess.get_sha256 produces for the same bytes — the
+	## exact comparison _on_checksum_completed makes before extracting.
+	var path := "user://_test_checksum_target.bin"
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	assert_true(f != null, "seed file must open for write")
+	f.store_string("godot-ai self-update integrity test payload")
+	f.close()
+
+	var real := FileAccess.get_sha256(path).to_lower()
+	var sidecar_line := "%s  godot-ai-plugin.zip\n" % real
+	var parsed := McpUpdateManagerScript._parse_sha256_digest(sidecar_line)
+	DirAccess.remove_absolute(ProjectSettings.globalize_path(path))
+
+	assert_eq(parsed, real,
+		"parsed sidecar digest must match FileAccess.get_sha256 (the verify compare)")
+
+
 # ---- parse_releases_response (pure / static) ---------------------------
 
 func _make_body(json_str: String) -> PackedByteArray:
@@ -202,6 +251,37 @@ func test_parse_releases_response_handles_malformed_json() -> void:
 	)
 	assert_false(bool(result.get("has_update", true)),
 		"Malformed JSON must not flag an update")
+
+
+func test_parse_releases_response_captures_checksum_asset_url() -> void:
+	## The release ships a `godot-ai-plugin.zip.sha256` sidecar; its URL must
+	## be surfaced so the installer can verify integrity before extract (#523).
+	var checksum_url := TEST_ASSET_URL + ".sha256"
+	var body := _make_body(JSON.stringify({
+		"tag_name": "v999.0.0",
+		"assets": [
+			{"name": TEST_ASSET_NAME, "browser_download_url": TEST_ASSET_URL},
+			{"name": TEST_ASSET_NAME + ".sha256", "browser_download_url": checksum_url},
+		],
+	}))
+	var result := McpUpdateManagerScript.parse_releases_response(
+		HTTPRequest.RESULT_SUCCESS, 200, body
+	)
+	assert_eq(String(result.get("download_url", "")), TEST_ASSET_URL,
+		"zip asset URL must still resolve when a checksum sidecar is present")
+	assert_eq(String(result.get("checksum_url", "")), checksum_url,
+		"the .sha256 sidecar URL must be captured")
+
+
+func test_parse_releases_response_checksum_empty_when_absent() -> void:
+	## Older releases without a sidecar must leave checksum_url empty so the
+	## installer takes the verify-if-present (skip) path rather than failing.
+	var body := _make_body(_make_release_payload("v999.0.0"))
+	var result := McpUpdateManagerScript.parse_releases_response(
+		HTTPRequest.RESULT_SUCCESS, 200, body
+	)
+	assert_eq(String(result.get("checksum_url", "")), "",
+		"no sidecar asset must yield an empty checksum_url")
 
 
 func test_parse_releases_response_missing_asset_returns_empty_url() -> void:


### PR DESCRIPTION
Completes the integrity half of #523. The download URL is already pinned to `https` on a GitHub host (landed in #575); this PR verifies the **bytes themselves** so a tampered release asset or a compromised CDN object can't be installed over live plugin code.

## Changes

### `release.yml`
After the plugin zip is built and structure-verified, publish a `godot-ai-plugin.zip.sha256` sidecar (standard `sha256sum` output) and attach it to the GitHub Release alongside the zip.

### `update_manager.gd`
- `parse_releases_response` now also captures the `godot-ai-plugin.zip.sha256` asset URL (`checksum_url`).
- After the zip download completes, `_verify_then_install` downloads the sidecar and gates `_install_zip` on `FileAccess.get_sha256(zip)` matching the published digest.
- On mismatch / malformed digest / checksum-download failure, `_fail_verification` drops the staged zip (so bad bytes never reach the extract path) and surfaces a retryable **"Verification failed — retry"** banner.
- The checksum URL clears the same trusted-host gate as the download; a present-but-untrusted checksum URL is treated as a tamper signal (refuse), not a skip.

### Verify-if-present
Releases published **without** a `.sha256` sidecar (older versions) still install, with a printed notice — verify-if-present rather than hard-fail, so existing releases stay updatable. The host pin still applies to those downloads. Once releases reliably ship the sidecar, this could be tightened to mandatory.

## Tests
- `_parse_sha256_digest`: sha256sum line, bare digest, uppercase normalization, malformed (empty/short/non-hex), and **equality with `FileAccess.get_sha256`** on a real temp file (the exact comparison the verify path makes).
- `parse_releases_response`: captures `checksum_url` when the sidecar is present; empty when absent.

All new tests pass headlessly; `script/ci-check-gdscript` is clean.

## Scope
This closes the remaining half of #523 (URL pinning was #575). Part of the self-update hardening cluster #573.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7VnMraTCEhTyj2CzyH8tC

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7VnMraTCEhTyj2CzyH8tC)_