### PR TITLE
Shared write-a-text-file + import-settle helper; write_file defers fresh .gd replies (#714)

### DIFF
--- a/plugin/addons/godot_ai/dispatcher.gd
+++ b/plugin/addons/godot_ai/dispatcher.gd
@@ -23,6 +23,9 @@ var deferred_timeout_overrides_ms: Dictionary = {}
 const DEFAULT_DEFERRED_TIMEOUT_MS := 4500
 const DEFERRED_TIMEOUT_MS_BY_COMMAND := {
 	"create_script": 4500,
+	## Fresh-`.gd` writes defer through the same import-settle window as
+	## create_script (#714) — same headroom over IMPORT_SETTLE_MAX_MSEC.
+	"write_file": 4500,
 	"stop_project": 4500,
 	"run_project": 6000,
 	"take_screenshot": 30000,

--- a/plugin/addons/godot_ai/handlers/filesystem_handler.gd
+++ b/plugin/addons/godot_ai/handlers/filesystem_handler.gd
@@ -68,28 +68,13 @@ func write_file(params: Dictionary) -> Dictionary:
 	if path_err != null:
 		return path_err
 
-	# Ensure parent directory exists
-	var dir_path := path.get_base_dir()
-	if not DirAccess.dir_exists_absolute(dir_path):
-		var err := DirAccess.make_dir_recursive_absolute(dir_path)
-		if err != OK:
-			return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to create directory: %s" % dir_path)
-
 	var existed_before := FileAccess.file_exists(path)
 
-	var file := FileAccess.open(path, FileAccess.WRITE)
-	if file == null:
-		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to open file for writing: %s" % path)
-
-	file.store_string(content)
-	file.flush()
-	var write_err := file.get_error()
-	file.close()
-	if write_err != OK:
-		return ErrorCodes.make(
-			ErrorCodes.INTERNAL_ERROR,
-			"Write failed for %s (%s); file may be truncated" % [path, error_string(write_err)]
-		)
+	# Shared write path (#714): parent mkdir + write/flush + explicit error
+	# check live on McpResourceIO so this can't drift from create_script.
+	var write_failure: Variant = McpResourceIO.write_text_to_disk(path, content)
+	if write_failure != null:
+		return write_failure
 
 	# Single-file register, not a full scan() — a scan() per write stacks
 	# filesystem WorkerThreadPool tasks under concurrent writes and can SIGABRT
@@ -105,15 +90,35 @@ func write_file(params: Dictionary) -> Dictionary:
 		"undoable": false,
 		"reason": "File system operations cannot be undone via editor undo",
 	}
+	var is_gdscript := path.ends_with(".gd")
 	## A .gd written through the filesystem tool used to skip the parse
 	## diagnostics create_script attaches (#714) — the agent's broken
 	## script reported plain success and the parse error surfaced only in
 	## later editor logs. Same shared check, same response fields. A bare
 	## ScriptHandler works here: the diagnostics path touches no instance
 	## state (it stays an instance method only for test stubbing).
-	if path.ends_with(".gd"):
+	if is_gdscript:
 		ScriptHandler.new(null)._attach_gdscript_diagnostics(data, path, content)
+		data["committed"] = true
+		data["import_settled"] = existed_before
+		data["import_settle"] = "already_known" if existed_before else "not_waited"
 	McpResourceIO.attach_cleanup_hint(data, existed_before, [path])
+
+	## Fresh `.gd` writes take create_script's import-settle deferral (#714,
+	## #261): reply only once ResourceLoader can see the new resource (or the
+	## bounded window elapses), so write_file -> script_attach back-to-back
+	## can't 404 on the not-yet-imported script. This CHANGES write_file's
+	## response timing for that case — the reply lands up to
+	## McpResourceIO.IMPORT_SETTLE_MAX_MSEC later instead of immediately.
+	## Scoped to .gd: ResourceLoader never learns plain text files, so an
+	## unconditional wait would burn the full window on every fresh .txt.
+	## Overwrites, batch_execute (no request_id) and unit-test contexts (no
+	## connection) keep the synchronous reply.
+	var request_id: String = params.get("_request_id", "")
+	if is_gdscript and not existed_before and _connection != null and not request_id.is_empty():
+		McpResourceIO.finish_text_write_deferred(_connection, request_id, path, data)
+		return McpDispatcher.DEFERRED_RESPONSE
+
 	return {"data": data}
 
 
@@ -229,7 +234,7 @@ static func _finish_scan_deferred(
 		_scan_in_flight = true
 		efs.scan()
 	# Hand back a frame so _dispatch() registers this request as deferred before
-	# the coroutine can push a reply (mirrors _finish_create_script_deferred).
+	# the coroutine can push a reply (mirrors McpResourceIO.finish_text_write_deferred).
 	await tree.process_frame
 	var deadline_ms := Time.get_ticks_msec() + _SCAN_SETTLE_MAX_MSEC
 	var start_grace_ms := Time.get_ticks_msec() + _SCAN_START_GRACE_MSEC

--- a/plugin/addons/godot_ai/handlers/script_handler.gd
+++ b/plugin/addons/godot_ai/handlers/script_handler.gd
@@ -10,15 +10,9 @@ const ValidationLogger := preload("res://addons/godot_ai/runtime/validation_logg
 var _undo_redo: EditorUndoRedoManager
 var _connection: McpConnection
 
-# Bounded settle window for `ResourceLoader.exists(path)` after `scan()` so
-# that an agent calling create_script -> attach_script back-to-back doesn't
-# race the editor's import pipeline (#261). Polled once per frame, with an
-# elapsed-time cap below the dispatcher's create_script deferred timeout. If
-# import is still not visible at the cap, we still return committed=true
-# instead of letting the already-written file surface as DEFERRED_TIMEOUT.
-const _IMPORT_SETTLE_MAX_FRAMES := 300
-const _IMPORT_SETTLE_MAX_MSEC := 3500
-
+# The bounded import-settle window and the deferred completion coroutine
+# live on McpResourceIO since #714 — write_file's fresh-`.gd` path shares
+# them, so create_script and write_file can't drift apart again (#261).
 
 func _init(undo_redo: EditorUndoRedoManager, connection: McpConnection = null) -> void:
 	_undo_redo = undo_redo
@@ -36,28 +30,13 @@ func create_script(params: Dictionary) -> Dictionary:
 	if not path.ends_with(".gd"):
 		return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "Path must end with .gd")
 
-	# Ensure parent directory exists
-	var dir_path := path.get_base_dir()
-	if not DirAccess.dir_exists_absolute(dir_path):
-		var err := DirAccess.make_dir_recursive_absolute(dir_path)
-		if err != OK:
-			return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to create directory: %s" % dir_path)
-
 	var existed_before := FileAccess.file_exists(path)
 
-	var file := FileAccess.open(path, FileAccess.WRITE)
-	if file == null:
-		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to open file for writing: %s" % path)
-
-	file.store_string(content)
-	file.flush()
-	var write_err := file.get_error()
-	file.close()
-	if write_err != OK:
-		return ErrorCodes.make(
-			ErrorCodes.INTERNAL_ERROR,
-			"Write failed for %s (%s); file may be truncated" % [path, error_string(write_err)]
-		)
+	# Shared write path (#714): parent mkdir + write/flush + explicit error
+	# check live on McpResourceIO so write_file can't drift from this again.
+	var write_failure: Variant = McpResourceIO.write_text_to_disk(path, content)
+	if write_failure != null:
+		return write_failure
 
 	var data := {
 		"path": path,
@@ -119,61 +98,12 @@ func create_script(params: Dictionary) -> Dictionary:
 	# overwrite the resource was already known to ResourceLoader, so reply now.
 	var request_id: String = params.get("_request_id", "")
 	if not existed_before and _connection != null and not request_id.is_empty():
-		_finish_create_script_deferred(_connection, request_id, path, data)
+		McpResourceIO.finish_text_write_deferred(_connection, request_id, path, data)
 		return McpDispatcher.DEFERRED_RESPONSE
 
 	# Synchronous fallback: batch_execute (no request_id) and unit-test contexts
 	# (no connection) get the immediate reply that the previous behaviour gave.
 	return {"data": data}
-
-
-# `static` is load-bearing: the deferred completion captures no `self`, so the
-# coroutine survives even if the ScriptHandler RefCounted is freed mid-await.
-# Under concurrent script_create storms with editor_reload_plugin fired during
-# the burst, the handler instance is otherwise GC'd between `await` and resume,
-# producing "Resumed function '_finish_create_script_deferred()' after await,
-# but class instance is gone" errors and dropping the response. Keep this
-# function static and parameterise everything it needs explicitly — do not
-# reference instance state.
-static func _finish_create_script_deferred(
-	connection: McpConnection,
-	request_id: String,
-	path: String,
-	data: Dictionary,
-) -> void:
-	if not is_instance_valid(connection):
-		return
-	var tree := connection.get_tree()
-	if tree == null:
-		return
-	var deadline_ms := Time.get_ticks_msec() + _IMPORT_SETTLE_MAX_MSEC
-	# Let _dispatch() return DEFERRED_RESPONSE and register the request before
-	# this coroutine can send a committed result. ResourceLoader.exists(path)
-	# may already be true on fast imports; without this handoff the connection
-	# treats the response as late/unregistered and drops it, then the dispatcher
-	# times out a file that was already written (#324). The deadline starts
-	# before this await so a slow handoff frame is counted against the bounded
-	# settle window.
-	await tree.process_frame
-	var frames := 0
-	while (
-		frames < _IMPORT_SETTLE_MAX_FRAMES
-		and Time.get_ticks_msec() < deadline_ms
-		and not ResourceLoader.exists(path)
-	):
-		await tree.process_frame
-		frames += 1
-	# If the plugin tears down (_exit_tree frees the connection) during the
-	# await, is_instance_valid() goes false and we drop the response silently —
-	# the server's request timeout will surface the failure to the caller.
-	if not is_instance_valid(connection):
-		return
-	var payload := data.duplicate()
-	var settled := ResourceLoader.exists(path)
-	payload["import_settled"] = settled
-	payload["import_settle"] = "settled" if settled else "timeout"
-	payload["import_pending"] = not settled
-	connection.send_deferred_response(request_id, {"data": payload})
 
 
 ## Extract the `class_name` a script declares, or "" if none. A cheap line scan
@@ -371,18 +301,12 @@ func patch_script(params: Dictionary) -> Dictionary:
 		new_content = content.substr(0, idx) + new_text + content.substr(idx + old_text.length())
 		replacements = 1
 
-	var write := FileAccess.open(path, FileAccess.WRITE)
-	if write == null:
-		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to open file for writing: %s" % path)
-	write.store_string(new_content)
-	write.flush()
-	var write_err := write.get_error()
-	write.close()
-	if write_err != OK:
-		return ErrorCodes.make(
-			ErrorCodes.INTERNAL_ERROR,
-			"Write failed for %s (%s); file may be truncated" % [path, error_string(write_err)]
-		)
+	# Shared write path (#714). No import-settle deferral here: the file
+	# already exists, so ResourceLoader knows it and there is no scan to wait
+	# for — same rationale as create_script's overwrite arm.
+	var write_failure: Variant = McpResourceIO.write_text_to_disk(path, new_content)
+	if write_failure != null:
+		return write_failure
 
 	var data := {
 		"path": path,

--- a/plugin/addons/godot_ai/utils/resource_io.gd
+++ b/plugin/addons/godot_ai/utils/resource_io.gd
@@ -8,6 +8,20 @@ const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
 ## path-vs-resource_path param validation that every resource-authoring
 ## handler needs. Extracted to remove 4-way duplication across
 ## resource_handler, environment_handler, texture_handler, and curve_handler.
+## Also home to the shared write-a-text-file path + deferred import-settle
+## completion used by both script_handler.create_script and
+## filesystem_handler.write_file (#714).
+
+# Bounded settle window for `ResourceLoader.exists(path)` after a fresh text
+# write registers with the filesystem, so an agent calling
+# create_script/write_file -> attach_script back-to-back doesn't race the
+# editor's import pipeline (#261, extended to write_file by #714). Polled once
+# per frame, with an elapsed-time cap below the dispatcher's deferred timeouts
+# for both commands. If import is still not visible at the cap, we still
+# return committed data instead of letting the already-written file surface
+# as DEFERRED_TIMEOUT.
+const IMPORT_SETTLE_MAX_FRAMES := 300
+const IMPORT_SETTLE_MAX_MSEC := 3500
 
 
 ## Validate that exactly one of {path, resource_path} is provided.
@@ -145,3 +159,83 @@ static func attach_cleanup_hint(data: Dictionary, existed_before: bool, paths: A
 	if existed_before:
 		return
 	data["cleanup"] = {"rm": paths}
+
+
+## Shared write-a-text-file path (#714): parent-directory mkdir, write +
+## flush with an explicit error check so a truncated write (disk full,
+## permission flip mid-write) surfaces as an error instead of plain success.
+## Deliberately does NOT call `EditorFileSystem.update_file()` — callers
+## register the file themselves after assembling their response fields, so
+## the registration comment (the dsarno/godot#6 scan-stacking rationale)
+## stays next to the call. Returns null on success or an error dict ready
+## to return from the handler.
+static func write_text_to_disk(path: String, content: String) -> Variant:
+	var dir_path := path.get_base_dir()
+	if not DirAccess.dir_exists_absolute(dir_path):
+		var err := DirAccess.make_dir_recursive_absolute(dir_path)
+		if err != OK:
+			return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to create directory: %s" % dir_path)
+
+	var file := FileAccess.open(path, FileAccess.WRITE)
+	if file == null:
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "Failed to open file for writing: %s" % path)
+
+	file.store_string(content)
+	file.flush()
+	var write_err := file.get_error()
+	file.close()
+	if write_err != OK:
+		return ErrorCodes.make(
+			ErrorCodes.INTERNAL_ERROR,
+			"Write failed for %s (%s); file may be truncated" % [path, error_string(write_err)]
+		)
+	return null
+
+
+# `static` is load-bearing: the deferred completion captures no `self`, so the
+# coroutine survives even if the calling handler RefCounted is freed mid-await.
+# Under concurrent create storms with editor_reload_plugin fired during the
+# burst, an instance-method coroutine is otherwise GC'd between `await` and
+# resume, producing "Resumed function ... after await, but class instance is
+# gone" errors and dropping the response. Keep this function static and
+# parameterise everything it needs explicitly — do not reference instance
+# state. Shared by create_script and write_file's fresh-`.gd` path (#714).
+static func finish_text_write_deferred(
+	connection: McpConnection,
+	request_id: String,
+	path: String,
+	data: Dictionary,
+) -> void:
+	if not is_instance_valid(connection):
+		return
+	var tree := connection.get_tree()
+	if tree == null:
+		return
+	var deadline_ms := Time.get_ticks_msec() + IMPORT_SETTLE_MAX_MSEC
+	# Let _dispatch() return DEFERRED_RESPONSE and register the request before
+	# this coroutine can send a committed result. ResourceLoader.exists(path)
+	# may already be true on fast imports; without this handoff the connection
+	# treats the response as late/unregistered and drops it, then the dispatcher
+	# times out a file that was already written (#324). The deadline starts
+	# before this await so a slow handoff frame is counted against the bounded
+	# settle window.
+	await tree.process_frame
+	var frames := 0
+	while (
+		frames < IMPORT_SETTLE_MAX_FRAMES
+		and Time.get_ticks_msec() < deadline_ms
+		and not ResourceLoader.exists(path)
+	):
+		await tree.process_frame
+		frames += 1
+	# If the plugin tears down (_exit_tree frees the connection) during the
+	# await, is_instance_valid() goes false and we drop the response silently —
+	# the server's request timeout will surface the failure to the caller.
+	if not is_instance_valid(connection):
+		return
+	var payload := data.duplicate()
+	var settled := ResourceLoader.exists(path)
+	payload["import_settled"] = settled
+	payload["import_settle"] = "settled" if settled else "timeout"
+	payload["import_pending"] = not settled
+	connection.send_deferred_response(request_id, {"data": payload})

--- a/test_project/tests/test_filesystem.gd
+++ b/test_project/tests/test_filesystem.gd
@@ -139,6 +139,50 @@ func test_write_file_non_gd_has_no_diagnostics_field() -> void:
 	DirAccess.remove_absolute(path)
 
 
+func test_write_file_fresh_gd_reports_import_settle_fields() -> void:
+	## #714: fresh .gd writes share create_script's import-settle contract.
+	## In this unit context (no connection) the sync fallback replies
+	## immediately with the not_waited marker; production defers until
+	## ResourceLoader sees the resource (see McpResourceIO).
+	var path := "res://tests/_mcp_test_written_settle.gd"
+	if FileAccess.file_exists(path):
+		DirAccess.remove_absolute(path)
+	var result := _handler.write_file({"path": path, "content": "extends Node\n"})
+	assert_has_key(result, "data")
+	assert_eq(result.data.committed, true)
+	assert_eq(result.data.import_settled, false)
+	assert_eq(result.data.import_settle, "not_waited")
+	DirAccess.remove_absolute(path)
+
+
+func test_write_file_overwrite_gd_reports_already_known() -> void:
+	## Overwrites reply synchronously — ResourceLoader already knows the
+	## resource, so there is no import to wait for (#714).
+	var path := "res://tests/_mcp_test_written_settle_overwrite.gd"
+	var first := _handler.write_file({"path": path, "content": "extends Node\n"})
+	assert_has_key(first, "data")
+	var second := _handler.write_file({"path": path, "content": "extends Node\n# v2\n"})
+	assert_has_key(second, "data")
+	assert_eq(second.data.import_settled, true)
+	assert_eq(second.data.import_settle, "already_known")
+	DirAccess.remove_absolute(path)
+
+
+func test_write_file_non_gd_has_no_import_settle_fields() -> void:
+	## ResourceLoader never learns plain text files — claiming settle
+	## semantics for them would be a lie, and deferring would burn the full
+	## settle window on every fresh .txt (#714).
+	var path := "res://tests/_mcp_test_written_plain_settle.txt"
+	if FileAccess.file_exists(path):
+		DirAccess.remove_absolute(path)
+	var result := _handler.write_file({"path": path, "content": "hello"})
+	assert_has_key(result, "data")
+	assert_false(result.data.has("import_settle"), "non-.gd writes carry no settle contract")
+	assert_false(result.data.has("import_settled"), "non-.gd writes carry no settle contract")
+	assert_false(result.data.has("committed"), "committed is part of the .gd settle contract")
+	DirAccess.remove_absolute(path)
+
+
 func test_write_file_overwrite_omits_cleanup_hint() -> void:
 	## Second write to the same path is an overwrite; dropping a cleanup hint
 	## on overwrite would invite callers to rm files they already had.

--- a/test_project/tests/test_script.gd
+++ b/test_project/tests/test_script.gd
@@ -159,25 +159,25 @@ func _expect_invalid_if_parse_errors() -> void:
 	expect_script_error_containing(INVALID_IF_PARSE_ERROR)
 
 
-func test_finish_create_script_deferred_is_static_and_handles_null_connection() -> void:
+func test_finish_text_write_deferred_is_static_and_handles_null_connection() -> void:
 	## Under stress (many concurrent script_create + editor_reload_plugin
-	## mid-burst) the ScriptHandler RefCounted was being freed mid-await of
-	## _finish_create_script_deferred, producing "Resumed function ... after
-	## await, but class instance is gone" errors and dropping the response.
-	## The fix is to make the deferred completion a `static` function so the
-	## coroutine doesn't capture self.
+	## mid-burst) the handler RefCounted was being freed mid-await of the
+	## deferred completion, producing "Resumed function ... after await, but
+	## class instance is gone" errors and dropping the response. The fix is
+	## the deferred completion being a `static` function so the coroutine
+	## doesn't capture self — it lives on McpResourceIO since #714, shared
+	## by create_script and write_file's fresh-`.gd` path.
 	##
-	## Calling the function directly via the Script resource exercises both
-	## guarantees in one go: if the function isn't `static`, the parser
-	## rejects this call site ("Cannot call non-static function ... directly,
-	## make an instance instead") and the whole test file fails to load. If
-	## it IS static, the null-connection branch must bail without awaiting or
+	## Calling the function directly via the class exercises both guarantees
+	## in one go: if the function isn't `static`, the parser rejects this
+	## call site ("Cannot call non-static function ... directly, make an
+	## instance instead") and the whole test file fails to load. If it IS
+	## static, the null-connection branch must bail without awaiting or
 	## sending a deferred response — the safety net for teardown-time callers.
 	##
 	## The Python source-pin in tests/unit/test_script_create_import_settle.py
 	## also asserts the `static func` declaration at the source-text level.
-	var ScriptHandlerScript := preload("res://addons/godot_ai/handlers/script_handler.gd")
-	ScriptHandlerScript._finish_create_script_deferred(null, "req-x", "res://nope.gd", {})
+	McpResourceIO.finish_text_write_deferred(null, "req-x", "res://nope.gd", {})
 	assert_true(true, "Static call with null connection must not raise")
 
 

--- a/tests/unit/test_script_create_import_settle.py
+++ b/tests/unit/test_script_create_import_settle.py
@@ -1,13 +1,16 @@
 """Source-structure regression tests for the create_script -> attach_script
-import-settle fix (issue #261).
+import-settle fix (issue #261), extended to write_file's fresh-`.gd` path
+(#714).
 
-Without this guard, an agent that calls `script_create` followed immediately
-by `script_attach` for the same `.gd` file races the editor's filesystem
-scan: `ResourceLoader.exists(path)` can return false while Godot is still
-recognising the new resource. The fix is to defer the `script_create`
+Without this guard, an agent that calls `script_create` (or `write_file` on a
+`.gd` path) followed immediately by `script_attach` for the same file races
+the editor's filesystem scan: `ResourceLoader.exists(path)` can return false
+while Godot is still recognising the new resource. The fix is to defer the
 response until either the resource is visible or a bounded settle window
 elapses, so a successful response means an immediate `script_attach` will
-succeed.
+succeed. The shared machinery lives on McpResourceIO
+(`utils/resource_io.gd::finish_text_write_deferred`) so the two handlers
+can't drift apart.
 
 These tests pin the structure so a future refactor can't silently regress
 the guarantee.
@@ -21,14 +24,17 @@ from tests.unit._gdscript_text import get_func_block
 
 PLUGIN_ROOT = Path(__file__).resolve().parents[2] / "plugin" / "addons" / "godot_ai"
 SCRIPT_HANDLER = PLUGIN_ROOT / "handlers" / "script_handler.gd"
+FILESYSTEM_HANDLER = PLUGIN_ROOT / "handlers" / "filesystem_handler.gd"
+RESOURCE_IO = PLUGIN_ROOT / "utils" / "resource_io.gd"
 PLUGIN_GD = PLUGIN_ROOT / "plugin.gd"
 
 
-def test_script_handler_holds_connection_for_deferred_replies() -> None:
-    """ScriptHandler needs an McpConnection ref to push the deferred response."""
-    source = SCRIPT_HANDLER.read_text(encoding="utf-8")
+def test_handlers_hold_connection_for_deferred_replies() -> None:
+    """Both handlers need an McpConnection ref to push the deferred response."""
+    script_source = SCRIPT_HANDLER.read_text(encoding="utf-8")
+    fs_source = FILESYSTEM_HANDLER.read_text(encoding="utf-8")
 
-    assert "var _connection: McpConnection" in source, (
+    assert "var _connection: McpConnection" in script_source, (
         "ScriptHandler must hold an McpConnection so create_script can defer "
         "its reply until the editor's filesystem scan settles. Without this "
         "field a fresh script_create -> script_attach pair races the import "
@@ -37,48 +43,92 @@ def test_script_handler_holds_connection_for_deferred_replies() -> None:
     # _init must accept the connection. Default null keeps batch_execute and
     # unit-test contexts working on the synchronous fallback path.
     expected_init = "func _init(undo_redo: EditorUndoRedoManager, connection: McpConnection = null)"
-    assert expected_init in source, (
+    assert expected_init in script_source, (
         "ScriptHandler._init must accept the connection as an optional "
         "second parameter so test contexts can keep using the sync fallback."
     )
+    assert "var _connection: McpConnection" in fs_source, (
+        "FilesystemHandler must hold an McpConnection so write_file's "
+        "fresh-.gd path can defer its reply (#714)."
+    )
 
 
-def test_create_script_defers_for_freshly_created_files() -> None:
-    """The new-file path returns DEFERRED_RESPONSE; existing-file path replies sync."""
-    source = SCRIPT_HANDLER.read_text(encoding="utf-8")
+def test_fresh_writes_defer_and_overwrites_reply_sync() -> None:
+    """The new-file paths return DEFERRED_RESPONSE; existing-file paths reply sync."""
+    script_source = SCRIPT_HANDLER.read_text(encoding="utf-8")
+    fs_source = FILESYSTEM_HANDLER.read_text(encoding="utf-8")
 
     # The deferred handoff must be guarded by `not existed_before` so that
     # overwriting an already-known resource still returns immediately —
     # ResourceLoader already knows it, no scan to wait for.
-    assert "not existed_before and _connection != null and not request_id.is_empty()" in source, (
+    create_guard = "not existed_before and _connection != null and not request_id.is_empty()"
+    assert create_guard in script_source, (
         "create_script must only defer when the file was newly created AND a "
         "connection is available AND a request_id is present. Overwrites and "
         "batch_execute / unit-test contexts must keep the synchronous reply."
     )
-    assert "return McpDispatcher.DEFERRED_RESPONSE" in source, (
+    assert "return McpDispatcher.DEFERRED_RESPONSE" in script_source, (
         "create_script must return the DEFERRED_RESPONSE sentinel on the "
         "deferred path so the dispatcher skips auto-sending the reply."
     )
+    # write_file's deferral must additionally be scoped to .gd paths:
+    # ResourceLoader never learns plain text files, so an unconditional wait
+    # would burn the full settle window on every fresh .txt write (#714).
+    assert (
+        "is_gdscript and not existed_before and _connection != null and not request_id.is_empty()"
+        in fs_source
+    ), (
+        "write_file must only defer for freshly-created .gd files with a "
+        "connection and request_id present — plain text files and overwrites "
+        "keep the synchronous reply (#714)."
+    )
+    assert "return McpDispatcher.DEFERRED_RESPONSE" in fs_source, (
+        "write_file must return the DEFERRED_RESPONSE sentinel on the "
+        "deferred fresh-.gd path (#714)."
+    )
 
 
-def test_finish_create_script_deferred_polls_resourceloader_with_bounded_loop() -> None:
+def test_handlers_share_one_write_and_one_settle_implementation() -> None:
+    """#714: the write path and the settle coroutine must not be duplicated."""
+    script_source = SCRIPT_HANDLER.read_text(encoding="utf-8")
+    fs_source = FILESYSTEM_HANDLER.read_text(encoding="utf-8")
+
+    for name, source in (("create_script", script_source), ("write_file", fs_source)):
+        assert "McpResourceIO.write_text_to_disk(path, content)" in source, (
+            f"{name} must write through the shared "
+            "McpResourceIO.write_text_to_disk helper — a private copy is how "
+            "the two paths drifted apart before #714."
+        )
+        defer_call = "McpResourceIO.finish_text_write_deferred(_connection, request_id, path, data)"
+        assert defer_call in source, (
+            f"{name} must defer through the shared "
+            "McpResourceIO.finish_text_write_deferred coroutine, passing "
+            "_connection explicitly (no instance-state capture)."
+        )
+        assert "FileAccess.open(path, FileAccess.WRITE)" not in source, (
+            f"{name} must not keep a private text-write path alongside the "
+            "shared helper (#714)."
+        )
+
+
+def test_finish_text_write_deferred_polls_resourceloader_with_bounded_loop() -> None:
     """The settle loop must be bounded and check ResourceLoader.exists each frame."""
-    source = SCRIPT_HANDLER.read_text(encoding="utf-8")
+    source = RESOURCE_IO.read_text(encoding="utf-8")
 
     # The bounded counter prevents an indefinite hang if the editor's
     # filesystem pipeline never reports the new resource.
-    assert "_IMPORT_SETTLE_MAX_FRAMES" in source, (
+    assert "IMPORT_SETTLE_MAX_FRAMES" in source, (
         "The deferred loop must use a named bounded-frame constant so the "
         "wait can't run forever if the filesystem scan stalls."
     )
-    assert "_IMPORT_SETTLE_MAX_MSEC := 3500" in source, (
+    assert "IMPORT_SETTLE_MAX_MSEC := 3500" in source, (
         "The deferred loop must be capped well below the dispatcher's "
-        "create_script deferred timeout. If this window reaches the dispatcher "
-        "timeout, a committed file can still surface to callers as "
-        "DEFERRED_TIMEOUT."
+        "create_script/write_file deferred timeouts. If this window reaches "
+        "the dispatcher timeout, a committed file can still surface to "
+        "callers as DEFERRED_TIMEOUT."
     )
-    deferred_block = get_func_block(source, "static func _finish_create_script_deferred")
-    assert "var deadline_ms := Time.get_ticks_msec() + _IMPORT_SETTLE_MAX_MSEC" in deferred_block
+    deferred_block = get_func_block(source, "static func finish_text_write_deferred")
+    assert "var deadline_ms := Time.get_ticks_msec() + IMPORT_SETTLE_MAX_MSEC" in deferred_block
     assert "Time.get_ticks_msec() < deadline_ms" in deferred_block
     assert "ResourceLoader.exists(path)" in deferred_block, (
         "The deferred loop must poll ResourceLoader.exists(path) — that's "
@@ -90,7 +140,7 @@ def test_finish_create_script_deferred_polls_resourceloader_with_bounded_loop() 
         "editor can actually run the import pipeline between checks."
     )
     assert deferred_block.find(
-        "var deadline_ms := Time.get_ticks_msec() + _IMPORT_SETTLE_MAX_MSEC"
+        "var deadline_ms := Time.get_ticks_msec() + IMPORT_SETTLE_MAX_MSEC"
     ) < deferred_block.find("await tree.process_frame"), (
         "The deferred coroutine must start its deadline before the registration "
         "handoff await. Otherwise a slow first frame is outside the bounded "
@@ -104,25 +154,31 @@ def test_finish_create_script_deferred_polls_resourceloader_with_bounded_loop() 
     assert 'payload["import_settle"] = "settled" if settled else "timeout"' in deferred_block
     assert 'payload["import_pending"] = not settled' in deferred_block
     # Match the project_handler.stop_project pattern: drop the response if
-    # the plugin tore down during the await. The static refactor passes
-    # `connection` explicitly instead of relying on `self._connection`.
+    # the plugin tore down during the await. The static function takes
+    # `connection` explicitly instead of relying on instance state.
     assert "is_instance_valid(connection)" in deferred_block, (
         "If _exit_tree fires during the await the connection is freed; the "
         "deferred reply must check is_instance_valid and bail silently."
     )
 
 
-def test_create_script_reports_committed_status_even_when_import_wait_times_out() -> None:
+def test_writes_report_committed_status_even_when_import_wait_times_out() -> None:
     """A committed file must not be indistinguishable from a failed mutation."""
-    source = SCRIPT_HANDLER.read_text(encoding="utf-8")
+    script_source = SCRIPT_HANDLER.read_text(encoding="utf-8")
+    fs_source = FILESYSTEM_HANDLER.read_text(encoding="utf-8")
+    io_source = RESOURCE_IO.read_text(encoding="utf-8")
 
-    assert '"committed": true' in source, (
+    assert '"committed": true' in script_source, (
         "create_script writes the file before waiting for ResourceLoader; the "
         "response must expose committed=true so callers know retrying is not a "
         "plain safe retry."
     )
-    assert '"import_settle": "already_known" if existed_before else "not_waited"' in source
-    deferred_block = get_func_block(source, "static func _finish_create_script_deferred")
+    assert '"import_settle": "already_known" if existed_before else "not_waited"' in script_source
+    # write_file mirrors the same fields for .gd paths (#714).
+    assert 'data["committed"] = true' in fs_source
+    fs_settle_marker = 'data["import_settle"] = "already_known" if existed_before else "not_waited"'
+    assert fs_settle_marker in fs_source
+    deferred_block = get_func_block(io_source, "static func finish_text_write_deferred")
     assert 'payload["import_settle"] = "settled" if settled else "timeout"' in deferred_block, (
         "Deferred completion must distinguish import success from import-settle "
         "timeout while still returning a success payload for the committed file."
@@ -133,20 +189,19 @@ def test_create_script_reports_committed_status_even_when_import_wait_times_out(
     )
 
 
-def test_finish_create_script_deferred_is_static() -> None:
+def test_finish_text_write_deferred_is_static() -> None:
     """Source-pin: the deferred completion must be a `static func`.
 
     Under concurrent script_create storms (e.g. /tmp/shitstorm2.py) combined
-    with editor_reload_plugin firing during the burst, the ScriptHandler
-    RefCounted was being freed mid-await, producing "Resumed function
-    '_finish_create_script_deferred()' after await, but class instance is
-    gone" and dropping the deferred response. The fix is to declare the
-    coroutine `static` so it captures no `self` reference, surviving handler
-    GC. This source check prevents a silent revert.
+    with editor_reload_plugin firing during the burst, the handler RefCounted
+    was being freed mid-await, producing "Resumed function ... after await,
+    but class instance is gone" and dropping the deferred response. The fix
+    is to declare the coroutine `static` so it captures no `self` reference,
+    surviving handler GC. This source check prevents a silent revert.
     """
-    source = SCRIPT_HANDLER.read_text(encoding="utf-8")
-    assert "static func _finish_create_script_deferred(" in source, (
-        "_finish_create_script_deferred must be declared `static` so the "
+    source = RESOURCE_IO.read_text(encoding="utf-8")
+    assert "static func finish_text_write_deferred(" in source, (
+        "finish_text_write_deferred must be declared `static` so the "
         "deferred coroutine doesn't capture self. Without this, a handler "
         "freed mid-await produces 'class instance is gone' errors and drops "
         "the response."
@@ -157,20 +212,29 @@ def test_finish_create_script_deferred_is_static() -> None:
         "parameter — referencing self._connection would re-introduce the "
         "implicit `self` capture the static refactor avoids."
     )
-    # The caller in create_script must thread _connection through.
-    assert "_finish_create_script_deferred(_connection, request_id, path, data)" in source, (
-        "create_script must pass `_connection` explicitly to the static "
-        "deferred completion. A bare call with no args would silently "
-        "regress to depending on instance state."
+
+
+def test_dispatcher_grants_write_file_the_settle_timeout_headroom() -> None:
+    """write_file's deferral needs the same dispatcher headroom as create_script."""
+    dispatcher_source = (PLUGIN_ROOT / "dispatcher.gd").read_text(encoding="utf-8")
+    assert '"write_file": 4500' in dispatcher_source, (
+        "write_file defers through the 3500ms import-settle window (#714); "
+        "without a matching dispatcher timeout entry the default deferred "
+        "timeout applies and the headroom contract with "
+        "IMPORT_SETTLE_MAX_MSEC is implicit instead of pinned."
     )
 
 
-def test_plugin_gd_passes_connection_to_script_handler() -> None:
-    """plugin.gd must wire _connection into ScriptHandler — the field is null otherwise."""
+def test_plugin_gd_passes_connection_to_handlers() -> None:
+    """plugin.gd must wire _connection into both handlers — the field is null otherwise."""
     source = PLUGIN_GD.read_text(encoding="utf-8")
 
     assert "ScriptHandler.new(get_undo_redo(), _connection)" in source, (
         "plugin.gd must construct ScriptHandler with the connection so the "
         "deferred-reply path is reachable in production. Without this, every "
         "create_script falls back to the synchronous reply and #261 returns."
+    )
+    assert "FilesystemHandler.new(_connection)" in source, (
+        "plugin.gd must construct FilesystemHandler with the connection so "
+        "write_file's fresh-.gd deferral is reachable in production (#714)."
     )


### PR DESCRIPTION
Lands the remaining item on #714 (the coercion/validation items landed in the Phase-3 train, a479420/#724): extract a shared write-a-text-file helper so `write_file` stops skipping `create_script`'s import-settle path.

## What

- **`McpResourceIO.write_text_to_disk`** — the parent-mkdir + write/flush + explicit-error-check block that was duplicated across `create_script`, `write_file`, and the script-edit path now has one implementation.
- **`McpResourceIO.finish_text_write_deferred`** — `create_script`'s static deferred import-settle coroutine, moved verbatim (same #324 deadline-before-handoff ordering, same #261 `ResourceLoader.exists` poll, same static/no-self-capture guarantee) so both handlers share it.
- **`write_file` on a freshly-created `.gd`** now defers its reply until ResourceLoader can see the new resource or the bounded 3.5s window elapses — `write_file` → `script_attach` back-to-back can no longer 404 on the not-yet-imported script.

## ⚠️ Response-timing contract change

`write_file` for a **fresh `.gd` file** no longer replies immediately: the response arrives once the import settles (typically <100ms, worst case `IMPORT_SETTLE_MAX_MSEC` = 3.5s), carrying `committed` / `import_settled` / `import_settle` / `import_pending` fields exactly like `create_script`. Unchanged: overwrites (`already_known`), non-`.gd` writes (no settle contract — ResourceLoader never learns plain text files, so deferring would burn the full window on every fresh `.txt`), `batch_execute`, and connection-less contexts (`not_waited` sync fallback). `dispatcher.gd` grants `write_file` the same 4500ms deferred-timeout headroom as `create_script`.

The Python source-pin suite (`test_script_create_import_settle.py`) is retargeted at the shared implementation and extended: both handlers must use the shared write + settle helpers (no private `FileAccess.WRITE` copies), and `write_file`'s deferral guard must be scoped to fresh `.gd` + connection + request_id.

## Testing
- ruff + full pytest (1364 passed, includes the retargeted/extended pin suite): green
- `script/ci-check-gdscript`: green
- Live editor `test_run`: 61 suites, **1833 passed / 0 failed** (new: fresh-`.gd` settle fields, overwrite `already_known`, non-`.gd` has no settle contract, static null-connection safety net now on `McpResourceIO`)

Closes #714.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `.gd` file creation and writing so responses wait briefly for imports to settle when needed.
  - Added clearer status reporting for committed files and import readiness.
  - Standardized text-file write handling, including directory creation and write-error reporting.
  - Preserved immediate responses for overwrites and non-script files.

- **Tests**
  - Added coverage for fresh script writes, overwrites, import-settle timeouts, and connection teardown scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->