### PR TITLE
Embed and preserve resource uids on MCP-written scenes/resources

### DIFF
--- a/plugin/addons/godot_ai/handlers/scene_handler.gd
+++ b/plugin/addons/godot_ai/handlers/scene_handler.gd
@@ -130,8 +130,9 @@ func create_scene(params: Dictionary) -> Dictionary:
 		_connection.pause_processing = true
 	var err := ResourceSaver.save(packed, path)
 	if err == OK:
-		McpResourceIO.ensure_uid(path, prior_uid)
-	EditorInterface.open_scene_from_path(path)
+		err = McpResourceIO.ensure_uid(path, prior_uid)
+	if err == OK:
+		EditorInterface.open_scene_from_path(path)
 	if _connection:
 		_connection.pause_processing = false
 

--- a/plugin/addons/godot_ai/handlers/scene_handler.gd
+++ b/plugin/addons/godot_ai/handlers/scene_handler.gd
@@ -122,9 +122,15 @@ func create_scene(params: Dictionary) -> Dictionary:
 	packed.pack(root)
 	root.free()
 
+	# Captured BEFORE the save below overwrites the file — see
+	# McpResourceIO.ensure_uid's doc comment.
+	var prior_uid := ResourceLoader.get_resource_uid(path) if FileAccess.file_exists(path) else ResourceUID.INVALID_ID
+
 	if _connection:
 		_connection.pause_processing = true
 	var err := ResourceSaver.save(packed, path)
+	if err == OK:
+		McpResourceIO.ensure_uid(path, prior_uid)
 	EditorInterface.open_scene_from_path(path)
 	if _connection:
 		_connection.pause_processing = false

--- a/plugin/addons/godot_ai/handlers/scene_handler.gd
+++ b/plugin/addons/godot_ai/handlers/scene_handler.gd
@@ -118,19 +118,9 @@ func create_scene(params: Dictionary) -> Dictionary:
 		root_name = path.get_file().get_basename()
 	root.name = root_name
 
-	var packed := PackedScene.new()
-	packed.pack(root)
-	root.free()
-
-	# Captured BEFORE the save below overwrites the file — see
-	# McpResourceIO.ensure_uid's doc comment.
-	var prior_uid := ResourceLoader.get_resource_uid(path) if FileAccess.file_exists(path) else ResourceUID.INVALID_ID
-
 	if _connection:
 		_connection.pause_processing = true
-	var err := ResourceSaver.save(packed, path)
-	if err == OK:
-		err = McpResourceIO.ensure_uid(path, prior_uid)
+	var err := _pack_and_save_with_uid(root, path)
 	if err == OK:
 		EditorInterface.open_scene_from_path(path)
 	if _connection:
@@ -148,6 +138,29 @@ func create_scene(params: Dictionary) -> Dictionary:
 			"reason": "Scene creation involves file system operations",
 		}
 	}
+
+
+## Pack `root` and save it to `path`, embedding a fresh uid or preserving the
+## one `path` already had — the exact save sequence `create_scene` runs,
+## minus the `pause_processing` guard (the caller owns that, since it also
+## needs to bracket `open_scene_from_path`) and minus opening the scene
+## (switching the editor's active scene isn't safe inside the shared test
+## runner, so tests call this directly instead of going through
+## `create_scene` end-to-end). Frees `root`. Returns `OK`, or the first
+## `Error` encountered.
+func _pack_and_save_with_uid(root: Node, path: String) -> Error:
+	var packed := PackedScene.new()
+	packed.pack(root)
+	root.free()
+
+	# Captured BEFORE the save below overwrites the file — see
+	# McpResourceIO.ensure_uid's doc comment.
+	var prior_uid := ResourceLoader.get_resource_uid(path) if FileAccess.file_exists(path) else ResourceUID.INVALID_ID
+
+	var err := ResourceSaver.save(packed, path)
+	if err == OK:
+		err = McpResourceIO.ensure_uid(path, prior_uid)
+	return err
 
 
 ## How long open_scene waits for the editor to actually switch to the

--- a/plugin/addons/godot_ai/utils/resource_io.gd
+++ b/plugin/addons/godot_ai/utils/resource_io.gd
@@ -95,6 +95,10 @@ static func save_to_disk(
 			ErrorCodes.INVALID_PARAMS,
 			"%s already exists at %s (pass overwrite=true to replace)" % [label, resource_path]
 		)
+	# Captured BEFORE the overwrite below so a resave of an already-uid'd file
+	# (overwrite=true) can restore its own uid instead of losing it — see
+	# ensure_uid's doc comment.
+	var prior_uid := ResourceLoader.get_resource_uid(resource_path) if existed_before else ResourceUID.INVALID_ID
 
 	var dir_path := resource_path.get_base_dir()
 	var mkdir_err := DirAccess.make_dir_recursive_absolute(dir_path)
@@ -114,6 +118,7 @@ static func save_to_disk(
 			ErrorCodes.INTERNAL_ERROR,
 			"Failed to save %s to %s: %s" % [label, resource_path, error_string(save_err)]
 		)
+	ensure_uid(resource_path, prior_uid)
 
 	var efs := EditorInterface.get_resource_filesystem()
 	if efs != null:
@@ -140,12 +145,34 @@ static func save_to_disk(
 ## `apply_to_node`'s inline-then-save branch). Returns the raw
 ## `ResourceSaver.save` error code.
 static func guarded_save(res: Resource, resource_path: String, pause_target: McpConnection) -> int:
+	var prior_uid := ResourceLoader.get_resource_uid(resource_path) if FileAccess.file_exists(resource_path) else ResourceUID.INVALID_ID
 	if pause_target != null:
 		pause_target.pause_processing = true
 	var save_err := ResourceSaver.save(res, resource_path)
 	if pause_target != null:
 		pause_target.pause_processing = false
+	if save_err == OK:
+		ensure_uid(resource_path, prior_uid)
 	return save_err
+
+
+## Make `resource_path` carry a stable uid after a successful
+## `ResourceSaver.save()`, matching what Godot's own "New Scene"/"New
+## Resource" editor flows always embed. A bare `ResourceSaver.save()` call
+## does neither on its own: a brand-new file gets no `uid=` at all, and
+## resaving a file that already had one silently drops it (#737). Call this
+## immediately after every successful save.
+##
+## `prior_uid` is whatever `ResourceLoader.get_resource_uid(resource_path)`
+## returned BEFORE this save overwrote the file (pass `ResourceUID.INVALID_ID`
+## for a brand-new path). Reusing the prior id — instead of always minting a
+## fresh one — keeps any `uid://...` references elsewhere in the project
+## resolving to the same file.
+static func ensure_uid(resource_path: String, prior_uid: int) -> void:
+	var id := prior_uid
+	if id == ResourceUID.INVALID_ID:
+		id = ResourceUID.create_id()
+	ResourceSaver.set_uid(resource_path, id)
 
 
 ## Attach a `cleanup.rm` hint listing `paths` to `data` — only when the call

--- a/plugin/addons/godot_ai/utils/resource_io.gd
+++ b/plugin/addons/godot_ai/utils/resource_io.gd
@@ -118,7 +118,12 @@ static func save_to_disk(
 			ErrorCodes.INTERNAL_ERROR,
 			"Failed to save %s to %s: %s" % [label, resource_path, error_string(save_err)]
 		)
-	ensure_uid(resource_path, prior_uid)
+	var uid_err := ensure_uid(resource_path, prior_uid)
+	if uid_err != OK:
+		return ErrorCodes.make(
+			ErrorCodes.INTERNAL_ERROR,
+			"%s saved to %s but failed to write its uid: %s" % [label, resource_path, error_string(uid_err)]
+		)
 
 	var efs := EditorInterface.get_resource_filesystem()
 	if efs != null:
@@ -151,9 +156,9 @@ static func guarded_save(res: Resource, resource_path: String, pause_target: Mcp
 	var save_err := ResourceSaver.save(res, resource_path)
 	if pause_target != null:
 		pause_target.pause_processing = false
-	if save_err == OK:
-		ensure_uid(resource_path, prior_uid)
-	return save_err
+	if save_err != OK:
+		return save_err
+	return ensure_uid(resource_path, prior_uid)
 
 
 ## Make `resource_path` carry a stable uid after a successful
@@ -168,11 +173,15 @@ static func guarded_save(res: Resource, resource_path: String, pause_target: Mcp
 ## for a brand-new path). Reusing the prior id — instead of always minting a
 ## fresh one — keeps any `uid://...` references elsewhere in the project
 ## resolving to the same file.
-static func ensure_uid(resource_path: String, prior_uid: int) -> void:
+##
+## Returns the `Error` from `ResourceSaver.set_uid()` so callers can surface a
+## uid-write failure instead of silently reporting success on a file that
+## didn't end up with the uid it was supposed to get.
+static func ensure_uid(resource_path: String, prior_uid: int) -> Error:
 	var id := prior_uid
 	if id == ResourceUID.INVALID_ID:
 		id = ResourceUID.create_id()
-	ResourceSaver.set_uid(resource_path, id)
+	return ResourceSaver.set_uid(resource_path, id)
 
 
 ## Attach a `cleanup.rm` hint listing `paths` to `data` — only when the call

--- a/test_project/tests/test_material.gd
+++ b/test_project/tests/test_material.gd
@@ -182,6 +182,17 @@ func test_create_shader_requires_shader_path() -> void:
 	assert_is_error(result)
 
 
+func test_create_material_embeds_uid() -> void:
+	# #737: a bare ResourceSaver.save() (what guarded_save used before the fix)
+	# writes a .tres with no uid= at all, unlike Godot's own "New Resource"
+	# editor flow. create_material must come out matching the editor.
+	_cleanup_file(TEST_MATERIAL_PATH)
+	var result := _handler.create_material({"path": TEST_MATERIAL_PATH, "type": "standard"})
+	assert_has_key(result, "data")
+	var uid := ResourceLoader.get_resource_uid(TEST_MATERIAL_PATH)
+	assert_true(uid != ResourceUID.INVALID_ID, "freshly created material must carry a uid")
+
+
 # ============================================================================
 # material_set_param
 # ============================================================================
@@ -199,6 +210,25 @@ func test_set_param_color_hex() -> void:
 	var c: Color = mat.get("albedo_color")
 	assert_true(c is Color)
 	assert_true(abs(c.r - 1.0) < 0.01, "Red should be 1.0")
+
+
+func test_set_param_preserves_uid_across_resave() -> void:
+	# #737: set_param's undo-callable (_apply_param) loads the material,
+	# mutates a property, and resaves via McpResourceIO.guarded_save. Before
+	# the fix, a bare ResourceSaver.save() resave silently dropped whatever
+	# uid the file already had -- this must survive unchanged.
+	_make_material()
+	var original_uid := ResourceLoader.get_resource_uid(TEST_MATERIAL_PATH)
+	assert_true(original_uid != ResourceUID.INVALID_ID, "precondition: fresh material must have a uid")
+
+	var result := _handler.set_param({
+		"path": TEST_MATERIAL_PATH,
+		"param": "albedo_color",
+		"value": "#00ff00",
+	})
+	assert_has_key(result, "data")
+	var uid_after_resave := ResourceLoader.get_resource_uid(TEST_MATERIAL_PATH)
+	assert_eq(uid_after_resave, original_uid, "resaving an existing material must keep its original uid")
 
 
 func test_set_param_color_dict() -> void:

--- a/test_project/tests/test_resource.gd
+++ b/test_project/tests/test_resource.gd
@@ -554,6 +554,10 @@ func test_create_resource_saves_to_disk() -> void:
 	assert_true(loaded is BoxShape3D)
 	assert_true(loaded.size is Vector3)
 	assert_eq(loaded.size.x, 1.0)
+	# #737: a freshly-created resource must carry a uid, matching what
+	# Godot's own "New Resource" editor flow would have embedded.
+	assert_true(ResourceLoader.get_resource_uid(out_path) != ResourceUID.INVALID_ID,
+		"freshly created resource must carry a uid")
 	# Clean up.
 	DirAccess.remove_absolute(ProjectSettings.globalize_path(out_path))
 
@@ -567,6 +571,8 @@ func test_create_resource_save_refuses_overwrite_without_flag() -> void:
 		"resource_path": out_path,
 	})
 	assert_has_key(first, "data")
+	var original_uid := ResourceLoader.get_resource_uid(out_path)
+	assert_true(original_uid != ResourceUID.INVALID_ID, "precondition: fresh resource must have a uid")
 	var second := _handler.create_resource({
 		"type": "BoxShape3D",
 		"resource_path": out_path,
@@ -582,6 +588,10 @@ func test_create_resource_save_refuses_overwrite_without_flag() -> void:
 	assert_true(third.data.overwritten)
 	# Overwrite must not emit a cleanup hint — the caller already had the file.
 	assert_false(third.data.has("cleanup"), "Overwrite must not emit a cleanup hint")
+	# #737: overwriting an existing resource must keep its original uid, not
+	# silently drop it (a bare ResourceSaver.save() resave used to strip it).
+	assert_eq(ResourceLoader.get_resource_uid(out_path), original_uid,
+		"overwrite must preserve the resource's original uid")
 	DirAccess.remove_absolute(ProjectSettings.globalize_path(out_path))
 
 

--- a/test_project/tests/test_scene.gd
+++ b/test_project/tests/test_scene.gd
@@ -184,6 +184,48 @@ func test_create_scene_rejects_project_godot_overwrite() -> void:
 	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
 
 
+func test_create_scene_embeds_and_preserves_uid() -> void:
+	## #737 regression. Deliberately does NOT call _handler.create_scene()
+	## with a real path — per this section's header comment, a full create
+	## switches the editor's active scene and isn't safe inside the shared
+	## test runner. Instead exercises the identical
+	## pack -> ResourceSaver.save -> McpResourceIO.ensure_uid sequence
+	## create_scene runs, standalone, so a regression in uid embedding or
+	## preservation-across-overwrite is still caught. create_scene's own
+	## wiring of this sequence was verified live against a running editor
+	## (scene_manage(op="create"), then a same-path recreate) during
+	## development of this fix.
+	var out_path := "res://tests/_mcp_test_uid_scene.tscn"
+	if FileAccess.file_exists(out_path):
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(out_path))
+
+	var root := Node3D.new()
+	root.name = "UidProbeRoot"
+	var packed := PackedScene.new()
+	packed.pack(root)
+	root.free()
+
+	assert_eq(ResourceSaver.save(packed, out_path), OK)
+	assert_eq(McpResourceIO.ensure_uid(out_path, ResourceUID.INVALID_ID), OK)
+	var original_uid := ResourceLoader.get_resource_uid(out_path)
+	assert_true(original_uid != ResourceUID.INVALID_ID, "freshly created scene must carry a uid")
+
+	# Recreate at the same path — mirrors create_scene being pointed at an
+	# existing scene path — and confirm the original uid survives.
+	var root2 := Node3D.new()
+	root2.name = "UidProbeRootV2"
+	var packed2 := PackedScene.new()
+	packed2.pack(root2)
+	root2.free()
+	var prior_uid := ResourceLoader.get_resource_uid(out_path)
+	assert_eq(ResourceSaver.save(packed2, out_path), OK)
+	assert_eq(McpResourceIO.ensure_uid(out_path, prior_uid), OK)
+	assert_eq(ResourceLoader.get_resource_uid(out_path), original_uid,
+		"overwriting a scene at the same path must preserve its original uid")
+
+	DirAccess.remove_absolute(ProjectSettings.globalize_path(out_path))
+
+
 # ----- open_scene (validation only — opening scenes triggers UI that blocks test runner) -----
 
 func test_open_scene_missing_path() -> void:

--- a/test_project/tests/test_scene.gd
+++ b/test_project/tests/test_scene.gd
@@ -40,6 +40,19 @@ func suite_setup(_ctx: Dictionary) -> void:
 	_handler = SceneHandler.new()
 
 
+const _UID_SCENE_FIXTURE_PATH := "res://tests/_mcp_test_uid_scene.tscn"
+
+
+func suite_teardown() -> void:
+	# Guarantees cleanup even if test_create_scene_embeds_and_preserves_uid
+	# fails or aborts partway through, rather than relying on the assertion
+	# flow to reach its own cleanup line.
+	if FileAccess.file_exists(_UID_SCENE_FIXTURE_PATH):
+		var remove_err := DirAccess.remove_absolute(ProjectSettings.globalize_path(_UID_SCENE_FIXTURE_PATH))
+		if remove_err != OK:
+			push_warning("MCP test cleanup: failed to remove %s: %s" % [_UID_SCENE_FIXTURE_PATH, error_string(remove_err)])
+
+
 # ----- get_scene_tree -----
 
 func test_scene_tree_returns_data() -> void:
@@ -185,28 +198,24 @@ func test_create_scene_rejects_project_godot_overwrite() -> void:
 
 
 func test_create_scene_embeds_and_preserves_uid() -> void:
-	## #737 regression. Deliberately does NOT call _handler.create_scene()
-	## with a real path — per this section's header comment, a full create
-	## switches the editor's active scene and isn't safe inside the shared
-	## test runner. Instead exercises the identical
-	## pack -> ResourceSaver.save -> McpResourceIO.ensure_uid sequence
-	## create_scene runs, standalone, so a regression in uid embedding or
-	## preservation-across-overwrite is still caught. create_scene's own
-	## wiring of this sequence was verified live against a running editor
-	## (scene_manage(op="create"), then a same-path recreate) during
-	## development of this fix.
-	var out_path := "res://tests/_mcp_test_uid_scene.tscn"
+	## #737 regression. Calls SceneHandler._pack_and_save_with_uid() directly
+	## — the real save+uid sequence create_scene runs — rather than
+	## create_scene() itself: per this section's header comment, a full
+	## create switches the editor's active scene and isn't safe inside the
+	## shared test runner. This exercises production code (not a duplicated
+	## reimplementation), just without create_scene's
+	## EditorInterface.open_scene_from_path side effect. create_scene's own
+	## end-to-end wiring was additionally verified live against a running
+	## editor (scene_manage(op="create"), then a same-path recreate) during
+	## development of this fix. Cleanup is guaranteed by suite_teardown()
+	## even if an assertion below fails.
+	var out_path := _UID_SCENE_FIXTURE_PATH
 	if FileAccess.file_exists(out_path):
 		DirAccess.remove_absolute(ProjectSettings.globalize_path(out_path))
 
 	var root := Node3D.new()
 	root.name = "UidProbeRoot"
-	var packed := PackedScene.new()
-	packed.pack(root)
-	root.free()
-
-	assert_eq(ResourceSaver.save(packed, out_path), OK)
-	assert_eq(McpResourceIO.ensure_uid(out_path, ResourceUID.INVALID_ID), OK)
+	assert_eq(_handler._pack_and_save_with_uid(root, out_path), OK)
 	var original_uid := ResourceLoader.get_resource_uid(out_path)
 	assert_true(original_uid != ResourceUID.INVALID_ID, "freshly created scene must carry a uid")
 
@@ -214,16 +223,9 @@ func test_create_scene_embeds_and_preserves_uid() -> void:
 	# existing scene path — and confirm the original uid survives.
 	var root2 := Node3D.new()
 	root2.name = "UidProbeRootV2"
-	var packed2 := PackedScene.new()
-	packed2.pack(root2)
-	root2.free()
-	var prior_uid := ResourceLoader.get_resource_uid(out_path)
-	assert_eq(ResourceSaver.save(packed2, out_path), OK)
-	assert_eq(McpResourceIO.ensure_uid(out_path, prior_uid), OK)
+	assert_eq(_handler._pack_and_save_with_uid(root2, out_path), OK)
 	assert_eq(ResourceLoader.get_resource_uid(out_path), original_uid,
 		"overwriting a scene at the same path must preserve its original uid")
-
-	DirAccess.remove_absolute(ProjectSettings.globalize_path(out_path))
 
 
 # ----- open_scene (validation only — opening scenes triggers UI that blocks test runner) -----


### PR DESCRIPTION
## Summary

Closes #737.

- `ResourceSaver.save()` called directly — `scene_handler.gd::create_scene`, and `McpResourceIO.save_to_disk`/`guarded_save` (the shared save path behind `resource_create`, `material_*`, `theme_*`, `environment_create`, `texture_*`, `curve_set_points`) — does not embed a `uid=` in a brand-new `.tscn`/`.tres`, unlike Godot's own "New Scene"/"New Resource" editor flows. Confirmed by direct reproduction against a live Godot 4.6.2 instance.
- Worse, resaving a resource that already had a uid (the "load existing resource, mutate a property, resave" pattern used throughout `material_handler.gd`/`theme_handler.gd`) silently **strips** the existing uid — verified the same way. This isn't limited to MCP-created files; it can corrupt a uid a human already committed.
- Added `McpResourceIO.ensure_uid(path, prior_uid)`, called right after every successful save in `save_to_disk`, `guarded_save`, and inlined in `create_scene`: reuse the uid the path had *before* this save if one existed (so any `uid://...` references elsewhere in the project keep resolving), otherwise mint a fresh one via `ResourceUID.create_id()` + `ResourceSaver.set_uid()`.

This isn't a recent regression — `create_scene`'s raw pack+save pattern dates back to the tool's original implementation (PR #3), and `McpResourceIO`'s helpers inherited the same pattern when extracted later. It's a long-standing gap that Godot's resource-uid feature made visible.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `script/ci-check-gdscript` (full-project `--import` parse scan) — clean
- [x] `pytest -v` — 1373 passed, 4 skipped (Python side untouched by this change)
- [x] Live Godot 4.6.2 editor, full GDScript suite via `test_run` — **1854 passed, 0 failed**, including new regression tests:
  - `test_resource.gd`: fresh `resource_create` embeds a uid; `overwrite=true` preserves the original uid
  - `test_material.gd`: fresh `material_create` embeds a uid; `material_set_param`'s load→mutate→resave cycle preserves the original uid (the "removes" half of #737)
- [x] Live smoke test of `scene_manage(op="create")` directly against the running editor (not covered by the automated suite, which documents that `create_scene` switches the active scene and isn't test-runner-safe): confirmed the created `.tscn` embeds a `uid=`, and recreating at the same path leaves the uid unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NGc97D45qbRo8m4dyFbzSY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resource files (including scenes and materials) now consistently retain stable Godot resource IDs when created or overwritten.
  * Scene creation/opening and disk saving now only proceed when the saved file successfully preserves a valid embedded UID.

* **Tests**
  * Added/expanded regression coverage to confirm UID embedding and preservation across creation, parameter updates + resaves, and scene overwrites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->