### PR TITLE
startup: adopt a crash-surviving server the bind probe missed

### DIFF
--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -1165,6 +1165,21 @@ func _find_managed_pid(port: int) -> int:
 	return _find_pid_on_port(port)
 
 
+## #745: after an editor crash the managed server keeps running, but the
+## bind probe can still report the HTTP port as free — Windows lets a
+## SO_REUSEADDR bind succeed straight over a live listener, and the OS
+## scrape fallback can fail transiently. The pid-file the server writes
+## via `--pid-file` survives the crash; when it names a live process
+## whose cmdline carries the godot-ai brand, a server is likely still
+## up. Liveness + brand only — the startup walk confirms with the HTTP
+## status probe before changing behavior, so a kernel-recycled PID can
+## never redirect startup on its own. Uses the `_for_proof` seams so
+## lifecycle tests can stub it without touching real processes.
+func _managed_server_evidence_alive() -> bool:
+	var pid := _read_pid_file_for_proof()
+	return pid > 0 and _pid_alive_for_proof(pid) and _pid_cmdline_is_godot_ai(pid)
+
+
 ## `live` is the result of a prior `_probe_live_server_status_for_port`
 ## call that the caller already has on hand. When non-empty it short-
 ## circuits the internal probe at the bottom of this helper, so a single

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -1177,7 +1177,7 @@ func _find_managed_pid(port: int) -> int:
 ## lifecycle tests can stub it without touching real processes.
 func _managed_server_evidence_alive() -> bool:
 	var pid := _read_pid_file_for_proof()
-	return pid > 0 and _pid_alive_for_proof(pid) and _pid_cmdline_is_godot_ai(pid)
+	return pid > 0 and _pid_alive_for_proof(pid) and _pid_cmdline_is_godot_ai_for_proof(pid)
 
 
 ## `live` is the result of a prior `_probe_live_server_status_for_port`

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -636,6 +636,29 @@ func _start_server_impl(async_gen: int) -> void:
 	))
 	if _async_stale(async_gen):
 		return
+	if not port_in_use:
+		## #745: after an editor crash the managed server keeps running, yet
+		## the bind probe can still say "free" (Windows lets a SO_REUSEADDR
+		## bind succeed over a live listener; the scrape fallback can fail
+		## transiently). The surviving pid-file is the tie-breaker: when it
+		## names a live, godot-ai-branded process AND the HTTP status probe
+		## on our port answers as a godot-ai server, treat the port as
+		## occupied so the adopt/recover branch below runs instead of
+		## blind-spawning a duplicate server. A dead/stale/foreign pid or an
+		## unresponsive port falls through to the normal spawn path
+		## unchanged.
+		var evidence_result: Variant = await _run_blocking(func() -> Variant:
+			if not is_instance_valid(_host):
+				return {}
+			if not _host._managed_server_evidence_alive():
+				return {}
+			return _host._probe_live_server_status_for_port(port)
+		)
+		if _async_stale(async_gen):
+			return
+		var evidence: Dictionary = evidence_result
+		if _live_status_identifies_godot_ai(evidence):
+			port_in_use = true
 	if port_in_use:
 		var record: Dictionary = _host._read_managed_server_record()
 		var record_version := str(record.get("version", ""))

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -78,6 +78,17 @@ class _ProofPlugin extends GodotAiPlugin:
 		cleared_record_calls += 1
 
 
+## #745 crash-survivor tests: like _ProofPlugin, but also stubs
+## `_find_managed_pid` (whose real body reads the on-disk pid-file and
+## falls back to a live port scrape) so the adopt branch stays fully
+## faked.
+class _CrashSurvivorPlugin extends _ProofPlugin:
+	var managed_pid_result := 0
+
+	func _find_managed_pid(_port: int) -> int:
+		return managed_pid_result
+
+
 ## Test port high enough to almost never collide with real services and
 ## distinct from the plugin's configured http_port() so the stop-finalize tests
 ## don't interact with a developer's running managed server.
@@ -1102,6 +1113,58 @@ func test_incompatible_status_exposes_actual_name_and_recovery_flag() -> void:
 
 	assert_eq(status.get("actual_name", ""), "godot-ai")
 	assert_true(bool(status.get("can_recover_incompatible", false)))
+
+
+func test_managed_server_evidence_requires_live_branded_pidfile() -> void:
+	## #745: the evidence gate that lets startup second-guess a "port is
+	## free" bind probe. Every tier must hold or the gate stays closed —
+	## a stale or kernel-recycled PID must never count as evidence.
+	var plugin := _ProofPlugin.new()
+	plugin.pid_file_pid = 0
+	assert_false(plugin._managed_server_evidence_alive(),
+		"no pid-file must yield no evidence")
+	plugin.pid_file_pid = 44444
+	assert_false(plugin._managed_server_evidence_alive(),
+		"pid-file naming a dead process must yield no evidence")
+	plugin.alive_pids = [44444] as Array[int]
+	assert_false(plugin._managed_server_evidence_alive(),
+		"live but unbranded pid (kernel-recycled) must yield no evidence")
+	plugin.branded_pids = [44444] as Array[int]
+	assert_true(plugin._managed_server_evidence_alive(),
+		"live godot-ai-branded pid-file process is evidence")
+	plugin.free()
+
+
+func test_start_adopts_crash_survivor_when_bind_probe_reports_port_free() -> void:
+	## #745: an editor crash leaves the managed server running, but the
+	## bind probe can report the HTTP port as free (Windows SO_REUSEADDR
+	## bind-over-listener semantics; transient scrape failures). With the
+	## surviving pid-file naming a live branded process AND the HTTP
+	## status probe answering as a compatible godot-ai server, startup
+	## must route through the normal adopt path instead of blind-spawning
+	## a duplicate server.
+	var current := McpClientConfigurator.get_plugin_version()
+	var plugin := _CrashSurvivorPlugin.new()
+	plugin.port_in_use = false
+	plugin.pid_file_pid = 33333
+	plugin.alive_pids = [33333] as Array[int]
+	plugin.branded_pids = [33333] as Array[int]
+	plugin.managed_pid_result = 33333
+	plugin.managed_record = {"pid": 33333, "version": current, "ws_port": 9500}
+	plugin.live_status = {"name": "godot-ai", "version": current, "ws_port": 9500, "status_code": 200}
+
+	plugin._start_server()
+	var status := plugin.get_server_status()
+	var probe_calls: int = plugin.probe_calls
+	var server_pid: int = int(plugin._lifecycle._server_pid)
+	plugin.free()
+
+	assert_eq(int(status.get("state", -1)), McpServerState.READY,
+		"crash survivor answering the status probe must be adopted, not duplicated")
+	assert_true(probe_calls >= 1,
+		"the evidence path must confirm via the HTTP status probe before adopting")
+	assert_eq(server_pid, 33333,
+		"matching-version crash survivor must adopt as the managed server")
 
 
 func test_drift_kill_without_strong_targets_sets_incompatible_and_preserves_record() -> void:


### PR DESCRIPTION
## Motivation

Closes #745.

After an editor crash (or a second editor window), the managed MCP server keeps running in the background. But the startup walk's first gate is only "can I bind the HTTP port?" (`_is_port_in_use` → `can_bind_local_port`). Two ways that reports **free** while a live server is listening:

- On **Windows**, a `SO_REUSEADDR` bind can succeed straight over an existing listener that didn't set `SO_EXCLUSIVEADDRUSE` (uvicorn doesn't) — the Windows branch of `_is_port_in_use` returns "free" on a successful bind without a scrape.
- The netstat/lsof scrape fallback can fail transiently (stripped installs, locale issues, contended spawn).

When that happens, the walk never reaches the existing (well-tested) probe/adopt/recover branch and blind-spawns a duplicate server — the reporter's "MCP is not detected" symptom.

## Change

Exactly what the issue asks for: check whether the server is *running*, not just whether the port is bindable, and use the pid-file the reporter pointed at as the surviving evidence.

When the bind probe says free, the walk now runs one extra evidence check (on the same off-main-thread worker as the rest of the walk):

1. **Pid-file** (`user://godot_ai_server.pid`, written by the server via `--pid-file`, survives a crash) names a PID,
2. that PID is **alive**, and
3. its cmdline carries the **godot-ai brand** (the #525 gate, so a kernel-recycled PID can never redirect startup), and
4. the **HTTP status probe** on our port actually answers as a godot-ai server ("if the MCP server does not reply properly through the port call it is likely another application" — per the issue),

→ then the port is treated as occupied and the *existing* adopt/recover branch runs: compatible server → adopted (`READY`), version drift → the established branded kill+respawn recovery. No new kill paths and no new terminal states: any tier failing (no pid-file, dead/stale/foreign pid, unresponsive port) falls through to the unchanged spawn path, and the check costs nothing when no pid-file exists.

## Tests

- `test_managed_server_evidence_requires_live_branded_pidfile` — the gate's truth table (no pid-file / dead pid / live-but-unbranded / live+branded).
- `test_start_adopts_crash_survivor_when_bind_probe_reports_port_free` — full startup walk with a stubbed "bind says free, pid-file + status probe say godot-ai" environment lands in `READY` with the survivor adopted as managed, confirming the HTTP probe ran.
- Full GDScript suite against a live headless editor (Godot 4.6.2, CI-style flow): **1873/1891 passed, 0 failed, 18 skipped** (+2 over baseline = the new tests).
- `ci-check-gdscript`: all GDScript files OK. No Python surface change.

The Windows `SO_REUSEADDR` reproduction itself can't run in this Linux environment — the stale/foreign-server CI smoke jobs cover the cross-OS recovery machinery this change routes into, and the new unit tests pin the gate's behavior on all tiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiPyzz94bmAjjDYEhzc8JY

---
_Generated by [Claude Code](https://claude.ai/code/session_01PiPyzz94bmAjjDYEhzc8JY)_