### PR TITLE
docs: replace broken Star History embed with a CI-generated chart

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -37,12 +37,14 @@ jobs:
 
       - name: Commit updated chart
         run: |
-          if git diff --quiet docs/images/star-history.svg; then
+          ## Stage first so a brand-new (untracked) chart is detected too —
+          ## `git diff --quiet` alone ignores untracked files.
+          git add docs/images/star-history.svg
+          if git diff --staged --quiet -- docs/images/star-history.svg; then
             echo "chart unchanged, nothing to commit"
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add docs/images/star-history.svg
           git commit -m "chore: update star history chart [skip ci]"
           git push

--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,0 +1,48 @@
+name: Star history chart
+
+## Regenerates the README's star-history chart (#750). GitHub restricted
+## detailed stargazer history to repo admins/collaborators, which broke
+## star-history.com's unauthenticated embed — so we render the chart
+## ourselves with the repo-scoped workflow token and commit the SVG.
+on:
+  workflow_dispatch:
+  schedule:
+    ## Weekly, Monday 06:20 UTC — off the top of the hour to dodge the
+    ## scheduled-workflow load spike.
+    - cron: "20 6 * * 1"
+
+permissions:
+  contents: write
+
+jobs:
+  update-chart:
+    runs-on: ubuntu-latest
+    ## Scheduled runs on forks would fail (no stargazer access) and spam.
+    if: github.repository == 'hi-godot/godot-ai'
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.13"
+
+      - name: Generate chart
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          ## Optional fallback: a collaborator PAT, only needed if GitHub
+          ## ever stops granting the workflow token stargazer access.
+          STAR_HISTORY_TOKEN: ${{ secrets.STAR_HISTORY_TOKEN }}
+        run: python script/generate-star-history --repo "$GITHUB_REPOSITORY"
+
+      - name: Commit updated chart
+        run: |
+          if git diff --quiet docs/images/star-history.svg; then
+            echo "chart unchanged, nothing to commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/images/star-history.svg
+          git commit -m "chore: update star history chart [skip ci]"
+          git push

--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@
 ### Prerequisites
 
 - Godot `4.5+` (`4.7+` recommended)
-- [uv](https://docs.astral.sh/uv/) (for the Python server):
+- [uv](https://docs.astral.sh/uv/) (for the Python server)
+
+  <details>
+  <summary>How to install uv (macOS / Linux / Windows / package managers)</summary>
+
   - **macOS / Linux:** `curl -LsSf https://astral.sh/uv/install.sh | sh`
   - **Windows (PowerShell):** `powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"`
   - **Prefer your package manager?** `uv` is a popular open-source tool packaged in
@@ -41,6 +45,8 @@
     - **Fedora:** `sudo dnf install uv`
     - **macOS (Homebrew):** `brew install uv`
   - Other options: [uv install docs](https://docs.astral.sh/uv/getting-started/installation/)
+
+  </details>
 - An MCP client ([Claude Code](https://docs.anthropic.com/en/docs/claude-code) | [Codex](https://openai.com/index/codex/) | [Antigravity](https://www.antigravity.dev/))
 
 ### 1. Install the plugin

--- a/README.md
+++ b/README.md
@@ -271,8 +271,12 @@ Full details (what's collected, where data lives, how to self-host the endpoint)
 
 ## Star History
 
-<a href="https://star-history.com/#hi-godot/godot-ai&Date">
-  <img src="https://api.star-history.com/svg?repos=hi-godot/godot-ai&type=Date" alt="Star History Chart" width="700">
+<!-- Regenerated weekly by .github/workflows/star-history.yml (#750):
+     GitHub restricted stargazer history to repo collaborators, which broke
+     star-history.com's unauthenticated embed, so the chart is now rendered
+     in CI and committed here. -->
+<a href="https://github.com/hi-godot/godot-ai/stargazers">
+  <img src="docs/images/star-history.svg" alt="Star History Chart" width="700">
 </a>
 
 ---

--- a/docs/images/star-history.svg
+++ b/docs/images/star-history.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="700" height="360" viewBox="0 0 700 360" role="img" aria-label="Star history of hi-godot/godot-ai">
+  <title>Star history of hi-godot/godot-ai</title>
+  <g font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif">
+    <text x="350.0" y="24" text-anchor="middle" font-size="16" font-weight="600" fill="#8b949e">hi-godot/godot-ai — GitHub stars over time</text>
+    <line x1="64" y1="312.0" x2="676" y2="312.0" stroke="#8b949e" stroke-opacity="0.25" stroke-width="1"/><text x="56" y="316.0" text-anchor="end" font-size="12" fill="#8b949e">0</text><line x1="64" y1="244.0" x2="676" y2="244.0" stroke="#8b949e" stroke-opacity="0.25" stroke-width="1"/><text x="56" y="248.0" text-anchor="end" font-size="12" fill="#8b949e">500</text><line x1="64" y1="176.0" x2="676" y2="176.0" stroke="#8b949e" stroke-opacity="0.25" stroke-width="1"/><text x="56" y="180.0" text-anchor="end" font-size="12" fill="#8b949e">1000</text><line x1="64" y1="108.0" x2="676" y2="108.0" stroke="#8b949e" stroke-opacity="0.25" stroke-width="1"/><text x="56" y="112.0" text-anchor="end" font-size="12" fill="#8b949e">1500</text><line x1="64" y1="40.0" x2="676" y2="40.0" stroke="#8b949e" stroke-opacity="0.25" stroke-width="1"/><text x="56" y="44.0" text-anchor="end" font-size="12" fill="#8b949e">2000</text>
+    <text x="64.0" y="332" text-anchor="start" font-size="12" fill="#8b949e">Apr 12, 2026</text><text x="218.6" y="332" text-anchor="middle" font-size="12" fill="#8b949e">May 06, 2026</text><text x="373.2" y="332" text-anchor="middle" font-size="12" fill="#8b949e">May 30, 2026</text><text x="521.4" y="332" text-anchor="middle" font-size="12" fill="#8b949e">Jun 22, 2026</text><text x="676.0" y="332" text-anchor="end" font-size="12" fill="#8b949e">Jul 16, 2026</text>
+    <polyline points="64.0,312.0 676.0,174.8" fill="none" stroke="#e8724c" stroke-width="2.5" stroke-linejoin="round" stroke-linecap="round"/>
+    <circle cx="676.0" cy="174.8" r="4" fill="#e8724c"/>
+    <text x="668.0" y="164.8" text-anchor="end" font-size="13" font-weight="600" fill="#e8724c">1009 ★</text>
+    <text x="676" y="352" text-anchor="end" font-size="10" fill="#8b949e" fill-opacity="0.7">updated 2026-07-16</text>
+  </g>
+</svg>

--- a/script/generate-star-history
+++ b/script/generate-star-history
@@ -140,7 +140,7 @@ def render_svg(points: list[tuple[date, int]], repo: str) -> str:
 
     poly = " ".join(f"{px(d):.1f},{py(c):.1f}" for d, c in points)
 
-    # Four horizontal gridlines with y-axis labels.
+    # Five horizontal gridlines (baseline + four intervals) with y-axis labels.
     grid_lines = []
     for i in range(5):
         value = round(y_max * i / 4)

--- a/script/generate-star-history
+++ b/script/generate-star-history
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Generate a static star-history SVG chart for the README.
+
+GitHub restricted detailed stargazer history (the `starred_at` timestamps
+behind `Accept: application/vnd.github.star+json`) to repository admins and
+collaborators, which broke star-history.com's unauthenticated README embed
+(#750). This script regenerates the chart from the GitHub API using an
+authenticated token (the Actions `GITHUB_TOKEN` qualifies for its own repo)
+and writes a self-contained SVG that the README references as a normal
+committed file.
+
+Usage:
+    GITHUB_TOKEN=... script/generate-star-history [--repo owner/name] [--out path]
+    script/generate-star-history --seed "2026-04-12:0,2026-07-16:1009" --out path
+
+`--seed` renders a chart from explicit `date:count` points without touching
+the network — used to commit an initial chart and for offline testing.
+
+Stdlib only; no dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import urllib.error
+import urllib.request
+from datetime import date, datetime, timezone
+
+API_ROOT = "https://api.github.com"
+# The stargazers endpoint is capped at 400 pages (40k stars) by GitHub.
+MAX_PAGES = 400
+PER_PAGE = 100
+
+WIDTH = 700
+HEIGHT = 360
+MARGIN_LEFT = 64
+MARGIN_RIGHT = 24
+MARGIN_TOP = 40
+MARGIN_BOTTOM = 48
+# Mid-tone palette readable on both GitHub light and dark backgrounds.
+LINE_COLOR = "#e8724c"
+TEXT_COLOR = "#8b949e"
+GRID_COLOR = "#8b949e"
+
+
+def fetch_star_dates(repo: str, token: str) -> list[date]:
+    """Return the starred_at date of every stargazer, oldest first."""
+    dates: list[date] = []
+    for page in range(1, MAX_PAGES + 1):
+        url = f"{API_ROOT}/repos/{repo}/stargazers?per_page={PER_PAGE}&page={page}"
+        req = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/vnd.github.star+json",
+                "Authorization": f"Bearer {token}",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                batch = json.load(resp)
+        except urllib.error.HTTPError as err:
+            if err.code in (401, 403, 404):
+                raise SystemExit(
+                    f"GitHub API returned {err.code} for {url}.\n"
+                    "Stargazer history requires repo-collaborator access. In CI, "
+                    "pass the workflow GITHUB_TOKEN; if GitHub stops granting it "
+                    "stargazer access, set a collaborator PAT as the "
+                    "STAR_HISTORY_TOKEN secret instead."
+                ) from err
+            raise
+        if not batch:
+            break
+        for entry in batch:
+            starred_at = entry.get("starred_at")
+            if starred_at:
+                dates.append(
+                    datetime.fromisoformat(starred_at.replace("Z", "+00:00")).date()
+                )
+        if len(batch) < PER_PAGE:
+            break
+    dates.sort()
+    return dates
+
+
+def cumulative_points(star_dates: list[date]) -> list[tuple[date, int]]:
+    """Collapse per-star dates into (date, cumulative_count) steps."""
+    points: list[tuple[date, int]] = []
+    count = 0
+    for day in star_dates:
+        count += 1
+        if points and points[-1][0] == day:
+            points[-1] = (day, count)
+        else:
+            points.append((day, count))
+    today = datetime.now(timezone.utc).date()
+    if points and points[-1][0] != today:
+        points.append((today, count))
+    return points
+
+
+def parse_seed(seed: str) -> list[tuple[date, int]]:
+    points = []
+    for chunk in seed.split(","):
+        day, _, count = chunk.strip().partition(":")
+        points.append((date.fromisoformat(day), int(count)))
+    return sorted(points)
+
+
+def _nice_ceiling(value: int) -> int:
+    """Round up to a tidy axis maximum (1/2/5 * 10^n)."""
+    if value <= 10:
+        return 10
+    magnitude = 1
+    while magnitude * 10 < value:
+        magnitude *= 10
+    for factor in (1, 2, 5, 10):
+        if factor * magnitude >= value:
+            return factor * magnitude
+    return 10 * magnitude
+
+
+def render_svg(points: list[tuple[date, int]], repo: str) -> str:
+    if len(points) < 2:
+        raise SystemExit("need at least 2 data points to draw a chart")
+
+    x0, x1 = points[0][0].toordinal(), points[-1][0].toordinal()
+    x_span = max(x1 - x0, 1)
+    y_max = _nice_ceiling(points[-1][1])
+    plot_w = WIDTH - MARGIN_LEFT - MARGIN_RIGHT
+    plot_h = HEIGHT - MARGIN_TOP - MARGIN_BOTTOM
+
+    def px(d: date) -> float:
+        return MARGIN_LEFT + (d.toordinal() - x0) / x_span * plot_w
+
+    def py(count: int) -> float:
+        return MARGIN_TOP + plot_h - (count / y_max) * plot_h
+
+    poly = " ".join(f"{px(d):.1f},{py(c):.1f}" for d, c in points)
+
+    # Four horizontal gridlines with y-axis labels.
+    grid_lines = []
+    for i in range(5):
+        value = round(y_max * i / 4)
+        y = py(value)
+        grid_lines.append(
+            f'<line x1="{MARGIN_LEFT}" y1="{y:.1f}" x2="{WIDTH - MARGIN_RIGHT}" '
+            f'y2="{y:.1f}" stroke="{GRID_COLOR}" stroke-opacity="0.25" stroke-width="1"/>'
+            f'<text x="{MARGIN_LEFT - 8}" y="{y + 4:.1f}" text-anchor="end" '
+            f'font-size="12" fill="{TEXT_COLOR}">{value}</text>'
+        )
+
+    # Up to five x-axis date labels, evenly spaced across the range.
+    x_labels = []
+    for i in range(5):
+        day = date.fromordinal(x0 + round(x_span * i / 4))
+        anchor = "start" if i == 0 else ("end" if i == 4 else "middle")
+        x_labels.append(
+            f'<text x="{px(day):.1f}" y="{HEIGHT - MARGIN_BOTTOM + 20}" '
+            f'text-anchor="{anchor}" font-size="12" fill="{TEXT_COLOR}">'
+            f"{day.strftime('%b %d, %Y')}</text>"
+        )
+
+    last_date, last_count = points[-1]
+    generated = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    title = f"{repo} — GitHub stars over time"
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{WIDTH}" height="{HEIGHT}"',
+        f' viewBox="0 0 {WIDTH} {HEIGHT}" role="img" aria-label="Star history of {repo}">\n',
+        f"  <title>Star history of {repo}</title>\n",
+        "  <g font-family=\"-apple-system, BlinkMacSystemFont, 'Segoe UI',"
+        ' Helvetica, Arial, sans-serif">\n',
+        f'    <text x="{WIDTH / 2}" y="24" text-anchor="middle" font-size="16"',
+        f' font-weight="600" fill="{TEXT_COLOR}">{title}</text>\n    ',
+        "".join(grid_lines),
+        "\n    ",
+        "".join(x_labels),
+        f'\n    <polyline points="{poly}" fill="none" stroke="{LINE_COLOR}"',
+        ' stroke-width="2.5" stroke-linejoin="round" stroke-linecap="round"/>\n',
+        f'    <circle cx="{px(last_date):.1f}" cy="{py(last_count):.1f}" r="4"',
+        f' fill="{LINE_COLOR}"/>\n',
+        f'    <text x="{px(last_date) - 8:.1f}" y="{py(last_count) - 10:.1f}"',
+        ' text-anchor="end" font-size="13" font-weight="600"',
+        f' fill="{LINE_COLOR}">{last_count} ★</text>\n',
+        f'    <text x="{WIDTH - MARGIN_RIGHT}" y="{HEIGHT - 8}" text-anchor="end"',
+        f' font-size="10" fill="{TEXT_COLOR}" fill-opacity="0.7">',
+        f"updated {generated}</text>\n",
+        "  </g>\n</svg>\n",
+    ]
+    return "".join(parts)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default="hi-godot/godot-ai")
+    parser.add_argument("--out", default="docs/images/star-history.svg")
+    parser.add_argument(
+        "--seed",
+        help="comma-separated date:count points to render offline "
+        '(e.g. "2026-04-12:0,2026-07-16:1009")',
+    )
+    args = parser.parse_args()
+
+    if args.seed:
+        points = parse_seed(args.seed)
+    else:
+        token = os.environ.get("STAR_HISTORY_TOKEN") or os.environ.get("GITHUB_TOKEN")
+        if not token:
+            raise SystemExit("set GITHUB_TOKEN (or STAR_HISTORY_TOKEN), or use --seed")
+        star_dates = fetch_star_dates(args.repo, token)
+        if not star_dates:
+            raise SystemExit(f"no stargazer data returned for {args.repo}")
+        points = cumulative_points(star_dates)
+
+    svg = render_svg(points, args.repo)
+    with open(args.out, "w", encoding="utf-8") as fh:
+        fh.write(svg)
+    print(f"wrote {args.out} ({len(points)} points, {points[-1][1]} stars)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_generate_star_history.py
+++ b/tests/unit/test_generate_star_history.py
@@ -1,0 +1,65 @@
+"""Tests for script/generate-star-history (#750).
+
+The script lives in script/ without a .py suffix, so load it via importlib.
+Network fetch is not exercised here — rendering and aggregation are.
+"""
+
+import importlib.util
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "script" / "generate-star-history"
+_spec = importlib.util.spec_from_loader(
+    "generate_star_history",
+    importlib.machinery.SourceFileLoader("generate_star_history", str(_SCRIPT)),
+)
+gsh = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gsh)
+
+
+def test_cumulative_points_collapses_same_day_stars():
+    stars = [date(2026, 4, 12), date(2026, 4, 12), date(2026, 4, 14)]
+    points = gsh.cumulative_points(stars)
+    # First point: both same-day stars collapsed into one step at count 2.
+    assert points[0] == (date(2026, 4, 12), 2)
+    assert (date(2026, 4, 14), 3) in points
+    # A trailing "today" point extends the line to the present.
+    assert points[-1][1] == 3
+
+
+def test_parse_seed_sorts_and_parses():
+    points = gsh.parse_seed("2026-07-16:1009, 2026-04-12:0")
+    assert points == [(date(2026, 4, 12), 0), (date(2026, 7, 16), 1009)]
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [(3, 10), (10, 10), (11, 20), (150, 200), (1009, 2000), (4999, 5000), (5001, 10000)],
+)
+def test_nice_ceiling(value, expected):
+    assert gsh._nice_ceiling(value) == expected
+
+
+def test_render_svg_is_valid_and_scaled():
+    import xml.dom.minidom
+
+    points = [
+        (date(2026, 4, 12), 0),
+        (date(2026, 5, 1), 200),
+        (date(2026, 6, 1), 700),
+        (date(2026, 7, 16), 1009),
+    ]
+    svg = gsh.render_svg(points, "hi-godot/godot-ai")
+    doc = xml.dom.minidom.parseString(svg)
+    assert doc.documentElement.tagName == "svg"
+    assert "1009" in svg  # final count labeled
+    assert "hi-godot/godot-ai" in svg
+    # No external references — the SVG must be self-contained for README use.
+    assert "http" not in svg.replace("http://www.w3.org/2000/svg", "")
+
+
+def test_render_svg_rejects_single_point():
+    with pytest.raises(SystemExit):
+        gsh.render_svg([(date(2026, 4, 12), 0)], "hi-godot/godot-ai")


### PR DESCRIPTION
## Motivation

Closes #750.

The README's Star History chart no longer renders. Verified the root cause the issue describes: GitHub now restricts detailed stargazer history to repo admins/collaborators — an unauthenticated `GET /repos/hi-godot/godot-ai/stargazers` with `Accept: application/vnd.github.star+json` returns **403 "You do not have permission to view the stargazers of this repository"** — so star-history.com's unauthenticated embed has no data to draw.

Of the issue's two options I took the static-chart-via-Actions route: it keeps the README image working with zero external service dependency and no account/token setup on star-history.com's side.

## Change

- **`script/generate-star-history`** — stdlib-only Python script. Fetches `starred_at` timestamps with an authenticated token (the workflow's repo-scoped `GITHUB_TOKEN`; optional `STAR_HISTORY_TOKEN` collaborator-PAT secret as fallback if GitHub ever drops the workflow token's stargazer access — the 403 error message says exactly which secret to set). Renders a self-contained SVG (no external refs, mid-tone palette readable on light and dark GitHub themes). A `--seed "date:count,…"` mode renders explicit points offline.
- **`.github/workflows/star-history.yml`** — weekly cron + `workflow_dispatch`, `contents: write`, commits `docs/images/star-history.svg` only when changed, with `[skip ci]`. Guarded with `if: github.repository == 'hi-godot/godot-ai'` so forks don't run it.
- **README** — image now points at the committed SVG; the wrapping link goes to the repo's stargazers page instead of the star-history.com page.
- **Seed chart committed** from two real data points (0 stars at repo creation 2026-04-12, 1009 stars today) so the README isn't broken between merge and the first workflow run — trigger the workflow manually after merge to draw the full curve.

## Tests

- `tests/unit/test_generate_star_history.py` — cumulative aggregation (same-day collapse, trailing "today" point), seed parsing, axis-ceiling rounding, SVG validity/self-containedness, single-point rejection. 11 tests.
- Full suite: `1384 passed, 4 skipped`; `ruff check` clean.
- Both workflow YAML and the generated SVG validated parseable.

One thing I could not verify from this environment: that the Actions `GITHUB_TOKEN` retains stargazer-history access under the new restriction. If the first manual run 403s, set a collaborator PAT as the `STAR_HISTORY_TOKEN` secret — the script's error message points there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiPyzz94bmAjjDYEhzc8JY

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiPyzz94bmAjjDYEhzc8JY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standalone Star History chart generator supporting authenticated API mode and offline seed-based rendering.
  * Introduced a GitHub Actions workflow to regenerate and commit the Star History SVG on a weekly schedule (and on demand).
* **Documentation**
  * Updated the README to reference the committed `star-history.svg` chart and explain the change from the previous embed source.
* **Tests**
  * Added unit tests for seed parsing, cumulative series building, SVG rendering/scaling, and validation/error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->