### PR TITLE
Error surfacing watermark

### DIFF
--- a/plugin/addons/godot_ai/connection.gd
+++ b/plugin/addons/godot_ai/connection.gd
@@ -462,11 +462,7 @@ static func _make_backpressure_error(
 
 
 func _stamp_error_watermark(response: Dictionary) -> void:
-	if surfaced_error_tracker == null:
-		return
-	if not surfaced_error_tracker.has_method("watermark"):
-		return
-	response["error_watermark"] = surfaced_error_tracker.watermark()
+	McpSurfacedErrorTracker.stamp_watermark(response, surfaced_error_tracker)
 
 
 ## Build a human-readable session ID of form "<slug>@<4hex>" from the project path.

--- a/plugin/addons/godot_ai/connection.gd
+++ b/plugin/addons/godot_ai/connection.gd
@@ -48,6 +48,7 @@ var server_version := ""
 
 var dispatcher
 var log_buffer
+var surfaced_error_tracker
 ## Set by plugin.gd when the HTTP port is occupied by an incompatible or
 ## unverified server. Keeping the Connection node alive lets handlers and the
 ## dock share one object, but no WebSocket is opened to the wrong server.
@@ -309,6 +310,8 @@ func send_deferred_response(request_id: String, payload: Dictionary) -> void:
 	## `readiness_after` payload field were ever dropped.
 	if not response.has("readiness"):
 		response["readiness"] = get_readiness()
+	if not response.has("error_watermark"):
+		_stamp_error_watermark(response)
 	if _send_json(response) and dispatcher != null:
 		dispatcher.complete_deferred_response(request_id)
 
@@ -403,6 +406,7 @@ func _handle_outbound_backpressure(
 		return false
 
 	var err_response := _make_backpressure_error(request_id, buffered_bytes, message_bytes)
+	_stamp_error_watermark(err_response)
 	var err_text := JSON.stringify(err_response)
 	var err_bytes := err_text.to_utf8_buffer().size()
 	if _would_exceed_outbound_backpressure(buffered_bytes, err_bytes):
@@ -455,6 +459,14 @@ static func _make_backpressure_error(
 			},
 		},
 	}
+
+
+func _stamp_error_watermark(response: Dictionary) -> void:
+	if surfaced_error_tracker == null:
+		return
+	if not surfaced_error_tracker.has_method("watermark"):
+		return
+	response["error_watermark"] = surfaced_error_tracker.watermark()
 
 
 ## Build a human-readable session ID of form "<slug>@<4hex>" from the project path.

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -82,6 +82,7 @@ var _game_run_token := 0
 var _ready_run_token := -1
 var _game_session_id := -1
 var _game_run_active := false
+var _manual_run_armed := false
 var _game_run_started_msec := 0
 var _game_run_started_editor_cursor := 0
 var _game_run_started_debugger_cursor := 0
@@ -110,8 +111,9 @@ func _has_capture(prefix: String) -> bool:
 ## plugin.gd's _enter_tree logs "plugin loaded", and ci-reload-test
 ## asserts "plugin loaded" is the first line after a plugin reload.
 func _setup_session(session_id: int) -> void:
+	_connect_session_stopped(session_id)
 	if EditorInterface.is_playing_scene() and not _game_run_active:
-		_begin_game_run_tracking(_editor_log_cursor(), true, true, false)
+		_begin_game_run_tracking(_editor_log_cursor(), true, true, true, true, true)
 	else:
 		_game_ready = false
 		_ready_run_token = -1
@@ -127,9 +129,12 @@ func _begin_game_run_tracking(
 	helper_expected: bool = true,
 	rotate_game_log: bool = true,
 	sticky_debugger_scan: bool = true,
+	quiet: bool = false,
+	manual_armed: bool = false,
 ) -> void:
 	_game_run_token += 1
 	_game_run_active = true
+	_manual_run_armed = manual_armed
 	_game_ready = false
 	_ready_run_token = -1
 	_game_session_id = -1
@@ -144,7 +149,7 @@ func _begin_game_run_tracking(
 	var run_id := ""
 	if _game_log_buffer and rotate_game_log:
 		run_id = _game_log_buffer.clear_for_new_run()
-	if _log_buffer:
+	if _log_buffer and not quiet:
 		var log_text := "[debug] game capture pending run token %d" % _game_run_token
 		if not run_id.is_empty():
 			log_text += " (run %s)" % run_id
@@ -157,11 +162,29 @@ func _editor_log_cursor() -> int:
 
 func end_game_run() -> void:
 	_game_run_active = false
+	_manual_run_armed = false
 	_game_ready = false
 	_ready_run_token = -1
 	_game_session_id = -1
 	if _surfaced_error_tracker != null:
 		_surfaced_error_tracker.note_game_run_stopped()
+
+
+func _connect_session_stopped(session_id: int) -> void:
+	var session = get_session(session_id)
+	if session == null:
+		return
+	var stopped := Callable(self, "_on_debugger_session_stopped").bind(session_id)
+	if not session.stopped.is_connected(stopped):
+		session.stopped.connect(stopped)
+
+
+func _on_debugger_session_stopped(session_id: int) -> void:
+	if not _manual_run_armed:
+		return
+	if _game_session_id != -1 and session_id != _game_session_id:
+		return
+	end_game_run()
 
 
 func is_game_capture_ready() -> bool:

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -110,12 +110,24 @@ func _has_capture(prefix: String) -> bool:
 ## plugin.gd's _enter_tree logs "plugin loaded", and ci-reload-test
 ## asserts "plugin loaded" is the first line after a plugin reload.
 func _setup_session(session_id: int) -> void:
-	_game_ready = false
-	_ready_run_token = -1
+	if EditorInterface.is_playing_scene() and not _game_run_active:
+		_begin_game_run_tracking(_editor_log_cursor(), true, true, false)
+	else:
+		_game_ready = false
+		_ready_run_token = -1
 	_game_session_id = session_id
 
 
 func begin_game_run(editor_log_cursor: int = 0, helper_expected: bool = true) -> void:
+	_begin_game_run_tracking(editor_log_cursor, helper_expected, true, true)
+
+
+func _begin_game_run_tracking(
+	editor_log_cursor: int = 0,
+	helper_expected: bool = true,
+	rotate_game_log: bool = true,
+	sticky_debugger_scan: bool = true,
+) -> void:
 	_game_run_token += 1
 	_game_run_active = true
 	_game_ready = false
@@ -124,19 +136,23 @@ func begin_game_run(editor_log_cursor: int = 0, helper_expected: bool = true) ->
 	_game_run_started_msec = Time.get_ticks_msec()
 	_game_run_started_editor_cursor = maxi(0, editor_log_cursor)
 	if _surfaced_error_tracker != null:
-		_surfaced_error_tracker.note_game_run_started()
+		_surfaced_error_tracker.note_game_run_started(sticky_debugger_scan)
 		_game_run_started_debugger_cursor = _surfaced_error_tracker.debugger_promoted_total()
 	else:
 		_game_run_started_debugger_cursor = 0
 	_game_helper_expected = helper_expected
 	var run_id := ""
-	if _game_log_buffer:
+	if _game_log_buffer and rotate_game_log:
 		run_id = _game_log_buffer.clear_for_new_run()
 	if _log_buffer:
 		var log_text := "[debug] game capture pending run token %d" % _game_run_token
 		if not run_id.is_empty():
 			log_text += " (run %s)" % run_id
 		_log_buffer.log(log_text)
+
+
+func _editor_log_cursor() -> int:
+	return _editor_log_buffer.appended_total() if _editor_log_buffer != null else 0
 
 
 func end_game_run() -> void:
@@ -235,7 +251,11 @@ func _recent_editor_errors_since(cursor: int) -> Dictionary:
 	var out: Array[Dictionary] = []
 	var truncated := false
 	if _surfaced_error_tracker != null:
-		var captured_by_tracker: Dictionary = _surfaced_error_tracker.editor_entries_since(maxi(0, cursor), _game_run_started_debugger_cursor)
+		var captured_by_tracker: Dictionary = _surfaced_error_tracker.editor_entries_since(
+			maxi(0, cursor),
+			_game_run_started_debugger_cursor,
+			false,
+		)
 		truncated = bool(captured_by_tracker.get("truncated", false))
 		for raw_entry in captured_by_tracker.get("entries", []):
 			var compact := _compact_editor_error(raw_entry)

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -123,7 +123,11 @@ func begin_game_run(editor_log_cursor: int = 0, helper_expected: bool = true) ->
 	_game_session_id = -1
 	_game_run_started_msec = Time.get_ticks_msec()
 	_game_run_started_editor_cursor = maxi(0, editor_log_cursor)
-	_game_run_started_debugger_cursor = _surfaced_error_tracker.debugger_promoted_total() if _surfaced_error_tracker != null else 0
+	if _surfaced_error_tracker != null:
+		_surfaced_error_tracker.note_game_run_started()
+		_game_run_started_debugger_cursor = _surfaced_error_tracker.debugger_promoted_total()
+	else:
+		_game_run_started_debugger_cursor = 0
 	_game_helper_expected = helper_expected
 	var run_id := ""
 	if _game_log_buffer:
@@ -140,6 +144,8 @@ func end_game_run() -> void:
 	_game_ready = false
 	_ready_run_token = -1
 	_game_session_id = -1
+	if _surfaced_error_tracker != null:
+		_surfaced_error_tracker.note_game_run_stopped()
 
 
 func is_game_capture_ready() -> bool:

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -65,6 +65,7 @@ const EVAL_PROBE_INTERVAL_SEC := 0.35
 var _log_buffer: McpLogBuffer
 var _game_log_buffer: McpGameLogBuffer
 var _editor_log_buffer: McpEditorLogBuffer
+var _surfaced_error_tracker
 
 ## Pending request_id -> {connection, timer, timeout_callable}.
 ## We retain the bound timeout lambda so `_clear_pending` can disconnect
@@ -83,14 +84,16 @@ var _game_session_id := -1
 var _game_run_active := false
 var _game_run_started_msec := 0
 var _game_run_started_editor_cursor := 0
+var _game_run_started_debugger_cursor := 0
 var _game_helper_expected := true
 signal game_ready
 
 
-func _init(log_buffer: McpLogBuffer = null, game_log_buffer: McpGameLogBuffer = null, editor_log_buffer: McpEditorLogBuffer = null) -> void:
+func _init(log_buffer: McpLogBuffer = null, game_log_buffer: McpGameLogBuffer = null, editor_log_buffer: McpEditorLogBuffer = null, surfaced_error_tracker = null) -> void:
 	_log_buffer = log_buffer
 	_game_log_buffer = game_log_buffer
 	_editor_log_buffer = editor_log_buffer
+	_surfaced_error_tracker = surfaced_error_tracker
 
 
 func _has_capture(prefix: String) -> bool:
@@ -120,6 +123,7 @@ func begin_game_run(editor_log_cursor: int = 0, helper_expected: bool = true) ->
 	_game_session_id = -1
 	_game_run_started_msec = Time.get_ticks_msec()
 	_game_run_started_editor_cursor = maxi(0, editor_log_cursor)
+	_game_run_started_debugger_cursor = _surfaced_error_tracker.debugger_promoted_total() if _surfaced_error_tracker != null else 0
 	_game_helper_expected = helper_expected
 	var run_id := ""
 	if _game_log_buffer:
@@ -224,6 +228,28 @@ func recent_editor_errors_since(cursor: int) -> Dictionary:
 func _recent_editor_errors_since(cursor: int) -> Dictionary:
 	var out: Array[Dictionary] = []
 	var truncated := false
+	if _surfaced_error_tracker != null:
+		var captured_by_tracker: Dictionary = _surfaced_error_tracker.editor_entries_since(maxi(0, cursor), _game_run_started_debugger_cursor)
+		truncated = bool(captured_by_tracker.get("truncated", false))
+		for raw_entry in captured_by_tracker.get("entries", []):
+			var compact := _compact_editor_error(raw_entry)
+			if compact.is_empty():
+				continue
+			out.append(compact)
+			if out.size() >= 5:
+				break
+		if not out.is_empty():
+			return {"errors": out, "truncated": truncated, "scope": "run"}
+		for raw_entry in _surfaced_error_tracker.retained_recent_editor_entries():
+			var compact := _compact_editor_error(raw_entry, true)
+			if compact.is_empty():
+				continue
+			out.append(compact)
+			if out.size() >= 5:
+				break
+		if not out.is_empty():
+			return {"errors": out, "truncated": false, "scope": "retained_recent"}
+		return {"errors": out, "truncated": false, "scope": "none"}
 	if _editor_log_buffer == null:
 		return {"errors": out, "truncated": false, "scope": "none"}
 	var captured: Dictionary = _editor_log_buffer.get_since(maxi(0, cursor), -1)

--- a/plugin/addons/godot_ai/dispatcher.gd
+++ b/plugin/addons/godot_ai/dispatcher.gd
@@ -9,6 +9,7 @@ var _command_queue: Array[Dictionary] = []
 var _handlers: Dictionary = {}  # command_name -> Callable
 var _pending_deferred: Dictionary = {}  # request_id -> {command, started_ms, timeout_ms}
 var _log_buffer
+var _surfaced_error_tracker
 var mcp_logging := true
 var deferred_timeout_overrides_ms: Dictionary = {}
 
@@ -26,8 +27,9 @@ const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
 const FuzzySuggestions := preload("res://addons/godot_ai/utils/fuzzy_suggestions.gd")
 
 
-func _init(log_buffer: McpLogBuffer) -> void:
+func _init(log_buffer: McpLogBuffer, surfaced_error_tracker = null) -> void:
 	_log_buffer = log_buffer
+	_surfaced_error_tracker = surfaced_error_tracker
 
 
 ## Register a command handler. The callable receives (params: Dictionary) -> Dictionary.
@@ -43,6 +45,11 @@ func clear() -> void:
 	_command_queue.clear()
 	_pending_deferred.clear()
 	_log_buffer = null
+	_surfaced_error_tracker = null
+
+
+func set_surfaced_error_tracker(surfaced_error_tracker) -> void:
+	_surfaced_error_tracker = surfaced_error_tracker
 
 
 ## Invoke a registered handler directly by name. Returns the handler's raw
@@ -162,6 +169,7 @@ func _dispatch(cmd: Dictionary) -> Dictionary:
 	## See connection.gd::send_deferred_response for the deferred-response
 	## counterpart, which stamps the same field.
 	result["readiness"] = McpConnection.get_readiness()
+	_stamp_error_watermark(result)
 
 	if mcp_logging:
 		var status: String = result.get("status", "ok")
@@ -253,10 +261,19 @@ func _collect_deferred_timeouts() -> Array[Dictionary]:
 		## dispatcher emits so the server cache can't drift just because
 		## the editor happened to time out a deferred command.
 		response["readiness"] = McpConnection.get_readiness()
+		_stamp_error_watermark(response)
 		responses.append(response)
 		if mcp_logging and _log_buffer != null:
 			_log_buffer.log("[defer] %s (request %s) -> timeout" % [command, request_id])
 	return responses
+
+
+func _stamp_error_watermark(response: Dictionary) -> void:
+	if _surfaced_error_tracker == null:
+		return
+	if not _surfaced_error_tracker.has_method("watermark"):
+		return
+	response["error_watermark"] = _surfaced_error_tracker.watermark()
 
 
 static func _capture_compact_backtrace(max_frames: int = 8) -> String:

--- a/plugin/addons/godot_ai/dispatcher.gd
+++ b/plugin/addons/godot_ai/dispatcher.gd
@@ -269,11 +269,7 @@ func _collect_deferred_timeouts() -> Array[Dictionary]:
 
 
 func _stamp_error_watermark(response: Dictionary) -> void:
-	if _surfaced_error_tracker == null:
-		return
-	if not _surfaced_error_tracker.has_method("watermark"):
-		return
-	response["error_watermark"] = _surfaced_error_tracker.watermark()
+	McpSurfacedErrorTracker.stamp_watermark(response, _surfaced_error_tracker)
 
 
 static func _capture_compact_backtrace(max_frames: int = 8) -> String:

--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -15,15 +15,19 @@ var _game_log_buffer: McpGameLogBuffer
 var _editor_log_buffer: McpEditorLogBuffer
 var _debugger_errors_root: Node
 var _debugger_search_root_cache: Node
+var _surfaced_error_tracker
 
 
-func _init(log_buffer: McpLogBuffer, connection: McpConnection = null, debugger_plugin: McpDebuggerPlugin = null, game_log_buffer: McpGameLogBuffer = null, editor_log_buffer: McpEditorLogBuffer = null, debugger_errors_root: Node = null) -> void:
+func _init(log_buffer: McpLogBuffer, connection: McpConnection = null, debugger_plugin: McpDebuggerPlugin = null, game_log_buffer: McpGameLogBuffer = null, editor_log_buffer: McpEditorLogBuffer = null, debugger_errors_root: Node = null, surfaced_error_tracker = null) -> void:
 	_log_buffer = log_buffer
 	_connection = connection
 	_debugger_plugin = debugger_plugin
 	_game_log_buffer = game_log_buffer
 	_editor_log_buffer = editor_log_buffer
 	_debugger_errors_root = debugger_errors_root
+	_surfaced_error_tracker = surfaced_error_tracker
+	if _surfaced_error_tracker == null:
+		_surfaced_error_tracker = McpSurfacedErrorTracker.new(_editor_log_buffer, _game_log_buffer, _debugger_errors_root)
 
 
 func get_editor_state(_params: Dictionary) -> Dictionary:
@@ -296,14 +300,7 @@ func _entries_for_response(entries: Array[Dictionary], include_details: bool) ->
 
 
 func _collect_editor_log_entries() -> Array[Dictionary]:
-	var entries: Array[Dictionary] = []
-	if _editor_log_buffer != null:
-		for entry in _editor_log_buffer.get_range(0, _editor_log_buffer.total_count()):
-			entries.append(entry)
-	for entry in _read_debugger_error_entries():
-		if not _has_equivalent_log_entry(entries, entry):
-			entries.append(entry)
-	return entries
+	return _surfaced_error_tracker.collect_editor_log_entries()
 
 
 func _read_debugger_error_entries() -> Array[Dictionary]:

--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -854,37 +854,7 @@ func clear_logs(params: Dictionary) -> Dictionary:
 
 
 func _clear_debugger_error_trees() -> int:
-	var cleared := 0
-	for tree in _surfaced_error_tracker.locate_debugger_error_trees():
-		cleared += McpSurfacedErrorTracker.entries_from_debugger_error_tree(tree).size()
-		if not _press_debugger_clear_button(tree):
-			## No Clear button near this tree (synthetic roots in tests).
-			## A raw clear is acceptable there; the real panel always routes
-			## through the button below.
-			tree.clear()
-	return cleared
-
-
-## Clear via ScriptEditorDebugger's own Clear button so the engine runs
-## _clear_errors_list() — clearing the Tree directly leaves error_count/
-## warning_count, the "Errors (N)" tab badge, the errors_cleared signal, and
-## the toolbar button states out of sync with the emptied tree. The button is
-## identified by its pressed-connection target, not its (translated) label.
-static func _press_debugger_clear_button(tree: Tree) -> bool:
-	var parent := tree.get_parent()
-	if parent == null:
-		return false
-	var stack: Array[Node] = [parent]
-	while not stack.is_empty():
-		var node: Node = stack.pop_back()
-		if node is BaseButton:
-			for conn in node.get_signal_connection_list("pressed"):
-				if str(conn.get("callable", "")).contains("_clear_errors_list"):
-					node.emit_signal("pressed")
-					return true
-		for child in node.get_children():
-			stack.push_back(child)
-	return false
+	return _surfaced_error_tracker.clear_debugger_error_trees()
 
 
 func reload_plugin(_params: Dictionary) -> Dictionary:

--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -14,7 +14,6 @@ var _debugger_plugin: McpDebuggerPlugin
 var _game_log_buffer: McpGameLogBuffer
 var _editor_log_buffer: McpEditorLogBuffer
 var _debugger_errors_root: Node
-var _debugger_search_root_cache: Node
 var _surfaced_error_tracker
 
 
@@ -303,223 +302,12 @@ func _collect_editor_log_entries() -> Array[Dictionary]:
 	return _surfaced_error_tracker.collect_editor_log_entries()
 
 
-func _read_debugger_error_entries() -> Array[Dictionary]:
-	var entries: Array[Dictionary] = []
-	for tree in _locate_debugger_error_trees():
-		for entry in _entries_from_debugger_error_tree(tree):
-			if not _has_equivalent_log_entry(entries, entry):
-				entries.append(entry)
-	return entries
-
-
-func _locate_debugger_error_trees() -> Array[Tree]:
-	var trees: Array[Tree] = []
-	if _debugger_plugin == null and _debugger_errors_root == null:
-		return trees
-	var root: Node = _debugger_errors_root
-	if root == null:
-		root = _debugger_search_root()
-	if root == null:
-		return trees
-	_collect_debugger_error_trees(root, trees)
-	return trees
-
-
-func _debugger_search_root() -> Node:
-	## logs_read is a polling tool, so per-call discovery must not recurse the
-	## entire editor UI. EditorDebuggerNode is the bottom-panel container that
-	## owns every ScriptEditorDebugger session tab and lives for the editor's
-	## lifetime — find it once from the base control, then scan only its
-	## subtree on later calls. The error Trees themselves can't be cached:
-	## they are identified by their content, and an emptied tree is
-	## indistinguishable from any other Tree.
-	if is_instance_valid(_debugger_search_root_cache):
-		return _debugger_search_root_cache
-	_debugger_search_root_cache = null
-	var base := EditorInterface.get_base_control()
-	if base == null:
-		return null
-	_debugger_search_root_cache = _find_first_of_class(base, "EditorDebuggerNode")
-	if _debugger_search_root_cache == null:
-		return base
-	return _debugger_search_root_cache
-
-
-static func _find_first_of_class(node: Node, klass: String) -> Node:
-	if node.get_class() == klass:
-		return node
-	for child in node.get_children():
-		var found := _find_first_of_class(child, klass)
-		if found != null:
-			return found
-	return null
-
-
-static func _collect_debugger_error_trees(node: Node, out: Array[Tree]) -> void:
-	if node is Tree and _tree_has_debugger_errors(node as Tree):
-		out.append(node as Tree)
-	for child in node.get_children():
-		if child is Node:
-			_collect_debugger_error_trees(child as Node, out)
-
-
-static func _tree_has_debugger_errors(tree: Tree) -> bool:
-	var root := tree.get_root()
-	if root == null:
-		return false
-	var item := root.get_first_child()
-	while item != null:
-		if _is_debugger_error_item(item):
-			return true
-		item = item.get_next()
-	return false
-
-
-static func _entries_from_debugger_error_tree(tree: Tree) -> Array[Dictionary]:
-	var entries: Array[Dictionary] = []
-	var root := tree.get_root()
-	if root == null:
-		return entries
-	var item := root.get_first_child()
-	while item != null:
-		if _is_debugger_error_item(item):
-			entries.append(_entry_from_debugger_error_item(item))
-		item = item.get_next()
-	return entries
-
-
-static func _entry_from_debugger_error_item(item: TreeItem) -> Dictionary:
-	var title := item.get_text(1)
-	var loc := _location_from_metadata(item.get_metadata(0))
-	var function := _function_from_title(title)
-	return {
-		"source": "editor",
-		"level": "warn" if item.has_meta("_is_warning") else "error",
-		"text": title,
-		"path": str(loc.get("path", "")),
-		"line": int(loc.get("line", 0)),
-		"function": function,
-		"details": _details_from_debugger_error_item(item, loc, function),
-	}
-
-
-static func _details_from_debugger_error_item(item: TreeItem, loc: Dictionary, function: String) -> Dictionary:
-	var children: Array[Dictionary] = []
-	var child := item.get_first_child()
-	while child != null:
-		var child_loc := _location_from_metadata(child.get_metadata(0))
-		children.append({
-			"label": child.get_text(0),
-			"text": child.get_text(1),
-			"path": str(child_loc.get("path", "")),
-			"line": int(child_loc.get("line", 0)),
-		})
-		child = child.get_next()
-	return {
-		"debugger_tab": "Errors",
-		"time": item.get_text(0),
-		"message": item.get_text(1),
-		"error_type_name": "warning" if item.has_meta("_is_warning") else "error",
-		"source": {
-			"path": str(loc.get("path", "")),
-			"line": int(loc.get("line", 0)),
-			"function": function,
-		},
-		"resolved": {
-			"path": str(loc.get("path", "")),
-			"line": int(loc.get("line", 0)),
-			"function": function,
-		},
-		"children": children,
-		"frames": _frames_from_error_children(children),
-	}
-
-
-static func _is_debugger_error_item(item: TreeItem) -> bool:
-	return item.has_meta("_is_warning") or item.has_meta("_is_error")
-
-
-## ScriptEditorDebugger lays out an error item's children flat, in order: an
-## optional "<X Error>" row, one "<X Source>" row, then one row per stack
-## frame. Only frame 0 carries the "<Stack Trace>" label (TTR-translated);
-## later frames have an empty label. Every frame row carries [path, line]
-## metadata, but so can the Error/Source rows, so metadata alone can't
-## identify frames — the frame run has to be found first.
-static func _frames_from_error_children(children: Array[Dictionary]) -> Array[Dictionary]:
-	var start := -1
-	for i in children.size():
-		if str(children[i].label).contains("Stack Trace"):
-			start = i
-			break
-	if start < 0:
-		## Non-English editor locale: the "<Stack Trace>" label is translated.
-		## Frames past the first are the only rows with an empty label and a
-		## real location; back up one row to recover the labeled first frame
-		## (rows before the frame run always have a non-empty label).
-		for i in children.size():
-			if str(children[i].label).is_empty() and not str(children[i].path).is_empty():
-				start = maxi(i - 1, 0)
-				break
-	if start < 0:
-		return []
-	var frames: Array[Dictionary] = []
-	for i in range(start, children.size()):
-		if str(children[i].path).is_empty():
-			continue
-		frames.append({
-			"path": children[i].path,
-			"line": children[i].line,
-			"function": _function_from_frame_text(children[i].text),
-		})
-	return frames
-
-
-static func _location_from_metadata(meta: Variant) -> Dictionary:
-	if meta is Array and meta.size() >= 2:
-		return {"path": str(meta[0]), "line": int(meta[1])}
-	return {"path": "", "line": 0}
-
-
-static func _function_from_title(title: String) -> String:
-	var colon := title.find(": ")
-	if colon <= 0:
-		return ""
-	return title.substr(0, colon)
-
-
-static func _function_from_frame_text(text: String) -> String:
-	var marker := text.find(" @ ")
-	if marker < 0:
-		return ""
-	var fn := text.substr(marker + 3).strip_edges()
-	if fn.ends_with("()"):
-		fn = fn.substr(0, fn.length() - 2)
-	return fn
-
-
 static func _slice_entries(entries: Array[Dictionary], offset: int, count: int) -> Array[Dictionary]:
 	var page: Array[Dictionary] = []
 	var stop := mini(entries.size(), offset + count)
 	for i in range(mini(offset, entries.size()), stop):
 		page.append(entries[i])
 	return page
-
-
-static func _has_equivalent_log_entry(entries: Array[Dictionary], candidate: Dictionary) -> bool:
-	var key := _log_entry_key(candidate)
-	for entry in entries:
-		if _log_entry_key(entry) == key:
-			return true
-	return false
-
-
-static func _log_entry_key(entry: Dictionary) -> String:
-	return "%s|%s|%s|%s" % [
-		str(entry.get("level", "")),
-		str(entry.get("text", "")),
-		str(entry.get("path", "")),
-		str(entry.get("line", 0)),
-	]
 
 
 ## Map of human-readable monitor names to Performance.Monitor enum values.
@@ -1067,8 +855,8 @@ func clear_logs(params: Dictionary) -> Dictionary:
 
 func _clear_debugger_error_trees() -> int:
 	var cleared := 0
-	for tree in _locate_debugger_error_trees():
-		cleared += _entries_from_debugger_error_tree(tree).size()
+	for tree in _surfaced_error_tracker.locate_debugger_error_trees():
+		cleared += McpSurfacedErrorTracker.entries_from_debugger_error_tree(tree).size()
 		if not _press_debugger_clear_button(tree):
 			## No Clear button near this tree (synthetic roots in tests).
 			## A raw clear is acceptable there; the real panel always routes

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -48,6 +48,7 @@ const Telemetry := preload("res://addons/godot_ai/telemetry.gd")
 const LogBuffer := preload("res://addons/godot_ai/utils/log_buffer.gd")
 const GameLogBuffer := preload("res://addons/godot_ai/utils/game_log_buffer.gd")
 const EditorLogBuffer := preload("res://addons/godot_ai/utils/editor_log_buffer.gd")
+const SurfacedErrorTracker := preload("res://addons/godot_ai/utils/surfaced_error_tracker.gd")
 const Dock := preload("res://addons/godot_ai/mcp_dock.gd")
 const DebuggerPlugin := preload("res://addons/godot_ai/debugger/mcp_debugger_plugin.gd")
 const ClientConfigurator := preload("res://addons/godot_ai/client_configurator.gd")
@@ -156,6 +157,7 @@ var _telemetry
 var _log_buffer
 var _game_log_buffer
 var _editor_log_buffer
+var _surfaced_error_tracker
 var _editor_logger
 var _dock
 var _handlers: Array = []  # prevent GC of RefCounted handlers
@@ -216,12 +218,14 @@ func _enter_tree() -> void:
 
 	_game_log_buffer = GameLogBuffer.new()
 	_editor_log_buffer = EditorLogBuffer.new()
+	_surfaced_error_tracker = SurfacedErrorTracker.new(_editor_log_buffer, _game_log_buffer)
 	_attach_editor_logger()
-	_dispatcher = Dispatcher.new(_log_buffer)
+	_dispatcher = Dispatcher.new(_log_buffer, _surfaced_error_tracker)
 	_startup_trace_phase("core_objects")
 
 	_connection = Connection.new()
 	_connection.log_buffer = _log_buffer
+	_connection.surfaced_error_tracker = _surfaced_error_tracker
 	_connection.ws_port = _resolved_ws_port
 	_connection.connect_blocked = _lifecycle.is_connection_blocked()
 	_connection.connect_block_reason = _lifecycle.get_status_dict().get("message", "")
@@ -233,11 +237,11 @@ func _enter_tree() -> void:
 
 	_telemetry = Telemetry.new(_connection)
 
-	_debugger_plugin = DebuggerPlugin.new(_log_buffer, _game_log_buffer, _editor_log_buffer)
+	_debugger_plugin = DebuggerPlugin.new(_log_buffer, _game_log_buffer, _editor_log_buffer, _surfaced_error_tracker)
 	add_debugger_plugin(_debugger_plugin)
 	_ensure_game_helper_autoload()
 
-	var editor_handler := EditorHandler.new(_log_buffer, _connection, _debugger_plugin, _game_log_buffer, _editor_log_buffer)
+	var editor_handler := EditorHandler.new(_log_buffer, _connection, _debugger_plugin, _game_log_buffer, _editor_log_buffer, null, _surfaced_error_tracker)
 	var scene_handler := SceneHandler.new(_connection)
 	var node_handler := NodeHandler.new(get_undo_redo())
 	var project_handler := ProjectHandler.new(_connection, _debugger_plugin, _editor_log_buffer)
@@ -490,6 +494,7 @@ func _exit_tree() -> void:
 	_log_buffer = null
 	_game_log_buffer = null
 	_editor_log_buffer = null
+	_surfaced_error_tracker = null
 
 	_stop_server()
 	## Symmetric with prepare_for_update_reload: the static guard persists

--- a/plugin/addons/godot_ai/utils/editor_log_buffer.gd
+++ b/plugin/addons/godot_ai/utils/editor_log_buffer.gd
@@ -26,6 +26,7 @@ extends McpStructuredLogRing
 const MAX_LINES := 500
 
 var _mutex := Mutex.new()
+var _error_appended_total := 0
 
 
 func _init() -> void:
@@ -33,9 +34,10 @@ func _init() -> void:
 
 
 func append(level: String, text: String, path: String = "", line: int = 0, function: String = "", details: Dictionary = {}) -> void:
+	var coerced_level := _coerce_level(level)
 	var entry := {
 		"source": "editor",
-		"level": _coerce_level(level),
+		"level": coerced_level,
 		"text": text,
 		"path": path,
 		"line": line,
@@ -45,6 +47,8 @@ func append(level: String, text: String, path: String = "", line: int = 0, funct
 		entry["details"] = details.duplicate(true)
 	_mutex.lock()
 	_append_entry(entry)
+	if coerced_level == "error":
+		_error_appended_total += 1
 	_mutex.unlock()
 
 
@@ -96,9 +100,17 @@ func appended_total() -> int:
 	return n
 
 
+func error_appended_total() -> int:
+	_mutex.lock()
+	var n := _error_appended_total
+	_mutex.unlock()
+	return n
+
+
 func clear() -> int:
 	_mutex.lock()
 	var n := _total_count_unlocked()
 	_clear_storage()
+	_error_appended_total = 0
 	_mutex.unlock()
 	return n

--- a/plugin/addons/godot_ai/utils/game_log_buffer.gd
+++ b/plugin/addons/godot_ai/utils/game_log_buffer.gd
@@ -17,6 +17,7 @@ const MAX_LINES := 2000
 
 var _run_id := ""
 var _run_seq := 0
+var _error_warn_total := 0
 
 
 func _init() -> void:
@@ -24,15 +25,18 @@ func _init() -> void:
 
 
 func append(level: String, text: String, details: Dictionary = {}) -> void:
+	var coerced_level := _coerce_level(level)
 	var entry := {
 		"source": "game",
-		"level": _coerce_level(level),
+		"level": coerced_level,
 		"text": text,
 		"run_id": _run_id,
 	}
 	if not details.is_empty():
 		entry["details"] = details.duplicate(true)
 	_append_entry(entry)
+	if coerced_level in ["warn", "error"]:
+		_error_warn_total += 1
 
 
 ## Rotate the run identifier without dropping buffered entries. Called at
@@ -41,11 +45,16 @@ func append(level: String, text: String, details: Dictionary = {}) -> void:
 ## queried explicitly.
 func clear_for_new_run() -> String:
 	_run_id = _generate_run_id()
+	_error_warn_total = 0
 	return _run_id
 
 
 func run_id() -> String:
 	return _run_id
+
+
+func error_warn_total() -> int:
+	return _error_warn_total
 
 
 func get_run_range(run_id: String, offset: int, count: int) -> Array[Dictionary]:

--- a/plugin/addons/godot_ai/utils/game_log_buffer.gd
+++ b/plugin/addons/godot_ai/utils/game_log_buffer.gd
@@ -18,6 +18,7 @@ const MAX_LINES := 2000
 var _run_id := ""
 var _run_seq := 0
 var _error_warn_total := 0
+var _error_total := 0
 
 
 func _init() -> void:
@@ -37,6 +38,8 @@ func append(level: String, text: String, details: Dictionary = {}) -> void:
 	_append_entry(entry)
 	if coerced_level in ["warn", "error"]:
 		_error_warn_total += 1
+	if coerced_level == "error":
+		_error_total += 1
 
 
 ## Rotate the run identifier without dropping buffered entries. Called at
@@ -46,6 +49,7 @@ func append(level: String, text: String, details: Dictionary = {}) -> void:
 func clear_for_new_run() -> String:
 	_run_id = _generate_run_id()
 	_error_warn_total = 0
+	_error_total = 0
 	return _run_id
 
 
@@ -55,6 +59,10 @@ func run_id() -> String:
 
 func error_warn_total() -> int:
 	return _error_warn_total
+
+
+func error_total() -> int:
+	return _error_total
 
 
 func get_run_range(run_id: String, offset: int, count: int) -> Array[Dictionary]:

--- a/plugin/addons/godot_ai/utils/surfaced_error_tracker.gd
+++ b/plugin/addons/godot_ai/utils/surfaced_error_tracker.gd
@@ -1,0 +1,278 @@
+@tool
+class_name McpSurfacedErrorTracker
+extends RefCounted
+
+## Central source for "errors the agent should know exist".
+##
+## Editor log cursors only cover McpEditorLogBuffer. Runtime errors from the
+## game subprocess can land solely in the Debugger Errors tab, so this tracker
+## promotes visible Debugger-tab rows into a monotonic sequence before the
+## dispatcher stamps a watermark on each response envelope.
+
+var _editor_log_buffer: McpEditorLogBuffer
+var _game_log_buffer: McpGameLogBuffer
+var _debugger_errors_root: Node
+var _debugger_search_root_cache: Node
+var _promoted_debugger_keys: Dictionary = {}
+var _promoted_debugger_entries: Array[Dictionary] = []
+var _debugger_promoted_total := 0
+
+
+func _init(editor_log_buffer: McpEditorLogBuffer = null, game_log_buffer: McpGameLogBuffer = null, debugger_errors_root: Node = null) -> void:
+	_editor_log_buffer = editor_log_buffer
+	_game_log_buffer = game_log_buffer
+	_debugger_errors_root = debugger_errors_root
+
+
+func refresh_debugger_errors() -> void:
+	for entry in _read_debugger_error_entries():
+		var key := _log_entry_key(entry)
+		if _promoted_debugger_keys.has(key):
+			continue
+		_promoted_debugger_keys[key] = true
+		var promoted := entry.duplicate(true)
+		_debugger_promoted_total += 1
+		promoted["_debugger_sequence"] = _debugger_promoted_total
+		_promoted_debugger_entries.append(promoted)
+
+
+func watermark() -> Dictionary:
+	refresh_debugger_errors()
+	return {
+		"editor_ring": _editor_log_buffer.appended_total() if _editor_log_buffer != null else 0,
+		"debugger_promoted": _debugger_promoted_total,
+		"game_error_warn": _game_log_buffer.error_warn_total() if _game_log_buffer != null else 0,
+	}
+
+
+func debugger_promoted_total() -> int:
+	refresh_debugger_errors()
+	return _debugger_promoted_total
+
+
+func collect_editor_log_entries() -> Array[Dictionary]:
+	refresh_debugger_errors()
+	var entries: Array[Dictionary] = []
+	if _editor_log_buffer != null:
+		for entry in _editor_log_buffer.get_range(0, _editor_log_buffer.total_count()):
+			entries.append(entry)
+	for entry in _read_debugger_error_entries():
+		if not _has_equivalent_log_entry(entries, entry):
+			entries.append(entry)
+	return entries
+
+
+func editor_entries_since(editor_cursor: int, debugger_cursor: int) -> Dictionary:
+	refresh_debugger_errors()
+	var entries: Array[Dictionary] = []
+	var truncated := false
+	if _editor_log_buffer != null:
+		var captured: Dictionary = _editor_log_buffer.get_since(maxi(0, editor_cursor), -1)
+		truncated = bool(captured.get("truncated", false))
+		for entry in captured.get("entries", []):
+			entries.append(entry)
+	for entry in _promoted_debugger_entries:
+		if int(entry.get("_debugger_sequence", 0)) > debugger_cursor:
+			entries.append(entry)
+	return {
+		"entries": entries,
+		"truncated": truncated,
+	}
+
+
+func retained_recent_editor_entries() -> Array[Dictionary]:
+	var entries := collect_editor_log_entries()
+	entries.reverse()
+	return entries
+
+
+func _read_debugger_error_entries() -> Array[Dictionary]:
+	var entries: Array[Dictionary] = []
+	for tree in _locate_debugger_error_trees():
+		for entry in _entries_from_debugger_error_tree(tree):
+			if not _has_equivalent_log_entry(entries, entry):
+				entries.append(entry)
+	return entries
+
+
+func _locate_debugger_error_trees() -> Array[Tree]:
+	var trees: Array[Tree] = []
+	var root: Node = _debugger_errors_root
+	if root == null:
+		root = _debugger_search_root()
+	if root == null:
+		return trees
+	_collect_debugger_error_trees(root, trees)
+	return trees
+
+
+func _debugger_search_root() -> Node:
+	if is_instance_valid(_debugger_search_root_cache):
+		return _debugger_search_root_cache
+	_debugger_search_root_cache = null
+	var base := EditorInterface.get_base_control()
+	if base == null:
+		return null
+	_debugger_search_root_cache = _find_first_of_class(base, "EditorDebuggerNode")
+	if _debugger_search_root_cache == null:
+		return base
+	return _debugger_search_root_cache
+
+
+static func _find_first_of_class(node: Node, klass: String) -> Node:
+	if node.get_class() == klass:
+		return node
+	for child in node.get_children():
+		var found := _find_first_of_class(child, klass)
+		if found != null:
+			return found
+	return null
+
+
+static func _collect_debugger_error_trees(node: Node, out: Array[Tree]) -> void:
+	if node is Tree and _tree_has_debugger_errors(node as Tree):
+		out.append(node as Tree)
+	for child in node.get_children():
+		if child is Node:
+			_collect_debugger_error_trees(child as Node, out)
+
+
+static func _tree_has_debugger_errors(tree: Tree) -> bool:
+	var root := tree.get_root()
+	if root == null:
+		return false
+	var item := root.get_first_child()
+	while item != null:
+		if _is_debugger_error_item(item):
+			return true
+		item = item.get_next()
+	return false
+
+
+static func _entries_from_debugger_error_tree(tree: Tree) -> Array[Dictionary]:
+	var entries: Array[Dictionary] = []
+	var root := tree.get_root()
+	if root == null:
+		return entries
+	var item := root.get_first_child()
+	while item != null:
+		if _is_debugger_error_item(item):
+			entries.append(_entry_from_debugger_error_item(item))
+		item = item.get_next()
+	return entries
+
+
+static func _entry_from_debugger_error_item(item: TreeItem) -> Dictionary:
+	var title := item.get_text(1)
+	var loc := _location_from_metadata(item.get_metadata(0))
+	var function := _function_from_title(title)
+	return {
+		"source": "editor",
+		"level": "warn" if item.has_meta("_is_warning") else "error",
+		"text": title,
+		"path": str(loc.get("path", "")),
+		"line": int(loc.get("line", 0)),
+		"function": function,
+		"details": _details_from_debugger_error_item(item, loc, function),
+	}
+
+
+static func _details_from_debugger_error_item(item: TreeItem, loc: Dictionary, function: String) -> Dictionary:
+	var children: Array[Dictionary] = []
+	var child := item.get_first_child()
+	while child != null:
+		var child_loc := _location_from_metadata(child.get_metadata(0))
+		children.append({
+			"label": child.get_text(0),
+			"text": child.get_text(1),
+			"path": str(child_loc.get("path", "")),
+			"line": int(child_loc.get("line", 0)),
+		})
+		child = child.get_next()
+	return {
+		"debugger_tab": "Errors",
+		"time": item.get_text(0),
+		"message": item.get_text(1),
+		"error_type_name": "warning" if item.has_meta("_is_warning") else "error",
+		"source": {
+			"path": str(loc.get("path", "")),
+			"line": int(loc.get("line", 0)),
+			"function": function,
+		},
+		"resolved": {
+			"path": str(loc.get("path", "")),
+			"line": int(loc.get("line", 0)),
+			"function": function,
+		},
+		"children": children,
+		"frames": _frames_from_error_children(children),
+	}
+
+
+static func _is_debugger_error_item(item: TreeItem) -> bool:
+	return item.has_meta("_is_warning") or item.has_meta("_is_error")
+
+
+static func _frames_from_error_children(children: Array[Dictionary]) -> Array[Dictionary]:
+	var start := -1
+	for i in children.size():
+		if str(children[i].label).contains("Stack Trace"):
+			start = i
+			break
+	if start < 0:
+		for i in children.size():
+			if str(children[i].label).is_empty() and not str(children[i].path).is_empty():
+				start = maxi(i - 1, 0)
+				break
+	if start < 0:
+		return []
+	var frames: Array[Dictionary] = []
+	for i in range(start, children.size()):
+		if str(children[i].path).is_empty():
+			continue
+		frames.append({
+			"path": children[i].path,
+			"line": children[i].line,
+			"function": _function_from_frame_text(children[i].text),
+		})
+	return frames
+
+
+static func _location_from_metadata(meta: Variant) -> Dictionary:
+	if meta is Array and meta.size() >= 2:
+		return {"path": str(meta[0]), "line": int(meta[1])}
+	return {"path": "", "line": 0}
+
+
+static func _function_from_title(title: String) -> String:
+	var colon := title.find(": ")
+	if colon <= 0:
+		return ""
+	return title.substr(0, colon)
+
+
+static func _function_from_frame_text(text: String) -> String:
+	var marker := text.find(" @ ")
+	if marker < 0:
+		return ""
+	var fn := text.substr(marker + 3).strip_edges()
+	if fn.ends_with("()"):
+		fn = fn.substr(0, fn.length() - 2)
+	return fn
+
+
+static func _has_equivalent_log_entry(entries: Array[Dictionary], candidate: Dictionary) -> bool:
+	var key := _log_entry_key(candidate)
+	for entry in entries:
+		if _log_entry_key(entry) == key:
+			return true
+	return false
+
+
+static func _log_entry_key(entry: Dictionary) -> String:
+	return "%s|%s|%s|%s" % [
+		str(entry.get("level", "")),
+		str(entry.get("text", "")),
+		str(entry.get("path", "")),
+		str(entry.get("line", 0)),
+	]

--- a/plugin/addons/godot_ai/utils/surfaced_error_tracker.gd
+++ b/plugin/addons/godot_ai/utils/surfaced_error_tracker.gd
@@ -10,7 +10,7 @@ extends RefCounted
 ## dispatcher stamps a watermark on each response envelope.
 
 const MAX_PROMOTED_DEBUGGER_ENTRIES := 500
-const MAX_SUPPRESSED_DEBUGGER_KEYS := 5000
+const MAX_PROMOTED_DEBUGGER_KEYS := 5000
 const DEBUGGER_REFRESH_MIN_INTERVAL_MS := 250
 const DEBUGGER_SCAN_AFTER_STOP_MS := 5000
 
@@ -19,9 +19,8 @@ var _game_log_buffer
 var _debugger_errors_root: Node
 var _debugger_search_root_cache: Node
 var _promoted_debugger_keys: Dictionary = {}
+var _promoted_debugger_key_order: Array[String] = []
 var _promoted_debugger_entries: Array[Dictionary] = []
-var _suppressed_debugger_keys: Dictionary = {}
-var _suppressed_debugger_key_order: Array[String] = []
 var _debugger_promoted_total := 0
 var _run_seq := 0
 var _oldest_retained_debugger_sequence := 1
@@ -38,10 +37,6 @@ func _init(editor_log_buffer = null, game_log_buffer = null, debugger_errors_roo
 
 func note_game_run_started(sticky_scan: bool = true) -> void:
 	_run_seq += 1
-	clear_debugger_error_trees()
-	_promoted_debugger_keys.clear()
-	_suppressed_debugger_keys.clear()
-	_suppressed_debugger_key_order.clear()
 	_debugger_scan_active = sticky_scan
 	_debugger_scan_until_msec = 0
 	if not sticky_scan:
@@ -59,18 +54,39 @@ func refresh_debugger_errors(force: bool = true) -> void:
 	if not force and not _should_scan_debugger_for_cached_watermark(now):
 		return
 	_last_debugger_refresh_msec = now
-	for entry in read_debugger_error_entries():
+	var current_by_key: Dictionary = {}
+	for entry in _raw_debugger_error_entries():
 		if str(entry.get("level", "")) != "error":
 			continue
 		var key := _log_entry_key(entry)
-		if _promoted_debugger_keys.has(key) or _suppressed_debugger_keys.has(key):
+		var info: Dictionary = current_by_key.get(key, {"count": 0, "entry": entry})
+		info["count"] = int(info.get("count", 0)) + 1
+		current_by_key[key] = info
+	for key in _promoted_debugger_keys.keys():
+		if not current_by_key.has(key):
+			_promoted_debugger_keys[key] = 0
+	for key in current_by_key.keys():
+		var info: Dictionary = current_by_key[key]
+		var current := int(info.get("count", 0))
+		var stored := int(_promoted_debugger_keys.get(key, 0))
+		if current < stored:
+			_promoted_debugger_keys[key] = current
 			continue
-		_promoted_debugger_keys[key] = true
-		var promoted := entry.duplicate(true)
-		_debugger_promoted_total += 1
+		if current == stored:
+			continue
+		if not _promoted_debugger_keys.has(key):
+			_promoted_debugger_key_order.append(key)
+		_promoted_debugger_keys[key] = current
+		_debugger_promoted_total += current - stored
+		var source_entry: Dictionary = info.get("entry", {})
+		var promoted := source_entry.duplicate(true)
+		promoted["_debugger_key"] = key
+		promoted["_debugger_occurrences"] = current
 		promoted["_debugger_sequence"] = _debugger_promoted_total
+		_remove_promoted_debugger_entry(key)
 		_promoted_debugger_entries.append(promoted)
 	_trim_promoted_debugger_entries()
+	_trim_promoted_debugger_key_counts()
 
 
 func watermark(force_debugger_scan: bool = false) -> Dictionary:
@@ -141,6 +157,10 @@ func editor_entries_since(editor_cursor: int, debugger_cursor: int, force_debugg
 
 
 func retained_recent_editor_entries() -> Array[Dictionary]:
+	## There is no shared timestamp across the editor logger ring and Godot's
+	## Debugger Errors tree. Preserve the pre-PR fallback contract: newest
+	## buffered editor entries first, then debugger-only rows that were not in
+	## the ring, so stale Debugger rows cannot outrank newer ring entries.
 	var entries: Array[Dictionary] = []
 	var seen_keys: Dictionary = {}
 	if _editor_log_buffer != null:
@@ -160,13 +180,12 @@ func retained_recent_editor_entries() -> Array[Dictionary]:
 func read_debugger_error_entries() -> Array[Dictionary]:
 	var entries: Array[Dictionary] = []
 	var seen_keys: Dictionary = {}
-	for tree in locate_debugger_error_trees():
-		for entry in entries_from_debugger_error_tree(tree):
-			var key := _log_entry_key(entry)
-			if seen_keys.has(key):
-				continue
-			seen_keys[key] = true
-			entries.append(entry)
+	for entry in _raw_debugger_error_entries():
+		var key := _log_entry_key(entry)
+		if seen_keys.has(key):
+			continue
+		seen_keys[key] = true
+		entries.append(entry)
 	return entries
 
 
@@ -377,7 +396,7 @@ func _error_appended_total() -> int:
 		return 0
 	if _editor_log_buffer.has_method("error_appended_total"):
 		return int(_editor_log_buffer.call("error_appended_total"))
-	return int(_editor_log_buffer.appended_total())
+	return 0
 
 
 func _game_error_total() -> int:
@@ -385,8 +404,6 @@ func _game_error_total() -> int:
 		return 0
 	if _game_log_buffer.has_method("error_total"):
 		return int(_game_log_buffer.call("error_total"))
-	if _game_log_buffer.has_method("error_warn_total"):
-		return int(_game_log_buffer.call("error_warn_total"))
 	return 0
 
 
@@ -398,14 +415,28 @@ func _should_scan_debugger_for_cached_watermark(now_msec: int) -> bool:
 
 func _trim_promoted_debugger_entries() -> void:
 	while _promoted_debugger_entries.size() > MAX_PROMOTED_DEBUGGER_ENTRIES:
-		var removed: Dictionary = _promoted_debugger_entries.pop_front()
-		var key := _log_entry_key(removed)
-		_promoted_debugger_keys.erase(key)
-		_suppressed_debugger_keys[key] = true
-		_suppressed_debugger_key_order.append(key)
-	while _suppressed_debugger_key_order.size() > MAX_SUPPRESSED_DEBUGGER_KEYS:
-		_suppressed_debugger_keys.erase(_suppressed_debugger_key_order.pop_front())
+		_promoted_debugger_entries.pop_front()
 	if _promoted_debugger_entries.is_empty():
 		_oldest_retained_debugger_sequence = _debugger_promoted_total + 1
 	else:
 		_oldest_retained_debugger_sequence = int(_promoted_debugger_entries[0].get("_debugger_sequence", 1))
+
+
+func _trim_promoted_debugger_key_counts() -> void:
+	while _promoted_debugger_key_order.size() > MAX_PROMOTED_DEBUGGER_KEYS:
+		var key := _promoted_debugger_key_order.pop_front()
+		_promoted_debugger_keys.erase(key)
+
+
+func _remove_promoted_debugger_entry(key: String) -> void:
+	for i in range(_promoted_debugger_entries.size() - 1, -1, -1):
+		if str(_promoted_debugger_entries[i].get("_debugger_key", "")) == key:
+			_promoted_debugger_entries.remove_at(i)
+			return
+
+
+func _raw_debugger_error_entries() -> Array[Dictionary]:
+	var entries: Array[Dictionary] = []
+	for tree in locate_debugger_error_trees():
+		entries.append_array(entries_from_debugger_error_tree(tree))
+	return entries

--- a/plugin/addons/godot_ai/utils/surfaced_error_tracker.gd
+++ b/plugin/addons/godot_ai/utils/surfaced_error_tracker.gd
@@ -14,8 +14,8 @@ const MAX_SUPPRESSED_DEBUGGER_KEYS := 5000
 const DEBUGGER_REFRESH_MIN_INTERVAL_MS := 250
 const DEBUGGER_SCAN_AFTER_STOP_MS := 5000
 
-var _editor_log_buffer: McpEditorLogBuffer
-var _game_log_buffer: McpGameLogBuffer
+var _editor_log_buffer
+var _game_log_buffer
 var _debugger_errors_root: Node
 var _debugger_search_root_cache: Node
 var _promoted_debugger_keys: Dictionary = {}
@@ -23,21 +23,29 @@ var _promoted_debugger_entries: Array[Dictionary] = []
 var _suppressed_debugger_keys: Dictionary = {}
 var _suppressed_debugger_key_order: Array[String] = []
 var _debugger_promoted_total := 0
+var _run_seq := 0
 var _oldest_retained_debugger_sequence := 1
 var _last_debugger_refresh_msec := -DEBUGGER_REFRESH_MIN_INTERVAL_MS
 var _debugger_scan_active := false
 var _debugger_scan_until_msec := 0
 
 
-func _init(editor_log_buffer: McpEditorLogBuffer = null, game_log_buffer: McpGameLogBuffer = null, debugger_errors_root: Node = null) -> void:
+func _init(editor_log_buffer = null, game_log_buffer = null, debugger_errors_root: Node = null) -> void:
 	_editor_log_buffer = editor_log_buffer
 	_game_log_buffer = game_log_buffer
 	_debugger_errors_root = debugger_errors_root
 
 
-func note_game_run_started() -> void:
-	_debugger_scan_active = true
+func note_game_run_started(sticky_scan: bool = true) -> void:
+	_run_seq += 1
+	clear_debugger_error_trees()
+	_promoted_debugger_keys.clear()
+	_suppressed_debugger_keys.clear()
+	_suppressed_debugger_key_order.clear()
+	_debugger_scan_active = sticky_scan
 	_debugger_scan_until_msec = 0
+	if not sticky_scan:
+		_debugger_scan_until_msec = Time.get_ticks_msec() + DEBUGGER_SCAN_AFTER_STOP_MS
 	refresh_debugger_errors(true)
 
 
@@ -52,6 +60,8 @@ func refresh_debugger_errors(force: bool = true) -> void:
 		return
 	_last_debugger_refresh_msec = now
 	for entry in read_debugger_error_entries():
+		if str(entry.get("level", "")) != "error":
+			continue
 		var key := _log_entry_key(entry)
 		if _promoted_debugger_keys.has(key) or _suppressed_debugger_keys.has(key):
 			continue
@@ -66,9 +76,10 @@ func refresh_debugger_errors(force: bool = true) -> void:
 func watermark(force_debugger_scan: bool = false) -> Dictionary:
 	refresh_debugger_errors(force_debugger_scan)
 	return {
-		"editor_ring": _editor_log_buffer.appended_total() if _editor_log_buffer != null else 0,
+		"run_seq": _run_seq,
+		"editor_ring": _error_appended_total(),
 		"debugger_promoted": _debugger_promoted_total,
-		"game_error_warn": _game_log_buffer.error_warn_total() if _game_log_buffer != null else 0,
+		"game_error_warn": _game_error_total(),
 	}
 
 
@@ -102,20 +113,27 @@ func collect_editor_log_entries() -> Array[Dictionary]:
 	return entries
 
 
-func editor_entries_since(editor_cursor: int, debugger_cursor: int) -> Dictionary:
-	refresh_debugger_errors(true)
+func editor_entries_since(editor_cursor: int, debugger_cursor: int, force_debugger_scan: bool = true) -> Dictionary:
+	refresh_debugger_errors(force_debugger_scan)
 	var entries: Array[Dictionary] = []
+	var seen_keys: Dictionary = {}
 	var truncated := false
 	if _editor_log_buffer != null:
 		var captured: Dictionary = _editor_log_buffer.get_since(maxi(0, editor_cursor), -1)
 		truncated = bool(captured.get("truncated", false))
 		for entry in captured.get("entries", []):
+			seen_keys[_log_entry_key(entry)] = true
 			entries.append(entry)
 	if debugger_cursor < _oldest_retained_debugger_sequence - 1:
 		truncated = true
 	for entry in _promoted_debugger_entries:
-		if int(entry.get("_debugger_sequence", 0)) > debugger_cursor:
-			entries.append(entry)
+		if int(entry.get("_debugger_sequence", 0)) <= debugger_cursor:
+			continue
+		var key := _log_entry_key(entry)
+		if seen_keys.has(key):
+			continue
+		seen_keys[key] = true
+		entries.append(entry)
 	return {
 		"entries": entries,
 		"truncated": truncated,
@@ -123,8 +141,19 @@ func editor_entries_since(editor_cursor: int, debugger_cursor: int) -> Dictionar
 
 
 func retained_recent_editor_entries() -> Array[Dictionary]:
-	var entries := collect_editor_log_entries()
-	entries.reverse()
+	var entries: Array[Dictionary] = []
+	var seen_keys: Dictionary = {}
+	if _editor_log_buffer != null:
+		entries = _editor_log_buffer.get_recent(_editor_log_buffer.total_count())
+		entries.reverse()
+		for entry in entries:
+			seen_keys[_log_entry_key(entry)] = true
+	for entry in collect_editor_log_entries():
+		var key := _log_entry_key(entry)
+		if seen_keys.has(key):
+			continue
+		seen_keys[key] = true
+		entries.append(entry)
 	return entries
 
 
@@ -150,6 +179,16 @@ func locate_debugger_error_trees() -> Array[Tree]:
 		return trees
 	_collect_debugger_error_trees(root, trees)
 	return trees
+
+
+func clear_debugger_error_trees() -> int:
+	var cleared := 0
+	for tree in locate_debugger_error_trees():
+		cleared += entries_from_debugger_error_tree(tree).size()
+		if not _press_debugger_clear_button(tree):
+			## Synthetic roots in tests do not have Godot's Clear button.
+			tree.clear()
+	return cleared
 
 
 func _debugger_search_root() -> Node:
@@ -192,6 +231,23 @@ static func _tree_has_debugger_errors(tree: Tree) -> bool:
 		if _is_debugger_error_item(item):
 			return true
 		item = item.get_next()
+	return false
+
+
+static func _press_debugger_clear_button(tree: Tree) -> bool:
+	var parent := tree.get_parent()
+	if parent == null:
+		return false
+	var stack: Array[Node] = [parent]
+	while not stack.is_empty():
+		var node: Node = stack.pop_back()
+		if node is BaseButton:
+			for conn in node.get_signal_connection_list("pressed"):
+				if str(conn.get("callable", "")).contains("_clear_errors_list"):
+					node.emit_signal("pressed")
+					return true
+		for child in node.get_children():
+			stack.push_back(child)
 	return false
 
 
@@ -314,6 +370,24 @@ static func _log_entry_key(entry: Dictionary) -> String:
 		str(entry.get("path", "")),
 		str(entry.get("line", 0)),
 	]
+
+
+func _error_appended_total() -> int:
+	if _editor_log_buffer == null:
+		return 0
+	if _editor_log_buffer.has_method("error_appended_total"):
+		return int(_editor_log_buffer.call("error_appended_total"))
+	return int(_editor_log_buffer.appended_total())
+
+
+func _game_error_total() -> int:
+	if _game_log_buffer == null:
+		return 0
+	if _game_log_buffer.has_method("error_total"):
+		return int(_game_log_buffer.call("error_total"))
+	if _game_log_buffer.has_method("error_warn_total"):
+		return int(_game_log_buffer.call("error_warn_total"))
+	return 0
 
 
 func _should_scan_debugger_for_cached_watermark(now_msec: int) -> bool:

--- a/plugin/addons/godot_ai/utils/surfaced_error_tracker.gd
+++ b/plugin/addons/godot_ai/utils/surfaced_error_tracker.gd
@@ -9,13 +9,23 @@ extends RefCounted
 ## promotes visible Debugger-tab rows into a monotonic sequence before the
 ## dispatcher stamps a watermark on each response envelope.
 
+const MAX_PROMOTED_DEBUGGER_ENTRIES := 500
+const DEBUGGER_REFRESH_MIN_INTERVAL_MS := 250
+const DEBUGGER_SCAN_AFTER_STOP_MS := 5000
+
 var _editor_log_buffer: McpEditorLogBuffer
 var _game_log_buffer: McpGameLogBuffer
 var _debugger_errors_root: Node
 var _debugger_search_root_cache: Node
 var _promoted_debugger_keys: Dictionary = {}
 var _promoted_debugger_entries: Array[Dictionary] = []
+var _suppressed_debugger_keys: Dictionary = {}
+var _suppressed_debugger_key_order: Array[String] = []
 var _debugger_promoted_total := 0
+var _oldest_retained_debugger_sequence := 1
+var _last_debugger_refresh_msec := -DEBUGGER_REFRESH_MIN_INTERVAL_MS
+var _debugger_scan_active := false
+var _debugger_scan_until_msec := 0
 
 
 func _init(editor_log_buffer: McpEditorLogBuffer = null, game_log_buffer: McpGameLogBuffer = null, debugger_errors_root: Node = null) -> void:
@@ -24,20 +34,36 @@ func _init(editor_log_buffer: McpEditorLogBuffer = null, game_log_buffer: McpGam
 	_debugger_errors_root = debugger_errors_root
 
 
-func refresh_debugger_errors() -> void:
-	for entry in _read_debugger_error_entries():
+func note_game_run_started() -> void:
+	_debugger_scan_active = true
+	_debugger_scan_until_msec = 0
+	refresh_debugger_errors(true)
+
+
+func note_game_run_stopped() -> void:
+	_debugger_scan_active = false
+	_debugger_scan_until_msec = Time.get_ticks_msec() + DEBUGGER_SCAN_AFTER_STOP_MS
+
+
+func refresh_debugger_errors(force: bool = true) -> void:
+	var now := Time.get_ticks_msec()
+	if not force and not _should_scan_debugger_for_cached_watermark(now):
+		return
+	_last_debugger_refresh_msec = now
+	for entry in read_debugger_error_entries():
 		var key := _log_entry_key(entry)
-		if _promoted_debugger_keys.has(key):
+		if _promoted_debugger_keys.has(key) or _suppressed_debugger_keys.has(key):
 			continue
 		_promoted_debugger_keys[key] = true
 		var promoted := entry.duplicate(true)
 		_debugger_promoted_total += 1
 		promoted["_debugger_sequence"] = _debugger_promoted_total
 		_promoted_debugger_entries.append(promoted)
+	_trim_promoted_debugger_entries()
 
 
-func watermark() -> Dictionary:
-	refresh_debugger_errors()
+func watermark(force_debugger_scan: bool = false) -> Dictionary:
+	refresh_debugger_errors(force_debugger_scan)
 	return {
 		"editor_ring": _editor_log_buffer.appended_total() if _editor_log_buffer != null else 0,
 		"debugger_promoted": _debugger_promoted_total,
@@ -45,25 +71,25 @@ func watermark() -> Dictionary:
 	}
 
 
-func debugger_promoted_total() -> int:
-	refresh_debugger_errors()
+func debugger_promoted_total(force_debugger_scan: bool = true) -> int:
+	refresh_debugger_errors(force_debugger_scan)
 	return _debugger_promoted_total
 
 
 func collect_editor_log_entries() -> Array[Dictionary]:
-	refresh_debugger_errors()
+	refresh_debugger_errors(true)
 	var entries: Array[Dictionary] = []
 	if _editor_log_buffer != null:
 		for entry in _editor_log_buffer.get_range(0, _editor_log_buffer.total_count()):
 			entries.append(entry)
-	for entry in _read_debugger_error_entries():
+	for entry in read_debugger_error_entries():
 		if not _has_equivalent_log_entry(entries, entry):
 			entries.append(entry)
 	return entries
 
 
 func editor_entries_since(editor_cursor: int, debugger_cursor: int) -> Dictionary:
-	refresh_debugger_errors()
+	refresh_debugger_errors(true)
 	var entries: Array[Dictionary] = []
 	var truncated := false
 	if _editor_log_buffer != null:
@@ -71,6 +97,8 @@ func editor_entries_since(editor_cursor: int, debugger_cursor: int) -> Dictionar
 		truncated = bool(captured.get("truncated", false))
 		for entry in captured.get("entries", []):
 			entries.append(entry)
+	if debugger_cursor < _oldest_retained_debugger_sequence - 1:
+		truncated = true
 	for entry in _promoted_debugger_entries:
 		if int(entry.get("_debugger_sequence", 0)) > debugger_cursor:
 			entries.append(entry)
@@ -86,16 +114,16 @@ func retained_recent_editor_entries() -> Array[Dictionary]:
 	return entries
 
 
-func _read_debugger_error_entries() -> Array[Dictionary]:
+func read_debugger_error_entries() -> Array[Dictionary]:
 	var entries: Array[Dictionary] = []
-	for tree in _locate_debugger_error_trees():
-		for entry in _entries_from_debugger_error_tree(tree):
+	for tree in locate_debugger_error_trees():
+		for entry in entries_from_debugger_error_tree(tree):
 			if not _has_equivalent_log_entry(entries, entry):
 				entries.append(entry)
 	return entries
 
 
-func _locate_debugger_error_trees() -> Array[Tree]:
+func locate_debugger_error_trees() -> Array[Tree]:
 	var trees: Array[Tree] = []
 	var root: Node = _debugger_errors_root
 	if root == null:
@@ -149,7 +177,7 @@ static func _tree_has_debugger_errors(tree: Tree) -> bool:
 	return false
 
 
-static func _entries_from_debugger_error_tree(tree: Tree) -> Array[Dictionary]:
+static func entries_from_debugger_error_tree(tree: Tree) -> Array[Dictionary]:
 	var entries: Array[Dictionary] = []
 	var root := tree.get_root()
 	if root == null:
@@ -276,3 +304,24 @@ static func _log_entry_key(entry: Dictionary) -> String:
 		str(entry.get("path", "")),
 		str(entry.get("line", 0)),
 	]
+
+
+func _should_scan_debugger_for_cached_watermark(now_msec: int) -> bool:
+	if not _debugger_scan_active and now_msec > _debugger_scan_until_msec:
+		return false
+	return now_msec - _last_debugger_refresh_msec >= DEBUGGER_REFRESH_MIN_INTERVAL_MS
+
+
+func _trim_promoted_debugger_entries() -> void:
+	while _promoted_debugger_entries.size() > MAX_PROMOTED_DEBUGGER_ENTRIES:
+		var removed: Dictionary = _promoted_debugger_entries.pop_front()
+		var key := _log_entry_key(removed)
+		_promoted_debugger_keys.erase(key)
+		_suppressed_debugger_keys[key] = true
+		_suppressed_debugger_key_order.append(key)
+	while _suppressed_debugger_key_order.size() > MAX_PROMOTED_DEBUGGER_ENTRIES:
+		_suppressed_debugger_keys.erase(_suppressed_debugger_key_order.pop_front())
+	if _promoted_debugger_entries.is_empty():
+		_oldest_retained_debugger_sequence = _debugger_promoted_total + 1
+	else:
+		_oldest_retained_debugger_sequence = int(_promoted_debugger_entries[0].get("_debugger_sequence", 1))

--- a/plugin/addons/godot_ai/utils/surfaced_error_tracker.gd
+++ b/plugin/addons/godot_ai/utils/surfaced_error_tracker.gd
@@ -10,6 +10,7 @@ extends RefCounted
 ## dispatcher stamps a watermark on each response envelope.
 
 const MAX_PROMOTED_DEBUGGER_ENTRIES := 500
+const MAX_SUPPRESSED_DEBUGGER_KEYS := 5000
 const DEBUGGER_REFRESH_MIN_INTERVAL_MS := 250
 const DEBUGGER_SCAN_AFTER_STOP_MS := 5000
 
@@ -71,6 +72,14 @@ func watermark(force_debugger_scan: bool = false) -> Dictionary:
 	}
 
 
+static func stamp_watermark(response: Dictionary, tracker) -> void:
+	if tracker == null:
+		return
+	if not tracker.has_method("watermark"):
+		return
+	response["error_watermark"] = tracker.watermark()
+
+
 func debugger_promoted_total(force_debugger_scan: bool = true) -> int:
 	refresh_debugger_errors(force_debugger_scan)
 	return _debugger_promoted_total
@@ -79,12 +88,17 @@ func debugger_promoted_total(force_debugger_scan: bool = true) -> int:
 func collect_editor_log_entries() -> Array[Dictionary]:
 	refresh_debugger_errors(true)
 	var entries: Array[Dictionary] = []
+	var seen_keys: Dictionary = {}
 	if _editor_log_buffer != null:
 		for entry in _editor_log_buffer.get_range(0, _editor_log_buffer.total_count()):
+			seen_keys[_log_entry_key(entry)] = true
 			entries.append(entry)
 	for entry in read_debugger_error_entries():
-		if not _has_equivalent_log_entry(entries, entry):
-			entries.append(entry)
+		var key := _log_entry_key(entry)
+		if seen_keys.has(key):
+			continue
+		seen_keys[key] = true
+		entries.append(entry)
 	return entries
 
 
@@ -116,10 +130,14 @@ func retained_recent_editor_entries() -> Array[Dictionary]:
 
 func read_debugger_error_entries() -> Array[Dictionary]:
 	var entries: Array[Dictionary] = []
+	var seen_keys: Dictionary = {}
 	for tree in locate_debugger_error_trees():
 		for entry in entries_from_debugger_error_tree(tree):
-			if not _has_equivalent_log_entry(entries, entry):
-				entries.append(entry)
+			var key := _log_entry_key(entry)
+			if seen_keys.has(key):
+				continue
+			seen_keys[key] = true
+			entries.append(entry)
 	return entries
 
 
@@ -289,14 +307,6 @@ static func _function_from_frame_text(text: String) -> String:
 	return fn
 
 
-static func _has_equivalent_log_entry(entries: Array[Dictionary], candidate: Dictionary) -> bool:
-	var key := _log_entry_key(candidate)
-	for entry in entries:
-		if _log_entry_key(entry) == key:
-			return true
-	return false
-
-
 static func _log_entry_key(entry: Dictionary) -> String:
 	return "%s|%s|%s|%s" % [
 		str(entry.get("level", "")),
@@ -319,7 +329,7 @@ func _trim_promoted_debugger_entries() -> void:
 		_promoted_debugger_keys.erase(key)
 		_suppressed_debugger_keys[key] = true
 		_suppressed_debugger_key_order.append(key)
-	while _suppressed_debugger_key_order.size() > MAX_PROMOTED_DEBUGGER_ENTRIES:
+	while _suppressed_debugger_key_order.size() > MAX_SUPPRESSED_DEBUGGER_KEYS:
 		_suppressed_debugger_keys.erase(_suppressed_debugger_key_order.pop_front())
 	if _promoted_debugger_entries.is_empty():
 		_oldest_retained_debugger_sequence = _debugger_promoted_total + 1

--- a/plugin/addons/godot_ai/utils/surfaced_error_tracker.gd.uid
+++ b/plugin/addons/godot_ai/utils/surfaced_error_tracker.gd.uid
@@ -1,0 +1,1 @@
+uid://o0ulahkt83re

--- a/src/godot_ai/godot_client/client.py
+++ b/src/godot_ai/godot_client/client.py
@@ -120,6 +120,7 @@ class GodotClient:
         params: dict[str, Any] | None = None,
         session_id: str | None = None,
         timeout: float = 5.0,
+        surface_error_hints: bool = True,
     ) -> dict[str, Any]:
         """Send a command to a Godot session and return the response data.
 
@@ -189,9 +190,13 @@ class GodotClient:
                 data=error.data if error else {},
             )
 
-        if response.new_errors_since_last_call > 0:
+        live_session = self.registry.get(session_id)
+        pending_new_errors = live_session.pending_new_errors if live_session else 0
+        if surface_error_hints and pending_new_errors > 0:
             data = dict(response.data)
-            count = response.new_errors_since_last_call
+            count = pending_new_errors
+            if live_session:
+                live_session.pending_new_errors = 0
             data["new_errors_since_last_call"] = count
             plural = "s" if count != 1 else ""
             data["new_errors_hint"] = (

--- a/src/godot_ai/godot_client/client.py
+++ b/src/godot_ai/godot_client/client.py
@@ -189,4 +189,16 @@ class GodotClient:
                 data=error.data if error else {},
             )
 
+        if response.new_errors_since_last_call > 0:
+            data = dict(response.data)
+            count = response.new_errors_since_last_call
+            data["new_errors_since_last_call"] = count
+            plural = "s" if count != 1 else ""
+            data["new_errors_hint"] = (
+                f"{count} new GDScript error{plural} since your last call. "
+                "Inspect with logs_read(source='editor', include_details=true) "
+                "and/or logs_read(source='game', include_details=true)."
+            )
+            return data
+
         return response.data

--- a/src/godot_ai/handlers/_readiness.py
+++ b/src/godot_ai/handlers/_readiness.py
@@ -121,7 +121,11 @@ async def require_writable_async(runtime: "DirectRuntime") -> None:
         return  # cache says writable — fast path, no probe
 
     try:
-        result = await runtime.send_command("get_editor_state", timeout=2.0)
+        result = await runtime.send_command(
+            "get_editor_state",
+            timeout=2.0,
+            surface_error_hints=False,
+        )
         sync_readiness_for_session(session, result.get("readiness"))
     except Exception:
         ## Probe failed (timeout, disconnect, plugin error). Fall through

--- a/src/godot_ai/protocol/envelope.py
+++ b/src/godot_ai/protocol/envelope.py
@@ -36,8 +36,9 @@ class CommandResponse(BaseModel):
     ## command. Components may reset independently (game run rotation), so the
     ## server compares per key and treats decreases as a reset baseline.
     error_watermark: dict[str, int] | None = None
-    ## Server-internal: populated by the WebSocket transport after comparing
-    ## `error_watermark` against the Session cache. Not sent by the plugin.
+    ## Server-internal compatibility field. Newer code accumulates observed
+    ## deltas on Session.pending_new_errors and consumes them only when a
+    ## user-facing success response can surface the hint.
     new_errors_since_last_call: int = 0
 
 

--- a/src/godot_ai/protocol/envelope.py
+++ b/src/godot_ai/protocol/envelope.py
@@ -32,6 +32,13 @@ class CommandResponse(BaseModel):
     ## omit the field; the server falls through to the existing event-driven
     ## path. See connection.gd::get_readiness for the producer.
     readiness: str | None = None
+    ## Optional monotonic-ish counters stamped by newer plugins after each
+    ## command. Components may reset independently (game run rotation), so the
+    ## server compares per key and treats decreases as a reset baseline.
+    error_watermark: dict[str, int] | None = None
+    ## Server-internal: populated by the WebSocket transport after comparing
+    ## `error_watermark` against the Session cache. Not sent by the plugin.
+    new_errors_since_last_call: int = 0
 
 
 class ErrorDetail(BaseModel):

--- a/src/godot_ai/runtime/direct.py
+++ b/src/godot_ai/runtime/direct.py
@@ -47,13 +47,33 @@ class DirectRuntime:
         params: dict[str, Any] | None = None,
         session_id: str | None = None,
         timeout: float = 5.0,
+        surface_error_hints: bool = True,
     ) -> dict[str, Any]:
-        return await self._client.send(
-            command=command,
-            params=params,
-            session_id=session_id if session_id is not None else self._bound_session_id,
-            timeout=timeout,
-        )
+        resolved_session_id = session_id if session_id is not None else self._bound_session_id
+        if surface_error_hints:
+            return await self._client.send(
+                command=command,
+                params=params,
+                session_id=resolved_session_id,
+                timeout=timeout,
+            )
+        try:
+            return await self._client.send(
+                command=command,
+                params=params,
+                session_id=resolved_session_id,
+                timeout=timeout,
+                surface_error_hints=False,
+            )
+        except TypeError as exc:
+            if "surface_error_hints" not in str(exc):
+                raise
+            return await self._client.send(
+                command=command,
+                params=params,
+                session_id=resolved_session_id,
+                timeout=timeout,
+            )
 
     def list_sessions(self) -> list[Session]:
         return self._registry.list_all()

--- a/src/godot_ai/runtime/direct.py
+++ b/src/godot_ai/runtime/direct.py
@@ -50,30 +50,13 @@ class DirectRuntime:
         surface_error_hints: bool = True,
     ) -> dict[str, Any]:
         resolved_session_id = session_id if session_id is not None else self._bound_session_id
-        if surface_error_hints:
-            return await self._client.send(
-                command=command,
-                params=params,
-                session_id=resolved_session_id,
-                timeout=timeout,
-            )
-        try:
-            return await self._client.send(
-                command=command,
-                params=params,
-                session_id=resolved_session_id,
-                timeout=timeout,
-                surface_error_hints=False,
-            )
-        except TypeError as exc:
-            if "surface_error_hints" not in str(exc):
-                raise
-            return await self._client.send(
-                command=command,
-                params=params,
-                session_id=resolved_session_id,
-                timeout=timeout,
-            )
+        return await self._client.send(
+            command=command,
+            params=params,
+            session_id=resolved_session_id,
+            timeout=timeout,
+            surface_error_hints=surface_error_hints,
+        )
 
     def list_sessions(self) -> list[Session]:
         return self._registry.list_all()

--- a/src/godot_ai/server.py
+++ b/src/godot_ai/server.py
@@ -257,7 +257,9 @@ def create_server(
             "  godot://test/results\n\n"
             "Always connect to an editor session first (session_activate or "
             'session_manage(op="list")). Write operations require session readiness; '
-            "check editor_state if a call is rejected as 'not writable'."
+            "check editor_state if a call is rejected as 'not writable'. After driving a "
+            "running game, check logs_read(source='editor' or 'game', include_details=true) "
+            "before declaring a feature verified."
         ),
         lifespan=_lifespan,
     )

--- a/src/godot_ai/sessions/registry.py
+++ b/src/godot_ai/sessions/registry.py
@@ -31,6 +31,7 @@ class Session:
     current_scene: str = ""
     play_state: str = "stopped"
     readiness: str = "ready"
+    error_watermark: dict[str, int] = field(default_factory=dict)
     editor_pid: int = 0
     ## Which launcher tier the plugin resolved the Python server from —
     ## "dev_venv" | "uvx" | "system" | "unknown". Lets agents notice when a

--- a/src/godot_ai/sessions/registry.py
+++ b/src/godot_ai/sessions/registry.py
@@ -32,6 +32,7 @@ class Session:
     play_state: str = "stopped"
     readiness: str = "ready"
     error_watermark: dict[str, int] = field(default_factory=dict)
+    error_watermark_seen: bool = False
     editor_pid: int = 0
     ## Which launcher tier the plugin resolved the Python server from —
     ## "dev_venv" | "uvx" | "system" | "unknown". Lets agents notice when a

--- a/src/godot_ai/sessions/registry.py
+++ b/src/godot_ai/sessions/registry.py
@@ -32,6 +32,7 @@ class Session:
     play_state: str = "stopped"
     readiness: str = "ready"
     error_watermark: dict[str, int] = field(default_factory=dict)
+    pending_new_errors: int = 0
     editor_pid: int = 0
     ## Which launcher tier the plugin resolved the Python server from —
     ## "dev_venv" | "uvx" | "system" | "unknown". Lets agents notice when a

--- a/src/godot_ai/sessions/registry.py
+++ b/src/godot_ai/sessions/registry.py
@@ -32,7 +32,6 @@ class Session:
     play_state: str = "stopped"
     readiness: str = "ready"
     error_watermark: dict[str, int] = field(default_factory=dict)
-    error_watermark_seen: bool = False
     editor_pid: int = 0
     ## Which launcher tier the plugin resolved the Python server from —
     ## "dev_venv" | "uvx" | "system" | "unknown". Lets agents notice when a

--- a/src/godot_ai/transport/websocket.py
+++ b/src/godot_ai/transport/websocket.py
@@ -226,9 +226,7 @@ class GodotWebSocketServer:
                 if response.readiness is not None and live is not None:
                     sync_readiness_for_session(live, response.readiness)
                 if response.error_watermark is not None and live is not None:
-                    response.new_errors_since_last_call = _sync_error_watermark_for_session(
-                        live, response.error_watermark
-                    )
+                    _sync_error_watermark_for_session(live, response.error_watermark)
                 future = self._pending.pop(response.request_id, None)
                 if future and not future.done():
                     future.set_result(response)
@@ -335,21 +333,41 @@ def _sync_error_watermark_for_session(session: Session, value: dict[str, int]) -
     new only when it is above zero.
     """
 
-    new_total = 0
     updates: dict[str, int] = {}
+    new_total = 0
+    incoming_run_seq = _normalized_watermark_int(value.get("run_seq"))
+    previous_run_seq = max(0, int(session.error_watermark.get("run_seq", 0)))
+    run_advanced = (
+        incoming_run_seq is not None
+        and previous_run_seq > 0
+        and incoming_run_seq > previous_run_seq
+    )
     for key, raw_current in value.items():
-        try:
-            current = max(0, int(raw_current))
-        except (TypeError, ValueError):
+        current = _normalized_watermark_int(raw_current)
+        if current is None:
+            continue
+        updates[key] = current
+        if key == "run_seq":
             continue
 
         previous = session.error_watermark.get(key)
         if previous is not None:
             previous_int = max(0, int(previous))
-            if current >= previous_int:
+            if run_advanced and key == "game_error_warn":
+                new_total += current
+            elif current >= previous_int:
                 new_total += current - previous_int
             else:
                 new_total += current
-        updates[key] = current
+        elif run_advanced and key == "game_error_warn":
+            new_total += current
     session.error_watermark.update(updates)
+    session.pending_new_errors += new_total
     return new_total
+
+
+def _normalized_watermark_int(value: object) -> int | None:
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return None

--- a/src/godot_ai/transport/websocket.py
+++ b/src/godot_ai/transport/websocket.py
@@ -335,24 +335,21 @@ def _sync_error_watermark_for_session(session: Session, value: dict[str, int]) -
     new only when it is above zero.
     """
 
-    normalized: dict[str, int] = {}
+    new_total = 0
+    updates: dict[str, int] = {}
     for key, raw_current in value.items():
         try:
             current = max(0, int(raw_current))
         except (TypeError, ValueError):
             continue
-        normalized[key] = current
 
-    if not session.error_watermark_seen:
-        session.error_watermark_seen = True
-        new_total = 0
-    else:
-        new_total = 0
-        for key, current in normalized.items():
-            previous = max(0, int(session.error_watermark.get(key, 0)))
-            if current >= previous:
-                new_total += current - previous
+        previous = session.error_watermark.get(key)
+        if previous is not None:
+            previous_int = max(0, int(previous))
+            if current >= previous_int:
+                new_total += current - previous_int
             else:
                 new_total += current
-    session.error_watermark = normalized
+        updates[key] = current
+    session.error_watermark.update(updates)
     return new_total

--- a/src/godot_ai/transport/websocket.py
+++ b/src/godot_ai/transport/websocket.py
@@ -348,5 +348,9 @@ def _sync_error_watermark_for_session(session: Session, value: dict[str, int]) -
         else:
             new_total += current
         normalized[key] = current
+    if not session.error_watermark_seen:
+        session.error_watermark = normalized
+        session.error_watermark_seen = True
+        return 0
     session.error_watermark = normalized
     return new_total

--- a/src/godot_ai/transport/websocket.py
+++ b/src/godot_ai/transport/websocket.py
@@ -327,10 +327,11 @@ class GodotWebSocketServer:
 def _sync_error_watermark_for_session(session: Session, value: dict[str, int]) -> int:
     """Update a session's error watermark and return newly observed errors.
 
-    Watermark components reset independently: game error/warn count resets on a
-    new run, while editor/debugger counters are session-scoped. A decrease is
-    therefore treated as a reset and the current component value is counted as
-    new only when it is above zero.
+    Watermark components reset independently. When run_seq advances, the
+    per-run game component is counted in full because the server may never
+    observe its zero between stop/start. Editor and debugger components remain
+    session-scoped monotonic deltas; a decrease is treated as a reset and the
+    current component value is counted when above zero.
     """
 
     updates: dict[str, int] = {}

--- a/src/godot_ai/transport/websocket.py
+++ b/src/godot_ai/transport/websocket.py
@@ -335,22 +335,24 @@ def _sync_error_watermark_for_session(session: Session, value: dict[str, int]) -
     new only when it is above zero.
     """
 
-    new_total = 0
     normalized: dict[str, int] = {}
     for key, raw_current in value.items():
         try:
             current = max(0, int(raw_current))
         except (TypeError, ValueError):
             continue
-        previous = max(0, int(session.error_watermark.get(key, 0)))
-        if current >= previous:
-            new_total += current - previous
-        else:
-            new_total += current
         normalized[key] = current
+
     if not session.error_watermark_seen:
-        session.error_watermark = normalized
         session.error_watermark_seen = True
-        return 0
+        new_total = 0
+    else:
+        new_total = 0
+        for key, current in normalized.items():
+            previous = max(0, int(session.error_watermark.get(key, 0)))
+            if current >= previous:
+                new_total += current - previous
+            else:
+                new_total += current
     session.error_watermark = normalized
     return new_total

--- a/src/godot_ai/transport/websocket.py
+++ b/src/godot_ai/transport/websocket.py
@@ -225,6 +225,10 @@ class GodotWebSocketServer:
                 ## existing event-driven path still applies.
                 if response.readiness is not None and live is not None:
                     sync_readiness_for_session(live, response.readiness)
+                if response.error_watermark is not None and live is not None:
+                    response.new_errors_since_last_call = _sync_error_watermark_for_session(
+                        live, response.error_watermark
+                    )
                 future = self._pending.pop(response.request_id, None)
                 if future and not future.done():
                     future.set_result(response)
@@ -320,3 +324,29 @@ class GodotWebSocketServer:
             )
         finally:
             self._pending.pop(request.request_id, None)
+
+
+def _sync_error_watermark_for_session(session: Session, value: dict[str, int]) -> int:
+    """Update a session's error watermark and return newly observed errors.
+
+    Watermark components reset independently: game error/warn count resets on a
+    new run, while editor/debugger counters are session-scoped. A decrease is
+    therefore treated as a reset and the current component value is counted as
+    new only when it is above zero.
+    """
+
+    new_total = 0
+    normalized: dict[str, int] = {}
+    for key, raw_current in value.items():
+        try:
+            current = max(0, int(raw_current))
+        except (TypeError, ValueError):
+            continue
+        previous = max(0, int(session.error_watermark.get(key, 0)))
+        if current >= previous:
+            new_total += current - previous
+        else:
+            new_total += current
+        normalized[key] = current
+    session.error_watermark = normalized
+    return new_total

--- a/test_project/tests/test_dispatcher.gd
+++ b/test_project/tests/test_dispatcher.gd
@@ -8,6 +8,18 @@ const ProjectHandler := preload("res://addons/godot_ai/handlers/project_handler.
 ## that catches handlers returning malformed results (null, empty dict,
 ## or dicts missing both "data" and "error" keys).
 
+class _FakeErrorTracker:
+	extends RefCounted
+	var calls := 0
+
+	func watermark() -> Dictionary:
+		calls += 1
+		return {
+			"editor_ring": 1,
+			"debugger_promoted": 2,
+			"game_error_warn": 3,
+		}
+
 
 func suite_name() -> String:
 	return "dispatcher"
@@ -273,6 +285,22 @@ func test_tick_stamps_envelope_readiness_on_success_response() -> void:
 	)
 
 
+func test_tick_stamps_error_watermark_on_success_response() -> void:
+	var tracker := _FakeErrorTracker.new()
+	var d := McpDispatcher.new(McpLogBuffer.new(), tracker)
+	d.mcp_logging = false
+	d.register("ok_cmd", func(_p): return {"data": {"value": 1}})
+	d.enqueue({"request_id": "req-ew-ok", "command": "ok_cmd", "params": {}})
+
+	var responses := d.tick(100.0)
+	assert_eq(responses.size(), 1)
+	assert_has_key(responses[0], "error_watermark")
+	assert_eq(responses[0].error_watermark.editor_ring, 1)
+	assert_eq(responses[0].error_watermark.debugger_promoted, 2)
+	assert_eq(responses[0].error_watermark.game_error_warn, 3)
+	assert_eq(tracker.calls, 1)
+
+
 func test_tick_stamps_envelope_readiness_on_handler_error_response() -> void:
 	## Error replies must also self-heal the cache. Otherwise an agent
 	## retrying a recoverable error sees the stale "playing" cache and
@@ -287,6 +315,20 @@ func test_tick_stamps_envelope_readiness_on_handler_error_response() -> void:
 	assert_eq(responses.size(), 1)
 	assert_is_error(responses[0], ErrorCodes.NODE_NOT_FOUND)
 	assert_has_key(responses[0], "readiness")
+
+
+func test_tick_stamps_error_watermark_on_handler_error_response() -> void:
+	var tracker := _FakeErrorTracker.new()
+	var d := McpDispatcher.new(McpLogBuffer.new(), tracker)
+	d.mcp_logging = false
+	d.register("bad_cmd", func(_p):
+		return ErrorCodes.make(ErrorCodes.NODE_NOT_FOUND, "no such node"))
+	d.enqueue({"request_id": "req-ew-err", "command": "bad_cmd", "params": {}})
+
+	var responses := d.tick(100.0)
+	assert_eq(responses.size(), 1)
+	assert_is_error(responses[0], ErrorCodes.NODE_NOT_FOUND)
+	assert_eq(responses[0].error_watermark.game_error_warn, 3)
 
 
 func test_tick_stamps_envelope_readiness_on_deferred_timeout_response() -> void:
@@ -308,3 +350,22 @@ func test_tick_stamps_envelope_readiness_on_deferred_timeout_response() -> void:
 	assert_eq(responses.size(), 1)
 	assert_is_error(responses[0], ErrorCodes.DEFERRED_TIMEOUT)
 	assert_has_key(responses[0], "readiness")
+
+
+func test_tick_stamps_error_watermark_on_deferred_timeout_response() -> void:
+	var tracker := _FakeErrorTracker.new()
+	var d := McpDispatcher.new(McpLogBuffer.new(), tracker)
+	d.mcp_logging = false
+	d.deferred_timeout_overrides_ms["never_replies"] = 1
+	d.register("never_replies", func(_p): return McpDispatcher.DEFERRED_RESPONSE)
+	d.enqueue({"request_id": "req-ew-defer", "command": "never_replies", "params": {}})
+
+	d.tick(100.0)
+	var responses: Array[Dictionary] = []
+	var started := Time.get_ticks_msec()
+	while responses.is_empty() and Time.get_ticks_msec() - started < 100:
+		responses = d.tick(100.0)
+
+	assert_eq(responses.size(), 1)
+	assert_is_error(responses[0], ErrorCodes.DEFERRED_TIMEOUT)
+	assert_eq(responses[0].error_watermark.debugger_promoted, 2)

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -786,11 +786,15 @@ func test_game_log_buffer_error_warn_total_ignores_info_and_resets_per_run() -> 
 	buf.append("warn", "careful")
 	buf.append("error", "boom")
 	assert_eq(buf.error_warn_total(), 2)
+	assert_eq(buf.error_total(), 1)
 	buf.clear_for_new_run()
 	assert_eq(buf.error_warn_total(), 0, "new game runs start a fresh error watermark")
+	assert_eq(buf.error_total(), 0, "new game runs start a fresh error-only watermark")
 	buf.append("info", "chatty print")
+	buf.append("warn", "new run warning")
 	buf.append("error", "new run boom")
-	assert_eq(buf.error_warn_total(), 1)
+	assert_eq(buf.error_warn_total(), 2)
+	assert_eq(buf.error_total(), 1)
 
 
 func test_game_log_buffer_preserves_details() -> void:
@@ -1146,6 +1150,8 @@ func test_editor_log_buffer_append_and_get_range() -> void:
 	assert_eq(entries[1].level, "warn")
 	assert_eq(entries[1].function, "_ready")
 	assert_eq(buf.total_count(), 2)
+	assert_eq(buf.appended_total(), 2)
+	assert_eq(buf.error_appended_total(), 1)
 
 
 func test_editor_log_buffer_unknown_level_coerces_to_info() -> void:
@@ -1265,6 +1271,7 @@ func test_editor_log_buffer_clear_resets_retained_counts_but_preserves_cursor() 
 	assert_eq(buf.total_count(), 0)
 	assert_eq(buf.dropped_count(), 0)
 	assert_eq(buf.appended_total(), cursor, "clear() must not reset the cursor")
+	assert_eq(buf.error_appended_total(), 0, "clear() resets the retained error watermark")
 
 
 func test_editor_log_buffer_get_since_reports_clear_truncation() -> void:
@@ -1418,10 +1425,10 @@ func test_surfaced_error_tracker_promotes_debugger_rows_into_watermark() -> void
 	assert_eq(cached.debugger_promoted, 0, "Inactive dispatch watermarks must be cheap cached reads")
 	var watermark := tracker.watermark(true)
 	assert_eq(watermark.editor_ring, 0)
-	assert_eq(watermark.debugger_promoted, 2)
+	assert_eq(watermark.debugger_promoted, 1)
 	assert_eq(watermark.game_error_warn, 0)
 	var second := tracker.watermark(true)
-	assert_eq(second.debugger_promoted, 2, "same visible rows must not double-count")
+	assert_eq(second.debugger_promoted, 1, "same visible rows must not double-count")
 	tree.free()
 
 
@@ -1430,11 +1437,47 @@ func test_surfaced_error_tracker_editor_entries_since_includes_debugger_only_row
 	var tracker := McpSurfacedErrorTracker.new(null, null, tree)
 	var baseline := 0
 	var captured := tracker.editor_entries_since(0, baseline)
-	assert_eq(captured.entries.size(), 2)
-	assert_eq(captured.entries[1].text, "Parse Error: Expected statement")
+	assert_eq(captured.entries.size(), 1)
+	assert_eq(captured.entries[0].text, "Parse Error: Expected statement")
 	baseline = tracker.debugger_promoted_total()
 	var after_baseline := tracker.editor_entries_since(0, baseline)
 	assert_eq(after_baseline.entries.size(), 0)
+	tree.free()
+
+
+func test_surfaced_error_tracker_run_start_repromotes_recurring_debugger_error() -> void:
+	var tree := _make_debugger_errors_tree()
+	var tracker := McpSurfacedErrorTracker.new(null, null, tree)
+	var first := tracker.watermark(true)
+	assert_eq(first.run_seq, 0)
+	assert_eq(first.debugger_promoted, 1)
+	tracker.note_game_run_started(false)
+	var root := tree.create_item()
+	var error := tree.create_item(root)
+	error.set_meta("_is_error", true)
+	error.set_text(0, "0:00:01:000")
+	error.set_text(1, "Parse Error: Expected statement")
+	error.set_metadata(0, ["res://scripts/broken.gd", 12])
+	var second := tracker.watermark(true)
+	assert_eq(second.run_seq, 1)
+	assert_eq(second.debugger_promoted, 2, "same error can promote again after run-start clears stale rows")
+	tree.free()
+
+
+func test_surfaced_error_tracker_watermark_ignores_warnings() -> void:
+	var editor_buf := McpEditorLogBuffer.new()
+	editor_buf.append("warn", "save warning", "res://warn.gd", 2)
+	editor_buf.append("error", "parse error", "res://broken.gd", 4)
+	var game_buf := McpGameLogBuffer.new()
+	game_buf.clear_for_new_run()
+	game_buf.append("warn", "runtime warning")
+	game_buf.append("error", "runtime error")
+	var tree := _make_debugger_errors_tree()
+	var tracker := McpSurfacedErrorTracker.new(editor_buf, game_buf, tree)
+	var watermark := tracker.watermark(true)
+	assert_eq(watermark.editor_ring, 1)
+	assert_eq(watermark.game_error_warn, 1)
+	assert_eq(watermark.debugger_promoted, 1)
 	tree.free()
 
 
@@ -1444,14 +1487,14 @@ func test_surfaced_error_tracker_caps_promoted_debugger_entries() -> void:
 	for i in range(McpSurfacedErrorTracker.MAX_PROMOTED_DEBUGGER_ENTRIES + 5):
 		_append_debugger_error(root, i)
 	var tracker := McpSurfacedErrorTracker.new(null, null, tree)
-	assert_eq(tracker.watermark(true).debugger_promoted, McpSurfacedErrorTracker.MAX_PROMOTED_DEBUGGER_ENTRIES + 7)
+	assert_eq(tracker.watermark(true).debugger_promoted, McpSurfacedErrorTracker.MAX_PROMOTED_DEBUGGER_ENTRIES + 6)
 	var captured := tracker.editor_entries_since(0, 0)
 	assert_true(captured.truncated, "Trimmed debugger entries should be reported as truncated")
 	assert_eq(captured.entries.size(), McpSurfacedErrorTracker.MAX_PROMOTED_DEBUGGER_ENTRIES)
 	assert_eq(captured.entries[0].text, "Synthetic Error 5")
 	assert_eq(
 		tracker.watermark(true).debugger_promoted,
-		McpSurfacedErrorTracker.MAX_PROMOTED_DEBUGGER_ENTRIES + 7,
+		McpSurfacedErrorTracker.MAX_PROMOTED_DEBUGGER_ENTRIES + 6,
 		"Trimmed but still-visible debugger rows must not be promoted again",
 	)
 	tree.free()

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -780,6 +780,19 @@ func test_game_log_buffer_unknown_level_coerces_to_info() -> void:
 	assert_eq(entries[0].level, "info", "Unknown level should coerce to info")
 
 
+func test_game_log_buffer_error_warn_total_ignores_info_and_resets_per_run() -> void:
+	var buf := McpGameLogBuffer.new()
+	buf.append("info", "ready")
+	buf.append("warn", "careful")
+	buf.append("error", "boom")
+	assert_eq(buf.error_warn_total(), 2)
+	buf.clear_for_new_run()
+	assert_eq(buf.error_warn_total(), 0, "new game runs start a fresh error watermark")
+	buf.append("info", "chatty print")
+	buf.append("error", "new run boom")
+	assert_eq(buf.error_warn_total(), 1)
+
+
 func test_game_log_buffer_preserves_details() -> void:
 	var buf := McpGameLogBuffer.new()
 	buf.append("error", "boom", {
@@ -1396,6 +1409,31 @@ func test_get_logs_source_editor_reads_debugger_errors_tree() -> void:
 	assert_eq(result.data.lines[0].function, "GDScript::reload")
 	assert_eq(result.data.lines[1].level, "error")
 	assert_eq(result.data.lines[1].path, "res://scripts/broken.gd")
+
+
+func test_surfaced_error_tracker_promotes_debugger_rows_into_watermark() -> void:
+	var tree := _make_debugger_errors_tree()
+	var tracker := McpSurfacedErrorTracker.new(null, null, tree)
+	var watermark := tracker.watermark()
+	assert_eq(watermark.editor_ring, 0)
+	assert_eq(watermark.debugger_promoted, 2)
+	assert_eq(watermark.game_error_warn, 0)
+	var second := tracker.watermark()
+	assert_eq(second.debugger_promoted, 2, "same visible rows must not double-count")
+	tree.free()
+
+
+func test_surfaced_error_tracker_editor_entries_since_includes_debugger_only_rows() -> void:
+	var tree := _make_debugger_errors_tree()
+	var tracker := McpSurfacedErrorTracker.new(null, null, tree)
+	var baseline := 0
+	var captured := tracker.editor_entries_since(0, baseline)
+	assert_eq(captured.entries.size(), 2)
+	assert_eq(captured.entries[1].text, "Parse Error: Expected statement")
+	baseline = tracker.debugger_promoted_total()
+	var after_baseline := tracker.editor_entries_since(0, baseline)
+	assert_eq(after_baseline.entries.size(), 0)
+	tree.free()
 
 
 func test_get_logs_source_editor_details_include_debugger_errors_children() -> void:

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -1414,11 +1414,13 @@ func test_get_logs_source_editor_reads_debugger_errors_tree() -> void:
 func test_surfaced_error_tracker_promotes_debugger_rows_into_watermark() -> void:
 	var tree := _make_debugger_errors_tree()
 	var tracker := McpSurfacedErrorTracker.new(null, null, tree)
-	var watermark := tracker.watermark()
+	var cached := tracker.watermark()
+	assert_eq(cached.debugger_promoted, 0, "Inactive dispatch watermarks must be cheap cached reads")
+	var watermark := tracker.watermark(true)
 	assert_eq(watermark.editor_ring, 0)
 	assert_eq(watermark.debugger_promoted, 2)
 	assert_eq(watermark.game_error_warn, 0)
-	var second := tracker.watermark()
+	var second := tracker.watermark(true)
 	assert_eq(second.debugger_promoted, 2, "same visible rows must not double-count")
 	tree.free()
 
@@ -1433,6 +1435,20 @@ func test_surfaced_error_tracker_editor_entries_since_includes_debugger_only_row
 	baseline = tracker.debugger_promoted_total()
 	var after_baseline := tracker.editor_entries_since(0, baseline)
 	assert_eq(after_baseline.entries.size(), 0)
+	tree.free()
+
+
+func test_surfaced_error_tracker_caps_promoted_debugger_entries() -> void:
+	var tree := _make_debugger_errors_tree()
+	var root := tree.get_root()
+	for i in range(McpSurfacedErrorTracker.MAX_PROMOTED_DEBUGGER_ENTRIES + 5):
+		_append_debugger_error(root, i)
+	var tracker := McpSurfacedErrorTracker.new(null, null, tree)
+	assert_eq(tracker.watermark(true).debugger_promoted, McpSurfacedErrorTracker.MAX_PROMOTED_DEBUGGER_ENTRIES + 7)
+	var captured := tracker.editor_entries_since(0, 0)
+	assert_true(captured.truncated, "Trimmed debugger entries should be reported as truncated")
+	assert_eq(captured.entries.size(), McpSurfacedErrorTracker.MAX_PROMOTED_DEBUGGER_ENTRIES)
+	assert_eq(captured.entries[0].text, "Synthetic Error 5")
 	tree.free()
 
 
@@ -1653,6 +1669,14 @@ func _make_debugger_errors_tree() -> Tree:
 	error.set_text(1, "Parse Error: Expected statement")
 	error.set_metadata(0, ["res://scripts/broken.gd", 12])
 	return tree
+
+
+func _append_debugger_error(root: TreeItem, index: int) -> void:
+	var error := root.get_tree().create_item(root)
+	error.set_meta("_is_error", true)
+	error.set_text(0, "0:00:01:%03d" % index)
+	error.set_text(1, "Synthetic Error %d" % index)
+	error.set_metadata(0, ["res://scripts/generated_%d.gd" % index, index + 1])
 
 
 func test_log_backtrace_resolve_error_preserves_all_frames() -> void:

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -1452,15 +1452,26 @@ func test_surfaced_error_tracker_run_start_repromotes_recurring_debugger_error()
 	assert_eq(first.run_seq, 0)
 	assert_eq(first.debugger_promoted, 1)
 	tracker.note_game_run_started(false)
-	var root := tree.create_item()
-	var error := tree.create_item(root)
-	error.set_meta("_is_error", true)
-	error.set_text(0, "0:00:01:000")
-	error.set_text(1, "Parse Error: Expected statement")
-	error.set_metadata(0, ["res://scripts/broken.gd", 12])
+	assert_eq(McpSurfacedErrorTracker.entries_from_debugger_error_tree(tree).size(), 2)
+	var unchanged := tracker.watermark(true)
+	assert_eq(unchanged.run_seq, 1)
+	assert_eq(unchanged.debugger_promoted, 1, "unchanged visible rows must not re-promote across a run boundary")
+	_append_duplicate_parse_error(tree.get_root())
 	var second := tracker.watermark(true)
 	assert_eq(second.run_seq, 1)
-	assert_eq(second.debugger_promoted, 2, "same error can promote again after run-start clears stale rows")
+	assert_eq(second.debugger_promoted, 2, "a new identical row should promote as a recurrence")
+	tree.free()
+
+
+func test_surfaced_error_tracker_user_clear_then_recurrence_promotes() -> void:
+	var tree := _make_debugger_errors_tree()
+	var tracker := McpSurfacedErrorTracker.new(null, null, tree)
+	assert_eq(tracker.watermark(true).debugger_promoted, 1)
+	tree.clear()
+	tracker.watermark(true)
+	var root := tree.create_item()
+	_append_duplicate_parse_error(root)
+	assert_eq(tracker.watermark(true).debugger_promoted, 2)
 	tree.free()
 
 
@@ -1725,6 +1736,14 @@ func _append_debugger_error(root: TreeItem, index: int) -> void:
 	error.set_text(0, "0:00:01:%03d" % index)
 	error.set_text(1, "Synthetic Error %d" % index)
 	error.set_metadata(0, ["res://scripts/generated_%d.gd" % index, index + 1])
+
+
+func _append_duplicate_parse_error(root: TreeItem) -> void:
+	var error := root.get_tree().create_item(root)
+	error.set_meta("_is_error", true)
+	error.set_text(0, "0:00:01:000")
+	error.set_text(1, "Parse Error: Expected statement")
+	error.set_metadata(0, ["res://scripts/broken.gd", 12])
 
 
 func test_log_backtrace_resolve_error_preserves_all_frames() -> void:
@@ -2229,6 +2248,31 @@ func test_debugger_plugin_ignores_hello_from_stale_session() -> void:
 	plugin._capture("mcp:hello", [], 22)
 	assert_true(plugin.is_game_capture_ready(), "hello from current session should ready capture")
 	assert_eq(game_buf.run_id(), run_id, "current hello confirms the existing run identity")
+
+
+func test_debugger_plugin_manual_run_stop_rearms_next_session() -> void:
+	var log_buf := McpLogBuffer.new()
+	var tracker := McpSurfacedErrorTracker.new()
+	var plugin := McpDebuggerPlugin.new(log_buf, McpGameLogBuffer.new(), McpEditorLogBuffer.new(), tracker)
+	plugin._begin_game_run_tracking(10, true, true, true, true, true)
+	plugin._game_session_id = 11
+	assert_eq(plugin.get_game_status().active, true)
+	assert_eq(plugin.get_game_status().run_token, 1)
+	assert_eq(log_buf.total_count(), 0, "manual _setup_session arming must stay quiet for reload tests")
+	assert_eq(tracker._debugger_scan_active, true, "manual runs should use sticky scanning until stopped")
+
+	plugin._on_debugger_session_stopped(12)
+	assert_eq(plugin.get_game_status().active, true, "stale session stop must not end the active run")
+	plugin._on_debugger_session_stopped(11)
+	assert_eq(plugin.get_game_status().status, "stopped")
+	assert_eq(tracker._debugger_scan_active, false)
+
+	plugin._begin_game_run_tracking(20, true, true, true, true, true)
+	plugin._game_session_id = 22
+	assert_eq(plugin.get_game_status().active, true)
+	assert_eq(plugin.get_game_status().run_token, 2)
+	assert_eq(plugin.get_game_status().editor_log_cursor, 20)
+	assert_eq(tracker._debugger_scan_active, true)
 
 
 func test_debugger_plugin_log_batch_no_buffer_is_safe() -> void:

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -1449,6 +1449,11 @@ func test_surfaced_error_tracker_caps_promoted_debugger_entries() -> void:
 	assert_true(captured.truncated, "Trimmed debugger entries should be reported as truncated")
 	assert_eq(captured.entries.size(), McpSurfacedErrorTracker.MAX_PROMOTED_DEBUGGER_ENTRIES)
 	assert_eq(captured.entries[0].text, "Synthetic Error 5")
+	assert_eq(
+		tracker.watermark(true).debugger_promoted,
+		McpSurfacedErrorTracker.MAX_PROMOTED_DEBUGGER_ENTRIES + 7,
+		"Trimmed but still-visible debugger rows must not be promoted again",
+	)
 	tree.free()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,7 @@ class MockGodotPlugin:
         message: str,
         data: dict | None = None,
         readiness: str | None = None,
+        error_watermark: dict[str, int] | None = None,
     ) -> None:
         msg: dict = {
             "request_id": request_id,
@@ -76,6 +77,8 @@ class MockGodotPlugin:
         }
         if readiness is not None:
             msg["readiness"] = readiness
+        if error_watermark is not None:
+            msg["error_watermark"] = error_watermark
         await self.ws.send(json.dumps(msg))
 
     async def send_event(self, event: str, data: dict) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,7 @@ class MockGodotPlugin:
         data: dict,
         status: str = "ok",
         readiness: str | None = None,
+        error_watermark: dict[str, int] | None = None,
     ) -> None:
         msg: dict = {"request_id": request_id, "status": status, "data": data}
         ## Mirror the real plugin: every dispatcher response carries a live
@@ -55,6 +56,8 @@ class MockGodotPlugin:
         ## simulate an old plugin pre-dating the per-envelope self-heal.
         if readiness is not None:
             msg["readiness"] = readiness
+        if error_watermark is not None:
+            msg["error_watermark"] = error_watermark
         await self.ws.send(json.dumps(msg))
 
     async def send_error(

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -130,6 +130,32 @@ class TestCommandRoundTrip:
         assert result == {"version": "4.4.1"}
         await plugin.close()
 
+    async def test_error_watermark_first_observation_baselines_silently(self, harness):
+        plugin = await harness.connect_plugin(session_id="err-baseline")
+        client = GodotClient(harness.server, harness.registry)
+
+        async def mock_handler():
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 1},
+                error_watermark={
+                    "editor_ring": 0,
+                    "debugger_promoted": 1,
+                    "game_error_warn": 0,
+                },
+            )
+
+        handler_task = asyncio.create_task(mock_handler())
+        first = await client.send("get_editor_state")
+        await handler_task
+
+        assert "new_errors_since_last_call" not in first
+        session = harness.registry.get("err-baseline")
+        assert session.error_watermark_seen is True
+        assert session.error_watermark["debugger_promoted"] == 1
+        await plugin.close()
+
     async def test_error_watermark_advance_injects_hint_once(self, harness):
         plugin = await harness.connect_plugin(session_id="err-watermark")
         client = GodotClient(harness.server, harness.registry)
@@ -151,7 +177,17 @@ class TestCommandRoundTrip:
                 {"ok": 2},
                 error_watermark={
                     "editor_ring": 0,
-                    "debugger_promoted": 1,
+                    "debugger_promoted": 2,
+                    "game_error_warn": 0,
+                },
+            )
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 3},
+                error_watermark={
+                    "editor_ring": 0,
+                    "debugger_promoted": 2,
                     "game_error_warn": 0,
                 },
             )
@@ -159,12 +195,14 @@ class TestCommandRoundTrip:
         handler_task = asyncio.create_task(mock_handler())
         first = await client.send("get_editor_state")
         second = await client.send("get_editor_state")
+        third = await client.send("get_editor_state")
         await handler_task
 
-        assert first["new_errors_since_last_call"] == 1
-        assert "logs_read(source='editor'" in first["new_errors_hint"]
-        assert "new_errors_since_last_call" not in second
-        assert harness.registry.get("err-watermark").error_watermark["debugger_promoted"] == 1
+        assert "new_errors_since_last_call" not in first
+        assert second["new_errors_since_last_call"] == 1
+        assert "logs_read(source='editor'" in second["new_errors_hint"]
+        assert "new_errors_since_last_call" not in third
+        assert harness.registry.get("err-watermark").error_watermark["debugger_promoted"] == 2
         await plugin.close()
 
     async def test_error_watermark_component_reset_counts_current_value(self, harness):
@@ -182,16 +220,24 @@ class TestCommandRoundTrip:
             await plugin.send_response(
                 cmd["request_id"],
                 {"ok": 2},
+                error_watermark={"game_error_warn": 3},
+            )
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 3},
                 error_watermark={"game_error_warn": 1},
             )
 
         handler_task = asyncio.create_task(mock_handler())
         first = await client.send("get_editor_state")
         second = await client.send("get_editor_state")
+        third = await client.send("get_editor_state")
         await handler_task
 
-        assert first["new_errors_since_last_call"] == 3
-        assert second["new_errors_since_last_call"] == 1
+        assert "new_errors_since_last_call" not in first
+        assert "new_errors_since_last_call" not in second
+        assert third["new_errors_since_last_call"] == 1
         await plugin.close()
 
     async def test_command_with_params(self, harness):

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -152,7 +152,6 @@ class TestCommandRoundTrip:
 
         assert "new_errors_since_last_call" not in first
         session = harness.registry.get("err-baseline")
-        assert session.error_watermark_seen is True
         assert session.error_watermark["debugger_promoted"] == 1
         await plugin.close()
 
@@ -238,6 +237,45 @@ class TestCommandRoundTrip:
         assert "new_errors_since_last_call" not in first
         assert "new_errors_since_last_call" not in second
         assert third["new_errors_since_last_call"] == 1
+        await plugin.close()
+
+    async def test_error_watermark_missing_key_retains_prior_baseline(self, harness):
+        plugin = await harness.connect_plugin(session_id="err-missing-key")
+        client = GodotClient(harness.server, harness.registry)
+
+        async def mock_handler():
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 1},
+                error_watermark={"debugger_promoted": 4, "game_error_warn": 1},
+            )
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 2},
+                error_watermark={"game_error_warn": 2},
+            )
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 3},
+                error_watermark={"debugger_promoted": 5},
+            )
+
+        handler_task = asyncio.create_task(mock_handler())
+        first = await client.send("get_editor_state")
+        second = await client.send("get_editor_state")
+        third = await client.send("get_editor_state")
+        await handler_task
+
+        assert "new_errors_since_last_call" not in first
+        assert second["new_errors_since_last_call"] == 1
+        assert third["new_errors_since_last_call"] == 1
+        assert harness.registry.get("err-missing-key").error_watermark == {
+            "debugger_promoted": 5,
+            "game_error_warn": 2,
+        }
         await plugin.close()
 
     async def test_command_with_params(self, harness):

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -130,6 +130,70 @@ class TestCommandRoundTrip:
         assert result == {"version": "4.4.1"}
         await plugin.close()
 
+    async def test_error_watermark_advance_injects_hint_once(self, harness):
+        plugin = await harness.connect_plugin(session_id="err-watermark")
+        client = GodotClient(harness.server, harness.registry)
+
+        async def mock_handler():
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 1},
+                error_watermark={
+                    "editor_ring": 0,
+                    "debugger_promoted": 1,
+                    "game_error_warn": 0,
+                },
+            )
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 2},
+                error_watermark={
+                    "editor_ring": 0,
+                    "debugger_promoted": 1,
+                    "game_error_warn": 0,
+                },
+            )
+
+        handler_task = asyncio.create_task(mock_handler())
+        first = await client.send("get_editor_state")
+        second = await client.send("get_editor_state")
+        await handler_task
+
+        assert first["new_errors_since_last_call"] == 1
+        assert "logs_read(source='editor'" in first["new_errors_hint"]
+        assert "new_errors_since_last_call" not in second
+        assert harness.registry.get("err-watermark").error_watermark["debugger_promoted"] == 1
+        await plugin.close()
+
+    async def test_error_watermark_component_reset_counts_current_value(self, harness):
+        plugin = await harness.connect_plugin(session_id="err-reset")
+        client = GodotClient(harness.server, harness.registry)
+
+        async def mock_handler():
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 1},
+                error_watermark={"game_error_warn": 3},
+            )
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 2},
+                error_watermark={"game_error_warn": 1},
+            )
+
+        handler_task = asyncio.create_task(mock_handler())
+        first = await client.send("get_editor_state")
+        second = await client.send("get_editor_state")
+        await handler_task
+
+        assert first["new_errors_since_last_call"] == 3
+        assert second["new_errors_since_last_call"] == 1
+        await plugin.close()
+
     async def test_command_with_params(self, harness):
         plugin = await harness.connect_plugin()
         client = GodotClient(harness.server, harness.registry)

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -140,6 +140,7 @@ class TestCommandRoundTrip:
                 cmd["request_id"],
                 {"ok": 1},
                 error_watermark={
+                    "run_seq": 1,
                     "editor_ring": 0,
                     "debugger_promoted": 1,
                     "game_error_warn": 0,
@@ -165,6 +166,7 @@ class TestCommandRoundTrip:
                 cmd["request_id"],
                 {"ok": 1},
                 error_watermark={
+                    "run_seq": 1,
                     "editor_ring": 0,
                     "debugger_promoted": 1,
                     "game_error_warn": 0,
@@ -175,6 +177,7 @@ class TestCommandRoundTrip:
                 cmd["request_id"],
                 {"ok": 2},
                 error_watermark={
+                    "run_seq": 1,
                     "editor_ring": 0,
                     "debugger_promoted": 2,
                     "game_error_warn": 0,
@@ -185,6 +188,7 @@ class TestCommandRoundTrip:
                 cmd["request_id"],
                 {"ok": 3},
                 error_watermark={
+                    "run_seq": 1,
                     "editor_ring": 0,
                     "debugger_promoted": 2,
                     "game_error_warn": 0,
@@ -213,19 +217,19 @@ class TestCommandRoundTrip:
             await plugin.send_response(
                 cmd["request_id"],
                 {"ok": 1},
-                error_watermark={"game_error_warn": 3},
+                error_watermark={"run_seq": 1, "game_error_warn": 3},
             )
             cmd = await plugin.recv_command()
             await plugin.send_response(
                 cmd["request_id"],
                 {"ok": 2},
-                error_watermark={"game_error_warn": 3},
+                error_watermark={"run_seq": 1, "game_error_warn": 3},
             )
             cmd = await plugin.recv_command()
             await plugin.send_response(
                 cmd["request_id"],
                 {"ok": 3},
-                error_watermark={"game_error_warn": 1},
+                error_watermark={"run_seq": 1, "game_error_warn": 1},
             )
 
         handler_task = asyncio.create_task(mock_handler())
@@ -248,19 +252,19 @@ class TestCommandRoundTrip:
             await plugin.send_response(
                 cmd["request_id"],
                 {"ok": 1},
-                error_watermark={"debugger_promoted": 4, "game_error_warn": 1},
+                error_watermark={"run_seq": 1, "debugger_promoted": 4, "game_error_warn": 1},
             )
             cmd = await plugin.recv_command()
             await plugin.send_response(
                 cmd["request_id"],
                 {"ok": 2},
-                error_watermark={"game_error_warn": 2},
+                error_watermark={"run_seq": 1, "game_error_warn": 2},
             )
             cmd = await plugin.recv_command()
             await plugin.send_response(
                 cmd["request_id"],
                 {"ok": 3},
-                error_watermark={"debugger_promoted": 5},
+                error_watermark={"run_seq": 1, "debugger_promoted": 5},
             )
 
         handler_task = asyncio.create_task(mock_handler())
@@ -273,9 +277,116 @@ class TestCommandRoundTrip:
         assert second["new_errors_since_last_call"] == 1
         assert third["new_errors_since_last_call"] == 1
         assert harness.registry.get("err-missing-key").error_watermark == {
+            "run_seq": 1,
             "debugger_promoted": 5,
             "game_error_warn": 2,
         }
+        await plugin.close()
+
+    async def test_error_watermark_run_boundary_counts_reaccumulated_game_errors(self, harness):
+        plugin = await harness.connect_plugin(session_id="err-run-seq")
+        client = GodotClient(harness.server, harness.registry)
+
+        async def mock_handler():
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 1},
+                error_watermark={"run_seq": 1, "game_error_warn": 3},
+            )
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 2},
+                error_watermark={"run_seq": 2, "game_error_warn": 3},
+            )
+
+        handler_task = asyncio.create_task(mock_handler())
+        first = await client.send("get_editor_state")
+        second = await client.send("get_editor_state")
+        await handler_task
+
+        assert "new_errors_since_last_call" not in first
+        assert second["new_errors_since_last_call"] == 3
+        await plugin.close()
+
+    async def test_error_watermark_error_response_accumulates_until_success(self, harness):
+        plugin = await harness.connect_plugin(session_id="err-accumulate")
+        client = GodotClient(harness.server, harness.registry)
+
+        async def mock_handler():
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 1},
+                error_watermark={"run_seq": 1, "debugger_promoted": 0},
+            )
+            cmd = await plugin.recv_command()
+            await plugin.send_error(
+                cmd["request_id"],
+                "BROKEN",
+                "broken",
+                error_watermark={"run_seq": 1, "debugger_promoted": 2},
+            )
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 3},
+                error_watermark={"run_seq": 1, "debugger_promoted": 2},
+            )
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 4},
+                error_watermark={"run_seq": 1, "debugger_promoted": 2},
+            )
+
+        handler_task = asyncio.create_task(mock_handler())
+        first = await client.send("get_editor_state")
+        with pytest.raises(GodotCommandError):
+            await client.send("get_editor_state")
+        third = await client.send("get_editor_state")
+        fourth = await client.send("get_editor_state")
+        await handler_task
+
+        assert "new_errors_since_last_call" not in first
+        assert third["new_errors_since_last_call"] == 2
+        assert "new_errors_since_last_call" not in fourth
+        await plugin.close()
+
+    async def test_error_watermark_probe_success_does_not_consume_pending_hint(self, harness):
+        plugin = await harness.connect_plugin(session_id="err-probe")
+        client = GodotClient(harness.server, harness.registry)
+
+        async def mock_handler():
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 1},
+                error_watermark={"run_seq": 1, "debugger_promoted": 0},
+            )
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 2},
+                error_watermark={"run_seq": 1, "debugger_promoted": 2},
+            )
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 3},
+                error_watermark={"run_seq": 1, "debugger_promoted": 2},
+            )
+
+        handler_task = asyncio.create_task(mock_handler())
+        first = await client.send("get_editor_state")
+        probe = await client.send("get_editor_state", surface_error_hints=False)
+        third = await client.send("get_editor_state")
+        await handler_task
+
+        assert "new_errors_since_last_call" not in first
+        assert "new_errors_since_last_call" not in probe
+        assert third["new_errors_since_last_call"] == 2
         await plugin.close()
 
     async def test_command_with_params(self, harness):

--- a/tests/unit/test_editor_state_mixed_state.py
+++ b/tests/unit/test_editor_state_mixed_state.py
@@ -31,6 +31,7 @@ class _EditorStateClient:
         params: dict | None = None,
         session_id: str | None = None,
         timeout: float = 5.0,
+        surface_error_hints: bool = True,
     ) -> dict:
         if command != "get_editor_state":
             raise AssertionError(f"unexpected command: {command}")

--- a/tests/unit/test_game_eval.py
+++ b/tests/unit/test_game_eval.py
@@ -22,6 +22,7 @@ class _StubGameEvalClient:
         params: dict | None = None,
         session_id: str | None = None,
         timeout: float = 5.0,
+        surface_error_hints: bool = True,
     ) -> dict:
         self.calls.append(
             {
@@ -88,6 +89,7 @@ class _RaisingGameEvalClient:
         params: dict | None = None,
         session_id: str | None = None,
         timeout: float = 5.0,
+        surface_error_hints: bool = True,
     ) -> dict:
         raise GodotCommandError(code=self._code, message=self._message)
 

--- a/tests/unit/test_protocol.py
+++ b/tests/unit/test_protocol.py
@@ -77,6 +77,34 @@ class TestCommandResponse:
         assert parsed.request_id == "abc123"
         assert parsed.data == {"version": "4.4"}
 
+    def test_error_watermark_is_optional_for_old_plugins(self):
+        resp = CommandResponse(
+            request_id="abc123",
+            status="ok",
+            data={},
+        )
+        assert resp.error_watermark is None
+        assert resp.new_errors_since_last_call == 0
+
+    def test_error_watermark_parses_from_new_plugins(self):
+        parsed = CommandResponse.model_validate(
+            {
+                "request_id": "abc123",
+                "status": "ok",
+                "data": {},
+                "error_watermark": {
+                    "editor_ring": 1,
+                    "debugger_promoted": 2,
+                    "game_error_warn": 3,
+                },
+            }
+        )
+        assert parsed.error_watermark == {
+            "editor_ring": 1,
+            "debugger_promoted": 2,
+            "game_error_warn": 3,
+        }
+
 
 class TestHandshakeMessage:
     def test_defaults(self):

--- a/tests/unit/test_readiness.py
+++ b/tests/unit/test_readiness.py
@@ -70,6 +70,7 @@ class _EditorStateClient:
         params: dict | None = None,
         session_id: str | None = None,
         timeout: float = 5.0,
+        surface_error_hints: bool = True,
     ) -> dict:
         if command != "get_editor_state":
             raise AssertionError(f"unexpected command: {command}")

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -56,6 +56,7 @@ class StubClient:
         params: dict | None = None,
         session_id: str | None = None,
         timeout: float = 5.0,
+        surface_error_hints: bool = True,
     ) -> dict:
         self.calls.append(
             {
@@ -63,6 +64,7 @@ class StubClient:
                 "params": params,
                 "session_id": session_id,
                 "timeout": timeout,
+                "surface_error_hints": surface_error_hints,
             }
         )
         if command == "quit_editor":
@@ -1217,6 +1219,7 @@ class ReloadStubClient:
         params: dict | None = None,
         session_id: str | None = None,
         timeout: float = 5.0,
+        surface_error_hints: bool = True,
     ) -> dict:
         self.calls.append(
             {
@@ -1224,6 +1227,7 @@ class ReloadStubClient:
                 "params": params,
                 "session_id": session_id,
                 "timeout": timeout,
+                "surface_error_hints": surface_error_hints,
             }
         )
         if command == "reload_plugin":
@@ -1491,7 +1495,9 @@ async def test_logs_read_handler_plugin_normalizes_structured_payload():
     ## the public Python API still returns the legacy [str] shape for that
     ## source so existing callers don't shift.
     class StructuredPluginClient(StubClient):
-        async def send(self, command, params=None, session_id=None, timeout=5.0):
+        async def send(
+            self, command, params=None, session_id=None, timeout=5.0, surface_error_hints=True
+        ):
             self.calls.append(
                 {
                     "command": command,
@@ -3444,7 +3450,9 @@ async def test_project_stop_handler_passes_through_idempotent_payload():
     """
 
     class IdempotentStopClient(StubClient):
-        async def send(self, command, params=None, session_id=None, timeout=5.0):
+        async def send(
+            self, command, params=None, session_id=None, timeout=5.0, surface_error_hints=True
+        ):
             self.calls.append({"command": command, "params": params})
             return {
                 "stopped": True,
@@ -3464,7 +3472,9 @@ async def test_project_run_handler_passes_through_already_running_payload():
     """Idempotent-run path (was_already_running=true) flows through unchanged."""
 
     class AlreadyRunningClient(StubClient):
-        async def send(self, command, params=None, session_id=None, timeout=5.0):
+        async def send(
+            self, command, params=None, session_id=None, timeout=5.0, surface_error_hints=True
+        ):
             self.calls.append({"command": command, "params": params})
             return {
                 "mode": (params or {}).get("mode", "main"),
@@ -3646,7 +3656,9 @@ async def test_editor_screenshot_handler_custom_angles():
 
 async def test_editor_screenshot_handler_view_target_not_found_single():
     class NotFoundClient:
-        async def send(self, command, params=None, session_id=None, timeout=5.0):
+        async def send(
+            self, command, params=None, session_id=None, timeout=5.0, surface_error_hints=True
+        ):
             return {
                 "source": "viewport",
                 "width": 1,
@@ -3670,7 +3682,9 @@ async def test_editor_screenshot_handler_view_target_not_found_single():
 
 async def test_editor_screenshot_handler_view_target_not_found_coverage():
     class NotFoundCoverageClient:
-        async def send(self, command, params=None, session_id=None, timeout=5.0):
+        async def send(
+            self, command, params=None, session_id=None, timeout=5.0, surface_error_hints=True
+        ):
             return {
                 "source": "viewport",
                 "view_target": params["view_target"],
@@ -3745,7 +3759,9 @@ async def test_editor_screenshot_handler_relays_viewport_not_3d_error():
     from godot_ai.godot_client.client import GodotCommandError
 
     class ViewportNot3DClient:
-        async def send(self, command, params=None, session_id=None, timeout=5.0):
+        async def send(
+            self, command, params=None, session_id=None, timeout=5.0, surface_error_hints=True
+        ):
             raise GodotCommandError(
                 code="EDITOR_NOT_READY",
                 message=(
@@ -3781,7 +3797,9 @@ async def test_editor_screenshot_handler_relays_viewport_empty_error():
     from godot_ai.godot_client.client import GodotCommandError
 
     class ViewportEmptyClient:
-        async def send(self, command, params=None, session_id=None, timeout=5.0):
+        async def send(
+            self, command, params=None, session_id=None, timeout=5.0, surface_error_hints=True
+        ):
             raise GodotCommandError(
                 code="EDITOR_NOT_READY",
                 message="Captured an empty image from viewport.",
@@ -4590,7 +4608,9 @@ def _make_stop_project_runtime(
     from godot_ai.sessions.registry import Session
 
     class ReadinessAfterStub(StubClient):
-        async def send(self, command, params=None, session_id=None, timeout=5.0):
+        async def send(
+            self, command, params=None, session_id=None, timeout=5.0, surface_error_hints=True
+        ):
             self.calls.append({"command": command, "params": params})
             return {"stopped": True, "undoable": False, "readiness_after": readiness_after}
 


### PR DESCRIPTION
## Summary

- add a central `McpSurfacedErrorTracker` that promotes Debugger Errors-tab rows into a monotonic surfaced-error watermark
- stamp `error_watermark` on plugin responses and inject `new_errors_since_last_call` / `new_errors_hint` on the Python client side
- route `recent_errors` through the same complete source so Debugger-tab-only runtime errors are no longer missed
- keep dispatch watermarks cheap with cached/throttled debugger scans, silent first-observation baselining, and capped promoted Debugger entries
- consolidate Debugger Errors-tree parsing in the tracker and remove the duplicate reader from `EditorHandler`

## Testing

- `python -m compileall -q src tests`
- `ruff check src/ tests/`
- `pytest -q`
  - `1204 passed, 11 skipped, 1 warning`
- Godot `test_run suite=editor`
  - `147 passed, 2 skipped`
- Godot full `test_run`
  - `1537 passed, 19 skipped`
- Live dev-Python smoke on `server_launch_mode=dev_venv`
  - triggered a deferred game runtime error
  - next successful `editor_state` returned `new_errors_since_last_call: 2`
  - `logs_read(source="editor", include_details=true)` showed the Debugger Errors-tab row
  - `logs_read(source="game", include_details=true)` showed the game error row

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added surfaced error tracking using per-response `error_watermark`, plus `new_errors_since_last_call` and a one-time `new_errors_hint` to guide you to relevant logs.
  * Improved debugger/editor error aggregation by promoting debugger errors into the surfaced error stream and supporting cursor-based pagination.
  * Added run-scoped game warning/error counters used for watermarking.

* **Bug Fixes**
  * Ensured success, handler-error, deferred-timeout, and backpressure responses consistently stamp/propagate watermark metadata.

* **Tests**
  * Expanded unit/integration coverage for watermark stamping, delta/hint behavior, reset/de-duplication, and capped debugger promotion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->