### PR TITLE
stormtest: cross-platform worktree launcher + isolated reload mode (#574)

### DIFF
--- a/docs/STRESS_TESTING.md
+++ b/docs/STRESS_TESTING.md
@@ -137,7 +137,7 @@ server reliably survive the reload is tracked in
 | `SS_RECONNECT_TIMEOUT` | 30 | seconds to wait for the server to return after a reload |
 | `SS_CLOSE_TIMEOUT` | 5 | hard cap (s) on client teardown so a dead-server socket can't wedge the loop |
 | `SS_URL` | `http://127.0.0.1:8000/mcp` | target MCP endpoint |
-| `SS_REPORT` | `$TMPDIR/stormtest_report.json` | where to write the JSON snapshot |
+| `SS_REPORT` | `<platform temp dir>/stormtest_report.json` | where to write the JSON snapshot (temp dir via `tempfile.gettempdir()`; `%TEMP%` on Windows) |
 
 Total calls ≈ `WORKERS × WAVES × CALLS` minus the chaos worker's reload waves.
 

--- a/docs/STRESS_TESTING.md
+++ b/docs/STRESS_TESTING.md
@@ -46,59 +46,82 @@ under load and across the disable→extract→enable reload window.
 
 The target editor's MCP server must be reachable (default `:8000`). For a true
 test of a branch's code, point the editor at that branch's worktree and serve
-that worktree's `src/` (see `script/serve-this-worktree`), so both the GDScript
-plugin and the Python server are the code under test.
+that worktree's `src/` (see [Serving a worktree](#serving-a-worktree-code-under-test)
+below), so both the GDScript plugin and the Python server are the code under test.
+
+The commands below use `python` (the same on every OS — activate the venv, or
+substitute the venv interpreter: `.venv/bin/python` on macOS/Linux,
+`.venv\Scripts\python.exe` on Windows). `stormtest.py`'s host-side paths are
+already platform-agnostic.
 
 ```bash
 # default ≈ 1000 calls, with reload churn, against localhost:8000
-.venv/bin/python script/stormtest.py
+python script/stormtest.py
 
 # brutal ≈ 9000 calls
-SS_WORKERS=12 SS_WAVES=30 .venv/bin/python script/stormtest.py
+SS_WORKERS=12 SS_WAVES=30 python script/stormtest.py
 
 # reads-only smoke, no reloads
-SS_RELOAD=0 SS_WORKERS=4 SS_WAVES=3 .venv/bin/python script/stormtest.py
+SS_RELOAD=0 SS_WORKERS=4 SS_WAVES=3 python script/stormtest.py
 
 # target a server on another port / host
-SS_URL=http://127.0.0.1:8010/mcp .venv/bin/python script/stormtest.py
+SS_URL=http://127.0.0.1:8010/mcp python script/stormtest.py
+
+# isolated reload survival (single-threaded; the Windows-friendly mode)
+SS_RELOAD_MODE=isolated python script/stormtest.py
+```
+
+### Serving a worktree (code under test)
+
+The shared `.venv` lives in the root repo and editable-installs the root's
+`src/godot_ai`, so a plugin launched from a worktree spawns the *root's* Python
+server — worktree Python changes are invisible. The cross-platform launcher
+`script/serve_worktree.py` fixes this: it resolves the venv interpreter, prepends
+the worktree's `src/` to `PYTHONPATH`, frees the HTTP port, and starts the server
+with `--reload` and **both** `--port` and `--ws-port` (so it matches an editor
+using non-default port overrides).
+
+```bash
+# any OS — pass the editor's HTTP and WS ports
+python script/serve_worktree.py --port 8000 --ws-port 9500
+
+# convenience wrappers (same launcher underneath)
+script/serve-this-worktree --port 8000 --ws-port 9500        # macOS / Linux
+.\script\serve-this-worktree.ps1 --port 18130 --ws-port 19630  # Windows (PowerShell)
 ```
 
 ### Windows / cross-platform notes
 
-> ⚠️ **Running on Windows? Reads/writes work; reload churn does not (yet).**
->
-> **Concurrent reads/writes are fine.** The harness *logic* is platform-agnostic:
-> the in-editor scratch paths (`res://_stormtest/…`) use Godot's virtual
-> filesystem, and the report path goes through `tempfile.gettempdir()` /
-> `os.path.join`, so both resolve correctly on every OS. A reads-dominant run
-> (`SS_RELOAD=0`) is clean on Windows.
->
-> **Reload churn (`SS_RELOAD=1`, the default) currently does NOT work on Windows**
-> — two independent problems, both tracked:
-> - Against a plugin-managed server, the first `editor_reload_plugin` **wedges the
->   harness**: the asyncio loop stalls past `CALL_TIMEOUT` when the server is
->   killed mid-reload under concurrent load. The *editor* survives fine (it
->   reloads and re-registers a new session) — only the harness hangs. See
->   [#513](https://github.com/hi-godot/godot-ai/issues/513).
-> - The "run the server externally" mitigation **also fails on Windows**:
->   `script/serve-this-worktree` is bash-only (no PowerShell port, and it never
->   passes `--ws-port`), and even a hand-started external `--reload` server gets
->   **killed by the reload** (`_stop_server` takes down the port owner with no
->   respawn). See [#514](https://github.com/hi-godot/godot-ai/issues/514).
->
->   Until those land, validate reload survival on Windows with a *single-threaded*
->   reload loop (reload → reconnect → confirm a new `session_id`) rather than the
->   concurrent churn mode.
->
-> **Invocation also differs (POSIX → Windows):**
-> - **venv interpreter** — use `.venv\Scripts\python.exe`, not `.venv/bin/python`.
-> - **`$TMPDIR`** in the examples is POSIX; the report lands in the platform temp
->   dir (`%TEMP%` on Windows). Pass an explicit `SS_REPORT=…` for a known
->   location, and prefer forward slashes (Python accepts them on Windows and they
->   dodge backslash-escaping surprises).
->
-> Making the tooling resilient enough to drop this heads-up is tracked in
-> [#509](https://github.com/hi-godot/godot-ai/issues/509).
+The harness and its tooling are cross-platform: the in-editor scratch paths
+(`res://_stormtest/…`) use Godot's virtual filesystem, the report path goes
+through `tempfile.gettempdir()` / `os.path.join`, the worktree launcher
+(`serve_worktree.py`) resolves the venv interpreter and frees the port per-OS,
+and `serve-this-worktree.ps1` gives Windows a discoverable serve command. The
+report lands in the platform temp dir (`%TEMP%` on Windows); pass an explicit
+`SS_REPORT=…` for a known path.
+
+**Reload survival on Windows — use isolated mode:**
+
+```bash
+SS_RELOAD_MODE=isolated python script/stormtest.py
+```
+
+Isolated mode runs a single-threaded `reload → reconnect → verify-session` loop
+with no concurrent load, printing a clean `survived N/N` count and per-reload
+recovery time. Prefer it on Windows: the **concurrent** churn mode
+(`SS_RELOAD_MODE=concurrent`, the default) can still wedge the asyncio loop when
+a *plugin-managed* server is killed mid-reload under concurrent load on Windows —
+the loop-wide stall is bounded now (client teardown is hard-capped by
+`SS_CLOSE_TIMEOUT`) but not fully root-caused
+([#513](https://github.com/hi-godot/godot-ai/issues/513)).
+
+To exercise **concurrent** churn on Windows without a managed server getting
+killed, serve the server externally with `--reload` (see
+[Serving a worktree](#serving-a-worktree-code-under-test)) and point the editor
+at it. Note: a known remaining gap is that `editor_reload_plugin` can still take
+down an externally-launched server's process on some setups — making an external
+server reliably survive the reload is tracked in
+[#514](https://github.com/hi-godot/godot-ai/issues/514).
 
 ### Knobs (env)
 
@@ -108,8 +131,11 @@ SS_URL=http://127.0.0.1:8010/mcp .venv/bin/python script/stormtest.py
 | `SS_WAVES` | 5 | waves per worker |
 | `SS_CALLS` | 25 | calls per worker per wave |
 | `SS_RELOAD` | 1 | include `editor_reload_plugin` churn (`0` to skip) |
-| `SS_RELOAD_EVERY` | 2 | chaos worker reloads every N waves |
+| `SS_RELOAD_EVERY` | 2 | chaos worker reloads every N waves (concurrent mode) |
+| `SS_RELOAD_MODE` | `concurrent` | `concurrent` churn, or `isolated` single-threaded reload survival loop |
+| `SS_ISOLATED_ITERS` | 10 | reload iterations in `isolated` mode |
 | `SS_RECONNECT_TIMEOUT` | 30 | seconds to wait for the server to return after a reload |
+| `SS_CLOSE_TIMEOUT` | 5 | hard cap (s) on client teardown so a dead-server socket can't wedge the loop |
 | `SS_URL` | `http://127.0.0.1:8000/mcp` | target MCP endpoint |
 | `SS_REPORT` | `$TMPDIR/stormtest_report.json` | where to write the JSON snapshot |
 

--- a/script/serve-this-worktree
+++ b/script/serve-this-worktree
@@ -1,80 +1,16 @@
 #!/usr/bin/env bash
-# Serve the MCP dev server using *this worktree's* src/godot_ai, not the root
-# repo's editable-installed copy.
+# Thin wrapper around the cross-platform launcher `script/serve_worktree.py`.
+# Kept so the documented `script/serve-this-worktree` command keeps working;
+# the real logic (venv resolution, port free, --port/--ws-port, --reload) lives
+# in the Python launcher so POSIX and Windows share one implementation. See
+# #509 / #514.
 #
-# Why: the shared .venv lives in the root repo and pip-installs the root's
-# src/godot_ai editable. When you launch Godot from a worktree, the plugin
-# spawns the root's python -m godot_ai, so Python-side changes in the worktree
-# are invisible. Prepending the worktree's src/ to PYTHONPATH makes
-# `import godot_ai` resolve to the worktree's source instead.
-#
-# Usage: script/serve-this-worktree [extra uvicorn/module args]
-#   e.g. script/serve-this-worktree --port 8001
-#
-# Kills any existing listener on the chosen port first so you don't stack
-# servers on top of the plugin-spawned one.
-
+# Usage: script/serve-this-worktree [--port N] [--ws-port N] [extra args]
 set -euo pipefail
-
-PORT=8000
-# Pull --port out of args if present so we can free it before starting.
-ARGS=()
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --port)
-            if [[ $# -lt 2 ]]; then
-                echo "error: --port requires a value" >&2
-                exit 1
-            fi
-            PORT="$2"
-            ARGS+=("$1" "$2")
-            shift 2
-            ;;
-        --port=*)
-            PORT="${1#*=}"
-            ARGS+=("$1")
-            shift
-            ;;
-        *)
-            ARGS+=("$1")
-            shift
-            ;;
-    esac
-done
-
-WORKTREE_ROOT="$(git rev-parse --show-toplevel)"
-# .venv and the editable install live in the main repo's common dir, not the
-# worktree. `git rev-parse --git-common-dir` returns that path (or the regular
-# .git if we're already on main), so .venv resolves correctly either way.
-COMMON_DIR="$(cd "$WORKTREE_ROOT" && git rev-parse --git-common-dir)"
-# --git-common-dir may return a relative path; absolutize via its parent.
-if [[ "$COMMON_DIR" != /* ]]; then
-    COMMON_DIR="$(cd "$WORKTREE_ROOT/$COMMON_DIR" && pwd)"
-fi
-ROOT_REPO="$(dirname "$COMMON_DIR")"
-
-VENV_PY="$ROOT_REPO/.venv/bin/python"
-if [[ ! -x "$VENV_PY" ]]; then
-    echo "error: $VENV_PY not found — run script/setup-dev in the root repo first" >&2
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PY="$(command -v python3 || command -v python || true)"
+if [[ -z "$PY" ]]; then
+    echo "error: python3 not found on PATH" >&2
     exit 1
 fi
-
-SRC="$WORKTREE_ROOT/src"
-if [[ ! -d "$SRC" ]]; then
-    echo "error: $SRC not found" >&2
-    exit 1
-fi
-
-# Free the port so we replace the plugin-spawned server rather than stack on it.
-if lsof -i ":$PORT" -sTCP:LISTEN -t >/dev/null 2>&1; then
-    echo "Stopping existing listener on port $PORT"
-    lsof -i ":$PORT" -sTCP:LISTEN -t | xargs kill 2>/dev/null || true
-    sleep 1
-fi
-
-echo "Serving worktree: $WORKTREE_ROOT"
-echo "Using venv:       $ROOT_REPO/.venv"
-echo "PYTHONPATH:       $SRC"
-
-export PYTHONPATH="$SRC${PYTHONPATH:+:$PYTHONPATH}"
-exec "$VENV_PY" -m godot_ai --transport streamable-http --port "$PORT" --reload "${ARGS[@]}"
+exec "$PY" "$DIR/serve_worktree.py" "$@"

--- a/script/serve-this-worktree.ps1
+++ b/script/serve-this-worktree.ps1
@@ -1,0 +1,18 @@
+# Thin PowerShell wrapper around the cross-platform launcher
+# `script/serve_worktree.py`, so Windows has a discoverable serve command. The
+# real logic (venv resolution, port free, --port/--ws-port, --reload) lives in
+# the Python launcher so POSIX and Windows share one implementation. See
+# #509 / #514.
+#
+# Usage: .\script\serve-this-worktree.ps1 --port 18130 --ws-port 19630
+$ErrorActionPreference = 'Stop'
+$dir = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+$py = Get-Command python -ErrorAction SilentlyContinue
+if (-not $py) { $py = Get-Command py -ErrorAction SilentlyContinue }
+if (-not $py) {
+    throw 'python not found on PATH (install Python, or run script\setup-dev.ps1)'
+}
+
+& $py.Source (Join-Path $dir 'serve_worktree.py') @args
+exit $LASTEXITCODE

--- a/script/serve_worktree.py
+++ b/script/serve_worktree.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Serve the MCP dev server using *this worktree's* src/godot_ai.
+
+Cross-platform replacement for the bash `serve-this-worktree` (#509/#514): it
+resolves the shared `.venv` interpreter (`.venv/bin/python` on POSIX,
+`.venv\\Scripts\\python.exe` on Windows), prepends this worktree's `src/` to
+PYTHONPATH so `import godot_ai` resolves to the worktree source (not the root
+repo's editable install), frees the HTTP port, and launches the server with
+`--reload` and **both** `--port` and `--ws-port` so it matches an editor using
+non-default port overrides.
+
+Run it with any Python on PATH — it re-launches the resolved venv interpreter:
+
+    python script/serve_worktree.py --port 8000 --ws-port 9500
+    python script/serve_worktree.py --port 18130 --ws-port 19630   # editor overrides
+
+Extra arguments are passed through to `python -m godot_ai`.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import subprocess
+import sys
+
+DEFAULT_PORT = 8000
+DEFAULT_WS_PORT = 9500
+
+
+def _run(cmd: list[str]) -> str:
+    """Best-effort subprocess capture; '' if the tool is missing or errors."""
+    try:
+        return subprocess.run(
+            cmd, capture_output=True, text=True, check=False
+        ).stdout
+    except (FileNotFoundError, OSError):
+        return ""
+
+
+def _git(args: list[str], cwd: str | None = None) -> str:
+    return _run(["git", *args] if cwd is None else ["git", "-C", cwd, *args]).strip()
+
+
+def _resolve_roots() -> tuple[str, str]:
+    """Return (worktree_root, root_repo). The `.venv` and editable install live
+    in the main repo's common dir, not the worktree, so resolve both."""
+    worktree = _git(["rev-parse", "--show-toplevel"])
+    if not worktree:
+        sys.exit("error: not inside a git repository")
+    common = _git(["rev-parse", "--git-common-dir"], cwd=worktree)
+    # --git-common-dir may be relative to the worktree root.
+    if not os.path.isabs(common):
+        common = os.path.abspath(os.path.join(worktree, common))
+    root_repo = os.path.dirname(common)
+    return worktree, root_repo
+
+
+def _venv_python(root_repo: str) -> str:
+    if platform.system() == "Windows":
+        return os.path.join(root_repo, ".venv", "Scripts", "python.exe")
+    return os.path.join(root_repo, ".venv", "bin", "python")
+
+
+def _pids_on_port(port: int) -> set[str]:
+    """LISTENING PIDs on `port`, via the OS's own tooling (no psutil dep)."""
+    if platform.system() == "Windows":
+        pids: set[str] = set()
+        for line in _run(["netstat", "-ano", "-p", "tcp"]).splitlines():
+            parts = line.split()
+            # proto  local-addr  foreign-addr  STATE  pid
+            if len(parts) >= 5 and parts[3].upper() == "LISTENING":
+                if parts[1].rsplit(":", 1)[-1] == str(port):
+                    pids.add(parts[4])
+        return pids
+    out = _run(["lsof", "-i", f":{port}", "-sTCP:LISTEN", "-t"])
+    return {p.strip() for p in out.split() if p.strip()}
+
+
+def _free_port(port: int) -> None:
+    """Best-effort: stop whatever is LISTENING on `port` so we replace the
+    plugin-spawned server rather than stack on top of it."""
+    pids = _pids_on_port(port)
+    if not pids:
+        return
+    print(f"Stopping existing listener(s) on port {port}: {', '.join(sorted(pids))}")
+    for pid in pids:
+        if platform.system() == "Windows":
+            _run(["taskkill", "/F", "/PID", pid])
+        else:
+            try:
+                os.kill(int(pid), 15)
+            except (ProcessLookupError, ValueError, PermissionError):
+                pass
+
+
+def _extract_int_flag(args: list[str], name: str, default: int) -> int:
+    """Read --name <v> / --name=v from a passthrough arg list (no removal)."""
+    for i, a in enumerate(args):
+        if a == name and i + 1 < len(args):
+            try:
+                return int(args[i + 1])
+            except ValueError:
+                return default
+        if a.startswith(name + "="):
+            try:
+                return int(a.split("=", 1)[1])
+            except ValueError:
+                return default
+    return default
+
+
+def _has_flag(args: list[str], name: str) -> bool:
+    return any(a == name or a.startswith(name + "=") for a in args)
+
+
+def main() -> int:
+    passthrough = sys.argv[1:]
+    worktree, root_repo = _resolve_roots()
+
+    venv_py = _venv_python(root_repo)
+    if not os.path.isfile(venv_py):
+        sys.exit(
+            f"error: {venv_py} not found — run script/setup-dev "
+            "(or setup-dev.ps1 on Windows) in the root repo first"
+        )
+
+    src = os.path.join(worktree, "src")
+    if not os.path.isdir(src):
+        sys.exit(f"error: {src} not found")
+
+    port = _extract_int_flag(passthrough, "--port", DEFAULT_PORT)
+    ws_port = _extract_int_flag(passthrough, "--ws-port", DEFAULT_WS_PORT)
+
+    _free_port(port)
+
+    # Default the transport/ports/reload, but let explicit passthrough args win.
+    cmd = [venv_py, "-m", "godot_ai"]
+    if not _has_flag(passthrough, "--transport"):
+        cmd += ["--transport", "streamable-http"]
+    if not _has_flag(passthrough, "--port"):
+        cmd += ["--port", str(port)]
+    if not _has_flag(passthrough, "--ws-port"):
+        cmd += ["--ws-port", str(ws_port)]
+    if not _has_flag(passthrough, "--reload"):
+        cmd += ["--reload"]
+    cmd += passthrough
+
+    env = dict(os.environ)
+    sep = os.pathsep
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = src + (sep + existing if existing else "")
+
+    print(f"Serving worktree: {worktree}")
+    print(f"Using venv:       {os.path.join(root_repo, '.venv')}")
+    print(f"PYTHONPATH:       {src}")
+    print(f"HTTP port:        {port}    WS port: {ws_port}")
+
+    # subprocess (not os.exec*) for consistent Windows behavior; forward the
+    # child's exit code and let Ctrl-C reach the server cleanly.
+    try:
+        return subprocess.run(cmd, env=env, check=False).returncode
+    except KeyboardInterrupt:
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/script/serve_worktree.py
+++ b/script/serve_worktree.py
@@ -23,6 +23,7 @@ import os
 import platform
 import subprocess
 import sys
+import time
 
 DEFAULT_PORT = 8000
 DEFAULT_WS_PORT = 9500
@@ -92,21 +93,38 @@ def _free_port(port: int) -> None:
                 os.kill(int(pid), 15)
             except (ProcessLookupError, ValueError, PermissionError):
                 pass
+    # The socket can stay bound briefly after the owner dies; wait for it to
+    # actually free so the new server doesn't lose a bind race. Bounded so a
+    # stubborn listener doesn't hang the launcher — we proceed and let the
+    # server's own bind error surface if it never releases.
+    deadline = time.monotonic() + 3.0
+    while time.monotonic() < deadline:
+        if not _pids_on_port(port):
+            return
+        time.sleep(0.2)
 
 
 def _extract_int_flag(args: list[str], name: str, default: int) -> int:
-    """Read --name <v> / --name=v from a passthrough arg list (no removal)."""
+    """Read --name <v> / --name=v from a passthrough arg list (no removal).
+
+    Exits on a present-but-malformed flag rather than silently using the
+    default — otherwise a typo'd `--port` would free/echo the default port
+    while the doomed bad value still passes through to the server, leaving the
+    editor with no server.
+    """
     for i, a in enumerate(args):
-        if a == name and i + 1 < len(args):
-            try:
-                return int(args[i + 1])
-            except ValueError:
-                return default
-        if a.startswith(name + "="):
-            try:
-                return int(a.split("=", 1)[1])
-            except ValueError:
-                return default
+        if a == name:
+            if i + 1 >= len(args):
+                sys.exit(f"error: {name} requires an integer value")
+            raw = args[i + 1]
+        elif a.startswith(name + "="):
+            raw = a.split("=", 1)[1]
+        else:
+            continue
+        try:
+            return int(raw)
+        except ValueError:
+            sys.exit(f"error: {name} value {raw!r} is not an integer")
     return default
 
 

--- a/script/stormtest.py
+++ b/script/stormtest.py
@@ -31,11 +31,14 @@ Knobs (all env-overridable):
     SS_CALLS     calls per worker per wave              (default 25)
     SS_RELOAD    1=include reload churn, 0=skip         (default 1)
     SS_RELOAD_EVERY       chaos worker reloads every N waves  (default 2)
+    SS_RELOAD_MODE        concurrent | isolated          (default concurrent)
+    SS_ISOLATED_ITERS     reloads in isolated mode       (default 10)
     SS_RECONNECT_TIMEOUT  seconds to wait for the server to return (default 30)
     SS_URL       target MCP endpoint  (default http://127.0.0.1:8000/mcp)
 
     Default ≈ 1000 calls.  Brutal: SS_WORKERS=12 SS_WAVES=30 (≈ 9000 calls).
     Reads-only smoke: SS_RELOAD=0.
+    Windows-friendly reload survival check: SS_RELOAD_MODE=isolated.
 """
 
 from __future__ import annotations
@@ -65,6 +68,17 @@ RECONNECT_TIMEOUT = float(os.environ.get("SS_RECONNECT_TIMEOUT", "30"))
 # forever and wedges the whole run. On timeout we treat it as a CONNECTION
 # failure and reconnect.
 CALL_TIMEOUT = float(os.environ.get("SS_CALL_TIMEOUT", "20"))
+# Reload mode. "concurrent" (default) = the chaos worker reloads mid-run while
+# N workers keep hammering. "isolated" = a single-threaded reload→reconnect→
+# verify loop with no concurrent load — the Windows-friendly survival check,
+# since concurrent churn against a plugin-managed server can wedge the asyncio
+# loop on Windows (#513). Isolated mode gives a clean survived-N/N number.
+RELOAD_MODE = os.environ.get("SS_RELOAD_MODE", "concurrent").strip().lower()
+ISOLATED_ITERS = int(os.environ.get("SS_ISOLATED_ITERS", "10"))
+# Hard ceiling on client teardown. On Windows a dead server's socket may not
+# get a prompt RST, so a graceful close can hang; cap it so teardown can never
+# wedge the loop (the concrete stall behind #513).
+CLOSE_TIMEOUT = float(os.environ.get("SS_CLOSE_TIMEOUT", "5"))
 
 SCRATCH_DIR = "res://_stormtest"
 SCRATCH_SCENE = f"{SCRATCH_DIR}/storm.tscn"
@@ -176,6 +190,18 @@ def _err_code(exc: Exception) -> str:
     return type(exc).__name__
 
 
+async def _hard_close(client) -> None:
+    """Close a client without ever hanging the loop. A graceful __aexit__ can
+    stall on Windows when the peer server died mid-reload (the socket gets no
+    prompt RST), so bound it with a timeout and swallow everything. See #513."""
+    if client is None:
+        return
+    try:
+        await asyncio.wait_for(client.__aexit__(None, None, None), timeout=CLOSE_TIMEOUT)
+    except (Exception, asyncio.TimeoutError, asyncio.CancelledError):
+        pass
+
+
 class Worker:
     def __init__(self, wi: int):
         self.wi = wi
@@ -195,12 +221,8 @@ class Worker:
 
     async def connect(self) -> bool:
         """(Re)establish this worker's MCP connection. Retries until timeout."""
-        if self.client is not None:
-            try:
-                await self.client.__aexit__(None, None, None)
-            except Exception:
-                pass
-            self.client = None
+        await _hard_close(self.client)
+        self.client = None
         deadline = time.monotonic() + RECONNECT_TIMEOUT
         attempt = 0
         while time.monotonic() < deadline and not STOP[0]:
@@ -212,10 +234,7 @@ class Worker:
                 self.client = c
                 return True
             except Exception:
-                try:
-                    await c.__aexit__(None, None, None)
-                except Exception:
-                    pass
+                await _hard_close(c)
                 await asyncio.sleep(min(2.0, 0.2 * attempt))
         return False
 
@@ -713,11 +732,8 @@ async def worker_loop(w: Worker):
                     M["by_op_err"]["UNCAUGHT"] += 1
         # tiny yield so workers interleave but stay hot
         await asyncio.sleep(0)
-    try:
-        if w.client:
-            await w.client.__aexit__(None, None, None)
-    except Exception:
-        pass
+    await _hard_close(w.client)
+    w.client = None
 
 
 async def do_reload(w: Worker):
@@ -754,6 +770,76 @@ async def do_reload(w: Worker):
         f"  [chaos] <<< reconnected after reload "
         f"(survived {M['reloads_survived']}/{M['reloads_attempted']})"
     )
+
+
+async def _active_session_id(w: Worker) -> str:
+    """Best-effort current session id, for confirming a reload rotated it.
+    Returns '?' on any hiccup — the survived count is the real signal."""
+    try:
+        res = await w.client.call_tool("session_manage", {"op": "list", "params": {}})
+        data = getattr(res, "data", None) or {}
+        sessions = data.get("sessions") or []
+        if sessions:
+            first = sessions[0]
+            return str(first.get("session_id") or first.get("id") or "?")
+    except Exception:
+        return "?"
+    return "?"
+
+
+async def run_isolated_reload() -> None:
+    """Single-threaded reload→reconnect→verify loop (#513). No concurrent load,
+    so it can't hit the Windows concurrent-churn wedge — it yields a clean
+    survived-N/N number and per-reload recovery time. This is the documented
+    Windows path for validating reload survival."""
+    print(
+        f"stormtest [isolated reload]  iters={ISOLATED_ITERS} "
+        f"reconnect_timeout={RECONNECT_TIMEOUT}s  url={URL}"
+    )
+    w = Worker(0)
+    if not await w.connect():
+        print("  could not reach the editor — is it running with the plugin enabled?")
+        STOP[0] = True
+        return
+
+    for i in range(ISOLATED_ITERS):
+        if STOP[0]:
+            break
+        before = await _active_session_id(w)
+        M["reloads_attempted"] += 1
+        print(f"  >>> reload #{i + 1}/{ISOLATED_ITERS}  (session before: {before})")
+        try:
+            async with asyncio.timeout(CALL_TIMEOUT):
+                await w.client.call_tool("editor_reload_plugin", {})
+        except Exception as exc:
+            print(f"      reload call returned/raised: {_err_code(exc)} (expected during handoff)")
+
+        # Drop the (now-severed) client without risking a teardown stall, then
+        # wait for the disable→extract→enable window before reconnecting.
+        await _hard_close(w.client)
+        w.client = None
+        t0 = time.monotonic()
+        await asyncio.sleep(2.0)
+        ok = await w.connect()
+        dt = time.monotonic() - t0
+        if not ok:
+            print(
+                f"      !!! editor did not return within {RECONNECT_TIMEOUT}s — "
+                "reload NOT survived (managed server likely killed by the reload)"
+            )
+            STOP[0] = True
+            break
+        after = await _active_session_id(w)
+        M["reloads_survived"] += 1
+        M["reload_recovery_s"].append(dt)
+        M["reconnects"] += 1
+        print(
+            f"      <<< reconnected in {dt:.1f}s  (session after: {after})  "
+            f"survived {M['reloads_survived']}/{M['reloads_attempted']}"
+        )
+
+    await _hard_close(w.client)
+    w.client = None
 
 
 async def health_monitor():
@@ -877,6 +963,17 @@ async def main():
             loop.add_signal_handler(sig, lambda: STOP.__setitem__(0, True))
         except (NotImplementedError, RuntimeError):
             pass
+
+    # Isolated reload mode: no scratch scene, no concurrent workers — just the
+    # single-threaded reload survival loop. Self-contained so it sidesteps the
+    # concurrent-churn wedge entirely (#513).
+    if RELOAD_MODE == "isolated":
+        START[0] = time.monotonic()
+        try:
+            await run_isolated_reload()
+        finally:
+            report()
+        return
 
     original = await setup()
     START[0] = time.monotonic()

--- a/script/stormtest.py
+++ b/script/stormtest.py
@@ -21,9 +21,10 @@ A full JSON snapshot is flushed to stormtest_report.json every few seconds so
 a crash or kill still leaves analyzable data (latency p50/p95/max + per-op
 error codes).
 
-Run against a running editor whose MCP server is on :8000:
+Run against a running editor whose MCP server is on :8000 (use `python` with
+the venv active, or the venv interpreter directly — same on every OS):
 
-    .venv/bin/python script/stormtest.py
+    python script/stormtest.py
 
 Knobs (all env-overridable):
     SS_WORKERS   parallel client connections           (default 8)


### PR DESCRIPTION
First increment on the stormtest-Windows umbrella (#574), making the stress-testing tooling usable on Windows across #509/#513/#514. Tooling-only — no plugin/server runtime code changes.

## Changes

### Cross-platform worktree launcher (#509, #514)
- **`script/serve_worktree.py`** (new): cross-platform replacement for the bash-only `serve-this-worktree`. Resolves the venv interpreter (`bin/python` vs `Scripts\python.exe`), prepends the worktree's `src/` to `PYTHONPATH`, frees the HTTP port per-OS (`netstat`/`taskkill` on Windows, `lsof` on POSIX — no `psutil` dep), and launches the server with `--reload` and **both** `--port` and `--ws-port` (the original only passed `--port`, so it couldn't match an editor on a non-default WS port — #514). Invoke with any Python on PATH; it re-launches the resolved venv interpreter.
- **`script/serve-this-worktree`** is now a thin wrapper around the launcher (one implementation for both OSes), and **`script/serve-this-worktree.ps1`** (new) gives Windows a discoverable serve command (#514).

### Isolated reload mode (#513)
- **`script/stormtest.py`**: `SS_RELOAD_MODE=isolated` runs a single-threaded `reload → reconnect → verify-session` loop with no concurrent load — the Windows-friendly survival check, yielding a clean `survived N/N` count and per-reload recovery time. Self-contained, so it sidesteps the concurrent-churn wedge entirely.
- Client teardown is now hard-capped by `SS_CLOSE_TIMEOUT` (`asyncio.wait_for`), so a dead-server socket that never gets a prompt RST on Windows can't wedge the loop — the concrete stall behind the concurrent hang.

### Docs (#509)
- `docs/STRESS_TESTING.md`: cross-platform invocation (use `python …` everywhere), a "Serving a worktree" section, isolated-mode guidance, refreshed knobs table; **dropped the stale "reload churn doesn't work on Windows" heads-up**.

## Still open (called out in the docs, not closing those issues yet)
- Root-causing the **concurrent**-churn loop-wide stall on Windows against a plugin-managed server (the teardown cap bounds it but doesn't fully explain it) — #513.
- Making an **externally-launched `--reload` server survive `editor_reload_plugin`** on Windows (a product/harness decision) — #514.

So this PR lets #509 close once verified on Windows; #513/#514 stay open for the deeper items, tracked by the #574 umbrella.

## Verification
`py_compile` + `ruff` clean on the Python; `bash -n` clean on the wrapper. The harness needs a live Windows editor to exercise end-to-end — best validated on Windows (per the plan to test there before merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V7VnMraTCEhTyj2CzyH8tC

---
_Generated by [Claude Code](https://claude.ai/code/session_01V7VnMraTCEhTyj2CzyH8tC)_