### PR TITLE
DirectRuntime: use public ctx.lifespan_context instead of fastmcp's private _lifespan_result

### DIFF
--- a/src/godot_ai/runtime/direct.py
+++ b/src/godot_ai/runtime/direct.py
@@ -30,8 +30,11 @@ class DirectRuntime:
 
     @classmethod
     def from_context(cls, ctx: Context, session_id: str | None = None) -> DirectRuntime:
-        app = ctx.fastmcp._lifespan_result
-        if app is None:
+        ## Public accessor for the value our lifespan yielded (an AppContext).
+        ## When the lifespan hasn't run it returns None or an empty dict
+        ## instead of the app object, so guard on shape rather than on None.
+        app = ctx.lifespan_context
+        if not (hasattr(app, "registry") and hasattr(app, "client")):
             raise RuntimeError("FastMCP lifespan context is not available")
         return cls.from_app_context(app, session_id=session_id)
 

--- a/src/godot_ai/runtime/direct.py
+++ b/src/godot_ai/runtime/direct.py
@@ -33,7 +33,10 @@ class DirectRuntime:
         ## Public accessor for the value our lifespan yielded (an AppContext).
         ## When the lifespan hasn't run it returns None or an empty dict
         ## instead of the app object, so guard on shape rather than on None.
-        app = ctx.lifespan_context
+        ## getattr, not attribute access: a Context-like object without the
+        ## accessor should surface as the same stable RuntimeError, not an
+        ## AttributeError.
+        app = getattr(ctx, "lifespan_context", None)
         if not (hasattr(app, "registry") and hasattr(app, "client")):
             raise RuntimeError("FastMCP lifespan context is not available")
         return cls.from_app_context(app, session_id=session_id)

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 
 import pytest
 
@@ -1360,6 +1361,33 @@ async def test_direct_runtime_unbound_preserves_active_routing():
     assert client.calls[-1]["session_id"] is None
 
 
+class _LifespanCtxStub:
+    """Quacks like fastmcp.Context for from_context: only lifespan_context is read."""
+
+    def __init__(self, lifespan_context):
+        self.lifespan_context = lifespan_context
+
+
+def test_direct_runtime_from_context_reads_public_lifespan_accessor():
+    registry = SessionRegistry()
+    registry.register(_make_session("a"))
+    registry.set_active("a")
+    app_context = SimpleNamespace(registry=registry, client=StubClient())
+
+    runtime = DirectRuntime.from_context(_LifespanCtxStub(app_context), session_id="a")
+
+    assert runtime.get_active_session().session_id == "a"
+
+
+@pytest.mark.parametrize("absent", [None, {}], ids=["none", "empty-dict"])
+def test_direct_runtime_from_context_rejects_absent_lifespan(absent):
+    ## fastmcp's public lifespan_context reports "lifespan never ran" as None
+    ## or an empty dict (never our AppContext shape) — both must raise, like
+    ## the old private-attribute None check did.
+    with pytest.raises(RuntimeError, match="lifespan context is not available"):
+        DirectRuntime.from_context(_LifespanCtxStub(absent))
+
+
 async def test_logs_read_handler_uses_runtime_and_paginates():
     runtime = DirectRuntime(registry=SessionRegistry(), client=StubClient())
 
@@ -1541,9 +1569,7 @@ async def test_logs_read_handler_game_forwards_editor_error_hint_fields():
             timeout: float = 5.0,
             surface_error_hints: bool = True,
         ) -> dict:
-            result = await super().send(
-                command, params, session_id, timeout, surface_error_hints
-            )
+            result = await super().send(command, params, session_id, timeout, surface_error_hints)
             if command == "get_logs" and (params or {}).get("source") == "game":
                 result = dict(result)
                 result["current_run_id"] = "rstub"
@@ -3571,9 +3597,7 @@ async def test_input_map_add_action_handler():
 async def test_input_map_ensure_action_handler():
     client = StubClient()
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)
-    result = await input_map_handlers.input_map_ensure_action(
-        runtime, action="jump", deadzone=0.3
-    )
+    result = await input_map_handlers.input_map_ensure_action(runtime, action="jump", deadzone=0.3)
     assert result["action"] == "jump"
     assert result["deadzone"] == 0.3
     assert client.calls[-1]["command"] == "ensure_action"

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -1388,6 +1388,14 @@ def test_direct_runtime_from_context_rejects_absent_lifespan(absent):
         DirectRuntime.from_context(_LifespanCtxStub(absent))
 
 
+def test_direct_runtime_from_context_rejects_context_without_accessor():
+    ## A Context-like object with no lifespan_context attribute at all (an
+    ## API change, or something that merely resembles Context) must surface
+    ## as the same stable RuntimeError, not an AttributeError.
+    with pytest.raises(RuntimeError, match="lifespan context is not available"):
+        DirectRuntime.from_context(object())
+
+
 async def test_logs_read_handler_uses_runtime_and_paginates():
     runtime = DirectRuntime(registry=SessionRegistry(), client=StubClient())
 


### PR DESCRIPTION
## Summary

Closes #717 (audit S2·defense, filed standalone because it's a one-line change under literally every tool call).

`DirectRuntime.from_context` reached into fastmcp's **private** `_lifespan_result` attribute while pyproject allows the whole 3.0.x–3.4.x range — a private name any patch release can rename. The public `Context.lifespan_context` accessor reads the same cached lifespan result; equivalence was verified against the pinned fastmcp 3.4.4 source (the accessor returns `_lifespan_result` whenever the lifespan has run — the request-context fallback only engages before that).

One behavioral nuance: the public accessor reports "lifespan never ran" as `None` **or an empty dict** rather than `None` only, so the unavailable-guard now checks for the `AppContext` shape (`registry` + `client` attributes, matching the module's own `SupportsDirectRuntime` protocol) instead of testing against `None`. Same `RuntimeError`, same message.

## Testing

3 new unit tests: `from_context` resolves a runtime through the public accessor; `None` and `{}` lifespan values both raise the unavailable `RuntimeError`.

Gauntlet: `ruff` clean · `pytest` **1348 passed** · `ci-check-gdscript` OK · live editor run through the modified path (`ci-start-server` + headless editor + `ci-godot-tests`): **1763/1781 passed, 0 failed** — every one of those live tool calls resolved its runtime via the new accessor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2zhpWvnqijYYRW3dwtUhV

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2zhpWvnqijYYRW3dwtUhV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime context handling by deriving the lifespan “app context” from the supported public accessor.
  * Added stronger validation for required fields and clearer errors when the lifespan context is missing or incomplete.
* **Tests**
  * Added unit tests for correct session selection when lifespan context is present.
  * Added negative test coverage for missing, empty, or absent lifespan accessor scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->