### PR TITLE
fix(clients): let Antigravity opt out of the Windows pythonw launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,10 @@ tiers, a small stdio-preserving `CREATE_NO_WINDOW` bootstrap). This prevents a
 terminal window from opening with Claude Desktop or Codex while keeping the MCP
 process attached to the client's stdin/stdout pipes. Do not simplify that
 generated entry back to a console-subsystem `python.exe`, `uvx.exe`, or
-`godot-ai.exe` command.
+`godot-ai.exe` command. Antigravity is the exception: its spawner hangs tool
+calls behind a GUI-subsystem executable (#863), so its entry is written with
+the plain console command instead — Antigravity hides child console windows
+itself.
 
 Advanced fallback for clients intentionally kept in URL mode:
 

--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -105,7 +105,11 @@ call `resolved_config_path()`, so they operate on the same effective file.
 Launch resolution intentionally fails **closed**: Configure returns ERROR and
 leaves the config untouched if no valid launch tier exists on any platform, or
 if `_finalize_attach_launch()` cannot resolve a consoleless interpreter on
-Windows. Non-Windows platforms succeed as soon as a valid launch tier is
+Windows. The Windows result also carries the unwrapped console shape
+(`console_command`/`console_args`); `launch_for_client()` swaps it in for
+descriptors that set `needs_consoleless_launcher = false` — clients whose
+spawner cannot drive a GUI-subsystem pythonw (Antigravity, #863) and which
+hide child consoles themselves. Non-Windows platforms succeed as soon as a valid launch tier is
 available; a missing entry is better than one known to be broken. Backend spawn
 intentionally fails **open**: `backend_python_executable()` prefers a sibling
 `pythonw.exe` on Windows but falls back to the current executable when it is

--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -571,6 +571,7 @@ static func _config_path_resolution_error(client: Client) -> String:
 # --- Strategy dispatch + verify (testable seam) --------------------------
 
 static func _dispatch_configure(client: Client, url: String, launch: Dictionary = {}) -> Dictionary:
+	launch = launch_for_client(client, launch)
 	match client.config_type:
 		"json":
 			return JsonStrategy.configure(client, SERVER_NAME, url, launch)
@@ -627,17 +628,17 @@ static func _dispatch_check_status_with_cli_path_details(
 		"json":
 			var launch := {}
 			if client.command_shape != Client.CommandShape.NONE:
-				launch = _resolved_or_discovered_launch(resolved_launch, launch_context)
+				launch = _resolved_or_discovered_launch(client, resolved_launch, launch_context)
 			return JsonStrategy.check_status_details(client, SERVER_NAME, url, launch)
 		"toml":
 			var launch := {}
 			if client.command_shape != Client.CommandShape.NONE:
-				launch = _resolved_or_discovered_launch(resolved_launch, launch_context)
+				launch = _resolved_or_discovered_launch(client, resolved_launch, launch_context)
 			return TomlStrategy.check_status_details(client, SERVER_NAME, url, launch)
 		"yaml":
 			var yaml_launch := {}
 			if client.command_shape != Client.CommandShape.NONE:
-				yaml_launch = _resolved_or_discovered_launch(resolved_launch, launch_context)
+				yaml_launch = _resolved_or_discovered_launch(client, resolved_launch, launch_context)
 			return YamlStrategy.check_status_details(client, SERVER_NAME, url, yaml_launch)
 		"cli":
 			# Command-shape CLI clients register through their CLI, but the entry
@@ -647,7 +648,7 @@ static func _dispatch_check_status_with_cli_path_details(
 			# pin, or exclusion list — which scanning `mcp list` stdout cannot,
 			# so it is preferred even when the CLI binary resolves.
 			if client.command_shape != Client.CommandShape.NONE and client.has_json_fallback():
-				var command_launch := _resolved_or_discovered_launch(resolved_launch, launch_context)
+				var command_launch := _resolved_or_discovered_launch(client, resolved_launch, launch_context)
 				return JsonStrategy.check_status_details(client, SERVER_NAME, url, command_launch)
 			var resolved_cli := cli_path if not cli_path.is_empty() else CliStrategy.resolve_cli_path(client)
 			# #463: with no CLI binary, read the JSON fallback config so a
@@ -655,23 +656,24 @@ static func _dispatch_check_status_with_cli_path_details(
 			if resolved_cli.is_empty() and client.has_json_fallback():
 				var fallback_launch := {}
 				if client.command_shape != Client.CommandShape.NONE:
-					fallback_launch = _resolved_or_discovered_launch(resolved_launch, launch_context)
+					fallback_launch = _resolved_or_discovered_launch(client, resolved_launch, launch_context)
 				return JsonStrategy.check_status_details(client, SERVER_NAME, url, fallback_launch)
 			var cli_launch := {}
 			if client.command_shape != Client.CommandShape.NONE:
-				cli_launch = _resolved_or_discovered_launch(resolved_launch, launch_context)
+				cli_launch = _resolved_or_discovered_launch(client, resolved_launch, launch_context)
 			return CliStrategy.check_status_details(client, SERVER_NAME, url, resolved_cli, cli_launch)
 	return {"status": Client.Status.NOT_CONFIGURED, "error_msg": ""}
 
 
 static func _resolved_or_discovered_launch(
-	resolved_launch: Dictionary, launch_context: Dictionary
+	client: Client, resolved_launch: Dictionary, launch_context: Dictionary
 ) -> Dictionary:
-	return (
+	var launch := (
 		resolved_launch
 		if not resolved_launch.is_empty()
 		else resolve_attach_launch(launch_context)
 	)
+	return launch_for_client(client, launch)
 
 
 ## After a configure/remove returns ok, re-read the live status. If it doesn't
@@ -715,7 +717,7 @@ static func manual_command(id: String) -> String:
 		return "Config path unavailable: %s" % path_error
 	var context := capture_launch_context() if client.command_shape != Client.CommandShape.NONE else {}
 	var launch := (
-		resolve_attach_launch(context)
+		launch_for_client(client, resolve_attach_launch(context))
 		if client.command_shape != Client.CommandShape.NONE
 		else {}
 	)
@@ -917,12 +919,40 @@ static func _finalize_attach_launch(
 			"Windows requires pythonw.exe to launch the MCP bridge without opening a terminal window. Repair this Python or uv installation, then retry Configure."
 		)
 
+	## `console_command`/`console_args` carry the unwrapped console-subsystem
+	## launch for clients that opt out of pythonw via
+	## `needs_consoleless_launcher = false` (#863). Strategies only consume
+	## `command`/`args`/`ok`; `launch_for_client` swaps the shapes per client.
 	if tier == "dev_venv":
-		return {"ok": true, "tier": tier, "command": pythonw, "args": args}
+		return {
+			"ok": true, "tier": tier, "command": pythonw, "args": args,
+			"console_command": command, "console_args": args,
+		}
 
 	var wrapped_args: Array[String] = ["-c", _WINDOWS_STDIO_BOOTSTRAP, command]
 	wrapped_args.append_array(args)
-	return {"ok": true, "tier": tier, "command": pythonw, "args": wrapped_args}
+	return {
+		"ok": true, "tier": tier, "command": pythonw, "args": wrapped_args,
+		"console_command": command, "console_args": args,
+	}
+
+
+## Select the launch shape a specific client should see. Clients with
+## `needs_consoleless_launcher = false` (Antigravity, #863) get the plain
+## console command captured by `_finalize_attach_launch`; everyone else keeps
+## the pythonw shape unchanged. Idempotent: the returned dict carries no
+## console keys, so a second application is a no-op.
+static func launch_for_client(client: Client, launch: Dictionary) -> Dictionary:
+	if client == null or client.needs_consoleless_launcher:
+		return launch
+	if not launch.has("console_command"):
+		return launch
+	var selected := launch.duplicate(true)
+	selected["command"] = selected["console_command"]
+	selected["args"] = selected["console_args"]
+	selected.erase("console_command")
+	selected.erase("console_args")
+	return selected
 
 
 static func _resolve_consoleless_python(

--- a/plugin/addons/godot_ai/clients/_base.gd
+++ b/plugin/addons/godot_ai/clients/_base.gd
@@ -152,6 +152,14 @@ var command_supports_url_fallback: bool = false
 var command_transport_key: String = ""
 var command_transport_value: Variant = null
 
+## Whether this client's Windows stdio entry must launch through the
+## GUI-subsystem pythonw bootstrap (#827). The bootstrap exists for clients
+## that run console-subsystem MCP commands in a visible terminal (Codex);
+## Electron-family spawners hide child consoles themselves, and at least one
+## (Antigravity) hangs tool calls when handed a GUI-subsystem executable
+## (#863). Set false to write the plain console launcher on Windows.
+var needs_consoleless_launcher: bool = true
+
 ## Keys from the legacy transport that Configure must delete. Codex removes
 ## `url`, because Codex rejects a server entry containing both URL and stdio
 ## launch fields.

--- a/plugin/addons/godot_ai/clients/antigravity.gd
+++ b/plugin/addons/godot_ai/clients/antigravity.gd
@@ -28,6 +28,11 @@ func _init() -> void:
 	command_initial_fields = {"disabled": false}
 	command_user_fields = PackedStringArray(["disabled", "disabledTools", "authProviderType", "env"])
 	command_supports_url_fallback = true
+	## Antigravity's spawner hangs stdio tool calls when the entry launches a
+	## GUI-subsystem pythonw.exe (#863), and it hides child console windows
+	## itself, so the visible-terminal problem the bootstrap solves (#827)
+	## never applies. Write the plain console launcher on Windows.
+	needs_consoleless_launcher = false
 	detect_paths = PackedStringArray(path_template.values() + [
 		"~/.gemini/antigravity/mcp_config.json",
 		"$USERPROFILE/.gemini/antigravity/mcp_config.json",

--- a/test_project/tests/test_client_attach_config.gd
+++ b/test_project/tests/test_client_attach_config.gd
@@ -201,6 +201,72 @@ func test_non_windows_launch_shape_stays_direct() -> void:
 	assert_eq(launch.get("args", [])[0], "--link-mode")
 
 
+func test_launch_for_client_unwraps_pythonw_for_opted_out_clients() -> void:
+	## #863: Antigravity hangs stdio tool calls behind a GUI-subsystem
+	## pythonw.exe, so its descriptor opts out of the consoleless launcher and
+	## must receive the plain console command on Windows.
+	var antigravity := McpClientRegistry.get_by_id("antigravity")
+	assert_false(
+		antigravity.needs_consoleless_launcher,
+		"antigravity must opt out of the pythonw launcher (#863)",
+	)
+	var launch := _uvx_launch("audio")
+	assert_eq(launch.get("command"), "C:/Python313/pythonw.exe")
+	var console := McpClientConfigurator.launch_for_client(antigravity, launch)
+	assert_eq(console.get("command"), "C:/Tools/uv/uvx.exe")
+	assert_eq(console.get("args", [])[0], "--link-mode")
+	assert_false(
+		str(console.get("args", [])).contains("creationflags"),
+		"console launch must not carry the pythonw bootstrap",
+	)
+	assert_false(console.has("console_command"), "console keys are internal-only")
+	assert_eq(
+		McpClientConfigurator.launch_for_client(antigravity, console),
+		console,
+		"launch_for_client must be idempotent",
+	)
+
+
+func test_launch_for_client_dev_venv_returns_console_python() -> void:
+	var antigravity := McpClientRegistry.get_by_id("antigravity")
+	var launch := McpClientConfigurator.resolve_attach_launch(
+		_context(),
+		{
+			"venv_python": "C:/repo/.venv/Scripts/python.exe",
+			"uvx_path": "",
+			"system_path": "",
+			"consoleless_python": "C:/repo/.venv/Scripts/pythonw.exe",
+		},
+	)
+	var console := McpClientConfigurator.launch_for_client(antigravity, launch)
+	assert_eq(console.get("command"), "C:/repo/.venv/Scripts/python.exe")
+	assert_eq(console.get("args"), launch.get("args"), "dev tier args are shared verbatim")
+
+
+func test_launch_for_client_keeps_pythonw_for_default_clients() -> void:
+	var codex := McpClientRegistry.get_by_id("codex")
+	assert_true(
+		codex.needs_consoleless_launcher,
+		"codex needs the pythonw launcher — its terminal problem is why it exists (#827)",
+	)
+	var launch := _uvx_launch()
+	var kept := McpClientConfigurator.launch_for_client(codex, launch)
+	assert_eq(kept.get("command"), "C:/Python313/pythonw.exe")
+	assert_eq(kept.get("args"), launch.get("args"))
+
+
+func test_launch_for_client_non_windows_launch_is_untouched() -> void:
+	var antigravity := McpClientRegistry.get_by_id("antigravity")
+	var context := _context()
+	context["platform"] = "Linux"
+	var launch := McpClientConfigurator.resolve_attach_launch(
+		context,
+		{"venv_python": "", "uvx_path": "/home/agent/.local/bin/uvx", "system_path": ""},
+	)
+	assert_false(launch.has("console_command"), "non-Windows launches carry no console shape")
+	assert_eq(McpClientConfigurator.launch_for_client(antigravity, launch), launch)
+
+
 func test_launch_context_values_are_worker_safe_and_exclusions_are_canonical() -> void:
 	var canonical_domains := McpClientConfigurator._canonicalize_excluded_domains(
 		" particle, audio,particle,unknown "


### PR DESCRIPTION
Fixes #863.

## Symptom

On v3.1.x, Antigravity IDE hangs at "Working…" on every godot-ai tool call on Windows. The reporter isolated it cleanly: hand-editing the generated `mcpConfig` entry from `pythonw.exe` to `python.exe` — same args — makes tool calls work.

## Root cause

#827 (shipped in v3.1.0) made Windows **Configure** write a GUI-subsystem `pythonw.exe` launch for **every** client — either directly (dev-venv tier) or as a stdio-forwarding `CREATE_NO_WINDOW` bootstrap (uvx/system tiers). That solves Codex launching console MCP commands in a visible terminal, but Antigravity's spawner cannot drive a GUI-subsystem executable over its stdio pipes, and it hides child console windows itself — so it never needed the bootstrap and now hangs on it.

## Fix

- New descriptor field `needs_consoleless_launcher` (default `true` — zero behavior change for every other client); `antigravity.gd` sets it `false`.
- `_finalize_attach_launch` now records the unwrapped console shape (`console_command`/`console_args`) in every Windows resolution. Strategies only consume `command`/`args`/`ok`, so the extra keys are inert.
- New `launch_for_client()` helper swaps in the console shape for opted-out clients; applied at the three choke points where a client meets a resolved launch: `_dispatch_configure`, `_resolved_or_discovered_launch` (all status paths, including the dock's shared-resolution worker), and `manual_command`. Idempotent, so the verify-after-write path double-applying is safe.
- Docs: README Windows note and `client-configuration.md` updated.

**Deliberate migration note:** Antigravity entries written by 3.1.x will report `configured_mismatch` after this change — that is desired, since it prompts affected users to reconfigure onto the working console shape.

## Tests

- 4 new GDScript tests in `test_client_attach_config.gd`: opt-out unwraps pythonw (uvx tier, bootstrap gone), dev-venv tier returns console python, default clients keep pythonw verbatim, non-Windows launches are untouched; plus idempotence and internal-keys-don't-leak assertions.
- Descriptor flag asserted for both antigravity (false) and codex (true) so neither can silently flip.

## Verification

- `ruff check` — clean
- `pytest tests/unit tests/integration` — 1682 passed, 5 skipped, 0 failed
- Edited GDScript parse-checked headless (`godot --check-only`) — clean; full editor suite runs in CI

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPBgG9kAdPZhfvr6bA1yxE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows client launching for Antigravity by using a standard console command, preventing tool calls from hanging.
  - Preserved consoleless launching for clients that require it.
  - Kept non-Windows launch behavior unchanged.

- **Documentation**
  - Updated Windows launcher guidance to explain the Antigravity exception.

- **Tests**
  - Added coverage for client-specific launch handling, virtual environments, repeated configuration, and cross-platform behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->