### PR TITLE
Fix unloadable godot-ai skill; trim derivable content from AGENTS.md

### DIFF
--- a/.claude/skills/godot-ai/SKILL.md
+++ b/.claude/skills/godot-ai/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: godot-ai
 description: Build, test, and extend the Godot AI server and editor plugin
-globs:
-  - "**/godot-ai/**"
-  - "**/godot_ai/**"
 ---
 
 # Godot AI Development

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,12 +8,6 @@ A production-grade MCP server for Godot. Python server (FastMCP v3) communicates
 
 ## Architecture
 
-```
-AI Client → MCP (stdio/sse/streamable-http) → Python FastMCP server → WebSocket (port 9500) → Godot EditorPlugin
-```
-
-- **Python server**: `src/godot_ai/` — FastMCP v3, async, lifespan manages WebSocket server
-- **GDScript plugin**: `plugin/addons/godot_ai/` — canonical source; symlinked into `test_project/addons/` for testing
 - **Protocol**: JSON over WebSocket. Request/response with `request_id` correlation. Handshake on connect.
 - **WS trust boundary**: the editor↔server WebSocket (port 9500) is **effectively unauthenticated** — the primary control is loopback-only binding: the WS port always binds `127.0.0.1` and `--allow-host` deliberately does NOT widen it (see `transport/websocket.py::start`). Defense in depth on top of that: unguessable `uuid4` request ids, session-scoped response correlation (a reply is only accepted from the connection its command was sent to — #690), and a compat-gated per-launch handshake token (#690 finding 4): the spawning plugin generates it, hands it to the server via the `GODOT_AI_WS_TOKEN` spawn env, and echoes it in the handshake; a handshake carrying a *wrong* token is rejected, but a token-less handshake is still accepted (older plugins, adopted servers, and the field is attacker-omittable — so the token is hardening, not an authentication boundary). Never bind the WS port beyond loopback. **The token authenticates the plugin TO the server, and nothing authenticates the server to the plugin**: `connection.gd` dials `ws://127.0.0.1:<ws_port>` and hands whatever answers the full write surface (`filesystem_write_text`, `script_create`, `game_eval`, `editor_quit`), adoption of an existing `:8000` listener is decided by a *self-reported* status JSON, and `_note_post_open_close` drops the token entirely after two close-4003 frames (an attacker-triggerable downgrade, deliberately accepted because omitting the field is always allowed anyway). Loopback binding is the whole boundary on the plugin side — do not add plugin-side logic that assumes the peer on 9500 is trusted.
 - **Session model**: Multiple Godot editors can connect. Tools route through active session.
@@ -22,42 +16,15 @@ AI Client → MCP (stdio/sse/streamable-http) → Python FastMCP server → WebS
 
 ## Project structure
 
-- `src/godot_ai/` — Python MCP server (FastMCP v3)
-  - `server.py` — entrypoint, lifespan, tool registration, `--exclude-domains` support
-  - `tools/` — MCP tool modules (session, editor, scene, node, project, script, resource, api, filesystem, signal, autoload, input_map, game, testing, batch, client, ui, theme, animation, material, particle, camera, audio, tilemap, tileset) + `_meta_tool.py` (`register_manage_tool` rollup factory)
-  - `resources/` — `godot://...` read-only URIs (sessions, editor, project, nodes, classes, scripts, scenes, library)
-  - `middleware/` — `PreserveGodotCommandErrorData`, `StripClientWrapperKwargs`, `ParseStringifiedParams`, `FoldFlatManageParams`, `HintOpTypoOnManage` (registration order is load-bearing — see the docstring above the `mcp.add_middleware(...)` calls in `server.py` and `tests/unit/test_server_middleware_order.py`)
-  - `handlers/` — shared sync handlers using `DirectRuntime`; `_readiness.py` gates writes
-  - `runtime/direct.py` — `DirectRuntime`, the in-process runtime adapter
-  - `transport/websocket.py` — WebSocket server for Godot plugin
-  - `sessions/registry.py` — multi-session tracking
-  - `godot_client/client.py` — typed async client, raises `GodotCommandError` on errors
-  - `protocol/` — envelope types, error codes
-- `plugin/addons/godot_ai/` — GDScript editor plugin (canonical source)
-  - `plugin.gd` — EditorPlugin lifecycle, handler registration, `_ensure_game_helper_autoload`
-  - `connection.gd` — WebSocket client, reconnection, `send_deferred_response`
-  - `dispatcher.gd` — command routing with frame budget; `DEFERRED_RESPONSE` sentinel; lazy handler load-at-first-dispatch (#736)
-  - `handlers/` — scene, node, editor, project, client, script, resource, filesystem, signal, autoload, input, test, batch, ui, theme, animation (+ values/presets), material (+ values/presets), particle (+ values/presets), camera, audio, environment, texture, curve, physics_shape, control_draw_recipe
-  - `clients/` — descriptor + strategy system (`_base`, `_registry`, `_json_strategy`, `_toml_strategy`, `_cli_strategy`, `_cli_exec`, `_atomic_write`, `_cli_finder`, `_path_template`, `_manual_command`) and 19 client descriptors
-  - `runtime/game_helper.gd` — game-side autoload that ferries logs back to the editor (`logs_read source=game`)
-  - `testing/` — McpTestRunner + McpTestSuite framework
-  - `utils/` — scene_path, error_codes, log_buffer
-  - `client_configurator.gd` — server discovery (venv → uvx → system), client config
-  - `mcp_dock.gd` — editor dock panel with status, setup, logs, self-update banner, Tools tab
-  - `tool_catalog.gd` — mirror of `src/godot_ai/tools/domains.py`; drives Tools tab; CI-enforced via `tests/unit/test_tool_domains.py`
-  - `update_reload_runner.gd` — self-update single-pass extract, filesystem scan, and plugin re-enable handoff
-- `test_project/` — Godot 4.7 project (plugin symlinked via `addons/godot_ai`, locally built — not tracked in git)
-  - `tests/` — GDScript test suites (auto-discovered by test_handler)
-- `tests/` — Python tests (pytest)
-  - `unit/` — protocol, session registry, runtime handlers, tool domains, middleware
-  - `integration/` — WebSocket server + mock Godot plugin, MCP tools, rollups
-- `script/` — dev and CI scripts
-  - `setup-dev` / `setup-dev.ps1` / `verify-worktree` — dev environment + worktree health
-  - `serve-this-worktree` / `open-godot-here` — point dev server / editor at the current worktree
-  - `local-self-update-smoke` — interactive local fixture for self-update changes
-  - `ci-start-server`, `ci-godot-tests`, `ci-reload-test`, `ci-quit-test`, `ci-check-gdscript`, `ci-game-capture-smoke` — CI scripts
-  - `ci-stale-server-smoke` — live cross-OS port-8000 conflict smoke. `--mode stale` (default) plants a godot-ai server simulator and asserts the recoverable kill+respawn path; `--mode foreign` plants a non-godot-ai listener and asserts the terminal, non-recoverable INCOMPATIBLE path (no kill, suggested free port logged). Drives the `stale-server-smoke` and `foreign-server-smoke` CI jobs.
-  - `ci-find-regression-range` — helper for identifying CI regression windows
+Read the tree directly — `src/godot_ai/` (Python MCP server) and
+`plugin/addons/godot_ai/` (GDScript editor plugin) are the two roots, and the
+directory names say what they hold. The parts the layout does *not* tell you:
+
+- `plugin/addons/godot_ai/` is the canonical GDScript copy. `test_project/addons/godot_ai`
+  is a locally-built symlink (Windows junction) into it, not tracked in git.
+- `src/godot_ai/tools/_meta_tool.py` holds `register_manage_tool`, the rollup factory.
+- `src/godot_ai/middleware/` registration order is load-bearing — see "Key conventions".
+- `script/` ships fixers for dev-environment problems; scan it before doing setup by hand.
 
 ## Key conventions
 
@@ -162,8 +129,6 @@ cd ~/godot-ai
 script/setup-dev             # creates .venv, installs deps, applies macOS .pth fix
 source .venv/bin/activate
 pytest -v                    # run tests
-ruff check src/ tests/       # lint
-ruff format src/ tests/      # format
 ```
 
 `uv.lock` is intentionally untracked: dependencies resolve from `pyproject.toml`, and CI installs with pip (`pip install -e ".[dev]"`) rather than enforcing a uv lockfile.
@@ -349,47 +314,21 @@ current working tree's `test_project/`.
 ## Client configuration
 
 The plugin auto-configures 19+ MCP clients via a registry + strategy system in
-`plugin/addons/godot_ai/clients/`:
+`plugin/addons/godot_ai/clients/`. Read that directory for the mechanics; two
+rules are not visible in the code:
 
-- `_base.gd` — `McpClient` descriptor (data only: id, display_name, config_type,
-  path_template, server_key_path, entry_url_field, entry_extra_fields,
-  entry_uvx_bridge, cli_register_template, cli_status_args, toml_body_template,
-  …). Descriptors carry no `Callable` fields and no control flow — strategies
-  interpret the data. The `test_descriptors_are_data_only` suite enforces this
-  (issue #229: hot-reloaded per-client lambdas raced with worker threads).
-- `_registry.gd` — explicit `preload(...)` list of every client. Adding a client
-  means: write `clients/<name>.gd` extending `McpClient`, then append one
-  preload here. No edits to dock or facade required.
-- `_json_strategy.gd` / `_toml_strategy.gd` / `_cli_strategy.gd` — three
-  reusable writers, selected by descriptor `config_type`. **No per-client
-  branching** inside strategies — non-standard entry shapes are expressed
-  declaratively: `entry_url_field` overrides the URL key (Antigravity's
-  `serverUrl`, Gemini's `httpUrl`); `entry_extra_fields` adds verbatim keys
-  (Roo's `type: streamable-http`, OpenCode's `enabled: true`); `entry_uvx_bridge`
-  composes the stdio→HTTP bridge shape for stdio-only clients (Claude Desktop's
-  `flat`).
-- `_manual_command.gd` — synthesizes the dock's "Run this manually" string
-  from the same declarative fields. No per-client builders.
-- `_path_template.gd` — expands `~`, `$HOME`, `$APPDATA`, `$XDG_CONFIG_HOME`,
-  `$LOCALAPPDATA`, `$USERPROFILE`; picks the right per-OS entry from a
-  `{"darwin": ..., "windows": ..., "linux": ...}` (or `"unix"` shorthand) map.
-- `_atomic_write.gd` — `.tmp` + rename + `.backup` so a crash mid-write never
-  truncates the user's MCP config.
-- `_cli_finder.gd` — three-tier lookup (well-known dirs → login shell →
-  `which`/`where`) with per-exe caching. Critical for GUI-launched editors
-  whose PATH doesn't include `~/.local/bin`, `/opt/homebrew/bin`, etc.
+- **Descriptors are data only** — no `Callable` fields, no control flow. Strategies
+  interpret the data. `test_descriptors_are_data_only` enforces this (issue #229:
+  hot-reloaded per-client lambdas raced with worker threads).
+- **No per-client branching inside strategies.** Non-standard entry shapes are
+  expressed declaratively on the descriptor (`entry_url_field`, `entry_extra_fields`,
+  `entry_uvx_bridge`). Adding a client means exactly two things: write
+  `clients/<name>.gd` extending `McpClient`, then append one `preload` to
+  `_registry.gd`. No edits to the dock, the facade, or the strategies.
 
-`client_configurator.gd` is a thin facade exposing string-id wrappers
-(`configure`, `check_status`, `remove`, `manual_command`, `is_installed`,
-`client_ids`, `client_display_name`). It also keeps the server-launch
-discovery (`get_server_command`, `find_uvx`, `is_dev_checkout`) since those
-are unrelated to client configuration.
+MCP tools `client_configure`, `client_remove`, and `client_status` expose this to
+AI clients.
 
-MCP tools `client_configure`, `client_remove`, and `client_status` expose this
-to AI clients. `client_status` returns `{"clients": [{id, display_name, status,
-installed}, …]}`. The dock renders one row per client with a status dot,
-Configure/Remove buttons, and a per-row "Run this manually" fallback for cases
-when auto-configure can't find a CLI.
 
 ## Tool-search friendliness + tool-count caps
 
@@ -450,7 +389,6 @@ When using `batch_execute`'s `commands[].command` field, use the **plugin comman
 - Write handlers: `await require_writable_async(runtime)` before sending commands (from `handlers/_readiness.py`).
 - Tools create `DirectRuntime.from_context(ctx)` and delegate to handlers.
 - Error codes in `protocol/errors.py` — keep in sync with `utils/error_codes.gd`.
-- Lint: `ruff check src/ tests/` — Format: `ruff format src/ tests/`.
 
 ## Deferred responses (tools whose reply flows out-of-band)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,12 +5,23 @@ this repository live in [AGENTS.md](AGENTS.md). Read and follow `AGENTS.md` as
 the source of truth for project structure, development workflow, tool changes,
 testing expectations, worktree safety, and release compatibility.
 
+`AGENTS.md` is long. Read the sections your task actually touches rather than
+the whole file:
+
+- Any change to plugin or server behavior — `## Architecture`, `## Key conventions`
+- Editing anything under `plugin/` — `## Worktrees`, `### Godot editor + worktree safety`
+- Adding or changing an MCP tool — `## Adding a new tool`, `## Tool-search friendliness + tool-count caps`
+- Writing tests — `## Testing`, `### Test hygiene checklist`
+- Before every commit — `## Pre-commit smoke test`
+- Release, self-update, or `class_name` changes — `### Releasing`, `### Self-update`, `### Published class_name compatibility`
+
 ## Claude-specific notes
 
 - Claude Code sessions may run in `.claude/worktrees/<name>`. The worktree and
   editor-routing guidance in `AGENTS.md` applies; verify the active worktree and
   connected Godot `test_project/` before editing or testing plugin code.
-- Keep `.claude/skills/godot-ai/skill.md` as a Claude adapter that points back
-  to `AGENTS.md`.
+- Keep `.claude/skills/godot-ai/SKILL.md` as a Claude adapter that points back
+  to `AGENTS.md`. The filename must be exactly `SKILL.md` — skill discovery is
+  case-sensitive, and a lowercase `skill.md` is silently never loaded.
 - When updating general repo operating guidance, update `AGENTS.md` first. Keep
   this file limited to Claude-specific loading behavior and reminders.

--- a/tests/unit/test_tool_domains.py
+++ b/tests/unit/test_tool_domains.py
@@ -27,7 +27,9 @@ _RUNTIME_BOUNDARY_DOCS = [
     _REPO_ROOT / "AGENTS.md",
     _REPO_ROOT / "CLAUDE.md",
     _REPO_ROOT / "docs" / "plugin-architecture.md",
-    _REPO_ROOT / ".claude" / "skills" / "godot-ai" / "skill.md",
+    # Must be `SKILL.md`: skill discovery globs for that exact name, so a
+    # lowercase `skill.md` is silently never loaded.
+    _REPO_ROOT / ".claude" / "skills" / "godot-ai" / "SKILL.md",
 ]
 
 
@@ -58,6 +60,10 @@ def test_runtime_protocol_is_not_reintroduced_without_injection_seam():
 
     stale_docs = []
     for path in _RUNTIME_BOUNDARY_DOCS:
+        assert path.exists(), (
+            f"{path.relative_to(_REPO_ROOT)} is listed in _RUNTIME_BOUNDARY_DOCS but "
+            "does not exist — it was moved or renamed. Update the list here."
+        )
         text = path.read_text(encoding="utf-8")
         if "runtime/interface.py" in text or "`Runtime` protocol" in text:
             stale_docs.append(str(path.relative_to(_REPO_ROOT)))


### PR DESCRIPTION
Findings from a `/doctor` health check of this repo's assistant configuration.

## The skill never loaded

`.claude/skills/godot-ai/skill.md` was named in lowercase. Claude Code discovers skills by globbing for `SKILL.md`, so on a case-sensitive filesystem the file was silently skipped — the adapter that `CLAUDE.md` documents and asks contributors to maintain has never actually been available to a session. Confirmed by its absence from the session skill list before the rename, and its appearance immediately after.

- `git mv skill.md SKILL.md`
- Recorded the constraint in `CLAUDE.md` so the trap doesn't come back
- Dropped the `globs:` frontmatter key — not part of skill frontmatter (`name`, `description`, optional `allowed-tools`), so it was ignored

## AGENTS.md trim: 70,179 → 64,310 chars

`CLAUDE.md` points every session at `AGENTS.md` as the source of truth, so its full ~17.5k tokens get read each session. Removed the content a session can reconstruct from the repo itself:

| Removed | Lines | Chars |
|---|---|---|
| "Project structure" file-by-file tour | 39 | 4,150 |
| "Client configuration" per-file tour | 44 | 2,756 |
| Architecture ASCII diagram + two path bullets | 7 | 452 |
| Duplicated `ruff check` / `ruff format` invocations | 3 | 146 |

Both tours became short pointers that preserve what reading the code does *not* teach: the untracked `test_project/addons` symlink, `_meta_tool.py` as the rollup factory, load-bearing middleware order, `script/` as the first stop for setup problems, the data-only descriptor rule and its #229 rationale, and the two-step process for adding a client (`clients/<name>.gd` + one `preload` in `_registry.gd`).

The surviving `ruff` mention is step 1 of the pre-commit checklist, where it's a required gate rather than a restated command.

Nothing else moved. The WS trust boundary, readiness gating, `class_name` compatibility rules, worktree safety, live-smoke hygiene, undo patterns, the test hygiene checklist, and "What NOT to do" are all untouched — those are gotchas, rationale, and prohibitions the code can't express.

## CLAUDE.md section index

`AGENTS.md` is still 64k chars, well over the ~40k large-memory-file threshold — the trim is a dent, not a fix. Added a six-line index mapping task types to sections (plugin work → Worktrees; adding a tool → Adding a new tool; before committing → Pre-commit smoke test; etc.) so a task can read the relevant sections instead of the whole file, at a cost of ~40 resident tokens.

## Testing

Documentation and skill-metadata only — no `src/`, `plugin/`, or `test_project/` code paths touched, so no test run applies. The skill fix is verified directly: `godot-ai` now appears in the session skill list.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJcN2A3fPpTxGa32XWNNRK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Streamlined onboarding guidance by shortening and reorganizing sections on project structure, development workflow, client configuration, and Python conventions.
  * Clarified how to focus on the parts of the guidance relevant to the current task.
  * Updated Claude adapter instructions to require the case-sensitive skill metadata filename (`SKILL.md`).
  * Simplified Godot AI skill metadata configuration without changing the documented content.
* **Tests**
  * Strengthened unit validation to ensure referenced runtime boundary documentation exists and fails clearly if moved or renamed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->