### PR TITLE
ci: let the ci-* runners target a non-default MCP port, document the headless opt-in

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -31,6 +31,19 @@ script/ci-godot-tests    # waits for the plugin, opens main.tscn, runs test_run,
                          # prints {suite}.{test}: {message} for each failure
 ```
 
+The probe above and every `script/ci-*` runner assume the server is on
+`:8000`, the plugin's default. If the connected editor's `godot_ai/http_port`
+is something else — the editor log names it in its
+`MCP | started server ... --port N` line — point them at it:
+
+```bash
+MCP_SERVER_URL=http://127.0.0.1:8123/mcp script/ci-godot-tests
+```
+
+The symptom of forgetting is a healthy editor log next to
+`No Godot session connected after 60 attempts`: the runner was polling a
+different server the whole time.
+
 **With several editors connected, pin the one you mean.** Multiple editors
 sharing port 8000 is a supported setup (see [worktrees](worktrees.md)), and
 `scene_open` would otherwise land in whichever session is active — yanking
@@ -59,8 +72,14 @@ editor to *look at* — the step 6 smoke test — or when nothing is running yet
    # macOS GUI
    /Applications/Godot_mono.app/Contents/MacOS/Godot --editor --path test_project/ &
    # headless (CI, containers, no display)
-   godot --headless --path test_project --editor >/tmp/godot-editor.log 2>&1 &
+   GODOT_AI_ALLOW_HEADLESS=1 GODOT_AI_DISABLE_TELEMETRY=true \
+     godot --headless --path test_project --editor >/tmp/godot-editor.log 2>&1 &
    ```
+   The headless form needs `GODOT_AI_ALLOW_HEADLESS=1`: without it the plugin
+   logs `MCP | plugin disabled in headless mode`, starts no server, and nothing
+   ever connects (see [server lifecycle](server-lifecycle.md)).
+   `GODOT_AI_DISABLE_TELEMETRY=true` keeps a local headless run out of
+   production telemetry, as `script/_ci_env.sh` does for the CI runners.
    Note the job's PID; `kill` it when you're done, and check `/tmp/godot-editor.log` if the plugin never connects.
 4. `session_activate` the test_project session if multiple editors are connected
 5. `test_run` via MCP — all GDScript tests pass (0 failures). `script/ci-godot-tests` does 3–5 in one command.

--- a/script/_ci_env.sh
+++ b/script/_ci_env.sh
@@ -7,3 +7,10 @@
 ## opt-out (no UUID generated, no worker thread, no _send). See
 ## docs/TELEMETRY.md.
 export GODOT_AI_DISABLE_TELEMETRY=true
+
+## Every ci-* runner reaches the MCP server through this URL. The default is
+## the plugin's default port; override it when the connected editor's
+## ``godot_ai/http_port`` is something else — the editor log names the port
+## in its ``MCP | started server ... --port N`` line. The Python runners
+## (ci-game-capture-smoke, local-game-capture-diag) read the same variable.
+export MCP_SERVER_URL="${MCP_SERVER_URL:-http://127.0.0.1:8000/mcp}"

--- a/script/ci-godot-tests
+++ b/script/ci-godot-tests
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
 # Run Godot handler tests via MCP in CI.
-# Expects: Python server running on port 8000, Godot editor launched with plugin.
+# Expects: Python server reachable at $MCP_SERVER_URL (default :8000, set in
+# _ci_env.sh), Godot editor launched with plugin.
 # This script waits for the plugin to connect before running tests.
 set -euo pipefail
 source "$(dirname "$0")/_ci_env.sh"
 
-SERVER_URL="http://127.0.0.1:8000/mcp"
+SERVER_URL="$MCP_SERVER_URL"
 HEADERS=(-H "Content-Type: application/json" -H "Accept: application/json, text/event-stream")
 
 # Wait for Godot plugin to connect (session_manage(op="list") returns count > 0)
-echo "Waiting for Godot plugin to connect..."
+echo "Waiting for Godot plugin to connect (server: $SERVER_URL)..."
 for i in $(seq 1 60); do
   # `|| true` neutralizes the pipeline status under `set -euo pipefail`:
   # a down server (curl exit 7) or a missing header (grep exit 1) must fall
@@ -56,7 +57,7 @@ for line in raw.split('\n'):
 done
 
 if [ -z "${SESSION_ID:-}" ]; then
-  echo "ERROR: Could not connect to MCP server"
+  echo "ERROR: Could not connect to MCP server at $SERVER_URL"
   exit 1
 fi
 
@@ -82,7 +83,9 @@ for line in raw.split('\n'):
 # silently pass the [ -eq ] test failure through (audit backlog).
 case "$FINAL_COUNT" in (""|*[!0-9]*) FINAL_COUNT=0;; esac
 if [ "$FINAL_COUNT" -eq 0 ] 2>/dev/null; then
-  echo "ERROR: No Godot session connected after 60 attempts. Plugin may not have loaded."
+  echo "ERROR: No Godot session connected after 60 attempts at $SERVER_URL."
+  echo "  Either the plugin did not load, or the editor's server is on another port:"
+  echo "  check the editor log's 'MCP | started server ... --port N' line and set MCP_SERVER_URL."
   exit 1
 fi
 

--- a/script/ci-quit-test
+++ b/script/ci-quit-test
@@ -2,11 +2,12 @@
 # Smoke-test the editor_quit tool in CI.
 # Calls editor_quit, then verifies the Godot session disconnects.
 #
-# Expects: Python server running on port 8000, Godot editor with plugin connected.
+# Expects: Python server reachable at $MCP_SERVER_URL (default :8000, set in
+# _ci_env.sh), Godot editor with plugin connected.
 set -euo pipefail
 source "$(dirname "$0")/_ci_env.sh"
 
-SERVER_URL="http://127.0.0.1:8000/mcp"
+SERVER_URL="$MCP_SERVER_URL"
 HEADERS=(-H "Content-Type: application/json" -H "Accept: application/json, text/event-stream")
 REQ_ID=0
 

--- a/script/ci-reload-test
+++ b/script/ci-reload-test
@@ -5,11 +5,12 @@
 # 3. Checks the log buffer is fresh (proves handlers were rebuilt)
 # 4. Finds the cube via the NEW plugin (proves scene tree continuity)
 #
-# Expects: Python server running on port 8000, Godot editor with plugin connected.
+# Expects: Python server reachable at $MCP_SERVER_URL (default :8000, set in
+# _ci_env.sh), Godot editor with plugin connected.
 set -euo pipefail
 source "$(dirname "$0")/_ci_env.sh"
 
-SERVER_URL="http://127.0.0.1:8000/mcp"
+SERVER_URL="$MCP_SERVER_URL"
 HEADERS=(-H "Content-Type: application/json" -H "Accept: application/json, text/event-stream")
 REQ_ID=0
 

--- a/script/ci-slow-suite-smoke
+++ b/script/ci-slow-suite-smoke
@@ -9,7 +9,7 @@
 # run, the server fails the in-flight future, and the tool call returns a
 # disconnect error — which this script reports as the reproduced bug.
 #
-# Expects (same contract as ci-godot-tests): Python server on :8000, Godot
+# Expects (same contract as ci-godot-tests): Python server at $MCP_SERVER_URL, Godot
 # editor running with the plugin connected. The fixture is removed on exit
 # via trap, pass or fail.
 #
@@ -27,7 +27,7 @@ FIXTURE_DST="$REPO_ROOT/test_project/tests/test_mcp_slow_smoke.gd"
 SUITE_NAME="mcp_slow_smoke"
 EXPECTED_TESTS=25
 
-SERVER_URL="http://127.0.0.1:8000/mcp"
+SERVER_URL="$MCP_SERVER_URL"
 HEADERS=(-H "Content-Type: application/json" -H "Accept: application/json, text/event-stream")
 
 cleanup() {


### PR DESCRIPTION
Two gaps found while running the verification gauntlet for #880 on a machine whose editor pins a non-default port.

### `ci-*` runners hard-coded `:8000`

`ci-godot-tests`, `ci-quit-test`, `ci-reload-test`, and `ci-slow-suite-smoke` all pinned `http://127.0.0.1:8000/mcp`. Two failure modes:

- An editor whose `godot_ai/http_port` is anything else connects fine to its own server, and the runner still reports `No Godot session connected after 60 attempts` — it was polling a different server the whole time. A healthy editor log next to that error is the telltale.
- Worse: if some *other* editor is on 8000, the runner drives it. The multi-session pin guard only fires past one session, so a single foreign session is driven without question — during verification here, a run at the default port reached a live game-project editor on 8000 and sent it `scene_open main.tscn` (the play-mode guard refused it, so nothing was touched, but only because that editor happened to be playing).

`script/_ci_env.sh` now exports `MCP_SERVER_URL` (default unchanged, so CI needs no changes), the four bash runners consume it, and `ci-godot-tests` names the URL in its wait/no-session messages so the mismatch is self-diagnosing. The variable name is the one `ci-game-capture-smoke` and `local-game-capture-diag` already read.

### `docs/verification.md` omitted the headless opt-in

The doc's headless launch line lacked `GODOT_AI_ALLOW_HEADLESS=1`; without it the plugin logs `MCP | plugin disabled in headless mode`, starts no server, and nothing ever connects. The session-start hook and `ci.yml` both set it — the doc a fresh contributor follows did not. The launch line now carries the opt-in plus `GODOT_AI_DISABLE_TELEMETRY=true` (mirroring `_ci_env.sh`), with a short explanation and a pointer to [docs/server-lifecycle.md](docs/server-lifecycle.md). The doc also documents the `MCP_SERVER_URL` override and its symptom.

### Verification

Godot 4.7.2-stable (`ed1daf0bf`), headless editor pinned to `:8123`:

- `MCP_SERVER_URL=http://127.0.0.1:8123/mcp script/ci-godot-tests` — **2164/2198 passed, 0 failed, 34 skipped, 69/69 suites** (the #883 suite-count guard active)
- default resolution unchanged: sourcing `_ci_env.sh` with nothing set yields `http://127.0.0.1:8000/mcp`; with the var exported, the override wins
- `bash -n` clean on all five scripts; `ruff` clean; `pytest` 1766 passed / 19 skipped

### Possible follow-up (not in this PR)

The single-foreign-session case above suggests `ci-godot-tests` should also verify the connected session's `project_path` matches this checkout's `test_project/` before `scene_open`, instead of trusting any lone session. Left out to keep this change to the two gaps it fixes; can file an issue if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring the MCP server URL when the editor uses a non-default port.
  - Automated checks now connect to the configured endpoint and provide clearer connection and session error guidance.

- **Documentation**
  - Documented the server URL configuration and troubleshooting steps.
  - Updated headless startup instructions to enable headless operation and disable telemetry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

