### PR TITLE
fix: recover stuck client configure actions

### DIFF
--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -42,6 +42,7 @@ const PortPickerPanelScript := preload("res://addons/godot_ai/dock_panels/port_p
 const DEV_MODE_SETTING := "godot_ai/dev_mode"
 const CLIENT_STATUS_REFRESH_COOLDOWN_MSEC := 15 * 1000
 const CLIENT_STATUS_REFRESH_TIMEOUT_MSEC := 30 * 1000
+const CLIENT_ACTION_TIMEOUT_MSEC := 30 * 1000
 static var COLOR_MUTED := Color(0.7, 0.7, 0.7)
 static var COLOR_HEADER := Color(0.95, 0.95, 0.95)
 ## Used for "in-progress" / "stale, action needed" UI: the startup-grace
@@ -164,6 +165,11 @@ static var _orphaned_client_status_refresh_threads: Array[Thread] = []
 ## does for the refresh worker.
 var _client_action_threads: Dictionary = {}
 var _client_action_generations: Dictionary = {}
+var _client_action_started_msec: Dictionary = {}
+var _client_action_names: Dictionary = {}
+## Timed-out Configure/Remove workers are abandoned but retained here until
+## they finish, so GDScript does not destroy a live Thread object.
+static var _orphaned_client_action_threads: Array[Thread] = []
 
 # Dev-mode only
 var _dev_section: VBoxContainer
@@ -238,10 +244,12 @@ func _ready() -> void:
 
 
 func _process(_delta: float) -> void:
+	_prune_orphaned_client_status_refresh_threads()
+	_prune_orphaned_client_action_threads()
+	_check_client_status_refresh_timeout()
+	_check_client_action_timeouts()
 	if _connection == null:
 		return
-	_prune_orphaned_client_status_refresh_threads()
-	_check_client_status_refresh_timeout()
 	_retry_deferred_client_status_refresh()
 	_update_status()
 	if _log_viewer != null and _log_viewer.visible:
@@ -309,8 +317,9 @@ func _drain_client_action_workers() -> void:
 	## plugin disable / install-update path reloads our script class, so any
 	## live Thread must finish before its slot is GC'd or we hit
 	## `~Thread … destroyed without its completion having been realized` →
-	## VM corruption. Bounded by `McpCliExec` wall-clock budgets, so the
-	## worst case is a ~10s blocking drain, vs. an unbounded SIGSEGV.
+	## VM corruption. Normal UI recovery is handled by the per-row watchdog;
+	## teardown still blocks because GDScript's Thread API has no kill/timeout
+	## primitive and destroying a live Thread corrupts the VM.
 	##
 	## Generation-bumped per-row so any pending `call_deferred(
 	## "_apply_client_action_result")` from a worker that finished after we
@@ -328,6 +337,8 @@ func _drain_client_action_workers() -> void:
 		if t != null:
 			t.wait_to_finish()
 		_client_action_generations[client_id] = int(_client_action_generations.get(client_id, 0)) + 1
+		_client_action_started_msec.erase(client_id)
+		_client_action_names.erase(client_id)
 		_finalize_action_buttons(String(client_id))
 		var row: Dictionary = _client_rows.get(String(client_id), {})
 		if not row.is_empty():
@@ -337,6 +348,71 @@ func _drain_client_action_workers() -> void:
 				""
 			)
 	_client_action_threads.clear()
+	for thread in _orphaned_client_action_threads:
+		if thread != null:
+			thread.wait_to_finish()
+	_orphaned_client_action_threads.clear()
+	_client_action_started_msec.clear()
+	_client_action_names.clear()
+
+
+func _check_client_action_timeouts() -> void:
+	var now := Time.get_ticks_msec()
+	for client_id in _client_action_threads.keys():
+		if not _client_action_started_msec.has(client_id):
+			continue
+		var started := int(_client_action_started_msec.get(client_id, 0))
+		if now - started >= CLIENT_ACTION_TIMEOUT_MSEC:
+			_abandon_client_action_thread(String(client_id))
+
+
+func _abandon_client_action_thread(client_id: String) -> void:
+	if not _client_action_threads.has(client_id):
+		return
+	var thread: Thread = _client_action_threads[client_id]
+	var elapsed := Time.get_ticks_msec() - int(_client_action_started_msec.get(client_id, Time.get_ticks_msec()))
+	var worker_alive := thread != null and thread.is_alive()
+	if thread != null:
+		_orphaned_client_action_threads.append(thread)
+	_client_action_threads.erase(client_id)
+	_client_action_started_msec.erase(client_id)
+	var action := str(_client_action_names.get(client_id, "configure"))
+	_client_action_names.erase(client_id)
+	_client_action_generations[client_id] = int(_client_action_generations.get(client_id, 0)) + 1
+	_finalize_action_buttons(client_id)
+	print("MCP | client action timed out: client=%s action=%s elapsed_ms=%d worker_alive=%s" % [
+		client_id,
+		action,
+		elapsed,
+		str(worker_alive),
+	])
+	var label := "Remove" if action == "remove" else "Configure"
+	_apply_row_status(
+		client_id,
+		Client.Status.ERROR,
+		"%s did not report completion in time; refreshing current status." % label
+	)
+	_refresh_clients_summary()
+	if is_inside_tree():
+		_request_client_status_refresh(true)
+
+
+func _prune_orphaned_client_action_threads() -> void:
+	var completed_orphan := false
+	for i in range(_orphaned_client_action_threads.size() - 1, -1, -1):
+		var thread := _orphaned_client_action_threads[i]
+		if thread == null:
+			_orphaned_client_action_threads.remove_at(i)
+		elif not thread.is_alive():
+			thread.wait_to_finish()
+			_orphaned_client_action_threads.remove_at(i)
+			completed_orphan = true
+	if completed_orphan and is_inside_tree():
+		_request_client_action_completion_refresh()
+
+
+func _request_client_action_completion_refresh() -> void:
+	_request_client_status_refresh(true)
 
 
 func _notification(what: int) -> void:
@@ -1555,11 +1631,15 @@ func _dispatch_client_action(client_id: String, action: String) -> void:
 	_client_action_generations[client_id] = generation
 	var thread := Thread.new()
 	_client_action_threads[client_id] = thread
+	_client_action_started_msec[client_id] = Time.get_ticks_msec()
+	_client_action_names[client_id] = action
 	var err := thread.start(
 		Callable(self, "_run_client_action_worker").bind(client_id, action, server_url, generation)
 	)
 	if err != OK:
 		_client_action_threads.erase(client_id)
+		_client_action_started_msec.erase(client_id)
+		_client_action_names.erase(client_id)
 		_finalize_action_buttons(client_id)
 		_apply_row_status(client_id, Client.Status.ERROR, "couldn't start worker thread")
 		_refresh_clients_summary()
@@ -1585,6 +1665,8 @@ func _apply_client_action_result(client_id: String, action: String, result: Dict
 		if t != null:
 			t.wait_to_finish()
 		_client_action_threads.erase(client_id)
+		_client_action_started_msec.erase(client_id)
+		_client_action_names.erase(client_id)
 	_finalize_action_buttons(client_id)
 	if _server_blocks_client_health():
 		_apply_row_status(client_id, Client.Status.ERROR, _server_blocked_client_message())

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -58,6 +58,17 @@ class _RestartDispatchPlugin extends GodotAiPlugin:
 		dev_running = false
 
 
+class _RefreshCountingDock extends McpDockScript:
+	var action_completion_refreshes := 0
+
+	func _request_client_action_completion_refresh() -> void:
+		action_completion_refreshes += 1
+
+
+static func _finished_thread_noop() -> void:
+	pass
+
+
 var _dock: Node
 
 
@@ -727,6 +738,128 @@ func test_timed_out_client_refresh_reenables_configure_all() -> void:
 		"Timed-out refreshes should still be visible in the summary")
 	assert_false(_dock._client_configure_all_btn.disabled,
 		"Timed-out refreshes must not keep client actions disabled")
+
+
+func test_timed_out_client_action_reenables_row_and_ignores_late_result() -> void:
+	## Configure/Remove actions have a separate worker slot from status
+	## refresh. If that worker wedges in a file/process primitive, the row
+	## must recover instead of leaving "Configuring..." up forever.
+	_dock._build_ui()
+	var any_id := _first_client_id()
+	if any_id.is_empty():
+		skip("No clients registered")
+		return
+	_dock._set_row_action_in_flight(any_id, "configure")
+	_dock._client_action_threads[any_id] = null
+	_dock._client_action_generations[any_id] = 4
+	_dock._client_action_started_msec[any_id] = Time.get_ticks_msec() - McpDockScript.CLIENT_ACTION_TIMEOUT_MSEC - 1
+	_dock._client_action_names[any_id] = "configure"
+
+	_dock._check_client_action_timeouts()
+
+	var row: Dictionary = _dock._client_rows[any_id]
+	assert_false(_dock._client_action_threads.has(any_id),
+		"Timed-out action slot must be cleared so the row can retry")
+	assert_false((row["configure_btn"] as Button).disabled,
+		"Configure button must re-enable after the action watchdog fires")
+	assert_false((row["remove_btn"] as Button).disabled,
+		"Remove button must re-enable too")
+	assert_eq(row.get("status"), McpClient.Status.ERROR,
+		"Timed-out action must leave an error status instead of stale busy UI")
+	assert_contains((row["name_label"] as Label).text, "Configure did not report completion",
+		"Timed-out action error should explain why the row recovered")
+	assert_eq(int(_dock._client_action_generations.get(any_id, 0)), 5,
+		"Watchdog must bump generation so a late worker result is ignored")
+
+	_dock._apply_client_action_result(any_id, "configure", {"status": "ok"}, 4)
+	assert_eq(row.get("status"), McpClient.Status.ERROR,
+		"Late success from the abandoned generation must not overwrite the timeout")
+
+
+func test_completed_client_action_clears_timeout_metadata() -> void:
+	## Mirror for the watchdog path: a normal fast completion must clear the
+	## per-row timeout bookkeeping, so a later tick cannot turn a successful
+	## Configure into a false timeout.
+	_dock._build_ui()
+	var any_id := _first_client_id()
+	if any_id.is_empty():
+		skip("No clients registered")
+		return
+	_dock._set_row_action_in_flight(any_id, "configure")
+	_dock._client_action_threads[any_id] = null
+	_dock._client_action_generations[any_id] = 9
+	_dock._client_action_started_msec[any_id] = Time.get_ticks_msec() - McpDockScript.CLIENT_ACTION_TIMEOUT_MSEC - 1
+	_dock._client_action_names[any_id] = "configure"
+
+	_dock._apply_client_action_result(any_id, "configure", {"status": "ok"}, 9)
+	_dock._check_client_action_timeouts()
+
+	var row: Dictionary = _dock._client_rows[any_id]
+	assert_false(_dock._client_action_threads.has(any_id),
+		"Successful completion must clear the action thread slot")
+	assert_false(_dock._client_action_started_msec.has(any_id),
+		"Successful completion must clear timeout start metadata")
+	assert_false(_dock._client_action_names.has(any_id),
+		"Successful completion must clear timeout action metadata")
+	assert_eq(row.get("status"), McpClient.Status.CONFIGURED,
+		"A completed Configure must remain configured after a later watchdog tick")
+	assert_false((row["configure_btn"] as Button).disabled,
+		"Successful completion must re-enable the configure button")
+
+
+func test_client_action_timeout_ticks_without_connection() -> void:
+	## A server reload or transport drop can temporarily clear the dock's
+	## connection object. The row watchdog must still tick in that state;
+	## otherwise a dropped configure result leaves "Configuring..." forever.
+	_dock._build_ui()
+	var any_id := _first_client_id()
+	if any_id.is_empty():
+		skip("No clients registered")
+		return
+	_dock._connection = null
+	_dock._set_row_action_in_flight(any_id, "configure")
+	_dock._client_action_threads[any_id] = null
+	_dock._client_action_generations[any_id] = 14
+	_dock._client_action_started_msec[any_id] = Time.get_ticks_msec() - McpDockScript.CLIENT_ACTION_TIMEOUT_MSEC - 1
+	_dock._client_action_names[any_id] = "configure"
+
+	_dock._process(0.0)
+
+	var row: Dictionary = _dock._client_rows[any_id]
+	assert_false(_dock._client_action_threads.has(any_id),
+		"Action watchdog must clear the stuck slot even without a connection")
+	assert_false((row["configure_btn"] as Button).disabled,
+		"Configure button must recover even while the MCP connection is absent")
+	assert_contains((row["name_label"] as Label).text, "Configure did not report completion",
+		"Recovered row should explain that the action result went missing")
+
+
+func test_completed_orphaned_client_action_requests_status_refresh() -> void:
+	## If a genuinely slow action is still alive at timeout, the immediate
+	## refresh can run before the side effect lands. When that abandoned
+	## worker later finishes, pruning it should request one more status sweep
+	## so the row can reconcile to the final on-disk state.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	assert_true(scene_root != null, "Dock orphan-prune test needs an edited scene root")
+	if scene_root == null:
+		return
+	var thread := Thread.new()
+	var err := thread.start(Callable(self, "_finished_thread_noop"))
+	assert_eq(err, OK, "Finished orphan fixture thread should start")
+	while thread.is_alive():
+		OS.delay_msec(1)
+	var dock := _RefreshCountingDock.new()
+	dock._orphaned_client_action_threads.append(thread)
+	scene_root.add_child(dock)
+
+	dock._prune_orphaned_client_action_threads()
+
+	assert_true(dock._orphaned_client_action_threads.is_empty(),
+		"Prune must reap the completed orphan action thread")
+	assert_eq(dock.action_completion_refreshes, 1,
+		"Completed orphan action should request a status refresh")
+	scene_root.remove_child(dock)
+	dock.free()
 
 
 func test_dispatch_client_action_short_circuits_during_self_update() -> void:


### PR DESCRIPTION
## Summary

Fixes a dock UI bug where clicking Configure/Remove for an MCP client could leave that row stuck on `Configuring...` / `Removing...` indefinitely.

This was reproduced with Codex: the TOML config write succeeded, but the dock never finalized the row, so the client stayed visually in-flight and the summary could remain stuck at `(checking...)`.

## Changes

- Add a per-client Configure/Remove action watchdog.
- On timeout, clear the row’s in-flight slot, re-enable Configure/Remove, and bump the action generation so late stale results are ignored.
- Retain abandoned `Thread` objects until they finish, matching the existing thread-lifetime safety pattern.
- Trigger an async status refresh after timeout so a config that actually landed can reconcile to green.
- Log timeout details (`client_id`, action, elapsed time, `worker_alive`) to distinguish a true worker hang from a dropped completion callback.
- Let watchdogs tick even when the dock connection object is temporarily unavailable, so connection/server churn cannot freeze the row forever.

## Tests

- `script/ci-check-gdscript`
- `test_run suite="dock" test_name="client_action"` → 7 passed
- `test_run suite="dock"` → 52 passed, 3 skipped

Manual verification:
- Opened the patched worktree in Godot 4.7.
- Removed/reconfigured Codex.
- Clicking Configure next to Codex now completes and turns the row green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added watchdog timeout handling for client Configure/Remove actions to prevent rows from getting stuck.
  * Automatically abandons timed-out actions, re-enables the Configure/Remove buttons, and sets an error state (without allowing later late results to overwrite it).
  * Keeps UI responsive and updates row text even when connection is unavailable, and refreshes client status when completed orphan actions are detected.
* **Tests**
  * Added new timeout/late-result and orphan-action refresh coverage for the dock behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->