### PR TITLE
Self-update follow-ups: reserved-suffix zip rejection, sanitizer tests, staged-zip cleanup, trusted-URL query split (#713)

### DIFF
--- a/plugin/addons/godot_ai/update_reload_runner.gd
+++ b/plugin/addons/godot_ai/update_reload_runner.gd
@@ -326,6 +326,13 @@ func _is_safe_zip_addon_file(file_path: String) -> bool:
 	var rel_path := file_path.trim_prefix(ZIP_ADDON_PREFIX)
 	if rel_path.is_empty() or rel_path.ends_with("/"):
 		return false
+	## Reserved install-machinery suffixes (#713): an entry named like the
+	## runner's own staging/backup files would collide with the temp file
+	## `_install_zip_file` writes, or overwrite / later be deleted with the
+	## rollback snapshots `_finalize_install_success` cleans up — corrupting
+	## the very rollback set protecting this install.
+	if rel_path.ends_with(TEMP_FILE_SUFFIX) or rel_path.ends_with(INSTALL_BACKUP_SUFFIX):
+		return false
 	for segment in rel_path.split("/", true):
 		if segment.is_empty() or segment == "." or segment == "..":
 			return false

--- a/plugin/addons/godot_ai/utils/update_manager.gd
+++ b/plugin/addons/godot_ai/utils/update_manager.gd
@@ -332,6 +332,14 @@ static func _is_trusted_download_url(url: String) -> bool:
 	var host := authority.to_lower()
 	if not _TRUSTED_DOWNLOAD_PATH_PREFIXES.has(host):
 		return false
+	## Scope the checks below to the path proper (#713): direct CDN asset
+	## URLs carry signed query params (X-Amz-Credential=...%2F...) whose
+	## legitimate %2F tokens made every CDN prefix unreachable when the
+	## needle scan covered the query string. Routing is decided by the
+	## path, so the query is safe to ignore.
+	var qmark := path.find("?")
+	if qmark >= 0:
+		path = path.substr(0, qmark)
 	## Reject dot-segments (and their percent-encoded forms) anywhere in the
 	## path: "/hi-godot/godot-ai/releases/download/../../evil/..." passes a
 	## raw string-prefix test but normalizes server-side to a different repo,
@@ -393,6 +401,11 @@ func _on_download_completed(
 
 	if result != HTTPRequest.RESULT_SUCCESS or response_code != 200:
 		print("MCP | update download failed: result=%d code=%d" % [result, response_code])
+		## Failure parity with _fail_verification (#713): HTTPRequest's
+		## download_file mode leaves whatever partial/error bytes it wrote
+		## staged at UPDATE_TEMP_ZIP — drop them so no later step can ever
+		## pick up a half-downloaded archive.
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(UPDATE_TEMP_ZIP))
 		install_state_changed.emit({
 			"button_text": "Download failed (%d)" % response_code,
 			"button_disabled": false,

--- a/test_project/tests/test_update_manager.gd
+++ b/test_project/tests/test_update_manager.gd
@@ -123,6 +123,41 @@ func test_trusted_download_url_rejects_wrong_repo_on_trusted_host() -> void:
 		"a bare trusted host with no path must be rejected")
 
 
+func test_trusted_download_url_accepts_cdn_url_with_signed_query() -> void:
+	## #713: direct CDN asset URLs carry S3-signed query params whose
+	## legitimate %2F tokens (in X-Amz-Credential) previously tripped the
+	## encoded-slash needle scan, making every CDN prefix unreachable. The
+	## needle scan must cover only the path proper.
+	assert_true(
+		McpUpdateManagerScript._is_trusted_download_url(
+			"https://objects.githubusercontent.com/github-production-release-asset-2e65be/1234/x.zip"
+			+ "?X-Amz-Algorithm=AWS4-HMAC-SHA256"
+			+ "&X-Amz-Credential=AKIA%2F20260713%2Fus-east-1%2Fs3%2Faws4_request"
+			+ "&X-Amz-Signature=deadbeef"),
+		"a CDN release-asset URL with a signed query string must be trusted")
+	assert_true(
+		McpUpdateManagerScript._is_trusted_download_url(
+			TEST_ASSET_URL + "?foo=..%2f.."),
+		"encoded slashes in the query (not the path) must not trip the scan")
+
+
+func test_trusted_download_url_still_rejects_bad_path_despite_query() -> void:
+	## Splitting the query off must not open a path-side hole: dot-segments
+	## and encoded slashes IN THE PATH stay rejected with a query present.
+	assert_false(
+		McpUpdateManagerScript._is_trusted_download_url(
+			"https://github.com/hi-godot/godot-ai/releases/download/../../evil/x.zip?sig=ok"),
+		"path traversal must stay rejected when a query string is present")
+	assert_false(
+		McpUpdateManagerScript._is_trusted_download_url(
+			"https://github.com/hi-godot/godot-ai/releases/download/v1/..%2fevil.zip?sig=ok"),
+		"encoded slash in the path must stay rejected when a query is present")
+	assert_false(
+		McpUpdateManagerScript._is_trusted_download_url(
+			"https://github.com/evil-org/godot-ai/releases/download/v1/x.zip?sig=ok"),
+		"wrong-repo path must stay rejected when a query is present")
+
+
 func test_trusted_download_url_rejects_untrusted_and_insecure() -> void:
 	assert_false(
 		McpUpdateManagerScript._is_trusted_download_url(
@@ -203,6 +238,45 @@ func test_parse_sha256_digest_matches_fileaccess_hash() -> void:
 
 	assert_eq(parsed, real,
 		"parsed sidecar digest must match FileAccess.get_sha256 (the verify compare)")
+
+
+# ---- download-failure staged-zip cleanup (#713) -------------------------
+
+func test_download_failure_drops_staged_zip() -> void:
+	## HTTPRequest's download_file mode writes whatever bytes arrived (an
+	## error page, a truncated body) to UPDATE_TEMP_ZIP even on failure.
+	## The failure branch must drop them — same guarantee _fail_verification
+	## states — so no later step can pick up a half-downloaded archive.
+	var global_dir := ProjectSettings.globalize_path(McpUpdateManagerScript.UPDATE_TEMP_DIR)
+	var global_zip := ProjectSettings.globalize_path(McpUpdateManagerScript.UPDATE_TEMP_ZIP)
+	DirAccess.make_dir_recursive_absolute(global_dir)
+	var f := FileAccess.open(global_zip, FileAccess.WRITE)
+	assert_true(f != null, "Seed staged zip must open for write")
+	f.store_string("partial download bytes")
+	f.close()
+
+	var manager = McpUpdateManagerScript.new()
+	var states: Array[Dictionary] = []
+	manager.install_state_changed.connect(func(state: Dictionary) -> void:
+		states.append(state)
+	)
+
+	manager._on_download_completed(HTTPRequest.RESULT_CANT_CONNECT, 0, [], PackedByteArray())
+
+	var zip_still_staged := FileAccess.file_exists(global_zip)
+	manager.free()
+	DirAccess.remove_absolute(global_zip)
+	DirAccess.remove_absolute(global_dir)
+
+	assert_false(zip_still_staged,
+		"a failed download must not leave partial bytes staged at UPDATE_TEMP_ZIP")
+	assert_eq(states.size(), 1,
+		"a failed download must emit exactly one failure state")
+	var state: Dictionary = states[0]
+	assert_contains(String(state.get("button_text", "")), "Download failed",
+		"a failed download must paint the download-failed button")
+	assert_eq(bool(state.get("button_disabled", true)), false,
+		"a failed download must leave the button enabled for retry")
 
 
 # ---- _verify_then_install mandatory verification (#599) ----------------

--- a/test_project/tests/test_update_reload_runner.gd
+++ b/test_project/tests/test_update_reload_runner.gd
@@ -287,6 +287,88 @@ func test_finalize_install_success_clears_backups() -> void:
 	runner.free()
 
 
+# ----- _is_safe_zip_addon_file rejection matrix (#713) -----
+
+
+func test_zip_sanitizer_accepts_normal_addon_entries() -> void:
+	var runner = _new_runner()
+	assert_true(runner._is_safe_zip_addon_file("addons/godot_ai/plugin.cfg"),
+		"a plain addon file entry must be accepted")
+	assert_true(runner._is_safe_zip_addon_file("addons/godot_ai/utils/settings.gd"),
+		"a nested addon file entry must be accepted")
+	assert_true(runner._is_safe_zip_addon_file("addons/godot_ai/a.b.c.txt"),
+		"dots inside a filename (not dot-segments) must be accepted")
+	runner.free()
+
+
+func test_zip_sanitizer_rejects_traversal_and_absolute_paths() -> void:
+	## Tier-1 S2: these are the containment guarantees the extractor relies
+	## on before writing zip bytes over live plugin code. Previously pinned
+	## only indirectly via the Python fixtures — this is the direct matrix.
+	var runner = _new_runner()
+	var bad := [
+		"/etc/passwd",
+		"/addons/godot_ai/plugin.gd",
+		"C:/evil/plugin.gd",
+		"addons\\godot_ai\\plugin.gd",
+		"addons/godot_ai/..\\evil.gd",
+		"addons/godot_ai/../../evil.gd",
+		"addons/godot_ai/sub/../../../evil.gd",
+		"addons/godot_ai/./plugin.gd",
+		"addons/godot_ai/..",
+		"addons/godot_ai//double_slash.gd",
+		"addons/other_addon/file.gd",
+		"not_addons/godot_ai/file.gd",
+		"addons/godot_ai/",
+		"addons/godot_ai/sub/",
+		"",
+	]
+	for entry in bad:
+		assert_false(runner._is_safe_zip_addon_file(entry),
+			"unsafe zip entry must be rejected: %s" % entry)
+	runner.free()
+
+
+func test_zip_sanitizer_rejects_reserved_install_suffixes() -> void:
+	## A zip entry named like the runner's own staging/backup machinery
+	## would collide with the temp file `_install_zip_file` writes, or be
+	## overwritten/deleted along with the rollback snapshots — corrupting
+	## the rollback set protecting this very install (#713).
+	var runner = _new_runner()
+	var reserved := [
+		"addons/godot_ai/plugin.gd" + UpdateReloadRunner.INSTALL_BACKUP_SUFFIX,
+		"addons/godot_ai/plugin.gd" + UpdateReloadRunner.TEMP_FILE_SUFFIX,
+		"addons/godot_ai/sub/x.gd" + UpdateReloadRunner.INSTALL_BACKUP_SUFFIX,
+		"addons/godot_ai/sub/x.gd" + UpdateReloadRunner.TEMP_FILE_SUFFIX,
+	]
+	for entry in reserved:
+		assert_false(runner._is_safe_zip_addon_file(entry),
+			"reserved install-machinery suffix must be rejected: %s" % entry)
+	runner.free()
+
+
+func test_manifest_rejects_zip_with_reserved_suffix_entry() -> void:
+	## End-to-end through _read_update_manifest: a release-shaped zip that
+	## also smuggles a *.update_backup entry must be refused outright.
+	var zip_path := _scratch_dir.path_join("update_reserved_suffix.zip")
+	_stage_release_zip(
+		zip_path,
+		{
+			"addons/godot_ai/plugin.cfg": "[plugin]\nname=\"Godot AI\"\n",
+			"addons/godot_ai/plugin.gd": "extends EditorPlugin\n",
+			"addons/godot_ai/plugin.gd.update_backup": "stale backup payload\n",
+		},
+	)
+
+	var runner = _new_runner()
+	runner._zip_path = zip_path
+	assert_false(
+		runner._read_update_manifest(),
+		"a zip smuggling a reserved-suffix entry must be rejected",
+	)
+	runner.free()
+
+
 # ----- _install_zip_file end-to-end -----
 
 


### PR DESCRIPTION
Lands the four code items on #713 (quarantined behind #695, which merged via #726):

- **Reserved-suffix zip rejection** — `_is_safe_zip_addon_file` now rejects entries ending in `.update_backup` / `.godot_ai_update_tmp`. A zip entry named like the runner's own install machinery could collide with the staging temp file `_install_zip_file` writes, or overwrite / get deleted with the rollback snapshots — corrupting the rollback set protecting that very install.
- **Sanitizer test matrix** — the zip path-traversal sanitizer had zero runtime GDScript tests; adds direct rejection-matrix coverage (absolute paths, backslashes, `..`/`.` segments, empty segments, wrong prefix, reserved suffixes, directory entries) plus an end-to-end `_read_update_manifest` rejection of a release-shaped zip smuggling a `.update_backup` entry.
- **Staged-zip cleanup on download failure** — `_on_download_completed`'s failure branch now removes `UPDATE_TEMP_ZIP` (HTTPRequest's `download_file` mode stages whatever error/partial bytes arrived), matching `_fail_verification`'s stated never-leave-bad-bytes guarantee.
- **Trusted-URL query split** — `_is_trusted_download_url` splits the query off before the dot-segment/`%2f`/`%5c` needle scan. Signed CDN asset URLs carry legitimate `%2F` tokens (X-Amz-Credential), which made every CDN prefix in `_TRUSTED_DOWNLOAD_PATH_PREFIXES` unreachable. Path-side rejections are still enforced when a query is present (covered by tests).

The fifth item (caller-less `cancel_check`/`clear_pending_download`) resolves as **keep as published API**: both are load-bearing seams for tests and the update flow, and #727 extended `clear_pending_download`'s reset set — deleting them buys nothing.

## Testing
- ruff + pytest (1362 passed), `script/ci-check-gdscript`: green
- Live editor `test_run`: 61 suites, 1818 passed / 0 failed (includes the new matrices)
- **`script/local-self-update-smoke` on this branch: all PASS** (interactive, operator-clicked)

Closes #713.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update safety by blocking archive files that could interfere with temporary installation or rollback processes.
  * Signed CDN download URLs are now handled correctly while path traversal remains blocked.
  * Failed or incomplete downloads are automatically cleaned up, preventing corrupted update files from being reused.
  * Retry controls remain available after a download failure.

* **Tests**
  * Added coverage for secure archive handling, signed download URLs, path traversal protection, and cleanup after failed downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->