### PR TITLE
Reject uncoercible Color strings instead of silently writing black

### DIFF
--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -706,7 +706,15 @@ static func _coerce_value(value: Variant, target_type: int) -> Variant:
 			if value is Dictionary and value.has_all(COLOR_KEYS):
 				return Color(value["r"], value["g"], value["b"], value.get("a", 1.0))
 			if value is String:
-				return Color(value)
+				# Color(String) silently returns black for an unparseable string
+				# (e.g. "Color(1,1,1,1)" or a typo). Validate with the two-sentinel
+				# from_string idiom (see theme_handler/material_values); on failure
+				# fall through so the value stays a String and _check_coerced flags
+				# it as an error instead of writing black.
+				var col_a := Color.from_string(value, Color(0, 0, 0, 0))
+				var col_b := Color.from_string(value, Color(1, 1, 1, 1))
+				if col_a == col_b:
+					return col_a
 		TYPE_BOOL:
 			if value is float or value is int:
 				return bool(value)

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -386,6 +386,18 @@ func test_set_property_color_rejects_vector3_shaped_dict() -> void:
 	assert_true(coerced is Dictionary, "Wrong-shape dict must flow through unchanged so caller's type check fires")
 
 
+func test_coerce_value_color_rejects_unparseable_string() -> void:
+	## "Color(1,1,1,1)" isn't a named or hex color; Color(String) would silently
+	## return black. It must flow through unchanged so the caller's type check
+	## fires instead of writing black — while valid named/hex strings still coerce.
+	var bad = NodeHandler._coerce_value("Color(1, 1, 1, 1)", TYPE_COLOR)
+	assert_true(bad is String, "Unparseable color string must flow through unchanged, not become black")
+	var hex = NodeHandler._coerce_value("#ff4400", TYPE_COLOR)
+	assert_true(hex is Color, "hex string must still coerce")
+	assert_ne(hex, Color(0, 0, 0, 1), "valid hex must parse to its color, not black")
+	assert_true(NodeHandler._coerce_value("red", TYPE_COLOR) is Color, "named color must still coerce")
+
+
 # ----- #191 — non-dict inputs to compound targets must error loudly -----
 
 func test_set_property_vector3_rejects_array_input() -> void:


### PR DESCRIPTION
## Why

Surfaced by the same blind test as #615. The agent passed a Color as the string `"Color(1,1,1,1)"` to `resource_manage(op="create")`. `Color(String)` only accepts **named** (`"red"`) or **hex** (`"#ff4400"`) strings — anything else returns **black** `Color(0,0,0,1)` with no error. So the agent got black blades, no signal, and had to hand-edit the `.tres` files to recover. A wrong guess at the encoding should fail loudly, not write wrong data.

## What

In `NodeHandler._coerce_value`, validate Color strings with the two-sentinel `Color.from_string` idiom already used by `theme_handler` / `material_values` (call it with two distinct defaults; if they disagree, the parse failed). On failure, **fall through** so the value stays a `String` — the existing `_check_coerced` guard then reports a proper coercion error instead of `res.set()` silently writing black.

No change for valid inputs: named strings, hex strings, and `{"r":..,"g":..,"b":..,"a":..}` dicts all still coerce. Benefits both `resource_create` and `node_set_property`, which share this coercer.

## Test

`_coerce_value("Color(1,1,1,1)", TYPE_COLOR)` now flows through as a `String` (caught downstream), while `"#ff4400"` and `"red"` still coerce to the right `Color`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved color input handling so invalid color strings are no longer silently accepted as a default value.
  * Unparseable color text now stays unchanged, allowing type mismatches to be surfaced instead of being hidden.
  * Valid color values continue to convert correctly as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->