### PR TITLE
Reap completed dock client workers from the main thread

### DIFF
--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -148,21 +148,17 @@ static var _orphaned_client_status_refresh_threads: Array[Thread] = []
 
 ## Per-row worker state for Configure / Remove. Issue #239: shelling out
 ## to a hung CLI on main hangs the editor. We dispatch each click to its
-## own thread (one slot per client) and apply the result via call_deferred
-## once the subprocess returns or the wall-clock budget in McpCliExec
-## kicks in. The buttons stay disabled while the slot is busy so the user
-## can't queue a re-click on the same row.
+## own thread (one slot per client), then `_process` reaps completed workers
+## and applies returned payloads on main. The buttons stay disabled while
+## the slot is busy so the user can't queue a re-click on the same row.
 ##
 ## Per-client (not single-slot) so Configure-all can fan out — the
 ## workers are independent, only the row UI is shared, and McpCliExec
 ## bounds the wall-clock for each.
 ##
-## No orphan-thread list (unlike the refresh worker): action threads
-## never get abandoned mid-flight. McpCliExec's wall-clock budget caps
-## the worst case at ~10s, so the `_exit_tree` / `McpUpdateManager`
-## install-time drain blocks briefly and finishes — there's no path that
-## "gives up" on an action thread the way `_abandon_client_status_refresh_thread`
-## does for the refresh worker.
+## A watchdog can abandon a slot when a worker fails to report completion.
+## The thread object is retained in `_orphaned_client_action_threads` until
+## it finishes so GDScript does not destroy a live Thread object.
 var _client_action_threads: Dictionary = {}
 var _client_action_generations: Dictionary = {}
 var _client_action_started_msec: Dictionary = {}
@@ -246,6 +242,8 @@ func _ready() -> void:
 func _process(_delta: float) -> void:
 	_prune_orphaned_client_status_refresh_threads()
 	_prune_orphaned_client_action_threads()
+	_poll_completed_client_status_refresh_thread()
+	_poll_completed_client_action_threads()
 	_check_client_status_refresh_timeout()
 	_check_client_action_timeouts()
 	if _connection == null:
@@ -321,10 +319,9 @@ func _drain_client_action_workers() -> void:
 	## teardown still blocks because GDScript's Thread API has no kill/timeout
 	## primitive and destroying a live Thread corrupts the VM.
 	##
-	## Generation-bumped per-row so any pending `call_deferred(
-	## "_apply_client_action_result")` from a worker that finished after we
-	## started draining detects the generation mismatch and short-circuits
-	## without touching freed UI state.
+	## Generation-bumped per-row so any result from a worker that finished
+	## after we started draining detects the generation mismatch and
+	## short-circuits without touching freed UI state.
 	##
 	## After draining, restore the row UI for any in-flight rows: bare
 	## `_client_action_threads.clear()` would leave the dock stuck showing
@@ -1645,18 +1642,51 @@ func _dispatch_client_action(client_id: String, action: String) -> void:
 		_refresh_clients_summary()
 
 
-func _run_client_action_worker(client_id: String, action: String, server_url: String, generation: int) -> void:
+func _run_client_action_worker(client_id: String, action: String, server_url: String, generation: int) -> Dictionary:
 	var result: Dictionary
 	if action == "remove":
 		result = ClientConfigurator.remove(client_id, server_url)
 	else:
 		result = ClientConfigurator.configure(client_id, server_url)
-	if _refresh_state != ClientRefreshStateScript.SHUTTING_DOWN:
-		call_deferred("_apply_client_action_result", client_id, action, result, generation)
+	return {
+		"client_id": client_id,
+		"action": action,
+		"result": result,
+		"generation": generation,
+	}
+
+
+func _poll_completed_client_action_threads() -> void:
+	for client_id in _client_action_threads.keys():
+		var thread: Thread = _client_action_threads[client_id]
+		if thread == null or thread.is_alive():
+			continue
+		var payload: Variant = thread.wait_to_finish()
+		_client_action_threads[client_id] = null
+		if payload is Dictionary:
+			var data := payload as Dictionary
+			var result: Dictionary = data.get("result", {})
+			_apply_client_action_result(
+				String(data.get("client_id", client_id)),
+				String(data.get("action", _client_action_names.get(client_id, "configure"))),
+				result,
+				int(data.get("generation", _client_action_generations.get(client_id, 0)))
+			)
+		else:
+			_apply_client_action_result(
+				String(client_id),
+				String(_client_action_names.get(client_id, "configure")),
+				{"status": "error", "message": "worker returned no result"},
+				int(_client_action_generations.get(client_id, 0))
+			)
 
 
 func _apply_client_action_result(client_id: String, action: String, result: Dictionary, generation: int) -> void:
 	if int(_client_action_generations.get(client_id, 0)) != generation:
+		if _client_action_threads.get(client_id, null) == null:
+			_client_action_threads.erase(client_id)
+			_client_action_started_msec.erase(client_id)
+			_client_action_names.erase(client_id)
 		return
 	if _refresh_state == ClientRefreshStateScript.SHUTTING_DOWN:
 		return
@@ -1664,9 +1694,9 @@ func _apply_client_action_result(client_id: String, action: String, result: Dict
 		var t: Thread = _client_action_threads[client_id]
 		if t != null:
 			t.wait_to_finish()
-		_client_action_threads.erase(client_id)
-		_client_action_started_msec.erase(client_id)
-		_client_action_names.erase(client_id)
+	_client_action_threads.erase(client_id)
+	_client_action_started_msec.erase(client_id)
+	_client_action_names.erase(client_id)
 	_finalize_action_buttons(client_id)
 	if _server_blocks_client_health():
 		_apply_row_status(client_id, Client.Status.ERROR, _server_blocked_client_message())
@@ -2256,8 +2286,8 @@ func _warm_strategy_bytecode() -> void:
 
 func _begin_client_status_refresh_run() -> int:
 	## Marks a refresh as starting and returns the new generation token.
-	## Generation is bumped here (not at completion) so that a worker callback
-	## arriving after `_abandon_client_status_refresh_thread` or `_exit_tree`
+	## Generation is bumped here (not at completion) so that a worker result
+	## reaped after `_abandon_client_status_refresh_thread` or `_exit_tree`
 	## fires can be detected as stale via generation mismatch.
 	_refresh_state = ClientRefreshStateScript.RUNNING
 	_client_status_refresh_pending = false
@@ -2270,7 +2300,7 @@ func _begin_client_status_refresh_run() -> int:
 
 func _finalize_completed_refresh() -> void:
 	## Stamps cooldown and clears in-flight state. Called at the end of every
-	## refresh that successfully applied results — the worker callback path
+	## refresh that successfully applied results — the worker reaping path
 	## and the no-CLI fast path in `_perform_initial_client_status_refresh`.
 	_last_client_status_refresh_completed_msec = Time.get_ticks_msec()
 	if _refresh_state != ClientRefreshStateScript.SHUTTING_DOWN:
@@ -2397,7 +2427,7 @@ func _retry_deferred_client_status_refresh() -> void:
 		_request_client_status_refresh(force)
 
 
-func _run_client_status_refresh_worker(client_probes: Array[Dictionary], server_url: String, generation: int) -> void:
+func _run_client_status_refresh_worker(client_probes: Array[Dictionary], server_url: String, generation: int) -> Dictionary:
 	var results: Dictionary = {}
 	for probe in client_probes:
 		var client_id := String(probe.get("id", ""))
@@ -2414,8 +2444,25 @@ func _run_client_status_refresh_worker(client_probes: Array[Dictionary], server_
 			"installed": installed,
 			"error_msg": details.get("error_msg", ""),
 		}
-	if _refresh_state != ClientRefreshStateScript.SHUTTING_DOWN:
-		call_deferred("_apply_client_status_refresh_results", results, generation)
+	return {"results": results, "generation": generation}
+
+
+func _poll_completed_client_status_refresh_thread() -> void:
+	if _client_status_refresh_thread == null:
+		return
+	if _client_status_refresh_thread.is_alive():
+		return
+	var payload: Variant = _client_status_refresh_thread.wait_to_finish()
+	_client_status_refresh_thread = null
+	if payload is Dictionary:
+		var data := payload as Dictionary
+		var results: Dictionary = data.get("results", {})
+		_apply_client_status_refresh_results(
+			results,
+			int(data.get("generation", _client_status_refresh_generation))
+		)
+	else:
+		_apply_client_status_refresh_results({}, _client_status_refresh_generation)
 
 
 func _apply_client_status_refresh_results(results: Dictionary, generation: int) -> void:

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -281,6 +281,8 @@ func _exit_tree() -> void:
 ## drains directly because it has additional state-machine work
 ## (SHUTTING_DOWN sticky-set) that the install-time path must NOT inherit.
 func prepare_for_self_update_drain() -> void:
+	_poll_completed_client_status_refresh_thread()
+	_poll_completed_client_action_threads()
 	_drain_client_status_refresh_workers()
 	_drain_client_action_workers()
 

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -69,6 +69,10 @@ static func _finished_thread_noop() -> void:
 	pass
 
 
+static func _finished_thread_payload(payload: Dictionary) -> Dictionary:
+	return payload
+
+
 var _dock: Node
 
 
@@ -890,7 +894,7 @@ func test_dispatch_client_action_noop_when_slot_already_in_flight() -> void:
 	## Double-click guard: a second click while the first worker is still
 	## running must not start a second thread on the same row. Without
 	## this, the row's button/label state would race between the two
-	## workers' deferred callbacks.
+	## workers' completion payloads.
 	_dock._build_ui()
 	var any_id := _first_client_id()
 	if any_id.is_empty():
@@ -905,6 +909,86 @@ func test_dispatch_client_action_noop_when_slot_already_in_flight() -> void:
 	assert_eq(_dock._client_action_threads[any_id], sentinel,
 		"Dispatch must leave the existing slot untouched while in flight")
 	_dock._client_action_threads.erase(any_id)
+
+
+func test_completed_action_thread_is_polled_and_applied() -> void:
+	## Regression for the dock showing "Configure did not report completion"
+	## even though the worker finished and the config file landed. The main
+	## thread must reap finished action workers directly instead of relying on
+	## a worker-thread deferred callback.
+	_dock._build_ui()
+	var any_id := _first_client_id()
+	if any_id.is_empty():
+		skip("No clients registered")
+		return
+	_dock._set_row_action_in_flight(any_id, "configure")
+	_dock._client_action_generations[any_id] = 12
+	_dock._client_action_started_msec[any_id] = Time.get_ticks_msec()
+	_dock._client_action_names[any_id] = "configure"
+	var payload := {
+		"client_id": any_id,
+		"action": "configure",
+		"result": {"status": "ok"},
+		"generation": 12,
+	}
+	var thread := Thread.new()
+	var err := thread.start(Callable(self, "_finished_thread_payload").bind(payload))
+	assert_eq(err, OK, "Completed action fixture thread should start")
+	while thread.is_alive():
+		OS.delay_msec(1)
+	_dock._client_action_threads[any_id] = thread
+
+	_dock._poll_completed_client_action_threads()
+
+	var row: Dictionary = _dock._client_rows[any_id]
+	assert_false(_dock._client_action_threads.has(any_id),
+		"Polling must clear the completed action slot")
+	assert_eq(row.get("status"), McpClient.Status.CONFIGURED,
+		"Completed configure payload must repaint the row as configured")
+	assert_contains(_dock._clients_summary_label.text, "1 /",
+		"Summary should reconcile as soon as the completed action is reaped")
+
+
+func test_completed_status_refresh_thread_is_polled_and_applied() -> void:
+	## A completed status worker with a missed callback used to strand the
+	## dock in "(checking...)" with stale row statuses. Reaping the Thread
+	## return value from `_process` must apply the snapshot and finalize the
+	## refresh state.
+	_dock._build_ui()
+	var any_id := _first_client_id()
+	if any_id.is_empty():
+		skip("No clients registered")
+		return
+	_dock._client_status_refresh_generation = 21
+	_dock._refresh_state = McpClientRefreshState.RUNNING
+	var payload := {
+		"generation": 21,
+		"results": {
+			any_id: {
+				"status": McpClient.Status.CONFIGURED,
+				"installed": true,
+				"error_msg": "",
+			},
+		},
+	}
+	var thread := Thread.new()
+	var err := thread.start(Callable(self, "_finished_thread_payload").bind(payload))
+	assert_eq(err, OK, "Completed status fixture thread should start")
+	while thread.is_alive():
+		OS.delay_msec(1)
+	_dock._client_status_refresh_thread = thread
+
+	_dock._poll_completed_client_status_refresh_thread()
+
+	var row: Dictionary = _dock._client_rows[any_id]
+	assert_eq(_dock._client_status_refresh_thread, null,
+		"Polling must clear the completed status refresh thread")
+	assert_eq(_dock._refresh_state, McpClientRefreshState.IDLE,
+		"Completed status refresh should finalize back to idle")
+	assert_eq(row.get("status"), McpClient.Status.CONFIGURED,
+		"Status refresh payload must repaint the row")
+	assert_false(_dock._clients_summary_label.text.contains("checking"),
+		"Summary must drop the checking badge after applying the payload")
 
 
 func test_apply_status_refresh_results_skips_rows_with_in_flight_action() -> void:
@@ -941,8 +1025,7 @@ func test_drain_client_action_workers_clears_threads_and_bumps_generation() -> v
 	## `_drain_dock_workers`) before extracting the release zip, same
 	## reason as the refresh worker drain — a worker mid-call into a
 	## half-overwritten script SIGABRTs the editor. The drain bumps
-	## generation per-row so any pending `call_deferred(
-	## "_apply_client_action_result")` from a worker that finished after
+	## generation per-row so any result from a worker that finished after
 	## the drain detects the mismatch and short-circuits before touching
 	## restored UI state.
 	_dock._client_action_threads["sentinel-id"] = null
@@ -951,7 +1034,7 @@ func test_drain_client_action_workers_clears_threads_and_bumps_generation() -> v
 	assert_true(_dock._client_action_threads.is_empty(),
 		"Drain must empty the action-thread map so a follow-up dispatch starts fresh")
 	assert_eq(int(_dock._client_action_generations.get("sentinel-id", 0)), 8,
-		"Drain must bump generation so any late call_deferred from the drained worker is rejected as stale")
+		"Drain must bump generation so any late result from the drained worker is rejected as stale")
 
 
 func test_drain_client_action_workers_restores_in_flight_row_buttons() -> void:

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -938,7 +938,7 @@ func test_completed_action_thread_is_polled_and_applied() -> void:
 		OS.delay_msec(1)
 	_dock._client_action_threads[any_id] = thread
 
-	_dock._poll_completed_client_action_threads()
+	_dock._process(0.0)
 
 	var row: Dictionary = _dock._client_rows[any_id]
 	assert_false(_dock._client_action_threads.has(any_id),
@@ -978,7 +978,7 @@ func test_completed_status_refresh_thread_is_polled_and_applied() -> void:
 		OS.delay_msec(1)
 	_dock._client_status_refresh_thread = thread
 
-	_dock._poll_completed_client_status_refresh_thread()
+	_dock._process(0.0)
 
 	var row: Dictionary = _dock._client_rows[any_id]
 	assert_eq(_dock._client_status_refresh_thread, null,

--- a/tests/unit/test_dock_cli_timeout.py
+++ b/tests/unit/test_dock_cli_timeout.py
@@ -93,9 +93,10 @@ def test_dock_dispatches_configure_and_remove_to_worker_thread() -> None:
     # The dispatch funnel must exist and route the click into a worker.
     assert "func _dispatch_client_action(" in dock_source
     assert "Thread.new()" in dock_source
-    # The deferred apply lives on main; the worker only does the
-    # blocking call and a call_deferred handoff.
-    assert 'call_deferred("_apply_client_action_result"' in dock_source
+    # The apply still lives on main, but completion is reaped from
+    # `_process` instead of trusting a worker-thread call_deferred handoff.
+    assert "func _poll_completed_client_action_threads(" in dock_source
+    assert 'call_deferred("_apply_client_action_result"' not in dock_source
     assert "func _run_client_action_worker(" in dock_source
     # The two button handlers should NOT call McpClientConfigurator
     # directly — that would re-introduce the main-thread block. They

--- a/tests/unit/test_editor_focus_refocus.py
+++ b/tests/unit/test_editor_focus_refocus.py
@@ -21,15 +21,18 @@ def test_focus_in_uses_async_cooled_down_refresh_instead_of_blocking_sweep() -> 
     assert "_refresh_all_client_statuses()" not in _focus_in_block(source)
 
 
-def test_client_status_refresh_runs_on_background_thread_and_applies_deferred() -> None:
-    """Blocking client probes should run off-thread; UI updates should apply deferred."""
+def test_client_status_refresh_runs_on_background_thread_and_reaps_on_main() -> None:
+    """Blocking client probes should run off-thread; UI updates should be reaped on main."""
 
     source = (PLUGIN_ROOT / "mcp_dock.gd").read_text(encoding="utf-8")
 
     assert "var _client_status_refresh_thread: Thread" in source
     assert "_client_status_refresh_thread.start" in source
     assert "ClientConfigurator.check_status" in source
-    assert 'call_deferred("_apply_client_status_refresh_results' in source
+    assert "func _poll_completed_client_status_refresh_thread(" in source
+    process_block = get_func_block(source, "func _process(_delta: float) -> void:")
+    assert "_poll_completed_client_status_refresh_thread()" in process_block
+    assert 'call_deferred("_apply_client_status_refresh_results' not in source
 
 
 def test_client_status_refresh_coalesces_and_manual_refresh_bypasses_cooldown() -> None:


### PR DESCRIPTION
## Summary

Fixes a Clients & Tools dock state bug where client configuration/status work could complete successfully, but the UI stayed stuck in a stale in-flight/error state such as:

- `0 / 19 configured (checking...)`
- `Configure did not report completion in time; refreshing current status. Retry`

## Problem

The dock previously relied on worker threads calling `call_deferred` back into `McpDock` after client configure/remove/status work finished. If that handoff was missed or delayed, the underlying operation could succeed, but the dock would keep the thread slot marked busy until the watchdog painted a timeout/error state.

This produced a visible mismatch: MCP `client_manage/status` could report Codex as `configured` while the dock still showed a stale retry row or `0 / 19 configured`.

## Fix

- Changed client action workers to return payloads from the thread instead of calling back with `call_deferred`.
- Added `_process` polling to reap completed action/status worker threads and apply their results on the main thread.
- Kept stale-generation handling so abandoned or drained worker results are ignored safely.
- Updated comments and structural tests to reflect the new worker reaping model.
- Added dock tests for completed action/status workers being polled and applied.

## Tests

- Godot MCP test runner: `dock` suite, `59 passed`
- Python: `tests/unit/test_dock_cli_timeout.py`, `7 passed`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how completed background client action updates are reaped and applied so UI row updates occur reliably on the main thread.
  * Tightened generation/stale-result handling to prevent late results from overwriting newer client state.
  * Refined client status refresh completion so row state and summary badges stay in sync, including during drain/shutdown.
* **Tests**
  * Added new tests validating polling-based completion for both client actions and status refreshes.
  * Updated existing unit tests to assert the old deferred-application path is no longer used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->