### PR TITLE
Close three write-path validation gaps

### DIFF
--- a/plugin/addons/godot_ai/handlers/filesystem_handler.gd
+++ b/plugin/addons/godot_ai/handlers/filesystem_handler.gd
@@ -87,7 +87,7 @@ func write_file(params: Dictionary) -> Dictionary:
 	if write_err != OK:
 		return ErrorCodes.make(
 			ErrorCodes.INTERNAL_ERROR,
-			"Write failed for %s (error %d); file may be truncated" % [path, write_err]
+			"Write failed for %s (%s); file may be truncated" % [path, error_string(write_err)]
 		)
 
 	# Single-file register, not a full scan() — a scan() per write stacks

--- a/plugin/addons/godot_ai/handlers/filesystem_handler.gd
+++ b/plugin/addons/godot_ai/handlers/filesystem_handler.gd
@@ -81,7 +81,14 @@ func write_file(params: Dictionary) -> Dictionary:
 		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to open file for writing: %s" % path)
 
 	file.store_string(content)
+	file.flush()
+	var write_err := file.get_error()
 	file.close()
+	if write_err != OK:
+		return ErrorCodes.make(
+			ErrorCodes.INTERNAL_ERROR,
+			"Write failed for %s (error %d); file may be truncated" % [path, write_err]
+		)
 
 	# Single-file register, not a full scan() — a scan() per write stacks
 	# filesystem WorkerThreadPool tasks under concurrent writes and can SIGABRT

--- a/plugin/addons/godot_ai/handlers/script_handler.gd
+++ b/plugin/addons/godot_ai/handlers/script_handler.gd
@@ -56,7 +56,7 @@ func create_script(params: Dictionary) -> Dictionary:
 	if write_err != OK:
 		return ErrorCodes.make(
 			ErrorCodes.INTERNAL_ERROR,
-			"Write failed for %s (error %d); file may be truncated" % [path, write_err]
+			"Write failed for %s (%s); file may be truncated" % [path, error_string(write_err)]
 		)
 
 	var data := {
@@ -377,7 +377,7 @@ func patch_script(params: Dictionary) -> Dictionary:
 	if write_err != OK:
 		return ErrorCodes.make(
 			ErrorCodes.INTERNAL_ERROR,
-			"Write failed for %s (error %d); file may be truncated" % [path, write_err]
+			"Write failed for %s (%s); file may be truncated" % [path, error_string(write_err)]
 		)
 
 	var data := {

--- a/plugin/addons/godot_ai/handlers/script_handler.gd
+++ b/plugin/addons/godot_ai/handlers/script_handler.gd
@@ -50,7 +50,14 @@ func create_script(params: Dictionary) -> Dictionary:
 		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to open file for writing: %s" % path)
 
 	file.store_string(content)
+	file.flush()
+	var write_err := file.get_error()
 	file.close()
+	if write_err != OK:
+		return ErrorCodes.make(
+			ErrorCodes.INTERNAL_ERROR,
+			"Write failed for %s (error %d); file may be truncated" % [path, write_err]
+		)
 
 	var data := {
 		"path": path,
@@ -364,7 +371,14 @@ func patch_script(params: Dictionary) -> Dictionary:
 	if write == null:
 		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to open file for writing: %s" % path)
 	write.store_string(new_content)
+	write.flush()
+	var write_err := write.get_error()
 	write.close()
+	if write_err != OK:
+		return ErrorCodes.make(
+			ErrorCodes.INTERNAL_ERROR,
+			"Write failed for %s (error %d); file may be truncated" % [path, write_err]
+		)
 
 	var data := {
 		"path": path,

--- a/plugin/addons/godot_ai/handlers/tileset_handler.gd
+++ b/plugin/addons/godot_ai/handlers/tileset_handler.gd
@@ -139,6 +139,10 @@ func _resolve_atlas_source(params: Dictionary) -> Dictionary:
 			"'source_id' parameter is required"
 		)
 
+	var tileset_path_err = McpPathValidator.loadable_error(tileset_path, "tileset_path")
+	if tileset_path_err != null:
+		return tileset_path_err
+
 	if not ResourceLoader.exists(tileset_path):
 		return ErrorCodes.make(
 			ErrorCodes.RESOURCE_NOT_FOUND,

--- a/plugin/addons/godot_ai/utils/path_validator.gd
+++ b/plugin/addons/godot_ai/utils/path_validator.gd
@@ -140,9 +140,16 @@ static func _reject_sensitive_write(path: String) -> String:
 		return "Refusing to write res://override.cfg (startup config override)"
 	# Reject the `.godot/` editor-metadata dir at any depth. Split drops empty
 	# segments so a trailing slash can't hide a segment from the check.
-	for segment in path.trim_prefix("res://").split("/", false):
+	var segments := path.trim_prefix("res://").split("/", false)
+	for segment in segments:
 		if segment.to_lower() == ".godot":
 			return "Refusing to write under res://.godot/ (editor metadata)"
+	# Reject the currently-loaded plugin's own script tree. Overwriting a
+	# loaded .gd here (plus the immediate reimport triggered by update_file())
+	# can SIGABRT the editor mid-call, or silently corrupt the installed
+	# plugin so the next enable fails to resolve scripts.
+	if segments.size() >= 2 and segments[0].to_lower() == "addons" and segments[1].to_lower() == "godot_ai":
+		return "Refusing to write under res://addons/godot_ai/ (overwriting a loaded plugin script can crash the editor)"
 	return ""
 
 

--- a/test_project/tests/test_path_validator.gd
+++ b/test_project/tests/test_path_validator.gd
@@ -174,6 +174,38 @@ func test_write_blocklist_is_case_insensitive() -> void:
 	assert_false(McpPathValidator.validate_resource_path("res://.GODOT/uid_cache.bin", true).is_empty())
 
 
+func test_write_rejects_loaded_plugin_tree() -> void:
+	## Overwriting a currently-loaded plugin script (plus the immediate
+	## update_file() reimport) can SIGABRT the editor or corrupt the installed
+	## plugin so the next enable fails to resolve scripts (#689).
+	var err := McpPathValidator.validate_resource_path("res://addons/godot_ai/plugin.gd", true)
+	assert_false(err.is_empty(), "writing under res://addons/godot_ai/ must be rejected")
+	assert_contains(err, "addons/godot_ai")
+
+
+func test_write_rejects_loaded_plugin_tree_nested() -> void:
+	var err := McpPathValidator.validate_resource_path(
+		"res://addons/godot_ai/handlers/new_handler.gd", true
+	)
+	assert_false(err.is_empty(), "writing anywhere under res://addons/godot_ai/ must be rejected")
+
+
+func test_write_rejects_loaded_plugin_tree_case_insensitive() -> void:
+	assert_false(
+		McpPathValidator.validate_resource_path("res://Addons/Godot_AI/plugin.gd", true).is_empty()
+	)
+
+
+func test_write_allows_other_addons() -> void:
+	## Only this plugin's own tree is blocked — other addons remain writable.
+	assert_eq(McpPathValidator.validate_resource_path("res://addons/some_other_plugin/plugin.gd", true), "")
+
+
+func test_read_allows_plugin_tree() -> void:
+	## The block is write-only; reading the plugin's own source must still work.
+	assert_eq(McpPathValidator.validate_resource_path("res://addons/godot_ai/plugin.gd"), "")
+
+
 func test_loadable_accepts_uid() -> void:
 	## uid:// is an opaque resource id ResourceLoader resolves to an in-project
 	## resource — it cannot express traversal, so load handlers must accept it.

--- a/test_project/tests/test_tileset_atlas.gd
+++ b/test_project/tests/test_tileset_atlas.gd
@@ -110,6 +110,21 @@ func test_nonexistent_path_returns_resource_not_found() -> void:
 	assert_contains(result.error.message, fake_path)
 
 
+func test_traversal_path_returns_value_out_of_range() -> void:
+	## #689: _resolve_atlas_source was the one resource-loading handler with
+	## zero McpPathValidator usage, so a res://../… traversal path (and raw
+	## absolute paths, which load() honors) reached ResourceLoader.exists /
+	## load() unchecked — the #347 info-disclosure surface every sibling
+	## handler already blocks.
+	var result := _handler.get_atlas_tiles({"tileset_path": "res://../etc/passwd", "source_id": 0})
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
+
+
+func test_traversal_path_rejected_before_load_atlas_image() -> void:
+	var result := _handler.get_atlas_image({"tileset_path": "res://../../etc/passwd", "source_id": 0})
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
+
+
 func test_wrong_type_resource_returns_wrong_type() -> void:
 	## A resource that is not a TileSet (plain Resource) → WRONG_TYPE
 	## Validates: Requirement 1.5


### PR DESCRIPTION
## Summary

Fixes #689 — three write-path validation gaps:

1. **`McpPathValidator._reject_sensitive_write` had no clause for `res://addons/godot_ai/`** — the currently-loaded plugin's own script tree. Every write entry point (`write_file`, `create_script`, `patch_script`, scene save) routed through it, so an agent asked to "fix the plugin" could write into its own live source: the write plus the immediate `update_file()` reimport can SIGABRT the editor, or silently corrupt the installed plugin so the next enable fails to resolve scripts. Writes whose first two `res://`-relative segments case-fold to `["addons", "godot_ai"]` are now refused; reads are unaffected.
2. **`patch_script` (and `create_script`, `write_file`) never checked `get_error()`** after `FileAccess.WRITE` + store + close — a failed or partial write (ENOSPC, quota, flaky mount) left the file truncated while the handler reported success with a size taken from the input string. All three write sites now `flush()` + `get_error()` before close and surface `INTERNAL_ERROR` when the write failed.
3. **`tileset_handler._resolve_atlas_source` was the one resource-loading handler with zero `McpPathValidator` usage** — `get_atlas_tiles`/`get_atlas_image` accepted `res://../…` traversal (and raw absolute paths) that every sibling read handler rejects, reopening the #347 info-disclosure surface. It now uses the same `loadable_error(tileset_path, "tileset_path")` guard as `audio_handler.set_stream`.

## Testing

Gauntlet run in the authoring session: ruff, pytest (1307 passed), `ci-check-gdscript`, `ci-godot-tests` (0 failed) all green. New tests in `test_path_validator.gd` and `test_tileset_atlas.gd`.

*Provenance: authored by the Phase-1 audit worker session per `docs/audit-tier2-plan.md`; that session couldn't push, so the commit was transported as a git patch and applied verbatim onto latest `origin/main`.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2zhpWvnqijYYRW3dwtUhV

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2zhpWvnqijYYRW3dwtUhV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-writing reliability by detecting flush and write failures and reporting clear errors.
  * Added protection against modifying the plugin’s own source files.
  * Strengthened path validation for tileset atlas operations, including traversal attempts.
* **Tests**
  * Added coverage for protected plugin paths, permitted addon paths, readable plugin files, and invalid tileset paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->