### PR TITLE
Fix in-run error misclassified as retained_recent across unscanned Errors-tab clear (#635)

### DIFF
--- a/plugin/addons/godot_ai/utils/surfaced_error_tracker.gd
+++ b/plugin/addons/godot_ai/utils/surfaced_error_tracker.gd
@@ -577,10 +577,16 @@ func _account_row_times(key: String, times: Dictionary) -> void:
 	if times.is_empty():
 		return
 	var accounted: Dictionary = _promoted_debugger_row_times.get(key, {})
-	if accounted.size() > MAX_ACCOUNTED_ROW_TIMES_PER_KEY:
-		accounted = {}
 	for time_text in times.keys():
 		accounted[time_text] = true
+	## Enforce the bound AFTER merging: a pre-merge `>` check let the set
+	## reach the cap and keep growing (and a batch of new times could jump
+	## past it). Past the cap, reset to just this scan's times — the live
+	## Errors tab is itself bounded, so this only fires under a pathological
+	## same-key flood, where "recent scan only" is an acceptable memory of
+	## what was promoted (worst case: a re-observed ancient row re-promotes).
+	if accounted.size() > MAX_ACCOUNTED_ROW_TIMES_PER_KEY:
+		accounted = times.duplicate()
 	_promoted_debugger_row_times[key] = accounted
 
 

--- a/plugin/addons/godot_ai/utils/surfaced_error_tracker.gd
+++ b/plugin/addons/godot_ai/utils/surfaced_error_tracker.gd
@@ -18,12 +18,20 @@ const DEBUGGER_SCAN_AFTER_STOP_MS := 5000
 ## the remote debugger delivers right around the event, and a late one past
 ## Godot's per-frame Errors-tab insertion throttle for error floods.
 const DEFERRED_SCAN_DELAYS_SEC: Array[float] = [1.0, 5.0]
+## #635: cap on accounted per-key row-time signatures. The live Errors tab is
+## itself bounded, so this only guards a pathological flood of same-keyed rows
+## with distinct time texts; past the cap the set resets to the current scan.
+const MAX_ACCOUNTED_ROW_TIMES_PER_KEY := 512
 
 var _editor_log_buffer
 var _game_log_buffer
 var _debugger_errors_root: Node
 var _debugger_search_root_cache: Node
 var _promoted_debugger_keys: Dictionary = {}
+## #635: per-key set of Errors-tab row time texts already promoted, so a row
+## observed after a clear+repopulate that no scan saw as empty still counts as
+## new (see the re-promotion comment in refresh_debugger_errors).
+var _promoted_debugger_row_times: Dictionary = {}
 var _promoted_debugger_key_order: Array[String] = []
 var _promoted_debugger_entries: Array[Dictionary] = []
 var _debugger_promoted_total := 0
@@ -92,8 +100,11 @@ func refresh_debugger_errors(force: bool = true) -> void:
 		if str(entry.get("level", "")) != "error":
 			continue
 		var key := _log_entry_key(entry)
-		var info: Dictionary = current_by_key.get(key, {"count": 0, "entry": entry})
+		var info: Dictionary = current_by_key.get(key, {"count": 0, "entry": entry, "times": {}})
 		info["count"] = int(info.get("count", 0)) + 1
+		var time_text := _row_time_text(entry)
+		if not time_text.is_empty():
+			(info["times"] as Dictionary)[time_text] = true
 		current_by_key[key] = info
 	for key in _promoted_debugger_keys.keys():
 		if not current_by_key.has(key):
@@ -102,15 +113,31 @@ func refresh_debugger_errors(force: bool = true) -> void:
 		var info: Dictionary = current_by_key[key]
 		var current := int(info.get("count", 0))
 		var stored := int(_promoted_debugger_keys.get(key, 0))
-		if current < stored:
-			_promoted_debugger_keys[key] = current
-			continue
-		if current == stored:
+		## #635: a count increase alone misses rows observed after a run
+		## boundary. Godot clears the Errors tab at run start; when the new run
+		## re-fires an error identical to one promoted before the clear, and no
+		## scan happened to observe the tab empty in between, the per-key count
+		## never dips — so the row kept its pre-run sequence and run-scoping
+		## (editor_entries_since against the run-start cursor) misclassified an
+		## in-run error as retained_recent. Each Errors-tab row carries its own
+		## time text; an unaccounted (key, time) signature is a row we have not
+		## promoted yet, so it earns a fresh sequence even at an equal or lower
+		## count. Boundary condition: rows with an empty time text, or a
+		## repopulated row whose time text is byte-identical to a pre-clear row,
+		## fall back to count-only dedup and can still be missed.
+		var unseen_times := _unaccounted_row_times(key, info.get("times", {}))
+		var delta := current - stored
+		if delta <= 0 and not unseen_times.is_empty():
+			delta = mini(unseen_times.size(), current)
+		if delta <= 0:
+			if current != stored:
+				_promoted_debugger_keys[key] = current
 			continue
 		if not _promoted_debugger_keys.has(key):
 			_promoted_debugger_key_order.append(key)
 		_promoted_debugger_keys[key] = current
-		_debugger_promoted_total += current - stored
+		_account_row_times(key, info.get("times", {}))
+		_debugger_promoted_total += delta
 		var source_entry: Dictionary = info.get("entry", {})
 		var promoted := source_entry.duplicate(true)
 		promoted["_debugger_key"] = key
@@ -524,6 +551,37 @@ func _trim_promoted_debugger_key_counts() -> void:
 	while _promoted_debugger_key_order.size() > MAX_PROMOTED_DEBUGGER_KEYS:
 		var key := _promoted_debugger_key_order.pop_front()
 		_promoted_debugger_keys.erase(key)
+		_promoted_debugger_row_times.erase(key)
+
+
+## #635: per-row time text from a scraped Errors-tab entry (column 0 of the
+## row, carried in details.time). Empty when the entry has no details — e.g.
+## synthetic records — which keeps those on count-only dedup.
+static func _row_time_text(entry: Dictionary) -> String:
+	var details: Variant = entry.get("details", {})
+	if details is Dictionary:
+		return str((details as Dictionary).get("time", ""))
+	return ""
+
+
+func _unaccounted_row_times(key: String, times: Dictionary) -> Array:
+	var accounted: Dictionary = _promoted_debugger_row_times.get(key, {})
+	var unseen := []
+	for time_text in times.keys():
+		if not accounted.has(time_text):
+			unseen.append(time_text)
+	return unseen
+
+
+func _account_row_times(key: String, times: Dictionary) -> void:
+	if times.is_empty():
+		return
+	var accounted: Dictionary = _promoted_debugger_row_times.get(key, {})
+	if accounted.size() > MAX_ACCOUNTED_ROW_TIMES_PER_KEY:
+		accounted = {}
+	for time_text in times.keys():
+		accounted[time_text] = true
+	_promoted_debugger_row_times[key] = accounted
 
 
 func _remove_promoted_debugger_entry(key: String) -> void:

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -1551,6 +1551,51 @@ func test_surfaced_error_tracker_run_start_repromotes_recurring_debugger_error()
 	tree.free()
 
 
+func test_surfaced_error_tracker_repromotes_row_reobserved_across_unscanned_clear() -> void:
+	## #635: Godot clears the Errors tab at run start; when the new run
+	## re-fires an error identical to a pre-run row and no scan observes the
+	## tab empty in between, the per-key count never dips. The per-row time
+	## signature must still earn the row a fresh sequence so the new run's
+	## cursor classifies it as run-scoped instead of retained_recent.
+	var tree := _make_debugger_errors_tree()
+	var tracker := McpSurfacedErrorTracker.new(null, null, tree)
+	assert_eq(tracker.watermark(true).debugger_promoted, 1)
+	tracker.note_game_run_started(true)
+	var cursor := tracker.debugger_promoted_total()
+	## Clear + identical repopulate (new row time) with no intermediate scan.
+	tree.clear()
+	var root := tree.create_item()
+	_append_duplicate_parse_error(root)
+	assert_eq(tracker.watermark(true).debugger_promoted, 2, "a re-observed row must promote with a fresh sequence")
+	var captured := tracker.editor_entries_since(0, cursor)
+	assert_eq(captured.entries.size(), 1, "the re-observed row must be visible past the run-start cursor")
+	assert_eq(captured.entries[0].text, "Parse Error: Expected statement")
+	assert_eq(tracker.watermark(true).debugger_promoted, 2, "an unchanged repopulated row must not double-count")
+	tree.free()
+
+
+func test_debugger_plugin_in_run_error_after_unscanned_clear_is_run_scoped() -> void:
+	## #635 end-to-end: a push_error early in a fresh run whose Errors-tab row
+	## matches a pre-run row (tab cleared and repopulated between scans) must
+	## come back as scope "run" / current_run_errors, not retained_recent.
+	var tree := _make_debugger_errors_tree()
+	var tracker := McpSurfacedErrorTracker.new(null, null, tree)
+	assert_eq(tracker.watermark(true).debugger_promoted, 1)
+	var plugin := McpDebuggerPlugin.new(null, null, null, tracker)
+	plugin.begin_game_run(0, true)
+	tree.clear()
+	var root := tree.create_item()
+	_append_duplicate_parse_error(root)
+	var errors_info: Dictionary = plugin.recent_editor_errors_since(0, true)
+	assert_eq(errors_info.scope, "run", "an in-run re-observed error must be run-scoped")
+	assert_eq(errors_info.errors.size(), 1)
+	assert_eq(errors_info.errors[0].text, "Parse Error: Expected statement")
+	var split := McpDebuggerPlugin.split_errors_by_scope(errors_info.errors, errors_info.scope)
+	assert_eq(split.current_run_errors.size(), 1, "run-scoped errors must land in current_run_errors")
+	assert_eq(split.retained_errors.size(), 0)
+	tree.free()
+
+
 func test_surfaced_error_tracker_user_clear_then_recurrence_promotes() -> void:
 	var tree := _make_debugger_errors_tree()
 	var tracker := McpSurfacedErrorTracker.new(null, null, tree)


### PR DESCRIPTION
Addresses item 1 of #635 — the last remaining item: items 2 (`input_mouse` position validation) and 3 (`test_run` edited-scene warning) already landed in #638.

## Root cause

Errors-tab promotion in `surfaced_error_tracker.gd` was count-keyed per content key (`level|text|path|line`). Godot clears the Errors tab at run start; when the new run re-fires an error content-identical to a pre-run row and no scan happens to observe the tab empty in between, the per-key count never dips. The row keeps its pre-run sequence, `editor_entries_since` (against the run-start cursor) finds nothing new, and the retained fallback fires: `recent_errors_scope: "retained_recent"`, `recent_errors_may_predate_run: true`, empty `current_run_errors` — exactly the reported 413ms symptom.

## Fix

Track per-key sets of promoted row **time texts** (every Errors-tab row stamps its own time in column 0, surfaced as `details.time`). A row whose `(key, time)` signature is unaccounted re-promotes with a fresh monotonic sequence even at an equal/lower count, so run-start-cursor scoping classifies it as `"run"` → `current_run_errors`.

- Memory bounded: `MAX_ACCOUNTED_ROW_TIMES_PER_KEY` (512) with reset past the cap; accounted sets are erased alongside key trimming.
- No double-count: once accounted, a re-scan of the same rows promotes nothing (asserted in tests).
- Documented boundary (in the scan-loop comment, per the issue's "safest version" framing): rows with an empty time text (synthetic records) or a repopulated row byte-identical in time to a pre-clear row fall back to count-only dedup and can still be missed.

## Tests

- `test_surfaced_error_tracker_repromotes_row_reobserved_across_unscanned_clear` — tracker-level: clear + identical repopulate with no intermediate scan promotes a fresh sequence past the run-start cursor, and doesn't double-count on re-scan.
- `test_debugger_plugin_in_run_error_after_unscanned_clear_is_run_scoped` — end-to-end: `recent_editor_errors_since` returns scope `"run"` and `split_errors_by_scope` lands the error in `current_run_errors`.

Verified with `gdparse` (no Godot runtime in this environment); the GDScript suite runs in CI. Recommended live check before merge: run a project twice with the same `push_error` firing early in run 2 and confirm the `project_run` response reports scope `"run"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017bCB9GDsZBp9wk7hjCGeu2

---
_Generated by [Claude Code](https://claude.ai/code/session_017bCB9GDsZBp9wk7hjCGeu2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of debugger errors that reappear after the Errors tab is cleared and repopulated.
  * Reappearing errors now receive fresh promotion tracking, ensuring they remain visible as current run errors when appropriate.

* **Tests**
  * Added coverage for repeated errors after an unscanned Errors tab reset.
  * Added end-to-end validation of run-scoped error classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->