### PR TITLE
docs: watermark counts events, not distinct errors; document headless MCP-write doorbell silence

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -128,12 +128,28 @@ it should finish the related writes and run `filesystem_manage(op="scan")`
 before debugging; otherwise it should inspect
 `logs_read(source="editor"|"game", include_details=true)`.
 
-The error count is of distinct new errors: a running game's script error
-reaches the server through both the game log buffer and the Errors tab, and
-those overlapping views are deduplicated rather than summed. Error and warning
-stamps are independent. Each stamp is delivered exactly once and consumed by
-that delivery — treat it as a doorbell, then read the logs; do not poll for it
-to repeat. It can appear on any tool's response, including `logs_read` itself.
+The count represents newly observed diagnostic entries after limited
+cross-source overlap handling. It is not a count of affected files or distinct
+logical error conditions. A single parse failure may contribute multiple
+root-error and derived-wrapper entries. Treat the value as a doorbell, not as
+a precise issue count, and inspect the diagnostics/logs for details. The
+overlap handling covers cross-source views of the same event: a running game's
+script error reaches the server through both the game log buffer and the
+Errors tab, and those overlapping views are deduplicated rather than summed.
+Error and warning stamps are independent. Each stamp is delivered exactly once
+and consumed by that delivery — do not poll for it to repeat. It can appear on
+any tool's response, including `logs_read` itself.
+
+Headless sessions: a parse failure in a `.gd` file written through MCP
+(`script_create`, `script_patch`, `filesystem_manage(op="write_text")`) is
+surfaced through the write response's `diagnostics` field and may never
+increment `new_errors_since_last_call` — even after a settled
+`filesystem_manage(op="scan")`. Per-write validation runs against a private
+capture buffer kept out of the shared editor log, and a scan does not reload
+an unchanged already-registered broken file, so no editor-origin parse event
+enters the ring. Headless agents and CI harnesses must inspect each write
+response's `diagnostics` — that is the contract-guaranteed channel for
+MCP-written code (#766).
 
 Set `GODOT_AI_SUPPRESS_DIAGNOSTIC_HINTS=true` (or `1`) before starting the
 server to consume these diagnostic stamps without adding their counts or hints
@@ -152,7 +168,10 @@ real parse diagnostics for the written file, `"fallback"` when validation failed
 but Logger details were unavailable, and `"none"`
 when no diagnostics were reported. Fallback diagnostics still prove the content
 failed validation, but their line number is a best-effort hint marked with
-`details.fallback_line`.
+`details.fallback_line`. In headless sessions this per-write `diagnostics`
+field is the reliable error channel for MCP-written code: the parse failure
+may never ring the `new_errors_since_last_call` doorbell (see "Headless
+sessions" above, #766).
 
 ## Domain rollups (`<domain>_manage`)
 

--- a/test_project/tests/test_script.gd
+++ b/test_project/tests/test_script.gd
@@ -5,6 +5,7 @@ const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
 
 const NodeHandler := preload("res://addons/godot_ai/handlers/node_handler.gd")
 const ScriptHandler := preload("res://addons/godot_ai/handlers/script_handler.gd")
+const FilesystemHandler := preload("res://addons/godot_ai/handlers/filesystem_handler.gd")
 const EditorLogger := preload("res://addons/godot_ai/runtime/editor_logger.gd")
 
 ## Tests for ScriptHandler — script creation, reading, attach/detach, and symbol inspection.
@@ -135,6 +136,73 @@ func test_create_script_validation_does_not_pollute_shared_editor_log() -> void:
 	assert_eq(result.data.diagnostics.size(), 1, "Invalid GDScript should report one diagnostic")
 	var captured := shared_buf.get_since(cursor)
 	assert_eq(captured.entries.size(), 0, "Validation load diagnostics must not leak into the shared editor log")
+	DirAccess.remove_absolute(path)
+
+
+func test_headless_mcp_write_parse_failure_does_not_ring_watermark() -> void:
+	## #766 contract pin: in headless MCP-only sessions, a broken .gd written
+	## via script_create surfaces its parse failure ONLY through the write
+	## response's `diagnostics` field — the diagnostic doorbell
+	## (`new_errors_since_last_call`) stays silent. Per-write validation runs
+	## against a private throwaway buffer, the shared EditorLogger drops
+	## addon-origin entries, and registration is efs.update_file() (no reload),
+	## so no editor-origin parse event reaches the watermark.
+	##
+	## The test runner is synchronous, so a real efs.scan() cannot settle
+	## in-test; the scan step below coalesces via the single-flight latch
+	## (same as test_filesystem.gd) and the settled scan's silence for an
+	## unchanged already-registered broken file was verified live in #766.
+	## If an engine or plugin change starts ringing the doorbell for these
+	## writes, this failing is the cue to update the "Headless sessions"
+	## paragraph in docs/TOOLS.md — a deliberate contract decision, not
+	## silent drift.
+	var shared_buf := McpEditorLogBuffer.new()
+	_attach_shared_editor_logger(shared_buf)
+	var empty_errors_tree := Tree.new()
+	track(empty_errors_tree)
+	empty_errors_tree.create_item()
+	var tracker := McpSurfacedErrorTracker.new(shared_buf, null, empty_errors_tree)
+	var before: Dictionary = tracker.watermark(true)
+
+	var path := "res://tests/_mcp_test_invalid_watermark.gd"
+	var content := "extends Node\n\nfunc _ready() -> void:\n\tif\n\tpass\n"
+	_expect_invalid_if_parse_errors()
+	var result := _handler.create_script({"path": path, "content": content})
+
+	# (a) The write response itself carries the error diagnostics — the
+	# contract-guaranteed channel for MCP-written code.
+	assert_has_key(result, "data")
+	assert_eq(result.data.committed, true)
+	assert_eq(result.data.diagnostics_scope, "this_file")
+	assert_gt(result.data.diagnostics.size(), 0, "Write response must carry the parse diagnostics")
+	assert_eq(result.data.diagnostics[0].level, "error")
+	assert_eq(result.data.diagnostics[0].path, path)
+	assert_contains(result.data.diagnostics[0].text, "Parse Error")
+
+	# The write registered the file with the resource pipeline (update_file),
+	# which is why a later scan treats it as known-and-unchanged and does not
+	# reload it.
+	var efs := EditorInterface.get_resource_filesystem()
+	assert_true(efs != null and efs.get_file_type(path) != "",
+		"Broken file must still be registered with the editor filesystem")
+
+	# (b) filesystem_manage(op="scan") — sync fallback with the single-flight
+	# latch pre-set so the call coalesces instead of kicking a real editor
+	# scan mid-suite (see test_filesystem.gd).
+	FilesystemHandler._scan_in_flight = true
+	var scan_result := FilesystemHandler.new().scan_filesystem({})
+	FilesystemHandler._scan_in_flight = false
+	assert_has_key(scan_result, "data")
+	assert_true(scan_result.data.was_already_scanning, "Latch set → coalesced, no new scan() kicked")
+
+	var after: Dictionary = tracker.watermark(true)
+	_detach_shared_editor_logger()
+	assert_eq(after.editor_ring, before.editor_ring,
+		"MCP-written parse failure must not append to the shared error ring")
+	assert_eq(after.editor_ring_warn, before.editor_ring_warn,
+		"MCP-written parse failure must not append to the shared warning ring")
+	assert_eq(after.debugger_promoted, before.debugger_promoted,
+		"No Debugger Errors-tab row may be promoted for an MCP-written parse failure")
 	DirAccess.remove_absolute(path)
 
 

--- a/test_project/tests/test_script.gd
+++ b/test_project/tests/test_script.gd
@@ -204,6 +204,12 @@ func test_headless_mcp_write_parse_failure_does_not_ring_watermark() -> void:
 	assert_eq(after.debugger_promoted, before.debugger_promoted,
 		"No Debugger Errors-tab row may be promoted for an MCP-written parse failure")
 	DirAccess.remove_absolute(path)
+	## Tell the editor filesystem the broken file is gone — this test asserted
+	## the path was registered, and leaving the record behind makes later scans
+	## re-emit its parse error into other suites' capture windows (same cleanup
+	## as test_filesystem.gd's parse-diagnostics test).
+	if efs != null:
+		efs.update_file(path)
 
 
 func _attach_shared_editor_logger(buffer: McpEditorLogBuffer) -> void:


### PR DESCRIPTION
Fixes #768
Fixes #766

Docs-only clarifications to the diagnostic-watermark contract in `docs/TOOLS.md`, plus one regression fixture pinning current behavior. **No behavior changes.**

## #768 — the watermark counts events, not distinct logical errors

The doorbell paragraph claimed "The error count is of distinct new errors". That overstates the dedup guarantee: cross-source overlap (game log vs Debugger Errors tab) is deduplicated, but `editor_ring` counts raw appended logger entries — one parse failure can contribute multiple root-error and derived-wrapper entries (the issue's repro: 1 broken file → `new_errors_since_last_call: 8`).

Replaced with the issue's proposed wording: the count is newly observed diagnostic entries after limited cross-source overlap handling; treat it as a doorbell, not a precise issue count. The existing overlap-dedup explanation, independent error/warning stamps, and exactly-once delivery text are all retained.

## #766 — headless MCP-written parse failures never ring the doorbell

Added a "Headless sessions" paragraph to the doorbell section: a parse failure in a `.gd` written via `script_create` / `script_patch` / `filesystem_manage(op="write_text")` is surfaced through the write response's `diagnostics` field and may never increment `new_errors_since_last_call` — even after a settled `filesystem_manage(op="scan")`. Per-write validation runs against a private capture buffer kept out of the shared editor log (`validation_logger.gd`, by design), the shared `EditorLogger` drops addon-origin entries, registration is `efs.update_file()` (no reload), and a settled scan does not reload an unchanged already-registered broken file. Headless agents and CI harnesses must inspect per-write `diagnostics` — the contract-guaranteed channel. Cross-referenced from the `script_create`/`script_patch` diagnostics section.

The follow-up enhancement floated in #766 (targeted post-scan revalidation of MCP-written known-broken paths) is intentionally **not** part of this PR.

## Regression fixture

`test_script.gd::test_headless_mcp_write_parse_failure_does_not_ring_watermark`, next to the existing validation-privacy test and using the same shared-logger harness plus `McpSurfacedErrorTracker` watermark components. It asserts:

- the broken write's response carries the error diagnostics (level, path, `Parse Error` text);
- the file is registered with the editor filesystem (the `update_file()` step that makes a later scan treat it as known-and-unchanged);
- after the `scan_filesystem` op (sync-fallback path, coalesced via the single-flight latch — the test runner is synchronous, so a real scan cannot settle in-test; the settled-scan silence was verified live in #766), the tracker's `editor_ring` / `editor_ring_warn` / `debugger_promoted` components have not incremented.

A comment links #766 so an engine/plugin change that starts ringing the doorbell for these writes surfaces as a deliberate contract decision, not silent drift.

## Test plan

- Full GDScript suite via MCP against a live editor on this branch's worktree: **1899 passed / 0 failed / 8 skipped** (63 suites); the new fixture passes with 13 assertions.
- `ruff check src/ tests/` clean. No Python files touched (`git diff main --stat`: `docs/TOOLS.md` + `test_project/tests/test_script.gd` only); Python unit tier green locally apart from two pre-existing environmental failures (`test_cli_reload` preflight-binds the live dev server's WS port — flagged separately, unrelated to this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
