### PR TITLE
Correct #687 self-update checksum docstring overclaim

### DIFF
--- a/plugin/addons/godot_ai/utils/update_manager.gd
+++ b/plugin/addons/godot_ai/utils/update_manager.gd
@@ -403,9 +403,13 @@ func _on_download_completed(
 
 ## Gate the extract on a SHA-256 match against the release's checksum sidecar.
 ## TLS + host pinning already constrain where the bytes came from; this
-## verifies the bytes themselves so a tampered asset (or a compromised CDN
-## object) can't be installed over live plugin code. Verification is
-## MANDATORY (#599): a release published without a `.sha256` sidecar —
+## verifies the bytes themselves so in-transit corruption or a substituted
+## CDN object can't be installed over live plugin code. This does NOT
+## protect against a compromised release: download_url and checksum_url
+## both come from the same GitHub Releases API response, so anyone able to
+## tamper with the release's assets can regenerate a matching sidecar
+## (tracked in #687 — signing the sidecar would close this gap). Verification
+## is MANDATORY (#599): a release published without a `.sha256` sidecar —
 ## mistake or tamper — refuses to install rather than silently downgrading
 ## to an unverified install. This is safe because self-update only ever
 ## verifies the *next* download, and every release since #523 publishes the


### PR DESCRIPTION
## Summary

Small follow-up on #687 finding 1 (self-signed checksum). The design fix (ed25519/minisign release signing) is a flagged maintainer decision — already asked as a comment on #687, still unanswered, not attempted here. This PR is the "immediate mechanical tightening" the issue calls out separately: `update_manager.gd::_verify_then_install`'s docstring claimed a tampered asset "can't be installed over live plugin code," which overclaims. `download_url` and `checksum_url` both come from the same GitHub Releases API response, so the SHA-256 check only guards against in-transit corruption / a substituted CDN object — **not** a compromised release (a leaked token or compromised release workflow could regenerate a matching sidecar). Restated the docstring to say so, and pointed at #687 for the actual fix.

Deletions/tightening only — no behavior change, comment-only diff.

## Context for reviewers

This session picked up `docs/audit-tier2-plan.md`'s Phase-1 issue list (#685–#691). By the time this session started, six of the seven were already closed and merged by a prior session + your review (#693/#694/#696/#697/#698/#699). #687 is the only one still open: PR #702 (open, unmerged) already fixes findings 2 and 3 (write-verification gaps) and is flagged for your `script/local-self-update-smoke` sign-off before merge. Finding 1's design question (signing scheme, key management, public-key distribution, rollout for pre-signing installs) is asked in a comment on #687 — this PR doesn't attempt an answer, just the safe mechanical piece.

## Test plan

- [x] `ruff check src/ tests/`
- [x] `pytest -q` — 1329 passed, 4 skipped
- [x] `bash script/ci-check-gdscript` — all GDScript OK
- [x] Live editor test: `script/ci-start-server` + headless editor + `script/ci-godot-tests` — 1752/1770 passed, 0 failed
- [x] `git checkout -- test_project/project.godot` — no editor churn was staged

Not a self-update/lifecycle/spawn/kill change, so the stale-server and self-update smoke scripts don't apply here (comment-only change to a docstring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKrxaeo4GgYjqWDEcw3PFg

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKrxaeo4GgYjqWDEcw3PFg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified update integrity verification behavior, including protection against corrupted downloads.
  * Documented that updates are refused when a checksum is unavailable.
  * Noted the limitations of verification when download and checksum sources are compromised together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->