### PR TITLE
Strip MCP autoload from exports (#740) and retry failed uv detection (#739)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,11 @@ jobs:
         timeout-minutes: 2
         run: bash script/ci-quit-test
 
+      - name: Export-strip smoke test
+        shell: bash
+        timeout-minutes: 5
+        run: GODOT_BIN=godot bash script/ci-export-strip-smoke
+
       - name: Dump Godot editor log on failure
         if: failure()
         shell: bash

--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -678,6 +678,26 @@ static func invalidate_uv_version_cache() -> void:
 	_uv_version_cache = ""
 
 
+## True when a probe has run this session and came back empty — i.e. the
+## dock is currently rendering "uv: not found". Lets callers decide when
+## a re-probe is worth paying for (server-connect transition, manual
+## Refresh) without ever re-probing once uv has been found.
+static func uv_probe_negative() -> bool:
+	return _uv_version_searched and _uv_version_cache.is_empty()
+
+
+## Drop both uv caches — the resolved uvx path AND the cached
+## `uvx --version` output — so the next check_uv_version() re-runs the
+## full detection. #739: a probe that fails once at editor startup
+## (contended spawn, cold Defender scan, stale PATH under a
+## Steam-launched editor) used to pin "uv: not found" for the whole
+## session; the Install-uv click was the only invalidation path. Callers
+## invoke this on events that suggest the failure was transient.
+static func invalidate_uv_detection() -> void:
+	invalidate_uvx_cli_cache()
+	invalidate_uv_version_cache()
+
+
 static var _venv_python_cache: String = ""
 static var _venv_python_searched: bool = false
 ## #678 worker threads write this cache while main-thread callers read

--- a/plugin/addons/godot_ai/export/mcp_export_plugin.gd
+++ b/plugin/addons/godot_ai/export/mcp_export_plugin.gd
@@ -1,0 +1,69 @@
+@tool
+extends EditorExportPlugin
+
+## Strips the MCP game-helper autoload from exported builds (#740).
+##
+## plugin.gd writes `autoload/_mcp_game_helper` into project.godot so the
+## editor-spawned game process loads the helper. Exports bake project
+## settings into the pack's project.binary, so without this plugin every
+## export ships the autoload — and users who exclude addons/godot_ai/**
+## in their export preset get three "Failed to instantiate an autoload"
+## errors at game start. Even when the files ARE shipped, the helper is
+## editor-tooling: no exported build should carry it.
+##
+## Strip mechanics: clear the in-memory ProjectSettings entry in
+## _export_begin, restore it in _export_end. The export pipeline reads
+## the live ProjectSettings when it bakes project.binary, which happens
+## after _export_begin — verified end-to-end by
+## script/ci-export-strip-smoke, which exports a real pack and asserts
+## the autoload is absent inside it. We never call ProjectSettings.save()
+## while stripped, so project.godot on disk keeps the autoload
+## throughout; only the export snapshot loses it.
+##
+## Failure containment: if an export aborts so hard that _export_end
+## never fires, the damage is bounded to the editor's in-memory settings
+## — the running game reads project.godot from disk, and plugin.gd's
+## _ensure_game_helper_autoload() re-asserts the entry on the next
+## plugin enable / editor launch.
+
+## Must equal "autoload/" + plugin.gd's GAME_HELPER_AUTOLOAD_NAME.
+## Duplicated (not preloaded from plugin.gd) to avoid a cyclic preload —
+## plugin.gd preloads this script. The pairing is locked by
+## test_export_strip.gd's constants-contract test.
+const AUTOLOAD_KEY := "autoload/_mcp_game_helper"
+
+var _saved_value: Variant = null
+var _stripped := false
+
+
+func _get_name() -> String:
+	return "GodotAIStripAutoload"
+
+
+func _export_begin(_features: PackedStringArray, _is_debug: bool, _path: String, _flags: int) -> void:
+	## `_stripped` guard: if a previous export died before _export_end,
+	## don't overwrite the genuinely-saved value with the already-cleared
+	## state — restore semantics stay anchored to the original value.
+	if _stripped:
+		return
+	if not ProjectSettings.has_setting(AUTOLOAD_KEY):
+		return
+	_saved_value = ProjectSettings.get_setting(AUTOLOAD_KEY)
+	## Setting a project setting to null erases it.
+	ProjectSettings.set_setting(AUTOLOAD_KEY, null)
+	_stripped = true
+	print("MCP | export: stripping %s from the exported pack (restored in the editor after export)" % AUTOLOAD_KEY)
+
+
+func _export_end() -> void:
+	if not _stripped:
+		return
+	ProjectSettings.set_setting(AUTOLOAD_KEY, _saved_value)
+	## Mirror _ensure_game_helper_autoload()'s registration shape so the
+	## restored entry is indistinguishable from the original: initial
+	## value "" keeps project.godot diff-clean, basic keeps it visible in
+	## the non-advanced settings view.
+	ProjectSettings.set_initial_value(AUTOLOAD_KEY, "")
+	ProjectSettings.set_as_basic(AUTOLOAD_KEY, true)
+	_saved_value = null
+	_stripped = false

--- a/plugin/addons/godot_ai/export/mcp_export_plugin.gd.uid
+++ b/plugin/addons/godot_ai/export/mcp_export_plugin.gd.uid
@@ -1,0 +1,1 @@
+uid://np0cp6fwpim7

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -991,6 +991,12 @@ func _update_status() -> void:
 	var changed: bool = connected != _last_connected or status_text != _last_status_text
 	if not changed:
 		return
+	if connected and not _last_connected:
+		## #739: the server just came up. If the startup uv probe failed
+		## (the reporter's screenshot: green "Server connected" beside a
+		## red "uv: not found" row), the failure was transient — re-probe
+		## now instead of pinning the red row for the whole session.
+		_reprobe_uv_if_negative()
 	_last_connected = connected
 	_last_status_text = status_text
 	_status_icon.color = status_color
@@ -1330,6 +1336,8 @@ func _on_dev_mode_toggled(enabled: bool) -> void:
 
 
 func _apply_dev_mode_visibility() -> void:
+	if _dev_mode_toggle == null:
+		return  ## dock UI not built yet (unit tests, teardown window)
 	var dev := _dev_mode_toggle.button_pressed
 	_dev_section.visible = dev
 	if _log_viewer != null:
@@ -1498,6 +1506,24 @@ func _dispatch_stale_server_restart() -> bool:
 
 
 # --- Setup section ---
+
+## #739: a `uvx --version` probe that failed once at editor startup used
+## to pin "uv: not found" for the whole session — the Install-uv click
+## was the only invalidation path, so the fix users discovered was
+## re-clicking Install on every launch. Re-probe on events that suggest
+## the failure was transient (server-connect transition, manual Refresh).
+## No-op once uv has been found, so this costs nothing in the healthy
+## steady state; when uv is genuinely absent, the re-probe is a fast
+## negative (CliFinder's well-known-dir walk plus one bounded `where`).
+## Runs on the main thread like the initial probe — same wall-clock
+## bound, and the triggering events are rare (once per connect / click).
+func _reprobe_uv_if_negative() -> void:
+	if not ClientConfigurator.uv_probe_negative():
+		return
+	ClientConfigurator.invalidate_uv_detection()
+	_refresh_setup_status()
+	_apply_dev_mode_visibility()
+
 
 func _refresh_setup_status() -> void:
 	if _setup_container == null:
@@ -1756,12 +1782,11 @@ func _on_install_uv() -> void:
 	## Drop the cached uvx path AND the cached `uvx --version` so the
 	## next `_refresh_setup_status` finds and reads the freshly-installed
 	## binary instead of returning the pre-install "not found" result.
-	## Routing through the configurator here matters on Windows, where
-	## the CLI-finder cache key is `uvx.exe` — invalidating just `"uvx"`
+	## Routing through the configurator matters on Windows, where the
+	## CLI-finder cache key is `uvx.exe` — invalidating just `"uvx"`
 	## would leave the cache stale and the dock would keep showing
 	## "uv: not found" for the rest of the session.
-	ClientConfigurator.invalidate_uvx_cli_cache()
-	ClientConfigurator.invalidate_uv_version_cache()
+	ClientConfigurator.invalidate_uv_detection()
 	_refresh_setup_status.call_deferred()
 
 
@@ -1946,6 +1971,9 @@ func _finalize_action_buttons(client_id: String) -> void:
 
 
 func _on_refresh_clients_pressed() -> void:
+	## Explicit user action — also give a failed uv probe another chance
+	## (#739), mirroring how the same click already re-sweeps client CLIs.
+	_reprobe_uv_if_negative()
 	_request_client_status_refresh(true)
 
 

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -991,16 +991,19 @@ func _update_status() -> void:
 	var changed: bool = connected != _last_connected or status_text != _last_status_text
 	if not changed:
 		return
-	if connected and not _last_connected:
-		## #739: the server just came up. If the startup uv probe failed
-		## (the reporter's screenshot: green "Server connected" beside a
-		## red "uv: not found" row), the failure was transient — re-probe
-		## now instead of pinning the red row for the whole session.
-		_reprobe_uv_if_negative()
+	var just_connected: bool = connected and not _last_connected
 	_last_connected = connected
 	_last_status_text = status_text
 	_status_icon.color = status_color
 	_status_label.text = status_text
+	if just_connected:
+		## #739: the server just came up. If the startup uv probe failed
+		## (the reporter's screenshot: green "Server connected" beside a
+		## red "uv: not found" row), the failure was transient — re-probe
+		## instead of pinning the red row for the whole session. Runs
+		## AFTER the label writes above and via the deferred queue, so the
+		## status-machine state is committed before the probe can block.
+		_schedule_uv_reprobe()
 
 	_update_dev_section_buttons()
 
@@ -1517,6 +1520,20 @@ func _dispatch_stale_server_restart() -> bool:
 ## negative (CliFinder's well-known-dir walk plus one bounded `where`).
 ## Runs on the main thread like the initial probe — same wall-clock
 ## bound, and the triggering events are rare (once per connect / click).
+##
+## Callers go through _schedule_uv_reprobe() rather than calling this
+## inline: the cache-miss probe shells out (bounded at 3s) on the
+## calling thread, and both call sites sit mid-flow in UI handlers —
+## the connect transition wants its status-label writes committed
+## first, and the Refresh click wants the client sweep dispatched
+## without waiting on the probe. Same deferred convention as
+## _on_install_uv. (The deferred queue still flushes on the main
+## thread, so a worst-case 3s probe delays that frame — acceptable for
+## a rare, bounded event; a worker thread would be the heavier cure.)
+func _schedule_uv_reprobe() -> void:
+	_reprobe_uv_if_negative.call_deferred()
+
+
 func _reprobe_uv_if_negative() -> void:
 	if not ClientConfigurator.uv_probe_negative():
 		return
@@ -1973,7 +1990,7 @@ func _finalize_action_buttons(client_id: String) -> void:
 func _on_refresh_clients_pressed() -> void:
 	## Explicit user action — also give a failed uv probe another chance
 	## (#739), mirroring how the same click already re-sweeps client CLIs.
-	_reprobe_uv_if_negative()
+	_schedule_uv_reprobe()
 	_request_client_status_refresh(true)
 
 

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -45,6 +45,7 @@ const EditorLogBuffer := preload("res://addons/godot_ai/utils/editor_log_buffer.
 const SurfacedErrorTracker := preload("res://addons/godot_ai/utils/surfaced_error_tracker.gd")
 const Dock := preload("res://addons/godot_ai/mcp_dock.gd")
 const DebuggerPlugin := preload("res://addons/godot_ai/debugger/mcp_debugger_plugin.gd")
+const ExportPlugin := preload("res://addons/godot_ai/export/mcp_export_plugin.gd")
 const ClientConfigurator := preload("res://addons/godot_ai/client_configurator.gd")
 const WindowsPortReservation := preload("res://addons/godot_ai/utils/windows_port_reservation.gd")
 
@@ -151,6 +152,7 @@ var _editor_logger: Logger
 var _dock
 var _handlers: Array = []  # prevent GC of RefCounted handlers
 var _debugger_plugin
+var _export_plugin
 ## Spawn / stop / adopt orchestration plus state machine; allocated in
 ## `_init` so test fixtures (which never enter the tree) can drive
 ## `_start_server`. Owns `_server_pid`, `_server_state`, the version-
@@ -191,6 +193,13 @@ func _enter_tree() -> void:
 	## it off until `_watch_for_adoption_confirmation` arms it, so the
 	## plugin has zero per-frame cost in the common case.
 	set_process(false)
+
+	## #740: register the export plugin BEFORE the headless guard so
+	## `godot --headless --export-*` runs strip the game-helper autoload
+	## from exported packs too — CI export pipelines are headless. The
+	## export plugin is inert outside exports: no server, no sockets.
+	_export_plugin = ExportPlugin.new()
+	add_export_plugin(_export_plugin)
 
 	if _mcp_disabled_for_headless_launch():
 		_headless_disabled = true
@@ -484,6 +493,12 @@ func _flush_pending_self_update_telemetry() -> void:
 
 
 func _exit_tree() -> void:
+	## Registered before the headless guard in _enter_tree, so it must be
+	## removed before the headless early-return here too.
+	if _export_plugin != null:
+		remove_export_plugin(_export_plugin)
+		_export_plugin = null
+
 	if _headless_disabled:
 		_server_started_this_session = false
 		_headless_disabled = false

--- a/script/ci-export-strip-smoke
+++ b/script/ci-export-strip-smoke
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# End-to-end check of the #740 export-strip EditorExportPlugin.
+#
+# Builds a throwaway Godot project with the plugin installed and the
+# `_mcp_game_helper` autoload registered (the state every real user
+# project is in), exports a real PCK twice — once with addons/* excluded
+# from the preset (the #740 reporter's setup) and once with everything
+# included — then boots each pack and asserts:
+#   1. the exported pack does NOT carry the autoload (probe prints <absent>)
+#   2. no "Failed to instantiate an autoload" error at game start
+#   3. the strip actually ran (plugin log line in export output)
+#   4. project.godot on disk still has the autoload after the export
+#      (the strip is in-memory only; restore leaves the project intact)
+#
+# Expects: GODOT_BIN (defaults to `godot` on PATH).
+set -euo pipefail
+
+GODOT_BIN=${GODOT_BIN:-godot}
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+FIXTURE="$WORK/fixture"
+mkdir -p "$FIXTURE/addons"
+# Copy (not symlink): Windows CI runners run this under Git Bash where
+# symlinks need special privileges.
+cp -R "$REPO_ROOT/plugin/addons/godot_ai" "$FIXTURE/addons/godot_ai"
+
+cat > "$FIXTURE/project.godot" <<'EOF'
+config_version=5
+
+[application]
+
+config/name="export_strip_smoke"
+run/main_scene="res://main.tscn"
+
+[autoload]
+
+_mcp_game_helper="*res://addons/godot_ai/runtime/game_helper.gd"
+
+[editor_plugins]
+
+enabled=PackedStringArray("res://addons/godot_ai/plugin.cfg")
+EOF
+
+cat > "$FIXTURE/probe.gd" <<'EOF'
+extends Node
+
+func _ready() -> void:
+	var setting = ProjectSettings.get_setting("autoload/_mcp_game_helper", "<absent>")
+	print("PROBE autoload_setting=", setting)
+	print("PROBE helper_node_present=", get_tree().root.has_node("_mcp_game_helper"))
+	get_tree().quit(0)
+EOF
+
+cat > "$FIXTURE/main.tscn" <<'EOF'
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://probe.gd" id="1"]
+
+[node name="Main" type="Node"]
+script = ExtResource("1")
+EOF
+
+# Platform "Windows Desktop" has kept that exact name across all of 4.x
+# (unlike Linux, which renamed), and pack-only export needs no templates
+# on any host OS.
+cat > "$FIXTURE/export_presets.cfg" <<'EOF'
+[preset.0]
+
+name="strip-excluded"
+platform="Windows Desktop"
+runnable=true
+custom_features=""
+export_filter="all_resources"
+include_filter=""
+exclude_filter="addons/*"
+export_path="ignored.pck"
+encrypt_pck=false
+encrypt_directory=false
+
+[preset.0.options]
+
+binary_format/embed_pck=false
+
+[preset.1]
+
+name="strip-included"
+platform="Windows Desktop"
+runnable=true
+custom_features=""
+export_filter="all_resources"
+include_filter=""
+exclude_filter=""
+export_path="ignored.pck"
+encrypt_pck=false
+encrypt_directory=false
+
+[preset.1.options]
+
+binary_format/embed_pck=false
+EOF
+
+echo "==> Importing fixture project"
+"$GODOT_BIN" --headless --path "$FIXTURE" --import > "$WORK/import.log" 2>&1 || true
+if [ ! -d "$FIXTURE/.godot" ]; then
+  echo "FAIL: --import produced no .godot directory"
+  tail -50 "$WORK/import.log"
+  exit 1
+fi
+
+fail() {
+  echo "FAIL: $1"
+  shift
+  for f in "$@"; do
+    echo "----- $f (last 60 lines) -----"
+    tail -60 "$f" || true
+  done
+  exit 1
+}
+
+run_one() {
+  local preset="$1"
+  local pck="$WORK/$preset.pck"
+  local export_log="$WORK/$preset-export.log"
+  local run_log="$WORK/$preset-run.log"
+
+  echo "==> Exporting preset '$preset'"
+  "$GODOT_BIN" --headless --path "$FIXTURE" --export-pack "$preset" "$pck" > "$export_log" 2>&1 \
+    || fail "--export-pack '$preset' exited nonzero" "$export_log"
+  [ -f "$pck" ] || fail "no pack produced for '$preset'" "$export_log"
+
+  grep -q "MCP | export: stripping autoload/_mcp_game_helper" "$export_log" \
+    || fail "strip log line missing — export plugin did not run for '$preset'" "$export_log"
+
+  grep -q "_mcp_game_helper" "$FIXTURE/project.godot" \
+    || fail "project.godot lost the autoload after exporting '$preset'"
+
+  echo "==> Booting exported pack '$preset'"
+  # --quit-after is a frame-count backstop in case the probe never runs;
+  # the probe itself quits in _ready.
+  (cd "$WORK" && "$GODOT_BIN" --headless --main-pack "$pck" --quit-after 300 > "$run_log" 2>&1) || true
+
+  grep -q "PROBE autoload_setting=<absent>" "$run_log" \
+    || fail "exported pack '$preset' still carries the autoload setting (or probe never ran)" "$run_log"
+  grep -q "PROBE helper_node_present=false" "$run_log" \
+    || fail "game helper node instantiated in exported '$preset' build" "$run_log"
+  if grep -q "Failed to instantiate an autoload" "$run_log"; then
+    fail "dangling-autoload error in exported '$preset' build (the #740 symptom)" "$run_log"
+  fi
+  echo "    OK: '$preset' pack is clean"
+}
+
+run_one "strip-excluded"
+run_one "strip-included"
+
+echo "PASS: export-strip smoke (both presets)"

--- a/test_project/tests/test_export_strip.gd
+++ b/test_project/tests/test_export_strip.gd
@@ -1,0 +1,155 @@
+@tool
+extends McpTestSuite
+
+## Tests for export/mcp_export_plugin.gd (#740) — the EditorExportPlugin
+## that strips the `_mcp_game_helper` autoload from exported packs.
+##
+## These tests drive the _export_begin/_export_end callbacks directly
+## against the live editor's ProjectSettings (the test_project has the
+## autoload registered by plugin.gd). The real export pipeline is covered
+## end-to-end by script/ci-export-strip-smoke, which exports an actual
+## pack and asserts the autoload is absent inside it; this suite locks
+## the strip/restore state machine and its edge cases.
+
+const ExportPlugin := preload("res://addons/godot_ai/export/mcp_export_plugin.gd")
+const GodotAiPlugin := preload("res://addons/godot_ai/plugin.gd")
+
+const KEY := "autoload/_mcp_game_helper"
+const CANONICAL_VALUE := "*res://addons/godot_ai/runtime/game_helper.gd"
+
+var _orig_value: Variant = null
+var _had_setting := false
+
+
+func suite_name() -> String:
+	return "export_strip"
+
+
+func setup() -> void:
+	_had_setting = ProjectSettings.has_setting(KEY)
+	_orig_value = ProjectSettings.get_setting(KEY, "") if _had_setting else null
+
+
+func teardown() -> void:
+	## Whatever a test did, put the live editor's setting back exactly as
+	## we found it so later suites (and the editor session itself) see the
+	## real autoload registration.
+	if _had_setting:
+		ProjectSettings.set_setting(KEY, _orig_value)
+		ProjectSettings.set_initial_value(KEY, "")
+		ProjectSettings.set_as_basic(KEY, true)
+	elif ProjectSettings.has_setting(KEY):
+		ProjectSettings.set_setting(KEY, null)
+
+
+func _make_plugin() -> EditorExportPlugin:
+	return ExportPlugin.new()
+
+
+static func _begin(plugin: EditorExportPlugin) -> void:
+	plugin._export_begin(PackedStringArray(), false, "/tmp/ignored.pck", 0)
+
+
+# ----- constants contract -----
+
+func test_autoload_key_matches_plugin_gd() -> void:
+	## The key is duplicated in the export plugin to avoid a cyclic
+	## preload with plugin.gd. This test is the lock that keeps the two
+	## in sync — if GAME_HELPER_AUTOLOAD_NAME ever changes, this fails.
+	assert_eq(
+		ExportPlugin.AUTOLOAD_KEY,
+		"autoload/" + GodotAiPlugin.GAME_HELPER_AUTOLOAD_NAME,
+		"export plugin must strip exactly the autoload plugin.gd registers"
+	)
+
+
+# ----- strip / restore -----
+
+func test_begin_strips_setting_and_end_restores_it() -> void:
+	ProjectSettings.set_setting(KEY, CANONICAL_VALUE)
+	var plugin := _make_plugin()
+
+	_begin(plugin)
+	assert_false(ProjectSettings.has_setting(KEY), "autoload must be gone during export")
+
+	plugin._export_end()
+	assert_true(ProjectSettings.has_setting(KEY), "autoload must be restored after export")
+	assert_eq(ProjectSettings.get_setting(KEY, ""), CANONICAL_VALUE)
+
+
+func test_begin_preserves_nonstandard_value_verbatim() -> void:
+	## If a user hand-edited the autoload value, restore must reproduce
+	## their value, not the canonical one.
+	var custom := "*res://somewhere/else/game_helper.gd"
+	ProjectSettings.set_setting(KEY, custom)
+	var plugin := _make_plugin()
+
+	_begin(plugin)
+	plugin._export_end()
+	assert_eq(ProjectSettings.get_setting(KEY, ""), custom)
+
+
+func test_disk_project_godot_untouched_while_stripped() -> void:
+	## The strip is in-memory only: project.godot on disk keeps the
+	## autoload for the whole export window (we never call save()).
+	ProjectSettings.set_setting(KEY, CANONICAL_VALUE)
+	var plugin := _make_plugin()
+
+	_begin(plugin)
+	var disk_text := FileAccess.get_file_as_string("res://project.godot")
+	plugin._export_end()
+
+	assert_true(
+		disk_text.contains("_mcp_game_helper"),
+		"project.godot on disk must keep the autoload during export"
+	)
+
+
+# ----- edge cases -----
+
+func test_begin_noop_when_setting_absent() -> void:
+	ProjectSettings.set_setting(KEY, null)
+	var plugin := _make_plugin()
+
+	_begin(plugin)
+	assert_false(ProjectSettings.has_setting(KEY))
+
+	plugin._export_end()
+	assert_false(
+		ProjectSettings.has_setting(KEY),
+		"end must not invent a setting that was never stripped"
+	)
+
+
+func test_end_without_begin_is_noop() -> void:
+	ProjectSettings.set_setting(KEY, CANONICAL_VALUE)
+	var plugin := _make_plugin()
+
+	plugin._export_end()
+	assert_eq(ProjectSettings.get_setting(KEY, ""), CANONICAL_VALUE)
+
+
+func test_double_begin_keeps_original_saved_value() -> void:
+	## Simulates an export that died before _export_end: the next export's
+	## _export_begin must not clobber the saved value with the
+	## already-stripped state, and its _export_end must still restore the
+	## original.
+	ProjectSettings.set_setting(KEY, CANONICAL_VALUE)
+	var plugin := _make_plugin()
+
+	_begin(plugin)
+	_begin(plugin)  ## second begin while stripped
+
+	plugin._export_end()
+	assert_eq(ProjectSettings.get_setting(KEY, ""), CANONICAL_VALUE)
+
+
+func test_two_sequential_exports_roundtrip() -> void:
+	ProjectSettings.set_setting(KEY, CANONICAL_VALUE)
+	var plugin := _make_plugin()
+
+	for i in 2:
+		_begin(plugin)
+		assert_false(ProjectSettings.has_setting(KEY), "export %d: stripped" % i)
+		plugin._export_end()
+		assert_eq(ProjectSettings.get_setting(KEY, ""), CANONICAL_VALUE, "export %d: restored" % i)

--- a/test_project/tests/test_export_strip.gd.uid
+++ b/test_project/tests/test_export_strip.gd.uid
@@ -1,0 +1,1 @@
+uid://ddvn0ju8lmmob

--- a/test_project/tests/test_uv_detection_retry.gd
+++ b/test_project/tests/test_uv_detection_retry.gd
@@ -1,0 +1,195 @@
+@tool
+extends McpTestSuite
+
+## Tests for the #739 fix: a `uvx --version` probe that fails once at
+## editor startup must not pin "uv: not found" for the whole session.
+## Covers the new ClientConfigurator helpers (uv_probe_negative /
+## invalidate_uv_detection) and the dock's _reprobe_uv_if_negative wiring
+## (server-connect transition + manual Refresh click).
+##
+## The configurator caches are session-global statics shared with the
+## live editor session running these tests, so every test snapshots and
+## restores them — including McpCliFinder's per-exe entries for the uvx
+## binary names.
+
+const McpDockScript = preload("res://addons/godot_ai/mcp_dock.gd")
+
+const UVX_NAMES := ["uvx", "uvx.exe"]
+
+var _orig_version_cache: String
+var _orig_version_searched: bool
+var _orig_finder_cache := {}
+var _orig_finder_searched := {}
+
+
+func suite_name() -> String:
+	return "uv_detection_retry"
+
+
+func setup() -> void:
+	_orig_version_cache = McpClientConfigurator._uv_version_cache
+	_orig_version_searched = McpClientConfigurator._uv_version_searched
+	_orig_finder_cache.clear()
+	_orig_finder_searched.clear()
+	for name in UVX_NAMES:
+		if McpCliFinder._cache.has(name):
+			_orig_finder_cache[name] = McpCliFinder._cache[name]
+		if McpCliFinder._searched.has(name):
+			_orig_finder_searched[name] = McpCliFinder._searched[name]
+
+
+func teardown() -> void:
+	McpClientConfigurator._uv_version_cache = _orig_version_cache
+	McpClientConfigurator._uv_version_searched = _orig_version_searched
+	for name in UVX_NAMES:
+		if _orig_finder_cache.has(name):
+			McpCliFinder._cache[name] = _orig_finder_cache[name]
+		else:
+			McpCliFinder._cache.erase(name)
+		if _orig_finder_searched.has(name):
+			McpCliFinder._searched[name] = _orig_finder_searched[name]
+		else:
+			McpCliFinder._searched.erase(name)
+
+
+func _seed_negative_probe() -> void:
+	McpClientConfigurator._uv_version_searched = true
+	McpClientConfigurator._uv_version_cache = ""
+	## Seed only the names this platform actually resolves ("uvx.exe" on
+	## Windows, "uvx" everywhere else) — invalidation deliberately targets
+	## the platform-specific cache keys, so foreign-platform entries would
+	## survive and fail the assertions below without ever mattering live.
+	for name in McpClientConfigurator._uvx_cli_names():
+		McpCliFinder._cache[name] = ""
+		McpCliFinder._searched[name] = true
+
+
+func _seed_positive_probe() -> void:
+	McpClientConfigurator._uv_version_searched = true
+	McpClientConfigurator._uv_version_cache = "uv 9.9.9"
+
+
+# ----- ClientConfigurator helpers -----
+
+func test_probe_negative_false_before_any_probe() -> void:
+	McpClientConfigurator._uv_version_searched = false
+	McpClientConfigurator._uv_version_cache = ""
+	assert_false(McpClientConfigurator.uv_probe_negative())
+
+
+func test_probe_negative_false_when_uv_found() -> void:
+	_seed_positive_probe()
+	assert_false(McpClientConfigurator.uv_probe_negative())
+
+
+func test_probe_negative_true_after_failed_probe() -> void:
+	_seed_negative_probe()
+	assert_true(McpClientConfigurator.uv_probe_negative())
+
+
+func test_invalidate_uv_detection_clears_both_caches() -> void:
+	_seed_negative_probe()
+
+	McpClientConfigurator.invalidate_uv_detection()
+
+	assert_false(
+		McpClientConfigurator._uv_version_searched,
+		"version cache must be re-probed on next check"
+	)
+	for name in McpClientConfigurator._uvx_cli_names():
+		assert_false(
+			McpCliFinder._searched.has(name),
+			"CliFinder entry for %s must be dropped so the path is re-resolved" % name
+		)
+
+
+# ----- dock reprobe helper -----
+
+class _UiSpyDock extends McpDockScript:
+	var setup_refreshes := 0
+	var visibility_applies := 0
+
+	func _refresh_setup_status() -> void:
+		setup_refreshes += 1
+
+	func _apply_dev_mode_visibility() -> void:
+		visibility_applies += 1
+
+
+func test_reprobe_noop_when_uv_already_found() -> void:
+	_seed_positive_probe()
+	var dock := _UiSpyDock.new()
+
+	dock._reprobe_uv_if_negative()
+
+	assert_true(
+		McpClientConfigurator._uv_version_searched,
+		"positive probe result must stay cached — no re-probe"
+	)
+	assert_eq(dock.setup_refreshes, 0, "no UI rebuild when nothing changed")
+	dock.free()
+
+
+func test_reprobe_invalidates_and_rerenders_when_negative() -> void:
+	_seed_negative_probe()
+	var dock := _UiSpyDock.new()
+
+	dock._reprobe_uv_if_negative()
+
+	assert_false(
+		McpClientConfigurator._uv_version_searched,
+		"negative probe result must be dropped for re-detection"
+	)
+	assert_eq(dock.setup_refreshes, 1, "setup section must re-render")
+	assert_eq(dock.visibility_applies, 1, "section visibility must be recomputed")
+	dock.free()
+
+
+# ----- dock wiring: connect transition + Refresh click -----
+
+class _ReprobeSpyDock extends McpDockScript:
+	var reprobe_calls := 0
+	var client_refresh_calls := 0
+
+	func _reprobe_uv_if_negative() -> void:
+		reprobe_calls += 1
+
+	func _request_client_status_refresh(_force: bool = false) -> bool:
+		client_refresh_calls += 1
+		return true
+
+
+class _ConnectionStub:
+	var is_connected := true
+	var server_version := ""
+
+
+func test_update_status_reprobes_only_on_connect_transition() -> void:
+	var dock := _ReprobeSpyDock.new()
+	dock._build_ui()
+	dock._connection = _ConnectionStub.new()
+
+	dock._update_status()
+	assert_eq(dock.reprobe_calls, 1, "disconnected -> connected must reprobe")
+
+	dock._update_status()
+	assert_eq(dock.reprobe_calls, 1, "steady connected state must not reprobe")
+
+	dock._connection.is_connected = false
+	dock._update_status()
+	assert_eq(dock.reprobe_calls, 1, "disconnect must not reprobe")
+
+	dock._connection.is_connected = true
+	dock._update_status()
+	assert_eq(dock.reprobe_calls, 2, "reconnect must reprobe again")
+	dock.free()
+
+
+func test_refresh_click_reprobes_uv() -> void:
+	var dock := _ReprobeSpyDock.new()
+
+	dock._on_refresh_clients_pressed()
+
+	assert_eq(dock.reprobe_calls, 1, "manual Refresh must give uv another chance")
+	assert_eq(dock.client_refresh_calls, 1, "client sweep must still run")
+	dock.free()

--- a/test_project/tests/test_uv_detection_retry.gd
+++ b/test_project/tests/test_uv_detection_retry.gd
@@ -147,12 +147,17 @@ func test_reprobe_invalidates_and_rerenders_when_negative() -> void:
 
 # ----- dock wiring: connect transition + Refresh click -----
 
+## Spies on _schedule_uv_reprobe (the deferred-dispatch seam) rather than
+## _reprobe_uv_if_negative: production defers the probe so paint-sensitive
+## callers never block on it, and a real call_deferred queued here would
+## fire after the test frees the dock — landing on a freed object and
+## polluting the runner's script-error capture.
 class _ReprobeSpyDock extends McpDockScript:
-	var reprobe_calls := 0
+	var reprobe_schedules := 0
 	var client_refresh_calls := 0
 
-	func _reprobe_uv_if_negative() -> void:
-		reprobe_calls += 1
+	func _schedule_uv_reprobe() -> void:
+		reprobe_schedules += 1
 
 	func _request_client_status_refresh(_force: bool = false) -> bool:
 		client_refresh_calls += 1
@@ -170,18 +175,18 @@ func test_update_status_reprobes_only_on_connect_transition() -> void:
 	dock._connection = _ConnectionStub.new()
 
 	dock._update_status()
-	assert_eq(dock.reprobe_calls, 1, "disconnected -> connected must reprobe")
+	assert_eq(dock.reprobe_schedules, 1, "disconnected -> connected must schedule a reprobe")
 
 	dock._update_status()
-	assert_eq(dock.reprobe_calls, 1, "steady connected state must not reprobe")
+	assert_eq(dock.reprobe_schedules, 1, "steady connected state must not reprobe")
 
 	dock._connection.is_connected = false
 	dock._update_status()
-	assert_eq(dock.reprobe_calls, 1, "disconnect must not reprobe")
+	assert_eq(dock.reprobe_schedules, 1, "disconnect must not reprobe")
 
 	dock._connection.is_connected = true
 	dock._update_status()
-	assert_eq(dock.reprobe_calls, 2, "reconnect must reprobe again")
+	assert_eq(dock.reprobe_schedules, 2, "reconnect must schedule a reprobe again")
 	dock.free()
 
 
@@ -190,6 +195,6 @@ func test_refresh_click_reprobes_uv() -> void:
 
 	dock._on_refresh_clients_pressed()
 
-	assert_eq(dock.reprobe_calls, 1, "manual Refresh must give uv another chance")
+	assert_eq(dock.reprobe_schedules, 1, "manual Refresh must give uv another chance")
 	assert_eq(dock.client_refresh_calls, 1, "client sweep must still run")
 	dock.free()

--- a/test_project/tests/test_uv_detection_retry.gd.uid
+++ b/test_project/tests/test_uv_detection_retry.gd.uid
@@ -1,0 +1,1 @@
+uid://ddnsec7ag6djc

--- a/tests/unit/test_editor_focus_refocus.py
+++ b/tests/unit/test_editor_focus_refocus.py
@@ -551,14 +551,25 @@ def test_check_uv_version_caches_for_session() -> None:
 
     dock_source = (PLUGIN_ROOT / "mcp_dock.gd").read_text(encoding="utf-8")
     install_block = get_func_block(dock_source, "func _on_install_uv() -> void:")
-    assert "ClientConfigurator.invalidate_uvx_cli_cache()" in install_block, (
-        "_on_install_uv must invalidate the CLI-path cache via the "
-        "configurator helper (which knows the OS-specific binary name). "
-        'A direct `CliFinder.invalidate("uvx")` would leave the '
-        "Windows cache stale — Windows caches under `uvx.exe`."
+    assert "ClientConfigurator.invalidate_uv_detection()" in install_block, (
+        "_on_install_uv must invalidate uv detection via the configurator "
+        "helper (which knows the OS-specific binary name). A direct "
+        '`CliFinder.invalidate("uvx")` would leave the Windows cache '
+        "stale — Windows caches under `uvx.exe`."
     )
-    assert "ClientConfigurator.invalidate_uv_version_cache()" in install_block, (
-        "_on_install_uv must invalidate the version cache too — without "
+
+    # #739: the combined invalidator must clear BOTH caches — the resolved
+    # uvx path and the cached `uvx --version` output. Dropping only one
+    # leaves the dock pinned on the stale half (path cache alone -> the old
+    # "not found" version string survives; version cache alone -> the old
+    # empty path survives).
+    detection_block = get_func_block(source, "static func invalidate_uv_detection() -> void:")
+    assert "invalidate_uvx_cli_cache()" in detection_block, (
+        "invalidate_uv_detection must drop the CLI-path cache via the "
+        "OS-aware helper so the uvx binary is re-resolved."
+    )
+    assert "invalidate_uv_version_cache()" in detection_block, (
+        "invalidate_uv_detection must drop the version cache too — without "
         "this, the dock's setup status keeps showing 'uv: not found' "
         "after a successful install."
     )


### PR DESCRIPTION
Fixes #739. Fixes the export contamination reported in discussion #740.

## Export strip (#740)

Every export shipped the `_mcp_game_helper` autoload because plugin.gd writes it into `project.godot` and Godot bakes autoloads into the exported pack's project settings. Users who excluded `addons/godot_ai/**` in their export preset (the discussion reporter's setup) got three `Failed to instantiate an autoload` errors at game start; users who didn't shipped editor tooling in their game.

- New `export/mcp_export_plugin.gd` (`EditorExportPlugin`, registered by plugin.gd alongside the existing debugger plugin): clears the in-memory `autoload/_mcp_game_helper` setting in `_export_begin`, restores it in `_export_end`. Never calls `ProjectSettings.save()` while stripped, so `project.godot` on disk is untouched throughout; if an export dies before `_export_end`, a begin-guard keeps the next restore anchored to the original value and `_ensure_game_helper_autoload()` re-asserts on the next launch.
- Registered **before** the headless guard in `_enter_tree` so headless CI export pipelines strip too.
- The "settings are snapshotted after `_export_begin`" ordering is implementation behavior, not documented contract — so it's pinned by an end-to-end smoke, not just unit tests.

## uv detection retry (#739)

`check_uv_version()` latched a failed probe for the entire editor session; the only invalidation path was the Install-uv click. One transient `uvx --version` failure at editor startup (contended spawn, cold AV scan, stale PATH under a Steam-launched editor) produced the reporter's screenshot: green "Server connected" beside a permanent red "uv: not found" — and re-clicking Install every launch as the accidental workaround.

- Success stays latched. A negative result is re-probed on events that suggest it was transient: the server's disconnected→connected transition (exactly the reporter's state) and the manual Refresh click. Both no-op once uv is found, so the healthy steady state pays nothing.
- New `ClientConfigurator.uv_probe_negative()` / `invalidate_uv_detection()` (path cache + version cache in one call; the Install-uv handler now uses it too).

## Testing

- `test_export_strip.gd` (8 tests): strip/restore state machine, verbatim value restore, disk untouched while stripped, absent-setting no-op, double-begin (crashed export) guard, sequential exports, and a constants-contract lock against plugin.gd's autoload name.
- `script/ci-export-strip-smoke` (new CI step in the godot-tests job): builds a throwaway project with the plugin installed, exports a **real PCK** twice (preset excluding `addons/*` and preset including everything), boots each pack, asserts the autoload setting is absent, the helper node never instantiates, no dangling-autoload error, the strip log line fired, and `project.godot` still has the autoload afterward. Verified locally on Godot 4.6.3 — and verified to **fail** when the registration is reverted (test-the-test).
- `test_uv_detection_retry.gd` (8 tests): helper truth table, both caches invalidated, reprobe gating (fires only on the false→true connect transition — not steady state, not disconnect), Refresh-click wiring, positive-cache no-op.
- Full GDScript battery: 63 suites, 1871 passed / 0 failed. `ci-reload-test` (10 enable/disable cycles + post-churn suite) and `ci-quit-test` pass with the new register/remove lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from one-time `uv` probing failures by re-probing and refreshing when the dock first connects or when clients are refreshed.
  * Prevented UI null-reference issues when dev-mode visibility runs before UI elements are ready.
  * Ensured export behavior works reliably in headless/export CI flows.
* **New Features**
  * Exported game packs now strip the MCP helper autoload during export and restore the editor’s original setting afterward.
* **Tests**
  * Added editor-level export strip/restore coverage and CI export-strip smoke testing.
  * Added/updated `uv` detection retry and cache invalidation test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->