### PR TITLE
Harden self-update

### DIFF
--- a/plugin/addons/godot_ai/utils/update_manager.gd
+++ b/plugin/addons/godot_ai/utils/update_manager.gd
@@ -314,6 +314,8 @@ static func _is_trusted_download_url(url: String) -> bool:
 	const SCHEME := "https://"
 	if not url.begins_with(SCHEME):
 		return false
+	if url.find("\\") >= 0:
+		return false
 	var rest := url.substr(SCHEME.length())
 	var authority := rest
 	var slash := rest.find("/")
@@ -457,7 +459,7 @@ func _on_checksum_completed(
 
 	print("MCP | self-update checksum verified (sha256 %s)" % actual)
 	install_state_changed.emit({"button_text": "Installing..."})
-	_install_zip()
+	_install_zip.call_deferred()
 
 
 ## Surface an integrity-check failure and drop the staged zip so the bad
@@ -483,8 +485,9 @@ static func _parse_sha256_digest(text: String) -> String:
 	if trimmed.is_empty():
 		return ""
 	## First whitespace-delimited token; `sha256sum` separates digest and
-	## filename with two spaces, so allow_empty=false collapses the run.
-	var tokens := trimmed.split(" ", false)
+	## filename with two spaces, but some tools use tabs.
+	var normalized := trimmed.replace("\t", " ").replace("\n", " ").replace("\r", " ")
+	var tokens := normalized.split(" ", false)
 	if tokens.is_empty():
 		return ""
 	var digest := String(tokens[0]).strip_edges().to_lower()

--- a/test_project/tests/test_update_manager.gd
+++ b/test_project/tests/test_update_manager.gd
@@ -126,6 +126,12 @@ func test_trusted_download_url_rejects_untrusted_and_insecure() -> void:
 		McpUpdateManagerScript._is_trusted_download_url("https://github.com@evil.com/x.zip"),
 		"userinfo spoofing (host is after the last @) must be rejected")
 	assert_false(
+		McpUpdateManagerScript._is_trusted_download_url("https://github.com\\@evil.com/x.zip"),
+		"a backslash before userinfo syntax must be rejected")
+	assert_false(
+		McpUpdateManagerScript._is_trusted_download_url("https://github.com\\evil.com/x.zip"),
+		"a backslash in the apparent authority must be rejected")
+	assert_false(
 		McpUpdateManagerScript._is_trusted_download_url(""),
 		"an empty URL must be rejected")
 
@@ -146,6 +152,14 @@ func test_parse_sha256_digest_accepts_bare_and_uppercase_digest() -> void:
 		"a bare digest line must be accepted")
 	assert_eq(McpUpdateManagerScript._parse_sha256_digest(hex.to_upper()), hex,
 		"an uppercase digest must be normalized to lowercase")
+
+
+func test_parse_sha256_digest_accepts_tab_and_newline_separators() -> void:
+	var hex := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	assert_eq(McpUpdateManagerScript._parse_sha256_digest(hex + "\tgodot-ai-plugin.zip"), hex,
+		"a tab-separated checksum sidecar must be accepted")
+	assert_eq(McpUpdateManagerScript._parse_sha256_digest(hex + "\ngodot-ai-plugin.zip"), hex,
+		"a newline-separated checksum sidecar must be accepted")
 
 
 func test_parse_sha256_digest_rejects_malformed() -> void:


### PR DESCRIPTION
Reject backslash-containing release asset URLs before authority parsing so spoofed text cannot be interpreted as a trusted GitHub host.

Accept tab/newline-separated sha256 sidecars by normalizing whitespace before reading the digest token, matching common checksum tool output.

Defer the verified install step until after the HTTPRequest checksum callback returns, avoiding update extraction/reload work on the request completion stack.

- `script/ci-check-gdscript`: All GDScript files OK
- `.venv/bin/python -m pytest -v`: 1172 passed, 4 skipped, 2 warnings in 78.21s
- `.venv/bin/ruff check src/ tests/`: All checks passed!
- `.venv/bin/ruff format --check src/ tests/`: 161 files already formatted
- `git diff --check`: passed
- Full Godot-side MCP test_run: 1439 passed, 0 failed, 19 skipped, total 1458
- `script/local-self-update-smoke --force`: completed successfully, exit code 0

The smoke harness did print Godot shutdown warnings about leaked ObjectDB/resources, but the harness verification itself passed and exited 0.

Did I miss anything?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened trusted URL validation by rejecting malformed download and checksum URLs containing backslashes
  * Improved checksum verification flow by deferring installation until after a successful SHA-256 match
  * Enhanced checksum sidecar parsing by normalizing whitespace for more reliable digest extraction
* **Tests**
  * Added coverage for additional malicious URL patterns and expanded checksum digest parsing scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->