### PR TITLE
Honor agent-specific config-home env vars in client auto-configuration (#617)

### DIFF
--- a/plugin/addons/godot_ai/clients/_base.gd
+++ b/plugin/addons/godot_ai/clients/_base.gd
@@ -90,8 +90,25 @@ enum UvxBridge { NONE, FLAT }
 var entry_uvx_bridge: UvxBridge = UvxBridge.NONE
 
 ## Paths whose existence implies the user has this client installed.
-## Used purely for the dock's "installed" badge.
+## Used purely for the dock's "installed" badge. `is_installed()` additionally
+## checks `resolved_config_path()`, so a config relocated via
+## `config_home_env` is detected without listing it here.
 var detect_paths: PackedStringArray = PackedStringArray()
+
+# Config-home env override ---------------------------------------------------
+## Some clients honor an env var that relocates their entire config home
+## (Codex: `$CODEX_HOME/config.toml`; Claude Code: `$CLAUDE_CONFIG_DIR/.claude.json`).
+## When `config_home_env` names an env var that is set and non-empty,
+## `resolved_config_path()` returns `<env value>/<config_home_env_subpath>`
+## instead of resolving `path_template`. Both fields must be non-empty for the
+## override to apply. Only declare a mapping when the client's docs guarantee
+## the env var relocates the exact file we write — a wrong mapping writes the
+## MCP entry somewhere the client never reads and Configure false-succeeds.
+var config_home_env: String = ""
+## Path of the config file relative to the env var's directory, e.g.
+## "config.toml". Joined verbatim — no per-OS variants needed because the env
+## value itself is already an absolute (or ~-prefixed) directory.
+var config_home_env_subpath: String = ""
 
 # CLI clients --------------------------------------------------------------
 var cli_names: PackedStringArray = PackedStringArray()
@@ -116,8 +133,26 @@ var toml_body_template: PackedStringArray = PackedStringArray()
 
 
 ## Resolved absolute config path for this client on the current OS.
+## A set, non-empty `config_home_env` env var overrides `path_template`
+## (issue #617: e.g. CODEX_HOME relocates ~/.codex — writing the default
+## path would false-succeed while Codex reads elsewhere).
 func resolved_config_path() -> String:
+	var override := config_home_override()
+	if not override.is_empty():
+		return override
 	return McpPathTemplate.resolve(path_template)
+
+
+## The env-var-relocated config path, or "" when no override applies
+## (no mapping declared, env var unset, or env var empty/whitespace).
+func config_home_override() -> String:
+	if config_home_env.is_empty() or config_home_env_subpath.is_empty():
+		return ""
+	var home := OS.get_environment(config_home_env).strip_edges()
+	if home.is_empty():
+		return ""
+	# Expand a leading ~ so `CODEX_HOME=~/codex-alt` behaves like the shell.
+	return McpPathTemplate.expand(home).path_join(config_home_env_subpath)
 
 
 ## True when a CLI client also declares where its config file lives, so it can

--- a/plugin/addons/godot_ai/clients/claude_code.gd
+++ b/plugin/addons/godot_ai/clients/claude_code.gd
@@ -22,3 +22,11 @@ func _init() -> void:
 	path_template = {"unix": "~/.claude.json", "windows": "~/.claude.json"}
 	server_key_path = PackedStringArray(["mcpServers"])
 	entry_extra_fields = {"type": "http"}
+	## Documented: $CLAUDE_CONFIG_DIR relocates Claude Code's config home,
+	## including .claude.json ($CLAUDE_CONFIG_DIR/.claude.json). The preferred
+	## CLI path needs no help — the spawned `claude` binary inherits the
+	## editor's environment and resolves the dir itself — but the JSON
+	## fallback above would otherwise write ~/.claude.json that a relocated
+	## install never reads (#617).
+	config_home_env = "CLAUDE_CONFIG_DIR"
+	config_home_env_subpath = ".claude.json"

--- a/plugin/addons/godot_ai/clients/codex.gd
+++ b/plugin/addons/godot_ai/clients/codex.gd
@@ -8,6 +8,10 @@ func _init() -> void:
 	config_type = "toml"
 	doc_url = "https://openai.com/index/codex/"
 	path_template = {"unix": "~/.codex/config.toml", "windows": "$USERPROFILE/.codex/config.toml"}
+	## Documented: when $CODEX_HOME is set, Codex reads config.toml directly
+	## from it instead of ~/.codex (#617).
+	config_home_env = "CODEX_HOME"
+	config_home_env_subpath = "config.toml"
 	toml_section_path = PackedStringArray(["mcp_servers", "godot-ai"])
 	# Older Codex builds used the unquoted form with underscore-substituted ids.
 	toml_legacy_section_aliases = PackedStringArray(["mcp_servers.godot_ai"])

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -711,6 +711,120 @@ func test_path_template_xdg_fallback() -> void:
 	assert_true(resolved.ends_with("/foo"))
 
 
+# ----- config-home env override (#617) -----
+
+const TEST_CFG_HOME_ENV := "GODOT_AI_TEST_CFG_HOME"
+
+
+func _make_env_override_toml_client(default_path: String) -> McpClient:
+	var c := _make_test_toml_client(default_path)
+	c.config_home_env = TEST_CFG_HOME_ENV
+	c.config_home_env_subpath = "config.toml"
+	return c
+
+
+func test_config_home_env_overrides_path_template() -> void:
+	var default_path := _scratch_dir.path_join("env_default/config.toml")
+	var client := _make_env_override_toml_client(default_path)
+	var prior_env := OS.get_environment(TEST_CFG_HOME_ENV)
+	var env_home := _scratch_dir.path_join("env_home")
+	OS.set_environment(TEST_CFG_HOME_ENV, env_home)
+	var resolved := client.resolved_config_path()
+	if prior_env.is_empty():
+		OS.unset_environment(TEST_CFG_HOME_ENV)
+	else:
+		OS.set_environment(TEST_CFG_HOME_ENV, prior_env)
+	assert_eq(resolved, env_home.path_join("config.toml"), "env var should override path_template")
+
+
+func test_config_home_env_unset_falls_back_to_path_template() -> void:
+	var default_path := _scratch_dir.path_join("env_default/config.toml")
+	var client := _make_env_override_toml_client(default_path)
+	var prior_env := OS.get_environment(TEST_CFG_HOME_ENV)
+	OS.unset_environment(TEST_CFG_HOME_ENV)
+	var resolved_unset := client.resolved_config_path()
+	# Empty / whitespace-only value must also fall back — an exported-but-blank
+	# var means "not relocated".
+	OS.set_environment(TEST_CFG_HOME_ENV, "   ")
+	var resolved_blank := client.resolved_config_path()
+	if prior_env.is_empty():
+		OS.unset_environment(TEST_CFG_HOME_ENV)
+	else:
+		OS.set_environment(TEST_CFG_HOME_ENV, prior_env)
+	assert_eq(resolved_unset, default_path, "unset env var should fall back to path_template")
+	assert_eq(resolved_blank, default_path, "blank env var should fall back to path_template")
+
+
+func test_config_home_override_requires_both_fields() -> void:
+	var default_path := _scratch_dir.path_join("env_default/config.toml")
+	var client := _make_test_toml_client(default_path)
+	client.config_home_env = TEST_CFG_HOME_ENV
+	# subpath left empty → no override even when the env var is set.
+	var prior_env := OS.get_environment(TEST_CFG_HOME_ENV)
+	OS.set_environment(TEST_CFG_HOME_ENV, _scratch_dir.path_join("env_home"))
+	var resolved := client.resolved_config_path()
+	var override := client.config_home_override()
+	if prior_env.is_empty():
+		OS.unset_environment(TEST_CFG_HOME_ENV)
+	else:
+		OS.set_environment(TEST_CFG_HOME_ENV, prior_env)
+	assert_eq(override, "", "missing subpath must disable the override")
+	assert_eq(resolved, default_path, "missing subpath must fall back to path_template")
+
+
+func test_config_home_env_configure_and_drift_use_override() -> void:
+	## End-to-end: with the env var set, Configure writes to the env-var
+	## location, drift detection reads it back from there, and Remove cleans
+	## it up — the path_template default is never touched.
+	var default_path := _scratch_dir.path_join("env_default_untouched.toml")
+	_remove_if_exists(default_path)
+	var client := _make_env_override_toml_client(default_path)
+	var env_home := _scratch_dir.path_join("env_home_e2e")
+	DirAccess.make_dir_recursive_absolute(env_home)
+	var env_path := env_home.path_join("config.toml")
+	_remove_if_exists(env_path)
+	var prior_env := OS.get_environment(TEST_CFG_HOME_ENV)
+	OS.set_environment(TEST_CFG_HOME_ENV, env_home)
+
+	var result := McpTomlStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+	var wrote_env := FileAccess.file_exists(env_path)
+	var wrote_default := FileAccess.file_exists(default_path)
+	var status := McpTomlStrategy.check_status(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+	var drift := McpTomlStrategy.check_status(client, "godot-ai", "http://127.0.0.1:9000/mcp")
+	var installed := client.is_installed()
+	var removed := McpTomlStrategy.remove(client, "godot-ai")
+	var post_remove := McpTomlStrategy.check_status(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+
+	if prior_env.is_empty():
+		OS.unset_environment(TEST_CFG_HOME_ENV)
+	else:
+		OS.set_environment(TEST_CFG_HOME_ENV, prior_env)
+	_remove_if_exists(env_path)
+
+	assert_eq(result.get("status"), "ok")
+	assert_true(wrote_env, "Configure must write the env-var location")
+	assert_false(wrote_default, "Configure must not touch the path_template default")
+	assert_eq(status, McpClient.Status.CONFIGURED)
+	assert_eq(drift, McpClient.Status.CONFIGURED_MISMATCH, "URL drift must be detected at the overridden path")
+	assert_true(installed, "config existing at the env-var location must count as installed")
+	assert_eq(removed.get("status"), "ok")
+	assert_eq(post_remove, McpClient.Status.NOT_CONFIGURED)
+
+
+func test_codex_declares_codex_home_override() -> void:
+	var client := McpClientRegistry.get_by_id("codex")
+	assert_true(client != null, "codex must be registered")
+	assert_eq(client.config_home_env, "CODEX_HOME")
+	assert_eq(client.config_home_env_subpath, "config.toml", "config.toml lives directly in $CODEX_HOME")
+
+
+func test_claude_code_declares_claude_config_dir_override() -> void:
+	var client := McpClientRegistry.get_by_id("claude_code")
+	assert_true(client != null, "claude_code must be registered")
+	assert_eq(client.config_home_env, "CLAUDE_CONFIG_DIR")
+	assert_eq(client.config_home_env_subpath, ".claude.json")
+
+
 # ----- JSON strategy round-trip -----
 
 func test_json_strategy_round_trip() -> void:


### PR DESCRIPTION
Fixes #617.

## Problem

Client descriptors hardcode default config paths. Users who relocate a client's config home via its documented env var (e.g. `CODEX_HOME`) got a false-success Configure: the plugin wrote `~/.codex/config.toml` while Codex read elsewhere.

## Change

- **`_base.gd`**: new data-only descriptor fields `config_home_env` + `config_home_env_subpath`. When the named env var is set and non-blank, `resolved_config_path()` returns `<env value>/<subpath>` (with `~` expansion); otherwise falls back to `path_template` unchanged. Because every strategy (JSON/TOML, the #463 CLI JSON fallback, verify-after-write, drift detection, manual-command hint, and `is_installed()`) already routes through `resolved_config_path()`, the override propagates everywhere with no strategy changes.
- **`codex.gd`**: `CODEX_HOME` → `config.toml` (documented: config lives directly in `$CODEX_HOME`).
- **`claude_code.gd`**: `CLAUDE_CONFIG_DIR` → `.claude.json`. The preferred CLI path needs no help (the spawned `claude` binary inherits the editor's env), but the #463 extension-only JSON fallback wrote `~/.claude.json` that a relocated install never reads — now fixed.

**Deliberately skipped** (conservative — a wrong mapping writes configs where the client never reads): OpenCode (`OPENCODE_CONFIG` points at a *file*, different semantics), Gemini CLI/Qwen Code (no confidently documented config-home var), XDG clients (`$XDG_CONFIG_HOME` already expanded by `_path_template.gd`).

## Tests

Six new cases in `test_clients.gd` using the existing `OS.set_environment` save/restore precedent: override applied; unset and blank-value fallbacks; both-fields-required guard; full configure→drift→installed→remove flow at the overridden path asserting the default path is never touched; registry pins for the codex/claude_code mappings.

Verified with `gdparse` (no Godot runtime in this environment); the GDScript suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017bCB9GDsZBp9wk7hjCGeu2

---
_Generated by [Claude Code](https://claude.ai/code/session_017bCB9GDsZBp9wk7hjCGeu2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting client configuration files in environment-variable-defined locations.
  * Claude Code now supports configurations relocated with `CLAUDE_CONFIG_DIR`.
  * Codex now supports configurations located via `CODEX_HOME`.
  * Configuration operations continue to fall back to default locations when overrides are unset or invalid.

* **Bug Fixes**
  * Improved configuration discovery, status detection, and removal for relocated configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->