### PR TITLE
Allow dock body to scroll vertically

### DIFF
--- a/plugin/addons/godot_ai/dock_panels/log_viewer.gd
+++ b/plugin/addons/godot_ai/dock_panels/log_viewer.gd
@@ -43,7 +43,6 @@ func setup(log_buffer: McpLogBuffer) -> void:
 
 
 func _build_ui() -> void:
-	size_flags_vertical = Control.SIZE_EXPAND_FILL
 	add_child(HSeparator.new())
 
 	var log_header_row := HBoxContainer.new()
@@ -62,8 +61,7 @@ func _build_ui() -> void:
 	add_child(log_header_row)
 
 	_log_display = RichTextLabel.new()
-	_log_display.size_flags_vertical = Control.SIZE_EXPAND_FILL
-	_log_display.custom_minimum_size = Vector2(0, 120)
+	_log_display.custom_minimum_size = Vector2(0, 80)
 	_log_display.scroll_following = true
 	_log_display.bbcode_enabled = false
 	_log_display.selection_enabled = true

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -527,6 +527,7 @@ func _build_ui() -> void:
 	add_child(_install_label)
 
 	_body_scroll = ScrollContainer.new()
+	_body_scroll.name = "DockBodyScroll"
 	_body_scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	_body_scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	_body_scroll.custom_minimum_size = Vector2(0, 48)
@@ -534,6 +535,7 @@ func _build_ui() -> void:
 	add_child(_body_scroll)
 
 	_body = VBoxContainer.new()
+	_body.name = "DockBody"
 	_body.add_theme_constant_override("separation", 8)
 	_body.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	_body_scroll.add_child(_body)

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -67,6 +67,8 @@ var _plugin: EditorPlugin
 var _redock_btn: Button
 var _status_icon: ColorRect
 var _status_label: Label
+var _body_scroll: ScrollContainer
+var _body: VBoxContainer
 var _client_grid: VBoxContainer
 var _client_configure_all_btn: Button
 var _client_empty_cta_btn: Button
@@ -524,6 +526,18 @@ func _build_ui() -> void:
 	_install_label.mouse_filter = Control.MOUSE_FILTER_STOP
 	add_child(_install_label)
 
+	_body_scroll = ScrollContainer.new()
+	_body_scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_body_scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	_body_scroll.custom_minimum_size = Vector2(0, 48)
+	_body_scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+	add_child(_body_scroll)
+
+	_body = VBoxContainer.new()
+	_body.add_theme_constant_override("separation", 8)
+	_body.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_body_scroll.add_child(_body)
+
 	# --- Spawn-failure panel (shown when `_start_server` reports a non-OK
 	# state via `get_server_status`). One body paragraph + the matching
 	# action; the top status label already carries the state headline.
@@ -570,7 +584,7 @@ func _build_ui() -> void:
 	_crash_panel.add_child(_crash_docs_btn)
 
 	_crash_panel.add_child(HSeparator.new())
-	add_child(_crash_panel)
+	_body.add_child(_crash_panel)
 
 	_build_mixed_state_banner()
 	_refresh_mixed_state_banner()
@@ -608,20 +622,20 @@ func _build_ui() -> void:
 	_update_banner.add_child(update_btn_row)
 	_update_banner.add_child(HSeparator.new())
 
-	add_child(_update_banner)
+	_body.add_child(_update_banner)
 
 	if _update_manager == null:
 		_update_manager = UpdateManagerScript.new()
 		_update_manager.setup(_plugin, self)
 		_update_manager.update_check_completed.connect(_on_update_check_result)
 		_update_manager.install_state_changed.connect(_on_install_state_changed)
-		add_child(_update_manager)
+		_body.add_child(_update_manager)
 	_update_manager.check_for_updates.call_deferred()
 
 	# --- Dev-only connection extras (server label + reload button) ---
 	_dev_section = VBoxContainer.new()
 	_dev_section.add_theme_constant_override("separation", 6)
-	add_child(_dev_section)
+	_body.add_child(_dev_section)
 
 	_server_label = Label.new()
 	_server_label.add_theme_color_override("font_color", COLOR_MUTED)
@@ -643,7 +657,7 @@ func _build_ui() -> void:
 	# --- Setup section (dev-only or when uv missing) ---
 	_setup_section = VBoxContainer.new()
 	_setup_section.add_theme_constant_override("separation", 6)
-	add_child(_setup_section)
+	_body.add_child(_setup_section)
 
 	_setup_section.add_child(HSeparator.new())
 	_setup_section.add_child(_make_header("Setup"))
@@ -651,7 +665,7 @@ func _build_ui() -> void:
 	_setup_container.add_theme_constant_override("separation", 6)
 	_setup_section.add_child(_setup_container)
 
-	add_child(HSeparator.new())
+	_body.add_child(HSeparator.new())
 
 	# --- Clients ---
 	var clients_header_row := HBoxContainer.new()
@@ -683,8 +697,8 @@ func _build_ui() -> void:
 	clients_open_btn.pressed.connect(_on_open_clients_window)
 	clients_actions.add_child(clients_open_btn)
 
-	add_child(clients_header_row)
-	add_child(clients_actions)
+	_body.add_child(clients_header_row)
+	_body.add_child(clients_actions)
 
 	_client_empty_cta_btn = Button.new()
 	_client_empty_cta_btn.text = "Configure an AI client ->"
@@ -692,7 +706,7 @@ func _build_ui() -> void:
 	_client_empty_cta_btn.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	_client_empty_cta_btn.visible = false
 	_client_empty_cta_btn.pressed.connect(_on_open_clients_window)
-	add_child(_client_empty_cta_btn)
+	_body.add_child(_client_empty_cta_btn)
 
 	# Drift banner — hidden until a sweep finds at least one mismatched client.
 	_drift_banner = VBoxContainer.new()
@@ -708,7 +722,7 @@ func _build_ui() -> void:
 	drift_btn.tooltip_text = "Re-run Configure on every client whose stored URL doesn't match the current server URL."
 	drift_btn.pressed.connect(_on_reconfigure_mismatched)
 	_drift_banner.add_child(drift_btn)
-	add_child(_drift_banner)
+	_body.add_child(_drift_banner)
 
 	_clients_window = Window.new()
 	_clients_window.title = "Godot AI"
@@ -757,7 +771,7 @@ func _build_ui() -> void:
 
 	_build_tools_tab(tabs)
 
-	add_child(HSeparator.new())
+	_body.add_child(HSeparator.new())
 
 	# --- Dev mode toggle (always visible) ---
 	var dev_toggle_row := HBoxContainer.new()
@@ -770,13 +784,13 @@ func _build_ui() -> void:
 	_dev_mode_toggle.button_pressed = _load_dev_mode()
 	_dev_mode_toggle.toggled.connect(_on_dev_mode_toggled)
 	dev_toggle_row.add_child(_dev_mode_toggle)
-	add_child(dev_toggle_row)
+	_body.add_child(dev_toggle_row)
 
 	# --- Log section (dev-only) ---
 	_log_viewer = LogViewerScript.new()
 	_log_viewer.setup(_log_buffer)
 	_log_viewer.logging_enabled_changed.connect(_on_log_logging_enabled_changed)
-	add_child(_log_viewer)
+	_body.add_child(_log_viewer)
 
 	# Apply initial dev-mode visibility
 	_apply_dev_mode_visibility()
@@ -1095,7 +1109,7 @@ func _build_mixed_state_banner() -> void:
 	_mixed_state_banner.add_child(_mixed_state_rescan_btn)
 
 	_mixed_state_banner.add_child(HSeparator.new())
-	add_child(_mixed_state_banner)
+	_body.add_child(_mixed_state_banner)
 
 
 func _refresh_mixed_state_banner(force: bool = false) -> void:

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -139,18 +139,18 @@ func test_clients_header_and_actions_use_narrow_layout() -> void:
 		TextServer.OVERRUN_TRIM_ELLIPSIS,
 		"Summary count should use ellipsis overrun")
 
-	var body_scroll := _dock.find_child("DockBodyScroll", false, false) as ScrollContainer
-	assert_true(body_scroll != null,
-		"Scrollable body should keep lower dock rows from forcing minimum height")
-	assert_eq(body_scroll.horizontal_scroll_mode, ScrollContainer.SCROLL_MODE_DISABLED,
-		"Dock body should wrap horizontally instead of showing a sideways scrollbar")
 	var body := clients_header_row.get_parent() as VBoxContainer
 	assert_true(body != null,
 		"Dock body should own regular rows while status/install stay pinned")
 	assert_eq(body.name, "DockBody",
 		"Clients header row should live inside the scrollable dock body")
-	assert_true(body.get_parent() == body_scroll,
+	var body_scroll := body.get_parent() as ScrollContainer
+	assert_true(body_scroll != null,
+		"Scrollable body should keep lower dock rows from forcing minimum height")
+	assert_eq(body_scroll.name, "DockBodyScroll",
 		"Dock body should live inside the scroll container")
+	assert_eq(body_scroll.horizontal_scroll_mode, ScrollContainer.SCROLL_MODE_DISABLED,
+		"Dock body should wrap horizontally instead of showing a sideways scrollbar")
 
 	var header_idx := body.get_children().find(clients_header_row)
 	assert_gt(header_idx, -1, "Clients header row should be a scroll-body child")

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -144,11 +144,13 @@ func test_clients_header_and_actions_use_narrow_layout() -> void:
 		"Scrollable body should keep lower dock rows from forcing minimum height")
 	assert_eq(body_scroll.horizontal_scroll_mode, ScrollContainer.SCROLL_MODE_DISABLED,
 		"Dock body should wrap horizontally instead of showing a sideways scrollbar")
-	var body := body_scroll.find_child("DockBody", false, false) as VBoxContainer
+	var body := clients_header_row.get_parent() as VBoxContainer
 	assert_true(body != null,
 		"Dock body should own regular rows while status/install stay pinned")
-	assert_true(clients_header_row.get_parent() == body,
+	assert_eq(body.name, "DockBody",
 		"Clients header row should live inside the scrollable dock body")
+	assert_true(body.get_parent() == body_scroll,
+		"Dock body should live inside the scroll container")
 
 	var header_idx := body.get_children().find(clients_header_row)
 	assert_gt(header_idx, -1, "Clients header row should be a scroll-body child")

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -147,8 +147,6 @@ func test_clients_header_and_actions_use_narrow_layout() -> void:
 	var body_scroll := body.get_parent() as ScrollContainer
 	assert_true(body_scroll != null,
 		"Scrollable body should keep lower dock rows from forcing minimum height")
-	assert_eq(body_scroll.name, "DockBodyScroll",
-		"Dock body should live inside the scroll container")
 	assert_eq(body_scroll.horizontal_scroll_mode, ScrollContainer.SCROLL_MODE_DISABLED,
 		"Dock body should wrap horizontally instead of showing a sideways scrollbar")
 

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -139,20 +139,22 @@ func test_clients_header_and_actions_use_narrow_layout() -> void:
 		TextServer.OVERRUN_TRIM_ELLIPSIS,
 		"Summary count should use ellipsis overrun")
 
-	assert_true(_dock._body_scroll is ScrollContainer,
+	var body_scroll := _dock.find_child("DockBodyScroll", false, false) as ScrollContainer
+	assert_true(body_scroll != null,
 		"Scrollable body should keep lower dock rows from forcing minimum height")
-	assert_eq(_dock._body_scroll.horizontal_scroll_mode, ScrollContainer.SCROLL_MODE_DISABLED,
+	assert_eq(body_scroll.horizontal_scroll_mode, ScrollContainer.SCROLL_MODE_DISABLED,
 		"Dock body should wrap horizontally instead of showing a sideways scrollbar")
-	assert_true(_dock._body is VBoxContainer,
+	var body := body_scroll.find_child("DockBody", false, false) as VBoxContainer
+	assert_true(body != null,
 		"Dock body should own regular rows while status/install stay pinned")
-	assert_true(clients_header_row.get_parent() == _dock._body,
+	assert_true(clients_header_row.get_parent() == body,
 		"Clients header row should live inside the scrollable dock body")
 
-	var header_idx := _dock._body.get_children().find(clients_header_row)
+	var header_idx := body.get_children().find(clients_header_row)
 	assert_gt(header_idx, -1, "Clients header row should be a scroll-body child")
-	assert_true(header_idx + 1 < _dock._body.get_child_count(),
+	assert_true(header_idx + 1 < body.get_child_count(),
 		"Clients actions row should follow the header row")
-	var clients_actions := _dock._body.get_child(header_idx + 1)
+	var clients_actions := body.get_child(header_idx + 1)
 	assert_true(clients_actions is HFlowContainer,
 		"Client actions should wrap in an HFlowContainer")
 	var actions_flow := clients_actions as HFlowContainer

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -139,11 +139,20 @@ func test_clients_header_and_actions_use_narrow_layout() -> void:
 		TextServer.OVERRUN_TRIM_ELLIPSIS,
 		"Summary count should use ellipsis overrun")
 
-	var header_idx := _dock.get_children().find(clients_header_row)
-	assert_gt(header_idx, -1, "Clients header row should be a direct dock child")
-	assert_true(header_idx + 1 < _dock.get_child_count(),
+	assert_true(_dock._body_scroll is ScrollContainer,
+		"Scrollable body should keep lower dock rows from forcing minimum height")
+	assert_eq(_dock._body_scroll.horizontal_scroll_mode, ScrollContainer.SCROLL_MODE_DISABLED,
+		"Dock body should wrap horizontally instead of showing a sideways scrollbar")
+	assert_true(_dock._body is VBoxContainer,
+		"Dock body should own regular rows while status/install stay pinned")
+	assert_true(clients_header_row.get_parent() == _dock._body,
+		"Clients header row should live inside the scrollable dock body")
+
+	var header_idx := _dock._body.get_children().find(clients_header_row)
+	assert_gt(header_idx, -1, "Clients header row should be a scroll-body child")
+	assert_true(header_idx + 1 < _dock._body.get_child_count(),
 		"Clients actions row should follow the header row")
-	var clients_actions := _dock.get_child(header_idx + 1)
+	var clients_actions := _dock._body.get_child(header_idx + 1)
 	assert_true(clients_actions is HFlowContainer,
 		"Client actions should wrap in an HFlowContainer")
 	var actions_flow := clients_actions as HFlowContainer


### PR DESCRIPTION
## Summary

- Put the Godot AI dock’s lower content into a vertical `ScrollContainer` so the editor dock can be resized smaller vertically.
- Keep the status row and install-mode label pinned outside the scroll area.
- Keep the MCP log as a bounded internally scrolling pane, reducing its minimum height from 120px to 80px.
- Update dock layout tests to assert the scroll-body structure and disabled horizontal scrolling.

## Tests

- `bash script/ci-check-gdscript`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Updated the dock to wrap its main panels in a scrollable body region, keeping key sections within a single scrollable layout.
  * Made the log viewer more compact by reducing the displayed area’s minimum height.
* **Tests**
  * Updated dock tests to validate the new scrollable structure, including locating the “Clients” header/actions relative to the scrollable body.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->