### PR TITLE
Honor active attach leases when the editor exits normally (#824)

### DIFF
--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -889,15 +889,42 @@ static func _probe_live_server_status(port: int, timeout_ms: int = SERVER_STATUS
 	if not (parsed is Dictionary):
 		result["error"] = "invalid_json"
 		return result
-	result["reachable"] = true
-	result["name"] = str(parsed.get("name", ""))
-	result["version"] = _extract_server_version(parsed)
-	result["ws_port"] = int(parsed.get("ws_port", 0))
-	## `package_path` was added in v2.4.4 (#416) so the dock's
-	## "Incompatible server" banner can name the source of a version
-	## skew. Older servers omit it; treat the missing field as "".
-	result["package_path"] = str(parsed.get("package_path", ""))
+	result.merge(_project_status_payload(parsed), true)
 	return result
+
+
+## Project a parsed `/godot-ai/status` body into the probe's result shape.
+##
+## Extracted from the probe so it can be tested against a real payload. The
+## probe is a whitelist — a field the server publishes does not reach callers
+## unless it is copied here — and that is silent: the consumer just sees a
+## missing key. #824's lease check shipped reading `active_lease_count` while
+## this projection dropped it, so the branch was dead on every platform, and
+## the tests could not see it because they hand-built the result dict this
+## function is supposed to produce. Add new fields here, and cover them with a
+## projection test rather than a fabricated `live_status`.
+static func _project_status_payload(parsed: Dictionary) -> Dictionary:
+	var projected := {
+		"reachable": true,
+		"name": str(parsed.get("name", "")),
+		"version": _extract_server_version(parsed),
+		"ws_port": int(parsed.get("ws_port", 0)),
+		## `package_path` was added in v2.4.4 (#416) so the dock's
+		## "Incompatible server" banner can name the source of a version
+		## skew. Older servers omit it; treat the missing field as "".
+		"package_path": str(parsed.get("package_path", "")),
+	}
+	## #824: advisory attach-lease count, consumed by teardown to decide
+	## detach-vs-kill. Absent stays absent rather than defaulting to 0, so
+	## `ServerLifecycleManager.active_lease_count` keeps distinguishing "backend
+	## too old to publish this" from "backend reports zero leases" — both stop
+	## the server, but only one of them is a compatibility statement.
+	## Non-numeric JSON is dropped for the same reason it is clamped
+	## downstream: a malformed value must not read as occupancy.
+	var raw: Variant = parsed.get("active_lease_count")
+	if raw is float or raw is int:
+		projected["active_lease_count"] = int(raw)
+	return projected
 
 
 func _probe_live_server_status_for_port(port: int) -> Dictionary:

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -919,11 +919,16 @@ static func _project_status_payload(parsed: Dictionary) -> Dictionary:
 	## `ServerLifecycleManager.active_lease_count` keeps distinguishing "backend
 	## too old to publish this" from "backend reports zero leases" — both stop
 	## the server, but only one of them is a compatibility statement.
-	## Non-numeric JSON is dropped for the same reason it is clamped
-	## downstream: a malformed value must not read as occupancy.
+	## Anything that is not a finite whole number is dropped, for the same
+	## reason the value is clamped downstream: a malformed count must not read
+	## as occupancy and keep a server alive. Godot parses every JSON number as
+	## a float, so the whole-number test is what distinguishes a real count
+	## from junk — truncating 1.5 to 1 would manufacture a held lease.
 	var raw: Variant = parsed.get("active_lease_count")
-	if raw is float or raw is int:
-		projected["active_lease_count"] = int(raw)
+	if raw is int or raw is float:
+		var numeric := float(raw)
+		if is_finite(numeric) and numeric == floor(numeric):
+			projected["active_lease_count"] = int(numeric)
 	return projected
 
 

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -984,19 +984,23 @@ func _start_server_impl(async_gen: int) -> void:
 ## the watch crossed SPAWN_GRACE_MS and reported an exit — rescued only by the
 ## crash-survivor adoption path.
 ##
-## A uv venv's `python.exe` is a shim rather than the interpreter, and the
-## real server does run under a *different* PID than the one
-## `OS.create_process` hands back — confirmed on a Windows runner (spawned
-## 7084, pid-file 6088). What is NOT confirmed is the original report's
-## suspected mechanism, that the shim exits once its child is up: on that
-## runner the spawned PID stayed alive for 90s, behaving as a live parent.
-## So the shim's exit is one possible cause of the reported death, not an
-## established one.
+## A uv venv's `python.exe` is a shim rather than the interpreter, and the real
+## server does run under a *different* PID than the one `OS.create_process`
+## hands back. But the original report's suspected mechanism — that the shim
+## exits once its child is up — is **disproven**, not merely unconfirmed. A
+## 12-boot run on Windows 11 with a uv venv found the spawned trampoline alive
+## on every boot, with the child owning both the pid-file and the listener; a
+## CI runner showed the same. The shim is a live parent for the process's whole
+## life, so it is not what kills the watched PID.
 ##
-## This gate is therefore keyed to the observable condition — watched PID
-## dead, no pid-file yet — and not to any theory of why it died. Whatever
-## kills it, waiting for the pid-file is the correct response, and when the
-## watched PID stays alive (as on that runner) this branch simply never fires.
+## Two consequences worth keeping straight. First, this gate is keyed to the
+## observable condition — watched PID dead, no pid-file yet — not to any theory
+## of why it died, so it stays correct whatever the cause. Second, and less
+## comfortable: in that same 12-boot run the false "server exited" line never
+## appeared AND the watched PID never died, so the guard never fired. Those
+## clean boots are evidence the symptom did not reproduce, NOT evidence this
+## guard fixes it. The true cause of the original 1-in-4 report is still
+## unknown; if it resurfaces, start from that rather than from the trampoline.
 ##
 ## `real_pid <= 0` means no pid-file exists yet, and that reliably means "this
 ## server has not published one" rather than "stale leftover": `start_server`

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -1365,8 +1365,69 @@ func recover_strong_port_occupant(port: int, wait_s: float, pre_kill_live: Dicti
 func teardown_for_editor_exit() -> void:
 	if _server_keep_alive:
 		detach_server()
-	else:
-		stop_server()
+		return
+	## #824: a backend we spawned may be keeping one or more MCP clients alive
+	## through their `godot-ai attach` bridges. Killing it because *this* editor
+	## is closing takes the server out from under them: an in-flight call can
+	## become TRANSPORT_OUTCOME_UNKNOWN, and every bridge has to establish a new
+	## backend before the next editor can reconnect. A live lease means the
+	## backend has consumers beyond this editor, so hand it over instead.
+	var leased := active_lease_count_at_exit()
+	if leased > 0:
+		## Give up kill authority along with the process: dropping the managed
+		## record means the next editor adopts it through the external branch
+		## rather than as a managed server it may kill. The server's own
+		## pid-file is deliberately left in place — it is the backend's
+		## publication, not our claim on it, and adoption reads it.
+		##
+		## The Python side remains the reaper of record: a plugin-spawned
+		## backend keeps its idle backstop armed (only keep_server_on_exit
+		## disarms it) and that backstop is lease-aware, so this defers the
+		## stop to "no editors AND no leases AND grace elapsed" rather than
+		## leaking the process.
+		_host._clear_managed_server_record()
+		detach_server(
+			"detaching server: %d attach lease(s) still held, leaving it to the "
+			% leased
+			+ "server's own idle reaper"
+		)
+		return
+	stop_server()
+
+
+## Active attach-bridge leases on the backend this editor manages, or 0 when
+## there is nothing to consult (#824).
+##
+## Returns 0 — preserving the historical kill-on-exit behavior — for every
+## uncertain case: no managed PID, a probe that fails or times out, a server
+## that does not identify as godot-ai, or one too old to publish the field.
+## That direction is deliberate. A false 0 costs what today already costs
+## (the backend is stopped and bridges reconnect); a false positive would
+## leave a process running on a guess.
+##
+## Bounded by the status probe's own timeout (SERVER_STATUS_PROBE_TIMEOUT_MS),
+## which is what keeps editor exit from hanging on a wedged HTTP server.
+func active_lease_count_at_exit() -> int:
+	if int(_server_pid) <= 0:
+		return 0
+	return active_lease_count(
+		_host._probe_live_server_status_for_port(ClientConfigurator.http_port())
+	)
+
+
+## Read the advisory lease count out of a `/godot-ai/status` payload.
+##
+## Gated on the payload identifying as godot-ai, so an unrelated process
+## answering on the port cannot talk this editor out of a clean stop. A
+## missing field means an older backend that predates #824; it reads as 0,
+## which keeps that pairing on today's behavior.
+static func active_lease_count(live: Dictionary) -> int:
+	if not _live_status_identifies_godot_ai(live):
+		return 0
+	var raw: Variant = live.get("active_lease_count")
+	if raw == null:
+		return 0
+	return maxi(0, int(raw))
 
 
 ## keep_server_on_exit (#800): editor teardown that leaves the server
@@ -1376,14 +1437,20 @@ func teardown_for_editor_exit() -> void:
 ## session's start_server walk adopts the survivor through the existing
 ## record-matches branch (#758/#774). Explicit stops (dock Restart,
 ## update reload) still route through stop_server and kill as before.
-func detach_server() -> void:
+## `log_reason` names why the server is being left alive; the default is the
+## keep_server_on_exit wording this function was written for. #824 reuses the
+## same bookkeeping for the active-lease handover, and a shared log line would
+## have reported the wrong cause for it.
+func detach_server(
+	log_reason: String = "keep_server_on_exit: leaving server running"
+) -> void:
 	_invalidate_async_startup()
 	_host._stop_server_watch()
 	var detached_pid := int(_server_pid)
 	_server_pid = -1
 	transition_state(McpServerStateScript.STOPPED)
 	if detached_pid > 0:
-		print("MCP | keep_server_on_exit: leaving server running (PID %d)" % detached_pid)
+		print("MCP | %s (PID %d)" % [log_reason, detached_pid])
 
 
 func stop_server() -> void:

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -1408,7 +1408,23 @@ func teardown_for_editor_exit() -> void:
 ## Bounded by the status probe's own timeout (SERVER_STATUS_PROBE_TIMEOUT_MS),
 ## which is what keeps editor exit from hanging on a wedged HTTP server.
 func active_lease_count_at_exit() -> int:
-	if int(_server_pid) <= 0:
+	var pid := int(_server_pid)
+	if pid <= 0:
+		return 0
+	## Only a process we can still prove is our godot-ai server earns the
+	## benefit of the doubt. The lease count comes from whoever answers on the
+	## port, which is not by itself proof that it IS the process we are about
+	## to stop — another editor's backend, or an attach-owned one, could hold
+	## the port after ours died. Requiring the same alive+branded proof
+	## `stop_server` uses before its kill closes that gap: without it, a
+	## stranger's leases could talk this editor out of stopping its own server.
+	##
+	## Failing this check is harmless either way. A dead PID has nothing to
+	## kill, and a recycled-but-unbranded PID is rejected by stop_server's own
+	## gate (#686) — both land on the historical path.
+	if not _host._pid_alive_for_proof(pid):
+		return 0
+	if not _host._pid_cmdline_is_godot_ai_for_proof(pid):
 		return 0
 	return active_lease_count(
 		_host._probe_live_server_status_for_port(ClientConfigurator.http_port())

--- a/src/godot_ai/server.py
+++ b/src/godot_ai/server.py
@@ -599,6 +599,16 @@ def create_server(
                 "owner_type": owner_type_from_env(),
                 "attach_protocol_version": ATTACH_PROTOCOL_VERSION,
                 "tool_catalog_hash": catalog_digest,
+                ## #824: how many attach bridges currently hold this instance
+                ## alive. The plugin reads it at editor teardown to decide
+                ## whether to detach a backend it spawned instead of killing
+                ## it out from under a live MCP client. Like every other field
+                ## here it is ADVISORY: it may justify declining to kill, and
+                ## must never be read as permission to kill. Instance-bound by
+                ## construction — the count ships in the same response as the
+                ## ``instance_id`` it belongs to, so it cannot be stale
+                ## relative to that instance.
+                "active_lease_count": leases.active_count(),
             }
         )
 

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -1330,3 +1330,63 @@ func test_lease_count_gate_is_a_threshold_not_an_equality() -> void:
 	assert_false(McpServerLifecycleManagerScript.active_lease_count(
 		{"name": "godot-ai", "active_lease_count": 0}) > 0,
 		"only the last release may return the backend to kill-on-exit")
+
+
+func test_teardown_routes_to_detach_for_more_than_one_lease() -> void:
+	## Routing, not just the helper: the earlier case holds exactly one lease,
+	## so a regression narrowing the gate to `== 1` would still pass it. Several
+	## bridges must reach detach too. `finalize_calls` is the discriminator —
+	## stop_server ends in _finalize_stop_if_port_free, detach_server never
+	## touches it.
+	var es := EditorInterface.get_editor_settings()
+	var saved := _save_keep_setting(es)
+	es.set_setting(McpClientConfigurator.SETTING_KEEP_SERVER_ON_EXIT, false)
+	var host := _ManagerHostStub.new()
+	host.listener_pids = [67777] as Array[int]
+	host.alive_pids = [67777] as Array[int]
+	host.branded_pids = [67777] as Array[int]
+	host.live_status = {"name": "godot-ai", "active_lease_count": 3}
+	var manager := McpServerLifecycleManagerScript.new(host)
+	manager._server_pid = 67777
+
+	manager.teardown_for_editor_exit()
+	var killed := host.killed_targets.duplicate()
+	var finalize_calls := host.finalize_calls
+	var cleared := host.cleared_record_calls
+	_restore_keep_setting(es, saved)
+	host.free()
+
+	assert_true(killed.is_empty(), "three held leases must still detach, not kill")
+	assert_eq(finalize_calls, 0, "detach must not run the stop path's finalize")
+	assert_eq(cleared, 1, "detach drops the managed claim")
+
+
+func test_teardown_routes_to_stop_when_the_pid_cannot_be_proven() -> void:
+	## The proof gate's routing half: a backend reporting leases must NOT keep
+	## the editor from stopping when the PID we hold cannot be proven ours.
+	## Teardown has to reach the stop path, and must not clear the managed
+	## record on the way (stop_server preserves it when the port is still held,
+	## so the next start_server's drift branch can retry the kill).
+	var es := EditorInterface.get_editor_settings()
+	var saved := _save_keep_setting(es)
+	es.set_setting(McpClientConfigurator.SETTING_KEEP_SERVER_ON_EXIT, false)
+	var host := _ManagerHostStub.new()
+	host.alive_pids = [68888] as Array[int]
+	host.branded_pids = [] as Array[int]
+	host.live_status = {"name": "godot-ai", "active_lease_count": 4}
+	var manager := McpServerLifecycleManagerScript.new(host)
+	manager._server_pid = 68888
+
+	manager.teardown_for_editor_exit()
+	var killed := host.killed_targets.duplicate()
+	var finalize_calls := host.finalize_calls
+	var cleared := host.cleared_record_calls
+	_restore_keep_setting(es, saved)
+	host.free()
+
+	assert_eq(finalize_calls, 1,
+		"an unprovable PID must reach the stop path despite reported leases")
+	assert_eq(cleared, 0,
+		"the lease detach's record clear must not fire on the stop path")
+	assert_true(killed.is_empty(),
+		"stop_server's own proof gate still declines to kill an unbranded PID")

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -1272,3 +1272,61 @@ func test_lease_probe_skipped_when_no_managed_pid() -> void:
 
 	assert_eq(count, 0)
 	assert_eq(probes, 0, "no managed PID must mean no status probe at exit")
+
+
+func test_leases_ignored_when_the_managed_pid_cannot_be_proven_ours() -> void:
+	## #824 instance-binding: the lease count comes from whoever answers on the
+	## port, which is not proof that it is the process we are about to stop.
+	## Another backend holding the port must not talk this editor out of
+	## stopping its own server, so an unbranded PID falls back to stop_server
+	## (whose own #686 gate then declines to kill a PID it cannot verify).
+	var es := EditorInterface.get_editor_settings()
+	var saved := _save_keep_setting(es)
+	es.set_setting(McpClientConfigurator.SETTING_KEEP_SERVER_ON_EXIT, false)
+	var host := _ManagerHostStub.new()
+	host.alive_pids = [65555] as Array[int]
+	## Deliberately NOT branded: a recycled PID, or a stranger's process.
+	host.branded_pids = [] as Array[int]
+	host.live_status = {"name": "godot-ai", "active_lease_count": 3}
+	var manager := McpServerLifecycleManagerScript.new(host)
+	manager._server_pid = 65555
+
+	var count := manager.active_lease_count_at_exit()
+	var cleared := host.cleared_record_calls
+	var probes := host.probe_calls
+	_restore_keep_setting(es, saved)
+	host.free()
+
+	assert_eq(count, 0,
+		"leases must not be honored for a PID we cannot prove is our server")
+	assert_eq(probes, 0,
+		"the proof gate must short-circuit before paying for the status probe")
+	assert_eq(cleared, 0)
+
+
+func test_leases_honored_only_for_a_live_branded_managed_pid() -> void:
+	## The positive half of the same gate, so it cannot silently start
+	## returning 0 for everything.
+	var host := _ManagerHostStub.new()
+	host.alive_pids = [66666] as Array[int]
+	host.branded_pids = [66666] as Array[int]
+	host.live_status = {"name": "godot-ai", "active_lease_count": 2}
+	var manager := McpServerLifecycleManagerScript.new(host)
+	manager._server_pid = 66666
+
+	var count := manager.active_lease_count_at_exit()
+	host.free()
+
+	assert_eq(count, 2, "a proven-ours backend's leases must be honored")
+
+
+func test_lease_count_gate_is_a_threshold_not_an_equality() -> void:
+	## Multiple bridges: teardown must detach while ANY lease is held, not only
+	## when exactly one is. Releasing one of several must keep the backend up.
+	for held in [1, 2, 7]:
+		assert_true(McpServerLifecycleManagerScript.active_lease_count(
+			{"name": "godot-ai", "active_lease_count": held}) > 0,
+			"%d held lease(s) must still count as occupied" % held)
+	assert_false(McpServerLifecycleManagerScript.active_lease_count(
+		{"name": "godot-ai", "active_lease_count": 0}) > 0,
+		"only the last release may return the backend to kill-on-exit")

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -1444,9 +1444,25 @@ func test_status_projection_leaves_an_older_backends_field_absent() -> void:
 
 func test_status_projection_drops_a_non_numeric_lease_count() -> void:
 	## A malformed value must not read as occupancy and keep a server alive.
-	for junk in ["3", [], {}, null]:
+	## 1.5 is the interesting one: Godot parses every JSON number as a float, so
+	## a naive int() cast would truncate it to 1 and manufacture a held lease
+	## out of a malformed payload. Infinities and NaN are junk for the same
+	## reason. Whole floats (2.0) are the NORMAL case and must survive.
+	for junk in ["3", [], {}, null, 1.5, 0.5, -2.5, INF, -INF, NAN]:
 		var projected := GodotAiPlugin._project_status_payload({
 			"name": "godot-ai", "active_lease_count": junk,
 		})
 		assert_eq(McpServerLifecycleManagerScript.active_lease_count(projected), 0,
 			"non-numeric lease count must not read as leases held")
+
+
+func test_status_projection_keeps_whole_number_lease_counts() -> void:
+	## The other side of the fractional guard: JSON numbers arrive as floats, so
+	## rejecting floats outright would drop every real count.
+	for whole in [0.0, 1.0, 2.0, 9.0]:
+		var projected := GodotAiPlugin._project_status_payload({
+			"name": "godot-ai", "active_lease_count": whole,
+		})
+		assert_true(projected.has("active_lease_count"),
+			"a whole-number count (%s) is the normal wire shape and must project" % whole)
+		assert_eq(McpServerLifecycleManagerScript.active_lease_count(projected), int(whole))

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -1177,3 +1177,98 @@ func test_first_death_stamp_takes_the_first_tick_that_saw_the_death() -> void:
 	## per spawn, so this is the fresh-spawn entry point.
 	assert_eq(McpServerLifecycleManagerScript.first_death_stamp(0, 5146), 5146,
 		"an unstamped watch must record the tick that first saw the spawn dead")
+
+
+# ----- #824: teardown honors active attach leases -----
+
+func test_teardown_detaches_when_attach_leases_are_active() -> void:
+	## The startup order the issue describes: editor spawns the backend, an MCP
+	## client's attach bridge adopts it and registers a lease, then the editor
+	## closes normally. Killing here would take the server out from under a live
+	## client, so the backend survives and the plugin drops its managed claim.
+	var es := EditorInterface.get_editor_settings()
+	var saved := _save_keep_setting(es)
+	es.set_setting(McpClientConfigurator.SETTING_KEEP_SERVER_ON_EXIT, false)
+	var host := _ManagerHostStub.new()
+	host.listener_pids = [63333] as Array[int]
+	host.alive_pids = [63333] as Array[int]
+	host.branded_pids = [63333] as Array[int]
+	host.live_status = {"name": "godot-ai", "active_lease_count": 1}
+	var manager := McpServerLifecycleManagerScript.new(host)
+	manager._server_pid = 63333
+
+	manager.teardown_for_editor_exit()
+	var killed := host.killed_targets.duplicate()
+	var cleared := host.cleared_record_calls
+	var pid_after := int(manager._server_pid)
+	_restore_keep_setting(es, saved)
+	host.free()
+
+	assert_true(killed.is_empty(),
+		"a backend with a live attach lease must survive normal editor exit")
+	assert_eq(cleared, 1,
+		"the plugin must drop its managed claim so the next editor adopts externally")
+	assert_eq(pid_after, -1, "the detached PID must not stay tracked as killable")
+
+
+func test_teardown_kills_when_no_leases_are_held() -> void:
+	## The no-lease case is the overwhelmingly common one and must not change:
+	## a backend nobody else is using still dies with the editor that spawned it.
+	var es := EditorInterface.get_editor_settings()
+	var saved := _save_keep_setting(es)
+	es.set_setting(McpClientConfigurator.SETTING_KEEP_SERVER_ON_EXIT, false)
+	var host := _ManagerHostStub.new()
+	host.listener_pids = [64444] as Array[int]
+	host.alive_pids = [64444] as Array[int]
+	host.branded_pids = [64444] as Array[int]
+	host.live_status = {"name": "godot-ai", "active_lease_count": 0}
+	var manager := McpServerLifecycleManagerScript.new(host)
+	manager._server_pid = 64444
+
+	manager.teardown_for_editor_exit()
+	var killed := host.killed_targets.duplicate()
+	_restore_keep_setting(es, saved)
+	host.free()
+
+	assert_true(killed.has(64444),
+		"a backend with no leases must still be stopped by the editor that spawned it")
+
+
+func test_lease_count_reads_zero_for_a_backend_too_old_to_publish_it() -> void:
+	## Staggered upgrade: plugin knows about leases, backend does not. Absent
+	## field must read as "no information", which keeps that pairing on the
+	## historical kill-on-exit behavior rather than stranding a process.
+	assert_eq(McpServerLifecycleManagerScript.active_lease_count(
+		{"name": "godot-ai", "server_version": "3.0.7"}), 0)
+
+
+func test_lease_count_ignores_a_process_that_is_not_godot_ai() -> void:
+	## An unrelated process answering on the port must not be able to talk this
+	## editor out of a clean stop by claiming leases.
+	assert_eq(McpServerLifecycleManagerScript.active_lease_count(
+		{"name": "something-else", "active_lease_count": 9}), 0)
+	assert_eq(McpServerLifecycleManagerScript.active_lease_count({}), 0,
+		"a failed or timed-out probe returns {} and must read as no leases")
+
+
+func test_lease_count_clamps_a_nonsense_value() -> void:
+	assert_eq(McpServerLifecycleManagerScript.active_lease_count(
+		{"name": "godot-ai", "active_lease_count": -3}), 0)
+	assert_eq(McpServerLifecycleManagerScript.active_lease_count(
+		{"name": "godot-ai", "active_lease_count": 4}), 4)
+
+
+func test_lease_probe_skipped_when_no_managed_pid() -> void:
+	## Nothing to hand over and nothing to kill: teardown must not pay for an
+	## HTTP probe on the way out.
+	var host := _ManagerHostStub.new()
+	host.live_status = {"name": "godot-ai", "active_lease_count": 5}
+	var manager := McpServerLifecycleManagerScript.new(host)
+	manager._server_pid = 0
+
+	var count := manager.active_lease_count_at_exit()
+	var probes := host.probe_calls
+	host.free()
+
+	assert_eq(count, 0)
+	assert_eq(probes, 0, "no managed PID must mean no status probe at exit")

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -1390,3 +1390,63 @@ func test_teardown_routes_to_stop_when_the_pid_cannot_be_proven() -> void:
 		"the lease detach's record clear must not fire on the stop path")
 	assert_true(killed.is_empty(),
 		"stop_server's own proof gate still declines to kill an unbranded PID")
+
+
+# ----- #824 regression: the probe must PROJECT what teardown consumes -----
+
+func test_status_projection_carries_the_lease_count_to_the_consumer() -> void:
+	## The gap that shipped in #839 and was caught only by a Windows smoke:
+	## teardown read `active_lease_count` off the probe result while
+	## `_probe_live_server_status` never copied it out of the JSON, so the
+	## lease branch was unreachable on every platform. The stubbed teardown
+	## tests could not see it because they hand-built the probe's result dict.
+	##
+	## This drives a real `/godot-ai/status` body through the actual projection
+	## and into the actual consumer, so the two halves cannot drift again.
+	var server_payload := {
+		"name": "godot-ai",
+		"server_version": "3.0.7",
+		"ws_port": 9500,
+		"tool_surface": "rollup",
+		"exclude_domains": [],
+		"package_path": "/src/godot_ai",
+		"instance_id": "e43bd1d9d15c418784676f87055d50b8",
+		"owner_type": "plugin",
+		"attach_protocol_version": 1,
+		"tool_catalog_hash": "deadbeef",
+		"active_lease_count": 2,
+	}
+
+	var projected := GodotAiPlugin._project_status_payload(server_payload)
+
+	assert_true(projected.has("active_lease_count"),
+		"the probe must project the field teardown reads, not drop it")
+	assert_eq(McpServerLifecycleManagerScript.active_lease_count(projected), 2,
+		"a real status body with held leases must reach the teardown consumer")
+	## The fields the projection already carried must survive the refactor.
+	assert_eq(projected.get("name"), "godot-ai")
+	assert_eq(projected.get("version"), "3.0.7")
+	assert_eq(projected.get("ws_port"), 9500)
+	assert_eq(projected.get("package_path"), "/src/godot_ai")
+	assert_true(bool(projected.get("reachable")))
+
+
+func test_status_projection_leaves_an_older_backends_field_absent() -> void:
+	## "Too old to publish it" must stay distinguishable from "reports zero",
+	## which is what the absent-stays-absent rule buys. Both stop the server.
+	var projected := GodotAiPlugin._project_status_payload({
+		"name": "godot-ai", "server_version": "3.0.6", "ws_port": 9500,
+	})
+	assert_false(projected.has("active_lease_count"),
+		"a backend that never published the field must not gain a synthetic 0")
+	assert_eq(McpServerLifecycleManagerScript.active_lease_count(projected), 0)
+
+
+func test_status_projection_drops_a_non_numeric_lease_count() -> void:
+	## A malformed value must not read as occupancy and keep a server alive.
+	for junk in ["3", [], {}, null]:
+		var projected := GodotAiPlugin._project_status_payload({
+			"name": "godot-ai", "active_lease_count": junk,
+		})
+		assert_eq(McpServerLifecycleManagerScript.active_lease_count(projected), 0,
+			"non-numeric lease count must not read as leases held")

--- a/tests/unit/test_server_status.py
+++ b/tests/unit/test_server_status.py
@@ -39,6 +39,7 @@ def test_status_route_reports_live_server_version():
         "package_path": str(Path(_godot_ai_pkg.__file__).resolve().parent),
         "owner_type": "external",
         "attach_protocol_version": 1,
+        "active_lease_count": 0,
     }
     assert len(instance_id) == 32
     assert len(catalog_hash) == 64
@@ -162,3 +163,33 @@ async def test_plugin_owned_lifespan_wires_lease_count_into_both_reapers(monkeyp
             "idle_sessions": 0,
             "idle_leases": 0,
         }
+
+
+def test_status_route_reports_active_attach_lease_count():
+    """#824: the plugin reads this at editor exit to decide detach vs kill."""
+    server = create_server(ws_port=9556)
+    app = server.http_app(transport="streamable-http")
+    client = TestClient(app, base_url="http://127.0.0.1")
+
+    instance_id = client.get("/godot-ai/status").json()["instance_id"]
+    assert client.get("/godot-ai/status").json()["active_lease_count"] == 0
+
+    registered = client.post(
+        "/godot-ai/lease/register", json={"instance_id": instance_id}
+    )
+    assert registered.status_code == 200
+    lease_id = registered.json()["lease_id"]
+
+    ## A held lease is what tells a closing editor to hand the backend over
+    ## instead of killing it out from under the bridge that registered.
+    assert client.get("/godot-ai/status").json()["active_lease_count"] == 1
+
+    released = client.post(
+        "/godot-ai/lease/release",
+        json={"instance_id": instance_id, "lease_id": lease_id},
+    )
+    assert released.status_code == 200
+
+    ## ...and once the last bridge lets go, the editor's normal stop applies
+    ## again on the next teardown.
+    assert client.get("/godot-ai/status").json()["active_lease_count"] == 0

--- a/tests/unit/test_server_status.py
+++ b/tests/unit/test_server_status.py
@@ -193,3 +193,38 @@ def test_status_route_reports_active_attach_lease_count():
     ## ...and once the last bridge lets go, the editor's normal stop applies
     ## again on the next teardown.
     assert client.get("/godot-ai/status").json()["active_lease_count"] == 0
+
+
+def test_status_lease_count_tracks_multiple_bridges():
+    """#824: releasing one of several bridges must not free the backend."""
+    server = create_server(ws_port=9557)
+    app = server.http_app(transport="streamable-http")
+    client = TestClient(app, base_url="http://127.0.0.1")
+
+    instance_id = client.get("/godot-ai/status").json()["instance_id"]
+
+    def count() -> int:
+        return client.get("/godot-ai/status").json()["active_lease_count"]
+
+    first = client.post(
+        "/godot-ai/lease/register", json={"instance_id": instance_id}
+    ).json()["lease_id"]
+    second = client.post(
+        "/godot-ai/lease/register", json={"instance_id": instance_id}
+    ).json()["lease_id"]
+    assert count() == 2
+
+    ## One bridge exits; the other still holds the backend, so the editor's
+    ## teardown must still see a non-zero count and decline to kill.
+    client.post(
+        "/godot-ai/lease/release",
+        json={"instance_id": instance_id, "lease_id": first},
+    )
+    assert count() == 1
+
+    ## Only the last release returns it to the reapable state.
+    client.post(
+        "/godot-ai/lease/release",
+        json={"instance_id": instance_id, "lease_id": second},
+    )
+    assert count() == 0


### PR DESCRIPTION
Closes #824.

## Problem

Both Python reaper paths already honor attach-bridge leases (#822 PR A). The GDScript teardown did not, so this order still caused churn:

1. Open Godot → plugin spawns the backend
2. Start an MCP client → its `godot-ai attach` bridge adopts that backend and registers a lease
3. Close Godot normally → **the plugin kills the backend despite the live lease**

An in-flight call can become `TRANSPORT_OUTCOME_UNKNOWN`, and every bridge must establish a new backend before the next editor can reconnect.

## Change

**Backend** — `/godot-ai/status` gains `active_lease_count`. Additive, so an older plugin ignores it and an older backend simply omits it. Advisory only, consistent with the existing fields: it may justify *declining* to kill, never permission to kill. Instance-bound by construction, since the count ships in the same response as the `instance_id` it belongs to and so cannot be stale relative to that instance.

**Plugin** — `teardown_for_editor_exit` consults it before stopping. With leases held it drops the managed record and detaches instead of killing, giving up kill authority so the next editor adopts the survivor through the external branch rather than as a managed server it may kill.

Two deliberate choices worth flagging for review:

- **The server's own pid-file is left in place.** It's the backend's publication, not the plugin's claim on it, and adoption reads it. Only the managed record — the thing that confers kill authority — is dropped.
- **Nothing leaks.** A plugin-spawned backend keeps its idle backstop armed (only `keep_server_on_exit` disarms it) and that backstop is lease-aware, so this *defers* the stop to "no editors AND no leases AND grace elapsed" rather than stranding a process.

## Fail direction

Every uncertain case reads as zero leases and keeps today's kill-on-exit behavior: no managed PID, a probe that fails or times out, a process that doesn't identify as `godot-ai`, or a backend too old to publish the field. A false zero costs exactly what today already costs; a false positive would leave a process running on a guess.

Bounded by `SERVER_STATUS_PROBE_TIMEOUT_MS`, so editor exit can't hang on a wedged server, and the probe is skipped entirely when there's no managed PID.

## Verification

- `ruff check src/ tests/` — clean
- `pytest` — 1644 passed, 5 skipped
- `script/ci-check-gdscript` — all files OK
- `script/ci-godot-tests` — **2021/2048, 0 failed** (+6, the new cases)
- **Live against the running plugin-spawned backend** — this is the real one, since the whole feature hinges on a plugin-owned server reporting leases truthfully:

```
status: name=godot-ai owner_type=plugin active_lease_count=0
POST /godot-ai/lease/register  -> active_lease_count: 1
POST /godot-ai/lease/release   -> active_lease_count: 0
```

## Tests

GDScript covers the issue's acceptance list: detach with a lease held (record cleared, PID untracked, nothing killed), kill with no leases, a backend too old to publish the field, a non-`godot-ai` process that can't talk the editor out of a clean stop, a clamped nonsense value, and no probe at all when there's no managed PID. The pre-existing `keep_server_on_exit` teardown tests are untouched and still pass, which is the regression guard for that path.

Python covers the additive field and a register/release round trip through the real lease routes. The exact-payload contract test in `test_server_status.py` was updated to include the new key — it exists to catch exactly this kind of surface change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPYvw7pkz6SxxGXHWQ2sAF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server status (`/godot-ai/status`) now includes `active_lease_count`, indicating how many editor attachment leases are currently active.
* **Bug Fixes**
  * Editor shutdown handling for keep-alive servers is now lease-aware: if active leases are present, the server is detached for later adoption rather than terminated; otherwise it is stopped as before.
* **Tests**
  * Updated and expanded lifecycle and status-route coverage for attach leases, including missing/invalid counts, zero vs. positive behavior, and multi-lease tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->