### PR TITLE
McpScenePath.from_node: single upward walk instead of two O(depth) passes

### DIFF
--- a/plugin/addons/godot_ai/utils/scene_path.gd
+++ b/plugin/addons/godot_ai/utils/scene_path.gd
@@ -9,18 +9,29 @@ const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
 
 
 ## Return a clean path relative to the scene root (e.g. /Main/Camera3D).
-## Returns "" when `node` is not the scene root or a descendant of it —
-## without the ancestry guard, get_path_to() returns an empty NodePath that
-## concatenates into a plausible-looking but invalid "/Main/".
+## Returns "" when `node` is not the scene root or a descendant of it.
+##
+## Single upward walk from `node` to `scene_root`, collecting names as we go.
+## The pre-PR version paid two O(depth) walks per node — `is_ancestor_of()`
+## (node -> root) to guard against get_path_to() emitting a "../"-style path
+## for non-descendants, then `get_path_to()` (root -> node) again. Walking up
+## once both validates ancestry (did we reach scene_root before the tree top?)
+## and builds the relative segments, halving the per-node cost on hot reads
+## like find_nodes / get_children with no change to the output or the guard.
 static func from_node(node: Node, scene_root: Node) -> String:
 	if scene_root == null or node == null:
 		return ""
 	if node == scene_root:
 		return "/" + scene_root.name
-	if not scene_root.is_ancestor_of(node):
-		return ""
-	var relative := scene_root.get_path_to(node)
-	return "/" + scene_root.name + "/" + str(relative)
+	var segments: Array[String] = []
+	var current := node
+	while current != null and current != scene_root:
+		segments.append(str(current.name))
+		current = current.get_parent()
+	if current != scene_root:
+		return ""  # walked off the top without hitting scene_root: not a descendant
+	segments.reverse()
+	return "/" + scene_root.name + "/" + "/".join(segments)
 
 
 ## Resolve a clean scene path like "/Main/Camera3D" to the actual node.


### PR DESCRIPTION
## Motivation

`McpScenePath.from_node` paid **two** O(depth) walks per node: `is_ancestor_of()` (node → root) to guard against `get_path_to()` emitting a `"../"`-style path for a non-descendant, then `get_path_to()` (root → node). On hot, unbounded reads like `find_nodes` / `get_children` over a deep tree that's O(n·depth) with a 2× constant.

## Change

Walk up from the node to `scene_root` once, collecting names: reaching `scene_root` proves ancestry **and** yields the relative segments in a single pass; walking off the tree top means it isn't a descendant (return `""`). Output and the empty-string guard are unchanged.

## Tests

Behavior-preserving — validated by the existing exhaustive `test_scene_path.gd` (root / child / nested / null node / null root / orphan / foreign tree / ancestor-of-root). Rebased onto v3.0.2 (clean — `from_node` was untouched upstream; the file's other functions gained the new `resolve("/")` alias); parse-clean. Full Godot `test_run` runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scene path generation for nodes within a scene hierarchy.
  * Invalid or unrelated nodes now correctly return an empty path.
  * Preserved correct handling for missing inputs and the scene root itself.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->