### PR TITLE
release.yml: fix embedded-PEM extraction in the signing self-check (#687)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,9 +198,22 @@ jobs:
           # Self-check against the public key EMBEDDED IN THE PLUGIN SOURCE,
           # not a key derived from the secret — a rotated/mismatched secret
           # must fail the release here, not in every user's editor at
-          # install time.
-          awk '/BEGIN PUBLIC KEY/,/END PUBLIC KEY/' \
-            plugin/addons/godot_ai/utils/update_manager.gd > embedded_public_key.pem
+          # install time. The BEGIN marker shares its source line with the
+          # GDScript const assignment (`const ... := """-----BEGIN...`), so
+          # strip everything before the marker or openssl refuses the file.
+          sed -n '/-----BEGIN PUBLIC KEY-----/,/-----END PUBLIC KEY-----/p' \
+            plugin/addons/godot_ai/utils/update_manager.gd \
+            | sed 's/^.*-----BEGIN PUBLIC KEY-----/-----BEGIN PUBLIC KEY-----/' \
+            > embedded_public_key.pem
+          # Guard the extraction itself: a refactor that moves/renames the
+          # const must fail here with a clear message, not as an opaque
+          # dgst error.
+          if ! openssl pkey -pubin -in embedded_public_key.pem -noout 2>/dev/null; then
+            echo "ERROR: could not extract a parseable public key PEM from" >&2
+            echo "plugin/addons/godot_ai/utils/update_manager.gd" >&2
+            echo "(RELEASE_SIGNING_PUBLIC_KEY_PEM const moved or reformatted?)" >&2
+            exit 1
+          fi
           openssl dgst -sha256 -verify embedded_public_key.pem \
             -signature godot-ai-plugin.zip.sha256.sig godot-ai-plugin.zip.sha256
           rm -f embedded_public_key.pem


### PR DESCRIPTION
Follow-up to #727, fixing the critical CodeRabbit finding: the `awk '/BEGIN PUBLIC KEY/,.../'` extraction includes the whole GDScript assignment line (`const RELEASE_SIGNING_PUBLIC_KEY_PEM := """-----BEGIN PUBLIC KEY-----`), so `embedded_public_key.pem` wasn't valid PEM and the release self-check would have failed every signing-era release. Fail-closed, but release-blocking.

Fix: `sed` range + a prefix strip on the BEGIN line, plus an `openssl pkey -pubin` guard so a future move/reformat of the const fails with a clear message instead of an opaque `dgst` error.

Verified locally end-to-end with the real signing key: sign the sidecar → extract from plugin source → `pkey` parse OK → `dgst -verify` → **Verified OK**. Also reproduced the pre-fix failure (`Could not find private key of public key`) against the merged awk output.

Workflow-only change; no plugin/server code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)