### PR TITLE
particle: stop silently dropping apply_preset draw overrides

### DIFF
--- a/plugin/addons/godot_ai/handlers/particle_handler.gd
+++ b/plugin/addons/godot_ai/handlers/particle_handler.gd
@@ -89,7 +89,7 @@ func create_particle(params: Dictionary) -> Dictionary:
 		# Without a material, the mesh renders flat white — ignoring
 		# ParticleProcessMaterial.color_ramp entirely. Give it the standard
 		# billboard + vertex-color-as-albedo setup so color_ramp works.
-		draw_material = ParticleValues.build_draw_material({})
+		draw_material = ParticleValues.build_draw_material({}).material
 		(draw_mesh as QuadMesh).material = draw_material
 		draw_pass_mesh_created = true
 		draw_material_created = true
@@ -627,18 +627,62 @@ func apply_preset(params: Dictionary) -> Dictionary:
 		process_mat = ParticleProcessMaterial.new()
 		process_material_created = true
 
+	# User-supplied override keys per group. Preset-blueprint keys may skip
+	# silently on types they don't apply to (presets are cross-type by
+	# design); user-requested overrides must apply or error (#770).
+	var user_keys: Dictionary = blueprint.get("user_keys", {})
+	var user_main: Dictionary = user_keys.get("main", {})
+	var user_process: Dictionary = user_keys.get("process", {})
+	var user_draw: Dictionary = user_keys.get("draw", {})
+
 	var draw_mesh: Mesh = null
 	var draw_material: StandardMaterial3D = null
 	var draw_pass_mesh_created := false
 	var draw_material_created := false
+	var applied_draw: Array[String] = []
+	var draw_config: Dictionary = blueprint.get("draw", {})
 	if type_str == "gpu_3d":
+		var draw_result := ParticleValues.build_draw_material(draw_config)
+		if not draw_result.ok:
+			node.free()
+			var msg := String(draw_result.error)
+			if draw_result.get("unknown_key", false):
+				msg = _draw_key_unsupported_message(String(draw_result.key), type_str)
+			return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, msg)
 		draw_mesh = QuadMesh.new()
 		(draw_mesh as QuadMesh).size = Vector2(0.25, 0.25)
-		var draw_config: Dictionary = blueprint.get("draw", {})
-		draw_material = ParticleValues.build_draw_material(draw_config)
+		draw_material = draw_result.material
 		(draw_mesh as QuadMesh).material = draw_material
 		draw_pass_mesh_created = true
 		draw_material_created = true
+		for applied_key in draw_result.applied:
+			applied_draw.append(String(applied_key))
+	elif type_str == "gpu_2d":
+		# GPUParticles2D has no draw-pass material; the one draw override it
+		# supports is draw.texture → the node's texture property.
+		for key in user_draw:
+			if String(key) != "texture":
+				node.free()
+				return ErrorCodes.make(
+					ErrorCodes.INVALID_PARAMS,
+					_draw_key_unsupported_message(String(key), type_str)
+				)
+		if user_draw.has("texture"):
+			var tex_result := _load_draw_texture(draw_config.get("texture"))
+			if tex_result.has("error"):
+				node.free()
+				return tex_result
+			node.set("texture", tex_result.texture)
+			applied_draw.append("texture")
+	else:
+		# cpu_3d / cpu_2d: no draw support — reject user draw overrides
+		# instead of dropping them.
+		for key in user_draw:
+			node.free()
+			return ErrorCodes.make(
+				ErrorCodes.INVALID_PARAMS,
+				_draw_key_unsupported_message(String(key), type_str)
+			)
 
 	# Pre-apply preset values to in-memory targets (no undo needed; nodes not in tree yet).
 	var main_values: Dictionary = blueprint.get("main", {})
@@ -650,9 +694,19 @@ func apply_preset(params: Dictionary) -> Dictionary:
 		var prop_name := String(prop)
 		var prop_type := _object_property_type(node, prop_name)
 		if prop_type == TYPE_NIL:
-			continue  # Silently skip: not all main keys apply to all types.
+			if user_main.has(prop_name):
+				var node_class := node.get_class()
+				node.free()
+				return ErrorCodes.make(
+					ErrorCodes.INVALID_PARAMS,
+					"Override main.%s does not apply to type '%s' (no such property on %s)" % [
+						prop_name, type_str, node_class
+					]
+				)
+			continue  # Blueprint key: not all main keys apply to all types.
 		var coerce_result := ParticleValues.coerce(prop_name, main_values[prop_name], prop_type)
 		if not coerce_result.ok:
+			node.free()
 			return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, String(coerce_result.error))
 		node.set(prop_name, coerce_result.value)
 		applied_main.append(prop_name)
@@ -663,9 +717,19 @@ func apply_preset(params: Dictionary) -> Dictionary:
 		var prop_name := String(prop)
 		var prop_type := _object_property_type(process_target, prop_name)
 		if prop_type == TYPE_NIL:
-			continue  # Silently skip: preset property doesn't apply to this variant.
+			if user_process.has(prop_name):
+				var target_class := process_target.get_class()
+				node.free()
+				return ErrorCodes.make(
+					ErrorCodes.INVALID_PARAMS,
+					"Override process.%s does not apply to type '%s' (no such property on %s)" % [
+						prop_name, type_str, target_class
+					]
+				)
+			continue  # Blueprint key: preset property doesn't apply to this variant.
 		var coerce_result := ParticleValues.coerce(prop_name, process_values[prop_name], prop_type)
 		if not coerce_result.ok:
+			node.free()
 			return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, String(coerce_result.error))
 		process_target.set(prop_name, coerce_result.value)
 		applied_process.append(prop_name)
@@ -695,6 +759,7 @@ func apply_preset(params: Dictionary) -> Dictionary:
 			"class": _VALID_TYPES[type_str],
 			"applied_main": applied_main,
 			"applied_process": applied_process,
+			"applied_draw": applied_draw,
 			"process_material_created": process_material_created,
 			"draw_pass_mesh_created": draw_pass_mesh_created,
 			"draw_material_created": draw_material_created,
@@ -707,6 +772,40 @@ func apply_preset(params: Dictionary) -> Dictionary:
 # ============================================================================
 # Helpers
 # ============================================================================
+
+## Actionable rejection for a user draw override that can't apply to the
+## selected particle type: name the key and where it IS supported.
+static func _draw_key_unsupported_message(key: String, type_str: String) -> String:
+	if key == "texture":
+		return "draw.texture is only supported for gpu_2d (got type '%s')" % type_str
+	var probe := StandardMaterial3D.new()
+	if _object_property_type(probe, key) != TYPE_NIL:
+		return "draw.%s is only supported for gpu_3d (got type '%s')" % [key, type_str]
+	return (
+		"Unknown draw key '%s' (draw overrides configure the gpu_3d "
+		+ "draw-pass StandardMaterial3D; gpu_2d supports only draw.texture)"
+	) % key
+
+
+## Load a Texture2D for the gpu_2d draw.texture override. Returns
+## {texture: Texture2D} or an error dict (same validation as set_draw_pass).
+static func _load_draw_texture(value: Variant) -> Dictionary:
+	if not (value is String) or String(value).is_empty():
+		return ErrorCodes.make(
+			ErrorCodes.INVALID_PARAMS,
+			"draw.texture must be a non-empty res:// path string (got %s)" % type_string(typeof(value))
+		)
+	var texture_path := String(value)
+	var texture_path_err = McpPathValidator.loadable_error(texture_path, "draw.texture")
+	if texture_path_err != null:
+		return texture_path_err
+	if not ResourceLoader.exists(texture_path):
+		return ErrorCodes.make(ErrorCodes.RESOURCE_NOT_FOUND, "Texture not found: %s" % texture_path)
+	var tex := ResourceLoader.load(texture_path)
+	if not (tex is Texture2D):
+		return ErrorCodes.make(ErrorCodes.WRONG_TYPE, "Resource at %s is not a Texture2D" % texture_path)
+	return {"texture": tex}
+
 
 static func _instantiate_particle(type_str: String) -> Node:
 	match type_str:

--- a/plugin/addons/godot_ai/handlers/particle_presets.gd
+++ b/plugin/addons/godot_ai/handlers/particle_presets.gd
@@ -236,9 +236,13 @@ static func has(preset_name: String) -> bool:
 	return _PRESETS.has(preset_name)
 
 
-## Return deep-copied {main, process, draw} blueprint with overrides merged in.
+## Return deep-copied {main, process, draw} blueprint with overrides merged in,
+## plus "user_keys" ({main/process/draw: {key: true}}) recording which keys the
+## caller supplied. The handler needs that distinction: preset-blueprint keys
+## may skip silently on types they don't apply to (presets are cross-type by
+## design), but user-requested overrides must apply or error (#770).
 ## Overrides may include top-level "main" / "process" / "draw" dicts, or bare
-## keys that get routed based on which group they belong to.
+## keys routed to main (_MAIN_KEYS) or process — draw keys must be nested.
 static func build(preset_name: String, overrides: Dictionary) -> Variant:
 	if not _PRESETS.has(preset_name):
 		return null
@@ -246,24 +250,31 @@ static func build(preset_name: String, overrides: Dictionary) -> Variant:
 	var main: Dictionary = entry.get("main", {})
 	var process: Dictionary = entry.get("process", {})
 	var draw: Dictionary = entry.get("draw", {})
+	var user_keys := {"main": {}, "process": {}, "draw": {}}
 	for key in overrides:
 		var val = overrides[key]
 		if key == "main" and val is Dictionary:
 			for k in val:
 				main[k] = val[k]
+				user_keys.main[String(k)] = true
 		elif key == "process" and val is Dictionary:
 			for k in val:
 				process[k] = val[k]
+				user_keys.process[String(k)] = true
 		elif key == "draw" and val is Dictionary:
 			for k in val:
 				draw[k] = val[k]
+				user_keys.draw[String(k)] = true
 		elif _MAIN_KEYS.has(key):
 			main[key] = val
+			user_keys.main[String(key)] = true
 		else:
 			process[key] = val
+			user_keys.process[String(key)] = true
 	entry["main"] = main
 	entry["process"] = process
 	entry["draw"] = draw
+	entry["user_keys"] = user_keys
 	return entry
 
 

--- a/plugin/addons/godot_ai/handlers/particle_values.gd
+++ b/plugin/addons/godot_ai/handlers/particle_values.gd
@@ -169,7 +169,12 @@ static func coerce(property: String, value: Variant, target_type: int) -> Dictio
 ##   albedo_color: Color
 ##   albedo_texture: res:// path
 ##   (anything else accepted by BaseMaterial3D.set())
-static func build_draw_material(config: Dictionary) -> StandardMaterial3D:
+##
+## Returns {ok: true, material: StandardMaterial3D, applied: Array[String]},
+## or {ok: false, key, error, unknown_key} when a config key is not a
+## StandardMaterial3D property or its value fails coercion — draw config must
+## not disappear silently (#770).
+static func build_draw_material(config: Dictionary) -> Dictionary:
 	var mat := StandardMaterial3D.new()
 	# Sensible defaults for particle draw-pass rendering.
 	mat.shading_mode = BaseMaterial3D.SHADING_MODE_UNSHADED
@@ -178,17 +183,30 @@ static func build_draw_material(config: Dictionary) -> StandardMaterial3D:
 	mat.billboard_mode = BaseMaterial3D.BILLBOARD_PARTICLES
 	mat.billboard_keep_scale = true
 	# Configure from dict overrides.
+	var applied: Array[String] = []
 	for key in config:
 		var prop_name := String(key)
 		var prop_type := _object_property_type(mat, prop_name)
 		if prop_type == TYPE_NIL:
-			continue
+			return {
+				"ok": false,
+				"key": prop_name,
+				"unknown_key": true,
+				"error": "Unknown draw key '%s' (not a StandardMaterial3D property)" % prop_name,
+			}
 		var coerce_result := MaterialValues.coerce_material_value(
 			prop_name, config[prop_name], prop_type
 		)
-		if coerce_result.ok:
-			mat.set(prop_name, coerce_result.value)
-	return mat
+		if not coerce_result.ok:
+			return {
+				"ok": false,
+				"key": prop_name,
+				"unknown_key": false,
+				"error": "draw.%s: %s" % [prop_name, coerce_result.error],
+			}
+		mat.set(prop_name, coerce_result.value)
+		applied.append(prop_name)
+	return {"ok": true, "material": mat, "applied": applied}
 
 
 static func _object_property_type(obj: Object, name: String) -> int:

--- a/src/godot_ai/tools/particle.py
+++ b/src/godot_ai/tools/particle.py
@@ -24,7 +24,9 @@ Ops:
   • set_process(node_path, properties)
         Behavior props (auto-creates ProcessMaterial for GPU). Emission shape,
         velocity, gravity, color_ramp, scale_curve, turbulence. See full
-        property list in the Godot reference.
+        property list in the Godot reference. GPU gravity is a Vector3 —
+        pass {x, y, z} or [x, y, z], including for gpu_2d (the shared
+        ProcessMaterial is 3D; z is ignored in 2D).
   • set_draw_pass(node_path, pass_=1, mesh="", texture="", material="")
         What gets drawn per particle. GPU 3D: mesh in draw_pass_N + optional
         material override. GPU 2D / CPU 2D: texture. CPU 3D: mesh.
@@ -35,6 +37,15 @@ Ops:
   • apply_preset(parent_path, name, preset, type="gpu_3d", overrides=None)
         Curated effects: fire, smoke, spark_burst, magic_swirl, rain,
         explosion, lightning. One-shot presets re-trigger via restart.
+        overrides = {"main": {...}, "process": {...}, "draw": {...}}; bare
+        keys are auto-routed to main (amount, lifetime, one_shot, ...) or
+        process — draw keys must be nested under "draw". draw configures
+        the gpu_3d draw-pass StandardMaterial3D (blend_mode, albedo_color,
+        emission, ...); on gpu_2d only draw.texture (res:// path) applies;
+        cpu_* types reject draw overrides. Unknown or malformed override
+        keys return INVALID_PARAMS (never silently dropped); response
+        reports applied_main / applied_process / applied_draw. GPU gravity
+        requires {x, y, z} (or [x, y, z]) even for gpu_2d.
 """
 
 

--- a/test_project/tests/test_particle.gd
+++ b/test_project/tests/test_particle.gd
@@ -29,6 +29,9 @@ func suite_teardown() -> void:
 	for path in _created_paths:
 		_remove_by_path(path)
 	_created_paths.clear()
+	# Safety net: a test failing before its manual cleanup must not leave the
+	# texture fixture on disk.
+	_cleanup_particle_texture()
 
 
 func _remove_by_path(path: String) -> void:

--- a/test_project/tests/test_particle.gd
+++ b/test_project/tests/test_particle.gd
@@ -552,3 +552,173 @@ func test_apply_preset_invalid_type() -> void:
 		"type": "gpu_5d",
 	})
 	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
+
+
+# ============================================================================
+# particle_apply_preset — draw overrides must never disappear silently (#770)
+# ============================================================================
+
+const _PARTICLE_TEX_PATH := "res://tests/_mcp_particle_texture.tres"
+
+
+## The test project ships no image assets, so the gpu_2d draw.texture tests
+## save (and afterwards remove) a real Texture2D .tres to load from.
+func _particle_texture_path() -> String:
+	if not FileAccess.file_exists(_PARTICLE_TEX_PATH):
+		var tex := GradientTexture2D.new()
+		assert_eq(ResourceSaver.save(tex, _PARTICLE_TEX_PATH), OK,
+			"seed texture must save")
+	return _PARTICLE_TEX_PATH
+
+
+func _cleanup_particle_texture() -> void:
+	if FileAccess.file_exists(_PARTICLE_TEX_PATH):
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(_PARTICLE_TEX_PATH))
+		var efs := EditorInterface.get_resource_filesystem()
+		if efs != null:
+			efs.update_file(_PARTICLE_TEX_PATH)
+
+
+func test_apply_preset_draw_override_gpu_3d_applied_and_reported() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root — is a scene open?")
+		return
+	var result := _handler.apply_preset({
+		"parent_path": "/" + scene_root.name,
+		"name": "TestDrawOverride3D",
+		"preset": "fire",
+		"overrides": {"draw": {
+			"emission_energy_multiplier": 3.5,
+			"albedo_color": {"r": 0.0, "g": 0.0, "b": 1.0, "a": 1.0},
+		}},
+	})
+	assert_has_key(result, "data")
+	assert_contains(result.data.applied_draw, "emission_energy_multiplier")
+	assert_contains(result.data.applied_draw, "albedo_color")
+	# Blueprint draw keys are applied and reported too — fire carries blend_mode.
+	assert_contains(result.data.applied_draw, "blend_mode")
+	# Read back the stored values, not just the report.
+	var node := McpScenePath.resolve(result.data.path, scene_root) as GPUParticles3D
+	var mat := (node.draw_pass_1 as QuadMesh).material as StandardMaterial3D
+	assert_true(mat != null, "draw material should be attached")
+	assert_true(abs(mat.emission_energy_multiplier - 3.5) < 0.01,
+		"emission_energy_multiplier override must land on the draw material")
+	assert_true(abs(mat.albedo_color.b - 1.0) < 0.01,
+		"albedo_color override must land on the draw material")
+	_created_paths.append(result.data.path)
+
+
+func test_apply_preset_draw_texture_gpu_2d_applied_and_undoable() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root — is a scene open?")
+		return
+	var result := _handler.apply_preset({
+		"parent_path": "/" + scene_root.name,
+		"name": "TestDrawTex2D",
+		"preset": "fire",
+		"type": "gpu_2d",
+		"overrides": {"draw": {"texture": _particle_texture_path()}},
+	})
+	assert_has_key(result, "data")
+	assert_contains(result.data.applied_draw, "texture")
+	var node := McpScenePath.resolve(result.data.path, scene_root) as GPUParticles2D
+	assert_true(node != null, "GPUParticles2D should exist at reported path")
+	assert_true(node.texture is Texture2D, "draw.texture override must land on node.texture")
+	# Undo removes the node; redo restores it with the texture intact.
+	var did_undo := editor_undo(_undo_redo)
+	assert_true(did_undo, "undo should succeed")
+	assert_true(McpScenePath.resolve(result.data.path, scene_root) == null,
+		"undo should remove the preset node")
+	var did_redo := editor_redo(_undo_redo)
+	assert_true(did_redo, "redo should succeed")
+	var restored := McpScenePath.resolve(result.data.path, scene_root) as GPUParticles2D
+	assert_true(restored != null, "redo should restore the preset node")
+	assert_true(restored.texture is Texture2D, "redo must restore the texture")
+	_created_paths.append(result.data.path)
+	_cleanup_particle_texture()
+
+
+func test_apply_preset_unknown_draw_key_errors() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root — is a scene open?")
+		return
+	var result := _handler.apply_preset({
+		"parent_path": "/" + scene_root.name,
+		"name": "TestBadDrawKey",
+		"preset": "fire",
+		"overrides": {"draw": {"bogus_key": 1}},
+	})
+	assert_is_error(result, ErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "bogus_key")
+
+
+func test_apply_preset_malformed_gravity_scalar_errors() -> void:
+	# GPU gravity is a Vector3; a bare scalar must be rejected, not dropped.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root — is a scene open?")
+		return
+	var result := _handler.apply_preset({
+		"parent_path": "/" + scene_root.name,
+		"name": "TestBadGravity",
+		"preset": "fire",
+		"overrides": {"gravity": 5},
+	})
+	assert_is_error(result, ErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "gravity")
+
+
+func test_apply_preset_draw_override_on_cpu_errors() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root — is a scene open?")
+		return
+	var result := _handler.apply_preset({
+		"parent_path": "/" + scene_root.name,
+		"name": "TestDrawOnCpu",
+		"preset": "fire",
+		"type": "cpu_3d",
+		"overrides": {"draw": {"blend_mode": "add"}},
+	})
+	assert_is_error(result, ErrorCodes.INVALID_PARAMS)
+	# The rejection must name the key and where draw overrides ARE supported.
+	assert_contains(result.error.message, "blend_mode")
+	assert_contains(result.error.message, "cpu_3d")
+	assert_contains(result.error.message, "gpu_3d")
+
+
+func test_apply_preset_user_main_override_not_on_type_errors() -> void:
+	# interp_to_end exists on GPU emitters only; as a USER override on cpu_3d
+	# it must error instead of silently skipping like blueprint keys do.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root — is a scene open?")
+		return
+	var result := _handler.apply_preset({
+		"parent_path": "/" + scene_root.name,
+		"name": "TestMainNotOnCpu",
+		"preset": "smoke",
+		"type": "cpu_3d",
+		"overrides": {"interp_to_end": 0.5},
+	})
+	assert_is_error(result, ErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "interp_to_end")
+
+
+func test_apply_preset_bare_unknown_override_errors() -> void:
+	# A typo'd bare key routes to the process group and must surface there.
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		skip("No scene root — is a scene open?")
+		return
+	var result := _handler.apply_preset({
+		"parent_path": "/" + scene_root.name,
+		"name": "TestTypoOverride",
+		"preset": "fire",
+		"overrides": {"amonut": 50},
+	})
+	assert_is_error(result, ErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.message, "amonut")


### PR DESCRIPTION
Fixes #770.

## Problem

`particle_manage(op="apply_preset")` could return success while user-requested overrides silently never landed:

- `particle_presets.gd::build` merged overrides with zero validation; bare keys not in the main-key list were dumped into `process`.
- The draw blueprint was consumed only for `gpu_3d` — on `gpu_2d`/`cpu_3d`/`cpu_2d`, every draw override was discarded.
- `particle_values.gd::build_draw_material` skipped unknown keys and swallowed failed coercions, unlike the main/process paths which return `INVALID_PARAMS`.
- The response reported `applied_main`/`applied_process` but nothing about draw.

This violates the repo's no-silent-filters principle: anomalies must surface, not be swallowed.

## Fix

**Track user overrides end-to-end.** `ParticlePresets.build` now also returns `user_keys` — the set of user-supplied override keys per group. Preset-blueprint keys may still skip silently on types they don't apply to (presets are cross-type by design); user-requested overrides must apply or error.

**Strict draw path.** `build_draw_material` returns a structured result: unknown keys and failed coercions become `INVALID_PARAMS` naming the key, exactly matching main/process behavior.

**gpu_2d draw.texture support; honest rejection elsewhere.** On `gpu_2d`, `draw.texture` loads the `Texture2D` onto the node (same validation as `set_draw_pass`, same single undo action). Any other draw key on `gpu_2d`, and all draw keys on `cpu_*`, are rejected with an error naming the key and where it IS supported (e.g. `draw.blend_mode is only supported for gpu_3d (got type 'cpu_3d')`). No cpu_* draw support was added.

**Truthful response.** `applied_draw` now sits alongside `applied_main`/`applied_process`. No `ignored_overrides` warnings channel was needed — after the changes above, every user-supplied skip case is a hard error.

**Docs.** `particle.py` documents the `overrides` structure (`{main, process, draw}`, bare-key routing), the draw support matrix, and that GPU gravity requires `{x, y, z}` (or `[x, y, z]`) including for gpu_2d.

Also: error paths now `free()` the not-yet-parented node instead of leaking it.

## ⚠️ Behavior change

Previously-ignored typos and inapplicable overrides now return `INVALID_PARAMS`. Callers that (accidentally) relied on silent dropping — e.g. passing `draw` overrides to `cpu_3d`, or misspelled bare keys — will start seeing errors. This ships strict directly, per the no-silent-filters rule; the errors name the offending key and the supported alternative, so recovery is one call away.

## Tests

New GDScript tests in `test_particle.gd` (apply_preset cluster):

- valid draw override on `gpu_3d` → applied and reported in `applied_draw`, values read back from the stored material
- `draw.texture` on `gpu_2d` → applied to `node.texture`; undo removes the node, redo restores it with the texture intact
- unknown draw key → `INVALID_PARAMS` naming the key
- gravity as scalar → `INVALID_PARAMS` (GPU gravity is Vector3)
- draw override on `cpu_3d` → actionable error naming the key, `cpu_3d`, and `gpu_3d`
- user `main` override not on the selected type (`interp_to_end` on `cpu_3d`) → `INVALID_PARAMS`
- bare-key typo (`amonut`) → `INVALID_PARAMS` naming it

## Verification

- `ruff check` / `ruff format` clean; `pytest tests/unit` green (2 pre-existing environmental failures also fail on clean `main` — they bind the real port 9500, held by the live dev server; follow-up task filed)
- Headless GDScript parse check clean (Godot 4.6.3)
- Live editor: particle suite 37/37; full GDScript suite 1906 passed / 0 failed across 63 suites (the 1 logged editor error is `test_runner`'s deliberate parse-error fixture)
- Live MCP smoke: `apply_preset` with a draw override reports `applied_draw`; bogus draw key errors through the full wire path; undo verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for GPU particle draw-material overrides, including 3D material properties and 2D textures.
  * Reports which draw overrides were successfully applied.
  * Improved particle preset override validation with clearer, type-specific errors.

* **Bug Fixes**
  * Prevents unsupported, unknown, or malformed overrides from being silently ignored.
  * Ensures particle draw changes work correctly with undo and redo.

* **Documentation**
  * Clarified particle configuration rules, gravity requirements, and supported override behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->