### PR TITLE
Add shared game liveness status

### DIFF
--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -80,6 +80,9 @@ var _game_run_token := 0
 var _ready_run_token := -1
 var _game_session_id := -1
 var _game_run_active := false
+var _game_run_started_msec := 0
+var _game_run_started_editor_cursor := 0
+var _game_helper_expected := true
 signal game_ready
 
 
@@ -107,12 +110,15 @@ func _setup_session(session_id: int) -> void:
 	_game_session_id = session_id
 
 
-func begin_game_run() -> void:
+func begin_game_run(editor_log_cursor: int = 0, helper_expected: bool = true) -> void:
 	_game_run_token += 1
 	_game_run_active = true
 	_game_ready = false
 	_ready_run_token = -1
 	_game_session_id = -1
+	_game_run_started_msec = Time.get_ticks_msec()
+	_game_run_started_editor_cursor = maxi(0, editor_log_cursor)
+	_game_helper_expected = helper_expected
 	if _log_buffer:
 		_log_buffer.log("[debug] game capture pending run token %d" % _game_run_token)
 
@@ -126,6 +132,34 @@ func end_game_run() -> void:
 
 func is_game_capture_ready() -> bool:
 	return _game_run_active and _game_ready and _ready_run_token == _game_run_token
+
+
+func get_game_status(now_msec: int = -1, ready_wait_sec: float = GAME_READY_WAIT_SEC) -> Dictionary:
+	var resolved_now := Time.get_ticks_msec() if now_msec < 0 else now_msec
+	var ready_wait_msec := maxi(0, int(ready_wait_sec * 1000.0))
+	var elapsed_msec := maxi(0, resolved_now - _game_run_started_msec) if _game_run_active else 0
+	## "stopped" also covers idle/never-ran; no game run is currently active.
+	var status := "stopped"
+	if _game_run_active:
+		if is_game_capture_ready():
+			status = "live"
+		elif not _game_helper_expected:
+			status = "no_helper"
+		elif elapsed_msec >= ready_wait_msec:
+			status = "not_live"
+		else:
+			status = "launching"
+	return {
+		"status": status,
+		"run_token": _game_run_token,
+		"active": _game_run_active,
+		"ready": is_game_capture_ready(),
+		"helper_expected": _game_helper_expected,
+		"run_started_msec": _game_run_started_msec,
+		"elapsed_msec": elapsed_msec,
+		"ready_wait_msec": ready_wait_msec,
+		"editor_log_cursor": _game_run_started_editor_cursor,
+	}
 
 
 func _capture(message: String, data: Array, session_id: int) -> bool:

--- a/plugin/addons/godot_ai/handlers/project_handler.gd
+++ b/plugin/addons/godot_ai/handlers/project_handler.gd
@@ -9,11 +9,13 @@ const NodeHandler := preload("res://addons/godot_ai/handlers/node_handler.gd")
 
 var _connection: McpConnection
 var _debugger_plugin
+var _editor_log_buffer
 
 
-func _init(connection: McpConnection = null, debugger_plugin = null) -> void:
+func _init(connection: McpConnection = null, debugger_plugin = null, editor_log_buffer = null) -> void:
 	_connection = connection
 	_debugger_plugin = debugger_plugin
+	_editor_log_buffer = editor_log_buffer
 
 
 func get_project_setting(params: Dictionary) -> Dictionary:
@@ -125,7 +127,7 @@ func run_project(params: Dictionary) -> Dictionary:
 		restore_setting = true
 
 	if _debugger_plugin != null:
-		_debugger_plugin.begin_game_run()
+		_debugger_plugin.begin_game_run(_editor_log_cursor(), _game_helper_autoload_expected())
 
 	match mode:
 		"main":
@@ -152,6 +154,14 @@ func run_project(params: Dictionary) -> Dictionary:
 			"reason": "Play/stop is a runtime action",
 		}
 	}
+
+
+func _editor_log_cursor() -> int:
+	return _editor_log_buffer.appended_total() if _editor_log_buffer != null else 0
+
+
+func _game_helper_autoload_expected() -> bool:
+	return ProjectSettings.has_setting("autoload/_mcp_game_helper")
 
 
 func stop_project(params: Dictionary) -> Dictionary:

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -240,7 +240,7 @@ func _enter_tree() -> void:
 	var editor_handler := EditorHandler.new(_log_buffer, _connection, _debugger_plugin, _game_log_buffer, _editor_log_buffer)
 	var scene_handler := SceneHandler.new(_connection)
 	var node_handler := NodeHandler.new(get_undo_redo())
-	var project_handler := ProjectHandler.new(_connection, _debugger_plugin)
+	var project_handler := ProjectHandler.new(_connection, _debugger_plugin, _editor_log_buffer)
 	var client_handler := ClientHandler.new()
 	var script_handler := ScriptHandler.new(get_undo_redo(), _connection)
 	var resource_handler := ResourceHandler.new(get_undo_redo(), _connection)

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -1773,6 +1773,58 @@ func test_debugger_plugin_readiness_is_scoped_to_current_run() -> void:
 	assert_false(plugin.is_game_capture_ready(), "late hello after stop must not restore readiness")
 
 
+func test_debugger_plugin_game_status_tracks_run_lifecycle() -> void:
+	var plugin := McpDebuggerPlugin.new()
+	var status := plugin.get_game_status()
+	assert_eq(status.status, "stopped")
+	assert_eq(status.active, false)
+	assert_eq(status.ready, false)
+
+	plugin.begin_game_run(42, true)
+	status = plugin.get_game_status(plugin._game_run_started_msec)
+	assert_eq(status.status, "launching")
+	assert_eq(status.run_token, 1)
+	assert_eq(status.active, true)
+	assert_eq(status.ready, false)
+	assert_eq(status.helper_expected, true)
+	assert_eq(status.editor_log_cursor, 42)
+
+	plugin._capture("mcp:hello", [], -1)
+	status = plugin.get_game_status()
+	assert_eq(status.status, "live")
+	assert_eq(status.ready, true)
+
+	plugin.begin_game_run(99, true)
+	status = plugin.get_game_status(plugin._game_run_started_msec)
+	assert_eq(status.status, "launching")
+	plugin._game_ready = true
+	status = plugin.get_game_status(plugin._game_run_started_msec)
+	assert_eq(status.status, "launching", "raw ready flag without the current token is stale")
+
+	var after_window := plugin._game_run_started_msec + int(McpDebuggerPlugin.GAME_READY_WAIT_SEC * 1000.0)
+	status = plugin.get_game_status(after_window - 1)
+	assert_eq(status.status, "launching", "run stays launching until the wait window is exhausted")
+	status = plugin.get_game_status(after_window)
+	assert_eq(status.status, "not_live", "wait window boundary is inclusive")
+	assert_eq(status.editor_log_cursor, 99)
+
+	plugin.end_game_run()
+	status = plugin.get_game_status()
+	assert_eq(status.status, "stopped")
+	assert_eq(status.active, false)
+	assert_eq(status.ready, false)
+
+
+func test_debugger_plugin_game_status_reports_no_helper_when_not_expected() -> void:
+	var plugin := McpDebuggerPlugin.new()
+	plugin.begin_game_run(7, false)
+	var after_window := plugin._game_run_started_msec + int(McpDebuggerPlugin.GAME_READY_WAIT_SEC * 1000.0)
+	var status := plugin.get_game_status(after_window)
+	assert_eq(status.status, "no_helper")
+	assert_eq(status.helper_expected, false)
+	assert_eq(status.editor_log_cursor, 7)
+
+
 func test_debugger_plugin_ignores_hello_from_stale_session() -> void:
 	var game_buf := McpGameLogBuffer.new()
 	var plugin := McpDebuggerPlugin.new(null, game_buf)


### PR DESCRIPTION
## Summary

Adds the shared game-liveness state needed for #597. The existing game helper handshake already had the core signal (`begin_game_run()` token + `mcp:hello`), but it was only used inline by game screenshot/eval paths. This promotes that signal into a queryable `game_status` state machine.

`get_game_status()` now reports:

- `stopped` — no active run, including idle/never-ran
- `launching` — run active, helper expected, no hello yet, still inside wait window
- `live` — current run received `mcp:hello` with the token-match guard
- `not_live` — helper expected, no hello, wait window elapsed
- `no_helper` — helper is not expected, so no hello should not be treated as a crash

`project_run` also snapshots the editor-log cursor and helper-autoload expectation at the authoritative play-start moment. Follow-up PRs can use that cursor to correlate `not_live` with run-scoped parse/load errors.

## Why

In #597, a parse/load failure can leave `EditorInterface.is_playing_scene()` true while `_mcp_game_helper` never checks in. Agents then see “playing” plus game-tool timeouts and mistake a crash/load failure for a bridge problem.

This PR does not change user-facing `project_run` or game-tool error messages yet. It creates the deterministic liveness primitive that C/D/B can consume next.

## Tests

- `test_run suite=editor`: 129 passed, 0 failed, 2 skipped
- `test_run suite=project`: 20 passed, 0 failed
- full `test_run`: 1475 passed, 0 failed, 19 skipped
- direct Godot import parse check completed cleanly
- `git diff --check` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved game run status reporting with clearer states for launching, live, stopped, and missing-helper scenarios.
  * Added more detailed run tracking, including timing and editor log position, to help diagnose startup behavior.

* **Bug Fixes**
  * Fixed status transitions around the readiness timeout so state changes are reported more consistently at the boundary.
  * Better handles runs where the game helper is not present, showing a dedicated status instead of ambiguous output.

* **Tests**
  * Added coverage for game-status transitions, readiness timing, and helper-not-expected cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->