### PR TITLE
Survive an in-session self-update without the error wall

### DIFF
--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -328,6 +328,8 @@ static func client_display_name(id: String) -> String:
 ## Empty defaults to the live server URL — appropriate for MCP-tool callers
 ## that always run on main.
 static func configure(id: String, url: String = "", launch_context: Dictionary = {}) -> Dictionary:
+	if ClientRegistry.stale_session_detected():
+		return {"status": "error", "message": ClientRegistry.RESTART_TO_FINISH_UPDATE}
 	var client := ClientRegistry.get_by_id(id)
 	if client == null:
 		return {"status": "error", "message": "Unknown client: %s" % id}
@@ -362,6 +364,8 @@ static func configure(id: String, url: String = "", launch_context: Dictionary =
 
 
 static func check_status(id: String) -> Client.Status:
+	if ClientRegistry.stale_session_detected():
+		return Client.Status.ERROR
 	var client := ClientRegistry.get_by_id(id)
 	if client == null:
 		return Client.Status.NOT_CONFIGURED
@@ -387,6 +391,10 @@ static func check_status_details_for_url_with_cli_path(
 	launch_context: Dictionary = {},
 	resolved_launch: Dictionary = {},
 ) -> Dictionary:
+	## One comprehensible line per row beats a wall of per-field type errors —
+	## the dock keeps painting, every row names the same repair (restart).
+	if ClientRegistry.stale_session_detected():
+		return {"status": Client.Status.ERROR, "error_msg": ClientRegistry.RESTART_TO_FINISH_UPDATE}
 	var client := ClientRegistry.get_by_id(id)
 	if client == null:
 		return {"status": Client.Status.NOT_CONFIGURED, "error_msg": ""}
@@ -423,9 +431,12 @@ static func warm_env_snapshot() -> void:
 		var client := ClientRegistry.get_by_id(String(id))
 		if client == null:
 			continue
-		for env_name in [client.config_file_env, client.config_home_env]:
-			if not String(env_name).is_empty() and not extras.has(String(env_name)):
-				extras.append(String(env_name))
+		## Reflected get(): after an in-session self-update these fields can
+		## read as Nil on stale instances, and String(Nil) is a hard error (#850). Skipping just degrades env-override
+		## resolution until the restart the registry is already asking for.
+		for env_name in [client.get("config_file_env"), client.get("config_home_env")]:
+			if env_name is String and not env_name.is_empty() and not extras.has(env_name):
+				extras.append(env_name)
 	McpPathTemplate.warm_env_snapshot(extras)
 	_editor_setting_lookup(MODE_OVERRIDE_SETTING)
 	_editor_setting_lookup(SETTING_STARTUP_TRACE)
@@ -520,6 +531,8 @@ static func _client_status_sweep_entry(
 ## `configure()` above for why. The url is only used to format the
 ## verify-after-write diagnostic message; the remove itself doesn't need it.
 static func remove(id: String, url: String = "", launch_context: Dictionary = {}) -> Dictionary:
+	if ClientRegistry.stale_session_detected():
+		return {"status": "error", "message": ClientRegistry.RESTART_TO_FINISH_UPDATE}
 	var client := ClientRegistry.get_by_id(id)
 	if client == null:
 		return {"status": "error", "message": "Unknown client: %s" % id}

--- a/plugin/addons/godot_ai/clients/_base.gd
+++ b/plugin/addons/godot_ai/clients/_base.gd
@@ -238,6 +238,17 @@ func resolved_config_path() -> String:
 ## is empty for ordinary unsupported/missing path mappings to preserve the
 ## long-standing status behavior for clients not installed on this platform.
 func resolved_config_path_details() -> Dictionary:
+	## Reflected reads: after an in-session self-update, an instance created
+	## before the update can answer Nil for vars the update added, and the
+	## typed calls below would each hard-error (Nil -> Dictionary, #850's
+	## per-row error wall). Fail with the
+	## one repair message instead; the registry's coherence probe drives the
+	## same text on the status path.
+	var candidates: Variant = get("config_path_candidates")
+	var template: Variant = get("path_template")
+	var file_env: Variant = get("config_file_env")
+	if not (candidates is Dictionary) or not (template is Dictionary) or not (file_env is String):
+		return {"path": "", "error": McpClientRegistry.RESTART_TO_FINISH_UPDATE}
 	var file_override := config_file_override_details()
 	if not str(file_override.get("path", "")).is_empty() or not str(file_override.get("error", "")).is_empty():
 		_clear_config_path_warning()
@@ -246,11 +257,11 @@ func resolved_config_path_details() -> Dictionary:
 	if not override.is_empty():
 		_clear_config_path_warning()
 		return {"path": override, "error": ""}
-	var candidate_key := McpPathTemplate.platform_key(config_path_candidates)
+	var candidate_key := McpPathTemplate.platform_key(candidates)
 	if not candidate_key.is_empty():
-		return _resolve_ordered_config_path_candidates(config_path_candidates[candidate_key])
+		return _resolve_ordered_config_path_candidates(candidates[candidate_key])
 	_clear_config_path_warning()
-	return {"path": McpPathTemplate.resolve(path_template), "error": ""}
+	return {"path": McpPathTemplate.resolve(template), "error": ""}
 
 
 ## The exact-file env override plus any fail-closed diagnostic. Empty path and

--- a/plugin/addons/godot_ai/clients/_registry.gd
+++ b/plugin/addons/godot_ai/clients/_registry.gd
@@ -44,6 +44,17 @@ static var _by_id: Dictionary = {}
 ## serialize the one-time load so a racing thread can never observe a
 ## half-built registry. load() itself is thread-safe via ResourceLoader.
 static var _load_mutex := Mutex.new()
+## True when even a fresh rebuild yields instances missing base-schema
+## fields — the deep stale-script state after an in-session self-update
+## (#850; docs/releasing.md release-shape rules). Only an editor restart
+## heals it; callers surface RESTART_TO_FINISH_UPDATE instead of erroring
+## per client. Never reset within a session: rebuilding again cannot help,
+## it would only repeat the load work and warning on every dock sweep.
+static var _stale_session := false
+
+const RESTART_TO_FINISH_UPDATE := (
+	"Godot AI was updated in this editor session. Restart the editor to finish the update."
+)
 
 
 static func all() -> Array[McpClient]:
@@ -68,12 +79,52 @@ static func has_id(id: String) -> bool:
 	return _by_id.has(id)
 
 
+## True when this editor session is running a self-update whose script
+## reloads left descriptor state unusable. Client operations short-circuit
+## with RESTART_TO_FINISH_UPDATE rather than spamming per-field errors.
+static func stale_session_detected() -> bool:
+	_ensure_loaded()
+	return _stale_session
+
+
+## An instance is coherent when fields added to the CURRENT McpClient schema
+## read back with their declared types. After an in-session self-update,
+## hot-patched or pre-update instances answer Nil for vars the update added
+## (#850: `config_path_candidates` and
+## `config_file_env` read as Nil, crashing platform_key / String()). The
+## reflected `get()` avoids typed-access errors on such instances.
+static func _instance_is_coherent(inst: Object) -> bool:
+	if inst == null:
+		return false
+	return (
+		inst.get("config_path_candidates") is Dictionary
+		and inst.get("config_file_env") is String
+		and inst.get("path_template") is Dictionary
+	)
+
+
+static func _cache_is_coherent() -> bool:
+	return not _instances.is_empty() and _instance_is_coherent(_instances[0])
+
+
 static func _ensure_loaded() -> void:
-	if not _instances.is_empty():
+	if _stale_session:
+		return
+	if _cache_is_coherent():
 		return
 	_load_mutex.lock()
-	if _instances.is_empty():
+	## Re-check under the lock: another thread may have rebuilt (or concluded
+	## staleness) while this one waited.
+	if not _stale_session and not _cache_is_coherent():
+		## Covers both the first load and the post-self-update rebuild: this
+		## registry file can survive an update unchanged, so its statics keep
+		## serving pre-update instances to freshly reloaded callers. A rebuild
+		## instantiates from the reloaded descriptor scripts, which repairs
+		## every case except a stale base Script object itself.
 		_load()
+		if not _instances.is_empty() and not _cache_is_coherent():
+			_stale_session = true
+			push_warning("MCP | %s" % RESTART_TO_FINISH_UPDATE)
 	_load_mutex.unlock()
 
 

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -503,17 +503,25 @@ static func _incompatible_server_message(
 	## walking the process tree. See #416.
 	var package_path := _live_package_path_for_message(live)
 	var path_suffix := " (loaded from %s)" % package_path if not package_path.is_empty() else ""
+	## After a plugin update, the usual occupant is a backend kept alive by
+	## AI-client attach bridges still pinned to the previous version (their
+	## leases outrank us — #669/#839, we must not kill it). Name that repair
+	## first; "stop the old server" alone reads as a dead end when the server
+	## respawns the moment the user kills it.
+	var repair := (
+		"If AI clients launched it, run Configure all and restart those apps — "
+		+ "the old server exits on its own. Otherwise stop it manually or "
+		+ "change both HTTP and WS ports."
+	)
 	if not version.is_empty():
 		if actual_ws_port > 0 and actual_ws_port != expected_ws_port:
 			return (
 				"Port %d is occupied by godot-ai server v%s using WS port %d%s; "
-				+ "plugin expects v%s with WS port %d. Stop the old server or "
-				+ "change both HTTP and WS ports."
-			) % [port, version, actual_ws_port, path_suffix, expected_version, expected_ws_port]
+				+ "plugin expects v%s with WS port %d. %s"
+			) % [port, version, actual_ws_port, path_suffix, expected_version, expected_ws_port, repair]
 		return (
-			"Port %d is occupied by godot-ai server v%s%s; plugin expects v%s. "
-			+ "Stop the old server or change both HTTP and WS ports."
-		) % [port, version, path_suffix, expected_version]
+			"Port %d is occupied by godot-ai server v%s%s; plugin expects v%s. %s"
+		) % [port, version, path_suffix, expected_version, repair]
 	var status_code := int(live.get("status_code", 0))
 	if status_code > 0:
 		return (

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -509,9 +509,9 @@ static func _incompatible_server_message(
 	## first; "stop the old server" alone reads as a dead end when the server
 	## respawns the moment the user kills it.
 	var repair := (
-		"If AI clients launched it, run Configure all and restart those apps — "
-		+ "the old server exits on its own. Otherwise stop it manually or "
-		+ "change both HTTP and WS ports."
+		"If AI-client attach bridges are keeping it alive, run Configure all to "
+		+ "repin them, then restart those client apps — the old server exits on "
+		+ "its own. Otherwise stop it manually or change both HTTP and WS ports."
 	)
 	if not version.is_empty():
 		if actual_ws_port > 0 and actual_ws_port != expected_ws_port:

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -1378,6 +1378,31 @@ func test_config_file_env_configure_status_remove_and_manual_use_exact_file() ->
 	assert_eq(post_remove, McpClient.Status.NOT_CONFIGURED)
 
 
+func test_registry_stale_session_probe_and_gate() -> void:
+	## #850: an in-session self-update can leave descriptor instances answering
+	## Nil for vars the update added. The registry's coherence probe detects
+	## that; a consistent checkout must never trip it, and an object without
+	## the current schema must.
+	assert_false(
+		McpClientRegistry.stale_session_detected(),
+		"a consistent session must not report a stale update"
+	)
+	assert_true(
+		McpClientRegistry._instance_is_coherent(McpClientRegistry.get_by_id("claude_desktop")),
+		"a freshly loaded descriptor must read coherent"
+	)
+	assert_false(
+		McpClientRegistry._instance_is_coherent(RefCounted.new()),
+		"an instance missing current-schema fields must read incoherent"
+	)
+	assert_false(McpClientRegistry._instance_is_coherent(null))
+	assert_contains(
+		McpClientRegistry.RESTART_TO_FINISH_UPDATE,
+		"Restart the editor",
+		"the stale-session message must name the one repair"
+	)
+
+
 func test_configure_message_names_the_written_transport() -> void:
 	## The success line must describe the transport that was actually written:
 	## "stdio attach" for command-shape entries, "(HTTP: <url>)" only for

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -1109,9 +1109,12 @@ func test_incompatible_server_message_names_actual_version_when_discoverable() -
 	assert_contains(message, "plugin expects v2.2.0")
 	assert_contains(message, "change both HTTP and WS ports")
 	## The usual occupant after a plugin update is a backend kept alive by
-	## attach-bridge leases; the message must name the repair that actually
-	## works (repin + restart clients), not just "stop the old server".
+	## attach-bridge leases; the message must name the full repair that
+	## actually works — repin AND restart the client apps — not just "stop
+	## the old server", which the bridges would undo by respawning it.
 	assert_contains(message, "Configure all")
+	assert_contains(message, "repin")
+	assert_contains(message, "restart those client apps")
 
 
 func test_incompatible_server_message_names_ws_port_mismatch() -> void:

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -1108,6 +1108,10 @@ func test_incompatible_server_message_names_actual_version_when_discoverable() -
 	assert_contains(message, "Port 8000 is occupied by godot-ai server v1.2.10")
 	assert_contains(message, "plugin expects v2.2.0")
 	assert_contains(message, "change both HTTP and WS ports")
+	## The usual occupant after a plugin update is a backend kept alive by
+	## attach-bridge leases; the message must name the repair that actually
+	## works (repin + restart clients), not just "stop the old server".
+	assert_contains(message, "Configure all")
 
 
 func test_incompatible_server_message_names_ws_port_mismatch() -> void:


### PR DESCRIPTION
## Summary

Closes #850 — the 3.1.0 field regression reported on Discord within minutes of release: an editor that self-updates in-session spams `Nil to Dictionary` / `Invalid String constructor` errors and shows a broken Clients dock until restarted.

Three layers, shallowest first:

- **Registry coherence probe + rebuild** — `_registry.gd` survives most updates unchanged, so its statics kept serving pre-update descriptor instances to freshly reloaded code. The registry now probes a cached instance for current-schema fields (reflected reads) and rebuilds from the reloaded scripts when the probe fails. This alone repairs the survived-statics case.
- **Stale-session gate** — if even a rebuild yields incoherent instances (stale base Script object, the deep case in docs/releasing.md), the session is flagged once and every client operation returns one calm message: *"Godot AI was updated in this editor session. Restart the editor to finish the update."* No more per-field red wall.
- **Crash-site guards** — `warm_env_snapshot` and `resolved_config_path_details` read the update-added fields via reflected `get()` with type checks and fail soft.

Also: the version-skew port-occupied message now leads with the repair that actually works after the #849 attach rollout (*"run Configure all and restart those apps — the old server exits on its own"*) — "stop the old server" alone is a dead end when attach-bridge leases respawn it.

## Verification

- Full GDScript suite live on Windows: **2098 passed / 0 failed** (65 suites), including new registry-probe and message tests; harness pytest 11/11; ruff clean.
- **`script/local-self-update-smoke --base-from-release-tag v3.0.7`** — the exact field scenario, real 3.0.7 base updating in-session to this branch, maintainer-clicked: every check PASS, and the post-update session log shows zero script errors where 3.1.0 produced the wall.

Related: #851 (console flash on cold uvx installs) stays open as its own verified-fix follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of stale client sessions and incompatible configurations.
  * Operations now show a clear restart-required message instead of failing unexpectedly.
  * Environment and path configuration handling is more resilient to missing or outdated values.
  * Updated incompatible-server guidance to recommend configuring all ports, refreshing connections, and restarting AI clients.

* **Tests**
  * Added regression coverage for stale sessions, incomplete configurations, and lifecycle remediation messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->