### PR TITLE
test: add deterministic MCP verification workflows

### DIFF
--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -1774,6 +1774,35 @@ func test_set_property_rect2_lands() -> void:
 	assert_true(editor_undo(_undo_redo), "undo create should succeed")
 
 
+func test_set_property_rect2_can_be_verified_by_readback() -> void:
+	_handler.create_node({"type": "Sprite2D", "name": "_McpTestRect2Readback", "parent_path": "/Main"})
+	var node := EditorInterface.get_edited_scene_root().get_node("_McpTestRect2Readback") as Sprite2D
+	var result := _handler.set_property({
+		"path": "/Main/_McpTestRect2Readback",
+		"property": "region_rect",
+		"value": {"position": {"x": 2, "y": 3}, "size": {"x": 8, "y": 13}},
+	})
+	assert_has_key(result, "data")
+	assert_eq(node.region_rect, Rect2(2, 3, 8, 13), "Rect2 must land before read-back")
+
+	var readback := _handler.get_node_properties({"path": "/Main/_McpTestRect2Readback"})
+	assert_has_key(readback, "data")
+	var found := false
+	for prop in readback.data.properties:
+		if prop.name == "region_rect":
+			found = true
+			assert_eq(prop.type, "Rect2")
+			assert_true(prop.value is Dictionary, "region_rect read-back must be structured")
+			assert_eq(prop.value.position.x, 2.0)
+			assert_eq(prop.value.position.y, 3.0)
+			assert_eq(prop.value.size.x, 8.0)
+			assert_eq(prop.value.size.y, 13.0)
+			break
+	assert_true(found, "region_rect property must be present in read-back")
+	assert_true(editor_undo(_undo_redo), "undo set should succeed")
+	assert_true(editor_undo(_undo_redo), "undo create should succeed")
+
+
 func test_set_property_transform2d_lands() -> void:
 	_handler.create_node({"type": "Node2D", "name": "_McpTestXform2D", "parent_path": "/Main"})
 	var node := EditorInterface.get_edited_scene_root().get_node("_McpTestXform2D") as Node2D

--- a/tests/integration/test_mcp_workflows.py
+++ b/tests/integration/test_mcp_workflows.py
@@ -1,0 +1,140 @@
+"""Deterministic MCP contract checks that mirror agent verification loops.
+
+These tests do not involve an LLM or a live editor; the integration fixture
+uses a mock Godot plugin. They pin the server-side request/response contract
+we want agents to lean on: capture visual feedback, mutate through a tool,
+then issue a read-back request.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+ONE_PX_PNG_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4"
+    "nGP4DwABAQEBYY2JxQAAAABJRU5ErkJggg=="
+)
+
+
+def _content_type(block: object) -> str:
+    return str(getattr(block, "type", "") or getattr(block, "kind", ""))
+
+
+class TestMcpVerificationWorkflows:
+    async def test_editor_screenshot_returns_consumable_image_content(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "take_screenshot"
+            assert cmd["params"].get("include_image", True) is True
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "source": "viewport",
+                    "width": 1,
+                    "height": 1,
+                    "original_width": 1,
+                    "original_height": 1,
+                    "format": "png",
+                    "image_base64": ONE_PX_PNG_B64,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool("editor_screenshot", {"include_image": True})
+        await task
+
+        assert not result.is_error
+        assert any(_content_type(block) == "image" for block in result.content), (
+            "include_image=true must expose a real image content block, not only "
+            "metadata text"
+        )
+
+    async def test_property_write_can_be_verified_by_readback(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            set_cmd = await plugin.recv_command()
+            assert set_cmd["command"] == "set_property"
+            assert set_cmd["params"] == {
+                "path": "/Main/Marker",
+                "property": "visible",
+                "value": False,
+            }
+            await plugin.send_response(
+                set_cmd["request_id"],
+                {
+                    "path": "/Main/Marker",
+                    "property": "visible",
+                    "value": False,
+                    "old_value": True,
+                    "undoable": True,
+                },
+            )
+
+            read_cmd = await plugin.recv_command()
+            assert read_cmd["command"] == "get_node_properties"
+            assert read_cmd["params"]["path"] == "/Main/Marker"
+            await plugin.send_response(
+                read_cmd["request_id"],
+                {
+                    "properties": [
+                        {"name": "visible", "type": "bool", "value": False},
+                        {"name": "name", "type": "String", "value": "Marker"},
+                    ]
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        write = await client.call_tool(
+            "node_set_property",
+            {"path": "/Main/Marker", "property": "visible", "value": False},
+        )
+        read = await client.call_tool("node_get_properties", {"path": "/Main/Marker"})
+        await task
+
+        assert write.data["value"] is False
+        visible = next(
+            prop for prop in read.data["properties"] if prop["name"] == "visible"
+        )
+        assert visible["value"] is False
+
+    async def test_scene_open_can_be_verified_by_hierarchy_readback(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            open_cmd = await plugin.recv_command()
+            assert open_cmd["command"] == "open_scene"
+            assert open_cmd["params"]["path"] == "res://levels/arena.tscn"
+            await plugin.send_response(
+                open_cmd["request_id"],
+                {"path": "res://levels/arena.tscn", "undoable": False},
+            )
+
+            hierarchy_cmd = await plugin.recv_command()
+            assert hierarchy_cmd["command"] == "get_scene_tree"
+            await plugin.send_response(
+                hierarchy_cmd["request_id"],
+                {
+                    "root": "Arena",
+                    "scene_path": "res://levels/arena.tscn",
+                    "nodes": [
+                        {"name": "Arena", "type": "Node3D", "path": "/Arena"},
+                        {
+                            "name": "PlayerSpawn",
+                            "type": "Marker3D",
+                            "path": "/Arena/PlayerSpawn",
+                        },
+                    ],
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        opened = await client.call_tool("scene_open", {"path": "res://levels/arena.tscn"})
+        hierarchy = await client.call_tool("scene_get_hierarchy", {"depth": 3})
+        await task
+
+        assert opened.data["path"] == "res://levels/arena.tscn"
+        assert hierarchy.data["root"] == "Arena"
+        assert any(node["name"] == "PlayerSpawn" for node in hierarchy.data["nodes"])


### PR DESCRIPTION
## Summary

Adds the first deterministic Layer 0 verification slice for godot-ai. This is intentionally test-only and independent of the GameDevBench harness work.

There are two layers here:

- Python MCP contract tests in `tests/integration/test_mcp_workflows.py`. These use the existing mock Godot plugin fixture, so they do not prove live editor behavior. They pin the FastMCP request/response contract agents rely on: screenshot calls expose a real image content block, property writes can be followed by a read-back request, and scene open can be followed by hierarchy read-back.
- A live-editor GDScript read-back test in `test_project/tests/test_node.gd`. This closes the mock blind spot for the verification loop by setting a real `Rect2` property through `NodeHandler`, calling `get_node_properties`, and asserting the stored value is returned as structured data.

## Why

The recent evaluation work showed we need a cheap, deterministic regression layer before spending on LLM benchmarks. These tests cover the basic verification primitives agents should lean on without involving an LLM, model variance, or benchmark cost.

## Proof The Tests Bite

Python contract layer:

- Baseline: `tests/integration/test_mcp_workflows.py` passed.
- Mutation proof already performed locally: removing the `McpImage` content block from `editor_screenshot` made `test_editor_screenshot_returns_consumable_image_content` fail with the expected assertion, then reverting restored green.

Live GDScript layer:

- Scratch-reintroduced the #582-style Rect2 regression by disabling Rect2 coercion and restoring the permissive checker path.
- Red result:
  - `test_set_property_rect2_lands`: `0/1`, failed on `Rect2 must land on the node, not just echo`
  - `test_set_property_rect2_can_be_verified_by_readback`: `0/1`, failed on `Rect2 must land before read-back`
- Restored the handler and reran green:
  - both targeted tests passed
  - full `node` suite passed `154/154`

## Determinism

Live editor suites were run 5 times with identical results:

- `node`: `154/154` each run
- `signal`: `18/18` each run
- `dock`: `53/53` each run

Python contract suite was also run 5 times:

- `tests/integration/test_mcp_workflows.py`: `3/3` each run

## Validation

- `uv run ruff check src/ tests/`
- `uv run pytest tests/integration/test_mcp_workflows.py`
- `uv run pytest -q` -> `1171 passed, 11 skipped, 1 warning`
- Godot 4.7 headless import parse check -> `All GDScript files OK`
- Live Godot 4.7 `test_run suite=node` -> `154/154`
- `git diff --check origin/main...HEAD`

## Scope Notes

The Python tests are contract tests with a mock plugin. They intentionally do not claim live editor correctness. The GDScript test is the live-editor guard for the read-back workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for setting node properties and verifying the values can be read back correctly.
  * Added integration coverage for MCP-style workflows, including screenshot handling, property updates, scene opening, and scene hierarchy checks.
  * Improved confidence that returned image content and structured node data are consumable and accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->