### PR TITLE
scene_get_hierarchy: paginate plugin-side instead of shipping the whole tree

### DIFF
--- a/plugin/addons/godot_ai/handlers/scene_handler.gd
+++ b/plugin/addons/godot_ai/handlers/scene_handler.gd
@@ -16,13 +16,38 @@ func _init(connection: McpConnection = null) -> void:
 
 func get_scene_tree(params: Dictionary) -> Dictionary:
 	var max_depth: int = params.get("depth", 10)
+	var offset: int = maxi(0, int(params.get("offset", 0)))
+	# limit <= 0 means "no limit" (the hierarchy resource reads the whole tree);
+	# the scene_get_hierarchy tool passes an explicit positive limit. Paginating
+	# here — rather than walking + serializing the full tree and slicing on the
+	# Python side — means only the requested window builds node dicts and clean
+	# scene paths, and only the window crosses the WebSocket.
+	var limit: int = int(params.get("limit", 0))
 	var scene_root := EditorInterface.get_edited_scene_root()
 	if scene_root == null:
-		return {"data": {"nodes": [], "message": "No scene open"}}
+		return {"data": {
+			"nodes": [],
+			"total_count": 0,
+			"offset": offset,
+			"limit": limit,
+			"has_more": false,
+			"message": "No scene open",
+		}}
 
 	var nodes: Array[Dictionary] = []
-	_walk_tree(scene_root, nodes, 0, max_depth, scene_root)
-	return {"data": {"nodes": nodes, "total_count": nodes.size()}}
+	# index_ref[0] is the running DFS index shared across the recursion (Arrays
+	# pass by reference in GDScript). The walk still visits every node to get an
+	# accurate total_count, but only materializes those inside the window.
+	var index_ref: Array[int] = [0]
+	_walk_tree(scene_root, nodes, 0, max_depth, scene_root, offset, limit, index_ref)
+	var total: int = index_ref[0]
+	return {"data": {
+		"nodes": nodes,
+		"total_count": total,
+		"offset": offset,
+		"limit": limit,
+		"has_more": limit > 0 and offset + limit < total,
+	}}
 
 
 func get_open_scenes(_params: Dictionary) -> Dictionary:
@@ -357,14 +382,21 @@ func _save_current_scene_as(path: String) -> void:
 	EditorInterface.save_scene_as(path)
 
 
-func _walk_tree(node: Node, out: Array[Dictionary], depth: int, max_depth: int, scene_root: Node) -> void:
+func _walk_tree(node: Node, out: Array[Dictionary], depth: int, max_depth: int, scene_root: Node, offset: int, limit: int, index_ref: Array[int]) -> void:
 	if depth > max_depth:
 		return
-	out.append({
-		"name": node.name,
-		"type": node.get_class(),
-		"path": McpScenePath.from_node(node, scene_root),
-		"children_count": node.get_child_count(),
-	})
+	var idx: int = index_ref[0]
+	index_ref[0] = idx + 1
+	# Materialize only nodes inside the [offset, offset+limit) window. Outside
+	# it we still recurse (to count total_count) but skip the per-node dict and
+	# the O(depth) scene-path build — the actual cost this pagination avoids.
+	var in_window := idx >= offset and (limit <= 0 or idx < offset + limit)
+	if in_window:
+		out.append({
+			"name": node.name,
+			"type": node.get_class(),
+			"path": McpScenePath.from_node(node, scene_root),
+			"children_count": node.get_child_count(),
+		})
 	for child in node.get_children():
-		_walk_tree(child, out, depth + 1, max_depth, scene_root)
+		_walk_tree(child, out, depth + 1, max_depth, scene_root, offset, limit, index_ref)

--- a/src/godot_ai/handlers/scene.py
+++ b/src/godot_ai/handlers/scene.py
@@ -13,9 +13,18 @@ async def scene_get_hierarchy(
     offset: int = 0,
     limit: int = 100,
 ) -> dict:
-    result = await runtime.send_command("get_scene_tree", {"depth": depth})
-    nodes = result.get("nodes", [])
-    return {"root": result.get("root", ""), **paginate(nodes, offset, limit, key="nodes")}
+    result = await runtime.send_command(
+        "get_scene_tree", {"depth": depth, "offset": offset, "limit": limit}
+    )
+    ## Newer plugins paginate server-side (only the window is walked into node
+    ## dicts and shipped) and stamp `has_more`; pass their result straight
+    ## through. Older plugins — and version-skewed installs — ignore the
+    ## offset/limit params and return the full node list without pagination
+    ## metadata, so fall back to slicing here. This keeps a mixed
+    ## new-server/old-plugin pair correct.
+    if "has_more" in result:
+        return result
+    return paginate(result.get("nodes", []), offset, limit, key="nodes")
 
 
 async def scene_get_roots(runtime: DirectRuntime) -> dict:

--- a/src/godot_ai/handlers/scene.py
+++ b/src/godot_ai/handlers/scene.py
@@ -91,4 +91,8 @@ async def current_scene_resource_data(runtime: DirectRuntime) -> dict:
 
 
 async def scene_hierarchy_resource_data(runtime: DirectRuntime) -> dict:
-    return await runtime.send_command("get_scene_tree", {"depth": 10})
+    ## Route through scene_get_hierarchy (limit=0 => full tree) rather than
+    ## calling the plugin directly, so the resource returns the same paginated
+    ## shape (total_count/offset/limit/has_more) regardless of plugin version —
+    ## the old-plugin fallback normalizes it. (CodeRabbit)
+    return await scene_get_hierarchy(runtime, depth=10, offset=0, limit=0)

--- a/src/godot_ai/handlers/scene.py
+++ b/src/godot_ai/handlers/scene.py
@@ -24,7 +24,22 @@ async def scene_get_hierarchy(
     ## new-server/old-plugin pair correct.
     if "has_more" in result:
         return result
-    return paginate(result.get("nodes", []), offset, limit, key="nodes")
+    ## Old-plugin fallback: slice here, but honor the same contract the plugin
+    ## does so a new-server/old-plugin pair matches a new/new pair — clamp a
+    ## negative offset to 0, and treat limit <= 0 as "no limit" (return
+    ## everything from offset) rather than paginate()'s empty-slice semantics.
+    nodes = result.get("nodes", [])
+    norm_offset = max(0, offset)
+    if limit <= 0:
+        page = nodes[norm_offset:]
+        return {
+            "nodes": page,
+            "total_count": len(nodes),
+            "offset": norm_offset,
+            "limit": limit,
+            "has_more": False,
+        }
+    return paginate(nodes, norm_offset, limit, key="nodes")
 
 
 async def scene_get_roots(runtime: DirectRuntime) -> dict:

--- a/test_project/tests/test_scene.gd
+++ b/test_project/tests/test_scene.gd
@@ -62,6 +62,44 @@ func test_scene_tree_returns_data() -> void:
 	assert_has_key(result.data, "total_count")
 
 
+func test_scene_tree_no_limit_returns_all() -> void:
+	var result := _handler.get_scene_tree({"depth": 10})
+	## No limit -> full tree, has_more false, nodes count equals total_count.
+	assert_eq(result.data.nodes.size(), result.data.total_count)
+	assert_false(result.data.has_more, "Unlimited read has nothing more")
+	assert_eq(result.data.offset, 0)
+
+
+func test_scene_tree_limit_windows_nodes_and_reports_total() -> void:
+	var full := _handler.get_scene_tree({"depth": 10})
+	var total: int = full.data.total_count
+	assert_gt(total, 2, "test scene needs >2 nodes to exercise paging")
+	var page := _handler.get_scene_tree({"depth": 10, "limit": 2})
+	assert_eq(page.data.nodes.size(), 2, "limit caps the returned window")
+	## total_count reflects the whole tree, not the returned window.
+	assert_eq(page.data.total_count, total)
+	assert_eq(page.data.limit, 2)
+	assert_true(page.data.has_more, "More nodes remain past a 2-node window")
+
+
+func test_scene_tree_offset_skips_leading_nodes() -> void:
+	var full := _handler.get_scene_tree({"depth": 10})
+	## DFS order is stable, so offset 1 drops the root and starts at its first
+	## walked descendant.
+	var offset_page := _handler.get_scene_tree({"depth": 10, "offset": 1, "limit": 1})
+	assert_eq(offset_page.data.nodes.size(), 1)
+	assert_eq(offset_page.data.offset, 1)
+	assert_eq(offset_page.data.nodes[0].name, full.data.nodes[1].name)
+
+
+func test_scene_tree_offset_past_end_returns_empty_window() -> void:
+	var full := _handler.get_scene_tree({"depth": 10})
+	var beyond := _handler.get_scene_tree({"depth": 10, "offset": full.data.total_count + 5, "limit": 10})
+	assert_eq(beyond.data.nodes.size(), 0, "offset past the end yields no nodes")
+	assert_eq(beyond.data.total_count, full.data.total_count, "total_count still reflects the full tree")
+	assert_false(beyond.data.has_more)
+
+
 func test_scene_tree_root_is_main() -> void:
 	var result := _handler.get_scene_tree({"depth": 10})
 	var nodes: Array = result.data.nodes

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -1622,16 +1622,26 @@ class TestResourceReads:
         async def respond():
             cmd = await plugin.recv_command()
             assert cmd["command"] == "get_scene_tree"
+            ## Mirror the current plugin contract: paginated shape, no `root`.
             await plugin.send_response(
                 cmd["request_id"],
-                {"root": "Main", "nodes": [{"name": "Camera3D"}]},
+                {
+                    "nodes": [{"name": "Main"}, {"name": "Camera3D"}],
+                    "total_count": 2,
+                    "offset": 0,
+                    "limit": 0,
+                    "has_more": False,
+                },
             )
 
         task = asyncio.create_task(respond())
         result = await client.read_resource("godot://scene/hierarchy")
         await task
         data = json.loads(result[0].text)
-        assert data["root"] == "Main"
+        assert "root" not in data
+        assert data["nodes"][0]["name"] == "Main"
+        assert data["total_count"] == 2
+        assert data["has_more"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_mcp_workflows.py
+++ b/tests/integration/test_mcp_workflows.py
@@ -150,5 +150,8 @@ class TestMcpVerificationWorkflows:
         await _bounded(task)
 
         assert opened.data["path"] == "res://levels/arena.tscn"
-        assert hierarchy.data["root"] == "Arena"
+        ## The readback's first (root) node is the arena scene root. (The old
+        ## `data["root"]` field was a dead passthrough — the real plugin never
+        ## sent it — so verify the loaded scene via the actual node list.)
+        assert hierarchy.data["nodes"][0]["name"] == "Arena"
         assert any(node["name"] == "PlayerSpawn" for node in hierarchy.data["nodes"])

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -2317,6 +2317,25 @@ async def test_scene_get_hierarchy_passthrough_when_plugin_paginates():
     assert "root" not in result
 
 
+async def test_scene_get_hierarchy_fallback_limit_zero_returns_all():
+    ## Old-plugin fallback must honor the plugin's `limit <= 0 = no limit`
+    ## contract, not paginate()'s empty-slice-on-zero-limit behavior.
+    runtime = DirectRuntime(registry=SessionRegistry(), client=StubClient())
+    result = await scene_handlers.scene_get_hierarchy(runtime, depth=5, offset=0, limit=0)
+    assert len(result["nodes"]) == 3  # StubClient returns 3 nodes
+    assert result["total_count"] == 3
+    assert result["has_more"] is False
+
+
+async def test_scene_get_hierarchy_fallback_clamps_negative_offset():
+    ## A negative offset must clamp to 0 (matches the plugin's maxi(0, offset)),
+    ## not slice from the end the way Python's paginate would.
+    runtime = DirectRuntime(registry=SessionRegistry(), client=StubClient())
+    result = await scene_handlers.scene_get_hierarchy(runtime, depth=5, offset=-5, limit=2)
+    assert result["offset"] == 0
+    assert [n["name"] for n in result["nodes"]] == ["Node0", "Node1"]
+
+
 async def test_scene_get_roots_handler():
     client = StubClient()
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -2269,12 +2269,52 @@ async def test_logs_resource_data_handler():
 
 
 async def test_scene_get_hierarchy_handler():
-    runtime = DirectRuntime(registry=SessionRegistry(), client=StubClient())
+    ## StubClient returns the OLD plugin shape (full node list, no `has_more`),
+    ## so the handler falls back to slicing server-side — the mixed
+    ## new-server/old-plugin path.
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
     result = await scene_handlers.scene_get_hierarchy(runtime, depth=5, offset=0, limit=2)
-    assert result["root"] == "Main"
     assert len(result["nodes"]) == 2
     assert result["total_count"] == 3
     assert result["has_more"] is True
+    ## offset/limit are forwarded to the plugin even though this old stub
+    ## ignores them.
+    assert client.calls[-1]["params"] == {"depth": 5, "offset": 0, "limit": 2}
+
+
+class _PaginatingSceneClient:
+    """Stub plugin that paginates server-side and stamps `has_more`."""
+
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    async def send(self, command, params=None, session_id=None, timeout=5.0, **_):
+        self.calls.append({"command": command, "params": params})
+        p = params or {}
+        off = int(p.get("offset", 0))
+        lim = int(p.get("limit", 0))
+        all_nodes = [{"name": f"Node{i}", "type": "Node3D"} for i in range(5)]
+        page = all_nodes[off:] if lim <= 0 else all_nodes[off : off + lim]
+        return {
+            "nodes": page,
+            "total_count": len(all_nodes),
+            "offset": off,
+            "limit": lim,
+            "has_more": lim > 0 and off + lim < len(all_nodes),
+        }
+
+
+async def test_scene_get_hierarchy_passthrough_when_plugin_paginates():
+    ## A plugin that already paginated must not be sliced again.
+    runtime = DirectRuntime(registry=SessionRegistry(), client=_PaginatingSceneClient())
+    result = await scene_handlers.scene_get_hierarchy(runtime, depth=5, offset=1, limit=2)
+    assert [n["name"] for n in result["nodes"]] == ["Node1", "Node2"]
+    assert result["total_count"] == 5
+    assert result["offset"] == 1
+    assert result["limit"] == 2
+    assert result["has_more"] is True
+    assert "root" not in result
 
 
 async def test_scene_get_roots_handler():

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -2352,9 +2352,15 @@ async def test_current_scene_resource_data_handler():
 
 
 async def test_scene_hierarchy_resource_data_handler():
+    ## StubClient returns the old plugin shape (no pagination metadata); routing
+    ## the resource through scene_get_hierarchy normalizes it, so the resource
+    ## exposes the same shape regardless of plugin version.
     runtime = DirectRuntime(registry=SessionRegistry(), client=StubClient())
     result = await scene_handlers.scene_hierarchy_resource_data(runtime)
     assert "nodes" in result
+    assert result["total_count"] == 3
+    assert result["has_more"] is False
+    assert "root" not in result
 
 
 async def test_scene_create_handler():


### PR DESCRIPTION
## Motivation

`get_scene_tree` ignored `offset`/`limit`: the plugin always walked the entire tree, built a node dict + clean scene path for **every** node, and shipped the whole thing over the WebSocket — then `scene_get_hierarchy` sliced it in Python. So `limit=1` on a large scene still paid the full walk + serialize + transport cost.

## Change

Thread `offset`/`limit` into the plugin. The walk still visits every node for an accurate `total_count`, but only nodes inside the `[offset, offset+limit)` window are materialized (dict + `McpScenePath.from_node`) and shipped. `limit <= 0` means unlimited (the hierarchy resource reads the whole tree).

Python side passes `offset`/`limit`/`depth` through and returns the plugin's paginated result when it carries `has_more`; otherwise it falls back to slicing the full list. That keeps a version-skewed **new-server / old-plugin** pair correct and leaves existing behavior intact. Also drops the dead `root` field — the real plugin never sent it, so it was always `""` in production.

## Tests

- GDScript: pagination window, offset, `total_count`, offset-past-end, and unlimited (`test_scene.gd`).
- Python: the fallback-slice path (old plugin shape) **and** the plugin-paginated passthrough path; updated the workflow readback to verify the loaded scene via the node list rather than the removed `root`.
- Rebased onto v3.0.2; parse-clean; Python suite green locally (the two `test_cli_reload` failures are a local port-9500-in-use artifact, unrelated). Full Godot `test_run` runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pagination to scene hierarchy results via `offset` and `limit`.
  * Pagination now includes `total_count`, `offset`, `limit`, and `has_more`, returning only the requested node window.
* **Bug Fixes**
  * Improved “no scene open” responses to return a structured empty page with `has_more: false`.
  * Normalized hierarchy response shape to remove the unused `root` field.
  * Safer pagination fallback: `limit=0` means “no limit” and negative `offset` is clamped to `0`.
* **Tests**
  * Expanded unit and integration tests to cover server-side passthrough, fallbacks, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->