### PR TITLE
clients: #873 follow-ups — sweep transparency, scope-aware hints, hermetic scope tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,15 @@ opened on that project. `local` is also accepted for clients that support it.
 The default stays `user` so existing installs are unchanged on upgrade. To move
 an existing entry, change the setting and press **Configure** again — Configure
 clears `godot-ai` out of every scope before writing the new one, so the old
-entry doesn't linger. **Remove**, by contrast, only targets the scope that is
-currently selected, so switch back before removing if you changed the setting.
+entry doesn't linger. That sweep runs on *every* Configure, whatever scope is
+selected, and its `project` pass resolves `.mcp.json` against the CLI's working
+directory (first caveat below) — so a `godot-ai` entry in that file is removed
+even when you only ever use `user` scope. The dock's "Run this manually" text
+shows the exact remove commands the sweep runs. **Remove**, by contrast, only
+targets the scope that is currently selected, so switch back before removing if
+you changed the setting.
 
-Two caveats for `project` scope:
+Caveats for `project` scope:
 
 - The client CLI resolves the project config against **its own working
   directory**, which is the one the Godot editor was launched from — not

--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -672,7 +672,7 @@ static func _dispatch_check_status_with_cli_path_details(
 			if (
 				client.command_shape != Client.CommandShape.NONE
 				and client.has_json_fallback()
-				and not _scope_diverges_from_json_fallback(client, cli_path)
+				and not _scope_diverges_from_json_fallback(client)
 			):
 				var command_launch := _resolved_or_discovered_launch(client, resolved_launch, launch_context)
 				return JsonStrategy.check_status_details(client, SERVER_NAME, url, command_launch)
@@ -754,18 +754,15 @@ static func _note_unhonoured_scope(client: Client, result: Dictionary) -> Dictio
 ## detection — a stdout scan sees the command, not the full argv — which is the
 ## documented trade for a status that is merely coarse instead of wrong.
 ##
-## Ordering matters: the token check and the scope compare both short-circuit
-## for every non-`{scope}` descriptor and for the default user scope, so the
-## PATH walk only runs when the answer can actually be true. An unresolvable
-## CLI means configure took the #463 JSON fallback, which writes user scope
-## whatever the setting says — so the file is the right thing to read again.
-static func _scope_diverges_from_json_fallback(client: Client, cli_path: String) -> bool:
+## No CLI-resolvability check here (#879): when the CLI is unresolvable —
+## meaning configure took the #463 JSON fallback, which writes user scope
+## whatever the setting says — the caller's own fallback branch reads the
+## file with identical arguments, so re-walking PATH to pre-empt it changed
+## no outcome and cost a duplicate McpCliFinder.find per status check.
+static func _scope_diverges_from_json_fallback(client: Client) -> bool:
 	if not CliStrategy.uses_scope_token(client):
 		return false
-	if McpSettings.client_scope() == McpSettings.DEFAULT_CLIENT_SCOPE:
-		return false
-	var resolved := cli_path if not cli_path.is_empty() else CliStrategy.resolve_cli_path(client)
-	return not resolved.is_empty()
+	return McpSettings.client_scope() != McpSettings.DEFAULT_CLIENT_SCOPE
 
 
 static func _resolved_or_discovered_launch(
@@ -793,13 +790,13 @@ static func _verify_post_state(
 ) -> Dictionary:
 	if result.get("status") != "ok":
 		return result
-	var actual := _dispatch_check_status_with_cli_path_details(
+	var details := _dispatch_check_status_with_cli_path_details(
 		client, url, "", {}, resolved_launch
-	).get("status", Client.Status.NOT_CONFIGURED)
+	)
+	var actual: Client.Status = details.get("status", Client.Status.NOT_CONFIGURED)
 	if actual == expected:
 		return result
-	var path := client.resolved_config_path()
-	var path_hint := "" if path.is_empty() else " Inspect %s and remove the godot-ai entry by hand if needed." % path
+	var path_hint := _post_state_path_hint(client, str(details.get("resolved_scope", "")))
 	return {
 		"status": "error",
 		"message": "%s reported %s ok but verification still reads %s (expected %s).%s" % [
@@ -808,6 +805,33 @@ static func _verify_post_state(
 			path_hint,
 		],
 	}
+
+
+## Where to point the user when verification finds a surviving entry. The
+## scope probe's mismatch verdict carries `resolved_scope` (#879); without it,
+## `resolved_config_path()` (`path_template`) is the right file only for the
+## default user scope — naming ~/.claude.json for a project-scope survivor
+## sends the user to a file where there is nothing to find. `path_template`
+## has no project-relative token (see _note_unhonoured_scope), so the
+## project hint is phrased rather than resolved.
+static func _post_state_path_hint(client: Client, resolved_scope: String) -> String:
+	match resolved_scope:
+		"project":
+			return (
+				" The surviving entry is project-scoped: inspect the .mcp.json in the"
+				+ " directory the editor was launched from and remove the godot-ai entry"
+				+ " by hand if needed."
+			)
+		"local":
+			return (
+				" The surviving entry is local-scoped: inspect this project's block in %s"
+				+ " and remove the godot-ai entry by hand if needed."
+			) % client.resolved_config_path()
+		_:
+			var path := client.resolved_config_path()
+			if path.is_empty():
+				return ""
+			return " Inspect %s and remove the godot-ai entry by hand if needed." % path
 
 
 static func manual_command(id: String) -> String:

--- a/plugin/addons/godot_ai/clients/_cli_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_cli_strategy.gd
@@ -320,10 +320,15 @@ static func _scope_probe_verdict(
 	if resolved.is_empty():
 		return _status_details(McpClient.Status.CONFIGURED)
 	if resolved != expected_scope:
-		return _status_details(
+		## `resolved_scope` rides along as a structured key so callers
+		## (`_verify_post_state`'s path hint) don't have to parse it back out
+		## of the human-facing message (#879).
+		var details := _status_details(
 			McpClient.Status.CONFIGURED_MISMATCH,
 			"registered at %s scope, not %s" % [resolved, expected_scope],
 		)
+		details["resolved_scope"] = resolved
+		return details
 	return _status_details(McpClient.Status.CONFIGURED)
 
 
@@ -333,6 +338,12 @@ static func _scope_probe_verdict(
 ## the JSON-fallback file is still a valid place to read status back from.
 static func uses_scope_token(client: McpClient) -> bool:
 	return client.cli_register_template.has(SCOPE_TOKEN)
+
+
+## Public view of the pre-cleanup sweep for the manual-command text, so what
+## the dock tells the user to run matches what Configure actually runs (#877).
+static func cleanup_scopes(client: McpClient) -> Array[String]:
+	return _cleanup_scopes(client)
 
 
 ## Scopes the configure pre-cleanup removes from. A descriptor without the

--- a/plugin/addons/godot_ai/clients/_manual_command.gd
+++ b/plugin/addons/godot_ai/clients/_manual_command.gd
@@ -66,13 +66,17 @@ static func _build_cli(
 			var parts: Array[String] = [short_name]
 			for arg in args:
 				parts.append(String(arg))
-			cmd = _format_shell_command(parts, shell_kind)
+			var lines := _sweep_lines(client, server_name, server_url, short_name, shell_kind)
+			lines.append(_render_command_line(parts, shell_kind))
+			cmd = _format_shell_block(lines, shell_kind)
 	else:
 		var args := McpCliStrategy.format_args(client.cli_register_template, server_name, server_url)
 		var parts: Array[String] = [short_name]
 		for arg in args:
 			parts.append(String(arg))
-		cmd = _format_shell_command(parts, shell_kind)
+		var lines := _sweep_lines(client, server_name, server_url, short_name, shell_kind)
+		lines.append(_render_command_line(parts, shell_kind))
+		cmd = _format_shell_block(lines, shell_kind)
 	# #463: a CLI client with a JSON fallback (Claude Code) may have no `claude`
 	# binary at all — e.g. installed only as a VS Code/Cursor extension. The CLI
 	# line above is useless to that user, so also show the config-file edit that
@@ -88,15 +92,50 @@ static func _shell_kind_for_platform() -> String:
 	return SHELL_POWERSHELL if OS.get_name() == "Windows" else SHELL_POSIX
 
 
+## #877: Configure's pre-cleanup removes `godot-ai` from every scope the
+## descriptor can write to before registering (see `_cli_strategy.gd`
+## `configure`). The manual text must show those removes too — otherwise the
+## snippet a user is told to run is not what Configure runs, and the sweep's
+## side effect (a `--scope project` remove edits the `.mcp.json` in the
+## CLI's cwd) stays invisible.
+static func _sweep_lines(
+	client: McpClient,
+	server_name: String,
+	server_url: String,
+	short_name: String,
+	shell_kind: String,
+) -> Array[String]:
+	var lines: Array[String] = []
+	if client.cli_unregister_template.is_empty():
+		return lines
+	for pre_scope in McpCliStrategy.cleanup_scopes(client):
+		var args := McpCliStrategy.format_args(
+			client.cli_unregister_template, server_name, server_url, {}, pre_scope
+		)
+		var parts: Array[String] = [short_name]
+		for arg in args:
+			parts.append(String(arg))
+		lines.append(_render_command_line(parts, shell_kind))
+	return lines
+
+
 ## Render a command for one explicitly named shell. The label is load-bearing:
 ## POSIX and PowerShell use different escaping for embedded single quotes, so
 ## presenting the command without its target shell invites a bad copy/paste.
 static func _format_shell_command(parts: Array[String], shell_kind: String) -> String:
+	return _format_shell_block([_render_command_line(parts, shell_kind)], shell_kind)
+
+
+static func _format_shell_block(lines: Array[String], shell_kind: String) -> String:
+	var label := "Run in PowerShell:" if shell_kind == SHELL_POWERSHELL else "Run in a POSIX shell:"
+	return "%s\n%s" % [label, "\n".join(lines)]
+
+
+static func _render_command_line(parts: Array[String], shell_kind: String) -> String:
 	var rendered: Array[String] = []
 	for part in parts:
 		rendered.append(_shell_display_arg(part, shell_kind))
-	var label := "Run in PowerShell:" if shell_kind == SHELL_POWERSHELL else "Run in a POSIX shell:"
-	return "%s\n%s" % [label, " ".join(rendered)]
+	return " ".join(rendered)
 
 
 ## Quote one argv element for the paste-into-terminal hint. Single-quoted

--- a/plugin/addons/godot_ai/clients/claude_code.gd
+++ b/plugin/addons/godot_ai/clients/claude_code.gd
@@ -19,6 +19,11 @@ func _init() -> void:
 	)
 	## Explicit scope: an unscoped `mcp remove` deletes from whichever scope
 	## matches first, which could eat a project-local entry the user made.
+	## The one sanctioned exception is Configure's pre-cleanup, which runs
+	## this template once per scope ON PURPOSE (`_cli_strategy.gd`
+	## `_cleanup_scopes`) so flipping the setting can't strand the old
+	## entry — the manual-command text renders those removes so the side
+	## effect is visible (#877).
 	cli_unregister_template = PackedStringArray(["mcp", "remove", "--scope", "{scope}", "{name}"])
 	## Scope caveat: `--scope project` resolves `.mcp.json` against the
 	## *spawned CLI's* working directory, which is whatever the editor process
@@ -43,18 +48,21 @@ func _init() -> void:
 	## #463: JSON fallback for when the `claude` binary isn't on PATH — e.g.
 	## Claude Code installed only as a VS Code / Cursor extension. The CLI is
 	## still preferred for Configure whenever it resolves; this is what gets
-	## written otherwise. `claude mcp add --scope user <name> -- <cmd> <args>`
-	## produces exactly this shape under `mcpServers` in ~/.claude.json
-	## (verified live against claude CLI in an isolated CLAUDE_CONFIG_DIR):
+	## written otherwise. At the default `user` scope, `claude mcp add
+	## --scope user <name> -- <cmd> <args>` produces exactly this shape under
+	## `mcpServers` in ~/.claude.json (verified live against claude CLI in an
+	## isolated CLAUDE_CONFIG_DIR):
 	##   "godot-ai": { "type": "stdio", "command": "<cmd>", "args": [...], "env": {} }
 	## The fallback writer omits the empty `env`; the verifier accepts both.
-	## Status always reads this file — it is the CLI's own store for user
-	## scope, and file reads give exact launch-drift detection that `mcp list`
-	## stdout scanning cannot.
+	## Status reads this file at the default `user` scope — the CLI's own
+	## store for that scope, and file reads give exact launch-drift detection
+	## that `mcp list` stdout scanning cannot. At `project`/`local` scope the
+	## entry lives elsewhere, so status routes to the `mcp get` scope probe
+	## instead — see `_scope_diverges_from_json_fallback` (#872).
 	path_template = {"unix": "~/.claude.json", "windows": "~/.claude.json"}
 	server_key_path = PackedStringArray(["mcpServers"])
 	## URL-mode shape, used only for the manual-instruction fallback text —
-	## `claude mcp add --scope user --transport http` writes {type: http, url}.
+	## `claude mcp add --scope <scope> --transport http` writes {type: http, url}.
 	entry_extra_fields = {"type": "http"}
 	command_shape = McpClient.CommandShape.FLAT
 	command_transport_key = "type"

--- a/test_project/tests/test_client_attach_config.gd
+++ b/test_project/tests/test_client_attach_config.gd
@@ -4,6 +4,7 @@ extends McpTestSuite
 ## #816 rollout steps 5-6: launch discovery plus Codex's TOML command shape.
 
 var _scratch_dir: String
+var _saved_client_scope: Variant = null
 
 
 func suite_name() -> String:
@@ -13,11 +14,30 @@ func suite_name() -> String:
 func suite_setup(_ctx: Dictionary) -> void:
 	_scratch_dir = OS.get_user_data_dir().path_join("mcp_attach_client_tests")
 	DirAccess.make_dir_recursive_absolute(_scratch_dir)
+	## #876: pin `godot_ai/mcp_client_scope` to the default for this suite.
+	## `_claude_cli_clone()` copies the real descriptor's `{scope}` templates
+	## (but deliberately not `cli_scope_status_template` — these tests prove
+	## the JSON fallback file is authoritative), and that premise only holds
+	## at the default `user` scope: at `project`/`local` the configurator
+	## routes status away from the file and the clone's fake CLI spawn-fails
+	## to NOT_CONFIGURED. The user's ambient editor setting must not decide
+	## whether this suite passes.
+	var es := EditorInterface.get_editor_settings()
+	if es != null:
+		if es.has_setting(McpSettings.SETTING_CLIENT_SCOPE):
+			_saved_client_scope = es.get_setting(McpSettings.SETTING_CLIENT_SCOPE)
+		es.set_setting(McpSettings.SETTING_CLIENT_SCOPE, McpSettings.DEFAULT_CLIENT_SCOPE)
 
 
 func suite_teardown() -> void:
 	for file_name in DirAccess.get_files_at(_scratch_dir):
 		DirAccess.remove_absolute(_scratch_dir.path_join(file_name))
+	var es := EditorInterface.get_editor_settings()
+	if es != null:
+		if _saved_client_scope == null:
+			es.set_setting(McpSettings.SETTING_CLIENT_SCOPE, McpSettings.DEFAULT_CLIENT_SCOPE)
+		else:
+			es.set_setting(McpSettings.SETTING_CLIENT_SCOPE, _saved_client_scope)
 
 
 func test_codex_descriptor_declares_attach_shape_and_timeouts() -> void:

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -1540,6 +1540,11 @@ func _make_scope_cli_client(path: String) -> McpClient:
 	)
 	c.cli_unregister_template = PackedStringArray(["mcp", "remove", "--scope", "{scope}", "{name}"])
 	c.cli_status_args = PackedStringArray(["mcp", "list"])
+	## #878: shaped like claude_code's, so the scope-probe gate in
+	## _dispatch_check_status_with_cli_path_details is actually reachable
+	## from a fixture — without this the probe wrapper only ever ran against
+	## a real `claude` binary, i.e. never in this suite.
+	c.cli_scope_status_template = PackedStringArray(["mcp", "get", "{name}"])
 	c.path_template = {"darwin": path, "windows": path, "linux": path, "unix": path}
 	c.server_key_path = PackedStringArray(["mcpServers"])
 	c.command_shape = McpClient.CommandShape.FLAT
@@ -1701,7 +1706,10 @@ func test_project_scope_status_leaves_the_user_scope_file() -> void:
 
 	## Passing cli_path explicitly is what makes the divergence real without
 	## depending on a `claude` binary existing on this machine. It never
-	## resolves, so the CLI probe spawn-fails rather than reporting CONFIGURED.
+	## resolves, so the probe spawn-fails rather than reporting CONFIGURED.
+	## (Since the fixture gained cli_scope_status_template (#878), the
+	## non-CONFIGURED reading below comes from the SCOPE probe spawn-failing,
+	## not the plain `mcp list` probe — same verdict, different path.)
 	var fake_cli := "godot-ai-nonexistent-cli-xyz"
 
 	es.set_setting(McpSettings.SETTING_CLIENT_SCOPE, McpSettings.DEFAULT_CLIENT_SCOPE)
@@ -1824,6 +1832,88 @@ func test_scope_probe_verdict_absent_entry_and_drift() -> void:
 	)
 
 
+## A fake CLI that records its argv to `argv_log` and prints `stdout_fixture`,
+## so the scope probe's SUBPROCESS wrapper (`check_scope_status_details`) and
+## the dispatch gate that calls it run for real without a `claude` binary on
+## the runner (#878). Windows gets a .bat — McpCliExec wraps those in
+## `cmd.exe /c` (#251); elsewhere a shebang script with the exec bit set.
+func _write_fake_probe_cli(stdout_fixture: String, argv_log: String) -> String:
+	var out_path := _scratch_dir.path_join("probe_stdout.txt")
+	_write_text(out_path, stdout_fixture)
+	if OS.get_name() == "Windows":
+		var bat := _scratch_dir.path_join("fake_scope_cli.bat")
+		_write_text(bat, "@echo off\r\necho %%* > \"%s\"\r\ntype \"%s\"\r\n" % [argv_log, out_path])
+		return bat
+	var sh := _scratch_dir.path_join("fake_scope_cli.sh")
+	_write_text(sh, "#!/bin/sh\nprintf '%%s ' \"$@\" > \"%s\"\ncat \"%s\"\n" % [argv_log, out_path])
+	var exec_mode := (
+		FileAccess.UNIX_READ_OWNER | FileAccess.UNIX_WRITE_OWNER | FileAccess.UNIX_EXECUTE_OWNER
+		| FileAccess.UNIX_READ_GROUP | FileAccess.UNIX_EXECUTE_GROUP
+		| FileAccess.UNIX_READ_OTHER | FileAccess.UNIX_EXECUTE_OTHER
+	)
+	assert_eq(FileAccess.set_unix_permissions(sh, exec_mode), OK, "test setup: chmod 0755")
+	return sh
+
+
+func test_dispatch_routes_scope_status_through_probe_with_selected_scope() -> void:
+	## #878: until this test, no fixture ever set cli_scope_status_template,
+	## so the probe gate in _dispatch_check_status_with_cli_path_details was
+	## unreachable in the suite — zero `mcp get` spawns — and two mutations
+	## survived: hardcoding the expected scope to the default, and rendering
+	## cli_status_args instead of the scope template. A fake CLI that echoes
+	## recorded `claude mcp get` output kills both.
+	var es := EditorInterface.get_editor_settings()
+	if es == null:
+		skip("EditorSettings unavailable in test environment")
+		return
+	var argv_log := _scratch_dir.path_join("probe_argv.log")
+	_remove_if_exists(argv_log)
+	var cli := _write_fake_probe_cli(_PROBE_USER, argv_log)
+	var client := _make_scope_cli_client(_scratch_dir.path_join("probe_route.json"))
+	var launch := {"ok": true, "command": _PROBE_TARGET, "args": []}
+
+	es.set_setting(McpSettings.SETTING_CLIENT_SCOPE, "project")
+	var at_project := McpClientConfigurator._dispatch_check_status_with_cli_path_details(
+		client, "", cli, {}, launch
+	)
+	## The fake CLI printed a user-scope entry, so the verdict must compare
+	## against the SELECTED scope — an expected-scope hardcoded to the
+	## default would read this as CONFIGURED.
+	assert_eq(at_project.get("status"), McpClient.Status.CONFIGURED_MISMATCH,
+		"a user-scope entry under a project selection must read as mismatch")
+	assert_contains(str(at_project.get("error_msg", "")), "user scope, not project")
+	assert_eq(at_project.get("resolved_scope"), "user",
+		"the mismatch verdict must carry the resolved scope as data, not only prose (#879)")
+	## And the spawned argv must come from cli_scope_status_template
+	## (`mcp get <name>`), not cli_status_args (`mcp list`).
+	var logged := _read_text(argv_log)
+	assert_contains(logged, "get")
+	assert_contains(logged, "godot-ai")
+	assert_false(logged.contains("list"),
+		"probe must render cli_scope_status_template, got argv: %s" % logged)
+
+	## A different selection flips only the expected side of the verdict —
+	## proof the live setting is threaded through, not a constant.
+	es.set_setting(McpSettings.SETTING_CLIENT_SCOPE, "local")
+	var at_local := McpClientConfigurator._dispatch_check_status_with_cli_path_details(
+		client, "", cli, {}, launch
+	)
+	assert_eq(at_local.get("status"), McpClient.Status.CONFIGURED_MISMATCH)
+	assert_contains(str(at_local.get("error_msg", "")), "user scope, not local")
+
+	## A matching entry goes green through the same subprocess path: swap the
+	## canned output to a project-scope entry and re-probe at project.
+	_write_text(_scratch_dir.path_join("probe_stdout.txt"), _PROBE_PROJECT)
+	es.set_setting(McpSettings.SETTING_CLIENT_SCOPE, "project")
+	var matching := McpClientConfigurator._dispatch_check_status_with_cli_path_details(
+		client, "", cli, {}, launch
+	)
+	assert_eq(matching.get("status"), McpClient.Status.CONFIGURED,
+		"a project-scope entry under a project selection is the ordinary green path")
+	_restore_client_scope()
+	_remove_if_exists(argv_log)
+
+
 func test_json_fallback_configure_notes_the_scope_it_could_not_honour() -> void:
 	## #872 + #463: with no CLI on PATH, Configure falls back to writing the
 	## config file directly — and that file is the USER-scope one whatever the
@@ -1891,6 +1981,21 @@ func test_claude_code_manual_command_shows_json_fallback() -> void:
 	assert_contains(cmd, "\"type\": \"stdio\"", "JSON fallback should show the stdio entry shape")
 	assert_contains(cmd, "Advanced fallback", "URL mode stays available as the documented fallback")
 	assert_contains(cmd, "\"type\": \"http\"", "URL fallback entry keeps the type:http shape")
+
+
+func test_claude_code_manual_command_renders_pre_cleanup_sweep() -> void:
+	## #877: Configure's first act is an all-scope `mcp remove` sweep, and
+	## its `--scope project` pass edits the `.mcp.json` in the CLI's cwd.
+	## The "Run this manually" text must show those removes — otherwise the
+	## snippet the user is told to run is not what Configure runs, and the
+	## sweep's side effect stays invisible.
+	var cmd := McpClientConfigurator.manual_command("claude_code")
+	for scope in McpSettings.CLIENT_SCOPES:
+		assert_contains(cmd, "mcp remove --scope %s godot-ai" % scope)
+	var remove_pos := cmd.find("mcp remove")
+	var add_pos := cmd.find("mcp add")
+	assert_true(add_pos >= 0 and remove_pos >= 0 and remove_pos < add_pos,
+		"the sweep must precede the register line, as Configure runs them")
 
 
 func test_manual_cli_shell_renderers_preserve_literal_argv() -> void:
@@ -2491,6 +2596,26 @@ func test_verify_post_state_errors_when_configure_did_not_land() -> void:
 	assert_contains(msg, "not_configured", "Error must name the actual status: %s" % msg)
 	assert_contains(msg, "configured", "Error must name the expected status: %s" % msg)
 	assert_contains(msg, path, "Error must include the resolved config path: %s" % msg)
+
+
+func test_post_state_path_hint_follows_resolved_scope() -> void:
+	## #879: after a cross-scope mismatch the surviving entry is NOT in
+	## `path_template`'s file — telling the user to inspect ~/.claude.json
+	## for a project-scope survivor sends them somewhere with nothing to
+	## find. The scope probe's verdict carries `resolved_scope`
+	## (test_dispatch_routes_scope_status_through_probe_with_selected_scope
+	## pins the plumbing); this pins the hint chosen from it.
+	var client := McpClientRegistry.get_by_id("claude_code")
+	var project_hint := McpClientConfigurator._post_state_path_hint(client, "project")
+	assert_contains(project_hint, ".mcp.json")
+	assert_false(project_hint.contains(".claude.json"),
+		"a project-scope survivor must not point at the user-scope file: %s" % project_hint)
+	var local_hint := McpClientConfigurator._post_state_path_hint(client, "local")
+	assert_contains(local_hint, ".claude.json",
+		"local scope lives in a per-project block of the user-scope file")
+	var default_hint := McpClientConfigurator._post_state_path_hint(client, "")
+	assert_contains(default_hint, client.resolved_config_path(),
+		"no probe scope keeps the historical resolved-path hint")
 
 
 func test_verify_post_state_errors_when_remove_left_entry_behind() -> void:


### PR DESCRIPTION
Fixes the four follow-up issues @azereki filed after #873 merged. Every specific claim in them was verified against `origin/main` (`143e3ba`) with file:line evidence before fixing — 12 of 13 confirmed exactly as written; the one nuance is noted under #879 below.

## #876 — suite red at `mcp_client_scope = project`

`test_client_attach_config.gd` now snapshots the setting in `suite_setup`, pins it to `McpSettings.DEFAULT_CLIENT_SCOPE` for the suite, and restores it in `suite_teardown`. The pin (rather than copying `cli_scope_status_template` into the clone) is deliberate: those tests exist to prove the JSON fallback file is authoritative, and that premise only holds at the default scope.

Regression proof: the full GDScript suite was run twice against a live editor — once at default scope and once with the ambient setting at `project`. Both green (2173/2200 passed, 0 failed; skips are environment-conditional).

## #877 — silent all-scope sweep (transparency only, no behavior change)

- The dock's "Run this manually" text now renders the pre-cleanup's remove commands (one per swept scope) ahead of the register line, via a new public `McpCliStrategy.cleanup_scopes()` view of the existing private helper — the snippet a user is told to run is now what Configure actually runs.
- The README's sweep sentence now states that the sweep runs on every Configure at any scope selection and links it to the CLI-cwd caveat it was previously divorced from.
- The sweep's behavior is intentionally unchanged — the stranded-entry guarantee from #873 stays, matching the issue's own lean toward option (1)+(2).

## #878 — scope probe now executes in the suite

- `_make_scope_cli_client()` gains `cli_scope_status_template`, making the probe gate reachable from a fixture.
- New `test_dispatch_routes_scope_status_through_probe_with_selected_scope` drives the real subprocess path with a fake recording CLI (a `.bat` on Windows — `McpCliExec` already wraps those in `cmd.exe /c` — a shebang script elsewhere) that echoes the recorded `claude mcp get` fixtures. It kills both surviving mutations from the issue: the fake CLI prints a user-scope entry, so a hardcoded default expected-scope reads green where the selected `project`/`local` scope must read `CONFIGURED_MISMATCH`; and the recorded argv is asserted to be `mcp get godot-ai`, not `cli_status_args`' `mcp list`.
- `test_project_scope_status_leaves_the_user_scope_file` got a comment noting it now exercises the scope-probe spawn-fail path rather than the plain probe (same verdict, different route), per the caveat in the issue analysis.

## #879 — cleanup trio

1. **Dead PATH walk dropped.** `_scope_diverges_from_json_fallback` loses the `resolve_cli_path` clause and its `cli_path` parameter; the docstring no longer claims the walk is decisive. When the CLI is unresolvable, the caller's #463 fallback branch reads the same file with identical arguments, so the clause could not change any outcome — it only cost a duplicate `McpCliFinder.find` per status check.
2. **Scope-aware verify hint.** The probe's mismatch verdict now carries `resolved_scope` as a structured key (no string-parsing of `error_msg`), and `_verify_post_state` picks its hint from it: a `project`-scope survivor points at the `.mcp.json` in the editor's launch directory (phrased, since `path_template` has no project-relative token), `local` at the per-project block in `~/.claude.json`, and the default keeps the historical `resolved_config_path()` hint. Pinned by `test_post_state_path_hint_follows_resolved_scope` plus the `resolved_scope` assertion in the #878 test.
3. **`claude_code.gd` comments refreshed.** The `--scope user` examples and the "Status always reads this file" claim now describe post-#873 behavior. One deviation from the issue: the `:20-21` unregister comment was **not** stale — it is the live rationale for the explicit `--scope` flag — but it was contradicted by the all-scope sweep, so it now names the sweep as the sanctioned exception instead of being deleted.

## Verification

- `ruff check` clean; `pytest`: 1780 passed, 5 skipped (no Python changes; confirms no breakage).
- `script/ci-check-gdscript`: all files OK.
- Live `script/ci-godot-tests` against a connected editor: **2173/2200 passed, 0 failed** at default scope **and** with ambient `mcp_client_scope = project` (the #876 repro).

Closes #876. Closes #877. Closes #878. Closes #879.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HL8hj91sBJdWj8ZoXkmrDz

---
_Generated by [Claude Code](https://claude.ai/code/session_01HL8hj91sBJdWj8ZoXkmrDz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client configuration checks for project and local scopes.
  * Corrected post-configuration status reporting and diagnostic file paths.
  * Ensured stale registrations are removed across configured scopes.

* **Improvements**
  * Manual setup commands now include accurate cleanup commands in the correct order.
  * Scope-specific behavior and mismatch details are reported more clearly.

* **Documentation**
  * Clarified Configure sweep behavior, scope handling, cleanup commands, and project-scope caveats in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->