### PR TITLE
Connection/dispatcher resilience: pause-depth restore, cross-connection queue clear, static deferred finishers

### DIFF
--- a/plugin/addons/godot_ai/connection.gd
+++ b/plugin/addons/godot_ai/connection.gd
@@ -212,6 +212,11 @@ func _clear_on_disconnect() -> void:
 	_packet_spillover_total = 0
 	if dispatcher:
 		dispatcher.clear_deferred_responses()
+		## Queued-but-unexecuted commands from the dead connection must not
+		## run under the next one (#712): their requester's futures were
+		## already failed server-side, so executing them after reconnect is
+		## an uncorrelatable surprise write.
+		dispatcher.clear_command_queue()
 
 
 ## Full pre-free cleanup for plugin unload: stop _process, close the

--- a/plugin/addons/godot_ai/dispatcher.gd
+++ b/plugin/addons/godot_ai/dispatcher.gd
@@ -10,6 +10,13 @@ var _handlers: Dictionary = {}  # command_name -> Callable
 var _pending_deferred: Dictionary = {}  # request_id -> {command, started_ms, timeout_ms}
 var _log_buffer
 var _surfaced_error_tracker
+## The McpConnection whose pause_processing handlers flip around unsafe
+## editor operations (#288 guard). Set by plugin.gd; untyped to honor the
+## self-update field-storage policy. When set, _call_handler restores the
+## pause depth a crashed handler left unbalanced (#712) — without this a
+## single handler crash inside a pause window freezes the transport
+## forever (pause has no watchdog or disconnect reset by design).
+var pause_target
 var mcp_logging := true
 var deferred_timeout_overrides_ms: Dictionary = {}
 
@@ -46,6 +53,17 @@ func clear() -> void:
 	_pending_deferred.clear()
 	_log_buffer = null
 	_surfaced_error_tracker = null
+	pause_target = null
+
+
+## Drop queued-but-unexecuted commands. Called by the connection on
+## disconnect (#712): commands queued by the previous connection must not
+## execute under the next one — the requester is gone, its in-flight
+## futures were already failed server-side, and a mutation landing after
+## reconnect is a surprise write nobody can correlate. Deferred bookkeeping
+## has its own reset (clear_deferred_responses).
+func clear_command_queue() -> void:
+	_command_queue.clear()
 
 
 ## Invoke a registered handler directly by name. Returns the handler's raw
@@ -195,7 +213,23 @@ const _MALFORMED_ARGS_MAX := 400
 
 
 func _call_handler(command: String, params: Dictionary) -> Dictionary:
+	## #712: a handler that crashes between pause_processing = true and its
+	## matching false leaves the pause depth unbalanced — GDScript swallows
+	## the error, the dispatcher reports "malformed result", and the
+	## transport stays paused FOREVER (no watchdog, no disconnect reset).
+	## Restore balance at this boundary: the depth a handler leaves behind
+	## must equal the depth it started with.
+	var pause_depth_before: int = pause_target.pause_depth() if pause_target != null else 0
 	var result: Dictionary = _handlers[command].call(params)
+	if pause_target != null and pause_target.pause_depth() > pause_depth_before:
+		var leaked: int = pause_target.pause_depth() - pause_depth_before
+		while pause_target.pause_depth() > pause_depth_before:
+			pause_target.resume()
+		if mcp_logging and _log_buffer != null:
+			_log_buffer.log(
+				"[error] %s leaked %d pause_processing level(s) — restored (handler crash?)"
+				% [command, leaked]
+			)
 	## Handlers must return {"data": ...} on success or {"error": ...} on failure.
 	## Anything else (null, empty, missing keys) means the handler crashed
 	## mid-call — GDScript swallows the error and returns an empty dict.

--- a/plugin/addons/godot_ai/handlers/project_handler.gd
+++ b/plugin/addons/godot_ai/handlers/project_handler.gd
@@ -153,7 +153,7 @@ func run_project(params: Dictionary) -> Dictionary:
 	)
 	var request_id: String = params.get("_request_id", "")
 	if _connection != null and _debugger_plugin != null and not request_id.is_empty():
-		_finish_run_project_deferred(request_id, base_data)
+		_finish_run_project_deferred(request_id, base_data, _connection, _debugger_plugin)
 		return McpDispatcher.DEFERRED_RESPONSE
 
 	return _run_project_current_liveness_response(base_data)
@@ -167,7 +167,7 @@ func _game_helper_autoload_expected() -> bool:
 	return ProjectSettings.has_setting("autoload/_mcp_game_helper")
 
 
-func _run_project_base_data(
+static func _run_project_base_data(
 	mode: String,
 	scene: String,
 	autosave: bool,
@@ -194,21 +194,30 @@ func _run_project_current_liveness_response(base_data: Dictionary) -> Dictionary
 	return _run_project_response(base_data, _run_project_liveness_decision(status, errors_info))
 
 
-func _finish_run_project_deferred(request_id: String, base_data: Dictionary) -> void:
-	var tree := _connection.get_tree()
+## `static` is load-bearing (#712, same rationale as the script/filesystem
+## handlers and editor_handler._do_reload_plugin): this coroutine awaits
+## across frames, and a plugin reload frees this RefCounted handler
+## mid-await — resuming an instance coroutine on a freed object errors.
+## `connection` and `debugger_plugin` are parameterized explicitly and
+## re-validated after every await; the response is dropped silently when
+## either died (the server's command timeout surfaces the failure).
+static func _finish_run_project_deferred(
+	request_id: String, base_data: Dictionary, connection, debugger_plugin
+) -> void:
+	var tree: SceneTree = connection.get_tree()
 	while true:
 		await tree.process_frame
-		if not is_instance_valid(_connection):
+		if not is_instance_valid(connection) or not is_instance_valid(debugger_plugin):
 			return
-		var pre_status: Dictionary = _debugger_plugin.get_game_status(-1, RUN_READY_WAIT_SEC)
+		var pre_status: Dictionary = debugger_plugin.get_game_status(-1, RUN_READY_WAIT_SEC)
 		if (
 			not EditorInterface.is_playing_scene()
 			and int(pre_status.get("elapsed_msec", 0)) > 100
 			and str(pre_status.get("status", "stopped")) == "launching"
 		):
-			_debugger_plugin.end_game_run()
-		var status: Dictionary = _debugger_plugin.get_game_status(-1, RUN_READY_WAIT_SEC)
-		var errors_info: Dictionary = _debugger_plugin.recent_editor_errors_since(int(status.get("editor_log_cursor", 0)))
+			debugger_plugin.end_game_run()
+		var status: Dictionary = debugger_plugin.get_game_status(-1, RUN_READY_WAIT_SEC)
+		var errors_info: Dictionary = debugger_plugin.recent_editor_errors_since(int(status.get("editor_log_cursor", 0)))
 		var decision := _run_project_liveness_decision(status, errors_info)
 		if not bool(decision.get("resolve", false)):
 			continue
@@ -218,13 +227,13 @@ func _finish_run_project_deferred(request_id: String, base_data: Dictionary) -> 
 		## response reports them instead of leaving them to a later
 		## logs_read. Rebuilding the decision with strictly-more errors can
 		## only keep it resolved (errors never un-resolve a decision).
-		errors_info = _debugger_plugin.recent_editor_errors_since(int(status.get("editor_log_cursor", 0)), true)
+		errors_info = debugger_plugin.recent_editor_errors_since(int(status.get("editor_log_cursor", 0)), true)
 		decision = _run_project_liveness_decision(status, errors_info)
-		_connection.send_deferred_response(request_id, _run_project_response(base_data, decision))
+		connection.send_deferred_response(request_id, _run_project_response(base_data, decision))
 		return
 
 
-func _run_project_response(base_data: Dictionary, decision: Dictionary) -> Dictionary:
+static func _run_project_response(base_data: Dictionary, decision: Dictionary) -> Dictionary:
 	var data := base_data.duplicate(true)
 	var game_status: Dictionary = decision.get("game_status", {})
 	data["game_status"] = game_status
@@ -242,7 +251,7 @@ func _run_project_response(base_data: Dictionary, decision: Dictionary) -> Dicti
 	return {"data": data}
 
 
-func _run_project_already_running_message(decision: Dictionary) -> String:
+static func _run_project_already_running_message(decision: Dictionary) -> String:
 	var state := str(decision.get("liveness_status", "unknown"))
 	match state:
 		"live":
@@ -278,7 +287,10 @@ func _run_project_already_running_message(decision: Dictionary) -> String:
 			return "Project was already running; current liveness status is %s." % state
 
 
-func _run_project_liveness_decision(status: Dictionary, errors_info: Dictionary = {}) -> Dictionary:
+## Static (with the rest of the deferred-finisher chain) so the #712
+## load-bearing-static coroutines above can call it after their owner
+## handler was freed. Uses no instance state.
+static func _run_project_liveness_decision(status: Dictionary, errors_info: Dictionary = {}) -> Dictionary:
 	var enriched_status := McpDebuggerPlugin.with_liveness_flags(status)
 	var state := str(status.get("status", "stopped"))
 	var recent_errors: Array = errors_info.get("errors", [])
@@ -359,7 +371,7 @@ func _run_project_liveness_decision(status: Dictionary, errors_info: Dictionary 
 	return decision
 
 
-func _format_editor_error_summary(entry: Dictionary) -> String:
+static func _format_editor_error_summary(entry: Dictionary) -> String:
 	return McpSurfacedErrorTracker.format_editor_error_summary(entry)
 
 
@@ -388,7 +400,7 @@ func stop_project(params: Dictionary) -> Dictionary:
 	# the server poll for the event. Issue #29.
 	var request_id: String = params.get("_request_id", "")
 	if _connection != null and not request_id.is_empty():
-		_finish_stop_project_deferred(request_id)
+		_finish_stop_project_deferred(request_id, _connection)
 		return McpDispatcher.DEFERRED_RESPONSE
 
 	# Fallback for contexts without a connection (e.g. batch_execute via
@@ -403,18 +415,19 @@ func stop_project(params: Dictionary) -> Dictionary:
 	}
 
 
-func _finish_stop_project_deferred(request_id: String) -> void:
-	# Wait two frames so Godot can tick the stop-play state change. After this
-	# is_playing_scene() reflects truth and get_readiness() is authoritative.
-	# If the plugin tears down (_exit_tree frees _connection) during the await,
-	# is_instance_valid() goes false and we drop the response silently — the
-	# server's 5s request timeout will surface the failure to the caller.
-	var tree := _connection.get_tree()
+# Wait two frames so Godot can tick the stop-play state change. After this
+# is_playing_scene() reflects truth and get_readiness() is authoritative.
+# If the plugin tears down (_exit_tree frees _connection) during the await,
+# is_instance_valid() goes false and we drop the response silently — the
+# server's 5s request timeout will surface the failure to the caller.
+# `static` is load-bearing (#712): see _finish_run_project_deferred.
+static func _finish_stop_project_deferred(request_id: String, connection) -> void:
+	var tree: SceneTree = connection.get_tree()
 	await tree.process_frame
 	await tree.process_frame
-	if not is_instance_valid(_connection):
+	if not is_instance_valid(connection):
 		return
-	_connection.send_deferred_response(request_id, {
+	connection.send_deferred_response(request_id, {
 		"data": {
 			"stopped": true,
 			"was_running": true,

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -248,6 +248,9 @@ func _enter_tree() -> void:
 	if _ws_auth_token.is_empty():
 		_ws_auth_token = str(_read_managed_server_record().get("ws_token", ""))
 	_connection.auth_token = _ws_auth_token
+	## Pause-depth restore boundary (#712): the dispatcher rebalances any
+	## pause_processing level a crashed handler leaked.
+	_dispatcher.pause_target = _connection
 	_connection.connect_blocked = _lifecycle.is_connection_blocked()
 	_connection.connect_block_reason = _lifecycle.get_status_dict().get("message", "")
 	if (

--- a/test_project/tests/test_connection.gd
+++ b/test_project/tests/test_connection.gd
@@ -187,6 +187,29 @@ func test_disconnect_clears_pending_deferred_responses() -> void:
 	conn.free()
 
 
+func test_disconnect_clears_queued_commands() -> void:
+	## #712: commands queued by the dead connection must not execute under
+	## the next one — the requester's futures were already failed
+	## server-side, so a mutation landing after reconnect is an
+	## uncorrelatable surprise write.
+	var conn := McpConnection.new()
+	var dispatcher := McpDispatcher.new(McpLogBuffer.new())
+	dispatcher.mcp_logging = false
+	var executed: Array = []
+	dispatcher.register("mutate", func(_p):
+		executed.append(true)
+		return {"data": {}})
+	dispatcher.enqueue({"request_id": "req-stale", "command": "mutate", "params": {}})
+
+	conn.dispatcher = dispatcher
+	conn._clear_on_disconnect()
+
+	var responses := dispatcher.tick(100.0)
+	assert_eq(executed.size(), 0, "queued command must not run after disconnect")
+	assert_eq(responses.size(), 0, "no responses should be produced for cleared commands")
+	conn.free()
+
+
 func test_send_event_reports_unsent_when_disconnected() -> void:
 	var conn := McpConnection.new()
 	assert_false(

--- a/test_project/tests/test_dispatcher.gd
+++ b/test_project/tests/test_dispatcher.gd
@@ -388,3 +388,63 @@ func test_dispatch_direct_strips_reserved_request_id_key() -> void:
 	assert_eq(seen[0].get("x"), 1)
 	assert_true(caller_params.has("_request_id"),
 		"stripping must not mutate the caller's dict")
+
+
+# ----- pause-depth restore on handler crash (#712) -----
+
+## Stand-in for McpConnection's pause surface: the dispatcher only reads
+## pause_depth() and calls resume() to rebalance.
+class _PauseTargetStub extends RefCounted:
+	var depth := 0
+	func pause_depth() -> int:
+		return depth
+	func pause() -> void:
+		depth += 1
+	func resume() -> void:
+		depth = maxi(0, depth - 1)
+
+
+func test_crashed_handler_leaked_pause_is_restored() -> void:
+	var d := _make_dispatcher()
+	d.mcp_logging = false
+	var target := _PauseTargetStub.new()
+	d.pause_target = target
+	## Simulates a handler that paused, then crashed before resuming —
+	## GDScript swallows the error and the dispatcher sees a malformed
+	## (empty) result. Without the boundary restore the transport would
+	## stay paused forever.
+	d.register("crashy_pauser", func(_p):
+		target.pause()
+		return {})
+	var result := d.dispatch_direct("crashy_pauser", {})
+	assert_is_error(result, ErrorCodes.INTERNAL_ERROR)
+	assert_eq(target.depth, 0, "leaked pause level must be restored at the call boundary")
+
+
+func test_pause_restore_preserves_outer_depth() -> void:
+	## Only the handler's OWN leaked levels are unwound — a pre-existing
+	## outer pause (e.g. batch_execute inside a paused save) must survive.
+	var d := _make_dispatcher()
+	d.mcp_logging = false
+	var target := _PauseTargetStub.new()
+	target.depth = 1
+	d.pause_target = target
+	d.register("crashy_pauser", func(_p):
+		target.pause()
+		return {})
+	d.dispatch_direct("crashy_pauser", {})
+	assert_eq(target.depth, 1, "restore must stop at the pre-call depth, not zero")
+
+
+func test_balanced_handler_is_untouched_by_pause_restore() -> void:
+	var d := _make_dispatcher()
+	d.mcp_logging = false
+	var target := _PauseTargetStub.new()
+	d.pause_target = target
+	d.register("balanced", func(_p):
+		target.pause()
+		target.resume()
+		return {"data": {"ok": true}})
+	var result := d.dispatch_direct("balanced", {})
+	assert_has_key(result, "data")
+	assert_eq(target.depth, 0)

--- a/tests/unit/test_project_deferred_statics.py
+++ b/tests/unit/test_project_deferred_statics.py
@@ -1,0 +1,60 @@
+"""Source-pins for project_handler's deferred-finisher statics (#712).
+
+The run/stop deferred finishers are coroutines that await across frames;
+`static` is load-bearing there (the same "class instance is gone" failure
+mode test_script_create_import_settle.py pins for script_create): a plugin
+reload frees the RefCounted handler mid-await, and resuming an instance
+coroutine on a freed object errors and drops the deferred response. These
+checks prevent a silent revert to instance methods.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+PROJECT_HANDLER = (
+    Path(__file__).resolve().parents[2]
+    / "plugin"
+    / "addons"
+    / "godot_ai"
+    / "handlers"
+    / "project_handler.gd"
+)
+
+
+def test_run_project_deferred_finisher_is_static() -> None:
+    source = PROJECT_HANDLER.read_text(encoding="utf-8")
+    assert "static func _finish_run_project_deferred(" in source, (
+        "_finish_run_project_deferred must be `static` so the multi-frame "
+        "liveness-poll coroutine doesn't capture self — a handler freed "
+        "mid-await produces 'class instance is gone' and drops the response."
+    )
+    # Dependencies must be threaded explicitly, not pulled from self.
+    assert (
+        "_finish_run_project_deferred(request_id, base_data, _connection, _debugger_plugin)"
+        in source
+    ), (
+        "run_project must pass _connection and _debugger_plugin explicitly "
+        "to the static finisher — reading them from self would re-introduce "
+        "the implicit self capture the static refactor removes."
+    )
+
+
+def test_stop_project_deferred_finisher_is_static() -> None:
+    source = PROJECT_HANDLER.read_text(encoding="utf-8")
+    assert "static func _finish_stop_project_deferred(" in source
+    assert "_finish_stop_project_deferred(request_id, _connection)" in source, (
+        "stop_project must pass _connection explicitly to the static finisher."
+    )
+
+
+def test_run_finisher_revalidates_dependencies_after_await() -> None:
+    """The finisher's poll loop must re-check BOTH parameterized objects
+    after each await — either can be freed while the coroutine sleeps."""
+    source = PROJECT_HANDLER.read_text(encoding="utf-8")
+    assert (
+        "if not is_instance_valid(connection) or not is_instance_valid(debugger_plugin):" in source
+    ), (
+        "_finish_run_project_deferred must drop the response when either "
+        "the connection or the debugger plugin died during an await."
+    )


### PR DESCRIPTION
## Summary

Implements the live items of #712 (each re-verified against current main first):

1. **Pause-depth restore at the handler-call boundary.** A handler that crashes between `pause_processing = true` and its matching `false` left the depth unbalanced *forever* — GDScript swallows the error, the dispatcher reports "malformed result", and the transport stays paused with no watchdog or disconnect reset. `_call_handler` now snapshots the pause depth before invoking and unwinds only the handler's own leaked levels after (a pre-existing outer pause survives), logging the rebalance. `plugin.gd` wires the connection in as the dispatcher's `pause_target`; `clear()` drops it.
2. **`_clear_on_disconnect` clears the command queue.** Cross-connection contract decided as *clear*, mirroring `clear_deferred_responses`: commands queued by the dead connection must not execute under the next one — their requester's futures were already failed server-side (#690), so a mutation landing after reconnect is an uncorrelatable surprise write.
3. **`project_handler`'s deferred finishers go static** (the item deferred from #710): `_finish_run_project_deferred` / `_finish_stop_project_deferred` with `connection` + `debugger_plugin` parameterized explicitly and re-validated after every await — the "static is load-bearing" pattern the script/filesystem handlers and `editor_handler` already follow. The feared cascade didn't materialize: the whole helper chain they call (`_run_project_liveness_decision`, `_run_project_response`, `_run_project_already_running_message`, `_format_editor_error_summary`, `_run_project_base_data`) uses no instance state and goes static with them.

**Verified already fixed on main (no change needed):**
- `_run_blocking` worker joins at teardown — `_active_blocking_thread` ownership + the `_invalidate_async_startup` join landed via #683/#682.
- `plugin.gd` mid-walk free — `_start_server` is already fire-and-forget with trace stamping in the manager's `is_instance_valid`-checked path.

**Remaining in #712** (deliberate refactor, not a tightening — left open): moving the three synchronous main-thread probe paths onto `_run_blocking`.

## Testing

3 new dispatcher tests (leaked pause restored + `INTERNAL_ERROR` still reported; outer depth preserved; balanced handler untouched), 1 new connection test (disconnect clears queued commands — nothing executes, nothing responds), and a new Python source-pin module (`test_project_deferred_statics.py`) locking the finisher statics, the explicit dependency threading, and the post-await revalidation, in the style of `test_script_create_import_settle.py`.

Gauntlet: `ruff` clean · `pytest` **1348 passed** · `ci-check-gdscript` OK · live editor run **1767/1785 passed, 0 failed** · **both** `ci-stale-server-smoke` modes **PASS** (reconnect/lifecycle-adjacent changes).

Part of #712.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2zhpWvnqijYYRW3dwtUhV

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2zhpWvnqijYYRW3dwtUhV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented queued commands from a disconnected session from executing after reconnect.
  * Improved dispatcher pause-state recovery when a handler crashes during a pause window.
  * Hardened project start/stop liveness responses to safely survive plugin reloads and mid-await connection/debugger invalidation.
  * Ensured boot-time parse errors are included in project liveness decisions.
* **Tests**
  * Added regression coverage for stale command clearing, pause-depth restoration on crashes, and deferred finisher safety for project operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->