### PR TITLE
Fix reversed 2D/3D screenshot source docs and guard against re-divergence

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -30,7 +30,7 @@ not the MCP tool names.
 | `project_run` | Play the project, then wait briefly for game liveness (autosave persists in-memory MCP edits unless `autosave=False`) |
 | `test_run` | Run GDScript test suites in the editor |
 | `logs_read` | Read plugin / game / editor / combined log buffers. `source="editor"` surfaces parse errors, GDScript reload warnings, @tool/EditorPlugin runtime errors, push_error/push_warning, and visible Debugger dock Errors-tab rows — use this when the editor's Output or Debugger Errors panel shows red/yellow rows |
-| `editor_screenshot` | Capture editor viewport, cinematic camera, or running game framebuffer |
+| `editor_screenshot` | Capture the editor 3D viewport (`viewport`), editor 2D viewport (`viewport_2d`), cinematic Camera3D render (`cinematic`), or running game framebuffer (`game`) |
 | `editor_reload_plugin` | Reload the plugin and wait for reconnect (works with external and plugin-managed servers) |
 | `animation_create` | Create an Animation clip (auto-creates AnimationPlayer + library if missing) |
 

--- a/docs/screenshot-testing.md
+++ b/docs/screenshot-testing.md
@@ -8,13 +8,19 @@ capture within 20s" timeouts.
 
 | Goal | `source` | Notes |
 |------|----------|-------|
-| Verify in-editor UI / inspector / dock layout | `viewport` | Captures the editor's 2D view directly — no debugger bridge, always works. |
-| Verify a 3D scene framing as the editor camera sees it | `viewport` | Same path, no game subprocess required. |
+| Verify a 3D scene framing as the editor camera sees it | `viewport` (the default) | Captures the editor's **3D** viewport — no debugger bridge, no game subprocess. Requires Node3D content in the edited scene; a 2D-only scene (or no scene open) returns `EDITOR_NOT_READY` with a hint. Supports `view_target` / `coverage` / `elevation` / `azimuth` / `fov` reframing. |
+| Verify a 2D scene as the editor shows it | `viewport_2d` | Captures the editor's **2D** viewport at its *current pan/zoom* — whatever is on screen in the 2D view. It has no framing parameters: `view_target`, `coverage`, `elevation`, `azimuth`, and `fov` are rejected with `INVALID_PARAMS`. |
 | Verify a running game's framebuffer (menus that exist at runtime, gameplay state, particle effects, runtime UI animations) | `game` | Requires the game subprocess + `_mcp_game_helper` autoload + a `project_run`-driven play cycle. |
-| Verify a specific `Camera3D` view without playing | `cinematic` (where supported) | Doesn't require Play. |
+| Verify a specific `Camera3D` view without playing | `cinematic` | Renders the edited scene through its active `Camera3D` (no editor gizmos). Prefers a camera marked `current`, else the first `Camera3D` found; `NODE_NOT_FOUND` if the scene has none. |
 
-**Default to `viewport` when in doubt.** `source="game"` is only the right
-answer when the thing you want to see only exists in the *running* game.
+No source captures the editor UI itself — docks, the Inspector, and panel
+layout are not screenshot-able through this tool. `viewport` and
+`viewport_2d` capture the scene *content* shown in the editor's 3D/2D
+views, not the surrounding editor chrome.
+
+**Default to `viewport` for 3D scenes and `viewport_2d` for 2D scenes.**
+`source="game"` is only the right answer when the thing you want to see
+only exists in the *running* game.
 
 ## Recipe: testing a runtime UI option (e.g. main menu)
 

--- a/docs/screenshot-testing.md
+++ b/docs/screenshot-testing.md
@@ -8,7 +8,7 @@ capture within 20s" timeouts.
 
 | Goal | `source` | Notes |
 |------|----------|-------|
-| Verify a 3D scene framing as the editor camera sees it | `viewport` (the default) | Captures the editor's **3D** viewport — no debugger bridge, no game subprocess. Requires Node3D content in the edited scene; a 2D-only scene (or no scene open) returns `EDITOR_NOT_READY` with a hint. Supports `view_target` / `coverage` / `elevation` / `azimuth` / `fov` reframing. |
+| Verify a 3D scene framing as the editor camera sees it | `viewport` (the default) | Captures the editor's **3D** viewport — no debugger bridge, no game subprocess. Requires Node3D content in the edited scene; a 2D-only scene (or no scene open) returns `EDITOR_NOT_READY` with a hint. Supports `view_target` reframing; `coverage` / `elevation` / `azimuth` / `fov` only take effect together with `view_target` (without it they are silently ignored). |
 | Verify a 2D scene as the editor shows it | `viewport_2d` | Captures the editor's **2D** viewport at its *current pan/zoom* — whatever is on screen in the 2D view. It has no framing parameters: `view_target`, `coverage`, `elevation`, `azimuth`, and `fov` are rejected with `INVALID_PARAMS`. |
 | Verify a running game's framebuffer (menus that exist at runtime, gameplay state, particle effects, runtime UI animations) | `game` | Requires the game subprocess + `_mcp_game_helper` autoload + a `project_run`-driven play cycle. |
 | Verify a specific `Camera3D` view without playing | `cinematic` | Renders the edited scene through its active `Camera3D` (no editor gizmos). Prefers a camera marked `current`, else the first `Camera3D` found; `NODE_NOT_FOUND` if the scene has none. |

--- a/tests/unit/test_docs_screenshot_sources.py
+++ b/tests/unit/test_docs_screenshot_sources.py
@@ -1,0 +1,75 @@
+"""Contract test: screenshot docs must only use real editor_screenshot sources.
+
+docs/screenshot-testing.md once described ``source="viewport"`` as the editor's
+2D view — it is the 3D viewport; the 2D view is ``source="viewport_2d"``
+(issue #773). This guard keeps the doc's source tokens aligned with the
+handler's accepted set so the two can't silently diverge again.
+
+The accepted set is parsed from the invalid-source error message in
+plugin/addons/godot_ai/handlers/editor_handler.gd — the one line the handler
+keeps in lockstep with its own ``match source:`` arms.
+"""
+
+from __future__ import annotations
+
+import functools
+import re
+from pathlib import Path
+
+from tests.unit._gdscript_text import get_func_block
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+EDITOR_HANDLER_GD = _REPO_ROOT / "plugin" / "addons" / "godot_ai" / "handlers" / "editor_handler.gd"
+SCREENSHOT_DOC = _REPO_ROOT / "docs" / "screenshot-testing.md"
+
+## Matches take_screenshot's rejection message (scoped to that function —
+## logs_read has its own "Invalid source" line with a different vocabulary):
+##   "Invalid source '%s' — use 'viewport', 'viewport_2d', 'cinematic', or 'game'"
+_INVALID_SOURCE_LINE_RE = re.compile(r"Invalid source '%s' — use ([^\"]+)")
+_QUOTED_TOKEN_RE = re.compile(r"'([a-z0-9_]+)'")
+
+## Matches source="viewport" / source='viewport' in prose and code fences.
+_DOC_SOURCE_TOKEN_RE = re.compile(r"""source\s*=\s*["']([^"']+)["']""")
+
+
+@functools.cache
+def _handler_sources() -> frozenset[str]:
+    text = EDITOR_HANDLER_GD.read_text(encoding="utf-8")
+    block = get_func_block(text, "func take_screenshot(params: Dictionary) -> Dictionary:")
+    match = _INVALID_SOURCE_LINE_RE.search(block)
+    assert match, (
+        f"Invalid-source error message not found in take_screenshot in {EDITOR_HANDLER_GD}; "
+        "if its wording changed, update _INVALID_SOURCE_LINE_RE."
+    )
+    return frozenset(_QUOTED_TOKEN_RE.findall(match.group(1)))
+
+
+def test_handler_sources_parsed_sanely() -> None:
+    # Guard the parser itself: an empty or shrunken set would let the doc
+    # assertions below pass (or fail) for the wrong reason.
+    assert _handler_sources() >= {"viewport", "viewport_2d", "cinematic", "game"}, (
+        f"Parsed handler sources {sorted(_handler_sources())} lost a known "
+        f"value; check {EDITOR_HANDLER_GD} and the regexes in this file."
+    )
+
+
+def test_doc_source_tokens_are_accepted_by_handler() -> None:
+    doc_tokens = _DOC_SOURCE_TOKEN_RE.findall(SCREENSHOT_DOC.read_text(encoding="utf-8"))
+    assert doc_tokens, f'No source="..." tokens found in {SCREENSHOT_DOC}; check the regex'
+    unknown = sorted(set(doc_tokens) - _handler_sources())
+    assert not unknown, (
+        f"{SCREENSHOT_DOC} references source values the editor_screenshot "
+        f"handler does not accept: {unknown}. Accepted: {sorted(_handler_sources())}."
+    )
+
+
+def test_every_handler_source_is_documented() -> None:
+    doc_text = SCREENSHOT_DOC.read_text(encoding="utf-8")
+    # \b keeps "viewport" from matching inside "viewport_2d" ("_" is a word char).
+    missing = sorted(
+        s for s in _handler_sources() if not re.search(rf"\b{re.escape(s)}\b", doc_text)
+    )
+    assert not missing, (
+        f"editor_screenshot sources missing from {SCREENSHOT_DOC}: {missing}. "
+        "Document each source in the 'Pick the right source' table."
+    )

--- a/tests/unit/test_docs_screenshot_sources.py
+++ b/tests/unit/test_docs_screenshot_sources.py
@@ -6,8 +6,9 @@ docs/screenshot-testing.md once described ``source="viewport"`` as the editor's
 handler's accepted set so the two can't silently diverge again.
 
 The accepted set is parsed from the invalid-source error message in
-plugin/addons/godot_ai/handlers/editor_handler.gd — the one line the handler
-keeps in lockstep with its own ``match source:`` arms.
+plugin/addons/godot_ai/handlers/editor_handler.gd, and a companion test pins
+that message to the actual ``match source:`` dispatch arms — so a new arm
+added without updating the message (or the docs) fails loudly here.
 """
 
 from __future__ import annotations
@@ -42,6 +43,29 @@ def _handler_sources() -> frozenset[str]:
         "if its wording changed, update _INVALID_SOURCE_LINE_RE."
     )
     return frozenset(_QUOTED_TOKEN_RE.findall(match.group(1)))
+
+
+@functools.cache
+def _dispatch_arm_sources() -> frozenset[str]:
+    text = EDITOR_HANDLER_GD.read_text(encoding="utf-8")
+    block = get_func_block(text, "func take_screenshot(params: Dictionary) -> Dictionary:")
+    section = re.search(r"match source:\n(.*?)^\t\t_:", block, re.MULTILINE | re.DOTALL)
+    assert section, (
+        f"`match source:` dispatch (with a `_:` default arm) not found in "
+        f"take_screenshot in {EDITOR_HANDLER_GD}; update this parser."
+    )
+    return frozenset(re.findall(r'^\t\t"([a-z0-9_]+)":\s*$', section.group(1), re.MULTILINE))
+
+
+def test_error_message_stays_in_sync_with_dispatch_arms() -> None:
+    # The doc assertions below key off the invalid-source error message; this
+    # pins that message to the actual `match source:` arms so a new arm added
+    # without updating the message can't silently escape the doc guard.
+    assert _dispatch_arm_sources() == _handler_sources(), (
+        f"take_screenshot's match arms {sorted(_dispatch_arm_sources())} and its "
+        f"invalid-source error message {sorted(_handler_sources())} disagree; "
+        "update the error message, then re-align docs/screenshot-testing.md."
+    )
 
 
 def test_handler_sources_parsed_sanely() -> None:


### PR DESCRIPTION
Fixes #773

`docs/screenshot-testing.md` described `source="viewport"` as capturing "the editor's 2D view". Ground truth from the tool schema (`src/godot_ai/tools/editor.py`) and the dispatch in `plugin/addons/godot_ai/handlers/editor_handler.gd::take_screenshot`:

| source | actually captures |
|---|---|
| `viewport` | editor **3D** viewport (errors with `EDITOR_NOT_READY` on 2D-only scenes) |
| `viewport_2d` | editor **2D** viewport, at the editor's current pan/zoom |
| `cinematic` | edited scene rendered through its active `Camera3D` |
| `game` | running game's framebuffer |

`viewport_2d` was never mentioned anywhere in the doc, and the "Verify in-editor UI / inspector / dock layout" row was doubly wrong — no source captures editor chrome at all.

## Changes

- **`docs/screenshot-testing.md`** — rewrote the "Pick the right source" table: `viewport` = 3D framing (with the no-Node3D error caveat and the `view_target`/`coverage`/angle params it supports), `viewport_2d` = 2D scenes with its pan/zoom limitation documented (framing params are rejected with `INVALID_PARAMS`, per `editor_handler.gd`), `cinematic` and `game` rows verified against the schema. Added an explicit note that no source captures the editor UI itself, and updated the "default to `viewport`" advice to route 2D scenes to `viewport_2d`.
- **`docs/TOOLS.md`** — the `editor_screenshot` row now names all four sources instead of an ambiguous "editor viewport".
- **`tests/unit/test_docs_screenshot_sources.py`** — consistency guard against silent re-divergence. It parses the accepted source set out of `take_screenshot`'s invalid-source error message (scoped to that function via the existing `_gdscript_text.get_func_block` helper, since `logs_read` has its own source vocabulary), then asserts (1) every `source="…"`/`source='…'` token in the doc is accepted by the handler and (2) every accepted source appears in the doc. Deliberately dumb and regex-based.

The rest of `docs/` + `README.md` were swept for `source=`/viewport mentions: the remaining hits are `logs_read` sources (`plugin`/`game`/`editor`/`all`), correct `source="game"` usage, or historical logs (friction-log, implementation-plan) — no other corrections needed.

## Testing

- `pytest tests/unit -q` — 1068 passed. (The two `test_cli_reload` port-preflight failures are environmental: they bind the real WS port 9500, which a live dev server from a concurrent session holds; same failure with or without this change.)
- `ruff check` / `ruff format --check` clean.
- No GDScript or Python source changed, so no live-editor smoke needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
