### PR TITLE
Telemetry privacy: salt project-slug hash with customer_uuid (#529) + require https off-loopback (#532)

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -10,11 +10,14 @@ goes, and how to opt out. All telemetry code is open source and lives in
 
 - **Anonymous**: a randomly generated UUID per installation. No account,
   no email, no machine fingerprint beyond OS / Python version.
-- **Hashed session ids**: Godot AI session ids include a project-directory
-  slug (e.g. `secret-game-prototype@a3f2`). Before any event leaves the
-  process, the slug is replaced with the first 8 hex chars of its sha256
-  — `3f1a8b22@a3f2`. The slug-derived hash is stable per project but
-  doesn't leak the directory name.
+- **Salted, hashed session ids**: Godot AI session ids include a
+  project-directory slug (e.g. `secret-game-prototype@a3f2`). Before any
+  event leaves the process, the slug is replaced with the first 8 hex
+  chars of `sha256(customer_uuid + slug)` — `3f1a8b22@a3f2`. Salting with
+  the per-installation UUID means the hash is stable per project on a
+  given install, but the same project name produces different hashes on
+  different installations — so hashes can't be correlated across users or
+  reversed with a dictionary of common project names.
 - **Non-blocking**: events go through a bounded in-process queue and a
   single daemon worker. Telemetry failures never propagate to tool
   callers.
@@ -122,7 +125,9 @@ export GODOT_AI_TELEMETRY_ENDPOINT=http://127.0.0.1:7777/
 ```
 
 Only `http://` and `https://` schemes are accepted; localhost is rejected
-unless `GODOT_AI_TELEMETRY_ALLOW_LOOPBACK=1` is also set. An invalid
+unless `GODOT_AI_TELEMETRY_ALLOW_LOOPBACK=1` is also set. Plain `http://`
+to a non-loopback host is rejected (it would ship telemetry in cleartext)
+unless `GODOT_AI_TELEMETRY_ALLOW_INSECURE_HTTP=1` is set. An invalid
 override does **not** silently fall back to the baked-in default — it
 disables sending and emits a warning, so a misconfigured self-host
 can't accidentally ship events to the maintainers' endpoint.

--- a/src/godot_ai/telemetry.py
+++ b/src/godot_ai/telemetry.py
@@ -109,23 +109,38 @@ class TelemetryRecord:
     milestone: MilestoneType | None = None
 
 
-def hash_session_id(session_id: str | None) -> str:
+def hash_session_id(session_id: str | None, *, salt: str = "") -> str:
     """Make a session id safe to ship: hash the slug, keep the twin suffix.
 
     Godot-AI session ids look like ``<slug>@<4hex>`` where ``<slug>`` is
     derived from the project directory name (potentially identifying:
-    ``secret-game-prototype@a3f2``). We sha256 the slug and keep the first
-    8 hex chars, preserving per-project stability without leaking the
-    name. Sessions without an ``@`` (legacy or absent) hash as a whole.
-    Empty / ``None`` returns ``""`` so callers can pass through raw values.
+    ``secret-game-prototype@a3f2``). We sha256 the salt-prefixed slug and
+    keep the first 8 hex chars, preserving per-install per-project
+    stability without leaking the name. Sessions without an ``@`` (legacy
+    or absent) hash as a whole. Empty / ``None`` returns ``""`` so callers
+    can pass through raw values.
+
+    ``salt`` should be the local ``customer_uuid`` (issue #529): an
+    unsalted truncated hash of a project name is dictionary-reversible
+    and — worse — identical across installations, enabling cross-user
+    correlation of common project names. Salting with the per-install
+    UUID kills both while keeping the hash stable for a given install +
+    project. NOTE: introducing the salt intentionally changes every
+    existing project hash fleet-wide — a one-time aggregation
+    discontinuity in the telemetry backend, accepted cost of the privacy
+    fix. Callers with no UUID available may pass ``salt=""`` (falls back
+    to the legacy unsalted digest).
     """
     if not session_id:
         return ""
+
+    def _digest(text: str) -> str:
+        return hashlib.sha256((salt + text).encode("utf-8", errors="replace")).hexdigest()[:8]
+
     if "@" in session_id:
         slug, _, suffix = session_id.rpartition("@")
-        digest = hashlib.sha256(slug.encode("utf-8", errors="replace")).hexdigest()[:8]
-        return f"{digest}@{suffix}"
-    return hashlib.sha256(session_id.encode("utf-8", errors="replace")).hexdigest()[:8]
+        return f"{_digest(slug)}@{suffix}"
+    return _digest(session_id)
 
 
 class TelemetryConfig:
@@ -158,6 +173,10 @@ class TelemetryConfig:
         ## allow_loopback must be resolved before _resolve_endpoint(), which
         ## reads it to decide whether to accept http://127.0.0.1 endpoints.
         self.allow_loopback = self._env_truthy("GODOT_AI_TELEMETRY_ALLOW_LOOPBACK")
+        ## Escape hatch for issue #532: plain http:// to a non-loopback
+        ## host ships customer_uuid + usage data in cleartext, so it is
+        ## rejected unless the operator explicitly opts in.
+        self.allow_insecure_http = self._env_truthy("GODOT_AI_TELEMETRY_ALLOW_INSECURE_HTTP")
         self.endpoint = self._resolve_endpoint()
         self.timeout = self._resolve_timeout()
 
@@ -222,10 +241,23 @@ class TelemetryConfig:
         if not parsed.netloc:
             return False
         host = (parsed.hostname or "").lower()
-        if host in ("localhost", "127.0.0.1", "::1") and not self.allow_loopback:
+        is_loopback = host in ("localhost", "127.0.0.1", "::1")
+        if is_loopback and not self.allow_loopback:
             ## Loopback is rejected unless the operator explicitly opts in.
             ## Self-hosters and the local-sink smoke flow set
             ## GODOT_AI_TELEMETRY_ALLOW_LOOPBACK=1.
+            return False
+        if parsed.scheme == "http" and not is_loopback and not self.allow_insecure_http:
+            ## Cleartext http to a real network host would ship the
+            ## customer_uuid and usage data unencrypted (issue #532).
+            ## Loopback http stays fine (never leaves the machine);
+            ## anything else requires the explicit escape hatch
+            ## GODOT_AI_TELEMETRY_ALLOW_INSECURE_HTTP=1.
+            logger.warning(
+                "Telemetry endpoint %r uses plain http to a non-loopback host; "
+                "use https or set GODOT_AI_TELEMETRY_ALLOW_INSECURE_HTTP=1",
+                candidate,
+            )
             return False
         return True
 
@@ -357,7 +389,13 @@ class TelemetryCollector:
             record_type=record_type,
             timestamp=time.time(),
             customer_uuid=self._customer_uuid or "unknown",
-            session_id=hash_session_id(session_id) if session_id else "",
+            ## Salt with the per-install customer_uuid (issue #529). The
+            ## uuid is always loaded before any record on an enabled
+            ## collector; the "" fallback (legacy unsalted digest) is
+            ## defensive only.
+            session_id=(
+                hash_session_id(session_id, salt=self._customer_uuid or "") if session_id else ""
+            ),
             data=data,
             milestone=milestone,
         )

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -30,6 +30,7 @@ def clean_env(monkeypatch) -> None:
         "GODOT_AI_TELEMETRY_ENDPOINT",
         "GODOT_AI_TELEMETRY_TIMEOUT",
         "GODOT_AI_TELEMETRY_ALLOW_LOOPBACK",
+        "GODOT_AI_TELEMETRY_ALLOW_INSECURE_HTTP",
     ):
         monkeypatch.delenv(name, raising=False)
 
@@ -67,6 +68,21 @@ class TestHashSessionId:
         result = tel.hash_session_id("legacy-session")
         assert "@" not in result
         assert len(result) == 8
+
+    def test_salt_changes_hash_across_uuids(self) -> None:
+        """Issue #529: the same slug must hash differently per install."""
+        a = tel.hash_session_id("common-project@1111", salt="uuid-a")
+        b = tel.hash_session_id("common-project@1111", salt="uuid-b")
+        assert a != b
+        assert a.endswith("@1111") and b.endswith("@1111")
+
+    def test_salt_stable_for_same_uuid_and_slug(self) -> None:
+        a = tel.hash_session_id("common-project@1111", salt="uuid-a")
+        b = tel.hash_session_id("common-project@1111", salt="uuid-a")
+        assert a == b
+
+    def test_salted_differs_from_unsalted(self) -> None:
+        assert tel.hash_session_id("proj@1111", salt="uuid-a") != tel.hash_session_id("proj@1111")
 
 
 # --- TelemetryConfig -----------------------------------------------------
@@ -132,6 +148,28 @@ class TestTelemetryConfig:
         monkeypatch.setenv("GODOT_AI_TELEMETRY_ENDPOINT", "http://127.0.0.1:7777")
         monkeypatch.setenv("GODOT_AI_TELEMETRY_ALLOW_LOOPBACK", "1")
         assert tel.TelemetryConfig().endpoint == "http://127.0.0.1:7777"
+
+    def test_rejects_plain_http_non_loopback(
+        self, monkeypatch, clean_env, isolated_data_dir
+    ) -> None:
+        """Issue #532: cleartext http to a real host must be rejected."""
+        monkeypatch.setenv("GODOT_AI_TELEMETRY_ENDPOINT", "http://telemetry.example.com/events")
+        assert tel.TelemetryConfig().endpoint == ""
+
+    def test_allows_plain_http_with_insecure_flag(
+        self, monkeypatch, clean_env, isolated_data_dir
+    ) -> None:
+        monkeypatch.setenv("GODOT_AI_TELEMETRY_ENDPOINT", "http://telemetry.example.com/events")
+        monkeypatch.setenv("GODOT_AI_TELEMETRY_ALLOW_INSECURE_HTTP", "1")
+        assert tel.TelemetryConfig().endpoint == "http://telemetry.example.com/events"
+
+    def test_loopback_http_still_allowed_with_loopback_flag(
+        self, monkeypatch, clean_env, isolated_data_dir
+    ) -> None:
+        """Loopback http needs only the loopback flag, not the insecure one."""
+        monkeypatch.setenv("GODOT_AI_TELEMETRY_ENDPOINT", "http://localhost:7777/")
+        monkeypatch.setenv("GODOT_AI_TELEMETRY_ALLOW_LOOPBACK", "1")
+        assert tel.TelemetryConfig().endpoint == "http://localhost:7777/"
 
     def test_default_timeout(self, clean_env, isolated_data_dir) -> None:
         assert tel.TelemetryConfig().timeout == tel.TelemetryConfig.DEFAULT_TIMEOUT
@@ -251,6 +289,12 @@ class TestTelemetryCollector:
         assert sent
         assert sent[0].session_id.endswith("@a3f2")
         assert "secret-game" not in sent[0].session_id
+        ## The record path salts with the install's customer_uuid (#529):
+        ## the shipped hash must not equal the unsalted digest.
+        assert sent[0].session_id == tel.hash_session_id(
+            "secret-game@a3f2", salt=collector._customer_uuid
+        )
+        assert sent[0].session_id != tel.hash_session_id("secret-game@a3f2")
         collector.shutdown()
 
     def test_milestone_idempotent(self, clean_env, isolated_data_dir) -> None:


### PR DESCRIPTION
Fixes #529 and #532.

## #529 — salted slug hash

`hash_session_id` was `sha256(slug)[:8]` — dictionary-reversible for common project names, and identical across every install, enabling exactly the cross-installation correlation `docs/TELEMETRY.md` implies doesn't happen.

Now `sha256(customer_uuid + slug)[:8]` (salt passed by `TelemetryCollector.record`, the only production caller — verified by grep). Per-install per-project stability is preserved; cross-user correlation and dictionary reversal are killed. The `@<4hex>` twin-suffix behavior is unchanged. `salt=""` remains as a documented legacy fallback for the no-UUID path (on an enabled collector the UUID is always loaded before any record).

**Heads-up for the telemetry backend:** this intentionally changes every existing project hash fleet-wide — a one-time aggregation discontinuity, the accepted cost of the privacy fix (noted in the docstring and commit message). `docs/TELEMETRY.md` privacy section rewritten to describe the salted scheme honestly.

## #532 — https required off-loopback

`_is_valid_endpoint` now rejects `http://` to any non-loopback host unless `GODOT_AI_TELEMETRY_ALLOW_INSECURE_HTTP=1` is set (naming/style mirrors the existing `GODOT_AI_TELEMETRY_ALLOW_LOOPBACK` escape hatch, resolved via the same `_env_truthy`). Rejection flows through the existing invalid-endpoint path — endpoint stays empty and sends are skipped, matching the file's documented no-silent-fallback posture — with a warning naming the escape hatch. Loopback http is unchanged (never leaves the machine; still governed only by `ALLOW_LOOPBACK`).

## Tests

Salted hash differs across UUIDs for the same slug / stable for same UUID+slug / differs from unsalted; record path uses the UUID-salted hash; http non-loopback rejected / accepted with flag / loopback unchanged; new env var added to the `clean_env` fixture.

**Full suite: 1274 passed, 2 pre-existing skips; `ruff` clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017bCB9GDsZBp9wk7hjCGeu2

---
_Generated by [Claude Code](https://claude.ai/code/session_017bCB9GDsZBp9wk7hjCGeu2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Session identifiers are now salted before hashing, improving privacy while preserving session suffixes.
  * Insecure HTTP telemetry endpoints are rejected by default, with explicit opt-in available for non-loopback hosts.
  * Loopback HTTP connections remain supported when enabled.
* **Documentation**
  * Updated telemetry documentation to explain session ID hashing and endpoint security rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->