### PR TITLE
Report game liveness from project_run

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -14,7 +14,7 @@ not the MCP tool names.
 
 | Tool | Description |
 |------|-------------|
-| `editor_state` | Editor version, project name, current scene, readiness, play state |
+| `editor_state` | Editor version, project name, current scene, readiness, play state, and game liveness status |
 | `scene_get_hierarchy` | Paginated scene tree walk (depth, offset, limit) |
 | `node_get_properties` | Full property snapshot of a node |
 | `session_activate` | Pin subsequent calls to a specific connected editor |
@@ -27,7 +27,7 @@ not the MCP tool names.
 | `node_create` / `node_set_property` / `node_find` | Common node writes + search |
 | `scene_open` / `scene_save` | Open and save scenes |
 | `script_create` / `script_attach` / `script_patch` | Create, attach, anchor-edit GDScript files |
-| `project_run` | Play the project (autosave persists in-memory MCP edits unless `autosave=False`) |
+| `project_run` | Play the project, then wait briefly for game liveness (autosave persists in-memory MCP edits unless `autosave=False`) |
 | `test_run` | Run GDScript test suites in the editor |
 | `logs_read` | Read plugin / game / editor / combined log buffers. `source="editor"` surfaces parse errors, GDScript reload warnings, @tool/EditorPlugin runtime errors, push_error/push_warning, and visible Debugger dock Errors-tab rows — use this when the editor's Output or Debugger Errors panel shows red/yellow rows |
 | `editor_screenshot` | Capture editor viewport, cinematic camera, or running game framebuffer |
@@ -40,6 +40,27 @@ Godot `_log_error` code/rationale when available, error type, resolved source
 location, and stack/error-tree context corresponding to the Debugger dock's
 Errors tab.
 
+`project_run` starts playback and waits briefly for the running game to become
+live through `_mcp_game_helper`. Its response includes `game_status`,
+`helper_live`, `session_active`, and any `recent_errors` found while waiting.
+The booleans are derived once inside `game_status` and mirrored at the top
+level for convenience.
+`game_status.status="live"` means the helper checked in. `"not_live"` means the
+game launched but did not become live before the helper-ready window elapsed;
+if a run-scoped parse/load error appeared, the response names it and points to
+`logs_read(source="editor", include_details=true)`. `"no_helper"` means the
+game launched but this project has no `_mcp_game_helper` autoload, as with some
+headless/custom-main-loop setups: `helper_live=false` while
+`session_active=true`. `"launching"` is a soft "not live yet" state and can
+reconcile on a later `editor_state` poll.
+
+`editor_state` includes the same `game_status` object in addition to the legacy
+`is_playing` boolean and `game_capture_ready`. It also mirrors
+`game_status.helper_live` (`game_status.status=="live"`) and
+`game_status.session_active` (`game_status.status` is not `"not_live"` or
+`"stopped"`). `is_playing` remains raw editor play-state for compatibility; use
+`game_status.status` for liveness decisions.
+
 For game logs, `logs_read(source="game")` returns lines from the current game
 run only. Each play-start creates a new `run_id`, even if the game never reaches
 the `_mcp_game_helper` hello beacon; prior run lines stay retained but do not
@@ -51,12 +72,15 @@ one. There is no single `source="game"` call that returns every retained game
 line across all runs; consumers that need history should retain run ids and
 query each run explicitly.
 
-Game and combined log responses also include `game_status` and a liveness-based
-`is_running`. `is_running` is no longer raw editor play-state: it is `false` for
+Game and combined log responses also include `game_status`, `helper_live`, and
+`session_active`; the top-level booleans mirror `game_status.helper_live` and
+`game_status.session_active`. For compatibility, `is_running` is retained as an
+alias of `session_active`; it is no longer raw editor play-state. Both are `false` for
 `game_status.status` of `"not_live"` or `"stopped"`, and `true` for `"live"`,
 `"launching"`, or `"no_helper"`. This lets a parse/load failure that leaves the
 editor play button active report as not running, while a legitimate headless or
-custom-main-loop project without `_mcp_game_helper` remains running with
+custom-main-loop project without `_mcp_game_helper` remains active with
+`helper_live=false`, `session_active=true`, and
 `game_status.status="no_helper"`.
 
 For incremental editor-log polling, call `logs_read(source="editor")` once and

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -142,6 +142,14 @@ func is_game_capture_ready() -> bool:
 	return _game_run_active and _game_ready and _ready_run_token == _game_run_token
 
 
+static func with_liveness_flags(status: Dictionary) -> Dictionary:
+	var enriched := status.duplicate(true)
+	var state := str(enriched.get("status", "stopped"))
+	enriched["helper_live"] = state == "live"
+	enriched["session_active"] = not state in ["not_live", "stopped"]
+	return enriched
+
+
 func get_game_status(now_msec: int = -1, ready_wait_sec: float = GAME_READY_WAIT_SEC) -> Dictionary:
 	var resolved_now := Time.get_ticks_msec() if now_msec < 0 else now_msec
 	var ready_wait_msec := maxi(0, int(ready_wait_sec * 1000.0))
@@ -157,7 +165,7 @@ func get_game_status(now_msec: int = -1, ready_wait_sec: float = GAME_READY_WAIT
 			status = "not_live"
 		else:
 			status = "launching"
-	return {
+	return with_liveness_flags({
 		"status": status,
 		"run_token": _game_run_token,
 		"active": _game_run_active,
@@ -167,12 +175,12 @@ func get_game_status(now_msec: int = -1, ready_wait_sec: float = GAME_READY_WAIT
 		"elapsed_msec": elapsed_msec,
 		"ready_wait_msec": ready_wait_msec,
 		"editor_log_cursor": _game_run_started_editor_cursor,
-	}
+	})
 
 
 func _explain_not_live(status: Dictionary, code: String = ErrorCodes.INTERNAL_ERROR) -> Dictionary:
 	var state := str(status.get("status", "stopped"))
-	var errors_info := _recent_editor_errors_since(int(status.get("editor_log_cursor", 0)))
+	var errors_info := recent_editor_errors_since(int(status.get("editor_log_cursor", 0)))
 	var recent_errors: Array = errors_info.get("errors", [])
 	var recent_errors_scope := str(errors_info.get("scope", "none"))
 	var truncated := bool(errors_info.get("truncated", false))
@@ -207,6 +215,10 @@ func _explain_not_live(status: Dictionary, code: String = ErrorCodes.INTERNAL_ER
 	inner["data"] = data
 	err["error"] = inner
 	return err
+
+
+func recent_editor_errors_since(cursor: int) -> Dictionary:
+	return _recent_editor_errors_since(cursor)
 
 
 func _recent_editor_errors_since(cursor: int) -> Dictionary:

--- a/plugin/addons/godot_ai/dispatcher.gd
+++ b/plugin/addons/godot_ai/dispatcher.gd
@@ -16,6 +16,7 @@ const DEFAULT_DEFERRED_TIMEOUT_MS := 4500
 const DEFERRED_TIMEOUT_MS_BY_COMMAND := {
 	"create_script": 4500,
 	"stop_project": 4500,
+	"run_project": 6000,
 	"take_screenshot": 30000,
 	"game_eval": 15000,
 	"game_command": 15000,

--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -28,6 +28,7 @@ func _init(log_buffer: McpLogBuffer, connection: McpConnection = null, debugger_
 
 func get_editor_state(_params: Dictionary) -> Dictionary:
 	var scene_root := EditorInterface.get_edited_scene_root()
+	var game_status := _current_game_status()
 	var data := {
 		"godot_version": Engine.get_version_info().get("string", "unknown"),
 		"project_name": ProjectSettings.get_setting("application/config/name", ""),
@@ -38,6 +39,9 @@ func get_editor_state(_params: Dictionary) -> Dictionary:
 		## false between Play→Stop cycles. Lets capture-source=game callers
 		## poll for a real ready signal instead of guessing with sleep().
 		"game_capture_ready": _debugger_plugin != null and _debugger_plugin.is_game_capture_ready(),
+		"game_status": game_status,
+		"helper_live": bool(game_status.get("helper_live", false)),
+		"session_active": bool(game_status.get("session_active", false)),
 	}
 	## Half-installed addon tree from a failed self-update rollback. When
 	## non-empty, the agent / dock paint the operator-facing recovery copy
@@ -93,18 +97,13 @@ func get_logs(params: Dictionary) -> Dictionary:
 
 func _current_game_status() -> Dictionary:
 	if _debugger_plugin == null:
-		return {
+		return McpDebuggerPlugin.with_liveness_flags({
 			"status": "stopped",
 			"active": false,
 			"ready": false,
 			"helper_expected": true,
-		}
+		})
 	return _debugger_plugin.get_game_status()
-
-
-func _is_game_log_running(game_status: Dictionary) -> bool:
-	var status := str(game_status.get("status", "stopped"))
-	return not status in ["not_live", "stopped"]
 
 
 func _get_plugin_logs(count: int, offset: int) -> Dictionary:
@@ -126,6 +125,8 @@ func _get_plugin_logs(count: int, offset: int) -> Dictionary:
 
 func _get_game_logs(count: int, offset: int, include_details: bool, since_run_id: String = "") -> Dictionary:
 	var game_status := _current_game_status()
+	var helper_live := bool(game_status.get("helper_live", false))
+	var session_active := bool(game_status.get("session_active", false))
 	if _game_log_buffer == null:
 		return {
 			"data": {
@@ -136,7 +137,9 @@ func _get_game_logs(count: int, offset: int, include_details: bool, since_run_id
 				"offset": offset,
 				"run_id": "",
 				"current_run_id": "",
-				"is_running": false,
+				"is_running": session_active,
+				"helper_live": helper_live,
+				"session_active": session_active,
 				"game_status": game_status,
 				"dropped_count": 0,
 				"stale_run_id": false,
@@ -156,7 +159,9 @@ func _get_game_logs(count: int, offset: int, include_details: bool, since_run_id
 			"offset": offset,
 			"run_id": target_run_id,
 			"current_run_id": current_run_id,
-			"is_running": _is_game_log_running(game_status),
+			"is_running": session_active,
+			"helper_live": helper_live,
+			"session_active": session_active,
 			"game_status": game_status,
 			"dropped_count": _game_log_buffer.dropped_count(),
 			"stale_run_id": stale_run_id,
@@ -266,7 +271,9 @@ func _get_all_logs(count: int, offset: int, include_details: bool) -> Dictionary
 			"offset": offset,
 			"run_id": run_id,
 			"current_run_id": current_run_id,
-			"is_running": _is_game_log_running(game_status),
+			"is_running": bool(game_status.get("session_active", false)),
+			"helper_live": bool(game_status.get("helper_live", false)),
+			"session_active": bool(game_status.get("session_active", false)),
 			"game_status": game_status,
 			"dropped_count": dropped,
 		}

--- a/plugin/addons/godot_ai/handlers/project_handler.gd
+++ b/plugin/addons/godot_ai/handlers/project_handler.gd
@@ -6,6 +6,7 @@ const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
 ## Handles project settings and filesystem search commands.
 
 const NodeHandler := preload("res://addons/godot_ai/handlers/node_handler.gd")
+const RUN_READY_WAIT_SEC := 3.0
 
 var _connection: McpConnection
 var _debugger_plugin
@@ -83,16 +84,15 @@ func run_project(params: Dictionary) -> Dictionary:
 	# stop-not-running case in telemetry). Surface state via was_already_running
 	# so a caller wanting a *different* scene can detect and stop+restart.
 	if EditorInterface.is_playing_scene():
-		return {
-			"data": {
-				"mode": mode,
-				"scene": params.get("scene", ""),
-				"autosave": autosave,
-				"was_already_running": true,
-				"undoable": false,
-				"reason": "Project was already running; no action taken",
-			}
-		}
+		return _run_project_current_liveness_response(
+			_run_project_base_data(
+				mode,
+				str(params.get("scene", "")),
+				autosave,
+				true,
+				"Project was already running; no action taken"
+			)
+		)
 
 	var validation_error: Variant = null
 	if mode == "custom":
@@ -144,16 +144,19 @@ func run_project(params: Dictionary) -> Dictionary:
 	if _connection:
 		_connection.pause_processing = false
 
-	return {
-		"data": {
-			"mode": mode,
-			"scene": params.get("scene", ""),
-			"autosave": autosave,
-			"was_already_running": false,
-			"undoable": false,
-			"reason": "Play/stop is a runtime action",
-		}
-	}
+	var base_data := _run_project_base_data(
+		mode,
+		str(params.get("scene", "")),
+		autosave,
+		false,
+		"Play/stop is a runtime action"
+	)
+	var request_id: String = params.get("_request_id", "")
+	if _connection != null and _debugger_plugin != null and not request_id.is_empty():
+		_finish_run_project_deferred(request_id, base_data)
+		return McpDispatcher.DEFERRED_RESPONSE
+
+	return _run_project_current_liveness_response(base_data)
 
 
 func _editor_log_cursor() -> int:
@@ -162,6 +165,150 @@ func _editor_log_cursor() -> int:
 
 func _game_helper_autoload_expected() -> bool:
 	return ProjectSettings.has_setting("autoload/_mcp_game_helper")
+
+
+func _run_project_base_data(
+	mode: String,
+	scene: String,
+	autosave: bool,
+	was_already_running: bool,
+	reason: String
+) -> Dictionary:
+	return {
+		"mode": mode,
+		"scene": scene,
+		"autosave": autosave,
+		"was_already_running": was_already_running,
+		"undoable": false,
+		"reason": reason,
+	}
+
+
+func _run_project_current_liveness_response(base_data: Dictionary) -> Dictionary:
+	if _debugger_plugin == null:
+		return {"data": base_data}
+	var status: Dictionary = _debugger_plugin.get_game_status(-1, RUN_READY_WAIT_SEC)
+	var errors_info: Dictionary = _debugger_plugin.recent_editor_errors_since(int(status.get("editor_log_cursor", 0)))
+	return _run_project_response(base_data, _run_project_liveness_decision(status, errors_info))
+
+
+func _finish_run_project_deferred(request_id: String, base_data: Dictionary) -> void:
+	var tree := _connection.get_tree()
+	while true:
+		await tree.process_frame
+		if not is_instance_valid(_connection):
+			return
+		var pre_status: Dictionary = _debugger_plugin.get_game_status(-1, RUN_READY_WAIT_SEC)
+		if (
+			not EditorInterface.is_playing_scene()
+			and int(pre_status.get("elapsed_msec", 0)) > 100
+			and str(pre_status.get("status", "stopped")) == "launching"
+		):
+			_debugger_plugin.end_game_run()
+		var status: Dictionary = _debugger_plugin.get_game_status(-1, RUN_READY_WAIT_SEC)
+		var errors_info: Dictionary = _debugger_plugin.recent_editor_errors_since(int(status.get("editor_log_cursor", 0)))
+		var decision := _run_project_liveness_decision(status, errors_info)
+		if not bool(decision.get("resolve", false)):
+			continue
+		_connection.send_deferred_response(request_id, _run_project_response(base_data, decision))
+		return
+
+
+func _run_project_response(base_data: Dictionary, decision: Dictionary) -> Dictionary:
+	var data := base_data.duplicate(true)
+	var game_status: Dictionary = decision.get("game_status", {})
+	data["game_status"] = game_status
+	data["helper_live"] = bool(game_status.get("helper_live", false))
+	data["session_active"] = bool(game_status.get("session_active", false))
+	if bool(data.get("was_already_running", false)):
+		data["reason"] = _run_project_already_running_message(decision)
+	else:
+		data["reason"] = decision.get("message", data.get("reason", "Play/stop is a runtime action"))
+	data["recent_errors"] = decision.get("recent_errors", [])
+	data["recent_errors_scope"] = decision.get("recent_errors_scope", "none")
+	data["recent_errors_may_predate_run"] = decision.get("recent_errors_may_predate_run", false)
+	data["recent_errors_truncated"] = decision.get("recent_errors_truncated", false)
+	return {"data": data}
+
+
+func _run_project_already_running_message(decision: Dictionary) -> String:
+	var state := str(decision.get("liveness_status", "unknown"))
+	match state:
+		"live":
+			return "Project was already running; the Godot AI game helper is live."
+		"not_live":
+			var errors: Array = decision.get("recent_errors", [])
+			var scope := str(decision.get("recent_errors_scope", "none"))
+			if not errors.is_empty() and scope == "run":
+				return "Project was already running but failed to load before the Godot AI game helper registered: %s. Check logs_read(source='editor', include_details=true)." % _format_editor_error_summary(errors[0])
+			if not errors.is_empty():
+				return "Project was already running but is not responding. A recent editor error may be related, but may predate this run: %s. Check logs_read(source='editor', include_details=true)." % _format_editor_error_summary(errors[0])
+			return "Project was already running but did not become live before the helper-ready window elapsed. Check logs_read(source='editor', include_details=true) and poll editor_state."
+		"no_helper":
+			return "Project was already running, but no _mcp_game_helper autoload is expected. Headless or custom-main-loop projects cannot confirm helper liveness."
+		"launching":
+			return "Project was already running and is still waiting for the Godot AI game helper to register. Poll editor_state shortly."
+		"stopped":
+			return "Project was already marked playing by the editor, but no active game liveness run exists."
+		_:
+			return "Project was already running; current liveness status is %s." % state
+
+
+func _run_project_liveness_decision(status: Dictionary, errors_info: Dictionary = {}) -> Dictionary:
+	var enriched_status := McpDebuggerPlugin.with_liveness_flags(status)
+	var state := str(status.get("status", "stopped"))
+	var recent_errors: Array = errors_info.get("errors", [])
+	var errors_scope := str(errors_info.get("scope", "none"))
+	var truncated := bool(errors_info.get("truncated", false))
+	var correlated_error := not recent_errors.is_empty() and errors_scope == "run"
+	var elapsed_msec := int(status.get("elapsed_msec", 0))
+	var ready_wait_msec := int(status.get("ready_wait_msec", int(RUN_READY_WAIT_SEC * 1000.0)))
+	var decision := {
+		"resolve": false,
+		"game_status": enriched_status,
+		"liveness_status": state,
+		"recent_errors": recent_errors,
+		"recent_errors_scope": errors_scope,
+		"recent_errors_may_predate_run": errors_scope == "retained_recent",
+		"recent_errors_truncated": truncated,
+		"message": "",
+	}
+	if state == "live":
+		decision["resolve"] = true
+		decision["message"] = "Game launched and the Godot AI game helper is live."
+	elif correlated_error:
+		decision["resolve"] = true
+		decision["liveness_status"] = "not_live"
+		decision["message"] = "Game launched but failed to load before the Godot AI game helper registered: %s. Check logs_read(source='editor', include_details=true)." % _format_editor_error_summary(recent_errors[0])
+		if truncated:
+			decision["message"] += " Editor logs since this run may be truncated; showing retained errors."
+	elif state == "not_live":
+		decision["resolve"] = true
+		if not recent_errors.is_empty():
+			decision["message"] = "Game launched but is not responding. A recent editor error may be related, but may predate this run: %s. Check logs_read(source='editor', include_details=true)." % _format_editor_error_summary(recent_errors[0])
+		else:
+			decision["message"] = "Game launched but did not become live before the helper-ready window elapsed. It may still be booting or may have failed silently; check logs_read(source='editor', include_details=true) and poll editor_state."
+	elif state == "no_helper":
+		decision["resolve"] = true
+		decision["message"] = "Game launched, but no _mcp_game_helper autoload is expected. Headless or custom-main-loop projects cannot confirm helper liveness; use editor_state and viewport/editor tools where applicable."
+	elif state == "stopped":
+		decision["resolve"] = true
+		decision["message"] = "The play session stopped, or no active game liveness run exists, before the Godot AI game helper became live."
+	elif state == "launching" and elapsed_msec >= ready_wait_msec:
+		decision["resolve"] = true
+		decision["message"] = "Game launched but is not yet live after %.1fs; it may still be booting. Poll editor_state and check logs_read(source='editor', include_details=true)." % (float(elapsed_msec) / 1000.0)
+	return decision
+
+
+func _format_editor_error_summary(entry: Dictionary) -> String:
+	var text := str(entry.get("text", "editor error"))
+	var path := str(entry.get("path", ""))
+	var line := int(entry.get("line", 0))
+	if not path.is_empty() and line > 0:
+		return "%s (%s:%d)" % [text, path, line]
+	if not path.is_empty():
+		return "%s (%s)" % [text, path]
+	return text
 
 
 func stop_project(params: Dictionary) -> Dictionary:

--- a/src/godot_ai/tools/editor.py
+++ b/src/godot_ai/tools/editor.py
@@ -63,6 +63,12 @@ def register_editor_tools(mcp: FastMCP, *, include_non_core: bool = True) -> Non
         the game has stopped — calling ``editor_state`` once syncs the cache
         and the next write proceeds. Issue #262.
 
+        Response includes ``game_status`` for authoritative game liveness,
+        plus ``helper_live`` (status == "live") and ``session_active``
+        (status not in {"not_live", "stopped"}) mirrored from the same fields
+        inside ``game_status``. ``is_playing`` remains raw editor play-state;
+        use ``game_status.status`` for liveness decisions.
+
         Args:
             session_id: Optional Godot session to target. Empty = active session.
         """
@@ -94,8 +100,10 @@ def register_editor_tools(mcp: FastMCP, *, include_non_core: bool = True) -> Non
           lines retained across runs and tagged by run_id. Default reads return
           current-run lines only; pass ``since_run_id`` from an earlier response
           to read that prior run. Entries: {source, level, text, run_id};
-          response carries run_id, current_run_id, is_running, game_status,
-          dropped_count, stale_run_id.
+          response carries run_id, current_run_id, game_status, helper_live,
+          session_active, dropped_count, stale_run_id. helper_live and
+          session_active mirror the same fields inside game_status; is_running
+          is retained as a compatibility alias of session_active.
         - "editor": editor-process script errors and the Debugger dock's
           visible Errors-tab rows — parse errors, GDScript reload warnings,
           @tool/EditorPlugin runtime errors, push_error/push_warning.

--- a/src/godot_ai/tools/project.py
+++ b/src/godot_ai/tools/project.py
@@ -55,6 +55,19 @@ def register_project_tools(mcp: FastMCP) -> None:
         ``data.was_already_running=true`` (no scene switch). To switch scenes,
         call ``project_manage(op="stop")`` first, then ``project_run`` again.
 
+        After starting playback, waits briefly for the Godot AI game helper to
+        check in. The response includes ``game_status``, ``helper_live``
+        (status == "live"), ``session_active`` (status not in {"not_live",
+        "stopped"}), and any ``recent_errors`` observed during the run window.
+        The top-level booleans mirror the same fields inside ``game_status``.
+        ``game_status.status="not_live"`` means playback launched but the game
+        did not become live before the helper-ready window elapsed;
+        ``"no_helper"`` means the project has no _mcp_game_helper autoload, as
+        with some headless/custom-main-loop setups (helper_live=false,
+        session_active=true); ``"stopped"`` means playback stopped or never
+        became active before liveness could be confirmed (helper_live=false,
+        session_active=false). Poll ``editor_state`` to see late transitions.
+
         Args:
             mode: "main" | "current" | "custom". Default "main".
             scene: Scene path (e.g. "res://levels/level1.tscn"). Required for "custom".

--- a/test_project/tests/test_dispatcher.gd
+++ b/test_project/tests/test_dispatcher.gd
@@ -2,6 +2,7 @@
 extends McpTestSuite
 
 const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+const ProjectHandler := preload("res://addons/godot_ai/handlers/project_handler.gd")
 
 ## Tests for McpDispatcher — specifically the crash-detection guardrail
 ## that catches handlers returning malformed results (null, empty dict,
@@ -208,6 +209,15 @@ func test_deferred_completion_removes_pending_entry() -> void:
 	assert_false(
 		d.complete_deferred_response("req-ok"),
 		"late duplicate deferred responses should be rejected",
+	)
+
+
+func test_run_project_has_deferred_timeout_budget() -> void:
+	assert_has_key(McpDispatcher.DEFERRED_TIMEOUT_MS_BY_COMMAND, "run_project")
+	assert_gt(
+		int(McpDispatcher.DEFERRED_TIMEOUT_MS_BY_COMMAND.run_project),
+		int(ProjectHandler.RUN_READY_WAIT_SEC * 1000.0),
+		"dispatcher timeout must exceed project_run's liveness wait window",
 	)
 
 

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -54,6 +54,12 @@ func test_editor_state_game_capture_ready_false_without_debugger_plugin() -> voi
 	var result := _handler.get_editor_state({})
 	assert_has_key(result.data, "game_capture_ready")
 	assert_eq(result.data.game_capture_ready, false)
+	assert_has_key(result.data, "game_status")
+	assert_eq(result.data.game_status.status, "stopped")
+	assert_eq(result.data.game_status.helper_live, false)
+	assert_eq(result.data.game_status.session_active, false)
+	assert_eq(result.data.helper_live, false)
+	assert_eq(result.data.session_active, false)
 
 
 func test_editor_state_game_capture_ready_tracks_debugger_plugin_flag() -> void:
@@ -69,6 +75,36 @@ func test_editor_state_game_capture_ready_tracks_debugger_plugin_flag() -> void:
 	plugin.begin_game_run()
 	result = handler.get_editor_state({})
 	assert_eq(result.data.game_capture_ready, false, "new project_run clears stale readiness immediately")
+
+
+func test_editor_state_game_status_tracks_debugger_plugin_lifecycle() -> void:
+	var plugin := McpDebuggerPlugin.new()
+	var handler := EditorHandler.new(McpLogBuffer.new(), null, plugin)
+
+	var result := handler.get_editor_state({})
+	assert_eq(result.data.game_status.status, "stopped")
+	assert_eq(result.data.game_status.helper_live, false)
+	assert_eq(result.data.game_status.session_active, false)
+	assert_eq(result.data.helper_live, false)
+	assert_eq(result.data.session_active, false)
+
+	plugin.begin_game_run(13, true)
+	result = handler.get_editor_state({})
+	assert_eq(result.data.game_status.status, "launching")
+	assert_eq(result.data.game_status.editor_log_cursor, 13)
+	assert_eq(result.data.game_status.helper_live, false)
+	assert_eq(result.data.game_status.session_active, true)
+	assert_eq(result.data.helper_live, false)
+	assert_eq(result.data.session_active, true)
+
+	plugin._capture("mcp:hello", [], -1)
+	result = handler.get_editor_state({})
+	assert_eq(result.data.game_status.status, "live")
+	assert_eq(result.data.game_capture_ready, true)
+	assert_eq(result.data.game_status.helper_live, true)
+	assert_eq(result.data.game_status.session_active, true)
+	assert_eq(result.data.helper_live, true)
+	assert_eq(result.data.session_active, true)
 
 
 # ----- get_selection -----
@@ -959,7 +995,11 @@ func test_get_logs_source_game_no_hello_run_reports_not_live_without_stale_lines
 	assert_eq(current.data.lines.size(), 0, "current no-hello run must not inherit prior lines")
 	assert_eq(current.data.total_count, 0)
 	assert_eq(current.data.game_status.status, "not_live")
+	assert_eq(current.data.game_status.helper_live, false)
+	assert_eq(current.data.game_status.session_active, false)
 	assert_eq(current.data.is_running, false)
+	assert_eq(current.data.helper_live, false)
+	assert_eq(current.data.session_active, false)
 	assert_eq(previous.data.lines.size(), 1, "previous run is still retrievable explicitly")
 	assert_eq(previous.data.lines[0].text, "previous run")
 	assert_true(previous.data.stale_run_id)
@@ -975,7 +1015,11 @@ func test_get_logs_source_game_no_helper_counts_as_running() -> void:
 	var result := handler.get_logs({"source": "game", "count": 10})
 
 	assert_eq(result.data.game_status.status, "no_helper")
+	assert_eq(result.data.game_status.helper_live, false)
+	assert_eq(result.data.game_status.session_active, true)
 	assert_eq(result.data.is_running, true)
+	assert_eq(result.data.helper_live, false)
+	assert_eq(result.data.session_active, true)
 
 
 func test_get_logs_source_game_live_run_counts_as_running() -> void:
@@ -990,7 +1034,11 @@ func test_get_logs_source_game_live_run_counts_as_running() -> void:
 	var result := handler.get_logs({"source": "game", "count": 10})
 
 	assert_eq(result.data.game_status.status, "live")
+	assert_eq(result.data.game_status.helper_live, true)
+	assert_eq(result.data.game_status.session_active, true)
 	assert_eq(result.data.is_running, true)
+	assert_eq(result.data.helper_live, true)
+	assert_eq(result.data.session_active, true)
 	assert_eq(result.data.lines.size(), 1)
 	assert_eq(result.data.lines[0].run_id, current_id)
 

--- a/test_project/tests/test_project.gd
+++ b/test_project/tests/test_project.gd
@@ -197,6 +197,134 @@ func test_run_project_autosave_false_restores_editor_setting() -> void:
 	editor_settings.set_setting(autosave_key, prior)
 
 
+func _run_status(status: String, elapsed_msec: int = 0, ready_wait_msec: int = 3000) -> Dictionary:
+	return {
+		"status": status,
+		"run_token": 1,
+		"active": status != "stopped",
+		"ready": status == "live",
+		"helper_expected": status != "no_helper",
+		"run_started_msec": 100,
+		"elapsed_msec": elapsed_msec,
+		"ready_wait_msec": ready_wait_msec,
+		"editor_log_cursor": 7,
+	}
+
+
+func _errors_info(errors: Array[Dictionary] = [], scope: String = "none", truncated: bool = false) -> Dictionary:
+	return {
+		"errors": errors,
+		"scope": scope,
+		"truncated": truncated,
+	}
+
+
+func test_run_project_liveness_decision_live_short_circuits() -> void:
+	var decision := _handler._run_project_liveness_decision(_run_status("live", 100), _errors_info())
+	assert_eq(decision.resolve, true)
+	assert_eq(decision.liveness_status, "live")
+	assert_contains(decision.message, "live")
+
+
+func test_run_project_liveness_decision_run_scoped_error_short_circuits() -> void:
+	var err := {"text": "Parse Error: Expected expression", "path": "res://broken.gd", "line": 4}
+	var decision := _handler._run_project_liveness_decision(
+		_run_status("launching", 100),
+		_errors_info([err], "run")
+	)
+	assert_eq(decision.resolve, true)
+	assert_eq(decision.liveness_status, "not_live")
+	assert_contains(decision.message, "failed to load")
+	assert_contains(decision.message, "res://broken.gd:4")
+	assert_eq(decision.recent_errors.size(), 1)
+	assert_eq(decision.recent_errors_scope, "run")
+
+
+func test_run_project_liveness_decision_retained_error_does_not_short_circuit_launching() -> void:
+	var err := {"text": "Parse Error: Old", "path": "res://old.gd", "line": 2}
+	var decision := _handler._run_project_liveness_decision(
+		_run_status("launching", 100),
+		_errors_info([err], "retained_recent")
+	)
+	assert_eq(decision.resolve, false)
+	assert_eq(decision.recent_errors_may_predate_run, true)
+
+
+func test_run_project_liveness_decision_not_live_without_errors_is_soft() -> void:
+	var decision := _handler._run_project_liveness_decision(_run_status("not_live", 3000), _errors_info())
+	assert_eq(decision.resolve, true)
+	assert_eq(decision.liveness_status, "not_live")
+	assert_contains(decision.message, "did not become live")
+	assert_false(decision.message.contains("crashed"), "no correlated error must not claim a crash")
+
+
+func test_run_project_liveness_decision_not_live_with_retained_error_is_labeled() -> void:
+	var err := {"text": "Parse Error: Old", "path": "res://old.gd", "line": 2}
+	var decision := _handler._run_project_liveness_decision(
+		_run_status("not_live", 3000),
+		_errors_info([err], "retained_recent")
+	)
+	assert_eq(decision.resolve, true)
+	assert_contains(decision.message, "may predate this run")
+	assert_eq(decision.recent_errors_may_predate_run, true)
+
+
+func test_run_project_liveness_decision_no_helper_resolves_running() -> void:
+	var decision := _handler._run_project_liveness_decision(_run_status("no_helper", 3000), _errors_info())
+	assert_eq(decision.resolve, true)
+	assert_eq(decision.liveness_status, "no_helper")
+	assert_contains(decision.message, "_mcp_game_helper")
+
+
+func test_run_project_liveness_decision_stopped_resolves_stop_race() -> void:
+	var decision := _handler._run_project_liveness_decision(_run_status("stopped", 250), _errors_info())
+	assert_eq(decision.resolve, true)
+	assert_eq(decision.liveness_status, "stopped")
+	assert_contains(decision.message, "stopped")
+
+
+func test_run_project_response_carries_liveness_shape() -> void:
+	var base := {
+		"mode": "main",
+		"scene": "",
+		"autosave": true,
+		"was_already_running": false,
+		"undoable": false,
+		"reason": "Play/stop is a runtime action",
+	}
+	var decision := _handler._run_project_liveness_decision(_run_status("live", 100), _errors_info())
+	var response := _handler._run_project_response(base, decision)
+	assert_has_key(response.data, "game_status")
+	assert_eq(response.data.game_status.status, "live")
+	assert_eq(response.data.game_status.helper_live, true)
+	assert_eq(response.data.game_status.session_active, true)
+	assert_eq(response.data.helper_live, true)
+	assert_eq(response.data.session_active, true)
+	assert_false(response.data.has("liveness_status"), "public response uses game_status.status")
+	assert_false(response.data.has("game_live"), "public response uses helper_live")
+	assert_has_key(response.data, "recent_errors")
+
+
+func test_run_project_response_carries_liveness_shape_when_already_running() -> void:
+	var base := _handler._run_project_base_data(
+		"main",
+		"",
+		true,
+		true,
+		"Project was already running; no action taken"
+	)
+	var decision := _handler._run_project_liveness_decision(_run_status("live", 100), _errors_info())
+	var response := _handler._run_project_response(base, decision)
+	assert_eq(response.data.was_already_running, true)
+	assert_has_key(response.data, "game_status")
+	assert_eq(response.data.game_status.status, "live")
+	assert_eq(response.data.game_status.helper_live, true)
+	assert_eq(response.data.game_status.session_active, true)
+	assert_eq(response.data.helper_live, true)
+	assert_eq(response.data.session_active, true)
+	assert_eq(response.data.reason, "Project was already running; the Godot AI game helper is live.")
+
+
 # ----- stop_project -----
 
 func test_stop_project_idempotent_when_not_playing() -> void:


### PR DESCRIPTION
## Summary

Closes #597.

Makes `project_run` truthful about game liveness instead of reporting success immediately after the editor play call. The handler now waits briefly for the `_mcp_game_helper` hello signal, short-circuits on live/check-in or run-scoped editor errors, and returns the same liveness vocabulary exposed by the rest of the #597 work.

This builds on #603, #604, and #605.

## Changes

- Convert `project_run` to the deferred response pattern with a short liveness wait.
- Return authoritative `game_status` from `project_run`, plus top-level convenience mirrors:
  - `helper_live`
  - `session_active`
- Add `game_status`, `helper_live`, and `session_active` to `editor_state`.
- Derive `helper_live` / `session_active` once in `McpDebuggerPlugin.get_game_status()` so `project_run`, `editor_state`, and `logs_read` share one definition.
- Keep `logs_read.is_running` as a compatibility alias for `session_active`.
- Reuse the editor-error correlation from #604 so parse/load errors surfaced before or during run are attached to the `project_run` response.
- Document the new `project_run`, `editor_state`, and `logs_read` liveness contract.

## Validation

- `test_run suite=editor`: 143 passed, 2 skipped
- `test_run suite=project`: 29 passed
- `test_run suite=dispatcher`: 18 passed
- Full windowed `test_run`: 1501 passed, 19 skipped
- Manual MCP smoke:
  - fresh `project_run` returns `game_status.status="live"`, `helper_live=true`, `session_active=true`
  - already-running `project_run` returns the same liveness fields with `was_already_running=true`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added richer liveness details to `editor_state` and `logs_read`, including helper and session activity indicators alongside `game_status`.
  * Enhanced `project_run` responses with liveness-aware status, optional recent editor errors, and improved “already running” behavior after playback starts.

* **Bug Fixes**
  * Aligned running/liveness semantics across editor and log views, including a compatibility alias for `is_running`.

* **Documentation**
  * Updated MCP tool documentation to reflect the new response schema and `game_status` interpretations.

* **Tests**
  * Expanded lifecycle and liveness decision coverage for run/login/readiness scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->