### PR TITLE
Fix opaque 8s timeout on editor_screenshot source=game for backgrounded games

### DIFF
--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -838,17 +838,27 @@ func _on_screenshot_response(data: Array) -> void:
 	if connection == null or not is_instance_valid(connection):
 		return
 
-	connection.send_deferred_response(request_id, {
-		"data": {
-			"source": "game",
-			"width": int(data[2]),
-			"height": int(data[3]),
-			"original_width": int(data[4]),
-			"original_height": int(data[5]),
-			"format": "png",
-			"image_base64": data[1],
-		}
-	})
+	var payload := {
+		"source": "game",
+		"width": int(data[2]),
+		"height": int(data[3]),
+		"original_width": int(data[4]),
+		"original_height": int(data[5]),
+		"format": "png",
+		"image_base64": data[1],
+	}
+	## #777: game helpers append frames_drawn + a stale flag so a capture
+	## taken while the game's main loop is frozen (backgrounded window) is
+	## honestly labeled instead of timing out. Older helpers send six fields
+	## — leave the keys absent rather than guessing.
+	if data.size() >= 8:
+		payload["frames_drawn"] = int(data[6])
+		payload["stale_frame"] = bool(data[7])
+		if bool(data[7]):
+			payload["note"] = ("The game window appears backgrounded or its main loop is "
+				+ "stalled; returning the last rendered frame. Focus the game window and "
+				+ "retry for a current frame.")
+	connection.send_deferred_response(request_id, {"data": payload})
 	if _log_buffer:
 		_log_buffer.log("[debug] <- mcp:screenshot_response (%s)" % request_id)
 
@@ -868,6 +878,14 @@ func _on_screenshot_error(data: Array) -> void:
 	_send_error(connection, request_id, ErrorCodes.INTERNAL_ERROR, message)
 
 
+## #777: the 8s reply timer fired — the screenshot request reached (or should
+## have reached) the game helper and no reply came back. Mirror the eval
+## timeout split (#518): a not-live game gets the attributed
+## _explain_not_live payload; a live game gets GAME_HELPER_TIMEOUT instead of
+## the former opaque INTERNAL_ERROR. With the game side's stalled-loop
+## stale-frame fallback, a live game only lands here when it has nothing
+## rendered to fall back on, its debugger servicing is itself wedged, or the
+## helper died mid-run.
 func _on_timeout(request_id: String) -> void:
 	var pending = _pending.get(request_id)
 	if pending == null:
@@ -877,10 +895,12 @@ func _on_timeout(request_id: String) -> void:
 	if connection == null or not is_instance_valid(connection):
 		return
 	var status := get_game_status(-1, GAME_READY_WAIT_SEC)
-	var err := ErrorCodes.make(ErrorCodes.INTERNAL_ERROR,
-		"Game screenshot timed out after reaching the game helper. The game may be busy or unable to render a frame. Check logs_read(source='game') and retry.")
+	var err: Dictionary
 	if status.get("status", "") != "live":
 		err = _explain_not_live(status, ErrorCodes.INTERNAL_ERROR)
+	else:
+		err = ErrorCodes.make(ErrorCodes.GAME_HELPER_TIMEOUT,
+			"The game process did not return a frame. The game window may be backgrounded or its main loop blocked — focus the game window and retry, or use game_command to confirm liveness.")
 	_send_error_response(connection, request_id, err)
 	if _log_buffer:
 		_log_buffer.log("[debug] !! screenshot timeout (%s)" % request_id)

--- a/plugin/addons/godot_ai/runtime/game_helper.gd
+++ b/plugin/addons/godot_ai/runtime/game_helper.gd
@@ -43,6 +43,16 @@ const FIRST_FRAME_WAIT_SEC := 6.0
 ## loop entirely, so any real threshold works; 1s keeps a merely-slow game
 ## (heavy frame, low FPS) on the fresh-frame await path.
 const MAIN_LOOP_STALL_MSEC := 1000
+## How long frames_drawn can stay flat before _handle_take_screenshot treats
+## rendering as suppressed and commits the synchronous stale-frame capture.
+## On Windows, minimizing the game window freezes frame presentation but NOT
+## the main loop — _process keeps ticking, so the MAIN_LOOP_STALL_MSEC beacon
+## never trips and every capture used to burn the full FIRST_FRAME_WAIT_SEC
+## await before replying stale (issue #794 smoke, item 1b). Larger than the
+## loop threshold so a heavy-but-rendering game (~1 FPS frame gaps) stays on
+## the fresh-frame await path; a sub-0.7 FPS game that trips this still gets
+## an honestly stale-flagged image immediately instead of a 6s wait.
+const RENDER_STALL_MSEC := 1500
 
 const GameLogger := preload("res://addons/godot_ai/runtime/game_logger.gd")
 const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
@@ -75,6 +85,13 @@ var _eval_token_counter: int = 0
 ## _handle_take_screenshot (running inside that capture) detects the freeze
 ## synchronously. -1 until the first tick.
 var _last_loop_tick_msec: int = -1
+## Rendering-freeze beacon for the Windows-minimize state (#794 smoke, 1b):
+## the frames_drawn value last observed in _process, and when it last
+## advanced. -1 until the first observed advance, so a booting or
+## render-less game (frames_drawn stuck at 0) can never read as
+## render-stalled and keeps the fresh-frame await path's error replies.
+var _last_frames_drawn_seen: int = -1
+var _last_frames_advance_msec: int = -1
 
 
 func _ready() -> void:
@@ -117,6 +134,13 @@ func _process(_delta: float) -> void:
 	## Recorded before the early returns below so the signal stays truthful
 	## even when the logger or debugger channel is unavailable.
 	_last_loop_tick_msec = Time.get_ticks_msec()
+	## Rendering beacon: on Windows a minimized game keeps ticking _process
+	## while presentation stops, so frames_drawn stagnation — not loop
+	## silence — is the observable freeze signal there (#794 smoke, 1b).
+	var frames_now := Engine.get_frames_drawn()
+	if frames_now != _last_frames_drawn_seen:
+		_last_frames_drawn_seen = frames_now
+		_last_frames_advance_msec = _last_loop_tick_msec
 	## Drain the logger queue on the main thread (Logger virtuals can fire
 	## from any thread; EngineDebugger.send_message is only safe from main).
 	## Send at most one FLUSH_BATCH_LIMIT-sized batch per frame so a runaway
@@ -187,7 +211,10 @@ func _handle_take_screenshot(data: Array) -> void:
 	## real image, flagged as such in the reply. Only fall through to the
 	## fresh-frame awaits when the loop is demonstrably alive.
 	if _should_capture_stale_sync(
-		_main_loop_appears_stalled(), tree.current_scene != null, Engine.get_frames_drawn()
+		_main_loop_appears_stalled(),
+		_rendering_appears_stalled(),
+		tree.current_scene != null,
+		Engine.get_frames_drawn()
 	):
 		_capture_and_reply(request_id, viewport, max_resolution, Engine.get_frames_drawn())
 		return
@@ -209,15 +236,16 @@ func _handle_take_screenshot(data: Array) -> void:
 
 
 ## #777: pure decision for the synchronous stale-frame path. Sync capture is
-## only worth committing when the main loop is stalled (an alive loop should
-## deliver a fresh frame instead) AND the viewport plausibly holds a real
-## frame: the main scene is in the tree and at least one frame was presented.
-## Without those, the stale readback would be the boot clear-color framebuffer
-## — worse than the honest timeout.
+## only worth committing when awaiting can't produce a fresh frame — the main
+## loop is frozen (macOS/suspend), or the loop still ticks but presentation
+## is suppressed (Windows minimize, #794 smoke 1b) — AND the viewport
+## plausibly holds a real frame: the main scene is in the tree and at least
+## one frame was presented. Without those, the stale readback would be the
+## boot clear-color framebuffer — worse than the honest timeout.
 static func _should_capture_stale_sync(
-	loop_stalled: bool, has_current_scene: bool, frames_drawn: int
+	loop_stalled: bool, render_stalled: bool, has_current_scene: bool, frames_drawn: int
 ) -> bool:
-	return loop_stalled and has_current_scene and frames_drawn > 0
+	return (loop_stalled or render_stalled) and has_current_scene and frames_drawn > 0
 
 
 ## #777: true when _process hasn't ticked within MAIN_LOOP_STALL_MSEC —
@@ -226,6 +254,18 @@ func _main_loop_appears_stalled() -> bool:
 	if _last_loop_tick_msec < 0:
 		return true
 	return Time.get_ticks_msec() - _last_loop_tick_msec > MAIN_LOOP_STALL_MSEC
+
+
+## True when frames_drawn has sat flat past RENDER_STALL_MSEC while _process
+## kept ticking — Windows minimize suppresses presentation without freezing
+## the loop, so the loop beacon alone misses it (#794 smoke, 1b). False until
+## the first observed frame advance: a game that has never presented has no
+## trustworthy frame to return, and must fall through to the await path's
+## texture/image error replies instead.
+func _rendering_appears_stalled() -> bool:
+	if _last_frames_advance_msec < 0:
+		return false
+	return Time.get_ticks_msec() - _last_frames_advance_msec > RENDER_STALL_MSEC
 
 
 ## Read back the viewport texture and reply — fully synchronous, so it is

--- a/plugin/addons/godot_ai/runtime/game_helper.gd
+++ b/plugin/addons/godot_ai/runtime/game_helper.gd
@@ -36,6 +36,13 @@ const FLUSH_BATCH_LIMIT := 200
 ## texture/image error replies before the editor gives up with its
 ## generic timeout.
 const FIRST_FRAME_WAIT_SEC := 6.0
+## #777: how long the main loop can go without ticking _process before
+## _handle_take_screenshot treats it as frozen and commits a synchronous
+## stale-frame capture instead of awaiting frames that will never come.
+## A backgrounded/minimized play-in-editor game stops iterating its main
+## loop entirely, so any real threshold works; 1s keeps a merely-slow game
+## (heavy frame, low FPS) on the fresh-frame await path.
+const MAIN_LOOP_STALL_MSEC := 1000
 
 const GameLogger := preload("res://addons/godot_ai/runtime/game_logger.gd")
 const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
@@ -63,6 +70,11 @@ var _pending_outbound: Array = []
 ## these to report a runtime error that aborted execute() before the reply.
 var _inflight_evals: Dictionary = {}
 var _eval_token_counter: int = 0
+## #777: last time _process ran, in ticks msec. The debugger message capture
+## stays live while a backgrounded game's main loop is frozen, so this is how
+## _handle_take_screenshot (running inside that capture) detects the freeze
+## synchronously. -1 until the first tick.
+var _last_loop_tick_msec: int = -1
 
 
 func _ready() -> void:
@@ -75,6 +87,11 @@ func _ready() -> void:
 	## to skip registration in the game and time out every capture.
 	if Engine.is_editor_hint():
 		return
+	## Keep ticking while the tree is paused: _process both ferries game logs
+	## and timestamps main-loop liveness for the stalled-loop screenshot
+	## fallback (#777). A paused game still iterates its loop and renders, and
+	## must not be misread as frozen.
+	process_mode = Node.PROCESS_MODE_ALWAYS
 	## register_message_capture is safe to call before the debugger
 	## handshake completes; the capture sits until a message arrives.
 	EngineDebugger.register_message_capture(CAPTURE_PREFIX, _on_debug_message)
@@ -96,6 +113,10 @@ func _ready() -> void:
 
 
 func _process(_delta: float) -> void:
+	## #777: liveness beacon for _handle_take_screenshot's stalled-loop check.
+	## Recorded before the early returns below so the signal stays truthful
+	## even when the logger or debugger channel is unavailable.
+	_last_loop_tick_msec = Time.get_ticks_msec()
 	## Drain the logger queue on the main thread (Logger virtuals can fire
 	## from any thread; EngineDebugger.send_message is only safe from main).
 	## Send at most one FLUSH_BATCH_LIMIT-sized batch per frame so a runaway
@@ -157,6 +178,20 @@ func _handle_take_screenshot(data: Array) -> void:
 		_reply_error(request_id, "No game root viewport available")
 		return
 
+	## #777: this function runs inside the debugger message capture, which
+	## stays live even when a backgrounded/minimized play-in-editor game has
+	## frozen its main loop. In that state awaiting `process_frame` parks
+	## this coroutine forever — no reply is ever sent, and the game side
+	## cannot self-timeout because timers need the same frozen loop. Commit a
+	## synchronous capture of the last rendered frame instead: stale, but a
+	## real image, flagged as such in the reply. Only fall through to the
+	## fresh-frame awaits when the loop is demonstrably alive.
+	if _should_capture_stale_sync(
+		_main_loop_appears_stalled(), tree.current_scene != null, Engine.get_frames_drawn()
+	):
+		_capture_and_reply(request_id, viewport, max_resolution, Engine.get_frames_drawn())
+		return
+
 	## Wait (bounded — see FIRST_FRAME_WAIT_SEC) until the main scene is in
 	## the tree and at least one frame has been drawn after this request, so
 	## the readback never precedes the first real present. Past the deadline,
@@ -170,6 +205,37 @@ func _handle_take_screenshot(data: Array) -> void:
 	while Engine.get_frames_drawn() <= frames_at_request and Time.get_ticks_msec() < deadline:
 		await tree.process_frame
 
+	_capture_and_reply(request_id, viewport, max_resolution, frames_at_request)
+
+
+## #777: pure decision for the synchronous stale-frame path. Sync capture is
+## only worth committing when the main loop is stalled (an alive loop should
+## deliver a fresh frame instead) AND the viewport plausibly holds a real
+## frame: the main scene is in the tree and at least one frame was presented.
+## Without those, the stale readback would be the boot clear-color framebuffer
+## — worse than the honest timeout.
+static func _should_capture_stale_sync(
+	loop_stalled: bool, has_current_scene: bool, frames_drawn: int
+) -> bool:
+	return loop_stalled and has_current_scene and frames_drawn > 0
+
+
+## #777: true when _process hasn't ticked within MAIN_LOOP_STALL_MSEC —
+## i.e. the main loop is frozen (backgrounded window) or has never run.
+func _main_loop_appears_stalled() -> bool:
+	if _last_loop_tick_msec < 0:
+		return true
+	return Time.get_ticks_msec() - _last_loop_tick_msec > MAIN_LOOP_STALL_MSEC
+
+
+## Read back the viewport texture and reply — fully synchronous, so it is
+## safe to call from the debugger capture while the main loop is frozen.
+## `frames_at_request` is Engine.get_frames_drawn() at request receipt: if no
+## further frame was drawn by capture time, the image predates the request
+## and the reply is flagged stale.
+func _capture_and_reply(
+	request_id: String, viewport: Viewport, max_resolution: int, frames_at_request: int
+) -> void:
 	var texture := viewport.get_texture()
 	if texture == null:
 		_reply_error(request_id, "Root viewport has no texture (headless?)")
@@ -181,19 +247,42 @@ func _handle_take_screenshot(data: Array) -> void:
 		return
 
 	var encoded: Dictionary = ScreenshotEncode.downscale_and_encode(image, max_resolution)
+	var frames_drawn := Engine.get_frames_drawn()
+	var stale := frames_drawn <= frames_at_request
 
-	EngineDebugger.send_message("mcp:screenshot_response", [
-		request_id,
-		encoded.base64,
-		encoded.width,
-		encoded.height,
-		encoded.original_width,
-		encoded.original_height,
-	])
+	_last_screenshot_reply = {
+		"kind": "response",
+		"request_id": request_id,
+		"frames_drawn": frames_drawn,
+		"stale": stale,
+		"width": encoded.width,
+		"height": encoded.height,
+	}
+	if EngineDebugger.is_active():
+		## Fields 7+8 are new in #777; older editors read the first six and
+		## ignore the rest.
+		EngineDebugger.send_message("mcp:screenshot_response", [
+			request_id,
+			encoded.base64,
+			encoded.width,
+			encoded.height,
+			encoded.original_width,
+			encoded.original_height,
+			frames_drawn,
+			stale,
+		])
+
+
+## Testing seam: the last screenshot reply (response or error), recorded
+## before hitting the EngineDebugger channel (inactive in the editor-side
+## test harness). Mirrors _last_eval_reply.
+var _last_screenshot_reply: Dictionary = {}
 
 
 func _reply_error(request_id: String, message: String) -> void:
-	EngineDebugger.send_message("mcp:screenshot_error", [request_id, message])
+	_last_screenshot_reply = {"kind": "error", "request_id": request_id, "message": message}
+	if EngineDebugger.is_active():
+		EngineDebugger.send_message("mcp:screenshot_error", [request_id, message])
 
 
 ## --- game_command: curated runtime inspection and input ---

--- a/plugin/addons/godot_ai/utils/error_codes.gd
+++ b/plugin/addons/godot_ai/utils/error_codes.gd
@@ -51,6 +51,16 @@ const EVAL_HUNG := "EVAL_HUNG"
 ## to the 10s backstop as a phantom "hang". Failing fast game-side with the
 ## real byte count makes the failure actionable (return a smaller slice).
 const EVAL_RESULT_TOO_LARGE := "EVAL_RESULT_TOO_LARGE"
+## #777: a game-side request (currently editor_screenshot source="game")
+## reached a live, registered game helper but no reply came back before the
+## editor-side timer fired. Every editor gate already passed
+## (is_playing_scene, helper hello) so this is a TOP-LEVEL code, not an
+## EDITOR_NOT_READY sub-code: the game process itself failed to respond —
+## backgrounded with a frozen main loop and nothing rendered to fall back
+## on, main thread blocked, or the helper died mid-run. Carved out of
+## INTERNAL_ERROR (the largest opaque timeout bucket fleet-wide) so the
+## residual timeout is attributable and actionable.
+const GAME_HELPER_TIMEOUT := "GAME_HELPER_TIMEOUT"
 ## audit-v2 #21 (issue #365): finer-grained codes carved out of the 471
 ## INVALID_PARAMS sites so agents can distinguish recoverable input
 ## errors from structural ones. INVALID_PARAMS stays for genuinely

--- a/src/godot_ai/handlers/editor.py
+++ b/src/godot_ai/handlers/editor.py
@@ -164,6 +164,12 @@ async def editor_screenshot(
         "aabb_size",
         "aabb_longest_ground_axis",
         "camera_path",
+        # #777: source="game" staleness metadata — a capture taken while the
+        # game's main loop was frozen (backgrounded window) returns the last
+        # rendered frame with stale_frame=true and an explanatory note.
+        "stale_frame",
+        "frames_drawn",
+        "note",
     ):
         if key in result:
             metadata[key] = result[key]

--- a/src/godot_ai/protocol/errors.py
+++ b/src/godot_ai/protocol/errors.py
@@ -36,6 +36,14 @@ class ErrorCode(StrEnum):
     # drops messages over ~8 MiB, which previously surfaced as a phantom 10s
     # "hang"). Keep in sync with utils/error_codes.gd.
     EVAL_RESULT_TOO_LARGE = "EVAL_RESULT_TOO_LARGE"
+    # #777: a game-side request (currently editor_screenshot source="game")
+    # reached a live game helper but no reply came back before the editor-side
+    # timer fired (backgrounded window with a frozen main loop and nothing
+    # rendered to fall back on, a blocked main thread, or a helper that died
+    # mid-run). Top-level code — the editor gates already passed, so this is
+    # not an EDITOR_NOT_READY sub-state. Keep in sync with
+    # utils/error_codes.gd.
+    GAME_HELPER_TIMEOUT = "GAME_HELPER_TIMEOUT"
     ## audit-v2 #21 (issue #365): finer-grained codes carved out of the
     ## 471 INVALID_PARAMS sites so agents can distinguish recoverable
     ## input errors from structural ones. INVALID_PARAMS stays for

--- a/src/godot_ai/tools/editor.py
+++ b/src/godot_ai/tools/editor.py
@@ -201,6 +201,13 @@ def register_editor_tools(mcp: FastMCP, *, include_non_core: bool = True) -> Non
           the first Camera3D found in a depth-first walk. NODE_NOT_FOUND only
           when the scene contains no Camera3D at all.
         - "game": running game's framebuffer (only when project is running).
+          A backgrounded/minimized game window freezes its main loop; the
+          capture then returns the last rendered frame with
+          ``stale_frame: true`` and a ``note`` in the metadata — focus the
+          game window and retry for a current frame. ``GAME_HELPER_TIMEOUT``
+          means the game process never replied at all (nothing rendered yet,
+          main thread blocked, or helper dead) — focus the window and retry,
+          or use game_command to confirm liveness.
 
         ``include_image=True`` (default) returns an MCP ImageContent block.
         ``view_target`` (comma-separated Node3D paths) reframes editor camera;

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -428,6 +428,119 @@ func test_debugger_plugin_clear_pending_disconnects_timer() -> void:
 	assert_false(timer.timeout.is_connected(cb), "_clear_pending should disconnect timeout signal")
 
 
+# ----- #777: game screenshot stale-frame plumbing + honest timeout -----
+
+## Records send_deferred_response payloads instead of touching a real socket.
+class _StubConnection:
+	extends McpConnection
+	var captured: Array = []
+
+	func send_deferred_response(request_id: String, payload: Dictionary) -> void:
+		captured.append({"request_id": request_id, "payload": payload})
+
+
+## Flip a bare plugin's flags so get_game_status() reports "live", the state
+## the timeout's GAME_HELPER_TIMEOUT branch requires.
+func _mark_game_live(plugin: McpDebuggerPlugin) -> void:
+	plugin._game_run_active = true
+	plugin._game_ready = true
+	plugin._ready_run_token = plugin._game_run_token
+
+
+func test_screenshot_response_plumbs_stale_metadata() -> void:
+	## #777: a frozen-main-loop capture arrives with frames_drawn + stale
+	## appended; the tool response must surface stale_frame, frames_drawn,
+	## and an explanatory note alongside the image.
+	var plugin := McpDebuggerPlugin.new()
+	var conn := _StubConnection.new()
+	var rid := "rid-stale-meta"
+	plugin._pending[rid] = {"connection": conn}
+	plugin._on_screenshot_response([rid, "aGk=", 320, 180, 640, 360, 42, true])
+	assert_false(plugin._pending.has(rid), "the response clears the pending entry")
+	assert_eq(conn.captured.size(), 1, "one deferred reply")
+	var data: Dictionary = conn.captured[0]["payload"]["data"]
+	assert_eq(data.get("stale_frame"), true, "the game's stale flag rides into the tool response")
+	assert_eq(int(data.get("frames_drawn", 0)), 42, "frames_drawn rides into the tool response")
+	assert_contains(str(data.get("note")), "backgrounded", "the note explains the stale frame")
+	assert_eq(data.get("image_base64"), "aGk=", "image payload is unchanged")
+	conn.free()
+
+
+func test_screenshot_response_fresh_frame_not_flagged() -> void:
+	var plugin := McpDebuggerPlugin.new()
+	var conn := _StubConnection.new()
+	var rid := "rid-fresh-meta"
+	plugin._pending[rid] = {"connection": conn}
+	plugin._on_screenshot_response([rid, "aGk=", 320, 180, 640, 360, 42, false])
+	var data: Dictionary = conn.captured[0]["payload"]["data"]
+	assert_eq(data.get("stale_frame"), false, "fresh captures carry an explicit false")
+	assert_false(data.has("note"), "no explanatory note on a fresh capture")
+	conn.free()
+
+
+func test_screenshot_response_legacy_payload_has_no_stale_keys() -> void:
+	## An older game helper (self-update window) sends six fields; the editor
+	## must not fabricate staleness metadata it wasn't given.
+	var plugin := McpDebuggerPlugin.new()
+	var conn := _StubConnection.new()
+	var rid := "rid-legacy-meta"
+	plugin._pending[rid] = {"connection": conn}
+	plugin._on_screenshot_response([rid, "aGk=", 320, 180, 640, 360])
+	var data: Dictionary = conn.captured[0]["payload"]["data"]
+	assert_false(data.has("stale_frame"), "six-field legacy payload carries no stale_frame")
+	assert_false(data.has("frames_drawn"), "six-field legacy payload carries no frames_drawn")
+	assert_eq(data.get("image_base64"), "aGk=", "legacy image payload still flows through")
+	conn.free()
+
+
+func test_screenshot_timeout_live_game_replies_game_helper_timeout() -> void:
+	## #777: the 8s reply timer on a live game replies GAME_HELPER_TIMEOUT
+	## with an actionable hint — never the opaque INTERNAL_ERROR that was
+	## the largest opaque failure bucket fleet-wide.
+	var plugin := McpDebuggerPlugin.new()
+	_mark_game_live(plugin)
+	var conn := _StubConnection.new()
+	var rid := "rid-shot-timeout-live"
+	plugin._pending[rid] = {"connection": conn}
+	plugin._on_timeout(rid)
+	assert_false(plugin._pending.has(rid), "the timeout clears the pending entry")
+	assert_eq(conn.captured.size(), 1, "one deferred reply")
+	var payload: Dictionary = conn.captured[0]["payload"]
+	assert_has_key(payload, "error")
+	assert_eq(payload["error"]["code"], ErrorCodes.GAME_HELPER_TIMEOUT,
+		"a live-game screenshot timeout replies GAME_HELPER_TIMEOUT")
+	assert_contains(payload["error"]["message"], "focus the game window",
+		"the message names the recovery action")
+	assert_contains(payload["error"]["message"], "game_command",
+		"the message names the liveness-check tool")
+	conn.free()
+
+
+func test_screenshot_timeout_not_live_keeps_attributed_shape() -> void:
+	## A game that is no longer live rides the existing _explain_not_live
+	## path (INTERNAL_ERROR top-level with the attributed game_status data),
+	## not the new GAME_HELPER_TIMEOUT.
+	var plugin := McpDebuggerPlugin.new()
+	var conn := _StubConnection.new()
+	var rid := "rid-shot-timeout-dead"
+	plugin._pending[rid] = {"connection": conn}
+	plugin._on_timeout(rid)
+	assert_eq(conn.captured.size(), 1, "one deferred reply")
+	var payload: Dictionary = conn.captured[0]["payload"]
+	assert_eq(payload["error"]["code"], ErrorCodes.INTERNAL_ERROR,
+		"the not-live path keeps the existing attributed shape")
+	assert_has_key(payload["error"], "data")
+	assert_has_key(payload["error"]["data"], "game_status",
+		"the not-live payload attributes the game state")
+	conn.free()
+
+
+func test_screenshot_timeout_unknown_request_no_crash() -> void:
+	var plugin := McpDebuggerPlugin.new()
+	plugin._on_timeout("unknown-id")
+	assert_true(true, "a timeout for an already-resolved request is a no-op")
+
+
 func test_screenshot_view_target_not_found() -> void:
 	var result := _handler.take_screenshot({"source": "viewport", "view_target": "/Main/NonExistent"})
 	assert_is_error(result, ErrorCodes.NODE_NOT_FOUND)

--- a/test_project/tests/test_game_helper.gd
+++ b/test_project/tests/test_game_helper.gd
@@ -248,16 +248,19 @@ func test_input_mouse_position_partial_dict_uses_number() -> void:
 
 # ----- #777: stalled-main-loop synchronous screenshot fallback -----
 
-func test_should_capture_stale_sync_requires_all_three_conditions() -> void:
-	## The sync stale capture only commits when awaiting would park forever
-	## (stalled loop) AND the viewport plausibly holds a real frame.
-	assert_true(GameHelper._should_capture_stale_sync(true, true, 5),
+func test_should_capture_stale_sync_requires_stall_plus_real_frame() -> void:
+	## The sync stale capture only commits when awaiting can't produce a fresh
+	## frame (frozen loop OR suppressed rendering) AND the viewport plausibly
+	## holds a real frame.
+	assert_true(GameHelper._should_capture_stale_sync(true, false, true, 5),
 		"stalled loop + scene in tree + drawn frames commits the sync capture")
-	assert_false(GameHelper._should_capture_stale_sync(false, true, 5),
-		"an alive loop must take the fresh-frame await path")
-	assert_false(GameHelper._should_capture_stale_sync(true, false, 5),
+	assert_true(GameHelper._should_capture_stale_sync(false, true, true, 5),
+		"stalled rendering with an alive loop (Windows minimize) also commits it")
+	assert_false(GameHelper._should_capture_stale_sync(false, false, true, 5),
+		"an alive, presenting game must take the fresh-frame await path")
+	assert_false(GameHelper._should_capture_stale_sync(true, true, false, 5),
 		"no current_scene (booting / custom main loop) has no trustworthy frame")
-	assert_false(GameHelper._should_capture_stale_sync(true, true, 0),
+	assert_false(GameHelper._should_capture_stale_sync(true, true, true, 0),
 		"zero frames drawn means the texture is the boot clear color, not a frame")
 
 
@@ -276,6 +279,50 @@ func test_main_loop_appears_stalled_uses_threshold() -> void:
 	helper._last_loop_tick_msec = Time.get_ticks_msec() - (GameHelper.MAIN_LOOP_STALL_MSEC + 500)
 	assert_true(helper._main_loop_appears_stalled(),
 		"a loop silent past MAIN_LOOP_STALL_MSEC reads as stalled")
+	helper.free()
+
+
+func test_rendering_appears_stalled_false_before_first_advance() -> void:
+	## A game that has never presented (booting, render-less) has no
+	## trustworthy frame — the -1 sentinel must read as NOT render-stalled so
+	## the await path's texture/image error replies stay in charge.
+	var helper: Node = GameHelper.new()
+	assert_false(helper._rendering_appears_stalled(),
+		"no observed frame advance yet must not read as render-stalled")
+	helper.free()
+
+
+func test_rendering_appears_stalled_uses_threshold() -> void:
+	## Windows minimize freezes presentation but not _process (#794 smoke,
+	## 1b): frames_drawn stagnation past RENDER_STALL_MSEC is the freeze
+	## signal there, independent of the loop beacon.
+	var helper: Node = GameHelper.new()
+	helper._last_frames_advance_msec = Time.get_ticks_msec()
+	assert_false(helper._rendering_appears_stalled(),
+		"a recent frame advance reads as rendering alive")
+	helper._last_frames_advance_msec = (
+		Time.get_ticks_msec() - (GameHelper.RENDER_STALL_MSEC + 500)
+	)
+	assert_true(helper._rendering_appears_stalled(),
+		"frames_drawn flat past RENDER_STALL_MSEC reads as render-stalled")
+	helper.free()
+
+
+func test_process_records_frame_advance_beacon() -> void:
+	## _process must update the rendering beacon only when frames_drawn
+	## actually moves, so stagnation ages honestly between presents.
+	var helper: Node = GameHelper.new()
+	helper._last_frames_drawn_seen = Engine.get_frames_drawn() - 1
+	helper._process(0.016)
+	assert_eq(helper._last_frames_drawn_seen, Engine.get_frames_drawn(),
+		"an observed frames_drawn change must be recorded")
+	assert_eq(helper._last_frames_advance_msec, helper._last_loop_tick_msec,
+		"the advance timestamp must match the tick that observed it")
+	var stamped: int = helper._last_frames_advance_msec - 5000
+	helper._last_frames_advance_msec = stamped
+	helper._process(0.016)
+	assert_eq(helper._last_frames_advance_msec, stamped,
+		"no frames_drawn change must leave the advance timestamp untouched")
 	helper.free()
 
 

--- a/test_project/tests/test_game_helper.gd
+++ b/test_project/tests/test_game_helper.gd
@@ -244,3 +244,85 @@ func test_input_mouse_position_partial_dict_uses_number() -> void:
 	var r: Dictionary = _helper.call("_resolve_mouse_position", {"x": 7})
 	assert_false(r.has("error"), "partial numeric dict must not error")
 	assert_eq(r.position.x, 7.0)
+
+
+# ----- #777: stalled-main-loop synchronous screenshot fallback -----
+
+func test_should_capture_stale_sync_requires_all_three_conditions() -> void:
+	## The sync stale capture only commits when awaiting would park forever
+	## (stalled loop) AND the viewport plausibly holds a real frame.
+	assert_true(GameHelper._should_capture_stale_sync(true, true, 5),
+		"stalled loop + scene in tree + drawn frames commits the sync capture")
+	assert_false(GameHelper._should_capture_stale_sync(false, true, 5),
+		"an alive loop must take the fresh-frame await path")
+	assert_false(GameHelper._should_capture_stale_sync(true, false, 5),
+		"no current_scene (booting / custom main loop) has no trustworthy frame")
+	assert_false(GameHelper._should_capture_stale_sync(true, true, 0),
+		"zero frames drawn means the texture is the boot clear color, not a frame")
+
+
+func test_main_loop_appears_stalled_before_first_tick() -> void:
+	var helper: Node = GameHelper.new()
+	assert_true(helper._main_loop_appears_stalled(),
+		"the -1 sentinel (no _process tick yet) reads as stalled")
+	helper.free()
+
+
+func test_main_loop_appears_stalled_uses_threshold() -> void:
+	var helper: Node = GameHelper.new()
+	helper._last_loop_tick_msec = Time.get_ticks_msec()
+	assert_false(helper._main_loop_appears_stalled(),
+		"a just-ticked loop is alive")
+	helper._last_loop_tick_msec = Time.get_ticks_msec() - (GameHelper.MAIN_LOOP_STALL_MSEC + 500)
+	assert_true(helper._main_loop_appears_stalled(),
+		"a loop silent past MAIN_LOOP_STALL_MSEC reads as stalled")
+	helper.free()
+
+
+func test_capture_and_reply_flags_stale_when_no_new_frame() -> void:
+	## frames_at_request == current frames_drawn is exactly the frozen-loop
+	## case: nothing can render between receipt and this synchronous capture,
+	## so the reply must carry stale=true plus the frames_drawn diagnostic.
+	## The editor 3D viewport stands in for the game root viewport.
+	var viewport := EditorInterface.get_editor_viewport_3d()
+	if viewport == null:
+		skip("No editor 3D viewport available")
+		return
+	var helper: Node = GameHelper.new()
+	helper._capture_and_reply("rid-stale", viewport, 64, Engine.get_frames_drawn())
+	var reply: Dictionary = helper._last_screenshot_reply
+	helper.free()
+	if str(reply.get("kind")) == "error":
+		skip("Viewport readback unavailable in this environment: %s" % str(reply.get("message")))
+		return
+	assert_eq(reply.get("request_id"), "rid-stale")
+	assert_true(bool(reply.get("stale")), "no frame drawn after receipt -> stale flag set")
+	assert_gt(int(reply.get("frames_drawn")), 0, "frames_drawn rides with the reply")
+
+
+func test_capture_and_reply_fresh_when_frame_advanced() -> void:
+	## frames_at_request one below the current count models the await path
+	## having seen a fresh present: the reply must NOT be flagged stale.
+	var viewport := EditorInterface.get_editor_viewport_3d()
+	if viewport == null:
+		skip("No editor 3D viewport available")
+		return
+	var helper: Node = GameHelper.new()
+	helper._capture_and_reply("rid-fresh", viewport, 64, Engine.get_frames_drawn() - 1)
+	var reply: Dictionary = helper._last_screenshot_reply
+	helper.free()
+	if str(reply.get("kind")) == "error":
+		skip("Viewport readback unavailable in this environment: %s" % str(reply.get("message")))
+		return
+	assert_false(bool(reply.get("stale")), "a frame drawn after receipt -> not stale")
+
+
+func test_screenshot_reply_error_records_seam() -> void:
+	## The error paths stay synchronous and record through the same testing
+	## seam (EngineDebugger is inactive in the editor harness).
+	var helper: Node = GameHelper.new()
+	helper._reply_error("rid-err", "No game root viewport available")
+	assert_eq(helper._last_screenshot_reply.get("kind"), "error")
+	assert_eq(helper._last_screenshot_reply.get("request_id"), "rid-err")
+	assert_contains(str(helper._last_screenshot_reply.get("message")), "No game root viewport")
+	helper.free()

--- a/tests/unit/test_game_screenshot_timeout_contract.py
+++ b/tests/unit/test_game_screenshot_timeout_contract.py
@@ -1,0 +1,112 @@
+"""Source-level contract for the #777 game-screenshot timeout split.
+
+``editor_screenshot(source="game")`` was the largest opaque failure bucket
+fleet-wide: a backgrounded play-in-editor game freezes its main loop, the
+game-side capture coroutine parks on ``await tree.process_frame``, no reply is
+ever sent, and the editor's 8s timer surfaced a bare INTERNAL_ERROR. The fix
+has two halves, both GDScript-side and neither reachable from the live
+GDScript test runner end-to-end (the harness editor has no frozen game
+subprocess), so this file locks the load-bearing source shapes the same way
+``test_editor_not_ready_hint_contract.py`` does for the no-scene branch:
+
+1. ``runtime/game_helper.gd`` commits a synchronous stale-frame capture when
+   the main loop is stalled, instead of awaiting frames that will never come.
+2. ``debugger/mcp_debugger_plugin.gd::_on_timeout`` mirrors the eval split
+   (#518): not-live keeps the attributed ``_explain_not_live`` payload; a
+   live-but-unresponsive game gets the new top-level GAME_HELPER_TIMEOUT with
+   an actionable hint.
+
+The GAME_HELPER_TIMEOUT GDScript/Python parity itself is enforced by
+``test_error_code_parity.py``; behavior of the decision helpers is covered by
+the GDScript suites (``test_game_helper.gd``, ``test_editor.gd``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from godot_ai.protocol.errors import ErrorCode
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[2] / "plugin" / "addons" / "godot_ai"
+
+
+def _debugger_plugin_source() -> str:
+    return (PLUGIN_ROOT / "debugger" / "mcp_debugger_plugin.gd").read_text(encoding="utf-8")
+
+
+def _game_helper_source() -> str:
+    return (PLUGIN_ROOT / "runtime" / "game_helper.gd").read_text(encoding="utf-8")
+
+
+def test_game_helper_timeout_is_a_python_error_code() -> None:
+    # Belt to the parity test's suspenders: the code agents/telemetry will
+    # match on must exist under the exact expected name.
+    assert ErrorCode.GAME_HELPER_TIMEOUT == "GAME_HELPER_TIMEOUT"
+
+
+def test_screenshot_timeout_live_branch_uses_game_helper_timeout() -> None:
+    source = _debugger_plugin_source()
+    marker = "func _on_timeout("
+    assert marker in source
+    body = source[source.index(marker) : source.index(marker) + 1400]
+    # Not-live keeps the attributed explanation; the live residual gets the
+    # honest top-level code instead of bare INTERNAL_ERROR.
+    assert "_explain_not_live" in body
+    assert "ErrorCodes.GAME_HELPER_TIMEOUT" in body, (
+        "_on_timeout's live branch must reply GAME_HELPER_TIMEOUT, not INTERNAL_ERROR"
+    )
+    # The hint must name concrete recovery actions so the LLM doesn't guess.
+    assert "focus the game window" in body
+    assert "game_command" in body
+
+
+def test_game_helper_screenshot_has_synchronous_stale_fallback() -> None:
+    source = _game_helper_source()
+    marker = "func _handle_take_screenshot("
+    assert marker in source
+    body = source[source.index(marker) : source.index(marker) + 2400]
+    # The stalled-loop decision must run BEFORE any await: a frozen main loop
+    # never fires process_frame, so an await-first structure can never reply.
+    sync_gate = body.index("_should_capture_stale_sync")
+    first_await = body.index("await tree.process_frame")
+    assert sync_gate < first_await, (
+        "the synchronous stale-capture gate must precede the first frame await, "
+        "or a frozen main loop parks the coroutine and the request times out"
+    )
+
+
+def test_game_helper_reply_carries_staleness_fields() -> None:
+    source = _game_helper_source()
+    marker = "func _capture_and_reply("
+    assert marker in source
+    body = source[source.index(marker) : source.index(marker) + 1800]
+    assert '"mcp:screenshot_response"' in body
+    # Fields 7+8 of the payload: frames_drawn + stale. Older editors read the
+    # first six and ignore the rest.
+    assert "frames_drawn," in body
+    assert "stale," in body
+
+
+def test_debugger_plugin_surfaces_stale_frame_metadata() -> None:
+    source = _debugger_plugin_source()
+    marker = "func _on_screenshot_response("
+    assert marker in source
+    body = source[source.index(marker) : source.index(marker) + 1800]
+    assert '"stale_frame"' in body
+    assert '"frames_drawn"' in body
+    # The stale note must explain the state and the recovery.
+    assert "backgrounded" in body
+
+
+def test_timeout_constants_unchanged() -> None:
+    """#777 is a structural fix — the ladder (game 6s first-frame wait <
+    editor 8s reply timer < server 35s budget) must not move as a side
+    effect. Telemetry keys on the ~8s cluster to verify the fix lands."""
+    helper = _game_helper_source()
+    plugin = _debugger_plugin_source()
+    editor_py = (
+        Path(__file__).resolve().parents[2] / "src" / "godot_ai" / "handlers" / "editor.py"
+    ).read_text(encoding="utf-8")
+    assert "const FIRST_FRAME_WAIT_SEC := 6.0" in helper
+    assert "const DEFAULT_TIMEOUT_SEC := 8.0" in plugin
+    assert "GAME_SCREENSHOT_TIMEOUT_SEC = 35.0" in editor_py

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -873,6 +873,13 @@ class StubClient:
                 result["fov"] = params["fov"]
             if params.get("source") == "cinematic":
                 result["camera_path"] = "/Main/Camera3D"
+            # #777: game-source captures taken while the game's main loop is
+            # frozen (backgrounded window) return the last rendered frame
+            # flagged stale plus an explanatory note.
+            if params.get("source") == "game":
+                result["stale_frame"] = True
+                result["frames_drawn"] = 42
+                result["note"] = "The game window appears backgrounded; returning last frame."
             return result
         if command == "clear_logs":
             return {"cleared_count": 5}
@@ -3933,6 +3940,31 @@ async def test_editor_screenshot_handler_passes_source():
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)
     await editor_handlers.editor_screenshot(runtime, source="game", include_image=False)
     assert client.calls[-1]["params"]["source"] == "game"
+
+
+async def test_editor_screenshot_game_stale_metadata_passthrough():
+    """#777: a frozen-main-loop game capture returns the last rendered frame
+    flagged stale; the handler must surface stale_frame/frames_drawn/note in
+    the metadata instead of dropping them."""
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await editor_handlers.editor_screenshot(runtime, source="game", include_image=False)
+    assert result["stale_frame"] is True
+    assert result["frames_drawn"] == 42
+    assert "backgrounded" in result["note"]
+
+
+async def test_editor_screenshot_viewport_has_no_stale_metadata():
+    """Staleness keys are game-source only; viewport captures must not grow
+    them from the passthrough list."""
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await editor_handlers.editor_screenshot(
+        runtime, source="viewport", include_image=False
+    )
+    assert "stale_frame" not in result
+    assert "frames_drawn" not in result
+    assert "note" not in result
 
 
 async def test_editor_screenshot_timeout_exceeds_plugin_deferred_timeout():


### PR DESCRIPTION
Fixes #777 — the largest opaque failure bucket fleet-wide (7d: 2,561 events, 760 installs, ~83% clustered at ~8.0s).

## Root cause

A backgrounded/minimized play-in-editor game freezes its main loop. The game helper receives `mcp:take_screenshot` fine (the debugger message capture stays live), but `_handle_take_screenshot` then awaits `process_frame` twice — with a frozen loop the coroutine parks forever, no reply is sent, the game side *cannot* self-timeout (timers need the same loop), and the editor's 8s reply timer fires an opaque `INTERNAL_ERROR`. This bites fully-booted, healthy games.

## Fix (structural — no timing constants changed)

1. **Stale-frame capture** (`runtime/game_helper.gd`): the helper stamps a liveness beacon in `_process`; when the beacon is stale (>1s) and a real frame exists (`current_scene != null`, `frames_drawn > 0`), the capture commits a **synchronous** readback of the viewport texture — the last rendered frame, stale but valid — with no awaits, so a parked coroutine can never again mean no-reply. The fresh-frame await path is unchanged and still used whenever the loop is demonstrably alive. The reply payload appends `frames_drawn` + a `stale` flag (older editors read the first six fields and ignore the rest). The helper now runs `PROCESS_MODE_ALWAYS` so a paused (still-rendering) tree isn't misread as frozen.
2. **Honest metadata** (`debugger/mcp_debugger_plugin.gd`, `handlers/editor.py`): stale captures surface `stale_frame: true`, `frames_drawn`, and a note ("game window appears backgrounded … returning the last rendered frame") in the tool response.
3. **Honest residual timeout** (`_on_timeout`): mirrors the eval split from #518 — not-live keeps the attributed `_explain_not_live` shape; live-but-unresponsive replies the new top-level **`GAME_HELPER_TIMEOUT`** ("focus the game window and retry, or use game_command to confirm liveness") instead of bare `INTERNAL_ERROR`. Constant added in `utils/error_codes.gd` + `protocol/errors.py` (parity auto-enforced by `test_error_code_parity.py`).

`DEFAULT_TIMEOUT_SEC` (8s), `GAME_SCREENSHOT_TIMEOUT_SEC` (35s), `FIRST_FRAME_WAIT_SEC` (6s) and all eval-path timing/codes are untouched (locked by `test_game_screenshot_timeout_contract.py`).

## Tests

- GDScript: sync-capture decision logic + stall detection + stale computation (`test_game_helper.gd`), stale-metadata plumbing incl. legacy 6-field compat, and both `_on_timeout` branches (`test_editor.gd`). Full suite: **1918 tests, 0 failures** (7 pre-existing environmental skips).
- Python: staleness metadata passthrough (`test_runtime_handlers.py`), source-level contract on the timeout split + frozen timing ladder (`test_game_screenshot_timeout_contract.py`), automatic code parity.

## Manual verification recipe

1. Open `test_project/` in Godot, run a scene (`project_run`).
2. Background/minimize the game window (on platforms where this freezes the loop; to force it anywhere: `game_eval` → `get_node("/root/_mcp_game_helper").set_process(false)` stalls the liveness beacon the same way).
3. Call `editor_screenshot source=game` — must return an image (stale flag set) instead of an 8s INTERNAL_ERROR.

Verified live against a running editor: beacon-stalled capture returned a valid image in **0.06s** with the game-side reply recording `stale: true`; a `SIGSTOP`'d game (nothing can reply) returned **`GAME_HELPER_TIMEOUT` at 8.01s** with the actionable hint. Focused-game captures stay fresh (`stale: false`, unchanged latency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved game screenshots when the game window is minimized, backgrounded, or rendering is stalled by returning the last available frame with clear stale-frame indicators.
  * Screenshot metadata now includes optional frame counts, staleness status, and explanatory notes.
  * Added a distinct timeout error for live game helpers that do not return a screenshot.

* **Bug Fixes**
  * Improved timeout messages and preserved actionable game-state details when the game is not running.
  * Maintained compatibility with older screenshot responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->