### PR TITLE
Typed Dictionary[K,V] writes (#612 stage 3)

### DIFF
--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -1149,7 +1149,7 @@ static func _coerce_typed_dictionary(
 			if coerced == null:
 				var null_err := ErrorCodes.make(
 					ErrorCodes.WRONG_TYPE,
-					"cannot store null as a %s value" % label,
+					"cannot store null as a %s value in %s" % [type_string(value_type), label],
 				)
 				return ErrorCodes.prefix_message(null_err, key_prefix)
 		out[key] = coerced
@@ -1186,7 +1186,15 @@ static func _coerce_typed_dict_key(
 			TYPE_FLOAT:
 				if key_str.is_valid_float():
 					return float(key_str)
-	elif raw_key is float and key_type == TYPE_INT and is_equal_approx(raw_key, roundf(raw_key)):
+		## String key that didn't parse: JSON object keys are ALWAYS strings,
+		## so blaming the String-ness would imply the caller could somehow
+		## send a non-string key — name the expected key type instead.
+		var parse_err := ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
+			"key does not parse as %s (the %s key type)" % [type_string(key_type), label],
+		)
+		return ErrorCodes.prefix_message(parse_err, key_prefix)
+	if raw_key is float and key_type == TYPE_INT and is_equal_approx(raw_key, roundf(raw_key)):
 		## Whole JSON numbers arrive as floats through some non-JSON callers.
 		return int(raw_key)
 	var err := ErrorCodes.make(

--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -261,6 +261,20 @@ func set_property(params: Dictionary) -> Dictionary:
 		if typed_out is Dictionary:
 			return typed_out
 		value = typed_out
+	elif (
+		target_type == TYPE_DICTIONARY
+		and old_value is Dictionary
+		and (old_value as Dictionary).is_typed()
+	):
+		## Typed Dictionary[K, V] slot (#612 stage 3) — same silent-drop
+		## family as typed arrays. A successful result is always a TYPED
+		## Dictionary (a cleared duplicate of the slot), while the error
+		## envelope is an untyped {"error": ...} — that's the discriminator
+		## (a legit payload could contain an "error" key; typedness can't lie).
+		var typed_dict_out: Dictionary = _coerce_typed_dictionary(value, old_value)
+		if not typed_dict_out.is_typed():
+			return typed_dict_out
+		value = typed_dict_out
 	else:
 		value = _coerce_value(value, target_type)
 		## Refuse any value that didn't land as the target compound Variant
@@ -981,11 +995,7 @@ static func _coerce_typed_array(value: Variant, slot_value: Array, prefix: Strin
 ## typed Array slot, for error messages.
 static func _typed_array_element_label(slot_value: Array) -> String:
 	if slot_value.get_typed_builtin() == TYPE_OBJECT:
-		var cls := String(slot_value.get_typed_class_name())
-		var script: Variant = slot_value.get_typed_script()
-		if script is Script and not String((script as Script).get_global_name()).is_empty():
-			cls = String((script as Script).get_global_name())
-		return cls if not cls.is_empty() else "Object"
+		return _object_type_label(slot_value.get_typed_class_name(), slot_value.get_typed_script())
 	return type_string(slot_value.get_typed_builtin())
 
 
@@ -1051,11 +1061,171 @@ static func _coerce_object_element(elem: Variant, elem_prefix: String) -> Varian
 ## otherwise. Checked per element so a wrong-class Resource errors naming
 ## the index instead of being rejected wholesale by `Array.assign()`.
 static func _object_element_conforms(elem: Object, slot_value: Array) -> bool:
-	var script: Variant = slot_value.get_typed_script()
+	return _object_conforms(elem, slot_value.get_typed_class_name(), slot_value.get_typed_script())
+
+
+## Shared class/script conformance predicate for typed Array elements and
+## typed Dictionary values (#612 stages 2–3).
+static func _object_conforms(elem: Object, cls_name: StringName, script: Variant) -> bool:
 	if script is Script:
 		return is_instance_of(elem, script)
-	var cls := String(slot_value.get_typed_class_name())
+	var cls := String(cls_name)
 	return cls.is_empty() or elem.is_class(cls)
+
+
+## Fill a typed `Dictionary[K, V]` slot from a JSON object (#612 stage 3).
+## `slot_value` is the property's current typed Dictionary — the getter
+## returns the (possibly empty) typed container carrying both constraint
+## sides. Keys coerce via `_coerce_typed_dict_key` (JSON object keys are
+## always Strings, so int/float/StringName key slots parse the string and
+## fail closed on anything inexact); values mirror the typed-array element
+## rules — object values through `_coerce_object_element` + conformance,
+## everything else through `_coerce_value`/`_check_coerced`. Never partial:
+## any bad key or value errors naming the key and nothing is written.
+##
+## Returns the filled TYPED Dictionary on success or an UNTYPED
+## `make(...)`-shaped error Dictionary — callers discriminate on
+## `is_typed()`, since a success result is always a duplicate of the typed
+## slot and error envelopes are plain dicts.
+static func _coerce_typed_dictionary(
+	value: Variant, slot_value: Dictionary, prefix: String = ""
+) -> Dictionary:
+	var label := _typed_dictionary_label(slot_value)
+	if not (value is Dictionary):
+		var err := ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
+			"Cannot write %s to a typed %s property; expected an object" % [
+				type_string(typeof(value)), label,
+			],
+		)
+		return ErrorCodes.prefix_message(err, prefix)
+	var key_type := slot_value.get_typed_key_builtin() if slot_value.is_typed_key() else TYPE_NIL
+	var value_type := (
+		slot_value.get_typed_value_builtin() if slot_value.is_typed_value() else TYPE_NIL
+	)
+	var out := slot_value.duplicate()
+	out.clear()
+	var in_dict: Dictionary = value
+	for raw_key in in_dict.keys():
+		var key_prefix := (
+			'key "%s"' % str(raw_key) if prefix.is_empty()
+			else '%s key "%s"' % [prefix, str(raw_key)]
+		)
+		var key: Variant = _coerce_typed_dict_key(raw_key, key_type, label, key_prefix)
+		if key is Dictionary:
+			## Scalar-only key coercion never returns a legit Dictionary key,
+			## so a Dictionary here is unambiguously the error envelope.
+			return key
+		var raw_value: Variant = in_dict[raw_key]
+		var coerced: Variant
+		if value_type == TYPE_NIL:
+			## Untyped value side (e.g. Dictionary[String, Variant]).
+			coerced = raw_value
+		elif value_type == TYPE_OBJECT:
+			coerced = _coerce_object_element(raw_value, key_prefix)
+			if coerced is Dictionary:
+				return coerced
+			if coerced != null and not _object_conforms(
+				coerced,
+				slot_value.get_typed_value_class_name(),
+				slot_value.get_typed_value_script(),
+			):
+				var conform_err := ErrorCodes.make(
+					ErrorCodes.WRONG_TYPE,
+					"value is %s, which is not a %s" % [
+						(coerced as Object).get_class(),
+						_object_type_label(
+							slot_value.get_typed_value_class_name(),
+							slot_value.get_typed_value_script(),
+						),
+					],
+				)
+				return ErrorCodes.prefix_message(conform_err, key_prefix)
+		else:
+			coerced = _coerce_value(raw_value, value_type)
+			var value_err := _check_coerced(coerced, value_type, key_prefix)
+			if value_err != null:
+				return value_err
+			if coerced == null:
+				var null_err := ErrorCodes.make(
+					ErrorCodes.WRONG_TYPE,
+					"cannot store null as a %s value" % label,
+				)
+				return ErrorCodes.prefix_message(null_err, key_prefix)
+		out[key] = coerced
+	if out.size() != in_dict.size():
+		## Two input keys collapsing onto one coerced key ("1" and "01" both
+		## parse to int 1) would silently lose an entry — refuse instead.
+		var collide_err := ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
+			"%s keys collide after coercion (%d of %d entries landed)" % [
+				label, out.size(), in_dict.size(),
+			],
+		)
+		return ErrorCodes.prefix_message(collide_err, prefix)
+	return out
+
+
+## Coerce one JSON-object key onto a typed Dictionary's key slot. JSON keys
+## are always Strings, so int/float/StringName key types accept exactly the
+## strings that parse cleanly; everything else fails closed naming the key.
+## Object/compound key types are unreachable from JSON and refuse loudly.
+static func _coerce_typed_dict_key(
+	raw_key: Variant, key_type: int, label: String, key_prefix: String
+) -> Variant:
+	if key_type == TYPE_NIL or typeof(raw_key) == key_type:
+		return raw_key
+	if raw_key is String:
+		var key_str := raw_key as String
+		match key_type:
+			TYPE_STRING_NAME:
+				return StringName(key_str)
+			TYPE_INT:
+				if key_str.is_valid_int():
+					return int(key_str)
+			TYPE_FLOAT:
+				if key_str.is_valid_float():
+					return float(key_str)
+	elif raw_key is float and key_type == TYPE_INT and is_equal_approx(raw_key, roundf(raw_key)):
+		## Whole JSON numbers arrive as floats through some non-JSON callers.
+		return int(raw_key)
+	var err := ErrorCodes.make(
+		ErrorCodes.WRONG_TYPE,
+		"cannot use %s as a %s key" % [type_string(typeof(raw_key)), label],
+	)
+	return ErrorCodes.prefix_message(err, key_prefix)
+
+
+## "Dictionary[String, int]" / "Dictionary[int, Texture2D]" — for error
+## messages. Untyped sides read as Variant.
+static func _typed_dictionary_label(slot_value: Dictionary) -> String:
+	var key_label := "Variant"
+	if slot_value.is_typed_key():
+		key_label = (
+			_object_type_label(
+				slot_value.get_typed_key_class_name(), slot_value.get_typed_key_script()
+			)
+			if slot_value.get_typed_key_builtin() == TYPE_OBJECT
+			else type_string(slot_value.get_typed_key_builtin())
+		)
+	var value_label := "Variant"
+	if slot_value.is_typed_value():
+		value_label = (
+			_object_type_label(
+				slot_value.get_typed_value_class_name(), slot_value.get_typed_value_script()
+			)
+			if slot_value.get_typed_value_builtin() == TYPE_OBJECT
+			else type_string(slot_value.get_typed_value_builtin())
+		)
+	return "Dictionary[%s, %s]" % [key_label, value_label]
+
+
+## Class/script display name for an object-typed constraint side.
+static func _object_type_label(cls_name: StringName, script: Variant) -> String:
+	var cls := String(cls_name)
+	if script is Script and not String((script as Script).get_global_name()).is_empty():
+		cls = String((script as Script).get_global_name())
+	return cls if not cls.is_empty() else "Object"
 
 
 func get_node_properties(params: Dictionary) -> Dictionary:

--- a/plugin/addons/godot_ai/handlers/resource_handler.gd
+++ b/plugin/addons/godot_ai/handlers/resource_handler.gd
@@ -382,6 +382,19 @@ static func _apply_resource_properties(res: Resource, properties: Dictionary, de
 				if typed_out is Dictionary:
 					return typed_out
 				v = typed_out
+			elif (
+				target_type == TYPE_DICTIONARY
+				and slot_value is Dictionary
+				and (slot_value as Dictionary).is_typed()
+			):
+				## Typed Dictionary[K, V] slot (#612 stage 3): success is a
+				## typed duplicate of the slot; the error envelope is untyped.
+				var typed_dict_out: Dictionary = NodeHandler._coerce_typed_dictionary(
+					v, slot_value, "Property '%s'" % key
+				)
+				if not typed_dict_out.is_typed():
+					return typed_dict_out
+				v = typed_dict_out
 			else:
 				v = NodeHandler._coerce_value(v, target_type)
 				## Mirror set_property's coerce check: wrong-shape dicts (#123) and

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -1937,6 +1937,9 @@ func _make_typed_array_probe(probe_name: String) -> Node:
 		"@export var nested: Array[Array] = []",
 		"@export var textures: Array[Texture2D] = []",
 		"@export var meshes: Array[Mesh] = []",
+		"@export var scores: Dictionary[String, int] = {}",
+		"@export var by_id: Dictionary[int, String] = {}",
+		"@export var mesh_map: Dictionary[String, Mesh] = {}",
 	])
 	script.reload()
 	node.set_script(script)
@@ -2229,6 +2232,180 @@ func test_set_property_typed_object_array_unconvertible_element_errors() -> void
 		"the error must name the offending element index")
 	assert_eq((node.get("textures") as Array).size(), 0)
 	_free_typed_array_probe(0)
+
+
+# ----- set_property: typed Dictionary[K, V] slots (#612 stage 3) -----
+
+func test_set_property_typed_dictionary_roundtrip() -> void:
+	## The Dictionary half of the #612 repro: {"a": 1} into a
+	## Dictionary[String, int] slot used to be silently dropped.
+	var node := _make_typed_array_probe("_McpTypedDict")
+	var result := _handler.set_property({
+		"path": "/Main/_McpTypedDict",
+		"property": "scores",
+		"value": {"a": 1, "b": 2},
+	})
+	assert_has_key(result, "data")
+	var stored: Variant = node.get("scores")
+	assert_true(stored is Dictionary, "scores must read back as a Dictionary")
+	assert_eq((stored as Dictionary).size(), 2, "all entries must land — no silent drop")
+	assert_eq(stored["a"], 1)
+	assert_eq(stored["b"], 2)
+	assert_true((stored as Dictionary).is_typed(), "the slot must keep its typing")
+	_free_typed_array_probe(1)
+
+
+func test_set_property_typed_dictionary_coerces_int_keys() -> void:
+	## JSON object keys are always strings; a Dictionary[int, V] slot must
+	## parse exact int strings and store real int keys.
+	var node := _make_typed_array_probe("_McpTypedDictIntKeys")
+	var result := _handler.set_property({
+		"path": "/Main/_McpTypedDictIntKeys",
+		"property": "by_id",
+		"value": {"3": "three", "7": "seven"},
+	})
+	assert_has_key(result, "data")
+	var stored: Variant = node.get("by_id")
+	assert_eq((stored as Dictionary).size(), 2)
+	assert_true((stored as Dictionary).has(3), "key must land as int 3, not String")
+	assert_eq(stored[7], "seven")
+	_free_typed_array_probe(1)
+
+
+func test_set_property_typed_dictionary_bad_int_key_errors() -> void:
+	var node := _make_typed_array_probe("_McpTypedDictBadKey")
+	var result := _handler.set_property({
+		"path": "/Main/_McpTypedDictBadKey",
+		"property": "by_id",
+		"value": {"3": "ok", "abc": "nope"},
+	})
+	assert_is_error(result, ErrorCodes.WRONG_TYPE)
+	assert_contains(result.error.message, 'key "abc"',
+		"the error must name the offending key")
+	assert_eq((node.get("by_id") as Dictionary).size(), 0, "nothing may be written on error")
+	_free_typed_array_probe(0)
+
+
+func test_set_property_typed_dictionary_colliding_keys_error() -> void:
+	## "1" and "01" both coerce to int 1 — landing one of them silently
+	## would be the exact data-loss shape this issue exists to kill.
+	var node := _make_typed_array_probe("_McpTypedDictCollide")
+	var result := _handler.set_property({
+		"path": "/Main/_McpTypedDictCollide",
+		"property": "by_id",
+		"value": {"1": "a", "01": "b"},
+	})
+	assert_is_error(result, ErrorCodes.WRONG_TYPE)
+	assert_contains(result.error.message, "collide",
+		"key collisions after coercion must refuse, not drop an entry")
+	assert_eq((node.get("by_id") as Dictionary).size(), 0)
+	_free_typed_array_probe(0)
+
+
+func test_set_property_typed_dictionary_wrong_value_errors_names_key() -> void:
+	var node := _make_typed_array_probe("_McpTypedDictBadValue")
+	var result := _handler.set_property({
+		"path": "/Main/_McpTypedDictBadValue",
+		"property": "scores",
+		"value": {"a": 1, "b": "two"},
+	})
+	assert_is_error(result, ErrorCodes.WRONG_TYPE)
+	assert_contains(result.error.message, 'key "b"',
+		"the error must name the offending key")
+	assert_eq((node.get("scores") as Dictionary).size(), 0, "slot must stay untouched on error")
+	_free_typed_array_probe(0)
+
+
+func test_set_property_typed_dictionary_object_values() -> void:
+	## Object values take the stage-2 element coercion: __class__ dicts
+	## instantiate, and wrong-class values error naming the key.
+	var node := _make_typed_array_probe("_McpTypedDictObjVals")
+	var result := _handler.set_property({
+		"path": "/Main/_McpTypedDictObjVals",
+		"property": "mesh_map",
+		"value": {"box": {"__class__": "BoxMesh", "size": {"x": 2, "y": 2, "z": 2}}},
+	})
+	assert_has_key(result, "data")
+	var stored: Variant = node.get("mesh_map")
+	assert_eq((stored as Dictionary).size(), 1)
+	assert_true(stored["box"] is BoxMesh, "__class__ value must instantiate")
+	assert_eq((stored["box"] as BoxMesh).size, Vector3(2, 2, 2))
+	_free_typed_array_probe(1)
+
+
+func test_set_property_typed_dictionary_wrong_class_value_errors() -> void:
+	var node := _make_typed_array_probe("_McpTypedDictWrongClass")
+	var result := _handler.set_property({
+		"path": "/Main/_McpTypedDictWrongClass",
+		"property": "mesh_map",
+		"value": {"tex": {"__class__": "GradientTexture2D"}},
+	})
+	assert_is_error(result, ErrorCodes.WRONG_TYPE)
+	assert_contains(result.error.message, 'key "tex"',
+		"the error must name the offending key")
+	assert_contains(result.error.message, "Mesh",
+		"the error must name the expected value class")
+	assert_eq((node.get("mesh_map") as Dictionary).size(), 0)
+	_free_typed_array_probe(0)
+
+
+func test_set_property_typed_dictionary_null_object_value_allowed() -> void:
+	var node := _make_typed_array_probe("_McpTypedDictNullObj")
+	var result := _handler.set_property({
+		"path": "/Main/_McpTypedDictNullObj",
+		"property": "mesh_map",
+		"value": {"empty": null},
+	})
+	assert_has_key(result, "data")
+	var stored: Variant = node.get("mesh_map")
+	assert_eq((stored as Dictionary).size(), 1)
+	assert_eq(stored["empty"], null)
+	_free_typed_array_probe(1)
+
+
+func test_set_property_typed_dictionary_null_scalar_value_errors() -> void:
+	var node := _make_typed_array_probe("_McpTypedDictNullScalar")
+	var result := _handler.set_property({
+		"path": "/Main/_McpTypedDictNullScalar",
+		"property": "scores",
+		"value": {"a": null},
+	})
+	assert_is_error(result, ErrorCodes.WRONG_TYPE)
+	assert_contains(result.error.message, 'key "a"',
+		"the error must name the offending key")
+	assert_eq((node.get("scores") as Dictionary).size(), 0)
+	_free_typed_array_probe(0)
+
+
+func test_set_property_typed_dictionary_non_object_value_errors() -> void:
+	var node := _make_typed_array_probe("_McpTypedDictNonObj")
+	var result := _handler.set_property({
+		"path": "/Main/_McpTypedDictNonObj",
+		"property": "scores",
+		"value": [1, 2],
+	})
+	assert_is_error(result, ErrorCodes.WRONG_TYPE)
+	assert_contains(result.error.message, "Dictionary[String, int]",
+		"the error must name the typed slot")
+	assert_eq((node.get("scores") as Dictionary).size(), 0)
+	_free_typed_array_probe(0)
+
+
+func test_set_property_typed_dictionary_undo_restores_previous_value() -> void:
+	var node := _make_typed_array_probe("_McpTypedDictUndo")
+	var first := _handler.set_property({
+		"path": "/Main/_McpTypedDictUndo", "property": "scores", "value": {"a": 7},
+	})
+	assert_has_key(first, "data")
+	var second := _handler.set_property({
+		"path": "/Main/_McpTypedDictUndo", "property": "scores", "value": {"b": 8},
+	})
+	assert_has_key(second, "data")
+	assert_true(editor_undo(_undo_redo), "undo second set should succeed")
+	var stored: Variant = node.get("scores")
+	assert_eq((stored as Dictionary).size(), 1, "undo must restore the previous dictionary")
+	assert_eq(stored["a"], 7)
+	_free_typed_array_probe(1)
 
 
 func test_set_property_typed_array_undo_restores_previous_value() -> void:

--- a/test_project/tests/test_resource.gd
+++ b/test_project/tests/test_resource.gd
@@ -861,6 +861,7 @@ func _make_typed_array_resource() -> Resource:
 		"@export var labels: Array[String] = []",
 		"@export var tints: Array[Color] = []",
 		"@export var textures: Array[Texture2D] = []",
+		"@export var scores: Dictionary[String, int] = {}",
 	])
 	script.reload()
 	return script.new()
@@ -934,6 +935,28 @@ func test_apply_resource_properties_object_element_wrong_class_errors() -> void:
 	assert_contains(err.error.message, "element 0",
 		"the error must name the offending element index")
 	assert_eq((res.get("textures") as Array).size(), 0, "slot must stay untouched on error")
+
+
+func test_apply_resource_properties_fills_typed_dictionary() -> void:
+	## #612 stage 3 through the resource entry point.
+	var res := _make_typed_array_resource()
+	var err: Variant = ResourceHandler._apply_resource_properties(res, {"scores": {"a": 1}})
+	assert_eq(err, null, "typed Dictionary[String, int] write must succeed")
+	var stored: Variant = res.get("scores")
+	assert_eq((stored as Dictionary).size(), 1)
+	assert_eq(stored["a"], 1)
+	assert_true((stored as Dictionary).is_typed(), "the slot must keep its typing")
+
+
+func test_apply_resource_properties_typed_dictionary_error_names_property_and_key() -> void:
+	var res := _make_typed_array_resource()
+	var err: Variant = ResourceHandler._apply_resource_properties(res, {"scores": {"a": "one"}})
+	assert_is_error(err, ErrorCodes.WRONG_TYPE)
+	assert_contains(err.error.message, "Property 'scores'",
+		"the error must name the property")
+	assert_contains(err.error.message, 'key "a"',
+		"the error must name the offending key")
+	assert_eq((res.get("scores") as Dictionary).size(), 0, "slot must stay untouched on error")
 
 
 func test_apply_resource_properties_typed_array_rejects_non_list() -> void:


### PR DESCRIPTION
Final stage of #612 (stage 1 value-element arrays: #682; stage 2 Object elements: #733): typed `Dictionary[K,V]` slots now fill from JSON objects instead of silently staying at their empty default with success reported.

## What

- **`_coerce_typed_dictionary`** mirrors the typed-array coercer. A successful result is always a **typed** duplicate of the slot and the error envelope is an untyped dict, so callers discriminate on `is_typed()` — a payload can't fake that (a legitimate typed dict could contain an `"error"` key, typedness can't lie).
- **Key coercion** settles the JSON-string-keys design question fail-closed: JSON object keys are always Strings, so `int`/`float`/`StringName` key slots accept exactly the strings that parse cleanly (`"3"` → `3`); anything inexact errors naming the key. Keys that **collide after coercion** (`"1"` and `"01"` both → `1`) refuse rather than silently dropping an entry.
- **Values** reuse the existing machinery: object values through stage 2's `_coerce_object_element` + class/script conformance (wrong-class errors name the key and expected class; null allowed for object values, rejected for scalars), scalars through `_coerce_value`/`_check_coerced`.
- Both entry points get the dispatch (`node_set_property` + `resource_create`/`_apply_resource_properties`); untyped `Dictionary` slots keep the existing passthrough. Errors never partially write.

## Testing
- Live editor `test_run`: full pass across all suites (new coverage: String/int-key roundtrips, int-key coercion, bad-key + collision + wrong-value + wrong-class + null-scalar refusals all naming the key, object-value instantiation, undo restore; resource-side fill + error). One unrelated `camera` viewport-timing flake appeared under full-suite load and passes in isolation and on re-run.
- `script/ci-check-gdscript`, ruff, full pytest (1364): green

This completes the #612 coercion plan. Remaining on the issue after this merges: only the scripted-getter untyped-copy residual (documented there) — I'll leave the close call on that to the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for editing and applying typed dictionaries in properties and resources.
  * Automatically converts compatible JSON string keys to typed dictionary keys.
  * Preserves dictionary typing during successful updates.

* **Bug Fixes**
  * Improved validation and error messages for invalid keys, values, object types, nulls, and key collisions.
  * Prevents partially applied changes when typed dictionary conversion fails.
  * Ensures undo correctly restores previous typed dictionary values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->