### PR TITLE
Coerce struct-valued property writes (Rect2, Transform, Vector4, …) instead of silently no-op-ing

### DIFF
--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -528,6 +528,7 @@ func _set_owner_recursive(node: Node, owner: Node) -> void:
 ## is optional — the coercer defaults it to 1.0 when absent.
 const VECTOR2_KEYS: Array[String] = ["x", "y"]
 const VECTOR3_KEYS: Array[String] = ["x", "y", "z"]
+const VECTOR4_KEYS: Array[String] = ["x", "y", "z", "w"]
 const COLOR_KEYS: Array[String] = ["r", "g", "b"]
 
 
@@ -568,6 +569,19 @@ static func _check_coerced(value: Variant, target_type: int, prefix: String = ""
 			ok = value is PackedFloat64Array
 		TYPE_PACKED_STRING_ARRAY:
 			ok = value is PackedStringArray
+		TYPE_VECTOR2I: ok = value is Vector2i
+		TYPE_VECTOR3I: ok = value is Vector3i
+		TYPE_VECTOR4: ok = value is Vector4
+		TYPE_VECTOR4I: ok = value is Vector4i
+		TYPE_QUATERNION: ok = value is Quaternion
+		TYPE_RECT2: ok = value is Rect2
+		TYPE_RECT2I: ok = value is Rect2i
+		TYPE_AABB: ok = value is AABB
+		TYPE_PLANE: ok = value is Plane
+		TYPE_BASIS: ok = value is Basis
+		TYPE_TRANSFORM2D: ok = value is Transform2D
+		TYPE_TRANSFORM3D: ok = value is Transform3D
+		TYPE_PROJECTION: ok = value is Projection
 		_:
 			# null / untyped-TYPE_NIL / already-correct-type are handled by
 			# Godot's setter; anything else would silently no-op, so error.
@@ -615,6 +629,24 @@ static func _shape_hint(target_type: int) -> String:
 			return "[float, ...]"
 		TYPE_PACKED_STRING_ARRAY:
 			return "[\"...\", ...]"
+		TYPE_VECTOR2I:
+			return "{\"x\":0,\"y\":0}"
+		TYPE_VECTOR3I:
+			return "{\"x\":0,\"y\":0,\"z\":0}"
+		TYPE_VECTOR4, TYPE_VECTOR4I, TYPE_QUATERNION:
+			return "{\"x\":0,\"y\":0,\"z\":0,\"w\":0}"
+		TYPE_RECT2, TYPE_RECT2I, TYPE_AABB:
+			return "{\"position\":{...},\"size\":{...}}"
+		TYPE_PLANE:
+			return "{\"normal\":{...},\"d\":0}"
+		TYPE_BASIS:
+			return "{\"x\":{...},\"y\":{...},\"z\":{...}}"
+		TYPE_TRANSFORM2D:
+			return "{\"x\":{...},\"y\":{...},\"origin\":{...}}"
+		TYPE_TRANSFORM3D:
+			return "{\"basis\":{...},\"origin\":{...}}"
+		TYPE_PROJECTION:
+			return "{\"x\":{...},\"y\":{...},\"z\":{...},\"w\":{...}}"
 	var keys: Array[String] = []
 	match target_type:
 		TYPE_VECTOR2: keys = VECTOR2_KEYS
@@ -767,6 +799,72 @@ static func _coerce_value(value: Variant, target_type: int) -> Variant:
 					else:
 						return value
 				return out
+		TYPE_VECTOR2I:
+			if value is Dictionary and value.has_all(VECTOR2_KEYS):
+				return Vector2i(int(value["x"]), int(value["y"]))
+		TYPE_VECTOR3I:
+			if value is Dictionary and value.has_all(VECTOR3_KEYS):
+				return Vector3i(int(value["x"]), int(value["y"]), int(value["z"]))
+		TYPE_VECTOR4:
+			if value is Dictionary and value.has_all(VECTOR4_KEYS):
+				return Vector4(value["x"], value["y"], value["z"], value["w"])
+		TYPE_VECTOR4I:
+			if value is Dictionary and value.has_all(VECTOR4_KEYS):
+				return Vector4i(int(value["x"]), int(value["y"]), int(value["z"]), int(value["w"]))
+		TYPE_QUATERNION:
+			if value is Dictionary and value.has_all(VECTOR4_KEYS):
+				return Quaternion(value["x"], value["y"], value["z"], value["w"])
+		TYPE_RECT2:
+			if value is Dictionary and value.has("position") and value.has("size"):
+				var p: Variant = _coerce_value(value["position"], TYPE_VECTOR2)
+				var s: Variant = _coerce_value(value["size"], TYPE_VECTOR2)
+				if p is Vector2 and s is Vector2:
+					return Rect2(p, s)
+		TYPE_RECT2I:
+			if value is Dictionary and value.has("position") and value.has("size"):
+				var p: Variant = _coerce_value(value["position"], TYPE_VECTOR2I)
+				var s: Variant = _coerce_value(value["size"], TYPE_VECTOR2I)
+				if p is Vector2i and s is Vector2i:
+					return Rect2i(p, s)
+		TYPE_AABB:
+			if value is Dictionary and value.has("position") and value.has("size"):
+				var p: Variant = _coerce_value(value["position"], TYPE_VECTOR3)
+				var s: Variant = _coerce_value(value["size"], TYPE_VECTOR3)
+				if p is Vector3 and s is Vector3:
+					return AABB(p, s)
+		TYPE_PLANE:
+			if value is Dictionary and value.has("normal") and value.has("d"):
+				var n: Variant = _coerce_value(value["normal"], TYPE_VECTOR3)
+				if n is Vector3:
+					return Plane(n, float(value["d"]))
+		TYPE_BASIS:
+			if value is Dictionary and value.has_all(["x", "y", "z"]):
+				var bx: Variant = _coerce_value(value["x"], TYPE_VECTOR3)
+				var by: Variant = _coerce_value(value["y"], TYPE_VECTOR3)
+				var bz: Variant = _coerce_value(value["z"], TYPE_VECTOR3)
+				if bx is Vector3 and by is Vector3 and bz is Vector3:
+					return Basis(bx, by, bz)
+		TYPE_TRANSFORM2D:
+			if value is Dictionary and value.has_all(["x", "y", "origin"]):
+				var tx: Variant = _coerce_value(value["x"], TYPE_VECTOR2)
+				var ty: Variant = _coerce_value(value["y"], TYPE_VECTOR2)
+				var to_: Variant = _coerce_value(value["origin"], TYPE_VECTOR2)
+				if tx is Vector2 and ty is Vector2 and to_ is Vector2:
+					return Transform2D(tx, ty, to_)
+		TYPE_TRANSFORM3D:
+			if value is Dictionary and value.has("basis") and value.has("origin"):
+				var b: Variant = _coerce_value(value["basis"], TYPE_BASIS)
+				var o: Variant = _coerce_value(value["origin"], TYPE_VECTOR3)
+				if b is Basis and o is Vector3:
+					return Transform3D(b, o)
+		TYPE_PROJECTION:
+			if value is Dictionary and value.has_all(VECTOR4_KEYS):
+				var px: Variant = _coerce_value(value["x"], TYPE_VECTOR4)
+				var py: Variant = _coerce_value(value["y"], TYPE_VECTOR4)
+				var pz: Variant = _coerce_value(value["z"], TYPE_VECTOR4)
+				var pw: Variant = _coerce_value(value["w"], TYPE_VECTOR4)
+				if px is Vector4 and py is Vector4 and pz is Vector4 and pw is Vector4:
+					return Projection(px, py, pz, pw)
 		# PackedByteArray intentionally unhandled — needs design decision
 		# (base64 string vs. raw int list); JSON has no native byte type.
 	return value

--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -557,6 +557,8 @@ static func _check_coerced(value: Variant, target_type: int, prefix: String = ""
 			ok = value is PackedVector2Array
 		TYPE_PACKED_VECTOR3_ARRAY:
 			ok = value is PackedVector3Array
+		TYPE_PACKED_VECTOR4_ARRAY:
+			ok = value is PackedVector4Array
 		TYPE_PACKED_COLOR_ARRAY:
 			ok = value is PackedColorArray
 		TYPE_PACKED_INT32_ARRAY:
@@ -621,6 +623,8 @@ static func _shape_hint(target_type: int) -> String:
 			return "[{\"x\":0,\"y\":0}, ...]"
 		TYPE_PACKED_VECTOR3_ARRAY:
 			return "[{\"x\":0,\"y\":0,\"z\":0}, ...]"
+		TYPE_PACKED_VECTOR4_ARRAY:
+			return "[{\"x\":0,\"y\":0,\"z\":0,\"w\":0}, ...]"
 		TYPE_PACKED_COLOR_ARRAY:
 			return "[{\"r\":0,\"g\":0,\"b\":0,\"a\":1}, ...]"
 		TYPE_PACKED_INT32_ARRAY, TYPE_PACKED_INT64_ARRAY:
@@ -756,6 +760,17 @@ static func _coerce_value(value: Variant, target_type: int) -> Variant:
 						out.append(item)
 					elif item is Dictionary and item.has_all(VECTOR3_KEYS):
 						out.append(Vector3(item["x"], item["y"], item["z"]))
+					else:
+						return value
+				return out
+		TYPE_PACKED_VECTOR4_ARRAY:
+			if value is Array:
+				var out := PackedVector4Array()
+				for item in value:
+					if item is Vector4:
+						out.append(item)
+					elif item is Dictionary and item.has_all(VECTOR4_KEYS):
+						out.append(Vector4(item["x"], item["y"], item["z"], item["w"]))
 					else:
 						return value
 				return out

--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -569,7 +569,17 @@ static func _check_coerced(value: Variant, target_type: int, prefix: String = ""
 		TYPE_PACKED_STRING_ARRAY:
 			ok = value is PackedStringArray
 		_:
-			return null
+			# null / untyped-TYPE_NIL / already-correct-type are handled by
+			# Godot's setter; anything else would silently no-op, so error.
+			if value == null or target_type == TYPE_NIL or typeof(value) == target_type:
+				return null
+			var unsupported := ErrorCodes.make(
+				ErrorCodes.WRONG_TYPE,
+				"Cannot write %s to a %s property; godot-ai has no coercion for that type" % [
+					type_string(typeof(value)), type_string(target_type),
+				],
+			)
+			return ErrorCodes.prefix_message(unsupported, prefix)
 	if ok:
 		return null
 	var dict_err := _check_dict_coerce_failed(value, target_type)

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -1598,3 +1598,26 @@ func test_create_node_scene_file_matching_active_scene_passes() -> void:
 	assert_true(editor_undo(_undo_redo), "undo should succeed")
 
 
+# ----- honest failure for un-coercible writes -----
+
+func test_check_coerced_rejects_unsupported_struct() -> void:
+	# PackedByteArray is intentionally never coerced (base64-vs-int design gap),
+	# so it is a durable stand-in for "a type with no coercion branch".
+	var result: Variant = NodeHandler._check_coerced([1, 2, 3], TYPE_PACKED_BYTE_ARRAY)
+	assert_is_error(result, ErrorCodes.WRONG_TYPE)
+
+
+func test_check_coerced_allows_null_clear() -> void:
+	# Clearing an Object/NodePath property to null must still pass (no regression).
+	assert_eq(NodeHandler._check_coerced(null, TYPE_OBJECT), null)
+
+
+func test_check_coerced_allows_untyped_property() -> void:
+	# Dynamic @export vars report a TYPE_NIL target; must stay permissive.
+	assert_eq(NodeHandler._check_coerced(42, TYPE_NIL), null)
+
+
+func test_check_coerced_allows_matching_scalar() -> void:
+	assert_eq(NodeHandler._check_coerced(50.0, TYPE_FLOAT), null)
+
+

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -629,6 +629,15 @@ func test_coerce_packed_vector3_array_from_dict_list() -> void:
 	assert_eq(coerced[0], Vector3(1, 2, 3))
 
 
+func test_coerce_packed_vector4_array_from_dict_list() -> void:
+	var coerced = NodeHandler._coerce_value(
+		[{"x": 1, "y": 2, "z": 3, "w": 4}],
+		TYPE_PACKED_VECTOR4_ARRAY,
+	)
+	assert_true(coerced is PackedVector4Array)
+	assert_eq(coerced[0], Vector4(1, 2, 3, 4))
+
+
 func test_coerce_packed_color_array_from_string() -> void:
 	var coerced = NodeHandler._coerce_value(["#ff0000", "#00ff00"], TYPE_PACKED_COLOR_ARRAY)
 	assert_true(coerced is PackedColorArray)
@@ -685,10 +694,22 @@ func test_check_coerced_array_packed_vector2_returns_wrong_type() -> void:
 	assert_contains(coerce_err.error.message, "Array")
 
 
+func test_check_coerced_array_packed_vector4_returns_wrong_type() -> void:
+	## A bad Array passed through _coerce_value must get the shape-hint
+	## WRONG_TYPE, same as the other packed types — not the generic
+	## "no coercion for that type" default.
+	var coerce_err: Variant = NodeHandler._check_coerced([1, 2, 3], TYPE_PACKED_VECTOR4_ARRAY)
+	assert_true(coerce_err is Dictionary)
+	assert_eq(coerce_err.error.code, ErrorCodes.WRONG_TYPE)
+	assert_contains(coerce_err.error.message, "PackedVector4Array")
+	assert_contains(coerce_err.error.message, "expected")
+
+
 func test_check_coerced_passes_correct_packed_arrays() -> void:
 	## Right-typed packed arrays must pass through (return null).
 	assert_eq(NodeHandler._check_coerced(PackedVector2Array(), TYPE_PACKED_VECTOR2_ARRAY), null)
 	assert_eq(NodeHandler._check_coerced(PackedVector3Array(), TYPE_PACKED_VECTOR3_ARRAY), null)
+	assert_eq(NodeHandler._check_coerced(PackedVector4Array(), TYPE_PACKED_VECTOR4_ARRAY), null)
 	assert_eq(NodeHandler._check_coerced(PackedColorArray(), TYPE_PACKED_COLOR_ARRAY), null)
 	assert_eq(NodeHandler._check_coerced(PackedInt32Array(), TYPE_PACKED_INT32_ARRAY), null)
 	assert_eq(NodeHandler._check_coerced(PackedFloat32Array(), TYPE_PACKED_FLOAT32_ARRAY), null)
@@ -700,6 +721,7 @@ func test_shape_hint_packed_arrays() -> void:
 	## each new packed type returns a list-shaped hint, not a dict.
 	assert_eq(NodeHandler._shape_hint(TYPE_PACKED_VECTOR2_ARRAY), "[{\"x\":0,\"y\":0}, ...]")
 	assert_eq(NodeHandler._shape_hint(TYPE_PACKED_VECTOR3_ARRAY), "[{\"x\":0,\"y\":0,\"z\":0}, ...]")
+	assert_eq(NodeHandler._shape_hint(TYPE_PACKED_VECTOR4_ARRAY), "[{\"x\":0,\"y\":0,\"z\":0,\"w\":0}, ...]")
 	assert_eq(NodeHandler._shape_hint(TYPE_PACKED_COLOR_ARRAY), "[{\"r\":0,\"g\":0,\"b\":0,\"a\":1}, ...]")
 	assert_eq(NodeHandler._shape_hint(TYPE_PACKED_INT32_ARRAY), "[int, ...]")
 	assert_eq(NodeHandler._shape_hint(TYPE_PACKED_INT64_ARRAY), "[int, ...]")

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -1621,3 +1621,86 @@ func test_check_coerced_allows_matching_scalar() -> void:
 	assert_eq(NodeHandler._check_coerced(50.0, TYPE_FLOAT), null)
 
 
+# ----- struct coercion (pure, no scene node) -----
+
+func test_coerce_vector2i() -> void:
+	# assert the TYPE strictly: a raw dict compares == to a struct under GDScript's
+	# permissive cross-type !=, so assert_eq alone would false-pass an un-coerced dict.
+	var result: Variant = NodeHandler._coerce_value({"x": 3, "y": 4}, TYPE_VECTOR2I)
+	assert_true(result is Vector2i, "should coerce to Vector2i")
+	assert_eq(result, Vector2i(3, 4))
+
+
+func test_coerce_vector4() -> void:
+	var result: Variant = NodeHandler._coerce_value({"x": 1, "y": 2, "z": 3, "w": 4}, TYPE_VECTOR4)
+	assert_true(result is Vector4, "should coerce to Vector4")
+	assert_eq(result, Vector4(1, 2, 3, 4))
+
+
+func test_coerce_rect2() -> void:
+	var shape := {"position": {"x": 0, "y": 0}, "size": {"x": 6, "y": 6}}
+	var result: Variant = NodeHandler._coerce_value(shape, TYPE_RECT2)
+	assert_true(result is Rect2, "should coerce to Rect2")
+	assert_eq(result, Rect2(0, 0, 6, 6))
+
+
+func test_coerce_transform2d() -> void:
+	var shape := {"x": {"x": 1, "y": 0}, "y": {"x": 0, "y": 1}, "origin": {"x": 5, "y": 7}}
+	var result: Variant = NodeHandler._coerce_value(shape, TYPE_TRANSFORM2D)
+	assert_true(result is Transform2D, "should coerce to Transform2D")
+	assert_eq(result, Transform2D(Vector2(1, 0), Vector2(0, 1), Vector2(5, 7)))
+
+
+func test_coerce_transform3d_nested() -> void:
+	# Compound-of-compound: Transform3D -> Basis -> Vector3, all via recursion.
+	var basis_shape := {
+		"x": {"x": 1, "y": 0, "z": 0},
+		"y": {"x": 0, "y": 1, "z": 0},
+		"z": {"x": 0, "y": 0, "z": 1},
+	}
+	var shape := {"basis": basis_shape, "origin": {"x": 2, "y": 3, "z": 4}}
+	var result: Variant = NodeHandler._coerce_value(shape, TYPE_TRANSFORM3D)
+	assert_true(result is Transform3D, "should coerce to Transform3D")
+	assert_eq((result as Transform3D).origin, Vector3(2, 3, 4))
+
+
+func test_coerce_rect2_wrong_shape_flows_through() -> void:
+	# Missing "size" -> not coerced -> stays a Dictionary so _check_coerced flags it.
+	var bad := {"position": {"x": 0, "y": 0}}
+	var coerced: Variant = NodeHandler._coerce_value(bad, TYPE_RECT2)
+	assert_true(coerced is Dictionary, "wrong-shape dict must flow through unchanged")
+	assert_is_error(NodeHandler._check_coerced(coerced, TYPE_RECT2), ErrorCodes.WRONG_TYPE)
+
+
+# ----- end-to-end set_property lands on the node -----
+
+func test_set_property_rect2_lands() -> void:
+	_handler.create_node({"type": "Sprite2D", "name": "_McpTestRect2", "parent_path": "/Main"})
+	var node := EditorInterface.get_edited_scene_root().get_node("_McpTestRect2") as Sprite2D
+	var result := _handler.set_property({
+		"path": "/Main/_McpTestRect2",
+		"property": "region_rect",
+		"value": {"position": {"x": 0, "y": 0}, "size": {"x": 6, "y": 6}},
+	})
+	assert_has_key(result, "data")
+	assert_true(result.data.undoable)
+	assert_eq(node.region_rect, Rect2(0, 0, 6, 6), "Rect2 must land on the node, not just echo")
+	assert_true(editor_undo(_undo_redo), "undo set should succeed")
+	assert_true(editor_undo(_undo_redo), "undo create should succeed")
+
+
+func test_set_property_transform2d_lands() -> void:
+	_handler.create_node({"type": "Node2D", "name": "_McpTestXform2D", "parent_path": "/Main"})
+	var node := EditorInterface.get_edited_scene_root().get_node("_McpTestXform2D") as Node2D
+	var expected := Transform2D(Vector2(1, 0), Vector2(0, 1), Vector2(5, 7))
+	var result := _handler.set_property({
+		"path": "/Main/_McpTestXform2D",
+		"property": "transform",
+		"value": {"x": {"x": 1, "y": 0}, "y": {"x": 0, "y": 1}, "origin": {"x": 5, "y": 7}},
+	})
+	assert_has_key(result, "data")
+	assert_eq(node.transform, expected, "Transform2D must land on the node")
+	assert_true(editor_undo(_undo_redo), "undo set should succeed")
+	assert_true(editor_undo(_undo_redo), "undo create should succeed")
+
+

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -1686,6 +1686,69 @@ func test_coerce_transform3d_nested() -> void:
 	assert_eq((result as Transform3D).origin, Vector3(2, 3, 4))
 
 
+func test_coerce_vector3i() -> void:
+	var result: Variant = NodeHandler._coerce_value({"x": 5, "y": 6, "z": 7}, TYPE_VECTOR3I)
+	assert_true(result is Vector3i, "should coerce to Vector3i")
+	assert_eq(result, Vector3i(5, 6, 7))
+
+
+func test_coerce_vector4i() -> void:
+	var result: Variant = NodeHandler._coerce_value({"x": 1, "y": 2, "z": 3, "w": 4}, TYPE_VECTOR4I)
+	assert_true(result is Vector4i, "should coerce to Vector4i")
+	assert_eq(result, Vector4i(1, 2, 3, 4))
+
+
+func test_coerce_quaternion() -> void:
+	var result: Variant = NodeHandler._coerce_value({"x": 0, "y": 0, "z": 0, "w": 1}, TYPE_QUATERNION)
+	assert_true(result is Quaternion, "should coerce to Quaternion")
+	assert_eq(result, Quaternion(0, 0, 0, 1))
+
+
+func test_coerce_rect2i() -> void:
+	var shape := {"position": {"x": 0, "y": 0}, "size": {"x": 6, "y": 6}}
+	var result: Variant = NodeHandler._coerce_value(shape, TYPE_RECT2I)
+	assert_true(result is Rect2i, "should coerce to Rect2i")
+	assert_eq(result, Rect2i(0, 0, 6, 6))
+
+
+func test_coerce_aabb() -> void:
+	var shape := {"position": {"x": 0, "y": 0, "z": 0}, "size": {"x": 1, "y": 2, "z": 3}}
+	var result: Variant = NodeHandler._coerce_value(shape, TYPE_AABB)
+	assert_true(result is AABB, "should coerce to AABB")
+	assert_eq(result, AABB(Vector3(0, 0, 0), Vector3(1, 2, 3)))
+
+
+func test_coerce_plane() -> void:
+	var shape := {"normal": {"x": 0, "y": 1, "z": 0}, "d": 5}
+	var result: Variant = NodeHandler._coerce_value(shape, TYPE_PLANE)
+	assert_true(result is Plane, "should coerce to Plane")
+	assert_eq(result, Plane(Vector3(0, 1, 0), 5))
+
+
+func test_coerce_basis() -> void:
+	var shape := {
+		"x": {"x": 1, "y": 0, "z": 0},
+		"y": {"x": 0, "y": 1, "z": 0},
+		"z": {"x": 0, "y": 0, "z": 1},
+	}
+	var result: Variant = NodeHandler._coerce_value(shape, TYPE_BASIS)
+	assert_true(result is Basis, "should coerce to Basis")
+	assert_eq(result, Basis(Vector3(1, 0, 0), Vector3(0, 1, 0), Vector3(0, 0, 1)))
+
+
+func test_coerce_projection_nested() -> void:
+	# Compound-of-compound: Projection -> Vector4 columns, all via recursion.
+	var shape := {
+		"x": {"x": 1, "y": 0, "z": 0, "w": 0},
+		"y": {"x": 0, "y": 1, "z": 0, "w": 0},
+		"z": {"x": 0, "y": 0, "z": 1, "w": 0},
+		"w": {"x": 0, "y": 0, "z": 0, "w": 1},
+	}
+	var result: Variant = NodeHandler._coerce_value(shape, TYPE_PROJECTION)
+	assert_true(result is Projection, "should coerce to Projection")
+	assert_eq((result as Projection).w, Vector4(0, 0, 0, 1))
+
+
 func test_coerce_rect2_wrong_shape_flows_through() -> void:
 	# Missing "size" -> not coerced -> stays a Dictionary so _check_coerced flags it.
 	var bad := {"position": {"x": 0, "y": 0}}


### PR DESCRIPTION
Fixes #579.

`node_set_property` silently no-op'd struct-valued types: `_coerce_value` had no branch for them, so an un-coerced dict was assigned to a hard-typed property — the engine rejected it, the old value stuck, and the response echoed the old value back with no error.

Three commits:

- **fix(node): return honest WRONG_TYPE for un-coercible property writes** — `_check_coerced`'s default now rejects un-coercible values (still passing `null`, untyped, and already-correct ones), so unsupported types fail honestly instead of no-op'ing.
- **feat(node): coerce struct-valued property writes** — adds the 13 inverse-serializer cases to `_coerce_value` (`Vector2i`, `Vector3i`, `Vector4`, `Vector4i`, `Quaternion`, `Rect2`, `Rect2i`, `AABB`, `Plane`, `Basis`, `Transform2D`, `Transform3D`, `Projection`) plus the matching `is`-checks and shape hints. Coercion recurses, so nested shapes come for free.
- **feat(node): coerce PackedVector4Array property writes** — it was serialized on read but had no coercion branch (same gap); now mirrored alongside the other `Packed*Array` types. `PackedByteArray` stays the only serialized type intentionally left un-coerced (base64-vs-int design choice).

The read serializer already defined the JSON shape for all of these, so each write is just its inverse — no new wire format.

Tests: per-type coercion, honest-error-with-shape-hint on bad input, and round-trips. Full GDScript suite green (1452 passed / 0 failed / 7 skipped, 55 suites); ruff + pytest unaffected (no Python touched).

Sibling fixes filed separately — #580 (custom `class_name` Resources) and #581 (signal persistence); independent, different files, PRs to follow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded automatic type coercion to support more Godot math/geometry types (including packed Vector4 arrays), converting structured inputs into the correct runtime types.
  * Improved validation and coercion error feedback so unsupported target types report clearer “wrong type” results.

* **Tests**
  * Added/extended unit and end-to-end tests covering packed Vector4 array coercion, structured dict-to-geometry conversions, failure cases, and real property assignment with undo verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->