### PR TITLE
Close write-path validation gaps: plugin self-overwrite, unchecked writes, tileset traversal

### DIFF
--- a/plugin/addons/godot_ai/handlers/filesystem_handler.gd
+++ b/plugin/addons/godot_ai/handlers/filesystem_handler.gd
@@ -81,7 +81,14 @@ func write_file(params: Dictionary) -> Dictionary:
 		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to open file for writing: %s" % path)
 
 	file.store_string(content)
+	file.flush()
+	var write_err := file.get_error()
 	file.close()
+	if write_err != OK:
+		return ErrorCodes.make(
+			ErrorCodes.INTERNAL_ERROR,
+			"Write failed for %s (error %d); file may be truncated" % [path, write_err]
+		)
 
 	# Single-file register, not a full scan() — a scan() per write stacks
 	# filesystem WorkerThreadPool tasks under concurrent writes and can SIGABRT

--- a/plugin/addons/godot_ai/handlers/script_handler.gd
+++ b/plugin/addons/godot_ai/handlers/script_handler.gd
@@ -50,7 +50,14 @@ func create_script(params: Dictionary) -> Dictionary:
 		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to open file for writing: %s" % path)
 
 	file.store_string(content)
+	file.flush()
+	var write_err := file.get_error()
 	file.close()
+	if write_err != OK:
+		return ErrorCodes.make(
+			ErrorCodes.INTERNAL_ERROR,
+			"Write failed for %s (error %d); file may be truncated" % [path, write_err]
+		)
 
 	var data := {
 		"path": path,
@@ -364,7 +371,14 @@ func patch_script(params: Dictionary) -> Dictionary:
 	if write == null:
 		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to open file for writing: %s" % path)
 	write.store_string(new_content)
+	write.flush()
+	var write_err := write.get_error()
 	write.close()
+	if write_err != OK:
+		return ErrorCodes.make(
+			ErrorCodes.INTERNAL_ERROR,
+			"Write failed for %s (error %d); file may be truncated" % [path, write_err]
+		)
 
 	var data := {
 		"path": path,

--- a/plugin/addons/godot_ai/handlers/tileset_handler.gd
+++ b/plugin/addons/godot_ai/handlers/tileset_handler.gd
@@ -139,6 +139,10 @@ func _resolve_atlas_source(params: Dictionary) -> Dictionary:
 			"'source_id' parameter is required"
 		)
 
+	var path_err = McpPathValidator.loadable_error(tileset_path, "tileset_path")
+	if path_err != null:
+		return path_err
+
 	if not ResourceLoader.exists(tileset_path):
 		return ErrorCodes.make(
 			ErrorCodes.RESOURCE_NOT_FOUND,

--- a/plugin/addons/godot_ai/utils/path_validator.gd
+++ b/plugin/addons/godot_ai/utils/path_validator.gd
@@ -140,9 +140,16 @@ static func _reject_sensitive_write(path: String) -> String:
 		return "Refusing to write res://override.cfg (startup config override)"
 	# Reject the `.godot/` editor-metadata dir at any depth. Split drops empty
 	# segments so a trailing slash can't hide a segment from the check.
-	for segment in path.trim_prefix("res://").split("/", false):
+	var segments := path.trim_prefix("res://").split("/", false)
+	for segment in segments:
 		if segment.to_lower() == ".godot":
 			return "Refusing to write under res://.godot/ (editor metadata)"
+	# Reject the currently-loaded plugin's own tree. Overwriting a live plugin
+	# script (plus the update_file() reimport every write path triggers) can
+	# crash the editor the same way an in-flight self-update save can, or
+	# corrupt the installed plugin so the next enable fails to resolve scripts.
+	if segments.size() >= 2 and segments[0].to_lower() == "addons" and segments[1].to_lower() == "godot_ai":
+		return "Refusing to write under res://addons/godot_ai/ (overwriting the loaded plugin can crash the editor)"
 	return ""
 
 

--- a/test_project/tests/test_path_validator.gd
+++ b/test_project/tests/test_path_validator.gd
@@ -167,6 +167,36 @@ func test_write_rejects_override_cfg() -> void:
 	assert_contains(err, "override.cfg")
 
 
+func test_write_rejects_own_plugin_tree() -> void:
+	## #689: overwriting the currently-loaded plugin's own scripts (plus the
+	## immediate reimport every write path triggers) can crash the editor or
+	## corrupt the installed plugin so the next enable fails to resolve scripts.
+	var err := McpPathValidator.validate_resource_path("res://addons/godot_ai/plugin.gd", true)
+	assert_false(err.is_empty(), "writing res://addons/godot_ai/plugin.gd must be rejected")
+	assert_contains(err, "addons/godot_ai")
+
+
+func test_write_rejects_own_plugin_tree_nested() -> void:
+	var err := McpPathValidator.validate_resource_path("res://addons/godot_ai/handlers/node_handler.gd", true)
+	assert_false(err.is_empty(), "writing nested under res://addons/godot_ai/ must be rejected")
+
+
+func test_read_allows_own_plugin_tree() -> void:
+	## for_write defaults to false — reading the plugin's own source (e.g. to
+	## inspect it) must not be blocked.
+	assert_eq(McpPathValidator.validate_resource_path("res://addons/godot_ai/plugin.gd"), "")
+
+
+func test_write_allows_other_addons() -> void:
+	## The block is scoped to the godot_ai plugin's own tree, not every addon.
+	assert_eq(McpPathValidator.validate_resource_path("res://addons/some_other_plugin/plugin.gd", true), "")
+
+
+func test_write_blocklist_is_case_insensitive_for_own_plugin_tree() -> void:
+	var err := McpPathValidator.validate_resource_path("res://Addons/Godot_AI/plugin.gd", true)
+	assert_false(err.is_empty(), "case-variant spelling of addons/godot_ai must still be rejected")
+
+
 func test_write_blocklist_is_case_insensitive() -> void:
 	## macOS/Windows default filesystems are case-insensitive, so a case-variant
 	## spelling resolves to the same protected file and must be refused.

--- a/test_project/tests/test_tileset_atlas.gd
+++ b/test_project/tests/test_tileset_atlas.gd
@@ -110,6 +110,27 @@ func test_nonexistent_path_returns_resource_not_found() -> void:
 	assert_contains(result.error.message, fake_path)
 
 
+func test_traversal_path_rejected_before_load() -> void:
+	## #689: _resolve_atlas_source skipped the #347 traversal guard every
+	## sibling load handler uses — checking only is_empty(). A res://../…
+	## payload must be rejected with VALUE_OUT_OF_RANGE, not handed to load().
+	var result := _handler.get_atlas_tiles({
+		"tileset_path": "res://../etc/passwd.tres",
+		"source_id": 0,
+	})
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
+
+
+func test_absolute_path_rejected_before_load() -> void:
+	## A raw absolute path (which load() honors directly) must be rejected too
+	## — it's outside res:// containment even without a literal '..'.
+	var result := _handler.get_atlas_tiles({
+		"tileset_path": "/etc/passwd",
+		"source_id": 0,
+	})
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
+
+
 func test_wrong_type_resource_returns_wrong_type() -> void:
 	## A resource that is not a TileSet (plain Resource) → WRONG_TYPE
 	## Validates: Requirement 1.5


### PR DESCRIPTION
## Summary

Fixes #689 — three independent gaps where a filesystem-touching handler was weaker than its siblings:

1. **Plugin self-overwrite** (`path_validator.gd:135`): `McpPathValidator._reject_sensitive_write` blocked `project.godot`, `override.cfg`, and `.godot/`, but had no clause for `res://addons/godot_ai/` — the directory holding the currently-loaded plugin scripts. Every write entry point (`write_file`, `create_script`/`patch_script`, scene save) routes through it. Writing there (plus the immediate `update_file()` reimport) can crash the editor or corrupt the installed plugin. Now refused for writes; reads remain unaffected (inspecting the plugin's own source is legitimate).
2. **Unchecked writes** (`script_handler.gd:375`, plus `:52-53` and `filesystem_handler.gd:83-84`): `create_script`, `patch_script`, and `write_file` opened the target with `FileAccess.WRITE` (truncating), called `store_string`, and reported success without checking `get_error()`. A failed/partial write (full disk, quota, flaky mount) silently truncates the file while the tool reports success with a size taken from the *input* string. Added `flush()` + `get_error()` checks that surface `INTERNAL_ERROR` instead, mirroring the existing pattern already used in `update_reload_runner.gd:378`.
3. **Tileset traversal guard** (`tileset_handler.gd:148`): `_resolve_atlas_source` was the one load handler with zero `McpPathValidator` references — checking only `is_empty()`. `tileset_get_atlas_tiles`/`get_atlas_image` accepted `res://../…` traversal and raw absolute paths that every sibling read handler rejects, re-opening the #347 info-disclosure surface. Added the same `loadable_error` guard `audio_handler.gd` uses.

None of these three findings were flagged as maintainer design decisions in `docs/audit-tier2-plan.md`, so all three are fully implemented here (unlike #685/#687/#688/#690's flagged items).

## Test plan

- [x] `ruff check src/ tests/`
- [x] `pytest -q` — 1307 passed, 4 skipped
- [x] `bash script/ci-check-gdscript` — all GDScript OK
- [x] Live editor test via `script/ci-start-server` + fresh headless editor + `script/ci-godot-tests` — 0 failed (1725/1743 passed)
- [x] New GDScript tests:
  - `test_path_validator.gd`: `test_write_rejects_own_plugin_tree`, `test_write_rejects_own_plugin_tree_nested`, `test_read_allows_own_plugin_tree`, `test_write_allows_other_addons`, `test_write_blocklist_is_case_insensitive_for_own_plugin_tree`
  - `test_tileset_atlas.gd`: `test_traversal_path_rejected_before_load`, `test_absolute_path_rejected_before_load`
  - The `flush()`/`get_error()` write-failure branch mirrors the existing (also untested for the same reason — a portable, deterministic disk-full/quota failure isn't feasible to simulate in this CI environment, including as root where permission-based tricks don't block writes) pattern at `update_reload_runner.gd:378`; the happy-path regression is covered by the full existing `script`/`filesystem` suites, which now exercise the new `flush()`/`get_error()` lines on every passing write and stayed green.
- [x] `git checkout -- test_project/project.godot` (no editor churn was staged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYSH45sEiTHKWx8rupx4vU

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYSH45sEiTHKWx8rupx4vU)_