### PR TITLE
Fix cinematic screenshot camera transform (#650) + accept "/" as scene-root alias (#624)

### DIFF
--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -687,6 +687,12 @@ func _take_cinematic_screenshot(max_resolution: int) -> Dictionary:
 	## global_transform is resolved against the ancestor Node3D chain, so it
 	## must be set after parenting — otherwise the camera ends up at origin.
 	cam.global_transform = scene_camera.global_transform
+	## NOTIFICATION_TRANSFORM_CHANGED is delivered deferred (next frame's
+	## flush_transform_notifications), but force_draw renders immediately —
+	## without this flush the RenderingServer still has the identity
+	## transform pushed at ENTER_WORLD and the capture shows only sky
+	## instead of the camera's actual view (issue #650).
+	cam.force_update_transform()
 
 	RenderingServer.force_draw(false)
 	var image: Image = sub_vp.get_texture().get_image()

--- a/plugin/addons/godot_ai/utils/scene_path.gd
+++ b/plugin/addons/godot_ai/utils/scene_path.gd
@@ -42,6 +42,13 @@ static func resolve(scene_path: String, scene_root: Node) -> Node:
 	if scene_root == null:
 		return null
 
+	## Bare "/" alias: the most natural first guess for "the scene root".
+	## There is exactly one edited-scene root, so the alias is unambiguous;
+	## without it, "/" falls through to get_node_or_null("/") → null and
+	## every call costs the agent a NODE_NOT_FOUND round trip (issue #624).
+	if scene_path == "/":
+		return scene_root
+
 	## /root/<scene_root_name>[/...] alias: strip the /root prefix and recurse.
 	## Match the scene root by name explicitly so we don't capture editor-
 	## internal paths that legitimately live under /root.

--- a/test_project/tests/test_scene_path.gd
+++ b/test_project/tests/test_scene_path.gd
@@ -118,6 +118,21 @@ func test_resolve_nested_descendant() -> void:
 	root.queue_free()
 
 
+# ----- resolve: bare "/" root alias (issue #624) -----
+
+func test_resolve_bare_slash_returns_scene_root() -> void:
+	## "/" is the most natural first guess for "the scene root" and is
+	## unambiguous (there is exactly one edited-scene root). Pre-#624 it fell
+	## through to get_node_or_null("/") → null, costing a round trip.
+	var root := _make_tree()
+	assert_eq(McpScenePath.resolve("/", root), root)
+	root.queue_free()
+
+
+func test_resolve_bare_slash_null_root_returns_null() -> void:
+	assert_eq(McpScenePath.resolve("/", null), null)
+
+
 # ----- resolve: /root/<scene_root_name> alias (issue #71) -----
 
 func test_resolve_root_alias_with_scene_name_returns_scene_root() -> void:


### PR DESCRIPTION
Two small fixes shipped from the open-issue queue.

## 1. Cinematic screenshot captures the wrong view (fixes #650)

`editor_screenshot(source="cinematic")` could report the correct active Camera3D while capturing only sky. The capture camera's `global_transform` is set after parenting, but `NOTIFICATION_TRANSFORM_CHANGED` is delivered deferred (next frame's `flush_transform_notifications`) while `RenderingServer.force_draw()` renders immediately — so the RenderingServer still held the identity transform pushed at `ENTER_WORLD`.

Fix: `cam.force_update_transform()` before `force_draw`, exactly as diagnosed (with repro project) by @quittingjack in #650.

## 2. Bare `"/"` resolves to the edited scene root (fixes #624)

`"/"` is the most natural first guess an LLM makes for "the scene root" and previously always failed (`get_node_or_null("/")` → null → `NODE_NOT_FOUND`), costing a wasted round trip on nearly every agent's first contact with a project. `McpScenePath.resolve()` now normalizes `"/"` to the scene root, next to the existing `/root/<name>` alias. Since `resolve()` is the single shared resolution path, one branch covers all handlers; `resolve_or_error`'s empty-path guard is unaffected (`"/"` is non-empty).

## Tests

- New `test_scene_path.gd` cases: `"/"` resolves to the scene root; `"/"` with null root returns null.
- The `#650` fix has no headless-testable surface (needs a real render); verified by the reporter's live repro in the issue.
- Modified GDScript parses clean (`gdparse`). No Godot editor is available in this environment to run the in-editor suite — relying on CI for the behavioral pass.

No new tools/ops/error codes — no `tool_catalog.gd`/`domains.py` sync needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017bCB9GDsZBp9wk7hjCGeu2

---
_Generated by [Claude Code](https://claude.ai/code/session_017bCB9GDsZBp9wk7hjCGeu2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cinematic screenshots capturing an incorrect or empty camera view. Screenshots now consistently reflect the intended camera position.
  * Improved scene navigation so the root scene can be correctly referenced using `/`.

* **Tests**
  * Added coverage to verify root scene references resolve correctly, including cases where no scene root is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->