### PR TITLE
Phase 2: handler error-format and validation parity (8 audit items)

### DIFF
--- a/plugin/addons/godot_ai/handlers/animation_handler.gd
+++ b/plugin/addons/godot_ai/handlers/animation_handler.gd
@@ -770,7 +770,7 @@ func _instantiate_player(player_path: String, scene_root: Node) -> Dictionary:
 	else:
 		parent = McpScenePath.resolve(parent_path, scene_root)
 	if parent == null:
-		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS,
+		return ErrorCodes.make(ErrorCodes.NODE_NOT_FOUND,
 			"Cannot auto-create AnimationPlayer at %s: %s" % [
 				player_path, McpScenePath.format_parent_error(parent_path, scene_root)])
 	var new_player := AnimationPlayer.new()

--- a/plugin/addons/godot_ai/handlers/camera_handler.gd
+++ b/plugin/addons/godot_ai/handlers/camera_handler.gd
@@ -793,7 +793,8 @@ func follow_2d(params: Dictionary) -> Dictionary:
 		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: target_path")
 	var target := McpScenePath.resolve(target_path, scene_root)
 	if target == null:
-		return ErrorCodes.make(ErrorCodes.NODE_NOT_FOUND, "Target not found: %s" % target_path)
+		return ErrorCodes.make(ErrorCodes.NODE_NOT_FOUND,
+			"target_path: %s" % McpScenePath.format_node_error(target_path, scene_root))
 	if not (target is Node2D) and target != scene_root:
 		return ErrorCodes.make(
 			ErrorCodes.WRONG_TYPE,

--- a/plugin/addons/godot_ai/handlers/curve_handler.gd
+++ b/plugin/addons/godot_ai/handlers/curve_handler.gd
@@ -69,7 +69,7 @@ func set_points(params: Dictionary) -> Dictionary:
 		if not (property in node):
 			return ErrorCodes.make(
 				ErrorCodes.PROPERTY_NOT_ON_CLASS,
-				"Property '%s' not found on %s" % [property, node.get_class()]
+				McpPropertyErrors.build_message(node, property)
 			)
 		curve = node.get(property)
 		# Auto-create a fresh Curve subclass if the slot is empty. Infer the

--- a/plugin/addons/godot_ai/handlers/material_handler.gd
+++ b/plugin/addons/godot_ai/handlers/material_handler.gd
@@ -567,17 +567,19 @@ func apply_preset(params: Dictionary) -> Dictionary:
 			inline_result.data["reason"] = "Inline material assigned to node"
 		return inline_result
 
-	# Save-to-disk path.
+	# Save-to-disk path. Validate the path BEFORE the exists/overwrite
+	# check, matching create_material's order — an invalid path should
+	# always be reported as invalid, not as an overwrite conflict.
+	var path_err := _validate_material_path(path, "path", true)
+	if path_err != null:
+		return path_err
+
 	var existed_before := FileAccess.file_exists(path)
 	if existed_before and not params.get("overwrite", false):
 		return ErrorCodes.make(
 			ErrorCodes.INVALID_PARAMS,
 			"Material already exists at %s (pass overwrite=true to replace)" % path
 		)
-
-	var path_err := _validate_material_path(path, "path", true)
-	if path_err != null:
-		return path_err
 
 	var mat := _instantiate_material(type_str)
 	for prop_name in preset_params:
@@ -639,6 +641,7 @@ func apply_preset(params: Dictionary) -> Dictionary:
 func _apply_param(mat_path: String, property: String, value: Variant, _is_shader: bool) -> void:
 	var mat: Material = ResourceLoader.load(mat_path)
 	if mat == null:
+		push_warning("MCP: Failed to load material for undo/redo: %s" % mat_path)
 		return
 	mat.set(property, value)
 	McpResourceIO.guarded_save(mat, mat_path, _connection)
@@ -647,6 +650,7 @@ func _apply_param(mat_path: String, property: String, value: Variant, _is_shader
 func _apply_shader_param(mat_path: String, param_name: String, value: Variant) -> void:
 	var mat: Material = ResourceLoader.load(mat_path)
 	if mat == null or not (mat is ShaderMaterial):
+		push_warning("MCP: Failed to load shader material for undo/redo: %s" % mat_path)
 		return
 	(mat as ShaderMaterial).set_shader_parameter(param_name, value)
 	McpResourceIO.guarded_save(mat, mat_path, _connection)

--- a/plugin/addons/godot_ai/handlers/physics_shape_handler.gd
+++ b/plugin/addons/godot_ai/handlers/physics_shape_handler.gd
@@ -60,7 +60,8 @@ func autofit(params: Dictionary) -> Dictionary:
 	else:
 		source = McpScenePath.resolve(source_path, scene_root)
 		if source == null:
-			return ErrorCodes.make(ErrorCodes.NODE_NOT_FOUND, "Source node not found: %s" % source_path)
+			return ErrorCodes.make(ErrorCodes.NODE_NOT_FOUND,
+				"source_path: %s" % McpScenePath.format_node_error(source_path, scene_root))
 
 	var shape_type: String = params.get("shape_type", "box" if is_3d else "rectangle")
 	var type_map := _SHAPE_3D_CLASSES if is_3d else _SHAPE_2D_CLASSES

--- a/plugin/addons/godot_ai/handlers/resource_handler.gd
+++ b/plugin/addons/godot_ai/handlers/resource_handler.gd
@@ -411,7 +411,7 @@ func _assign_created_resource(res: Resource, type_str: String, node_path: String
 	if not found:
 		return ErrorCodes.make(
 			ErrorCodes.PROPERTY_NOT_ON_CLASS,
-			"Property '%s' not found on %s" % [property, node.get_class()]
+			McpPropertyErrors.build_message(node, property)
 		)
 	if prop_type != TYPE_NIL and prop_type != TYPE_OBJECT:
 		return ErrorCodes.make(

--- a/plugin/addons/godot_ai/handlers/script_handler.gd
+++ b/plugin/addons/godot_ai/handlers/script_handler.gd
@@ -499,9 +499,17 @@ func find_symbols(params: Dictionary) -> Dictionary:
 	for i in lines.size():
 		var line := lines[i].strip_edges()
 
-		# class_name
+		# class_name — same cut logic as _extract_class_name so the
+		# `extends Bar` / icon-form tails don't leak into the symbol name.
 		if line.begins_with("class_name "):
-			class_name_str = line.substr(11).strip_edges()
+			var cn_rest := line.substr(11).strip_edges()
+			var cn_cut := cn_rest.length()
+			for ci in cn_rest.length():
+				var cn_ch := cn_rest[ci]
+				if cn_ch == " " or cn_ch == "\t" or cn_ch == ",":
+					cn_cut = ci
+					break
+			class_name_str = cn_rest.substr(0, cn_cut)
 
 		# extends
 		if line.begins_with("extends "):

--- a/plugin/addons/godot_ai/handlers/signal_handler.gd
+++ b/plugin/addons/godot_ai/handlers/signal_handler.gd
@@ -13,7 +13,11 @@ func _init(undo_redo: EditorUndoRedoManager) -> void:
 
 
 func list_signals(params: Dictionary) -> Dictionary:
-	var path: String = params.get("path", "")
+	var path_value: Variant = params.get("path", "")
+	var path_type_err = McpParamValidators.require_string("path", path_value)
+	if path_type_err != null:
+		return path_type_err
+	var path: String = path_value
 	if path.is_empty():
 		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
 

--- a/plugin/addons/godot_ai/handlers/signal_handler.gd
+++ b/plugin/addons/godot_ai/handlers/signal_handler.gd
@@ -17,7 +17,9 @@ func list_signals(params: Dictionary) -> Dictionary:
 	var path_type_err = McpParamValidators.require_string("path", path_value)
 	if path_type_err != null:
 		return path_type_err
-	var path: String = path_value
+	## String(...) conversion: require_string accepts StringName too, and
+	## a bare typed assignment from StringName would defeat the guard.
+	var path: String = String(path_value)
 	if path.is_empty():
 		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: path")
 

--- a/plugin/addons/godot_ai/handlers/texture_handler.gd
+++ b/plugin/addons/godot_ai/handlers/texture_handler.gd
@@ -170,7 +170,7 @@ func _assign_texture(tex: Resource, sub_resources: Array, node_path: String, pro
 	if not found:
 		return ErrorCodes.make(
 			ErrorCodes.PROPERTY_NOT_ON_CLASS,
-			"Property '%s' not found on %s" % [property, node.get_class()]
+			McpPropertyErrors.build_message(node, property)
 		)
 	if prop_type != TYPE_NIL and prop_type != TYPE_OBJECT:
 		return ErrorCodes.make(

--- a/test_project/tests/test_animation.gd
+++ b/test_project/tests/test_animation.gd
@@ -2190,8 +2190,9 @@ func test_auto_create_player_missing_parent_is_node_not_found() -> void:
 	if scene_root == null:
 		skip("No scene root — is a scene open?")
 		return
+	var missing_player_path := "/%s/NoSuchParentNode/AutoPlayerProbe" % scene_root.name
 	var result := _handler.create_simple({
-		"player_path": "/%s/NoSuchParentNode/AutoPlayerProbe" % scene_root.name,
+		"player_path": missing_player_path,
 		"name": "probe",
 		"tweens": [
 			{"target": ".", "property": "position",
@@ -2201,3 +2202,5 @@ func test_auto_create_player_missing_parent_is_node_not_found() -> void:
 	})
 	assert_is_error(result, ErrorCodes.NODE_NOT_FOUND)
 	assert_contains(result.error.message, "Cannot auto-create AnimationPlayer")
+	assert_contains(result.error.message, missing_player_path,
+		"error must name the failing player_path")

--- a/test_project/tests/test_animation.gd
+++ b/test_project/tests/test_animation.gd
@@ -2181,3 +2181,23 @@ func test_preset_shake_accepts_scene_absolute_target() -> void:
 		"absolute target_path must convert to root_node-relative track path, got '%s'" % track_path)
 	_remove_node(player_path)
 	_remove_node(abs_target)
+
+
+func test_auto_create_player_missing_parent_is_node_not_found() -> void:
+	## Parity with the seven sibling parent resolutions: a missing parent
+	## is NODE_NOT_FOUND, not INVALID_PARAMS.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root — is a scene open?")
+		return
+	var result := _handler.create_simple({
+		"player_path": "/%s/NoSuchParentNode/AutoPlayerProbe" % scene_root.name,
+		"name": "probe",
+		"tweens": [
+			{"target": ".", "property": "position",
+			 "from": {"x": 0.0, "y": 0.0, "z": 0.0},
+			 "to": {"x": 1.0, "y": 0.0, "z": 0.0}, "duration": 0.5},
+		],
+	})
+	assert_is_error(result, ErrorCodes.NODE_NOT_FOUND)
+	assert_contains(result.error.message, "Cannot auto-create AnimationPlayer")

--- a/test_project/tests/test_camera.gd
+++ b/test_project/tests/test_camera.gd
@@ -1051,3 +1051,18 @@ func _collect(node: Node, out: Array) -> void:
 		out.append(node)
 	for child in node.get_children():
 		_collect(child, out)
+
+
+func test_follow_2d_missing_target_uses_shared_node_error_format() -> void:
+	var r := _create("FollowCamNoTarget", "2d")
+	if r.is_empty():
+		assert_true(false, "camera create failed")
+		return
+	var result := _handler.follow_2d({
+		"camera_path": r.data.path,
+		"target_path": "/Main/NoSuchFollowTarget",
+	})
+	assert_is_error(result, ErrorCodes.NODE_NOT_FOUND)
+	assert_contains(result.error.message, "target_path:",
+		"target resolution must use the shared format_node_error output with param context")
+	assert_contains(result.error.message, "NoSuchFollowTarget")

--- a/test_project/tests/test_curve.gd
+++ b/test_project/tests/test_curve.gd
@@ -423,3 +423,14 @@ func test_set_points_2d_non_dict_position_is_rejected() -> void:
 	assert_contains(msg, "Curve2D points[0].position")
 	assert_contains(msg, "Vector2")
 	_remove_node(p)
+
+
+func test_set_points_unknown_property_enriches_error() -> void:
+	var result := _handler.set_points({
+		"points": [{"x": 0.0, "y": 0.0}, {"x": 1.0, "y": 1.0}],
+		"path": "/Main/Camera3D",
+		"property": "not_a_curve_prop",
+	})
+	assert_is_error(result, ErrorCodes.PROPERTY_NOT_ON_CLASS)
+	assert_contains(result.error.message, "available:",
+		"property errors must use McpPropertyErrors.build_message enrichment")

--- a/test_project/tests/test_curve.gd
+++ b/test_project/tests/test_curve.gd
@@ -426,6 +426,10 @@ func test_set_points_2d_non_dict_position_is_rejected() -> void:
 
 
 func test_set_points_unknown_property_enriches_error() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root — is a scene open?")
+		return
 	var result := _handler.set_points({
 		"points": [{"x": 0.0, "y": 0.0}, {"x": 1.0, "y": 1.0}],
 		"path": "/Main/Camera3D",

--- a/test_project/tests/test_material.gd
+++ b/test_project/tests/test_material.gd
@@ -622,3 +622,15 @@ func test_apply_preset_with_overrides() -> void:
 	assert_true(abs(mat.metallic - 0.5) < 0.01)
 	assert_true(abs(mat.roughness - 0.9) < 0.01)
 	_remove_node(node)
+
+
+func test_apply_preset_invalid_path_reported_before_overwrite() -> void:
+	## Order parity with create_material: a path that both EXISTS and is
+	## invalid must fail path validation, not the exists/overwrite check.
+	var result := _handler.apply_preset({
+		"preset": "metal",
+		"path": "res://project.godot",
+	})
+	assert_has_key(result, "error")
+	assert_false(str(result.error.message).contains("already exists"),
+		"invalid path must be reported as invalid, not as an overwrite conflict")

--- a/test_project/tests/test_resource.gd
+++ b/test_project/tests/test_resource.gd
@@ -922,3 +922,18 @@ func test_apply_resource_properties_typed_array_null_element_prefixes_once() -> 
 	assert_contains(msg, "cannot store null", "the error must name the null cause")
 	assert_eq(msg.count("Property 'items'"), 1,
 		"the property context must be stamped exactly once")
+
+
+func test_create_resource_unknown_assign_property_enriches_error() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root — is a scene open?")
+		return
+	var result := _handler.create_resource({
+		"type": "BoxMesh",
+		"path": "/%s/Camera3D" % scene_root.name,
+		"property": "definitely_not_a_property",
+	})
+	assert_is_error(result, ErrorCodes.PROPERTY_NOT_ON_CLASS)
+	assert_contains(result.error.message, "available:",
+		"assign-property errors must use McpPropertyErrors.build_message enrichment")

--- a/test_project/tests/test_script.gd
+++ b/test_project/tests/test_script.gd
@@ -687,3 +687,20 @@ func test_find_symbols_rejects_traversal_path() -> void:
 	var result := _handler.find_symbols({"path": "res://../etc/passwd.gd"})
 	assert_is_error(result)
 	assert_contains(result.error.message, "..")
+
+
+func test_find_symbols_class_name_with_extends_tail() -> void:
+	## find_symbols' class_name parse drifted from _extract_class_name:
+	## `class_name Foo extends Bar` leaked the tail into the symbol name.
+	const CN_FORM_PATH := "res://tests/_mcp_cn_form_probe.gd"
+	var f := FileAccess.open(CN_FORM_PATH, FileAccess.WRITE)
+	if f == null:
+		assert_true(false, "could not write probe script")
+		return
+	f.store_string("class_name _McpCnFormProbe extends Node\n\nfunc noop() -> void:\n\tpass\n")
+	f.close()
+	var result := _handler.find_symbols({"path": CN_FORM_PATH})
+	DirAccess.remove_absolute(ProjectSettings.globalize_path(CN_FORM_PATH))
+	assert_has_key(result, "data")
+	assert_eq(result.data.class_name, "_McpCnFormProbe",
+		"the `extends` tail must not leak into the class_name symbol")

--- a/test_project/tests/test_signal.gd
+++ b/test_project/tests/test_signal.gd
@@ -454,3 +454,11 @@ func test_disconnect_undo_preserves_runtime_only_connection() -> void:
 		src.disconnect("ready", callable)
 	src.free()
 	tgt.free()
+
+
+func test_list_signals_rejects_non_string_path() -> void:
+	## Parity with connect/disconnect: the typed `path: String` local used
+	## to hard-error on a non-string, crashing the handler mid-call.
+	var result := _handler.list_signals({"path": 5})
+	assert_is_error(result, ErrorCodes.WRONG_TYPE)
+	assert_contains(result.error.message, "path")

--- a/test_project/tests/test_signal.gd
+++ b/test_project/tests/test_signal.gd
@@ -462,3 +462,5 @@ func test_list_signals_rejects_non_string_path() -> void:
 	var result := _handler.list_signals({"path": 5})
 	assert_is_error(result, ErrorCodes.WRONG_TYPE)
 	assert_contains(result.error.message, "path")
+	assert_contains(result.error.message, "int",
+		"require_string reports the offending param's got-type")

--- a/test_project/tests/test_texture.gd
+++ b/test_project/tests/test_texture.gd
@@ -232,3 +232,21 @@ func test_noise_saves_to_disk() -> void:
 	var loaded := ResourceLoader.load(out_path)
 	assert_true(loaded is NoiseTexture2D)
 	DirAccess.remove_absolute(ProjectSettings.globalize_path(out_path))
+
+
+func test_gradient_unknown_assign_property_enriches_error() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root — is a scene open?")
+		return
+	var result := _handler.create_gradient_texture({
+		"stops": [
+			{"offset": 0.0, "color": "#ff0000"},
+			{"offset": 1.0, "color": "#0000ff"},
+		],
+		"path": "/%s/Camera3D" % scene_root.name,
+		"property": "definitely_not_a_property",
+	})
+	assert_is_error(result, ErrorCodes.PROPERTY_NOT_ON_CLASS)
+	assert_contains(result.error.message, "available:",
+		"assign-property errors must use McpPropertyErrors.build_message enrichment")


### PR DESCRIPTION
## Summary

Second themed PR of the audit plan's Phase 2 (`docs/audit-tier2-plan.md`): eight Tier-1 backlog items where a handler drifted from the shared error/validation conventions its siblings follow. Each was re-verified against current main before touching anything:

1. **`camera_follow_2d` target resolution** returned a bare `"Target not found"` while `get_camera` in the same file uses `McpScenePath.format_node_error` — now uses the shared formatter with `target_path:` context.
2. **`physics_shape` `source_path` resolution** — same fix, `source_path:` context preserved.
3. **`animation` auto-create parent-not-found** returned `INVALID_PARAMS` while all seven sibling parent resolutions return `NODE_NOT_FOUND` — code aligned, message unchanged.
4. **`resource`/`texture`/`curve` property-not-found errors** hand-rolled bare messages, bypassing the `McpPropertyErrors.build_message` helper their own module doc mandates — now enriched with did-you-mean suggestions and the available-property tail.
5. **`signal` `list_signals`** skipped the `McpParamValidators.require_string` guard that `connect`/`disconnect` apply to the identical `path` param — a non-string `path` hard-errored the typed local mid-call; now a clean `WRONG_TYPE`.
6. **`material` `apply_preset`** checked file-exists **before** validating the path — opposite order to `create_material` in the same file, so an invalid path was misreported as an overwrite conflict. Order swapped.
7. **`material` undo/redo reload callables** silently swallowed load failures while `theme_handler`'s identical callables `push_warning` — parity restored (both `_apply_param` and `_apply_shader_param`).
8. **`script` `find_symbols`** carried a naive `class_name` parser that drifted from `_extract_class_name` twenty lines away — `class_name Foo extends Bar` leaked `extends Bar` into the symbol name. Same cut logic applied.

## Testing

8 new GDScript tests, one per item, across `test_camera`, `test_signal`, `test_material`, `test_curve`, `test_resource`, `test_texture`, `test_animation`, `test_script`.

Gauntlet: `ruff` clean · `pytest` 1329 passed · `ci-check-gdscript` OK · `ci-godot-tests` **1759/1778 passed, 0 failed** (live editor). Error-message/validation changes only — no lifecycle/spawn/self-update paths touched, so the smokes don't apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2zhpWvnqijYYRW3dwtUhV

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2zhpWvnqijYYRW3dwtUhV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “not found” error classification and message formatting for auto-created/missing targets across animations, cameras, physics fitting, and resources.
  * Standardized invalid-property error messaging for curves, resources, textures, and gradients.
  * Tightened `list_signals` path validation to return proper type errors.
  * Enhanced material preset validation ordering and added visible warnings when undo/redo can’t load materials.
  * Fixed `class_name` extraction when written with `extends`.

* **Tests**
  * Added regression tests covering updated error codes/messages for the above scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->