### PR TITLE
feat: Vision Routing - route screenshot tool through vision APIs for text-only models

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -30,7 +30,7 @@ not the MCP tool names.
 | `project_run` | Play the project, then wait briefly for game liveness (autosave persists in-memory MCP edits unless `autosave=False`) |
 | `test_run` | Run GDScript test suites in the editor — see [testing.md](testing.md) for writing suites and the `McpTestSuite` API |
 | `logs_read` | Read plugin / game / editor / combined log buffers. `source="editor"` surfaces parse errors, GDScript reload warnings, @tool/EditorPlugin runtime errors, push_error/push_warning, and visible Debugger dock Errors-tab rows — use this when the editor's Output or Debugger Errors panel shows red/yellow rows |
-| `editor_screenshot` | Capture the editor 3D viewport (`viewport`), editor 2D viewport (`viewport_2d`), cinematic Camera3D render (`cinematic`), or running game framebuffer (`game`) |
+| `editor_screenshot` | Capture the editor 3D viewport (`viewport`), editor 2D viewport (`viewport_2d`), cinematic Camera3D render (`cinematic`), or running game framebuffer (`game`). With Vision Routing enabled, images are replaced by a text description (`vision_description` / `routed_via`) - see [vision-routing.md](vision-routing.md) |
 | `editor_reload_plugin` | Reload the plugin and wait for reconnect (works with external and plugin-managed servers) |
 | `animation_create` | Create an Animation clip (auto-creates AnimationPlayer + library if missing) |
 

--- a/docs/vision-routing.md
+++ b/docs/vision-routing.md
@@ -1,0 +1,83 @@
+# Vision Routing
+
+Vision Routing lets models without image support (e.g. DeepSeek) still "see"
+the editor and the running game. When enabled, every capture made through the
+`editor_screenshot` tool is sent to Groq's free vision API on a worker thread,
+and the resulting **text description** is returned to the AI instead of the raw
+image.
+
+The feature is implemented natively in the plugin (`vision_routing.gd`) and is
+off by default. It is opt-in per editor installation; the enabled flag and the
+API key live in **Editor Settings**, so they are not committed with the
+project.
+
+## Why
+
+Most MCP clients used with godot-ai can consume image blocks. Some cannot
+(DeepSeek and other text-only models reject or ignore them). With routing on,
+the screenshot tool stays useful for those models: the image is replaced by a
+tiny 2x2 placeholder, and the description is delivered as text metadata
+(`vision_description`, plus a `note` that the server forwards into the tool
+result's text block).
+
+## How it works
+
+1. The AI calls `editor_screenshot` (any `source`).
+2. The plugin captures the frame exactly as before.
+3. If routing is enabled, the image is sent to
+   `qwen/qwen3.6-27b` on Groq (free tier) on a background thread - the editor
+   main thread never blocks.
+4. The response is deferred until the description is ready; the payload the
+   model receives contains:
+   - `vision_description`: the Groq description.
+   - `note`: the description (plus any pre-existing note, e.g. stale-frame).
+   - `routed_via`: the model id, so the client knows the capture was routed.
+   - `image_base64`: a 2x2 transparent placeholder PNG (kept so the payload
+     stays well-formed; the server omits the image block for routed captures).
+5. Any failure (missing key, network error, API error) passes the **original
+   image through unchanged** - the screenshot tool never breaks.
+
+The same flow applies to editor viewport / cinematic / 2D captures and to
+running-game captures (`source="game"`, which are intercepted in the debugger
+plugin).
+
+Coverage sweeps (`coverage=true`, multiple images) are passed through
+untouched - routing applies to single-image captures.
+
+## Setup
+
+1. Open the Godot AI dock -> **Clients & Tools** -> **Vision Routing** tab.
+2. Toggle **Enable routing** on.
+3. Paste a Groq API key (free tier: <https://console.groq.com>). The key is
+   stored encrypted (AES-256-CBC, key derived from this machine) in Editor
+   Settings - not plain text, but local obfuscation only. Alternatively set
+   the `GROQ_API_KEY` environment variable; it takes priority over the stored
+   key.
+4. Press **Test connection** to verify the key works.
+
+A quick **Vision Routing** toggle also sits in the dock right under
+**Developer mode**, so you can flip routing on/off without opening the settings
+window (e.g. when you switch from a text-only model to one that analyzes
+images itself).
+
+## Notes
+
+- The Groq call adds ~1-2s to each screenshot while routing is enabled.
+- Screenshots are downscaled to at most 1024px on the longest edge before
+  being sent to Groq.
+- If you stop using a key that was typed into the settings window, consider
+  rotating it in the Groq console - an encrypted-at-rest key is still local
+  obfuscation, not a secret vault.
+- Routing only applies when the connected model is expected to be text-only;
+  keep it off for image-capable models to avoid the extra hop.
+
+## Developer notes
+
+- `plugin/addons/godot_ai/vision_routing.gd` - routing core, Groq worker,
+  encrypted key storage, UI construction.
+- Hook points: `editor_handler.gd::take_screenshot` (editor captures) and
+  `mcp_debugger_plugin.gd::_on_screenshot_response` (game captures).
+- Server-side metadata forwarding: `src/godot_ai/handlers/editor.py`.
+- Tests: `tests/unit/test_runtime_handlers.py` (routed metadata + image-block
+  omission) and `test_project/tests/test_vision_routing.gd` (key storage,
+  prompt, deferred-reply conversion).

--- a/docs/vision-routing.md
+++ b/docs/vision-routing.md
@@ -2,7 +2,7 @@
 
 Vision Routing lets models without image support (e.g. DeepSeek) still "see"
 the editor and the running game. When enabled, every capture made through the
-`editor_screenshot` tool is sent to Groq's free vision API on a worker thread,
+`editor_screenshot` tool is sent to a curated vision model on a worker thread,
 and the resulting **text description** is returned to the AI instead of the raw
 image.
 
@@ -10,6 +10,23 @@ The feature is implemented natively in the plugin (`vision_routing.gd`) and is
 off by default. It is opt-in per editor installation; the enabled flag and the
 API key live in **Editor Settings**, so they are not committed with the
 project.
+
+## Providers
+
+The provider and its model are **curated** - the model id is fixed per provider
+and shown in brackets in the Provider dropdown, so switching providers can
+never silently call the wrong model:
+
+| Provider | Model | Dialect | Free tier |
+| --- | --- | --- | --- |
+| Groq | `qwen/qwen3.6-27b` | OpenAI chat-completions | Yes |
+| Google Gemini | `gemini-2.5-flash` | generateContent (REST) | Yes (AI Studio key) |
+| xAI Grok | `grok-2-vision-latest` | OpenAI chat-completions | No (paid) |
+
+Each provider has its own encrypted key slot and its own environment-variable
+override: `GROQ_API_KEY`, `GOOGLE_API_KEY` and `XAI_API_KEY`. The environment
+variable always takes priority over the stored key. Changing the provider in
+the dropdown switches the key field to that provider's stored key.
 
 ## Why
 
@@ -24,14 +41,15 @@ result's text block).
 
 1. The AI calls `editor_screenshot` (any `source`).
 2. The plugin captures the frame exactly as before.
-3. If routing is enabled, the image is sent to
-   `qwen/qwen3.6-27b` on Groq (free tier) on a background thread - the editor
-   main thread never blocks.
+3. If routing is enabled, the image is sent to the selected provider's model
+   (see [Providers](#providers)) on a background thread - the editor main
+   thread never blocks.
 4. The response is deferred until the description is ready; the payload the
    model receives contains:
-   - `vision_description`: the Groq description.
+   - `vision_description`: the text description.
    - `note`: the description (plus any pre-existing note, e.g. stale-frame).
-   - `routed_via`: the model id, so the client knows the capture was routed.
+   - `routed_via`: `provider:model` (e.g. `groq:qwen/qwen3.6-27b`), so the
+     client knows the capture was routed and by which model.
    - `image_base64`: a 2x2 transparent placeholder PNG (kept so the payload
      stays well-formed; the server omits the image block for routed captures).
 5. Any failure (missing key, network error, API error) passes the **original
@@ -48,12 +66,15 @@ untouched - routing applies to single-image captures.
 
 1. Open the Godot AI dock -> **Clients & Tools** -> **Vision Routing** tab.
 2. Toggle **Enable routing** on.
-3. Paste a Groq API key (free tier: <https://console.groq.com>). The key is
-   stored encrypted (AES-256-CBC, key derived from this machine) in Editor
-   Settings - not plain text, but local obfuscation only. Alternatively set
-   the `GROQ_API_KEY` environment variable; it takes priority over the stored
-   key.
-4. Press **Test connection** to verify the key works.
+3. Pick a provider in the **Provider** dropdown (the model it will use is
+   shown in brackets, e.g. `Google Gemini (gemini-2.5-flash)`).
+4. Paste the key for that provider (Groq: <https://console.groq.com>, Google:
+   <https://aistudio.google.com>, xAI: <https://console.x.ai>). Each provider
+   keeps its own key slot. Keys are stored encrypted (AES-256-CBC, key derived
+   from this machine) in Editor Settings - not plain text, but local
+   obfuscation only. Alternatively set `GROQ_API_KEY`, `GOOGLE_API_KEY` or
+   `XAI_API_KEY`; the environment variable takes priority over the stored key.
+5. Press **Test connection** to verify the key works.
 
 A quick **Vision Routing** toggle also sits in the dock right under
 **Developer mode**, so you can flip routing on/off without opening the settings
@@ -62,19 +83,21 @@ images itself).
 
 ## Notes
 
-- The Groq call adds ~1-2s to each screenshot while routing is enabled.
+- The vision call adds ~1-2s to each screenshot while routing is enabled.
 - Screenshots are downscaled to at most 1024px on the longest edge before
-  being sent to Groq.
+  being sent to the provider.
 - If you stop using a key that was typed into the settings window, consider
-  rotating it in the Groq console - an encrypted-at-rest key is still local
-  obfuscation, not a secret vault.
+  rotating it in the provider console - an encrypted-at-rest key is still
+  local obfuscation, not a secret vault.
 - Routing only applies when the connected model is expected to be text-only;
   keep it off for image-capable models to avoid the extra hop.
 
 ## Developer notes
 
-- `plugin/addons/godot_ai/vision_routing.gd` - routing core, Groq worker,
-  encrypted key storage, UI construction.
+- `plugin/addons/godot_ai/vision_routing.gd` - routing core, per-provider
+  workers (OpenAI chat-completions + Gemini generateContent dialects),
+  encrypted key storage, UI construction. The `PROVIDERS` constant is the
+  single place where provider/model pairs are curated.
 - Hook points: `editor_handler.gd::take_screenshot` (editor captures) and
   `mcp_debugger_plugin.gd::_on_screenshot_response` (game captures).
 - Server-side metadata forwarding: `src/godot_ai/handlers/editor.py`.

--- a/docs/vision-routing.md
+++ b/docs/vision-routing.md
@@ -1,7 +1,7 @@
 # Vision Routing
 
 Vision Routing lets models without image support (e.g. DeepSeek) still "see"
-the editor and the running game. When enabled, every capture made through the
+the editor and the running game. When enabled, every single-image capture made through the
 `editor_screenshot` tool is sent to a curated vision model on a worker thread,
 and the resulting **text description** is returned to the AI instead of the raw
 image.
@@ -21,7 +21,7 @@ never silently call the wrong model:
 | --- | --- | --- | --- |
 | Groq | `qwen/qwen3.6-27b` | OpenAI chat-completions | Yes |
 | Google Gemini | `gemini-2.5-flash` | generateContent (REST) | Yes (AI Studio key) |
-| xAI Grok | `grok-2-vision-latest` | OpenAI chat-completions | No (paid) |
+| xAI Grok | `grok-4.5` | OpenAI chat-completions | No (paid) |
 
 Each provider has its own encrypted key slot and its own environment-variable
 override: `GROQ_API_KEY`, `GOOGLE_API_KEY` and `XAI_API_KEY`. The environment

--- a/docs/vision-routing.md
+++ b/docs/vision-routing.md
@@ -13,20 +13,28 @@ project.
 
 ## Providers
 
-The provider and its model are **curated** - the model id is fixed per provider
-and shown in brackets in the Provider dropdown, so switching providers can
-never silently call the wrong model:
+The provider itself is **curated** - label, API dialect, endpoint shape,
+environment variable and encrypted key slot are fixed in the `PROVIDERS`
+table. The **model id is not**: third-party model ids retire, and only the
+account holder gets notified when one does, so the model is a required
+per-provider field you enter next to the key. Switching providers switches to
+that provider's entered model - the software never guesses a model name.
 
-| Provider | Model | Dialect | Free tier |
+Suggestions that were verified working **as of 2026-08** (always check your
+provider console for current ids; a provider's model *listing* API still
+advertises retired ids - only a real call proves serviceability):
+
+| Provider | Dialect | Suggested model | Free tier |
 | --- | --- | --- | --- |
-| Groq | `qwen/qwen3.6-27b` | OpenAI chat-completions | Yes |
-| Google Gemini | `gemini-2.5-flash` | generateContent (REST) | Yes (AI Studio key) |
-| xAI Grok | `grok-4.5` | OpenAI chat-completions | No (paid) |
+| Groq | OpenAI chat-completions | `qwen/qwen3.6-27b` | Yes |
+| Google Gemini | generateContent (REST) | `gemini-flash-latest` (or `gemini-3-flash-preview`) | Yes (AI Studio key) |
+| xAI Grok | OpenAI chat-completions | `grok-4.5` | No (paid) |
 
-Each provider has its own encrypted key slot and its own environment-variable
-override: `GROQ_API_KEY`, `GOOGLE_API_KEY` and `XAI_API_KEY`. The environment
-variable always takes priority over the stored key. Changing the provider in
-the dropdown switches the key field to that provider's stored key.
+Each provider has its own encrypted key slot, its own model-id slot and its
+own environment-variable override for the key: `GROQ_API_KEY`,
+`GOOGLE_API_KEY` and `XAI_API_KEY`. The environment variable always takes
+priority over the stored key. Changing the provider in the dropdown switches
+the key and model fields to that provider's stored values.
 
 ## Why
 
@@ -50,12 +58,16 @@ result's text block).
    model receives contains:
    - `vision_description`: the text description.
    - `note`: the description (plus any pre-existing note, e.g. stale-frame).
-   - `routed_via`: `provider:model` (e.g. `groq:qwen/qwen3.6-27b`), so the
-     client knows the capture was routed and by which model.
+   - `routed_via`: `provider:<entered model>` (e.g.
+     `groq:qwen/qwen3.6-27b`), so the client knows the capture was routed and
+     by which model.
    - `image_base64`: a 2x2 transparent placeholder PNG (kept so the payload
      stays well-formed; the server omits the image block for routed captures).
-5. Any failure (missing key, network error, API error) passes the **original
-   image through unchanged** - the screenshot tool never breaks.
+5. Any failure (missing key, missing model id, network error, API error)
+   passes the **original image through unchanged**, with a short
+   "Vision routing unavailable (provider): reason" note appended so text-only
+   agents learn the feature is down and why - the screenshot tool never
+   breaks.
 
 The same flow applies to editor viewport / cinematic / 2D captures and to
 running-game captures (`source="game"`, which are intercepted in the debugger
@@ -66,22 +78,22 @@ untouched - routing applies to single-image captures.
 
 ## Setup
 
-1. Open the Godot AI dock -> **Clients & Tools** -> **Vision Routing** tab.
-2. Toggle **Enable routing** on.
-3. Pick a provider in the **Provider** dropdown (the model it will use is
-   shown in brackets, e.g. `Google Gemini (gemini-2.5-flash)`).
-4. Paste the key for that provider (Groq: <https://console.groq.com>, Google:
+1. Open the Godot AI dock -> **Clients & Tools** -> **Settings** tab.
+2. In the **Vision Routing** section, toggle **Enable routing** on.
+3. Pick a provider in the **Provider** dropdown.
+4. Enter the **model id** for that provider (required - see the suggestions
+   above; ids retire, so check your provider console). Empty behaves exactly
+   like an empty key: routing declines and screenshots pass through.
+5. Paste the key for that provider (Groq: <https://console.groq.com>, Google:
    <https://aistudio.google.com>, xAI: <https://console.x.ai>). Each provider
    keeps its own key slot. Keys are stored encrypted (AES-256-CBC, key derived
    from this machine) in Editor Settings - not plain text, but local
    obfuscation only. Alternatively set `GROQ_API_KEY`, `GOOGLE_API_KEY` or
    `XAI_API_KEY`; the environment variable takes priority over the stored key.
-5. Press **Test connection** to verify the key works.
-
-A quick **Vision Routing** toggle also sits in the dock right under
-**Developer mode**, so you can flip routing on/off without opening the settings
-window (e.g. when you switch from a text-only model to one that analyzes
-images itself).
+6. Press **Test connection** - it sends the same image-bearing request as
+   real routing (with the placeholder image), so one click validates key +
+   model existence + image capability. A wrong or retired model id fails
+   loudly right where you entered it.
 
 ## Notes
 
@@ -91,6 +103,11 @@ images itself).
 - If you stop using a key that was typed into the settings window, consider
   rotating it in the provider console - an encrypted-at-rest key is still
   local obfuscation, not a secret vault.
+- The model id is yours to maintain: when a provider retires a model, replace
+  the id in the settings (the provider notifies the account holder - not this
+  repo). A stale id surfaces as a loud `Test connection` failure and as a
+  "Vision routing unavailable" note on routed screenshots, never as a silent
+  wrong-model call.
 - Routing only applies when the connected model is expected to be text-only;
   keep it off for image-capable models to avoid the extra hop.
 - Metadata-only captures (`include_image=false`) are still routed and still
@@ -102,8 +119,9 @@ images itself).
 
 - `plugin/addons/godot_ai/vision_routing.gd` - routing core, per-provider
   workers (OpenAI chat-completions + Gemini generateContent dialects),
-  encrypted key storage, UI construction. The `PROVIDERS` constant is the
-  single place where provider/model pairs are curated.
+  encrypted key storage, per-provider model id, UI construction. The
+  `PROVIDERS` constant curates everything repo-owned (label, dialect,
+  endpoint, env var, setting slots); model ids are user-entered.
 - Hook points: `editor_handler.gd::take_screenshot` (editor captures) and
   `mcp_debugger_plugin.gd::_on_screenshot_response` (game captures).
 - Server-side metadata forwarding: `src/godot_ai/handlers/editor.py`.

--- a/docs/vision-routing.md
+++ b/docs/vision-routing.md
@@ -39,7 +39,9 @@ result's text block).
 
 ## How it works
 
-1. The AI calls `editor_screenshot` (any `source`).
+1. The AI calls `editor_screenshot` (any `source`), optionally passing a
+   `user_prompt` with context that is sent to the vision model alongside the
+   image.
 2. The plugin captures the frame exactly as before.
 3. If routing is enabled, the image is sent to the selected provider's model
    (see [Providers](#providers)) on a background thread - the editor main
@@ -91,6 +93,10 @@ images itself).
   local obfuscation, not a secret vault.
 - Routing only applies when the connected model is expected to be text-only;
   keep it off for image-capable models to avoid the extra hop.
+- Metadata-only captures (`include_image=false`) are still routed and still
+  pay the vision call - for a text-only model that is the point, since the
+  description is what makes the capture readable. Image-capable clients that
+  only want capture metadata should turn routing off.
 
 ## Developer notes
 

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -62,10 +62,13 @@ const EVAL_COMPILE_GRACE_SEC := 3.0
 ## without flooding the channel; most evals reply before the first probe.
 const EVAL_PROBE_INTERVAL_SEC := 0.35
 
+const VisionRoutingScript := preload("res://addons/godot_ai/vision_routing.gd")
+
 var _log_buffer: McpLogBuffer
 var _game_log_buffer: McpGameLogBuffer
 var _editor_log_buffer: McpEditorLogBuffer
 var _surfaced_error_tracker
+var vision_routing: VisionRoutingScript = null
 
 ## Pending request_id -> {connection, timer, timeout_callable}.
 ## We retain the bound timeout lambda so `_clear_pending` can disconnect
@@ -111,11 +114,12 @@ const BREAK_FRAME_SCRAPE_DELAYS_SEC: Array[float] = [0.5, 2.0]
 
 
 
-func _init(log_buffer: McpLogBuffer = null, game_log_buffer: McpGameLogBuffer = null, editor_log_buffer: McpEditorLogBuffer = null, surfaced_error_tracker = null) -> void:
+func _init(log_buffer: McpLogBuffer = null, game_log_buffer: McpGameLogBuffer = null, editor_log_buffer: McpEditorLogBuffer = null, surfaced_error_tracker = null, vision_routing: VisionRoutingScript = null) -> void:
 	_log_buffer = log_buffer
 	_game_log_buffer = game_log_buffer
 	_editor_log_buffer = editor_log_buffer
 	_surfaced_error_tracker = surfaced_error_tracker
+	vision_routing = vision_routing
 
 
 func _has_capture(prefix: String) -> bool:
@@ -858,6 +862,12 @@ func _on_screenshot_response(data: Array) -> void:
 			payload["note"] = ("The game window appears backgrounded or its main loop is "
 				+ "stalled; returning the last rendered frame. Focus the game window and "
 				+ "retry for a current frame.")
+	## Vision Routing: when enabled, describe the frame through Groq on a
+	## worker thread and reply with the text description instead of the raw
+	## image (see vision_routing.gd). The router replies for us in that case.
+	if vision_routing != null and vision_routing.is_routing_enabled():
+		if vision_routing.route_game_payload(connection, request_id, {"data": payload}):
+			return
 	connection.send_deferred_response(request_id, {"data": payload})
 	if _log_buffer:
 		_log_buffer.log("[debug] <- mcp:screenshot_response (%s)" % request_id)

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -119,7 +119,7 @@ func _init(log_buffer: McpLogBuffer = null, game_log_buffer: McpGameLogBuffer = 
 	_game_log_buffer = game_log_buffer
 	_editor_log_buffer = editor_log_buffer
 	_surfaced_error_tracker = surfaced_error_tracker
-	vision_routing = vision_routing
+	self.vision_routing = vision_routing
 
 
 func _has_capture(prefix: String) -> bool:
@@ -862,7 +862,8 @@ func _on_screenshot_response(data: Array) -> void:
 			payload["note"] = ("The game window appears backgrounded or its main loop is "
 				+ "stalled; returning the last rendered frame. Focus the game window and "
 				+ "retry for a current frame.")
-	## Vision Routing: when enabled, describe the frame through Groq on a
+	## Vision Routing: when enabled, describe the frame through the configured
+	## vision provider on a
 	## worker thread and reply with the text description instead of the raw
 	## image (see vision_routing.gd). The router replies for us in that case.
 	if vision_routing != null and vision_routing.is_routing_enabled():

--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -422,25 +422,12 @@ func _compute_coverage_angles(aabb: AABB) -> Array[Dictionary]:
 
 
 func take_screenshot(params: Dictionary) -> Dictionary:
-	## Source guard: mirrors the implementation's own `match source:` dispatch
-	## below and is pinned by tests/unit/test_docs_screenshot_sources.py, so an
-	## unknown source is rejected before the Vision Routing hook can touch it.
-	var source: String = params.get("source", "viewport")
-	match source:
-		"viewport":
-			pass
-		"viewport_2d":
-			pass
-		"cinematic":
-			pass
-		"game":
-			pass
-		_:
-			return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "Invalid source '%s' — use 'viewport', 'viewport_2d', 'cinematic', or 'game'" % source)
-	## Vision Routing hook: when enabled, the capture is described by a vision
-	## model on a worker thread and the text description is returned instead of
-	## the raw image (see vision_routing.gd). Off, no key, or non-image results
-	## keep the original behavior.
+	## Vision Routing hook: when enabled, the capture is described by the
+	## configured vision provider on a worker thread and the text description
+	## is returned instead of the raw image (see vision_routing.gd). Off, no
+	## key, or non-image results keep the original behavior. The single source
+	## of truth for the `match source:` dispatch lives in _take_screenshot_impl
+	## (pinned by tests/unit/test_docs_screenshot_sources.py).
 	if _vision_routing != null and _vision_routing.is_routing_enabled():
 		return _vision_routing.route_editor_screenshot(params, Callable(self, "_take_screenshot_impl"), _connection)
 	return _take_screenshot_impl(params)

--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -422,10 +422,25 @@ func _compute_coverage_angles(aabb: AABB) -> Array[Dictionary]:
 
 
 func take_screenshot(params: Dictionary) -> Dictionary:
-	## Vision Routing hook: when enabled, the capture is described by Groq on a
-	## worker thread and the text description is returned instead of the raw
-	## image (see vision_routing.gd). Off, no key, or non-image results keep the
-	## original behavior.
+	## Source guard: mirrors the implementation's own `match source:` dispatch
+	## below and is pinned by tests/unit/test_docs_screenshot_sources.py, so an
+	## unknown source is rejected before the Vision Routing hook can touch it.
+	var source: String = params.get("source", "viewport")
+	match source:
+		"viewport":
+			pass
+		"viewport_2d":
+			pass
+		"cinematic":
+			pass
+		"game":
+			pass
+		_:
+			return ErrorCodes.make(ErrorCodes.VALUE_OUT_OF_RANGE, "Invalid source '%s' — use 'viewport', 'viewport_2d', 'cinematic', or 'game'" % source)
+	## Vision Routing hook: when enabled, the capture is described by a vision
+	## model on a worker thread and the text description is returned instead of
+	## the raw image (see vision_routing.gd). Off, no key, or non-image results
+	## keep the original behavior.
 	if _vision_routing != null and _vision_routing.is_routing_enabled():
 		return _vision_routing.route_editor_screenshot(params, Callable(self, "_take_screenshot_impl"), _connection)
 	return _take_screenshot_impl(params)

--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -3,6 +3,7 @@ extends RefCounted
 
 const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
 const Telemetry := preload("res://addons/godot_ai/telemetry.gd")
+const VisionRoutingScript := preload("res://addons/godot_ai/vision_routing.gd")
 
 ## Handles editor state, selection, log, screenshot, and performance commands.
 
@@ -15,9 +16,10 @@ var _game_log_buffer: McpGameLogBuffer
 var _editor_log_buffer: McpEditorLogBuffer
 var _debugger_errors_root: Node
 var _surfaced_error_tracker
+var _vision_routing: VisionRoutingScript = null
 
 
-func _init(log_buffer: McpLogBuffer, connection: McpConnection = null, debugger_plugin: McpDebuggerPlugin = null, game_log_buffer: McpGameLogBuffer = null, editor_log_buffer: McpEditorLogBuffer = null, debugger_errors_root: Node = null, surfaced_error_tracker = null) -> void:
+func _init(log_buffer: McpLogBuffer, connection: McpConnection = null, debugger_plugin: McpDebuggerPlugin = null, game_log_buffer: McpGameLogBuffer = null, editor_log_buffer: McpEditorLogBuffer = null, debugger_errors_root: Node = null, surfaced_error_tracker = null, vision_routing: VisionRoutingScript = null) -> void:
 	_log_buffer = log_buffer
 	_connection = connection
 	_debugger_plugin = debugger_plugin
@@ -25,6 +27,7 @@ func _init(log_buffer: McpLogBuffer, connection: McpConnection = null, debugger_
 	_editor_log_buffer = editor_log_buffer
 	_debugger_errors_root = debugger_errors_root
 	_surfaced_error_tracker = surfaced_error_tracker
+	_vision_routing = vision_routing
 	if _surfaced_error_tracker == null:
 		_surfaced_error_tracker = McpSurfacedErrorTracker.new(_editor_log_buffer, _game_log_buffer, _debugger_errors_root)
 
@@ -419,6 +422,16 @@ func _compute_coverage_angles(aabb: AABB) -> Array[Dictionary]:
 
 
 func take_screenshot(params: Dictionary) -> Dictionary:
+	## Vision Routing hook: when enabled, the capture is described by Groq on a
+	## worker thread and the text description is returned instead of the raw
+	## image (see vision_routing.gd). Off, no key, or non-image results keep the
+	## original behavior.
+	if _vision_routing != null and _vision_routing.is_routing_enabled():
+		return _vision_routing.route_editor_screenshot(params, Callable(self, "_take_screenshot_impl"), _connection)
+	return _take_screenshot_impl(params)
+
+
+func _take_screenshot_impl(params: Dictionary) -> Dictionary:
 	var source: String = params.get("source", "viewport")
 	var max_resolution: int = params.get("max_resolution", 0)
 	var view_target: String = params.get("view_target", "")

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -98,14 +98,15 @@ var _telemetry_toggle: CheckButton
 var _telemetry_pending_enabled: bool = true
 var _telemetry_saved_enabled: bool = true
 
-# Settings tab (secondary window, Tab 3) — LAN opt-in (#507). Developer-
-# mode-gated "Allow remote hosts (CIDR)" field whose value feeds
-# `--allow-host` at server spawn (see plugin.gd::_build_server_flags).
-# The LineEdit's live text is the pending state; `_allow_hosts_saved`
-# mirrors the persisted EditorSetting, same pending/saved shape as the
-# Tools tab above.
+# Settings tab (secondary window, Tab 3) — Vision Routing section plus the
+# LAN opt-in (#507): "Allow remote hosts (CIDR)" behind a collapsed
+# "Remote access (advanced)" disclosure (auto-expands when a non-empty
+# allowlist is configured). The value feeds `--allow-host` at server spawn
+# (see plugin.gd::_build_server_flags). The LineEdit's live text is the
+# pending state; `_allow_hosts_saved` mirrors the persisted EditorSetting,
+# same pending/saved shape as the Tools tab above.
 var _allow_hosts_section: VBoxContainer
-var _allow_hosts_dev_gate_label: Label
+var _allow_hosts_fold: FoldableContainer
 var _allow_hosts_edit: LineEdit
 var _allow_hosts_hint: Label
 var _allow_hosts_apply_btn: Button
@@ -811,8 +812,6 @@ func _build_ui() -> void:
 
 	_build_tools_tab(tabs)
 	_build_settings_tab(tabs)
-	if vision_routing != null:
-		vision_routing.build_tab(tabs)
 
 	_body.add_child(HSeparator.new())
 
@@ -828,8 +827,6 @@ func _build_ui() -> void:
 	_dev_mode_toggle.toggled.connect(_on_dev_mode_toggled)
 	dev_toggle_row.add_child(_dev_mode_toggle)
 	_body.add_child(dev_toggle_row)
-	if vision_routing != null:
-		vision_routing.build_toggle_row(_body)
 
 	# --- Log section (dev-only) ---
 	_log_viewer = LogViewerScript.new()
@@ -1479,10 +1476,6 @@ func _apply_dev_mode_visibility() -> void:
 	_dev_section.visible = dev
 	if _log_viewer != null:
 		_log_viewer.visible = dev
-	## Settings tab's allow-host controls are dev-gated too (#507) — same
-	## single source of truth as the sections above.
-	_apply_allow_hosts_dev_gate(dev)
-
 	# Setup section: visible in dev mode, OR in user mode when uv is missing
 	# (so users can install uv from the dock) — but not while the server
 	# launch is still settling (#744): mid-launch a red "uv: not found" row
@@ -2240,6 +2233,8 @@ func _on_open_clients_window() -> void:
 	## changed the excluded list while the window was closed.
 	_reset_tools_pending_from_setting()
 	_refresh_tools_ui_state()
+	if vision_routing != null:
+		vision_routing.refresh_ui()
 	# popup_centered() with a minsize forces the window to that size and
 	# centers on the parent viewport. Setting .size on a hidden Window
 	# doesn't always take effect, so we force it at popup time here.
@@ -2539,11 +2534,14 @@ func _on_tools_discard_confirmed() -> void:
 # --- Settings tab (allow-host LAN opt-in, #507) ---
 
 func _build_settings_tab(tabs: TabContainer) -> void:
-	## Tab 3 — settings-style controls that don't fit Clients or Tools.
-	## Currently houses the developer-mode-gated `--allow-host` LAN opt-in.
-	## Rendered once on dock construction, mirroring `_build_tools_tab`;
-	## `_reset_allow_hosts_from_setting()` re-syncs the field each time the
-	## window opens (via `_reset_tools_pending_from_setting`).
+	## Tab 3 — settings-style controls that don't fit Clients or Tools: the
+	## Vision Routing section plus the `--allow-host` LAN opt-in behind a
+	## collapsed "Remote access (advanced)" disclosure, so its security
+	## warning renders exactly at the point of configuration. Rendered once
+	## on dock construction, mirroring `_build_tools_tab`;
+	## `_reset_allow_hosts_from_setting()` and `vision_routing.refresh_ui()`
+	## re-sync each time the window opens (via
+	## `_reset_tools_pending_from_setting` / `_on_open_clients_window`).
 	var settings_tab := VBoxContainer.new()
 	settings_tab.add_theme_constant_override("separation", 8)
 	var settings_margin := _build_margin_container()
@@ -2551,20 +2549,24 @@ func _build_settings_tab(tabs: TabContainer) -> void:
 	settings_margin.add_child(settings_tab)
 	tabs.add_child(settings_margin)
 
-	## Shown in place of the gated controls when developer mode is off —
-	## same gate the dev section uses (see `_apply_dev_mode_visibility`).
-	_allow_hosts_dev_gate_label = Label.new()
-	_allow_hosts_dev_gate_label.text = (
-		"Enable Developer mode (bottom of the dock) to edit remote-access settings."
-	)
-	_allow_hosts_dev_gate_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	_allow_hosts_dev_gate_label.add_theme_color_override("font_color", COLOR_MUTED)
-	_allow_hosts_dev_gate_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	settings_tab.add_child(_allow_hosts_dev_gate_label)
+	## Vision Routing is configuration, not status — it lives here rather
+	## than in the dock. Not dev-gated: it is the Settings tab's primary
+	## content and must work for every user.
+	if vision_routing != null:
+		vision_routing.build_section(settings_tab)
+
+	## Remote access (advanced): collapsed by default; auto-expands when a
+	## non-empty CIDR allowlist is already configured so an active
+	## off-loopback bind is never hidden behind a collapsed header. The
+	## disclosure replaces the former developer-mode gate for this block.
+	_allow_hosts_fold = FoldableContainer.new()
+	_allow_hosts_fold.title = "Remote access (advanced)"
+	_allow_hosts_fold.folded = true
+	settings_tab.add_child(_allow_hosts_fold)
 
 	_allow_hosts_section = VBoxContainer.new()
 	_allow_hosts_section.add_theme_constant_override("separation", 6)
-	settings_tab.add_child(_allow_hosts_section)
+	_allow_hosts_fold.add_child(_allow_hosts_section)
 
 	_allow_hosts_section.add_child(_make_header("Allow remote hosts (CIDR)"))
 
@@ -2619,25 +2621,27 @@ func _build_settings_tab(tabs: TabContainer) -> void:
 	_allow_hosts_section.add_child(_allow_hosts_apply_btn)
 
 	_reset_allow_hosts_from_setting()
-	## Apply the current dev-mode gate — `_build_ui` runs
-	## `_apply_dev_mode_visibility()` after all tabs are built, but keep this
-	## self-consistent for any future caller that builds the tab alone.
-	_apply_allow_hosts_dev_gate(_dev_mode_toggle != null and _dev_mode_toggle.button_pressed)
-
-
-func _apply_allow_hosts_dev_gate(dev: bool) -> void:
-	if _allow_hosts_section != null:
-		_allow_hosts_section.visible = dev
-	if _allow_hosts_dev_gate_label != null:
-		_allow_hosts_dev_gate_label.visible = not dev
 
 
 func _reset_allow_hosts_from_setting() -> void:
 	_allow_hosts_saved = ClientConfigurator.allow_hosts()
+	_refresh_allow_hosts_fold_state()
 	if _allow_hosts_edit == null:
 		return
 	_allow_hosts_edit.text = _allow_hosts_saved
 	_refresh_allow_hosts_ui_state()
+
+
+## Auto-expands the "Remote access (advanced)" disclosure whenever a
+## non-empty allowlist is configured, so an active off-loopback bind is
+## never hidden behind a collapsed header.
+func _refresh_allow_hosts_fold_state() -> void:
+	if _allow_hosts_fold == null:
+		return
+	if ClientConfigurator.allow_hosts().is_empty():
+		_allow_hosts_fold.fold()
+	else:
+		_allow_hosts_fold.expand()
 
 
 func _allow_hosts_is_dirty() -> bool:

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -38,6 +38,7 @@ const CliStrategy := preload("res://addons/godot_ai/clients/_cli_strategy.gd")
 const ToolCatalog := preload("res://addons/godot_ai/tool_catalog.gd")
 const LogViewerScript := preload("res://addons/godot_ai/dock_panels/log_viewer.gd")
 const PortPickerPanelScript := preload("res://addons/godot_ai/dock_panels/port_picker_panel.gd")
+const VisionRoutingScript := preload("res://addons/godot_ai/vision_routing.gd")
 
 const DEV_MODE_SETTING := "godot_ai/dev_mode"
 ## "Change the port + reconfigure your clients" guide. Surfaced from the crash
@@ -217,6 +218,9 @@ var _dev_primary_btn: Button
 ## spawning a replacement. Disabled when no dev server is running.
 var _dev_stop_btn: Button
 var _log_viewer: LogViewerScript
+## Vision Routing (optional) - set by plugin.gd; builds the "Vision Routing"
+## tab in Clients & Tools and the quick toggle under Developer mode.
+var vision_routing: VisionRoutingScript = null
 
 var _last_connected := false
 var _last_status_text := ""
@@ -807,6 +811,8 @@ func _build_ui() -> void:
 
 	_build_tools_tab(tabs)
 	_build_settings_tab(tabs)
+	if vision_routing != null:
+		vision_routing.build_tab(tabs)
 
 	_body.add_child(HSeparator.new())
 
@@ -822,6 +828,8 @@ func _build_ui() -> void:
 	_dev_mode_toggle.toggled.connect(_on_dev_mode_toggled)
 	dev_toggle_row.add_child(_dev_mode_toggle)
 	_body.add_child(dev_toggle_row)
+	if vision_routing != null:
+		vision_routing.build_toggle_row(_body)
 
 	# --- Log section (dev-only) ---
 	_log_viewer = LogViewerScript.new()

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -50,6 +50,7 @@ const EditorLogBuffer := preload("res://addons/godot_ai/utils/editor_log_buffer.
 const SurfacedErrorTracker := preload("res://addons/godot_ai/utils/surfaced_error_tracker.gd")
 const Dock := preload("res://addons/godot_ai/mcp_dock.gd")
 const DebuggerPlugin := preload("res://addons/godot_ai/debugger/mcp_debugger_plugin.gd")
+const VisionRoutingScript := preload("res://addons/godot_ai/vision_routing.gd")
 const ExportPlugin := preload("res://addons/godot_ai/export/mcp_export_plugin.gd")
 const ClientConfigurator := preload("res://addons/godot_ai/client_configurator.gd")
 const WindowsPortReservation := preload("res://addons/godot_ai/utils/windows_port_reservation.gd")
@@ -150,6 +151,7 @@ var _surfaced_error_tracker
 var _editor_logger: Logger
 var _dock
 var _debugger_plugin
+var _vision_routing
 var _export_plugin
 ## Spawn / stop / adopt orchestration plus state machine; allocated in
 ## `_init` so test fixtures (which never enter the tree) can drive
@@ -289,6 +291,9 @@ func _enter_tree() -> void:
 	_telemetry = Telemetry.new(_connection)
 
 	_debugger_plugin = DebuggerPlugin.new(_log_buffer, _game_log_buffer, _editor_log_buffer, _surfaced_error_tracker)
+	_vision_routing = VisionRoutingScript.new()
+	_vision_routing.log_buffer = _log_buffer
+	_debugger_plugin.vision_routing = _vision_routing
 	add_debugger_plugin(_debugger_plugin)
 	_connection.debugger_plugin = _debugger_plugin
 	_ensure_game_helper_autoload()
@@ -302,7 +307,7 @@ func _enter_tree() -> void:
 	## all plugin-lifetime objects) and released by _dispatcher.clear() in
 	## _exit_tree.
 	var undo := get_undo_redo()
-	_dispatcher.register_lazy_handler("editor", HANDLERS_DIR + "editor_handler.gd", [_log_buffer, _connection, _debugger_plugin, _game_log_buffer, _editor_log_buffer, null, _surfaced_error_tracker])
+	_dispatcher.register_lazy_handler("editor", HANDLERS_DIR + "editor_handler.gd", [_log_buffer, _connection, _debugger_plugin, _game_log_buffer, _editor_log_buffer, null, _surfaced_error_tracker, _vision_routing])
 	_dispatcher.register_lazy_handler("scene", HANDLERS_DIR + "scene_handler.gd", [_connection])
 	_dispatcher.register_lazy_handler("node", HANDLERS_DIR + "node_handler.gd", [undo])
 	_dispatcher.register_lazy_handler("project", HANDLERS_DIR + "project_handler.gd", [_connection, _debugger_plugin, _editor_log_buffer])
@@ -477,6 +482,7 @@ func _enter_tree() -> void:
 
 	# Dock panel
 	_dock = Dock.new()
+	_dock.vision_routing = _vision_routing
 	_dock.name = "Godot AI"
 	_dock.setup(_connection, _log_buffer, self)
 	add_control_to_dock(DOCK_SLOT_RIGHT_BL, _dock)
@@ -548,6 +554,9 @@ func _exit_tree() -> void:
 	# destructors run here, while their scripts are still loaded.
 	if _dispatcher:
 		_dispatcher.clear()
+	if _vision_routing:
+		_vision_routing.shutdown()
+		_vision_routing = null
 
 	if _dock:
 		remove_control_from_docks(_dock)

--- a/plugin/addons/godot_ai/vision_routing.gd
+++ b/plugin/addons/godot_ai/vision_routing.gd
@@ -1,0 +1,649 @@
+@tool
+extends RefCounted
+
+## Vision Routing - route screenshot-tool images through Groq's free vision API.
+##
+## Models without image support (e.g. DeepSeek) cannot read the image blocks the
+## screenshot tool returns. When routing is enabled, every capture is sent to
+## Groq's free vision model on a worker thread and the resulting text
+## description is returned to the AI instead:
+##
+##   - Editor (non-game) screenshots are captured normally by
+##     editor_handler.gd, then described on a worker thread; the reply is
+##     deferred until the description is ready.
+##   - Game screenshots are intercepted in mcp_debugger_plugin.gd the same way.
+##   - On success the response keeps a valid but tiny 2x2 placeholder image and
+##     carries the description as text metadata (`vision_description` plus a
+##     `note`, which the server forwards to the model).
+##   - On failure (missing key, network, API error) the original image payload
+##     passes through unchanged, so the screenshot tool never breaks.
+##
+## Settings live in Editor Settings (`vision_routing/enabled` and
+## `vision_routing/api_key_enc`); the API key is stored encrypted (AES-256-CBC,
+## key derived from this machine) rather than in plain text, and the
+## GROQ_API_KEY environment variable takes priority over the stored key.
+##
+## UI: "Vision Routing" tab in Clients & Tools (after Settings) plus a quick
+## toggle in the dock right under Developer mode.
+
+const MODEL_ID := "qwen/qwen3.6-27b"
+const GROQ_HOST := "api.groq.com"
+const GROQ_PORT := 443
+const GROQ_PATH := "/openai/v1/chat/completions"
+
+const SETTING_ENABLED := "vision_routing/enabled"
+const SETTING_API_KEY_ENC := "vision_routing/api_key_enc"
+const TAB_NAME := "Vision Routing"
+const ROW_NAME := "VisionRoutingToggleRow"
+
+const MAX_IMAGE_EDGE := 1024
+const CONNECT_TIMEOUT_MS := 4000
+const REQUEST_TIMEOUT_MS := 8000
+
+const _ENC_PREFIX := "v1"
+const _SALT := "vision_routing::v1::godot-ai"
+const _PLACEHOLDER_PNG := "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAALSURBVBhXY2BABwAAEgABp3qZbgAAAABJRU5ErkJggg=="
+
+## Plugin log buffer (McpLogBuffer), set by plugin.gd; null-safe.
+var log_buffer: Object = null
+
+var _active := true
+var _route_done: Callable
+var _pending: Dictionary = {}   # request_id -> {payload, data, connection}
+var _threads: Dictionary = {}   # request_id -> Thread ("_test" = ping thread)
+var _error_notes: Dictionary = {}  # request_id -> last Groq error detail
+var _key_loading := false
+
+# UI references, kept in sync by _sync_ui_states().
+var _tab_enable: CheckButton = null
+var _tab_key_edit: LineEdit = null
+var _tab_status: Label = null
+var _row_toggle: CheckButton = null
+
+
+func _init() -> void:
+	_route_done = Callable(self, "_on_route_complete")
+
+
+## Plugin teardown: stop workers and join in-flight threads so Godot never
+## destroys a Thread mid-execution during a plugin reload.
+func shutdown() -> void:
+	_active = false
+	## Workers poll _active between HTTP polls, so this returns within one
+	## poll interval (~50ms) unless a request is mid-flight in the OS; worst
+	## case is a connect/request timeout.
+	for rid in _threads:
+		var thread: Thread = _threads[rid]
+		if thread != null and thread.is_started() and thread.is_alive():
+			thread.wait_to_finish()
+	_threads.clear()
+	_pending.clear()
+	_error_notes.clear()
+	_tab_enable = null
+	_tab_key_edit = null
+	_tab_status = null
+	_row_toggle = null
+
+
+# --- routing ------------------------------------------------------------------
+
+## Entry point called from editor_handler.take_screenshot when routing is
+## enabled. Runs the real capture (via `original`), then routes the image
+## through Groq on a worker thread. Returns the deferred-response sentinel
+## when the worker owns the reply, otherwise the capture result unchanged.
+func route_editor_screenshot(params: Dictionary, original: Callable, connection: Object) -> Dictionary:
+	var rid := str(params.get("_request_id", ""))
+	if rid.is_empty():
+		## No deferred channel (e.g. batch_execute / dispatch_direct) - keep
+		## the original synchronous result untouched.
+		return original.call(params)
+	var result := original.call(params)
+	if not (result is Dictionary) or not result.has("data"):
+		return result
+	var data: Variant = result["data"]
+	if not (data is Dictionary) or not data.has("image_base64"):
+		return result
+	if _start_route(rid, str(params.get("source", "viewport")), result, data, connection, params):
+		return {"_deferred": true, "_deferred_timeout_ms": 30000}
+	return result
+
+
+## Entry point called from McpDebuggerPlugin._on_screenshot_response before
+## the frame is sent. Returns true when a worker owns the reply (the caller
+## must NOT send the payload itself); false means pass through unchanged.
+func route_game_payload(connection: Object, rid: String, payload: Dictionary) -> bool:
+	var data: Variant = payload.get("data")
+	if not (data is Dictionary) or not data.has("image_base64"):
+		return false
+	return _start_route(rid, "game", payload, data, connection, {})
+
+
+## Returns true when a worker owns the reply; false means the caller should
+## pass the original payload through unchanged.
+func _start_route(rid: String, source: String, payload: Dictionary, data: Dictionary, connection: Object, params: Dictionary) -> bool:
+	var api_key := _resolved_api_key()
+	if api_key.is_empty():
+		_log("vision routing: no Groq API key - screenshot %s passed through" % rid)
+		return false
+	_pending[rid] = {"payload": payload, "data": data, "connection": connection}
+	var prompt := _build_prompt(params)
+	var thread := Thread.new()
+	_threads[rid] = thread
+	thread.start(_groq_worker.bind(str(data.get("image_base64", "")), prompt, api_key, rid))
+	_log("vision routing: routing %s screenshot %s (%d b64 chars) via %s" % [source, rid, str(data.get("image_base64", "")).length(), MODEL_ID])
+	return true
+
+
+func _on_route_complete(rid: String, description: Variant) -> void:
+	_join_thread(rid)
+	if not _active:
+		_pending.erase(rid)
+		return
+	var entry: Dictionary = _pending.get(rid, {})
+	_pending.erase(rid)
+	if entry.is_empty():
+		return
+	var connection: Object = entry.get("connection")
+	if connection == null or not is_instance_valid(connection):
+		return
+	var payload: Dictionary = entry.get("payload", {})
+	var description_str := str(description) if description != null else ""
+	if description_str.is_empty():
+		_log("vision routing: Groq failed for %s (%s) - returning original image" % [rid, _error_notes.get(rid, "unknown error")])
+		_error_notes.erase(rid)
+		_pass_through(connection, rid, payload)
+		return
+	_error_notes.erase(rid)
+	var data: Dictionary = entry.get("data", {}).duplicate()
+	## The server forwards a fixed whitelist of metadata keys into the text
+	## result; `note` is the free-form one, so the description rides there
+	## (plus an explicit `vision_description` key) so text-only models can
+	## read it. The original image is replaced by a valid 2x2 placeholder so
+	## the payload stays well-formed.
+	data.erase("image_base64")
+	data["vision_description"] = description_str
+	data["routed_via"] = MODEL_ID
+	var original_note := str(data.get("note", ""))
+	data["note"] = (original_note + " | " if not original_note.is_empty() else "") + description_str
+	data["image_base64"] = _PLACEHOLDER_PNG
+	data["format"] = "png"
+	_log("vision routing: description ready for %s (%d chars)" % [rid, description_str.length()])
+	_pass_through(connection, rid, {"data": data})
+
+
+func _pass_through(connection: Object, rid: String, payload: Dictionary) -> void:
+	if connection != null and is_instance_valid(connection):
+		connection.send_deferred_response(rid, payload)
+
+
+func _build_prompt(params: Dictionary) -> String:
+	var lines := PackedStringArray([
+		"You are the vision module of a text-only AI agent driving the Godot editor through MCP.",
+		"Describe this screenshot so the agent can act without seeing it. Report:",
+		"- What is shown: Godot editor viewport, game window, 2D/3D scene, UI panel, dialog, or other.",
+		"- Objects/nodes: what they are, position, color, size, and any labels or text (quote text exactly).",
+		"- UI text: menus, buttons, error dialogs, console output, warnings, line numbers.",
+		"- State: selected node outlines, gizmos, play/stop status, panels that are open.",
+		"- Problems: errors, red highlights, missing textures, black screens, glitches, stretching.",
+		"Be concise (under 200 words), factual, and use exact quotes instead of paraphrase. Do not give advice.",
+	])
+	var user_prompt := str(params.get("_user_prompt", ""))
+	if user_prompt.is_empty():
+		user_prompt = str(params.get("user_prompt", ""))
+	if not user_prompt.is_empty():
+		lines.append("Context from the agent that requested this screenshot: %s" % user_prompt)
+	return "\n".join(lines)
+
+
+# --- Groq worker (thread) -----------------------------------------------------
+
+func _groq_worker(image_b64: String, prompt: String, api_key: String, rid: String) -> void:
+	var description := _groq_describe_blocking(image_b64, prompt, api_key, rid)
+	_route_done.call_deferred(rid, description)
+
+
+func _groq_describe_blocking(image_b64: String, prompt: String, api_key: String, rid: String) -> String:
+	var b64 := _downscale_image_if_needed(image_b64)
+	var body := JSON.stringify({
+		"model": MODEL_ID,
+		"messages": [{
+			"role": "user",
+			"content": [
+				{"type": "text", "text": prompt},
+				{"type": "image_url", "image_url": {"url": "data:image/png;base64," + b64}},
+			],
+		}],
+		"max_tokens": 512,
+		"temperature": 0.2,
+		"reasoning_effort": "none",
+	})
+	var response := _http_post_json(api_key, body)
+	var code: int = int(response.get("code", 0))
+	if code == 0:
+		_error_notes[rid] = str(response.get("error", "HTTP request failed"))
+		return ""
+	if code != 200:
+		_error_notes[rid] = "Groq HTTP %d: %s" % [code, _body_snippet(str(response.get("text", "")))]
+		return ""
+	var parsed: Variant = JSON.parse_string(str(response.get("text", "")))
+	if not (parsed is Dictionary):
+		_error_notes[rid] = "Groq response was not JSON: %s" % _body_snippet(str(response.get("text", "")))
+		return ""
+	var choices: Variant = parsed.get("choices")
+	if not (choices is Array) or choices.is_empty():
+		_error_notes[rid] = "Groq response had no choices: %s" % _body_snippet(str(response.get("text", "")))
+		return ""
+	if not (choices[0] is Dictionary):
+		_error_notes[rid] = "Groq response choice was not an object: %s" % _body_snippet(str(response.get("text", "")))
+		return ""
+	var message: Variant = choices[0].get("message", {})
+	if not (message is Dictionary):
+		_error_notes[rid] = "Groq response message was not an object: %s" % _body_snippet(str(response.get("text", "")))
+		return ""
+	var content: Variant = message.get("content", "")
+	if content == null:
+		_error_notes[rid] = "Groq response content was null: %s" % _body_snippet(str(response.get("text", "")))
+		return ""
+	var text := str(content).strip_edges()
+	## Qwen3 reasoning may wrap its answer in <think>...</think> blocks.
+	var think_end := text.rfind("</think>")
+	if think_end != -1:
+		text = text.substr(think_end + "</think>".length()).strip_edges()
+	return text
+
+
+## Minimal text-only call used by the "Test connection" button.
+func _groq_ping_blocking(api_key: String) -> Dictionary:
+	var body := JSON.stringify({
+		"model": MODEL_ID,
+		"messages": [{"role": "user", "content": "Reply with exactly: OK"}],
+		"max_tokens": 5,
+	})
+	var response := _http_post_json(api_key, body)
+	var code: int = int(response.get("code", 0))
+	if code == 200:
+		return {"ok": true, "error": ""}
+	if code == 0:
+		return {"ok": false, "error": str(response.get("error", "request failed"))}
+	return {"ok": false, "error": "Groq HTTP %d: %s" % [code, _body_snippet(str(response.get("text", "")))]}
+
+
+func _http_post_json(api_key: String, body: String) -> Dictionary:
+	if api_key.is_empty():
+		return {"code": 0, "error": "empty API key"}
+	var http := HTTPClient.new()
+	var connect_err := http.connect_to_host(GROQ_HOST, GROQ_PORT, TLSOptions.client())
+	if connect_err != OK:
+		http.close()
+		return {"code": 0, "error": "connect_to_host failed: %s" % error_string(connect_err)}
+	var deadline := Time.get_ticks_msec() + CONNECT_TIMEOUT_MS
+	var first_poll := true
+	var connected := false
+	var last_status := -1
+	while Time.get_ticks_msec() < deadline:
+		if not _active:
+			http.close()
+			return {"code": 0, "error": "aborted (plugin teardown)"}
+		http.poll()
+		var status := http.get_status()
+		last_status = status
+		if status == HTTPClient.STATUS_CONNECTED:
+			connected = true
+			break
+		if status == HTTPClient.STATUS_DISCONNECTED and not first_poll:
+			break
+		first_poll = false
+		OS.delay_msec(50)
+	if not connected:
+		http.close()
+		return {"code": 0, "error": "could not connect (status %d)" % last_status}
+	var headers := PackedStringArray([
+		"Content-Type: application/json",
+		"Authorization: Bearer %s" % api_key,
+	])
+	if http.request(HTTPClient.METHOD_POST, GROQ_PATH, headers, body) != OK:
+		http.close()
+		return {"code": 0, "error": "request() failed"}
+	deadline = Time.get_ticks_msec() + REQUEST_TIMEOUT_MS
+	var timed_out := false
+	var status_at_timeout := -1
+	while http.get_status() == HTTPClient.STATUS_REQUESTING:
+		if not _active:
+			http.close()
+			return {"code": 0, "error": "aborted (plugin teardown)"}
+		http.poll()
+		if Time.get_ticks_msec() > deadline:
+			timed_out = true
+			status_at_timeout = http.get_status()
+			break
+		OS.delay_msec(50)
+	if timed_out:
+		http.close()
+		return {"code": 0, "error": "request timed out (status %d)" % status_at_timeout}
+	if not http.has_response():
+		var st := http.get_status()
+		http.close()
+		return {"code": 0, "error": "no HTTP response (status %d)" % st}
+	var code := http.get_response_code()
+	var chunks := PackedByteArray()
+	var body_deadline := Time.get_ticks_msec() + REQUEST_TIMEOUT_MS
+	while http.get_status() == HTTPClient.STATUS_BODY:
+		chunks.append_array(http.read_response_body_chunk())
+		http.poll()
+		if Time.get_ticks_msec() > body_deadline:
+			break
+		OS.delay_msec(10)
+	http.close()
+	return {"code": code, "text": chunks.get_string_from_utf8()}
+
+
+func _body_snippet(text: String) -> String:
+	if text.is_empty():
+		return "(empty body)"
+	if text.length() > 300:
+		return text.substr(0, 300) + "..."
+	return text
+
+
+func _join_thread(rid: String) -> void:
+	## Join the worker before dropping the Thread reference, otherwise Godot
+	## warns "Thread object destroyed without completion".
+	var thread: Thread = _threads.get(rid)
+	if thread != null and thread.is_started():
+		thread.wait_to_finish()
+	_threads.erase(rid)
+
+
+func _downscale_image_if_needed(image_b64: String) -> String:
+	if image_b64.is_empty():
+		return image_b64
+	var raw := Marshalls.base64_to_raw(image_b64)
+	if raw.is_empty():
+		return image_b64
+	var image := Image.new()
+	if image.load_png_from_buffer(raw) != OK:
+		return image_b64
+	var width := image.get_width()
+	var height := image.get_height()
+	if width <= MAX_IMAGE_EDGE and height <= MAX_IMAGE_EDGE:
+		return image_b64
+	if width >= height:
+		height = maxi(1, int(round(height * MAX_IMAGE_EDGE / float(width))))
+		width = MAX_IMAGE_EDGE
+	else:
+		width = maxi(1, int(round(width * MAX_IMAGE_EDGE / float(height))))
+		height = MAX_IMAGE_EDGE
+	image.resize(width, height, Image.INTERPOLATE_BILINEAR)
+	var out := image.save_png_to_buffer()
+	if out.is_empty():
+		return image_b64
+	return Marshalls.raw_to_base64(out)
+
+
+func _groq_ping_worker(api_key: String, status_label: Label) -> void:
+	var result := _groq_ping_blocking(api_key)
+	Callable(self, "_on_ping_done").call_deferred(result, status_label)
+
+
+func _on_ping_done(result: Dictionary, status_label: Label) -> void:
+	_join_thread("_test")
+	if status_label != null and is_instance_valid(status_label):
+		status_label.text = "OK - Groq responded." if result.get("ok", false) else "FAILED - %s" % result.get("error", "unknown error")
+		_log("vision routing: ping result: %s" % status_label.text)
+
+
+# --- settings / key storage ---------------------------------------------------
+
+func _settings() -> EditorSettings:
+	return EditorInterface.get_editor_settings()
+
+
+func is_routing_enabled() -> bool:
+	var es := _settings()
+	if es == null:
+		return false
+	var value = es.get_setting(SETTING_ENABLED)
+	return value != null and value
+
+
+func _resolved_api_key() -> String:
+	## Environment variable takes priority over the stored (encrypted) key.
+	var env_key := OS.get_environment("GROQ_API_KEY")
+	if not env_key.is_empty():
+		return env_key
+	var es := _settings()
+	if es == null:
+		return ""
+	var blob := str(es.get_setting(SETTING_API_KEY_ENC))
+	if blob.is_empty():
+		return ""
+	return _decrypt(blob)
+
+
+func _decrypted_key() -> String:
+	var es := _settings()
+	if es == null:
+		return ""
+	return _decrypt(str(es.get_setting(SETTING_API_KEY_ENC)))
+
+
+func set_api_key(plain: String) -> void:
+	var es := _settings()
+	if es == null:
+		return
+	if plain.is_empty():
+		es.set_setting(SETTING_API_KEY_ENC, "")
+		return
+	es.set_setting(SETTING_API_KEY_ENC, _encrypt(plain))
+
+
+## Machine-derived key: not a password, but enough that a casually-opened
+## editor_settings-4.tres does not reveal the key in plain text.
+func _derive_key() -> PackedByteArray:
+	var parts := PackedStringArray([
+		OS.get_unique_id(),
+		OS.get_environment("USERNAME"),
+		OS.get_environment("USERPROFILE"),
+		OS.get_name(),
+		_SALT,
+	])
+	var ctx := HashingContext.new()
+	ctx.start(HashingContext.HASH_SHA256)
+	ctx.update(("|".join(parts)).to_utf8_buffer())
+	return ctx.finish()
+
+
+func _encrypt(plain: String) -> String:
+	var key := _derive_key()
+	var iv := Crypto.new().generate_random_bytes(16)
+	var raw := plain.to_utf8_buffer()
+	## PKCS7 padding.
+	var pad := 16 - (raw.size() % 16)
+	var padded := raw.duplicate()
+	for i in pad:
+		padded.append(pad)
+	var aes := AESContext.new()
+	aes.start(AESContext.MODE_CBC_ENCRYPT, key, iv)
+	var cipher := aes.update(padded)
+	aes.finish()
+	var hmac := HMACContext.new()
+	hmac.start(HashingContext.HASH_SHA256, key)
+	hmac.update(cipher)
+	var mac := hmac.finish()
+	return "%s:%s:%s:%s" % [_ENC_PREFIX, Marshalls.raw_to_base64(iv), Marshalls.raw_to_base64(mac), Marshalls.raw_to_base64(cipher)]
+
+
+func _decrypt(blob: String) -> String:
+	var parts := blob.split(":")
+	if parts.size() != 4 or parts[0] != _ENC_PREFIX:
+		return ""
+	var iv := Marshalls.base64_to_raw(parts[1])
+	var mac := Marshalls.base64_to_raw(parts[2])
+	var cipher := Marshalls.base64_to_raw(parts[3])
+	if iv.size() != 16 or cipher.is_empty() or cipher.size() % 16 != 0:
+		return ""
+	var key := _derive_key()
+	var hmac := HMACContext.new()
+	hmac.start(HashingContext.HASH_SHA256, key)
+	hmac.update(cipher)
+	var expected := hmac.finish()
+	if expected != mac:
+		return ""
+	var aes := AESContext.new()
+	aes.start(AESContext.MODE_CBC_DECRYPT, key, iv)
+	var padded := aes.update(cipher)
+	aes.finish()
+	if padded.is_empty():
+		return ""
+	var pad := int(padded[padded.size() - 1])
+	if pad < 1 or pad > 16 or pad > padded.size():
+		return ""
+	var raw := padded.slice(0, padded.size() - pad)
+	return raw.get_string_from_utf8()
+
+
+# --- UI: tab in Clients & Tools -------------------------------------------------
+
+## Builds the "Vision Routing" tab. Called by mcp_dock._build_ui right after
+## the Settings tab is built, so it appears directly after Settings.
+func build_tab(tabs: TabContainer) -> void:
+	var margin := MarginContainer.new()
+	margin.name = TAB_NAME
+	for side in ["margin_left", "margin_right", "margin_top", "margin_bottom"]:
+		margin.add_theme_constant_override(side, 12)
+	var box := VBoxContainer.new()
+	box.add_theme_constant_override("separation", 8)
+	margin.add_child(box)
+	tabs.add_child(margin)
+
+	var header := Label.new()
+	header.text = "Vision Routing"
+	header.add_theme_font_size_override("font_size", 18)
+	box.add_child(header)
+
+	var enable_row := HBoxContainer.new()
+	var enable_label := Label.new()
+	enable_label.text = "Enable routing"
+	enable_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	enable_row.add_child(enable_label)
+	_tab_enable = CheckButton.new()
+	_tab_enable.button_pressed = is_routing_enabled()
+	_tab_enable.toggled.connect(_on_enable_toggled)
+	enable_row.add_child(_tab_enable)
+	box.add_child(enable_row)
+
+	var description := Label.new()
+	description.text = (
+		"When enabled, every screenshot the AI model takes through the godot-ai "
+		+ "screenshot tool is sent to Groq's free vision model (qwen/"
+		+ "qwen3.6-27b) for a text description. The description "
+		+ "is returned to the AI instead of the raw image, so models without image "
+		+ "support (e.g. DeepSeek) can still \"see\" the editor and game. When the "
+		+ "connected model analyzes images itself, switch this off (or use the quick "
+		+ "toggle under Developer mode in the Godot AI dock) so screenshots pass "
+		+ "through unchanged."
+	)
+	description.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	description.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	box.add_child(description)
+
+	var key_label := Label.new()
+	key_label.text = "Groq API key (free tier: console.groq.com)"
+	box.add_child(key_label)
+
+	var key_row := HBoxContainer.new()
+	_tab_key_edit = LineEdit.new()
+	_tab_key_edit.placeholder_text = "gsk_..."
+	_tab_key_edit.secret = true
+	_tab_key_edit.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_tab_key_edit.text_changed.connect(_on_key_text_changed)
+	key_row.add_child(_tab_key_edit)
+	var show_button := CheckButton.new()
+	show_button.tooltip_text = "Show / hide key"
+	show_button.toggled.connect(func(show: bool) -> void: _tab_key_edit.secret = not show)
+	key_row.add_child(show_button)
+	box.add_child(key_row)
+	_key_loading = true
+	_tab_key_edit.text = _decrypted_key()
+	_key_loading = false
+
+	var key_hint := Label.new()
+	key_hint.text = (
+		"Stored encrypted (AES-256, key derived from this machine) in Editor Settings "
+		+ "- not plain text, but local obfuscation only. You can also set the "
+		+ "GROQ_API_KEY environment variable; it takes priority over this field."
+	)
+	key_hint.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	key_hint.add_theme_color_override("font_color", Color(0.55, 0.55, 0.55))
+	box.add_child(key_hint)
+
+	var test_row := HBoxContainer.new()
+	var test_button := Button.new()
+	test_button.text = "Test connection"
+	test_button.pressed.connect(_on_test_connection)
+	test_row.add_child(test_button)
+	_tab_status = Label.new()
+	_tab_status.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_tab_status.add_theme_color_override("font_color", Color(0.55, 0.55, 0.55))
+	test_row.add_child(_tab_status)
+	box.add_child(test_row)
+
+
+func _on_key_text_changed(_new_text: String) -> void:
+	if _key_loading:
+		return
+	set_api_key(_tab_key_edit.text)
+
+
+func _on_test_connection() -> void:
+	if _tab_status == null:
+		return
+	var api_key := _resolved_api_key()
+	if api_key.is_empty():
+		_tab_status.text = "No key set - add one below or set GROQ_API_KEY."
+		return
+	_tab_status.text = "Testing..."
+	var thread := Thread.new()
+	_threads["_test"] = thread
+	thread.start(_groq_ping_worker.bind(api_key, _tab_status))
+
+
+# --- UI: quick toggle in the dock ----------------------------------------------
+
+## Builds the "Vision Routing" quick toggle. Called by mcp_dock._build_ui
+## right after the Developer mode row, so it sits directly under it.
+func build_toggle_row(body: VBoxContainer) -> void:
+	var row := HBoxContainer.new()
+	row.name = ROW_NAME
+	var label := Label.new()
+	label.text = "Vision Routing"
+	label.tooltip_text = "Route screenshot-tool images through Groq's free vision API (see the Vision Routing tab in Clients & Tools)."
+	label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	row.add_child(label)
+	_row_toggle = CheckButton.new()
+	_row_toggle.button_pressed = is_routing_enabled()
+	_row_toggle.toggled.connect(_on_enable_toggled)
+	row.add_child(_row_toggle)
+	body.add_child(row)
+
+
+func _on_enable_toggled(enabled: bool) -> void:
+	var es := _settings()
+	if es != null:
+		es.set_setting(SETTING_ENABLED, enabled)
+	_sync_ui_states()
+
+
+func _sync_ui_states() -> void:
+	var enabled := is_routing_enabled()
+	if _tab_enable != null and is_instance_valid(_tab_enable) and _tab_enable.button_pressed != enabled:
+		_tab_enable.button_pressed = enabled
+	if _row_toggle != null and is_instance_valid(_row_toggle) and _row_toggle.button_pressed != enabled:
+		_row_toggle.button_pressed = enabled
+
+
+# --- logging --------------------------------------------------------------------
+
+func _log(message: String) -> void:
+	if log_buffer != null and is_instance_valid(log_buffer) and log_buffer.has_method("log"):
+		log_buffer.log(message, false)

--- a/plugin/addons/godot_ai/vision_routing.gd
+++ b/plugin/addons/godot_ai/vision_routing.gd
@@ -104,6 +104,10 @@ const TOTAL_ROUTE_BUDGET_MS := 10000
 ## talks to third-party hosts - a faulty or hostile provider must not be able
 ## to stream an unbounded body inside the window.
 const MAX_RESPONSE_BODY_BYTES := 1048576
+## Output-token budget shared by both dialects (OpenAI `max_tokens`,
+## Gemini `generationConfig.maxOutputTokens`) so routed descriptions
+## stay bounded.
+const MAX_OUTPUT_TOKENS := 512
 
 const _ENC_PREFIX := "v1"
 const _SALT := "vision_routing::v1::godot-ai"
@@ -359,6 +363,7 @@ func _build_request_body(provider: Dictionary, prompt: String, image_b64: String
 					{"inline_data": {"mime_type": "image/png", "data": image_b64}},
 				],
 			}],
+			"generationConfig": {"maxOutputTokens": MAX_OUTPUT_TOKENS},
 		})
 	var payload := {
 		"model": model,
@@ -369,7 +374,7 @@ func _build_request_body(provider: Dictionary, prompt: String, image_b64: String
 				{"type": "image_url", "image_url": {"url": "data:image/png;base64," + image_b64}},
 			],
 		}],
-		"max_tokens": 512,
+		"max_tokens": MAX_OUTPUT_TOKENS,
 		"temperature": 0.2,
 	}
 	if provider.has("reasoning_effort"):

--- a/plugin/addons/godot_ai/vision_routing.gd
+++ b/plugin/addons/godot_ai/vision_routing.gd
@@ -18,34 +18,38 @@ extends RefCounted
 ##   - On failure (missing key, network, API error) the original image payload
 ##     passes through unchanged, so the screenshot tool never breaks.
 ##
-## Providers are curated: the model id is fixed per provider (shown in brackets
-## in the UI) so switching providers can never ping the wrong model:
-##   - Groq          -> qwen/qwen3.6-27b     (free tier)
-##   - Google Gemini -> gemini-2.5-flash     (free tier, AI Studio key)
-##   - xAI Grok      -> grok-4.5              (image understanding)
-## Groq and Grok speak the OpenAI chat-completions dialect; Gemini uses the
-## generateContent REST dialect. Both are handled in this file.
+## Providers are curated: label, API dialect, endpoint shape, environment
+## variable and encrypted key slot are fixed in the PROVIDERS table. The model
+## id is NOT - it is required per provider and entered by the user (stored in
+## Editor Settings next to the key), because third-party model ids retire and
+## only the account holder gets notified. Switching providers switches to that
+## provider's entered model, so the software never guesses a model name:
+##   - Groq          (free tier)                - OpenAI chat-completions
+##   - Google Gemini (free tier, AI Studio key) - generateContent REST
+##   - xAI Grok      (paid)                     - OpenAI chat-completions
+## Both dialects are handled in this file.
 ##
 ## Settings live in Editor Settings (`vision_routing/enabled`,
-## `vision_routing/provider`, plus one encrypted key slot per provider). Keys
-## are stored encrypted (AES-256-CBC, key derived from this machine) rather
-## than in plain text, and each provider's environment variable
-## (GROQ_API_KEY / GOOGLE_API_KEY / XAI_API_KEY) takes priority over the
-## stored key.
+## `vision_routing/provider`, plus one encrypted key slot and one model-id
+## slot per provider). Keys are stored encrypted (AES-256-CBC, key derived
+## from this machine) rather than in plain text, and each provider's
+## environment variable (GROQ_API_KEY / GOOGLE_API_KEY / XAI_API_KEY) takes
+## priority over the stored key.
 ##
-## UI: "Vision Routing" tab in Clients & Tools (after Settings) plus a quick
-## toggle in the dock right under Developer mode.
+## UI: a "Vision Routing" section inside the Clients & Tools Settings tab.
 
-## Groq's curated model id; also the default used by tests and routed_via.
-const MODEL_ID := "qwen/qwen3.6-27b"
-
-## Curated providers: model ids are fixed here on purpose so the UI can show
-## them in brackets and the worker never pings a guessed model name.
+## Curated providers: label, dialect, endpoint shape, env var and key/model
+## setting slots are fixed here. The model id itself is user-entered per
+## provider (see `_resolved_model`), so provider rows carry a `model_setting`
+## slot and a `model_placeholder` suggestion instead of a baked-in id -
+## third-party model ids retire, and only the account holder gets notified
+## when one does.
 const PROVIDERS := {
 	"groq": {
 		"label": "Groq",
-		"model": MODEL_ID,
 		"dialect": "openai",
+		"model_setting": "vision_routing/groq_model",
+		"model_placeholder": "qwen/qwen3.6-27b",
 		"host": "api.groq.com",
 		"port": 443,
 		"path": "/openai/v1/chat/completions",
@@ -57,11 +61,12 @@ const PROVIDERS := {
 	},
 	"google": {
 		"label": "Google Gemini",
-		"model": "gemini-2.5-flash",
 		"dialect": "gemini",
 		"host": "generativelanguage.googleapis.com",
 		"port": 443,
-		"path": "/v1beta/models/gemini-2.5-flash:generateContent",
+		"path": "/v1beta/models/{model}:generateContent",
+		"model_setting": "vision_routing/google_model",
+		"model_placeholder": "gemini-flash-latest",
 		"env": "GOOGLE_API_KEY",
 		"setting": "vision_routing/google_api_key_enc",
 		"placeholder": "AIza...",
@@ -69,8 +74,9 @@ const PROVIDERS := {
 	},
 	"grok": {
 		"label": "xAI Grok",
-		"model": "grok-4.5",
 		"dialect": "openai",
+		"model_setting": "vision_routing/grok_model",
+		"model_placeholder": "grok-4.5",
 		"host": "api.x.ai",
 		"port": 443,
 		"path": "/v1/chat/completions",
@@ -86,7 +92,6 @@ const SETTING_ENABLED := "vision_routing/enabled"
 const SETTING_PROVIDER := "vision_routing/provider"
 const SETTING_API_KEY_ENC := "vision_routing/api_key_enc"
 const TAB_NAME := "Vision Routing"
-const ROW_NAME := "VisionRoutingToggleRow"
 
 const MAX_IMAGE_EDGE := 1024
 const CONNECT_TIMEOUT_MS := 4000
@@ -95,6 +100,10 @@ const REQUEST_TIMEOUT_MS := 8000
 ## Kept under the server's 15s editor_screenshot window so the fallback
 ## pass-through always lands before the server gives up on slow providers.
 const TOTAL_ROUTE_BUDGET_MS := 10000
+## Response body cap: the deadline bounds time but not bytes, and the socket
+## talks to third-party hosts - a faulty or hostile provider must not be able
+## to stream an unbounded body inside the window.
+const MAX_RESPONSE_BODY_BYTES := 1048576
 
 const _ENC_PREFIX := "v1"
 const _SALT := "vision_routing::v1::godot-ai"
@@ -105,9 +114,9 @@ var log_buffer: Object = null
 
 var _active := true
 var _route_done: Callable
-var _pending: Dictionary = {}   # request_id -> {payload, data, connection}
+var _pending: Dictionary = {}   # request_id -> {payload, data, connection, provider_id, provider, params}
 var _threads: Dictionary = {}   # request_id -> Thread ("_test" = ping thread)
-var _key_loading := false
+var _ui_loading := false
 
 # UI references, kept in sync by _sync_ui_states().
 var _tab_provider: OptionButton = null
@@ -115,9 +124,11 @@ var _tab_enable: CheckButton = null
 var _tab_key_label: Label = null
 var _tab_key_hint: Label = null
 var _tab_key_edit: LineEdit = null
+var _tab_model_label: Label = null
+var _tab_model_hint: Label = null
+var _tab_model_edit: LineEdit = null
 var _tab_status: Label = null
 var _tab_test_button: Button = null
-var _row_toggle: CheckButton = null
 
 
 func _init() -> void:
@@ -144,7 +155,9 @@ func shutdown() -> void:
 	_tab_key_edit = null
 	_tab_status = null
 	_tab_test_button = null
-	_row_toggle = null
+	_tab_model_label = null
+	_tab_model_hint = null
+	_tab_model_edit = null
 
 
 # --- routing ------------------------------------------------------------------
@@ -161,6 +174,11 @@ func route_editor_screenshot(params: Dictionary, original: Callable, connection:
 		return original.call(params)
 	var result := original.call(params)
 	if not (result is Dictionary) or not result.has("data"):
+		## Deferred capture (source="game"): the frame arrives later through
+		## route_game_payload. Stash the caller params (e.g. user_prompt) by
+		## request id so the routed description keeps the agent's context.
+		if result is Dictionary and result.get("_deferred", false):
+			_pending[rid] = {"params": params}
 		return result
 	var data: Variant = result["data"]
 	if not (data is Dictionary) or not data.has("image_base64"):
@@ -180,29 +198,47 @@ func route_editor_screenshot(params: Dictionary, original: Callable, connection:
 func route_game_payload(connection: Object, rid: String, payload: Dictionary) -> bool:
 	var data: Variant = payload.get("data")
 	if not (data is Dictionary) or not data.has("image_base64"):
+		## Not a routeable frame - drop any params stashed by
+		## route_editor_screenshot for this request id.
+		_pending.erase(rid)
 		return false
-	return _start_route(rid, "game", payload, data, connection, {})
+	## The editor handler stashed the caller params (user_prompt etc.) by
+	## request id when it deferred the capture; hand them to the prompt
+	## builder. Absent (older helper, direct call) = generic prompt.
+	var params: Dictionary = _pending.get(rid, {}).get("params", {})
+	return _start_route(rid, "game", payload, data, connection, params)
 
 
 ## Returns true when a worker owns the reply; false means the caller should
 ## pass the original payload through unchanged.
 func _start_route(rid: String, source: String, payload: Dictionary, data: Dictionary, connection: Object, params: Dictionary) -> bool:
 	var provider_id := _active_provider_id()
-	var provider: Dictionary = PROVIDERS.get(provider_id, PROVIDERS["groq"])
+	var base_provider: Dictionary = PROVIDERS.get(provider_id, PROVIDERS["groq"])
+	## Worker-thread snapshot: the entered model id is resolved into the
+	## provider dict here, once, so the thread sees a stable copy and
+	## routed_via can report the exact model that was pinged.
+	var provider := _provider_with_model(provider_id)
 	var api_key := _resolved_api_key(provider_id)
 	if api_key.is_empty():
-		_log("vision routing: no API key for %s (set %s or paste one in the Vision Routing tab) - screenshot %s passed through" % [provider_id, provider.get("env", ""), rid])
+		_log("vision routing: no API key for %s (set %s or paste one in the Vision Routing section) - screenshot %s passed through" % [provider_id, base_provider.get("env", ""), rid])
+		_pending.erase(rid)
 		return false
-	_pending[rid] = {"payload": payload, "data": data, "connection": connection, "provider": provider_id}
+	if str(provider.get("model", "")).is_empty():
+		## Empty model behaves exactly like empty key: routing declines, the
+		## image passes through, and the log line says what is missing.
+		_log("vision routing: no model id set for %s - screenshot %s passed through (set a model id in the Vision Routing section)" % [provider_id, rid])
+		_pending.erase(rid)
+		return false
+	_pending[rid] = {"payload": payload, "data": data, "connection": connection, "provider_id": provider_id, "provider": provider, "params": params}
 	var prompt := _build_prompt(params)
 	var thread := Thread.new()
-	var start_err := thread.start(_route_worker.bind(provider_id, str(data.get("image_base64", "")), prompt, api_key, rid))
+	var start_err := thread.start(_route_worker.bind(provider, str(data.get("image_base64", "")), prompt, api_key, rid))
 	if start_err != OK:
 		_pending.erase(rid)
 		_log("vision routing: could not start worker for %s: %s - screenshot %s passed through" % [rid, error_string(start_err), source])
 		return false
 	_threads[rid] = thread
-	_log("vision routing: routing %s screenshot %s (%d b64 chars) via %s (%s)" % [source, rid, str(data.get("image_base64", "")).length(), provider.get("label", provider_id), provider.get("model", "")])
+	_log("vision routing: routing %s screenshot %s (%d b64 chars) via %s (%s)" % [source, rid, str(data.get("image_base64", "")).length(), base_provider.get("label", provider_id), provider.get("model", "")])
 	return true
 
 
@@ -218,8 +254,12 @@ func _on_route_complete(rid: String, result: Variant) -> void:
 	var connection: Object = entry.get("connection")
 	if connection == null or not is_instance_valid(connection):
 		return
-	var provider_id := str(entry.get("provider", "groq"))
-	var payload: Dictionary = entry.get("payload", {})
+	var provider_id := str(entry.get("provider_id", "groq"))
+	## Provider snapshot taken at route start (with the entered model id);
+	## falls back to a fresh resolve if absent (direct test callers).
+	var provider: Dictionary = entry.get("provider", {})
+	if provider.is_empty():
+		provider = _provider_with_model(provider_id)
 	## Workers return {"desc": ..., "error": ...}; plain strings are accepted
 	## for backwards compatibility (tests / older callers).
 	var description_str := ""
@@ -232,12 +272,18 @@ func _on_route_complete(rid: String, result: Variant) -> void:
 	if description_str.is_empty():
 		if error_str.is_empty():
 			error_str = "unknown error"
-		_log("vision routing: %s failed for %s (%s) - returning original image" % [provider_id, rid, error_str])
-		_pass_through(connection, rid, payload)
+		_log("vision routing: %s failed for %s (%s) - returning original image with failure note" % [provider_id, rid, error_str])
+		## Append a short templated reason to the note so text-only agents
+		## (who otherwise just receive a useless image block) learn the
+		## feature is down and why.
+		var failed_data: Dictionary = entry.get("data", {}).duplicate()
+		var failure_note := "Vision routing unavailable (%s): %s" % [provider_id, error_str]
+		var existing_note := str(failed_data.get("note", ""))
+		failed_data["note"] = (existing_note + " | " if not existing_note.is_empty() else "") + failure_note
+		_pass_through(connection, rid, {"data": failed_data})
 		return
 	var data: Dictionary = entry.get("data", {}).duplicate()
-	var provider: Dictionary = PROVIDERS.get(provider_id, PROVIDERS["groq"])
-	var routed_via := "%s:%s" % [provider_id, provider.get("model", MODEL_ID)]
+	var routed_via := "%s:%s" % [provider_id, provider.get("model", "")]
 	## The server forwards a fixed whitelist of metadata keys into the text
 	## result; `note` is the free-form one, so a self-attributing description
 	## rides there (plus an explicit `vision_description` key) so text-only
@@ -279,25 +325,31 @@ func _build_prompt(params: Dictionary) -> String:
 
 # --- routing worker (thread) ---------------------------------------------------
 
-func _route_worker(provider_id: String, image_b64: String, prompt: String, api_key: String, rid: String) -> void:
-	var result := _describe_blocking(provider_id, image_b64, prompt, api_key)
+func _route_worker(provider: Dictionary, image_b64: String, prompt: String, api_key: String, rid: String) -> void:
+	var result := _describe_blocking(provider, image_b64, prompt, api_key)
 	_route_done.call_deferred(rid, result)
 
 
 ## Returns {"desc": String, "error": String}; "desc" is empty on failure and
 ## "error" carries the reason. Runs on a worker thread, so it never writes
-## shared state - everything it needs is passed in and returned.
-func _describe_blocking(provider_id: String, image_b64: String, prompt: String, api_key: String) -> Dictionary:
-	var provider: Dictionary = PROVIDERS.get(provider_id, PROVIDERS["groq"])
+## shared state - everything it needs is passed in and returned. `provider`
+## is the route-start snapshot (includes the entered model id).
+func _describe_blocking(provider: Dictionary, image_b64: String, prompt: String, api_key: String) -> Dictionary:
 	var b64 := _downscale_image_if_needed(image_b64)
 	var body := _build_request_body(provider, prompt, b64)
 	var headers := _build_headers(provider, api_key)
-	var response := _http_post_json(str(provider.get("host", "")), int(provider.get("port", 443)), str(provider.get("path", "")), headers, body)
+	var response := _http_post_json(str(provider.get("host", "")), int(provider.get("port", 443)), _resolve_path(provider), headers, body)
 	return _parse_description(provider, response)
 
 
+## Provider paths may carry a {model} placeholder (Gemini's endpoint embeds
+## the model id); substitute the entered model id verbatim.
+func _resolve_path(provider: Dictionary) -> String:
+	return str(provider.get("path", "")).replace("{model}", str(provider.get("model", "")))
+
+
 func _build_request_body(provider: Dictionary, prompt: String, image_b64: String) -> String:
-	var model := str(provider.get("model", MODEL_ID))
+	var model := str(provider.get("model", ""))
 	if str(provider.get("dialect", "")) == "gemini":
 		return JSON.stringify({
 			"contents": [{
@@ -406,27 +458,20 @@ func _strip_think(text: String) -> String:
 	return out
 
 
-## Minimal text-only call used by the "Test connection" button.
-func _ping_blocking(provider_id: String, api_key: String) -> Dictionary:
-	var provider: Dictionary = PROVIDERS.get(provider_id, PROVIDERS["groq"])
-	var body := ""
-	if str(provider.get("dialect", "")) == "gemini":
-		body = JSON.stringify({
-			"contents": [{"role": "user", "parts": [{"text": "Reply with exactly: OK"}]}],
-		})
-	else:
-		body = JSON.stringify({
-			"model": provider.get("model", MODEL_ID),
-			"messages": [{"role": "user", "content": "Reply with exactly: OK"}],
-			"max_tokens": 5,
-		})
-	var response := _http_post_json(str(provider.get("host", "")), int(provider.get("port", 443)), str(provider.get("path", "")), _build_headers(provider, api_key), body)
+## Minimal vision call used by the "Test connection" button. Sends the same
+## image-bearing body shape as real routing (with the 2x2 placeholder PNG),
+## so one click validates key + model existence + image capability - a
+## text-only or retired model id fails loudly here instead of at screenshot
+## time. `provider` is the route-style snapshot (includes the model id).
+func _ping_blocking(provider: Dictionary, api_key: String) -> Dictionary:
+	var body := _build_request_body(provider, "Reply with exactly: OK", _PLACEHOLDER_PNG)
+	var response := _http_post_json(str(provider.get("host", "")), int(provider.get("port", 443)), _resolve_path(provider), _build_headers(provider, api_key), body)
 	var code: int = int(response.get("code", 0))
 	if code == 200:
 		return {"ok": true, "error": ""}
 	if code == 0:
 		return {"ok": false, "error": str(response.get("error", "request failed"))}
-	return {"ok": false, "error": "%s HTTP %d: %s" % [provider.get("label", provider_id), code, _body_snippet(str(response.get("text", "")))]}
+	return {"ok": false, "error": "%s HTTP %d: %s" % [provider.get("label", "provider"), code, _body_snippet(str(response.get("text", "")))]}
 
 
 func _http_post_json(host: String, port: int, path: String, headers: PackedStringArray, body: String) -> Dictionary:
@@ -492,6 +537,9 @@ func _http_post_json(host: String, port: int, path: String, headers: PackedStrin
 			http.close()
 			return {"code": 0, "error": "aborted (plugin teardown)"}
 		chunks.append_array(http.read_response_body_chunk())
+		if chunks.size() > MAX_RESPONSE_BODY_BYTES:
+			http.close()
+			return {"code": 0, "error": "response body exceeded %d bytes" % MAX_RESPONSE_BODY_BYTES}
 		http.poll()
 		if Time.get_ticks_msec() > body_deadline:
 			break
@@ -543,17 +591,17 @@ func _downscale_image_if_needed(image_b64: String) -> String:
 	return Marshalls.raw_to_base64(out)
 
 
-func _ping_worker(provider_id: String, api_key: String, status_label: Label, key_source: String) -> void:
-	var result := _ping_blocking(provider_id, api_key)
-	Callable(self, "_on_ping_done").call_deferred(result, provider_id, status_label, key_source)
+func _ping_worker(provider: Dictionary, api_key: String, status_label: Label, key_source: String) -> void:
+	var result := _ping_blocking(provider, api_key)
+	Callable(self, "_on_ping_done").call_deferred(result, provider, status_label, key_source)
 
 
-func _on_ping_done(result: Dictionary, provider_id: String, status_label: Label, key_source: String) -> void:
+func _on_ping_done(result: Dictionary, provider: Dictionary, status_label: Label, key_source: String) -> void:
 	_join_thread("_test")
 	if _tab_test_button != null and is_instance_valid(_tab_test_button):
 		_tab_test_button.disabled = false
 	if status_label != null and is_instance_valid(status_label):
-		var label := str(PROVIDERS.get(provider_id, PROVIDERS["groq"]).get("label", provider_id))
+		var label := str(provider.get("label", "provider"))
 		if result.get("ok", false):
 			status_label.text = "OK - %s responded (%s)." % [label, key_source]
 		else:
@@ -631,6 +679,38 @@ func set_api_key(provider_id: String, plain: String) -> void:
 		_log("vision routing: cannot store %s key - this machine reports no unique id; set %s instead" % [provider_id, PROVIDERS.get(provider_id, PROVIDERS["groq"]).get("env", "")])
 		return
 	es.set_setting(_provider_setting(provider_id), blob)
+
+
+## The model id is stored per provider next to the key (a plain Editor
+## Setting - it is not a secret). Empty clears the slot.
+func set_model_id(provider_id: String, model: String) -> void:
+	var es := _settings()
+	if es == null:
+		return
+	es.set_setting(_model_setting(provider_id), model.strip_edges())
+
+
+func _model_setting(provider_id: String) -> String:
+	return str(PROVIDERS.get(provider_id, PROVIDERS["groq"]).get("model_setting", ""))
+
+
+func _resolved_model(provider_id: String) -> String:
+	var es := _settings()
+	if es == null:
+		return ""
+	var setting := _model_setting(provider_id)
+	if not es.has_setting(setting):
+		return ""
+	return str(es.get_setting(setting)).strip_edges()
+
+
+## Route-start snapshot: the curated provider table plus the user's entered
+## model id. Used by the worker thread and by _on_route_complete for the
+## routed_via label, so it always reports the model that was actually pinged.
+func _provider_with_model(provider_id: String) -> Dictionary:
+	var provider: Dictionary = PROVIDERS.get(provider_id, PROVIDERS["groq"]).duplicate()
+	provider["model"] = _resolved_model(provider_id)
+	return provider
 
 
 ## Machine-derived key: not a password, but enough that a casually-opened
@@ -714,17 +794,13 @@ func _decrypt(blob: String) -> String:
 
 # --- UI: tab in Clients & Tools -------------------------------------------------
 
-## Builds the "Vision Routing" tab. Called by mcp_dock._build_ui right after
-## the Settings tab is built, so it appears directly after Settings.
-func build_tab(tabs: TabContainer) -> void:
-	var margin := MarginContainer.new()
-	margin.name = TAB_NAME
-	for side in ["margin_left", "margin_right", "margin_top", "margin_bottom"]:
-		margin.add_theme_constant_override(side, 12)
+## Builds the "Vision Routing" section inside the Clients & Tools Settings
+## tab. Called by mcp_dock._build_settings_tab; `refresh_ui()` re-syncs the
+## controls from Editor Settings each time the window opens.
+func build_section(parent: VBoxContainer) -> void:
 	var box := VBoxContainer.new()
 	box.add_theme_constant_override("separation", 8)
-	margin.add_child(box)
-	tabs.add_child(margin)
+	parent.add_child(box)
 
 	var header := Label.new()
 	header.text = "Vision Routing"
@@ -737,11 +813,11 @@ func build_tab(tabs: TabContainer) -> void:
 	provider_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	provider_row.add_child(provider_label)
 	_tab_provider = OptionButton.new()
-	_tab_provider.tooltip_text = "Which vision provider routes the screenshots. The model is fixed per provider (shown in brackets) so it can never silently change."
+	_tab_provider.tooltip_text = "Which vision provider routes the screenshots. The model id is required per provider and is yours to maintain."
 	var active_provider := _active_provider_id()
 	for provider_index in PROVIDER_ORDER.size():
 		var provider_item: Dictionary = PROVIDERS[PROVIDER_ORDER[provider_index]]
-		_tab_provider.add_item("%s (%s)" % [provider_item.get("label", PROVIDER_ORDER[provider_index]), provider_item.get("model", "")], provider_index)
+		_tab_provider.add_item(str(provider_item.get("label", PROVIDER_ORDER[provider_index])), provider_index)
 		if PROVIDER_ORDER[provider_index] == active_provider:
 			_tab_provider.select(provider_index)
 	_tab_provider.item_selected.connect(_on_provider_changed)
@@ -766,8 +842,7 @@ func build_tab(tabs: TabContainer) -> void:
 		+ "the Provider dropdown) for a text description. The description is "
 		+ "returned to the AI instead of the raw image, so models without image "
 		+ "support (e.g. DeepSeek) can still \"see\" the editor and game. When "
-		+ "the connected model analyzes images itself, switch this off (or use "
-		+ "the quick toggle under Developer mode in the Godot AI dock) so "
+		+ "the connected model analyzes images itself, switch this off here so "
 		+ "screenshots pass through unchanged."
 	)
 	description.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
@@ -779,7 +854,6 @@ func build_tab(tabs: TabContainer) -> void:
 
 	var key_row := HBoxContainer.new()
 	_tab_key_edit = LineEdit.new()
-	_tab_key_edit.placeholder_text = "gsk_..."
 	_tab_key_edit.secret = true
 	_tab_key_edit.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	## Persist on commit (Enter / focus loss) instead of per keystroke, so
@@ -793,15 +867,28 @@ func build_tab(tabs: TabContainer) -> void:
 	show_button.toggled.connect(func(show: bool) -> void: _tab_key_edit.secret = not show)
 	key_row.add_child(show_button)
 	box.add_child(key_row)
-	_key_loading = true
-	_tab_key_edit.text = _decrypted_key(_active_provider_id())
-	_key_loading = false
-	_sync_provider_ui()
 
 	_tab_key_hint = Label.new()
 	_tab_key_hint.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	_tab_key_hint.add_theme_color_override("font_color", Color(0.55, 0.55, 0.55))
 	box.add_child(_tab_key_hint)
+
+	_tab_model_label = Label.new()
+	box.add_child(_tab_model_label)
+
+	var model_row := HBoxContainer.new()
+	_tab_model_edit = LineEdit.new()
+	_tab_model_edit.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	## Persist on commit (Enter / focus loss), same pattern as the key field.
+	_tab_model_edit.text_submitted.connect(_on_model_committed)
+	_tab_model_edit.focus_exited.connect(func() -> void: _on_model_committed(_tab_model_edit.text))
+	model_row.add_child(_tab_model_edit)
+	box.add_child(model_row)
+
+	_tab_model_hint = Label.new()
+	_tab_model_hint.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_tab_model_hint.add_theme_color_override("font_color", Color(0.55, 0.55, 0.55))
+	box.add_child(_tab_model_hint)
 
 	var test_row := HBoxContainer.new()
 	var test_button := Button.new()
@@ -815,11 +902,34 @@ func build_tab(tabs: TabContainer) -> void:
 	test_row.add_child(_tab_status)
 	box.add_child(test_row)
 
+	refresh_ui()
+
+
+## Re-syncs every control from Editor Settings. Called after the section is
+## built and again by mcp_dock each time the Clients & Tools window opens,
+## so a change made in another editor instance (or a hand-edit of
+## editor_settings-4.tres) is reflected.
+func refresh_ui() -> void:
+	_sync_ui_states()
+	_sync_provider_ui()
+	_ui_loading = true
+	if _tab_key_edit != null and is_instance_valid(_tab_key_edit):
+		_tab_key_edit.text = _decrypted_key(_active_provider_id())
+	if _tab_model_edit != null and is_instance_valid(_tab_model_edit):
+		_tab_model_edit.text = _resolved_model(_active_provider_id())
+	_ui_loading = false
+
 
 func _on_key_committed(_new_text: String) -> void:
-	if _key_loading:
+	if _ui_loading:
 		return
 	set_api_key(_active_provider_id(), _tab_key_edit.text)
+
+
+func _on_model_committed(_new_text: String) -> void:
+	if _ui_loading:
+		return
+	set_model_id(_active_provider_id(), _tab_model_edit.text)
 
 
 func _on_provider_changed(index: int) -> void:
@@ -829,12 +939,14 @@ func _on_provider_changed(index: int) -> void:
 	var es := _settings()
 	if es != null:
 		es.set_setting(SETTING_PROVIDER, provider_id)
-	_key_loading = true
+	_ui_loading = true
 	if _tab_key_edit != null and is_instance_valid(_tab_key_edit):
 		_tab_key_edit.text = _decrypted_key(provider_id)
-	_key_loading = false
+	if _tab_model_edit != null and is_instance_valid(_tab_model_edit):
+		_tab_model_edit.text = _resolved_model(provider_id)
+	_ui_loading = false
 	_sync_provider_ui()
-	_log("vision routing: provider changed to %s (%s)" % [provider_id, PROVIDERS[provider_id].get("model", "")])
+	_log("vision routing: provider changed to %s (%s)" % [provider_id, PROVIDERS[provider_id].get("label", provider_id)])
 
 
 func _sync_provider_ui() -> void:
@@ -857,14 +969,28 @@ func _sync_provider_ui() -> void:
 		_tab_key_hint.text = hint
 	if _tab_key_edit != null and is_instance_valid(_tab_key_edit):
 		_tab_key_edit.placeholder_text = str(provider.get("placeholder", ""))
+	if _tab_model_label != null and is_instance_valid(_tab_model_label):
+		_tab_model_label.text = "Model id (required) - %s" % provider.get("label", provider_id)
+	if _tab_model_edit != null and is_instance_valid(_tab_model_edit):
+		_tab_model_edit.placeholder_text = str(provider.get("model_placeholder", ""))
+		_tab_model_edit.tooltip_text = "The vision model this provider should ping. Yours to maintain: when a model id retires, replace it here."
+	if _tab_model_hint != null and is_instance_valid(_tab_model_hint):
+		_tab_model_hint.text = (
+			"Required per provider; empty behaves like an empty key (routing "
+			+ "declines and screenshots pass through). Suggested id (as of "
+			+ "2026-08 - check your provider console, ids retire): %s."
+		) % provider.get("model_placeholder", "")
 
 
 func _on_test_connection() -> void:
 	if _tab_status == null:
 		return
 	var provider_id := _active_provider_id()
-	var provider: Dictionary = PROVIDERS.get(provider_id, PROVIDERS["groq"])
-	var env_name := str(provider.get("env", ""))
+	var provider := _provider_with_model(provider_id)
+	var env_name := str(PROVIDERS.get(provider_id, PROVIDERS["groq"]).get("env", ""))
+	if str(provider.get("model", "")).is_empty():
+		_tab_status.text = "No model id set for %s - add one below." % provider.get("label", provider_id)
+		return
 	var api_key := _resolved_api_key(provider_id)
 	if api_key.is_empty():
 		_tab_status.text = "No key set - add one below or set %s." % env_name
@@ -872,6 +998,7 @@ func _on_test_connection() -> void:
 	var running: Thread = _threads.get("_test")
 	if running != null and running.is_started() and running.is_alive():
 		return
+	var previous_status := _tab_status.text
 	_tab_status.text = "Testing..."
 	if _tab_test_button != null and is_instance_valid(_tab_test_button):
 		_tab_test_button.disabled = true
@@ -880,26 +1007,15 @@ func _on_test_connection() -> void:
 		key_source = "via %s" % env_name
 	var thread := Thread.new()
 	_threads["_test"] = thread
-	thread.start(_ping_worker.bind(provider_id, api_key, _tab_status, key_source))
-
-
-# --- UI: quick toggle in the dock ----------------------------------------------
-
-## Builds the "Vision Routing" quick toggle. Called by mcp_dock._build_ui
-## right after the Developer mode row, so it sits directly under it.
-func build_toggle_row(body: VBoxContainer) -> void:
-	var row := HBoxContainer.new()
-	row.name = ROW_NAME
-	var label := Label.new()
-	label.text = "Vision Routing"
-	label.tooltip_text = "Route screenshot-tool images through the selected provider's vision API (see the Vision Routing tab in Clients & Tools)."
-	label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	row.add_child(label)
-	_row_toggle = CheckButton.new()
-	_row_toggle.button_pressed = is_routing_enabled()
-	_row_toggle.toggled.connect(_on_enable_toggled)
-	row.add_child(_row_toggle)
-	body.add_child(row)
+	var start_err := thread.start(_ping_worker.bind(provider, api_key, _tab_status, key_source))
+	if start_err != OK:
+		## A failed thread start must not leave the button disabled and the
+		## status stuck on "Testing..." forever.
+		_threads.erase("_test")
+		_tab_status.text = previous_status
+		if _tab_test_button != null and is_instance_valid(_tab_test_button):
+			_tab_test_button.disabled = false
+		_log("vision routing: could not start ping thread: %s" % error_string(start_err))
 
 
 func _on_enable_toggled(enabled: bool) -> void:
@@ -913,8 +1029,6 @@ func _sync_ui_states() -> void:
 	var enabled := is_routing_enabled()
 	if _tab_enable != null and is_instance_valid(_tab_enable) and _tab_enable.button_pressed != enabled:
 		_tab_enable.set_pressed_no_signal(enabled)
-	if _row_toggle != null and is_instance_valid(_row_toggle) and _row_toggle.button_pressed != enabled:
-		_row_toggle.set_pressed_no_signal(enabled)
 
 
 # --- logging --------------------------------------------------------------------

--- a/plugin/addons/godot_ai/vision_routing.gd
+++ b/plugin/addons/godot_ai/vision_routing.gd
@@ -4,7 +4,7 @@ extends RefCounted
 ## Vision Routing - route screenshot-tool images through a curated vision API.
 ##
 ## Models without image support (e.g. DeepSeek) cannot read the image blocks the
-## screenshot tool returns. When routing is enabled, every capture is sent to a
+## screenshot tool returns. When routing is enabled, every single-image capture is sent to a
 ## vision model on a worker thread and the resulting text description is
 ## returned to the AI instead:
 ##
@@ -22,7 +22,7 @@ extends RefCounted
 ## in the UI) so switching providers can never ping the wrong model:
 ##   - Groq          -> qwen/qwen3.6-27b     (free tier)
 ##   - Google Gemini -> gemini-2.5-flash     (free tier, AI Studio key)
-##   - xAI Grok      -> grok-2-vision-latest (image understanding)
+##   - xAI Grok      -> grok-4.5              (image understanding)
 ## Groq and Grok speak the OpenAI chat-completions dialect; Gemini uses the
 ## generateContent REST dialect. Both are handled in this file.
 ##
@@ -69,7 +69,7 @@ const PROVIDERS := {
 	},
 	"grok": {
 		"label": "xAI Grok",
-		"model": "grok-2-vision-latest",
+		"model": "grok-4.5",
 		"dialect": "openai",
 		"host": "api.x.ai",
 		"port": 443,
@@ -103,7 +103,6 @@ var _active := true
 var _route_done: Callable
 var _pending: Dictionary = {}   # request_id -> {payload, data, connection}
 var _threads: Dictionary = {}   # request_id -> Thread ("_test" = ping thread)
-var _error_notes: Dictionary = {}  # request_id -> last vision-routing error detail
 var _key_loading := false
 
 # UI references, kept in sync by _sync_ui_states().
@@ -129,11 +128,10 @@ func shutdown() -> void:
 	## case is a connect/request timeout.
 	for rid in _threads:
 		var thread: Thread = _threads[rid]
-		if thread != null and thread.is_started() and thread.is_alive():
+		if thread != null and thread.is_started():
 			thread.wait_to_finish()
 	_threads.clear()
 	_pending.clear()
-	_error_notes.clear()
 	_tab_provider = null
 	_tab_enable = null
 	_tab_key_label = null
@@ -188,13 +186,17 @@ func _start_route(rid: String, source: String, payload: Dictionary, data: Dictio
 	_pending[rid] = {"payload": payload, "data": data, "connection": connection, "provider": provider_id}
 	var prompt := _build_prompt(params)
 	var thread := Thread.new()
+	var start_err := thread.start(_route_worker.bind(provider_id, str(data.get("image_base64", "")), prompt, api_key, rid))
+	if start_err != OK:
+		_pending.erase(rid)
+		_log("vision routing: could not start worker for %s: %s - screenshot %s passed through" % [rid, error_string(start_err), source])
+		return false
 	_threads[rid] = thread
-	thread.start(_route_worker.bind(provider_id, str(data.get("image_base64", "")), prompt, api_key, rid))
 	_log("vision routing: routing %s screenshot %s (%d b64 chars) via %s (%s)" % [source, rid, str(data.get("image_base64", "")).length(), provider.get("label", provider_id), provider.get("model", "")])
 	return true
 
 
-func _on_route_complete(rid: String, description: Variant) -> void:
+func _on_route_complete(rid: String, result: Variant) -> void:
 	_join_thread(rid)
 	if not _active:
 		_pending.erase(rid)
@@ -208,13 +210,21 @@ func _on_route_complete(rid: String, description: Variant) -> void:
 		return
 	var provider_id := str(entry.get("provider", "groq"))
 	var payload: Dictionary = entry.get("payload", {})
-	var description_str := str(description) if description != null else ""
+	## Workers return {"desc": ..., "error": ...}; plain strings are accepted
+	## for backwards compatibility (tests / older callers).
+	var description_str := ""
+	var error_str := ""
+	if result is Dictionary:
+		description_str = str(result.get("desc", ""))
+		error_str = str(result.get("error", ""))
+	elif result != null:
+		description_str = str(result)
 	if description_str.is_empty():
-		_log("vision routing: %s failed for %s (%s) - returning original image" % [provider_id, rid, _error_notes.get(rid, "unknown error")])
-		_error_notes.erase(rid)
+		if error_str.is_empty():
+			error_str = "unknown error"
+		_log("vision routing: %s failed for %s (%s) - returning original image" % [provider_id, rid, error_str])
 		_pass_through(connection, rid, payload)
 		return
-	_error_notes.erase(rid)
 	var data: Dictionary = entry.get("data", {}).duplicate()
 	## The server forwards a fixed whitelist of metadata keys into the text
 	## result; `note` is the free-form one, so the description rides there
@@ -260,17 +270,20 @@ func _build_prompt(params: Dictionary) -> String:
 # --- routing worker (thread) ---------------------------------------------------
 
 func _route_worker(provider_id: String, image_b64: String, prompt: String, api_key: String, rid: String) -> void:
-	var description := _describe_blocking(provider_id, image_b64, prompt, api_key, rid)
-	_route_done.call_deferred(rid, description)
+	var result := _describe_blocking(provider_id, image_b64, prompt, api_key)
+	_route_done.call_deferred(rid, result)
 
 
-func _describe_blocking(provider_id: String, image_b64: String, prompt: String, api_key: String, rid: String) -> String:
+## Returns {"desc": String, "error": String}; "desc" is empty on failure and
+## "error" carries the reason. Runs on a worker thread, so it never writes
+## shared state - everything it needs is passed in and returned.
+func _describe_blocking(provider_id: String, image_b64: String, prompt: String, api_key: String) -> Dictionary:
 	var provider: Dictionary = PROVIDERS.get(provider_id, PROVIDERS["groq"])
 	var b64 := _downscale_image_if_needed(image_b64)
 	var body := _build_request_body(provider, prompt, b64)
 	var headers := _build_headers(provider, api_key)
 	var response := _http_post_json(str(provider.get("host", "")), int(provider.get("port", 443)), str(provider.get("path", "")), headers, body)
-	return _parse_description(provider, response, rid)
+	return _parse_description(provider, response)
 
 
 func _build_request_body(provider: Dictionary, prompt: String, image_b64: String) -> String:
@@ -314,44 +327,37 @@ func _build_headers(provider: Dictionary, api_key: String) -> PackedStringArray:
 	])
 
 
-func _parse_description(provider: Dictionary, response: Dictionary, rid: String) -> String:
+func _parse_description(provider: Dictionary, response: Dictionary) -> Dictionary:
 	var code: int = int(response.get("code", 0))
 	var label := str(provider.get("label", str(provider.get("model", "?"))))
 	if code == 0:
-		_error_notes[rid] = str(response.get("error", "HTTP request failed"))
-		return ""
+		return {"desc": "", "error": str(response.get("error", "HTTP request failed"))}
 	if code != 200:
-		_error_notes[rid] = "%s HTTP %d: %s" % [label, code, _body_snippet(str(response.get("text", "")))]
-		return ""
+		return {"desc": "", "error": "%s HTTP %d: %s" % [label, code, _body_snippet(str(response.get("text", "")))]}
 	var parsed: Variant = JSON.parse_string(str(response.get("text", "")))
 	if not (parsed is Dictionary):
-		_error_notes[rid] = "%s response was not JSON: %s" % [label, _body_snippet(str(response.get("text", "")))]
-		return ""
+		return {"desc": "", "error": "%s response was not JSON: %s" % [label, _body_snippet(str(response.get("text", "")))]}
 	if str(provider.get("dialect", "")) == "gemini":
-		return _parse_gemini(parsed, label, response, rid)
-	return _parse_openai(parsed, label, response, rid)
+		return _parse_gemini(parsed, label, response)
+	return _parse_openai(parsed, label, response)
 
 
-func _parse_openai(parsed: Dictionary, label: String, response: Dictionary, rid: String) -> String:
+func _parse_openai(parsed: Dictionary, label: String, response: Dictionary) -> Dictionary:
 	var choices: Variant = parsed.get("choices")
 	if not (choices is Array) or choices.is_empty():
-		_error_notes[rid] = "%s response had no choices: %s" % [label, _body_snippet(str(response.get("text", "")))]
-		return ""
+		return {"desc": "", "error": "%s response had no choices: %s" % [label, _body_snippet(str(response.get("text", "")))]}
 	if not (choices[0] is Dictionary):
-		_error_notes[rid] = "%s response choice was not an object: %s" % [label, _body_snippet(str(response.get("text", "")))]
-		return ""
+		return {"desc": "", "error": "%s response choice was not an object: %s" % [label, _body_snippet(str(response.get("text", "")))]}
 	var message: Variant = choices[0].get("message", {})
 	if not (message is Dictionary):
-		_error_notes[rid] = "%s response message was not an object: %s" % [label, _body_snippet(str(response.get("text", "")))]
-		return ""
+		return {"desc": "", "error": "%s response message was not an object: %s" % [label, _body_snippet(str(response.get("text", "")))]}
 	var content: Variant = message.get("content", "")
 	if content == null:
-		_error_notes[rid] = "%s response content was null: %s" % [label, _body_snippet(str(response.get("text", "")))]
-		return ""
-	return _strip_think(str(content))
+		return {"desc": "", "error": "%s response content was null: %s" % [label, _body_snippet(str(response.get("text", "")))]}
+	return {"desc": _strip_think(str(content)), "error": ""}
 
 
-func _parse_gemini(parsed: Dictionary, label: String, response: Dictionary, rid: String) -> String:
+func _parse_gemini(parsed: Dictionary, label: String, response: Dictionary) -> Dictionary:
 	var candidates: Variant = parsed.get("candidates")
 	if not (candidates is Array) or candidates.is_empty():
 		var reason := ""
@@ -361,19 +367,15 @@ func _parse_gemini(parsed: Dictionary, label: String, response: Dictionary, rid:
 		var reason_part := ""
 		if not reason.is_empty():
 			reason_part = " (blocked: %s)" % reason
-		_error_notes[rid] = "%s response had no candidates%s: %s" % [label, reason_part, _body_snippet(str(response.get("text", "")))]
-		return ""
+		return {"desc": "", "error": "%s response had no candidates%s: %s" % [label, reason_part, _body_snippet(str(response.get("text", "")))]}
 	if not (candidates[0] is Dictionary):
-		_error_notes[rid] = "%s response candidate was not an object: %s" % [label, _body_snippet(str(response.get("text", "")))]
-		return ""
+		return {"desc": "", "error": "%s response candidate was not an object: %s" % [label, _body_snippet(str(response.get("text", "")))]}
 	var content: Variant = candidates[0].get("content", {})
 	if not (content is Dictionary):
-		_error_notes[rid] = "%s response content was missing: %s" % [label, _body_snippet(str(response.get("text", "")))]
-		return ""
+		return {"desc": "", "error": "%s response content was missing: %s" % [label, _body_snippet(str(response.get("text", "")))]}
 	var parts: Variant = content.get("parts")
 	if not (parts is Array) or parts.is_empty():
-		_error_notes[rid] = "%s response had no parts: %s" % [label, _body_snippet(str(response.get("text", "")))]
-		return ""
+		return {"desc": "", "error": "%s response had no parts: %s" % [label, _body_snippet(str(response.get("text", "")))]}
 	var texts := PackedStringArray()
 	for part in parts:
 		if part is Dictionary:
@@ -381,9 +383,8 @@ func _parse_gemini(parsed: Dictionary, label: String, response: Dictionary, rid:
 			if not part_text.is_empty():
 				texts.append(part_text)
 	if texts.is_empty():
-		_error_notes[rid] = "%s response parts had no text: %s" % [label, _body_snippet(str(response.get("text", "")))]
-		return ""
-	return _strip_think("\n".join(texts))
+		return {"desc": "", "error": "%s response parts had no text: %s" % [label, _body_snippet(str(response.get("text", "")))]}
+	return {"desc": _strip_think("\n".join(texts)), "error": ""}
 
 
 func _strip_think(text: String) -> String:
@@ -474,6 +475,9 @@ func _http_post_json(host: String, port: int, path: String, headers: PackedStrin
 	var chunks := PackedByteArray()
 	var body_deadline := Time.get_ticks_msec() + REQUEST_TIMEOUT_MS
 	while http.get_status() == HTTPClient.STATUS_BODY:
+		if not _active:
+			http.close()
+			return {"code": 0, "error": "aborted (plugin teardown)"}
 		chunks.append_array(http.read_response_body_chunk())
 		http.poll()
 		if Time.get_ticks_msec() > body_deadline:
@@ -550,7 +554,7 @@ func _settings() -> EditorSettings:
 
 func is_routing_enabled() -> bool:
 	var es := _settings()
-	if es == null:
+	if es == null or not es.has_setting(SETTING_ENABLED):
 		return false
 	var value = es.get_setting(SETTING_ENABLED)
 	return value != null and value
@@ -560,7 +564,9 @@ func _active_provider_id() -> String:
 	var es := _settings()
 	if es == null:
 		return "groq"
-	var stored := str(es.get_setting(SETTING_PROVIDER))
+	var stored := ""
+	if es.has_setting(SETTING_PROVIDER):
+		stored = str(es.get_setting(SETTING_PROVIDER))
 	if stored.is_empty() or not PROVIDERS.has(stored):
 		return "groq"
 	return stored
@@ -579,7 +585,10 @@ func _resolved_api_key(provider_id: String) -> String:
 	var es := _settings()
 	if es == null:
 		return ""
-	var blob := str(es.get_setting(_provider_setting(provider_id)))
+	var setting := _provider_setting(provider_id)
+	var blob := ""
+	if es.has_setting(setting):
+		blob = str(es.get_setting(setting))
 	if blob.is_empty():
 		return ""
 	return _decrypt(blob)
@@ -589,7 +598,10 @@ func _decrypted_key(provider_id: String) -> String:
 	var es := _settings()
 	if es == null:
 		return ""
-	return _decrypt(str(es.get_setting(_provider_setting(provider_id))))
+	var setting := _provider_setting(provider_id)
+	if not es.has_setting(setting):
+		return ""
+	return _decrypt(str(es.get_setting(setting)))
 
 
 func set_api_key(provider_id: String, plain: String) -> void:
@@ -633,6 +645,7 @@ func _encrypt(plain: String) -> String:
 	aes.finish()
 	var hmac := HMACContext.new()
 	hmac.start(HashingContext.HASH_SHA256, key)
+	hmac.update(iv)
 	hmac.update(cipher)
 	var mac := hmac.finish()
 	return "%s:%s:%s:%s" % [_ENC_PREFIX, Marshalls.raw_to_base64(iv), Marshalls.raw_to_base64(mac), Marshalls.raw_to_base64(cipher)]
@@ -650,6 +663,7 @@ func _decrypt(blob: String) -> String:
 	var key := _derive_key()
 	var hmac := HMACContext.new()
 	hmac.start(HashingContext.HASH_SHA256, key)
+	hmac.update(iv)
 	hmac.update(cipher)
 	var expected := hmac.finish()
 	if expected != mac:
@@ -716,8 +730,8 @@ func build_tab(tabs: TabContainer) -> void:
 
 	var description := Label.new()
 	description.text = (
-		"When enabled, every screenshot the AI model takes through the godot-ai "
-		+ "screenshot tool is sent to the selected provider's vision model (see "
+		"When enabled, every single-image screenshot the AI model takes through "
+		+ "the godot-ai screenshot tool is sent to the selected provider's vision model (see "
 		+ "the Provider dropdown) for a text description. The description is "
 		+ "returned to the AI instead of the raw image, so models without image "
 		+ "support (e.g. DeepSeek) can still \"see\" the editor and game. When "
@@ -737,7 +751,11 @@ func build_tab(tabs: TabContainer) -> void:
 	_tab_key_edit.placeholder_text = "gsk_..."
 	_tab_key_edit.secret = true
 	_tab_key_edit.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	_tab_key_edit.text_changed.connect(_on_key_text_changed)
+	## Persist on commit (Enter / focus loss) instead of per keystroke, so
+	## pasting a key does not re-encrypt and rewrite Editor Settings dozens
+	## of times.
+	_tab_key_edit.text_submitted.connect(_on_key_committed)
+	_tab_key_edit.focus_exited.connect(func() -> void: _on_key_committed(_tab_key_edit.text))
 	key_row.add_child(_tab_key_edit)
 	var show_button := CheckButton.new()
 	show_button.tooltip_text = "Show / hide key"
@@ -766,7 +784,7 @@ func build_tab(tabs: TabContainer) -> void:
 	box.add_child(test_row)
 
 
-func _on_key_text_changed(_new_text: String) -> void:
+func _on_key_committed(_new_text: String) -> void:
 	if _key_loading:
 		return
 	set_api_key(_active_provider_id(), _tab_key_edit.text)
@@ -816,6 +834,9 @@ func _on_test_connection() -> void:
 		_tab_status.text = "No key set - add one below or set %s." % provider.get("env", "")
 		return
 	_tab_status.text = "Testing..."
+	var running: Thread = _threads.get("_test")
+	if running != null and running.is_started() and running.is_alive():
+		return
 	var thread := Thread.new()
 	_threads["_test"] = thread
 	thread.start(_ping_worker.bind(provider_id, api_key, _tab_status))

--- a/plugin/addons/godot_ai/vision_routing.gd
+++ b/plugin/addons/godot_ai/vision_routing.gd
@@ -1,12 +1,12 @@
 @tool
 extends RefCounted
 
-## Vision Routing - route screenshot-tool images through Groq's free vision API.
+## Vision Routing - route screenshot-tool images through a curated vision API.
 ##
 ## Models without image support (e.g. DeepSeek) cannot read the image blocks the
-## screenshot tool returns. When routing is enabled, every capture is sent to
-## Groq's free vision model on a worker thread and the resulting text
-## description is returned to the AI instead:
+## screenshot tool returns. When routing is enabled, every capture is sent to a
+## vision model on a worker thread and the resulting text description is
+## returned to the AI instead:
 ##
 ##   - Editor (non-game) screenshots are captured normally by
 ##     editor_handler.gd, then described on a worker thread; the reply is
@@ -18,20 +18,72 @@ extends RefCounted
 ##   - On failure (missing key, network, API error) the original image payload
 ##     passes through unchanged, so the screenshot tool never breaks.
 ##
-## Settings live in Editor Settings (`vision_routing/enabled` and
-## `vision_routing/api_key_enc`); the API key is stored encrypted (AES-256-CBC,
-## key derived from this machine) rather than in plain text, and the
-## GROQ_API_KEY environment variable takes priority over the stored key.
+## Providers are curated: the model id is fixed per provider (shown in brackets
+## in the UI) so switching providers can never ping the wrong model:
+##   - Groq          -> qwen/qwen3.6-27b     (free tier)
+##   - Google Gemini -> gemini-2.5-flash     (free tier, AI Studio key)
+##   - xAI Grok      -> grok-2-vision-latest (image understanding)
+## Groq and Grok speak the OpenAI chat-completions dialect; Gemini uses the
+## generateContent REST dialect. Both are handled in this file.
+##
+## Settings live in Editor Settings (`vision_routing/enabled`,
+## `vision_routing/provider`, plus one encrypted key slot per provider). Keys
+## are stored encrypted (AES-256-CBC, key derived from this machine) rather
+## than in plain text, and each provider's environment variable
+## (GROQ_API_KEY / GOOGLE_API_KEY / XAI_API_KEY) takes priority over the
+## stored key.
 ##
 ## UI: "Vision Routing" tab in Clients & Tools (after Settings) plus a quick
 ## toggle in the dock right under Developer mode.
 
+## Backwards-compatible alias for the Groq model (used by tests + routed_via).
 const MODEL_ID := "qwen/qwen3.6-27b"
-const GROQ_HOST := "api.groq.com"
-const GROQ_PORT := 443
-const GROQ_PATH := "/openai/v1/chat/completions"
+
+## Curated providers: model ids are fixed here on purpose so the UI can show
+## them in brackets and the worker never pings a guessed model name.
+const PROVIDERS := {
+	"groq": {
+		"label": "Groq",
+		"model": MODEL_ID,
+		"dialect": "openai",
+		"host": "api.groq.com",
+		"port": 443,
+		"path": "/openai/v1/chat/completions",
+		"env": "GROQ_API_KEY",
+		"setting": "vision_routing/api_key_enc",
+		"placeholder": "gsk_...",
+		"key_label": "Groq API key (free tier: console.groq.com)",
+		"reasoning_effort": "none",
+	},
+	"google": {
+		"label": "Google Gemini",
+		"model": "gemini-2.5-flash",
+		"dialect": "gemini",
+		"host": "generativelanguage.googleapis.com",
+		"port": 443,
+		"path": "/v1beta/models/gemini-2.5-flash:generateContent",
+		"env": "GOOGLE_API_KEY",
+		"setting": "vision_routing/google_api_key_enc",
+		"placeholder": "AIza...",
+		"key_label": "Google AI Studio API key (free tier: aistudio.google.com)",
+	},
+	"grok": {
+		"label": "xAI Grok",
+		"model": "grok-2-vision-latest",
+		"dialect": "openai",
+		"host": "api.x.ai",
+		"port": 443,
+		"path": "/v1/chat/completions",
+		"env": "XAI_API_KEY",
+		"setting": "vision_routing/grok_api_key_enc",
+		"placeholder": "xai-...",
+		"key_label": "xAI API key (api.x.ai)",
+	},
+}
+const PROVIDER_ORDER := ["groq", "google", "grok"]
 
 const SETTING_ENABLED := "vision_routing/enabled"
+const SETTING_PROVIDER := "vision_routing/provider"
 const SETTING_API_KEY_ENC := "vision_routing/api_key_enc"
 const TAB_NAME := "Vision Routing"
 const ROW_NAME := "VisionRoutingToggleRow"
@@ -51,11 +103,14 @@ var _active := true
 var _route_done: Callable
 var _pending: Dictionary = {}   # request_id -> {payload, data, connection}
 var _threads: Dictionary = {}   # request_id -> Thread ("_test" = ping thread)
-var _error_notes: Dictionary = {}  # request_id -> last Groq error detail
+var _error_notes: Dictionary = {}  # request_id -> last vision-routing error detail
 var _key_loading := false
 
 # UI references, kept in sync by _sync_ui_states().
+var _tab_provider: OptionButton = null
 var _tab_enable: CheckButton = null
+var _tab_key_label: Label = null
+var _tab_key_hint: Label = null
 var _tab_key_edit: LineEdit = null
 var _tab_status: Label = null
 var _row_toggle: CheckButton = null
@@ -79,7 +134,10 @@ func shutdown() -> void:
 	_threads.clear()
 	_pending.clear()
 	_error_notes.clear()
+	_tab_provider = null
 	_tab_enable = null
+	_tab_key_label = null
+	_tab_key_hint = null
 	_tab_key_edit = null
 	_tab_status = null
 	_row_toggle = null
@@ -89,7 +147,7 @@ func shutdown() -> void:
 
 ## Entry point called from editor_handler.take_screenshot when routing is
 ## enabled. Runs the real capture (via `original`), then routes the image
-## through Groq on a worker thread. Returns the deferred-response sentinel
+## through the selected provider's vision API on a worker thread. Returns the deferred-response sentinel
 ## when the worker owns the reply, otherwise the capture result unchanged.
 func route_editor_screenshot(params: Dictionary, original: Callable, connection: Object) -> Dictionary:
 	var rid := str(params.get("_request_id", ""))
@@ -121,16 +179,18 @@ func route_game_payload(connection: Object, rid: String, payload: Dictionary) ->
 ## Returns true when a worker owns the reply; false means the caller should
 ## pass the original payload through unchanged.
 func _start_route(rid: String, source: String, payload: Dictionary, data: Dictionary, connection: Object, params: Dictionary) -> bool:
-	var api_key := _resolved_api_key()
+	var provider_id := _active_provider_id()
+	var provider: Dictionary = PROVIDERS.get(provider_id, PROVIDERS["groq"])
+	var api_key := _resolved_api_key(provider_id)
 	if api_key.is_empty():
-		_log("vision routing: no Groq API key - screenshot %s passed through" % rid)
+		_log("vision routing: no API key for %s (set %s or paste one in the Vision Routing tab) - screenshot %s passed through" % [provider_id, provider.get("env", ""), rid])
 		return false
-	_pending[rid] = {"payload": payload, "data": data, "connection": connection}
+	_pending[rid] = {"payload": payload, "data": data, "connection": connection, "provider": provider_id}
 	var prompt := _build_prompt(params)
 	var thread := Thread.new()
 	_threads[rid] = thread
-	thread.start(_groq_worker.bind(str(data.get("image_base64", "")), prompt, api_key, rid))
-	_log("vision routing: routing %s screenshot %s (%d b64 chars) via %s" % [source, rid, str(data.get("image_base64", "")).length(), MODEL_ID])
+	thread.start(_route_worker.bind(provider_id, str(data.get("image_base64", "")), prompt, api_key, rid))
+	_log("vision routing: routing %s screenshot %s (%d b64 chars) via %s (%s)" % [source, rid, str(data.get("image_base64", "")).length(), provider.get("label", provider_id), provider.get("model", "")])
 	return true
 
 
@@ -146,10 +206,11 @@ func _on_route_complete(rid: String, description: Variant) -> void:
 	var connection: Object = entry.get("connection")
 	if connection == null or not is_instance_valid(connection):
 		return
+	var provider_id := str(entry.get("provider", "groq"))
 	var payload: Dictionary = entry.get("payload", {})
 	var description_str := str(description) if description != null else ""
 	if description_str.is_empty():
-		_log("vision routing: Groq failed for %s (%s) - returning original image" % [rid, _error_notes.get(rid, "unknown error")])
+		_log("vision routing: %s failed for %s (%s) - returning original image" % [provider_id, rid, _error_notes.get(rid, "unknown error")])
 		_error_notes.erase(rid)
 		_pass_through(connection, rid, payload)
 		return
@@ -162,7 +223,8 @@ func _on_route_complete(rid: String, description: Variant) -> void:
 	## the payload stays well-formed.
 	data.erase("image_base64")
 	data["vision_description"] = description_str
-	data["routed_via"] = MODEL_ID
+	var provider: Dictionary = PROVIDERS.get(provider_id, PROVIDERS["groq"])
+	data["routed_via"] = "%s:%s" % [provider_id, provider.get("model", MODEL_ID)]
 	var original_note := str(data.get("note", ""))
 	data["note"] = (original_note + " | " if not original_note.is_empty() else "") + description_str
 	data["image_base64"] = _PLACEHOLDER_PNG
@@ -195,84 +257,172 @@ func _build_prompt(params: Dictionary) -> String:
 	return "\n".join(lines)
 
 
-# --- Groq worker (thread) -----------------------------------------------------
+# --- routing worker (thread) ---------------------------------------------------
 
-func _groq_worker(image_b64: String, prompt: String, api_key: String, rid: String) -> void:
-	var description := _groq_describe_blocking(image_b64, prompt, api_key, rid)
+func _route_worker(provider_id: String, image_b64: String, prompt: String, api_key: String, rid: String) -> void:
+	var description := _describe_blocking(provider_id, image_b64, prompt, api_key, rid)
 	_route_done.call_deferred(rid, description)
 
 
-func _groq_describe_blocking(image_b64: String, prompt: String, api_key: String, rid: String) -> String:
+func _describe_blocking(provider_id: String, image_b64: String, prompt: String, api_key: String, rid: String) -> String:
+	var provider: Dictionary = PROVIDERS.get(provider_id, PROVIDERS["groq"])
 	var b64 := _downscale_image_if_needed(image_b64)
-	var body := JSON.stringify({
-		"model": MODEL_ID,
+	var body := _build_request_body(provider, prompt, b64)
+	var headers := _build_headers(provider, api_key)
+	var response := _http_post_json(str(provider.get("host", "")), int(provider.get("port", 443)), str(provider.get("path", "")), headers, body)
+	return _parse_description(provider, response, rid)
+
+
+func _build_request_body(provider: Dictionary, prompt: String, image_b64: String) -> String:
+	var model := str(provider.get("model", MODEL_ID))
+	if str(provider.get("dialect", "")) == "gemini":
+		return JSON.stringify({
+			"contents": [{
+				"role": "user",
+				"parts": [
+					{"text": prompt},
+					{"inline_data": {"mime_type": "image/png", "data": image_b64}},
+				],
+			}],
+		})
+	var payload := {
+		"model": model,
 		"messages": [{
 			"role": "user",
 			"content": [
 				{"type": "text", "text": prompt},
-				{"type": "image_url", "image_url": {"url": "data:image/png;base64," + b64}},
+				{"type": "image_url", "image_url": {"url": "data:image/png;base64," + image_b64}},
 			],
 		}],
 		"max_tokens": 512,
 		"temperature": 0.2,
-		"reasoning_effort": "none",
-	})
-	var response := _http_post_json(api_key, body)
+	}
+	if provider.has("reasoning_effort"):
+		payload["reasoning_effort"] = provider["reasoning_effort"]
+	return JSON.stringify(payload)
+
+
+func _build_headers(provider: Dictionary, api_key: String) -> PackedStringArray:
+	if str(provider.get("dialect", "")) == "gemini":
+		return PackedStringArray([
+			"Content-Type: application/json",
+			"x-goog-api-key: %s" % api_key,
+		])
+	return PackedStringArray([
+		"Content-Type: application/json",
+		"Authorization: Bearer %s" % api_key,
+	])
+
+
+func _parse_description(provider: Dictionary, response: Dictionary, rid: String) -> String:
 	var code: int = int(response.get("code", 0))
+	var label := str(provider.get("label", str(provider.get("model", "?"))))
 	if code == 0:
 		_error_notes[rid] = str(response.get("error", "HTTP request failed"))
 		return ""
 	if code != 200:
-		_error_notes[rid] = "Groq HTTP %d: %s" % [code, _body_snippet(str(response.get("text", "")))]
+		_error_notes[rid] = "%s HTTP %d: %s" % [label, code, _body_snippet(str(response.get("text", "")))]
 		return ""
 	var parsed: Variant = JSON.parse_string(str(response.get("text", "")))
 	if not (parsed is Dictionary):
-		_error_notes[rid] = "Groq response was not JSON: %s" % _body_snippet(str(response.get("text", "")))
+		_error_notes[rid] = "%s response was not JSON: %s" % [label, _body_snippet(str(response.get("text", "")))]
 		return ""
+	if str(provider.get("dialect", "")) == "gemini":
+		return _parse_gemini(parsed, label, response, rid)
+	return _parse_openai(parsed, label, response, rid)
+
+
+func _parse_openai(parsed: Dictionary, label: String, response: Dictionary, rid: String) -> String:
 	var choices: Variant = parsed.get("choices")
 	if not (choices is Array) or choices.is_empty():
-		_error_notes[rid] = "Groq response had no choices: %s" % _body_snippet(str(response.get("text", "")))
+		_error_notes[rid] = "%s response had no choices: %s" % [label, _body_snippet(str(response.get("text", "")))]
 		return ""
 	if not (choices[0] is Dictionary):
-		_error_notes[rid] = "Groq response choice was not an object: %s" % _body_snippet(str(response.get("text", "")))
+		_error_notes[rid] = "%s response choice was not an object: %s" % [label, _body_snippet(str(response.get("text", "")))]
 		return ""
 	var message: Variant = choices[0].get("message", {})
 	if not (message is Dictionary):
-		_error_notes[rid] = "Groq response message was not an object: %s" % _body_snippet(str(response.get("text", "")))
+		_error_notes[rid] = "%s response message was not an object: %s" % [label, _body_snippet(str(response.get("text", "")))]
 		return ""
 	var content: Variant = message.get("content", "")
 	if content == null:
-		_error_notes[rid] = "Groq response content was null: %s" % _body_snippet(str(response.get("text", "")))
+		_error_notes[rid] = "%s response content was null: %s" % [label, _body_snippet(str(response.get("text", "")))]
 		return ""
-	var text := str(content).strip_edges()
-	## Qwen3 reasoning may wrap its answer in <think>...</think> blocks.
-	var think_end := text.rfind("</think>")
+	return _strip_think(str(content))
+
+
+func _parse_gemini(parsed: Dictionary, label: String, response: Dictionary, rid: String) -> String:
+	var candidates: Variant = parsed.get("candidates")
+	if not (candidates is Array) or candidates.is_empty():
+		var reason := ""
+		var feedback: Variant = parsed.get("promptFeedback")
+		if feedback is Dictionary:
+			reason = str(feedback.get("blockReason", ""))
+		var reason_part := ""
+		if not reason.is_empty():
+			reason_part = " (blocked: %s)" % reason
+		_error_notes[rid] = "%s response had no candidates%s: %s" % [label, reason_part, _body_snippet(str(response.get("text", "")))]
+		return ""
+	if not (candidates[0] is Dictionary):
+		_error_notes[rid] = "%s response candidate was not an object: %s" % [label, _body_snippet(str(response.get("text", "")))]
+		return ""
+	var content: Variant = candidates[0].get("content", {})
+	if not (content is Dictionary):
+		_error_notes[rid] = "%s response content was missing: %s" % [label, _body_snippet(str(response.get("text", "")))]
+		return ""
+	var parts: Variant = content.get("parts")
+	if not (parts is Array) or parts.is_empty():
+		_error_notes[rid] = "%s response had no parts: %s" % [label, _body_snippet(str(response.get("text", "")))]
+		return ""
+	var texts := PackedStringArray()
+	for part in parts:
+		if part is Dictionary:
+			var part_text := str(part.get("text", ""))
+			if not part_text.is_empty():
+				texts.append(part_text)
+	if texts.is_empty():
+		_error_notes[rid] = "%s response parts had no text: %s" % [label, _body_snippet(str(response.get("text", "")))]
+		return ""
+	return _strip_think("\n".join(texts))
+
+
+func _strip_think(text: String) -> String:
+	var out := text.strip_edges()
+	## Reasoning models may wrap their answer in <think>...</think> blocks.
+	var think_end := out.rfind("</think>")
 	if think_end != -1:
-		text = text.substr(think_end + "</think>".length()).strip_edges()
-	return text
+		out = out.substr(think_end + "</think>".length()).strip_edges()
+	return out
 
 
 ## Minimal text-only call used by the "Test connection" button.
-func _groq_ping_blocking(api_key: String) -> Dictionary:
-	var body := JSON.stringify({
-		"model": MODEL_ID,
-		"messages": [{"role": "user", "content": "Reply with exactly: OK"}],
-		"max_tokens": 5,
-	})
-	var response := _http_post_json(api_key, body)
+func _ping_blocking(provider_id: String, api_key: String) -> Dictionary:
+	var provider: Dictionary = PROVIDERS.get(provider_id, PROVIDERS["groq"])
+	var body := ""
+	if str(provider.get("dialect", "")) == "gemini":
+		body = JSON.stringify({
+			"contents": [{"role": "user", "parts": [{"text": "Reply with exactly: OK"}]}],
+		})
+	else:
+		body = JSON.stringify({
+			"model": provider.get("model", MODEL_ID),
+			"messages": [{"role": "user", "content": "Reply with exactly: OK"}],
+			"max_tokens": 5,
+		})
+	var response := _http_post_json(str(provider.get("host", "")), int(provider.get("port", 443)), str(provider.get("path", "")), _build_headers(provider, api_key), body)
 	var code: int = int(response.get("code", 0))
 	if code == 200:
 		return {"ok": true, "error": ""}
 	if code == 0:
 		return {"ok": false, "error": str(response.get("error", "request failed"))}
-	return {"ok": false, "error": "Groq HTTP %d: %s" % [code, _body_snippet(str(response.get("text", "")))]}
+	return {"ok": false, "error": "%s HTTP %d: %s" % [provider.get("label", provider_id), code, _body_snippet(str(response.get("text", "")))]}
 
 
-func _http_post_json(api_key: String, body: String) -> Dictionary:
-	if api_key.is_empty():
-		return {"code": 0, "error": "empty API key"}
+func _http_post_json(host: String, port: int, path: String, headers: PackedStringArray, body: String) -> Dictionary:
+	if host.is_empty() or body.is_empty():
+		return {"code": 0, "error": "invalid request (empty host or body)"}
 	var http := HTTPClient.new()
-	var connect_err := http.connect_to_host(GROQ_HOST, GROQ_PORT, TLSOptions.client())
+	var connect_err := http.connect_to_host(host, port, TLSOptions.client())
 	if connect_err != OK:
 		http.close()
 		return {"code": 0, "error": "connect_to_host failed: %s" % error_string(connect_err)}
@@ -297,11 +447,7 @@ func _http_post_json(api_key: String, body: String) -> Dictionary:
 	if not connected:
 		http.close()
 		return {"code": 0, "error": "could not connect (status %d)" % last_status}
-	var headers := PackedStringArray([
-		"Content-Type: application/json",
-		"Authorization: Bearer %s" % api_key,
-	])
-	if http.request(HTTPClient.METHOD_POST, GROQ_PATH, headers, body) != OK:
+	if http.request(HTTPClient.METHOD_POST, path, headers, body) != OK:
 		http.close()
 		return {"code": 0, "error": "request() failed"}
 	deadline = Time.get_ticks_msec() + REQUEST_TIMEOUT_MS
@@ -380,15 +526,19 @@ func _downscale_image_if_needed(image_b64: String) -> String:
 	return Marshalls.raw_to_base64(out)
 
 
-func _groq_ping_worker(api_key: String, status_label: Label) -> void:
-	var result := _groq_ping_blocking(api_key)
-	Callable(self, "_on_ping_done").call_deferred(result, status_label)
+func _ping_worker(provider_id: String, api_key: String, status_label: Label) -> void:
+	var result := _ping_blocking(provider_id, api_key)
+	Callable(self, "_on_ping_done").call_deferred(result, provider_id, status_label)
 
 
-func _on_ping_done(result: Dictionary, status_label: Label) -> void:
+func _on_ping_done(result: Dictionary, provider_id: String, status_label: Label) -> void:
 	_join_thread("_test")
 	if status_label != null and is_instance_valid(status_label):
-		status_label.text = "OK - Groq responded." if result.get("ok", false) else "FAILED - %s" % result.get("error", "unknown error")
+		var label := str(PROVIDERS.get(provider_id, PROVIDERS["groq"]).get("label", provider_id))
+		if result.get("ok", false):
+			status_label.text = "OK - %s responded." % label
+		else:
+			status_label.text = "FAILED - %s" % result.get("error", "unknown error")
 		_log("vision routing: ping result: %s" % status_label.text)
 
 
@@ -406,35 +556,50 @@ func is_routing_enabled() -> bool:
 	return value != null and value
 
 
-func _resolved_api_key() -> String:
+func _active_provider_id() -> String:
+	var es := _settings()
+	if es == null:
+		return "groq"
+	var stored := str(es.get_setting(SETTING_PROVIDER))
+	if stored.is_empty() or not PROVIDERS.has(stored):
+		return "groq"
+	return stored
+
+
+func _provider_setting(provider_id: String) -> String:
+	return str(PROVIDERS.get(provider_id, PROVIDERS["groq"]).get("setting", SETTING_API_KEY_ENC))
+
+
+func _resolved_api_key(provider_id: String) -> String:
 	## Environment variable takes priority over the stored (encrypted) key.
-	var env_key := OS.get_environment("GROQ_API_KEY")
+	var provider: Dictionary = PROVIDERS.get(provider_id, PROVIDERS["groq"])
+	var env_key := OS.get_environment(str(provider.get("env", "")))
 	if not env_key.is_empty():
 		return env_key
 	var es := _settings()
 	if es == null:
 		return ""
-	var blob := str(es.get_setting(SETTING_API_KEY_ENC))
+	var blob := str(es.get_setting(_provider_setting(provider_id)))
 	if blob.is_empty():
 		return ""
 	return _decrypt(blob)
 
 
-func _decrypted_key() -> String:
+func _decrypted_key(provider_id: String) -> String:
 	var es := _settings()
 	if es == null:
 		return ""
-	return _decrypt(str(es.get_setting(SETTING_API_KEY_ENC)))
+	return _decrypt(str(es.get_setting(_provider_setting(provider_id))))
 
 
-func set_api_key(plain: String) -> void:
+func set_api_key(provider_id: String, plain: String) -> void:
 	var es := _settings()
 	if es == null:
 		return
 	if plain.is_empty():
-		es.set_setting(SETTING_API_KEY_ENC, "")
+		es.set_setting(_provider_setting(provider_id), "")
 		return
-	es.set_setting(SETTING_API_KEY_ENC, _encrypt(plain))
+	es.set_setting(_provider_setting(provider_id), _encrypt(plain))
 
 
 ## Machine-derived key: not a password, but enough that a casually-opened
@@ -521,6 +686,23 @@ func build_tab(tabs: TabContainer) -> void:
 	header.add_theme_font_size_override("font_size", 18)
 	box.add_child(header)
 
+	var provider_row := HBoxContainer.new()
+	var provider_label := Label.new()
+	provider_label.text = "Provider"
+	provider_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	provider_row.add_child(provider_label)
+	_tab_provider = OptionButton.new()
+	_tab_provider.tooltip_text = "Which vision provider routes the screenshots. The model is fixed per provider (shown in brackets) so it can never silently change."
+	var active_provider := _active_provider_id()
+	for provider_index in PROVIDER_ORDER.size():
+		var provider_item: Dictionary = PROVIDERS[PROVIDER_ORDER[provider_index]]
+		_tab_provider.add_item("%s (%s)" % [provider_item.get("label", PROVIDER_ORDER[provider_index]), provider_item.get("model", "")], provider_index)
+		if PROVIDER_ORDER[provider_index] == active_provider:
+			_tab_provider.select(provider_index)
+	_tab_provider.item_selected.connect(_on_provider_changed)
+	provider_row.add_child(_tab_provider)
+	box.add_child(provider_row)
+
 	var enable_row := HBoxContainer.new()
 	var enable_label := Label.new()
 	enable_label.text = "Enable routing"
@@ -535,21 +717,20 @@ func build_tab(tabs: TabContainer) -> void:
 	var description := Label.new()
 	description.text = (
 		"When enabled, every screenshot the AI model takes through the godot-ai "
-		+ "screenshot tool is sent to Groq's free vision model (qwen/"
-		+ "qwen3.6-27b) for a text description. The description "
-		+ "is returned to the AI instead of the raw image, so models without image "
-		+ "support (e.g. DeepSeek) can still \"see\" the editor and game. When the "
-		+ "connected model analyzes images itself, switch this off (or use the quick "
-		+ "toggle under Developer mode in the Godot AI dock) so screenshots pass "
-		+ "through unchanged."
+		+ "screenshot tool is sent to the selected provider's vision model (see "
+		+ "the Provider dropdown) for a text description. The description is "
+		+ "returned to the AI instead of the raw image, so models without image "
+		+ "support (e.g. DeepSeek) can still \"see\" the editor and game. When "
+		+ "the connected model analyzes images itself, switch this off (or use "
+		+ "the quick toggle under Developer mode in the Godot AI dock) so "
+		+ "screenshots pass through unchanged."
 	)
 	description.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	description.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	box.add_child(description)
 
-	var key_label := Label.new()
-	key_label.text = "Groq API key (free tier: console.groq.com)"
-	box.add_child(key_label)
+	_tab_key_label = Label.new()
+	box.add_child(_tab_key_label)
 
 	var key_row := HBoxContainer.new()
 	_tab_key_edit = LineEdit.new()
@@ -564,18 +745,14 @@ func build_tab(tabs: TabContainer) -> void:
 	key_row.add_child(show_button)
 	box.add_child(key_row)
 	_key_loading = true
-	_tab_key_edit.text = _decrypted_key()
+	_tab_key_edit.text = _decrypted_key(_active_provider_id())
 	_key_loading = false
+	_sync_provider_ui()
 
-	var key_hint := Label.new()
-	key_hint.text = (
-		"Stored encrypted (AES-256, key derived from this machine) in Editor Settings "
-		+ "- not plain text, but local obfuscation only. You can also set the "
-		+ "GROQ_API_KEY environment variable; it takes priority over this field."
-	)
-	key_hint.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	key_hint.add_theme_color_override("font_color", Color(0.55, 0.55, 0.55))
-	box.add_child(key_hint)
+	_tab_key_hint = Label.new()
+	_tab_key_hint.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_tab_key_hint.add_theme_color_override("font_color", Color(0.55, 0.55, 0.55))
+	box.add_child(_tab_key_hint)
 
 	var test_row := HBoxContainer.new()
 	var test_button := Button.new()
@@ -592,20 +769,56 @@ func build_tab(tabs: TabContainer) -> void:
 func _on_key_text_changed(_new_text: String) -> void:
 	if _key_loading:
 		return
-	set_api_key(_tab_key_edit.text)
+	set_api_key(_active_provider_id(), _tab_key_edit.text)
+
+
+func _on_provider_changed(index: int) -> void:
+	if index < 0 or index >= PROVIDER_ORDER.size():
+		return
+	var provider_id: String = PROVIDER_ORDER[index]
+	var es := _settings()
+	if es != null:
+		es.set_setting(SETTING_PROVIDER, provider_id)
+	_key_loading = true
+	if _tab_key_edit != null and is_instance_valid(_tab_key_edit):
+		_tab_key_edit.text = _decrypted_key(provider_id)
+	_key_loading = false
+	_sync_provider_ui()
+	_log("vision routing: provider changed to %s (%s)" % [provider_id, PROVIDERS[provider_id].get("model", "")])
+
+
+func _sync_provider_ui() -> void:
+	var provider_id := _active_provider_id()
+	var provider: Dictionary = PROVIDERS.get(provider_id, PROVIDERS["groq"])
+	if _tab_provider != null and is_instance_valid(_tab_provider):
+		var provider_index := PROVIDER_ORDER.find(provider_id)
+		if provider_index != -1 and _tab_provider.selected != provider_index:
+			_tab_provider.select(provider_index)
+	if _tab_key_label != null and is_instance_valid(_tab_key_label):
+		_tab_key_label.text = str(provider.get("key_label", "API key"))
+	if _tab_key_hint != null and is_instance_valid(_tab_key_hint):
+		_tab_key_hint.text = (
+			"Stored encrypted (AES-256, key derived from this machine) in Editor Settings "
+			+ "- not plain text, but local obfuscation only. You can also set the "
+			+ "%s environment variable; it takes priority over this field."
+		) % provider.get("env", "")
+	if _tab_key_edit != null and is_instance_valid(_tab_key_edit):
+		_tab_key_edit.placeholder_text = str(provider.get("placeholder", ""))
 
 
 func _on_test_connection() -> void:
 	if _tab_status == null:
 		return
-	var api_key := _resolved_api_key()
+	var provider_id := _active_provider_id()
+	var provider: Dictionary = PROVIDERS.get(provider_id, PROVIDERS["groq"])
+	var api_key := _resolved_api_key(provider_id)
 	if api_key.is_empty():
-		_tab_status.text = "No key set - add one below or set GROQ_API_KEY."
+		_tab_status.text = "No key set - add one below or set %s." % provider.get("env", "")
 		return
 	_tab_status.text = "Testing..."
 	var thread := Thread.new()
 	_threads["_test"] = thread
-	thread.start(_groq_ping_worker.bind(api_key, _tab_status))
+	thread.start(_ping_worker.bind(provider_id, api_key, _tab_status))
 
 
 # --- UI: quick toggle in the dock ----------------------------------------------
@@ -617,7 +830,7 @@ func build_toggle_row(body: VBoxContainer) -> void:
 	row.name = ROW_NAME
 	var label := Label.new()
 	label.text = "Vision Routing"
-	label.tooltip_text = "Route screenshot-tool images through Groq's free vision API (see the Vision Routing tab in Clients & Tools)."
+	label.tooltip_text = "Route screenshot-tool images through the selected provider's vision API (see the Vision Routing tab in Clients & Tools)."
 	label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	row.add_child(label)
 	_row_toggle = CheckButton.new()

--- a/plugin/addons/godot_ai/vision_routing.gd
+++ b/plugin/addons/godot_ai/vision_routing.gd
@@ -36,7 +36,7 @@ extends RefCounted
 ## UI: "Vision Routing" tab in Clients & Tools (after Settings) plus a quick
 ## toggle in the dock right under Developer mode.
 
-## Backwards-compatible alias for the Groq model (used by tests + routed_via).
+## Groq's curated model id; also the default used by tests and routed_via.
 const MODEL_ID := "qwen/qwen3.6-27b"
 
 ## Curated providers: model ids are fixed here on purpose so the UI can show
@@ -91,6 +91,10 @@ const ROW_NAME := "VisionRoutingToggleRow"
 const MAX_IMAGE_EDGE := 1024
 const CONNECT_TIMEOUT_MS := 4000
 const REQUEST_TIMEOUT_MS := 8000
+## Total budget for the whole provider exchange (connect + request + body).
+## Kept under the server's 15s editor_screenshot window so the fallback
+## pass-through always lands before the server gives up on slow providers.
+const TOTAL_ROUTE_BUDGET_MS := 10000
 
 const _ENC_PREFIX := "v1"
 const _SALT := "vision_routing::v1::godot-ai"
@@ -112,6 +116,7 @@ var _tab_key_label: Label = null
 var _tab_key_hint: Label = null
 var _tab_key_edit: LineEdit = null
 var _tab_status: Label = null
+var _tab_test_button: Button = null
 var _row_toggle: CheckButton = null
 
 
@@ -138,6 +143,7 @@ func shutdown() -> void:
 	_tab_key_hint = null
 	_tab_key_edit = null
 	_tab_status = null
+	_tab_test_button = null
 	_row_toggle = null
 
 
@@ -160,7 +166,11 @@ func route_editor_screenshot(params: Dictionary, original: Callable, connection:
 	if not (data is Dictionary) or not data.has("image_base64"):
 		return result
 	if _start_route(rid, str(params.get("source", "viewport")), result, data, connection, params):
-		return {"_deferred": true, "_deferred_timeout_ms": 30000}
+		## Keep the deferred ledger inside the server's 15s editor_screenshot
+		## window (the worker itself is capped at TOTAL_ROUTE_BUDGET_MS), so
+		## a hung provider surfaces as a clean plugin timeout, not a
+		## server-side abort.
+		return {"_deferred": true, "_deferred_timeout_ms": 13000}
 	return result
 
 
@@ -226,17 +236,19 @@ func _on_route_complete(rid: String, result: Variant) -> void:
 		_pass_through(connection, rid, payload)
 		return
 	var data: Dictionary = entry.get("data", {}).duplicate()
-	## The server forwards a fixed whitelist of metadata keys into the text
-	## result; `note` is the free-form one, so the description rides there
-	## (plus an explicit `vision_description` key) so text-only models can
-	## read it. The original image is replaced by a valid 2x2 placeholder so
-	## the payload stays well-formed.
-	data.erase("image_base64")
-	data["vision_description"] = description_str
 	var provider: Dictionary = PROVIDERS.get(provider_id, PROVIDERS["groq"])
-	data["routed_via"] = "%s:%s" % [provider_id, provider.get("model", MODEL_ID)]
+	var routed_via := "%s:%s" % [provider_id, provider.get("model", MODEL_ID)]
+	## The server forwards a fixed whitelist of metadata keys into the text
+	## result; `note` is the free-form one, so a self-attributing description
+	## rides there (plus an explicit `vision_description` key) so text-only
+	## models can read it. The label keeps provider text from reading as if
+	## the plugin said it. The image is replaced by a valid 2x2 placeholder
+	## so the payload stays well-formed.
+	data["vision_description"] = description_str
+	data["routed_via"] = routed_via
 	var original_note := str(data.get("note", ""))
-	data["note"] = (original_note + " | " if not original_note.is_empty() else "") + description_str
+	var labeled := "Vision description (%s): %s" % [routed_via, description_str]
+	data["note"] = (original_note + " | " if not original_note.is_empty() else "") + labeled
 	data["image_base64"] = _PLACEHOLDER_PNG
 	data["format"] = "png"
 	_log("vision routing: description ready for %s (%d chars)" % [rid, description_str.length()])
@@ -259,9 +271,7 @@ func _build_prompt(params: Dictionary) -> String:
 		"- Problems: errors, red highlights, missing textures, black screens, glitches, stretching.",
 		"Be concise (under 200 words), factual, and use exact quotes instead of paraphrase. Do not give advice.",
 	])
-	var user_prompt := str(params.get("_user_prompt", ""))
-	if user_prompt.is_empty():
-		user_prompt = str(params.get("user_prompt", ""))
+	var user_prompt := str(params.get("user_prompt", ""))
 	if not user_prompt.is_empty():
 		lines.append("Context from the agent that requested this screenshot: %s" % user_prompt)
 	return "\n".join(lines)
@@ -427,7 +437,10 @@ func _http_post_json(host: String, port: int, path: String, headers: PackedStrin
 	if connect_err != OK:
 		http.close()
 		return {"code": 0, "error": "connect_to_host failed: %s" % error_string(connect_err)}
-	var deadline := Time.get_ticks_msec() + CONNECT_TIMEOUT_MS
+	## One total deadline for the whole exchange (see TOTAL_ROUTE_BUDGET_MS),
+	## so connect + request + body can never exceed it.
+	var budget_deadline := Time.get_ticks_msec() + TOTAL_ROUTE_BUDGET_MS
+	var deadline := mini(Time.get_ticks_msec() + CONNECT_TIMEOUT_MS, budget_deadline)
 	var first_poll := true
 	var connected := false
 	var last_status := -1
@@ -451,7 +464,7 @@ func _http_post_json(host: String, port: int, path: String, headers: PackedStrin
 	if http.request(HTTPClient.METHOD_POST, path, headers, body) != OK:
 		http.close()
 		return {"code": 0, "error": "request() failed"}
-	deadline = Time.get_ticks_msec() + REQUEST_TIMEOUT_MS
+	deadline = mini(Time.get_ticks_msec() + REQUEST_TIMEOUT_MS, budget_deadline)
 	var timed_out := false
 	var status_at_timeout := -1
 	while http.get_status() == HTTPClient.STATUS_REQUESTING:
@@ -473,7 +486,7 @@ func _http_post_json(host: String, port: int, path: String, headers: PackedStrin
 		return {"code": 0, "error": "no HTTP response (status %d)" % st}
 	var code := http.get_response_code()
 	var chunks := PackedByteArray()
-	var body_deadline := Time.get_ticks_msec() + REQUEST_TIMEOUT_MS
+	var body_deadline := mini(Time.get_ticks_msec() + REQUEST_TIMEOUT_MS, budget_deadline)
 	while http.get_status() == HTTPClient.STATUS_BODY:
 		if not _active:
 			http.close()
@@ -530,19 +543,21 @@ func _downscale_image_if_needed(image_b64: String) -> String:
 	return Marshalls.raw_to_base64(out)
 
 
-func _ping_worker(provider_id: String, api_key: String, status_label: Label) -> void:
+func _ping_worker(provider_id: String, api_key: String, status_label: Label, key_source: String) -> void:
 	var result := _ping_blocking(provider_id, api_key)
-	Callable(self, "_on_ping_done").call_deferred(result, provider_id, status_label)
+	Callable(self, "_on_ping_done").call_deferred(result, provider_id, status_label, key_source)
 
 
-func _on_ping_done(result: Dictionary, provider_id: String, status_label: Label) -> void:
+func _on_ping_done(result: Dictionary, provider_id: String, status_label: Label, key_source: String) -> void:
 	_join_thread("_test")
+	if _tab_test_button != null and is_instance_valid(_tab_test_button):
+		_tab_test_button.disabled = false
 	if status_label != null and is_instance_valid(status_label):
 		var label := str(PROVIDERS.get(provider_id, PROVIDERS["groq"]).get("label", provider_id))
 		if result.get("ok", false):
-			status_label.text = "OK - %s responded." % label
+			status_label.text = "OK - %s responded (%s)." % [label, key_source]
 		else:
-			status_label.text = "FAILED - %s" % result.get("error", "unknown error")
+			status_label.text = "FAILED - %s (%s)." % [result.get("error", "unknown error"), key_source]
 		_log("vision routing: ping result: %s" % status_label.text)
 
 
@@ -611,18 +626,27 @@ func set_api_key(provider_id: String, plain: String) -> void:
 	if plain.is_empty():
 		es.set_setting(_provider_setting(provider_id), "")
 		return
-	es.set_setting(_provider_setting(provider_id), _encrypt(plain))
+	var blob := _encrypt(plain)
+	if blob.is_empty():
+		_log("vision routing: cannot store %s key - this machine reports no unique id; set %s instead" % [provider_id, PROVIDERS.get(provider_id, PROVIDERS["groq"]).get("env", "")])
+		return
+	es.set_setting(_provider_setting(provider_id), blob)
 
 
 ## Machine-derived key: not a password, but enough that a casually-opened
-## editor_settings-4.tres does not reveal the key in plain text.
-func _derive_key() -> PackedByteArray:
+## editor_settings-4.tres does not reveal the key in plain text. Separate
+## domain tags give AES and HMAC independent keys so neither reuses the
+## other's bytes.
+func _derive_key(tag: String) -> PackedByteArray:
 	var parts := PackedStringArray([
 		OS.get_unique_id(),
 		OS.get_environment("USERNAME"),
 		OS.get_environment("USERPROFILE"),
+		OS.get_environment("USER"),
+		OS.get_environment("HOME"),
 		OS.get_name(),
 		_SALT,
+		tag,
 	])
 	var ctx := HashingContext.new()
 	ctx.start(HashingContext.HASH_SHA256)
@@ -631,7 +655,13 @@ func _derive_key() -> PackedByteArray:
 
 
 func _encrypt(plain: String) -> String:
-	var key := _derive_key()
+	if OS.get_unique_id().is_empty():
+		## Without a machine id the key would be near-constant across users
+		## on the same machine - refuse, and let callers fall back to the
+		## provider's environment variable.
+		return ""
+	var aes_key := _derive_key("aes")
+	var mac_key := _derive_key("mac")
 	var iv := Crypto.new().generate_random_bytes(16)
 	var raw := plain.to_utf8_buffer()
 	## PKCS7 padding.
@@ -640,11 +670,11 @@ func _encrypt(plain: String) -> String:
 	for i in pad:
 		padded.append(pad)
 	var aes := AESContext.new()
-	aes.start(AESContext.MODE_CBC_ENCRYPT, key, iv)
+	aes.start(AESContext.MODE_CBC_ENCRYPT, aes_key, iv)
 	var cipher := aes.update(padded)
 	aes.finish()
 	var hmac := HMACContext.new()
-	hmac.start(HashingContext.HASH_SHA256, key)
+	hmac.start(HashingContext.HASH_SHA256, mac_key)
 	hmac.update(iv)
 	hmac.update(cipher)
 	var mac := hmac.finish()
@@ -660,16 +690,17 @@ func _decrypt(blob: String) -> String:
 	var cipher := Marshalls.base64_to_raw(parts[3])
 	if iv.size() != 16 or cipher.is_empty() or cipher.size() % 16 != 0:
 		return ""
-	var key := _derive_key()
+	var aes_key := _derive_key("aes")
+	var mac_key := _derive_key("mac")
 	var hmac := HMACContext.new()
-	hmac.start(HashingContext.HASH_SHA256, key)
+	hmac.start(HashingContext.HASH_SHA256, mac_key)
 	hmac.update(iv)
 	hmac.update(cipher)
 	var expected := hmac.finish()
 	if expected != mac:
 		return ""
 	var aes := AESContext.new()
-	aes.start(AESContext.MODE_CBC_DECRYPT, key, iv)
+	aes.start(AESContext.MODE_CBC_DECRYPT, aes_key, iv)
 	var padded := aes.update(cipher)
 	aes.finish()
 	if padded.is_empty():
@@ -776,6 +807,7 @@ func build_tab(tabs: TabContainer) -> void:
 	var test_button := Button.new()
 	test_button.text = "Test connection"
 	test_button.pressed.connect(_on_test_connection)
+	_tab_test_button = test_button
 	test_row.add_child(test_button)
 	_tab_status = Label.new()
 	_tab_status.size_flags_horizontal = Control.SIZE_EXPAND_FILL
@@ -815,11 +847,14 @@ func _sync_provider_ui() -> void:
 	if _tab_key_label != null and is_instance_valid(_tab_key_label):
 		_tab_key_label.text = str(provider.get("key_label", "API key"))
 	if _tab_key_hint != null and is_instance_valid(_tab_key_hint):
-		_tab_key_hint.text = (
+		var hint := (
 			"Stored encrypted (AES-256, key derived from this machine) in Editor Settings "
 			+ "- not plain text, but local obfuscation only. You can also set the "
 			+ "%s environment variable; it takes priority over this field."
 		) % provider.get("env", "")
+		if OS.get_unique_id().is_empty():
+			hint += " This machine reports no unique id, so keys cannot be stored locally - use the %s environment variable." % provider.get("env", "")
+		_tab_key_hint.text = hint
 	if _tab_key_edit != null and is_instance_valid(_tab_key_edit):
 		_tab_key_edit.placeholder_text = str(provider.get("placeholder", ""))
 
@@ -829,17 +864,23 @@ func _on_test_connection() -> void:
 		return
 	var provider_id := _active_provider_id()
 	var provider: Dictionary = PROVIDERS.get(provider_id, PROVIDERS["groq"])
+	var env_name := str(provider.get("env", ""))
 	var api_key := _resolved_api_key(provider_id)
 	if api_key.is_empty():
-		_tab_status.text = "No key set - add one below or set %s." % provider.get("env", "")
+		_tab_status.text = "No key set - add one below or set %s." % env_name
 		return
-	_tab_status.text = "Testing..."
 	var running: Thread = _threads.get("_test")
 	if running != null and running.is_started() and running.is_alive():
 		return
+	_tab_status.text = "Testing..."
+	if _tab_test_button != null and is_instance_valid(_tab_test_button):
+		_tab_test_button.disabled = true
+	var key_source := "stored key"
+	if not OS.get_environment(env_name).is_empty():
+		key_source = "via %s" % env_name
 	var thread := Thread.new()
 	_threads["_test"] = thread
-	thread.start(_ping_worker.bind(provider_id, api_key, _tab_status))
+	thread.start(_ping_worker.bind(provider_id, api_key, _tab_status, key_source))
 
 
 # --- UI: quick toggle in the dock ----------------------------------------------
@@ -871,9 +912,9 @@ func _on_enable_toggled(enabled: bool) -> void:
 func _sync_ui_states() -> void:
 	var enabled := is_routing_enabled()
 	if _tab_enable != null and is_instance_valid(_tab_enable) and _tab_enable.button_pressed != enabled:
-		_tab_enable.button_pressed = enabled
+		_tab_enable.set_pressed_no_signal(enabled)
 	if _row_toggle != null and is_instance_valid(_row_toggle) and _row_toggle.button_pressed != enabled:
-		_row_toggle.button_pressed = enabled
+		_row_toggle.set_pressed_no_signal(enabled)
 
 
 # --- logging --------------------------------------------------------------------

--- a/plugin/addons/godot_ai/vision_routing.gd.uid
+++ b/plugin/addons/godot_ai/vision_routing.gd.uid
@@ -1,0 +1,1 @@
+uid://dp444q4ocpx45

--- a/src/godot_ai/handlers/editor.py
+++ b/src/godot_ai/handlers/editor.py
@@ -170,12 +170,24 @@ async def editor_screenshot(
         "stale_frame",
         "frames_drawn",
         "note",
+        # Vision Routing: when the plugin routes a screenshot through a vision
+        # API, the image is replaced by a placeholder and the text description
+        # rides here so text-only models can read it (docs/vision-routing.md).
+        "vision_description",
+        "routed_via",
     ):
         if key in result:
             metadata[key] = result[key]
 
     if not include_image:
         return metadata
+
+    # Routed captures: the plugin already converted the screenshot into a text
+    # description (and a 2x2 placeholder image). Send the metadata text only -
+    # a text-only model cannot use the image block, and forwarding the
+    # placeholder would just waste tokens.
+    if result.get("routed_via"):
+        return [TextContent(type="text", text=json.dumps(metadata))]
 
     image_b64 = result.get("image_base64", "")
     image_bytes = base64.b64decode(image_b64)

--- a/src/godot_ai/handlers/editor.py
+++ b/src/godot_ai/handlers/editor.py
@@ -80,6 +80,7 @@ async def editor_screenshot(
     elevation: float | None = None,
     azimuth: float | None = None,
     fov: float | None = None,
+    user_prompt: str = "",
 ) -> dict | list:
     params: dict = {"source": source}
     if max_resolution > 0:
@@ -94,6 +95,8 @@ async def editor_screenshot(
         params["azimuth"] = azimuth
     if fov is not None:
         params["fov"] = fov
+    if user_prompt:
+        params["user_prompt"] = user_prompt
 
     timeout = GAME_SCREENSHOT_TIMEOUT_SEC if source == "game" else SCREENSHOT_TIMEOUT_SEC
     result = await runtime.send_command(

--- a/src/godot_ai/tools/editor.py
+++ b/src/godot_ai/tools/editor.py
@@ -179,6 +179,7 @@ def register_editor_tools(mcp: FastMCP, *, include_non_core: bool = True) -> Non
         elevation: float | None = None,
         azimuth: float | None = None,
         fov: float | None = None,
+        user_prompt: str = "",
         session_id: str = "",
     ):
         """Capture a screenshot of the Godot editor viewport or running game.
@@ -223,6 +224,10 @@ def register_editor_tools(mcp: FastMCP, *, include_non_core: bool = True) -> Non
             elevation: Camera elevation in degrees (0=level, 90=overhead).
             azimuth: Camera azimuth in degrees (0=front, 90=right).
             fov: Camera FOV in degrees. Tight 20-30 = zoom; 60-75 = context.
+            user_prompt: Optional context from the agent that requested the
+                capture. With Vision Routing enabled it is sent alongside the
+                image so the vision model can describe what the agent is
+                looking for.
             session_id: Optional Godot session to target. Empty = active session.
         """
         runtime = DirectRuntime.from_context(ctx, session_id=session_id or None)
@@ -236,6 +241,7 @@ def register_editor_tools(mcp: FastMCP, *, include_non_core: bool = True) -> Non
             elevation=elevation,
             azimuth=azimuth,
             fov=fov,
+            user_prompt=user_prompt,
         )
 
     @mcp.tool(meta=DEFER_META)

--- a/test_project/tests/test_vision_routing.gd
+++ b/test_project/tests/test_vision_routing.gd
@@ -59,11 +59,22 @@ func test_decrypt_rejects_tampered_blob() -> void:
 	assert_eq(router._decrypt(":".join(parts)), "")
 
 
+func test_decrypt_rejects_tampered_iv() -> void:
+	var router := _make_router()
+	var parts := router._encrypt("gsk_test_secret_key_123").split(":")
+	## Flip one byte of the IV: it is inside the MAC, so decryption must fail
+	## instead of silently decrypting to a different plaintext.
+	var iv := Marshalls.base64_to_raw(parts[1])
+	iv[0] = iv[0] ^ 0xFF
+	parts[1] = Marshalls.raw_to_base64(iv)
+	assert_eq(router._decrypt(":".join(parts)), "")
+
+
 # ----- prompt -----
 
 func test_build_prompt_includes_user_context() -> void:
 	var router := _make_router()
-	var prompt := router._build_prompt({"_user_prompt": "Why is the spider red?"})
+	var prompt := router._build_prompt({"user_prompt": "Why is the spider red?"})
 	assert_true(prompt.contains("Why is the spider red?"))
 	assert_true(prompt.contains("Godot editor"))
 
@@ -84,7 +95,7 @@ func test_route_complete_injects_description_and_placeholder() -> void:
 	var data: Dictionary = stub.replies[0]["payload"]["data"]
 	assert_eq(data["vision_description"], "A rusty spider robot on a platform.")
 	assert_eq(data["routed_via"], "groq:" + VisionRoutingScript.MODEL_ID)
-	assert_true(str(data["note"]).contains("A rusty spider robot on a platform."))
+	assert_true(str(data["note"]).contains("Vision description (groq:" + VisionRoutingScript.MODEL_ID + "): A rusty spider robot on a platform."))
 	## The original image is replaced by the 2x2 placeholder PNG.
 	assert_eq(data["image_base64"], VisionRoutingScript._PLACEHOLDER_PNG)
 	assert_eq(data["format"], "png")
@@ -151,6 +162,11 @@ func test_provider_table_is_curated() -> void:
 		assert_true(str(provider.get("env", "")).length() > 0)
 		assert_true(str(provider.get("setting", "")).begins_with("vision_routing/"))
 		assert_true(str(provider.get("dialect", "")) in ["openai", "gemini"])
+
+
+func test_aes_and_mac_keys_are_distinct() -> void:
+	var router := _make_router()
+	assert_ne(router._derive_key("aes"), router._derive_key("mac"))
 
 
 func test_provider_models_are_distinct_and_fixed() -> void:

--- a/test_project/tests/test_vision_routing.gd
+++ b/test_project/tests/test_vision_routing.gd
@@ -99,8 +99,7 @@ func test_route_complete_failure_passes_original_through() -> void:
 		"data": {"source": "viewport", "image_base64": "AAAA", "format": "png"},
 		"connection": stub,
 	}
-	router._error_notes[rid] = "Groq HTTP 401: bad key"
-	router._on_route_complete(rid, "")
+	router._on_route_complete(rid, {"desc": "", "error": "Groq HTTP 401: bad key"})
 	assert_eq(stub.replies.size(), 1)
 	var data: Dictionary = stub.replies[0]["payload"]["data"]
 	assert_eq(data["image_base64"], "AAAA")
@@ -121,6 +120,24 @@ func test_route_complete_keeps_existing_note() -> void:
 	var note := str(data["note"])
 	assert_true(note.contains("stale frame"))
 	assert_true(note.contains("A game window showing the main menu."))
+
+func test_route_complete_reports_active_provider_in_routed_via() -> void:
+	for provider_id in VisionRoutingScript.PROVIDER_ORDER:
+		var router := _make_router()
+		var stub := StubConnection.new()
+		var rid := "test-rid-%s" % provider_id
+		router._pending[rid] = {
+			"payload": {"data": {"source": "viewport", "image_base64": "AAAA"}},
+			"data": {"source": "viewport", "width": 100, "height": 100, "image_base64": "AAAA", "format": "png"},
+			"connection": stub,
+			"provider": provider_id,
+		}
+		router._on_route_complete(rid, {"desc": "A rusty spider robot on a platform.", "error": ""})
+		assert_eq(stub.replies.size(), 1)
+		var data: Dictionary = stub.replies[0]["payload"]["data"]
+		var model := str(VisionRoutingScript.PROVIDERS[provider_id]["model"])
+		assert_eq(str(data["routed_via"]), "%s:%s" % [provider_id, model])
+
 
 # ----- providers -----
 
@@ -182,7 +199,7 @@ func test_gemini_response_parser_extracts_text() -> void:
 		"code": 200,
 		"text": JSON.stringify({"candidates": [{"content": {"parts": [{"text": "A goldfish in a bowl."}]}}]}),
 	}
-	assert_eq(router._parse_description(provider, response, "rid-g"), "A goldfish in a bowl.")
+	assert_eq(router._parse_description(provider, response)["desc"], "A goldfish in a bowl.")
 
 
 func test_gemini_response_parser_rejects_empty_candidates() -> void:
@@ -192,8 +209,9 @@ func test_gemini_response_parser_rejects_empty_candidates() -> void:
 		"code": 200,
 		"text": JSON.stringify({"candidates": [], "promptFeedback": {"blockReason": "SAFETY"}}),
 	}
-	assert_eq(router._parse_description(provider, response, "rid-g2"), "")
-	assert_true(str(router._error_notes.get("rid-g2", "")).contains("SAFETY"))
+	var failed := router._parse_description(provider, response)
+	assert_eq(failed["desc"], "")
+	assert_true(str(failed["error"]).contains("SAFETY"))
 
 
 func test_openai_parser_strips_think_blocks() -> void:
@@ -203,4 +221,4 @@ func test_openai_parser_strips_think_blocks() -> void:
 		"code": 200,
 		"text": JSON.stringify({"choices": [{"message": {"content": "<think>hmm</think>\nThe scene shows a red door."}}]}),
 	}
-	assert_eq(router._parse_description(provider, response, "rid-t"), "The scene shows a red door.")
+	assert_eq(router._parse_description(provider, response)["desc"], "The scene shows a red door.")

--- a/test_project/tests/test_vision_routing.gd
+++ b/test_project/tests/test_vision_routing.gd
@@ -83,7 +83,7 @@ func test_route_complete_injects_description_and_placeholder() -> void:
 	assert_eq(stub.replies.size(), 1)
 	var data: Dictionary = stub.replies[0]["payload"]["data"]
 	assert_eq(data["vision_description"], "A rusty spider robot on a platform.")
-	assert_eq(data["routed_via"], VisionRoutingScript.MODEL_ID)
+	assert_eq(data["routed_via"], "groq:" + VisionRoutingScript.MODEL_ID)
 	assert_true(str(data["note"]).contains("A rusty spider robot on a platform."))
 	## The original image is replaced by the 2x2 placeholder PNG.
 	assert_eq(data["image_base64"], VisionRoutingScript._PLACEHOLDER_PNG)
@@ -121,3 +121,86 @@ func test_route_complete_keeps_existing_note() -> void:
 	var note := str(data["note"])
 	assert_true(note.contains("stale frame"))
 	assert_true(note.contains("A game window showing the main menu."))
+
+# ----- providers -----
+
+func test_provider_table_is_curated() -> void:
+	assert_eq(VisionRoutingScript.PROVIDER_ORDER, ["groq", "google", "grok"])
+	for provider_id in VisionRoutingScript.PROVIDER_ORDER:
+		var provider: Dictionary = VisionRoutingScript.PROVIDERS[provider_id]
+		assert_true(str(provider.get("model", "")).length() > 0)
+		assert_true(str(provider.get("host", "")).length() > 0)
+		assert_true(str(provider.get("path", "")).length() > 0)
+		assert_true(str(provider.get("env", "")).length() > 0)
+		assert_true(str(provider.get("setting", "")).begins_with("vision_routing/"))
+		assert_true(str(provider.get("dialect", "")) in ["openai", "gemini"])
+
+
+func test_provider_models_are_distinct_and_fixed() -> void:
+	var models := {}
+	for provider_id in VisionRoutingScript.PROVIDER_ORDER:
+		var model := str(VisionRoutingScript.PROVIDERS[provider_id]["model"])
+		assert_false(models.has(model), "duplicate model %s across providers" % model)
+		models[model] = true
+	assert_eq(VisionRoutingScript.PROVIDERS["groq"]["model"], VisionRoutingScript.MODEL_ID)
+
+
+func test_provider_key_slots_are_distinct() -> void:
+	var router := _make_router()
+	var slots := {}
+	for provider_id in VisionRoutingScript.PROVIDER_ORDER:
+		var setting := router._provider_setting(provider_id)
+		assert_false(slots.has(setting), "duplicate key slot %s" % setting)
+		slots[setting] = true
+
+
+func test_openai_body_builder_sends_image_data_url() -> void:
+	var router := _make_router()
+	for provider_id in ["groq", "grok"]:
+		var provider: Dictionary = VisionRoutingScript.PROVIDERS[provider_id]
+		var body: Dictionary = JSON.parse_string(router._build_request_body(provider, "describe it", "B64DATA"))
+		assert_eq(body["model"], provider["model"])
+		var content: Array = body["messages"][0]["content"]
+		assert_eq(content[1]["image_url"]["url"], "data:image/png;base64,B64DATA")
+
+
+func test_gemini_body_builder_uses_inline_data() -> void:
+	var router := _make_router()
+	var provider: Dictionary = VisionRoutingScript.PROVIDERS["google"]
+	var body: Dictionary = JSON.parse_string(router._build_request_body(provider, "describe it", "B64DATA"))
+	assert_false(body.has("messages"))
+	var parts: Array = body["contents"][0]["parts"]
+	var inline: Dictionary = parts[1]["inline_data"]
+	assert_eq(inline["mime_type"], "image/png")
+	assert_eq(inline["data"], "B64DATA")
+
+
+func test_gemini_response_parser_extracts_text() -> void:
+	var router := _make_router()
+	var provider: Dictionary = VisionRoutingScript.PROVIDERS["google"]
+	var response := {
+		"code": 200,
+		"text": JSON.stringify({"candidates": [{"content": {"parts": [{"text": "A goldfish in a bowl."}]}}]}),
+	}
+	assert_eq(router._parse_description(provider, response, "rid-g"), "A goldfish in a bowl.")
+
+
+func test_gemini_response_parser_rejects_empty_candidates() -> void:
+	var router := _make_router()
+	var provider: Dictionary = VisionRoutingScript.PROVIDERS["google"]
+	var response := {
+		"code": 200,
+		"text": JSON.stringify({"candidates": [], "promptFeedback": {"blockReason": "SAFETY"}}),
+	}
+	assert_eq(router._parse_description(provider, response, "rid-g2"), "")
+	assert_true(str(router._error_notes.get("rid-g2", "")).contains("SAFETY"))
+
+
+func test_openai_parser_strips_think_blocks() -> void:
+	var router := _make_router()
+	var provider: Dictionary = VisionRoutingScript.PROVIDERS["groq"]
+	var response := {
+		"code": 200,
+		"text": JSON.stringify({"choices": [{"message": {"content": "<think>hmm</think>\nThe scene shows a red door."}}]}),
+	}
+	assert_eq(router._parse_description(provider, response, "rid-t"), "The scene shows a red door.")

--- a/test_project/tests/test_vision_routing.gd
+++ b/test_project/tests/test_vision_routing.gd
@@ -89,13 +89,15 @@ func test_route_complete_injects_description_and_placeholder() -> void:
 		"payload": {"data": {"source": "viewport", "image_base64": "AAAA"}},
 		"data": {"source": "viewport", "width": 100, "height": 100, "image_base64": "AAAA", "format": "png"},
 		"connection": stub,
+		"provider_id": "groq",
+		"provider": {"label": "Groq", "model": "qwen/qwen3.6-27b"},
 	}
 	router._on_route_complete(rid, "A rusty spider robot on a platform.")
 	assert_eq(stub.replies.size(), 1)
 	var data: Dictionary = stub.replies[0]["payload"]["data"]
 	assert_eq(data["vision_description"], "A rusty spider robot on a platform.")
-	assert_eq(data["routed_via"], "groq:" + VisionRoutingScript.MODEL_ID)
-	assert_true(str(data["note"]).contains("Vision description (groq:" + VisionRoutingScript.MODEL_ID + "): A rusty spider robot on a platform."))
+	assert_eq(data["routed_via"], "groq:qwen/qwen3.6-27b")
+	assert_true(str(data["note"]).contains("Vision description (groq:qwen/qwen3.6-27b): A rusty spider robot on a platform."))
 	## The original image is replaced by the 2x2 placeholder PNG.
 	assert_eq(data["image_base64"], VisionRoutingScript._PLACEHOLDER_PNG)
 	assert_eq(data["format"], "png")
@@ -109,11 +111,15 @@ func test_route_complete_failure_passes_original_through() -> void:
 		"payload": {"data": {"source": "viewport", "image_base64": "AAAA"}},
 		"data": {"source": "viewport", "image_base64": "AAAA", "format": "png"},
 		"connection": stub,
+		"provider_id": "groq",
+		"provider": {"label": "Groq", "model": "qwen/qwen3.6-27b"},
 	}
 	router._on_route_complete(rid, {"desc": "", "error": "Groq HTTP 401: bad key"})
 	assert_eq(stub.replies.size(), 1)
 	var data: Dictionary = stub.replies[0]["payload"]["data"]
 	assert_eq(data["image_base64"], "AAAA")
+	## A text-only agent gets a short templated reason instead of a bare image.
+	assert_true(str(data["note"]).contains("Vision routing unavailable (groq): Groq HTTP 401: bad key"))
 
 
 func test_route_complete_keeps_existing_note() -> void:
@@ -124,6 +130,8 @@ func test_route_complete_keeps_existing_note() -> void:
 		"payload": {"data": {"source": "game", "image_base64": "AAAA"}},
 		"data": {"source": "game", "image_base64": "AAAA", "format": "png", "note": "stale frame"},
 		"connection": stub,
+		"provider_id": "groq",
+		"provider": {"label": "Groq", "model": "qwen/qwen3.6-27b"},
 	}
 	router._on_route_complete(rid, "A game window showing the main menu.")
 	assert_eq(stub.replies.size(), 1)
@@ -133,6 +141,11 @@ func test_route_complete_keeps_existing_note() -> void:
 	assert_true(note.contains("A game window showing the main menu."))
 
 func test_route_complete_reports_active_provider_in_routed_via() -> void:
+	var models := {
+		"groq": "qwen/qwen3.6-27b",
+		"google": "gemini-flash-latest",
+		"grok": "grok-4.5",
+	}
 	for provider_id in VisionRoutingScript.PROVIDER_ORDER:
 		var router := _make_router()
 		var stub := StubConnection.new()
@@ -141,13 +154,13 @@ func test_route_complete_reports_active_provider_in_routed_via() -> void:
 			"payload": {"data": {"source": "viewport", "image_base64": "AAAA"}},
 			"data": {"source": "viewport", "width": 100, "height": 100, "image_base64": "AAAA", "format": "png"},
 			"connection": stub,
-			"provider": provider_id,
+			"provider_id": provider_id,
+			"provider": {"label": provider_id, "model": models[provider_id]},
 		}
 		router._on_route_complete(rid, {"desc": "A rusty spider robot on a platform.", "error": ""})
 		assert_eq(stub.replies.size(), 1)
 		var data: Dictionary = stub.replies[0]["payload"]["data"]
-		var model := str(VisionRoutingScript.PROVIDERS[provider_id]["model"])
-		assert_eq(str(data["routed_via"]), "%s:%s" % [provider_id, model])
+		assert_eq(str(data["routed_via"]), "%s:%s" % [provider_id, models[provider_id]])
 
 
 # ----- providers -----
@@ -156,7 +169,12 @@ func test_provider_table_is_curated() -> void:
 	assert_eq(VisionRoutingScript.PROVIDER_ORDER, ["groq", "google", "grok"])
 	for provider_id in VisionRoutingScript.PROVIDER_ORDER:
 		var provider: Dictionary = VisionRoutingScript.PROVIDERS[provider_id]
-		assert_true(str(provider.get("model", "")).length() > 0)
+		## Model ids are NOT baked into the table - they are user-entered per
+		## provider. The table only curates label, dialect, endpoint, env var
+		## and the key/model setting slots.
+		assert_false(provider.has("model"))
+		assert_true(str(provider.get("model_setting", "")).begins_with("vision_routing/"))
+		assert_true(str(provider.get("model_placeholder", "")).length() > 0)
 		assert_true(str(provider.get("host", "")).length() > 0)
 		assert_true(str(provider.get("path", "")).length() > 0)
 		assert_true(str(provider.get("env", "")).length() > 0)
@@ -169,13 +187,35 @@ func test_aes_and_mac_keys_are_distinct() -> void:
 	assert_ne(router._derive_key("aes"), router._derive_key("mac"))
 
 
-func test_provider_models_are_distinct_and_fixed() -> void:
-	var models := {}
+func test_provider_model_round_trip_via_settings() -> void:
+	var router := _make_router()
+	var es := EditorInterface.get_editor_settings()
+	if es == null:
+		skip("EditorInterface.get_editor_settings() unavailable in test env")
+		return
+	## Save/restore so the test never leaves junk in the user's Editor
+	## Settings (same pattern as test_allow_hosts.gd).
+	var had := {}
+	var saved := {}
 	for provider_id in VisionRoutingScript.PROVIDER_ORDER:
-		var model := str(VisionRoutingScript.PROVIDERS[provider_id]["model"])
-		assert_false(models.has(model), "duplicate model %s across providers" % model)
-		models[model] = true
-	assert_eq(VisionRoutingScript.PROVIDERS["groq"]["model"], VisionRoutingScript.MODEL_ID)
+		var setting := router._model_setting(provider_id)
+		had[provider_id] = es.has_setting(setting)
+		saved[provider_id] = es.get_setting(setting) if had[provider_id] else ""
+	router.set_model_id("groq", "qwen/qwen3.6-27b")
+	assert_eq(router._resolved_model("groq"), "qwen/qwen3.6-27b")
+	router.set_model_id("google", "gemini-flash-latest")
+	assert_eq(router._resolved_model("google"), "gemini-flash-latest")
+	assert_eq(router._resolved_model("grok"), "")
+	## _provider_with_model snapshots the entered id into the worker dict.
+	var snapshot := router._provider_with_model("google")
+	assert_eq(snapshot["model"], "gemini-flash-latest")
+	assert_false(VisionRoutingScript.PROVIDERS["google"].has("model"))
+	for provider_id in VisionRoutingScript.PROVIDER_ORDER:
+		var setting := router._model_setting(provider_id)
+		if had[provider_id]:
+			es.set_setting(setting, saved[provider_id])
+		elif es.has_setting(setting):
+			es.erase(setting)
 
 
 func test_provider_key_slots_are_distinct() -> void:
@@ -190,16 +230,18 @@ func test_provider_key_slots_are_distinct() -> void:
 func test_openai_body_builder_sends_image_data_url() -> void:
 	var router := _make_router()
 	for provider_id in ["groq", "grok"]:
-		var provider: Dictionary = VisionRoutingScript.PROVIDERS[provider_id]
+		var provider: Dictionary = VisionRoutingScript.PROVIDERS[provider_id].duplicate()
+		provider["model"] = "test-model"
 		var body: Dictionary = JSON.parse_string(router._build_request_body(provider, "describe it", "B64DATA"))
-		assert_eq(body["model"], provider["model"])
+		assert_eq(body["model"], "test-model")
 		var content: Array = body["messages"][0]["content"]
 		assert_eq(content[1]["image_url"]["url"], "data:image/png;base64,B64DATA")
 
 
 func test_gemini_body_builder_uses_inline_data() -> void:
 	var router := _make_router()
-	var provider: Dictionary = VisionRoutingScript.PROVIDERS["google"]
+	var provider: Dictionary = VisionRoutingScript.PROVIDERS["google"].duplicate()
+	provider["model"] = "gemini-test"
 	var body: Dictionary = JSON.parse_string(router._build_request_body(provider, "describe it", "B64DATA"))
 	assert_false(body.has("messages"))
 	var parts: Array = body["contents"][0]["parts"]
@@ -238,3 +280,79 @@ func test_openai_parser_strips_think_blocks() -> void:
 		"text": JSON.stringify({"choices": [{"message": {"content": "<think>hmm</think>\nThe scene shows a red door."}}]}),
 	}
 	assert_eq(router._parse_description(provider, response)["desc"], "The scene shows a red door.")
+# ----- round-3 regressions -----
+
+func test_resolve_path_substitutes_model_placeholder() -> void:
+	var router := _make_router()
+	var provider: Dictionary = VisionRoutingScript.PROVIDERS["google"].duplicate()
+	provider["model"] = "gemini-flash-latest"
+	assert_eq(router._resolve_path(provider), "/v1beta/models/gemini-flash-latest:generateContent")
+	## Openai-dialect paths carry no placeholder and pass through unchanged.
+	var groq_provider: Dictionary = VisionRoutingScript.PROVIDERS["groq"].duplicate()
+	groq_provider["model"] = "qwen/qwen3.6-27b"
+	assert_eq(router._resolve_path(groq_provider), "/openai/v1/chat/completions")
+
+
+func test_ping_body_shape_matches_routing() -> void:
+	## The Test connection button must validate vision, not just auth: the
+	## ping body carries the placeholder image exactly like a real route.
+	var router := _make_router()
+	var provider: Dictionary = VisionRoutingScript.PROVIDERS["groq"].duplicate()
+	provider["model"] = "qwen/qwen3.6-27b"
+	var body: Dictionary = JSON.parse_string(router._build_request_body(provider, "Reply with exactly: OK", VisionRoutingScript._PLACEHOLDER_PNG))
+	assert_eq(body["model"], "qwen/qwen3.6-27b")
+	var content: Array = body["messages"][0]["content"]
+	assert_eq(content[0]["text"], "Reply with exactly: OK")
+	assert_true(str(content[1]["image_url"]["url"]).begins_with("data:image/png;base64,"))
+
+
+func test_empty_model_declines_route_like_empty_key() -> void:
+	var router := _make_router()
+	var es := EditorInterface.get_editor_settings()
+	if es == null:
+		skip("EditorInterface.get_editor_settings() unavailable in test env")
+		return
+	## Save/restore the groq key + model slots so the test never leaves junk
+	## behind. The model slot is forced empty; the key slot is set so the
+	## decline is provably caused by the missing model, not the missing key.
+	var model_setting := router._model_setting("groq")
+	var had_model := es.has_setting(model_setting)
+	var saved_model: String = es.get_setting(model_setting) if had_model else ""
+	var key_setting := router._provider_setting("groq")
+	var had_key := es.has_setting(key_setting)
+	var saved_key: String = es.get_setting(key_setting) if had_key else ""
+	router.set_model_id("groq", "")
+	es.set_setting(key_setting, router._encrypt("gsk_test_route_key"))
+	var declined := not router._start_route(
+		"test-rid-empty-model", "viewport",
+		{"data": {"image_base64": "AAAA"}}, {"image_base64": "AAAA"},
+		StubConnection.new(), {})
+	if had_key:
+		es.set_setting(key_setting, saved_key)
+	elif es.has_setting(key_setting):
+		es.erase(key_setting)
+	if had_model:
+		es.set_setting(model_setting, saved_model)
+	elif es.has_setting(model_setting):
+		es.erase(model_setting)
+	assert_true(declined)
+	assert_false(router._pending.has("test-rid-empty-model"))
+
+
+func test_game_capture_stashes_and_forwards_user_prompt() -> void:
+	## The editor handler stashes params by request id when it defers a game
+	## capture; route_game_payload hands them to the prompt builder.
+	var router := _make_router()
+	var rid := "test-rid-game"
+	router._pending[rid] = {"params": {"user_prompt": "Why is the spider red?", "source": "game"}}
+	var params: Dictionary = router._pending.get(rid, {}).get("params", {})
+	var prompt := router._build_prompt(params)
+	assert_true(prompt.contains("Why is the spider red?"))
+
+
+func test_route_game_payload_clears_stash_when_not_routeable() -> void:
+	var router := _make_router()
+	var rid := "test-rid-game-nodata"
+	router._pending[rid] = {"params": {"user_prompt": "x"}}
+	assert_false(router.route_game_payload(StubConnection.new(), rid, {"data": {"note": "no image"}}))
+	assert_false(router._pending.has(rid))

--- a/test_project/tests/test_vision_routing.gd
+++ b/test_project/tests/test_vision_routing.gd
@@ -22,6 +22,17 @@ class StubConnection:
 		replies.append({"request_id": request_id, "payload": payload})
 
 
+## Spy router: captures the prompt the route-start path binds into the
+## worker thread, so a test can assert the stashed game-capture params
+## reached the provider prompt without making a real network call.
+class SpyRouter:
+	extends VisionRoutingScript
+	var captured_prompt := ""
+
+	func _route_worker(_provider: Dictionary, _image_b64: String, prompt: String, _api_key: String, _rid: String) -> void:
+		captured_prompt = prompt
+
+
 func _make_router() -> VisionRoutingScript:
 	var router := VisionRoutingScript.new()
 	router.log_buffer = null
@@ -244,6 +255,8 @@ func test_gemini_body_builder_uses_inline_data() -> void:
 	provider["model"] = "gemini-test"
 	var body: Dictionary = JSON.parse_string(router._build_request_body(provider, "describe it", "B64DATA"))
 	assert_false(body.has("messages"))
+	## Both dialects cap output tokens; Gemini uses generationConfig.
+	assert_eq(body["generationConfig"]["maxOutputTokens"], 512)
 	var parts: Array = body["contents"][0]["parts"]
 	var inline: Dictionary = parts[1]["inline_data"]
 	assert_eq(inline["mime_type"], "image/png")
@@ -312,15 +325,27 @@ func test_empty_model_declines_route_like_empty_key() -> void:
 	if es == null:
 		skip("EditorInterface.get_editor_settings() unavailable in test env")
 		return
-	## Save/restore the groq key + model slots so the test never leaves junk
-	## behind. The model slot is forced empty; the key slot is set so the
-	## decline is provably caused by the missing model, not the missing key.
+	if router._encrypt("x").is_empty():
+		skip("machine reports no unique id; cannot store a test key")
+		return
+	## Save/restore provider + key + model slots so the test never leaves
+	## junk behind and behaves the same on any configured provider. The
+	## route-start path resolves the provider from Editor Settings, so it
+	## must be pinned to groq for the duration (otherwise, on a machine
+	## configured for google/grok, the route proceeds and fires a real
+	## network request). The model slot is forced empty; the key slot is
+	## set so the decline is provably caused by the missing model, not the
+	## missing key.
+	var provider_setting := VisionRoutingScript.SETTING_PROVIDER
+	var had_provider := es.has_setting(provider_setting)
+	var saved_provider: String = es.get_setting(provider_setting) if had_provider else ""
 	var model_setting := router._model_setting("groq")
 	var had_model := es.has_setting(model_setting)
 	var saved_model: String = es.get_setting(model_setting) if had_model else ""
 	var key_setting := router._provider_setting("groq")
 	var had_key := es.has_setting(key_setting)
 	var saved_key: String = es.get_setting(key_setting) if had_key else ""
+	es.set_setting(provider_setting, "groq")
 	router.set_model_id("groq", "")
 	es.set_setting(key_setting, router._encrypt("gsk_test_route_key"))
 	var declined := not router._start_route(
@@ -335,19 +360,70 @@ func test_empty_model_declines_route_like_empty_key() -> void:
 		es.set_setting(model_setting, saved_model)
 	elif es.has_setting(model_setting):
 		es.erase(model_setting)
+	if had_provider:
+		es.set_setting(provider_setting, saved_provider)
+	elif es.has_setting(provider_setting):
+		es.erase(provider_setting)
 	assert_true(declined)
 	assert_false(router._pending.has("test-rid-empty-model"))
 
 
 func test_game_capture_stashes_and_forwards_user_prompt() -> void:
 	## The editor handler stashes params by request id when it defers a game
-	## capture; route_game_payload hands them to the prompt builder.
-	var router := _make_router()
+	## capture; route_game_payload must hand them to the prompt built on the
+	## route-start path, so the provider prompt carries the agent's context.
+	## The worker is spied (_route_worker) so no network call happens.
+	var router := SpyRouter.new()
+	router.log_buffer = null
+	var es := EditorInterface.get_editor_settings()
+	if es == null:
+		skip("EditorInterface.get_editor_settings() unavailable in test env")
+		return
+	if router._encrypt("x").is_empty():
+		skip("machine reports no unique id; cannot store a test key")
+		return
+	## Save/restore provider + key + model so the route-start path is
+	## deterministic regardless of the user's configured provider.
+	var provider_setting := VisionRoutingScript.SETTING_PROVIDER
+	var had_provider := es.has_setting(provider_setting)
+	var saved_provider: String = es.get_setting(provider_setting) if had_provider else ""
+	var key_setting := router._provider_setting("groq")
+	var had_key := es.has_setting(key_setting)
+	var saved_key: String = es.get_setting(key_setting) if had_key else ""
+	var model_setting := router._model_setting("groq")
+	var had_model := es.has_setting(model_setting)
+	var saved_model: String = es.get_setting(model_setting) if had_model else ""
+	es.set_setting(provider_setting, "groq")
+	es.set_setting(key_setting, router._encrypt("gsk_test_route_key"))
+	router.set_model_id("groq", "qwen/qwen3.6-27b")
 	var rid := "test-rid-game"
-	router._pending[rid] = {"params": {"user_prompt": "Why is the spider red?", "source": "game"}}
-	var params: Dictionary = router._pending.get(rid, {}).get("params", {})
-	var prompt := router._build_prompt(params)
-	assert_true(prompt.contains("Why is the spider red?"))
+	## Deferred editor capture of a game frame: the params (user_prompt)
+	## are stashed by request id for the later game payload.
+	var deferred: Dictionary = router.route_editor_screenshot(
+		{"user_prompt": "Why is the spider red?", "source": "game", "_request_id": rid},
+		func(_params: Dictionary) -> Dictionary: return {"_deferred": true},
+		null)
+	assert_true(deferred.get("_deferred", false))
+	## The deferred frame arrives through route_game_payload, which reads
+	## the stash and runs the real route-start path (worker spied for the
+	## prompt).
+	var owned := router.route_game_payload(StubConnection.new(), rid, {"data": {"image_base64": "AAAA", "format": "png"}})
+	assert_true(owned)
+	router._join_thread(rid)
+	assert_true(router.captured_prompt.contains("Why is the spider red?"))
+	assert_true(router.captured_prompt.contains("Godot editor"))
+	if had_key:
+		es.set_setting(key_setting, saved_key)
+	elif es.has_setting(key_setting):
+		es.erase(key_setting)
+	if had_model:
+		es.set_setting(model_setting, saved_model)
+	elif es.has_setting(model_setting):
+		es.erase(model_setting)
+	if had_provider:
+		es.set_setting(provider_setting, saved_provider)
+	elif es.has_setting(provider_setting):
+		es.erase(provider_setting)
 
 
 func test_route_game_payload_clears_stash_when_not_routeable() -> void:

--- a/test_project/tests/test_vision_routing.gd
+++ b/test_project/tests/test_vision_routing.gd
@@ -1,0 +1,123 @@
+@tool
+extends McpTestSuite
+
+## Tests for Vision Routing (vision_routing.gd): the encrypted key storage,
+## prompt building, and the deferred-reply conversion that replaces the raw
+## screenshot with a text description for text-only models. The Groq HTTP
+## worker itself is live-verified in the editor (see docs/vision-routing.md).
+
+const VisionRoutingScript := preload("res://addons/godot_ai/vision_routing.gd")
+
+
+func suite_name() -> String:
+	return "vision_routing"
+
+
+## Stub connection capturing deferred replies instead of sending them.
+class StubConnection:
+	extends RefCounted
+	var replies: Array = []
+
+	func send_deferred_response(request_id: String, payload: Dictionary) -> void:
+		replies.append({"request_id": request_id, "payload": payload})
+
+
+func _make_router() -> VisionRoutingScript:
+	var router := VisionRoutingScript.new()
+	router.log_buffer = null
+	return router
+
+
+# ----- key storage -----
+
+func test_key_encrypt_decrypt_roundtrip() -> void:
+	var router := _make_router()
+	var plain := "gsk_test_secret_key_123"
+	var blob := router._encrypt(plain)
+	assert_ne(blob, "")
+	assert_eq(router._decrypt(blob), plain)
+
+
+func test_key_encrypted_blob_hides_plaintext() -> void:
+	var router := _make_router()
+	var plain := "gsk_super_secret_value"
+	var blob := router._encrypt(plain)
+	assert_ne(blob, plain)
+	assert_true(blob.begins_with("v1:"))
+	assert_false(blob.contains("super_secret"))
+
+
+func test_decrypt_rejects_tampered_blob() -> void:
+	var router := _make_router()
+	var parts := router._encrypt("gsk_test_secret_key_123").split(":")
+	assert_eq(parts.size(), 4)
+	## Flip one byte of the ciphertext so the MAC check must fail.
+	var tampered := Marshalls.base64_to_raw(parts[3])
+	var mid := tampered.size() / 2
+	tampered[mid] = tampered[mid] ^ 0xFF
+	parts[3] = Marshalls.raw_to_base64(tampered)
+	assert_eq(router._decrypt(":".join(parts)), "")
+
+
+# ----- prompt -----
+
+func test_build_prompt_includes_user_context() -> void:
+	var router := _make_router()
+	var prompt := router._build_prompt({"_user_prompt": "Why is the spider red?"})
+	assert_true(prompt.contains("Why is the spider red?"))
+	assert_true(prompt.contains("Godot editor"))
+
+
+# ----- deferred reply conversion -----
+
+func test_route_complete_injects_description_and_placeholder() -> void:
+	var router := _make_router()
+	var stub := StubConnection.new()
+	var rid := "test-rid-1"
+	router._pending[rid] = {
+		"payload": {"data": {"source": "viewport", "image_base64": "AAAA"}},
+		"data": {"source": "viewport", "width": 100, "height": 100, "image_base64": "AAAA", "format": "png"},
+		"connection": stub,
+	}
+	router._on_route_complete(rid, "A rusty spider robot on a platform.")
+	assert_eq(stub.replies.size(), 1)
+	var data: Dictionary = stub.replies[0]["payload"]["data"]
+	assert_eq(data["vision_description"], "A rusty spider robot on a platform.")
+	assert_eq(data["routed_via"], VisionRoutingScript.MODEL_ID)
+	assert_true(str(data["note"]).contains("A rusty spider robot on a platform."))
+	## The original image is replaced by the 2x2 placeholder PNG.
+	assert_eq(data["image_base64"], VisionRoutingScript._PLACEHOLDER_PNG)
+	assert_eq(data["format"], "png")
+
+
+func test_route_complete_failure_passes_original_through() -> void:
+	var router := _make_router()
+	var stub := StubConnection.new()
+	var rid := "test-rid-2"
+	router._pending[rid] = {
+		"payload": {"data": {"source": "viewport", "image_base64": "AAAA"}},
+		"data": {"source": "viewport", "image_base64": "AAAA", "format": "png"},
+		"connection": stub,
+	}
+	router._error_notes[rid] = "Groq HTTP 401: bad key"
+	router._on_route_complete(rid, "")
+	assert_eq(stub.replies.size(), 1)
+	var data: Dictionary = stub.replies[0]["payload"]["data"]
+	assert_eq(data["image_base64"], "AAAA")
+
+
+func test_route_complete_keeps_existing_note() -> void:
+	var router := _make_router()
+	var stub := StubConnection.new()
+	var rid := "test-rid-3"
+	router._pending[rid] = {
+		"payload": {"data": {"source": "game", "image_base64": "AAAA"}},
+		"data": {"source": "game", "image_base64": "AAAA", "format": "png", "note": "stale frame"},
+		"connection": stub,
+	}
+	router._on_route_complete(rid, "A game window showing the main menu.")
+	assert_eq(stub.replies.size(), 1)
+	var data: Dictionary = stub.replies[0]["payload"]["data"]
+	var note := str(data["note"])
+	assert_true(note.contains("stale frame"))
+	assert_true(note.contains("A game window showing the main menu."))

--- a/test_project/tests/test_vision_routing.gd.uid
+++ b/test_project/tests/test_vision_routing.gd.uid
@@ -1,0 +1,1 @@
+uid://cfuetf8yk7o8x

--- a/tests/unit/test_docs_screenshot_sources.py
+++ b/tests/unit/test_docs_screenshot_sources.py
@@ -36,10 +36,10 @@ _DOC_SOURCE_TOKEN_RE = re.compile(r"""source\s*=\s*["']([^"']+)["']""")
 @functools.cache
 def _handler_sources() -> frozenset[str]:
     text = EDITOR_HANDLER_GD.read_text(encoding="utf-8")
-    block = get_func_block(text, "func take_screenshot(params: Dictionary) -> Dictionary:")
+    block = get_func_block(text, "func _take_screenshot_impl(params: Dictionary) -> Dictionary:")
     match = _INVALID_SOURCE_LINE_RE.search(block)
     assert match, (
-        f"Invalid-source error message not found in take_screenshot in {EDITOR_HANDLER_GD}; "
+        f"Invalid-source error message not found in _take_screenshot_impl in {EDITOR_HANDLER_GD}; "
         "if its wording changed, update _INVALID_SOURCE_LINE_RE."
     )
     return frozenset(_QUOTED_TOKEN_RE.findall(match.group(1)))
@@ -48,11 +48,11 @@ def _handler_sources() -> frozenset[str]:
 @functools.cache
 def _dispatch_arm_sources() -> frozenset[str]:
     text = EDITOR_HANDLER_GD.read_text(encoding="utf-8")
-    block = get_func_block(text, "func take_screenshot(params: Dictionary) -> Dictionary:")
+    block = get_func_block(text, "func _take_screenshot_impl(params: Dictionary) -> Dictionary:")
     section = re.search(r"match source:\n(.*?)^\t\t_:", block, re.MULTILINE | re.DOTALL)
     assert section, (
         f"`match source:` dispatch (with a `_:` default arm) not found in "
-        f"take_screenshot in {EDITOR_HANDLER_GD}; update this parser."
+        f"_take_screenshot_impl in {EDITOR_HANDLER_GD}; update this parser."
     )
     return frozenset(re.findall(r'^\t\t"([a-z0-9_]+)":\s*$', section.group(1), re.MULTILINE))
 
@@ -62,7 +62,7 @@ def test_error_message_stays_in_sync_with_dispatch_arms() -> None:
     # pins that message to the actual `match source:` arms so a new arm added
     # without updating the message can't silently escape the doc guard.
     assert _dispatch_arm_sources() == _handler_sources(), (
-        f"take_screenshot's match arms {sorted(_dispatch_arm_sources())} and its "
+        f"_take_screenshot_impl's match arms {sorted(_dispatch_arm_sources())} and its "
         f"invalid-source error message {sorted(_handler_sources())} disagree; "
         "update the error message, then re-align docs/screenshot-testing.md."
     )

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -4049,6 +4049,55 @@ async def test_editor_screenshot_handler_passes_comma_view_target():
     assert result["view_target_count"] == 2
 
 
+
+async def test_editor_screenshot_routed_metadata_forwarded_without_image():
+    """Vision Routing: a capture the plugin routed through a vision API
+    carries `vision_description` / `routed_via`; with include_image=False
+    they must surface in the returned metadata."""
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+
+    original_send = client.send
+
+    async def routed_send(command: str, params: dict | None = None, **kwargs):
+        result = await original_send(command, params, **kwargs)
+        if command == "take_screenshot":
+            result["routed_via"] = "qwen/qwen3.6-27b"
+            result["vision_description"] = "A rusty spider robot on a platform."
+        return result
+
+    client.send = routed_send  # type: ignore[method-assign]
+    result = await editor_handlers.editor_screenshot(runtime, include_image=False)
+    assert result["routed_via"] == "qwen/qwen3.6-27b"
+    assert "spider" in result["vision_description"]
+
+
+async def test_editor_screenshot_routed_drops_image_block():
+    """Vision Routing: when the plugin replaced the image with a text
+    description (`routed_via` set), the handler must not forward an image
+    block - a text-only model cannot use it, and the placeholder would
+    waste tokens. Only the metadata text is returned."""
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+
+    original_send = client.send
+
+    async def routed_send(command: str, params: dict | None = None, **kwargs):
+        result = await original_send(command, params, **kwargs)
+        if command == "take_screenshot":
+            result["routed_via"] = "qwen/qwen3.6-27b"
+            result["vision_description"] = "A rusty spider robot on a platform."
+        return result
+
+    client.send = routed_send  # type: ignore[method-assign]
+    result = await editor_handlers.editor_screenshot(runtime, include_image=True)
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0].type == "text"
+    assert "routed_via" in result[0].text
+    assert "vision_description" in result[0].text
+    assert "spider" in result[0].text
+
 async def test_editor_screenshot_handler_coverage_passes_param():
     client = StubClient()
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -4049,6 +4049,24 @@ async def test_editor_screenshot_handler_passes_comma_view_target():
     assert result["view_target_count"] == 2
 
 
+async def test_editor_screenshot_handler_forwards_user_prompt():
+    """Vision Routing: a caller-supplied user_prompt must reach the plugin so
+    the vision model can describe what the agent is looking for."""
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    await editor_handlers.editor_screenshot(
+        runtime, user_prompt="Why is the spider red?"
+    )
+    assert client.calls[-1]["params"]["user_prompt"] == "Why is the spider red?"
+
+
+async def test_editor_screenshot_handler_omits_empty_user_prompt():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    await editor_handlers.editor_screenshot(runtime, user_prompt="")
+    assert "user_prompt" not in client.calls[-1]["params"]
+
+
 
 async def test_editor_screenshot_routed_metadata_forwarded_without_image():
     """Vision Routing: a capture the plugin routed through a vision API

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -4062,13 +4062,13 @@ async def test_editor_screenshot_routed_metadata_forwarded_without_image():
     async def routed_send(command: str, params: dict | None = None, **kwargs):
         result = await original_send(command, params, **kwargs)
         if command == "take_screenshot":
-            result["routed_via"] = "qwen/qwen3.6-27b"
+            result["routed_via"] = "groq:qwen/qwen3.6-27b"
             result["vision_description"] = "A rusty spider robot on a platform."
         return result
 
     client.send = routed_send  # type: ignore[method-assign]
     result = await editor_handlers.editor_screenshot(runtime, include_image=False)
-    assert result["routed_via"] == "qwen/qwen3.6-27b"
+    assert result["routed_via"] == "groq:qwen/qwen3.6-27b"
     assert "spider" in result["vision_description"]
 
 
@@ -4085,7 +4085,7 @@ async def test_editor_screenshot_routed_drops_image_block():
     async def routed_send(command: str, params: dict | None = None, **kwargs):
         result = await original_send(command, params, **kwargs)
         if command == "take_screenshot":
-            result["routed_via"] = "qwen/qwen3.6-27b"
+            result["routed_via"] = "groq:qwen/qwen3.6-27b"
             result["vision_description"] = "A rusty spider robot on a platform."
         return result
 
@@ -4094,7 +4094,7 @@ async def test_editor_screenshot_routed_drops_image_block():
     assert isinstance(result, list)
     assert len(result) == 1
     assert result[0].type == "text"
-    assert "routed_via" in result[0].text
+    assert '"routed_via": "groq:qwen/qwen3.6-27b"' in result[0].text
     assert "vision_description" in result[0].text
     assert "spider" in result[0].text
 


### PR DESCRIPTION
## Summary

Adds **Vision Routing**: an opt-in way for text-only AI models (e.g. DeepSeek) to "see" the editor and the running game. When enabled, every single-image `editor_screenshot` capture is sent to a vision model on a worker thread, and the resulting **text description** is returned to the AI instead of the raw image (`vision_description` + `note`; the server drops the image block for routed captures, and `include_image=false` captures carry the description in metadata). On any failure (missing key/model, network error, API error) the original image passes through unchanged, with a short "Vision routing unavailable (provider): reason" note - the screenshot tool never breaks.

## What's included

- **Vision Routing section** inside **Clients & Tools -> Settings** (no dock row): enable checkbox, provider dropdown, per-provider API key field (masked, with show/hide), per-provider model-id field, **Test connection** button and status line.
- **Providers are curated; the model id is required user input.** The `PROVIDERS` table fixes what is repo-owned - label, API dialect (OpenAI chat-completions vs Gemini `generateContent`), endpoint shape, environment variable and encrypted key slot. The model id is entered per provider (stored in Editor Settings next to the key), because third-party model ids retire and only the account holder gets notified; date-stamped suggestions live in the UI placeholder and `docs/vision-routing.md`:
  - Groq - `qwen/qwen3.6-27b` (free tier)
  - Google Gemini - `gemini-flash-latest` (free tier, AI Studio key)
  - xAI Grok - `grok-4.5` (paid)
  - Switching providers switches to that provider's entered model - the software never guesses a model name.
- **Keys never stored in plain text**: AES-256-CBC encrypted in Editor Settings with a machine-derived key (domain-tagged AES/MAC keys; the IV is inside the MAC; storage is refused when the machine reports no unique id). Local obfuscation, documented as such. `GROQ_API_KEY` / `GOOGLE_API_KEY` / `XAI_API_KEY` env vars take priority over stored keys.
- **Test connection validates vision, not just auth**: it sends the same image-bearing request as real routing (placeholder image), so one click checks key + model existence + image capability; it reports the key source (`stored key` / `via ENV_VAR`) and disables the button while testing.
- **Bounded worker exchange**: one absolute 10s budget for connect + request + body, a 1 MiB response-body cap, and a 13s deferred ledger inside the server's 15s `editor_screenshot` window, so a hung provider surfaces as a clean plugin timeout, not a server-side abort.
- **Agent context preserved**: `user_prompt` from the requesting agent is included in the vision prompt for editor captures and game captures (stashed by request id across the deferred game hop).
- `routed_via` reports `provider:<entered model>` verbatim (e.g. `groq:qwen/qwen3.6-27b`).
- **Settings tab rework**: the Settings tab is now usable without Developer mode. The LAN `--allow-host` block moved behind a collapsed "Remote access (advanced)" disclosure (warning text unchanged) that auto-expands when a non-empty CIDR allowlist is configured; Developer mode still gates the log viewer and dev sections.
- Docs: `docs/vision-routing.md` (providers table with date-stamped suggestions, setup, behavior, failure modes).
- Tests: `test_project/tests/test_vision_routing.gd` - 23/23 pass in-editor (encrypted key roundtrip + tamper rejection incl. IV flip, prompt, deferred-reply conversion, per-provider model round-trip, empty-model decline, game-capture stash forwarding, OpenAI/Gemini body builders incl. `generationConfig.maxOutputTokens`, Gemini parser, ping body shape); full project suite green.

## Notes

- Feature is **off by default**; the enabled flag, provider, model ids and keys live in Editor Settings, never committed with a project.
- No API keys are included in this PR.
- Live-verified in the editor: editor + game screenshots routed through real providers (Groq and Gemini) return accurate descriptions; failure paths (missing key/model, provider HTTP errors) pass the original image through with the failure note; Test connection shows both OK and provider-error states.