### PR TITLE
Surface boot-time debugger breaks that were invisible to every MCP surface (#645)

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -52,7 +52,16 @@ if a run-scoped parse/load error appeared, the response names it and points to
 game launched but this project has no `_mcp_game_helper` autoload, as with some
 headless/custom-main-loop setups: `helper_live=false` while
 `session_active=true`. `"launching"` is a soft "not live yet" state and can
-reconcile on a later `editor_state` poll.
+reconcile on a later `editor_state` poll. `"break"` means the game process is
+parked in a remote-debugger break: during boot this is a GDScript parse/load
+error (`GDScriptLanguage::debug_break_parse`) that freezes the game before the
+helper can register and before any error record reaches the Errors tab, the
+editor Logger, or the game log (#645). The plugin synthesizes an error record
+from the debugger break (reason + Stack Trace frames) so the `project_run`
+response names the failing script, and `game_status.break` carries `{reason,
+can_debug, pre_live}`. The run cannot continue on its own — call
+`project_manage(op="stop")`, fix the error, and relaunch. `helper_live=false`,
+`session_active=true` while at a break.
 
 `editor_state` includes the same `game_status` object in addition to the legacy
 `is_playing` boolean and `game_capture_ready`. It also mirrors
@@ -84,7 +93,7 @@ Game and combined log responses also include `game_status`, `helper_live`, and
 `game_status.session_active`. For compatibility, `is_running` is retained as an
 alias of `session_active`; it is no longer raw editor play-state. Both are `false` for
 `game_status.status` of `"not_live"` or `"stopped"`, and `true` for `"live"`,
-`"launching"`, or `"no_helper"`. This lets a parse/load failure that leaves the
+`"launching"`, `"break"`, or `"no_helper"`. This lets a parse/load failure that leaves the
 editor play button active report as not running, while a legitimate headless or
 custom-main-loop project without `_mcp_game_helper` remains active with
 `helper_live=false`, `session_active=true`, and

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -87,6 +87,28 @@ var _game_run_started_msec := 0
 var _game_run_started_editor_cursor := 0
 var _game_run_started_debugger_cursor := 0
 var _game_helper_expected := true
+
+## #645: a GDScript parse error hit while an editor-launched game boots calls
+## GDScriptLanguage::debug_break_parse — the game parks in a remote-debugger
+## break BEFORE the helper's mcp:hello and before any record reaches the
+## Errors tab, the editor Logger, or the game log. The only editor-side traces
+## are the debugger break signals; the stack frames land in the Stack Trace
+## panel a few frames later. Track the break here so game_status can report
+## status="break" and a synthesized error record can name the failure.
+var _break_active := false
+var _break_can_debug := false
+var _break_reason := ""
+var _break_pre_live := false
+var _break_run_token := -1
+var _break_record_synthesized := false
+
+## #645: how long after the break signal to scrape the Stack Trace panel for
+## frames. The editor requests the stack dump from the game separately, so the
+## panel is empty at signal time; ~0.5s has it populated. The late tick
+## synthesizes with whatever is available so a scrape failure still yields a
+## record carrying the break reason.
+const BREAK_FRAME_SCRAPE_DELAYS_SEC: Array[float] = [0.5, 2.0]
+
 signal game_ready
 
 
@@ -112,6 +134,7 @@ func _has_capture(prefix: String) -> bool:
 ## asserts "plugin loaded" is the first line after a plugin reload.
 func _setup_session(session_id: int) -> void:
 	_connect_session_stopped(session_id)
+	_connect_session_break_signals(session_id)
 	if EditorInterface.is_playing_scene() and not _game_run_active:
 		_begin_game_run_tracking(_editor_log_cursor(), true, true, true, true, true)
 	else:
@@ -138,6 +161,7 @@ func _begin_game_run_tracking(
 	_game_ready = false
 	_ready_run_token = -1
 	_game_session_id = -1
+	clear_debug_break()
 	_game_run_started_msec = Time.get_ticks_msec()
 	_game_run_started_editor_cursor = maxi(0, editor_log_cursor)
 	if _surfaced_error_tracker != null:
@@ -166,6 +190,7 @@ func end_game_run() -> void:
 	_game_ready = false
 	_ready_run_token = -1
 	_game_session_id = -1
+	clear_debug_break()
 	if _surfaced_error_tracker != null:
 		_surfaced_error_tracker.note_game_run_stopped()
 
@@ -206,6 +231,201 @@ func _on_debugger_session_stopped(session_id: int) -> void:
 	end_game_run()
 
 
+## --- #645: boot-time debugger breaks ---------------------------------------
+
+func _connect_session_break_signals(session_id: int) -> void:
+	var session = get_session(session_id)
+	if session != null:
+		var breaked_cb := Callable(self, "_on_debugger_session_breaked").bind(session_id)
+		if not session.breaked.is_connected(breaked_cb):
+			session.breaked.connect(breaked_cb)
+		var continued_cb := Callable(self, "_on_debugger_session_continued").bind(session_id)
+		if not session.continued.is_connected(continued_cb):
+			session.continued.connect(continued_cb)
+	_connect_script_debugger_breaked()
+
+
+## The session-level `breaked` signal carries only can_debug; the underlying
+## ScriptEditorDebugger's own `breaked` also carries the human-readable break
+## reason ("Parser Error: ..."), which is otherwise visible only in the
+## Debugger UI. EditorDebuggerSession does not expose its debugger node, so
+## locate ScriptEditorDebugger instances by walking the editor UI — the same
+## approach as the tracker's Errors-tab scrape.
+func _connect_script_debugger_breaked() -> void:
+	var base := EditorInterface.get_base_control()
+	if base == null:
+		return
+	var debuggers: Array[Node] = []
+	_collect_nodes_of_class(base, "ScriptEditorDebugger", debuggers)
+	for dbg in debuggers:
+		if not dbg.has_signal("breaked"):
+			continue
+		var cb := Callable(self, "_on_script_debugger_breaked")
+		if not dbg.is_connected("breaked", cb):
+			dbg.connect("breaked", cb)
+
+
+static func _collect_nodes_of_class(node: Node, klass: String, out: Array[Node]) -> void:
+	if node.get_class() == klass:
+		out.append(node)
+	for child in node.get_children():
+		_collect_nodes_of_class(child, klass, out)
+
+
+func _on_debugger_session_breaked(can_debug: bool, session_id: int) -> void:
+	if _game_session_id != -1 and session_id != _game_session_id:
+		return
+	note_debug_break(can_debug, "")
+
+
+func _on_debugger_session_continued(session_id: int) -> void:
+	if _game_session_id != -1 and session_id != _game_session_id:
+		return
+	clear_debug_break()
+
+
+## reallydid=false is Godot's "left the break" notification (debug_exit).
+func _on_script_debugger_breaked(reallydid: bool, can_debug: bool, reason: String, _has_stackdump: bool) -> void:
+	if not reallydid:
+		clear_debug_break()
+		return
+	note_debug_break(can_debug, reason)
+
+
+## Record that the game process is parked in a remote-debugger break. Fires
+## once per break from the session signal (no reason text) and again moments
+## later from the ScriptEditorDebugger signal (with reason) — the notices
+## merge into one break. Public so tests can drive break state directly.
+func note_debug_break(can_debug: bool, reason: String) -> void:
+	var first_notice := not _break_active
+	_break_active = true
+	_break_can_debug = can_debug
+	if not reason.is_empty():
+		_break_reason = reason
+	if not first_notice:
+		return
+	_break_run_token = _game_run_token
+	_break_pre_live = _game_run_active and not is_game_capture_ready()
+	_break_record_synthesized = false
+	if _log_buffer:
+		_log_buffer.log("[debug] debugger break (pre_live=%s can_debug=%s)" % [str(_break_pre_live), str(can_debug)])
+	if _break_pre_live:
+		_schedule_break_record_synthesis()
+
+
+func clear_debug_break() -> void:
+	_break_active = false
+	_break_can_debug = false
+	_break_reason = ""
+	_break_pre_live = false
+	_break_run_token = -1
+	_break_record_synthesized = false
+
+
+## Stack frames land in the Stack Trace panel a few frames after the break
+## signal (the editor requests the stack dump separately), so the record is
+## synthesized on short timers rather than at signal time.
+func _schedule_break_record_synthesis() -> void:
+	var tree := Engine.get_main_loop() as SceneTree
+	if tree == null:
+		return
+	var token := _break_run_token
+	for i in BREAK_FRAME_SCRAPE_DELAYS_SEC.size():
+		var final := i == BREAK_FRAME_SCRAPE_DELAYS_SEC.size() - 1
+		var timer := tree.create_timer(BREAK_FRAME_SCRAPE_DELAYS_SEC[i])
+		timer.timeout.connect(func() -> void: _on_break_scrape_tick(token, final))
+
+
+func _on_break_scrape_tick(run_token: int, final: bool) -> void:
+	if not _break_active or _break_record_synthesized or run_token != _break_run_token:
+		return
+	var frames := _scrape_break_stack_frames()
+	if frames.is_empty() and not final:
+		return
+	synthesize_break_error_record(frames)
+
+
+## Read the debugger's Stack Trace panel rows. Row metadata is a Dictionary
+## {frame, file, function, line} regardless of editor locale, so stack trees
+## are identified by metadata shape rather than the translated column title.
+func _scrape_break_stack_frames() -> Array[Dictionary]:
+	var base := EditorInterface.get_base_control()
+	if base == null:
+		return []
+	var debuggers: Array[Node] = []
+	_collect_nodes_of_class(base, "ScriptEditorDebugger", debuggers)
+	for dbg in debuggers:
+		var trees: Array[Node] = []
+		_collect_nodes_of_class(dbg, "Tree", trees)
+		for t in trees:
+			var frames := _frames_from_stack_tree(t as Tree)
+			if not frames.is_empty():
+				return frames
+	return []
+
+
+static func _frames_from_stack_tree(tree: Tree) -> Array[Dictionary]:
+	var frames: Array[Dictionary] = []
+	var root := tree.get_root()
+	if root == null:
+		return frames
+	var item := root.get_first_child()
+	while item != null:
+		var meta = item.get_metadata(0)
+		if not (meta is Dictionary and meta.has("file") and meta.has("frame")):
+			return []
+		frames.append({
+			"path": str(meta.get("file", "")),
+			"line": int(meta.get("line", 0)),
+			"function": str(meta.get("function", "")),
+		})
+		item = item.get_next()
+	return frames
+
+
+## Build the Errors-tab-shaped record for a boot-time break and promote it via
+## the tracker so recent_editor_errors_since / logs_read / the watermark all
+## surface it — the break itself produces no record anywhere else (#645).
+## Public so tests can synthesize without waiting on scrape timers.
+func synthesize_break_error_record(frames: Array[Dictionary]) -> void:
+	if _break_record_synthesized:
+		return
+	_break_record_synthesized = true
+	if _surfaced_error_tracker == null:
+		return
+	var reason := _break_reason
+	if reason.is_empty():
+		reason = "Game process broke into the debugger during startup (script parse/load error; reason not captured)"
+	var top: Dictionary = frames[0] if not frames.is_empty() else {}
+	var location := {
+		"path": str(top.get("path", "")),
+		"line": int(top.get("line", 0)),
+		"function": str(top.get("function", "")),
+	}
+	var entry := {
+		"source": "editor",
+		"level": "error",
+		"text": reason,
+		"path": location["path"],
+		"line": location["line"],
+		"function": location["function"],
+		"details": {
+			"debugger_tab": "Stack Trace",
+			"message": reason,
+			"error_type_name": "debugger_break",
+			"source": location.duplicate(true),
+			"resolved": location.duplicate(true),
+			"frames": frames.duplicate(true),
+		},
+	}
+	_surfaced_error_tracker.record_synthetic_error(entry)
+	if _log_buffer:
+		_log_buffer.log("[debug] synthesized boot-break error record: %s" % McpSurfacedErrorTracker.format_editor_error_summary(entry))
+
+
+## --- end #645 ---------------------------------------------------------------
+
+
 func is_game_capture_ready() -> bool:
 	return _game_run_active and _game_ready and _ready_run_token == _game_run_token
 
@@ -225,7 +445,12 @@ func get_game_status(now_msec: int = -1, ready_wait_sec: float = GAME_READY_WAIT
 	## "stopped" also covers idle/never-ran; no game run is currently active.
 	var status := "stopped"
 	if _game_run_active:
-		if is_game_capture_ready():
+		## #645: a parked process takes precedence over "live" — a game frozen
+		## in a remote-debugger break cannot service game-side tools even when
+		## its helper registered before the break.
+		if _break_active:
+			status = "break"
+		elif is_game_capture_ready():
 			status = "live"
 		elif not _game_helper_expected:
 			status = "no_helper"
@@ -233,7 +458,7 @@ func get_game_status(now_msec: int = -1, ready_wait_sec: float = GAME_READY_WAIT
 			status = "not_live"
 		else:
 			status = "launching"
-	return with_liveness_flags({
+	var out := {
 		"status": status,
 		"run_token": _game_run_token,
 		"active": _game_run_active,
@@ -243,7 +468,14 @@ func get_game_status(now_msec: int = -1, ready_wait_sec: float = GAME_READY_WAIT
 		"elapsed_msec": elapsed_msec,
 		"ready_wait_msec": ready_wait_msec,
 		"editor_log_cursor": _game_run_started_editor_cursor,
-	})
+	}
+	if status == "break":
+		out["break"] = {
+			"reason": _break_reason,
+			"can_debug": _break_can_debug,
+			"pre_live": _break_pre_live,
+		}
+	return with_liveness_flags(out)
 
 
 func _explain_not_live(status: Dictionary, code: String = ErrorCodes.INTERNAL_ERROR) -> Dictionary:
@@ -271,6 +503,14 @@ func _explain_not_live(status: Dictionary, code: String = ErrorCodes.INTERNAL_ER
 				message = "The game is not responding and reported no load errors during this run. A recent editor error may be related, but may predate this run: %s. Check logs_read(source='editor', include_details=true)." % _format_editor_error_summary(recent_errors[0])
 			else:
 				message = "The game is not responding and reported no load errors before the helper-ready window elapsed. It may still be booting or may have failed silently; check logs_read(source='editor', include_details=true) and retry."
+		"break":
+			var break_info: Dictionary = status.get("break", {})
+			var break_reason := str(break_info.get("reason", ""))
+			var reason_suffix := (": %s" % break_reason) if not break_reason.is_empty() else ""
+			if bool(break_info.get("pre_live", true)):
+				message = "The game hit a script error during startup and is frozen at a debugger break%s. It cannot become live; call project_manage(op='stop') to end the run, fix the error, and relaunch. Check logs_read(source='editor', include_details=true)." % reason_suffix
+			else:
+				message = "The game is paused at a debugger break%s. Resume it from the editor's Debugger panel or call project_manage(op='stop')." % reason_suffix
 		"no_helper":
 			message = "The running game has no _mcp_game_helper autoload, so game-side tools cannot connect. If this is a headless or custom-main-loop project, use editor_screenshot(source='viewport') where applicable. Otherwise, re-enable the plugin and relaunch the game."
 		"launching":
@@ -534,7 +774,13 @@ func _wait_then_send(
 	timeout_sec: float,
 ) -> void:
 	var deadline := Time.get_ticks_msec() + int(GAME_READY_WAIT_SEC * 1000.0)
-	while not is_game_capture_ready() and Time.get_ticks_msec() < deadline:
+	## #645: always yield at least one frame — the dispatcher registers the
+	## deferred request only after the handler returns DEFERRED_RESPONSE, so a
+	## same-frame error reply would be dropped as an expired request. The break
+	## check then bails out with the actionable break error instead of waiting
+	## out the full window (a game parked in a debugger break never beacons).
+	await tree.process_frame
+	while not is_game_capture_ready() and not _break_active and Time.get_ticks_msec() < deadline:
 		await tree.process_frame
 	if not is_game_capture_ready():
 		_send_error_response(connection, request_id,
@@ -722,7 +968,12 @@ func _wait_then_eval(
 	## the not-ready path returns its actionable error before the 15s server-side
 	## command timeout fires an opaque TimeoutError. See EVAL_READY_WAIT_SEC.
 	var deadline := Time.get_ticks_msec() + int(EVAL_READY_WAIT_SEC * 1000.0)
-	while not is_game_capture_ready() and Time.get_ticks_msec() < deadline:
+	## #645: the leading yield guarantees the dispatcher has registered the
+	## deferred request before any reply (a same-frame reply is dropped as
+	## expired); the break check bails out early because a parked game never
+	## registers its capture.
+	await tree.process_frame
+	while not is_game_capture_ready() and not _break_active and Time.get_ticks_msec() < deadline:
 		await tree.process_frame
 	if not is_game_capture_ready():
 		## #518: EVAL_GAME_NOT_READY (not INTERNAL_ERROR) — the play session is up
@@ -983,7 +1234,12 @@ func _wait_then_game_command(
 	timeout_sec: float,
 ) -> void:
 	var deadline := Time.get_ticks_msec() + int(GAME_READY_WAIT_SEC * 1000.0)
-	while not is_game_capture_ready() and Time.get_ticks_msec() < deadline:
+	## #645: the leading yield guarantees the dispatcher has registered the
+	## deferred request before any reply (a same-frame reply is dropped as
+	## expired); the break check bails out early because a parked game never
+	## registers its capture.
+	await tree.process_frame
+	while not is_game_capture_ready() and not _break_active and Time.get_ticks_msec() < deadline:
 		await tree.process_frame
 	if not is_game_capture_ready():
 		_send_error_response(connection, request_id,

--- a/plugin/addons/godot_ai/handlers/project_handler.gd
+++ b/plugin/addons/godot_ai/handlers/project_handler.gd
@@ -265,6 +265,8 @@ func _run_project_already_running_message(decision: Dictionary) -> String:
 			var break_errors: Array = decision.get("recent_errors", [])
 			if not break_errors.is_empty() and str(decision.get("recent_errors_scope", "none")) == "run":
 				return "Project was already running but the game is parked at a debugger break: %s. Call project_manage(op='stop') to end the run, fix the error, and relaunch." % _format_editor_error_summary(break_errors[0])
+			if not break_errors.is_empty():
+				return "Project was already running but the game is parked at a debugger break. A recent editor error may be related, but may predate this run: %s. Call project_manage(op='stop') to end the run." % _format_editor_error_summary(break_errors[0])
 			return "Project was already running but the game is parked at a debugger break. Call project_manage(op='stop') to end the run; the break reason is in the editor's Debugger panel."
 		"no_helper":
 			return "Project was already running, but no _mcp_game_helper autoload is expected. Headless or custom-main-loop projects cannot confirm helper liveness."
@@ -321,8 +323,8 @@ func _run_project_liveness_decision(status: Dictionary, errors_info: Dictionary 
 		## fallback if synthesis never lands.
 		var break_info: Dictionary = status.get("break", {})
 		var break_reason := str(break_info.get("reason", ""))
-		decision["resolve"] = correlated_error or elapsed_msec >= ready_wait_msec
 		if bool(break_info.get("pre_live", true)):
+			decision["resolve"] = correlated_error or elapsed_msec >= ready_wait_msec
 			var summary := break_reason
 			if correlated_error:
 				summary = _format_editor_error_summary(recent_errors[0])

--- a/plugin/addons/godot_ai/handlers/project_handler.gd
+++ b/plugin/addons/godot_ai/handlers/project_handler.gd
@@ -261,6 +261,11 @@ func _run_project_already_running_message(decision: Dictionary) -> String:
 			if not errors.is_empty():
 				return "Project was already running but is not responding. A recent editor error may be related, but may predate this run: %s. Check logs_read(source='editor', include_details=true)." % _format_editor_error_summary(errors[0])
 			return "Project was already running but did not become live before the helper-ready window elapsed. Check logs_read(source='editor', include_details=true) and poll editor_state."
+		"break":
+			var break_errors: Array = decision.get("recent_errors", [])
+			if not break_errors.is_empty() and str(decision.get("recent_errors_scope", "none")) == "run":
+				return "Project was already running but the game is parked at a debugger break: %s. Call project_manage(op='stop') to end the run, fix the error, and relaunch." % _format_editor_error_summary(break_errors[0])
+			return "Project was already running but the game is parked at a debugger break. Call project_manage(op='stop') to end the run; the break reason is in the editor's Debugger panel."
 		"no_helper":
 			return "Project was already running, but no _mcp_game_helper autoload is expected. Headless or custom-main-loop projects cannot confirm helper liveness."
 		"launching":
@@ -306,6 +311,28 @@ func _run_project_liveness_decision(status: Dictionary, errors_info: Dictionary 
 				decision["message"] += " Editor logs since this run may be truncated; showing retained errors."
 		else:
 			decision["message"] = "Game launched and the Godot AI game helper is live."
+	elif state == "break":
+		## #645: the game process is parked in a remote-debugger break. A
+		## boot-time parse error (GDScriptLanguage::debug_break_parse) produces
+		## no Errors-tab row, no Logger entry, and no game-log line — the
+		## synthesized break record is the only evidence, and it lands a
+		## moment after the break signal (stack frames arrive async). Wait for
+		## it (correlated_error) before resolving; the ready window is the
+		## fallback if synthesis never lands.
+		var break_info: Dictionary = status.get("break", {})
+		var break_reason := str(break_info.get("reason", ""))
+		decision["resolve"] = correlated_error or elapsed_msec >= ready_wait_msec
+		if bool(break_info.get("pre_live", true)):
+			var summary := break_reason
+			if correlated_error:
+				summary = _format_editor_error_summary(recent_errors[0])
+			if summary.is_empty():
+				summary = "script parse/load error (reason not captured)"
+			decision["message"] = "Game hit a script error during startup and is frozen at a debugger break before the Godot AI game helper registered: %s. The run cannot continue; call project_manage(op='stop'), fix the error, and relaunch. Check logs_read(source='editor', include_details=true)." % summary
+		else:
+			var reason_suffix := (": %s" % break_reason) if not break_reason.is_empty() else ""
+			decision["resolve"] = true
+			decision["message"] = "Game is paused at a debugger break%s. Resume it from the editor's Debugger panel or call project_manage(op='stop')." % reason_suffix
 	elif correlated_error:
 		decision["resolve"] = true
 		decision["liveness_status"] = "not_live"

--- a/plugin/addons/godot_ai/utils/surfaced_error_tracker.gd
+++ b/plugin/addons/godot_ai/utils/surfaced_error_tracker.gd
@@ -122,6 +122,33 @@ func refresh_debugger_errors(force: bool = true) -> void:
 	_trim_promoted_debugger_key_counts()
 
 
+## #645: promote an error record that has no Errors-tab row to scrape — e.g. a
+## boot-time parse error that parked the game in a remote-debugger break before
+## any surface got a record. The entry joins the same promoted sequence as
+## scraped Debugger rows, so run-scoping (editor_entries_since), the retained
+## fallback, and the response watermark all see it with no extra plumbing.
+## Re-recording the same key later (the same script still broken on the next
+## run) re-promotes it with a fresh sequence, mirroring how re-appearing
+## Errors-tab rows behave; scan reconciliation zeroes the key's count once the
+## break ends since the row never exists in the live tab.
+func record_synthetic_error(entry: Dictionary) -> void:
+	var key := _log_entry_key(entry)
+	var occurrences := int(_promoted_debugger_keys.get(key, 0)) + 1
+	if not _promoted_debugger_keys.has(key):
+		_promoted_debugger_key_order.append(key)
+	_promoted_debugger_keys[key] = occurrences
+	_debugger_promoted_total += 1
+	var promoted := entry.duplicate(true)
+	promoted["_debugger_key"] = key
+	promoted["_debugger_occurrences"] = occurrences
+	promoted["_debugger_sequence"] = _debugger_promoted_total
+	promoted["_debugger_synthetic"] = true
+	_remove_promoted_debugger_entry(key)
+	_promoted_debugger_entries.append(promoted)
+	_trim_promoted_debugger_entries()
+	_trim_promoted_debugger_key_counts()
+
+
 func watermark(force_debugger_scan: bool = false) -> Dictionary:
 	refresh_debugger_errors(force_debugger_scan)
 	return {
@@ -159,7 +186,25 @@ func collect_editor_log_entries() -> Array[Dictionary]:
 			continue
 		seen_keys[key] = true
 		entries.append(entry)
+	## #645: synthesized break records have no live Errors-tab row to scrape —
+	## merge them from the promoted list so logs_read(source="editor") shows
+	## the record that run/game responses point at.
+	for entry in _promoted_debugger_entries:
+		if not bool(entry.get("_debugger_synthetic", false)):
+			continue
+		var key := _log_entry_key(entry)
+		if seen_keys.has(key):
+			continue
+		seen_keys[key] = true
+		entries.append(_strip_promotion_bookkeeping(entry))
 	return entries
+
+
+static func _strip_promotion_bookkeeping(entry: Dictionary) -> Dictionary:
+	var clean := entry.duplicate(true)
+	for key in ["_debugger_key", "_debugger_occurrences", "_debugger_sequence", "_debugger_synthetic"]:
+		clean.erase(key)
+	return clean
 
 
 func editor_entries_since(editor_cursor: int, debugger_cursor: int, force_debugger_scan: bool = true) -> Dictionary:

--- a/src/godot_ai/tools/editor.py
+++ b/src/godot_ai/tools/editor.py
@@ -68,6 +68,10 @@ def register_editor_tools(mcp: FastMCP, *, include_non_core: bool = True) -> Non
         (status not in {"not_live", "stopped"}) mirrored from the same fields
         inside ``game_status``. ``is_playing`` remains raw editor play-state;
         use ``game_status.status`` for liveness decisions.
+        ``game_status.status="break"`` means the game process is parked in a
+        remote-debugger break (boot-time parse errors do this before the game
+        helper registers); it will not resume on its own — call
+        ``project_manage(op="stop")``.
 
         Args:
             session_id: Optional Godot session to target. Empty = active session.

--- a/src/godot_ai/tools/project.py
+++ b/src/godot_ai/tools/project.py
@@ -66,7 +66,14 @@ def register_project_tools(mcp: FastMCP) -> None:
         with some headless/custom-main-loop setups (helper_live=false,
         session_active=true); ``"stopped"`` means playback stopped or never
         became active before liveness could be confirmed (helper_live=false,
-        session_active=false). Poll ``editor_state`` to see late transitions.
+        session_active=false); ``"break"`` means the game process is parked in
+        a remote-debugger break — during boot this is a GDScript parse/load
+        error that froze the game before the helper could register, and the
+        response names the failing script when captured
+        (``game_status.break`` = ``{reason, can_debug, pre_live}``). A game at
+        a break cannot continue on its own: call ``project_manage(op="stop")``,
+        fix the error, and relaunch. Poll ``editor_state`` to see late
+        transitions.
 
         Args:
             mode: "main" | "current" | "custom". Default "main".

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -2342,6 +2342,217 @@ func test_debugger_plugin_explain_not_live_marks_truncated_editor_errors() -> vo
 	assert_eq(err.error.data.recent_errors.size(), 5, "recent errors are capped")
 
 
+# ----- boot-time debugger breaks (issue #645) -----
+
+func test_debugger_plugin_break_pre_live_reports_status_break() -> void:
+	var plugin := McpDebuggerPlugin.new()
+	plugin.begin_game_run(0, true)
+	plugin.note_debug_break(false, "Parser Error: Expected parameter name.")
+	var status := plugin.get_game_status(plugin._game_run_started_msec)
+	assert_eq(status.status, "break")
+	assert_eq(status.helper_live, false)
+	assert_eq(status.session_active, true, "a parked game still holds an attached debugger session")
+	assert_eq(status["break"].reason, "Parser Error: Expected parameter name.")
+	assert_eq(status["break"].pre_live, true)
+	assert_eq(status["break"].can_debug, false)
+
+
+func test_debugger_plugin_break_takes_precedence_over_live() -> void:
+	var plugin := McpDebuggerPlugin.new()
+	plugin.begin_game_run(0, true)
+	plugin._capture("mcp:hello", [], -1)
+	assert_eq(plugin.get_game_status().status, "live")
+	plugin.note_debug_break(true, "Breakpoint")
+	var status := plugin.get_game_status()
+	assert_eq(status.status, "break", "a frozen game cannot service game tools even after the helper registered")
+	assert_eq(status["break"].pre_live, false)
+	assert_eq(status["break"].can_debug, true)
+
+
+func test_debugger_plugin_break_signal_notices_merge_reason() -> void:
+	## The session-level breaked signal lands first with no reason text; the
+	## ScriptEditorDebugger signal follows with the reason. Both notices must
+	## merge into one break instead of the later one resetting state.
+	var plugin := McpDebuggerPlugin.new()
+	plugin.begin_game_run(0, true)
+	plugin.note_debug_break(false, "")
+	assert_eq(plugin.get_game_status(plugin._game_run_started_msec).status, "break")
+	plugin.note_debug_break(false, "Parser Error: Expected parameter name.")
+	var status := plugin.get_game_status(plugin._game_run_started_msec)
+	assert_eq(status["break"].reason, "Parser Error: Expected parameter name.")
+	assert_eq(status["break"].pre_live, true, "the merged notice must keep the first notice's pre-live scope")
+
+
+func test_debugger_plugin_break_synthesizes_run_scoped_record() -> void:
+	var empty_tree := Tree.new()
+	empty_tree.create_item()
+	var tracker := McpSurfacedErrorTracker.new(null, null, empty_tree)
+	var plugin := McpDebuggerPlugin.new(null, null, null, tracker)
+	plugin.begin_game_run(0, true)
+	plugin.note_debug_break(false, "Parser Error: Expected parameter name.")
+	var frames: Array[Dictionary] = [{"path": "res://smoke_broken.gd", "line": 2, "function": ""}]
+	plugin.synthesize_break_error_record(frames)
+
+	var errors_info: Dictionary = plugin.recent_editor_errors_since(0)
+	assert_eq(errors_info.scope, "run", "the synthesized break record must be run-scoped")
+	assert_eq(errors_info.errors.size(), 1)
+	assert_eq(errors_info.errors[0].text, "Parser Error: Expected parameter name.")
+	assert_eq(errors_info.errors[0].path, "res://smoke_broken.gd")
+	assert_eq(errors_info.errors[0].line, 2)
+	assert_eq(errors_info.errors[0].details.frames.size(), 1)
+
+	plugin.synthesize_break_error_record(frames)
+	assert_eq(plugin.recent_editor_errors_since(0).errors.size(), 1, "a break synthesizes at most one record")
+	empty_tree.free()
+
+
+func test_debugger_plugin_break_record_without_frames_keeps_reason() -> void:
+	var empty_tree := Tree.new()
+	empty_tree.create_item()
+	var tracker := McpSurfacedErrorTracker.new(null, null, empty_tree)
+	var plugin := McpDebuggerPlugin.new(null, null, null, tracker)
+	plugin.begin_game_run(0, true)
+	plugin.note_debug_break(false, "Parser Error: Expected parameter name.")
+	plugin.synthesize_break_error_record([] as Array[Dictionary])
+	var errors_info: Dictionary = plugin.recent_editor_errors_since(0)
+	assert_eq(errors_info.errors.size(), 1, "a failed stack scrape must still record the break reason")
+	assert_eq(errors_info.errors[0].text, "Parser Error: Expected parameter name.")
+	assert_eq(errors_info.errors[0].path, "")
+	empty_tree.free()
+
+
+func test_debugger_plugin_post_live_break_does_not_arm_synthesis() -> void:
+	var empty_tree := Tree.new()
+	empty_tree.create_item()
+	var tracker := McpSurfacedErrorTracker.new(null, null, empty_tree)
+	var plugin := McpDebuggerPlugin.new(null, null, null, tracker)
+	plugin.begin_game_run(0, true)
+	plugin._capture("mcp:hello", [], -1)
+	plugin.note_debug_break(true, "Breakpoint")
+	assert_eq(plugin._break_pre_live, false)
+	assert_eq(plugin.recent_editor_errors_since(0).errors.size(), 0, "a resumable post-live break is not a boot failure record")
+	empty_tree.free()
+
+
+func test_debugger_plugin_break_cleared_on_run_end_and_continue() -> void:
+	var plugin := McpDebuggerPlugin.new()
+	plugin.begin_game_run(0, true)
+	plugin.note_debug_break(false, "Parser Error: X")
+	assert_eq(plugin.get_game_status(plugin._game_run_started_msec).status, "break")
+	plugin._on_debugger_session_continued(0)
+	assert_eq(plugin.get_game_status(plugin._game_run_started_msec).status, "launching", "continue must clear the break state")
+
+	plugin.note_debug_break(false, "Parser Error: X")
+	plugin.end_game_run()
+	assert_eq(plugin.get_game_status().status, "stopped")
+	assert_eq(plugin._break_active, false)
+
+	plugin.note_debug_break(false, "stale break with no run")
+	plugin.begin_game_run(0, true)
+	assert_eq(plugin.get_game_status(plugin._game_run_started_msec).status, "launching", "a new run must not inherit stale break state")
+
+
+func test_debugger_plugin_script_debugger_breaked_relay() -> void:
+	## reallydid=false is Godot's "left the break" notification (debug_exit).
+	var plugin := McpDebuggerPlugin.new()
+	plugin.begin_game_run(0, true)
+	plugin._on_script_debugger_breaked(true, false, "Parser Error: Expected parameter name.", true)
+	var status := plugin.get_game_status(plugin._game_run_started_msec)
+	assert_eq(status.status, "break")
+	assert_eq(status["break"].reason, "Parser Error: Expected parameter name.")
+	plugin._on_script_debugger_breaked(false, false, "", false)
+	assert_eq(plugin.get_game_status(plugin._game_run_started_msec).status, "launching")
+
+
+func test_debugger_plugin_explain_not_live_break_instructs_stop() -> void:
+	var plugin := McpDebuggerPlugin.new()
+	plugin.begin_game_run(0, true)
+	plugin.note_debug_break(false, "Parser Error: Expected parameter name.")
+	var status := plugin.get_game_status(plugin._game_run_started_msec)
+
+	var err := plugin._explain_not_live(status, ErrorCodes.INTERNAL_ERROR)
+
+	assert_contains(err.error.message, "frozen at a debugger break")
+	assert_contains(err.error.message, "Parser Error: Expected parameter name.")
+	assert_contains(err.error.message, "project_manage(op='stop')")
+	assert_eq(err.error.data.game_status.status, "break")
+
+
+func test_debugger_plugin_explain_not_live_post_live_break_suggests_resume() -> void:
+	var plugin := McpDebuggerPlugin.new()
+	plugin.begin_game_run(0, true)
+	plugin._capture("mcp:hello", [], -1)
+	plugin.note_debug_break(true, "Breakpoint")
+	var status := plugin.get_game_status()
+
+	var err := plugin._explain_not_live(status, ErrorCodes.INTERNAL_ERROR)
+
+	assert_contains(err.error.message, "paused at a debugger break")
+	assert_contains(err.error.message, "Resume")
+	assert_false(err.error.message.contains("cannot become live"), "post-live breaks are resumable, not boot failures")
+
+
+func test_get_logs_source_editor_includes_synthetic_break_record() -> void:
+	## #645: run/game responses point at logs_read(source="editor") for the
+	## break record — it must actually be there despite having no Errors-tab
+	## row or Logger entry behind it.
+	var empty_tree := Tree.new()
+	empty_tree.create_item()
+	var tracker := McpSurfacedErrorTracker.new(null, null, empty_tree)
+	var plugin := McpDebuggerPlugin.new(null, null, null, tracker)
+	plugin.begin_game_run(0, true)
+	plugin.note_debug_break(false, "Parser Error: Expected parameter name.")
+	var frames: Array[Dictionary] = [{"path": "res://smoke_broken.gd", "line": 2, "function": ""}]
+	plugin.synthesize_break_error_record(frames)
+	var handler := EditorHandler.new(McpLogBuffer.new(), null, plugin, null, null, null, tracker)
+
+	var result := handler.get_logs({"source": "editor", "count": 10, "include_details": true})
+
+	assert_eq(result.data.lines.size(), 1)
+	assert_eq(result.data.lines[0].text, "Parser Error: Expected parameter name.")
+	assert_eq(result.data.lines[0].path, "res://smoke_broken.gd")
+	assert_eq(result.data.lines[0].line, 2)
+	assert_eq(result.data.lines[0].details.frames.size(), 1)
+	assert_false(result.data.lines[0].has("_debugger_key"), "promotion bookkeeping must not leak into responses")
+	assert_false(result.data.lines[0].has("_debugger_synthetic"), "promotion bookkeeping must not leak into responses")
+	empty_tree.free()
+
+
+func test_surfaced_error_tracker_record_synthetic_error_promotes_and_repromotes() -> void:
+	var empty_tree := Tree.new()
+	empty_tree.create_item()
+	var tracker := McpSurfacedErrorTracker.new(null, null, empty_tree)
+	var entry := {
+		"source": "editor",
+		"level": "error",
+		"text": "Parser Error: Expected parameter name.",
+		"path": "res://smoke_broken.gd",
+		"line": 2,
+		"function": "",
+	}
+	tracker.record_synthetic_error(entry)
+	assert_eq(tracker.watermark(true).debugger_promoted, 1)
+	var captured := tracker.editor_entries_since(0, 0)
+	assert_eq(captured.entries.size(), 1)
+	assert_eq(captured.entries[0].text, "Parser Error: Expected parameter name.")
+
+	## A forced scan reconciles against the (empty) live tab; the synthetic
+	## record must survive it without eviction or double-counting.
+	tracker.refresh_debugger_errors(true)
+	assert_eq(tracker.watermark(true).debugger_promoted, 1)
+	assert_eq(tracker.editor_entries_since(0, 0).entries.size(), 1)
+
+	## The same failure on a later run re-promotes with a fresh sequence, so
+	## the new run's cursor still sees it as run-scoped.
+	tracker.note_game_run_started(true)
+	var cursor := tracker.debugger_promoted_total()
+	tracker.record_synthetic_error(entry)
+	assert_eq(tracker.watermark(true).debugger_promoted, 2)
+	var second_run := tracker.editor_entries_since(0, cursor)
+	assert_eq(second_run.entries.size(), 1, "re-recorded break must be visible past the prior run's cursor")
+	empty_tree.free()
+
+
 func test_debugger_plugin_ignores_hello_from_stale_session() -> void:
 	var game_buf := McpGameLogBuffer.new()
 	var plugin := McpDebuggerPlugin.new(null, game_buf)

--- a/test_project/tests/test_project.gd
+++ b/test_project/tests/test_project.gd
@@ -352,6 +352,21 @@ func test_run_project_already_running_break_message_instructs_stop() -> void:
 	assert_contains(message, "project_manage(op='stop')")
 
 
+func test_run_project_already_running_break_message_labels_retained_errors() -> void:
+	## Parity with the "not_live" already-running case: a retained error is
+	## still worth naming, with the may-predate caveat, instead of dropping it.
+	var err := {"text": "Parse Error: Old", "path": "res://old.gd", "line": 2}
+	var decision := _handler._run_project_liveness_decision(
+		_break_status(1200),
+		_errors_info([err], "retained_recent")
+	)
+	var message := _handler._run_project_already_running_message(decision)
+	assert_contains(message, "parked at a debugger break")
+	assert_contains(message, "may predate this run")
+	assert_contains(message, "res://old.gd:2")
+	assert_contains(message, "project_manage(op='stop')")
+
+
 func test_run_project_liveness_decision_not_live_without_errors_is_soft() -> void:
 	var decision := _handler._run_project_liveness_decision(_run_status("not_live", 3000), _errors_info())
 	assert_eq(decision.resolve, true)

--- a/test_project/tests/test_project.gd
+++ b/test_project/tests/test_project.gd
@@ -291,6 +291,67 @@ func test_run_project_liveness_decision_retained_error_does_not_short_circuit_la
 	assert_eq(decision.recent_errors_may_predate_run, true)
 
 
+func _break_status(elapsed_msec: int, pre_live: bool = true, reason: String = "Parser Error: Expected parameter name.") -> Dictionary:
+	var status := _run_status("break", elapsed_msec)
+	status["break"] = {"reason": reason, "can_debug": not pre_live, "pre_live": pre_live}
+	return status
+
+
+func test_run_project_liveness_decision_break_waits_for_record_inside_window() -> void:
+	## #645: the synthesized break record lands a moment after the break signal
+	## (stack frames arrive async) — hold the reply so it can name the script.
+	var decision := _handler._run_project_liveness_decision(_break_status(800), _errors_info())
+	assert_eq(decision.resolve, false)
+	assert_eq(decision.liveness_status, "break")
+	assert_contains(decision.message, "frozen at a debugger break")
+
+
+func test_run_project_liveness_decision_break_with_record_resolves() -> void:
+	var err := {"text": "Parser Error: Expected parameter name.", "path": "res://smoke_broken.gd", "line": 2}
+	var decision := _handler._run_project_liveness_decision(
+		_break_status(1200),
+		_errors_info([err], "run")
+	)
+	assert_eq(decision.resolve, true)
+	assert_eq(decision.liveness_status, "break")
+	assert_contains(decision.message, "frozen at a debugger break")
+	assert_contains(decision.message, "res://smoke_broken.gd:2")
+	assert_contains(decision.message, "project_manage(op='stop')")
+	assert_contains(decision.message, "logs_read(source='editor'")
+	assert_eq(decision.recent_errors_scope, "run")
+
+
+func test_run_project_liveness_decision_break_falls_back_to_reason_after_window() -> void:
+	var decision := _handler._run_project_liveness_decision(_break_status(3000), _errors_info())
+	assert_eq(decision.resolve, true)
+	assert_eq(decision.liveness_status, "break")
+	assert_contains(decision.message, "Parser Error: Expected parameter name.")
+	assert_contains(decision.message, "project_manage(op='stop')")
+
+
+func test_run_project_liveness_decision_post_live_break_resolves_softly() -> void:
+	var decision := _handler._run_project_liveness_decision(
+		_break_status(500, false, "Breakpoint"),
+		_errors_info()
+	)
+	assert_eq(decision.resolve, true)
+	assert_contains(decision.message, "paused at a debugger break")
+	assert_false(decision.message.contains("cannot continue"), "post-live breaks are resumable and must not be framed as boot failures")
+
+
+func test_run_project_already_running_break_message_instructs_stop() -> void:
+	var err := {"text": "Parser Error: Expected parameter name.", "path": "res://smoke_broken.gd", "line": 2}
+	var decision := _handler._run_project_liveness_decision(
+		_break_status(1200),
+		_errors_info([err], "run")
+	)
+	var message := _handler._run_project_already_running_message(decision)
+	assert_contains(message, "already running")
+	assert_contains(message, "parked at a debugger break")
+	assert_contains(message, "res://smoke_broken.gd:2")
+	assert_contains(message, "project_manage(op='stop')")
+
+
 func test_run_project_liveness_decision_not_live_without_errors_is_soft() -> void:
 	var decision := _handler._run_project_liveness_decision(_run_status("not_live", 3000), _errors_info())
 	assert_eq(decision.resolve, true)


### PR DESCRIPTION
Fixes #645.

## Problem

On Godot 4.6.3, an editor-launched game that hits a GDScript parse error during boot (broken scene-node script or autoload) calls `GDScriptLanguage::debug_break_parse` and freezes in a remote-debugger break **before the game helper goes live**. No record reaches any MCP surface — no Errors-tab row, no editor Logger entry, no game-log line — so `project_run` resolved `not_live` with the generic "may still be booting or may have failed silently" message. The error text existed only in the Debugger's Stack Trace panel. (Found in the #642 live smoke; this was the core #641 flavor that remained unreachable.)

## Feasibility spike (phase 1)

Empirically established on 4.6.3, driving the break with the issue's repro (`func f(:` attached to a `main.tscn` node):

- `EditorDebuggerSession.breaked(can_debug)` carries **no reason text** (`can_debug=false` for parse errors), but the underlying `ScriptEditorDebugger` node's own `breaked(reallydid, can_debug, reason, has_stackdump)` signal — located by walking the editor UI, same approach as the existing Errors-tab scrape — delivers the full `"Parser Error: Expected parameter name."` ~4 ms later. So: signal, not scrape, for the reason.
- Stack frames are not exposed by any session API, but the Stack Trace `Tree` rows carry locale-independent metadata dicts `{frame, file, function, line}`. The panel is **empty at signal time** and populated by ~0.5 s (the editor requests the stack dump separately), so frames are scraped on short timers.
- The break fires at ~0.7 s with `game_ready=false` — well before the helper hello, and the game reuses the debugger session created at plugin load, so signal connections made in `_setup_session` persist across runs.

## Implementation (phase 2)

**`McpDebuggerPlugin`**
- Connects `session.breaked`/`continued` per session plus `ScriptEditorDebugger.breaked` for the reason text; tracks break state (`reason`, `can_debug`, `pre_live`), cleared on continue/run-end/new-run.
- On a **pre-live** break, scrapes the Stack Trace panel at 0.5 s / 2 s and synthesizes an Errors-tab-shaped record via the new `McpSurfacedErrorTracker.record_synthetic_error`, joining the same promoted sequence as scraped Debugger rows — so run-scoping, `logs_read(source="editor")`, the retained fallback, and the response watermark all surface it with no extra plumbing.
- `game_status` gains **`status="break"`** (takes precedence over `"live"`; `helper_live=false`, `session_active=true`) with `break={reason, can_debug, pre_live}`.
- Game-tool ready-wait loops bail out early on a break — a parked game never beacons. `game_manage(op="get_scene_tree")` against a parked game went from an opaque **15 s timeout to ~65 ms** with the actionable break error.

**`project_handler`**
- The liveness decision resolves a pre-live break once the synthesized record correlates (ready window as fallback), naming the failing script and instructing `project_manage(op="stop")`. Policy per the issue: **report + leave the game parked**. Post-live breaks (user breakpoints) get resumable wording instead of boot-failure framing.

**Docs**: `docs/TOOLS.md` status list, `project_run`/`editor_state` docstrings.

## Two bugs the live smoke caught that unit tests could not

1. The synthesized record was missing from `logs_read(source="editor")` — `collect_editor_log_entries` read only the Logger ring + live Errors tab. Fixed by merging synthetic promoted entries (promotion bookkeeping keys stripped from responses).
2. The break early-exit made the not-ready error reply **synchronous**, but the dispatcher registers a deferred request only *after* the handler returns `DEFERRED_RESPONSE` — the reply was dropped as `expired` and the server timed out at 15 s. Fixed by yielding one `process_frame` before any reply in the three wait coroutines.

## Live verification (Godot 4.6.3, macOS)

Repro loop run end-to-end twice (fresh editor per plugin build, raw streamable-http driver, session verified via `session_manage`):

- `project_run` resolves at ~1.2 s with `game_status.status="break"`, `break.reason="Parser Error: Expected parameter name."`, run-scoped `recent_errors` carrying `res://smoke_broken.gd:2` + frames, and the stop instruction in `reason`.
- `editor_state` and `logs_read(source="game")` report `status="break"` (game hint names the parse error); `logs_read(source="editor", include_details=true)` shows the synthesized record with frames and no `_debugger_*` leaks.
- `project_manage(op="stop")` recovers cleanly (`stopped=true`, status → `"stopped"`).

## Tests

- 17 new GDScript tests (break state machine, precedence over live, signal-notice merge, record synthesis ± frames, post-live non-synthesis, clear-on-continue/run-end, `_explain_not_live` wording, tracker promote/re-promote/refresh-survival, `logs_read` inclusion, liveness-decision branches, already-running message). Full suite: **1631 passed, 0 failed**.
- Python: **1255 passed** (docstring-only changes; `project_run`/`editor_state`/`logs_read` responses pass plugin fields through).
- Headless `--import` parse check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer handling for projects paused by a debugger break, including more detailed status metadata and targeted stop/resume/relaunch guidance.
* **Bug Fixes**
  * Prevented screenshot, eval, and command requests from hanging while the game is paused at a break.
  * Improved break-state precedence and synthetic error promotion so break-related issues surface reliably.
* **Documentation**
  * Updated tool help/docs to explain the new `break` status and recommended next steps.
* **Tests**
  * Expanded coverage for boot-time debugger breaks, synthetic error promotion, and break-state lifecycle/clearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->