### PR TITLE
Guard null lifecycle in _process during script reload

### DIFF
--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -947,6 +947,9 @@ func _arm_server_version_check() -> void:
 
 
 func _update_process_enabled() -> void:
+	if _lifecycle == null:
+		set_process(false)
+		return
 	set_process(
 		_lifecycle.get_adoption_watch_deadline_ms() > 0
 		or _lifecycle.is_awaiting_server_version()
@@ -954,6 +957,12 @@ func _update_process_enabled() -> void:
 
 
 func _process(_delta: float) -> void:
+	## Guard: during script-reload / dual-plugin enable races `_lifecycle`
+	## can be null while process is still armed — spam would otherwise flood
+	## the Output dock every frame.
+	if _lifecycle == null:
+		set_process(false)
+		return
 	var now := Time.get_ticks_msec()
 	var version_check = _lifecycle.get_version_check()
 	if version_check != null:

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -1439,6 +1439,32 @@ func test_process_self_disarms_after_deadline_without_connect() -> void:
 	assert_eq(deadline, 0, "_process must zero the deadline on timeout")
 
 
+func test_process_null_lifecycle_disarms_without_crash() -> void:
+	## Dual-plugin enable / script-reload races can leave `_lifecycle` null
+	## while process is still armed. Guard must disable process and return
+	## without dereferencing null (Output-dock spam).
+	var plugin := GodotAiPlugin.new()
+	plugin._lifecycle = null
+	plugin.set_process(true)
+	plugin._process(0.0)
+	var still_processing := plugin.is_processing()
+	plugin.free()
+	assert_false(still_processing, "_process with null lifecycle must set_process(false)")
+
+
+func test_update_process_enabled_null_lifecycle_disarms() -> void:
+	var plugin := GodotAiPlugin.new()
+	plugin._lifecycle = null
+	plugin.set_process(true)
+	plugin._update_process_enabled()
+	var still_processing := plugin.is_processing()
+	plugin.free()
+	assert_false(
+		still_processing,
+		"_update_process_enabled with null lifecycle must set_process(false)"
+	)
+
+
 # ----- lsof multi-pid parsing -----
 #
 # `_find_pid_on_port` / `_find_all_pids_on_port` drive the `force_restart_server`


### PR DESCRIPTION
## Motivation

During dual-plugin enable or script-reload races, `_lifecycle` can be null while `_process` is still armed. That floods the Output dock with null errors every frame.

## Change

- Guard `_lifecycle == null` in `_update_process_enabled` and `_process`.
- Disable process and return early when lifecycle is unavailable.

## Tests (docs/CONTRIBUTING.md)

- [x] Branched from main
- [x] Godot-side tests for new plugin behavior (test_plugin_lifecycle.gd):
  - test_process_null_lifecycle_disarms_without_crash
  - test_update_process_enabled_null_lifecycle_disarms
- [x] ruff check src/ tests/ (no Python surface change)

## Scope

GDScript safety fix + tests. No version bump.
