### PR TITLE
Rename Windsurf client to Devin Desktop (#623)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ covers:
 <details>
 <summary><strong>…and 16+ more clients</strong></summary>
 
-Codex, Cursor, Windsurf, VS Code, VS Code Insiders, Zed, Gemini CLI, Cline,
+Codex, Cursor, Devin Desktop (formerly Windsurf), VS Code, VS Code Insiders, Zed, Gemini CLI, Cline,
 Kilo Code, Roo Code, Kiro, Trae, Cherry Studio, OpenCode, Qwen Code,
 Kimi Code.
 

--- a/plugin/addons/godot_ai/clients/windsurf.gd
+++ b/plugin/addons/godot_ai/clients/windsurf.gd
@@ -3,10 +3,16 @@ extends McpClient
 
 
 func _init() -> void:
+	# #623: Windsurf was rebranded to Devin Desktop by Cognition (June 2026).
+	# The id stays "windsurf" — it is the stable registry key used for
+	# configured-status lookups. The MCP config path is unchanged by the
+	# rebrand: per the official docs (docs.devin.ai/desktop/cascade/mcp) the
+	# global config still lives under ~/.codeium/windsurf/, and migrated
+	# installs carry their settings over in place.
 	id = "windsurf"
-	display_name = "Windsurf"
+	display_name = "Devin Desktop (Windsurf)"
 	config_type = "json"
-	doc_url = "https://docs.codeium.com/windsurf/mcp"
+	doc_url = "https://docs.devin.ai/desktop/cascade/mcp"
 	path_template = {
 		"unix": "~/.codeium/windsurf/mcp_config.json",
 		"windows": "$USERPROFILE/.codeium/windsurf/mcp_config.json",

--- a/plugin/addons/godot_ai/clients/windsurf.gd
+++ b/plugin/addons/godot_ai/clients/windsurf.gd
@@ -7,8 +7,9 @@ func _init() -> void:
 	# The id stays "windsurf" — it is the stable registry key used for
 	# configured-status lookups. The MCP config path is unchanged by the
 	# rebrand: per the official docs (docs.devin.ai/desktop/cascade/mcp) the
-	# global config still lives under ~/.codeium/windsurf/, and migrated
-	# installs carry their settings over in place.
+	# global config still lives under the platform's `.codeium/windsurf/`
+	# directory (~/.codeium/windsurf/ on unix, $USERPROFILE/.codeium/windsurf/
+	# on Windows), and migrated installs carry their settings over in place.
 	id = "windsurf"
 	display_name = "Devin Desktop (Windsurf)"
 	config_type = "json"

--- a/src/godot_ai/tools/client.py
+++ b/src/godot_ai/tools/client.py
@@ -9,7 +9,7 @@ from godot_ai.tools._meta_tool import register_manage_tool
 
 _DESCRIPTION = """\
 Configure AI clients to use this Godot AI MCP server. Writes / removes
-client config files (Claude Code, Codex, Antigravity, Cursor, Windsurf,
+client config files (Claude Code, Codex, Antigravity, Cursor, Devin Desktop (Windsurf),
 Zed, etc.).
 
 Ops:

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -66,13 +66,21 @@ func test_windsurf_rebrand_to_devin_desktop() -> void:
 	## #623: Windsurf was rebranded to Devin Desktop by Cognition (June 2026).
 	## The registry id must stay "windsurf" (stable key for configured-status
 	## lookups) and the config path is unchanged — migrated installs keep
-	## ~/.codeium/windsurf/mcp_config.json. Only the display name changed.
+	## ~/.codeium/windsurf/mcp_config.json. Only the display name and docs
+	## URL changed. Pin the exact path templates so base-path drift (not
+	## just a suffix change) fails loudly.
 	var client := McpClientRegistry.get_by_id("windsurf")
 	assert_true(client != null, "windsurf id must remain registered after #623 rebrand")
 	assert_eq(client.display_name, "Devin Desktop (Windsurf)")
-	assert_true(
-		String(client.path_template.get("unix", "")).ends_with(".codeium/windsurf/mcp_config.json"),
-		"windsurf config path must stay under ~/.codeium/windsurf/ (#623)"
+	assert_eq(
+		String(client.path_template.get("unix", "")),
+		"~/.codeium/windsurf/mcp_config.json",
+		"windsurf unix config path must stay exactly ~/.codeium/windsurf/mcp_config.json (#623)"
+	)
+	assert_eq(
+		String(client.path_template.get("windows", "")),
+		"$USERPROFILE/.codeium/windsurf/mcp_config.json",
+		"windsurf windows config path must stay exactly $USERPROFILE/.codeium/windsurf/mcp_config.json (#623)"
 	)
 
 

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -62,6 +62,20 @@ func test_registry_ids_are_unique() -> void:
 	assert_gt(seen.size(), 0)
 
 
+func test_windsurf_rebrand_to_devin_desktop() -> void:
+	## #623: Windsurf was rebranded to Devin Desktop by Cognition (June 2026).
+	## The registry id must stay "windsurf" (stable key for configured-status
+	## lookups) and the config path is unchanged — migrated installs keep
+	## ~/.codeium/windsurf/mcp_config.json. Only the display name changed.
+	var client := McpClientRegistry.get_by_id("windsurf")
+	assert_true(client != null, "windsurf id must remain registered after #623 rebrand")
+	assert_eq(client.display_name, "Devin Desktop (Windsurf)")
+	assert_true(
+		String(client.path_template.get("unix", "")).ends_with(".codeium/windsurf/mcp_config.json"),
+		"windsurf config path must stay under ~/.codeium/windsurf/ (#623)"
+	)
+
+
 func test_every_client_has_required_fields() -> void:
 	for client in McpClientRegistry.all():
 		assert_true(not client.id.is_empty(), "Client missing id: %s" % client)


### PR DESCRIPTION
Fixes #623.

Cognition rebranded Windsurf to **Devin Desktop** on June 2, 2026. This updates the client descriptor accordingly — deliberately minimal, because research shows the rebrand does **not** move the MCP config:

- `display_name` → "Devin Desktop (Windsurf)"; `doc_url` → the docs.devin.ai MCP page.
- **`id` stays `"windsurf"`** — it's the stable registry key for configured-status lookups; renaming it would orphan every existing configured install.
- **Config path stays `~/.codeium/windsurf/mcp_config.json`** — per the official docs (docs.devin.ai/desktop/cascade/mcp, corroborated by multiple migration writeups), the `~/.codeium/` tree is unchanged by the rebrand; new `~/.config/Devin/`-style dirs hold app data, not MCP config. Per-issue guardrail, no speculative path was added.
- README client list and a `client.py` docstring mention updated.
- New test pins id stability, exact display name, and the config path staying under `~/.codeium/windsurf/`.

Caveat: docs.devin.ai bot-blocks direct fetches, so the "path unchanged" claim rests on search-indexed quotes of that page plus independent migration guides. Worth a 30-second live check on a machine with Devin Desktop installed: confirm Configure lights up as CONFIGURED and Devin sees the server.

`gdparse` clean; GDScript suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017bCB9GDsZBp9wk7hjCGeu2

---
_Generated by [Claude Code](https://claude.ai/code/session_017bCB9GDsZBp9wk7hjCGeu2)_