### PR TITLE
Document the watermark's fold-unknown-keys contract (#782)

### DIFF
--- a/src/godot_ai/transport/websocket.py
+++ b/src/godot_ai/transport/websocket.py
@@ -505,6 +505,19 @@ def _sync_error_watermark_for_session(session: Session, value: dict[str, int]) -
     current component value is counted when above zero. The debugger and game
     error components overlap (both observe the running game's script errors),
     so their deltas are combined with max(), not summed.
+
+    **Adding a component is a cross-version contract change.** Every integer
+    key that isn't explicitly popped below lands in ``sum(deltas.values())``,
+    so a new counter is folded into the error total by servers that have never
+    heard of it — a plugin stamping one against an older server inflates the
+    "N new errors" doorbell rather than being ignored. There is no allow-list
+    to gate that: ``_PER_RUN_WATERMARK_KEYS`` and ``_WARN_WATERMARK_KEYS`` only
+    route keys they recognize, and everything else falls through to the sum.
+    Carry genuinely new signal (paths, classifications, anything that isn't a
+    count of new errors) in a separate optional envelope field instead, where a
+    server that doesn't know it drops it: non-int values already fail
+    ``_normalized_watermark_int`` and are skipped, so that shape degrades
+    safely on both sides. See #782 for the case that established this.
     """
 
     updates: dict[str, int] = {}

--- a/src/godot_ai/transport/websocket.py
+++ b/src/godot_ai/transport/websocket.py
@@ -506,18 +506,22 @@ def _sync_error_watermark_for_session(session: Session, value: dict[str, int]) -
     error components overlap (both observe the running game's script errors),
     so their deltas are combined with max(), not summed.
 
-    **Adding a component is a cross-version contract change.** Every integer
-    key that isn't explicitly popped below lands in ``sum(deltas.values())``,
-    so a new counter is folded into the error total by servers that have never
-    heard of it — a plugin stamping one against an older server inflates the
-    "N new errors" doorbell rather than being ignored. There is no allow-list
-    to gate that: ``_PER_RUN_WATERMARK_KEYS`` and ``_WARN_WATERMARK_KEYS`` only
-    route keys they recognize, and everything else falls through to the sum.
-    Carry genuinely new signal (paths, classifications, anything that isn't a
-    count of new errors) in a separate optional envelope field instead, where a
-    server that doesn't know it drops it: non-int values already fail
-    ``_normalized_watermark_int`` and are skipped, so that shape degrades
-    safely on both sides. See #782 for the case that established this.
+    **Adding a component is a cross-version contract change.** An unrecognized
+    key is not rejected. Its first stamp only establishes a baseline (recorded
+    in ``updates``, no delta), but every later increase becomes a delta, and any
+    delta not popped below falls through ``sum(deltas.values())`` into the
+    *error* total — on a server that has never heard of the key. Only
+    ``run_seq`` (skipped outright), the two warn components, and the
+    overlapping debugger/game error pair are routed elsewhere; nothing gates
+    the rest. So a plugin that stamps a new counter against an older server
+    silently inflates its "N new errors" doorbell from the second stamp onward.
+
+    Carry genuinely new signal (paths, classifications — anything that is not a
+    count of new errors) in a separate optional envelope field instead, which a
+    server that does not know it simply ignores. Note how narrow the skip is:
+    ``_normalized_watermark_int`` drops only what ``int()`` refuses, so a list
+    or dict falls out, while ``"5"``, ``1.5`` and ``True`` all coerce and count.
+    See #782 for the case that established this.
     """
 
     updates: dict[str, int] = {}


### PR DESCRIPTION
Comment only, no behavior change.

## Why

`_sync_error_watermark_for_session` ends in:

```python
new_total = overlap + sum(deltas.values())
```

Every integer key that isn't explicitly popped (`_WARN_WATERMARK_KEYS`, the two overlapping debugger/game components) lands in that sum — **including keys the receiving server has never heard of**. So a plugin that stamps a new watermark counter against an older server doesn't get it ignored; it inflates that server's "N new errors since your last call" doorbell. There's no allow-list gating this: the existing key sets only route what they recognize, and everything else falls through to the sum.

Nothing at the call site said so. The docstring covered the reset/overlap semantics carefully but not the one rule that bites a future contributor from another process's version.

This constraint was worked out while investigating #782 (naming the failing file in the doorbell hint). That investigation is being closed unstarted — its A/B gate now requires rebuilding an eval harness that was never committed to this repo — so the landmine is recorded here rather than left in a closed issue. It applies to anyone extending the watermark, not just to that proposal.

The comment also names the safe alternative, which the #782 sketch had right: carry genuinely new signal in a separate optional envelope field. Non-int values already fail `_normalized_watermark_int` and get skipped, so that shape degrades safely in both directions.

## Verification

- `ruff check src/ tests/` — clean
- `pytest tests/unit -k "watermark or websocket"` — 11 passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPYvw7pkz6SxxGXHWQ2sAF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified cross-version behavior for error and warning counter synchronization, including how unrecognized watermark keys are handled over time.
  * Documented a compatibility approach for transmitting genuinely new signal data via an optional envelope that older servers will ignore.
  * Added guidance on counter value normalization, including how coercible inputs are treated and what gets dropped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->