### PR TITLE
Bound spawn fast-exit re-adoption to one attempt per recovery

### DIFF
--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -1114,6 +1114,13 @@ static func _crash_body_for_state(state: int, server_status: Dictionary = {}) ->
 				return foreign_message
 			return "Another process is already bound to port %d. Pick a free port or stop the other process." % port
 		ServerStateScript.CRASHED:
+			## #805: a specific crash diagnosis from the lifecycle (e.g. the
+			## flapping-occupant latch) beats the generic launch-mode copy.
+			## Generic crash paths clear the message, so stale text from an
+			## earlier state can't leak in here.
+			var crash_message := str(server_status.get("message", ""))
+			if not crash_message.is_empty():
+				return crash_message
 			## Both spawn attempts failed on the uvx tier — stock releases:
 			## PyPI lag. Local builds (version with +metadata): almost always the
 			## dev venv was not found (unresolved junction/symlink) so uvx tried

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -68,11 +68,20 @@ var _connection_blocked: bool = false
 var _refresh_retried: bool = false
 
 ## One-shot guard for the spawn-lost-port-race re-adoption (see
-## `_diagnose_spawn_fast_exit`). Reset at the top of `start_server` like
-## `_refresh_retried`, so each walk gets one re-adopt budget; a second
-## fast exit in the same walk falls through to the legacy CRASHED
-## diagnosis instead of re-walking forever.
+## `_diagnose_spawn_fast_exit`). #805: the budget is per RECOVERY, not per
+## walk — a walk the re-adopt arm itself triggered must NOT refresh it
+## (`_readopt_walk_pending` skips the top-of-walk reset), or a flapping
+## godot-ai occupant sustains spawn → fast-exit → re-walk forever. The
+## budget refreshes on the paths that prove recovery: a fresh
+## user/plugin-initiated walk, a successful `adopt_compatible_server`,
+## or a spawn that survives to publish its pid-file.
 var _readopt_after_spawn_exit_retried: bool = false
+
+## #805: set by the re-adopt arm just before it re-runs `start_server`,
+## consumed by the top of `_start_server_impl` to skip that walk's
+## `_readopt_after_spawn_exit_retried` reset. Never true outside that
+## one triggered walk.
+var _readopt_walk_pending: bool = false
 
 ## Bounded deadline for the foreign-port adoption-confirmation watcher.
 ## Zero when disarmed.
@@ -655,7 +664,16 @@ func _start_server_impl(async_gen: int) -> void:
 		return
 
 	_refresh_retried = false
-	_readopt_after_spawn_exit_retried = false
+	if _readopt_walk_pending:
+		## #805: this walk was triggered by the fast-exit re-adopt arm.
+		## Keep the spent budget: if this walk ends up spawning and that
+		## spawn fast-exits against a live godot-ai again, the occupant is
+		## flapping and the diagnosis must latch terminal instead of
+		## re-walking forever. Recovery paths (adoption, healthy spawn)
+		## refresh the budget explicitly.
+		_readopt_walk_pending = false
+	else:
+		_readopt_after_spawn_exit_retried = false
 	_conflict_port = 0
 
 	var port := ClientConfigurator.http_port()
@@ -943,6 +961,7 @@ func _start_server_impl(async_gen: int) -> void:
 		print("MCP | started server (PID %d, v%s): %s %s%s" % [spawned_pid, current_version, cmd, " ".join(args), suffix])
 		_host._start_server_watch()
 	else:
+		_server_status_message = ""
 		set_terminal_diagnosis(McpServerStateScript.CRASHED)
 		_startup_path = McpStartupPathScript.CRASHED
 		push_warning("MCP | failed to start server")
@@ -965,6 +984,9 @@ func check_server_health() -> void:
 		## authoritative PID; future adoption requires the recorded PID to be
 		## the actual live listener (#759).
 		_host._write_managed_server_record(real_pid, _expected_server_version(), _server_keep_alive)
+		## #805: the spawn survived to publish its pid-file — proven
+		## recovery, so the fast-exit re-adopt budget refreshes.
+		_readopt_after_spawn_exit_retried = false
 	elif not PortResolver.pid_alive(spawn_pid):
 		if elapsed >= int(_host.SPAWN_GRACE_MS) and not McpServerStateScript.is_terminal_diagnosis(_server_state):
 			_diagnose_spawn_fast_exit(elapsed)
@@ -982,8 +1004,13 @@ func check_server_health() -> void:
 ##      and the token it staged in the record is now stale). Re-run the
 ##      startup walk so the adopt/recover branch handles the survivor —
 ##      latching CRASHED here left the connection redialing forever with
-##      a token the surviving server rejects (close code 4003). One-shot
-##      per walk via `_readopt_after_spawn_exit_retried`.
+##      a token the surviving server rejects (close code 4003). One
+##      re-adopt per recovery via `_readopt_after_spawn_exit_retried`
+##      (#805): the triggered walk preserves the spent budget, so a
+##      flapping occupant (alive at each fast-exit probe, gone by each
+##      walk's probes — sustained multi-editor churn) latches a specific
+##      CRASHED diagnosis on the second round instead of re-walking
+##      forever.
 ##   2. #647: foreign process on the HTTP or WS port -> FOREIGN_PORT with
 ##      an actionable message (we can't read the child's "port already in
 ##      use" stderr). Checked before the --refresh retry: respawning
@@ -994,21 +1021,44 @@ func _diagnose_spawn_fast_exit(elapsed: int) -> void:
 	var live: Dictionary = _host._probe_live_server_status_for_port(
 		ClientConfigurator.http_port()
 	)
-	if _live_status_identifies_godot_ai(live) and not _readopt_after_spawn_exit_retried:
-		_readopt_after_spawn_exit_retried = true
-		_host._log_buffer.log(
-			"server exited after %dms but a live godot-ai server answers on port %d — re-running adoption"
-			% [elapsed, ClientConfigurator.http_port()]
-		)
+	if _live_status_identifies_godot_ai(live):
+		if not _readopt_after_spawn_exit_retried:
+			_readopt_after_spawn_exit_retried = true
+			_readopt_walk_pending = true
+			_host._log_buffer.log(
+				"server exited after %dms but a live godot-ai server answers on port %d — re-running adoption"
+				% [elapsed, ClientConfigurator.http_port()]
+			)
+			_host._stop_server_watch()
+			_server_pid = -1
+			## Clear the spawn guard so the re-walk isn't GUARDED away. The
+			## walk's adopt arm re-sets it and fixes the stale token/record
+			## (external adoption drops both; managed adoption re-records).
+			_host._server_started_this_session = false
+			## Fire-and-forget (mirrors force_restart_server): the walk is a
+			## coroutine in production; its continuation lives on the manager.
+			start_server()
+			return
+		## #805: the re-adopt budget is spent and a live godot-ai still
+		## answers while our spawns keep dying — a flapping occupant
+		## (another editor's server starting/stopping under it). Re-walking
+		## or respawning can only repeat the cycle; latch a terminal
+		## diagnosis that names the actual conflict. Reload Plugin (a fresh
+		## walk) refreshes the budget for a deliberate retry.
+		_server_exit_ms = elapsed
+		_server_status_message = (
+			"The spawned server keeps exiting while another godot-ai server "
+			+ "answers on port %d, and re-adoption was already attempted. "
+			+ "Another editor may be repeatedly starting/stopping a server on "
+			+ "this port. Stop the other process or pick a different port, "
+			+ "then click Reload Plugin."
+		) % ClientConfigurator.http_port()
+		set_terminal_diagnosis(McpServerStateScript.CRASHED)
+		disarm_version_check()
+		_host._update_process_enabled()
+		_host._log_buffer.log(str(_server_status_message))
+		push_warning("MCP | %s" % _server_status_message)
 		_host._stop_server_watch()
-		_server_pid = -1
-		## Clear the spawn guard so the re-walk isn't GUARDED away. The
-		## walk's adopt arm re-sets it and fixes the stale token/record
-		## (external adoption drops both; managed adoption re-records).
-		_host._server_started_this_session = false
-		## Fire-and-forget (mirrors force_restart_server): the walk is a
-		## coroutine in production; its continuation lives on the manager.
-		start_server()
 		return
 	var conflict := _diagnose_spawn_port_conflict(live)
 	if not conflict.is_empty():
@@ -1027,6 +1077,10 @@ func _diagnose_spawn_fast_exit(elapsed: int) -> void:
 		respawn_with_refresh()
 		return
 	_server_exit_ms = elapsed
+	## Generic crash: clear any stale per-state message so the dock's
+	## CRASHED body falls back to its launch-mode copy instead of text
+	## from an earlier diagnosis.
+	_server_status_message = ""
 	set_terminal_diagnosis(McpServerStateScript.CRASHED)
 	disarm_version_check()
 	_host._update_process_enabled()
@@ -1114,6 +1168,7 @@ func respawn_with_refresh() -> void:
 	else:
 		## OS.create_process returned -1 on the retry — surface CRASHED
 		## rather than loop. `_refresh_retried` is already true.
+		_server_status_message = ""
 		set_terminal_diagnosis(McpServerStateScript.CRASHED)
 		disarm_version_check()
 		_host._update_process_enabled()
@@ -1129,6 +1184,10 @@ func adopt_compatible_server(
 ) -> String:
 	_server_actual_name = "godot-ai"
 	_can_recover_incompatible = false
+	## #805: adoption (managed or external) is a proven recovery — the
+	## session now has a live compatible server. Refresh the fast-exit
+	## re-adopt budget so a later, unrelated port race can heal again.
+	_readopt_after_spawn_exit_retried = false
 	if record_version == current_version and owner > 0 and record_owns_listener:
 		## Managed adoption keeps the record's token (loaded into
 		## _ws_auth_token at plugin startup) — the running server was

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -788,6 +788,25 @@ func test_crashed_body_mentions_pypi_propagation_on_uvx_tier() -> void:
 		assert_contains(body, "output log", "Non-uvx body should still point at Godot's traceback")
 
 
+func test_crashed_body_prefers_lifecycle_message() -> void:
+	## #805: a specific crash diagnosis from the lifecycle (the flapping-
+	## occupant latch) must render verbatim instead of the generic
+	## launch-mode copy. Generic crash paths clear the message, so this
+	## preference can't surface stale text.
+	var message := "The spawned server keeps exiting while another godot-ai server answers on port 8000, and re-adoption was already attempted."
+	var body := McpDockScript._crash_body_for_state(
+		McpServerState.CRASHED, {"message": message}
+	)
+	assert_eq(body, message)
+
+
+func test_crashed_body_without_message_keeps_launch_mode_copy() -> void:
+	var body := McpDockScript._crash_body_for_state(McpServerState.CRASHED, {"message": ""})
+	assert_false(body.is_empty())
+	assert_false(body.contains("another godot-ai server"),
+		"an empty lifecycle message must fall back to the launch-mode copy")
+
+
 func test_foreign_port_body_prefers_lifecycle_message() -> void:
 	## #647: when the post-crash probe diagnosed which port a foreign
 	## process holds, the crash body must render that message verbatim

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -731,6 +731,7 @@ func test_spawn_fast_exit_readopts_live_godot_ai_survivor() -> void:
 	var killed := host.killed_targets.duplicate()
 	var stop_watch_calls := host.stop_watch_calls
 	var readopt_guard: bool = manager._readopt_after_spawn_exit_retried
+	var walk_pending: bool = manager._readopt_walk_pending
 	var token_after: String = GodotAiPlugin._ws_auth_token
 	host.free()
 	GodotAiPlugin._server_started_this_session = saved_guard
@@ -742,15 +743,18 @@ func test_spawn_fast_exit_readopts_live_godot_ai_survivor() -> void:
 	assert_true(killed.is_empty(), "re-adoption must not kill the survivor")
 	assert_true(stop_watch_calls >= 1, "the dead spawn's watch must stop")
 	assert_false(readopt_guard,
-		"the re-walk must reset the one-shot so a later walk keeps its budget")
+		"successful adoption must refresh the re-adopt budget (#805)")
+	assert_false(walk_pending,
+		"the triggered walk must consume the pending flag (#805)")
 	assert_eq(token_after, "",
 		"external re-adoption must drop the stale spawn token")
 
 
-func test_spawn_fast_exit_readopt_is_one_shot_per_walk() -> void:
-	## A consumed re-adopt budget must fall through to the legacy diagnosis
-	## (a godot-ai occupant is not a foreign conflict -> CRASHED) instead of
-	## re-walking forever.
+func test_spawn_fast_exit_latches_flapping_crash_when_budget_spent() -> void:
+	## #805 terminal bound: the budget was spent by an earlier fast exit and
+	## the triggered walk preserved it (see the walk-budget tests below), so
+	## a second fast exit against a live godot-ai occupant must latch a
+	## specific CRASHED diagnosis — never re-walk again.
 	var host := _ManagerHostStub.new()
 	host._log_buffer = McpLogBuffer.new()
 	host.port_in_use = true
@@ -764,12 +768,73 @@ func test_spawn_fast_exit_readopt_is_one_shot_per_walk() -> void:
 	var state := manager.get_state()
 	var exit_ms := int(manager._server_exit_ms)
 	var stop_watch_calls := host.stop_watch_calls
+	var probe_calls := host.probe_calls
+	var message: String = str(manager.get_status_dict().get("message", ""))
 	host.free()
 
 	assert_eq(state, McpServerState.CRASHED,
-		"second fast exit in one walk must latch CRASHED, not loop")
+		"a spent budget with a live godot-ai occupant must latch CRASHED, not loop")
 	assert_eq(exit_ms, 6000)
 	assert_eq(stop_watch_calls, 1)
+	assert_eq(probe_calls, 1, "the flapping latch must not trigger another walk or probe")
+	assert_contains(message, "another godot-ai server",
+		"the diagnosis must name the flapping occupant, not a generic crash")
+	assert_contains(message, "Reload Plugin",
+		"the diagnosis must point at the deliberate-retry action")
+
+
+func test_triggered_walk_preserves_readopt_budget() -> void:
+	## #805: a walk triggered by the re-adopt arm must NOT refresh the
+	## budget at its top — if it fails to adopt (here: the occupant turned
+	## incompatible by walk time) and later spawns fast-exit again, the
+	## flapping latch above must be reachable. Drives the REAL walk.
+	var saved_guard: bool = GodotAiPlugin._server_started_this_session
+	GodotAiPlugin._server_started_this_session = false
+	var host := _ManagerHostStub.new()
+	host._log_buffer = McpLogBuffer.new()
+	host._connection = null
+	host.port_in_use = true
+	host.live_status = {"name": "godot-ai", "version": "0.0.1", "ws_port": 9500, "status_code": 200}
+	var manager := McpServerLifecycleManagerScript.new(host)
+	manager._readopt_after_spawn_exit_retried = true
+	manager._readopt_walk_pending = true
+
+	manager.start_server()
+	var state := manager.get_state()
+	var guard_after: bool = manager._readopt_after_spawn_exit_retried
+	var pending_after: bool = manager._readopt_walk_pending
+	host.free()
+	GodotAiPlugin._server_started_this_session = saved_guard
+
+	assert_eq(state, McpServerState.INCOMPATIBLE,
+		"fixture: the walk must terminate on the incompatible occupant, not spawn")
+	assert_true(guard_after,
+		"a re-adopt-triggered walk must preserve the spent budget (#805)")
+	assert_false(pending_after,
+		"the pending flag is one-shot: consumed by the walk it triggered")
+
+
+func test_fresh_walk_resets_readopt_budget() -> void:
+	## Complement of the preservation test: a user/plugin-initiated walk
+	## (no pending flag) refreshes the budget, so a deliberate Reload
+	## Plugin after the flapping latch gets a new re-adopt attempt.
+	var saved_guard: bool = GodotAiPlugin._server_started_this_session
+	GodotAiPlugin._server_started_this_session = false
+	var host := _ManagerHostStub.new()
+	host._log_buffer = McpLogBuffer.new()
+	host._connection = null
+	host.port_in_use = true
+	host.live_status = {"name": "godot-ai", "version": "0.0.1", "ws_port": 9500, "status_code": 200}
+	var manager := McpServerLifecycleManagerScript.new(host)
+	manager._readopt_after_spawn_exit_retried = true
+
+	manager.start_server()
+	var guard_after: bool = manager._readopt_after_spawn_exit_retried
+	host.free()
+	GodotAiPlugin._server_started_this_session = saved_guard
+
+	assert_false(guard_after,
+		"a fresh walk must reset the re-adopt budget at its top")
 
 
 func test_spawn_fast_exit_foreign_occupant_reuses_probe_snapshot() -> void:


### PR DESCRIPTION
## Summary

Fixes #805 (post-merge finding on #798).

#798's re-adopt guard (`_readopt_after_spawn_exit_retried`) was reset at the top of **every** startup walk — including the walk the re-adopt arm itself triggered — so the documented bound ("a second fast exit in the same walk falls through to the legacy CRASHED diagnosis") never held on the main path: every post-re-adopt spawn belongs to a fresh walk with a fresh guard. Under a flapping godot-ai occupant — alive at each fast-exit probe, gone by each walk's probes, i.e. sustained multi-editor churn, the exact scenario #798 hardens — *spawn → fast exit → re-walk* could cycle unbounded and nothing ever latched a terminal state.

## Change

The budget is now **per recovery, not per walk**:

- New `_readopt_walk_pending`, set by the re-adopt arm just before it re-runs `start_server`, is consumed at the top of `_start_server_impl` to skip that one triggered walk's guard reset.
- The budget refreshes only on the paths that prove recovery:
  - a fresh user/plugin-initiated walk (Reload Plugin / dock Restart / editor boot),
  - a successful `adopt_compatible_server` (managed or external),
  - a spawn that survives to publish its pid-file.
- When the budget is spent and a live godot-ai still answers over a dead spawn, the diagnosis latches **CRASHED with a flapping-occupant message** naming the port and the deliberate-retry action, instead of re-walking. The dock's CRASHED body now prefers a non-empty lifecycle message (mirroring the FOREIGN_PORT pattern); every generic crash path clears `_server_status_message`, so stale text from an earlier diagnosis can't leak into that preference.

## Tests

The old one-shot test hand-set the guard and never drove the triggered walk that reset it — exactly the interaction that broke the bound. Replaced/extended with real-sequence coverage in `test_server_lifecycle.gd`:

- `test_triggered_walk_preserves_readopt_budget` — drives a REAL re-adopt-triggered walk that fails to adopt (occupant turned incompatible by walk time): the spent budget survives, the pending flag is consumed.
- `test_fresh_walk_resets_readopt_budget` — a non-triggered walk refreshes the budget at its top.
- `test_spawn_fast_exit_latches_flapping_crash_when_budget_spent` — spent budget + live godot-ai occupant → CRASHED with the flapping message, no second walk or probe.
- `test_spawn_fast_exit_readopts_live_godot_ai_survivor` — extended: adoption refreshes the budget and consumes the pending flag.
- `test_dock.gd`: CRASHED body renders a non-empty lifecycle message verbatim; empty message keeps the launch-mode copy.

## Validation

- Full Godot suite against a live headless editor + server pair: **1959/1984 passed, 0 failed, 25 skipped** (same skips as main).
- `script/ci-check-gdscript` (headless `--import` parse validation): all files OK.
- `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FrnFNat8k16QNZfaUBiLto

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrnFNat8k16QNZfaUBiLto)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crash diagnostics by displaying specific server-provided error messages instead of generic or outdated text.
  * Improved recovery when servers exit unexpectedly, preventing repeated unsuccessful re-adoption attempts.
  * Correctly clears stale error messages after successful recovery or new launch attempts.
  * Detects repeated server flapping and provides clearer guidance to reload the plugin.

* **Tests**
  * Added coverage for crash messaging, recovery behavior, retry limits, and fresh launch attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->