### PR TITLE
ui: let clients dock row shrink

### DIFF
--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -558,30 +558,37 @@ func _build_ui() -> void:
 	add_child(HSeparator.new())
 
 	# --- Clients ---
-	var clients_row := HBoxContainer.new()
-	clients_row.add_theme_constant_override("separation", 8)
+	var clients_header_row := HBoxContainer.new()
+	clients_header_row.add_theme_constant_override("separation", 8)
 
 	var clients_header := _make_header("Clients")
-	clients_row.add_child(clients_header)
+	clients_header_row.add_child(clients_header)
 
 	_clients_summary_label = Label.new()
 	_clients_summary_label.add_theme_color_override("font_color", COLOR_MUTED)
+	_clients_summary_label.clip_text = true
+	_clients_summary_label.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
 	_clients_summary_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	clients_row.add_child(_clients_summary_label)
+	clients_header_row.add_child(_clients_summary_label)
+
+	var clients_actions := HFlowContainer.new()
+	clients_actions.add_theme_constant_override("h_separation", 8)
+	clients_actions.add_theme_constant_override("v_separation", 4)
 
 	var clients_refresh_btn := Button.new()
 	clients_refresh_btn.text = "Refresh"
 	clients_refresh_btn.tooltip_text = "Refresh client status in the background. Cached status stays visible while checks run."
 	clients_refresh_btn.pressed.connect(_on_refresh_clients_pressed)
-	clients_row.add_child(clients_refresh_btn)
+	clients_actions.add_child(clients_refresh_btn)
 
 	var clients_open_btn := Button.new()
-	clients_open_btn.text = "Clients & Settings"
+	clients_open_btn.text = "Settings"
 	clients_open_btn.tooltip_text = "Open the MCP settings window — configure AI clients, choose telemetry preferences, or disable tool domains to fit under a client's hard tool-count cap (e.g. Antigravity's 100)."
 	clients_open_btn.pressed.connect(_on_open_clients_window)
-	clients_row.add_child(clients_open_btn)
+	clients_actions.add_child(clients_open_btn)
 
-	add_child(clients_row)
+	add_child(clients_header_row)
+	add_child(clients_actions)
 
 	# Drift banner — hidden until a sweep finds at least one mismatched client.
 	_drift_banner = VBoxContainer.new()

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -65,7 +65,7 @@ var _clients_window: Window
 var _dev_mode_toggle: CheckButton
 var _install_label: Label
 
-# Settings tab (secondary window, Tab 2) — domain-exclusion UI for clients
+# Tools tab (secondary window, Tab 2) — domain-exclusion UI for clients
 # that cap total tool count (Antigravity: 100). Pending set is mutated by
 # checkbox clicks; saved set reflects what the spawned server actually
 # sees. `Apply & Restart Server` writes pending → setting and triggers a
@@ -582,8 +582,8 @@ func _build_ui() -> void:
 	clients_actions.add_child(clients_refresh_btn)
 
 	var clients_open_btn := Button.new()
-	clients_open_btn.text = "Settings"
-	clients_open_btn.tooltip_text = "Open the MCP settings window — configure AI clients, choose telemetry preferences, or disable tool domains to fit under a client's hard tool-count cap (e.g. Antigravity's 100)."
+	clients_open_btn.text = "Clients & Tools"
+	clients_open_btn.tooltip_text = "Open the Clients & Tools window — configure AI clients, choose telemetry preferences, or disable tool domains to fit under a client's hard tool-count cap (e.g. Antigravity's 100)."
 	clients_open_btn.pressed.connect(_on_open_clients_window)
 	clients_actions.add_child(clients_open_btn)
 
@@ -607,7 +607,7 @@ func _build_ui() -> void:
 	add_child(_drift_banner)
 
 	_clients_window = Window.new()
-	_clients_window.title = "MCP Clients & Settings"
+	_clients_window.title = "Godot AI"
 	## `Vector2i * float` yields Vector2; wrap the result back to Vector2i.
 	_clients_window.min_size = Vector2i(Vector2(560, 460) * EditorInterface.get_editor_scale())
 	_clients_window.visible = false
@@ -1707,7 +1707,7 @@ func _build_tools_tab(tabs: TabContainer) -> void:
 	var tools_tab := VBoxContainer.new()
 	tools_tab.add_theme_constant_override("separation", 8)
 	var tools_margin := _build_margin_container()
-	tools_margin.name = "Settings"
+	tools_margin.name = "Tools"
 	tools_margin.add_child(tools_tab)
 	tabs.add_child(tools_margin)
 

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -97,6 +97,46 @@ func test_install_label_mouse_filter_allows_tooltip() -> void:
 	assert_eq(_dock._install_label.mouse_filter, Control.MOUSE_FILTER_STOP)
 
 
+func test_clients_header_and_actions_use_narrow_layout() -> void:
+	## The dock's minimum width is the max of the direct VBox children. Keep
+	## the Clients section split so the header/count and action buttons do not
+	## add their minimum widths into one wide HBox row.
+	_dock._build_ui()
+	var clients_header_row := _dock._clients_summary_label.get_parent() as HBoxContainer
+	assert_true(clients_header_row != null, "Clients header row should exist")
+	var has_clients_header := false
+	for row_child in clients_header_row.get_children():
+		if row_child is Label:
+			var label := row_child as Label
+			if label.text == "Clients":
+				has_clients_header = true
+				break
+	assert_true(has_clients_header, "Summary count should stay with the Clients header")
+	assert_true(_dock._clients_summary_label.clip_text,
+		"Summary count should ellipsize instead of expanding the dock")
+	assert_eq(
+		_dock._clients_summary_label.text_overrun_behavior,
+		TextServer.OVERRUN_TRIM_ELLIPSIS,
+		"Summary count should use ellipsis overrun")
+
+	var header_idx := _dock.get_children().find(clients_header_row)
+	assert_gt(header_idx, -1, "Clients header row should be a direct dock child")
+	assert_true(header_idx + 1 < _dock.get_child_count(),
+		"Clients actions row should follow the header row")
+	var clients_actions := _dock.get_child(header_idx + 1)
+	assert_true(clients_actions is HFlowContainer,
+		"Client actions should wrap in an HFlowContainer")
+	var actions_flow := clients_actions as HFlowContainer
+	var button_texts: Array[String] = []
+	for action_child in actions_flow.get_children():
+		var button := action_child as Button
+		if button != null:
+			button_texts.append(button.text)
+	var expected: Array[String] = ["Refresh", "Settings"]
+	assert_eq(button_texts, expected,
+		"Client action buttons should stay compact and keep their handlers")
+
+
 func test_drift_banner_hidden_when_no_mismatched_clients() -> void:
 	## The amber banner should stay hidden until a sweep finds at least one
 	## mismatched client — otherwise it'd flash up on every `_build_ui` call

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -132,9 +132,15 @@ func test_clients_header_and_actions_use_narrow_layout() -> void:
 		var button := action_child as Button
 		if button != null:
 			button_texts.append(button.text)
-	var expected: Array[String] = ["Refresh", "Settings"]
+	var expected: Array[String] = ["Refresh", "Clients & Tools"]
 	assert_eq(button_texts, expected,
 		"Client action buttons should stay compact and keep their handlers")
+	assert_eq(_dock._clients_window.title, "Godot AI",
+		"Clients & Tools window should use the product context as its title")
+	var tabs := _dock._clients_window.get_child(0) as TabContainer
+	assert_true(tabs != null, "Clients & Tools window should contain a tab container")
+	assert_eq(tabs.get_tab_title(0), "Clients")
+	assert_eq(tabs.get_tab_title(1), "Tools")
 
 
 func test_drift_banner_hidden_when_no_mismatched_clients() -> void:


### PR DESCRIPTION
## Summary

Makes the Godot AI dock able to shrink narrower by splitting the Clients header/actions row into two rows.

The old Clients row put the header, summary, Refresh button, and Clients & Settings button in one `HBoxContainer`, so the dock minimum width was pinned by the sum of all four controls. Since `McpDock` is a `VBoxContainer`, that one wide child row set the minimum width for the whole dock.

## Changes

- Split the Clients section into:
  - a header/status row with `Clients` + the configured-count summary
  - an action row with `Refresh` + `Settings`
- Put the action row in an `HFlowContainer` so buttons can wrap at narrow widths.
- Made the summary label shrinkable with `clip_text` and ellipsis overrun.
- Shortened `Clients & Settings` to `Settings`; the tooltip still explains the full settings window behavior.
- Added a GDScript regression test that pins the narrow-layout structure.


## Old minimum width
<img width="482" height="247" alt="Screenshot 2026-06-20 225810" src="https://github.com/user-attachments/assets/31bed51b-edcb-437c-aa72-81b28623bab2" />

## New minimum width
<img width="240" height="316" alt="Screenshot 2026-06-21 153122" src="https://github.com/user-attachments/assets/80d0ae71-c5db-44b3-9384-037aeea2d05a" />

## Verification

- Manual visual check passed:
  - dock can shrink closer to the Inspector width
  - summary ellipsizes cleanly
  - action buttons wrap cleanly
  - Refresh and Settings still behave correctly
- Godot 4.7 headless import completed.
- `script/ci-check-gdscript` via Git Bash:
  - `All GDScript files OK`
- `git diff --check`


Follow-up pushed to make the Clients entry point and secondary window naming congruent.

Wording now maps the button to the two tabs:
- Dock button: `Clients & Tools`
- Window title: `Godot AI`
- Tabs: `Clients` / `Tools`

I gave the window a product/context title instead of repeating the button/tab phrase, so the UI does not read “Clients & Tools” three times. Happy to switch the title to the more literal `MCP Clients & Tools` if you prefer the existing mirrored-title convention.

The dock regression test now pins the button text, window title, and both tab labels. No layout behavior changed from the two-row `HFlowContainer` split.