### PR TITLE
Add manual verify-signing workflow: e2e check of the signing secret (#687)

### DIFF
--- a/.github/workflows/verify-signing.yml
+++ b/.github/workflows/verify-signing.yml
@@ -1,0 +1,59 @@
+name: Verify signing secret
+
+# Manual end-to-end check of the release-signing chain (#687) WITHOUT cutting
+# a release: signs a synthetic payload with the RELEASE_SIGNING_KEY_PEM
+# secret and verifies it against the public key embedded in the plugin
+# source — the exact commands release.yml runs. Dispatch this after setting
+# or rotating the secret; a green run means the next tagged release will
+# sign successfully and ship updates the plugin can verify. Runs no build,
+# publishes nothing, needs no permissions.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  GODOT_AI_DISABLE_TELEMETRY: "true"
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Sign synthetic payload and verify against embedded public key
+        env:
+          RELEASE_SIGNING_KEY_PEM: ${{ secrets.RELEASE_SIGNING_KEY_PEM }}
+        run: |
+          if [ -z "$RELEASE_SIGNING_KEY_PEM" ]; then
+            echo "ERROR: RELEASE_SIGNING_KEY_PEM secret is not configured." >&2
+            exit 1
+          fi
+          key_file=$(mktemp)
+          printf '%s\n' "$RELEASE_SIGNING_KEY_PEM" > "$key_file"
+          # The secret must be a parseable private key on its own — catches
+          # missing BEGIN/END lines, truncation, or wrong-field paste errors.
+          if ! openssl pkey -in "$key_file" -noout 2>/dev/null; then
+            echo "ERROR: RELEASE_SIGNING_KEY_PEM does not parse as a private key." >&2
+            echo "It must be the COMPLETE PEM file, including the" >&2
+            echo "-----BEGIN/END PRIVATE KEY----- lines." >&2
+            rm -f "$key_file"
+            exit 1
+          fi
+          echo "synthetic release sidecar payload" > payload.txt
+          openssl dgst -sha256 -sign "$key_file" -out payload.sig payload.txt
+          rm -f "$key_file"
+          # Same extraction release.yml uses: the BEGIN marker shares its
+          # line with the GDScript const assignment, so strip the prefix.
+          sed -n '/-----BEGIN PUBLIC KEY-----/,/-----END PUBLIC KEY-----/p' \
+            plugin/addons/godot_ai/utils/update_manager.gd \
+            | sed 's/^.*-----BEGIN PUBLIC KEY-----/-----BEGIN PUBLIC KEY-----/' \
+            > embedded_public_key.pem
+          if ! openssl pkey -pubin -in embedded_public_key.pem -noout 2>/dev/null; then
+            echo "ERROR: could not extract a parseable public key from update_manager.gd" >&2
+            exit 1
+          fi
+          openssl dgst -sha256 -verify embedded_public_key.pem \
+            -signature payload.sig payload.txt
+          echo "OK: the stored secret signs payloads the plugin's embedded key verifies."

--- a/.github/workflows/verify-signing.yml
+++ b/.github/workflows/verify-signing.yml
@@ -21,6 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Defense-in-depth for a signing-adjacent workflow: don't leave the
+          # (read-only) GITHUB_TOKEN in .git/config.
+          persist-credentials: false
 
       - name: Sign synthetic payload and verify against embedded public key
         env:
@@ -31,6 +35,9 @@ jobs:
             exit 1
           fi
           key_file=$(mktemp)
+          # Guarantee key-material cleanup on every exit path, including the
+          # openssl failures below.
+          trap 'rm -f "$key_file"' EXIT
           printf '%s\n' "$RELEASE_SIGNING_KEY_PEM" > "$key_file"
           # The secret must be a parseable private key on its own — catches
           # missing BEGIN/END lines, truncation, or wrong-field paste errors.
@@ -38,7 +45,6 @@ jobs:
             echo "ERROR: RELEASE_SIGNING_KEY_PEM does not parse as a private key." >&2
             echo "It must be the COMPLETE PEM file, including the" >&2
             echo "-----BEGIN/END PRIVATE KEY----- lines." >&2
-            rm -f "$key_file"
             exit 1
           fi
           echo "synthetic release sidecar payload" > payload.txt


### PR DESCRIPTION
Closes the last untested link in the #687 signing chain: nothing had ever read the `RELEASE_SIGNING_KEY_PEM` secret **as stored in GitHub** (and it's been edited twice during setup). This adds a `workflow_dispatch`-only job that:

1. Parse-checks the secret as a private key (catches missing BEGIN/END lines, truncation, wrong-field paste),
2. Signs a synthetic payload with it,
3. Extracts the embedded public key from `update_manager.gd` (same fixed extraction as release.yml post-#732) and verifies the signature.

A green run proves the next tagged release will sign successfully and produce updates the plugin can verify — without cutting a release. Also the standing self-check for future key rotations.

Coverage context: local e2e already verified the on-disk key + workflow commands (`Verified OK`), and a headless Godot run confirmed the plugin's production `Crypto.verify` path accepts a real-key openssl signature and rejects tampered bytes. This workflow covers the one remaining variable: the secret value in Actions.

Workflow-only change; I'll dispatch it once merged and report the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a manually triggered validation workflow for release-signing configuration.
  * Verifies signing keys, signature generation, public-key extraction, and signature validation.
  * Reports clear failures when keys are missing, invalid, or unable to verify signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->