### PR TITLE
Capture forensics when a spawn is judged to have fast-exited (#797)

### DIFF
--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -1050,11 +1050,24 @@ static func first_death_stamp(current_stamp_ms: int, elapsed_ms: int) -> int:
 ## through seams the surrounding diagnosis already uses, on a path that only
 ## runs when a spawn is being declared dead, so it costs nothing in the
 ## healthy case.
+## Deliberately does NOT scrape the port for listener PIDs. This runs from the
+## 1 Hz watch loop, on a live frame, so a `_find_all_pids_on_port` subprocess
+## here would stall the editor for a diagnostic. Deferring it via
+## `_run_blocking` was the alternative and is worse: that helper is
+## `await`-based, so it would turn this, `_diagnose_spawn_fast_exit` and
+## `check_server_health` into coroutines — making the watch callback resume
+## across arbitrary frames while its branches set terminal state and trigger
+## re-adoption walks. That is the teardown-ordering hazard
+## `_invalidate_async_startup` exists to contain, and it is not worth taking
+## on for a log line.
+##
+## Little is lost: the probe on the very next line already establishes whether
+## a godot-ai server answers on the port, and `_diagnose_spawn_port_conflict`
+## names a foreign occupant when there is one. If you are tempted to add the
+## PID list back, put it behind that existing conflict path rather than here.
 func _log_spawn_exit_forensics(elapsed: int) -> void:
-	var port := ClientConfigurator.http_port()
 	var spawn_pid := int(_server_pid)
 	var pid_file_pid := int(_host._read_pid_file_for_proof())
-	var listeners: Array[int] = _host._find_all_pids_on_port(port)
 	_host._log_buffer.log(format_spawn_exit_forensics({
 		"os": OS.get_name(),
 		"launch_mode": ClientConfigurator.get_server_launch_mode(),
@@ -1069,7 +1082,6 @@ func _log_spawn_exit_forensics(elapsed: int) -> void:
 		"spawn_alive": spawn_pid > 0 and bool(_host._pid_alive_for_proof(spawn_pid)),
 		"pid_file_pid": pid_file_pid,
 		"pid_file_alive": pid_file_pid > 0 and bool(_host._pid_alive_for_proof(pid_file_pid)),
-		"listeners": listeners,
 	}))
 
 
@@ -1078,7 +1090,6 @@ func _log_spawn_exit_forensics(elapsed: int) -> void:
 static func format_spawn_exit_forensics(facts: Dictionary) -> String:
 	var spawn_pid := int(facts.get("spawn_pid", 0))
 	var pid_file_pid := int(facts.get("pid_file_pid", 0))
-	var listeners: Array = facts.get("listeners", [])
 	## The single most diagnostic bit, stated rather than left to be inferred:
 	## a live pid-file process while the watched one is gone is the launcher
 	## handoff shape; both gone is a real crash.
@@ -1095,7 +1106,7 @@ static func format_spawn_exit_forensics(facts: Dictionary) -> String:
 		shape = "all_dead"
 	return (
 		"#797 spawn-exit forensics: shape=%s os=%s launch=%s elapsed=%dms "
-		+ "first_dead=%dms spawn_pid=%d(alive=%s) pid_file_pid=%d(alive=%s) listeners=%s"
+		+ "first_dead=%dms spawn_pid=%d(alive=%s) pid_file_pid=%d(alive=%s)"
 	) % [
 		shape,
 		str(facts.get("os", "")),
@@ -1106,7 +1117,6 @@ static func format_spawn_exit_forensics(facts: Dictionary) -> String:
 		str(spawn_alive),
 		pid_file_pid,
 		str(file_alive),
-		str(listeners),
 	]
 
 

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -1065,13 +1065,21 @@ static func first_death_stamp(current_stamp_ms: int, elapsed_ms: int) -> int:
 ## a godot-ai server answers on the port, and `_diagnose_spawn_port_conflict`
 ## names a foreign occupant when there is one. If you are tempted to add the
 ## PID list back, put it behind that existing conflict path rather than here.
-func _log_spawn_exit_forensics(elapsed: int) -> void:
+func _log_spawn_exit_forensics() -> void:
 	var spawn_pid := int(_server_pid)
 	var pid_file_pid := int(_host._read_pid_file_for_proof())
+	## Computed here rather than accepted as a parameter. The caller's
+	## `elapsed` IS `_spawn_dead_since_ms` — #837 passes the true death time so
+	## the user-facing "server exited after Nms" line stays honest — so taking
+	## it would make these two fields report the same number, collapsing the
+	## exact distinction they exist to record.
+	var diagnosed_at_ms := 0
+	if int(_server_spawn_ms) > 0:
+		diagnosed_at_ms = Time.get_ticks_msec() - int(_server_spawn_ms)
 	_host._log_buffer.log(format_spawn_exit_forensics({
 		"os": OS.get_name(),
 		"launch_mode": ClientConfigurator.get_server_launch_mode(),
-		"elapsed_ms": elapsed,
+		"elapsed_ms": diagnosed_at_ms,
 		## Differs from elapsed_ms when a Windows handoff window was waited out
 		## (#824/#837): the true death time versus when we gave up on it.
 		"first_dead_ms": int(_spawn_dead_since_ms),
@@ -1177,7 +1185,7 @@ func check_server_health() -> void:
 ##   3. #172: stale uvx index -> one `--refresh` respawn.
 ##   4. Otherwise -> CRASHED, pointing at the Godot output log.
 func _diagnose_spawn_fast_exit(elapsed: int) -> void:
-	_log_spawn_exit_forensics(elapsed)
+	_log_spawn_exit_forensics()
 	var live: Dictionary = _host._probe_live_server_status_for_port(
 		ClientConfigurator.http_port()
 	)

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -1034,6 +1034,82 @@ static func first_death_stamp(current_stamp_ms: int, elapsed_ms: int) -> int:
 	return current_stamp_ms if current_stamp_ms > 0 else elapsed_ms
 
 
+## One-line forensic snapshot taken the moment a spawn is judged to have
+## fast-exited (#797).
+##
+## #797 reported `server exited after 5146ms` on a healthy Windows boot, once
+## in four. It is still unexplained: a 12-boot run on the reported
+## configuration reproduced neither the symptom nor its suspected mechanism —
+## the uv trampoline was alive on every boot, with the child owning the
+## pid-file and the listener, so the shim's exit is ruled out as the cause.
+## What killed that watched PID is unknown, and the log line at the time
+## carried no evidence to answer it with.
+##
+## So capture the state at the moment of judgement rather than asking the next
+## person to reproduce a 1-in-4 bug under observation. Everything here is read
+## through seams the surrounding diagnosis already uses, on a path that only
+## runs when a spawn is being declared dead, so it costs nothing in the
+## healthy case.
+func _log_spawn_exit_forensics(elapsed: int) -> void:
+	var port := ClientConfigurator.http_port()
+	var spawn_pid := int(_server_pid)
+	var pid_file_pid := int(_host._read_pid_file_for_proof())
+	var listeners: Array[int] = _host._find_all_pids_on_port(port)
+	_host._log_buffer.log(format_spawn_exit_forensics({
+		"os": OS.get_name(),
+		"launch_mode": ClientConfigurator.get_server_launch_mode(),
+		"elapsed_ms": elapsed,
+		## Differs from elapsed_ms when a Windows handoff window was waited out
+		## (#824/#837): the true death time versus when we gave up on it.
+		"first_dead_ms": int(_spawn_dead_since_ms),
+		"spawn_pid": spawn_pid,
+		## Re-read rather than trusted from the watch tick: if the spawn PID is
+		## alive HERE, the death that triggered this was transient, which is a
+		## different bug from a process that really exited.
+		"spawn_alive": spawn_pid > 0 and bool(_host._pid_alive_for_proof(spawn_pid)),
+		"pid_file_pid": pid_file_pid,
+		"pid_file_alive": pid_file_pid > 0 and bool(_host._pid_alive_for_proof(pid_file_pid)),
+		"listeners": listeners,
+	}))
+
+
+## Render the forensic snapshot. Pure so the format is testable without a live
+## editor, and kept to one line so it survives log truncation in a bug report.
+static func format_spawn_exit_forensics(facts: Dictionary) -> String:
+	var spawn_pid := int(facts.get("spawn_pid", 0))
+	var pid_file_pid := int(facts.get("pid_file_pid", 0))
+	var listeners: Array = facts.get("listeners", [])
+	## The single most diagnostic bit, stated rather than left to be inferred:
+	## a live pid-file process while the watched one is gone is the launcher
+	## handoff shape; both gone is a real crash.
+	var shape := "unknown"
+	var spawn_alive := bool(facts.get("spawn_alive", false))
+	var file_alive := bool(facts.get("pid_file_alive", false))
+	if spawn_alive:
+		shape = "watched_pid_still_alive"
+	elif file_alive and pid_file_pid != spawn_pid:
+		shape = "handoff_child_alive"
+	elif not file_alive and pid_file_pid <= 0:
+		shape = "no_pid_file_published"
+	else:
+		shape = "all_dead"
+	return (
+		"#797 spawn-exit forensics: shape=%s os=%s launch=%s elapsed=%dms "
+		+ "first_dead=%dms spawn_pid=%d(alive=%s) pid_file_pid=%d(alive=%s) listeners=%s"
+	) % [
+		shape,
+		str(facts.get("os", "")),
+		str(facts.get("launch_mode", "")),
+		int(facts.get("elapsed_ms", 0)),
+		int(facts.get("first_dead_ms", 0)),
+		spawn_pid,
+		str(spawn_alive),
+		pid_file_pid,
+		str(file_alive),
+		str(listeners),
+	]
+
+
 ## Watch-loop callback (1 Hz, capped by SERVER_WATCH_MS).
 ## `--pid-file` is the source of truth on Windows / uvx where the
 ## launcher PID dies quickly after spawning the real interpreter.
@@ -1091,6 +1167,7 @@ func check_server_health() -> void:
 ##   3. #172: stale uvx index -> one `--refresh` respawn.
 ##   4. Otherwise -> CRASHED, pointing at the Godot output log.
 func _diagnose_spawn_fast_exit(elapsed: int) -> void:
+	_log_spawn_exit_forensics(elapsed)
 	var live: Dictionary = _host._probe_live_server_status_for_port(
 		ClientConfigurator.http_port()
 	)

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -1466,3 +1466,74 @@ func test_status_projection_keeps_whole_number_lease_counts() -> void:
 		assert_true(projected.has("active_lease_count"),
 			"a whole-number count (%s) is the normal wire shape and must project" % whole)
 		assert_eq(McpServerLifecycleManagerScript.active_lease_count(projected), int(whole))
+
+
+# ----- #797 forensics: capture evidence at the moment of judgement -----
+
+func test_forensics_names_the_handoff_shape() -> void:
+	## The shape #797 hypothesised: watched PID gone, a different live PID in
+	## the pid-file. Naming it in the line means a bug report answers the
+	## question without the reporter knowing to look.
+	var line := McpServerLifecycleManagerScript.format_spawn_exit_forensics({
+		"os": "Windows", "launch_mode": "dev_venv",
+		"elapsed_ms": 5146, "first_dead_ms": 5146,
+		"spawn_pid": 30188, "spawn_alive": false,
+		"pid_file_pid": 9360, "pid_file_alive": true,
+		"listeners": [9360],
+	})
+	assert_contains(line, "shape=handoff_child_alive")
+	assert_contains(line, "spawn_pid=30188(alive=false)")
+	assert_contains(line, "pid_file_pid=9360(alive=true)")
+	assert_contains(line, "elapsed=5146ms")
+
+
+func test_forensics_flags_a_watched_pid_that_is_actually_alive() -> void:
+	## The case the 12-boot smoke found: the trampoline never dies. If a
+	## fast-exit is ever diagnosed while the watched PID is alive here, the
+	## death was transient — a different bug from a process that really exited,
+	## and one nobody would guess from "server exited after Nms".
+	var line := McpServerLifecycleManagerScript.format_spawn_exit_forensics({
+		"os": "Windows", "launch_mode": "dev_venv",
+		"elapsed_ms": 5200, "first_dead_ms": 5100,
+		"spawn_pid": 30188, "spawn_alive": true,
+		"pid_file_pid": 9360, "pid_file_alive": true,
+		"listeners": [9360],
+	})
+	assert_contains(line, "shape=watched_pid_still_alive")
+
+
+func test_forensics_distinguishes_a_real_crash_from_a_missing_pid_file() -> void:
+	var crashed := McpServerLifecycleManagerScript.format_spawn_exit_forensics({
+		"spawn_pid": 111, "spawn_alive": false,
+		"pid_file_pid": 111, "pid_file_alive": false, "listeners": [],
+	})
+	assert_contains(crashed, "shape=all_dead")
+
+	var never_published := McpServerLifecycleManagerScript.format_spawn_exit_forensics({
+		"spawn_pid": 111, "spawn_alive": false,
+		"pid_file_pid": 0, "pid_file_alive": false, "listeners": [],
+	})
+	assert_contains(never_published, "shape=no_pid_file_published")
+
+
+func test_forensics_reports_true_death_time_separately_from_detection() -> void:
+	## After a #837 handoff wait, elapsed is when we gave up and first_dead is
+	## when the process actually died. Conflating them would misdate the event
+	## in exactly the reports this line exists to serve.
+	var line := McpServerLifecycleManagerScript.format_spawn_exit_forensics({
+		"elapsed_ms": 15000, "first_dead_ms": 312,
+		"spawn_pid": 1, "spawn_alive": false,
+		"pid_file_pid": 0, "pid_file_alive": false, "listeners": [],
+	})
+	assert_contains(line, "elapsed=15000ms")
+	assert_contains(line, "first_dead=312ms")
+
+
+func test_forensics_is_a_single_line() -> void:
+	## It has to survive being pasted into an issue with surrounding log noise.
+	var line := McpServerLifecycleManagerScript.format_spawn_exit_forensics({
+		"os": "Windows", "spawn_pid": 1, "pid_file_pid": 2, "listeners": [2, 3],
+	})
+	assert_eq(line.count("\n"), 0, "forensics must stay one line")
+	assert_true(line.begins_with("#797 "),
+		"prefix the issue number so a future reporter can search for it")

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -1479,7 +1479,6 @@ func test_forensics_names_the_handoff_shape() -> void:
 		"elapsed_ms": 5146, "first_dead_ms": 5146,
 		"spawn_pid": 30188, "spawn_alive": false,
 		"pid_file_pid": 9360, "pid_file_alive": true,
-		"listeners": [9360],
 	})
 	assert_contains(line, "shape=handoff_child_alive")
 	assert_contains(line, "spawn_pid=30188(alive=false)")
@@ -1497,7 +1496,6 @@ func test_forensics_flags_a_watched_pid_that_is_actually_alive() -> void:
 		"elapsed_ms": 5200, "first_dead_ms": 5100,
 		"spawn_pid": 30188, "spawn_alive": true,
 		"pid_file_pid": 9360, "pid_file_alive": true,
-		"listeners": [9360],
 	})
 	assert_contains(line, "shape=watched_pid_still_alive")
 
@@ -1505,13 +1503,13 @@ func test_forensics_flags_a_watched_pid_that_is_actually_alive() -> void:
 func test_forensics_distinguishes_a_real_crash_from_a_missing_pid_file() -> void:
 	var crashed := McpServerLifecycleManagerScript.format_spawn_exit_forensics({
 		"spawn_pid": 111, "spawn_alive": false,
-		"pid_file_pid": 111, "pid_file_alive": false, "listeners": [],
+		"pid_file_pid": 111, "pid_file_alive": false,
 	})
 	assert_contains(crashed, "shape=all_dead")
 
 	var never_published := McpServerLifecycleManagerScript.format_spawn_exit_forensics({
 		"spawn_pid": 111, "spawn_alive": false,
-		"pid_file_pid": 0, "pid_file_alive": false, "listeners": [],
+		"pid_file_pid": 0, "pid_file_alive": false,
 	})
 	assert_contains(never_published, "shape=no_pid_file_published")
 
@@ -1523,7 +1521,7 @@ func test_forensics_reports_true_death_time_separately_from_detection() -> void:
 	var line := McpServerLifecycleManagerScript.format_spawn_exit_forensics({
 		"elapsed_ms": 15000, "first_dead_ms": 312,
 		"spawn_pid": 1, "spawn_alive": false,
-		"pid_file_pid": 0, "pid_file_alive": false, "listeners": [],
+		"pid_file_pid": 0, "pid_file_alive": false,
 	})
 	assert_contains(line, "elapsed=15000ms")
 	assert_contains(line, "first_dead=312ms")
@@ -1532,7 +1530,7 @@ func test_forensics_reports_true_death_time_separately_from_detection() -> void:
 func test_forensics_is_a_single_line() -> void:
 	## It has to survive being pasted into an issue with surrounding log noise.
 	var line := McpServerLifecycleManagerScript.format_spawn_exit_forensics({
-		"os": "Windows", "spawn_pid": 1, "pid_file_pid": 2, "listeners": [2, 3],
+		"os": "Windows", "spawn_pid": 1, "pid_file_pid": 2,
 	})
 	assert_eq(line.count("\n"), 0, "forensics must stay one line")
 	assert_true(line.begins_with("#797 "),

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -1514,17 +1514,42 @@ func test_forensics_distinguishes_a_real_crash_from_a_missing_pid_file() -> void
 	assert_contains(never_published, "shape=no_pid_file_published")
 
 
-func test_forensics_reports_true_death_time_separately_from_detection() -> void:
-	## After a #837 handoff wait, elapsed is when we gave up and first_dead is
-	## when the process actually died. Conflating them would misdate the event
-	## in exactly the reports this line exists to serve.
-	var line := McpServerLifecycleManagerScript.format_spawn_exit_forensics({
-		"elapsed_ms": 15000, "first_dead_ms": 312,
-		"spawn_pid": 1, "spawn_alive": false,
-		"pid_file_pid": 0, "pid_file_alive": false,
-	})
-	assert_contains(line, "elapsed=15000ms")
-	assert_contains(line, "first_dead=312ms")
+func test_forensics_wiring_reports_diagnosis_time_not_the_death_time() -> void:
+	## Caught in review after the formatter-only version of this test passed
+	## while production was broken: `check_server_health` calls
+	## `_diagnose_spawn_fast_exit(_spawn_dead_since_ms)` (#837, so the
+	## user-facing line dates the real exit), so forwarding that same value into
+	## the forensics made elapsed_ms and first_dead_ms identical — collapsing
+	## the one distinction they exist to record.
+	##
+	## Asserting on the ACTUAL logged line rather than on the formatter, because
+	## a formatter test cannot see the two inputs converge upstream.
+	var host := _ManagerHostStub.new()
+	host._log_buffer = McpLogBuffer.new()
+	var manager := McpServerLifecycleManagerScript.new(host)
+	manager._server_pid = 4242
+	## Spawned "a while ago", died early: a handoff wait between the two.
+	manager._server_spawn_ms = Time.get_ticks_msec() - 9000
+	manager._spawn_dead_since_ms = 300
+
+	manager._log_spawn_exit_forensics()
+	var lines: Array = host._log_buffer.get_recent(5)
+	host.free()
+
+	var found := ""
+	for line in lines:
+		if str(line).find("#797 spawn-exit forensics") >= 0:
+			found = str(line)
+	assert_false(found.is_empty(), "the forensics line must actually be logged")
+	assert_contains(found, "first_dead=300ms")
+	assert_false(found.contains("elapsed=300ms"),
+		"elapsed must be the diagnosis time, not a copy of the death time")
+	## Spawned ~9s ago, so the diagnosis timestamp is in that neighbourhood.
+	## Asserting the magnitude rather than an exact tick keeps it non-flaky.
+	var elapsed_at := found.find("elapsed=")
+	var reported := found.substr(elapsed_at + 8).split("ms")[0].to_int()
+	assert_true(reported >= 9000,
+		"elapsed should measure from spawn (>=9000ms), got %d" % reported)
 
 
 func test_forensics_is_a_single_line() -> void:


### PR DESCRIPTION
Follow-up to #797, which is closed but **not solved**.

## Why

A 12-boot run on the reported configuration (Windows 11, uv venv) reproduced neither the symptom nor its suspected mechanism. The trampoline was alive on every boot, with the child owning both the pid-file and the listener — so "the shim exits once its child is up" is ruled out as the cause. Something killed that watched PID once in four boots, and we still don't know what.

The reason it stayed unexplained is that the log line at the time carried no evidence:

```
MCP | server exited after 5146ms
```

That's the whole record. Asking someone to reproduce a 1-in-4 bug under observation is a poor plan; capturing the state at the moment of judgement is a better one.

## What it emits

One line at the top of `_diagnose_spawn_fast_exit`, with the facts that would settle it:

```
#797 spawn-exit forensics: shape=handoff_child_alive os=Windows launch=dev_venv
elapsed=5146ms first_dead=5146ms spawn_pid=30188(alive=false)
pid_file_pid=9360(alive=true) listeners=[9360]
```

It **names the shape** rather than leaving it to be inferred:

| shape | meaning |
|---|---|
| `handoff_child_alive` | watched PID gone, a different live PID owns the pid-file — the launcher-handoff hypothesis |
| `watched_pid_still_alive` | the death that triggered this was transient |
| `no_pid_file_published` | the server never got far enough to publish |
| `all_dead` | an ordinary crash |

`watched_pid_still_alive` is the one worth having. Given the trampoline demonstrably never dies, a fast-exit diagnosed while the watched PID is *alive on re-read* would mean a transient liveness read — a different bug from a process that really exited, and one nobody would guess from the old line.

`elapsed` and `first_dead` are reported separately because they diverge after a #837 handoff wait: one is when we gave up, the other is when the process actually died. Conflating them would misdate the event in exactly the reports this exists to serve.

## Cost and safety

Nothing in the healthy case — the path only runs when a spawn is already being declared dead, and every seam is one the surrounding diagnosis already calls. No behavior change; logging only.

I verified every seam exists on the **real** host rather than only the test stub (`_read_pid_file_for_proof`, `_find_all_pids_on_port`, `_pid_alive_for_proof`, `get_server_launch_mode`, `_log_buffer.log`). That check is a direct response to the #824 projection bug, which shipped green precisely because a stub supplied something production didn't.

## Verification

- `script/ci-check-gdscript` — OK
- `script/ci-godot-tests` — **2035/2062, 0 failed** (+5)
- `ruff` clean (no Python touched)

Formatting is a pure function, so the contract is tested without a live editor. **What is not verified: the line firing in production** — the condition is a spawn fast-exit, which I can't force here. The call site is on the diagnosis path and its seams are real, but the first genuine sighting will be the next occurrence, which is the point.

The line is prefixed with the issue number so a future reporter can search for it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NPYvw7pkz6SxxGXHWQ2sAF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced Windows “fast-exit” diagnostics by emitting a one-line “spawn-exit forensics” snapshot when a server terminates immediately after launch.
  - The snapshot reports timing details (elapsed vs. first-dead), PID/identity evidence, and a deterministic `shape=` classification to clearly distinguish handoff/child-alive, watched-process-alive, missing PID publication, and fully dead scenarios.

- **Tests**
  - Added coverage to verify correct `shape` classification, that `elapsed` differs appropriately from `first_dead`, and that the output is a strict single-line string with the expected prefix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->