### PR TITLE
node_get_properties: add fields filter + total_count to cut response size

### DIFF
--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -895,10 +895,22 @@ func get_node_properties(params: Dictionary) -> Dictionary:
 	var node_path: String = resolved.path
 	var scene_root: Node = resolved.scene_root
 
+	# Optional token-reducing filter: `fields` restricts the response to a
+	# named subset. Defaults off (empty), so existing callers see the full
+	# dump unchanged.
+	var field_filter := {}
+	for f in params.get("fields", []):
+		field_filter[str(f)] = true
+	var use_field_filter := not field_filter.is_empty()
+
 	var properties: Array[Dictionary] = []
+	var editor_property_count := 0
 	for prop in node.get_property_list():
 		var usage: int = prop.get("usage", 0)
 		if not (usage & PROPERTY_USAGE_EDITOR):
+			continue
+		editor_property_count += 1
+		if use_field_filter and not field_filter.has(prop.name):
 			continue
 		# Safe read: custom script getters can error; skip bad properties
 		# rather than letting one bad read timeout the entire request.
@@ -916,6 +928,9 @@ func get_node_properties(params: Dictionary) -> Dictionary:
 			"node_type": node.get_class(),
 			"properties": properties,
 			"count": properties.size(),
+			# Total editor-visible properties before field filtering, so a
+			# caller that passed `fields` knows how many were withheld.
+			"total_count": editor_property_count,
 		}
 	}
 

--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -897,9 +897,18 @@ func get_node_properties(params: Dictionary) -> Dictionary:
 
 	# Optional token-reducing filter: `fields` restricts the response to a
 	# named subset. Defaults off (empty), so existing callers see the full
-	# dump unchanged.
+	# dump unchanged. The MCP tool types this as a list, but batch_execute and
+	# raw callers bypass that, so validate the shape here before iterating.
+	var fields_param: Variant = params.get("fields", [])
+	if fields_param == null:
+		fields_param = []
+	if not (fields_param is Array):
+		return ErrorCodes.make(
+			ErrorCodes.INVALID_PARAMS,
+			"'fields' must be an array of property names, got %s" % type_string(typeof(fields_param)),
+		)
 	var field_filter := {}
-	for f in params.get("fields", []):
+	for f in fields_param:
 		field_filter[str(f)] = true
 	var use_field_filter := not field_filter.is_empty()
 

--- a/src/godot_ai/handlers/node.py
+++ b/src/godot_ai/handlers/node.py
@@ -54,8 +54,15 @@ async def node_find(
     return paginate(result.get("nodes", []), offset, limit, key="nodes")
 
 
-async def node_get_properties(runtime: DirectRuntime, path: str) -> dict:
-    return await runtime.send_command("get_node_properties", {"path": path})
+async def node_get_properties(
+    runtime: DirectRuntime,
+    path: str,
+    fields: list[str] | None = None,
+) -> dict:
+    params: dict = {"path": path}
+    if fields:
+        params["fields"] = fields
+    return await runtime.send_command("get_node_properties", params)
 
 
 async def node_get_children(runtime: DirectRuntime, path: str) -> dict:

--- a/src/godot_ai/tools/node.py
+++ b/src/godot_ai/tools/node.py
@@ -51,20 +51,32 @@ doesn't match.
 
 def register_node_tools(mcp: FastMCP, *, include_non_core: bool = True) -> None:
     @mcp.tool()
-    async def node_get_properties(ctx: Context, path: str, session_id: str = "") -> dict:
-        """Get all properties of a node.
+    async def node_get_properties(
+        ctx: Context,
+        path: str,
+        fields: list[str] | None = None,
+        session_id: str = "",
+    ) -> dict:
+        """Get properties of a node.
 
         Resource form: ``godot://node/{path}/properties`` — prefer for
-        active-session reads.
+        active-session reads (returns the full property set).
+
+        The default returns every editor-visible property, which can be
+        50-150 entries. Pass ``fields`` to return only the properties you
+        need — a large response-size cut on this hot read. The response
+        always carries ``total_count`` (all editor-visible properties)
+        alongside ``count`` (returned) so you can tell how much was withheld.
 
         Args:
             path: Scene path relative to the edited scene root (e.g.
                 "/Main/Camera3D"), NOT runtime "/root/..." paths. Derive
                 from prior tool responses or scene_get_hierarchy.
+            fields: When non-empty, return only these property names.
             session_id: Optional Godot session to target. Empty = active session.
         """
         runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
-        return await node_handlers.node_get_properties(runtime, path=path)
+        return await node_handlers.node_get_properties(runtime, path=path, fields=fields)
 
     if not include_non_core:
         return

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -96,6 +96,52 @@ func test_get_properties_has_value_and_type() -> void:
 	assert_gt(fov_prop.value, 0, "FOV should be positive")
 
 
+func test_get_properties_reports_total_count() -> void:
+	var result := _handler.get_node_properties({"path": "/Main/Camera3D"})
+	assert_has_key(result.data, "total_count")
+	## Unfiltered: count equals total_count (every editor-visible prop returned,
+	## minus safe-read skips which also drop from total). count must never exceed
+	## total_count.
+	assert_true(
+		result.data.count <= result.data.total_count,
+		"count must not exceed total_count",
+	)
+	assert_gt(result.data.total_count, 0, "Camera3D has editor-visible properties")
+
+
+func test_get_properties_fields_filter_returns_only_requested() -> void:
+	var full := _handler.get_node_properties({"path": "/Main/Camera3D"})
+	var filtered := _handler.get_node_properties({
+		"path": "/Main/Camera3D",
+		"fields": ["fov", "current"],
+	})
+	var names: Array[String] = []
+	for prop: Dictionary in filtered.data.properties:
+		names.append(prop.name)
+	names.sort()
+	assert_eq(names, ["current", "fov"], "Only requested fields returned")
+	assert_eq(filtered.data.count, 2)
+	## total_count is unaffected by the filter — it reflects the full set so a
+	## caller knows how much was withheld.
+	assert_eq(
+		filtered.data.total_count,
+		full.data.total_count,
+		"total_count reflects the full property set regardless of fields",
+	)
+	assert_true(filtered.data.count < full.data.count, "fields cuts the response")
+
+
+func test_get_properties_fields_unknown_name_is_skipped() -> void:
+	var result := _handler.get_node_properties({
+		"path": "/Main/Camera3D",
+		"fields": ["fov", "totally_not_a_real_property"],
+	})
+	var names: Array[String] = []
+	for prop: Dictionary in result.data.properties:
+		names.append(prop.name)
+	assert_eq(names, ["fov"], "Unknown field names are silently skipped, known ones kept")
+
+
 func test_get_properties_invalid_path() -> void:
 	var result := _handler.get_node_properties({"path": "/Main/Nope"})
 	assert_is_error(result, ErrorCodes.NODE_NOT_FOUND)

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -99,9 +99,10 @@ func test_get_properties_has_value_and_type() -> void:
 func test_get_properties_reports_total_count() -> void:
 	var result := _handler.get_node_properties({"path": "/Main/Camera3D"})
 	assert_has_key(result.data, "total_count")
-	## Unfiltered: count equals total_count (every editor-visible prop returned,
-	## minus safe-read skips which also drop from total). count must never exceed
-	## total_count.
+	## total_count counts every editor-visible property; count is what was
+	## returned. Even unfiltered they can differ: a property whose getter
+	## returns null is skipped from the response but still counted in
+	## total_count. So the invariant is count <= total_count, not equality.
 	assert_true(
 		result.data.count <= result.data.total_count,
 		"count must not exceed total_count",
@@ -140,6 +141,16 @@ func test_get_properties_fields_unknown_name_is_skipped() -> void:
 	for prop: Dictionary in result.data.properties:
 		names.append(prop.name)
 	assert_eq(names, ["fov"], "Unknown field names are silently skipped, known ones kept")
+
+
+func test_get_properties_fields_non_array_is_rejected() -> void:
+	## The MCP tool types `fields` as a list, but batch_execute / raw callers
+	## bypass that, so a malformed value must be rejected, not crash the loop.
+	var result := _handler.get_node_properties({
+		"path": "/Main/Camera3D",
+		"fields": "fov",
+	})
+	assert_is_error(result, ErrorCodes.INVALID_PARAMS)
 
 
 func test_get_properties_invalid_path() -> void:

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -2381,6 +2381,28 @@ async def test_node_get_properties_handler():
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)
     result = await node_handlers.node_get_properties(runtime, path="/Main/Camera3D")
     assert "properties" in result
+    ## No fields -> params stay minimal so existing callers are unaffected.
+    assert client.calls[-1]["params"] == {"path": "/Main/Camera3D"}
+
+
+async def test_node_get_properties_handler_forwards_fields():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    await node_handlers.node_get_properties(
+        runtime, path="/Main/Camera3D", fields=["fov", "current"]
+    )
+    assert client.calls[-1]["params"] == {
+        "path": "/Main/Camera3D",
+        "fields": ["fov", "current"],
+    }
+
+
+async def test_node_get_properties_handler_empty_fields_omitted():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    await node_handlers.node_get_properties(runtime, path="/Main/Camera3D", fields=[])
+    ## An empty list is not a filter — it must not be forwarded (would filter
+    ## everything out plugin-side otherwise).
     assert client.calls[-1]["params"] == {"path": "/Main/Camera3D"}
 
 


### PR DESCRIPTION
## Motivation

`node_get_properties` is one of the four always-loaded core tools and a high-traffic read, but it returns **every** editor-visible property — 50-150 entries for rich node types (Camera3D, Control, etc.), most sitting at their defaults. That's a large, mostly-redundant payload on a call agents make constantly.

## Change

- Add a `fields` param: when non-empty, return only the named properties. On a Camera3D, `fields=["fov","current"]` returns 2 entries instead of 25.
- Always include `total_count` (all editor-visible properties) alongside `count` (returned), so a caller that filtered can see how much was withheld.
- Defaults are unchanged (`fields` empty → full dump), so existing callers and the `godot://node/{path}/properties` resource form are unaffected.
- An empty `fields` list means "no filter" and is not forwarded to the plugin (so it can't accidentally filter everything out).

## On `changed_only`

I prototyped a `changed_only` variant (skip properties still at their class default) and **dropped it**: Godot exposes no reliable public "is at default" API. `property_can_revert`/`property_get_revert` only cover a small subset — on a Camera3D it filtered just position/rotation/scale (3/25) while leaving `fov`/`near`/`far` in the response despite being at defaults. A half-working filter is more misleading than none, so I left it out pending a real design. `fields` delivers the token win cleanly today.

No new tools/ops, error codes, or telemetry — a param addition, so no `tool_catalog.gd`/`domains.py` sync.

## Tests

- GDScript: `fields` filtering, unknown-field-name skip, and `total_count`/`count` invariants (verified live against Godot 4.7; full `test_run` 1624 passed / 0 failed).
- Python: handler forwards `fields`, and omits an empty list. Full `pytest` green, `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * You can now request node property lookups with a `fields` filter to return only selected properties.
  * Property responses now report both `count` (returned items) and `total_count` (available editor-visible properties).

* **Bug Fixes**
  * An empty `fields` list is ignored to prevent hiding all properties.
  * Unknown requested field names are omitted (while known ones are returned).
  * Invalid (non-array) `fields` values return an `INVALID_PARAMS` error.

* **Tests**
  * Added/expanded tests for `fields` filtering, `total_count`/`count` behavior, and request/validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->