### PR TITLE
Phase 2: cross-language parity tests (command names, timeout ladder, SUB_* regex, readiness)

### DIFF
--- a/tests/unit/test_command_name_parity.py
+++ b/tests/unit/test_command_name_parity.py
@@ -1,0 +1,67 @@
+"""Contract test: every command Python sends is registered by the plugin.
+
+The WebSocket command namespace (~135 names) is duplicated between the
+Python handlers' ``send_command("<name>", ...)`` literals and plugin.gd's
+``_dispatcher.register("<name>", ...)`` literals with no compiler on either
+side of the wire. A typo'd or renamed command on one side only surfaces at
+runtime as UNKNOWN_COMMAND — and the Python unit suite's StubClient answers
+ANY command, so unit tests can't catch it.
+
+The contract is one-way: Python-sent ⊆ plugin-registered. The plugin may
+register commands Python doesn't call by literal (e.g. rollup-internal
+names dispatched via batch_execute payloads); that asymmetry is fine.
+
+Audit backlog item (S3 · tests). Style per test_error_code_parity.py.
+"""
+
+from __future__ import annotations
+
+import functools
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_GD = REPO_ROOT / "plugin" / "addons" / "godot_ai" / "plugin.gd"
+PYTHON_SRC = REPO_ROOT / "src" / "godot_ai"
+
+## Multiline-aware: `register(\n\t"name"` and `send_command(\n    "name"`
+## both match — \s* spans the newline.
+_REGISTER_RE = re.compile(r'\.register\(\s*"([a-z0-9_]+)"')
+_SEND_RE = re.compile(r'send_command\(\s*"([a-z0-9_]+)"')
+
+
+@functools.cache
+def _registered_plugin_commands() -> frozenset[str]:
+    return frozenset(_REGISTER_RE.findall(PLUGIN_GD.read_text(encoding="utf-8")))
+
+
+@functools.cache
+def _python_sent_commands() -> frozenset[str]:
+    names: set[str] = set()
+    for path in sorted(PYTHON_SRC.rglob("*.py")):
+        names.update(_SEND_RE.findall(path.read_text(encoding="utf-8")))
+    return frozenset(names)
+
+
+def test_extraction_is_non_vacuous() -> None:
+    # Guard the test itself: a regex regression returning near-nothing
+    # would let the subset assertion below pass vacuously.
+    registered = _registered_plugin_commands()
+    sent = _python_sent_commands()
+    assert len(registered) > 100, (
+        f"only {len(registered)} register() literals parsed from plugin.gd; "
+        f"check _REGISTER_RE against the current registration style"
+    )
+    assert len(sent) > 50, (
+        f"only {len(sent)} send_command() literals parsed from src/godot_ai; "
+        f"check _SEND_RE against the current call style"
+    )
+
+
+def test_every_python_sent_command_is_registered_by_plugin() -> None:
+    unknown = sorted(_python_sent_commands() - _registered_plugin_commands())
+    assert not unknown, (
+        f"Python sends commands plugin.gd never registers — these fail at "
+        f"runtime as UNKNOWN_COMMAND and the StubClient-based unit tests "
+        f"can't catch them: {unknown}"
+    )

--- a/tests/unit/test_editor_not_ready_hint_contract.py
+++ b/tests/unit/test_editor_not_ready_hint_contract.py
@@ -61,7 +61,17 @@ def test_gdscript_sub_code_constants_match_python_enum() -> None:
     added only on the GDScript side would be silently dropped from
     attribution."""
     source = (PLUGIN_ROOT / "utils" / "error_codes.gd").read_text(encoding="utf-8")
-    gd_sub_codes = set(re.findall(r'const SUB_\w+ := "(\w+)"', source))
+    ## Whitespace/annotation-tolerant (mirrors test_error_code_parity's
+    ## _CONST_RE): `const X := "v"`, `const X: String = "v"`, and
+    ## `const X = "v"` all match, so a sub-code added in any legal
+    ## declaration style can't silently vanish from this parity check.
+    gd_sub_codes = set(
+        re.findall(
+            r'^\s*const\s+SUB_\w+\s*(?::\s*String\s*)?:?=\s*"(\w+)"',
+            source,
+            re.MULTILINE,
+        )
+    )
     py_sub_codes = {member.value for member in EditorNotReadySubCode}
     assert gd_sub_codes == py_sub_codes, (
         f"GDScript SUB_* constants and EditorNotReadySubCode drifted: "

--- a/tests/unit/test_game_eval_timeout_ordering.py
+++ b/tests/unit/test_game_eval_timeout_ordering.py
@@ -1,0 +1,122 @@
+"""Contract test: the game_eval/game_command timeout ladder stays ordered.
+
+The four-tier timeout contract spans four files and, by its own admission
+(game_helper.gd's "TIMEOUT ORDERING — load-bearing across three files ...
+Nothing enforces the order — change one, re-check the other two"), had no
+enforcement. The ladder:
+
+    game (8s)  <  editor (10s)  <  ready-wait + editor (3+10s)  <  dispatcher (15s) == server (15s)
+
+- **game**: ``game_helper.gd::EVAL_TIMEOUT_SEC`` — the only tier that can
+  name the hung await ("Eval exceeded 8s"). If it rises to/above the editor
+  timer, the less specific editor message wins the race and the diagnostic
+  is silently lost (#487/#518).
+- **editor**: ``mcp_debugger_plugin.gd`` ``timeout_sec`` defaults on the
+  request_game_* entry points.
+- **ready-wait**: ``project_handler.gd::RUN_READY_WAIT_SEC`` — stacked on
+  top of the editor timer on the run path; the sum must still beat the
+  dispatcher budget.
+- **dispatcher/server**: ``dispatcher.gd::DEFERRED_TIMEOUT_MS_BY_COMMAND``
+  and ``handlers/game.py::GAME_COMMAND_TIMEOUT_SEC`` — the outermost
+  budgets; if either undercuts the inner tiers, the deferred reply is
+  dropped as expired and the actionable message never reaches the agent.
+
+Audit backlog item (S3 · drift, game_helper.gd:640). Source-scraping
+pattern per test_dock_cli_timeout.py / test_deferred_timeout_contract.py.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from godot_ai.handlers.game import GAME_COMMAND_TIMEOUT_SEC
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[2] / "plugin" / "addons" / "godot_ai"
+
+
+def _scrape_float(path: Path, pattern: str) -> float:
+    source = path.read_text(encoding="utf-8")
+    match = re.search(pattern, source, re.MULTILINE)
+    assert match, f"pattern {pattern!r} not found in {path}"
+    return float(match.group(1))
+
+
+def _scrape_all_floats(path: Path, pattern: str) -> list[float]:
+    source = path.read_text(encoding="utf-8")
+    values = [float(v) for v in re.findall(pattern, source, re.MULTILINE)]
+    assert values, f"pattern {pattern!r} not found in {path}"
+    return values
+
+
+def _game_timeout_sec() -> float:
+    return _scrape_float(
+        PLUGIN_ROOT / "runtime" / "game_helper.gd",
+        r"^const EVAL_TIMEOUT_SEC := ([0-9.]+)",
+    )
+
+
+def _editor_timeout_secs() -> list[float]:
+    ## Both request_game_eval and request_game_command carry the default.
+    return _scrape_all_floats(
+        PLUGIN_ROOT / "debugger" / "mcp_debugger_plugin.gd",
+        r"^\ttimeout_sec: float = ([0-9.]+),",
+    )
+
+
+def _ready_wait_sec() -> float:
+    return _scrape_float(
+        PLUGIN_ROOT / "handlers" / "project_handler.gd",
+        r"^const RUN_READY_WAIT_SEC := ([0-9.]+)",
+    )
+
+
+def _dispatcher_budget_secs() -> dict[str, float]:
+    source = (PLUGIN_ROOT / "dispatcher.gd").read_text(encoding="utf-8")
+    budgets = {
+        name: int(ms) / 1000.0
+        for name, ms in re.findall(r'"(game_eval|game_command)":\s*(\d+)', source)
+    }
+    assert set(budgets) == {"game_eval", "game_command"}, (
+        f"expected both game_* entries in DEFERRED_TIMEOUT_MS_BY_COMMAND, got {budgets}"
+    )
+    return budgets
+
+
+def test_game_guard_stays_below_editor_fallback() -> None:
+    game = _game_timeout_sec()
+    for editor in _editor_timeout_secs():
+        assert game < editor, (
+            f"game EVAL_TIMEOUT_SEC ({game}s) must stay below the editor "
+            f"fallback ({editor}s) or the specific 'Eval exceeded' "
+            f"diagnostic loses the race to the generic editor message"
+        )
+
+
+def test_editor_fallback_stays_below_dispatcher_budget() -> None:
+    budgets = _dispatcher_budget_secs()
+    for editor in _editor_timeout_secs():
+        for name, budget in budgets.items():
+            assert editor < budget, (
+                f"editor fallback ({editor}s) must stay below the "
+                f"dispatcher's {name} budget ({budget}s) or the deferred "
+                f"reply is dropped as expired before the editor can answer"
+            )
+
+
+def test_ready_wait_plus_editor_stays_below_dispatcher_budget() -> None:
+    stacked = _ready_wait_sec() + max(_editor_timeout_secs())
+    for name, budget in _dispatcher_budget_secs().items():
+        assert stacked < budget, (
+            f"RUN_READY_WAIT_SEC + editor fallback ({stacked}s) must stay "
+            f"below the dispatcher's {name} budget ({budget}s)"
+        )
+
+
+def test_server_timeout_covers_dispatcher_budget() -> None:
+    for name, budget in _dispatcher_budget_secs().items():
+        assert GAME_COMMAND_TIMEOUT_SEC >= budget, (
+            f"server GAME_COMMAND_TIMEOUT_SEC ({GAME_COMMAND_TIMEOUT_SEC}s) "
+            f"must not undercut the dispatcher's {name} budget ({budget}s) — "
+            f"the server would time out first and misattribute the failure"
+        )

--- a/tests/unit/test_readiness.py
+++ b/tests/unit/test_readiness.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 import pytest
 
 from godot_ai.godot_client.client import GodotCommandError
@@ -275,3 +277,26 @@ async def test_require_writable_async_probe_handles_unknown_state_gracefully():
         await require_writable_async(runtime)
     assert client.probe_calls == 1
     assert session.readiness == "playing"
+
+
+def test_known_readiness_matches_plugin_get_readiness_source():
+    """Cross-language parity: KNOWN_READINESS must mirror the actual
+    return literals of connection.gd::get_readiness — not another Python
+    constant. The previous docstring cited get_readiness as the source of
+    truth but never read it (audit backlog: Python-vs-Python tautology)."""
+    from pathlib import Path
+
+    from tests.unit._gdscript_text import get_func_block
+
+    connection_gd = (
+        Path(__file__).resolve().parents[2] / "plugin" / "addons" / "godot_ai" / "connection.gd"
+    )
+    source = connection_gd.read_text(encoding="utf-8")
+    block = get_func_block(source, "static func get_readiness() -> String:")
+    emitted = set(re.findall(r'return "(\w+)"', block))
+    assert emitted, "no return literals parsed from get_readiness — check the block extraction"
+    assert emitted == set(KNOWN_READINESS), (
+        f"connection.gd::get_readiness and Python KNOWN_READINESS drifted: "
+        f"gd-only={sorted(emitted - set(KNOWN_READINESS))}, "
+        f"py-only={sorted(set(KNOWN_READINESS) - emitted)}"
+    )


### PR DESCRIPTION
## Summary

Fourth themed PR of the audit plan's Phase 2 (`docs/audit-tier2-plan.md`): four Tier-1 contract/parity items, all Python-test-only.

1. **`test_command_name_parity.py` (new)** — the ~135-name WebSocket command namespace is duplicated between Python `send_command("...")` literals and plugin.gd `register("...")` literals with no enforcement on either side, and the unit suite's StubClient answers *any* command, so a typo'd name only ever surfaced live as `UNKNOWN_COMMAND`. New one-way contract test (Python-sent ⊆ plugin-registered) with non-vacuous extraction guards, in the style of `test_error_code_parity.py`.
2. **`test_game_eval_timeout_ordering.py` (new)** — the four-tier timeout ladder (game 8s < editor 10s < ready-wait+editor 13s < dispatcher 15s == server 15s) spans four files, and `game_helper.gd`'s own comment admits "Nothing enforces the order — change one, re-check the other two." Now something enforces it: each constant is scraped from source and every ordering edge asserted, with messages explaining which diagnostic gets lost when an edge inverts.
3. **`test_editor_not_ready_hint_contract.py`** — the SUB_* parity regex was format-brittle (exactly one space around `:=`), so a sub-code declared in any other legal style silently vanished from the check. Now whitespace/annotation-tolerant, mirroring `test_error_code_parity`'s `_CONST_RE`.
4. **`test_readiness.py`** — `test_known_readiness_covers_all_states_handlers_emit` cited `connection.gd::get_readiness` as its source of truth but never read it (a Python-vs-Python tautology). New parity assertion extracts `get_readiness`'s actual return literals via `get_func_block` and compares them to `KNOWN_READINESS`.

## Testing

Gauntlet: `ruff` clean · `pytest` **1336 passed** (includes the 8 new tests) · `ci-check-gdscript` OK. Python-test-only diff — zero GDScript delta from main, so the live editor suite state is main's (green there today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2zhpWvnqijYYRW3dwtUhV

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2zhpWvnqijYYRW3dwtUhV)_