### PR TITLE
docs: add test framework guide (testing.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,10 +275,10 @@ GDScript test suites in `test_project/tests/` exercise handlers inside the runni
 test_run                     # compact: summary + failures only
 test_run suite=scene         # run one suite
 test_run verbose=true        # include every individual test result
-test_results_get             # review last results
+test_manage op=results_get   # review last results (resource form: godot://test/results)
 ```
 
-Test suites extend `McpTestSuite` (assertion methods: `assert_true`, `assert_eq`, `assert_has_key`, `assert_contains`, `assert_is_error`, etc.). Drop `test_*.gd` files in `res://tests/` and they're auto-discovered.
+Test suites extend `McpTestSuite`; drop `test_*.gd` files in `res://tests/` and they're auto-discovered. Authoring guide + full assertion/lifecycle API reference: [docs/testing.md](docs/testing.md).
 
 ### Stress / load testing — `script/stormtest.py`
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ snippet.
 
 **Tools and resources:** see [docs/TOOLS.md](docs/TOOLS.md) for the full tool, op, and resource list (~43 tools exposing 120+ ops, plus read-only `godot://` resources), grouped by domain.
 
+**Testing:** the plugin ships an in-editor GDScript test framework — your AI client (or you) can write `McpTestSuite` suites for your own game under `res://tests/` and run them with `test_run`. See [docs/testing.md](docs/testing.md).
+
 <details>
 <summary><strong>Manual Client Configuration</strong></summary>
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -53,8 +53,11 @@ GDScript test suites run inside the connected editor via MCP:
 ```
 test_run                     # run all suites
 test_run suite=scene         # run one suite
-test_results_get             # review last results
+test_manage op=results_get   # review last results
 ```
+
+See [testing.md](testing.md) for how to write suites and the full
+`McpTestSuite` API reference.
 
 ### CI regression range helper
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -28,7 +28,7 @@ not the MCP tool names.
 | `scene_open` / `scene_save` | Open and save scenes |
 | `script_create` / `script_attach` / `script_patch` | Create, attach, anchor-edit GDScript files |
 | `project_run` | Play the project, then wait briefly for game liveness (autosave persists in-memory MCP edits unless `autosave=False`) |
-| `test_run` | Run GDScript test suites in the editor |
+| `test_run` | Run GDScript test suites in the editor — see [testing.md](testing.md) for writing suites and the `McpTestSuite` API |
 | `logs_read` | Read plugin / game / editor / combined log buffers. `source="editor"` surfaces parse errors, GDScript reload warnings, @tool/EditorPlugin runtime errors, push_error/push_warning, and visible Debugger dock Errors-tab rows — use this when the editor's Output or Debugger Errors panel shows red/yellow rows |
 | `editor_screenshot` | Capture editor viewport, cinematic camera, or running game framebuffer |
 | `editor_reload_plugin` | Reload the plugin and wait for reconnect (works with external and plugin-managed servers) |

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -6,6 +6,9 @@ This document defines how Godot AI should prove that new capability is real, sta
 
 Use the related docs for adjacent concerns:
 
+- [testing.md](testing.md) for how to write and run GDScript test suites
+  (authoring guide + `McpTestSuite` API reference) — this document covers
+  test-layer policy and CI expectations, not authoring
 - [implementation-plan.md](implementation-plan.md) for active priorities
 - [packaging-distribution.md](packaging-distribution.md) for release-smoke install coverage
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -150,7 +150,7 @@ String)` removes it.
 
 MCP tool `test_run` (120 s server-side timeout for the whole run):
 
-```
+```text
 test_run                              # all suites — compact: counts + failures only
 test_run suite=player                 # one suite (exact match on suite_name())
 test_run test_name=speed              # only tests whose name contains "speed"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -90,7 +90,7 @@ failure message.
 | Method | Behavior |
 |---|---|
 | `suite_name() -> String` | Override. Short suite id (e.g. `"scene"`), matched exactly by `test_run suite=...`. Default `"unnamed"`. |
-| `suite_setup(ctx: Dictionary) -> void` | Override. Runs once before the suite. `ctx` is `{"undo_redo": EditorUndoRedoManager, "log_buffer": McpLogBuffer}`; each suite gets a fresh duplicate, so mutations can't leak between suites. |
+| `suite_setup(ctx: Dictionary) -> void` | Override. Runs once before the suite. `ctx` is `{"undo_redo": EditorUndoRedoManager, "log_buffer": McpLogBuffer}`; each suite receives a fresh `ctx.duplicate(true)`, so Dictionary mutations can't leak between suites — but the contained Objects (the undo/redo manager, the log buffer) are shared editor references, so treat them as shared state. |
 | `setup() -> void` | Override. Runs before each test. |
 | `teardown() -> void` | Override. Runs after each test. |
 | `suite_teardown() -> void` | Override. Runs once after the suite. |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,211 @@
+# GDScript Testing — Writing and Running Test Suites
+
+The plugin ships an in-editor GDScript test framework: `McpTestSuite` (base
+class: assertions + lifecycle hooks) and `McpTestRunner` (discovery, execution,
+result collection), invoked via the `test_run` MCP tool. It runs against
+**whatever project the connected editor has open** — godot-ai's own
+`test_project/`, or **your game** (any project with the plugin enabled — see
+[Testing your own game](#testing-your-own-game)).
+
+Sources of truth:
+[`test_suite.gd`](../plugin/addons/godot_ai/testing/test_suite.gd) (API),
+[`test_runner.gd`](../plugin/addons/godot_ai/testing/test_runner.gd) (runner),
+[`test_handler.gd`](../plugin/addons/godot_ai/handlers/test_handler.gd)
+(discovery), [`tools/testing.py`](../src/godot_ai/tools/testing.py) (MCP
+surface). CI policy and test-layer strategy live in
+[testing-strategy.md](testing-strategy.md); test-hygiene rules for
+contributors are in [AGENTS.md](../AGENTS.md).
+
+## Skeleton
+
+```gdscript
+@tool
+extends McpTestSuite
+
+func suite_name() -> String:
+	return "player"              # short id, used by test_run suite=...
+
+func test_something() -> void:   # every test_* method runs, alphabetical order
+	assert_eq(1 + 1, 2)
+```
+
+Save as `res://tests/test_player.gd` in the open project, then call `test_run`.
+That's the whole loop.
+
+## Discovery rules
+
+- Scanned directory: `res://tests/` in the currently open project. Top level
+  only — subdirectories are not scanned.
+- Filename must match `test_*.gd`; the script must extend `McpTestSuite` and
+  be instantiable.
+- A file that fails to load (parse error, duplicate method, wrong base class)
+  is reported in the response's `load_errors`; the remaining suites still run.
+- Suites run sorted by `suite_name()`; within a suite, `test_*` methods run in
+  alphabetical order.
+- Test methods must be synchronous. The runner does not await coroutines — a
+  test suspends at its first `await` and everything after it never runs
+  (usually surfacing as a zero-assertion failure).
+
+## Complete minimal example
+
+Own-game flavor (`res://tests/test_player.gd`):
+
+```gdscript
+@tool
+extends McpTestSuite
+
+const PlayerScene := preload("res://player/player.tscn")
+
+func suite_name() -> String:
+	return "player"
+
+func test_player_instantiates() -> void:
+	var player = track(PlayerScene.instantiate())  # track() = freed after the test
+	assert_true(player is CharacterBody2D, "player root should be a CharacterBody2D")
+
+func test_speed_positive() -> void:
+	var player = track(PlayerScene.instantiate())
+	assert_gt(player.speed, 0.0, "speed must be positive")
+
+func test_selected_node_readable() -> void:
+	if EditorInterface.get_edited_scene_root() == null:
+		skip("no scene open")   # unmet precondition — counts as skipped, not passed
+		return
+	assert_true(EditorInterface.get_edited_scene_root().name != "")
+```
+
+Contributor flavor: plugin handler suites `preload` the handler in
+`suite_setup()` and assert on the `{"data": ...}` / `{"error": ...}` dict each
+handler returns. Reference pattern:
+[`test_project/tests/test_scene.gd`](../test_project/tests/test_scene.gd).
+
+## API reference — `McpTestSuite`
+
+Ordered as in `test_suite.gd`. Assertions latch on the first failure: later
+assertions in the same test still increment the count but cannot overwrite the
+failure message.
+
+### Lifecycle and helpers
+
+| Method | Behavior |
+|---|---|
+| `suite_name() -> String` | Override. Short suite id (e.g. `"scene"`), matched exactly by `test_run suite=...`. Default `"unnamed"`. |
+| `suite_setup(ctx: Dictionary) -> void` | Override. Runs once before the suite. `ctx` is `{"undo_redo": EditorUndoRedoManager, "log_buffer": McpLogBuffer}`; each suite gets a fresh duplicate, so mutations can't leak between suites. |
+| `setup() -> void` | Override. Runs before each test. |
+| `teardown() -> void` | Override. Runs after each test. |
+| `suite_teardown() -> void` | Override. Runs once after the suite. |
+| `track(obj: Object) -> Object` | Register a plain Object or out-of-tree Node to be freed after the current test (and again after `suite_teardown`). RefCounted instances are accepted but ignored (they self-manage). Returns `obj` for inline use. |
+| `skip(reason := "") -> void` | Mark the current test skipped (unmet precondition — no scene open, etc.). Skips count separately from passed/failed; a prior failed assertion always beats a later `skip()`. |
+| `fail_setup(reason: String) -> void` | Call inside `suite_setup()` to abort the suite with a single suite-level failure (reported as test `<suite_setup>`) instead of N zero-assertion failures. |
+| `skip_suite(reason: String) -> void` | Call inside `suite_setup()` to skip the whole suite with a single suite-level skip (reported as test `<suite_setup>`). |
+| `skip_on_godot_lt(min_version: String, reason := "") -> bool` | Skip the current test when the running Godot is older than `"major.minor"`. Returns `true` when skipped, so: `if skip_on_godot_lt("4.6", "..."): return`. |
+| `expect_script_error_containing(substring: String) -> void` | Allow one captured `SCRIPT ERROR` whose text contains `substring`. Only for negative-path tests that intentionally run invalid GDScript; any unexpected script error fails the test (`Aborted by SCRIPT ERROR: ...`). |
+| `editor_undo(undo_redo: EditorUndoRedoManager) -> bool` | Undo the most recent action across the scene and global undo histories. Returns `false` when nothing was undone — assert on the return value. |
+| `editor_redo(undo_redo: EditorUndoRedoManager) -> bool` | Redo mirror of `editor_undo`. |
+
+### Assertions
+
+Each records one assertion; `msg` is optional everywhere and replaces the
+default failure message.
+
+| Method | Passes when |
+|---|---|
+| `assert_true(condition, msg := "")` | `condition` is true |
+| `assert_false(condition, msg := "")` | `condition` is false |
+| `assert_eq(actual, expected, msg := "")` | `actual == expected` |
+| `assert_ne(actual, not_expected, msg := "")` | `actual != not_expected` |
+| `assert_gt(actual, threshold, msg := "")` | `actual > threshold` |
+| `assert_has_key(dict, key, msg := "")` | `dict` is a Dictionary and has `key` (failure message lists the actual keys) |
+| `assert_contains(haystack, needle, msg := "")` | String `haystack` contains `needle` as substring, or Array `haystack` has `needle` as element; any other haystack type fails |
+| `assert_is_error(result, expected_code := "", msg := "")` | `result` has an `"error"` key; when `expected_code` is given, `result.error.code` must match it |
+
+### Scene helpers
+
+Underscore-prefixed convenience shared by the plugin's own suites (not a
+stable public API): `_add_control(ctl_name: String, ctl: Control = null) ->
+String` adds a Control (defaults to a new Panel) under the scene root and
+returns its scene path (`""` when no scene is open); `_remove_control(path:
+String)` removes it.
+
+## Runner behavior and guardrails
+
+- **Zero-assertion detection**: a test that completes with 0 assertions fails
+  (`"likely skipped its logic"`). Use `skip("reason")` before any early
+  `return` whose precondition can't be met.
+- **Script-error capture**: any `SCRIPT ERROR` emitted during a test fails it
+  unless allowlisted via `expect_script_error_containing`.
+- **Failure beats skip**: a test that fails an assertion and then hits a
+  `skip()` guard reports the failure.
+- **Per-test cleanup**: `track()`-ed objects are freed after `teardown()`; any
+  scene node whose name starts with `_McpTest` is freed after every test,
+  anywhere in the tree, bypassing undo. Name throwaway scene nodes
+  `_McpTest...` to get this for free.
+- **Per-suite cleanup**: nodes added under the scene root during a suite and
+  left behind are removed when the suite ends.
+- **Suite isolation**: each suite receives a fresh `ctx.duplicate()`.
+- **Resilient discovery**: broken `test_*.gd` files land in `load_errors`
+  without stopping the rest of the run.
+
+## Running tests
+
+MCP tool `test_run` (120 s server-side timeout for the whole run):
+
+```
+test_run                              # all suites — compact: counts + failures only
+test_run suite=player                 # one suite (exact match on suite_name())
+test_run test_name=speed              # only tests whose name contains "speed"
+test_run exclude_test_name=slow,flaky # skip tests matching any comma-separated substring
+test_run verbose=true                 # include every individual test result
+test_run session_id=mygame@1a2b       # pin to one editor when several are connected
+```
+
+Re-fetch the last results without re-running: `test_manage(op="results_get")`
+(accepts `verbose` in `params`), or read the resource `godot://test/results`.
+
+### Result shape
+
+```json
+{
+  "passed": 12, "failed": 1, "skipped": 2, "total": 15,
+  "duration_ms": 240,
+  "suites_run": ["player", "scene"], "suite_count": 2,
+  "failures": [
+    {"suite": "player", "test": "test_speed_positive",
+     "passed": false, "message": "Expected 0.0 > 0.0", "assertion_count": 1}
+  ],
+  "edited_scene": "res://main.tscn"
+}
+```
+
+- `failures` is present only when non-empty. `verbose=true` adds `results`
+  with every test (skipped entries carry `"skipped": true` and the skip
+  reason as `message`).
+- `load_errors` (array of `"file (reason)"` strings) appears when any
+  `test_*.gd` failed to load.
+- `edited_scene` is always present. `scene_warning` appears when there are
+  failures and the edited scene differs from the project's main scene — many
+  suites assume the main scene is open, so `scene_open` it and re-run before
+  treating those failures as real.
+- A suite aborted by `fail_setup` / `skip_suite` reports one entry with
+  `"test": "<suite_setup>"`.
+
+## Testing your own game
+
+Everything above works in any project with the plugin enabled: discovery is
+`res://tests/` of whatever project the connected editor has open, and
+`McpTestSuite` is a global class registered by the plugin. A typical loop with
+an AI client: ask it to *"write a test suite for the player controller and run
+it"* — it creates `res://tests/test_player.gd` (e.g. via `script_create`),
+calls `test_run`, and iterates on the failures.
+
+Constraints (tests run synchronously on the editor's main thread):
+
+- Don't open modal dialogs, switch scenes, or start/stop the game from a test
+  — these block or invalidate the runner mid-run. Test the validation paths
+  synchronously and `skip()` on unmet preconditions (see the
+  "validation only" sections in
+  [`test_scene.gd`](../test_project/tests/test_scene.gd)).
+- Keep per-test work small; the whole run must finish within `test_run`'s
+  120 s timeout.
+- Free what you create: `track()` for objects and out-of-tree nodes, or the
+  `_McpTest*` name prefix for scene nodes.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -142,7 +142,9 @@ String)` removes it.
   `_McpTest...` to get this for free.
 - **Per-suite cleanup**: nodes added under the scene root during a suite and
   left behind are removed when the suite ends.
-- **Suite isolation**: each suite receives a fresh `ctx.duplicate()`.
+- **Suite isolation**: each suite receives a fresh `ctx.duplicate(true)` —
+  Dictionary mutations can't leak between suites; the contained Objects are
+  shared editor references (see `suite_setup` above).
 - **Resilient discovery**: broken `test_*.gd` files land in `load_errors`
   without stopping the rest of the run.
 


### PR DESCRIPTION
Fixes #775 — there was no documentation on the GDScript test framework, so AI clients had to re-read the test examples (or `test_suite.gd` itself) every session.

## What's added

**New `docs/testing.md`** — one agent-consumable doc covering both audiences:

- **Writing tests** (end users *and* contributors): the `@tool` + `extends McpTestSuite` skeleton front-loaded, discovery rules (`res://tests/test_*.gd` in the currently open project, top level only, sync-only test methods), a complete minimal own-game example plus a pointer to `test_scene.gd` as the contributor handler-suite pattern, and the **full `McpTestSuite` API reference** — every assertion (`assert_true/false/eq/ne/gt/has_key/contains/is_error`), lifecycle hook (`suite_name`, `suite_setup`, `setup`, `teardown`, `suite_teardown`), and helper (`track`, `skip`, `fail_setup`, `skip_suite`, `skip_on_godot_lt`, `expect_script_error_containing`, `editor_undo/redo`), one line each with signature and behavior, ordered to match `test_suite.gd` so future diffs stay easy.
- **Running tests**: `test_run` and all its filters (`suite=`, `test_name=`, `exclude_test_name=`, `verbose`, `session_id`), `test_manage(op="results_get")`, the `godot://test/results` resource, and result-shape notes (`failures[]`, `load_errors`, `edited_scene`/`scene_warning`, `<suite_setup>` entries, 120 s timeout).
- **Own-game usage is now explicit**: discovery runs against whatever project the connected editor has open, so users can have their AI write and run suites for their own game.

## Cross-links

- `docs/TOOLS.md` — `test_run` entry points at the guide
- `README.md` — testing note next to the tools pointer
- `AGENTS.md` — the "assertion methods: …, etc." list replaced with a pointer
- `docs/CONTRIBUTING.md` — pointer under Godot-side tests
- `docs/testing-strategy.md` — scope note (strategy doc = CI/test-layer policy; testing.md = authoring how-to); otherwise untouched

Also fixed in passing: `AGENTS.md`/`CONTRIBUTING.md` still showed the retired `test_results_get` invocation; the op now lives at `test_manage(op="results_get")`.

Docs-only; no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Testing” guide for the in-editor GDScript test framework, including how to author suites, discovery/execution rules, lifecycle hooks, cleanup/isolation behavior, and the expected `test_run` result details.
  * Expanded `test_run` documentation with links to the new authoring/API reference.
  * Updated README and contributor/testing strategy docs with clearer testing links.
  * Refreshed MCP guidance for reviewing the last test results, including the correct resource reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->