### PR TITLE
Add Zoo Code client configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ covers:
 - **Claude Code**, **Claude Desktop**, **Antigravity**
 
 <details>
-<summary><strong>…and 16+ more clients</strong></summary>
+<summary><strong>…and 17+ more clients</strong></summary>
 
 Codex, Cursor, Windsurf, VS Code, VS Code Insiders, Zed, Gemini CLI, Cline,
-Kilo Code, Roo Code, Kiro, Trae, Cherry Studio, OpenCode, Qwen Code,
+Kilo Code, Roo Code, Zoo Code, Kiro, Trae, Cherry Studio, OpenCode, Qwen Code,
 Kimi Code.
 
 </details>

--- a/plugin/addons/godot_ai/clients/_registry.gd
+++ b/plugin/addons/godot_ai/clients/_registry.gd
@@ -19,6 +19,7 @@ const _CLIENT_SCRIPTS := [
 	preload("res://addons/godot_ai/clients/cline.gd"),
 	preload("res://addons/godot_ai/clients/kilo_code.gd"),
 	preload("res://addons/godot_ai/clients/roo_code.gd"),
+	preload("res://addons/godot_ai/clients/zoo_code.gd"),
 	preload("res://addons/godot_ai/clients/kiro.gd"),
 	preload("res://addons/godot_ai/clients/trae.gd"),
 	preload("res://addons/godot_ai/clients/cherry_studio.gd"),

--- a/plugin/addons/godot_ai/clients/zoo_code.gd
+++ b/plugin/addons/godot_ai/clients/zoo_code.gd
@@ -1,0 +1,23 @@
+@tool
+extends McpClient
+
+
+func _init() -> void:
+	id = "zoo_code"
+	display_name = "Zoo Code"
+	config_type = "json"
+	doc_url = "https://docs.zoocode.dev/features/mcp/using-mcp-in-zoo"
+	path_template = {
+		"darwin": "~/Library/Application Support/Code/User/globalStorage/zoocodeorganization.zoo-code/settings/mcp_settings.json",
+		"windows": "$APPDATA/Code/User/globalStorage/zoocodeorganization.zoo-code/settings/mcp_settings.json",
+		"linux": "$XDG_CONFIG_HOME/Code/User/globalStorage/zoocodeorganization.zoo-code/settings/mcp_settings.json",
+	}
+	server_key_path = PackedStringArray(["mcpServers"])
+	## Local validation against the installed extension shows Zoo stores MCP
+	## entries in `settings/mcp_settings.json` under `mcpServers`, matching Roo's
+	## shape. Its changelog also references Streamable HTTP support, so pin the
+	## transport explicitly to avoid any typeless entry falling back to SSE.
+	entry_extra_fields = {"type": "streamable-http"}
+	## Preserve user-controlled state across reconfigure, parallel to Roo/Kilo.
+	entry_initial_fields = {"disabled": false, "alwaysAllow": []}
+	detect_paths = PackedStringArray(path_template.values())

--- a/plugin/addons/godot_ai/clients/zoo_code.gd.uid
+++ b/plugin/addons/godot_ai/clients/zoo_code.gd.uid
@@ -1,0 +1,1 @@
+uid://fmp0nlzcm3ukl

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -50,7 +50,7 @@ func test_registry_loads_all_clients() -> void:
 	var ids := McpClientRegistry.ids()
 	assert_gt(ids.size(), 10, "Expected at least 10 registered clients, got %d" % ids.size())
 	# Each existing client must remain registered for behaviour parity.
-	for required in ["claude_code", "claude_desktop", "codex", "antigravity"]:
+	for required in ["claude_code", "claude_desktop", "codex", "antigravity", "zoo_code"]:
 		assert_true(McpClientRegistry.has_id(required), "Missing client: %s" % required)
 
 
@@ -1847,6 +1847,33 @@ func test_kilo_code_verify_flags_pre_fix_typeless_entry_as_drift() -> void:
 	assert_true(McpJsonStrategy.verify_entry(c, current, "http://x"), "current entry must verify")
 	var legacy_typeless := {"url": "http://x", "disabled": false, "alwaysAllow": []}
 	assert_false(McpJsonStrategy.verify_entry(c, legacy_typeless, "http://x"), "pre-fix typeless entry must register as drift")
+	var legacy_sse := {"type": "sse", "url": "http://x", "disabled": false, "alwaysAllow": []}
+	assert_false(McpJsonStrategy.verify_entry(c, legacy_sse, "http://x"), "explicit sse entry must register as drift")
+	var url_drift := {"type": "streamable-http", "url": "http://other", "disabled": false, "alwaysAllow": []}
+	assert_false(McpJsonStrategy.verify_entry(c, url_drift, "http://x"), "URL drift must still register as drift")
+
+
+func test_zoo_code_pins_streamable_http_transport() -> void:
+	## Zoo Code uses the Roo-family `mcp_settings.json` / `mcpServers` shape.
+	## Pin `type: streamable-http` so a fresh entry negotiates against our
+	## streamable-http endpoint without relying on upstream defaults.
+	var c := McpClientRegistry.get_by_id("zoo_code")
+	var entry := McpJsonStrategy.build_entry(c, "http://x")
+	assert_eq(entry.get("type", ""), "streamable-http")
+	assert_eq(entry.get("url", ""), "http://x")
+	var manual := McpManualCommand.build(c, "godot-ai", "http://x", "/tmp/zoo.json")
+	assert_contains(manual, "\"type\": \"streamable-http\"")
+
+
+func test_zoo_code_verify_flags_typeless_entry_as_drift() -> void:
+	## Local extension inspection confirmed Zoo stores MCP settings in the same
+	## `mcp_settings.json` shape as Roo. A typeless legacy entry must therefore
+	## register as drift so Configure rewrites it with the transport pin.
+	var c := McpClientRegistry.get_by_id("zoo_code")
+	var current := McpJsonStrategy.build_entry(c, "http://x")
+	assert_true(McpJsonStrategy.verify_entry(c, current, "http://x"), "current entry must verify")
+	var legacy_typeless := {"url": "http://x", "disabled": false, "alwaysAllow": []}
+	assert_false(McpJsonStrategy.verify_entry(c, legacy_typeless, "http://x"), "typeless Zoo entry must register as drift")
 	var legacy_sse := {"type": "sse", "url": "http://x", "disabled": false, "alwaysAllow": []}
 	assert_false(McpJsonStrategy.verify_entry(c, legacy_sse, "http://x"), "explicit sse entry must register as drift")
 	var url_drift := {"type": "streamable-http", "url": "http://other", "disabled": false, "alwaysAllow": []}


### PR DESCRIPTION
## Summary
[Zoo Code](https://github.com/Zoo-Code-Org/Zoo-Code) is the official community successor to [Roo Code](https://github.com/RooCodeInc/Roo-Code#disclaimer) after it officially sunsetted. We would like to add ourselves to the config here. 

- add a Zoo Code client descriptor that writes to Zoo's `mcp_settings.json` using the Roo-style `mcpServers` shape
- pin Zoo Code entries to `streamable-http` and preserve user-controlled fields during reconfigure
- register the client in the shared registry, document it in the README, and cover the transport drift behavior in GDScript tests

## Testing
- Not run (not requested)
