### PR TITLE
Phase 2: telemetry + CI-script hygiene (no CI sends, validated identity, sanitized handshake fields, declared deps)

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -24,6 +24,10 @@ fi
 
 cd "$CLAUDE_PROJECT_DIR"
 
+# Headless web-session editors/servers must not inject fake install/update
+# events into production telemetry (audit backlog; mirrors script/_ci_env.sh).
+export GODOT_AI_DISABLE_TELEMETRY=true
+
 # Keep in step with ci.yml (godot-version: "4.7.0" — the chickensoft action
 # wants 3-part semver; the Godot release tag/asset uses the 2-part form) and
 # test_project/project.godot (config/features "4.7"). See #672.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,11 @@ dependencies = [
     "fastmcp>=3.0.0,!=3.3.*,<3.5.0",
     "websockets>=13.0",
     "pydantic>=2.0",
+    # asgi.py imports these directly; declare them instead of relying on
+    # them arriving transitively through fastmcp (audit backlog). Floors
+    # match the mcp SDK's own minimums — resolution is unchanged.
+    "uvicorn>=0.23",
+    "starlette>=0.27",
 ]
 
 [project.urls]

--- a/script/ci-game-capture-smoke
+++ b/script/ci-game-capture-smoke
@@ -50,6 +50,10 @@ import urllib.request
 
 from PIL import Image
 
+# Mirror script/_ci_env.sh: smoke-run editors/servers must not send
+# telemetry from CI (audit backlog). setdefault keeps explicit overrides.
+os.environ.setdefault("GODOT_AI_DISABLE_TELEMETRY", "true")
+
 SERVER_URL = os.environ.get("MCP_SERVER_URL", "http://127.0.0.1:8000/mcp")
 HEADERS = {
     "Content-Type": "application/json",

--- a/script/ci-stale-server-smoke
+++ b/script/ci-stale-server-smoke
@@ -159,6 +159,10 @@ import os
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from socketserver import TCPServer
 
+# Mirror script/_ci_env.sh: smoke-run editors/servers must not send
+# telemetry from CI (audit backlog). setdefault keeps explicit overrides.
+os.environ.setdefault("GODOT_AI_DISABLE_TELEMETRY", "true")
+
 ap = argparse.ArgumentParser()
 ap.add_argument("--port", type=int, default=8000)
 args, _ = ap.parse_known_args()

--- a/script/local-self-update-smoke
+++ b/script/local-self-update-smoke
@@ -21,7 +21,11 @@ import tempfile
 import time
 import urllib.request
 import zipfile
-from pathlib import Path
+from pathlib import Path, PurePosixPath
+
+# The fixture editor auto-spawns a real MCP server; neither may send
+# telemetry from a local smoke run (audit backlog).
+os.environ.setdefault("GODOT_AI_DISABLE_TELEMETRY", "true")
 
 ROOT = Path(__file__).resolve().parent.parent
 PLUGIN_ROOT = ROOT / "plugin" / "addons" / "godot_ai"
@@ -234,6 +238,16 @@ def extract_release_zip_to_addon(zip_path: Path, addon_dir: Path) -> None:
             rel = name[len("addons/godot_ai/") :]
             if not rel:
                 continue
+            ## Same containment the plugin's own update runner enforces:
+            ## refuse traversal/absolute/backslash entries instead of
+            ## writing wherever a hostile zip points (audit backlog).
+            segments = rel.split("/")
+            if (
+                "\\" in rel
+                or PurePosixPath(rel).is_absolute()
+                or any(seg in ("", ".", "..") for seg in segments)
+            ):
+                raise RuntimeError(f"unsafe zip entry refused: {name!r}")
             dest = addon_dir / rel
             if member.is_dir():
                 dest.mkdir(parents=True, exist_ok=True)

--- a/script/local-self-update-smoke
+++ b/script/local-self-update-smoke
@@ -238,6 +238,10 @@ def extract_release_zip_to_addon(zip_path: Path, addon_dir: Path) -> None:
             rel = name[len("addons/godot_ai/") :]
             if not rel:
                 continue
+            ## Directory entries end with "/" and nothing is written for
+            ## them — file entries' parent mkdir below covers the tree.
+            if member.is_dir():
+                continue
             ## Same containment the plugin's own update runner enforces:
             ## refuse traversal/absolute/backslash entries instead of
             ## writing wherever a hostile zip points (audit backlog).
@@ -249,9 +253,10 @@ def extract_release_zip_to_addon(zip_path: Path, addon_dir: Path) -> None:
             ):
                 raise RuntimeError(f"unsafe zip entry refused: {name!r}")
             dest = addon_dir / rel
-            if member.is_dir():
-                dest.mkdir(parents=True, exist_ok=True)
-                continue
+            ## Belt-and-suspenders resolved-path net (mirrors
+            ## tests/integration/_self_update_fixture.py).
+            if not dest.resolve().is_relative_to(addon_dir.resolve()):
+                raise RuntimeError(f"unsafe zip entry refused: {name!r}")
             dest.parent.mkdir(parents=True, exist_ok=True)
             with zf.open(member) as src, open(dest, "wb") as out:
                 shutil.copyfileobj(src, out)

--- a/src/godot_ai/sessions/registry.py
+++ b/src/godot_ai/sessions/registry.py
@@ -130,7 +130,7 @@ class SessionRegistry:
                     ## for MCP clients.
                     "godot_version": _safe_version_token(session.godot_version),
                     "plugin_version": _safe_version_token(session.plugin_version),
-                    "protocol_version": _safe_version_token(session.protocol_version),
+                    "protocol_version": _safe_version_token(str(session.protocol_version)),
                     "server_launch_mode": _safe_version_token(session.server_launch_mode),
                     "session_count": len(self._sessions),
                 },

--- a/src/godot_ai/sessions/registry.py
+++ b/src/godot_ai/sessions/registry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from functools import cached_property
@@ -17,6 +18,20 @@ from godot_ai.telemetry import (
 )
 
 logger = logging.getLogger(__name__)
+
+## Handshake fields ride into telemetry verbatim otherwise — any local
+## process can connect (see AGENTS.md WS trust boundary) and stuff
+## arbitrary text into godot_version/plugin_version/etc. Mirror the
+## version-token shape the rest of telemetry expects; anything else is
+## replaced wholesale rather than truncated so the collector can count
+## the anomaly without storing attacker-controlled text.
+_VERSION_TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9 ._+()-]{0,63}$")
+
+
+def _safe_version_token(value: str) -> str:
+    if isinstance(value, str) and _VERSION_TOKEN_RE.match(value):
+        return value
+    return "invalid"
 
 
 @dataclass
@@ -110,10 +125,13 @@ class SessionRegistry:
                 RecordType.GODOT_CONNECTION,
                 {
                     "event": "connected",
-                    "godot_version": session.godot_version,
-                    "plugin_version": session.plugin_version,
-                    "protocol_version": session.protocol_version,
-                    "server_launch_mode": session.server_launch_mode,
+                    ## Handshake-supplied strings are sanitized for the
+                    ## telemetry payload only; Session fields stay verbatim
+                    ## for MCP clients.
+                    "godot_version": _safe_version_token(session.godot_version),
+                    "plugin_version": _safe_version_token(session.plugin_version),
+                    "protocol_version": _safe_version_token(session.protocol_version),
+                    "server_launch_mode": _safe_version_token(session.server_launch_mode),
                     "session_count": len(self._sessions),
                 },
                 session_id=session.session_id,

--- a/src/godot_ai/telemetry.py
+++ b/src/godot_ai/telemetry.py
@@ -336,11 +336,18 @@ class TelemetryCollector:
 
     def _load_persistent_data(self) -> None:
         try:
+            raw = ""
             if self.config.uuid_file.exists():
-                self._customer_uuid = self.config.uuid_file.read_text(
-                    encoding="utf-8"
-                ).strip() or str(uuid.uuid4())
-            else:
+                raw = self.config.uuid_file.read_text(encoding="utf-8").strip()
+            try:
+                ## Validate instead of trusting file content verbatim; also
+                ## canonicalizes case. Empty/missing raises ValueError too.
+                self._customer_uuid = str(uuid.UUID(raw))
+            except ValueError:
+                ## Missing, empty, or malformed: mint a fresh id and PERSIST
+                ## it — the old empty-file branch regenerated a new uuid on
+                ## every start without ever writing it back, so the install
+                ## never converged on one stable identity.
                 self._customer_uuid = str(uuid.uuid4())
                 try:
                     self.config.uuid_file.write_text(self._customer_uuid, encoding="utf-8")

--- a/tests/unit/test_session_registry.py
+++ b/tests/unit/test_session_registry.py
@@ -323,6 +323,11 @@ class TestHandshakeTelemetrySanitization:
         )
         assert captured["data"]["godot_version"] == "invalid"
         assert captured["data"]["plugin_version"] == "2.9.1"
+        ## protocol_version is an int on Session — it must be stringified
+        ## before sanitizing, not blanket-flagged as invalid.
+        assert captured["data"]["protocol_version"] == str(
+            registry.get("probe@1234").protocol_version
+        )
 
     def test_normal_version_strings_pass_through(self, monkeypatch):
         captured = {}
@@ -340,3 +345,7 @@ class TestHandshakeTelemetrySanitization:
             )
         )
         assert captured["data"]["godot_version"] == "4.7.0-stable (official)"
+        assert captured["data"]["protocol_version"] == str(
+            registry.get("probe@5678").protocol_version
+        )
+        assert captured["data"]["server_launch_mode"] != "invalid"

--- a/tests/unit/test_session_registry.py
+++ b/tests/unit/test_session_registry.py
@@ -299,3 +299,44 @@ class TestWaitForSession:
         assert {session.session_id for session in reg.list_all()} == {"a", "b"}
         assert len(reg) == 2
         assert reg._session_waiters == []
+
+
+class TestHandshakeTelemetrySanitization:
+    """Audit backlog: handshake-supplied version strings ride into
+    telemetry verbatim otherwise — any local process can connect and
+    stuff arbitrary text into them (see AGENTS.md WS trust boundary)."""
+
+    def test_hostile_version_strings_are_sanitized_in_telemetry(self, monkeypatch):
+        captured = {}
+
+        def _capture(record_type, data, session_id=None):
+            captured["data"] = data
+
+        monkeypatch.setattr("godot_ai.sessions.registry.record_telemetry", _capture)
+        registry = SessionRegistry()
+        registry.register(
+            _make_session(
+                session_id="probe@1234",
+                godot_version="4.7\nX-Injected: gotcha " + "A" * 200,
+                plugin_version="2.9.1",
+            )
+        )
+        assert captured["data"]["godot_version"] == "invalid"
+        assert captured["data"]["plugin_version"] == "2.9.1"
+
+    def test_normal_version_strings_pass_through(self, monkeypatch):
+        captured = {}
+
+        def _capture(record_type, data, session_id=None):
+            captured["data"] = data
+
+        monkeypatch.setattr("godot_ai.sessions.registry.record_telemetry", _capture)
+        registry = SessionRegistry()
+        registry.register(
+            _make_session(
+                session_id="probe@5678",
+                godot_version="4.7.0-stable (official)",
+                plugin_version="2.9.1",
+            )
+        )
+        assert captured["data"]["godot_version"] == "4.7.0-stable (official)"

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import time
+import uuid
 from pathlib import Path
 from unittest.mock import patch
 
@@ -425,3 +426,46 @@ class TestPublicHelpers:
         while not sent and time.monotonic() < deadline:
             time.sleep(0.02)
         assert sent and sent[0].data["after_restart"] is True
+
+
+class TestCustomerUuidValidation:
+    """Audit backlog: uuid file content must be validated, and a
+    regenerated uuid must be PERSISTED so the install converges on one
+    stable identity (the old empty-file branch re-minted every start)."""
+
+    def test_malformed_uuid_file_regenerates_and_persists(
+        self, clean_env, isolated_data_dir
+    ) -> None:
+        uuid_file = isolated_data_dir / "customer_uuid.txt"
+        uuid_file.write_text("not-a-uuid; drop table installs")
+        collector = tel.TelemetryCollector()
+        try:
+            stored = uuid_file.read_text(encoding="utf-8").strip()
+            assert stored == collector._customer_uuid
+            uuid.UUID(stored)  # must now be a real UUID
+            assert "drop table" not in stored
+        finally:
+            collector.shutdown()
+
+    def test_empty_uuid_file_regenerates_and_persists(self, clean_env, isolated_data_dir) -> None:
+        uuid_file = isolated_data_dir / "customer_uuid.txt"
+        uuid_file.write_text("")
+        collector = tel.TelemetryCollector()
+        try:
+            stored = uuid_file.read_text(encoding="utf-8").strip()
+            assert stored, "regenerated uuid must be written back"
+            assert stored == collector._customer_uuid
+            uuid.UUID(stored)
+        finally:
+            collector.shutdown()
+
+    def test_valid_uuid_file_is_preserved(self, clean_env, isolated_data_dir) -> None:
+        uuid_file = isolated_data_dir / "customer_uuid.txt"
+        fixed = str(uuid.uuid4())
+        uuid_file.write_text(fixed)
+        collector = tel.TelemetryCollector()
+        try:
+            assert collector._customer_uuid == fixed
+            assert uuid_file.read_text(encoding="utf-8").strip() == fixed
+        finally:
+            collector.shutdown()


### PR DESCRIPTION
## Summary

Sixth themed PR of the audit plan's Phase 2 (`docs/audit-tier2-plan.md`): seven Tier-1 telemetry/CI-hygiene items.

**Stop CI/dev fixtures polluting production telemetry:**
1. `.claude/hooks/session-start.sh` now exports `GODOT_AI_DISABLE_TELEMETRY=true` in its remote-only section — every Claude web session's headless editor (and the server it spawns) was injecting fake install events into production telemetry.
2. `ci-stale-server-smoke`, `ci-game-capture-smoke`, and `local-self-update-smoke` now `os.environ.setdefault("GODOT_AI_DISABLE_TELEMETRY", "true")` — the Python-implemented smoke runners bypassed `_ci_env.sh`'s stance, and every `os.environ.copy()` spawn inherited telemetry ON.

**Local fixture safety:**
3. `local-self-update-smoke`'s `extract_release_zip_to_addon` now refuses traversal segments, absolute paths, and backslash entries — the exact zip containment the plugin's own update runner enforces was missing from the local fixture that extracts release zips onto the operator's disk.

**Trust boundaries:**
4. `telemetry.py`: `customer_uuid.txt` content is **validated** (`uuid.UUID`) instead of trusted verbatim, and a regenerated id is **persisted** — the old empty-file branch minted a fresh uuid every start without writing it back, so the install never converged on one identity.
5. `sessions/registry.py`: handshake-supplied `godot_version`/`plugin_version`/`protocol_version`/`server_launch_mode` are sanitized (version-token regex, else `"invalid"`) **in the telemetry payload only** — any local process can connect and stuff arbitrary text into these (AGENTS.md WS trust boundary). `Session` fields stay verbatim for MCP clients.

**Supply-chain honesty:**
6. `pyproject.toml` declares `uvicorn>=0.23` + `starlette>=0.27` — `asgi.py` imports both directly but they only arrived transitively through fastmcp. Floors match the mcp SDK's minimums; resolution unchanged (installed 0.51.0/1.3.1 satisfy).

**Skipped (verify-first):** the `telemetry.py` module-docstring item — its endpoint bullet already states the send-by-default behavior on current main.

## Testing

5 new unit tests: uuid-file malformed/empty/valid matrix (regeneration persists, valid ids preserved, hostile content never stored), hostile-vs-normal handshake version strings in the registry's telemetry payload.

Gauntlet: `ruff` clean · `pytest` full suite green · `ci-check-gdscript` OK (no GDScript changes) · `bash -n`/`py_compile` clean on all four scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2zhpWvnqijYYRW3dwtUhV

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2zhpWvnqijYYRW3dwtUhV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Disabled telemetry during web, headless, CI, and smoke-test sessions by default.
  - Sanitized session version details before telemetry transmission.
  - Repaired invalid or missing telemetry identifiers so they persist consistently.
  - Hardened archive extraction against unsafe file paths.

- **Maintenance**
  - Added explicit support for ASGI server dependencies.
  - Expanded automated coverage for telemetry validation and security safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->