### PR TITLE
Raise the capture smoke's project_run reply timeout to 60s (#673)

### DIFF
--- a/script/ci-game-capture-smoke
+++ b/script/ci-game-capture-smoke
@@ -411,12 +411,18 @@ def main() -> int:
     _tool_call(session_id, "scene_open", {"path": SCENE_PATH}, 10)
     time.sleep(1)
 
-    print("Running project (current scene)")
-    _tool_call(session_id, "project_run", {"mode": "current"}, 11, timeout=20)
-
     attempt_log: list[str] = []
     last_png: bytes | None = None
     try:
+        print("Running project (current scene)")
+        ## 60s, not 20 (#673): the reply waits on the editor spawning a
+        ## whole game process under a software rasterizer, and a busy
+        ## runner has blown a 20s socket margin. The ready-poll below
+        ## exits the moment the game is up, so the higher ceiling costs
+        ## nothing on healthy runs. Inside the try so a timeout here
+        ## still dumps diagnostics and writes the diag artifacts.
+        _tool_call(session_id, "project_run", {"mode": "current"}, 11, timeout=60)
+
         _wait_for_game_capture_ready(session_id, history=attempt_log)
 
         deadline = time.monotonic() + CAPTURE_BUDGET_SEC


### PR DESCRIPTION
## What this is

The one-line hardening #673 asked for, plus a small evidence-preservation tweak, following up on #676.

## Context

#673 caught the smoke script dying in its own HTTP client at the `project_run` call's hardcoded 20s socket timeout, with the editor healthy. The #675/#676 investigation showed the run that flaked was actually on the D3D12 Microsoft Basic Render Driver fallback (lavapipe had never engaged), which #676 fixed — post-merge, the play path is roughly 3× faster, so the 20s margin is under far less pressure. But it's still a hardcoded ceiling on a shared runner, so this applies the bump anyway as cheap insurance.

## Changes

- `script/ci-game-capture-smoke`: `project_run` reply timeout 20s → 60s. The `_wait_for_game_capture_ready` poll right after exits the moment the game is up, so healthy runs pay nothing for the higher ceiling.
- Moved the `project_run` call inside the try block so a timeout there now dumps diagnostics and writes the `capture-smoke-diag/` artifacts (timeline + traceback) like every later failure — previously it crashed out ahead of the diagnostics scope with a bare traceback and an empty artifact upload.

## Testing

- `ruff check` clean; script compiles.
- Behavior-wise this only widens a timeout and relocates a call within `main()`; the `finally` cleanup (`project_manage op=stop`) was already tolerant of the project never having started.

Closes #673 (refs #676, #661)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABBBYLuqvDSf7f8mLyBmu9

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABBBYLuqvDSf7f8mLyBmu9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved game capture smoke test reliability by allowing more time for the current scene to start.
  * Ensured startup failures produce diagnostic information and CI artifacts for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->