### PR TITLE
Surface the --allow-host LAN opt-in in the dock Settings tab + manual command (#507)

### DIFF
--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -138,6 +138,19 @@ static func excluded_domains() -> String:
 	return ",".join(parts)
 
 
+## Read the `godot_ai/allow_remote_hosts` EditorSetting as a canonicalized
+## comma-separated list of CIDRs / bare IPs (#507). Returns "" when the
+## setting is missing or empty — callers skip appending `--allow-host` in
+## that case so spawns stay byte-for-byte identical to the loopback-only
+## default (and compatible with pre-#421 servers). Mirrors
+## `excluded_domains()` above.
+static func allow_hosts() -> String:
+	var es := EditorInterface.get_editor_settings()
+	if es == null or not es.has_setting(McpSettings.SETTING_ALLOW_HOSTS):
+		return ""
+	return McpAllowHosts.normalize(str(es.get_setting(McpSettings.SETTING_ALLOW_HOSTS)))
+
+
 ## Suggest a port the caller can actually switch to. Walks
 ## `candidate`..`candidate+span-1` and returns the first port that is both
 ## (a) NOT inside a Windows winnat reservation range (Hyper-V / WSL2 / Docker
@@ -363,7 +376,17 @@ static func manual_command(id: String) -> String:
 	var client := ClientRegistry.get_by_id(id)
 	if client == null:
 		return ""
-	return ManualCommand.build(client, SERVER_NAME, http_url(), client.resolved_config_path())
+	var cmd := ManualCommand.build(client, SERVER_NAME, http_url(), client.resolved_config_path())
+	if cmd.is_empty():
+		return cmd
+	## #507: when the allow-host opt-in names a non-loopback range, also
+	## surface the LAN URL so the user can copy-paste the right address into
+	## a remote agent. Informational only — configure/remove still WRITE the
+	## loopback URL above; nothing about the config-file contract changes.
+	var note := McpAllowHosts.lan_url_note(allow_hosts(), IP.get_local_addresses(), http_port())
+	if not note.is_empty():
+		cmd += "\n\n" + note
+	return cmd
 
 
 static func config_path(id: String) -> String:

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -94,6 +94,19 @@ var _telemetry_toggle: CheckButton
 var _telemetry_pending_enabled: bool = true
 var _telemetry_saved_enabled: bool = true
 
+# Settings tab (secondary window, Tab 3) — LAN opt-in (#507). Developer-
+# mode-gated "Allow remote hosts (CIDR)" field whose value feeds
+# `--allow-host` at server spawn (see plugin.gd::_build_server_flags).
+# The LineEdit's live text is the pending state; `_allow_hosts_saved`
+# mirrors the persisted EditorSetting, same pending/saved shape as the
+# Tools tab above.
+var _allow_hosts_section: VBoxContainer
+var _allow_hosts_dev_gate_label: Label
+var _allow_hosts_edit: LineEdit
+var _allow_hosts_hint: Label
+var _allow_hosts_apply_btn: Button
+var _allow_hosts_saved: String = ""
+
 ## Per-client UI handles, keyed by client id. Each entry holds the row's
 ## status dot, configure/remove buttons, config-file buttons, and manual panel.
 var _client_rows: Dictionary = {}
@@ -734,10 +747,11 @@ func _build_ui() -> void:
 	_clients_window.close_requested.connect(_on_clients_window_close_requested)
 	add_child(_clients_window)
 
-	## Two-tab secondary window: Clients (existing per-client rows) and Tools
-	## (domain-exclusion checkboxes for clients that cap total tool count,
-	## like Antigravity at 100). Adding a third tab is one more _build_*_tab
-	## call and a set_tab_title line — no surgery on the rest of the window.
+	## Tabbed secondary window: Clients (per-client rows), Tools (domain-
+	## exclusion checkboxes for clients that cap total tool count, like
+	## Antigravity at 100), and Settings (allow-host LAN opt-in, #507).
+	## Adding another tab is one more _build_*_tab call — no surgery on the
+	## rest of the window.
 	var tabs := TabContainer.new()
 	tabs.anchor_right = 1.0
 	tabs.anchor_bottom = 1.0
@@ -772,6 +786,7 @@ func _build_ui() -> void:
 		_build_client_row(client_id)
 
 	_build_tools_tab(tabs)
+	_build_settings_tab(tabs)
 
 	_body.add_child(HSeparator.new())
 
@@ -1303,6 +1318,9 @@ func _apply_dev_mode_visibility() -> void:
 	_dev_section.visible = dev
 	if _log_viewer != null:
 		_log_viewer.visible = dev
+	## Settings tab's allow-host controls are dev-gated too (#507) — same
+	## single source of truth as the sections above.
+	_apply_allow_hosts_dev_gate(dev)
 
 	# Setup section: visible in dev mode, OR in user mode when uv is missing
 	# (so users can install uv from the dock).
@@ -1945,7 +1963,11 @@ func _on_open_clients_window() -> void:
 
 
 func _settings_are_dirty() -> bool:
-	return _tools_pending_excluded != _tools_saved_excluded or _telemetry_pending_enabled != _telemetry_saved_enabled
+	return (
+		_tools_pending_excluded != _tools_saved_excluded
+		or _telemetry_pending_enabled != _telemetry_saved_enabled
+		or _allow_hosts_is_dirty()
+	)
 
 
 func _on_clients_window_close_requested() -> void:
@@ -2147,6 +2169,9 @@ func _reset_tools_pending_from_setting() -> void:
 	## Also reset telemetry pending state from the persisted setting.
 	if _telemetry_toggle != null:
 		_load_telemetry_setting()
+	## And the Settings tab's allow-host field (#507) — same window-open /
+	## discard-confirm re-sync contract as the tools checkboxes.
+	_reset_allow_hosts_from_setting()
 
 
 func _on_tools_domain_toggled(pressed: bool, domain_id: String) -> void:
@@ -2216,6 +2241,155 @@ func _on_tools_discard_confirmed() -> void:
 	_refresh_tools_ui_state()
 	if _clients_window != null:
 		_clients_window.hide()
+
+
+# --- Settings tab (allow-host LAN opt-in, #507) ---
+
+func _build_settings_tab(tabs: TabContainer) -> void:
+	## Tab 3 — settings-style controls that don't fit Clients or Tools.
+	## Currently houses the developer-mode-gated `--allow-host` LAN opt-in.
+	## Rendered once on dock construction, mirroring `_build_tools_tab`;
+	## `_reset_allow_hosts_from_setting()` re-syncs the field each time the
+	## window opens (via `_reset_tools_pending_from_setting`).
+	var settings_tab := VBoxContainer.new()
+	settings_tab.add_theme_constant_override("separation", 8)
+	var settings_margin := _build_margin_container()
+	settings_margin.name = "Settings"
+	settings_margin.add_child(settings_tab)
+	tabs.add_child(settings_margin)
+
+	## Shown in place of the gated controls when developer mode is off —
+	## same gate the dev section uses (see `_apply_dev_mode_visibility`).
+	_allow_hosts_dev_gate_label = Label.new()
+	_allow_hosts_dev_gate_label.text = (
+		"Enable Developer mode (bottom of the dock) to edit remote-access settings."
+	)
+	_allow_hosts_dev_gate_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_allow_hosts_dev_gate_label.add_theme_color_override("font_color", COLOR_MUTED)
+	_allow_hosts_dev_gate_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	settings_tab.add_child(_allow_hosts_dev_gate_label)
+
+	_allow_hosts_section = VBoxContainer.new()
+	_allow_hosts_section.add_theme_constant_override("separation", 6)
+	settings_tab.add_child(_allow_hosts_section)
+
+	_allow_hosts_section.add_child(_make_header("Allow remote hosts (CIDR)"))
+
+	var intro := Label.new()
+	intro.text = (
+		"Comma-separated CIDRs or bare IPs (e.g. 192.168.1.0/24, 10.0.0.5). "
+		+ "When non-empty, the server binds off loopback and accepts MCP "
+		+ "connections from these ranges (--allow-host)."
+	)
+	intro.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	intro.add_theme_color_override("font_color", COLOR_MUTED)
+	intro.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_allow_hosts_section.add_child(intro)
+
+	## Warning banner — the DNS-rebinding guard is widened to every machine
+	## in the named ranges, so make the user name a network they trust
+	## instead of offering a blanket "expose everything" toggle (#507).
+	var warning := Label.new()
+	warning.text = (
+		"Warning: every machine in these ranges can drive this Godot editor, "
+		+ "and the DNS-rebinding guard's Host allowlist is widened to match. "
+		+ "Only name networks you trust. On untrusted or shared networks, "
+		+ "prefer an SSH tunnel or Tailscale instead of exposing the port."
+	)
+	warning.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	warning.add_theme_color_override("font_color", COLOR_AMBER)
+	warning.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_allow_hosts_section.add_child(warning)
+
+	_allow_hosts_edit = LineEdit.new()
+	_allow_hosts_edit.placeholder_text = "e.g. 192.168.1.0/24, 10.0.0.5 — empty = loopback only"
+	_allow_hosts_edit.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_allow_hosts_edit.text_changed.connect(_on_allow_hosts_text_changed)
+	_allow_hosts_section.add_child(_allow_hosts_edit)
+
+	_allow_hosts_hint = Label.new()
+	_allow_hosts_hint.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_allow_hosts_hint.add_theme_color_override("font_color", Color.RED)
+	_allow_hosts_hint.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_allow_hosts_hint.visible = false
+	_allow_hosts_section.add_child(_allow_hosts_hint)
+
+	_allow_hosts_apply_btn = Button.new()
+	_allow_hosts_apply_btn.text = "Apply and Restart Server"
+	_allow_hosts_apply_btn.tooltip_text = (
+		"Save the allowlist to Editor Settings and reload the plugin so the "
+		+ "server respawns with --allow-host. Clear the field and Apply to "
+		+ "return to loopback-only."
+	)
+	_allow_hosts_apply_btn.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_allow_hosts_apply_btn.pressed.connect(_on_allow_hosts_apply)
+	_allow_hosts_section.add_child(_allow_hosts_apply_btn)
+
+	_reset_allow_hosts_from_setting()
+	## Apply the current dev-mode gate — `_build_ui` runs
+	## `_apply_dev_mode_visibility()` after all tabs are built, but keep this
+	## self-consistent for any future caller that builds the tab alone.
+	_apply_allow_hosts_dev_gate(_dev_mode_toggle != null and _dev_mode_toggle.button_pressed)
+
+
+func _apply_allow_hosts_dev_gate(dev: bool) -> void:
+	if _allow_hosts_section != null:
+		_allow_hosts_section.visible = dev
+	if _allow_hosts_dev_gate_label != null:
+		_allow_hosts_dev_gate_label.visible = not dev
+
+
+func _reset_allow_hosts_from_setting() -> void:
+	_allow_hosts_saved = ClientConfigurator.allow_hosts()
+	if _allow_hosts_edit == null:
+		return
+	_allow_hosts_edit.text = _allow_hosts_saved
+	_refresh_allow_hosts_ui_state()
+
+
+func _allow_hosts_is_dirty() -> bool:
+	if _allow_hosts_edit == null:
+		return false
+	return McpAllowHosts.normalize(_allow_hosts_edit.text) != _allow_hosts_saved
+
+
+func _on_allow_hosts_text_changed(_new_text: String) -> void:
+	_refresh_allow_hosts_ui_state()
+
+
+func _refresh_allow_hosts_ui_state() -> void:
+	if _allow_hosts_edit == null or _allow_hosts_apply_btn == null:
+		return
+	var invalid := McpAllowHosts.invalid_tokens(_allow_hosts_edit.text)
+	if invalid.is_empty():
+		_allow_hosts_hint.visible = false
+	else:
+		## Name the accepted syntax in the hint — matches the server's
+		## `parse_allow_hosts` (CIDR / bare IP, comma-separated).
+		_allow_hosts_hint.text = (
+			"Invalid entries (must be a CIDR like 192.168.1.0/24 or a bare IP, comma-separated): %s"
+			% ", ".join(invalid)
+		)
+		_allow_hosts_hint.visible = true
+	_allow_hosts_apply_btn.disabled = not _allow_hosts_is_dirty() or not invalid.is_empty()
+
+
+func _on_allow_hosts_apply() -> void:
+	if _allow_hosts_edit == null:
+		return
+	var normalized := McpAllowHosts.normalize(_allow_hosts_edit.text)
+	if not McpAllowHosts.invalid_tokens(normalized).is_empty():
+		return
+	var es := EditorInterface.get_editor_settings()
+	if es != null:
+		es.set_setting(McpSettings.SETTING_ALLOW_HOSTS, normalized)
+	_allow_hosts_saved = normalized
+	_allow_hosts_edit.text = normalized
+	_refresh_allow_hosts_ui_state()
+	## Plugin reload respawns the server with the new `--allow-host` flag
+	## (see `plugin.gd::_build_server_flags`). Mirrors the Tools-tab Apply
+	## and port-change flows.
+	_on_reload_plugin()
 
 
 func _refresh_clients_summary() -> void:

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -2101,9 +2101,12 @@ func _build_tools_tab(tabs: TabContainer) -> void:
 
 	_tools_close_confirm = ConfirmationDialog.new()
 	_tools_close_confirm.title = "Discard unapplied changes?"
+	## Generic wording: _settings_are_dirty() covers domain toggles, the
+	## telemetry switch, AND the Settings tab's allow-host field (#507) —
+	## the old "checked/unchecked domains" text misled non-domain edits.
 	_tools_close_confirm.dialog_text = (
-		"You've checked/unchecked domains but haven't clicked Apply.\n"
-		+ "Close the window and discard those changes?"
+		"You have unapplied changes in this window.\n"
+		+ "Close it and discard those changes?"
 	)
 	_tools_close_confirm.ok_button_text = "Discard"
 	_tools_close_confirm.confirmed.connect(_on_tools_discard_confirmed)

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -1270,6 +1270,15 @@ static func _build_server_flags(port: int, ws_port: int) -> Array[String]:
 	if not excluded.is_empty():
 		flags.append("--exclude-domains")
 		flags.append(excluded)
+	## LAN opt-in (#507, server core #421): pass `--allow-host` only when the
+	## developer-mode Settings tab named at least one CIDR / bare IP. Skipping
+	## the empty case keeps the default spawn byte-for-byte identical and
+	## compatible with older servers that don't know the flag — same pattern
+	## as `--exclude-domains` above.
+	var allow_hosts := ClientConfigurator.allow_hosts()
+	if not allow_hosts.is_empty():
+		flags.append("--allow-host")
+		flags.append(allow_hosts)
 	return flags
 
 

--- a/plugin/addons/godot_ai/utils/allow_hosts.gd
+++ b/plugin/addons/godot_ai/utils/allow_hosts.gd
@@ -36,7 +36,11 @@ static func token_is_valid(token: String) -> bool:
 	if t.is_empty():
 		return false
 	var ip := t
-	var prefix := -1
+	var prefix := 0
+	## Track slash presence separately from the prefix value: reusing -1 as
+	## the "no slash" sentinel let an explicit negative prefix like
+	## "10.0.0.0/-1" validate (is_valid_int accepts "-1"). CodeRabbit review.
+	var has_prefix := false
 	var slash := t.find("/")
 	if slash != -1:
 		ip = t.substr(0, slash)
@@ -44,10 +48,11 @@ static func token_is_valid(token: String) -> bool:
 		if not prefix_text.is_valid_int():
 			return false
 		prefix = int(prefix_text)
+		has_prefix = true
 	if not ip.is_valid_ip_address():
 		return false
 	var max_prefix := 128 if ip.contains(":") else 32
-	return prefix == -1 or (prefix >= 0 and prefix <= max_prefix)
+	return not has_prefix or (prefix >= 0 and prefix <= max_prefix)
 
 
 ## Every token in `raw` that fails `token_is_valid` — the dock surfaces

--- a/plugin/addons/godot_ai/utils/allow_hosts.gd
+++ b/plugin/addons/godot_ai/utils/allow_hosts.gd
@@ -1,0 +1,153 @@
+@tool
+class_name McpAllowHosts
+extends RefCounted
+
+## Client-side helpers for the `--allow-host` LAN opt-in (#507, server core
+## in #421). Pure static functions only — no EditorSettings, no sockets —
+## so the settings-value → launch-args plumbing and the manual-command LAN
+## URL builder are deterministically testable without a live editor.
+##
+## Accepted syntax mirrors the server's `parse_allow_hosts`
+## (src/godot_ai/transport/origin_guard.py): each token is a bare IP
+## (IPv4 or IPv6) or a CIDR, comma-separated. Host bits set on a CIDR are
+## tolerated server-side (`strict=False`), so we only validate the IP part
+## and the prefix length here — anything else fails loudly at server
+## startup, which the dock-side validation exists to pre-empt.
+
+
+## Canonicalize a comma-separated allow-host value: whitespace-stripped,
+## deduplicated, sorted. Returns "" for a value with no usable tokens so
+## callers can skip appending `--allow-host` entirely (keeps spawns
+## compatible with pre-#421 servers — same contract as
+## `ClientConfigurator.excluded_domains()`).
+static func normalize(raw: String) -> String:
+	var parts := PackedStringArray()
+	for p in raw.split(","):
+		var t := p.strip_edges()
+		if not t.is_empty() and parts.find(t) == -1:
+			parts.append(t)
+	parts.sort()
+	return ",".join(parts)
+
+
+## Whether a single token is a bare IP or a CIDR the server will accept.
+static func token_is_valid(token: String) -> bool:
+	var t := token.strip_edges()
+	if t.is_empty():
+		return false
+	var ip := t
+	var prefix := -1
+	var slash := t.find("/")
+	if slash != -1:
+		ip = t.substr(0, slash)
+		var prefix_text := t.substr(slash + 1)
+		if not prefix_text.is_valid_int():
+			return false
+		prefix = int(prefix_text)
+	if not ip.is_valid_ip_address():
+		return false
+	var max_prefix := 128 if ip.contains(":") else 32
+	return prefix == -1 or (prefix >= 0 and prefix <= max_prefix)
+
+
+## Every token in `raw` that fails `token_is_valid` — the dock surfaces
+## these inline so a typo is caught before it aborts the server spawn.
+static func invalid_tokens(raw: String) -> PackedStringArray:
+	var bad := PackedStringArray()
+	for p in raw.split(","):
+		var t := p.strip_edges()
+		if t.is_empty():
+			continue
+		if not token_is_valid(t) and bad.find(t) == -1:
+			bad.append(t)
+	return bad
+
+
+## True when the allowlist names at least one non-loopback range — i.e.
+## the server is actually reachable off this machine and the manual
+## command should surface a LAN URL.
+static func is_lan_allowlist_active(value: String) -> bool:
+	for p in value.split(","):
+		var t := p.strip_edges()
+		if t.is_empty():
+			continue
+		var ip := t.substr(0, t.find("/")) if t.contains("/") else t
+		if not _is_loopback(ip):
+			return true
+	return false
+
+
+## Choose the LAN address to show in the manual command from the
+## machine's local addresses (caller passes `IP.get_local_addresses()`
+## so this stays pure). Loopback and link-local addresses are dropped;
+## the first private-range IPv4 wins, then any remaining IPv4, then
+## anything left (IPv6). Returns `{"address": String, "ambiguous": bool}`
+## — `ambiguous` flags multiple viable candidates so the note can tell
+## the user to pick the interface on their trusted network.
+static func pick_lan_address(addresses: PackedStringArray) -> Dictionary:
+	var candidates := PackedStringArray()
+	for a in addresses:
+		var addr := String(a).strip_edges()
+		if addr.is_empty() or _is_loopback(addr) or _is_link_local(addr):
+			continue
+		candidates.append(addr)
+	if candidates.is_empty():
+		return {"address": "", "ambiguous": false}
+	var chosen := ""
+	for addr in candidates:
+		if _is_private_ipv4(addr):
+			chosen = addr
+			break
+	if chosen.is_empty():
+		for addr in candidates:
+			if addr.contains("."):
+				chosen = addr
+				break
+	if chosen.is_empty():
+		chosen = candidates[0]
+	return {"address": chosen, "ambiguous": candidates.size() > 1}
+
+
+## Informational LAN-URL note appended to the manual command when the
+## allowlist is active (#507). Never changes what gets WRITTEN to client
+## configs — loopback stays the write target; this is copy-paste help for
+## pointing a remote agent at the right address.
+static func lan_url_note(allow_hosts_value: String, addresses: PackedStringArray, http_port: int) -> String:
+	if not is_lan_allowlist_active(allow_hosts_value):
+		return ""
+	var pick := pick_lan_address(addresses)
+	var addr := String(pick.get("address", ""))
+	if addr.is_empty():
+		return (
+			"LAN access is enabled (--allow-host %s), but no LAN address was detected on this machine."
+			% allow_hosts_value
+		)
+	var host := "[%s]" % addr if addr.contains(":") else addr
+	var note := (
+		"LAN access is enabled (--allow-host %s). Remote agents on the allowed network can use: http://%s:%d/mcp"
+		% [allow_hosts_value, host, http_port]
+	)
+	if bool(pick.get("ambiguous", false)):
+		note += "\n(multiple network interfaces detected — pick the address on the network you allowed)"
+	return note
+
+
+static func _is_loopback(addr: String) -> bool:
+	var a := addr.to_lower()
+	return a.begins_with("127.") or a == "::1" or a == "localhost"
+
+
+static func _is_link_local(addr: String) -> bool:
+	var a := addr.to_lower()
+	return a.begins_with("169.254.") or a.begins_with("fe80")
+
+
+static func _is_private_ipv4(addr: String) -> bool:
+	if not addr.contains("."):
+		return false
+	if addr.begins_with("10.") or addr.begins_with("192.168."):
+		return true
+	if addr.begins_with("172."):
+		var second := int(addr.get_slice(".", 1))
+		return second >= 16 and second <= 31
+	return false

--- a/plugin/addons/godot_ai/utils/allow_hosts.gd
+++ b/plugin/addons/godot_ai/utils/allow_hosts.gd
@@ -139,7 +139,14 @@ static func _is_loopback(addr: String) -> bool:
 
 static func _is_link_local(addr: String) -> bool:
 	var a := addr.to_lower()
-	return a.begins_with("169.254.") or a.begins_with("fe80")
+	if a.begins_with("169.254."):
+		return true
+	## IPv6 link-local is fe80::/10 — the whole fe80-febf first hextet, not
+	## just literal "fe80" (Copilot review on #507's PR: fea0::... etc. must
+	## also be excluded from LAN-URL candidates).
+	if a.length() >= 4 and a.begins_with("fe") and a[2] in "89ab":
+		return true
+	return false
 
 
 static func _is_private_ipv4(addr: String) -> bool:

--- a/plugin/addons/godot_ai/utils/allow_hosts.gd.uid
+++ b/plugin/addons/godot_ai/utils/allow_hosts.gd.uid
@@ -1,0 +1,1 @@
+uid://b7qk3vw2nxr4d

--- a/plugin/addons/godot_ai/utils/settings.gd
+++ b/plugin/addons/godot_ai/utils/settings.gd
@@ -13,6 +13,9 @@ const SETTING_HTTP_PORT := "godot_ai/http_port"
 ## Comma-separated list of tool domains excluded from the server at spawn time.
 const SETTING_EXCLUDED_DOMAINS := "godot_ai/excluded_domains"
 const SETTING_TELEMETRY_ENABLED := "godot_ai/telemetry_enabled"
+## Comma-separated CIDRs / bare IPs passed to the server as `--allow-host`
+## at spawn time (#507, server core #421). Empty means loopback-only.
+const SETTING_ALLOW_HOSTS := "godot_ai/allow_remote_hosts"
 ## Whether MCP log lines echo to the Godot console (dock "Log" toggle).
 ## The dock's ring-buffer log panel keeps recording regardless.
 const SETTING_MCP_LOGGING := "godot_ai/mcp_logging"

--- a/test_project/tests/test_allow_hosts.gd
+++ b/test_project/tests/test_allow_hosts.gd
@@ -1,0 +1,173 @@
+@tool
+extends McpTestSuite
+
+const PluginScript := preload("res://addons/godot_ai/plugin.gd")
+
+## Deterministic tests for the `--allow-host` LAN opt-in plumbing (#507):
+## the pure McpAllowHosts helpers (value normalization, token validation,
+## LAN-address pick, manual-command LAN URL note) and the
+## EditorSetting → `_build_server_flags` launch-args path. The Settings-tab
+## UI itself is live-verified in the editor.
+
+## Snapshot the user's live allow-hosts setting at suite entry so the
+## set/clear dance below can't leave the editor exposing a range the user
+## never opted into if a test fails mid-flight.
+var _saved_allow_hosts: Variant = null
+var _had_allow_hosts_setting := false
+
+
+func suite_name() -> String:
+	return "allow_hosts"
+
+
+func suite_setup(_ctx: Dictionary) -> void:
+	var es := EditorInterface.get_editor_settings()
+	if es != null and es.has_setting(McpSettings.SETTING_ALLOW_HOSTS):
+		_had_allow_hosts_setting = true
+		_saved_allow_hosts = es.get_setting(McpSettings.SETTING_ALLOW_HOSTS)
+
+
+func suite_teardown() -> void:
+	var es := EditorInterface.get_editor_settings()
+	if es == null:
+		return
+	if _had_allow_hosts_setting:
+		es.set_setting(McpSettings.SETTING_ALLOW_HOSTS, _saved_allow_hosts)
+	elif es.has_setting(McpSettings.SETTING_ALLOW_HOSTS):
+		es.erase(McpSettings.SETTING_ALLOW_HOSTS)
+
+
+# ----- normalize -----
+
+func test_normalize_strips_dedupes_and_sorts() -> void:
+	var normalized := McpAllowHosts.normalize(" 192.168.1.0/24 ,10.0.0.5, 192.168.1.0/24 ,, ")
+	assert_eq(normalized, "10.0.0.5,192.168.1.0/24")
+
+
+func test_normalize_empty_and_whitespace_only() -> void:
+	assert_eq(McpAllowHosts.normalize(""), "")
+	assert_eq(McpAllowHosts.normalize(" , ,  "), "")
+
+
+# ----- token validation (mirrors server parse_allow_hosts) -----
+
+func test_valid_tokens() -> void:
+	for token in ["192.168.1.50", "192.168.1.0/24", "10.0.0.0/8", "::1", "fd00::/8", "fe80::1/64", "192.168.1.5/24"]:
+		assert_true(McpAllowHosts.token_is_valid(token), "expected valid: %s" % token)
+
+
+func test_invalid_tokens() -> void:
+	for token in ["", "example.com", "192.168.1", "192.168.1.0/33", "::1/129", "10.0.0.0/abc", "not-an-ip/24"]:
+		assert_false(McpAllowHosts.token_is_valid(token), "expected invalid: %s" % token)
+
+
+func test_invalid_tokens_reports_offenders_only() -> void:
+	var bad := McpAllowHosts.invalid_tokens("192.168.1.0/24, example.com, 10.0.0.5, 1.2.3.4/40")
+	assert_eq(bad.size(), 2)
+	assert_true(bad.has("example.com"))
+	assert_true(bad.has("1.2.3.4/40"))
+
+
+# ----- LAN allowlist detection -----
+
+func test_loopback_only_allowlist_is_not_lan_active() -> void:
+	assert_false(McpAllowHosts.is_lan_allowlist_active(""))
+	assert_false(McpAllowHosts.is_lan_allowlist_active("127.0.0.1"))
+	assert_false(McpAllowHosts.is_lan_allowlist_active("127.0.0.0/8,::1"))
+
+
+func test_non_loopback_allowlist_is_lan_active() -> void:
+	assert_true(McpAllowHosts.is_lan_allowlist_active("192.168.1.0/24"))
+	assert_true(McpAllowHosts.is_lan_allowlist_active("127.0.0.1,10.0.0.5"))
+
+
+# ----- LAN address pick -----
+
+func test_pick_prefers_private_ipv4_and_skips_loopback_link_local() -> void:
+	var pick := McpAllowHosts.pick_lan_address(PackedStringArray(
+		["127.0.0.1", "::1", "169.254.10.10", "fe80::1", "192.168.1.50"]
+	))
+	assert_eq(String(pick["address"]), "192.168.1.50")
+	assert_false(bool(pick["ambiguous"]))
+
+
+func test_pick_flags_ambiguity_with_multiple_candidates() -> void:
+	var pick := McpAllowHosts.pick_lan_address(PackedStringArray(["10.0.0.7", "192.168.1.50"]))
+	assert_eq(String(pick["address"]), "10.0.0.7")
+	assert_true(bool(pick["ambiguous"]))
+
+
+func test_pick_returns_empty_when_only_loopback() -> void:
+	var pick := McpAllowHosts.pick_lan_address(PackedStringArray(["127.0.0.1", "::1"]))
+	assert_eq(String(pick["address"]), "")
+
+
+func test_pick_falls_back_to_public_ipv4_then_ipv6() -> void:
+	var ipv4 := McpAllowHosts.pick_lan_address(PackedStringArray(["203.0.113.9"]))
+	assert_eq(String(ipv4["address"]), "203.0.113.9")
+	var ipv6 := McpAllowHosts.pick_lan_address(PackedStringArray(["fd12:3456::1"]))
+	assert_eq(String(ipv6["address"]), "fd12:3456::1")
+
+
+# ----- manual-command LAN URL note -----
+
+func test_lan_url_note_names_lan_url() -> void:
+	var note := McpAllowHosts.lan_url_note(
+		"192.168.1.0/24",
+		PackedStringArray(["127.0.0.1", "192.168.1.50"]),
+		8000
+	)
+	assert_contains(note, "http://192.168.1.50:8000/mcp")
+	assert_contains(note, "--allow-host 192.168.1.0/24")
+
+
+func test_lan_url_note_brackets_ipv6() -> void:
+	var note := McpAllowHosts.lan_url_note(
+		"fd00::/8", PackedStringArray(["fd12:3456::1"]), 8000
+	)
+	assert_contains(note, "http://[fd12:3456::1]:8000/mcp")
+
+
+func test_lan_url_note_empty_when_allowlist_empty_or_loopback_only() -> void:
+	assert_eq(McpAllowHosts.lan_url_note("", PackedStringArray(["192.168.1.50"]), 8000), "")
+	assert_eq(McpAllowHosts.lan_url_note("127.0.0.1", PackedStringArray(["192.168.1.50"]), 8000), "")
+
+
+func test_lan_url_note_mentions_ambiguity() -> void:
+	var note := McpAllowHosts.lan_url_note(
+		"10.0.0.0/8", PackedStringArray(["10.0.0.7", "192.168.1.50"]), 8000
+	)
+	assert_contains(note, "multiple network interfaces")
+
+
+# ----- setting → launch-args plumbing -----
+
+func test_allow_host_flag_appended_when_setting_non_empty() -> void:
+	var es := EditorInterface.get_editor_settings()
+	if es == null:
+		skip("no EditorSettings in this context")
+		return
+	es.set_setting(McpSettings.SETTING_ALLOW_HOSTS, "192.168.1.0/24, 10.0.0.5")
+	var flags := PluginScript._build_server_flags(8000, 9500)
+	var idx := flags.find("--allow-host")
+	assert_gt(idx, -1, "expected --allow-host in server flags: %s" % str(flags))
+	assert_eq(flags[idx + 1], "10.0.0.5,192.168.1.0/24")
+
+
+func test_allow_host_flag_absent_when_setting_empty() -> void:
+	var es := EditorInterface.get_editor_settings()
+	if es == null:
+		skip("no EditorSettings in this context")
+		return
+	es.set_setting(McpSettings.SETTING_ALLOW_HOSTS, "")
+	var flags := PluginScript._build_server_flags(8000, 9500)
+	assert_eq(flags.find("--allow-host"), -1, "empty setting must not emit --allow-host: %s" % str(flags))
+
+
+func test_configurator_allow_hosts_normalizes_setting() -> void:
+	var es := EditorInterface.get_editor_settings()
+	if es == null:
+		skip("no EditorSettings in this context")
+		return
+	es.set_setting(McpSettings.SETTING_ALLOW_HOSTS, " 192.168.1.5 , 192.168.1.5 ")
+	assert_eq(McpClientConfigurator.allow_hosts(), "192.168.1.5")

--- a/test_project/tests/test_allow_hosts.gd
+++ b/test_project/tests/test_allow_hosts.gd
@@ -85,7 +85,7 @@ func test_non_loopback_allowlist_is_lan_active() -> void:
 
 func test_pick_prefers_private_ipv4_and_skips_loopback_link_local() -> void:
 	var pick := McpAllowHosts.pick_lan_address(PackedStringArray(
-		["127.0.0.1", "::1", "169.254.10.10", "fe80::1", "192.168.1.50"]
+		["127.0.0.1", "::1", "169.254.10.10", "fe80::1", "fea0::1", "192.168.1.50"]
 	))
 	assert_eq(String(pick["address"]), "192.168.1.50")
 	assert_false(bool(pick["ambiguous"]))

--- a/test_project/tests/test_allow_hosts.gd
+++ b/test_project/tests/test_allow_hosts.gd
@@ -57,7 +57,7 @@ func test_valid_tokens() -> void:
 
 
 func test_invalid_tokens() -> void:
-	for token in ["", "example.com", "192.168.1", "192.168.1.0/33", "::1/129", "10.0.0.0/abc", "not-an-ip/24"]:
+	for token in ["", "example.com", "192.168.1", "192.168.1.0/33", "::1/129", "10.0.0.0/abc", "not-an-ip/24", "10.0.0.0/-1", "::1/-8"]:
 		assert_false(McpAllowHosts.token_is_valid(token), "expected invalid: %s" % token)
 
 

--- a/test_project/tests/test_allow_hosts.gd.uid
+++ b/test_project/tests/test_allow_hosts.gd.uid
@@ -1,0 +1,1 @@
+uid://cx5m8tq1hyw6e


### PR DESCRIPTION
Fixes #507 — the two UI/UX pieces deferred from #421 (whose server-side `--allow-host` core landed in #505/#506).

## 1. Settings tab in the Clients & Tools window

New third tab (`_build_settings_tab`, the "one more `_build_*_tab`" the existing comment promised):

- **"Allow remote hosts (CIDR)"** field — developer-mode-gated via the same `_apply_dev_mode_visibility` mechanism as `_dev_section`, with a muted "enable Developer mode" label when gated off.
- **Amber DNS-rebinding warning banner** recommending SSH tunnel/Tailscale on untrusted networks — the user names the network they trust, no blanket "expose everything" toggle.
- **Inline validation** (red hint) against the same syntax the server's `parse_allow_hosts` accepts (bare IP or CIDR, IPv4/IPv6, comma-separated), so typos are caught before they abort a spawn.
- **Apply and Restart Server** button reusing the existing `_on_reload_plugin()` flow; dirty state participates in `_settings_are_dirty()` so the close-confirm dialog covers it; field re-syncs from the persisted setting on window open.
- Persisted as `godot_ai/allow_remote_hosts` EditorSetting; `_build_server_flags` appends `--allow-host <normalized>` only when non-empty (same pattern as `--exclude-domains`), so the default spawn is byte-for-byte unchanged and compatible with older servers.

## 2. LAN URL in the manual command

When a non-loopback allowlist is active, `manual_command()` appends an informational note with the copy-pasteable LAN URL (`http://<lan-ip>:8000/mcp`), built from `IP.get_local_addresses()` — loopback/link-local filtered, first private-range IPv4 preferred, ambiguity flagged when multiple interfaces qualify, IPv6 bracketed. **What gets written to client configs is unchanged** — loopback stays the write target.

All selection/validation logic lives in a new pure-static `McpAllowHosts` util so it's deterministically testable: 16 tests in `test_allow_hosts.gd` (normalization, token validation, LAN detection/pick/ambiguity, URL note, EditorSetting → launch-flags plumbing with save/restore).

`gdparse` clean on all 7 files; GDScript suite runs in CI.

## Needs live-editor verification

Tab layout/rendering; dev-mode gating toggle; Apply → reload → respawn with `--allow-host` (check the `MCP | started server` log line); close-confirm on dirty field; LAN note on a machine with a real LAN IP. Also: `.uid` files for the two new `.gd` files will generate on first editor open — commit them then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017bCB9GDsZBp9wk7hjCGeu2

---
_Generated by [Claude Code](https://claude.ai/code/session_017bCB9GDsZBp9wk7hjCGeu2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional developer setting to allow remote hosts using IP addresses or CIDR ranges.
  * Added a Settings tab for configuring, validating, and applying remote-host access.
  * Server launch commands now include the configured access list when enabled.
  * Manual commands display a LAN access URL when applicable.

* **Bug Fixes**
  * Invalid entries are identified before settings can be applied.
  * Settings are normalized consistently, with duplicates removed and formatting standardized.

* **Tests**
  * Added coverage for validation, normalization, LAN address selection, URL messaging, and server configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->