### PR TITLE
ci: fail ci-godot-tests on silent partial suite discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,13 @@ jobs:
       - name: Run handler tests
         shell: bash
         timeout-minutes: 3
+        env:
+          # #882: floor on test_run's `total`, catching in-suite discovery
+          # truncation that the script's suite-count gate cannot see (a suite
+          # can register and still run fewer tests than it has). Keep this a
+          # little below the real count so ordinary churn doesn't trip it;
+          # lower it deliberately when tests are legitimately removed.
+          GODOT_AI_MIN_TESTS: "2190"
         run: bash script/ci-godot-tests
 
       - name: Reload smoke test

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -42,6 +42,9 @@ That's the whole loop.
   is reported in the response's `load_errors`; the remaining suites still run.
 - Suites run sorted by `suite_name()`; within a suite, `test_*` methods run in
   alphabetical order.
+- A `suite=` filter that names no registered suite is an error carrying
+  `suites_available`, not an empty run — `{"total": 0}` would be
+  indistinguishable from a silently truncated discovery (#882).
 - Test methods must be synchronous. The runner does not await coroutines — a
   test suspends at its first `await` and everything after it never runs
   (usually surfacing as a zero-assertion failure).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -42,9 +42,10 @@ That's the whole loop.
   is reported in the response's `load_errors`; the remaining suites still run.
 - Suites run sorted by `suite_name()`; within a suite, `test_*` methods run in
   alphabetical order.
-- A `suite=` filter that names no registered suite is an error carrying
-  `suites_available`, not an empty run — `{"total": 0}` would be
-  indistinguishable from a silently truncated discovery (#882).
+- A `suite=` filter that names no registered suite is an `INVALID_PARAMS`
+  protocol error carrying `suite` and `suites_available` in its error data,
+  not an empty run — `{"total": 0}` would be indistinguishable from a
+  silently truncated discovery (#882).
 - Test methods must be synchronous. The runner does not await coroutines — a
   test suspends at its first `await` and everything after it never runs
   (usually surfacing as a zero-assertion failure).

--- a/plugin/addons/godot_ai/handlers/test_handler.gd
+++ b/plugin/addons/godot_ai/handlers/test_handler.gd
@@ -88,6 +88,17 @@ func run_tests(params: Dictionary) -> Dictionary:
 		)
 
 	var suites: Array = discovery.suites
+	## #882: an explicit `suite` filter that matches nothing must say so, not
+	## return {"total": 0} — a caller cannot otherwise distinguish "suite has
+	## no tests" from "suite was never registered" (truncated discovery).
+	## Checked BEFORE the no-suites branch so an empty discovery still names
+	## the unmatched filter (with suites_available: []).
+	var unknown := unknown_suite_error(suite_filter, suites)
+	if not unknown.is_empty():
+		if not discovery.errors.is_empty():
+			unknown["error"]["data"]["load_errors"] = discovery.errors
+		return unknown
+
 	if suites.is_empty():
 		var msg := "No test suites found in res://tests/"
 		if not discovery.errors.is_empty():
@@ -100,14 +111,6 @@ func run_tests(params: Dictionary) -> Dictionary:
 		## so the response contract is consistent across every return path.
 		_annotate_edited_scene(no_suites)
 		return {"data": no_suites}
-
-	## #882: an explicit `suite` filter that matches nothing must say so, not
-	## return {"total": 0} — a caller cannot otherwise distinguish "suite has
-	## no tests" from "suite was never registered" (truncated discovery).
-	var unknown := unknown_suite_error(suite_filter, suites)
-	if not unknown.is_empty():
-		_annotate_edited_scene(unknown)
-		return {"data": unknown}
 
 	var ctx := {
 		"undo_redo": _undo_redo,
@@ -128,9 +131,11 @@ func run_tests(params: Dictionary) -> Dictionary:
 
 
 ## Empty when `suite_filter` is empty or names a discovered suite; otherwise
-## the error payload run_tests returns. Static + pure so the suite can pin it
-## without calling run_tests() end-to-end (which would recursively re-run the
-## whole corpus from inside itself — see test_serviced_test_run.gd).
+## the INVALID_PARAMS protocol error run_tests returns (same ErrorCodes.make
+## shape as the paused/timeout aborts — never an error inside a success
+## envelope). Static + pure so the suite can pin it without calling
+## run_tests() end-to-end (which would recursively re-run the whole corpus
+## from inside itself — see test_serviced_test_run.gd).
 static func unknown_suite_error(suite_filter: String, suites: Array) -> Dictionary:
 	if suite_filter.is_empty():
 		return {}
@@ -139,15 +144,19 @@ static func unknown_suite_error(suite_filter: String, suites: Array) -> Dictiona
 		names.append(suite.suite_name())
 	if names.has(suite_filter):
 		return {}
-	return {
-		"error": (
+	var err := ErrorCodes.make(
+		ErrorCodes.INVALID_PARAMS,
+		(
 			"No suite named '%s' is registered (%d discovered)."
 			+ " If it should exist, discovery may be truncated —"
 			+ " re-import and restart the editor (#882)."
 		) % [suite_filter, names.size()],
-		"total": 0,
+	)
+	err["error"]["data"] = {
+		"suite": suite_filter,
 		"suites_available": Array(names),
 	}
+	return err
 
 
 ## Map a runner/discovery outcome onto the response envelope. Ownership is

--- a/plugin/addons/godot_ai/handlers/test_handler.gd
+++ b/plugin/addons/godot_ai/handlers/test_handler.gd
@@ -101,6 +101,14 @@ func run_tests(params: Dictionary) -> Dictionary:
 		_annotate_edited_scene(no_suites)
 		return {"data": no_suites}
 
+	## #882: an explicit `suite` filter that matches nothing must say so, not
+	## return {"total": 0} — a caller cannot otherwise distinguish "suite has
+	## no tests" from "suite was never registered" (truncated discovery).
+	var unknown := unknown_suite_error(suite_filter, suites)
+	if not unknown.is_empty():
+		_annotate_edited_scene(unknown)
+		return {"data": unknown}
+
 	var ctx := {
 		"undo_redo": _undo_redo,
 		"log_buffer": _log_buffer,
@@ -117,6 +125,29 @@ func run_tests(params: Dictionary) -> Dictionary:
 	return _map_outcome(
 		run["outcome"], "run", results, run["tests_not_run"], started_ms, budget_sec
 	)
+
+
+## Empty when `suite_filter` is empty or names a discovered suite; otherwise
+## the error payload run_tests returns. Static + pure so the suite can pin it
+## without calling run_tests() end-to-end (which would recursively re-run the
+## whole corpus from inside itself — see test_serviced_test_run.gd).
+static func unknown_suite_error(suite_filter: String, suites: Array) -> Dictionary:
+	if suite_filter.is_empty():
+		return {}
+	var names := PackedStringArray()
+	for suite: McpTestSuite in suites:
+		names.append(suite.suite_name())
+	if names.has(suite_filter):
+		return {}
+	return {
+		"error": (
+			"No suite named '%s' is registered (%d discovered)."
+			+ " If it should exist, discovery may be truncated —"
+			+ " re-import and restart the editor (#882)."
+		) % [suite_filter, names.size()],
+		"total": 0,
+		"suites_available": Array(names),
+	}
 
 
 ## Map a runner/discovery outcome onto the response envelope. Ownership is

--- a/script/ci-godot-tests
+++ b/script/ci-godot-tests
@@ -242,8 +242,14 @@ for line in raw.split('\n'):
         suites_run = content.get('suites_run', []) or []
         if expected_suites and suite_count < expected_suites:
             print(f'ERROR: only {suite_count} of {expected_suites} expected suites ran — suite discovery was truncated (#882).')
+            # Normalize BOTH sides by stripping an optional test_ prefix:
+            # suite_name() usually drops it (test_clients.gd -> 'clients')
+            # but not always (test_runner.gd -> 'test_runner'), and naming
+            # the wrong missing suite would misdirect the debugging.
+            def stripped(name):
+                return name[5:] if name.startswith('test_') else name
             expected_names = set(os.environ.get('EXPECTED_SUITE_NAMES', '').split())
-            missing = sorted(expected_names - set(suites_run))
+            missing = sorted(expected_names - {stripped(s) for s in suites_run})
             if missing:
                 print('  suites with no matching run (filename-derived names): ' + ', '.join(missing))
             print('  Re-import and restart the editor, then re-run.')

--- a/script/ci-godot-tests
+++ b/script/ci-godot-tests
@@ -185,9 +185,28 @@ RESULT=$(curl -s "$SERVER_URL" -X POST "${HEADERS[@]}" \
   -H "Mcp-Session-Id: $SESSION_ID" \
   -d "$(printf '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"test_run","arguments":%s}}' "$TEST_ARGS")")
 
+# #882: discovery can be silently truncated — whole suites absent from
+# suites_run, or individual tests missing from a suite that did register —
+# with failed=0, no load_errors, and a non-zero total, so every gate below
+# this comment would pass over a hollowed-out run. Derive the expected suite
+# count from the checkout itself (suite files map 1:1 onto test_*.gd; helper
+# fixtures use mcp_/stub_ prefixes) so there is no magic number to drift.
+# GODOT_AI_MIN_TESTS (optional, set in the CI workflow) additionally floors
+# the total, because a suite-count check alone cannot see in-suite loss.
+# Anchored to the script's own location so the gate cannot be silently
+# disabled by running from a different cwd (an empty glob would read as
+# "expect 0 suites" and pass anything).
+TESTS_DIR="$(dirname "$0")/../test_project/tests"
+EXPECTED_SUITES=$(ls "$TESTS_DIR"/test_*.gd 2>/dev/null | wc -l | tr -d ' ')
+EXPECTED_SUITE_NAMES=$(ls "$TESTS_DIR"/test_*.gd 2>/dev/null | xargs -n1 basename 2>/dev/null | sed -e 's/^test_//' -e 's/\.gd$//')
+if [ "$EXPECTED_SUITES" -eq 0 ]; then
+  echo "ERROR: found no test_*.gd files under $TESTS_DIR — cannot establish the expected suite count (#882)"
+  exit 1
+fi
+
 # Parse and report results
-echo "$RESULT" | python3 -c "
-import json, sys
+echo "$RESULT" | EXPECTED_SUITES="$EXPECTED_SUITES" EXPECTED_SUITE_NAMES="$EXPECTED_SUITE_NAMES" python3 -c "
+import json, os, sys
 raw = sys.stdin.read()
 for line in raw.split('\n'):
     if line.startswith('data: '):
@@ -217,6 +236,25 @@ for line in raw.split('\n'):
         if total == 0:
             print('ERROR: No tests ran — Godot plugin may not have connected')
             sys.exit(1)
+        # #882: fail on partial discovery, not just all-or-nothing loss.
+        expected_suites = int(os.environ.get('EXPECTED_SUITES', '0') or 0)
+        suite_count = content.get('suite_count', 0)
+        suites_run = content.get('suites_run', []) or []
+        if expected_suites and suite_count < expected_suites:
+            print(f'ERROR: only {suite_count} of {expected_suites} expected suites ran — suite discovery was truncated (#882).')
+            expected_names = set(os.environ.get('EXPECTED_SUITE_NAMES', '').split())
+            missing = sorted(expected_names - set(suites_run))
+            if missing:
+                print('  suites with no matching run (filename-derived names): ' + ', '.join(missing))
+            print('  Re-import and restart the editor, then re-run.')
+            sys.exit(1)
+        min_tests = int(os.environ.get('GODOT_AI_MIN_TESTS', '0') or 0)
+        if min_tests and total < min_tests:
+            print(f'ERROR: total {total} is below the GODOT_AI_MIN_TESTS floor of {min_tests} — in-suite discovery was truncated (#882).')
+            print('  If tests were legitimately removed, lower GODOT_AI_MIN_TESTS in .github/workflows/ci.yml.')
+            sys.exit(1)
+        if expected_suites:
+            print(f'Suites: {suite_count}/{expected_suites} expected' + (f'; total floor: {min_tests}' if min_tests else ''))
         break
 else:
     print('ERROR: No valid response from test_run')

--- a/test_project/tests/test_serviced_test_run.gd
+++ b/test_project/tests/test_serviced_test_run.gd
@@ -360,7 +360,7 @@ func test_unknown_suite_filter_is_an_error_not_an_empty_run() -> void:
 	## #882: {"total": 0} for an unmatched `suite` filter is indistinguishable
 	## from a suite that registered with no tests — so a truncated discovery
 	## (suite file never registered) read as a harmless empty run. Pure-helper
-	## pin; run_tests() wires it in right after discovery.
+	## pin; run_tests() wires it in ahead of the no-suites branch.
 	var suites: Array = [ProbeSuite.new(), ClassifyProbe.new()]
 	assert_eq(TestHandlerScript.unknown_suite_error("", suites), {},
 		"no filter means no error")
@@ -368,10 +368,21 @@ func test_unknown_suite_filter_is_an_error_not_an_empty_run() -> void:
 		"a matching filter means no error")
 	var unknown: Dictionary = TestHandlerScript.unknown_suite_error("custom_tools", suites)
 	assert_false(unknown.is_empty(), "an unmatched filter must produce the error payload")
-	assert_contains(str(unknown.get("error", "")), "custom_tools")
-	assert_contains(str(unknown.get("error", "")), "truncated",
+	## A protocol error, never an "error" key inside a data success envelope —
+	## the same ErrorCodes.make contract as the paused/timeout aborts.
+	assert_is_error(unknown, ErrorCodes.INVALID_PARAMS)
+	var message := str(unknown["error"]["message"])
+	assert_contains(message, "custom_tools")
+	assert_contains(message, "truncated",
 		"the message must name the truncated-discovery possibility")
-	assert_eq(unknown.get("total"), 0)
-	var available: Array = unknown.get("suites_available", [])
+	var data: Dictionary = unknown["error"].get("data", {})
+	assert_eq(data.get("suite"), "custom_tools")
+	var available: Array = data.get("suites_available", [])
 	assert_true(available.has("probe") and available.has("classify_probe"),
 		"the payload lists what IS registered so the caller can self-diagnose")
+	## An EMPTY discovery with a filter still names the filter — the check
+	## runs before run_tests' no-suites branch (#883 review).
+	var empty_unknown: Dictionary = TestHandlerScript.unknown_suite_error("custom_tools", [])
+	assert_is_error(empty_unknown, ErrorCodes.INVALID_PARAMS)
+	assert_eq(empty_unknown["error"]["data"].get("suites_available"), [],
+		"zero discovered suites reads as an empty available list, not a crash")

--- a/test_project/tests/test_serviced_test_run.gd
+++ b/test_project/tests/test_serviced_test_run.gd
@@ -355,3 +355,23 @@ func test_batch_rejects_run_tests() -> void:
 		"rejection points at the test_run tool"
 	)
 	dispatcher.clear()
+
+func test_unknown_suite_filter_is_an_error_not_an_empty_run() -> void:
+	## #882: {"total": 0} for an unmatched `suite` filter is indistinguishable
+	## from a suite that registered with no tests — so a truncated discovery
+	## (suite file never registered) read as a harmless empty run. Pure-helper
+	## pin; run_tests() wires it in right after discovery.
+	var suites: Array = [ProbeSuite.new(), ClassifyProbe.new()]
+	assert_eq(TestHandlerScript.unknown_suite_error("", suites), {},
+		"no filter means no error")
+	assert_eq(TestHandlerScript.unknown_suite_error("probe", suites), {},
+		"a matching filter means no error")
+	var unknown: Dictionary = TestHandlerScript.unknown_suite_error("custom_tools", suites)
+	assert_false(unknown.is_empty(), "an unmatched filter must produce the error payload")
+	assert_contains(str(unknown.get("error", "")), "custom_tools")
+	assert_contains(str(unknown.get("error", "")), "truncated",
+		"the message must name the truncated-discovery possibility")
+	assert_eq(unknown.get("total"), 0)
+	var available: Array = unknown.get("suites_available", [])
+	assert_true(available.has("probe") and available.has("classify_probe"),
+		"the payload lists what IS registered so the caller can self-diagnose")


### PR DESCRIPTION
Implements the guard @azereki proposed in #882, including the revision from their follow-up comment: a suite-count floor alone cannot catch in-suite truncation (their `clients` suite registered and ran 163 of 174 tests while reporting green), so the suite-count gate is paired with an optional total floor.

## What changed

**`script/ci-godot-tests`** — after `test_run`, two new fail-closed gates:

1. **Suite-count assertion.** The expected count is derived from the checkout itself (`test_*.gd` files map 1:1 onto suites; helper fixtures use `mcp_`/`stub_` prefixes), so there is no magic number to drift. On a shortfall the script exits non-zero and prints the filename-derived names of the suites that never ran, plus the re-import/restart remedy. The glob is anchored to the script's own directory — running from a different cwd errors out rather than silently reading as "expect 0 suites".
2. **`GODOT_AI_MIN_TESTS` total floor** (optional env var). Catches the in-suite loss the suite-count check cannot see. Unset for local runs; set in `ci.yml` at `2190` (current total 2198) with a comment saying to lower it deliberately when tests are legitimately removed.

A healthy run now also prints `Suites: 69/69 expected` so the number is visible in CI logs even when nothing fires.

**`test_run` unknown-suite error** (the issue's optional suggestion) — a `suite=` filter that names no registered suite previously returned `{"total": 0}`, indistinguishable from "suite was never registered". It now returns an error naming the filter, the truncated-discovery possibility, and a `suites_available` list. The check is a pure static helper (`unknown_suite_error`) so `test_serviced_test_run.gd` can pin it without calling `run_tests()` end-to-end; documented in `docs/testing.md`.

## Verification

- Parser gates simulated offline against synthetic payloads: healthy run passes; 68/69-suite payload fails naming `custom_tools`; total-below-floor payload fails; env-less local run stays permissive on the floor.
- `bash -n` and `script/ci-check-gdscript` clean.
- Live run against a connected editor through the new gates: **2171/2198 passed, 0 failed, 27 skipped — `Suites: 69/69 expected`**, and the reported total matches the static `func test_` count exactly (2198), so the gate was proven against a verified-complete run.
- Live MCP smoke: `test_run(suite="definitely_not_a_suite")` returns the new error payload with 69 `suites_available`.

Not addressed here: the underlying discovery race itself (the `sleep 8` in the script). This PR makes the race loud when lost, per the issue's framing; making it un-losable is separable work.

Closes #882.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HL8hj91sBJdWj8ZoXkmrDz

---
_Generated by [Claude Code](https://claude.ai/code/session_01HL8hj91sBJdWj8ZoXkmrDz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid test-suite filters now return a clear error instead of an empty test run.
  - Test results now detect incomplete suite discovery and report missing suites and expected counts.
  - Added safeguards to ensure reported test totals meet the expected minimum.

- **Documentation**
  - Clarified the expected error response and available suite information for unknown filters.

- **Tests**
  - Added coverage for unknown, matching, empty, and unfiltered suite selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->