### PR TITLE
project_run: stop leaking stale errors from past runs into launch responses

### DIFF
--- a/plugin/addons/godot_ai/handlers/project_handler.gd
+++ b/plugin/addons/godot_ai/handlers/project_handler.gd
@@ -296,9 +296,14 @@ static func _run_project_liveness_decision(status: Dictionary, errors_info: Dict
 	var recent_errors: Array = errors_info.get("errors", [])
 	var errors_scope := str(errors_info.get("scope", "none"))
 	var truncated := bool(errors_info.get("truncated", false))
-	## When the game launches successfully, don't carry forward retained errors
-	## from past runs — they were already reported in earlier run responses and
-	## only add noise to the current response.
+		## When the game launches successfully, clear errors that predate this
+		## run's window — they don't belong in a successful launch response and
+		## only add noise. They remain reachable via logs_read(source='editor') and
+		## the retained buffer so failed-run debugging is unaffected.
+		## #635 tradeoff: a genuine in-run error whose Errors-tab row carries an
+		## empty or byte-identical time text can be misclassified as
+		## retained_recent and will be dropped here. It is still reachable via
+		## logs_read.
 	if state == "live" and errors_scope == "retained_recent":
 		recent_errors = []
 		errors_scope = "none"

--- a/plugin/addons/godot_ai/handlers/project_handler.gd
+++ b/plugin/addons/godot_ai/handlers/project_handler.gd
@@ -296,6 +296,12 @@ static func _run_project_liveness_decision(status: Dictionary, errors_info: Dict
 	var recent_errors: Array = errors_info.get("errors", [])
 	var errors_scope := str(errors_info.get("scope", "none"))
 	var truncated := bool(errors_info.get("truncated", false))
+	## When the game launches successfully, don't carry forward retained errors
+	## from past runs — they were already reported in earlier run responses and
+	## only add noise to the current response.
+	if state == "live" and errors_scope == "retained_recent":
+		recent_errors = []
+		errors_scope = "none"
 	var correlated_error := not recent_errors.is_empty() and errors_scope == "run"
 	var elapsed_msec := int(status.get("elapsed_msec", 0))
 	var ready_wait_msec := int(status.get("ready_wait_msec", int(RUN_READY_WAIT_SEC * 1000.0)))

--- a/plugin/addons/godot_ai/handlers/project_handler.gd
+++ b/plugin/addons/godot_ai/handlers/project_handler.gd
@@ -296,14 +296,14 @@ static func _run_project_liveness_decision(status: Dictionary, errors_info: Dict
 	var recent_errors: Array = errors_info.get("errors", [])
 	var errors_scope := str(errors_info.get("scope", "none"))
 	var truncated := bool(errors_info.get("truncated", false))
-		## When the game launches successfully, clear errors that predate this
-		## run's window — they don't belong in a successful launch response and
-		## only add noise. They remain reachable via logs_read(source='editor') and
-		## the retained buffer so failed-run debugging is unaffected.
-		## #635 tradeoff: a genuine in-run error whose Errors-tab row carries an
-		## empty or byte-identical time text can be misclassified as
-		## retained_recent and will be dropped here. It is still reachable via
-		## logs_read.
+	## Clear errors that predate this run's window — they don't belong in
+	## a successful launch response and only add noise. They remain
+	## reachable via logs_read(source='editor') and the retained buffer so
+	## failed-run debugging is unaffected.
+	## #635 tradeoff: a genuine in-run error whose Errors-tab row carries
+	## an empty or byte-identical time text can be misclassified as
+	## retained_recent and will be dropped here. Still reachable via
+	## logs_read.
 	if state == "live" and errors_scope == "retained_recent":
 		recent_errors = []
 		errors_scope = "none"

--- a/test_project/tests/test_project.gd
+++ b/test_project/tests/test_project.gd
@@ -261,6 +261,20 @@ func test_run_project_liveness_decision_live_ignores_retained_errors_in_message(
 	assert_false(decision.message.contains("res://old.gd"), "errors that may predate the run must not taint the live message")
 
 
+func test_run_project_liveness_decision_live_clears_retained_errors() -> void:
+	## When the game is live and the error scope is "retained_recent",
+	## the decision must clear recent_errors so stale errors from
+	## previous runs don't appear in the response.
+	var err := {"text": "Parse Error: Old", "path": "res://old.gd", "line": 2}
+	var decision := _handler._run_project_liveness_decision(
+		_run_status("live", 100),
+		_errors_info([err], "retained_recent")
+	)
+	assert_eq(decision.recent_errors, [])
+	assert_eq(decision.recent_errors_scope, "none")
+	assert_eq(decision.recent_errors_may_predate_run, false)
+
+
 func test_run_project_already_running_live_message_reports_run_scoped_errors() -> void:
 	var err := {"text": "Parse Error: Expected expression", "path": "res://broken.gd", "line": 4}
 	var decision := _handler._run_project_liveness_decision(


### PR DESCRIPTION
Before the fix: _recent_editor_errors_since() falls back to stale errors from the buffer when the current run produces no new errors (scope = "retained_recent"). These could be issues fixed 10 minutes ago, cluttering the response with outdated context and confusing the AI agent.

After the fix: stale errors are cleared only when the game launches successfully. If the game fails to start (crash, script error, timeout, etc.), previous errors are preserved for debugging. This mirrors Unity's behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented retained editor errors from carrying over into success messaging when the project run state is confirmed as live.
  * Added logic to clear retained-error data and normalize related scope/flags after the live-state decision.
  * Expanded automated coverage with a new unit test to verify the retained-error reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->