### PR TITLE
Register lavapipe ICD via HKLM + preserve capture-smoke evidence on failure (#675)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,13 +392,21 @@ jobs:
       ## Godot 4.7 on the headless Windows runner fails with
       ## "Required Vulkan instance extension VK_KHR_surface not found"
       ## because the runner has no GPU/Vulkan driver. Install Mesa's
-      ## lavapipe software Vulkan ICD from mesa-dist-win and point the
-      ## Vulkan loader at it (VK_DRIVER_FILES; VK_ICD_FILENAMES kept for
-      ## older loaders). Release is pinned for reproducibility. Every
-      ## setup failure exits non-zero — no silent fallback to the broken
-      ## no-ICD state. NOTE (#586): this can only be truly verified by a
-      ## Windows CI run; if 4.7 capture still fails there, suspect the
-      ## surface/swapchain path rather than the ICD install itself.
+      ## lavapipe software Vulkan ICD from mesa-dist-win. Release is
+      ## pinned for reproducibility. Every setup failure exits non-zero —
+      ## no silent fallback to the broken no-ICD state.
+      ##
+      ## Registration is via the HKLM registry, not just env vars (#675):
+      ## the Vulkan loader silently discards VK_DRIVER_FILES /
+      ## VK_ICD_FILENAMES in elevated processes, and GitHub's Windows
+      ## runner executes jobs elevated — job logs from #675 show both a
+      ## passing and a failing run hitting the VK_KHR_surface error and
+      ## falling back to the D3D12 Microsoft Basic Render Driver with the
+      ## env vars set correctly. HKLM\SOFTWARE\Khronos\Vulkan\Drivers is
+      ## the loader's system-wide discovery path and is honored regardless
+      ## of integrity level. The env vars are kept as a belt-and-braces
+      ## for any non-elevated child. The "Report rendering driver" step
+      ## below surfaces which driver actually engaged on every run.
       - name: Install software Vulkan driver (Mesa lavapipe)
         if: matrix.os == 'windows-latest'
         shell: pwsh
@@ -416,9 +424,12 @@ jobs:
           $dll = Join-Path $dest "x64\vulkan_lvp.dll"
           if (-not (Test-Path $icd)) { throw "lavapipe ICD manifest not found: $icd" }
           if (-not (Test-Path $dll)) { throw "lavapipe driver DLL not found: $dll" }
+          $reg = "HKLM:\SOFTWARE\Khronos\Vulkan\Drivers"
+          New-Item -Path $reg -Force | Out-Null
+          New-ItemProperty -Path $reg -Name $icd -Value 0 -PropertyType DWord -Force | Out-Null
           "VK_DRIVER_FILES=$icd" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           "VK_ICD_FILENAMES=$icd" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-          Write-Host "Installed lavapipe ICD: $icd"
+          Write-Host "Installed lavapipe ICD: $icd (registered in $reg)"
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
@@ -441,17 +452,50 @@ jobs:
           godot --headless --path test_project --import > godot-import.log 2>&1 || true
           bash script/ci-check-gdscript godot-import.log
 
+      ## Editor output goes to godot-editor.log (mirroring the godot-tests
+      ## jobs) so a failed run keeps the boot/driver evidence — before #675
+      ## the smoke job's editor output was only interleaved into whichever
+      ## step happened to be running, and a stalled run left no artifact.
       - name: Start Godot editor (Linux / xvfb)
         if: matrix.os == 'ubuntu-latest'
         shell: bash
         run: |
           xvfb-run -a --server-args="-screen 0 1280x720x24" \
-            godot --rendering-driver opengl3 --path test_project --editor &
+            godot --rendering-driver opengl3 --path test_project --editor \
+            > godot-editor.log 2>&1 &
 
       - name: Start Godot editor (windowed)
         if: matrix.os != 'ubuntu-latest'
         shell: bash
-        run: godot --path test_project --editor &
+        run: godot --path test_project --editor > godot-editor.log 2>&1 &
+
+      ## Surface which rendering driver actually engaged, pass or fail.
+      ## On Windows this is the canary for the #661 lavapipe path: if the
+      ## editor fell back to the D3D12 Microsoft Basic Render Driver the
+      ## software path is in play (slow enough to flake — #675), so warn
+      ## loudly. A warning rather than a failure: the smoke has passed on
+      ## the fallback driver, so don't turn a working (if fragile) run
+      ## into a hard outage. Promote to a hard check once lavapipe is
+      ## confirmed engaging on the runner.
+      - name: Report rendering driver
+        shell: bash
+        run: |
+          pattern='Vulkan [0-9]|D3D12 |Metal [0-9]|OpenGL API'
+          for _ in $(seq 1 60); do
+            if grep -qE "$pattern" godot-editor.log 2>/dev/null; then
+              break
+            fi
+            sleep 1
+          done
+          driver_line=$(grep -m1 -E "$pattern" godot-editor.log 2>/dev/null || true)
+          if [ -z "$driver_line" ]; then
+            echo "::warning title=No rendering driver detected::godot-editor.log has no driver line after 60s — editor may not have booted"
+            exit 0
+          fi
+          echo "Rendering driver: $driver_line"
+          if echo "$driver_line" | grep -q "Microsoft Basic Render Driver"; then
+            echo "::warning title=lavapipe did not engage::Editor fell back to the D3D12 Microsoft Basic Render Driver (#675) — the Mesa lavapipe ICD was not picked up, and the software D3D12 path is slow enough to flake"
+          fi
 
       - name: Run capture smoke test
         ## Covers the worst case of the script's internal ceilings: 120s
@@ -464,10 +508,21 @@ jobs:
           PYTHONUNBUFFERED: "1"
         run: python script/ci-game-capture-smoke
 
+      - name: Dump Godot editor log on failure
+        if: failure()
+        shell: bash
+        run: |
+          echo "===== godot-editor.log (last 500 lines) ====="
+          tail -n 500 godot-editor.log || echo "(log not found)"
+          echo "===== godot-import.log (last 200 lines) ====="
+          tail -n 200 godot-import.log || echo "(log not found)"
+
       - name: Upload capture diagnostics
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: capture-smoke-diag-${{ matrix.label }}
-          path: capture-smoke-diag/
+          path: |
+            capture-smoke-diag/
+            godot-editor.log
           if-no-files-found: ignore

--- a/script/ci-game-capture-smoke
+++ b/script/ci-game-capture-smoke
@@ -44,6 +44,7 @@ import json
 import os
 import sys
 import time
+import traceback
 import urllib.error
 import urllib.request
 
@@ -77,6 +78,12 @@ CAPTURE_RETRY_DELAY_SEC = 2.0
 ## Where the final-failure artifacts (last PNG + attempt log) land; CI
 ## uploads this directory when the job fails.
 DIAG_DIR = os.environ.get("CAPTURE_DIAG_DIR", "capture-smoke-diag")
+## How long the editor's WS session may stay unreachable mid-wait before
+## the ready-poll gives up. The plugin auto-reconnects after transient
+## drops, so a brief outage is tolerated; a persistent one means the
+## editor bridge is gone and the remaining minutes of ready-wait can only
+## end in a misleading "never registered" timeout (#675).
+SESSION_LOSS_GRACE_SEC = 45.0
 
 
 def _post(session_id: str | None, body: dict, timeout: float = 10.0) -> dict:
@@ -174,7 +181,9 @@ def _wait_for_godot_session(session_id: str, timeout: float = 120.0) -> None:
 ## over a minute to boot far enough to register its capture on a
 ## paravirtualized runner. The poll exits the moment it's ready, so the
 ## ceiling only costs time when something is genuinely wrong.
-def _wait_for_game_capture_ready(session_id: str, timeout: float = 180.0) -> None:
+def _wait_for_game_capture_ready(
+    session_id: str, timeout: float = 180.0, history: list[str] | None = None
+) -> None:
     ## is_playing flips when the editor *spawns* the game subprocess; it does
     ## NOT imply the game's _mcp_game_helper autoload has reached _ready() and
     ## registered its EngineDebugger "mcp" capture. Sending take_screenshot
@@ -185,14 +194,66 @@ def _wait_for_game_capture_ready(session_id: str, timeout: float = 180.0) -> Non
     ## game_capture_ready is the editor-side mirror of the game-side
     ## "mcp:hello" boot beacon — it flips true exactly when the capture
     ## handler is wired up, so polling it is the deterministic replacement.
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        state = _tool_call(session_id, "editor_state", {}, 100)
-        if state.get("is_playing") and state.get("game_capture_ready"):
-            print(f"Game capture ready (readiness={state.get('readiness')})")
+    ##
+    ## Each observed state change is printed and appended to `history` so a
+    ## failed wait leaves a timeline in the diag artifacts (#675: this path
+    ## used to raise with zero evidence of what the editor reported). A
+    ## persistently unreachable session fails fast with an honest message
+    ## instead of burning the rest of the timeout — in the #675 run the
+    ## editor's WS session dropped mid-wait and the "never registered"
+    ## timeout pointed away from the real problem.
+    start = time.monotonic()
+    deadline = start + timeout
+    lost_since: float | None = None
+    last_note = ""
+    last_logged_at = start
+
+    def _note(note: str) -> None:
+        nonlocal last_note, last_logged_at
+        now = time.monotonic()
+        if note == last_note and now - last_logged_at < 30.0:
             return
+        line = f"[ready-wait +{now - start:.1f}s] {note}"
+        print(line)
+        if history is not None:
+            history.append(line)
+        last_note = note
+        last_logged_at = now
+
+    while time.monotonic() < deadline:
+        try:
+            state = _tool_call(session_id, "editor_state", {}, 100)
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            state = {"error": {"code": "TRANSPORT_ERROR", "message": str(exc)}}
+        err = state.get("error")
+        if err:
+            code = err.get("code", "?") if isinstance(err, dict) else str(err)
+            now = time.monotonic()
+            if lost_since is None:
+                lost_since = now
+            _note(f"editor_state failing: {code}")
+            if now - lost_since > SESSION_LOSS_GRACE_SEC:
+                raise RuntimeError(
+                    "Editor session lost while waiting for game capture: "
+                    f"editor_state has failed with {code} for "
+                    f"{now - lost_since:.0f}s straight — the editor<->server "
+                    "bridge dropped, not a slow game boot"
+                )
+        else:
+            lost_since = None
+            if state.get("is_playing") and state.get("game_capture_ready"):
+                print(f"Game capture ready (readiness={state.get('readiness')})")
+                return
+            _note(
+                f"is_playing={state.get('is_playing')} "
+                f"game_capture_ready={state.get('game_capture_ready')} "
+                f"readiness={state.get('readiness')}"
+            )
         time.sleep(0.5)
-    raise RuntimeError("Game subprocess never registered its mcp capture")
+    raise RuntimeError(
+        "Game subprocess never registered its mcp capture within "
+        f"{timeout:.0f}s (last observed: {last_note or 'nothing'})"
+    )
 
 
 def _within_tolerance(a: tuple[int, int, int], b: tuple[int, int, int]) -> bool:
@@ -353,14 +414,14 @@ def main() -> int:
     print("Running project (current scene)")
     _tool_call(session_id, "project_run", {"mode": "current"}, 11, timeout=20)
 
+    attempt_log: list[str] = []
+    last_png: bytes | None = None
     try:
-        _wait_for_game_capture_ready(session_id)
+        _wait_for_game_capture_ready(session_id, history=attempt_log)
 
         deadline = time.monotonic() + CAPTURE_BUDGET_SEC
         attempt = 0
-        attempt_log: list[str] = []
         last_failures: list[str] = []
-        last_png: bytes | None = None
         while True:
             attempt += 1
             print(f"Capturing source='game' (attempt {attempt})")
@@ -397,6 +458,12 @@ def main() -> int:
     except Exception:
         print("\nCapture smoke test raised — dumping diagnostics:", file=sys.stderr)
         _dump_diagnostics(session_id)
+        ## This path used to exit without touching DIAG_DIR, so a
+        ## ready-wait failure uploaded no artifacts at all (#675). Write
+        ## whatever timeline exists plus the traceback.
+        attempt_log.append("")
+        attempt_log.append(traceback.format_exc().rstrip())
+        _write_diag_artifacts(attempt_log, last_png)
         raise
     finally:
         try:


### PR DESCRIPTION
## What this is

Investigation + fix for the `Game capture smoke / Windows` flake in #675.

## Root-cause finding

Comparing the editor boot logs of the **passing** run ([29161439511](https://github.com/hi-godot/godot-ai/actions/runs/29161439511), job 86567084579) and the **failing** run ([job 86567971866](https://github.com/hi-godot/godot-ai/actions/runs/29161779868/job/86567971866)) answers the issue's first investigation avenue: **both runs show the identical failure signature** —

```
ERROR: Required Vulkan instance extension VK_KHR_surface not found.
D3D12 12_0 - Forward+ - Using Device #0: Microsoft - Microsoft Basic Render Driver
WARNING: Your video card drivers seem not to support Vulkan, switching to Direct3D 12.
```

So the #661 lavapipe path **never engages** — it isn't intermittent. The Vulkan loader silently discards `VK_DRIVER_FILES` / `VK_ICD_FILENAMES` in elevated processes, and GitHub's Windows runner executes jobs elevated (`runneradmin`). The smoke has been running on the D3D12 **Microsoft Basic Render Driver** software fallback the whole time — passing slowly (the "pass" took 53s for the game to register its capture and another 43s for the first capture round-trip) and occasionally stalling past the 180s ready-wait, during which the editor's WS session also drops. That's the flake.

## Changes

**`.github/workflows/ci.yml`** (game-capture-smoke job):
- Register the lavapipe ICD under `HKLM\SOFTWARE\Khronos\Vulkan\Drivers` — the loader's system-wide discovery path, honored regardless of process integrity level (this is also what mesa-dist-win's own deploy script does). Env vars kept as belt-and-braces for non-elevated children.
- New **Report rendering driver** step: waits for the editor's driver line and prints it on every run; emits a workflow warning when the editor fell back to the Basic Render Driver. Warning rather than failure since the smoke demonstrably can pass on the fallback — promote to a hard check once lavapipe is confirmed engaging.
- The editor now logs to `godot-editor.log`, dumped on failure (mirroring the godot-tests jobs) and included in the `capture-smoke-diag` artifact — a failed run no longer destroys the boot/driver evidence.

**`script/ci-game-capture-smoke`**:
- `_wait_for_game_capture_ready` now records a state timeline (printed live + kept for the diag artifacts), tolerates transient transport errors instead of crashing the wait, and **fails fast with an honest message** when `editor_state` stays unreachable past a 45s grace window — in the #675 run the session dropped mid-wait and the eventual "Game subprocess never registered its mcp capture" pointed away from the real problem.
- The exception path now writes the diag artifacts (timeline + traceback). Previously the `_wait_for_game_capture_ready` raise exited before any diag file landed, so `capture-smoke-diag/` was empty and the artifact upload found nothing.

## Testing

- `pytest tests/unit` — 983 passed, 2 skipped.
- `ruff check` clean on the smoke script; workflow YAML validated.
- The new ready-wait logic was exercised in a harness with a mocked `_tool_call` across four paths: normal success, persistent `PLUGIN_DISCONNECTED` (fast-fails at the grace window with the session-loss message), plain timeout (message now includes the last observed state), and transient transport errors followed by recovery.
- The registry-registration path itself can only be truly verified by this PR's own Windows CI round — the "Report rendering driver" step will show whether lavapipe engages.

Closes #675 (refs #661, #620, #586)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABBBYLuqvDSf7f8mLyBmu9

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABBBYLuqvDSf7f8mLyBmu9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of game capture smoke tests during temporary editor or connection interruptions.
  - Improved Windows Vulkan rendering setup to ensure the intended graphics driver is detected.

- **Diagnostics**
  - Added clearer rendering-driver status reporting and warnings for unexpected fallback drivers.
  - Expanded failure diagnostics with editor logs, readiness timelines, and detailed error traces.
  - Ensured diagnostic artifacts are retained even when failures occur early in testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->