### PR TITLE
Add Grok Build MCP client descriptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Godot Asset Library](https://img.shields.io/badge/Godot-Asset%20Library-478cbf?logo=godotengine&logoColor=white)](https://godotengine.org/asset-library/asset/5050)
 [![Discord](https://img.shields.io/badge/Discord-Join%20chat-5865F2?logo=discord&logoColor=white)](https://discord.gg/FDZ5fr2QkP)
 
-**Connect MCP clients directly to a live Godot editor** via the [Model Context Protocol](https://modelcontextprotocol.io/introduction). Over **120 ops across ~43 MCP tools** ([full list](docs/TOOLS.md)) let AI assistants (Claude Code, Codex, Antigravity, Hermes Agent, etc.) build scenes, edit nodes and scripts, wire signals, and configure UI, materials, animations, particles, cameras, and environments.
+**Connect MCP clients directly to a live Godot editor** via the [Model Context Protocol](https://modelcontextprotocol.io/introduction). Over **120 ops across ~43 MCP tools** ([full list](docs/TOOLS.md)) let AI assistants (Claude Code, Codex, **Grok Build**, Antigravity, Hermes Agent, etc.) build scenes, edit nodes and scripts, wire signals, and configure UI, materials, animations, particles, cameras, and environments.
 
 > 🎉 **Now on the [Godot Asset Library](https://godotengine.org/asset-library/asset/5050) and the [new Godot Asset Store](https://store.godotengine.org/asset/dlight/godot-ai/)** — one-click install from Godot's **AssetLib** tab. You'll still need [uv](https://docs.astral.sh/uv/) for the Python server (see [Quick Start](#quick-start)).
 
@@ -82,7 +82,7 @@ covers:
 <details>
 <summary><strong>…and 17+ more clients</strong></summary>
 
-Codex, Cursor, Devin Desktop (formerly Windsurf), VS Code, VS Code Insiders, Zed, Gemini CLI, Cline,
+Codex, **Grok Build**, Cursor, Devin Desktop (formerly Windsurf), VS Code, VS Code Insiders, Zed, Gemini CLI, Cline,
 Kilo Code, Roo Code, Zoo Code, Kiro, Trae, Cherry Studio, OpenCode, Qwen Code,
 Kimi Code.
 
@@ -125,6 +125,16 @@ claude mcp add --scope user --transport http godot-ai http://127.0.0.1:8000/mcp
 url = "http://127.0.0.1:8000/mcp"
 enabled = true
 ```
+
+**Grok Build** (`~/.grok/config.toml`)
+
+```toml
+[mcp_servers.godot-ai]
+url = "http://127.0.0.1:8000/mcp"
+enabled = true
+```
+
+Or dock → **Clients** → **Grok Build** → **Configure**.
 
 **Antigravity** (`~/.gemini/config/mcp_config.json`)
 

--- a/docs/packaging-distribution.md
+++ b/docs/packaging-distribution.md
@@ -119,6 +119,7 @@ The install docs should explicitly cover:
 
 - Claude Code
 - Codex
+- Grok Build
 - at least one more MCP client
 
 ---

--- a/docs/port-conflicts.md
+++ b/docs/port-conflicts.md
@@ -66,10 +66,11 @@ claude mcp remove godot-ai
 claude mcp add --scope user --transport http godot-ai http://127.0.0.1:8001/mcp
 ```
 
-For config-file clients (Codex, Antigravity, Cursor, …), edit the `url` /
-`serverUrl` field to match the new port. See the **Manual Client
+For config-file clients (Codex, Grok Build, Antigravity, Cursor, …), edit the
+`url` / `serverUrl` field to match the new port. See the **Manual Client
 Configuration** section in the [README](../README.md) for each client's file
-and format.
+and format. Grok Build uses `~/.grok/config.toml`
+(`[mcp_servers.godot-ai]`).
 
 ## Reverting
 

--- a/plugin/addons/godot_ai/clients/_registry.gd
+++ b/plugin/addons/godot_ai/clients/_registry.gd
@@ -9,6 +9,7 @@ const _CLIENT_SCRIPTS := [
 	preload("res://addons/godot_ai/clients/claude_code.gd"),
 	preload("res://addons/godot_ai/clients/claude_desktop.gd"),
 	preload("res://addons/godot_ai/clients/codex.gd"),
+	preload("res://addons/godot_ai/clients/grok.gd"),
 	preload("res://addons/godot_ai/clients/antigravity.gd"),
 	preload("res://addons/godot_ai/clients/cursor.gd"),
 	preload("res://addons/godot_ai/clients/windsurf.gd"),

--- a/plugin/addons/godot_ai/clients/grok.gd
+++ b/plugin/addons/godot_ai/clients/grok.gd
@@ -1,0 +1,22 @@
+@tool
+extends McpClient
+
+
+func _init() -> void:
+	id = "grok"
+	display_name = "Grok Build"
+	config_type = "toml"
+	# Grok Build reads MCP servers from ~/.grok/config.toml
+	# (https://x.ai / Grok user guide: MCP servers section).
+	path_template = {
+		"unix": "~/.grok/config.toml",
+		"windows": "$USERPROFILE/.grok/config.toml",
+	}
+	toml_section_path = PackedStringArray(["mcp_servers", "godot-ai"])
+	# Some docs / older notes used an underscore form.
+	toml_legacy_section_aliases = PackedStringArray(["mcp_servers.godot_ai"])
+	toml_body_template = PackedStringArray([
+		"url = \"{url}\"",
+		"enabled = true",
+	])
+	detect_paths = PackedStringArray(path_template.values())

--- a/plugin/addons/godot_ai/clients/grok.gd.uid
+++ b/plugin/addons/godot_ai/clients/grok.gd.uid
@@ -1,0 +1,1 @@
+uid://ckchsj5s3q1b0

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -50,8 +50,23 @@ func test_registry_loads_all_clients() -> void:
 	var ids := McpClientRegistry.ids()
 	assert_gt(ids.size(), 10, "Expected at least 10 registered clients, got %d" % ids.size())
 	# Each existing client must remain registered for behaviour parity.
-	for required in ["claude_code", "claude_desktop", "codex", "antigravity", "zoo_code", "hermes"]:
+	for required in ["claude_code", "claude_desktop", "codex", "grok", "antigravity", "zoo_code", "hermes"]:
 		assert_true(McpClientRegistry.has_id(required), "Missing client: %s" % required)
+
+
+func test_grok_client_toml_descriptor() -> void:
+	var client := McpClientRegistry.get_by_id("grok")
+	assert_true(client != null, "grok client must be registered")
+	assert_eq(client.display_name, "Grok Build")
+	assert_eq(client.config_type, "toml")
+	assert_eq(
+		String(client.path_template.get("unix", "")),
+		"~/.grok/config.toml",
+		"Grok Build config path must be ~/.grok/config.toml"
+	)
+	assert_eq(client.toml_section_path.size(), 2)
+	assert_eq(String(client.toml_section_path[0]), "mcp_servers")
+	assert_eq(String(client.toml_section_path[1]), "godot-ai")
 
 
 func test_registry_ids_are_unique() -> void:


### PR DESCRIPTION
## Motivation

Grok Build reads MCP server config from ~/.grok/config.toml. Godot AI already supports many clients via the descriptor registry; Grok Build was missing.

## Change

- Add clients/grok.gd (TOML, same shape as Codex).
- Register in _registry.gd.
- Document configure path in README + port-conflicts / packaging lists.
- Registry + descriptor tests in test_clients.gd.

## Tests (docs/CONTRIBUTING.md)

- [x] Branched from main
- [x] Godot-side tests for new client (plugin boundary): registry requires grok; test_grok_client_toml_descriptor
- [x] ruff check src/ tests/ (no Python surface change)

## Scope

Client descriptor only. No workflow tools, no version bump.
