### PR TITLE
Robustness: cap nested-resource recursion (#536) + harden atomic config writes (#534)

### DIFF
--- a/plugin/addons/godot_ai/clients/_atomic_write.gd
+++ b/plugin/addons/godot_ai/clients/_atomic_write.gd
@@ -15,6 +15,11 @@ extends RefCounted
 
 
 static func write(path: String, content: String) -> bool:
+	# If the target is a symlink (stow/chezmoi-managed dotfiles), rename-over
+	# would replace the LINK with a regular file, silently detaching the
+	# config from the user's dotfile repo (#534). Resolve the link chain and
+	# write to the real target so the symlink survives.
+	path = _resolve_symlink_target(path)
 	var dir_path := path.get_base_dir()
 	if not DirAccess.dir_exists_absolute(dir_path):
 		if DirAccess.make_dir_recursive_absolute(dir_path) != OK:
@@ -32,7 +37,11 @@ static func write(path: String, content: String) -> bool:
 	var had_original := FileAccess.file_exists(path)
 	var target_mode := _resolve_target_mode(path, had_original)
 
-	var tmp_path := path + ".tmp"
+	# Suffix the temp name with this process's PID so two editors writing the
+	# same config concurrently (both clicking Configure) can't interleave
+	# bytes on a shared fixed ".tmp" path (#534). Each process stages its own
+	# temp file; the final rename remains the atomic commit point.
+	var tmp_path := "%s.tmp.%d" % [path, OS.get_process_id()]
 	var file := FileAccess.open(tmp_path, FileAccess.WRITE)
 	if file == null:
 		return false
@@ -116,6 +125,32 @@ static func write(path: String, content: String) -> bool:
 	# backup we couldn't take.)
 	DirAccess.remove_absolute(tmp_path)
 	return false
+
+
+## Follow a symlink chain at `path` and return the final real target, so the
+## temp+rename lands on the linked-to file instead of replacing the link.
+##
+## Best-effort by design: DirAccess.is_link()/read_link() are only implemented
+## on platforms with POSIX symlinks (Linux/macOS; on Windows and other
+## platforms is_link() returns false), and opening the parent dir can fail for
+## exotic paths. In every "can't tell" case we return `path` unchanged, which
+## is exactly the pre-#534 behavior — never worse, symlink-preserving where
+## the engine lets us detect one.
+static func _resolve_symlink_target(path: String) -> String:
+	var resolved := path
+	# Bounded hops so a symlink cycle can't loop us forever.
+	for _hop in 8:
+		var base_dir := resolved.get_base_dir()
+		var da := DirAccess.open(base_dir)
+		if da == null or not da.is_link(resolved):
+			return resolved
+		var target := da.read_link(resolved)
+		if target.is_empty():
+			return resolved
+		if target.is_relative_path():
+			target = base_dir.path_join(target)
+		resolved = target.simplify_path()
+	return resolved
 
 
 static func _resolve_target_mode(path: String, had_original: bool) -> int:

--- a/plugin/addons/godot_ai/handlers/resource_handler.gd
+++ b/plugin/addons/godot_ai/handlers/resource_handler.gd
@@ -286,10 +286,24 @@ static func _instantiate_resource(type_str: String) -> Variant:
 	return _unknown_resource_type_error(type_str)
 
 
+## Maximum nesting depth for the {"__class__": ...} sub-resource shortcut.
+## Caller-supplied dicts recurse through _apply_resource_properties; without a
+## cap a deeply nested payload overflows the GDScript call stack and crashes
+## the editor (#536). 32 is far beyond any legitimate sub-resource chain.
+const MAX_NESTED_RESOURCE_DEPTH := 32
+
+
 ## Apply a dict of property values to a freshly-instantiated Resource,
 ## reusing NodeHandler's coercion so Vector3/Color/etc. dicts land typed.
 ## Returns null on success or an error dict on failure.
-static func _apply_resource_properties(res: Resource, properties: Dictionary) -> Variant:
+## `depth` is internal recursion bookkeeping for the nested {"__class__": ...}
+## shortcut — external callers use the default of 0.
+static func _apply_resource_properties(res: Resource, properties: Dictionary, depth: int = 0) -> Variant:
+	if depth > MAX_NESTED_RESOURCE_DEPTH:
+		return ErrorCodes.make(
+			ErrorCodes.INVALID_PARAMS,
+			"Nested resource properties exceed the maximum depth of %d — flatten the {\"__class__\": ...} nesting or create the deep sub-resources in separate calls" % MAX_NESTED_RESOURCE_DEPTH
+		)
 	var prop_types := {}
 	for prop in res.get_property_list():
 		prop_types[prop.name] = prop.get("type", TYPE_NIL)
@@ -350,7 +364,7 @@ static func _apply_resource_properties(res: Resource, properties: Dictionary) ->
 			var remaining: Dictionary = (v as Dictionary).duplicate()
 			remaining.erase("__class__")
 			if not remaining.is_empty():
-				var nested_err := _apply_resource_properties(sub_res, remaining)
+				var nested_err := _apply_resource_properties(sub_res, remaining, depth + 1)
 				if nested_err != null:
 					return nested_err
 			v = sub_res

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -1461,6 +1461,81 @@ func test_atomic_write_preserves_existing_file_when_swap_fails() -> void:
 	DirAccess.remove_absolute(backup_path)
 
 
+# ----- atomic write: concurrency + symlink targets (#534) -----
+
+## List leftover files in _scratch_dir whose name starts with `prefix` — used
+## to prove no temp staging file (fixed or PID-suffixed) lingers after a write.
+func _leftover_tmp_files(prefix: String) -> Array[String]:
+	var out: Array[String] = []
+	for f in DirAccess.get_files_at(_scratch_dir):
+		if f.begins_with(prefix):
+			out.append(f)
+	return out
+
+
+func test_atomic_write_leaves_no_stale_tmp_of_any_name() -> void:
+	## #534: the temp name is now PID-suffixed. Whatever the exact name, no
+	## staging file starting with "<file>.tmp" may survive a successful write.
+	var path := _scratch_dir.path_join("pid_tmp.txt")
+	assert_true(McpAtomicWrite.write(path, "hello"))
+	var leftovers := _leftover_tmp_files("pid_tmp.txt.tmp")
+	assert_eq(leftovers.size(), 0, "no .tmp staging file may linger: %s" % str(leftovers))
+
+
+func test_atomic_write_does_not_use_fixed_tmp_name() -> void:
+	## #534: two editors clicking Configure at once must not interleave bytes
+	## on a shared "<path>.tmp". Prove the fixed name is no longer the staging
+	## path by parking an unwritable obstacle (a directory) at it — the write
+	## must still succeed because it stages elsewhere (PID-suffixed).
+	var path := _scratch_dir.path_join("no_fixed_tmp.txt")
+	var fixed_tmp := path + ".tmp"
+	DirAccess.make_dir_recursive_absolute(fixed_tmp)
+
+	assert_true(
+		McpAtomicWrite.write(path, "content"),
+		"write must succeed even when '<path>.tmp' is occupied — the staging name must be process-unique",
+	)
+	var rf := FileAccess.open(path, FileAccess.READ)
+	var got := rf.get_as_text()
+	rf.close()
+	assert_eq(got, "content")
+	# Cleanup — the obstacle dir is outside suite_teardown's flat-file sweep.
+	DirAccess.remove_absolute(fixed_tmp)
+
+
+func test_atomic_write_preserves_symlinked_target() -> void:
+	## #534: stow/chezmoi users symlink their configs. A rename over the link
+	## path would replace the LINK with a regular file, detaching the config
+	## from the dotfile repo. The write must land through the link into the
+	## real target, leaving the symlink intact.
+	if OS.get_name() == "Windows":
+		skip("creating POSIX symlinks is not portable on Windows")
+		return
+	var target := _scratch_dir.path_join("symlink_real_target.json")
+	var link := _scratch_dir.path_join("symlink_config.json")
+	var tf := FileAccess.open(target, FileAccess.WRITE)
+	tf.store_string("old")
+	tf.close()
+	DirAccess.remove_absolute(link)
+	# Godot has no symlink-create API; shell out. Skip if ln isn't usable.
+	var rc := OS.execute("ln", ["-s", target, link])
+	var da := DirAccess.open(_scratch_dir)
+	if rc != 0 or da == null or not da.is_link(link):
+		skip("could not create a symlink on this platform")
+		return
+
+	assert_true(McpAtomicWrite.write(link, "new via link"))
+
+	assert_true(da.is_link(link), "the symlink must survive the atomic write — issue #534")
+	var rf := FileAccess.open(target, FileAccess.READ)
+	var got := rf.get_as_text()
+	rf.close()
+	assert_eq(got, "new via link", "the new bytes must land in the symlink's real target")
+	# Cleanup (the .backup lands next to the resolved target).
+	DirAccess.remove_absolute(target + ".backup")
+	DirAccess.remove_absolute(link)
+
+
 # ----- atomic write: permission preservation (#297 finding TC-1) -----
 #
 # The Claude CLI creates ~/.claude.json as 0600 (it holds OAuth creds). A

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -1482,6 +1482,21 @@ func test_atomic_write_leaves_no_stale_tmp_of_any_name() -> void:
 	assert_eq(leftovers.size(), 0, "no .tmp staging file may linger: %s" % str(leftovers))
 
 
+func test_atomic_write_leaves_no_stale_tmp_after_failed_write() -> void:
+	## #534 review follow-up: the PID-suffixed staging file must also be
+	## cleaned up when the write FAILS (destination is a directory, so the
+	## rename and the copy fallback both reject) — otherwise a regression
+	## could accumulate ".tmp.<pid>" files invisibly.
+	var dir_dest := _scratch_dir.path_join("tmp_fail_dir.txt")
+	DirAccess.make_dir_recursive_absolute(dir_dest)
+	assert_false(
+		McpAtomicWrite.write(dir_dest, "content"),
+		"writing over a directory must fail",
+	)
+	var leftovers := _leftover_tmp_files("tmp_fail_dir.txt.tmp")
+	assert_eq(leftovers.size(), 0, "no .tmp staging file may linger after a failed write: %s" % str(leftovers))
+
+
 func test_atomic_write_does_not_use_fixed_tmp_name() -> void:
 	## #534: two editors clicking Configure at once must not interleave bytes
 	## on a shared "<path>.tmp". Prove the fixed name is no longer the staging

--- a/test_project/tests/test_resource.gd
+++ b/test_project/tests/test_resource.gd
@@ -731,6 +731,48 @@ func test_apply_properties_nested_custom_class_name_instantiates_sub_resource() 
 		assert_eq((host.sub as MyTestResource).label, "child")
 
 
+## Build a {"__class__": "MyTestResource", "sub": {...}} chain `levels` deep.
+func _nested_class_payload(levels: int) -> Dictionary:
+	var payload := {"__class__": "MyTestResource"}
+	for i in levels - 1:
+		payload = {"__class__": "MyTestResource", "sub": payload}
+	return payload
+
+
+# ----- regression #536: nested __class__ recursion must be depth-capped -----
+
+func test_apply_properties_rejects_nesting_beyond_depth_cap() -> void:
+	# A caller-supplied payload nested past MAX_NESTED_RESOURCE_DEPTH must be
+	# rejected with a clean structured error — not overflow the GDScript call
+	# stack and crash the editor, and not silently truncate the chain.
+	var host := MyTestResource.new()
+	var over_cap := ResourceHandler.MAX_NESTED_RESOURCE_DEPTH + 8
+	var err: Variant = ResourceHandler._apply_resource_properties(host, {
+		"sub": _nested_class_payload(over_cap),
+	})
+	assert_true(err is Dictionary, "over-deep nesting must return an error dict; got: %s" % str(err))
+	assert_is_error(err, ErrorCodes.INVALID_PARAMS)
+	assert_contains(
+		err.error.message,
+		str(ResourceHandler.MAX_NESTED_RESOURCE_DEPTH),
+		"the error must name the depth limit so the caller can adapt",
+	)
+
+
+func test_apply_properties_accepts_reasonable_nesting_depth() -> void:
+	# The cap must not reject legitimate multi-level sub-resource chains.
+	var host := MyTestResource.new()
+	var err: Variant = ResourceHandler._apply_resource_properties(host, {
+		"sub": _nested_class_payload(8),
+	})
+	assert_true(err == null, "8-level nesting should apply cleanly; got: %s" % str(err))
+	# Walk the chain to confirm every level actually instantiated.
+	var cursor: Resource = host
+	for i in 8:
+		assert_true(cursor.sub is MyTestResource, "level %d must be a MyTestResource" % (i + 1))
+		cursor = cursor.sub
+
+
 func test_instantiate_resource_non_instantiable_project_class_is_wrong_type() -> void:
 	# A project class_name whose can_instantiate() is false (here a non-@tool
 	# script, non-instantiable in the editor) must return WRONG_TYPE — mirroring


### PR DESCRIPTION
Fixes #536 and #534 — the two remaining low-severity items from the 2026-06-09 robustness review.

## #536 — recursion-depth guard

`_apply_resource_properties` recursed unbounded on caller-supplied nested `{"__class__": ...}` dicts — a deep payload could overflow the GDScript stack and crash the editor. Now: `MAX_NESTED_RESOURCE_DEPTH := 32`, threaded as an internal `depth` param (default 0, external callers unchanged); depth 33+ returns a clean `INVALID_PARAMS` naming the limit and the workaround. Callsite audit: the issue's cited locations were stale — actual callers (`environment_handler.gd:87,95`, `node_handler.gd:249`, `resource_handler.gd:187`) all funnel through this one static helper, so the single guard covers everything. FS scanners deliberately untouched (per issue, lower risk).

## #534 — atomic write hardening

1. **Symlink preservation**: `write()` resolves the symlink chain (8-hop bound against cycles) via `DirAccess.is_link`/`read_link` before the temp+rename, so stow/chezmoi-managed configs keep their link instead of having it silently replaced by a regular file. Best-effort by design — these APIs are POSIX-only; every "can't tell" case falls back to exactly the pre-#534 behavior. Resolution happens before parent-dir/mode/backup logic so those operate on the real target.
2. **Race-safe staging**: temp path is now `<path>.tmp.<pid>` — two editors clicking Configure simultaneously stage separate files instead of interleaving on a shared fixed `.tmp`. The rename remains the atomic commit point.

## Tests

- `test_resource.gd`: 40-deep chain → `INVALID_PARAMS` mentioning "32"; 8-deep chain applies and round-trips.
- `test_clients.gd`: no `.tmp*` staging file lingers; a directory parked at the old fixed `<path>.tmp` no longer blocks writes (proves process-unique staging); symlink-preservation test on Linux/macOS via `ln -s` (self-skips where unavailable — Godot has no symlink-create API).

`gdparse` clean on all four files; GDScript suite runs in CI. Live-editor checks worth doing: the symlink test on the CI platform, and a two-editor concurrent Configure if convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017bCB9GDsZBp9wk7hjCGeu2

---
_Generated by [Claude Code](https://claude.ai/code/session_017bCB9GDsZBp9wk7hjCGeu2)_