### PR TITLE
Fix game log run lifecycle

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -40,6 +40,25 @@ Godot `_log_error` code/rationale when available, error type, resolved source
 location, and stack/error-tree context corresponding to the Debugger dock's
 Errors tab.
 
+For game logs, `logs_read(source="game")` returns lines from the current game
+run only. Each play-start creates a new `run_id`, even if the game never reaches
+the `_mcp_game_helper` hello beacon; prior run lines stay retained but do not
+appear in the default response. To retrieve a prior run, keep the `run_id` from
+an earlier response and pass `logs_read(source="game", since_run_id="...")`;
+the response includes both `run_id` (the run being read) and `current_run_id`
+(the latest run). `stale_run_id=true` means the requested run is not the current
+one. There is no single `source="game"` call that returns every retained game
+line across all runs; consumers that need history should retain run ids and
+query each run explicitly.
+
+Game and combined log responses also include `game_status` and a liveness-based
+`is_running`. `is_running` is no longer raw editor play-state: it is `false` for
+`game_status.status` of `"not_live"` or `"stopped"`, and `true` for `"live"`,
+`"launching"`, or `"no_helper"`. This lets a parse/load failure that leaves the
+editor play button active report as not running, while a legitimate headless or
+custom-main-loop project without `_mcp_game_helper` remains running with
+`game_status.status="no_helper"`.
+
 For incremental editor-log polling, call `logs_read(source="editor")` once and
 save the returned `next_cursor`; later calls can pass
 `logs_read(source="editor", since_cursor=N)` to receive only Logger-backed

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -121,8 +121,14 @@ func begin_game_run(editor_log_cursor: int = 0, helper_expected: bool = true) ->
 	_game_run_started_msec = Time.get_ticks_msec()
 	_game_run_started_editor_cursor = maxi(0, editor_log_cursor)
 	_game_helper_expected = helper_expected
+	var run_id := ""
+	if _game_log_buffer:
+		run_id = _game_log_buffer.clear_for_new_run()
 	if _log_buffer:
-		_log_buffer.log("[debug] game capture pending run token %d" % _game_run_token)
+		var log_text := "[debug] game capture pending run token %d" % _game_run_token
+		if not run_id.is_empty():
+			log_text += " (run %s)" % run_id
+		_log_buffer.log(log_text)
 
 
 func end_game_run() -> void:
@@ -300,18 +306,15 @@ func _capture(message: String, data: Array, session_id: int) -> bool:
 			## Boot beacon from the game-side autoload. Tells us the
 			## game has registered its "mcp" capture and is safe to send
 			## take_screenshot to — before this, Godot's debugger would
-			## drop our message silently. Also marks a fresh play
-			## cycle: rotate the game-log buffer so each run starts
-			## clean and gets a new run_id.
+			## drop our message silently.
 			_game_ready = true
 			_ready_run_token = _game_run_token
 			game_ready.emit()
-			if _game_log_buffer:
-				var run_id := _game_log_buffer.clear_for_new_run()
-				if _log_buffer:
-					_log_buffer.log("[debug] <- mcp:hello from game_helper (run %s)" % run_id)
-			elif _log_buffer:
-				_log_buffer.log("[debug] <- mcp:hello from game_helper")
+			if _log_buffer:
+				if _game_log_buffer:
+					_log_buffer.log("[debug] <- mcp:hello from game_helper (run %s)" % _game_log_buffer.run_id())
+				else:
+					_log_buffer.log("[debug] <- mcp:hello from game_helper")
 			return true
 		"mcp:eval_response":
 			_on_eval_response(data)

--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -72,6 +72,7 @@ func get_logs(params: Dictionary) -> Dictionary:
 	var include_details: bool = bool(params.get("include_details", false))
 	var has_since_cursor := params.has("since_cursor") and params.get("since_cursor") != null
 	var since_cursor: int = maxi(0, int(params.get("since_cursor", 0)))
+	var since_run_id := "" if params.get("since_run_id", null) == null else str(params.get("since_run_id", ""))
 	if not source in VALID_LOG_SOURCES:
 		return ErrorCodes.make(
 			ErrorCodes.VALUE_OUT_OF_RANGE,
@@ -82,12 +83,28 @@ func get_logs(params: Dictionary) -> Dictionary:
 		"plugin":
 			return _get_plugin_logs(count, offset)
 		"game":
-			return _get_game_logs(count, offset, include_details)
+			return _get_game_logs(count, offset, include_details, since_run_id)
 		"editor":
 			return _get_editor_logs(count, offset, include_details, has_since_cursor, since_cursor)
 		"all":
 			return _get_all_logs(count, offset, include_details)
 	return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Unreachable")
+
+
+func _current_game_status() -> Dictionary:
+	if _debugger_plugin == null:
+		return {
+			"status": "stopped",
+			"active": false,
+			"ready": false,
+			"helper_expected": true,
+		}
+	return _debugger_plugin.get_game_status()
+
+
+func _is_game_log_running(game_status: Dictionary) -> bool:
+	var status := str(game_status.get("status", "stopped"))
+	return not status in ["not_live", "stopped"]
 
 
 func _get_plugin_logs(count: int, offset: int) -> Dictionary:
@@ -107,7 +124,8 @@ func _get_plugin_logs(count: int, offset: int) -> Dictionary:
 	}
 
 
-func _get_game_logs(count: int, offset: int, include_details: bool) -> Dictionary:
+func _get_game_logs(count: int, offset: int, include_details: bool, since_run_id: String = "") -> Dictionary:
+	var game_status := _current_game_status()
 	if _game_log_buffer == null:
 		return {
 			"data": {
@@ -117,21 +135,31 @@ func _get_game_logs(count: int, offset: int, include_details: bool) -> Dictionar
 				"returned_count": 0,
 				"offset": offset,
 				"run_id": "",
+				"current_run_id": "",
 				"is_running": false,
+				"game_status": game_status,
 				"dropped_count": 0,
+				"stale_run_id": false,
 			}
 		}
-	var page := _entries_for_response(_game_log_buffer.get_range(offset, count), include_details)
+	var current_run_id := _game_log_buffer.run_id()
+	var target_run_id := since_run_id if not since_run_id.is_empty() else current_run_id
+	var stale_run_id := not since_run_id.is_empty() and since_run_id != current_run_id
+	var run_page := _game_log_buffer.get_run_page(target_run_id, offset, count)
+	var page := _entries_for_response(run_page.get("entries", []), include_details)
 	return {
 		"data": {
 			"source": "game",
 			"lines": page,
-			"total_count": _game_log_buffer.total_count(),
+			"total_count": int(run_page.get("total_count", 0)),
 			"returned_count": page.size(),
 			"offset": offset,
-			"run_id": _game_log_buffer.run_id(),
-			"is_running": EditorInterface.is_playing_scene(),
+			"run_id": target_run_id,
+			"current_run_id": current_run_id,
+			"is_running": _is_game_log_running(game_status),
+			"game_status": game_status,
 			"dropped_count": _game_log_buffer.dropped_count(),
+			"stale_run_id": stale_run_id,
 		}
 	}
 
@@ -211,21 +239,24 @@ func _get_all_logs(count: int, offset: int, include_details: bool) -> Dictionary
 		combined.append({"source": "plugin", "level": "info", "text": line})
 	for entry in _collect_editor_log_entries():
 		combined.append(entry)
+	var run_id := ""
+	var current_run_id := ""
+	var dropped := 0
 	if _game_log_buffer != null:
-		for entry in _game_log_buffer.get_range(0, _game_log_buffer.total_count()):
+		run_id = _game_log_buffer.run_id()
+		current_run_id = run_id
+		dropped = _game_log_buffer.dropped_count()
+		var run_page := _game_log_buffer.get_run_page(run_id, 0, McpGameLogBuffer.MAX_LINES)
+		for entry in run_page.get("entries", []):
 			combined.append(entry)
 	var stop := mini(combined.size(), offset + count)
 	var page: Array[Dictionary] = []
 	for i in range(mini(offset, combined.size()), stop):
 		page.append(combined[i])
 	page = _entries_for_response(page, include_details)
-	var run_id := ""
-	var dropped := 0
-	if _game_log_buffer != null:
-		run_id = _game_log_buffer.run_id()
-		dropped = _game_log_buffer.dropped_count()
 	if _editor_log_buffer != null:
 		dropped += _editor_log_buffer.dropped_count()
+	var game_status := _current_game_status()
 	return {
 		"data": {
 			"source": "all",
@@ -234,7 +265,9 @@ func _get_all_logs(count: int, offset: int, include_details: bool) -> Dictionary
 			"returned_count": page.size(),
 			"offset": offset,
 			"run_id": run_id,
-			"is_running": EditorInterface.is_playing_scene(),
+			"current_run_id": current_run_id,
+			"is_running": _is_game_log_running(game_status),
+			"game_status": game_status,
 			"dropped_count": dropped,
 		}
 	}

--- a/plugin/addons/godot_ai/utils/game_log_buffer.gd
+++ b/plugin/addons/godot_ai/utils/game_log_buffer.gd
@@ -6,9 +6,8 @@ extends McpStructuredLogRing
 ## ferried back from the playing game over the EngineDebugger channel.
 ##
 ## Larger cap than McpEditorLogBuffer because games can be noisy. `run_id`
-## rotates each time clear_for_new_run() fires (called on the game's
-## mcp:hello boot beacon), giving agents a stable cursor for "lines since
-## this play started".
+## rotates at play-start, giving agents a stable cursor for "lines from
+## this run" even when the game never reaches the mcp:hello boot beacon.
 ##
 ## Single-threaded — game_helper.gd drains its logger from `_process` and
 ## calls `append` from the main thread, so this subclass can use the base
@@ -17,6 +16,7 @@ extends McpStructuredLogRing
 const MAX_LINES := 2000
 
 var _run_id := ""
+var _run_seq := 0
 
 
 func _init() -> void:
@@ -24,17 +24,22 @@ func _init() -> void:
 
 
 func append(level: String, text: String, details: Dictionary = {}) -> void:
-	var entry := {"source": "game", "level": _coerce_level(level), "text": text}
+	var entry := {
+		"source": "game",
+		"level": _coerce_level(level),
+		"text": text,
+		"run_id": _run_id,
+	}
 	if not details.is_empty():
 		entry["details"] = details.duplicate(true)
 	_append_entry(entry)
 
 
-## Rotate the run identifier and drop all buffered entries. Called when the
-## game-side autoload sends its mcp:hello beacon, marking a fresh play cycle.
-## Returns the new run_id.
+## Rotate the run identifier without dropping buffered entries. Called at
+## play-start so even no-hello parse failures get a fresh current-run identity.
+## Historical lines stay tagged with their original run_id and can still be
+## queried explicitly.
 func clear_for_new_run() -> String:
-	_clear_storage()
 	_run_id = _generate_run_id()
 	return _run_id
 
@@ -43,8 +48,38 @@ func run_id() -> String:
 	return _run_id
 
 
-static func _generate_run_id() -> String:
+func get_run_range(run_id: String, offset: int, count: int) -> Array[Dictionary]:
+	return get_run_page(run_id, offset, count).entries
+
+
+func run_total_count(run_id: String) -> int:
+	return int(get_run_page(run_id, 0, 0).total_count)
+
+
+func get_run_page(run_id: String, offset: int, count: int) -> Dictionary:
+	var entries := _entries_for_run(run_id)
+	var start := mini(maxi(0, offset), entries.size())
+	var stop := mini(entries.size(), start + maxi(0, count))
+	var out: Array[Dictionary] = []
+	for i in range(start, stop):
+		out.append(entries[i])
+	return {
+		"entries": out,
+		"total_count": entries.size(),
+	}
+
+
+func _entries_for_run(run_id: String) -> Array[Dictionary]:
+	var out: Array[Dictionary] = []
+	for entry in get_range(0, total_count()):
+		if str(entry.get("run_id", "")) == run_id:
+			out.append(entry)
+	return out
+
+
+func _generate_run_id() -> String:
 	## Opaque to agents — they only check equality. Time-based is plenty
-	## unique within a single editor session and avoids the RNG-seed
-	## reproducibility footgun.
-	return "r%d" % Time.get_ticks_msec()
+	## unique within a single editor session; the local sequence protects
+	## fast back-to-back test runs within the same millisecond.
+	_run_seq += 1
+	return "r%d-%d" % [Time.get_ticks_msec(), _run_seq]

--- a/src/godot_ai/tools/editor.py
+++ b/src/godot_ai/tools/editor.py
@@ -90,9 +90,12 @@ def register_editor_tools(mcp: FastMCP, *, include_non_core: bool = True) -> Non
         Sources:
         - "plugin" (default): MCP plugin recv/send/event traffic. Buffer 500.
         - "game": stdout/stderr/push_error/push_warning from playing game
-          via ``_mcp_game_helper`` autoload (Godot 4.5+). Buffer 2000, clears
-          on each ``project_run``. Entries: {source, level, text}; response
-          carries run_id, is_running, dropped_count.
+          via ``_mcp_game_helper`` autoload (Godot 4.5+). Buffer 2000, with
+          lines retained across runs and tagged by run_id. Default reads return
+          current-run lines only; pass ``since_run_id`` from an earlier response
+          to read that prior run. Entries: {source, level, text, run_id};
+          response carries run_id, current_run_id, is_running, game_status,
+          dropped_count, stale_run_id.
         - "editor": editor-process script errors and the Debugger dock's
           visible Errors-tab rows — parse errors, GDScript reload warnings,
           @tool/EditorPlugin runtime errors, push_error/push_warning.
@@ -106,9 +109,12 @@ def register_editor_tools(mcp: FastMCP, *, include_non_core: bool = True) -> Non
           are not captured.
         - "all": plugin → editor → game lines (with source per entry).
 
-        Tail pattern: for game logs, poll with offset=N + since_run_id=R.
-        ``stale_run_id: true`` means the buffer has rotated; reset offset to 0
-        and capture new run_id. For editor logs, read once to capture
+        Tail pattern: for game logs, poll the current run with offset=N and
+        keep the returned run_id. ``current_run_id`` identifies the active run;
+        ``run_id`` identifies the run being read. Passing
+        ``since_run_id=old_run_id`` reads retained lines for that prior run, and
+        ``stale_run_id: true`` means the requested run is not the current run.
+        For editor logs, read once to capture
         ``next_cursor`` and pass it back as ``since_cursor`` on later calls.
         ``since_cursor`` reads Logger-backed editor entries only; live Debugger
         Errors-tab rows are included in regular source="editor" reads but do
@@ -124,7 +130,8 @@ def register_editor_tools(mcp: FastMCP, *, include_non_core: bool = True) -> Non
             count: Max lines to return. Default 50.
             offset: Lines to skip. Default 0.
             source: "plugin" | "game" | "editor" | "all". Default "plugin".
-            since_run_id: Stale-detection token from a previous response.
+            since_run_id: Game-log run id from a previous response; reads that
+                retained run instead of the current run.
             since_cursor: Editor-log cursor from a previous source="editor" response.
             include_details: Include rich error metadata for game/editor entries.
             session_id: Optional Godot session to target. Empty = active session.

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -768,18 +768,21 @@ func test_game_log_buffer_ring_evicts_and_tracks_dropped() -> void:
 	assert_eq(first[0].text, "n 5")
 
 
-func test_game_log_buffer_clear_for_new_run_rotates_run_id() -> void:
+func test_game_log_buffer_clear_for_new_run_rotates_run_id_without_dropping_lines() -> void:
 	var buf := McpGameLogBuffer.new()
 	buf.append("info", "before")
-	## Time.get_ticks_msec changes between calls — guarantees distinct ids.
+	## Run ids include a sequence so fast back-to-back rotations differ.
 	var first_id := buf.clear_for_new_run()
 	assert_ne(first_id, "", "Initial clear should return a non-empty run id")
-	assert_eq(buf.total_count(), 0, "Buffer should be empty after clear")
-	OS.delay_msec(2)
+	assert_eq(buf.total_count(), 1, "Rotating should preserve prior lines")
+	assert_eq(buf.get_range(0, 1)[0].run_id, "", "Pre-run lines keep their original empty run id")
 	buf.append("info", "after")
 	var second_id := buf.clear_for_new_run()
 	assert_ne(first_id, second_id, "Each clear should rotate the run id")
-	assert_eq(buf.dropped_count(), 0, "dropped_count resets on new run")
+	assert_eq(buf.total_count(), 2, "Second rotation should still preserve history")
+	assert_eq(buf.get_run_range(first_id, 0, 10).size(), 1)
+	assert_eq(buf.get_run_range(first_id, 0, 10)[0].text, "after")
+	assert_eq(buf.get_run_range(second_id, 0, 10).size(), 0)
 
 
 func test_game_log_buffer_preserves_order_after_multiple_wraps() -> void:
@@ -902,6 +905,96 @@ func test_get_logs_source_game_returns_buffered_entries() -> void:
 	assert_ne(result.data.run_id, "", "run_id should be set after clear_for_new_run")
 
 
+func test_get_logs_source_game_defaults_to_current_run_only() -> void:
+	var game_buf := McpGameLogBuffer.new()
+	var first_id := game_buf.clear_for_new_run()
+	game_buf.append("info", "first run")
+	var second_id := game_buf.clear_for_new_run()
+	game_buf.append("info", "second run")
+	var handler := EditorHandler.new(McpLogBuffer.new(), null, null, game_buf)
+
+	var result := handler.get_logs({"source": "game", "count": 10})
+
+	assert_eq(result.data.run_id, second_id)
+	assert_eq(result.data.current_run_id, second_id)
+	assert_eq(result.data.total_count, 1)
+	assert_eq(result.data.lines.size(), 1)
+	assert_eq(result.data.lines[0].text, "second run")
+	assert_eq(result.data.lines[0].run_id, second_id)
+	assert_false(result.data.stale_run_id)
+	assert_eq(game_buf.get_run_range(first_id, 0, 10).size(), 1, "prior run remains retrievable")
+
+
+func test_get_logs_source_game_since_run_id_reads_prior_run() -> void:
+	var game_buf := McpGameLogBuffer.new()
+	var first_id := game_buf.clear_for_new_run()
+	game_buf.append("info", "first run")
+	var second_id := game_buf.clear_for_new_run()
+	game_buf.append("info", "second run")
+	var handler := EditorHandler.new(McpLogBuffer.new(), null, null, game_buf)
+
+	var result := handler.get_logs({"source": "game", "since_run_id": first_id, "count": 10})
+
+	assert_eq(result.data.run_id, first_id)
+	assert_eq(result.data.current_run_id, second_id)
+	assert_eq(result.data.lines.size(), 1)
+	assert_eq(result.data.lines[0].text, "first run")
+	assert_true(result.data.stale_run_id)
+
+
+func test_get_logs_source_game_no_hello_run_reports_not_live_without_stale_lines() -> void:
+	var game_buf := McpGameLogBuffer.new()
+	var previous_id := game_buf.clear_for_new_run()
+	game_buf.append("info", "previous run")
+	var plugin := McpDebuggerPlugin.new(null, game_buf)
+	plugin.begin_game_run(0, true)
+	var current_id := game_buf.run_id()
+	plugin._game_run_started_msec -= int(McpDebuggerPlugin.GAME_READY_WAIT_SEC * 1000.0) + 1
+	var handler := EditorHandler.new(McpLogBuffer.new(), null, plugin, game_buf)
+
+	var current := handler.get_logs({"source": "game", "count": 10})
+	var previous := handler.get_logs({"source": "game", "since_run_id": previous_id, "count": 10})
+
+	assert_eq(current.data.run_id, current_id)
+	assert_eq(current.data.lines.size(), 0, "current no-hello run must not inherit prior lines")
+	assert_eq(current.data.total_count, 0)
+	assert_eq(current.data.game_status.status, "not_live")
+	assert_eq(current.data.is_running, false)
+	assert_eq(previous.data.lines.size(), 1, "previous run is still retrievable explicitly")
+	assert_eq(previous.data.lines[0].text, "previous run")
+	assert_true(previous.data.stale_run_id)
+
+
+func test_get_logs_source_game_no_helper_counts_as_running() -> void:
+	var game_buf := McpGameLogBuffer.new()
+	var plugin := McpDebuggerPlugin.new(null, game_buf)
+	plugin.begin_game_run(0, false)
+	plugin._game_run_started_msec -= int(McpDebuggerPlugin.GAME_READY_WAIT_SEC * 1000.0) + 1
+	var handler := EditorHandler.new(McpLogBuffer.new(), null, plugin, game_buf)
+
+	var result := handler.get_logs({"source": "game", "count": 10})
+
+	assert_eq(result.data.game_status.status, "no_helper")
+	assert_eq(result.data.is_running, true)
+
+
+func test_get_logs_source_game_live_run_counts_as_running() -> void:
+	var game_buf := McpGameLogBuffer.new()
+	var plugin := McpDebuggerPlugin.new(null, game_buf)
+	plugin.begin_game_run(0, true)
+	var current_id := game_buf.run_id()
+	plugin._capture("mcp:hello", [], -1)
+	game_buf.append("info", "ready")
+	var handler := EditorHandler.new(McpLogBuffer.new(), null, plugin, game_buf)
+
+	var result := handler.get_logs({"source": "game", "count": 10})
+
+	assert_eq(result.data.game_status.status, "live")
+	assert_eq(result.data.is_running, true)
+	assert_eq(result.data.lines.size(), 1)
+	assert_eq(result.data.lines[0].run_id, current_id)
+
+
 func test_get_logs_include_details_returns_buffered_metadata() -> void:
 	var game_buf := McpGameLogBuffer.new()
 	game_buf.append("error", "game boom", {
@@ -955,6 +1048,25 @@ func test_get_logs_source_all_includes_both_streams() -> void:
 	assert_eq(result.data.lines[2].source, "game")
 	assert_eq(result.data.lines[2].level, "warn")
 	assert_eq(result.data.lines[2].text, "game-c")
+
+
+func test_get_logs_source_all_scopes_game_entries_to_current_run() -> void:
+	var plugin_buf := McpLogBuffer.new()
+	plugin_buf.log("plugin")
+	var game_buf := McpGameLogBuffer.new()
+	game_buf.clear_for_new_run()
+	game_buf.append("info", "old game")
+	var current_id := game_buf.clear_for_new_run()
+	game_buf.append("info", "current game")
+	var handler := EditorHandler.new(plugin_buf, null, null, game_buf)
+
+	var result := handler.get_logs({"source": "all", "count": 10})
+
+	assert_eq(result.data.run_id, current_id)
+	assert_eq(result.data.lines.size(), 2)
+	assert_contains(result.data.lines[0].text, "plugin")
+	assert_eq(result.data.lines[1].text, "current game")
+	assert_eq(result.data.lines[1].run_id, current_id)
 
 
 # ----- McpEditorLogBuffer (issue #231) -----
@@ -1744,14 +1856,16 @@ func test_debugger_plugin_log_batch_preserves_details() -> void:
 	assert_eq(entries[1].details.code, "WARN")
 
 
-func test_debugger_plugin_hello_rotates_run_id() -> void:
+func test_debugger_plugin_begin_game_run_rotates_run_id() -> void:
 	var game_buf := McpGameLogBuffer.new()
 	game_buf.append("info", "stale from previous run")
 	var plugin := McpDebuggerPlugin.new(null, game_buf)
 	plugin.begin_game_run()
+	var run_id := game_buf.run_id()
+	assert_ne(run_id, "", "begin_game_run should set a run_id")
+	assert_eq(game_buf.total_count(), 1, "begin_game_run should preserve prior lines")
 	plugin._capture("mcp:hello", [], 0)
-	assert_eq(game_buf.total_count(), 0, "hello should clear the game buffer")
-	assert_ne(game_buf.run_id(), "", "hello should set a run_id")
+	assert_eq(game_buf.run_id(), run_id, "hello should confirm liveness without rotating run identity")
 
 
 func test_debugger_plugin_readiness_is_scoped_to_current_run() -> void:
@@ -1948,14 +2062,15 @@ func test_debugger_plugin_ignores_hello_from_stale_session() -> void:
 	var game_buf := McpGameLogBuffer.new()
 	var plugin := McpDebuggerPlugin.new(null, game_buf)
 	plugin.begin_game_run()
+	var run_id := game_buf.run_id()
 	plugin._setup_session(22)
 	plugin._capture("mcp:hello", [], 21)
 	assert_false(plugin.is_game_capture_ready(), "hello from an old debugger session must not ready current run")
-	assert_eq(game_buf.run_id(), "", "stale hello must not rotate logs for current run")
+	assert_eq(game_buf.run_id(), run_id, "stale hello must not rotate logs for current run")
 
 	plugin._capture("mcp:hello", [], 22)
 	assert_true(plugin.is_game_capture_ready(), "hello from current session should ready capture")
-	assert_ne(game_buf.run_id(), "", "current hello rotates run logs")
+	assert_eq(game_buf.run_id(), run_id, "current hello confirms the existing run identity")
 
 
 func test_debugger_plugin_log_batch_no_buffer_is_safe() -> void:


### PR DESCRIPTION
## Summary

Addresses the stale game-log lifecycle problem from #597. Builds on #603 and #604.

This removes the second false-confidence signal from the parse/load failure path: `logs_read(source="game")` can no longer report stale lines from a prior run while the current run never reached `_mcp_game_helper`.

Game-log identity is now established at play-start, not at `mcp:hello`, so a no-hello run gets its own current run id even when the game fails before the helper can register.

## What changed

- Rotate game-log `run_id` in `begin_game_run()` instead of the `mcp:hello` path.
- Keep historical game-log lines instead of clearing them on run rotation.
- Tag game-log entries with their `run_id`.
- Make `logs_read(source="game")` return current-run lines by default.
- Add `since_run_id` support for retrieving prior-run lines explicitly.
- Add `game_status`, `current_run_id`, and `stale_run_id` to game-log responses.
- Compute `is_running` from `game_status`, not raw editor play-state:
  - `false` for `not_live` / `stopped`
  - `true` for `live` / `launching` / `no_helper`
- Scope `logs_read(source="all")` to current-run game lines so stale game lines do not leak through the combined view.
- Update `docs/TOOLS.md` for the changed game-log contract.

## Why

Before this change, a parse/load failure could leave editor play-state active while the helper never checked in. Because game-log identity was only created at `mcp:hello`, `logs_read(source="game")` could still expose the previous run's lines and report `is_running=true`.

That made a dead current run look alive and reinforced the wrong agent conclusion.

After this change, a no-hello run reports as the current run with empty current-run game logs, `game_status.status="not_live"`, and `is_running=false`.

## Validation

- `test_run suite=editor`: 142 passed, 0 failed, 2 skipped
- Full `test_run`: 1490 passed, 0 failed, 19 skipped
- `git diff --check`: clean aside from existing line-ending warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Game log reads are now run-aware with `since_run_id` for older runs; default results return only the current run.
  * Game log responses now include `run_id`, `current_run_id`, `stale_run_id`, `game_status`, `is_running`, and `dropped_count`.
* **Bug Fixes**
  * New play sessions no longer mix buffered entries across runs; buffered lines retain their original run identifier.
  * Stale hello/ready handling no longer changes the active run identity.
* **Documentation**
  * Updated tool docs to explain run scoping, retention behavior, and the session status fields.
* **Tests**
  * Expanded coverage for run-scoped pagination and readiness/liveness transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->