### PR TITLE
game_manage: add input_sequence for frame-timed play-test input (#814)

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -208,7 +208,7 @@ Calls take the form:
 | `camera_manage` | `create`, `configure`, `set_limits_2d`, `set_damping_2d`, `follow_2d`, `get`, `list`, `apply_preset` |
 | `signal_manage` | `list`, `connect`, `disconnect` |
 | `input_map_manage` | `list`, `add_action`, `ensure_action`, `remove_action`, `bind_event`, `ensure_binding` |
-| `game_manage` | `get_scene_tree`, `get_node_info`, `get_ui_elements`, `input_key`, `input_mouse`, `input_gamepad`, `input_action`, `input_state` |
+| `game_manage` | `get_scene_tree`, `get_node_info`, `get_ui_elements`, `input_key`, `input_mouse`, `input_gamepad`, `input_action`, `input_sequence`, `input_state` |
 | `autoload_manage` | `list`, `add`, `remove` |
 | `filesystem_manage` | `read_text`, `write_text`, `reimport`, `scan`, `search` |
 | `theme_manage` | `create`, `set_color`, `set_constant`, `set_font_size`, `set_stylebox_flat`, `apply` |
@@ -237,6 +237,47 @@ thousands of tokens it rarely wanted. Pass `sections` to widen it
 When paginating, request one section at a time so `offset`/`limit` apply only
 to the list you are paging. The `godot://class/{class_name}` resource form
 cannot take `sections`, so it always returns the full set.
+
+`game_manage(op="input_sequence")` drives a **frame-timed** action timeline in
+the running game in a single call — the frame-accurate, multi-step form of
+`input_action`. Reach for it whenever timing matters (jump arcs, combos,
+"walk into the trigger then assert"): expressing the same thing as separate
+`input_action` calls fails because each call lands on whichever frame its
+network round-trip happens to complete on, so the timing drifts and the run
+isn't reproducible. The game applies each step's action on its scheduled frame,
+awaits `settle_frames` more, then replies once.
+
+Each step is `{at_frame, action, pressed=True, strength=1.0}`. Steps must be
+ordered by non-decreasing `at_frame`; two steps sharing a frame is a valid
+combo. Frames (not milliseconds) are the timing basis — that's what reproduces
+identically across runs. Action-based input is focus-independent, so a sequence
+works even against a backgrounded game window. A sequence is bounded (step and
+frame caps) and cannot be nested inside `batch_execute` (its reply is deferred
+and a batch has no completion channel for it).
+
+Worked example — a jump arc (hold jump 6 frames, run right for 24, then let
+1 frame settle before reading the landing):
+
+```json
+{
+  "op": "input_sequence",
+  "params": {
+    "steps": [
+      {"at_frame": 0,  "action": "jump",       "pressed": true},
+      {"at_frame": 6,  "action": "jump",       "pressed": false},
+      {"at_frame": 6,  "action": "move_right", "pressed": true},
+      {"at_frame": 30, "action": "move_right", "pressed": false}
+    ],
+    "settle_frames": 1
+  }
+}
+```
+
+The reply reports `steps_applied`, `frames_elapsed`, and
+`actions_pressed_at_end` — the last so you know which actions are still held
+(a press with no matching release stays down) and must be released before the
+next check. Follow with `get_node_info` / `get_scene_tree` to assert the
+resulting world state.
 
 Every rolled-up tool also accepts an optional top-level `session_id` for
 per-call multi-editor routing (sibling of `op` and `params`, *not* nested

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -273,10 +273,10 @@ Worked example — a jump arc (hold jump 6 frames, run right for 24, then let
 }
 ```
 
-The reply reports `steps_applied`, `frames_elapsed`, and
-`actions_pressed_at_end` — the last so you know which actions are still held
-(a press with no matching release stays down) and must be released before the
-next check. Follow with `get_node_info` / `get_scene_tree` to assert the
+The reply reports `completed`, `steps_applied`, `frames_elapsed`, an `applied`
+array (each step's `at_frame`/`action`/`pressed`), and `actions_pressed_at_end`
+— the last so you know which actions are still held (a press with no matching
+release stays down) and must be released before the next check. Follow with `get_node_info` / `get_scene_tree` to assert the
 resulting world state.
 
 Every rolled-up tool also accepts an optional top-level `session_id` for

--- a/plugin/addons/godot_ai/dispatcher.gd
+++ b/plugin/addons/godot_ai/dispatcher.gd
@@ -225,7 +225,12 @@ func _dispatch(cmd: Dictionary) -> Dictionary:
 		result = ErrorCodes.make(ErrorCodes.UNKNOWN_COMMAND, "Unknown command: %s" % command)
 
 	if result.get("_deferred", false):
-		_register_deferred(request_id, command)
+		## A handler may attach `_deferred_timeout_ms` to its deferred sentinel
+		## to claim a per-request budget larger than its command's shared entry
+		## (e.g. game_command's `input_sequence`, which steps frames well past
+		## the 15s that suits one-shot game ops). 0/absent falls back to the
+		## per-command table.
+		_register_deferred(request_id, command, int(result.get("_deferred_timeout_ms", 0)))
 		if mcp_logging:
 			_log_buffer.log("[defer] %s (request %s)" % [command, request_id])
 		return result
@@ -359,13 +364,21 @@ func _materialize_lazy_command(command: String) -> Dictionary:
 	return {}
 
 
-func _register_deferred(request_id: String, command: String) -> void:
+func _register_deferred(request_id: String, command: String, timeout_override_ms: int = 0) -> void:
 	if request_id.is_empty():
 		return
+	## A positive per-request override wins over the per-command table so a
+	## single deferred call can claim more headroom without globally widening
+	## the command's budget (see _dispatch: input_sequence needs ~30s, but the
+	## other game_command ops must keep their tight 15s).
+	var timeout_ms: int = (
+		timeout_override_ms if timeout_override_ms > 0
+		else _deferred_timeout_ms_for_command(command)
+	)
 	_pending_deferred[request_id] = {
 		"command": command,
 		"started_ms": Time.get_ticks_msec(),
-		"timeout_ms": _deferred_timeout_ms_for_command(command),
+		"timeout_ms": timeout_ms,
 	}
 
 

--- a/plugin/addons/godot_ai/handlers/batch_handler.gd
+++ b/plugin/addons/godot_ai/handlers/batch_handler.gd
@@ -7,12 +7,28 @@ const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
 ## semantics. When undo=true (default), any successful sub-commands are rolled
 ## back via the scene's UndoRedo history if a later sub-command fails.
 
-## run_tests is forbidden because a batch executes synchronously inside one
-## dispatcher tick with NO transport servicing: a full suite in a batch
-## starves the WebSocket heartbeat (the exact disconnect the serviced
-## test_run path exists to prevent) and the Python batch handler only
-## allows 30s anyway. Use the test_run tool directly.
-const FORBIDDEN_SUBCOMMANDS := ["batch_execute", "run_tests"]
+## Commands that cannot run as batch sub-commands, each with the reason a batch
+## can't host it.
+## - batch_execute: would recurse.
+## - run_tests: a batch executes synchronously inside one dispatcher tick with
+##   NO transport servicing, so a full suite starves the WebSocket heartbeat
+##   (the exact disconnect the serviced test_run path exists to prevent) and
+##   the Python batch handler only allows 30s anyway — call the test_run tool
+##   directly.
+## - game_command: it is deferred — its reply flows out-of-band correlated by a
+##   _request_id that dispatch_direct deliberately strips (see
+##   McpDispatcher.dispatch_direct), so a game op nested in a batch would have
+##   no completion channel and hang or lose its reply. input_sequence made this
+##   concrete (#814); the whole game_command surface shares the deferred path.
+const FORBIDDEN_SUBCOMMANDS := {
+	"batch_execute": "batch_execute cannot be nested inside another batch",
+	"run_tests":
+		"run_tests is not allowed as a sub-command — a batch runs synchronously "
+		+ "with no transport servicing; call the test_run tool directly",
+	"game_command":
+		"game_command ops are deferred (their reply arrives out-of-band) and "
+		+ "have no completion channel inside a batch — run them as their own tool call",
+}
 
 ## The whole batch executes synchronously inside one dispatcher tick,
 ## outside the 4ms frame budget — an unbounded array freezes the editor
@@ -50,11 +66,9 @@ func batch_execute(params: Dictionary) -> Dictionary:
 		var cmd_name: String = item.get("command", "")
 		if cmd_name.is_empty():
 			return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "commands[%d] missing 'command' field" % idx)
-		if cmd_name in FORBIDDEN_SUBCOMMANDS:
-			var forbidden_msg := "commands[%d]: '%s' is not allowed as a sub-command" % [idx, cmd_name]
-			if cmd_name == "run_tests":
-				forbidden_msg += " — a batch runs synchronously with no transport servicing; call the test_run tool directly"
-			return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, forbidden_msg)
+		if FORBIDDEN_SUBCOMMANDS.has(cmd_name):
+			return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE,
+				"commands[%d]: %s" % [idx, FORBIDDEN_SUBCOMMANDS[cmd_name]])
 		if not _dispatcher.has_command(cmd_name):
 			return _unknown_command_error(idx, cmd_name)
 		## Pre-validate params type: the execution loop's typed Dictionary

--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -68,6 +68,13 @@ func get_selection(_params: Dictionary) -> Dictionary:
 
 const VALID_LOG_SOURCES := ["plugin", "game", "editor", "all"]
 
+## Deferred budget for the `input_sequence` game op. Unlike the one-shot game
+## ops (covered by game_command's 15s entry), it drives the game forward one
+## frame per step, so the reply legitimately takes seconds. The game side caps
+## the sequence length (GameHelper.MAX_SEQUENCE_FRAMES) well inside this; the
+## budget is the backstop for a frozen game loop, mirroring take_screenshot.
+const INPUT_SEQUENCE_TIMEOUT_SEC := 30.0
+
 
 func get_logs(params: Dictionary) -> Dictionary:
 	## Coerce defensively — MCP clients can send JSON numbers as floats or
@@ -1018,5 +1025,21 @@ func game_command(params: Dictionary) -> Dictionary:
 			"Missing request_id — cannot correlate deferred response")
 
 	var command_params: Dictionary = params.get("params", {})
+
+	## input_sequence steps the game forward frame-by-frame in one call, so it
+	## needs a far larger budget than the one-shot game ops that share the
+	## `game_command` deferred entry (15s). Widen both timers only for it: the
+	## debugger-side pending timer (below) and the dispatcher-side deferred
+	## budget (via the sentinel's `_deferred_timeout_ms`). Every other op keeps
+	## request_game_command's tight default.
+	if op == "input_sequence":
+		_debugger_plugin.request_game_command(
+			op, command_params, request_id, _connection, INPUT_SEQUENCE_TIMEOUT_SEC
+		)
+		return {
+			"_deferred": true,
+			"_deferred_timeout_ms": int(INPUT_SEQUENCE_TIMEOUT_SEC * 1000.0),
+		}
+
 	_debugger_plugin.request_game_command(op, command_params, request_id, _connection)
 	return McpDispatcher.DEFERRED_RESPONSE

--- a/plugin/addons/godot_ai/runtime/game_helper.gd
+++ b/plugin/addons/godot_ai/runtime/game_helper.gd
@@ -362,6 +362,12 @@ func _handle_game_command(data: Array) -> void:
 			result = _game_input_action(json.data)
 		"input_state":
 			result = _game_input_state(json.data)
+		"input_sequence":
+			## Async: steps frames and replies itself (deferred), so bail out
+			## before the synchronous send below — same shape as the eval and
+			## screenshot capture paths.
+			_run_input_sequence(request_id, json.data)
+			return
 		_:
 			_reply_game_command_error(request_id, "Unknown game op: %s" % op)
 			return
@@ -680,6 +686,151 @@ func _game_input_state(params: Dictionary) -> Dictionary:
 		var name := str(action)
 		states[name] = Input.is_action_pressed(name)
 	return {"actions": states}
+
+
+## --- input_sequence: frame-timed action timeline (deferred) ---
+##
+## Per-step round-trips can't hit a target frame — network jitter lands each
+## input on whatever frame its reply happens to arrive on, so a jump arc or a
+## timed combo is unreproducible (#814). input_sequence takes the whole
+## timeline in one call and drives it game-side, applying each step's action on
+## its scheduled frame, then replies once (deferred). Frame count (not ms) is
+## the timing basis: it's what reproduces identically across runs.
+
+## Hard caps mirrored by the server-side schema (see game handlers). The game
+## side re-checks them so a malformed direct message can't park the coroutine
+## on an unbounded await; the server rejects the same cases up front with a
+## clearer error.
+const MAX_SEQUENCE_STEPS := 256
+const MAX_SEQUENCE_FRAMES := 600
+
+## Testing seam: the last input_sequence reply (response or error), recorded
+## before the EngineDebugger channel (inactive in the editor-side test
+## harness). Mirrors _last_screenshot_reply / _last_eval_reply.
+var _last_game_command_reply: Dictionary = {}
+
+
+## Validate + normalize an input_sequence request. Pure (no engine state), so
+## the ordering/cap/shape rules are unit-testable without a running game.
+## Returns {"error": String} or {"steps": Array, "end_frame": int}.
+func _plan_input_sequence(params: Dictionary) -> Dictionary:
+	var raw_steps: Variant = params.get("steps", null)
+	if not (raw_steps is Array):
+		return {"error": "steps must be an array"}
+	var steps_arr: Array = raw_steps
+	if steps_arr.is_empty():
+		return {"error": "steps must not be empty"}
+	if steps_arr.size() > MAX_SEQUENCE_STEPS:
+		return {"error": "steps exceeds cap of %d (got %d)" % [MAX_SEQUENCE_STEPS, steps_arr.size()]}
+
+	var settle_frames := int(params.get("settle_frames", 0))
+	if settle_frames < 0:
+		return {"error": "settle_frames must be >= 0"}
+
+	var normalized: Array = []
+	var prev_frame := -1
+	for i in steps_arr.size():
+		var raw: Variant = steps_arr[i]
+		if not (raw is Dictionary):
+			return {"error": "steps[%d] must be an object" % i}
+		var step: Dictionary = raw
+		var action := str(step.get("action", ""))
+		if action.is_empty():
+			return {"error": "steps[%d].action is required" % i}
+		var at_frame := int(step.get("at_frame", 0))
+		if at_frame < 0:
+			return {"error": "steps[%d].at_frame must be >= 0" % i}
+		if at_frame < prev_frame:
+			return {"error": "steps must be ordered by at_frame (steps[%d]=%d < previous %d)" % [i, at_frame, prev_frame]}
+		prev_frame = at_frame
+		normalized.append({
+			"at_frame": at_frame,
+			"action": action,
+			"pressed": bool(step.get("pressed", true)),
+			"strength": clampf(float(step.get("strength", 1.0)), 0.0, 1.0),
+		})
+
+	var end_frame: int = int(normalized[-1]["at_frame"]) + settle_frames
+	if end_frame > MAX_SEQUENCE_FRAMES:
+		return {"error": "sequence spans %d frames, exceeds cap of %d" % [end_frame, MAX_SEQUENCE_FRAMES]}
+	return {"steps": normalized, "end_frame": end_frame}
+
+
+## Async: apply each step's action on its scheduled frame, awaiting one
+## process_frame per frame, then reply (deferred). Bails out before applying
+## anything if the plan is invalid or any action is unknown to the running
+## game's InputMap — a half-applied timeline leaves inputs in an undefined
+## state, so it's all-or-nothing on the pre-checks.
+func _run_input_sequence(request_id: String, params: Dictionary) -> void:
+	var plan := _plan_input_sequence(params)
+	if plan.has("error"):
+		_reply_input_sequence_error(request_id, plan["error"])
+		return
+
+	var steps: Array = plan["steps"]
+	var end_frame: int = plan["end_frame"]
+
+	## Resolve action names against the *game's* InputMap up front — the server
+	## can't see it, so this is the first place unknown actions surface.
+	for step in steps:
+		if not InputMap.has_action(step["action"]):
+			_reply_input_sequence_error(request_id, "Unknown action: %s" % step["action"])
+			return
+
+	var tree := get_tree()
+	if tree == null:
+		_reply_input_sequence_error(request_id, "No SceneTree available for input sequence")
+		return
+
+	var applied: Array = []
+	var step_i := 0
+	for f in range(0, end_frame + 1):
+		while step_i < steps.size() and int(steps[step_i]["at_frame"]) == f:
+			var step: Dictionary = steps[step_i]
+			_game_input_action(step)
+			applied.append({"at_frame": f, "action": step["action"], "pressed": step["pressed"]})
+			step_i += 1
+		if f < end_frame:
+			await tree.process_frame
+
+	_reply_input_sequence_ok(request_id, {
+		"completed": true,
+		"steps_applied": applied.size(),
+		"frames_elapsed": end_frame,
+		"applied": applied,
+		"actions_pressed_at_end": _actions_pressed_at_end(steps),
+	})
+
+
+## Distinct actions the sequence touched that are still held at the end, so the
+## caller knows what it must release (a press with no matching release leaves
+## the action stuck on across the next frames).
+func _actions_pressed_at_end(steps: Array) -> Array:
+	var seen := {}
+	var pressed: Array = []
+	for step in steps:
+		var action: String = step["action"]
+		if seen.has(action):
+			continue
+		seen[action] = true
+		if Input.is_action_pressed(action):
+			pressed.append(action)
+	return pressed
+
+
+func _reply_input_sequence_ok(request_id: String, result: Dictionary) -> void:
+	result["source"] = "game"
+	result["op"] = "input_sequence"
+	_last_game_command_reply = {"kind": "response", "op": "input_sequence", "result": result}
+	if EngineDebugger.is_active():
+		EngineDebugger.send_message("mcp:game_command_response",
+			[request_id, JSON.stringify(_variant_to_json(result))])
+
+
+func _reply_input_sequence_error(request_id: String, message: String) -> void:
+	_last_game_command_reply = {"kind": "error", "op": "input_sequence", "message": message}
+	if EngineDebugger.is_active():
+		EngineDebugger.send_message("mcp:game_command_error", [request_id, message])
 
 
 ## Resolve a mouse-position param. Absent (null, or an empty {}) falls back to

--- a/plugin/addons/godot_ai/runtime/game_helper.gd
+++ b/plugin/addons/godot_ai/runtime/game_helper.gd
@@ -717,6 +717,15 @@ const MAX_SEQUENCE_FRAMES := 600
 ## harness). Mirrors _last_screenshot_reply / _last_eval_reply.
 var _last_game_command_reply: Dictionary = {}
 
+## Testing seam: overrides the per-frame wait in _run_input_sequence. Left
+## invalid in production (real `process_frame` awaits). A test sets it to a
+## synchronously-returning Callable so the multi-frame loop runs to completion
+## in one call — the editor test runner invokes tests synchronously and never
+## pumps `process_frame`, so a real frame-await would suspend and record zero
+## assertions. Timing itself (one frame per step) is engine-guaranteed; this
+## seam covers the scheduling/application/reply logic layered on top.
+var _frame_waiter: Callable = Callable()
+
 
 ## Validate + normalize an input_sequence request. Pure (no engine state), so
 ## the ordering/cap/shape rules are unit-testable without a running game.
@@ -731,7 +740,17 @@ func _plan_input_sequence(params: Dictionary) -> Dictionary:
 	if steps_arr.size() > MAX_SEQUENCE_STEPS:
 		return {"error": "steps exceeds cap of %d (got %d)" % [MAX_SEQUENCE_STEPS, steps_arr.size()]}
 
-	var settle_frames := int(params.get("settle_frames", 0))
+	## Validate field *kinds* rather than coercing them: the server already
+	## rejects bad shapes, but this planner is also the backstop for a
+	## malformed direct debugger message, so it must not silently turn
+	## pressed="false" into true or at_frame="oops" into 0. _is_number accepts
+	## int or float (JSON round-trips whole numbers as either) but not bool or
+	## string, so this stays consistent with the server without tripping on
+	## JSON's number typing.
+	var settle_raw: Variant = params.get("settle_frames", 0)
+	if not _is_number(settle_raw):
+		return {"error": "settle_frames must be a number"}
+	var settle_frames := int(settle_raw)
 	if settle_frames < 0:
 		return {"error": "settle_frames must be >= 0"}
 
@@ -742,20 +761,29 @@ func _plan_input_sequence(params: Dictionary) -> Dictionary:
 		if not (raw is Dictionary):
 			return {"error": "steps[%d] must be an object" % i}
 		var step: Dictionary = raw
-		var action := str(step.get("action", ""))
-		if action.is_empty():
+		if not (step.get("action", "") is String) or str(step.get("action", "")).is_empty():
 			return {"error": "steps[%d].action is required" % i}
-		var at_frame := int(step.get("at_frame", 0))
+		var action: String = step["action"]
+		var at_frame_raw: Variant = step.get("at_frame", 0)
+		if not _is_number(at_frame_raw):
+			return {"error": "steps[%d].at_frame must be a number" % i}
+		var at_frame := int(at_frame_raw)
 		if at_frame < 0:
 			return {"error": "steps[%d].at_frame must be >= 0" % i}
 		if at_frame < prev_frame:
 			return {"error": "steps must be ordered by at_frame (steps[%d]=%d < previous %d)" % [i, at_frame, prev_frame]}
 		prev_frame = at_frame
+		var pressed_raw: Variant = step.get("pressed", true)
+		if not (pressed_raw is bool):
+			return {"error": "steps[%d].pressed must be a boolean" % i}
+		var strength_raw: Variant = step.get("strength", 1.0)
+		if not _is_number(strength_raw):
+			return {"error": "steps[%d].strength must be a number" % i}
 		normalized.append({
 			"at_frame": at_frame,
 			"action": action,
-			"pressed": bool(step.get("pressed", true)),
-			"strength": clampf(float(step.get("strength", 1.0)), 0.0, 1.0),
+			"pressed": pressed_raw,
+			"strength": clampf(float(strength_raw), 0.0, 1.0),
 		})
 
 	var end_frame: int = int(normalized[-1]["at_frame"]) + settle_frames
@@ -799,7 +827,10 @@ func _run_input_sequence(request_id: String, params: Dictionary) -> void:
 			applied.append({"at_frame": f, "action": step["action"], "pressed": step["pressed"]})
 			step_i += 1
 		if f < end_frame:
-			await tree.process_frame
+			if _frame_waiter.is_valid():
+				await _frame_waiter.call()
+			else:
+				await tree.process_frame
 
 	_reply_input_sequence_ok(request_id, {
 		"completed": true,

--- a/plugin/addons/godot_ai/runtime/game_helper.gd
+++ b/plugin/addons/godot_ai/runtime/game_helper.gd
@@ -701,6 +701,14 @@ func _game_input_state(params: Dictionary) -> Dictionary:
 ## side re-checks them so a malformed direct message can't park the coroutine
 ## on an unbounded await; the server rejects the same cases up front with a
 ## clearer error.
+##
+## The frame cap bounds the sequence in *frames*, which is a wall-clock time
+## only at a given FPS: 600 frames is ~10s at 60fps but longer under load or on
+## a throttled runner. It is not sized to the ~30s deferred budget
+## (editor_handler.INPUT_SEQUENCE_TIMEOUT_SEC) — the two are independent
+## safeguards. If a genuinely slow run exceeds the budget, the dispatcher
+## returns a clean DEFERRED_TIMEOUT rather than hanging, so the cap can stay a
+## simple frame count.
 const MAX_SEQUENCE_STEPS := 256
 const MAX_SEQUENCE_FRAMES := 600
 

--- a/src/godot_ai/handlers/game.py
+++ b/src/godot_ai/handlers/game.py
@@ -161,7 +161,7 @@ def _validate_input_sequence(
         raise _invalid_params("steps must be a non-empty list")
     if len(steps) > MAX_SEQUENCE_STEPS:
         raise _invalid_params(f"steps exceeds the {MAX_SEQUENCE_STEPS}-step cap (got {len(steps)})")
-    if not isinstance(settle_frames, int) or settle_frames < 0:
+    if not isinstance(settle_frames, int) or isinstance(settle_frames, bool) or settle_frames < 0:
         raise _invalid_params("settle_frames must be an integer >= 0")
 
     normalized: list[dict[str, Any]] = []
@@ -180,12 +180,25 @@ def _validate_input_sequence(
                 f"steps must be ordered by at_frame (steps[{i}]={at_frame} < previous {prev_frame})"
             )
         prev_frame = at_frame
+
+        ## Validate rather than coerce: bool(step["pressed"]) would turn the
+        ## string "false" into True, and float(step["strength"]) on a bad
+        ## value would escape as an internal error instead of INVALID_PARAMS.
+        pressed = step.get("pressed", True)
+        if not isinstance(pressed, bool):
+            raise _invalid_params(f"steps[{i}].pressed must be a boolean")
+        strength = step.get("strength", 1.0)
+        if isinstance(strength, bool) or not isinstance(strength, (int, float)):
+            raise _invalid_params(f"steps[{i}].strength must be a number")
+        ## Clamp to [0, 1] to match the plugin's input_action semantics.
+        strength = max(0.0, min(1.0, float(strength)))
+
         normalized.append(
             {
                 "at_frame": at_frame,
                 "action": action,
-                "pressed": bool(step.get("pressed", True)),
-                "strength": float(step.get("strength", 1.0)),
+                "pressed": pressed,
+                "strength": strength,
             }
         )
 

--- a/src/godot_ai/handlers/game.py
+++ b/src/godot_ai/handlers/game.py
@@ -4,9 +4,23 @@ from __future__ import annotations
 
 from typing import Any
 
+from godot_ai.godot_client.client import GodotCommandError
+from godot_ai.protocol.errors import ErrorCode
 from godot_ai.runtime.direct import DirectRuntime
 
 GAME_COMMAND_TIMEOUT_SEC = 15.0
+
+## input_sequence drives the game forward one frame per step, so its reply
+## legitimately takes seconds — it gets a wider client timeout than the
+## one-shot ops, matched by the plugin's INPUT_SEQUENCE_TIMEOUT_SEC and the
+## dispatcher's per-request deferred budget.
+INPUT_SEQUENCE_TIMEOUT_SEC = 30.0
+
+## Bounds on a single input_sequence, mirrored by the plugin
+## (GameHelper.MAX_SEQUENCE_STEPS / MAX_SEQUENCE_FRAMES). Rejecting here keeps
+## a runaway `at_frame` from holding the deferred response open indefinitely.
+MAX_SEQUENCE_STEPS = 256
+MAX_SEQUENCE_FRAMES = 600
 
 
 async def _game_command(runtime: DirectRuntime, op: str, params: dict[str, Any]) -> dict:
@@ -127,3 +141,80 @@ async def game_input_state(
     if actions is not None:
         params["actions"] = actions
     return await _game_command(runtime, "input_state", params)
+
+
+def _invalid_params(message: str) -> GodotCommandError:
+    return GodotCommandError(code=ErrorCode.INVALID_PARAMS, message=message)
+
+
+def _validate_input_sequence(
+    steps: list[dict[str, Any]], settle_frames: int
+) -> list[dict[str, Any]]:
+    """Reject the cases the plugin can't safely absorb, up front and clearly.
+
+    Frames only for v1 (deterministic, reproducible). Steps must be ordered by
+    ``at_frame`` and stay within the frame/step caps so a large ``at_frame``
+    can't hold the deferred reply open indefinitely. Returns the normalized
+    step list to forward to the game.
+    """
+    if not isinstance(steps, list) or not steps:
+        raise _invalid_params("steps must be a non-empty list")
+    if len(steps) > MAX_SEQUENCE_STEPS:
+        raise _invalid_params(f"steps exceeds the {MAX_SEQUENCE_STEPS}-step cap (got {len(steps)})")
+    if not isinstance(settle_frames, int) or settle_frames < 0:
+        raise _invalid_params("settle_frames must be an integer >= 0")
+
+    normalized: list[dict[str, Any]] = []
+    prev_frame = -1
+    for i, step in enumerate(steps):
+        if not isinstance(step, dict):
+            raise _invalid_params(f"steps[{i}] must be an object")
+        action = step.get("action")
+        if not isinstance(action, str) or not action:
+            raise _invalid_params(f"steps[{i}].action is required and must be a non-empty string")
+        at_frame = step.get("at_frame", 0)
+        if not isinstance(at_frame, int) or isinstance(at_frame, bool) or at_frame < 0:
+            raise _invalid_params(f"steps[{i}].at_frame must be an integer >= 0")
+        if at_frame < prev_frame:
+            raise _invalid_params(
+                f"steps must be ordered by at_frame (steps[{i}]={at_frame} < previous {prev_frame})"
+            )
+        prev_frame = at_frame
+        normalized.append(
+            {
+                "at_frame": at_frame,
+                "action": action,
+                "pressed": bool(step.get("pressed", True)),
+                "strength": float(step.get("strength", 1.0)),
+            }
+        )
+
+    span = normalized[-1]["at_frame"] + settle_frames
+    if span > MAX_SEQUENCE_FRAMES:
+        raise _invalid_params(
+            f"sequence spans {span} frames, exceeds the {MAX_SEQUENCE_FRAMES}-frame cap"
+        )
+    return normalized
+
+
+async def game_input_sequence(
+    runtime: DirectRuntime,
+    steps: list[dict[str, Any]],
+    settle_frames: int = 0,
+) -> dict:
+    """Apply a frame-timed action timeline in the running game in one call.
+
+    Each step is ``{at_frame, action, pressed=True, strength=1.0}``; the game
+    applies each step's action on its scheduled frame, awaits ``settle_frames``
+    more, then replies once. See ``game_input_action`` for the per-step
+    semantics — this is the frame-accurate, multi-step form.
+    """
+    normalized = _validate_input_sequence(steps, settle_frames)
+    return await runtime.send_command(
+        "game_command",
+        {
+            "op": "input_sequence",
+            "params": {"steps": normalized, "settle_frames": settle_frames},
+        },
+        timeout=INPUT_SEQUENCE_TIMEOUT_SEC,
+    )

--- a/src/godot_ai/tools/game.py
+++ b/src/godot_ai/tools/game.py
@@ -35,6 +35,17 @@ Ops:
         Send a joypad button or axis event. control: "button" | "axis".
   - input_action(action, pressed=True, strength=1.0)
         Set a project action's pressed state directly in the running game.
+  - input_sequence(steps, settle_frames=0)
+        Apply a frame-timed action timeline in one call — the frame-accurate,
+        multi-step form of input_action. Each step is
+        {at_frame, action, pressed=True, strength=1.0}; the game applies each
+        step's action on its scheduled frame, awaits settle_frames more, then
+        replies once. Use this instead of separate input_action calls whenever
+        timing matters (jump arcs, combos, walk-into-trigger): per-call network
+        latency makes hitting a target frame impossible otherwise. Steps must
+        be ordered by non-decreasing at_frame; frames (not ms) are the timing
+        basis. Action-based input is focus-independent, so it works on a
+        backgrounded game window. Cannot run inside batch_execute.
   - input_state(actions=None)
         Read current action pressed states. Empty actions = all project actions."""
 
@@ -52,6 +63,7 @@ def register_game_tools(mcp: FastMCP) -> None:
             "input_mouse": game_handlers.game_input_mouse,
             "input_gamepad": game_handlers.game_input_gamepad,
             "input_action": game_handlers.game_input_action,
+            "input_sequence": game_handlers.game_input_sequence,
             "input_state": game_handlers.game_input_state,
         },
         read_resource_forms={
@@ -62,6 +74,7 @@ def register_game_tools(mcp: FastMCP) -> None:
             "input_mouse": None,
             "input_gamepad": None,
             "input_action": None,
+            "input_sequence": None,
             "input_state": None,
         },
     )

--- a/test_project/tests/test_batch.gd
+++ b/test_project/tests/test_batch.gd
@@ -111,6 +111,17 @@ func test_rejects_batch_execute_as_subcommand() -> void:
 	assert_is_error(result)
 
 
+func test_rejects_game_command_as_subcommand() -> void:
+	## game_command ops are deferred — their reply flows out-of-band and has no
+	## completion channel inside a batch (#814). Reject up front with a clear
+	## message rather than letting the stripped-_request_id path hang/half-run.
+	var result := _handler.batch_execute({
+		"commands": [{"command": "game_command", "params": {"op": "input_sequence"}}],
+	})
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
+	assert_contains(result.error.message, "deferred")
+
+
 # ----- Success path -----
 
 func test_all_succeed_returns_results() -> void:

--- a/test_project/tests/test_dispatcher.gd
+++ b/test_project/tests/test_dispatcher.gd
@@ -231,6 +231,32 @@ func test_run_project_has_deferred_timeout_budget() -> void:
 	)
 
 
+func test_deferred_timeout_ms_override_from_sentinel() -> void:
+	## A handler that attaches _deferred_timeout_ms claims a per-request budget
+	## (game_command's input_sequence needs ~30s where the command's table
+	## entry is 15s). The registered timeout must reflect the override.
+	var d := _make_dispatcher()
+	d.mcp_logging = false
+	d.register("wide", func(_p): return {"_deferred": true, "_deferred_timeout_ms": 30000})
+	d.enqueue({"request_id": "req-wide", "command": "wide", "params": {}})
+	d.tick(100.0)
+	assert_eq(d.pending_deferred_count(), 1)
+	assert_eq(int(d._pending_deferred["req-wide"].timeout_ms), 30000,
+		"the sentinel's _deferred_timeout_ms must win over the per-command table")
+
+
+func test_deferred_timeout_ms_falls_back_without_override() -> void:
+	## No override → the per-command table (or default) still applies.
+	var d := _make_dispatcher()
+	d.mcp_logging = false
+	d.register("plain", func(_p): return McpDispatcher.DEFERRED_RESPONSE)
+	d.enqueue({"request_id": "req-plain", "command": "plain", "params": {}})
+	d.tick(100.0)
+	assert_eq(int(d._pending_deferred["req-plain"].timeout_ms),
+		McpDispatcher.DEFAULT_DEFERRED_TIMEOUT_MS,
+		"absent override falls back to the default budget")
+
+
 # ----- deferred response path -----
 
 func test_tick_suppresses_deferred_response_and_threads_request_id() -> void:

--- a/test_project/tests/test_game_helper.gd
+++ b/test_project/tests/test_game_helper.gd
@@ -444,6 +444,43 @@ func test_plan_input_sequence_rejects_over_step_cap() -> void:
 	assert_true(plan.has("error"), "exceeding the step cap must be rejected")
 
 
+# The planner validates field *kinds* rather than coercing (matches the
+# server-side validator), so a malformed direct message can't silently change
+# meaning (pressed="false" -> true, at_frame="oops" -> 0).
+
+func test_plan_input_sequence_rejects_non_bool_pressed() -> void:
+	var plan: Dictionary = _helper.call("_plan_input_sequence",
+		{"steps": [{"at_frame": 0, "action": "a", "pressed": "false"}]})
+	assert_true(plan.has("error"), "string pressed must be rejected, not coerced to true")
+
+
+func test_plan_input_sequence_rejects_non_number_at_frame() -> void:
+	var plan: Dictionary = _helper.call("_plan_input_sequence",
+		{"steps": [{"at_frame": "oops", "action": "a"}]})
+	assert_true(plan.has("error"), "non-numeric at_frame must be rejected, not coerced to 0")
+
+
+func test_plan_input_sequence_rejects_non_number_strength() -> void:
+	var plan: Dictionary = _helper.call("_plan_input_sequence",
+		{"steps": [{"at_frame": 0, "action": "a", "strength": "hard"}]})
+	assert_true(plan.has("error"), "non-numeric strength must be rejected")
+
+
+func test_plan_input_sequence_rejects_non_number_settle() -> void:
+	var plan: Dictionary = _helper.call("_plan_input_sequence",
+		{"steps": [{"at_frame": 0, "action": "a"}], "settle_frames": "nope"})
+	assert_true(plan.has("error"), "non-numeric settle_frames must be rejected")
+
+
+func test_plan_input_sequence_accepts_float_frames_from_json() -> void:
+	## JSON round-trips whole numbers as float; the kind-check must still accept
+	## them (it validates number-ness, not strictly int).
+	var plan: Dictionary = _helper.call("_plan_input_sequence",
+		{"steps": [{"at_frame": 2.0, "action": "a"}], "settle_frames": 1.0})
+	assert_false(plan.has("error"), "float at_frame/settle from JSON must be accepted")
+	assert_eq(plan.end_frame, 3)
+
+
 # ----- input_sequence: async frame-stepping (#814) -----
 
 const _SEQ_ACTION := "mcp_test_seq_action"
@@ -460,30 +497,33 @@ func _clear_seq_action() -> void:
 		InputMap.erase_action(_SEQ_ACTION)
 
 
-func test_run_input_sequence_applies_all_steps_and_replies() -> void:
-	## Multi-frame progression (steps landing on distinct future frames) is
-	## covered by the isolated `--script` probe: the editor test runner calls
-	## test methods synchronously (test_runner.gd::_run_one_test) and never
-	## pumps `process_frame`, so a sequence that awaits real frame advances
-	## records 0 assertions. This is the same reason take_screenshot's frame
-	## loop is only tested via its pure `_should_capture_stale_sync` helper.
-	## Here: two steps on one frame (a combo), settle 0 — end_frame is 0, so
-	## the runner never awaits, and we can still assert the applied count and
-	## reply shape synchronously.
+func test_run_input_sequence_applies_steps_across_frames() -> void:
+	## The editor test runner calls tests synchronously and never pumps
+	## `process_frame` (test_runner.gd::_run_one_test), so a real frame-await
+	## would suspend and record 0 assertions. Inject a synchronous frame-waiter
+	## so the multi-frame loop runs to completion in one call — the per-step
+	## timing (one frame each) is engine-guaranteed; what we assert here is the
+	## scheduling/application layered on top: steps fire on their scheduled
+	## frame, settle is counted, and the reply shape is right.
 	_register_seq_action()
 	var helper: GameHelper = _helper
-	await helper._run_input_sequence("req-seq-combo", {
+	helper._frame_waiter = func() -> void: pass
+	await helper._run_input_sequence("req-seq-1", {
 		"steps": [
 			{"at_frame": 0, "action": _SEQ_ACTION, "pressed": true},
-			{"at_frame": 0, "action": _SEQ_ACTION, "pressed": false},
+			{"at_frame": 2, "action": _SEQ_ACTION, "pressed": false},
 		],
+		"settle_frames": 1,
 	})
+	helper._frame_waiter = Callable()
 	var reply: Dictionary = helper._last_game_command_reply
 	assert_eq(reply.kind, "response", "a valid sequence replies with a response")
 	var result: Dictionary = reply.result
 	assert_eq(result.completed, true)
-	assert_eq(result.steps_applied, 2, "both same-frame steps applied")
-	assert_eq(result.frames_elapsed, 0)
+	assert_eq(result.steps_applied, 2, "both steps applied across frames")
+	assert_eq(result.frames_elapsed, 3, "2 (last step) + 1 settle")
+	assert_eq(result.applied[0].at_frame, 0)
+	assert_eq(result.applied[1].at_frame, 2, "second step fires on its scheduled frame")
 	assert_false(Input.is_action_pressed(_SEQ_ACTION),
 		"the release step must have run, leaving the action up")
 	assert_eq(result.actions_pressed_at_end, [], "nothing left held")

--- a/test_project/tests/test_game_helper.gd
+++ b/test_project/tests/test_game_helper.gd
@@ -456,22 +456,30 @@ func _clear_seq_action() -> void:
 		InputMap.erase_action(_SEQ_ACTION)
 
 
-func test_run_input_sequence_applies_actions_and_replies() -> void:
+func test_run_input_sequence_applies_all_steps_and_replies() -> void:
+	## Multi-frame progression (steps landing on distinct future frames) is
+	## covered by the isolated `--script` probe: the editor test runner calls
+	## test methods synchronously (test_runner.gd::_run_one_test) and never
+	## pumps `process_frame`, so a sequence that awaits real frame advances
+	## records 0 assertions. This is the same reason take_screenshot's frame
+	## loop is only tested via its pure `_should_capture_stale_sync` helper.
+	## Here: two steps on one frame (a combo), settle 0 — end_frame is 0, so
+	## the runner never awaits, and we can still assert the applied count and
+	## reply shape synchronously.
 	_register_seq_action()
 	var helper: GameHelper = _helper
-	await helper._run_input_sequence("req-seq-1", {
+	await helper._run_input_sequence("req-seq-combo", {
 		"steps": [
 			{"at_frame": 0, "action": _SEQ_ACTION, "pressed": true},
-			{"at_frame": 2, "action": _SEQ_ACTION, "pressed": false},
+			{"at_frame": 0, "action": _SEQ_ACTION, "pressed": false},
 		],
-		"settle_frames": 1,
 	})
 	var reply: Dictionary = helper._last_game_command_reply
 	assert_eq(reply.kind, "response", "a valid sequence replies with a response")
 	var result: Dictionary = reply.result
 	assert_eq(result.completed, true)
-	assert_eq(result.steps_applied, 2)
-	assert_eq(result.frames_elapsed, 3, "2 (last step) + 1 settle")
+	assert_eq(result.steps_applied, 2, "both same-frame steps applied")
+	assert_eq(result.frames_elapsed, 0)
 	assert_false(Input.is_action_pressed(_SEQ_ACTION),
 		"the release step must have run, leaving the action up")
 	assert_eq(result.actions_pressed_at_end, [], "nothing left held")

--- a/test_project/tests/test_game_helper.gd
+++ b/test_project/tests/test_game_helper.gd
@@ -72,6 +72,10 @@ func suite_teardown() -> void:
 
 
 func setup() -> void:
+	## Reset input_sequence test state here (not just at each test's end) so a
+	## mid-test assertion failure can't leak a registered/pressed _SEQ_ACTION
+	## into a later test.
+	_clear_seq_action()
 	if _root == null:
 		return
 	for child in _root.get_children():
@@ -483,7 +487,7 @@ func test_run_input_sequence_applies_all_steps_and_replies() -> void:
 	assert_false(Input.is_action_pressed(_SEQ_ACTION),
 		"the release step must have run, leaving the action up")
 	assert_eq(result.actions_pressed_at_end, [], "nothing left held")
-	_clear_seq_action()
+	# cleanup is fail-safe in setup(), so no per-test _clear_seq_action() here
 
 
 func test_run_input_sequence_reports_actions_left_pressed() -> void:
@@ -496,7 +500,6 @@ func test_run_input_sequence_reports_actions_left_pressed() -> void:
 	var result: Dictionary = helper._last_game_command_reply.result
 	assert_eq(result.actions_pressed_at_end, [_SEQ_ACTION])
 	assert_true(Input.is_action_pressed(_SEQ_ACTION))
-	_clear_seq_action()
 
 
 func test_run_input_sequence_unknown_action_fails_fast() -> void:

--- a/test_project/tests/test_game_helper.gd
+++ b/test_project/tests/test_game_helper.gd
@@ -373,3 +373,139 @@ func test_screenshot_reply_error_records_seam() -> void:
 	assert_eq(helper._last_screenshot_reply.get("request_id"), "rid-err")
 	assert_contains(str(helper._last_screenshot_reply.get("message")), "No game root viewport")
 	helper.free()
+
+
+# ----- input_sequence: pure plan validation (#814) -----
+
+func test_plan_input_sequence_normalizes_defaults() -> void:
+	var plan: Dictionary = _helper.call(
+		"_plan_input_sequence", {"steps": [{"at_frame": 0, "action": "jump"}]})
+	assert_false(plan.has("error"), "valid plan must not error")
+	assert_eq(plan.end_frame, 0)
+	var step: Dictionary = plan.steps[0]
+	assert_eq(step.pressed, true, "pressed defaults to true")
+	assert_eq(step.strength, 1.0, "strength defaults to 1.0")
+
+
+func test_plan_input_sequence_end_frame_includes_settle() -> void:
+	var plan: Dictionary = _helper.call("_plan_input_sequence", {
+		"steps": [{"at_frame": 6, "action": "jump"}],
+		"settle_frames": 5,
+	})
+	assert_eq(plan.end_frame, 11, "end_frame is last at_frame + settle_frames")
+
+
+func test_plan_input_sequence_rejects_empty() -> void:
+	var plan: Dictionary = _helper.call("_plan_input_sequence", {"steps": []})
+	assert_true(plan.has("error"), "empty steps must be rejected")
+
+
+func test_plan_input_sequence_rejects_out_of_order() -> void:
+	var plan: Dictionary = _helper.call("_plan_input_sequence", {"steps": [
+		{"at_frame": 10, "action": "a"},
+		{"at_frame": 5, "action": "b"},
+	]})
+	assert_true(plan.has("error"), "descending at_frame must be rejected")
+	assert_contains(plan.error, "ordered")
+
+
+func test_plan_input_sequence_allows_equal_frames() -> void:
+	var plan: Dictionary = _helper.call("_plan_input_sequence", {"steps": [
+		{"at_frame": 3, "action": "a"},
+		{"at_frame": 3, "action": "b"},
+	]})
+	assert_false(plan.has("error"), "equal at_frame (a combo) is valid")
+
+
+func test_plan_input_sequence_rejects_negative_frame() -> void:
+	var plan: Dictionary = _helper.call(
+		"_plan_input_sequence", {"steps": [{"at_frame": -1, "action": "a"}]})
+	assert_true(plan.has("error"), "negative at_frame must be rejected")
+
+
+func test_plan_input_sequence_rejects_over_frame_cap() -> void:
+	var cap: int = GameHelper.MAX_SEQUENCE_FRAMES
+	var plan: Dictionary = _helper.call("_plan_input_sequence", {
+		"steps": [{"at_frame": cap, "action": "a"}],
+		"settle_frames": 1,
+	})
+	assert_true(plan.has("error"), "spanning past the frame cap must be rejected")
+
+
+func test_plan_input_sequence_rejects_over_step_cap() -> void:
+	var steps: Array = []
+	for i in GameHelper.MAX_SEQUENCE_STEPS + 1:
+		steps.append({"at_frame": 0, "action": "a"})
+	var plan: Dictionary = _helper.call("_plan_input_sequence", {"steps": steps})
+	assert_true(plan.has("error"), "exceeding the step cap must be rejected")
+
+
+# ----- input_sequence: async frame-stepping (#814) -----
+
+const _SEQ_ACTION := "mcp_test_seq_action"
+
+
+func _register_seq_action() -> void:
+	if not InputMap.has_action(_SEQ_ACTION):
+		InputMap.add_action(_SEQ_ACTION)
+
+
+func _clear_seq_action() -> void:
+	Input.action_release(_SEQ_ACTION)
+	if InputMap.has_action(_SEQ_ACTION):
+		InputMap.erase_action(_SEQ_ACTION)
+
+
+func test_run_input_sequence_applies_actions_and_replies() -> void:
+	_register_seq_action()
+	var helper: GameHelper = _helper
+	await helper._run_input_sequence("req-seq-1", {
+		"steps": [
+			{"at_frame": 0, "action": _SEQ_ACTION, "pressed": true},
+			{"at_frame": 2, "action": _SEQ_ACTION, "pressed": false},
+		],
+		"settle_frames": 1,
+	})
+	var reply: Dictionary = helper._last_game_command_reply
+	assert_eq(reply.kind, "response", "a valid sequence replies with a response")
+	var result: Dictionary = reply.result
+	assert_eq(result.completed, true)
+	assert_eq(result.steps_applied, 2)
+	assert_eq(result.frames_elapsed, 3, "2 (last step) + 1 settle")
+	assert_false(Input.is_action_pressed(_SEQ_ACTION),
+		"the release step must have run, leaving the action up")
+	assert_eq(result.actions_pressed_at_end, [], "nothing left held")
+	_clear_seq_action()
+
+
+func test_run_input_sequence_reports_actions_left_pressed() -> void:
+	_register_seq_action()
+	var helper: GameHelper = _helper
+	# press with no matching release — caller must be told it's still held
+	await helper._run_input_sequence("req-seq-2", {
+		"steps": [{"at_frame": 0, "action": _SEQ_ACTION, "pressed": true}],
+	})
+	var result: Dictionary = helper._last_game_command_reply.result
+	assert_eq(result.actions_pressed_at_end, [_SEQ_ACTION])
+	assert_true(Input.is_action_pressed(_SEQ_ACTION))
+	_clear_seq_action()
+
+
+func test_run_input_sequence_unknown_action_fails_fast() -> void:
+	var helper: GameHelper = _helper
+	var absent := "mcp_definitely_not_an_action"
+	assert_false(InputMap.has_action(absent), "precondition: action must not exist")
+	await helper._run_input_sequence("req-seq-3", {
+		"steps": [{"at_frame": 0, "action": absent, "pressed": true}],
+	})
+	var reply: Dictionary = helper._last_game_command_reply
+	assert_eq(reply.kind, "error", "an unknown action must error, not apply partially")
+	assert_contains(reply.message, absent)
+	assert_false(Input.is_action_pressed(absent))
+
+
+func test_run_input_sequence_invalid_plan_replies_error() -> void:
+	var helper: GameHelper = _helper
+	await helper._run_input_sequence("req-seq-4", {"steps": []})
+	assert_eq(helper._last_game_command_reply.kind, "error",
+		"a plan error must surface as a game_command error")

--- a/tests/unit/test_game_input_sequence.py
+++ b/tests/unit/test_game_input_sequence.py
@@ -1,0 +1,158 @@
+"""Tests for the game_input_sequence handler and its server-side validation."""
+
+import pytest
+
+from godot_ai.godot_client.client import GodotCommandError
+from godot_ai.handlers import game as game_handlers
+from godot_ai.handlers.game import (
+    INPUT_SEQUENCE_TIMEOUT_SEC,
+    MAX_SEQUENCE_FRAMES,
+    MAX_SEQUENCE_STEPS,
+    _validate_input_sequence,
+)
+from godot_ai.protocol.errors import ErrorCode
+from godot_ai.runtime.direct import DirectRuntime
+from godot_ai.sessions.registry import SessionRegistry
+
+
+class _StubClient:
+    """Records send() calls and returns a canned input_sequence response."""
+
+    def __init__(self, *, result: dict | None = None):
+        self.calls: list[dict] = []
+        self._result = result or {"data": {"completed": True, "steps_applied": 2, "source": "game"}}
+
+    async def send(
+        self,
+        command: str,
+        params: dict | None = None,
+        session_id: str | None = None,
+        timeout: float = 5.0,
+        surface_error_hints: bool = True,
+    ) -> dict:
+        self.calls.append({"command": command, "params": params, "timeout": timeout})
+        return self._result
+
+
+def _runtime(client: _StubClient) -> DirectRuntime:
+    return DirectRuntime(registry=SessionRegistry(), client=client)
+
+
+# ----- _validate_input_sequence: accepts -----
+
+
+def test_validate_normalizes_defaults():
+    steps = _validate_input_sequence([{"at_frame": 0, "action": "jump"}], 0)
+    assert steps == [{"at_frame": 0, "action": "jump", "pressed": True, "strength": 1.0}]
+
+
+def test_validate_preserves_order_and_fields():
+    raw = [
+        {"at_frame": 0, "action": "jump", "pressed": True},
+        {"at_frame": 6, "action": "jump", "pressed": False},
+        {"at_frame": 6, "action": "move_right", "pressed": True, "strength": 0.5},
+    ]
+    steps = _validate_input_sequence(raw, 5)
+    assert [s["at_frame"] for s in steps] == [0, 6, 6]
+    assert steps[2]["strength"] == 0.5
+
+
+def test_validate_allows_equal_frames():
+    # non-decreasing is fine; two steps on the same frame is a valid combo
+    _validate_input_sequence([{"at_frame": 3, "action": "a"}, {"at_frame": 3, "action": "b"}], 0)
+
+
+def test_validate_span_at_cap_is_ok():
+    _validate_input_sequence([{"at_frame": MAX_SEQUENCE_FRAMES, "action": "a"}], 0)
+
+
+# ----- _validate_input_sequence: rejects -----
+
+
+@pytest.mark.parametrize("bad", [[], None, "nope", {}])
+def test_validate_rejects_non_list_or_empty(bad):
+    with pytest.raises(GodotCommandError) as exc:
+        _validate_input_sequence(bad, 0)
+    assert exc.value.code == ErrorCode.INVALID_PARAMS
+
+
+def test_validate_rejects_over_step_cap():
+    steps = [{"at_frame": 0, "action": "a"}] * (MAX_SEQUENCE_STEPS + 1)
+    with pytest.raises(GodotCommandError, match="step cap"):
+        _validate_input_sequence(steps, 0)
+
+
+def test_validate_rejects_negative_at_frame():
+    with pytest.raises(GodotCommandError, match="at_frame"):
+        _validate_input_sequence([{"at_frame": -1, "action": "a"}], 0)
+
+
+def test_validate_rejects_out_of_order():
+    raw = [{"at_frame": 10, "action": "a"}, {"at_frame": 5, "action": "b"}]
+    with pytest.raises(GodotCommandError, match="ordered by at_frame"):
+        _validate_input_sequence(raw, 0)
+
+
+def test_validate_rejects_missing_action():
+    with pytest.raises(GodotCommandError, match="action"):
+        _validate_input_sequence([{"at_frame": 0, "action": ""}], 0)
+
+
+def test_validate_rejects_negative_settle():
+    with pytest.raises(GodotCommandError, match="settle_frames"):
+        _validate_input_sequence([{"at_frame": 0, "action": "a"}], -1)
+
+
+def test_validate_rejects_over_frame_cap():
+    raw = [{"at_frame": MAX_SEQUENCE_FRAMES, "action": "a"}]
+    with pytest.raises(GodotCommandError, match="frame cap"):
+        _validate_input_sequence(raw, 1)  # span = cap + 1
+
+
+def test_validate_rejects_bool_at_frame():
+    # bool is an int subclass in Python — must not sneak through as at_frame
+    with pytest.raises(GodotCommandError, match="at_frame"):
+        _validate_input_sequence([{"at_frame": True, "action": "a"}], 0)
+
+
+# ----- game_input_sequence dispatch -----
+
+
+@pytest.mark.asyncio
+async def test_dispatch_forwards_normalized_steps():
+    client = _StubClient()
+    result = await game_handlers.game_input_sequence(
+        _runtime(client),
+        steps=[
+            {"at_frame": 0, "action": "jump"},
+            {"at_frame": 6, "action": "jump", "pressed": False},
+        ],
+        settle_frames=5,
+    )
+    call = client.calls[-1]
+    assert call["command"] == "game_command"
+    assert call["params"]["op"] == "input_sequence"
+    assert call["params"]["params"]["settle_frames"] == 5
+    forwarded = call["params"]["params"]["steps"]
+    assert forwarded[0] == {"at_frame": 0, "action": "jump", "pressed": True, "strength": 1.0}
+    assert forwarded[1]["pressed"] is False
+    assert result["data"]["completed"] is True
+
+
+@pytest.mark.asyncio
+async def test_dispatch_uses_wide_timeout():
+    client = _StubClient()
+    await game_handlers.game_input_sequence(
+        _runtime(client), steps=[{"at_frame": 0, "action": "jump"}]
+    )
+    assert client.calls[-1]["timeout"] == INPUT_SEQUENCE_TIMEOUT_SEC
+
+
+@pytest.mark.asyncio
+async def test_dispatch_rejects_before_sending():
+    client = _StubClient()
+    with pytest.raises(GodotCommandError):
+        await game_handlers.game_input_sequence(
+            _runtime(client), steps=[{"at_frame": -1, "action": "a"}]
+        )
+    assert client.calls == []  # validation fails fast, nothing hits the wire

--- a/tests/unit/test_game_input_sequence.py
+++ b/tests/unit/test_game_input_sequence.py
@@ -28,7 +28,7 @@ class _StubClient:
         params: dict | None = None,
         session_id: str | None = None,
         timeout: float = 5.0,
-        surface_error_hints: bool = True,
+        hint_policy=None,
     ) -> dict:
         self.calls.append({"command": command, "params": params, "timeout": timeout})
         return self._result
@@ -64,6 +64,18 @@ def test_validate_allows_equal_frames():
 
 def test_validate_span_at_cap_is_ok():
     _validate_input_sequence([{"at_frame": MAX_SEQUENCE_FRAMES, "action": "a"}], 0)
+
+
+def test_validate_clamps_strength():
+    steps = _validate_input_sequence(
+        [
+            {"at_frame": 0, "action": "a", "strength": 5.0},
+            {"at_frame": 0, "action": "b", "strength": -1.0},
+        ],
+        0,
+    )
+    assert steps[0]["strength"] == 1.0
+    assert steps[1]["strength"] == 0.0
 
 
 # ----- _validate_input_sequence: rejects -----
@@ -113,6 +125,28 @@ def test_validate_rejects_bool_at_frame():
     # bool is an int subclass in Python — must not sneak through as at_frame
     with pytest.raises(GodotCommandError, match="at_frame"):
         _validate_input_sequence([{"at_frame": True, "action": "a"}], 0)
+
+
+def test_validate_rejects_bool_settle_frames():
+    with pytest.raises(GodotCommandError, match="settle_frames"):
+        _validate_input_sequence([{"at_frame": 0, "action": "a"}], True)
+
+
+def test_validate_rejects_non_bool_pressed():
+    # "false" must not silently coerce to True
+    with pytest.raises(GodotCommandError, match="pressed"):
+        _validate_input_sequence([{"at_frame": 0, "action": "a", "pressed": "false"}], 0)
+
+
+def test_validate_rejects_non_numeric_strength():
+    # a bad strength must be a clean INVALID_PARAMS, not an internal error
+    with pytest.raises(GodotCommandError, match="strength"):
+        _validate_input_sequence([{"at_frame": 0, "action": "a", "strength": "hard"}], 0)
+
+
+def test_validate_rejects_bool_strength():
+    with pytest.raises(GodotCommandError, match="strength"):
+        _validate_input_sequence([{"at_frame": 0, "action": "a", "strength": True}], 0)
 
 
 # ----- game_input_sequence dispatch -----

--- a/tests/unit/test_game_input_sequence.py
+++ b/tests/unit/test_game_input_sequence.py
@@ -105,6 +105,11 @@ def test_validate_rejects_out_of_order():
         _validate_input_sequence(raw, 0)
 
 
+def test_validate_rejects_non_dict_step():
+    with pytest.raises(GodotCommandError, match="must be an object"):
+        _validate_input_sequence(["not a dict"], 0)
+
+
 def test_validate_rejects_missing_action():
     with pytest.raises(GodotCommandError, match="action"):
         _validate_input_sequence([{"at_frame": 0, "action": ""}], 0)


### PR DESCRIPTION
Implements `input_sequence` on `game_manage`, per the routing call on #814.

## What & why

Driving a running game through per-step input calls can't hit a target frame — each `input_action` lands on whichever frame its round-trip happens to complete on, so jump arcs, combos, and "walk into the trigger then assert" flows drift and aren't reproducible. `input_sequence` takes the whole timeline in one call and drives it game-side, applying each step's action on its scheduled frame, then replies once (deferred).

Scope follows @dsarno's call on #814:
- **`input_sequence` only** — `snapshot` and `wait_until` intentionally held.
- **Frames** as the timing basis (reproducible), not ms.
- **Action-based** input (`Input.action_press/release`), so it's focus-independent and works against a backgrounded game window.

```json
{
  "op": "input_sequence",
  "params": {
    "steps": [
      {"at_frame": 0,  "action": "jump",       "pressed": true},
      {"at_frame": 6,  "action": "jump",       "pressed": false},
      {"at_frame": 6,  "action": "move_right", "pressed": true},
      {"at_frame": 30, "action": "move_right", "pressed": false}
    ],
    "settle_frames": 1
  }
}
```

## How the constraints from the issue thread are met

- **Own deferred budget.** Every game op collapses to the single `game_command` dispatcher command (15s), so there was no per-op entry to add. Rather than globally widen `game_command`, a handler can now attach `_deferred_timeout_ms` to its deferred sentinel and the dispatcher registers that per-request budget; `input_sequence` claims ~30s across the debugger timer, the dispatcher deferred entry, and the Python client, while every other game op keeps its tight 15s.
- **Bounded sequence.** Server-side schema rejects empty / negative `at_frame` / out-of-order / over step-cap (256) / over frame-cap (600) up front as `INVALID_PARAMS`, before anything reaches the game. The game side re-checks the caps defensively so a malformed direct message can't park the coroutine on an unbounded await; the 30s budget is the frozen-loop backstop (same shape as `take_screenshot`).
- **`batch_execute`.** `game_command` is deferred and its reply flows out-of-band correlated by a `_request_id` that `dispatch_direct` deliberately strips — so a game op nested in a batch has no completion channel. It's now rejected up front with a clear message (previously it surfaced a confusing "Missing request_id").
- **Main-thread yielding.** The runner awaits one `process_frame` per frame and never blocks.
- **Unknown actions** resolve against the *running game's* InputMap (the server can't see it) and fail fast before applying anything — no half-applied timeline.

The reply reports `steps_applied`, `frames_elapsed`, and `actions_pressed_at_end` (so the caller knows what's still held and must release before the next assertion).

## Testing

- **Python:** new `tests/unit/test_game_input_sequence.py` (validation + dispatch, incl. the `bool`-isn't-`int` edge and fail-fast-before-send); full suite green.
- **GDScript:** planner + async frame-stepping in `test_game_helper.gd`, per-request timeout override in `test_dispatcher.gd`, batch rejection in `test_batch.gd`.
- Worked jump-arc example added to `docs/TOOLS.md`.

Implements the `input_sequence` portion of #814. `snapshot` and `wait_until` remain deferred per the routing call there ("not-yet" — revisit once `input_sequence` is in real use), so this references #814 rather than closing it and leaves the close/keep call to you.

@dsarno — pinging you as requested; happy to adjust the per-request timeout mechanism if you'd rather it took a different shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a frame-timed, multi-step in-game `input_sequence` operation with `settle_frames`, step ordering/limits, and completion reply details.
* **Bug Fixes**
  * Improved deferred-response scheduling with support for per-request timeout overrides.
  * Updated batch validation errors for forbidden subcommands with clearer, command-specific reasons.
* **Documentation**
  * Expanded `input_sequence` documentation, including step structure, frame timing semantics, constraints, reply fields, and a worked JSON example.
* **Tests**
  * Added unit/integration coverage for `input_sequence` validation/execution, dispatcher timeout overrides, and batch rejection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
