### PR TITLE
Stop non-finite floats (NaN/Infinity) crossing the wire in either direction

### DIFF
--- a/plugin/addons/godot_ai/utils/variant_serializer.gd
+++ b/plugin/addons/godot_ai/utils/variant_serializer.gd
@@ -4,29 +4,60 @@ extends RefCounted
 ## Converts Godot Variants into values that can be encoded as JSON.
 
 
+## Non-finite floats (NaN/INF) have no JSON representation: JSON.stringify
+## emits them as the bare tokens `inf`/`nan`, which are invalid JSON — the
+## server drops the whole frame and the pending request times out (#688).
+## Serialize them as null instead (the same choice web JSON.stringify makes),
+## applied uniformly across the supported 4.5+ floor — no version gate, so
+## wire output is identical on every supported engine.
+static func _safe_float(f: float) -> Variant:
+	return f if is_finite(f) else null
+
+
 static func serialize(value: Variant) -> Variant:
 	if value == null:
 		return null
 	match typeof(value):
-		TYPE_BOOL, TYPE_INT, TYPE_FLOAT, TYPE_STRING:
+		TYPE_BOOL, TYPE_INT, TYPE_STRING:
 			return value
+		TYPE_FLOAT:
+			return _safe_float(value)
 		TYPE_STRING_NAME:
 			return str(value)
-		TYPE_VECTOR2, TYPE_VECTOR2I:
+		# Integer vector types are listed separately from their float twins so
+		# int components stay ints on the wire (no float coercion via
+		# _safe_float's typed parameter).
+		TYPE_VECTOR2I:
 			return {"x": value.x, "y": value.y}
-		TYPE_VECTOR3, TYPE_VECTOR3I:
+		TYPE_VECTOR2:
+			return {"x": _safe_float(value.x), "y": _safe_float(value.y)}
+		TYPE_VECTOR3I:
 			return {"x": value.x, "y": value.y, "z": value.z}
-		TYPE_VECTOR4, TYPE_VECTOR4I, TYPE_QUATERNION:
+		TYPE_VECTOR3:
+			return {"x": _safe_float(value.x), "y": _safe_float(value.y), "z": _safe_float(value.z)}
+		TYPE_VECTOR4I:
 			return {"x": value.x, "y": value.y, "z": value.z, "w": value.w}
+		TYPE_VECTOR4, TYPE_QUATERNION:
+			return {
+				"x": _safe_float(value.x),
+				"y": _safe_float(value.y),
+				"z": _safe_float(value.z),
+				"w": _safe_float(value.w),
+			}
 		TYPE_COLOR:
-			return {"r": value.r, "g": value.g, "b": value.b, "a": value.a}
+			return {
+				"r": _safe_float(value.r),
+				"g": _safe_float(value.g),
+				"b": _safe_float(value.b),
+				"a": _safe_float(value.a),
+			}
 		TYPE_RECT2, TYPE_RECT2I, TYPE_AABB:
 			return {
 				"position": serialize(value.position),
 				"size": serialize(value.size),
 			}
 		TYPE_PLANE:
-			return {"normal": serialize(value.normal), "d": value.d}
+			return {"normal": serialize(value.normal), "d": _safe_float(value.d)}
 		TYPE_BASIS:
 			return {
 				"x": serialize(value.x),

--- a/src/godot_ai/godot_client/client.py
+++ b/src/godot_ai/godot_client/client.py
@@ -14,6 +14,7 @@ from godot_ai.godot_client.session_diagnostics import (
     session_not_found_data,
     session_not_found_message,
 )
+from godot_ai.protocol.envelope import find_non_finite_float
 from godot_ai.protocol.errors import ErrorCode
 from godot_ai.sessions.registry import SessionRegistry
 from godot_ai.transport.websocket import GodotWebSocketServer
@@ -131,7 +132,25 @@ class GodotClient:
         Raises GodotCommandError(PLUGIN_DISCONNECTED) when the per-session
         transport circuit is open (death-spiral protection — see
         ``EditorBridgeCircuitBreaker``).
+        Raises GodotCommandError(INVALID_PARAMS) when params contain a
+        non-finite float — JSON cannot represent NaN/Infinity, and
+        ``model_dump_json`` would silently serialize it as null, corrupting
+        the value the plugin stores (#688).
         """
+        ## Rejected before session resolution: bad params are a caller error
+        ## regardless of editor state, and must not count as a transport
+        ## failure against the circuit breaker.
+        non_finite_path = find_non_finite_float(params) if params else None
+        if non_finite_path is not None:
+            raise GodotCommandError(
+                code=ErrorCode.INVALID_PARAMS,
+                message=(
+                    f"non-finite float in param '{non_finite_path}' — "
+                    "NaN/Infinity cannot be represented in JSON; send a finite "
+                    "number or omit the param"
+                ),
+            )
+
         ## Resolve the active session first so the circuit check below
         ## keys on a concrete session_id when possible. The no-session
         ## sentinel is only used when there genuinely is no session —

--- a/src/godot_ai/protocol/envelope.py
+++ b/src/godot_ai/protocol/envelope.py
@@ -2,10 +2,35 @@
 
 from __future__ import annotations
 
+import math
 from typing import Any
 from uuid import uuid4
 
 from pydantic import BaseModel, Field
+
+
+def find_non_finite_float(value: Any, path: str = "params") -> str | None:
+    """Return the key path of the first non-finite float in a params tree.
+
+    NaN/Infinity are not representable in JSON: ``model_dump_json`` serializes
+    them as ``null``, so a write-tool param that went NaN upstream (physics
+    blowup, divide-by-zero position) would silently corrupt scene data while
+    the tool reports success (#688). Callers reject the command instead.
+    Returns ``None`` when every float in the tree is finite.
+    """
+    if isinstance(value, float) and not math.isfinite(value):
+        return path
+    if isinstance(value, dict):
+        for key, item in value.items():
+            found = find_non_finite_float(item, f"{path}.{key}")
+            if found is not None:
+                return found
+    elif isinstance(value, (list, tuple)):
+        for index, item in enumerate(value):
+            found = find_non_finite_float(item, f"{path}[{index}]")
+            if found is not None:
+                return found
+    return None
 
 
 class CommandRequest(BaseModel):

--- a/test_project/tests/test_variant_serializer.gd
+++ b/test_project/tests/test_variant_serializer.gd
@@ -1,0 +1,107 @@
+@tool
+extends McpTestSuite
+
+const VariantSerializer := preload("res://addons/godot_ai/utils/variant_serializer.gd")
+
+## Tests for McpVariantSerializer's JSON-safety contract, in particular the
+## #688 non-finite-float clamp: NaN/INF must serialize as null, never reach
+## JSON.stringify as bare `inf`/`nan` tokens (invalid JSON — the server drops
+## the whole frame and the request times out).
+
+
+func suite_name() -> String:
+	return "variant_serializer"
+
+
+func test_finite_float_passes_through() -> void:
+	assert_eq(VariantSerializer.serialize(1.5), 1.5)
+	assert_eq(VariantSerializer.serialize(-0.25), -0.25)
+	assert_eq(VariantSerializer.serialize(0.0), 0.0)
+
+
+func test_nan_serializes_as_null() -> void:
+	assert_eq(VariantSerializer.serialize(NAN), null,
+		"NaN has no JSON representation and must clamp to null (#688)")
+
+
+func test_inf_serializes_as_null() -> void:
+	assert_eq(VariantSerializer.serialize(INF), null)
+	assert_eq(VariantSerializer.serialize(-INF), null)
+
+
+func test_vector2_with_nan_component_clamps_component() -> void:
+	var out: Dictionary = VariantSerializer.serialize(Vector2(NAN, 2.0))
+	assert_eq(out.x, null, "NaN component must clamp to null, not leak into JSON")
+	assert_eq(out.y, 2.0)
+
+
+func test_vector3_with_inf_component_clamps_component() -> void:
+	var out: Dictionary = VariantSerializer.serialize(Vector3(1.0, INF, 3.0))
+	assert_eq(out.x, 1.0)
+	assert_eq(out.y, null)
+	assert_eq(out.z, 3.0)
+
+
+func test_vector2i_components_stay_ints() -> void:
+	var out: Dictionary = VariantSerializer.serialize(Vector2i(3, -7))
+	assert_true(out.x is int, "int vector components must not be coerced to float")
+	assert_eq(out.x, 3)
+	assert_eq(out.y, -7)
+
+
+func test_quaternion_with_nan_component_clamps_component() -> void:
+	var out: Dictionary = VariantSerializer.serialize(Quaternion(NAN, 0.0, 0.0, 1.0))
+	assert_eq(out.x, null)
+	assert_eq(out.w, 1.0)
+
+
+func test_color_with_nan_channel_clamps_channel() -> void:
+	var out: Dictionary = VariantSerializer.serialize(Color(NAN, 0.5, 0.25, 1.0))
+	assert_eq(out.r, null)
+	assert_eq(out.g, 0.5)
+
+
+func test_plane_with_inf_d_clamps_d() -> void:
+	var out: Dictionary = VariantSerializer.serialize(Plane(Vector3.UP, 0.0))
+	assert_eq(out.d, 0.0)
+	var bad := Plane(Vector3(0, 1, 0), INF)
+	var bad_out: Dictionary = VariantSerializer.serialize(bad)
+	assert_eq(bad_out.d, null)
+
+
+func test_nested_dict_with_nan_clamps() -> void:
+	var out: Dictionary = VariantSerializer.serialize({"speed": NAN, "name": "x"})
+	assert_eq(out.speed, null)
+	assert_eq(out.name, "x")
+
+
+func test_array_with_inf_clamps_element() -> void:
+	var out: Array = VariantSerializer.serialize([1.0, INF, 3.0])
+	assert_eq(out[0], 1.0)
+	assert_eq(out[1], null)
+	assert_eq(out[2], 3.0)
+
+
+func test_packed_float_array_with_nan_clamps_element() -> void:
+	var out: Array = VariantSerializer.serialize(PackedFloat64Array([1.0, NAN]))
+	assert_eq(out[0], 1.0)
+	assert_eq(out[1], null)
+
+
+func test_serialized_nan_payload_survives_json_roundtrip() -> void:
+	## End-to-end shape of the #688 failure: a node property dict containing
+	## NaN must stringify to VALID json (parse_string returns non-null).
+	## Pre-clamp, JSON.stringify emitted a bare `nan` token and the server
+	## dropped the frame.
+	var payload: Variant = VariantSerializer.serialize({
+		"position": Vector2(NAN, INF),
+		"health": NAN,
+		"scale": 1.0,
+	})
+	var text := JSON.stringify(payload)
+	var parsed: Variant = JSON.parse_string(text)
+	assert_true(parsed != null, "serialized payload must be valid JSON (got: %s)" % text)
+	assert_eq(parsed.health, null)
+	assert_eq(parsed.scale, 1.0)
+	assert_eq(parsed.position.x, null)
+	assert_eq(parsed.position.y, null)

--- a/test_project/tests/test_variant_serializer.gd.uid
+++ b/test_project/tests/test_variant_serializer.gd.uid
@@ -1,0 +1,1 @@
+uid://bqfobmgr13p64

--- a/tests/unit/test_nonfinite_params.py
+++ b/tests/unit/test_nonfinite_params.py
@@ -1,0 +1,134 @@
+"""Non-finite float rejection on the server->plugin params path (#688).
+
+JSON cannot represent NaN/Infinity. Empirically, pydantic accepts them into
+``dict[str, Any]`` params and ``model_dump_json`` serializes them as ``null``
+— so without a guard, a client whose float computation went NaN calls a write
+tool, the value silently becomes null in transit, and the plugin stores null
+while the tool reports success. ``GodotClient.send`` now rejects such params
+with INVALID_PARAMS naming the offending key path, before the command touches
+the transport or the circuit breaker.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+
+import pytest
+
+from godot_ai.godot_client.circuit_breaker import EditorBridgeCircuitBreaker
+from godot_ai.godot_client.client import GodotClient, GodotCommandError
+from godot_ai.protocol.envelope import CommandRequest, find_non_finite_float
+from godot_ai.sessions.registry import Session, SessionRegistry
+
+
+class _RecordingWsServer:
+    """send_command stub that records calls and returns a canned response."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+
+    async def send_command(self, session_id, command, params=None, timeout=5.0):
+        self.calls.append((command, params or {}))
+        from godot_ai.protocol.envelope import CommandResponse
+
+        return CommandResponse(request_id="r", status="ok", data={})
+
+
+def _make_client() -> tuple[GodotClient, _RecordingWsServer, EditorBridgeCircuitBreaker]:
+    registry = SessionRegistry()
+    registry.register(
+        Session(
+            session_id="proj@abcd",
+            godot_version="4.7",
+            project_path="/tmp/proj",
+            plugin_version="2.9.2",
+        )
+    )
+    registry.set_active("proj@abcd")
+    ws = _RecordingWsServer()
+    breaker = EditorBridgeCircuitBreaker()
+    return GodotClient(ws, registry, circuit_breaker=breaker), ws, breaker
+
+
+class TestFindNonFiniteFloat:
+    def test_none_for_finite_tree(self) -> None:
+        params = {"a": 1.5, "b": [1, 2.0, {"c": -3.25}], "d": "nan", "e": True}
+        assert find_non_finite_float(params) is None
+
+    def test_top_level_nan(self) -> None:
+        assert find_non_finite_float({"speed": float("nan")}) == "params.speed"
+
+    def test_top_level_inf(self) -> None:
+        assert find_non_finite_float({"x": float("inf")}) == "params.x"
+        assert find_non_finite_float({"x": float("-inf")}) == "params.x"
+
+    def test_nested_dict_path(self) -> None:
+        params = {"value": {"position": {"x": 1.0, "y": float("nan")}}}
+        assert find_non_finite_float(params) == "params.value.position.y"
+
+    def test_list_index_path(self) -> None:
+        params = {"points": [1.0, 2.0, float("inf")]}
+        assert find_non_finite_float(params) == "params.points[2]"
+
+    def test_tuple_supported(self) -> None:
+        assert find_non_finite_float({"t": (1.0, float("nan"))}) == "params.t[1]"
+
+    def test_bool_is_not_treated_as_float(self) -> None:
+        ## bool is an int subclass, not float — but guard the assumption.
+        assert find_non_finite_float({"flag": True}) is None
+
+    def test_empty_params(self) -> None:
+        assert find_non_finite_float({}) is None
+
+
+class TestSendRejectsNonFinite:
+    async def test_nan_param_raises_invalid_params_before_transport(self) -> None:
+        client, ws, _ = _make_client()
+        with pytest.raises(GodotCommandError) as exc_info:
+            await client.send("set_property", {"path": "/Main", "value": float("nan")})
+        assert exc_info.value.code == "INVALID_PARAMS"
+        assert "params.value" in exc_info.value.message
+        assert ws.calls == [], "command must never reach the transport"
+
+    async def test_nested_inf_names_key_path(self) -> None:
+        client, ws, _ = _make_client()
+        with pytest.raises(GodotCommandError) as exc_info:
+            await client.send(
+                "set_property",
+                {"value": {"gravity": [0.0, float("-inf")]}},
+            )
+        assert "params.value.gravity[1]" in exc_info.value.message
+        assert ws.calls == []
+
+    async def test_rejection_does_not_trip_circuit_breaker(self) -> None:
+        client, _, breaker = _make_client()
+        for _ in range(10):
+            with pytest.raises(GodotCommandError):
+                await client.send("set_property", {"v": float("nan")})
+        assert breaker.check_open("proj@abcd") is None, (
+            "param validation errors are caller errors, not transport failures"
+        )
+
+    async def test_finite_params_still_sent(self) -> None:
+        client, ws, _ = _make_client()
+        result = await client.send("set_property", {"path": "/Main", "value": 1.5})
+        assert isinstance(result, dict)
+        assert ws.calls == [("set_property", {"path": "/Main", "value": 1.5})]
+
+
+class TestWhyTheGuardExists:
+    def test_model_dump_json_silently_nullifies_nan(self) -> None:
+        """Documents the pydantic behavior the guard defends against: if a
+        NaN ever reached serialization it would become null on the wire."""
+        request = CommandRequest(command="set_property", params={"v": float("nan")})
+        wire = json.loads(request.model_dump_json())
+        assert wire["params"]["v"] is None
+
+    def test_json_loads_accepts_nonstandard_nan_inbound(self) -> None:
+        """Documents that stdlib json.loads accepts non-standard NaN/Infinity
+        tokens, so stringified-params coercion cannot be relied on to reject
+        them — the send-side guard is the enforcement point."""
+        parsed = json.loads('{"v": NaN, "w": Infinity}')
+        assert math.isnan(parsed["v"])
+        assert math.isinf(parsed["w"])


### PR DESCRIPTION
## Summary

Fixes #688, in both directions:

**Plugin → server**: `variant_serializer.gd` returned `TYPE_FLOAT` verbatim, and Godot's `JSON.stringify` emits non-finite floats as the bare tokens `inf`/`nan` — invalid JSON, so the server dropped the whole frame and the pending request waited out its full timeout, misattributed as a transport failure by the circuit breaker. `node_get_properties` on any node with a NaN/INF property (common after physics blowups — exactly when an agent is debugging) made the entire response unparseable. Non-finite floats are now clamped to `null` in `serialize()`: the bare `TYPE_FLOAT` branch plus the raw float components of the Vector2/3/4, Quaternion, Color, and Plane branches (nested/packed shapes recurse through those). Integer vector twins are split into their own match arms so int components stay ints on the wire. **Per the maintainer decision on the flagged design question, the clamp applies uniformly across the supported 4.5+ floor — no version gate** — so wire output is identical on every supported engine.

**Server → plugin**: pydantic accepts NaN/Infinity into dict params and `model_dump_json` serializes them as `null`, so a client whose float went NaN could call a write tool, have the value silently become null in transit, and get success back while the plugin stored null. New `find_non_finite_float()` (`protocol/envelope.py`) rejects such params in `GodotClient.send` with `INVALID_PARAMS` naming the offending key path — before session resolution, so a validation rejection never counts as a transport failure against the circuit breaker.

## Testing

- `tests/unit/test_nonfinite_params.py`: key-path walker, send-side rejection incl. breaker isolation, and characterization of the pydantic/`json.loads` behaviors the guard defends against.
- `test_project/tests/test_variant_serializer.gd`: clamp matrix across float, vector/quat/color/plane components, nested dict/array, packed arrays, and a JSON round-trip proving the payload parses.
- Gauntlet in the authoring session: ruff, pytest (1321 passed), `ci-check-gdscript`, `ci-godot-tests` (1727/1745, 0 failed). Re-verified on this applied branch: ruff clean, pytest 1321 passed.

*Provenance: authored by the Phase-1 audit worker session per `docs/audit-tier2-plan.md`; that session couldn't push, so the commit was transported as a git patch and applied verbatim onto latest `origin/main`.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2zhpWvnqijYYRW3dwtUhV

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2zhpWvnqijYYRW3dwtUhV)_