### PR TITLE
Add dock readiness headline and client CTA

### DIFF
--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -69,6 +69,7 @@ var _status_icon: ColorRect
 var _status_label: Label
 var _client_grid: VBoxContainer
 var _client_configure_all_btn: Button
+var _client_empty_cta_btn: Button
 var _clients_summary_label: Label
 var _clients_window: Window
 var _dev_mode_toggle: CheckButton
@@ -685,6 +686,14 @@ func _build_ui() -> void:
 	add_child(clients_header_row)
 	add_child(clients_actions)
 
+	_client_empty_cta_btn = Button.new()
+	_client_empty_cta_btn.text = "Configure an AI client ->"
+	_client_empty_cta_btn.tooltip_text = "Open the Clients tab to configure an AI coding client for this Godot AI server."
+	_client_empty_cta_btn.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_client_empty_cta_btn.visible = false
+	_client_empty_cta_btn.pressed.connect(_on_open_clients_window)
+	add_child(_client_empty_cta_btn)
+
 	# Drift banner — hidden until a sweep finds at least one mismatched client.
 	_drift_banner = VBoxContainer.new()
 	_drift_banner.add_theme_constant_override("separation", 4)
@@ -860,7 +869,7 @@ func _build_client_row(client_id: String) -> void:
 # --- Status updates ---
 
 func _update_status() -> void:
-	var connected: bool = _connection.is_connected
+	var connected: bool = _connection != null and _connection.is_connected
 	## During plugin self-update there's a brief window where this dock
 	## script is already the new version (Godot hot-reloads scripts on
 	## file change) but `_plugin` is still the old `EditorPlugin` instance
@@ -887,7 +896,7 @@ func _update_status() -> void:
 		status_text = "Restarting server..."
 		status_color = COLOR_AMBER
 	elif connected:
-		status_text = "Connected"
+		status_text = _connected_status_text()
 		status_color = Color.GREEN
 	elif state == ServerStateScript.CRASHED:
 		var exit_ms: int = server_status.get("exit_ms", 0)
@@ -1623,6 +1632,30 @@ func _update_dev_section_buttons() -> void:
 		_dev_stop_btn.tooltip_text = stop_state["tooltip"]
 
 
+func _configured_client_count() -> int:
+	var configured := 0
+	for client_id in _client_rows:
+		var status: Client.Status = _client_rows[client_id].get("status", Client.Status.NOT_CONFIGURED)
+		if status == Client.Status.CONFIGURED:
+			configured += 1
+	return configured
+
+
+func _client_status_refresh_has_completed() -> bool:
+	return _last_client_status_refresh_completed_msec > 0
+
+
+func _connected_status_text() -> String:
+	var configured := _configured_client_count()
+	if configured == 0:
+		if not _client_status_refresh_has_completed():
+			return "Server connected · checking AI client configuration"
+		return "Server connected · no AI client configured"
+	if configured == 1:
+		return "Server connected · 1 AI client configured"
+	return "Server connected · %d AI clients configured" % configured
+
+
 func _on_install_uv() -> void:
 	match OS.get_name():
 		"Windows":
@@ -2159,7 +2192,10 @@ func _refresh_clients_summary() -> void:
 	_clients_summary_label.text = text
 	if _client_configure_all_btn != null:
 		_client_configure_all_btn.disabled = ClientRefreshStateScript.should_disable_client_actions(_refresh_state)
+	if _client_empty_cta_btn != null:
+		_client_empty_cta_btn.visible = configured == 0 and _client_status_refresh_has_completed()
 	_refresh_drift_banner(mismatched_ids)
+	_update_status()
 
 
 func _show_manual_command_for(client_id: String) -> void:

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -65,6 +65,11 @@ class _RefreshCountingDock extends McpDockScript:
 		action_completion_refreshes += 1
 
 
+class _ConnectionStub:
+	var is_connected := true
+	var server_version := ""
+
+
 static func _finished_thread_noop() -> void:
 	pass
 
@@ -156,6 +161,86 @@ func test_clients_header_and_actions_use_narrow_layout() -> void:
 	assert_true(tabs != null, "Clients & Tools window should contain a tab container")
 	assert_eq(tabs.get_tab_title(0), "Clients")
 	assert_eq(tabs.get_tab_title(1), "Tools")
+
+
+func test_connected_status_summarizes_client_readiness() -> void:
+	_dock._build_ui()
+	_dock._connection = _ConnectionStub.new()
+	_dock._last_client_status_refresh_completed_msec = 0
+
+	_dock._refresh_clients_summary()
+	assert_eq(
+		_dock._status_label.text,
+		"Server connected · checking AI client configuration",
+		"Connected status should not claim no clients before the initial status sweep completes",
+	)
+
+	_dock._last_client_status_refresh_completed_msec = Time.get_ticks_msec()
+	_dock._refresh_clients_summary()
+	assert_eq(
+		_dock._status_label.text,
+		"Server connected · no AI client configured",
+		"Connected status should tell first-run users the AI-client setup is not done",
+	)
+
+	var any_id := _first_client_id()
+	if any_id.is_empty():
+		skip("No clients registered")
+		return
+	_dock._apply_row_status(any_id, McpClient.Status.CONFIGURED)
+	_dock._refresh_clients_summary()
+	assert_eq(
+		_dock._status_label.text,
+		"Server connected · 1 AI client configured",
+		"Connected status should summarize configured AI clients once setup has started",
+	)
+
+	var ids := McpClientConfigurator.client_ids()
+	if ids.size() < 2:
+		skip("Need at least two clients registered")
+		return
+	_dock._apply_row_status(ids[1], McpClient.Status.CONFIGURED)
+	_dock._refresh_clients_summary()
+	assert_eq(
+		_dock._status_label.text,
+		"Server connected · 2 AI clients configured",
+		"Connected status should pluralize the configured-client count",
+	)
+
+
+func test_empty_client_cta_visible_only_until_a_client_is_configured() -> void:
+	_dock._build_ui()
+	_dock._last_client_status_refresh_completed_msec = 0
+	_dock._refresh_clients_summary()
+	assert_false(
+		_dock._client_empty_cta_btn.visible,
+		"CTA should stay hidden until the initial client status sweep proves there are no configured clients",
+	)
+
+	_dock._last_client_status_refresh_completed_msec = Time.get_ticks_msec()
+	_dock._refresh_clients_summary()
+	assert_true(
+		_dock._client_empty_cta_btn.visible,
+		"First-run dock should surface a direct configure-client CTA",
+	)
+
+	var any_id := _first_client_id()
+	if any_id.is_empty():
+		skip("No clients registered")
+		return
+	_dock._apply_row_status(any_id, McpClient.Status.CONFIGURED)
+	_dock._refresh_clients_summary()
+	assert_false(
+		_dock._client_empty_cta_btn.visible,
+		"CTA should collapse once at least one AI client is configured",
+	)
+
+	_dock._apply_row_status(any_id, McpClient.Status.NOT_CONFIGURED)
+	_dock._refresh_clients_summary()
+	assert_true(
+		_dock._client_empty_cta_btn.visible,
+		"CTA should reappear when the last configured AI client is removed",
+	)
 
 
 func test_drift_banner_hidden_when_no_mismatched_clients() -> void:


### PR DESCRIPTION
## Summary

Makes the dock headline answer the first user-facing readiness question: whether any AI client is configured to use the connected Godot AI server.

Previously, the top status could show a bare `Connected`, which only meant the editor was connected to the Python server. A first-time user with `0 / 19 configured` could reasonably read that as “setup is done,” even though no AI client could drive Godot yet.

## Changes

- Updates the connected status copy to include client readiness:
  - `Server connected · no AI client configured`
  - `Server connected · 1 AI client configured`
  - `Server connected · N AI clients configured`
- Adds a first-run dock CTA:
  - `Configure an AI client ->`
  - opens the existing Clients tab/window
- Hides the CTA once at least one client is configured.
- Shows the CTA again if the last configured client is removed.
- Keeps disconnected / starting / failure status states unchanged.

## Notes

This is the shallow readiness tier: it reflects configured-client presence from the dock’s existing client status cache. A later server-side follow-up can upgrade the same headline to true live-client readiness using active sessions / recent tool-call data.

A stale or mismatched client still does not count as configured for this server, so the headline can say no client is configured while the drift banner explains the stale config.

## Tests

- `bash script/ci-check-gdscript`
- `test_run suite="dock"` → 63 passed, 0 failed, 3 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a clearer empty-state button in the Clients section when no AI clients are configured.
  * Improved connected status messaging, including “checking” feedback and correct 0/1/many configured-client text.

* **Bug Fixes**
  * Hardened connection status handling to safely cope when connection data isn’t available.
  * Updated the client summary UI so the empty-state button visibility and status label correctly update during configuration changes.

* **Tests**
  * Added deterministic coverage for connected status transitions and empty-state button visibility rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->