### PR TITLE
scene_get_hierarchy: build full-read paths incrementally down the DFS

### DIFF
--- a/plugin/addons/godot_ai/handlers/scene_handler.gd
+++ b/plugin/addons/godot_ai/handlers/scene_handler.gd
@@ -39,7 +39,9 @@ func get_scene_tree(params: Dictionary) -> Dictionary:
 	# pass by reference in GDScript). The walk still visits every node to get an
 	# accurate total_count, but only materializes those inside the window.
 	var index_ref: Array[int] = [0]
-	_walk_tree(scene_root, nodes, 0, max_depth, scene_root, offset, limit, index_ref)
+	# Full reads thread clean paths down the DFS (see _walk_tree); seed the root's.
+	var root_path := ("/" + String(scene_root.name)) if limit <= 0 else ""
+	_walk_tree(scene_root, nodes, 0, max_depth, scene_root, offset, limit, index_ref, root_path)
 	var total: int = index_ref[0]
 	return {"data": {
 		"nodes": nodes,
@@ -382,21 +384,32 @@ func _save_current_scene_as(path: String) -> void:
 	EditorInterface.save_scene_as(path)
 
 
-func _walk_tree(node: Node, out: Array[Dictionary], depth: int, max_depth: int, scene_root: Node, offset: int, limit: int, index_ref: Array[int]) -> void:
+func _walk_tree(node: Node, out: Array[Dictionary], depth: int, max_depth: int, scene_root: Node, offset: int, limit: int, index_ref: Array[int], node_path: String = "") -> void:
 	if depth > max_depth:
 		return
 	var idx: int = index_ref[0]
 	index_ref[0] = idx + 1
 	# Materialize only nodes inside the [offset, offset+limit) window. Outside
-	# it we still recurse (to count total_count) but skip the per-node dict and
-	# the O(depth) scene-path build — the actual cost this pagination avoids.
+	# it we still recurse (to count total_count) but skip the per-node dict.
+	#
+	# Path build strategy depends on the read shape (identical output either way):
+	#   * Full reads (limit <= 0, e.g. the godot://scene/hierarchy resource) thread
+	#     the parent's clean path down the DFS — each node's path is one O(1) concat
+	#     reusing the descent, instead of McpScenePath.from_node's two native walks
+	#     back up (is_ancestor_of + get_path_to). Benchmarked ~1.8x faster on a
+	#     ~1.5k-node tree, up to ~5x on deep chains.
+	#   * Paginated reads (limit > 0) keep from_node for just the windowed nodes:
+	#     threading would concatenate a path for every node (all are still visited
+	#     for total_count), which benchmarks ~20% slower for a small window.
+	var incremental := limit <= 0
 	var in_window := idx >= offset and (limit <= 0 or idx < offset + limit)
 	if in_window:
 		out.append({
 			"name": node.name,
 			"type": node.get_class(),
-			"path": McpScenePath.from_node(node, scene_root),
+			"path": node_path if incremental else McpScenePath.from_node(node, scene_root),
 			"children_count": node.get_child_count(),
 		})
 	for child in node.get_children():
-		_walk_tree(child, out, depth + 1, max_depth, scene_root, offset, limit, index_ref)
+		var child_path := (node_path + "/" + String(child.name)) if incremental else ""
+		_walk_tree(child, out, depth + 1, max_depth, scene_root, offset, limit, index_ref, child_path)

--- a/plugin/addons/godot_ai/handlers/scene_handler.gd
+++ b/plugin/addons/godot_ai/handlers/scene_handler.gd
@@ -39,9 +39,8 @@ func get_scene_tree(params: Dictionary) -> Dictionary:
 	# pass by reference in GDScript). The walk still visits every node to get an
 	# accurate total_count, but only materializes those inside the window.
 	var index_ref: Array[int] = [0]
-	# Full reads thread clean paths down the DFS (see _walk_tree); seed the root's.
-	var root_path := ("/" + String(scene_root.name)) if limit <= 0 else ""
-	_walk_tree(scene_root, nodes, 0, max_depth, scene_root, offset, limit, index_ref, root_path)
+	# _walk_tree self-seeds the root's path for full reads; pass "" explicitly.
+	_walk_tree(scene_root, nodes, 0, max_depth, scene_root, offset, limit, index_ref, "")
 	var total: int = index_ref[0]
 	return {"data": {
 		"nodes": nodes,
@@ -384,7 +383,7 @@ func _save_current_scene_as(path: String) -> void:
 	EditorInterface.save_scene_as(path)
 
 
-func _walk_tree(node: Node, out: Array[Dictionary], depth: int, max_depth: int, scene_root: Node, offset: int, limit: int, index_ref: Array[int], node_path: String = "") -> void:
+func _walk_tree(node: Node, out: Array[Dictionary], depth: int, max_depth: int, scene_root: Node, offset: int, limit: int, index_ref: Array[int], node_path: String) -> void:
 	if depth > max_depth:
 		return
 	var idx: int = index_ref[0]
@@ -393,15 +392,21 @@ func _walk_tree(node: Node, out: Array[Dictionary], depth: int, max_depth: int, 
 	# it we still recurse (to count total_count) but skip the per-node dict.
 	#
 	# Path build strategy depends on the read shape (identical output either way):
-	#   * Full reads (limit <= 0, e.g. the godot://scene/hierarchy resource) thread
-	#     the parent's clean path down the DFS — each node's path is one O(1) concat
-	#     reusing the descent, instead of McpScenePath.from_node's two native walks
-	#     back up (is_ancestor_of + get_path_to). Benchmarked ~1.8x faster on a
-	#     ~1.5k-node tree, up to ~5x on deep chains.
-	#   * Paginated reads (limit > 0) keep from_node for just the windowed nodes:
-	#     threading would concatenate a path for every node (all are still visited
-	#     for total_count), which benchmarks ~20% slower for a small window.
-	var incremental := limit <= 0
+	#   * A whole-tree read (offset == 0 and limit <= 0 — the resource-style read
+	#     backing godot://scene/hierarchy) threads the parent's clean path down the
+	#     DFS: each node's path is one O(1) concat reusing the descent, instead of
+	#     McpScenePath.from_node's two native walks back up (is_ancestor_of +
+	#     get_path_to). Benchmarked ~1.8x faster on a ~1.5k-node tree, up to ~5x on
+	#     deep chains.
+	#   * Any windowed read (limit > 0, or an offset > 0 skip) keeps from_node for
+	#     just the emitted nodes: threading would concatenate a path for every node
+	#     visited for total_count, which benchmarks ~20% slower for a small window.
+	#
+	# `node_path` is self-seeded at the scene root below, so a caller cannot leave
+	# a full read unseeded (it has no default — pass "" for windowed reads).
+	var incremental := limit <= 0 and offset == 0
+	if incremental and node == scene_root:
+		node_path = "/" + String(scene_root.name)
 	var in_window := idx >= offset and (limit <= 0 or idx < offset + limit)
 	if in_window:
 		out.append({

--- a/test_project/tests/test_scene.gd
+++ b/test_project/tests/test_scene.gd
@@ -120,6 +120,33 @@ func test_scene_tree_contains_expected_nodes() -> void:
 	assert_contains(names, "TriggerZone")
 
 
+func test_scene_tree_full_read_builds_clean_scene_paths() -> void:
+	## Full reads (limit <= 0) build paths by threading the prefix down the DFS.
+	## Pin the exact format against the known fixture, including a nested node.
+	var result := _handler.get_scene_tree({"depth": 10})
+	var path_by_name := {}
+	for node: Dictionary in result.data.nodes:
+		path_by_name[node.name] = node.path
+	assert_eq(path_by_name["Main"], "/Main", "root path")
+	assert_eq(path_by_name["Camera3D"], "/Main/Camera3D", "direct child path")
+	assert_eq(path_by_name["Ground"], "/Main/World/Ground", "nested descendant path")
+
+
+func test_scene_tree_full_and_paginated_paths_agree() -> void:
+	## The full read threads the prefix down the DFS; a paginated read (limit > 0)
+	## builds paths via McpScenePath.from_node. The two strategies must produce
+	## byte-identical node dicts — this is what makes the perf branch safe.
+	var full := _handler.get_scene_tree({"depth": 10})
+	var total: int = full.data.total_count
+	var paged := _handler.get_scene_tree({"depth": 10, "limit": total})
+	assert_eq(paged.data.nodes.size(), full.data.nodes.size(), "same node count")
+	for i in full.data.nodes.size():
+		assert_eq(full.data.nodes[i].path, paged.data.nodes[i].path,
+			"path mismatch at index %d (full vs paginated)" % i)
+		assert_eq(full.data.nodes[i].name, paged.data.nodes[i].name)
+		assert_eq(full.data.nodes[i].type, paged.data.nodes[i].type)
+
+
 func test_scene_tree_depth_zero_returns_only_root() -> void:
 	var result := _handler.get_scene_tree({"depth": 0})
 	assert_eq(result.data.nodes.size(), 1, "Depth 0 should return only root")


### PR DESCRIPTION
## Summary

`get_scene_tree` (backing `scene_get_hierarchy` and the `godot://scene/hierarchy` resource) builds a clean scene path for each materialized node with `McpScenePath.from_node`, which walks **back up** the tree twice — `is_ancestor_of` + `get_path_to` — so a full-tree read is effectively O(n·depth).

But the walk is *already descending* from the root, so it knows each node's path prefix. This threads that prefix down the DFS: a child's path is `parent_path + "/" + name` — one O(1) concat, no walk back up.

The catch (measured, not assumed): threading helps a **full** read (every node emitted) but *hurts* a **paginated** read, because it would concat a path for every node — and every node is still visited for `total_count` — while `from_node` only runs for the small in-window set. So this branches on the read shape:

- **`limit <= 0` (full read** — the resource form, `scene_hierarchy_resource_data`): thread the prefix.
- **`limit > 0` (paginated tool call)**: unchanged, keep `from_node` for the window.

Output is **byte-identical** between the two paths.

## Correctness

`test_project/tests/test_scene.gd`:
- `test_scene_tree_full_and_paginated_paths_agree` — asserts a full read and a `limit == total_count` read produce identical node dicts (name/type/path), i.e. the threaded path exactly matches `from_node`.
- `test_scene_tree_full_read_builds_clean_scene_paths` — pins exact paths against the fixture, incl. the nested `Ground` → `/Main/World/Ground`.

Validated locally on Godot 4.7.1: headless `--check-only` parse, plus a direct `_walk_tree` probe confirming full-read and paginated paths agree across the fixture (`/Main`, `/Main/Camera3D`, `/Main/World/Ground`, …).

## Benchmark

Godot 4.7.1 headless, Apple M3 Pro, 1000 iters/scenario. `current` = `from_node` (baseline); `incremental` = thread-always; `branched` = what this PR ships. Correctness cross-check (`current`/`incremental`/`branched` agree) passed on all shapes before timing.

| scenario | current µs/call | incremental µs/call | branched µs/call | incremental/current | branched/current |
|---|---|---|---|---|---|
| chain-50 full | 135.79 | 52.00 | 52.54 | 0.38× | **0.39×** |
| chain-200 full | 1212.86 | 222.23 | 220.99 | 0.18× | **0.18×** |
| bushy-1555 full | 2439.53 | 1361.51 | 1432.00 | 0.56× | **0.59×** |
| bushy-1555 win50@0 | 679.05 | 818.39 | 675.32 | 1.21× | **0.99×** |
| bushy-1555 win50@600 | 657.36 | 789.93 | 666.37 | 1.20× | **1.01×** |

Reading it: `incremental` alone wins on full reads (up to ~5.5× on deep chains, ~1.8× on a realistic ~1.5k-node tree) but regresses paginated reads ~20%. `branched` (shipped) captures the full-read win **and** stays within noise of `current` on paginated (0.99–1.01×) — a win with no regression.

<details>
<summary>Benchmark script (<code>godot --headless --script scene_walk.gd</code>) + raw output</summary>

```gdscript
extends SceneTree
## scene_get_hierarchy walk: current from_node vs incremental prefix-threading
## vs branched (shipped: incremental iff limit<=0, else current).

var _sink: Variant = null
var _trees := {}

func _initialize() -> void:
	var variants := {
		"current": _walk_current,
		"incremental": _walk_incremental,
		"branched": _walk_branched,
	}
	var c_bushy := _make_bushy(3, 3)
	var c_chain := _make_chain(6)
	var cases := [
		{"label": "bushy full", "args": [c_bushy, 0, 0, 100]},
		{"label": "bushy window", "args": [c_bushy, 5, 10, 100]},
		{"label": "bushy depth-cap", "args": [c_bushy, 0, 0, 2]},
		{"label": "chain full", "args": [c_chain, 0, 0, 100]},
		{"label": "chain window", "args": [c_chain, 2, 2, 100]},
	]
	var make_workload := func(label: String) -> Array: return _scenario_args(label)
	var sizes := ["chain-50 full", "chain-200 full", "bushy-1555 full",
		"bushy-1555 win50@0", "bushy-1555 win50@600"]
	var iters := 1000
	print(_env_line("scene walk; args = [root, offset, limit, max_depth]"))
	print("")
	var agree := _check_agreement(variants, cases)
	print("")
	_run_timings(variants, make_workload, sizes, iters)
	c_bushy.free(); c_chain.free()
	for k in _trees: (_trees[k] as Node).free()
	if not agree: push_error("candidates disagree")
	quit(0 if agree else 1)

func _walk_current(root: Node, offset: int, limit: int, max_depth: int) -> Array:
	var out: Array = []; var idx: Array[int] = [0]
	_wc(root, out, 0, max_depth, root, offset, limit, idx); return out

func _wc(node: Node, out: Array, depth: int, max_depth: int, scene_root: Node, offset: int, limit: int, idx: Array[int]) -> void:
	if depth > max_depth: return
	var i: int = idx[0]; idx[0] = i + 1
	if i >= offset and (limit <= 0 or i < offset + limit):
		out.append({"name": node.name, "type": node.get_class(),
			"path": _from_node(node, scene_root), "children_count": node.get_child_count()})
	for child in node.get_children():
		_wc(child, out, depth + 1, max_depth, scene_root, offset, limit, idx)

func _from_node(node: Node, scene_root: Node) -> String:
	if scene_root == null or node == null: return ""
	if node == scene_root: return "/" + scene_root.name
	if not scene_root.is_ancestor_of(node): return ""
	return "/" + scene_root.name + "/" + str(scene_root.get_path_to(node))

func _walk_incremental(root: Node, offset: int, limit: int, max_depth: int) -> Array:
	var out: Array = []; var idx: Array[int] = [0]
	_wi(root, "/" + String(root.name), out, 0, max_depth, offset, limit, idx); return out

func _walk_branched(root: Node, offset: int, limit: int, max_depth: int) -> Array:
	if limit <= 0: return _walk_incremental(root, offset, limit, max_depth)
	return _walk_current(root, offset, limit, max_depth)

func _wi(node: Node, node_path: String, out: Array, depth: int, max_depth: int, offset: int, limit: int, idx: Array[int]) -> void:
	if depth > max_depth: return
	var i: int = idx[0]; idx[0] = i + 1
	if i >= offset and (limit <= 0 or i < offset + limit):
		out.append({"name": node.name, "type": node.get_class(),
			"path": node_path, "children_count": node.get_child_count()})
	for child in node.get_children():
		_wi(child, node_path + "/" + String(child.name), out, depth + 1, max_depth, offset, limit, idx)

func _make_chain(depth: int) -> Node:
	var root := Node.new(); root.name = "Main"; var cur := root
	for i in depth:
		var c := Node.new(); c.name = "Child%d" % i; cur.add_child(c); cur = c
	return root

func _make_bushy(branch: int, depth: int) -> Node:
	var root := Node.new(); root.name = "Main"; _grow(root, branch, depth); return root

func _grow(parent: Node, branch: int, depth: int) -> void:
	if depth <= 0: return
	for i in branch:
		var c := Node.new(); c.name = "N%d" % i; parent.add_child(c); _grow(c, branch, depth - 1)

func _scenario_args(label: String) -> Array:
	match label:
		"chain-50 full": return [_tree(label, 50, 0), 0, 0, 1000]
		"chain-200 full": return [_tree(label, 200, 0), 0, 0, 1000]
		"bushy-1555 full": return [_tree(label, 6, 4), 0, 0, 100]
		"bushy-1555 win50@0": return [_tree(label, 6, 4), 0, 50, 100]
		"bushy-1555 win50@600": return [_tree(label, 6, 4), 600, 50, 100]
	return [_tree(label, 3, 3), 0, 0, 100]

func _tree(label: String, a: int, b: int) -> Node:
	if not _trees.has(label):
		_trees[label] = _make_chain(a) if b == 0 else _make_bushy(a, b)
	return _trees[label]

func _env_line(note: String) -> String:
	var v: Dictionary = Engine.get_version_info()
	return "env: Godot %s headless | %s | %s | %s" % [v.get("string","?"), OS.get_name(), OS.get_processor_name(), note]

func _check_agreement(variants: Dictionary, cases: Array) -> bool:
	var names: Array = variants.keys(); var baseline: String = names[0]; var all_ok := true
	print("correctness cross-check (baseline = %s):" % baseline)
	for case in cases:
		var args: Array = case["args"]
		var base_val: Variant = (variants[baseline] as Callable).callv(args); var ok := true
		for n in names:
			if n == baseline: continue
			if (variants[n] as Callable).callv(args) != base_val: ok = false
		if not ok: all_ok = false
		print("  %-18s %d nodes  -> %s" % [str(case["label"]), (base_val as Array).size(), "OK" if ok else "MISMATCH"])
	print("correctness: %s" % ("ALL AGREE" if all_ok else "MISMATCH FOUND"))
	return all_ok

func _run_timings(variants: Dictionary, make_workload: Callable, sizes: Array, iters: int) -> void:
	var names: Array = variants.keys(); var baseline: String = names[0]
	var header := "| scenario |"
	for n in names: header += " %s µs/call |" % n
	for n in names:
		if n != baseline: header += " %s/%s |" % [n, baseline]
	print("timing: %d iters per variant per scenario" % iters)
	print(header)
	print("|" + "---|".repeat(1 + names.size() + (names.size() - 1)))
	for size in sizes:
		var args: Array = make_workload.call(size); var per_call := {}
		for n in names:
			var cb: Callable = variants[n]
			for _w in range(mini(iters / 10, 5000)): _sink = cb.callv(args)
			var t0 := Time.get_ticks_usec()
			for _i in iters: _sink = cb.callv(args)
			per_call[n] = float(Time.get_ticks_usec() - t0) / float(iters)
		var row := "| %s |" % str(size)
		for n in names: row += " %.2f |" % float(per_call[n])
		for n in names:
			if n != baseline:
				var base: float = per_call[baseline]
				row += " %.2f× |" % ((float(per_call[n]) / base) if base > 0.0 else 0.0)
		print(row)
```

Raw output:

```
env: Godot 4.7.1-stable (official) headless | macOS | Apple M3 Pro | scene walk; args = [root, offset, limit, max_depth]
correctness cross-check (baseline = current):
  bushy full         40 nodes  -> OK
  bushy window       10 nodes  -> OK
  bushy depth-cap    13 nodes  -> OK
  chain full         7 nodes  -> OK
  chain window       2 nodes  -> OK
correctness: ALL AGREE
timing: 1000 iters per variant per scenario
| scenario | current µs/call | incremental µs/call | branched µs/call | incremental/current | branched/current |
| chain-50 full | 135.79 | 52.00 | 52.54 | 0.38× | 0.39× |
| chain-200 full | 1212.86 | 222.23 | 220.99 | 0.18× | 0.18× |
| bushy-1555 full | 2439.53 | 1361.51 | 1432.00 | 0.56× | 0.59× |
| bushy-1555 win50@0 | 679.05 | 818.39 | 675.32 | 1.21× | 0.99× |
| bushy-1555 win50@600 | 657.36 | 789.93 | 666.37 | 1.20× | 1.01× |
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scene tree reads so node `path` values are consistently formatted across full and paginated results.
  * Ensured nested descendants retain correct paths during full scene tree retrieval, while paginated reads produce matching node data.
* **Tests**
  * Added new test coverage to verify exact scene-path formatting for full reads and to confirm full vs paginated path/name/type agreement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->