### PR TITLE
api_manage(get_class): default to properties only, add "all" keyword

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -216,12 +216,17 @@ Calls take the form:
 | `tileset_manage` | `tileset_get_atlas_tiles`, `tileset_get_atlas_image` |
 
 `api_manage(op="get_class")` inspects Godot API/ClassDB metadata for a class
-without creating an instance. By default it returns direct class members only,
-with each returned section capped at 100 items. Pass `sections` (`properties`,
-`methods`, `signals`, `enums`, `constants`, `inheritors`),
-`include_inherited=true`, `include_inheritors=true`, `offset`, or `limit=0`
-when a fuller class reference is needed. When paginating, request one section
-at a time so `offset`/`limit` apply only to the list you are paging.
+without creating an instance. By default it returns **only `properties`**
+(direct members, capped at 100 items) — a bare `get_class` is almost always
+"what properties does X have", and the full section dump costs an agent
+thousands of tokens it rarely wanted. Pass `sections` to widen it
+(`properties`, `methods`, `signals`, `enums`, `constants`, `inheritors`), or
+`sections="all"` for the full documentation set (all of those **except**
+`inheritors`, which stays opt-in by name). `include_inherited=true`,
+`include_inheritors=true`, `offset`, and `limit=0` further shape the result.
+When paginating, request one section at a time so `offset`/`limit` apply only
+to the list you are paging. The `godot://class/{class_name}` resource form
+cannot take `sections`, so it always returns the full set.
 
 Every rolled-up tool also accepts an optional top-level `session_id` for
 per-call multi-editor routing (sibling of `op` and `params`, *not* nested

--- a/plugin/addons/godot_ai/handlers/api_handler.gd
+++ b/plugin/addons/godot_ai/handlers/api_handler.gd
@@ -76,11 +76,11 @@ static func _invalid_sections_error(invalid_sections: Array[String]) -> Dictiona
 	for section in invalid_sections:
 		suggestions[section] = FuzzySuggestions.rank(
 			section,
-			ClassIntrospection.KNOWN_SECTIONS,
+			ClassIntrospection.SUGGESTABLE_SECTION_TOKENS,
 			3,
 			0.3
 		)
-	var message := "Unknown class-info section(s): %s. Valid sections: %s" % [
+	var message := "Unknown class-info section(s): %s. Valid sections: %s (or \"all\" for the full set)" % [
 		", ".join(invalid_sections),
 		", ".join(ClassIntrospection.KNOWN_SECTIONS),
 	]

--- a/plugin/addons/godot_ai/handlers/api_handler.gd
+++ b/plugin/addons/godot_ai/handlers/api_handler.gd
@@ -80,7 +80,7 @@ static func _invalid_sections_error(invalid_sections: Array[String]) -> Dictiona
 			3,
 			0.3
 		)
-	var message := "Unknown class-info section(s): %s. Valid sections: %s (or \"all\" for the full set)" % [
+	var message := "Unknown class-info section(s): %s. Valid sections: %s (or \"all\" for all documentation sections; \"inheritors\" must be requested by name)" % [
 		", ".join(invalid_sections),
 		", ".join(ClassIntrospection.KNOWN_SECTIONS),
 	]

--- a/plugin/addons/godot_ai/utils/class_introspection.gd
+++ b/plugin/addons/godot_ai/utils/class_introspection.gd
@@ -5,7 +5,15 @@ extends RefCounted
 
 const VariantSerializer := preload("res://addons/godot_ai/utils/variant_serializer.gd")
 
-const DEFAULT_SECTIONS := ["properties", "methods", "signals", "enums", "constants"]
+## Sections returned when the caller does not name any. Deliberately narrow:
+## a bare `get_class` is almost always "what properties does X have", and the
+## full five-section dump for a large class (e.g. Node, Control) costs an agent
+## thousands of tokens it rarely wanted. Callers opt into the rest by name, or
+## request the lot with the "all" keyword (see `_sections`).
+const DEFAULT_SECTIONS := ["properties"]
+## The full documentation-shaped section set (excludes the heavier, separately
+## gated "inheritors"). Expanded from the "all" keyword.
+const ALL_SECTIONS := ["properties", "methods", "signals", "enums", "constants"]
 const KNOWN_SECTIONS := ["properties", "methods", "signals", "enums", "constants", "inheritors"]
 const MAX_DEFAULT_ITEMS := 100
 
@@ -90,6 +98,11 @@ static func _sections(raw_sections: Variant) -> Array[String]:
 		values = DEFAULT_SECTIONS
 	for raw_section in values:
 		var section := str(raw_section).strip_edges().to_lower()
+		if section == "all":
+			for expanded in ALL_SECTIONS:
+				if not result.has(expanded):
+					result.append(expanded)
+			continue
 		if not section.is_empty() and not result.has(section):
 			result.append(section)
 	if result.is_empty():

--- a/plugin/addons/godot_ai/utils/class_introspection.gd
+++ b/plugin/addons/godot_ai/utils/class_introspection.gd
@@ -10,11 +10,18 @@ const VariantSerializer := preload("res://addons/godot_ai/utils/variant_serializ
 ## full five-section dump for a large class (e.g. Node, Control) costs an agent
 ## thousands of tokens it rarely wanted. Callers opt into the rest by name, or
 ## request the lot with the "all" keyword (see `_sections`).
-const DEFAULT_SECTIONS := ["properties"]
+const DEFAULT_SECTIONS: Array[String] = ["properties"]
 ## The full documentation-shaped section set (excludes the heavier, separately
 ## gated "inheritors"). Expanded from the "all" keyword.
-const ALL_SECTIONS := ["properties", "methods", "signals", "enums", "constants"]
-const KNOWN_SECTIONS := ["properties", "methods", "signals", "enums", "constants", "inheritors"]
+const ALL_SECTIONS: Array[String] = ["properties", "methods", "signals", "enums", "constants"]
+const KNOWN_SECTIONS: Array[String] = ["properties", "methods", "signals", "enums", "constants", "inheritors"]
+## Tokens a caller may legitimately pass in `sections` — the known sections plus
+## the "all" meta-keyword. Used for error suggestions so a typo like "al" can
+## resolve to "all"; "all" is NOT a section (it expands in `_sections`), so it
+## stays out of KNOWN_SECTIONS which gates validity.
+const SUGGESTABLE_SECTION_TOKENS: Array[String] = [
+	"properties", "methods", "signals", "enums", "constants", "inheritors", "all"
+]
 const MAX_DEFAULT_ITEMS := 100
 
 

--- a/src/godot_ai/resources/classes.py
+++ b/src/godot_ai/resources/classes.py
@@ -14,6 +14,15 @@ from godot_ai.runtime.direct import DirectRuntime
 def register_class_resources(mcp: FastMCP) -> None:
     @mcp.resource("godot://class/{class_name}", mime_type="application/json")
     async def get_class_info(ctx: Context, class_name: str) -> dict[str, Any]:
-        """ClassDB metadata for a class in the active Godot editor."""
+        """ClassDB metadata for a class in the active Godot editor.
+
+        Returns the full documentation set (properties, methods, signals,
+        enums, constants). The `get_class` tool defaults to properties-only,
+        but a resource URI cannot carry a `sections` argument, so the resource
+        pins `sections="all"` to preserve its advertised full-reference
+        contract.
+        """
         runtime = DirectRuntime.from_context(ctx)
-        return await safe_payload(api_handlers.api_get_class(runtime, class_name=class_name))
+        return await safe_payload(
+            api_handlers.api_get_class(runtime, class_name=class_name, sections="all")
+        )

--- a/src/godot_ai/tools/api.py
+++ b/src/godot_ai/tools/api.py
@@ -21,6 +21,10 @@ Ops:
         Return selected class-reference sections without creating a scene
         instance. sections may be a comma-separated string or list containing
         properties, methods, signals, enums, constants, inheritors.
+        Defaults to ["properties"] only — a bare get_class answers "what
+        properties does X have" without the multi-thousand-token full dump.
+        Pass the sections you want by name, or "all" for the full set
+        (properties, methods, signals, enums, constants).
         For pagination, request one section at a time so offset/limit apply
         only to the list you are paging.
 """

--- a/src/godot_ai/tools/api.py
+++ b/src/godot_ai/tools/api.py
@@ -24,7 +24,8 @@ Ops:
         Defaults to ["properties"] only — a bare get_class answers "what
         properties does X have" without the multi-thousand-token full dump.
         Pass the sections you want by name, or "all" for the full set
-        (properties, methods, signals, enums, constants).
+        (properties, methods, signals, enums, constants). "all" does NOT
+        include the heavier "inheritors" section — request that by name.
         For pagination, request one section at a time so offset/limit apply
         only to the list you are paging.
 """

--- a/test_project/tests/test_api.gd
+++ b/test_project/tests/test_api.gd
@@ -70,6 +70,7 @@ func test_get_class_info_singleton_does_not_report_abstract() -> void:
 func test_get_class_info_character_body_3d() -> void:
 	var result := _handler.get_class_info({
 		"class_name": "CharacterBody3D",
+		"sections": "all",
 		"include_inherited": true,
 		"limit": 0,
 	})
@@ -112,8 +113,35 @@ func test_get_class_info_default_is_direct_and_limited() -> void:
 	var result := _handler.get_class_info({"class_name": "Control"})
 	assert_has_key(result, "data")
 	assert_false(result.data.include_inherited)
-	assert_true(result.data.methods.size() <= result.data.limit)
-	assert_eq(_find_named(result.data.methods, "get_parent"), {})
+	## Default section set is properties-only (see DEFAULT_SECTIONS).
+	assert_has_key(result.data, "properties")
+	assert_true(result.data.properties.size() <= result.data.limit)
+	## Direct-only: an inherited Node property must not appear.
+	assert_eq(_find_named(result.data.properties, "name"), {})
+
+
+func test_get_class_info_default_sections_are_properties_only() -> void:
+	## A bare get_class returns only properties; the heavier sections are
+	## opt-in so an agent asking "what does X have" doesn't pay for the lot.
+	var result := _handler.get_class_info({"class_name": "CharacterBody3D"})
+	assert_has_key(result, "data")
+	assert_has_key(result.data, "properties")
+	assert_false(result.data.has("methods"), "methods must be opt-in, not default")
+	assert_false(result.data.has("signals"), "signals must be opt-in, not default")
+	assert_false(result.data.has("enums"), "enums must be opt-in, not default")
+	assert_false(result.data.has("constants"), "constants must be opt-in, not default")
+
+
+func test_get_class_info_all_keyword_returns_full_set() -> void:
+	var result := _handler.get_class_info({
+		"class_name": "CharacterBody3D",
+		"sections": "all",
+	})
+	assert_has_key(result, "data")
+	for key in ["properties", "methods", "signals", "enums", "constants"]:
+		assert_true(result.data.has(key), "section %s should be present for 'all'" % key)
+	## "inheritors" is heavier and separately gated — not folded into "all".
+	assert_false(result.data.has("inheritors"))
 
 
 func _find_named(items: Array, item_name: String) -> Dictionary:

--- a/test_project/tests/test_api.gd
+++ b/test_project/tests/test_api.gd
@@ -3,6 +3,7 @@ extends McpTestSuite
 
 const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
 const ApiHandler := preload("res://addons/godot_ai/handlers/api_handler.gd")
+const ClassIntrospection := preload("res://addons/godot_ai/utils/class_introspection.gd")
 
 var _handler: ApiHandler
 
@@ -142,6 +143,38 @@ func test_get_class_info_all_keyword_returns_full_set() -> void:
 		assert_true(result.data.has(key), "section %s should be present for 'all'" % key)
 	## "inheritors" is heavier and separately gated — not folded into "all".
 	assert_false(result.data.has("inheritors"))
+
+
+func test_get_class_info_all_keyword_as_list_element_expands_and_dedups() -> void:
+	## "all" also works inside a list alongside explicit names; the duplicate
+	## "properties" must not produce a doubled section.
+	var result := _handler.get_class_info({
+		"class_name": "Node",
+		"sections": ["properties", "all", "methods"],
+	})
+	assert_has_key(result, "data")
+	for key in ["properties", "methods", "signals", "enums", "constants"]:
+		assert_true(result.data.has(key), "list 'all' should expand section %s" % key)
+
+
+func test_sections_all_keyword_dedups_to_five() -> void:
+	## Direct check on the normalizer: "all" expands to the five doc sections
+	## and the redundant explicit "properties" is de-duplicated, not repeated.
+	var check := ClassIntrospection.validate_sections(["properties", "all", "properties"])
+	assert_true(check.invalid.is_empty(), "'all' must be accepted, never flagged invalid")
+	assert_eq(check.sections.size(), 5)
+
+
+func test_invalid_section_suggests_all_keyword() -> void:
+	## A near-miss for the meta-keyword should surface "all", and the error
+	## message must advertise it — it isn't in KNOWN_SECTIONS.
+	var result := _handler.get_class_info({
+		"class_name": "CharacterBody3D",
+		"sections": ["al"],
+	})
+	assert_is_error(result, ErrorCodes.INVALID_PARAMS)
+	assert_contains(result.error.data.suggestions.al, "all")
+	assert_contains(result.error.message, "all")
 
 
 func _find_named(items: Array, item_name: String) -> Dictionary:

--- a/tests/integration/test_mcp_resources.py
+++ b/tests/integration/test_mcp_resources.py
@@ -276,8 +276,12 @@ class TestClassResourceTemplate:
         async def respond():
             cmd = await plugin.recv_command()
             assert cmd["command"] == "get_class_info"
+            # The resource cannot take a `sections` arg, so it pins "all" to
+            # preserve the full-reference contract despite the tool's
+            # properties-only default.
             assert cmd["params"] == {
                 "class_name": "CharacterBody3D",
+                "sections": "all",
                 "include_inherited": False,
                 "include_inheritors": False,
                 "offset": 0,


### PR DESCRIPTION
> ⚠️ **Behavior change — release note (please land on a minor version bump).**
> Every existing *bare* `api_manage(op="get_class")` call (no `sections`) now
> returns **only `properties`** instead of all five sections. Opt back into the
> old shape with `sections="all"` (or name the sections). The
> `godot://class/{class_name}` resource is **unchanged** — it pins `sections="all"`.
> Version skew is benign both ways: older plugin + newer server returns extra
> sections; newer plugin + older server just needs an explicit `sections` for the
> old shape.

## Summary

`api_manage(op="get_class")` returned **all five** reference sections — properties, methods, signals, enums, constants — whenever the caller named none. For a large class (`Node`, `Control`, `CharacterBody3D` with `include_inherited`) that is a multi-thousand-token dump, and a bare `get_class` is almost always *"what properties does X have"* — which is exactly how the tool's own description leads.

This narrows the default to `["properties"]` and adds an `"all"` keyword so "give me everything" stays a one-word request.

## Change

- `DEFAULT_SECTIONS` → `["properties"]` (was the full five-section set).
- New `ALL_SECTIONS` constant holds the full documentation set; `_sections()` expands an `"all"` token (as a string or a list element) to it, with dedup.
- `"all"` is accepted by `validate_sections` (it expands to valid sections), so it never trips the invalid-section error.
- `"inheritors"` stays separately gated behind `include_inheritors` / an explicit `sections=["inheritors"]` — it is **not** folded into `"all"`, since it's the heaviest section and rarely wanted alongside the doc set.
- Tool description updated to state the new default and the `"all"` shortcut.

**Item shape is unchanged** — properties/methods/etc. still carry the same fields. Only *which sections are present by default* changes. Callers that want the old behaviour pass `sections="all"` (or list the sections they need).

## Why this is safe / low-risk

- Fully reversible and opt-out in one word (`sections="all"`).
- No change to the returned item structure, pagination, or any explicit-`sections` call.
- Aligns the default with the documented primary use ("what properties does X have").

## Tests

`test_project/tests/test_api.gd`:

- `test_get_class_info_default_sections_are_properties_only` — a bare `get_class` returns `properties` and omits methods/signals/enums/constants.
- `test_get_class_info_all_keyword_returns_full_set` — `sections="all"` yields all five doc sections and does **not** include `inheritors`.
- `test_get_class_info_default_is_direct_and_limited` — updated to assert the properties-only default (direct-only, count ≤ limit).
- `test_get_class_info_character_body_3d` — now passes `sections="all"` since it exercises methods/signals/enums.

Validated locally on Godot 4.7.1: headless `--check-only` parse of all changed GDScript, plus direct execution of `ApiHandler.get_class_info` covering the default, the `"all"` keyword (string, list-element, and mixed/dedup forms), explicit single-section requests, and `validate_sections("all")`. Python side: `ruff check` clean and the `api_get_class` handler / `TestApiGetClassTool` / `TestClassResourceTemplate` suites pass (the mock-plugin contract tests are unaffected, since the Python handler still forwards no `sections` when the caller omits them).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Class information now returns **properties-only** by default.
  * Added support for **`sections: "all"`** to fetch **properties, methods, signals, enums, and constants** (with **inheritors** still opt-in).
* **Documentation**
  * Updated `get_class`/API guidance to clarify default output, pagination/section behavior, and `"all"` semantics.
* **Tests**
  * Expanded coverage for default sections, `"all"` requests, and `"all"` expansion/de-duplication.
* **Bug Fixes**
  * Improved “invalid section” errors to better suggest valid options, including `"all"`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->