### PR TITLE
Update Antigravity client config path to ~/.gemini/config/mcp_config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ url = "http://127.0.0.1:8000/mcp"
 enabled = true
 ```
 
-**Antigravity** (`~/.gemini/antigravity/mcp_config.json`)
+**Antigravity** (`~/.gemini/config/mcp_config.json`)
 
 ```json
 {

--- a/plugin/addons/godot_ai/clients/antigravity.gd
+++ b/plugin/addons/godot_ai/clients/antigravity.gd
@@ -7,13 +7,20 @@ func _init() -> void:
 	display_name = "Antigravity"
 	config_type = "json"
 	doc_url = "https://www.antigravity.dev/"
+	## Antigravity moved its shared MCP config from `~/.gemini/antigravity/`
+	## to `~/.gemini/config/` (IDE + CLI now read the same file there); the
+	## old path is left in `detect_paths` below so an existing install is
+	## still recognized, but new/updated entries write to the current path.
 	path_template = {
-		"unix": "~/.gemini/antigravity/mcp_config.json",
-		"windows": "$USERPROFILE/.gemini/antigravity/mcp_config.json",
+		"unix": "~/.gemini/config/mcp_config.json",
+		"windows": "$USERPROFILE/.gemini/config/mcp_config.json",
 	}
 	server_key_path = PackedStringArray(["mcpServers"])
 	entry_url_field = "serverUrl"
 	## `disabled` is user-state (they may have flipped the entry off in the
 	## UI); seeded on first Configure but preserved across reconfigure.
 	entry_initial_fields = {"disabled": false}
-	detect_paths = PackedStringArray(path_template.values())
+	detect_paths = PackedStringArray(path_template.values() + [
+		"~/.gemini/antigravity/mcp_config.json",
+		"$USERPROFILE/.gemini/antigravity/mcp_config.json",
+	])


### PR DESCRIPTION
## Summary
- Antigravity restructured its config layout: the IDE and CLI now share `~/.gemini/config/mcp_config.json`, and the old `~/.gemini/antigravity/mcp_config.json` path our auto-configure wrote to is no longer read by current Antigravity versions (2.2.1+). Confirmed by a user report — auto-configure wrote a valid entry that Antigravity silently ignored until they moved it to the new path by hand.
- Updates `plugin/addons/godot_ai/clients/antigravity.gd` to write the new path, while keeping the old path in `detect_paths` so an existing install is still recognized for the dock's "installed" badge.
- Updates the manual-configuration path shown in `README.md` to match.

## Test plan
- [x] `bash script/ci-check-gdscript` — all GDScript parses cleanly
- [ ] CI: full GDScript test suite (`test_clients.gd`) on this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01LJnUaDrTHguF3q1jYnmUmF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the app’s local configuration path to use the current shared MCP config location.
  * Preserved compatibility with older config locations so existing setups continue to work without manual changes.

* **Documentation**
  * Aligned the README example with the updated configuration path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->