### PR TITLE
Tighten dock UI and restore manage op hints

### DIFF
--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -78,7 +78,7 @@ var _install_label: Label
 # Tools tab (secondary window, Tab 2) — domain-exclusion UI for clients
 # that cap total tool count (Antigravity: 100). Pending set is mutated by
 # checkbox clicks; saved set reflects what the spawned server actually
-# sees. `Apply & Restart Server` writes pending → setting and triggers a
+# sees. `Apply and Restart Server` writes pending → setting and triggers a
 # plugin reload so the new server comes up with the trimmed list.
 var _tools_pending_excluded: PackedStringArray = PackedStringArray()
 var _tools_saved_excluded: PackedStringArray = PackedStringArray()
@@ -1456,7 +1456,9 @@ func _refresh_setup_status() -> void:
 	# User mode — check for uv
 	var uv_version := ClientConfigurator.check_uv_version()
 	if not uv_version.is_empty():
-		_setup_container.add_child(_make_status_row("uv", uv_version, Color.GREEN))
+		var compact_uv_version := _compact_uv_version_text(uv_version)
+		var uv_tooltip := uv_version if compact_uv_version != uv_version else ""
+		_setup_container.add_child(_make_status_row("uv", compact_uv_version, Color.GREEN, uv_tooltip))
 		## Build the Server row with a placeholder label we can update every
 		## frame. `_refresh_server_version_label` replaces the text + color
 		## once `McpConnection.server_version` lands via `handshake_ack`, and
@@ -1517,19 +1519,39 @@ func _resolve_plugin_symlink_target() -> String:
 	return target
 
 
-func _make_status_row(label_text: String, value_text: String, value_color: Color) -> HBoxContainer:
+static func _compact_uv_version_text(uv_version: String) -> String:
+	var text := uv_version.strip_edges()
+	if text.ends_with(")"):
+		var metadata_start := text.rfind(" (")
+		if metadata_start >= 0:
+			return text.substr(0, metadata_start).strip_edges()
+	return text
+
+
+func _make_status_row(
+	label_text: String,
+	value_text: String,
+	value_color: Color,
+	tooltip_text: String = ""
+) -> HBoxContainer:
 	var row := HBoxContainer.new()
 	row.add_theme_constant_override("separation", 6)
+	if not tooltip_text.is_empty():
+		row.tooltip_text = tooltip_text
 
 	var label := Label.new()
 	label.text = label_text
 	label.add_theme_color_override("font_color", COLOR_MUTED)
 	label.custom_minimum_size.x = 60
+	if not tooltip_text.is_empty():
+		label.tooltip_text = tooltip_text
 	row.add_child(label)
 
 	var value := Label.new()
 	value.text = value_text
 	value.add_theme_color_override("font_color", value_color)
+	if not tooltip_text.is_empty():
+		value.tooltip_text = tooltip_text
 	row.add_child(value)
 
 	return row
@@ -1639,28 +1661,12 @@ func _update_dev_section_buttons() -> void:
 		_dev_stop_btn.tooltip_text = stop_state["tooltip"]
 
 
-func _configured_client_count() -> int:
-	var configured := 0
-	for client_id in _client_rows:
-		var status: Client.Status = _client_rows[client_id].get("status", Client.Status.NOT_CONFIGURED)
-		if status == Client.Status.CONFIGURED:
-			configured += 1
-	return configured
-
-
 func _client_status_refresh_has_completed() -> bool:
 	return _last_client_status_refresh_completed_msec > 0
 
 
 func _connected_status_text() -> String:
-	var configured := _configured_client_count()
-	if configured == 0:
-		if not _client_status_refresh_has_completed():
-			return "Server connected · checking AI client configuration"
-		return "Server connected · no AI client configured"
-	if configured == 1:
-		return "Server connected · 1 AI client configured"
-	return "Server connected · %d AI clients configured" % configured
+	return "Server connected"
 
 
 func _on_install_uv() -> void:
@@ -2015,7 +2021,7 @@ func _build_tools_tab(tabs: TabContainer) -> void:
 	footer.add_theme_constant_override("separation", 8)
 
 	_tools_apply_btn = Button.new()
-	_tools_apply_btn.text = "Apply && Restart Server"
+	_tools_apply_btn.text = "Apply and Restart Server"
 	_tools_apply_btn.tooltip_text = "Save the excluded list to Editor Settings and reload the plugin so the server respawns with --exclude-domains."
 	_tools_apply_btn.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	_tools_apply_btn.pressed.connect(_on_tools_apply)

--- a/src/godot_ai/middleware/op_typo_hint.py
+++ b/src/godot_ai/middleware/op_typo_hint.py
@@ -64,6 +64,17 @@ class HintOpTypoOnManage(Middleware):
                 raise
             logger.debug("Rewrote op typo error on %s: %s", context.message.name, hint)
             raise ToolError(hint) from exc
+        except ToolError as exc:
+            candidates = MANAGE_TOOL_OPS.get(context.message.name)
+            if candidates is None:
+                raise
+            hint = _build_hint_from_tool_error(exc, context.message.arguments, candidates)
+            if hint is None:
+                raise
+            logger.debug(
+                "Rewrote wrapped op typo error on %s: %s", context.message.name, hint
+            )
+            raise ToolError(hint) from exc
 
 
 def _build_hint(
@@ -86,6 +97,20 @@ def _build_hint(
     if err.get("type") != "literal_error" or err.get("loc") != ("op",):
         return None
 
+    return _build_hint_for_raw_op(arguments, candidates)
+
+
+def _build_hint_from_tool_error(
+    exc: ToolError, arguments: dict | None, candidates: tuple[str, ...]
+) -> str | None:
+    """Return a hint when FastMCP wraps the op ``ValidationError`` as ToolError."""
+    message = str(exc)
+    if "literal_error" not in message or "\nop\n" not in message:
+        return None
+    return _build_hint_for_raw_op(arguments, candidates)
+
+
+def _build_hint_for_raw_op(arguments: dict | None, candidates: tuple[str, ...]) -> str:
     raw_op = arguments.get("op") if isinstance(arguments, dict) else None
     valid_list = ", ".join(repr(c) for c in candidates)
 

--- a/src/godot_ai/middleware/op_typo_hint.py
+++ b/src/godot_ai/middleware/op_typo_hint.py
@@ -37,7 +37,7 @@ from fastmcp.exceptions import ValidationError as FastMCPValidationError
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 from fastmcp.tools.base import ToolResult
 from mcp.types import CallToolRequestParams
-from pydantic import ValidationError
+from pydantic import ValidationError as PydanticValidationError
 
 from godot_ai.tools._meta_tool import MANAGE_TOOL_OPS
 
@@ -52,14 +52,13 @@ class HintOpTypoOnManage(Middleware):
     ) -> ToolResult:
         try:
             return await call_next(context)
-        except (ValidationError, FastMCPValidationError) as exc:
-            pydantic_exc = exc if isinstance(exc, ValidationError) else exc.__cause__
-            if not isinstance(pydantic_exc, ValidationError):
-                raise
+        except (PydanticValidationError, FastMCPValidationError) as exc:
             candidates = MANAGE_TOOL_OPS.get(context.message.name)
             if candidates is None:
                 raise
-            hint = _build_hint(pydantic_exc, context.message.arguments, candidates)
+            hint = _build_hint_from_validation_error(
+                exc, context.message.arguments, candidates
+            )
             if hint is None:
                 raise
             logger.debug("Rewrote op typo error on %s: %s", context.message.name, hint)
@@ -78,7 +77,7 @@ class HintOpTypoOnManage(Middleware):
 
 
 def _build_hint(
-    exc: ValidationError, arguments: dict | None, candidates: tuple[str, ...]
+    exc: PydanticValidationError, arguments: dict | None, candidates: tuple[str, ...]
 ) -> str | None:
     """Return a ``Did you mean`` message for an op literal_error, else None.
 
@@ -100,14 +99,51 @@ def _build_hint(
     return _build_hint_for_raw_op(arguments, candidates)
 
 
+def _build_hint_from_validation_error(
+    exc: PydanticValidationError | FastMCPValidationError,
+    arguments: dict | None,
+    candidates: tuple[str, ...],
+) -> str | None:
+    if isinstance(exc, PydanticValidationError):
+        return _build_hint(exc, arguments, candidates)
+    cause = exc.__cause__
+    if isinstance(cause, PydanticValidationError):
+        return _build_hint(cause, arguments, candidates)
+    context = exc.__context__
+    if isinstance(context, PydanticValidationError):
+        return _build_hint(context, arguments, candidates)
+    return None
+
+
 def _build_hint_from_tool_error(
     exc: ToolError, arguments: dict | None, candidates: tuple[str, ...]
 ) -> str | None:
     """Return a hint when FastMCP wraps the op ``ValidationError`` as ToolError."""
+    cause = exc.__cause__
+    if isinstance(cause, PydanticValidationError):
+        return _build_hint(cause, arguments, candidates)
+    if isinstance(cause, FastMCPValidationError):
+        return _build_hint_from_validation_error(cause, arguments, candidates)
+    context = exc.__context__
+    if isinstance(context, PydanticValidationError):
+        return _build_hint(context, arguments, candidates)
+    if isinstance(context, FastMCPValidationError):
+        return _build_hint_from_validation_error(context, arguments, candidates)
+
     message = str(exc)
-    if "literal_error" not in message or "\nop\n" not in message:
+    if not _looks_like_single_op_literal_error(message):
         return None
     return _build_hint_for_raw_op(arguments, candidates)
+
+
+def _looks_like_single_op_literal_error(message: str) -> bool:
+    lines = message.splitlines()
+    if not lines or not lines[0].startswith("1 validation error "):
+        return False
+    loc_lines = [line for line in lines[1:] if line and not line[:1].isspace()]
+    if loc_lines != ["op"]:
+        return False
+    return "type=literal_error" in message
 
 
 def _build_hint_for_raw_op(arguments: dict | None, candidates: tuple[str, ...]) -> str:

--- a/src/godot_ai/tools/_meta_tool.py
+++ b/src/godot_ai/tools/_meta_tool.py
@@ -24,10 +24,9 @@ import inspect
 import json
 from collections.abc import Awaitable, Callable, Mapping, MutableMapping, MutableSequence, Sequence
 from types import UnionType
-from typing import Annotated, Any, Union, get_args, get_origin, get_type_hints
+from typing import Annotated, Any, Literal, Union, get_args, get_origin, get_type_hints
 
 from fastmcp import Context, FastMCP
-from pydantic import Field
 
 from godot_ai.godot_client.client import GodotCommandError
 from godot_ai.protocol.errors import ErrorCode
@@ -63,7 +62,7 @@ MANAGE_TOOL_RESOURCE_FORMS: dict[str, dict[str, str | None]] = {}
 def _op_schema_type_for(op_names: frozenset[str]) -> Any:
     ## Sort because the cache key is a frozenset (orderless); a stable arg
     ## order keeps the exposed JSON-schema enum deterministic.
-    return Annotated[str, Field(json_schema_extra={"enum": list(sorted(op_names))})]
+    return Literal[tuple(sorted(op_names))]
 
 
 def register_manage_tool(
@@ -142,9 +141,8 @@ def register_manage_tool(
     ## ``from __future__ import annotations`` would stringify local type
     ## objects; pydantic resolves forward refs against module globals.
     ## Setting ``__annotations__`` post-hoc with real type objects bypasses
-    ## that resolution path. ``op_schema_type`` preserves the schema enum
-    ## while validating as ``str`` so unknown ops reach ``dispatch_manage_op``
-    ## and get structured fuzzy suggestions.
+    ## that resolution path. ``op_schema_type`` is a generated ``Literal`` so
+    ## FastMCP exposes the enum and validates op values at the schema boundary.
     manage.__annotations__ = {
         "ctx": Context,
         "op": op_schema_type,

--- a/src/godot_ai/tools/_meta_tool.py
+++ b/src/godot_ai/tools/_meta_tool.py
@@ -6,10 +6,9 @@ The shape mirrors `batch_execute`'s `(command, params)` ergonomic and
 keeps the tool count small for clients with hard tool-count caps that
 ignore Anthropic's `defer_loading` hint.
 
-Each registered tool exposes `Literal["op_a", "op_b", ...]` for `op`,
-so MCP clients with schema-driven autocomplete still see every valid
-verb. Unknown ops surface as a structured error with fuzzy
-`data.suggestions`.
+Each registered tool exposes an enum in the `op` JSON schema, so MCP
+clients with schema-driven autocomplete still see every valid verb.
+Unknown ops surface as a structured error with fuzzy `data.suggestions`.
 
 Op handlers are registered as bare callables: each entry in ``ops`` is a
 shared handler function (sync or async) accepting ``runtime`` plus the
@@ -25,9 +24,10 @@ import inspect
 import json
 from collections.abc import Awaitable, Callable, Mapping, MutableMapping, MutableSequence, Sequence
 from types import UnionType
-from typing import Annotated, Any, Literal, Union, get_args, get_origin, get_type_hints
+from typing import Annotated, Any, Union, get_args, get_origin, get_type_hints
 
 from fastmcp import Context, FastMCP
+from pydantic import Field
 
 from godot_ai.godot_client.client import GodotCommandError
 from godot_ai.protocol.errors import ErrorCode
@@ -60,10 +60,10 @@ MANAGE_TOOL_RESOURCE_FORMS: dict[str, dict[str, str | None]] = {}
 
 
 @functools.cache
-def _op_literal_for(op_names: frozenset[str]) -> Any:
+def _op_schema_type_for(op_names: frozenset[str]) -> Any:
     ## Sort because the cache key is a frozenset (orderless); a stable arg
-    ## order keeps Pydantic's "Input should be …" error message consistent.
-    return Literal[tuple(sorted(op_names))]  # type: ignore[valid-type]
+    ## order keeps the exposed JSON-schema enum deterministic.
+    return Annotated[str, Field(json_schema_extra={"enum": list(sorted(op_names))})]
 
 
 def register_manage_tool(
@@ -127,7 +127,7 @@ def register_manage_tool(
     MANAGE_TOOL_RESOURCE_FORMS[tool_name] = (
         dict(read_resource_forms) if read_resource_forms is not None else {}
     )
-    op_literal = _op_literal_for(frozenset(ops.keys()))
+    op_schema_type = _op_schema_type_for(frozenset(ops.keys()))
 
     async def manage(ctx: Context, op, params=None, session_id="") -> dict:
         runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
@@ -139,13 +139,15 @@ def register_manage_tool(
             params=params,
         )
 
-    ## ``from __future__ import annotations`` would stringify ``op_literal``
-    ## and pydantic resolves forward refs against module globals — where the
-    ## local Literal does not exist. Setting ``__annotations__`` post-hoc
-    ## with real type objects bypasses that resolution path.
+    ## ``from __future__ import annotations`` would stringify local type
+    ## objects; pydantic resolves forward refs against module globals.
+    ## Setting ``__annotations__`` post-hoc with real type objects bypasses
+    ## that resolution path. ``op_schema_type`` preserves the schema enum
+    ## while validating as ``str`` so unknown ops reach ``dispatch_manage_op``
+    ## and get structured fuzzy suggestions.
     manage.__annotations__ = {
         "ctx": Context,
-        "op": op_literal,
+        "op": op_schema_type,
         "params": dict[str, Any] | None,
         "session_id": str,
         "return": dict,

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -163,7 +163,7 @@ func test_clients_header_and_actions_use_narrow_layout() -> void:
 	assert_eq(tabs.get_tab_title(1), "Tools")
 
 
-func test_connected_status_summarizes_client_readiness() -> void:
+func test_connected_status_stays_compact_across_client_readiness() -> void:
 	_dock._build_ui()
 	_dock._connection = _ConnectionStub.new()
 	_dock._last_client_status_refresh_completed_msec = 0
@@ -171,16 +171,16 @@ func test_connected_status_summarizes_client_readiness() -> void:
 	_dock._refresh_clients_summary()
 	assert_eq(
 		_dock._status_label.text,
-		"Server connected · checking AI client configuration",
-		"Connected status should not claim no clients before the initial status sweep completes",
+		"Server connected",
+		"Connected status should stay compact before the initial status sweep completes",
 	)
 
 	_dock._last_client_status_refresh_completed_msec = Time.get_ticks_msec()
 	_dock._refresh_clients_summary()
 	assert_eq(
 		_dock._status_label.text,
-		"Server connected · no AI client configured",
-		"Connected status should tell first-run users the AI-client setup is not done",
+		"Server connected",
+		"Connected status should stay compact when no AI clients are configured",
 	)
 
 	var any_id := _first_client_id()
@@ -191,8 +191,8 @@ func test_connected_status_summarizes_client_readiness() -> void:
 	_dock._refresh_clients_summary()
 	assert_eq(
 		_dock._status_label.text,
-		"Server connected · 1 AI client configured",
-		"Connected status should summarize configured AI clients once setup has started",
+		"Server connected",
+		"Connected status should stay compact once setup has started",
 	)
 
 	var ids := McpClientConfigurator.client_ids()
@@ -203,8 +203,8 @@ func test_connected_status_summarizes_client_readiness() -> void:
 	_dock._refresh_clients_summary()
 	assert_eq(
 		_dock._status_label.text,
-		"Server connected · 2 AI clients configured",
-		"Connected status should pluralize the configured-client count",
+		"Server connected",
+		"Connected status should stay compact with multiple configured AI clients",
 	)
 
 
@@ -1484,6 +1484,33 @@ func test_log_viewer_tick_keeps_painting_after_buffer_caps_at_max_lines() -> voi
 
 
 # --- Dev-section primary + stop buttons ---------------------------------
+
+func test_uv_version_display_hides_trailing_build_metadata() -> void:
+	var full_version := "uv-tool-uvx 0.5.9 (0652800cb 2024-12-13)"
+	assert_eq(
+		McpDockScript._compact_uv_version_text(full_version),
+		"uv-tool-uvx 0.5.9",
+		"Setup's uv row should hide trailing build metadata from the visible value",
+	)
+	assert_eq(
+		McpDockScript._compact_uv_version_text("uvx 0.5.9"),
+		"uvx 0.5.9",
+		"Setup's uv row should leave already-compact versions unchanged",
+	)
+
+	var row: HBoxContainer = _dock._make_status_row(
+		"uv",
+		McpDockScript._compact_uv_version_text(full_version),
+		Color.GREEN,
+		full_version
+	)
+	var value := row.get_child(1) as Label
+	assert_eq(value.text, "uv-tool-uvx 0.5.9",
+		"Visible uv row value should stay compact")
+	assert_eq(value.tooltip_text, full_version,
+		"Full uv version details should remain available as tooltip text")
+	row.free()
+
 
 func test_dev_buttons_rendered_in_dev_checkout() -> void:
 	## Dev checkout's Setup section gets the primary "Restart Dev Server"

--- a/tests/unit/test_meta_tool.py
+++ b/tests/unit/test_meta_tool.py
@@ -171,6 +171,16 @@ def test_op_schema_type_for_enum_is_sorted_for_determinism():
     assert TypeAdapter(schema_type).json_schema()["enum"] == ["alpha", "mu", "zeta"]
 
 
+def test_op_schema_type_for_rejects_unknown_ops_at_runtime():
+    from pydantic import TypeAdapter, ValidationError
+
+    schema_type = _op_schema_type_for(frozenset({"create", "delete"}))
+    adapter = TypeAdapter(schema_type)
+    assert adapter.validate_python("create") == "create"
+    with pytest.raises(ValidationError):
+        adapter.validate_python("rename")
+
+
 # ---------------------------------------------------------------------------
 # Dispatch — happy path. Handlers are invoked as ``handler(runtime, **params)``,
 # so test handlers accept the same keyword args the dispatcher unpacks.

--- a/tests/unit/test_meta_tool.py
+++ b/tests/unit/test_meta_tool.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, get_args
+from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
@@ -14,7 +14,7 @@ from godot_ai.tools._meta_tool import (
     MANAGE_TOOL_HANDLERS,
     MANAGE_TOOL_OPS,
     MANAGE_TOOL_RESOURCE_FORMS,
-    _op_literal_for,
+    _op_schema_type_for,
     dispatch_manage_op,
     register_manage_tool,
 )
@@ -50,7 +50,7 @@ def _restore_registries():
 
 
 @pytest.mark.asyncio
-async def test_register_exposes_op_literal_in_schema():
+async def test_register_exposes_op_enum_in_schema():
     mcp = FastMCP("test")
     register_manage_tool(
         mcp,
@@ -149,24 +149,26 @@ def test_register_accepts_resource_form_with_uri_and_waiver():
 # ---------------------------------------------------------------------------
 
 
-def test_op_literal_for_returns_same_object_for_equal_op_sets():
+def test_op_schema_type_for_returns_same_object_for_equal_op_sets():
     ## Two registrations with the same op names — even in different insertion
-    ## orders — must share one Literal so Pydantic doesn't rebuild equivalent
+    ## orders — must share one schema type so Pydantic doesn't rebuild equivalent
     ## schema fragments per domain.
-    a = _op_literal_for(frozenset({"create", "delete", "rename"}))
-    b = _op_literal_for(frozenset({"rename", "create", "delete"}))
+    a = _op_schema_type_for(frozenset({"create", "delete", "rename"}))
+    b = _op_schema_type_for(frozenset({"rename", "create", "delete"}))
     assert a is b
 
 
-def test_op_literal_for_returns_distinct_object_for_different_op_sets():
-    a = _op_literal_for(frozenset({"create", "delete"}))
-    b = _op_literal_for(frozenset({"create", "delete", "rename"}))
+def test_op_schema_type_for_returns_distinct_object_for_different_op_sets():
+    a = _op_schema_type_for(frozenset({"create", "delete"}))
+    b = _op_schema_type_for(frozenset({"create", "delete", "rename"}))
     assert a is not b
 
 
-def test_op_literal_for_args_are_sorted_for_determinism():
-    literal = _op_literal_for(frozenset({"zeta", "alpha", "mu"}))
-    assert get_args(literal) == ("alpha", "mu", "zeta")
+def test_op_schema_type_for_enum_is_sorted_for_determinism():
+    from pydantic import TypeAdapter
+
+    schema_type = _op_schema_type_for(frozenset({"zeta", "alpha", "mu"}))
+    assert TypeAdapter(schema_type).json_schema()["enum"] == ["alpha", "mu", "zeta"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_middleware_op_typo_hint.py
+++ b/tests/unit/test_middleware_op_typo_hint.py
@@ -87,6 +87,29 @@ class TestHintOpTypoOnManage:
         assert "'delete'" in msg
         assert "'rename'" in msg
 
+    async def test_rewrites_fastmcp_validation_error_with_pydantic_cause(
+        self, register_node_manage
+    ):
+        mw = HintOpTypoOnManage()
+        pydantic_exc = _make_op_validation_error("get_childen", register_node_manage)
+        try:
+            raise FastMCPValidationError(str(pydantic_exc)) from pydantic_exc
+        except FastMCPValidationError as exc:
+            fastmcp_exc = exc
+        ctx = _FakeContext(
+            message=CallToolRequestParams(
+                name="node_manage",
+                arguments={"op": "get_childen", "params": {"path": "/Main"}},
+            )
+        )
+        with pytest.raises(ToolError) as info:
+            await mw.on_call_tool(ctx, await _raise_call_next(fastmcp_exc))
+
+        msg = str(info.value)
+        assert "'get_childen'" in msg
+        assert "did you mean" in msg.lower()
+        assert "'get_children'" in msg
+
     async def test_rewrites_fastmcp_wrapped_op_typo_tool_error(self, register_node_manage):
         mw = HintOpTypoOnManage()
         exc = ToolError(
@@ -108,6 +131,34 @@ class TestHintOpTypoOnManage:
         assert "'get_childen'" in msg
         assert "did you mean" in msg.lower()
         assert "'get_children'" in msg
+
+    async def test_preserves_wrapped_tool_error_with_multiple_validation_issues(
+        self, register_node_manage
+    ):
+        mw = HintOpTypoOnManage()
+        exc = ToolError(
+            "2 validation errors for call[node_manage]\n"
+            "op\n"
+            "  Input should be 'get_children', 'delete', 'rename' or 'duplicate' "
+            "[type=literal_error, input_value='get_childen', input_type=str]\n"
+            "params\n"
+            "  Input should be a valid dictionary [type=dict_type, "
+            "input_value='not-a-dict', input_type=str]"
+        )
+        ctx = _FakeContext(
+            message=CallToolRequestParams(
+                name="node_manage",
+                arguments={"op": "get_childen", "params": "not-a-dict"},
+            )
+        )
+        with pytest.raises(ToolError) as info:
+            await mw.on_call_tool(ctx, await _raise_call_next(exc))
+
+        assert info.value is exc
+        msg = str(info.value)
+        assert "2 validation errors" in msg
+        assert "params" in msg
+        assert "did you mean" not in msg.lower()
 
     async def test_falls_back_to_valid_list_when_no_close_match(self):
         ops = ("create", "delete")

--- a/tests/unit/test_middleware_op_typo_hint.py
+++ b/tests/unit/test_middleware_op_typo_hint.py
@@ -87,6 +87,28 @@ class TestHintOpTypoOnManage:
         assert "'delete'" in msg
         assert "'rename'" in msg
 
+    async def test_rewrites_fastmcp_wrapped_op_typo_tool_error(self, register_node_manage):
+        mw = HintOpTypoOnManage()
+        exc = ToolError(
+            "1 validation error for call[node_manage]\n"
+            "op\n"
+            "  Input should be 'get_children', 'delete', 'rename' or 'duplicate' "
+            "[type=literal_error, input_value='get_childen', input_type=str]"
+        )
+        ctx = _FakeContext(
+            message=CallToolRequestParams(
+                name="node_manage",
+                arguments={"op": "get_childen", "params": {"path": "/Main"}},
+            )
+        )
+        with pytest.raises(ToolError) as info:
+            await mw.on_call_tool(ctx, await _raise_call_next(exc))
+
+        msg = str(info.value)
+        assert "'get_childen'" in msg
+        assert "did you mean" in msg.lower()
+        assert "'get_children'" in msg
+
     async def test_falls_back_to_valid_list_when_no_close_match(self):
         ops = ("create", "delete")
         MANAGE_TOOL_OPS["thing_manage"] = ops

--- a/tests/unit/test_middleware_op_typo_hint.py
+++ b/tests/unit/test_middleware_op_typo_hint.py
@@ -59,6 +59,22 @@ async def _ok_call_next(_context):
     return "ok"
 
 
+def _node_manage_typo_context():
+    return _FakeContext(
+        message=CallToolRequestParams(
+            name="node_manage",
+            arguments={"op": "get_childen", "params": {"path": "/Main"}},
+        )
+    )
+
+
+def _assert_get_children_hint(exc: BaseException) -> None:
+    msg = str(exc)
+    assert "'get_childen'" in msg
+    assert "did you mean" in msg.lower()
+    assert "'get_children'" in msg
+
+
 class TestHintOpTypoOnManage:
     async def test_passes_through_when_handler_succeeds(self, register_node_manage):
         mw = HintOpTypoOnManage()
@@ -79,13 +95,10 @@ class TestHintOpTypoOnManage:
         with pytest.raises(ToolError) as info:
             await mw.on_call_tool(ctx, await _raise_call_next(exc))
 
-        msg = str(info.value)
-        assert "'get_childen'" in msg
-        assert "did you mean" in msg.lower()
-        assert "'get_children'" in msg
+        _assert_get_children_hint(info.value)
         ## The hint should keep the full valid-op list for the agent.
-        assert "'delete'" in msg
-        assert "'rename'" in msg
+        assert "'delete'" in str(info.value)
+        assert "'rename'" in str(info.value)
 
     async def test_rewrites_fastmcp_validation_error_with_pydantic_cause(
         self, register_node_manage
@@ -96,19 +109,31 @@ class TestHintOpTypoOnManage:
             raise FastMCPValidationError(str(pydantic_exc)) from pydantic_exc
         except FastMCPValidationError as exc:
             fastmcp_exc = exc
-        ctx = _FakeContext(
-            message=CallToolRequestParams(
-                name="node_manage",
-                arguments={"op": "get_childen", "params": {"path": "/Main"}},
-            )
-        )
         with pytest.raises(ToolError) as info:
-            await mw.on_call_tool(ctx, await _raise_call_next(fastmcp_exc))
+            await mw.on_call_tool(
+                _node_manage_typo_context(), await _raise_call_next(fastmcp_exc)
+            )
 
-        msg = str(info.value)
-        assert "'get_childen'" in msg
-        assert "did you mean" in msg.lower()
-        assert "'get_children'" in msg
+        _assert_get_children_hint(info.value)
+
+    async def test_rewrites_fastmcp_validation_error_with_pydantic_context(
+        self, register_node_manage
+    ):
+        mw = HintOpTypoOnManage()
+        pydantic_exc = _make_op_validation_error("get_childen", register_node_manage)
+        try:
+            raise pydantic_exc
+        except ValidationError:
+            try:
+                raise FastMCPValidationError(str(pydantic_exc))
+            except FastMCPValidationError as exc:
+                fastmcp_exc = exc
+        with pytest.raises(ToolError) as info:
+            await mw.on_call_tool(
+                _node_manage_typo_context(), await _raise_call_next(fastmcp_exc)
+            )
+
+        _assert_get_children_hint(info.value)
 
     async def test_rewrites_fastmcp_wrapped_op_typo_tool_error(self, register_node_manage):
         mw = HintOpTypoOnManage()
@@ -118,19 +143,127 @@ class TestHintOpTypoOnManage:
             "  Input should be 'get_children', 'delete', 'rename' or 'duplicate' "
             "[type=literal_error, input_value='get_childen', input_type=str]"
         )
+        with pytest.raises(ToolError) as info:
+            await mw.on_call_tool(_node_manage_typo_context(), await _raise_call_next(exc))
+
+        _assert_get_children_hint(info.value)
+
+    async def test_rewrites_tool_error_with_fastmcp_validation_cause(
+        self, register_node_manage
+    ):
+        mw = HintOpTypoOnManage()
+        pydantic_exc = _make_op_validation_error("get_childen", register_node_manage)
+        try:
+            raise FastMCPValidationError(str(pydantic_exc)) from pydantic_exc
+        except FastMCPValidationError as fastmcp_exc:
+            try:
+                raise ToolError(str(fastmcp_exc)) from fastmcp_exc
+            except ToolError as exc:
+                tool_exc = exc
+        with pytest.raises(ToolError) as info:
+            await mw.on_call_tool(
+                _node_manage_typo_context(), await _raise_call_next(tool_exc)
+            )
+
+        _assert_get_children_hint(info.value)
+
+    async def test_rewrites_tool_error_with_pydantic_cause(self, register_node_manage):
+        mw = HintOpTypoOnManage()
+        pydantic_exc = _make_op_validation_error("get_childen", register_node_manage)
+        try:
+            raise ToolError(str(pydantic_exc)) from pydantic_exc
+        except ToolError as exc:
+            tool_exc = exc
+        with pytest.raises(ToolError) as info:
+            await mw.on_call_tool(
+                _node_manage_typo_context(), await _raise_call_next(tool_exc)
+            )
+
+        _assert_get_children_hint(info.value)
+
+    async def test_rewrites_tool_error_with_pydantic_context(self, register_node_manage):
+        mw = HintOpTypoOnManage()
+        pydantic_exc = _make_op_validation_error("get_childen", register_node_manage)
+        try:
+            raise pydantic_exc
+        except ValidationError:
+            try:
+                raise ToolError(str(pydantic_exc))
+            except ToolError as exc:
+                tool_exc = exc
+        with pytest.raises(ToolError) as info:
+            await mw.on_call_tool(
+                _node_manage_typo_context(), await _raise_call_next(tool_exc)
+            )
+
+        _assert_get_children_hint(info.value)
+
+    async def test_rewrites_tool_error_with_fastmcp_validation_context(
+        self, register_node_manage
+    ):
+        mw = HintOpTypoOnManage()
+        pydantic_exc = _make_op_validation_error("get_childen", register_node_manage)
+        fastmcp_exc = FastMCPValidationError(str(pydantic_exc))
+        fastmcp_exc.__cause__ = pydantic_exc
+        try:
+            raise fastmcp_exc
+        except FastMCPValidationError:
+            try:
+                raise ToolError(str(fastmcp_exc))
+            except ToolError as exc:
+                tool_exc = exc
+        with pytest.raises(ToolError) as info:
+            await mw.on_call_tool(
+                _node_manage_typo_context(), await _raise_call_next(tool_exc)
+            )
+
+        _assert_get_children_hint(info.value)
+
+    async def test_preserves_tool_error_with_non_validation_text(self, register_node_manage):
+        mw = HintOpTypoOnManage()
+        exc = ToolError("")
+        with pytest.raises(ToolError) as info:
+            await mw.on_call_tool(_node_manage_typo_context(), await _raise_call_next(exc))
+
+        assert info.value is exc
+
+    async def test_preserves_tool_error_for_unregistered_tool(self, register_node_manage):
+        mw = HintOpTypoOnManage()
+        exc = ToolError(
+            "1 validation error for call[other_manage]\n"
+            "op\n"
+            "  Input should be 'x' [type=literal_error, input_value='y', input_type=str]"
+        )
         ctx = _FakeContext(
             message=CallToolRequestParams(
-                name="node_manage",
-                arguments={"op": "get_childen", "params": {"path": "/Main"}},
+                name="other_manage",
+                arguments={"op": "y", "params": {}},
             )
         )
         with pytest.raises(ToolError) as info:
             await mw.on_call_tool(ctx, await _raise_call_next(exc))
 
-        msg = str(info.value)
-        assert "'get_childen'" in msg
-        assert "did you mean" in msg.lower()
-        assert "'get_children'" in msg
+        assert info.value is exc
+
+    async def test_preserves_tool_error_for_literal_error_on_other_field(
+        self, register_node_manage
+    ):
+        mw = HintOpTypoOnManage()
+        exc = ToolError(
+            "1 validation error for call[node_manage]\n"
+            "params\n"
+            "  Input should be 'dict' [type=literal_error, input_value='bad', input_type=str]"
+        )
+        ctx = _FakeContext(
+            message=CallToolRequestParams(
+                name="node_manage",
+                arguments={"op": "get_childen", "params": "bad"},
+            )
+        )
+        with pytest.raises(ToolError) as info:
+            await mw.on_call_tool(ctx, await _raise_call_next(exc))
+
+        assert info.value is exc
 
     async def test_preserves_wrapped_tool_error_with_multiple_validation_issues(
         self, register_node_manage
@@ -192,29 +325,6 @@ class TestHintOpTypoOnManage:
         )
         with pytest.raises(ValidationError):
             await mw.on_call_tool(ctx, await _raise_call_next(exc))
-
-    async def test_rewrites_op_typo_wrapped_in_fastmcp_validation_error(self, register_node_manage):
-        ## fastmcp 3.4.3 (fastmcp #4128) stopped propagating pydantic's
-        ## ValidationError raw: FunctionTool re-raises it as fastmcp's own
-        ## ValidationError with the pydantic error as __cause__. The hint
-        ## must survive that wrapping regardless of installed fastmcp.
-        mw = HintOpTypoOnManage()
-        pydantic_exc = _make_op_validation_error("get_childen", register_node_manage)
-        wrapped = FastMCPValidationError(str(pydantic_exc))
-        wrapped.__cause__ = pydantic_exc
-        ctx = _FakeContext(
-            message=CallToolRequestParams(
-                name="node_manage",
-                arguments={"op": "get_childen", "params": {"path": "/Main"}},
-            )
-        )
-        with pytest.raises(ToolError) as info:
-            await mw.on_call_tool(ctx, await _raise_call_next(wrapped))
-
-        msg = str(info.value)
-        assert "'get_childen'" in msg
-        assert "did you mean" in msg.lower()
-        assert "'get_children'" in msg
 
     async def test_passes_through_fastmcp_validation_error_without_pydantic_cause(
         self, register_node_manage


### PR DESCRIPTION
## Summary

- Keep the top dock connection status compact by showing only `Server connected`
- Hide trailing `uvx --version` build metadata from the visible Setup row while preserving the full value as tooltip text
- Rename the Tools tab apply button from `Apply && Restart Server` to `Apply and Restart Server`
- Keep manage-tool `op` enum values in the JSON schema while allowing unknown ops to reach the dispatcher and return fuzzy `Did you mean` suggestions under current FastMCP
- Update dock and manage-tool tests for the compact UI and op-typo behavior

## Verification

- `bash script/ci-check-gdscript`
- `.\.venv\Scripts\python.exe -m pytest tests/unit/test_meta_tool.py tests/unit/test_middleware_op_typo_hint.py tests/integration/test_mcp_tools.py::TestManageRollupHintsOnOpTypo::test_op_typo_surfaces_did_you_mean_message -q`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `<domain>_manage` tool schemas now expose valid `op` values as an enum; invalid `op` values return structured `INVALID_PARAMS` including fuzzy suggestions.
* **Bug Fixes**
  * Connected status remains consistently “Server connected” across client readiness phases.
  * “Did you mean …” hints for `op` typos now work correctly even when validation errors are wrapped.
* **UI Improvements**
  * Setup shows a compact `uv` version, with the full version available in a tooltip when different.
  * Tools button label updated to “Apply and Restart Server”; status rows can display tooltips.
* **Tests**
  * Expanded coverage for `uv` compaction, connected-status stability, and enhanced hint rewrite behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->