### PR TITLE
Report non-imported paths distinctly from reimport (#778)

### DIFF
--- a/plugin/addons/godot_ai/handlers/filesystem_handler.gd
+++ b/plugin/addons/godot_ai/handlers/filesystem_handler.gd
@@ -15,6 +15,11 @@ const ScriptHandler := preload("res://addons/godot_ai/handlers/script_handler.gd
 const _SCAN_START_GRACE_MSEC := 750
 const _SCAN_SETTLE_MAX_MSEC := 28000
 
+## Sidecar the editor writes next to every imported resource. `reimport` reads
+## it to tell imported assets from files that merely have a filesystem entry
+## (see `_is_imported_resource`).
+const IMPORT_SIDECAR_SUFFIX := ".import"
+
 ## Shared single-flight latch for scan_filesystem. `is_scanning()` alone can't
 ## enforce single-flight: `EditorFileSystem.scan()` doesn't flip `is_scanning()`
 ## for a frame or two (hence _SCAN_START_GRACE_MSEC), so a second request landing
@@ -135,6 +140,7 @@ func reimport(params: Dictionary) -> Dictionary:
 			"EditorFileSystem not available", false)
 
 	var reimported: Array[String] = []
+	var skipped_non_imported: Array[String] = []
 	var not_found: Array[String] = []
 
 	for path_variant in paths:
@@ -147,18 +153,56 @@ func reimport(params: Dictionary) -> Dictionary:
 			not_found.append("%s (file does not exist)" % path)
 			continue
 		efs.update_file(path)
-		reimported.append(path)
+		if _is_imported_resource(path):
+			reimported.append(path)
+		else:
+			skipped_non_imported.append(path)
 
-	return {
-		"data": {
-			"reimported": reimported,
-			"not_found": not_found,
-			"reimported_count": reimported.size(),
-			"not_found_count": not_found.size(),
-			"undoable": false,
-			"reason": "Reimport is a file system operation",
-		}
+	var data := {
+		"reimported": reimported,
+		"skipped_non_imported": skipped_non_imported,
+		"not_found": not_found,
+		"reimported_count": reimported.size(),
+		"skipped_non_imported_count": skipped_non_imported.size(),
+		"not_found_count": not_found.size(),
+		"undoable": false,
+		"reason": "Reimport is a file system operation",
 	}
+	## Only when it applies: a hint on every call would cost tokens on the
+	## all-assets path this op is actually for.
+	if not skipped_non_imported.is_empty():
+		data["skipped_non_imported_hint"] = (
+			"%d path(s) are not imported resources. Their editor filesystem entry was "
+			+ "refreshed, but no import ran — a success here is not evidence that a "
+			+ "script parsed or that diagnostics were produced. Use script_patch/"
+			+ "script_create for GDScript diagnostics, or filesystem_manage(op=\"scan\") "
+			+ "for an asset the editor has not imported yet."
+		) % skipped_non_imported.size()
+	return {"data": data}
+
+
+## #778: `update_file()` registers a path with the resource pipeline; it only
+## runs an *import* for files that have one. Scripts, scenes and hand-written
+## `.tres` are not imported resources, so listing them under `reimported` reads
+## as proof that a parse or import ran when nothing did.
+##
+## The `.import` sidecar is the editor's own record that a path goes through
+## the import pipeline, so it decides the split. An extension allow-list was
+## rejected: importers come and go with plugins, so the list would drift out of
+## agreement with the editor it claims to describe.
+##
+## Known edge: an asset the editor has never imported (just written, no scan
+## yet) has no sidecar and reports as non-imported. That is accurate at the
+## moment of the call — `update_file()` did not import it either — and the
+## hint names `scan` as the way through.
+##
+## Behaviour is unchanged for every path: `update_file()` still runs on all of
+## them, because refreshing an externally-edited `.tscn`/`.tres` is a real use
+## of this op. This splits the report, not the work.
+static func _is_imported_resource(path: String) -> bool:
+	if path.ends_with(IMPORT_SIDECAR_SUFFIX):
+		return false  ## The sidecar itself is not an imported resource.
+	return FileAccess.file_exists(path + IMPORT_SIDECAR_SUFFIX)
 
 
 ## Force a full EditorFileSystem scan and wait for it to settle. This is the

--- a/src/godot_ai/tools/filesystem.py
+++ b/src/godot_ai/tools/filesystem.py
@@ -22,11 +22,16 @@ Ops:
   • reimport(paths)
         Force-reimport the listed files via ``EditorFileSystem.update_file``.
         ``paths`` is a list of res:// paths.
-        Intended for imported assets such as textures, models, and audio. ``.gd``
-        scripts are not imported resources; a successful ``.gd`` entry only means
-        its editor filesystem cache entry was refreshed, not that it was parsed or
-        diagnostics were produced. Use ``script_patch``/``script_create`` to save a
-        script and receive fresh diagnostics.
+        Intended for imported assets such as textures, models, and audio.
+        Paths that are not imported resources (``.gd`` scripts, ``.tscn``,
+        hand-written ``.tres``, or an asset the editor has not imported yet)
+        report under ``skipped_non_imported`` rather than ``reimported``: their
+        filesystem entry is refreshed, but no import runs, so a success there is
+        not evidence that a script parsed or that diagnostics were produced. Use
+        ``script_patch``/``script_create`` to save a script and receive fresh
+        diagnostics, or ``scan`` for an asset awaiting its first import.
+        Returns ``reimported``, ``skipped_non_imported``, ``not_found`` and their
+        counts.
   • scan()
         Force a full ``EditorFileSystem.scan()`` and wait for it to settle.
         This is the headless equivalent of the editor regaining window focus:

--- a/test_project/tests/test_filesystem.gd
+++ b/test_project/tests/test_filesystem.gd
@@ -309,7 +309,7 @@ func test_reimport_sidecar_path_is_not_an_imported_resource() -> void:
 	var result := _handler.reimport({"paths": [IMPORTED_ASSET_PATH + ".import"]})
 	assert_has_key(result, "data")
 	assert_eq(result.data.reimported_count, 0)
-	assert_eq(result.data.skipped_non_imported_count, 1)
+	assert_eq(result.data.skipped_non_imported, [IMPORTED_ASSET_PATH + ".import"])
 
 
 func test_reimport_invalid_prefix() -> void:

--- a/test_project/tests/test_filesystem.gd
+++ b/test_project/tests/test_filesystem.gd
@@ -12,6 +12,11 @@ var _handler: FilesystemHandler
 const TEST_FILE_PATH := "res://tests/_mcp_test_file.txt"
 const TEST_FILE_CONTENT := "Hello from MCP test\nLine 2\nLine 3\n"
 
+## #778 fixture: a file that looks imported to the editor. `.dat` has no
+## importer, so the sidecar stays inert (no import runs, no import error is
+## logged) while still exercising the sidecar-based classification.
+const IMPORTED_ASSET_PATH := "res://tests/_mcp_test_imported.dat"
+
 
 func suite_name() -> String:
 	return "filesystem"
@@ -24,6 +29,12 @@ func suite_setup(_ctx: Dictionary) -> void:
 	if file:
 		file.store_string(TEST_FILE_CONTENT)
 		file.close()
+	# Imported-asset fixture: source + its `.import` sidecar (#778).
+	for path in [IMPORTED_ASSET_PATH, IMPORTED_ASSET_PATH + ".import"]:
+		var asset := FileAccess.open(path, FileAccess.WRITE)
+		if asset:
+			asset.store_string("[remap]\n")
+			asset.close()
 
 
 func suite_teardown() -> void:
@@ -33,6 +44,9 @@ func suite_teardown() -> void:
 	var written_path := "res://tests/_mcp_test_written.txt"
 	if FileAccess.file_exists(written_path):
 		DirAccess.remove_absolute(written_path)
+	for path in [IMPORTED_ASSET_PATH, IMPORTED_ASSET_PATH + ".import"]:
+		if FileAccess.file_exists(path):
+			DirAccess.remove_absolute(path)
 
 
 # ----- read_file -----
@@ -245,11 +259,57 @@ func test_reimport_nonexistent_file() -> void:
 
 
 func test_reimport_existing_file() -> void:
-	# Use the test file we created in setup
+	## #778: a .txt is not an imported resource — it has no `.import` sidecar,
+	## so it reports as refreshed-not-reimported rather than padding
+	## `reimported` with a path no importer ever touched.
 	var result := _handler.reimport({"paths": [TEST_FILE_PATH]})
 	assert_has_key(result, "data")
+	assert_eq(result.data.reimported_count, 0)
+	assert_eq(result.data.skipped_non_imported_count, 1)
+	assert_contains(result.data.skipped_non_imported, TEST_FILE_PATH)
+
+
+func test_reimport_imported_asset_is_reported_as_reimported() -> void:
+	## The `.import` sidecar is the signal, not the extension (#778).
+	var result := _handler.reimport({"paths": [IMPORTED_ASSET_PATH]})
+	assert_has_key(result, "data")
 	assert_eq(result.data.reimported_count, 1)
-	assert_contains(result.data.reimported, TEST_FILE_PATH)
+	assert_contains(result.data.reimported, IMPORTED_ASSET_PATH)
+	assert_eq(result.data.skipped_non_imported_count, 0)
+	assert_false(
+		result.data.has("skipped_non_imported_hint"),
+		"an all-imported batch must not pay for the hint"
+	)
+
+
+func test_reimport_mixed_batch_splits_the_report() -> void:
+	## The case #778 is about: one imported asset, one script, one missing
+	## path in a single call. Each lands in its own bucket, and the script
+	## never counts as reimported.
+	var script_path := "res://addons/godot_ai/handlers/filesystem_handler.gd"
+	var result := _handler.reimport({
+		"paths": [IMPORTED_ASSET_PATH, script_path, "res://nonexistent.png"],
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.reimported, [IMPORTED_ASSET_PATH])
+	assert_eq(result.data.skipped_non_imported, [script_path])
+	assert_eq(result.data.reimported_count, 1)
+	assert_eq(result.data.skipped_non_imported_count, 1)
+	assert_eq(result.data.not_found_count, 1)
+	assert_contains(result.data.not_found[0], "res://nonexistent.png")
+	assert_true(
+		result.data.has("skipped_non_imported_hint"),
+		"a batch carrying non-imported paths must say so"
+	)
+
+
+func test_reimport_sidecar_path_is_not_an_imported_resource() -> void:
+	## `foo.png.import` is the record, not the resource — passing it must not
+	## report an import that never ran.
+	var result := _handler.reimport({"paths": [IMPORTED_ASSET_PATH + ".import"]})
+	assert_has_key(result, "data")
+	assert_eq(result.data.reimported_count, 0)
+	assert_eq(result.data.skipped_non_imported_count, 1)
 
 
 func test_reimport_invalid_prefix() -> void:

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -2698,6 +2698,39 @@ class TestImportReimportTool:
         assert result.data["reimported_count"] == 2
         assert result.data["not_found_count"] == 0
 
+    async def test_reimport_passes_through_non_imported_split(self, mcp_stack):
+        """#778: the imported/non-imported split survives the round trip."""
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "reimport"
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "reimported": ["res://icon.png"],
+                    "skipped_non_imported": ["res://player.gd"],
+                    "not_found": [],
+                    "reimported_count": 1,
+                    "skipped_non_imported_count": 1,
+                    "not_found_count": 0,
+                    "skipped_non_imported_hint": "1 path(s) are not imported resources.",
+                    "undoable": False,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "filesystem_manage",
+            {"op": "reimport", "params": {"paths": ["res://icon.png", "res://player.gd"]}},
+        )
+        await task
+
+        assert result.data["reimported"] == ["res://icon.png"]
+        assert result.data["skipped_non_imported"] == ["res://player.gd"]
+        assert result.data["skipped_non_imported_count"] == 1
+        assert "not imported resources" in result.data["skipped_non_imported_hint"]
+
 
 # ---------------------------------------------------------------------------
 # signal_list / signal_connect / signal_disconnect


### PR DESCRIPTION
Closes #778.

## Problem

`filesystem_manage(op="reimport")` called `EditorFileSystem.update_file()` on every existing path and appended all of them to `reimported`. Scripts, scenes and hand-written resources are not imported assets, so a `.gd` entry in that list read as proof that a parse or import had run when nothing had. #765 documented the limitation in the tool description but left the response shape saying otherwise.

## Change

The `.import` sidecar decides the split — it is the editor's own record that a path goes through the import pipeline:

- `reimported` — imported assets only
- `skipped_non_imported` + `skipped_non_imported_count` — everything else
- `skipped_non_imported_hint` — attached **only** when that bucket is non-empty, so the all-assets path this op exists for pays nothing. It names `script_patch`/`script_create` for GDScript diagnostics and `scan` for an asset awaiting its first import.

An extension allow-list was rejected: importers come and go with plugins, so the list would drift out of agreement with the editor it claims to describe.

**Behaviour is unchanged for every path** — `update_file()` still runs on all of them, because refreshing an externally-edited `.tscn`/`.tres` is a real use of this op. This splits the report, not the work.

One documented edge: an asset the editor has never imported (just written, no scan yet) has no sidecar and reports as non-imported. That is accurate at the moment of the call — `update_file()` did not import it either — and the hint names `scan` as the way through.

## Verification

- `ruff check src/ tests/` — clean
- `pytest` — 1643 passed, 5 skipped
- `script/ci-check-gdscript` — all files OK
- `script/ci-godot-tests` — 2009/2036 passed, 0 failed; confirmed by name that the four new `test_reimport_*` cases actually executed rather than a stale script passing
- **Live smoke against the running editor**, including a real Godot-imported asset rather than only the fixture — wrote an actual PNG into `test_project/`, let the editor import it, and confirmed Godot writes the `.import` sidecar the classification depends on:

```
paths: ["res://_mcp_smoke_778.png", "res://main.tscn"]
  reimported:            ["res://_mcp_smoke_778.png"]
  skipped_non_imported:  ["res://main.tscn"]
```

Smoke artifacts removed and the project rescanned; `git status` clean apart from the four changed files.

## Tests

GDScript coverage for the mixed imported/non-imported batch the issue asks for, plus the sidecar-path edge (`foo.png.import` is the record, not the resource). The pre-existing `test_reimport_existing_file` asserted a `.txt` counted as reimported — updated, since that assertion encoded the bug. One Python integration test covers the pass-through of the new fields.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPYvw7pkz6SxxGXHWQ2sAF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved filesystem reimport reporting by distinguishing resources that were actually reimported from refreshed entries that lacked import evidence.
  - Added dedicated result lists and counts for **reimported**, **skipped non-imported**, and **not found** outcomes.
  - Added clearer messaging to help interpret cases where a refresh was performed but reimport couldn’t be confirmed.

- **Documentation**
  - Updated reimport operation documentation to reflect the new result categories and the meaning of skipped items and hints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->