### PR TITLE
Expose WebSocket reconnect transport state

### DIFF
--- a/plugin/addons/godot_ai/connection.gd
+++ b/plugin/addons/godot_ai/connection.gd
@@ -8,7 +8,7 @@ extends Node
 
 const RECONNECT_DELAYS: Array[float] = [1.0, 2.0, 4.0, 8.0, 16.0, 30.0, 60.0]
 const RECONNECT_VERBOSE_ATTEMPTS := 5
-const RECONNECT_LOG_EVERY_N_ATTEMPTS := 10
+const RECONNECT_LOG_HEARTBEAT_MSEC := 60_000
 ## Backpressure policy: do not queue responses once the WebSocket's current
 ## outbound buffer plus the next payload would exceed this cap. Command
 ## responses get a compact structured error when that can still be sent;
@@ -55,6 +55,13 @@ var _url := ""
 var _connected := false
 var _reconnect_attempt := 0
 var _reconnect_timer := 0.0
+## Pull-based reconnect observability. The peer owns CONNECTING/CLOSING
+## timing; tracking entry time here lets logs and the dock distinguish those
+## phases from the plugin-owned CLOSED-state backoff without changing policy.
+var _observed_peer_state := WebSocketPeer.STATE_CLOSED
+var _peer_state_entered_msec := 0
+var _last_reconnect_transition_log_msec := -1
+var _transient_diagnostic: Dictionary = {}
 ## One pre-OPEN failure diagnostic per WebSocketPeer. Without this guard the
 ## CLOSED state is polled every frame and would flood the editor log.
 var _preopen_failure_logged_for_peer := false
@@ -130,7 +137,9 @@ func _process(delta: float) -> void:
 	## reconnect would still observe stale "live" state (PR #642 review).
 	_check_game_run_play_state(EditorInterface.is_playing_scene())
 
-	match _peer.get_ready_state():
+	var peer_state := _peer.get_ready_state()
+	var transition := _observe_peer_state(peer_state, Time.get_ticks_msec())
+	match peer_state:
 		WebSocketPeer.STATE_OPEN:
 			if not _connected:
 				_connected = true
@@ -164,22 +173,46 @@ func _process(delta: float) -> void:
 				_clear_on_disconnect()
 				var code := _peer.get_close_code()
 				var reason := _peer.get_close_reason()
-				log_buffer.log(_close_diagnostic(true, code, reason, _url))
-				_note_post_open_close(code)
+				var open_elapsed_sec := float(transition.get("previous_elapsed_sec", 0.0))
+				var close_diagnostic := _note_post_open_close(code)
+				if close_diagnostic.is_empty():
+					close_diagnostic = {
+						"reason_code": "connection_lost",
+						"reason": _close_reason_text(code, reason),
+					}
+				_transient_diagnostic = close_diagnostic
+				_log_reconnect_transition(
+					_postopen_close_diagnostic(
+						open_elapsed_sec,
+						code,
+						reason,
+						_url,
+						close_diagnostic,
+					),
+					maxi(1, _reconnect_attempt),
+					true,
+				)
 				connection_state_changed.emit(false)
 			elif not _preopen_failure_logged_for_peer:
 				_preopen_failure_logged_for_peer = true
-				## Initial failure is attempt 1 for diagnostics. Later failures
-				## follow the same first-five/each-tenth throttle as reconnect
-				## progress so a missing listener stays observable but bounded.
+				## Initial failure is attempt 1 for diagnostics. Later transition
+				## summaries are time-throttled so a missing listener stays
+				## observable without tying log volume to attempt duration.
 				var failed_attempt := maxi(1, _reconnect_attempt)
-				if _should_log_reconnect_attempt(failed_attempt):
-					log_buffer.log(_close_diagnostic(
-						false,
+				var connecting_elapsed_sec := float(
+					transition.get("previous_elapsed_sec", 0.0)
+				)
+				_log_reconnect_transition(
+					_preopen_failure_diagnostic(
+						failed_attempt,
+						connecting_elapsed_sec,
+						_reconnect_timer,
 						_peer.get_close_code(),
 						_peer.get_close_reason(),
 						_url
-					))
+					),
+					failed_attempt,
+				)
 			_reconnect_timer -= delta
 			if _reconnect_timer <= 0.0:
 				_attempt_reconnect()
@@ -277,6 +310,8 @@ func _connect_to_server() -> void:
 	var err := _peer.connect_to_url(_url)
 	if err != OK:
 		log_buffer.log("failed to initiate connection (error %d)" % err)
+	_observed_peer_state = _peer.get_ready_state()
+	_peer_state_entered_msec = Time.get_ticks_msec()
 
 
 func _attempt_reconnect() -> void:
@@ -287,11 +322,10 @@ func _attempt_reconnect() -> void:
 	var delay := _reconnect_delay_for_attempt(_reconnect_attempt)
 	_reconnect_attempt += 1
 	_reconnect_timer = delay
-	if _should_log_reconnect_attempt(_reconnect_attempt):
-		log_buffer.log(
-			"reconnecting (attempt %d; next retry in %.0fs if needed)"
-			% [_reconnect_attempt, delay]
-		)
+	_log_reconnect_transition(
+		"connecting to server (attempt %d)" % _reconnect_attempt,
+		_reconnect_attempt,
+	)
 	## Always create a fresh WebSocketPeer before reconnecting. A peer that has
 	## reached STATE_CLOSED is terminal; reusing it can leave the editor stuck in
 	## a quiet reconnect loop after the Python server restarts.
@@ -320,28 +354,90 @@ static func _reconnect_delay_for_attempt(attempt_index: int) -> float:
 	return RECONNECT_DELAYS[delay_idx]
 
 
-static func _should_log_reconnect_attempt(attempt_number: int) -> bool:
-	## Log the first few failures for immediate diagnostics, then only periodic
-	## progress markers. Reconnect continues indefinitely; the log should not.
+static func _should_log_reconnect_transition(
+	attempt_number: int,
+	now_msec: int,
+	last_log_msec: int
+) -> bool:
+	## Keep the first few transitions visible, then emit at most one summary per
+	## minute. Attempt-number throttling goes quiet for minutes when the engine
+	## spends a long time in CONNECTING, which is the state this log explains.
 	return (
 		attempt_number <= RECONNECT_VERBOSE_ATTEMPTS
-		or attempt_number % RECONNECT_LOG_EVERY_N_ATTEMPTS == 0
+		or last_log_msec < 0
+		or now_msec - last_log_msec >= RECONNECT_LOG_HEARTBEAT_MSEC
 	)
 
 
-static func _close_diagnostic(
-	reached_open: bool,
+func _log_reconnect_transition(message: String, attempt_number: int, force := false) -> void:
+	if not log_buffer:
+		return
+	var now_msec := Time.get_ticks_msec()
+	if not force and not _should_log_reconnect_transition(
+		attempt_number,
+		now_msec,
+		_last_reconnect_transition_log_msec,
+	):
+		return
+	_last_reconnect_transition_log_msec = now_msec
+	log_buffer.log(message)
+
+
+static func _preopen_failure_diagnostic(
+	attempt_number: int,
+	connecting_elapsed_sec: float,
+	retry_in_sec: float,
 	code: int,
 	reason: String,
 	url: String
 ) -> String:
-	var phase := "disconnected after OPEN" if reached_open else "connection failed before OPEN"
+	var retry_text := "retrying now"
+	if retry_in_sec > 0.0:
+		retry_text = "retrying in %.0fs" % retry_in_sec
+	return (
+		"connection attempt %d failed before OPEN after %.1fs; %s"
+		+ " (code %d, reason %s, url %s)"
+	) % [
+		attempt_number,
+		maxf(0.0, connecting_elapsed_sec),
+		retry_text,
+		code,
+		_sanitized_close_reason(reason),
+		url,
+	]
+
+
+static func _postopen_close_diagnostic(
+	open_elapsed_sec: float,
+	code: int,
+	reason: String,
+	url: String,
+	diagnostic: Dictionary = {}
+) -> String:
+	var message := (
+		"connection lost after being open for %.1fs (code %d, reason %s, url %s); reconnecting"
+		% [maxf(0.0, open_elapsed_sec), code, _sanitized_close_reason(reason), url]
+	)
+	match str(diagnostic.get("recovery_action", "")):
+		"retry_authenticated":
+			message += " with the current auth token (rejection 1/%d)" % AUTH_MISMATCH_FALLBACK_CLOSES
+		"retry_tokenless":
+			message += " with a token-less handshake (rejection %d/%d)" % [
+				int(diagnostic.get("occurrence", AUTH_MISMATCH_FALLBACK_CLOSES)),
+				AUTH_MISMATCH_FALLBACK_CLOSES,
+			]
+	return message
+
+
+static func _sanitized_close_reason(reason: String) -> String:
 	var reason_label := reason.strip_edges()
 	if reason_label.is_empty():
-		reason_label = "<none>"
-	else:
-		reason_label = reason_label.replace("\r", "\\r").replace("\n", "\\n")
-	return "%s (code %d, reason %s, url %s)" % [phase, code, reason_label, url]
+		return "<none>"
+	return reason_label.replace("\r", "\\r").replace("\n", "\\n")
+
+
+static func _close_reason_text(code: int, reason: String) -> String:
+	return "Close code %d: %s" % [code, _sanitized_close_reason(reason)]
 
 
 ## Token-mismatch fallback (#690 follow-up). The server's auth token is
@@ -356,20 +452,106 @@ static func _close_diagnostic(
 ## see websocket.py; omitting it gives up no security). Scope note: only
 ## this connection's copy of the token is dropped — the plugin static and
 ## the persisted record heal via the startup walk's adoption arms.
-func _note_post_open_close(code: int) -> void:
+func _note_post_open_close(code: int) -> Dictionary:
 	if code != CLOSE_CODE_AUTH_TOKEN_MISMATCH or auth_token.is_empty():
 		_auth_mismatch_closes = 0
-		return
+		return {}
 	_auth_mismatch_closes += 1
+	var occurrence := _auth_mismatch_closes
 	if _auth_mismatch_closes < AUTH_MISMATCH_FALLBACK_CLOSES:
-		return
+		return {
+			"reason_code": "auth_token_mismatch",
+			"reason": "Server rejected the editor auth token; retrying once in case of a server-swap race.",
+			"occurrence": occurrence,
+			"recovery_action": "retry_authenticated",
+		}
 	auth_token = ""
 	_auth_mismatch_closes = 0
-	if log_buffer:
-		log_buffer.log(
-			"auth token rejected %d times (close code %d) — retrying with a token-less handshake"
-			% [AUTH_MISMATCH_FALLBACK_CLOSES, CLOSE_CODE_AUTH_TOKEN_MISMATCH]
-		)
+	return {
+		"reason_code": "auth_token_mismatch",
+		"reason": "Server rejected the editor auth token twice; the next handshake will omit it.",
+		"occurrence": occurrence,
+		"recovery_action": "retry_tokenless",
+	}
+
+
+## Record one peer-state transition and return the duration of the state that
+## just ended. Kept separate from `_transport_status_snapshot` so tests can
+## exercise the status contract with injected values and no live socket.
+func _observe_peer_state(state: int, now_msec: int) -> Dictionary:
+	if _peer_state_entered_msec <= 0:
+		_observed_peer_state = state
+		_peer_state_entered_msec = now_msec
+		return {"changed": false, "previous_elapsed_sec": 0.0}
+	if state == _observed_peer_state:
+		return {"changed": false, "previous_elapsed_sec": 0.0}
+	var previous_elapsed_sec := maxf(
+		0.0,
+		(now_msec - _peer_state_entered_msec) / 1000.0,
+	)
+	var previous_state := _observed_peer_state
+	_observed_peer_state = state
+	_peer_state_entered_msec = now_msec
+	return {
+		"changed": true,
+		"previous_state": previous_state,
+		"previous_elapsed_sec": previous_elapsed_sec,
+	}
+
+
+## Pure transport-status contract shared by the connection log and dock. It
+## intentionally knows nothing about lifecycle diagnoses; the thin public
+## wrapper below applies generic `blocked`, while server_lifecycle.gd remains
+## authoritative for exact terminal states such as incompatible/foreign port.
+static func _transport_status_snapshot(
+	state: int,
+	state_elapsed_sec: float,
+	attempt: int,
+	retry_timer: float
+) -> Dictionary:
+	var phase := "closing"
+	match state:
+		WebSocketPeer.STATE_OPEN:
+			phase = "connected"
+		WebSocketPeer.STATE_CONNECTING:
+			phase = "connecting"
+		WebSocketPeer.STATE_CLOSED:
+			phase = "retrying"
+		WebSocketPeer.STATE_CLOSING:
+			phase = "closing"
+	var snapshot := {
+		"phase": phase,
+		"attempt": maxi(0, attempt),
+		"state_elapsed_sec": maxf(0.0, state_elapsed_sec),
+	}
+	## `retry_in_sec` is deliberately unrepresentable outside CLOSED-state
+	## backoff. CONNECTING is an in-flight attempt, never "retrying in 0s".
+	if phase == "retrying":
+		snapshot["retry_in_sec"] = maxf(0.0, retry_timer)
+	return snapshot
+
+
+func get_transport_status() -> Dictionary:
+	var now_msec := Time.get_ticks_msec()
+	var elapsed_sec := 0.0
+	if _peer_state_entered_msec > 0:
+		elapsed_sec = maxf(0.0, (now_msec - _peer_state_entered_msec) / 1000.0)
+	var snapshot := _transport_status_snapshot(
+		_peer.get_ready_state(),
+		elapsed_sec,
+		_reconnect_attempt,
+		_reconnect_timer,
+	)
+	if connect_blocked:
+		snapshot["phase"] = "blocked"
+		snapshot.erase("retry_in_sec")
+		snapshot["reason_code"] = "connection_blocked"
+		if not connect_block_reason.is_empty():
+			snapshot["reason"] = connect_block_reason
+	elif not _transient_diagnostic.is_empty():
+		for key in _transient_diagnostic:
+			snapshot[key] = _transient_diagnostic[key]
+	return snapshot
 
 
 func _log_blocked_notice_once() -> void:
@@ -448,6 +630,7 @@ func _handle_handshake_ack(parsed: Dictionary) -> void:
 	## The server accepted our handshake — any token-mismatch streak is
 	## over; a later unrelated 4003 starts a fresh one.
 	_auth_mismatch_closes = 0
+	_transient_diagnostic.clear()
 
 
 ## Never enqueue a malformed command frame: the dispatcher's typed casts

--- a/plugin/addons/godot_ai/connection.gd
+++ b/plugin/addons/godot_ai/connection.gd
@@ -195,6 +195,9 @@ func _process(delta: float) -> void:
 				connection_state_changed.emit(false)
 			elif not _preopen_failure_logged_for_peer:
 				_preopen_failure_logged_for_peer = true
+				## A failed attempt never reached OPEN, so any post-OPEN reason
+				## belongs to the previous peer and must not describe this one.
+				_transient_diagnostic.clear()
 				## Initial failure is attempt 1 for diagnostics. Later transition
 				## summaries are time-throttled so a missing listener stays
 				## observable without tying log volume to attempt duration.

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -1034,7 +1034,10 @@ func _update_status() -> void:
 	_update_crash_panel(server_status)
 	_refresh_server_version_label(server_status)
 
-	var status_tooltip := str(transport_status.get("reason", ""))
+	## A transient disconnect reason remains in the transport snapshot until
+	## handshake_ack. Once the dock renders the connection as OPEN, do not pair
+	## its green label with the previous peer's recovery diagnostic.
+	var status_tooltip := "" if connected else str(transport_status.get("reason", ""))
 	var changed: bool = (
 		connected != _last_connected
 		or status_text != _last_status_text

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -220,6 +220,7 @@ var _log_viewer: LogViewerScript
 
 var _last_connected := false
 var _last_status_text := ""
+var _last_status_tooltip := ""
 var _startup_grace_until_msec: int = 0
 
 # Spawn-failure panel — rendered when `get_server_status` reports a
@@ -946,6 +947,14 @@ func _apply_editor_icon(button: Button, icon_name: String, fallback_text: String
 
 func _update_status() -> void:
 	var connected: bool = _connection != null and _connection.is_connected
+	## Pull the connection's transport snapshot on this existing refresh tick.
+	## `has_method` preserves the plugin self-update seam while an older
+	## Connection instance is still alive under a hot-reloaded dock script.
+	var transport_status: Dictionary = (
+		_connection.get_transport_status()
+		if _connection != null and _connection.has_method("get_transport_status")
+		else {}
+	)
 	## During plugin self-update there's a brief window where this dock
 	## script is already the new version (Godot hot-reloads scripts on
 	## file change) but `_plugin` is still the old `EditorPlugin` instance
@@ -966,8 +975,12 @@ func _update_status() -> void:
 	## One `match`/`elif` chain, one source of truth. Adding a new
 	## spawn outcome = one `ServerStateScript` constant + one arm here +
 	## one body string in `_crash_body_for_state`.
-	var status_text: String
-	var status_color: Color
+	## Default covers both a missing/old Connection instance and an unknown
+	## future transport phase. Every recognized state below overrides it, so
+	## startup grace and settled disconnect have one rendering path.
+	var inside_startup_grace := Time.get_ticks_msec() < _startup_grace_until_msec
+	var status_text := "Starting server…" if inside_startup_grace else "Disconnected"
+	var status_color := COLOR_AMBER if inside_startup_grace else Color.RED
 	if _server_restart_in_progress:
 		status_text = "Restarting server..."
 		status_color = COLOR_AMBER
@@ -995,14 +1008,22 @@ func _update_status() -> void:
 	elif state == ServerStateScript.NO_COMMAND:
 		status_text = "No server command found"
 		status_color = Color.RED
-	elif Time.get_ticks_msec() < _startup_grace_until_msec:
-		## Inside startup grace — distinguish from real disconnect so
-		## first-run users don't assume it's broken while uvx downloads.
-		status_text = "Starting server…"
-		status_color = COLOR_AMBER
-	else:
-		status_text = "Disconnected"
-		status_color = Color.RED
+	elif not transport_status.is_empty():
+		var transport_phase := str(transport_status.get("phase", ""))
+		if transport_phase == "connecting":
+			status_text = _transport_status_text(transport_status)
+			status_color = COLOR_AMBER
+		elif transport_phase == "retrying":
+			status_text = _transport_status_text(transport_status)
+			status_color = COLOR_AMBER
+		elif transport_phase == "closing":
+			status_text = _transport_status_text(transport_status)
+			status_color = COLOR_AMBER
+		elif transport_phase == "blocked":
+			## Exact terminal labels come from lifecycle state above. This is a
+			## generic fallback for a blocked connection without a diagnosis.
+			status_text = _transport_status_text(transport_status)
+			status_color = Color.RED
 
 	## keep_server_on_exit (#800): the reaper env opt-outs are staged at
 	## spawn, so a mid-session toggle only lands on the next server start —
@@ -1013,14 +1034,21 @@ func _update_status() -> void:
 	_update_crash_panel(server_status)
 	_refresh_server_version_label(server_status)
 
-	var changed: bool = connected != _last_connected or status_text != _last_status_text
+	var status_tooltip := str(transport_status.get("reason", ""))
+	var changed: bool = (
+		connected != _last_connected
+		or status_text != _last_status_text
+		or status_tooltip != _last_status_tooltip
+	)
 	if not changed:
 		return
 	var just_connected: bool = connected and not _last_connected
 	_last_connected = connected
 	_last_status_text = status_text
+	_last_status_tooltip = status_tooltip
 	_status_icon.color = status_color
 	_status_label.text = status_text
+	_status_label.tooltip_text = status_tooltip
 	if just_connected:
 		## #739: the server just came up. If the startup uv probe failed
 		## (the reporter's screenshot: green "Server connected" beside a
@@ -1875,6 +1903,26 @@ func _client_status_refresh_has_completed() -> bool:
 
 func _connected_status_text() -> String:
 	return "Server connected"
+
+
+static func _transport_status_text(snapshot: Dictionary) -> String:
+	## Total over the transport enum for isolated consumers/tests. The dock's
+	## connected fast path renders `_connected_status_text()` before calling it.
+	var phase := str(snapshot.get("phase", ""))
+	var attempt := maxi(1, int(snapshot.get("attempt", 0)))
+	match phase:
+		"connected":
+			return "Server connected"
+		"connecting":
+			return "Connecting — attempt %d" % attempt
+		"retrying":
+			var retry_in_sec := ceili(maxf(0.0, float(snapshot.get("retry_in_sec", 0.0))))
+			return "Retrying in %ds — attempt %d" % [retry_in_sec, attempt]
+		"closing":
+			return "Disconnecting…"
+		"blocked":
+			return "Connection blocked"
+	return "Disconnected"
 
 
 ## Open uv's official install documentation rather than executing an

--- a/test_project/tests/test_connection.gd
+++ b/test_project/tests/test_connection.gd
@@ -357,13 +357,13 @@ func test_transport_status_wrapper_applies_generic_blocked_reason() -> void:
 func test_reconnect_diagnostics_keep_preopen_and_postopen_failures_distinct() -> void:
 	var preopen := McpConnection._preopen_failure_diagnostic(
 		4,
-		30.25,
+		30.0,
 		8.0,
 		-1,
 		"",
 		"ws://127.0.0.1:9500"
 	)
-	assert_contains(preopen, "connection attempt 4 failed before OPEN after 30.3s")
+	assert_contains(preopen, "connection attempt 4 failed before OPEN after 30.0s")
 	assert_contains(preopen, "retrying in 8s")
 	assert_contains(preopen, "code -1")
 	assert_contains(preopen, "reason <none>")
@@ -389,6 +389,35 @@ func test_reconnect_diagnostics_keep_preopen_and_postopen_failures_distinct() ->
 	)
 	assert_contains(tokenless, "token-less handshake (rejection 2/2)",
 		"the post-OPEN line must surface the recovery action before the next ack")
+
+
+func test_preopen_failure_clears_stale_postopen_diagnostic() -> void:
+	var conn := McpConnection.new()
+	var buffer := McpLogBuffer.new()
+	conn.log_buffer = buffer
+	conn._url = "ws://127.0.0.1:9500"
+	conn._reconnect_timer = 5.0
+	conn._preopen_failure_logged_for_peer = false
+	conn._auth_mismatch_closes = 1
+	conn._transient_diagnostic = {
+		"reason_code": "auth_token_mismatch",
+		"reason": "stale post-OPEN diagnostic",
+		"occurrence": 1,
+		"recovery_action": "retry_authenticated",
+	}
+
+	## A fresh WebSocketPeer starts CLOSED, exercising the pre-OPEN failure
+	## branch without opening a real socket or advancing to another attempt.
+	conn._process(0.0)
+
+	assert_true(conn._transient_diagnostic.is_empty(),
+		"the new pre-OPEN failure must clear the previous peer's diagnosis")
+	assert_eq(conn._auth_mismatch_closes, 1,
+		"clearing presentation state must not reset the separate auth counter")
+	var snapshot := conn.get_transport_status()
+	assert_false(snapshot.has("reason_code"))
+	assert_false(snapshot.has("reason"))
+	conn.free()
 
 
 func test_post_open_close_does_not_emit_preopen_duplicate() -> void:

--- a/test_project/tests/test_connection.gd
+++ b/test_project/tests/test_connection.gd
@@ -319,7 +319,7 @@ func test_reconnect_transition_logging_uses_time_heartbeat_after_initial_attempt
 
 func test_transport_snapshot_distinguishes_connecting_retrying_closing_and_open() -> void:
 	var connecting := McpConnection._transport_status_snapshot(
-		WebSocketPeer.STATE_CONNECTING, 12.5, 3, 0.0)
+		WebSocketPeer.STATE_CONNECTING, 12.5, 3, 9.0)
 	assert_eq(connecting.get("phase"), "connecting")
 	assert_eq(connecting.get("attempt"), 3)
 	assert_eq(connecting.get("state_elapsed_sec"), 12.5)
@@ -329,16 +329,22 @@ func test_transport_snapshot_distinguishes_connecting_retrying_closing_and_open(
 	var retrying := McpConnection._transport_status_snapshot(
 		WebSocketPeer.STATE_CLOSED, 0.25, 3, 4.5)
 	assert_eq(retrying.get("phase"), "retrying")
+	assert_eq(retrying.get("attempt"), 3)
+	assert_eq(retrying.get("state_elapsed_sec"), 0.25)
 	assert_eq(retrying.get("retry_in_sec"), 4.5)
 
 	var closing := McpConnection._transport_status_snapshot(
 		WebSocketPeer.STATE_CLOSING, 1.0, 3, 4.5)
 	assert_eq(closing.get("phase"), "closing")
+	assert_eq(closing.get("attempt"), 3)
+	assert_eq(closing.get("state_elapsed_sec"), 1.0)
 	assert_false(closing.has("retry_in_sec"))
 
 	var connected := McpConnection._transport_status_snapshot(
 		WebSocketPeer.STATE_OPEN, 30.0, 0, 4.5)
 	assert_eq(connected.get("phase"), "connected")
+	assert_eq(connected.get("attempt"), 0)
+	assert_eq(connected.get("state_elapsed_sec"), 30.0)
 	assert_false(connected.has("retry_in_sec"))
 
 
@@ -346,11 +352,17 @@ func test_transport_status_wrapper_applies_generic_blocked_reason() -> void:
 	var conn := McpConnection.new()
 	conn.connect_blocked = true
 	conn.connect_block_reason = "blocked for test"
+	conn._reconnect_attempt = 7
+	conn._reconnect_timer = 6.0
+	conn._peer_state_entered_msec = Time.get_ticks_msec() - 1250
 	var snapshot := conn.get_transport_status()
 	assert_eq(snapshot.get("phase"), "blocked")
+	assert_eq(snapshot.get("attempt"), 7)
+	assert_gt(snapshot.get("state_elapsed_sec"), 1.0)
 	assert_eq(snapshot.get("reason_code"), "connection_blocked")
 	assert_eq(snapshot.get("reason"), "blocked for test")
-	assert_false(snapshot.has("retry_in_sec"))
+	assert_false(snapshot.has("retry_in_sec"),
+		"blocked must hide the positive retry timer from the underlying CLOSED state")
 	conn.free()
 
 

--- a/test_project/tests/test_connection.gd
+++ b/test_project/tests/test_connection.gd
@@ -116,23 +116,25 @@ func test_build_handshake_includes_auth_token_when_set() -> void:
 
 func test_auth_mismatch_fallback_drops_token_after_repeated_4003() -> void:
 	var conn := McpConnection.new()
-	var buffer := McpLogBuffer.new()
-	conn.log_buffer = buffer
 	conn.auth_token = "stale-token"
 
-	conn._note_post_open_close(McpConnection.CLOSE_CODE_AUTH_TOKEN_MISMATCH)
+	var first := conn._note_post_open_close(McpConnection.CLOSE_CODE_AUTH_TOKEN_MISMATCH)
 	assert_eq(conn.auth_token, "stale-token",
 		"one rejection may be a transient swap race — keep the token")
-	conn._note_post_open_close(McpConnection.CLOSE_CODE_AUTH_TOKEN_MISMATCH)
+	assert_eq(first.get("reason_code"), "auth_token_mismatch")
+	assert_eq(first.get("occurrence"), 1)
+	assert_eq(first.get("recovery_action"), "retry_authenticated")
+
+	var second := conn._note_post_open_close(McpConnection.CLOSE_CODE_AUTH_TOKEN_MISMATCH)
 	assert_eq(conn.auth_token, "",
 		"repeated 4003 must fall back to a token-less handshake")
+	assert_eq(second.get("reason_code"), "auth_token_mismatch")
+	assert_eq(second.get("occurrence"), 2)
+	assert_eq(second.get("recovery_action"), "retry_tokenless")
 
 	var payload := conn._build_handshake()
 	assert_false(payload.has("auth_token"),
 		"fallback handshake must omit the token field entirely")
-	var lines := buffer.get_recent(5)
-	assert_true(lines.size() >= 1, "fallback must be logged")
-	assert_contains(lines[lines.size() - 1], "token-less")
 	conn.free()
 
 
@@ -156,12 +158,16 @@ func test_auth_mismatch_streak_resets_on_handshake_ack() -> void:
 	var conn := McpConnection.new()
 	conn.auth_token = "per-launch-secret"
 
-	conn._note_post_open_close(McpConnection.CLOSE_CODE_AUTH_TOKEN_MISMATCH)
+	conn._transient_diagnostic = conn._note_post_open_close(
+		McpConnection.CLOSE_CODE_AUTH_TOKEN_MISMATCH
+	)
 	conn._handle_message('{"type":"handshake_ack","server_version":"1.0.0"}')
 	conn._note_post_open_close(McpConnection.CLOSE_CODE_AUTH_TOKEN_MISMATCH)
 
 	assert_eq(conn.auth_token, "per-launch-secret",
 		"an accepted handshake must reset the mismatch streak")
+	assert_true(conn._transient_diagnostic.is_empty(),
+		"an accepted handshake must clear the healed reconnect reason")
 	conn.free()
 
 
@@ -290,49 +296,99 @@ func test_reconnect_delay_caps_at_sixty_seconds() -> void:
 	assert_eq(McpConnection._reconnect_delay_for_attempt(42), 60.0)
 
 
-func test_reconnect_logging_includes_initial_attempts() -> void:
+func test_reconnect_transition_logging_includes_initial_attempts() -> void:
 	for attempt in range(1, 6):
 		assert_true(
-			McpConnection._should_log_reconnect_attempt(attempt),
+			McpConnection._should_log_reconnect_transition(attempt, 1000, 1000),
 			"attempt %d should be logged for immediate diagnostics" % attempt,
 		)
 
 
-func test_reconnect_logging_throttles_later_attempts() -> void:
-	assert_false(McpConnection._should_log_reconnect_attempt(6), "attempt 6 should be quiet")
-	assert_false(McpConnection._should_log_reconnect_attempt(9), "attempt 9 should be quiet")
-	assert_true(
-		McpConnection._should_log_reconnect_attempt(10),
-		"attempt 10 should log periodic progress",
+func test_reconnect_transition_logging_uses_time_heartbeat_after_initial_attempts() -> void:
+	assert_false(
+		McpConnection._should_log_reconnect_transition(6, 60_999, 1000),
+		"later transition inside the one-minute heartbeat should stay quiet",
 	)
-	assert_false(McpConnection._should_log_reconnect_attempt(11), "attempt 11 should be quiet again")
 	assert_true(
-		McpConnection._should_log_reconnect_attempt(20),
-		"attempt 20 should log periodic progress",
+		McpConnection._should_log_reconnect_transition(6, 61_000, 1000),
+		"later transition should log after one minute regardless of attempt number",
 	)
+	assert_true(McpConnection._should_log_reconnect_transition(99, 1, -1),
+		"the first observed transition should always be visible")
 
 
-func test_close_diagnostic_distinguishes_preopen_failure_and_reason() -> void:
-	var preopen := McpConnection._close_diagnostic(
-		false,
+func test_transport_snapshot_distinguishes_connecting_retrying_closing_and_open() -> void:
+	var connecting := McpConnection._transport_status_snapshot(
+		WebSocketPeer.STATE_CONNECTING, 12.5, 3, 0.0)
+	assert_eq(connecting.get("phase"), "connecting")
+	assert_eq(connecting.get("attempt"), 3)
+	assert_eq(connecting.get("state_elapsed_sec"), 12.5)
+	assert_false(connecting.has("retry_in_sec"),
+		"an in-flight connection must not advertise a scheduled retry")
+
+	var retrying := McpConnection._transport_status_snapshot(
+		WebSocketPeer.STATE_CLOSED, 0.25, 3, 4.5)
+	assert_eq(retrying.get("phase"), "retrying")
+	assert_eq(retrying.get("retry_in_sec"), 4.5)
+
+	var closing := McpConnection._transport_status_snapshot(
+		WebSocketPeer.STATE_CLOSING, 1.0, 3, 4.5)
+	assert_eq(closing.get("phase"), "closing")
+	assert_false(closing.has("retry_in_sec"))
+
+	var connected := McpConnection._transport_status_snapshot(
+		WebSocketPeer.STATE_OPEN, 30.0, 0, 4.5)
+	assert_eq(connected.get("phase"), "connected")
+	assert_false(connected.has("retry_in_sec"))
+
+
+func test_transport_status_wrapper_applies_generic_blocked_reason() -> void:
+	var conn := McpConnection.new()
+	conn.connect_blocked = true
+	conn.connect_block_reason = "blocked for test"
+	var snapshot := conn.get_transport_status()
+	assert_eq(snapshot.get("phase"), "blocked")
+	assert_eq(snapshot.get("reason_code"), "connection_blocked")
+	assert_eq(snapshot.get("reason"), "blocked for test")
+	assert_false(snapshot.has("retry_in_sec"))
+	conn.free()
+
+
+func test_reconnect_diagnostics_keep_preopen_and_postopen_failures_distinct() -> void:
+	var preopen := McpConnection._preopen_failure_diagnostic(
+		4,
+		30.25,
+		8.0,
 		-1,
 		"",
 		"ws://127.0.0.1:9500"
 	)
-	assert_contains(preopen, "connection failed before OPEN")
+	assert_contains(preopen, "connection attempt 4 failed before OPEN after 30.3s")
+	assert_contains(preopen, "retrying in 8s")
 	assert_contains(preopen, "code -1")
 	assert_contains(preopen, "reason <none>")
 	assert_contains(preopen, "ws://127.0.0.1:9500")
 
-	var opened := McpConnection._close_diagnostic(
-		true,
+	var opened := McpConnection._postopen_close_diagnostic(
+		3600.0,
 		4003,
 		"auth\nfailed",
 		"ws://127.0.0.1:9500"
 	)
-	assert_contains(opened, "disconnected after OPEN")
+	assert_contains(opened, "connection lost after being open for 3600.0s")
+	assert_contains(opened, "; reconnecting")
 	assert_contains(opened, "code 4003")
 	assert_contains(opened, "reason auth\\nfailed")
+
+	var tokenless := McpConnection._postopen_close_diagnostic(
+		1.0,
+		McpConnection.CLOSE_CODE_AUTH_TOKEN_MISMATCH,
+		"token mismatch",
+		"ws://127.0.0.1:9500",
+		{"occurrence": 2, "recovery_action": "retry_tokenless"},
+	)
+	assert_contains(tokenless, "token-less handshake (rejection 2/2)",
+		"the post-OPEN line must surface the recovery action before the next ack")
 
 
 func test_post_open_close_does_not_emit_preopen_duplicate() -> void:
@@ -356,9 +412,9 @@ func test_post_open_close_does_not_emit_preopen_duplicate() -> void:
 
 	var lines := buffer.get_recent(10)
 	assert_eq(lines.size(), 1, "one CLOSED peer must emit exactly one diagnostic")
-	assert_contains(lines[0], "disconnected after OPEN")
+	assert_contains(lines[0], "connection lost after being open")
 	assert_false(
-		lines[0].contains("connection failed before OPEN"),
+		lines[0].contains("failed before OPEN"),
 		"post-OPEN close must never be relabeled as a pre-OPEN failure"
 	)
 	conn.free()

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -267,6 +267,29 @@ func test_update_status_renders_transport_phase_and_transient_reason() -> void:
 	)
 
 
+func test_update_status_hides_stale_transient_reason_while_connected() -> void:
+	_dock._build_ui()
+	var connection := _ConnectionStub.new()
+	connection.is_connected = true
+	connection.transport_status = {
+		"phase": "connected",
+		"attempt": 0,
+		"state_elapsed_sec": 0.0,
+		"reason": "Previous peer rejected the editor auth token.",
+	}
+	_dock._connection = connection
+	_dock._startup_grace_until_msec = 0
+
+	_dock._update_status()
+
+	assert_eq(_dock._status_label.text, "Server connected")
+	assert_eq(
+		_dock._status_label.tooltip_text,
+		"",
+		"an OPEN connection must not show the previous peer's transient reason",
+	)
+
+
 func test_empty_client_cta_visible_only_until_a_client_is_configured() -> void:
 	_dock._build_ui()
 	_dock._last_client_status_refresh_completed_msec = 0

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -68,6 +68,10 @@ class _RefreshCountingDock extends McpDockScript:
 class _ConnectionStub:
 	var is_connected := true
 	var server_version := ""
+	var transport_status: Dictionary = {"phase": "connected", "attempt": 0, "state_elapsed_sec": 0.0}
+
+	func get_transport_status() -> Dictionary:
+		return transport_status.duplicate(true)
 
 
 static func _finished_thread_noop() -> void:
@@ -216,6 +220,50 @@ func test_connected_status_stays_compact_across_client_readiness() -> void:
 		_dock._status_label.text,
 		"Server connected",
 		"Connected status should stay compact with multiple configured AI clients",
+	)
+
+
+func test_transport_status_text_distinguishes_each_reconnect_phase() -> void:
+	assert_eq(
+		McpDockScript._transport_status_text({"phase": "connecting", "attempt": 3}),
+		"Connecting — attempt 3",
+	)
+	assert_eq(
+		McpDockScript._transport_status_text(
+			{"phase": "retrying", "attempt": 4, "retry_in_sec": 2.1}
+		),
+		"Retrying in 3s — attempt 4",
+	)
+	assert_eq(
+		McpDockScript._transport_status_text({"phase": "closing", "attempt": 4}),
+		"Disconnecting…",
+	)
+	assert_eq(
+		McpDockScript._transport_status_text({"phase": "blocked", "attempt": 4}),
+		"Connection blocked",
+	)
+
+
+func test_update_status_renders_transport_phase_and_transient_reason() -> void:
+	_dock._build_ui()
+	var connection := _ConnectionStub.new()
+	connection.is_connected = false
+	connection.transport_status = {
+		"phase": "connecting",
+		"attempt": 2,
+		"state_elapsed_sec": 10.0,
+		"reason": "Server rejected the editor auth token.",
+	}
+	_dock._connection = connection
+	_dock._startup_grace_until_msec = 0
+
+	_dock._update_status()
+
+	assert_eq(_dock._status_label.text, "Connecting — attempt 2")
+	assert_eq(
+		_dock._status_label.tooltip_text,
+		"Server rejected the editor auth token.",
+		"the compact primary label should keep transient detail in its tooltip",
 	)
 
 


### PR DESCRIPTION
## Summary

Closes #846.

Expose the editor WebSocket’s actual transport phase through one shared, pull-based status snapshot consumed by reconnect logging and the Godot AI dock.

This corrects the existing presentation where starting a potentially long `STATE_CONNECTING` attempt was logged as though the next retry were already scheduled. Reconnect timing and backend ownership behavior are unchanged.

## What changed

### Shared transport snapshot

`McpConnection` now reports:

- `connected`
- `connecting`
- `retrying`
- `closing`
- generic `blocked`

The snapshot includes the current attempt and elapsed time in the transport state. `retry_in_sec` exists only during closed-state backoff; it is absent during connecting, connected, closing, and blocked states.

The pure snapshot calculation accepts injected state, elapsed time, attempt number, and timer values, so the contract can be tested without waiting on a live socket or assuming a platform-specific WebSocket timeout.

Lifecycle state remains authoritative for specific terminal diagnoses such as incompatible servers, foreign port occupants, excluded ports, and missing commands. The connection layer exposes only a generic blocked state and reason.

### State-aware reconnect logging

Reconnect logs now distinguish:

- an attempt that failed before reaching OPEN
- an established connection that was later lost
- an active connection attempt
- closed-state retry backoff
- a terminal blocked state

Examples include:

- `connection attempt N failed before OPEN after Xs; retrying in Ys`
- `connection lost after being open for Xs (...); reconnecting`
- `connecting to server (attempt N)`

The old first-five/every-tenth-attempt throttle is replaced with a time-aware heartbeat. Initial attempts remain visible, established-connection loss is always surfaced, and later reconnect transition summaries are limited to one per minute.

### Authentication fallback diagnostics

The existing two-strike `4003` recovery behavior is unchanged but now exposes structured transition metadata:

- `reason_code: auth_token_mismatch`
- `occurrence: 1 | 2`
- `recovery_action: retry_authenticated | retry_tokenless`

The first rejection keeps the token for one server-swap race retry. The second drops it for a tokenless handshake. Transient recovery details are cleared after a successful handshake.

### Dock presentation

The dock consumes the same snapshot through its existing update path and renders:

- `Server connected`
- `Connecting — attempt N`
- `Retrying in Xs — attempt N`
- `Disconnecting…`
- generic connection-blocked fallback

Detailed transient reasons appear in the status tooltip. Existing lifecycle-specific terminal labels continue to take precedence.

The snapshot call is guarded with `has_method("get_transport_status")` so a hot-reloaded dock remains compatible with an older live connection instance during plugin self-update.

## Scope

This is an observability change only. It does not change:

- reconnect delays or retry policy
- WebSocket connection timeouts
- backend spawning or ownership
- attach leases
- backend-instance or port-occupant monitoring
- response-stream resumption tracked by #823

This implements the **server transport-state half** of #838 step 5. The client-row mode labels—URL, attach bridge, plugin-managed, and externally adopted—remain separate future work. This PR does not mark that broader step complete.

## Verification

- Ruff: clean
- Python: **1,659 passed / 19 skipped**
- `connection`: **51 passed**
- `dock`: **78 passed / 1 skipped**
- Full normal-display GDScript run: **2,080 passed / 21 skipped / 1 known unrelated failure**

The full-run failure is the existing `test_reimport_mixed_batch_splits_the_report` filesystem instability in code untouched by this PR.

A separate headless run reported **2,068 passed / 34 skipped / 0 failed**. Its additional skips were 11 editor screenshot tests and two game-helper viewport-readback tests gated by unavailable headless rendering. The filesystem test passed in that run. The normal-display result above is used as the primary full-suite result so the known failure is reported explicitly.

The worktree plugin also loaded, connected to the live backend, and serviced test and tool calls successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer connection status reporting for connecting, retrying, closing, blocked, and open states.
  * Added retry timing, attempt details, elapsed state duration, and transient failure information.
  * Improved authentication-token mismatch recovery with automatic retry and tokenless fallback.

* **Bug Fixes**
  * Improved diagnostics for connection failures and unexpected closures.
  * Reduced repetitive reconnect logging while preserving initial and periodic updates.

* **Tests**
  * Added coverage for transport states, recovery behavior, diagnostics, and status display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->