### PR TITLE
Honor godot_ai/ws_port override on the first WebSocket dial

### DIFF
--- a/plugin/addons/godot_ai/connection.gd
+++ b/plugin/addons/godot_ai/connection.gd
@@ -31,9 +31,11 @@ const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
 signal connection_state_changed(is_open: bool)
 
 var _peer := WebSocketPeer.new()
-## Set by plugin.gd after resolving the configured WebSocket port once for the
-## server spawn. Reconnects reuse this cached value so they keep dialing the
-## same port the Python server was asked to bind.
+## Seeded by plugin.gd from the configured EditorSettings port before the
+## first dial, then republished with the fully resolved port once the
+## deferred startup walk (#678) finishes resolving/spawning. Each connect
+## attempt recomputes the URL from the latest value, so reconnects keep
+## dialing the port the Python server was asked to bind.
 var ws_port := ClientConfigurator.DEFAULT_WS_PORT
 ## Per-launch handshake auth token (#690). Set by plugin.gd from the value
 ## it generated for the server spawn (also persisted in the managed-server

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -161,6 +161,13 @@ var _export_plugin
 var _lifecycle
 static var _server_started_this_session := false  # guard against re-entrant spawns
 static var _resolved_ws_port := ClientConfigurator.DEFAULT_WS_PORT
+## True once a startup walk has published a port via `_set_resolved_ws_port`
+## this editor session. Gates the `_enter_tree` pre-resolution seed: a fresh
+## session seeds `_resolved_ws_port` from the configured EditorSettings
+## value, but a plugin reload must keep the prior instance's published
+## resolution, which can legitimately differ from the configured value
+## (Windows-reservation remap, adopted-server record).
+static var _ws_port_resolution_published := false
 ## Per-launch WS handshake auth token (#690). Static for the same reason as
 ## _resolved_ws_port: a plugin reload in the same editor session adopts the
 ## server the previous instance spawned, and must keep its token. Empty
@@ -216,6 +223,19 @@ func _enter_tree() -> void:
 	## builds the CLI args.
 	ClientConfigurator.ensure_settings_registered()
 	_startup_trace_phase("settings_registered")
+
+	## With the startup walk's blocking port resolution deferred to a worker
+	## (#678), the Connection below dials before `_set_resolved_ws_port`
+	## publishes. Seed the pre-resolution port from the configured
+	## EditorSettings value (a cheap main-thread read, not a blocking probe)
+	## so the first dial honors a `godot_ai/ws_port` override — without this
+	## it targeted the compile-time default and the override only took
+	## effect on the 1s retry.
+	_resolved_ws_port = _startup_ws_port_seed(
+		_ws_port_resolution_published,
+		_resolved_ws_port,
+		ClientConfigurator.ws_port(),
+	)
 
 	## #691: pre-warm the env snapshot on the main thread before any worker
 	## exists, so worker-thread env reads (dock refresh/action workers, the
@@ -1069,9 +1089,21 @@ func get_resolved_ws_port() -> int:
 
 
 func _set_resolved_ws_port(port: int) -> void:
+	_ws_port_resolution_published = true
 	_resolved_ws_port = port
 	if _connection != null:
 		_connection.ws_port = port
+
+
+## Pure decision helper — environment-state reads (the published flag, the
+## EditorSettings port) stay in `_enter_tree`; the logic lives here so tests
+## can drive the three inputs directly without mutating the shared statics.
+static func _startup_ws_port_seed(
+	resolution_published: bool,
+	session_ws_port: int,
+	configured_ws_port: int
+) -> int:
+	return session_ws_port if resolution_published else configured_ws_port
 
 
 func _resolve_ws_port() -> int:

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -93,8 +93,25 @@ class _CrashSurvivorPlugin extends _ProofPlugin:
 const TEST_PORT := 65432
 
 
+## The spawn/adopt-path tests below drive the real startup walk on
+## _ProofPlugin fixtures, and the walk publishes via _set_resolved_ws_port —
+## which writes plugin.gd's SHARED statics (GDScript statics are per-Script,
+## so fixtures extending plugin.gd share them with the live plugin
+## instance). The first-dial seed made the kept resolution load-bearing: a
+## leaked fixture port (e.g. a record's 9500) would poison the next live
+## plugin reload's first dial. Capture the live values once, restore after
+## every test.
+var _saved_resolved_ws_port := 0
+var _saved_ws_port_published := false
+
+
 func suite_name() -> String:
 	return "plugin_lifecycle"
+
+
+func suite_setup(_ctx: Dictionary) -> void:
+	_saved_resolved_ws_port = GodotAiPlugin._resolved_ws_port
+	_saved_ws_port_published = GodotAiPlugin._ws_port_resolution_published
 
 
 func setup() -> void:
@@ -105,6 +122,8 @@ func setup() -> void:
 
 func teardown() -> void:
 	GodotAiPlugin._server_started_this_session = false
+	GodotAiPlugin._resolved_ws_port = _saved_resolved_ws_port
+	GodotAiPlugin._ws_port_resolution_published = _saved_ws_port_published
 	## Stop-finalize tests write to EditorSettings + the pid-file on disk;
 	## scrub both so state doesn't leak across tests or outlast the suite.
 	var es := EditorInterface.get_editor_settings()

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -867,6 +867,58 @@ func test_managed_compatible_adoption_log_reports_owned_pid() -> void:
 	assert_contains(message, "adopted managed server (PID 22222")
 
 
+func test_startup_ws_port_seed_prefers_configured_before_first_resolution() -> void:
+	## Regression: with the startup walk's port resolution deferred to a
+	## worker (#678), `_enter_tree` builds the Connection before
+	## `_set_resolved_ws_port` publishes. The pre-seed static held
+	## DEFAULT_WS_PORT, so a `godot_ai/ws_port` EditorSettings override
+	## (e.g. 19630) was ignored on the first dial — it failed against
+	## ws://127.0.0.1:9500 and only the 1s retry reached the configured
+	## port. The seed must hand the configured value to the first dial.
+	var seeded := GodotAiPlugin._startup_ws_port_seed(
+		false, McpClientConfigurator.DEFAULT_WS_PORT, 19630
+	)
+	assert_eq(seeded, 19630, "fresh session must dial the configured override first")
+
+	var unchanged := GodotAiPlugin._startup_ws_port_seed(
+		false, McpClientConfigurator.DEFAULT_WS_PORT, McpClientConfigurator.DEFAULT_WS_PORT
+	)
+	assert_eq(unchanged, McpClientConfigurator.DEFAULT_WS_PORT, "no override keeps the default")
+
+
+func test_startup_ws_port_seed_keeps_published_resolution_on_reload() -> void:
+	## A plugin reload in the same editor session adopts the server the
+	## previous instance spawned — the published resolution can differ from
+	## the configured value (Windows-reservation remap, adopted-server
+	## record) and must win over a re-read of the setting.
+	var remapped := GodotAiPlugin._startup_ws_port_seed(true, 9505, 9500)
+	assert_eq(remapped, 9505, "reload must keep the prior instance's remapped port")
+
+	var setting_changed_mid_session := GodotAiPlugin._startup_ws_port_seed(true, 10500, 19630)
+	assert_eq(
+		setting_changed_mid_session,
+		10500,
+		"a mid-session setting change must not clobber a published resolution — the walk republishes"
+	)
+
+
+func test_set_resolved_ws_port_marks_resolution_published() -> void:
+	## The seed's reload guard must flip exactly when a walk publishes.
+	var saved_port := GodotAiPlugin._resolved_ws_port
+	var saved_published := GodotAiPlugin._ws_port_resolution_published
+	GodotAiPlugin._ws_port_resolution_published = false
+	var plugin := GodotAiPlugin.new()
+	plugin._set_resolved_ws_port(TEST_PORT)
+	plugin.free()
+	assert_eq(GodotAiPlugin._resolved_ws_port, TEST_PORT)
+	assert_true(
+		GodotAiPlugin._ws_port_resolution_published,
+		"a published resolution must arm the reload guard so _enter_tree stops re-seeding"
+	)
+	GodotAiPlugin._resolved_ws_port = saved_port
+	GodotAiPlugin._ws_port_resolution_published = saved_published
+
+
 func test_resolved_ws_port_drops_stale_record_value() -> void:
 	## Regression for the cached-ws-port + stale-ownership interaction.
 	## Setup mirrors the bad shape from the field:

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -101,18 +101,37 @@ func suite_name() -> String:
 	return "server_lifecycle"
 
 
+## The manager walks below run on _ManagerHostStub (which extends
+## plugin.gd) and can publish via _host._set_resolved_ws_port — writing
+## plugin.gd's SHARED statics. See the twin guard in
+## test_plugin_lifecycle.gd: a leaked fixture port would poison the next
+## live plugin reload's first dial now that the seed keeps a published
+## resolution. Capture once, restore after every test.
+var _saved_resolved_ws_port := 0
+var _saved_ws_port_published := false
+
+
 func suite_setup(_ctx: Dictionary) -> void:
 	_saved_tenv1 = OS.get_environment(_TENV1) if OS.has_environment(_TENV1) else null
 	_saved_tenv2 = OS.get_environment(_TENV2) if OS.has_environment(_TENV2) else null
 	var es := EditorInterface.get_editor_settings()
 	if es.has_setting(McpSettings.SETTING_TELEMETRY_ENABLED):
 		_saved_telemetry_setting = es.get_setting(McpSettings.SETTING_TELEMETRY_ENABLED)
+	_saved_resolved_ws_port = GodotAiPlugin._resolved_ws_port
+	_saved_ws_port_published = GodotAiPlugin._ws_port_resolution_published
+
+
+func teardown() -> void:
+	GodotAiPlugin._resolved_ws_port = _saved_resolved_ws_port
+	GodotAiPlugin._ws_port_resolution_published = _saved_ws_port_published
 
 
 func suite_teardown() -> void:
 	_restore_tenv(_TENV1, _saved_tenv1)
 	_restore_tenv(_TENV2, _saved_tenv2)
 	EditorInterface.get_editor_settings().set_setting(McpSettings.SETTING_TELEMETRY_ENABLED, _saved_telemetry_setting)
+	GodotAiPlugin._resolved_ws_port = _saved_resolved_ws_port
+	GodotAiPlugin._ws_port_resolution_published = _saved_ws_port_published
 
 
 func _restore_tenv(name: String, saved: Variant) -> void:


### PR DESCRIPTION
## Problem

When EditorSettings override `godot_ai/ws_port` (e.g. 19630), the plugin's first WebSocket connect at editor startup still targeted `ws://127.0.0.1:9500` and failed with `connection failed before OPEN (code -1, ...)` before the 1s retry succeeded on the configured port.

Root cause: since #678 deferred the startup walk's blocking work to a worker thread, `_enter_tree` builds the Connection while the static `_resolved_ws_port` still holds `ClientConfigurator.DEFAULT_WS_PORT`; the worker publishes the resolved port only after the first dial has already gone out. Reproduced on Windows, Godot 4.6.2 (surfaced during the #794 triage smoke).

## Fix

- `_enter_tree` now seeds `_resolved_ws_port` from `ClientConfigurator.ws_port()` — a cheap main-thread EditorSettings read, not a blocking probe — before the Connection is created, so the first dial honors the override.
- A new `_ws_port_resolution_published` static (latched in `_set_resolved_ws_port`) gates the seed: a plugin reload keeps the prior instance's published resolution, which can legitimately differ from the configured value (Windows-reservation remap, adopted-server record).
- The decision lives in a pure static helper `_startup_ws_port_seed` per the existing decision-helper pattern.

## Test-isolation fixup (second commit)

Live smoke on the first commit exposed a latent leak the seed made load-bearing: the spawn/adopt-path tests in `plugin_lifecycle` / `server_lifecycle` drive the real walk on fixtures extending plugin.gd, publishing fixture ports (9500) into plugin.gd's shared per-Script statics — so a `test_run`-then-`editor_reload_plugin` sequence resurrected the failed 9500 dial once. Both suites now capture the live statics in `suite_setup` and restore them after every test.

## Testing

- New regression tests: seed prefers the configured override before first resolution, reload keeps a published resolution (incl. mid-session setting change), publishing arms the reload guard.
- `pytest`: 1390 passed / 13 skipped. `ruff check`: clean. `ci-check-gdscript`: clean.
- Full in-editor `test_run`: 1890 passed / 0 failed across 63 suites (Windows, Godot 4.6.2), run twice.
- Live smoke with the 19630 override (headed, Windows): fresh boot, suite-then-reload, and full-63-suite-then-reload all dial `ws://127.0.0.1:19630` clean on the first attempt — 0 failed pre-OPEN dials, 0 occurrences of 9500 in the editor log. Independently smoke-verified cross-session on a detached checkout (fresh boot + plain reload cycles clean; the residual suite-then-reload case found there is what the second commit closes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WebSocket connections now consistently use the resolved server port after startup.
  * Reloading the editor plugin preserves remapped or adopted ports instead of reverting to the configured value.
  * Reconnecting automatically targets the latest resolved port, improving connection reliability.
* **Tests**
  * Added coverage for startup port selection, plugin reload behavior, and resolution state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->