### PR TITLE
Add workflow_manage helpers for modeling and visual QA

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -181,6 +181,7 @@ Calls take the form:
 | `resource_manage` | `search`, `load`, `assign`, `get_info`, `create`, `curve_set_points`, `environment_create`, `physics_shape_autofit`, `gradient_texture_create`, `noise_texture_create` |
 | `api_manage` | `get_class` |
 | `client_manage` | `status`, `configure`, `remove` |
+| `workflow_manage` | `modeling_guidance`, `asset_pipeline`, `screenshot_verify`, `visual_qa`, `install_hints` |
 | `tilemap_manage` | `tilemap_set_cell`, `tilemap_set_cells_rect`, `tilemap_clear`, `tilemap_get_cells` |
 | `tileset_manage` | `tileset_get_atlas_tiles`, `tileset_get_atlas_image` |
 

--- a/plugin/addons/godot_ai/tool_catalog.gd
+++ b/plugin/addons/godot_ai/tool_catalog.gd
@@ -47,6 +47,7 @@ const DOMAINS := [
 	{"id": "editor", "label": "editor", "count": 4, "tools": ["editor_manage", "editor_reload_plugin", "editor_screenshot", "logs_read"]},
 	{"id": "filesystem", "label": "filesystem", "count": 1, "tools": ["filesystem_manage"]},
 	{"id": "game", "label": "game", "count": 1, "tools": ["game_manage"]},
+	{"id": "workflow", "label": "workflow", "count": 1, "tools": ["workflow_manage"]},
 	{"id": "input_map", "label": "input_map", "count": 1, "tools": ["input_map_manage"]},
 	{"id": "material", "label": "material", "count": 1, "tools": ["material_manage"]},
 	{"id": "node", "label": "node", "count": 4, "tools": ["node_create", "node_find", "node_manage", "node_set_property"]},

--- a/src/godot_ai/handlers/workflow.py
+++ b/src/godot_ai/handlers/workflow.py
@@ -1,0 +1,409 @@
+"""Shared handlers for agent workflow helpers (modeling, assets, visual QA).
+
+These ops are intentionally composition-first: they use existing editor
+commands (filesystem search, screenshots, editor state) rather than new
+plugin WebSocket commands. Pure-guidance ops ignore the runtime connection
+when no Godot session is required.
+
+Exposed via the ``workflow_manage`` MCP rollup (domain id: ``workflow``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from godot_ai.handlers import editor as editor_handlers
+from godot_ai.handlers import filesystem as filesystem_handlers
+from godot_ai.handlers import project as project_handlers
+from godot_ai.runtime.direct import DirectRuntime
+
+## Default visual-QA checklist — project-agnostic; callers may override.
+_DEFAULT_CHECKLIST: tuple[str, ...] = (
+    "Composition readable at play-camera distance",
+    "Materials/textures intentional (not pure white or single flat color)",
+    "Props sit on surfaces (no major floating or sinking)",
+    "Lighting not over-blown; emission intentional",
+    "UI readable; no debug clutter covering important art",
+    "No obvious z-fighting or double geometry on surfaces",
+)
+
+_STYLE_GUIDANCE: dict[str, dict[str, Any]] = {
+    "general_pbr": {
+        "summary": "General-purpose PBR props and environments for Godot 4.",
+        "silhouette": [
+            "Readable massing at game camera distance before fine detail",
+            "Avoid hairline spikes; thicken thin silhouettes for 3D readability",
+        ],
+        "naming": [
+            "Mesh names describe role (Body, Trim, Glass, Collision if separate)",
+            "Keep glTF node names stable — Godot material overrides key off names",
+        ],
+        "materials": [
+            "Albedo + Normal + Roughness (AO optional); pack height in alpha when required",
+            "Prefer StandardMaterial3D or ORM; avoid unique shaders until needed",
+            "sRGB albedo, linear normal maps (OpenGL convention for Godot)",
+        ],
+        "poly_budget": [
+            "Hero props: roughly 1k–8k tris depending on screen size",
+            "Background clutter: under ~500 tris; use LODs for dense forests",
+        ],
+        "export": [
+            "glTF 2.0 binary (.glb) preferred for single-file props",
+            "Apply scale in Blender (unit = meter); Y-up; forward -Z",
+            "Apply modifiers; freeze transforms before export",
+        ],
+    },
+    "low_poly": {
+        "summary": "Stylized low-poly assets with clear faceting.",
+        "silhouette": [
+            "Bold primary shapes; secondary bevels sparingly",
+            "Canopy / foliage as clusters of simple solids, not leaf cards (unless intentional)",
+        ],
+        "naming": [
+            "Prefix role: Trunk*, Canopy*, Rock*, Building*",
+            "One mesh per material role when possible for runtime recolor",
+        ],
+        "materials": [
+            "Flat or soft gradients; limited palette (3–5 colors per prop)",
+            "Roughness high for rock/bark; mid for painted wood; low for crystals",
+            "Emission only for hero glow states (power, magic, interactables)",
+        ],
+        "poly_budget": [
+            "Trees: ~200–800 tris; buildings: modular pieces under ~1k each",
+            "Prefer instances over unique high-density meshes",
+        ],
+        "export": [
+            "glTF .glb; no subdivision surface modifiers left active",
+            "Hard edges via auto-smooth or marked edges for faceted look",
+        ],
+    },
+    "stylized_ethereal": {
+        "summary": "Dreamy / ethereal stylized look (soft glow, cool rock, mint flora).",
+        "silhouette": [
+            "Soft organic forms and lobed foliage; avoid photoreal tree noise",
+            "Floating or elevated forms need clear underside mass so they read as solid",
+        ],
+        "naming": [
+            "Trees: Trunk* / Canopy* (classifiers often key off these substrings)",
+            "Split walkable top vs cliff/side materials when both are visible",
+        ],
+        "materials": [
+            "Bark: muted purple-brown, high roughness (~0.85–0.92)",
+            "Leaves: mint/teal, mid roughness; soft emission for magical states",
+            "Rock: cool grey-blue, not sandy warm beige",
+            "Dead/desaturated vs restored theme-color emission when games use restore loops",
+        ],
+        "poly_budget": [
+            "Stylized trees ~300–900 tris with 4–6 canopy lobes + short branches",
+            "Keep cliff skirts separate from walkable tops when dual materials help",
+        ],
+        "export": [
+            "glTF .glb; headless Blender pipelines work well for agent iteration",
+            "Keep origin at base (characters/props) or logical center (islands/platforms)",
+        ],
+    },
+}
+
+
+def _normalize_style(style: str) -> str:
+    key = (style or "general_pbr").strip().lower().replace("-", "_")
+    if key in _STYLE_GUIDANCE:
+        return key
+    return "general_pbr"
+
+
+async def workflow_modeling_guidance(
+    runtime: DirectRuntime,
+    style: str = "general_pbr",
+    topic: str = "props",
+) -> dict:
+    """Return structured 3D modeling guidance for agent asset work.
+
+    Does not require a live Godot write lock. ``runtime`` is accepted for
+    manage-tool API consistency and may be unused.
+    """
+    del runtime  # pure guidance
+    style_key = _normalize_style(style)
+    guide = dict(_STYLE_GUIDANCE[style_key])
+    guide["style"] = style_key
+    guide["topic"] = topic or "props"
+    guide["godot_notes"] = [
+        "Godot 4.x Forward+; import .glb via EditorFileSystem",
+        "Prefer runtime material overrides for state changes over many mesh variants",
+        "Name meshes for classification (trunk vs canopy, cliff vs top)",
+        "Keep collision simpler than render mesh (convex or trimmed trimesh)",
+    ]
+    guide["checklist"] = [
+        "Silhouette readable at play camera distance",
+        "Mesh names match material override conventions",
+        "Scale is meters; player height ~1.7 m reference",
+        "Exported .glb opens cleanly in Godot without missing buffers",
+        "Materials not pure white/black; roughness set intentionally",
+    ]
+    return guide
+
+
+async def workflow_asset_pipeline(
+    runtime: DirectRuntime,
+    path: str = "res://",
+    limit: int = 80,
+) -> dict:
+    """Scan the project for common asset-pipeline signals."""
+    root = path or "res://"
+    if not root.startswith("res://"):
+        root = "res://" + root.lstrip("/")
+
+    glb = await filesystem_handlers.filesystem_search(runtime, name=".glb", path=root, limit=limit)
+    gltf = await filesystem_handlers.filesystem_search(
+        runtime, name=".gltf", path=root, limit=max(20, limit // 4)
+    )
+    blender = await filesystem_handlers.filesystem_search(
+        runtime, name="blender", path=root, limit=40
+    )
+    pbr = await filesystem_handlers.filesystem_search(
+        runtime, name=".jpg", path="res://assets", limit=limit
+    )
+    terrain = await filesystem_handlers.filesystem_search(
+        runtime, name="terrain_3d", path="res://addons", limit=20
+    )
+
+    glb_files = list(glb.get("files") or [])
+    gltf_files = list(gltf.get("files") or [])
+    blender_hits = list(blender.get("files") or [])
+    pbr_hits = list(pbr.get("files") or [])
+    terrain_hits = list(terrain.get("files") or [])
+
+    found = {
+        "glb_count": len(glb_files),
+        "gltf_count": len(gltf_files),
+        "blender_path_hits": len(blender_hits),
+        "pbr_jpg_hits": len(pbr_hits),
+        "terrain3d_hits": len(terrain_hits),
+        "sample_glb": glb_files[:12],
+        "sample_blender": blender_hits[:8],
+    }
+
+    missing: list[str] = []
+    recommendations: list[str] = []
+    if found["glb_count"] + found["gltf_count"] == 0:
+        missing.append("No .glb/.gltf under scan root")
+        recommendations.append(
+            "Add props via Blender glTF export or kitbash packs under res://assets/"
+        )
+    if found["blender_path_hits"] == 0:
+        recommendations.append(
+            "Optional: tools/blender (or similar) scripts help agents regenerate assets headlessly"
+        )
+    if found["pbr_jpg_hits"] == 0:
+        recommendations.append(
+            "Consider CC0 PBR maps (albedo/normal/roughness) under "
+            "res://assets/pbr/ when using textured materials"
+        )
+    if found["terrain3d_hits"] == 0:
+        recommendations.append(
+            "Terrain3D not detected — use mesh heightfields or install "
+            "Terrain3D for painted terrain"
+        )
+    else:
+        recommendations.append(
+            "Terrain3D present — prefer discrete regions/holes when the "
+            "world should not be a continuous floor"
+        )
+
+    recommendations.append(
+        "After asset changes: EditorFileSystem scan / reimport; smoke with project_run + screenshot"
+    )
+
+    return {
+        "root": root,
+        "found": found,
+        "missing": missing,
+        "recommendations": recommendations,
+    }
+
+
+async def workflow_screenshot_verify(
+    runtime: DirectRuntime,
+    source: str = "viewport",
+    max_resolution: int = 800,
+    include_image: bool = False,
+    checklist: list[str] | None = None,
+    view_target: str = "",
+    elevation: float | None = None,
+    azimuth: float | None = None,
+    fov: float | None = None,
+) -> dict:
+    """Capture a screenshot and attach a structured visual checklist.
+
+    Defaults to ``include_image=False`` so tool-capped clients get compact
+    JSON metadata; set ``include_image=True`` when the agent must see pixels.
+    Checklist items are returned as *pending agent review* (not auto-scored).
+    """
+    items = list(checklist) if checklist else list(_DEFAULT_CHECKLIST)
+    capture = await editor_handlers.editor_screenshot(
+        runtime,
+        source=source,
+        max_resolution=max_resolution,
+        include_image=include_image,
+        view_target=view_target,
+        elevation=elevation,
+        azimuth=azimuth,
+        fov=fov,
+    )
+
+    # When include_image=True the editor handler may return a content-block list.
+    if isinstance(capture, list):
+        meta: dict[str, Any] = {"content_blocks": True, "block_count": len(capture)}
+        for block in capture:
+            if hasattr(block, "text"):
+                try:
+                    import json
+
+                    meta.update(json.loads(block.text))
+                except Exception:
+                    meta["text_preview"] = str(getattr(block, "text", ""))[:200]
+                break
+        capture_out: Any = meta
+    else:
+        capture_out = capture
+
+    checklist_results = [
+        {
+            "item": item,
+            "status": "pending_agent_review",
+            "hint": "Compare against the capture; mark pass/fail in your notes",
+        }
+        for item in items
+    ]
+
+    return {
+        "capture": capture_out,
+        "source": source,
+        "checklist_results": checklist_results,
+        "agent_instructions": (
+            "Visually inspect the capture (or re-call with include_image=true). "
+            "Update each checklist item to pass/fail with a one-line reason. "
+            "For game-view QA, prefer source=game after project_run when helper_live."
+        ),
+    }
+
+
+async def workflow_visual_qa(
+    runtime: DirectRuntime,
+    sources: list[str] | None = None,
+    run_if_needed: bool = False,
+    max_resolution: int = 640,
+    include_image: bool = False,
+) -> dict:
+    """Multi-shot visual QA: optional play, then screenshots per source."""
+    sources = sources or ["viewport"]
+    state = await editor_handlers.editor_state(runtime)
+    game_status = state.get("game_status") or {}
+    helper_live = bool(state.get("helper_live") or game_status.get("helper_live"))
+    is_playing = bool(state.get("is_playing"))
+
+    ran = False
+    if run_if_needed and not is_playing:
+        await project_handlers.project_run(runtime, mode="main", autosave=True)
+        ran = True
+        # Wait briefly for helper liveness (best-effort; do not hang forever).
+        for _ in range(20):
+            await asyncio.sleep(0.5)
+            state = await editor_handlers.editor_state(runtime)
+            game_status = state.get("game_status") or {}
+            helper_live = bool(state.get("helper_live") or game_status.get("helper_live"))
+            is_playing = bool(state.get("is_playing"))
+            if helper_live or not is_playing:
+                break
+
+    shots: list[dict[str, Any]] = []
+    for src in sources:
+        src_norm = (src or "viewport").strip().lower()
+        if src_norm == "game" and not helper_live:
+            shots.append(
+                {
+                    "source": src_norm,
+                    "skipped": True,
+                    "reason": "Game helper not live; project_run first or set run_if_needed=true",
+                }
+            )
+            continue
+        try:
+            result = await workflow_screenshot_verify(
+                runtime,
+                source=src_norm,
+                max_resolution=max_resolution,
+                include_image=include_image,
+            )
+            shots.append({"source": src_norm, "skipped": False, "result": result})
+        except Exception as exc:  # noqa: BLE001 — surface per-shot failures
+            shots.append({"source": src_norm, "skipped": True, "reason": str(exc)})
+
+    return {
+        "ran_project": ran,
+        "is_playing": is_playing,
+        "helper_live": helper_live,
+        "shots": shots,
+        "summary": (
+            f"{sum(1 for s in shots if not s.get('skipped'))} shot(s) captured; "
+            f"{sum(1 for s in shots if s.get('skipped'))} skipped"
+        ),
+    }
+
+
+async def workflow_install_hints(runtime: DirectRuntime) -> dict:
+    """Return instructions to wire Godot AI into Grok Build and common installs."""
+    del runtime
+    return {
+        "title": "Connect Godot AI to Grok Build (and related clients)",
+        "mcp_url": "http://127.0.0.1:8000/mcp",
+        "grok_config_toml": (
+            '[mcp_servers.godot-ai]\nurl = "http://127.0.0.1:8000/mcp"\nenabled = true\n'
+        ),
+        "options": [
+            {
+                "name": "dock_configure",
+                "steps": [
+                    "Install the Godot AI plugin under res://addons/godot_ai and enable it",
+                    "Open the Godot AI dock → Clients → Grok Build → Configure",
+                    "Confirm ~/.grok/config.toml has [mcp_servers.godot-ai] with the MCP URL",
+                    "Restart or reload Grok Build so it picks up the MCP server",
+                ],
+            },
+            {
+                "name": "manual_toml",
+                "steps": [
+                    "Create or edit ~/.grok/config.toml "
+                    "(Windows: %USERPROFILE%\\.grok\\config.toml)",
+                    'Add: [mcp_servers.godot-ai] url = "http://127.0.0.1:8000/mcp" '
+                    "enabled = true",
+                    "Ensure the Godot editor is running with the plugin so the server is up",
+                ],
+            },
+            {
+                "name": "external_python_server",
+                "steps": [
+                    "From a godot-ai checkout: "
+                    "python -m godot_ai --transport streamable-http --port 8000",
+                    "Plugin adopts an existing server on :8000 when already listening",
+                    "Point Grok at http://127.0.0.1:8000/mcp",
+                ],
+            },
+            {
+                "name": "dev_checkout_junction",
+                "steps": [
+                    "For local development, junction/symlink project addons/godot_ai → "
+                    "checkout/plugin/addons/godot_ai so the plugin finds the fork .venv",
+                    "Optional: set GODOT_AI_VENV_PYTHON to the checkout .venv python",
+                    "Plugin versions with PEP 440 local tags (e.g. 3.0.2+local.1) pin uvx "
+                    "to the base PyPI version; prefer the dev venv for extras not on PyPI",
+                ],
+            },
+        ],
+        "docs": [
+            "README.md (install + clients)",
+            "docs/TOOLS.md (workflow_manage ops)",
+            "docs/port-conflicts.md (MCP URL / ports)",
+        ],
+    }

--- a/src/godot_ai/handlers/workflow.py
+++ b/src/godot_ai/handlers/workflow.py
@@ -376,8 +376,7 @@ async def workflow_install_hints(runtime: DirectRuntime) -> dict:
                 "steps": [
                     "Create or edit ~/.grok/config.toml "
                     "(Windows: %USERPROFILE%\\.grok\\config.toml)",
-                    'Add: [mcp_servers.godot-ai] url = "http://127.0.0.1:8000/mcp" '
-                    "enabled = true",
+                    'Add: [mcp_servers.godot-ai] url = "http://127.0.0.1:8000/mcp" enabled = true',
                     "Ensure the Godot editor is running with the plugin so the server is up",
                 ],
             },

--- a/src/godot_ai/server.py
+++ b/src/godot_ai/server.py
@@ -77,6 +77,7 @@ from godot_ai.tools.theme import register_theme_tools
 from godot_ai.tools.tilemap import register_tilemap_tools
 from godot_ai.tools.tileset import register_tileset_tools
 from godot_ai.tools.ui import register_ui_tools
+from godot_ai.tools.workflow import register_workflow_tools
 from godot_ai.transport.origin_guard import IPNetwork, LocalhostOnlyHTTPMiddleware
 from godot_ai.transport.websocket import GodotWebSocketServer
 
@@ -291,7 +292,9 @@ def create_server(
             "                   physics_shape_autofit, gradient_texture_create,\n"
             "                   noise_texture_create\n"
             "  api_manage       get_class\n"
-            "  client_manage    status, configure, remove\n\n"
+            "  client_manage    status, configure, remove\n"
+            "  workflow_manage  modeling_guidance, asset_pipeline, screenshot_verify,\n"
+            "                   visual_qa, install_hints\n\n"
             "  tilemap_manage   tilemap_set_cell, tilemap_set_cells_rect,\n"
             "                   tilemap_clear, tilemap_get_cells\n"
             "  tileset_manage   tileset_get_atlas_tiles, tileset_get_atlas_image\n\n"
@@ -417,6 +420,8 @@ def create_server(
         register_input_map_tools(mcp)
     if "game" not in exclude:
         register_game_tools(mcp)
+    if "workflow" not in exclude:
+        register_workflow_tools(mcp)
     if "testing" not in exclude:
         register_testing_tools(mcp)
     if "batch" not in exclude:

--- a/src/godot_ai/tools/domains.py
+++ b/src/godot_ai/tools/domains.py
@@ -40,6 +40,7 @@ DOMAINS: tuple[str, ...] = (
     "autoload",
     "input_map",
     "game",
+    "workflow",
     "testing",
     "batch",
     "ui",

--- a/src/godot_ai/tools/workflow.py
+++ b/src/godot_ai/tools/workflow.py
@@ -1,0 +1,55 @@
+"""MCP tools for agent workflow helpers (modeling, assets, visual QA)."""
+
+from __future__ import annotations
+
+from fastmcp import FastMCP
+
+from godot_ai.handlers import workflow as workflow_handlers
+from godot_ai.tools._meta_tool import register_manage_tool
+
+_DESCRIPTION = """\
+Agent workflow helpers for Godot: modeling guidance, asset pipeline scans,
+screenshot verification, multi-shot visual QA, and client install hints
+(including Grok Build MCP config).
+
+Ops:
+  • modeling_guidance(style="general_pbr", topic="props")
+        Structured 3D modeling guidance (silhouette, naming, materials,
+        poly budget, export). Styles: general_pbr | low_poly | stylized_ethereal.
+  • asset_pipeline(path="res://", limit=80)
+        Scan the project for glTF/glb, Blender tooling paths, PBR maps,
+        Terrain3D; return found/missing/recommendations.
+  • screenshot_verify(source="viewport", max_resolution=800,
+                      include_image=false, checklist=null, view_target="",
+                      elevation=null, azimuth=null, fov=null)
+        Capture a screenshot (metadata by default) plus a visual checklist
+        for agent review. Prefer source=game when the project is playing.
+  • visual_qa(sources=null, run_if_needed=false, max_resolution=640,
+              include_image=false)
+        Optional project_run, then multi-source screenshot_verify shots.
+  • install_hints()
+        How to wire Godot AI into Grok Build and related clients.
+"""
+
+
+def register_workflow_tools(mcp: FastMCP) -> None:
+    register_manage_tool(
+        mcp,
+        tool_name="workflow_manage",
+        description=_DESCRIPTION,
+        ops={
+            "modeling_guidance": workflow_handlers.workflow_modeling_guidance,
+            "asset_pipeline": workflow_handlers.workflow_asset_pipeline,
+            "screenshot_verify": workflow_handlers.workflow_screenshot_verify,
+            "visual_qa": workflow_handlers.workflow_visual_qa,
+            "install_hints": workflow_handlers.workflow_install_hints,
+        },
+        read_resource_forms={
+            # Workflow helpers — no godot:// resource counterparts.
+            "modeling_guidance": None,
+            "asset_pipeline": None,
+            "screenshot_verify": None,
+            "visual_qa": None,
+            "install_hints": None,
+        },
+    )

--- a/tests/unit/test_workflow_handlers.py
+++ b/tests/unit/test_workflow_handlers.py
@@ -1,0 +1,203 @@
+"""Unit tests for workflow helpers (no live Godot required)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from godot_ai.handlers import workflow as workflow_handlers
+from godot_ai.server import create_server
+from godot_ai.tools.domains import DOMAINS, EXCLUDABLE_DOMAINS
+
+
+class _FakeRuntime:
+    """Minimal runtime stub for pure guidance ops."""
+
+
+@pytest.mark.asyncio
+async def test_modeling_guidance_styles() -> None:
+    rt = _FakeRuntime()
+    for style in ("general_pbr", "low_poly", "stylized_ethereal"):
+        out = await workflow_handlers.workflow_modeling_guidance(rt, style=style)  # type: ignore[arg-type]
+        assert out["style"] == style
+        assert "silhouette" in out
+        assert "materials" in out
+        assert out["checklist"]
+
+
+@pytest.mark.asyncio
+async def test_modeling_guidance_unknown_style_falls_back() -> None:
+    out = await workflow_handlers.workflow_modeling_guidance(_FakeRuntime(), style="nope")  # type: ignore[arg-type]
+    assert out["style"] == "general_pbr"
+
+
+@pytest.mark.asyncio
+async def test_install_hints_has_options() -> None:
+    out = await workflow_handlers.workflow_install_hints(_FakeRuntime())  # type: ignore[arg-type]
+    assert out["mcp_url"].startswith("http://127.0.0.1:8000")
+    assert len(out["options"]) >= 2
+    names = {o["name"] for o in out["options"]}
+    assert "dock_configure" in names
+    assert "manual_toml" in names
+    assert "dev_checkout_junction" in names
+    # Upstream-safe: no hard dependency on a personal fork URL in title
+    assert "shelbykb2" not in out["title"].lower()
+
+
+@pytest.mark.asyncio
+async def test_asset_pipeline_aggregates_searches(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    async def fake_search(
+        runtime: Any,
+        name: str = "",
+        type: str = "",
+        path: str = "",
+        offset: int = 0,
+        limit: int = 100,
+    ) -> dict:
+        calls.append({"name": name, "path": path, "limit": limit})
+        if name == ".glb":
+            return {"files": ["res://assets/a.glb", "res://assets/b.glb"]}
+        if name == "terrain_3d":
+            return {"files": ["res://addons/terrain_3d/plugin.cfg"]}
+        return {"files": []}
+
+    monkeypatch.setattr(
+        "godot_ai.handlers.filesystem.filesystem_search",
+        fake_search,
+    )
+    out = await workflow_handlers.workflow_asset_pipeline(_FakeRuntime())  # type: ignore[arg-type]
+    assert out["found"]["glb_count"] == 2
+    assert out["found"]["terrain3d_hits"] == 1
+    assert any("Terrain3D present" in r for r in out["recommendations"])
+    assert len(calls) >= 4
+
+
+@pytest.mark.asyncio
+async def test_asset_pipeline_normalizes_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_search(*_a: Any, **kwargs: Any) -> dict:
+        return {"files": []}
+
+    monkeypatch.setattr("godot_ai.handlers.filesystem.filesystem_search", fake_search)
+    out = await workflow_handlers.workflow_asset_pipeline(
+        _FakeRuntime(),  # type: ignore[arg-type]
+        path="assets/props",
+    )
+    assert out["root"] == "res://assets/props"
+
+
+@pytest.mark.asyncio
+async def test_screenshot_verify_checklist(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_shot(*_a: Any, **_k: Any) -> dict:
+        return {
+            "source": "viewport",
+            "width": 640,
+            "height": 360,
+            "original_width": 1280,
+            "original_height": 720,
+            "format": "png",
+        }
+
+    monkeypatch.setattr(
+        "godot_ai.handlers.editor.editor_screenshot",
+        fake_shot,
+    )
+    out = await workflow_handlers.workflow_screenshot_verify(
+        _FakeRuntime(),  # type: ignore[arg-type]
+        source="viewport",
+        checklist=["Item A", "Item B"],
+    )
+    assert out["capture"]["width"] == 640
+    assert len(out["checklist_results"]) == 2
+    assert out["checklist_results"][0]["status"] == "pending_agent_review"
+
+
+@pytest.mark.asyncio
+async def test_screenshot_verify_content_blocks(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Block:
+        def __init__(self, text: str) -> None:
+            self.text = text
+
+    async def fake_shot(*_a: Any, **_k: Any) -> list:
+        return [_Block('{"width": 320, "height": 180}')]
+
+    monkeypatch.setattr("godot_ai.handlers.editor.editor_screenshot", fake_shot)
+    out = await workflow_handlers.workflow_screenshot_verify(_FakeRuntime())  # type: ignore[arg-type]
+    assert out["capture"]["content_blocks"] is True
+    assert out["capture"]["width"] == 320
+
+
+@pytest.mark.asyncio
+async def test_visual_qa_skips_game_when_not_live(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_state(_runtime: Any) -> dict:
+        return {"is_playing": False, "helper_live": False, "game_status": {"helper_live": False}}
+
+    monkeypatch.setattr("godot_ai.handlers.editor.editor_state", fake_state)
+
+    out = await workflow_handlers.workflow_visual_qa(
+        _FakeRuntime(),  # type: ignore[arg-type]
+        sources=["game"],
+        run_if_needed=False,
+    )
+    assert out["shots"][0]["skipped"] is True
+    assert out["ran_project"] is False
+
+
+@pytest.mark.asyncio
+async def test_visual_qa_run_if_needed(monkeypatch: pytest.MonkeyPatch) -> None:
+    states = iter(
+        [
+            {"is_playing": False, "helper_live": False, "game_status": {"helper_live": False}},
+            {"is_playing": True, "helper_live": True, "game_status": {"helper_live": True}},
+            {"is_playing": True, "helper_live": True, "game_status": {"helper_live": True}},
+        ]
+    )
+    ran: list[bool] = []
+
+    async def fake_state(_runtime: Any) -> dict:
+        return next(states)
+
+    async def fake_run(_runtime: Any, **_k: Any) -> dict:
+        ran.append(True)
+        return {"ok": True}
+
+    async def fake_shot(*_a: Any, **_k: Any) -> dict:
+        return {"source": "viewport", "width": 64, "height": 36}
+
+    monkeypatch.setattr("godot_ai.handlers.editor.editor_state", fake_state)
+    monkeypatch.setattr("godot_ai.handlers.project.project_run", fake_run)
+    monkeypatch.setattr("godot_ai.handlers.editor.editor_screenshot", fake_shot)
+    monkeypatch.setattr("godot_ai.handlers.workflow.asyncio.sleep", _async_noop)
+
+    out = await workflow_handlers.workflow_visual_qa(
+        _FakeRuntime(),  # type: ignore[arg-type]
+        sources=["viewport"],
+        run_if_needed=True,
+    )
+    assert ran == [True]
+    assert out["ran_project"] is True
+    assert out["shots"][0]["skipped"] is False
+
+
+async def _async_noop(_seconds: float) -> None:
+    return None
+
+
+def test_workflow_domain_registered_and_excludable() -> None:
+    assert "workflow" in DOMAINS
+    assert "workflow" in EXCLUDABLE_DOMAINS
+    assert "grok" not in DOMAINS
+    server = create_server()
+    import asyncio
+
+    tools = asyncio.run(server.list_tools())
+    names = {t.name for t in tools}
+    assert "workflow_manage" in names
+    assert "grok_manage" not in names
+
+    server_ex = create_server(exclude_domains={"workflow"})
+    tools_ex = asyncio.run(server_ex.list_tools())
+    names_ex = {t.name for t in tools_ex}
+    assert "workflow_manage" not in names_ex


### PR DESCRIPTION
## Motivation

Agents repeatedly need modeling guidance, asset inventory, screenshot checklists, multi-shot visual QA, and MCP install hints. An excludable workflow domain keeps tool caps manageable (--exclude-domains=workflow) without new WebSocket commands.

## Change

- New domain workflow / tool workflow_manage (modeling_guidance, asset_pipeline, screenshot_verify, visual_qa, install_hints)
- Wired in domains.py, server.py, tool_catalog.gd, docs/TOOLS.md
- Composition-first handlers; pure-guidance ops do not require write lock

## Tests (docs/CONTRIBUTING.md)

- [x] Branched from main
- [x] Python unit tests: tests/unit/test_workflow_handlers.py
- [x] Domain catalog parity: tests/unit/test_tool_domains.py (Python to tool_catalog.gd)
- [x] ruff check / format on new modules
- [x] No new GDScript WebSocket commands; catalog row covered by parity tests

## Scope

New excludable tool domain only. Independent of the Grok client descriptor PR.
