### PR TITLE
fix: stop handshake verdicts from stealing the startup walk's worker slot

### DIFF
--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -151,9 +151,14 @@ var _active_blocking_thread: Thread = null
 ##
 ## Returns null (without joining) when `_invalidate_async_startup` took
 ## ownership of the thread mid-flight — the walk is stale at that point
-## and must bail at its next staleness check, so callers assign the
-## result to an untyped local BEFORE the staleness check (a typed
-## assignment would trip on the null first).
+## and must bail. Callers therefore assign the result to an untyped
+## local and bail on `_async_stale(...) or result == null` BEFORE any
+## typed use — a typed assignment (or a bool()/int() constructor, both
+## of which have no Nil form) trips on the null first. The null check is
+## not redundant with the generation check: a caller that loses the slot
+## without a generation bump — an invariant violation, but exactly what
+## a concurrent fire-and-forget `_run_blocking` user produces — must
+## still unwind instead of crashing on the Nil.
 func _run_blocking(work: Callable) -> Variant:
 	if not defer_blocking_work:
 		return work.call()
@@ -407,7 +412,12 @@ static func _managed_record_has_version_drift(record_version: String, current_ve
 
 # ---- Incompatible-server bookkeeping ----------------------------------
 
-func _set_incompatible_server(live: Dictionary, expected_version: String, port: int) -> void:
+func _set_incompatible_server(
+	live: Dictionary,
+	expected_version: String,
+	port: int,
+	caller_owns_worker_slot := false
+) -> void:
 	## Latches the incompatible diagnosis into manager state and asks
 	## the dock to re-sweep client rows so they don't show stale green.
 	## Threads the caller's `live` snapshot through the recovery proof
@@ -420,10 +430,25 @@ func _set_incompatible_server(live: Dictionary, expected_version: String, port: 
 	## either. Everything user-visible (status message, connection block,
 	## version-check disarm) is latched synchronously before the first
 	## await; only the recovery verdict and the suggested-port diagnostic
-	## arrive with the worker. Sync callers (handshake verdicts, the
-	## force-restart failure arm) fire-and-forget the tail; the startup
-	## walk awaits it so `_run_blocking`'s single-active-worker tracking
-	## keeps one owner at a time.
+	## arrive with the worker.
+	##
+	## `_run_blocking` tracks a single active worker, so the tail below
+	## needs exclusive ownership of that slot. The startup walk awaits
+	## this call with `caller_owns_worker_slot=true` — it already owns the
+	## slot and serializes the tail behind its own blocking ops. Sync
+	## callers (the handshake verdicts via `handle_server_version_*`, the
+	## force-restart failure arm) fire-and-forget the tail and leave the
+	## flag false, so the head takes ownership for them: a handshake
+	## verdict lands from `_process` while a startup walk can still be
+	## suspended in `_run_blocking`, and starting the tail's worker then
+	## would steal the slot — the walk's op is orphaned from the
+	## `_invalidate_async_startup` join guarantee and its resume gets a
+	## null without a generation bump (the Nil-into-Dictionary crash on
+	## the incompatible-occupant walk). Cancelling the walk first mirrors
+	## the recovery click (#712): the diagnosis in hand supersedes
+	## whatever the walk was still probing for.
+	if not caller_owns_worker_slot:
+		_invalidate_async_startup()
 	transition_state(McpServerStateScript.INCOMPATIBLE)
 	_connection_blocked = true
 	_server_expected_version = expected_version
@@ -464,7 +489,7 @@ func _set_incompatible_server(live: Dictionary, expected_version: String, port: 
 			return {"proof": "", "pids": []}
 		return _host._evaluate_recovery_port_occupant_proof(port, live, record)
 	)
-	if _async_stale(async_gen):
+	if _async_stale(async_gen) or proof_result == null:
 		return
 	var proof: Dictionary = proof_result
 	var proof_name := str(proof.get("proof", ""))
@@ -481,7 +506,7 @@ func _set_incompatible_server(live: Dictionary, expected_version: String, port: 
 		var suggested_result: Variant = await _run_blocking(func() -> Variant:
 			return ClientConfigurator.suggest_free_port(port + 1)
 		)
-		if _async_stale(async_gen):
+		if _async_stale(async_gen) or suggested_result == null:
 			return
 		print("MCP | port %d occupant not recoverable (no ownership proof); suggested free port %d (set godot_ai/http_port)" % [port, int(suggested_result)])
 	## Second sweep so the dock's recovery affordance reflects the verdict
@@ -698,11 +723,12 @@ func _start_server_impl(async_gen: int) -> void:
 	## The worker closures re-check the host: the plugin can be freed while
 	## a bounded shell probe is still running, and the generation check only
 	## protects state after resume, not calls inside the task (#682 review).
-	var port_in_use := bool(await _run_blocking(func() -> Variant:
+	var port_in_use_result: Variant = await _run_blocking(func() -> Variant:
 		return is_instance_valid(_host) and _host._is_port_in_use(port)
-	))
-	if _async_stale(async_gen):
+	)
+	if _async_stale(async_gen) or port_in_use_result == null:
 		return
+	var port_in_use := bool(port_in_use_result)
 	if not port_in_use:
 		## #745: after an editor crash (or under multi-editor churn) the
 		## managed server keeps running, yet the bind probe can still say
@@ -722,7 +748,7 @@ func _start_server_impl(async_gen: int) -> void:
 				return {}
 			return _host._probe_live_server_status_for_port(port)
 		)
-		if _async_stale(async_gen):
+		if _async_stale(async_gen) or evidence_result == null:
 			return
 		var evidence: Dictionary = evidence_result
 		if _live_status_identifies_godot_ai(evidence):
@@ -745,7 +771,7 @@ func _start_server_impl(async_gen: int) -> void:
 				return {}
 			return _host._probe_live_server_status_for_port(port)
 		)
-		if _async_stale(async_gen):
+		if _async_stale(async_gen) or live_result == null:
 			return
 		var live: Dictionary = live_result
 		var live_version := str(_host._verified_status_version(live))
@@ -770,7 +796,7 @@ func _start_server_impl(async_gen: int) -> void:
 					return {"proof": "", "pids": []}
 				return _host._evaluate_strong_port_occupant_proof(port, live, record)
 			)
-			if _async_stale(async_gen):
+			if _async_stale(async_gen) or adoption_proof_result == null:
 				return
 			var adoption_proof: Dictionary = adoption_proof_result
 			var proof_pids: Array[int] = []
@@ -810,15 +836,17 @@ func _start_server_impl(async_gen: int) -> void:
 					return {}
 				return _host._probe_live_server_status_for_port(port)
 			)
-			if _async_stale(async_gen):
+			if _async_stale(async_gen) or post_recovery_result == null:
 				return
 			var post_recovery_live: Dictionary = post_recovery_result
-			## Awaited (#712): the diagnosis tail runs its own _run_blocking
-			## proof, and the walk must stay the single owner of the
-			## active-worker slot until that lands. The status message is
-			## latched before the tail's first await, so the push_warning
-			## below reads the final text either way.
-			await _set_incompatible_server(post_recovery_live, current_version, port)
+			## Awaited with caller_owns_worker_slot=true (#712): the
+			## diagnosis tail runs its own _run_blocking proof, and the walk
+			## stays the single owner of the active-worker slot by
+			## serializing that tail behind this await instead of letting it
+			## re-take the slot. The status message is latched before the
+			## tail's first await, so the push_warning below reads the final
+			## text either way.
+			await _set_incompatible_server(post_recovery_live, current_version, port, true)
 			if _async_stale(async_gen):
 				return
 			_startup_path = McpStartupPathScript.INCOMPATIBLE
@@ -836,7 +864,7 @@ func _start_server_impl(async_gen: int) -> void:
 	var server_cmd_result: Variant = await _run_blocking(func() -> Variant:
 		return ClientConfigurator.get_server_command()
 	)
-	if _async_stale(async_gen):
+	if _async_stale(async_gen) or server_cmd_result == null:
 		return
 	var server_cmd: Array = server_cmd_result
 	if server_cmd.is_empty():
@@ -1432,7 +1460,7 @@ func recover_strong_port_occupant(port: int, wait_s: float, pre_kill_live: Dicti
 			return {"proof": "", "pids": []}
 		return _host._evaluate_strong_port_occupant_proof(port, pre_kill_live, record)
 	)
-	if _async_stale(async_gen):
+	if _async_stale(async_gen) or proof_result == null:
 		return false
 	var proof: Dictionary = proof_result
 	var targets: Array[int] = []
@@ -1441,7 +1469,7 @@ func recover_strong_port_occupant(port: int, wait_s: float, pre_kill_live: Dicti
 		return false
 
 	print("MCP | strong proof: %s" % str(proof.get("proof", "")))
-	var freed := bool(await _run_blocking(func() -> Variant:
+	var freed_result: Variant = await _run_blocking(func() -> Variant:
 		if not is_instance_valid(_host):
 			return false
 		## verify_brand=true: the proof above ran in a separate _run_blocking
@@ -1452,10 +1480,10 @@ func recover_strong_port_occupant(port: int, wait_s: float, pre_kill_live: Dicti
 			print("MCP | killed pids %s on port %d" % [str(killed), port])
 		_host._wait_for_port_free(port, wait_s)
 		return not bool(_host._is_port_in_use(port))
-	))
-	if _async_stale(async_gen):
+	)
+	if _async_stale(async_gen) or freed_result == null:
 		return false
-	if not freed:
+	if not bool(freed_result):
 		return false
 
 	_host._clear_managed_server_record()
@@ -1704,7 +1732,7 @@ func recover_incompatible_server() -> bool:
 			return {"proof": "", "pids": []}
 		return _host._evaluate_recovery_port_occupant_proof(port, {}, record)
 	)
-	if _async_stale(async_gen):
+	if _async_stale(async_gen) or proof_result == null:
 		return false
 	var proof: Dictionary = proof_result
 	var targets: Array[int] = []
@@ -1729,7 +1757,7 @@ func recover_incompatible_server() -> bool:
 		_host._wait_for_port_free(port, 5.0)
 		return not bool(_host._is_port_in_use(port))
 	)
-	if _async_stale(async_gen):
+	if _async_stale(async_gen) or freed_result == null:
 		return false
 	if not bool(freed_result):
 		## Kill failed; re-latch INCOMPATIBLE so the dock keeps the

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -136,6 +136,12 @@ func _init(host) -> void:
 ## churn (main CI, post-#682). Null when no blocking work is in flight.
 var _active_blocking_thread: Thread = null
 
+## When a cancelled worker thread needs to be joined later (rather than
+## synchronously), this holds the thread reference until
+## `_wait_for_worker_completion` joins it. Null when no deferred join is
+## pending. Only set by `_invalidate_async_startup(join_worker=false)`.
+var _deferred_join_thread: Thread = null
+
 
 ## Run `work` off the main thread and suspend until it completes (#678).
 ## Falls back to inline execution when `defer_blocking_work` is off, or
@@ -201,13 +207,72 @@ func _async_stale(generation: int) -> bool:
 ## port-drain wait). `stop_server` runs this from `_exit_tree`, so once
 ## it returns no worker thread can still be executing a method of the
 ## plugin that is about to be freed — the macOS reload-churn wedge.
-func _invalidate_async_startup() -> void:
+##
+## `join_worker`: when true (default), synchronously joins the active
+## worker thread. Teardown paths (stop_server, detach_server) must pass
+## true to prevent use-after-free. Synchronous verdict paths
+## (handshake mismatch) pass false so the main thread doesn't block —
+## the worker completes naturally and its own staleness check discards
+## the result, but the thread itself is kept alive in
+## `_deferred_join_thread` for `_wait_for_worker_completion` to join.
+func _invalidate_async_startup(join_worker := true) -> void:
 	_async_generation += 1
 	_start_in_flight = false
 	var thread := _active_blocking_thread
 	_active_blocking_thread = null
 	if thread != null:
-		thread.wait_to_finish()
+		if join_worker:
+			thread.wait_to_finish()
+		else:
+			## Defer the join: the thread must still be joined before
+			## it's freed (Godot requirement), but we don't want to
+			## block the main thread here. Stash it for
+			## _wait_for_worker_completion to handle.
+			## Edge case: if there's already a deferred thread, join it
+			## first to prevent leaking the old thread handle. The join
+			## is bounded by that op's own timeout (same as the
+			## synchronous path above).
+			if _deferred_join_thread != null:
+				_deferred_join_thread.wait_to_finish()
+			_deferred_join_thread = thread
+
+
+## Wait for any active worker thread to complete naturally, then join
+## any deferred worker thread. Used by synchronous verdict paths that
+## cancelled a walk without joining — the worker's `_run_blocking` loop
+## sees the cancellation flag and unwinds on its own, but we must wait
+## for it to finish AND join it (Godot requirement) before starting a
+## new `_run_blocking` operation (which needs exclusive ownership of the
+## `_active_blocking_thread` slot). Suspends frame-by-frame until the
+## worker is gone, then joins the deferred thread if present. No-ops
+## immediately when no worker is active.
+func _wait_for_worker_completion() -> void:
+	if _active_blocking_thread == null and _deferred_join_thread == null:
+		return
+	var tree := Engine.get_main_loop()
+	if not (tree is SceneTree):
+		## No SceneTree available to pump frames against. If there's a
+		## deferred join pending, we must join it synchronously to
+		## satisfy Godot's Thread requirements, even though this
+		## defeats the non-blocking intent. This is a failsafe for edge
+		## cases (tool scripts, tests) where defer_blocking_work might
+		## be on but no SceneTree is available.
+		if _deferred_join_thread != null:
+			_deferred_join_thread.wait_to_finish()
+			_deferred_join_thread = null
+		return
+	## Wait for the deferred worker to naturally complete. The
+	## _run_blocking loop detects the cancellation and returns null
+	## without joining, so the thread is still alive and running its
+	## work. Poll until it finishes.
+	while _deferred_join_thread != null and _deferred_join_thread.is_alive():
+		await (tree as SceneTree).process_frame
+	## Join the deferred thread. By this point the thread has exited,
+	## so wait_to_finish is non-blocking (just retrieves the already-
+	## completed result).
+	if _deferred_join_thread != null:
+		_deferred_join_thread.wait_to_finish()
+		_deferred_join_thread = null
 
 
 # ---- Public state accessors --------------------------------------------
@@ -441,14 +506,14 @@ func _set_incompatible_server(
 	## flag false, so the head takes ownership for them: a handshake
 	## verdict lands from `_process` while a startup walk can still be
 	## suspended in `_run_blocking`, and starting the tail's worker then
-	## would steal the slot — the walk's op is orphaned from the
-	## `_invalidate_async_startup` join guarantee and its resume gets a
-	## null without a generation bump (the Nil-into-Dictionary crash on
-	## the incompatible-occupant walk). Cancelling the walk first mirrors
+	## would steal the slot. Cancelling the walk without joining mirrors
 	## the recovery click (#712): the diagnosis in hand supersedes
-	## whatever the walk was still probing for.
+	## whatever the walk was still probing for, and the cancelled walk's
+	## worker completes naturally (its resume checks `_async_stale()` and
+	## unwinds). The tail waits for that natural completion before taking
+	## the worker slot.
 	if not caller_owns_worker_slot:
-		_invalidate_async_startup()
+		_invalidate_async_startup(false)
 	transition_state(McpServerStateScript.INCOMPATIBLE)
 	_connection_blocked = true
 	_server_expected_version = expected_version
@@ -482,6 +547,14 @@ func _set_incompatible_server(
 	## Off-thread recovery proof (#712), mirroring recover_strong_port_occupant:
 	## the EditorSettings record is read on the main thread up front and
 	## injected as record_override — EditorSettings is main-thread-only.
+	##
+	## When `caller_owns_worker_slot` is false, the `_invalidate_async_startup`
+	## call above cancelled any in-flight walk WITHOUT joining its worker thread,
+	## so we must wait for that worker to complete naturally before our own
+	## `_run_blocking` can take the slot. The worker's `_run_blocking` loop checks
+	## `_active_blocking_thread != thread` and returns null, unwinding the walk.
+	if not caller_owns_worker_slot:
+		await _wait_for_worker_completion()
 	var async_gen := _async_generation
 	var record: Dictionary = _host._read_managed_server_record()
 	var proof_result: Variant = await _run_blocking(func() -> Variant:

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -136,12 +136,6 @@ func _init(host) -> void:
 ## churn (main CI, post-#682). Null when no blocking work is in flight.
 var _active_blocking_thread: Thread = null
 
-## When a cancelled worker thread needs to be joined later (rather than
-## synchronously), this holds the thread reference until
-## `_wait_for_worker_completion` joins it. Null when no deferred join is
-## pending. Only set by `_invalidate_async_startup(join_worker=false)`.
-var _deferred_join_thread: Thread = null
-
 
 ## Run `work` off the main thread and suspend until it completes (#678).
 ## Falls back to inline execution when `defer_blocking_work` is off, or
@@ -207,72 +201,13 @@ func _async_stale(generation: int) -> bool:
 ## port-drain wait). `stop_server` runs this from `_exit_tree`, so once
 ## it returns no worker thread can still be executing a method of the
 ## plugin that is about to be freed — the macOS reload-churn wedge.
-##
-## `join_worker`: when true (default), synchronously joins the active
-## worker thread. Teardown paths (stop_server, detach_server) must pass
-## true to prevent use-after-free. Synchronous verdict paths
-## (handshake mismatch) pass false so the main thread doesn't block —
-## the worker completes naturally and its own staleness check discards
-## the result, but the thread itself is kept alive in
-## `_deferred_join_thread` for `_wait_for_worker_completion` to join.
-func _invalidate_async_startup(join_worker := true) -> void:
+func _invalidate_async_startup() -> void:
 	_async_generation += 1
 	_start_in_flight = false
 	var thread := _active_blocking_thread
 	_active_blocking_thread = null
 	if thread != null:
-		if join_worker:
-			thread.wait_to_finish()
-		else:
-			## Defer the join: the thread must still be joined before
-			## it's freed (Godot requirement), but we don't want to
-			## block the main thread here. Stash it for
-			## _wait_for_worker_completion to handle.
-			## Edge case: if there's already a deferred thread, join it
-			## first to prevent leaking the old thread handle. The join
-			## is bounded by that op's own timeout (same as the
-			## synchronous path above).
-			if _deferred_join_thread != null:
-				_deferred_join_thread.wait_to_finish()
-			_deferred_join_thread = thread
-
-
-## Wait for any active worker thread to complete naturally, then join
-## any deferred worker thread. Used by synchronous verdict paths that
-## cancelled a walk without joining — the worker's `_run_blocking` loop
-## sees the cancellation flag and unwinds on its own, but we must wait
-## for it to finish AND join it (Godot requirement) before starting a
-## new `_run_blocking` operation (which needs exclusive ownership of the
-## `_active_blocking_thread` slot). Suspends frame-by-frame until the
-## worker is gone, then joins the deferred thread if present. No-ops
-## immediately when no worker is active.
-func _wait_for_worker_completion() -> void:
-	if _active_blocking_thread == null and _deferred_join_thread == null:
-		return
-	var tree := Engine.get_main_loop()
-	if not (tree is SceneTree):
-		## No SceneTree available to pump frames against. If there's a
-		## deferred join pending, we must join it synchronously to
-		## satisfy Godot's Thread requirements, even though this
-		## defeats the non-blocking intent. This is a failsafe for edge
-		## cases (tool scripts, tests) where defer_blocking_work might
-		## be on but no SceneTree is available.
-		if _deferred_join_thread != null:
-			_deferred_join_thread.wait_to_finish()
-			_deferred_join_thread = null
-		return
-	## Wait for the deferred worker to naturally complete. The
-	## _run_blocking loop detects the cancellation and returns null
-	## without joining, so the thread is still alive and running its
-	## work. Poll until it finishes.
-	while _deferred_join_thread != null and _deferred_join_thread.is_alive():
-		await (tree as SceneTree).process_frame
-	## Join the deferred thread. By this point the thread has exited,
-	## so wait_to_finish is non-blocking (just retrieves the already-
-	## completed result).
-	if _deferred_join_thread != null:
-		_deferred_join_thread.wait_to_finish()
-		_deferred_join_thread = null
+		thread.wait_to_finish()
 
 
 # ---- Public state accessors --------------------------------------------
@@ -506,14 +441,14 @@ func _set_incompatible_server(
 	## flag false, so the head takes ownership for them: a handshake
 	## verdict lands from `_process` while a startup walk can still be
 	## suspended in `_run_blocking`, and starting the tail's worker then
-	## would steal the slot. Cancelling the walk without joining mirrors
+	## would steal the slot — the walk's op is orphaned from the
+	## `_invalidate_async_startup` join guarantee and its resume gets a
+	## null without a generation bump (the Nil-into-Dictionary crash on
+	## the incompatible-occupant walk). Cancelling the walk first mirrors
 	## the recovery click (#712): the diagnosis in hand supersedes
-	## whatever the walk was still probing for, and the cancelled walk's
-	## worker completes naturally (its resume checks `_async_stale()` and
-	## unwinds). The tail waits for that natural completion before taking
-	## the worker slot.
+	## whatever the walk was still probing for.
 	if not caller_owns_worker_slot:
-		_invalidate_async_startup(false)
+		_invalidate_async_startup()
 	transition_state(McpServerStateScript.INCOMPATIBLE)
 	_connection_blocked = true
 	_server_expected_version = expected_version
@@ -547,14 +482,6 @@ func _set_incompatible_server(
 	## Off-thread recovery proof (#712), mirroring recover_strong_port_occupant:
 	## the EditorSettings record is read on the main thread up front and
 	## injected as record_override — EditorSettings is main-thread-only.
-	##
-	## When `caller_owns_worker_slot` is false, the `_invalidate_async_startup`
-	## call above cancelled any in-flight walk WITHOUT joining its worker thread,
-	## so we must wait for that worker to complete naturally before our own
-	## `_run_blocking` can take the slot. The worker's `_run_blocking` loop checks
-	## `_active_blocking_thread != thread` and returns null, unwinding the walk.
-	if not caller_owns_worker_slot:
-		await _wait_for_worker_completion()
 	var async_gen := _async_generation
 	var record: Dictionary = _host._read_managed_server_record()
 	var proof_result: Variant = await _run_blocking(func() -> Variant:

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -95,6 +95,17 @@ class _ManagerHostStub extends GodotAiPlugin:
 		return managed_pid_lookup
 
 
+## Host for the deferred-walk (#678) verdict-race test below: a worker-side
+## nap keeps the startup walk deterministically suspended inside its first
+## `_run_blocking` op (without it a fast worker can finish before the first
+## `is_alive()` check and the whole walk completes without suspending). The
+## nap runs on the worker thread, never the main thread.
+class _SuspendedWalkHostStub extends _ManagerHostStub:
+	func _is_port_in_use(port: int) -> bool:
+		OS.delay_msec(100)
+		return super._is_port_in_use(port)
+
+
 const TEST_PORT := 65431
 
 const _TENV1 := "GODOT_AI_DISABLE_TELEMETRY"
@@ -273,6 +284,61 @@ func test_set_incompatible_server_tolerates_missing_connection() -> void:
 	var state := manager.get_state()
 	host.free()
 
+	assert_eq(state, McpServerState.INCOMPATIBLE)
+
+
+# ----- sync verdict vs suspended startup walk (worker-slot ownership) ---
+
+func test_sync_verdict_mid_walk_cancels_walk_before_claiming_worker_slot() -> void:
+	## An incompatible-occupant startup walk suspends in _run_blocking
+	## while the WS handshake verdict (McpServerVersionCheck, ticked from
+	## the plugin's _process) can land handle_server_version_verified
+	## concurrently. The verdict's _set_incompatible_server tail claims
+	## the single active-worker slot, so it must cancel the suspended walk
+	## first — pre-fix it stole the slot instead, the walk's op lost the
+	## _invalidate_async_startup join guarantee, and the walk's resume got
+	## a null with no generation bump ("Trying to assign value of type
+	## 'Nil' to a variable of type 'Dictionary'" on v3.1.2/v3.1.3 startup
+	## against an older attach-owned server holding the port).
+	##
+	## The runner does not await test coroutines, so this test makes only
+	## synchronous observations: everything asserted below is latched
+	## before _set_incompatible_server's first await. The closing
+	## _invalidate_async_startup joins the tail's in-flight worker and
+	## stales the detached walk/tail continuations, so they unwind on
+	## later frames without touching the freed host.
+	var saved_guard: bool = GodotAiPlugin._server_started_this_session
+	GodotAiPlugin._server_started_this_session = false
+	var host := _SuspendedWalkHostStub.new()
+	host._log_buffer = McpLogBuffer.new()
+	host._connection = null
+	host.port_in_use = true
+	host.live_status = {"name": "godot-ai", "version": "0.0.1", "ws_port": 9500, "status_code": 200}
+	var manager := McpServerLifecycleManagerScript.new(host)
+	manager.defer_blocking_work = true
+
+	manager.start_server()
+	var walk_suspended: bool = manager._active_blocking_thread != null
+	var in_flight_before: bool = manager._start_in_flight
+	var gen_before := int(manager._async_generation)
+
+	manager.handle_server_version_verified("9.9.9", "0.0.1")
+	var gen_after := int(manager._async_generation)
+	var in_flight_after: bool = manager._start_in_flight
+	var state := manager.get_state()
+
+	manager._invalidate_async_startup()
+	GodotAiPlugin._server_started_this_session = saved_guard
+	host.free()
+
+	assert_true(walk_suspended,
+		"precondition: the deferred walk must be suspended in _run_blocking")
+	assert_true(in_flight_before,
+		"precondition: the suspended walk must hold the re-entrancy guard")
+	assert_gt(gen_after, gen_before,
+		"sync verdict must invalidate the suspended walk before its tail claims the worker slot")
+	assert_false(in_flight_after,
+		"cancelling the walk must release its re-entrancy guard")
 	assert_eq(state, McpServerState.INCOMPATIBLE)
 
 


### PR DESCRIPTION
## Symptom

On v3.1.2/v3.1.3, whenever editor startup finds an older godot-ai server holding the HTTP port (e.g. a v3.1.1 attach-owned server on :8000), the editor Output shows:

```
SCRIPT ERROR: Trying to assign value of type 'Nil' to a variable of type 'Dictionary'.
  at: McpServerLifecycleManager._start_server_impl (res://addons/godot_ai/utils/server_lifecycle.gd:815)
  GDScript backtrace: [0] _start_server_impl (server_lifecycle.gd:815), [1] _run_blocking (server_lifecycle.gd:173)
```

A retry walk then completes the incompatible-server banner + `MCP | proof: status_name`, masking the failure from users.

## Root cause

The deferred startup walk (#678) suspends in `_run_blocking` while the plugin's connection dials the occupant's WS port in parallel. The handshake against the old server delivers a version-mismatch verdict from `_process` (`McpServerVersionCheck` → `handle_server_version_verified`), which fires `_set_incompatible_server` fire-and-forget. Its #712 diagnosis tail (`_evaluate_recovery_port_occupant_proof` via `_run_blocking`) then claimed the single active-worker slot out from under the suspended walk — violating the single-owner invariant the comment at the crash site documents. The walk's op lost the `_invalidate_async_startup` join guarantee, and its resume received `null` **without** a generation bump, so the only guard (`_async_stale`) passed and the typed `Dictionary` assignment crashed. The missing-handshake_ack verdict (`handle_server_version_unverified`) had the same race.

## Fix (two layers)

1. **Restore the single-owner invariant**: `_set_incompatible_server` takes a `caller_owns_worker_slot` parameter. Sync callers (both verdict arms, the force-restart failure arm) leave it false, so the head runs `_invalidate_async_startup()` first — cancelling and joining the suspended walk exactly the way the recovery click already does (#712) — before the tail claims the slot. The startup walk, which owns the slot and awaits the tail, passes `true`.
2. **Harden every `_run_blocking` call site** (12 sites): bail on `_async_stale(...) or result == null` before any typed use. The two `bool(await _run_blocking(...))` wrappers were restructured to untyped-first as well — `bool(null)` / `int(null)` are themselves SCRIPT ERRORs in GDScript ("Nonexistent 'bool' constructor"), and the port-probe site crashed *before* its staleness check. A future slot loss without a generation bump now unwinds instead of crashing.

## Regression test

`test_sync_verdict_mid_walk_cancels_walk_before_claiming_worker_slot` suspends a real deferred walk (worker-side nap guarantees suspension) and lands the verdict synchronously. It makes only synchronous observations because the test runner never awaits test coroutines. Stash-verified red on the unfixed code: it aborts with "Attempted to free a locked object" — the un-joined worker still executing a host method, the same use-after-free class the join guarantee exists to prevent (the macOS reload-churn wedge).

## Verification

- `ruff check` clean; `pytest`: 1682 passed, 5 skipped
- Full GDScript suite against a live editor: 2116/2143 passed, 0 failed (server_lifecycle 76/76; new test red pre-fix, green post-fix)
- Live mismatch fixture (v3.1.1 server on an isolated port vs v3.1.3 plugin, Godot 4.6.3): pre-fix reproduces the exact SCRIPT ERROR at line 815 on the first launch; post-fix, two runs latch the banner + proof with zero errors
- `script/local-self-update-smoke`: all checks PASS (v3.1.3 → synthetic v3.1.4, both sides carrying the fixed lifecycle; no crash, no `.ips`, temp dir consumed, no vNext `_exit_tree` during the update window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server startup and recovery reliability when an incompatible server version is detected.
  * Prevented outdated or cancelled background operations from incorrectly changing server state.
  * Improved cancellation handling across server checks, shutdown, recovery, and restart flows.
  * Ensured competing startup work is cancelled before a new startup attempt proceeds.

* **Tests**
  * Added regression coverage for interrupted startup operations and incompatible server detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->