### PR TITLE
Surface launch-time parse errors that agents never saw (#641)

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -72,6 +72,13 @@ one. There is no single `source="game"` call that returns every retained game
 line across all runs; consumers that need history should retain run ids and
 query each run explicitly.
 
+Boot-time parse/load errors happen while autoload scripts compile — before the
+game helper's logger attaches — so they can never appear in `source="game"`.
+When editor-side errors were recorded during the current run, the game-scope
+response adds `editor_errors_count` and `editor_errors_hint` pointing at
+`logs_read(source="editor", include_details=true)`; a clean game log carrying
+that hint means the run lost scripts, not that the launch was clean (#641).
+
 Game and combined log responses also include `game_status`, `helper_live`, and
 `session_active`; the top-level booleans mirror `game_status.helper_live` and
 `game_status.session_active`. For compatibility, `is_running` is retained as an

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -109,6 +109,18 @@ clear the Debugger dock's visible Errors-tab rows (routed through the panel's
 own Clear path so the tab badge and counters reset). The Errors panel is
 user-facing UI, so the default leaves it untouched.
 
+When new GDScript errors are observed since a client's previous call — from
+the editor logger, the game log buffer, or Debugger Errors-tab rows promoted
+by the run/stop deferred scans (#641) — the next tool response carries
+`new_errors_since_last_call` (int) and `new_errors_hint` (text pointing at
+`logs_read(source="editor"|"game", include_details=true)`). The count is of
+distinct new errors: a running game's script error reaches the server through
+both the game log buffer and the Errors tab, and those overlapping views are
+deduplicated rather than summed. The stamp is delivered exactly once and is
+consumed by that delivery — treat it as a doorbell, then read the logs; do not
+poll for it to repeat. It can appear on any tool's response, including
+`logs_read` itself.
+
 `script_create` and `script_patch` validate written `.gd` content before the
 editor import step and include per-write diagnostics in their response:
 `diagnostics` (array of structured editor-style entries), `diagnostics_scope`

--- a/plugin/addons/godot_ai/connection.gd
+++ b/plugin/addons/godot_ai/connection.gd
@@ -49,6 +49,11 @@ var server_version := ""
 var dispatcher
 var log_buffer
 var surfaced_error_tracker
+## Set by plugin.gd. Lets the per-frame play-state poll end game-run
+## bookkeeping when the game exits on its own (self-quit, crash) — the
+## debugger session's stopped signal is not reliably connected, and no MCP
+## stop op runs in that path (#642).
+var debugger_plugin
 ## Set by plugin.gd when the HTTP port is occupied by an incompatible or
 ## unverified server. Keeping the Connection node alive lets handlers and the
 ## dock share one object, but no WebSocket is opened to the wrong server.
@@ -322,10 +327,15 @@ func _hook_editor_signals() -> void:
 	EditorInterface.get_editor_settings()  # ensure interface is ready
 	_last_scene_path = _get_current_scene_path()
 	_last_play_state = EditorInterface.is_playing_scene()
+	_last_play_state_for_run = _last_play_state
 
 
 var _last_scene_path := ""
 var _last_play_state := false
+## Separate edge tracker for game-run bookkeeping: _last_play_state only
+## advances when the play_state_changed event sends successfully, but ending
+## run tracking must not depend on the websocket being up.
+var _last_play_state_for_run := false
 var _last_readiness := ""
 
 
@@ -350,6 +360,11 @@ func _check_state_changes() -> void:
 				log_buffer.log("[event] scene_changed -> %s" % scene_path)
 
 	var playing := EditorInterface.is_playing_scene()
+	if playing != _last_play_state_for_run:
+		if not playing and debugger_plugin != null:
+			debugger_plugin.note_editor_play_stopped()
+		_last_play_state_for_run = playing
+
 	if playing != _last_play_state:
 		var state := "playing" if playing else "stopped"
 		if send_event("play_state_changed", {"play_state": state}):

--- a/plugin/addons/godot_ai/connection.gd
+++ b/plugin/addons/godot_ai/connection.gd
@@ -95,6 +95,10 @@ func _process(delta: float) -> void:
 	if pause_processing:
 		return
 	_peer.poll()
+	## Run-stop bookkeeping must not wait behind the socket-state machine:
+	## if the game stops while disconnected, the first command drained on
+	## reconnect would still observe stale "live" state (PR #642 review).
+	_check_game_run_play_state(EditorInterface.is_playing_scene())
 
 	match _peer.get_ready_state():
 		WebSocketPeer.STATE_OPEN:
@@ -360,11 +364,6 @@ func _check_state_changes() -> void:
 				log_buffer.log("[event] scene_changed -> %s" % scene_path)
 
 	var playing := EditorInterface.is_playing_scene()
-	if playing != _last_play_state_for_run:
-		if not playing and debugger_plugin != null:
-			debugger_plugin.note_editor_play_stopped()
-		_last_play_state_for_run = playing
-
 	if playing != _last_play_state:
 		var state := "playing" if playing else "stopped"
 		if send_event("play_state_changed", {"play_state": state}):
@@ -382,6 +381,17 @@ func _check_state_changes() -> void:
 				## console spams every install during normal editing (#626).
 				## The line stays in the ring for the dock's log panel.
 				log_buffer.log("[event] readiness -> %s" % readiness, false)
+
+
+## Playing→stopped edge for game-run bookkeeping. Runs every process tick
+## (any socket state) so a self-quit game's run ends even while the
+## transport is down or reconnecting.
+func _check_game_run_play_state(playing: bool) -> void:
+	if playing == _last_play_state_for_run:
+		return
+	if not playing and debugger_plugin != null:
+		debugger_plugin.note_editor_play_stopped()
+	_last_play_state_for_run = playing
 
 
 func _get_current_scene_path() -> String:

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -280,18 +280,22 @@ static func split_errors_by_scope(recent_errors: Array, scope: String) -> Dictio
 	}
 
 
-func recent_editor_errors_since(cursor: int) -> Dictionary:
-	return _recent_editor_errors_since(cursor)
+## `force_debugger_scan` bypasses the tracker's scan gate for one read. Keep it
+## false on per-frame polling paths (the run-liveness loop) — a forced scan
+## walks the Debugger dock UI — and pass true only for one-shot reads that must
+## see rows which landed after the last gated scan (#641).
+func recent_editor_errors_since(cursor: int, force_debugger_scan: bool = false) -> Dictionary:
+	return _recent_editor_errors_since(cursor, force_debugger_scan)
 
 
-func _recent_editor_errors_since(cursor: int) -> Dictionary:
+func _recent_editor_errors_since(cursor: int, force_debugger_scan: bool = false) -> Dictionary:
 	var out: Array[Dictionary] = []
 	var truncated := false
 	if _surfaced_error_tracker != null:
 		var captured_by_tracker: Dictionary = _surfaced_error_tracker.editor_entries_since(
 			maxi(0, cursor),
 			_game_run_started_debugger_cursor,
-			false,
+			force_debugger_scan,
 		)
 		truncated = bool(captured_by_tracker.get("truncated", false))
 		for raw_entry in captured_by_tracker.get("entries", []):
@@ -411,6 +415,13 @@ func _capture(message: String, data: Array, session_id: int) -> bool:
 			_game_ready = true
 			_ready_run_token = _game_run_token
 			game_ready.emit()
+			## #641: boot-time parse errors race the hello beacon — both ride
+			## the same debugger channel, and the editor inserts Errors-tab
+			## rows with a per-frame throttle, so rows can land moments after
+			## the run is declared live. Arm forced scans so those rows get
+			## promoted into the watermark even if no tool call follows.
+			if _surfaced_error_tracker != null:
+				_surfaced_error_tracker.schedule_deferred_scans()
 			if _log_buffer:
 				if _game_log_buffer:
 					_log_buffer.log("[debug] <- mcp:hello from game_helper (run %s)" % _game_log_buffer.run_id())

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -170,6 +170,19 @@ func end_game_run() -> void:
 		_surfaced_error_tracker.note_game_run_stopped()
 
 
+## Authoritative fallback for runs whose debugger `stopped` signal never
+## fired or was never connected: the editor's play state falling to stopped
+## means the game process is gone. A game that exits on its own
+## (get_tree().quit(), crash) has no MCP stop op to run the bookkeeping, and
+## without this game_status stayed "live" until the next run (#642 smoke).
+## Called on the playing→stopped edge only, so the pre-play launch window
+## (run tracking begun, is_playing_scene() not yet true) is never clipped.
+func note_editor_play_stopped() -> void:
+	if not _game_run_active:
+		return
+	end_game_run()
+
+
 func _connect_session_stopped(session_id: int) -> void:
 	var session = get_session(session_id)
 	if session == null:
@@ -180,9 +193,15 @@ func _connect_session_stopped(session_id: int) -> void:
 
 
 func _on_debugger_session_stopped(session_id: int) -> void:
-	if not _manual_run_armed:
-		return
 	if _game_session_id != -1 and session_id != _game_session_id:
+		return
+	## MCP-started runs normally end via project_manage(op="stop"), but a game
+	## that exits on its own (get_tree().quit(), crash) emits only this signal.
+	## Without ending the run here, game_status stays "live" until the next
+	## run's bookkeeping rewrites it (#642 live smoke). Before the game session
+	## attaches (_game_session_id == -1) only manual runs may end on this
+	## signal — a foreign session's stop must not cancel a launching MCP run.
+	if not _manual_run_armed and _game_session_id == -1:
 		return
 	end_game_run()
 

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -377,14 +377,7 @@ func _reversed_entries(entries: Array[Dictionary]) -> Array[Dictionary]:
 
 
 func _format_editor_error_summary(entry: Dictionary) -> String:
-	var text := str(entry.get("text", "editor error"))
-	var path := str(entry.get("path", ""))
-	var line := int(entry.get("line", 0))
-	if not path.is_empty() and line > 0:
-		return "%s (%s:%d)" % [text, path, line]
-	if not path.is_empty():
-		return "%s (%s)" % [text, path]
-	return text
+	return McpSurfacedErrorTracker.format_editor_error_summary(entry)
 
 
 func _capture(message: String, data: Array, session_id: int) -> bool:

--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -180,13 +180,20 @@ func _get_game_logs(count: int, offset: int, include_details: bool, since_run_id
 func _merge_editor_errors_hint(data: Dictionary, game_status: Dictionary) -> void:
 	if _debugger_plugin == null:
 		return
+	## A since_run_id read of a prior run must not carry the CURRENT run's
+	## editor errors — the hint interprets the run being read.
+	if bool(data.get("stale_run_id", false)):
+		return
 	## run_token == 0 means no tracked run ever started this session; the
 	## run-start cursor would be 0 and every retained editor error would be
 	## misattributed to "this run".
 	if int(game_status.get("run_token", 0)) <= 0:
 		return
+	## One-shot read — force the scan so rows that landed after the last
+	## gated scan (and before the deferred timers fire) make the FIRST
+	## logs_read(source='game') response, not just a later one.
 	var errors_info: Dictionary = _debugger_plugin.recent_editor_errors_since(
-		int(game_status.get("editor_log_cursor", 0)))
+		int(game_status.get("editor_log_cursor", 0)), true)
 	if str(errors_info.get("scope", "none")) != "run":
 		return
 	var errors: Array = errors_info.get("errors", [])
@@ -200,14 +207,7 @@ func _merge_editor_errors_hint(data: Dictionary, game_status: Dictionary) -> voi
 
 
 func _format_editor_error_summary(entry: Dictionary) -> String:
-	var text := str(entry.get("text", "editor error"))
-	var path := str(entry.get("path", ""))
-	var line := int(entry.get("line", 0))
-	if not path.is_empty() and line > 0:
-		return "%s (%s:%d)" % [text, path, line]
-	if not path.is_empty():
-		return "%s (%s)" % [text, path]
-	return text
+	return McpSurfacedErrorTracker.format_editor_error_summary(entry)
 
 
 func _get_editor_logs(count: int, offset: int, include_details: bool, has_since_cursor: bool = false, since_cursor: int = 0) -> Dictionary:

--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -153,23 +153,61 @@ func _get_game_logs(count: int, offset: int, include_details: bool, since_run_id
 	var stale_run_id := not since_run_id.is_empty() and since_run_id != current_run_id
 	var run_page := _game_log_buffer.get_run_page(target_run_id, offset, count)
 	var page := _entries_for_response(run_page.get("entries", []), include_details)
-	return {
-		"data": {
-			"source": "game",
-			"lines": page,
-			"total_count": int(run_page.get("total_count", 0)),
-			"returned_count": page.size(),
-			"offset": offset,
-			"run_id": target_run_id,
-			"current_run_id": current_run_id,
-			"is_running": session_active,
-			"helper_live": helper_live,
-			"session_active": session_active,
-			"game_status": game_status,
-			"dropped_count": _game_log_buffer.dropped_count(),
-			"stale_run_id": stale_run_id,
-		}
+	var data := {
+		"source": "game",
+		"lines": page,
+		"total_count": int(run_page.get("total_count", 0)),
+		"returned_count": page.size(),
+		"offset": offset,
+		"run_id": target_run_id,
+		"current_run_id": current_run_id,
+		"is_running": session_active,
+		"helper_live": helper_live,
+		"session_active": session_active,
+		"game_status": game_status,
+		"dropped_count": _game_log_buffer.dropped_count(),
+		"stale_run_id": stale_run_id,
 	}
+	_merge_editor_errors_hint(data, game_status)
+	return {"data": data}
+
+
+## #641: boot-time parse errors happen while autoload scripts compile — before
+## the game helper's logger attaches via OS.add_logger — so they can NEVER
+## appear in the game buffer. They surface only through the editor scope
+## (Errors-tab rows + editor logger). Cross-reference them here so an
+## empty/clean game log is not mistaken for a clean launch.
+func _merge_editor_errors_hint(data: Dictionary, game_status: Dictionary) -> void:
+	if _debugger_plugin == null:
+		return
+	## run_token == 0 means no tracked run ever started this session; the
+	## run-start cursor would be 0 and every retained editor error would be
+	## misattributed to "this run".
+	if int(game_status.get("run_token", 0)) <= 0:
+		return
+	var errors_info: Dictionary = _debugger_plugin.recent_editor_errors_since(
+		int(game_status.get("editor_log_cursor", 0)))
+	if str(errors_info.get("scope", "none")) != "run":
+		return
+	var errors: Array = errors_info.get("errors", [])
+	if errors.is_empty():
+		return
+	data["editor_errors_count"] = errors.size()
+	data["editor_errors_hint"] = (
+		"%d editor-side error%s from this run (first: %s) missing from the game log — boot-time parse/load errors occur before the game helper's logger attaches. Read logs_read(source='editor', include_details=true)."
+		% [errors.size(), "s" if errors.size() != 1 else "", _format_editor_error_summary(errors[0])]
+	)
+
+
+func _format_editor_error_summary(entry: Dictionary) -> String:
+	var text := str(entry.get("text", "editor error"))
+	var path := str(entry.get("path", ""))
+	var line := int(entry.get("line", 0))
+	if not path.is_empty() and line > 0:
+		return "%s (%s:%d)" % [text, path, line]
+	if not path.is_empty():
+		return "%s (%s)" % [text, path]
+	return text
 
 
 func _get_editor_logs(count: int, offset: int, include_details: bool, has_since_cursor: bool = false, since_cursor: int = 0) -> Dictionary:

--- a/plugin/addons/godot_ai/handlers/project_handler.gd
+++ b/plugin/addons/godot_ai/handlers/project_handler.gd
@@ -188,7 +188,9 @@ func _run_project_current_liveness_response(base_data: Dictionary) -> Dictionary
 	if _debugger_plugin == null:
 		return {"data": base_data}
 	var status: Dictionary = _debugger_plugin.get_game_status(-1, RUN_READY_WAIT_SEC)
-	var errors_info: Dictionary = _debugger_plugin.recent_editor_errors_since(int(status.get("editor_log_cursor", 0)))
+	## One-shot read — force a Debugger-tab scan so boot errors that landed
+	## after the last gated scan are in this response (#641).
+	var errors_info: Dictionary = _debugger_plugin.recent_editor_errors_since(int(status.get("editor_log_cursor", 0)), true)
 	return _run_project_response(base_data, _run_project_liveness_decision(status, errors_info))
 
 
@@ -210,6 +212,14 @@ func _finish_run_project_deferred(request_id: String, base_data: Dictionary) -> 
 		var decision := _run_project_liveness_decision(status, errors_info)
 		if not bool(decision.get("resolve", false)):
 			continue
+		## #641: the loop above polls with gated (cheap) scans; boot parse
+		## errors can land in the Errors tab in the same frames the run goes
+		## live. Re-gather once with a forced scan before replying so the
+		## response reports them instead of leaving them to a later
+		## logs_read. Rebuilding the decision with strictly-more errors can
+		## only keep it resolved (errors never un-resolve a decision).
+		errors_info = _debugger_plugin.recent_editor_errors_since(int(status.get("editor_log_cursor", 0)), true)
+		decision = _run_project_liveness_decision(status, errors_info)
 		_connection.send_deferred_response(request_id, _run_project_response(base_data, decision))
 		return
 
@@ -236,6 +246,12 @@ func _run_project_already_running_message(decision: Dictionary) -> String:
 	var state := str(decision.get("liveness_status", "unknown"))
 	match state:
 		"live":
+			var live_errors: Array = decision.get("recent_errors", [])
+			if not live_errors.is_empty() and str(decision.get("recent_errors_scope", "none")) == "run":
+				return (
+					"Project was already running; the Godot AI game helper is live, but %d editor error%s surfaced during this run (first: %s). Check logs_read(source='editor', include_details=true)."
+					% [live_errors.size(), "s" if live_errors.size() != 1 else "", _format_editor_error_summary(live_errors[0])]
+				)
 			return "Project was already running; the Godot AI game helper is live."
 		"not_live":
 			var errors: Array = decision.get("recent_errors", [])
@@ -276,7 +292,20 @@ func _run_project_liveness_decision(status: Dictionary, errors_info: Dictionary 
 	}
 	if state == "live":
 		decision["resolve"] = true
-		decision["message"] = "Game launched and the Godot AI game helper is live."
+		if correlated_error:
+			## #641: "live" only means the helper autoload registered — scripts
+			## can still have failed to parse or load during boot (a broken
+			## node script does not stop the game from running). Surface those
+			## errors in the success message so agents don't read a clean
+			## launch into a run that silently lost scripts.
+			decision["message"] = (
+				"Game launched and the Godot AI game helper is live, but %d editor error%s surfaced during startup (first: %s) — likely a script that failed to parse or load. Check logs_read(source='editor', include_details=true)."
+				% [recent_errors.size(), "s" if recent_errors.size() != 1 else "", _format_editor_error_summary(recent_errors[0])]
+			)
+			if truncated:
+				decision["message"] += " Editor logs since this run may be truncated; showing retained errors."
+		else:
+			decision["message"] = "Game launched and the Godot AI game helper is live."
 	elif correlated_error:
 		decision["resolve"] = true
 		decision["liveness_status"] = "not_live"

--- a/plugin/addons/godot_ai/handlers/project_handler.gd
+++ b/plugin/addons/godot_ai/handlers/project_handler.gd
@@ -331,14 +331,7 @@ func _run_project_liveness_decision(status: Dictionary, errors_info: Dictionary 
 
 
 func _format_editor_error_summary(entry: Dictionary) -> String:
-	var text := str(entry.get("text", "editor error"))
-	var path := str(entry.get("path", ""))
-	var line := int(entry.get("line", 0))
-	if not path.is_empty() and line > 0:
-		return "%s (%s:%d)" % [text, path, line]
-	if not path.is_empty():
-		return "%s (%s)" % [text, path]
-	return text
+	return McpSurfacedErrorTracker.format_editor_error_summary(entry)
 
 
 func stop_project(params: Dictionary) -> Dictionary:

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -233,6 +233,7 @@ func _enter_tree() -> void:
 
 	_debugger_plugin = DebuggerPlugin.new(_log_buffer, _game_log_buffer, _editor_log_buffer, _surfaced_error_tracker)
 	add_debugger_plugin(_debugger_plugin)
+	_connection.debugger_plugin = _debugger_plugin
 	_ensure_game_helper_autoload()
 
 	var editor_handler := EditorHandler.new(_log_buffer, _connection, _debugger_plugin, _game_log_buffer, _editor_log_buffer, null, _surfaced_error_tracker)

--- a/plugin/addons/godot_ai/utils/surfaced_error_tracker.gd
+++ b/plugin/addons/godot_ai/utils/surfaced_error_tracker.gd
@@ -13,6 +13,11 @@ const MAX_PROMOTED_DEBUGGER_ENTRIES := 500
 const MAX_PROMOTED_DEBUGGER_KEYS := 5000
 const DEBUGGER_REFRESH_MIN_INTERVAL_MS := 250
 const DEBUGGER_SCAN_AFTER_STOP_MS := 5000
+## #641: delays for the self-scheduled forced scans armed on run stop (and on
+## game-helper hello, via McpDebuggerPlugin). Two ticks: an early one for rows
+## the remote debugger delivers right around the event, and a late one past
+## Godot's per-frame Errors-tab insertion throttle for error floods.
+const DEFERRED_SCAN_DELAYS_SEC: Array[float] = [1.0, 5.0]
 
 var _editor_log_buffer
 var _game_log_buffer
@@ -27,6 +32,7 @@ var _oldest_retained_debugger_sequence := 1
 var _last_debugger_refresh_msec := -DEBUGGER_REFRESH_MIN_INTERVAL_MS
 var _debugger_scan_active := false
 var _debugger_scan_until_msec := 0
+var _deferred_scans_scheduled_total := 0
 
 
 func _init(editor_log_buffer = null, game_log_buffer = null, debugger_errors_root: Node = null) -> void:
@@ -47,6 +53,33 @@ func note_game_run_started(sticky_scan: bool = true) -> void:
 func note_game_run_stopped() -> void:
 	_debugger_scan_active = false
 	_debugger_scan_until_msec = Time.get_ticks_msec() + DEBUGGER_SCAN_AFTER_STOP_MS
+	schedule_deferred_scans()
+
+
+## #641: promotion into the watermark used to depend on a tool call arriving
+## while the scan gate was open (run active, or within DEBUGGER_SCAN_AFTER_STOP_MS
+## of stop). Boot parse errors that landed in the Errors tab with no tool call
+## in that window were never promoted, so the agent never got the
+## new_errors_since_last_call hint. These editor-side timers force a scan
+## regardless of tool-call cadence; the next stamped response then carries the
+## already-promoted count even after the gate closes. Scans are content-keyed
+## and idempotent, so a timer firing after an unrelated new run is harmless.
+func schedule_deferred_scans(delays: Array = DEFERRED_SCAN_DELAYS_SEC) -> void:
+	var tree := Engine.get_main_loop() as SceneTree
+	if tree == null:
+		return
+	for delay in delays:
+		var timer := tree.create_timer(maxf(0.05, float(delay)))
+		timer.timeout.connect(_on_deferred_scan_timeout)
+		_deferred_scans_scheduled_total += 1
+
+
+func deferred_scans_scheduled_total() -> int:
+	return _deferred_scans_scheduled_total
+
+
+func _on_deferred_scan_timeout() -> void:
+	refresh_debugger_errors(true)
 
 
 func refresh_debugger_errors(force: bool = true) -> void:
@@ -192,6 +225,12 @@ func read_debugger_error_entries() -> Array[Dictionary]:
 func locate_debugger_error_trees() -> Array[Tree]:
 	var trees: Array[Tree] = []
 	var root: Node = _debugger_errors_root
+	## #641: a deferred-scan timer can outlive an injected root (tests,
+	## teardown). A freed root must not fall through to the live editor UI —
+	## that would promote unrelated real errors into a tracker scoped to the
+	## dead root — so treat it as "nothing to scan".
+	if root != null and not is_instance_valid(root):
+		return trees
 	if root == null:
 		root = _debugger_search_root()
 	if root == null:

--- a/plugin/addons/godot_ai/utils/surfaced_error_tracker.gd
+++ b/plugin/addons/godot_ai/utils/surfaced_error_tracker.gd
@@ -421,6 +421,20 @@ static func _function_from_frame_text(text: String) -> String:
 	return fn
 
 
+## Shared one-line rendering of a compact editor-error entry for messages and
+## hints ("text (path:line)"). Single home so the debugger plugin, project
+## handler, and editor handler can't drift apart.
+static func format_editor_error_summary(entry: Dictionary) -> String:
+	var text := str(entry.get("text", "editor error"))
+	var path := str(entry.get("path", ""))
+	var line := int(entry.get("line", 0))
+	if not path.is_empty() and line > 0:
+		return "%s (%s:%d)" % [text, path, line]
+	if not path.is_empty():
+		return "%s (%s)" % [text, path]
+	return text
+
+
 static func _log_entry_key(entry: Dictionary) -> String:
 	return "%s|%s|%s|%s" % [
 		str(entry.get("level", "")),

--- a/src/godot_ai/handlers/editor.py
+++ b/src/godot_ai/handlers/editor.py
@@ -228,7 +228,9 @@ async def logs_read(
                 flat.append(str(entry.get("text", "")))
             else:
                 flat.append(str(entry))
-        return paginate(flat, offset, count, key="lines")
+        response = paginate(flat, offset, count, key="lines")
+        _forward_error_watermark_stamp(result, response)
+        return response
 
     ## game / editor / all: ask the plugin to apply offset+count itself so the
     ## ring buffer's run_id, dropped_count, and is_running stay
@@ -247,7 +249,7 @@ async def logs_read(
         ## A new game run has started since the caller's last poll —
         ## tell them to reset their cursor instead of returning stale
         ## lines from the previous play session.
-        return {
+        stale_response = {
             "source": source,
             "lines": [],
             "total_count": 0,
@@ -260,6 +262,8 @@ async def logs_read(
             "dropped_count": result.get("dropped_count", 0),
             "stale_run_id": True,
         }
+        _forward_error_watermark_stamp(result, stale_response)
+        return stale_response
     lines = result.get("lines", [])
     total = int(result.get("total_count", len(lines)))
     response = {
@@ -290,7 +294,23 @@ async def logs_read(
     ):
         if key in result:
             response[key] = result[key]
+    _forward_error_watermark_stamp(result, response)
     return response
+
+
+def _forward_error_watermark_stamp(result: dict, response: dict) -> None:
+    """Carry the client-injected error-watermark hint through a rebuild.
+
+    ``GodotClient.send`` consumes ``Session.pending_new_errors`` into the raw
+    command result exactly once. A handler that rebuilds its response instead
+    of passing the result through must re-attach the stamp, or the one
+    delivery is silently destroyed — the #641 failure mode (an agent whose
+    first call after a broken launch is ``logs_read`` would never learn
+    errors happened).
+    """
+    for key in ("new_errors_since_last_call", "new_errors_hint"):
+        if key in result:
+            response[key] = result[key]
 
 
 async def editor_reload_plugin(runtime: DirectRuntime) -> dict:

--- a/src/godot_ai/handlers/editor.py
+++ b/src/godot_ai/handlers/editor.py
@@ -281,6 +281,12 @@ async def logs_read(
         "next_cursor",
         "appended_total",
         "truncated",
+        "current_run_id",
+        "helper_live",
+        "session_active",
+        "game_status",
+        "editor_errors_count",
+        "editor_errors_hint",
     ):
         if key in result:
             response[key] = result[key]

--- a/src/godot_ai/middleware/op_typo_hint.py
+++ b/src/godot_ai/middleware/op_typo_hint.py
@@ -19,6 +19,12 @@ candidate ops up in ``MANAGE_TOOL_OPS`` (the same registry that built the
 with a ``difflib.get_close_matches``-derived "Did you mean: ..." hint. The
 schema itself is unchanged, so tool-search-aware clients still see the
 full ``Literal`` enum.
+
+Two propagation shapes must be handled: through fastmcp 3.4.2, the raw
+``pydantic.ValidationError`` flows up through the middleware chain; from
+3.4.3 (fastmcp #4128), ``FunctionTool`` wraps it in fastmcp's own
+``ValidationError`` with the pydantic error as ``__cause__``. Both shapes
+are unwrapped to the same pydantic error before building the hint.
 """
 
 from __future__ import annotations
@@ -27,6 +33,7 @@ import difflib
 import logging
 
 from fastmcp.exceptions import ToolError
+from fastmcp.exceptions import ValidationError as FastMCPValidationError
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 from fastmcp.tools.base import ToolResult
 from mcp.types import CallToolRequestParams
@@ -45,11 +52,14 @@ class HintOpTypoOnManage(Middleware):
     ) -> ToolResult:
         try:
             return await call_next(context)
-        except ValidationError as exc:
+        except (ValidationError, FastMCPValidationError) as exc:
+            pydantic_exc = exc if isinstance(exc, ValidationError) else exc.__cause__
+            if not isinstance(pydantic_exc, ValidationError):
+                raise
             candidates = MANAGE_TOOL_OPS.get(context.message.name)
             if candidates is None:
                 raise
-            hint = _build_hint(exc, context.message.arguments, candidates)
+            hint = _build_hint(pydantic_exc, context.message.arguments, candidates)
             if hint is None:
                 raise
             logger.debug("Rewrote op typo error on %s: %s", context.message.name, hint)

--- a/src/godot_ai/tools/editor.py
+++ b/src/godot_ai/tools/editor.py
@@ -104,6 +104,12 @@ def register_editor_tools(mcp: FastMCP, *, include_non_core: bool = True) -> Non
           session_active, dropped_count, stale_run_id. helper_live and
           session_active mirror the same fields inside game_status; is_running
           is retained as a compatibility alias of session_active.
+          Boot-time parse/load errors fire before the game helper's logger
+          attaches, so they are NEVER in this buffer; when editor-side errors
+          were recorded during the current run the response adds
+          ``editor_errors_count`` and ``editor_errors_hint`` pointing at
+          source="editor" — treat a clean game log carrying that hint as a
+          run that lost scripts, not a clean launch.
         - "editor": editor-process script errors and the Debugger dock's
           visible Errors-tab rows — parse errors, GDScript reload warnings,
           @tool/EditorPlugin runtime errors, push_error/push_warning.

--- a/src/godot_ai/transport/websocket.py
+++ b/src/godot_ai/transport/websocket.py
@@ -331,11 +331,13 @@ def _sync_error_watermark_for_session(session: Session, value: dict[str, int]) -
     per-run game component is counted in full because the server may never
     observe its zero between stop/start. Editor and debugger components remain
     session-scoped monotonic deltas; a decrease is treated as a reset and the
-    current component value is counted when above zero.
+    current component value is counted when above zero. The debugger and game
+    components overlap (both observe the running game's script errors), so
+    their deltas are combined with max(), not summed.
     """
 
     updates: dict[str, int] = {}
-    new_total = 0
+    deltas: dict[str, int] = {}
     incoming_run_seq = _normalized_watermark_int(value.get("run_seq"))
     previous_run_seq = max(0, int(session.error_watermark.get("run_seq", 0)))
     run_advanced = (
@@ -355,13 +357,21 @@ def _sync_error_watermark_for_session(session: Session, value: dict[str, int]) -
         if previous is not None:
             previous_int = max(0, int(previous))
             if run_advanced and key == "game_error_warn":
-                new_total += current
+                deltas[key] = current
             elif current >= previous_int:
-                new_total += current - previous_int
+                deltas[key] = current - previous_int
             else:
-                new_total += current
+                deltas[key] = current
         elif run_advanced and key == "game_error_warn":
-            new_total += current
+            deltas[key] = current
+    ## A running game's script errors surface twice: in the game log buffer
+    ## (game_error_warn) and as Debugger Errors-tab rows (debugger_promoted).
+    ## Those are alternate views of the same error stream — summing them
+    ## reports 2 for every push_error once the #641 deferred scans promote
+    ## rows reliably. Take the larger of the two overlapping views; only
+    ## editor-process components accumulate independently.
+    overlap = max(deltas.pop("debugger_promoted", 0), deltas.pop("game_error_warn", 0))
+    new_total = overlap + sum(deltas.values())
     session.error_watermark.update(updates)
     session.pending_new_errors += new_total
     return new_total

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -2382,6 +2382,56 @@ func test_debugger_plugin_manual_run_stop_rearms_next_session() -> void:
 	assert_eq(tracker._debugger_scan_active, true)
 
 
+func test_debugger_plugin_mcp_run_self_quit_ends_run() -> void:
+	## #642 live smoke: an MCP-started game that exits on its own
+	## (get_tree().quit(), crash) emits only the debugger session's stopped
+	## signal — no stop op performs the bookkeeping, and game_status stayed
+	## "live" until the next run rewrote it.
+	var tracker := McpSurfacedErrorTracker.new()
+	var plugin := McpDebuggerPlugin.new(
+		McpLogBuffer.new(), McpGameLogBuffer.new(), McpEditorLogBuffer.new(), tracker)
+	plugin.begin_game_run(0, true)
+	plugin._setup_session(31)
+	plugin._capture("mcp:hello", [], 31)
+	assert_eq(plugin.get_game_status().active, true)
+
+	plugin._on_debugger_session_stopped(30)
+	assert_eq(plugin.get_game_status().active, true,
+		"foreign session stop must not end the MCP run")
+	plugin._on_debugger_session_stopped(31)
+	assert_eq(plugin.get_game_status().status, "stopped",
+		"self-quit must end MCP run bookkeeping")
+	assert_eq(tracker._debugger_scan_active, false)
+
+	## Pre-attach window: no game session yet, so a foreign session's stop
+	## must not cancel a launching MCP run.
+	plugin.begin_game_run(0, true)
+	assert_eq(plugin.get_game_status().active, true)
+	plugin._on_debugger_session_stopped(31)
+	assert_eq(plugin.get_game_status().active, true,
+		"stop signal before the game session attaches must be ignored for MCP runs")
+
+
+func test_debugger_plugin_note_editor_play_stopped_ends_run() -> void:
+	## Fallback for self-quit when the session stopped signal never fires:
+	## the connection's play-state poll reports the playing→stopped edge.
+	var plugin := McpDebuggerPlugin.new(
+		McpLogBuffer.new(), McpGameLogBuffer.new(), McpEditorLogBuffer.new(),
+		McpSurfacedErrorTracker.new())
+	plugin.begin_game_run(0, true)
+	plugin._setup_session(51)
+	plugin._capture("mcp:hello", [], 51)
+	assert_eq(plugin.get_game_status().status, "live")
+
+	plugin.note_editor_play_stopped()
+	assert_eq(plugin.get_game_status().status, "stopped",
+		"play-state edge must end run bookkeeping for self-quit games")
+
+	plugin.note_editor_play_stopped()
+	assert_eq(plugin.get_game_status().status, "stopped",
+		"repeat edge with no active run is a no-op")
+
+
 func test_debugger_plugin_log_batch_no_buffer_is_safe() -> void:
 	## Plugin started without a game buffer should silently no-op on
 	## log batches rather than crash — defensive for partial init.

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -1104,6 +1104,32 @@ func test_get_logs_source_game_no_editor_errors_hint_without_tracked_run() -> vo
 	empty_tree.free()
 
 
+func test_get_logs_source_game_no_editor_errors_hint_for_stale_run_reads() -> void:
+	## A since_run_id read of a PRIOR run must not carry the current run's
+	## editor errors — the hint interprets the run being read.
+	var game_buf := McpGameLogBuffer.new()
+	var previous_id := game_buf.clear_for_new_run()
+	game_buf.append("info", "previous run line")
+	var editor_buf := McpEditorLogBuffer.new()
+	var empty_tree := Tree.new()
+	empty_tree.create_item()
+	var tracker := McpSurfacedErrorTracker.new(editor_buf, game_buf, empty_tree)
+	var plugin := McpDebuggerPlugin.new(null, game_buf, editor_buf, tracker)
+	plugin.begin_game_run(editor_buf.appended_total(), true)
+	editor_buf.append("error", "Parse Error: Expected expression", "res://broken.gd", 4, "GDScript::reload")
+	plugin._capture("mcp:hello", [], -1)
+	var handler := EditorHandler.new(McpLogBuffer.new(), null, plugin, game_buf, editor_buf, null, tracker)
+
+	var current := handler.get_logs({"source": "game", "count": 10})
+	var previous := handler.get_logs({"source": "game", "since_run_id": previous_id, "count": 10})
+
+	assert_eq(current.data.editor_errors_count, 1, "current-run read keeps the hint")
+	assert_true(previous.data.stale_run_id)
+	assert_false(previous.data.has("editor_errors_hint"), "prior-run read must not carry the current run's errors")
+	assert_false(previous.data.has("editor_errors_count"))
+	empty_tree.free()
+
+
 func test_get_logs_source_game_no_editor_errors_hint_for_pre_run_errors() -> void:
 	var game_buf := McpGameLogBuffer.new()
 	var editor_buf := McpEditorLogBuffer.new()

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -1063,6 +1063,65 @@ func test_get_logs_source_game_live_run_counts_as_running() -> void:
 	assert_eq(result.data.lines[0].run_id, current_id)
 
 
+func test_get_logs_source_game_cross_references_run_scoped_editor_errors() -> void:
+	## #641: boot parse errors fire before the game helper's logger attaches,
+	## so they can never be in the game buffer. A game-scope read must point
+	## at the editor scope instead of presenting a clean-looking log.
+	var game_buf := McpGameLogBuffer.new()
+	var editor_buf := McpEditorLogBuffer.new()
+	var empty_tree := Tree.new()
+	empty_tree.create_item()
+	var tracker := McpSurfacedErrorTracker.new(editor_buf, game_buf, empty_tree)
+	var plugin := McpDebuggerPlugin.new(null, game_buf, editor_buf, tracker)
+	plugin.begin_game_run(editor_buf.appended_total(), true)
+	editor_buf.append("error", "Parse Error: Expected expression", "res://broken.gd", 4, "GDScript::reload")
+	plugin._capture("mcp:hello", [], -1)
+	var handler := EditorHandler.new(McpLogBuffer.new(), null, plugin, game_buf, editor_buf, null, tracker)
+
+	var result := handler.get_logs({"source": "game", "count": 10})
+
+	assert_eq(result.data.lines.size(), 0, "the boot error must NOT be in the game buffer")
+	assert_eq(result.data.editor_errors_count, 1)
+	assert_contains(result.data.editor_errors_hint, "res://broken.gd:4")
+	assert_contains(result.data.editor_errors_hint, "logs_read(source='editor'")
+	empty_tree.free()
+
+
+func test_get_logs_source_game_no_editor_errors_hint_without_tracked_run() -> void:
+	var game_buf := McpGameLogBuffer.new()
+	var editor_buf := McpEditorLogBuffer.new()
+	editor_buf.append("error", "Parse Error: Old", "res://old.gd", 2, "")
+	var empty_tree := Tree.new()
+	empty_tree.create_item()
+	var tracker := McpSurfacedErrorTracker.new(editor_buf, game_buf, empty_tree)
+	var plugin := McpDebuggerPlugin.new(null, game_buf, editor_buf, tracker)
+	var handler := EditorHandler.new(McpLogBuffer.new(), null, plugin, game_buf, editor_buf, null, tracker)
+
+	var result := handler.get_logs({"source": "game", "count": 10})
+
+	assert_false(result.data.has("editor_errors_hint"), "no run ever started — retained errors must not be attributed to a run")
+	assert_false(result.data.has("editor_errors_count"))
+	empty_tree.free()
+
+
+func test_get_logs_source_game_no_editor_errors_hint_for_pre_run_errors() -> void:
+	var game_buf := McpGameLogBuffer.new()
+	var editor_buf := McpEditorLogBuffer.new()
+	editor_buf.append("error", "Parse Error: Old", "res://old.gd", 2, "")
+	var empty_tree := Tree.new()
+	empty_tree.create_item()
+	var tracker := McpSurfacedErrorTracker.new(editor_buf, game_buf, empty_tree)
+	var plugin := McpDebuggerPlugin.new(null, game_buf, editor_buf, tracker)
+	plugin.begin_game_run(editor_buf.appended_total(), true)
+	plugin._capture("mcp:hello", [], -1)
+	var handler := EditorHandler.new(McpLogBuffer.new(), null, plugin, game_buf, editor_buf, null, tracker)
+
+	var result := handler.get_logs({"source": "game", "count": 10})
+
+	assert_false(result.data.has("editor_errors_hint"), "errors from before the run must not be pinned on this run")
+	empty_tree.free()
+
+
 func test_get_logs_include_details_returns_buffered_metadata() -> void:
 	var game_buf := McpGameLogBuffer.new()
 	game_buf.append("error", "game boom", {
@@ -1510,6 +1569,61 @@ func test_surfaced_error_tracker_caps_promoted_debugger_entries() -> void:
 		tracker.watermark(true).debugger_promoted,
 		McpSurfacedErrorTracker.MAX_PROMOTED_DEBUGGER_ENTRIES + 6,
 		"Trimmed but still-visible debugger rows must not be promoted again",
+	)
+	tree.free()
+
+
+func test_surfaced_error_tracker_deferred_scan_promotes_with_gate_closed() -> void:
+	## #641: a fresh tracker's scan gate is closed (no active run, stop window
+	## expired), so gated watermark stamps must not promote — but the
+	## timer-driven forced scan must, so the next stamped response carries the
+	## count without any tool call having landed inside the gate window.
+	var tree := _make_debugger_errors_tree()
+	var tracker := McpSurfacedErrorTracker.new(null, null, tree)
+	assert_eq(tracker.watermark().debugger_promoted, 0, "gated stamp must stay a cheap cached read")
+	tracker._on_deferred_scan_timeout()
+	assert_eq(tracker.watermark().debugger_promoted, 1, "deferred scan must promote visible rows past the gate")
+	tree.free()
+
+
+func test_surfaced_error_tracker_run_stop_schedules_deferred_scans() -> void:
+	var tree := _make_debugger_errors_tree()
+	var tracker := McpSurfacedErrorTracker.new(null, null, tree)
+	assert_eq(tracker.deferred_scans_scheduled_total(), 0)
+	tracker.note_game_run_stopped()
+	assert_eq(
+		tracker.deferred_scans_scheduled_total(),
+		McpSurfacedErrorTracker.DEFERRED_SCAN_DELAYS_SEC.size(),
+		"run stop must arm one forced scan per configured delay",
+	)
+	tree.free()
+
+
+func test_surfaced_error_tracker_deferred_scan_survives_freed_root() -> void:
+	## Deferred-scan timers can outlive an injected debugger root. A freed
+	## root must scan as "nothing visible" — not crash, and not fall through
+	## to the live editor UI.
+	var tree := _make_debugger_errors_tree()
+	var tracker := McpSurfacedErrorTracker.new(null, null, tree)
+	assert_eq(tracker.watermark(true).debugger_promoted, 1)
+	tree.free()
+	tracker._on_deferred_scan_timeout()
+	assert_eq(tracker.watermark().debugger_promoted, 1, "freed root must not change promoted counts")
+	assert_eq(tracker.read_debugger_error_entries().size(), 0)
+
+
+func test_debugger_plugin_hello_schedules_deferred_scans() -> void:
+	var game_buf := McpGameLogBuffer.new()
+	var tree := _make_debugger_errors_tree()
+	var tracker := McpSurfacedErrorTracker.new(null, game_buf, tree)
+	var plugin := McpDebuggerPlugin.new(null, game_buf, null, tracker)
+	plugin.begin_game_run(0, true)
+	var scheduled_before := tracker.deferred_scans_scheduled_total()
+	plugin._capture("mcp:hello", [], -1)
+	assert_eq(
+		tracker.deferred_scans_scheduled_total() - scheduled_before,
+		McpSurfacedErrorTracker.DEFERRED_SCAN_DELAYS_SEC.size(),
+		"hello must arm forced scans for boot errors racing the beacon",
 	)
 	tree.free()
 

--- a/test_project/tests/test_project.gd
+++ b/test_project/tests/test_project.gd
@@ -226,6 +226,47 @@ func test_run_project_liveness_decision_live_short_circuits() -> void:
 	assert_contains(decision.message, "live")
 
 
+func test_run_project_liveness_decision_live_reports_run_scoped_boot_errors() -> void:
+	## #641: "live" only means the helper registered — a broken node script
+	## still parse-fails during boot without stopping the game. The success
+	## message must surface those errors, not read as a clean launch.
+	var err := {"text": "Parse Error: Expected expression", "path": "res://broken.gd", "line": 4}
+	var decision := _handler._run_project_liveness_decision(
+		_run_status("live", 100),
+		_errors_info([err], "run")
+	)
+	assert_eq(decision.resolve, true)
+	assert_eq(decision.liveness_status, "live")
+	assert_contains(decision.message, "live")
+	assert_contains(decision.message, "res://broken.gd:4")
+	assert_contains(decision.message, "logs_read(source='editor'")
+	assert_eq(decision.recent_errors.size(), 1)
+	assert_eq(decision.recent_errors_scope, "run")
+
+
+func test_run_project_liveness_decision_live_ignores_retained_errors_in_message() -> void:
+	var err := {"text": "Parse Error: Old", "path": "res://old.gd", "line": 2}
+	var decision := _handler._run_project_liveness_decision(
+		_run_status("live", 100),
+		_errors_info([err], "retained_recent")
+	)
+	assert_eq(decision.resolve, true)
+	assert_eq(decision.liveness_status, "live")
+	assert_false(decision.message.contains("res://old.gd"), "errors that may predate the run must not taint the live message")
+
+
+func test_run_project_already_running_live_message_reports_run_scoped_errors() -> void:
+	var err := {"text": "Parse Error: Expected expression", "path": "res://broken.gd", "line": 4}
+	var decision := _handler._run_project_liveness_decision(
+		_run_status("live", 100),
+		_errors_info([err], "run")
+	)
+	var message := _handler._run_project_already_running_message(decision)
+	assert_contains(message, "already running")
+	assert_contains(message, "res://broken.gd:4")
+	assert_contains(message, "logs_read(source='editor'")
+
+
 func test_run_project_liveness_decision_run_scoped_error_short_circuits() -> void:
 	var err := {"text": "Parse Error: Expected expression", "path": "res://broken.gd", "line": 4}
 	var decision := _handler._run_project_liveness_decision(

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -208,6 +208,62 @@ class TestCommandRoundTrip:
         assert harness.registry.get("err-watermark").error_watermark["debugger_promoted"] == 2
         await plugin.close()
 
+    async def test_error_watermark_overlapping_game_and_debugger_count_once(self, harness):
+        ## A push_error in a helper-live run lands in the game log buffer AND
+        ## as a Debugger Errors-tab row. Both components advance by 1; the
+        ## agent must be told about 1 new error, not 2 (#642 live smoke).
+        plugin = await harness.connect_plugin(session_id="err-overlap")
+        client = GodotClient(harness.server, harness.registry)
+
+        async def mock_handler():
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 1},
+                error_watermark={
+                    "run_seq": 1,
+                    "editor_ring": 0,
+                    "debugger_promoted": 0,
+                    "game_error_warn": 0,
+                },
+            )
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 2},
+                error_watermark={
+                    "run_seq": 1,
+                    "editor_ring": 0,
+                    "debugger_promoted": 1,
+                    "game_error_warn": 1,
+                },
+            )
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 3},
+                error_watermark={
+                    "run_seq": 1,
+                    "editor_ring": 2,
+                    "debugger_promoted": 2,
+                    "game_error_warn": 1,
+                },
+            )
+
+        handler_task = asyncio.create_task(mock_handler())
+        first = await client.send("get_editor_state")
+        second = await client.send("get_editor_state")
+        third = await client.send("get_editor_state")
+        await handler_task
+
+        assert "new_errors_since_last_call" not in first
+        ## One physical error seen through two overlapping views.
+        assert second["new_errors_since_last_call"] == 1
+        ## Editor-process errors are an independent stream: 2 editor + 1
+        ## debugger-only advance = 3.
+        assert third["new_errors_since_last_call"] == 3
+        await plugin.close()
+
     async def test_error_watermark_component_reset_counts_current_value(self, harness):
         plugin = await harness.connect_plugin(session_id="err-reset")
         client = GodotClient(harness.server, harness.registry)

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -264,6 +264,37 @@ class TestCommandRoundTrip:
         assert third["new_errors_since_last_call"] == 3
         await plugin.close()
 
+    async def test_error_watermark_first_game_component_on_new_run_counts_full(self, harness):
+        ## A watermark that never carried game_error_warn (older plugin, or a
+        ## session that never ran a game) reports it for the first time on an
+        ## ADVANCED run: the per-run component has no baseline to diff
+        ## against, so it counts in full rather than baselining silently.
+        plugin = await harness.connect_plugin(session_id="err-first-game")
+        client = GodotClient(harness.server, harness.registry)
+
+        async def mock_handler():
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 1},
+                error_watermark={"run_seq": 1, "editor_ring": 0},
+            )
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 2},
+                error_watermark={"run_seq": 2, "editor_ring": 0, "game_error_warn": 2},
+            )
+
+        handler_task = asyncio.create_task(mock_handler())
+        first = await client.send("get_editor_state")
+        second = await client.send("get_editor_state")
+        await handler_task
+
+        assert "new_errors_since_last_call" not in first
+        assert second["new_errors_since_last_call"] == 2
+        await plugin.close()
+
     async def test_error_watermark_component_reset_counts_current_value(self, harness):
         plugin = await harness.connect_plugin(session_id="err-reset")
         client = GodotClient(harness.server, harness.registry)

--- a/tests/unit/test_middleware_op_typo_hint.py
+++ b/tests/unit/test_middleware_op_typo_hint.py
@@ -7,6 +7,7 @@ from typing import Literal
 
 import pytest
 from fastmcp.exceptions import ToolError
+from fastmcp.exceptions import ValidationError as FastMCPValidationError
 from mcp.types import CallToolRequestParams
 from pydantic import TypeAdapter, ValidationError
 
@@ -118,6 +119,43 @@ class TestHintOpTypoOnManage:
         )
         with pytest.raises(ValidationError):
             await mw.on_call_tool(ctx, await _raise_call_next(exc))
+
+    async def test_rewrites_op_typo_wrapped_in_fastmcp_validation_error(self, register_node_manage):
+        ## fastmcp 3.4.3 (fastmcp #4128) stopped propagating pydantic's
+        ## ValidationError raw: FunctionTool re-raises it as fastmcp's own
+        ## ValidationError with the pydantic error as __cause__. The hint
+        ## must survive that wrapping regardless of installed fastmcp.
+        mw = HintOpTypoOnManage()
+        pydantic_exc = _make_op_validation_error("get_childen", register_node_manage)
+        wrapped = FastMCPValidationError(str(pydantic_exc))
+        wrapped.__cause__ = pydantic_exc
+        ctx = _FakeContext(
+            message=CallToolRequestParams(
+                name="node_manage",
+                arguments={"op": "get_childen", "params": {"path": "/Main"}},
+            )
+        )
+        with pytest.raises(ToolError) as info:
+            await mw.on_call_tool(ctx, await _raise_call_next(wrapped))
+
+        msg = str(info.value)
+        assert "'get_childen'" in msg
+        assert "did you mean" in msg.lower()
+        assert "'get_children'" in msg
+
+    async def test_passes_through_fastmcp_validation_error_without_pydantic_cause(
+        self, register_node_manage
+    ):
+        ## A fastmcp ValidationError that does NOT wrap a pydantic error
+        ## (e.g. output-schema validation) carries nothing the hint builder
+        ## can inspect — re-raise it untouched.
+        mw = HintOpTypoOnManage()
+        bare = FastMCPValidationError("output failed validation")
+        ctx = _FakeContext(
+            message=CallToolRequestParams(name="node_manage", arguments={"op": "delete"})
+        )
+        with pytest.raises(FastMCPValidationError, match="output failed validation"):
+            await mw.on_call_tool(ctx, await _raise_call_next(bare))
 
     async def test_passes_through_non_op_validation_errors(self, register_node_manage):
         ## A literal_error on a different field (e.g. a typed param value)

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -1392,6 +1392,54 @@ async def test_logs_read_handler_since_run_id_stale_returns_empty():
     assert result["run_id"] == "rstub"
 
 
+class StampingClient(StubClient):
+    """Simulates GodotClient.send merging the consumed error-watermark
+    stamp into the raw command result (client.py does this exactly once
+    per pending batch)."""
+
+    async def send(
+        self,
+        command: str,
+        params: dict | None = None,
+        session_id: str | None = None,
+        timeout: float = 5.0,
+        surface_error_hints: bool = True,
+    ) -> dict:
+        result = await super().send(command, params, session_id, timeout, surface_error_hints)
+        if command == "get_logs":
+            result = dict(result)
+            result["new_errors_since_last_call"] = 3
+            result["new_errors_hint"] = (
+                "3 new GDScript errors since your last call. Inspect with "
+                "logs_read(source='editor', include_details=true) and/or "
+                "logs_read(source='game', include_details=true)."
+            )
+        return result
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expect_stale"),
+    [
+        ({"source": "plugin"}, False),
+        ({"source": "game"}, False),
+        ({"source": "editor"}, False),
+        ({"source": "game", "since_run_id": "r-old"}, True),
+    ],
+)
+async def test_logs_read_handler_preserves_error_watermark_stamp(kwargs, expect_stale):
+    ## The client consumes Session.pending_new_errors into the raw result
+    ## exactly once; every logs_read rebuild branch must re-attach it or the
+    ## single delivery is destroyed (#641 silent-drop class — an agent whose
+    ## first call after a broken launch is logs_read would never see it).
+    runtime = DirectRuntime(registry=SessionRegistry(), client=StampingClient())
+
+    result = await editor_handlers.logs_read(runtime, **kwargs)
+
+    assert result["new_errors_since_last_call"] == 3
+    assert "logs_read(source='editor'" in result["new_errors_hint"]
+    assert result.get("stale_run_id", False) is expect_stale
+
+
 async def test_logs_read_handler_game_forwards_editor_error_hint_fields():
     class HintingClient(StubClient):
         async def send(

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -1392,6 +1392,50 @@ async def test_logs_read_handler_since_run_id_stale_returns_empty():
     assert result["run_id"] == "rstub"
 
 
+async def test_logs_read_handler_game_forwards_editor_error_hint_fields():
+    class HintingClient(StubClient):
+        async def send(
+            self,
+            command: str,
+            params: dict | None = None,
+            session_id: str | None = None,
+            timeout: float = 5.0,
+            surface_error_hints: bool = True,
+        ) -> dict:
+            result = await super().send(
+                command, params, session_id, timeout, surface_error_hints
+            )
+            if command == "get_logs" and (params or {}).get("source") == "game":
+                result = dict(result)
+                result["current_run_id"] = "rstub"
+                result["helper_live"] = True
+                result["session_active"] = True
+                result["game_status"] = {"status": "live", "run_token": 3}
+                result["editor_errors_count"] = 2
+                result["editor_errors_hint"] = (
+                    "2 editor-side errors from this run (first: Parse Error: "
+                    "Expected parameter name. (res://boom.gd:3)) missing from "
+                    "the game log — boot-time parse/load errors occur before "
+                    "the game helper's logger attaches. Read "
+                    "logs_read(source='editor', include_details=true)."
+                )
+            return result
+
+    runtime = DirectRuntime(registry=SessionRegistry(), client=HintingClient())
+
+    result = await editor_handlers.logs_read(runtime, source="game")
+
+    ## #641/#642: the plugin's cross-scope hint (and liveness context) must
+    ## survive the python response reshaping — a clean game log carrying the
+    ## hint is the only signal that boot-time scripts failed to parse.
+    assert result["editor_errors_count"] == 2
+    assert "res://boom.gd" in result["editor_errors_hint"]
+    assert result["current_run_id"] == "rstub"
+    assert result["helper_live"] is True
+    assert result["session_active"] is True
+    assert result["game_status"]["status"] == "live"
+
+
 async def test_logs_read_handler_source_all_returns_structured():
     runtime = DirectRuntime(registry=SessionRegistry(), client=StubClient())
 


### PR DESCRIPTION
Fixes #641.

## Problem

Boot-time parse errors fire while autoload scripts compile — **before** the game helper's logger attaches via `OS.add_logger` — so they can never appear in `logs_read(source='game')`. Their Debugger Errors-tab rows *were* scraped by `McpSurfacedErrorTracker`, but promotion into the error watermark only happened when a tool call landed while the scan gate was open (run active, or within 5s of stop). Agent turnaround is routinely longer than that window, so an agent could launch a project, read a clean game log, get no `new_errors_since_last_call` hint, and conclude the launch was clean while scripts had silently failed to parse or load.

## Changes

**Timer-driven Errors-tab scans** (`surfaced_error_tracker.gd`, `mcp_debugger_plugin.gd`)
- `note_game_run_stopped()` and the game helper's `mcp:hello` beacon now arm editor-side `SceneTreeTimer`s that force a scan at +1s/+5s, decoupling promotion from tool-call cadence. The next stamped response carries the already-promoted count even after the gate closes.
- A freed injected debugger root (tests, teardown) is treated as "nothing to scan" instead of falling through to the live editor UI — a late timer can neither crash nor promote unrelated real errors.

**Boot errors reported on the successful launch path** (`project_handler.gd`)
- A "live" run with run-scoped errors now says so in its message ("…but N editor errors surfaced during startup (first: …)") instead of reading as a clean launch — a registered helper does not mean every script parsed. The already-running live message does the same.
- When the liveness decision resolves, errors are re-gathered once with a forced scan, closing the race where rows land in the Errors tab the same frames the run goes live. The per-frame polling loop keeps the cheap gated scans.

**Cross-scope hint on game logs** (`editor_handler.gd`)
- `logs_read(source='game')` now adds `editor_errors_count` / `editor_errors_hint` when run-scoped editor errors exist, pointing at `logs_read(source='editor', include_details=true)` — closing the trap where a clean game log masquerades as a clean launch. Guarded so retained pre-run errors, sessions with no tracked run, and `since_run_id` reads of prior runs never get misattributed.

**Plumbing**: `recent_editor_errors_since()` gains an optional `force_debugger_scan` flag for one-shot reads; the triplicated error-summary formatter is consolidated into `McpSurfacedErrorTracker.format_editor_error_summary`; docstrings in `src/godot_ai/tools/editor.py` and `docs/TOOLS.md` document the new fields.

**CI unblock (deliberately included): fastmcp 3.4.3 compatibility** (`middleware/op_typo_hint.py`)
- fastmcp 3.4.3 shipped upstream (inside the repo's `<3.5.0` pin) mid-PR and changed argument-validation propagation (fastmcp #4128): pydantic's `ValidationError` is now wrapped in fastmcp's own `ValidationError` with the pydantic error as `__cause__`, which silenced the `HintOpTypoOnManage` "did you mean" hint and failed `test_op_typo_surfaces_did_you_mean_message` on every CI run — on this branch and on main alike, since CI resolves the latest allowed fastmcp. The middleware now handles both shapes (verified against 3.4.2 and 3.4.3). Kept in this PR because no PR can go green without it.

## Testing

- 11 new GDScript tests (`test_editor.gd`, `test_project.gd`) covering: gated stamp stays cheap while the deferred scan promotes, run-stop/hello arm the timers, freed-root safety, live-decision messages with run-scoped vs retained errors, the already-running live message, and the game-log hint (positive + three negative attribution guards including stale `since_run_id` reads).
- Full suite via headless editor: **1601/1619 passed, 0 failed** (rest are environment-gated skips); reload smoke (10 reloads + post-churn suite) and quit smoke pass.
- Python: full suite (1243 passed) under fastmcp 3.4.3 and the op-typo tests re-verified under 3.4.2; `ruff` clean; `ci-check-gdscript` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01So5f4h5nyGKVfkumTceVC6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved boot-time error reporting, including run-correlated editor script-loss hints and counts in game log reads.
  * Enhanced run tracking so a run ends correctly when play stops without a debugger stop signal.
  * Upgraded project live/already-running messaging to reference relevant recent script-parse/load errors.
* **Bug Fixes**
  * Fixed delayed error surfacing by promoting debugger/error-tab entries via deferred scans.
  * Corrected overlapping error-watermark counting so combined sources advance once (no double-counting).
  * Improved operation typo hints for wrapped validation errors.
* **Tests**
  * Added coverage for log routing, deferred scanning behavior, live-status messaging, and overlapping watermark counts.  
* **Documentation**
  * Updated tool documentation to reflect boot-time parse/load error behavior and hint semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->