### PR TITLE
Diagnose and survive the stargazers API outage

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -50,9 +50,16 @@ jobs:
         ## Restore via a temp file: `> star-history.json` would create the file
         ## before git show could fail, leaving an empty one that the generator
         ## then has to treat as corrupt. Only move it into place on success.
+        ##
+        ## The refspec must be explicit. actions/checkout configures a narrow
+        ## remote.origin.fetch covering only the checked-out branch, so a bare
+        ## `git fetch origin star-history` populates FETCH_HEAD without ever
+        ## creating refs/remotes/origin/star-history — git show would then fail
+        ## and every run would report "no series yet" while the branch had one.
         run: |
           if git ls-remote --exit-code --heads origin star-history >/dev/null; then
-            git fetch --depth 1 origin star-history
+            git fetch --depth 1 origin \
+              '+refs/heads/star-history:refs/remotes/origin/star-history'
             if git show origin/star-history:star-history.json > series.tmp; then
               mv series.tmp star-history.json
               echo "restored $(wc -c < star-history.json) bytes of stored series"

--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -47,10 +47,22 @@ jobs:
         ## The series is the chart's memory. Exact per-star history is
         ## preferred, but when GitHub refuses the stargazers list the run
         ## extends this instead of failing, so it must survive across runs.
+        ## Restore via a temp file: `> star-history.json` would create the file
+        ## before git show could fail, leaving an empty one that the generator
+        ## then has to treat as corrupt. Only move it into place on success.
         run: |
-          git fetch --depth 1 origin star-history || true
-          git show origin/star-history:star-history.json > star-history.json \
-            || echo "no stored series yet — a successful history fetch will create it"
+          if git ls-remote --exit-code --heads origin star-history >/dev/null; then
+            git fetch --depth 1 origin star-history
+            if git show origin/star-history:star-history.json > series.tmp; then
+              mv series.tmp star-history.json
+              echo "restored $(wc -c < star-history.json) bytes of stored series"
+            else
+              rm -f series.tmp
+              echo "branch carries no series yet — an exact-history fetch will create it"
+            fi
+          else
+            echo "star-history branch does not exist yet — it will be created on publish"
+          fi
 
       - name: Generate chart
         env:

--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -8,8 +8,12 @@ name: Star history chart
 ## Background: GitHub restricted detailed stargazer history to repo
 ## admins/collaborators, which broke star-history.com's unauthenticated
 ## embed — so we render the chart ourselves with a collaborator PAT
-## (the STAR_HISTORY_TOKEN secret; the workflow token is an app token,
-## not a collaborator, and gets 403 on stargazer history).
+## (the STAR_HISTORY_TOKEN secret).
+##
+## Since 2026-07-24 the stargazers endpoint refuses every credential class
+## (403 demanding `contents=write` to read a public list; anonymous gets 401),
+## so runs currently take the fallback path: extend the stored series with the
+## repo's stargazers_count. Diagnosis and evidence in docs/star-history.md.
 on:
   workflow_dispatch:
   schedule:
@@ -39,22 +43,38 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: Restore the accumulated series
+        ## The series is the chart's memory. Exact per-star history is
+        ## preferred, but when GitHub refuses the stargazers list the run
+        ## extends this instead of failing, so it must survive across runs.
+        run: |
+          git fetch --depth 1 origin star-history || true
+          git show origin/star-history:star-history.json > star-history.json \
+            || echo "no stored series yet — a successful history fetch will create it"
+
       - name: Generate chart
         env:
           GITHUB_TOKEN: ${{ github.token }}
           STAR_HISTORY_TOKEN: ${{ secrets.STAR_HISTORY_TOKEN }}
-        run: python script/generate-star-history --repo "$GITHUB_REPOSITORY" --out star-history.svg
+        run: |
+          python script/generate-star-history \
+            --repo "$GITHUB_REPOSITORY" \
+            --series star-history.json \
+            --out star-history.svg
 
       - name: Publish to the star-history branch
-        ## The branch holds exactly one orphan commit — history lives in the
-        ## chart itself — so each run rebuilds it with git plumbing and
-        ## force-pushes. If the branch was deleted, this recreates it.
+        ## The branch holds exactly one orphan commit — the chart and its
+        ## series — so each run rebuilds it with git plumbing and force-pushes.
+        ## If the branch was deleted, this recreates it.
         ## Any protection rule on star-history must restrict deletions ONLY
         ## and leave force pushes allowed, or this push starts failing.
+        ## git mktree requires entries sorted by name (.json before .svg).
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          blob=$(git hash-object -w star-history.svg)
-          tree=$(printf '100644 blob %s\tstar-history.svg\n' "$blob" | git mktree)
+          json_blob=$(git hash-object -w star-history.json)
+          svg_blob=$(git hash-object -w star-history.svg)
+          tree=$(printf '100644 blob %s\tstar-history.json\n100644 blob %s\tstar-history.svg\n' \
+            "$json_blob" "$svg_blob" | git mktree)
           commit=$(git commit-tree "$tree" -m "Update star history chart")
           git push --force origin "$commit:refs/heads/star-history"

--- a/docs/star-history.md
+++ b/docs/star-history.md
@@ -1,0 +1,71 @@
+# Star history chart
+
+The README's star-history chart is rendered by
+[`script/generate-star-history`](../script/generate-star-history) and published
+by [`.github/workflows/star-history.yml`](../.github/workflows/star-history.yml)
+to the dedicated `star-history` branch, which the README embeds by raw URL.
+
+Publishing off `main` keeps chart refreshes out of `main`'s history, lets the
+job run daily, and stops it conflicting with PRs (#818, #819).
+
+## Data sources, in preference order
+
+1. **Exact history** — `GET /repos/{repo}/stargazers` with
+   `Accept: application/vnd.github.star+json`, which returns a `starred_at`
+   timestamp per stargazer. This rebuilds the entire curve from scratch and
+   corrects any drift, so it is used whenever it is reachable.
+2. **Accumulated series** — `star-history.json` on the `star-history` branch,
+   a list of `[date, count]` points. When the stargazers endpoint refuses the
+   request, the run keeps this history and appends one point from
+   `GET /repos/{repo}` → `stargazers_count`, which needs only `metadata=read`.
+
+The series is the chart's memory. A run that cannot reach either source fails
+loudly rather than drawing an invented curve.
+
+## The 2026-07-24 outage
+
+Daily runs began failing `403` on 2026-07-24 even though `STAR_HISTORY_TOKEN`
+was set and healthy. Probing all three credential classes against the same repo
+in the same minute (workflow run 30161903920 / 30161955416):
+
+| Credential | `GET /repos/{repo}` | stargazers (plain) | stargazers (`star+json`) |
+| --- | --- | --- | --- |
+| Fine-grained PAT (repo admin) | 200 | 403 | 403 |
+| Workflow `GITHUB_TOKEN` (App) | 200 | 403 | 403 |
+| No `Authorization` header | — | 401 | 401 |
+
+The 403s carry `x-accepted-github-permissions: 'metadata=read; contents=write'`
+and `message: Resource not accessible by personal access token`.
+
+What that establishes:
+
+- **The token is fine.** It authenticates (`/user` → 200), has a 5,000/hr
+  limit, and reads `/repos/{repo}` on `metadata=read` alone.
+- **It is not about the timestamps.** The plain stargazer list — public data —
+  fails identically to the `star+json` variant, so this is not the
+  admins-and-collaborators restriction that motivated #750.
+- **The demanded permission is incoherent.** Reading a public list cannot
+  legitimately require *write* access to repository contents.
+- **It is not specific to us.** A GitHub App token fails the same way, which no
+  org policy or token grant can explain.
+
+Do **not** grant `contents=write` to work around this: it is repository write
+access in exchange for a README image, and it would be pointless privilege once
+GitHub corrects the mapping. The fallback path above keeps the chart current
+with the permissions the token already has.
+
+When the endpoint recovers, no change is needed — source 1 is tried first on
+every run and will silently resume, rebuilding the exact curve.
+
+## Local use
+
+```bash
+# Offline, from explicit points — no network, no token.
+script/generate-star-history --seed "2026-04-12:0,2026-07-16:1009" --out /tmp/chart.svg
+
+# Against the live API.
+STAR_HISTORY_TOKEN=... script/generate-star-history --repo owner/name
+```
+
+Rendering is deterministic for a given (repo, data, date) — the starfield is
+seeded from the repo name — so unchanged data produces byte-identical output.

--- a/script/generate-star-history
+++ b/script/generate-star-history
@@ -214,20 +214,43 @@ def fetch_star_count(repo: str, token: str, token_source: str) -> int:
     return count
 
 
-def load_series(path: str) -> list[tuple[date, int]]:
-    """Read the accumulated (date, count) series, or [] if absent."""
+def load_series(path: str, repo: str) -> list[tuple[date, int]]:
+    """Read the accumulated (date, count) series for `repo`, or [] if absent.
+
+    An *empty* file counts as absent. The workflow restores this file from a
+    branch that may not carry it yet, and a shell redirection creates the file
+    before the command feeding it can fail — so a half-created file must not
+    wedge the run before it can even try the exact-history path.
+
+    A series belonging to another repo is refused rather than silently
+    rendered: its points would be drawn as this repo's history and then
+    overwritten with this repo's, destroying both.
+    """
     try:
         with open(path, encoding="utf-8") as fh:
-            payload = json.load(fh)
+            raw = fh.read()
     except FileNotFoundError:
         return []
+    if not raw.strip():
+        return []
+    try:
+        payload = json.loads(raw)
     except ValueError as err:
         raise SystemExit(f"{path} is not valid JSON: {err}") from err
+
+    stored = payload.get("repo")
+    if stored and stored != repo:
+        raise SystemExit(
+            f"{path} holds the series for {stored}, not {repo}. Point --series "
+            f"at that repo's file, or delete it to start a fresh series — "
+            f"grafting one repo's history onto another would corrupt both."
+        )
     points = [(date.fromisoformat(d), int(c)) for d, c in payload.get("points", [])]
     return sorted(points)
 
 
 def save_series(path: str, repo: str, points: list[tuple[date, int]]) -> None:
+    """Write the series, stamped with the repo it belongs to."""
     payload = {
         "repo": repo,
         "points": [[d.isoformat(), c] for d, c in points],
@@ -521,7 +544,7 @@ def main() -> None:
         if not token:
             raise SystemExit("set GITHUB_TOKEN (or STAR_HISTORY_TOKEN), or use --seed")
 
-        series = load_series(args.series)
+        series = load_series(args.series, args.repo)
         try:
             ## Exact per-star history is still the preferred source: when the
             ## endpoint is reachable it rebuilds the whole curve and corrects

--- a/script/generate-star-history
+++ b/script/generate-star-history
@@ -15,12 +15,20 @@ date) — the starfield is seeded from the repo name — so reruns with unchange
 data produce byte-identical output and the workflow's "chart unchanged" check
 keeps working.
 
+Two data sources, in preference order. Exact per-star history rebuilds the
+whole curve and is used whenever the stargazers endpoint is reachable. When it
+refuses (as it has since 2026-07-24 — see docs/star-history.md), the run keeps
+the history banked in `--series` and extends it with the repo's
+`stargazers_count`, which needs only `metadata=read`. A run that can reach
+neither fails rather than drawing an invented curve.
+
 Usage:
     GITHUB_TOKEN=... script/generate-star-history [--repo owner/name] [--out path]
     script/generate-star-history --seed "2026-04-12:0,2026-07-16:1009" --out path
 
 `--seed` renders a chart from explicit `date:count` points without touching
-the network — used to commit an initial chart and for offline testing.
+the network — used to commit an initial chart and for offline testing; it
+neither reads nor writes the series.
 
 Stdlib only; no dependencies.
 """
@@ -31,6 +39,7 @@ import argparse
 import json
 import math
 import os
+import sys
 import urllib.error
 import urllib.request
 import zlib
@@ -59,6 +68,15 @@ GRID_COLOR = "#4a5470"
 LINE_START = "#4f9cff"
 LINE_END = "#ffd166"
 GOLD = "#ffd166"
+
+
+class StargazerFetchError(SystemExit):
+    """A refused stargazers request, carrying the full diagnostic.
+
+    Derives from SystemExit so an uncaught one still exits 1 with the message
+    printed, while callers that have a stored series can catch it specifically
+    and carry on.
+    """
 
 
 def describe_http_error(err: urllib.error.HTTPError, url: str, token_source: str) -> str:
@@ -151,7 +169,7 @@ def fetch_star_dates(repo: str, token: str, token_source: str = "STAR_HISTORY_TO
                 batch = json.load(resp)
         except urllib.error.HTTPError as err:
             if 400 <= err.code < 500:
-                raise SystemExit(describe_http_error(err, url, token_source)) from err
+                raise StargazerFetchError(describe_http_error(err, url, token_source)) from err
             raise
         if not batch:
             break
@@ -163,6 +181,71 @@ def fetch_star_dates(repo: str, token: str, token_source: str = "STAR_HISTORY_TO
             break
     dates.sort()
     return dates
+
+
+def fetch_star_count(repo: str, token: str, token_source: str) -> int:
+    """Return the repo's current stargazers_count.
+
+    Deliberately a different endpoint from fetch_star_dates: /repos/{repo}
+    answers on `metadata=read` alone, and kept working through the 2026-07-24
+    outage that made the stargazers list demand `contents=write` (see
+    docs/star-history.md). It gives a total but no history, which is why the
+    series file exists.
+    """
+    url = f"{API_ROOT}/repos/{repo}"
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = json.load(resp)
+    except urllib.error.HTTPError as err:
+        if 400 <= err.code < 500:
+            raise StargazerFetchError(describe_http_error(err, url, token_source)) from err
+        raise
+    count = payload.get("stargazers_count")
+    if not isinstance(count, int):
+        raise StargazerFetchError(f"{url} returned no stargazers_count")
+    return count
+
+
+def load_series(path: str) -> list[tuple[date, int]]:
+    """Read the accumulated (date, count) series, or [] if absent."""
+    try:
+        with open(path, encoding="utf-8") as fh:
+            payload = json.load(fh)
+    except FileNotFoundError:
+        return []
+    except ValueError as err:
+        raise SystemExit(f"{path} is not valid JSON: {err}") from err
+    points = [(date.fromisoformat(d), int(c)) for d, c in payload.get("points", [])]
+    return sorted(points)
+
+
+def save_series(path: str, repo: str, points: list[tuple[date, int]]) -> None:
+    payload = {
+        "repo": repo,
+        "points": [[d.isoformat(), c] for d, c in points],
+    }
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(payload, fh, indent=1)
+        fh.write("\n")
+
+
+def append_today(series: list[tuple[date, int]], count: int, today: date) -> list[tuple[date, int]]:
+    """Extend the series with today's total, replacing a same-day point.
+
+    Same-day replacement keeps reruns idempotent; without it a manual dispatch
+    after the scheduled run would stack duplicate x-positions onto the curve.
+    """
+    points = [(d, c) for d, c in series if d != today]
+    points.append((today, count))
+    return sorted(points)
 
 
 def cumulative_points(star_dates: list[date]) -> list[tuple[date, int]]:
@@ -413,6 +496,12 @@ def main() -> None:
     parser.add_argument("--repo", default="hi-godot/godot-ai")
     parser.add_argument("--out", default="star-history.svg")
     parser.add_argument(
+        "--series",
+        default="star-history.json",
+        help="accumulated date:count points, carried between runs so the "
+        "chart survives the stargazers endpoint being unavailable",
+    )
+    parser.add_argument(
         "--seed",
         help="comma-separated date:count points to render offline "
         '(e.g. "2026-04-12:0,2026-07-16:1009")',
@@ -431,10 +520,30 @@ def main() -> None:
             token = os.environ.get("GITHUB_TOKEN")
         if not token:
             raise SystemExit("set GITHUB_TOKEN (or STAR_HISTORY_TOKEN), or use --seed")
-        star_dates = fetch_star_dates(args.repo, token, token_source)
-        if not star_dates:
-            raise SystemExit(f"no stargazer data returned for {args.repo}")
-        points = cumulative_points(star_dates)
+
+        series = load_series(args.series)
+        try:
+            ## Exact per-star history is still the preferred source: when the
+            ## endpoint is reachable it rebuilds the whole curve and corrects
+            ## any drift the append-only path accumulated.
+            star_dates = fetch_star_dates(args.repo, token, token_source)
+            if not star_dates:
+                raise SystemExit(f"no stargazer data returned for {args.repo}")
+            points = cumulative_points(star_dates)
+        except StargazerFetchError as err:
+            if not series:
+                raise
+            ## Degrade instead of failing: keep the history already banked and
+            ## extend it with a total from an endpoint that still answers.
+            print(
+                f"stargazer history unavailable, extending the stored series "
+                f"with today's total instead.\n{err}",
+                file=sys.stderr,
+            )
+            count = fetch_star_count(args.repo, token, token_source)
+            points = append_today(series, count, datetime.now(timezone.utc).date())
+
+        save_series(args.series, args.repo, points)
 
     svg = render_svg(points, args.repo)
     with open(args.out, "w", encoding="utf-8") as fh:

--- a/script/generate-star-history
+++ b/script/generate-star-history
@@ -61,7 +61,75 @@ LINE_END = "#ffd166"
 GOLD = "#ffd166"
 
 
-def fetch_star_dates(repo: str, token: str) -> list[date]:
+def describe_http_error(
+    err: urllib.error.HTTPError, url: str, token_source: str
+) -> str:
+    """Explain a refused stargazers request using GitHub's own answer.
+
+    GitHub states the reason in the response body and the rate-limit headers,
+    and the distinctions matter: 401 means the credential itself was rejected,
+    a 403 with an exhausted quota is a rate limit, and any other 403 means the
+    token is alive but not authorized for this repo (org PAT policy, a revoked
+    or still-unapproved grant, SAML). A hardcoded hint cannot tell those apart
+    and sent a real investigation down the wrong path (#750 follow-up), so
+    quote the API verbatim and only then suggest where to look.
+    """
+    try:
+        api_message = json.loads(err.read().decode("utf-8", "replace")).get("message")
+    except (ValueError, OSError):
+        api_message = None
+
+    headers = err.headers or {}
+    remaining = headers.get("x-ratelimit-remaining")
+    rate_limited = err.code in (403, 429) and remaining == "0"
+
+    lines = [
+        f"GitHub API returned {err.code} for {url}.",
+        f'GitHub says: "{api_message}"'
+        if api_message
+        else "GitHub returned no message body.",
+        f"Token used: {token_source}.",
+    ]
+
+    if rate_limited:
+        reset = headers.get("x-ratelimit-reset")
+        when = ""
+        if reset and reset.isdigit():
+            when = (
+                " (resets "
+                + datetime.fromtimestamp(int(reset), timezone.utc).strftime(
+                    "%Y-%m-%d %H:%M UTC"
+                )
+                + ")"
+            )
+        lines.append(f"Rate limited: 0 requests remaining{when}. Retry later.")
+    elif err.code == 401:
+        lines.append(
+            "The credential itself was rejected — the token is expired, revoked, "
+            "or malformed. Issue a new collaborator PAT and update the "
+            "STAR_HISTORY_TOKEN secret."
+        )
+    elif err.code == 403:
+        lines.append(
+            "The token is live but not authorized for this repo's stargazer "
+            "history. Check, in order: the org's personal-access-token policy "
+            "(a policy change can revoke a working token), whether the token's "
+            "approval or repository-access grant was withdrawn, and whether it "
+            "has expired. Note the workflow's built-in GITHUB_TOKEN is a GitHub "
+            "App token, not a collaborator, and is always refused here."
+        )
+    elif err.code == 404:
+        lines.append(
+            f"The token cannot see {url.split('/repos/')[-1].split('/stargazers')[0]} "
+            "at all — check the repo name and the token's repository access."
+        )
+
+    return "\n".join(lines)
+
+
+def fetch_star_dates(
+    repo: str, token: str, token_source: str = "STAR_HISTORY_TOKEN"
+) -> list[date]:
     """Return the starred_at date of every stargazer, oldest first."""
     dates: list[date] = []
     for page in range(1, MAX_PAGES + 1):
@@ -78,14 +146,8 @@ def fetch_star_dates(repo: str, token: str) -> list[date]:
             with urllib.request.urlopen(req, timeout=30) as resp:
                 batch = json.load(resp)
         except urllib.error.HTTPError as err:
-            if err.code in (401, 403, 404):
-                raise SystemExit(
-                    f"GitHub API returned {err.code} for {url}.\n"
-                    "Stargazer history requires repo-collaborator access. In CI, "
-                    "pass the workflow GITHUB_TOKEN; if GitHub stops granting it "
-                    "stargazer access, set a collaborator PAT as the "
-                    "STAR_HISTORY_TOKEN secret instead."
-                ) from err
+            if 400 <= err.code < 500:
+                raise SystemExit(describe_http_error(err, url, token_source)) from err
             raise
         if not batch:
             break
@@ -358,10 +420,16 @@ def main() -> None:
     if args.seed:
         points = parse_seed(args.seed)
     else:
-        token = os.environ.get("STAR_HISTORY_TOKEN") or os.environ.get("GITHUB_TOKEN")
+        ## Which token answered matters when a run is refused, so name it
+        ## rather than collapsing the two into one lookup.
+        token_source = "STAR_HISTORY_TOKEN"
+        token = os.environ.get("STAR_HISTORY_TOKEN")
+        if not token:
+            token_source = "GITHUB_TOKEN (fallback)"
+            token = os.environ.get("GITHUB_TOKEN")
         if not token:
             raise SystemExit("set GITHUB_TOKEN (or STAR_HISTORY_TOKEN), or use --seed")
-        star_dates = fetch_star_dates(args.repo, token)
+        star_dates = fetch_star_dates(args.repo, token, token_source)
         if not star_dates:
             raise SystemExit(f"no stargazer data returned for {args.repo}")
         points = cumulative_points(star_dates)

--- a/script/generate-star-history
+++ b/script/generate-star-history
@@ -61,18 +61,16 @@ LINE_END = "#ffd166"
 GOLD = "#ffd166"
 
 
-def describe_http_error(
-    err: urllib.error.HTTPError, url: str, token_source: str
-) -> str:
+def describe_http_error(err: urllib.error.HTTPError, url: str, token_source: str) -> str:
     """Explain a refused stargazers request using GitHub's own answer.
 
     GitHub states the reason in the response body and the rate-limit headers,
     and the distinctions matter: 401 means the credential itself was rejected,
-    a 403 with an exhausted quota is a rate limit, and any other 403 means the
-    token is alive but not authorized for this repo (org PAT policy, a revoked
-    or still-unapproved grant, SAML). A hardcoded hint cannot tell those apart
-    and sent a real investigation down the wrong path (#750 follow-up), so
-    quote the API verbatim and only then suggest where to look.
+    a throttled 403 is a rate limit, and any other 403 means the token is alive
+    but not authorized for this repo (org PAT policy, a revoked or
+    still-unapproved grant, SAML). A hardcoded hint cannot tell those apart and
+    sent a real investigation down the wrong path (#750 follow-up), so quote
+    the API verbatim and only then suggest where to look.
     """
     try:
         api_message = json.loads(err.read().decode("utf-8", "replace")).get("message")
@@ -81,28 +79,36 @@ def describe_http_error(
 
     headers = err.headers or {}
     remaining = headers.get("x-ratelimit-remaining")
-    rate_limited = err.code in (403, 429) and remaining == "0"
+    retry_after = headers.get("retry-after")
+    ## A *secondary* limit answers 403 with primary quota still on the clock,
+    ## so remaining == "0" alone misses it and the run would be reported as an
+    ## authorization failure — telling the reader to go replace a token that
+    ## is working fine. Retry-After and the message text are the other tells.
+    throttled_message = bool(api_message) and "rate limit" in api_message.lower()
+    rate_limited = err.code == 429 or (
+        err.code == 403 and (remaining == "0" or retry_after is not None or throttled_message)
+    )
 
     lines = [
         f"GitHub API returned {err.code} for {url}.",
-        f'GitHub says: "{api_message}"'
-        if api_message
-        else "GitHub returned no message body.",
+        f'GitHub says: "{api_message}"' if api_message else "GitHub returned no message body.",
         f"Token used: {token_source}.",
     ]
 
     if rate_limited:
+        detail = []
+        if remaining is not None:
+            detail.append(f"{remaining} requests remaining")
         reset = headers.get("x-ratelimit-reset")
-        when = ""
         if reset and reset.isdigit():
-            when = (
-                " (resets "
-                + datetime.fromtimestamp(int(reset), timezone.utc).strftime(
-                    "%Y-%m-%d %H:%M UTC"
-                )
-                + ")"
+            detail.append(
+                "resets "
+                + datetime.fromtimestamp(int(reset), timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
             )
-        lines.append(f"Rate limited: 0 requests remaining{when}. Retry later.")
+        if retry_after:
+            detail.append(f"retry after {retry_after}s")
+        suffix = f" ({'; '.join(detail)})" if detail else ""
+        lines.append(f"Rate limited{suffix}. Retry later.")
     elif err.code == 401:
         lines.append(
             "The credential itself was rejected — the token is expired, revoked, "
@@ -127,9 +133,7 @@ def describe_http_error(
     return "\n".join(lines)
 
 
-def fetch_star_dates(
-    repo: str, token: str, token_source: str = "STAR_HISTORY_TOKEN"
-) -> list[date]:
+def fetch_star_dates(repo: str, token: str, token_source: str = "STAR_HISTORY_TOKEN") -> list[date]:
     """Return the starred_at date of every stargazer, oldest first."""
     dates: list[date] = []
     for page in range(1, MAX_PAGES + 1):
@@ -154,9 +158,7 @@ def fetch_star_dates(
         for entry in batch:
             starred_at = entry.get("starred_at")
             if starred_at:
-                dates.append(
-                    datetime.fromisoformat(starred_at.replace("Z", "+00:00")).date()
-                )
+                dates.append(datetime.fromisoformat(starred_at.replace("Z", "+00:00")).date())
         if len(batch) < PER_PAGE:
             break
     dates.sort()

--- a/tests/unit/test_generate_star_history.py
+++ b/tests/unit/test_generate_star_history.py
@@ -185,12 +185,44 @@ def test_series_round_trips(tmp_path):
     path = tmp_path / "series.json"
     points = [(date(2026, 4, 13), 2), (date(2026, 7, 25), 1221)]
     gsh.save_series(str(path), "hi-godot/godot-ai", points)
-    assert gsh.load_series(str(path)) == points
+    assert gsh.load_series(str(path), "hi-godot/godot-ai") == points
 
 
 def test_load_series_returns_empty_when_absent(tmp_path):
     # First ever run has no series yet; that is not an error.
-    assert gsh.load_series(str(tmp_path / "nope.json")) == []
+    assert gsh.load_series(str(tmp_path / "nope.json"), "hi-godot/godot-ai") == []
+
+
+def test_load_series_treats_an_empty_file_as_absent(tmp_path):
+    # The workflow restores this file from a branch that may not carry it, and
+    # a shell redirection creates the file before the command feeding it can
+    # fail. An empty file must not wedge the run before it can try exact
+    # history — that would take the whole chart down, not just the fallback.
+    empty = tmp_path / "series.json"
+    empty.write_text("", encoding="utf-8")
+    assert gsh.load_series(str(empty), "hi-godot/godot-ai") == []
+    empty.write_text("   \n", encoding="utf-8")
+    assert gsh.load_series(str(empty), "hi-godot/godot-ai") == []
+
+
+def test_load_series_rejects_another_repos_series(tmp_path):
+    # Rendering one repo's points as another's would then overwrite them with
+    # the second repo's history, destroying both.
+    path = tmp_path / "series.json"
+    gsh.save_series(str(path), "someone/else", [(date(2026, 4, 13), 2)])
+    with pytest.raises(SystemExit) as excinfo:
+        gsh.load_series(str(path), "hi-godot/godot-ai")
+    assert "someone/else" in str(excinfo.value)
+    assert "hi-godot/godot-ai" in str(excinfo.value)
+
+
+def test_load_series_still_rejects_corrupt_json(tmp_path):
+    # Non-empty garbage is a real problem and must not be silently discarded.
+    path = tmp_path / "series.json"
+    path.write_text("{not json", encoding="utf-8")
+    with pytest.raises(SystemExit) as excinfo:
+        gsh.load_series(str(path), "hi-godot/godot-ai")
+    assert "not valid JSON" in str(excinfo.value)
 
 
 def test_append_today_replaces_a_same_day_point():
@@ -283,7 +315,7 @@ def test_main_extends_stored_series_when_history_is_refused(tmp_path, monkeypatc
 
     gsh.main()
 
-    points = gsh.load_series(str(series))
+    points = gsh.load_series(str(series), "hi-godot/godot-ai")
     assert points[0] == (date(2026, 4, 13), 2)  # banked history preserved
     assert points[-1][1] == 1221  # today's total appended
     assert "1,221 stars" in out.read_text(encoding="utf-8")

--- a/tests/unit/test_generate_star_history.py
+++ b/tests/unit/test_generate_star_history.py
@@ -286,7 +286,7 @@ def test_main_extends_stored_series_when_history_is_refused(tmp_path, monkeypatc
     points = gsh.load_series(str(series))
     assert points[0] == (date(2026, 4, 13), 2)  # banked history preserved
     assert points[-1][1] == 1221  # today's total appended
-    assert "1,221 stars" in out.read_text()
+    assert "1,221 stars" in out.read_text(encoding="utf-8")
     # The refusal is reported even though the run succeeded — a silently
     # degraded chart would hide the outage indefinitely.
     assert "stargazer history unavailable" in capsys.readouterr().err

--- a/tests/unit/test_generate_star_history.py
+++ b/tests/unit/test_generate_star_history.py
@@ -1,10 +1,13 @@
 """Tests for script/generate-star-history (#750).
 
 The script lives in script/ without a .py suffix, so load it via importlib.
-Network fetch is not exercised here — rendering and aggregation are.
+Network fetch is not exercised here — rendering, aggregation, and the
+failure diagnostics are.
 """
 
 import importlib.util
+import io
+import urllib.error
 from datetime import date
 from pathlib import Path
 
@@ -91,3 +94,56 @@ def test_render_svg_is_deterministic():
 def test_render_svg_rejects_single_point():
     with pytest.raises(SystemExit):
         gsh.render_svg([(date(2026, 4, 12), 0)], "hi-godot/godot-ai")
+
+
+_URL = "https://api.github.com/repos/hi-godot/godot-ai/stargazers?per_page=100&page=1"
+
+
+def _http_error(code, message="Forbidden", body=None, headers=None):
+    payload = b"" if body is None else body
+    return urllib.error.HTTPError(_URL, code, message, headers or {}, io.BytesIO(payload))
+
+
+def test_describe_http_error_quotes_the_api_message():
+    # The whole point of the diagnostic: GitHub's own words, not our guess.
+    # A 403 naming an org policy must not be reported as a missing secret.
+    err = _http_error(
+        403,
+        body=b'{"message": "hi-godot forbids access via a personal access token"}',
+    )
+    detail = gsh.describe_http_error(err, _URL, "STAR_HISTORY_TOKEN")
+    assert "hi-godot forbids access via a personal access token" in detail
+    assert "Token used: STAR_HISTORY_TOKEN." in detail
+    # 403 is an authorization refusal, not an expiry — don't send the reader
+    # off to reissue a token that is working fine.
+    assert "not authorized" in detail
+    assert "Rate limited" not in detail
+
+
+def test_describe_http_error_flags_rate_limiting():
+    err = _http_error(
+        403,
+        body=b'{"message": "API rate limit exceeded"}',
+        # 2026-07-25T09:00:00Z
+        headers={"x-ratelimit-remaining": "0", "x-ratelimit-reset": "1784970000"},
+    )
+    detail = gsh.describe_http_error(err, _URL, "STAR_HISTORY_TOKEN")
+    assert "Rate limited" in detail
+    assert "2026-07-25 09:00 UTC" in detail
+    assert "not authorized" not in detail
+
+
+def test_describe_http_error_distinguishes_rejected_credentials():
+    err = _http_error(401, body=b'{"message": "Bad credentials"}')
+    detail = gsh.describe_http_error(err, _URL, "GITHUB_TOKEN (fallback)")
+    assert "Bad credentials" in detail
+    assert "expired, revoked, or malformed" in detail
+    assert "Token used: GITHUB_TOKEN (fallback)." in detail
+
+
+def test_describe_http_error_survives_a_bodyless_response():
+    # An empty or non-JSON body must still yield a usable report rather than
+    # masking the original failure with a decode error.
+    detail = gsh.describe_http_error(_http_error(403, body=b"<html>"), _URL, "tok")
+    assert "GitHub returned no message body." in detail
+    assert "403" in detail

--- a/tests/unit/test_generate_star_history.py
+++ b/tests/unit/test_generate_star_history.py
@@ -133,6 +133,21 @@ def test_describe_http_error_flags_rate_limiting():
     assert "not authorized" not in detail
 
 
+def test_describe_http_error_flags_secondary_rate_limiting():
+    # A secondary limit answers 403 with primary quota left, so classifying on
+    # remaining == "0" alone would file it as an authorization failure and send
+    # the reader off to replace a perfectly good token.
+    err = _http_error(
+        403,
+        body=b'{"message": "You have exceeded a secondary rate limit"}',
+        headers={"x-ratelimit-remaining": "4312", "retry-after": "60"},
+    )
+    detail = gsh.describe_http_error(err, _URL, "STAR_HISTORY_TOKEN")
+    assert "Rate limited" in detail
+    assert "retry after 60s" in detail
+    assert "not authorized" not in detail
+
+
 def test_describe_http_error_distinguishes_rejected_credentials():
     err = _http_error(401, body=b'{"message": "Bad credentials"}')
     detail = gsh.describe_http_error(err, _URL, "GITHUB_TOKEN (fallback)")
@@ -147,3 +162,31 @@ def test_describe_http_error_survives_a_bodyless_response():
     detail = gsh.describe_http_error(_http_error(403, body=b"<html>"), _URL, "tok")
     assert "GitHub returned no message body." in detail
     assert "403" in detail
+
+
+def test_fetch_star_dates_routes_4xx_through_the_diagnostic(monkeypatch):
+    # Cross-function contract: the fetch layer must hand refusals to
+    # describe_http_error with the token label attached, not swallow them or
+    # report a bare status code.
+    def refuse(req, timeout=None):
+        raise _http_error(404, body=b'{"message": "Not Found"}')
+
+    monkeypatch.setattr(gsh.urllib.request, "urlopen", refuse)
+    with pytest.raises(SystemExit) as excinfo:
+        gsh.fetch_star_dates("hi-godot/godot-ai", "tok", "STAR_HISTORY_TOKEN")
+
+    detail = str(excinfo.value)
+    assert "Not Found" in detail
+    assert "Token used: STAR_HISTORY_TOKEN." in detail
+    assert "cannot see hi-godot/godot-ai" in detail
+
+
+def test_fetch_star_dates_reraises_server_errors(monkeypatch):
+    # 5xx is an outage, not a misconfiguration — it must not be dressed up as
+    # a credential problem, and the traceback is the useful artifact.
+    def boom(req, timeout=None):
+        raise _http_error(502, body=b"")
+
+    monkeypatch.setattr(gsh.urllib.request, "urlopen", boom)
+    with pytest.raises(urllib.error.HTTPError):
+        gsh.fetch_star_dates("hi-godot/godot-ai", "tok", "STAR_HISTORY_TOKEN")

--- a/tests/unit/test_generate_star_history.py
+++ b/tests/unit/test_generate_star_history.py
@@ -181,6 +181,141 @@ def test_fetch_star_dates_routes_4xx_through_the_diagnostic(monkeypatch):
     assert "cannot see hi-godot/godot-ai" in detail
 
 
+def test_series_round_trips(tmp_path):
+    path = tmp_path / "series.json"
+    points = [(date(2026, 4, 13), 2), (date(2026, 7, 25), 1221)]
+    gsh.save_series(str(path), "hi-godot/godot-ai", points)
+    assert gsh.load_series(str(path)) == points
+
+
+def test_load_series_returns_empty_when_absent(tmp_path):
+    # First ever run has no series yet; that is not an error.
+    assert gsh.load_series(str(tmp_path / "nope.json")) == []
+
+
+def test_append_today_replaces_a_same_day_point():
+    # Reruns must be idempotent — a manual dispatch after the scheduled run
+    # would otherwise stack two points on the same x-position.
+    today = date(2026, 7, 25)
+    series = [(date(2026, 7, 24), 1200), (today, 1215)]
+    assert gsh.append_today(series, 1221, today) == [
+        (date(2026, 7, 24), 1200),
+        (today, 1221),
+    ]
+
+
+def test_append_today_extends_and_keeps_order():
+    today = date(2026, 7, 25)
+    series = [(date(2026, 7, 24), 1200)]
+    assert gsh.append_today(series, 1221, today)[-1] == (today, 1221)
+
+
+class _Resp:
+    """Minimal stand-in for the urlopen context manager."""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def __enter__(self):
+        return io.BytesIO(self._payload)
+
+    def __exit__(self, *exc):
+        return False
+
+
+def test_fetch_star_count_reads_the_repo_endpoint(monkeypatch):
+    # The whole point of the fallback: /repos/{repo} answers on metadata=read
+    # and kept working when the stargazers list did not.
+    seen = {}
+
+    def ok(req, timeout=None):
+        seen["url"] = req.full_url
+        return _Resp(b'{"stargazers_count": 1221}')
+
+    monkeypatch.setattr(gsh.urllib.request, "urlopen", ok)
+    assert gsh.fetch_star_count("hi-godot/godot-ai", "tok", "STAR_HISTORY_TOKEN") == 1221
+    assert seen["url"].endswith("/repos/hi-godot/godot-ai")
+
+
+def test_fetch_star_count_routes_4xx_through_the_diagnostic(monkeypatch):
+    def refuse(req, timeout=None):
+        raise _http_error(403, body=b'{"message": "Resource not accessible"}')
+
+    monkeypatch.setattr(gsh.urllib.request, "urlopen", refuse)
+    with pytest.raises(gsh.StargazerFetchError) as excinfo:
+        gsh.fetch_star_count("hi-godot/godot-ai", "tok", "STAR_HISTORY_TOKEN")
+    assert "Resource not accessible" in str(excinfo.value)
+
+
+def test_stargazer_fetch_error_is_a_system_exit():
+    # Uncaught, it must still exit 1 with the diagnostic printed rather than
+    # dumping a traceback — the pre-existing contract for a refused run.
+    assert issubclass(gsh.StargazerFetchError, SystemExit)
+
+
+def test_main_extends_stored_series_when_history_is_refused(tmp_path, monkeypatch, capsys):
+    # Reproduces the 2026-07-24 outage exactly: the stargazers list 403s for
+    # every credential class while /repos/{repo} still answers. The chart must
+    # still be produced, keeping banked history and gaining today's total.
+    series = tmp_path / "series.json"
+    out = tmp_path / "chart.svg"
+    gsh.save_series(
+        str(series),
+        "hi-godot/godot-ai",
+        [(date(2026, 4, 13), 2), (date(2026, 7, 24), 1200)],
+    )
+
+    def respond(req, timeout=None):
+        if "/stargazers" in req.full_url:
+            raise _http_error(
+                403,
+                body=b'{"message": "Resource not accessible by personal access token"}',
+            )
+        return _Resp(b'{"stargazers_count": 1221}')
+
+    monkeypatch.setattr(gsh.urllib.request, "urlopen", respond)
+    monkeypatch.setenv("STAR_HISTORY_TOKEN", "tok")
+    monkeypatch.setattr(
+        gsh.sys,
+        "argv",
+        ["generate-star-history", "--series", str(series), "--out", str(out)],
+    )
+
+    gsh.main()
+
+    points = gsh.load_series(str(series))
+    assert points[0] == (date(2026, 4, 13), 2)  # banked history preserved
+    assert points[-1][1] == 1221  # today's total appended
+    assert "1,221 stars" in out.read_text()
+    # The refusal is reported even though the run succeeded — a silently
+    # degraded chart would hide the outage indefinitely.
+    assert "stargazer history unavailable" in capsys.readouterr().err
+
+
+def test_main_fails_when_refused_with_no_stored_series(tmp_path, monkeypatch):
+    # Nothing banked and no history reachable means there is genuinely no
+    # chart to draw — fail loudly with the diagnostic rather than inventing one.
+    def refuse(req, timeout=None):
+        raise _http_error(403, body=b'{"message": "Resource not accessible"}')
+
+    monkeypatch.setattr(gsh.urllib.request, "urlopen", refuse)
+    monkeypatch.setenv("STAR_HISTORY_TOKEN", "tok")
+    monkeypatch.setattr(
+        gsh.sys,
+        "argv",
+        [
+            "generate-star-history",
+            "--series",
+            str(tmp_path / "absent.json"),
+            "--out",
+            str(tmp_path / "chart.svg"),
+        ],
+    )
+    with pytest.raises(SystemExit) as excinfo:
+        gsh.main()
+    assert "Resource not accessible" in str(excinfo.value)
+
+
 def test_fetch_star_dates_reraises_server_errors(monkeypatch):
     # 5xx is an outage, not a misconfiguration — it must not be dressed up as
     # a credential problem, and the traceback is the useful artifact.


### PR DESCRIPTION
## What

The daily star-history run has been failing since 2026-07-24 and the README chart froze at 1,164 stars. This PR diagnoses why and makes the chart immune to it.

## The outage

Probing all three credential classes against the same repo in the same minute ([run 30161903920](https://github.com/hi-godot/godot-ai/actions/runs/30161903920), [run 30161955416](https://github.com/hi-godot/godot-ai/actions/runs/30161955416)):

| Credential | `GET /repos/{repo}` | stargazers (plain) | stargazers (`star+json`) |
|---|---|---|---|
| Fine-grained PAT (repo admin) | 200 | **403** | **403** |
| Workflow `GITHUB_TOKEN` (App) | 200 | **403** | **403** |
| No `Authorization` header | — | **401** | **401** |

The 403s carry `x-accepted-github-permissions: 'metadata=read; contents=write'`.

- **The token is healthy** — `/user` → 200, 5,000/hr, reads `/repos/{repo}` on `metadata=read` alone. Not expired, not revoked.
- **Not about the timestamps** — the *plain* public stargazer list fails identically, so this is not the admins-and-collaborators restriction behind #750.
- **The demanded permission is incoherent** — reading a public list cannot legitimately require *write* access to repository contents.
- **Not specific to us** — a GitHub App token fails identically, which no org policy or token grant can explain.

Deliberately **not** granting `contents=write`: repository write access in exchange for a README image, and pointless privilege once GitHub corrects the mapping.

## The fix

`/repos/{repo}` still answers on `metadata=read` and carries `stargazers_count` — a total without history. Paired with history we already have, that keeps the chart moving:

- `star-history.json` on the `star-history` branch accumulates `[date, count]` points, published alongside the SVG in the same orphan commit.
- **Exact history stays preferred** and is tried first on every run, so recovery is automatic and re-corrects drift — no change needed when GitHub fixes this.
- On refusal with a series present: append today's total, report the refusal on stderr. Degraded, not silent. With no series: still fails loudly with the full diagnostic.
- Same-day reruns replace rather than stack the day's point.

The `star-history` branch is already seeded with the 100-point series and a chart current at **1,221 stars**, so the embed is live now.

## Diagnostics (what made the above possible)

`describe_http_error` quotes GitHub's `message` verbatim, names which env var supplied the token, and branches on `401` (rejected credential) / throttled `403`+`429` (rate limit, incl. secondary limits via `Retry-After`) / other `403` (live but unauthorized) / `404` (repo invisible). Previously a fixed hint was printed regardless of cause, which sent this very investigation down the wrong path.

## Testing

- `uv run pytest tests/unit/test_generate_star_history.py` — 29 passed, including an end-to-end test reproducing the outage exactly (stargazers 403 + working count endpoint) and asserting banked history survives
- `uv run ruff check` / `ruff format` clean; workflow YAML validated
- Publish path exercised against the live branch; raw embed URL verified serving 1,221 stars
- Chart rendered via headless Chromium against light and dark backgrounds

Background and evidence preserved in `docs/star-history.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf656vf5xyFyQ87HSEA8Nw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when GitHub stargazer access is refused: the chart can still be generated by restoring and extending a persisted accumulated series.
  * Improved, status-specific API error diagnostics (including rate-limit timing) and clearer token-source labeling; better behavior for empty/malformed error bodies.
* **New Features**
  * Added `--series` to load/update an on-disk `star-history.json` series across runs, with fallback growth using `stargazers_count` when needed.
* **Documentation**
  * Expanded star-history generation docs, including observed outage behavior and refresh strategy.
* **Tests**
  * Expanded unit tests for HTTP error formatting, 4xx vs 5xx handling, and CLI fallback scenarios.
* **Chores**
  * Updated CI workflow to restore the accumulated series and publish both `star-history.json` and `star-history.svg` together.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->