### PR TITLE
connection.gd: avoid double UTF-8 encode on every WS send

### DIFF
--- a/plugin/addons/godot_ai/connection.gd
+++ b/plugin/addons/godot_ai/connection.gd
@@ -554,10 +554,16 @@ func _send_json(data: Dictionary) -> bool:
 	if not _connected:
 		return false
 	var text := JSON.stringify(data)
-	var message_bytes := text.to_utf8_buffer().size()
 	var buffered_bytes := _peer.get_current_outbound_buffered_amount()
-	if _would_exceed_outbound_backpressure(buffered_bytes, message_bytes):
-		return _handle_outbound_backpressure(data, buffered_bytes, message_bytes)
+	## `send_text` encodes the string to UTF-8 internally, so an exact
+	## `to_utf8_buffer().size()` here would encode every payload twice. Almost
+	## all payloads sit far below the limit, so gate on a cheap upper bound
+	## (<= 4 UTF-8 bytes per code point) and only pay for the exact count when
+	## the estimate lands near the backpressure ceiling.
+	if _might_exceed_outbound_backpressure(buffered_bytes, text.length()):
+		var message_bytes := text.to_utf8_buffer().size()
+		if _would_exceed_outbound_backpressure(buffered_bytes, message_bytes):
+			return _handle_outbound_backpressure(data, buffered_bytes, message_bytes)
 	var err := _peer.send_text(text)
 	if err != OK:
 		if log_buffer:
@@ -568,6 +574,14 @@ func _send_json(data: Dictionary) -> bool:
 
 static func _would_exceed_outbound_backpressure(buffered_bytes: int, message_bytes: int) -> bool:
 	return buffered_bytes + message_bytes > OUTBOUND_BUFFER_LIMIT_BYTES
+
+
+## Cheap pre-check on the code-point count: UTF-8 uses at most 4 bytes per code
+## point, so `char_count * 4` upper-bounds the encoded size. When even that
+## upper bound fits under the ceiling the payload is definitely safe and we can
+## skip the exact encode; only a positive here warrants `to_utf8_buffer()`.
+static func _might_exceed_outbound_backpressure(buffered_bytes: int, char_count: int) -> bool:
+	return buffered_bytes + char_count * 4 > OUTBOUND_BUFFER_LIMIT_BYTES
 
 
 func _handle_outbound_backpressure(

--- a/test_project/tests/test_connection.gd
+++ b/test_project/tests/test_connection.gd
@@ -523,6 +523,9 @@ func test_might_exceed_uses_worst_case_four_bytes_per_code_point() -> void:
 	## The cheap gate must upper-bound the encoded size (<= 4 UTF-8 bytes per
 	## code point) so a "safe" verdict is never wrong.
 	assert_false(McpConnection._might_exceed_outbound_backpressure(0, 1024))
+	# Exact quarter of the limit; the operands are ints, so int-division is
+	# intended (the limit is a power of two, so it divides evenly).
+	@warning_ignore("integer_division")
 	var char_budget := McpConnection.OUTBOUND_BUFFER_LIMIT_BYTES / 4
 	assert_false(McpConnection._might_exceed_outbound_backpressure(0, char_budget))
 	assert_true(McpConnection._might_exceed_outbound_backpressure(0, char_budget + 1))

--- a/test_project/tests/test_connection.gd
+++ b/test_project/tests/test_connection.gd
@@ -519,6 +519,29 @@ func test_outbound_backpressure_limit_rejects_payload_that_would_overflow() -> v
 	)
 
 
+func test_might_exceed_uses_worst_case_four_bytes_per_code_point() -> void:
+	## The cheap gate must upper-bound the encoded size (<= 4 UTF-8 bytes per
+	## code point) so a "safe" verdict is never wrong.
+	assert_false(McpConnection._might_exceed_outbound_backpressure(0, 1024))
+	var char_budget := McpConnection.OUTBOUND_BUFFER_LIMIT_BYTES / 4
+	assert_false(McpConnection._might_exceed_outbound_backpressure(0, char_budget))
+	assert_true(McpConnection._might_exceed_outbound_backpressure(0, char_budget + 1))
+
+
+func test_might_exceed_is_conservative_relative_to_exact_check() -> void:
+	## When the cheap gate says "safe" the exact byte check must agree, because
+	## actual UTF-8 bytes can never exceed char_count * 4. Guarding the exact
+	## encode behind this gate must not let an overflowing payload slip through.
+	var near := McpConnection.OUTBOUND_BUFFER_LIMIT_BYTES - 8
+	## 1 code point -> at most 4 bytes, within the 8-byte headroom -> cleared as
+	## safe, and the exact check agrees for any real 1..4 byte encoding.
+	assert_false(McpConnection._might_exceed_outbound_backpressure(near, 1))
+	assert_false(McpConnection._would_exceed_outbound_backpressure(near, 4))
+	## 3 code points -> up to 12 bytes, over the 8-byte headroom -> the gate must
+	## refuse to clear it so the exact encode still runs.
+	assert_true(McpConnection._might_exceed_outbound_backpressure(near, 3))
+
+
 func test_backpressure_error_is_structured_and_actionable() -> void:
 	var err := McpConnection._make_backpressure_error("rid-1", 100, 200)
 	assert_eq(err.request_id, "rid-1")


### PR DESCRIPTION
## Summary

`McpConnection._send_json` runs on every outbound WebSocket frame. It was encoding each payload to UTF-8 **twice**:

1. `text.to_utf8_buffer().size()` — a full encode, used only to measure the byte length for the backpressure check, and
2. `_peer.send_text(text)` — which encodes the same string to UTF-8 again internally to put it on the wire.

The first encode is pure overhead on the hot send path, and it allocates a throwaway `PackedByteArray` the size of the whole payload every time.

## Change

Gate the backpressure check on a cheap upper bound first: UTF-8 uses at most 4 bytes per code point, so `text.length() * 4` upper-bounds the encoded size without touching the bytes. Only when that bound lands near the 4 MiB ceiling do we fall through to an exact `to_utf8_buffer().size()`.

The exact byte count still drives the real overflow decision (`_would_exceed_outbound_backpressure`) and is still what's reported in the backpressure error payload — so **behaviour is unchanged**. The only difference is that a payload comfortably under the limit (i.e. essentially every frame) now encodes once, inside `send_text`, instead of twice.

New static helper `_might_exceed_outbound_backpressure(buffered_bytes, char_count)` mirrors the existing `_would_exceed_outbound_backpressure` and keeps the cheap check unit-testable.

## Why the upper bound is safe

`_might_exceed` is deliberately conservative: because actual UTF-8 bytes can never exceed `char_count * 4`, a "safe" verdict from the cheap gate guarantees the exact check would also pass. It can only ever be *too cautious* (running the exact encode when it turns out not to be needed), never too permissive — so an overflowing payload can never slip past the exact check.

## Tests

`test_project/tests/test_connection.gd`:

- `test_might_exceed_uses_worst_case_four_bytes_per_code_point` — pins the `* 4` worst-case boundary (exactly at the ceiling = safe; one code point over = flagged).
- `test_might_exceed_is_conservative_relative_to_exact_check` — asserts the cheap gate never clears a payload the exact check would reject.

Validated locally on Godot 4.7.1 (headless `--check-only` parse + direct execution of the static helpers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved outbound WebSocket backpressure checks using a fast upper-bound pre-check to reduce extra work for smaller payloads.
  * Kept precise UTF-8 byte accounting for messages that may approach or exceed the configured outbound buffer limit.

* **Tests**
  * Added unit tests validating the new conservative pre-check behavior across UTF-8 worst-case sizing and consistency with the exact size evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->