### PR TITLE
Gate self-update below Godot 4.5

### DIFF
--- a/plugin/addons/godot_ai/utils/update_manager.gd
+++ b/plugin/addons/godot_ai/utils/update_manager.gd
@@ -124,13 +124,10 @@ func clear_pending_download() -> void:
 	_latest_checksum_url = ""
 
 
-## True when the running Godot can self-update in place. Godot < 4.4 takes
-## the `_install_zip_inline` extract-then-restart path, and that engine's
-## stricter `GDScript::reload()` (`!p_keep_state && has_instances` ->
-## `ERR_ALREADY_IN_USE`) turns the extract-over-live-scripts into a reload
-## error flood plus a SIGSEGV in `EditorDockManager::remove_dock` /
-## `SceneTree::finalize` on the restart/quit (#475). So on < 4.4 we don't
-## run the in-editor pipeline at all — the user updates manually.
+## True when the running Godot is within the supported self-update floor.
+## The next compatibility-breaking release requires Godot 4.5 APIs/classes
+## in always-loaded scripts, so engines below 4.5 must not be offered a
+## one-click update into that release.
 ## Guards `major` too so a future Godot 5.x (minor 0) isn't misclassified.
 func _can_self_update() -> bool:
 	var v := Engine.get_version_info()
@@ -138,49 +135,45 @@ func _can_self_update() -> bool:
 
 
 ## Pure version predicate, split out so it's testable without faking the
-## running engine. In-editor self-update needs Godot >= 4.4.
+## running engine. In-editor self-update needs Godot >= 4.5.
 static func _version_can_self_update(major: int, minor: int) -> bool:
+	return major > 4 or (major == 4 and minor >= 5)
+
+
+## Runner-backed reload is available on Godot 4.4+, but the public
+## self-update gate may be stricter when the next release raises the floor.
+static func _version_supports_runner_reload(major: int, minor: int) -> bool:
 	return major > 4 or (major == 4 and minor >= 4)
 
 
-## Banner guidance for the gated (< 4.4) path. Shown up-front at check time
-## (with the available version) and again on click, so the user understands
-## the manual-update flow before they press anything. Single source of truth
-## so check-time and click-time text never drift.
+## Banner guidance for the gated (< 4.5) path. Shown up-front at check time
+## so users know this is the last compatible plugin for their editor.
 static func _manual_update_label(version: String) -> String:
-	var prefix := "Update available"
+	var release_noun := "release"
+	var suffix := ""
 	if not version.is_empty():
-		prefix = "Update v%s available" % version
+		release_noun = "version"
+		suffix = " (latest: v%s)" % version
 	return (
-		prefix
-		+ " — in-editor update needs Godot 4.4+. Open the download page, then "
-		+ "replace addons/godot_ai/ manually and relaunch."
+		"This is the last Godot AI %s for this Godot%s. " % [release_noun, suffix]
+		+ "Upgrade to Godot 4.5+ to keep receiving updates."
 	)
 
 
-## Driven by the dock's Update button. On Godot < 4.4 (see `_can_self_update`)
-## the in-editor install is disabled — we open the release page for a manual
-## download instead, never entering the extract pipeline that crashes those
-## engines. With no resolved download URL — either the check never completed,
-## or the release didn't ship a matching asset — also falls back to opening
-## the release page. Otherwise kicks off the download → extract → reload
-## pipeline.
+## Driven by the dock's Update button. On Godot < 4.5 (see `_can_self_update`)
+## the in-editor install is disabled so users cannot install an incompatible
+## latest release. With no resolved download URL — either the check never
+## completed, or the release didn't ship a matching asset — falls back to
+## opening the release page. Otherwise kicks off the download → extract →
+## reload pipeline.
 func start_install() -> void:
 	if not _can_self_update():
-		## Only claim success + lock the button if the browser actually opened.
-		## On failure (no handler, headless) keep the button enabled so the
-		## user can retry. Either way, leave the version-bearing guidance label
-		## from check time in place — don't re-emit label_text.
-		if OS.shell_open(RELEASES_PAGE) == OK:
-			install_state_changed.emit({
-				"button_text": "Opened download page",
-				"button_disabled": true,
-			})
-		else:
-			install_state_changed.emit({
-				"button_text": "Couldn't open browser — retry",
-				"button_disabled": false,
-			})
+		install_state_changed.emit({
+			"button_text": "Upgrade Godot",
+			"button_disabled": true,
+			"label_text": _manual_update_label(""),
+			"banner_visible": true,
+		})
 		return
 
 	if _latest_download_url.is_empty():
@@ -355,17 +348,20 @@ func _on_update_check_completed(
 	var parsed := parse_releases_response(result, response_code, body)
 	if not bool(parsed.get("has_update", false)):
 		return
+	## On engines below the next support floor, do not arm the download URL
+	## or emit a normal update offer. A later 4.5+-only `latest` release would
+	## otherwise let 4.4 users install a plugin their editor cannot parse.
+	if not _can_self_update():
+		install_state_changed.emit({
+			"button_text": "Upgrade Godot",
+			"button_disabled": true,
+			"label_text": _manual_update_label(String(parsed.get("version", ""))),
+			"banner_visible": true,
+		})
+		return
 	_latest_download_url = String(parsed.get("download_url", ""))
 	_latest_checksum_url = String(parsed.get("checksum_url", ""))
 	update_check_completed.emit(parsed)
-	## On engines that can't self-update (Godot < 4.4, #475), surface the
-	## full manual-update guidance AND relabel the button up-front — before
-	## any click — so the user knows what the button does and why.
-	if not _can_self_update():
-		install_state_changed.emit({
-			"button_text": "Open download page",
-			"label_text": _manual_update_label(String(parsed.get("version", ""))),
-		})
 
 
 func _on_download_completed(
@@ -526,11 +522,10 @@ func _install_zip() -> void:
 		_plugin != null
 		and _plugin.has_method("install_downloaded_update")
 	)
-	## Same major-aware predicate as the _can_self_update() gate, so a future
-	## Godot 5.x (minor 0) takes the runner path the gate promised — not the
-	## pre-4.4 inline extract. A bare `minor >= 4` here would route 5.0 to the
-	## crash-prone inline path even though the gate let it in.
-	if _version_can_self_update(int(version.get("major", 0)), int(version.get("minor", 0))) and has_runner:
+	## Runner support starts at 4.4 even though the public self-update offer is
+	## currently gated at 4.5. Keep this separate so bypassed/internal install
+	## paths do not accidentally send a 4.4 editor through the inline fallback.
+	if _version_supports_runner_reload(int(version.get("major", 0)), int(version.get("minor", 0))) and has_runner:
 		install_state_changed.emit({"button_text": "Reloading..."})
 		## Runner takes over: plugin tears down, runner extracts + scans +
 		## re-enables. `install_downloaded_update` calls
@@ -610,7 +605,7 @@ func _install_zip_inline(version: Dictionary) -> void:
 	if _plugin != null and _plugin.has_method("prepare_for_update_reload"):
 		_plugin.prepare_for_update_reload()
 
-	if _version_can_self_update(int(version.get("major", 0)), int(version.get("minor", 0))):
+	if _version_supports_runner_reload(int(version.get("major", 0)), int(version.get("minor", 0))):
 		install_state_changed.emit({"button_text": "Scanning..."})
 		## Filesystem scan must complete before plugin reload — otherwise
 		## plugin.gd re-parses against a ClassDB that hasn't seen the new

--- a/test_project/tests/test_update_manager.gd
+++ b/test_project/tests/test_update_manager.gd
@@ -25,9 +25,11 @@ func suite_name() -> String:
 
 # ---- _version_can_self_update (pure / static, #475 gate) ---------------
 
-func test_version_can_self_update_false_below_4_4() -> void:
-	## Godot < 4.4 takes the extract-then-restart path that crashes (#475),
-	## so the in-editor self-update is gated off on those engines.
+func test_version_can_self_update_false_below_4_5() -> void:
+	## Godot < 4.5 must not self-update into releases that require the
+	## 4.5 Logger API at parse time.
+	assert_false(McpUpdateManagerScript._version_can_self_update(4, 4),
+		"4.4 must be gated once the next plugin release requires Godot 4.5+")
 	assert_false(McpUpdateManagerScript._version_can_self_update(4, 3),
 		"4.3 must be gated (in-editor self-update disabled)")
 	assert_false(McpUpdateManagerScript._version_can_self_update(4, 0),
@@ -36,31 +38,43 @@ func test_version_can_self_update_false_below_4_4() -> void:
 		"a hypothetical 3.x must be gated")
 
 
-func test_version_can_self_update_true_at_and_above_4_4() -> void:
-	assert_true(McpUpdateManagerScript._version_can_self_update(4, 4),
-		"4.4 is the first engine that can self-update in place")
+func test_version_can_self_update_true_at_and_above_4_5() -> void:
+	assert_true(McpUpdateManagerScript._version_can_self_update(4, 5),
+		"4.5 is the first engine that can self-update in place")
 	assert_true(McpUpdateManagerScript._version_can_self_update(4, 6),
 		"4.6 can self-update")
 	assert_true(McpUpdateManagerScript._version_can_self_update(5, 0),
 		"a future 5.0 (minor 0) must not be misclassified by the minor check")
 
 
+func test_runner_reload_support_stays_available_on_4_4() -> void:
+	## The transitional release suppresses the public update offer on 4.4,
+	## but runner reload support itself still starts at 4.4. Keep these
+	## predicates separate so internal/bypassed install paths do not route
+	## 4.4 through the legacy inline fallback.
+	assert_true(McpUpdateManagerScript._version_supports_runner_reload(4, 4),
+		"4.4 supports runner-backed reloads")
+	assert_false(McpUpdateManagerScript._version_supports_runner_reload(4, 3),
+		"4.3 still uses the inline fallback")
+	assert_true(McpUpdateManagerScript._version_supports_runner_reload(5, 0),
+		"future majors must not be misclassified by the minor check")
+
+
 func test_manual_update_label_includes_version_and_guidance() -> void:
-	## Shown up-front on < 4.4 (before any click) so the user understands the
-	## manual-update flow. Must name the version and the 4.4+ requirement.
+	## Shown up-front on < 4.5 so the user understands they need a newer
+	## editor before installing the latest plugin.
 	var with_v := McpUpdateManagerScript._manual_update_label("2.5.7")
 	assert_contains(with_v, "2.5.7", "label must name the available version")
-	assert_contains(with_v, "Godot 4.4+", "label must state the engine requirement")
-	assert_contains(with_v, "addons/godot_ai/", "label must point at the manual-swap path")
+	assert_contains(with_v, "Godot 4.5+", "label must state the engine requirement")
+	assert_contains(with_v, "last Godot AI version", "label must say updates are gated")
 
 
 func test_manual_update_label_omits_version_when_unknown() -> void:
-	## On the click path the version isn't re-threaded; the label degrades to
-	## a generic "Update available" without a stray "v" token.
+	## On the click path the version isn't re-threaded; the label still gives
+	## floor guidance without a stray "v" token.
 	var no_v := McpUpdateManagerScript._manual_update_label("")
-	assert_contains(no_v, "Update available", "generic label must still lead with 'Update available'")
 	assert_false(no_v.contains(" v"), "no version token when version is empty")
-	assert_contains(no_v, "Godot 4.4+", "label must still state the engine requirement")
+	assert_contains(no_v, "Godot 4.5+", "label must still state the engine requirement")
 
 
 # ---- _is_safe_zip_addon_file (pure / static, #522) --------------------
@@ -389,6 +403,72 @@ func test_install_in_flight_default_false() -> void:
 	var manager = McpUpdateManagerScript.new()
 	assert_false(manager.is_install_in_flight(),
 		"A fresh manager must default to is_install_in_flight() == false")
+	manager.free()
+
+
+# ---- Godot floor update gate -------------------------------------------
+
+class _NoSelfUpdateManager extends McpUpdateManagerScript:
+	func _can_self_update() -> bool:
+		return false
+
+
+func test_update_check_below_floor_does_not_arm_download() -> void:
+	## A 4.4 editor must not cache the latest ZIP URL or emit the normal
+	## update offer. Otherwise one click can install the 4.5+-only release.
+	var manager = _NoSelfUpdateManager.new()
+	var body := _make_body(_make_release_payload("v999.0.0"))
+	var states: Array = []
+	var update_results: Array = []
+	manager.install_state_changed.connect(func(state: Dictionary) -> void:
+		states.append(state)
+	)
+	manager.update_check_completed.connect(func(result: Dictionary) -> void:
+		update_results.append(result)
+	)
+
+	manager._on_update_check_completed(HTTPRequest.RESULT_SUCCESS, 200, [], body)
+
+	assert_eq(update_results.size(), 0,
+		"below-floor update checks must not emit the normal update offer")
+	assert_eq(manager._latest_download_url, "",
+		"below-floor update checks must not arm the ZIP download URL")
+	assert_eq(manager._latest_checksum_url, "",
+		"below-floor update checks must not arm the checksum URL")
+	assert_eq(states.size(), 1,
+		"below-floor update checks must emit one guidance banner state")
+	var state: Dictionary = states[0]
+	assert_eq(String(state.get("button_text", "")), "Upgrade Godot",
+		"below-floor banner must make the required action clear")
+	assert_eq(bool(state.get("button_disabled", false)), true,
+		"below-floor update button must be disabled")
+	assert_eq(bool(state.get("banner_visible", false)), true,
+		"below-floor guidance must keep the banner visible")
+	assert_contains(String(state.get("label_text", "")), "Godot 4.5+",
+		"below-floor guidance must state the new engine floor")
+	manager.free()
+
+
+func test_start_install_below_floor_only_repaints_guidance() -> void:
+	## If a stale UI path calls start_install anyway, keep it inside the
+	## guidance state rather than opening the browser or entering install.
+	var manager = _NoSelfUpdateManager.new()
+	var states: Array = []
+	manager.install_state_changed.connect(func(state: Dictionary) -> void:
+		states.append(state)
+	)
+
+	manager.start_install()
+
+	assert_eq(states.size(), 1,
+		"below-floor start_install must emit guidance exactly once")
+	var state: Dictionary = states[0]
+	assert_eq(String(state.get("button_text", "")), "Upgrade Godot",
+		"below-floor click path must keep the action as Godot upgrade")
+	assert_eq(bool(state.get("button_disabled", false)), true,
+		"below-floor click path must keep the button disabled")
+	assert_contains(String(state.get("label_text", "")), "Godot 4.5+",
+		"below-floor click path must restate the engine requirement")
 	manager.free()
 
 


### PR DESCRIPTION
## Summary
Related to #628
Adds the transitional updater gate before the Godot 4.5+ floor-bump release.

- Keeps the plugin otherwise 4.3-compatible.
- Changes the self-update offer gate from Godot 4.4+ to Godot 4.5+.
- On Godot <4.5, update checks now show an “Upgrade Godot” guidance banner instead of arming the latest ZIP download URL.
- Prevents `update_check_completed` from emitting a normal update offer on below-floor editors.
- Keeps runner-reload capability separate from the public self-update floor, so Godot 4.4 still uses the safe runner path if an internal/bypassed install path reaches it.

## Why

The next floor-bump release will contain always-loaded scripts that require Godot 4.5 APIs/classes. Without this transitional release, existing Godot 4.4 installs could click Update and install a plugin their editor cannot parse.

## Testing

- `godot --headless --path test_project --import`
- `bash script/ci-check-gdscript godot-import.log`
- Focused `update_manager` GDScript suite: `29 passed, 0 failed, 1 skipped`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the in-editor update flow to better handle older editor versions, showing a clear upgrade notice when updates aren’t supported.
  * Clarified the update guidance so users on older versions see the latest compatible plugin path instead of a misleading download prompt.
  * Preserved install/reload behavior for supported versions while falling back to a restart message on older ones.

* **Tests**
  * Expanded coverage for version checks, update prompts, and install behavior across supported and unsupported editor versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->