### PR TITLE
Release signing: RSA-4096 signature over the checksum sidecar (#687)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,12 +170,49 @@ jobs:
           sha256sum godot-ai-plugin.zip > godot-ai-plugin.zip.sha256
           cat godot-ai-plugin.zip.sha256
 
+      - name: Sign checksum sidecar
+        # RSA-4096 signature over the .sha256 sidecar (#687). The private key
+        # lives only in the RELEASE_SIGNING_KEY_PEM secret — outside the repo
+        # token's scope, so a leaked token that can rewrite release assets
+        # still can't forge a signature. The plugin verifies this signature
+        # against its embedded public key before trusting the digest
+        # (utils/update_manager.gd::_verify_sidecar_signature) and HARD-FAILS
+        # any release >= SIGNING_REQUIRED_FROM_VERSION that lacks it, so this
+        # step must fail the release loudly rather than skip when the secret
+        # is missing — an unsigned signing-era release would be uninstallable.
+        env:
+          RELEASE_SIGNING_KEY_PEM: ${{ secrets.RELEASE_SIGNING_KEY_PEM }}
+        run: |
+          if [ -z "$RELEASE_SIGNING_KEY_PEM" ]; then
+            echo "ERROR: RELEASE_SIGNING_KEY_PEM secret is not configured." >&2
+            echo "Releases must ship a signed .sha256 sidecar: the plugin's" >&2
+            echo "self-updater refuses unsigned releases at or above" >&2
+            echo "SIGNING_REQUIRED_FROM_VERSION (see #687)." >&2
+            exit 1
+          fi
+          key_file=$(mktemp)
+          printf '%s\n' "$RELEASE_SIGNING_KEY_PEM" > "$key_file"
+          openssl dgst -sha256 -sign "$key_file" \
+            -out godot-ai-plugin.zip.sha256.sig godot-ai-plugin.zip.sha256
+          rm -f "$key_file"
+          # Self-check against the public key EMBEDDED IN THE PLUGIN SOURCE,
+          # not a key derived from the secret — a rotated/mismatched secret
+          # must fail the release here, not in every user's editor at
+          # install time.
+          awk '/BEGIN PUBLIC KEY/,/END PUBLIC KEY/' \
+            plugin/addons/godot_ai/utils/update_manager.gd > embedded_public_key.pem
+          openssl dgst -sha256 -verify embedded_public_key.pem \
+            -signature godot-ai-plugin.zip.sha256.sig godot-ai-plugin.zip.sha256
+          rm -f embedded_public_key.pem
+          echo "Sidecar signed and verified against the plugin's embedded public key."
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
           files: |
             godot-ai-plugin.zip
             godot-ai-plugin.zip.sha256
+            godot-ai-plugin.zip.sha256.sig
           generate_release_notes: true
 
       - name: Post changelog to Discord

--- a/plugin/addons/godot_ai/utils/update_manager.gd
+++ b/plugin/addons/godot_ai/utils/update_manager.gd
@@ -34,6 +34,38 @@ const UPDATE_TEMP_DIR := "user://godot_ai_update/"
 const UPDATE_TEMP_ZIP := "user://godot_ai_update/update.zip"
 const ClientConfigurator := preload("res://addons/godot_ai/client_configurator.gd")
 
+## RSA-4096 public key for release-signature verification (#687). The paired
+## private key exists only in the GitHub Actions secret RELEASE_SIGNING_KEY_PEM
+## (plus the maintainer's offline backup) — deliberately outside the repo
+## token's scope, because the threat model is release-asset substitution by a
+## leaked token or compromised workflow, and a token that can rewrite assets
+## still cannot read secrets. Rotation requires shipping a new plugin release
+## embedding the new key (and bumping SIGNING_REQUIRED_FROM_VERSION past the
+## last release signed with the old one).
+const RELEASE_SIGNING_PUBLIC_KEY_PEM := """-----BEGIN PUBLIC KEY-----
+MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAr4OmbONFTONGFcXSUQ2p
+e54YaUhWDA75wxeDWhOc476vsdo53YnXEFT7EPr2hUKqeNxv++LqKOkFuAsxSNZy
+wBe6P1tmQA4Og6Ezv4CGnZdEj1uhlDJFK9ShQ29oWfC6bf/84625SvvBxZos2Br9
+yPKl7h5wzqDoeUSpv+f0ynTiC0i/HAUo/NQBlkgGwkomK2Fr3pP1VDxxq2xvgHSk
+lU6Qcomr9WjJxI+HkDN5tRPPn0pDrg6YFx2J18OfD8KIa/kMGxuXOcHlPyRYpjyu
+qTtg2oL0NyUIG+1TmJ3DcN4GlKC55eOrkfJ04vudS5pxdnUIFRmkGBXZLdaetoPc
+ixtlD4w6gi8KIH1CTG+/TtHP1KVdOogCWDcjRCAmMJPFZe6eEKXmGQUZDb9wfnbx
+h++XiVe5tq83BTLWmaFTy+fZbNo12uhNCNS1LJ42/yj+S1xvo0yMbkkNr1hIYk0P
+584XnBQeBSVJDf3667NZXaxnWv94K9zbb+1OvOvPwhbOdgi2Ymcw5QEOQIavtg86
+XLLcWzG+SJsycz1imikjv6sStWh8WHneKSTMq6A7V6PBj7oJyEJp10696BDw287k
+YlH+9VGqowPEMXpWX57wOBKiWb4K1kw1LfxjT8W1e/pcX9pJqiv0DkjTXUxo9CDG
+1X1+ZXBBR3MkGuFAOCjy0x8CAwEAAQ==
+-----END PUBLIC KEY-----
+"""
+
+## Every release at or above this version ships a signed sidecar
+## (release.yml hard-fails without the signing secret). At or above it, a
+## missing `.sha256.sig` asset is treated as tampering — an attacker who can
+## rewrite release assets could otherwise just strip the signature to skip
+## verification. Below it (releases published before signing existed), the
+## legacy checksum-only path still installs.
+const SIGNING_REQUIRED_FROM_VERSION := "2.9.3"
+
 ## Host -> required path prefix for self-update downloads (ZIP and checksum
 ## sidecar). The URLs are taken verbatim from the GitHub Releases API's
 ## `browser_download_url`, so before fetching we pin them to https on a
@@ -78,12 +110,26 @@ var _dock
 var _http_request: HTTPRequest
 var _download_request: HTTPRequest
 var _verify_request: HTTPRequest
+var _signature_request: HTTPRequest
 var _latest_download_url: String = ""
 ## URL of the `godot-ai-plugin.zip.sha256` sidecar asset. Used to verify the
 ## downloaded archive's integrity before extract (#523). Verification is
 ## mandatory (#599): when a release ships no sidecar this stays empty and
 ## `_verify_then_install` refuses the install.
 var _latest_checksum_url: String = ""
+## URL of the `godot-ai-plugin.zip.sha256.sig` signature asset (#687). Empty
+## on releases published before signing existed; `_verify_then_install`
+## refuses an empty URL once the remote version is inside the signing era
+## (see SIGNING_REQUIRED_FROM_VERSION).
+var _latest_signature_url: String = ""
+## Remote version from the last update check — drives the
+## signature-required compat gate in `_verify_then_install`.
+var _latest_remote_version: String = ""
+## Sidecar bytes + parsed digest held between the checksum download and the
+## signature verdict, so the signature is checked against exactly the bytes
+## the digest was parsed from.
+var _pending_sidecar_body := PackedByteArray()
+var _pending_expected_digest: String = ""
 
 ## Set for the duration of `_install_zip` — extract-overwrite of plugin
 ## scripts on disk would crash any worker mid-`GDScriptFunction::call`
@@ -136,6 +182,10 @@ func cancel_check() -> void:
 func clear_pending_download() -> void:
 	_latest_download_url = ""
 	_latest_checksum_url = ""
+	_latest_signature_url = ""
+	_latest_remote_version = ""
+	_pending_sidecar_body = PackedByteArray()
+	_pending_expected_digest = ""
 
 
 ## True when the running Godot is within the supported self-update floor.
@@ -246,6 +296,7 @@ func is_install_in_flight() -> bool:
 ##   label_text: String              ## "Update available: vX.Y.Z" + " (forced)"
 ##   download_url: String            ## matching `godot-ai-plugin.zip` asset URL
 ##   checksum_url: String            ## `godot-ai-plugin.zip.sha256` asset URL ("" if absent)
+##   signature_url: String           ## `godot-ai-plugin.zip.sha256.sig` asset URL ("" if absent)
 ##
 ## Static so tests drive it without instancing the manager.
 static func parse_releases_response(
@@ -258,6 +309,7 @@ static func parse_releases_response(
 		"label_text": "",
 		"download_url": "",
 		"checksum_url": "",
+		"signature_url": "",
 	}
 	if result != HTTPRequest.RESULT_SUCCESS or response_code != 200:
 		return out
@@ -275,6 +327,7 @@ static func parse_releases_response(
 
 	var url := ""
 	var checksum_url := ""
+	var signature_url := ""
 	var assets: Array = json.get("assets", [])
 	for asset in assets:
 		var asset_dict: Dictionary = asset
@@ -283,6 +336,8 @@ static func parse_releases_response(
 			url = String(asset_dict.get("browser_download_url", ""))
 		elif asset_name == "godot-ai-plugin.zip.sha256":
 			checksum_url = String(asset_dict.get("browser_download_url", ""))
+		elif asset_name == "godot-ai-plugin.zip.sha256.sig":
+			signature_url = String(asset_dict.get("browser_download_url", ""))
 
 	var forced := ClientConfigurator.mode_override() == "user"
 	var label_text := "Update available: v%s" % remote_version
@@ -297,6 +352,7 @@ static func parse_releases_response(
 	out["label_text"] = label_text
 	out["download_url"] = url
 	out["checksum_url"] = checksum_url
+	out["signature_url"] = signature_url
 	return out
 
 
@@ -378,6 +434,8 @@ func _on_update_check_completed(
 		return
 	_latest_download_url = String(parsed.get("download_url", ""))
 	_latest_checksum_url = String(parsed.get("checksum_url", ""))
+	_latest_signature_url = String(parsed.get("signature_url", ""))
+	_latest_remote_version = String(parsed.get("version", ""))
 	update_check_completed.emit(parsed)
 
 
@@ -403,25 +461,29 @@ func _on_download_completed(
 	_verify_then_install.call_deferred()
 
 
-# ---- Integrity verification (#523) -------------------------------------
+# ---- Integrity verification (#523, #599, #687) --------------------------
 
-## Gate the extract on a SHA-256 match against the release's checksum sidecar.
-## TLS + host pinning already constrain where the bytes came from; this
-## verifies the bytes themselves, guarding against in-transit corruption and
-## single-object substitution (a tampered CDN edge, a partial/garbled
-## download). It is NOT protection against a compromised release: both
-## `download_url` and `checksum_url` come from the same GitHub Releases API
-## response over the same channel (`parse_releases_response`), so anyone able
-## to modify the release's assets (leaked repo token, compromised release
-## workflow) can regenerate the sidecar to match a tampered zip (#687
-## follow-up: signing the sidecar with a key outside the release workflow's
-## default token scope closes this gap; not yet implemented). Verification
-## is MANDATORY (#599): a release published without a `.sha256` sidecar —
-## mistake or tamper — refuses to install rather than silently downgrading
-## to an unverified install. This is safe because self-update only ever
-## verifies the *next* download, and every release since #523 publishes the
-## sidecar (release.yml), so no supported update target lacks one.
+## Gate the extract on (1) an RSA signature over the checksum sidecar and
+## (2) a SHA-256 match of the archive against that sidecar. TLS + host
+## pinning constrain where the bytes came from; the digest verifies the
+## bytes themselves (in-transit corruption, single-object substitution);
+## the signature verifies the digest's *provenance*. Both `download_url`
+## and `checksum_url` come from the same GitHub Releases API response over
+## the same channel, so anyone able to modify the release's assets (leaked
+## repo token, compromised release workflow) can regenerate the sidecar to
+## match a tampered zip — but cannot forge the `.sha256.sig` signature,
+## whose private key lives only in an Actions secret outside the repo
+## token's scope (#687).
+##
+## Verification is MANDATORY (#599): no `.sha256` sidecar — mistake or
+## tamper — refuses to install. The signature is mandatory for every
+## release at or above SIGNING_REQUIRED_FROM_VERSION: a missing signature
+## there is a strip-attack signal, not a compat case, and hard-fails. Only
+## releases predating signing take the legacy checksum-only path.
 func _verify_then_install() -> void:
+	_pending_sidecar_body = PackedByteArray()
+	_pending_expected_digest = ""
+
 	if _latest_checksum_url.is_empty():
 		_fail_verification(
 			"release published no godot-ai-plugin.zip.sha256 sidecar; "
@@ -434,6 +496,23 @@ func _verify_then_install() -> void:
 	## means a GitHub host AND this repo's release-asset path (#599).
 	if not _is_trusted_download_url(_latest_checksum_url):
 		_fail_verification("checksum URL is not a trusted hi-godot/godot-ai release asset")
+		return
+
+	if _latest_signature_url.is_empty():
+		if _signature_required(_latest_remote_version):
+			_fail_verification(
+				"release v%s ships no godot-ai-plugin.zip.sha256.sig signature. "
+				% _latest_remote_version
+				+ "Every release from v%s on is signed" % SIGNING_REQUIRED_FROM_VERSION
+				+ " — a missing signature means a stripped or tampered release (#687)"
+			)
+			return
+		print(
+			"MCP | self-update: release v%s predates signing; " % _latest_remote_version
+			+ "using legacy checksum-only verification (#687)"
+		)
+	elif not _is_trusted_download_url(_latest_signature_url):
+		_fail_verification("signature URL is not a trusted hi-godot/godot-ai release asset")
 		return
 
 	install_state_changed.emit({"button_text": "Verifying..."})
@@ -469,6 +548,68 @@ func _on_checksum_completed(
 		_fail_verification("malformed checksum file")
 		return
 
+	## Signature verification (when armed) runs over the exact sidecar bytes
+	## the digest was parsed from — hold both until the signature verdict.
+	if not _latest_signature_url.is_empty():
+		_pending_sidecar_body = body
+		_pending_expected_digest = expected
+		_fetch_signature()
+		return
+
+	## Legacy pre-signing release: `_verify_then_install` already gated this
+	## on the remote version predating SIGNING_REQUIRED_FROM_VERSION.
+	_finish_digest_check_and_install(expected)
+
+
+## Download the `.sha256.sig` release asset; `_on_signature_completed`
+## verifies it over the held sidecar bytes before the digest is trusted.
+func _fetch_signature() -> void:
+	if _signature_request != null:
+		_signature_request.queue_free()
+	_signature_request = HTTPRequest.new()
+	_signature_request.max_redirects = 10
+	_signature_request.request_completed.connect(_on_signature_completed)
+	add_child(_signature_request)
+	var err := _signature_request.request(_latest_signature_url)
+	if err != OK:
+		_signature_request.queue_free()
+		_signature_request = null
+		_fail_verification("could not request signature (error %d)" % err)
+
+
+func _on_signature_completed(
+	result: int,
+	response_code: int,
+	_headers: PackedStringArray,
+	body: PackedByteArray
+) -> void:
+	if _signature_request != null:
+		_signature_request.queue_free()
+		_signature_request = null
+
+	if result != HTTPRequest.RESULT_SUCCESS or response_code != 200:
+		_fail_verification(
+			"signature download failed (result=%d code=%d)" % [result, response_code]
+		)
+		return
+
+	if not _verify_sidecar_signature(RELEASE_SIGNING_PUBLIC_KEY_PEM, _pending_sidecar_body, body):
+		_fail_verification(
+			"release signature does not verify against the embedded public key — "
+			+ "the checksum sidecar was not produced by the release pipeline (#687)"
+		)
+		return
+
+	print("MCP | self-update release signature verified (rsa-4096/sha256)")
+	_finish_digest_check_and_install(_pending_expected_digest)
+
+
+## Final gate shared by the signed and legacy paths: the staged archive's
+## SHA-256 must match the (now-trusted) sidecar digest before extract.
+func _finish_digest_check_and_install(expected: String) -> void:
+	_pending_sidecar_body = PackedByteArray()
+	_pending_expected_digest = ""
+
 	var zip_path := ProjectSettings.globalize_path(UPDATE_TEMP_ZIP)
 	var actual := FileAccess.get_sha256(zip_path).to_lower()
 	if actual.is_empty():
@@ -486,9 +627,44 @@ func _on_checksum_completed(
 	_install_zip.call_deferred()
 
 
+## True when `remote_version` falls inside the signing era — every release
+## at or above SIGNING_REQUIRED_FROM_VERSION ships a signed sidecar, so a
+## missing signature there must hard-fail rather than fall back to the
+## legacy checksum-only path. An empty/unknown version fails closed. Static
+## so it's unit-testable.
+static func _signature_required(remote_version: String) -> bool:
+	if remote_version.strip_edges().is_empty():
+		return true
+	return not _is_newer(SIGNING_REQUIRED_FROM_VERSION, remote_version)
+
+
+## PKCS#1 v1.5 RSA verification of `signature` over SHA-256(`sidecar`) —
+## the exact output of release.yml's `openssl dgst -sha256 -sign`. Takes
+## the PEM as a parameter (rather than reading the const) so tests can
+## exercise both verdicts with a generated throwaway keypair. Static so
+## it's unit-testable without instancing the manager.
+static func _verify_sidecar_signature(
+	public_key_pem: String, sidecar: PackedByteArray, signature: PackedByteArray
+) -> bool:
+	if sidecar.is_empty() or signature.is_empty():
+		return false
+	var key := CryptoKey.new()
+	if key.load_from_string(public_key_pem, true) != OK:
+		return false
+	var ctx := HashingContext.new()
+	if ctx.start(HashingContext.HASH_SHA256) != OK:
+		return false
+	ctx.update(sidecar)
+	var digest := ctx.finish()
+	var crypto := Crypto.new()
+	return crypto.verify(HashingContext.HASH_SHA256, digest, signature, key)
+
+
 ## Surface an integrity-check failure and drop the staged zip so the bad
 ## bytes can never reach the extract path. Keeps the button enabled for retry.
 func _fail_verification(reason: String) -> void:
+	_pending_sidecar_body = PackedByteArray()
+	_pending_expected_digest = ""
 	push_error(
 		"MCP | self-update integrity check failed: %s. The download was not installed."
 		% reason

--- a/test_project/tests/test_update_manager.gd
+++ b/test_project/tests/test_update_manager.gd
@@ -286,10 +286,12 @@ func test_verify_refuses_wrong_repo_checksum_url() -> void:
 
 
 func test_checksum_match_on_repo_release_proceeds_to_install() -> void:
-	## Happy path: staged ZIP whose FileAccess.get_sha256 matches the digest
-	## in the (trusted, repo-scoped) sidecar body must proceed to install —
-	## the manager paints "Installing..." and does NOT delete the staged ZIP
-	## (only _fail_verification does that).
+	## Happy path (legacy pre-signing release: no signature URL armed, so
+	## the checksum verdict alone gates the install — #687): staged ZIP
+	## whose FileAccess.get_sha256 matches the digest in the (trusted,
+	## repo-scoped) sidecar body must proceed to install — the manager
+	## paints "Installing..." and does NOT delete the staged ZIP (only
+	## _fail_verification does that).
 	var global_dir := ProjectSettings.globalize_path(McpUpdateManagerScript.UPDATE_TEMP_DIR)
 	var global_zip := ProjectSettings.globalize_path(McpUpdateManagerScript.UPDATE_TEMP_ZIP)
 	DirAccess.make_dir_recursive_absolute(global_dir)
@@ -327,6 +329,204 @@ func test_checksum_match_on_repo_release_proceeds_to_install() -> void:
 	var state: Dictionary = states[0]
 	assert_eq(String(state.get("button_text", "")), "Installing...",
 		"a matching digest must advance the pipeline to Installing...")
+
+
+# ---- Release-signature verification (#687) ------------------------------
+
+func _sha256_of(bytes: PackedByteArray) -> PackedByteArray:
+	var ctx := HashingContext.new()
+	ctx.start(HashingContext.HASH_SHA256)
+	ctx.update(bytes)
+	return ctx.finish()
+
+
+func test_verify_sidecar_signature_accepts_valid_signature() -> void:
+	## Round-trip with a throwaway keypair: sign SHA-256(sidecar) the way
+	## release.yml's `openssl dgst -sha256 -sign` does (PKCS#1 v1.5), then
+	## verify through the exact helper `_on_signature_completed` calls.
+	var crypto := Crypto.new()
+	var key := crypto.generate_rsa(2048)
+	var pub_pem := key.save_to_string(true)
+	var sidecar := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  godot-ai-plugin.zip\n".to_utf8_buffer()
+	var signature := crypto.sign(HashingContext.HASH_SHA256, _sha256_of(sidecar), key)
+
+	assert_true(
+		McpUpdateManagerScript._verify_sidecar_signature(pub_pem, sidecar, signature),
+		"a signature produced over the sidecar's SHA-256 must verify")
+
+
+func test_verify_sidecar_signature_rejects_tampered_and_missing() -> void:
+	var crypto := Crypto.new()
+	var key := crypto.generate_rsa(2048)
+	var pub_pem := key.save_to_string(true)
+	var sidecar := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  godot-ai-plugin.zip\n".to_utf8_buffer()
+	var signature := crypto.sign(HashingContext.HASH_SHA256, _sha256_of(sidecar), key)
+
+	var tampered := sidecar.duplicate()
+	tampered[0] = tampered[0] ^ 0xFF
+	assert_false(
+		McpUpdateManagerScript._verify_sidecar_signature(pub_pem, tampered, signature),
+		"a signature must not verify over different sidecar bytes")
+
+	var other_key := crypto.generate_rsa(2048)
+	var forged := crypto.sign(HashingContext.HASH_SHA256, _sha256_of(sidecar), other_key)
+	assert_false(
+		McpUpdateManagerScript._verify_sidecar_signature(pub_pem, sidecar, forged),
+		"a signature from a different private key must not verify")
+
+	assert_false(
+		McpUpdateManagerScript._verify_sidecar_signature(pub_pem, sidecar, PackedByteArray()),
+		"an empty signature must not verify")
+	assert_false(
+		McpUpdateManagerScript._verify_sidecar_signature(pub_pem, PackedByteArray(), signature),
+		"empty sidecar bytes must not verify")
+	assert_false(
+		McpUpdateManagerScript._verify_sidecar_signature("not a pem", sidecar, signature),
+		"a malformed public key must fail closed, not crash or pass")
+
+
+func test_embedded_public_key_loads_as_rsa_public_key() -> void:
+	## The const must stay a loadable public-only PEM — a paste error here
+	## would brick signature verification for every user on the next release.
+	var key := CryptoKey.new()
+	assert_eq(
+		key.load_from_string(McpUpdateManagerScript.RELEASE_SIGNING_PUBLIC_KEY_PEM, true), OK,
+		"RELEASE_SIGNING_PUBLIC_KEY_PEM must load as a public key")
+	assert_true(key.is_public_only(),
+		"the embedded key must be public-only — never ship private material")
+
+
+func test_signature_required_gates_on_signing_era() -> void:
+	## Below the first signed release: legacy checksum-only path allowed.
+	## At/above it (every future release): a missing signature is a
+	## strip-attack signal and must hard-fail. Unknown fails closed.
+	assert_false(McpUpdateManagerScript._signature_required("2.9.2"),
+		"pre-signing releases must keep installing via the legacy path")
+	assert_false(McpUpdateManagerScript._signature_required("1.0.0"),
+		"old releases must keep installing via the legacy path")
+	assert_true(McpUpdateManagerScript._signature_required(
+		McpUpdateManagerScript.SIGNING_REQUIRED_FROM_VERSION),
+		"the first signing-era version must require a signature")
+	assert_true(McpUpdateManagerScript._signature_required("999.0.0"),
+		"future releases must require a signature")
+	assert_true(McpUpdateManagerScript._signature_required(""),
+		"an unknown remote version must fail closed")
+
+
+func test_verify_refuses_unsigned_signing_era_release() -> void:
+	## A release inside the signing era whose .sig asset is absent must be
+	## treated as stripped/tampered — hard fail, staged ZIP dropped. This is
+	## what stops an attacker who can rewrite release assets from simply
+	## deleting the signature to skip verification.
+	var global_dir := ProjectSettings.globalize_path(McpUpdateManagerScript.UPDATE_TEMP_DIR)
+	var global_zip := ProjectSettings.globalize_path(McpUpdateManagerScript.UPDATE_TEMP_ZIP)
+	DirAccess.make_dir_recursive_absolute(global_dir)
+	var f := FileAccess.open(global_zip, FileAccess.WRITE)
+	assert_true(f != null, "Seed staged zip must open for write")
+	f.store_string("staged update payload")
+	f.close()
+
+	var manager = McpUpdateManagerScript.new()
+	manager._latest_checksum_url = TEST_ASSET_URL + ".sha256"
+	manager._latest_signature_url = ""
+	manager._latest_remote_version = "999.0.0"
+	var states: Array[Dictionary] = []
+	manager.install_state_changed.connect(func(state: Dictionary) -> void:
+		states.append(state)
+	)
+
+	manager._verify_then_install()
+
+	var zip_still_staged := FileAccess.file_exists(global_zip)
+	manager.free()
+	DirAccess.remove_absolute(global_zip)
+	DirAccess.remove_absolute(global_dir)
+
+	assert_false(zip_still_staged,
+		"an unsigned signing-era release must drop the staged ZIP")
+	assert_eq(states.size(), 1,
+		"an unsigned signing-era release must emit exactly one failure state")
+	assert_contains(String(states[0].get("button_text", "")), "Verification failed",
+		"an unsigned signing-era release must paint the verification-failed button")
+
+
+func test_verify_refuses_wrong_repo_signature_url() -> void:
+	## A signature URL pointing at another repo's release asset is a tamper
+	## signal — refuse before fetching it.
+	var global_dir := ProjectSettings.globalize_path(McpUpdateManagerScript.UPDATE_TEMP_DIR)
+	var global_zip := ProjectSettings.globalize_path(McpUpdateManagerScript.UPDATE_TEMP_ZIP)
+	DirAccess.make_dir_recursive_absolute(global_dir)
+	var f := FileAccess.open(global_zip, FileAccess.WRITE)
+	assert_true(f != null, "Seed staged zip must open for write")
+	f.store_string("staged update payload")
+	f.close()
+
+	var manager = McpUpdateManagerScript.new()
+	manager._latest_checksum_url = TEST_ASSET_URL + ".sha256"
+	manager._latest_signature_url = (
+		"https://github.com/evil-org/godot-ai/releases/download/v999.0.0/"
+		+ "godot-ai-plugin.zip.sha256.sig"
+	)
+	manager._latest_remote_version = "999.0.0"
+	var states: Array[Dictionary] = []
+	manager.install_state_changed.connect(func(state: Dictionary) -> void:
+		states.append(state)
+	)
+
+	manager._verify_then_install()
+
+	var zip_still_staged := FileAccess.file_exists(global_zip)
+	manager.free()
+	DirAccess.remove_absolute(global_zip)
+	DirAccess.remove_absolute(global_dir)
+
+	assert_false(zip_still_staged,
+		"a wrong-repo signature URL must drop the staged ZIP")
+	assert_eq(states.size(), 1,
+		"a wrong-repo signature URL must emit exactly one failure state")
+	assert_contains(String(states[0].get("button_text", "")), "Verification failed",
+		"a wrong-repo signature URL must paint the verification-failed button")
+
+
+func test_bad_signature_bytes_fail_verification_and_drop_zip() -> void:
+	## Drive the signature-completion callback with bytes that cannot verify
+	## against the embedded release key — the hard-fail path an attacker
+	## hits after regenerating the sidecar for a tampered zip.
+	var global_dir := ProjectSettings.globalize_path(McpUpdateManagerScript.UPDATE_TEMP_DIR)
+	var global_zip := ProjectSettings.globalize_path(McpUpdateManagerScript.UPDATE_TEMP_ZIP)
+	DirAccess.make_dir_recursive_absolute(global_dir)
+	var f := FileAccess.open(global_zip, FileAccess.WRITE)
+	assert_true(f != null, "Seed staged zip must open for write")
+	f.store_string("staged update payload")
+	f.close()
+
+	var manager = McpUpdateManagerScript.new()
+	manager._latest_signature_url = TEST_ASSET_URL + ".sha256.sig"
+	manager._pending_sidecar_body = "digest  godot-ai-plugin.zip\n".to_utf8_buffer()
+	manager._pending_expected_digest = "0000000000000000000000000000000000000000000000000000000000000000"
+	var states: Array[Dictionary] = []
+	manager.install_state_changed.connect(func(state: Dictionary) -> void:
+		states.append(state)
+	)
+
+	manager._on_signature_completed(
+		HTTPRequest.RESULT_SUCCESS, 200, [], "not a real signature".to_utf8_buffer()
+	)
+
+	var zip_still_staged := FileAccess.file_exists(global_zip)
+	var pending_cleared: bool = manager._pending_sidecar_body.is_empty()
+	manager.free()
+	DirAccess.remove_absolute(global_zip)
+	DirAccess.remove_absolute(global_dir)
+
+	assert_false(zip_still_staged,
+		"a non-verifying signature must drop the staged ZIP, not install it")
+	assert_true(pending_cleared,
+		"failure must clear the held sidecar bytes")
+	assert_eq(states.size(), 1,
+		"a non-verifying signature must emit exactly one failure state")
+	assert_contains(String(states[0].get("button_text", "")), "Verification failed",
+		"a non-verifying signature must paint the verification-failed button")
 
 
 # ---- parse_releases_response (pure / static) ---------------------------
@@ -421,6 +621,68 @@ func test_parse_releases_response_captures_checksum_asset_url() -> void:
 		"zip asset URL must still resolve when a checksum sidecar is present")
 	assert_eq(String(result.get("checksum_url", "")), checksum_url,
 		"the .sha256 sidecar URL must be captured")
+
+
+func test_parse_releases_response_captures_signature_asset_url() -> void:
+	## Signing-era releases ship a `.sha256.sig` third asset (#687); its URL
+	## must surface so the installer can verify provenance before extract.
+	var checksum_url := TEST_ASSET_URL + ".sha256"
+	var signature_url := TEST_ASSET_URL + ".sha256.sig"
+	var body := _make_body(JSON.stringify({
+		"tag_name": "v999.0.0",
+		"assets": [
+			{"name": TEST_ASSET_NAME, "browser_download_url": TEST_ASSET_URL},
+			{"name": TEST_ASSET_NAME + ".sha256", "browser_download_url": checksum_url},
+			{"name": TEST_ASSET_NAME + ".sha256.sig", "browser_download_url": signature_url},
+		],
+	}))
+	var result := McpUpdateManagerScript.parse_releases_response(
+		HTTPRequest.RESULT_SUCCESS, 200, body
+	)
+	assert_eq(String(result.get("checksum_url", "")), checksum_url,
+		"the .sha256 sidecar URL must still be captured alongside the signature")
+	assert_eq(String(result.get("signature_url", "")), signature_url,
+		"the .sha256.sig signature URL must be captured")
+
+
+func test_parse_releases_response_signature_empty_when_absent() -> void:
+	## Pre-signing releases have no .sig asset — signature_url must stay
+	## empty; `_verify_then_install` decides legacy-vs-refuse from the
+	## remote version (#687).
+	var body := _make_body(_make_release_payload("v999.0.0"))
+	var result := McpUpdateManagerScript.parse_releases_response(
+		HTTPRequest.RESULT_SUCCESS, 200, body
+	)
+	assert_eq(String(result.get("signature_url", "")), "",
+		"no signature asset must yield an empty signature_url")
+
+
+func test_checksum_completed_with_signature_armed_defers_install() -> void:
+	## With a signature URL armed, a checksum download completing must NOT
+	## advance to Installing... — the digest is untrusted until the
+	## signature verdict. (In-tree, _fetch_signature would fire the HTTP
+	## request; out-of-tree it fails closed. Either way: no install.)
+	var manager = McpUpdateManagerScript.new()
+	manager._latest_signature_url = TEST_ASSET_URL + ".sha256.sig"
+	var digest := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	var states: Array[Dictionary] = []
+	manager.install_state_changed.connect(func(state: Dictionary) -> void:
+		states.append(state)
+	)
+
+	manager._on_checksum_completed(
+		HTTPRequest.RESULT_SUCCESS, 200, [],
+		("%s  godot-ai-plugin.zip\n" % digest).to_utf8_buffer()
+	)
+
+	var reached_install := false
+	for state in states:
+		if String(state.get("button_text", "")) == "Installing...":
+			reached_install = true
+	manager.free()
+
+	assert_false(reached_install,
+		"a signed release must never reach Installing... before the signature verdict")
 
 
 func test_parse_releases_response_checksum_empty_when_absent() -> void:


### PR DESCRIPTION
Implements the maintainer decision recorded on #687 (finding 1 — self-signed checksum): RSA instead of ed25519 because Godot core `Crypto`/`CryptoKey` (mbedTLS) only supports RSA.

## What

- **release.yml**: new *Sign checksum sidecar* step — signs `godot-ai-plugin.zip.sha256` with the `RELEASE_SIGNING_KEY_PEM` Actions secret (`openssl dgst -sha256 -sign`, PKCS#1 v1.5), uploads `godot-ai-plugin.zip.sha256.sig` as a third release asset. The step **self-checks the fresh signature against the public key extracted from the plugin source**, so a rotated/mismatched secret fails the release run, not every user's editor. It hard-fails when the secret is unset — a signing-era release must never ship unsigned.
- **update_manager.gd**: embeds the RSA-4096 public PEM; `parse_releases_response` surfaces the `.sig` asset URL; the verify pipeline becomes checksum-download → signature-download → `Crypto.verify(HASH_SHA256, sha256(sidecar_bytes), sig, embedded_key)` → digest compare → install. Signature verification runs over the exact bytes the digest was parsed from.
- **Compat gate** (`SIGNING_REQUIRED_FROM_VERSION = "2.9.3"`): releases *below* it (published before signing existed) keep the legacy checksum-only path. At or above it — i.e. every future release — a **missing** signature asset hard-fails: an attacker who can rewrite release assets could otherwise strip the `.sig` to skip verification, so absence inside the signing era is a tamper signal, not a compat case. A present-but-invalid signature always hard-fails and drops the staged zip. Unknown remote version fails closed.
- Docstring-honesty rewrite of `_verify_then_install` (the remaining mechanical item on #687).

## Threat model

Both `download_url` and `checksum_url` come from the same Releases API response, so anyone able to modify release assets (leaked repo token, compromised workflow) can regenerate the sidecar to match a tampered zip — but cannot forge the signature: the private key lives only in an Actions secret (outside the repo token's scope) plus the maintainer's offline backup.

## Testing

- `ruff` + full `pytest` (1362 passed): green
- `script/ci-check-gdscript`: green
- Live editor `test_run`: 60 suites, 1780 passed / 0 failed; `update_manager` suite 41 passed (new coverage: sign/verify round-trip with a throwaway keypair, tampered/forged/missing signature rejection, embedded-PEM loadability + public-only, signing-era gate boundaries, unsigned-signing-era refusal, wrong-repo `.sig` URL refusal, no-install-before-signature-verdict)
- **`script/local-self-update-smoke` on this branch: all PASS** (interactive, operator-clicked)

Key rotation note: rotating requires a new plugin release embedding the new public key and bumping `SIGNING_REQUIRED_FROM_VERSION` past the last old-key release.

Closes #687 (the signing follow-up; findings 2–3 landed in #702/#695).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added signed integrity verification for plugin releases.
  * Releases now include a cryptographic signature alongside the checksum file.
  * Updates verify signatures before installation and reject unsigned or tampered releases.
  * Older releases continue to use checksum-only verification.

* **Bug Fixes**
  * Failed verification now safely cancels installation, clears temporary data, and keeps retry available.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->