### PR TITLE
diagnostics: soften watermark hints and add policies

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -118,17 +118,29 @@ clear the Debugger dock's visible Errors-tab rows (routed through the panel's
 own Clear path so the tab badge and counters reset). The Errors panel is
 user-facing UI, so the default leaves it untouched.
 
-When new GDScript errors are observed since a client's previous call — from
-the editor logger, the game log buffer, or Debugger Errors-tab rows promoted
-by the run/stop deferred scans (#641) — the next tool response carries
-`new_errors_since_last_call` (int) and `new_errors_hint` (text pointing at
-`logs_read(source="editor"|"game", include_details=true)`). The count is of
-distinct new errors: a running game's script error reaches the server through
-both the game log buffer and the Errors tab, and those overlapping views are
-deduplicated rather than summed. The stamp is delivered exactly once and is
-consumed by that delivery — treat it as a doorbell, then read the logs; do not
-poll for it to repeat. It can appear on any tool's response, including
-`logs_read` itself.
+When new GDScript errors or warnings are observed since a client's previous
+call — from the editor logger, the game log buffer, or Debugger Errors-tab
+rows promoted by the run/stop deferred scans (#641) — the next tool response
+carries `new_errors_since_last_call` / `new_warnings_since_last_call` (int)
+and the corresponding `new_errors_hint` / `new_warnings_hint`. The hint is
+conditional: if the client is partway through a planned multi-file scaffold,
+it should finish the related writes and run `filesystem_manage(op="scan")`
+before debugging; otherwise it should inspect
+`logs_read(source="editor"|"game", include_details=true)`.
+
+The error count is of distinct new errors: a running game's script error
+reaches the server through both the game log buffer and the Errors tab, and
+those overlapping views are deduplicated rather than summed. Error and warning
+stamps are independent. Each stamp is delivered exactly once and consumed by
+that delivery — treat it as a doorbell, then read the logs; do not poll for it
+to repeat. It can appear on any tool's response, including `logs_read` itself.
+
+Set `GODOT_AI_SUPPRESS_DIAGNOSTIC_HINTS=true` (or `1`) before starting the
+server to consume these diagnostic stamps without adding their counts or hints
+to tool responses. Suppression covers both errors and warnings and discards
+real diagnostic hints too; changing it requires a server restart. This is an
+escape hatch, not a rollback switch for later scaffold-aware classification or
+settlement stages.
 
 `script_create` and `script_patch` validate written `.gd` content before the
 editor import step and include per-write diagnostics in their response:

--- a/src/godot_ai/godot_client/client.py
+++ b/src/godot_ai/godot_client/client.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+import os
+from typing import Any, Literal, TypeAlias
 
 from fastmcp.exceptions import FastMCPError
 
@@ -20,6 +21,24 @@ from godot_ai.sessions.registry import SessionRegistry
 from godot_ai.transport.websocket import GodotWebSocketServer
 
 logger = logging.getLogger(__name__)
+
+HintPolicy: TypeAlias = Literal["surface", "retain", "discard"]
+_HINT_POLICIES = frozenset({"surface", "retain", "discard"})
+
+
+def _default_hint_policy_from_env() -> HintPolicy:
+    value = os.getenv("GODOT_AI_SUPPRESS_DIAGNOSTIC_HINTS", "")
+    return "discard" if value.strip().lower() in {"1", "true"} else "surface"
+
+
+def _diagnostic_hint(kind: Literal["error", "warning"], count: int) -> str:
+    plural = "s" if count != 1 else ""
+    return (
+        f"{count} new GDScript {kind}{plural} since your last call. "
+        "If you are mid-way through a planned multi-file scaffold, finish the related "
+        'writes and run filesystem_manage(op="scan") before debugging; otherwise inspect '
+        "with logs_read(source='editor'|'game', include_details=true)."
+    )
 
 
 class GodotCommandError(FastMCPError):
@@ -52,9 +71,17 @@ class GodotClient:
         ws_server: GodotWebSocketServer,
         registry: SessionRegistry,
         circuit_breaker: EditorBridgeCircuitBreaker | None = None,
+        default_hint_policy: HintPolicy | None = None,
     ):
         self.ws_server = ws_server
         self.registry = registry
+        self.default_hint_policy = (
+            _default_hint_policy_from_env()
+            if default_hint_policy is None
+            else default_hint_policy
+        )
+        if self.default_hint_policy not in _HINT_POLICIES:
+            raise ValueError(f"Unknown diagnostic hint policy: {self.default_hint_policy!r}")
         ## F-006: stop death-spiral hot retries from melting the bridge.
         ## Defaults: 5 consecutive transport failures opens for 1s, doubles
         ## per re-open up to 30s. While open, the next call short-circuits
@@ -121,7 +148,7 @@ class GodotClient:
         params: dict[str, Any] | None = None,
         session_id: str | None = None,
         timeout: float = 5.0,
-        surface_error_hints: bool = True,
+        hint_policy: HintPolicy | None = None,
     ) -> dict[str, Any]:
         """Send a command to a Godot session and return the response data.
 
@@ -136,7 +163,14 @@ class GodotClient:
         non-finite float — JSON cannot represent NaN/Infinity, and
         ``model_dump_json`` would silently serialize it as null, corrupting
         the value the plugin stores (#688).
+        ``hint_policy=None`` uses the construction-time client default;
+        explicit ``surface``, ``retain``, or ``discard`` values override it
+        for this response's diagnostic counters.
         """
+        effective_hint_policy = self.default_hint_policy if hint_policy is None else hint_policy
+        if effective_hint_policy not in _HINT_POLICIES:
+            raise ValueError(f"Unknown diagnostic hint policy: {effective_hint_policy!r}")
+
         ## Rejected before session resolution: bad params are a caller error
         ## regardless of editor state, and must not count as a transport
         ## failure against the circuit breaker.
@@ -212,30 +246,30 @@ class GodotClient:
         live_session = self.registry.get(session_id)
         pending_new_errors = live_session.pending_new_errors if live_session else 0
         pending_new_warnings = live_session.pending_new_warnings if live_session else 0
-        if surface_error_hints and (pending_new_errors > 0 or pending_new_warnings > 0):
+
+        if effective_hint_policy == "discard":
+            if live_session:
+                live_session.pending_new_errors = 0
+                live_session.pending_new_warnings = 0
+            return response.data
+
+        if effective_hint_policy == "retain":
+            return response.data
+
+        if pending_new_errors > 0 or pending_new_warnings > 0:
             data = dict(response.data)
             if pending_new_errors > 0:
                 count = pending_new_errors
                 if live_session:
                     live_session.pending_new_errors = 0
                 data["new_errors_since_last_call"] = count
-                plural = "s" if count != 1 else ""
-                data["new_errors_hint"] = (
-                    f"{count} new GDScript error{plural} since your last call. "
-                    "Inspect with logs_read(source='editor', include_details=true) "
-                    "and/or logs_read(source='game', include_details=true)."
-                )
+                data["new_errors_hint"] = _diagnostic_hint("error", count)
             if pending_new_warnings > 0:
                 wcount = pending_new_warnings
                 if live_session:
                     live_session.pending_new_warnings = 0
                 data["new_warnings_since_last_call"] = wcount
-                wplural = "s" if wcount != 1 else ""
-                data["new_warnings_hint"] = (
-                    f"{wcount} new GDScript warning{wplural} since your last call. "
-                    "Inspect with logs_read(source='editor', include_details=true) "
-                    "and/or logs_read(source='game', include_details=true)."
-                )
+                data["new_warnings_hint"] = _diagnostic_hint("warning", wcount)
             return data
 
         return response.data

--- a/src/godot_ai/handlers/_readiness.py
+++ b/src/godot_ai/handlers/_readiness.py
@@ -132,7 +132,7 @@ async def require_writable_async(runtime: "DirectRuntime") -> None:
         result = await runtime.send_command(
             "get_editor_state",
             timeout=2.0,
-            surface_error_hints=False,
+            hint_policy="retain",
         )
         sync_readiness_for_session(session, result.get("readiness"))
     except Exception:

--- a/src/godot_ai/runtime/direct.py
+++ b/src/godot_ai/runtime/direct.py
@@ -6,7 +6,7 @@ from typing import Any, Protocol
 
 from fastmcp import Context
 
-from godot_ai.godot_client.client import GodotClient
+from godot_ai.godot_client.client import GodotClient, HintPolicy
 from godot_ai.sessions.registry import Session, SessionRegistry
 
 
@@ -53,7 +53,7 @@ class DirectRuntime:
         params: dict[str, Any] | None = None,
         session_id: str | None = None,
         timeout: float = 5.0,
-        surface_error_hints: bool = True,
+        hint_policy: HintPolicy | None = None,
     ) -> dict[str, Any]:
         resolved_session_id = session_id if session_id is not None else self._bound_session_id
         return await self._client.send(
@@ -61,7 +61,7 @@ class DirectRuntime:
             params=params,
             session_id=resolved_session_id,
             timeout=timeout,
-            surface_error_hints=surface_error_hints,
+            hint_policy=hint_policy,
         )
 
     def list_sessions(self) -> list[Session]:

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -432,7 +432,7 @@ class TestCommandRoundTrip:
         handler_task = asyncio.create_task(mock_handler())
         first = await client.send("get_editor_state")
         with pytest.raises(GodotCommandError):
-            await client.send("get_editor_state")
+            await client.send("get_editor_state", hint_policy="discard")
         third = await client.send("get_editor_state")
         fourth = await client.send("get_editor_state")
         await handler_task
@@ -451,30 +451,102 @@ class TestCommandRoundTrip:
             await plugin.send_response(
                 cmd["request_id"],
                 {"ok": 1},
-                error_watermark={"run_seq": 1, "debugger_promoted": 0},
+                error_watermark={
+                    "run_seq": 1,
+                    "debugger_promoted": 0,
+                    "editor_ring_warn": 0,
+                },
             )
             cmd = await plugin.recv_command()
             await plugin.send_response(
                 cmd["request_id"],
                 {"ok": 2},
-                error_watermark={"run_seq": 1, "debugger_promoted": 2},
+                error_watermark={
+                    "run_seq": 1,
+                    "debugger_promoted": 2,
+                    "editor_ring_warn": 2,
+                },
             )
             cmd = await plugin.recv_command()
             await plugin.send_response(
                 cmd["request_id"],
                 {"ok": 3},
-                error_watermark={"run_seq": 1, "debugger_promoted": 2},
+                error_watermark={
+                    "run_seq": 1,
+                    "debugger_promoted": 2,
+                    "editor_ring_warn": 2,
+                },
             )
 
         handler_task = asyncio.create_task(mock_handler())
         first = await client.send("get_editor_state")
-        probe = await client.send("get_editor_state", surface_error_hints=False)
+        probe = await client.send("get_editor_state", hint_policy="retain")
         third = await client.send("get_editor_state")
         await handler_task
 
         assert "new_errors_since_last_call" not in first
         assert "new_errors_since_last_call" not in probe
+        assert "new_warnings_since_last_call" not in probe
         assert third["new_errors_since_last_call"] == 2
+        assert third["new_warnings_since_last_call"] == 2
+        await plugin.close()
+
+    async def test_error_watermark_discard_consumes_both_channels_without_backlog(
+        self, harness
+    ):
+        plugin = await harness.connect_plugin(session_id="err-discard")
+        client = GodotClient(
+            harness.server,
+            harness.registry,
+            default_hint_policy="discard",
+        )
+
+        async def mock_handler():
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 1},
+                error_watermark={
+                    "run_seq": 1,
+                    "debugger_promoted": 0,
+                    "editor_ring_warn": 0,
+                },
+            )
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 2},
+                error_watermark={
+                    "run_seq": 1,
+                    "debugger_promoted": 2,
+                    "editor_ring_warn": 3,
+                },
+            )
+            cmd = await plugin.recv_command()
+            await plugin.send_response(
+                cmd["request_id"],
+                {"ok": 3},
+                error_watermark={
+                    "run_seq": 1,
+                    "debugger_promoted": 2,
+                    "editor_ring_warn": 3,
+                },
+            )
+
+        handler_task = asyncio.create_task(mock_handler())
+        first = await client.send("get_editor_state")
+        discarded = await client.send("get_editor_state")
+        session = harness.registry.get("err-discard")
+        assert session.pending_new_errors == 0
+        assert session.pending_new_warnings == 0
+        surfaced = await client.send("get_editor_state", hint_policy="surface")
+        await handler_task
+
+        for result in (first, discarded, surfaced):
+            assert "new_errors_since_last_call" not in result
+            assert "new_errors_hint" not in result
+            assert "new_warnings_since_last_call" not in result
+            assert "new_warnings_hint" not in result
         await plugin.close()
 
     async def test_warning_watermark_advance_injects_warning_hint_once(self, harness):

--- a/tests/unit/test_diagnostic_hint_policy.py
+++ b/tests/unit/test_diagnostic_hint_policy.py
@@ -1,0 +1,99 @@
+"""Contracts for scaffold-aware diagnostic hint policy."""
+
+from __future__ import annotations
+
+import pytest
+
+from godot_ai.godot_client.client import GodotClient
+from godot_ai.protocol.envelope import CommandResponse
+from godot_ai.sessions.registry import Session, SessionRegistry
+
+
+class _StaticWsServer:
+    async def send_command(self, **_kwargs) -> CommandResponse:
+        return CommandResponse(request_id="hint-contract", status="ok", data={"ok": True})
+
+
+def _client_with_pending_diagnostics(*, errors: int = 0, warnings: int = 0) -> GodotClient:
+    session = Session(
+        session_id="hint-contract",
+        godot_version="4.7",
+        project_path="/tmp/hint-contract",
+        plugin_version="test",
+        pending_new_errors=errors,
+        pending_new_warnings=warnings,
+    )
+    registry = SessionRegistry()
+    registry.register(session)
+    return GodotClient(_StaticWsServer(), registry)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("errors", "warnings", "hint_key", "expected_lead"),
+    [
+        (2, 0, "new_errors_hint", "2 new GDScript errors since your last call."),
+        (0, 1, "new_warnings_hint", "1 new GDScript warning since your last call."),
+    ],
+)
+async def test_injected_diagnostic_hints_keep_scaffold_condition_and_logs_fallback(
+    errors, warnings, hint_key, expected_lead
+) -> None:
+    client = _client_with_pending_diagnostics(errors=errors, warnings=warnings)
+
+    result = await client.send("get_editor_state")
+    hint = result[hint_key]
+
+    assert hint.startswith(expected_lead)
+    assert 'filesystem_manage(op="scan") before debugging' in hint
+    assert "logs_read(source='editor'|'game', include_details=true)" in hint
+
+
+@pytest.mark.parametrize(
+    ("env_value", "expected_policy"),
+    [
+        (None, "surface"),
+        ("true", "discard"),
+        ("TRUE", "discard"),
+        ("1", "discard"),
+        ("garbage", "surface"),
+    ],
+)
+def test_suppress_diagnostic_hints_env_sets_client_default(
+    monkeypatch, env_value, expected_policy
+) -> None:
+    if env_value is None:
+        monkeypatch.delenv("GODOT_AI_SUPPRESS_DIAGNOSTIC_HINTS", raising=False)
+    else:
+        monkeypatch.setenv("GODOT_AI_SUPPRESS_DIAGNOSTIC_HINTS", env_value)
+
+    client = GodotClient(None, None)  # type: ignore[arg-type]
+
+    assert client.default_hint_policy == expected_policy
+
+
+def test_constructor_hint_policy_override_beats_environment(monkeypatch) -> None:
+    monkeypatch.setenv("GODOT_AI_SUPPRESS_DIAGNOSTIC_HINTS", "true")
+
+    client = GodotClient(  # type: ignore[arg-type]
+        None,
+        None,
+        default_hint_policy="surface",
+    )
+
+    assert client.default_hint_policy == "surface"
+
+
+def test_constructor_rejects_unknown_hint_policy() -> None:
+    with pytest.raises(ValueError, match="Unknown diagnostic hint policy"):
+        GodotClient(  # type: ignore[arg-type]
+            None,
+            None,
+            default_hint_policy="banana",  # type: ignore[arg-type]
+        )
+
+
+async def test_send_rejects_unknown_hint_policy() -> None:
+    client = GodotClient(None, None)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="Unknown diagnostic hint policy"):
+        await client.send("get_editor_state", hint_policy="banana")  # type: ignore[arg-type]

--- a/tests/unit/test_editor_state_mixed_state.py
+++ b/tests/unit/test_editor_state_mixed_state.py
@@ -31,7 +31,7 @@ class _EditorStateClient:
         params: dict | None = None,
         session_id: str | None = None,
         timeout: float = 5.0,
-        surface_error_hints: bool = True,
+        hint_policy=None,
     ) -> dict:
         if command != "get_editor_state":
             raise AssertionError(f"unexpected command: {command}")

--- a/tests/unit/test_game_eval.py
+++ b/tests/unit/test_game_eval.py
@@ -22,7 +22,7 @@ class _StubGameEvalClient:
         params: dict | None = None,
         session_id: str | None = None,
         timeout: float = 5.0,
-        surface_error_hints: bool = True,
+        hint_policy=None,
     ) -> dict:
         self.calls.append(
             {
@@ -95,7 +95,7 @@ class _RaisingGameEvalClient:
         params: dict | None = None,
         session_id: str | None = None,
         timeout: float = 5.0,
-        surface_error_hints: bool = True,
+        hint_policy=None,
     ) -> dict:
         raise GodotCommandError(code=self._code, message=self._message)
 

--- a/tests/unit/test_readiness.py
+++ b/tests/unit/test_readiness.py
@@ -72,7 +72,7 @@ class _EditorStateClient:
         params: dict | None = None,
         session_id: str | None = None,
         timeout: float = 5.0,
-        surface_error_hints: bool = True,
+        hint_policy=None,
     ) -> dict:
         if command != "get_editor_state":
             raise AssertionError(f"unexpected command: {command}")

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -60,7 +60,7 @@ class StubClient:
         params: dict | None = None,
         session_id: str | None = None,
         timeout: float = 5.0,
-        surface_error_hints: bool = True,
+        hint_policy=None,
     ) -> dict:
         self.calls.append(
             {
@@ -68,7 +68,7 @@ class StubClient:
                 "params": params,
                 "session_id": session_id,
                 "timeout": timeout,
-                "surface_error_hints": surface_error_hints,
+                "hint_policy": hint_policy,
             }
         )
         if command == "quit_editor":
@@ -1261,7 +1261,7 @@ class ReloadStubClient:
         params: dict | None = None,
         session_id: str | None = None,
         timeout: float = 5.0,
-        surface_error_hints: bool = True,
+        hint_policy=None,
     ) -> dict:
         self.calls.append(
             {
@@ -1269,7 +1269,7 @@ class ReloadStubClient:
                 "params": params,
                 "session_id": session_id,
                 "timeout": timeout,
-                "surface_error_hints": surface_error_hints,
+                "hint_policy": hint_policy,
             }
         )
         if command == "reload_plugin":
@@ -1530,16 +1530,17 @@ class StampingClient(StubClient):
         params: dict | None = None,
         session_id: str | None = None,
         timeout: float = 5.0,
-        surface_error_hints: bool = True,
+        hint_policy=None,
     ) -> dict:
-        result = await super().send(command, params, session_id, timeout, surface_error_hints)
+        result = await super().send(command, params, session_id, timeout, hint_policy)
         if command == "get_logs":
             result = dict(result)
             result["new_errors_since_last_call"] = 3
             result["new_errors_hint"] = (
-                "3 new GDScript errors since your last call. Inspect with "
-                "logs_read(source='editor', include_details=true) and/or "
-                "logs_read(source='game', include_details=true)."
+                "3 new GDScript errors since your last call. If you are mid-way through "
+                "a planned multi-file scaffold, finish the related writes and run "
+                'filesystem_manage(op="scan") before debugging; otherwise inspect with '
+                "logs_read(source='editor'|'game', include_details=true)."
             )
         return result
 
@@ -1575,9 +1576,9 @@ async def test_logs_read_handler_game_forwards_editor_error_hint_fields():
             params: dict | None = None,
             session_id: str | None = None,
             timeout: float = 5.0,
-            surface_error_hints: bool = True,
+            hint_policy=None,
         ) -> dict:
-            result = await super().send(command, params, session_id, timeout, surface_error_hints)
+            result = await super().send(command, params, session_id, timeout, hint_policy)
             if command == "get_logs" and (params or {}).get("source") == "game":
                 result = dict(result)
                 result["current_run_id"] = "rstub"
@@ -1731,7 +1732,7 @@ async def test_logs_read_handler_plugin_normalizes_structured_payload():
     ## source so existing callers don't shift.
     class StructuredPluginClient(StubClient):
         async def send(
-            self, command, params=None, session_id=None, timeout=5.0, surface_error_hints=True
+            self, command, params=None, session_id=None, timeout=5.0, hint_policy=None
         ):
             self.calls.append(
                 {
@@ -3822,7 +3823,7 @@ async def test_project_stop_handler_passes_through_idempotent_payload():
 
     class IdempotentStopClient(StubClient):
         async def send(
-            self, command, params=None, session_id=None, timeout=5.0, surface_error_hints=True
+            self, command, params=None, session_id=None, timeout=5.0, hint_policy=None
         ):
             self.calls.append({"command": command, "params": params})
             return {
@@ -3844,7 +3845,7 @@ async def test_project_run_handler_passes_through_already_running_payload():
 
     class AlreadyRunningClient(StubClient):
         async def send(
-            self, command, params=None, session_id=None, timeout=5.0, surface_error_hints=True
+            self, command, params=None, session_id=None, timeout=5.0, hint_policy=None
         ):
             self.calls.append({"command": command, "params": params})
             return {
@@ -4028,7 +4029,7 @@ async def test_editor_screenshot_handler_custom_angles():
 async def test_editor_screenshot_handler_view_target_not_found_single():
     class NotFoundClient:
         async def send(
-            self, command, params=None, session_id=None, timeout=5.0, surface_error_hints=True
+            self, command, params=None, session_id=None, timeout=5.0, hint_policy=None
         ):
             return {
                 "source": "viewport",
@@ -4054,7 +4055,7 @@ async def test_editor_screenshot_handler_view_target_not_found_single():
 async def test_editor_screenshot_handler_view_target_not_found_coverage():
     class NotFoundCoverageClient:
         async def send(
-            self, command, params=None, session_id=None, timeout=5.0, surface_error_hints=True
+            self, command, params=None, session_id=None, timeout=5.0, hint_policy=None
         ):
             return {
                 "source": "viewport",
@@ -4131,7 +4132,7 @@ async def test_editor_screenshot_handler_relays_viewport_not_3d_error():
 
     class ViewportNot3DClient:
         async def send(
-            self, command, params=None, session_id=None, timeout=5.0, surface_error_hints=True
+            self, command, params=None, session_id=None, timeout=5.0, hint_policy=None
         ):
             raise GodotCommandError(
                 code="EDITOR_NOT_READY",
@@ -4169,7 +4170,7 @@ async def test_editor_screenshot_handler_relays_viewport_empty_error():
 
     class ViewportEmptyClient:
         async def send(
-            self, command, params=None, session_id=None, timeout=5.0, surface_error_hints=True
+            self, command, params=None, session_id=None, timeout=5.0, hint_policy=None
         ):
             raise GodotCommandError(
                 code="EDITOR_NOT_READY",
@@ -4980,7 +4981,7 @@ def _make_stop_project_runtime(
 
     class ReadinessAfterStub(StubClient):
         async def send(
-            self, command, params=None, session_id=None, timeout=5.0, surface_error_hints=True
+            self, command, params=None, session_id=None, timeout=5.0, hint_policy=None
         ):
             self.calls.append({"command": command, "params": params})
             return {"stopped": True, "undoable": False, "readiness_after": readiness_after}

--- a/tests/unit/test_tilemap_tileset_handlers.py
+++ b/tests/unit/test_tilemap_tileset_handlers.py
@@ -17,7 +17,7 @@ class StubClient:
         params=None,
         session_id=None,
         timeout=5.0,
-        surface_error_hints=True,
+        hint_policy=None,
     ):
         self.calls.append(
             {
@@ -25,7 +25,7 @@ class StubClient:
                 "params": params or {},
                 "session_id": session_id,
                 "timeout": timeout,
-                "surface_error_hints": surface_error_hints,
+                "hint_policy": hint_policy,
             }
         )
         if command == "take_screenshot":
@@ -224,9 +224,9 @@ async def test_tileset_get_atlas_tiles_returns_result_unchanged():
             params=None,
             session_id=None,
             timeout=5.0,
-            surface_error_hints=True,
+            hint_policy=None,
         ):
-            await super().send(command, params, session_id, timeout, surface_error_hints)
+            await super().send(command, params, session_id, timeout, hint_policy)
             return expected
 
     client = FixedClient()
@@ -301,9 +301,9 @@ async def test_tileset_get_atlas_image_returns_result_unchanged():
             params=None,
             session_id=None,
             timeout=5.0,
-            surface_error_hints=True,
+            hint_policy=None,
         ):
-            await super().send(command, params, session_id, timeout, surface_error_hints)
+            await super().send(command, params, session_id, timeout, hint_policy)
             return expected
 
     client = FixedClient()

--- a/tests/unit/test_tileset_handler_properties.py
+++ b/tests/unit/test_tileset_handler_properties.py
@@ -39,7 +39,7 @@ class _FixedReturnClient:
         params: dict | None = None,
         session_id: str | None = None,
         timeout: float = 5.0,
-        surface_error_hints: bool = True,
+        hint_policy=None,
     ) -> dict:
         self.calls.append({"command": command, "params": params or {}})
         return self._return_value


### PR DESCRIPTION
## Summary

Implements Stage 0 of #761: soften diagnostic hints, split hint handling into explicit policies, and add a suppression escape hatch.

This is intentionally server-side only. It does not change the plugin, protocol envelope, watermark synchronization, or diagnostic classification.

## What changed

- Replace the internal `surface_error_hints` Boolean with three explicit policies:
  - `surface`: consume pending diagnostics and inject counts and hints.
  - `retain`: inject nothing and preserve pending counts.
  - `discard`: consume pending counts without injecting anything.
- Preserve `retain` behavior for the readiness probe.
- Apply the same policy to both error and warning channels.
- Soften both hints so agents finishing a planned multi-file scaffold are told to complete related writes and scan before debugging.
- Add `GODOT_AI_SUPPRESS_DIAGNOSTIC_HINTS`:
  - `true`, `TRUE`, or `1` selects `discard`.
  - Unset or unrecognized values fail open to `surface`.
  - The value is resolved when `GodotClient` is constructed, so changing it requires a server restart.
- Document that suppression discards real error and warning hints and is not a rollback switch for later stages.
- Reject invalid explicit policies with `ValueError`.

## Preserved contracts

- Error responses still raise before any hint policy handling. They never consume or inject diagnostic hints.
- `retain` leaves both pending counters untouched.
- `discard` clears both counters, preventing a stale backlog from flushing later.
- Explicit per-call policies override the client default.
- Existing response keys remain unchanged:
  - `new_errors_since_last_call`
  - `new_errors_hint`
  - `new_warnings_since_last_call`
  - `new_warnings_hint`
- `src/godot_ai/transport/websocket.py` and all plugin code remain untouched.

## Testing

- `uv run --extra dev ruff check src tests`
  - Passed.
- Focused hint-policy and WebSocket contracts:
  - 88 passed.
- Integration suite:
  - 331 passed, 3 skipped.
- Unit suite while the live Godot MCP server occupied port 9500:
  - 1,056 passed, 10 skipped, 2 deselected.
  - The two deselected CLI bind tests require port 9500 to be free.
- Live MCP smoke:
  - An editor-origin parse error surfaced the exact softened Stage 0 hint.
  - The private per-write validation path correctly did not ring the shared watermark.
  - The temporary fixture and UID were removed and the editor filesystem was rescanned.

## Follow-up

After merge, the next step is the V3 behavioral baseline against Stage 0. Stage 1 should proceed only if the measured detour rate shows that additional classification machinery is still warranted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable handling for diagnostic error and warning hints: surface, retain, or discard.
  * Diagnostic responses now include distinct error and warning counts with actionable guidance.
  * Added an environment setting to suppress diagnostic hints when desired.
  * Hints are delivered once and can appear on any tool response.

* **Documentation**
  * Updated diagnostic stamp documentation with delivery behavior, deduplication, scaffold guidance, and suppression options.

* **Tests**
  * Added coverage for hint policies, environment configuration, validation, warning handling, and backlog clearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->