### PR TITLE
fix: fail game_eval fast when the game loop is unavailable

### DIFF
--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -1204,6 +1204,7 @@ func _send_eval(
 	_pending[request_id] = {
 		"kind": "eval",
 		"connection": connection,
+		"run_token": _game_run_token,
 		"timer": timer,
 		"timeout_callable": timeout_callable,
 		"grace_timer": grace,
@@ -1240,9 +1241,17 @@ func _on_eval_timeout(request_id: String, timeout_sec: float) -> void:
 	var pending_entry = _pending.get(request_id)
 	if pending_entry == null:
 		return
+	var run_token := int(pending_entry.get("run_token", _game_run_token))
 	_clear_pending(request_id)
 	var conn: McpConnection = pending_entry.connection
 	if conn == null or not is_instance_valid(conn):
+		return
+	if run_token != _game_run_token:
+		_send_error(conn, request_id, ErrorCodes.EVAL_GAME_NOT_READY,
+			"The game run changed before game_eval completed — the original game stopped or restarted. Retry against the current run.")
+		if _log_buffer:
+			_log_buffer.log("[debug] !! eval timeout from prior run (%s, run=%d, current=%d)"
+				% [request_id, run_token, _game_run_token])
 		return
 	var status := get_game_status(-1, EVAL_READY_WAIT_SEC)
 	if str(status.get("status", "")) != "live":

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -76,11 +76,16 @@ var _editor_log_buffer: McpEditorLogBuffer
 var _surfaced_error_tracker
 var vision_routing: VisionRoutingScript = null
 
-## Pending request_id -> {connection, timer, timeout_callable}.
-## We retain the bound timeout lambda so `_clear_pending` can disconnect
-## it on success/error; otherwise the SceneTreeTimer pins the captured
-## request_id until `timeout_sec` elapses (8s default).
+## Pending request_id -> phase-specific data. Every eval phase carries kind
+## and connection; timer-backed phases also retain their bound timeout lambda
+## so `_clear_pending` can disconnect it on success/error. Otherwise the
+## SceneTreeTimer pins the captured request_id until its timeout elapses.
 var _pending: Dictionary = {}
+
+## Testing seam for the readiness wait below. Production leaves this invalid
+## and awaits SceneTree.process_frame; editor tests inject a synchronous
+## callable because their runner does not pump frames while a test is running.
+var _eval_ready_frame_waiter: Callable = Callable()
 
 ## Flipped true when the game-side autoload sends its "mcp:hello" boot
 ## beacon for the current project_run. Reset as soon as a new run is
@@ -249,12 +254,26 @@ func _on_debugger_session_stopped(session_id: int) -> void:
 func _fail_pending_evals_not_ready(message: String) -> void:
 	for request_id in _pending.keys():
 		var pending: Dictionary = _pending.get(request_id, {})
-		if str(pending.get("kind", "")) not in ["eval_liveness", "eval"]:
+		if str(pending.get("kind", "")) not in [
+			"eval_ready_wait", "eval_liveness", "eval"
+		]:
 			continue
 		var connection: McpConnection = pending.get("connection")
 		_clear_pending(str(request_id))
 		if connection != null and is_instance_valid(connection):
 			_send_error(connection, str(request_id), ErrorCodes.EVAL_GAME_NOT_READY, message)
+
+
+func _is_current_game_run(run_token: int) -> bool:
+	return _game_run_active and _game_run_token == run_token
+
+
+func _fail_eval_not_ready(request_id: String, message: String) -> void:
+	var pending: Dictionary = _pending.get(request_id, {})
+	var connection: McpConnection = pending.get("connection")
+	_clear_pending(request_id)
+	if connection != null and is_instance_valid(connection):
+		_send_error(connection, request_id, ErrorCodes.EVAL_GAME_NOT_READY, message)
 
 
 ## --- #645: boot-time debugger breaks ---------------------------------------
@@ -1005,13 +1024,14 @@ func request_game_eval(
 			"Editor main loop is not a SceneTree — cannot schedule eval")
 		return
 
+	var run_token := _game_run_token
 	if is_game_capture_ready():
-		_probe_then_eval(tree, code, request_id, connection, timeout_sec)
+		_probe_then_eval(tree, code, request_id, connection, timeout_sec, run_token)
 		return
 
 	if _log_buffer:
 		_log_buffer.log("[debug] waiting for game_helper hello before eval (%s)" % request_id)
-	_wait_then_eval(tree, code, request_id, connection, timeout_sec)
+	_wait_then_eval(tree, code, request_id, connection, timeout_sec, run_token)
 
 
 func _wait_then_eval(
@@ -1020,27 +1040,54 @@ func _wait_then_eval(
 	request_id: String,
 	connection: McpConnection,
 	timeout_sec: float,
+	run_token: int,
 ) -> void:
 	## #500: eval uses EVAL_READY_WAIT_SEC (not the 20s GAME_READY_WAIT_SEC) so
 	## the not-ready path returns its actionable error before the 15s server-side
 	## command timeout fires an opaque TimeoutError. See EVAL_READY_WAIT_SEC.
+	_pending[request_id] = {
+		"kind": "eval_ready_wait",
+		"connection": connection,
+		"run_token": run_token,
+	}
 	var deadline := Time.get_ticks_msec() + int(EVAL_READY_WAIT_SEC * 1000.0)
 	## #645: the leading yield guarantees the dispatcher has registered the
 	## deferred request before any reply (a same-frame reply is dropped as
 	## expired); the break check bails out early because a parked game never
 	## registers its capture.
-	await tree.process_frame
-	while not is_game_capture_ready() and not _break_active and Time.get_ticks_msec() < deadline:
+	if _eval_ready_frame_waiter.is_valid():
+		await _eval_ready_frame_waiter.call()
+	else:
 		await tree.process_frame
+	while (
+		_pending.has(request_id)
+		and _is_current_game_run(run_token)
+		and not is_game_capture_ready()
+		and not _break_active
+		and Time.get_ticks_msec() < deadline
+	):
+		if _eval_ready_frame_waiter.is_valid():
+			await _eval_ready_frame_waiter.call()
+		else:
+			await tree.process_frame
+	## end_game_run() owns the reply once it has cleared this tracked wait.
+	if not _pending.has(request_id):
+		return
+	if not _is_current_game_run(run_token):
+		_fail_eval_not_ready(request_id,
+			"The game run changed before game_eval could start — the game stopped or restarted. Retry against the current run.")
+		return
 	if not is_game_capture_ready():
 		## #518: EVAL_GAME_NOT_READY (not INTERNAL_ERROR) — the play session is up
 		## but the game-side capture didn't register within the short wait. Fast
 		## and caller-actionable; classifying it apart from the opaque 10s hang
 		## keeps the INTERNAL_ERROR telemetry bucket meaning "the eval truly hung".
+		_clear_pending(request_id)
 		_send_error_response(connection, request_id,
 			_explain_not_live(get_game_status(-1, EVAL_READY_WAIT_SEC), ErrorCodes.EVAL_GAME_NOT_READY))
 		return
-	_probe_then_eval(tree, code, request_id, connection, timeout_sec)
+	_clear_pending(request_id)
+	_probe_then_eval(tree, code, request_id, connection, timeout_sec, run_token)
 
 
 ## #859: registration is run-scoped but not a liveness guarantee. Ping the
@@ -1052,7 +1099,12 @@ func _probe_then_eval(
 	request_id: String,
 	connection: McpConnection,
 	timeout_sec: float,
+	run_token: int,
 ) -> void:
+	if not _is_current_game_run(run_token) or not is_game_capture_ready():
+		_send_error(connection, request_id, ErrorCodes.EVAL_GAME_NOT_READY,
+			"The game run changed before game_eval could be checked — the game stopped or restarted. Retry against the current run.")
+		return
 	var session: EditorDebuggerSession = _first_active_session()
 	if session == null:
 		_send_error(connection, request_id, ErrorCodes.EVAL_GAME_NOT_READY,
@@ -1069,6 +1121,7 @@ func _probe_then_eval(
 		"timeout_callable": timeout_callable,
 		"code": code,
 		"eval_timeout_sec": timeout_sec,
+		"run_token": run_token,
 	}
 	session.send_message("mcp:eval_liveness", [request_id])
 	if _log_buffer:
@@ -1099,9 +1152,14 @@ func _on_eval_liveness_response(data: Array) -> void:
 	var connection: McpConnection = pending_entry.get("connection")
 	var code := str(pending_entry.get("code", ""))
 	var timeout_sec := float(pending_entry.get("eval_timeout_sec", 10.0))
+	var run_token := int(pending_entry.get("run_token", -1))
 	var loop_live := bool(data[1])
 	_clear_pending(request_id)
 	if connection == null or not is_instance_valid(connection):
+		return
+	if not _is_current_game_run(run_token) or not is_game_capture_ready():
+		_send_error(connection, request_id, ErrorCodes.EVAL_GAME_NOT_READY,
+			"The game run changed while game_eval liveness was being checked — the game stopped or restarted. Retry against the current run.")
 		return
 	if not loop_live:
 		_send_error(connection, request_id, ErrorCodes.EVAL_GAME_NOT_READY,

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -33,20 +33,26 @@ const GAME_READY_WAIT_SEC := 20.0
 ## #500: how long to wait for the game-side autoload to beacon mcp:hello before
 ## issuing a game_eval. This is deliberately MUCH shorter than the 20s
 ## screenshot wait above: the eval path's total editor-side budget is this wait
-## plus the 10s eval backstop (request_game_eval's timeout_sec), and that total
-## MUST stay below the 15s game_eval timeout enforced at two layers: the Python
-## server's send_command budget (src/godot_ai/handlers/editor.py::game_eval) and
-## this plugin's own deferred budget (dispatcher.gd's 15000ms game_eval entry,
-## editor/plugin-side — not server-side). Either firing produces the opaque tail.
+## plus the 250ms liveness probe and 10s eval backstop
+## (request_game_eval's timeout_sec), and that total MUST stay below the 15s
+## game_eval timeout enforced at two layers: the Python server's send_command
+## budget (src/godot_ai/handlers/editor.py::game_eval) and this plugin's own
+## deferred budget (dispatcher.gd's 15000ms game_eval entry, editor/plugin-side
+## — not server-side). Either firing produces the opaque tail.
 ## With the 20s screenshot wait, a not-yet-ready game made the editor poll past
 ## the 15s deadline, so the server gave up first with an opaque
 ## ~15s TimeoutError instead of the actionable "Is the game actually running?"
 ## error below ever reaching the client (#500's residual TimeoutError bucket).
-## 3s wait + 10s backstop = 13s, comfortably under the 15s server timeout, so
-## the actionable error always wins. A game launched moments before the eval
-## still has the 3s grace to register; if it needs longer, the user gets a fast,
-## clear "is it running?" rather than a 15s hang.
+## 3s wait + 0.25s probe + 10s backstop = 13.25s, comfortably under the 15s
+## server timeout, so the actionable error always wins. A game launched moments
+## before the eval still has the 3s grace to register; if it needs longer, the
+## user gets a fast, clear "is it running?" rather than a 15s hang.
 const EVAL_READY_WAIT_SEC := 3.0
+## #859: once the helper has registered, confirm its game loop is still
+## advancing before dispatching an eval. The helper replies synchronously from
+## the debugger capture, so 250ms is ample while keeping not-ready failures
+## below the telemetry target of 0.5s.
+const EVAL_LIVENESS_WAIT_SEC := 0.25
 ## #490: how long to wait for the game's mcp:eval_compiled beacon before
 ## concluding the eval source failed to compile. A parse error aborts the
 ## game-side handler before it can reply, so without this we'd wait the
@@ -188,6 +194,9 @@ func _editor_log_cursor() -> int:
 
 
 func end_game_run() -> void:
+	_fail_pending_evals_not_ready(
+		"The game run ended before game_eval completed — the game stopped, crashed, or is restarting. Confirm it is running and retry."
+	)
 	_game_run_active = false
 	_manual_run_armed = false
 	_game_ready = false
@@ -232,6 +241,20 @@ func _on_debugger_session_stopped(session_id: int) -> void:
 	if not _manual_run_armed and _game_session_id == -1:
 		return
 	end_game_run()
+
+
+## #859: a closed debugger session is authoritative. Do not leave evals on
+## their 10s backstop after the game process has already gone away. Other
+## pending request kinds keep their existing ownership and timeout behavior.
+func _fail_pending_evals_not_ready(message: String) -> void:
+	for request_id in _pending.keys():
+		var pending: Dictionary = _pending.get(request_id, {})
+		if str(pending.get("kind", "")) not in ["eval_liveness", "eval"]:
+			continue
+		var connection: McpConnection = pending.get("connection")
+		_clear_pending(str(request_id))
+		if connection != null and is_instance_valid(connection):
+			_send_error(connection, str(request_id), ErrorCodes.EVAL_GAME_NOT_READY, message)
 
 
 ## --- #645: boot-time debugger breaks ---------------------------------------
@@ -682,6 +705,9 @@ func _capture(message: String, data: Array, session_id: int) -> bool:
 				else:
 					_log_buffer.log("[debug] <- mcp:hello from game_helper")
 			return true
+		"mcp:eval_liveness_response":
+			_on_eval_liveness_response(data)
+			return true
 		"mcp:eval_response":
 			_on_eval_response(data)
 			return true
@@ -956,12 +982,13 @@ func _clear_pending(request_id: String) -> void:
 ## the game's more specific "Eval exceeded 8s" message — see the TIMEOUT
 ## ORDERING note on EVAL_TIMEOUT_SEC.
 ##
-## #500: the *not-ready* path adds EVAL_READY_WAIT_SEC (3s) on top of this 10s
-## backstop. That sum (13s) must also stay below the dispatcher/server 15s
-## budget, or a not-yet-ready game makes the server time out opaquely before
-## the editor's actionable error returns — which is exactly the residual ~15s
-## TimeoutError bucket #500 tracked down. Keep EVAL_READY_WAIT_SEC + timeout_sec
-## < 15s if you tune either.
+## #500/#859: the *not-ready* path adds EVAL_READY_WAIT_SEC (3s) and the
+## EVAL_LIVENESS_WAIT_SEC probe (0.25s) on top of this 10s backstop. That sum
+## (13.25s) must also stay below the dispatcher/server 15s budget, or a
+## not-yet-ready game makes the server time out opaquely before the editor's
+## actionable error returns — exactly the residual ~15s TimeoutError bucket
+## #500 tracked down. The cross-file contract is enforced by
+## tests/unit/test_game_eval_timeout_ordering.py.
 func request_game_eval(
 	code: String,
 	request_id: String,
@@ -979,7 +1006,7 @@ func request_game_eval(
 		return
 
 	if is_game_capture_ready():
-		_send_eval(tree, code, request_id, connection, timeout_sec)
+		_probe_then_eval(tree, code, request_id, connection, timeout_sec)
 		return
 
 	if _log_buffer:
@@ -1013,7 +1040,79 @@ func _wait_then_eval(
 		_send_error_response(connection, request_id,
 			_explain_not_live(get_game_status(-1, EVAL_READY_WAIT_SEC), ErrorCodes.EVAL_GAME_NOT_READY))
 		return
-	_send_eval(tree, code, request_id, connection, timeout_sec)
+	_probe_then_eval(tree, code, request_id, connection, timeout_sec)
+
+
+## #859: registration is run-scoped but not a liveness guarantee. Ping the
+## helper's debugger capture and let it report whether its _process beacon is
+## still advancing before arming the much longer eval backstop.
+func _probe_then_eval(
+	tree: SceneTree,
+	code: String,
+	request_id: String,
+	connection: McpConnection,
+	timeout_sec: float,
+) -> void:
+	var session: EditorDebuggerSession = _first_active_session()
+	if session == null:
+		_send_error(connection, request_id, ErrorCodes.EVAL_GAME_NOT_READY,
+			"Game-side capture registered but its debugger session is no longer active — the game likely just stopped or is restarting. Confirm it is running and retry.")
+		return
+
+	var timer := tree.create_timer(EVAL_LIVENESS_WAIT_SEC)
+	var timeout_callable := func() -> void: _on_eval_liveness_timeout(request_id)
+	timer.timeout.connect(timeout_callable)
+	_pending[request_id] = {
+		"kind": "eval_liveness",
+		"connection": connection,
+		"timer": timer,
+		"timeout_callable": timeout_callable,
+		"code": code,
+		"eval_timeout_sec": timeout_sec,
+	}
+	session.send_message("mcp:eval_liveness", [request_id])
+	if _log_buffer:
+		_log_buffer.log("[debug] -> mcp:eval_liveness (%s)" % request_id)
+
+
+func _on_eval_liveness_timeout(request_id: String) -> void:
+	var pending_entry = _pending.get(request_id)
+	if pending_entry == null or str(pending_entry.get("kind", "")) != "eval_liveness":
+		return
+	var connection: McpConnection = pending_entry.get("connection")
+	_clear_pending(request_id)
+	if connection == null or not is_instance_valid(connection):
+		return
+	_send_error(connection, request_id, ErrorCodes.EVAL_GAME_NOT_READY,
+		("The game helper did not answer the liveness probe within %.0fms — the game may be backgrounded, frozen, stopped, or restarting. Focus the game window (or relaunch it) and retry."
+			% (EVAL_LIVENESS_WAIT_SEC * 1000.0)))
+
+
+func _on_eval_liveness_response(data: Array) -> void:
+	if data.size() < 2:
+		push_warning("MCP debugger: malformed eval liveness response")
+		return
+	var request_id := str(data[0])
+	var pending_entry = _pending.get(request_id)
+	if pending_entry == null or str(pending_entry.get("kind", "")) != "eval_liveness":
+		return
+	var connection: McpConnection = pending_entry.get("connection")
+	var code := str(pending_entry.get("code", ""))
+	var timeout_sec := float(pending_entry.get("eval_timeout_sec", 10.0))
+	var loop_live := bool(data[1])
+	_clear_pending(request_id)
+	if connection == null or not is_instance_valid(connection):
+		return
+	if not loop_live:
+		_send_error(connection, request_id, ErrorCodes.EVAL_GAME_NOT_READY,
+			"The game helper is registered but its main loop is not advancing — the game window may be backgrounded or the game may be frozen. Focus the game window (or relaunch it) and retry.")
+		return
+	var current_tree := Engine.get_main_loop() as SceneTree
+	if current_tree == null:
+		_send_error(connection, request_id, ErrorCodes.INTERNAL_ERROR,
+			"Editor main loop is not a SceneTree — cannot schedule eval")
+		return
+	_send_eval(current_tree, code, request_id, connection, timeout_sec)
 
 
 func _send_eval(
@@ -1045,6 +1144,7 @@ func _send_eval(
 	grace.timeout.connect(grace_callable)
 
 	_pending[request_id] = {
+		"kind": "eval",
 		"connection": connection,
 		"timer": timer,
 		"timeout_callable": timeout_callable,

--- a/plugin/addons/godot_ai/runtime/game_helper.gd
+++ b/plugin/addons/godot_ai/runtime/game_helper.gd
@@ -270,6 +270,9 @@ static func _should_capture_stale_sync(
 ## #777: true when _process hasn't ticked within MAIN_LOOP_STALL_MSEC —
 ## i.e. the main loop is frozen (backgrounded window) or has never run.
 func _main_loop_appears_stalled() -> bool:
+	## The hello→probe round trip normally follows at least one _process tick.
+	## Treat the never-ticked sentinel as stalled defensively rather than
+	## dispatching an eval into a game whose main loop has not started.
 	if _last_loop_tick_msec < 0:
 		return true
 	return Time.get_ticks_msec() - _last_loop_tick_msec > MAIN_LOOP_STALL_MSEC

--- a/plugin/addons/godot_ai/runtime/game_helper.gd
+++ b/plugin/addons/godot_ai/runtime/game_helper.gd
@@ -92,6 +92,11 @@ var _last_loop_tick_msec: int = -1
 ## render-stalled and keeps the fresh-frame await path's error replies.
 var _last_frames_drawn_seen: int = -1
 var _last_frames_advance_msec: int = -1
+## #859: test/diagnostic seam for the synchronous eval liveness reply. The
+## debugger capture remains callable while the game loop is parked, so the
+## reply reports whether the _process beacon is actually advancing rather
+## than merely proving that the capture was registered once.
+var _last_eval_liveness_reply: Dictionary = {}
 
 
 func _ready() -> void:
@@ -180,6 +185,9 @@ func _on_debug_message(message: String, data: Array) -> bool:
 		"take_screenshot":
 			_handle_take_screenshot(data)
 			return true
+		"eval_liveness":
+			_reply_eval_liveness(data)
+			return true
 		"eval":
 			_handle_eval(data)
 			return true
@@ -190,6 +198,17 @@ func _on_debug_message(message: String, data: Array) -> bool:
 			_handle_game_command(data)
 			return true
 	return false
+
+
+## #859: answer from the debugger capture without awaiting a game frame. The
+## capture can still run while a backgrounded/frozen game's main loop cannot,
+## so the _process beacon is the liveness signal that matters for game_eval.
+func _reply_eval_liveness(data: Array) -> void:
+	var request_id: String = data[0] if data.size() > 0 else ""
+	var loop_live := not _main_loop_appears_stalled()
+	_last_eval_liveness_reply = {"request_id": request_id, "loop_live": loop_live}
+	if EngineDebugger.is_active():
+		EngineDebugger.send_message("mcp:eval_liveness_response", [request_id, loop_live])
 
 
 func _handle_take_screenshot(data: Array) -> void:
@@ -942,8 +961,8 @@ func _mouse_button_index(name: String) -> int:
 ## EVAL_HUNG code, #518, but the editor's message can't name the cause).
 ## Raise this at/above the editor timer (or drop that timer below this) and
 ## the less specific editor message wins the race, silently losing the
-## diagnostic this fix exists to provide. Nothing enforces the order —
-## change one, re-check the other two.
+## diagnostic this fix exists to provide. The cross-file contract is enforced
+## by tests/unit/test_game_eval_timeout_ordering.py.
 ##
 ## NOTE: this catches a hung `await`, not a CPU-bound loop with no `await` —
 ## a tight `while true:` with no yield blocks the main thread, so nothing

--- a/plugin/addons/godot_ai/utils/error_codes.gd
+++ b/plugin/addons/godot_ai/utils/error_codes.gd
@@ -39,14 +39,12 @@ const BACKEND_START_TIMEOUT := "BACKEND_START_TIMEOUT"
 # game_eval failure codes (#490) — keep in sync with protocol/errors.py
 const EVAL_COMPILE_ERROR := "EVAL_COMPILE_ERROR"
 const EVAL_RUNTIME_ERROR := "EVAL_RUNTIME_ERROR"
-## #518: the play session is up (EditorInterface.is_playing_scene() is true, so
-## editor_handler's EDITOR_NOT_READY "game is not running" gate already passed)
-## but the game-side _mcp_game_helper autoload never registered its debugger
-## capture within EVAL_READY_WAIT_SEC. Carved out of INTERNAL_ERROR so this
-## boot-window / missing-autoload race stops masquerading as the opaque "eval
-## hung" 10s timeout in telemetry — the same split #490 made for compile/runtime
-## errors. NOT a hang: it fires fast (~3s) and is caller-actionable (let the game
-## finish booting and retry, or check the autoload is enabled).
+## #518/#859: the play session is up (EditorInterface.is_playing_scene() is true,
+## so editor_handler's EDITOR_NOT_READY "game is not running" gate already
+## passed) but the game cannot service evals: the helper did not register within
+## EVAL_READY_WAIT_SEC, its main-loop beacon is stale, or its debugger session
+## closed mid-eval. Carved out of INTERNAL_ERROR so these fast,
+## caller-actionable failures do not burn the opaque 10s eval backstop.
 const EVAL_GAME_NOT_READY := "EVAL_GAME_NOT_READY"
 ## #518: the eval genuinely never finished inside the timeout ladder — the
 ## game-side 8s deadline aborted a hung await, or the editor-side 10s backstop

--- a/src/godot_ai/handlers/editor.py
+++ b/src/godot_ai/handlers/editor.py
@@ -469,15 +469,15 @@ async def game_eval(runtime: DirectRuntime, code: str) -> dict:
     ``EVAL_GAME_NOT_READY`` (#518) means the game can't service evals right
     now: the play session is up but the game-side capture hasn't registered
     yet (let the game finish launching and retry, or check the
-    ``_mcp_game_helper`` autoload is enabled), or the game is parked in a
-    debugger break / stopped mid-eval (stop and relaunch it). ``EVAL_HUNG``
-    (#518) means the eval code itself never finished: a genuine infinite loop
-    or never-firing await, aborted by the game's 8s deadline or the editor's
-    10s backstop. ``EVAL_RESULT_TOO_LARGE`` (#518) means the eval finished but
+    ``_mcp_game_helper`` autoload is enabled), its main loop is not advancing
+    (focus the backgrounded game), or the debugger session closed mid-eval
+    (stop and relaunch it). ``EVAL_HUNG`` (#518) means a live game accepted the
+    eval but the code itself never finished: a genuine infinite loop or
+    never-firing await, aborted by the game's 8s deadline or the editor's 10s
+    backstop. ``EVAL_RESULT_TOO_LARGE`` (#518) means the eval finished but
     its serialized result exceeds what the debugger channel can carry (~6 MiB)
     — return a smaller slice. Note that ``await`` (timers, signals, frames)
-    only progresses while the game window is focused; a backgrounded
-    play-in-editor game has a frozen idle loop, so an awaiting eval reads as
-    ``EVAL_HUNG`` until the game is focused.
+    only progresses while the game loop advances; focus a backgrounded game
+    before retrying an ``EVAL_GAME_NOT_READY`` response.
     """
     return await runtime.send_command("game_eval", {"code": code}, timeout=15.0)

--- a/src/godot_ai/protocol/errors.py
+++ b/src/godot_ai/protocol/errors.py
@@ -38,11 +38,11 @@ class ErrorCode(StrEnum):
     # actionable reply. Keep in sync with utils/error_codes.gd.
     EVAL_COMPILE_ERROR = "EVAL_COMPILE_ERROR"
     EVAL_RUNTIME_ERROR = "EVAL_RUNTIME_ERROR"
-    # #518: the play session is up but the game-side autoload never registered
-    # its debugger capture within the readiness wait (boot-window race, worst on
-    # Windows, or a missing/disabled autoload). Carved out of INTERNAL_ERROR so
-    # this fast (~3s), caller-actionable failure stops being counted as the
-    # opaque "eval hung" 10s timeout. Keep in sync with utils/error_codes.gd.
+    # #518/#859: the play session is up but the game cannot service evals: the
+    # autoload did not register within the readiness wait, its main-loop beacon
+    # is stale, or its debugger session closed mid-eval. Carved out of
+    # INTERNAL_ERROR so these fast, caller-actionable failures do not burn the
+    # opaque 10s eval backstop. Keep in sync with utils/error_codes.gd.
     EVAL_GAME_NOT_READY = "EVAL_GAME_NOT_READY"
     # #518: the eval genuinely never finished inside the timeout ladder (hung
     # await caught by the game-side 8s deadline, or no game reply at all by the

--- a/src/godot_ai/tools/editor.py
+++ b/src/godot_ai/tools/editor.py
@@ -44,11 +44,11 @@ Ops:
         EVAL_RUNTIME_ERROR (with the real message + line) for a runtime
         error; EVAL_GAME_NOT_READY if the game can't service evals — still
         launching (retry once it's up), the _mcp_game_helper autoload is
-        missing/disabled, or the game is parked in a debugger break (stop
-        and relaunch); EVAL_HUNG for a genuine infinite loop / never-firing
-        await; EVAL_RESULT_TOO_LARGE if the returned value serializes past
-        the debugger channel's capacity (return a smaller slice). 'await'
-        only progresses while the game window is focused."""
+        missing/disabled, its main loop is not advancing (focus the game),
+        or its debugger session closed; EVAL_HUNG for a live game's genuine
+        infinite loop / never-firing await; EVAL_RESULT_TOO_LARGE if the
+        returned value serializes past the debugger channel's capacity
+        (return a smaller slice)."""
 
 
 def register_editor_tools(mcp: FastMCP, *, include_non_core: bool = True) -> None:

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -493,6 +493,32 @@ func test_eval_liveness_positive_response_dispatches_eval() -> void:
 	assert_eq(conn.captured.size(), 0, "a live probe should not emit an error")
 	conn.free()
 
+
+func test_eval_probe_without_active_debugger_session_fails_fast() -> void:
+	var tree := Engine.get_main_loop() as SceneTree
+	if tree == null:
+		skip("No SceneTree available")
+		return
+	var plugin := _RecordingEvalPlugin.new()
+	_mark_game_live(plugin)
+	if plugin._first_active_session() != null:
+		skip("an active debugger session is present; no-session branch not exercised")
+		return
+	var conn := _StubConnection.new()
+	var rid := "rid-probe-no-session"
+
+	plugin._probe_then_eval(
+		tree, "return 42", rid, conn, 10.0, plugin._game_run_token
+	)
+
+	assert_true(plugin.dispatched.is_empty(), "the eval must not be dispatched")
+	assert_false(plugin._pending.has(rid), "the guard must not leave pending state")
+	assert_eq(conn.captured.size(), 1, "one deferred failure reply")
+	assert_eq(conn.captured[0].payload.error.code, ErrorCodes.EVAL_GAME_NOT_READY)
+	assert_contains(conn.captured[0].payload.error.message, "debugger session")
+	conn.free()
+
+
 func test_eval_liveness_negative_response_fails_fast() -> void:
 	var plugin := McpDebuggerPlugin.new()
 	var conn := _StubConnection.new()

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -475,11 +475,13 @@ func test_eval_liveness_positive_response_dispatches_eval() -> void:
 	var plugin := _RecordingEvalPlugin.new()
 	var conn := _StubConnection.new()
 	var rid := "rid-eval-live"
+	_mark_game_live(plugin)
 	plugin._pending[rid] = {
 		"kind": "eval_liveness",
 		"connection": conn,
 		"code": "return 42",
 		"eval_timeout_sec": 7.5,
+		"run_token": plugin._game_run_token,
 	}
 	assert_true(plugin._capture("mcp:eval_liveness_response", [rid, true], 0),
 		"the editor should capture positive helper liveness replies")
@@ -495,11 +497,13 @@ func test_eval_liveness_negative_response_fails_fast() -> void:
 	var plugin := McpDebuggerPlugin.new()
 	var conn := _StubConnection.new()
 	var rid := "rid-eval-not-live"
+	_mark_game_live(plugin)
 	plugin._pending[rid] = {
 		"kind": "eval_liveness",
 		"connection": conn,
 		"code": "return 1",
 		"eval_timeout_sec": 10.0,
+		"run_token": plugin._game_run_token,
 	}
 	assert_true(plugin._capture("mcp:eval_liveness_response", [rid, false], 0),
 		"the editor should capture helper liveness replies")
@@ -526,16 +530,84 @@ func test_eval_liveness_timeout_fails_fast() -> void:
 	conn.free()
 
 
+func test_eval_readiness_wait_stop_then_restart_does_not_cross_runs() -> void:
+	## The test runner does not pump process_frame while a test is active, so a
+	## synchronous waiter drives the exact coroutine path without suspending it.
+	var tree := Engine.get_main_loop() as SceneTree
+	if tree == null:
+		skip("No SceneTree available")
+		return
+	var plugin := _RecordingEvalPlugin.new()
+	var conn := _StubConnection.new()
+	plugin.begin_game_run()
+	var original_run_token := plugin._game_run_token
+	plugin._eval_ready_frame_waiter = func() -> void:
+		plugin.end_game_run()
+		plugin.begin_game_run()
+		plugin._game_ready = true
+		plugin._ready_run_token = plugin._game_run_token
+
+	await plugin._wait_then_eval(
+		tree, "return 42", "rid-ready-restart", conn, 10.0, original_run_token
+	)
+	plugin._eval_ready_frame_waiter = Callable()
+
+	assert_ne(plugin._game_run_token, original_run_token,
+		"the replacement game must have a distinct run token")
+	assert_true(plugin.is_game_capture_ready(),
+		"the replacement run is ready, so the old implementation would dispatch")
+	assert_true(plugin.dispatched.is_empty(),
+		"an eval created for the stopped run must never reach the replacement run")
+	assert_false(plugin._pending.has("rid-ready-restart"),
+		"ending the original run clears the tracked readiness wait")
+	assert_eq(conn.captured.size(), 1, "the stopped request receives one failure")
+	assert_eq(conn.captured[0].payload.error.code, ErrorCodes.EVAL_GAME_NOT_READY)
+	conn.free()
+
+
+func test_eval_liveness_response_from_prior_run_is_not_dispatched() -> void:
+	var plugin := _RecordingEvalPlugin.new()
+	var conn := _StubConnection.new()
+	var rid := "rid-liveness-prior-run"
+	_mark_game_live(plugin)
+	var original_run_token := plugin._game_run_token
+	plugin._pending[rid] = {
+		"kind": "eval_liveness",
+		"connection": conn,
+		"code": "return 42",
+		"eval_timeout_sec": 10.0,
+		"run_token": original_run_token,
+	}
+	## Model a replacement run being tracked before the old session's late
+	## response arrives; the token check is the fallback if stop cleanup missed.
+	plugin.begin_game_run()
+	plugin._game_ready = true
+	plugin._ready_run_token = plugin._game_run_token
+
+	plugin._on_eval_liveness_response([rid, true])
+
+	assert_true(plugin.dispatched.is_empty(),
+		"a liveness response from the prior run must not dispatch into the new run")
+	assert_false(plugin._pending.has(rid), "the stale liveness response is consumed")
+	assert_eq(conn.captured.size(), 1, "the stale request receives one failure")
+	assert_eq(conn.captured[0].payload.error.code, ErrorCodes.EVAL_GAME_NOT_READY)
+	conn.free()
+
+
 func test_debugger_session_stop_fails_only_pending_evals() -> void:
 	var plugin := McpDebuggerPlugin.new()
 	plugin._game_run_active = true
 	plugin._game_session_id = 31
 	var eval_conn := _StubConnection.new()
 	var liveness_conn := _StubConnection.new()
+	var readiness_conn := _StubConnection.new()
 	var shot_conn := _StubConnection.new()
 	plugin._pending["rid-eval"] = {"kind": "eval", "connection": eval_conn}
 	plugin._pending["rid-eval-liveness"] = {
 		"kind": "eval_liveness", "connection": liveness_conn
+	}
+	plugin._pending["rid-eval-readiness"] = {
+		"kind": "eval_ready_wait", "connection": readiness_conn
 	}
 	plugin._pending["rid-shot"] = {"connection": shot_conn}
 
@@ -545,6 +617,8 @@ func test_debugger_session_stop_fails_only_pending_evals() -> void:
 		"session close should immediately clear pending evals")
 	assert_false(plugin._pending.has("rid-eval-liveness"),
 		"session close should immediately clear pending liveness probes")
+	assert_false(plugin._pending.has("rid-eval-readiness"),
+		"session close should immediately clear pending readiness waits")
 	assert_true(plugin._pending.has("rid-shot"),
 		"session close should not steal another request kind's timeout ownership")
 	assert_eq(eval_conn.captured.size(), 1, "the eval receives one immediate failure")
@@ -553,11 +627,16 @@ func test_debugger_session_stop_fails_only_pending_evals() -> void:
 		"the liveness probe receives one immediate failure")
 	assert_eq(liveness_conn.captured[0].payload.error.code,
 		ErrorCodes.EVAL_GAME_NOT_READY)
+	assert_eq(readiness_conn.captured.size(), 1,
+		"the readiness wait receives one immediate failure")
+	assert_eq(readiness_conn.captured[0].payload.error.code,
+		ErrorCodes.EVAL_GAME_NOT_READY)
 	assert_eq(plugin.get_game_status().status, "stopped")
 
 	plugin._clear_pending("rid-shot")
 	eval_conn.free()
 	liveness_conn.free()
+	readiness_conn.free()
 	shot_conn.free()
 
 

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -439,12 +439,126 @@ class _StubConnection:
 		captured.append({"request_id": request_id, "payload": payload})
 
 
+## Records the positive liveness transition without requiring a real debugger
+## session. The production method is still covered end-to-end by live smoke.
+class _RecordingEvalPlugin:
+	extends McpDebuggerPlugin
+	var dispatched: Dictionary = {}
+
+	func _send_eval(
+		tree: SceneTree,
+		code: String,
+		request_id: String,
+		connection: McpConnection,
+		timeout_sec: float,
+	) -> void:
+		dispatched = {
+			"tree": tree,
+			"code": code,
+			"request_id": request_id,
+			"connection": connection,
+			"timeout_sec": timeout_sec,
+		}
+
+
 ## Flip a bare plugin's flags so get_game_status() reports "live", the state
 ## the timeout's GAME_HELPER_TIMEOUT branch requires.
 func _mark_game_live(plugin: McpDebuggerPlugin) -> void:
 	plugin._game_run_active = true
 	plugin._game_ready = true
 	plugin._ready_run_token = plugin._game_run_token
+
+
+# ----- #859: game_eval liveness gate + session-close fast failure -----
+
+func test_eval_liveness_positive_response_dispatches_eval() -> void:
+	var plugin := _RecordingEvalPlugin.new()
+	var conn := _StubConnection.new()
+	var rid := "rid-eval-live"
+	plugin._pending[rid] = {
+		"kind": "eval_liveness",
+		"connection": conn,
+		"code": "return 42",
+		"eval_timeout_sec": 7.5,
+	}
+	assert_true(plugin._capture("mcp:eval_liveness_response", [rid, true], 0),
+		"the editor should capture positive helper liveness replies")
+	assert_false(plugin._pending.has(rid), "the liveness reply clears the probe")
+	assert_eq(plugin.dispatched.code, "return 42")
+	assert_eq(plugin.dispatched.request_id, rid)
+	assert_eq(plugin.dispatched.connection, conn)
+	assert_eq(plugin.dispatched.timeout_sec, 7.5)
+	assert_eq(conn.captured.size(), 0, "a live probe should not emit an error")
+	conn.free()
+
+func test_eval_liveness_negative_response_fails_fast() -> void:
+	var plugin := McpDebuggerPlugin.new()
+	var conn := _StubConnection.new()
+	var rid := "rid-eval-not-live"
+	plugin._pending[rid] = {
+		"kind": "eval_liveness",
+		"connection": conn,
+		"code": "return 1",
+		"eval_timeout_sec": 10.0,
+	}
+	assert_true(plugin._capture("mcp:eval_liveness_response", [rid, false], 0),
+		"the editor should capture helper liveness replies")
+	assert_false(plugin._pending.has(rid), "the liveness reply clears the probe")
+	assert_eq(conn.captured.size(), 1, "one deferred failure reply")
+	var error: Dictionary = conn.captured[0].payload.error
+	assert_eq(error.code, ErrorCodes.EVAL_GAME_NOT_READY)
+	assert_contains(error.message, "backgrounded",
+		"the fast failure should preserve the existing recovery hint")
+	conn.free()
+
+
+func test_eval_liveness_timeout_fails_fast() -> void:
+	var plugin := McpDebuggerPlugin.new()
+	var conn := _StubConnection.new()
+	var rid := "rid-eval-probe-timeout"
+	plugin._pending[rid] = {"kind": "eval_liveness", "connection": conn}
+	plugin._on_eval_liveness_timeout(rid)
+	assert_false(plugin._pending.has(rid), "the timeout clears the probe")
+	assert_eq(conn.captured.size(), 1, "one deferred failure reply")
+	var error: Dictionary = conn.captured[0].payload.error
+	assert_eq(error.code, ErrorCodes.EVAL_GAME_NOT_READY)
+	assert_contains(error.message, "250ms", "the message states the fast budget")
+	conn.free()
+
+
+func test_debugger_session_stop_fails_only_pending_evals() -> void:
+	var plugin := McpDebuggerPlugin.new()
+	plugin._game_run_active = true
+	plugin._game_session_id = 31
+	var eval_conn := _StubConnection.new()
+	var liveness_conn := _StubConnection.new()
+	var shot_conn := _StubConnection.new()
+	plugin._pending["rid-eval"] = {"kind": "eval", "connection": eval_conn}
+	plugin._pending["rid-eval-liveness"] = {
+		"kind": "eval_liveness", "connection": liveness_conn
+	}
+	plugin._pending["rid-shot"] = {"connection": shot_conn}
+
+	plugin._on_debugger_session_stopped(31)
+
+	assert_false(plugin._pending.has("rid-eval"),
+		"session close should immediately clear pending evals")
+	assert_false(plugin._pending.has("rid-eval-liveness"),
+		"session close should immediately clear pending liveness probes")
+	assert_true(plugin._pending.has("rid-shot"),
+		"session close should not steal another request kind's timeout ownership")
+	assert_eq(eval_conn.captured.size(), 1, "the eval receives one immediate failure")
+	assert_eq(eval_conn.captured[0].payload.error.code, ErrorCodes.EVAL_GAME_NOT_READY)
+	assert_eq(liveness_conn.captured.size(), 1,
+		"the liveness probe receives one immediate failure")
+	assert_eq(liveness_conn.captured[0].payload.error.code,
+		ErrorCodes.EVAL_GAME_NOT_READY)
+	assert_eq(plugin.get_game_status().status, "stopped")
+
+	plugin._clear_pending("rid-shot")
+	eval_conn.free()
+	liveness_conn.free()
+	shot_conn.free()
 
 
 func test_screenshot_response_plumbs_stale_metadata() -> void:

--- a/test_project/tests/test_game_eval_errors.gd
+++ b/test_project/tests/test_game_eval_errors.gd
@@ -431,7 +431,12 @@ func test_eval_timeout_replies_eval_hung_when_game_live() -> void:
 	_mark_game_live(plugin)
 	var conn := _StubConnection.new()
 	var rid := "rid-timeout-live"
-	plugin._pending[rid] = {"connection": conn, "acked": true, "compiled": true}
+	plugin._pending[rid] = {
+		"connection": conn,
+		"run_token": plugin._game_run_token,
+		"acked": true,
+		"compiled": true,
+	}
 	plugin._on_eval_timeout(rid, 10.0)
 	assert_false(plugin._pending.has(rid), "the timeout clears the pending entry")
 	assert_eq(conn.captured.size(), 1, "one deferred reply")
@@ -451,7 +456,12 @@ func test_eval_timeout_unacked_names_unserviced_eval() -> void:
 	_mark_game_live(plugin)
 	var conn := _StubConnection.new()
 	var rid := "rid-timeout-noack"
-	plugin._pending[rid] = {"connection": conn, "acked": false, "compiled": false}
+	plugin._pending[rid] = {
+		"connection": conn,
+		"run_token": plugin._game_run_token,
+		"acked": false,
+		"compiled": false,
+	}
 	plugin._on_eval_timeout(rid, 10.0)
 	var payload: Dictionary = conn.captured[0]["payload"]
 	assert_eq(payload["error"]["code"], ErrorCodes.EVAL_HUNG,
@@ -470,13 +480,49 @@ func test_eval_timeout_replies_not_ready_when_game_in_break() -> void:
 	plugin.note_debug_break(false, "Invalid call. Nonexistent function 'foo' in base 'Nil'.")
 	var conn := _StubConnection.new()
 	var rid := "rid-timeout-break"
-	plugin._pending[rid] = {"connection": conn, "acked": true, "compiled": true}
+	plugin._pending[rid] = {
+		"connection": conn,
+		"run_token": plugin._game_run_token,
+		"acked": true,
+		"compiled": true,
+	}
 	plugin._on_eval_timeout(rid, 10.0)
 	var payload: Dictionary = conn.captured[0]["payload"]
 	assert_eq(payload["error"]["code"], ErrorCodes.EVAL_GAME_NOT_READY,
 		"a break-parked game replies EVAL_GAME_NOT_READY, not a phantom hang")
 	assert_contains(payload["error"]["message"], "debugger break",
 		"the break state is named in the message")
+	conn.free()
+
+
+func test_eval_timeout_from_prior_run_replies_not_ready() -> void:
+	## Model the defensive fallback when replacement-run tracking advances before
+	## an old timeout callback observes the cleanup normally owned by end_game_run().
+	var plugin := McpDebuggerPlugin.new()
+	_mark_game_live(plugin)
+	var original_run_token := plugin._game_run_token
+	var conn := _StubConnection.new()
+	var rid := "rid-timeout-prior-run"
+	plugin._pending[rid] = {
+		"connection": conn,
+		"run_token": original_run_token,
+		"acked": true,
+		"compiled": true,
+	}
+	plugin.begin_game_run()
+	plugin._game_ready = true
+	plugin._ready_run_token = plugin._game_run_token
+
+	plugin._on_eval_timeout(rid, 10.0)
+
+	assert_ne(plugin._game_run_token, original_run_token,
+		"the replacement game must have a distinct run token")
+	assert_false(plugin._pending.has(rid), "the prior-run timeout is consumed")
+	assert_eq(conn.captured.size(), 1, "one deferred failure reply")
+	var payload: Dictionary = conn.captured[0]["payload"]
+	assert_eq(payload["error"]["code"], ErrorCodes.EVAL_GAME_NOT_READY,
+		"a prior-run timeout must not be attributed as a hang in the new game")
+	assert_contains(payload["error"]["message"], "game run changed")
 	conn.free()
 
 

--- a/test_project/tests/test_game_helper.gd
+++ b/test_project/tests/test_game_helper.gd
@@ -286,6 +286,26 @@ func test_main_loop_appears_stalled_uses_threshold() -> void:
 	helper.free()
 
 
+func test_eval_liveness_probe_reports_loop_beacon() -> void:
+	var helper: Node = GameHelper.new()
+	helper._last_loop_tick_msec = Time.get_ticks_msec()
+	assert_true(helper._on_debug_message("mcp:eval_liveness", ["rid-live"]),
+		"the helper should capture eval liveness probes")
+	assert_eq(helper._last_eval_liveness_reply.request_id, "rid-live")
+	assert_eq(helper._last_eval_liveness_reply.loop_live, true,
+		"a recent _process beacon should report a live loop")
+
+	helper._last_loop_tick_msec = (
+		Time.get_ticks_msec() - (GameHelper.MAIN_LOOP_STALL_MSEC + 500)
+	)
+	assert_true(helper._on_debug_message("eval_liveness", ["rid-stalled"]),
+		"the capture should also accept the trimmed action form used by tests")
+	assert_eq(helper._last_eval_liveness_reply.request_id, "rid-stalled")
+	assert_eq(helper._last_eval_liveness_reply.loop_live, false,
+		"a stale _process beacon should report a parked loop")
+	helper.free()
+
+
 func test_rendering_appears_stalled_false_before_first_advance() -> void:
 	## A game that has never presented (booting, render-less) has no
 	## trustworthy frame — the -1 sentinel must read as NOT render-stalled so

--- a/tests/unit/test_game_eval_timeout_ordering.py
+++ b/tests/unit/test_game_eval_timeout_ordering.py
@@ -1,26 +1,26 @@
-"""Contract test: the game_eval timeout ladder stays ordered.
+"""Contract tests: the game_eval/game_command timeout ladders stay ordered.
 
-The timeout contract spans four files with no shared constant across the
+The timeout contracts span several files with no shared constant across the
 Python/GDScript boundary, so this test scrapes each source of truth and enforces
-the ladder:
+both ladders:
 
     game (8s) < editor (10s)
     liveness (0.25s) + editor (10s) < dispatcher (15s)
     ready-wait (3s) + liveness + editor < dispatcher == server (15s)
+    run-ready (3s) + game-command editor (10s) < dispatcher == server (15s)
 
 - **game**: ``game_helper.gd::EVAL_TIMEOUT_SEC`` — the only tier that can
   name the hung await ("Eval exceeded 8s"). If it rises to/above the editor
   timer, the less specific editor message wins the race and the diagnostic
   is silently lost (#487/#518).
-- **editor**: ``mcp_debugger_plugin.gd::request_game_eval``'s
-  ``timeout_sec`` default.
-- **ready-wait**: ``mcp_debugger_plugin.gd::EVAL_READY_WAIT_SEC`` — stacked
-  on top of the liveness probe and editor timer when the helper has not yet
-  registered; the sum must still beat the dispatcher budget.
+- **editor**: ``mcp_debugger_plugin.gd`` ``timeout_sec`` defaults on the
+  ``request_game_eval`` and ``request_game_command`` entry points.
+- **ready-waits**: ``mcp_debugger_plugin.gd::EVAL_READY_WAIT_SEC`` for eval
+  and ``project_handler.gd::RUN_READY_WAIT_SEC`` for the run path.
 - **dispatcher/server**: ``dispatcher.gd::DEFERRED_TIMEOUT_MS_BY_COMMAND``
-  and ``handlers/editor.py::game_eval`` — the outermost budgets; if either
-  undercuts the inner tiers, the deferred reply is dropped as expired and
-  the actionable message never reaches the agent.
+  plus the Python handler budgets — the outermost layers; if either undercuts
+  the inner tiers, the deferred reply is dropped as expired and the actionable
+  message never reaches the agent.
 
 Source-scraping pattern per test_dock_cli_timeout.py /
 test_deferred_timeout_contract.py.
@@ -30,6 +30,8 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+
+from godot_ai.handlers.game import GAME_COMMAND_TIMEOUT_SEC
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PLUGIN_ROOT = REPO_ROOT / "plugin" / "addons" / "godot_ai"
@@ -56,10 +58,24 @@ def _editor_eval_timeout_sec() -> float:
     )
 
 
+def _editor_game_command_timeout_sec() -> float:
+    return _scrape_float(
+        PLUGIN_ROOT / "debugger" / "mcp_debugger_plugin.gd",
+        r"^func request_game_command\([\s\S]*?^\ttimeout_sec: float = ([0-9.]+),",
+    )
+
+
 def _ready_wait_sec() -> float:
     return _scrape_float(
         PLUGIN_ROOT / "debugger" / "mcp_debugger_plugin.gd",
         r"^const EVAL_READY_WAIT_SEC := ([0-9.]+)",
+    )
+
+
+def _run_ready_wait_sec() -> float:
+    return _scrape_float(
+        PLUGIN_ROOT / "handlers" / "project_handler.gd",
+        r"^const RUN_READY_WAIT_SEC := ([0-9.]+)",
     )
 
 
@@ -70,17 +86,22 @@ def _eval_liveness_wait_sec() -> float:
     )
 
 
-def _dispatcher_budget_sec() -> float:
-    return _scrape_float(
-        PLUGIN_ROOT / "dispatcher.gd",
-        r'^\s*"game_eval":\s*(\d+),',
-    ) / 1000.0
+def _dispatcher_budget_secs() -> dict[str, float]:
+    source = (PLUGIN_ROOT / "dispatcher.gd").read_text(encoding="utf-8")
+    budgets = {
+        name: int(ms) / 1000.0
+        for name, ms in re.findall(r'"(game_eval|game_command)":\s*(\d+)', source)
+    }
+    assert set(budgets) == {"game_eval", "game_command"}, (
+        f"expected both game_* entries in DEFERRED_TIMEOUT_MS_BY_COMMAND, got {budgets}"
+    )
+    return budgets
 
 
-def _server_timeout_sec() -> float:
+def _server_eval_timeout_sec() -> float:
     return _scrape_float(
         REPO_ROOT / "src" / "godot_ai" / "handlers" / "editor.py",
-        r'^async def game_eval\([\s\S]*?timeout=([0-9.]+)\)',
+        r"^async def game_eval\([\s\S]*?timeout=([0-9.]+)\)",
     )
 
 
@@ -103,7 +124,7 @@ def test_eval_liveness_probe_stays_sub_half_second() -> None:
 
 def test_editor_fallback_stays_below_dispatcher_budget() -> None:
     stacked = _eval_liveness_wait_sec() + _editor_eval_timeout_sec()
-    budget = _dispatcher_budget_sec()
+    budget = _dispatcher_budget_secs()["game_eval"]
     assert stacked < budget, (
         f"liveness probe + editor fallback ({stacked}s) must stay below the "
         f"game_eval dispatcher budget ({budget}s) or the deferred reply is "
@@ -112,23 +133,47 @@ def test_editor_fallback_stays_below_dispatcher_budget() -> None:
 
 
 def test_ready_wait_plus_editor_stays_below_dispatcher_budget() -> None:
-    stacked = (
-        _ready_wait_sec()
-        + _eval_liveness_wait_sec()
-        + _editor_eval_timeout_sec()
-    )
-    budget = _dispatcher_budget_sec()
+    stacked = _ready_wait_sec() + _eval_liveness_wait_sec() + _editor_eval_timeout_sec()
+    budget = _dispatcher_budget_secs()["game_eval"]
     assert stacked < budget, (
         f"ready wait + liveness probe + editor fallback ({stacked}s) must stay "
         f"below the game_eval dispatcher budget ({budget}s)"
     )
 
 
-def test_server_timeout_covers_dispatcher_budget() -> None:
-    server = _server_timeout_sec()
-    dispatcher = _dispatcher_budget_sec()
+def test_game_command_editor_fallback_stays_below_dispatcher_budgets() -> None:
+    editor = _editor_game_command_timeout_sec()
+    for name, budget in _dispatcher_budget_secs().items():
+        assert editor < budget, (
+            f"game_command editor fallback ({editor}s) must stay below the "
+            f"dispatcher's {name} budget ({budget}s) or the deferred reply is "
+            "dropped as expired before the editor can answer"
+        )
+
+
+def test_run_ready_wait_plus_game_command_stays_below_dispatcher_budgets() -> None:
+    stacked = _run_ready_wait_sec() + _editor_game_command_timeout_sec()
+    for name, budget in _dispatcher_budget_secs().items():
+        assert stacked < budget, (
+            f"RUN_READY_WAIT_SEC + game_command editor fallback ({stacked}s) "
+            f"must stay below the dispatcher's {name} budget ({budget}s)"
+        )
+
+
+def test_eval_server_timeout_covers_dispatcher_budget() -> None:
+    server = _server_eval_timeout_sec()
+    dispatcher = _dispatcher_budget_secs()["game_eval"]
     assert server >= dispatcher, (
         f"server game_eval timeout ({server}s) must not undercut the dispatcher "
         f"budget ({dispatcher}s) — the server would time out first and "
         "misattribute the failure"
     )
+
+
+def test_game_command_server_timeout_covers_dispatcher_budgets() -> None:
+    for name, budget in _dispatcher_budget_secs().items():
+        assert GAME_COMMAND_TIMEOUT_SEC >= budget, (
+            f"server GAME_COMMAND_TIMEOUT_SEC ({GAME_COMMAND_TIMEOUT_SEC}s) "
+            f"must not undercut the dispatcher's {name} budget ({budget}s) — "
+            "the server would time out first and misattribute the failure"
+        )

--- a/tests/unit/test_game_eval_timeout_ordering.py
+++ b/tests/unit/test_game_eval_timeout_ordering.py
@@ -1,28 +1,29 @@
-"""Contract test: the game_eval/game_command timeout ladder stays ordered.
+"""Contract test: the game_eval timeout ladder stays ordered.
 
-The four-tier timeout contract spans four files and, by its own admission
-(game_helper.gd's "TIMEOUT ORDERING — load-bearing across three files ...
-Nothing enforces the order — change one, re-check the other two"), had no
-enforcement. The ladder:
+The timeout contract spans four files with no shared constant across the
+Python/GDScript boundary, so this test scrapes each source of truth and enforces
+the ladder:
 
-    game (8s)  <  editor (10s)  <  ready-wait + editor (3+10s)  <  dispatcher (15s) == server (15s)
+    game (8s) < editor (10s)
+    liveness (0.25s) + editor (10s) < dispatcher (15s)
+    ready-wait (3s) + liveness + editor < dispatcher == server (15s)
 
 - **game**: ``game_helper.gd::EVAL_TIMEOUT_SEC`` — the only tier that can
   name the hung await ("Eval exceeded 8s"). If it rises to/above the editor
   timer, the less specific editor message wins the race and the diagnostic
   is silently lost (#487/#518).
-- **editor**: ``mcp_debugger_plugin.gd`` ``timeout_sec`` defaults on the
-  request_game_* entry points.
-- **ready-wait**: ``project_handler.gd::RUN_READY_WAIT_SEC`` — stacked on
-  top of the editor timer on the run path; the sum must still beat the
-  dispatcher budget.
+- **editor**: ``mcp_debugger_plugin.gd::request_game_eval``'s
+  ``timeout_sec`` default.
+- **ready-wait**: ``mcp_debugger_plugin.gd::EVAL_READY_WAIT_SEC`` — stacked
+  on top of the liveness probe and editor timer when the helper has not yet
+  registered; the sum must still beat the dispatcher budget.
 - **dispatcher/server**: ``dispatcher.gd::DEFERRED_TIMEOUT_MS_BY_COMMAND``
-  and ``handlers/game.py::GAME_COMMAND_TIMEOUT_SEC`` — the outermost
-  budgets; if either undercuts the inner tiers, the deferred reply is
-  dropped as expired and the actionable message never reaches the agent.
+  and ``handlers/editor.py::game_eval`` — the outermost budgets; if either
+  undercuts the inner tiers, the deferred reply is dropped as expired and
+  the actionable message never reaches the agent.
 
-Audit backlog item (S3 · drift, game_helper.gd:640). Source-scraping
-pattern per test_dock_cli_timeout.py / test_deferred_timeout_contract.py.
+Source-scraping pattern per test_dock_cli_timeout.py /
+test_deferred_timeout_contract.py.
 """
 
 from __future__ import annotations
@@ -30,9 +31,8 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from godot_ai.handlers.game import GAME_COMMAND_TIMEOUT_SEC
-
-PLUGIN_ROOT = Path(__file__).resolve().parents[2] / "plugin" / "addons" / "godot_ai"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_ROOT = REPO_ROOT / "plugin" / "addons" / "godot_ai"
 
 
 def _scrape_float(path: Path, pattern: str) -> float:
@@ -42,13 +42,6 @@ def _scrape_float(path: Path, pattern: str) -> float:
     return float(match.group(1))
 
 
-def _scrape_all_floats(path: Path, pattern: str) -> list[float]:
-    source = path.read_text(encoding="utf-8")
-    values = [float(v) for v in re.findall(pattern, source, re.MULTILINE)]
-    assert values, f"pattern {pattern!r} not found in {path}"
-    return values
-
-
 def _game_timeout_sec() -> float:
     return _scrape_float(
         PLUGIN_ROOT / "runtime" / "game_helper.gd",
@@ -56,67 +49,86 @@ def _game_timeout_sec() -> float:
     )
 
 
-def _editor_timeout_secs() -> list[float]:
-    ## Both request_game_eval and request_game_command carry the default.
-    return _scrape_all_floats(
+def _editor_eval_timeout_sec() -> float:
+    return _scrape_float(
         PLUGIN_ROOT / "debugger" / "mcp_debugger_plugin.gd",
-        r"^\ttimeout_sec: float = ([0-9.]+),",
+        r"^func request_game_eval\([\s\S]*?^\ttimeout_sec: float = ([0-9.]+),",
     )
 
 
 def _ready_wait_sec() -> float:
     return _scrape_float(
-        PLUGIN_ROOT / "handlers" / "project_handler.gd",
-        r"^const RUN_READY_WAIT_SEC := ([0-9.]+)",
+        PLUGIN_ROOT / "debugger" / "mcp_debugger_plugin.gd",
+        r"^const EVAL_READY_WAIT_SEC := ([0-9.]+)",
     )
 
 
-def _dispatcher_budget_secs() -> dict[str, float]:
-    source = (PLUGIN_ROOT / "dispatcher.gd").read_text(encoding="utf-8")
-    budgets = {
-        name: int(ms) / 1000.0
-        for name, ms in re.findall(r'"(game_eval|game_command)":\s*(\d+)', source)
-    }
-    assert set(budgets) == {"game_eval", "game_command"}, (
-        f"expected both game_* entries in DEFERRED_TIMEOUT_MS_BY_COMMAND, got {budgets}"
+def _eval_liveness_wait_sec() -> float:
+    return _scrape_float(
+        PLUGIN_ROOT / "debugger" / "mcp_debugger_plugin.gd",
+        r"^const EVAL_LIVENESS_WAIT_SEC := ([0-9.]+)",
     )
-    return budgets
+
+
+def _dispatcher_budget_sec() -> float:
+    return _scrape_float(
+        PLUGIN_ROOT / "dispatcher.gd",
+        r'^\s*"game_eval":\s*(\d+),',
+    ) / 1000.0
+
+
+def _server_timeout_sec() -> float:
+    return _scrape_float(
+        REPO_ROOT / "src" / "godot_ai" / "handlers" / "editor.py",
+        r'^async def game_eval\([\s\S]*?timeout=([0-9.]+)\)',
+    )
 
 
 def test_game_guard_stays_below_editor_fallback() -> None:
     game = _game_timeout_sec()
-    for editor in _editor_timeout_secs():
-        assert game < editor, (
-            f"game EVAL_TIMEOUT_SEC ({game}s) must stay below the editor "
-            f"fallback ({editor}s) or the specific 'Eval exceeded' "
-            f"diagnostic loses the race to the generic editor message"
-        )
+    editor = _editor_eval_timeout_sec()
+    assert game < editor, (
+        f"game EVAL_TIMEOUT_SEC ({game}s) must stay below the editor "
+        f"fallback ({editor}s) or the specific 'Eval exceeded' "
+        f"diagnostic loses the race to the generic editor message"
+    )
+
+
+def test_eval_liveness_probe_stays_sub_half_second() -> None:
+    assert _eval_liveness_wait_sec() < 0.5, (
+        "the #859 pre-dispatch liveness probe must fail non-live game_eval "
+        "calls inside the telemetry target of 0.5s"
+    )
 
 
 def test_editor_fallback_stays_below_dispatcher_budget() -> None:
-    budgets = _dispatcher_budget_secs()
-    for editor in _editor_timeout_secs():
-        for name, budget in budgets.items():
-            assert editor < budget, (
-                f"editor fallback ({editor}s) must stay below the "
-                f"dispatcher's {name} budget ({budget}s) or the deferred "
-                f"reply is dropped as expired before the editor can answer"
-            )
+    stacked = _eval_liveness_wait_sec() + _editor_eval_timeout_sec()
+    budget = _dispatcher_budget_sec()
+    assert stacked < budget, (
+        f"liveness probe + editor fallback ({stacked}s) must stay below the "
+        f"game_eval dispatcher budget ({budget}s) or the deferred reply is "
+        "dropped as expired before the editor can answer"
+    )
 
 
 def test_ready_wait_plus_editor_stays_below_dispatcher_budget() -> None:
-    stacked = _ready_wait_sec() + max(_editor_timeout_secs())
-    for name, budget in _dispatcher_budget_secs().items():
-        assert stacked < budget, (
-            f"RUN_READY_WAIT_SEC + editor fallback ({stacked}s) must stay "
-            f"below the dispatcher's {name} budget ({budget}s)"
-        )
+    stacked = (
+        _ready_wait_sec()
+        + _eval_liveness_wait_sec()
+        + _editor_eval_timeout_sec()
+    )
+    budget = _dispatcher_budget_sec()
+    assert stacked < budget, (
+        f"ready wait + liveness probe + editor fallback ({stacked}s) must stay "
+        f"below the game_eval dispatcher budget ({budget}s)"
+    )
 
 
 def test_server_timeout_covers_dispatcher_budget() -> None:
-    for name, budget in _dispatcher_budget_secs().items():
-        assert GAME_COMMAND_TIMEOUT_SEC >= budget, (
-            f"server GAME_COMMAND_TIMEOUT_SEC ({GAME_COMMAND_TIMEOUT_SEC}s) "
-            f"must not undercut the dispatcher's {name} budget ({budget}s) — "
-            f"the server would time out first and misattribute the failure"
-        )
+    server = _server_timeout_sec()
+    dispatcher = _dispatcher_budget_sec()
+    assert server >= dispatcher, (
+        f"server game_eval timeout ({server}s) must not undercut the dispatcher "
+        f"budget ({dispatcher}s) — the server would time out first and "
+        "misattribute the failure"
+    )


### PR DESCRIPTION
## Summary

- Add a synchronous game-side liveness probe before dispatching `game_eval`, using the existing main-loop beacon.
- Return `EVAL_GAME_NOT_READY` within the probe window when the helper is registered but the main loop is stale or unresponsive.
- Fail pending eval/liveness requests immediately when the debugger session ends, while preserving timeout ownership for unrelated requests.
- Keep Python/GDScript documentation and cross-layer timeout contracts aligned.

## Validation

- Normal `game_eval`: 267.5 ms, returned `42`.
- Stale helper beacon: 201.3 ms, returned `EVAL_GAME_NOT_READY`.
- Game stopped during a 5-second await: 648.6 ms, returned `EVAL_GAME_NOT_READY`.

Fixes #859

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved evaluation reliability by checking whether the game loop is active before starting.
  * Evaluations now fail promptly with clearer guidance when the game is inactive, stalled, unresponsive, or the debugger closes.
  * Prevented responses from previous game runs from affecting new evaluations.
  * Cleaned up pending evaluations when a game run ends.

* **Documentation**
  * Clarified readiness errors, timeout behavior, and guidance for backgrounded or stalled games.

* **Tests**
  * Added coverage for liveness checks, timeout ordering, stale responses, and debugger shutdown scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->