### PR TITLE
Suggest a free port inline + docs link for foreign port conflicts

### DIFF
--- a/docs/port-conflicts.md
+++ b/docs/port-conflicts.md
@@ -19,25 +19,33 @@ second half: changing the port and pointing your MCP clients at the new one.
 > older godot-ai server it *can* reclaim — click that rather than changing the
 > port. This guide is only for the foreign-process case.
 
-## 1. Pick a free port
+## 1. Pick free ports
 
-The crash body already suggests one (e.g. `8001`). On Windows that suggestion
-is checked against the Hyper-V / WSL2 / Docker reservation table, so it won't
-itself fail with `WinError 10013`. You can use the suggested port or choose
-your own free port.
+The plugin uses **two** ports: HTTP (`8000`, the one your MCP clients talk to)
+and WebSocket (`9500`, used internally between the server and the editor). The
+crash body suggests a free value for each (e.g. HTTP `8001`, WS `9501`). On
+Windows those suggestions are checked against the Hyper-V / WSL2 / Docker
+reservation table, so they won't themselves fail with `WinError 10013`. You can
+use the suggested ports or choose your own free ones.
 
-## 2. Change `godot_ai/http_port` in Editor Settings
+If only port `8000` is taken, you technically only need to move the HTTP port —
+but the incompatible-server case that lands you here can hold both, so changing
+both settings is the reliable fix.
+
+## 2. Change `godot_ai/http_port` and `godot_ai/ws_port` in Editor Settings
 
 1. In the Godot editor, open **Editor → Editor Settings**.
-2. Search for `godot_ai/http_port`.
-3. Set it to the free port from step 1 (e.g. `8001`).
+2. Search for `godot_ai/http_port` and set it to the free HTTP port from step 1
+   (e.g. `8001`).
+3. Search for `godot_ai/ws_port` and set it to the free WS port from step 1
+   (e.g. `9501`).
 4. Reload the plugin (toggle it off/on in **Project → Project Settings →
    Plugins**, or restart the editor).
 
-> **Note:** `godot_ai/http_port` is an **Editor Setting**, not a project
-> setting — it is stored per editor install, so the change applies to *every*
-> project you open with this editor. If you only hit the conflict on one
-> machine, remember to revert it later if the foreign process goes away.
+> **Note:** both are **Editor Settings**, not project settings — they are
+> stored per editor install, so the change applies to *every* project you open
+> with this editor. If you only hit the conflict on one machine, remember to
+> revert them later if the foreign process goes away.
 
 ## 3. Reconfigure your MCP clients
 
@@ -65,6 +73,7 @@ and format.
 
 ## Reverting
 
-If the foreign process is gone and you want `8000` back, set
-`godot_ai/http_port` back to `8000` (or clear the override) in Editor Settings,
-reload the plugin, and re-run **Configure all** to point your clients back.
+If the foreign process is gone and you want the defaults back, set
+`godot_ai/http_port` back to `8000` and `godot_ai/ws_port` back to `9500` (or
+clear the overrides) in Editor Settings, reload the plugin, and re-run
+**Configure all** to point your clients back.

--- a/docs/port-conflicts.md
+++ b/docs/port-conflicts.md
@@ -1,0 +1,70 @@
+# Port 8000 is in use by another process
+
+Godot AI's Python server listens on HTTP port `8000` (and WebSocket port
+`9500`). Port `8000` is a popular default for other dev tools — Django,
+`python -m http.server`, and many local servers grab it — so a genuinely
+foreign occupant is not rare.
+
+When a **non-godot-ai** process is already bound to `8000`, the dock can't
+reclaim the port (it has no proof it owns whatever is there), so it stops and
+shows a message like:
+
+> Port 8000 is occupied by an incompatible server. Port 8001 is free — set
+> `godot_ai/http_port` in Editor Settings, then update your client config.
+
+The crash panel names a concrete free port for you. This guide covers the
+second half: changing the port and pointing your MCP clients at the new one.
+
+> If the dock instead offers a **Restart Server** button, the occupant is an
+> older godot-ai server it *can* reclaim — click that rather than changing the
+> port. This guide is only for the foreign-process case.
+
+## 1. Pick a free port
+
+The crash body already suggests one (e.g. `8001`). On Windows that suggestion
+is checked against the Hyper-V / WSL2 / Docker reservation table, so it won't
+itself fail with `WinError 10013`. You can use the suggested port or choose
+your own free port.
+
+## 2. Change `godot_ai/http_port` in Editor Settings
+
+1. In the Godot editor, open **Editor → Editor Settings**.
+2. Search for `godot_ai/http_port`.
+3. Set it to the free port from step 1 (e.g. `8001`).
+4. Reload the plugin (toggle it off/on in **Project → Project Settings →
+   Plugins**, or restart the editor).
+
+> **Note:** `godot_ai/http_port` is an **Editor Setting**, not a project
+> setting — it is stored per editor install, so the change applies to *every*
+> project you open with this editor. If you only hit the conflict on one
+> machine, remember to revert it later if the foreign process goes away.
+
+## 3. Reconfigure your MCP clients
+
+Editor Settings only moves the *server*. Every MCP client still points at the
+old URL (`http://127.0.0.1:8000/mcp`), so they'll silently fail to connect
+until you update them too.
+
+The fastest way is the dock itself: each client row's **Configure** button
+rewrites that client's config with the current server URL, so once the server
+is on the new port, click **Configure** (or **Configure all**) again to rewrite
+every already-configured client.
+
+If you configured a client by hand, update its URL to use the new port. For
+example, for Claude Code:
+
+```bash
+claude mcp remove godot-ai
+claude mcp add --scope user --transport http godot-ai http://127.0.0.1:8001/mcp
+```
+
+For config-file clients (Codex, Antigravity, Cursor, …), edit the `url` /
+`serverUrl` field to match the new port. See the **Manual Client
+Configuration** section in the [README](../README.md) for each client's file
+and format.
+
+## Reverting
+
+If the foreign process is gone and you want `8000` back, set
+`godot_ai/http_port` back to `8000` (or clear the override) in Editor Settings,
+reload the plugin, and re-run **Configure all** to point your clients back.

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -40,6 +40,10 @@ const LogViewerScript := preload("res://addons/godot_ai/dock_panels/log_viewer.g
 const PortPickerPanelScript := preload("res://addons/godot_ai/dock_panels/port_picker_panel.gd")
 
 const DEV_MODE_SETTING := "godot_ai/dev_mode"
+## "Change the port + reconfigure your clients" guide. Surfaced from the crash
+## panel when a foreign process holds the HTTP port — the one piece of recovery
+## (per-client config rewrite) that doesn't fit in the inline crash body.
+const PORT_CONFLICT_DOCS := "https://github.com/hi-godot/godot-ai/blob/main/docs/port-conflicts.md"
 const CLIENT_STATUS_REFRESH_COOLDOWN_MSEC := 15 * 1000
 const CLIENT_STATUS_REFRESH_TIMEOUT_MSEC := 30 * 1000
 const CLIENT_ACTION_TIMEOUT_MSEC := 30 * 1000
@@ -195,6 +199,11 @@ var _crash_panel: VBoxContainer
 var _crash_output: RichTextLabel
 var _crash_restart_btn: Button
 var _crash_reload_btn: Button
+## Help link — visible only for the genuinely-foreign-occupant INCOMPATIBLE
+## case (no `can_recover_incompatible` proof). The inline body names a free
+## port; this button carries the per-client reconfigure steps that don't fit
+## inline. See `PORT_CONFLICT_DOCS` and `_update_crash_panel`.
+var _crash_docs_btn: Button
 ## Port-picker escape hatch — visible inside the crash panel when the root
 ## cause is port contention (PORT_EXCLUDED or FOREIGN_PORT). The dock writes
 ## the EditorSetting and reloads the plugin in response to the panel's
@@ -547,6 +556,13 @@ func _build_ui() -> void:
 	_crash_reload_btn.tooltip_text = "Re-run the spawn after fixing the underlying issue"
 	_crash_reload_btn.pressed.connect(_on_reload_plugin)
 	_crash_panel.add_child(_crash_reload_btn)
+
+	_crash_docs_btn = Button.new()
+	_crash_docs_btn.text = "How to change the port"
+	_crash_docs_btn.tooltip_text = "Open the guide: change godot_ai/http_port and reconfigure your MCP clients"
+	_crash_docs_btn.visible = false
+	_crash_docs_btn.pressed.connect(func(): OS.shell_open(PORT_CONFLICT_DOCS))
+	_crash_panel.add_child(_crash_docs_btn)
 
 	_crash_panel.add_child(HSeparator.new())
 	add_child(_crash_panel)
@@ -940,6 +956,15 @@ func _update_crash_panel(server_status: Dictionary) -> void:
 			not show_recovery_restart
 			and state != ServerStateScript.INCOMPATIBLE
 		)
+	## Docs link only for the genuinely-foreign occupant: a recoverable
+	## (older godot-ai) server gets Restart Server instead, and the inline
+	## body already names a free port — the link carries the per-client
+	## reconfigure steps that don't fit inline.
+	if _crash_docs_btn != null:
+		_crash_docs_btn.visible = (
+			state == ServerStateScript.INCOMPATIBLE
+			and not bool(server_status.get("can_recover_incompatible", false))
+		)
 
 	var port_picker_visible := (
 		state == ServerStateScript.PORT_EXCLUDED
@@ -969,9 +994,16 @@ static func _crash_body_for_state(state: int, server_status: Dictionary = {}) ->
 				if not message.is_empty():
 					return "%s Click Restart Server below to replace it with godot-ai v%s." % [message, expected]
 				return "Port %d is occupied by an older godot-ai server. Click Restart Server below to replace it with godot-ai v%s." % [port, expected]
+			## Genuinely foreign occupant (no recovery proof). Name a concrete
+			## free port so the user doesn't have to hunt for one, and let the
+			## crash panel's "How to change the port" link carry the per-client
+			## reconfigure steps. `suggest_free_port` already routes through the
+			## Windows reservation table, so the named port won't itself fail
+			## with WinError 10013.
+			var hint := _free_port_hint(port)
 			if not message.is_empty():
-				return message
-			return "Port %d is occupied by an incompatible server. Stop it or change both HTTP and WS ports." % port
+				return "%s %s" % [message, hint]
+			return "Port %d is occupied by an incompatible server. %s" % [port, hint]
 		ServerStateScript.FOREIGN_PORT:
 			return "Another process is already bound to port %d. Pick a free port or stop the other process." % port
 		ServerStateScript.CRASHED:
@@ -987,6 +1019,15 @@ static func _crash_body_for_state(state: int, server_status: Dictionary = {}) ->
 			return "No godot-ai server found. Install `uv` via the Setup panel above, or run `pip install godot-ai`."
 		_:
 			return ""
+
+
+## One sentence naming a concrete free port for the user to switch to. Routed
+## through `suggest_free_port` so the suggestion clears Windows' winnat
+## reservation table (no point suggesting a port that 10013s on bind). The
+## per-client reconfigure steps live behind the crash panel's docs link.
+static func _free_port_hint(port: int) -> String:
+	var free_port := ClientConfigurator.suggest_free_port(port + 1)
+	return "Port %d is free — set `godot_ai/http_port` in Editor Settings, then update your client config (How to change the port, below)." % free_port
 
 
 ## Build the mixed-state banner. Hidden until `_refresh_mixed_state_banner`

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -1025,13 +1025,18 @@ static func _crash_body_for_state(state: int, server_status: Dictionary = {}) ->
 			return ""
 
 
-## One sentence naming a concrete free port for the user to switch to. Routed
-## through `suggest_free_port` so the suggestion clears Windows' winnat
-## reservation table (no point suggesting a port that 10013s on bind). The
-## per-client reconfigure steps live behind the crash panel's docs link.
+## One sentence naming concrete free ports for the user to switch to. Names
+## BOTH http and ws: this branch also fires for an incompatible godot-ai
+## server we can't prove we own, which commonly holds both ports — moving only
+## http would then leave the new server unable to bind ws. Both suggestions are
+## routed through `suggest_free_port` so they clear Windows' winnat reservation
+## table (no point suggesting a port that 10013s on bind). Only the http port
+## reaches client configs; the ws port is server↔plugin, hence the wording.
+## The per-client reconfigure steps live behind the crash panel's docs link.
 static func _free_port_hint(port: int) -> String:
-	var free_port := ClientConfigurator.suggest_free_port(port + 1)
-	return "Port %d is free — set `godot_ai/http_port` in Editor Settings, then update your client config (How to change the port, below)." % free_port
+	var free_http := ClientConfigurator.suggest_free_port(port + 1)
+	var free_ws := ClientConfigurator.suggest_free_port(ClientConfigurator.ws_port() + 1)
+	return "Ports %d (HTTP) and %d (WS) are free — set `godot_ai/http_port` and `godot_ai/ws_port` in Editor Settings, then update your client config with the new HTTP port (How to change the port, below)." % [free_http, free_ws]
 
 
 ## URL for the port-conflict guide, pinned to the release tag that matches the

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -43,7 +43,11 @@ const DEV_MODE_SETTING := "godot_ai/dev_mode"
 ## "Change the port + reconfigure your clients" guide. Surfaced from the crash
 ## panel when a foreign process holds the HTTP port — the one piece of recovery
 ## (per-client config rewrite) that doesn't fit in the inline crash body.
-const PORT_CONFLICT_DOCS := "https://github.com/hi-godot/godot-ai/blob/main/docs/port-conflicts.md"
+## Resolved against the installed plugin version at click time (see
+## `_port_conflict_docs_url`) so a shipped build opens the guide as it shipped,
+## not tip-of-main, which may have drifted from that build's UI.
+const PORT_CONFLICT_DOCS_PATH := "docs/port-conflicts.md"
+const REPO_BLOB_BASE := "https://github.com/hi-godot/godot-ai/blob"
 const CLIENT_STATUS_REFRESH_COOLDOWN_MSEC := 15 * 1000
 const CLIENT_STATUS_REFRESH_TIMEOUT_MSEC := 30 * 1000
 const CLIENT_ACTION_TIMEOUT_MSEC := 30 * 1000
@@ -561,7 +565,7 @@ func _build_ui() -> void:
 	_crash_docs_btn.text = "How to change the port"
 	_crash_docs_btn.tooltip_text = "Open the guide: change godot_ai/http_port and reconfigure your MCP clients"
 	_crash_docs_btn.visible = false
-	_crash_docs_btn.pressed.connect(func(): OS.shell_open(PORT_CONFLICT_DOCS))
+	_crash_docs_btn.pressed.connect(func(): OS.shell_open(_port_conflict_docs_url()))
 	_crash_panel.add_child(_crash_docs_btn)
 
 	_crash_panel.add_child(HSeparator.new())
@@ -1028,6 +1032,17 @@ static func _crash_body_for_state(state: int, server_status: Dictionary = {}) ->
 static func _free_port_hint(port: int) -> String:
 	var free_port := ClientConfigurator.suggest_free_port(port + 1)
 	return "Port %d is free — set `godot_ai/http_port` in Editor Settings, then update your client config (How to change the port, below)." % free_port
+
+
+## URL for the port-conflict guide, pinned to the release tag that matches the
+## installed plugin version (releases are tagged `v<version>`). The crash-panel
+## button only exists in builds that ship `docs/port-conflicts.md`, so the
+## versioned ref always resolves — and a shipped build never points users at a
+## tip-of-main guide that has drifted from its own UI.
+static func _port_conflict_docs_url() -> String:
+	var version := ClientConfigurator.get_plugin_version()
+	var git_ref := ("v%s" % version) if not version.is_empty() else "main"
+	return "%s/%s/%s" % [REPO_BLOB_BASE, git_ref, PORT_CONFLICT_DOCS_PATH]
 
 
 ## Build the mixed-state banner. Hidden until `_refresh_mixed_state_banner`

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -1085,6 +1085,61 @@ func test_incompatible_server_hides_http_only_port_picker() -> void:
 	assert_false(_dock._port_picker_panel.visible, "HTTP-only picker must stay hidden")
 
 
+func test_foreign_incompatible_body_names_a_concrete_free_port() -> void:
+	## Issue #607 cheap version: the foreign-occupant crash body should hand
+	## the user a concrete free port (reservation-aware on Windows) and point
+	## them at Editor Settings + the client reconfigure, instead of leaving
+	## them to hunt for a port themselves.
+	var port := McpClientConfigurator.http_port()
+	var free_port := McpClientConfigurator.suggest_free_port(port + 1)
+	var body := McpDockScript._crash_body_for_state(
+		McpServerState.INCOMPATIBLE,
+		{"message": "Port %d is occupied by another process." % port},
+	)
+	assert_contains(body, "Port %d is free" % free_port,
+		"foreign-occupant body must name a concrete free port")
+	assert_contains(body, "godot_ai/http_port",
+		"foreign-occupant body must point at the Editor Setting to change")
+
+
+func test_recoverable_incompatible_body_keeps_restart_copy() -> void:
+	## A recoverable (older godot-ai) occupant must NOT be told to flee to a
+	## free port — reclaiming the port via Restart Server is the better path,
+	## so the free-port hint stays out of that branch.
+	var body := McpDockScript._crash_body_for_state(
+		McpServerState.INCOMPATIBLE,
+		{"can_recover_incompatible": true, "expected_version": "2.8.0"},
+	)
+	assert_contains(body, "Restart Server", "recoverable body must keep the restart guidance")
+	assert_false(body.contains("is free"), "recoverable body must not push a free-port switch")
+
+
+func test_foreign_incompatible_shows_docs_link_button() -> void:
+	## The "How to change the port" docs link carries the per-client
+	## reconfigure steps that don't fit inline. It belongs only to the
+	## genuinely-foreign case (no recovery proof).
+	_dock._build_ui()
+	_dock._update_crash_panel({
+		"state": McpServerState.INCOMPATIBLE,
+		"message": "Port 8000 is occupied by another process.",
+	})
+	assert_true(_dock._crash_docs_btn.visible,
+		"foreign-occupant case must surface the reconfigure docs link")
+
+
+func test_recoverable_incompatible_hides_docs_link_button() -> void:
+	## A recoverable godot-ai occupant gets Restart Server, not the
+	## change-the-port docs link.
+	_dock._build_ui()
+	_dock._update_crash_panel({
+		"state": McpServerState.INCOMPATIBLE,
+		"can_recover_incompatible": true,
+		"message": "Port 8000 is occupied by godot-ai server v1.2.10",
+	})
+	assert_false(_dock._crash_docs_btn.visible,
+		"recoverable case keeps Restart Server, not the docs link")
+
+
 # --- Signal-emit contracts on the audit-v2 #360 extracted subpanels ---
 # These pin the new panel boundary: panels emit; dock owns side effects.
 

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -1085,21 +1085,29 @@ func test_incompatible_server_hides_http_only_port_picker() -> void:
 	assert_false(_dock._port_picker_panel.visible, "HTTP-only picker must stay hidden")
 
 
-func test_foreign_incompatible_body_names_a_concrete_free_port() -> void:
+func test_foreign_incompatible_body_names_concrete_free_ports() -> void:
 	## Issue #607 cheap version: the foreign-occupant crash body should hand
-	## the user a concrete free port (reservation-aware on Windows) and point
+	## the user concrete free ports (reservation-aware on Windows) and point
 	## them at Editor Settings + the client reconfigure, instead of leaving
-	## them to hunt for a port themselves.
-	var port := McpClientConfigurator.http_port()
-	var free_port := McpClientConfigurator.suggest_free_port(port + 1)
+	## them to hunt for a port themselves. Names BOTH http and ws: this branch
+	## also fires for an incompatible godot-ai server that commonly holds both
+	## ports, so suggesting only http would leave the new server unable to
+	## bind ws.
+	var http_port := McpClientConfigurator.http_port()
+	var free_http := McpClientConfigurator.suggest_free_port(http_port + 1)
+	var free_ws := McpClientConfigurator.suggest_free_port(McpClientConfigurator.ws_port() + 1)
 	var body := McpDockScript._crash_body_for_state(
 		McpServerState.INCOMPATIBLE,
-		{"message": "Port %d is occupied by another process." % port},
+		{"message": "Port %d is occupied by another process." % http_port},
 	)
-	assert_contains(body, "Port %d is free" % free_port,
-		"foreign-occupant body must name a concrete free port")
+	assert_contains(body, "%d (HTTP)" % free_http,
+		"foreign-occupant body must name a concrete free HTTP port")
+	assert_contains(body, "%d (WS)" % free_ws,
+		"foreign-occupant body must name a concrete free WS port")
 	assert_contains(body, "godot_ai/http_port",
-		"foreign-occupant body must point at the Editor Setting to change")
+		"foreign-occupant body must point at the HTTP Editor Setting to change")
+	assert_contains(body, "godot_ai/ws_port",
+		"foreign-occupant body must point at the WS Editor Setting too")
 
 
 func test_recoverable_incompatible_body_keeps_restart_copy() -> void:

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -1127,6 +1127,21 @@ func test_foreign_incompatible_shows_docs_link_button() -> void:
 		"foreign-occupant case must surface the reconfigure docs link")
 
 
+func test_port_conflict_docs_url_is_pinned_to_installed_version() -> void:
+	## The docs button must open the guide as it shipped, not tip-of-main —
+	## so the URL is pinned to the release tag (`v<version>`) matching the
+	## installed plugin version. Guards against a regression back to a bare
+	## blob/main link that drifts away from older builds' UI.
+	var url := McpDockScript._port_conflict_docs_url()
+	var version := McpClientConfigurator.get_plugin_version()
+	assert_contains(url, "/blob/v%s/" % version,
+		"docs URL must pin to the installed plugin version's release tag")
+	assert_contains(url, McpDockScript.PORT_CONFLICT_DOCS_PATH,
+		"docs URL must point at the port-conflict guide")
+	assert_false(url.contains("/blob/main/"),
+		"docs URL must not hard-link to tip-of-main")
+
+
 func test_recoverable_incompatible_hides_docs_link_button() -> void:
 	## A recoverable godot-ai occupant gets Restart Server, not the
 	## change-the-port docs link.


### PR DESCRIPTION
Closes #607.

## Summary

Implements the **cheap version** from #607. When the HTTP port (default `8000`) is held by a genuinely **foreign** (non-godot-ai) process, the dock lands in terminal `INCOMPATIBLE` and tells the user *what* to do but leaves them with the chore — hunt for a free port, then hand-edit each MCP client config. This surfaces a concrete free port inline and adds a docs link carrying the reconfigure steps.

## Changes

- **Inline copy names a concrete free port.** `_crash_body_for_state` in `mcp_dock.gd` now appends a suggestion for the `INCOMPATIBLE && !can_recover_incompatible` case, e.g.:
  > Port 8001 is free — set `godot_ai/http_port` in Editor Settings, then update your client config (How to change the port, below).

  The suggestion comes from the existing `ClientConfigurator.suggest_free_port(...)`, which already routes through `WindowsPortReservation.suggest_non_excluded_port`, so the suggested port won't itself fail with `WinError 10013` on Windows. String/seam change only.

- **Docs link in the crash panel.** A new "How to change the port" button surfaces in the crash panel **only** for the foreign-occupant case, opening `docs/port-conflicts.md` — a short guide covering "change the port + reconfigure your clients" (the per-client reconfigure steps that don't fit inline).

- **New doc:** `docs/port-conflicts.md`.

## Scope / no behavior change

- Applies only to `INCOMPATIBLE && !can_recover_incompatible` (genuinely foreign occupant). When `can_recover_incompatible` is true (a stale/older godot-ai we can prove we own), **Restart Server** stays the primary action and the docs link/free-port hint are suppressed — reclaiming `8000` beats fleeing to a random port.
- No change to `PORT_EXCLUDED` / `FOREIGN_PORT` states or their `port_picker_panel`.

## Acceptance (cheap version)

- [x] Foreign-occupant `INCOMPATIBLE` crash body names a concrete free port (reservation-aware on Windows)
- [x] Docs link surfaced from the dock covering "change the port + reconfigure clients"
- [x] No behavior change for `PORT_EXCLUDED` / `FOREIGN_PORT` / recoverable-godot-ai (`can_recover_incompatible`) cases

## Testing

- `script/ci-check-gdscript` — clean (no parse errors).
- Full Godot handler suite via `script/ci-godot-tests` against a live server + headless editor: **1505/1524 passed, 0 failed** (gap is pre-existing platform skips).
- New `test_dock.gd` coverage: foreign-occupant body names a free port + points at `godot_ai/http_port`; recoverable body keeps Restart Server copy and omits the free-port hint; docs button visibility is gated to the foreign case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwE7zCBJ6qvjk7wyw3X5aU

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwE7zCBJ6qvjk7wyw3X5aU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a version-pinned “How to change the port” help button in the dock’s crash panel for non-recoverable incompatible server situations.
  * Enhanced incompatible-server messaging with concrete free-port suggestions for both HTTP and WebSocket settings, including client reconfiguration guidance.

* **Documentation**
  * Added a step-by-step guide for resolving “Port 8000 is occupied” conflicts and updating MCP client URLs.

* **Tests**
  * Expanded dock UI/integration coverage for recoverable vs genuinely foreign incompatible cases, including verification that the reconfiguration docs link is pinned to the installed plugin version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->