### PR TITLE
Client config strategy parity: TOML initial-vs-pinned split, ERROR status details, CliFinder delegation, fail-closed symlink guard

### DIFF
--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -739,7 +739,10 @@ static func find_worktree_src_dir(start_dir: String) -> String:
 ## PATH tiers plus its per-exe cache, and this drops the private
 ## `_pick_best_path` cross-class reach (#711).
 static func _find_system_install() -> String:
-	var names: Array[String] = (
-		["godot-ai.exe", "godot-ai"] if OS.get_name() == "Windows" else ["godot-ai"]
-	)
+	## Built with append, not a ternary of untyped literals — assigning a
+	## ternary's Array to Array[String] is a runtime error on newer Godot
+	## builds (same idiom as _uvx_cli_names above).
+	var names: Array[String] = ["godot-ai"]
+	if OS.get_name() == "Windows":
+		names.push_front("godot-ai.exe")
 	return CliFinder.find(names)

--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -382,15 +382,15 @@ static func _dispatch_check_status_with_cli_path(client: Client, url: String, cl
 static func _dispatch_check_status_with_cli_path_details(client: Client, url: String, cli_path: String) -> Dictionary:
 	match client.config_type:
 		"json":
-			return {"status": JsonStrategy.check_status(client, SERVER_NAME, url), "error_msg": ""}
+			return JsonStrategy.check_status_details(client, SERVER_NAME, url)
 		"toml":
-			return {"status": TomlStrategy.check_status(client, SERVER_NAME, url), "error_msg": ""}
+			return TomlStrategy.check_status_details(client, SERVER_NAME, url)
 		"cli":
 			var resolved_cli := cli_path if not cli_path.is_empty() else CliStrategy.resolve_cli_path(client)
 			# #463: with no CLI binary, read the JSON fallback config so a
 			# fallback-configured entry reports CONFIGURED instead of red.
 			if resolved_cli.is_empty() and client.has_json_fallback():
-				return {"status": JsonStrategy.check_status(client, SERVER_NAME, url), "error_msg": ""}
+				return JsonStrategy.check_status_details(client, SERVER_NAME, url)
 			return CliStrategy.check_status_details(client, SERVER_NAME, url, resolved_cli)
 	return {"status": Client.Status.NOT_CONFIGURED, "error_msg": ""}
 
@@ -529,7 +529,13 @@ static func _is_symlink(path: String) -> bool:
 	if path.is_empty():
 		return false
 	var dir := DirAccess.open(path.get_base_dir())
-	return dir != null and dir.is_link(path)
+	if dir == null:
+		## This is a data-safety guard (a symlinked addons dir is a dev
+		## checkout self-update must never write through). When the path
+		## exists but its parent can't be opened, we can't PROVE it isn't
+		## a link — fail closed and treat it as one (#711).
+		return DirAccess.dir_exists_absolute(path) or FileAccess.file_exists(path)
+	return dir.is_link(path)
 
 
 ## `refresh` forces uvx to re-fetch PyPI index metadata on spawn — used by
@@ -728,14 +734,12 @@ static func find_worktree_src_dir(start_dir: String) -> String:
 	return ""
 
 
+## Delegates to McpCliFinder rather than shelling out to which/where
+## directly: the finder adds the well-known-install-dirs and login-shell
+## PATH tiers plus its per-exe cache, and this drops the private
+## `_pick_best_path` cross-class reach (#711).
 static func _find_system_install() -> String:
-	var cmd := "which" if OS.get_name() != "Windows" else "where"
-	var result := McpCliExec.run(cmd, ["godot-ai"], _DISCOVERY_TIMEOUT_MS, false)
-	if int(result.get("exit_code", -1)) == 0:
-		var lines := PackedStringArray(str(result.get("stdout", "")).split("\n"))
-		if lines.is_empty():
-			return ""
-		var found := CliFinder._pick_best_path(lines) if OS.get_name() == "Windows" else lines[0].strip_edges()
-		if not found.is_empty():
-			return found
-	return ""
+	var names: Array[String] = (
+		["godot-ai.exe", "godot-ai"] if OS.get_name() == "Windows" else ["godot-ai"]
+	)
+	return CliFinder.find(names)

--- a/plugin/addons/godot_ai/clients/_json_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_json_strategy.gd
@@ -30,23 +30,34 @@ static func configure(client: McpClient, server_name: String, server_url: String
 
 
 static func check_status(client: McpClient, server_name: String, server_url: String) -> McpClient.Status:
+	return check_status_details(client, server_name, server_url).get("status", McpClient.Status.NOT_CONFIGURED)
+
+
+## Detailed variant feeding the dock's error_msg plumbing (#711): a config
+## file that EXISTS but can't be read or parsed is Status.ERROR carrying the
+## read/parse error, not NOT_CONFIGURED — the write path refuses to touch
+## such a file (see `_read_or_init`), so the status dot must say "broken
+## file", not "click Configure".
+static func check_status_details(client: McpClient, server_name: String, server_url: String) -> Dictionary:
 	var path := client.resolved_config_path()
 	if path.is_empty() or not FileAccess.file_exists(path):
-		return McpClient.Status.NOT_CONFIGURED
+		return {"status": McpClient.Status.NOT_CONFIGURED, "error_msg": ""}
 	var read := _read_or_init(path)
 	if not read["ok"]:
-		return McpClient.Status.NOT_CONFIGURED
+		return {"status": McpClient.Status.ERROR, "error_msg": String(read["error"])}
 	var config: Dictionary = read["data"]
 	var holder := _walk_path(config, client.server_key_path)
 	if not (holder is Dictionary) or not holder.has(server_name):
-		return McpClient.Status.NOT_CONFIGURED
+		return {"status": McpClient.Status.NOT_CONFIGURED, "error_msg": ""}
 	var entry = holder[server_name]
 	if not (entry is Dictionary):
-		return McpClient.Status.NOT_CONFIGURED
+		return {"status": McpClient.Status.NOT_CONFIGURED, "error_msg": ""}
 	## An entry under `server_name` exists — if the URL doesn't match,
 	## that's drift (the user changed the port and the client config is stale),
 	## not "never configured". The dock surfaces that as an amber banner.
-	return McpClient.Status.CONFIGURED if verify_entry(client, entry, server_url) else McpClient.Status.CONFIGURED_MISMATCH
+	if verify_entry(client, entry, server_url):
+		return {"status": McpClient.Status.CONFIGURED, "error_msg": ""}
+	return {"status": McpClient.Status.CONFIGURED_MISMATCH, "error_msg": ""}
 
 
 static func remove(client: McpClient, server_name: String) -> Dictionary:

--- a/plugin/addons/godot_ai/clients/_toml_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_toml_strategy.gd
@@ -23,39 +23,67 @@ static func configure(client: McpClient, _server_name: String, server_url: Strin
 	var section := _find_section(lines, _all_headers(client))
 	var header := _primary_header(client)
 	var new_lines: Array[String] = [header]
-	for b in body:
-		new_lines.append(b)
+
+	if section.is_empty():
+		for b in body:
+			new_lines.append(b)
+		var output_fresh: Array[String] = []
+		output_fresh.append_array(lines)
+		if not output_fresh.is_empty() and not output_fresh[-1].strip_edges().is_empty():
+			output_fresh.append("")
+		output_fresh.append_array(new_lines)
+		if not McpAtomicWrite.write(path, "\n".join(output_fresh)):
+			return {"status": "error", "message": "Cannot write to %s" % path}
+		return {"status": "ok", "message": "%s configured (HTTP: %s)" % [client.display_name, server_url]}
+
+	## Reconfigure of an existing section — the TOML mirror of the JSON
+	## strategy's initial-vs-pinned split (#711): template lines carrying
+	## the {url} placeholder are PINS and always win (repointing is the
+	## whole point of reconfigure); placeholder-less template lines
+	## (`enabled = true`) are INITIAL values, written only when the user's
+	## section doesn't already set that key. User-added keys the template
+	## doesn't know and standalone comments are carried over verbatim.
+	var old_lines_by_key := _section_lines_by_key(lines, section)
+	for idx in range(body.size()):
+		var raw := String(client.toml_body_template[idx])
+		var key := _line_key(raw)
+		if raw.contains("{url}") or key.is_empty() or not old_lines_by_key.has(key):
+			new_lines.append(body[idx])
+		else:
+			new_lines.append(String(old_lines_by_key[key]))
+	new_lines.append_array(_preserved_section_lines(lines, section, body))
 
 	var output: Array[String] = []
-	if section.is_empty():
-		output.append_array(lines)
-		if not output.is_empty() and not output[-1].strip_edges().is_empty():
-			output.append("")
-		output.append_array(new_lines)
-	else:
-		output.append_array(_slice(lines, 0, section["start"]))
-		output.append_array(new_lines)
-		output.append_array(_slice(lines, section["end"], lines.size()))
+	output.append_array(_slice(lines, 0, section["start"]))
+	output.append_array(new_lines)
+	output.append_array(_slice(lines, section["end"], lines.size()))
 
 	if not McpAtomicWrite.write(path, "\n".join(output)):
 		return {"status": "error", "message": "Cannot write to %s" % path}
 	return {"status": "ok", "message": "%s configured (HTTP: %s)" % [client.display_name, server_url]}
 
 
-static func check_status(client: McpClient, _server_name: String, server_url: String) -> McpClient.Status:
+static func check_status(client: McpClient, server_name: String, server_url: String) -> McpClient.Status:
+	return check_status_details(client, server_name, server_url).get("status", McpClient.Status.NOT_CONFIGURED)
+
+
+## Detailed variant feeding the dock's error_msg plumbing (#711): a config
+## file that EXISTS but can't be read is Status.ERROR with the read error,
+## not NOT_CONFIGURED — conflating the two invites a "Configure" click that
+## the write path then refuses (or worse, clobbers state through).
+static func check_status_details(client: McpClient, _server_name: String, server_url: String) -> Dictionary:
 	var path := client.resolved_config_path()
 	if path.is_empty() or not FileAccess.file_exists(path):
-		return McpClient.Status.NOT_CONFIGURED
+		return {"status": McpClient.Status.NOT_CONFIGURED, "error_msg": ""}
 	var read := _read_or_init(path)
 	if not read["ok"]:
-		return McpClient.Status.NOT_CONFIGURED
+		return {"status": McpClient.Status.ERROR, "error_msg": String(read["error"])}
 	var lines: Array[String] = _split_lines(String(read["data"]))
 	var section := _find_section(lines, _all_headers(client))
 	if section.is_empty():
-		return McpClient.Status.NOT_CONFIGURED
+		return {"status": McpClient.Status.NOT_CONFIGURED, "error_msg": ""}
 
 	var configured_url := ""
-	var enabled := true
 	for i in range(section["start"] + 1, section["end"]):
 		var trimmed := lines[i].strip_edges()
 		if trimmed.begins_with("url ="):
@@ -63,13 +91,15 @@ static func check_status(client: McpClient, _server_name: String, server_url: St
 			var last := trimmed.rfind("\"")
 			if first >= 0 and last > first:
 				configured_url = trimmed.substr(first + 1, last - first - 1)
-		elif trimmed.begins_with("enabled ="):
-			enabled = trimmed.to_lower().find("false") < 0
-	## Section exists with our `SERVER_NAME` header — a URL mismatch (or a
-	## disabled entry) is drift, not "never configured". See `_base.gd`.
-	if configured_url != server_url or not enabled:
-		return McpClient.Status.CONFIGURED_MISMATCH
-	return McpClient.Status.CONFIGURED
+	## Section exists with our `SERVER_NAME` header — a URL mismatch is
+	## drift, not "never configured". See `_base.gd`. The `enabled` toggle
+	## is deliberately NOT drift (#711): it's user-mutable state (the JSON
+	## strategy's `entry_initial_fields` contract — the verifier ignores
+	## those keys entirely), and reconfigure preserves it, so counting it
+	## as mismatch would flag the user's own choice amber forever.
+	if configured_url != server_url:
+		return {"status": McpClient.Status.CONFIGURED_MISMATCH, "error_msg": ""}
+	return {"status": McpClient.Status.CONFIGURED, "error_msg": ""}
 
 
 static func remove(client: McpClient, _server_name: String) -> Dictionary:
@@ -115,6 +145,51 @@ static func format_body(template: PackedStringArray, server_url: String) -> Pack
 
 
 # --- helpers --------------------------------------------------------------
+
+## Map of `key -> full original line` for every key/value line in the
+## existing section body. Feeds the initial-vs-pinned split in configure().
+static func _section_lines_by_key(lines: Array[String], section: Dictionary) -> Dictionary:
+	var out := {}
+	for i in range(int(section["start"]) + 1, int(section["end"])):
+		var key := _line_key(lines[i].strip_edges())
+		if not key.is_empty() and not out.has(key):
+			out[key] = lines[i]
+	return out
+
+
+## Lines from the existing section body worth carrying over on reconfigure:
+## key/value lines whose key the template does NOT re-emit (user toggles
+## like `enabled = false`) and standalone comments. Blank lines are dropped
+## — the rewritten section is template body + carried lines. Template keys
+## are never carried (the whole point of reconfigure is repointing them).
+static func _preserved_section_lines(
+	lines: Array[String], section: Dictionary, body: PackedStringArray
+) -> Array[String]:
+	var template_keys := {}
+	for b in body:
+		var key := _line_key(String(b))
+		if not key.is_empty():
+			template_keys[key] = true
+	var out: Array[String] = []
+	for i in range(int(section["start"]) + 1, int(section["end"])):
+		var trimmed := lines[i].strip_edges()
+		if trimmed.is_empty():
+			continue
+		if trimmed.begins_with("#"):
+			out.append(lines[i])
+			continue
+		var key := _line_key(trimmed)
+		if not key.is_empty() and not template_keys.has(key):
+			out.append(lines[i])
+	return out
+
+
+## The bare key of a `key = value` line ("" when the line has no `=`).
+static func _line_key(line: String) -> String:
+	var eq := line.find("=")
+	if eq <= 0:
+		return ""
+	return line.substr(0, eq).strip_edges()
 
 ## Returns {"ok": true, "data": String} when the file is absent or readable,
 ## and {"ok": false, "error": String} when the file exists but cannot be

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -97,6 +97,20 @@ func test_every_client_has_required_fields() -> void:
 		elif client.config_type == "toml":
 			assert_gt(client.toml_section_path.size(), 0, "%s toml client missing toml_section_path" % client.id)
 			assert_gt(client.toml_body_template.size(), 0, "%s toml client missing toml_body_template" % client.id)
+			## #711: check_status parses a literal `url = "..."` line and
+			## configure's initial-vs-pinned split keys on the {url}
+			## placeholder — a template without that exact line shape would
+			## silently break both. Pin the contract per descriptor.
+			var has_url_line := false
+			for template_line in client.toml_body_template:
+				var line_text := String(template_line)
+				if line_text.strip_edges().begins_with("url =") and line_text.contains("{url}"):
+					has_url_line = true
+					break
+			assert_true(
+				has_url_line,
+				"%s toml_body_template must carry a `url = ...{url}...` line — check_status parses it" % client.id
+			)
 
 
 func test_config_path_facade_matches_client_descriptors() -> void:
@@ -1343,15 +1357,100 @@ func test_toml_strategy_distinguishes_missing_section_from_url_drift() -> void:
 		McpClient.Status.CONFIGURED_MISMATCH,
 	)
 
-	# Disabled section is also drift, not absence — the entry is there,
-	# the user just turned it off, and re-running Configure restores it.
+	# A disabled section is CONFIGURED, not drift (#711): `enabled` is
+	# user-mutable state under the JSON strategy's entry_initial_fields
+	# contract — the verifier ignores those keys, and reconfigure preserves
+	# them — so flagging the user's own toggle amber would nag forever and
+	# wedge configure's post-verify against the preserved value.
 	var f := FileAccess.open(path, FileAccess.WRITE)
 	f.store_string("[mcp_servers.\"godot-ai\"]\nurl = \"http://127.0.0.1:8000/mcp\"\nenabled = false\n")
 	f.close()
 	assert_eq(
 		McpTomlStrategy.check_status(client, "godot-ai", "http://127.0.0.1:8000/mcp"),
-		McpClient.Status.CONFIGURED_MISMATCH,
+		McpClient.Status.CONFIGURED,
 	)
+
+
+func test_toml_reconfigure_preserves_user_mutable_state() -> void:
+	## #711: the TOML mirror of the JSON initial-vs-pinned split. On
+	## reconfigure of an existing section: {url}-bearing template lines are
+	## pinned (repointed), placeholder-less template lines (`enabled`) keep
+	## the user's value, and unknown user keys + comments survive verbatim.
+	var path := _scratch_dir.path_join("reconfigure_preserve.toml")
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	f.store_string(
+		"[mcp_servers.\"godot-ai\"]\n"
+		+ "url = \"http://127.0.0.1:9999/mcp\"\n"
+		+ "enabled = false\n"
+		+ "# user note: keep disabled until launch\n"
+		+ "startup_timeout_ms = 20000\n"
+	)
+	f.close()
+
+	var client := _make_test_toml_client(path)
+	var result := McpTomlStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+	assert_eq(result.get("status"), "ok")
+
+	var content_file := FileAccess.open(path, FileAccess.READ)
+	var content := content_file.get_as_text()
+	content_file.close()
+	_remove_if_exists(path)
+	assert_contains(content, "url = \"http://127.0.0.1:8000/mcp\"", "pinned url line must repoint")
+	assert_false(content.contains("9999"), "old url must not survive the repoint")
+	assert_contains(content, "enabled = false", "user's enabled toggle must survive reconfigure")
+	assert_false(content.contains("enabled = true"), "template initial must not duplicate the preserved key")
+	assert_contains(content, "# user note: keep disabled until launch", "user comments must survive")
+	assert_contains(content, "startup_timeout_ms = 20000", "unknown user keys must survive")
+
+
+func test_toml_fresh_configure_writes_template_initials() -> void:
+	## Fresh section: no user state to preserve — the template body lands
+	## verbatim, including the `enabled = true` initial.
+	var path := _scratch_dir.path_join("fresh_initials.toml")
+	_remove_if_exists(path)
+	var client := _make_test_toml_client(path)
+	var result := McpTomlStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+	assert_eq(result.get("status"), "ok")
+	var content_file := FileAccess.open(path, FileAccess.READ)
+	var content := content_file.get_as_text()
+	content_file.close()
+	_remove_if_exists(path)
+	assert_contains(content, "enabled = true")
+	assert_contains(content, "url = \"http://127.0.0.1:8000/mcp\"")
+
+
+func test_json_unparseable_config_reports_error_status() -> void:
+	## #711: an existing-but-broken config file is Status.ERROR carrying the
+	## parse error — NOT_CONFIGURED would invite a Configure click the write
+	## path then refuses.
+	var path := _scratch_dir.path_join("broken_config.json")
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	f.store_string("{ this is not json")
+	f.close()
+	var client := _make_test_json_client(path)
+	var details := McpJsonStrategy.check_status_details(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+	_remove_if_exists(path)
+	assert_eq(details.get("status"), McpClient.Status.ERROR)
+	assert_contains(String(details.get("error_msg", "")), "parse error", "error_msg must carry the parse diagnostic")
+
+
+func test_status_details_shape_for_missing_config() -> void:
+	## Both strategies return the {status, error_msg} shape the dock's
+	## refresh worker consumes — absent file is NOT_CONFIGURED with no error.
+	var missing := _scratch_dir.path_join("never_written.toml")
+	_remove_if_exists(missing)
+	var toml_details := McpTomlStrategy.check_status_details(
+		_make_test_toml_client(missing), "godot-ai", "http://127.0.0.1:8000/mcp"
+	)
+	assert_eq(toml_details.get("status"), McpClient.Status.NOT_CONFIGURED)
+	assert_eq(toml_details.get("error_msg"), "")
+	var missing_json := _scratch_dir.path_join("never_written.json")
+	_remove_if_exists(missing_json)
+	var json_details := McpJsonStrategy.check_status_details(
+		_make_test_json_client(missing_json), "godot-ai", "http://127.0.0.1:8000/mcp"
+	)
+	assert_eq(json_details.get("status"), McpClient.Status.NOT_CONFIGURED)
+	assert_eq(json_details.get("error_msg"), "")
 
 
 func test_toml_strategy_preserves_other_sections() -> void:


### PR DESCRIPTION
## Summary

Implements #711 (each item re-verified against current main first):

1. **TOML reconfigure no longer clobbers user-mutable state** — the TOML mirror of the JSON strategy's initial-vs-pinned contract: `{url}`-bearing template lines are pins and always repoint; placeholder-less template lines (`enabled = true`) are initials, written only when the user's section doesn't already set the key; unknown user keys and standalone comments survive verbatim.
   ⚠️ One deliberate contract change falls out: a **disabled entry now reads CONFIGURED, not CONFIGURED_MISMATCH**. `enabled` is user-owned state the JSON verifier deliberately ignores (`entry_initial_fields` contract in `_base.gd`), and preserving it while flagging it amber would wedge configure's post-verify loop (configure preserves `false` → verify expects CONFIGURED → permanent error). The old behavior ("Configure restores it") had a test pinning it; that test is updated to the new contract with the rationale inline.
2. **`check_status_details` on both strategies** — an existing-but-unreadable (TOML) or unparseable (JSON) config is `Status.ERROR` carrying the read/parse diagnostic instead of `NOT_CONFIGURED`; the dock's refresh worker already plumbs `error_msg` onto the row (same shape `CliStrategy.check_status_details` uses). The configurator dispatch consumes the details variants; `check_status` remains as a thin wrapper.
3. **Template contract pinned** — `test_every_client_has_required_fields` now asserts every TOML client's `toml_body_template` carries a `url = ..."{url}"...` line, since `check_status` parses exactly that shape.
4. **`_find_system_install` delegates to `McpCliFinder.find`** — gains the well-known-install-dirs and login-shell-PATH tiers plus the per-exe cache, and drops the private `_pick_best_path` cross-class reach.
5. **`_is_symlink` fails closed** when the path exists but its parent can't be opened — it's the data-safety guard deciding whether self-update may write through `addons/godot_ai`, so unprovable must mean blocked.

## Testing

4 new GDScript tests (reconfigure preservation matrix: repoint + keep `enabled = false` + keep comments/unknown keys + no duplicate initials; fresh-configure writes initials; JSON parse error → ERROR with diagnostic; details-shape contract for missing configs) plus the updated disabled-entry test and the template-contract assertion.

Gauntlet: `ruff` clean · `pytest` 1345 passed · `ci-check-gdscript` OK · live editor run **1767/1785 passed, 0 failed**. No lifecycle/spawn/self-update paths touched, so the smokes don't apply (the `_is_symlink` change is read-only guard logic).

Closes #711.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2zhpWvnqijYYRW3dwtUhV

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2zhpWvnqijYYRW3dwtUhV)_