### PR TITLE
material_apply_to_node: refuse to clobber an existing save_to file without overwrite=true

### DIFF
--- a/plugin/addons/godot_ai/handlers/material_handler.gd
+++ b/plugin/addons/godot_ai/handlers/material_handler.gd
@@ -473,10 +473,22 @@ func apply_to_node(params: Dictionary) -> Dictionary:
 
 	var save_to: String = params.get("save_to", "")
 	var saved := false
+	var overwritten := false
 	if not save_to.is_empty():
 		var save_err_validation := _validate_material_path(save_to, "save_to", true)
 		if save_err_validation != null:
 			return save_err_validation
+		# Same clobber guard as create_material/apply_preset: agents reuse
+		# names like res://materials/metal.tres, and a silent save here
+		# destroys a hand-authored file that undo can't restore (undo only
+		# reverts the node's slot assignment, not file contents). See #685.
+		var existed_before := FileAccess.file_exists(save_to)
+		if existed_before and not params.get("overwrite", false):
+			return ErrorCodes.make(
+				ErrorCodes.INVALID_PARAMS,
+				"Material already exists at %s (pass overwrite=true to replace)" % save_to
+			)
+		overwritten = existed_before
 		var dir_path := save_to.get_base_dir()
 		var mkdir_err := DirAccess.make_dir_recursive_absolute(dir_path)
 		if mkdir_err != OK and mkdir_err != ERR_ALREADY_EXISTS:
@@ -513,6 +525,7 @@ func apply_to_node(params: Dictionary) -> Dictionary:
 			"applied_params": applied,
 			"material_created": true,
 			"saved_to": save_to if saved else "",
+			"overwritten": overwritten,
 			"undoable": true,
 		}
 	}

--- a/src/godot_ai/handlers/material.py
+++ b/src/godot_ai/handlers/material.py
@@ -90,6 +90,7 @@ async def material_apply_to_node(
     params: dict[str, Any] | None = None,
     slot: str = "override",
     save_to: str = "",
+    overwrite: bool = False,
 ) -> dict:
     await require_writable_async(runtime)
     payload: dict[str, Any] = {
@@ -100,6 +101,7 @@ async def material_apply_to_node(
     }
     if save_to:
         payload["save_to"] = save_to
+        payload["overwrite"] = overwrite
     return await runtime.send_command("material_apply_to_node", payload)
 
 

--- a/src/godot_ai/tools/material.py
+++ b/src/godot_ai/tools/material.py
@@ -35,9 +35,10 @@ Ops:
         "surface_<N>" | "canvas" | "process". When create_if_missing=True
         and no resource_path, makes an inline material of `type`.
   • apply_to_node(node_path, type="standard", params=None, slot="override",
-                   save_to="")
+                   save_to="", overwrite=False)
         High-level: build + set params + assign in one undo.
-        save_to optionally persists to disk.
+        save_to optionally persists to disk; errors if the file already
+        exists unless overwrite=True.
   • apply_preset(preset, path="", node_path="", overrides=None)
         Curated looks: metal, glass, emissive, unlit, matte, ceramic.
         path saves to disk; node_path assigns to a node; overrides merge.

--- a/test_project/tests/test_material.gd
+++ b/test_project/tests/test_material.gd
@@ -536,6 +536,51 @@ func test_apply_to_node_with_save_to() -> void:
 	_remove_node(node)
 
 
+func test_apply_to_node_save_to_refuses_existing_file_without_overwrite() -> void:
+	# #685: save_to must not silently clobber an existing .tres — undo only
+	# restores the node's slot assignment, never the file contents.
+	_make_material(TEST_MATERIAL_PATH_2)
+	var before := FileAccess.get_file_as_bytes(TEST_MATERIAL_PATH_2)
+	var node := _add_mesh_node("TestApplyNoClobber") as Node
+	if node == null:
+		assert_true(false, "No scene root — is a scene open?")
+		return
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var result := _handler.apply_to_node({
+		"node_path": McpScenePath.from_node(node, scene_root),
+		"type": "standard",
+		"save_to": TEST_MATERIAL_PATH_2,
+	})
+	assert_is_error(result, ErrorCodes.INVALID_PARAMS)
+	assert_true(
+		result.error.message.contains("overwrite=true"),
+		"Error should name the overwrite escape hatch"
+	)
+	var after := FileAccess.get_file_as_bytes(TEST_MATERIAL_PATH_2)
+	assert_eq(after, before, "Refused save must leave the existing file untouched")
+	_remove_node(node)
+
+
+func test_apply_to_node_save_to_overwrites_with_flag() -> void:
+	_make_material(TEST_MATERIAL_PATH_2)
+	var node := _add_mesh_node("TestApplyOverwrite") as Node
+	if node == null:
+		assert_true(false, "No scene root — is a scene open?")
+		return
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var result := _handler.apply_to_node({
+		"node_path": McpScenePath.from_node(node, scene_root),
+		"type": "standard",
+		"params": {"metallic": 0.5},
+		"save_to": TEST_MATERIAL_PATH_2,
+		"overwrite": true,
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.saved_to, TEST_MATERIAL_PATH_2)
+	assert_true(result.data.overwritten, "Response should report the overwrite")
+	_remove_node(node)
+
+
 # ============================================================================
 # material_apply_preset
 # ============================================================================

--- a/test_project/tests/test_material.gd
+++ b/test_project/tests/test_material.gd
@@ -543,7 +543,7 @@ func test_apply_to_node_save_to_refuses_existing_file_without_overwrite() -> voi
 	var before := FileAccess.get_file_as_bytes(TEST_MATERIAL_PATH_2)
 	var node := _add_mesh_node("TestApplyNoClobber") as Node
 	if node == null:
-		assert_true(false, "No scene root — is a scene open?")
+		skip("No scene root — is a scene open?")
 		return
 	var scene_root := EditorInterface.get_edited_scene_root()
 	var result := _handler.apply_to_node({
@@ -565,7 +565,7 @@ func test_apply_to_node_save_to_overwrites_with_flag() -> void:
 	_make_material(TEST_MATERIAL_PATH_2)
 	var node := _add_mesh_node("TestApplyOverwrite") as Node
 	if node == null:
-		assert_true(false, "No scene root — is a scene open?")
+		skip("No scene root — is a scene open?")
 		return
 	var scene_root := EditorInterface.get_edited_scene_root()
 	var result := _handler.apply_to_node({

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -1541,9 +1541,7 @@ async def test_logs_read_handler_game_forwards_editor_error_hint_fields():
             timeout: float = 5.0,
             surface_error_hints: bool = True,
         ) -> dict:
-            result = await super().send(
-                command, params, session_id, timeout, surface_error_hints
-            )
+            result = await super().send(command, params, session_id, timeout, surface_error_hints)
             if command == "get_logs" and (params or {}).get("source") == "game":
                 result = dict(result)
                 result["current_run_id"] = "rstub"
@@ -3571,9 +3569,7 @@ async def test_input_map_add_action_handler():
 async def test_input_map_ensure_action_handler():
     client = StubClient()
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)
-    result = await input_map_handlers.input_map_ensure_action(
-        runtime, action="jump", deadzone=0.3
-    )
+    result = await input_map_handlers.input_map_ensure_action(runtime, action="jump", deadzone=0.3)
     assert result["action"] == "jump"
     assert result["deadzone"] == 0.3
     assert client.calls[-1]["command"] == "ensure_action"
@@ -5063,6 +5059,31 @@ async def test_material_apply_to_node_forwards_save_to():
     )
     sent = client.calls[-1]["params"]
     assert sent["save_to"] == "res://materials/my_mat.tres"
+
+
+async def test_material_apply_to_node_forwards_overwrite_with_save_to():
+    ## #685: overwrite defaults to False and travels only alongside save_to —
+    ## the plugin's clobber guard keys on it, so an inline apply (no save_to)
+    ## must not carry the flag at all.
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    await material_handlers.material_apply_to_node(
+        runtime,
+        node_path="/Main/Box",
+        save_to="res://materials/my_mat.tres",
+    )
+    assert client.calls[-1]["params"]["overwrite"] is False
+
+    await material_handlers.material_apply_to_node(
+        runtime,
+        node_path="/Main/Box",
+        save_to="res://materials/my_mat.tres",
+        overwrite=True,
+    )
+    assert client.calls[-1]["params"]["overwrite"] is True
+
+    await material_handlers.material_apply_to_node(runtime, node_path="/Main/Box")
+    assert "overwrite" not in client.calls[-1]["params"]
 
 
 async def test_material_apply_preset_handler():


### PR DESCRIPTION
## Summary

Completes the second half of #685 (the #288 pause-guard half landed in #693). Implements the maintainer's decision from today: **`overwrite` param, default `false`**, matching the siblings.

`apply_to_node`'s `save_to` branch was the only save path in `material_handler.gd` with no exists check — it validated the path, mkdir'd, and saved unconditionally. An agent pointing `save_to` at an existing hand-authored material (an easy collision — agents reuse names like `res://materials/metal.tres`) silently destroyed the user's file, and undo restores only the node's slot assignment, never the file contents.

- The branch now carries the exact clobber guard `create_material` and `apply_preset` already use: `INVALID_PARAMS`, "pass overwrite=true to replace".
- The response reports `overwritten`, like `create_material` does.
- The Python handler exposes `overwrite: bool = False`, sent only alongside `save_to` (an inline apply has nothing to clobber); the tool docstring documents the new behavior.

## Testing

2 new GDScript tests (refusal leaves the existing file byte-identical + names the escape hatch; `overwrite=true` succeeds and reports `overwritten`), 1 new Python unit test (forwarding matrix: default false with save_to, true when passed, absent without save_to).

Gauntlet: `ruff` clean · `pytest` **1346 passed** · `ci-check-gdscript` OK · live editor run: **1765/1783 passed, 0 failed** (includes the new tests). No lifecycle/spawn/self-update paths touched, so the smokes don't apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2zhpWvnqijYYRW3dwtUhV

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2zhpWvnqijYYRW3dwtUhV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `overwrite` option for saving materials to an existing `.tres` file.
  * Save responses now include whether the target file was overwritten.

* **Bug Fixes**
  * Prevented accidental replacement of existing material files unless overwrite is explicitly allowed.
  * Improved overwrite-related validation and user-facing error messaging.

* **Tests**
  * Added new tests for blocked saves, successful overwrites, and correct request forwarding of the `overwrite` option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->