### PR TITLE
Close the residual #678 async-startup seams

### DIFF
--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -109,7 +109,8 @@ static func _register_bool_setting(es: EditorSettings, key: String, default_valu
 
 
 static func startup_trace_enabled() -> bool:
-	var raw := OS.get_environment(STARTUP_TRACE_ENV).strip_edges().to_lower()
+	## env_lookup for the same worker-thread reason as mode_override (#691).
+	var raw := McpPathTemplate.env_lookup(STARTUP_TRACE_ENV).strip_edges().to_lower()
 	if raw == "1" or raw == "true" or raw == "yes" or raw == "on":
 		return true
 	if Engine.is_editor_hint():
@@ -259,6 +260,21 @@ static func check_status_details_for_url_with_cli_path(id: String, url: String, 
 	if client.config_type == "cli" and cli_path.is_empty() and not client.has_json_fallback():
 		return {"status": Client.Status.NOT_CONFIGURED, "error_msg": ""}
 	return _dispatch_check_status_with_cli_path_details(client, url, cli_path)
+
+
+## #691: main-thread pre-warm of McpPathTemplate's env snapshot, covering
+## the base vars plus every descriptor-declared `config_home_env`
+## (CLAUDE_CONFIG_DIR, CODEX_HOME, …), so worker-thread config-path
+## resolution never calls OS.get_environment concurrently with the spawn
+## window's setenv/unsetenv. Idempotent; called from plugin _enter_tree and
+## before each dock worker dispatch.
+static func warm_env_snapshot() -> void:
+	var extras := PackedStringArray()
+	for id in client_ids():
+		var client := ClientRegistry.get_by_id(String(id))
+		if client != null and not client.config_home_env.is_empty():
+			extras.append(client.config_home_env)
+	McpPathTemplate.warm_env_snapshot(extras)
 
 
 static func client_status_probe_snapshot(id: String) -> Dictionary:
@@ -447,8 +463,10 @@ static func mode_override() -> String:
 			var setting_val := str(es.get_setting(MODE_OVERRIDE_SETTING)).strip_edges().to_lower()
 			if setting_val == "dev" or setting_val == "user":
 				return setting_val
-	# 2. Env var fallback.
-	var raw := OS.get_environment(MODE_OVERRIDE_ENV).strip_edges().to_lower()
+	# 2. Env var fallback. env_lookup, not OS.get_environment: this runs on
+	#    the #678 startup walk's discovery worker and must not race a
+	#    main-thread setenv/unsetenv window (#691).
+	var raw := McpPathTemplate.env_lookup(MODE_OVERRIDE_ENV).strip_edges().to_lower()
 	if raw == "dev" or raw == "user":
 		return raw
 	return ""

--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -109,15 +109,44 @@ static func _register_bool_setting(es: EditorSettings, key: String, default_valu
 
 
 static func startup_trace_enabled() -> bool:
-	## env_lookup for the same worker-thread reason as mode_override (#691).
+	## env_lookup + _editor_setting_lookup for the same worker-thread
+	## reason as mode_override (#691).
 	var raw := McpPathTemplate.env_lookup(STARTUP_TRACE_ENV).strip_edges().to_lower()
 	if raw == "1" or raw == "true" or raw == "yes" or raw == "on":
 		return true
-	if Engine.is_editor_hint():
-		var es := EditorInterface.get_editor_settings()
-		if es != null and es.has_setting(SETTING_STARTUP_TRACE):
-			return bool(es.get_setting(SETTING_STARTUP_TRACE))
+	var setting: Variant = _editor_setting_lookup(SETTING_STARTUP_TRACE)
+	if setting != null:
+		return bool(setting)
 	return false
+
+
+## #691: EditorSettings counterpart of McpPathTemplate.env_lookup. The #678
+## startup walk's discovery worker reaches mode_override() (via
+## get_server_command) and EditorInterface / EditorSettings are not
+## thread-safe objects. Main thread: live read + mutex-guarded snapshot
+## refresh. Worker thread: snapshot only — a never-warmed key reads as
+## null (unset), never a live EditorInterface call. Warmed alongside the
+## env snapshot in warm_env_snapshot(), which runs on the main thread
+## before any worker dispatch.
+static var _setting_snapshot := {}
+static var _setting_snapshot_mutex := Mutex.new()
+
+
+static func _editor_setting_lookup(key: String) -> Variant:
+	if OS.get_thread_caller_id() == OS.get_main_thread_id():
+		var live: Variant = null
+		if Engine.is_editor_hint():
+			var es := EditorInterface.get_editor_settings()
+			if es != null and es.has_setting(key):
+				live = es.get_setting(key)
+		_setting_snapshot_mutex.lock()
+		_setting_snapshot[key] = live
+		_setting_snapshot_mutex.unlock()
+		return live
+	_setting_snapshot_mutex.lock()
+	var cached: Variant = _setting_snapshot.get(key, null)
+	_setting_snapshot_mutex.unlock()
+	return cached
 
 
 ## Read the `godot_ai/excluded_domains` EditorSetting as a canonicalized
@@ -266,8 +295,10 @@ static func check_status_details_for_url_with_cli_path(id: String, url: String, 
 ## the base vars plus every descriptor-declared `config_home_env`
 ## (CLAUDE_CONFIG_DIR, CODEX_HOME, …), so worker-thread config-path
 ## resolution never calls OS.get_environment concurrently with the spawn
-## window's setenv/unsetenv. Idempotent; called from plugin _enter_tree and
-## before each dock worker dispatch.
+## window's setenv/unsetenv. Also warms the EditorSettings snapshot for
+## the mode/trace overrides so worker-thread mode_override() /
+## startup_trace_enabled() never touch EditorInterface. Idempotent;
+## called from plugin _enter_tree and before each dock worker dispatch.
 static func warm_env_snapshot() -> void:
 	var extras := PackedStringArray()
 	for id in client_ids():
@@ -275,6 +306,8 @@ static func warm_env_snapshot() -> void:
 		if client != null and not client.config_home_env.is_empty():
 			extras.append(client.config_home_env)
 	McpPathTemplate.warm_env_snapshot(extras)
+	_editor_setting_lookup(MODE_OVERRIDE_SETTING)
+	_editor_setting_lookup(SETTING_STARTUP_TRACE)
 
 
 static func client_status_probe_snapshot(id: String) -> Dictionary:
@@ -453,19 +486,18 @@ const MODE_OVERRIDE_SETTING := "godot_ai/mode_override"
 
 static func mode_override() -> String:
 	# 1. EditorSetting wins — the user explicitly set it via Editor Settings.
-	#    Guarded on `Engine.is_editor_hint()` so this is a no-op when the
-	#    plugin code runs inside the game subprocess (where EditorInterface
-	#    isn't available). See CLAUDE.md "Game-side code: gate on
-	#    Engine.is_editor_hint(), not OS.has_feature("editor")".
-	if Engine.is_editor_hint():
-		var es := EditorInterface.get_editor_settings()
-		if es != null and es.has_setting(MODE_OVERRIDE_SETTING):
-			var setting_val := str(es.get_setting(MODE_OVERRIDE_SETTING)).strip_edges().to_lower()
-			if setting_val == "dev" or setting_val == "user":
-				return setting_val
-	# 2. Env var fallback. env_lookup, not OS.get_environment: this runs on
-	#    the #678 startup walk's discovery worker and must not race a
-	#    main-thread setenv/unsetenv window (#691).
+	#    _editor_setting_lookup handles the `Engine.is_editor_hint()` gate
+	#    (no-op in the game subprocess; see CLAUDE.md "Game-side code") and
+	#    serves worker threads from a main-thread-warmed snapshot — this
+	#    runs on the #678 startup walk's discovery worker, and
+	#    EditorInterface/EditorSettings are not thread-safe (#691).
+	var setting: Variant = _editor_setting_lookup(MODE_OVERRIDE_SETTING)
+	if setting != null:
+		var setting_val := str(setting).strip_edges().to_lower()
+		if setting_val == "dev" or setting_val == "user":
+			return setting_val
+	# 2. Env var fallback. env_lookup, not OS.get_environment: same
+	#    worker-thread reason (#691).
 	var raw := McpPathTemplate.env_lookup(MODE_OVERRIDE_ENV).strip_edges().to_lower()
 	if raw == "dev" or raw == "user":
 		return raw

--- a/plugin/addons/godot_ai/clients/_base.gd
+++ b/plugin/addons/godot_ai/clients/_base.gd
@@ -148,7 +148,9 @@ func resolved_config_path() -> String:
 func config_home_override() -> String:
 	if config_home_env.is_empty() or config_home_env_subpath.is_empty():
 		return ""
-	var home := OS.get_environment(config_home_env).strip_edges()
+	## env_lookup, not OS.get_environment: this runs on dock worker threads,
+	## which must not race the spawn window's setenv/unsetenv (#691).
+	var home := McpPathTemplate.env_lookup(config_home_env).strip_edges()
 	if home.is_empty():
 		return ""
 	# Expand a leading ~ so `CODEX_HOME=~/codex-alt` behaves like the shell.

--- a/plugin/addons/godot_ai/clients/_cli_finder.gd
+++ b/plugin/addons/godot_ai/clients/_cli_finder.gd
@@ -80,7 +80,10 @@ static func _resolve(exe_name: String) -> String:
 
 	# 2. Login shell lookup (Unix only)
 	if not is_windows:
-		var shell := OS.get_environment("SHELL")
+		## env_lookup, not OS.get_environment: CLI resolution runs on dock
+		## worker threads (configure/remove actions) and must not race the
+		## spawn window's setenv/unsetenv (#691).
+		var shell := McpPathTemplate.env_lookup("SHELL")
 		if shell.is_empty():
 			shell = "/bin/bash"
 		var stripped := exe_name.trim_suffix(".exe")
@@ -141,9 +144,11 @@ static func _pick_best_path(lines: PackedStringArray) -> String:
 
 
 static func _well_known_dirs() -> Array[String]:
-	var home := OS.get_environment("HOME")
+	## env_lookup, not OS.get_environment — see _resolve()'s worker-thread
+	## note (#691).
+	var home := McpPathTemplate.env_lookup("HOME")
 	if home.is_empty():
-		home = OS.get_environment("USERPROFILE")
+		home = McpPathTemplate.env_lookup("USERPROFILE")
 	match OS.get_name():
 		"macOS":
 			return [
@@ -154,8 +159,8 @@ static func _well_known_dirs() -> Array[String]:
 				"/usr/local/bin",
 			]
 		"Windows":
-			var local := OS.get_environment("LOCALAPPDATA")
-			var prog := OS.get_environment("ProgramFiles")
+			var local := McpPathTemplate.env_lookup("LOCALAPPDATA")
+			var prog := McpPathTemplate.env_lookup("ProgramFiles")
 			var paths: Array[String] = []
 			if not home.is_empty():
 				paths.append(home.path_join(".claude/local"))

--- a/plugin/addons/godot_ai/clients/_path_template.gd
+++ b/plugin/addons/godot_ai/clients/_path_template.gd
@@ -43,8 +43,11 @@ const _BASE_ENV_VARS: Array[String] = [
 
 ## Thread-safe env read (#691). Main thread: live read + snapshot refresh.
 ## Worker thread: snapshot only, so it can never race a main-thread
-## setenv/unsetenv. A worker read of a never-warmed var falls back to the
-## pre-#691 direct read — keep vars out of that path by warming them.
+## setenv/unsetenv. A worker read of a never-warmed var returns "" — the
+## same value an unset var reads as — never a live OS.get_environment,
+## which would reintroduce the race for exactly the vars nobody thought
+## to warm. Missing warm-up degrades resolution; it must not touch the
+## process-global environment off-main.
 static func env_lookup(name: String) -> String:
 	if OS.get_thread_caller_id() == OS.get_main_thread_id():
 		var live := OS.get_environment(name)
@@ -57,7 +60,7 @@ static func env_lookup(name: String) -> String:
 	_env_snapshot_mutex.unlock()
 	if cached != null:
 		return str(cached)
-	return OS.get_environment(name)
+	return ""
 
 
 ## Main-thread pre-warm so subsequent worker reads never touch the real

--- a/plugin/addons/godot_ai/clients/_path_template.gd
+++ b/plugin/addons/godot_ai/clients/_path_template.gd
@@ -6,6 +6,69 @@ extends RefCounted
 ## inside path templates so per-client descriptors can declare paths declaratively
 ## without hand-rolling per-OS lookups.
 
+## #691: dock worker threads (client-status refresh, configure/remove
+## actions) and the #678 startup walk's discovery worker expand these
+## templates off the main thread, while the spawn step mutates the
+## process-global environment around `OS.create_process`
+## (`GODOT_AI_OWNER_PID`, `GODOT_AI_PLUGIN_SPAWNED`, `PYTHONPATH`,
+## `GODOT_AI_DISABLE_TELEMETRY`). A glibc `getenv` racing a concurrent
+## `setenv` can return a freed pointer — rare but process-fatal. All env
+## reads in this layer therefore go through `env_lookup`: on the MAIN
+## thread it reads live and refreshes a mutex-guarded snapshot; off the
+## main thread it serves from the snapshot, so no `OS.get_environment`
+## runs concurrently with the spawn window's mutations. Callers pre-warm
+## every var their workers can touch via `warm_env_snapshot` (plugin
+## `_enter_tree` and the dock's phase-1 refresh prep, both main-thread,
+## both before any worker starts).
+static var _env_snapshot := {}
+static var _env_snapshot_mutex := Mutex.new()
+
+## Every var this layer and its sibling consumers (`_base.gd`
+## `config_home_override`, `_cli_finder.gd` lookups,
+## `client_configurator.gd` mode/trace reads) can touch off-main.
+## Descriptor-declared `config_home_env` names are passed as extras by
+## the warm callers.
+const _BASE_ENV_VARS: Array[String] = [
+	"HOME",
+	"USERPROFILE",
+	"XDG_CONFIG_HOME",
+	"APPDATA",
+	"LOCALAPPDATA",
+	"SHELL",
+	"ProgramFiles",
+	"GODOT_AI_MODE",
+	"GODOT_AI_STARTUP_TRACE",
+]
+
+
+## Thread-safe env read (#691). Main thread: live read + snapshot refresh.
+## Worker thread: snapshot only, so it can never race a main-thread
+## setenv/unsetenv. A worker read of a never-warmed var falls back to the
+## pre-#691 direct read — keep vars out of that path by warming them.
+static func env_lookup(name: String) -> String:
+	if OS.get_thread_caller_id() == OS.get_main_thread_id():
+		var live := OS.get_environment(name)
+		_env_snapshot_mutex.lock()
+		_env_snapshot[name] = live
+		_env_snapshot_mutex.unlock()
+		return live
+	_env_snapshot_mutex.lock()
+	var cached: Variant = _env_snapshot.get(name, null)
+	_env_snapshot_mutex.unlock()
+	if cached != null:
+		return str(cached)
+	return OS.get_environment(name)
+
+
+## Main-thread pre-warm so subsequent worker reads never touch the real
+## environment. Idempotent; safe to call before every worker dispatch.
+static func warm_env_snapshot(extra_vars: PackedStringArray = PackedStringArray()) -> void:
+	for var_name in _BASE_ENV_VARS:
+		env_lookup(var_name)
+	for var_name in extra_vars:
+		if not String(var_name).is_empty():
+			env_lookup(String(var_name))
+
 
 ## Pick the right entry from a {"darwin": ..., "windows": ..., "linux": ...} map.
 static func resolve(template_map: Dictionary) -> String:
@@ -32,7 +95,7 @@ static func expand(template: String) -> String:
 	for var_name in ["XDG_CONFIG_HOME", "LOCALAPPDATA", "USERPROFILE", "APPDATA", "HOME"]:
 		var token := "$%s" % var_name
 		if out.find(token) >= 0:
-			var value := OS.get_environment(var_name)
+			var value := env_lookup(var_name)
 			if value.is_empty() and var_name == "XDG_CONFIG_HOME":
 				value = _home().path_join(".config")
 			if value.is_empty() and var_name == "APPDATA":
@@ -56,7 +119,7 @@ static func _os_key() -> String:
 
 
 static func _home() -> String:
-	var h := OS.get_environment("HOME")
+	var h := env_lookup("HOME")
 	if h.is_empty():
-		h = OS.get_environment("USERPROFILE")
+		h = env_lookup("USERPROFILE")
 	return h

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -1811,6 +1811,10 @@ func _dispatch_client_action(client_id: String, action: String) -> void:
 	## `_perform_initial_client_status_refresh` and
 	## `_request_client_status_refresh`.
 	var server_url := ClientConfigurator.http_url()
+	## #691: refresh the env snapshot on main before this worker starts —
+	## configure/remove resolve CLI + config paths off-thread and must not
+	## race a concurrent spawn window's setenv/unsetenv.
+	ClientConfigurator.warm_env_snapshot()
 	var generation := int(_client_action_generations.get(client_id, 0)) + 1
 	_client_action_generations[client_id] = generation
 	var thread := Thread.new()
@@ -2668,6 +2672,10 @@ func _warm_strategy_bytecode() -> void:
 		JsonStrategy.verify_entry(any_client, {}, "")
 	TomlStrategy.format_body(PackedStringArray(), "")
 	CliStrategy.format_args(PackedStringArray(), "", "")
+	## #691: refresh the env snapshot on main before the worker starts, so
+	## its config-path expansions read the snapshot instead of racing a
+	## concurrent spawn window's setenv/unsetenv.
+	ClientConfigurator.warm_env_snapshot()
 
 
 func _begin_client_status_refresh_run() -> int:

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -204,6 +204,13 @@ func _enter_tree() -> void:
 	ClientConfigurator.ensure_settings_registered()
 	_startup_trace_phase("settings_registered")
 
+	## #691: pre-warm the env snapshot on the main thread before any worker
+	## exists, so worker-thread env reads (dock refresh/action workers, the
+	## #678 startup walk's discovery worker) serve from the snapshot and can
+	## never race the spawn window's setenv/unsetenv around
+	## OS.create_process.
+	ClientConfigurator.warm_env_snapshot()
+
 	_log_buffer = LogBuffer.new()
 	## Apply the persisted dock "Log" toggle before anything logs through the
 	## buffer. Without this the choice only took effect after a manual toggle

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -323,12 +323,10 @@ func handle_server_version_verified(expected_version: String, version: String) -
 		_host._update_process_enabled()
 		return
 	var live := {"version": version, "status_code": 200, "name": "godot-ai"}
+	## Connection propagation + version-check disarm + process re-evaluation
+	## all live inside _set_incompatible_server now (#691) so the startup-walk
+	## recovery-failure and force-restart-failure paths get them too.
 	_set_incompatible_server(live, expected, ClientConfigurator.http_port())
-	if _host._connection != null:
-		_host._connection.connect_blocked = true
-		_host._connection.connect_block_reason = _server_status_message
-		_host._connection.disconnect_from_server()
-	_host._update_process_enabled()
 
 
 func handle_server_version_unverified(expected_version: String) -> void:
@@ -336,11 +334,6 @@ func handle_server_version_unverified(expected_version: String) -> void:
 	_server_expected_version = expected
 	var live := {"version": "", "status_code": 0, "error": "missing_handshake_ack"}
 	_set_incompatible_server(live, expected, ClientConfigurator.http_port())
-	if _host._connection != null:
-		_host._connection.connect_blocked = true
-		_host._connection.connect_block_reason = _server_status_message
-		_host._connection.disconnect_from_server()
-	_host._update_process_enabled()
 
 
 # ---- Compatibility / version helpers (pure) ---------------------------
@@ -410,6 +403,22 @@ func _set_incompatible_server(live: Dictionary, expected_version: String, port: 
 		var suggested := ClientConfigurator.suggest_free_port(port + 1)
 		print("MCP | port %d occupant not recoverable (no ownership proof); suggested free port %d (set godot_ai/http_port)" % [port, suggested])
 	_host._refresh_dock_client_statuses()
+	## Propagate the verdict to the live connection (#691). Pre-#678 the
+	## startup walk finished synchronously before `_connection` existed, so
+	## plugin.gd captured the INCOMPATIBLE verdict when constructing it.
+	## Post-#678 the walk suspends at its first `_run_blocking` and the
+	## plugin snapshots the pre-walk defaults (`connect_blocked=false`) — so
+	## a verdict landing later (startup-walk recovery failure, handshake
+	## mismatch, force-restart failure) must reach the connection here, or
+	## it keeps dialing the WS port forever. Also disarm the version check:
+	## the diagnosis already landed, so leaving the check armed keeps
+	## per-frame `_process` on for the plugin's whole lifetime.
+	if _host._connection != null:
+		_host._connection.connect_blocked = true
+		_host._connection.connect_block_reason = _server_status_message
+		_host._connection.disconnect_from_server()
+	disarm_version_check()
+	_host._update_process_enabled()
 
 
 static func _incompatible_server_message(
@@ -687,6 +696,23 @@ func _start_server_impl(async_gen: int) -> void:
 		push_warning("MCP | port %d is reserved by Windows (Hyper-V / WSL2 / Docker)" % port)
 		return
 
+	## ---- Spawn-time env-mutation window (#691) -------------------------
+	## From here to the post-spawn unsets below, the editor's process-global
+	## environment is mutated around OS.create_process (which has no
+	## per-child env parameter). Two invariants keep this safe:
+	## 1. The window is SYNCHRONOUS main-thread code — no `await` between
+	##    the first setenv and the last unsetenv — and worker dispatch also
+	##    only happens on the main thread, so no new worker can start inside
+	##    the window.
+	## 2. Already-running workers never call OS.get_environment: every env
+	##    read reachable from a worker (path templates, config_home_override,
+	##    CLI finder, mode_override/startup-trace) routes through
+	##    McpPathTemplate.env_lookup, which serves worker threads from a
+	##    main-thread-warmed snapshot. A concurrent glibc getenv during
+	##    setenv can return a freed pointer — process-fatal.
+	## Residual (accepted): a worker's own OS.execute child (CLI status
+	## probe) launched while this window is open inherits the temp vars —
+	## rare, and tame next to the crash class above.
 	var injected_telemetry_env := _inject_telemetry_env()
 
 	## PYTHONPATH handling for dev checkouts: when the editor is launched

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -770,14 +770,68 @@ func test_env_lookup_worker_thread_serves_snapshot_not_live_env() -> void:
 	OS.unset_environment(TEST_SNAPSHOT_ENV)
 
 
+func test_env_lookup_worker_thread_never_warmed_var_reads_empty() -> void:
+	## A worker read of a var nobody warmed must return "" (the unset
+	## value), NOT fall back to a live OS.get_environment — the fallback
+	## would reintroduce the #691 race for exactly the un-warmed vars.
+	const NEVER_WARMED := "GODOT_AI_TEST_ENV_NEVER_WARMED"
+	OS.set_environment(NEVER_WARMED, "live-only-value")
+	var thread := Thread.new()
+	var start_err := thread.start(func() -> String:
+		return McpPathTemplate.env_lookup(NEVER_WARMED)
+	)
+	assert_eq(start_err, OK, "worker thread must start")
+	var worker_value := str(thread.wait_to_finish())
+	OS.unset_environment(NEVER_WARMED)
+	assert_eq(worker_value, "",
+		"un-warmed worker read must degrade to \"\", never touch the live env")
+
+
+func test_editor_setting_lookup_worker_thread_serves_snapshot() -> void:
+	## #691: mode_override() runs on the startup walk's discovery worker
+	## (via get_server_command) and EditorSettings is not thread-safe. A
+	## worker read must come from the main-thread-warmed snapshot; a
+	## never-warmed key must read as null (unset), never touch
+	## EditorInterface off-main.
+	var es := EditorInterface.get_editor_settings()
+	var setting_name := McpClientConfigurator.MODE_OVERRIDE_SETTING
+	var had_setting := es.has_setting(setting_name)
+	var prior: Variant = es.get_setting(setting_name) if had_setting else null
+	es.set_setting(setting_name, "dev")
+	McpClientConfigurator.warm_env_snapshot()
+
+	var thread := Thread.new()
+	var start_err := thread.start(func() -> Array:
+		return [
+			McpClientConfigurator._editor_setting_lookup(setting_name),
+			McpClientConfigurator._editor_setting_lookup("godot_ai/never_warmed_probe"),
+		]
+	)
+	assert_eq(start_err, OK, "worker thread must start")
+	var results: Array = thread.wait_to_finish()
+
+	if had_setting:
+		es.set_setting(setting_name, prior)
+	else:
+		es.erase(setting_name)
+	McpClientConfigurator.warm_env_snapshot()
+
+	assert_eq(str(results[0]), "dev",
+		"worker read must serve the warmed EditorSetting value")
+	assert_true(results[1] == null,
+		"a never-warmed setting must read as null on a worker, not hit EditorInterface")
+
+
 func test_warm_env_snapshot_covers_descriptor_config_home_envs() -> void:
 	## ClientConfigurator.warm_env_snapshot must include every descriptor's
 	## config_home_env (CLAUDE_CONFIG_DIR, CODEX_HOME, …) so worker-side
-	## config_home_override() never falls into the direct-read path.
+	## config_home_override() never falls into the degraded un-warmed path.
+	var tested_count := 0
 	for id in McpClientConfigurator.client_ids():
 		var client := McpClientRegistry.get_by_id(String(id))
 		if client == null or client.config_home_env.is_empty():
 			continue
+		tested_count += 1
 		OS.set_environment(client.config_home_env, "warm-probe")
 		McpClientConfigurator.warm_env_snapshot()
 		OS.unset_environment(client.config_home_env)
@@ -793,6 +847,8 @@ func test_warm_env_snapshot_covers_descriptor_config_home_envs() -> void:
 		## Re-warm now that the var is unset so the snapshot doesn't leak
 		## the probe value into later tests.
 		McpClientConfigurator.warm_env_snapshot()
+	assert_true(tested_count > 0,
+		"no descriptor declared config_home_env — this test exercised nothing")
 
 
 # ----- config-home env override (#617) -----

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -733,6 +733,68 @@ func test_path_template_xdg_fallback() -> void:
 	assert_true(resolved.ends_with("/foo"))
 
 
+# ----- env snapshot (#691) -----
+
+const TEST_SNAPSHOT_ENV := "GODOT_AI_TEST_ENV_SNAPSHOT"
+
+
+func test_env_lookup_main_thread_reads_live_and_refreshes_snapshot() -> void:
+	OS.set_environment(TEST_SNAPSHOT_ENV, "live-value")
+	assert_eq(McpPathTemplate.env_lookup(TEST_SNAPSHOT_ENV), "live-value")
+	OS.set_environment(TEST_SNAPSHOT_ENV, "updated-value")
+	assert_eq(McpPathTemplate.env_lookup(TEST_SNAPSHOT_ENV), "updated-value",
+		"main-thread reads must always be live, never stale snapshot")
+	OS.unset_environment(TEST_SNAPSHOT_ENV)
+
+
+func test_env_lookup_worker_thread_serves_snapshot_not_live_env() -> void:
+	## The #691 contract: a worker-thread read must come from the snapshot,
+	## proving it can never call OS.get_environment concurrently with a
+	## main-thread setenv/unsetenv window. We change the real env AFTER
+	## warming and assert the worker still sees the warmed value.
+	OS.set_environment(TEST_SNAPSHOT_ENV, "warmed-value")
+	McpPathTemplate.warm_env_snapshot(PackedStringArray([TEST_SNAPSHOT_ENV]))
+	OS.set_environment(TEST_SNAPSHOT_ENV, "mutated-after-warm")
+
+	var thread := Thread.new()
+	var start_err := thread.start(func() -> String:
+		return McpPathTemplate.env_lookup(TEST_SNAPSHOT_ENV)
+	)
+	assert_eq(start_err, OK, "worker thread must start")
+	var worker_value := str(thread.wait_to_finish())
+
+	assert_eq(worker_value, "warmed-value",
+		"worker read must be served from the snapshot, not the live env")
+	## Main-thread read refreshes the snapshot to the current live value.
+	assert_eq(McpPathTemplate.env_lookup(TEST_SNAPSHOT_ENV), "mutated-after-warm")
+	OS.unset_environment(TEST_SNAPSHOT_ENV)
+
+
+func test_warm_env_snapshot_covers_descriptor_config_home_envs() -> void:
+	## ClientConfigurator.warm_env_snapshot must include every descriptor's
+	## config_home_env (CLAUDE_CONFIG_DIR, CODEX_HOME, …) so worker-side
+	## config_home_override() never falls into the direct-read path.
+	for id in McpClientConfigurator.client_ids():
+		var client := McpClientRegistry.get_by_id(String(id))
+		if client == null or client.config_home_env.is_empty():
+			continue
+		OS.set_environment(client.config_home_env, "warm-probe")
+		McpClientConfigurator.warm_env_snapshot()
+		OS.unset_environment(client.config_home_env)
+		var thread := Thread.new()
+		var env_name := client.config_home_env
+		var start_err := thread.start(func() -> String:
+			return McpPathTemplate.env_lookup(env_name)
+		)
+		assert_eq(start_err, OK)
+		var worker_value := str(thread.wait_to_finish())
+		assert_eq(worker_value, "warm-probe",
+			"%s must be pre-warmed by ClientConfigurator.warm_env_snapshot" % env_name)
+		## Re-warm now that the var is unset so the snapshot doesn't leak
+		## the probe value into later tests.
+		McpClientConfigurator.warm_env_snapshot()
+
+
 # ----- config-home env override (#617) -----
 
 const TEST_CFG_HOME_ENV := "GODOT_AI_TEST_CFG_HOME"

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -184,6 +184,66 @@ func test_recover_preserves_record_when_port_held() -> void:
 	assert_eq(cleared, 0)
 
 
+# ----- _set_incompatible_server connection propagation (#691) ----------
+
+func test_set_incompatible_server_propagates_to_live_connection() -> void:
+	## Post-#678 the startup walk suspends before plugin.gd constructs
+	## _connection, so an INCOMPATIBLE verdict landing later (recovery
+	## failure, force-restart failure) must reach the live connection from
+	## _set_incompatible_server itself — otherwise it keeps dialing the WS
+	## port forever with the dock showing INCOMPATIBLE.
+	var host := _ManagerHostStub.new()
+	var conn := McpConnection.new()
+	host._connection = conn
+	var manager := McpServerLifecycleManagerScript.new(host)
+
+	var live := {"name": "godot-ai", "version": "0.0.1", "ws_port": 9500, "status_code": 200}
+	manager._set_incompatible_server(live, "9.9.9", TEST_PORT)
+	var blocked := conn.connect_blocked
+	var reason := conn.connect_block_reason
+	var status_message := str(manager._server_status_message)
+	conn.free()
+	host.free()
+
+	assert_true(blocked, "verdict must flip connect_blocked on the live connection")
+	assert_false(reason.is_empty(), "block reason must carry the diagnosis")
+	assert_eq(reason, status_message, "connection reason must match the manager's message")
+
+
+func test_set_incompatible_server_disarms_version_check() -> void:
+	## Leaving the version check armed after the diagnosis keeps per-frame
+	## _process on for the plugin's whole lifetime (#691).
+	var host := _ManagerHostStub.new()
+	var manager := McpServerLifecycleManagerScript.new(host)
+	var conn := McpConnection.new()
+	manager.arm_version_check(conn, "9.9.9")
+	assert_true(manager.is_awaiting_server_version(), "precondition: check armed")
+
+	var live := {"name": "godot-ai", "version": "0.0.1", "ws_port": 9500, "status_code": 200}
+	manager._set_incompatible_server(live, "9.9.9", TEST_PORT)
+	var still_awaiting: bool = manager.is_awaiting_server_version()
+	conn.free()
+	host.free()
+
+	assert_false(still_awaiting,
+		"_set_incompatible_server must disarm the version check")
+
+
+func test_set_incompatible_server_tolerates_missing_connection() -> void:
+	## Pre-connection verdicts (startup walk before plugin.gd builds
+	## _connection, unit-test hosts) must not crash on the null connection.
+	var host := _ManagerHostStub.new()
+	host._connection = null
+	var manager := McpServerLifecycleManagerScript.new(host)
+
+	var live := {"name": "godot-ai", "version": "0.0.1", "ws_port": 9500, "status_code": 200}
+	manager._set_incompatible_server(live, "9.9.9", TEST_PORT)
+	var state := manager.get_state()
+	host.free()
+
+	assert_eq(state, McpServerState.INCOMPATIBLE)
+
+
 # ----- adopt_compatible_server -----------------------------------------
 
 func test_adopt_managed_when_versions_match() -> void:


### PR DESCRIPTION
## Summary

Fixes #691 — the two residual seams left after #678 made the startup walk a multi-frame coroutine:

1. **Spawn-time env mutation vs worker-thread env reads.** The spawn step's process-global setenv/unsetenv window around `OS.create_process` (`GODOT_AI_OWNER_PID`, `GODOT_AI_PLUGIN_SPAWNED`, `PYTHONPATH`, `GODOT_AI_DISABLE_TELEMETRY`) runs concurrently with the dock's client refresh/action worker threads and the walk's own discovery worker — and a glibc `getenv` racing a `setenv` can return a freed pointer: rare but process-fatal. All env reads reachable from a worker now route through `McpPathTemplate.env_lookup` — main-thread reads stay live and refresh a mutex-guarded snapshot; worker-thread reads serve from the snapshot and never touch the real environment. The snapshot is warmed on the main thread before any worker exists (plugin `_enter_tree`) and re-warmed before each dock worker dispatch, covering the template vars, CLI-finder lookups, mode/trace overrides, and every descriptor's `config_home_env`. The env window itself is documented as synchronous main-thread code; the only residual is a worker's own `OS.execute` child inheriting the temp vars for the window's duration — the issue's "tamer" semantic case, explicitly accepted in a comment.
2. **Startup-walk INCOMPATIBLE verdict now reaches the live connection.** Post-#678 the walk suspends at its first `_run_blocking`, so `plugin.gd` snapshots the pre-walk defaults (`connect_blocked=false`) when building `_connection`; #683 patched the two handshake paths but the recovery-failure path (`_set_incompatible_server` via `recover_*` — the foreign/unprovable occupant case) still only set the manager flag, leaving the connection dialing the WS port forever, the version check armed forever, and per-frame `_process` on for the plugin's lifetime. The connection propagation (`connect_blocked` + reason + disconnect), the version-check disarm, and the process re-evaluation now live inside `_set_incompatible_server` itself, so every caller gets them; the two handshake callers' duplicated copies are deleted.

## Testing

New tests: worker-thread `env_lookup` snapshot semantics (worker sees warmed value while live env has changed), main-thread live-read refresh, descriptor `config_home_env` warm coverage; `_set_incompatible_server` propagation to a live connection, version-check disarm, and null-connection tolerance.

Gauntlet in the authoring session: ruff, pytest (1307 passed), `ci-check-gdscript`, `ci-godot-tests` (1720/1738, 0 failed), and `ci-stale-server-smoke` in BOTH modes (stale kill+respawn and foreign non-recoverable INCOMPATIBLE — the latter exercises the new propagation path live).

*Provenance: authored by the Phase-1 audit worker session per `docs/audit-tier2-plan.md`; that session couldn't push, so the commit was transported as a git patch and applied verbatim onto latest `origin/main`.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2zhpWvnqijYYRW3dwtUhV

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2zhpWvnqijYYRW3dwtUhV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when discovering, configuring, and refreshing client tools while environment settings change.
  - Prevented background operations from using inconsistent environment or configuration paths.
  - Improved handling of incompatible server versions, including connection blocking, cleanup, and status updates.
  - Ensured startup and workspace refresh operations use current environment settings more consistently.

- **Tests**
  - Added coverage for environment handling and incompatible-server behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->