### PR TITLE
Fix remove_action for actions persisted in project.godot but not loaded in InputMap

### DIFF
--- a/plugin/addons/godot_ai/handlers/input_handler.gd
+++ b/plugin/addons/godot_ai/handlers/input_handler.gd
@@ -129,23 +129,31 @@ func remove_action(params: Dictionary) -> Dictionary:
 	if action.is_empty():
 		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: action")
 
-	if not InputMap.has_action(action):
+	var key := "input/%s" % action
+	var was_loaded := InputMap.has_action(action)
+	var old_setting = ProjectSettings.get_setting(key) if ProjectSettings.has_setting(key) else null
+
+	## An action can live in the editor process's InputMap, in project.godot,
+	## or both. Actions persisted by a previous editor session exist only on
+	## disk (`loaded_in_input_map: false` in list_actions) — those must still
+	## be removable. #632
+	if not was_loaded and old_setting == null:
 		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "Action '%s' not found" % action)
 
-	var key := "input/%s" % action
-	var old_setting = ProjectSettings.get_setting(key) if ProjectSettings.has_setting(key) else null
-	InputMap.erase_action(action)
+	if was_loaded:
+		InputMap.erase_action(action)
 
 	if old_setting != null:
 		ProjectSettings.clear(key)
 		var err := ProjectSettings.save()
 		if err != OK:
-			var dz: float = old_setting.get("deadzone", 0.5) if old_setting is Dictionary else 0.5
-			InputMap.add_action(action, dz)
-			if old_setting is Dictionary:
-				for ev in old_setting.get("events", []):
-					if ev is InputEvent:
-						InputMap.action_add_event(action, ev)
+			if was_loaded:
+				var dz: float = old_setting.get("deadzone", 0.5) if old_setting is Dictionary else 0.5
+				InputMap.add_action(action, dz)
+				if old_setting is Dictionary:
+					for ev in old_setting.get("events", []):
+						if ev is InputEvent:
+							InputMap.action_add_event(action, ev)
 			ProjectSettings.set_setting(key, old_setting)
 			return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR,
 				"Failed to save project settings while removing action '%s': %s (error %d)" % [action, error_string(err), err])
@@ -154,6 +162,7 @@ func remove_action(params: Dictionary) -> Dictionary:
 		"data": {
 			"action": action,
 			"removed": true,
+			"was_loaded": was_loaded,
 			"undoable": false,
 			"reason": "Input actions are saved to project.godot",
 		}

--- a/src/godot_ai/tools/input_map.py
+++ b/src/godot_ai/tools/input_map.py
@@ -31,7 +31,10 @@ Ops:
         Idempotently create or persist an input action. If the action exists
         in live InputMap or in project.godot, the existing state is preserved.
   • remove_action(action)
-        Remove an action and all its event bindings.
+        Remove an action and all its event bindings. Also removes actions
+        persisted in project.godot but not loaded in the live InputMap
+        (``loaded_in_input_map: false`` in ``list``), e.g. actions created
+        by a previous editor session.
   • bind_event(action, event_type, keycode="", ctrl=False, alt=False,
                 shift=False, meta=False, button=None, axis=None,
                 axis_value=1.0)

--- a/test_project/tests/test_input.gd
+++ b/test_project/tests/test_input.gd
@@ -181,6 +181,34 @@ func test_remove_action_not_found() -> void:
 	assert_is_error(result)
 
 
+func test_remove_action_loaded_and_persisted() -> void:
+	_handler.ensure_action({"action": TEST_ACTION})
+	assert_true(InputMap.has_action(TEST_ACTION), "precondition: action loaded")
+	assert_true(ProjectSettings.has_setting("input/" + TEST_ACTION), "precondition: action persisted")
+
+	var result := _handler.remove_action({"action": TEST_ACTION})
+	assert_has_key(result, "data")
+	assert_eq(result.data.removed, true)
+	assert_eq(result.data.was_loaded, true)
+	assert_false(InputMap.has_action(TEST_ACTION), "action must leave InputMap")
+	assert_false(ProjectSettings.has_setting("input/" + TEST_ACTION), "action must leave project.godot")
+
+
+func test_remove_action_persisted_but_not_loaded() -> void:
+	## #632: actions persisted by a previous editor session are in
+	## project.godot but not in this process's InputMap. remove_action
+	## must still clear them instead of erroring VALUE_OUT_OF_RANGE.
+	var key := "input/" + TEST_ACTION
+	ProjectSettings.set_setting(key, {"deadzone": 0.5, "events": []})
+	assert_false(InputMap.has_action(TEST_ACTION), "precondition: not in live InputMap")
+
+	var result := _handler.remove_action({"action": TEST_ACTION})
+	assert_has_key(result, "data")
+	assert_eq(result.data.removed, true)
+	assert_eq(result.data.was_loaded, false)
+	assert_false(ProjectSettings.has_setting(key), "persisted setting must be cleared")
+
+
 # ----- bind_event -----
 
 func test_bind_event_missing_params() -> void:


### PR DESCRIPTION
## Summary

Fixes #632 — `input_map_manage(op="remove_action")` errored `VALUE_OUT_OF_RANGE: Action not found` for actions persisted in `project.godot` but absent from the editor process's live `InputMap` (the `loaded_in_input_map: false` state that `list` has surfaced since #625). Any action created by a previous editor session was un-removable; found while cleaning up 43 smoke/storm actions after a stormtest run.

## Changes

- `remove_action` now treats presence in **either** store as removable: erases from `InputMap` only when loaded, clears `input/<name>` from ProjectSettings when persisted, and reports `was_loaded` in the response. Not-found now means "in neither store".
- Save-failure rollback restores the `InputMap` entry only when one was actually erased (setting restore unchanged).
- Tool docstring documents the persisted-but-unloaded case.

## Testing

- New GDScript tests: `test_remove_action_loaded_and_persisted` (both stores cleared, `was_loaded: true`) and `test_remove_action_persisted_but_not_loaded` (#632 repro: setting-only action removed, `was_loaded: false`).
- Full suite green against a live Godot 4.6.3 editor via MCP `test_run`: **0 failed, 1589 passed / 7 skipped, 57 suites**.
- `script/ci-check-gdscript`: all files OK. `pytest tests/unit -k input`: 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved action removal so it now handles actions that exist only in saved project settings, even if they aren’t currently loaded in the editor.
  * Removal now correctly clears both live input bindings and persisted settings when applicable, and reports whether the action was loaded at the time.
  * Added coverage for both loaded and persisted-only removal cases to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->