### PR TITLE
ci: verify editor project before driving a session

### DIFF
--- a/docs/verification.md
+++ b/docs/verification.md
@@ -48,8 +48,8 @@ Every shell `script/ci-*` runner verifies the editor before its first tool
 mutation. With no explicit pin, exactly one session must be connected and its
 normalized `project_path` must match this checkout's `test_project/`. This also
 catches a wrong `MCP_SERVER_URL` that happens to lead to one unrelated editor.
-Once selected, the runner pins every subsequent tool call to that session so a
-later connection cannot change the target.
+Once selected, the runner pins every subsequent non-session-management tool
+call to that session so a later connection cannot change the target.
 
 **With several editors connected, pin the one you mean.** Multiple editors
 sharing port 8000 is a supported setup (see [worktrees](worktrees.md)), so the

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -44,17 +44,23 @@ The symptom of forgetting is a healthy editor log next to
 `No Godot session connected after 60 attempts`: the runner was polling a
 different server the whole time.
 
+Every shell `script/ci-*` runner verifies the editor before its first tool
+mutation. With no explicit pin, exactly one session must be connected and its
+normalized `project_path` must match this checkout's `test_project/`. This also
+catches a wrong `MCP_SERVER_URL` that happens to lead to one unrelated editor.
+Once selected, the runner pins every subsequent tool call to that session so a
+later connection cannot change the target.
+
 **With several editors connected, pin the one you mean.** Multiple editors
-sharing port 8000 is a supported setup (see [worktrees](worktrees.md)), and
-`scene_open` would otherwise land in whichever session is active — yanking
-another session's open scene and testing the wrong project. The script refuses
-to guess: past one connected session it lists them and exits. Pick one with
+sharing port 8000 is a supported setup (see [worktrees](worktrees.md)), so the
+runners refuse to guess and list the connected sessions. Pick one with
 
 ```bash
 GODOT_AI_SESSION_ID='<project-slug>@<4hex>' script/ci-godot-tests
 ```
 
-which is passed as a per-call `session_id`, so it does not disturb the active
+which intentionally bypasses the checkout-path match for cross-worktree smoke
+runs and is passed as a per-call `session_id`, so it does not disturb the active
 session other clients are using. A pinned session that isn't connected fails
 loudly rather than falling back to the active one.
 

--- a/script/_ci_session_guard.py
+++ b/script/_ci_session_guard.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Select and pin the Godot editor session used by shell CI runners.
+
+The ci-* scripts may be run locally against a server shared by several editor
+worktrees.  A lone session is not automatically trustworthy: the configured
+MCP URL can point at an unrelated project.  This helper keeps the selection and
+path-normalization policy in one place so every shell runner fails closed in
+the same way.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _normalized_project_path(raw: str) -> str:
+    """Return a comparison form for a Godot or shell-reported project path."""
+
+    value = raw.strip().replace("\\", "/")
+    if os.name == "nt":
+        # Git Bash reports ``/c/path`` while Godot reports ``C:/path``.
+        match = re.match(r"^/([A-Za-z])(?:/(.*))?$", value)
+        if match:
+            suffix = match.group(2) or ""
+            value = f"{match.group(1)}:/{suffix}"
+
+    resolved = Path(value).expanduser().resolve(strict=False)
+    return os.path.normcase(os.path.normpath(str(resolved))).replace("\\", "/")
+
+
+def _read_object() -> dict[str, Any]:
+    try:
+        payload = json.load(sys.stdin)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"session response is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("session response must be a JSON object")
+    return payload
+
+
+def _sessions(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    sessions = payload.get("sessions")
+    if not isinstance(sessions, list):
+        raise ValueError("session response is missing a sessions array")
+    if not all(isinstance(session, dict) for session in sessions):
+        raise ValueError("session response contains a non-object session")
+    return sessions
+
+
+def _print_sessions(sessions: list[dict[str, Any]]) -> None:
+    print("Connected sessions:", file=sys.stderr)
+    if not sessions:
+        print("  (none)", file=sys.stderr)
+        return
+    for session in sessions:
+        session_id = session.get("session_id", "?")
+        project_path = session.get("project_path", "?")
+        print(f"  {session_id}  {project_path}", file=sys.stderr)
+
+
+def _select_session(payload: dict[str, Any], *, expected_project: str, explicit_pin: str) -> str:
+    sessions = _sessions(payload)
+
+    if explicit_pin:
+        matches = [session for session in sessions if session.get("session_id") == explicit_pin]
+        if len(matches) != 1:
+            print(
+                f"ERROR: GODOT_AI_SESSION_ID={explicit_pin!r} is not connected.",
+                file=sys.stderr,
+            )
+            _print_sessions(sessions)
+            raise SystemExit(1)
+        return explicit_pin
+
+    if len(sessions) != 1:
+        if not sessions:
+            print("ERROR: no Godot session is connected.", file=sys.stderr)
+        else:
+            print(
+                f"ERROR: {len(sessions)} Godot sessions are connected; "
+                "refusing to guess which one to drive.",
+                file=sys.stderr,
+            )
+        _print_sessions(sessions)
+        if sessions:
+            print(
+                "Re-run with GODOT_AI_SESSION_ID set to the one you mean.",
+                file=sys.stderr,
+            )
+        raise SystemExit(1)
+
+    selected = sessions[0]
+    session_id = selected.get("session_id")
+    project_path = selected.get("project_path")
+    if not isinstance(session_id, str) or not session_id:
+        raise ValueError("connected session is missing a non-empty session_id")
+    if not isinstance(project_path, str) or not project_path:
+        raise ValueError("connected session is missing a non-empty project_path")
+
+    expected_normalized = _normalized_project_path(expected_project)
+    actual_normalized = _normalized_project_path(project_path)
+    if actual_normalized != expected_normalized:
+        print(
+            "ERROR: the only connected Godot session belongs to a different project; "
+            "refusing to drive it.",
+            file=sys.stderr,
+        )
+        print(f"Expected project:  {expected_project}", file=sys.stderr)
+        print(f"Connected project: {project_path}", file=sys.stderr)
+        _print_sessions(sessions)
+        print(
+            "Check MCP_SERVER_URL, or set GODOT_AI_SESSION_ID explicitly if this "
+            "cross-project target is intentional.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    return session_id
+
+
+def _pin_args(payload: dict[str, Any], *, session_id: str) -> dict[str, Any]:
+    existing = payload.get("session_id")
+    if existing not in (None, "", session_id):
+        raise ValueError(
+            f"tool arguments already target session_id={existing!r}, "
+            f"not selected session {session_id!r}"
+        )
+    payload["session_id"] = session_id
+    return payload
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    select = subparsers.add_parser("select")
+    select.add_argument("--expected-project", required=True)
+    select.add_argument("--pin", default="")
+
+    pin_args = subparsers.add_parser("pin-args")
+    pin_args.add_argument("--session-id", required=True)
+    return parser
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    try:
+        payload = _read_object()
+        if args.command == "select":
+            print(
+                _select_session(
+                    payload,
+                    expected_project=args.expected_project,
+                    explicit_pin=args.pin,
+                )
+            )
+        else:
+            print(json.dumps(_pin_args(payload, session_id=args.session_id), separators=(",", ":")))
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/script/_ci_session_guard.py
+++ b/script/_ci_session_guard.py
@@ -38,9 +38,9 @@ def _read_object() -> dict[str, Any]:
     try:
         payload = json.load(sys.stdin)
     except json.JSONDecodeError as exc:
-        raise ValueError(f"session response is not valid JSON: {exc}") from exc
+        raise ValueError(f"input is not valid JSON: {exc}") from exc
     if not isinstance(payload, dict):
-        raise ValueError("session response must be a JSON object")
+        raise ValueError("input must be a JSON object")
     return payload
 
 

--- a/script/_ci_session_guard.sh
+++ b/script/_ci_session_guard.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+## Shared target-selection helpers for the shell ci-* runners.
+
+_CI_SESSION_GUARD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+ci_select_godot_session() { # sessions-json expected-project [explicit-pin]
+  local sessions_json="$1"
+  local expected_project="$2"
+  local explicit_pin="${3:-}"
+  printf '%s' "$sessions_json" | python3 \
+    "$_CI_SESSION_GUARD_DIR/_ci_session_guard.py" select \
+    --expected-project "$expected_project" \
+    --pin "$explicit_pin"
+}
+
+ci_pin_tool_args() { # arguments-json selected-session-id
+  local arguments_json="$1"
+  local session_id="$2"
+  printf '%s' "$arguments_json" | python3 \
+    "$_CI_SESSION_GUARD_DIR/_ci_session_guard.py" pin-args \
+    --session-id "$session_id"
+}

--- a/script/ci-godot-tests
+++ b/script/ci-godot-tests
@@ -4,7 +4,10 @@
 # _ci_env.sh), Godot editor launched with plugin.
 # This script waits for the plugin to connect before running tests.
 set -euo pipefail
-source "$(dirname "$0")/_ci_env.sh"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/_ci_env.sh"
+source "$SCRIPT_DIR/_ci_session_guard.sh"
 
 SERVER_URL="$MCP_SERVER_URL"
 HEADERS=(-H "Content-Type: application/json" -H "Accept: application/json, text/event-stream")
@@ -61,8 +64,10 @@ if [ -z "${SESSION_ID:-}" ]; then
   exit 1
 fi
 
-# Verify a Godot session is actually connected before running tests
-FINAL_COUNT=$(curl -s "$SERVER_URL" -X POST "${HEADERS[@]}" \
+# Resolve the exact editor this run will drive. A lone session is not trusted
+# until its project_path matches this checkout; after selection every call is
+# pinned so a later connection cannot change the active target (#885).
+FINAL_SESSIONS=$(curl -s "$SERVER_URL" -X POST "${HEADERS[@]}" \
   -H "Mcp-Session-Id: $SESSION_ID" \
   -d '{"jsonrpc":"2.0","id":99,"method":"tools/call","params":{"name":"session_manage","arguments":{"op":"list"}}}' \
   | python3 -c "
@@ -75,47 +80,16 @@ for line in raw.split('\n'):
         if not sc:
             text = data.get('result',{}).get('content',[{}])[0].get('text','{}')
             sc = json.loads(text)
-        print(sc.get('count', 0))
+        print(json.dumps(sc))
         break
-" 2>/dev/null || echo "0")
+" 2>/dev/null || true)
 
-# Fail closed: an empty/non-numeric parse must read as "no session", not
-# silently pass the [ -eq ] test failure through (audit backlog).
-case "$FINAL_COUNT" in (""|*[!0-9]*) FINAL_COUNT=0;; esac
-if [ "$FINAL_COUNT" -eq 0 ] 2>/dev/null; then
-  echo "ERROR: No Godot session connected after 60 attempts at $SERVER_URL."
-  echo "  Either the plugin did not load, or the editor's server is on another port:"
-  echo "  check the editor log's 'MCP | started server ... --port N' line and set MCP_SERVER_URL."
+if [ -z "$FINAL_SESSIONS" ]; then
+  echo "ERROR: Could not read connected sessions from $SERVER_URL."
   exit 1
 fi
-
-# Fail closed on ambiguity too. CI runs exactly one editor, but locally several
-# can share port 8000 — one per worktree is a supported setup. Without a pin,
-# `scene_open` and `test_run` below hit whichever session is active, which can
-# yank another session's open scene and run tests against the wrong project.
-# Set GODOT_AI_SESSION_ID=<project-slug>@<4hex> to target one deliberately.
-PIN_SESSION="${GODOT_AI_SESSION_ID:-}"
-if [ "$FINAL_COUNT" -gt 1 ] && [ -z "$PIN_SESSION" ]; then
-  echo "ERROR: $FINAL_COUNT Godot sessions are connected; refusing to guess which one to drive."
-  echo "Connected sessions:"
-  curl -s "$SERVER_URL" -X POST "${HEADERS[@]}" \
-    -H "Mcp-Session-Id: $SESSION_ID" \
-    -d '{"jsonrpc":"2.0","id":98,"method":"tools/call","params":{"name":"session_manage","arguments":{"op":"list"}}}' \
-    | python3 -c "
-import json, sys
-raw = sys.stdin.read()
-for line in raw.split('\n'):
-    if line.startswith('data: '):
-        data = json.loads(line[6:])
-        sc = data.get('result',{}).get('structuredContent',{})
-        if not sc:
-            text = data.get('result',{}).get('content',[{}])[0].get('text','{}')
-            sc = json.loads(text)
-        for s in sc.get('sessions', []):
-            print('  %s  %s' % (s.get('session_id','?'), s.get('project_path','?')))
-        break
-" 2>/dev/null || echo "  (could not list sessions)"
-  echo "Re-run with GODOT_AI_SESSION_ID set to the one you mean."
+if ! PIN_SESSION=$(ci_select_godot_session \
+  "$FINAL_SESSIONS" "$REPO_ROOT/test_project" "${GODOT_AI_SESSION_ID:-}"); then
   exit 1
 fi
 
@@ -199,7 +173,7 @@ RESULT=$(curl -s "$SERVER_URL" -X POST "${HEADERS[@]}" \
 # Anchored to the script's own location so the gate cannot be silently
 # disabled by running from a different cwd (an empty glob would read as
 # "expect 0 suites" and pass anything).
-TESTS_DIR="$(dirname "$0")/../test_project/tests"
+TESTS_DIR="$REPO_ROOT/test_project/tests"
 EXPECTED_SUITES=$(ls "$TESTS_DIR"/test_*.gd 2>/dev/null | wc -l | tr -d ' ')
 EXPECTED_SUITE_NAMES=$(ls "$TESTS_DIR"/test_*.gd 2>/dev/null | xargs -n1 basename 2>/dev/null | sed -e 's/^test_//' -e 's/\.gd$//')
 if [ "$EXPECTED_SUITES" -eq 0 ]; then

--- a/script/ci-quit-test
+++ b/script/ci-quit-test
@@ -104,7 +104,12 @@ for i in $(seq 1 20); do
   if ! TARGET_PRESENT=$(TARGET_GODOT_SESSION="$TARGET_GODOT_SESSION" python3 -c "
 import json, os, sys
 target = os.environ['TARGET_GODOT_SESSION']
-sessions = json.loads(sys.stdin.read()).get('sessions', [])
+payload = json.loads(sys.stdin.read())
+if not isinstance(payload, dict):
+    raise ValueError('session response must be a JSON object')
+sessions = payload.get('sessions')
+if not isinstance(sessions, list) or not all(isinstance(s, dict) for s in sessions):
+    raise ValueError('session response is missing a valid sessions array')
 print(1 if any(s.get('session_id') == target for s in sessions) else 0)
 " <<< "$SESSIONS"); then
     TARGET_PRESENT=1

--- a/script/ci-quit-test
+++ b/script/ci-quit-test
@@ -5,7 +5,10 @@
 # Expects: Python server reachable at $MCP_SERVER_URL (default :8000, set in
 # _ci_env.sh), Godot editor with plugin connected.
 set -euo pipefail
-source "$(dirname "$0")/_ci_env.sh"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/_ci_env.sh"
+source "$SCRIPT_DIR/_ci_session_guard.sh"
 
 SERVER_URL="$MCP_SERVER_URL"
 HEADERS=(-H "Content-Type: application/json" -H "Accept: application/json, text/event-stream")
@@ -15,6 +18,9 @@ REQ_ID=0
 mcp_call() {
   local tool="$1"
   local args="$2"
+  if [ "$tool" != "session_manage" ] && [ -n "${TARGET_GODOT_SESSION:-}" ]; then
+    args=$(ci_pin_tool_args "$args" "$TARGET_GODOT_SESSION") || return 1
+  fi
   REQ_ID=$((REQ_ID + 1))
   local raw
   raw=$(curl -s --max-time 30 "$SERVER_URL" -X POST "${HEADERS[@]}" \
@@ -64,13 +70,11 @@ curl -s "$SERVER_URL" -X POST "${HEADERS[@]}" \
 # Verify Godot is connected before quitting
 echo "Verifying Godot session..."
 SESSIONS=$(mcp_call session_manage '{"op":"list"}')
-COUNT=$(echo "$SESSIONS" | python3 -c "import json,sys; print(json.loads(sys.stdin.read()).get('count',0))")
-
-if [ "$COUNT" -eq 0 ] 2>/dev/null; then
-  echo "ERROR: No Godot session connected"
+if ! TARGET_GODOT_SESSION=$(ci_select_godot_session \
+  "$SESSIONS" "$REPO_ROOT/test_project" "${GODOT_AI_SESSION_ID:-}"); then
   exit 1
 fi
-echo "Godot session active (count: $COUNT)"
+echo "Godot session selected: $TARGET_GODOT_SESSION"
 
 # Call editor_quit
 echo "Calling editor_quit..."
@@ -91,15 +95,20 @@ echo "Waiting for session to disconnect..."
 for i in $(seq 1 20); do
   sleep 0.5
   # session_manage may fail if the MCP session expired — that's also fine
-  SESSIONS=$(mcp_call session_manage '{"op":"list"}' 2>/dev/null || echo '{"count":0}')
-  COUNT=$(echo "$SESSIONS" | python3 -c "import json,sys; print(json.loads(sys.stdin.read()).get('count',0))" 2>/dev/null || echo "0")
-  if [ "$COUNT" -eq 0 ] 2>/dev/null; then
+  SESSIONS=$(mcp_call session_manage '{"op":"list"}' 2>/dev/null || echo '{"sessions":[]}')
+  TARGET_PRESENT=$(TARGET_GODOT_SESSION="$TARGET_GODOT_SESSION" python3 -c "
+import json, os, sys
+target = os.environ['TARGET_GODOT_SESSION']
+sessions = json.loads(sys.stdin.read()).get('sessions', [])
+print(1 if any(s.get('session_id') == target for s in sessions) else 0)
+" <<< "$SESSIONS" 2>/dev/null || echo "0")
+  if [ "$TARGET_PRESENT" -eq 0 ] 2>/dev/null; then
     echo "Session disconnected after ~$((i / 2))s"
     break
   fi
 done
 
-if [ "$COUNT" -ne 0 ] 2>/dev/null; then
+if [ "$TARGET_PRESENT" -ne 0 ] 2>/dev/null; then
   echo "FAIL: Godot session still connected after 10s — quit did not work"
   exit 1
 fi

--- a/script/ci-quit-test
+++ b/script/ci-quit-test
@@ -92,16 +92,25 @@ print(f'editor_quit OK: {content.get(\"message\", \"\")}')
 # Verify the session disconnected (proves Godot actually shut down).
 # The session should disappear from the registry within a few seconds.
 echo "Waiting for session to disconnect..."
+TARGET_PRESENT=1
 for i in $(seq 1 20); do
   sleep 0.5
-  # session_manage may fail if the MCP session expired — that's also fine
-  SESSIONS=$(mcp_call session_manage '{"op":"list"}' 2>/dev/null || echo '{"sessions":[]}')
-  TARGET_PRESENT=$(TARGET_GODOT_SESSION="$TARGET_GODOT_SESSION" python3 -c "
+  # A failed registry query is not proof that the editor disconnected. Retry,
+  # and only pass after a successful response no longer contains our target.
+  if ! SESSIONS=$(mcp_call session_manage '{"op":"list"}'); then
+    echo "Session status check failed on attempt $i; retrying..." >&2
+    continue
+  fi
+  if ! TARGET_PRESENT=$(TARGET_GODOT_SESSION="$TARGET_GODOT_SESSION" python3 -c "
 import json, os, sys
 target = os.environ['TARGET_GODOT_SESSION']
 sessions = json.loads(sys.stdin.read()).get('sessions', [])
 print(1 if any(s.get('session_id') == target for s in sessions) else 0)
-" <<< "$SESSIONS" 2>/dev/null || echo "0")
+" <<< "$SESSIONS"); then
+    TARGET_PRESENT=1
+    echo "Session status response was invalid on attempt $i; retrying..." >&2
+    continue
+  fi
   if [ "$TARGET_PRESENT" -eq 0 ] 2>/dev/null; then
     echo "Session disconnected after ~$((i / 2))s"
     break

--- a/script/ci-reload-test
+++ b/script/ci-reload-test
@@ -8,7 +8,10 @@
 # Expects: Python server reachable at $MCP_SERVER_URL (default :8000, set in
 # _ci_env.sh), Godot editor with plugin connected.
 set -euo pipefail
-source "$(dirname "$0")/_ci_env.sh"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/_ci_env.sh"
+source "$SCRIPT_DIR/_ci_session_guard.sh"
 
 SERVER_URL="$MCP_SERVER_URL"
 HEADERS=(-H "Content-Type: application/json" -H "Accept: application/json, text/event-stream")
@@ -19,6 +22,9 @@ REQ_ID=0
 mcp_call() {
   local tool="$1"
   local args="$2"
+  if [ "$tool" != "session_manage" ] && [ -n "${TARGET_GODOT_SESSION:-}" ]; then
+    args=$(ci_pin_tool_args "$args" "$TARGET_GODOT_SESSION") || return 1
+  fi
   REQ_ID=$((REQ_ID + 1))
   local raw
   raw=$(curl -s --max-time 30 "$SERVER_URL" -X POST "${HEADERS[@]}" \
@@ -78,6 +84,17 @@ curl -s "$SERVER_URL" -X POST "${HEADERS[@]}" \
   -H "Mcp-Session-Id: $SESSION_ID" \
   -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' > /dev/null
 
+# Resolve and pin the exact editor before the first scene mutation. An
+# explicit pin intentionally bypasses the checkout path check for supported
+# cross-worktree smoke runs; an implicit lone session must match (#885).
+echo "Verifying Godot session..."
+SESSIONS=$(mcp_call_or_die "session list" session_manage '{"op":"list"}')
+if ! TARGET_GODOT_SESSION=$(ci_select_godot_session \
+  "$SESSIONS" "$REPO_ROOT/test_project" "${GODOT_AI_SESSION_ID:-}"); then
+  exit 1
+fi
+echo "Godot session selected: $TARGET_GODOT_SESSION"
+
 # --- Step 1: Create a cube with the OLD plugin ---
 echo "Creating test node with old plugin..."
 CREATE_RESULT=$(mcp_call_or_die "node_create" node_create '{"type":"MeshInstance3D","name":"ReloadTestCube","parent_path":""}')
@@ -109,6 +126,13 @@ if old_id == new_id:
     sys.exit(1)
 print(f'editor_reload_plugin OK: {old_id[:12]}... -> {new_id[:12]}...')
 "
+TARGET_GODOT_SESSION=$(python3 -c "
+import json, sys
+new_id = json.loads(sys.stdin.read()).get('new_session_id', '')
+if not new_id:
+    raise SystemExit('FAIL: editor_reload_plugin did not return new_session_id')
+print(new_id)
+" <<< "$RELOAD_RESULT")
 
 # --- Step 3: Verify log buffer is fresh (proves plugin fully rebuilt) ---
 echo "Checking log buffer..."
@@ -185,7 +209,14 @@ print(f'Game-logs path OK: total={total}, returned={content.get(\"returned_count
 # calls — catches both single-reload and cumulative-state regressions.
 echo "Running 9 more reload iterations..."
 for i in $(seq 2 10); do
-  mcp_call_or_die "editor_reload_plugin #$i" editor_reload_plugin '{}' > /dev/null
+  RELOAD_ITER_RESULT=$(mcp_call_or_die "editor_reload_plugin #$i" editor_reload_plugin '{}')
+  TARGET_GODOT_SESSION=$(python3 -c "
+import json, sys
+new_id = json.loads(sys.stdin.read()).get('new_session_id', '')
+if not new_id:
+    raise SystemExit('FAIL: editor_reload_plugin did not return new_session_id')
+print(new_id)
+" <<< "$RELOAD_ITER_RESULT")
   # Rotate the post-reload probe across the three reported-stable tools.
   case $(( i % 3 )) in
     0)

--- a/script/ci-slow-suite-smoke
+++ b/script/ci-slow-suite-smoke
@@ -19,9 +19,11 @@
 # a same session_id before/after is only a sanity check, because the plugin
 # reuses its session_id across reconnects (connection.gd::_ready).
 set -euo pipefail
-source "$(dirname "$0")/_ci_env.sh"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/_ci_env.sh"
+source "$SCRIPT_DIR/_ci_session_guard.sh"
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 FIXTURE_SRC="$REPO_ROOT/script/fixtures/test_mcp_slow_smoke.gd"
 FIXTURE_DST="$REPO_ROOT/test_project/tests/test_mcp_slow_smoke.gd"
 SUITE_NAME="mcp_slow_smoke"
@@ -62,22 +64,33 @@ else:
 }
 
 mcp_call() { # id name arguments-json
+  local args="$3"
+  if [ "$2" != "session_manage" ] && [ -n "${TARGET_GODOT_SESSION:-}" ]; then
+    args=$(ci_pin_tool_args "$args" "$TARGET_GODOT_SESSION") || return 1
+  fi
   curl -s -m 300 "$SERVER_URL" -X POST "${HEADERS[@]}" \
     -H "Mcp-Session-Id: $SESSION_ID" \
-    -d "{\"jsonrpc\":\"2.0\",\"id\":$1,\"method\":\"tools/call\",\"params\":{\"name\":\"$2\",\"arguments\":$3}}"
+    -d "{\"jsonrpc\":\"2.0\",\"id\":$1,\"method\":\"tools/call\",\"params\":{\"name\":\"$2\",\"arguments\":$args}}"
 }
 
-godot_session_id() {
+godot_sessions() {
   mcp_call 7 session_manage '{"op":"list"}' | extract_content | python3 -c "
 import json, sys
 sc = json.loads(sys.stdin.read())
-sessions = sc.get('sessions', [])
-print(sessions[0]['session_id'] if sessions else '')
+sc.pop('_is_error', None)
+sc.pop('_rpc_id', None)
+print(json.dumps(sc))
 "
 }
 
-echo "Installing slow fixture suite ($EXPECTED_TESTS tests)..."
-cp "$FIXTURE_SRC" "$FIXTURE_DST"
+godot_target_session_id() {
+  godot_sessions | TARGET_GODOT_SESSION="$TARGET_GODOT_SESSION" python3 -c "
+import json, os, sys
+target = os.environ['TARGET_GODOT_SESSION']
+sessions = json.loads(sys.stdin.read()).get('sessions', [])
+print(target if any(s.get('session_id') == target for s in sessions) else '')
+"
+}
 
 # --- MCP handshake + wait for a Godot session (mirrors ci-godot-tests) ---
 echo "Waiting for Godot plugin to connect..."
@@ -89,8 +102,15 @@ for i in $(seq 1 60); do
   if [ -z "$SESSION_ID" ]; then sleep 2; continue; fi
   curl -s "$SERVER_URL" -X POST "${HEADERS[@]}" -H "Mcp-Session-Id: $SESSION_ID" \
     -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' > /dev/null || true
-  GODOT_SESSION_BEFORE=$(godot_session_id || true)
-  if [ -n "${GODOT_SESSION_BEFORE:-}" ]; then
+  SESSIONS=$(godot_sessions || true)
+  SESSION_COUNT=$(python3 -c "import json,sys; print(len(json.loads(sys.stdin.read()).get('sessions', [])))" \
+    <<< "$SESSIONS" 2>/dev/null || echo "0")
+  if [ "$SESSION_COUNT" -gt 0 ] 2>/dev/null; then
+    if ! TARGET_GODOT_SESSION=$(ci_select_godot_session \
+      "$SESSIONS" "$REPO_ROOT/test_project" "${GODOT_AI_SESSION_ID:-}"); then
+      exit 1
+    fi
+    GODOT_SESSION_BEFORE="$TARGET_GODOT_SESSION"
     echo "Godot plugin connected (session: $GODOT_SESSION_BEFORE)"
     break
   fi
@@ -101,6 +121,9 @@ if [ -z "${GODOT_SESSION_BEFORE:-}" ]; then
   echo "ERROR: no Godot session connected"
   exit 1
 fi
+
+echo "Installing slow fixture suite ($EXPECTED_TESTS tests)..."
+cp "$FIXTURE_SRC" "$FIXTURE_DST"
 
 # Make sure discovery sees the just-copied fixture (fresh scan; the tool is
 # single-flight and settles before replying).
@@ -143,7 +166,7 @@ if failed or total != expected or passed != expected:
     sys.exit(1)
 "
 
-GODOT_SESSION_AFTER=$(godot_session_id || true)
+GODOT_SESSION_AFTER=$(godot_target_session_id || true)
 if [ "$GODOT_SESSION_AFTER" != "$GODOT_SESSION_BEFORE" ]; then
   echo "FAIL: session identity changed across the run ('$GODOT_SESSION_BEFORE' -> '$GODOT_SESSION_AFTER')"
   exit 1

--- a/tests/unit/test_ci_session_guard.py
+++ b/tests/unit/test_ci_session_guard.py
@@ -1,0 +1,170 @@
+"""Regression coverage for the shell CI session/project guard (#885)."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+HELPER_PATH = ROOT / "script" / "_ci_session_guard.py"
+
+
+def _load_helper() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("ci_session_guard", HELPER_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+guard = _load_helper()
+
+
+def _payload(*sessions: tuple[str, str]) -> dict:
+    return {
+        "count": len(sessions),
+        "sessions": [
+            {"session_id": session_id, "project_path": project_path}
+            for session_id, project_path in sessions
+        ],
+    }
+
+
+def test_selects_lone_matching_project_with_normalized_path(tmp_path: Path) -> None:
+    expected = tmp_path / "repo" / "test_project"
+    expected.mkdir(parents=True)
+    reported = str(expected).replace("/", "\\") + "\\"
+
+    selected = guard._select_session(
+        _payload(("godot-ai@a1b2", reported)),
+        expected_project=str(expected),
+        explicit_pin="",
+    )
+
+    assert selected == "godot-ai@a1b2"
+
+
+def test_rejects_lone_foreign_project(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    expected = tmp_path / "repo" / "test_project"
+    foreign = tmp_path / "other" / "test_project"
+    expected.mkdir(parents=True)
+    foreign.mkdir(parents=True)
+
+    with pytest.raises(SystemExit):
+        guard._select_session(
+            _payload(("other@ffff", str(foreign))),
+            expected_project=str(expected),
+            explicit_pin="",
+        )
+
+    error = capsys.readouterr().err
+    assert "different project" in error
+    assert "MCP_SERVER_URL" in error
+    assert "GODOT_AI_SESSION_ID" in error
+
+
+def test_explicit_pin_bypasses_project_check_and_selects_among_many(tmp_path: Path) -> None:
+    selected = guard._select_session(
+        _payload(
+            ("one@1111", str(tmp_path / "one")),
+            ("two@2222", str(tmp_path / "two")),
+        ),
+        expected_project=str(tmp_path / "expected"),
+        explicit_pin="two@2222",
+    )
+
+    assert selected == "two@2222"
+
+
+def test_rejects_ambiguous_sessions_without_pin(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with pytest.raises(SystemExit):
+        guard._select_session(
+            _payload(
+                ("one@1111", str(tmp_path / "one")),
+                ("two@2222", str(tmp_path / "two")),
+            ),
+            expected_project=str(tmp_path / "expected"),
+            explicit_pin="",
+        )
+
+    error = capsys.readouterr().err
+    assert "refusing to guess" in error
+    assert "one@1111" in error
+    assert "two@2222" in error
+
+
+def test_rejects_explicit_pin_that_is_not_connected(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with pytest.raises(SystemExit):
+        guard._select_session(
+            _payload(("one@1111", str(tmp_path / "one"))),
+            expected_project=str(tmp_path / "expected"),
+            explicit_pin="missing@9999",
+        )
+
+    assert "is not connected" in capsys.readouterr().err
+
+
+def test_pin_args_adds_selected_session_without_mutating_input() -> None:
+    original = {"op": "quit", "params": {}}
+
+    pinned = guard._pin_args(dict(original), session_id="godot-ai@a1b2")
+
+    assert pinned == {
+        "op": "quit",
+        "params": {},
+        "session_id": "godot-ai@a1b2",
+    }
+    assert "session_id" not in original
+
+
+def test_pin_args_rejects_conflicting_existing_target() -> None:
+    with pytest.raises(ValueError, match="already target"):
+        guard._pin_args(
+            {"op": "quit", "session_id": "other@ffff"},
+            session_id="godot-ai@a1b2",
+        )
+
+
+@pytest.mark.parametrize(
+    ("script_name", "first_mutation"),
+    [
+        ("ci-godot-tests", "SCENE_ARGS="),
+        ("ci-quit-test", "QUIT_RESULT="),
+        ("ci-reload-test", "CREATE_RESULT="),
+        ("ci-slow-suite-smoke", 'cp "$FIXTURE_SRC"'),
+    ],
+)
+def test_every_shell_runner_selects_a_session_before_mutation(
+    script_name: str, first_mutation: str
+) -> None:
+    source = (ROOT / "script" / script_name).read_text(encoding="utf-8")
+
+    assert 'source "$SCRIPT_DIR/_ci_session_guard.sh"' in source
+    assert source.index("ci_select_godot_session") < source.index(first_mutation)
+
+
+@pytest.mark.parametrize(
+    "script_name",
+    ["ci-quit-test", "ci-reload-test", "ci-slow-suite-smoke"],
+)
+def test_shared_mcp_call_runners_pin_non_session_tools(script_name: str) -> None:
+    source = (ROOT / "script" / script_name).read_text(encoding="utf-8")
+
+    assert 'if [ "$tool" != "session_manage" ]' in source or (
+        script_name == "ci-slow-suite-smoke" and 'if [ "$2" != "session_manage" ]' in source
+    )
+    assert "ci_pin_tool_args" in source
+
+
+def test_main_runner_pins_scene_and_test_calls() -> None:
+    source = (ROOT / "script" / "ci-godot-tests").read_text(encoding="utf-8")
+
+    assert "PIN_SESSION=$(ci_select_godot_session" in source
+    assert "args['session_id'] = pin" in source

--- a/tests/unit/test_ci_session_guard.py
+++ b/tests/unit/test_ci_session_guard.py
@@ -189,4 +189,6 @@ def test_quit_runner_fails_closed_when_session_status_query_fails() -> None:
     assert "TARGET_PRESENT=1" in source
     assert "if ! SESSIONS=$(mcp_call session_manage" in source
     assert "A failed registry query is not proof" in source
+    assert "sessions = payload.get('sessions')" in source
+    assert "if not isinstance(sessions, list)" in source
     assert "|| echo '{\"sessions\":[]}'" not in source

--- a/tests/unit/test_ci_session_guard.py
+++ b/tests/unit/test_ci_session_guard.py
@@ -98,6 +98,19 @@ def test_rejects_ambiguous_sessions_without_pin(
     assert "two@2222" in error
 
 
+def test_rejects_zero_sessions_without_pin(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with pytest.raises(SystemExit):
+        guard._select_session(
+            _payload(),
+            expected_project=str(tmp_path / "expected"),
+            explicit_pin="",
+        )
+
+    assert "no Godot session is connected" in capsys.readouterr().err
+
+
 def test_rejects_explicit_pin_that_is_not_connected(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -168,3 +181,12 @@ def test_main_runner_pins_scene_and_test_calls() -> None:
 
     assert "PIN_SESSION=$(ci_select_godot_session" in source
     assert "args['session_id'] = pin" in source
+
+
+def test_quit_runner_fails_closed_when_session_status_query_fails() -> None:
+    source = (ROOT / "script" / "ci-quit-test").read_text(encoding="utf-8")
+
+    assert "TARGET_PRESENT=1" in source
+    assert "if ! SESSIONS=$(mcp_call session_manage" in source
+    assert "A failed registry query is not proof" in source
+    assert "|| echo '{\"sessions\":[]}'" not in source


### PR DESCRIPTION
## Summary

Fixes the remaining session-identity gap in the shell `ci-*` runners.

A server URL with exactly one connected editor was previously trusted without checking which project owned that session. That let `ci-godot-tests`, `ci-quit-test`, `ci-reload-test`, and `ci-slow-suite-smoke` mutate, reload, test, or quit an unrelated editor if `MCP_SERVER_URL` pointed at the wrong backend.

This PR adds one shared selector and applies it before the first mutation in all four runners:

- without `GODOT_AI_SESSION_ID`, require exactly one connected session and require its normalized `project_path` to match this checkout's `test_project/`;
- with an explicit pin, require that session to exist and intentionally allow a cross-worktree project path;
- after selection, inject the selected `session_id` into every non-session-management tool call so a later connection cannot change the active target.

## Lifecycle details

- `ci-reload-test` adopts each `new_session_id` returned by `editor_reload_plugin` before its next call.
- `ci-quit-test` waits for the selected session to disappear rather than requiring every session on the server to disappear.
- `ci-slow-suite-smoke` does not install its fixture until the editor target passes the guard.
- `ci-godot-tests` reuses its existing JSON argument builder, but now always feeds it the validated selected ID.
- The verification guide documents the lone-session project check and explicit-pin bypass.

## Tests

- `pytest -q` — **1803 passed, 3 skipped**
- `ruff check src tests script/_ci_session_guard.py`
- `bash -n script/_ci_session_guard.sh script/ci-godot-tests script/ci-quit-test script/ci-reload-test script/ci-slow-suite-smoke`
- `git diff --check`

The new focused suite covers path normalization, lone-foreign rejection, ambiguous-session rejection, explicit-pin selection/bypass, conflicting argument pins, and guard-before-mutation wiring in every runner.

Fixes #885.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI smoke tests now select the editor session associated with the checkout and pin subsequent tool calls to it.
  * Explicit session selection is supported for cross-worktree testing.
  * Multiple connected editors are handled safely without guessing.

* **Bug Fixes**
  * Prevented actions from targeting unrelated or ambiguous sessions.
  * Added safeguards for invalid, disconnected, conflicting, or malformed session data.
  * Improved session identity verification after reloads and disconnects.

* **Documentation**
  * Updated the verification guide with session-selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->