### PR TITLE
Phase 2: protocol-boundary defense (batch pre-validation + cap, reserved-key strip, malformed-frame guard)

### DIFF
--- a/plugin/addons/godot_ai/connection.gd
+++ b/plugin/addons/godot_ai/connection.gd
@@ -321,6 +321,7 @@ func _handle_message(raw: String) -> void:
 			)
 			response["request_id"] = rid
 			response["readiness"] = get_readiness()
+			_stamp_error_watermark(response)
 			_send_json(response)
 
 

--- a/plugin/addons/godot_ai/connection.gd
+++ b/plugin/addons/godot_ai/connection.gd
@@ -299,8 +299,29 @@ func _handle_message(raw: String) -> void:
 		server_version = str(parsed.get("server_version", ""))
 		return
 	if parsed.has("request_id") and parsed.has("command"):
-		if dispatcher:
-			dispatcher.enqueue(parsed)
+		if (
+			parsed.get("request_id") is String
+			and parsed.get("command") is String
+			and (not parsed.has("params") or parsed.get("params") is Dictionary)
+		):
+			if dispatcher:
+				dispatcher.enqueue(parsed)
+			return
+		## Never enqueue a malformed command frame: the dispatcher's typed
+		## casts would error on the queue head every tick, wedging every
+		## later command behind it. Reply with an error when the request_id
+		## is usable so the server's pending future resolves instead of
+		## waiting out the full command timeout.
+		push_warning("MCP: dropping malformed command frame (request_id/command must be String, params a Dictionary)")
+		var rid: Variant = parsed.get("request_id")
+		if rid is String and not String(rid).is_empty():
+			var response := ErrorCodes.make(
+				ErrorCodes.INVALID_PARAMS,
+				"Malformed command frame: request_id/command must be strings and params a dict"
+			)
+			response["request_id"] = rid
+			response["readiness"] = get_readiness()
+			_send_json(response)
 
 
 ## Send a state event to the server (not a command response).

--- a/plugin/addons/godot_ai/dispatcher.gd
+++ b/plugin/addons/godot_ai/dispatcher.gd
@@ -54,6 +54,15 @@ func clear() -> void:
 func dispatch_direct(command: String, params: Dictionary) -> Dictionary:
 	if not _handlers.has(command):
 		return ErrorCodes.make(ErrorCodes.UNKNOWN_COMMAND, "Unknown command: %s" % command)
+	## Strip the reserved deferred-reply key: only _dispatch may thread it.
+	## A caller-supplied _request_id (e.g. inside a batch_execute
+	## sub-command's params) would flip a deferred-capable handler into
+	## deferred mode against a request id the dispatcher never registered —
+	## the direct caller would get the DEFERRED sentinel instead of a result
+	## and the out-of-band reply would be dropped as expired.
+	if params.has("_request_id"):
+		params = params.duplicate()
+		params.erase("_request_id")
 	return _call_handler(command, params)
 
 

--- a/plugin/addons/godot_ai/handlers/batch_handler.gd
+++ b/plugin/addons/godot_ai/handlers/batch_handler.gd
@@ -9,6 +9,12 @@ const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
 
 const FORBIDDEN_SUBCOMMANDS := ["batch_execute"]
 
+## The whole batch executes synchronously inside one dispatcher tick,
+## outside the 4ms frame budget — an unbounded array freezes the editor
+## for the batch's full duration. 500 is far above any legitimate scene
+## edit while keeping worst-case stalls in check.
+const MAX_BATCH_COMMANDS := 500
+
 var _dispatcher: McpDispatcher
 var _undo_redo: EditorUndoRedoManager
 
@@ -24,6 +30,11 @@ func batch_execute(params: Dictionary) -> Dictionary:
 		return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "commands must be a list")
 	if commands.is_empty():
 		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "commands must not be empty")
+	if commands.size() > MAX_BATCH_COMMANDS:
+		return ErrorCodes.make(
+			ErrorCodes.VALUE_OUT_OF_RANGE,
+			"commands exceeds the %d-command batch cap (got %d) — split into multiple batches" % [MAX_BATCH_COMMANDS, commands.size()]
+		)
 
 	var undo: bool = params.get("undo", true)
 
@@ -38,6 +49,12 @@ func batch_execute(params: Dictionary) -> Dictionary:
 			return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "commands[%d]: '%s' is not allowed as a sub-command" % [idx, cmd_name])
 		if not _dispatcher.has_command(cmd_name):
 			return _unknown_command_error(idx, cmd_name)
+		## Pre-validate params type: the execution loop's typed Dictionary
+		## local would hard-error on a non-dict mid-batch, aborting AFTER
+		## earlier mutations committed. Catching it here keeps the
+		## all-or-nothing contract for malformed input.
+		if typeof(item.get("params", {})) != TYPE_DICTIONARY:
+			return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "commands[%d].params must be a dict" % idx)
 
 	var results: Array = []
 	var succeeded := 0

--- a/test_project/tests/test_batch.gd
+++ b/test_project/tests/test_batch.gd
@@ -241,6 +241,7 @@ func test_batch_sub_command_cannot_carry_reserved_request_id() -> void:
 		{"command": "_capture_params", "params": {"_request_id": "hijack", "x": 1}},
 	]})
 	assert_has_key(result, "data")
+	assert_eq(result.data.succeeded, 1, "the sub-command should execute normally")
 	assert_eq(seen.size(), 1)
 	assert_true(not seen[0].has("_request_id"),
 		"dispatch_direct must strip the reserved deferred-reply key")

--- a/test_project/tests/test_batch.gd
+++ b/test_project/tests/test_batch.gd
@@ -207,3 +207,41 @@ func test_real_multi_step_success() -> void:
 	var ur := _undo_for_scene(scene_root)
 	ur.undo()
 	ur.undo()
+
+
+# ----- pre-validation: params type, batch cap, reserved keys -----
+
+func test_batch_rejects_non_dict_params_without_executing() -> void:
+	var result := _handler.batch_execute({"commands": [
+		{"command": "_ok_pure"},
+		{"command": "_ok_pure", "params": "nope"},
+	]})
+	assert_is_error(result, ErrorCodes.WRONG_TYPE)
+	assert_contains(result.error.message, "commands[1].params")
+	assert_eq(_call_log.size(), 0,
+		"pre-validation failure must execute nothing (all-or-nothing)")
+
+
+func test_batch_rejects_over_cap_without_executing() -> void:
+	var commands: Array = []
+	for i in range(BatchHandler.MAX_BATCH_COMMANDS + 1):
+		commands.append({"command": "_ok_pure"})
+	var result := _handler.batch_execute({"commands": commands})
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
+	assert_contains(result.error.message, "batch cap")
+	assert_eq(_call_log.size(), 0, "an over-cap batch must execute nothing")
+
+
+func test_batch_sub_command_cannot_carry_reserved_request_id() -> void:
+	var seen: Array = []
+	_dispatcher.register("_capture_params", func(p: Dictionary) -> Dictionary:
+		seen.append(p.duplicate())
+		return {"data": {"undoable": false}})
+	var result := _handler.batch_execute({"commands": [
+		{"command": "_capture_params", "params": {"_request_id": "hijack", "x": 1}},
+	]})
+	assert_has_key(result, "data")
+	assert_eq(seen.size(), 1)
+	assert_true(not seen[0].has("_request_id"),
+		"dispatch_direct must strip the reserved deferred-reply key")
+	assert_eq(seen[0].get("x"), 1)

--- a/test_project/tests/test_connection.gd
+++ b/test_project/tests/test_connection.gd
@@ -560,3 +560,55 @@ func test_clear_on_disconnect_resets_spillover_counter() -> void:
 
 	assert_eq(conn._packet_spillover_total, 0, "disconnect must reset the spillover counter")
 	conn.free()
+
+
+# ----- inbound command-frame validation -----
+
+func _make_conn_with_dispatcher() -> Array:
+	var conn := McpConnection.new()
+	var dispatcher := McpDispatcher.new(McpLogBuffer.new())
+	dispatcher.mcp_logging = false
+	conn.dispatcher = dispatcher
+	return [conn, dispatcher]
+
+
+func test_handle_message_enqueues_well_formed_command_frame() -> void:
+	var pair := _make_conn_with_dispatcher()
+	var conn: McpConnection = pair[0]
+	var dispatcher: McpDispatcher = pair[1]
+	conn._handle_message('{"request_id": "r1", "command": "noop", "params": {}}')
+	conn._handle_message('{"request_id": "r2", "command": "noop"}')
+	assert_eq(dispatcher._command_queue.size(), 2,
+		"well-formed frames (params optional) must be enqueued")
+	conn.free()
+
+
+func test_handle_message_drops_non_string_request_id() -> void:
+	var pair := _make_conn_with_dispatcher()
+	var conn: McpConnection = pair[0]
+	var dispatcher: McpDispatcher = pair[1]
+	conn._handle_message('{"request_id": 5, "command": "noop", "params": {}}')
+	assert_eq(dispatcher._command_queue.size(), 0,
+		"a non-String request_id would wedge the dispatcher's typed cast")
+	conn.free()
+
+
+func test_handle_message_drops_non_string_command() -> void:
+	var pair := _make_conn_with_dispatcher()
+	var conn: McpConnection = pair[0]
+	var dispatcher: McpDispatcher = pair[1]
+	conn._handle_message('{"request_id": "r1", "command": {"nested": true}}')
+	assert_eq(dispatcher._command_queue.size(), 0,
+		"a non-String command would wedge the dispatcher's typed cast")
+	conn.free()
+
+
+func test_handle_message_drops_non_dict_params() -> void:
+	var pair := _make_conn_with_dispatcher()
+	var conn: McpConnection = pair[0]
+	var dispatcher: McpDispatcher = pair[1]
+	conn._handle_message('{"request_id": "r1", "command": "noop", "params": [1, 2]}')
+	conn._handle_message('{"request_id": "r2", "command": "noop", "params": "str"}')
+	assert_eq(dispatcher._command_queue.size(), 0,
+		"non-Dictionary params would wedge the dispatcher's typed cast")
+	conn.free()

--- a/test_project/tests/test_dispatcher.gd
+++ b/test_project/tests/test_dispatcher.gd
@@ -381,6 +381,7 @@ func test_dispatch_direct_strips_reserved_request_id_key() -> void:
 	var caller_params := {"_request_id": "hijack", "x": 1}
 	var result := d.dispatch_direct("capture_params", caller_params)
 	assert_has_key(result, "data")
+	assert_eq(result.data.ok, true, "handler should run normally and return its data")
 	assert_eq(seen.size(), 1)
 	assert_true(not seen[0].has("_request_id"),
 		"reserved key must be stripped before the handler sees params")

--- a/test_project/tests/test_dispatcher.gd
+++ b/test_project/tests/test_dispatcher.gd
@@ -367,3 +367,23 @@ func test_tick_stamps_error_watermark_on_deferred_timeout_response() -> void:
 	assert_eq(responses.size(), 1)
 	assert_is_error(responses[0], ErrorCodes.DEFERRED_TIMEOUT)
 	assert_eq(responses[0].error_watermark.debugger_promoted, 2)
+
+
+# ----- reserved-key stripping (dispatch_direct) -----
+
+func test_dispatch_direct_strips_reserved_request_id_key() -> void:
+	var d := _make_dispatcher()
+	d.mcp_logging = false
+	var seen: Array = []
+	d.register("capture_params", func(p: Dictionary) -> Dictionary:
+		seen.append(p.duplicate())
+		return {"data": {"ok": true}})
+	var caller_params := {"_request_id": "hijack", "x": 1}
+	var result := d.dispatch_direct("capture_params", caller_params)
+	assert_has_key(result, "data")
+	assert_eq(seen.size(), 1)
+	assert_true(not seen[0].has("_request_id"),
+		"reserved key must be stripped before the handler sees params")
+	assert_eq(seen[0].get("x"), 1)
+	assert_true(caller_params.has("_request_id"),
+		"stripping must not mutate the caller's dict")


### PR DESCRIPTION
## Summary

First themed PR of the audit plan's Phase 2 (`docs/audit-tier2-plan.md`), batching the four Tier-1 backlog defense items at the WebSocket → dispatcher → batch boundary. Each was re-verified against current main before touching anything:

1. **`batch_execute` pre-validates sub-command `params` type.** The execution loop's typed `Dictionary` local hard-errors on a non-dict *mid-batch*, aborting after earlier mutations already committed — breaking the all-or-nothing contract. Malformed input is now rejected up front with `WRONG_TYPE` naming the offending index, before anything executes.
2. **`MAX_BATCH_COMMANDS` cap (500).** The whole batch executes synchronously inside one dispatcher tick, outside the 4ms frame budget — an unbounded `commands` array freezes the editor for the batch's full duration. Over-cap batches are rejected with `VALUE_OUT_OF_RANGE` before anything executes.
3. **`dispatch_direct` strips the reserved `_request_id` key.** A caller-supplied `_request_id` inside a `batch_execute` sub-command's params flipped deferred-capable handlers into deferred mode against a request id the dispatcher never registered — the batch received the DEFERRED sentinel as its result and the out-of-band reply was dropped as expired. Stripping at the single chokepoint covers batch and any future direct callers; the caller's dict is not mutated.
4. **`_handle_message` typed guard on inbound command frames.** A frame with a non-String `request_id`/`command` or non-Dictionary `params` used to be enqueued verbatim; the dispatcher's typed casts then errored on the queue head **every tick**, permanently wedging all later commands behind it. Malformed frames are now dropped with a warning — and when the `request_id` is usable, the plugin replies with `INVALID_PARAMS` (on a readiness-stamped envelope, per the AGENTS.md response-builder rule) so the server's pending future resolves instead of waiting out the full command timeout.

## Testing

8 new GDScript tests: `test_batch` (params-type rejection executes nothing; over-cap executes nothing; sub-command `_request_id` is stripped), `test_dispatcher` (`dispatch_direct` strips the reserved key without mutating the caller's dict), `test_connection` (well-formed frames enqueue with params optional; non-String `request_id`, non-String `command`, and non-dict `params` are all dropped).

Gauntlet: `ruff` clean · `pytest` 1329 passed · `ci-check-gdscript` OK · `ci-godot-tests` **1760/1778 passed, 0 failed** (live editor). Doesn't touch spawn/kill/self-update paths, so the stale-server and self-update smokes don't apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2zhpWvnqijYYRW3dwtUhV

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2zhpWvnqijYYRW3dwtUhV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added strict validation for incoming command frames; malformed requests are dropped with a warning and an `INVALID_PARAMS` error when a valid `request_id` is available.
  * Prevented reserved `_request_id` metadata from being forwarded by stripping it from dispatched handler params.
  * Enforced a maximum batch size (500) and improved per-command `params` type validation with clearer, index-specific errors.

* **Tests**
  * Added tests for inbound frame validation, batch caps/type checks, all-or-nothing batch execution, and `_request_id` stripping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->