### PR TITLE
Surface a clear port-in-use message for foreign occupants of the HTTP/WS ports (#647)

### DIFF
--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -951,7 +951,12 @@ func _update_status() -> void:
 		status_text = "Incompatible server on port %d" % ClientConfigurator.http_port()
 		status_color = Color.RED
 	elif state == ServerStateScript.FOREIGN_PORT:
-		status_text = "Port %d held by another process" % ClientConfigurator.http_port()
+		## #647: the post-crash probe names the actual conflicting port
+		## (HTTP or WS) — don't blame port 8000 when 9500 is the occupant.
+		var conflict_port: int = int(server_status.get("conflict_port", 0))
+		if conflict_port <= 0:
+			conflict_port = ClientConfigurator.http_port()
+		status_text = "Port %d held by another process" % conflict_port
 		status_color = Color.RED
 	elif state == ServerStateScript.NO_COMMAND:
 		status_text = "No server command found"
@@ -1021,9 +1026,14 @@ func _update_crash_panel(server_status: Dictionary) -> void:
 			and not bool(server_status.get("can_recover_incompatible", false))
 		)
 
+	## #647: the quick picker only moves `godot_ai/http_port`, so hide it
+	## when the diagnosed conflict is on the WebSocket port — the crash
+	## body already points at `godot_ai/ws_port` in Editor Settings.
+	var conflict_port := int(server_status.get("conflict_port", 0))
+	var http_conflict := conflict_port <= 0 or conflict_port == ClientConfigurator.http_port()
 	var port_picker_visible := (
 		state == ServerStateScript.PORT_EXCLUDED
-		or state == ServerStateScript.FOREIGN_PORT
+		or (state == ServerStateScript.FOREIGN_PORT and http_conflict)
 	)
 	_port_picker_panel.visible = port_picker_visible
 	if port_picker_visible:
@@ -1060,6 +1070,12 @@ static func _crash_body_for_state(state: int, server_status: Dictionary = {}) ->
 				return "%s %s" % [message, hint]
 			return "Port %d is occupied by an incompatible server. %s" % [port, hint]
 		ServerStateScript.FOREIGN_PORT:
+			## #647: prefer the lifecycle's diagnosis (it names the right
+			## port — HTTP vs WS — and the Editor Setting to change) over
+			## the generic HTTP-port fallback.
+			var foreign_message := str(server_status.get("message", ""))
+			if not foreign_message.is_empty():
+				return foreign_message
 			return "Another process is already bound to port %d. Pick a free port or stop the other process." % port
 		ServerStateScript.CRASHED:
 			## Both spawn attempts failed on the uvx tier — almost always

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -46,6 +46,11 @@ var _server_actual_name: String = ""
 
 ## Diagnostic + recovery flags surfaced to the dock via `get_status()`.
 var _server_status_message: String = ""
+## #647: when a post-crash probe pins the failure on a specific port held
+## by a foreign process, this names that port (HTTP or WS) so the dock's
+## status line and port-picker gating don't blame the wrong one. Zero when
+## no conflict was diagnosed.
+var _conflict_port: int = 0
 var _can_recover_incompatible: bool = false
 var _connection_blocked: bool = false
 
@@ -88,6 +93,7 @@ func get_status_dict() -> Dictionary:
 		"message": _server_status_message,
 		"can_recover_incompatible": _can_recover_incompatible,
 		"connection_blocked": _connection_blocked,
+		"conflict_port": _conflict_port,
 	}
 
 
@@ -425,6 +431,7 @@ func start_server() -> void:
 		return
 
 	_refresh_retried = false
+	_conflict_port = 0
 
 	var port := ClientConfigurator.http_port()
 	var ws_port := ClientConfigurator.ws_port()
@@ -615,6 +622,26 @@ func check_server_health() -> void:
 		_server_pid = real_pid
 	elif not PortResolver.pid_alive(spawn_pid):
 		if elapsed >= int(_host.SPAWN_GRACE_MS) and not McpServerStateScript.is_terminal_diagnosis(_server_state):
+			## #647: the server died inside the grace window. If a foreign
+			## (non-godot-ai) process holds the HTTP or WS port, the server
+			## exited fast with its "port already in use" stderr message and
+			## EXIT_PORT_IN_USE — but we can't read the child's stderr, so
+			## re-probe the ports and surface FOREIGN_PORT with an actionable
+			## message instead of a bare CRASHED pointing at the output log.
+			## Checked before the --refresh retry: respawning against an
+			## occupied port can only fail the same way.
+			var conflict := _diagnose_spawn_port_conflict()
+			if not conflict.is_empty():
+				_server_exit_ms = elapsed
+				_server_status_message = str(conflict.get("message", ""))
+				_conflict_port = int(conflict.get("port", 0))
+				set_terminal_diagnosis(McpServerStateScript.FOREIGN_PORT)
+				disarm_version_check()
+				_host._update_process_enabled()
+				_host._log_buffer.log(str(_server_status_message))
+				push_warning("MCP | %s" % _server_status_message)
+				_host._stop_server_watch()
+				return
 			if bool(_host._should_retry_with_refresh()):
 				_refresh_retried = true
 				respawn_with_refresh()
@@ -629,6 +656,38 @@ func check_server_health() -> void:
 	if elapsed >= int(_host.SERVER_WATCH_MS):
 		## Survived startup — mid-session crashes surface via WebSocket disconnect.
 		_host._stop_server_watch()
+
+
+## #647: post-crash port-conflict probe. Returns `{}` when no foreign
+## conflict is detected (fall through to the CRASHED / retry path), or
+## `{"message": String, "port": int}` when the HTTP or WS port is held by
+## a process we can't identify as godot-ai. An occupant that *does*
+## identify as godot-ai is deliberately not diagnosed here — that's the
+## stale-server / adoption territory handled by the next `start_server`
+## walk, not a foreign conflict.
+func _diagnose_spawn_port_conflict() -> Dictionary:
+	var http_port := ClientConfigurator.http_port()
+	if bool(_host._is_port_in_use(http_port)):
+		var live: Dictionary = _host._probe_live_server_status_for_port(http_port)
+		if _live_status_identifies_godot_ai(live):
+			return {}
+		return {
+			"message": (
+				"Port %d is in use by another application. Stop it or change "
+				+ "the port in Editor Settings (godot_ai/http_port)."
+			) % http_port,
+			"port": http_port,
+		}
+	var ws_port := int(_host._resolved_ws_port)
+	if ws_port > 0 and bool(_host._is_port_in_use(ws_port)):
+		return {
+			"message": (
+				"WebSocket port %d is in use by another application. Stop it "
+				+ "or change the port in Editor Settings (godot_ai/ws_port)."
+			) % ws_port,
+			"port": ws_port,
+		}
+	return {}
 
 
 ## Retry the spawn with uvx `--refresh` prepended (PyPI index can lag a
@@ -842,6 +901,7 @@ func recover_incompatible_server() -> bool:
 	transition_state(McpServerStateScript.STOPPED)
 	_connection_blocked = false
 	_server_status_message = ""
+	_conflict_port = 0
 	_server_actual_version = ""
 	_server_actual_name = ""
 	_can_recover_incompatible = false

--- a/src/godot_ai/__init__.py
+++ b/src/godot_ai/__init__.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import argparse
+import errno
 import os
+import socket
+import sys
 import tomllib
 from collections.abc import Sequence
 from importlib.metadata import PackageNotFoundError
@@ -38,6 +41,60 @@ def _resolve_version(package_file: str | Path) -> str:
 
 
 __version__ = _resolve_version(__file__)
+
+
+## #647: distinctive exit code for "a port we need is held by another
+## process" — mirrors Linux's EADDRINUSE errno so it reads naturally in
+## logs, and is distinguishable from uvicorn's generic exit(1) so the Godot
+## plugin (and CI) can recognize a port conflict from the exit alone.
+EXIT_PORT_IN_USE = 98
+
+
+def _is_eaddrinuse(exc: OSError) -> bool:
+    ## #647: POSIX raises errno.EADDRINUSE (48 macOS / 98 Linux). Windows
+    ## surfaces WSAEADDRINUSE 10048 — usually mapped onto errno.EADDRINUSE
+    ## by CPython, but check winerror and the raw value too so no platform
+    ## variant slips through to a generic traceback.
+    return (
+        exc.errno == errno.EADDRINUSE
+        or exc.errno == 10048
+        or getattr(exc, "winerror", None) == 10048
+    )
+
+
+def preflight_check_port(port: int, *, label: str, setting: str, host: str = "127.0.0.1") -> None:
+    """Exit with a distinctive stderr message + exit code when `port` is taken.
+
+    #647: when a foreign process (e.g. a docker container) already owns the
+    HTTP or WebSocket port, uvicorn/websockets fail with an opaque bind error
+    (or, for the WS port, a warning that leaves the server half-alive). Probe
+    the bind up front and fail fast with a message humans can act on and an
+    exit code (EXIT_PORT_IN_USE) the Godot plugin can recognize.
+
+    Ports that fail to bind for other reasons (EACCES, Windows winnat
+    exclusion ranges) keep their existing downstream failure modes.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        if os.name != "nt":
+            ## Mirror uvicorn/websockets SO_REUSEADDR so a just-stopped
+            ## server's TIME_WAIT socket doesn't false-positive as a
+            ## foreign occupant. Skipped on Windows, where SO_REUSEADDR
+            ## means "hijack the active listener".
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.bind((host, port))
+        except OSError as exc:
+            if _is_eaddrinuse(exc):
+                print(
+                    f"godot-ai: {label} port {port} is already in use by another "
+                    f"process. Stop it or change the port ({setting} in Godot "
+                    "Editor Settings).",
+                    file=sys.stderr,
+                )
+                raise SystemExit(EXIT_PORT_IN_USE) from exc
+    finally:
+        sock.close()
 
 
 def main(argv: Sequence[str] | None = None) -> None:
@@ -138,6 +195,19 @@ def main(argv: Sequence[str] | None = None) -> None:
         import fastmcp
 
         fastmcp.settings.host = bind_host_for_networks(allow_host_networks)
+
+    ## #647: fail fast — with a recognizable message and exit code — when a
+    ## foreign process holds a port we need, instead of uvicorn's opaque bind
+    ## error (HTTP) or the half-alive warn-and-continue (WS). Scoped to the
+    ## HTTP transports, i.e. the plugin-managed / dev-server spawn paths;
+    ## stdio keeps the existing tolerate-WS-conflict behavior so a stdio
+    ## client can still use non-Godot tools next to a running editor server.
+    if args.transport in ("sse", "streamable-http"):
+        http_host = (
+            bind_host_for_networks(allow_host_networks) if allow_host_networks else "127.0.0.1"
+        )
+        preflight_check_port(args.port, label="HTTP", setting="godot_ai/http_port", host=http_host)
+        preflight_check_port(args.ws_port, label="WebSocket", setting="godot_ai/ws_port")
 
     from godot_ai.runtime_info import install_pid_file
 

--- a/src/godot_ai/__init__.py
+++ b/src/godot_ai/__init__.py
@@ -74,7 +74,11 @@ def preflight_check_port(port: int, *, label: str, setting: str, host: str = "12
     Ports that fail to bind for other reasons (EACCES, Windows winnat
     exclusion ranges) keep their existing downstream failure modes.
     """
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    ## --allow-host can resolve an IPv6 bind host ("::") via
+    ## bind_host_for_networks(); an AF_INET socket can't bind those, so pick
+    ## the family from the host (Copilot review on #647's PR).
+    family = socket.AF_INET6 if ":" in host else socket.AF_INET
+    sock = socket.socket(family, socket.SOCK_STREAM)
     try:
         if os.name != "nt":
             ## Mirror uvicorn/websockets SO_REUSEADDR so a just-stopped
@@ -93,6 +97,11 @@ def preflight_check_port(port: int, *, label: str, setting: str, host: str = "12
                     file=sys.stderr,
                 )
                 raise SystemExit(EXIT_PORT_IN_USE) from exc
+            ## Any other bind failure (EACCES, EADDRNOTAVAIL, winnat
+            ## exclusion ranges, exotic address families) is NOT the
+            ## condition this preflight exists to catch — let the real
+            ## server startup produce its existing failure mode instead
+            ## of the probe inventing a new earlier crash.
     finally:
         sock.close()
 

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -788,6 +788,23 @@ func test_crashed_body_mentions_pypi_propagation_on_uvx_tier() -> void:
 		assert_contains(body, "output log", "Non-uvx body should still point at Godot's traceback")
 
 
+func test_foreign_port_body_prefers_lifecycle_message() -> void:
+	## #647: when the post-crash probe diagnosed which port a foreign
+	## process holds, the crash body must render that message verbatim
+	## (it names the right port and Editor Setting) instead of the
+	## generic HTTP-port fallback.
+	var message := "WebSocket port 9500 is in use by another application. Stop it or change the port in Editor Settings (godot_ai/ws_port)."
+	var body := McpDockScript._crash_body_for_state(
+		McpServerState.FOREIGN_PORT, {"message": message}
+	)
+	assert_eq(body, message)
+
+
+func test_foreign_port_body_without_message_keeps_generic_fallback() -> void:
+	var body := McpDockScript._crash_body_for_state(McpServerState.FOREIGN_PORT)
+	assert_contains(body, "Another process is already bound to port")
+
+
 # --- Configure / Remove run off-thread (issue #239) ----------------------
 
 func _first_client_id() -> String:

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -308,6 +308,77 @@ func test_check_server_health_short_circuits_when_pid_zero() -> void:
 	assert_eq(stops, 1)
 
 
+# ----- #647: post-crash foreign-port-conflict diagnosis ----------------
+
+func test_diagnose_spawn_port_conflict_flags_foreign_http_occupant() -> void:
+	var host := _ManagerHostStub.new()
+	host.port_in_use = true
+	host.live_status = {"name": "", "version": "", "ws_port": 0, "status_code": 0}
+	var manager := McpServerLifecycleManagerScript.new(host)
+
+	var conflict: Dictionary = manager._diagnose_spawn_port_conflict()
+	host.free()
+
+	assert_has_key(conflict, "message")
+	var http_port := McpClientConfigurator.http_port()
+	assert_eq(int(conflict.get("port", 0)), http_port)
+	assert_contains(str(conflict.get("message", "")), "Port %d is in use by another application" % http_port)
+	assert_contains(str(conflict.get("message", "")), "godot_ai/http_port")
+
+
+func test_diagnose_spawn_port_conflict_ignores_godot_ai_occupant() -> void:
+	## A port holder that identifies as godot-ai is stale-server /
+	## adoption territory, not a foreign conflict — the CRASHED / retry
+	## path must keep handling it. See #647.
+	var host := _ManagerHostStub.new()
+	host.port_in_use = true
+	host.live_status = {"name": "godot-ai", "version": "1.0.0", "ws_port": 9500, "status_code": 200}
+	var manager := McpServerLifecycleManagerScript.new(host)
+
+	var conflict: Dictionary = manager._diagnose_spawn_port_conflict()
+	host.free()
+
+	assert_true(conflict.is_empty(), "godot-ai occupant must not be diagnosed as foreign")
+
+
+func test_diagnose_spawn_port_conflict_flags_foreign_ws_occupant() -> void:
+	var host := _ManagerHostStub.new()
+	## First probe (HTTP port) free, second (WS port) occupied.
+	host.port_in_use_sequence = [false, true] as Array[bool]
+	var manager := McpServerLifecycleManagerScript.new(host)
+
+	var conflict: Dictionary = manager._diagnose_spawn_port_conflict()
+	var ws_port := int(GodotAiPlugin._resolved_ws_port)
+	host.free()
+
+	assert_has_key(conflict, "message")
+	assert_eq(int(conflict.get("port", 0)), ws_port)
+	assert_contains(str(conflict.get("message", "")), "WebSocket port %d is in use" % ws_port)
+	assert_contains(str(conflict.get("message", "")), "godot_ai/ws_port")
+
+
+func test_diagnose_spawn_port_conflict_empty_when_ports_free() -> void:
+	var host := _ManagerHostStub.new()
+	host.port_in_use = false
+	var manager := McpServerLifecycleManagerScript.new(host)
+
+	var conflict: Dictionary = manager._diagnose_spawn_port_conflict()
+	host.free()
+
+	assert_true(conflict.is_empty(), "no conflict expected when both ports are free")
+
+
+func test_status_dict_carries_conflict_port() -> void:
+	var host := _ManagerHostStub.new()
+	var manager := McpServerLifecycleManagerScript.new(host)
+	manager._conflict_port = 9500
+
+	var status: Dictionary = manager.get_status_dict()
+	host.free()
+
+	assert_eq(int(status.get("conflict_port", 0)), 9500)
+
+
 func test_start_server_short_circuits_on_static_guard() -> void:
 	GodotAiPlugin._server_started_this_session = true
 	var host := _ManagerHostStub.new()

--- a/tests/unit/test_port_preflight.py
+++ b/tests/unit/test_port_preflight.py
@@ -90,3 +90,32 @@ def test_main_exits_when_ws_port_taken(capsys: pytest.CaptureFixture[str]) -> No
     err = capsys.readouterr().err
     assert f"WebSocket port {ws_port} is already in use" in err
     assert "godot_ai/ws_port" in err
+
+
+def test_preflight_ipv6_host_binds_with_correct_family():
+    ## Copilot review on the #647 PR: --allow-host can resolve an IPv6 bind
+    ## host ("::"); an AF_INET probe would raise an address-family error and
+    ## crash startup instead of preflighting. A free port on "::1" must probe
+    ## clean (no SystemExit, no OSError).
+    import socket
+
+    sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    sock.bind(("::1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    preflight_check_port(port, label="HTTP", setting="godot_ai/http_port", host="::1")
+
+
+def test_preflight_ipv6_host_detects_occupied_port():
+    import socket
+
+    holder = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    holder.bind(("::1", 0))
+    holder.listen(1)
+    port = holder.getsockname()[1]
+    try:
+        with pytest.raises(SystemExit) as excinfo:
+            preflight_check_port(port, label="HTTP", setting="godot_ai/http_port", host="::1")
+        assert excinfo.value.code == EXIT_PORT_IN_USE
+    finally:
+        holder.close()

--- a/tests/unit/test_port_preflight.py
+++ b/tests/unit/test_port_preflight.py
@@ -92,6 +92,16 @@ def test_main_exits_when_ws_port_taken(capsys: pytest.CaptureFixture[str]) -> No
     assert "godot_ai/ws_port" in err
 
 
+def _ipv6_available() -> bool:
+    import socket
+
+    try:
+        socket.socket(socket.AF_INET6, socket.SOCK_STREAM).close()
+        return True
+    except OSError:
+        return False
+
+
 def test_preflight_ipv6_host_binds_with_correct_family():
     ## Copilot review on the #647 PR: --allow-host can resolve an IPv6 bind
     ## host ("::"); an AF_INET probe would raise an address-family error and
@@ -99,6 +109,8 @@ def test_preflight_ipv6_host_binds_with_correct_family():
     ## clean (no SystemExit, no OSError).
     import socket
 
+    if not _ipv6_available():
+        pytest.skip("IPv6 not available in this environment")
     sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
     sock.bind(("::1", 0))
     port = sock.getsockname()[1]
@@ -109,6 +121,8 @@ def test_preflight_ipv6_host_binds_with_correct_family():
 def test_preflight_ipv6_host_detects_occupied_port():
     import socket
 
+    if not _ipv6_available():
+        pytest.skip("IPv6 not available in this environment")
     holder = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
     holder.bind(("::1", 0))
     holder.listen(1)

--- a/tests/unit/test_port_preflight.py
+++ b/tests/unit/test_port_preflight.py
@@ -1,0 +1,92 @@
+"""#647: startup pre-flight for HTTP/WS ports held by a foreign process."""
+
+from __future__ import annotations
+
+import socket
+from contextlib import closing
+
+import pytest
+
+from godot_ai import EXIT_PORT_IN_USE, main, preflight_check_port
+
+
+def _reserve_port() -> tuple[socket.socket, int]:
+    """Bind + listen a throwaway socket on a random free loopback port."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(1)
+    return sock, sock.getsockname()[1]
+
+
+def _free_port() -> int:
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def test_preflight_passes_on_free_port() -> None:
+    ## Must also not leave the port unbindable afterwards (probe socket is
+    ## closed, SO_REUSEADDR set) — bind it again to prove that.
+    port = _free_port()
+    preflight_check_port(port, label="HTTP", setting="godot_ai/http_port")
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        sock.bind(("127.0.0.1", port))
+
+
+def test_preflight_exits_with_distinctive_code_and_message(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    blocker, port = _reserve_port()
+    try:
+        with pytest.raises(SystemExit) as excinfo:
+            preflight_check_port(port, label="HTTP", setting="godot_ai/http_port")
+    finally:
+        blocker.close()
+    assert excinfo.value.code == EXIT_PORT_IN_USE
+    err = capsys.readouterr().err
+    assert f"HTTP port {port} is already in use by another process" in err
+    assert "godot_ai/http_port" in err
+
+
+def test_main_exits_before_serving_when_http_port_taken(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    blocker, port = _reserve_port()
+    try:
+        with pytest.raises(SystemExit) as excinfo:
+            main(
+                [
+                    "--transport",
+                    "streamable-http",
+                    "--port",
+                    str(port),
+                    "--ws-port",
+                    str(_free_port()),
+                ]
+            )
+    finally:
+        blocker.close()
+    assert excinfo.value.code == EXIT_PORT_IN_USE
+    assert f"HTTP port {port} is already in use" in capsys.readouterr().err
+
+
+def test_main_exits_when_ws_port_taken(capsys: pytest.CaptureFixture[str]) -> None:
+    blocker, ws_port = _reserve_port()
+    try:
+        with pytest.raises(SystemExit) as excinfo:
+            main(
+                [
+                    "--transport",
+                    "streamable-http",
+                    "--port",
+                    str(_free_port()),
+                    "--ws-port",
+                    str(ws_port),
+                ]
+            )
+    finally:
+        blocker.close()
+    assert excinfo.value.code == EXIT_PORT_IN_USE
+    err = capsys.readouterr().err
+    assert f"WebSocket port {ws_port} is already in use" in err
+    assert "godot_ai/ws_port" in err


### PR DESCRIPTION
Fixes #647.

## What was actually broken

The pre-spawn foreign-occupant check on the HTTP port already existed (the `foreign-server` smoke asserts it). The real gaps were **post-spawn**:

1. A bind failure on the HTTP port (TOCTOU race past the pre-check) made uvicorn exit with an opaque error; the dock showed only "Server exited after N.Ns — check Godot's output log".
2. A foreign process on the **WS port (9500)** was never checked at all — `transport/websocket.py` deliberately swallows EADDRINUSE and keeps serving MCP-without-WS, leaving the dock stuck on "Disconnected" with zero diagnosis. (This is the docker-container scenario from the issue.)

## Server side

`preflight_check_port()` in `__init__.py` + `EXIT_PORT_IN_USE = 98`: for HTTP transports, `main()` test-binds both ports up front and exits 98 with an actionable stderr message naming the port and the Editor Setting to change. `SO_REUSEADDR` on POSIX so a just-stopped server's TIME_WAIT never false-positives (skipped on Windows where it means listener hijack); handles POSIX `EADDRINUSE` and Windows 10048/winerror. stdio transport keeps its tolerate-WS-conflict behavior (locked in by its existing tests).

## Plugin side

When a spawn dies inside the grace window, `check_server_health` now re-probes both ports **before** the `--refresh` retry (respawning against an occupied port can only fail identically). A non-godot-ai occupant latches the existing `FOREIGN_PORT` terminal state with the actionable message and a new `conflict_port` status field; godot-ai-branded occupants still fall through to the untouched stale-server/adoption flows. Dock: crash panel prefers the lifecycle's diagnosis, the status line names the *actual* conflicting port, and the HTTP-only quick port picker hides for WS-port conflicts.

## Tests

- Python: 4 new tests in `tests/unit/test_port_preflight.py` (bind a throwaway socket first, assert exit 98 + message via helper and `main()`). Full suite 1272 passed / 2 pre-existing skips; `ruff` clean. Also live-verified: a real subprocess against a blocked port exits 98 with the exact message for both HTTP and WS.
- GDScript: 5 stub-driven tests in `test_server_lifecycle.gd` (foreign HTTP / godot-ai occupant ignored / foreign WS / no conflict / status plumbing) + 2 in `test_dock.gd` (crash-body preference/fallback). `gdparse` clean; suite runs in CI.

## Needs live-editor verification

Dock rendering of the FOREIGN_PORT panel for this path — hold 8000 or 9500 with `python -m http.server` / `nc -l` while the editor spawns the server, and confirm message text, port-picker hidden for the WS case, Reload Plugin visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017bCB9GDsZBp9wk7hjCGeu2

---
_Generated by [Claude Code](https://claude.ai/code/session_017bCB9GDsZBp9wk7hjCGeu2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and reporting of HTTP and WebSocket port conflicts.
  * Error messages now identify the specific conflicting port or resource.
  * The Port Picker appears only when changing the affected HTTP port can resolve the issue.
  * Server startup now stops earlier with a clear error when required ports are already in use.
* **Tests**
  * Added coverage for HTTP, WebSocket, IPv4, and IPv6 port-conflict scenarios.
  * Added validation for conflict details shown in the crash panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->