### PR TITLE
Fix client configure stuck

### DIFF
--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -509,8 +509,8 @@ static func invalidate_uvx_cli_cache() -> void:
 ## Thread safety: `CliFinder.invalidate()` guards `_cache` / `_searched`
 ## with a mutex so it can race safely against worker threads calling
 ## `find()` from `_run_client_action_worker`. The mutex is held only
-## across the dictionary clear, never across `OS.execute`, so this call
-## can never block the main thread on a subprocess.
+## across the dictionary clear, never across the bounded subprocess lookup,
+## so this call can never block the main thread on a subprocess.
 static func invalidate_cli_cache() -> void:
 	CliFinder.invalidate()
 

--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -39,6 +39,7 @@ const MIN_PORT := 1024
 const MAX_PORT := 65535
 const SETTING_WS_PORT := "godot_ai/ws_port"
 const SETTING_STARTUP_TRACE := "godot_ai/log_startup_timing"
+const _DISCOVERY_TIMEOUT_MS := 3000
 
 
 ## Active HTTP port: user override (if in range) or `DEFAULT_HTTP_PORT`.
@@ -521,10 +522,9 @@ static var _uv_version_searched: bool = false
 
 ## Cached for the editor session. The dock's `_refresh_setup_status`
 ## (called via `call_deferred` from `_build_ui`) calls this on the
-## main thread in user mode, so a single cold `OS.execute(uvx,
-## ["--version"])` adds ~80 ms to the dock's first paint on Linux and
-## more on Windows. Subsequent calls (focus-in refresh, manual Refresh
-## clicks) reuse the cached string.
+## main thread in user mode, so the cold `uvx --version` probe is
+## wall-clock bounded and cached. Subsequent calls (focus-in refresh,
+## manual Refresh clicks) reuse the cached string.
 ##
 ## Invalidate via `invalidate_uv_version_cache()` when the user
 ## installs / reinstalls uv via the dock so the next refresh reflects
@@ -539,9 +539,10 @@ static func check_uv_version() -> String:
 		_uv_version_searched = true
 		_uv_version_cache = ""
 		return ""
-	var output: Array = []
-	if OS.execute(uvx, ["--version"], output, true) == 0 and output.size() > 0:
-		_uv_version_cache = output[0].strip_edges()
+	var result := McpCliExec.run(uvx, ["--version"], _DISCOVERY_TIMEOUT_MS, false)
+	if int(result.get("exit_code", -1)) == 0:
+		var lines := PackedStringArray(str(result.get("stdout", "")).split("\n"))
+		_uv_version_cache = lines[0].strip_edges() if lines.size() > 0 else ""
 	else:
 		_uv_version_cache = ""
 	_uv_version_searched = true
@@ -612,9 +613,12 @@ static func find_worktree_src_dir(start_dir: String) -> String:
 
 static func _find_system_install() -> String:
 	var cmd := "which" if OS.get_name() != "Windows" else "where"
-	var output: Array = []
-	if OS.execute(cmd, ["godot-ai"], output, true) == 0 and output.size() > 0:
-		var found: String = output[0].strip_edges()
+	var result := McpCliExec.run(cmd, ["godot-ai"], _DISCOVERY_TIMEOUT_MS, false)
+	if int(result.get("exit_code", -1)) == 0:
+		var lines := PackedStringArray(str(result.get("stdout", "")).split("\n"))
+		if lines.is_empty():
+			return ""
+		var found := CliFinder._pick_best_path(lines) if OS.get_name() == "Windows" else lines[0].strip_edges()
 		if not found.is_empty():
 			return found
 	return ""

--- a/plugin/addons/godot_ai/clients/_cli_exec.gd
+++ b/plugin/addons/godot_ai/clients/_cli_exec.gd
@@ -34,6 +34,7 @@ extends RefCounted
 
 const DEFAULT_TIMEOUT_MS := 8000
 const _POLL_INTERVAL_MS := 50
+const _KILL_GRACE_MS := 500
 
 
 static func run(
@@ -45,6 +46,9 @@ static func run(
 	if exe.is_empty():
 		return _spawn_failed_result()
 	if _uses_blocking_legacy_path():
+		## Godot 4.3 keeps the old blocking path because execute_with_pipe
+		## capture/exit semantics differ there. The bounded timeout/kill
+		## behavior is available on Godot 4.4+ only.
 		return _run_blocking_legacy(exe, args)
 
 	return _run_piped(exe, args, timeout_ms, capture_stderr)
@@ -91,9 +95,15 @@ static func _run_piped(
 			## Kill before draining: a pipe read can block while the child is
 			## still alive. Once it exits, drain any buffered partial output.
 			OS.kill(pid)
-			OS.delay_msec(_POLL_INTERVAL_MS)
-			var partial_stdout := _drain_pipe(stdio)
-			var partial_stderr := _drain_pipe(stderr_pipe) if capture_stderr else ""
+			var kill_deadline := Time.get_ticks_msec() + _KILL_GRACE_MS
+			while OS.is_process_running(pid) and Time.get_ticks_msec() < kill_deadline:
+				OS.delay_msec(_POLL_INTERVAL_MS)
+
+			var partial_stdout := ""
+			var partial_stderr := ""
+			if not OS.is_process_running(pid):
+				partial_stdout = _drain_pipe(stdio)
+				partial_stderr = _drain_pipe(stderr_pipe) if capture_stderr else ""
 			_close_pipes(stdio, stderr_pipe)
 			return {
 				"exit_code": -1,

--- a/plugin/addons/godot_ai/clients/_cli_exec.gd
+++ b/plugin/addons/godot_ai/clients/_cli_exec.gd
@@ -44,6 +44,18 @@ static func run(
 ) -> Dictionary:
 	if exe.is_empty():
 		return _spawn_failed_result()
+	if _uses_blocking_legacy_path():
+		return _run_blocking_legacy(exe, args)
+
+	return _run_piped(exe, args, timeout_ms, capture_stderr)
+
+
+static func _run_piped(
+	exe: String,
+	args: Array,
+	timeout_ms: int,
+	capture_stderr: bool,
+) -> Dictionary:
 
 	var spawn_exe := exe
 	var spawn_args := args
@@ -107,6 +119,27 @@ static func run(
 	}
 
 
+static func _run_blocking_legacy(exe: String, args: Array) -> Dictionary:
+	## Godot 4.3's OS.execute_with_pipe has capture/exit-code differences
+	## locked by the 4.3 canary skips in test_cli_exec.gd. Preserve the old
+	## blocking discovery behavior there so startup-critical probes keep the
+	## same semantics that worked before the bounded-pipe path landed.
+	var output: Array = []
+	var exit_code := OS.execute(exe, args, output, true)
+	var lines := PackedStringArray()
+	for line in output:
+		lines.append(str(line))
+	var stdout := "\n".join(lines)
+	return {
+		"exit_code": exit_code,
+		"stdout": stdout,
+		"stderr": "",
+		"output": stdout,
+		"timed_out": false,
+		"spawn_failed": exit_code == -1,
+	}
+
+
 static func _spawn_failed_result() -> Dictionary:
 	return {
 		"exit_code": -1,
@@ -151,3 +184,10 @@ static func _close_pipes(stdio: Variant, stderr_pipe: Variant) -> void:
 		(stdio as FileAccess).close()
 	if stderr_pipe is FileAccess:
 		(stderr_pipe as FileAccess).close()
+
+
+static func _uses_blocking_legacy_path() -> bool:
+	var version := Engine.get_version_info()
+	var major := int(version.get("major", 4))
+	var minor := int(version.get("minor", 0))
+	return major < 4 or (major == 4 and minor < 4)

--- a/plugin/addons/godot_ai/clients/_cli_exec.gd
+++ b/plugin/addons/godot_ai/clients/_cli_exec.gd
@@ -76,12 +76,12 @@ static func run(
 	var deadline := Time.get_ticks_msec() + maxi(timeout_ms, _POLL_INTERVAL_MS)
 	while OS.is_process_running(pid):
 		if Time.get_ticks_msec() >= deadline:
-			## Read whatever made it to the pipes before we kill the
-			## process — partial output beats blank "timed out" when the
-			## CLI was emitting useful diagnostics on its way to hanging.
+			## Kill before draining: a pipe read can block while the child is
+			## still alive. Once it exits, drain any buffered partial output.
+			OS.kill(pid)
+			OS.delay_msec(_POLL_INTERVAL_MS)
 			var partial_stdout := _drain_pipe(stdio)
 			var partial_stderr := _drain_pipe(stderr_pipe) if capture_stderr else ""
-			OS.kill(pid)
 			_close_pipes(stdio, stderr_pipe)
 			return {
 				"exit_code": -1,
@@ -119,9 +119,19 @@ static func _spawn_failed_result() -> Dictionary:
 
 
 static func _drain_pipe(pipe: Variant) -> String:
-	if pipe is FileAccess:
-		return (pipe as FileAccess).get_as_text()
-	return ""
+	if not (pipe is FileAccess):
+		return ""
+	var f := pipe as FileAccess
+	var bytes := PackedByteArray()
+	var max_bytes := 1 << 20  # 1 MiB, far above expected client CLI output.
+	while bytes.size() < max_bytes:
+		var chunk := f.get_buffer(mini(4096, max_bytes - bytes.size()))
+		if chunk.is_empty():
+			break
+		bytes.append_array(chunk)
+		if f.eof_reached():
+			break
+	return bytes.get_string_from_utf8()
 
 
 static func _join_streams(stdout: String, stderr_text: String) -> String:

--- a/plugin/addons/godot_ai/clients/_cli_finder.gd
+++ b/plugin/addons/godot_ai/clients/_cli_finder.gd
@@ -14,7 +14,7 @@ extends RefCounted
 ## the main thread (manual Refresh path). Godot `Dictionary` is not safe for
 ## concurrent mutation, so `_cache` / `_searched` access is guarded by
 ## `_mutex`. The mutex is held only across dictionary read/write — the slow
-## `_resolve()` path (FileAccess + `OS.execute`) runs unlocked, so a
+## `_resolve()` path (FileAccess + bounded subprocess lookup) runs unlocked, so a
 ## main-thread `invalidate()` can never block on a worker's subprocess.
 ## Two workers racing the same exe both call `_resolve()` and both write
 ## back the same answer; that's wasted work, not corruption.
@@ -23,6 +23,8 @@ extends RefCounted
 static var _mutex: Mutex = Mutex.new()
 static var _cache: Dictionary = {}  # exe_name -> resolved path (or "")
 static var _searched: Dictionary = {}
+
+const _LOOKUP_TIMEOUT_MS := 3000
 
 
 ## Find any of the supplied exe names; returns the first hit.
@@ -54,8 +56,8 @@ static func _find_one(exe_name: String) -> String:
 	_mutex.unlock()
 	if already_searched:
 		return cached
-	# `_resolve()` does FileAccess + `OS.execute` (forks `bash -lc` /
-	# `which`), which can take 100ms-1s. Holding the mutex across that
+	# `_resolve()` does FileAccess + bounded subprocess lookup (forks
+	# `bash -lc` / `which`), which can take 100ms-1s. Holding the mutex across that
 	# would let a concurrent `invalidate()` on the main thread freeze the
 	# editor for the duration of the subprocess — which defeats the whole
 	# point of running CLI lookup off the main thread.
@@ -81,20 +83,19 @@ static func _resolve(exe_name: String) -> String:
 		var shell := OS.get_environment("SHELL")
 		if shell.is_empty():
 			shell = "/bin/bash"
-		var login_output: Array = []
 		var stripped := exe_name.trim_suffix(".exe")
-		var login_exit := OS.execute(shell, ["-lc", "command -v %s" % stripped], login_output, true)
-		if login_exit == 0 and login_output.size() > 0:
-			var login_found: String = login_output[0].strip_edges()
+		var login_result := McpCliExec.run(shell, ["-lc", "command -v %s" % stripped], _LOOKUP_TIMEOUT_MS, false)
+		if int(login_result.get("exit_code", -1)) == 0:
+			var login_found: String = str(login_result.get("stdout", "")).strip_edges()
 			if not login_found.is_empty() and FileAccess.file_exists(login_found):
 				return login_found
 
 	# 3. which / where with inherited PATH
 	var lookup := "where" if is_windows else "which"
-	var output: Array = []
-	var exit_code := OS.execute(lookup, [exe_name], output, true)
-	if exit_code == 0 and output.size() > 0:
-		var lines := PackedStringArray(output[0].split("\n"))
+	var result := McpCliExec.run(lookup, [exe_name], _LOOKUP_TIMEOUT_MS, false)
+	if int(result.get("exit_code", -1)) == 0:
+		var output := str(result.get("stdout", ""))
+		var lines := PackedStringArray(output.split("\n"))
 		var found := _pick_best_path(lines) if is_windows else lines[0].strip_edges()
 		if not found.is_empty():
 			return found

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -1645,7 +1645,7 @@ func _on_configure_all_clients() -> void:
 			_apply_row_status(String(client_id), Client.Status.ERROR, _server_blocked_client_message())
 		_refresh_clients_summary()
 		return
-	if ClientRefreshStateScript.has_worker_alive(_refresh_state):
+	if ClientRefreshStateScript.should_disable_client_actions(_refresh_state):
 		return
 	for client_id in _client_rows:
 		var status: Client.Status = _client_rows[client_id].get("status", Client.Status.NOT_CONFIGURED)
@@ -1976,7 +1976,7 @@ func _refresh_clients_summary() -> void:
 		)
 	_clients_summary_label.text = text
 	if _client_configure_all_btn != null:
-		_client_configure_all_btn.disabled = ClientRefreshStateScript.has_worker_alive(_refresh_state)
+		_client_configure_all_btn.disabled = ClientRefreshStateScript.should_disable_client_actions(_refresh_state)
 	_refresh_drift_banner(mismatched_ids)
 
 

--- a/plugin/addons/godot_ai/utils/mcp_client_refresh_state.gd
+++ b/plugin/addons/godot_ai/utils/mcp_client_refresh_state.gd
@@ -57,6 +57,14 @@ static func has_worker_alive(state: int) -> bool:
 	return state == RUNNING or state == RUNNING_TIMED_OUT
 
 
+## True while the status worker is still within its healthy budget. Once a
+## refresh has timed out, the dock keeps the warning badge but must let users
+## retry Configure / Configure all instead of stranding the controls behind an
+## orphaned, uninterruptible worker.
+static func should_disable_client_actions(state: int) -> bool:
+	return state == RUNNING
+
+
 ## True when the dock should reject new refresh spawns. Used by the
 ## focus-in / manual button / cooldown-timer entrypoints.
 static func is_blocked_for_spawn(state: int) -> bool:

--- a/test_project/tests/test_cli_exec.gd
+++ b/test_project/tests/test_cli_exec.gd
@@ -94,6 +94,8 @@ func test_run_can_skip_stderr_capture_for_status_probe() -> void:
 
 
 func test_run_kills_subprocess_when_budget_expires() -> void:
+	if skip_on_godot_lt("4.4", "bounded timeout/kill only exists on the 4.4+ execute_with_pipe path; 4.3 uses the blocking legacy path with no kill"):
+		return
 	## The headline behavior: a hung CLI no longer hangs the editor.
 	## Spawn `sleep 5` with a 200ms budget — McpCliExec should kill it
 	## and return timed_out=true. The whole assertion path must complete

--- a/test_project/tests/test_client_refresh_state.gd
+++ b/test_project/tests/test_client_refresh_state.gd
@@ -36,6 +36,17 @@ func test_has_worker_alive_only_for_running_states() -> void:
 	assert_false(McpClientRefreshState.has_worker_alive(McpClientRefreshState.SHUTTING_DOWN))
 
 
+func test_timed_out_refresh_does_not_disable_client_actions() -> void:
+	assert_true(McpClientRefreshState.should_disable_client_actions(McpClientRefreshState.RUNNING))
+	assert_false(McpClientRefreshState.should_disable_client_actions(
+		McpClientRefreshState.RUNNING_TIMED_OUT),
+		"Timed-out workers are orphanable, but the dock must let users retry client actions")
+	assert_false(McpClientRefreshState.should_disable_client_actions(McpClientRefreshState.IDLE))
+	assert_false(McpClientRefreshState.should_disable_client_actions(
+		McpClientRefreshState.DEFERRED_FOR_FILESYSTEM))
+	assert_false(McpClientRefreshState.should_disable_client_actions(McpClientRefreshState.SHUTTING_DOWN))
+
+
 func test_is_blocked_for_spawn_only_during_shutdown() -> void:
 	## SHUTTING_DOWN is sticky; no spawn paths should fire while it's set.
 	assert_true(McpClientRefreshState.is_blocked_for_spawn(McpClientRefreshState.SHUTTING_DOWN))

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -669,6 +669,20 @@ func test_finalize_action_buttons_reenables_after_in_flight() -> void:
 		"Remove button must re-enable too")
 
 
+func test_timed_out_client_refresh_reenables_configure_all() -> void:
+	## A status refresh can outlive the watchdog when an underlying process
+	## blocks in a way GDScript cannot interrupt. The dock should keep the
+	## warning badge, but it must not strand Configure all behind the orphaned
+	## worker forever.
+	_dock._build_ui()
+	_dock._refresh_state = McpClientRefreshState.RUNNING_TIMED_OUT
+	_dock._refresh_clients_summary()
+	assert_contains(_dock._clients_summary_label.text, "client probe still running",
+		"Timed-out refreshes should still be visible in the summary")
+	assert_false(_dock._client_configure_all_btn.disabled,
+		"Timed-out refreshes must not keep client actions disabled")
+
+
 func test_dispatch_client_action_short_circuits_during_self_update() -> void:
 	## Same gate the refresh worker honors: while
 	## `McpUpdateManager._install_zip` is overwriting plugin scripts on

--- a/tests/unit/test_dock_cli_timeout.py
+++ b/tests/unit/test_dock_cli_timeout.py
@@ -57,6 +57,10 @@ def test_cli_exec_helper_uses_pipe_spawn_and_poll_kill() -> None:
     assert "OS.execute_with_pipe(" in helper_source
     assert "OS.is_process_running(" in helper_source
     assert "OS.kill(" in helper_source
+    assert "get_as_text()" not in helper_source, (
+        "Do not drain OS.execute_with_pipe FileAccess handles with get_as_text(); "
+        "on Windows it can emit native PeekNamedPipe errors into Godot's Output panel."
+    )
     # Sanity-check the return shape so callers can rely on the four keys.
     for key in ("exit_code", "stdout", "timed_out", "spawn_failed"):
         assert f'"{key}"' in helper_source, (


### PR DESCRIPTION
## Summary

Fixes a dock failure mode where client status/configuration work could leave the Clients UI stuck in an in-progress state.

This PR hardens the client-probing path in three layers:

- Bounds CLI discovery subprocesses through `McpCliExec.run` instead of raw blocking `OS.execute(..., true)`.
- Lets timed-out client status refreshes keep showing a warning badge without keeping Configure actions disabled forever.
- Avoids noisy Windows `PeekNamedPipe` errors when draining `OS.execute_with_pipe` output.

## Details

`McpCliFinder` now routes `where` / `which` / Unix login-shell lookups through the bounded CLI helper. This prevents a stuck lookup from permanently trapping the refresh worker.

The dock state machine now distinguishes between:

- a worker that is still within its normal running budget, and
- a timed-out/orphanable worker that should no longer block user actions.

So the summary can still show “client probe still running,” while Configure / Configure all are available again.

I also updated `_cli_exec.gd` to drain process pipes with bounded `get_buffer()` chunks instead of `get_as_text()`. On Windows, `get_as_text()` on these pipe handles can emit native `PeekNamedPipe` errors into Godot’s Output panel.

## Tests

- `script/ci-check-gdscript`
- Live `test_run`: 1439 passed, 21 skipped
- Focused suites:
  - `client_refresh_state`
  - `cli_finder`
  - `clients`
  - `dock`
  - `cli_exec`
- `uv run pytest -q tests/unit/test_dock_cli_timeout.py`
- `uv run ruff check tests/unit/test_dock_cli_timeout.py`