### PR TITLE
Verify self-update/atomic-write bytes actually landed before trusting them

### DIFF
--- a/plugin/addons/godot_ai/clients/_atomic_write.gd
+++ b/plugin/addons/godot_ai/clients/_atomic_write.gd
@@ -66,6 +66,16 @@ static func write(path: String, content: String) -> bool:
 	# which preserves it.
 	_apply_mode(tmp_path, target_mode)
 
+	# Verify the staged temp actually landed on disk before either commit path
+	# (rename or the copy-fallback below) trusts it. The copy-fallback path
+	# already guards this (_written_size_matches at line ~95 below) — under
+	# disk-full/quota a truncated rename would otherwise "succeed" and the
+	# caller would treat a corrupt config as correctly written while the
+	# `.backup` (not yet taken) holds nothing to recover from.
+	if not _written_size_matches(tmp_path, content):
+		DirAccess.remove_absolute(tmp_path)
+		return false
+
 	# Best-effort: snapshot the prior file before we touch the target so we
 	# can restore on a failed swap. The backup is also kept on success as a
 	# one-shot rollback aid for the user — give it the same (preserved) mode

--- a/plugin/addons/godot_ai/update_reload_runner.gd
+++ b/plugin/addons/godot_ai/update_reload_runner.gd
@@ -374,13 +374,25 @@ func _install_zip_file(
 			FileAccess.get_open_error(),
 		])
 		return {}
-	f.store_buffer(content)
+	## store_buffer only reports a short write via its bool return — it does
+	## NOT set the last-error state get_error() reads — and the write is
+	## stdio-buffered, so disk-full can surface only at close(). Check both
+	## signals, then verify the bytes actually landed on disk before trusting
+	## this temp file: a truncated file renamed over a live plugin script (or
+	## project.godot) parse-error-cascades the next enable with no rollback.
+	var stored := f.store_buffer(content)
 	var write_error := f.get_error()
 	f.close()
-	if write_error != OK:
-		print("MCP | update extract failed: write error %d for %s" % [
+	var on_disk_size := -1
+	if stored and write_error == OK:
+		on_disk_size = FileAccess.get_file_as_bytes(temp_path).size()
+	if not stored or write_error != OK or on_disk_size != content.size():
+		print("MCP | update extract failed: write error %d for %s (stored=%s, on_disk_size=%d, expected=%d)" % [
 			write_error,
 			temp_path,
+			stored,
+			on_disk_size,
+			content.size(),
 		])
 		DirAccess.remove_absolute(temp_path)
 		return {}

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -1597,6 +1597,44 @@ func test_atomic_write_preserves_existing_file_when_swap_fails() -> void:
 	DirAccess.remove_absolute(backup_path)
 
 
+# ----- atomic write: staged-temp size verification (#687 finding 3) -----
+#
+# _written_size_matches is the same integrity gate the copy-fallback path
+# (line ~95) already enforced; write() now calls it on the staged temp file
+# too, before either commit path (rename or copy-fallback) trusts it. Actually
+# forcing FileAccess to report a false "success" on a truncated write requires
+# OS-level fault injection (disk-full/quota) that isn't portable or
+# deterministic in CI — the same limitation noted on the analogous
+# update_reload_runner.gd:378 write-verification gap. These tests pin the
+# helper's exact contract directly instead.
+
+func test_written_size_matches_true_for_exact_content() -> void:
+	var path := _scratch_dir.path_join("size_match_ok.txt")
+	var content := "exact byte match"
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	f.store_string(content)
+	f.flush()
+	f.close()
+	assert_true(McpAtomicWrite._written_size_matches(path, content))
+
+
+func test_written_size_matches_false_for_truncated_content() -> void:
+	## Simulates the disk-full/quota failure shape: the temp file on disk has
+	## fewer bytes than the content that was supposed to be written.
+	var path := _scratch_dir.path_join("size_match_truncated.txt")
+	var full_content := "this content did not fully land on disk"
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	f.store_string(full_content.substr(0, 10))  # only the first 10 bytes "landed"
+	f.flush()
+	f.close()
+	assert_false(McpAtomicWrite._written_size_matches(path, full_content))
+
+
+func test_written_size_matches_false_for_missing_file() -> void:
+	var path := _scratch_dir.path_join("size_match_missing.txt")
+	assert_false(McpAtomicWrite._written_size_matches(path, "anything"))
+
+
 # ----- atomic write: concurrency + symlink targets (#534) -----
 
 ## List leftover files in _scratch_dir whose name starts with `prefix` — used


### PR DESCRIPTION
## Summary

Fixes findings 2 and 3 of #687 — two mechanical write-verification gaps in the self-update/atomic-write paths that could install or persist a truncated file with no rollback path left:

- **`update_reload_runner.gd::_install_zip_file`** ignored `store_buffer`'s bool return (confirmed via a scratch script against this engine's Godot 4.7 — `store_buffer` returns `bool`, unlike `store_string`, and does **not** set the `get_error()` state on a short write) and never verified the temp file's actual on-disk size before renaming it over a live plugin script. A disk-full mid-update could rename a truncated file over e.g. `plugin.gd`, delete backups via `_finalize_install_success`, and leave the plugin to re-enable against a corrupt tree. Now checks `stored`, `write_error`, and the real on-disk byte count before trusting the temp file.
- **`_atomic_write.gd::write()`** staged its temp file via `store_string`/`flush`/`close` with no size check, then committed by rename — while the copy-fallback path immediately below already enforced exactly this via `_written_size_matches` (the #297 data-loss guard the module header cites). Both commit paths now share the same integrity gate.

## Not included — needs a maintainer decision

Finding 1 of #687 (self-signed checksum: `download_url` and `checksum_url` both come from the same GitHub Releases API response, so a compromised release workflow/token can regenerate a matching `.sha256`) is a release-pipeline design change — `docs/audit-tier2-plan.md` flags "#687 release signing (ed25519/minisign + key management)" as a maintainer infra decision. Raised as a comment on #687; not attempted here.

## ⚠️ Verification gap — needs maintainer sign-off before merge

This PR touches `update_reload_runner.gd` and `_atomic_write.gd`, which per `AGENTS.md` requires running `script/local-self-update-smoke` — an **interactive** harness where "the operator still performs the one step that matters: click Update in the dock." This session is headless with no GUI, so I have no way to drive that click. I did not skip this by choice; I'm flagging it explicitly rather than claiming a check I couldn't run. Everything else in the gauntlet is green (see below). Please run `script/local-self-update-smoke` before merging.

## Test plan

- [x] `ruff check src/ tests/`
- [x] `pytest -q` — 1307 passed, 4 skipped
- [x] `bash script/ci-check-gdscript` — all GDScript OK
- [x] Live editor test via `script/ci-start-server` + fresh headless editor + `script/ci-godot-tests` — 0 failed (1724/1742 passed); `update_reload_runner` suite 16/16, `clients` suite 115/115
- [x] New GDScript tests in `test_clients.gd`: `test_written_size_matches_true_for_exact_content`, `test_written_size_matches_false_for_truncated_content`, `test_written_size_matches_false_for_missing_file` — pin `_written_size_matches`'s exact contract directly, since forcing a genuine disk-full/quota failure through the real `write()`/`_install_zip_file` call path isn't portable or deterministic in this CI environment (same limitation as the existing, similarly-untested `update_reload_runner.gd:378` pattern this PR extends)
- [ ] `script/local-self-update-smoke` — **not run**, see above
- [x] `git checkout -- test_project/project.godot` (no editor churn was staged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYSH45sEiTHKWx8rupx4vU

---
_Generated by [Claude Code](https://claude.ai/code/session_01MYSH45sEiTHKWx8rupx4vU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented incomplete or truncated temporary files from being committed during atomic writes.
  - Added validation to ensure extracted update files are fully written before installation.
  - Improved write failure reporting with details about stored and expected file sizes.

- **Tests**
  - Added coverage for complete, truncated, and missing temporary files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->