### PR TITLE
Typed Array[T] writes: Object elements (#612 stage 2)

### DIFF
--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -906,9 +906,12 @@ static func _coerce_value(value: Variant, target_type: int) -> Variant:
 ## `make(...)`-shaped error Dictionary (callers discriminate on
 ## `result is Dictionary` — a successful result is always an Array).
 ##
-## Object elements (Array[Texture2D], Array[MyResource], ...) are #612
-## stage 2 — refused loudly here rather than left to the generic
-## passthrough that silently dropped them.
+## Object elements (Array[Texture2D], Array[MyResource], ...) coerce per
+## element through `_coerce_object_element` (#612 stage 2), mirroring the
+## single-slot TYPE_OBJECT paths: res:// strings load, {"__class__": ...}
+## instantiates, and each landed element is conformance-checked against the
+## slot's element class/script so a wrong-class Resource errors naming the
+## index instead of being rejected wholesale by `assign`.
 static func _coerce_typed_array(value: Variant, slot_value: Array, prefix: String = "") -> Variant:
 	var elem_label := _typed_array_element_label(slot_value)
 	if not (value is Array):
@@ -920,31 +923,42 @@ static func _coerce_typed_array(value: Variant, slot_value: Array, prefix: Strin
 		)
 		return ErrorCodes.prefix_message(err, prefix)
 	var elem_type := slot_value.get_typed_builtin()
-	## An empty list has no elements to coerce, so it may clear the slot even
-	## when the element type is stage-2 territory (PR #682 review).
-	if elem_type == TYPE_OBJECT and not (value as Array).is_empty():
-		var obj_err := ErrorCodes.make(
-			ErrorCodes.WRONG_TYPE,
-			"Writing elements into a typed Array[%s] property is not supported yet (#612 stage 2 covers Object elements); assign the elements individually in the editor for now" % elem_label,
-		)
-		return ErrorCodes.prefix_message(obj_err, prefix)
 	var staging: Array = []
 	var in_list: Array = value
 	for i in in_list.size():
 		var elem_prefix := ("element %d" % i) if prefix.is_empty() else "%s element %d" % [prefix, i]
-		var coerced: Variant = _coerce_value(in_list[i], elem_type)
-		var elem_err := _check_coerced(coerced, elem_type, elem_prefix)
-		if elem_err != null:
-			return elem_err
-		if coerced == null:
-			## Prefix with `elem_prefix` (which already folds in `prefix`),
-			## not `prefix` again — the latter double-stamped the property
-			## context (PR #682 review).
-			var null_err := ErrorCodes.make(
-				ErrorCodes.WRONG_TYPE,
-				"cannot store null in Array[%s]" % elem_label,
-			)
-			return ErrorCodes.prefix_message(null_err, elem_prefix)
+		var coerced: Variant
+		if elem_type == TYPE_OBJECT:
+			coerced = _coerce_object_element(in_list[i], elem_prefix)
+			if coerced is Dictionary:
+				## Object elements are never legit Dictionaries (a dict input
+				## is either {"__class__"} — consumed above — or an error), so
+				## a Dictionary return is unambiguously the error envelope.
+				return coerced
+			if coerced != null and not _object_element_conforms(coerced, slot_value):
+				var conform_err := ErrorCodes.make(
+					ErrorCodes.WRONG_TYPE,
+					"element is %s, which is not a %s" % [
+						(coerced as Object).get_class(), elem_label,
+					],
+				)
+				return ErrorCodes.prefix_message(conform_err, elem_prefix)
+		else:
+			coerced = _coerce_value(in_list[i], elem_type)
+			var elem_err := _check_coerced(coerced, elem_type, elem_prefix)
+			if elem_err != null:
+				return elem_err
+			if coerced == null:
+				## Prefix with `elem_prefix` (which already folds in `prefix`),
+				## not `prefix` again — the latter double-stamped the property
+				## context (PR #682 review). Object arrays allow null entries
+				## (Godot typed object arrays store null); value-type arrays
+				## don't.
+				var null_err := ErrorCodes.make(
+					ErrorCodes.WRONG_TYPE,
+					"cannot store null in Array[%s]" % elem_label,
+				)
+				return ErrorCodes.prefix_message(null_err, elem_prefix)
 		staging.append(coerced)
 	var out := slot_value.duplicate()
 	out.clear()
@@ -973,6 +987,75 @@ static func _typed_array_element_label(slot_value: Array) -> String:
 			cls = String((script as Script).get_global_name())
 		return cls if not cls.is_empty() else "Object"
 	return type_string(slot_value.get_typed_builtin())
+
+
+## Coerce one element of an object-typed Array (#612 stage 2). Mirrors the
+## single-slot TYPE_OBJECT paths in set_property: a res:// path string loads
+## the Resource; {"__class__": "X", ...} (including the #206 stringified
+## form) instantiates via ResourceHandler and applies the remaining keys;
+## "" / null store a null entry (typed object arrays allow them). Returns
+## the Object (or null), or a make(...)-shaped error Dictionary with
+## `elem_prefix` already folded in.
+static func _coerce_object_element(elem: Variant, elem_prefix: String) -> Variant:
+	if elem == null:
+		return null
+	if elem is Object:
+		return elem
+	if elem is String and (elem as String).begins_with("{"):
+		var json := JSON.new()
+		if json.parse(elem) == OK and json.data is Dictionary and (json.data as Dictionary).has("__class__"):
+			elem = json.data
+	if elem is String:
+		if String(elem).is_empty():
+			return null
+		var path_err = McpPathValidator.loadable_error(elem, "value")
+		if path_err != null:
+			return ErrorCodes.prefix_message(path_err, elem_prefix)
+		if not ResourceLoader.exists(elem):
+			return ErrorCodes.prefix_message(
+				ErrorCodes.make(ErrorCodes.RESOURCE_NOT_FOUND, "Resource not found: %s" % elem),
+				elem_prefix,
+			)
+		var loaded := ResourceLoader.load(elem)
+		if loaded == null:
+			return ErrorCodes.prefix_message(
+				ErrorCodes.make(ErrorCodes.RESOURCE_NOT_FOUND, "Resource not found: %s" % elem),
+				elem_prefix,
+			)
+		return loaded
+	if elem is Dictionary and (elem as Dictionary).has("__class__"):
+		var type_str: String = (elem as Dictionary).get("__class__", "")
+		var made := ResourceHandler._instantiate_resource(type_str)
+		if made is Dictionary:
+			return ErrorCodes.prefix_message(made, elem_prefix)
+		var res: Resource = made
+		var remaining: Dictionary = (elem as Dictionary).duplicate()
+		remaining.erase("__class__")
+		if not remaining.is_empty():
+			var apply_err: Variant = ResourceHandler._apply_resource_properties(res, remaining)
+			if apply_err != null:
+				return ErrorCodes.prefix_message(apply_err, elem_prefix)
+		return res
+	return ErrorCodes.prefix_message(
+		ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
+			'cannot convert %s to an Object element; pass a res:// path or {"__class__": ...}'
+			% type_string(typeof(elem)),
+		),
+		elem_prefix,
+	)
+
+
+## True when `elem` satisfies the object-typed slot's element constraint —
+## script type when the slot is Array[MyScriptClass], native class
+## otherwise. Checked per element so a wrong-class Resource errors naming
+## the index instead of being rejected wholesale by `Array.assign()`.
+static func _object_element_conforms(elem: Object, slot_value: Array) -> bool:
+	var script: Variant = slot_value.get_typed_script()
+	if script is Script:
+		return is_instance_of(elem, script)
+	var cls := String(slot_value.get_typed_class_name())
+	return cls.is_empty() or elem.is_class(cls)
 
 
 func get_node_properties(params: Dictionary) -> Dictionary:

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -1936,6 +1936,7 @@ func _make_typed_array_probe(probe_name: String) -> Node:
 		"@export var colors: Array[Color] = []",
 		"@export var nested: Array[Array] = []",
 		"@export var textures: Array[Texture2D] = []",
+		"@export var meshes: Array[Mesh] = []",
 	])
 	script.reload()
 	node.set_script(script)
@@ -2100,18 +2101,132 @@ func test_set_property_typed_object_array_clears_with_empty_list() -> void:
 	_free_typed_array_probe(0)
 
 
-func test_set_property_typed_object_array_refuses_loudly() -> void:
-	## Object elements are #612 stage 2 — until then the write must REFUSE,
-	## not silently drop like the old generic passthrough did.
+# ----- set_property: object-element typed arrays (#612 stage 2) -----
+
+const _STAGE2_TEX_PATH := "res://tests/_mcp_stage2_texture.tres"
+
+
+## The test project ships no image assets, so stage-2 path-element tests
+## save (and afterwards remove) a real Texture2D .tres to load from.
+func _stage2_texture_path() -> String:
+	if not FileAccess.file_exists(_STAGE2_TEX_PATH):
+		var tex := GradientTexture2D.new()
+		assert_eq(ResourceSaver.save(tex, _STAGE2_TEX_PATH), OK,
+			"seed texture must save")
+	return _STAGE2_TEX_PATH
+
+
+func _cleanup_stage2_texture() -> void:
+	if FileAccess.file_exists(_STAGE2_TEX_PATH):
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(_STAGE2_TEX_PATH))
+		var efs := EditorInterface.get_resource_filesystem()
+		if efs != null:
+			efs.update_file(_STAGE2_TEX_PATH)
+
+
+func test_set_property_typed_object_array_loads_resource_paths() -> void:
+	## Stage 2 headline: res:// path elements load into Array[Texture2D] —
+	## previously refused loudly, before that silently dropped.
 	var node := _make_typed_array_probe("_McpTypedObjects")
 	var result := _handler.set_property({
 		"path": "/Main/_McpTypedObjects",
 		"property": "textures",
-		"value": ["res://icon.svg"],
+		"value": [_stage2_texture_path()],
+	})
+	assert_has_key(result, "data")
+	var stored: Variant = node.get("textures")
+	assert_eq((stored as Array).size(), 1, "the loaded element must land")
+	assert_true(stored[0] is Texture2D, "res:// element must load as Texture2D")
+	assert_true((stored as Array).is_typed(), "the slot must keep its typing")
+	_free_typed_array_probe(1)
+	_cleanup_stage2_texture()
+
+
+func test_set_property_typed_object_array_instantiates_class_dicts() -> void:
+	## {"__class__": ...} elements instantiate + apply remaining keys, the
+	## same shortcut single Object slots support.
+	var node := _make_typed_array_probe("_McpTypedObjMeshes")
+	var result := _handler.set_property({
+		"path": "/Main/_McpTypedObjMeshes",
+		"property": "meshes",
+		"value": [
+			{"__class__": "BoxMesh", "size": {"x": 2, "y": 2, "z": 2}},
+			{"__class__": "SphereMesh"},
+		],
+	})
+	assert_has_key(result, "data")
+	var stored: Variant = node.get("meshes")
+	assert_eq((stored as Array).size(), 2)
+	assert_true(stored[0] is BoxMesh, "__class__ element must instantiate")
+	assert_eq((stored[0] as BoxMesh).size, Vector3(2, 2, 2),
+		"remaining __class__ keys must apply as properties")
+	assert_true(stored[1] is SphereMesh)
+	_free_typed_array_probe(1)
+
+
+func test_set_property_typed_object_array_wrong_class_errors_names_index() -> void:
+	## A BoxMesh is a Resource but not a Texture2D — the conformance check
+	## must error naming the element index, not let assign() reject the
+	## whole write with a generic message (or worse, partially land it).
+	var node := _make_typed_array_probe("_McpTypedObjWrongClass")
+	var result := _handler.set_property({
+		"path": "/Main/_McpTypedObjWrongClass",
+		"property": "textures",
+		"value": [{"__class__": "BoxMesh"}],
 	})
 	assert_is_error(result, ErrorCodes.WRONG_TYPE)
-	assert_contains(result.error.message, "not supported yet",
-		"stage-2 deferral must be loud, not a silent drop")
+	assert_contains(result.error.message, "element 0",
+		"the error must name the offending element index")
+	assert_contains(result.error.message, "Texture2D",
+		"the error must name the expected element class")
+	assert_eq((node.get("textures") as Array).size(), 0, "slot must stay untouched on error")
+	_free_typed_array_probe(0)
+
+
+func test_set_property_typed_object_array_allows_null_entries() -> void:
+	## Godot's object-typed arrays store null entries; null and "" elements
+	## mirror the single-slot clear semantics instead of erroring.
+	var node := _make_typed_array_probe("_McpTypedObjNulls")
+	var result := _handler.set_property({
+		"path": "/Main/_McpTypedObjNulls",
+		"property": "textures",
+		"value": [null, _stage2_texture_path(), ""],
+	})
+	assert_has_key(result, "data")
+	var stored: Variant = node.get("textures")
+	assert_eq((stored as Array).size(), 3)
+	assert_eq(stored[0], null)
+	assert_true(stored[1] is Texture2D)
+	assert_eq(stored[2], null)
+	_free_typed_array_probe(1)
+	_cleanup_stage2_texture()
+
+
+func test_set_property_typed_object_array_missing_path_errors_names_index() -> void:
+	var node := _make_typed_array_probe("_McpTypedObjMissing")
+	var result := _handler.set_property({
+		"path": "/Main/_McpTypedObjMissing",
+		"property": "textures",
+		"value": [_stage2_texture_path(), "res://does_not_exist.png"],
+	})
+	assert_is_error(result, ErrorCodes.RESOURCE_NOT_FOUND)
+	assert_contains(result.error.message, "element 1",
+		"the error must name the offending element index")
+	assert_eq((node.get("textures") as Array).size(), 0, "slot must stay untouched on error")
+	_free_typed_array_probe(0)
+	_cleanup_stage2_texture()
+
+
+func test_set_property_typed_object_array_unconvertible_element_errors() -> void:
+	var node := _make_typed_array_probe("_McpTypedObjBad")
+	var result := _handler.set_property({
+		"path": "/Main/_McpTypedObjBad",
+		"property": "textures",
+		"value": [42],
+	})
+	assert_is_error(result, ErrorCodes.WRONG_TYPE)
+	assert_contains(result.error.message, "element 0",
+		"the error must name the offending element index")
 	assert_eq((node.get("textures") as Array).size(), 0)
 	_free_typed_array_probe(0)
 

--- a/test_project/tests/test_resource.gd
+++ b/test_project/tests/test_resource.gd
@@ -860,6 +860,7 @@ func _make_typed_array_resource() -> Resource:
 		"@export var items: Array[int] = []",
 		"@export var labels: Array[String] = []",
 		"@export var tints: Array[Color] = []",
+		"@export var textures: Array[Texture2D] = []",
 	])
 	script.reload()
 	return script.new()
@@ -901,6 +902,38 @@ func test_apply_resource_properties_typed_array_error_names_property_and_index()
 	assert_contains(err.error.message, "element 1",
 		"the error must name the offending element index")
 	assert_eq((res.get("items") as Array).size(), 0, "slot must stay untouched on error")
+
+
+func test_apply_resource_properties_fills_object_element_array() -> void:
+	## #612 stage 2 through the resource entry point — the custom-Resource
+	## Array[Texture2D] idiom the issue calls the dominant case. The test
+	## project ships no image assets, so stage a .tres texture to load from.
+	var tex_path := "res://tests/_mcp_stage2_res_texture.tres"
+	assert_eq(ResourceSaver.save(GradientTexture2D.new(), tex_path), OK,
+		"seed texture must save")
+	var res := _make_typed_array_resource()
+	var err: Variant = ResourceHandler._apply_resource_properties(res, {
+		"textures": [tex_path],
+	})
+	var stored: Variant = res.get("textures")
+	DirAccess.remove_absolute(ProjectSettings.globalize_path(tex_path))
+	var efs := EditorInterface.get_resource_filesystem()
+	if efs != null:
+		efs.update_file(tex_path)
+	assert_eq(err, null, "typed Array[Texture2D] write must succeed")
+	assert_eq((stored as Array).size(), 1)
+	assert_true(stored[0] is Texture2D, "res:// element must load as Texture2D")
+
+
+func test_apply_resource_properties_object_element_wrong_class_errors() -> void:
+	var res := _make_typed_array_resource()
+	var err: Variant = ResourceHandler._apply_resource_properties(res, {
+		"textures": [{"__class__": "BoxMesh"}],
+	})
+	assert_is_error(err, ErrorCodes.WRONG_TYPE)
+	assert_contains(err.error.message, "element 0",
+		"the error must name the offending element index")
+	assert_eq((res.get("textures") as Array).size(), 0, "slot must stay untouched on error")
 
 
 func test_apply_resource_properties_typed_array_rejects_non_list() -> void:


### PR DESCRIPTION
Stage 2 of #612 per the maintainer-endorsed staging (stage 1 = value elements, landed in #682): object-element typed arrays now fill from JSON lists instead of the loud stage-2 refusal.

## What

- `_coerce_typed_array` routes `TYPE_OBJECT` elements through a new `_coerce_object_element`, mirroring the single-slot TYPE_OBJECT paths exactly: `res://` strings path-validate + load (`RESOURCE_NOT_FOUND` on missing, error naming the element index), `{"__class__": ...}` — including the #206 stringified form — instantiates via `ResourceHandler._instantiate_resource` and applies remaining keys via `_apply_resource_properties`, and `null`/`""` store a null entry (Godot's object-typed arrays hold nulls; value-element arrays keep rejecting null).
- Per-element **conformance check** against the slot's element class/script (`_object_element_conforms`): a `BoxMesh` into `Array[Texture2D]` errors as `element 0 is BoxMesh, which is not a Texture2D` instead of `Array.assign()` rejecting wholesale. The stage-1 post-assign size backstop remains as the last-resort guard.
- Both entry points share the coercer (resource_handler already delegates), so `resource_create` on custom Resources — where `Array[Texture2D]`-style exports are the dominant idiom — gets stage 2 for free.
- Errors never partially write; the slot stays untouched.

## Testing
- Live editor `test_run`: 61 suites, all passed (new node-side coverage: res:// loads, `__class__` instantiation with property apply, wrong-class error naming index+class, null entries, missing-path error naming index, unconvertible element; new resource-side coverage: fill + wrong-class through `_apply_resource_properties`)
- `script/ci-check-gdscript`, ruff, full pytest: green

Stage 3 (typed `Dictionary[K,V]`) and the scripted-getter residual stay tracked on #612.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Typed object and resource arrays now support element-by-element conversion from resource paths, class dictionaries, and null values.
  * Resource properties can populate typed arrays with compatible saved resources.
  * Invalid elements report the specific array index and prevent partial updates.

* **Bug Fixes**
  * Improved validation for incorrect object types, missing resources, and unconvertible array elements.
  * Null values are now handled consistently in typed arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->