### PR TITLE
Hermes Agent support (YAML config + working HTTP integration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Godot Asset Library](https://img.shields.io/badge/Godot-Asset%20Library-478cbf?logo=godotengine&logoColor=white)](https://godotengine.org/asset-library/asset/5050)
 [![Discord](https://img.shields.io/badge/Discord-Join%20chat-5865F2?logo=discord&logoColor=white)](https://discord.gg/FDZ5fr2QkP)
 
-**Connect MCP clients directly to a live Godot editor** via the [Model Context Protocol](https://modelcontextprotocol.io/introduction). Over **120 ops across ~41 MCP tools** ([full list](docs/TOOLS.md)) let AI assistants (Claude Code, Codex, Antigravity, etc.) build scenes, edit nodes and scripts, wire signals, and configure UI, materials, animations, particles, cameras, and environments.
+**Connect MCP clients directly to a live Godot editor** via the [Model Context Protocol](https://modelcontextprotocol.io/introduction). Over **120 ops across ~41 MCP tools** ([full list](docs/TOOLS.md)) let AI assistants (Claude Code, Codex, Antigravity, Hermes Agent, etc.) build scenes, edit nodes and scripts, wire signals, and configure UI, materials, animations, particles, cameras, and environments.
 
 > 🎉 **Now on the [Godot Asset Library](https://godotengine.org/asset-library/asset/5050) and the [new Godot Asset Store](https://store.godotengine.org/asset/dlight/godot-ai/)** — one-click install from Godot's **AssetLib** tab. You'll still need [uv](https://docs.astral.sh/uv/) for the Python server (see [Quick Start](#quick-start)).
 
@@ -77,7 +77,7 @@ The dock lists every supported client with a status dot and per-row
 **Configure** / **Remove** buttons, or press **Configure all**. Auto-configure
 covers:
 
-- **Claude Code**, **Claude Desktop**, **Antigravity**
+- **Claude Code**, **Claude Desktop**, **Antigravity**, **Hermes Agent**
 
 <details>
 <summary><strong>…and 16+ more clients</strong></summary>

--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -20,6 +20,7 @@ const Client := preload("res://addons/godot_ai/clients/_base.gd")
 const ClientRegistry := preload("res://addons/godot_ai/clients/_registry.gd")
 const JsonStrategy := preload("res://addons/godot_ai/clients/_json_strategy.gd")
 const TomlStrategy := preload("res://addons/godot_ai/clients/_toml_strategy.gd")
+const YamlStrategy := preload("res://addons/godot_ai/clients/_yaml_strategy.gd")
 const CliStrategy := preload("res://addons/godot_ai/clients/_cli_strategy.gd")
 const ManualCommand := preload("res://addons/godot_ai/clients/_manual_command.gd")
 const CliFinder := preload("res://addons/godot_ai/clients/_cli_finder.gd")
@@ -283,6 +284,8 @@ static func _dispatch_configure(client: Client, url: String) -> Dictionary:
 			return JsonStrategy.configure(client, SERVER_NAME, url)
 		"toml":
 			return TomlStrategy.configure(client, SERVER_NAME, url)
+		"yaml":
+			return YamlStrategy.configure(client, SERVER_NAME, url)
 		"cli":
 			# #463: fall back to writing the config file directly when the CLI
 			# binary isn't on PATH (Claude Code as a VS Code/Cursor extension).
@@ -298,6 +301,8 @@ static func _dispatch_remove(client: Client) -> Dictionary:
 			return JsonStrategy.remove(client, SERVER_NAME)
 		"toml":
 			return TomlStrategy.remove(client, SERVER_NAME)
+		"yaml":
+			return YamlStrategy.remove(client, SERVER_NAME)
 		"cli":
 			# #463: mirror the configure fallback so Remove also works without
 			# the CLI binary — otherwise a fallback-written entry is unremovable.
@@ -321,6 +326,8 @@ static func _dispatch_check_status_with_cli_path_details(client: Client, url: St
 			return {"status": JsonStrategy.check_status(client, SERVER_NAME, url), "error_msg": ""}
 		"toml":
 			return {"status": TomlStrategy.check_status(client, SERVER_NAME, url), "error_msg": ""}
+		"yaml":
+			return {"status": YamlStrategy.check_status(client, SERVER_NAME, url), "error_msg": ""}
 		"cli":
 			var resolved_cli := cli_path if not cli_path.is_empty() else CliStrategy.resolve_cli_path(client)
 			# #463: with no CLI binary, read the JSON fallback config so a

--- a/plugin/addons/godot_ai/clients/_base.gd
+++ b/plugin/addons/godot_ai/clients/_base.gd
@@ -38,7 +38,7 @@ static func status_label(status: McpClient.Status) -> String:
 
 var id: String = ""                              ## stable key, e.g. "cursor"
 var display_name: String = ""                    ## "Cursor"
-var config_type: String = ""                     ## "json" | "toml" | "cli"
+var config_type: String = ""                     ## "json" | "toml" | "yaml" | "cli"
 var doc_url: String = ""
 
 # JSON / TOML clients ------------------------------------------------------

--- a/plugin/addons/godot_ai/clients/_manual_command.gd
+++ b/plugin/addons/godot_ai/clients/_manual_command.gd
@@ -16,6 +16,8 @@ static func build(client: McpClient, server_name: String, server_url: String, re
 			return _build_json(client, server_name, server_url, resolved_path)
 		"toml":
 			return _build_toml(client, server_name, server_url, resolved_path)
+		"yaml":
+			return _build_yaml(client, server_name, server_url, resolved_path)
 	return ""
 
 
@@ -60,6 +62,18 @@ static func _build_toml(client: McpClient, _server_name: String, server_url: Str
 	var lines: Array[String] = ["Edit %s and add:" % resolved_path, "  %s" % header]
 	for b in body:
 		lines.append("  %s" % String(b))
+	return "\n".join(lines)
+
+
+static func _build_yaml(client: McpClient, server_name: String, server_url: String, resolved_path: String) -> String:
+	var entry := McpYamlStrategy.build_entry(client, server_url)
+	var key := client.server_key_path[0] if client.server_key_path.size() > 0 else "mcp_servers"
+	var lines: Array[String] = [
+		"Edit %s and add under '%s':" % [resolved_path, key],
+		"  %s:" % server_name,
+	]
+	for k in entry:
+		lines.append("    %s: %s" % [k, str(entry[k])])
 	return "\n".join(lines)
 
 

--- a/plugin/addons/godot_ai/clients/_registry.gd
+++ b/plugin/addons/godot_ai/clients/_registry.gd
@@ -25,6 +25,7 @@ const _CLIENT_SCRIPTS := [
 	preload("res://addons/godot_ai/clients/opencode.gd"),
 	preload("res://addons/godot_ai/clients/qwen_code.gd"),
 	preload("res://addons/godot_ai/clients/kimi_code.gd"),
+	preload("res://addons/godot_ai/clients/hermes.gd"),
 ]
 
 static var _instances: Array[McpClient] = []

--- a/plugin/addons/godot_ai/clients/_yaml_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_yaml_strategy.gd
@@ -26,11 +26,11 @@ static func configure(client: McpClient, server_name: String, server_url: String
 
 	var text: String = read["data"]
 	var block := _extract_block(text)
-	var entries := block["entries"]
+	var entries: Dictionary = block["entries"]
 
 	# Preserve existing entry's user-mutable keys; force url.
 	var existing: Dictionary = entries.get(server_name, {})
-	var new_entry := _build_entry(client, server_url, existing)
+	var new_entry := build_entry(client, server_url, existing)
 	entries[server_name] = new_entry
 
 	var out := _assemble(text, block["prefix_lines"], entries, block["suffix_lines"])
@@ -76,10 +76,13 @@ static func remove(client: McpClient, server_name: String) -> Dictionary:
 
 
 ## Build the entry dict written under mcp_servers[server_name].
-## Hermes HTTP entries: { url: <url> } plus preserved user keys
-## (headers, enabled, tools, ...). No `type` field — transport inferred.
-static func build_entry(client: McpClient, server_url: String, existing: Variant = null) -> Dictionary:
-	var entry: Dictionary = (existing as Dictionary).duplicate() if existing is Dictionary else {}
+## Hermes HTTP entries are transport-inferred: just { url: <url> }. We do NOT
+## preserve stale keys from a prior entry (e.g. a `command: uvx mcp-proxy`
+## stdio-bridge form) — Hermes would then have both a url and a command and
+## pick the wrong transport. A clean { url: ... } is the correct, documented
+## Hermes shape. No `type` field.
+static func build_entry(client: McpClient, server_url: String, _existing: Variant = null) -> Dictionary:
+	var entry: Dictionary = {}
 	entry[client.entry_url_field] = server_url
 	return entry
 
@@ -101,9 +104,9 @@ static func verify_entry(client: McpClient, entry: Dictionary, server_url: Strin
 ## user's config.yaml byte-for-byte intact.
 static func _extract_block(text: String) -> Dictionary:
 	var lines := text.split("\n", false)
-	var prefix: Array[String] = []
+	var prefix: PackedStringArray = []
 	var entries: Dictionary = {}
-	var suffix: Array[String] = []
+	var suffix: PackedStringArray = []
 	var header_idx := -1
 	for i in range(lines.size()):
 		if lines[i].strip_edges().begins_with("mcp_servers:"):
@@ -117,17 +120,29 @@ static func _extract_block(text: String) -> Dictionary:
 	for i in range(0, header_idx):
 		prefix.append(lines[i])
 
-	# Walk indented entries until the next top-level key (no indent) or EOF.
+	# Determine the indent of the first entry so we can tell sibling
+	# entries (same indent) apart from nested keys (deeper indent) and
+	# parent-level keys (less indent). All server entries under
+	# `mcp_servers:` share one indent level; breaking on 0-indent alone
+	# mis-nests 2-space-indented siblings under the first entry.
+	var entry_indent := -1
+	var probe := header_idx + 1
+	while probe < lines.size() and lines[probe].strip_edges().is_empty():
+		probe += 1
+	if probe < lines.size():
+		entry_indent = _indent_of(lines[probe])
+
 	var i := header_idx + 1
 	while i < lines.size():
 		var raw := lines[i]
 		if raw.strip_edges().is_empty():
 			i += 1
 			continue
-		# Top-level key = first char is not whitespace.
-		if not (raw[0] == " " or raw[0] == "\t"):
+		# Stop at any line indented less than a sibling entry (parent key
+		# or a new top-level section), or at the header's own level.
+		if _indent_of(raw) < entry_indent:
 			break
-		var entry := _parse_entry(raw, lines, i)
+		var entry := _parse_entry(raw, lines, i, entry_indent)
 		if not entry["name"].is_empty():
 			entries[entry["name"]] = entry["data"]
 		i = entry["next_idx"]
@@ -140,7 +155,7 @@ static func _extract_block(text: String) -> Dictionary:
 
 ## Parse one `  name:` entry starting at `lines[start]`. Consumes all deeper-
 ## indented sublines (url, headers, etc.) and returns the next sibling index.
-static func _parse_entry(raw: String, lines: Array[String], start: int) -> Dictionary:
+static func _parse_entry(raw: String, lines: PackedStringArray, start: int, entry_indent: int) -> Dictionary:
 	var name := raw.strip_edges().trim_suffix(":").strip_edges()
 	var data: Dictionary = {}
 	var i := start + 1
@@ -149,8 +164,9 @@ static func _parse_entry(raw: String, lines: Array[String], start: int) -> Dicti
 		if l.strip_edges().is_empty():
 			i += 1
 			continue
-		if not (l[0] == " " or l[0] == "\t"):
-			break  # sibling or parent-level key
+		# A line at or above the entry's indent is a sibling/parent key.
+		if _indent_of(l) <= entry_indent:
+			break
 		var stripped := l.strip_edges()
 		var colon := stripped.find(":")
 		if colon < 0:
@@ -161,7 +177,7 @@ static func _parse_entry(raw: String, lines: Array[String], start: int) -> Dicti
 		if val.is_empty():
 			# Nested block (e.g. headers:). Parse as raw sub-dict lines for
 			# preservation; we don't introspect deeper than url at the top.
-			var sub := _parse_subblock(lines, i + 1)
+			var sub := _parse_subblock(lines, i + 1, entry_indent)
 			data[key] = sub["value"]
 			i = sub["next_idx"]
 		else:
@@ -173,7 +189,7 @@ static func _parse_entry(raw: String, lines: Array[String], start: int) -> Dicti
 ## Parse a nested block (e.g. headers:) as a preserved sub-dictionary of
 ## scalar key/values. Deeper nesting is flattened into scalar strings — fine
 ## for Hermes' known shape (headers are flat key: value).
-static func _parse_subblock(lines: Array[String], start: int) -> Dictionary:
+static func _parse_subblock(lines: PackedStringArray, start: int, entry_indent: int) -> Dictionary:
 	var sub: Dictionary = {}
 	var i := start
 	while i < lines.size():
@@ -181,7 +197,8 @@ static func _parse_subblock(lines: Array[String], start: int) -> Dictionary:
 		if l.strip_edges().is_empty():
 			i += 1
 			continue
-		if not (l[0] == " " or l[0] == "\t"):
+		# A line at or above the parent entry's indent ends the nested block.
+		if _indent_of(l) <= entry_indent:
 			break
 		var stripped := l.strip_edges()
 		var colon := stripped.find(":")
@@ -200,12 +217,12 @@ static func _parse_subblock(lines: Array[String], start: int) -> Dictionary:
 
 ## Reassemble the full file text from prefix + a freshly built mcp_servers
 ## block + suffix. If the block didn't exist before, it is appended.
-static func _assemble(_text: String, prefix: Array[String], entries: Dictionary, suffix: Array[String]) -> String:
-	var out: Array[String] = []
+static func _assemble(_text: String, prefix: PackedStringArray, entries: Dictionary, suffix: PackedStringArray) -> String:
+	var out: PackedStringArray = []
 	for l in prefix:
 		out.append(l)
 	# Trim trailing blank lines from prefix so we don't stack double blanks.
-	while out.size() > 0 and out[-1].strip_edges().is_empty():
+	while out.size() > 0 and out[out.size() - 1].strip_edges().is_empty():
 		out.remove_at(out.size() - 1)
 
 	if not _text.contains("mcp_servers:"):
@@ -228,8 +245,8 @@ static func _assemble(_text: String, prefix: Array[String], entries: Dictionary,
 
 ## Emit one `  name:` entry with its scalar keys (top level only; headers
 ## sub-dict is re-emitted as nested scalars).
-static func _emit_entry(name: String, data: Dictionary) -> Array[String]:
-	var lines: Array[String] = []
+static func _emit_entry(name: String, data: Dictionary) -> PackedStringArray:
+	var lines: PackedStringArray = []
 	lines.append(INDENT + "%s:" % name)
 	for key in data:
 		var val = data[key]
@@ -252,6 +269,16 @@ static func _emit_scalar(v: Variant) -> String:
 			return str(float(v))
 		_:
 			return str(v)
+
+
+## Returns the leading-whitespace indent width of a line (spaces + tabs
+## counted as 1 each). Used to distinguish sibling entries (same indent)
+## from nested keys (deeper indent) and parent-level keys (less indent).
+static func _indent_of(line: String) -> int:
+	var n := 0
+	while n < line.length() and (line[n] == " " or line[n] == "\t"):
+		n += 1
+	return n
 
 
 ## Minimal scalar coercion for parsed YAML values. Quotes are stripped;

--- a/plugin/addons/godot_ai/clients/_yaml_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_yaml_strategy.gd
@@ -12,7 +12,7 @@ extends RefCounted
 ## that block. No general YAML parser — Godot has none in stdlib, and Hermes
 ## only needs this one shape. See issue #640.
 
-const INDENT := "\t"
+const INDENT := "  "  # YAML forbids tab indentation; match the 2-space style of ~/.hermes/config.yaml
 
 
 static func configure(client: McpClient, server_name: String, server_url: String) -> Dictionary:

--- a/plugin/addons/godot_ai/clients/_yaml_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_yaml_strategy.gd
@@ -1,0 +1,289 @@
+@tool
+class_name McpYamlStrategy
+extends RefCounted
+
+## Minimal YAML upsert for Hermes Agent MCP config.
+##
+## Hermes reads MCP servers from ~/.hermes/config.yaml under the
+## `mcp_servers` key (snake_case, YAML). HTTP entries are transport-inferred:
+## just `url` (plus optional `headers`), no `type` field. We only parse the
+## `mcp_servers` block and re-emit it; other top-level keys in the user's
+## config.yaml are preserved verbatim by round-tripping the raw lines around
+## that block. No general YAML parser — Godot has none in stdlib, and Hermes
+## only needs this one shape. See issue #640.
+
+const INDENT := "\t"
+
+
+static func configure(client: McpClient, server_name: String, server_url: String) -> Dictionary:
+	var path := client.resolved_config_path()
+	if path.is_empty():
+		return {"status": "error", "message": "Could not resolve config path for %s on this OS" % client.display_name}
+
+	var read := _read(path)
+	if not read["ok"]:
+		return {"status": "error", "message": "Refusing to overwrite %s: %s. Fix or move the file, then re-run Configure." % [path, read["error"]]}
+
+	var text: String = read["data"]
+	var block := _extract_block(text)
+	var entries := block["entries"]
+
+	# Preserve existing entry's user-mutable keys; force url.
+	var existing: Dictionary = entries.get(server_name, {})
+	var new_entry := _build_entry(client, server_url, existing)
+	entries[server_name] = new_entry
+
+	var out := _assemble(text, block["prefix_lines"], entries, block["suffix_lines"])
+	if not McpAtomicWrite.write(path, out):
+		return {"status": "error", "message": "Cannot write to %s" % path}
+	return {"status": "ok", "message": "%s configured (HTTP: %s)" % [client.display_name, server_url]}
+
+
+static func check_status(client: McpClient, server_name: String, server_url: String) -> McpClient.Status:
+	var path := client.resolved_config_path()
+	if path.is_empty() or not FileAccess.file_exists(path):
+		return McpClient.Status.NOT_CONFIGURED
+	var read := _read(path)
+	if not read["ok"]:
+		return McpClient.Status.NOT_CONFIGURED
+	var block := _extract_block(String(read["data"]))
+	var entries: Dictionary = block["entries"]
+	if not entries.has(server_name):
+		return McpClient.Status.NOT_CONFIGURED
+	var entry: Variant = entries[server_name]
+	if not (entry is Dictionary):
+		return McpClient.Status.NOT_CONFIGURED
+	return McpClient.Status.CONFIGURED if verify_entry(client, entry, server_url) else McpClient.Status.CONFIGURED_MISMATCH
+
+
+static func remove(client: McpClient, server_name: String) -> Dictionary:
+	var path := client.resolved_config_path()
+	if path.is_empty() or not FileAccess.file_exists(path):
+		return {"status": "ok", "message": "Not configured"}
+	var read := _read(path)
+	if not read["ok"]:
+		return {"status": "error", "message": "Refusing to rewrite %s: %s." % [path, read["error"]]}
+	var text: String = read["data"]
+	var block := _extract_block(text)
+	var entries: Dictionary = block["entries"]
+	if not entries.has(server_name):
+		return {"status": "ok", "message": "%s configuration removed" % client.display_name}
+	entries.erase(server_name)
+	var out := _assemble(text, block["prefix_lines"], entries, block["suffix_lines"])
+	if not McpAtomicWrite.write(path, out):
+		return {"status": "error", "message": "Cannot write to %s" % path}
+	return {"status": "ok", "message": "%s configuration removed" % client.display_name}
+
+
+## Build the entry dict written under mcp_servers[server_name].
+## Hermes HTTP entries: { url: <url> } plus preserved user keys
+## (headers, enabled, tools, ...). No `type` field — transport inferred.
+static func build_entry(client: McpClient, server_url: String, existing: Variant = null) -> Dictionary:
+	var entry: Dictionary = (existing as Dictionary).duplicate() if existing is Dictionary else {}
+	entry[client.entry_url_field] = server_url
+	return entry
+
+
+## Verify a stored entry matches. Hermes entries have no transport type pin,
+## so verification is: url matches. Extra keys (headers, enabled, tools) are
+## user-mutable and intentionally NOT checked (mirrors json entry_initial_fields).
+static func verify_entry(client: McpClient, entry: Dictionary, server_url: String) -> bool:
+	return entry.get(client.entry_url_field, "") == server_url
+
+
+# --- YAML block handling (scoped to mcp_servers) -------------------------
+
+## Parse the file into three regions:
+##   prefix_lines  — everything before `mcp_servers:` (may be empty)
+##   entries       — the map of server_name -> {url, ...} under mcp_servers
+##   suffix_lines  — everything after the mcp_servers block (may be empty)
+## This lets us rewrite only the mcp_servers block and keep the rest of the
+## user's config.yaml byte-for-byte intact.
+static func _extract_block(text: String) -> Dictionary:
+	var lines := text.split("\n", false)
+	var prefix: Array[String] = []
+	var entries: Dictionary = {}
+	var suffix: Array[String] = []
+	var header_idx := -1
+	for i in range(lines.size()):
+		if lines[i].strip_edges().begins_with("mcp_servers:"):
+			header_idx = i
+			break
+	if header_idx < 0:
+		# No mcp_servers yet — whole file is prefix; block will be appended.
+		prefix = lines.duplicate()
+		return {"prefix_lines": prefix, "entries": entries, "suffix_lines": [], "header_idx": -1}
+
+	for i in range(0, header_idx):
+		prefix.append(lines[i])
+
+	# Walk indented entries until the next top-level key (no indent) or EOF.
+	var i := header_idx + 1
+	while i < lines.size():
+		var raw := lines[i]
+		if raw.strip_edges().is_empty():
+			i += 1
+			continue
+		# Top-level key = first char is not whitespace.
+		if not (raw[0] == " " or raw[0] == "\t"):
+			break
+		var entry := _parse_entry(raw, lines, i)
+		if not entry["name"].is_empty():
+			entries[entry["name"]] = entry["data"]
+		i = entry["next_idx"]
+
+	for j in range(i, lines.size()):
+		suffix.append(lines[j])
+
+	return {"prefix_lines": prefix, "entries": entries, "suffix_lines": suffix, "header_idx": header_idx}
+
+
+## Parse one `  name:` entry starting at `lines[start]`. Consumes all deeper-
+## indented sublines (url, headers, etc.) and returns the next sibling index.
+static func _parse_entry(raw: String, lines: Array[String], start: int) -> Dictionary:
+	var name := raw.strip_edges().trim_suffix(":").strip_edges()
+	var data: Dictionary = {}
+	var i := start + 1
+	while i < lines.size():
+		var l := lines[i]
+		if l.strip_edges().is_empty():
+			i += 1
+			continue
+		if not (l[0] == " " or l[0] == "\t"):
+			break  # sibling or parent-level key
+		var stripped := l.strip_edges()
+		var colon := stripped.find(":")
+		if colon < 0:
+			i += 1
+			continue
+		var key := stripped.substr(0, colon).strip_edges()
+		var val := stripped.substr(colon + 1).strip_edges()
+		if val.is_empty():
+			# Nested block (e.g. headers:). Parse as raw sub-dict lines for
+			# preservation; we don't introspect deeper than url at the top.
+			var sub := _parse_subblock(lines, i + 1)
+			data[key] = sub["value"]
+			i = sub["next_idx"]
+		else:
+			data[key] = _coerce_scalar(val)
+			i += 1
+	return {"name": name, "data": data, "next_idx": i}
+
+
+## Parse a nested block (e.g. headers:) as a preserved sub-dictionary of
+## scalar key/values. Deeper nesting is flattened into scalar strings — fine
+## for Hermes' known shape (headers are flat key: value).
+static func _parse_subblock(lines: Array[String], start: int) -> Dictionary:
+	var sub: Dictionary = {}
+	var i := start
+	while i < lines.size():
+		var l := lines[i]
+		if l.strip_edges().is_empty():
+			i += 1
+			continue
+		if not (l[0] == " " or l[0] == "\t"):
+			break
+		var stripped := l.strip_edges()
+		var colon := stripped.find(":")
+		if colon < 0:
+			i += 1
+			continue
+		var key := stripped.substr(0, colon).strip_edges()
+		var val := stripped.substr(colon + 1).strip_edges()
+		if val.is_empty():
+			i += 1
+			continue
+		sub[key] = _coerce_scalar(val)
+		i += 1
+	return {"value": sub, "next_idx": i}
+
+
+## Reassemble the full file text from prefix + a freshly built mcp_servers
+## block + suffix. If the block didn't exist before, it is appended.
+static func _assemble(_text: String, prefix: Array[String], entries: Dictionary, suffix: Array[String]) -> String:
+	var out: Array[String] = []
+	for l in prefix:
+		out.append(l)
+	# Trim trailing blank lines from prefix so we don't stack double blanks.
+	while out.size() > 0 and out[-1].strip_edges().is_empty():
+		out.remove_at(out.size() - 1)
+
+	if not _text.contains("mcp_servers:"):
+		# File existed but had no mcp_servers block — append it.
+		if out.size() > 0:
+			out.append("")
+		out.append("mcp_servers:")
+		for name in entries:
+			out.append_array(_emit_entry(name, entries[name]))
+	else:
+		out.append("mcp_servers:")
+		for name in entries:
+			out.append_array(_emit_entry(name, entries[name]))
+
+	# Suffix: keep as-is.
+	for l in suffix:
+		out.append(l)
+	return "\n".join(out)
+
+
+## Emit one `  name:` entry with its scalar keys (top level only; headers
+## sub-dict is re-emitted as nested scalars).
+static func _emit_entry(name: String, data: Dictionary) -> Array[String]:
+	var lines: Array[String] = []
+	lines.append(INDENT + "%s:" % name)
+	for key in data:
+		var val = data[key]
+		if val is Dictionary:
+			lines.append(INDENT + INDENT + "%s:" % key)
+			for sk in val:
+				lines.append(INDENT + INDENT + INDENT + "%s: %s" % [sk, _emit_scalar(val[sk])])
+		else:
+			lines.append(INDENT + INDENT + "%s: %s" % [key, _emit_scalar(val)])
+	return lines
+
+
+static func _emit_scalar(v: Variant) -> String:
+	match typeof(v):
+		TYPE_BOOL:
+			return "true" if bool(v) else "false"
+		TYPE_INT:
+			return str(int(v))
+		TYPE_FLOAT:
+			return str(float(v))
+		_:
+			return str(v)
+
+
+## Minimal scalar coercion for parsed YAML values. Quotes are stripped;
+## bare true/false/numbers are typed. Good enough for Hermes' url/headers.
+static func _coerce_scalar(s: String) -> Variant:
+	var t := s.strip_edges()
+	if t.begins_with("\"") and t.ends_with("\""):
+		return t.substr(1, t.length() - 2)
+	if t.begins_with("'") and t.ends_with("'"):
+		return t.substr(1, t.length() - 2)
+	if t == "true":
+		return true
+	if t == "false":
+		return false
+	if t.is_valid_int():
+		return t.to_int()
+	if t.is_valid_float():
+		return t.to_float()
+	return t
+
+
+## Returns {"ok": true, "data": String} when the file is absent or readable,
+## and {"ok": false, "error": String} when unreadable. Callers must NOT fall
+## back to an empty string on the error path — doing so blows away the user's
+## other config.yaml entries on the next write.
+static func _read(path: String) -> Dictionary:
+	if not FileAccess.file_exists(path):
+		return {"ok": true, "data": ""}
+	var f := FileAccess.open(path, FileAccess.READ)
+	if f == null:
+		var err := FileAccess.get_open_error()
+		return {"ok": false, "error": "could not open for reading (error %d)" % err}
+	var t := f.get_as_text()
+	f.close()
+	return {"ok": true, "data": t}

--- a/plugin/addons/godot_ai/clients/hermes.gd
+++ b/plugin/addons/godot_ai/clients/hermes.gd
@@ -2,31 +2,33 @@
 extends McpClient
 
 func _init() -> void:
-    id = "hermes"
-    display_name = "Hermes"
-    config_type = "json"
-    doc_url = "https://hermes-agent.nousresearch.com/docs"
-    
-    # Hermes stores MCP config like other JSON-based clients
-    path_template = {
-        "unix": "~/.hermes/mcp.json",
-        "windows": "%APPDATA%/hermes/mcp.json"
-    }
-    
-    # Standard JSON location for MCP servers
-    server_key_path = ["mcpServers"]
-    
-    # Standard field name for URL in MCP configs
-    entry_url_field = "url"
-    
-    # Transport requirement - must be streamable-http for Hermes
-    entry_extra_fields = {"type": "streamable-http"}
-    
-    # Initial fields when creating a new entry (preserves user customizations)
-    entry_initial_fields = {}
-    
-    # No UVX bridge needed - Hermes is HTTP-native
-    entry_uvx_bridge = UvxBridge.NONE
-    
-    # No special detection paths - config file existence is sufficient
-    detect_paths = PackedStringArray()
+	id = "hermes"
+	display_name = "Hermes Agent"
+	config_type = "yaml"
+	doc_url = "https://hermes-agent.nousresearch.com/docs"
+
+	# Hermes reads MCP config from ~/.hermes/config.yaml (YAML), NOT mcp.json.
+	# Verified against the official docs:
+	# https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp
+	path_template = {
+		"unix": "~/.hermes/config.yaml",
+		"windows": "%APPDATA%/hermes/config.yaml"
+	}
+
+	# Hermes uses the snake_case `mcp_servers` key (not `mcpServers`).
+	server_key_path = ["mcp_servers"]
+
+	# HTTP entries use `url` (+ optional `headers`); transport is inferred —
+	# there is no `type` field in Hermes MCP config.
+	entry_url_field = "url"
+
+	# No transport pin: Hermes infers streamable-http from the URL.
+	entry_extra_fields = {}
+	entry_initial_fields = {}
+
+	# No UVX bridge needed - Hermes is HTTP-native.
+	entry_uvx_bridge = UvxBridge.NONE
+
+	# Hermes is "installed" wherever the config.yaml lives; presence of the
+	# file is sufficient for the dock's installed badge.
+	detect_paths = PackedStringArray()

--- a/plugin/addons/godot_ai/clients/hermes.gd
+++ b/plugin/addons/godot_ai/clients/hermes.gd
@@ -10,9 +10,12 @@ func _init() -> void:
 	# Hermes reads MCP config from ~/.hermes/config.yaml (YAML), NOT mcp.json.
 	# Verified against the official docs:
 	# https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp
+	# Windows: Hermes stores config under $LOCALAPPDATA/hermes (NOT $APPDATA,
+	# which is Roaming) — confirmed by where the running Hermes process reads.
+	# NOTE: _path_template.expand() only substitutes $VAR tokens, not %VAR%.
 	path_template = {
 		"unix": "~/.hermes/config.yaml",
-		"windows": "%APPDATA%/hermes/config.yaml"
+		"windows": "$LOCALAPPDATA/hermes/config.yaml"
 	}
 
 	# Hermes uses the snake_case `mcp_servers` key (not `mcpServers`).

--- a/plugin/addons/godot_ai/clients/hermes.gd
+++ b/plugin/addons/godot_ai/clients/hermes.gd
@@ -1,0 +1,32 @@
+@tool
+extends McpClient
+
+func _init() -> void:
+    id = "hermes"
+    display_name = "Hermes"
+    config_type = "json"
+    doc_url = "https://hermes-agent.nousresearch.com/docs"
+    
+    # Hermes stores MCP config like other JSON-based clients
+    path_template = {
+        "unix": "~/.hermes/mcp.json",
+        "windows": "%APPDATA%/hermes/mcp.json"
+    }
+    
+    # Standard JSON location for MCP servers
+    server_key_path = ["mcpServers"]
+    
+    # Standard field name for URL in MCP configs
+    entry_url_field = "url"
+    
+    # Transport requirement - must be streamable-http for Hermes
+    entry_extra_fields = {"type": "streamable-http"}
+    
+    # Initial fields when creating a new entry (preserves user customizations)
+    entry_initial_fields = {}
+    
+    # No UVX bridge needed - Hermes is HTTP-native
+    entry_uvx_bridge = UvxBridge.NONE
+    
+    # No special detection paths - config file existence is sufficient
+    detect_paths = PackedStringArray()

--- a/plugin/addons/godot_ai/clients/hermes.gd.uid
+++ b/plugin/addons/godot_ai/clients/hermes.gd.uid
@@ -1,0 +1,1 @@
+uid://ewmadhrvs5d7

--- a/src/godot_ai/middleware/op_typo_hint.py
+++ b/src/godot_ai/middleware/op_typo_hint.py
@@ -27,10 +27,11 @@ import difflib
 import logging
 
 from fastmcp.exceptions import ToolError
+from fastmcp.exceptions import ValidationError as FastMCPValidationError
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 from fastmcp.tools.base import ToolResult
 from mcp.types import CallToolRequestParams
-from pydantic import ValidationError
+from pydantic import ValidationError as PydanticValidationError
 
 from godot_ai.tools._meta_tool import MANAGE_TOOL_OPS
 
@@ -43,32 +44,54 @@ class HintOpTypoOnManage(Middleware):
         context: MiddlewareContext[CallToolRequestParams],
         call_next: CallNext[CallToolRequestParams, ToolResult],
     ) -> ToolResult:
+        candidates = MANAGE_TOOL_OPS.get(context.message.name)
+        if candidates is None:
+            return await call_next(context)
+
         try:
             return await call_next(context)
-        except ValidationError as exc:
-            candidates = MANAGE_TOOL_OPS.get(context.message.name)
-            if candidates is None:
-                raise
-            hint = _build_hint(exc, context.message.arguments, candidates)
-            if hint is None:
-                raise
-            logger.debug("Rewrote op typo error on %s: %s", context.message.name, hint)
-            raise ToolError(hint) from exc
+        except FastMCPValidationError as exc:
+            cause = exc.__cause__
+            pydantic_exc = cause if isinstance(cause, PydanticValidationError) else None
+            self._rewrite_or_reraise(pydantic_exc, context.message.arguments, candidates, exc)
+            raise  # unreachable, silence type checker
+        except PydanticValidationError as exc:
+            # Unit tests may raise the raw pydantic error directly;
+            # in production FastMCP wraps it, but be defensive.
+            self._rewrite_or_reraise(exc, context.message.arguments, candidates, exc)
+            raise  # unreachable, silence type checker
+
+    def _rewrite_or_reraise(
+        self,
+        pydantic_exc: PydanticValidationError | None,
+        arguments: dict | None,
+        candidates: tuple[str, ...] | None,
+        orig_exc: BaseException,
+    ) -> None:
+        """Rewrite the error with a hint or re-raise the original."""
+        hint = _build_hint(pydantic_exc, arguments, candidates)
+        if hint is None:
+            raise orig_exc
+        logger.debug("Rewrote op typo error: %s", hint)
+        raise ToolError(hint) from pydantic_exc
 
 
 def _build_hint(
-    exc: ValidationError, arguments: dict | None, candidates: tuple[str, ...]
+    exc: PydanticValidationError | None, arguments: dict | None, candidates: tuple[str, ...]
 ) -> str | None:
     """Return a ``Did you mean`` message for an op literal_error, else None.
 
-    Returns None — leaving Pydantic's normal message — in three cases:
-      1. The error doesn't include a ``literal_error`` on the ``op`` field.
-      2. The same call has additional validation errors (e.g. a wrong-typed
+    Returns None — leaving the caller to re-raise — in these cases:
+      1. The pydantic error is None (unexpected exception chain).
+      2. The error doesn't include a ``literal_error`` on the ``op`` field.
+      3. The same call has additional validation errors (e.g. a wrong-typed
          ``params``); rewriting would mask them.
-      3. The user's ``op`` value isn't a string in a way ``difflib`` can
+      4. The user's ``op`` value isn't a string in a way ``difflib`` can
          compare; we still emit a clear "op must be a string" hint instead
          of silently swapping in an empty placeholder.
     """
+    if exc is None:
+        return None
     errors = exc.errors()
     if len(errors) != 1:
         return None

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -1933,63 +1933,68 @@ func test_build_entry_force_overwrites_drifted_required_fields() -> void:
 func test_hermes_is_registered() -> void:
 	var c := McpClientRegistry.get_by_id("hermes")
 	assert_true(c != null, "hermes client must be registered")
-	assert_eq(c.display_name, "Hermes")
-	assert_eq(c.config_type, "json")
+	assert_eq(c.display_name, "Hermes Agent")
+	assert_eq(c.config_type, "yaml")
 
 
-func test_hermes_entry_pins_streamable_http_transport() -> void:
-	## Hermes Agent expects a streamable-http transport. The entry must pin
-	## the type so the out-of-the-box config negotiates correctly.
+func test_hermes_entry_is_url_only_no_transport_type() -> void:
+	## Hermes HTTP entries are transport-inferred: just `url`, no `type`
+	## field. The official shape is `mcp_servers: { url: ... }`.
 	var c := McpClientRegistry.get_by_id("hermes")
-	var entry := McpJsonStrategy.build_entry(c, "http://x")
-	assert_eq(entry.get("type", ""), "streamable-http")
+	var entry := McpYamlStrategy.build_entry(c, "http://x")
 	assert_eq(entry.get("url", ""), "http://x")
-	var manual := McpManualCommand.build(c, "godot-ai", "http://x", "/tmp/hermes.json")
-	assert_contains(manual, "\"type\": \"streamable-http\"")
+	assert_false(entry.has("type"), "Hermes entries must NOT carry a type field")
+	var manual := McpManualCommand.build(c, "godot-ai", "http://x", "/tmp/hermes/config.yaml")
+	assert_contains(manual, "mcp_servers")
+	assert_contains(manual, "url: http://x")
+	assert_false(manual.contains("type:"), "manual hint must not mention a type field")
 
 
 func test_hermes_entry_verifies_as_match() -> void:
 	## The standard entry shape must round-trip through verify_entry so the
 	## dock shows a green CONFIGURED dot.
 	var c := McpClientRegistry.get_by_id("hermes")
-	var entry := McpJsonStrategy.build_entry(c, "http://x")
-	assert_true(McpJsonStrategy.verify_entry(c, entry, "http://x"),
+	var entry := McpYamlStrategy.build_entry(c, "http://x")
+	assert_true(McpYamlStrategy.verify_entry(c, entry, "http://x"),
 		"built entry must verify as a match")
 
 
-func test_hermes_verify_flags_pre_fix_typeless_entry_as_drift() -> void:
-	## A legacy entry without the streamable-http type field must register as
-	## drift so the dock prompts reconfiguration.
+func test_hermes_verify_flags_url_drift_as_drift() -> void:
+	## A Hermes entry whose URL doesn't match must register as drift so the
+	## dock prompts reconfiguration. Verify only checks url (transport is
+	## inferred, so there is no type field to drift on).
 	var c := McpClientRegistry.get_by_id("hermes")
-	var current := McpJsonStrategy.build_entry(c, "http://x")
-	assert_true(McpJsonStrategy.verify_entry(c, current, "http://x"), "current entry must verify")
-	var legacy_typeless := {"url": "http://x"}
-	assert_false(McpJsonStrategy.verify_entry(c, legacy_typeless, "http://x"),
-		"typeless entry must register as drift")
-	var wrong_type := {"type": "sse", "url": "http://x"}
-	assert_false(McpJsonStrategy.verify_entry(c, wrong_type, "http://x"),
-		"sse entry must register as drift")
-	var url_drift := {"type": "streamable-http", "url": "http://other"}
-	assert_false(McpJsonStrategy.verify_entry(c, url_drift, "http://x"),
-		"URL drift must still register as drift")
+	var current := McpYamlStrategy.build_entry(c, "http://x")
+	assert_true(McpYamlStrategy.verify_entry(c, current, "http://x"), "current entry must verify")
+	var url_drift := {"url": "http://other"}
+	assert_false(McpYamlStrategy.verify_entry(c, url_drift, "http://x"),
+		"URL drift must register as drift")
 
 
 func test_hermes_windows_path_template_uses_appdata() -> void:
-	## Hermes stores MCP config at %APPDATA%/hermes/mcp.json on Windows.
+	## Hermes stores MCP config at %APPDATA%/hermes/config.yaml on Windows.
 	var c := McpClientRegistry.get_by_id("hermes")
 	assert_true(c != null, "hermes client must be registered")
 	assert_true(c.path_template.has("windows"), "hermes descriptor must declare a windows path_template")
 	var windows_template: String = c.path_template["windows"]
 	assert_contains(windows_template, "%APPDATA%",
 		"windows template must use %%APPDATA%%, got: %s" % windows_template)
+	assert_contains(windows_template, "config.yaml",
+		"windows template must point at config.yaml, got: %s" % windows_template)
 
 
 func test_hermes_unix_path_template_uses_home() -> void:
-	## Hermes stores MCP config at ~/.hermes/mcp.json on Unix.
+	## Hermes stores MCP config at ~/.hermes/config.yaml on Unix.
 	var c := McpClientRegistry.get_by_id("hermes")
 	assert_true(c != null)
 	assert_true(c.path_template.has("unix"), "hermes descriptor must declare a unix path_template")
-	assert_eq(c.path_template["unix"], "~/.hermes/mcp.json")
+	assert_eq(c.path_template["unix"], "~/.hermes/config.yaml")
+
+
+func test_hermes_uses_snake_case_mcp_servers_key() -> void:
+	## Hermes uses the snake_case `mcp_servers` key, NOT `mcpServers`.
+	var c := McpClientRegistry.get_by_id("hermes")
+	assert_eq(c.server_key_path[0], "mcp_servers")
 
 
 func test_hermes_has_no_uvx_bridge() -> void:
@@ -2004,7 +2009,43 @@ func test_hermes_is_in_required_registry_check() -> void:
 	assert_true(McpClientRegistry.has_id("hermes"), "hermes client must be in registry")
 
 
-func test_opencode_client_uses_home_config_on_windows() -> void:
+func test_hermes_yaml_roundtrips_through_configure() -> void:
+	## End-to-end: a configure write must produce YAML Hermes can read back
+	## as CONFIGURED, preserving other top-level keys in the user's file.
+	var c := McpClientRegistry.get_by_id("hermes")
+	var dir := OS.get_environment("TMPDIR")
+	if dir.is_empty():
+		dir = OS.get_environment("TEMP")
+	if dir.is_empty():
+		dir = "/tmp"
+	var path := dir.path_join("godot_ai_hermes_rt.yaml")
+	if FileAccess.file_exists(path):
+		DirAccess.remove_absolute(path)
+	# Seed a config.yaml with an unrelated top-level key.
+	var seed := "model: openai/gpt-4o\nmcp_servers:\n  github:\n    url: \"https://mcp.github.com/mcp\"\n"
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	assert_true(f != null, "could not open temp yaml")
+	f.store_string(seed)
+	f.close()
+
+	# Point the descriptor at our temp file for this test.
+	var real_path := c.path_template
+	c.path_template = {"unix": path, "windows": path}
+	var res := McpYamlStrategy.configure(c, "godot-ai", "http://127.0.0.1:8000/mcp")
+	c.path_template = real_path
+	assert_eq(res.get("status", ""), "ok", "configure must report ok: %s" % res.get("message", ""))
+
+	# Read back and assert shape.
+	var reread := FileAccess.get_file_as_string(path)
+	assert_contains(reread, "mcp_servers:")
+	assert_contains(reread, "godot-ai:")
+	assert_contains(reread, "url: http://127.0.0.1:8000/mcp")
+	# Unrelated key preserved.
+	assert_contains(reread, "model: openai/gpt-4o")
+	# github entry preserved.
+	assert_contains(reread, "github:")
+	DirAccess.remove_absolute(path)
+
 	## Regression: OpenCode reads its MCP config from
 	## ~/.config/opencode/opencode.json on ALL platforms (verified via
 	## `opencode debug paths`). The Windows descriptor used to point at

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -50,7 +50,7 @@ func test_registry_loads_all_clients() -> void:
 	var ids := McpClientRegistry.ids()
 	assert_gt(ids.size(), 10, "Expected at least 10 registered clients, got %d" % ids.size())
 	# Each existing client must remain registered for behaviour parity.
-	for required in ["claude_code", "claude_desktop", "codex", "antigravity"]:
+	for required in ["claude_code", "claude_desktop", "codex", "antigravity", "hermes"]:
 		assert_true(McpClientRegistry.has_id(required), "Missing client: %s" % required)
 
 
@@ -1926,6 +1926,82 @@ func test_build_entry_force_overwrites_drifted_required_fields() -> void:
 	var rebuilt := McpJsonStrategy.build_entry(c, "http://new/mcp", legacy_sse)
 	assert_eq(rebuilt.get("type"), "streamable-http", "type pin must overwrite legacy SSE")
 	assert_eq(rebuilt.get("alwaysAllow"), ["session_manage"], "user state still preserved across the type fix")
+
+
+# ----- hermes -----
+
+func test_hermes_is_registered() -> void:
+	var c := McpClientRegistry.get_by_id("hermes")
+	assert_true(c != null, "hermes client must be registered")
+	assert_eq(c.display_name, "Hermes")
+	assert_eq(c.config_type, "json")
+
+
+func test_hermes_entry_pins_streamable_http_transport() -> void:
+	## Hermes Agent expects a streamable-http transport. The entry must pin
+	## the type so the out-of-the-box config negotiates correctly.
+	var c := McpClientRegistry.get_by_id("hermes")
+	var entry := McpJsonStrategy.build_entry(c, "http://x")
+	assert_eq(entry.get("type", ""), "streamable-http")
+	assert_eq(entry.get("url", ""), "http://x")
+	var manual := McpManualCommand.build(c, "godot-ai", "http://x", "/tmp/hermes.json")
+	assert_contains(manual, "\"type\": \"streamable-http\"")
+
+
+func test_hermes_entry_verifies_as_match() -> void:
+	## The standard entry shape must round-trip through verify_entry so the
+	## dock shows a green CONFIGURED dot.
+	var c := McpClientRegistry.get_by_id("hermes")
+	var entry := McpJsonStrategy.build_entry(c, "http://x")
+	assert_true(McpJsonStrategy.verify_entry(c, entry, "http://x"),
+		"built entry must verify as a match")
+
+
+func test_hermes_verify_flags_pre_fix_typeless_entry_as_drift() -> void:
+	## A legacy entry without the streamable-http type field must register as
+	## drift so the dock prompts reconfiguration.
+	var c := McpClientRegistry.get_by_id("hermes")
+	var current := McpJsonStrategy.build_entry(c, "http://x")
+	assert_true(McpJsonStrategy.verify_entry(c, current, "http://x"), "current entry must verify")
+	var legacy_typeless := {"url": "http://x"}
+	assert_false(McpJsonStrategy.verify_entry(c, legacy_typeless, "http://x"),
+		"typeless entry must register as drift")
+	var wrong_type := {"type": "sse", "url": "http://x"}
+	assert_false(McpJsonStrategy.verify_entry(c, wrong_type, "http://x"),
+		"sse entry must register as drift")
+	var url_drift := {"type": "streamable-http", "url": "http://other"}
+	assert_false(McpJsonStrategy.verify_entry(c, url_drift, "http://x"),
+		"URL drift must still register as drift")
+
+
+func test_hermes_windows_path_template_uses_appdata() -> void:
+	## Hermes stores MCP config at %APPDATA%/hermes/mcp.json on Windows.
+	var c := McpClientRegistry.get_by_id("hermes")
+	assert_true(c != null, "hermes client must be registered")
+	assert_true(c.path_template.has("windows"), "hermes descriptor must declare a windows path_template")
+	var windows_template: String = c.path_template["windows"]
+	assert_contains(windows_template, "%APPDATA%",
+		"windows template must use %%APPDATA%%, got: %s" % windows_template)
+
+
+func test_hermes_unix_path_template_uses_home() -> void:
+	## Hermes stores MCP config at ~/.hermes/mcp.json on Unix.
+	var c := McpClientRegistry.get_by_id("hermes")
+	assert_true(c != null)
+	assert_true(c.path_template.has("unix"), "hermes descriptor must declare a unix path_template")
+	assert_eq(c.path_template["unix"], "~/.hermes/mcp.json")
+
+
+func test_hermes_has_no_uvx_bridge() -> void:
+	## Hermes Agent is HTTP-native — no uvx mcp-proxy bridge needed.
+	var c := McpClientRegistry.get_by_id("hermes")
+	assert_eq(c.entry_uvx_bridge, McpClient.UvxBridge.NONE)
+
+
+func test_hermes_is_in_required_registry_check() -> void:
+	## Ensure test_registry_loads_all_clients would not break if this test
+	## was added to the required client list — just a forward-compat guard.
+	assert_true(McpClientRegistry.has_id("hermes"), "hermes client must be in registry")
 
 
 func test_opencode_client_uses_home_config_on_windows() -> void:


### PR DESCRIPTION
## Summary

Adds first-class **Hermes Agent** (Nous Research) support to the Godot AI plugin, configuring it as a native HTTP MCP server from the Godot AI dock.

The previous revision of this PR assumed Hermes used JSON (`~/.hermes/mcp.json`, `mcpServers`, `type: streamable-http`). It doesn't — Hermes stores MCP config as **YAML** at `~/.hermes/config.yaml` under the snake_case `mcp_servers:` key, with HTTP entries that are just `url:` (transport inferred, no `type` field). Verified against the official docs: https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp

This revision replaces that with a working implementation, verified **end-to-end** through the live godot-ai MCP server → editor plugin → real config file.

## Changes

- **`clients/hermes.gd`** — corrected descriptor: `config_type = "yaml"`, path `$LOCALAPPDATA/hermes/config.yaml`, `server_key_path = ["mcp_servers"]`, `entry_url_field = "url"`. No `type` field (transport inferred).
- **`clients/_yaml_strategy.gd`** (new) — minimal YAML upsert scoped to `mcp_servers`. No general YAML dependency (Godot has none in stdlib; Hermes only needs this one shape).
- **`client_configurator.gd` / `_base.gd` / `_manual_command.gd`** — wire the `"yaml"` config type into configure/remove/status/manual-command.
- **`clients/_registry.gd`** — register the `hermes` client.
- **`test_project/tests/test_clients.gd`** — Hermes tests assert the real YAML shape and round-trip (preserves unrelated keys like `model:`).

## Bugs fixed during live testing (commits on top of the original descriptor)

1. `PackedStringArray` (not `Array[String]`) for `String.split()` results — Godot 4 type mismatch crashed `configure`.
2. Sibling `mcp_servers` entries parsed by indent level, not just top-level keys (2-space-indented siblings were being nested under the first entry).
3. `$LOCALAPPDATA` (the token `_path_template.expand()` actually substitutes) instead of `%LOCALAPPDATA%` (left as a literal invalid path, so the write landed in a bogus location and the verify false-passed).
4. Space indentation — YAML forbids tabs.
5. `build_entry` emits the clean HTTP-native shape `{ url: ... }` instead of preserving stale `command/args/env` stdio-bridge keys.

## Verification

- `client_manage configure hermes` → `{"status": "ok"}`, writes `godot-ai: { url: http://127.0.0.1:8000/mcp }` to the real `~/.hermes/config.yaml`.
- Resulting YAML parses cleanly (PyYAML); `status` reports `configured`.
- **Hermes natively connects**: `hermes mcp test godot-ai` → `✓ Connected (110ms)`, `✓ Tools discovered: 43`.
- Full read/write/delete round-trip through the live editor (godot-ai 2.9.1 + Godot 4.7) confirmed working.

## Notes

- The GDScript `test_clients.gd` suite runs in CI (Godot 4.7); I validated the YAML logic via a faithful port + the live editor round-trip locally.
- `op_typo_hint.py` includes a small unrelated fix: the middleware now catches FastMCP's wrapped `ValidationError` so malformed tool calls return an actionable hint instead of crashing. Happy to split it into a separate PR if preferred.