### PR TITLE
Polish: reject malformed game mouse position; flag test_run scene mismatch (#635)

### DIFF
--- a/plugin/addons/godot_ai/handlers/test_handler.gd
+++ b/plugin/addons/godot_ai/handlers/test_handler.gd
@@ -30,7 +30,11 @@ func run_tests(params: Dictionary) -> Dictionary:
 				discovery.errors.size(),
 				", ".join(discovery.errors),
 			]
-		return {"data": {"error": msg, "total": 0, "load_errors": discovery.errors}}
+		var no_suites := {"error": msg, "total": 0, "load_errors": discovery.errors}
+		## Keep the edited_scene annotation on the no-suites error payload too,
+		## so the response contract is consistent across every return path.
+		_annotate_edited_scene(no_suites)
+		return {"data": no_suites}
 
 	var ctx := {
 		"undo_redo": _undo_redo,

--- a/plugin/addons/godot_ai/handlers/test_handler.gd
+++ b/plugin/addons/godot_ai/handlers/test_handler.gd
@@ -40,7 +40,30 @@ func run_tests(params: Dictionary) -> Dictionary:
 	var results := _runner.run_suites(suites, suite_filter, test_filter, ctx, verbose, exclude_test_filter)
 	if not discovery.errors.is_empty():
 		results["load_errors"] = discovery.errors
+	_annotate_edited_scene(results)
 	return {"data": results}
+
+
+## Many suites assume the project's main scene is the edited scene (they read
+## /Main/... nodes directly). Running with another scene open produces a flood
+## of phantom failures that look like real regressions. Surface the edited
+## scene and a warning when it differs from run/main_scene so the failures are
+## attributable at a glance instead of costing a debugging round (#635).
+func _annotate_edited_scene(results: Dictionary) -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var edited := scene_root.scene_file_path if scene_root else ""
+	results["edited_scene"] = edited
+	var main_scene := str(ProjectSettings.get_setting("application/run/main_scene", ""))
+	if main_scene.is_empty() or edited == main_scene:
+		return
+	if int(results.get("failed", 0)) <= 0:
+		return
+	results["scene_warning"] = (
+		"Edited scene is '%s' but the project main scene is '%s'. Many suites "
+		% [edited if not edited.is_empty() else "<none>", main_scene]
+		+ "assume the main scene is open and will report phantom failures "
+		+ "otherwise. If these failures are unexpected, scene_open('%s') and re-run." % main_scene
+	)
 
 
 func get_test_results(params: Dictionary) -> Dictionary:

--- a/plugin/addons/godot_ai/runtime/game_helper.gd
+++ b/plugin/addons/godot_ai/runtime/game_helper.gd
@@ -479,7 +479,10 @@ func _game_input_key(params: Dictionary) -> Dictionary:
 
 func _game_input_mouse(params: Dictionary) -> Dictionary:
 	var event := str(params.get("event", "button"))
-	var pos := _dict_to_vector2(params.get("position", {}))
+	var pos_result := _resolve_mouse_position(params.get("position"))
+	if pos_result.has("error"):
+		return {"sent": false, "event": event, "error": pos_result.error}
+	var pos: Vector2 = pos_result.position
 	match event:
 		"motion":
 			var motion := InputEventMouseMotion.new()
@@ -565,6 +568,29 @@ func _dict_to_vector2(value: Variant) -> Vector2:
 			return fallback
 		return Vector2(float(value.get("x", fallback.x)), float(value.get("y", fallback.y)))
 	return fallback
+
+
+## Resolve a mouse-position param. Absent (null/missing) falls back to the
+## live cursor position — a deliberate default. A present but wrong-shaped
+## value is rejected instead of silently substituting the cursor, which
+## previously hid caller bugs (#635). Accepts a {x, y} dict or an [x, y]
+## array; returns {position: Vector2} or {error: String}.
+func _resolve_mouse_position(value: Variant) -> Dictionary:
+	var viewport := get_viewport()
+	var fallback := viewport.get_mouse_position() if viewport != null else Vector2.ZERO
+	if value == null:
+		return {"position": fallback}
+	if value is Dictionary:
+		var dict: Dictionary = value
+		if dict.is_empty() or (not dict.has("x") and not dict.has("y")):
+			return {"position": fallback}
+		return {"position": Vector2(float(dict.get("x", fallback.x)), float(dict.get("y", fallback.y)))}
+	if value is Array:
+		var arr: Array = value
+		if arr.size() != 2:
+			return {"error": "position array must be [x, y] (got %d elements)" % arr.size()}
+		return {"position": Vector2(float(arr[0]), float(arr[1]))}
+	return {"error": "position must be a {x, y} object or [x, y] array (got %s)" % type_string(typeof(value))}
 
 
 func _mouse_button_index(name: String) -> int:

--- a/plugin/addons/godot_ai/runtime/game_helper.gd
+++ b/plugin/addons/godot_ai/runtime/game_helper.gd
@@ -560,21 +560,11 @@ func _game_input_state(params: Dictionary) -> Dictionary:
 	return {"actions": states}
 
 
-func _dict_to_vector2(value: Variant) -> Vector2:
-	var viewport := get_viewport()
-	var fallback := viewport.get_mouse_position() if viewport != null else Vector2.ZERO
-	if value is Dictionary:
-		if value.is_empty() or (not value.has("x") and not value.has("y")):
-			return fallback
-		return Vector2(float(value.get("x", fallback.x)), float(value.get("y", fallback.y)))
-	return fallback
-
-
-## Resolve a mouse-position param. Absent (null/missing) falls back to the
-## live cursor position — a deliberate default. A present but wrong-shaped
+## Resolve a mouse-position param. Absent (null, or an empty {}) falls back to
+## the live cursor position — a deliberate default. A present but wrong-shaped
 ## value is rejected instead of silently substituting the cursor, which
-## previously hid caller bugs (#635). Accepts a {x, y} dict or an [x, y]
-## array; returns {position: Vector2} or {error: String}.
+## previously hid caller bugs (#635). Accepts a {x, y} dict or an [x, y] array;
+## returns {position: Vector2} or {error: String}.
 func _resolve_mouse_position(value: Variant) -> Dictionary:
 	var viewport := get_viewport()
 	var fallback := viewport.get_mouse_position() if viewport != null else Vector2.ZERO
@@ -582,15 +572,29 @@ func _resolve_mouse_position(value: Variant) -> Dictionary:
 		return {"position": fallback}
 	if value is Dictionary:
 		var dict: Dictionary = value
-		if dict.is_empty() or (not dict.has("x") and not dict.has("y")):
+		if dict.is_empty():
 			return {"position": fallback}
-		return {"position": Vector2(float(dict.get("x", fallback.x)), float(dict.get("y", fallback.y)))}
+		# A non-empty dict that carries neither coordinate is a caller mistake,
+		# not "use the default" — reject rather than silently substitute.
+		if not dict.has("x") and not dict.has("y"):
+			return {"error": "position object must have an 'x' and/or 'y' key (got keys %s)" % str(dict.keys())}
+		var x_val: Variant = dict.get("x", fallback.x)
+		var y_val: Variant = dict.get("y", fallback.y)
+		if not _is_number(x_val) or not _is_number(y_val):
+			return {"error": "position x/y must be numbers (got x=%s, y=%s)" % [type_string(typeof(x_val)), type_string(typeof(y_val))]}
+		return {"position": Vector2(float(x_val), float(y_val))}
 	if value is Array:
 		var arr: Array = value
 		if arr.size() != 2:
 			return {"error": "position array must be [x, y] (got %d elements)" % arr.size()}
+		if not _is_number(arr[0]) or not _is_number(arr[1]):
+			return {"error": "position array elements must be numbers (got [%s, %s])" % [type_string(typeof(arr[0])), type_string(typeof(arr[1]))]}
 		return {"position": Vector2(float(arr[0]), float(arr[1]))}
 	return {"error": "position must be a {x, y} object or [x, y] array (got %s)" % type_string(typeof(value))}
+
+
+func _is_number(v: Variant) -> bool:
+	return typeof(v) == TYPE_INT or typeof(v) == TYPE_FLOAT
 
 
 func _mouse_button_index(name: String) -> int:

--- a/src/godot_ai/tools/game.py
+++ b/src/godot_ai/tools/game.py
@@ -28,6 +28,9 @@ Ops:
         Send a key press/release to the running game.
   - input_mouse(event, position=None, button="left", pressed=True)
         Send a mouse motion or button event. event: "motion" | "button".
+        position is a {x, y} object or [x, y] array; omit it to use the
+        game's current cursor position. A present but malformed position is
+        rejected rather than silently falling back to the cursor.
   - input_gamepad(device=0, control="button", index=0, pressed=True, value=0.0)
         Send a joypad button or axis event. control: "button" | "axis".
   - input_action(action, pressed=True, strength=1.0)

--- a/src/godot_ai/tools/testing.py
+++ b/src/godot_ai/tools/testing.py
@@ -42,6 +42,12 @@ def register_testing_tools(mcp: FastMCP) -> None:
         suite names, duration) plus failures only. verbose=True includes
         every individual test result.
 
+        The response includes ``edited_scene`` (the scene currently open in
+        the editor). Many suites assume the project's main scene is open; if
+        it is not and there are failures, the response also carries a
+        ``scene_warning`` — open the main scene (``scene_open``) and re-run
+        before treating those failures as real.
+
         Args:
             suite: Run only the named suite (e.g. "scene", "node", "editor").
                 Empty runs all suites.

--- a/test_project/tests/test_game_helper.gd
+++ b/test_project/tests/test_game_helper.gd
@@ -197,6 +197,9 @@ func test_input_mouse_position_absent_falls_back() -> void:
 func test_input_mouse_position_malformed_array_rejected() -> void:
 	var r: Dictionary = _helper.call("_resolve_mouse_position", [1.0, 2.0, 3.0])
 	assert_true(r.has("error"), "3-element array must be rejected, not silently substituted")
+	## A rejection must NOT also hand back a fallback position — otherwise a
+	## regression could silently substitute cursor coords despite the error.
+	assert_false(r.has("position"), "rejected input must not carry a fallback position")
 
 
 func test_input_mouse_position_wrong_type_rejected() -> void:
@@ -205,3 +208,4 @@ func test_input_mouse_position_wrong_type_rejected() -> void:
 	## caller bugs.
 	var r: Dictionary = _helper.call("_resolve_mouse_position", 42.0)
 	assert_true(r.has("error"), "scalar position must be rejected")
+	assert_false(r.has("position"), "rejected input must not carry a fallback position")

--- a/test_project/tests/test_game_helper.gd
+++ b/test_project/tests/test_game_helper.gd
@@ -209,3 +209,38 @@ func test_input_mouse_position_wrong_type_rejected() -> void:
 	var r: Dictionary = _helper.call("_resolve_mouse_position", 42.0)
 	assert_true(r.has("error"), "scalar position must be rejected")
 	assert_false(r.has("position"), "rejected input must not carry a fallback position")
+
+
+func test_input_mouse_position_empty_dict_falls_back() -> void:
+	## An empty {} is treated as "unspecified" (like absent) and falls back.
+	var r: Dictionary = _helper.call("_resolve_mouse_position", {})
+	assert_false(r.has("error"), "empty dict must fall back, not error")
+	assert_true(r.has("position"))
+
+
+func test_input_mouse_position_dict_without_xy_rejected() -> void:
+	## Copilot review: a NON-empty dict carrying neither coordinate (e.g.
+	## {"foo": 1}) is a caller mistake, not a request for the default — reject
+	## it instead of silently substituting the cursor.
+	var r: Dictionary = _helper.call("_resolve_mouse_position", {"foo": 1})
+	assert_true(r.has("error"), "non-empty dict without x/y must be rejected")
+	assert_false(r.has("position"))
+
+
+func test_input_mouse_position_non_numeric_rejected() -> void:
+	## Copilot review: non-numeric coordinates must be rejected rather than
+	## coerced through float() (which would silently produce 0.0).
+	var r_dict: Dictionary = _helper.call("_resolve_mouse_position", {"x": "left", "y": 5})
+	assert_true(r_dict.has("error"), "non-numeric dict x must be rejected")
+	assert_false(r_dict.has("position"))
+	var r_arr: Dictionary = _helper.call("_resolve_mouse_position", ["a", "b"])
+	assert_true(r_arr.has("error"), "non-numeric array elements must be rejected")
+	assert_false(r_arr.has("position"))
+
+
+func test_input_mouse_position_partial_dict_uses_number() -> void:
+	## A partial dict with one numeric coordinate is still valid — the missing
+	## axis defaults to the current cursor. (x present and numeric here.)
+	var r: Dictionary = _helper.call("_resolve_mouse_position", {"x": 7})
+	assert_false(r.has("error"), "partial numeric dict must not error")
+	assert_eq(r.position.x, 7.0)

--- a/test_project/tests/test_game_helper.gd
+++ b/test_project/tests/test_game_helper.gd
@@ -169,3 +169,39 @@ func test_get_ui_elements_can_filter_disabled_and_include_hidden() -> void:
 	assert_true(names.has("NameInput"), "enabled control should be included")
 	assert_true(names.has("HiddenButIncluded"), "hidden control should be included when requested")
 	assert_false(names.has("DisabledButton"), "disabled control should be filtered when requested")
+
+
+# ----- input_mouse position resolution (#635) -----
+
+func test_input_mouse_position_dict() -> void:
+	var r: Dictionary = _helper.call("_resolve_mouse_position", {"x": 12.0, "y": 34.0})
+	assert_false(r.has("error"), "valid dict must not error")
+	assert_eq(r.position, Vector2(12, 34))
+
+
+func test_input_mouse_position_array_coerces() -> void:
+	## Arrays [x, y] are accepted as a coercion, matching the dict-or-array
+	## flexibility elsewhere in the tool surface.
+	var r: Dictionary = _helper.call("_resolve_mouse_position", [56.0, 78.0])
+	assert_false(r.has("error"), "2-element array must not error")
+	assert_eq(r.position, Vector2(56, 78))
+
+
+func test_input_mouse_position_absent_falls_back() -> void:
+	## Omitting position (null) is a deliberate default: use the live cursor.
+	var r: Dictionary = _helper.call("_resolve_mouse_position", null)
+	assert_false(r.has("error"), "absent position must fall back, not error")
+	assert_true(r.has("position"))
+
+
+func test_input_mouse_position_malformed_array_rejected() -> void:
+	var r: Dictionary = _helper.call("_resolve_mouse_position", [1.0, 2.0, 3.0])
+	assert_true(r.has("error"), "3-element array must be rejected, not silently substituted")
+
+
+func test_input_mouse_position_wrong_type_rejected() -> void:
+	## #635: a present but wrong-shaped position (here a bare number) must be
+	## rejected instead of silently falling back to the cursor, which hid
+	## caller bugs.
+	var r: Dictionary = _helper.call("_resolve_mouse_position", 42.0)
+	assert_true(r.has("error"), "scalar position must be rejected")

--- a/test_project/tests/test_runner.gd
+++ b/test_project/tests/test_runner.gd
@@ -1,6 +1,8 @@
 @tool
 extends McpTestSuite
 
+const TestHandler := preload("res://addons/godot_ai/handlers/test_handler.gd")
+
 ## Tests for McpTestRunner itself — specifically the guardrails that
 ## catch silent failures: skip() mechanism, zero-assertion detection,
 ## deep ctx isolation, and leaked-node cleanup.
@@ -237,6 +239,42 @@ func test_expected_script_error_does_not_fail_test() -> void:
 
 	assert_eq(result.failed, 0, "expected script errors should be filtered")
 	assert_eq(result.passed, 1)
+
+
+func test_run_tests_annotates_edited_scene() -> void:
+	## #635: run_tests surfaces the edited scene so main-scene-assuming suites'
+	## phantom failures are attributable. Verify the annotation is populated.
+	var handler := TestHandler.new(null, null)
+	var results := {"failed": 0}
+	handler._annotate_edited_scene(results)
+	assert_has_key(results, "edited_scene")
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var expected := scene_root.scene_file_path if scene_root else ""
+	assert_eq(results.edited_scene, expected)
+	## Tests run with the main scene open, so no warning should be emitted even
+	## though failed=0 here.
+	assert_false(results.has("scene_warning"),
+		"no warning when edited scene is the main scene")
+
+
+func test_annotate_scene_warns_on_mismatch_with_failures() -> void:
+	## The warning fires only when the edited scene differs from main AND there
+	## are failures. Simulate by calling with a main_scene that cannot match
+	## the (main.tscn) edited scene via a synthetic failing result — the guard
+	## is edited != main_scene, so if the project's main scene IS open the
+	## warning is correctly suppressed. Assert the suppression contract holds.
+	var handler := TestHandler.new(null, null)
+	var main_scene := str(ProjectSettings.get_setting("application/run/main_scene", ""))
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var edited := scene_root.scene_file_path if scene_root else ""
+	var results := {"failed": 3}
+	handler._annotate_edited_scene(results)
+	if edited == main_scene:
+		assert_false(results.has("scene_warning"),
+			"main scene open => no warning even with failures")
+	else:
+		assert_true(results.has("scene_warning"),
+			"non-main scene + failures => warning")
 
 
 static func _edited_scene_root() -> Node:

--- a/test_project/tests/test_runner.gd
+++ b/test_project/tests/test_runner.gd
@@ -258,23 +258,37 @@ func test_run_tests_annotates_edited_scene() -> void:
 
 
 func test_annotate_scene_warns_on_mismatch_with_failures() -> void:
-	## The warning fires only when the edited scene differs from main AND there
-	## are failures. Simulate by calling with a main_scene that cannot match
-	## the (main.tscn) edited scene via a synthetic failing result — the guard
-	## is edited != main_scene, so if the project's main scene IS open the
-	## warning is correctly suppressed. Assert the suppression contract holds.
+	## #635: deterministically exercise BOTH the warn and no-warn branches by
+	## overriding application/run/main_scene to a path that cannot equal the
+	## edited scene, then restoring it. (Reading the live main_scene and
+	## branching the assertion on it — as an earlier draft did — is tautological:
+	## in CI the main scene is open, so only the suppression branch ever ran.)
 	var handler := TestHandler.new(null, null)
-	var main_scene := str(ProjectSettings.get_setting("application/run/main_scene", ""))
-	var scene_root := EditorInterface.get_edited_scene_root()
-	var edited := scene_root.scene_file_path if scene_root else ""
-	var results := {"failed": 3}
-	handler._annotate_edited_scene(results)
-	if edited == main_scene:
-		assert_false(results.has("scene_warning"),
-			"main scene open => no warning even with failures")
+	var key := "application/run/main_scene"
+	var had_setting := ProjectSettings.has_setting(key)
+	var original = ProjectSettings.get_setting(key) if had_setting else null
+	var fake_main := "res://__mcp_nonexistent_main__.tscn"
+
+	# mismatch + failures => warning naming the mismatched main scene
+	ProjectSettings.set_setting(key, fake_main)
+	var failing := {"failed": 3}
+	handler._annotate_edited_scene(failing)
+	# mismatch + zero failures => no warning
+	var clean := {"failed": 0}
+	handler._annotate_edited_scene(clean)
+
+	# restore BEFORE asserting so a failed assert can't leak the override
+	if had_setting:
+		ProjectSettings.set_setting(key, original)
 	else:
-		assert_true(results.has("scene_warning"),
-			"non-main scene + failures => warning")
+		ProjectSettings.clear(key)
+
+	assert_true(failing.has("scene_warning"),
+		"edited scene != main_scene with failures must warn")
+	assert_true(str(failing.get("scene_warning", "")).contains(fake_main),
+		"warning should name the mismatched main scene")
+	assert_false(clean.has("scene_warning"),
+		"mismatch but zero failures must not warn")
 
 
 static func _edited_scene_root() -> Node:


### PR DESCRIPTION
## Summary

Addresses two of the three items in #635 (both low-risk, found during a live smoke of main). The third is intentionally deferred — see below.

### 1. `game input_mouse` rejects malformed `position`

Previously a present-but-wrong-shaped `position` (an `[x, y]` array, or a bare number) silently fell through to the game's live cursor position, hiding caller bugs. Now:
- `{x, y}` object — accepted (unchanged)
- `[x, y]` array — accepted as a coercion (matches the dict-or-array flexibility elsewhere in the surface)
- omitted / null — falls back to the live cursor (a deliberate default, unchanged)
- present but any other shape (wrong-length array, scalar) — **rejected** with a clear error instead of silent substitution

### 2. `test_run` flags scene mismatch

Many GDScript suites assume the project main scene is the edited scene (they read `/Main/...` directly). Running with another scene open produces a flood of phantom failures that read like real regressions — this cost a full debugging round during the smoke. The response now includes:
- `edited_scene` — the scene currently open
- `scene_warning` — emitted only when `edited_scene` differs from `run/main_scene` **and** there are failures, pointing at `scene_open(main)` + re-run

## Deferred (item 3 of #635)

The in-run `push_error` labeled `recent_errors_scope: "retained_recent"` instead of run-scoped is **not** in this PR. It intersects the surfaced-error-tracker cursor bookkeeping that #518/#621 are built on, and a blind `retained_recent → run` flip risks regressing error surfacing. The error is already fully surfaced (stack + details); only the scope label is conservative. It warrants a focused change with its own verification. #635 stays open for it.

## Testing

Verified live on a freshly-restarted Godot 4.6.3 editor via MCP:
- 5 new `game_helper` tests for `_resolve_mouse_position` (dict, array coerce, absent-fallback, malformed-array reject, wrong-type reject) — all pass.
- 2 new `test_runner` tests for the scene annotation (`edited_scene` populated; warning suppressed when main scene is open) — all pass.
- Full suite green: **0 failed, 1594 passed / 7 skipped, 57 suites**; `edited_scene: res://main.tscn` present in the response.
- `pytest tests/unit -k "game or testing or tool"`: 77 passed. `ci-check-gdscript`: all files OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Test runs now include the currently open editor scene as `edited_scene`, and may add a `scene_warning` when failures occur while a non-main scene is open.
  * Mouse input can accept pointer positions as `{x, y}` objects or `[x, y]` arrays.
* **Bug Fixes**
  * Requests with malformed pointer position payloads are rejected with a clear error instead of silently using the current cursor position.
* **Documentation / Tests**
  * Updated tool documentation and added/expanded tests for scene annotation and pointer position resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->