### PR TITLE
Document the headless path in the verification gauntlet

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -31,14 +31,19 @@ script/ci-godot-tests    # waits for the plugin, opens main.tscn, runs test_run,
                          # prints {suite}.{test}: {message} for each failure
 ```
 
-**Confirm which editor you are about to drive first.** `script/ci-godot-tests`
-waits only for a session count greater than zero — it never calls
-`session_activate` — then runs `scene_open` and `test_run` against whatever
-session is active. Multiple editors sharing port 8000 is a supported setup (see
-[worktrees](worktrees.md)), so with more than one connected, the script can open
-a scene in and run tests against the wrong project. Use the shortcut only when
-`pgrep -af` shows exactly one editor on the `test_project/` you mean; otherwise
-`session_activate` the right session first, or take the interactive path.
+**With several editors connected, pin the one you mean.** Multiple editors
+sharing port 8000 is a supported setup (see [worktrees](worktrees.md)), and
+`scene_open` would otherwise land in whichever session is active — yanking
+another session's open scene and testing the wrong project. The script refuses
+to guess: past one connected session it lists them and exits. Pick one with
+
+```bash
+GODOT_AI_SESSION_ID='<project-slug>@<4hex>' script/ci-godot-tests
+```
+
+which is passed as a per-call `session_id`, so it does not disturb the active
+session other clients are using. A pinned session that isn't connected fails
+loudly rather than falling back to the active one.
 
 That satisfies steps 3–5. Use the interactive path below when you need a live
 editor to *look at* — the step 6 smoke test — or when nothing is running yet.

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -14,8 +14,9 @@ server via `.claude/hooks/session-start.sh`, so steps 3–5 below are usually
 already done for you. Check before concluding anything is unavailable:
 
 ```bash
-command -v godot                      # engine installed?
-pgrep -f 'godot.*--editor'            # editor already running?
+command -v godot                          # engine on PATH?
+ls -d /Applications/Godot*.app 2>/dev/null # ...or a macOS app bundle (not on PATH)
+pgrep -af 'godot.*--editor'               # editor already running, and against which --path?
 curl -sf -o /dev/null http://127.0.0.1:8000/mcp -X POST \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json, text/event-stream' \
@@ -30,6 +31,15 @@ script/ci-godot-tests    # waits for the plugin, opens main.tscn, runs test_run,
                          # prints {suite}.{test}: {message} for each failure
 ```
 
+**Confirm which editor you are about to drive first.** `script/ci-godot-tests`
+waits only for a session count greater than zero — it never calls
+`session_activate` — then runs `scene_open` and `test_run` against whatever
+session is active. Multiple editors sharing port 8000 is a supported setup (see
+[worktrees](worktrees.md)), so with more than one connected, the script can open
+a scene in and run tests against the wrong project. Use the shortcut only when
+`pgrep -af` shows exactly one editor on the `test_project/` you mean; otherwise
+`session_activate` the right session first, or take the interactive path.
+
 That satisfies steps 3–5. Use the interactive path below when you need a live
 editor to *look at* — the step 6 smoke test — or when nothing is running yet.
 
@@ -39,7 +49,14 @@ editor to *look at* — the step 6 smoke test — or when nothing is running yet
 
 1. `ruff check src/ tests/` — lint passes
 2. `pytest -v` — all Python tests pass
-3. Open `test_project/` in Godot — macOS GUI: `/Applications/Godot_mono.app/Contents/MacOS/Godot --editor --path test_project/`; headless: `godot --headless --path test_project --editor`. Skip if one is already running (see above).
+3. Open `test_project/` in Godot. Skip if one is already running (see above). Both forms occupy the shell, so background them or use a second terminal — you need this one for steps 4–5:
+   ```bash
+   # macOS GUI
+   /Applications/Godot_mono.app/Contents/MacOS/Godot --editor --path test_project/ &
+   # headless (CI, containers, no display)
+   godot --headless --path test_project --editor >/tmp/godot-editor.log 2>&1 &
+   ```
+   Note the job's PID; `kill` it when you're done, and check `/tmp/godot-editor.log` if the plugin never connects.
 4. `session_activate` the test_project session if multiple editors are connected
 5. `test_run` via MCP — all GDScript tests pass (0 failures). `script/ci-godot-tests` does 3–5 in one command.
 6. **Live smoke test** new/changed features against the real editor:

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -6,15 +6,42 @@ Part of the Godot AI agent guide — see [AGENTS.md](../AGENTS.md) for the alway
 The full pre-commit gauntlet. Run this before every commit — Python mocks do not
 catch GDScript bugs, editor API regressions, or undo/redo issues.
 
+## First: check whether an editor is already running
+
+**Do not assume you need a GUI, or that a headless environment can't run these
+tests.** Claude Code on the web bootstraps a headless Godot and a live MCP
+server via `.claude/hooks/session-start.sh`, so steps 3–5 below are usually
+already done for you. Check before concluding anything is unavailable:
+
+```bash
+command -v godot                      # engine installed?
+pgrep -f 'godot.*--editor'            # editor already running?
+curl -sf -o /dev/null http://127.0.0.1:8000/mcp -X POST \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"check","version":"1"}}}'
+```
+
+If the editor is up, run the whole GDScript suite non-interactively — no GUI, no
+MCP client, no human:
+
+```bash
+script/ci-godot-tests    # waits for the plugin, opens main.tscn, runs test_run,
+                         # prints {suite}.{test}: {message} for each failure
+```
+
+That satisfies steps 3–5. Use the interactive path below when you need a live
+editor to *look at* — the step 6 smoke test — or when nothing is running yet.
+
 ## Pre-commit smoke test
 
 **Always do this before every commit.** Python mocks don't catch GDScript bugs, editor API regressions, or undo/redo issues.
 
 1. `ruff check src/ tests/` — lint passes
 2. `pytest -v` — all Python tests pass
-3. Open `test_project/` in Godot (or launch: `/Applications/Godot_mono.app/Contents/MacOS/Godot --editor --path test_project/`)
+3. Open `test_project/` in Godot — macOS GUI: `/Applications/Godot_mono.app/Contents/MacOS/Godot --editor --path test_project/`; headless: `godot --headless --path test_project --editor`. Skip if one is already running (see above).
 4. `session_activate` the test_project session if multiple editors are connected
-5. `test_run` via MCP — all GDScript tests pass (0 failures)
+5. `test_run` via MCP — all GDScript tests pass (0 failures). `script/ci-godot-tests` does 3–5 in one command.
 6. **Live smoke test** new/changed features against the real editor:
    - Call each new tool and verify the response makes sense
    - For write tools: verify the change is visible in the editor, and verify undo works (Ctrl+Z in Godot)

--- a/script/ci-godot-tests
+++ b/script/ci-godot-tests
@@ -117,14 +117,23 @@ for line in raw.split('\n'):
 fi
 
 # Built via python3 so the id is JSON-escaped rather than spliced into the body.
+# `set -e` does not propagate failures out of a command substitution, so a
+# broken python3 would otherwise splice an empty string into the request body
+# and surface as a confusing parse error downstream. Fail here instead.
 _tool_args() {
-  GODOT_AI_PIN="$PIN_SESSION" python3 -c "
+  local out
+  out=$(GODOT_AI_PIN="$PIN_SESSION" python3 -c "
 import json, os, sys
 args = json.loads(sys.argv[1])
 pin = os.environ.get('GODOT_AI_PIN', '')
 if pin:
     args['session_id'] = pin
-print(json.dumps(args))" "$1"
+print(json.dumps(args))" "$1") || { echo "ERROR: failed to build tool arguments" >&2; exit 1; }
+  if [ -z "$out" ]; then
+    echo "ERROR: tool arguments came back empty" >&2
+    exit 1
+  fi
+  printf '%s' "$out"
 }
 if [ -n "$PIN_SESSION" ]; then
   echo "Pinned to session: $PIN_SESSION"
@@ -139,9 +148,13 @@ sleep 8
 # Open main.tscn so tests that need a scene root can actually run.
 # In a fresh CI checkout there's no editor state, so no scene is open by default.
 echo "Opening main.tscn..."
+# Assign first: a bare $(_tool_args ...) nested inside the request body would
+# swallow its failure, since exiting a command substitution does not exit the
+# parent shell. The assignment propagates the status so `|| exit 1` can catch it.
+SCENE_ARGS=$(_tool_args '{"path":"res://main.tscn"}') || exit 1
 SCENE_OPEN_RESULT=$(curl -s "$SERVER_URL" -X POST "${HEADERS[@]}" \
   -H "Mcp-Session-Id: $SESSION_ID" \
-  -d "$(printf '{"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"scene_open","arguments":%s}}' "$(_tool_args '{"path":"res://main.tscn"}')")")
+  -d "$(printf '{"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"scene_open","arguments":%s}}' "$SCENE_ARGS")")
 # A failed open hollows the run out: scene-dependent tests skip and the
 # summary still reads green. Fail loudly instead (audit backlog).
 echo "$SCENE_OPEN_RESULT" | python3 -c "
@@ -167,9 +180,10 @@ sleep 2
 
 # Call test_run
 echo "Running handler tests..."
+TEST_ARGS=$(_tool_args '{}') || exit 1
 RESULT=$(curl -s "$SERVER_URL" -X POST "${HEADERS[@]}" \
   -H "Mcp-Session-Id: $SESSION_ID" \
-  -d "$(printf '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"test_run","arguments":%s}}' "$(_tool_args '{}')")")
+  -d "$(printf '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"test_run","arguments":%s}}' "$TEST_ARGS")")
 
 # Parse and report results
 echo "$RESULT" | python3 -c "

--- a/script/ci-godot-tests
+++ b/script/ci-godot-tests
@@ -86,6 +86,50 @@ if [ "$FINAL_COUNT" -eq 0 ] 2>/dev/null; then
   exit 1
 fi
 
+# Fail closed on ambiguity too. CI runs exactly one editor, but locally several
+# can share port 8000 — one per worktree is a supported setup. Without a pin,
+# `scene_open` and `test_run` below hit whichever session is active, which can
+# yank another session's open scene and run tests against the wrong project.
+# Set GODOT_AI_SESSION_ID=<project-slug>@<4hex> to target one deliberately.
+PIN_SESSION="${GODOT_AI_SESSION_ID:-}"
+if [ "$FINAL_COUNT" -gt 1 ] && [ -z "$PIN_SESSION" ]; then
+  echo "ERROR: $FINAL_COUNT Godot sessions are connected; refusing to guess which one to drive."
+  echo "Connected sessions:"
+  curl -s "$SERVER_URL" -X POST "${HEADERS[@]}" \
+    -H "Mcp-Session-Id: $SESSION_ID" \
+    -d '{"jsonrpc":"2.0","id":98,"method":"tools/call","params":{"name":"session_manage","arguments":{"op":"list"}}}' \
+    | python3 -c "
+import json, sys
+raw = sys.stdin.read()
+for line in raw.split('\n'):
+    if line.startswith('data: '):
+        data = json.loads(line[6:])
+        sc = data.get('result',{}).get('structuredContent',{})
+        if not sc:
+            text = data.get('result',{}).get('content',[{}])[0].get('text','{}')
+            sc = json.loads(text)
+        for s in sc.get('sessions', []):
+            print('  %s  %s' % (s.get('session_id','?'), s.get('project_path','?')))
+        break
+" 2>/dev/null || echo "  (could not list sessions)"
+  echo "Re-run with GODOT_AI_SESSION_ID set to the one you mean."
+  exit 1
+fi
+
+# Built via python3 so the id is JSON-escaped rather than spliced into the body.
+_tool_args() {
+  GODOT_AI_PIN="$PIN_SESSION" python3 -c "
+import json, os, sys
+args = json.loads(sys.argv[1])
+pin = os.environ.get('GODOT_AI_PIN', '')
+if pin:
+    args['session_id'] = pin
+print(json.dumps(args))" "$1"
+}
+if [ -n "$PIN_SESSION" ]; then
+  echo "Pinned to session: $PIN_SESSION"
+fi
+
 # Give the editor time to finish its filesystem scan and script class
 # registration. Without this, test_run fires before DirAccess sees the
 # test scripts — the plugin connects before the scan completes.
@@ -97,7 +141,7 @@ sleep 8
 echo "Opening main.tscn..."
 SCENE_OPEN_RESULT=$(curl -s "$SERVER_URL" -X POST "${HEADERS[@]}" \
   -H "Mcp-Session-Id: $SESSION_ID" \
-  -d '{"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"scene_open","arguments":{"path":"res://main.tscn"}}}')
+  -d "$(printf '{"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"scene_open","arguments":%s}}' "$(_tool_args '{"path":"res://main.tscn"}')")")
 # A failed open hollows the run out: scene-dependent tests skip and the
 # summary still reads green. Fail loudly instead (audit backlog).
 echo "$SCENE_OPEN_RESULT" | python3 -c "
@@ -125,7 +169,7 @@ sleep 2
 echo "Running handler tests..."
 RESULT=$(curl -s "$SERVER_URL" -X POST "${HEADERS[@]}" \
   -H "Mcp-Session-Id: $SESSION_ID" \
-  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"test_run","arguments":{}}}')
+  -d "$(printf '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"test_run","arguments":%s}}' "$(_tool_args '{}')")")
 
 # Parse and report results
 echo "$RESULT" | python3 -c "


### PR DESCRIPTION
Follow-up to #832, which created `docs/verification.md`.

## Why

Step 3 of the gauntlet offered exactly one way to get an editor:

> Open `test_project/` in Godot (or launch: `/Applications/Godot_mono.app/Contents/MacOS/Godot --editor --path test_project/`)

A macOS GUI path and nothing else. Read by an agent in a headless environment, that says *this step needs a human at a desktop* — so the rational conclusion is "can't run the GDScript suites here, ship on `pytest` alone."

That conclusion is wrong, and it isn't hypothetical. I drew it in #831, #832, and #833, each time stating in the PR description that the suites "need a running Godot this environment doesn't have." Godot 4.7 was installed the whole time, a headless editor was running against `test_project`, and the MCP server was answering on `:8000` — all set up by `.claude/hooks/session-start.sh`.

The information existed, in a comment inside the hook script:

```
#   - godot:   command -v godot
#   - editor:  pgrep -f 'godot.*--editor' >/dev/null
#   - server:  curl -sf ... http://127.0.0.1:8000/mcp ...
```

`.claude/hooks/` is not part of the guidance tree. Nothing a session reads while following the gauntlet points there.

## Changes

`docs/verification.md` only:

- New leading section: check whether an editor is already running, with the three probes moved out of the hook comment
- Names `script/ci-godot-tests`, which waits for the plugin, opens `main.tscn`, runs `test_run`, and prints `{suite}.{test}: {message}` per failure — steps 3–5 in one non-interactive command
- Step 3 now gives the headless invocation alongside the macOS GUI one, and says to skip it if an editor is already up
- Step 5 notes the one-command equivalent

The interactive path stays for step 6's live smoke, where you genuinely need an editor to look at.

## Verification

Ran the whole gauntlet this file describes, using the headless path it now documents:

- `ruff check src/ tests/` — clean
- `pytest -q` — **1638 passed, 4 skipped**
- `script/ci-godot-tests` — **1985/2013 passed, 0 failed, 28 skipped**, against the live editor
- MD001 heading check and relative-link check across `AGENTS.md`, `CLAUDE.md`, `docs/`, and the remaining skill — clean

(The GDScript skip count moves by one between runs — 27 vs 28 — as an environment-gated suite flips. Zero failures either way.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJcN2A3fPpTxGa32XWNNRK

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJcN2A3fPpTxGa32XWNNRK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded pre-commit verification guidance to detect a pre-existing Godot editor instance and confirm MCP connectivity.
  * Reworked the smoke test instructions with clearer interactive vs headless Godot commands and log/PID guidance.
  * Clarified how session activation works when multiple editors are connected, and how it ties into the combined test workflow.
* **CI / Test Automation**
  * Updated the Godot test runner to fail safely when multiple MCP-connected sessions are available unless a session pin is provided.
  * Added support for pinning a specific session to ensure subsequent test actions run in the intended editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->