### PR TITLE
scene_open: wait for the scene switch to land before replying (#633)

### DIFF
--- a/plugin/addons/godot_ai/handlers/scene_handler.gd
+++ b/plugin/addons/godot_ai/handlers/scene_handler.gd
@@ -143,6 +143,13 @@ func create_scene(params: Dictionary) -> Dictionary:
 	}
 
 
+## How long open_scene waits for the editor to actually switch to the
+## requested scene before replying switched=false. Tab switches normally land
+## within a few frames; keep this under the dispatcher's 4500 ms deferred
+## default so the coroutine always answers before DEFERRED_TIMEOUT fires.
+const _OPEN_SETTLE_MAX_MSEC := 3000
+
+
 ## Open an existing scene by file path.
 func open_scene(params: Dictionary) -> Dictionary:
 	var path: String = params.get("path", "")
@@ -159,23 +166,78 @@ func open_scene(params: Dictionary) -> Dictionary:
 
 	var scene_root := EditorInterface.get_edited_scene_root()
 	var current_path := scene_root.scene_file_path if scene_root else ""
-	var reloaded_from_disk := false
+	var payload := {
+		"path": path,
+		"force_reload": force_reload,
+		"reloaded_from_disk": false,
+		"previous_scene_path": current_path,
+		"undoable": false,
+		"reason": "Scene navigation cannot be undone via editor undo",
+	}
+
+	if current_path == path and not force_reload:
+		## Already the edited scene — nothing switches, reply immediately.
+		payload["switched"] = true
+		payload["settle"] = "already_current"
+		return {"data": payload}
+
 	if force_reload and current_path == path:
 		EditorInterface.reload_scene_from_path(path)
-		reloaded_from_disk = true
+		payload["reloaded_from_disk"] = true
 	else:
 		EditorInterface.open_scene_from_path(path)
 
-	return {
-		"data": {
-			"path": path,
-			"force_reload": force_reload,
-			"reloaded_from_disk": reloaded_from_disk,
-			"previous_scene_path": current_path,
-			"undoable": false,
-			"reason": "Scene navigation cannot be undone via editor undo",
-		}
-	}
+	## The tab switch completes asynchronously; replying now lets an immediate
+	## follow-up write land on the PREVIOUS scene (#633 — a scene_save issued
+	## right after open_scene saved the old scene). Defer the reply until the
+	## edited scene actually is `path`, so success means "the editor is now
+	## editing the scene you asked for".
+	var request_id: String = params.get("_request_id", "")
+	if _connection != null and not request_id.is_empty():
+		_finish_open_scene_deferred(_connection, request_id, path, payload)
+		return McpDispatcher.DEFERRED_RESPONSE
+
+	## Synchronous fallback (batch_execute and unit-test contexts can't await):
+	## preserve the old reply-immediately behavior, flagged as not waited on.
+	payload["switched"] = false
+	payload["settle"] = "not_waited"
+	return {"data": payload}
+
+
+## `static` is load-bearing (same reason as FilesystemHandler's deferred scan
+## finish): the coroutine must outlive this RefCounted handler, which can be
+## freed mid-await by an editor_reload_plugin. Parameterise everything;
+## reference no instance state.
+static func _finish_open_scene_deferred(
+	connection: McpConnection,
+	request_id: String,
+	path: String,
+	payload: Dictionary,
+) -> void:
+	if not is_instance_valid(connection):
+		return
+	var tree := connection.get_tree()
+	if tree == null:
+		return
+	# Hand back a frame so _dispatch() registers this request as deferred
+	# before the coroutine can push a reply.
+	await tree.process_frame
+	var deadline_ms := Time.get_ticks_msec() + _OPEN_SETTLE_MAX_MSEC
+	while Time.get_ticks_msec() < deadline_ms:
+		var root := EditorInterface.get_edited_scene_root()
+		if root != null and root.scene_file_path == path:
+			if not is_instance_valid(connection):
+				return
+			payload["switched"] = true
+			payload["settle"] = "settled"
+			connection.send_deferred_response(request_id, {"data": payload})
+			return
+		await tree.process_frame
+	if not is_instance_valid(connection):
+		return
+	payload["switched"] = false
+	payload["settle"] = "timeout"
+	connection.send_deferred_response(request_id, {"data": payload})
 
 
 ## Save the currently edited scene.

--- a/plugin/addons/godot_ai/handlers/scene_handler.gd
+++ b/plugin/addons/godot_ai/handlers/scene_handler.gd
@@ -166,6 +166,11 @@ func open_scene(params: Dictionary) -> Dictionary:
 
 	var scene_root := EditorInterface.get_edited_scene_root()
 	var current_path := scene_root.scene_file_path if scene_root else ""
+	## Instance id of the root at call time. A completed open OR reload always
+	## replaces the edited-scene root with a NEW instance, so this is the
+	## reliable completion signal — unlike scene_file_path, which is unchanged
+	## across a force_reload of the already-open scene (#633 review).
+	var prev_root_id := scene_root.get_instance_id() if scene_root else 0
 	var payload := {
 		"path": path,
 		"force_reload": force_reload,
@@ -190,11 +195,11 @@ func open_scene(params: Dictionary) -> Dictionary:
 	## The tab switch completes asynchronously; replying now lets an immediate
 	## follow-up write land on the PREVIOUS scene (#633 — a scene_save issued
 	## right after open_scene saved the old scene). Defer the reply until the
-	## edited scene actually is `path`, so success means "the editor is now
-	## editing the scene you asked for".
+	## edited scene actually is `path` AND its root is a fresh instance, so
+	## success means "the editor is now editing the (re)loaded scene".
 	var request_id: String = params.get("_request_id", "")
 	if _connection != null and not request_id.is_empty():
-		_finish_open_scene_deferred(_connection, request_id, path, payload)
+		_finish_open_scene_deferred(_connection, request_id, path, prev_root_id, payload)
 		return McpDispatcher.DEFERRED_RESPONSE
 
 	## Synchronous fallback (batch_execute and unit-test contexts can't await):
@@ -212,6 +217,7 @@ static func _finish_open_scene_deferred(
 	connection: McpConnection,
 	request_id: String,
 	path: String,
+	prev_root_id: int,
 	payload: Dictionary,
 ) -> void:
 	if not is_instance_valid(connection):
@@ -225,7 +231,11 @@ static func _finish_open_scene_deferred(
 	var deadline_ms := Time.get_ticks_msec() + _OPEN_SETTLE_MAX_MSEC
 	while Time.get_ticks_msec() < deadline_ms:
 		var root := EditorInterface.get_edited_scene_root()
-		if root != null and root.scene_file_path == path:
+		# Require BOTH the target path AND a fresh root instance: a
+		# force_reload keeps scene_file_path == path across the reload, so the
+		# instance swap is what proves the (re)load actually completed rather
+		# than the coroutine settling on the stale pre-reload root.
+		if root != null and root.scene_file_path == path and root.get_instance_id() != prev_root_id:
 			if not is_instance_valid(connection):
 				return
 			payload["switched"] = true

--- a/src/godot_ai/tools/scene.py
+++ b/src/godot_ai/tools/scene.py
@@ -79,6 +79,12 @@ def register_scene_tools(mcp: FastMCP, *, include_non_core: bool = True) -> None
         authority and the editor should discard the open in-memory copy and
         re-read the scene from disk.
 
+        The reply is sent only after the editor has actually switched to the
+        requested scene (``switched: true``), so follow-up writes are safe
+        immediately. ``switched: false`` with ``settle: "timeout"`` means the
+        switch had not landed within the wait window — re-check
+        ``editor_state`` before writing.
+
         Args:
             path: File path of the scene to open (e.g. "res://main.tscn").
             force_reload: Re-read the scene from disk even when it is already

--- a/src/godot_ai/tools/scene.py
+++ b/src/godot_ai/tools/scene.py
@@ -82,8 +82,10 @@ def register_scene_tools(mcp: FastMCP, *, include_non_core: bool = True) -> None
         The reply is sent only after the editor has actually switched to the
         requested scene (``switched: true``), so follow-up writes are safe
         immediately. ``switched: false`` with ``settle: "timeout"`` means the
-        switch had not landed within the wait window — re-check
-        ``editor_state`` before writing.
+        switch had not landed within the wait window. In synchronous contexts
+        (e.g. inside ``batch_execute``) the reply returns immediately with
+        ``switched: false`` and ``settle: "not_waited"``. In both of those
+        cases, re-check ``editor_state`` before issuing follow-up writes.
 
         Args:
             path: File path of the scene to open (e.g. "res://main.tscn").

--- a/test_project/tests/test_scene.gd
+++ b/test_project/tests/test_scene.gd
@@ -196,6 +196,23 @@ func test_open_scene_nonexistent() -> void:
 	assert_is_error(result)
 
 
+func test_open_scene_already_current_reports_switched() -> void:
+	## #633: opening the scene that is already edited must not go through the
+	## async switch path — it replies immediately with switched=true. This is
+	## also the only open_scene success path testable synchronously (opening a
+	## different scene triggers UI that blocks the test runner).
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null or scene_root.scene_file_path.is_empty():
+		skip("No saved scene open")
+		return
+	var current := scene_root.scene_file_path
+	var result := _handler.open_scene({"path": current})
+	assert_has_key(result, "data")
+	assert_eq(result.data.switched, true, "already-current open is switched")
+	assert_eq(result.data.settle, "already_current")
+	assert_eq(result.data.previous_scene_path, current)
+
+
 # ----- save_scene / save_scene_as (validation only — save triggers modal dialog) -----
 
 func test_save_scene_never_saved_returns_actionable_validation_error() -> void:


### PR DESCRIPTION
## Summary

Fixes #633 — `scene_open` replied with success as soon as it *requested* the tab switch, but `EditorInterface.open_scene_from_path()` completes the switch asynchronously. An agent issuing an immediate follow-up write could hit the **previous** scene. Observed live during a smoke: a `scene_save` issued right after `scene_open` saved the *old* scene to disk, and a `script_attach` resolved against the old scene's root.

## Fix

`open_scene` now defers its reply (via the dispatcher's existing `DEFERRED_RESPONSE` mechanism) until `EditorInterface.get_edited_scene_root().scene_file_path == path`. A success reply now means "the editor is now editing the scene you asked for", so follow-up writes are safe.

New response fields:
- `switched: true` / `settle: "settled"` — switch confirmed landed
- `settle: "already_current"` — requested scene was already edited (immediate, no async)
- `switched: false` / `settle: "timeout"` — switch not observed within 3s (re-check `editor_state` before writing)
- `switched: false` / `settle: "not_waited"` — synchronous fallback for `batch_execute` / no-connection contexts that can't await

The deferred coroutine is `static` (mirrors `FilesystemHandler._finish_scan_deferred`) so it survives the handler being freed by an `editor_reload_plugin` mid-await. Wait window (3s) stays under the dispatcher's 4500ms deferred default.

## Testing

Verified live on Godot 4.6.3 via MCP:
- Two throwaway scenes; `scene_open(B)` from A → `settle: settled, switched: true`; `editor_state` immediately after shows `current_scene` already switched.
- `scene_open` of the already-current scene → `settle: already_current`.
- `batch_execute([open_scene(A), create_node])` → open reports `not_waited`, and the node still lands on `/SceneA` (switch behavior preserved).
- New GDScript test `test_open_scene_already_current_reports_switched`.
- Full suite green via `test_run`: **0 failed, 1587 passed / 8 skipped, 57 suites**. `ci-check-gdscript`: all files OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scene opening can now report completion after the editor finishes switching, including whether the target scene was already current, settled successfully, or timed out.

* **Bug Fixes**
  * Improved reliability by preventing follow-up actions from occurring before the editor actually switches scenes, with a clear fallback when waiting isn’t possible.

* **Tests**
  * Added a validation test to confirm that opening the already-current scene reports `switched=true` with `settle="already_current"` and the correct `previous_scene_path`.

* **Documentation**
  * Updated tool documentation to clarify response timing and how to interpret timeout results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->