### PR TITLE
Dock: scroll the 'Run this manually' panel into view when it appears

### DIFF
--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -2456,6 +2456,20 @@ func _show_manual_command_for(client_id: String) -> void:
 		return
 	row["manual_text"].text = cmd
 	row["manual_panel"].visible = true
+	## #680: for rows low in the list the panel materializes below the
+	## visible scroll area and the Configure click looks like a no-op.
+	## Deferred so the just-shown panel has a settled rect to scroll to.
+	_scroll_manual_panel_into_view.call_deferred(row["manual_panel"])
+
+
+func _scroll_manual_panel_into_view(panel: Control) -> void:
+	if panel == null or not panel.is_inside_tree():
+		return
+	var ancestor := panel.get_parent()
+	while ancestor != null and not (ancestor is ScrollContainer):
+		ancestor = ancestor.get_parent()
+	if ancestor != null:
+		(ancestor as ScrollContainer).ensure_control_visible(panel)
 
 
 func _on_copy_manual_command(client_id: String) -> void:


### PR DESCRIPTION
Fixes #680.

Found during the 2026-07-11 live verification: clicking Configure on a not-detected client low in the Clients & Tools list (e.g. Kimi Code) correctly failed and expanded the 'Run this manually:' panel — but below the fold, so the click read as a no-op.

Fix: after `_show_manual_command_for` makes the panel visible, a deferred `ensure_control_visible` on the enclosing ScrollContainer (walked up from the panel, so it keeps working if the container nesting changes) scrolls it into view. Deferred one frame so the just-shown panel has a settled rect.

Verification: UI-only change; verified live by reloading the plugin in the affected editor and re-triggering a failed Configure on the bottom-most row — panel scrolls into view. CI's `ci-check-gdscript` covers the parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Manual configuration panels now automatically scroll into view when opened, making previously hidden configuration options accessible.
  * Fixed cases where selecting **Configure** appeared unresponsive when the panel was below the visible area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->