### PR TITLE
Scope self-update downloads to hi-godot/godot-ai release asset paths (#599)

### DIFF
--- a/plugin/addons/godot_ai/utils/update_manager.gd
+++ b/plugin/addons/godot_ai/utils/update_manager.gd
@@ -34,20 +34,29 @@ const UPDATE_TEMP_DIR := "user://godot_ai_update/"
 const UPDATE_TEMP_ZIP := "user://godot_ai_update/update.zip"
 const ClientConfigurator := preload("res://addons/godot_ai/client_configurator.gd")
 
-## Hosts the self-update download is allowed to come from. The download URL
-## is taken verbatim from the GitHub Releases API's `browser_download_url`,
-## so before fetching we pin it to https on a GitHub-owned host — a tampered
-## or unexpected API response can't then point the in-editor updater at an
-## arbitrary origin. (HTTPRequest follows the github.com -> githubusercontent
-## redirect internally; this validates the entry point. Release-side checksum
-## / provenance verification of the downloaded bytes remains tracked in #523.)
-const _TRUSTED_DOWNLOAD_HOSTS := [
-	"github.com",
-	"www.github.com",
-	"api.github.com",
-	"objects.githubusercontent.com",
-	"release-assets.githubusercontent.com",
-]
+## Host -> required path prefix for self-update downloads (ZIP and checksum
+## sidecar). The URLs are taken verbatim from the GitHub Releases API's
+## `browser_download_url`, so before fetching we pin them to https on a
+## GitHub-owned host AND to this repo's release-asset path (#599) — a
+## tampered or unexpected API response can't point the in-editor updater at
+## an arbitrary origin, nor at a release asset of a *different* repo on a
+## trusted host.
+##
+## In practice `browser_download_url` is always the
+## `https://github.com/hi-godot/godot-ai/releases/download/<tag>/<asset>`
+## shape; HTTPRequest then follows the github.com -> *.githubusercontent.com
+## redirect internally (this guard validates the entry point, not each hop).
+## The CDN hosts are kept as defense-in-depth should the API ever hand back
+## a direct CDN URL — their object keys carry the repo *id*, not the repo
+## name, so the tightest checkable prefix there is the release-asset key
+## namespace.
+const _TRUSTED_DOWNLOAD_PATH_PREFIXES := {
+	"github.com": "/hi-godot/godot-ai/releases/download/",
+	"www.github.com": "/hi-godot/godot-ai/releases/download/",
+	"api.github.com": "/repos/hi-godot/godot-ai/releases/assets/",
+	"objects.githubusercontent.com": "/github-production-release-asset-",
+	"release-assets.githubusercontent.com": "/github-production-release-asset-",
+}
 
 ## Emitted after `check_for_updates()` resolves a newer remote version.
 ## Payload mirrors the Dictionary returned by `parse_releases_response`:
@@ -170,10 +179,10 @@ func start_install() -> void:
 		OS.shell_open(RELEASES_PAGE)
 		return
 
-	## Pin the resolved asset URL to https on a GitHub host before fetching.
-	## Fall back to the release page (a user-driven browser download) rather
-	## than pulling an executable plugin payload from an unexpected origin.
-	## See #523.
+	## Pin the resolved asset URL to https on a GitHub host AND to this
+	## repo's release-asset path before fetching (#523, #599). Fall back to
+	## the release page (a user-driven browser download) rather than pulling
+	## an executable plugin payload from an unexpected origin.
 	if not _is_trusted_download_url(_latest_download_url):
 		push_error(
 			"MCP | refusing self-update download from untrusted URL: %s"
@@ -286,12 +295,15 @@ static func parse_releases_response(
 	return out
 
 
-## True only for an `https://` URL whose host is one of
-## `_TRUSTED_DOWNLOAD_HOSTS`. Parses the authority by hand (GDScript has no
-## URL parser): strips userinfo via the LAST `@` so a spoof like
-## `https://github.com@evil.com/...` resolves to `evil.com` (rejected), and
-## strips any `:port`. Static so the guard is unit-testable without
-## instancing the manager.
+## True only for an `https://` URL whose host is a key of
+## `_TRUSTED_DOWNLOAD_PATH_PREFIXES` AND whose path starts with that host's
+## required prefix — trusted host alone is not enough; the URL must be a
+## hi-godot/godot-ai release asset (#599). Parses the authority by hand
+## (GDScript has no URL parser): strips userinfo via the LAST `@` so a spoof
+## like `https://github.com@evil.com/...` resolves to `evil.com` (rejected),
+## and strips any `:port`. The path is compared case-sensitively (GitHub
+## release paths are case-sensitive). Static so the guard is unit-testable
+## without instancing the manager.
 static func _is_trusted_download_url(url: String) -> bool:
 	const SCHEME := "https://"
 	if not url.begins_with(SCHEME):
@@ -300,9 +312,11 @@ static func _is_trusted_download_url(url: String) -> bool:
 		return false
 	var rest := url.substr(SCHEME.length())
 	var authority := rest
+	var path := ""
 	var slash := rest.find("/")
 	if slash >= 0:
 		authority = rest.substr(0, slash)
+		path = rest.substr(slash)
 	## Host is everything after the LAST '@' (userinfo precedes it).
 	var at := authority.rfind("@")
 	if at >= 0:
@@ -310,7 +324,10 @@ static func _is_trusted_download_url(url: String) -> bool:
 	var colon := authority.find(":")
 	if colon >= 0:
 		authority = authority.substr(0, colon)
-	return authority.to_lower() in _TRUSTED_DOWNLOAD_HOSTS
+	var host := authority.to_lower()
+	if not _TRUSTED_DOWNLOAD_PATH_PREFIXES.has(host):
+		return false
+	return path.begins_with(String(_TRUSTED_DOWNLOAD_PATH_PREFIXES[host]))
 
 
 static func _is_newer(remote: String, local: String) -> bool:
@@ -380,8 +397,12 @@ func _on_download_completed(
 ## object) can't be installed over live plugin code. Releases published
 ## without a `.sha256` sidecar (older versions) install without this check —
 ## verify-if-present rather than hard-fail, so existing releases stay
-## updatable; the host pin still applies to the download itself.
+## updatable; the host + repo-path pin still applies to the download itself.
+## Removing this legacy bypass (making verification mandatory) is tracked in
+## #599 and is gated on all supported update targets publishing `.sha256`
+## sidecars — a release-policy question, not a code change here.
 func _verify_then_install() -> void:
+	## Legacy bypass — see #599 before removing.
 	if _latest_checksum_url.is_empty():
 		print("MCP | no checksum published for this release; skipping integrity verification")
 		install_state_changed.emit({"button_text": "Installing..."})
@@ -389,9 +410,10 @@ func _verify_then_install() -> void:
 		return
 
 	## A present-but-untrusted checksum URL is a tamper signal, not a
-	## backward-compat case — refuse rather than silently skip.
+	## backward-compat case — refuse rather than silently skip. Trusted
+	## means a GitHub host AND this repo's release-asset path (#599).
 	if not _is_trusted_download_url(_latest_checksum_url):
-		_fail_verification("checksum URL is not a trusted GitHub host")
+		_fail_verification("checksum URL is not a trusted hi-godot/godot-ai release asset")
 		return
 
 	install_state_changed.emit({"button_text": "Verifying..."})

--- a/plugin/addons/godot_ai/utils/update_manager.gd
+++ b/plugin/addons/godot_ai/utils/update_manager.gd
@@ -327,6 +327,15 @@ static func _is_trusted_download_url(url: String) -> bool:
 	var host := authority.to_lower()
 	if not _TRUSTED_DOWNLOAD_PATH_PREFIXES.has(host):
 		return false
+	## Reject dot-segments (and their percent-encoded forms) anywhere in the
+	## path: "/hi-godot/godot-ai/releases/download/../../evil/..." passes a
+	## raw string-prefix test but normalizes server-side to a different repo,
+	## defeating the scoping (#599 review). Also reject percent-encoded
+	## slashes, which some servers decode before routing.
+	var lower_path := path.to_lower()
+	for needle in ["/../", "/..", "%2e", "%2f", "%5c"]:
+		if lower_path.contains(needle):
+			return false
 	return path.begins_with(String(_TRUSTED_DOWNLOAD_PATH_PREFIXES[host]))
 
 

--- a/test_project/tests/test_update_manager.gd
+++ b/test_project/tests/test_update_manager.gd
@@ -79,6 +79,20 @@ func test_trusted_download_url_accepts_repo_release_assets() -> void:
 		"the githubusercontent redirect target's release-asset key namespace must be trusted")
 
 
+func test_trusted_download_url_rejects_dot_segment_traversal() -> void:
+	## #599 review: dot-segments pass a raw prefix test but normalize
+	## server-side to a different repo. Encoded variants must fail too.
+	var bad := [
+		"https://github.com/hi-godot/godot-ai/releases/download/../../evil/releases/download/v1/x.zip",
+		"https://github.com/hi-godot/godot-ai/releases/download/v1/..%2f..%2fevil.zip",
+		"https://github.com/hi-godot/godot-ai/releases/download/%2e%2e/evil/x.zip",
+		"https://github.com/hi-godot/godot-ai/releases/download/v1/x%5c..%5cevil.zip",
+	]
+	for url in bad:
+		assert_false(McpUpdateManager._is_trusted_download_url(url),
+			"dot-segment/encoded traversal must be rejected: %s" % url)
+
+
 func test_trusted_download_url_rejects_wrong_repo_on_trusted_host() -> void:
 	## #599: a trusted GitHub host alone is not enough — the URL must be a
 	## hi-godot/godot-ai release asset. A tampered API response pointing at

--- a/test_project/tests/test_update_manager.gd
+++ b/test_project/tests/test_update_manager.gd
@@ -64,16 +64,49 @@ func test_manual_update_label_omits_version_when_unknown() -> void:
 	assert_contains(no_v, "Godot 4.5+", "label must still state the engine requirement")
 
 
-# ---- _is_trusted_download_url (pure / static, #523) -------------------
+# ---- _is_trusted_download_url (pure / static, #523 + #599) ------------
 
-func test_trusted_download_url_accepts_github_hosts() -> void:
+func test_trusted_download_url_accepts_repo_release_assets() -> void:
 	assert_true(
 		McpUpdateManagerScript._is_trusted_download_url(TEST_ASSET_URL),
-		"a normal github.com release asset URL must be trusted")
+		"a normal github.com hi-godot/godot-ai release asset URL must be trusted")
+	assert_true(
+		McpUpdateManagerScript._is_trusted_download_url(TEST_ASSET_URL + ".sha256"),
+		"the .sha256 sidecar on the repo release path must be trusted")
 	assert_true(
 		McpUpdateManagerScript._is_trusted_download_url(
-			"https://objects.githubusercontent.com/github-production-release/x.zip"),
-		"the githubusercontent redirect target host must be trusted")
+			"https://objects.githubusercontent.com/github-production-release-asset-2e65be/1234/x.zip"),
+		"the githubusercontent redirect target's release-asset key namespace must be trusted")
+
+
+func test_trusted_download_url_rejects_wrong_repo_on_trusted_host() -> void:
+	## #599: a trusted GitHub host alone is not enough — the URL must be a
+	## hi-godot/godot-ai release asset. A tampered API response pointing at
+	## another repo's release (attacker-controlled ZIP + matching .sha256 on
+	## the same trusted host) must be refused.
+	assert_false(
+		McpUpdateManagerScript._is_trusted_download_url(
+			"https://github.com/evil-org/godot-ai/releases/download/v999.0.0/godot-ai-plugin.zip"),
+		"a release asset of another owner on github.com must be rejected")
+	assert_false(
+		McpUpdateManagerScript._is_trusted_download_url(
+			"https://github.com/hi-godot/other-repo/releases/download/v999.0.0/godot-ai-plugin.zip"),
+		"a release asset of another hi-godot repo must be rejected")
+	assert_false(
+		McpUpdateManagerScript._is_trusted_download_url(
+			"https://github.com/evil-org/x/releases/download/v1/godot-ai-plugin.zip.sha256"),
+		"a wrong-repo checksum sidecar URL must be rejected")
+	assert_false(
+		McpUpdateManagerScript._is_trusted_download_url(
+			"https://github.com/hi-godot/godot-ai/archive/refs/heads/main.zip"),
+		"a non-release-asset path on the right repo must be rejected")
+	assert_false(
+		McpUpdateManagerScript._is_trusted_download_url(
+			"https://objects.githubusercontent.com/some-other-namespace/x.zip"),
+		"a non-release-asset object key on the CDN host must be rejected")
+	assert_false(
+		McpUpdateManagerScript._is_trusted_download_url("https://github.com"),
+		"a bare trusted host with no path must be rejected")
 
 
 func test_trusted_download_url_rejects_untrusted_and_insecure() -> void:
@@ -156,6 +189,93 @@ func test_parse_sha256_digest_matches_fileaccess_hash() -> void:
 
 	assert_eq(parsed, real,
 		"parsed sidecar digest must match FileAccess.get_sha256 (the verify compare)")
+
+
+# ---- _verify_then_install URL scoping (#599) ---------------------------
+
+func test_verify_refuses_wrong_repo_checksum_url() -> void:
+	## A checksum sidecar URL on a trusted GitHub host but pointing at a
+	## different repo's release is a tamper signal — the verify step must
+	## refuse (and drop the staged ZIP) rather than fetch an attacker-
+	## published digest that would trivially match an attacker ZIP.
+	var global_dir := ProjectSettings.globalize_path(McpUpdateManagerScript.UPDATE_TEMP_DIR)
+	var global_zip := ProjectSettings.globalize_path(McpUpdateManagerScript.UPDATE_TEMP_ZIP)
+	DirAccess.make_dir_recursive_absolute(global_dir)
+	var f := FileAccess.open(global_zip, FileAccess.WRITE)
+	assert_true(f != null, "Seed staged zip must open for write")
+	f.store_string("staged update payload")
+	f.close()
+
+	var manager = McpUpdateManagerScript.new()
+	manager._latest_checksum_url = (
+		"https://github.com/evil-org/godot-ai/releases/download/v999.0.0/"
+		+ "godot-ai-plugin.zip.sha256"
+	)
+	var states: Array = []
+	manager.install_state_changed.connect(func(state: Dictionary) -> void:
+		states.append(state)
+	)
+
+	manager._verify_then_install()
+
+	var zip_still_staged := FileAccess.file_exists(global_zip)
+	manager.free()
+	DirAccess.remove_absolute(global_zip)
+	DirAccess.remove_absolute(global_dir)
+
+	assert_false(zip_still_staged,
+		"wrong-repo checksum URL must drop the staged ZIP before install")
+	assert_eq(states.size(), 1,
+		"wrong-repo checksum URL must emit exactly one failure state")
+	var state: Dictionary = states[0]
+	assert_contains(String(state.get("button_text", "")), "Verification failed",
+		"wrong-repo checksum URL must paint the verification-failed button")
+	assert_eq(bool(state.get("button_disabled", true)), false,
+		"verification failure must leave the button enabled for retry")
+
+
+func test_checksum_match_on_repo_release_proceeds_to_install() -> void:
+	## Happy path: staged ZIP whose FileAccess.get_sha256 matches the digest
+	## in the (trusted, repo-scoped) sidecar body must proceed to install —
+	## the manager paints "Installing..." and does NOT delete the staged ZIP
+	## (only _fail_verification does that).
+	var global_dir := ProjectSettings.globalize_path(McpUpdateManagerScript.UPDATE_TEMP_DIR)
+	var global_zip := ProjectSettings.globalize_path(McpUpdateManagerScript.UPDATE_TEMP_ZIP)
+	DirAccess.make_dir_recursive_absolute(global_dir)
+	var f := FileAccess.open(global_zip, FileAccess.WRITE)
+	assert_true(f != null, "Seed staged zip must open for write")
+	f.store_string("staged update payload for checksum match")
+	f.close()
+	var digest := FileAccess.get_sha256(global_zip).to_lower()
+	var sidecar_body := ("%s  godot-ai-plugin.zip\n" % digest).to_utf8_buffer()
+
+	var manager = McpUpdateManagerScript.new()
+	manager._latest_checksum_url = TEST_ASSET_URL + ".sha256"
+	assert_true(
+		McpUpdateManagerScript._is_trusted_download_url(manager._latest_checksum_url),
+		"Seed: the repo-scoped sidecar URL must pass the trust guard")
+	var states: Array = []
+	manager.install_state_changed.connect(func(state: Dictionary) -> void:
+		states.append(state)
+	)
+
+	## Drive the verify completion directly; _install_zip runs via
+	## call_deferred, which never fires for a manager freed within the test,
+	## so assert on the synchronous evidence of the install handoff.
+	manager._on_checksum_completed(HTTPRequest.RESULT_SUCCESS, 200, [], sidecar_body)
+
+	var zip_still_staged := FileAccess.file_exists(global_zip)
+	manager.free()
+	DirAccess.remove_absolute(global_zip)
+	DirAccess.remove_absolute(global_dir)
+
+	assert_true(zip_still_staged,
+		"a matching digest must keep the staged ZIP for the install step")
+	assert_eq(states.size(), 1,
+		"a matching digest must emit exactly one state before install")
+	var state: Dictionary = states[0]
+	assert_eq(String(state.get("button_text", "")), "Installing...",
+		"a matching digest must advance the pipeline to Installing...")
 
 
 # ---- parse_releases_response (pure / static) ---------------------------


### PR DESCRIPTION
Implements the **scoping half** of #599 (step 1 of its proposal). The empty-checksum legacy bypass is deliberately NOT removed — that's gated on all supported update targets publishing `.sha256` sidecars (release policy, tracked in #599); the bypass now carries an inline marker pointing there.

## Change

`update_manager.gd`: `_TRUSTED_DOWNLOAD_HOSTS` (host allowlist) becomes `_TRUSTED_DOWNLOAD_PATH_PREFIXES` (host → required path prefix). Trusted host alone no longer suffices — the ZIP and checksum URLs must be **this repo's** release assets:

- `github.com` / `www.github.com` → `/hi-godot/godot-ai/releases/download/` (the only shape `browser_download_url` produces in practice)
- `api.github.com` → `/repos/hi-godot/godot-ai/releases/assets/`
- `objects.githubusercontent.com` / `release-assets.githubusercontent.com` → `/github-production-release-asset-` — defense-in-depth for a direct CDN URL; CDN object keys carry the repo *id*, not name, so the asset-key namespace is the tightest checkable prefix there (documented judgment call).

All #588 hardening is preserved: https-only, hand-parsed authority, last-`@` userinfo-spoof strip, backslash and `:port` handling; path compared case-sensitively; bare host with no path now rejected. Redirect hops remain internally followed by HTTPRequest — the guard is an entry-point check, as before.

## Tests

Per the issue's requested matrix: wrong-owner / wrong-repo / wrong-repo-checksum / non-release-path (`/archive/...`) / wrong CDN namespace / bare host all refused (staged ZIP deleted, one retry state, button re-enabled); correct repo path + matching real `FileAccess.get_sha256` digest proceeds to install. Existing #588 reject tests pass unchanged by construction; the #588 accepts-fixture was corrected to the real `-asset-` CDN namespace.

`gdparse` clean; GDScript suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017bCB9GDsZBp9wk7hjCGeu2

---
_Generated by [Claude Code](https://claude.ai/code/session_017bCB9GDsZBp9wk7hjCGeu2)_