### PR TITLE
Steer "Unknown resource type" toward filesystem_manage(op="scan")

### DIFF
--- a/plugin/addons/godot_ai/handlers/resource_handler.gd
+++ b/plugin/addons/godot_ai/handlers/resource_handler.gd
@@ -217,6 +217,25 @@ static func _validate_resource_class(type_str: String) -> Variant:
 	return null
 
 
+## Build the "Unknown resource type" error with a steer toward op="scan". A type
+## that reaches here is neither an engine built-in (ClassDB) nor a registered
+## project class (the global script-class registry). In an agent-driven workflow
+## the most common cause is a `class_name` script just made via script_create
+## that isn't registered yet — the global class table only rebuilds on a
+## filesystem scan (normally an editor-focus event). Point the caller at the one
+## cheap call that fixes that, so it doesn't fall back to a full plugin reload.
+## See #614 for the headless scan op.
+static func _unknown_resource_type_error(type_str: String) -> Dictionary:
+	return ErrorCodes.make(
+		ErrorCodes.VALUE_OUT_OF_RANGE,
+		(
+			"Unknown resource type: %s — not an engine built-in or a registered project class. "
+			+ "If you just created it with script_create, the global class table is stale until a "
+			+ "scan: call filesystem_manage(op=\"scan\"), then retry. Otherwise check the spelling."
+		) % type_str
+	)
+
+
 ## Resolve a resource type name to a fresh instance. Handles engine built-ins
 ## (ClassDB) and project `class_name` Resources (the global script-class
 ## registry). Returns a Resource on success, or an error dict on failure.
@@ -264,7 +283,7 @@ static func _instantiate_resource(type_str: String) -> Variant:
 			if made == null or not (made is Resource):
 				return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to instantiate %s as a Resource" % type_str)
 			return made
-	return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "Unknown resource type: %s" % type_str)
+	return _unknown_resource_type_error(type_str)
 
 
 ## Apply a dict of property values to a freshly-instantiated Resource,
@@ -415,7 +434,7 @@ func get_resource_info(params: Dictionary) -> Dictionary:
 		var custom_info: Variant = _custom_resource_info(type_str)
 		if custom_info != null:
 			return custom_info
-		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "Unknown resource type: %s" % type_str)
+		return _unknown_resource_type_error(type_str)
 	if ClassDB.is_parent_class(type_str, "Node"):
 		return ErrorCodes.make(
 			ErrorCodes.WRONG_TYPE,

--- a/test_project/tests/test_resource.gd
+++ b/test_project/tests/test_resource.gd
@@ -198,6 +198,9 @@ func test_create_resource_unknown_class() -> void:
 	})
 	assert_is_error(result)
 	assert_contains(result.error.message, "Unknown")
+	# Steer agents to the one cheap recovery for a just-created class_name
+	# instead of a full plugin reload (#614).
+	assert_contains(result.error.message, "filesystem_manage(op=\"scan\")")
 
 
 func test_create_resource_node_class_redirects_to_create_node() -> void:
@@ -328,6 +331,7 @@ func test_get_resource_info_unknown_type() -> void:
 	var result := _handler.get_resource_info({"type": "DefinitelyNotAClass_xyz"})
 	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
 	assert_contains(result.error.message, "Unknown resource type")
+	assert_contains(result.error.message, "filesystem_manage(op=\"scan\")")
 
 
 func test_get_resource_info_non_resource_type() -> void:
@@ -689,8 +693,9 @@ func test_instantiate_resource_custom_class_name() -> void:
 
 
 func test_instantiate_resource_unknown_type_errors() -> void:
-	assert_is_error(ResourceHandler._instantiate_resource("NotARealType_xyz"),
-		ErrorCodes.VALUE_OUT_OF_RANGE)
+	var result = ResourceHandler._instantiate_resource("NotARealType_xyz")
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
+	assert_contains(result.error.message, "filesystem_manage(op=\"scan\")")
 
 
 func test_create_resource_custom_class_to_file() -> void:


### PR DESCRIPTION
## Why

Follow-up to #614. A blind end-to-end test (a Haiku agent, no memory of the prior work) of the headless `class_name` flow surfaced a real **discoverability gap**: when a freshly-created `class_name` isn't registered yet, `resource_manage(op="create")` fails with a bare `Unknown resource type: Foo`. That error says nothing about scanning, so the agent **fell back to two full `editor_reload_plugin` calls** instead of the one cheap `filesystem_manage(op="scan")` that #614 added — even though the op and the `script_create` `scan_required` hint were both available.

The proactive hint rides on the `script_create` response (easy for a weaker model to skip). This PR covers the **reactive** path: meet the agent at the point it actually fails.

## What

Route the two reachable `Unknown resource type` sites — `_instantiate_resource` (used by `resource_create` **and** the `{"__class__": ...}` shortcut) and `get_resource_info` — through one helper:

> Unknown resource type: Foo — not an engine built-in or a registered project class. If you just created it with `script_create`, the global class table is stale until a scan: call `filesystem_manage(op="scan")`, then retry. Otherwise check the spelling.

Conditional wording, so it's accurate for both the unregistered-class case and a plain typo. No behavior change beyond the message.

## Tests

Extended the existing unknown-type GUT cases (`create_resource`, `get_resource_info`, `_instantiate_resource`) to assert the steer is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “unknown resource type” errors to include a clearer recovery hint, directing users to run a filesystem scan after creating a script.
  * Applied the updated error message consistently when creating resources and viewing resource details.

* **Tests**
  * Updated validation to ensure the new guidance appears in relevant error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->