### PR TITLE
telemetry: report diagnostic-hint suppression on STARTUP records

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -40,6 +40,11 @@ A single `startup` record on server lifespan enter:
 - `server_version`
 - `ws_port`
 - `lifespan_start_ms` (time from lifespan begin to telemetry emit)
+- `diagnostic_hints_suppressed` — whether the client's default diagnostic
+  hint policy is `discard` (the `GODOT_AI_SUPPRESS_DIAGNOSTIC_HINTS`
+  escape hatch). Read from the constructed client, not the env var, so
+  the flag reflects actual behavior. A single boolean derived from a
+  config flag — no new identifying data.
 - `FIRST_STARTUP` milestone (one-shot, persisted to `milestones.json`)
 
 ### Connection events

--- a/src/godot_ai/server.py
+++ b/src/godot_ai/server.py
@@ -119,11 +119,12 @@ def _startup_record_data(
 ) -> dict[str, Any]:
     """Build the STARTUP telemetry payload (#761 follow-up).
 
-    ``diagnostic_hints_suppressed`` must read the constructed client's
-    hint policy, not re-read ``GODOT_AI_SUPPRESS_DIAGNOSTIC_HINTS`` —
-    the policy is resolved once at client construction (env default or
-    explicit override), so only the client value can never drift from
-    the behavior the process actually runs with.
+    ``diagnostic_hints_suppressed`` reads the hint policy off the
+    already-constructed client instead of re-reading
+    ``GODOT_AI_SUPPRESS_DIAGNOSTIC_HINTS``: the policy is resolved once
+    at client construction (env default or explicit override), so the
+    client's value is the behavior the process actually runs with — a
+    fresh env read could disagree with it.
     """
     return {
         "server_version": _SERVER_VERSION,

--- a/src/godot_ai/server.py
+++ b/src/godot_ai/server.py
@@ -114,6 +114,25 @@ class GodotAIFastMCP(FastMCP):
         return LocalhostOnlyHTTPMiddleware(app, getattr(self, "_allow_host_networks", None))
 
 
+def _startup_record_data(
+    client: GodotClient, ws_port: int, lifespan_start_ms: float
+) -> dict[str, Any]:
+    """Build the STARTUP telemetry payload (#761 follow-up).
+
+    ``diagnostic_hints_suppressed`` must read the constructed client's
+    hint policy, not re-read ``GODOT_AI_SUPPRESS_DIAGNOSTIC_HINTS`` —
+    the policy is resolved once at client construction (env default or
+    explicit override), so only the client value can never drift from
+    the behavior the process actually runs with.
+    """
+    return {
+        "server_version": _SERVER_VERSION,
+        "ws_port": ws_port,
+        "lifespan_start_ms": lifespan_start_ms,
+        "diagnostic_hints_suppressed": client.default_hint_policy == "discard",
+    }
+
+
 def create_server(
     ws_port: int = 9500,
     *,
@@ -197,11 +216,9 @@ def create_server(
             try:
                 record_telemetry(
                     RecordType.STARTUP,
-                    {
-                        "server_version": _SERVER_VERSION,
-                        "ws_port": ws_port,
-                        "lifespan_start_ms": (time.perf_counter() - start_clk) * 1000.0,
-                    },
+                    _startup_record_data(
+                        client, ws_port, (time.perf_counter() - start_clk) * 1000.0
+                    ),
                 )
                 record_milestone(MilestoneType.FIRST_STARTUP)
             except Exception:  # noqa: BLE001

--- a/tests/unit/test_cli_reload.py
+++ b/tests/unit/test_cli_reload.py
@@ -189,7 +189,16 @@ def test_main_widens_http_bind_only_when_allow_host_set(monkeypatch):
     monkeypatch.setattr(fastmcp.settings, "host", "127.0.0.1")
 
     godot_ai.main(
-        ["--transport", "streamable-http", "--port", "8123", "--allow-host", "192.168.1.0/24"]
+        [
+            "--transport",
+            "streamable-http",
+            "--port",
+            "8123",
+            "--ws-port",
+            "9555",
+            "--allow-host",
+            "192.168.1.0/24",
+        ]
     )
     assert fastmcp.settings.host == "0.0.0.0"
 
@@ -200,7 +209,10 @@ def test_main_does_not_widen_bind_without_allow_host(monkeypatch):
     monkeypatch.setattr("godot_ai.server.create_server", lambda **kw: StubServer(app=None))
     monkeypatch.setattr(fastmcp.settings, "host", "127.0.0.1")
 
-    godot_ai.main(["--transport", "streamable-http", "--port", "8123"])
+    ## --ws-port avoids the default-9500 preflight, which trips when a live
+    ## dev server is running on this machine (same reason as the other
+    ## main() tests above).
+    godot_ai.main(["--transport", "streamable-http", "--port", "8123", "--ws-port", "9555"])
     assert fastmcp.settings.host == "127.0.0.1"
 
 

--- a/tests/unit/test_startup_telemetry.py
+++ b/tests/unit/test_startup_telemetry.py
@@ -1,0 +1,73 @@
+"""STARTUP record contracts, incl. the diagnostic-hint escape-hatch flag (#761)."""
+
+from __future__ import annotations
+
+import pytest
+
+from godot_ai import __version__ as _SERVER_VERSION
+from godot_ai.godot_client.client import GodotClient
+from godot_ai.server import _startup_record_data
+
+
+def _client(monkeypatch, *, env_value: str | None = None, **kwargs) -> GodotClient:
+    if env_value is None:
+        monkeypatch.delenv("GODOT_AI_SUPPRESS_DIAGNOSTIC_HINTS", raising=False)
+    else:
+        monkeypatch.setenv("GODOT_AI_SUPPRESS_DIAGNOSTIC_HINTS", env_value)
+    return GodotClient(None, None, **kwargs)  # type: ignore[arg-type]
+
+
+def test_startup_record_defaults_to_hints_not_suppressed(monkeypatch) -> None:
+    client = _client(monkeypatch)
+
+    data = _startup_record_data(client, ws_port=9500, lifespan_start_ms=12.5)
+
+    assert data["diagnostic_hints_suppressed"] is False
+
+
+def test_startup_record_flags_suppression_from_env_constructed_client(monkeypatch) -> None:
+    client = _client(monkeypatch, env_value="true")
+
+    data = _startup_record_data(client, ws_port=9500, lifespan_start_ms=12.5)
+
+    assert data["diagnostic_hints_suppressed"] is True
+
+
+def test_startup_record_reads_client_policy_not_env(monkeypatch) -> None:
+    ## Drift-proofing contract: env says suppress, but the client was
+    ## constructed with an explicit override — the record must report
+    ## the client's live policy, not a fresh env read.
+    client = _client(monkeypatch, env_value="true", default_hint_policy="surface")
+
+    data = _startup_record_data(client, ws_port=9500, lifespan_start_ms=12.5)
+
+    assert data["diagnostic_hints_suppressed"] is False
+
+
+@pytest.mark.parametrize(
+    ("policy", "expected"),
+    [
+        ("surface", False),
+        ("retain", False),
+        ("discard", True),
+    ],
+)
+def test_startup_record_suppressed_only_for_discard_policy(monkeypatch, policy, expected) -> None:
+    client = _client(monkeypatch, default_hint_policy=policy)
+
+    data = _startup_record_data(client, ws_port=9500, lifespan_start_ms=12.5)
+
+    assert data["diagnostic_hints_suppressed"] is expected
+
+
+def test_startup_record_keeps_existing_fields(monkeypatch) -> None:
+    client = _client(monkeypatch)
+
+    data = _startup_record_data(client, ws_port=9501, lifespan_start_ms=7.25)
+
+    assert data == {
+        "server_version": _SERVER_VERSION,
+        "ws_port": 9501,
+        "lifespan_start_ms": 7.25,
+        "diagnostic_hints_suppressed": False,
+    }


### PR DESCRIPTION
## Summary

Adds `diagnostic_hints_suppressed: bool` to the existing STARTUP telemetry record — the extracted V4 follow-up from #761 (whose closing comment records this patch as "PR incoming"; this PR does **not** close any issue).

**Why:** PR #763 (v3.0.4) shipped the `GODOT_AI_SUPPRESS_DIAGNOSTIC_HINTS` escape hatch mapping the default hint policy to `discard`. Escape-hatch adoption is the one low-ambiguity early field signal for whether the softened hints are smooth enough — high adoption means they are not.

## Implementation

- The flag is derived from the constructed `GodotClient`'s live policy (`default_hint_policy == "discard"`), **not** a fresh env-var read at record-build time — so the reported value can never drift from the behavior the process actually constructed with (e.g. an explicit constructor override beating the env var).
- STARTUP payload construction is extracted into `_startup_record_data()` in `server.py` so tests exercise the real builder with a real client; `_emit_startup` in the lifespan now calls it. No other record types change.
- `docs/TELEMETRY.md` STARTUP field list updated.

**Privacy:** a single boolean derived from a config flag — no new identifying data leaves the process.

## Tests

New `tests/unit/test_startup_telemetry.py`:
- default construction → `diagnostic_hints_suppressed=False`
- client constructed under `GODOT_AI_SUPPRESS_DIAGNOSTIC_HINTS=true` → `True`
- drift-proofing contract: env says suppress but constructor override says `surface` → record reports `False` (proves the flag reads the client, not the env)
- `surface`/`retain`/`discard` parametrize — only `discard` reports suppressed
- exact-payload assertion locking the pre-existing STARTUP fields

Also verified the live lifespan wiring end-to-end in-process (real `create_server` + FastMCP client context, intercepted `record_telemetry`): emits `True` under the env var, `False` without.

**Drive-by fix:** `test_main_widens_http_bind_only_when_allow_host_set` and `test_main_does_not_widen_bind_without_allow_host` in `tests/unit/test_cli_reload.py` were missing the `--ws-port 9555` pattern the rest of the file uses, so they failed whenever a live dev server holds the default WS port 9500 (reproduced identically on `main`). They now pass alongside a running dev server.

No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
