### PR TITLE
Add client config file shortcuts

### DIFF
--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -366,6 +366,11 @@ static func manual_command(id: String) -> String:
 	return ManualCommand.build(client, SERVER_NAME, http_url(), client.resolved_config_path())
 
 
+static func config_path(id: String) -> String:
+	var client := ClientRegistry.get_by_id(id)
+	return client.resolved_config_path() if client != null else ""
+
+
 static func is_installed(id: String) -> bool:
 	var client := ClientRegistry.get_by_id(id)
 	return client != null and client.is_installed()

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -95,7 +95,7 @@ var _telemetry_pending_enabled: bool = true
 var _telemetry_saved_enabled: bool = true
 
 ## Per-client UI handles, keyed by client id. Each entry holds the row's
-## status dot, configure button, remove button, manual-command panel + text.
+## status dot, configure/remove buttons, config-file buttons, and manual panel.
 var _client_rows: Dictionary = {}
 
 # Drift banner — surfaced near the Clients section when one or more clients
@@ -727,7 +727,7 @@ func _build_ui() -> void:
 	_body.add_child(_drift_banner)
 
 	_clients_window = Window.new()
-	_clients_window.title = "Godot AI"
+	_clients_window.title = "Godot AI Settings"
 	## `Vector2i * float` yields Vector2; wrap the result back to Vector2i.
 	_clients_window.min_size = Vector2i(Vector2(560, 460) * EditorInterface.get_editor_scale())
 	_clients_window.visible = false
@@ -847,6 +847,21 @@ func _build_client_row(client_id: String) -> void:
 	remove_btn.pressed.connect(_on_remove_client.bind(client_id))
 	row.add_child(remove_btn)
 
+	var config_path := ClientConfigurator.config_path(client_id)
+	var open_config_btn := Button.new()
+	_apply_editor_icon(open_config_btn, "ExternalLink", "Open")
+	open_config_btn.custom_minimum_size = Vector2(28, 28)
+	open_config_btn.visible = not config_path.is_empty()
+	open_config_btn.pressed.connect(_on_open_config_file.bind(client_id))
+	row.add_child(open_config_btn)
+
+	var reveal_btn := Button.new()
+	_apply_editor_icon(reveal_btn, "Folder", "Reveal")
+	reveal_btn.custom_minimum_size = Vector2(28, 28)
+	reveal_btn.visible = not config_path.is_empty()
+	reveal_btn.pressed.connect(_on_reveal_config_folder.bind(client_id))
+	row.add_child(reveal_btn)
+
 	_client_grid.add_child(row)
 
 	var manual_panel := VBoxContainer.new()
@@ -877,9 +892,20 @@ func _build_client_row(client_id: String) -> void:
 		"name_label": name_label,
 		"configure_btn": configure_btn,
 		"remove_btn": remove_btn,
+		"open_config_btn": open_config_btn,
+		"reveal_btn": reveal_btn,
+		"config_path": config_path,
 		"manual_panel": manual_panel,
 		"manual_text": manual_text,
 	}
+	_refresh_client_config_file_buttons(client_id)
+
+
+func _apply_editor_icon(button: Button, icon_name: String, fallback_text: String) -> void:
+	if has_theme_icon(icon_name, "EditorIcons"):
+		button.icon = get_theme_icon(icon_name, "EditorIcons")
+	else:
+		button.text = fallback_text
 
 
 # --- Status updates ---
@@ -2246,6 +2272,37 @@ func _on_copy_manual_command(client_id: String) -> void:
 	DisplayServer.clipboard_set(row["manual_text"].text)
 
 
+func _on_open_config_file(client_id: String) -> void:
+	var path := _client_config_path_for_row(client_id)
+	if path.is_empty():
+		return
+	if FileAccess.file_exists(path):
+		OS.shell_open(path)
+		return
+	_reveal_config_folder(path)
+
+
+func _on_reveal_config_folder(client_id: String) -> void:
+	var path := _client_config_path_for_row(client_id)
+	if path.is_empty():
+		return
+	_reveal_config_folder(path)
+
+
+func _client_config_path_for_row(client_id: String) -> String:
+	var row: Dictionary = _client_rows.get(client_id, {})
+	if row.is_empty():
+		return ""
+	return String(row.get("config_path", ""))
+
+
+func _reveal_config_folder(path: String) -> void:
+	var dir := path.get_base_dir()
+	if dir.is_empty():
+		return
+	OS.shell_open(dir)
+
+
 func _refresh_all_client_statuses() -> void:
 	## Compatibility wrapper for older explicit call sites. Treat this as a manual
 	## refresh: it bypasses focus-in cooldown but still runs probes off the editor
@@ -2698,6 +2755,7 @@ func _apply_row_status(
 	var remove_btn: Button = row["remove_btn"]
 	var name_label: Label = row["name_label"]
 	var base_name := ClientConfigurator.client_display_name(client_id)
+	_refresh_client_config_file_buttons(client_id)
 	match status:
 		Client.Status.CONFIGURED:
 			dot.color = Color.GREEN
@@ -2722,6 +2780,26 @@ func _apply_row_status(
 			configure_btn.text = "Retry"
 			remove_btn.visible = false
 			name_label.text = "%s — %s" % [base_name, error_msg] if not error_msg.is_empty() else base_name
+
+
+func _refresh_client_config_file_buttons(client_id: String) -> void:
+	var row: Dictionary = _client_rows.get(client_id, {})
+	if row.is_empty():
+		return
+	var config_path := String(row.get("config_path", ""))
+	var has_path := not config_path.is_empty()
+	var open_config_btn: Button = row["open_config_btn"]
+	var reveal_btn: Button = row["reveal_btn"]
+	open_config_btn.visible = has_path
+	reveal_btn.visible = has_path
+	open_config_btn.disabled = not has_path
+	reveal_btn.disabled = not has_path
+	if has_path:
+		open_config_btn.tooltip_text = "Open config file:\n%s" % config_path
+		reveal_btn.tooltip_text = "Reveal in folder:\n%s" % config_path.get_base_dir()
+	else:
+		open_config_btn.tooltip_text = ""
+		reveal_btn.tooltip_text = ""
 
 
 # --- Update check & self-update ---

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -77,6 +77,29 @@ func test_every_client_has_required_fields() -> void:
 			assert_gt(client.toml_body_template.size(), 0, "%s toml client missing toml_body_template" % client.id)
 
 
+func test_config_path_facade_matches_client_descriptors() -> void:
+	for client in McpClientRegistry.all():
+		assert_eq(
+			McpClientConfigurator.config_path(client.id),
+			client.resolved_config_path(),
+			"%s config_path facade must mirror resolved_config_path" % client.id
+		)
+
+
+func test_config_path_facade_handles_unknown_and_file_clients() -> void:
+	assert_eq(McpClientConfigurator.config_path("__missing_client__"), "")
+	var cursor_path := McpClientConfigurator.config_path("cursor")
+	assert_false(cursor_path.is_empty(), "Cursor should expose a JSON config file path")
+	assert_true(cursor_path.ends_with("mcp.json"), "Cursor config should resolve to mcp.json, got %s" % cursor_path)
+
+
+func test_config_path_facade_returns_empty_for_pure_cli_client() -> void:
+	var client := McpClientRegistry.get_by_id("kimi_code")
+	assert_true(client != null, "kimi_code must remain registered as a pure CLI client")
+	assert_eq(client.config_type, "cli")
+	assert_eq(McpClientConfigurator.config_path("kimi_code"), "")
+
+
 func test_descriptors_are_data_only() -> void:
 	## #229 race-surface guard: every shipped descriptor must be pure data.
 	## A worker thread walking a Callable on a hot-reloadable per-client `.gd`

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -166,8 +166,8 @@ func test_clients_header_and_actions_use_narrow_layout() -> void:
 	var expected: Array[String] = ["Refresh", "Clients & Tools"]
 	assert_eq(button_texts, expected,
 		"Client action buttons should stay compact and keep their handlers")
-	assert_eq(_dock._clients_window.title, "Godot AI",
-		"Clients & Tools window should use the product context as its title")
+	assert_eq(_dock._clients_window.title, "Godot AI Settings",
+		"Clients & Tools window should title the settings surface with product context")
 	var tabs := _dock._clients_window.get_child(0) as TabContainer
 	assert_true(tabs != null, "Clients & Tools window should contain a tab container")
 	assert_eq(tabs.get_tab_title(0), "Clients")
@@ -406,6 +406,35 @@ func test_apply_row_status_renders_mismatch_as_amber_with_url_hint() -> void:
 		"Mismatched row must label itself so the user reads it as drift")
 	assert_eq((row["configure_btn"] as Button).text, "Reconfigure",
 		"Mismatched rows offer the same Reconfigure action as the banner")
+
+
+func test_client_rows_show_config_file_buttons_only_for_file_clients() -> void:
+	_dock._build_ui()
+	var file_id := "cursor"
+	if not _dock._client_rows.has(file_id):
+		skip("Cursor client not registered")
+		return
+	var file_row: Dictionary = _dock._client_rows[file_id]
+	var file_path := McpClientConfigurator.config_path(file_id)
+	assert_false(file_path.is_empty(), "Cursor should expose a config path")
+	assert_eq(String(file_row.get("config_path", "")), file_path)
+	assert_true((file_row["open_config_btn"] as Button).visible,
+		"File-based clients must show Open config file")
+	assert_true((file_row["reveal_btn"] as Button).visible,
+		"File-based clients must show Reveal in folder")
+	assert_contains((file_row["open_config_btn"] as Button).tooltip_text, file_path,
+		"Open tooltip should carry the full path without widening the row")
+
+	var cli_id := "kimi_code"
+	if not _dock._client_rows.has(cli_id):
+		skip("Pure CLI client not registered")
+		return
+	var cli_row: Dictionary = _dock._client_rows[cli_id]
+	assert_eq(String(cli_row.get("config_path", "")), "")
+	assert_false((cli_row["open_config_btn"] as Button).visible,
+		"Pure CLI clients should not show a dead Open config file button")
+	assert_false((cli_row["reveal_btn"] as Button).visible,
+		"Pure CLI clients should not show a dead Reveal in folder button")
 
 
 func test_incompatible_server_marks_clients_unhealthy() -> void:


### PR DESCRIPTION
## Summary

Adds per-client config file shortcuts in the Godot AI Settings window.

File-backed clients now show two compact icon buttons per row:

- Open config file
- Reveal in folder

Pure CLI clients without a config file path keep their existing manual-command panel and do not show dead config-file buttons.

## Details

- Adds `McpClientConfigurator.config_path(id)` as a small facade over each client descriptor’s `resolved_config_path()`.
- Caches each row’s config path at build time.
- Adds Open/Reveal icon buttons with full paths in tooltips to preserve row density.
- Uses `ExternalLink` for Open and `Folder` for Reveal.
- Uses `OS.shell_open()` for both actions.
- If the config file does not exist yet, Open falls back to revealing the parent folder.
- Renames the secondary window title from `Godot AI` to `Godot AI Settings`.

## Screenshot

<img width="1030" height="726" alt="Screenshot 2026-07-07 212258" src="https://github.com/user-attachments/assets/6d8af1d7-3071-4ef5-8781-6a6cd1e2d94b" />


## Tests

- Added facade coverage in `test_clients.gd`.
- Added dock row assertions in `test_dock.gd`.
- Verified locally with:

```bash
bash script/ci-check-gdscript
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-client config-file actions in the Clients panel, including **Open** and **Reveal in folder** buttons for applicable clients.
  * Updated the secondary Clients & Tools window title to **Godot AI Settings**.

* **Bug Fixes**
  * Client rows now correctly show or hide config-file actions based on whether a config path exists.
  * Config-file details stay in sync as the list updates, improving reliability of the client UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->