### PR TITLE
Harden startup walk against multi-editor duplicate-spawn + 4003 token loop

### DIFF
--- a/plugin/addons/godot_ai/connection.gd
+++ b/plugin/addons/godot_ai/connection.gd
@@ -20,6 +20,14 @@ const OUTBOUND_BUFFER_LIMIT_BYTES := 4 * 1024 * 1024
 ## next frame; the cumulative spill counter is logged so flood patterns
 ## are observable in `logs_read`. See audit-v2 finding #12 (issue #356).
 const PACKET_DRAIN_CAP_PER_TICK := 32
+## Mirror of the server's application close code for a handshake carrying a
+## wrong auth token (#690; `websocket.py::_CLOSE_CODE_AUTH_TOKEN_MISMATCH`).
+const CLOSE_CODE_AUTH_TOKEN_MISMATCH := 4003
+## After this many consecutive post-OPEN token-mismatch rejections, drop the
+## token and handshake token-less (see `_note_post_open_close`). Two, not
+## one: a transient stale-record race during a server swap gets one chance
+## to resolve before the token is given up.
+const AUTH_MISMATCH_FALLBACK_CLOSES := 2
 const ClientConfigurator := preload("res://addons/godot_ai/client_configurator.gd")
 const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
 
@@ -49,6 +57,11 @@ var _reconnect_timer := 0.0
 ## CLOSED state is polled every frame and would flood the editor log.
 var _preopen_failure_logged_for_peer := false
 var _session_id := ""
+## Consecutive post-OPEN closes with CLOSE_CODE_AUTH_TOKEN_MISMATCH. NOT
+## reset by `_clear_on_disconnect` — the streak is counted exactly at the
+## close events it exists to observe, across reconnect attempts. Reset on
+## any other close code and on a successful `handshake_ack`.
+var _auth_mismatch_closes := 0
 ## Godot-AI Python package version reported by the server in its `handshake_ack`
 ## reply. Empty until the ack lands. Older servers (pre-handshake_ack) leave
 ## this empty forever — callers that gate on it (the dock's mismatch banner)
@@ -150,6 +163,7 @@ func _process(delta: float) -> void:
 				var code := _peer.get_close_code()
 				var reason := _peer.get_close_reason()
 				log_buffer.log(_close_diagnostic(true, code, reason, _url))
+				_note_post_open_close(code)
 				connection_state_changed.emit(false)
 			elif not _preopen_failure_logged_for_peer:
 				_preopen_failure_logged_for_peer = true
@@ -328,6 +342,34 @@ static func _close_diagnostic(
 	return "%s (code %d, reason %s, url %s)" % [phase, code, reason_label, url]
 
 
+## Token-mismatch fallback (#690 follow-up). The server's auth token is
+## fixed for its whole launch, so redialing with the same wrong token can
+## never succeed — without this the reconnect loop 4003s forever. The
+## reproduced multi-editor failure: a duplicate spawn overwrites the shared
+## managed-server record with its fresh token, dies unable to bind, and
+## this editor is left holding a token the surviving server never saw.
+## After AUTH_MISMATCH_FALLBACK_CLOSES consecutive rejections, drop to a
+## token-less handshake, which the server accepts by design (older plugins
+## and adopted servers have no token, and the field is attacker-omittable —
+## see websocket.py; omitting it gives up no security). Scope note: only
+## this connection's copy of the token is dropped — the plugin static and
+## the persisted record heal via the startup walk's adoption arms.
+func _note_post_open_close(code: int) -> void:
+	if code != CLOSE_CODE_AUTH_TOKEN_MISMATCH or auth_token.is_empty():
+		_auth_mismatch_closes = 0
+		return
+	_auth_mismatch_closes += 1
+	if _auth_mismatch_closes < AUTH_MISMATCH_FALLBACK_CLOSES:
+		return
+	auth_token = ""
+	_auth_mismatch_closes = 0
+	if log_buffer:
+		log_buffer.log(
+			"auth token rejected %d times (close code %d) — retrying with a token-less handshake"
+			% [AUTH_MISMATCH_FALLBACK_CLOSES, CLOSE_CODE_AUTH_TOKEN_MISMATCH]
+		)
+
+
 func _log_blocked_notice_once() -> void:
 	if _blocked_notice_logged:
 		return
@@ -371,6 +413,9 @@ func _handle_message(raw: String) -> void:
 		return
 	if parsed.get("type", "") == "handshake_ack":
 		server_version = str(parsed.get("server_version", ""))
+		## The server accepted our handshake — any token-mismatch streak is
+		## over; a later unrelated 4003 starts a fresh one.
+		_auth_mismatch_closes = 0
 		return
 	if parsed.has("request_id") and parsed.has("command"):
 		if (

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -1174,21 +1174,6 @@ func _find_managed_pid(port: int) -> int:
 	return _find_pid_on_port(port)
 
 
-## #745: after an editor crash the managed server keeps running, but the
-## bind probe can still report the HTTP port as free — Windows lets a
-## SO_REUSEADDR bind succeed straight over a live listener, and the OS
-## scrape fallback can fail transiently. The pid-file the server writes
-## via `--pid-file` survives the crash; when it names a live process
-## whose cmdline carries the godot-ai brand, a server is likely still
-## up. Liveness + brand only — the startup walk confirms with the HTTP
-## status probe before changing behavior, so a kernel-recycled PID can
-## never redirect startup on its own. Uses the `_for_proof` seams so
-## lifecycle tests can stub it without touching real processes.
-func _managed_server_evidence_alive() -> bool:
-	var pid := _read_pid_file_for_proof()
-	return pid > 0 and _pid_alive_for_proof(pid) and _pid_cmdline_is_godot_ai_for_proof(pid)
-
-
 ## `live` is the result of a prior `_probe_live_server_status_for_port`
 ## call that the caller already has on hand. When non-empty it short-
 ## circuits the internal probe at the bottom of this helper, so a single

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -59,6 +59,13 @@ var _connection_blocked: bool = false
 ## refresh budget.
 var _refresh_retried: bool = false
 
+## One-shot guard for the spawn-lost-port-race re-adoption (see
+## `_diagnose_spawn_fast_exit`). Reset at the top of `start_server` like
+## `_refresh_retried`, so each walk gets one re-adopt budget; a second
+## fast exit in the same walk falls through to the legacy CRASHED
+## diagnosis instead of re-walking forever.
+var _readopt_after_spawn_exit_retried: bool = false
+
 ## Bounded deadline for the foreign-port adoption-confirmation watcher.
 ## Zero when disarmed.
 var _adoption_watch_deadline_ms: int = 0
@@ -621,6 +628,7 @@ func _start_server_impl(async_gen: int) -> void:
 		return
 
 	_refresh_retried = false
+	_readopt_after_spawn_exit_retried = false
 	_conflict_port = 0
 
 	var port := ClientConfigurator.http_port()
@@ -637,20 +645,21 @@ func _start_server_impl(async_gen: int) -> void:
 	if _async_stale(async_gen):
 		return
 	if not port_in_use:
-		## #745: after an editor crash the managed server keeps running, yet
-		## the bind probe can still say "free" (Windows lets a SO_REUSEADDR
-		## bind succeed over a live listener; the scrape fallback can fail
-		## transiently). The surviving pid-file is the tie-breaker: when it
-		## names a live, godot-ai-branded process AND the HTTP status probe
-		## on our port answers as a godot-ai server, treat the port as
-		## occupied so the adopt/recover branch below runs instead of
-		## blind-spawning a duplicate server. A dead/stale/foreign pid or an
-		## unresponsive port falls through to the normal spawn path
-		## unchanged.
+		## #745: after an editor crash (or under multi-editor churn) the
+		## managed server keeps running, yet the bind probe can still say
+		## "free" (Windows lets a SO_REUSEADDR bind succeed over a live
+		## listener; the scrape fallback can fail transiently). The HTTP
+		## status probe is the authoritative tie-breaker and runs
+		## UNCONDITIONALLY: the pid-file evidence gate that used to guard it
+		## goes stale exactly when it's needed most — same-named test
+		## projects share one app_userdata dir, so another editor's walk can
+		## clear or overwrite the pid-file, and blind-spawning here produced
+		## the reproduced duplicate-spawn + 4003 token loop. A live godot-ai
+		## answer forces the adopt/recover branch below; an unresponsive
+		## port falls through to the normal spawn path at the cost of one
+		## fast connection-refused probe (off-thread in production).
 		var evidence_result: Variant = await _run_blocking(func() -> Variant:
 			if not is_instance_valid(_host):
-				return {}
-			if not _host._managed_server_evidence_alive():
 				return {}
 			return _host._probe_live_server_status_for_port(port)
 		)
@@ -927,40 +936,71 @@ func check_server_health() -> void:
 		_host._write_managed_server_record(real_pid, _expected_server_version())
 	elif not PortResolver.pid_alive(spawn_pid):
 		if elapsed >= int(_host.SPAWN_GRACE_MS) and not McpServerStateScript.is_terminal_diagnosis(_server_state):
-			## #647: the server died inside the grace window. If a foreign
-			## (non-godot-ai) process holds the HTTP or WS port, the server
-			## exited fast with its "port already in use" stderr message and
-			## EXIT_PORT_IN_USE — but we can't read the child's stderr, so
-			## re-probe the ports and surface FOREIGN_PORT with an actionable
-			## message instead of a bare CRASHED pointing at the output log.
-			## Checked before the --refresh retry: respawning against an
-			## occupied port can only fail the same way.
-			var conflict := _diagnose_spawn_port_conflict()
-			if not conflict.is_empty():
-				_server_exit_ms = elapsed
-				_server_status_message = str(conflict.get("message", ""))
-				_conflict_port = int(conflict.get("port", 0))
-				set_terminal_diagnosis(McpServerStateScript.FOREIGN_PORT)
-				disarm_version_check()
-				_host._update_process_enabled()
-				_host._log_buffer.log(str(_server_status_message))
-				push_warning("MCP | %s" % _server_status_message)
-				_host._stop_server_watch()
-				return
-			if bool(_host._should_retry_with_refresh()):
-				_refresh_retried = true
-				respawn_with_refresh()
-				return
-			_server_exit_ms = elapsed
-			set_terminal_diagnosis(McpServerStateScript.CRASHED)
-			disarm_version_check()
-			_host._update_process_enabled()
-			_host._log_buffer.log("server exited after %dms — see Godot output log" % int(_server_exit_ms))
-			_host._stop_server_watch()
+			_diagnose_spawn_fast_exit(elapsed)
 		return
 	if elapsed >= int(_host.SERVER_WATCH_MS):
 		## Survived startup — mid-session crashes surface via WebSocket disconnect.
 		_host._stop_server_watch()
+
+
+## The spawned server died inside the SPAWN_GRACE_MS window. Decide what
+## that means, in order:
+##   1. A live godot-ai server answers on the HTTP port -> our spawn lost
+##      a port race the bind probe never saw (#745 bind-trap: the walk
+##      thought the port was free, the duplicate exited unable to bind,
+##      and the token it staged in the record is now stale). Re-run the
+##      startup walk so the adopt/recover branch handles the survivor —
+##      latching CRASHED here left the connection redialing forever with
+##      a token the surviving server rejects (close code 4003). One-shot
+##      per walk via `_readopt_after_spawn_exit_retried`.
+##   2. #647: foreign process on the HTTP or WS port -> FOREIGN_PORT with
+##      an actionable message (we can't read the child's "port already in
+##      use" stderr). Checked before the --refresh retry: respawning
+##      against an occupied port can only fail the same way.
+##   3. #172: stale uvx index -> one `--refresh` respawn.
+##   4. Otherwise -> CRASHED, pointing at the Godot output log.
+func _diagnose_spawn_fast_exit(elapsed: int) -> void:
+	var live: Dictionary = _host._probe_live_server_status_for_port(
+		ClientConfigurator.http_port()
+	)
+	if _live_status_identifies_godot_ai(live) and not _readopt_after_spawn_exit_retried:
+		_readopt_after_spawn_exit_retried = true
+		_host._log_buffer.log(
+			"server exited after %dms but a live godot-ai server answers on port %d — re-running adoption"
+			% [elapsed, ClientConfigurator.http_port()]
+		)
+		_host._stop_server_watch()
+		_server_pid = -1
+		## Clear the spawn guard so the re-walk isn't GUARDED away. The
+		## walk's adopt arm re-sets it and fixes the stale token/record
+		## (external adoption drops both; managed adoption re-records).
+		_host._server_started_this_session = false
+		## Fire-and-forget (mirrors force_restart_server): the walk is a
+		## coroutine in production; its continuation lives on the manager.
+		start_server()
+		return
+	var conflict := _diagnose_spawn_port_conflict(live)
+	if not conflict.is_empty():
+		_server_exit_ms = elapsed
+		_server_status_message = str(conflict.get("message", ""))
+		_conflict_port = int(conflict.get("port", 0))
+		set_terminal_diagnosis(McpServerStateScript.FOREIGN_PORT)
+		disarm_version_check()
+		_host._update_process_enabled()
+		_host._log_buffer.log(str(_server_status_message))
+		push_warning("MCP | %s" % _server_status_message)
+		_host._stop_server_watch()
+		return
+	if bool(_host._should_retry_with_refresh()):
+		_refresh_retried = true
+		respawn_with_refresh()
+		return
+	_server_exit_ms = elapsed
+	set_terminal_diagnosis(McpServerStateScript.CRASHED)
+	disarm_version_check()
+	_host._update_process_enabled()
+	_host._log_buffer.log("server exited after %dms — see Godot output log" % int(_server_exit_ms))
+	_host._stop_server_watch()
 
 
 ## #647: post-crash port-conflict probe. Returns `{}` when no foreign
@@ -968,12 +1008,19 @@ func check_server_health() -> void:
 ## `{"message": String, "port": int}` when the HTTP or WS port is held by
 ## a process we can't identify as godot-ai. An occupant that *does*
 ## identify as godot-ai is deliberately not diagnosed here — that's the
-## stale-server / adoption territory handled by the next `start_server`
-## walk, not a foreign conflict.
-func _diagnose_spawn_port_conflict() -> Dictionary:
+## stale-server / adoption territory handled by `_diagnose_spawn_fast_exit`'s
+## re-adopt arm (or the next `start_server` walk), not a foreign conflict.
+## `pre_probed_live`: an HTTP status snapshot the caller already has on
+## hand; non-empty skips the internal ~500ms probe (the probe helper never
+## returns a bare `{}`, so the sentinel is unambiguous).
+func _diagnose_spawn_port_conflict(pre_probed_live: Dictionary = {}) -> Dictionary:
 	var http_port := ClientConfigurator.http_port()
 	if bool(_host._is_port_in_use(http_port)):
-		var live: Dictionary = _host._probe_live_server_status_for_port(http_port)
+		var live: Dictionary = (
+			pre_probed_live
+			if not pre_probed_live.is_empty()
+			else _host._probe_live_server_status_for_port(http_port)
+		)
 		if _live_status_identifies_godot_ai(live):
 			return {}
 		return {

--- a/test_project/tests/test_connection.gd
+++ b/test_project/tests/test_connection.gd
@@ -105,6 +105,66 @@ func test_build_handshake_includes_auth_token_when_set() -> void:
 	conn.free()
 
 
+# ----- 4003 auth-token-mismatch fallback -----
+#
+# The server's token is fixed per launch, so redialing with the same wrong
+# token can never succeed — the reproduced multi-editor duplicate-spawn left
+# an editor 4003-looping forever. After repeated rejections the connection
+# must fall back to a token-less handshake, which the server accepts by
+# design (#690).
+
+
+func test_auth_mismatch_fallback_drops_token_after_repeated_4003() -> void:
+	var conn := McpConnection.new()
+	var buffer := McpLogBuffer.new()
+	conn.log_buffer = buffer
+	conn.auth_token = "stale-token"
+
+	conn._note_post_open_close(McpConnection.CLOSE_CODE_AUTH_TOKEN_MISMATCH)
+	assert_eq(conn.auth_token, "stale-token",
+		"one rejection may be a transient swap race — keep the token")
+	conn._note_post_open_close(McpConnection.CLOSE_CODE_AUTH_TOKEN_MISMATCH)
+	assert_eq(conn.auth_token, "",
+		"repeated 4003 must fall back to a token-less handshake")
+
+	var payload := conn._build_handshake()
+	assert_false(payload.has("auth_token"),
+		"fallback handshake must omit the token field entirely")
+	var lines := buffer.get_recent(5)
+	assert_true(lines.size() >= 1, "fallback must be logged")
+	assert_contains(lines[lines.size() - 1], "token-less")
+	conn.free()
+
+
+func test_auth_mismatch_streak_resets_on_other_close_codes() -> void:
+	var conn := McpConnection.new()
+	conn.auth_token = "per-launch-secret"
+
+	conn._note_post_open_close(McpConnection.CLOSE_CODE_AUTH_TOKEN_MISMATCH)
+	conn._note_post_open_close(1000)
+	conn._note_post_open_close(McpConnection.CLOSE_CODE_AUTH_TOKEN_MISMATCH)
+
+	assert_eq(conn.auth_token, "per-launch-secret",
+		"non-consecutive rejections must not trigger the fallback")
+	conn.free()
+
+
+func test_auth_mismatch_streak_resets_on_handshake_ack() -> void:
+	## Server swap shape: rejected once, then the next server accepted us.
+	## A later unrelated 4003 must start a fresh streak, not inherit the
+	## pre-ack one.
+	var conn := McpConnection.new()
+	conn.auth_token = "per-launch-secret"
+
+	conn._note_post_open_close(McpConnection.CLOSE_CODE_AUTH_TOKEN_MISMATCH)
+	conn._handle_message('{"type":"handshake_ack","server_version":"1.0.0"}')
+	conn._note_post_open_close(McpConnection.CLOSE_CODE_AUTH_TOKEN_MISMATCH)
+
+	assert_eq(conn.auth_token, "per-launch-secret",
+		"an accepted handshake must reset the mismatch streak")
+	conn.free()
+
+
 func test_handle_message_stores_server_version_from_ack() -> void:
 	var conn := McpConnection.new()
 	assert_eq(conn.server_version, "", "server_version defaults to empty")

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -1130,34 +1130,51 @@ func test_incompatible_status_exposes_actual_name_and_recovery_flag() -> void:
 	assert_true(bool(status.get("can_recover_incompatible", false)))
 
 
-func test_managed_server_evidence_requires_live_branded_pidfile() -> void:
-	## #745: the evidence gate that lets startup second-guess a "port is
-	## free" bind probe. Every tier must hold or the gate stays closed —
-	## a stale or kernel-recycled PID must never count as evidence.
+func test_start_adopts_survivor_when_bind_probe_free_and_pidfile_missing() -> void:
+	## Reproduced multi-editor failure (2026-07, Windows): two editors whose
+	## test projects share one app_userdata dir (same project name) share the
+	## pid-file too, so editor B's walk can find it missing/stale while
+	## editor A's managed server is alive behind a lying bind probe (#745
+	## SO_REUSEADDR bind-trap). The HTTP status probe now runs
+	## unconditionally — a live godot-ai answer must force the adopt path.
+	## Blind-spawning here produced a duplicate server that exited unable to
+	## bind and left a stale spawn token 4003-looping against the survivor.
+	var current := McpClientConfigurator.get_plugin_version()
 	var plugin := _ProofPlugin.new()
+	plugin.port_in_use = false
 	plugin.pid_file_pid = 0
-	assert_false(plugin._managed_server_evidence_alive(),
-		"no pid-file must yield no evidence")
-	plugin.pid_file_pid = 44444
-	assert_false(plugin._managed_server_evidence_alive(),
-		"pid-file naming a dead process must yield no evidence")
-	plugin.alive_pids = [44444] as Array[int]
-	assert_false(plugin._managed_server_evidence_alive(),
-		"live but unbranded pid (kernel-recycled) must yield no evidence")
-	plugin.branded_pids = [44444] as Array[int]
-	assert_true(plugin._managed_server_evidence_alive(),
-		"live godot-ai-branded pid-file process is evidence")
+	plugin.listener_pids = [12321] as Array[int]
+	plugin.alive_pids = [12321] as Array[int]
+	plugin.branded_pids = [12321] as Array[int]
+	plugin.managed_record = {"pid": 55555, "version": current, "ws_port": 9500}
+	plugin.live_status = {"name": "godot-ai", "version": current, "ws_port": 9500, "status_code": 200}
+	GodotAiPlugin._ws_auth_token = "stale-spawn-token"
+
+	plugin._start_server()
+	var status := plugin.get_server_status()
+	var server_pid := int(plugin._lifecycle._server_pid)
+	var killed := plugin.killed_targets.duplicate()
+	var token_after := GodotAiPlugin._ws_auth_token
 	plugin.free()
+
+	assert_eq(int(status.get("state", -1)), McpServerState.READY,
+		"a live godot-ai answer on a 'free' port must adopt, not blind-spawn")
+	assert_true(killed.is_empty(), "adoption must not kill the surviving server")
+	assert_eq(server_pid, -1,
+		"dead recorded PID means the survivor is adopted externally")
+	assert_eq(token_after, "",
+		"external adoption must drop the stale token so the handshake goes token-less")
 
 
 func test_start_adopts_crash_survivor_when_bind_probe_reports_port_free() -> void:
 	## #745: an editor crash leaves the managed server running, but the
 	## bind probe can report the HTTP port as free (Windows SO_REUSEADDR
 	## bind-over-listener semantics; transient scrape failures). With the
-	## surviving pid-file naming a live branded process AND the HTTP
-	## status probe answering as a compatible godot-ai server, startup
-	## must route through the normal adopt path instead of blind-spawning
-	## a duplicate server.
+	## HTTP status probe (now unconditional — no pid-file evidence gate)
+	## answering as a compatible godot-ai server, startup must route
+	## through the normal adopt path instead of blind-spawning a duplicate
+	## server. The surviving pid-file here additionally makes the recorded
+	## PID adoptable as managed.
 	var current := McpClientConfigurator.get_plugin_version()
 	var plugin := _CrashSurvivorPlugin.new()
 	plugin.port_in_use = false

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -31,6 +31,7 @@ class _ManagerHostStub extends GodotAiPlugin:
 	var cleared_record_calls := 0
 	var stop_watch_calls := 0
 	var finalize_calls := 0
+	var probe_calls := 0
 
 	func _find_all_pids_on_port(_port: int) -> Array[int]:
 		var pids: Array[int] = []
@@ -50,7 +51,14 @@ class _ManagerHostStub extends GodotAiPlugin:
 		return branded_pids.has(pid)
 
 	func _probe_live_server_status_for_port(_port: int) -> Dictionary:
+		probe_calls += 1
 		return live_status.duplicate()
+
+	## Deterministic false: the real helper consults the launch mode and the
+	## on-disk pid-file, which vary across dev machines / CI. No test in this
+	## suite exercises the uvx --refresh retry.
+	func _should_retry_with_refresh() -> bool:
+		return false
 
 	func _is_port_in_use(_port: int) -> bool:
 		if not port_in_use_sequence.is_empty():
@@ -500,6 +508,102 @@ func test_status_dict_carries_conflict_port() -> void:
 	host.free()
 
 	assert_eq(int(status.get("conflict_port", 0)), 9500)
+
+
+# ----- spawn fast-exit: lost-port-race re-adoption ----------------------
+
+func test_spawn_fast_exit_readopts_live_godot_ai_survivor() -> void:
+	## Reproduced multi-editor failure (2026-07, Windows): the duplicate
+	## spawn exits unable to bind while the surviving server still answers
+	## /godot-ai/status. The watch must re-run the startup walk (which
+	## adopts the survivor) instead of latching CRASHED and leaving the
+	## stale spawn token 4003-looping against it.
+	var current := McpClientConfigurator.get_plugin_version()
+	var saved_guard: bool = GodotAiPlugin._server_started_this_session
+	var saved_token: String = GodotAiPlugin._ws_auth_token
+	var host := _ManagerHostStub.new()
+	host._log_buffer = McpLogBuffer.new()
+	host.port_in_use = false
+	host.listener_pids = [12321] as Array[int]
+	host.alive_pids = [12321] as Array[int]
+	host.branded_pids = [12321] as Array[int]
+	host.managed_record = {"pid": 55555, "version": current, "ws_port": 9500}
+	host.live_status = {"name": "godot-ai", "version": current, "ws_port": 9500, "status_code": 200}
+	GodotAiPlugin._server_started_this_session = true
+	GodotAiPlugin._ws_auth_token = "stale-spawn-token"
+	var manager := McpServerLifecycleManagerScript.new(host)
+	manager._server_pid = 99999
+	manager.transition_state(McpServerState.SPAWNING)
+
+	manager._diagnose_spawn_fast_exit(5500)
+	var state := manager.get_state()
+	var path := manager.get_startup_path()
+	var killed := host.killed_targets.duplicate()
+	var stop_watch_calls := host.stop_watch_calls
+	var readopt_guard: bool = manager._readopt_after_spawn_exit_retried
+	var token_after: String = GodotAiPlugin._ws_auth_token
+	host.free()
+	GodotAiPlugin._server_started_this_session = saved_guard
+	GodotAiPlugin._ws_auth_token = saved_token
+
+	assert_eq(state, McpServerState.READY,
+		"fast exit with a live godot-ai survivor must re-walk and adopt")
+	assert_eq(path, McpStartupPath.ADOPTED)
+	assert_true(killed.is_empty(), "re-adoption must not kill the survivor")
+	assert_true(stop_watch_calls >= 1, "the dead spawn's watch must stop")
+	assert_false(readopt_guard,
+		"the re-walk must reset the one-shot so a later walk keeps its budget")
+	assert_eq(token_after, "",
+		"external re-adoption must drop the stale spawn token")
+
+
+func test_spawn_fast_exit_readopt_is_one_shot_per_walk() -> void:
+	## A consumed re-adopt budget must fall through to the legacy diagnosis
+	## (a godot-ai occupant is not a foreign conflict -> CRASHED) instead of
+	## re-walking forever.
+	var host := _ManagerHostStub.new()
+	host._log_buffer = McpLogBuffer.new()
+	host.port_in_use = true
+	host.live_status = {"name": "godot-ai", "version": "1.0.0", "ws_port": 9500, "status_code": 200}
+	var manager := McpServerLifecycleManagerScript.new(host)
+	manager._server_pid = 99999
+	manager.transition_state(McpServerState.SPAWNING)
+	manager._readopt_after_spawn_exit_retried = true
+
+	manager._diagnose_spawn_fast_exit(6000)
+	var state := manager.get_state()
+	var exit_ms := int(manager._server_exit_ms)
+	var stop_watch_calls := host.stop_watch_calls
+	host.free()
+
+	assert_eq(state, McpServerState.CRASHED,
+		"second fast exit in one walk must latch CRASHED, not loop")
+	assert_eq(exit_ms, 6000)
+	assert_eq(stop_watch_calls, 1)
+
+
+func test_spawn_fast_exit_foreign_occupant_reuses_probe_snapshot() -> void:
+	## The fast-exit handler probes the HTTP status endpoint once; the
+	## foreign-conflict diagnosis must consume that snapshot instead of
+	## paying a second ~500ms probe on the main thread.
+	var host := _ManagerHostStub.new()
+	host._log_buffer = McpLogBuffer.new()
+	host.port_in_use = true
+	host.live_status = {"name": "", "version": "", "ws_port": 0, "status_code": 0}
+	var manager := McpServerLifecycleManagerScript.new(host)
+	manager._server_pid = 99999
+	manager.transition_state(McpServerState.SPAWNING)
+
+	manager._diagnose_spawn_fast_exit(6000)
+	var state := manager.get_state()
+	var probe_calls := host.probe_calls
+	var conflict_port := int(manager._conflict_port)
+	host.free()
+
+	assert_eq(state, McpServerState.FOREIGN_PORT,
+		"a non-godot-ai occupant must still surface FOREIGN_PORT through the new seam")
+	assert_eq(probe_calls, 1, "conflict diagnosis must reuse the fast-exit probe snapshot")
+	assert_eq(conflict_port, McpClientConfigurator.http_port())
 
 
 func test_start_server_short_circuits_on_static_guard() -> void:


### PR DESCRIPTION
## Problem

Reproduced 2026-07-20 on Windows (plugin/server 3.0.4, EditorSettings ports HTTP 18130 / WS 19630): editor A runs the managed server; launching editor B (another worktree) did **not** adopt it:

- B's `_is_port_in_use()` bind probe reported the HTTP port free (the #745 Windows SO_REUSEADDR bind-trap class).
- The #745 pid-file evidence fallback failed: both test projects are named "MCP Test Project", so they share one `app_userdata` dir — the shared `user://godot_ai_server.pid` was missing/stale.
- B blind-spawned a duplicate server, which exited ~5.5s later unable to bind, after overwriting the shared EditorSettings managed record + `ws_token` with its fresh spawn token.
- B's connection then looped forever on `disconnected after OPEN (code 4003, reason auth token mismatch)` against A's surviving server — the token never changes, so reconnect can never recover. B's session never registered.

## Fix — three layers, each independently sufficient to heal the repro

1. **`start_server` walk** (`server_lifecycle.gd`): when the bind probe says free, probe the HTTP status endpoint **unconditionally** — the pid-file evidence gate is removed (it goes stale exactly when it's needed most). A live godot-ai answer forces the adopt/recover branch instead of a blind spawn. On a genuinely free port the probe is a fast connection-refused failure, and it runs off-thread in production (#678). The now-unused `_managed_server_evidence_alive` helper is deleted from `plugin.gd`.
2. **Spawn fast-exit feedback** (new `_diagnose_spawn_fast_exit` seam): a spawn dying inside the grace window re-probes the port first; a live godot-ai answer re-runs the startup walk — whose adoption arm also heals the stale token/record — instead of latching CRASHED. One-shot per walk. The foreign-port (#647) and uvx `--refresh` (#172) diagnoses are unchanged and now reuse the probe snapshot instead of paying a second ~500ms probe.
3. **4003 fallback** (`connection.gd`): after 2 consecutive post-OPEN 4003 closes, drop to a token-less handshake, which the server accepts by design (#690 — the field is attacker-omittable, so omitting it gives up no security). Streak resets on any other close code and on `handshake_ack`.

## Testing

- 7 new regression tests: repro-shaped adopt-without-pidfile walk test (`plugin_lifecycle`), fast-exit readopt / one-shot / foreign-snapshot tests (`server_lifecycle`), 4003 fallback + streak-reset tests (`connection`).
- Full gauntlet green on the repro machine: 1893 GDScript tests / 0 failures in the live editor, `ruff` clean, 1390 pytest passed.
- Live smoke of the exact repro scenario: second editor launched against a running managed server now adopts (managed, PID healed), connects, and registers its session — no duplicate spawn, no token loop.

Note: the separate ws_port first-dial seed fix (commit 1f926a9 on `dlight-win/dreamy-wescoff-b3c585`) is intentionally not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)