### PR TITLE
node_get_properties: return null editor-visible properties instead of dropping them

### DIFF
--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -1277,23 +1277,31 @@ func get_node_properties(params: Dictionary) -> Dictionary:
 
 	var properties: Array[Dictionary] = []
 	var editor_property_count := 0
+	var matched_fields := {}
 	for prop in node.get_property_list():
 		var usage: int = prop.get("usage", 0)
 		if not (usage & PROPERTY_USAGE_EDITOR):
 			continue
 		editor_property_count += 1
-		if use_field_filter and not field_filter.has(prop.name):
-			continue
-		# Safe read: custom script getters can error; skip bad properties
-		# rather than letting one bad read timeout the entire request.
-		var value = node.get(prop.name)
-		if value == null and prop.type != TYPE_NIL:
-			continue
+		if use_field_filter:
+			if not field_filter.has(prop.name):
+				continue
+			matched_fields[prop.name] = true
+		# Null reads are values, not omissions: `script` on an unscripted node
+		# and unset Resource slots (mesh, material, …) read back null and must
+		# appear as "value": null with their declared type, so callers can tell
+		# "Object-typed, currently unset" from "doesn't exist" (#771).
 		properties.append({
 			"name": prop.name,
 			"type": type_string(prop.type),
-			"value": _serialize_value(value),
+			"value": _serialize_value(node.get(prop.name)),
 		})
+	# Requested names that matched no editor-visible property — distinguishes
+	# "you asked for something that doesn't exist" from "exists and is null".
+	var unknown_fields: Array[String] = []
+	for f in field_filter:
+		if not matched_fields.has(f):
+			unknown_fields.append(f)
 	return {
 		"data": {
 			"path": node_path,
@@ -1302,7 +1310,11 @@ func get_node_properties(params: Dictionary) -> Dictionary:
 			"count": properties.size(),
 			# Total editor-visible properties before field filtering, so a
 			# caller that passed `fields` knows how many were withheld.
+			# Invariant: an unfiltered call returns every editor-visible
+			# property, so count == total_count; only the `fields` filter
+			# can make count < total_count.
 			"total_count": editor_property_count,
+			"unknown_fields": unknown_fields,
 		}
 	}
 

--- a/src/godot_ai/tools/node.py
+++ b/src/godot_ai/tools/node.py
@@ -66,7 +66,19 @@ def register_node_tools(mcp: FastMCP, *, include_non_core: bool = True) -> None:
         50-150 entries. Pass ``fields`` to return only the properties you
         need — a large response-size cut on this hot read. The response
         always carries ``total_count`` (all editor-visible properties)
-        alongside ``count`` (returned) so you can tell how much was withheld.
+        alongside ``count`` (returned): an unfiltered call returns the full
+        set, so ``count == total_count``; only the ``fields`` filter can
+        make ``count`` smaller. Requested names that match no
+        editor-visible property are listed in ``unknown_fields``, so a
+        nonexistent name is distinguishable from a property that exists
+        with a null value.
+
+        Null-valued properties are included: an unset object/resource slot
+        (``script`` on an unscripted node, an empty ``mesh`` or
+        ``material``, …) returns ``"value": null`` with its declared type.
+        An attached script serializes to its ``res://`` path; built-in
+        scripts (no resource path) fall back to their string
+        representation.
 
         Args:
             path: Scene path relative to the edited scene root (e.g.

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -11,6 +11,7 @@ var _handler: NodeHandler
 var _undo_redo: EditorUndoRedoManager
 
 const TEST_MATERIAL_PATH := "res://tests/_mcp_test_material.tres"
+const TEST_NODE_SCRIPT_PATH := "res://tests/_mcp_test_node_script.gd"
 
 
 func suite_name() -> String:
@@ -22,11 +23,20 @@ func suite_setup(ctx: Dictionary) -> void:
 	_handler = NodeHandler.new(_undo_redo)
 	var mat := StandardMaterial3D.new()
 	ResourceSaver.save(mat, TEST_MATERIAL_PATH)
+	# Fixture script for the attached-script serialization test.
+	var file := FileAccess.open(TEST_NODE_SCRIPT_PATH, FileAccess.WRITE)
+	if file:
+		file.store_string("extends Node3D\n")
+		file.close()
 
 
 func suite_teardown() -> void:
 	if FileAccess.file_exists(TEST_MATERIAL_PATH):
 		DirAccess.remove_absolute(TEST_MATERIAL_PATH)
+	if FileAccess.file_exists(TEST_NODE_SCRIPT_PATH):
+		DirAccess.remove_absolute(TEST_NODE_SCRIPT_PATH)
+	if FileAccess.file_exists(TEST_NODE_SCRIPT_PATH + ".uid"):
+		DirAccess.remove_absolute(TEST_NODE_SCRIPT_PATH + ".uid")
 
 
 # ----- get_children -----
@@ -99,13 +109,13 @@ func test_get_properties_has_value_and_type() -> void:
 func test_get_properties_reports_total_count() -> void:
 	var result := _handler.get_node_properties({"path": "/Main/Camera3D"})
 	assert_has_key(result.data, "total_count")
-	## total_count counts every editor-visible property; count is what was
-	## returned. Even unfiltered they can differ: a property whose getter
-	## returns null is skipped from the response but still counted in
-	## total_count. So the invariant is count <= total_count, not equality.
-	assert_true(
-		result.data.count <= result.data.total_count,
-		"count must not exceed total_count",
+	## An unfiltered call returns every editor-visible property — null-valued
+	## ones included (#771) — so count and total_count agree exactly. Only the
+	## `fields` filter can make count < total_count.
+	assert_eq(
+		result.data.count,
+		result.data.total_count,
+		"unfiltered call returns every editor-visible property",
 	)
 	assert_gt(result.data.total_count, 0, "Camera3D has editor-visible properties")
 
@@ -132,15 +142,73 @@ func test_get_properties_fields_filter_returns_only_requested() -> void:
 	assert_true(filtered.data.count < full.data.count, "fields cuts the response")
 
 
-func test_get_properties_fields_unknown_name_is_skipped() -> void:
+func test_get_properties_fields_unknown_name_is_reported() -> void:
+	## Unknown names are no longer silently skipped (#771): known fields come
+	## back (even null-valued ones like `script`), unknown ones are listed in
+	## unknown_fields so callers can tell "doesn't exist" from "is null".
 	var result := _handler.get_node_properties({
 		"path": "/Main/Camera3D",
-		"fields": ["fov", "totally_not_a_real_property"],
+		"fields": ["script", "no_such_prop"],
 	})
 	var names: Array[String] = []
 	for prop: Dictionary in result.data.properties:
 		names.append(prop.name)
-	assert_eq(names, ["fov"], "Unknown field names are silently skipped, known ones kept")
+	assert_eq(names, ["script"], "known field names are returned, unknown ones are not")
+	assert_has_key(result.data, "unknown_fields")
+	assert_eq(
+		result.data.unknown_fields,
+		["no_such_prop"],
+		"requested names matching no editor-visible property are reported",
+	)
+
+
+func test_get_properties_null_script_returned_as_null() -> void:
+	## Camera3D in the test scene has no script attached. `script` is
+	## editor-visible with a null value and must be returned as value: null
+	## with its declared type, not dropped from the response (#771).
+	var result := _handler.get_node_properties({
+		"path": "/Main/Camera3D",
+		"fields": ["script"],
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.count, 1, "script property should be returned")
+	var prop: Dictionary = result.data.properties[0]
+	assert_eq(prop.name, "script")
+	assert_eq(prop.value, null, "unscripted node reports script as null")
+	assert_eq(result.data.unknown_fields, [], "script is a real property, not unknown")
+
+
+func test_get_properties_attached_script_returns_res_path() -> void:
+	var created := _handler.create_node({
+		"type": "Node3D",
+		"name": "_McpScriptProbe",
+		"parent_path": "/Main",
+	})
+	assert_has_key(created, "data")
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var node: Node = scene_root.get_node_or_null(NodePath(String(created.data.name)))
+	assert_true(node != null, "created probe node should be resolvable")
+	var script: Script = load(TEST_NODE_SCRIPT_PATH)
+	assert_true(script != null, "fixture script should load")
+	node.set_script(script)
+
+	var result := _handler.get_node_properties({
+		"path": String(created.data.path),
+		"fields": ["script"],
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.count, 1, "script property should be returned")
+	assert_eq(result.data.properties[0].name, "script")
+	assert_eq(
+		result.data.properties[0].value,
+		TEST_NODE_SCRIPT_PATH,
+		"attached script serializes to its res:// path",
+	)
+
+	## Detach before undoing the create so the fixture script isn't referenced
+	## by the undo stack when suite_teardown deletes the file.
+	node.set_script(null)
+	assert_true(editor_undo(_undo_redo), "undo should remove the probe node")
 
 
 func test_get_properties_fields_non_array_is_rejected() -> void:

--- a/tests/unit/test_cli_reload.py
+++ b/tests/unit/test_cli_reload.py
@@ -188,8 +188,19 @@ def test_main_widens_http_bind_only_when_allow_host_set(monkeypatch):
     monkeypatch.setattr("godot_ai.server.create_server", lambda **kw: StubServer(app=None))
     monkeypatch.setattr(fastmcp.settings, "host", "127.0.0.1")
 
+    ## --ws-port keeps the preflight check off the default 9500, which a live
+    ## dev server on this machine may legitimately hold.
     godot_ai.main(
-        ["--transport", "streamable-http", "--port", "8123", "--allow-host", "192.168.1.0/24"]
+        [
+            "--transport",
+            "streamable-http",
+            "--port",
+            "8123",
+            "--ws-port",
+            "9555",
+            "--allow-host",
+            "192.168.1.0/24",
+        ]
     )
     assert fastmcp.settings.host == "0.0.0.0"
 
@@ -200,7 +211,7 @@ def test_main_does_not_widen_bind_without_allow_host(monkeypatch):
     monkeypatch.setattr("godot_ai.server.create_server", lambda **kw: StubServer(app=None))
     monkeypatch.setattr(fastmcp.settings, "host", "127.0.0.1")
 
-    godot_ai.main(["--transport", "streamable-http", "--port", "8123"])
+    godot_ai.main(["--transport", "streamable-http", "--port", "8123", "--ws-port", "9555"])
     assert fastmcp.settings.host == "127.0.0.1"
 
 


### PR DESCRIPTION
Fixes #771

## Problem

`get_node_properties` in `node_handler.gd` skipped any editor-visible property whose value read back `null` and whose declared type wasn't `TYPE_NIL`. That silently dropped `script` on an unscripted node and every unset Resource slot (`mesh`, `material`, `environment`, `attributes`, `compositor`, …). The dropped property still incremented `total_count`, and a caller had no way to distinguish "withheld by my `fields` filter" from "silently null-dropped". The Python tool docstring promised "every editor-visible property", which was false.

## Changes

- **Null values are returned, not dropped**: properties whose value is null now appear as `"value": null` with their declared type string (e.g. `"type": "Object"`), so callers can tell "Object-typed, currently unset" from "doesn't exist". Attached scripts continue to serialize to their `res://` path via the existing `variant_serializer.gd` Resource branch; built-in scripts (no `resource_path`) keep the existing `str()` fallback. No serializer changes were needed — `serialize(null)` already produces JSON null.
- **New `unknown_fields` response array**: requested `fields` names that match no editor-visible property are reported back, making "you asked for something that doesn't exist" distinguishable from "exists and is null".
- **`count`/`total_count` invariant documented**: with the null-skip gone, an unfiltered call satisfies `count == total_count`; only the `fields` filter can make `count` smaller. Both fields are kept for compatibility; the invariant is documented in the handler comment and the `node_get_properties` docstring.
- Out of scope by design: no `script_path`/`script_class` convenience metadata (the issue's optional suggestion) — this PR is the correctness fix only.
- Drive-by test robustness fix: the two CLI bind-widening tests in `tests/unit/test_cli_reload.py` now pass `--ws-port 9555` like the rest of the file, so a live dev server holding the default WS port 9500 no longer fails them.

## ⚠️ Response-shape change

`node_get_properties` (and its `godot://node/{path}/properties` resource form) now includes null-valued entries that previous versions omitted, and the response carries a new `unknown_fields` array. Clients that iterated `properties` assuming every entry has a non-null value should handle `null`. Unfiltered responses grow by the number of previously-dropped null properties (e.g. Camera3D: 25 → 29 entries).

## Tests

- `test_project/tests/test_node.gd`:
  - unscripted node + `fields=["script"]` returns `script` with `value: null` (new)
  - node with attached script returns its `res://` path (new)
  - `fields=["script", "no_such_prop"]` → `unknown_fields == ["no_such_prop"]` (rewritten from the old silent-skip test)
  - unfiltered call satisfies `count == total_count` (rewritten `test_get_properties_reports_total_count`, whose comment described the old lossy behavior)
- Full gauntlet: `ruff check` clean, Python `pytest` 1399 passed / 4 skipped, GDScript `test_run` 1901 passed / 0 failed / 7 version-gated skips across 63 suites, plus a live editor smoke over the MCP wire verifying `script: null`, `unknown_fields`, and `count == total_count` on Godot 4.6.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
