### PR TITLE
godot://scene/hierarchy: cap the resource read at 100 nodes

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -256,7 +256,7 @@ don't, and the only path that supports `session_id` pinning.
 | `godot://selection/current` | Current editor selection |
 | `godot://logs/recent` | Last 100 plugin log lines |
 | `godot://scene/current` | Active scene path + project + play state |
-| `godot://scene/hierarchy` | Full scene hierarchy from the active editor |
+| `godot://scene/hierarchy` | Scene hierarchy from the active editor (first 100 nodes; sets `resource_truncated` + hint when larger — use the `scene_get_hierarchy` tool to page) |
 | `godot://node/{path}/properties` | All properties of a node by scene path |
 | `godot://node/{path}/children` | Direct children (name, type, path each) |
 | `godot://node/{path}/groups` | Group memberships for a node |

--- a/src/godot_ai/handlers/scene.py
+++ b/src/godot_ai/handlers/scene.py
@@ -90,9 +90,28 @@ async def current_scene_resource_data(runtime: DirectRuntime) -> dict:
     }
 
 
+## The godot://scene/hierarchy resource takes no arguments and cannot paginate,
+## so a full read of a large scene would dump an unbounded node list into the
+## reader's context. Cap it at the same node budget the tool defaults to (100)
+## and stamp a truncated read so the reader knows to reach for the
+## scene_get_hierarchy tool (offset/limit, or a narrower depth) for the rest.
+_RESOURCE_HIERARCHY_NODE_CAP = 100
+
+
 async def scene_hierarchy_resource_data(runtime: DirectRuntime) -> dict:
-    ## Route through scene_get_hierarchy (limit=0 => full tree) rather than
-    ## calling the plugin directly, so the resource returns the same paginated
-    ## shape (total_count/offset/limit/has_more) regardless of plugin version —
-    ## the old-plugin fallback normalizes it. (CodeRabbit)
-    return await scene_get_hierarchy(runtime, depth=10, offset=0, limit=0)
+    ## Route through scene_get_hierarchy rather than calling the plugin directly,
+    ## so the resource returns the same paginated shape
+    ## (total_count/offset/limit/has_more) regardless of plugin version — the
+    ## old-plugin fallback normalizes it. (CodeRabbit)
+    result = await scene_get_hierarchy(
+        runtime, depth=10, offset=0, limit=_RESOURCE_HIERARCHY_NODE_CAP
+    )
+    if result.get("has_more"):
+        total = result.get("total_count")
+        result["resource_truncated"] = True
+        result["hint"] = (
+            f"Scene tree has {total} nodes; this resource returns the first "
+            f"{_RESOURCE_HIERARCHY_NODE_CAP}. Use the scene_get_hierarchy tool with "
+            "offset/limit to page the rest, or a smaller depth to scope it."
+        )
+    return result

--- a/src/godot_ai/resources/scenes.py
+++ b/src/godot_ai/resources/scenes.py
@@ -20,6 +20,11 @@ def register_scene_resources(mcp: FastMCP) -> None:
 
     @mcp.resource("godot://scene/hierarchy", mime_type="application/json")
     async def get_scene_hierarchy(ctx: Context) -> dict[str, Any]:
-        """Full scene tree hierarchy from the active Godot editor."""
+        """Scene tree hierarchy from the active Godot editor (first 100 nodes).
+
+        A resource URI takes no arguments, so this read is capped; a truncated
+        result sets `resource_truncated` with a hint. Use the
+        `scene_get_hierarchy` tool for offset/limit pagination or a scoped depth.
+        """
         runtime = DirectRuntime.from_context(ctx)
         return await safe_payload(scene_handlers.scene_hierarchy_resource_data(runtime))

--- a/tests/integration/test_mcp_resources.py
+++ b/tests/integration/test_mcp_resources.py
@@ -95,6 +95,9 @@ class TestSceneHierarchyResource:
             cmd = await plugin.recv_command()
             assert cmd["command"] == "get_scene_tree"
             assert cmd["params"]["depth"] == 10
+            ## The resource caps its read (it can't paginate) rather than
+            ## requesting the whole tree (limit=0).
+            assert cmd["params"]["limit"] == 100
             await plugin.send_response(cmd["request_id"], {"nodes": nodes, "total_count": 2})
 
         task = asyncio.create_task(respond())
@@ -104,6 +107,40 @@ class TestSceneHierarchyResource:
         data = _parse_resource(result)
         assert len(data["nodes"]) == 2
         assert data["nodes"][0]["name"] == "Main"
+        ## A within-cap tree is not flagged truncated.
+        assert "resource_truncated" not in data
+
+    async def test_large_tree_is_capped_and_hinted(self, mcp_stack):
+        client, plugin = mcp_stack
+        nodes = [
+            {"name": f"N{i}", "type": "Node", "path": f"/Main/N{i}"} for i in range(100)
+        ]
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "get_scene_tree"
+            ## Plugin paginated server-side and reports more remain.
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "nodes": nodes,
+                    "total_count": 250,
+                    "offset": 0,
+                    "limit": 100,
+                    "has_more": True,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.read_resource("godot://scene/hierarchy")
+        await task
+
+        data = _parse_resource(result)
+        assert len(data["nodes"]) == 100
+        assert data["has_more"] is True
+        assert data["resource_truncated"] is True
+        assert "250" in data["hint"]
+        assert "scene_get_hierarchy" in data["hint"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_mcp_resources.py
+++ b/tests/integration/test_mcp_resources.py
@@ -84,7 +84,7 @@ class TestSceneCurrentResource:
 
 
 class TestSceneHierarchyResource:
-    async def test_returns_full_tree(self, mcp_stack):
+    async def test_within_cap_returns_all_untruncated(self, mcp_stack):
         client, plugin = mcp_stack
         nodes = [
             {"name": "Main", "type": "Node3D", "path": "/Main"},
@@ -140,6 +140,34 @@ class TestSceneHierarchyResource:
         assert data["has_more"] is True
         assert data["resource_truncated"] is True
         assert "250" in data["hint"]
+        assert "scene_get_hierarchy" in data["hint"]
+
+    async def test_old_plugin_fallback_also_caps_and_hints(self, mcp_stack):
+        ## Old/skewed plugins ignore offset/limit and return the whole node list
+        ## with no `has_more`. scene_get_hierarchy's fallback then slices to the
+        ## cap and stamps `has_more`, so the resource must still truncate + hint
+        ## on that path too (Copilot).
+        client, plugin = mcp_stack
+        nodes = [
+            {"name": f"N{i}", "type": "Node", "path": f"/Main/N{i}"} for i in range(150)
+        ]
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "get_scene_tree"
+            ## No has_more / offset / limit in the response — the old-plugin shape.
+            await plugin.send_response(cmd["request_id"], {"nodes": nodes})
+
+        task = asyncio.create_task(respond())
+        result = await client.read_resource("godot://scene/hierarchy")
+        await task
+
+        data = _parse_resource(result)
+        assert len(data["nodes"]) == 100, "fallback must slice to the cap"
+        assert data["total_count"] == 150
+        assert data["has_more"] is True
+        assert data["resource_truncated"] is True
+        assert "150" in data["hint"]
         assert "scene_get_hierarchy" in data["hint"]
 
 


### PR DESCRIPTION
## Summary

The `godot://scene/hierarchy` resource routed through `scene_get_hierarchy(..., limit=0)` — a full, uncapped tree read. For a large scene that dumps an unbounded node list straight into the reader's context, and because a resource URI takes no arguments, the reader has **no way to page it down** (unlike the `scene_get_hierarchy` tool, which defaults to `limit=100`).

This caps the resource read at **100 nodes** — the same node budget used as the default across the tool surface (`api`, `filesystem`, `node`, `resource`, and the `scene_get_hierarchy` tool itself) — and, when the scene is larger, stamps the result so the reader knows it's truncated and where to go:

```json
{
  "nodes": [ /* first 100 */ ],
  "total_count": 250,
  "has_more": true,
  "resource_truncated": true,
  "hint": "Scene tree has 250 nodes; this resource returns the first 100. Use the scene_get_hierarchy tool with offset/limit to page the rest, or a smaller depth to scope it."
}
```

Within-cap scenes are unaffected (no `resource_truncated` flag). The `scene_get_hierarchy` **tool** is unchanged — it still paginates and still takes `limit=0` for a genuine full read.

## Why a cap rather than preserving "full"

Unlike `godot://class/{class_name}` (bounded metadata, where I pinned `sections="all"` to keep it full in a recent PR), a scene tree is unbounded and can be arbitrarily large, so "full" is the wrong default for a param-less resource. A signaled truncation + a pointer to the paginating tool is the honest resolution — the reader always learns the true `total_count` and how to get the rest.

Note: `100` is a named constant (`_RESOURCE_HIERARCHY_NODE_CAP`) chosen to match the pervasive default; easy to tune if you'd prefer a different overview budget.

## Tests

`tests/integration/test_mcp_resources.py`:
- Existing `test_returns_full_tree` now also asserts the resource forwards `limit=100` and that a within-cap tree is **not** flagged truncated.
- New `test_large_tree_is_capped_and_hinted` — a plugin response with `has_more=true`/`total_count=250` yields `resource_truncated=true` and a hint naming the total and the tool.

`ruff check` clean; the scene-hierarchy resource suite passes. Python-only change (no plugin/GDScript side); no benchmark relevant — this is a payload/token bound, not a hot-path perf change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the scene hierarchy resource to return only the first 100 nodes to improve responsiveness.
  - When more nodes are available, responses now signal truncation and include a hint to fetch additional nodes via the paging tool.
- **Documentation**
  - Clarified the 100-node cap, truncation behavior, and how to page through larger hierarchies.
- **Bug Fixes**
  - Improved truncation handling and messaging for hierarchies exceeding the response limit.
- **Tests**
  - Expanded integration coverage for within-cap, large-tree pagination, and legacy fallback behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->