### PR TITLE
Resolve addon junction for dev venv; strip local tags from uvx pins

### DIFF
--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -471,14 +471,13 @@ static func get_plugin_version() -> String:
 	return "0.0.1"
 
 
-## Strip local build metadata for PyPI pins: `3.0.2+grok.1` → `3.0.2`.
+## Strip PEP 440 local build metadata for PyPI pins: `3.0.2+local.1` → `3.0.2`.
+## Pre-release segments (`3.1.0-rc1`) are preserved — only `+…` is removed.
 static func _pypi_pin_version(version: String) -> String:
 	var v := version.strip_edges()
 	var plus := v.find("+")
 	if plus >= 0:
 		v = v.substr(0, plus)
-	## Also strip pre-release style local tags after a second hyphen segment
-	## that is clearly not a numeric patch (keep 3.0.2 as-is).
 	return v
 
 

--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -471,6 +471,17 @@ static func get_plugin_version() -> String:
 	return "0.0.1"
 
 
+## Strip local build metadata for PyPI pins: `3.0.2+grok.1` → `3.0.2`.
+static func _pypi_pin_version(version: String) -> String:
+	var v := version.strip_edges()
+	var plus := v.find("+")
+	if plus >= 0:
+		v = v.substr(0, plus)
+	## Also strip pre-release style local tags after a second hyphen segment
+	## that is clearly not a numeric patch (keep 3.0.2 as-is).
+	return v
+
+
 ## Override for the dev-vs-user heuristic. Accepted values:
 ##   "dev"   — force dev-checkout mode (skip update check + self-install)
 ##   "user"  — force user-install mode (run update check, allow self-install)
@@ -564,6 +575,11 @@ static func get_server_command(refresh: bool = false) -> Array[String]:
 	var uvx := find_uvx()
 	if not uvx.is_empty():
 		var version := get_plugin_version()
+		## PEP 440 local build tags (e.g. 3.0.2+local.1) are not on PyPI.
+		## Pin uvx to the public base version so the server still boots;
+		## checkout-local extras need the dev_venv tier above
+		## (symlink/junction → repo .venv).
+		var pypi_version := _pypi_pin_version(version)
 		## Pin to the EXACT plugin version rather than `~=<minor>`. Under the
 		## tilde form, uvx was happy to reuse a cached tool env that matched
 		## the minor constraint — so an install that first spawned 1.2.0 kept
@@ -572,11 +588,17 @@ static func get_server_command(refresh: bool = false) -> Array[String]:
 		## otherwise uvx installs the exact version fresh. Keeps plugin and
 		## server version in lockstep without needing `--refresh-package` on
 		## every spawn. See issue #133.
-		print("MCP | using uvx (godot-ai==%s)%s" % [version, " [refresh]" if refresh else ""])
+		if pypi_version != version:
+			print(
+				"MCP | using uvx (godot-ai==%s; local plugin %s not on PyPI)%s"
+				% [pypi_version, version, " [refresh]" if refresh else ""]
+			)
+		else:
+			print("MCP | using uvx (godot-ai==%s)%s" % [pypi_version, " [refresh]" if refresh else ""])
 		var cmd: Array[String] = [uvx]
 		if refresh:
 			cmd.append("--refresh")
-		cmd.append_array(["--from", "godot-ai==%s" % version, "godot-ai"])
+		cmd.append_array(["--from", "godot-ai==%s" % pypi_version, "godot-ai"])
 		return cmd
 
 	var system_cmd := _find_system_install()
@@ -715,8 +737,43 @@ static func _cached_venv_python() -> String:
 	return cached
 
 
+## Absolute path to `res://addons/godot_ai`, resolving Windows junctions /
+## POSIX symlinks via `DirAccess.read_link`. Unresolved globalize_path only
+## walks the *logical* project path (e.g. MyGame/addons/godot_ai → MyGame)
+## and never reaches a fork checkout's `.venv` (…/godot-ai/.venv).
+static func resolve_addons_realpath() -> String:
+	var addons_path := ProjectSettings.globalize_path("res://addons/godot_ai").rstrip("/").rstrip("\\")
+	if addons_path.is_empty():
+		return ""
+	var parent := addons_path.get_base_dir()
+	var dir := DirAccess.open(parent)
+	if dir != null and dir.is_link(addons_path):
+		var target := dir.read_link(addons_path)
+		if not target.is_empty():
+			if target.is_relative_path():
+				target = parent.path_join(target).simplify_path()
+			return target.rstrip("/").rstrip("\\")
+	return addons_path
+
+
 static func _find_venv_python() -> String:
-	return _find_venv_python_in(ProjectSettings.globalize_path("res://").rstrip("/"))
+	## Optional hard override (junction edge cases / CI).
+	var env_py := McpPathTemplate.env_lookup("GODOT_AI_VENV_PYTHON").strip_edges()
+	if not env_py.is_empty() and FileAccess.file_exists(env_py):
+		return env_py
+	## 1) Walk up from the open project (classic monorepo / test_project layout).
+	var from_project := _find_venv_python_in(
+		ProjectSettings.globalize_path("res://").rstrip("/").rstrip("\\")
+	)
+	if not from_project.is_empty():
+		return from_project
+	## 2) Junctioned plugin: resolve reparse target, then walk up to fork root.
+	var addons_real := resolve_addons_realpath()
+	if not addons_real.is_empty():
+		var from_addons := _find_venv_python_in(addons_real)
+		if not from_addons.is_empty():
+			return from_addons
+	return ""
 
 
 ## Pure path-based lookup so tests can drive it with a scratch dir instead of
@@ -729,15 +786,17 @@ static func _find_venv_python() -> String:
 ## the uvx tier, so the dev_venv misidentification has no escape hatch — the
 ## detection has to be right the first time.
 static func _find_venv_python_in(start_dir: String) -> String:
-	var dir := start_dir.rstrip("/")
+	var dir := start_dir.rstrip("/").rstrip("\\")
 	var python_name := "python" if OS.get_name() != "Windows" else "python.exe"
 	var venv_dir := ".venv/bin/" if OS.get_name() != "Windows" else ".venv/Scripts/"
-	for i in 5:
+	## 8 hops: game project roots are shallow; junctioned plugins sit at
+	## <repo>/plugin/addons/godot_ai (4) and nested worktrees may be deeper.
+	for i in 8:
 		var venv_path := dir.path_join(venv_dir + python_name)
 		if FileAccess.file_exists(venv_path) and DirAccess.dir_exists_absolute(dir.path_join("src/godot_ai")):
 			return venv_path
 		var parent := dir.get_base_dir()
-		if parent == dir:
+		if parent == dir or parent.is_empty():
 			break
 		dir = parent
 	return ""

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -1102,13 +1102,29 @@ static func _crash_body_for_state(state: int, server_status: Dictionary = {}) ->
 				return foreign_message
 			return "Another process is already bound to port %d. Pick a free port or stop the other process." % port
 		ServerStateScript.CRASHED:
-			## Both spawn attempts failed on the uvx tier — almost always
-			## means PyPI hasn't propagated this version yet (~10 min after
-			## publish). `_start_server` already tried `--refresh` once, so
-			## the next realistic move is to wait and reload.
+			## Both spawn attempts failed on the uvx tier — stock releases:
+			## PyPI lag. Local builds (version with +metadata): almost always the
+			## dev venv was not found (unresolved junction/symlink) so uvx tried
+			## a pin that may lack checkout-local extras.
 			if ClientConfigurator.get_server_launch_mode() == "uvx":
 				var version := ClientConfigurator.get_plugin_version()
-				return "The server exited before the WebSocket handshake, even after a `uvx --refresh` retry. If this is a brand-new release, PyPI's index may still be propagating (~10 min). Wait a moment and click Reload Plugin to retry, or check Godot's output log for Python's traceback. Target: godot-ai==%s." % version
+				var pin := ClientConfigurator._pypi_pin_version(version)
+				if pin != version:
+					return (
+						"The server exited before the WebSocket handshake. "
+						+ "Local plugin version is %s (PEP 440 local build metadata) — uvx pins PyPI godot-ai==%s. "
+						+ "If you need checkout-local server code, ensure addons/godot_ai resolves to your "
+						+ "dev tree (symlink/junction) with a `.venv`, or set GODOT_AI_VENV_PYTHON to that "
+						+ "python.exe, then Reload Plugin. Log should show 'MCP | using dev venv: ...'."
+						% [version, pin]
+					)
+				return (
+					"The server exited before the WebSocket handshake, even after a `uvx --refresh` retry. "
+					+ "If this is a brand-new release, PyPI's index may still be propagating (~10 min). "
+					+ "Wait a moment and click Reload Plugin to retry, or check Godot's output log for Python's traceback. "
+					+ "Target: godot-ai==%s."
+					% pin
+				)
 			return "The server exited before the WebSocket handshake. Check Godot's output log (bottom panel) for Python's traceback."
 		ServerStateScript.NO_COMMAND:
 			return "No godot-ai server found. Install `uv` via the Setup panel above, or run `pip install godot-ai`."
@@ -1628,16 +1644,11 @@ func _install_mode_tooltip() -> String:
 
 
 func _resolve_plugin_symlink_target() -> String:
-	var addons_path := ProjectSettings.globalize_path("res://addons/godot_ai")
-	var dir := DirAccess.open(addons_path.get_base_dir())
-	if dir == null or not dir.is_link(addons_path):
+	var logical := ProjectSettings.globalize_path("res://addons/godot_ai").rstrip("/").rstrip("\\")
+	var resolved := ClientConfigurator.resolve_addons_realpath()
+	if resolved.is_empty() or resolved == logical:
 		return ""
-	var target := dir.read_link(addons_path)
-	if target.is_empty():
-		return ""
-	if target.is_relative_path():
-		target = addons_path.get_base_dir().path_join(target).simplify_path()
-	return target
+	return resolved
 
 
 static func _compact_uv_version_text(uv_version: String) -> String:

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -63,6 +63,18 @@ func test_pypi_pin_strips_local_build_metadata() -> void:
 	assert_eq(McpClientConfigurator._pypi_pin_version("3.0.2"), "3.0.2")
 	# Pre-release segments stay intact (only '+' local metadata is stripped).
 	assert_eq(McpClientConfigurator._pypi_pin_version("3.1.0-rc1"), "3.1.0-rc1")
+	assert_eq(McpClientConfigurator._pypi_pin_version("  1.2.3+dev  "), "1.2.3")
+
+
+func test_resolve_addons_realpath_non_empty() -> void:
+	## Always returns a usable absolute path for res://addons/godot_ai
+	## (logical path, or junction/symlink target when linked).
+	var path := McpClientConfigurator.resolve_addons_realpath()
+	assert_false(path.is_empty(), "resolve_addons_realpath must not be empty in test_project")
+	assert_true(
+		path.contains("godot_ai"),
+		"resolved path should name the godot_ai addons dir, got: %s" % path
+	)
 
 func test_registry_ids_are_unique() -> void:
 	var seen := {}
@@ -410,6 +422,32 @@ func test_find_venv_python_walks_up_from_nested_start_dir() -> void:
 	DirAccess.remove_absolute(deep)
 	DirAccess.remove_absolute(root.path_join("test_project/addons"))
 	DirAccess.remove_absolute(root.path_join("test_project"))
+	DirAccess.remove_absolute(root)
+
+
+func test_find_venv_python_walks_junction_plugin_layout() -> void:
+	## Junctioned plugins resolve to <repo>/plugin/addons/godot_ai (4 hops
+	## to checkout root). Guard the 8-hop walk still finds the checkout venv.
+	var root := _scratch_dir.path_join("junction_layout")
+	var deep := root.path_join("plugin/addons/godot_ai")
+	var venv_python := root.path_join(_venv_python_relpath())
+	DirAccess.make_dir_recursive_absolute(deep)
+	DirAccess.make_dir_recursive_absolute(venv_python.get_base_dir())
+	_touch_file(venv_python)
+	DirAccess.make_dir_recursive_absolute(root.path_join("src/godot_ai"))
+	assert_eq(
+		McpClientConfigurator._find_venv_python_in(deep),
+		venv_python,
+		"walk from plugin/addons/godot_ai must reach checkout .venv"
+	)
+	DirAccess.remove_absolute(venv_python)
+	DirAccess.remove_absolute(venv_python.get_base_dir())
+	DirAccess.remove_absolute(root.path_join(".venv"))
+	DirAccess.remove_absolute(root.path_join("src/godot_ai"))
+	DirAccess.remove_absolute(root.path_join("src"))
+	DirAccess.remove_absolute(deep)
+	DirAccess.remove_absolute(root.path_join("plugin/addons"))
+	DirAccess.remove_absolute(root.path_join("plugin"))
 	DirAccess.remove_absolute(root)
 
 

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -54,6 +54,16 @@ func test_registry_loads_all_clients() -> void:
 		assert_true(McpClientRegistry.has_id(required), "Missing client: %s" % required)
 
 
+
+
+func test_pypi_pin_strips_local_build_metadata() -> void:
+	## PEP 440 local version tags must not be sent to uvx/PyPI.
+	assert_eq(McpClientConfigurator._pypi_pin_version("3.0.2+local.1"), "3.0.2")
+	assert_eq(McpClientConfigurator._pypi_pin_version("3.0.2+grok.2"), "3.0.2")
+	assert_eq(McpClientConfigurator._pypi_pin_version("3.0.2"), "3.0.2")
+	# Pre-release segments stay intact (only '+' local metadata is stripped).
+	assert_eq(McpClientConfigurator._pypi_pin_version("3.1.0-rc1"), "3.1.0-rc1")
+
 func test_registry_ids_are_unique() -> void:
 	var seen := {}
 	for id in McpClientRegistry.ids():

--- a/tests/unit/test_self_update_smoke_harness.py
+++ b/tests/unit/test_self_update_smoke_harness.py
@@ -123,7 +123,11 @@ def test_self_update_smoke_harness_prepares_fixture(tmp_path: Path) -> None:
     assert "extends McpSelfUpdateSmokeBase" in vnext_child
     assert "const DEFAULT_HTTP_PORT := 18000" in vnext_configurator
     assert 'const SELF_UPDATE_SMOKE_SERVER_VERSION := "2.2.0"' in vnext_configurator
-    assert 'godot-ai==%s" % version' in vnext_configurator
+    # uvx pin: stock uses `version`; local-build builds use `_pypi_pin_version` → `pypi_version`.
+    assert (
+        'godot-ai==%s" % version' in vnext_configurator
+        or 'godot-ai==%s" % pypi_version' in vnext_configurator
+    )
     assert "var version := SELF_UPDATE_SMOKE_SERVER_VERSION" in vnext_configurator
     assert "return default_port" in vnext_configurator
     assert "static func ensure_settings_registered() -> void:" in vnext_configurator


### PR DESCRIPTION
## Motivation

When res://addons/godot_ai is a directory junction or symlink into a source checkout, ProjectSettings.globalize_path only walks the logical project path and never finds the checkout .venv. The plugin then falls through to uvx with a package version that may include PEP 440 local metadata (e.g. 3.0.2+local.1), which is not on PyPI.

## Change

- Resolve addon real path via DirAccess.read_link and walk up from that target for .venv + src/godot_ai.
- Optional GODOT_AI_VENV_PYTHON override.
- Strip +local metadata for uvx pins (_pypi_pin_version); keep pre-release tags like -rc1.
- Clearer dock crash copy for local-build metadata.

## Tests (docs/CONTRIBUTING.md)

- [x] Branched from main
- [x] Godot-side (test_clients.gd): pypi pin, resolve_addons_realpath, junction-depth venv walk
- [x] Python: self-update smoke harness accepts pypi_version pin form
- [x] ruff check src/ tests/

## Scope

Infra only. No new MCP tools. No package version bump.
