### PR TITLE
Document --allow-host for remote/LAN MCP access in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,26 @@ The plugin starts or reuses the Python server, connects over WebSocket, and expo
 </details>
 
 <details>
+<summary><strong>Remote / LAN access (<code>--allow-host</code>)</strong></summary>
+
+The MCP server binds to `127.0.0.1` by default. To reach it from another
+machine on your network (e.g. a remote coding agent), pass `--allow-host`
+with a CIDR or bare IP when launching the server:
+
+```bash
+godot-ai --allow-host 192.168.1.0/24
+```
+
+This binds the HTTP transport off loopback and gates every request on the
+real (unforgeable) socket peer address, so only hosts inside the named
+range(s) get in — DNS-rebinding defenses (Origin / Host / Sec-Fetch-Site
+checks) stay active. The plugin's WebSocket bridge to the editor always
+stays loopback-only since it's unauthenticated. Only name ranges you trust;
+prefer an SSH tunnel or Tailscale on untrusted networks.
+
+</details>
+
+<details>
 <summary><strong>Windows: <code>uvx mcp-proxy</code> won't start (<code>pywin32</code> install fails)</strong></summary>
 
 Symptom (in your MCP client's server log):

--- a/README.md
+++ b/README.md
@@ -166,7 +166,8 @@ The plugin starts or reuses the Python server, connects over WebSocket, and expo
 
 The MCP server binds to `127.0.0.1` by default. To reach it from another
 machine on your network (e.g. a remote coding agent), pass `--allow-host`
-with a CIDR or bare IP when launching the server:
+with one or more CIDRs or bare IPs (repeat the flag or comma-separate
+values) when launching the server:
 
 ```bash
 godot-ai --allow-host 192.168.1.0/24


### PR DESCRIPTION
## Summary
- `--allow-host` (issue #421) already lets the MCP server bind off loopback for a trusted LAN range, gated on the unforgeable socket peer address — but it was only discoverable via `--help`, so users assumed the loopback bind was a hard limit and reached for proxy workarounds.
- Adds a short collapsible README section next to the existing "How It Works" / Windows troubleshooting sections showing the flag, what it does, and the security guarantees that stay in place (peer-IP gate, Origin/Host/Sec-Fetch-Site checks, WebSocket bridge stays loopback-only).

## Test plan
- [x] Docs-only change; verified rendered Markdown structure matches existing `<details>` sections in README.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01LJnUaDrTHguF3q1jYnmUmF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Remote / LAN access (`--allow-host`)” subsection.
  * Clarified that the server listens on localhost by default, and `--allow-host` exposes the HTTP transport to other machines on the local network for specified CIDRs or IPs.
  * Explained the request-safety behavior to preserve DNS-rebinding protections.
  * Noted that the editor’s WebSocket bridge remains loopback-only, and provided guidance to trust only controlled name ranges or use safer options like SSH tunnels or Tailscale.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->