### PR TITLE
Fix self-update write-verification gaps; document checksum's real guarantee

### DIFF
--- a/plugin/addons/godot_ai/clients/_atomic_write.gd
+++ b/plugin/addons/godot_ai/clients/_atomic_write.gd
@@ -66,6 +66,16 @@ static func write(path: String, content: String) -> bool:
 	# which preserves it.
 	_apply_mode(tmp_path, target_mode)
 
+	# Verify the staged temp landed intact before committing it anywhere. The
+	# copy-fallback path below already guards this (`_written_size_matches` at
+	# the rename-fallback check); the rename path was the one gap — under
+	# disk-full/quota the temp can be silently truncated, and an unverified
+	# rename would swap a truncated file over the live target while the
+	# caller is told the write succeeded (#687).
+	if not _written_size_matches(tmp_path, content):
+		DirAccess.remove_absolute(tmp_path)
+		return false
+
 	# Best-effort: snapshot the prior file before we touch the target so we
 	# can restore on a failed swap. The backup is also kept on success as a
 	# one-shot rollback aid for the user — give it the same (preserved) mode

--- a/plugin/addons/godot_ai/update_reload_runner.gd
+++ b/plugin/addons/godot_ai/update_reload_runner.gd
@@ -374,13 +374,24 @@ func _install_zip_file(
 			FileAccess.get_open_error(),
 		])
 		return {}
-	f.store_buffer(content)
+	## `store_buffer` reports a short write only via its return value — it
+	## does NOT set the last-error state `get_error()` reads — and the write
+	## is stdio-buffered, so disk-full surfaces at flush/close, not here.
+	## Capture the return and re-verify the on-disk size after close() so a
+	## disk-full "succeeds" write can't rename a truncated file over the
+	## live target (#687).
+	var stored := f.store_buffer(content)
+	f.flush()
 	var write_error := f.get_error()
 	f.close()
-	if write_error != OK:
-		print("MCP | update extract failed: write error %d for %s" % [
+	var written_size := FileAccess.get_file_as_bytes(temp_path).size() if FileAccess.file_exists(temp_path) else -1
+	if not stored or write_error != OK or written_size != content.size():
+		print("MCP | update extract failed: write error %d for %s (stored=%s size=%d expected=%d)" % [
 			write_error,
 			temp_path,
+			stored,
+			written_size,
+			content.size(),
 		])
 		DirAccess.remove_absolute(temp_path)
 		return {}

--- a/plugin/addons/godot_ai/update_reload_runner.gd
+++ b/plugin/addons/godot_ai/update_reload_runner.gd
@@ -384,9 +384,16 @@ func _install_zip_file(
 	f.flush()
 	var write_error := f.get_error()
 	f.close()
-	var written_size := FileAccess.get_file_as_bytes(temp_path).size() if FileAccess.file_exists(temp_path) else -1
+	## get_length() on a read handle, not get_file_as_bytes().size() — the
+	## latter re-reads the whole file into memory per extracted entry just
+	## to learn its length.
+	var written_size := -1
+	var verify := FileAccess.open(temp_path, FileAccess.READ)
+	if verify != null:
+		written_size = verify.get_length()
+		verify.close()
 	if not stored or write_error != OK or written_size != content.size():
-		print("MCP | update extract failed: write error %d for %s (stored=%s size=%d expected=%d)" % [
+		print("MCP | update extract failed: write validation failed (error %d) for %s (stored=%s size=%d expected=%d)" % [
 			write_error,
 			temp_path,
 			stored,

--- a/plugin/addons/godot_ai/utils/update_manager.gd
+++ b/plugin/addons/godot_ai/utils/update_manager.gd
@@ -403,9 +403,16 @@ func _on_download_completed(
 
 ## Gate the extract on a SHA-256 match against the release's checksum sidecar.
 ## TLS + host pinning already constrain where the bytes came from; this
-## verifies the bytes themselves so a tampered asset (or a compromised CDN
-## object) can't be installed over live plugin code. Verification is
-## MANDATORY (#599): a release published without a `.sha256` sidecar —
+## verifies the bytes themselves, guarding against in-transit corruption and
+## single-object substitution (a tampered CDN edge, a partial/garbled
+## download). It is NOT protection against a compromised release: both
+## `download_url` and `checksum_url` come from the same GitHub Releases API
+## response over the same channel (`parse_releases_response`), so anyone able
+## to modify the release's assets (leaked repo token, compromised release
+## workflow) can regenerate the sidecar to match a tampered zip (#687
+## follow-up: signing the sidecar with a key outside the release workflow's
+## default token scope closes this gap; not yet implemented). Verification
+## is MANDATORY (#599): a release published without a `.sha256` sidecar —
 ## mistake or tamper — refuses to install rather than silently downgrading
 ## to an unverified install. This is safe because self-update only ever
 ## verifies the *next* download, and every release since #523 publishes the

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -1520,6 +1520,33 @@ func test_atomic_write_cleans_up_tmp_on_success() -> void:
 	)
 
 
+func test_atomic_write_written_size_matches_detects_match() -> void:
+	## Direct unit test of the primitive the rename-commit gate (#687) relies
+	## on: an intact write must report a match.
+	var path := _scratch_dir.path_join("size_match_ok.txt")
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	f.store_string("hello world")
+	f.close()
+	assert_true(McpAtomicWrite._written_size_matches(path, "hello world"))
+
+
+func test_atomic_write_written_size_matches_detects_truncation() -> void:
+	## Simulates the disk-full failure mode #687 guards against: the on-disk
+	## file is shorter than what was supposed to be written (a truncated
+	## store_string). `_written_size_matches` must catch the mismatch so the
+	## rename-commit gate added to `write()` can refuse to commit it.
+	var path := _scratch_dir.path_join("size_match_truncated.txt")
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	f.store_string("hello")  # on-disk bytes shorter than the intended content
+	f.close()
+	assert_false(McpAtomicWrite._written_size_matches(path, "hello world"))
+
+
+func test_atomic_write_written_size_matches_missing_file() -> void:
+	var missing := _scratch_dir.path_join("does_not_exist.txt")
+	assert_false(McpAtomicWrite._written_size_matches(missing, "anything"))
+
+
 func test_atomic_write_preserves_destination_when_swap_fails() -> void:
 	## Direct simulation of a Windows AV / lock failure is not portable, but
 	## the on-disk invariant for #297 finding #10 is testable: when the


### PR DESCRIPTION
## Summary

Addresses findings 2 and 3 of #687 (the mechanical write-verification items — no design call):

- **`update_reload_runner.gd` `_install_zip_file`**: `store_buffer()` reports a short write only via its return value — it does not set the last-error state `get_error()` reads — and the write is stdio-buffered, so disk-full surfaces at flush/close. Now captures `store_buffer`'s return, flushes before checking `get_error()`, and verifies the on-disk temp file's size matches the intended content before treating the write as successful. A mismatch removes the temp and returns `{}`, engaging the existing rollback path instead of renaming a truncated file over a live plugin target.
- **`_atomic_write.gd` `write()`**: the copy-fallback path already guarded against a truncated temp via `_written_size_matches` before committing; the rename path did not. The same check now runs right after staging the temp (before the backup snapshot), so a disk-full/quota truncation can't get renamed over the user's MCP config with `write()` reporting success.
- **`_verify_then_install`'s docstring** now states the checksum's actual guarantee: integrity against in-transit corruption and single-object substitution, not against a compromised release (`download_url` and `checksum_url` come from the same API response over the same channel).

**Not included:** finding 1 of #687 (embed an ed25519/minisign key and sign the release checksum sidecar) is the flagged infra/key-management design decision, left for the maintainer — so this PR does not close #687.

## Testing

Gauntlet run in the authoring session: ruff, pytest (1307 passed), `ci-check-gdscript`, `ci-godot-tests` (0 failed) all green. New `test_clients.gd` cases cover the truncation guards.

> **⚠️ Maintainer note:** this touches the self-update write path, so per AGENTS.md it needs `script/local-self-update-smoke` sign-off. That harness requires an interactive GUI Godot editor and a manual "click Update in the dock" step, which the headless authoring session could not perform. **Please run it before merging.**

*Provenance: authored by the Phase-1 audit worker session per `docs/audit-tier2-plan.md`; that session couldn't push, so the commit was transported as a git patch and applied verbatim onto latest `origin/main`.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2zhpWvnqijYYRW3dwtUhV

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2zhpWvnqijYYRW3dwtUhV)_