### PR TITLE
Add session-idle self-terminate backstop to the orphan reaper (#498, Windows coverage for #497)

### DIFF
--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -410,6 +410,19 @@ func _set_owner_pid_env() -> bool:
 	return true
 
 
+## Mark the next OS.create_process as plugin-spawned so the server arms its
+## session-idle self-terminate backstop (#498): with zero editor sessions for
+## a grace window, it exits on its own. Unlike the owner-PID reaper this is
+## pure session-count on the server side, so it is set on EVERY platform —
+## including Windows, where owner-PID is skipped; this marker is what finally
+## gives Windows orphan coverage (#497). Same env-channel rationale and same
+## tight scoping as _set_owner_pid_env: callers unset it right after spawning
+## so a later manually-started dev server can never inherit it and idle-kill
+## itself.
+func _set_plugin_spawned_env() -> void:
+	OS.set_environment("GODOT_AI_PLUGIN_SPAWNED", "1")
+
+
 ## Branch table (recorded version is the "is this ours?" signal — uvx
 ## launcher PIDs go stale; #135/#137):
 ##   port free                                -> spawn fresh, record PID
@@ -557,12 +570,14 @@ func start_server() -> void:
 	## process-liveness/self-shutdown isn't live-validated yet). The server
 	## gates on this too.
 	var owner_env_set := _set_owner_pid_env()
+	_set_plugin_spawned_env()
 
 	_server_pid = OS.create_process(cmd, args)
 	var spawned_pid := int(_server_pid)
 
 	if owner_env_set:
 		OS.unset_environment("GODOT_AI_OWNER_PID")
+	OS.unset_environment("GODOT_AI_PLUGIN_SPAWNED")
 
 	## Restore PYTHONPATH immediately — the spawned child has already
 	## copied the env, so the editor's own process state returns to
@@ -648,9 +663,11 @@ func respawn_with_refresh() -> void:
 	## Set owner PID for THIS spawn too (don't rely on it lingering from
 	## start_server) — and unset right after, same scoping as start_server.
 	var owner_env_set := _set_owner_pid_env()
+	_set_plugin_spawned_env()
 	_server_pid = OS.create_process(cmd, args)
 	if owner_env_set:
 		OS.unset_environment("GODOT_AI_OWNER_PID")
+	OS.unset_environment("GODOT_AI_PLUGIN_SPAWNED")
 	if injected_telemetry_env:
 		OS.unset_environment("GODOT_AI_DISABLE_TELEMETRY")
 	var spawn_pid := int(_server_pid)

--- a/src/godot_ai/orphan_reaper.py
+++ b/src/godot_ai/orphan_reaper.py
@@ -19,6 +19,12 @@ sessions are again zero) reaps it.
 Servers started without ``--owner-pid`` (CI's ci-start-server, manual
 ``--reload`` dev runs, ``uvx`` one-shots) never enable the watchdog and behave
 exactly as before.
+
+Alongside the owner-PID watchdog, ``watch_idle`` implements the session-idle
+self-terminate backstop (#498): a plugin-spawned server with zero connected
+sessions for a full grace window exits on its own. Being pure session-count +
+monotonic-clock, it also runs on Windows, where the owner-PID reaper is
+disabled — the first orphan coverage there (#497).
 """
 
 from __future__ import annotations
@@ -28,12 +34,99 @@ import logging
 import os
 import signal
 import sys
+import time
 from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_POLL_SECONDS = 5.0
 POLL_SECONDS_ENV = "GODOT_AI_REAPER_POLL_SECONDS"
+
+## ---- Idle self-terminate backstop (#498; Windows coverage for #497) ----
+##
+## The owner-PID watchdog above is POSIX-only and depends on the editor PID
+## surviving env plumbing. The idle backstop is a second, independent line of
+## defense: a plugin-spawned server that has had ZERO connected editor sessions
+## for a full grace window exits on its own. It needs no process probing at
+## all — just the session registry count and a monotonic clock — so it works
+## identically on Windows, where the owner-PID reaper is disabled.
+
+## Marker set by the plugin (server_lifecycle.gd) around OS.create_process,
+## exactly like GODOT_AI_OWNER_PID. Only plugin-spawned servers may idle-exit;
+## manually launched dev servers (`python -m godot_ai`, serve-this-worktree)
+## never see this marker and are never idle-killed.
+PLUGIN_SPAWNED_ENV = "GODOT_AI_PLUGIN_SPAWNED"
+
+## Opt-out escape hatch: a user who wants a plugin-spawned server to outlive
+## all editors (e.g. debugging the server itself) sets this truthy.
+NO_IDLE_EXIT_ENV = "GODOT_AI_NO_IDLE_EXIT"
+
+## Grace before the FIRST-ever session connects (server boot → plugin
+## handshake), and grace after the LAST session disconnects. The observed
+## plugin-reload reconnect gap is ~6s; 120s is a wide safety margin over that
+## while still reclaiming a truly orphaned server within minutes.
+DEFAULT_IDLE_GRACE_SECONDS = 120.0
+BOOT_GRACE_ENV = "GODOT_AI_IDLE_BOOT_GRACE_SECONDS"
+IDLE_GRACE_ENV = "GODOT_AI_IDLE_GRACE_SECONDS"
+
+## Set by asgi.run_with_reload for the uvicorn reload supervisor + worker.
+## Duplicated string (not imported from godot_ai.asgi) to keep this module
+## free of the uvicorn/fastmcp import chain.
+_DEV_TRANSPORT_ENV = "GODOT_AI_DEV_TRANSPORT"
+
+
+def _env_truthy(name: str) -> bool:
+    ## Same truthiness contract as telemetry's opt-out vars ("1"/"true"/...).
+    return os.environ.get(name, "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _grace_from_env(name: str) -> float:
+    """Grace window in seconds from ``name``, defaulting to 120s.
+
+    Malformed or non-positive values fall back to the default — a bad env var
+    must never turn the backstop into an instant kill.
+    """
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return DEFAULT_IDLE_GRACE_SECONDS
+    try:
+        value = float(raw)
+    except ValueError:
+        return DEFAULT_IDLE_GRACE_SECONDS
+    return value if value > 0 else DEFAULT_IDLE_GRACE_SECONDS
+
+
+def boot_grace_from_env() -> float:
+    return _grace_from_env(BOOT_GRACE_ENV)
+
+
+def idle_grace_from_env() -> float:
+    return _grace_from_env(IDLE_GRACE_ENV)
+
+
+def should_arm_idle_exit(owner_pid: int | None) -> bool:
+    """Whether the idle self-terminate backstop (#498) should run.
+
+    Arms only for plugin-spawned servers: either the explicit
+    ``GODOT_AI_PLUGIN_SPAWNED`` marker is present (set by server_lifecycle.gd on
+    every platform, including Windows where owner-PID is skipped — that's the
+    #497 coverage), or an owner pid was plumbed through (older plugin builds
+    that predate the marker). Never arms for:
+
+    - manual dev servers / CI (neither marker nor owner pid in the env);
+    - ``--reload`` dev runs (detected via the reload runner's
+      ``GODOT_AI_DEV_TRANSPORT`` env, inherited by uvicorn's reload worker) —
+      an idle reloading server is a dev convenience, not an orphan;
+    - explicit opt-out via ``GODOT_AI_NO_IDLE_EXIT``.
+
+    Unlike ``should_arm_reaper`` there is no Windows gate: this path does no
+    process probing, only session counts + monotonic time.
+    """
+    if _env_truthy(NO_IDLE_EXIT_ENV):
+        return False
+    if os.environ.get(_DEV_TRANSPORT_ENV, "").strip():
+        return False
+    return _env_truthy(PLUGIN_SPAWNED_ENV) or bool(owner_pid and owner_pid > 0)
 
 
 def poll_seconds_from_env() -> float:
@@ -116,8 +209,18 @@ def _request_self_shutdown() -> None:
     SIGTERM is what uvicorn / the FastMCP HTTP runner already handle as a
     graceful shutdown (drain + lifespan teardown), so this reuses the exact
     path a ``kill <pid>`` from the plugin would trigger — no abrupt exit.
+
+    On Windows (reachable via the idle backstop, #498/#497 — the owner-PID
+    reaper stays POSIX-only) ``os.kill(pid, SIGTERM)`` would be
+    ``TerminateProcess`` — an abrupt kill that skips lifespan teardown. Use
+    ``signal.raise_signal`` there instead: it invokes uvicorn's installed
+    Python-level SIGTERM handler in-process, giving the same graceful
+    drain; with no handler installed the default disposition still exits.
     """
-    os.kill(os.getpid(), signal.SIGTERM)
+    if sys.platform.startswith("win"):
+        signal.raise_signal(signal.SIGTERM)
+    else:
+        os.kill(os.getpid(), signal.SIGTERM)
 
 
 async def watch_owner(
@@ -159,6 +262,61 @@ async def watch_owner(
             "Owner editor pid %d is gone and no sessions are connected; "
             "shutting down orphaned server.",
             owner_pid,
+        )
+        shutdown()
+        return
+
+
+async def watch_idle(
+    session_count: Callable[[], int],
+    *,
+    poll_seconds: float = DEFAULT_POLL_SECONDS,
+    boot_grace_seconds: float = DEFAULT_IDLE_GRACE_SECONDS,
+    idle_grace_seconds: float = DEFAULT_IDLE_GRACE_SECONDS,
+    clock: Callable[[], float] = time.monotonic,
+    shutdown: Callable[[], None] = _request_self_shutdown,
+) -> None:
+    """Exit once ZERO sessions have been connected for a full grace window.
+
+    The idle self-terminate backstop from #498 (and the Windows orphan story
+    for #497). Runs alongside — never instead of — the owner-PID watchdog:
+    owner-PID reaps fast when the editor demonstrably died; this backstop
+    reaps eventually with no process probing at all, so it also covers
+    platforms/paths where owner-PID can't run.
+
+    Two windows, both measured on the injectable monotonic ``clock``:
+
+    - boot grace (``boot_grace_seconds``): from task start until the
+      first-ever session connects. Covers a spawn whose editor dies before
+      the plugin's WebSocket handshake lands.
+    - idle grace (``idle_grace_seconds``): restarts every poll that observes
+      a live session, so it effectively measures time since the last
+      disconnect. Sized well above the ~6s plugin-reload reconnect gap, so a
+      reload's brief zero-session dip can never trigger an exit.
+
+    Runs until it triggers a shutdown or is cancelled on lifespan teardown.
+    """
+    idle_since = clock()
+    ever_connected = False
+    while True:
+        await asyncio.sleep(poll_seconds)
+        now = clock()
+        if session_count() > 0:
+            ever_connected = True
+            ## Restart the idle window at the last poll that saw a session —
+            ## the true disconnect happened somewhere in the following poll
+            ## interval, so this under-counts idle time by at most one poll.
+            idle_since = now
+            continue
+        grace = idle_grace_seconds if ever_connected else boot_grace_seconds
+        if now - idle_since < grace:
+            continue
+        logger.info(
+            "No editor session for %.0fs (%s grace %.0fs); "
+            "idle backstop shutting down plugin-spawned server.",
+            now - idle_since,
+            "idle" if ever_connected else "boot",
+            grace,
         )
         shutdown()
         return

--- a/src/godot_ai/server.py
+++ b/src/godot_ai/server.py
@@ -25,7 +25,15 @@ from godot_ai.middleware import (
     PreserveGodotCommandErrorData,
     StripClientWrapperKwargs,
 )
-from godot_ai.orphan_reaper import poll_seconds_from_env, should_arm_reaper, watch_owner
+from godot_ai.orphan_reaper import (
+    boot_grace_from_env,
+    idle_grace_from_env,
+    poll_seconds_from_env,
+    should_arm_idle_exit,
+    should_arm_reaper,
+    watch_idle,
+    watch_owner,
+)
 from godot_ai.resources.classes import register_class_resources
 from godot_ai.resources.editor import register_editor_resources
 from godot_ai.resources.library import register_library_resources
@@ -150,6 +158,24 @@ def create_server(
                 owner_pid,
             )
 
+        ## Idle self-terminate backstop (#498). Runs ALONGSIDE the owner-PID
+        ## watchdog, not instead of it: pure session-count + monotonic-clock, so
+        ## it also covers Windows (where should_arm_reaper is False — #497) and
+        ## any path where the owner pid didn't survive env plumbing. Arms only
+        ## for plugin-spawned servers (GODOT_AI_PLUGIN_SPAWNED marker or owner
+        ## pid); manual dev servers, CI, and --reload runs are never idle-killed.
+        idle_task: asyncio.Task | None = None
+        if should_arm_idle_exit(owner_pid):
+            idle_task = asyncio.create_task(
+                watch_idle(
+                    lambda: len(registry.list_all()),
+                    poll_seconds=poll_seconds_from_env(),
+                    boot_grace_seconds=boot_grace_from_env(),
+                    idle_grace_seconds=idle_grace_from_env(),
+                )
+            )
+            logger.info("Idle self-terminate backstop armed for plugin-spawned server")
+
         ## Defer initial telemetry off the lifespan start tick — mirrors
         ## unity-mcp's 1s stdio-handshake guard so the first POST never
         ## races the MCP protocol's own startup chatter. Scheduled via
@@ -183,6 +209,12 @@ def create_server(
                 reaper_task.cancel()
                 try:
                     await reaper_task
+                except (asyncio.CancelledError, OSError):
+                    pass
+            if idle_task is not None:
+                idle_task.cancel()
+                try:
+                    await idle_task
                 except (asyncio.CancelledError, OSError):
                     pass
             ws_task.cancel()

--- a/tests/unit/test_orphan_reaper.py
+++ b/tests/unit/test_orphan_reaper.py
@@ -10,7 +10,14 @@ import sys
 import pytest
 
 from godot_ai import orphan_reaper
-from godot_ai.orphan_reaper import pid_alive, should_arm_reaper, watch_owner
+from godot_ai.orphan_reaper import (
+    DEFAULT_IDLE_GRACE_SECONDS,
+    pid_alive,
+    should_arm_idle_exit,
+    should_arm_reaper,
+    watch_idle,
+    watch_owner,
+)
 
 POSIX_ONLY_PID_ALIVE = pytest.mark.skipif(
     sys.platform.startswith("win"),
@@ -163,3 +170,202 @@ async def test_grace_recheck_prevents_reap_on_transient_zero():
     with pytest.raises(asyncio.CancelledError):
         await task
     assert calls == [], "must not reap when a transient zero recovers within the grace window"
+
+
+## ---- Idle self-terminate backstop (#498 / #497) -------------------------
+
+
+@pytest.fixture
+def _clean_idle_env(monkeypatch):
+    for name in (
+        orphan_reaper.PLUGIN_SPAWNED_ENV,
+        orphan_reaper.NO_IDLE_EXIT_ENV,
+        orphan_reaper.BOOT_GRACE_ENV,
+        orphan_reaper.IDLE_GRACE_ENV,
+        "GODOT_AI_DEV_TRANSPORT",
+        "GODOT_AI_OWNER_PID",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    return monkeypatch
+
+
+def test_idle_exit_not_armed_without_marker(_clean_idle_env):
+    ## Manual dev servers / CI have neither the marker nor an owner pid — they
+    ## must NEVER be idle-killed (#498's hard constraint).
+    assert should_arm_idle_exit(None) is False
+    assert should_arm_idle_exit(0) is False
+
+
+def test_idle_exit_armed_by_plugin_spawned_marker(_clean_idle_env):
+    _clean_idle_env.setenv(orphan_reaper.PLUGIN_SPAWNED_ENV, "1")
+    assert should_arm_idle_exit(None) is True
+
+
+def test_idle_exit_armed_by_owner_pid(_clean_idle_env):
+    ## Older plugin builds that predate the marker still plumb an owner pid;
+    ## that is proof enough of a plugin spawn.
+    assert should_arm_idle_exit(4242) is True
+
+
+def test_idle_exit_armed_on_windows(_clean_idle_env):
+    ## Unlike should_arm_reaper there is NO platform gate — this is the #497
+    ## Windows orphan coverage.
+    _clean_idle_env.setattr(orphan_reaper.sys, "platform", "win32")
+    _clean_idle_env.setenv(orphan_reaper.PLUGIN_SPAWNED_ENV, "1")
+    assert should_arm_idle_exit(None) is True
+
+
+def test_idle_exit_opt_out_disables(_clean_idle_env):
+    _clean_idle_env.setenv(orphan_reaper.PLUGIN_SPAWNED_ENV, "1")
+    _clean_idle_env.setenv(orphan_reaper.NO_IDLE_EXIT_ENV, "1")
+    assert should_arm_idle_exit(4242) is False
+    ## Falsey opt-out value does not disable.
+    _clean_idle_env.setenv(orphan_reaper.NO_IDLE_EXIT_ENV, "0")
+    assert should_arm_idle_exit(4242) is True
+
+
+def test_idle_exit_disabled_in_reload_mode(_clean_idle_env):
+    ## --reload dev runs export GODOT_AI_DEV_TRANSPORT for the uvicorn worker;
+    ## an idle reloading server is a dev convenience, not an orphan.
+    _clean_idle_env.setenv(orphan_reaper.PLUGIN_SPAWNED_ENV, "1")
+    _clean_idle_env.setenv("GODOT_AI_DEV_TRANSPORT", "streamable-http")
+    assert should_arm_idle_exit(4242) is False
+
+
+def test_idle_grace_env_defaults_and_fallbacks(_clean_idle_env):
+    assert orphan_reaper.boot_grace_from_env() == DEFAULT_IDLE_GRACE_SECONDS
+    assert orphan_reaper.idle_grace_from_env() == DEFAULT_IDLE_GRACE_SECONDS
+    _clean_idle_env.setenv(orphan_reaper.BOOT_GRACE_ENV, "7.5")
+    _clean_idle_env.setenv(orphan_reaper.IDLE_GRACE_ENV, "9")
+    assert orphan_reaper.boot_grace_from_env() == 7.5
+    assert orphan_reaper.idle_grace_from_env() == 9.0
+    ## Malformed / non-positive values must never become an instant kill.
+    _clean_idle_env.setenv(orphan_reaper.BOOT_GRACE_ENV, "banana")
+    _clean_idle_env.setenv(orphan_reaper.IDLE_GRACE_ENV, "-3")
+    assert orphan_reaper.boot_grace_from_env() == DEFAULT_IDLE_GRACE_SECONDS
+    assert orphan_reaper.idle_grace_from_env() == DEFAULT_IDLE_GRACE_SECONDS
+
+
+class _FakeClock:
+    """Monotonic fake advanced by the test, so no real sleeps beyond the
+    sub-millisecond asyncio poll ticks."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+async def test_idle_exits_after_boot_grace_with_no_session_ever():
+    calls: list[bool] = []
+    clock = _FakeClock()
+
+    def session_count() -> int:
+        clock.now += 4.0  # each poll "takes" 4s on the fake clock
+        return 0
+
+    await asyncio.wait_for(
+        watch_idle(
+            session_count,
+            poll_seconds=0.001,
+            boot_grace_seconds=10.0,
+            idle_grace_seconds=1000.0,
+            clock=clock,
+            shutdown=lambda: calls.append(True),
+        ),
+        timeout=2.0,
+    )
+    assert calls == [True]
+    assert clock.now >= 10.0, "must not exit before the boot grace elapses"
+
+
+async def test_idle_boot_grace_honored_before_expiry():
+    ## Clock advances but stays inside the boot grace — no shutdown.
+    calls: list[bool] = []
+    clock = _FakeClock()
+
+    def session_count() -> int:
+        clock.now = min(clock.now + 1.0, 9.0)  # never reaches the 10s grace
+        return 0
+
+    task = asyncio.create_task(
+        watch_idle(
+            session_count,
+            poll_seconds=0.001,
+            boot_grace_seconds=10.0,
+            idle_grace_seconds=10.0,
+            clock=clock,
+            shutdown=lambda: calls.append(True),
+        )
+    )
+    await asyncio.sleep(0.05)  # many poll cycles
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert calls == []
+
+
+async def test_idle_clock_resets_on_session_connect_and_starts_on_disconnect():
+    ## Sessions connected well past the boot grace, then disconnect: the exit
+    ## must come one idle grace after the LAST poll that saw a session, not
+    ## relative to boot.
+    calls: list[bool] = []
+    clock = _FakeClock()
+    state = {"last_seen": None}
+
+    def auto_advancing_clock() -> float:
+        clock.now += 5.0  # each poll "takes" 5s on the fake clock
+        return clock.now
+
+    def session_count() -> int:
+        if clock.now < 100.0:  # connected far beyond the 10s boot grace
+            state["last_seen"] = clock.now
+            return 1
+        return 0
+
+    await asyncio.wait_for(
+        watch_idle(
+            session_count,
+            poll_seconds=0.001,
+            boot_grace_seconds=10.0,
+            idle_grace_seconds=30.0,
+            clock=auto_advancing_clock,
+            shutdown=lambda: calls.append(True),
+        ),
+        timeout=2.0,
+    )
+    assert calls == [True]
+    ## Connected phase outlived the boot grace many times over without a reap,
+    ## and the exit happened only after a full idle grace after the last poll
+    ## that observed a session (watch_idle's documented disconnect anchor).
+    assert state["last_seen"] is not None
+    assert clock.now - state["last_seen"] >= 30.0
+
+
+async def test_idle_transient_zero_dip_does_not_exit():
+    ## Plugin-reload reconnect gap: one zero-session poll inside the grace,
+    ## then the session is back. Must not exit.
+    calls: list[bool] = []
+    clock = _FakeClock()
+    counts = iter([1, 1, 0])  # transient dip, then 1 forever
+
+    def session_count() -> int:
+        clock.now += 1.0
+        return next(counts, 1)
+
+    task = asyncio.create_task(
+        watch_idle(
+            session_count,
+            poll_seconds=0.001,
+            boot_grace_seconds=10.0,
+            idle_grace_seconds=10.0,
+            clock=clock,
+            shutdown=lambda: calls.append(True),
+        )
+    )
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert calls == []


### PR DESCRIPTION
Implements stage 1 of the decision recorded on #498: session-idle self-terminate as a cross-platform backstop **alongside** the existing owner-PID watchdog (which stays untouched as the POSIX fast path). This is also the first orphan coverage on Windows, where `should_arm_reaper` is gated off (#497).

## How it works

`watch_idle` in `orphan_reaper.py`: a plugin-spawned server with **zero connected editor sessions** for a full grace window shuts itself down. Pure session-count + monotonic clock — no process probing, so no Windows gate.

- **Boot grace** (default 120s): from task start until the first-ever session connects — covers a spawn whose editor dies before the WebSocket handshake.
- **Idle grace** (default 120s): restarts on every poll that observes a session, i.e. measures time since last disconnect (under-counts by at most one poll interval). Sized ~20× the observed ~6s plugin-reload reconnect gap, so a reload's zero-session dip can never trigger it.
- Env knobs: `GODOT_AI_IDLE_BOOT_GRACE_SECONDS` / `GODOT_AI_IDLE_GRACE_SECONDS` (malformed/non-positive values fall back to the default — a bad env var can never become an instant kill); opt-out `GODOT_AI_NO_IDLE_EXIT`.

## Arming (the safety-critical part)

`should_arm_idle_exit` arms **only** for plugin-spawned servers: the new `GODOT_AI_PLUGIN_SPAWNED` marker (set by `server_lifecycle.gd` around `OS.create_process` on every platform, unset immediately after spawn — same tight scoping as `GODOT_AI_OWNER_PID`) or a plumbed owner pid (older plugin builds). Never arms for manual dev servers, CI (`ci-start-server`), `--reload` runs (detected via `GODOT_AI_DEV_TRANSPORT`), or when opted out.

## Windows shutdown path

`_request_self_shutdown` now uses `signal.raise_signal(SIGTERM)` on win32 — invoking uvicorn's in-process handler for a graceful drain — instead of `os.kill`, which is `TerminateProcess` there.

## Tests

`tests/unit/test_orphan_reaper.py`: arming matrix (marker / owner-pid / win32 / opt-out incl. falsey "0" / reload-mode), grace env defaults/overrides/malformed fallback, boot-grace exit and no-early-exit, connect-resets-then-disconnect-starts-clock, transient zero-dip no-exit. All on fake monotonic clocks.

**Full suite: 1279 passed, 2 skipped (pre-existing platform skips); `ruff` clean.** `server_lifecycle.gd` verified with `gdparse`.

## Not verifiable in this environment (flagging for live testing)

- A real plugin-spawned server receiving the marker and idle-exiting after grace (env scoping around `OS.create_process` is reasoned + parse-checked, not live-exercised).
- The Windows `raise_signal` → uvicorn graceful-drain path end to end.

Stage 2 (removing the owner-PID channel once idle soaks) stays tracked in #498.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017bCB9GDsZBp9wk7hjCGeu2

---
_Generated by [Claude Code](https://claude.ai/code/session_017bCB9GDsZBp9wk7hjCGeu2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic cleanup of abandoned plugin-launched servers, including on Windows.
  * Added safeguards to terminate servers that remain disconnected beyond configurable grace periods.
  * Prevented shutdown during startup grace periods and tolerated brief connection drops.
  * Improved Windows shutdown behavior for more reliable termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->