### PR TITLE
game_eval: classify the remaining opaque INTERNAL_ERROR envelopes (#518)

### DIFF
--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -921,10 +921,11 @@ func _clear_pending(request_id: String) -> void:
 ## Editor-side fallback timer for game_eval. MUST stay above the game-side
 ## EVAL_TIMEOUT_SEC (8.0) in runtime/game_helper.gd and below the dispatcher's
 ## game_eval budget (15000 ms) in dispatcher.gd — i.e. game 8s < editor 10s <
-## dispatcher 15s. This timer only fires when the game never replies at all,
-## and its message (the timeout_callable below) is intentionally generic. Drop
-## timeout_sec at/below 8s and it pre-empts the game's actionable "Eval
-## exceeded 8s" message — see the TIMEOUT ORDERING note on EVAL_TIMEOUT_SEC.
+## dispatcher 15s. This timer only fires when the game never replies at all;
+## _on_eval_timeout then attributes the failure (game not live vs never-acked
+## vs started-and-hung, #518). Drop timeout_sec at/below 8s and it pre-empts
+## the game's more specific "Eval exceeded 8s" message — see the TIMEOUT
+## ORDERING note on EVAL_TIMEOUT_SEC.
 ##
 ## #500: the *not-ready* path adds EVAL_READY_WAIT_SEC (3s) on top of this 10s
 ## backstop. That sum (13s) must also stay below the dispatcher/server 15s
@@ -1003,18 +1004,7 @@ func _send_eval(
 		return
 
 	var timer: SceneTreeTimer = tree.create_timer(timeout_sec)
-	var timeout_callable := func() -> void:
-		var pending_entry = _pending.get(request_id)
-		if pending_entry == null:
-			return
-		_clear_pending(request_id)
-		var conn: McpConnection = pending_entry.connection
-		if conn == null or not is_instance_valid(conn):
-			return
-		_send_error(conn, request_id, ErrorCodes.INTERNAL_ERROR,
-			"Game eval compiled and started running but never returned within %.0fs — the code is likely stuck in an infinite loop or awaiting a signal/timer that never fires. Check logs_read(source='game')." % timeout_sec)
-		if _log_buffer:
-			_log_buffer.log("[debug] !! eval timeout (%s)" % request_id)
+	var timeout_callable := func() -> void: _on_eval_timeout(request_id, timeout_sec)
 	timer.timeout.connect(timeout_callable)
 
 	## #490: arm the compile-grace timer. _on_eval_grace concludes a parse error
@@ -1038,6 +1028,57 @@ func _send_eval(
 	session.send_message("mcp:eval", [request_id, code])
 	if _log_buffer:
 		_log_buffer.log("[debug] -> mcp:eval (%s)" % request_id)
+
+
+## #518: the 10s editor-side backstop fired — the game never replied at all.
+## Attribute the failure instead of emitting a one-size-fits-all INTERNAL_ERROR:
+##
+## - game not live anymore (parked in a debugger break, stopped, crashed):
+##   the eval couldn't run/finish for a *game-state* reason. Reply with the
+##   same caller-actionable EVAL_GAME_NOT_READY + `_explain_not_live` payload
+##   the pre-hello break path already uses — a break freezes the game's idle
+##   loop, so any awaiting eval parks here even though sync evals still work.
+## - game live but never acked the eval: its main thread never serviced the
+##   debugger message (long frame/load, CPU-bound prior eval, or a
+##   backgrounded window whose idle loop is frozen).
+## - game live, acked, compiled: the eval genuinely started and never
+##   finished, and the game couldn't even self-report via its own 8s guard
+##   (which needs a ticking idle loop) — hung await, CPU-bound loop, or a
+##   reply the debugger channel dropped.
+##
+## The live branches reply EVAL_HUNG: the eval code never finished. That code
+## plus the game-side 8s guard (also EVAL_HUNG, via mcp:eval_error's code
+## element) empties the former INTERNAL_ERROR bucket on this path.
+func _on_eval_timeout(request_id: String, timeout_sec: float) -> void:
+	var pending_entry = _pending.get(request_id)
+	if pending_entry == null:
+		return
+	_clear_pending(request_id)
+	var conn: McpConnection = pending_entry.connection
+	if conn == null or not is_instance_valid(conn):
+		return
+	var status := get_game_status(-1, EVAL_READY_WAIT_SEC)
+	if str(status.get("status", "")) != "live":
+		_send_error_response(conn, request_id,
+			_explain_not_live(status, ErrorCodes.EVAL_GAME_NOT_READY))
+		if _log_buffer:
+			_log_buffer.log("[debug] !! eval timeout, game not live (%s, status=%s)"
+				% [request_id, str(status.get("status", ""))])
+		return
+	var message: String
+	if not bool(pending_entry.get("acked", false)):
+		message = ("Game eval was sent but the game never picked it up within %.0fs — "
+			+ "its main thread is busy or frozen (a long frame/load, a CPU-bound "
+			+ "prior eval, or a backgrounded game window whose loop is throttled). "
+			+ "Check logs_read(source='game') and retry.") % timeout_sec
+	else:
+		message = ("Game eval compiled and started running but never returned within "
+			+ "%.0fs — the code is likely stuck in an infinite loop or awaiting a "
+			+ "signal/timer that never fires (a backgrounded game window also freezes "
+			+ "awaits). Check logs_read(source='game').") % timeout_sec
+	_send_error(conn, request_id, ErrorCodes.EVAL_HUNG, message)
+	if _log_buffer:
+		_log_buffer.log("[debug] !! eval timeout (%s)" % request_id)
 
 
 func _on_eval_response(data: Array) -> void:
@@ -1067,6 +1108,17 @@ func _on_eval_response(data: Array) -> void:
 		_log_buffer.log("[debug] <- mcp:eval_response (%s)" % request_id)
 
 
+## #518: codes the game side may attach as mcp:eval_error's optional third
+## payload element. Allowlisted so a game process can't mint arbitrary
+## top-level error codes over the debugger channel; anything else (including
+## the legacy two-element payload from an older game helper mid-update)
+## falls back to INTERNAL_ERROR exactly as before.
+const _GAME_EVAL_ERROR_CODES: Array[String] = [
+	ErrorCodes.EVAL_HUNG,
+	ErrorCodes.EVAL_RESULT_TOO_LARGE,
+]
+
+
 func _on_eval_error(data: Array) -> void:
 	if data.size() < 2:
 		return
@@ -1079,7 +1131,10 @@ func _on_eval_error(data: Array) -> void:
 	var connection: McpConnection = pending_entry.connection
 	if connection == null or not is_instance_valid(connection):
 		return
-	_send_error(connection, request_id, ErrorCodes.INTERNAL_ERROR, message)
+	var code := ErrorCodes.INTERNAL_ERROR
+	if data.size() > 2 and str(data[2]) in _GAME_EVAL_ERROR_CODES:
+		code = str(data[2])
+	_send_error(connection, request_id, code, message)
 	if _log_buffer:
 		_log_buffer.log("[debug] <- mcp:eval_error (%s): %s" % [request_id, message])
 

--- a/plugin/addons/godot_ai/runtime/game_helper.gd
+++ b/plugin/addons/godot_ai/runtime/game_helper.gd
@@ -38,6 +38,7 @@ const FLUSH_BATCH_LIMIT := 200
 const FIRST_FRAME_WAIT_SEC := 6.0
 
 const GameLogger := preload("res://addons/godot_ai/runtime/game_logger.gd")
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
 
 var _registered := false
 ## Captures game-process print, warning, and error output for the editor.
@@ -625,11 +626,12 @@ func _mouse_button_index(name: String) -> int:
 ## `debugger/mcp_debugger_plugin.gd::request_game_eval` (`timeout_sec`,
 ## default 10.0), which in turn stays below the dispatcher's `game_eval`
 ## budget in `dispatcher.gd` (15000 ms). So: game 8s < editor 10s <
-## dispatcher 15s. Only this game-side guard emits the actionable
-## "Eval exceeded 8s" message; the editor timer emits a *generic* "Game eval
-## timed out" message. Raise this at/above the editor timer (or drop that
-## timer below this) and the generic message wins the race, silently losing
-## the diagnostic this fix exists to provide. Nothing enforces the order —
+## dispatcher 15s. Only this game-side guard emits the specific
+## "Eval exceeded 8s" message (both it and the editor backstop now carry the
+## EVAL_HUNG code, #518, but the editor's message can't name the cause).
+## Raise this at/above the editor timer (or drop that timer below this) and
+## the less specific editor message wins the race, silently losing the
+## diagnostic this fix exists to provide. Nothing enforces the order —
 ## change one, re-check the other two.
 ##
 ## NOTE: this catches a hung `await`, not a CPU-bound loop with no `await` —
@@ -743,7 +745,8 @@ func _handle_eval(data: Array) -> void:
 			("Eval exceeded %ds and was aborted — the code likely awaits "
 				+ "something that never completes (a signal that never fires, a timer on "
 				+ "a paused tree) or loops forever. Check logs_read(source='game').")
-				% int(EVAL_TIMEOUT_SEC))
+				% int(EVAL_TIMEOUT_SEC),
+			ErrorCodes.EVAL_HUNG)
 		return
 
 	## Clean finish.
@@ -775,13 +778,45 @@ func _drive_eval(node: Node, holder: Dictionary) -> void:
 	holder["done"] = true
 
 
-func _reply_eval_error(request_id: String, message: String) -> void:
-	EngineDebugger.send_message("mcp:eval_error", [request_id, message])
+## #518: cap on the serialized eval result. Godot's remote-debugger TCP peer
+## silently discards any single message over ~8 MiB, so a bigger reply never
+## reaches the editor and the request rides to the 10s backstop as a phantom
+## "hang". (Results over the editor↔server WebSocket buffer cap of 4 MiB fail
+## there with their own explicit error; this game-side cap only needs to stay
+## under the debugger peer's drop threshold to keep the failure visible.)
+const EVAL_RESULT_MAX_BYTES := 6 * 1024 * 1024
+
+## Testing seam: the last eval reply, recorded before hitting the
+## EngineDebugger channel (inactive in the editor-side test harness).
+var _last_eval_reply: Dictionary = {}
+
+
+## `code` (optional) rides as a third payload element so the editor can map
+## the reply to a specific error code instead of the generic INTERNAL_ERROR;
+## the editor allowlists the value (see mcp_debugger_plugin._on_eval_error).
+func _reply_eval_error(request_id: String, message: String, code: String = "") -> void:
+	_last_eval_reply = {"kind": "error", "request_id": request_id,
+		"message": message, "code": code}
+	var payload := [request_id, message]
+	if not code.is_empty():
+		payload.append(code)
+	if EngineDebugger.is_active():
+		EngineDebugger.send_message("mcp:eval_error", payload)
 
 
 func _reply_eval_response(request_id: String, value: Variant) -> void:
-	EngineDebugger.send_message("mcp:eval_response",
-		[request_id, JSON.stringify(_variant_to_json(value))])
+	var serialized := JSON.stringify(_variant_to_json(value))
+	var serialized_bytes := serialized.to_utf8_buffer().size()
+	if serialized_bytes > EVAL_RESULT_MAX_BYTES:
+		_reply_eval_error(request_id,
+			("Eval result too large to return (%d bytes serialized, limit %d). "
+				+ "Return a smaller slice instead — e.g. counts, node paths, or a "
+				+ "truncated substring.") % [serialized_bytes, EVAL_RESULT_MAX_BYTES],
+			ErrorCodes.EVAL_RESULT_TOO_LARGE)
+		return
+	_last_eval_reply = {"kind": "response", "request_id": request_id}
+	if EngineDebugger.is_active():
+		EngineDebugger.send_message("mcp:eval_response", [request_id, serialized])
 
 
 ## #490: if a logged script error past THIS eval's baseline carries its unique

--- a/plugin/addons/godot_ai/utils/error_codes.gd
+++ b/plugin/addons/godot_ai/utils/error_codes.gd
@@ -38,6 +38,19 @@ const EVAL_RUNTIME_ERROR := "EVAL_RUNTIME_ERROR"
 ## errors. NOT a hang: it fires fast (~3s) and is caller-actionable (let the game
 ## finish booting and retry, or check the autoload is enabled).
 const EVAL_GAME_NOT_READY := "EVAL_GAME_NOT_READY"
+## #518: the eval genuinely never finished inside the timeout ladder — the
+## game-side 8s deadline aborted a hung await, or the editor-side 10s backstop
+## fired because the game never replied at all (CPU-bound loop, frozen /
+## backgrounded idle loop). Carved out of INTERNAL_ERROR — the last big
+## still-unlabeled bucket from #487/#488 — so "your eval code never finished"
+## stops reading as an internal fault in telemetry and agent-facing errors.
+const EVAL_HUNG := "EVAL_HUNG"
+## #518: the eval completed but its serialized result is too large for the
+## debugger + WebSocket pipeline. Without this the reply is dropped silently
+## (the debugger TCP peer discards messages over ~8 MiB) and the request rides
+## to the 10s backstop as a phantom "hang". Failing fast game-side with the
+## real byte count makes the failure actionable (return a smaller slice).
+const EVAL_RESULT_TOO_LARGE := "EVAL_RESULT_TOO_LARGE"
 ## audit-v2 #21 (issue #365): finer-grained codes carved out of the 471
 ## INVALID_PARAMS sites so agents can distinguish recoverable input
 ## errors from structural ones. INVALID_PARAMS stays for genuinely

--- a/src/godot_ai/handlers/editor.py
+++ b/src/godot_ai/handlers/editor.py
@@ -412,12 +412,18 @@ async def game_eval(runtime: DirectRuntime, code: str) -> dict:
     Errors come back fast and actionable (#490): a syntax/parse error returns
     ``EVAL_COMPILE_ERROR`` and a runtime error returns ``EVAL_RUNTIME_ERROR``
     with the real message and resolved line, instead of a generic timeout.
-    ``EVAL_GAME_NOT_READY`` (#518) means the play session is up but the
-    game-side capture hasn't registered yet — let the game finish launching and
-    retry, or check the ``_mcp_game_helper`` autoload is enabled. A genuine
-    infinite loop / never-firing await still hits the timeout. Note that
-    ``await`` (timers, signals, frames) only progresses while the game window is
-    focused; a backgrounded play-in-editor game has a frozen idle loop, so an
-    awaiting eval reads as a timeout until the game is focused.
+    ``EVAL_GAME_NOT_READY`` (#518) means the game can't service evals right
+    now: the play session is up but the game-side capture hasn't registered
+    yet (let the game finish launching and retry, or check the
+    ``_mcp_game_helper`` autoload is enabled), or the game is parked in a
+    debugger break / stopped mid-eval (stop and relaunch it). ``EVAL_HUNG``
+    (#518) means the eval code itself never finished: a genuine infinite loop
+    or never-firing await, aborted by the game's 8s deadline or the editor's
+    10s backstop. ``EVAL_RESULT_TOO_LARGE`` (#518) means the eval finished but
+    its serialized result exceeds what the debugger channel can carry (~6 MiB)
+    — return a smaller slice. Note that ``await`` (timers, signals, frames)
+    only progresses while the game window is focused; a backgrounded
+    play-in-editor game has a frozen idle loop, so an awaiting eval reads as
+    ``EVAL_HUNG`` until the game is focused.
     """
     return await runtime.send_command("game_eval", {"code": code}, timeout=15.0)

--- a/src/godot_ai/protocol/errors.py
+++ b/src/godot_ai/protocol/errors.py
@@ -26,6 +26,17 @@ class ErrorCode(StrEnum):
     # this fast (~3s), caller-actionable failure stops being counted as the
     # opaque "eval hung" 10s timeout. Keep in sync with utils/error_codes.gd.
     EVAL_GAME_NOT_READY = "EVAL_GAME_NOT_READY"
+    # #518: the eval genuinely never finished inside the timeout ladder (hung
+    # await caught by the game-side 8s deadline, or no game reply at all by the
+    # editor-side 10s backstop). Carved out of INTERNAL_ERROR so the "eval code
+    # never finished" failure stops reading as an internal fault. Keep in sync
+    # with utils/error_codes.gd.
+    EVAL_HUNG = "EVAL_HUNG"
+    # #518: the eval finished but its serialized result exceeds what the
+    # debugger + WebSocket pipeline can carry (the debugger TCP peer silently
+    # drops messages over ~8 MiB, which previously surfaced as a phantom 10s
+    # "hang"). Keep in sync with utils/error_codes.gd.
+    EVAL_RESULT_TOO_LARGE = "EVAL_RESULT_TOO_LARGE"
     ## audit-v2 #21 (issue #365): finer-grained codes carved out of the
     ## 471 INVALID_PARAMS sites so agents can distinguish recoverable
     ## input errors from structural ones. INVALID_PARAMS stays for

--- a/src/godot_ai/tools/editor.py
+++ b/src/godot_ai/tools/editor.py
@@ -42,10 +42,13 @@ Ops:
         'await' so user code can await internally. Errors return fast and
         actionable: EVAL_COMPILE_ERROR for a syntax/parse error,
         EVAL_RUNTIME_ERROR (with the real message + line) for a runtime
-        error; EVAL_GAME_NOT_READY if the game isn't ready yet — still
-        launching (retry once it's up) or the _mcp_game_helper autoload is
-        missing/disabled; a genuine infinite loop / never-firing await still
-        times out. 'await' only progresses while the game window is focused."""
+        error; EVAL_GAME_NOT_READY if the game can't service evals — still
+        launching (retry once it's up), the _mcp_game_helper autoload is
+        missing/disabled, or the game is parked in a debugger break (stop
+        and relaunch); EVAL_HUNG for a genuine infinite loop / never-firing
+        await; EVAL_RESULT_TOO_LARGE if the returned value serializes past
+        the debugger channel's capacity (return a smaller slice). 'await'
+        only progresses while the game window is focused."""
 
 
 def register_editor_tools(mcp: FastMCP, *, include_non_core: bool = True) -> None:

--- a/test_project/tests/test_game_eval_errors.gd
+++ b/test_project/tests/test_game_eval_errors.gd
@@ -365,4 +365,154 @@ func test_send_eval_without_active_session_replies_game_not_ready() -> void:
 	assert_eq(conn.captured.size(), 1, "exactly one deferred reply is sent")
 	assert_eq(conn.captured[0]["payload"]["error"]["code"], ErrorCodes.EVAL_GAME_NOT_READY,
 		"no active debugger session replies with EVAL_GAME_NOT_READY, not INTERNAL_ERROR")
+
+
+# --- #518: EVAL_HUNG / EVAL_RESULT_TOO_LARGE classification ---
+
+func test_on_eval_error_maps_allowlisted_code() -> void:
+	## The game side attaches a code as mcp:eval_error's optional third payload
+	## element (its 8s deadline sends EVAL_HUNG); the editor maps it through.
+	var plugin := McpDebuggerPlugin.new()
+	var conn := _StubConnection.new()
+	var rid := "rid-eval-hung"
+	plugin._pending[rid] = {"connection": conn}
+	plugin._on_eval_error([rid, "Eval exceeded 8s and was aborted", ErrorCodes.EVAL_HUNG])
+	assert_eq(conn.captured.size(), 1, "one deferred reply")
+	assert_eq(conn.captured[0]["payload"]["error"]["code"], ErrorCodes.EVAL_HUNG,
+		"the game-supplied EVAL_HUNG code is mapped through to the reply")
+	conn.free()
+
+
+func test_on_eval_error_legacy_payload_stays_internal_error() -> void:
+	## A two-element payload (older game helper mid-update) keeps today's
+	## INTERNAL_ERROR fallback — no crash, no behavior change.
+	var plugin := McpDebuggerPlugin.new()
+	var conn := _StubConnection.new()
+	var rid := "rid-eval-legacy"
+	plugin._pending[rid] = {"connection": conn}
+	plugin._on_eval_error([rid, "No code provided"])
+	assert_eq(conn.captured[0]["payload"]["error"]["code"], ErrorCodes.INTERNAL_ERROR,
+		"a code-less eval_error payload falls back to INTERNAL_ERROR")
+	conn.free()
+
+
+func test_on_eval_error_rejects_unknown_code() -> void:
+	## The allowlist keeps a game process from minting arbitrary top-level
+	## codes over the debugger channel.
+	var plugin := McpDebuggerPlugin.new()
+	var conn := _StubConnection.new()
+	var rid := "rid-eval-badcode"
+	plugin._pending[rid] = {"connection": conn}
+	plugin._on_eval_error([rid, "boom", "TOTALLY_MADE_UP"])
+	assert_eq(conn.captured[0]["payload"]["error"]["code"], ErrorCodes.INTERNAL_ERROR,
+		"an unknown code in the eval_error payload falls back to INTERNAL_ERROR")
+	conn.free()
+
+
+## Flip a bare plugin's flags so get_game_status() reports "live", the state
+## the backstop's EVAL_HUNG branch requires.
+func _mark_game_live(plugin: McpDebuggerPlugin) -> void:
+	plugin._game_run_active = true
+	plugin._game_ready = true
+	plugin._ready_run_token = plugin._game_run_token
+
+
+func test_eval_timeout_replies_eval_hung_when_game_live() -> void:
+	## #518: the 10s backstop on a live game replies EVAL_HUNG (the eval code
+	## never finished), not the opaque INTERNAL_ERROR the telemetry bucket
+	## used to hide behind.
+	var plugin := McpDebuggerPlugin.new()
+	_mark_game_live(plugin)
+	var conn := _StubConnection.new()
+	var rid := "rid-timeout-live"
+	plugin._pending[rid] = {"connection": conn, "acked": true, "compiled": true}
+	plugin._on_eval_timeout(rid, 10.0)
+	assert_false(plugin._pending.has(rid), "the timeout clears the pending entry")
+	assert_eq(conn.captured.size(), 1, "one deferred reply")
+	var payload: Dictionary = conn.captured[0]["payload"]
+	assert_eq(payload["error"]["code"], ErrorCodes.EVAL_HUNG,
+		"a live-game eval timeout replies EVAL_HUNG")
+	assert_contains(payload["error"]["message"], "never returned",
+		"the acked+compiled branch says the eval started and never returned")
+	conn.free()
+
+
+func test_eval_timeout_unacked_names_unserviced_eval() -> void:
+	## Never acked = the game's main thread never serviced the eval message —
+	## a different failure than an eval that started and hung, and the message
+	## says so (still EVAL_HUNG so telemetry counts one bucket).
+	var plugin := McpDebuggerPlugin.new()
+	_mark_game_live(plugin)
+	var conn := _StubConnection.new()
+	var rid := "rid-timeout-noack"
+	plugin._pending[rid] = {"connection": conn, "acked": false, "compiled": false}
+	plugin._on_eval_timeout(rid, 10.0)
+	var payload: Dictionary = conn.captured[0]["payload"]
+	assert_eq(payload["error"]["code"], ErrorCodes.EVAL_HUNG,
+		"an unserviced eval still lands in the EVAL_HUNG bucket")
+	assert_contains(payload["error"]["message"], "never picked it up",
+		"the un-acked branch names the unserviced-message failure")
+	conn.free()
+
+
+func test_eval_timeout_replies_not_ready_when_game_in_break() -> void:
+	## #518: a game parked in a debugger break freezes its idle loop, so any
+	## awaiting eval rides to the backstop. The plugin already tracks the break
+	## (#645); the timeout must attribute it instead of claiming the eval hung.
+	var plugin := McpDebuggerPlugin.new()
+	_mark_game_live(plugin)
+	plugin.note_debug_break(false, "Invalid call. Nonexistent function 'foo' in base 'Nil'.")
+	var conn := _StubConnection.new()
+	var rid := "rid-timeout-break"
+	plugin._pending[rid] = {"connection": conn, "acked": true, "compiled": true}
+	plugin._on_eval_timeout(rid, 10.0)
+	var payload: Dictionary = conn.captured[0]["payload"]
+	assert_eq(payload["error"]["code"], ErrorCodes.EVAL_GAME_NOT_READY,
+		"a break-parked game replies EVAL_GAME_NOT_READY, not a phantom hang")
+	assert_contains(payload["error"]["message"], "debugger break",
+		"the break state is named in the message")
+	conn.free()
+
+
+func test_eval_timeout_unknown_request_no_crash() -> void:
+	var plugin := McpDebuggerPlugin.new()
+	plugin._on_eval_timeout("unknown-id", 10.0)
+	assert_true(true, "a timeout for an already-resolved request is a no-op")
+
+
+func test_reply_eval_error_records_code_element() -> void:
+	## Game side: _reply_eval_error appends the optional code as the third
+	## payload element (recorded via the testing seam — EngineDebugger is
+	## inactive in the editor test harness).
+	var helper: Node = GameHelper.new()
+	helper._reply_eval_error("rid-code", "Eval exceeded 8s", ErrorCodes.EVAL_HUNG)
+	assert_eq(helper._last_eval_reply.get("kind"), "error")
+	assert_eq(helper._last_eval_reply.get("code"), ErrorCodes.EVAL_HUNG,
+		"the code rides with the eval_error reply")
+	helper.free()
+
+
+func test_reply_eval_response_normal_value_is_response() -> void:
+	var helper: Node = GameHelper.new()
+	helper._reply_eval_response("rid-normal", 42)
+	assert_eq(helper._last_eval_reply.get("kind"), "response",
+		"a small result replies mcp:eval_response as before")
+	helper.free()
+
+
+func test_reply_eval_response_oversized_sends_too_large_error() -> void:
+	## #518: a result bigger than the debugger channel can carry must fail
+	## fast game-side with EVAL_RESULT_TOO_LARGE — previously the debugger
+	## peer dropped the reply silently and the request rode to the 10s
+	## backstop as a phantom hang.
+	var helper: Node = GameHelper.new()
+	var oversized := "x".repeat(GameHelper.EVAL_RESULT_MAX_BYTES + 1024)
+	helper._reply_eval_response("rid-huge", oversized)
+	assert_eq(helper._last_eval_reply.get("kind"), "error",
+		"an oversized result replies with an error, not a doomed response")
+	assert_eq(helper._last_eval_reply.get("code"), ErrorCodes.EVAL_RESULT_TOO_LARGE,
+		"the oversized result carries EVAL_RESULT_TOO_LARGE")
+	assert_contains(str(helper._last_eval_reply.get("message")), "too large",
+		"the message names the failure and the byte count")
+	helper.free()
 	conn.free()

--- a/test_project/tests/test_game_eval_errors.gd
+++ b/test_project/tests/test_game_eval_errors.gd
@@ -515,4 +515,3 @@ func test_reply_eval_response_oversized_sends_too_large_error() -> void:
 	assert_contains(str(helper._last_eval_reply.get("message")), "too large",
 		"the message names the failure and the byte count")
 	helper.free()
-	conn.free()

--- a/tests/unit/test_game_eval.py
+++ b/tests/unit/test_game_eval.py
@@ -74,6 +74,12 @@ def test_eval_error_codes_exist():
     # #518: the play-session-up-but-capture-not-ready race, carved out of
     # INTERNAL_ERROR so it stops being counted as a genuine eval hang.
     assert ErrorCode.EVAL_GAME_NOT_READY == "EVAL_GAME_NOT_READY"
+    # #518: the eval code itself never finished (hung await / infinite loop),
+    # aborted by the game's 8s deadline or the editor's 10s backstop.
+    assert ErrorCode.EVAL_HUNG == "EVAL_HUNG"
+    # #518: the eval finished but its serialized result exceeds what the
+    # debugger channel can deliver; failed fast instead of a phantom hang.
+    assert ErrorCode.EVAL_RESULT_TOO_LARGE == "EVAL_RESULT_TOO_LARGE"
 
 
 class _RaisingGameEvalClient:
@@ -101,6 +107,30 @@ async def test_game_eval_propagates_compile_error_code():
     with pytest.raises(GodotCommandError) as exc:
         await editor_handlers.game_eval(runtime, code="return 1 +")
     assert exc.value.code == ErrorCode.EVAL_COMPILE_ERROR
+
+
+@pytest.mark.asyncio
+async def test_game_eval_propagates_hung_error_code():
+    client = _RaisingGameEvalClient(
+        ErrorCode.EVAL_HUNG,
+        "Eval exceeded 8s and was aborted — the code likely awaits something that never completes",
+    )
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    with pytest.raises(GodotCommandError) as exc:
+        await editor_handlers.game_eval(runtime, code="await get_tree().create_timer(999).timeout")
+    assert exc.value.code == ErrorCode.EVAL_HUNG
+
+
+@pytest.mark.asyncio
+async def test_game_eval_propagates_result_too_large_code():
+    client = _RaisingGameEvalClient(
+        ErrorCode.EVAL_RESULT_TOO_LARGE,
+        "Eval result too large to return (10000213 bytes serialized, limit 6291456).",
+    )
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    with pytest.raises(GodotCommandError) as exc:
+        await editor_handlers.game_eval(runtime, code="return 'x'.repeat(10_000_000)")
+    assert exc.value.code == ErrorCode.EVAL_RESULT_TOO_LARGE
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Diagnosis-first session for #518 — root cause confirmed live, fix included

## TL;DR

The "regression" arithmetic in #518 was already explained and half-fixed by #519 (`EVAL_GAME_NOT_READY`, shipped 2.6.1). **The other half — the residual "true hang" bucket that still rides as code-less `INTERNAL_ERROR` — reproduces on current main and decomposes into three distinct failure modes, all reproduced live this session.** This PR classifies them following the #491/#519 playbook: `EVAL_HUNG`, `EVAL_RESULT_TOO_LARGE`, and break-aware attribution into the existing `EVAL_GAME_NOT_READY`.

## Archaeology: the 2.5.10 → 2.6.0 window (STEP 1)

`git log v2.5.10..v2.6.0` over the eval path (`game_helper.gd`, `editor_handler.gd`, `mcp_debugger_plugin.gd`, `dispatcher.gd`, `handlers/editor.py`, `tools/editor.py`, `protocol/errors.py`) yields exactly **two** commits:

| commit | PR | eval-path relevance | verdict |
|---|---|---|---|
| `deb0643` | #494 audit fixes | `mcp_debugger_plugin.gd`: pure param rename `_session_id`→`session_id` (cosmetic) | **killed** |
| `c728323` | #503 | capped eval readiness wait 20s→3s; converted #500's ~15s `TimeoutError`s into fast `_explain_not_live` envelopes **defaulting to `INTERNAL_ERROR`** | **confirmed** — the 2.6.0 jump |

The 2.5.10→2.5.13 step contains **no eval-path behavior change at all** (v2.5.11..v2.5.13 is one Discord-webhook commit; #495 orphan reaper and #496 ring-buffer echo are non-eval) — consistent with #519's cohort-artifact conclusion (2.5.10 baseline = 9 installs / 1,546 calls). The #488 deadline + temp_node cleanup machinery was never weakened: verified live (8s guard fires at 8.26s; a 7.5s boundary await succeeds).

## Candidate emitting sites for a code-less envelope (kill/confirm)

| site | status | evidence |
|---|---|---|
| `_wait_then_eval` not-ready expiry | **fixed by #519** → `EVAL_GAME_NOT_READY` (~3s), confirmed live | E2 |
| `_on_eval_error` (maps every game-side `mcp:eval_error` → `INTERNAL_ERROR`, incl. the #488 8s deadline) | **confirmed, fixed here** → `EVAL_HUNG` | F4 |
| `_send_eval` 10s editor backstop | **confirmed, fixed here** → attributed (`EVAL_HUNG` / `EVAL_GAME_NOT_READY`) | E6, F7, F9b, G4 |
| debugger TCP peer silently dropping >8 MiB replies → rides to backstop | **confirmed, fixed here** → game-side size check, `EVAL_RESULT_TOO_LARGE` | G1 |
| editor→server WS outbound buffer (4 MiB cap) | confirmed but **out of scope** — cross-cutting connection layer, already has message+`data` | H1 |
| server-side 15s `send_command` timeout | killed — emits `TimeoutError`, its own bucket (quiet since #503) | — |
| dispatcher 15s deferred budget | killed — emits `DEFERRED_TIMEOUT`, its own code | — |
| game-process crash/quit mid-request | killed as a *distinct* site — resolves through the backstop, now attributed via `get_game_status()` | G3b |

## Live experiments (STEP 2; Linux, Godot 4.6.2, xvfb, current main incl. #667)

| # | experiment | envelope observed (before this PR) | after this PR |
|---|---|---|---|
| E1 | eval, no game running | `EDITOR_NOT_READY` 0.01s ✅ | unchanged |
| E2 | eval immediately after `project_run` | success 0.37s (helper won the race) ✅ | unchanged |
| E3 | baseline `return 1+1` on live game | success 0.37s ✅ | unchanged |
| E4 | compile error | `EVAL_COMPILE_ERROR` 3.06s ✅ | unchanged |
| E5/F8 | runtime error | `EVAL_RUNTIME_ERROR` 0.57s ✅ — **but parks the game in a debugger break** (`game_status.status="break"`, frame counter frozen) | unchanged (see F9b) |
| F4 | hung await, live game | **`INTERNAL_ERROR`** 8.26s (game 8s guard, good message, wrong code) | `EVAL_HUNG` |
| F5 | 7.5s boundary await, live game | success 7.77s ✅ (#488 machinery sound) | unchanged |
| F9b | awaiting eval after the game was break-parked by F8 | **`INTERNAL_ERROR`** 10.01s, misleading "infinite loop" message | `EVAL_GAME_NOT_READY` + break reason + stop/relaunch hint |
| G4 | CPU-bound `while true` | **`INTERNAL_ERROR`** 10.12s | `EVAL_HUNG` (stage-attributed message) |
| G1/H1 | result 5–8 MB | fast `INTERNAL_ERROR` (WS buffer cap message, ~0.8s) | unchanged (out of scope) |
| G1/F7 | result >8.4 MB | **`INTERNAL_ERROR`** 10.01s — reply silently dropped by the debugger peer (8.0 MB delivered, 8.4 MB vanished) | `EVAL_RESULT_TOO_LARGE`, fast, with byte count |
| E13 | 3 concurrent evals | all succeed 0.07s ✅ | unchanged |
| G3/G3b | eval quits game → next eval | `EDITOR_NOT_READY` fast ✅ | unchanged |

**The F8→F9b chain is the important discovery**: one runtime-error eval freezes the game's idle loop for the rest of the run (debugger break), so sync evals still work (deceptive) while *every* awaiting eval fails as a phantom 10s "hang". In an agent loop — error once, then retry variations — this is a self-sustaining `INTERNAL_ERROR` generator, and matches the issue's long-tail install distribution. The plugin's own #645 break tracking already knows the state; the eval path just never consulted it.

**Windows note (6.66% vs 4.05–5.42%)**: not reproducible under xvfb, but the #491-documented backgrounded-game idle-loop freeze means any awaiting eval reads as a hang while the game window is occluded — and agent-driven flows keep the game backgrounded by default, with Windows the most aggressive about throttling occluded windows. Code-audit-plausible site for the platform skew; a Windows session can verify by focusing/occluding the game window around an awaiting eval.

## The change

- **`EVAL_HUNG`** — game-side 8s deadline attaches it as an optional third `mcp:eval_error` payload element; the editor allowlists it (older two-element payloads keep the `INTERNAL_ERROR` fallback, so mid-update version skew is safe). The 10s backstop (extracted into `_on_eval_timeout`) also emits it when the game is live, with the message attributed by ack/compile stage (never-serviced vs started-and-never-returned).
- **Break/stopped attribution** — `_on_eval_timeout` consults `get_game_status()`; a non-live game replies `EVAL_GAME_NOT_READY` via the existing `_explain_not_live` payload (break reason, stop/relaunch hint) — the same family the pre-hello break path already uses, and mirrors what the screenshot `_on_timeout` already did.
- **`EVAL_RESULT_TOO_LARGE`** — game-side serialized-size check (6 MiB cap, under the ~8 MiB debugger-peer drop threshold) replies fast with the real byte count instead of a silent drop. Results in the 4–6 MiB band still fail at the WS layer with its existing explicit message (unchanged).
- Codes added to `protocol/errors.py` + `utils/error_codes.gd` in sync (existing parity test covers them); docstrings updated.

**No timing machinery touched** — the 8s < 10s < 15s ladder is unchanged; this classifies, it does not re-tune.

## Telemetry follow-up (proposed, deliberately not built)

After this ships, `INTERNAL_ERROR` on game_eval should approach zero and mean "genuinely unknown fault". For stage-level self-diagnosis (#667's playbook), the natural extension is allowlisting an eval-family `error_sub_code` (e.g. `EVAL_STAGE_NEVER_ACKED` / `EVAL_STAGE_STARTED` on `EVAL_HUNG`, break vs boot-race on `EVAL_GAME_NOT_READY`) using the `error_sub_code` field #667 just added — a separate, small PR if the post-ship window shows the split is worth it.

## Verification status

- ✅ `ruff check src/ tests/` clean
- ✅ Targeted Python units green: `test_game_eval.py`, `test_error_code_parity.py`, `test_error_code_distribution.py`, `test_editor_not_ready_hint_contract.py` (17 passed) — includes the #667 contract tests against my registry additions
- ✅ Rebased onto main *after* #667 merged; overlap is additive-only (two registry files; my behavior changes are in `mcp_debugger_plugin.gd`/`game_helper.gd`, which #667 doesn't touch)
- ⏳ Full Python + GDScript suites and the live end-to-end re-run of the new codes: deferring to CI (session was asked to wrap up before the full local runs)
- New GDScript tests: `_on_eval_error` code mapping (allowlisted / legacy / unknown), `_on_eval_timeout` live-vs-break-vs-unacked branches, game-side reply seam (code element, normal response, oversized result)

Refs #518 (and the residual-hang half left open by #519).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016J1zYMokbvK25Lu2mWZ6VG

---
_Generated by [Claude Code](https://claude.ai/code/session_016J1zYMokbvK25Lu2mWZ6VG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `game_eval` timeout reporting with clearer distinctions for “not ready,” “hung,” and “unresponsive” states.
  * Added new actionable error codes for hung evaluations and for results too large to transmit.
  * Prevented oversized evaluation responses from being silently dropped.
  * Kept safe fallback behavior for unknown or unsupported game-provided error codes.
* **Documentation**
  * Clarified timeout conditions, retry guidance, and focus-related expectations.
* **Tests**
  * Added coverage for timeout classification, error-code propagation, oversized results handling, and debugger-break scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->