### PR TITLE
Ship a store-only plugin zip without the root license

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,23 +86,39 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Build plugin ZIP
-        # Ship `addons/` + `godot-ai-LICENSE.txt` at the zip's top level. The
-        # multi-top shape matters: Godot's AssetLib install dialog defaults
-        # "Ignore asset root" to CHECKED whenever it detects a single top-
-        # level folder, which would strip `addons/` and drop `godot_ai/` at
-        # res:// — outside the plugin path and outside the addons-warning
-        # exclusion. With two top-level entries, Godot doesn't offer the
-        # strip option, so files land as-archived at res://addons/godot_ai/
-        # regardless of any user-toggled preference.
+      - name: Build plugin ZIPs
+        # Two artifacts from the same staging tree:
         #
-        # The second top-level entry is namespaced (`godot-ai-LICENSE.txt`)
-        # rather than a bare `LICENSE`. A bare `LICENSE` lands at
-        # `res://LICENSE` on install and silently overwrites the user's own
-        # project LICENSE file — issue #450. The namespaced name preserves
-        # the AssetLib trick without clobbering anything in a typical project.
-        # The canonical addon-scoped license still ships at
-        # `addons/godot_ai/LICENSE` for in-tree consumers.
+        # 1. `godot-ai-plugin.zip` — classic Asset Library entry (asset
+        #    5050 points straight at this release asset), self-updater, and
+        #    manual GitHub downloads. Ships `addons/` +
+        #    `godot-ai-LICENSE.txt` at the zip's top level. The multi-top
+        #    shape matters: the AssetLib-tab flow calls the installer with
+        #    autoskip enabled, and on Godot <= 4.6 that defaults "Ignore
+        #    Asset Root" to CHECKED for any single-top-folder zip — which
+        #    would strip `addons/` and drop `godot_ai/` at res:// — outside
+        #    the plugin path and outside the addons-warning exclusion. With
+        #    two top-level entries there is no root to strip, so files land
+        #    as-archived at res://addons/godot_ai/. Godot 4.7 added an
+        #    installer special case that refuses to strip a bare `addons/`
+        #    root by default (editor_asset_installer.cpp), so this trick —
+        #    and the whole two-artifact split — can be retired once the
+        #    supported floor reaches 4.7.
+        #
+        #    The sibling entry is namespaced (`godot-ai-LICENSE.txt`)
+        #    rather than a bare `LICENSE`. A bare `LICENSE` lands at
+        #    `res://LICENSE` on install and silently overwrites the user's
+        #    own project LICENSE file — issue #450.
+        #
+        # 2. `godot-ai-plugin-store.zip` — the upload for the new Godot
+        #    Asset Store. `addons/` only, no root-level license: store
+        #    review asked that the zip not duplicate the license at its
+        #    root since the canonical copy already ships at
+        #    `addons/godot_ai/LICENSE`. The single-top shape is safe for
+        #    every store consumer: browser downloads install via the
+        #    editor's manual Import... path (autoskip is off there on all
+        #    versions), and in-editor store browsing exists only on 4.7+,
+        #    which has the `addons/`-root guard.
         run: |
           mkdir -p staging/addons
           cp -r plugin/addons/godot_ai staging/addons/
@@ -114,6 +130,7 @@ jobs:
           # the extract. Stripping directory entries lets those installs
           # successfully self-update to a fixed runner.
           zip -D -r ../godot-ai-plugin.zip addons/ godot-ai-LICENSE.txt
+          zip -D -r ../godot-ai-plugin-store.zip addons/
 
       - name: Verify zip structure
         run: |
@@ -160,6 +177,38 @@ jobs:
             exit 1
           fi
           echo "Zip structure verified: addons/godot_ai/... + godot-ai-LICENSE.txt (multi-top)"
+
+          # --- Store zip (Asset Store upload) ---
+          # Exactly one top-level entry: `addons`. No root-level license —
+          # Asset Store review feedback: the license must not be duplicated
+          # at the zip root because it already ships inside the addon
+          # folder. Verify that inner copy is actually present before
+          # trusting its absence at the root.
+          store_tops=$(unzip -Z1 godot-ai-plugin-store.zip | awk -F/ '{print $1}' | sort -u | tr '\n' ' ' | sed 's/ $//')
+          if [ "$store_tops" != "addons" ]; then
+            echo "ERROR: expected sole top-level entry 'addons' in store zip, got:" >&2
+            echo "  $store_tops" >&2
+            exit 1
+          fi
+          if ! unzip -Z1 godot-ai-plugin-store.zip | grep -qx 'addons/godot_ai/plugin.cfg'; then
+            echo "ERROR: plugin.cfg not at expected path addons/godot_ai/plugin.cfg in store zip" >&2
+            exit 1
+          fi
+          if ! unzip -Z1 godot-ai-plugin-store.zip | grep -qx 'addons/godot_ai/LICENSE'; then
+            echo "ERROR: store zip is missing addons/godot_ai/LICENSE — the root license was dropped on the premise that this copy exists" >&2
+            exit 1
+          fi
+          if unzip -Z1 godot-ai-plugin-store.zip | grep -qE '/$'; then
+            echo "ERROR: store zip contains directory entries (forgot \`zip -D\`?):" >&2
+            unzip -Z1 godot-ai-plugin-store.zip | grep -E '/$' >&2
+            exit 1
+          fi
+          if unzip -Z1 godot-ai-plugin-store.zip | grep -q ' 2\.'; then
+            echo "ERROR: store zip contains iCloud-duplicate files (pattern ' 2.'):" >&2
+            unzip -Z1 godot-ai-plugin-store.zip | grep ' 2\.' >&2
+            exit 1
+          fi
+          echo "Store zip structure verified: addons/godot_ai/... only (license inside addon folder)"
 
       - name: Generate SHA-256 checksum
         # Sidecar checksum for the plugin's self-updater to verify the
@@ -222,10 +271,16 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
+          # godot-ai-plugin-store.zip ships without .sha256/.sig sidecars
+          # on purpose: only the self-updater verifies sidecars, and it
+          # downloads godot-ai-plugin.zip exclusively. The store zip exists
+          # solely to be uploaded to the Godot Asset Store, whose review
+          # asked for no root-level license duplicate.
           files: |
             godot-ai-plugin.zip
             godot-ai-plugin.zip.sha256
             godot-ai-plugin.zip.sha256.sig
+            godot-ai-plugin-store.zip
           generate_release_notes: true
 
       - name: Post changelog to Discord

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -11,7 +11,12 @@ Use the GitHub Actions workflow to cut a release:
 ```bash
 gh workflow run bump-and-release.yml -f bump=patch   # or minor / major
 ```
-This bumps `plugin.cfg` + `pyproject.toml`, commits, tags, and pushes. The `release.yml` workflow triggers on the tag and builds a `godot-ai-plugin.zip` attached to the GitHub Release.
+This bumps `plugin.cfg` + `pyproject.toml`, commits, tags, and pushes. The `release.yml` workflow triggers on the tag and attaches two plugin zips to the GitHub Release:
+
+- **`godot-ai-plugin.zip`** — the artifact the classic Asset Library entry ([asset 5050](https://godotengine.org/asset-library/asset/5050)) downloads directly, the self-updater installs, and the README links for manual install. Ships `addons/` plus a `godot-ai-LICENSE.txt` sibling at the zip root: the multi-top shape stops the AssetLib-tab installer on Godot ≤ 4.6 from auto-stripping a lone `addons/` root (which would install to `res://godot_ai/`), and the namespaced filename avoids clobbering the user's project `LICENSE` (issue #450). Godot 4.7+ no longer strips a bare `addons/` root, so the sibling — and the split below — can be retired once the supported floor reaches 4.7.
+- **`godot-ai-plugin-store.zip`** — the upload for the [new Godot Asset Store](https://store.godotengine.org/asset/dlight/godot-ai/) listing. `addons/` only, no root license: store review requires no license duplicate at the zip root since the canonical copy ships at `addons/godot_ai/LICENSE`. Store installs never hit the ≤ 4.6 autoskip default (browser download + manual Import, or the 4.7+ in-editor store), so the single-top shape is safe there. No `.sha256`/`.sig` sidecars — the self-updater never consumes this artifact. **Use this zip, not `godot-ai-plugin.zip`, when updating the Asset Store listing.**
+
+The shape contract for both zips is pinned by `tests/unit/test_release_zip_shape.py` and re-verified against the built artifacts in the workflow's "Verify zip structure" step.
 
 ## Self-update
 

--- a/tests/unit/test_release_zip_shape.py
+++ b/tests/unit/test_release_zip_shape.py
@@ -1,7 +1,10 @@
 """Pin the release-zip contract enforced by `.github/workflows/release.yml`.
 
-This test exists to keep two invariants from regressing in CI's
-`build-plugin-zip` step, both motivated by issue #450:
+CI's `build-plugin-zip` step produces two artifacts with deliberately
+different shapes; this test keeps both from regressing:
+
+`godot-ai-plugin.zip` (classic AssetLib entry, self-updater, manual
+downloads) — invariants motivated by issue #450:
 
   1. The zip's second top-level entry is `godot-ai-LICENSE.txt`, not a
      bare `LICENSE`. A bare `LICENSE` lands at `res://LICENSE` on
@@ -9,13 +12,22 @@ This test exists to keep two invariants from regressing in CI's
      LICENSE file.
 
   2. The multi-top-level shape (`addons/` + a sibling file) is preserved.
-     A single-top-folder zip lets AssetLib's "Ignore asset root" toggle
-     strip the `addons/` prefix and drop `godot_ai/` outside the
-     plugin path.
+     On Godot <= 4.6 a single-top-folder zip lets AssetLib's autoskipped
+     "Ignore asset root" toggle strip the `addons/` prefix and drop
+     `godot_ai/` outside the plugin path. (Godot 4.7+ special-cases a
+     bare `addons/` root; the sibling can be retired — and the two
+     artifacts re-unified — once the supported floor reaches 4.7.)
+
+`godot-ai-plugin-store.zip` (Godot Asset Store upload) — Asset Store
+review asked that the zip carry no root-level license duplicate, so it
+ships `addons/` only, with the canonical license at
+`addons/godot_ai/LICENSE`. Its consumers never hit the <= 4.6 autoskip
+default (browser download + manual Import, or the 4.7+ in-editor store).
 
 We assert against the workflow YAML text directly so a casual edit (e.g.
-"clean up the rename, just call it LICENSE again") trips this test before
-shipping a release that would clobber user files.
+"clean up the rename, just call it LICENSE again" or "add the license
+back to the store zip root") trips this test before shipping a release
+that would clobber user files or bounce off store review.
 """
 
 from __future__ import annotations
@@ -59,4 +71,36 @@ def test_release_zip_preserves_multi_top_shape(workflow_text: str) -> None:
     assert "addons/ godot-ai-LICENSE.txt" in workflow_text, (
         "release.yml must keep the multi-top-level zip shape so "
         "AssetLib doesn't strip the `addons/` prefix on install."
+    )
+
+
+def test_store_zip_packs_addons_only(workflow_text: str) -> None:
+    # The Asset Store upload must contain `addons/` and nothing else at
+    # the top level — store review rejects a root-level license
+    # duplicate, and any other root sibling is clutter installed into
+    # the user's project.
+    assert "../godot-ai-plugin-store.zip addons/\n" in workflow_text, (
+        "release.yml must build godot-ai-plugin-store.zip from `addons/` "
+        "alone — no root-level license or other sibling entries (Asset "
+        "Store review feedback)."
+    )
+
+
+def test_store_zip_verifies_inner_license_present(workflow_text: str) -> None:
+    # Dropping the root license is only valid while the canonical copy
+    # ships inside the addon folder; the workflow must keep verifying
+    # that premise at build time.
+    assert "addons/godot_ai/LICENSE" in workflow_text, (
+        "release.yml must verify addons/godot_ai/LICENSE exists in the "
+        "store zip — it is the only license copy in that artifact."
+    )
+
+
+def test_store_zip_attached_to_release(workflow_text: str) -> None:
+    # The store zip is only useful if it ships with the release for the
+    # maintainer to upload; building it and forgetting to attach it
+    # would silently revert the store to the multi-top zip.
+    assert workflow_text.count("godot-ai-plugin-store.zip") >= 3, (
+        "release.yml must build, verify, and attach "
+        "godot-ai-plugin-store.zip to the GitHub Release."
     )

--- a/tests/unit/test_release_zip_shape.py
+++ b/tests/unit/test_release_zip_shape.py
@@ -86,11 +86,27 @@ def test_store_zip_packs_addons_only(workflow_text: str) -> None:
     )
 
 
+def _step_block(workflow_text: str, step_name: str, next_step_name: str) -> str:
+    # Slice the text of one workflow step so assertions can't be
+    # satisfied by comments or unrelated steps elsewhere in the file.
+    start_marker = f"      - name: {step_name}"
+    end_marker = f"      - name: {next_step_name}"
+    assert start_marker in workflow_text, f"release.yml is missing step {step_name!r}"
+    block = workflow_text.split(start_marker, 1)[1]
+    assert end_marker in block, (
+        f"release.yml is missing step {next_step_name!r} after {step_name!r}"
+    )
+    return block.split(end_marker, 1)[0]
+
+
 def test_store_zip_verifies_inner_license_present(workflow_text: str) -> None:
     # Dropping the root license is only valid while the canonical copy
     # ships inside the addon folder; the workflow must keep verifying
-    # that premise at build time.
-    assert "addons/godot_ai/LICENSE" in workflow_text, (
+    # that premise at build time. Scoped to the verify step: the build
+    # step's comments also mention the path, so a whole-file substring
+    # match would pass even with the actual check deleted.
+    verify_step = _step_block(workflow_text, "Verify zip structure", "Generate SHA-256 checksum")
+    assert "grep -qx 'addons/godot_ai/LICENSE'" in verify_step, (
         "release.yml must verify addons/godot_ai/LICENSE exists in the "
         "store zip — it is the only license copy in that artifact."
     )
@@ -99,8 +115,11 @@ def test_store_zip_verifies_inner_license_present(workflow_text: str) -> None:
 def test_store_zip_attached_to_release(workflow_text: str) -> None:
     # The store zip is only useful if it ships with the release for the
     # maintainer to upload; building it and forgetting to attach it
-    # would silently revert the store to the multi-top zip.
-    assert workflow_text.count("godot-ai-plugin-store.zip") >= 3, (
-        "release.yml must build, verify, and attach "
-        "godot-ai-plugin-store.zip to the GitHub Release."
+    # would silently revert the store to the multi-top zip. Scoped to
+    # the release step's files list: the name appears many times in the
+    # build/verify steps, so a bare count can't catch a missing entry.
+    release_step = _step_block(workflow_text, "Create GitHub Release", "Post changelog to Discord")
+    assert "\n            godot-ai-plugin-store.zip\n" in release_step, (
+        "release.yml must attach godot-ai-plugin-store.zip to the "
+        "GitHub Release."
     )


### PR DESCRIPTION
## Why

Godot Asset Store review feedback: *"you should remove the license from the root of the zip because it is already inside the addon's content folder."*

The root `godot-ai-LICENSE.txt` can't simply be dropped from `godot-ai-plugin.zip`: it is what gives the zip two top-level entries, and the classic Asset Library entry ([asset 5050](https://godotengine.org/asset-library/asset/5050)) downloads that artifact directly. On Godot ≤ 4.6 the AssetLib-tab installer defaults "Ignore Asset Root" to checked for any single-top-folder zip (verified against `editor_asset_installer.cpp` on the 4.5/4.6 stable branches), which would strip `addons/` and install to `res://godot_ai/`. Godot 4.7 added a special case that refuses to strip a bare `addons/` root, so the whole split can be retired once the supported floor reaches 4.7.

## What

- `release.yml` builds and attaches a second artifact, **`godot-ai-plugin-store.zip`**: `addons/` only, license solely at `addons/godot_ai/LICENSE`. This is the upload for the [Asset Store listing](https://store.godotengine.org/asset/dlight/godot-ai/). Its consumers never hit the ≤ 4.6 autoskip default (browser download + manual Import, or the 4.7+ in-editor store). No `.sha256`/`.sig` sidecars — the self-updater only ever downloads `godot-ai-plugin.zip`.
- `godot-ai-plugin.zip` is unchanged in shape (multi-top, namespaced license per #450).
- The workflow's verify step pins the store zip's shape: sole `addons` top-level, `plugin.cfg` and `LICENSE` present inside the addon folder, no directory entries, no iCloud-duplicate files.
- `tests/unit/test_release_zip_shape.py` pins the two-artifact contract.
- `docs/releasing.md` documents which zip feeds which listing.

## Verification

- ruff clean; all zip-shape/rescue-contract unit tests pass; workflow YAML parses.
- Ran the CI build+verify shell logic locally: both zips produce exactly the expected shapes.
- **Live self-update smoke (`script/local-self-update-smoke`) passed all checks** on Godot 4.6.3, using a base zip built exactly as this workflow builds it (`--base-from-zip`): plugin advanced v3.0.7 to v3.0.8 in place, editor survived without restart, update temp dir consumed, no vNext `_exit_tree` during the update window, correct server lifecycle, no version-mismatch reports, no new `.ips` crash reports.
- Bonus (unscripted) coverage from an earlier run: the fixture plugin also successfully self-updated from the synthetic v3.0.8 to the real v3.1.2 GitHub release zip in place.

## Operational note

After the next release, upload `godot-ai-plugin-store.zip` (not `godot-ai-plugin.zip`) when updating the Asset Store listing. The classic Asset Library entry needs no change — it keeps pointing at `godot-ai-plugin.zip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Releases now include a dedicated Godot Asset Store package containing only the required add-ons.
  * The existing Asset Library/self-update package remains available with its license included.

* **Documentation**
  * Updated release guidance explains both package formats, installation requirements, licensing, and validation checks.

* **Quality Improvements**
  * Added automated validation for package contents, license placement, archive structure, and release attachment to help ensure reliable downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->