### PR TITLE
Don't tear down the editor session on a single malformed WebSocket frame (#526)

### DIFF
--- a/src/godot_ai/transport/websocket.py
+++ b/src/godot_ai/transport/websocket.py
@@ -207,7 +207,21 @@ class GodotWebSocketServer:
                 if live is not None:
                     live.touch()
 
-                data = json.loads(raw_msg)
+                ## Parse/validation failures of a single frame must not tear
+                ## down the whole editor session (#526): before this guard,
+                ## one garbled frame raised out of the loop into the
+                ## catch-all, and the finally block unregistered the session
+                ## and dropped the editor↔server bridge. Skip the bad frame
+                ## with a warning instead, mirroring the event path's
+                ## ValidationError handling. Only parse/validation errors are
+                ## swallowed — everything else still propagates.
+                try:
+                    data = json.loads(raw_msg)
+                except json.JSONDecodeError as exc:
+                    logger.warning(
+                        "Dropping non-JSON frame from session %s: %s", session_id[:8], exc
+                    )
+                    continue
 
                 # Handle state events from the plugin
                 if data.get("type") == "event":
@@ -215,7 +229,29 @@ class GodotWebSocketServer:
                     continue
 
                 # Handle command responses
-                response = CommandResponse.model_validate(data)
+                try:
+                    response = CommandResponse.model_validate(data)
+                except ValidationError as exc:
+                    logger.warning(
+                        "Dropping malformed command response from session %s: %s",
+                        session_id[:8],
+                        exc.errors(include_url=False, include_context=False, include_input=False),
+                    )
+                    ## If the malformed frame carried a request_id for a
+                    ## pending command, fail that future immediately with a
+                    ## clear error instead of leaving the caller to hit its
+                    ## timeout (#526).
+                    request_id = data.get("request_id") if isinstance(data, dict) else None
+                    if isinstance(request_id, str):
+                        pending = self._pending.pop(request_id, None)
+                        if pending and not pending.done():
+                            pending.set_exception(
+                                ConnectionError(
+                                    f"Malformed response from session {session_id} "
+                                    f"for request {request_id}"
+                                )
+                            )
+                    continue
                 ## Heal `Session.readiness` from every response envelope.
                 ## The plugin stamps live readiness onto its dispatcher
                 ## output, so the cache stays in lockstep with editor

--- a/src/godot_ai/transport/websocket.py
+++ b/src/godot_ai/transport/websocket.py
@@ -217,9 +217,21 @@ class GodotWebSocketServer:
                 ## swallowed — everything else still propagates.
                 try:
                     data = json.loads(raw_msg)
-                except json.JSONDecodeError as exc:
+                except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+                    ## UnicodeDecodeError covers a bytes frame with invalid
+                    ## UTF-8 — same malformed-frame class as bad JSON (#526).
                     logger.warning(
                         "Dropping non-JSON frame from session %s: %s", session_id[:8], exc
+                    )
+                    continue
+                if not isinstance(data, dict):
+                    ## Valid JSON but not an object (e.g. `[]` or `42`) —
+                    ## `.get()` below would raise AttributeError and tear the
+                    ## session down through the catch-all (#526).
+                    logger.warning(
+                        "Dropping non-object JSON frame from session %s: %s",
+                        session_id[:8],
+                        type(data).__name__,
                     )
                     continue
 

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -1430,6 +1430,20 @@ class TestMalformedFrameResilience:
         assert result == {"version": "4.4.1"}
         await plugin.close()
 
+    async def test_non_object_json_frame_is_skipped_and_session_survives(self, harness):
+        ## Valid JSON that isn't an object (`[]`, `42`) reaches `.get()` and
+        ## would raise AttributeError through the catch-all without the
+        ## isinstance guard (#526 Copilot follow-up).
+        plugin = await harness.connect_plugin(session_id="non-obj-frame")
+
+        await plugin.ws.send("[]")
+        await plugin.ws.send("42")
+        await asyncio.sleep(0.1)
+        assert harness.registry.get("non-obj-frame") is not None, (
+            "non-object JSON frames must not unregister the session"
+        )
+        await plugin.close()
+
     async def test_invalid_command_response_is_skipped_and_session_survives(self, harness):
         plugin = await harness.connect_plugin(session_id="bad-response")
 

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -1392,3 +1392,84 @@ class TestResponseEnvelopeReadinessSelfHeal:
         finally:
             await asyncio.wait_for(task, timeout=2.0)
             await plugin.close()
+
+
+# ---------------------------------------------------------------------------
+# Malformed-frame resilience (#526)
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedFrameResilience:
+    """A single garbled frame must not tear down the editor session (#526).
+
+    Before the fix, a non-JSON frame or a command response failing Pydantic
+    validation raised out of the per-message loop into the catch-all, and the
+    finally block unregistered the session — one bad frame dropped the whole
+    editor↔server bridge.
+    """
+
+    async def test_non_json_frame_is_skipped_and_session_survives(self, harness):
+        plugin = await harness.connect_plugin(session_id="bad-frame")
+
+        await plugin.ws.send("this is not json {")
+        await asyncio.sleep(0.1)
+        assert harness.registry.get("bad-frame") is not None, (
+            "one non-JSON frame must not unregister the session"
+        )
+
+        ## Subsequent commands still round-trip over the surviving connection.
+        client = GodotClient(harness.server, harness.registry)
+
+        async def mock_handler():
+            cmd = await plugin.recv_command()
+            await plugin.send_response(cmd["request_id"], {"version": "4.4.1"})
+
+        handler_task = asyncio.create_task(mock_handler())
+        result = await client.send("get_editor_state")
+        await handler_task
+        assert result == {"version": "4.4.1"}
+        await plugin.close()
+
+    async def test_invalid_command_response_is_skipped_and_session_survives(self, harness):
+        plugin = await harness.connect_plugin(session_id="bad-response")
+
+        ## Not an event and fails CommandResponse validation (no request_id,
+        ## bad status type).
+        await plugin.ws.send(json.dumps({"status": 42, "data": "nope"}))
+        await asyncio.sleep(0.1)
+        assert harness.registry.get("bad-response") is not None, (
+            "one invalid command response must not unregister the session"
+        )
+
+        client = GodotClient(harness.server, harness.registry)
+
+        async def mock_handler():
+            cmd = await plugin.recv_command()
+            await plugin.send_response(cmd["request_id"], {"ok": True})
+
+        handler_task = asyncio.create_task(mock_handler())
+        result = await client.send("get_editor_state")
+        await handler_task
+        assert result == {"ok": True}
+        await plugin.close()
+
+    async def test_invalid_response_with_request_id_fails_pending_fast(self, harness):
+        """A malformed frame that names a pending request_id fails that
+        future immediately with a clear error instead of leaving the caller
+        to hit its timeout — and the session still survives."""
+        plugin = await harness.connect_plugin(session_id="bad-corr")
+        client = GodotClient(harness.server, harness.registry)
+
+        async def mock_handler():
+            cmd = await plugin.recv_command()
+            ## Correct request_id, but `status` has the wrong type so
+            ## CommandResponse validation fails.
+            await plugin.ws.send(json.dumps({"request_id": cmd["request_id"], "status": 42}))
+
+        handler_task = asyncio.create_task(mock_handler())
+        with pytest.raises(ConnectionError, match="Malformed response"):
+            await client.send("get_editor_state", timeout=5.0)
+        await handler_task
+
+        assert harness.registry.get("bad-corr") is not None
+        await plugin.close()


### PR DESCRIPTION
Fixes #526.

## Problem

In the per-message loop of `_handle_connection`, a non-JSON frame or a command response failing Pydantic validation raised out of the loop into the catch-all, and the `finally` block unregistered the session and dropped the connection — one garbled frame took down the whole editor↔server bridge. The event path already handled this correctly (local `ValidationError` catch); the command path did not.

## Fix

- `json.loads` and `CommandResponse.model_validate` each get a local catch (`json.JSONDecodeError` / `ValidationError`) that logs a warning (same `exc.errors(include_url=False, ...)` idiom as the event path) and skips the frame. **Only those two exception types are swallowed** — everything else still propagates to the existing catch-all/finally.
- Pending-future handling: if the malformed frame carries a string `request_id` matching a pending command, that future is failed immediately with a clear `ConnectionError` instead of leaving the caller to eat the 5s timeout. `send_command`'s `finally`-pop makes this race-safe (pop is idempotent). No usable `request_id` → normal timeout, the safe default.

## Tests

New `TestMalformedFrameResilience` (3 tests) on the existing harness: non-JSON frame skipped + session survives + subsequent command round-trips; invalid CommandResponse skipped + session survives; malformed frame with a valid pending `request_id` raises `ConnectionError` fast, session survives.

Full suite: **1271 passed, 2 pre-existing skips**; `ruff` clean. Python-transport-only — no GDScript surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017bCB9GDsZBp9wk7hjCGeu2

---
_Generated by [Claude Code](https://claude.ai/code/session_017bCB9GDsZBp9wk7hjCGeu2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved WebSocket session stability when malformed or invalid frames are received.
  - Invalid messages are now ignored without disconnecting the editor session.
  - Malformed command responses with a request ID now fail immediately with a clear connection error instead of timing out.
  - Valid command and response exchanges continue working after invalid frames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->