### PR TITLE
ci: add Python 3.14 to test matrix and classifiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,11 @@ jobs:
         # release-smoke and godot-tests jobs, which still run on all 3 OSes.
         # See issue #35 before restoring the full matrix.
         os: [ubuntu-latest]
-        python-version: ["3.11", "3.13"]
+        # 3.11 is the floor (requires-python >=3.11); 3.14 is the ceiling —
+        # uvx may select it for user installs, so a 3.14-only regression
+        # must fail CI before release (#746). 3.13 stays as the coverage/
+        # tooling default used by the other jobs.
+        python-version: ["3.11", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Operating System :: OS Independent",
     "Environment :: Console",
     "Framework :: AsyncIO",


### PR DESCRIPTION
## Motivation

Closes #746.

`requires-python = ">=3.11"` has no upper bound, so `uvx` may select CPython 3.14 for user installs — but the `python-tests` CI matrix stopped at 3.13. A future dependency or language regression specific to 3.14 could ship to uvx users undetected. The issue reporter verified the current suite is already green on 3.14.2 (1364 passed, 13 skipped), so this closes a coverage gap rather than fixing a known failure.

## Change

- Add a `3.14` row to the `python-tests` matrix. The matrix is now floor (3.11) + coverage/tooling default (3.13) + ceiling (3.14). I kept 3.13 rather than dropping to the issue's optional two-row suggestion because every other job (release-smoke, godot-tests, smokes) pins 3.13 — the coverage cell condition from #749 stays keyed to it unchanged, and the new 3.14 row runs plain `pytest` via the existing complementary conditions.
- Add the `Programming Language :: Python :: 3.14` trove classifier in `pyproject.toml`.

## Tests

- `pyproject.toml` and `ci.yml` verified parseable (tomllib / yaml).
- No code change; the new matrix row exercises the existing suite on 3.14 in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiPyzz94bmAjjDYEhzc8JY

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiPyzz94bmAjjDYEhzc8JY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Python 3.14 to automated test coverage.
  * Updated package metadata to indicate Python 3.14 support.
  * Documented Python 3.11 as the minimum supported version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->