### PR TITLE
Document mcp-proxy compatibility with mcp 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,21 @@ prefer an SSH tunnel or Tailscale on untrusted networks.
 </details>
 
 <details>
+<summary><strong><code>ImportError</code> from <code>mcp-proxy</code> (<code>streamablehttp_client</code> or <code>request_ctx</code>)</strong></summary>
+
+An older client configuration may launch `mcp-proxy` against an unbounded
+`mcp>=1.17.0` dependency. `mcp` 2.x is incompatible with released
+`mcp-proxy` versions: 0.11.0 fails on `streamablehttp_client`, while 0.12.0
+contains both incompatible imports and may report `request_ctx` first.
+
+Preferred fix: update Godot AI, click **Configure** for Claude Desktop, and
+restart it. This replaces the legacy proxy entry with the current
+`godot-ai attach` launcher. As a temporary workaround, constrain the old uvx
+command with `--with "mcp<2"` before its `mcp-proxy` package argument.
+
+</details>
+
+<details>
 <summary><strong>Windows: an <code>uvx</code> attach launcher won't start (<code>pywin32</code> install fails)</strong></summary>
 
 Symptom (in your MCP client's server log):


### PR DESCRIPTION
## Summary

Document the `ImportError` affecting legacy `mcp-proxy` client configurations when their unbounded `mcp>=1.17.0` dependency resolves to `mcp` 2.x.

The troubleshooting entry:

- identifies the `streamablehttp_client` failure in `mcp-proxy` 0.11.0
- explains that 0.12.0 contains both incompatible imports and may fail on `request_ctx` first
- recommends updating Godot AI and re-running **Configure** to migrate Claude Desktop or Codex to the current `godot-ai attach` launcher
- provides `uvx --with "mcp<2"` as a temporary workaround for users who cannot migrate immediately

## Why

Users with legacy generated configurations can currently encounter an opaque import failure before the MCP server starts. The first failing import can obscure that the underlying problem is the same incompatible `mcp` 2.x resolution.

This gives affected users an actionable recovery path while steering them toward the current attach configuration.

## Scope

Documentation only. No runtime, dependency, or configuration behavior changes.

## Verification

- Confirmed the branch differs from `main` only in `README.md`
- `git diff --check` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guidance for `ImportError` failures caused by legacy proxy configurations.
  * Documented recommended Claude Desktop configuration updates using `godot-ai attach`.
  * Added a temporary compatibility workaround for affected setups using `mcp<2`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->