### PR TITLE
Fix test_run transport starvation: cooperative servicing + run budget

### DIFF
--- a/docs/test-run-transport-starvation-plan.md
+++ b/docs/test-run-transport-starvation-plan.md
@@ -1,0 +1,414 @@
+# Plan v3: fix `test_run` transport starvation (MCP disconnect during long suites)
+
+Status: APPROVED for implementation — v3 with round-3 amendments folded in.
+v1 review: request changes (frame-yield concurrency blockers) → v2 removed
+frame-yielding. v2 review: request changes (poll() is not heartbeat-only;
+single-frame fallback unsafe) → v3 added drain-and-reject servicing and a
+hard stop/re-vet gate. v3 review: **approved** with three clarifications
+(drain-to-quiescence, discovery lifecycle, paused-response correction) —
+all folded in below. Dispositions: §8. Resolved decisions: §9.
+
+Origin: Discord report (SloppyMayor, 2026-07-21/22, Godot 4.7.1 + plugin
+3.0.5), diagnosis verified claim-by-claim against this repo at `764c9c4`.
+
+## 1. Problem (condensed)
+
+`run_tests` runs the whole suite synchronously on the editor main thread
+(`test_handler.gd:51` → `test_runner.gd:110-172`). The WebSocket is serviced
+only by `McpConnection._process` (`connection.gd:124-154`); the Python server
+uses `websockets` default heartbeats (20 s ping interval / 20 s timeout, no
+overrides at `websocket.py:140`). Any suite whose synchronous run exceeds
+~20–40 s starves the pong; the server closes the socket (1011), unregisters
+the session (`websocket.py:354-374`), and fails the in-flight `test_run`
+future with `ConnectionError`. The 120 s `TEST_RUN_TIMEOUT_SEC` never fires —
+the heartbeat always wins. Threshold is duration, not count: our
+63-suite/~2000-test corpus passes in CI; the reporter's 299 heavy tests
+(~107 s) cannot.
+
+## 2. Design evolution and the hard decision gate
+
+- **v1**: deferred, frame-yielding runner. Rejected: yielding editor frames
+  mid-suite turns snapshot-diff leak cleanup into a deletion path for
+  legitimate nodes, violates the no-caching-`get_edited_scene_root()` rule,
+  and needs an orphanable exclusive-run gate.
+- **v2**: synchronous runner + "heartbeat-only" cooperative `poll()`.
+  Rejected: **there is no heartbeat-only mode** — `WebSocketPeer.poll()`
+  buffers inbound application frames. Commands from other clients would
+  accumulate silently during a run and replay *stale* afterward (their
+  server-side futures are popped after the 5 s default timeout,
+  `websocket.py:430-455`) — exactly the "uncorrelatable surprise write"
+  that `dispatcher.clear_command_queue()` (#712) exists to prevent, plus a
+  packet-buffer exhaustion risk under flood.
+- **v3 (this plan)**: synchronous runner + cooperative servicing that
+  **drains and rejects**: every application frame received during a run is
+  answered immediately with a structured retryable busy error, never
+  buffered past the run, never dispatched.
+
+**Hard gate replacing v2's fallback clause:** the step-1 spike (§6 harness)
+must prove that cooperative `poll()`-based servicing keeps the session alive
+through a ~50 s run. If it does not, **Phase 1 stops and the plan returns to
+vetting** — the previously-sketched "await a single frame between tests"
+fallback is withdrawn entirely, because one frame yield runs
+`McpConnection._process` → drain → `dispatcher.tick()`, reviving every v1
+concurrency hazard (interleaving, cleanup deletion, root caching, autosave
+exposure, exclusive-run lifecycle). There is no safe in-plan fallback.
+
+## 3. Phase 1 design
+
+### D1: cooperative servicing = poll + drain-and-reject
+
+New `McpConnection` method, called only by the test runner via callback
+(doc-commented contract: exclusive-run servicing, not general use):
+
+```
+enum ServiceStatus { SERVICED, DISCONNECTED, PAUSED, BLOCKED }
+func service_transport_during_exclusive_run() -> ServiceStatus
+```
+
+- `connect_blocked` → `BLOCKED` (unreachable via MCP in practice — a blocked
+  connection never carried the command — treated like DISCONNECTED by the
+  runner).
+- `pause_processing` active → `PAUSED`, **without polling**. See §9 Q2: the
+  runner treats this as an abort-worthy invariant violation, because a
+  leaked pause at a between-test boundary would otherwise silently skip
+  every subsequent poll and recreate the exact starvation this plan fixes.
+- Otherwise: **drain to quiescence — never spill buffered packets to a
+  later checkpoint**. A full application-packet queue can prevent `poll()`
+  from reading deeper into the TCP stream (including a ping behind those
+  packets), and any deferred packet decays into a stale command. Loop:
+  1. `_peer.poll()`.
+  2. Drain and handle every currently available application packet.
+  3. `_peer.poll()` again now that inbound capacity is free.
+  4. Repeat until no packets remain (the flood cap guarantees termination).
+  5. If the cap is reached mid-loop, close with 1013 immediately.
+
+  Each drained packet is handled by kind:
+  - `handshake_ack` → existing ack handling.
+  - Malformed frame → existing warning + INVALID_PARAMS reply path.
+  - Valid command frame → **immediate rejection reply** over the socket:
+    top-level `EDITOR_NOT_READY`, `data.sub_code = EDITOR_TEST_RUNNING`,
+    `retryable = true`, hint: *"A test run is in progress on this editor;
+    retry when it completes, or fetch results afterward with
+    test_manage(op=\"results_get\")."* Readiness + error-watermark stamped
+    like the existing malformed-frame reply (`connection.gd:437-446`). No
+    dispatcher involvement, no execution, no allowlist — `get_test_results`
+    is also rejected (mid-run progress is Phase 2).
+  - Implementation shares parsing with `_handle_message` via an extracted
+    `_classify_message(raw)` helper — the normal path enqueues commands, the
+    service path rejects them; one parser, two sinks.
+- Return `DISCONNECTED` when the peer leaves `STATE_OPEN`.
+
+**Flood policy** (cap approved at review round 3): the counter counts
+**every application packet processed during exclusive servicing** — valid
+commands, malformed frames, and handshake-like frames alike — so no frame
+kind can evade it. It lives in a small mutable run-state dictionary owned
+by the runner and passed into the service callback (no connection-global
+begin/end state, so there is no lifecycle to leak or clean up). At **2048**
+cumulative packets the connection is closed
+(`_peer.close(1013, "command flood during test run")`) and `DISCONNECTED`
+is returned; the run aborts at that checkpoint with results preserved.
+Rationale for 2048: it leaves headroom under Godot 4.5's default
+`max_queued_packets` of 4096 (both directions) and sits above stormtest's
+~1000-call **default** workload (the brutal configuration is ~9000 and is
+expected to trip the cap — that is the cap working). Treat 2048 as
+telemetry- and benchmark-tunable in the implementation PR: if emitting 2048
+rejection envelopes materially extends a checkpoint, lower it.
+
+**Final checkpoint:** after the last test and before the handler builds its
+response, one more drain-to-quiescence pass so no already-buffered command
+survives into the post-run `_process` drain. Commands arriving *after* that
+final pass are genuinely fresh (their futures are still pending against
+5–15 s timeouts) and execute normally after the run — correlated, not stale.
+
+**Servicing checkpoints:** after each test, after each
+`suite_setup`/`suite_teardown`, after each suite's leak-cleanup pass, and
+between per-file `ResourceLoader.load()` calls in
+`test_handler._discover_suites()`.
+
+**Transport-loss reality check (per review):** if servicing observes
+`STATE_CLOSED`, `McpConnection._connected` remains `true` until the next
+`_process` pass, so the handler's normal response is not "skipped by the
+`_connected` check" — it reaches `_send_json`, whose `send_text` fails
+against the closed peer and returns `false`. Functionally fine; documented
+as the actual behavior, and tests assert the runner outcome, not send
+success.
+
+### D2: per-call time budget + explicit runner outcome contract
+
+- `src/godot_ai/handlers/testing.py`: raise `TEST_RUN_TIMEOUT_SEC` 120→300
+  and inject `params["timeout_budget_sec"] = TEST_RUN_TIMEOUT_SEC` into the
+  `run_tests` envelope — one shared constant, so the wire value and the
+  `asyncio.wait_for` deadline cannot drift. (Replaces v1's handshake-ack
+  advertisement, which raced registration at `websocket.py:225` vs ack at
+  `:240`.)
+- Plugin validation: numeric (int/float), finite, then clamp to
+  **[30, 3600]**; malformed/missing/non-positive → conservative default
+  **110 s** (safe inside an old server's 120 s). Old plugins ignore the
+  unknown param; old servers don't send it — both directions degrade to
+  today's behavior.
+- Runner ceiling = `budget − 10 s`, checked at the same between-phase
+  checkpoints. **Best-effort, not a guarantee**: an atomic phase (test body,
+  setup/teardown, one script load) that starts before the ceiling can
+  overshoot it, and a hard main-thread block still dies by heartbeat
+  (~40 s) — which is the desired fail-fast for genuine hangs, and the
+  server fails the in-flight future immediately on that disconnect (#690).
+  No cancel op in Phase 1 (nothing can be dispatched mid-run to deliver
+  one); a client that cancels early leaves the plugin finishing a run
+  nobody awaits, bounded by the ceiling. Documented.
+- **Outcome contract** (per review — response-envelope ownership is the
+  handler's, not the runner's): a new serviced entry point (existing
+  `run_suites()` keeps its exact signature/return for direct callers and
+  fixtures; both drive one shared execution core):
+
+  ```gdscript
+  ## run_suites_serviced(...) ->
+  ## {
+  ##   "outcome": "completed" | "timeout" | "transport_lost" | "paused",
+  ##   "results": <same dict get_results() returns>,
+  ## }
+  ```
+
+  Handler mapping — deterministic, no ambiguity:
+  - `completed` → `{"data": results}` + today's `load_errors` /
+    `edited_scene` / `scene_warning` annotations.
+  - `timeout` → `TEST_RUN_TIMEOUT` error envelope; `error.data` carries
+    partial counts, elapsed, remaining estimate, filter hint; full partials
+    stay retrievable via `test_manage(op="results_get")`.
+  - `transport_lost` → the data envelope is still returned to the
+    dispatcher (a sync handler must return something); the send fails
+    against the dead peer as described in D1. Results preserved for
+    `results_get` after reconnect.
+  - `paused` → `INTERNAL_ERROR` envelope with the observed pause depth in
+    `error.data` + partials note. Delivery is normal, not deferred
+    (corrected at review round 3): in the live MCP path `run_tests` itself
+    executes through `_call_handler`, whose pause-depth guard
+    (`dispatcher.gd:276-286`) restores any leaked depth right after the
+    handler returns — so the response goes out in the same `_process` pass.
+    A live-dispatch test proves both the error response and the restored
+    depth.
+
+  Every non-`completed` path that has entered a suite runs current-suite
+  `suite_teardown` + ownership-safe cleanup, restores `console_echo`, and
+  unregisters the capture logger before returning; an abort during
+  discovery (below) skips suite teardown — no suite has begun.
+
+- **Discovery is inside the outcome lifecycle** (review round 3): the
+  budget deadline starts *before* `_discover_suites()`, and the previous
+  run's results are cleared before discovery so an early abort can never
+  expose stale results through `results_get`. Discovery checkpoints check
+  both servicing status **and the ceiling** — a pathological discovery
+  phase is bounded by the same advertised budget as the run itself.
+  Discovery returns its partial `load_errors` plus an optional terminal
+  outcome (`timeout` / `transport_lost` / `paused`), which the handler maps
+  through the same envelope contract above.
+
+### D3: forbid `run_tests` inside `batch_execute`
+
+Add `"run_tests"` to the existing `FORBIDDEN_SUBCOMMANDS`
+(`batch_handler.gd:10`); error message points at the `test_run` tool.
+`get_test_results` stays batch-allowed. Direct fixture calls and
+`run_suites()` untouched. (Also resolves the 30 s Python batch timeout
+mismatch, `batch.py:28`.)
+
+### D4: per-test duration in results
+
+Add `duration_ms` to each per-test result entry (`test_runner.gd:98` block).
+Additive; surfaced by `verbose=true`; makes the "find the slow test"
+guidance actionable.
+
+### D5: close-code telemetry, concrete
+
+`SessionRegistry.unregister()` already emits a `GODOT_CONNECTION`
+`disconnected` telemetry event (`registry.py:169-180`). Changes:
+- `websocket.py` passes an optional normalized `close_code: int | None`
+  into `unregister()` from the `ConnectionClosed` exception; the numeric
+  code joins the telemetry payload (e.g. `{"event": "disconnected",
+  "close_code": 1011, ...}`).
+- The free-form close *reason* goes to local logs only, never telemetry.
+- This directly measures the 1011 rate before/after release.
+
+### D6: unchanged decisions
+
+- Server heartbeat settings stay default (#698 fail-fast preserved).
+- Per-test #19 leak cleanup byte-identical (no yields → no new exposure).
+- Error-code parity: `TEST_RUN_TIMEOUT` and the revived
+  `EDITOR_TEST_RUNNING` sub-code added to both `utils/error_codes.gd` and
+  `protocol/errors.py`. (`EDITOR_TEST_RUNNING` returns from v1 in a much
+  narrower role: emitted only by the service-reject path, no dispatcher
+  gate.)
+- No `in_progress` field (unobservable in Phase 1; Phase 2 adds it with
+  `elapsed_ms` + `run_id`).
+
+## 4. Implementation steps
+
+1. **Spike/harness (red on HEAD)**: `script/ci-slow-suite-smoke` (§6) as the
+   first commit of the feature branch; record the HEAD failure mode in the
+   PR. This is the §2 hard gate — if cooperative servicing can't keep the
+   session alive, stop and re-vet.
+2. **Connection**: `_classify_message` extraction;
+   `service_transport_during_exclusive_run()` with drain-and-reject, flood
+   cap, status enum.
+3. **Runner + discovery lifecycle**: shared execution core;
+   `run_suites_serviced` with checkpoints, ceiling, outcome contract,
+   teardown-on-every-exit; discovery inside the deadline/outcome lifecycle
+   (results cleared first, no suite teardown before a suite begins);
+   `duration_ms`.
+4. **Handler + wiring**: budget validation/clamp; outcome→envelope mapping;
+   connection ctor arg (4th, default `null`); `plugin.gd:306` registration
+   args; discovery servicing.
+5. **Server**: timeout constant 300 + envelope injection; close-code →
+   `unregister()` → telemetry; batch denylist + tests; error codes both
+   sides.
+6. **Docs**: `docs/testing.md` (budget/ceiling/best-effort framing,
+   residual-limitation wording from §5, busy-error behavior for concurrent
+   clients, batch rejection); `tools/testing.py` docstring.
+
+## 5. Visible behavior changes (release-notes material)
+
+- Full-suite runs no longer drop the MCP session. The editor still freezes
+  during a run (unchanged; interactivity is Phase 2).
+- **Concurrent commands during a run now get an immediate retryable
+  `EDITOR_NOT_READY` / `EDITOR_TEST_RUNNING` busy error** instead of
+  five-second timeouts followed by session death (v2's "timeouts as today"
+  expectation is superseded — timeouts would imply buffered stale commands,
+  which v3 forbids).
+- Runs may take up to ~290 s before aborting with `TEST_RUN_TIMEOUT` +
+  partial results (server budget 300 s, was 120 s).
+- `run_tests` inside `batch_execute` is rejected with a clear error.
+- Per-test `duration_ms` in verbose results.
+- **Residual limitation:** any single non-serviced atomic phase longer than
+  the heartbeat window (~20–40 s) — a long test body, `suite_setup`/
+  `suite_teardown`, `setup`/`teardown`, one huge script load, a pathological
+  cleanup walk — can still starve the transport and end in a heartbeat
+  disconnect (which doubles as the hang fail-fast). Servicing happens
+  *between* phases; per-test `duration_ms` identifies the offenders.
+
+## 6. Test plan
+
+**Starvation regression harness** — `script/ci-slow-suite-smoke`:
+- Fixture suite (`test_mcp_slow_smoke.gd`, ~25 × 2 s busy-wait ≈ 50 s,
+  unique suite name) copied into `test_project/tests/`; removal via shell
+  `trap` on EXIT.
+- Runs `test_run suite=mcp_slow_smoke` (filter excludes the corpus).
+- Asserts: the JSON-RPC response arrives **with the original request id and
+  correct pass counts** — this is the primary continuity evidence, because
+  a heartbeat disconnect fails the server-side future and the client gets
+  `ConnectionError` instead of a result. Same `session_id` before/after is
+  kept as a sanity check but **not** described as proof of no-reconnect
+  (`_session_id` is created once in `_ready` and survives reconnects,
+  `connection.gd:61,106`). Additionally: grep the captured server log for
+  `Session disconnected` / re-handshake lines inside the run window and
+  assert zero.
+- Development gate: run against HEAD first; record the reproduced failure.
+
+**Concurrent-client E2E** (new, per review):
+1. Start the slow suite from client A.
+2. From client B, send a write (`create_node`) mid-run → assert an
+   **immediate** `EDITOR_TEST_RUNNING` busy error, not a timeout.
+3. After the suite completes → assert the mutation **never appears** in the
+   scene.
+4. Flood variant: a **mix of valid commands and malformed frames** crossing
+   the packet cap — proving neither kind evades it → assert the connection
+   closes (1013), the run aborts with preserved partials retrievable via
+   `results_get` after reconnect.
+
+**GDScript unit** (`test_project/tests/`):
+- `_classify_message`: ack / valid command / malformed classification.
+- Service-reject reply shape (code, sub_code, retryable, readiness +
+  watermark stamped).
+- Flood cap → close + `DISCONNECTED`.
+- Runner: ceiling abort (tiny ceiling via runner param) → `timeout` outcome
+  + teardown + echo/capture restored; `service_cb` → `DISCONNECTED` →
+  `transport_lost` outcome with results preserved; `PAUSED` at checkpoint →
+  `paused` outcome + teardown + pause depth logged; **live-dispatch paused
+  test**: a run aborted by `PAUSED` while executing through `_call_handler`
+  yields the `INTERNAL_ERROR` response AND restored pause depth in the same
+  pass; checkpoint cadence (counting fake callback); drain-to-quiescence:
+  no packet remains buffered after any checkpoint, and the cap counter
+  advances on malformed and ack-like frames, not just valid commands;
+  discovery aborts: a terminal outcome during discovery maps through the
+  handler contract, skips suite teardown, and never exposes the prior run's
+  results; `duration_ms` per entry; refactor-equivalence for
+  pass/fail/skip/zero-assert/script-error classification.
+- Handler: outcome→envelope mapping (all four); budget validation —
+  missing, malformed (string/dict), negative, zero, fractional, sub-clamp,
+  over-clamp.
+- Batch: `run_tests` rejected; `get_test_results` still allowed.
+
+**Python unit** (`tests/`): shared-constant test (envelope budget ==
+`TEST_RUN_TIMEOUT_SEC`); `unregister(close_code=...)` telemetry payload
+shape (numeric code present, no free-form reason); error-code parity
+extended (`TEST_RUN_TIMEOUT`, `EDITOR_TEST_RUNNING`).
+
+**CI end-to-end**: `ci-godot-tests` full corpus stays green (now exercises
+servicing on every run).
+
+**Stress**: stormtest does not call `test_run`, so run stormtest
+concurrently with the slow-suite harness on the branch. Expected outcome:
+storm workers receive **immediate structured busy errors** during the run
+window — not timeouts — with no session death, no wedge, and no post-run
+surprise mutations. Record in PR.
+
+**Manual smoke**: reporter-shaped project (heavy scene tests >60 s) via the
+local-smoke recipe; partials-after-ceiling by temporarily lowering the
+budget; old-server pairing (3.0.5 server from tag checkout → 110 s default
+engages).
+
+## 7. Phase 2 (separate future work)
+
+Interactive-editor runs (frame-yielding), reconsidered only with:
+ownership-based leak cleanup (track/tag test-created nodes, no
+snapshot-diffing), edited-root identity checks across barriers, a single
+dispatcher-owned run token with generation counter self-clearing on every
+terminal path, `test_manage(op="cancel")`, mid-run progress (`in_progress`,
+`elapsed_ms`, `run_id`), and an exact read-only allowlist (plugin command
+names: `get_test_results`, `get_editor_state`, `get_logs`). File as a
+tracking issue when Phase 1 merges.
+
+## 8. Disposition of v2 review findings
+
+| Finding | Disposition |
+|---|---|
+| **B1: `poll()` receives command frames; stale execution + buffer exhaustion** | **Accepted — verified** (`send_command` pops futures on 5 s timeout, `websocket.py:430-455`; drain at `connection.gd:203` would replay). D1 is now drain-and-reject with immediate `EDITOR_TEST_RUNNING` busy errors, bounded flood cap with close-on-flood, and a final-checkpoint drain. "Heartbeat-only" language removed. |
+| **B2: single-frame fallback revives v1 hazards** | **Accepted.** Fallback withdrawn; §2 is now a hard stop-and-re-vet gate. |
+| Transport-loss is not a no-op (`_connected` lag) | **Accepted.** Documented actual `send_text`-fails behavior (D1); tests assert runner outcome, not send success. |
+| Stable session ID ≠ no reconnect (`connection.gd:61,106`) | **Accepted.** Harness reworded: original-response completion is primary evidence; session-id check demoted to sanity; server-log grep added. |
+| Close-code telemetry: make concrete via `unregister()` | **Accepted — verified** (`registry.py:169` event exists). D5 passes normalized `close_code` into it; reason stays in local logs. |
+| Define runner return contract | **Accepted.** Outcome envelope + deterministic handler mapping (D2); `run_suites()` signature preserved via new `run_suites_serviced`. |
+| Paused transport should abort | **Accepted** (flips my v2 lean — see §9 Q2). Status enum `SERVICED/DISCONNECTED/PAUSED/BLOCKED` adopted. |
+| Stress expectation "ordinary timeouts" unsafe | **Accepted.** Superseded by immediate-busy-error expectation (§5, §6). |
+
+Round 3 (approval review) clarifications — all folded in:
+
+| Clarification | Where |
+|---|---|
+| No packet spillover across checkpoints — drain to quiescence; close 1013 on cap mid-loop | D1 |
+| Cap counts **all** application packets (valid, malformed, ack-like); counter in runner-owned run-state, not connection-global | D1 |
+| Discovery inside the deadline/outcome lifecycle; clear prior results first; no suite teardown before a suite begins; ceiling checked at discovery checkpoints | D2 |
+| Paused response is sent same-pass via the `_call_handler` depth guard, not queued | D2 |
+| Flood-cap wording: above stormtest *default* (~1000, not "brutal" ~9000); headroom under Godot's 4096 `max_queued_packets`; tunable in the implementation PR | D1 |
+| Flood E2E mixes valid + malformed frames | §6 |
+
+Round 1 (v1 review) dispositions are preserved in git history
+(`docs/test-run-transport-starvation-plan.md` @ v2); summary: both blockers
+eliminated by dropping frame-yielding; all six major findings accepted, of
+which the gate/allowlist items moved to Phase 2 prerequisites.
+
+## 9. Resolved decisions (formerly open questions)
+
+1. **Spike timing** — RESOLVED: spike-first as the first red/green commit of
+   the feature branch (§4 step 1). If cooperative servicing cannot keep the
+   session alive, Phase 1 stops and returns to vetting; no in-plan fallback
+   exists. (Reviewer and author agree.)
+2. **Paused transport at a checkpoint** — RESOLVED: **abort** with teardown,
+   preserved partials, and logged pause depth (`paused` outcome). Rationale
+   for flipping from "accept the conflation": the #712 depth-restoration
+   guard only covers handlers invoked through `_call_handler`; a test that
+   constructs a handler directly and crashes inside a pause window leaks
+   depth *outside* that guard, and skip-poll-while-paused would then
+   silently starve the heartbeat at every remaining checkpoint — recreating
+   the exact bug this plan fixes, minutes from the cause. Abort surfaces the
+   invariant violation at the first checkpoint that observes it.
+3. **Budget clamp floor 30 s** — RESOLVED: keep. Purely defensive (no
+   user-facing knob exists in Phase 1; the new server always injects 300);
+   revisit only if a public `timeout_sec` parameter is added later.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -150,7 +150,8 @@ String)` removes it.
 
 ## Running tests
 
-MCP tool `test_run` (120 s server-side timeout for the whole run):
+MCP tool `test_run` (300 s server-side budget for the whole run; see
+"Long runs and the abort ceiling" below):
 
 ```text
 test_run                              # all suites — compact: counts + failures only
@@ -190,6 +191,41 @@ Re-fetch the last results without re-running: `test_manage(op="results_get")`
   treating those failures as real.
 - A suite aborted by `fail_setup` / `skip_suite` reports one entry with
   `"test": "<suite_setup>"`.
+- Every executed test entry carries `duration_ms` (visible with
+  `verbose=true`) — use it to find the slow tests when a run approaches the
+  abort ceiling.
+
+## Long runs and the abort ceiling
+
+Live `test_run` calls service the WebSocket transport between tests, suite
+phases, and discovery script-loads, so a long suite no longer starves the
+server's keepalive and drops the MCP session. Three consequences:
+
+- **Budget**: the server grants each run a 300 s budget (sent to the plugin
+  in the command envelope). The plugin aborts between tests ~10 s before the
+  budget expires and replies with a `TEST_RUN_TIMEOUT` error carrying the
+  partial summary; full partial results stay available via
+  `test_manage(op="results_get")`. Against an older server (which sends no
+  budget) the plugin uses a conservative 110 s ceiling. The ceiling is
+  **best-effort**: it is only checked between atomic phases, so a test that
+  starts just before it can overshoot.
+- **Concurrent clients**: commands arriving from other MCP clients while a
+  run holds the editor are rejected immediately with a retryable
+  `EDITOR_NOT_READY` (`sub_code: EDITOR_TEST_RUNNING`) instead of timing
+  out — retry after the run, or fetch results with
+  `test_manage(op="results_get")`. A pathological command flood (>2048
+  packets in one run) closes the connection (code 1013) rather than
+  buffering stale commands; the run aborts with partials preserved.
+- **Residual limitation**: any single non-yielding phase longer than the
+  heartbeat window (~20-40 s) — one long test body, `suite_setup`/
+  `suite_teardown`, or a huge script load — still blocks servicing and ends
+  in a keepalive disconnect. That doubles as the fail-fast for genuinely
+  hung tests. Keep individual phases well under ~20 s; `duration_ms` in
+  verbose results identifies offenders.
+
+`run_tests` is rejected inside `batch_execute` — a batch executes
+synchronously with no transport servicing (and a 30 s server budget), which
+is exactly the starvation this design removes. Call `test_run` directly.
 
 ## Testing your own game
 
@@ -207,7 +243,9 @@ Constraints (tests run synchronously on the editor's main thread):
   synchronously and `skip()` on unmet preconditions (see the
   "validation only" sections in
   [`test_scene.gd`](../test_project/tests/test_scene.gd)).
-- Keep per-test work small; the whole run must finish within `test_run`'s
-  120 s timeout.
+- Keep per-test work small: each test (and each `suite_setup`/teardown)
+  should stay well under ~20 s so transport servicing between phases keeps
+  the MCP session alive, and the whole run must finish within `test_run`'s
+  300 s budget (see "Long runs and the abort ceiling" above).
 - Free what you create: `track()` for objects and out-of-tree nodes, or the
   `_McpTest*` name prefix for scene nodes.

--- a/plugin/addons/godot_ai/connection.gd
+++ b/plugin/addons/godot_ai/connection.gd
@@ -406,44 +406,67 @@ func _build_handshake() -> Dictionary:
 	return payload
 
 
-func _handle_message(raw: String) -> void:
+## Classify one raw inbound frame. Shared by the normal dispatch path
+## (`_handle_message`, which enqueues commands) and the exclusive-run
+## service path (`_service_handle_message`, which rejects them) — one
+## parser, two sinks, so the paths can't drift. `kind` is one of:
+## "ack", "command", "malformed_command", "ignore".
+func _classify_message(raw: String) -> Dictionary:
 	var parsed = JSON.parse_string(raw)
 	if parsed == null:
 		push_warning("MCP: failed to parse message: %s" % raw)
-		return
+		return {"kind": "ignore", "parsed": null}
 	if not (parsed is Dictionary):
-		return
+		return {"kind": "ignore", "parsed": null}
 	if parsed.get("type", "") == "handshake_ack":
-		server_version = str(parsed.get("server_version", ""))
-		## The server accepted our handshake — any token-mismatch streak is
-		## over; a later unrelated 4003 starts a fresh one.
-		_auth_mismatch_closes = 0
-		return
+		return {"kind": "ack", "parsed": parsed}
 	if parsed.has("request_id") and parsed.has("command"):
 		if (
 			parsed.get("request_id") is String
 			and parsed.get("command") is String
 			and (not parsed.has("params") or parsed.get("params") is Dictionary)
 		):
+			return {"kind": "command", "parsed": parsed}
+		return {"kind": "malformed_command", "parsed": parsed}
+	return {"kind": "ignore", "parsed": parsed}
+
+
+func _handle_message(raw: String) -> void:
+	var classified := _classify_message(raw)
+	match classified["kind"]:
+		"ack":
+			_handle_handshake_ack(classified["parsed"])
+		"command":
 			if dispatcher:
-				dispatcher.enqueue(parsed)
-			return
-		## Never enqueue a malformed command frame: the dispatcher's typed
-		## casts would error on the queue head every tick, wedging every
-		## later command behind it. Reply with an error when the request_id
-		## is usable so the server's pending future resolves instead of
-		## waiting out the full command timeout.
-		push_warning("MCP: dropping malformed command frame (request_id/command must be String, params a Dictionary)")
-		var rid: Variant = parsed.get("request_id")
-		if rid is String and not String(rid).is_empty():
-			var response := ErrorCodes.make(
-				ErrorCodes.INVALID_PARAMS,
-				"Malformed command frame: request_id/command must be strings and params a dict"
-			)
-			response["request_id"] = rid
-			response["readiness"] = get_readiness()
-			_stamp_error_watermark(response)
-			_send_json(response)
+				dispatcher.enqueue(classified["parsed"])
+		"malformed_command":
+			_reply_malformed_command(classified["parsed"])
+
+
+func _handle_handshake_ack(parsed: Dictionary) -> void:
+	server_version = str(parsed.get("server_version", ""))
+	## The server accepted our handshake — any token-mismatch streak is
+	## over; a later unrelated 4003 starts a fresh one.
+	_auth_mismatch_closes = 0
+
+
+## Never enqueue a malformed command frame: the dispatcher's typed casts
+## would error on the queue head every tick, wedging every later command
+## behind it. Reply with an error when the request_id is usable so the
+## server's pending future resolves instead of waiting out the full
+## command timeout.
+func _reply_malformed_command(parsed: Dictionary) -> void:
+	push_warning("MCP: dropping malformed command frame (request_id/command must be String, params a Dictionary)")
+	var rid: Variant = parsed.get("request_id")
+	if rid is String and not String(rid).is_empty():
+		var response := ErrorCodes.make(
+			ErrorCodes.INVALID_PARAMS,
+			"Malformed command frame: request_id/command must be strings and params a dict"
+		)
+		response["request_id"] = rid
+		response["readiness"] = get_readiness()
+		_stamp_error_watermark(response)
+		_send_json(response)
 
 
 ## Send a state event to the server (not a command response).
@@ -474,6 +497,126 @@ func send_deferred_response(request_id: String, payload: Dictionary) -> void:
 		_stamp_error_watermark(response)
 	if _send_json(response) and dispatcher != null:
 		dispatcher.complete_deferred_response(request_id)
+
+
+## Result of one cooperative transport-servicing pass during an exclusive
+## synchronous run (currently only the test runner). PAUSED is an
+## invariant violation for callers, not a healthy state: a pause held
+## across servicing checkpoints would silently starve the heartbeat.
+enum ServiceStatus { SERVICED, DISCONNECTED, PAUSED, BLOCKED }
+
+## Cumulative cap on application packets processed across ONE exclusive
+## run. Counts every drained packet — valid command, malformed frame, or
+## ack-like — so no frame kind evades it. Past the cap the connection is
+## closed (1013): bounded rejects, never unbounded stale buffering. 2048
+## leaves headroom under Godot's default max_queued_packets (4096) and
+## sits above stormtest's ~1000-call default workload; tune with
+## telemetry/benchmarks if rejection traffic ever extends a checkpoint.
+const EXCLUSIVE_RUN_PACKET_CAP := 2048
+const CLOSE_CODE_EXCLUSIVE_RUN_FLOOD := 1013
+## Reject-log throttle: first few rejects verbatim, then periodic totals.
+const _SERVICE_REJECT_LOG_FIRST := 5
+const _SERVICE_REJECT_LOG_EVERY := 100
+
+## Service the WebSocket transport from inside a long synchronous handler
+## (an "exclusive run" — the test runner). The editor main thread is
+## blocked, so `_process` cannot poll; without this the server keepalive
+## (20s ping interval / 20s timeout) closes the session mid-run. See
+## docs/test-run-transport-starvation-plan.md.
+##
+## Contract — do NOT extend this method to dispatch:
+## - `WebSocketPeer.poll()` has no heartbeat-only mode; it also buffers
+##   application frames. Buffering them past this call would replay them
+##   STALE after their server-side futures expire (the #712 hazard), so
+##   every drained command frame is REJECTED immediately with a retryable
+##   EDITOR_NOT_READY / EDITOR_TEST_RUNNING error instead.
+## - Drains to quiescence: poll → drain everything available → poll again,
+##   until no packets remain. A full packet queue could hide a ping deeper
+##   in the TCP stream, so nothing may spill to a later checkpoint.
+## - `run_state` is caller-owned mutable state carrying the cumulative
+##   packet counter under "packets_serviced" — no connection-global
+##   lifecycle that could leak if the run dies.
+func service_transport_during_exclusive_run(run_state: Dictionary) -> ServiceStatus:
+	if connect_blocked:
+		return ServiceStatus.BLOCKED
+	if pause_processing:
+		return ServiceStatus.PAUSED
+	while true:
+		_peer.poll()
+		if _peer.get_ready_state() != WebSocketPeer.STATE_OPEN:
+			return ServiceStatus.DISCONNECTED
+		if _peer.get_available_packet_count() == 0:
+			return ServiceStatus.SERVICED
+		while _peer.get_available_packet_count() > 0:
+			var raw: String = _peer.get_packet().get_string_from_utf8()
+			if _service_note_packet(run_state):
+				if log_buffer:
+					log_buffer.log(
+						"[busy] packet flood during test run (%d > cap %d) — closing connection"
+						% [int(run_state.get("packets_serviced", 0)), EXCLUSIVE_RUN_PACKET_CAP]
+					)
+				_peer.close(CLOSE_CODE_EXCLUSIVE_RUN_FLOOD, "command flood during test run")
+				return ServiceStatus.DISCONNECTED
+			_service_handle_message(raw, int(run_state.get("packets_serviced", 0)))
+	## Unreachable: every exit above returns. Keeps the typed signature happy.
+	return ServiceStatus.SERVICED
+
+
+## Count one application packet against the exclusive-run cap. Counts EVERY
+## drained packet regardless of kind (valid command, malformed, ack-like)
+## so no frame kind can evade the flood limit. Returns true once the cap is
+## exceeded — the caller closes the connection.
+static func _service_note_packet(run_state: Dictionary) -> bool:
+	var count: int = int(run_state.get("packets_serviced", 0)) + 1
+	run_state["packets_serviced"] = count
+	return count > EXCLUSIVE_RUN_PACKET_CAP
+
+
+## Exclusive-run sink for `_classify_message`: acks are still processed,
+## malformed frames keep their normal reply, and valid commands are
+## rejected without touching the dispatcher.
+func _service_handle_message(raw: String, packets_serviced: int) -> void:
+	var classified := _classify_message(raw)
+	match classified["kind"]:
+		"ack":
+			_handle_handshake_ack(classified["parsed"])
+		"command":
+			_service_reject_command(classified["parsed"], packets_serviced)
+		"malformed_command":
+			_reply_malformed_command(classified["parsed"])
+
+
+func _service_reject_command(parsed: Dictionary, packets_serviced: int) -> void:
+	_send_json(_build_service_reject(parsed))
+	if log_buffer and (
+		packets_serviced <= _SERVICE_REJECT_LOG_FIRST
+		or packets_serviced % _SERVICE_REJECT_LOG_EVERY == 0
+	):
+		## Ring-buffer only (echo=false): a flood must not bury the console.
+		log_buffer.log(
+			"[busy] rejected '%s' during test run (packet %d)"
+			% [parsed.get("command", ""), packets_serviced],
+			false,
+		)
+
+
+## Build the busy-reject response for a valid command frame that arrived
+## mid-run. Split from the send so tests can assert the exact wire shape.
+func _build_service_reject(parsed: Dictionary) -> Dictionary:
+	var command: String = parsed.get("command", "")
+	var response := ErrorCodes.make_not_ready(
+		ErrorCodes.SUB_EDITOR_TEST_RUNNING,
+		(
+			"A test run is in progress on this editor — '%s' was not executed. "
+			+ "Retry when the run completes, or fetch results afterward with "
+			+ "test_manage(op=\"results_get\")."
+		) % command,
+		true,
+	)
+	response["request_id"] = parsed.get("request_id", "")
+	response["readiness"] = get_readiness()
+	_stamp_error_watermark(response)
+	return response
 
 
 func _hook_editor_signals() -> void:

--- a/plugin/addons/godot_ai/connection.gd
+++ b/plugin/addons/godot_ai/connection.gd
@@ -562,6 +562,29 @@ func service_transport_during_exclusive_run(run_state: Dictionary) -> ServiceSta
 	return ServiceStatus.SERVICED
 
 
+## Shared between-phase checkpoint for exclusive runs: deadline first
+## (cheap), then transport servicing via `service_cb`. Returns "" to
+## continue, or a terminal outcome: "timeout" | "transport_lost" |
+## "paused". Static and stateless so the runner's between-test checkpoints
+## and the handler's discovery checkpoints share ONE outcome mapping —
+## PAUSED is abort-worthy (a held pause would silently skip every later
+## poll and starve the heartbeat), and DISCONNECTED/BLOCKED both mean "no
+## live transport".
+static func exclusive_run_checkpoint(
+	service_cb: Callable, deadline_ticks_ms: int, run_state: Dictionary
+) -> String:
+	if deadline_ticks_ms > 0 and Time.get_ticks_msec() >= deadline_ticks_ms:
+		return "timeout"
+	if not service_cb.is_valid():
+		return ""
+	var status: int = service_cb.call(run_state)
+	if status == ServiceStatus.SERVICED:
+		return ""
+	if status == ServiceStatus.PAUSED:
+		return "paused"
+	return "transport_lost"
+
+
 ## Count one application packet against the exclusive-run cap. Counts EVERY
 ## drained packet regardless of kind (valid command, malformed, ack-like)
 ## so no frame kind can evade the flood limit. Returns true once the cap is

--- a/plugin/addons/godot_ai/handlers/batch_handler.gd
+++ b/plugin/addons/godot_ai/handlers/batch_handler.gd
@@ -7,7 +7,12 @@ const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
 ## semantics. When undo=true (default), any successful sub-commands are rolled
 ## back via the scene's UndoRedo history if a later sub-command fails.
 
-const FORBIDDEN_SUBCOMMANDS := ["batch_execute"]
+## run_tests is forbidden because a batch executes synchronously inside one
+## dispatcher tick with NO transport servicing: a full suite in a batch
+## starves the WebSocket heartbeat (the exact disconnect the serviced
+## test_run path exists to prevent) and the Python batch handler only
+## allows 30s anyway. Use the test_run tool directly.
+const FORBIDDEN_SUBCOMMANDS := ["batch_execute", "run_tests"]
 
 ## The whole batch executes synchronously inside one dispatcher tick,
 ## outside the 4ms frame budget — an unbounded array freezes the editor
@@ -46,7 +51,10 @@ func batch_execute(params: Dictionary) -> Dictionary:
 		if cmd_name.is_empty():
 			return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "commands[%d] missing 'command' field" % idx)
 		if cmd_name in FORBIDDEN_SUBCOMMANDS:
-			return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "commands[%d]: '%s' is not allowed as a sub-command" % [idx, cmd_name])
+			var forbidden_msg := "commands[%d]: '%s' is not allowed as a sub-command" % [idx, cmd_name]
+			if cmd_name == "run_tests":
+				forbidden_msg += " — a batch runs synchronously with no transport servicing; call the test_run tool directly"
+			return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, forbidden_msg)
 		if not _dispatcher.has_command(cmd_name):
 			return _unknown_command_error(idx, cmd_name)
 		## Pre-validate params type: the execution loop's typed Dictionary

--- a/plugin/addons/godot_ai/handlers/test_handler.gd
+++ b/plugin/addons/godot_ai/handlers/test_handler.gd
@@ -3,6 +3,29 @@ extends RefCounted
 
 ## Discovers and runs McpTestSuite scripts from res://tests/.
 ## Exposes run_tests and get_test_results as MCP commands.
+##
+## Live MCP runs service the WebSocket transport between tests
+## (McpConnection.service_transport_during_exclusive_run) so a long suite
+## can no longer starve the server's keepalive, and abort at a per-call
+## ceiling derived from the server-provided time budget. Direct callers,
+## unit-test fixtures, and batch contexts (no request id / no connection)
+## keep the legacy fully-synchronous behavior with no ceiling.
+## See docs/test-run-transport-starvation-plan.md.
+
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
+## Clamp bounds for the server-provided ``timeout_budget_sec`` param. The
+## floor is purely defensive (a malformed or buggy server value must not
+## abort every run instantly); the param is not user-facing.
+const BUDGET_MIN_SEC := 30.0
+const BUDGET_MAX_SEC := 3600.0
+## Conservative default when the server sent no (or an invalid) budget: an
+## old server's own test_run timeout is 120s, and the plugin must abort
+## and reply before that future expires.
+const BUDGET_DEFAULT_SEC := 110.0
+## Abort this long before the server would time the call out, so the
+## partial-results reply beats the server-side timeout.
+const CEILING_MARGIN_SEC := 10.0
 
 var _runner: McpTestRunner
 var _undo_redo: EditorUndoRedoManager
@@ -12,13 +35,22 @@ var _log_buffer: McpLogBuffer
 ## Optional third arg keeps old two-arg fixtures working; untyped because
 ## the dispatcher constructs this handler (avoids a load-time type cycle).
 var _dispatcher
+## Live connection for exclusive-run transport servicing. Null in unit-test
+## fixtures and batch contexts, which keep the legacy synchronous path.
+var _connection: McpConnection
 
 
-func _init(undo_redo: EditorUndoRedoManager, log_buffer: McpLogBuffer, dispatcher = null) -> void:
+func _init(
+	undo_redo: EditorUndoRedoManager,
+	log_buffer: McpLogBuffer,
+	dispatcher = null,
+	connection: McpConnection = null,
+) -> void:
 	_runner = McpTestRunner.new()
 	_undo_redo = undo_redo
 	_log_buffer = log_buffer
 	_dispatcher = dispatcher
+	_connection = connection
 
 
 func run_tests(params: Dictionary) -> Dictionary:
@@ -27,7 +59,34 @@ func run_tests(params: Dictionary) -> Dictionary:
 	var exclude_test_filter: String = params.get("exclude_test_name", "")
 	var verbose: bool = params.get("verbose", false)
 
-	var discovery := _discover_suites()
+	var request_id: String = params.get("_request_id", "")
+	var live := _connection != null and not request_id.is_empty()
+	var service_cb := Callable()
+	var deadline_ticks_ms := 0
+	var budget_sec := 0.0
+	var started_ms := Time.get_ticks_msec()
+	var run_state := {}
+	if live:
+		budget_sec = _validated_budget_sec(params)
+		service_cb = Callable(_connection, "service_transport_during_exclusive_run")
+		deadline_ticks_ms = started_ms + int((budget_sec - CEILING_MARGIN_SEC) * 1000.0)
+
+	## Clear the previous run's results BEFORE discovery so an abort at any
+	## later point can never expose a stale prior run via get_test_results.
+	_runner.clear()
+
+	var discovery := _discover_suites(service_cb, deadline_ticks_ms, run_state)
+	var discovery_outcome: String = discovery.get("outcome", "")
+	if not discovery_outcome.is_empty():
+		## Aborted during discovery: no suite has begun, so there is no
+		## suite teardown to run. Same outcome mapping as the run itself.
+		var empty_results: Dictionary = _runner.get_results(verbose)
+		if not discovery.errors.is_empty():
+			empty_results["load_errors"] = discovery.errors
+		return _map_outcome(
+			discovery_outcome, "discovery", empty_results, 0, started_ms, budget_sec
+		)
+
 	var suites: Array = discovery.suites
 	if suites.is_empty():
 		var msg := "No test suites found in res://tests/"
@@ -48,11 +107,121 @@ func run_tests(params: Dictionary) -> Dictionary:
 		"dispatcher": _dispatcher,
 	}
 
-	var results := _runner.run_suites(suites, suite_filter, test_filter, ctx, verbose, exclude_test_filter)
+	var run: Dictionary = _runner.run_suites_serviced(
+		suites, suite_filter, test_filter, ctx, verbose, exclude_test_filter,
+		service_cb, deadline_ticks_ms, run_state
+	)
+	var results: Dictionary = run["results"]
 	if not discovery.errors.is_empty():
 		results["load_errors"] = discovery.errors
-	_annotate_edited_scene(results)
-	return {"data": results}
+	return _map_outcome(
+		run["outcome"], "run", results, run["tests_not_run"], started_ms, budget_sec
+	)
+
+
+## Map a runner/discovery outcome onto the response envelope. Ownership is
+## deliberately here, not in the runner: the runner reports WHAT happened,
+## the handler decides how it goes over the wire (plan D2).
+func _map_outcome(
+	outcome: String,
+	phase: String,
+	results: Dictionary,
+	tests_not_run: int,
+	started_ms: int,
+	budget_sec: float,
+) -> Dictionary:
+	var elapsed_ms := Time.get_ticks_msec() - started_ms
+	match outcome:
+		"completed":
+			_annotate_edited_scene(results)
+			return {"data": results}
+		"transport_lost":
+			## The peer is gone (or flood-closed); the send will fail against
+			## the dead socket regardless, but a sync handler must return an
+			## envelope. Partials stay retrievable via get_test_results after
+			## the plugin reconnects.
+			results["aborted"] = "transport_lost"
+			results["tests_not_run"] = tests_not_run
+			_annotate_edited_scene(results)
+			return {"data": results}
+		"paused":
+			var depth := _connection.pause_depth() if _connection != null else 0
+			if _log_buffer != null:
+				_log_buffer.log(
+					"[error] test run aborted in %s: transport paused at checkpoint (depth %d)"
+					% [phase, depth]
+				)
+			var paused_err := ErrorCodes.make(
+				ErrorCodes.INTERNAL_ERROR,
+				(
+					"Test run aborted: the MCP transport was paused at a between-test "
+					+ "checkpoint (pause depth %d) — a paused transport cannot service "
+					+ "the WebSocket heartbeat, so continuing would starve the session. "
+					+ "Partial results: test_manage(op=\"results_get\")."
+				) % depth
+			)
+			paused_err["error"]["data"] = _abort_data(
+				phase, results, tests_not_run, elapsed_ms, budget_sec, {"pause_depth": depth}
+			)
+			return paused_err
+		"timeout":
+			var timeout_err := ErrorCodes.make(
+				ErrorCodes.TEST_RUN_TIMEOUT,
+				(
+					"Test run hit its abort ceiling after %.1fs (budget %.0fs, ceiling = "
+					+ "budget - %.0fs): %d passed, %d failed, %d of the selected tests "
+					+ "never ran. Narrow the run with suite=/test_name= filters, or fetch "
+					+ "the partial results with test_manage(op=\"results_get\")."
+				) % [
+					elapsed_ms / 1000.0, budget_sec, CEILING_MARGIN_SEC,
+					int(results.get("passed", 0)), int(results.get("failed", 0)),
+					tests_not_run,
+				]
+			)
+			timeout_err["error"]["data"] = _abort_data(
+				phase, results, tests_not_run, elapsed_ms, budget_sec, {}
+			)
+			return timeout_err
+	## Unknown outcome is a runner bug — surface it loudly.
+	return ErrorCodes.make(
+		ErrorCodes.INTERNAL_ERROR, "Unknown test run outcome '%s'" % outcome
+	)
+
+
+func _abort_data(
+	phase: String,
+	results: Dictionary,
+	tests_not_run: int,
+	elapsed_ms: int,
+	budget_sec: float,
+	extra: Dictionary,
+) -> Dictionary:
+	var data := {
+		"phase": phase,
+		"elapsed_ms": elapsed_ms,
+		"budget_sec": budget_sec,
+		"passed": int(results.get("passed", 0)),
+		"failed": int(results.get("failed", 0)),
+		"skipped": int(results.get("skipped", 0)),
+		"total": int(results.get("total", 0)),
+		"tests_not_run": tests_not_run,
+	}
+	data.merge(extra)
+	return data
+
+
+## Strict validation of the server-provided per-call budget: numeric,
+## finite, positive, then clamped to [BUDGET_MIN_SEC, BUDGET_MAX_SEC].
+## Everything else (missing, wrong type, NaN/inf, non-positive) falls back
+## to BUDGET_DEFAULT_SEC. typeof() so bool never sneaks through as int.
+func _validated_budget_sec(params: Dictionary) -> float:
+	var raw: Variant = params.get("timeout_budget_sec", null)
+	var t := typeof(raw)
+	if t == TYPE_FLOAT or t == TYPE_INT:
+		var v := float(raw)
+		if is_finite(v) and v > 0.0:
+			return clampf(v, BUDGET_MIN_SEC, BUDGET_MAX_SEC)
+	return BUDGET_DEFAULT_SEC
 
 
 ## Many suites assume the project's main scene is the edited scene (they read
@@ -82,19 +251,34 @@ func get_test_results(params: Dictionary) -> Dictionary:
 	return {"data": _runner.get_results(verbose)}
 
 
-func _discover_suites() -> Dictionary:
-	## Returns {"suites": Array, "errors": Array[String]}.
-	## Resilient: a broken script doesn't kill discovery of the rest.
+## Returns {"suites": Array, "errors": Array[String], "outcome": String}.
+## Resilient: a broken script doesn't kill discovery of the rest. A
+## non-empty outcome ("timeout" / "transport_lost" / "paused") means a
+## between-load checkpoint aborted discovery — script loading is itself an
+## atomic phase, and a directory of heavy scripts must neither starve the
+## heartbeat nor escape the run budget.
+func _discover_suites(
+	service_cb: Callable = Callable(),
+	deadline_ticks_ms: int = 0,
+	run_state: Dictionary = {},
+) -> Dictionary:
 	var suites := []
 	var errors: Array[String] = []
 	var dir := DirAccess.open("res://tests")
 	if dir == null:
-		return {"suites": suites, "errors": ["DirAccess.open('res://tests') returned null — directory may not exist"]}
+		return {
+			"suites": suites,
+			"errors": ["DirAccess.open('res://tests') returned null — directory may not exist"],
+			"outcome": "",
+		}
 
 	dir.list_dir_begin()
 	var file_name := dir.get_next()
 	while not file_name.is_empty():
 		if file_name.begins_with("test_") and file_name.ends_with(".gd"):
+			var stop := _discovery_checkpoint(service_cb, deadline_ticks_ms, run_state)
+			if not stop.is_empty():
+				return {"suites": suites, "errors": errors, "outcome": stop}
 			var path := "res://tests/" + file_name
 			var script = ResourceLoader.load(path, "", ResourceLoader.CACHE_MODE_IGNORE)
 			if script == null:
@@ -113,4 +297,21 @@ func _discover_suites() -> Dictionary:
 	suites.sort_custom(func(a, b) -> bool:
 		return a.suite_name() < b.suite_name()
 	)
-	return {"suites": suites, "errors": errors}
+	return {"suites": suites, "errors": errors, "outcome": ""}
+
+
+## Discovery-phase twin of McpTestRunner._checkpoint (deadline first, then
+## servicing). Kept local: the runner doesn't exist yet at discovery time.
+func _discovery_checkpoint(
+	service_cb: Callable, deadline_ticks_ms: int, run_state: Dictionary
+) -> String:
+	if deadline_ticks_ms > 0 and Time.get_ticks_msec() >= deadline_ticks_ms:
+		return "timeout"
+	if not service_cb.is_valid():
+		return ""
+	var status: int = service_cb.call(run_state)
+	if status == McpConnection.ServiceStatus.SERVICED:
+		return ""
+	if status == McpConnection.ServiceStatus.PAUSED:
+		return "paused"
+	return "transport_lost"

--- a/plugin/addons/godot_ai/handlers/test_handler.gd
+++ b/plugin/addons/godot_ai/handlers/test_handler.gd
@@ -300,18 +300,10 @@ func _discover_suites(
 	return {"suites": suites, "errors": errors, "outcome": ""}
 
 
-## Discovery-phase twin of McpTestRunner._checkpoint (deadline first, then
-## servicing). Kept local: the runner doesn't exist yet at discovery time.
+## Discovery-phase twin of McpTestRunner._checkpoint. Both delegate to the
+## shared McpConnection.exclusive_run_checkpoint so the outcome mapping
+## cannot drift between the discovery and between-test paths.
 func _discovery_checkpoint(
 	service_cb: Callable, deadline_ticks_ms: int, run_state: Dictionary
 ) -> String:
-	if deadline_ticks_ms > 0 and Time.get_ticks_msec() >= deadline_ticks_ms:
-		return "timeout"
-	if not service_cb.is_valid():
-		return ""
-	var status: int = service_cb.call(run_state)
-	if status == McpConnection.ServiceStatus.SERVICED:
-		return ""
-	if status == McpConnection.ServiceStatus.PAUSED:
-		return "paused"
-	return "transport_lost"
+	return McpConnection.exclusive_run_checkpoint(service_cb, deadline_ticks_ms, run_state)

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -303,7 +303,7 @@ func _enter_tree() -> void:
 	_dispatcher.register_lazy_handler("signal", HANDLERS_DIR + "signal_handler.gd", [undo])
 	_dispatcher.register_lazy_handler("autoload", HANDLERS_DIR + "autoload_handler.gd", [])
 	_dispatcher.register_lazy_handler("input", HANDLERS_DIR + "input_handler.gd", [])
-	_dispatcher.register_lazy_handler("test", HANDLERS_DIR + "test_handler.gd", [undo, _log_buffer, _dispatcher])
+	_dispatcher.register_lazy_handler("test", HANDLERS_DIR + "test_handler.gd", [undo, _log_buffer, _dispatcher, _connection])
 	_dispatcher.register_lazy_handler("batch", HANDLERS_DIR + "batch_handler.gd", [_dispatcher, undo])
 	_dispatcher.register_lazy_handler("ui", HANDLERS_DIR + "ui_handler.gd", [undo])
 	_dispatcher.register_lazy_handler("theme", HANDLERS_DIR + "theme_handler.gd", [undo, _connection])

--- a/plugin/addons/godot_ai/testing/test_runner.gd
+++ b/plugin/addons/godot_ai/testing/test_runner.gd
@@ -24,6 +24,25 @@ func run_suite(suite: McpTestSuite, test_filter: String = "", exclude_test_filte
 	if owns_capture:
 		_register_capture()
 
+	_run_suite_tests(suite, test_filter, exclude_test_filter, Callable(), 0, {})
+
+	if owns_capture:
+		_unregister_capture()
+
+
+## Shared per-test loop for both the legacy synchronous path and the
+## serviced driver. Returns "" when the loop completed, or a terminal
+## outcome ("timeout" / "transport_lost" / "paused") when a checkpoint
+## aborted it. Checkpoints run BETWEEN tests — an atomic test body is
+## never preempted (see docs/test-run-transport-starvation-plan.md).
+func _run_suite_tests(
+	suite: McpTestSuite,
+	test_filter: String,
+	exclude_test_filter: String,
+	service_cb: Callable,
+	deadline_ticks_ms: int,
+	run_state: Dictionary,
+) -> String:
 	var name := suite.suite_name()
 	var methods := _get_test_methods(suite)
 	var exclusions := _parse_exclusions(exclude_test_filter)
@@ -31,6 +50,7 @@ func run_suite(suite: McpTestSuite, test_filter: String = "", exclude_test_filte
 	for method_name in methods:
 		if not test_filter.is_empty() and method_name.find(test_filter) == -1:
 			continue
+		_selected_processed += 1
 		if _matches_any_exclusion(method_name, exclusions):
 			_results.append({
 				"suite": name,
@@ -39,77 +59,125 @@ func run_suite(suite: McpTestSuite, test_filter: String = "", exclude_test_filte
 				"skipped": true,
 				"message": "Excluded by exclude_test_name filter",
 				"assertion_count": 0,
+				"duration_ms": 0,
 			})
 			continue
 
-		suite._reset()
-		_begin_script_error_capture()
-		suite.setup()
-		suite.call(method_name)
-		suite.teardown()
-		var script_errors := suite._unexpected_script_errors(_end_script_error_capture())
-		suite._free_tracked()
+		var test_start := Time.get_ticks_msec()
+		var entry := _run_one_test(suite, name, method_name)
+		entry["duration_ms"] = Time.get_ticks_msec() - test_start
+		_results.append(entry)
 
-		## Issue #19 defence: free any `_McpTest*` nodes the test created, even
-		## nested ones. If the scene gets auto-saved mid-test while one of these
-		## exists, the reference bakes into main.tscn and breaks the next open
-		## with a "missing dependency" error. Runs after every test, not just at
-		## suite boundaries, so a test that fails mid-flow can't leave a trap
-		## for the next test or for scene autosave.
-		var scene_root_for_cleanup := _edited_scene_root()
-		if scene_root_for_cleanup != null and scene_root_for_cleanup.is_inside_tree():
-			_free_mcp_test_nodes_recursive(scene_root_for_cleanup)
+		var stop := _checkpoint(service_cb, deadline_ticks_ms, run_state)
+		if not stop.is_empty():
+			return stop
+	return ""
 
-		if not script_errors.is_empty():
-			var abort_message := "Aborted by SCRIPT ERROR: %s" % "; ".join(script_errors)
-			if suite._failed:
-				abort_message += " (after assertion failure: %s)" % suite._message
-			_results.append({
-				"suite": name,
-				"test": method_name,
-				"passed": false,
-				"message": abort_message,
-				"assertion_count": suite._assertion_count,
-			})
-			continue
 
-		## A failed assertion always wins over a later skip(): a test that
-		## fails and then hits a skip-guard must report the failure, not
-		## park itself as green-skipped.
-		if suite._skipped and not suite._failed:
-			_results.append({
-				"suite": name,
-				"test": method_name,
-				"passed": true,
-				"skipped": true,
-				"message": suite._skip_reason,
-				"assertion_count": 0,
-			})
-			continue
+## Execute one test method and return its result entry (not yet appended;
+## the caller stamps `duration_ms`). Extracted from run_suite so the legacy
+## and serviced drivers share one execution core — behavior must stay
+## byte-identical to the pre-refactor loop body.
+func _run_one_test(suite: McpTestSuite, name: String, method_name: String) -> Dictionary:
+	suite._reset()
+	_begin_script_error_capture()
+	suite.setup()
+	suite.call(method_name)
+	suite.teardown()
+	var script_errors := suite._unexpected_script_errors(_end_script_error_capture())
+	suite._free_tracked()
 
-		var passed := not suite._failed
-		var msg := suite._message
+	## Issue #19 defence: free any `_McpTest*` nodes the test created, even
+	## nested ones. If the scene gets auto-saved mid-test while one of these
+	## exists, the reference bakes into main.tscn and breaks the next open
+	## with a "missing dependency" error. Runs after every test, not just at
+	## suite boundaries, so a test that fails mid-flow can't leave a trap
+	## for the next test or for scene autosave.
+	var scene_root_for_cleanup := _edited_scene_root()
+	if scene_root_for_cleanup != null and scene_root_for_cleanup.is_inside_tree():
+		_free_mcp_test_nodes_recursive(scene_root_for_cleanup)
 
-		## Warn about zero-assertion tests (likely silently skipped logic).
-		if passed and suite._assertion_count == 0:
-			passed = false
-			msg = "Test completed with 0 assertions (likely skipped its logic)"
-
-		_results.append({
+	if not script_errors.is_empty():
+		var abort_message := "Aborted by SCRIPT ERROR: %s" % "; ".join(script_errors)
+		if suite._failed:
+			abort_message += " (after assertion failure: %s)" % suite._message
+		return {
 			"suite": name,
 			"test": method_name,
-			"passed": passed,
-			"message": msg,
+			"passed": false,
+			"message": abort_message,
 			"assertion_count": suite._assertion_count,
-		})
+		}
 
-	if owns_capture:
-		_unregister_capture()
+	## A failed assertion always wins over a later skip(): a test that
+	## fails and then hits a skip-guard must report the failure, not
+	## park itself as green-skipped.
+	if suite._skipped and not suite._failed:
+		return {
+			"suite": name,
+			"test": method_name,
+			"passed": true,
+			"skipped": true,
+			"message": suite._skip_reason,
+			"assertion_count": 0,
+		}
+
+	var passed := not suite._failed
+	var msg := suite._message
+
+	## Warn about zero-assertion tests (likely silently skipped logic).
+	if passed and suite._assertion_count == 0:
+		passed = false
+		msg = "Test completed with 0 assertions (likely skipped its logic)"
+
+	return {
+		"suite": name,
+		"test": method_name,
+		"passed": passed,
+		"message": msg,
+		"assertion_count": suite._assertion_count,
+	}
 
 
 func run_suites(suites: Array, suite_filter: String = "", test_filter: String = "", ctx: Dictionary = {}, verbose: bool = false, exclude_test_filter: String = "") -> Dictionary:
+	## Legacy synchronous API — unchanged signature and semantics for direct
+	## callers, unit-test fixtures, and any batch context. No servicing, no
+	## ceiling: with an invalid Callable and deadline 0 every checkpoint is a
+	## no-op and the outcome is always "completed".
+	var run := run_suites_serviced(suites, suite_filter, test_filter, ctx, verbose, exclude_test_filter)
+	return run["results"]
+
+
+## Serviced driver for live MCP runs. Between tests and at suite
+## boundaries it (a) aborts once `deadline_ticks_ms` passes and (b) calls
+## `service_cb` (McpConnection.service_transport_during_exclusive_run) so
+## the WebSocket heartbeat stays alive while the suite monopolizes the
+## main thread. Returns:
+##   {
+##     "outcome": "completed" | "timeout" | "transport_lost" | "paused",
+##     "results": <same dict get_results(verbose) returns>,
+##     "tests_not_run": <int, 0 when completed>,
+##   }
+## Every outcome path — including aborts — runs the current suite's
+## teardown + leak cleanup, restores console echo, and unregisters the
+## capture logger. `run_state` is caller-owned and threaded through to the
+## service callback (cumulative packet counter lives there).
+func run_suites_serviced(
+	suites: Array,
+	suite_filter: String = "",
+	test_filter: String = "",
+	ctx: Dictionary = {},
+	verbose: bool = false,
+	exclude_test_filter: String = "",
+	service_cb: Callable = Callable(),
+	deadline_ticks_ms: int = 0,
+	run_state: Dictionary = {},
+) -> Dictionary:
 	_results.clear()
+	_selected_processed = 0
+	var selected_total := _count_selected_tests(suites, suite_filter, test_filter)
 	var start := Time.get_ticks_msec()
+	var outcome := ""
 
 	## Silence the plugin's ring-buffer console echo while tests run. Negative-
 	## path suites deliberately fill the ring with 500 lines and log malformed-
@@ -148,6 +216,8 @@ func run_suites(suites: Array, suite_filter: String = "", test_filter: String = 
 				"message": "suite_setup() failed: %s (subsequent tests not run)" % suite._suite_failed_message,
 				"assertion_count": 0,
 			})
+			## The bailed suite's tests are accounted for, not "not run".
+			_selected_processed += _count_selected_tests([suite], "", test_filter)
 		elif suite._suite_skipped:
 			_results.append({
 				"suite": suite.suite_name(),
@@ -157,8 +227,16 @@ func run_suites(suites: Array, suite_filter: String = "", test_filter: String = 
 				"message": "suite_setup() skipped: %s" % suite._suite_skipped_reason,
 				"assertion_count": 0,
 			})
+			_selected_processed += _count_selected_tests([suite], "", test_filter)
 		else:
-			run_suite(suite, test_filter, exclude_test_filter)
+			outcome = _checkpoint(service_cb, deadline_ticks_ms, run_state)
+			if outcome.is_empty():
+				outcome = _run_suite_tests(
+					suite, test_filter, exclude_test_filter,
+					service_cb, deadline_ticks_ms, run_state
+				)
+		## Suite epilogue runs on EVERY path, including aborts: the suite has
+		## begun, so its teardown and leak cleanup must not be skipped.
 		suite.suite_teardown()
 		suite._free_tracked()
 
@@ -166,10 +244,60 @@ func run_suites(suites: Array, suite_filter: String = "", test_filter: String = 
 		if scene_root != null and scene_root.is_inside_tree():
 			_cleanup_leaked_nodes(scene_root, before_children)
 
+		if not outcome.is_empty():
+			break
+
+		outcome = _checkpoint(service_cb, deadline_ticks_ms, run_state)
+		if not outcome.is_empty():
+			break
+
 	_last_run_ms = Time.get_ticks_msec() - start
 	McpLogBuffer.console_echo = _prev_console_echo
 	_unregister_capture()
-	return get_results(verbose)
+	if outcome.is_empty():
+		outcome = "completed"
+	return {
+		"outcome": outcome,
+		"results": get_results(verbose),
+		"tests_not_run": maxi(0, selected_total - _selected_processed),
+	}
+
+
+## Count of selected (filter-surviving) tests already looped over this run,
+## including exclusion-skips and bailed-suite accounting. Drives the
+## `tests_not_run` estimate on aborted runs.
+var _selected_processed := 0
+
+
+func _count_selected_tests(suites: Array, suite_filter: String, test_filter: String) -> int:
+	var count := 0
+	for suite: McpTestSuite in suites:
+		if not suite_filter.is_empty() and suite.suite_name() != suite_filter:
+			continue
+		for method_name in _get_test_methods(suite):
+			if not test_filter.is_empty() and method_name.find(test_filter) == -1:
+				continue
+			count += 1
+	return count
+
+
+## Between-phase checkpoint: "" to continue, or a terminal outcome.
+## Deadline first (cheap), then transport servicing. PAUSED maps to its
+## own outcome — a pause held at a between-test boundary would silently
+## skip every remaining poll and starve the heartbeat, so the run must
+## surface it instead of continuing (plan §9 Q2).
+func _checkpoint(service_cb: Callable, deadline_ticks_ms: int, run_state: Dictionary) -> String:
+	if deadline_ticks_ms > 0 and Time.get_ticks_msec() >= deadline_ticks_ms:
+		return "timeout"
+	if not service_cb.is_valid():
+		return ""
+	var status: int = service_cb.call(run_state)
+	if status == McpConnection.ServiceStatus.SERVICED:
+		return ""
+	if status == McpConnection.ServiceStatus.PAUSED:
+		return "paused"
+	## DISCONNECTED and BLOCKED both mean "no live transport".
+	return "transport_lost"
 
 
 func _register_capture() -> void:

--- a/plugin/addons/godot_ai/testing/test_runner.gd
+++ b/plugin/addons/godot_ai/testing/test_runner.gd
@@ -282,22 +282,10 @@ func _count_selected_tests(suites: Array, suite_filter: String, test_filter: Str
 
 
 ## Between-phase checkpoint: "" to continue, or a terminal outcome.
-## Deadline first (cheap), then transport servicing. PAUSED maps to its
-## own outcome — a pause held at a between-test boundary would silently
-## skip every remaining poll and starve the heartbeat, so the run must
-## surface it instead of continuing (plan §9 Q2).
+## Delegates to the shared mapping so the discovery checkpoints in
+## test_handler.gd can never drift from the between-test ones (plan §9 Q2).
 func _checkpoint(service_cb: Callable, deadline_ticks_ms: int, run_state: Dictionary) -> String:
-	if deadline_ticks_ms > 0 and Time.get_ticks_msec() >= deadline_ticks_ms:
-		return "timeout"
-	if not service_cb.is_valid():
-		return ""
-	var status: int = service_cb.call(run_state)
-	if status == McpConnection.ServiceStatus.SERVICED:
-		return ""
-	if status == McpConnection.ServiceStatus.PAUSED:
-		return "paused"
-	## DISCONNECTED and BLOCKED both mean "no live transport".
-	return "transport_lost"
+	return McpConnection.exclusive_run_checkpoint(service_cb, deadline_ticks_ms, run_state)
 
 
 func _register_capture() -> void:

--- a/plugin/addons/godot_ai/utils/error_codes.gd
+++ b/plugin/addons/godot_ai/utils/error_codes.gd
@@ -105,6 +105,16 @@ const SUB_EDITOR_VIEWPORT_UNAVAILABLE := "EDITOR_VIEWPORT_UNAVAILABLE"
 const SUB_EDITOR_VIEWPORT_NOT_3D := "EDITOR_VIEWPORT_NOT_3D"
 const SUB_EDITOR_VIEWPORT_EMPTY := "EDITOR_VIEWPORT_EMPTY"
 const SUB_EDITOR_UNAVAILABLE := "EDITOR_UNAVAILABLE"
+## Emitted only by the exclusive-run transport servicing path: a command
+## arrived while a synchronous test run holds the main thread, and was
+## rejected (not buffered) so it can't replay stale after its server-side
+## future expires. See connection.gd::service_transport_during_exclusive_run.
+const SUB_EDITOR_TEST_RUNNING := "EDITOR_TEST_RUNNING"
+
+## Terminal code for a test run that hit its between-test abort ceiling
+## before finishing. error.data carries the partial summary; full partial
+## results stay retrievable via get_test_results.
+const TEST_RUN_TIMEOUT := "TEST_RUN_TIMEOUT"
 
 
 ## Build a standard error response dictionary.

--- a/script/ci-slow-suite-smoke
+++ b/script/ci-slow-suite-smoke
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Regression harness for test_run transport starvation
+# (docs/test-run-transport-starvation-plan.md).
+#
+# Copies a ~50s main-thread-blocking fixture suite into test_project/tests/,
+# runs it via the test_run MCP tool, and asserts the ORIGINAL request
+# completes with correct counts. On pre-fix plugins the websockets heartbeat
+# (20s ping interval / 20s timeout) kills the editor session ~40s into the
+# run, the server fails the in-flight future, and the tool call returns a
+# disconnect error — which this script reports as the reproduced bug.
+#
+# Expects (same contract as ci-godot-tests): Python server on :8000, Godot
+# editor running with the plugin connected. The fixture is removed on exit
+# via trap, pass or fail.
+#
+# Optional: SERVER_LOG=<path to captured server stdout/stderr>. When set,
+# also asserts no "Session disconnected" lines were added during the run.
+# The primary continuity evidence is the completed original response —
+# a same session_id before/after is only a sanity check, because the plugin
+# reuses its session_id across reconnects (connection.gd::_ready).
+set -euo pipefail
+source "$(dirname "$0")/_ci_env.sh"
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FIXTURE_SRC="$REPO_ROOT/script/fixtures/test_mcp_slow_smoke.gd"
+FIXTURE_DST="$REPO_ROOT/test_project/tests/test_mcp_slow_smoke.gd"
+SUITE_NAME="mcp_slow_smoke"
+EXPECTED_TESTS=25
+
+SERVER_URL="http://127.0.0.1:8000/mcp"
+HEADERS=(-H "Content-Type: application/json" -H "Accept: application/json, text/event-stream")
+
+cleanup() {
+  rm -f "$FIXTURE_DST" "$FIXTURE_DST.uid"
+}
+trap cleanup EXIT
+
+# Shared SSE-response field extractor: prints structuredContent JSON for the
+# first data: line, or exits 3 when none is present.
+extract_content() {
+  python3 -c "
+import json, sys
+raw = sys.stdin.read()
+for line in raw.split('\n'):
+    if line.startswith('data: '):
+        data = json.loads(line[6:])
+        result = data.get('result', {})
+        sc = result.get('structuredContent', {})
+        if not sc:
+            text = result.get('content', [{}])[0].get('text', '{}')
+            try:
+                sc = json.loads(text)
+            except json.JSONDecodeError:
+                sc = {'_raw_text': text}
+        sc['_is_error'] = bool(result.get('isError'))
+        sc['_rpc_id'] = data.get('id')
+        print(json.dumps(sc))
+        break
+else:
+    sys.exit(3)
+"
+}
+
+mcp_call() { # id name arguments-json
+  curl -s -m 300 "$SERVER_URL" -X POST "${HEADERS[@]}" \
+    -H "Mcp-Session-Id: $SESSION_ID" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":$1,\"method\":\"tools/call\",\"params\":{\"name\":\"$2\",\"arguments\":$3}}"
+}
+
+godot_session_id() {
+  mcp_call 7 session_manage '{"op":"list"}' | extract_content | python3 -c "
+import json, sys
+sc = json.loads(sys.stdin.read())
+sessions = sc.get('sessions', [])
+print(sessions[0]['session_id'] if sessions else '')
+"
+}
+
+echo "Installing slow fixture suite ($EXPECTED_TESTS tests)..."
+cp "$FIXTURE_SRC" "$FIXTURE_DST"
+
+# --- MCP handshake + wait for a Godot session (mirrors ci-godot-tests) ---
+echo "Waiting for Godot plugin to connect..."
+SESSION_ID=""
+for i in $(seq 1 60); do
+  SESSION_ID=$(curl -si "$SERVER_URL" -X POST "${HEADERS[@]}" \
+    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"slow-smoke","version":"1.0"}}}' \
+    2>&1 | grep -i 'mcp-session-id' | tr -d '\r' | awk '{print $2}' || true)
+  if [ -z "$SESSION_ID" ]; then sleep 2; continue; fi
+  curl -s "$SERVER_URL" -X POST "${HEADERS[@]}" -H "Mcp-Session-Id: $SESSION_ID" \
+    -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' > /dev/null || true
+  GODOT_SESSION_BEFORE=$(godot_session_id || true)
+  if [ -n "${GODOT_SESSION_BEFORE:-}" ]; then
+    echo "Godot plugin connected (session: $GODOT_SESSION_BEFORE)"
+    break
+  fi
+  echo "  attempt $i — no session yet"
+  sleep 2
+done
+if [ -z "${GODOT_SESSION_BEFORE:-}" ]; then
+  echo "ERROR: no Godot session connected"
+  exit 1
+fi
+
+# Make sure discovery sees the just-copied fixture (fresh scan; the tool is
+# single-flight and settles before replying).
+echo "Scanning filesystem so discovery sees the fixture..."
+mcp_call 8 filesystem_manage '{"op":"scan"}' > /dev/null || true
+
+if [ -n "${SERVER_LOG:-}" ] && [ -f "$SERVER_LOG" ]; then
+  DISCONNECTS_BEFORE=$(grep -c "Session disconnected" "$SERVER_LOG" || true)
+fi
+
+echo "Running $SUITE_NAME (~50s of main-thread blocking)..."
+START_TS=$(date +%s)
+RESULT=$(mcp_call 42 test_run "{\"suite\":\"$SUITE_NAME\"}")
+ELAPSED=$(( $(date +%s) - START_TS ))
+
+CONTENT=$(echo "$RESULT" | extract_content) || {
+  echo "REPRODUCED/FAIL: no SSE data line from test_run after ${ELAPSED}s"
+  echo "Raw response (first 500 chars): $(echo "$RESULT" | head -c 500)"
+  exit 1
+}
+
+echo "$CONTENT" | python3 -c "
+import json, sys
+sc = json.loads(sys.stdin.read())
+elapsed = $ELAPSED
+expected = $EXPECTED_TESTS
+if sc.get('_rpc_id') != 42:
+    print(f'FAIL: response id {sc.get(\"_rpc_id\")} does not match original request id 42')
+    sys.exit(1)
+if sc.get('_is_error'):
+    print(f'REPRODUCED: test_run failed after {elapsed}s — the in-flight call died instead of completing.')
+    print('Error payload:', json.dumps(sc)[:600])
+    sys.exit(1)
+passed, failed, total = sc.get('passed', 0), sc.get('failed', 0), sc.get('total', 0)
+print(f'test_run completed in {elapsed}s: {passed}/{total} passed, {failed} failed')
+if failed or total != expected or passed != expected:
+    print(f'FAIL: expected {expected}/{expected} passed in the fixture suite')
+    for f in sc.get('failures', []) or []:
+        print(f'  FAIL: {f[\"suite\"]}.{f[\"test\"]}: {f[\"message\"]}')
+    sys.exit(1)
+"
+
+GODOT_SESSION_AFTER=$(godot_session_id || true)
+if [ "$GODOT_SESSION_AFTER" != "$GODOT_SESSION_BEFORE" ]; then
+  echo "FAIL: session identity changed across the run ('$GODOT_SESSION_BEFORE' -> '$GODOT_SESSION_AFTER')"
+  exit 1
+fi
+echo "Session sanity check passed ($GODOT_SESSION_AFTER)"
+
+if [ -n "${SERVER_LOG:-}" ] && [ -f "$SERVER_LOG" ]; then
+  DISCONNECTS_AFTER=$(grep -c "Session disconnected" "$SERVER_LOG" || true)
+  if [ "${DISCONNECTS_AFTER:-0}" -gt "${DISCONNECTS_BEFORE:-0}" ]; then
+    echo "FAIL: server log shows $((DISCONNECTS_AFTER - DISCONNECTS_BEFORE)) disconnect(s) during the run window"
+    exit 1
+  fi
+  echo "Server-log check passed (no disconnects during run)"
+fi
+
+echo "PASS: slow suite completed without losing the editor session"

--- a/script/fixtures/test_mcp_slow_smoke.gd
+++ b/script/fixtures/test_mcp_slow_smoke.gd
@@ -1,0 +1,58 @@
+@tool
+extends McpTestSuite
+
+## Transport-starvation regression fixture — NOT part of the normal corpus.
+## Lives in script/fixtures/ and is copied into test_project/tests/ only by
+## script/ci-slow-suite-smoke, which removes it again on exit.
+##
+## Each test blocks the editor main thread for ~BLOCK_MS; the whole suite
+## runs ~50 s — well past the websockets heartbeat window (~20-40 s) that
+## used to kill the editor session mid-run (see
+## docs/test-run-transport-starvation-plan.md). The blocks sit BETWEEN
+## runner checkpoints, so cooperative transport servicing gets a chance to
+## answer pings 25 times across the run; on pre-fix plugins the suite
+## reliably reproduces the 1011 keepalive disconnect instead.
+
+const BLOCK_MS := 2000
+
+
+func suite_name() -> String:
+	return "mcp_slow_smoke"
+
+
+func _block_main_thread() -> void:
+	var end := Time.get_ticks_msec() + BLOCK_MS
+	while Time.get_ticks_msec() < end:
+		pass
+
+
+func _blocked_ok() -> void:
+	_block_main_thread()
+	assert_true(true, "blocked ~%dms on the main thread" % BLOCK_MS)
+
+
+func test_block_01() -> void: _blocked_ok()
+func test_block_02() -> void: _blocked_ok()
+func test_block_03() -> void: _blocked_ok()
+func test_block_04() -> void: _blocked_ok()
+func test_block_05() -> void: _blocked_ok()
+func test_block_06() -> void: _blocked_ok()
+func test_block_07() -> void: _blocked_ok()
+func test_block_08() -> void: _blocked_ok()
+func test_block_09() -> void: _blocked_ok()
+func test_block_10() -> void: _blocked_ok()
+func test_block_11() -> void: _blocked_ok()
+func test_block_12() -> void: _blocked_ok()
+func test_block_13() -> void: _blocked_ok()
+func test_block_14() -> void: _blocked_ok()
+func test_block_15() -> void: _blocked_ok()
+func test_block_16() -> void: _blocked_ok()
+func test_block_17() -> void: _blocked_ok()
+func test_block_18() -> void: _blocked_ok()
+func test_block_19() -> void: _blocked_ok()
+func test_block_20() -> void: _blocked_ok()
+func test_block_21() -> void: _blocked_ok()
+func test_block_22() -> void: _blocked_ok()
+func test_block_23() -> void: _blocked_ok()
+func test_block_24() -> void: _blocked_ok()
+func test_block_25() -> void: _blocked_ok()

--- a/src/godot_ai/handlers/testing.py
+++ b/src/godot_ai/handlers/testing.py
@@ -6,7 +6,12 @@ from typing import Any
 
 from godot_ai.runtime.direct import DirectRuntime
 
-TEST_RUN_TIMEOUT_SEC = 120.0
+## Whole-run budget. Raised from 120s once run_tests stopped starving the
+## WebSocket heartbeat (docs/test-run-transport-starvation-plan.md): real
+## projects' full suites exceed 120s, and a genuinely hung test still fails
+## fast via the keepalive disconnect (~40s), so the long budget only ever
+## extends legitimately progressing runs.
+TEST_RUN_TIMEOUT_SEC = 300.0
 
 
 async def test_run(
@@ -25,6 +30,11 @@ async def test_run(
         params["exclude_test_name"] = exclude_test_name
     if verbose:
         params["verbose"] = True
+    ## Thread the per-call budget into the command envelope so the plugin
+    ## derives its between-test abort ceiling from the SAME constant that
+    ## bounds this await — the two cannot drift. Old plugins ignore the
+    ## extra key; the plugin clamps/validates on its side.
+    params["timeout_budget_sec"] = TEST_RUN_TIMEOUT_SEC
     return await runtime.send_command("run_tests", params, timeout=TEST_RUN_TIMEOUT_SEC)
 
 

--- a/src/godot_ai/protocol/errors.py
+++ b/src/godot_ai/protocol/errors.py
@@ -14,6 +14,10 @@ class ErrorCode(StrEnum):
     UNKNOWN_COMMAND = "UNKNOWN_COMMAND"
     INTERNAL_ERROR = "INTERNAL_ERROR"
     DEFERRED_TIMEOUT = "DEFERRED_TIMEOUT"
+    # A test run aborted at its between-test ceiling before finishing;
+    # error.data carries the partial summary and get_test_results keeps the
+    # partial results. Keep in sync with utils/error_codes.gd.
+    TEST_RUN_TIMEOUT = "TEST_RUN_TIMEOUT"
     # game_eval failure codes (#490): distinguish a compile/parse failure
     # or a runtime error from the generic 10s timeout so agents get a fast,
     # actionable reply. Keep in sync with utils/error_codes.gd.
@@ -81,3 +85,7 @@ class EditorNotReadySubCode(StrEnum):
     EDITOR_VIEWPORT_NOT_3D = "EDITOR_VIEWPORT_NOT_3D"
     EDITOR_VIEWPORT_EMPTY = "EDITOR_VIEWPORT_EMPTY"
     EDITOR_UNAVAILABLE = "EDITOR_UNAVAILABLE"
+    # Emitted plugin-side by the exclusive-run transport servicing path: a
+    # command arrived while a synchronous test run held the editor main
+    # thread and was rejected (retryable) instead of buffered.
+    EDITOR_TEST_RUNNING = "EDITOR_TEST_RUNNING"

--- a/src/godot_ai/sessions/registry.py
+++ b/src/godot_ai/sessions/registry.py
@@ -166,7 +166,7 @@ class SessionRegistry:
             if not future.done():
                 future.set_result(session)
 
-    def unregister(self, session_id: str) -> None:
+    def unregister(self, session_id: str, close_code: int | None = None) -> None:
         ## Active-session promotion policy on disconnect:
         ## - n>=2 survivors: do NOT auto-promote — picking by insertion order
         ##   would route the user's commands to whichever editor happened to
@@ -179,9 +179,17 @@ class SessionRegistry:
         ## - n=0: keep cleared; nothing to promote.
         self._sessions.pop(session_id, None)
         try:
+            ## close_code is the normalized WebSocket close code (e.g. 1011
+            ## = keepalive timeout, 1013 = exclusive-run flood). None means
+            ## no close frame was observed (non-WS teardown paths). Included
+            ## even when None so the field is always present downstream.
             record_telemetry(
                 RecordType.GODOT_CONNECTION,
-                {"event": "disconnected", "session_count": len(self._sessions)},
+                {
+                    "event": "disconnected",
+                    "session_count": len(self._sessions),
+                    "close_code": close_code,
+                },
                 session_id=session_id,
             )
         except Exception:  # noqa: BLE001

--- a/src/godot_ai/tools/testing.py
+++ b/src/godot_ai/tools/testing.py
@@ -40,7 +40,14 @@ def register_testing_tools(mcp: FastMCP) -> None:
         Discovers test_*.gd in res://tests/, instantiates them, and runs
         all test_* methods. Returns a compact summary by default (counts,
         suite names, duration) plus failures only. verbose=True includes
-        every individual test result.
+        every individual test result (each with per-test ``duration_ms``).
+
+        The whole run has a 300s budget; the plugin aborts between tests
+        shortly before it expires and returns TEST_RUN_TIMEOUT with the
+        partial summary (full partials via test_manage(op="results_get")).
+        Long suites are safe — the editor services the MCP transport
+        between tests — but one single test blocking the main thread for
+        20s+ can still drop the session. Not allowed inside batch_execute.
 
         The response includes ``edited_scene`` (the scene currently open in
         the editor). Many suites assume the project's main scene is open; if

--- a/src/godot_ai/transport/websocket.py
+++ b/src/godot_ai/transport/websocket.py
@@ -167,6 +167,7 @@ class GodotWebSocketServer:
 
     async def _handle_connection(self, ws: ServerConnection):
         session_id: str | None = None
+        close_code: int | None = None
         try:
             # First message must be a handshake
             raw = await asyncio.wait_for(ws.recv(), timeout=10.0)
@@ -347,13 +348,28 @@ class GodotWebSocketServer:
                         if not future.done():
                             future.set_result(response)
 
-        except websockets.ConnectionClosed:
-            logger.info("Session disconnected: %s", session_id)
+        except websockets.ConnectionClosed as exc:
+            ## Normalize the close frame: prefer the one the peer sent
+            ## (rcvd); the keepalive watchdog's own 1011 lives on ``sent``.
+            ## The numeric code flows into disconnect telemetry (so 1011
+            ## keepalive kills are measurable); the free-form reason stays
+            ## in local logs only.
+            frame = exc.rcvd or exc.sent
+            close_reason = ""
+            if frame is not None:
+                close_code = frame.code
+                close_reason = frame.reason or ""
+            logger.info(
+                "Session disconnected: %s (close code %s, reason %r)",
+                session_id,
+                close_code,
+                close_reason,
+            )
         except Exception:
             logger.exception("Error in WebSocket handler for session %s", session_id)
         finally:
             if session_id:
-                self.registry.unregister(session_id)
+                self.registry.unregister(session_id, close_code=close_code)
                 self._connections.pop(session_id, None)
                 ## Fail this session's in-flight futures NOW (#690): a close
                 ## settles nothing by itself, so every in-flight command used

--- a/test_project/tests/test_serviced_test_run.gd
+++ b/test_project/tests/test_serviced_test_run.gd
@@ -1,0 +1,357 @@
+@tool
+extends McpTestSuite
+
+## Tests for the serviced test-run path (transport-starvation fix):
+## McpTestRunner.run_suites_serviced outcome contract, the handler's budget
+## validation + outcome→envelope mapping, and McpConnection's exclusive-run
+## servicing primitives. See docs/test-run-transport-starvation-plan.md.
+##
+## NOTE: nothing here calls TestHandler.run_tests() end-to-end — that would
+## recursively re-run the whole corpus from inside itself. The live path is
+## covered by script/ci-slow-suite-smoke and the concurrent-client E2E.
+
+const TestHandlerScript := preload("res://addons/godot_ai/handlers/test_handler.gd")
+const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
+
+
+func suite_name() -> String:
+	return "serviced_test_run"
+
+
+## Three-test probe with lifecycle instrumentation.
+class ProbeSuite:
+	extends McpTestSuite
+	var suite_teardown_calls := 0
+
+	func suite_name() -> String:
+		return "probe"
+
+	func suite_teardown() -> void:
+		suite_teardown_calls += 1
+
+	func test_a() -> void:
+		assert_true(true, "a")
+
+	func test_b() -> void:
+		assert_true(true, "b")
+
+	func test_c() -> void:
+		assert_true(true, "c")
+
+
+## Classification probe: one fail, one skip, one zero-assert.
+class ClassifyProbe:
+	extends McpTestSuite
+
+	func suite_name() -> String:
+		return "classify_probe"
+
+	func test_fails() -> void:
+		assert_true(false, "deliberate failure")
+
+	func test_skips() -> void:
+		skip("deliberate skip")
+
+	func test_zero_asserts() -> void:
+		pass
+
+
+func test_completed_outcome_and_duration() -> void:
+	var runner := McpTestRunner.new()
+	var run: Dictionary = runner.run_suites_serviced([ProbeSuite.new()])
+	assert_eq(run["outcome"], "completed", "unserviced run completes")
+	assert_eq(int(run["tests_not_run"]), 0, "nothing left unrun")
+	var results: Dictionary = run["results"]
+	assert_eq(int(results["passed"]), 3, "all probe tests pass")
+	assert_eq(int(results["total"]), 3, "three entries")
+	var verbose: Dictionary = runner.get_results(true)
+	for entry in verbose["results"]:
+		assert_true(entry.has("duration_ms"), "per-test duration_ms present")
+		assert_true(int(entry["duration_ms"]) >= 0, "duration_ms non-negative")
+
+
+func test_legacy_run_suites_shape_unchanged() -> void:
+	var runner := McpTestRunner.new()
+	var results: Dictionary = runner.run_suites([ProbeSuite.new()])
+	assert_true(results.has("passed"), "legacy API returns the results dict")
+	assert_true(not results.has("outcome"), "legacy API has no outcome wrapper")
+	assert_eq(int(results["passed"]), 3, "legacy run passes all probe tests")
+
+
+func test_classification_equivalence() -> void:
+	var runner := McpTestRunner.new()
+	var results: Dictionary = runner.run_suites([ClassifyProbe.new()])
+	assert_eq(int(results["failed"]), 2, "fail + zero-assert both count as failures")
+	assert_eq(int(results["skipped"]), 1, "skip() counts as skipped")
+	var messages := []
+	for f in results.get("failures", []):
+		messages.append(str(f["message"]))
+	assert_true(
+		"0 assertions" in "\n".join(messages),
+		"zero-assert guardrail message survives the refactor"
+	)
+
+
+func test_ceiling_abort_before_first_test() -> void:
+	var probe := ProbeSuite.new()
+	var runner := McpTestRunner.new()
+	var expired := Time.get_ticks_msec() - 10
+	var run: Dictionary = runner.run_suites_serviced(
+		[probe], "", "", {}, false, "", Callable(), expired
+	)
+	assert_eq(run["outcome"], "timeout", "expired deadline aborts at first checkpoint")
+	assert_eq(int(run["tests_not_run"]), 3, "no probe test ran")
+	assert_eq(int(run["results"]["total"]), 0, "no result entries")
+	assert_eq(probe.suite_teardown_calls, 1, "suite teardown still ran on abort")
+
+
+func test_transport_lost_mid_suite_preserves_partials() -> void:
+	var probe := ProbeSuite.new()
+	var runner := McpTestRunner.new()
+	## Checkpoint order per suite: after suite_setup, then after each test.
+	## SERVICED once (post-setup), then DISCONNECTED after test_a.
+	var calls := [0]
+	var cb := func(_run_state: Dictionary) -> int:
+		calls[0] += 1
+		if calls[0] <= 1:
+			return McpConnection.ServiceStatus.SERVICED
+		return McpConnection.ServiceStatus.DISCONNECTED
+	var run: Dictionary = runner.run_suites_serviced(
+		[probe], "", "", {}, false, "", cb
+	)
+	assert_eq(run["outcome"], "transport_lost", "disconnect maps to transport_lost")
+	assert_eq(int(run["results"]["total"]), 1, "exactly one test ran before the abort")
+	assert_eq(int(run["tests_not_run"]), 2, "two tests never ran")
+	assert_eq(probe.suite_teardown_calls, 1, "suite teardown ran on abort")
+
+
+func test_paused_outcome() -> void:
+	var probe := ProbeSuite.new()
+	var runner := McpTestRunner.new()
+	var cb := func(_run_state: Dictionary) -> int:
+		return McpConnection.ServiceStatus.PAUSED
+	var run: Dictionary = runner.run_suites_serviced([probe], "", "", {}, false, "", cb)
+	assert_eq(run["outcome"], "paused", "paused transport aborts the run")
+	assert_eq(probe.suite_teardown_calls, 1, "suite teardown ran on paused abort")
+
+
+func test_checkpoint_cadence() -> void:
+	var runner := McpTestRunner.new()
+	var calls := [0]
+	var cb := func(_run_state: Dictionary) -> int:
+		calls[0] += 1
+		return McpConnection.ServiceStatus.SERVICED
+	runner.run_suites_serviced([ProbeSuite.new()], "", "", {}, false, "", cb)
+	## Post-suite_setup (1) + after each of 3 tests (3) + suite epilogue (1).
+	assert_eq(calls[0], 5, "checkpoints fire between every phase")
+
+
+func test_run_state_threaded_to_callback() -> void:
+	var runner := McpTestRunner.new()
+	var seen := [null]
+	var cb := func(run_state: Dictionary) -> int:
+		seen[0] = run_state
+		run_state["marker"] = true
+		return McpConnection.ServiceStatus.SERVICED
+	var shared := {}
+	runner.run_suites_serviced([ProbeSuite.new()], "", "", {}, false, "", cb, 0, shared)
+	assert_true(seen[0] != null, "callback received a run_state")
+	assert_true(shared.get("marker", false), "the caller-owned dict is the one threaded through")
+
+
+func test_excluded_test_has_zero_duration() -> void:
+	var runner := McpTestRunner.new()
+	runner.run_suites_serviced([ProbeSuite.new()], "", "", {}, false, "test_b")
+	var verbose: Dictionary = runner.get_results(true)
+	var saw_excluded := false
+	for entry in verbose["results"]:
+		if entry["test"] == "test_b":
+			saw_excluded = true
+			assert_true(bool(entry.get("skipped", false)), "excluded test is skipped")
+			assert_eq(int(entry["duration_ms"]), 0, "excluded test never ran")
+	assert_true(saw_excluded, "excluded test still gets an entry")
+
+
+func test_handler_budget_validation() -> void:
+	var handler := TestHandlerScript.new(null, null)
+	assert_eq(handler._validated_budget_sec({}), 110.0, "missing -> default")
+	assert_eq(
+		handler._validated_budget_sec({"timeout_budget_sec": 300.0}), 300.0, "valid float"
+	)
+	assert_eq(handler._validated_budget_sec({"timeout_budget_sec": 300}), 300.0, "valid int")
+	assert_eq(
+		handler._validated_budget_sec({"timeout_budget_sec": 45.5}), 45.5, "fractional kept"
+	)
+	assert_eq(handler._validated_budget_sec({"timeout_budget_sec": 5}), 30.0, "clamped up")
+	assert_eq(
+		handler._validated_budget_sec({"timeout_budget_sec": 100000}), 3600.0, "clamped down"
+	)
+	assert_eq(handler._validated_budget_sec({"timeout_budget_sec": 0}), 110.0, "zero -> default")
+	assert_eq(handler._validated_budget_sec({"timeout_budget_sec": -5}), 110.0, "negative -> default")
+	assert_eq(
+		handler._validated_budget_sec({"timeout_budget_sec": "300"}), 110.0, "string -> default"
+	)
+	assert_eq(handler._validated_budget_sec({"timeout_budget_sec": true}), 110.0, "bool -> default")
+	assert_eq(handler._validated_budget_sec({"timeout_budget_sec": NAN}), 110.0, "NaN -> default")
+	assert_eq(handler._validated_budget_sec({"timeout_budget_sec": INF}), 110.0, "inf -> default")
+	assert_eq(
+		handler._validated_budget_sec({"timeout_budget_sec": {"nested": 1}}), 110.0,
+		"dict -> default"
+	)
+
+
+func test_handler_map_outcome_timeout_shape() -> void:
+	var handler := TestHandlerScript.new(null, null)
+	var results := {"passed": 4, "failed": 1, "skipped": 0, "total": 5}
+	var envelope: Dictionary = handler._map_outcome(
+		"timeout", "run", results, 7, Time.get_ticks_msec() - 5000, 120.0
+	)
+	assert_eq(envelope["error"]["code"], ErrorCodes.TEST_RUN_TIMEOUT, "timeout error code")
+	var data: Dictionary = envelope["error"]["data"]
+	assert_eq(int(data["tests_not_run"]), 7, "remaining estimate carried")
+	assert_eq(int(data["passed"]), 4, "partial pass count carried")
+	assert_eq(data["phase"], "run", "phase carried")
+	assert_true(int(data["elapsed_ms"]) >= 5000, "elapsed measured")
+	assert_true("results_get" in str(envelope["error"]["message"]), "message points at partials")
+
+
+func test_handler_map_outcome_paused_shape() -> void:
+	var handler := TestHandlerScript.new(null, null)
+	var envelope: Dictionary = handler._map_outcome(
+		"paused", "run", {"passed": 1, "failed": 0, "skipped": 0, "total": 1},
+		2, Time.get_ticks_msec(), 110.0
+	)
+	assert_eq(envelope["error"]["code"], ErrorCodes.INTERNAL_ERROR, "paused is an invariant violation")
+	assert_true(envelope["error"]["data"].has("pause_depth"), "pause depth surfaced")
+
+
+func test_handler_map_outcome_transport_lost_shape() -> void:
+	var handler := TestHandlerScript.new(null, null)
+	var results := {"passed": 2, "failed": 0, "skipped": 0, "total": 2}
+	var envelope: Dictionary = handler._map_outcome(
+		"transport_lost", "run", results, 1, Time.get_ticks_msec(), 110.0
+	)
+	assert_true(envelope.has("data"), "transport loss still returns a data envelope")
+	assert_eq(envelope["data"]["aborted"], "transport_lost", "abort cause marked")
+	assert_eq(int(envelope["data"]["tests_not_run"]), 1, "remaining count carried")
+
+
+func test_handler_discovery_checkpoint_outcomes() -> void:
+	## NOTE: only the ABORT paths of _discover_suites run here — they bail at
+	## the first checkpoint, BEFORE any script load. The completed path is
+	## deliberately not exercised in-suite: it would re-load every res://tests
+	## script (CACHE_MODE_IGNORE) including this currently-executing one,
+	## which trips a Godot VM internal error. Every live test_run covers it.
+	var handler := TestHandlerScript.new(null, null)
+	var paused_cb := func(_run_state: Dictionary) -> int:
+		return McpConnection.ServiceStatus.PAUSED
+	var discovery: Dictionary = handler._discover_suites(paused_cb, 0, {})
+	assert_eq(discovery["outcome"], "paused", "paused during discovery is terminal")
+	assert_eq(discovery["suites"].size(), 0, "aborted before any suite loaded")
+	var expired: Dictionary = handler._discover_suites(Callable(), Time.get_ticks_msec() - 10, {})
+	assert_eq(expired["outcome"], "timeout", "expired deadline aborts discovery")
+	## The checkpoint helper itself, all three continue/abort classes:
+	var ok_cb := func(_run_state: Dictionary) -> int:
+		return McpConnection.ServiceStatus.SERVICED
+	assert_eq(handler._discovery_checkpoint(ok_cb, 0, {}), "", "SERVICED continues")
+	var lost_cb := func(_run_state: Dictionary) -> int:
+		return McpConnection.ServiceStatus.DISCONNECTED
+	assert_eq(
+		handler._discovery_checkpoint(lost_cb, 0, {}), "transport_lost",
+		"DISCONNECTED is terminal"
+	)
+
+
+func test_connection_classify_message() -> void:
+	var conn := McpConnection.new()
+	track(conn)
+	var ack: Dictionary = conn._classify_message('{"type":"handshake_ack","server_version":"9.9.9"}')
+	assert_eq(ack["kind"], "ack", "ack classified")
+	var cmd: Dictionary = conn._classify_message(
+		'{"request_id":"r1","command":"node_create","params":{}}'
+	)
+	assert_eq(cmd["kind"], "command", "valid command classified")
+	var malformed: Dictionary = conn._classify_message('{"request_id":42,"command":"x"}')
+	assert_eq(malformed["kind"], "malformed_command", "non-string request_id is malformed")
+	assert_eq(conn._classify_message("not json")["kind"], "ignore", "garbage ignored")
+	assert_eq(conn._classify_message("[1,2]")["kind"], "ignore", "non-dict JSON ignored")
+	assert_eq(conn._classify_message('{"type":"other"}')["kind"], "ignore", "unknown dict ignored")
+
+
+func test_connection_ack_handling_shared_by_service_path() -> void:
+	var conn := McpConnection.new()
+	track(conn)
+	conn._service_handle_message('{"type":"handshake_ack","server_version":"7.7.7"}', 1)
+	assert_eq(conn.server_version, "7.7.7", "ack processed during exclusive servicing")
+
+
+func test_connection_service_reject_shape() -> void:
+	var conn := McpConnection.new()
+	track(conn)
+	var response: Dictionary = conn._build_service_reject(
+		{"request_id": "req-9", "command": "node_create", "params": {}}
+	)
+	assert_eq(response["error"]["code"], ErrorCodes.EDITOR_NOT_READY, "top-level code frozen")
+	assert_eq(
+		response["error"]["data"]["sub_code"], ErrorCodes.SUB_EDITOR_TEST_RUNNING,
+		"sub-code names the state"
+	)
+	assert_true(bool(response["error"]["data"]["retryable"]), "reject is retryable")
+	assert_eq(response["request_id"], "req-9", "request id preserved")
+	assert_true(response.has("readiness"), "readiness stamped like every reply")
+	assert_true("node_create" in str(response["error"]["message"]), "message names the command")
+
+
+func test_connection_service_status_without_socket() -> void:
+	var conn := McpConnection.new()
+	track(conn)
+	assert_eq(
+		conn.service_transport_during_exclusive_run({}),
+		McpConnection.ServiceStatus.DISCONNECTED,
+		"fresh peer is not OPEN"
+	)
+	conn.pause_processing = true
+	assert_eq(
+		conn.service_transport_during_exclusive_run({}),
+		McpConnection.ServiceStatus.PAUSED,
+		"paused wins over socket state"
+	)
+	conn.pause_processing = false
+	conn.connect_blocked = true
+	assert_eq(
+		conn.service_transport_during_exclusive_run({}),
+		McpConnection.ServiceStatus.BLOCKED,
+		"blocked connection reports BLOCKED"
+	)
+
+
+func test_connection_packet_cap_boundary() -> void:
+	var run_state := {"packets_serviced": McpConnection.EXCLUSIVE_RUN_PACKET_CAP - 1}
+	assert_true(
+		not McpConnection._service_note_packet(run_state),
+		"packet AT the cap is still processed"
+	)
+	assert_true(
+		McpConnection._service_note_packet(run_state),
+		"packet PAST the cap trips the flood close"
+	)
+	assert_eq(
+		int(run_state["packets_serviced"]), McpConnection.EXCLUSIVE_RUN_PACKET_CAP + 1,
+		"counter counts every packet"
+	)
+
+
+func test_batch_rejects_run_tests() -> void:
+	var log_buffer := McpLogBuffer.new()
+	var dispatcher := McpDispatcher.new(log_buffer)
+	var BatchHandler := preload("res://addons/godot_ai/handlers/batch_handler.gd")
+	var batch = BatchHandler.new(dispatcher, null)
+	var result: Dictionary = batch.batch_execute(
+		{"commands": [{"command": "run_tests", "params": {}}]}
+	)
+	assert_true(result.has("error"), "run_tests in a batch is rejected")
+	assert_true(
+		"test_run" in str(result["error"]["message"]),
+		"rejection points at the test_run tool"
+	)
+	dispatcher.clear()

--- a/test_project/tests/test_serviced_test_run.gd.uid
+++ b/test_project/tests/test_serviced_test_run.gd.uid
@@ -1,0 +1,1 @@
+uid://dry6v68pey6am

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -53,6 +53,26 @@ class TestHandshake:
         await asyncio.sleep(0.1)  # let server process disconnect
         assert harness.registry.get("sess-dc") is None
 
+    async def test_disconnect_records_normalized_close_code(self, harness, monkeypatch):
+        ## The handler must extract the close frame off ConnectionClosed and
+        ## pass the numeric code into unregister() so disconnect telemetry
+        ## can distinguish keepalive kills (1011) and exclusive-run floods
+        ## (1013) from ordinary closes. The free-form reason stays in local
+        ## logs only.
+        captured = {}
+        real_unregister = harness.registry.unregister
+
+        def spy(session_id, close_code=None):
+            captured["close_code"] = close_code
+            return real_unregister(session_id, close_code=close_code)
+
+        monkeypatch.setattr(harness.registry, "unregister", spy)
+        plugin = await harness.connect_plugin(session_id="sess-cc")
+        await plugin.ws.close(code=1011, reason="keepalive ping timeout")
+        await asyncio.sleep(0.1)  # let server process disconnect
+        assert captured["close_code"] == 1011
+        assert harness.registry.get("sess-cc") is None
+
     async def test_handshake_captures_editor_pid(self, harness):
         plugin = await harness.connect_plugin(session_id="sess-pid", editor_pid=4242)
         session = harness.registry.get("sess-pid")
@@ -491,9 +511,7 @@ class TestCommandRoundTrip:
         assert third["new_warnings_since_last_call"] == 2
         await plugin.close()
 
-    async def test_error_watermark_discard_consumes_both_channels_without_backlog(
-        self, harness
-    ):
+    async def test_error_watermark_discard_consumes_both_channels_without_backlog(self, harness):
         plugin = await harness.connect_plugin(session_id="err-discard")
         client = GodotClient(
             harness.server,

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -60,16 +60,22 @@ class TestHandshake:
         ## (1013) from ordinary closes. The free-form reason stays in local
         ## logs only.
         captured = {}
+        unregistered = asyncio.Event()
         real_unregister = harness.registry.unregister
 
         def spy(session_id, close_code=None):
             captured["close_code"] = close_code
-            return real_unregister(session_id, close_code=close_code)
+            try:
+                return real_unregister(session_id, close_code=close_code)
+            finally:
+                unregistered.set()
 
         monkeypatch.setattr(harness.registry, "unregister", spy)
         plugin = await harness.connect_plugin(session_id="sess-cc")
         await plugin.ws.close(code=1011, reason="keepalive ping timeout")
-        await asyncio.sleep(0.1)  # let server process disconnect
+        ## Deterministic wait — a fixed sleep can race server cleanup under
+        ## CI load (CodeRabbit review on #817).
+        await asyncio.wait_for(unregistered.wait(), timeout=2.0)
         assert captured["close_code"] == 1011
         assert harness.registry.get("sess-cc") is None
 

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -1752,9 +1752,7 @@ async def test_logs_read_handler_plugin_normalizes_structured_payload():
     ## the public Python API still returns the legacy [str] shape for that
     ## source so existing callers don't shift.
     class StructuredPluginClient(StubClient):
-        async def send(
-            self, command, params=None, session_id=None, timeout=5.0, hint_policy=None
-        ):
+        async def send(self, command, params=None, session_id=None, timeout=5.0, hint_policy=None):
             self.calls.append(
                 {
                     "command": command,
@@ -2710,7 +2708,12 @@ async def test_run_tests_handler_with_no_params():
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)
     result = await testing_handlers.test_run(runtime)
     assert result["passed"] == 5
-    assert client.calls[-1]["params"] == {}
+    ## The per-call budget always rides in the envelope so the plugin can
+    ## derive its between-test abort ceiling from the same constant that
+    ## bounds the server-side await (transport-starvation plan D2).
+    assert client.calls[-1]["params"] == {
+        "timeout_budget_sec": testing_handlers.TEST_RUN_TIMEOUT_SEC
+    }
 
 
 async def test_run_tests_handler_uses_full_suite_timeout():
@@ -2725,14 +2728,21 @@ async def test_run_tests_handler_with_suite_and_test_name():
     client = StubClient()
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)
     await testing_handlers.test_run(runtime, suite="scene", test_name="test_tree")
-    assert client.calls[-1]["params"] == {"suite": "scene", "test_name": "test_tree"}
+    assert client.calls[-1]["params"] == {
+        "suite": "scene",
+        "test_name": "test_tree",
+        "timeout_budget_sec": testing_handlers.TEST_RUN_TIMEOUT_SEC,
+    }
 
 
 async def test_run_tests_handler_with_exclude_test_name():
     client = StubClient()
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)
     await testing_handlers.test_run(runtime, exclude_test_name="test_flaky")
-    assert client.calls[-1]["params"] == {"exclude_test_name": "test_flaky"}
+    assert client.calls[-1]["params"] == {
+        "exclude_test_name": "test_flaky",
+        "timeout_budget_sec": testing_handlers.TEST_RUN_TIMEOUT_SEC,
+    }
 
 
 async def test_get_test_results_handler():
@@ -2747,7 +2757,10 @@ async def test_run_tests_handler_verbose():
     client = StubClient()
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)
     await testing_handlers.test_run(runtime, verbose=True)
-    assert client.calls[-1]["params"] == {"verbose": True}
+    assert client.calls[-1]["params"] == {
+        "verbose": True,
+        "timeout_budget_sec": testing_handlers.TEST_RUN_TIMEOUT_SEC,
+    }
 
 
 async def test_get_test_results_handler_verbose():
@@ -3875,9 +3888,7 @@ async def test_project_stop_handler_passes_through_idempotent_payload():
     """
 
     class IdempotentStopClient(StubClient):
-        async def send(
-            self, command, params=None, session_id=None, timeout=5.0, hint_policy=None
-        ):
+        async def send(self, command, params=None, session_id=None, timeout=5.0, hint_policy=None):
             self.calls.append({"command": command, "params": params})
             return {
                 "stopped": True,
@@ -3897,9 +3908,7 @@ async def test_project_run_handler_passes_through_already_running_payload():
     """Idempotent-run path (was_already_running=true) flows through unchanged."""
 
     class AlreadyRunningClient(StubClient):
-        async def send(
-            self, command, params=None, session_id=None, timeout=5.0, hint_policy=None
-        ):
+        async def send(self, command, params=None, session_id=None, timeout=5.0, hint_policy=None):
             self.calls.append({"command": command, "params": params})
             return {
                 "mode": (params or {}).get("mode", "main"),
@@ -4106,9 +4115,7 @@ async def test_editor_screenshot_handler_custom_angles():
 
 async def test_editor_screenshot_handler_view_target_not_found_single():
     class NotFoundClient:
-        async def send(
-            self, command, params=None, session_id=None, timeout=5.0, hint_policy=None
-        ):
+        async def send(self, command, params=None, session_id=None, timeout=5.0, hint_policy=None):
             return {
                 "source": "viewport",
                 "width": 1,
@@ -4132,9 +4139,7 @@ async def test_editor_screenshot_handler_view_target_not_found_single():
 
 async def test_editor_screenshot_handler_view_target_not_found_coverage():
     class NotFoundCoverageClient:
-        async def send(
-            self, command, params=None, session_id=None, timeout=5.0, hint_policy=None
-        ):
+        async def send(self, command, params=None, session_id=None, timeout=5.0, hint_policy=None):
             return {
                 "source": "viewport",
                 "view_target": params["view_target"],
@@ -4209,9 +4214,7 @@ async def test_editor_screenshot_handler_relays_viewport_not_3d_error():
     from godot_ai.godot_client.client import GodotCommandError
 
     class ViewportNot3DClient:
-        async def send(
-            self, command, params=None, session_id=None, timeout=5.0, hint_policy=None
-        ):
+        async def send(self, command, params=None, session_id=None, timeout=5.0, hint_policy=None):
             raise GodotCommandError(
                 code="EDITOR_NOT_READY",
                 message=(
@@ -4247,9 +4250,7 @@ async def test_editor_screenshot_handler_relays_viewport_empty_error():
     from godot_ai.godot_client.client import GodotCommandError
 
     class ViewportEmptyClient:
-        async def send(
-            self, command, params=None, session_id=None, timeout=5.0, hint_policy=None
-        ):
+        async def send(self, command, params=None, session_id=None, timeout=5.0, hint_policy=None):
             raise GodotCommandError(
                 code="EDITOR_NOT_READY",
                 message="Captured an empty image from viewport.",
@@ -5058,9 +5059,7 @@ def _make_stop_project_runtime(
     from godot_ai.sessions.registry import Session
 
     class ReadinessAfterStub(StubClient):
-        async def send(
-            self, command, params=None, session_id=None, timeout=5.0, hint_policy=None
-        ):
+        async def send(self, command, params=None, session_id=None, timeout=5.0, hint_policy=None):
             self.calls.append({"command": command, "params": params})
             return {"stopped": True, "undoable": False, "readiness_after": readiness_after}
 

--- a/tests/unit/test_telemetry_integration.py
+++ b/tests/unit/test_telemetry_integration.py
@@ -103,6 +103,26 @@ class TestSessionRegistryTelemetry:
         ]
         assert len(match) == 1
         assert match[0].data["session_count"] == 0
+        ## close_code is always present; None means no close frame was
+        ## observed (non-WS teardown), a numeric value is the normalized
+        ## WebSocket close code (1011 keepalive, 1013 exclusive-run flood).
+        assert "close_code" in match[0].data
+        assert match[0].data["close_code"] is None
+
+    def test_unregister_records_normalized_close_code(self, captured) -> None:
+        reg = SessionRegistry()
+        reg.register(self._make_session())
+        reg.unregister("demo@a3f2", close_code=1011)
+        _wait_for(captured, 2)
+
+        match = [
+            r
+            for r in captured
+            if r.record_type is tel.RecordType.GODOT_CONNECTION
+            and r.data.get("event") == "disconnected"
+        ]
+        assert len(match) == 1
+        assert match[0].data["close_code"] == 1011
 
     def test_multiple_sessions_milestone(self, captured) -> None:
         reg = SessionRegistry()


### PR DESCRIPTION
## Problem

`run_tests` executes the whole suite synchronously on the editor main thread. The WebSocket is serviced only by `McpConnection._process`, and the Python server uses the `websockets` default keepalive (20s ping / 20s timeout, never overridden). Any suite whose run exceeds ~20-40s therefore starves the pong: the server closes the socket (1011), unregisters the session, and fails the in-flight `test_run` with `ConnectionError` — surfacing to the MCP client as "MCP disconnected". Reported on Discord (plugin 3.0.5, Godot 4.7.1); the threshold is duration, not test count.

**Red-harness proof on HEAD** (commit 1, before the fix):
```
REPRODUCED: test_run failed after 35s
Error: Session test-project@39d6 disconnected while the command was in flight
```

## Fix

**Plugin**
- `McpConnection.service_transport_during_exclusive_run()` — called by the runner between tests, suite phases, and discovery script-loads. Polls and **drains to quiescence**: `poll()` has no heartbeat-only mode, so every application frame received mid-run is handled immediately — acks processed, malformed frames replied to normally, valid commands **rejected** with retryable `EDITOR_NOT_READY` / `EDITOR_TEST_RUNNING` (never buffered: a buffered command would replay stale after its server-side future expires). Cumulative per-run packet cap (2048, all frame kinds counted) closes the connection (1013) under flood.
- `McpTestRunner.run_suites_serviced()` — shared execution core with the unchanged legacy `run_suites()`; between-phase checkpoints enforce a best-effort abort ceiling and return an explicit outcome (`completed | timeout | transport_lost | paused`). Every abort path still runs current-suite teardown + leak cleanup and restores console echo / the capture logger. Per-test `duration_ms` added.
- Handler: server-provided `timeout_budget_sec` strictly validated and clamped [30, 3600] (default 110s — safely inside an old server's 120s); discovery runs inside the deadline/outcome lifecycle; deterministic outcome-to-envelope mapping (`TEST_RUN_TIMEOUT` carries the partial summary; partials stay retrievable via `test_manage(op="results_get")`).
- `run_tests` added to `batch_execute`'s `FORBIDDEN_SUBCOMMANDS` (a batch has no transport servicing and a 30s server budget).

**Server**
- `TEST_RUN_TIMEOUT_SEC` 120 -> 300, threaded into the command envelope from the same constant that bounds the await (no drift, no handshake race).
- Disconnects now log + record the normalized WebSocket close code in `GODOT_CONNECTION` telemetry, so 1011 keepalive kills are measurable before/after release.
- Error-code parity both sides: `TEST_RUN_TIMEOUT`, `EDITOR_TEST_RUNNING`.

## Verification (live, Godot 4.6.3 headless)

- `script/ci-slow-suite-smoke` (new regression harness, 25 x 2s blocking fixture): **red on HEAD** (above) -> **green on this branch** — 25/25 passed in 51s, same session, zero disconnects in the server log.
- Full corpus over live MCP: **1979 passed / 0 failed / 64 suites** (refactor equivalence).
- Concurrent-client E2E: mid-run `node_create` from a second client rejected in **1s** with `EDITOR_TEST_RUNNING`; the mutation verifiably never executed.
- Flood E2E (cap temporarily lowered to 64 to exercise the mechanism; the 2048 boundary is unit-tested): exactly cap rejects -> close `1013 "command flood during test run"` (visible via the new close-code logging) -> plugin auto-reconnects -> partials retrievable via `results_get`.
- Old-server pairing: the first green harness ran against a pre-change server binary — the 110s fallback ceiling engaged as designed.
- `pytest`: 1473 passed; ruff clean; 20 new GDScript unit tests (`test_serviced_test_run.gd`).

## Design record

`docs/test-run-transport-starvation-plan.md` — the approved plan including three rounds of external review with full disposition tables (section 8). Notable decisions: no frame-yielding (rejected twice in review — leak-cleanup deletion hazard + gate orphaning; parked as Phase 2 with prerequisites), drain-and-reject over buffering, per-call budget over handshake advertisement (registration/ack race).

Known residual limitation (documented): a **single** atomic phase blocking the main thread longer than the heartbeat window (~20-40s) still drops the session — which doubles as the fail-fast for genuinely hung tests.

Relation to #816: no file overlap, but two contract edges — the attach bridge must tolerate 300s tool calls, and `EDITOR_TEST_RUNNING` is a new retryable recovery state bridges should pass through unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Long-running test runs now service the connection during execution using an exclusive servicing mode, enforce a 300-second budget, and return partial results on abort.
  * Verbose results include `duration_ms` per executed test.
  * Commands received during active runs get structured retryable “busy” responses; `run_tests` is rejected inside batch execution.
* **Bug Fixes**
  * Malformed commands now return structured validation errors instead of being dropped silently.
  * Disconnect telemetry now records the WebSocket `close_code` when available.
* **Documentation**
  * Updated guidance for `test_run` timeout budgeting and partial-results behavior.
* **Tests**
  * Added regression/E2E coverage, including CI slow-suite smoke fixtures and serviced-run timeout/transport/pause outcome checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->