### PR TITLE
game_helper: keep the game at full FPS when its window is backgrounded

### DIFF
--- a/plugin/addons/godot_ai/runtime/game_helper.gd
+++ b/plugin/addons/godot_ai/runtime/game_helper.gd
@@ -75,6 +75,13 @@ func _ready() -> void:
 	## handshake completes; the capture sits until a message arrives.
 	EngineDebugger.register_message_capture(CAPTURE_PREFIX, _on_debug_message)
 	_registered = true
+	## Keep the game ticking at full speed even when its window is backgrounded
+	## behind the editor. Otherwise Godot's idle throttle slows the frame loop to a
+	## crawl and MCP game_eval awaits (create_timer / process_frame) stall or hit the
+	## deadline. (macOS App Nap is OS-level and can't be fully disabled from script,
+	## so this greatly reduces — but may not 100% eliminate — occluded-window slowdown.)
+	OS.low_processor_usage_mode = false
+	Engine.max_fps = 0
 	## Capture print() / printerr() / push_error() / push_warning() and
 	## ferry them to the editor in mcp:log_batch messages flushed from
 	## _process. Logger subclassing was added in Godot 4.5 — gate on

--- a/tests/unit/test_game_helper_no_throttle.py
+++ b/tests/unit/test_game_helper_no_throttle.py
@@ -1,0 +1,55 @@
+"""Source-pin: game_helper.gd must disable idle throttling in _ready().
+
+game_helper.gd is the _mcp_game_helper autoload that runs inside the game
+process. When the game window sits behind the focused editor, Godot's idle
+throttle slows the frame loop, so MCP game_eval awaits that depend on the frame
+loop advancing (create_timer, process_frame) stall or hit the reply deadline.
+_ready() sets OS.low_processor_usage_mode = false and Engine.max_fps = 0 so the
+game keeps ticking at full speed regardless of window focus. These checks pin
+that behavior so a later edit does not reintroduce the throttle.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[2] / "plugin" / "addons" / "godot_ai"
+GAME_HELPER = PLUGIN_ROOT / "runtime" / "game_helper.gd"
+
+
+def _ready_body(source: str) -> str:
+    """Return the source of game_helper.gd from `func _ready()` up to the next
+    top-level `func ` declaration, so assertions target _ready() only.
+    """
+    lines = source.splitlines()
+    start = next(
+        (i for i, line in enumerate(lines) if line.startswith("func _ready(")),
+        None,
+    )
+    assert start is not None, "game_helper.gd has no func _ready()"
+    end = len(lines)
+    for i in range(start + 1, len(lines)):
+        if lines[i].startswith("func "):
+            end = i
+            break
+    return "\n".join(lines[start:end])
+
+
+def test_game_helper_disables_low_processor_usage_mode() -> None:
+    """_ready() must turn off idle throttling so a backgrounded game keeps ticking."""
+    body = _ready_body(GAME_HELPER.read_text(encoding="utf-8"))
+    assert re.search(r"OS\.low_processor_usage_mode\s*=\s*false", body), (
+        "game_helper.gd _ready() must set OS.low_processor_usage_mode = false so "
+        "the game does not idle-throttle when its window is backgrounded behind "
+        "the editor, which would stall MCP game_eval awaits."
+    )
+
+
+def test_game_helper_uncaps_max_fps() -> None:
+    """_ready() must uncap the frame rate for the same reason."""
+    body = _ready_body(GAME_HELPER.read_text(encoding="utf-8"))
+    assert re.search(r"Engine\.max_fps\s*=\s*0", body), (
+        "game_helper.gd _ready() must set Engine.max_fps = 0 so the game runs at "
+        "full speed when backgrounded, keeping MCP game_eval awaits responsive."
+    )


### PR DESCRIPTION
## Summary

The game_helper autoload now keeps the running game at full frame rate when its
window is not focused. Before this, a game running behind the focused editor was
slowed by Godot's idle throttle, which made MCP game_eval calls that wait on the
frame loop unreliable during editor-driven sessions.

## What changed

game_helper.gd sets OS.low_processor_usage_mode = false and Engine.max_fps = 0 in
_ready(). The game_helper autoload runs inside the game process, so this keeps the
frame loop advancing at full speed even when the editor, not the game, has focus.
game_eval awaits that depend on the frame loop, such as
get_tree().create_timer(...) and await get_tree().process_frame, no longer stall
or hit the editor-side reply deadline.

The change is scoped to the MCP helper autoload, which is only registered while
the plugin is active, so exported and shipped builds are unaffected. It adds no
new API surface or parameters.

macOS App Nap is an OS-level throttle that cannot be fully disabled from GDScript,
so a fully occluded window may still slow somewhat. This change removes the
engine-level idle throttle, which is the dominant factor in practice.

A source-pin unit test (tests/unit/test_game_helper_no_throttle.py) asserts both
assignments are present in _ready(), matching the existing
test_game_helper_no_editor_interface_identifier.py.

## Validation

    uv run --extra dev ruff check src tests
        All checks passed
    uv run --extra dev pytest tests/unit/test_game_helper_no_editor_interface_identifier.py tests/unit/test_game_helper_no_throttle.py -q
        4 passed
    uv run --extra dev pytest tests/unit -q
        929 passed, 2 skipped
    bash script/ci-check-gdscript
        All GDScript files OK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background performance so the game continues running smoothly at full speed even when not focused.
  * Removed idle throttling and frame limiting to prevent unintended FPS caps during editor-side testing.  
* **Tests**
  * Added unit tests to verify throttling is disabled and FPS is uncapped in the game helper startup logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->