### PR TITLE
Phase 2: concurrency statics/caches + port-scrape and mirror parity (8 audit items)

### DIFF
--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -667,13 +667,19 @@ static func invalidate_uv_version_cache() -> void:
 
 static var _venv_python_cache: String = ""
 static var _venv_python_searched: bool = false
+## #678 worker threads write this cache while main-thread callers read
+## it; same lock discipline as McpCliFinder (clients/_cli_finder.gd).
+static var _venv_mutex: Mutex = Mutex.new()
 
 
 static func _cached_venv_python() -> String:
+	_venv_mutex.lock()
 	if not _venv_python_searched:
 		_venv_python_cache = _find_venv_python()
 		_venv_python_searched = true
-	return _venv_python_cache
+	var cached := _venv_python_cache
+	_venv_mutex.unlock()
+	return cached
 
 
 static func _find_venv_python() -> String:

--- a/plugin/addons/godot_ai/connection.gd
+++ b/plugin/addons/godot_ai/connection.gd
@@ -113,6 +113,12 @@ func _process(delta: float) -> void:
 				_reconnect_attempt = 0
 				log_buffer.log("connected to server")
 				_send_handshake()
+				## Reset the edge detectors so the next _check_state_changes
+				## tick re-emits any non-default scene/play state — the
+				## handshake carries readiness only, so without this a
+				## (re)connected server never learns the current scene.
+				_last_scene_path = ""
+				_last_play_state = false
 				connection_state_changed.emit(true)
 
 			_drain_inbound_packets(_peer)
@@ -181,6 +187,10 @@ func disconnect_from_server() -> void:
 	if _connected:
 		_peer.close(1000, "Plugin unloading")
 		_connected = false
+		## Pre-clearing _connected makes the STATE_CLOSED branch skip its
+		## _clear_on_disconnect() — run it here so deliberate closes don't
+		## leak the old server's version/deferred state into the next one.
+		_clear_on_disconnect()
 		connection_state_changed.emit(false)
 
 

--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -958,7 +958,11 @@ func reload_plugin(_params: Dictionary) -> Dictionary:
 ## fail with "Could not find type X" when new class_name scripts are on disk
 ## but not yet registered, leaving the plugin disabled with no recovery path
 ## short of killing the editor. See issue #83.
-func _do_reload_plugin() -> void:
+# `static` is load-bearing: the deferred coroutine captures no `self`, so
+# it survives even if the EditorHandler RefCounted is freed mid-await —
+# which is exactly what reload does to this handler's owner. An instance
+# coroutine here resumes on a freed object under reload churn.
+static func _do_reload_plugin() -> void:
 	var fs := EditorInterface.get_resource_filesystem()
 	fs.scan()
 	var tree := Engine.get_main_loop() as SceneTree

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -1722,6 +1722,10 @@ func stop_dev_server() -> void:
 		# We have a managed server — use normal stop
 		_stop_server()
 		return
+	## A suspended startup walk holds pre-kill probe results; without this
+	## it can resume against the listener we are about to kill and adopt a
+	## dead server.
+	_lifecycle._invalidate_async_startup()
 	var port := ClientConfigurator.http_port()
 	var candidates: Array[int] = []
 	for pid in _find_all_pids_on_port(port):
@@ -1762,8 +1766,10 @@ func _kill_processes_and_windows_spawn_children(pids: Array[int], verify_brand: 
 			if exit_code == 0 or not _pid_alive(pid):
 				killed.append(pid)
 		else:
-			OS.kill(pid)
-			killed.append(pid)
+			## Mirror the Windows branch: only report the PID as killed if
+			## the kill succeeded or the process is verifiably gone.
+			if OS.kill(pid) == OK or not _pid_alive(pid):
+				killed.append(pid)
 	return killed
 
 

--- a/plugin/addons/godot_ai/utils/allow_hosts.gd
+++ b/plugin/addons/godot_ai/utils/allow_hosts.gd
@@ -45,6 +45,11 @@ static func token_is_valid(token: String) -> bool:
 	if slash != -1:
 		ip = t.substr(0, slash)
 		var prefix_text := t.substr(slash + 1)
+		## Explicit signs are rejected by the server's parse_allow_hosts
+		## (ipaddress refuses "10.0.0.0/+8"), but is_valid_int accepts
+		## them — keep the mirror honest.
+		if prefix_text.is_empty() or prefix_text.begins_with("+") or prefix_text.begins_with("-"):
+			return false
 		if not prefix_text.is_valid_int():
 			return false
 		prefix = int(prefix_text)

--- a/plugin/addons/godot_ai/utils/port_resolver.gd
+++ b/plugin/addons/godot_ai/utils/port_resolver.gd
@@ -40,9 +40,11 @@ static func is_port_in_use_via_scrape(port: int) -> bool:
 	var output: Array = []
 	if OS.get_name() == "Windows":
 		var exit_code := OS.execute("netstat", ["-ano"], output, true)
-		if exit_code == 0 and output.size() > 0:
-			return parse_windows_netstat_listening(str(output[0]), port)
-		return false
+		if exit_code == 0 and output.size() > 0 and parse_windows_netstat_listening(str(output[0]), port):
+			return true
+		## Mirror find_all_pids_on_port's fallback: netstat can be absent
+		## or unparseable on stripped/locale-odd Windows installs.
+		return not find_listener_pids_windows(port).is_empty()
 	var exit_code := OS.execute("lsof", ["-ti:%d" % port, "-sTCP:LISTEN"], output, true)
 	return exit_code == 0 and output.size() > 0 and not output[0].strip_edges().is_empty()
 
@@ -176,7 +178,10 @@ static func parse_windows_netstat_pids(stdout: String, port: int) -> Array[int]:
 		var fields := split_on_whitespace(s)
 		if fields.size() < 5:  # proto, local, remote, state, pid
 			continue
-		if fields[3] != "LISTENING":
+		## Locale-independent listener signal (mirrors script/_dev_env.py):
+		## the state column is localized ("LISTENING"/"ABHÖREN"/"ÉCOUTE"...),
+		## but a listener's FOREIGN address is always the wildcard ":0".
+		if not fields[2].ends_with(":0"):
 			continue
 		if not fields[1].ends_with(port_suffix):
 			continue
@@ -256,6 +261,9 @@ static func pid_alive(pid: int) -> bool:
 
 ## Poll until the given port is no longer bound, or the timeout elapses.
 ## Used after `OS.kill` so we don't race the port-in-use check on rebind.
+## NOTE: plugin.gd::_wait_for_port_free (and _is_port_in_use) is a
+## deliberate line-for-line fork of this pair kept for _ProofPlugin
+## isolation — keep the two in sync when editing either.
 static func wait_for_port_free(port: int, timeout_s: float) -> void:
 	var deadline := Time.get_ticks_msec() + int(timeout_s * 1000.0)
 	while is_port_in_use(port):

--- a/test_project/tests/test_allow_hosts.gd
+++ b/test_project/tests/test_allow_hosts.gd
@@ -171,3 +171,13 @@ func test_configurator_allow_hosts_normalizes_setting() -> void:
 		return
 	es.set_setting(McpSettings.SETTING_ALLOW_HOSTS, " 192.168.1.5 , 192.168.1.5 ")
 	assert_eq(McpClientConfigurator.allow_hosts(), "192.168.1.5")
+
+
+func test_signed_and_empty_prefixes_rejected() -> void:
+	## Parity with the server's parse_allow_hosts: ipaddress refuses
+	## explicit signs ("10.0.0.0/+8") and empty prefixes, but GDScript's
+	## is_valid_int accepts "+8" — the mirror must reject them too.
+	assert_false(McpAllowHosts.token_is_valid("10.0.0.0/+8"))
+	assert_false(McpAllowHosts.token_is_valid("10.0.0.0/-1"))
+	assert_false(McpAllowHosts.token_is_valid("10.0.0.0/"))
+	assert_true(McpAllowHosts.token_is_valid("10.0.0.0/8"))

--- a/test_project/tests/test_port_resolver.gd
+++ b/test_project/tests/test_port_resolver.gd
@@ -127,3 +127,21 @@ func test_windows_powershell_candidates_prefers_system32_path() -> void:
 	var candidates := McpPortResolver.windows_powershell_candidates()
 	assert_true(candidates.size() >= 3)
 	assert_true(candidates[0].ends_with("powershell.exe"))
+
+
+func test_netstat_parse_is_locale_independent() -> void:
+	## The state column is localized ("ABHÖREN", "ÉCOUTE", ...); the
+	## listener signal is the wildcard ":0" FOREIGN address, which is
+	## locale-independent (mirrors script/_dev_env.py).
+	var german := "  TCP  0.0.0.0:8000  0.0.0.0:0  ABHÖREN  4242\n"
+	var pids := McpPortResolver.parse_windows_netstat_pids(german, 8000)
+	assert_eq(pids.size(), 1, "localized state must still parse via the :0 foreign addr")
+	assert_eq(pids[0], 4242)
+
+
+func test_netstat_parse_still_skips_established_rows() -> void:
+	## An ESTABLISHED row's foreign address carries a real port — it must
+	## not be mistaken for a listener even when the local port matches.
+	var established := "  TCP  10.0.0.5:8000  10.0.0.9:51515  HERGESTELLT  777\n"
+	var pids := McpPortResolver.parse_windows_netstat_pids(established, 8000)
+	assert_eq(pids.size(), 0, "non-listener rows must be skipped regardless of locale")


### PR DESCRIPTION
## Summary

Seventh themed PR of the audit plan's Phase 2 (`docs/audit-tier2-plan.md`): eight Tier-1 concurrency/parity items, each re-verified against current main.

1. **`editor_handler._do_reload_plugin` → `static`** with the same "`static` is load-bearing" rationale as its script/filesystem siblings — an instance coroutine here resumes on a freed handler under reload churn, and reload frees exactly this handler's owner mid-await.
2. **`_venv_python_cache`/`_venv_python_searched` mutex** (McpCliFinder's lock discipline) — #678 worker threads write these statics while main-thread callers read them.
3. **`allow_hosts.token_is_valid` rejects explicit-sign prefixes** (`10.0.0.0/+8`) — GDScript's `is_valid_int` accepts `"+8"` but the server's `parse_allow_hosts` (ipaddress) rejects it, breaking the mirror promise. Verified empirically against `origin_guard`.
4. **Locale-independent netstat parsing** — `parse_windows_netstat_pids` now keys on the wildcard `:0` *foreign* address instead of the localized `"LISTENING"` state literal (mirrors `script/_dev_env.py`'s earlier fix). Non-English Windows never matched a listener.
5. **`is_port_in_use_via_scrape` gains the PowerShell fallback** its PID-lookup twin already has — netstat can be absent/unparseable on stripped installs, silently reporting "free".
6. **Cross-reference comment** on `port_resolver.wait_for_port_free` naming the deliberate `plugin.gd` fork, mirroring the comment that already exists on the other side.
7. **POSIX kill verification** — `plugin.gd`'s POSIX branch unconditionally reported PIDs as killed; it now requires `OS.kill == OK` or a verified-dead process, matching the Windows branch.
8. **`connection.gd` state hygiene** — `disconnect_from_server` now runs `_clear_on_disconnect()` (deliberate closes pre-cleared `_connected`, so the CLOSED-branch cleanup was skipped on exactly those paths, leaking the old server's version/deferred state into the next connection); and (re)connect resets the scene/play edge detectors so a reconnected server — which only gets readiness in the handshake — re-learns the current scene on the next tick.

**Deferred to a filed issue (verify-first, not a tightening):** the `project_handler` deferred-finisher static conversion — parameterizing the connection + debugger plugin cascades through the liveness-decision helpers, i.e. a real refactor.

## Testing

New GDScript tests: allow-hosts signed/empty-prefix rejection matrix; netstat locale-independence (localized state parses via `:0`) and ESTABLISHED-row rejection.

Gauntlet: `ruff` clean · `pytest` 1329 passed · `ci-check-gdscript` OK · `ci-godot-tests` **1755/1773 passed, 0 failed** · `ci-stale-server-smoke` **PASS in both modes** (kill/lifecycle paths touched, so both smokes were required and run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2zhpWvnqijYYRW3dwtUhV

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2zhpWvnqijYYRW3dwtUhV)_