### PR TITLE
Issue sweep: CI hardening, mandatory update verification, typed Array[T] writes, non-blocking startup probes

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -24,9 +24,14 @@ fi
 
 cd "$CLAUDE_PROJECT_DIR"
 
-GODOT_VERSION="4.6.2"
+# Keep in step with ci.yml (godot-version: "4.7.0" — the chickensoft action
+# wants 3-part semver; the Godot release tag/asset uses the 2-part form) and
+# test_project/project.godot (config/features "4.7"). See #672.
+GODOT_VERSION="4.7"
 GODOT_CACHE="$HOME/.cache/godot-ai"
-GODOT_BIN="$GODOT_CACHE/godot"
+# Version-keyed binary path: bumping GODOT_VERSION invalidates the cache, so
+# warm containers can't keep serving a stale engine after a version bump.
+GODOT_BIN="$GODOT_CACHE/godot-${GODOT_VERSION}"
 GODOT_ZIP="Godot_v${GODOT_VERSION}-stable_linux.x86_64.zip"
 GODOT_EXE="Godot_v${GODOT_VERSION}-stable_linux.x86_64"
 GODOT_URL="https://github.com/godotengine/godot/releases/download/${GODOT_VERSION}-stable/${GODOT_ZIP}"
@@ -37,7 +42,17 @@ script/setup-dev
 if [ ! -x "$GODOT_BIN" ]; then
   echo "[godot-ai session-start] downloading Godot ${GODOT_VERSION}..."
   mkdir -p "$GODOT_CACHE"
-  curl -fsSL -o "$GODOT_CACHE/godot.zip" "$GODOT_URL"
+  if ! curl -fsSL -o "$GODOT_CACHE/godot.zip" "$GODOT_URL"; then
+    cat >&2 <<EOF
+[godot-ai session-start] ERROR: could not download Godot ${GODOT_VERSION} from
+  $GODOT_URL
+If this is a 403, the session's environment network policy is blocking
+github.com/godotengine release downloads (out-of-scope repo). Allow that
+domain/repo in the environment's network policy, or pre-seed the binary at
+$GODOT_BIN. Godot-dependent MCP tools will be unavailable this session.
+EOF
+    exit 1
+  fi
   unzip -q -o "$GODOT_CACHE/godot.zip" -d "$GODOT_CACHE"
   mv "$GODOT_CACHE/${GODOT_EXE}" "$GODOT_BIN"
   chmod +x "$GODOT_BIN"
@@ -45,6 +60,11 @@ if [ ! -x "$GODOT_BIN" ]; then
 else
   echo "[godot-ai session-start] reusing cached Godot at $GODOT_BIN"
 fi
+
+# Drop superseded cache entries: the pre-#672 unversioned path and any
+# godot-<other-version> binaries left behind by earlier pins.
+find "$GODOT_CACHE" -maxdepth 1 -type f \( -name 'godot' -o -name 'godot-*' \) \
+  ! -name "godot-${GODOT_VERSION}" -delete 2>/dev/null || true
 
 mkdir -p "$HOME/.local/bin"
 ln -sf "$GODOT_BIN" "$HOME/.local/bin/godot"

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -84,7 +84,11 @@ if curl -sf -o /dev/null -X POST \
   echo "[godot-ai session-start] MCP server already running on :8000"
 else
   echo "[godot-ai session-start] launching headless Godot editor (plugin auto-spawns MCP server on :8000)..."
-  nohup "$GODOT_BIN" --headless --path test_project --editor \
+  # GODOT_AI_ALLOW_HEADLESS=1 is required: without it the plugin disables
+  # itself in --headless launches (plugin.gd::_mcp_disabled_for_headless)
+  # and the promised MCP server never spawns. A web session driving MCP
+  # tools is exactly the intentional-headless case AGENTS.md carves out.
+  nohup env GODOT_AI_ALLOW_HEADLESS=1 "$GODOT_BIN" --headless --path test_project --editor \
     > /tmp/godot-editor.log 2>&1 &
   disown
 fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -61,9 +61,10 @@ else
   echo "[godot-ai session-start] reusing cached Godot at $GODOT_BIN"
 fi
 
-# Drop superseded cache entries: the pre-#672 unversioned path and any
-# godot-<other-version> binaries left behind by earlier pins.
-find "$GODOT_CACHE" -maxdepth 1 -type f \( -name 'godot' -o -name 'godot-*' \) \
+# Drop superseded cache entries: the pre-#672 unversioned path, any
+# godot-<other-version> binaries left behind by earlier pins, and a
+# leftover godot.zip from an interrupted download.
+find "$GODOT_CACHE" -maxdepth 1 -type f \( -name 'godot' -o -name 'godot-*' -o -name 'godot.zip' \) \
   ! -name "godot-${GODOT_VERSION}" -delete 2>/dev/null || true
 
 mkdir -p "$HOME/.local/bin"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,6 +186,7 @@ Or in cmd: `mklink /J test_project\addons\godot_ai ..\..\plugin\addons\godot_ai`
 The plugin manages the server process:
 - On startup, plugin checks if port 8000 is already in use. If yes, uses existing server. If no, spawns `.venv/bin/python -m godot_ai --transport streamable-http --port 8000`.
 - The plugin prefers the local `.venv` over system-installed `godot-ai` so dev checkouts always use source code.
+- **Adoption transfers end-of-life, not just management (#669)**: when the plugin adopts an externally started server (CI's `script/ci-start-server`, a hand-started dev server without `--owner-pid`), a clean editor exit tears that server down via `_exit_tree → stop_server` — the same as for a plugin-spawned server. A "keep one server running, restart the editor around it" dev loop therefore loses the server on the first editor exit (and the next editor spawns a *managed* server, silently degrading a `--reload` workflow). To keep a long-lived `--reload` server across editor restarts, run it on a non-default port the plugin won't adopt, or restart it after each editor exit.
 - In `--headless` / headless-display launches, the plugin returns early and does not start/adopt the server, open a WebSocket, add the dock, attach loggers, register the debugger plugin, instantiate handlers, or write the game-helper autoload. Set `GODOT_AI_ALLOW_HEADLESS=1` only for intentional headless MCP sessions such as CI handler tests.
 
 For Python auto-reload during dev (no need to touch Godot):

--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -922,7 +922,9 @@ static func _coerce_typed_array(value: Variant, slot_value: Array, prefix: Strin
 		)
 		return ErrorCodes.prefix_message(err, prefix)
 	var elem_type := slot_value.get_typed_builtin()
-	if elem_type == TYPE_OBJECT:
+	## An empty list has no elements to coerce, so it may clear the slot even
+	## when the element type is stage-2 territory (PR #682 review).
+	if elem_type == TYPE_OBJECT and not (value as Array).is_empty():
 		var obj_err := ErrorCodes.make(
 			ErrorCodes.WRONG_TYPE,
 			"Writing elements into a typed Array[%s] property is not supported yet (#612 stage 2 covers Object elements); assign the elements individually in the editor for now" % elem_label,

--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -939,11 +939,14 @@ static func _coerce_typed_array(value: Variant, slot_value: Array, prefix: Strin
 		if elem_err != null:
 			return elem_err
 		if coerced == null:
+			## Prefix with `elem_prefix` (which already folds in `prefix`),
+			## not `prefix` again — the latter double-stamped the property
+			## context (PR #682 review).
 			var null_err := ErrorCodes.make(
 				ErrorCodes.WRONG_TYPE,
-				"%s: cannot store null in Array[%s]" % [elem_prefix, elem_label],
+				"cannot store null in Array[%s]" % elem_label,
 			)
-			return ErrorCodes.prefix_message(null_err, prefix)
+			return ErrorCodes.prefix_message(null_err, elem_prefix)
 		staging.append(coerced)
 	var out := slot_value.duplicate()
 	out.clear()

--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -251,6 +251,16 @@ func set_property(params: Dictionary) -> Dictionary:
 				return apply_err
 		value = res
 		instantiated_resource = true
+	elif target_type == TYPE_ARRAY and old_value is Array and (old_value as Array).is_typed():
+		## Typed Array[T] slot (#612): the generic TYPE_ARRAY passthrough
+		## hands an untyped Array to Godot's typed setter, which rejects it
+		## wholesale and leaves the slot at its default — with success still
+		## reported. Route through the element-aware coercer instead; errors
+		## name the offending element index.
+		var typed_out: Variant = _coerce_typed_array(value, old_value)
+		if typed_out is Dictionary:
+			return typed_out
+		value = typed_out
 	else:
 		value = _coerce_value(value, target_type)
 		## Refuse any value that didn't land as the target compound Variant
@@ -885,6 +895,81 @@ static func _coerce_value(value: Variant, target_type: int) -> Variant:
 		# PackedByteArray intentionally unhandled — needs design decision
 		# (base64 string vs. raw int list); JSON has no native byte type.
 	return value
+
+
+## Fill a typed `Array[T]` slot from a JSON list (#612 stage 1: value-element
+## types). `slot_value` is the property's current typed Array — Godot's getter
+## returns the (possibly empty) typed container, which carries the element
+## type, so no PROPERTY_HINT_TYPE_STRING parsing is needed. Elements coerce
+## one at a time through the existing `_coerce_value` / `_check_coerced`
+## pair, then bulk-move via `Array.assign()` with a post-assign size check,
+## so a wrong element can never silently drop the write: it errors naming
+## the element index. Returns the filled typed Array on success, or a
+## `make(...)`-shaped error Dictionary (callers discriminate on
+## `result is Dictionary` — a successful result is always an Array).
+##
+## Object elements (Array[Texture2D], Array[MyResource], ...) are #612
+## stage 2 — refused loudly here rather than left to the generic
+## passthrough that silently dropped them.
+static func _coerce_typed_array(value: Variant, slot_value: Array, prefix: String = "") -> Variant:
+	var elem_label := _typed_array_element_label(slot_value)
+	if not (value is Array):
+		var err := ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
+			"Cannot write %s to a typed Array[%s] property; expected a list" % [
+				type_string(typeof(value)), elem_label,
+			],
+		)
+		return ErrorCodes.prefix_message(err, prefix)
+	var elem_type := slot_value.get_typed_builtin()
+	if elem_type == TYPE_OBJECT:
+		var obj_err := ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
+			"Writing elements into a typed Array[%s] property is not supported yet (#612 stage 2 covers Object elements); assign the elements individually in the editor for now" % elem_label,
+		)
+		return ErrorCodes.prefix_message(obj_err, prefix)
+	var staging: Array = []
+	var in_list: Array = value
+	for i in in_list.size():
+		var elem_prefix := ("element %d" % i) if prefix.is_empty() else "%s element %d" % [prefix, i]
+		var coerced: Variant = _coerce_value(in_list[i], elem_type)
+		var elem_err := _check_coerced(coerced, elem_type, elem_prefix)
+		if elem_err != null:
+			return elem_err
+		if coerced == null:
+			var null_err := ErrorCodes.make(
+				ErrorCodes.WRONG_TYPE,
+				"%s: cannot store null in Array[%s]" % [elem_prefix, elem_label],
+			)
+			return ErrorCodes.prefix_message(null_err, prefix)
+		staging.append(coerced)
+	var out := slot_value.duplicate()
+	out.clear()
+	out.assign(staging)
+	if out.size() != staging.size():
+		## Backstop for element shapes `_check_coerced` waves through but the
+		## typed container still rejects — `assign` loud-rejects and leaves a
+		## short array, which without this check would be a partial write.
+		var assign_err := ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
+			"Array[%s] element conversion failed during assign (%d of %d elements landed)" % [
+				elem_label, out.size(), staging.size(),
+			],
+		)
+		return ErrorCodes.prefix_message(assign_err, prefix)
+	return out
+
+
+## "int" / "Vector3" / "Texture2D" / "MyItemData" — element-type name of a
+## typed Array slot, for error messages.
+static func _typed_array_element_label(slot_value: Array) -> String:
+	if slot_value.get_typed_builtin() == TYPE_OBJECT:
+		var cls := String(slot_value.get_typed_class_name())
+		var script: Variant = slot_value.get_typed_script()
+		if script is Script and not String((script as Script).get_global_name()).is_empty():
+			cls = String((script as Script).get_global_name())
+		return cls if not cls.is_empty() else "Object"
+	return type_string(slot_value.get_typed_builtin())
 
 
 func get_node_properties(params: Dictionary) -> Dictionary:

--- a/plugin/addons/godot_ai/handlers/resource_handler.gd
+++ b/plugin/addons/godot_ai/handlers/resource_handler.gd
@@ -371,13 +371,25 @@ static func _apply_resource_properties(res: Resource, properties: Dictionary, de
 					return nested_err
 			v = sub_res
 		else:
-			v = NodeHandler._coerce_value(v, target_type)
-			## Mirror set_property's coerce check: wrong-shape dicts (#123) and
-			## non-dict inputs that don't land as the target compound Variant
-			## (#191) both error here instead of writing zero-filled Variants.
-			var coerce_err := NodeHandler._check_coerced(v, target_type, "Property '%s'" % key)
-			if coerce_err != null:
-				return coerce_err
+			var slot_value: Variant = res.get(key)
+			if target_type == TYPE_ARRAY and slot_value is Array and (slot_value as Array).is_typed():
+				## Typed Array[T] slot (#612): mirror set_property's dispatch —
+				## the generic passthrough would hand an untyped Array to the
+				## typed setter, which drops it silently while we report success.
+				var typed_out: Variant = NodeHandler._coerce_typed_array(
+					v, slot_value, "Property '%s'" % key
+				)
+				if typed_out is Dictionary:
+					return typed_out
+				v = typed_out
+			else:
+				v = NodeHandler._coerce_value(v, target_type)
+				## Mirror set_property's coerce check: wrong-shape dicts (#123) and
+				## non-dict inputs that don't land as the target compound Variant
+				## (#191) both error here instead of writing zero-filled Variants.
+				var coerce_err := NodeHandler._check_coerced(v, target_type, "Property '%s'" % key)
+				if coerce_err != null:
+					return coerce_err
 		res.set(key, v)
 	return null
 

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -1462,7 +1462,7 @@ func _on_restart_stale_server() -> void:
 	_last_rendered_server_text = ""
 	_refresh_server_version_label()
 	if not is_inside_tree():
-		_dispatch_stale_server_restart()
+		await _dispatch_stale_server_restart()
 		_server_restart_in_progress = false
 		_last_rendered_server_text = ""
 		_refresh_server_version_label()
@@ -1472,7 +1472,7 @@ func _on_restart_stale_server() -> void:
 
 func _restart_stale_server_after_feedback() -> void:
 	await get_tree().create_timer(0.15).timeout
-	if not _dispatch_stale_server_restart():
+	if not await _dispatch_stale_server_restart():
 		_server_restart_in_progress = false
 		_last_rendered_server_text = ""
 		_refresh_server_version_label()
@@ -1488,7 +1488,9 @@ func _dispatch_stale_server_restart() -> bool:
 	)
 	if int(status.get("state", ServerStateScript.UNINITIALIZED)) == ServerStateScript.INCOMPATIBLE:
 		if _plugin.has_method("recover_incompatible_server"):
-			return bool(_plugin.recover_incompatible_server())
+			## Coroutine in production (#678): recovery reports success only
+			## after the respawn walk completes and the connection unblocks.
+			return bool(await _plugin.recover_incompatible_server())
 	elif _plugin.has_method("force_restart_server"):
 		_plugin.force_restart_server()
 		return true

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -170,6 +170,9 @@ var _startup_trace_enabled := false
 var _startup_trace_start_ms := 0
 var _startup_trace_last_ms := 0
 var _startup_trace_counters: Dictionary = {}
+## Startup-path probes can now run on a worker thread (#678); the trace
+## counters they bump are shared with the main thread, so serialize.
+var _startup_trace_mutex := Mutex.new()
 var _startup_trace_netsh_start_count := 0
 
 
@@ -206,6 +209,12 @@ func _enter_tree() -> void:
 	## buffer. Without this the choice only took effect after a manual toggle
 	## and reset to noisy on every editor restart (#626).
 	_log_buffer.enabled = McpSettings.mcp_logging_enabled()
+	## #678: in the real editor, run the startup path's blocking probes and
+	## kill-drain waits off the main thread so a contended port can't freeze
+	## plugin init/reload. Set here (not _init) so test fixtures — which
+	## extend this plugin but never enter the tree — keep the synchronous
+	## default and can call-then-assert.
+	_lifecycle.defer_blocking_work = true
 	_start_server()
 	_startup_trace_phase("server_start")
 
@@ -664,7 +673,9 @@ func _startup_trace_begin() -> void:
 func _startup_trace_count(counter: String, amount: int = 1) -> void:
 	if not _startup_trace_enabled:
 		return
+	_startup_trace_mutex.lock()
 	_startup_trace_counters[counter] = int(_startup_trace_counters.get(counter, 0)) + amount
+	_startup_trace_mutex.unlock()
 
 
 func _startup_trace_phase(name: String) -> void:
@@ -1107,13 +1118,20 @@ func _find_managed_pid(port: int) -> int:
 ## preserves the historical behavior for callers outside the spawn flow
 ## (`can_recover_incompatible_server`, the dock's UI buttons), where a
 ## fresh probe is the right thing.
-func _evaluate_strong_port_occupant_proof(port: int, live: Dictionary = {}) -> Dictionary:
+## `record_override`: a managed-server record snapshot the caller already
+## read. Non-empty skips the internal `_read_managed_server_record()` —
+## required when this helper runs on a worker thread (#678), because the
+## record lives in EditorSettings, which is main-thread-only. `{}` keeps
+## the historical read-it-here behavior for synchronous callers
+## (`_read_managed_server_record` never returns a bare `{}`, so the
+## sentinel is unambiguous).
+func _evaluate_strong_port_occupant_proof(port: int, live: Dictionary = {}, record_override: Dictionary = {}) -> Dictionary:
 	var result := {"proof": "", "pids": []}
 	var listener_pids := _find_all_pids_on_port(port)
 	if listener_pids.is_empty():
 		return result
 
-	var record := _read_managed_server_record()
+	var record: Dictionary = record_override if not record_override.is_empty() else _read_managed_server_record()
 	var record_pid := int(record.get("pid", 0))
 	var record_version := str(record.get("version", ""))
 
@@ -1162,7 +1180,10 @@ func _evaluate_recovery_port_occupant_proof(port: int, live: Dictionary = {}) ->
 
 
 func _recover_strong_port_occupant(port: int, wait_s: float, pre_kill_live: Dictionary = {}) -> bool:
-	return _lifecycle.recover_strong_port_occupant(port, wait_s, pre_kill_live)
+	## `await` because the manager method is a coroutine in production
+	## (#678); with `defer_blocking_work` off it completes synchronously
+	## and this await is a pass-through.
+	return await _lifecycle.recover_strong_port_occupant(port, wait_s, pre_kill_live)
 
 
 func _legacy_pidfile_kill_targets(_port: int, listener_pids: Array[int]) -> Array[int]:

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -429,8 +429,8 @@ func _enter_tree() -> void:
 		_telemetry.record_dock_startup()
 		_flush_pending_self_update_telemetry()
 		_telemetry.flush_pending_plugin_reload()
-	var startup_path: String = str(_lifecycle.get_startup_path())
-	_startup_trace_finish(startup_path if not startup_path.is_empty() else "loaded")
+	## The startup-trace 'done' line is stamped by _start_server after the
+	## (possibly suspended) walk completes — not here (#682 review).
 
 
 ## Public wrapper around the dev-server-toggle telemetry emit. Lets the
@@ -693,17 +693,28 @@ func _startup_trace_finish(path: String) -> void:
 	if not _startup_trace_enabled:
 		return
 	var now := Time.get_ticks_msec()
+	## Same lock as _startup_trace_count — a worker probe may still be
+	## bumping counters while this reads/writes the shared dictionary.
+	_startup_trace_mutex.lock()
 	_startup_trace_counters["netsh"] = (
 		WindowsPortReservation.netsh_query_count() - _startup_trace_netsh_start_count
 	)
+	var counters_snapshot: Dictionary = _startup_trace_counters.duplicate()
+	_startup_trace_mutex.unlock()
 	print(
 		"MCP startup trace | done path=%s total_ms=%d counters=%s"
-		% [path, now - _startup_trace_start_ms, str(_startup_trace_counters)]
+		% [path, now - _startup_trace_start_ms, str(counters_snapshot)]
 	)
 
 
 func _start_server() -> void:
-	_lifecycle.start_server()
+	await _lifecycle.start_server()
+	## The walk may have suspended (#678), so this line — not _enter_tree's
+	## tail — is where the real startup outcome is known. Stamp the trace
+	## 'done' here so the contended-port path and duration stay honest
+	## instead of reporting a placeholder before the walk finished.
+	var startup_path: String = str(_lifecycle.get_startup_path())
+	_startup_trace_finish(startup_path if not startup_path.is_empty() else "loaded")
 
 
 ## Test-fixture shim — characterization tests in test_plugin_lifecycle
@@ -1568,7 +1579,11 @@ func _resume_connection_after_recovery() -> void:
 
 
 func recover_incompatible_server() -> bool:
-	if not _lifecycle.recover_incompatible_server():
+	## `await` because the manager's recovery is a coroutine in production
+	## (#678): `_resume_connection_after_recovery` gates on the post-walk
+	## state, so it must not run until the respawn walk has completed. With
+	## `defer_blocking_work` off this completes synchronously.
+	if not await _lifecycle.recover_incompatible_server():
 		return false
 	_resume_connection_after_recovery()
 	return true

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -72,9 +72,53 @@ var _startup_path: String = McpStartupPathScript.UNSET
 ## stub it out.
 var _version_check
 
+## #678: when true, the blocking primitives on the startup path (port
+## scrapes, per-PID brand shells, the HTTP status probe, kill + port-drain
+## waits) run on a WorkerThreadPool thread while the main thread keeps
+## pumping frames — the editor stays responsive during plugin init/reload
+## on a contended port; the dock panel just arrives a beat later. The
+## plugin enables this in production. Default false: unit tests (and any
+## legacy caller) keep the historical fully-synchronous behavior, where
+## the startup coroutines never actually suspend and call-then-assert
+## still works.
+var defer_blocking_work: bool = false
+
+## Cancellation for in-flight async startup work: bumped by `stop_server`
+## (and therefore by `_exit_tree` and update-reload prep), checked after
+## every await so a suspended `start_server` can't resurrect state — or
+## spawn a server — after teardown started.
+var _async_generation: int = 0
+
+## Re-entrancy guard: with startup a coroutine, a second `start_server`
+## call (respawn watch, dock button) can land mid-flight.
+var _start_in_flight: bool = false
+
 
 func _init(host) -> void:
 	_host = host
+
+
+## Run `work` off the main thread and suspend until it completes (#678).
+## Falls back to inline execution when `defer_blocking_work` is off, or
+## when no SceneTree is available to pump frames against.
+func _run_blocking(work: Callable) -> Variant:
+	if not defer_blocking_work:
+		return work.call()
+	var tree := Engine.get_main_loop()
+	if not (tree is SceneTree):
+		return work.call()
+	var result: Array = [null]
+	var task_id := WorkerThreadPool.add_task(func() -> void:
+		result[0] = work.call()
+	)
+	while not WorkerThreadPool.is_task_completed(task_id):
+		await (tree as SceneTree).process_frame
+	WorkerThreadPool.wait_for_task_completion(task_id)
+	return result[0]
+
+
+func _async_stale(generation: int) -> bool:
+	return generation != _async_generation
 
 
 # ---- Public state accessors --------------------------------------------
@@ -435,7 +479,21 @@ func _set_plugin_spawned_env() -> void:
 ##   port in use, record matches + live ok   -> adopt port owner (heals PID)
 ##   port in use, record drifts              -> kill owner + respawn
 ##   port in use, no verified live match     -> block adoption + warn
+##
+## #678: this is a coroutine in production (`defer_blocking_work`) — the
+## port scrapes, status probes, and kill-drain waits run off the main
+## thread and the state machine resumes between frames, so the editor
+## stays responsive when the port is contended. With the flag off (unit
+## tests) nothing suspends and the call completes synchronously.
 func start_server() -> void:
+	if _start_in_flight:
+		return
+	_start_in_flight = true
+	await _start_server_impl(_async_generation)
+	_start_in_flight = false
+
+
+func _start_server_impl(async_gen: int) -> void:
 	if _host._server_started_this_session:
 		## Static flag persists across disable/enable cycles in one editor
 		## session — re-entrant spawn guard for plugin-reload-during-update.
@@ -451,7 +509,12 @@ func start_server() -> void:
 	var current_version := _expected_server_version()
 	_server_expected_version = current_version
 
-	if bool(_host._is_port_in_use(port)):
+	var port_in_use := bool(await _run_blocking(func() -> Variant:
+		return _host._is_port_in_use(port)
+	))
+	if _async_stale(async_gen):
+		return
+	if port_in_use:
 		var record: Dictionary = _host._read_managed_server_record()
 		var record_version := str(record.get("version", ""))
 		var record_ws_port := int(record.get("ws_port", 0))
@@ -462,7 +525,11 @@ func start_server() -> void:
 			int(_host._resolve_ws_port())
 		))
 		ws_port = int(_host._resolved_ws_port)
-		var live: Dictionary = _host._probe_live_server_status_for_port(port)
+		var live: Dictionary = await _run_blocking(func() -> Variant:
+			return _host._probe_live_server_status_for_port(port)
+		)
+		if _async_stale(async_gen):
+			return
 		var live_version := str(_host._verified_status_version(live))
 		var live_ws_port := int(_host._verified_status_ws_port(live))
 		var compatibility: Dictionary = _server_status_compatibility(
@@ -494,9 +561,16 @@ func start_server() -> void:
 				% [record_version, current_version])
 		## Forward `live` so the recovery proof helper reuses our snapshot.
 		## The kill invalidates it, so the failure arm re-probes below.
-		if not recover_strong_port_occupant(port, 3.0, live):
+		var recovered: bool = await recover_strong_port_occupant(port, 3.0, live)
+		if _async_stale(async_gen):
+			return
+		if not recovered:
 			_host._server_started_this_session = true
-			var post_recovery_live: Dictionary = _host._probe_live_server_status_for_port(port)
+			var post_recovery_live: Dictionary = await _run_blocking(func() -> Variant:
+				return _host._probe_live_server_status_for_port(port)
+			)
+			if _async_stale(async_gen):
+				return
 			_set_incompatible_server(post_recovery_live, current_version, port)
 			_startup_path = McpStartupPathScript.INCOMPATIBLE
 			push_warning(str(_server_status_message))
@@ -508,7 +582,13 @@ func start_server() -> void:
 	ws_port = _host._resolved_ws_port
 
 	_host._startup_trace_count("server_command_discovery")
-	var server_cmd := ClientConfigurator.get_server_command()
+	## CLI-finder discovery shells out (which/where, login shell) on cache
+	## misses — the same #238/#239 family the dock already runs off-thread.
+	var server_cmd: Array = await _run_blocking(func() -> Variant:
+		return ClientConfigurator.get_server_command()
+	)
+	if _async_stale(async_gen):
+		return
 	if server_cmd.is_empty():
 		set_terminal_diagnosis(McpServerStateScript.NO_COMMAND)
 		_startup_path = McpStartupPathScript.NO_COMMAND
@@ -786,19 +866,36 @@ static func _compatible_adoption_log_message(
 ## re-probe a port the caller already probed. The kill invalidates the
 ## snapshot — callers MUST re-probe before consuming live-status data
 ## after this returns.
+##
+## #678: coroutine in production — the proof evaluation (port scrapes +
+## per-PID brand shells) and the kill + port-drain wait run off the main
+## thread. The EditorSettings record is read on the main thread up front
+## and injected into the proof helper; record/pid-file clears stay on the
+## main thread after the awaits.
 func recover_strong_port_occupant(port: int, wait_s: float, pre_kill_live: Dictionary = {}) -> bool:
-	var proof: Dictionary = _host._evaluate_strong_port_occupant_proof(port, pre_kill_live)
+	var async_gen := _async_generation
+	var record: Dictionary = _host._read_managed_server_record()
+	var proof: Dictionary = await _run_blocking(func() -> Variant:
+		return _host._evaluate_strong_port_occupant_proof(port, pre_kill_live, record)
+	)
+	if _async_stale(async_gen):
+		return false
 	var targets: Array[int] = []
 	targets.assign(proof.get("pids", []))
 	if targets.is_empty():
 		return false
 
 	print("MCP | strong proof: %s" % str(proof.get("proof", "")))
-	var killed: Array = _host._kill_processes_and_windows_spawn_children(targets)
-	if not killed.is_empty():
-		print("MCP | killed pids %s on port %d" % [str(killed), port])
-	_host._wait_for_port_free(port, wait_s)
-	if bool(_host._is_port_in_use(port)):
+	var freed := bool(await _run_blocking(func() -> Variant:
+		var killed: Array = _host._kill_processes_and_windows_spawn_children(targets)
+		if not killed.is_empty():
+			print("MCP | killed pids %s on port %d" % [str(killed), port])
+		_host._wait_for_port_free(port, wait_s)
+		return not bool(_host._is_port_in_use(port))
+	))
+	if _async_stale(async_gen):
+		return false
+	if not freed:
 		return false
 
 	_host._clear_managed_server_record()
@@ -807,6 +904,9 @@ func recover_strong_port_occupant(port: int, wait_s: float, pre_kill_live: Dicti
 
 
 func stop_server() -> void:
+	## Cancel any in-flight async startup (#678): a suspended start_server
+	## resuming after teardown must not resurrect state or spawn a server.
+	_async_generation += 1
 	_host._stop_server_watch()
 	if int(_server_pid) <= 0:
 		transition_state(McpServerStateScript.STOPPED)

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -1070,7 +1070,11 @@ func recover_incompatible_server() -> bool:
 	_can_recover_incompatible = false
 	_host._server_started_this_session = false
 	_server_pid = -1
-	start_server()
+	## Await the respawn walk: the plugin gates its connection unblock on
+	## the post-walk state (SPAWNING/READY), so returning true while the
+	## walk is still suspended would leave the connection blocked forever
+	## after a successful recovery click (#682 review).
+	await start_server()
 	return true
 
 

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -127,6 +127,20 @@ func _async_stale(generation: int) -> bool:
 	return generation != _async_generation
 
 
+## Cancel any in-flight async startup walk AND release the re-entrancy
+## guard so the very next `start_server()` call walks fresh (#682 review).
+## Every one-shot kill-and-restart path must call this before its
+## follow-up start: without the generation bump the suspended walk
+## resumes against post-kill reality (stale live-status snapshots), and
+## without releasing the guard the follow-up start is silently swallowed.
+## The cancelled walk unwinds via its post-await staleness checks and
+## must NOT clear the guard itself — a newer walk may already own it
+## (see the generation check in `start_server`).
+func _invalidate_async_startup() -> void:
+	_async_generation += 1
+	_start_in_flight = false
+
+
 # ---- Public state accessors --------------------------------------------
 
 func get_state() -> int:
@@ -495,8 +509,18 @@ func start_server() -> void:
 	if _start_in_flight:
 		return
 	_start_in_flight = true
-	await _start_server_impl(_async_generation)
-	_start_in_flight = false
+	var gen := _async_generation
+	await _start_server_impl(gen)
+	## Only release the guard if this walk is still the current one — a
+	## cancelled (stale) walk unwinding here must not clobber the guard a
+	## newer walk armed after `_invalidate_async_startup`.
+	if gen == _async_generation:
+		_start_in_flight = false
+		## The walk suspends now (#678), so the caller-side trace phase
+		## stamps the first suspension; stamp completion here to keep the
+		## old contended-port cost visible in startup traces (#682 review).
+		if is_instance_valid(_host):
+			_host._startup_trace_phase("server_start_walk_complete")
 
 
 func _start_server_impl(async_gen: int) -> void:
@@ -515,8 +539,11 @@ func _start_server_impl(async_gen: int) -> void:
 	var current_version := _expected_server_version()
 	_server_expected_version = current_version
 
+	## The worker closures re-check the host: the plugin can be freed while
+	## a bounded shell probe is still running, and the generation check only
+	## protects state after resume, not calls inside the task (#682 review).
 	var port_in_use := bool(await _run_blocking(func() -> Variant:
-		return _host._is_port_in_use(port)
+		return is_instance_valid(_host) and _host._is_port_in_use(port)
 	))
 	if _async_stale(async_gen):
 		return
@@ -532,6 +559,8 @@ func _start_server_impl(async_gen: int) -> void:
 		))
 		ws_port = int(_host._resolved_ws_port)
 		var live: Dictionary = await _run_blocking(func() -> Variant:
+			if not is_instance_valid(_host):
+				return {}
 			return _host._probe_live_server_status_for_port(port)
 		)
 		if _async_stale(async_gen):
@@ -573,6 +602,8 @@ func _start_server_impl(async_gen: int) -> void:
 		if not recovered:
 			_host._server_started_this_session = true
 			var post_recovery_live: Dictionary = await _run_blocking(func() -> Variant:
+				if not is_instance_valid(_host):
+					return {}
 				return _host._probe_live_server_status_for_port(port)
 			)
 			if _async_stale(async_gen):
@@ -882,6 +913,8 @@ func recover_strong_port_occupant(port: int, wait_s: float, pre_kill_live: Dicti
 	var async_gen := _async_generation
 	var record: Dictionary = _host._read_managed_server_record()
 	var proof: Dictionary = await _run_blocking(func() -> Variant:
+		if not is_instance_valid(_host):
+			return {"proof": "", "pids": []}
 		return _host._evaluate_strong_port_occupant_proof(port, pre_kill_live, record)
 	)
 	if _async_stale(async_gen):
@@ -893,6 +926,8 @@ func recover_strong_port_occupant(port: int, wait_s: float, pre_kill_live: Dicti
 
 	print("MCP | strong proof: %s" % str(proof.get("proof", "")))
 	var freed := bool(await _run_blocking(func() -> Variant:
+		if not is_instance_valid(_host):
+			return false
 		var killed: Array = _host._kill_processes_and_windows_spawn_children(targets)
 		if not killed.is_empty():
 			print("MCP | killed pids %s on port %d" % [str(killed), port])
@@ -912,7 +947,7 @@ func recover_strong_port_occupant(port: int, wait_s: float, pre_kill_live: Dicti
 func stop_server() -> void:
 	## Cancel any in-flight async startup (#678): a suspended start_server
 	## resuming after teardown must not resurrect state or spawn a server.
-	_async_generation += 1
+	_invalidate_async_startup()
 	_host._stop_server_watch()
 	if int(_server_pid) <= 0:
 		transition_state(McpServerStateScript.STOPPED)
@@ -1005,6 +1040,11 @@ func recover_incompatible_server() -> bool:
 		return false
 	print("MCP | proof: %s" % str(proof.get("proof", "")))
 
+	## Committed to the kill: cancel any suspended contended-port walk so
+	## it can't resume against pre-kill data, and release the guard so the
+	## respawn at the bottom isn't silently swallowed (#682 review).
+	_invalidate_async_startup()
+
 	## Move into STOPPING so the post-kill respawn passes the
 	## first-writer-wins guards.
 	transition_state(McpServerStateScript.STOPPING)
@@ -1052,6 +1092,10 @@ func has_managed_server() -> bool:
 ## the pid-file, and resets the spawn guard so the follow-up
 ## `start_server()` walks the spawn arm.
 func reset_for_force_restart() -> void:
+	## The user's explicit restart takes over: cancel any suspended
+	## contended-port walk and release the re-entrancy guard so the
+	## follow-up start isn't silently swallowed (#682 review).
+	_invalidate_async_startup()
 	_host._clear_managed_server_record()
 	_host._clear_pid_file()
 	_host._server_started_this_session = false

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -101,20 +101,26 @@ func _init(host) -> void:
 ## Run `work` off the main thread and suspend until it completes (#678).
 ## Falls back to inline execution when `defer_blocking_work` is off, or
 ## when no SceneTree is available to pump frames against.
+##
+## Uses a dedicated Thread (the dock's #238/#239 worker pattern) rather
+## than WorkerThreadPool: `wait_to_finish()` hands the return value back
+## without a shared mutable container, and this plugin has already seen
+## WorkerThreadPool tasks SIGABRT under concurrency (see the notes in
+## script_handler.gd / filesystem_handler.gd). `wait_to_finish` after
+## `is_alive()` goes false joins an already-dead thread, so it never
+## blocks the main thread.
 func _run_blocking(work: Callable) -> Variant:
 	if not defer_blocking_work:
 		return work.call()
 	var tree := Engine.get_main_loop()
 	if not (tree is SceneTree):
 		return work.call()
-	var result: Array = [null]
-	var task_id := WorkerThreadPool.add_task(func() -> void:
-		result[0] = work.call()
-	)
-	while not WorkerThreadPool.is_task_completed(task_id):
+	var thread := Thread.new()
+	if thread.start(work) != OK:
+		return work.call()
+	while thread.is_alive():
 		await (tree as SceneTree).process_frame
-	WorkerThreadPool.wait_for_task_completion(task_id)
-	return result[0]
+	return thread.wait_to_finish()
 
 
 func _async_stale(generation: int) -> bool:

--- a/plugin/addons/godot_ai/utils/update_manager.gd
+++ b/plugin/addons/godot_ai/utils/update_manager.gd
@@ -79,9 +79,10 @@ var _http_request: HTTPRequest
 var _download_request: HTTPRequest
 var _verify_request: HTTPRequest
 var _latest_download_url: String = ""
-## URL of the `godot-ai-plugin.zip.sha256` sidecar asset, when the release
-## ships one. Used to verify the downloaded archive's integrity before extract
-## (#523). Empty for older releases published without a checksum sidecar.
+## URL of the `godot-ai-plugin.zip.sha256` sidecar asset. Used to verify the
+## downloaded archive's integrity before extract (#523). Verification is
+## mandatory (#599): when a release ships no sidecar this stays empty and
+## `_verify_then_install` refuses the install.
 var _latest_checksum_url: String = ""
 
 ## Set for the duration of `_install_zip` — extract-overwrite of plugin
@@ -403,19 +404,18 @@ func _on_download_completed(
 ## Gate the extract on a SHA-256 match against the release's checksum sidecar.
 ## TLS + host pinning already constrain where the bytes came from; this
 ## verifies the bytes themselves so a tampered asset (or a compromised CDN
-## object) can't be installed over live plugin code. Releases published
-## without a `.sha256` sidecar (older versions) install without this check —
-## verify-if-present rather than hard-fail, so existing releases stay
-## updatable; the host + repo-path pin still applies to the download itself.
-## Removing this legacy bypass (making verification mandatory) is tracked in
-## #599 and is gated on all supported update targets publishing `.sha256`
-## sidecars — a release-policy question, not a code change here.
+## object) can't be installed over live plugin code. Verification is
+## MANDATORY (#599): a release published without a `.sha256` sidecar —
+## mistake or tamper — refuses to install rather than silently downgrading
+## to an unverified install. This is safe because self-update only ever
+## verifies the *next* download, and every release since #523 publishes the
+## sidecar (release.yml), so no supported update target lacks one.
 func _verify_then_install() -> void:
-	## Legacy bypass — see #599 before removing.
 	if _latest_checksum_url.is_empty():
-		print("MCP | no checksum published for this release; skipping integrity verification")
-		install_state_changed.emit({"button_text": "Installing..."})
-		_install_zip()
+		_fail_verification(
+			"release published no godot-ai-plugin.zip.sha256 sidecar; "
+			+ "refusing unverified install (#599)"
+		)
 		return
 
 	## A present-but-untrusted checksum URL is a tamper signal, not a

--- a/script/ci-godot-tests
+++ b/script/ci-godot-tests
@@ -11,9 +11,12 @@ HEADERS=(-H "Content-Type: application/json" -H "Accept: application/json, text/
 # Wait for Godot plugin to connect (session_manage(op="list") returns count > 0)
 echo "Waiting for Godot plugin to connect..."
 for i in $(seq 1 60); do
+  # `|| true` neutralizes the pipeline status under `set -euo pipefail`:
+  # a down server (curl exit 7) or a missing header (grep exit 1) must fall
+  # through to the empty-SESSION_ID retry below, not abort the script (#668).
   SESSION_ID=$(curl -si "$SERVER_URL" -X POST "${HEADERS[@]}" \
     -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"ci","version":"1.0"}}}' \
-    2>&1 | grep -i 'mcp-session-id' | tr -d '\r' | awk '{print $2}')
+    2>&1 | grep -i 'mcp-session-id' | tr -d '\r' | awk '{print $2}' || true)
 
   if [ -z "$SESSION_ID" ]; then
     sleep 2
@@ -22,11 +25,11 @@ for i in $(seq 1 60); do
 
   curl -s "$SERVER_URL" -X POST "${HEADERS[@]}" \
     -H "Mcp-Session-Id: $SESSION_ID" \
-    -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' > /dev/null
+    -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' > /dev/null || true
 
   SESSIONS=$(curl -s "$SERVER_URL" -X POST "${HEADERS[@]}" \
     -H "Mcp-Session-Id: $SESSION_ID" \
-    -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"session_manage","arguments":{"op":"list"}}}')
+    -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"session_manage","arguments":{"op":"list"}}}' || true)
 
   if echo "$SESSIONS" | grep -q '"count":'; then
     COUNT=$(echo "$SESSIONS" | python3 -c "

--- a/script/ci-stale-server-smoke
+++ b/script/ci-stale-server-smoke
@@ -31,16 +31,27 @@ and test_dock.gd mock all OS interactions, and `script/manual-orphan-test`
 exercises the real kill path but is a manual operator helper. This script runs
 the real per-OS classification + kill / cmdline-brand machinery in CI on every
 OS, so a regression is caught before merge.
+
+Windows bind nuance (#679): both planted occupants bind `127.0.0.1`
+EXPLICITLY, and that is load-bearing. Windows (no `SO_EXCLUSIVEADDRUSE` on
+either side) allows a specific-address `127.0.0.1` bind to coexist with a
+foreign process's wildcard `0.0.0.0` bind on the same port — so a squatter
+bound to the wildcard address does NOT produce a conflict: the plugin's server
+binds loopback alongside it and startup proceeds normally. Only a loopback
+squatter reproduces the conflict path on Windows. Keep the planted listeners
+on `127.0.0.1`, and bind loopback explicitly in any manual repro too.
 """
 
 from __future__ import annotations
 
 import argparse
+import errno
 import json
 import os
 import platform
 import shutil
 import signal
+import socket
 import subprocess
 import sys
 import tempfile
@@ -123,7 +134,9 @@ class FastBindServer(ThreadingHTTPServer):
 
 
 # Bind FIRST so the "listening" print isn't a lie — the smoke polls
-# /godot-ai/status immediately after seeing it.
+# /godot-ai/status immediately after seeing it. Loopback EXPLICITLY, not
+# the wildcard address: on Windows a 0.0.0.0 bind coexists with the
+# plugin's 127.0.0.1 bind and no conflict ever materializes (#679).
 server = FastBindServer(("127.0.0.1", args.port), H)
 print(f"stale-sim pid={os.getpid()} listening on :{args.port}", flush=True)
 server.serve_forever()
@@ -172,7 +185,9 @@ class FastBindServer(ThreadingHTTPServer):
 
 
 # Bind FIRST so the "listening" print isn't a lie — the smoke polls the port
-# immediately after seeing it.
+# immediately after seeing it. Loopback EXPLICITLY, not the wildcard
+# address: on Windows a 0.0.0.0 bind coexists with the plugin's 127.0.0.1
+# bind and the conflict path is never exercised (#679).
 server = FastBindServer(("127.0.0.1", args.port), H)
 print(f"foreign-sim pid={os.getpid()} listening on :{args.port}", flush=True)
 server.serve_forever()
@@ -186,6 +201,67 @@ KILL_GUARD_WINDOW = 8.0
 
 class SmokeError(RuntimeError):
     pass
+
+
+def port_in_use(port: int) -> bool:
+    """True when something is bound on 127.0.0.1:`port`. Only a prompt
+    connection-refused proves the port free — a timeout or any other error
+    (e.g. a listener with a full backlog) conservatively counts as in use."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(1.0)
+        try:
+            err = s.connect_ex(("127.0.0.1", port))
+        except OSError:
+            return True
+    if err == 0:
+        return True
+    return err != errno.ECONNREFUSED
+
+
+def drain_leftover_servers(timeout_s: float = 150.0) -> None:
+    """Wait until the HTTP and WS ports are actually free before planting the
+    sim/listener (#671). A run started right after a previous run can race that
+    run's plugin-spawned server: it lingers in its orphan-reap window (owner-pid
+    poll ~5s, idle grace up to 120s) and, if still bound when our editor starts,
+    gets *adopted* as a live compatible godot-ai server — so the planted
+    occupant is never diagnosed and the mode's assertions can't match.
+
+    We only wait — never kill. The leftover is marked plugin-spawned with a
+    dead owner, so its own reaper takes it down; a genuinely foreign occupant
+    that never frees the port is a real environment problem the operator has to
+    resolve, and gets a clear failure here instead of a confusing one later."""
+    deadline = time.monotonic() + timeout_s
+    reported = False
+    while time.monotonic() < deadline:
+        busy = [p for p in (PORT, WS_PORT) if port_in_use(p)]
+        if not busy:
+            if reported:
+                print("drain: ports are free, continuing")
+            return
+        if not reported:
+            reported = True
+            occupant = "unknown"
+            try:
+                with urllib.request.urlopen(STATUS_URL, timeout=2) as r:
+                    payload = json.loads(r.read().decode())
+                    occupant = (
+                        f"godot-ai v{extract_version(payload)} "
+                        f"(likely a previous run's server in its reap window)"
+                    )
+            except (urllib.error.URLError, ConnectionError, TimeoutError, ValueError):
+                pass
+            print(
+                f"drain: port(s) {busy} still occupied by {occupant}; "
+                f"waiting up to {timeout_s:.0f}s for them to free..."
+            )
+        time.sleep(1.0)
+    busy = [p for p in (PORT, WS_PORT) if port_in_use(p)]
+    if busy:
+        raise SmokeError(
+            f"port(s) {busy} still occupied after {timeout_s:.0f}s pre-plant "
+            f"drain; refusing to run — the smoke would race the occupant "
+            f"instead of testing the planted one (#671)"
+        )
 
 
 def discover_user_dir(godot: str) -> Path:
@@ -690,6 +766,10 @@ def main() -> int:
     # the plugin false ownership proof over a port it does not actually own.
     if pidfile.exists():
         pidfile.unlink()
+
+    # Pre-plant drain: back-to-back runs (stale then foreign) can otherwise
+    # cross-contaminate via the previous run's server reap window (#671).
+    drain_leftover_servers()
 
     if args.mode == "foreign":
         return run_foreign_smoke(godot, plugin_version, user_dir, pidfile, log_dir, args.timeout)

--- a/script/ci-stale-server-smoke
+++ b/script/ci-stale-server-smoke
@@ -216,7 +216,13 @@ def port_in_use(port: int) -> bool:
     Windows where SO_REUSEADDR means "hijack the active listener". Only
     EADDRINUSE counts as occupied — any other bind failure (EACCES, winnat
     exclusion ranges) is not a drainable occupant, and the plant will surface
-    its own honest failure for those."""
+    its own honest failure for those.
+
+    Known Windows residual: without SO_REUSEADDR, server-side TIME_WAIT
+    sockets (connections the previous run's server closed first) also
+    bind-fail EADDRINUSE, and Windows' TIME_WAIT default (~4 min) exceeds
+    the 150s drain timeout. If the Windows smoke ever flakes on
+    "port(s) still occupied" with occupant "unknown", look here first."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         if os.name != "nt":
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)

--- a/script/ci-stale-server-smoke
+++ b/script/ci-stale-server-smoke
@@ -203,6 +203,15 @@ class SmokeError(RuntimeError):
     pass
 
 
+# connect_ex speaks WSA on Windows: a free port refuses with
+# WSAECONNREFUSED (10061), not the POSIX ECONNREFUSED value — comparing
+# against errno.ECONNREFUSED alone made every free port read as occupied
+# and stalled the pre-plant drain to its timeout on Windows CI.
+_REFUSED_ERRNOS = frozenset(
+    {errno.ECONNREFUSED, getattr(errno, "WSAECONNREFUSED", 10061)}
+)
+
+
 def port_in_use(port: int) -> bool:
     """True when something is bound on 127.0.0.1:`port`. Only a prompt
     connection-refused proves the port free — a timeout or any other error
@@ -215,7 +224,7 @@ def port_in_use(port: int) -> bool:
             return True
     if err == 0:
         return True
-    return err != errno.ECONNREFUSED
+    return err not in _REFUSED_ERRNOS
 
 
 def drain_leftover_servers(timeout_s: float = 150.0) -> None:

--- a/script/ci-stale-server-smoke
+++ b/script/ci-stale-server-smoke
@@ -203,28 +203,32 @@ class SmokeError(RuntimeError):
     pass
 
 
-# connect_ex speaks WSA on Windows: a free port refuses with
-# WSAECONNREFUSED (10061), not the POSIX ECONNREFUSED value — comparing
-# against errno.ECONNREFUSED alone made every free port read as occupied
-# and stalled the pre-plant drain to its timeout on Windows CI.
-_REFUSED_ERRNOS = frozenset(
-    {errno.ECONNREFUSED, getattr(errno, "WSAECONNREFUSED", 10061)}
-)
-
-
 def port_in_use(port: int) -> bool:
-    """True when something is bound on 127.0.0.1:`port`. Only a prompt
-    connection-refused proves the port free — a timeout or any other error
-    (e.g. a listener with a full backlog) conservatively counts as in use."""
+    """True when something is bound on 127.0.0.1:`port`, probed by BINDING —
+    the exact operation the planted sim/listener will perform. Connect-based
+    probing is unusable here: GitHub's Windows runners silently drop SYNs to
+    closed loopback ports (no RST), so a connect probe can never distinguish
+    free from occupied and the drain stalls to its timeout (#682 CI).
+
+    Mirrors `preflight_check_port` in src/godot_ai/__init__.py: SO_REUSEADDR
+    on POSIX so a just-freed port's TIME_WAIT connections don't read as an
+    occupant (the sim's HTTPServer sets allow_reuse_address too), skipped on
+    Windows where SO_REUSEADDR means "hijack the active listener". Only
+    EADDRINUSE counts as occupied — any other bind failure (EACCES, winnat
+    exclusion ranges) is not a drainable occupant, and the plant will surface
+    its own honest failure for those."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.settimeout(1.0)
+        if os.name != "nt":
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
-            err = s.connect_ex(("127.0.0.1", port))
-        except OSError:
-            return True
-    if err == 0:
-        return True
-    return err not in _REFUSED_ERRNOS
+            s.bind(("127.0.0.1", port))
+        except OSError as exc:
+            return (
+                exc.errno == errno.EADDRINUSE
+                or exc.errno == 10048
+                or getattr(exc, "winerror", None) == 10048
+            )
+    return False
 
 
 def drain_leftover_servers(timeout_s: float = 150.0) -> None:

--- a/script/ci-start-server
+++ b/script/ci-start-server
@@ -2,6 +2,12 @@
 # Start the MCP server and wait for it to be ready.
 # Usage: ci-start-server [python-command]
 # Default python command: python
+#
+# Adoption-teardown contract (#669): a Godot editor that finds this server on
+# port 8000 ADOPTS it — and the adopter owns teardown, so a clean editor exit
+# stops this server too. That's fine in CI (editor and server die together at
+# job end), but don't reuse this script for a long-lived local dev server you
+# expect to survive editor restarts.
 set -euo pipefail
 source "$(dirname "$0")/_ci_env.sh"
 

--- a/src/godot_ai/__init__.py
+++ b/src/godot_ai/__init__.py
@@ -148,7 +148,12 @@ def main(argv: Sequence[str] | None = None) -> None:
             "server self-terminates if that editor dies (crash / hard-kill with "
             "no clean stop_server) and no other editor has adopted it, so a "
             "detached server can't orphan onto the port. Omitted for externally "
-            "managed servers (CI, manual --reload)."
+            "managed servers (CI, manual --reload). Note: omitting it does NOT "
+            "exempt the server from editor lifecycle teardown — an editor that "
+            "adopts this server owns its end-of-life and will stop it on clean "
+            "editor exit (see #669). To keep a long-lived dev server across "
+            "editor restarts, run it on a non-default port the plugin won't "
+            "adopt."
         ),
     )
     parser.add_argument(

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -1831,3 +1831,195 @@ func test_set_property_transform2d_lands() -> void:
 	assert_true(editor_undo(_undo_redo), "undo create should succeed")
 
 
+
+# ----- set_property: typed Array[T] slots (#612 stage 1) -----
+
+## Attach a @tool script with typed-array exports to a fresh probe node
+## created through the handler (so undo cleanup mirrors the other
+## set_property tests). Returns the live node.
+func _make_typed_array_probe(probe_name: String) -> Node:
+	_handler.create_node({"type": "Node", "name": probe_name, "parent_path": "/Main"})
+	var node := EditorInterface.get_edited_scene_root().get_node(probe_name)
+	var script := GDScript.new()
+	script.source_code = "\n".join([
+		"@tool",
+		"extends Node",
+		"@export var ints: Array[int] = []",
+		"@export var strings: Array[String] = []",
+		"@export var vectors: Array[Vector3] = []",
+		"@export var colors: Array[Color] = []",
+		"@export var nested: Array[Array] = []",
+		"@export var textures: Array[Texture2D] = []",
+	])
+	script.reload()
+	node.set_script(script)
+	return node
+
+
+## Undo the probe's create action (set_property failures commit nothing, so
+## error-path tests only need this single undo).
+func _free_typed_array_probe(sets_to_undo: int) -> void:
+	for i in sets_to_undo:
+		assert_true(editor_undo(_undo_redo), "undo set should succeed")
+	assert_true(editor_undo(_undo_redo), "undo create should succeed")
+
+
+func test_set_property_typed_int_array_roundtrip() -> void:
+	## The #612 headline case: a JSON list into an Array[int] slot used to be
+	## silently dropped (slot stayed []) while the call reported success.
+	var node := _make_typed_array_probe("_McpTypedInts")
+	var result := _handler.set_property({
+		"path": "/Main/_McpTypedInts",
+		"property": "ints",
+		"value": [1, 2, 3],
+	})
+	assert_has_key(result, "data")
+	var stored: Variant = node.get("ints")
+	assert_true(stored is Array, "ints must read back as an Array")
+	assert_eq((stored as Array).size(), 3, "all elements must land — no silent drop")
+	assert_eq(stored[0], 1)
+	assert_eq(stored[2], 3)
+	assert_true((stored as Array).is_typed(), "the slot must keep its typing")
+	_free_typed_array_probe(1)
+
+
+func test_set_property_typed_int_array_coerces_json_floats() -> void:
+	## JSON numbers arrive as floats; whole floats must land as ints.
+	var node := _make_typed_array_probe("_McpTypedIntFloats")
+	var result := _handler.set_property({
+		"path": "/Main/_McpTypedIntFloats",
+		"property": "ints",
+		"value": [1.0, 2.0],
+	})
+	assert_has_key(result, "data")
+	var stored: Variant = node.get("ints")
+	assert_eq((stored as Array).size(), 2)
+	assert_true(stored[0] is int, "JSON float must coerce to the int element type")
+	assert_eq(stored[1], 2)
+	_free_typed_array_probe(1)
+
+
+func test_set_property_typed_vector3_array_coerces_dicts() -> void:
+	## Struct elements go through the same dict->Variant coercion as scalar
+	## slots; assert on the stored Variant, not the count (AGENTS.md).
+	var node := _make_typed_array_probe("_McpTypedVecs")
+	var result := _handler.set_property({
+		"path": "/Main/_McpTypedVecs",
+		"property": "vectors",
+		"value": [{"x": 1, "y": 2, "z": 3}, {"x": 4, "y": 5, "z": 6}],
+	})
+	assert_has_key(result, "data")
+	var stored: Variant = node.get("vectors")
+	assert_eq((stored as Array).size(), 2)
+	assert_true(stored[0] is Vector3, "dict element must land as Vector3, not Dictionary")
+	assert_eq(stored[1], Vector3(4, 5, 6))
+	_free_typed_array_probe(1)
+
+
+func test_set_property_typed_color_array_accepts_dicts_and_names() -> void:
+	var node := _make_typed_array_probe("_McpTypedColors")
+	var result := _handler.set_property({
+		"path": "/Main/_McpTypedColors",
+		"property": "colors",
+		"value": [{"r": 1, "g": 0, "b": 0}, "#00ff00"],
+	})
+	assert_has_key(result, "data")
+	var stored: Variant = node.get("colors")
+	assert_eq((stored as Array).size(), 2)
+	assert_true(stored[0] is Color, "dict element must land as Color")
+	assert_eq(stored[1], Color("#00ff00"))
+	_free_typed_array_probe(1)
+
+
+func test_set_property_typed_color_array_rejects_bogus_color_string() -> void:
+	## Color("zznothex") silently returns black on the scalar path history
+	## (#612 rider) — the typed-array path must clean-error instead.
+	var node := _make_typed_array_probe("_McpTypedBadColor")
+	var result := _handler.set_property({
+		"path": "/Main/_McpTypedBadColor",
+		"property": "colors",
+		"value": ["#ff0000", "zznothex"],
+	})
+	assert_is_error(result, ErrorCodes.WRONG_TYPE)
+	assert_contains(result.error.message, "element 1",
+		"the error must name the offending element index")
+	assert_eq((node.get("colors") as Array).size(), 0, "nothing may be written on error")
+	_free_typed_array_probe(0)
+
+
+func test_set_property_typed_nested_array_roundtrip() -> void:
+	var node := _make_typed_array_probe("_McpTypedNested")
+	var result := _handler.set_property({
+		"path": "/Main/_McpTypedNested",
+		"property": "nested",
+		"value": [[1, 2], [3]],
+	})
+	assert_has_key(result, "data")
+	var stored: Variant = node.get("nested")
+	assert_eq((stored as Array).size(), 2)
+	assert_true(stored[0] is Array)
+	assert_eq(stored[0][1], 2)
+	_free_typed_array_probe(1)
+
+
+func test_set_property_typed_array_mixed_elements_error_names_index() -> void:
+	## Wrong/mixed elements clean-error naming the index — never a partial
+	## or silent write (#612 maintainer decision).
+	var node := _make_typed_array_probe("_McpTypedMixed")
+	var result := _handler.set_property({
+		"path": "/Main/_McpTypedMixed",
+		"property": "ints",
+		"value": [1, "two", 3],
+	})
+	assert_is_error(result, ErrorCodes.WRONG_TYPE)
+	assert_contains(result.error.message, "element 1",
+		"the error must name the offending element index")
+	assert_eq((node.get("ints") as Array).size(), 0, "slot must stay untouched on error")
+	_free_typed_array_probe(0)
+
+
+func test_set_property_typed_array_non_list_value_errors() -> void:
+	var node := _make_typed_array_probe("_McpTypedNonList")
+	var result := _handler.set_property({
+		"path": "/Main/_McpTypedNonList",
+		"property": "ints",
+		"value": 5,
+	})
+	assert_is_error(result, ErrorCodes.WRONG_TYPE)
+	assert_contains(result.error.message, "Array[int]",
+		"the error must name the typed slot")
+	assert_eq((node.get("ints") as Array).size(), 0)
+	_free_typed_array_probe(0)
+
+
+func test_set_property_typed_object_array_refuses_loudly() -> void:
+	## Object elements are #612 stage 2 — until then the write must REFUSE,
+	## not silently drop like the old generic passthrough did.
+	var node := _make_typed_array_probe("_McpTypedObjects")
+	var result := _handler.set_property({
+		"path": "/Main/_McpTypedObjects",
+		"property": "textures",
+		"value": ["res://icon.svg"],
+	})
+	assert_is_error(result, ErrorCodes.WRONG_TYPE)
+	assert_contains(result.error.message, "not supported yet",
+		"stage-2 deferral must be loud, not a silent drop")
+	assert_eq((node.get("textures") as Array).size(), 0)
+	_free_typed_array_probe(0)
+
+
+func test_set_property_typed_array_undo_restores_previous_value() -> void:
+	var node := _make_typed_array_probe("_McpTypedUndo")
+	var first := _handler.set_property({
+		"path": "/Main/_McpTypedUndo", "property": "ints", "value": [7],
+	})
+	assert_has_key(first, "data")
+	var second := _handler.set_property({
+		"path": "/Main/_McpTypedUndo", "property": "ints", "value": [8, 9],
+	})
+	assert_has_key(second, "data")
+	assert_true(editor_undo(_undo_redo), "undo second set should succeed")
+	var stored: Variant = node.get("ints")
+	assert_eq((stored as Array).size(), 1, "undo must restore the previous array")
+	assert_eq(stored[0], 7)
+	_free_typed_array_probe(1)

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -1992,6 +1992,28 @@ func test_set_property_typed_array_non_list_value_errors() -> void:
 	_free_typed_array_probe(0)
 
 
+func test_set_property_typed_object_array_clears_with_empty_list() -> void:
+	## An empty list carries no elements to coerce, so it must be allowed to
+	## CLEAR an Object-element typed array even while writing elements is
+	## stage-2 (#682 review finding).
+	var node := _make_typed_array_probe("_McpTypedObjClear")
+	var live: Array = node.get("textures")
+	live.append(ImageTexture.new())
+	assert_eq((node.get("textures") as Array).size(), 1, "seed texture must be present")
+	var result := _handler.set_property({
+		"path": "/Main/_McpTypedObjClear",
+		"property": "textures",
+		"value": [],
+	})
+	assert_has_key(result, "data")
+	var stored: Variant = node.get("textures")
+	assert_eq((stored as Array).size(), 0, "empty list must clear the slot")
+	assert_true((stored as Array).is_typed(), "the slot must keep its typing")
+	assert_true(editor_undo(_undo_redo), "undo clear should succeed")
+	assert_eq((node.get("textures") as Array).size(), 1, "undo must restore the seeded element")
+	_free_typed_array_probe(0)
+
+
 func test_set_property_typed_object_array_refuses_loudly() -> void:
 	## Object elements are #612 stage 2 — until then the write must REFUSE,
 	## not silently drop like the old generic passthrough did.

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -1069,7 +1069,7 @@ func test_recover_incompatible_returns_false_and_leaves_state_when_port_remains_
 	plugin.listener_pids = [24680] as Array[int]
 	plugin.live_status = {"name": "godot-ai", "version": "1.2.10", "ws_port": 9500, "status_code": 200}
 
-	var ok := plugin.recover_incompatible_server()
+	var ok: bool = await plugin.recover_incompatible_server()
 	var status := plugin.get_server_status()
 	var killed := plugin.killed_targets.duplicate()
 	var clear_calls := plugin.cleared_record_calls

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -641,7 +641,7 @@ func test_strong_recovery_kills_pidfile_listener_when_port_frees() -> void:
 	plugin.branded_pids = [11111] as Array[int]
 	plugin.port_in_use_sequence = [false] as Array[bool]
 
-	var ok := plugin._recover_strong_port_occupant(TEST_PORT, 0.1)
+	var ok: bool = await plugin._recover_strong_port_occupant(TEST_PORT, 0.1)
 	var killed := plugin.killed_targets.duplicate()
 	var waited_calls := plugin.waited_calls
 	var clear_calls := plugin.cleared_record_calls
@@ -661,7 +661,7 @@ func test_strong_recovery_preserves_state_when_port_stays_held() -> void:
 	plugin.branded_pids = [11111] as Array[int]
 	plugin.port_in_use_sequence = [true] as Array[bool]
 
-	var ok := plugin._recover_strong_port_occupant(TEST_PORT, 0.1)
+	var ok: bool = await plugin._recover_strong_port_occupant(TEST_PORT, 0.1)
 	var killed := plugin.killed_targets.duplicate()
 	var waited_calls := plugin.waited_calls
 	var clear_calls := plugin.cleared_record_calls
@@ -678,7 +678,7 @@ func test_strong_recovery_rejects_status_name_only() -> void:
 	plugin.listener_pids = [13579] as Array[int]
 	plugin.live_status = {"name": "godot-ai", "version": "2.1.0", "ws_port": 9500, "status_code": 200}
 
-	var ok := plugin._recover_strong_port_occupant(TEST_PORT, 0.1)
+	var ok: bool = await plugin._recover_strong_port_occupant(TEST_PORT, 0.1)
 	var killed := plugin.killed_targets.duplicate()
 	var waited_calls := plugin.waited_calls
 	var clear_calls := plugin.cleared_record_calls
@@ -1416,7 +1416,7 @@ func test_recover_strong_port_occupant_threads_live_to_proof() -> void:
 	plugin.port_in_use_sequence = [false] as Array[bool]
 	var caller_live := {"name": "godot-ai", "version": "2.1.0", "ws_port": 9500, "status_code": 200}
 
-	var ok := plugin._recover_strong_port_occupant(TEST_PORT, 0.1, caller_live)
+	var ok: bool = await plugin._recover_strong_port_occupant(TEST_PORT, 0.1, caller_live)
 	var probe_calls := plugin.probe_calls
 	plugin.free()
 

--- a/test_project/tests/test_resource.gd
+++ b/test_project/tests/test_resource.gd
@@ -846,3 +846,66 @@ func test_apply_properties_nested_failure_names_the_property() -> void:
 	assert_true(err is Dictionary, "expected an error dict; got: %s" % str(err))
 	if err is Dictionary:
 		assert_contains(err["error"]["message"], "for property 'sub'")
+
+# ----- _apply_resource_properties: typed Array[T] slots (#612 stage 1) -----
+
+## Build a scripted Resource with typed-array exports — the exact shape of
+## the #612 repro (custom Resources are where typed-array exports are the
+## dominant idiom).
+func _make_typed_array_resource() -> Resource:
+	var script := GDScript.new()
+	script.source_code = "\n".join([
+		"@tool",
+		"extends Resource",
+		"@export var items: Array[int] = []",
+		"@export var labels: Array[String] = []",
+		"@export var tints: Array[Color] = []",
+	])
+	script.reload()
+	return script.new()
+
+
+func test_apply_resource_properties_fills_typed_int_array() -> void:
+	## The literal #612 repro: {"items": [1, 2, 3]} used to return success
+	## while the slot silently stayed [].
+	var res := _make_typed_array_resource()
+	var err: Variant = ResourceHandler._apply_resource_properties(res, {"items": [1, 2, 3]})
+	assert_eq(err, null, "typed Array[int] write must succeed")
+	var stored: Variant = res.get("items")
+	assert_eq((stored as Array).size(), 3, "all elements must land — no silent drop")
+	assert_eq(stored[0], 1)
+	assert_eq(stored[2], 3)
+	assert_true((stored as Array).is_typed(), "the slot must keep its typing")
+
+
+func test_apply_resource_properties_typed_string_and_color_arrays() -> void:
+	var res := _make_typed_array_resource()
+	var err: Variant = ResourceHandler._apply_resource_properties(res, {
+		"labels": ["a", "b"],
+		"tints": [{"r": 1, "g": 0, "b": 0}, "#0000ff"],
+	})
+	assert_eq(err, null, "typed String/Color array writes must succeed")
+	assert_eq((res.get("labels") as Array).size(), 2)
+	assert_eq(res.get("labels")[1], "b")
+	var tints: Variant = res.get("tints")
+	assert_true(tints[0] is Color, "dict element must land as Color")
+	assert_eq(tints[1], Color("#0000ff"))
+
+
+func test_apply_resource_properties_typed_array_error_names_property_and_index() -> void:
+	var res := _make_typed_array_resource()
+	var err: Variant = ResourceHandler._apply_resource_properties(res, {"items": [1, "two"]})
+	assert_is_error(err, ErrorCodes.WRONG_TYPE)
+	assert_contains(err.error.message, "Property 'items'",
+		"the error must name the property")
+	assert_contains(err.error.message, "element 1",
+		"the error must name the offending element index")
+	assert_eq((res.get("items") as Array).size(), 0, "slot must stay untouched on error")
+
+
+func test_apply_resource_properties_typed_array_rejects_non_list() -> void:
+	var res := _make_typed_array_resource()
+	var err: Variant = ResourceHandler._apply_resource_properties(res, {"items": "1,2,3"})
+	assert_is_error(err, ErrorCodes.WRONG_TYPE)
+	assert_contains(err.error.message, "Array[int]", "the error must name the typed slot")
+	assert_eq((res.get("items") as Array).size(), 0)

--- a/test_project/tests/test_resource.gd
+++ b/test_project/tests/test_resource.gd
@@ -909,3 +909,16 @@ func test_apply_resource_properties_typed_array_rejects_non_list() -> void:
 	assert_is_error(err, ErrorCodes.WRONG_TYPE)
 	assert_contains(err.error.message, "Array[int]", "the error must name the typed slot")
 	assert_eq((res.get("items") as Array).size(), 0)
+
+
+func test_apply_resource_properties_typed_array_null_element_prefixes_once() -> void:
+	## PR #682 review: the null-element error used to stamp the property
+	## context twice ("Property 'items': Property 'items' element 0: ...").
+	var res := _make_typed_array_resource()
+	var err: Variant = ResourceHandler._apply_resource_properties(res, {"items": [null]})
+	assert_is_error(err, ErrorCodes.WRONG_TYPE)
+	var msg := str(err.error.message)
+	assert_contains(msg, "element 0", "the error must name the offending element index")
+	assert_contains(msg, "cannot store null", "the error must name the null cause")
+	assert_eq(msg.count("Property 'items'"), 1,
+		"the property context must be stamped exactly once")

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -140,7 +140,7 @@ func test_recover_returns_false_with_no_proof() -> void:
 	var host := _ManagerHostStub.new()
 	var manager := McpServerLifecycleManagerScript.new(host)
 
-	var ok := manager.recover_strong_port_occupant(TEST_PORT, 0.1)
+	var ok: bool = await manager.recover_strong_port_occupant(TEST_PORT, 0.1)
 	var killed := host.killed_targets.duplicate()
 	host.free()
 
@@ -159,7 +159,7 @@ func test_recover_kills_and_clears_when_port_frees() -> void:
 	host.port_in_use_sequence = [false] as Array[bool]
 	var manager := McpServerLifecycleManagerScript.new(host)
 
-	var ok := manager.recover_strong_port_occupant(TEST_PORT, 0.1)
+	var ok: bool = await manager.recover_strong_port_occupant(TEST_PORT, 0.1)
 	host.free()
 
 	assert_true(ok)
@@ -176,7 +176,7 @@ func test_recover_preserves_record_when_port_held() -> void:
 	host.port_in_use_sequence = [true] as Array[bool]
 	var manager := McpServerLifecycleManagerScript.new(host)
 
-	var ok := manager.recover_strong_port_occupant(TEST_PORT, 0.1)
+	var ok: bool = await manager.recover_strong_port_occupant(TEST_PORT, 0.1)
 	var cleared := host.cleared_record_calls
 	host.free()
 
@@ -530,3 +530,66 @@ func test_inject_when_env_present_but_falsey_and_setting_disabled() -> void:
 
 	assert_true(injected, "a falsey DISABLE_TELEMETRY must not suppress the UI opt-out")
 	assert_true(env_present, "GODOT_AI_DISABLE_TELEMETRY must be injected for the spawn")
+
+
+# ----- #678 async startup plumbing --------------------------------------
+
+func test_run_blocking_inline_by_default() -> void:
+	## With defer_blocking_work off (the default every unit test relies on)
+	## the work runs inline and the surrounding coroutines never suspend —
+	## call-then-assert keeps working.
+	var host := _ManagerHostStub.new()
+	var manager := McpServerLifecycleManagerScript.new(host)
+	assert_false(manager.defer_blocking_work,
+		"synchronous behavior must be the default (tests depend on it)")
+	## `await` is a pass-through here: inline mode never suspends.
+	var value: Variant = await manager._run_blocking(func() -> Variant: return 42)
+	host.free()
+	assert_eq(value, 42, "inline _run_blocking must return the work's value")
+
+
+func test_start_server_reentrancy_guard() -> void:
+	## Startup is a coroutine in production, so a second start_server can
+	## arrive mid-flight — it must be a no-op, not a second walk.
+	var host := _ManagerHostStub.new()
+	host.port_in_use = true
+	var manager := McpServerLifecycleManagerScript.new(host)
+	manager._start_in_flight = true
+	manager.start_server()
+	var state := manager.get_state()
+	host.free()
+	assert_eq(state, McpServerState.UNINITIALIZED,
+		"an in-flight start must block a second walk from mutating state")
+
+
+func test_stop_server_invalidates_async_generation() -> void:
+	## stop_server (and therefore _exit_tree / update-reload prep) must
+	## cancel in-flight async startup work so a suspended start_server
+	## can't resurrect state after teardown began.
+	var host := _ManagerHostStub.new()
+	var manager := McpServerLifecycleManagerScript.new(host)
+	var before := int(manager._async_generation)
+	manager.stop_server()
+	var after := int(manager._async_generation)
+	var stale := manager._async_stale(before)
+	host.free()
+	assert_eq(after, before + 1, "stop_server must bump the async generation")
+	assert_true(stale, "work captured before stop_server must read as stale")
+
+
+func test_proof_helper_honors_record_override() -> void:
+	## #678: when the proof helper runs on a worker thread it must not read
+	## EditorSettings — the caller injects the record snapshot instead.
+	var host := _ManagerHostStub.new()
+	host.listener_pids = [4242]
+	host.alive_pids = [4242]
+	host.branded_pids = [4242]
+	## The stub's internal record would NOT match; the override must win.
+	host.managed_record = {"pid": 0, "version": "", "ws_port": 0}
+	var proof: Dictionary = host._evaluate_strong_port_occupant_proof(
+		TEST_PORT, {"name": ""}, {"pid": 4242, "version": "9.9.9", "ws_port": 0}
+	)
+	host.free()
+	assert_eq(str(proof.get("proof", "")), "managed_record",
+		"the injected record snapshot must drive the managed_record proof tier")
+	assert_eq(proof.get("pids", []), [4242])

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -593,3 +593,24 @@ func test_proof_helper_honors_record_override() -> void:
 	assert_eq(str(proof.get("proof", "")), "managed_record",
 		"the injected record snapshot must drive the managed_record proof tier")
 	assert_eq(proof.get("pids", []), [4242])
+
+
+func test_force_restart_reset_invalidates_async_generation_and_guard() -> void:
+	## #682 review: the one-shot kill-and-restart paths must cancel an
+	## in-flight contended-port walk AND release the re-entrancy guard —
+	## otherwise the dock's explicit restart is silently swallowed while
+	## the stale walk resumes against post-kill reality.
+	var host := _ManagerHostStub.new()
+	var manager := McpServerLifecycleManagerScript.new(host)
+	manager._start_in_flight = true
+	var before := int(manager._async_generation)
+	manager.reset_for_force_restart()
+	var after := int(manager._async_generation)
+	var stale := manager._async_stale(before)
+	var guard_released: bool = not manager._start_in_flight
+	host.free()
+	assert_eq(after, before + 1,
+		"reset_for_force_restart must bump the async generation")
+	assert_true(stale, "the in-flight walk must read as stale after the reset")
+	assert_true(guard_released,
+		"the follow-up start_server must not be swallowed by the stale walk's guard")

--- a/test_project/tests/test_update_manager.gd
+++ b/test_project/tests/test_update_manager.gd
@@ -221,7 +221,7 @@ func test_verify_refuses_missing_checksum_sidecar() -> void:
 
 	var manager = McpUpdateManagerScript.new()
 	manager._latest_checksum_url = ""
-	var states: Array = []
+	var states: Array[Dictionary] = []
 	manager.install_state_changed.connect(func(state: Dictionary) -> void:
 		states.append(state)
 	)
@@ -260,7 +260,7 @@ func test_verify_refuses_wrong_repo_checksum_url() -> void:
 		"https://github.com/evil-org/godot-ai/releases/download/v999.0.0/"
 		+ "godot-ai-plugin.zip.sha256"
 	)
-	var states: Array = []
+	var states: Array[Dictionary] = []
 	manager.install_state_changed.connect(func(state: Dictionary) -> void:
 		states.append(state)
 	)
@@ -303,7 +303,7 @@ func test_checksum_match_on_repo_release_proceeds_to_install() -> void:
 	assert_true(
 		McpUpdateManagerScript._is_trusted_download_url(manager._latest_checksum_url),
 		"Seed: the repo-scoped sidecar URL must pass the trust guard")
-	var states: Array = []
+	var states: Array[Dictionary] = []
 	manager.install_state_changed.connect(func(state: Dictionary) -> void:
 		states.append(state)
 	)
@@ -538,8 +538,8 @@ func test_update_check_below_floor_does_not_arm_download() -> void:
 	## update offer. Otherwise one click can install the 4.5+-only release.
 	var manager = _NoSelfUpdateManager.new()
 	var body := _make_body(_make_release_payload("v999.0.0"))
-	var states: Array = []
-	var update_results: Array = []
+	var states: Array[Dictionary] = []
+	var update_results: Array[Dictionary] = []
 	manager.install_state_changed.connect(func(state: Dictionary) -> void:
 		states.append(state)
 	)
@@ -573,7 +573,7 @@ func test_start_install_below_floor_only_repaints_guidance() -> void:
 	## If a stale UI path calls start_install anyway, keep it inside the
 	## guidance state rather than opening the browser or entering install.
 	var manager = _NoSelfUpdateManager.new()
-	var states: Array = []
+	var states: Array[Dictionary] = []
 	manager.install_state_changed.connect(func(state: Dictionary) -> void:
 		states.append(state)
 	)

--- a/test_project/tests/test_update_manager.gd
+++ b/test_project/tests/test_update_manager.gd
@@ -205,7 +205,42 @@ func test_parse_sha256_digest_matches_fileaccess_hash() -> void:
 		"parsed sidecar digest must match FileAccess.get_sha256 (the verify compare)")
 
 
-# ---- _verify_then_install URL scoping (#599) ---------------------------
+# ---- _verify_then_install mandatory verification (#599) ----------------
+
+func test_verify_refuses_missing_checksum_sidecar() -> void:
+	## Verification is mandatory: a release published without a `.sha256`
+	## sidecar (mistake or tamper) must refuse to install — the old
+	## verify-if-present bypass silently downgraded to an unverified install.
+	var global_dir := ProjectSettings.globalize_path(McpUpdateManagerScript.UPDATE_TEMP_DIR)
+	var global_zip := ProjectSettings.globalize_path(McpUpdateManagerScript.UPDATE_TEMP_ZIP)
+	DirAccess.make_dir_recursive_absolute(global_dir)
+	var f := FileAccess.open(global_zip, FileAccess.WRITE)
+	assert_true(f != null, "Seed staged zip must open for write")
+	f.store_string("staged update payload")
+	f.close()
+
+	var manager = McpUpdateManagerScript.new()
+	manager._latest_checksum_url = ""
+	var states: Array = []
+	manager.install_state_changed.connect(func(state: Dictionary) -> void:
+		states.append(state)
+	)
+
+	manager._verify_then_install()
+
+	var zip_still_staged := FileAccess.file_exists(global_zip)
+	manager.free()
+	DirAccess.remove_absolute(global_zip)
+	DirAccess.remove_absolute(global_dir)
+
+	assert_false(zip_still_staged,
+		"a missing checksum sidecar must drop the staged ZIP, not install it")
+	assert_eq(states.size(), 1,
+		"a missing checksum sidecar must emit exactly one failure state")
+	var state: Dictionary = states[0]
+	assert_contains(String(state.get("button_text", "")), "Verification failed",
+		"a missing checksum sidecar must paint the verification-failed button")
+
 
 func test_verify_refuses_wrong_repo_checksum_url() -> void:
 	## A checksum sidecar URL on a trusted GitHub host but pointing at a
@@ -387,8 +422,8 @@ func test_parse_releases_response_captures_checksum_asset_url() -> void:
 
 
 func test_parse_releases_response_checksum_empty_when_absent() -> void:
-	## Older releases without a sidecar must leave checksum_url empty so the
-	## installer takes the verify-if-present (skip) path rather than failing.
+	## A release without a sidecar must leave checksum_url empty — that's the
+	## signal `_verify_then_install` uses to REFUSE the install (#599).
 	var body := _make_body(_make_release_payload("v999.0.0"))
 	var result := McpUpdateManagerScript.parse_releases_response(
 		HTTPRequest.RESULT_SUCCESS, 200, body

--- a/test_project/tests/test_update_manager.gd
+++ b/test_project/tests/test_update_manager.gd
@@ -240,6 +240,8 @@ func test_verify_refuses_missing_checksum_sidecar() -> void:
 	var state: Dictionary = states[0]
 	assert_contains(String(state.get("button_text", "")), "Verification failed",
 		"a missing checksum sidecar must paint the verification-failed button")
+	assert_eq(bool(state.get("button_disabled", true)), false,
+		"a missing checksum sidecar must leave the button enabled for retry")
 
 
 func test_verify_refuses_wrong_repo_checksum_url() -> void:


### PR DESCRIPTION
Sweeps eight open issues, one commit each, ordered smallest to largest.

## CI / tooling

- **#668 — `ci-godot-tests` aborts instead of retrying.** The session-probe pipeline (`curl | grep | awk`) killed the whole script under `set -euo pipefail` on exactly the conditions the retry loop targets (server down → curl exit 7; header missing → grep exit 1). `|| true` neutralizes the pipeline status so the empty-`SESSION_ID` retry branch is reachable; the two other in-loop curl calls are hardened the same way.
- **#671 — `ci-stale-server-smoke` back-to-back cross-contamination.** Both modes now run a bounded pre-plant drain: wait (never kill) until the HTTP and WS ports are genuinely free before planting the sim/listener, so a previous run's server in its orphan-reap window can't get adopted in place of the planted occupant. The probe **binds** rather than connects — GitHub's Windows runners silently drop SYNs to closed loopback ports, so connect-based probing reads every free port as occupied there (found via this PR's first two CI rounds); binding is also the exact operation the plant performs, mirroring `preflight_check_port`. Only `EADDRINUSE` counts as occupied; on drain timeout the harness fails naming the occupant.
- **#679 (docs half) — Windows wildcard-bind coexistence.** Confirmed the planted listeners already bind `127.0.0.1` explicitly — the Windows CI rows do exercise the conflict path. That being load-bearing is now documented in the module docstring and at both bind sites (a `0.0.0.0` squatter coexists with the plugin's loopback bind on Windows and never conflicts). The `SO_EXCLUSIVEADDRUSE` hardening idea remains open on the issue.
- **#672 — web-session hook pinned Godot 4.6.2.** Bumped to 4.7, cache keyed by version (`godot-4.7`) so warm containers replace stale engines on a bump, superseded cache entries pruned, and a blocked download now fails with a message pointing at the environment network policy (verified live in this environment, where the download 403s). Plus an adjacent bug found while testing: the hook launched the editor without `GODOT_AI_ALLOW_HEADLESS=1`, so the plugin disabled itself and the promised `:8000` server never spawned; fixed and verified live.

## Docs / contract

- **#669 — adoption-teardown contract.** Stated in AGENTS.md (server lifecycle section), the `--owner-pid` help text, and `ci-start-server`'s header: an editor that adopts an externally started server owns its end-of-life and stops it on clean editor exit; a long-lived `--reload` dev server should run on a non-default port.

## Plugin

- **#599 — self-update verification now mandatory.** The verify-if-present bypass is removed: a release without a `godot-ai-plugin.zip.sha256` sidecar refuses to install and drops the staged ZIP, per the maintainer's analysis that no population breaks (self-update only verifies the *next* download, and every release since #523 ships the sidecar). The URL-scoping follow-up had already shipped, so this completes the issue. New test covers the refusal (and that the retry button stays enabled); the existing trusted/untrusted/match tests still pass.
- **#612 stage 1 — typed `Array[T]` values silently dropped.** A JSON list into a typed `Array[T]` `@export` slot used to pass the element-type-agnostic `TYPE_ARRAY` passthrough as an untyped Array, get rejected wholesale by Godot's typed setter, and leave the slot empty with success reported. New `NodeHandler._coerce_typed_array` detects the typed slot from the property's current value (the getter returns the empty typed container — no `hint_string` parsing), coerces each element through the existing `_coerce_value`/`_check_coerced` pair, and bulk-moves via `Array.assign()` with a post-assign size check. Wrong/mixed elements clean-error naming the element index; nothing partially writes. Both `set_property` and `_apply_resource_properties` dispatch ahead of the generic passthrough. Object elements (`Array[Texture2D]`, …) are stage 2 and refuse loudly instead of dropping silently — except an empty list, which clears the slot (review finding, regression-tested); typed `Dictionary[K,V]` remains a follow-up per the maintainer's PR-shape decision on the issue.
- **#678 — editor semi-freeze during plugin init/reload on contended ports.** `start_server`'s contended branch chained port scrapes (lsof/netstat/PowerShell), per-PID cmdline brand shells, an 800ms HTTP status-probe busy-wait, and up to 3s of `_wait_for_port_free` — synchronously on the main thread (same family as #238/#239). `start_server` and `recover_strong_port_occupant` are now coroutines: blocking sections run on `WorkerThreadPool` via a `_run_blocking` primitive while the main thread keeps pumping frames. Safety rails: `defer_blocking_work` defaults off so the synchronous characterization tests keep call-then-assert behavior (the real plugin enables it in `_enter_tree`, which test fixtures never reach); an async-generation counter bumped by `stop_server` cancels in-flight startup on teardown; a re-entrancy guard blocks double-starts; EditorSettings reads/writes stay main-thread-only (the managed record is injected into the proof helper via a new `record_override` param); the trace counters bumped off-thread are mutex-guarded. `stop_server` stays synchronous — `_exit_tree` teardown must complete, and its wait is bounded at 2s.

## Verification

- Full GDScript suite live against the editor: **1709/1728 passed, 0 failed** (includes 15 typed-array tests, 2 self-update tests, and 4 async-startup tests; lifecycle characterization suites all green through the synchronous inline path).
- Both `ci-stale-server-smoke` modes pass back-to-back locally **with the async startup path active** — the two #678 repro scenarios (foreign-occupant INCOMPATIBLE diagnosis and stale kill+respawn) work end-to-end, and the #671 drain absorbs the between-runs reap window.
- `pytest` green; `ruff check` clean; hook exercised live (blocked-download error path, version-keyed reuse, pruning, headless editor + server bring-up).

Not addressed here: #651 stage 2 / #670 (gated on post-release telemetry), #612 stages 2–3 (per maintainer's staging), #518 (needs fleet data on 2.9.2+), #574 (needs a Windows machine), #498 (deferred by design discussion), #680 (open PR #681).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZkpsWbMrFMHxfVm42T2ks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for setting typed arrays with automatic conversion for values such as numbers, colors, vectors, and nested arrays.
  - Improved asynchronous startup and recovery to prevent stale server processes from reappearing during shutdown or restart.

- **Bug Fixes**
  - Updates now require checksum verification before installation.
  - Improved handling of unavailable servers, port conflicts, and startup retries.
  - Godot sessions now use version-specific caching and Godot 4.7.

- **Documentation**
  - Clarified server ownership, adoption, and lifecycle behavior during editor restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->