### PR TITLE
stormtest: fix stale params starving bind_event/logs_read; log every abort reason (#634)

### DIFF
--- a/script/stormtest.py
+++ b/script/stormtest.py
@@ -117,8 +117,20 @@ REPORT_JSON = os.environ.get(
     "SS_REPORT", os.path.join(tempfile.gettempdir(), "stormtest_report.json")
 )
 START = [0.0]
-STOP = [False]  # set by signal handler / fatal server loss
+STOP = [False]  # set by signal handler / fatal server loss / normal teardown
+# ABORTED distinguishes an early failure abort from STOP being set by the
+# normal end-of-run teardown (the `finally` in main). Only the former should
+# print "aborted — see reason above"; a clean run also has STOP set.
+ABORTED = [False]
 ROOT_PATH = ["/Root"]  # resolved after scratch-scene creation
+
+
+def _abort(reason: str) -> None:
+    """Flip STOP + ABORTED and log why. Every early-exit failure path routes
+    through here so a truncated run always states its cause (#634)."""
+    print(f"  !!! stormtest aborting: {reason}")
+    STOP[0] = True
+    ABORTED[0] = True
 
 
 def _pct(vals: list[float], p: float) -> float:
@@ -157,6 +169,7 @@ def flush_report_json():
         "reload_recovery_s": [round(x, 1) for x in M["reload_recovery_s"]],
         "reconnects": M["reconnects"],
         "stopped": STOP[0],
+        "aborted": ABORTED[0],
         "overall_latency_ms": _lat_stats(all_lat),
         "err_codes": dict(M["err_codes"].most_common()),
         "per_op": {
@@ -324,7 +337,7 @@ async def op_logs(w: Worker):
         "logs_read",
         {
             "count": random.choice([10, 50]),
-            "source": random.choice(["plugin", "editor", "combined"]),
+            "source": random.choice(["plugin", "editor", "all"]),
         },
     )
 
@@ -643,7 +656,7 @@ async def op_input_map(w: Worker):
             {"op": "add_action", "params": {"action": action}},
             op_label="input_map_manage.add_action",
         )
-        params = {"action": action, "event_type": "key", "key": "A"}
+        params = {"action": action, "event_type": "key", "keycode": "A"}
     elif op == "remove_action":
         params = {"action": action}
     else:
@@ -714,7 +727,10 @@ OPS = (
 
 async def worker_loop(w: Worker):
     if not await w.connect():
-        STOP[0] = True
+        _abort(
+            f"worker {w.wi} could not reach the editor on initial connect — "
+            f"is it running with the plugin enabled?"
+        )
         return
     await w.ensure_container()
     for wave in range(WAVES):
@@ -737,7 +753,11 @@ async def worker_loop(w: Worker):
                     M["reconnects"] += 1
                     ok = await w.connect()
                     if not ok:
-                        STOP[0] = True
+                        _abort(
+                            f"worker {w.wi} reconnect failed after a CONNECTION "
+                            f"error (wave {wave}) — server did not return within "
+                            f"the reconnect window"
+                        )
                         break
                     w.nodes.clear()  # scene may have reset after reload
                     await w.ensure_container()
@@ -765,11 +785,10 @@ async def do_reload(w: Worker):
     ok = await w.connect()
     M["reload_recovery_s"].append(time.monotonic() - t_reload)
     if not ok:
-        print(
-            "  [chaos] !!! server did not come back after reload "
-            "(managed server likely killed by reload). Aborting."
+        _abort(
+            "server did not come back after a chaos-worker reload "
+            "(managed server likely killed by the reload)"
         )
-        STOP[0] = True
         return
     M["reloads_survived"] += 1
     # reload may have reset the edited scene off our scratch scene — reopen it
@@ -811,8 +830,7 @@ async def run_isolated_reload() -> None:
     )
     w = Worker(0)
     if not await w.connect():
-        print("  could not reach the editor — is it running with the plugin enabled?")
-        STOP[0] = True
+        _abort("could not reach the editor — is it running with the plugin enabled?")
         return
 
     for i in range(ISOLATED_ITERS):
@@ -836,11 +854,11 @@ async def run_isolated_reload() -> None:
         ok = await w.connect()
         dt = time.monotonic() - t0
         if not ok:
-            print(
-                f"      !!! editor did not return within {RECONNECT_TIMEOUT}s — "
-                "reload NOT survived (managed server likely killed by the reload)"
+            _abort(
+                f"editor did not return within {RECONNECT_TIMEOUT}s of an "
+                f"isolated reload — reload NOT survived (managed server likely "
+                f"killed by the reload)"
             )
-            STOP[0] = True
             break
         after = await _active_session_id(w)
         M["reloads_survived"] += 1
@@ -875,8 +893,10 @@ async def health_monitor():
             if misses == 1:
                 print("  [health] editor not answering (reload window?) ...")
             if misses >= int(RECONNECT_TIMEOUT / 3) + 1:
-                print("  [health] !!! editor unreachable too long — presumed DEAD. Aborting.")
-                STOP[0] = True
+                _abort(
+                    f"health monitor: editor unreachable for ~{misses * 3}s "
+                    f"(> reconnect window) — presumed DEAD"
+                )
                 return
 
 
@@ -942,10 +962,10 @@ def report():
     s = _lat_stats(all_lat)
     if s["n"]:
         print(f"  latency (ms)     : p50={s['p50']} p95={s['p95']} max={s['max']} avg={s['avg']}")
-    verdict = "EDITOR ALIVE" if (not STOP[0] or M["ok"]) else "EDITOR DEAD/UNREACHABLE"
+    verdict = "EDITOR ALIVE" if (not ABORTED[0] or M["ok"]) else "EDITOR DEAD/UNREACHABLE"
     print(f"  final verdict    : {verdict}")
-    if STOP[0]:
-        print("  (STOP was set — see log above for why)")
+    if ABORTED[0]:
+        print("  (run aborted early — see the 'stormtest aborting:' reason above)")
     print("\n  error codes:")
     for code, n in M["err_codes"].most_common():
         print(f"    {n:6d}  {code}")

--- a/script/stormtest.py
+++ b/script/stormtest.py
@@ -962,7 +962,14 @@ def report():
     s = _lat_stats(all_lat)
     if s["n"]:
         print(f"  latency (ms)     : p50={s['p50']} p95={s['p95']} max={s['max']} avg={s['avg']}")
-    verdict = "EDITOR ALIVE" if (not ABORTED[0] or M["ok"]) else "EDITOR DEAD/UNREACHABLE"
+    # Verdict keys off STOP[0] as it stands at report() time, which is the
+    # authoritative end-of-run liveness signal — NOT any prior success. In
+    # concurrent mode the final liveness probe in main() sets STOP[0]=False
+    # when the editor answers editor_state (True if it can't be reached); in
+    # isolated mode STOP[0] is left False unless a path aborted. A mid-run
+    # abort that the editor recovered from still reads ALIVE (correct — it is
+    # alive now); the ABORTED line below explains any truncation separately.
+    verdict = "EDITOR ALIVE" if not STOP[0] else "EDITOR DEAD/UNREACHABLE"
     print(f"  final verdict    : {verdict}")
     if ABORTED[0]:
         print("  (run aborted early — see the 'stormtest aborting:' reason above)")


### PR DESCRIPTION
## Summary

Fixes #634. Two classes of problem in the stormtest harness, both found while reconciling error buckets during a live smoke.

### 1. Stale params starved two ops of coverage

- `op_input_map` sent `{"event_type": "key", "key": "A"}` for `bind_event`, but the op requires `keycode`. **26/26** bind_event calls failed `MISSING_REQUIRED_PARAM` in a heavy run — zero real coverage.
- `op_logs` drew `source` from `["plugin", "editor", "combined"]`; `"combined"` is not a valid source (`plugin|game|editor|all`). ~**50/148** logs_read calls failed `ToolError`, and the `all` path was never exercised.

Both fixed (`keycode`, `all`). Verified live: `bind_event` and `logs_read` now report **0 errors**.

### 2. Silent aborts

Several early-exit paths set `STOP[0]` with no reason logged, so a truncated run gave no cause — a heavy run ended at 6115/~9000 calls with the summary literally saying "see log above for why" while the log said nothing. Every genuine abort now routes through a new `_abort(reason)` helper that prints the cause and sets a distinct `ABORTED` flag. `STOP` alone is also set by the normal end-of-run teardown and by a user Ctrl-C (SIGINT), so the report/JSON now distinguish:
- clean finish → `aborted: false`, no "aborted early" line
- early failure → `aborted: true`, `!!! stormtest aborting: <reason>` printed, reason named in the summary

## Note on parallel work

A separate local session (spun off as a task chip during the smoke) began the two param-name edits but stopped without committing — its 2-line change sat uncommitted in a worktree. This PR includes those same two fixes plus the abort-logging (item 2 of #634), so it supersedes that unpushed work as the complete fix.

## Testing

- `python -m py_compile` + `ruff check`: clean.
- Live short run (4 workers × 3 waves, reload off) against Godot 4.6.3: `input_map_manage.bind_event` 1/0, `logs_read` 9/0, `final verdict EDITOR ALIVE`, JSON `stopped:false aborted:false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of early test shutdowns so abort reasons are reported more clearly.
  * Final results now distinguish between a normal stop and an aborted run, with clearer messaging in the report.
  * JSON output now includes an explicit `aborted` status for easier result tracking.
  * Updated stress-test input values to better match current expectations (log source and event key name).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->