### PR TITLE
feat(clients): make CLI registration scope selectable (#872)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,25 @@ configuration supports URL transport also show an advanced URL fallback.
 (Cherry Studio intentionally stays URL-mode — its MCP servers are managed
 inside the app, not via an external config file.)
 
+<details>
+<summary><strong>Registering per-project instead of globally</strong></summary>
+
+CLI-configured clients register at **user** scope by default, which is a single
+global config the client loads in every workspace — so the Godot AI tools are
+present even in projects that have nothing to do with Godot.
+
+Set **Editor Settings → Plugins → `godot_ai/mcp_client_scope`** to `project` and
+Configure writes the entry into the project's own config (for Claude Code,
+`<project>/.mcp.json`) instead. The server is then loaded only when the client is
+opened on that project. `local` is also accepted for clients that support it.
+
+The default stays `user` so existing installs are unchanged on upgrade. Change
+the setting and press **Configure** again to move an entry; press **Remove**
+*before* changing it if you want the old-scope entry cleaned up, since Remove
+targets whichever scope is currently selected.
+
+</details>
+
 ### 4. Try it
 
 - *"Show me the current scene hierarchy."*

--- a/README.md
+++ b/README.md
@@ -129,11 +129,16 @@ Two caveats for `project` scope:
   directory**, which is the one the Godot editor was launched from — not
   necessarily the project folder. Launching Godot from the project directory
   (or from a shell already `cd`'d into it) puts `.mcp.json` where you expect.
+- Claude Code will not actually load a `project`-scoped server until you
+  approve it: run `claude` in that project once and accept the prompt. Until
+  then `claude mcp get godot-ai` reports *Pending approval*, and an older
+  `user`-scoped entry can keep answering in its place.
 - Status for a project- or local-scoped entry is read back by asking the client
-  CLI to list its servers, rather than by reading the config file directly. The
-  dock still reports configured / not configured correctly, but it can no
-  longer spot a stale entry whose arguments drifted — press **Configure** again
-  after changing the port or excluded domains.
+  CLI about the server rather than by reading the config file directly. The
+  dock reports configured / not configured correctly and will flag an entry
+  that resolved from a different scope than the one you selected, but it can no
+  longer spot a stale entry whose *arguments* drifted — press **Configure**
+  again after changing the port or excluded domains.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -117,10 +117,23 @@ Configure writes the entry into the project's own config (for Claude Code,
 `<project>/.mcp.json`) instead. The server is then loaded only when the client is
 opened on that project. `local` is also accepted for clients that support it.
 
-The default stays `user` so existing installs are unchanged on upgrade. Change
-the setting and press **Configure** again to move an entry; press **Remove**
-*before* changing it if you want the old-scope entry cleaned up, since Remove
-targets whichever scope is currently selected.
+The default stays `user` so existing installs are unchanged on upgrade. To move
+an existing entry, change the setting and press **Configure** again — Configure
+clears `godot-ai` out of every scope before writing the new one, so the old
+entry doesn't linger. **Remove**, by contrast, only targets the scope that is
+currently selected, so switch back before removing if you changed the setting.
+
+Two caveats for `project` scope:
+
+- The client CLI resolves the project config against **its own working
+  directory**, which is the one the Godot editor was launched from — not
+  necessarily the project folder. Launching Godot from the project directory
+  (or from a shell already `cd`'d into it) puts `.mcp.json` where you expect.
+- Status for a project- or local-scoped entry is read back by asking the client
+  CLI to list its servers, rather than by reading the config file directly. The
+  dock still reports configured / not configured correctly, but it can no
+  longer spot a stale entry whose arguments drifted — press **Configure** again
+  after changing the port or excluded domains.
 
 </details>
 

--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -54,10 +54,19 @@ Per-strategy command rendering (`CommandShape` docs in `_base.gd`):
 - **YAML** — FLAT with flow-style `args` (Hermes); `url`/`headers` are the
   legacy keys there because Hermes infers transport from key presence.
 - **CLI** — `cli_register_template` uses the whole-element tokens
-  `{command}` / `{args...}` (Claude Code:
-  `mcp add --scope user {name} -- {command} {args...}`). Status for
-  command-shape CLI clients reads the JSON fallback file the CLI itself
-  writes — exact drift detection that `mcp list` stdout scanning cannot give.
+  `{command}` / `{args...}`, plus the optional `{scope}` token resolved from
+  the `godot_ai/mcp_client_scope` EditorSetting (Claude Code:
+  `mcp add --scope {scope} {name} -- {command} {args...}`; `{scope}` is one of
+  `user` / `project` / `local`, defaulting to `user`). Status for command-shape
+  CLI clients reads the JSON fallback file the CLI itself writes — exact drift
+  detection that `mcp list` stdout scanning cannot give — but **only while the
+  selected scope is the one `path_template` points at**. `project` and `local`
+  land outside that file, so status falls through to the `mcp list` probe,
+  which inherits the same cwd the register ran in and therefore agrees with it
+  by construction (#872). Trading exact drift detection for a correct status
+  dot is deliberate: `_verify_post_state` re-reads status after every
+  Configure, so a file read that can't see the entry would report every
+  successful project-scope Configure as a failure.
 
 Per-client sharp edges (each is descriptor data, cited in the descriptor):
 Kilo Code stdio entries must stay TYPELESS (`type` is a legacy key — its v7

--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -61,12 +61,26 @@ Per-strategy command rendering (`CommandShape` docs in `_base.gd`):
   CLI clients reads the JSON fallback file the CLI itself writes — exact drift
   detection that `mcp list` stdout scanning cannot give — but **only while the
   selected scope is the one `path_template` points at**. `project` and `local`
-  land outside that file, so status falls through to the `mcp list` probe,
-  which inherits the same cwd the register ran in and therefore agrees with it
-  by construction (#872). Trading exact drift detection for a correct status
-  dot is deliberate: `_verify_post_state` re-reads status after every
-  Configure, so a file read that can't see the entry would report every
-  successful project-scope Configure as a failure.
+  land outside that file, so status falls through to a CLI probe, which
+  inherits the same cwd the register ran in and therefore agrees with it by
+  construction (#872). Trading exact drift detection for a correct status dot
+  is deliberate: `_verify_post_state` re-reads status after every Configure, so
+  a file read that can't see the entry would report every successful
+  project-scope Configure as a failure.
+
+  That probe is `cli_scope_status_template`, **not** `cli_status_args`.
+  `mcp list` prints whatever resolved for the current directory without saying
+  which scope won, so a leftover user-scope entry carrying our exact command
+  reads as CONFIGURED while the selected project scope is empty — a green dot
+  over precisely the "loaded in every workspace" state the setting exists to
+  end. `mcp get <name>` returns the command *and* a `Scope:` line in the same
+  single subprocess (adding a second spawn per status check would be
+  unacceptable — see #238 / #239), so an entry resolved from another scope is
+  reported as MISMATCH and the dock's Reconfigure moves it. Verified against
+  claude 2.1.241, which prints `Scope: User config (…)` /
+  `Scope: Project config (…)` / `Scope: Local config (…)` and exits non-zero
+  when the entry is absent. The parser matches the first word after `Scope:`
+  and degrades to the command check if a future release drops the line.
 
 Per-client sharp edges (each is descriptor data, cited in the descriptor):
 Kilo Code stdio entries must stay TYPELESS (`type` is a legacy key — its v7

--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -458,6 +458,7 @@ static func warm_env_snapshot() -> void:
 	_editor_setting_lookup(MODE_OVERRIDE_SETTING)
 	_editor_setting_lookup(SETTING_STARTUP_TRACE)
 	_editor_setting_lookup(SETTING_KEEP_SERVER_ON_EXIT)
+	McpSettings.warm_client_scope()
 	# Publish the complete launch context while EditorInterface access is safe;
 	# worker callers of capture_launch_context() read this snapshot only.
 	capture_launch_context()
@@ -664,7 +665,13 @@ static func _dispatch_check_status_with_cli_path_details(
 			# file gives exact launch-drift detection — a changed port, version
 			# pin, or exclusion list — which scanning `mcp list` stdout cannot,
 			# so it is preferred even when the CLI binary resolves.
-			if client.command_shape != Client.CommandShape.NONE and client.has_json_fallback():
+			# #872: ...but only while the selected scope is still the one
+			# `path_template` points at — see _scope_diverges_from_json_fallback.
+			if (
+				client.command_shape != Client.CommandShape.NONE
+				and client.has_json_fallback()
+				and not _scope_diverges_from_json_fallback(client, cli_path)
+			):
 				var command_launch := _resolved_or_discovered_launch(client, resolved_launch, launch_context)
 				return JsonStrategy.check_status_details(client, SERVER_NAME, url, command_launch)
 			var resolved_cli := cli_path if not cli_path.is_empty() else CliStrategy.resolve_cli_path(client)
@@ -680,6 +687,36 @@ static func _dispatch_check_status_with_cli_path_details(
 				cli_launch = _resolved_or_discovered_launch(client, resolved_launch, launch_context)
 			return CliStrategy.check_status_details(client, SERVER_NAME, url, resolved_cli, cli_launch)
 	return {"status": Client.Status.NOT_CONFIGURED, "error_msg": ""}
+
+
+## True when this client's CLI writes its entry somewhere `path_template`
+## cannot see, so reading that file would describe the wrong thing (#872).
+##
+## `claude mcp add --scope project` writes <cwd>/.mcp.json and `--scope local`
+## writes a per-project block inside ~/.claude.json — neither is the top-level
+## `mcpServers` map `path_template` + `server_key_path` resolve to. Reading it
+## anyway makes `_verify_post_state` turn every successful project-scope
+## Configure into "configure ok but verification still reads Not configured",
+## and pins the dock row red (or green, describing a stale user-scope entry).
+##
+## Diverging sends status down the CLI probe instead: `mcp list` is
+## scope-agnostic and inherits the same cwd the register ran in, so read-back
+## and write agree by construction. The cost is losing exact launch-drift
+## detection — a stdout scan sees the command, not the full argv — which is the
+## documented trade for a status that is merely coarse instead of wrong.
+##
+## Ordering matters: the token check and the scope compare both short-circuit
+## for every non-`{scope}` descriptor and for the default user scope, so the
+## PATH walk only runs when the answer can actually be true. An unresolvable
+## CLI means configure took the #463 JSON fallback, which writes user scope
+## whatever the setting says — so the file is the right thing to read again.
+static func _scope_diverges_from_json_fallback(client: Client, cli_path: String) -> bool:
+	if not CliStrategy.uses_scope_token(client):
+		return false
+	if McpSettings.client_scope() == McpSettings.DEFAULT_CLIENT_SCOPE:
+		return false
+	var resolved := cli_path if not cli_path.is_empty() else CliStrategy.resolve_cli_path(client)
+	return not resolved.is_empty()
 
 
 static func _resolved_or_discovered_launch(

--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -111,6 +111,7 @@ static func ensure_settings_registered() -> void:
 	_register_port_setting(es, SETTING_WS_PORT, DEFAULT_WS_PORT)
 	_register_bool_setting(es, SETTING_STARTUP_TRACE, false)
 	_register_bool_setting(es, SETTING_KEEP_SERVER_ON_EXIT, false)
+	_register_client_scope_setting(es)
 
 
 static func _register_port_setting(es: EditorSettings, key: String, default_port: int) -> void:
@@ -122,6 +123,22 @@ static func _register_port_setting(es: EditorSettings, key: String, default_port
 		"type": TYPE_INT,
 		"hint": PROPERTY_HINT_RANGE,
 		"hint_string": "%d,%d,1" % [MIN_PORT, MAX_PORT],
+	})
+
+
+## Surface the CLI registration scope as an enum in Settings > Plugins so it is
+## discoverable without hand-editing editor_settings-4.tres. Kept at `user` by
+## default; `project` writes the entry into <project>/.mcp.json instead.
+static func _register_client_scope_setting(es: EditorSettings) -> void:
+	var key := McpSettings.SETTING_CLIENT_SCOPE
+	if not es.has_setting(key):
+		es.set_setting(key, McpSettings.DEFAULT_CLIENT_SCOPE)
+	es.set_initial_value(key, McpSettings.DEFAULT_CLIENT_SCOPE, false)
+	es.add_property_info({
+		"name": key,
+		"type": TYPE_STRING,
+		"hint": PROPERTY_HINT_ENUM,
+		"hint_string": ",".join(PackedStringArray(McpSettings.CLIENT_SCOPES)),
 	})
 
 

--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -685,6 +685,17 @@ static func _dispatch_check_status_with_cli_path_details(
 			var cli_launch := {}
 			if client.command_shape != Client.CommandShape.NONE:
 				cli_launch = _resolved_or_discovered_launch(client, resolved_launch, launch_context)
+			# #872: at a scope `path_template` can't see, a plain listing probe
+			# cannot tell our entry from a leftover one in another scope. When
+			# the descriptor offers a scope-aware probe, use it — same single
+			# subprocess, but it reports which scope actually resolved.
+			if (
+				not client.cli_scope_status_template.is_empty()
+				and CliStrategy.uses_scope_token(client)
+			):
+				return CliStrategy.check_scope_status_details(
+					client, SERVER_NAME, url, resolved_cli, cli_launch, McpSettings.client_scope()
+				)
 			return CliStrategy.check_status_details(client, SERVER_NAME, url, resolved_cli, cli_launch)
 	return {"status": Client.Status.NOT_CONFIGURED, "error_msg": ""}
 

--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -601,7 +601,9 @@ static func _dispatch_configure(client: Client, url: String, launch: Dictionary 
 			# #463: fall back to writing the config file directly when the CLI
 			# binary isn't on PATH (Claude Code as a VS Code/Cursor extension).
 			if client.has_json_fallback() and CliStrategy.resolve_cli_path(client).is_empty():
-				return JsonStrategy.configure(client, SERVER_NAME, url, launch)
+				return _note_unhonoured_scope(
+					client, JsonStrategy.configure(client, SERVER_NAME, url, launch)
+				)
 			return CliStrategy.configure(client, SERVER_NAME, url, launch)
 	return {"status": "error", "message": "Unknown config_type for %s: %s" % [client.id, client.config_type]}
 
@@ -698,6 +700,42 @@ static func _dispatch_check_status_with_cli_path_details(
 				)
 			return CliStrategy.check_status_details(client, SERVER_NAME, url, resolved_cli, cli_launch)
 	return {"status": Client.Status.NOT_CONFIGURED, "error_msg": ""}
+
+
+## #872: the #463 JSON fallback writes the user-scope file whatever
+## `godot_ai/mcp_client_scope` says — that file IS `path_template`, and
+## `clients/_path_template.gd` has no project-relative token to aim it
+## elsewhere. Returning a bare "configured" would hide that the requested
+## scope was not honoured, so say so in the message.
+##
+## Deliberately a message and not a status. `_verify_post_state` compares the
+## post-write status against CONFIGURED and replaces the ok with an error on
+## any mismatch (pinned by test_verify_post_state_treats_drift_as_failure_
+## after_configure), so reporting this write as NOT_CONFIGURED or MISMATCH
+## would turn a *successful* configure into a user-facing failure — the same
+## false-error class #872's blocker was about, just moved onto the fallback
+## path. The entry is genuinely written and genuinely works; only its scope
+## differs from the request, and that is a caveat, not a failure.
+static func _note_unhonoured_scope(client: Client, result: Dictionary) -> Dictionary:
+	if result.get("status") != "ok":
+		return result
+	if not CliStrategy.uses_scope_token(client):
+		return result
+	var scope := McpSettings.client_scope()
+	if scope == McpSettings.DEFAULT_CLIENT_SCOPE:
+		return result
+	var noted := result.duplicate(true)
+	noted["message"] = (
+		"%s — wrote %s scope, not %s: the %s CLI wasn't found, and the file fallback can only write %s"
+		% [
+			str(result.get("message", "")),
+			McpSettings.DEFAULT_CLIENT_SCOPE,
+			scope,
+			client.display_name,
+			client.resolved_config_path(),
+		]
+	)
+	return noted
 
 
 ## True when this client's CLI writes its entry somewhere `path_template`

--- a/plugin/addons/godot_ai/clients/_base.gd
+++ b/plugin/addons/godot_ai/clients/_base.gd
@@ -222,6 +222,16 @@ var cli_unregister_template: PackedStringArray = PackedStringArray()
 ## URL. Presence of `name` AND `url` → CONFIGURED, name only → MISMATCH,
 ## neither → NOT_CONFIGURED.
 var cli_status_args: PackedStringArray = PackedStringArray()
+## Optional scope-aware status template with a `{name}` token, for descriptors
+## that also take `{scope}` in their register template. `cli_status_args` lists
+## whatever the CLI resolves for the current directory and cannot say WHICH
+## scope an entry came from, so a leftover user-scope entry reads as CONFIGURED
+## while the selected project scope is empty — the dock then shows green over
+## exactly the "loaded in every workspace" state the scope setting exists to
+## end (#872). This template must print a `Scope: <user|project|local> …` line
+## (`claude mcp get <name>` does) and exit non-zero when the server is absent.
+## Only consulted when the selected scope isn't the one `path_template` reads.
+var cli_scope_status_template: PackedStringArray = PackedStringArray()
 
 # Codex / TOML clients -----------------------------------------------------
 ## Dotted TOML path under which our entry lives, e.g. ["mcp_servers", "godot-ai"].

--- a/plugin/addons/godot_ai/clients/_cli_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_cli_strategy.gd
@@ -296,8 +296,19 @@ static func _scope_from_probe_output(text: String) -> String:
 ## Pure verdict for a scope probe. A non-zero exit is the CLI's "no such
 ## server" signal. An entry resolved from a scope other than the selected one
 ## is MISMATCH, not CONFIGURED: the dock offers Reconfigure, and Configure's
-## all-scope pre-cleanup is what actually moves it. An unparseable Scope line
-## degrades to the target check alone rather than reporting a false red.
+## all-scope pre-cleanup is what actually moves it.
+##
+## A missing or unrecognised `Scope:` line degrades to the target check alone,
+## deliberately rather than failing closed. `_verify_post_state` turns any
+## non-CONFIGURED status after a successful write into an error, so treating an
+## unparsed label as MISMATCH would mean a future CLI release that reworded or
+## dropped that line breaks Configure outright — a false error plus a
+## permanently amber row whose Reconfigure button cannot clear it. The entry
+## has already been matched by name and exact launcher path at that point; the
+## only thing in doubt is which scope it came from, and a slightly optimistic
+## dot is a much cheaper failure than a configure flow that reports success as
+## failure. Today's claude (2.1.241) always prints the line, so this is a
+## forward-compatibility hedge, not a live code path.
 static func _scope_probe_verdict(
 	exit_code: int, text: String, expected_scope: String, expected_target: String
 ) -> Dictionary:

--- a/plugin/addons/godot_ai/clients/_cli_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_cli_strategy.gd
@@ -238,6 +238,84 @@ static func _format_args(
 	return out
 
 
+## Scope-aware status for descriptors that declare `cli_scope_status_template`.
+## Returns the same `{"status", "error_msg"}` shape as check_status_details.
+##
+## Split from the subprocess call so the verdict is a pure function of what the
+## CLI printed — `_scope_probe_verdict` is unit-tested against real recorded
+## `claude mcp get` output rather than needing a `claude` binary on the runner.
+static func check_scope_status_details(
+	client: McpClient,
+	server_name: String,
+	server_url: String,
+	cli: String,
+	launch: Dictionary,
+	expected_scope: String,
+) -> Dictionary:
+	if cli.is_empty() or client.cli_scope_status_template.is_empty():
+		return _status_details(McpClient.Status.NOT_CONFIGURED)
+	var expected_target := server_url
+	if client.command_shape != McpClient.CommandShape.NONE:
+		## Same fail-closed contract as configure and the plain status probe.
+		var launch_error := command_launch_error(client, launch)
+		if not launch_error.is_empty():
+			return _status_details(McpClient.Status.ERROR, launch_error)
+		expected_target = str(launch.get("command", ""))
+	var args := _format_args(client.cli_scope_status_template, server_name, server_url)
+	var result := McpCliExec.run(cli, args, _STATUS_TIMEOUT_MS, false)
+	if result.get("timed_out", false):
+		return _status_details(McpClient.Status.ERROR, "probe timed out")
+	if result.get("spawn_failed", false):
+		return _status_details(McpClient.Status.NOT_CONFIGURED)
+	return _scope_probe_verdict(
+		int(result.get("exit_code", -1)),
+		str(result.get("stdout", "")),
+		expected_scope,
+		expected_target,
+	)
+
+
+## The `Scope:` label the probe printed, normalised to a CLIENT_SCOPES value,
+## or "" when no line was recognisable. Matched on the first word after the
+## label so the parenthetical blurb ("(shared via .mcp.json)") can change
+## wording between CLI releases without breaking detection.
+static func _scope_from_probe_output(text: String) -> String:
+	for raw_line in text.split("\n"):
+		var line := String(raw_line).strip_edges()
+		var marker := line.find("Scope:")
+		if marker < 0:
+			continue
+		var rest := line.substr(marker + 6).strip_edges().to_lower()
+		for scope in McpSettings.CLIENT_SCOPES:
+			var name := String(scope)
+			if rest.begins_with(name):
+				return name
+	return ""
+
+
+## Pure verdict for a scope probe. A non-zero exit is the CLI's "no such
+## server" signal. An entry resolved from a scope other than the selected one
+## is MISMATCH, not CONFIGURED: the dock offers Reconfigure, and Configure's
+## all-scope pre-cleanup is what actually moves it. An unparseable Scope line
+## degrades to the target check alone rather than reporting a false red.
+static func _scope_probe_verdict(
+	exit_code: int, text: String, expected_scope: String, expected_target: String
+) -> Dictionary:
+	if exit_code != 0:
+		return _status_details(McpClient.Status.NOT_CONFIGURED)
+	if not expected_target.is_empty() and text.find(expected_target) < 0:
+		return _status_details(McpClient.Status.CONFIGURED_MISMATCH)
+	var resolved := _scope_from_probe_output(text)
+	if resolved.is_empty():
+		return _status_details(McpClient.Status.CONFIGURED)
+	if resolved != expected_scope:
+		return _status_details(
+			McpClient.Status.CONFIGURED_MISMATCH,
+			"registered at %s scope, not %s" % [resolved, expected_scope],
+		)
+	return _status_details(McpClient.Status.CONFIGURED)
+
+
 ## True when the descriptor's register template takes `{scope}`, i.e. where
 ## its entry lands is decided by the `godot_ai/mcp_client_scope` setting rather
 ## than fixed by the descriptor. The configurator uses this to decide whether

--- a/plugin/addons/godot_ai/clients/_cli_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_cli_strategy.gd
@@ -14,6 +14,10 @@ extends RefCounted
 ## inter-Claude-Code contention) gets killed at the budget instead of
 ## locking up the caller forever — see issues #238 / #239.
 
+## The descriptor token resolved from `godot_ai/mcp_client_scope` (#872).
+## Only Claude Code takes it today; any `config_type = "cli"` descriptor can.
+const SCOPE_TOKEN := "{scope}"
+
 const _CONFIGURE_TIMEOUT_MS := 10000
 const _REMOVE_TIMEOUT_MS := 10000
 const _STATUS_TIMEOUT_MS := 6000
@@ -39,8 +43,18 @@ static func configure(
 	# the same budget — a hung unregister shouldn't block the configure
 	# that follows.
 	if not client.cli_unregister_template.is_empty():
-		var pre_args := _format_args(client.cli_unregister_template, server_name, server_url)
-		McpCliExec.run(cli, pre_args, _REMOVE_TIMEOUT_MS)
+		## #872: a `{scope}` descriptor sweeps EVERY scope, not just the
+		## selected one. Flipping the setting user -> project and pressing
+		## Configure would otherwise leave the old user-scope entry alive —
+		## exactly the "loaded in every unrelated workspace" problem the
+		## setting exists to fix. `mcp remove` on an absent entry is a no-op
+		## and the result is discarded either way, so the extra passes are
+		## safe; they cost one bounded subprocess per additional scope.
+		for pre_scope in _cleanup_scopes(client):
+			var pre_args := _format_args(
+				client.cli_unregister_template, server_name, server_url, {}, pre_scope
+			)
+			McpCliExec.run(cli, pre_args, _REMOVE_TIMEOUT_MS)
 
 	if client.cli_register_template.is_empty():
 		return {"status": "error", "message": "%s descriptor missing cli_register_template" % client.display_name}
@@ -182,15 +196,28 @@ static func remove(client: McpClient, server_name: String) -> Dictionary:
 ## is exactly `{args...}` is spliced into the argv as one element per launch
 ## arg. Whole-element matching keeps a literal brace inside a path or flag
 ## from ever triggering an expansion.
+##
+## `scope_override` forces a specific `{scope}` value instead of the live
+## setting; the configure pre-cleanup uses it to sweep the scopes the user is
+## NOT currently on. Empty means "resolve from the setting".
 static func format_args(
-	template: PackedStringArray, server_name: String, server_url: String, launch: Dictionary = {}
+	template: PackedStringArray,
+	server_name: String,
+	server_url: String,
+	launch: Dictionary = {},
+	scope_override: String = "",
 ) -> Array[String]:
-	return _format_args(template, server_name, server_url, launch)
+	return _format_args(template, server_name, server_url, launch, scope_override)
 
 
 static func _format_args(
-	template: PackedStringArray, server_name: String, server_url: String, launch: Dictionary = {}
+	template: PackedStringArray,
+	server_name: String,
+	server_url: String,
+	launch: Dictionary = {},
+	scope_override: String = "",
 ) -> Array[String]:
+	var scope := scope_override if not scope_override.is_empty() else McpSettings.client_scope()
 	var out: Array[String] = []
 	for arg in template:
 		var s := String(arg)
@@ -206,9 +233,29 @@ static func _format_args(
 		## Resolved per-call rather than baked into the descriptor so the
 		## setting can change without an editor restart, and so the manual
 		## command shown in the dock always matches what Configure would run.
-		s = s.replace("{scope}", McpSettings.client_scope())
+		s = s.replace(SCOPE_TOKEN, scope)
 		out.append(s)
 	return out
+
+
+## True when the descriptor's register template takes `{scope}`, i.e. where
+## its entry lands is decided by the `godot_ai/mcp_client_scope` setting rather
+## than fixed by the descriptor. The configurator uses this to decide whether
+## the JSON-fallback file is still a valid place to read status back from.
+static func uses_scope_token(client: McpClient) -> bool:
+	return client.cli_register_template.has(SCOPE_TOKEN)
+
+
+## Scopes the configure pre-cleanup removes from. A descriptor without the
+## `{scope}` token has exactly one place its entry can live, so it keeps the
+## single pass it always had — "" means "resolve the scope normally".
+static func _cleanup_scopes(client: McpClient) -> Array[String]:
+	if not uses_scope_token(client):
+		return [""]
+	var scopes: Array[String] = []
+	for scope in McpSettings.CLIENT_SCOPES:
+		scopes.append(String(scope))
+	return scopes
 
 
 static func _resolve_cli(client: McpClient) -> String:

--- a/plugin/addons/godot_ai/clients/_cli_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_cli_strategy.gd
@@ -203,6 +203,10 @@ static func _format_args(
 			continue
 		s = s.replace("{name}", server_name)
 		s = s.replace("{url}", server_url)
+		## Resolved per-call rather than baked into the descriptor so the
+		## setting can change without an editor restart, and so the manual
+		## command shown in the dock always matches what Configure would run.
+		s = s.replace("{scope}", McpSettings.client_scope())
 		out.append(s)
 	return out
 

--- a/plugin/addons/godot_ai/clients/claude_code.gd
+++ b/plugin/addons/godot_ai/clients/claude_code.gd
@@ -9,14 +9,17 @@ func _init() -> void:
 	cli_names = PackedStringArray(["claude", "claude.exe"] if OS.get_name() == "Windows" else ["claude"])
 	## Stdio registration through the client-owned `godot-ai attach` bridge
 	## (#838). `--` stops claude's own flag parsing so the attach argv passes
-	## through verbatim; stdio is the CLI's default transport. Scope stays
-	## `user` — the same ~/.claude.json the pre-attach HTTP entry lived in.
+	## through verbatim; stdio is the CLI's default transport. Scope comes from
+	## the `godot_ai/mcp_client_scope` EditorSetting via the `{scope}` token; it
+	## defaults to `user` — the same ~/.claude.json the pre-attach HTTP entry
+	## lived in — and can be set to `project` to write <project>/.mcp.json so the
+	## server is not loaded in every unrelated workspace.
 	cli_register_template = PackedStringArray(
-		["mcp", "add", "--scope", "user", "{name}", "--", "{command}", "{args...}"]
+		["mcp", "add", "--scope", "{scope}", "{name}", "--", "{command}", "{args...}"]
 	)
 	## Explicit scope: an unscoped `mcp remove` deletes from whichever scope
 	## matches first, which could eat a project-local entry the user made.
-	cli_unregister_template = PackedStringArray(["mcp", "remove", "--scope", "user", "{name}"])
+	cli_unregister_template = PackedStringArray(["mcp", "remove", "--scope", "{scope}", "{name}"])
 	cli_status_args = PackedStringArray(["mcp", "list"])
 	## #463: JSON fallback for when the `claude` binary isn't on PATH — e.g.
 	## Claude Code installed only as a VS Code / Cursor extension. The CLI is

--- a/plugin/addons/godot_ai/clients/claude_code.gd
+++ b/plugin/addons/godot_ai/clients/claude_code.gd
@@ -20,6 +20,14 @@ func _init() -> void:
 	## Explicit scope: an unscoped `mcp remove` deletes from whichever scope
 	## matches first, which could eat a project-local entry the user made.
 	cli_unregister_template = PackedStringArray(["mcp", "remove", "--scope", "{scope}", "{name}"])
+	## Scope caveat: `--scope project` resolves `.mcp.json` against the
+	## *spawned CLI's* working directory, which is whatever the editor process
+	## inherited at launch — not necessarily `res://`. Godot has no API to set
+	## a child's cwd (`OS.execute_with_pipe` takes none), so this is an
+	## accepted limitation rather than something the descriptor can pin. It is
+	## self-consistent: `cli_status_args` runs from the same cwd, so the
+	## read-back finds whatever the register wrote (see
+	## `_scope_diverges_from_json_fallback` in client_configurator.gd).
 	cli_status_args = PackedStringArray(["mcp", "list"])
 	## #463: JSON fallback for when the `claude` binary isn't on PATH — e.g.
 	## Claude Code installed only as a VS Code / Cursor extension. The CLI is

--- a/plugin/addons/godot_ai/clients/claude_code.gd
+++ b/plugin/addons/godot_ai/clients/claude_code.gd
@@ -29,6 +29,17 @@ func _init() -> void:
 	## read-back finds whatever the register wrote (see
 	## `_scope_diverges_from_json_fallback` in client_configurator.gd).
 	cli_status_args = PackedStringArray(["mcp", "list"])
+	## `mcp list` prints the resolved entry for the cwd without saying which
+	## scope won, so it cannot tell "registered at project scope" from "an old
+	## user-scope entry is shadowing an empty project scope". `mcp get` prints
+	## both the command and a `Scope: …` line, in the same single subprocess,
+	## so scope-token clients probe with it instead (#872). Verified against
+	## claude 2.1.241, which prints one of:
+	##   Scope: User config (available in all your projects)
+	##   Scope: Project config (shared via .mcp.json)
+	##   Scope: Local config (private to you in this project)
+	## and exits 1 with "No MCP server named …" when the entry is absent.
+	cli_scope_status_template = PackedStringArray(["mcp", "get", "{name}"])
 	## #463: JSON fallback for when the `claude` binary isn't on PATH — e.g.
 	## Claude Code installed only as a VS Code / Cursor extension. The CLI is
 	## still preferred for Configure whenever it resolves; this is what gets

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -3278,7 +3278,15 @@ func _apply_row_status(
 			dot.color = COLOR_AMBER
 			configure_btn.text = "Reconfigure"
 			remove_btn.visible = true
-			name_label.text = "%s  (URL out of date)" % base_name
+			## Drift is usually a stale URL, but a `{scope}` client can also be
+			## registered in a scope the user did not select (#872), and
+			## "URL out of date" would be a wrong description of that. Prefer
+			## the probe's own words whenever it supplied any.
+			name_label.text = (
+				"%s  (%s)" % [base_name, error_msg]
+				if not error_msg.is_empty()
+				else "%s  (URL out of date)" % base_name
+			)
 		_:
 			dot.color = Color.RED
 			configure_btn.text = "Retry"

--- a/plugin/addons/godot_ai/utils/settings.gd
+++ b/plugin/addons/godot_ai/utils/settings.gd
@@ -19,6 +19,19 @@ const SETTING_ALLOW_HOSTS := "godot_ai/allow_remote_hosts"
 ## Whether MCP log lines echo to the Godot console (dock "Log" toggle).
 ## The dock's ring-buffer log panel keeps recording regardless.
 const SETTING_MCP_LOGGING := "godot_ai/mcp_logging"
+## Which scope CLI-configured clients register the server in. Claude Code's
+## `--scope user` writes the global block of ~/.claude.json, which that client
+## loads in EVERY workspace — so the server gets spawned in unrelated,
+## non-Godot projects. `project` writes <project>/.mcp.json instead, so the
+## entry travels with the project. Defaults to `user` to preserve the
+## historical behaviour for existing installs.
+const SETTING_CLIENT_SCOPE := "godot_ai/mcp_client_scope"
+
+## Scopes accepted for SETTING_CLIENT_SCOPE. These are the values the Claude
+## Code CLI's `--scope` flag takes; an unrecognised setting falls back to
+## DEFAULT_CLIENT_SCOPE rather than passing junk to the CLI.
+const CLIENT_SCOPES := ["user", "project", "local"]
+const DEFAULT_CLIENT_SCOPE := "user"
 
 
 ## Returns true if the string value is truthy
@@ -30,6 +43,22 @@ static func truthy(value: String) -> bool:
 ## Returns true if the named environment variable is set to a truthy value.
 static func env_truthy(var_name: String) -> bool:
 	return truthy(OS.get_environment(var_name))
+
+
+## Returns the scope CLI clients should register the MCP server in, as
+## substituted into `{scope}` in a descriptor's cli_register_template /
+## cli_unregister_template. Read on the main thread from the dock's Configure
+## action and from the manual-command renderer, same as mcp_logging_enabled().
+## Unrecognised values fall back to DEFAULT_CLIENT_SCOPE so a hand-edited
+## editor_settings-4.tres can never make the plugin shell out with a bad flag.
+static func client_scope() -> String:
+	var es := EditorInterface.get_editor_settings()
+	if es == null or not es.has_setting(SETTING_CLIENT_SCOPE):
+		return DEFAULT_CLIENT_SCOPE
+	var raw := String(es.get_setting(SETTING_CLIENT_SCOPE)).strip_edges().to_lower()
+	if raw in CLIENT_SCOPES:
+		return raw
+	return DEFAULT_CLIENT_SCOPE
 
 
 ## Returns true if telemetry should be active, checking in priority order:

--- a/plugin/addons/godot_ai/utils/settings.gd
+++ b/plugin/addons/godot_ai/utils/settings.gd
@@ -45,17 +45,60 @@ static func env_truthy(var_name: String) -> bool:
 	return truthy(OS.get_environment(var_name))
 
 
+## #691: EditorInterface / EditorSettings are not thread-safe, and the dock
+## runs Configure / Remove on a worker Thread (mcp_dock.gd
+## `_run_client_action_worker` -> McpClientConfigurator -> McpCliStrategy
+## `_format_args` -> client_scope()). Same contract as
+## McpClientConfigurator._editor_setting_lookup: the main thread does a live
+## read and refreshes the snapshot; worker threads read the snapshot only, so
+## a never-warmed value reads as null (unset) rather than touching
+## EditorInterface off-thread. Warmed on the main thread by
+## McpClientConfigurator.warm_env_snapshot() before each worker dispatch.
+##
+## Kept here rather than reusing the configurator's `_editor_setting_lookup`
+## so utils/settings.gd stays free of the client_configurator.gd dep tree —
+## see this file's header.
+static var _client_scope_snapshot: Variant = null
+static var _client_scope_mutex := Mutex.new()
+
+
+static func _client_scope_setting() -> Variant:
+	if OS.get_thread_caller_id() == OS.get_main_thread_id():
+		var live: Variant = null
+		if Engine.is_editor_hint():
+			var es := EditorInterface.get_editor_settings()
+			if es != null and es.has_setting(SETTING_CLIENT_SCOPE):
+				live = es.get_setting(SETTING_CLIENT_SCOPE)
+		_client_scope_mutex.lock()
+		_client_scope_snapshot = live
+		_client_scope_mutex.unlock()
+		return live
+	_client_scope_mutex.lock()
+	var cached: Variant = _client_scope_snapshot
+	_client_scope_mutex.unlock()
+	return cached
+
+
+## Main-thread pre-warm of the scope snapshot so the dock's Configure/Remove
+## worker resolves `{scope}` from a value captured while EditorSettings access
+## was safe. Idempotent; called from warm_env_snapshot().
+static func warm_client_scope() -> void:
+	_client_scope_setting()
+
+
 ## Returns the scope CLI clients should register the MCP server in, as
 ## substituted into `{scope}` in a descriptor's cli_register_template /
-## cli_unregister_template. Read on the main thread from the dock's Configure
-## action and from the manual-command renderer, same as mcp_logging_enabled().
-## Unrecognised values fall back to DEFAULT_CLIENT_SCOPE so a hand-edited
-## editor_settings-4.tres can never make the plugin shell out with a bad flag.
+## cli_unregister_template. Safe to call from either thread (see
+## _client_scope_setting). Unrecognised values fall back to
+## DEFAULT_CLIENT_SCOPE so a hand-edited editor_settings-4.tres can never make
+## the plugin shell out with a bad flag.
 static func client_scope() -> String:
-	var es := EditorInterface.get_editor_settings()
-	if es == null or not es.has_setting(SETTING_CLIENT_SCOPE):
+	var value: Variant = _client_scope_setting()
+	## String(null) is a hard error (#850) — an unset/never-warmed key must
+	## short-circuit before the cast.
+	if value == null:
 		return DEFAULT_CLIENT_SCOPE
-	var raw := String(es.get_setting(SETTING_CLIENT_SCOPE)).strip_edges().to_lower()
+	var raw := String(value).strip_edges().to_lower()
 	if raw in CLIENT_SCOPES:
 		return raw
 	return DEFAULT_CLIENT_SCOPE

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -1824,6 +1824,48 @@ func test_scope_probe_verdict_absent_entry_and_drift() -> void:
 	)
 
 
+func test_json_fallback_configure_notes_the_scope_it_could_not_honour() -> void:
+	## #872 + #463: with no CLI on PATH, Configure falls back to writing the
+	## config file directly — and that file is the USER-scope one whatever the
+	## setting says. The write is real and works, so it stays `ok`; the caveat
+	## rides in the message rather than in the status, because
+	## _verify_post_state converts any non-CONFIGURED status after a successful
+	## write into an error (see test_verify_post_state_treats_drift_as_failure_
+	## after_configure) and a correct write must not report as a failure.
+	var es := EditorInterface.get_editor_settings()
+	if es == null:
+		skip("EditorSettings unavailable in test environment")
+		return
+	var path := _scratch_dir.path_join("fallback_scope_note.json")
+	_remove_if_exists(path)
+	var client := _make_scope_cli_client(path)
+	var launch := {"ok": true, "command": "uvx", "args": ["godot-ai", "attach"]}
+
+	es.set_setting(McpSettings.SETTING_CLIENT_SCOPE, "project")
+	var noted := McpClientConfigurator._dispatch_configure(client, "", launch)
+	assert_eq(noted.get("status"), "ok", "the fallback write really did land — it is not a failure")
+	var msg := str(noted.get("message", ""))
+	assert_contains(msg, "project", "the message must name the scope that was asked for")
+	assert_contains(msg, "user", "...and the scope it actually wrote")
+
+	## The status still reads CONFIGURED, so Configure does not end in the
+	## "configure ok but verification reads Not configured" false error.
+	var status := McpClientConfigurator._dispatch_check_status_with_cli_path_details(
+		client, "", "", {}, launch
+	)
+	assert_eq(status.get("status"), McpClient.Status.CONFIGURED,
+		"a fallback-written entry must verify clean, or configure reports success as failure")
+
+	## At the default scope there is nothing to warn about — no note.
+	es.set_setting(McpSettings.SETTING_CLIENT_SCOPE, McpSettings.DEFAULT_CLIENT_SCOPE)
+	var plain := McpClientConfigurator._dispatch_configure(client, "", launch)
+	assert_eq(plain.get("status"), "ok")
+	assert_false(str(plain.get("message", "")).contains("wrote user scope"),
+		"no scope caveat when the selected scope is the one the fallback writes")
+	_restore_client_scope()
+	_remove_if_exists(path)
+
+
 func test_claude_code_declares_scope_aware_status_probe() -> void:
 	## `mcp list` cannot say which scope resolved, so a `{scope}` descriptor
 	## needs the richer probe. Same single subprocess — see #238/#239 for why

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -1525,6 +1525,29 @@ func _make_cli_json_fallback_client(path: String) -> McpClient:
 	return c
 
 
+## A command-shape CLI descriptor that takes `{scope}`, shaped like
+## claude_code but pointed at a scratch file. Used to exercise the scope-aware
+## status routing without touching the user's real ~/.claude.json.
+func _make_scope_cli_client(path: String) -> McpClient:
+	var c := McpClient.new()
+	c.id = "scope_cli_test"
+	c.display_name = "Scope CLI Test"
+	c.config_type = "cli"
+	# Never resolves on PATH, so the CLI probe spawn-fails deterministically.
+	c.cli_names = PackedStringArray(["godot-ai-nonexistent-cli-xyz"])
+	c.cli_register_template = PackedStringArray(
+		["mcp", "add", "--scope", "{scope}", "{name}", "--", "{command}", "{args...}"]
+	)
+	c.cli_unregister_template = PackedStringArray(["mcp", "remove", "--scope", "{scope}", "{name}"])
+	c.cli_status_args = PackedStringArray(["mcp", "list"])
+	c.path_template = {"darwin": path, "windows": path, "linux": path, "unix": path}
+	c.server_key_path = PackedStringArray(["mcpServers"])
+	c.command_shape = McpClient.CommandShape.FLAT
+	c.command_transport_key = "type"
+	c.command_transport_value = "stdio"
+	return c
+
+
 func test_has_json_fallback_semantics() -> void:
 	var path := _scratch_dir.path_join("fallback_sem.json")
 	var with_fallback := _make_cli_json_fallback_client(path)
@@ -1598,6 +1621,7 @@ func test_client_scope_project_renders_in_argv() -> void:
 	## <project>/.mcp.json instead of the global ~/.claude.json block.
 	var es := EditorInterface.get_editor_settings()
 	if es == null:
+		skip("EditorSettings unavailable in test environment")
 		return
 	es.set_setting(McpSettings.SETTING_CLIENT_SCOPE, "project")
 	assert_eq(McpSettings.client_scope(), "project")
@@ -1606,12 +1630,15 @@ func test_client_scope_project_renders_in_argv() -> void:
 		client.cli_register_template, "godot-ai", "", {"command": "uvx", "args": ["godot-ai"]}
 	)
 	var reg_index := register.find("--scope")
+	assert_true(reg_index >= 0, "register argv must carry --scope")
 	assert_eq(register[reg_index + 1], "project")
 	## Remove must follow the same scope, or Configure-then-Remove leaves the
 	## entry behind in whichever scope the register actually wrote.
 	var unregister := McpCliStrategy.format_args(client.cli_unregister_template, "godot-ai", "")
 	var unreg_index := unregister.find("--scope")
+	assert_true(unreg_index >= 0, "unregister argv must carry --scope")
 	assert_eq(unregister[unreg_index + 1], "project")
+	_restore_client_scope()
 
 
 func test_client_scope_rejects_unknown_value() -> void:
@@ -1619,11 +1646,88 @@ func test_client_scope_rejects_unknown_value() -> void:
 	## with a bad --scope flag; fall back to the default instead.
 	var es := EditorInterface.get_editor_settings()
 	if es == null:
+		skip("EditorSettings unavailable in test environment")
 		return
 	es.set_setting(McpSettings.SETTING_CLIENT_SCOPE, "not-a-scope")
 	assert_eq(McpSettings.client_scope(), McpSettings.DEFAULT_CLIENT_SCOPE)
 	es.set_setting(McpSettings.SETTING_CLIENT_SCOPE, "  PROJECT  ")
 	assert_eq(McpSettings.client_scope(), "project", "value should be trimmed and case-folded")
+	_restore_client_scope()
+
+
+func test_client_scope_pre_cleanup_sweeps_every_scope() -> void:
+	## #872: flipping the setting and pressing Configure must not strand the
+	## entry the previous scope wrote — that is precisely the "loaded in every
+	## unrelated workspace" problem the setting exists to fix. The pre-cleanup
+	## therefore removes from all CLIENT_SCOPES, not just the selected one.
+	var client := McpClientRegistry.get_by_id("claude_code")
+	assert_true(client != null, "claude_code must be registered")
+	assert_true(McpCliStrategy.uses_scope_token(client), "claude_code register template takes {scope}")
+	var swept := McpCliStrategy._cleanup_scopes(client)
+	for scope in McpSettings.CLIENT_SCOPES:
+		assert_true(swept.has(String(scope)), "pre-cleanup must sweep the %s scope" % scope)
+	## A descriptor without the token keeps its single pass, so opting into
+	## `{scope}` is what costs the extra subprocess spawns — nothing else
+	## changes. claude_code is currently the only registered cli client, so
+	## the negative case uses the synthetic descriptor rather than a dead
+	## `if config_type == "cli"` branch that would pass with zero assertions.
+	var plain := _make_cli_json_fallback_client(_scratch_dir.path_join("cleanup_scopes.json"))
+	assert_false(McpCliStrategy.uses_scope_token(plain), "descriptor without the token must not opt in")
+	var plain_scopes := McpCliStrategy._cleanup_scopes(plain)
+	assert_eq(plain_scopes.size(), 1, "non-scope clients keep one pass")
+	assert_eq(plain_scopes[0], "", "the single pass resolves the scope normally")
+
+
+func test_project_scope_status_leaves_the_user_scope_file() -> void:
+	## #872 blocker: `--scope project` writes <cwd>/.mcp.json and `--scope
+	## local` writes a per-project block, neither of which is the file
+	## `path_template` resolves to. A status path that keeps reading the
+	## user-scope file makes _verify_post_state turn every successful
+	## project-scope Configure into "configure ok but verification still reads
+	## Not configured", and pins the dock row red.
+	var es := EditorInterface.get_editor_settings()
+	if es == null:
+		skip("EditorSettings unavailable in test environment")
+		return
+	var path := _scratch_dir.path_join("scope_status.json")
+	_remove_if_exists(path)
+	var client := _make_scope_cli_client(path)
+	var launch := {"ok": true, "command": "uvx", "args": ["godot-ai", "attach"]}
+	## Seed the user-scope file through the strategy that actually writes it,
+	## so the entry is in exactly the shape the verifier accepts and a JSON
+	## read-back would report CONFIGURED.
+	var seeded := McpJsonStrategy.configure(client, "godot-ai", "", launch)
+	assert_eq(seeded.get("status"), "ok", "seed write should succeed: %s" % seeded.get("message", ""))
+
+	## Passing cli_path explicitly is what makes the divergence real without
+	## depending on a `claude` binary existing on this machine. It never
+	## resolves, so the CLI probe spawn-fails rather than reporting CONFIGURED.
+	var fake_cli := "godot-ai-nonexistent-cli-xyz"
+
+	es.set_setting(McpSettings.SETTING_CLIENT_SCOPE, McpSettings.DEFAULT_CLIENT_SCOPE)
+	var at_user := McpClientConfigurator._dispatch_check_status_with_cli_path_details(
+		client, "", fake_cli, {}, launch
+	)
+	assert_eq(at_user.get("status"), McpClient.Status.CONFIGURED,
+		"user scope must keep reading the JSON fallback file for exact drift detection")
+
+	es.set_setting(McpSettings.SETTING_CLIENT_SCOPE, "project")
+	var at_project := McpClientConfigurator._dispatch_check_status_with_cli_path_details(
+		client, "", fake_cli, {}, launch
+	)
+	assert_ne(at_project.get("status"), McpClient.Status.CONFIGURED,
+		"project scope must not verify against the user-scope file it never wrote")
+
+	## With no CLI to run the register, Configure falls back to the #463 JSON
+	## writer, which is user-scoped whatever the setting says — so the file is
+	## the correct thing to read again even at project scope.
+	var at_project_no_cli := McpClientConfigurator._dispatch_check_status_with_cli_path_details(
+		client, "", "", {}, launch
+	)
+	assert_eq(at_project_no_cli.get("status"), McpClient.Status.CONFIGURED,
+		"without a CLI the JSON fallback owns both the write and the read-back")
+	_restore_client_scope()
+	_remove_if_exists(path)
 
 
 func test_claude_code_manual_command_shows_json_fallback() -> void:
@@ -3692,6 +3796,16 @@ func _restore_port_settings() -> void:
 		es.set_setting(McpClientConfigurator.SETTING_WS_PORT, McpClientConfigurator.DEFAULT_WS_PORT)
 	else:
 		es.set_setting(McpClientConfigurator.SETTING_WS_PORT, _saved_ws_port)
+	_restore_client_scope()
+
+
+## Per-test restore. The scope setting now steers status routing as well as
+## argv (#872), so leaking `project` out of one test silently changes which
+## code path every later test in the suite exercises.
+func _restore_client_scope() -> void:
+	var es := EditorInterface.get_editor_settings()
+	if es == null:
+		return
 	if _saved_client_scope == null:
 		es.set_setting(McpSettings.SETTING_CLIENT_SCOPE, McpSettings.DEFAULT_CLIENT_SCOPE)
 	else:

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -18,6 +18,10 @@ var _scratch_dir: String
 ## port if a test fails mid-flight.
 var _saved_http_port: Variant = null
 var _saved_ws_port: Variant = null
+## Same reason as the ports: these tests drive godot_ai/mcp_client_scope
+## through its valid and invalid values and must not leave the editor
+## registering at a scope the user never chose.
+var _saved_client_scope: Variant = null
 
 
 func suite_name() -> String:
@@ -34,6 +38,8 @@ func suite_setup(_ctx: Dictionary) -> void:
 			_saved_http_port = es.get_setting(McpSettings.SETTING_HTTP_PORT)
 		if es.has_setting(McpClientConfigurator.SETTING_WS_PORT):
 			_saved_ws_port = es.get_setting(McpClientConfigurator.SETTING_WS_PORT)
+		if es.has_setting(McpSettings.SETTING_CLIENT_SCOPE):
+			_saved_client_scope = es.get_setting(McpSettings.SETTING_CLIENT_SCOPE)
 
 
 func suite_teardown() -> void:
@@ -1542,7 +1548,7 @@ func test_claude_code_has_claude_json_fallback() -> void:
 
 
 func test_claude_code_declares_stdio_attach_registration() -> void:
-	## #838: registration goes through `claude mcp add --scope user <name> --
+	## #838: registration goes through `claude mcp add --scope <scope> <name> --
 	## <command> <args...>` (stdio is the CLI's default transport; verified
 	## live in an isolated CLAUDE_CONFIG_DIR). The JSON fallback file renders
 	## the same entry the CLI itself writes: type:stdio + command + args.
@@ -1553,7 +1559,8 @@ func test_claude_code_declares_stdio_attach_registration() -> void:
 	assert_true(client.command_legacy_keys.has("url"), "legacy HTTP entry's url must be removed")
 	assert_true(client.command_supports_url_fallback)
 	var register := client.cli_register_template
-	assert_true(register.has("--scope"), "registration stays user-scoped")
+	assert_true(register.has("--scope"), "registration must stay explicitly scoped")
+	assert_true(register.has("{scope}"), "scope comes from the setting, not a hardcoded value")
 	assert_true(register.has("--"), "`--` must stop claude's own flag parsing")
 	assert_true(register.has("{command}"), "register template must take the launch command token")
 	assert_true(register.has("{args...}"), "register template must splice the launch args")
@@ -1565,6 +1572,58 @@ func test_claude_code_declares_stdio_attach_registration() -> void:
 	assert_eq(args_index, command_index + 1, "{args...} must immediately follow {command}")
 	assert_false(register.has("--transport"), "stdio is the default transport — no pin in argv")
 	assert_true(client.cli_unregister_template.has("--scope"), "unscoped remove could eat a project-local entry")
+	assert_true(client.cli_unregister_template.has("{scope}"),
+		"remove must target the same scope the register wrote to")
+
+
+func test_client_scope_defaults_to_user() -> void:
+	## Existing installs must keep registering where they always have; the
+	## setting is opt-in, not a silent behaviour change on upgrade.
+	var es := EditorInterface.get_editor_settings()
+	if es != null and es.has_setting(McpSettings.SETTING_CLIENT_SCOPE):
+		es.set_setting(McpSettings.SETTING_CLIENT_SCOPE, McpSettings.DEFAULT_CLIENT_SCOPE)
+	assert_eq(McpSettings.client_scope(), "user")
+	var client := McpClientRegistry.get_by_id("claude_code")
+	var args := McpCliStrategy.format_args(
+		client.cli_register_template, "godot-ai", "", {"command": "uvx", "args": ["godot-ai"]}
+	)
+	var scope_index := args.find("--scope")
+	assert_true(scope_index >= 0, "register argv must carry --scope")
+	assert_eq(args[scope_index + 1], "user", "default scope must render as user")
+	assert_false(args.has("{scope}"), "the token must be substituted, never passed through to the CLI")
+
+
+func test_client_scope_project_renders_in_argv() -> void:
+	## The whole point of the setting: `project` makes the CLI write
+	## <project>/.mcp.json instead of the global ~/.claude.json block.
+	var es := EditorInterface.get_editor_settings()
+	if es == null:
+		return
+	es.set_setting(McpSettings.SETTING_CLIENT_SCOPE, "project")
+	assert_eq(McpSettings.client_scope(), "project")
+	var client := McpClientRegistry.get_by_id("claude_code")
+	var register := McpCliStrategy.format_args(
+		client.cli_register_template, "godot-ai", "", {"command": "uvx", "args": ["godot-ai"]}
+	)
+	var reg_index := register.find("--scope")
+	assert_eq(register[reg_index + 1], "project")
+	## Remove must follow the same scope, or Configure-then-Remove leaves the
+	## entry behind in whichever scope the register actually wrote.
+	var unregister := McpCliStrategy.format_args(client.cli_unregister_template, "godot-ai", "")
+	var unreg_index := unregister.find("--scope")
+	assert_eq(unregister[unreg_index + 1], "project")
+
+
+func test_client_scope_rejects_unknown_value() -> void:
+	## A hand-edited editor_settings-4.tres must not make the plugin shell out
+	## with a bad --scope flag; fall back to the default instead.
+	var es := EditorInterface.get_editor_settings()
+	if es == null:
+		return
+	es.set_setting(McpSettings.SETTING_CLIENT_SCOPE, "not-a-scope")
+	assert_eq(McpSettings.client_scope(), McpSettings.DEFAULT_CLIENT_SCOPE)
+	es.set_setting(McpSettings.SETTING_CLIENT_SCOPE, "  PROJECT  ")
+	assert_eq(McpSettings.client_scope(), "project", "value should be trimmed and case-folded")
 
 
 func test_claude_code_manual_command_shows_json_fallback() -> void:
@@ -3633,3 +3692,7 @@ func _restore_port_settings() -> void:
 		es.set_setting(McpClientConfigurator.SETTING_WS_PORT, McpClientConfigurator.DEFAULT_WS_PORT)
 	else:
 		es.set_setting(McpClientConfigurator.SETTING_WS_PORT, _saved_ws_port)
+	if _saved_client_scope == null:
+		es.set_setting(McpSettings.SETTING_CLIENT_SCOPE, McpSettings.DEFAULT_CLIENT_SCOPE)
+	else:
+		es.set_setting(McpSettings.SETTING_CLIENT_SCOPE, _saved_client_scope)

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -1730,6 +1730,115 @@ func test_project_scope_status_leaves_the_user_scope_file() -> void:
 	_remove_if_exists(path)
 
 
+## Real `claude mcp get godot-ai` output, captured from claude 2.1.241 in an
+## isolated CLAUDE_CONFIG_DIR. Recorded verbatim so the parser is tested
+## against what the CLI actually prints rather than an idealised shape.
+const _PROBE_USER := """godot-ai:
+  Scope: User config (available in all your projects)
+  Status: ✘ Failed to connect
+  Issue: -32000: MCP error -32000: Connection closed
+  Type: stdio
+  Command: C:/Program Files/Git/usr/bin/true
+  Args: --flag
+  Environment:
+"""
+
+const _PROBE_PROJECT := """godot-ai:
+  Scope: Project config (shared via .mcp.json)
+  Status: ⏸ Pending approval (run `claude` to approve)
+  Type: stdio
+  Command: C:/Program Files/Git/usr/bin/true
+  Args: --p
+  Environment:
+"""
+
+const _PROBE_LOCAL := """godot-ai:
+  Scope: Local config (private to you in this project)
+  Status: ✘ Failed to connect
+  Type: stdio
+  Command: C:/Program Files/Git/usr/bin/true
+  Args: --l
+  Environment:
+"""
+
+const _PROBE_TARGET := "C:/Program Files/Git/usr/bin/true"
+
+
+func test_scope_probe_parses_real_cli_scope_labels() -> void:
+	## The parser matches the first word after "Scope:", so the parenthetical
+	## blurb can be reworded by a future CLI release without breaking us.
+	assert_eq(McpCliStrategy._scope_from_probe_output(_PROBE_USER), "user")
+	assert_eq(McpCliStrategy._scope_from_probe_output(_PROBE_PROJECT), "project")
+	assert_eq(McpCliStrategy._scope_from_probe_output(_PROBE_LOCAL), "local")
+	assert_eq(McpCliStrategy._scope_from_probe_output("no scope line here"), "",
+		"an unrecognisable probe must report empty, not guess a scope")
+
+
+func test_scope_probe_verdict_flags_entry_resolved_from_another_scope() -> void:
+	## The bug this exists to catch: `mcp list` prints a leftover user-scope
+	## entry with our exact command, so a name+target scan calls an EMPTY
+	## project scope CONFIGURED — a green dot over the "loaded in every
+	## workspace" state the setting exists to end. Verified against claude
+	## 2.1.241, where the user entry does win the resolve.
+	var wrong_scope := McpCliStrategy._scope_probe_verdict(
+		0, _PROBE_USER, "project", _PROBE_TARGET
+	)
+	assert_eq(wrong_scope.get("status"), McpClient.Status.CONFIGURED_MISMATCH,
+		"an entry resolved from user scope is not a configured project scope")
+	assert_contains(str(wrong_scope.get("error_msg", "")), "user",
+		"the row message should name the scope that actually resolved")
+
+	## Same output, matching selection — this is the ordinary green path.
+	assert_eq(
+		McpCliStrategy._scope_probe_verdict(0, _PROBE_USER, "user", _PROBE_TARGET).get("status"),
+		McpClient.Status.CONFIGURED,
+	)
+	assert_eq(
+		McpCliStrategy._scope_probe_verdict(0, _PROBE_PROJECT, "project", _PROBE_TARGET).get("status"),
+		McpClient.Status.CONFIGURED,
+	)
+	assert_eq(
+		McpCliStrategy._scope_probe_verdict(0, _PROBE_LOCAL, "local", _PROBE_TARGET).get("status"),
+		McpClient.Status.CONFIGURED,
+	)
+
+
+func test_scope_probe_verdict_absent_entry_and_drift() -> void:
+	## `claude mcp get` exits 1 with "No MCP server named ..." when absent.
+	assert_eq(
+		McpCliStrategy._scope_probe_verdict(1, "No MCP server named \"godot-ai\".", "project", _PROBE_TARGET).get("status"),
+		McpClient.Status.NOT_CONFIGURED,
+	)
+	## Right scope, wrong launcher — still drift, same as the JSON path.
+	assert_eq(
+		McpCliStrategy._scope_probe_verdict(0, _PROBE_PROJECT, "project", "/somewhere/else/uvx").get("status"),
+		McpClient.Status.CONFIGURED_MISMATCH,
+	)
+	## A future CLI that stops printing a Scope line must degrade to the
+	## target check, not invent a red dot on a working install.
+	var no_label := "godot-ai:\n  Command: %s\n" % _PROBE_TARGET
+	assert_eq(
+		McpCliStrategy._scope_probe_verdict(0, no_label, "project", _PROBE_TARGET).get("status"),
+		McpClient.Status.CONFIGURED,
+		"an unparseable Scope line degrades to the target check",
+	)
+
+
+func test_claude_code_declares_scope_aware_status_probe() -> void:
+	## `mcp list` cannot say which scope resolved, so a `{scope}` descriptor
+	## needs the richer probe. Same single subprocess — see #238/#239 for why
+	## adding a second CLI spawn per status check would not be acceptable.
+	var client := McpClientRegistry.get_by_id("claude_code")
+	assert_true(client != null, "claude_code must be registered")
+	var probe := client.cli_scope_status_template
+	assert_false(probe.is_empty(), "scope-token client must declare a scope probe")
+	assert_true(probe.has("get"), "the probe must be `mcp get`, which prints the Scope line")
+	assert_true(probe.has("{name}"), "probe must target our server by name")
+	var args := McpCliStrategy.format_args(probe, "godot-ai", "")
+	assert_true(args.has("godot-ai"), "{name} must substitute")
+	assert_false(args.has("{name}"), "no token may reach the CLI unsubstituted")
+
+
 func test_claude_code_manual_command_shows_json_fallback() -> void:
 	# The CLI form is still the primary hint, but a user without the `claude`
 	# binary (VS Code extension) needs the ~/.claude.json edit too (#463).

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -479,6 +479,25 @@ func test_apply_row_status_renders_mismatch_as_amber_with_url_hint() -> void:
 		"Mismatched rows offer the same Reconfigure action as the banner")
 
 
+func test_apply_row_status_mismatch_prefers_probe_message() -> void:
+	## A `{scope}` client can drift by being registered in a scope the user
+	## did not select (#872). "URL out of date" is a wrong description of
+	## that, so a probe-supplied message wins the label.
+	_dock._build_ui()
+	var any_id := McpClientConfigurator.client_ids()[0]
+	_dock._apply_row_status(
+		any_id, McpClient.Status.CONFIGURED_MISMATCH, "registered at user scope, not project"
+	)
+	var row: Dictionary = _dock._client_rows[any_id]
+	assert_eq((row["dot"] as ColorRect).color, McpDockScript.COLOR_AMBER,
+		"a scope mismatch is still drift, so it stays amber")
+	var label := (row["name_label"] as Label).text
+	assert_contains(label, "registered at user scope, not project",
+		"the probe's own words must reach the row")
+	assert_false(label.contains("URL out of date"),
+		"a scope mismatch is not a stale URL — that label would misdescribe it")
+
+
 func test_client_rows_show_config_file_buttons_only_for_file_clients() -> void:
 	_dock._build_ui()
 	var file_id := "cursor"


### PR DESCRIPTION
Closes #872.

## Problem

`clients/claude_code.gd` hardcodes `--scope user` in both its register and unregister
templates, so **Configure** always writes `godot-ai` into the global `mcpServers` block
of `~/.claude.json`. Claude Code loads that block in *every* workspace, so the plugin's
tools get spawned in projects unrelated to Godot — and hand-removing the entry doesn't
stick, because the next Configure silently re-adds it.

## Approach

A `{scope}` token resolved in `McpCliStrategy._format_args`, backed by a new
`godot_ai/mcp_client_scope` EditorSetting.

`_format_args` is the single substitution point for CLI templates — `_manual_command.gd`
routes through `McpCliStrategy.format_args` too — so the executed argv and the dock's
"Run this manually" snippet stay in agreement with no extra plumbing, and the token can
never leak through to the CLI unsubstituted.

**The default stays `user`**, so existing installs are byte-identical on upgrade. This
is opt-in, not a behaviour change.

| | |
|---|---|
| `utils/settings.gd` | `SETTING_CLIENT_SCOPE`, `CLIENT_SCOPES`, `DEFAULT_CLIENT_SCOPE`, and a validating `client_scope()` accessor |
| `clients/_cli_strategy.gd` | resolve `{scope}` in `_format_args` |
| `clients/claude_code.gd` | templates use `{scope}` instead of a literal `user` |
| `client_configurator.gd` | register the setting with `PROPERTY_HINT_ENUM` so it's discoverable in Settings > Plugins |
| `test_project/tests/test_clients.gd` | 3 new tests + snapshot/restore + tightened existing assertions |
| `README.md` | a collapsed section under step 3 explaining per-project registration |

Unrecognised values fall back to the default, so a hand-edited `editor_settings-4.tres`
can't make the plugin shell out with a bad `--scope` flag. Values are trimmed and
case-folded.

The generalisation is deliberate: any `config_type = "cli"` descriptor can now opt into
the token. `claude_code.gd` is just the one that needs it today.

## Verification

- `godot --headless --path test_project --import` → **0 parse errors** on Godot 4.7.2
  (the same check `script/ci-check-gdscript` performs). This caught a real bug first
  time round: `const CLIENT_SCOPES := PackedStringArray([...])` isn't a constant
  expression in GDScript; it's a plain Array literal now, converted at the one
  `String.join` call site.
- The end state is verified by hand on Windows: registering `godot-ai` at project scope
  puts it in `<project>/.mcp.json`, `claude mcp list` shows it from the project root and
  not from an unrelated directory, and the global `mcpServers` block stays clean.

**What I could not run:** the GDScript suite in `test_project/tests/` needs a live
Python server plus a connected editor session (`script/ci-godot-tests` drives it over
MCP), which I couldn't stand up here — so the three new tests are unexecuted and I'd
ask CI to be the judge. They parse clean and only touch `EditorSettings` +
`McpCliStrategy.format_args`, both guarded for a null `EditorInterface`.

## Deliberately out of scope

The #463 JSON fallback (`path_template` → `~/.claude.json`) stays user-scoped, because
`clients/_path_template.gd` has no project-relative token. It only fires when the
`claude` binary is off PATH. Folding it in would mean inventing new template-resolution
machinery in the same change, so it's flagged in a code comment as a known limitation
rather than half-fixed — happy to follow up if you'd like it covered.

One UX note I left alone: **Remove** targets whichever scope is currently selected, so
changing the setting and pressing Remove won't clean up an entry written under the old
scope. The README calls this out. If you'd rather Remove swept all scopes, say the word
and I'll add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable MCP client scopes: `user`, `project`, and `local`.
  - Registration, removal, cleanup, and status checks now honor the selected scope.
  - Improved detection of missing, shadowed, or incorrectly scoped registrations.
  - Mismatch messages now show specific diagnostic details when available.
  - Added project-scoped approval guidance for Claude Code.

- **Documentation**
  - Documented scope options, working-directory behavior, defaults, status verification, and configuration limitations.

- **Tests**
  - Added coverage for scope selection, cleanup, status detection, fallback handling, mismatch reporting, and argument validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->