### PR TITLE
fix(clients): post-#873 scope follow-ups — test hermeticity, sweep transparency, probe coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,17 @@ clears `godot-ai` out of every scope before writing the new one, so the old
 entry doesn't linger. **Remove**, by contrast, only targets the scope that is
 currently selected, so switch back before removing if you changed the setting.
 
+> [!IMPORTANT]
+> That clearing step runs at **every** setting, including the default `user`.
+> One of its passes is `claude mcp remove --scope project godot-ai`, which
+> rewrites the `.mcp.json` in the client CLI's working directory — see the
+> first caveat below for why that is not necessarily this project's folder. If
+> a repository keeps a hand-maintained `godot-ai` entry in a checked-in
+> `.mcp.json`, pressing **Configure** deletes that entry and leaves the file
+> dirty. Only a key named `godot-ai` is touched; other servers are left in
+> place. The dock's "Run this manually" text lists these removes alongside the
+> register line so you can see exactly what Configure will run.
+
 Two caveats for `project` scope:
 
 - The client CLI resolves the project config against **its own working

--- a/README.md
+++ b/README.md
@@ -132,8 +132,10 @@ currently selected, so switch back before removing if you changed the setting.
 > `.mcp.json`, pressing **Configure** deletes that entry and leaves the file
 > dirty. Only a key named `godot-ai` is touched; other servers are left in
 > place. After a successful **Configure** the client's row names the scopes it
-> cleared; if Configure fails, the dock's "Run this manually" text lists these
-> removes alongside the register line so you can run them yourself.
+> attempted to clear (the remove results are not checked, so a scope can be
+> listed without its removal having succeeded); if Configure fails, the dock's
+> "Run this manually" text lists these removes alongside the register line so
+> you can run them yourself.
 
 Two caveats for `project` scope:
 

--- a/README.md
+++ b/README.md
@@ -131,8 +131,9 @@ currently selected, so switch back before removing if you changed the setting.
 > a repository keeps a hand-maintained `godot-ai` entry in a checked-in
 > `.mcp.json`, pressing **Configure** deletes that entry and leaves the file
 > dirty. Only a key named `godot-ai` is touched; other servers are left in
-> place. The dock's "Run this manually" text lists these removes alongside the
-> register line so you can see exactly what Configure will run.
+> place. After a successful **Configure** the client's row names the scopes it
+> cleared; if Configure fails, the dock's "Run this manually" text lists these
+> removes alongside the register line so you can run them yourself.
 
 Two caveats for `project` scope:
 

--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -828,15 +828,37 @@ static func _post_state_path_hint(client: Client, resolved_scope: String) -> Str
 				+ " by hand if needed."
 			)
 		"local":
+			var local_path := client.resolved_config_path()
+			if local_path.is_empty():
+				return ""
 			return (
-				" The surviving entry is local-scoped: inspect this project's block in %s"
-				+ " and remove the godot-ai entry by hand if needed."
-			) % client.resolved_config_path()
+				" The surviving entry is local-scoped: inspect the block for the"
+				+ " directory the editor was launched from in %s and remove the"
+				+ " godot-ai entry by hand if needed."
+			) % local_path
 		_:
 			var path := client.resolved_config_path()
 			if path.is_empty():
 				return ""
 			return " Inspect %s and remove the godot-ai entry by hand if needed." % path
+
+
+## #877: Configure's first act is the all-scope pre-cleanup — it deletes the
+## `godot-ai` entry from every scope the descriptor can write to, including a
+## `.mcp.json` resolved against the CLI's working directory, which need not be
+## this project's folder. The manual-command panel that spells those removes
+## out is only shown when Configure FAILS (`mcp_dock.gd`), so on the success
+## path — the one where the sweep actually ran — this note is its only
+## disclosure. Empty for descriptors without a scope token: their single
+## implicit pass removes exactly the entry the register is about to rewrite,
+## which needs no warning (the same rule `_sweep_caveat` applies).
+static func configure_sweep_note(id: String) -> String:
+	var client := ClientRegistry.get_by_id(id)
+	if client == null or client.config_type != "cli":
+		return ""
+	if client.cli_unregister_template.is_empty() or not CliStrategy.uses_scope_token(client):
+		return ""
+	return "cleared %s from %s" % [SERVER_NAME, ", ".join(CliStrategy.cleanup_scopes(client))]
 
 
 static func manual_command(id: String) -> String:

--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -672,7 +672,7 @@ static func _dispatch_check_status_with_cli_path_details(
 			if (
 				client.command_shape != Client.CommandShape.NONE
 				and client.has_json_fallback()
-				and not _scope_diverges_from_json_fallback(client, cli_path)
+				and not _scope_diverges_from_json_fallback(client)
 			):
 				var command_launch := _resolved_or_discovered_launch(client, resolved_launch, launch_context)
 				return JsonStrategy.check_status_details(client, SERVER_NAME, url, command_launch)
@@ -754,18 +754,20 @@ static func _note_unhonoured_scope(client: Client, result: Dictionary) -> Dictio
 ## detection — a stdout scan sees the command, not the full argv — which is the
 ## documented trade for a status that is merely coarse instead of wrong.
 ##
-## Ordering matters: the token check and the scope compare both short-circuit
-## for every non-`{scope}` descriptor and for the default user scope, so the
-## PATH walk only runs when the answer can actually be true. An unresolvable
-## CLI means configure took the #463 JSON fallback, which writes user scope
-## whatever the setting says — so the file is the right thing to read again.
-static func _scope_diverges_from_json_fallback(client: Client, cli_path: String) -> bool:
+## Deliberately says nothing about whether the CLI resolves (#879). An earlier
+## version walked PATH here and returned false for an unresolvable binary, on
+## the reasoning that configure would then have taken the #463 JSON fallback —
+## which writes user scope whatever the setting says — so the file was the
+## right thing to read again. That extra clause could not change any outcome:
+## this is only consulted from the one call site below, already guarded on
+## `has_json_fallback()`, and when the CLI does not resolve the very next
+## branch (`resolved_cli.is_empty() and client.has_json_fallback()`) takes the
+## fallback read anyway. All it bought was a second full `McpCliFinder.find`
+## sweep per status check, on top of the one that immediately follows.
+static func _scope_diverges_from_json_fallback(client: Client) -> bool:
 	if not CliStrategy.uses_scope_token(client):
 		return false
-	if McpSettings.client_scope() == McpSettings.DEFAULT_CLIENT_SCOPE:
-		return false
-	var resolved := cli_path if not cli_path.is_empty() else CliStrategy.resolve_cli_path(client)
-	return not resolved.is_empty()
+	return McpSettings.client_scope() != McpSettings.DEFAULT_CLIENT_SCOPE
 
 
 static func _resolved_or_discovered_launch(
@@ -793,13 +795,25 @@ static func _verify_post_state(
 ) -> Dictionary:
 	if result.get("status") != "ok":
 		return result
-	var actual := _dispatch_check_status_with_cli_path_details(
+	var details := _dispatch_check_status_with_cli_path_details(
 		client, url, "", {}, resolved_launch
-	).get("status", Client.Status.NOT_CONFIGURED)
+	)
+	var actual := details.get("status", Client.Status.NOT_CONFIGURED)
 	if actual == expected:
 		return result
+	## #879: prefer whatever the probe actually learned. `resolved_config_path()`
+	## is always `path_template` (~/.claude.json for Claude Code), which is the
+	## wrong place to send the user when the entry that survived lives in
+	## another scope — a project-scope survivor is in <cwd>/.mcp.json, and the
+	## scope probe already put "registered at user scope, not project" in
+	## error_msg. Naming a file with nothing in it is worse than naming none.
+	var probe_note := str(details.get("error_msg", "")).strip_edges()
 	var path := client.resolved_config_path()
-	var path_hint := "" if path.is_empty() else " Inspect %s and remove the godot-ai entry by hand if needed." % path
+	var path_hint := ""
+	if not probe_note.is_empty():
+		path_hint = " Probe reports: %s — remove the godot-ai entry from that scope by hand if needed." % probe_note
+	elif not path.is_empty():
+		path_hint = " Inspect %s and remove the godot-ai entry by hand if needed." % path
 	return {
 		"status": "error",
 		"message": "%s reported %s ok but verification still reads %s (expected %s).%s" % [

--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -801,19 +801,7 @@ static func _verify_post_state(
 	var actual := details.get("status", Client.Status.NOT_CONFIGURED)
 	if actual == expected:
 		return result
-	## #879: prefer whatever the probe actually learned. `resolved_config_path()`
-	## is always `path_template` (~/.claude.json for Claude Code), which is the
-	## wrong place to send the user when the entry that survived lives in
-	## another scope — a project-scope survivor is in <cwd>/.mcp.json, and the
-	## scope probe already put "registered at user scope, not project" in
-	## error_msg. Naming a file with nothing in it is worse than naming none.
-	var probe_note := str(details.get("error_msg", "")).strip_edges()
-	var path := client.resolved_config_path()
-	var path_hint := ""
-	if not probe_note.is_empty():
-		path_hint = " Probe reports: %s — remove the godot-ai entry from that scope by hand if needed." % probe_note
-	elif not path.is_empty():
-		path_hint = " Inspect %s and remove the godot-ai entry by hand if needed." % path
+	var path_hint := _post_state_path_hint(client, str(details.get("resolved_scope", "")))
 	return {
 		"status": "error",
 		"message": "%s reported %s ok but verification still reads %s (expected %s).%s" % [
@@ -822,6 +810,33 @@ static func _verify_post_state(
 			path_hint,
 		],
 	}
+
+
+## Where to send the user when verification finds an entry that should not be
+## there. `resolved_config_path()` is `path_template` — right only for the
+## default user scope. Naming ~/.claude.json for a project-scope survivor sends
+## them to a file with nothing in it, which is worse than naming no file at all
+## (#879). The scope probe supplies `resolved_scope`; `path_template` has no
+## project-relative token (see `_note_unhonoured_scope`), so the project case is
+## described rather than resolved to a path.
+static func _post_state_path_hint(client: Client, resolved_scope: String) -> String:
+	match resolved_scope:
+		"project":
+			return (
+				" The surviving entry is project-scoped: inspect the .mcp.json in the"
+				+ " directory the editor was launched from and remove the godot-ai entry"
+				+ " by hand if needed."
+			)
+		"local":
+			return (
+				" The surviving entry is local-scoped: inspect this project's block in %s"
+				+ " and remove the godot-ai entry by hand if needed."
+			) % client.resolved_config_path()
+		_:
+			var path := client.resolved_config_path()
+			if path.is_empty():
+				return ""
+			return " Inspect %s and remove the godot-ai entry by hand if needed." % path
 
 
 static func manual_command(id: String) -> String:

--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -852,13 +852,21 @@ static func _post_state_path_hint(client: Client, resolved_scope: String) -> Str
 ## disclosure. Empty for descriptors without a scope token: their single
 ## implicit pass removes exactly the entry the register is about to rewrite,
 ## which needs no warning (the same rule `_sweep_caveat` applies).
+##
+## "attempted", not "cleared": `CliStrategy.configure` discards every
+## pre-cleanup result, and `mcp remove` exits non-zero for an absent entry as
+## well as for a real failure, so a timed-out or failed remove leaves the scope
+## untouched while the register still returns ok. The note names what ran,
+## not what it can prove.
 static func configure_sweep_note(id: String) -> String:
 	var client := ClientRegistry.get_by_id(id)
 	if client == null or client.config_type != "cli":
 		return ""
 	if client.cli_unregister_template.is_empty() or not CliStrategy.uses_scope_token(client):
 		return ""
-	return "cleared %s from %s" % [SERVER_NAME, ", ".join(CliStrategy.cleanup_scopes(client))]
+	return "attempted to clear %s from %s" % [
+		SERVER_NAME, ", ".join(CliStrategy.cleanup_scopes(client)),
+	]
 
 
 static func manual_command(id: String) -> String:

--- a/plugin/addons/godot_ai/clients/_cli_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_cli_strategy.gd
@@ -320,10 +320,16 @@ static func _scope_probe_verdict(
 	if resolved.is_empty():
 		return _status_details(McpClient.Status.CONFIGURED)
 	if resolved != expected_scope:
-		return _status_details(
+		## `resolved_scope` rides along as structured data so callers can act
+		## on it — `_verify_post_state`'s path hint needs to know WHICH scope
+		## survived to name the right file, and parsing it back out of the
+		## human-facing message would couple that hint to this wording (#879).
+		var details := _status_details(
 			McpClient.Status.CONFIGURED_MISMATCH,
 			"registered at %s scope, not %s" % [resolved, expected_scope],
 		)
+		details["resolved_scope"] = resolved
+		return details
 	return _status_details(McpClient.Status.CONFIGURED)
 
 
@@ -333,6 +339,12 @@ static func _scope_probe_verdict(
 ## the JSON-fallback file is still a valid place to read status back from.
 static func uses_scope_token(client: McpClient) -> bool:
 	return client.cli_register_template.has(SCOPE_TOKEN)
+
+
+## Public view of the pre-cleanup sweep, for the manual-command text: what the
+## dock tells the user to run has to match what Configure actually runs (#877).
+static func cleanup_scopes(client: McpClient) -> Array[String]:
+	return _cleanup_scopes(client)
 
 
 ## Scopes the configure pre-cleanup removes from. A descriptor without the

--- a/plugin/addons/godot_ai/clients/_cli_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_cli_strategy.gd
@@ -314,16 +314,21 @@ static func _scope_probe_verdict(
 ) -> Dictionary:
 	if exit_code != 0:
 		return _status_details(McpClient.Status.NOT_CONFIGURED)
-	if not expected_target.is_empty() and text.find(expected_target) < 0:
-		return _status_details(McpClient.Status.CONFIGURED_MISMATCH)
+	## `resolved_scope` rides along as structured data so callers can act on it
+	## — `_verify_post_state`'s path hint needs to know WHICH scope survived to
+	## name the right file, and parsing it back out of the human-facing message
+	## would couple that hint to this wording (#879). Parsed BEFORE the target
+	## check so both mismatch paths carry it: an entry whose launcher drifted
+	## sends the user to the wrong file just as readily as one whose scope did.
 	var resolved := _scope_from_probe_output(text)
+	if not expected_target.is_empty() and text.find(expected_target) < 0:
+		var drifted := _status_details(McpClient.Status.CONFIGURED_MISMATCH)
+		if not resolved.is_empty():
+			drifted["resolved_scope"] = resolved
+		return drifted
 	if resolved.is_empty():
 		return _status_details(McpClient.Status.CONFIGURED)
 	if resolved != expected_scope:
-		## `resolved_scope` rides along as structured data so callers can act
-		## on it — `_verify_post_state`'s path hint needs to know WHICH scope
-		## survived to name the right file, and parsing it back out of the
-		## human-facing message would couple that hint to this wording (#879).
 		var details := _status_details(
 			McpClient.Status.CONFIGURED_MISMATCH,
 			"registered at %s scope, not %s" % [resolved, expected_scope],

--- a/plugin/addons/godot_ai/clients/_manual_command.gd
+++ b/plugin/addons/godot_ai/clients/_manual_command.gd
@@ -73,6 +73,16 @@ static func _build_cli(
 		for arg in args:
 			parts.append(String(arg))
 		cmd = _format_shell_command(parts, shell_kind)
+	## #877: Configure runs more than the line above. For a `{scope}` descriptor
+	## it first runs the unregister template once per scope in CLIENT_SCOPES, so
+	## pressing Configure at ANY setting — the default `user` included — deletes
+	## a `godot-ai` entry from every scope, including one a team keeps by hand in
+	## a checked-in `.mcp.json`. Rendering only the register line made this hint
+	## disagree with what the button actually does, which is the worst property a
+	## "run this manually" string can have.
+	var sweep := _scope_sweep_note(client, server_name, server_url, short_name, shell_kind)
+	if not sweep.is_empty():
+		cmd = "%s\n\n%s" % [cmd, sweep]
 	# #463: a CLI client with a JSON fallback (Claude Code) may have no `claude`
 	# binary at all — e.g. installed only as a VS Code/Cursor extension. The CLI
 	# line above is useless to that user, so also show the config-file edit that
@@ -82,6 +92,46 @@ static func _build_cli(
 			cmd, short_name, _build_json(client, server_name, server_url, resolved_path, launch),
 		]
 	return cmd
+
+
+## Render the pre-cleanup removes Configure runs before registering a `{scope}`
+## descriptor. Shares `_shell_display_arg` with `_format_shell_command` but not
+## its label — these lines belong under the caller's own heading, and repeating
+## "Run in PowerShell:" four times would bury the one line that registers.
+##
+## Returns "" for descriptors without the token: those keep the single
+## implicit-scope pass they always had, which removes exactly the entry the
+## register is about to rewrite and so has no side effect worth surfacing.
+static func _scope_sweep_note(
+	client: McpClient,
+	server_name: String,
+	server_url: String,
+	short_name: String,
+	shell_kind: String,
+) -> String:
+	if client.cli_unregister_template.is_empty():
+		return ""
+	if not McpCliStrategy.uses_scope_token(client):
+		return ""
+	var lines: Array[String] = []
+	for scope in McpSettings.CLIENT_SCOPES:
+		var args := McpCliStrategy.format_args(
+			client.cli_unregister_template, server_name, server_url, {}, String(scope)
+		)
+		var rendered: Array[String] = [_shell_display_arg(short_name, shell_kind)]
+		for arg in args:
+			rendered.append(_shell_display_arg(String(arg), shell_kind))
+		lines.append(" ".join(rendered))
+	if lines.is_empty():
+		return ""
+	return (
+		"Configure also runs these first, clearing %s out of every scope. "
+		% server_name
+		+ "The project-scope line rewrites the .mcp.json in the editor's working "
+		+ "directory — which is wherever the editor was launched from, not "
+		+ "necessarily this project — so it will drop a hand-maintained %s entry there:\n%s"
+		% [server_name, "\n".join(lines)]
+	)
 
 
 static func _shell_kind_for_platform() -> String:

--- a/plugin/addons/godot_ai/clients/_manual_command.gd
+++ b/plugin/addons/godot_ai/clients/_manual_command.gd
@@ -66,23 +66,17 @@ static func _build_cli(
 			var parts: Array[String] = [short_name]
 			for arg in args:
 				parts.append(String(arg))
-			cmd = _format_shell_command(parts, shell_kind)
+			var lines := _sweep_lines(client, server_name, server_url, short_name, shell_kind)
+			lines.append(_render_command_line(parts, shell_kind))
+			cmd = _format_shell_block(lines, shell_kind) + _sweep_caveat(client)
 	else:
 		var args := McpCliStrategy.format_args(client.cli_register_template, server_name, server_url)
 		var parts: Array[String] = [short_name]
 		for arg in args:
 			parts.append(String(arg))
-		cmd = _format_shell_command(parts, shell_kind)
-	## #877: Configure runs more than the line above. For a `{scope}` descriptor
-	## it first runs the unregister template once per scope in CLIENT_SCOPES, so
-	## pressing Configure at ANY setting — the default `user` included — deletes
-	## a `godot-ai` entry from every scope, including one a team keeps by hand in
-	## a checked-in `.mcp.json`. Rendering only the register line made this hint
-	## disagree with what the button actually does, which is the worst property a
-	## "run this manually" string can have.
-	var sweep := _scope_sweep_note(client, server_name, server_url, short_name, shell_kind)
-	if not sweep.is_empty():
-		cmd = "%s\n\n%s" % [cmd, sweep]
+		var lines := _sweep_lines(client, server_name, server_url, short_name, shell_kind)
+		lines.append(_render_command_line(parts, shell_kind))
+		cmd = _format_shell_block(lines, shell_kind) + _sweep_caveat(client)
 	# #463: a CLI client with a JSON fallback (Claude Code) may have no `claude`
 	# binary at all — e.g. installed only as a VS Code/Cursor extension. The CLI
 	# line above is useless to that user, so also show the config-file edit that
@@ -94,43 +88,48 @@ static func _build_cli(
 	return cmd
 
 
-## Render the pre-cleanup removes Configure runs before registering a `{scope}`
-## descriptor. Shares `_shell_display_arg` with `_format_shell_command` but not
-## its label — these lines belong under the caller's own heading, and repeating
-## "Run in PowerShell:" four times would bury the one line that registers.
-##
-## Returns "" for descriptors without the token: those keep the single
-## implicit-scope pass they always had, which removes exactly the entry the
-## register is about to rewrite and so has no side effect worth surfacing.
-static func _scope_sweep_note(
+## #877: Configure's first act is the pre-cleanup — it runs the unregister
+## template once per scope the descriptor can write to (`_cli_strategy.gd`
+## `configure`) before registering. Rendering only the register line made this
+## hint disagree with what the button does, which is the worst property a
+## "run this manually" string can have. The removes go in the SAME shell block
+## as the register, in the order Configure runs them, so the whole thing stays
+## one copy-paste rather than a labelled command plus loose prose.
+static func _sweep_lines(
 	client: McpClient,
 	server_name: String,
 	server_url: String,
 	short_name: String,
 	shell_kind: String,
-) -> String:
-	if client.cli_unregister_template.is_empty():
-		return ""
-	if not McpCliStrategy.uses_scope_token(client):
-		return ""
+) -> Array[String]:
 	var lines: Array[String] = []
-	for scope in McpSettings.CLIENT_SCOPES:
+	if client.cli_unregister_template.is_empty():
+		return lines
+	for pre_scope in McpCliStrategy.cleanup_scopes(client):
 		var args := McpCliStrategy.format_args(
-			client.cli_unregister_template, server_name, server_url, {}, String(scope)
+			client.cli_unregister_template, server_name, server_url, {}, pre_scope
 		)
-		var rendered: Array[String] = [_shell_display_arg(short_name, shell_kind)]
+		var parts: Array[String] = [short_name]
 		for arg in args:
-			rendered.append(_shell_display_arg(String(arg), shell_kind))
-		lines.append(" ".join(rendered))
-	if lines.is_empty():
+			parts.append(String(arg))
+		lines.append(_render_command_line(parts, shell_kind))
+	return lines
+
+
+## The one thing the commands themselves cannot show: that the project pass
+## resolves `.mcp.json` against the CLI's cwd, so it can delete an entry from a
+## repository that has nothing to do with this project. Only for `{scope}`
+## descriptors — a single implicit-scope pass removes exactly the entry the
+## register is about to rewrite, which needs no warning. Kept outside the shell
+## block so pasting the block never picks up prose.
+static func _sweep_caveat(client: McpClient) -> String:
+	if client.cli_unregister_template.is_empty() or not McpCliStrategy.uses_scope_token(client):
 		return ""
 	return (
-		"Configure also runs these first, clearing %s out of every scope. "
-		% server_name
-		+ "The project-scope line rewrites the .mcp.json in the editor's working "
-		+ "directory — which is wherever the editor was launched from, not "
-		+ "necessarily this project — so it will drop a hand-maintained %s entry there:\n%s"
-		% [server_name, "\n".join(lines)]
+		"\n\nThe project-scope remove rewrites the .mcp.json in the directory the"
+		+ " editor was launched from — not necessarily this project — so it drops a"
+		+ " hand-maintained godot-ai entry there. Other servers in that file are left"
+		+ " alone."
 	)
 
 
@@ -142,11 +141,22 @@ static func _shell_kind_for_platform() -> String:
 ## POSIX and PowerShell use different escaping for embedded single quotes, so
 ## presenting the command without its target shell invites a bad copy/paste.
 static func _format_shell_command(parts: Array[String], shell_kind: String) -> String:
+	return _format_shell_block([_render_command_line(parts, shell_kind)], shell_kind)
+
+
+## One label over N command lines. The label is per-block, not per-line:
+## repeating "Run in PowerShell:" four times would bury the single line that
+## actually registers.
+static func _format_shell_block(lines: Array[String], shell_kind: String) -> String:
+	var label := "Run in PowerShell:" if shell_kind == SHELL_POWERSHELL else "Run in a POSIX shell:"
+	return "%s\n%s" % [label, "\n".join(lines)]
+
+
+static func _render_command_line(parts: Array[String], shell_kind: String) -> String:
 	var rendered: Array[String] = []
 	for part in parts:
 		rendered.append(_shell_display_arg(part, shell_kind))
-	var label := "Run in PowerShell:" if shell_kind == SHELL_POWERSHELL else "Run in a POSIX shell:"
-	return "%s\n%s" % [label, " ".join(rendered)]
+	return " ".join(rendered)
 
 
 ## Quote one argv element for the paste-into-terminal hint. Single-quoted

--- a/plugin/addons/godot_ai/clients/claude_code.gd
+++ b/plugin/addons/godot_ai/clients/claude_code.gd
@@ -18,7 +18,12 @@ func _init() -> void:
 		["mcp", "add", "--scope", "{scope}", "{name}", "--", "{command}", "{args...}"]
 	)
 	## Explicit scope: an unscoped `mcp remove` deletes from whichever scope
-	## matches first, which could eat a project-local entry the user made.
+	## matches first, so the flag keeps each removal aimed at one known place.
+	## Note what that does and does not protect (#877): the dock's **Remove**
+	## button runs this once, at the selected scope only. **Configure** runs it
+	## once per scope in `CLIENT_SCOPES` before registering, so a Configure at
+	## any setting does delete a `godot-ai` entry from <cwd>/.mcp.json if one is
+	## there — see the cwd caveat below for which directory that actually is.
 	cli_unregister_template = PackedStringArray(["mcp", "remove", "--scope", "{scope}", "{name}"])
 	## Scope caveat: `--scope project` resolves `.mcp.json` against the
 	## *spawned CLI's* working directory, which is whatever the editor process
@@ -48,13 +53,17 @@ func _init() -> void:
 	## (verified live against claude CLI in an isolated CLAUDE_CONFIG_DIR):
 	##   "godot-ai": { "type": "stdio", "command": "<cmd>", "args": [...], "env": {} }
 	## The fallback writer omits the empty `env`; the verifier accepts both.
-	## Status always reads this file — it is the CLI's own store for user
-	## scope, and file reads give exact launch-drift detection that `mcp list`
-	## stdout scanning cannot.
+	## Status reads this file only while the selected scope is still `user` —
+	## it is the CLI's own store for that scope, and file reads give exact
+	## launch-drift detection that `mcp list` stdout scanning cannot. At
+	## `project`/`local` the entry is somewhere `path_template` cannot see, so
+	## `_scope_diverges_from_json_fallback` (client_configurator.gd) routes
+	## status to `cli_scope_status_template` instead and this file is not read.
 	path_template = {"unix": "~/.claude.json", "windows": "~/.claude.json"}
 	server_key_path = PackedStringArray(["mcpServers"])
 	## URL-mode shape, used only for the manual-instruction fallback text —
-	## `claude mcp add --scope user --transport http` writes {type: http, url}.
+	## `claude mcp add --scope <scope> --transport http` writes {type: http, url},
+	## where <scope> is whatever `godot_ai/mcp_client_scope` resolves to.
 	entry_extra_fields = {"type": "http"}
 	command_shape = McpClient.CommandShape.FLAT
 	command_transport_key = "type"

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -2152,7 +2152,14 @@ func _apply_client_action_result(client_id: String, action: String, result: Dict
 
 	var success_status := Client.Status.NOT_CONFIGURED if action == "remove" else Client.Status.CONFIGURED
 	if result.get("status") == "ok":
-		_apply_row_status(client_id, success_status)
+		## #877: Remove targets only the selected scope, so a configure is the
+		## only action with an all-scope sweep to disclose. The manual panel
+		## that lists those removes is shown on the failure path below, which
+		## left the success path — where the sweep actually ran — silent.
+		var sweep_note := (
+			ClientConfigurator.configure_sweep_note(client_id) if action == "configure" else ""
+		)
+		_apply_row_status(client_id, success_status, sweep_note)
 		var row: Dictionary = _client_rows.get(client_id, {})
 		if not row.is_empty():
 			(row["manual_panel"] as VBoxContainer).visible = false
@@ -3363,7 +3370,13 @@ func _apply_row_status(
 			dot.color = Color.GREEN
 			configure_btn.text = "Reconfigure"
 			remove_btn.visible = true
-			name_label.text = base_name
+			## `error_msg` doubles as a detail slot on the green path: a
+			## successful configure passes the sweep note (#877). Transient by
+			## design — the next status refresh re-applies CONFIGURED with no
+			## detail, so the row settles back to its plain name.
+			name_label.text = (
+				"%s  (%s)" % [base_name, error_msg] if not error_msg.is_empty() else base_name
+			)
 		Client.Status.NOT_CONFIGURED:
 			dot.color = COLOR_MUTED
 			configure_btn.text = "Configure"

--- a/test_project/tests/test_client_attach_config.gd
+++ b/test_project/tests/test_client_attach_config.gd
@@ -4,6 +4,7 @@ extends McpTestSuite
 ## #816 rollout steps 5-6: launch discovery plus Codex's TOML command shape.
 
 var _scratch_dir: String
+var _saved_client_scope: Variant = null
 
 
 func suite_name() -> String:
@@ -13,11 +14,30 @@ func suite_name() -> String:
 func suite_setup(_ctx: Dictionary) -> void:
 	_scratch_dir = OS.get_user_data_dir().path_join("mcp_attach_client_tests")
 	DirAccess.make_dir_recursive_absolute(_scratch_dir)
+	## #876: `_claude_cli_clone` copies the real descriptor's
+	## `cli_register_template`, which carries `{scope}` since #872 — so this
+	## suite's fixtures report `uses_scope_token() == true` and become
+	## sensitive to `godot_ai/mcp_client_scope`, a setting it never opts into.
+	## At `project`/`local` that flips `_scope_diverges_from_json_fallback`,
+	## skipping the JSON read these tests exist to prove is authoritative.
+	## Pin the default for the run so the suite is hermetic against whatever
+	## the developer has selected, and restore their value in teardown.
+	var es := EditorInterface.get_editor_settings()
+	if es != null:
+		if es.has_setting(McpSettings.SETTING_CLIENT_SCOPE):
+			_saved_client_scope = es.get_setting(McpSettings.SETTING_CLIENT_SCOPE)
+		es.set_setting(McpSettings.SETTING_CLIENT_SCOPE, McpSettings.DEFAULT_CLIENT_SCOPE)
 
 
 func suite_teardown() -> void:
 	for file_name in DirAccess.get_files_at(_scratch_dir):
 		DirAccess.remove_absolute(_scratch_dir.path_join(file_name))
+	var es := EditorInterface.get_editor_settings()
+	if es != null:
+		es.set_setting(
+			McpSettings.SETTING_CLIENT_SCOPE,
+			McpSettings.DEFAULT_CLIENT_SCOPE if _saved_client_scope == null else _saved_client_scope,
+		)
 
 
 func test_codex_descriptor_declares_attach_shape_and_timeouts() -> void:

--- a/test_project/tests/test_client_attach_config.gd
+++ b/test_project/tests/test_client_attach_config.gd
@@ -4,6 +4,7 @@ extends McpTestSuite
 ## #816 rollout steps 5-6: launch discovery plus Codex's TOML command shape.
 
 var _scratch_dir: String
+var _had_client_scope_setting := false
 var _saved_client_scope: Variant = null
 
 
@@ -22,9 +23,19 @@ func suite_setup(_ctx: Dictionary) -> void:
 	## skipping the JSON read these tests exist to prove is authoritative.
 	## Pin the default for the run so the suite is hermetic against whatever
 	## the developer has selected, and restore their value in teardown.
+	##
+	## Presence is tracked separately from value, following test_allow_hosts.gd
+	## and test_dock.gd's `_restore_mcp_logging_setting`: writing the default
+	## back into a key that was absent would leave the suite having *created*
+	## an EditorSetting. `plugin.gd._enter_tree` calls
+	## `ClientConfigurator.ensure_settings_registered()`, so in a live editor
+	## the key always exists by the time tests run and the absent branch is
+	## unreachable — but a restore helper that only round-trips in the state it
+	## happens to meet is the kind that breaks silently when that changes.
 	var es := EditorInterface.get_editor_settings()
 	if es != null:
-		if es.has_setting(McpSettings.SETTING_CLIENT_SCOPE):
+		_had_client_scope_setting = es.has_setting(McpSettings.SETTING_CLIENT_SCOPE)
+		if _had_client_scope_setting:
 			_saved_client_scope = es.get_setting(McpSettings.SETTING_CLIENT_SCOPE)
 		es.set_setting(McpSettings.SETTING_CLIENT_SCOPE, McpSettings.DEFAULT_CLIENT_SCOPE)
 
@@ -33,11 +44,12 @@ func suite_teardown() -> void:
 	for file_name in DirAccess.get_files_at(_scratch_dir):
 		DirAccess.remove_absolute(_scratch_dir.path_join(file_name))
 	var es := EditorInterface.get_editor_settings()
-	if es != null:
-		es.set_setting(
-			McpSettings.SETTING_CLIENT_SCOPE,
-			McpSettings.DEFAULT_CLIENT_SCOPE if _saved_client_scope == null else _saved_client_scope,
-		)
+	if es == null:
+		return
+	if _had_client_scope_setting:
+		es.set_setting(McpSettings.SETTING_CLIENT_SCOPE, _saved_client_scope)
+	elif es.has_setting(McpSettings.SETTING_CLIENT_SCOPE):
+		es.erase(McpSettings.SETTING_CLIENT_SCOPE)
 
 
 func test_codex_descriptor_declares_attach_shape_and_timeouts() -> void:

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -2699,6 +2699,8 @@ func test_configure_sweep_note_names_every_cleared_scope() -> void:
 	assert_true(client != null, "claude_code must be registered")
 	var note := McpClientConfigurator.configure_sweep_note("claude_code")
 	assert_contains(note, "godot-ai", "the note must name the key Configure deletes")
+	assert_contains(note, "attempted to clear",
+		"configure() discards every remove result, so the note must not claim the scopes were cleared")
 	for scope in McpCliStrategy.cleanup_scopes(client):
 		assert_contains(note, String(scope),
 			"the note must name every scope Configure clears, including %s" % scope)

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -1540,6 +1540,13 @@ func _make_scope_cli_client(path: String) -> McpClient:
 	)
 	c.cli_unregister_template = PackedStringArray(["mcp", "remove", "--scope", "{scope}", "{name}"])
 	c.cli_status_args = PackedStringArray(["mcp", "list"])
+	## #878: without this the dispatch gate in client_configurator.gd is
+	## unreachable from any test, so `check_scope_status_details` never runs —
+	## a full suite spawned `mcp list` three times and `mcp get` zero times.
+	## Mirrors claude_code.gd so the fixture routes the way the real descriptor
+	## does; `mcp get` also renders differently from `cli_status_args`, which is
+	## what lets a test notice if the two are ever swapped.
+	c.cli_scope_status_template = PackedStringArray(["mcp", "get", "{name}"])
 	c.path_template = {"darwin": path, "windows": path, "linux": path, "unix": path}
 	c.server_key_path = PackedStringArray(["mcpServers"])
 	c.command_shape = McpClient.CommandShape.FLAT
@@ -1726,6 +1733,56 @@ func test_project_scope_status_leaves_the_user_scope_file() -> void:
 	)
 	assert_eq(at_project_no_cli.get("status"), McpClient.Status.CONFIGURED,
 		"without a CLI the JSON fallback owns both the write and the read-back")
+	_restore_client_scope()
+	_remove_if_exists(path)
+
+
+func test_scope_probe_dispatch_uses_its_own_template_and_the_selected_scope() -> void:
+	## #878: the probe's dispatch had no coverage — the suite exercised only the
+	## pure verdict helpers, so two mutations survived a full run: routing the
+	## probe through `cli_status_args` instead of `cli_scope_status_template`,
+	## and comparing against DEFAULT_CLIENT_SCOPE instead of the live setting.
+	## Both silently disable scope detection for the one client that has it.
+	var es := EditorInterface.get_editor_settings()
+	if es == null:
+		skip("EditorSettings unavailable in test environment")
+		return
+	var path := _scratch_dir.path_join("scope_probe_dispatch.json")
+	_remove_if_exists(path)
+	var client := _make_scope_cli_client(path)
+	assert_false(
+		client.cli_scope_status_template.is_empty(),
+		"the scope fixture must declare a probe or the dispatch gate is unreachable",
+	)
+
+	## Kills the "probe runs cli_status_args" mutation: the two templates render
+	## different subcommands, so swapping them changes this argv.
+	var probe_args := McpCliStrategy.format_args(client.cli_scope_status_template, "godot-ai", "")
+	var plain_args := McpCliStrategy.format_args(client.cli_status_args, "godot-ai", "")
+	assert_eq(probe_args, ["mcp", "get", "godot-ai"] as Array[String])
+	assert_ne(probe_args, plain_args, "scope probe must not render the plain status args")
+
+	## Kills the "compare against DEFAULT_CLIENT_SCOPE" mutation: `{scope}` has
+	## to resolve from the live setting, and `local` is neither the default nor
+	## the value the other scope tests use.
+	es.set_setting(McpSettings.SETTING_CLIENT_SCOPE, "local")
+	assert_eq(McpSettings.client_scope(), "local")
+	var unregister := McpCliStrategy.format_args(client.cli_unregister_template, "godot-ai", "")
+	assert_true(unregister.has("local"), "{scope} must resolve from the live setting")
+
+	## And the routed path itself: a probe whose binary cannot spawn fails
+	## closed to NOT_CONFIGURED rather than inventing a verdict. Reached through
+	## the real gate in _dispatch_check_status_with_cli_path_details, not by
+	## calling check_scope_status_details directly.
+	var launch := {"ok": true, "command": "uvx", "args": ["godot-ai", "attach"]}
+	var routed := McpClientConfigurator._dispatch_check_status_with_cli_path_details(
+		client, "", "godot-ai-nonexistent-cli-xyz", {}, launch
+	)
+	assert_eq(
+		routed.get("status"),
+		McpClient.Status.NOT_CONFIGURED,
+		"an unspawnable scope probe must fail closed, not report CONFIGURED",
+	)
 	_restore_client_scope()
 	_remove_if_exists(path)
 

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -1932,10 +1932,26 @@ func test_scope_probe_verdict_absent_entry_and_drift() -> void:
 		McpClient.Status.NOT_CONFIGURED,
 	)
 	## Right scope, wrong launcher — still drift, same as the JSON path.
-	assert_eq(
-		McpCliStrategy._scope_probe_verdict(0, _PROBE_PROJECT, "project", "/somewhere/else/uvx").get("status"),
-		McpClient.Status.CONFIGURED_MISMATCH,
+	var drifted := McpCliStrategy._scope_probe_verdict(
+		0, _PROBE_PROJECT, "project", "/somewhere/else/uvx"
 	)
+	assert_eq(drifted.get("status"), McpClient.Status.CONFIGURED_MISMATCH)
+	## #879 regression guard: a launcher drift sends the user to the wrong file
+	## just as readily as a scope drift does. The `Scope:` label is right there
+	## in the probe output, so the verdict must carry it — without it
+	## `_post_state_path_hint` falls back to `resolved_config_path()` and names
+	## ~/.claude.json for an entry that actually lives in .mcp.json.
+	assert_eq(drifted.get("resolved_scope"), "project",
+		"a target drift must still report the scope the entry resolved from")
+
+	## ...but only when the label actually parsed. A drift with no readable
+	## scope must not fabricate one; the hint degrades to the historical path.
+	var drift_no_label := McpCliStrategy._scope_probe_verdict(
+		0, "godot-ai:\n  Command: /somewhere/else/uvx\n", "project", _PROBE_TARGET
+	)
+	assert_eq(drift_no_label.get("status"), McpClient.Status.CONFIGURED_MISMATCH)
+	assert_false(drift_no_label.has("resolved_scope"),
+		"an unparseable Scope line must not invent a scope for the path hint")
 	## A future CLI that stops printing a Scope line must degrade to the
 	## target check, not invent a red dot on a working install.
 	var no_label := "godot-ai:\n  Command: %s\n" % _PROBE_TARGET
@@ -2652,9 +2668,52 @@ func test_post_state_path_hint_follows_resolved_scope() -> void:
 	var local_hint := McpClientConfigurator._post_state_path_hint(client, "local")
 	assert_contains(local_hint, ".claude.json",
 		"local scope lives in a per-project block of the user-scope file")
+	## Which block, though: `local` is keyed by the CLI's working directory, the
+	## same cwd distinction the project branch spells out. "this project's
+	## block" sends a user who launched the editor from elsewhere to a key that
+	## does not exist while the entry sits under the launch directory.
+	assert_contains(local_hint, "launched from",
+		"the local hint must name the launch directory, not this project")
+
+	## Every other branch guards an unresolvable path; this one used to render
+	## " ... in  and remove ..." with a hole where the path belongs. Uses a
+	## scratch descriptor rather than clearing `path_template` on the registered
+	## claude_code, which the registry hands out by reference (#878).
+	var unresolvable := _make_scope_cli_client(_scratch_dir.path_join("hint_no_path.json"))
+	unresolvable.path_template = {}
+	assert_eq(McpClientConfigurator._post_state_path_hint(unresolvable, "local"), "",
+		"an unresolvable path yields no hint rather than a sentence with a hole")
+
 	var default_hint := McpClientConfigurator._post_state_path_hint(client, "")
 	assert_contains(default_hint, client.resolved_config_path(),
 		"no probe scope keeps the historical resolved-path hint")
+
+
+func test_configure_sweep_note_names_every_cleared_scope() -> void:
+	## #877: the manual-command panel listing the pre-cleanup removes is only
+	## shown when Configure FAILS, which left the success path — the one where
+	## the sweep actually deleted `godot-ai` from a .mcp.json that may belong to
+	## an unrelated repository — with no disclosure at all. The row note is that
+	## disclosure, so it must name the same scopes the sweep actually walks.
+	var client := McpClientRegistry.get_by_id("claude_code")
+	assert_true(client != null, "claude_code must be registered")
+	var note := McpClientConfigurator.configure_sweep_note("claude_code")
+	assert_contains(note, "godot-ai", "the note must name the key Configure deletes")
+	for scope in McpCliStrategy.cleanup_scopes(client):
+		assert_contains(note, String(scope),
+			"the note must name every scope Configure clears, including %s" % scope)
+
+	## Only `{scope}` CLI descriptors sweep beyond the entry they rewrite. A
+	## single implicit pass removes exactly what the register puts back, so
+	## everything else stays silent — the same rule `_sweep_caveat` applies.
+	for id in McpClientConfigurator.client_ids():
+		var other := McpClientRegistry.get_by_id(id)
+		if other != null and other.config_type != "cli":
+			assert_eq(McpClientConfigurator.configure_sweep_note(id), "",
+				"%s is not a CLI client and must not claim a scope sweep" % id)
+
+	assert_eq(McpClientConfigurator.configure_sweep_note("no_such_client_xyz"), "",
+		"an unknown id yields no note rather than an error string")
 
 
 func test_verify_post_state_errors_when_remove_left_entry_behind() -> void:

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -1748,54 +1748,108 @@ func test_project_scope_status_leaves_the_user_scope_file() -> void:
 	_remove_if_exists(path)
 
 
+## A fake CLI that records its argv to `argv_log` and prints whatever is in
+## `probe_stdout.txt`, so the scope probe's SUBPROCESS wrapper
+## (`check_scope_status_details`) and the dispatch gate that reaches it run for
+## real without a `claude` binary on the machine (#878). Windows gets a .bat —
+## McpCliExec wraps those in `cmd.exe /c`; elsewhere a shebang script chmod 0755.
+## Approach adapted from @dsarno's #881, which was closed unmerged.
+func _write_fake_probe_cli(stdout_fixture: String, argv_log: String) -> String:
+	var out_path := _scratch_dir.path_join("probe_stdout.txt")
+	_write_text(out_path, stdout_fixture)
+	if OS.get_name() == "Windows":
+		var bat := _scratch_dir.path_join("fake_scope_cli.bat")
+		## Backslashes are load-bearing. `user://` paths come back with forward
+		## slashes and cmd.exe's `type` cannot open one — it exits 1 with "The
+		## system cannot find the file specified" and prints nothing, which
+		## reaches the probe as empty stdout and a NOT_CONFIGURED verdict for
+		## entirely the wrong reason. Verified both ways before relying on it.
+		var bat_body := (
+			"@echo off\r\n"
+			+ "echo %%* > \"%s\"\r\n" % argv_log.replace("/", "\\")
+			+ "type \"%s\"\r\n" % out_path.replace("/", "\\")
+		)
+		_write_text(bat, bat_body)
+		return bat
+	var sh := _scratch_dir.path_join("fake_scope_cli.sh")
+	var sh_body := (
+		"#!/bin/sh\n"
+		+ "printf '%%s ' \"$@\" > \"%s\"\n" % argv_log
+		+ "cat \"%s\"\n" % out_path
+	)
+	_write_text(sh, sh_body)
+	var exec_mode := (
+		FileAccess.UNIX_READ_OWNER | FileAccess.UNIX_WRITE_OWNER | FileAccess.UNIX_EXECUTE_OWNER
+		| FileAccess.UNIX_READ_GROUP | FileAccess.UNIX_EXECUTE_GROUP
+		| FileAccess.UNIX_READ_OTHER | FileAccess.UNIX_EXECUTE_OTHER
+	)
+	assert_eq(FileAccess.set_unix_permissions(sh, exec_mode), OK, "test setup: chmod 0755")
+	return sh
+
 func test_scope_probe_dispatch_uses_its_own_template_and_the_selected_scope() -> void:
-	## #878: the probe's dispatch had no coverage — the suite exercised only the
-	## pure verdict helpers, so two mutations survived a full run: routing the
-	## probe through `cli_status_args` instead of `cli_scope_status_template`,
-	## and comparing against DEFAULT_CLIENT_SCOPE instead of the live setting.
-	## Both silently disable scope detection for the one client that has it.
+	## #878: until this test nothing set `cli_scope_status_template`, so the
+	## probe gate in _dispatch_check_status_with_cli_path_details was unreachable
+	## from the suite — a full run spawned `mcp get` zero times — and two
+	## mutations survived it:
+	##   1. client_configurator.gd passing DEFAULT_CLIENT_SCOPE to the probe
+	##      instead of the live setting;
+	##   2. _cli_strategy.gd probing with `cli_status_args` instead of
+	##      `cli_scope_status_template`.
+	## Asserting on rendered templates does NOT catch either — the mutations
+	## change which template the probe *passes* and which scope it *compares*,
+	## neither of which a direct format_args() call observes. Both are verified
+	## dead by mutating those two lines and watching this test fail.
 	var es := EditorInterface.get_editor_settings()
 	if es == null:
 		skip("EditorSettings unavailable in test environment")
 		return
-	var path := _scratch_dir.path_join("scope_probe_dispatch.json")
-	_remove_if_exists(path)
-	var client := _make_scope_cli_client(path)
-	assert_false(
-		client.cli_scope_status_template.is_empty(),
-		"the scope fixture must declare a probe or the dispatch gate is unreachable",
+	var argv_log := _scratch_dir.path_join("probe_argv.log")
+	_remove_if_exists(argv_log)
+	var cli := _write_fake_probe_cli(_PROBE_USER, argv_log)
+	var client := _make_scope_cli_client(_scratch_dir.path_join("probe_route.json"))
+	var launch := {"ok": true, "command": _PROBE_TARGET, "args": []}
+
+	## The fake CLI prints a USER-scope entry. Under a `project` selection that
+	## must read as mismatch — mutation 1 (expected scope hardcoded to the
+	## default) would call this the ordinary green path.
+	es.set_setting(McpSettings.SETTING_CLIENT_SCOPE, "project")
+	var at_project := McpClientConfigurator._dispatch_check_status_with_cli_path_details(
+		client, "", cli, {}, launch
 	)
+	assert_eq(at_project.get("status"), McpClient.Status.CONFIGURED_MISMATCH,
+		"a user-scope entry under a project selection must read as mismatch")
+	assert_contains(str(at_project.get("error_msg", "")), "user scope, not project")
+	assert_eq(at_project.get("resolved_scope"), "user",
+		"the mismatch verdict must carry the resolved scope as data, not only prose (#879)")
 
-	## Kills the "probe runs cli_status_args" mutation: the two templates render
-	## different subcommands, so swapping them changes this argv.
-	var probe_args := McpCliStrategy.format_args(client.cli_scope_status_template, "godot-ai", "")
-	var plain_args := McpCliStrategy.format_args(client.cli_status_args, "godot-ai", "")
-	assert_eq(probe_args, ["mcp", "get", "godot-ai"] as Array[String])
-	assert_ne(probe_args, plain_args, "scope probe must not render the plain status args")
+	## The spawned argv must come from cli_scope_status_template (`mcp get`),
+	## not cli_status_args (`mcp list`) — mutation 2.
+	var logged := _read_text(argv_log)
+	assert_contains(logged, "get")
+	assert_contains(logged, "godot-ai")
+	assert_false(logged.contains("list"),
+		"probe must render cli_scope_status_template, got argv: %s" % logged)
 
-	## Kills the "compare against DEFAULT_CLIENT_SCOPE" mutation: `{scope}` has
-	## to resolve from the live setting, and `local` is neither the default nor
-	## the value the other scope tests use.
+	## A different selection moves only the expected side of the comparison,
+	## proving the live setting is threaded through rather than a constant.
 	es.set_setting(McpSettings.SETTING_CLIENT_SCOPE, "local")
-	assert_eq(McpSettings.client_scope(), "local")
-	var unregister := McpCliStrategy.format_args(client.cli_unregister_template, "godot-ai", "")
-	assert_true(unregister.has("local"), "{scope} must resolve from the live setting")
+	var at_local := McpClientConfigurator._dispatch_check_status_with_cli_path_details(
+		client, "", cli, {}, launch
+	)
+	assert_eq(at_local.get("status"), McpClient.Status.CONFIGURED_MISMATCH)
+	assert_contains(str(at_local.get("error_msg", "")), "user scope, not local")
 
-	## And the routed path itself: a probe whose binary cannot spawn fails
-	## closed to NOT_CONFIGURED rather than inventing a verdict. Reached through
-	## the real gate in _dispatch_check_status_with_cli_path_details, not by
-	## calling check_scope_status_details directly.
-	var launch := {"ok": true, "command": "uvx", "args": ["godot-ai", "attach"]}
-	var routed := McpClientConfigurator._dispatch_check_status_with_cli_path_details(
-		client, "", "godot-ai-nonexistent-cli-xyz", {}, launch
+	## And the green path through the same subprocess: swap the canned output to
+	## a project-scope entry and re-probe at project scope.
+	_write_text(_scratch_dir.path_join("probe_stdout.txt"), _PROBE_PROJECT)
+	es.set_setting(McpSettings.SETTING_CLIENT_SCOPE, "project")
+	var matching := McpClientConfigurator._dispatch_check_status_with_cli_path_details(
+		client, "", cli, {}, launch
 	)
-	assert_eq(
-		routed.get("status"),
-		McpClient.Status.NOT_CONFIGURED,
-		"an unspawnable scope probe must fail closed, not report CONFIGURED",
-	)
+	assert_eq(matching.get("status"), McpClient.Status.CONFIGURED,
+		"a project-scope entry under a project selection is the ordinary green path")
 	_restore_client_scope()
-	_remove_if_exists(path)
+	_remove_if_exists(argv_log)
 
 
 ## Real `claude mcp get godot-ai` output, captured from claude 2.1.241 in an
@@ -1959,6 +2013,27 @@ func test_claude_code_manual_command_shows_json_fallback() -> void:
 	assert_contains(cmd, "\"type\": \"stdio\"", "JSON fallback should show the stdio entry shape")
 	assert_contains(cmd, "Advanced fallback", "URL mode stays available as the documented fallback")
 	assert_contains(cmd, "\"type\": \"http\"", "URL fallback entry keeps the type:http shape")
+
+
+func test_claude_code_manual_command_renders_pre_cleanup_sweep() -> void:
+	## #877: Configure's first act is the all-scope `mcp remove` sweep, and its
+	## `--scope project` pass edits the .mcp.json in the CLI's cwd. The manual
+	## text has to show those removes, in the order Configure runs them —
+	## otherwise the snippet the user is told to run is not what the button runs
+	## and the sweep's side effect stays invisible.
+	var cmd := McpClientConfigurator.manual_command("claude_code")
+	for scope in McpSettings.CLIENT_SCOPES:
+		assert_contains(cmd, "mcp remove --scope %s godot-ai" % scope)
+	var remove_pos := cmd.find("mcp remove")
+	var add_pos := cmd.find("mcp add")
+	assert_true(add_pos >= 0 and remove_pos >= 0 and remove_pos < add_pos,
+		"the sweep must precede the register line, as Configure runs them")
+	## One shell label for the whole block, so it stays a single copy-paste.
+	assert_eq(cmd.count("Run in PowerShell:") + cmd.count("Run in a POSIX shell:"), 1,
+		"removes and register belong under one label, not one label each")
+	## The cwd hazard cannot be read off the commands themselves.
+	assert_contains(cmd, "launched from",
+		"the manual text must say the project remove targets the editor's cwd")
 
 
 func test_manual_cli_shell_renderers_preserve_literal_argv() -> void:
@@ -2559,6 +2634,27 @@ func test_verify_post_state_errors_when_configure_did_not_land() -> void:
 	assert_contains(msg, "not_configured", "Error must name the actual status: %s" % msg)
 	assert_contains(msg, "configured", "Error must name the expected status: %s" % msg)
 	assert_contains(msg, path, "Error must include the resolved config path: %s" % msg)
+
+
+func test_post_state_path_hint_follows_resolved_scope() -> void:
+	## #879: after a cross-scope mismatch the surviving entry is NOT in the file
+	## `path_template` resolves to. Telling the user to inspect ~/.claude.json
+	## for a project-scope survivor sends them somewhere with nothing to find.
+	## The probe supplies `resolved_scope`; this pins the hint chosen from it
+	## (the plumbing that produces it is pinned by
+	## test_scope_probe_dispatch_uses_its_own_template_and_the_selected_scope).
+	var client := McpClientRegistry.get_by_id("claude_code")
+	assert_true(client != null, "claude_code must be registered")
+	var project_hint := McpClientConfigurator._post_state_path_hint(client, "project")
+	assert_contains(project_hint, ".mcp.json")
+	assert_false(project_hint.contains(".claude.json"),
+		"a project-scope survivor must not point at the user-scope file: %s" % project_hint)
+	var local_hint := McpClientConfigurator._post_state_path_hint(client, "local")
+	assert_contains(local_hint, ".claude.json",
+		"local scope lives in a per-project block of the user-scope file")
+	var default_hint := McpClientConfigurator._post_state_path_hint(client, "")
+	assert_contains(default_hint, client.resolved_config_path(),
+		"no probe scope keeps the historical resolved-path hint")
 
 
 func test_verify_post_state_errors_when_remove_left_entry_behind() -> void:

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -16,11 +16,19 @@ var _scratch_dir: String
 ## Snapshot the user's live port overrides at suite entry so our
 ## per-test set/clear dance doesn't leave the editor pointing at the wrong
 ## port if a test fails mid-flight.
+##
+## Presence is tracked alongside value for each key: a `null` snapshot means
+## "no such setting", and writing the default back into it would leave the
+## suite having *created* an EditorSetting it found absent. Same idiom as
+## test_allow_hosts.gd and test_dock.gd's `_restore_mcp_logging_setting`.
+var _had_http_port_setting := false
 var _saved_http_port: Variant = null
+var _had_ws_port_setting := false
 var _saved_ws_port: Variant = null
 ## Same reason as the ports: these tests drive godot_ai/mcp_client_scope
 ## through its valid and invalid values and must not leave the editor
 ## registering at a scope the user never chose.
+var _had_client_scope_setting := false
 var _saved_client_scope: Variant = null
 
 
@@ -34,11 +42,14 @@ func suite_setup(_ctx: Dictionary) -> void:
 	DirAccess.make_dir_recursive_absolute(_scratch_dir)
 	var es := EditorInterface.get_editor_settings()
 	if es != null:
-		if es.has_setting(McpSettings.SETTING_HTTP_PORT):
+		_had_http_port_setting = es.has_setting(McpSettings.SETTING_HTTP_PORT)
+		if _had_http_port_setting:
 			_saved_http_port = es.get_setting(McpSettings.SETTING_HTTP_PORT)
-		if es.has_setting(McpClientConfigurator.SETTING_WS_PORT):
+		_had_ws_port_setting = es.has_setting(McpClientConfigurator.SETTING_WS_PORT)
+		if _had_ws_port_setting:
 			_saved_ws_port = es.get_setting(McpClientConfigurator.SETTING_WS_PORT)
-		if es.has_setting(McpSettings.SETTING_CLIENT_SCOPE):
+		_had_client_scope_setting = es.has_setting(McpSettings.SETTING_CLIENT_SCOPE)
+		if _had_client_scope_setting:
 			_saved_client_scope = es.get_setting(McpSettings.SETTING_CLIENT_SCOPE)
 
 
@@ -3996,14 +4007,14 @@ func _restore_port_settings() -> void:
 	var es := EditorInterface.get_editor_settings()
 	if es == null:
 		return
-	if _saved_http_port == null:
-		es.set_setting(McpSettings.SETTING_HTTP_PORT, McpClientConfigurator.DEFAULT_HTTP_PORT)
-	else:
+	if _had_http_port_setting:
 		es.set_setting(McpSettings.SETTING_HTTP_PORT, _saved_http_port)
-	if _saved_ws_port == null:
-		es.set_setting(McpClientConfigurator.SETTING_WS_PORT, McpClientConfigurator.DEFAULT_WS_PORT)
-	else:
+	elif es.has_setting(McpSettings.SETTING_HTTP_PORT):
+		es.erase(McpSettings.SETTING_HTTP_PORT)
+	if _had_ws_port_setting:
 		es.set_setting(McpClientConfigurator.SETTING_WS_PORT, _saved_ws_port)
+	elif es.has_setting(McpClientConfigurator.SETTING_WS_PORT):
+		es.erase(McpClientConfigurator.SETTING_WS_PORT)
 	_restore_client_scope()
 
 
@@ -4014,7 +4025,7 @@ func _restore_client_scope() -> void:
 	var es := EditorInterface.get_editor_settings()
 	if es == null:
 		return
-	if _saved_client_scope == null:
-		es.set_setting(McpSettings.SETTING_CLIENT_SCOPE, McpSettings.DEFAULT_CLIENT_SCOPE)
-	else:
+	if _had_client_scope_setting:
 		es.set_setting(McpSettings.SETTING_CLIENT_SCOPE, _saved_client_scope)
+	elif es.has_setting(McpSettings.SETTING_CLIENT_SCOPE):
+		es.erase(McpSettings.SETTING_CLIENT_SCOPE)

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -600,6 +600,8 @@ func test_successful_configure_discloses_the_scope_sweep_on_the_row() -> void:
 	## scope, including a .mcp.json in whatever directory the editor happened to
 	## be launched from, and told the user nothing. The green row carries that.
 	_dock._build_ui()
+	assert_true(_dock._client_rows.has("claude_code"),
+		"claude_code is a static registry entry and must have a row")
 	if not _dock._client_rows.has("claude_code"):
 		return
 	var row: Dictionary = _dock._client_rows["claude_code"]
@@ -608,7 +610,7 @@ func test_successful_configure_discloses_the_scope_sweep_on_the_row() -> void:
 
 	_dock._apply_row_status("claude_code", McpClient.Status.CONFIGURED, note)
 	var label := (row["name_label"] as Label).text
-	assert_contains(label, "cleared",
+	assert_contains(label, note,
 		"a successful configure must disclose the sweep it just performed")
 	assert_contains(label, "project",
 		"the destructive pass is the project one — the row has to name it")

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -593,6 +593,39 @@ func test_drift_banner_clears_after_per_row_reconfigure() -> void:
 		"Cache must drop the now-green client so a follow-up Reconfigure-mismatched click is a no-op")
 
 
+func test_successful_configure_discloses_the_scope_sweep_on_the_row() -> void:
+	## #877: `_show_manual_command_for` — the only thing that reveals the panel
+	## listing the pre-cleanup removes — is called just once, on the Configure
+	## FAILURE branch. So a successful Configure cleared `godot-ai` out of every
+	## scope, including a .mcp.json in whatever directory the editor happened to
+	## be launched from, and told the user nothing. The green row carries that.
+	_dock._build_ui()
+	if not _dock._client_rows.has("claude_code"):
+		return
+	var row: Dictionary = _dock._client_rows["claude_code"]
+	var note := McpClientConfigurator.configure_sweep_note("claude_code")
+	assert_false(note.is_empty(), "claude_code is the scope-sweeping descriptor")
+
+	_dock._apply_row_status("claude_code", McpClient.Status.CONFIGURED, note)
+	var label := (row["name_label"] as Label).text
+	assert_contains(label, "cleared",
+		"a successful configure must disclose the sweep it just performed")
+	assert_contains(label, "project",
+		"the destructive pass is the project one — the row has to name it")
+	assert_eq((row["dot"] as ColorRect).color, Color.GREEN,
+		"the note is a disclosure on a healthy row, not a warning state")
+
+	## Transient by design: the next status refresh re-applies CONFIGURED with
+	## no detail, so the row settles back to its plain name rather than pinning
+	## a note that no longer describes anything that just happened.
+	_dock._apply_row_status("claude_code", McpClient.Status.CONFIGURED)
+	assert_eq(
+		(row["name_label"] as Label).text,
+		McpClientConfigurator.client_display_name("claude_code"),
+		"the note must not survive an ordinary status refresh",
+	)
+
+
 func test_focus_in_auto_refresh_is_enabled_with_async_cooldown() -> void:
 	## Focus-in should still refresh client status, but the refresh path must be
 	## async/cooldown-protected so it does not run blocking CLI checks on the


### PR DESCRIPTION
Follow-ups from reviewing #873 after it merged.

Closes #876, closes #877, closes #878, closes #879.

> **Credit:** @dsarno's #881 fixed the same four issues independently and was closed unmerged. Three of its approaches were better than mine and are adopted here — the fake-CLI probe test, the structured `resolved_scope` hint, and the single-shell-block manual command. Each is marked below and in the relevant commit.

### #876 — suite red at `mcp_client_scope = project`

`_claude_cli_clone` builds its fixture from the real `claude_code` descriptor, so since #872 it inherits `{scope}` and reports `uses_scope_token() == true` — but it does not copy `cli_scope_status_template`. At `project`/`local` that flips `_scope_diverges_from_json_fallback`, skipping the JSON read the suite exists to prove is authoritative, while the scope probe does not fire either, so the fake CLI just spawn-fails.

| `godot_ai/mcp_client_scope` | full suite (before) |
|---|---|
| `user` | 2161 passed / **0 failed** |
| `project` | 2160 passed / **1 failed** |

The suite now pins the default for its run and restores the developer's value in teardown. Presence is tracked separately from value in both `test_client_attach_config.gd` and `test_clients.gd` (scope **and** both ports), so a key that was absent is erased rather than created — the repo's existing idiom from `test_allow_hosts.gd` and `test_dock.gd`.

### #877 — the all-scope sweep was invisible

Configure runs the unregister template once per scope before registering, so pressing it at **any** setting — the default `user` included — runs `claude mcp remove --scope project godot-ai`. That rewrites the `.mcp.json` in the CLI's working directory, which is wherever the editor was launched from. Confirmed against claude 2.1.241: a hand-maintained `godot-ai` entry in a checked-in `.mcp.json` is deleted, the file is left dirty, and the command exits 0 so the discarded result cannot tell us anything happened.

The sweep is intended and stays unchanged. What changed is that it is now visible: the dock's "Run this manually" text renders the removes and the register line under **one** shell label in the order Configure runs them (structure from #881), with the cwd hazard as a caveat outside the block so pasting never picks up prose. README states the consequence where it describes the sweep.

### #878 — the scope probe never ran in the suite

`_make_scope_cli_client` never set `cli_scope_status_template`, so the dispatch gate was unreachable and `check_scope_status_details` never executed — a full run spawned `mcp list` three times and `mcp get` zero times.

**Correction to an earlier version of this PR:** the first test I added here did *not* kill the two mutations its commit message claimed. It asserted on templates rendered directly via `format_args` and drove the dispatch only with an unspawnable binary, which proves reachability and fail-closed behaviour and nothing else. That claim was asserted, not tested.

It is now replaced (technique from #881) with a fake CLI that records its argv and prints the recorded `claude mcp get` fixtures, so the real subprocess path runs. Verified by actually applying each mutation on Godot 4.7.2:

| mutation | result |
|---|---|
| `client_configurator.gd:699` `client_scope()` → `DEFAULT_CLIENT_SCOPE` | **FAIL** — "a user-scope entry under a project selection must read as mismatch" |
| `_cli_strategy.gd:264` `cli_scope_status_template` → `cli_status_args` | **FAIL** — "'get' not found in 'mcp list'" |

Both reverted; suite green with them restored.

### #879 — cleanup

- `_scope_diverges_from_json_fallback`'s PATH walk could not change any outcome — one call site, already guarded on `has_json_fallback()`, and the next branch takes the fallback read when the CLI does not resolve. It only cost a second `McpCliFinder.find` sweep per status check. Dropped, with the unused parameter and the docstring that claimed it was decisive.
- `_verify_post_state` pointed at `resolved_config_path()` (`~/.claude.json`), the wrong file when the survivor is project-scoped. The probe now carries `resolved_scope` as structured data and `_post_state_path_hint` picks the matching location (approach from #881, replacing the prose hint I had).
- Three `claude_code.gd` comment blocks still described pre-#873 behaviour.

### Verification

Full gauntlet on **Godot 4.7.2-stable** (`ed1daf0bf`), headless editor, isolated self-contained config and non-default ports:

- `ruff check src/ tests/` — clean
- `pytest -q` — 1766 passed, 19 skipped, 0 failed
- `script/ci-check-gdscript` — all GDScript files OK
- `test_run` — **2164 passed / 0 failed / 36 skipped across 69 suites**, run at both `user` and `project` scope

One environment note for reviewers: on a freshly created worktree the first editor start can register only part of the test tree (I saw 68 suites / 2171 tests, with `clients` reporting 163 of 174, no load errors and nothing failing). Re-importing and restarting the editor restores the full 69. That is the silent-shortfall case filed separately as #882; it is not caused by this branch, but it does mean a single short run can under-report.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Manual configuration commands are now provided in one copy-pasteable block, including cleanup commands for all applicable scopes.
  - Successful configuration displays which scopes were cleared in the client status row.
  - Status checks and post-action guidance identify project, local, and user scopes more accurately.

- **Bug Fixes**
  - Improved detection of scope mismatches and configured entries, reducing misleading status results and cleanup instructions.

- **Documentation**
  - Added an important notice explaining that Configure removes `godot-ai` entries across client scopes and may modify project configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->