### PR TITLE
dock: don't show the Install-uv setup section while the server launch is settling

### DIFF
--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -1005,6 +1005,12 @@ func _update_status() -> void:
 		## status-machine state is committed before the probe can block.
 		_schedule_uv_reprobe()
 
+	## Status transitions are exactly when "is the launch still settling?"
+	## can change (Starting server… -> connected / Disconnected / terminal
+	## diagnosis), so re-evaluate the Setup section's visibility here (#744).
+	## Cheap: runs only on `changed`, and the uv probe result is cached.
+	_apply_dev_mode_visibility()
+
 	_update_dev_section_buttons()
 
 
@@ -1350,10 +1356,44 @@ func _apply_dev_mode_visibility() -> void:
 	_apply_allow_hosts_dev_gate(dev)
 
 	# Setup section: visible in dev mode, OR in user mode when uv is missing
-	# (so users can install uv from the dock).
+	# (so users can install uv from the dock) — but not while the server
+	# launch is still settling (#744): mid-launch a red "uv: not found" row
+	# is usually a transient probe failure (#739) or irrelevant because the
+	# launch is succeeding via the .venv or system tiers. `_update_status`
+	# re-applies visibility on every status transition, so the section
+	# appears the moment the launch outcome makes it relevant.
 	var is_dev := ClientConfigurator.is_dev_checkout()
 	var uv_missing := not is_dev and ClientConfigurator.check_uv_version().is_empty()
-	_setup_section.visible = dev or uv_missing
+	_setup_section.visible = _setup_section_should_show(dev, uv_missing, _server_launch_pending())
+
+
+## Pure visibility decision for the Setup section (#744). Split out so the
+## truth table is unit-testable without faking the uv probe or a dev
+## checkout: dev toggle always shows the section; a missing uv only shows
+## it once the server launch has settled.
+static func _setup_section_should_show(
+	dev_toggle: bool, uv_missing: bool, launch_pending: bool
+) -> bool:
+	return dev_toggle or (uv_missing and not launch_pending)
+
+
+## True while the server launch outcome is still unknown: not connected,
+## no terminal diagnosis yet, and the startup grace window ("Starting
+## server…" in the status row) is still running. Mirrors the status-label
+## logic in `_update_status` so the Setup section and the amber status
+## text agree on what "still launching" means.
+func _server_launch_pending() -> bool:
+	if _last_connected:
+		return false
+	var server_status: Dictionary = (
+		_plugin.get_server_status()
+		if _plugin != null and _plugin.has_method("get_server_status")
+		else {}
+	)
+	var state: int = int(server_status.get("state", ServerStateScript.UNINITIALIZED))
+	if ServerStateScript.is_terminal_diagnosis(state):
+		return false
+	return Time.get_ticks_msec() < _startup_grace_until_msec
 
 
 # --- Button handlers ---

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -1611,6 +1611,60 @@ func test_dev_buttons_visibility_follows_dev_mode_toggle() -> void:
 		"dev toggle off must hide the Setup section, hiding both dev buttons")
 
 
+func test_setup_section_should_show_truth_table() -> void:
+	## #744: the Install-uv Setup section must not appear while the server
+	## launch is still settling — only dev mode, or uv missing once the
+	## launch outcome is known, shows it.
+	assert_true(McpDockScript._setup_section_should_show(true, false, false),
+		"Dev toggle alone must show the Setup section")
+	assert_true(McpDockScript._setup_section_should_show(true, true, true),
+		"Dev toggle must win even mid-launch")
+	assert_true(McpDockScript._setup_section_should_show(false, true, false),
+		"uv missing after the launch settled must show the section")
+	assert_false(McpDockScript._setup_section_should_show(false, true, true),
+		"uv missing mid-launch must NOT show the section (#744)")
+	assert_false(McpDockScript._setup_section_should_show(false, false, false),
+		"dev off + uv present must hide the section")
+
+
+func test_server_launch_pending_tracks_state_connection_and_grace() -> void:
+	var plugin := _RestartDispatchPlugin.new()
+	_dock._plugin = plugin
+	_dock._last_connected = false
+	_dock._startup_grace_until_msec = Time.get_ticks_msec() + 10_000
+
+	plugin.status = {"state": McpServerState.SPAWNING}
+	assert_true(_dock._server_launch_pending(),
+		"Spawning inside the grace window is a pending launch")
+
+	plugin.status = {"state": McpServerState.UNINITIALIZED}
+	assert_true(_dock._server_launch_pending(),
+		"Uninitialized inside the grace window is a pending launch")
+
+	plugin.status = {"state": McpServerState.CRASHED}
+	assert_false(_dock._server_launch_pending(),
+		"A terminal diagnosis settles the launch even inside grace")
+
+	plugin.status = {"state": McpServerState.NO_COMMAND}
+	assert_false(_dock._server_launch_pending(),
+		"NO_COMMAND settles the launch — that's exactly when Install uv helps")
+
+	plugin.status = {"state": McpServerState.SPAWNING}
+	_dock._last_connected = true
+	assert_false(_dock._server_launch_pending(),
+		"A committed connection settles the launch")
+
+	_dock._last_connected = false
+	_dock._startup_grace_until_msec = Time.get_ticks_msec() - 1
+	assert_false(_dock._server_launch_pending(),
+		"Grace expiry settles the launch (the status row shows Disconnected)")
+
+	## Reset shared-suite state so later tests see the defaults.
+	_dock._startup_grace_until_msec = 0
+	_dock._plugin = null
+	plugin.free()
+
+
 ## Mirrors `_seed_server_row` / `_cleanup_server_row`: stand up just enough
 ## of the dock for the per-frame button helpers to run without a full
 ## `_build_ui` pass.


### PR DESCRIPTION
## Motivation

Closes #744.

While the plugin is launching, the dock shows the Setup section with a red "uv: not found" row and an **Install uv** button. The visibility check (`_apply_dev_mode_visibility`) only consulted the cached uv probe, which mid-launch is often wrong or irrelevant:

- the startup probe can fail transiently (the #739 shape — contended spawn, cold Defender scan, stale PATH), and it only self-corrects when the server connects;
- the launch may be succeeding via the `.venv` or system-CLI tiers, where uv isn't needed at all.

Either way the user watches "Starting server…" next to install guidance they don't need.

## Change

- The uv-missing branch of the Setup section's visibility is now gated on the server launch having **settled**: connected, a terminal diagnosis (`CRASHED` / `NO_COMMAND` / `PORT_EXCLUDED` / `INCOMPATIBLE` / `FOREIGN_PORT` — `NO_COMMAND` is exactly when "Install uv" is the right guidance), or startup-grace expiry (the same window that renders "Starting server…", so the amber status text and the Setup section agree on what "still launching" means).
- `_update_status` re-applies visibility on every status transition (`changed` only, so nothing new runs per-frame), so the section appears the moment the launch outcome makes it relevant.
- The decision is factored into a static `_setup_section_should_show(dev, uv_missing, launch_pending)` plus an instance `_server_launch_pending()`, so the truth table is testable without faking the uv probe or a dev checkout. Dev-toggle behavior is unchanged (always shows the section).

## Tests

- New GDScript tests in `test_project/tests/test_dock.gd`: the visibility truth table, and `_server_launch_pending` across spawning/terminal/connected/grace-expired states (using the existing `_RestartDispatchPlugin` stub).
- Full GDScript suite against a live headless editor (Godot 4.6.2, CI-style `ci-start-server` + `ci-godot-tests` flow): **1873/1891 passed, 0 failed, 18 skipped** (the skips are the pre-existing environment-gated ones).
- `ci-check-gdscript` on the import log: all GDScript files OK.
- No Python surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiPyzz94bmAjjDYEhzc8JY

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiPyzz94bmAjjDYEhzc8JY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Setup panel’s visibility updates as server connection status changes.
  * Prevented the panel from appearing prematurely while the server is still starting.
  * Ensured the panel appears promptly when required setup actions are detected, including when uv is unavailable.

* **Tests**
  * Added coverage for Setup panel visibility across launch states and configuration combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->