### PR TITLE
logs_read: forward since_run_id so retained prior-run game logs are reachable

### DIFF
--- a/src/godot_ai/handlers/editor.py
+++ b/src/godot_ai/handlers/editor.py
@@ -234,6 +234,11 @@ async def logs_read(
     ## ring buffer's run_id, dropped_count, and is_running stay
     ## authoritative on the editor side.
     params = {"count": count, "offset": offset, "source": source}
+    if source == "game" and since_run_id:
+        ## The plugin resolves since_run_id against its retained ring
+        ## (get_run_page), returning the prior run's lines with
+        ## stale_run_id=true when the id is no longer current.
+        params["since_run_id"] = since_run_id
     if source == "editor" and since_cursor is not None:
         params["since_cursor"] = since_cursor
     if include_details:
@@ -244,9 +249,10 @@ async def logs_read(
     )
     run_id = result.get("run_id", "")
     if since_run_id and run_id and run_id != since_run_id:
-        ## A new game run has started since the caller's last poll —
-        ## tell them to reset their cursor instead of returning stale
-        ## lines from the previous play session.
+        ## The plugin echoes the requested run id back as `run_id` when it
+        ## honors since_run_id, so a mismatch means an older plugin ignored
+        ## the param and served the current run. Return the empty stale
+        ## shape rather than mislabeling current-run lines as the old run.
         return {
             "source": source,
             "lines": [],
@@ -273,9 +279,10 @@ async def logs_read(
         "run_id": run_id,
         "is_running": result.get("is_running", False),
         "dropped_count": result.get("dropped_count", 0),
-        "stale_run_id": False,
+        "stale_run_id": bool(result.get("stale_run_id", False)),
     }
     for key in (
+        "current_run_id",
         "cursor",
         "oldest_cursor",
         "next_cursor",

--- a/src/godot_ai/handlers/editor.py
+++ b/src/godot_ai/handlers/editor.py
@@ -253,7 +253,7 @@ async def logs_read(
         ## honors since_run_id, so a mismatch means an older plugin ignored
         ## the param and served the current run. Return the empty stale
         ## shape rather than mislabeling current-run lines as the old run.
-        return {
+        stale = {
             "source": source,
             "lines": [],
             "total_count": 0,
@@ -266,6 +266,9 @@ async def logs_read(
             "dropped_count": result.get("dropped_count", 0),
             "stale_run_id": True,
         }
+        if "current_run_id" in result:
+            stale["current_run_id"] = result["current_run_id"]
+        return stale
     lines = result.get("lines", [])
     total = int(result.get("total_count", len(lines)))
     response = {

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -462,6 +462,45 @@ class TestLogsReadTool:
         assert data["lines"] == []
         assert data["run_id"] == "rNEW"
 
+    async def test_since_run_id_forwarded_and_retained_run_returned(self, mcp_stack):
+        client, plugin = mcp_stack
+        retained = [
+            {"source": "game", "level": "info", "text": "old run line", "run_id": "rOLD"},
+        ]
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "get_logs"
+            ## The whole prior-run feature hinges on this param reaching
+            ## the plugin — it used to be dropped here (see #642 smoke).
+            assert cmd["params"]["since_run_id"] == "rOLD"
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "source": "game",
+                    "lines": retained,
+                    "total_count": 1,
+                    "returned_count": 1,
+                    "offset": 0,
+                    "run_id": "rOLD",
+                    "current_run_id": "rNEW",
+                    "is_running": False,
+                    "dropped_count": 0,
+                    "stale_run_id": True,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool("logs_read", {"source": "game", "since_run_id": "rOLD"})
+        await task
+
+        data = result.data
+        assert data["lines"] == retained
+        assert data["total_count"] == 1
+        assert data["run_id"] == "rOLD"
+        assert data["current_run_id"] == "rNEW"
+        assert data["stale_run_id"] is True
+
     async def test_source_editor_returns_structured_script_errors(self, mcp_stack):
         client, plugin = mcp_stack
         entries = [

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -1458,6 +1458,29 @@ async def test_logs_read_handler_since_run_id_old_plugin_falls_back_to_stale_sha
     assert result["stale_run_id"] is True
     assert result["lines"] == []
     assert result["run_id"] == "rstub"
+    assert "current_run_id" not in result
+
+
+async def test_logs_read_handler_stale_fallback_preserves_current_run_id():
+    ## If a plugin ever reports current_run_id while still mismatching the
+    ## requested run, the stale shape must carry it so callers can resync.
+    class MismatchingClient(StubClient):
+        async def send(self, command, params=None, **kwargs):
+            result = await super().send(command, params, **kwargs)
+            if command == "get_logs" and (params or {}).get("source") == "game":
+                result = dict(result)
+                result["run_id"] = "rNEW"
+                result["current_run_id"] = "rNEW"
+            return result
+
+    runtime = DirectRuntime(registry=SessionRegistry(), client=MismatchingClient())
+
+    result = await editor_handlers.logs_read(runtime, source="game", since_run_id="r-old")
+
+    assert result["stale_run_id"] is True
+    assert result["lines"] == []
+    assert result["run_id"] == "rNEW"
+    assert result["current_run_id"] == "rNEW"
 
 
 async def test_logs_read_handler_source_all_returns_structured():

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -49,6 +49,9 @@ class StubClient:
         ## the cached value (otherwise the probe heals the cache and the
         ## write incorrectly slips through).
         self.live_readiness: str = "ready"
+        ## Plugins before get_run_page ignore since_run_id and serve the
+        ## current run; tests flip this to exercise that fallback.
+        self.game_supports_since_run_id: bool = True
 
     async def send(
         self,
@@ -76,8 +79,21 @@ class StubClient:
             if source == "game":
                 req_offset = int(params_dict.get("offset", 0))
                 req_count = int(params_dict.get("count", 50))
+                ## Mirror the plugin's get_run_page: the ring retains
+                ## prior-run lines keyed by run_id, and the requested run
+                ## is echoed back as `run_id` (unknown ids page empty).
+                current_run_id = "rstub"
+                retained_runs = {
+                    "rstub": [f"game {i}" for i in range(5)],
+                    "rprev": ["prev 0", "prev 1"],
+                }
+                since_run_id = str(params_dict.get("since_run_id") or "")
+                if not self.game_supports_since_run_id:
+                    since_run_id = ""
+                target_run_id = since_run_id or current_run_id
                 all_entries = [
-                    {"source": "game", "level": "info", "text": f"game {i}"} for i in range(5)
+                    {"source": "game", "level": "info", "text": text}
+                    for text in retained_runs.get(target_run_id, [])
                 ]
                 if include_details:
                     for entry in all_entries:
@@ -91,16 +107,23 @@ class StubClient:
                             "frames": [],
                         }
                 page = all_entries[req_offset : req_offset + req_count]
-                return {
+                response = {
                     "source": "game",
                     "lines": page,
                     "total_count": len(all_entries),
                     "returned_count": len(page),
                     "offset": req_offset,
-                    "run_id": "rstub",
+                    "run_id": target_run_id,
+                    "current_run_id": current_run_id,
                     "is_running": True,
                     "dropped_count": 0,
+                    "stale_run_id": bool(since_run_id) and since_run_id != current_run_id,
                 }
+                if not self.game_supports_since_run_id:
+                    ## Old plugins predate these keys entirely.
+                    del response["current_run_id"]
+                    del response["stale_run_id"]
+                return response
             if source == "editor":
                 req_offset = int(params_dict.get("offset", 0))
                 req_count = int(params_dict.get("count", 50))
@@ -1382,8 +1405,53 @@ async def test_logs_read_handler_source_game_passes_through():
     assert result["stale_run_id"] is False
 
 
-async def test_logs_read_handler_since_run_id_stale_returns_empty():
+async def test_logs_read_handler_since_run_id_returns_retained_run():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+
+    result = await editor_handlers.logs_read(runtime, source="game", since_run_id="rprev")
+
+    ## The param must reach the plugin — dropping it here is what made
+    ## retained prior-run reads unreachable through MCP.
+    assert client.calls[-1]["params"]["since_run_id"] == "rprev"
+    assert [entry["text"] for entry in result["lines"]] == ["prev 0", "prev 1"]
+    assert result["total_count"] == 2
+    assert result["run_id"] == "rprev"
+    assert result["current_run_id"] == "rstub"
+    assert result["stale_run_id"] is True
+
+
+async def test_logs_read_handler_since_run_id_matching_current_run_not_stale():
     runtime = DirectRuntime(registry=SessionRegistry(), client=StubClient())
+
+    result = await editor_handlers.logs_read(runtime, source="game", since_run_id="rstub")
+
+    assert result["stale_run_id"] is False
+    assert result["run_id"] == "rstub"
+    assert result["total_count"] == 5
+
+
+async def test_logs_read_handler_since_run_id_unknown_run_returns_empty_stale():
+    runtime = DirectRuntime(registry=SessionRegistry(), client=StubClient())
+
+    result = await editor_handlers.logs_read(runtime, source="game", since_run_id="r-evicted")
+
+    assert result["stale_run_id"] is True
+    assert result["lines"] == []
+    assert result["total_count"] == 0
+    ## The plugin echoes the requested id; the caller learns the current
+    ## run from current_run_id.
+    assert result["run_id"] == "r-evicted"
+    assert result["current_run_id"] == "rstub"
+
+
+async def test_logs_read_handler_since_run_id_old_plugin_falls_back_to_stale_shape():
+    ## Plugins that predate get_run_page ignore since_run_id and serve the
+    ## current run under the current run_id. The handler must not mislabel
+    ## those lines as the requested run.
+    client = StubClient()
+    client.game_supports_since_run_id = False
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
 
     result = await editor_handlers.logs_read(runtime, source="game", since_run_id="r-old")
 


### PR DESCRIPTION
## Problem

`logs_read` in `src/godot_ai/handlers/editor.py` built the `get_logs` params as `{count, offset, source}` and never forwarded `since_run_id`. The plugin side has supported it since ~#572 (`_get_game_logs` → `get_run_page(target_run_id, ...)`), and the tool docstring promises "pass `since_run_id` from an earlier response to read that prior run" — but because the param was dropped, the plugin always served the current run, the python `run_id != since_run_id` guard always fired, and every prior-run read came back as the empty `stale_run_id=true` shape. Retained prior-run reads were unreachable through MCP.

Found during live smoke of #642; pre-existing on `main`.

## Fix

- Forward `since_run_id` in the `get_logs` params for `source="game"`.
- Propagate the plugin's `stale_run_id` instead of hardcoding `false` — a retained-run read now returns the lines **with** `stale_run_id=true`, as documented.
- Pass `current_run_id` through (already promised by the tool docstring).
- Keep the `run_id != since_run_id` guard, repurposed: the new plugin echoes the requested id back as `run_id`, so a mismatch now only means an older plugin ignored the param and served the current run — the guard prevents those lines from being mislabeled as the requested run. Genuinely unknown/evicted run ids flow through normally as an empty page with `stale_run_id=true` (the plugin's own shape for them).

No plugin-side changes — the GDScript side was already correct.

## Tests

- Unit (`tests/unit/test_runtime_handlers.py`): StubClient now mirrors the plugin's retained-ring semantics; new cases cover the retained-run read (asserting the param is actually on the wire, since dropping it was the bug), `since_run_id` matching the current run, an unknown/evicted run id, and the old-plugin fallback.
- Integration (`tests/integration/test_mcp_tools.py`): new test asserting `since_run_id` reaches the plugin over the real MCP stack and the retained run round-trips with `current_run_id` and `stale_run_id=true`. The existing stale-shape test survives unchanged as the old-plugin case.

Full suite: 1245 passed, 4 skipped.

## Relation to #642

Independent fixes with one trivial textual overlap: both add `current_run_id` to the passthrough tuple in `logs_read` (#642 also adds `helper_live`/`session_active`/`game_status`/`editor_errors_count`/`editor_errors_hint`), and #642 inserts a test adjacent to ones touched here. Whichever merges second needs a one-line conflict resolution (dedupe the tuple entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Game log requests now honor a run boundary parameter to resume or inspect retained logs from prior runs.
  * Log responses can include additional run metadata (including the current run identifier) for clearer paging context.

* **Bug Fixes**
  * Improved stale detection behavior: stale results are returned with empty lines and `stale_run_id` correctly flagged.
  * Enhanced older-plugin compatibility and ensured stale flags are consistently represented.

* **Tests**
  * Added/expanded integration and unit tests covering run-boundary forwarding, unknown-run handling, and stale/current run metadata behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->