### PR TITLE
Avoid running the Python test suite twice on 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,10 @@ jobs:
       - name: Install dependencies
         run: pip install -e ".[dev]"
 
+      # Keep these conditions complementary so every matrix cell runs pytest
+      # exactly once: with coverage on the Codecov cell, plain everywhere else.
       - name: Run tests
+        if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.13'
         run: pytest -v
 
       - name: Run tests with coverage


### PR DESCRIPTION
## Summary

- Skip the plain `pytest` run on the Ubuntu/Python 3.13 matrix cell.
- Run that cell once with coverage instead.
- Keep the plain and coverage conditions complementary so every matrix cell runs the full suite exactly once.
- Leave Codecov upload behavior unchanged.

## Why

The Python 3.13 CI cell currently runs the complete test suite twice: once normally and once with coverage. The coverage invocation exercises and fails on the same tests, so the plain invocation adds no additional validation and unnecessarily increases CI time.

Using complementary conditions also keeps the workflow safe if the full OS matrix is restored later: non-Ubuntu Python 3.13 cells will use the plain test run.

## Verification

- `actionlint`
- YAML parse
- `ruff check src/ tests/`
- Python tests: 1,364 passed, 13 skipped
- GDScript import validation
- Godot tests: 1,859 passed, 30 skipped, 0 failed

Closes #747

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated test workflow coverage across supported operating systems and Python versions.
  * Ensured each test configuration runs the test suite exactly once while retaining dedicated coverage reporting for the latest Ubuntu/Python combination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->