### PR TITLE
Phase 2: test honesty round 2 (readbacks, guards, fail-closed CI gates)

### DIFF
--- a/script/ci-godot-tests
+++ b/script/ci-godot-tests
@@ -78,6 +78,9 @@ for line in raw.split('\n'):
         break
 " 2>/dev/null || echo "0")
 
+# Fail closed: an empty/non-numeric parse must read as "no session", not
+# silently pass the [ -eq ] test failure through (audit backlog).
+case "$FINAL_COUNT" in (""|*[!0-9]*) FINAL_COUNT=0;; esac
 if [ "$FINAL_COUNT" -eq 0 ] 2>/dev/null; then
   echo "ERROR: No Godot session connected after 60 attempts. Plugin may not have loaded."
   exit 1
@@ -92,9 +95,23 @@ sleep 8
 # Open main.tscn so tests that need a scene root can actually run.
 # In a fresh CI checkout there's no editor state, so no scene is open by default.
 echo "Opening main.tscn..."
-curl -s "$SERVER_URL" -X POST "${HEADERS[@]}" \
+SCENE_OPEN_RESULT=$(curl -s "$SERVER_URL" -X POST "${HEADERS[@]}" \
   -H "Mcp-Session-Id: $SESSION_ID" \
-  -d '{"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"scene_open","arguments":{"path":"res://main.tscn"}}}' > /dev/null
+  -d '{"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"scene_open","arguments":{"path":"res://main.tscn"}}}')
+# A failed open hollows the run out: scene-dependent tests skip and the
+# summary still reads green. Fail loudly instead (audit backlog).
+echo "$SCENE_OPEN_RESULT" | python3 -c "
+import json, sys
+raw = sys.stdin.read()
+for line in raw.split('\n'):
+    if line.startswith('data: '):
+        data = json.loads(line[6:])
+        result = data.get('result', {})
+        if result.get('isError'):
+            print('ERROR: scene_open failed:', json.dumps(result)[:500])
+            sys.exit(1)
+        break
+" || { echo "ERROR: could not open main.tscn — aborting before a hollow run"; exit 1; }
 sleep 2
 
 # Call test_run
@@ -118,7 +135,8 @@ for line in raw.split('\n'):
         failed = content.get('failed', 0)
         total = content.get('total', 0)
         load_errors = content.get('load_errors', []) or []
-        print(f'Godot tests: {passed}/{total} passed, {failed} failed')
+        skipped = content.get('skipped', 0)
+        print(f'Godot tests: {passed}/{total} passed, {failed} failed, {skipped} skipped')
         if content.get('failures'):
             for f in content['failures']:
                 print(f'  FAIL: {f[\"suite\"]}.{f[\"test\"]}: {f[\"message\"]}')

--- a/script/ci-godot-tests
+++ b/script/ci-godot-tests
@@ -103,14 +103,21 @@ SCENE_OPEN_RESULT=$(curl -s "$SERVER_URL" -X POST "${HEADERS[@]}" \
 echo "$SCENE_OPEN_RESULT" | python3 -c "
 import json, sys
 raw = sys.stdin.read()
+saw_data_line = False
 for line in raw.split('\n'):
     if line.startswith('data: '):
+        saw_data_line = True
         data = json.loads(line[6:])
         result = data.get('result', {})
         if result.get('isError'):
             print('ERROR: scene_open failed:', json.dumps(result)[:500])
             sys.exit(1)
         break
+if not saw_data_line:
+    # Fail closed: an empty/non-SSE response is exactly the server-hiccup
+    # case this gate exists to catch — falling off the end must not pass.
+    print('ERROR: scene_open returned no SSE data line:', raw[:300])
+    sys.exit(1)
 " || { echo "ERROR: could not open main.tscn — aborting before a hollow run"; exit 1; }
 sleep 2
 

--- a/script/ci-quit-test
+++ b/script/ci-quit-test
@@ -47,7 +47,9 @@ sys.exit(1)
 echo "Initializing MCP session..."
 SESSION_ID=$(curl -si "$SERVER_URL" -X POST "${HEADERS[@]}" \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"ci-quit","version":"1.0"}}}' \
-  2>&1 | grep -i 'mcp-session-id' | tr -d '\r' | awk '{print $2}')
+  2>&1 | grep -i 'mcp-session-id' | tr -d '\r' | awk '{print $2}' || true)
+  # `|| true`: under pipefail a header miss would abort the script instead of
+  # falling through to the empty-SESSION_ID check below (#668).
 
 if [ -z "$SESSION_ID" ]; then
   echo "ERROR: Could not initialize MCP session"

--- a/script/ci-reload-test
+++ b/script/ci-reload-test
@@ -64,7 +64,9 @@ mcp_call_or_die() {
 echo "Initializing MCP session..."
 SESSION_ID=$(curl -si "$SERVER_URL" -X POST "${HEADERS[@]}" \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"ci-reload","version":"1.0"}}}' \
-  2>&1 | grep -i 'mcp-session-id' | tr -d '\r' | awk '{print $2}')
+  2>&1 | grep -i 'mcp-session-id' | tr -d '\r' | awk '{print $2}' || true)
+  # `|| true`: under pipefail a header miss would abort the script instead of
+  # falling through to the empty-SESSION_ID check below (#668).
 
 if [ -z "$SESSION_ID" ]; then
   echo "ERROR: Could not initialize MCP session"

--- a/test_project/tests/test_camera.gd
+++ b/test_project/tests/test_camera.gd
@@ -756,6 +756,7 @@ func test_follow_2d_target_not_node2d() -> void:
 		return
 	var r := _create("FollowBad", "2d")
 	if r.is_empty():
+		assert_true(false, "camera create failed")
 		return
 	# Make a plain Node (not Node2D).
 	var plain := Node.new()

--- a/test_project/tests/test_input.gd
+++ b/test_project/tests/test_input.gd
@@ -118,9 +118,15 @@ func test_add_action_rejects_deadzone_above_one() -> void:
 func test_add_action_accepts_boundary_deadzones() -> void:
 	var result := _handler.add_action({"action": TEST_ACTION, "deadzone": 0.0})
 	assert_has_key(result, "data")
+	assert_true(InputMap.has_action(TEST_ACTION), "action must actually be registered")
+	assert_true(abs(InputMap.action_get_deadzone(TEST_ACTION) - 0.0) < 0.001,
+		"boundary deadzone 0.0 must be STORED, not just accepted")
 	_handler.remove_action({"action": TEST_ACTION})
 	result = _handler.add_action({"action": TEST_ACTION, "deadzone": 1.0})
 	assert_has_key(result, "data")
+	assert_true(InputMap.has_action(TEST_ACTION), "action must actually be registered")
+	assert_true(abs(InputMap.action_get_deadzone(TEST_ACTION) - 1.0) < 0.001,
+		"boundary deadzone 1.0 must be STORED, not just accepted")
 	_handler.remove_action({"action": TEST_ACTION})
 
 

--- a/test_project/tests/test_project.gd
+++ b/test_project/tests/test_project.gd
@@ -61,6 +61,12 @@ func test_set_project_setting_roundtrip() -> void:
 	assert_eq(result.data.value, "_McpTestName")
 	assert_has_key(result.data, "old_value")
 
+	## Actually round-trip: read the STORED setting back, don't trust the
+	## handler's echo of its own input.
+	var readback := _handler.get_project_setting({"key": "application/config/name"})
+	assert_eq(readback.data.value, "_McpTestName",
+		"stored setting must reflect the write, not just the response echo")
+
 	## Restore
 	_handler.set_project_setting({"key": "application/config/name", "value": old_name})
 

--- a/tests/unit/test_audit_data_loss_safeguards.py
+++ b/tests/unit/test_audit_data_loss_safeguards.py
@@ -62,7 +62,10 @@ def test_runner_tracks_paths_written_for_cross_batch_rollback() -> None:
 def test_install_zip_paths_returns_install_status_and_drives_rollback() -> None:
     source = RUNNER_PATH.read_text(encoding="utf-8")
     paths_block = get_func_block(source, "func _install_zip_paths(")
-    assert "-> int:" in source[: source.index(paths_block) + len(paths_block)]
+    assert "-> int:" in paths_block[: paths_block.index(":", paths_block.index("->")) + 1], (
+        "return type must be declared on the target function's own "
+        "signature, not anywhere in the file before it"
+    )
     assert "InstallStatus.OK" in paths_block, (
         "Function must signal success via the typed enum, not bare `true`."
     )
@@ -80,7 +83,11 @@ def test_install_zip_paths_returns_install_status_and_drives_rollback() -> None:
 def test_install_zip_file_returns_dictionary_record_with_backup_metadata() -> None:
     source = RUNNER_PATH.read_text(encoding="utf-8")
     install_block = get_func_block(source, "func _install_zip_file(")
-    assert "-> Dictionary:" in source[: source.index(install_block) + len(install_block)]
+    sig_end = install_block.index(":", install_block.index("->"))
+    assert "-> Dictionary:" in install_block[: sig_end + 1], (
+        "return type must be declared on the target function's own "
+        "signature, not anywhere in the file before it"
+    )
     # Backup is taken via COPY (not rename) so the original stays in place
     # if the swap that follows fails. Pin the COPY semantics specifically.
     assert "DirAccess.copy_absolute(target_path, backup_path)" in install_block, (
@@ -114,7 +121,11 @@ def test_install_zip_file_does_not_remove_target_before_rename_attempt() -> None
 def test_rollback_returns_failed_mixed_when_any_restore_fails() -> None:
     source = RUNNER_PATH.read_text(encoding="utf-8")
     rollback_block = get_func_block(source, "func _rollback_paths_written(")
-    assert "-> int:" in source[: source.index(rollback_block) + len(rollback_block)]
+    sig_end = rollback_block.index(":", rollback_block.index("->"))
+    assert "-> int:" in rollback_block[: sig_end + 1], (
+        "return type must be declared on the target function's own "
+        "signature, not anywhere in the file before it"
+    )
     assert "InstallStatus.FAILED_MIXED" in rollback_block, (
         "Rollback must surface FAILED_MIXED when a restore step fails so "
         "the caller knows not to re-enable the plugin against a mixed tree."

--- a/tests/unit/test_audit_data_loss_safeguards.py
+++ b/tests/unit/test_audit_data_loss_safeguards.py
@@ -62,7 +62,11 @@ def test_runner_tracks_paths_written_for_cross_batch_rollback() -> None:
 def test_install_zip_paths_returns_install_status_and_drives_rollback() -> None:
     source = RUNNER_PATH.read_text(encoding="utf-8")
     paths_block = get_func_block(source, "func _install_zip_paths(")
-    assert "-> int:" in paths_block[: paths_block.index(":", paths_block.index("->")) + 1], (
+    arrow = paths_block.find("->")
+    assert arrow != -1, "_install_zip_paths signature has no return-type arrow"
+    sig_end = paths_block.find(":", arrow)
+    assert sig_end != -1, "_install_zip_paths signature never terminates with ':'"
+    assert "-> int:" in paths_block[: sig_end + 1], (
         "return type must be declared on the target function's own "
         "signature, not anywhere in the file before it"
     )
@@ -83,7 +87,10 @@ def test_install_zip_paths_returns_install_status_and_drives_rollback() -> None:
 def test_install_zip_file_returns_dictionary_record_with_backup_metadata() -> None:
     source = RUNNER_PATH.read_text(encoding="utf-8")
     install_block = get_func_block(source, "func _install_zip_file(")
-    sig_end = install_block.index(":", install_block.index("->"))
+    arrow = install_block.find("->")
+    assert arrow != -1, "_install_zip_file signature has no return-type arrow"
+    sig_end = install_block.find(":", arrow)
+    assert sig_end != -1, "_install_zip_file signature never terminates with ':'"
     assert "-> Dictionary:" in install_block[: sig_end + 1], (
         "return type must be declared on the target function's own "
         "signature, not anywhere in the file before it"
@@ -121,7 +128,10 @@ def test_install_zip_file_does_not_remove_target_before_rename_attempt() -> None
 def test_rollback_returns_failed_mixed_when_any_restore_fails() -> None:
     source = RUNNER_PATH.read_text(encoding="utf-8")
     rollback_block = get_func_block(source, "func _rollback_paths_written(")
-    sig_end = rollback_block.index(":", rollback_block.index("->"))
+    arrow = rollback_block.find("->")
+    assert arrow != -1, "_rollback_paths_written signature has no return-type arrow"
+    sig_end = rollback_block.find(":", arrow)
+    assert sig_end != -1, "_rollback_paths_written signature never terminates with ':'"
     assert "-> int:" in rollback_block[: sig_end + 1], (
         "return type must be declared on the target function's own "
         "signature, not anywhere in the file before it"

--- a/tests/unit/test_orphan_reaper.py
+++ b/tests/unit/test_orphan_reaper.py
@@ -369,3 +369,59 @@ async def test_idle_transient_zero_dip_does_not_exit():
     with pytest.raises(asyncio.CancelledError):
         await task
     assert calls == []
+
+
+# ----- pid_alive conservative errno branches (audit backlog) -----
+
+
+@POSIX_ONLY_PID_ALIVE
+def test_pid_alive_true_on_permission_error(monkeypatch):
+    """Exists-but-foreign (EPERM) must read as alive — never-wrong-reap."""
+
+    def _raise(_pid, _sig):
+        raise PermissionError
+
+    monkeypatch.setattr(orphan_reaper.os, "kill", _raise)
+    assert orphan_reaper.pid_alive(12345) is True
+
+
+@POSIX_ONLY_PID_ALIVE
+def test_pid_alive_true_on_unexpected_oserror(monkeypatch):
+    """Unknown errno must be conservative (treat as alive), not reap."""
+    import errno
+
+    def _raise(_pid, _sig):
+        raise OSError(errno.EINVAL, "unexpected")
+
+    monkeypatch.setattr(orphan_reaper.os, "kill", _raise)
+    assert orphan_reaper.pid_alive(12345) is True
+
+
+# ----- _request_self_shutdown (audit backlog: zero coverage) -----
+
+
+def test_request_self_shutdown_posix_signals_own_pid(monkeypatch):
+    monkeypatch.setattr(orphan_reaper.sys, "platform", "linux")
+    calls: list[tuple[int, int]] = []
+    monkeypatch.setattr(orphan_reaper.os, "kill", lambda pid, sig: calls.append((pid, sig)))
+    orphan_reaper._request_self_shutdown()
+    import signal as _signal
+
+    assert calls == [(os.getpid(), _signal.SIGTERM)]
+
+
+def test_request_self_shutdown_windows_raises_signal_in_process(monkeypatch):
+    """Windows must use raise_signal (graceful in-process handler), never
+    os.kill, which is TerminateProcess there and skips lifespan teardown."""
+    monkeypatch.setattr(orphan_reaper.sys, "platform", "win32")
+    raised: list[int] = []
+    monkeypatch.setattr(orphan_reaper.signal, "raise_signal", lambda sig: raised.append(sig))
+
+    def _forbidden(*_a):
+        raise AssertionError("os.kill must not be used on Windows")
+
+    monkeypatch.setattr(orphan_reaper.os, "kill", _forbidden)
+    orphan_reaper._request_self_shutdown()
+    import signal as _signal
+
+    assert raised == [_signal.SIGTERM]


### PR DESCRIPTION
## Summary

Third themed PR of the audit plan's Phase 2 (`docs/audit-tier2-plan.md`): nine Tier-1 test-honesty items — tests that passed for the wrong reason and CI gates that failed open. Each re-verified against current main first:

**Tests that didn't test what they claimed:**
1. `test_set_project_setting_roundtrip` never round-tripped — it asserted the handler's echo of its own input. Now reads the **stored** setting back.
2. `test_add_action_accepts_boundary_deadzones` asserted only response presence. Now verifies the boundary deadzones (0.0/1.0) were actually stored in `InputMap`.
3. `test_camera`'s follow-target guard used a bare silent `return` — the checklist's #1 masking pattern. Now `assert_true(false, ...)` per the file's own convention.
4. `test_audit_data_loss_safeguards`' return-type asserts scanned the **entire file prefix**, so any earlier function's signature satisfied them. Now scoped to the target function's own signature span.

**Untested production paths:**
5. `orphan_reaper.pid_alive`'s conservative PermissionError / generic-OSError treat-as-alive branches (the never-wrong-reap safety) — now unit-tested.
6. `orphan_reaper._request_self_shutdown` — the production shutdown for the Windows idle backstop (#497) was never executed by any test. Both the POSIX path (`os.kill` own pid, SIGTERM) and the Windows path (`raise_signal`, never `os.kill` = TerminateProcess) are now pinned.

**CI gates that failed open:**
7. `ci-godot-tests` never verified the `scene_open` response — a failed open hollowed the run into invisible skips under a green summary. The response is now checked and the run aborts loudly; the **skipped count** is also printed in the summary line.
8. `ci-godot-tests`' final session-count gate: an empty/non-numeric parse silently passed the `[ -eq ]` test failure through. Now normalized to 0 first — fails closed.
9. `ci-quit-test` / `ci-reload-test` still carried the pre-#668 aborting copy of the MCP-init header pipeline under pipefail — `|| true` ported with the same comment.

**Skipped (verify-first):** the `test_dispatcher` null-result duplicate-test item — its misleading comment was already rewritten on main to document the null→`{}` coercion accurately.

## Testing

Gauntlet: `ruff` clean · `pytest` **1333 passed** · `ci-check-gdscript` OK · `ci-godot-tests` **1752/1770 passed, 0 failed, 18 skipped** — run through the modified script itself, so the new scene_open verification and skip reporting were exercised live. `bash -n` clean on all three edited scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2zhpWvnqijYYRW3dwtUhV

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2zhpWvnqijYYRW3dwtUhV)_