### PR TITLE
Brand-gate every kill path against PID reuse

### DIFF
--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -1179,7 +1179,20 @@ func _evaluate_strong_port_occupant_proof(port: int, live: Dictionary = {}, reco
 		and not record_version.is_empty()
 		and str(current_live.get("version", "")) == record_version
 	):
-		return {"proof": "status_matches_record", "pids": listener_pids}
+		## Brand-check every listener before returning it as a kill target
+		## (#686): the /godot-ai/status match proves *a* godot-ai server owns
+		## the port, but `listener_pids` is a raw scrape that can include an
+		## unrelated process sharing the port number (e.g. a ::1-only
+		## listener lsof reports alongside our IPv4 one). The other two tiers
+		## brand-check every target (#525); this tier feeds the fully
+		## automatic start_server drift-kill path, so it must too.
+		var branded_listeners: Array[int] = []
+		for pid in listener_pids:
+			var listener_pid := int(pid)
+			if _pid_cmdline_is_godot_ai_for_proof(listener_pid):
+				branded_listeners.append(listener_pid)
+		if not branded_listeners.is_empty():
+			return {"proof": "status_matches_record", "pids": branded_listeners}
 
 	return result
 
@@ -1713,11 +1726,23 @@ func stop_dev_server() -> void:
 		print("MCP | stopped dev server on port %d" % port)
 
 
-func _kill_processes_and_windows_spawn_children(pids: Array[int]) -> Array[int]:
+## `verify_brand`: re-check `pid_alive` + the godot-ai cmdline brand
+## immediately before the kill (#686). Pass true when the proof that
+## nominated `pids` was evaluated in an earlier scheduling window (e.g.
+## `recover_strong_port_occupant`'s proof runs in one `_run_blocking` task
+## and the kill in a second, with main-thread frames in between) — a branded
+## target that exits in that gap can have its PID recycled to an innocent
+## process. Default false preserves the intentionally-unbranded call sites
+## (the dock's explicit-consent Restart button, orphan spawn workers whose
+## parent died so brand detection misses them).
+func _kill_processes_and_windows_spawn_children(pids: Array[int], verify_brand: bool = false) -> Array[int]:
 	var unique: Array[int] = []
 	for pid in pids:
-		if pid > 0 and not unique.has(pid):
-			unique.append(pid)
+		if pid <= 0 or unique.has(pid):
+			continue
+		if verify_brand and not (_pid_alive_for_proof(pid) and _pid_cmdline_is_godot_ai_for_proof(pid)):
+			continue
+		unique.append(pid)
 	if OS.get_name() == "Windows":
 		for child_pid in _find_windows_spawn_children(unique):
 			if not unique.has(child_pid):

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -965,7 +965,10 @@ func recover_strong_port_occupant(port: int, wait_s: float, pre_kill_live: Dicti
 	var freed := bool(await _run_blocking(func() -> Variant:
 		if not is_instance_valid(_host):
 			return false
-		var killed: Array = _host._kill_processes_and_windows_spawn_children(targets)
+		## verify_brand=true: the proof above ran in a separate _run_blocking
+		## task with main-thread frames in between — re-check each target at
+		## kill time so a PID recycled inside that gap isn't killed (#686).
+		var killed: Array = _host._kill_processes_and_windows_spawn_children(targets, true)
 		if not killed.is_empty():
 			print("MCP | killed pids %s on port %d" % [str(killed), port])
 		_host._wait_for_port_free(port, wait_s)
@@ -995,7 +998,21 @@ func stop_server() -> void:
 	## `OS.kill` is `TerminateProcess` which doesn't walk the child tree.
 	var port := ClientConfigurator.http_port()
 	var killed: Array = []
-	var candidates: Array[int] = [int(_server_pid)]
+	var candidates: Array[int] = []
+	## Re-verify the tracked PID at kill time (#686): nothing clears
+	## `_server_pid` when the server dies mid-session (`check_server_health`
+	## stops watching after SERVER_WATCH_MS), so hours later the kernel may
+	## have recycled this PID to an unrelated process. Every other candidate
+	## in this function is brand-gated; the tracked seed must be too. A false
+	## negative is fail-safe: the port stays held and the record is preserved,
+	## so the next start_server's drift branch retries the kill.
+	var tracked_pid := int(_server_pid)
+	if (
+		tracked_pid > 0
+		and _host._pid_alive_for_proof(tracked_pid)
+		and _host._pid_cmdline_is_godot_ai_for_proof(tracked_pid)
+	):
+		candidates.append(tracked_pid)
 	var real_pid := int(_host._find_managed_pid(port))
 	## Add the real Python PID only if it isn't already tracked and proves out
 	## as ours — re-appending an already-present PID just produces a duplicate
@@ -1158,8 +1175,20 @@ func force_restart_server() -> void:
 	## reloader parent AND a worker child — killing only one (or zero,
 	## if the single-pid parse fell over on multi-line lsof output) leaves
 	## the other holding the port past `_wait_for_port_free`'s window.
+	##
+	## Brand-gate each raw listener PID (#686): `can_restart_managed_server()`
+	## only proves we once managed *a* server, not that the port's current
+	## occupants are ours — an adopted server that exited on its own can be
+	## replaced on the port by an unrelated dev tool before the user clicks
+	## Restart. Unbranded PIDs fall through to `_set_incompatible_server`
+	## below instead of being killed.
 	transition_state(McpServerStateScript.STOPPING)
-	_host._kill_processes_and_windows_spawn_children(_host._find_all_pids_on_port(port))
+	var restart_targets: Array[int] = []
+	for pid in _host._find_all_pids_on_port(port):
+		var listener_pid := int(pid)
+		if _host._pid_cmdline_is_godot_ai_for_proof(listener_pid):
+			restart_targets.append(listener_pid)
+	_host._kill_processes_and_windows_spawn_children(restart_targets)
 	_host._wait_for_port_free(port, 5.0)
 	if _host._is_port_in_use(port):
 		## Kill failed; clean baseline for the follow-up

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -58,13 +58,18 @@ class _ProofPlugin extends GodotAiPlugin:
 			return bool(port_in_use_sequence.pop_front())
 		return port_in_use
 
-	func _kill_processes_and_windows_spawn_children(pids: Array[int]) -> Array[int]:
+	func _kill_processes_and_windows_spawn_children(pids: Array[int], verify_brand: bool = false) -> Array[int]:
+		var accepted: Array[int] = []
 		for pid in pids:
+			## Mirror production's kill-time re-check (#686) against the
+			## stub's alive/branded lists so tests can exercise the
+			## proof→kill TOCTOU gap.
+			if verify_brand and not (alive_pids.has(pid) and branded_pids.has(pid)):
+				continue
+			accepted.append(pid)
 			if not killed_targets.has(pid):
 				killed_targets.append(pid)
-		var killed: Array[int] = []
-		killed.assign(pids)
-		return killed
+		return accepted
 
 	func _wait_for_port_free(_port: int, _timeout_s: float) -> void:
 		waited_calls += 1
@@ -592,6 +597,9 @@ func test_legacy_pidfile_proof_rejects_unbranded_pidfile_pid() -> void:
 func test_strong_proof_accepts_status_matching_managed_record_version() -> void:
 	var plugin := _ProofPlugin.new()
 	plugin.listener_pids = [13579] as Array[int]
+	## The status tier now brand-checks each listener before nominating it
+	## as a kill target (#686) — a genuinely-ours occupant is branded.
+	plugin.branded_pids = [13579] as Array[int]
 	plugin.managed_record = {"pid": 0, "version": "2.1.0", "ws_port": 9500}
 	plugin.live_status = {"name": "godot-ai", "version": "2.1.0", "ws_port": 9500, "status_code": 200}
 
@@ -602,6 +610,45 @@ func test_strong_proof_accepts_status_matching_managed_record_version() -> void:
 	var pids: Array[int] = []
 	pids.assign(proof.get("pids", []))
 	assert_eq(pids, [13579] as Array[int])
+
+
+func test_strong_proof_status_tier_filters_unbranded_listeners() -> void:
+	## #686: /godot-ai/status matching the record proves *a* godot-ai server
+	## owns the port, but the raw listener scrape can include an unrelated
+	## process sharing the port number (e.g. a ::1-only listener). Only
+	## branded PIDs may be nominated to the automatic drift-kill path.
+	var plugin := _ProofPlugin.new()
+	plugin.listener_pids = [13579, 24680] as Array[int]
+	plugin.branded_pids = [13579] as Array[int]
+	plugin.managed_record = {"pid": 0, "version": "2.1.0", "ws_port": 9500}
+	plugin.live_status = {"name": "godot-ai", "version": "2.1.0", "ws_port": 9500, "status_code": 200}
+
+	var proof := plugin._evaluate_strong_port_occupant_proof(TEST_PORT)
+	plugin.free()
+
+	assert_eq(proof.get("proof", ""), "status_matches_record")
+	var pids: Array[int] = []
+	pids.assign(proof.get("pids", []))
+	assert_eq(pids, [13579] as Array[int],
+		"the unbranded co-listener must be filtered out of the kill list")
+
+
+func test_strong_proof_status_tier_requires_at_least_one_branded_listener() -> void:
+	var plugin := _ProofPlugin.new()
+	plugin.listener_pids = [24680] as Array[int]
+	## No branded PIDs at all: the tier must not fire, even though the
+	## status probe matched the record version.
+	plugin.managed_record = {"pid": 0, "version": "2.1.0", "ws_port": 9500}
+	plugin.live_status = {"name": "godot-ai", "version": "2.1.0", "ws_port": 9500, "status_code": 200}
+
+	var proof := plugin._evaluate_strong_port_occupant_proof(TEST_PORT)
+	plugin.free()
+
+	assert_eq(proof.get("proof", ""), "")
+	var pids: Array[int] = []
+	pids.assign(proof.get("pids", []))
+	assert_true(pids.is_empty(),
+		"status-matches-record with zero branded listeners must not authorize a kill")
 
 
 func test_strong_proof_rejects_status_name_only() -> void:
@@ -1047,6 +1094,9 @@ func test_force_restart_preserves_record_when_port_remains_held() -> void:
 	var plugin := _ProofPlugin.new()
 	plugin.port_in_use = true
 	plugin.listener_pids = [24680] as Array[int]
+	## force_restart brand-gates each raw listener PID now (#686), so the
+	## kill-attempted-but-port-still-held scenario needs a branded occupant.
+	plugin.branded_pids = [24680] as Array[int]
 	plugin.managed_record = {"pid": 24680, "version": "old-managed-for-test", "ws_port": 9500}
 	plugin.live_status = {"name": "other-server", "version": "old-managed-for-test", "ws_port": 9500, "status_code": 200}
 
@@ -1059,6 +1109,54 @@ func test_force_restart_preserves_record_when_port_remains_held() -> void:
 	assert_eq(int(status.get("state", -1)), McpServerState.INCOMPATIBLE)
 	assert_eq(killed, [24680] as Array[int])
 	assert_eq(clear_calls, 0, "force restart must not clear ownership while the port is still held")
+
+
+func test_force_restart_does_not_kill_unbranded_port_occupant() -> void:
+	## #686: can_restart_managed_server() proves we once managed *a* server
+	## (stale record), not that the port's CURRENT occupant is ours. An
+	## adopted server that exited on its own can be replaced on the port by
+	## an unrelated dev tool before the user clicks Restart — that process
+	## must survive the click.
+	var plugin := _ProofPlugin.new()
+	plugin.port_in_use = true
+	plugin.listener_pids = [24680] as Array[int]
+	## 24680 is NOT branded — an unrelated tool that bound the port.
+	plugin.managed_record = {"pid": 0, "version": "old-managed-for-test", "ws_port": 9500}
+	plugin.live_status = {"name": "other-server", "version": "", "ws_port": 0, "status_code": 200}
+
+	plugin.force_restart_server()
+	var killed := plugin.killed_targets.duplicate()
+	plugin.free()
+
+	assert_true(killed.is_empty(),
+		"force restart must not kill an unbranded process that took over the port")
+
+
+## Overrides only the proof helpers, NOT the kill helper — so the
+## verify_brand test below exercises plugin.gd's production filter body.
+## Safe: every PID is filtered out before any OS.kill/taskkill runs.
+class _BrandFilterHost extends GodotAiPlugin:
+	func _pid_alive_for_proof(pid: int) -> bool:
+		return pid == 55555
+
+	func _pid_cmdline_is_godot_ai_for_proof(_pid: int) -> bool:
+		return false
+
+
+func test_kill_helper_verify_brand_filters_at_kill_time() -> void:
+	## #686: proof evaluation and the kill can run in separate scheduling
+	## windows (recover_strong_port_occupant's two _run_blocking tasks). A
+	## target that died — or lost its brand to PID recycling — inside that
+	## gap must be dropped by the kill helper itself when verify_brand is
+	## passed, before any signal is sent.
+	var plugin := _BrandFilterHost.new()
+	var killed := plugin._kill_processes_and_windows_spawn_children(
+		[55555, 66666] as Array[int], true
+	)
+	plugin.free()
+
+	assert_true(killed.is_empty(),
+		"alive-but-unbranded (55555) and dead (66666) targets must both be filtered")
 
 
 func test_recover_incompatible_returns_false_and_leaves_state_when_port_remains_held() -> void:
@@ -1361,6 +1459,7 @@ func test_dev_server_detection_accepts_branded_port_listener() -> void:
 func test_strong_proof_uses_provided_live_without_probing() -> void:
 	var plugin := _ProofPlugin.new()
 	plugin.listener_pids = [13579] as Array[int]
+	plugin.branded_pids = [13579] as Array[int]
 	plugin.managed_record = {"pid": 0, "version": "2.1.0", "ws_port": 9500}
 	var caller_live := {"name": "godot-ai", "version": "2.1.0", "ws_port": 9500, "status_code": 200}
 
@@ -1375,6 +1474,7 @@ func test_strong_proof_uses_provided_live_without_probing() -> void:
 func test_strong_proof_probes_when_live_omitted() -> void:
 	var plugin := _ProofPlugin.new()
 	plugin.listener_pids = [13579] as Array[int]
+	plugin.branded_pids = [13579] as Array[int]
 	plugin.managed_record = {"pid": 0, "version": "2.1.0", "ws_port": 9500}
 	plugin.live_status = {"name": "godot-ai", "version": "2.1.0", "ws_port": 9500, "status_code": 200}
 
@@ -1413,6 +1513,7 @@ func test_recover_strong_port_occupant_threads_live_to_proof() -> void:
 	plugin.listener_pids = [13579] as Array[int]
 	plugin.managed_record = {"pid": 13579, "version": "2.1.0", "ws_port": 9500}
 	plugin.alive_pids = [13579] as Array[int]
+	plugin.branded_pids = [13579] as Array[int]
 	plugin.port_in_use_sequence = [false] as Array[bool]
 	var caller_live := {"name": "godot-ai", "version": "2.1.0", "ws_port": 9500, "status_code": 200}
 

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -57,13 +57,18 @@ class _ManagerHostStub extends GodotAiPlugin:
 			return bool(port_in_use_sequence.pop_front())
 		return port_in_use
 
-	func _kill_processes_and_windows_spawn_children(pids: Array[int]) -> Array[int]:
+	func _kill_processes_and_windows_spawn_children(pids: Array[int], verify_brand: bool = false) -> Array[int]:
+		var accepted: Array[int] = []
 		for pid in pids:
+			## Mirror production's kill-time re-check (#686) against the
+			## stub's alive/branded lists so tests can exercise the
+			## proof→kill TOCTOU gap.
+			if verify_brand and not (alive_pids.has(pid) and branded_pids.has(pid)):
+				continue
+			accepted.append(pid)
 			if not killed_targets.has(pid):
 				killed_targets.append(pid)
-		var killed: Array[int] = []
-		killed.assign(pids)
-		return killed
+		return accepted
 
 	func _wait_for_port_free(_port: int, _timeout_s: float) -> void:
 		pass
@@ -230,7 +235,10 @@ func test_stop_aggregates_launcher_pidfile_and_branded_listener_pids() -> void:
 	var host := _ManagerHostStub.new()
 	host.managed_pid_lookup = 22222
 	host.listener_pids = [33333] as Array[int]
-	host.branded_pids = [22222, 33333] as Array[int]
+	## The tracked PID is brand-gated at kill time too now (#686), so the
+	## live managed-server scenario seeds it alive + branded.
+	host.alive_pids = [11111] as Array[int]
+	host.branded_pids = [11111, 22222, 33333] as Array[int]
 	var manager := McpServerLifecycleManagerScript.new(host)
 	manager._server_pid = 11111
 
@@ -250,6 +258,8 @@ func test_stop_does_not_trust_unbranded_managed_pid_fallback() -> void:
 	var host := _ManagerHostStub.new()
 	host.managed_pid_lookup = 22222
 	host.listener_pids = [22222] as Array[int]
+	host.alive_pids = [11111] as Array[int]
+	host.branded_pids = [11111] as Array[int]
 	var manager := McpServerLifecycleManagerScript.new(host)
 	manager._server_pid = 11111
 
@@ -268,6 +278,8 @@ func test_stop_does_not_kill_unbranded_port_listeners() -> void:
 	## just because they share the configured HTTP port.
 	var host := _ManagerHostStub.new()
 	host.listener_pids = [33333] as Array[int]
+	host.alive_pids = [11111] as Array[int]
+	host.branded_pids = [11111] as Array[int]
 	var manager := McpServerLifecycleManagerScript.new(host)
 	manager._server_pid = 11111
 
@@ -278,6 +290,43 @@ func test_stop_does_not_kill_unbranded_port_listeners() -> void:
 	assert_eq(killed.size(), 1)
 	assert_true(killed.has(11111))
 	assert_false(killed.has(33333))
+
+
+func test_stop_does_not_kill_recycled_tracked_pid() -> void:
+	## #686: nothing clears `_server_pid` when the server dies mid-session
+	## (the health watch stops after SERVER_WATCH_MS). If the kernel
+	## recycled the PID to an unrelated process by the time the user quits
+	## Godot, stop_server must not kill it: the tracked seed is now gated on
+	## alive + branded like every other candidate.
+	var host := _ManagerHostStub.new()
+	host.alive_pids = [11111] as Array[int]
+	## Alive but NOT branded — the recycled-PID shape.
+	var manager := McpServerLifecycleManagerScript.new(host)
+	manager._server_pid = 11111
+
+	manager.stop_server()
+	var killed := host.killed_targets.duplicate()
+	host.free()
+
+	assert_true(killed.is_empty(),
+		"a tracked PID that no longer passes the brand check must not be killed")
+
+
+func test_stop_does_not_kill_dead_tracked_pid() -> void:
+	## Dead tracked PID: branded lists can be stale too — a PID that is not
+	## alive must be skipped without OS.kill ever seeing it.
+	var host := _ManagerHostStub.new()
+	host.branded_pids = [11111] as Array[int]
+	## Not in alive_pids — the server crashed hours ago.
+	var manager := McpServerLifecycleManagerScript.new(host)
+	manager._server_pid = 11111
+
+	manager.stop_server()
+	var killed := host.killed_targets.duplicate()
+	host.free()
+
+	assert_true(killed.is_empty(),
+		"a dead tracked PID must not be forwarded to the kill helper")
 
 
 func test_stop_invokes_finalize_for_record_cleanup() -> void:


### PR DESCRIPTION
## Summary

Fixes #686. Kernel PID recycling turned four server-kill paths into "kill an innocent process" hazards — each trusted a PID that was branded (or merely recorded) earlier and SIGKILL/taskkill'd it later with no re-verification:

- **`stop_server`** seeded its candidate list with the tracked `_server_pid` unconditionally; nothing clears it when the server dies mid-session, so quitting Godot hours after a server crash could kill whatever process the OS recycled the PID to. The tracked seed is now gated on `_pid_alive_for_proof` + `_pid_cmdline_is_godot_ai_for_proof` like every other candidate. A false negative is fail-safe: the port stays held for the next drift retry.
- **`force_restart_server`** killed the raw `_find_all_pids_on_port` scrape gated only by `can_restart_managed_server()` — proof we once managed *a* server, not that the current occupants are ours. Each listener PID is now brand-checked; unbranded occupants fall through to the existing `_set_incompatible_server` diagnosis instead of being killed.
- **`_evaluate_strong_port_occupant_proof`**'s `status_matches_record` tier returned the unfiltered listener scrape while its sibling tiers brand-check every target (#525) — and this tier feeds the fully automatic `start_server` drift-kill path. Listeners are now filtered through the brand check and the tier only fires when at least one branded PID survives.
- **`recover_strong_port_occupant`** evaluates proof in one `_run_blocking` task and kills in a second, with main-thread frames in between — a branded target exiting in that gap can hand its PID to an innocent process. `_kill_processes_and_windows_spawn_children` gains a `verify_brand` param that re-checks alive+brand immediately before the kill; the strong-recovery call site passes true, the intentionally-unbranded sites (explicit-consent dock Restart, orphan spawn workers) are unchanged.

## Testing

Full gauntlet run in the authoring session: ruff, pytest (1307 passed), `ci-check-gdscript`, `ci-godot-tests` (1720/1738, 0 failed), plus `ci-stale-server-smoke` in BOTH modes — stale (branded kill+respawn still fires, fresh server verified) and foreign (unbranded occupant survives, non-recoverable INCOMPATIBLE diagnosis with suggested free port). New tests cover the recycled/dead tracked PID, the unbranded force-restart occupant, the status-tier listener filter, and the kill-time `verify_brand` filter.

*Provenance: authored by the Phase-1 audit worker session per `docs/audit-tier2-plan.md`; that session couldn't push, so the commit was transported as a git patch and applied verbatim onto latest `origin/main`.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2zhpWvnqijYYRW3dwtUhV

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2zhpWvnqijYYRW3dwtUhV)_