### PR TITLE
test: add deterministic MCP verification workflows

### DIFF
--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -1774,6 +1774,36 @@ func test_set_property_rect2_lands() -> void:
 	assert_true(editor_undo(_undo_redo), "undo create should succeed")
 
 
+func test_set_property_rect2_can_be_verified_by_readback() -> void:
+	_handler.create_node({"type": "Sprite2D", "name": "_McpTestRect2Readback", "parent_path": "/Main"})
+	var node := EditorInterface.get_edited_scene_root().get_node("_McpTestRect2Readback") as Sprite2D
+	node.region_enabled = true
+	var result := _handler.set_property({
+		"path": "/Main/_McpTestRect2Readback",
+		"property": "region_rect",
+		"value": {"position": {"x": 2, "y": 3}, "size": {"x": 8, "y": 13}},
+	})
+	assert_has_key(result, "data")
+	assert_eq(node.region_rect, Rect2(2, 3, 8, 13), "Rect2 must land before read-back")
+
+	var readback := _handler.get_node_properties({"path": "/Main/_McpTestRect2Readback"})
+	assert_has_key(readback, "data")
+	var found := false
+	for prop in readback.data.properties:
+		if prop.name == "region_rect":
+			found = true
+			assert_eq(prop.type, "Rect2")
+			assert_true(prop.value is Dictionary, "region_rect read-back must be structured")
+			assert_eq(prop.value.position.x, 2.0)
+			assert_eq(prop.value.position.y, 3.0)
+			assert_eq(prop.value.size.x, 8.0)
+			assert_eq(prop.value.size.y, 13.0)
+			break
+	assert_true(found, "region_rect property must be present in read-back")
+	assert_true(editor_undo(_undo_redo), "undo set should succeed")
+	assert_true(editor_undo(_undo_redo), "undo create should succeed")
+
+
 func test_set_property_transform2d_lands() -> void:
 	_handler.create_node({"type": "Node2D", "name": "_McpTestXform2D", "parent_path": "/Main"})
 	var node := EditorInterface.get_edited_scene_root().get_node("_McpTestXform2D") as Node2D

--- a/tests/integration/test_mcp_workflows.py
+++ b/tests/integration/test_mcp_workflows.py
@@ -1,0 +1,154 @@
+"""Deterministic MCP contract checks that mirror agent verification loops.
+
+These tests do not involve an LLM or a live editor; the integration fixture
+uses a mock Godot plugin. They pin the server-side request/response contract
+we want agents to lean on: capture visual feedback, mutate through a tool,
+then issue a read-back request.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+ONE_PX_PNG_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4"
+    "nGP4DwABAQEBYY2JxQAAAABJRU5ErkJggg=="
+)
+
+
+def _content_type(block: object) -> str:
+    return str(getattr(block, "type", "") or getattr(block, "kind", ""))
+
+
+async def _bounded(awaitable):
+    return await asyncio.wait_for(awaitable, timeout=5)
+
+
+class TestMcpVerificationWorkflows:
+    async def test_editor_screenshot_returns_consumable_image_content(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "take_screenshot"
+            assert cmd["params"].get("include_image", True) is True
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "source": "viewport",
+                    "width": 1,
+                    "height": 1,
+                    "original_width": 1,
+                    "original_height": 1,
+                    "format": "png",
+                    "image_base64": ONE_PX_PNG_B64,
+                },
+        )
+
+        task = asyncio.create_task(respond())
+        result = await _bounded(
+            client.call_tool("editor_screenshot", {"include_image": True})
+        )
+        await _bounded(task)
+
+        assert not result.is_error
+        assert any(_content_type(block) == "image" for block in result.content), (
+            "include_image=true must expose a real image content block, not only "
+            "metadata text"
+        )
+
+    async def test_property_write_can_be_verified_by_readback(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            set_cmd = await plugin.recv_command()
+            assert set_cmd["command"] == "set_property"
+            assert set_cmd["params"] == {
+                "path": "/Main/Marker",
+                "property": "visible",
+                "value": False,
+            }
+            await plugin.send_response(
+                set_cmd["request_id"],
+                {
+                    "path": "/Main/Marker",
+                    "property": "visible",
+                    "value": False,
+                    "old_value": True,
+                    "undoable": True,
+                },
+            )
+
+            read_cmd = await plugin.recv_command()
+            assert read_cmd["command"] == "get_node_properties"
+            assert read_cmd["params"]["path"] == "/Main/Marker"
+            await plugin.send_response(
+                read_cmd["request_id"],
+                {
+                    "properties": [
+                        {"name": "visible", "type": "bool", "value": False},
+                        {"name": "name", "type": "String", "value": "Marker"},
+                    ]
+                },
+        )
+
+        task = asyncio.create_task(respond())
+        write = await _bounded(
+            client.call_tool(
+                "node_set_property",
+                {"path": "/Main/Marker", "property": "visible", "value": False},
+            )
+        )
+        read = await _bounded(
+            client.call_tool("node_get_properties", {"path": "/Main/Marker"})
+        )
+        await _bounded(task)
+
+        assert write.data["value"] is False
+        visible = next(
+            prop for prop in read.data["properties"] if prop["name"] == "visible"
+        )
+        assert visible["value"] is False
+
+    async def test_scene_open_can_be_verified_by_hierarchy_readback(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            open_cmd = await plugin.recv_command()
+            assert open_cmd["command"] == "open_scene"
+            assert open_cmd["params"]["path"] == "res://levels/arena.tscn"
+            await plugin.send_response(
+                open_cmd["request_id"],
+                {"path": "res://levels/arena.tscn", "undoable": False},
+            )
+
+            hierarchy_cmd = await plugin.recv_command()
+            assert hierarchy_cmd["command"] == "get_scene_tree"
+            await plugin.send_response(
+                hierarchy_cmd["request_id"],
+                {
+                    "root": "Arena",
+                    "scene_path": "res://levels/arena.tscn",
+                    "nodes": [
+                        {"name": "Arena", "type": "Node3D", "path": "/Arena"},
+                        {
+                            "name": "PlayerSpawn",
+                            "type": "Marker3D",
+                            "path": "/Arena/PlayerSpawn",
+                        },
+                    ],
+                },
+        )
+
+        task = asyncio.create_task(respond())
+        opened = await _bounded(
+            client.call_tool("scene_open", {"path": "res://levels/arena.tscn"})
+        )
+        hierarchy = await _bounded(
+            client.call_tool("scene_get_hierarchy", {"depth": 3})
+        )
+        await _bounded(task)
+
+        assert opened.data["path"] == "res://levels/arena.tscn"
+        assert hierarchy.data["root"] == "Arena"
+        assert any(node["name"] == "PlayerSpawn" for node in hierarchy.data["nodes"])


### PR DESCRIPTION
## Summary

Adds deterministic tests for the MCP workflows agents rely on when checking their own work.

There are two parts:

- **Python MCP contract tests** in `tests/integration/test_mcp_workflows.py`
  - Use the existing mock Godot plugin fixture.
  - Verify the server/tool response shape:
    - `editor_screenshot(include_image=true)` returns an actual image content block.
    - `node_set_property` can be followed by `node_get_properties`.
    - `scene_open` can be followed by `scene_get_hierarchy`.

- **Live-editor GDScript read-back test** in `test_project/tests/test_node.gd`
  - Sets a real `Rect2` property through `NodeHandler`.
  - Calls `get_node_properties`.
  - Asserts the stored value is returned as structured read-back data.

## Why

These tests cover the basic verification loop we want agents to use: make a change, then read back editor state instead of trusting the write response alone.

The Python tests pin the MCP server contract. The GDScript test covers the real editor path, so a write that silently fails but returns a plausible response is caught.

## Proof

I verified the tests fail on real regressions:

- Removing the screenshot image block made `test_editor_screenshot_returns_consumable_image_content` fail, then restoring it made the test pass again.
- Reintroducing the old Rect2 silent-no-op behavior made both the existing stored-value test and the new read-back test fail, then restoring the handler made them pass again.

## Validation

- `uv run ruff check src/ tests/`
- `uv run pytest tests/integration/test_mcp_workflows.py`
- `uv run pytest -q` → `1171 passed, 11 skipped`
- Godot 4.7 import parse check → clean
- Live Godot 4.7 `test_run suite=node` → `154/154`
- Repeated live runs:
  - `node`: `154/154`, 5x identical
  - `signal`: `18/18`, 5x identical
  - `dock`: `53/53`, 5x identical
  - Python workflow tests: `3/3`, 5x identical

## Scope

This is test-only.

The Python tests use a mock plugin, so they verify MCP request/response contracts rather than live editor behavior. The new GDScript test covers the live editor write→read-back path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deterministic end-to-end verification for MCP tool workflows, enforcing expected request/response behavior.
  * Added coverage for editor screenshots, including returning consumable image content when requested.
  * Added workflow coverage for setting node properties and validating readback correctness.
  * Added workflow coverage for opening scenes and verifying the resulting hierarchy.

* **Bug Fixes**
  * Added a regression test to ensure `Sprite2D.region_rect` round-trips correctly as a structured `Rect2` payload (numeric position and size).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->