### PR TITLE
Surface GDScript warnings that the error watermark silently dropped

### DIFF
--- a/plugin/addons/godot_ai/utils/editor_log_buffer.gd
+++ b/plugin/addons/godot_ai/utils/editor_log_buffer.gd
@@ -27,6 +27,7 @@ const MAX_LINES := 500
 
 var _mutex := Mutex.new()
 var _error_appended_total := 0
+var _warn_appended_total := 0
 
 
 func _init() -> void:
@@ -49,6 +50,8 @@ func append(level: String, text: String, path: String = "", line: int = 0, funct
 	_append_entry(entry)
 	if coerced_level == "error":
 		_error_appended_total += 1
+	elif coerced_level == "warn":
+		_warn_appended_total += 1
 	_mutex.unlock()
 
 
@@ -107,10 +110,18 @@ func error_appended_total() -> int:
 	return n
 
 
+func warn_appended_total() -> int:
+	_mutex.lock()
+	var n := _warn_appended_total
+	_mutex.unlock()
+	return n
+
+
 func clear() -> int:
 	_mutex.lock()
 	var n := _total_count_unlocked()
 	_clear_storage()
 	_error_appended_total = 0
+	_warn_appended_total = 0
 	_mutex.unlock()
 	return n

--- a/plugin/addons/godot_ai/utils/game_log_buffer.gd
+++ b/plugin/addons/godot_ai/utils/game_log_buffer.gd
@@ -65,6 +65,13 @@ func error_total() -> int:
 	return _error_total
 
 
+## Warn-level lines for the current run: the combined error+warn tally minus
+## the error-only tally. Feeds the `game_warn` watermark component so a run
+## that only emitted push_warning is no longer reported as clean.
+func warn_total() -> int:
+	return _error_warn_total - _error_total
+
+
 func get_run_range(run_id: String, offset: int, count: int) -> Array[Dictionary]:
 	return get_run_page(run_id, offset, count).entries
 

--- a/plugin/addons/godot_ai/utils/surfaced_error_tracker.gd
+++ b/plugin/addons/godot_ai/utils/surfaced_error_tracker.gd
@@ -155,7 +155,15 @@ func watermark(force_debugger_scan: bool = false) -> Dictionary:
 		"run_seq": _run_seq,
 		"editor_ring": _error_appended_total(),
 		"debugger_promoted": _debugger_promoted_total,
+		## Historically misnamed: carries game-process ERROR counts only.
 		"game_error_warn": _game_error_total(),
+		## Warn-level components, parallel to the error counts above. The server
+		## diffs these into `new_warnings_since_last_call` so a warning-only run
+		## surfaces instead of reading as clean. Debugger Errors-tab warning rows
+		## are not promoted here yet (buffers cover push_warning from the game and
+		## editor parse/@tool warnings) — tracked as a follow-up.
+		"editor_ring_warn": _warn_appended_total(),
+		"game_warn": _game_warn_total(),
 	}
 
 
@@ -502,6 +510,22 @@ func _game_error_total() -> int:
 		return 0
 	if _game_log_buffer.has_method("error_total"):
 		return int(_game_log_buffer.call("error_total"))
+	return 0
+
+
+func _warn_appended_total() -> int:
+	if _editor_log_buffer == null:
+		return 0
+	if _editor_log_buffer.has_method("warn_appended_total"):
+		return int(_editor_log_buffer.call("warn_appended_total"))
+	return 0
+
+
+func _game_warn_total() -> int:
+	if _game_log_buffer == null:
+		return 0
+	if _game_log_buffer.has_method("warn_total"):
+		return int(_game_log_buffer.call("warn_total"))
 	return 0
 
 

--- a/src/godot_ai/godot_client/client.py
+++ b/src/godot_ai/godot_client/client.py
@@ -192,18 +192,31 @@ class GodotClient:
 
         live_session = self.registry.get(session_id)
         pending_new_errors = live_session.pending_new_errors if live_session else 0
-        if surface_error_hints and pending_new_errors > 0:
+        pending_new_warnings = live_session.pending_new_warnings if live_session else 0
+        if surface_error_hints and (pending_new_errors > 0 or pending_new_warnings > 0):
             data = dict(response.data)
-            count = pending_new_errors
-            if live_session:
-                live_session.pending_new_errors = 0
-            data["new_errors_since_last_call"] = count
-            plural = "s" if count != 1 else ""
-            data["new_errors_hint"] = (
-                f"{count} new GDScript error{plural} since your last call. "
-                "Inspect with logs_read(source='editor', include_details=true) "
-                "and/or logs_read(source='game', include_details=true)."
-            )
+            if pending_new_errors > 0:
+                count = pending_new_errors
+                if live_session:
+                    live_session.pending_new_errors = 0
+                data["new_errors_since_last_call"] = count
+                plural = "s" if count != 1 else ""
+                data["new_errors_hint"] = (
+                    f"{count} new GDScript error{plural} since your last call. "
+                    "Inspect with logs_read(source='editor', include_details=true) "
+                    "and/or logs_read(source='game', include_details=true)."
+                )
+            if pending_new_warnings > 0:
+                wcount = pending_new_warnings
+                if live_session:
+                    live_session.pending_new_warnings = 0
+                data["new_warnings_since_last_call"] = wcount
+                wplural = "s" if wcount != 1 else ""
+                data["new_warnings_hint"] = (
+                    f"{wcount} new GDScript warning{wplural} since your last call. "
+                    "Inspect with logs_read(source='editor', include_details=true) "
+                    "and/or logs_read(source='game', include_details=true)."
+                )
             return data
 
         return response.data

--- a/src/godot_ai/handlers/editor.py
+++ b/src/godot_ai/handlers/editor.py
@@ -317,7 +317,12 @@ def _forward_error_watermark_stamp(result: dict, response: dict) -> None:
     first call after a broken launch is ``logs_read`` would never learn
     errors happened).
     """
-    for key in ("new_errors_since_last_call", "new_errors_hint"):
+    for key in (
+        "new_errors_since_last_call",
+        "new_errors_hint",
+        "new_warnings_since_last_call",
+        "new_warnings_hint",
+    ):
         if key in result:
             response[key] = result[key]
 

--- a/src/godot_ai/protocol/envelope.py
+++ b/src/godot_ai/protocol/envelope.py
@@ -40,6 +40,8 @@ class CommandResponse(BaseModel):
     ## deltas on Session.pending_new_errors and consumes them only when a
     ## user-facing success response can surface the hint.
     new_errors_since_last_call: int = 0
+    ## Parallel to new_errors_since_last_call for warning-level diagnostics.
+    new_warnings_since_last_call: int = 0
 
 
 class ErrorDetail(BaseModel):

--- a/src/godot_ai/sessions/registry.py
+++ b/src/godot_ai/sessions/registry.py
@@ -33,6 +33,13 @@ class Session:
     readiness: str = "ready"
     error_watermark: dict[str, int] = field(default_factory=dict)
     pending_new_errors: int = 0
+    ## Warnings ride a channel parallel to pending_new_errors: the plugin's
+    ## warn-level buffer counters accumulate here as a separate delta, consumed
+    ## once into `new_warnings_since_last_call` on the next surfaceable success
+    ## response. Kept distinct from errors so a warning-only run is reported
+    ## (it previously read as "clean" — the error-only watermark filter dropped
+    ## every warning).
+    pending_new_warnings: int = 0
     editor_pid: int = 0
     ## Which launcher tier the plugin resolved the Python server from —
     ## "dev_venv" | "uvx" | "system" | "unknown". Lets agents notice when a

--- a/src/godot_ai/transport/websocket.py
+++ b/src/godot_ai/transport/websocket.py
@@ -324,16 +324,36 @@ class GodotWebSocketServer:
             self._pending.pop(request.request_id, None)
 
 
-def _sync_error_watermark_for_session(session: Session, value: dict[str, int]) -> int:
-    """Update a session's error watermark and return newly observed errors.
+## Watermark components whose baseline resets each game run. The server may
+## never observe their zero between stop/start, so on an advanced run_seq the
+## current value is counted in full rather than diffed against a stale baseline.
+## `game_error_warn` is historically misnamed — it carries game-process ERROR
+## counts (see McpGameLogBuffer.error_total); `game_warn` is its warn-level
+## sibling.
+_PER_RUN_WATERMARK_KEYS = frozenset({"game_error_warn", "game_warn"})
 
-    Watermark components reset independently. When run_seq advances, the
-    per-run game component is counted in full because the server may never
-    observe its zero between stop/start. Editor and debugger components remain
+## Warn-level watermark components. Split out from error components so a
+## warning-only run surfaces as `new_warnings_since_last_call` instead of
+## reading as clean. Editor and game warn streams are independent processes
+## with no overlap, so their deltas sum (unlike the error path, where the game
+## buffer and Debugger Errors tab are two views of one stream).
+_WARN_WATERMARK_KEYS = frozenset({"editor_ring_warn", "game_warn"})
+
+
+def _sync_error_watermark_for_session(session: Session, value: dict[str, int]) -> int:
+    """Update a session's error watermark; return newly observed errors.
+
+    Also accumulates newly observed warnings onto ``session.pending_new_warnings``
+    as a parallel, independently-consumed channel (the return value stays the
+    error count for backward compatibility).
+
+    Watermark components reset independently. When run_seq advances, per-run
+    game components are counted in full because the server may never observe
+    their zero between stop/start. Editor and debugger components remain
     session-scoped monotonic deltas; a decrease is treated as a reset and the
     current component value is counted when above zero. The debugger and game
-    components overlap (both observe the running game's script errors), so
-    their deltas are combined with max(), not summed.
+    error components overlap (both observe the running game's script errors),
+    so their deltas are combined with max(), not summed.
     """
 
     updates: dict[str, int] = {}
@@ -356,14 +376,19 @@ def _sync_error_watermark_for_session(session: Session, value: dict[str, int]) -
         previous = session.error_watermark.get(key)
         if previous is not None:
             previous_int = max(0, int(previous))
-            if run_advanced and key == "game_error_warn":
+            if run_advanced and key in _PER_RUN_WATERMARK_KEYS:
                 deltas[key] = current
             elif current >= previous_int:
                 deltas[key] = current - previous_int
             else:
                 deltas[key] = current
-        elif run_advanced and key == "game_error_warn":
+        elif run_advanced and key in _PER_RUN_WATERMARK_KEYS:
             deltas[key] = current
+
+    ## Warnings first — pull them out before the error math so they can't be
+    ## conflated with the error total. Independent process streams, so sum.
+    new_warnings = sum(deltas.pop(key, 0) for key in _WARN_WATERMARK_KEYS)
+
     ## A running game's script errors surface twice: in the game log buffer
     ## (game_error_warn) and as Debugger Errors-tab rows (debugger_promoted).
     ## Those are alternate views of the same error stream — summing them
@@ -374,6 +399,7 @@ def _sync_error_watermark_for_session(session: Session, value: dict[str, int]) -
     new_total = overlap + sum(deltas.values())
     session.error_watermark.update(updates)
     session.pending_new_errors += new_total
+    session.pending_new_warnings += new_warnings
     return new_total
 
 

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -790,14 +790,17 @@ func test_game_log_buffer_error_warn_total_ignores_info_and_resets_per_run() -> 
 	buf.append("error", "boom")
 	assert_eq(buf.error_warn_total(), 2)
 	assert_eq(buf.error_total(), 1)
+	assert_eq(buf.warn_total(), 1, "warn_total is the warn-only slice of error_warn_total")
 	buf.clear_for_new_run()
 	assert_eq(buf.error_warn_total(), 0, "new game runs start a fresh error watermark")
 	assert_eq(buf.error_total(), 0, "new game runs start a fresh error-only watermark")
+	assert_eq(buf.warn_total(), 0, "new game runs start a fresh warn watermark")
 	buf.append("info", "chatty print")
 	buf.append("warn", "new run warning")
 	buf.append("error", "new run boom")
 	assert_eq(buf.error_warn_total(), 2)
 	assert_eq(buf.error_total(), 1)
+	assert_eq(buf.warn_total(), 1)
 
 
 func test_game_log_buffer_preserves_details() -> void:
@@ -1240,6 +1243,7 @@ func test_editor_log_buffer_append_and_get_range() -> void:
 	assert_eq(buf.total_count(), 2)
 	assert_eq(buf.appended_total(), 2)
 	assert_eq(buf.error_appended_total(), 1)
+	assert_eq(buf.warn_appended_total(), 1)
 
 
 func test_editor_log_buffer_unknown_level_coerces_to_info() -> void:
@@ -1353,13 +1357,16 @@ func test_editor_log_buffer_clear_resets_retained_counts_but_preserves_cursor() 
 	var buf := McpEditorLogBuffer.new()
 	for i in range(5):
 		buf.append("error", "n %d" % i)
+	buf.append("warn", "a warning")
 	var cursor := buf.appended_total()
+	assert_eq(buf.warn_appended_total(), 1)
 	var cleared := buf.clear()
-	assert_eq(cleared, 5, "clear() should report cleared count")
+	assert_eq(cleared, 6, "clear() should report cleared count")
 	assert_eq(buf.total_count(), 0)
 	assert_eq(buf.dropped_count(), 0)
 	assert_eq(buf.appended_total(), cursor, "clear() must not reset the cursor")
 	assert_eq(buf.error_appended_total(), 0, "clear() resets the retained error watermark")
+	assert_eq(buf.warn_appended_total(), 0, "clear() resets the retained warn watermark")
 
 
 func test_editor_log_buffer_get_since_reports_clear_truncation() -> void:
@@ -1563,7 +1570,7 @@ func test_surfaced_error_tracker_user_clear_then_recurrence_promotes() -> void:
 	tree.free()
 
 
-func test_surfaced_error_tracker_watermark_ignores_warnings() -> void:
+func test_surfaced_error_tracker_watermark_separates_errors_and_warnings() -> void:
 	var editor_buf := McpEditorLogBuffer.new()
 	editor_buf.append("warn", "save warning", "res://warn.gd", 2)
 	editor_buf.append("error", "parse error", "res://broken.gd", 4)
@@ -1574,9 +1581,15 @@ func test_surfaced_error_tracker_watermark_ignores_warnings() -> void:
 	var tree := _make_debugger_errors_tree()
 	var tracker := McpSurfacedErrorTracker.new(editor_buf, game_buf, tree)
 	var watermark := tracker.watermark(true)
+	## Error components count errors only (game_error_warn is a historical
+	## misnomer — it carries errors, not warnings).
 	assert_eq(watermark.editor_ring, 1)
 	assert_eq(watermark.game_error_warn, 1)
 	assert_eq(watermark.debugger_promoted, 1)
+	## Warnings now surface in their own components instead of being dropped —
+	## previously a warning-only run reported as clean.
+	assert_eq(watermark.editor_ring_warn, 1)
+	assert_eq(watermark.game_warn, 1)
 	tree.free()
 
 

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -476,6 +476,145 @@ class TestCommandRoundTrip:
         assert third["new_errors_since_last_call"] == 2
         await plugin.close()
 
+    async def test_warning_watermark_advance_injects_warning_hint_once(self, harness):
+        ## A push_warning during a run advances game_warn. It must surface as
+        ## new_warnings_since_last_call — the pre-fix watermark dropped every
+        ## warning, so a warning-only run read as clean.
+        plugin = await harness.connect_plugin(session_id="warn-watermark")
+        client = GodotClient(harness.server, harness.registry)
+
+        async def mock_handler():
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 1},
+                error_watermark={"run_seq": 1, "editor_ring": 0, "game_warn": 0},
+            )
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 2},
+                error_watermark={"run_seq": 1, "editor_ring": 0, "game_warn": 1},
+            )
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 3},
+                error_watermark={"run_seq": 1, "editor_ring": 0, "game_warn": 1},
+            )
+
+        handler_task = asyncio.create_task(mock_handler())
+        first = await client.send("get_editor_state")
+        second = await client.send("get_editor_state")
+        third = await client.send("get_editor_state")
+        await handler_task
+
+        assert "new_warnings_since_last_call" not in first
+        assert second["new_warnings_since_last_call"] == 1
+        assert "logs_read(source='editor'" in second["new_warnings_hint"]
+        ## Warnings are not errors — the error hint must stay absent.
+        assert "new_errors_since_last_call" not in second
+        assert "new_warnings_since_last_call" not in third
+        await plugin.close()
+
+    async def test_warning_and_error_watermark_surface_independently(self, harness):
+        ## Errors and warnings advancing in the same response each get their
+        ## own hint and count; neither is folded into the other.
+        plugin = await harness.connect_plugin(session_id="warn-and-err")
+        client = GodotClient(harness.server, harness.registry)
+
+        async def mock_handler():
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 1},
+                error_watermark={
+                    "run_seq": 1,
+                    "editor_ring": 0,
+                    "editor_ring_warn": 0,
+                },
+            )
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 2},
+                error_watermark={
+                    "run_seq": 1,
+                    "editor_ring": 1,
+                    "editor_ring_warn": 2,
+                },
+            )
+
+        handler_task = asyncio.create_task(mock_handler())
+        first = await client.send("get_editor_state")
+        second = await client.send("get_editor_state")
+        await handler_task
+
+        assert "new_errors_since_last_call" not in first
+        assert "new_warnings_since_last_call" not in first
+        assert second["new_errors_since_last_call"] == 1
+        assert second["new_warnings_since_last_call"] == 2
+        await plugin.close()
+
+    async def test_warning_watermark_editor_and_game_streams_sum(self, harness):
+        ## Editor-process and game-process warnings are independent streams
+        ## (no shared view like the error path's game/debugger overlap), so
+        ## their deltas sum rather than dedupe with max().
+        plugin = await harness.connect_plugin(session_id="warn-sum")
+        client = GodotClient(harness.server, harness.registry)
+
+        async def mock_handler():
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 1},
+                error_watermark={"run_seq": 1, "editor_ring_warn": 0, "game_warn": 0},
+            )
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 2},
+                error_watermark={"run_seq": 1, "editor_ring_warn": 1, "game_warn": 2},
+            )
+
+        handler_task = asyncio.create_task(mock_handler())
+        first = await client.send("get_editor_state")
+        second = await client.send("get_editor_state")
+        await handler_task
+
+        assert "new_warnings_since_last_call" not in first
+        assert second["new_warnings_since_last_call"] == 3
+        await plugin.close()
+
+    async def test_warning_watermark_first_game_warn_on_new_run_counts_full(self, harness):
+        ## game_warn is per-run: first seen on an advanced run has no baseline
+        ## to diff, so it counts in full (mirrors game_error_warn).
+        plugin = await harness.connect_plugin(session_id="warn-new-run")
+        client = GodotClient(harness.server, harness.registry)
+
+        async def mock_handler():
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 1},
+                error_watermark={"run_seq": 1, "editor_ring": 0},
+            )
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 2},
+                error_watermark={"run_seq": 2, "editor_ring": 0, "game_warn": 2},
+            )
+
+        handler_task = asyncio.create_task(mock_handler())
+        first = await client.send("get_editor_state")
+        second = await client.send("get_editor_state")
+        await handler_task
+
+        assert "new_warnings_since_last_call" not in first
+        assert second["new_warnings_since_last_call"] == 2
+        await plugin.close()
+
     async def test_command_with_params(self, harness):
         plugin = await harness.connect_plugin()
         client = GodotClient(harness.server, harness.registry)


### PR DESCRIPTION
## Problem

A run or test that emitted only **warnings** (`push_warning`, editor parse/`@tool` warnings) was reported to the agent as **clean**. Warnings were captured in the log buffers and returned by `logs_read`, but every watermark/promotion path filtered to `level == "error"`, so `new_errors_since_last_call` stayed `0` and no hint ever surfaced. An agent that ran the game, saw no error hint, and moved on never learned a warning had fired.

## Fix

Add a warning channel parallel to the existing error one, reusing the same plumbing:

- **`editor_log_buffer`**: track `warn_appended_total()` alongside the error count; reset on `clear()`.
- **`game_log_buffer`**: expose `warn_total()` (the warn slice of the existing `error_warn_total`).
- **`surfaced_error_tracker`**: stamp `editor_ring_warn` + `game_warn` on the watermark. (`game_error_warn` is left as-is — a historical misnomer that carries errors only; documented in a comment.)
- **`transport/websocket`**: split warn deltas out of the error math and accumulate them onto `Session.pending_new_warnings`. Editor and game warn streams are independent processes, so they **sum** (no game/debugger `max()` overlap like the error path); `game_warn` is per-run like `game_error_warn`.
- **`godot_client`**: surface `new_warnings_since_last_call` + `new_warnings_hint`, independently of errors, consumed exactly once.
- **`logs_read` rebuild**: re-attach the warning stamp exactly like the error one (the #641 "first call after a broken launch is logs_read" path).

## Scope

Debugger Errors-tab **warning-row promotion** is a deliberate follow-up — the log buffers already cover the common cases (game `push_warning`, editor parse/`@tool` warnings). This PR does not touch the debugger-tab scrape filter.

No new tools/ops, error codes, telemetry events, or `class_name` changes — purely internal watermark plumbing, so no `tool_catalog.gd`/`domains.py` sync needed.

## Tests

- **Python**: watermark/hint cases — independent error/warning surfacing, editor+game warn sum, per-run full count on an advanced run. `pytest` full suite green; `ruff` clean.
- **GDScript**: buffer warn counters (+ `clear()`/`clear_for_new_run()` resets) and tracker watermark warn keys. Renamed the old `..._watermark_ignores_warnings` test (which encoded the bug as intended) to assert the corrected behavior.
- Verified live against Godot 4.7: parse-clean import + full `test_run` (1622 passed / 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Warning-level log activity is now tracked and surfaced alongside errors.
  * Command responses can now include separate warning and error counts/hints.
  * WebSocket sync now preserves warning information across runs and sessions.

* **Bug Fixes**
  * Fixed warning counts being lost or mixed with error counts after log resets.
  * Improved consistency so editor and game warnings are reported independently.

* **Tests**
  * Expanded coverage for warning/error separation and end-to-end response hints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->