### PR TITLE
fix: adopt editor-started game runs so the runtime bridge is not silently dead

### DIFF
--- a/plugin/addons/godot_ai/connection.gd
+++ b/plugin/addons/godot_ai/connection.gd
@@ -894,8 +894,17 @@ func _check_state_changes() -> void:
 func _check_game_run_play_state(playing: bool) -> void:
 	if playing == _last_play_state_for_run:
 		return
-	if not playing and debugger_plugin != null:
-		debugger_plugin.note_editor_play_stopped()
+	if debugger_plugin != null:
+		if playing:
+			## #891: adopt a play the user started from the editor. The
+			## debugger session's own adoption in `_setup_session` only fires
+			## when `is_playing_scene()` is already true when the session
+			## attaches, which an F5/F6 launch routinely misses; this edge is
+			## the other half of that race. Polled every tick regardless of
+			## socket state, same as the stop edge below.
+			debugger_plugin.note_editor_play_started()
+		else:
+			debugger_plugin.note_editor_play_stopped()
 	_last_play_state_for_run = playing
 
 

--- a/plugin/addons/godot_ai/connection.gd
+++ b/plugin/addons/godot_ai/connection.gd
@@ -888,9 +888,10 @@ func _check_state_changes() -> void:
 				log_buffer.log("[event] readiness -> %s" % readiness, false)
 
 
-## Playing→stopped edge for game-run bookkeeping. Runs every process tick
-## (any socket state) so a self-quit game's run ends even while the
-## transport is down or reconnecting.
+## Stopped↔playing edge handler for game-run bookkeeping. Handles both the
+## stopped→playing edge (adopting editor-started runs) and the playing→stopped
+## edge (ending runs). Runs every process tick (any socket state) so a
+## self-quit game's run ends even while the transport is down or reconnecting.
 func _check_game_run_play_state(playing: bool) -> void:
 	if playing == _last_play_state_for_run:
 		return

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -96,6 +96,13 @@ var _game_run_token := 0
 var _ready_run_token := -1
 var _game_session_id := -1
 var _game_run_active := false
+## Debugger session id of an `mcp:hello` that arrived before the run was
+## adopted, or -1 when none is held (#891). A manually started play can beat
+## its own adoption: the helper's boot beacon is a one-shot, so discarding it
+## left the runtime bridge dead for the whole run with no retry. Buffer it and
+## replay on adoption instead. Cleared whenever a run ends, so a beacon can
+## never carry across into a later run.
+var _pending_hello_session_id := -1
 var _manual_run_armed := false
 var _game_run_started_msec := 0
 var _game_run_started_editor_cursor := 0
@@ -192,6 +199,10 @@ func _begin_game_run_tracking(
 		if not run_id.is_empty():
 			log_text += " (run %s)" % run_id
 		_log_buffer.log(log_text)
+	## #891: a beacon that beat this adoption is held rather than dropped —
+	## consume it now so the bridge comes up without waiting for a second
+	## hello the game will never send.
+	_replay_pending_hello()
 
 
 func _editor_log_cursor() -> int:
@@ -202,6 +213,8 @@ func end_game_run() -> void:
 	_fail_pending_evals_not_ready(
 		"The game run ended before game_eval completed — the game stopped, crashed, or is restarting. Confirm it is running and retry."
 	)
+	## Never carry a held beacon across a run boundary (#891).
+	_pending_hello_session_id = -1
 	_game_run_active = false
 	_manual_run_armed = false
 	_game_ready = false
@@ -210,6 +223,20 @@ func end_game_run() -> void:
 	clear_debug_break()
 	if _surfaced_error_tracker != null:
 		_surfaced_error_tracker.note_game_run_stopped()
+
+
+## Editor play-state edge, stopped -> playing (#891). `_setup_session` adopts a
+## manually started play only when `EditorInterface.is_playing_scene()` is
+## ALREADY true at the instant Godot attaches the debugger session — an F5/F6
+## launch routinely loses that race, and the run was then never adopted at all,
+## leaving game_eval, game logs and runtime inspection silently dead for its
+## whole lifetime. This closes the race from the other side: whichever of the
+## two edges lands second performs the adoption. No-op for MCP-started runs,
+## which `project_run` already adopted via `begin_game_run`.
+func note_editor_play_started() -> void:
+	if _game_run_active:
+		return
+	_begin_game_run_tracking(_editor_log_cursor(), true, true, true, true, true)
 
 
 ## Authoritative fallback for runs whose debugger `stopped` signal never
@@ -221,8 +248,53 @@ func end_game_run() -> void:
 ## (run tracking begun, is_playing_scene() not yet true) is never clipped.
 func note_editor_play_stopped() -> void:
 	if not _game_run_active:
+		## A beacon held for an adoption that never happened must not survive
+		## into the next run (#891).
+		_pending_hello_session_id = -1
 		return
 	end_game_run()
+
+
+## Apply the game helper's boot beacon: the game has registered its "mcp"
+## capture and is safe to send take_screenshot / eval requests to — before
+## this, Godot's debugger drops our messages silently. Shared by the live
+## `mcp:hello` branch in `_capture` and by the buffered replay in
+## `_replay_pending_hello`, so a held beacon produces exactly the same state
+## and side effects as one that arrived after adoption (#891).
+func _accept_game_hello() -> void:
+	_pending_hello_session_id = -1
+	_game_ready = true
+	_ready_run_token = _game_run_token
+	## #641: boot-time parse errors race the hello beacon — both ride
+	## the same debugger channel, and the editor inserts Errors-tab
+	## rows with a per-frame throttle, so rows can land moments after
+	## the run is declared live. Arm forced scans so those rows get
+	## promoted into the watermark even if no tool call follows.
+	if _surfaced_error_tracker != null:
+		_surfaced_error_tracker.schedule_deferred_scans()
+	if _log_buffer:
+		if _game_log_buffer:
+			_log_buffer.log("[debug] <- mcp:hello from game_helper (run %s)" % _game_log_buffer.run_id())
+		else:
+			_log_buffer.log("[debug] <- mcp:hello from game_helper")
+
+
+## Consume a beacon that arrived before this run was adopted. Called at the end
+## of run-tracking setup; no-op when nothing is held (#891).
+func _replay_pending_hello() -> void:
+	if _pending_hello_session_id == -1:
+		return
+	var held := _pending_hello_session_id
+	if _game_session_id != -1 and held != _game_session_id:
+		## Belongs to a different debugger session than the one this run is
+		## bound to — drop it rather than declare the wrong game live.
+		_pending_hello_session_id = -1
+		if _log_buffer:
+			_log_buffer.log("[debug] dropped held mcp:hello from debugger session %d (current %d)" % [held, _game_session_id])
+		return
+	if _log_buffer:
+		_log_buffer.log("[debug] replaying held mcp:hello from debugger session %d" % held)
+	_accept_game_hello()
 
 
 func _connect_session_stopped(session_id: int) -> void:
@@ -698,31 +770,21 @@ func _capture(message: String, data: Array, session_id: int) -> bool:
 			return true
 		"mcp:hello":
 			if not _game_run_active:
+				## #891: the run is not adopted YET — a manually started play
+				## whose debugger session attached before the editor flipped
+				## `is_playing_scene()` lands here. The beacon is a one-shot,
+				## so hold it for the imminent adoption instead of dropping it
+				## (which left game_eval waiting forever for a hello that had
+				## already been thrown away).
+				_pending_hello_session_id = session_id
 				if _log_buffer:
-					_log_buffer.log("[debug] ignored mcp:hello with no active game run")
+					_log_buffer.log("[debug] holding mcp:hello from debugger session %d until the run is adopted" % session_id)
 				return true
 			if _game_session_id != -1 and session_id != _game_session_id:
 				if _log_buffer:
 					_log_buffer.log("[debug] ignored stale mcp:hello from debugger session %d (current %d)" % [session_id, _game_session_id])
 				return true
-			## Boot beacon from the game-side autoload. Tells us the
-			## game has registered its "mcp" capture and is safe to send
-			## take_screenshot to — before this, Godot's debugger would
-			## drop our message silently.
-			_game_ready = true
-			_ready_run_token = _game_run_token
-			## #641: boot-time parse errors race the hello beacon — both ride
-			## the same debugger channel, and the editor inserts Errors-tab
-			## rows with a per-frame throttle, so rows can land moments after
-			## the run is declared live. Arm forced scans so those rows get
-			## promoted into the watermark even if no tool call follows.
-			if _surfaced_error_tracker != null:
-				_surfaced_error_tracker.schedule_deferred_scans()
-			if _log_buffer:
-				if _game_log_buffer:
-					_log_buffer.log("[debug] <- mcp:hello from game_helper (run %s)" % _game_log_buffer.run_id())
-				else:
-					_log_buffer.log("[debug] <- mcp:hello from game_helper")
+			_accept_game_hello()
 			return true
 		"mcp:eval_liveness_response":
 			_on_eval_liveness_response(data)

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -103,6 +103,9 @@ var _game_run_active := false
 ## replay on adoption instead. Cleared whenever a run ends, so a beacon can
 ## never carry across into a later run.
 var _pending_hello_session_id := -1
+## True when holding a beacon already rotated the game-log run id, so the
+## adoption that consumes it must not rotate again (#891 review).
+var _pre_adoption_log_rotated := false
 var _manual_run_armed := false
 var _game_run_started_msec := 0
 var _game_run_started_editor_cursor := 0
@@ -175,13 +178,20 @@ func _begin_game_run_tracking(
 	sticky_debugger_scan: bool = true,
 	quiet: bool = false,
 	manual_armed: bool = false,
+	keep_session_id: int = -1,
 ) -> void:
 	_game_run_token += 1
 	_game_run_active = true
 	_manual_run_armed = manual_armed
 	_game_ready = false
 	_ready_run_token = -1
-	_game_session_id = -1
+	## Adopting a run whose game is ALREADY attached keeps that session id
+	## (#891 review): clearing it would leave every staleness guard comparing
+	## against -1, so a foreign session's `stopped` could end this live run —
+	## `_on_debugger_session_stopped` lets a manual-armed run end on any
+	## session while the id is unknown. Spawn-first callers pass -1 and keep
+	## the historical clear, since their game has not attached yet.
+	_game_session_id = keep_session_id
 	clear_debug_break()
 	_game_run_started_msec = Time.get_ticks_msec()
 	_game_run_started_editor_cursor = maxi(0, editor_log_cursor)
@@ -193,7 +203,17 @@ func _begin_game_run_tracking(
 	_game_helper_expected = helper_expected
 	var run_id := ""
 	if _game_log_buffer and rotate_game_log:
-		run_id = _game_log_buffer.clear_for_new_run()
+		if _pre_adoption_log_rotated:
+			## Already rotated when this game's beacon was held, so its boot
+			## output is tagged with the run id this adoption is about to
+			## announce. Rotating again here would orphan those lines under a
+			## superseded id and `logs_read(source="game")` — which returns the
+			## CURRENT run only — would report an empty log for a game whose
+			## only output happens in `_ready()` (#891 review).
+			run_id = _game_log_buffer.run_id()
+		else:
+			run_id = _game_log_buffer.clear_for_new_run()
+	_pre_adoption_log_rotated = false
 	if _log_buffer and not quiet:
 		var log_text := "[debug] game capture pending run token %d" % _game_run_token
 		if not run_id.is_empty():
@@ -215,6 +235,7 @@ func end_game_run() -> void:
 	)
 	## Never carry a held beacon across a run boundary (#891).
 	_pending_hello_session_id = -1
+	_pre_adoption_log_rotated = false
 	_game_run_active = false
 	_manual_run_armed = false
 	_game_ready = false
@@ -236,7 +257,23 @@ func end_game_run() -> void:
 func note_editor_play_started() -> void:
 	if _game_run_active:
 		return
-	_begin_game_run_tracking(_editor_log_cursor(), true, true, true, true, true)
+	## State belonging to the game that is already talking must survive the
+	## adoption that is about to reset run bookkeeping (#891 review).
+	var attached_session := _game_session_id
+	var had_break := _break_active
+	var break_can_debug := _break_can_debug
+	var break_reason := _break_reason
+	_begin_game_run_tracking(
+		_editor_log_cursor(), true, true, true, true, true, attached_session
+	)
+	if had_break:
+		## A boot parse error can break the game before the play-state edge
+		## lands. `_begin_game_run_tracking` clears break state, which would
+		## drop the actionable #645 diagnosis and leave game_status reporting
+		## "not_live" instead of "break". Re-record it against the new run so
+		## `_break_pre_live` and the synthetic-error scan are computed for THIS
+		## run — the beacon will never arrive for a game parked at a break.
+		note_debug_break(break_can_debug, break_reason)
 
 
 ## Authoritative fallback for runs whose debugger `stopped` signal never
@@ -251,6 +288,7 @@ func note_editor_play_stopped() -> void:
 		## A beacon held for an adoption that never happened must not survive
 		## into the next run (#891).
 		_pending_hello_session_id = -1
+		_pre_adoption_log_rotated = false
 		return
 	end_game_run()
 
@@ -792,6 +830,15 @@ func _capture(message: String, data: Array, session_id: int) -> bool:
 				## (which left game_eval waiting forever for a hello that had
 				## already been thrown away).
 				_pending_hello_session_id = session_id
+				## The beacon is this game's first word, and its boot output
+				## follows immediately (the helper flushes on its first
+				## `_process`). Rotate the run id NOW so those lines are tagged
+				## with the identity adoption will announce, instead of landing
+				## under the previous run and vanishing from
+				## `logs_read(source="game")` (#891 review).
+				if _game_log_buffer and not _pre_adoption_log_rotated:
+					_game_log_buffer.clear_for_new_run()
+					_pre_adoption_log_rotated = true
 				if _log_buffer:
 					_log_buffer.log("[debug] holding mcp:hello from debugger session %d until the run is adopted" % session_id)
 				return true

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -261,8 +261,14 @@ func note_editor_play_stopped() -> void:
 ## `mcp:hello` branch in `_capture` and by the buffered replay in
 ## `_replay_pending_hello`, so a held beacon produces exactly the same state
 ## and side effects as one that arrived after adoption (#891).
-func _accept_game_hello() -> void:
+func _accept_game_hello(session_id: int) -> void:
 	_pending_hello_session_id = -1
+	## Bind the run to the game that actually announced itself. Adoption
+	## clears `_game_session_id`, so without this a replayed beacon would
+	## leave the run bound to nothing and the staleness checks toothless
+	## until Godot's next `_setup_session` (#891 review).
+	if session_id != -1:
+		_game_session_id = session_id
 	_game_ready = true
 	_ready_run_token = _game_run_token
 	## #641: boot-time parse errors race the hello beacon — both ride
@@ -294,7 +300,7 @@ func _replay_pending_hello() -> void:
 		return
 	if _log_buffer:
 		_log_buffer.log("[debug] replaying held mcp:hello from debugger session %d" % held)
-	_accept_game_hello()
+	_accept_game_hello(held)
 
 
 func _connect_session_stopped(session_id: int) -> void:
@@ -769,6 +775,15 @@ func _capture(message: String, data: Array, session_id: int) -> bool:
 			_on_log_batch(data)
 			return true
 		"mcp:hello":
+			## Staleness is checked FIRST, before the buffering branch below:
+			## `_begin_game_run_tracking` clears `_game_session_id`, so a beacon
+			## validated only at replay time could never be rejected (#891
+			## review). A beacon from a session other than the attached one is
+			## some other game's — never hold it, never apply it.
+			if _game_session_id != -1 and session_id != _game_session_id:
+				if _log_buffer:
+					_log_buffer.log("[debug] ignored stale mcp:hello from debugger session %d (current %d)" % [session_id, _game_session_id])
+				return true
 			if not _game_run_active:
 				## #891: the run is not adopted YET — a manually started play
 				## whose debugger session attached before the editor flipped
@@ -780,11 +795,7 @@ func _capture(message: String, data: Array, session_id: int) -> bool:
 				if _log_buffer:
 					_log_buffer.log("[debug] holding mcp:hello from debugger session %d until the run is adopted" % session_id)
 				return true
-			if _game_session_id != -1 and session_id != _game_session_id:
-				if _log_buffer:
-					_log_buffer.log("[debug] ignored stale mcp:hello from debugger session %d (current %d)" % [session_id, _game_session_id])
-				return true
-			_accept_game_hello()
+			_accept_game_hello(session_id)
 			return true
 		"mcp:eval_liveness_response":
 			_on_eval_liveness_response(data)

--- a/test_project/tests/test_manual_play_adoption.gd
+++ b/test_project/tests/test_manual_play_adoption.gd
@@ -1,0 +1,102 @@
+@tool
+extends McpTestSuite
+
+## Repro for the manual-play adoption gap (observed live 2026-08-26).
+##
+## Pressing Play (F5/F6) in the editor can leave the MCP runtime bridge dead:
+## game_eval, game logs and runtime inspection silently never work for that
+## run. `begin_game_run()` has exactly ONE caller -- project_handler.gd's
+## `project_run` -- so an editor-started play depends entirely on the adoption
+## branch in `_setup_session`, which fires only when
+## `EditorInterface.is_playing_scene()` is ALREADY true at the instant the
+## debugger session attaches. When the session attaches first, the run is
+## never adopted and the game helper's boot beacon is discarded, while
+## game_eval waits forever for the hello that was thrown away:
+##
+##     MCP | [event] play_state_changed -> playing
+##     MCP | [debug] ignored mcp:hello with no active game run
+##     MCP | [debug] ignored mcp:hello with no active game run
+##     MCP | [debug] waiting for game_helper hello before eval
+
+func suite_name() -> String:
+	return "manual_play_adoption"
+
+
+func _plugin_with_log() -> McpDebuggerPlugin:
+	var plugin := McpDebuggerPlugin.new()
+	plugin._log_buffer = McpLogBuffer.new()
+	return plugin
+
+
+func test_manual_play_adopted_when_play_state_lands_before_hello() -> void:
+	## The reported ordering: session attaches first (adoption gate declines
+	## because is_playing_scene() is not yet true), the editor then flips play
+	## state, and only afterwards does the game announce itself.
+	var plugin := _plugin_with_log()
+	assert_false(EditorInterface.is_playing_scene(),
+		"precondition: suite runs with no game playing, matching the pre-play-state instant")
+	plugin._setup_session(1)
+	assert_false(plugin._game_run_active,
+		"characterization: _setup_session cannot adopt before the play-state flip")
+	plugin.note_editor_play_started()
+	assert_true(plugin._game_run_active,
+		"the play-state edge adopts the run the session attach could not")
+	var consumed := plugin._capture("mcp:hello", [], 1)
+	assert_true(consumed, "the hello is consumed off the debugger wire")
+	assert_true(plugin.is_game_capture_ready(),
+		"a manually started play must be adopted so game_eval / game logs work")
+
+
+func test_manual_play_hello_arriving_before_adoption_is_replayed() -> void:
+	## The reverse ordering: the beacon beats the play-state edge. It is a
+	## one-shot, so it must be held and replayed on adoption rather than
+	## dropped -- the game never sends a second one.
+	var plugin := _plugin_with_log()
+	plugin._setup_session(1)
+	var consumed := plugin._capture("mcp:hello", [], 1)
+	assert_true(consumed, "the early hello is consumed off the wire")
+	assert_false(plugin.is_game_capture_ready(),
+		"the bridge cannot be ready before the run is adopted")
+	plugin.note_editor_play_started()
+	assert_true(plugin.is_game_capture_ready(),
+		"the held beacon must be replayed on adoption, not discarded")
+
+
+func test_held_hello_is_not_carried_into_a_later_run() -> void:
+	## A beacon held for an adoption that never happened must not make some
+	## later, unrelated run look live without its own hello.
+	var plugin := _plugin_with_log()
+	plugin._setup_session(1)
+	plugin._capture("mcp:hello", [], 1)
+	plugin.note_editor_play_stopped()
+	plugin.note_editor_play_started()
+	assert_false(plugin.is_game_capture_ready(),
+		"a stale held beacon must be cleared when the play session ends")
+
+
+func test_play_started_edge_does_not_disturb_an_mcp_started_run() -> void:
+	## project_run adopts via begin_game_run(); the play-state edge then fires
+	## for the same launch and must be inert -- re-adopting would bump the run
+	## token and invalidate the hello that already landed.
+	var plugin := _plugin_with_log()
+	plugin._setup_session(1)
+	plugin.begin_game_run(0, true)
+	plugin._capture("mcp:hello", [], 1)
+	var token_before: int = plugin._game_run_token
+	plugin.note_editor_play_started()
+	assert_eq(plugin._game_run_token, token_before,
+		"an already-adopted run must not be re-adopted by the play-state edge")
+	assert_true(plugin.is_game_capture_ready(),
+		"the MCP-started run stays live across the play-state edge")
+
+
+func test_mcp_started_run_accepts_the_same_hello() -> void:
+	## Control: identical to the case above except for begin_game_run(), the one
+	## call project_run makes. This is why launching through MCP always works.
+	var plugin := _plugin_with_log()
+	plugin._setup_session(1)
+	plugin.begin_game_run(0, true)
+	var consumed := plugin._capture("mcp:hello", [], 1)
+	assert_true(consumed, "the hello is consumed off the debugger wire")
+	assert_true(plugin.is_game_capture_ready(),
+		"project_run's begin_game_run() makes the identical hello land")

--- a/test_project/tests/test_manual_play_adoption.gd
+++ b/test_project/tests/test_manual_play_adoption.gd
@@ -130,3 +130,98 @@ func test_accepted_hello_binds_the_run_to_its_debugger_session() -> void:
 	assert_true(plugin.is_game_capture_ready(), "precondition: held beacon replayed")
 	assert_eq(plugin._game_session_id, 7,
 		"the replayed beacon must bind the run to its own debugger session")
+
+
+## Counts the adoption calls the production play-state poll makes.
+class _SpyDebugger extends McpDebuggerPlugin:
+	var started := 0
+	var stopped := 0
+
+	func note_editor_play_started() -> void:
+		started += 1
+
+	func note_editor_play_stopped() -> void:
+		stopped += 1
+
+
+func test_connection_play_state_edge_drives_adoption() -> void:
+	## #891 review: without this, deleting the start-edge call in connection.gd
+	## -- the half that actually makes F5/F6 work -- leaves every other test in
+	## this suite passing. Drives the real McpConnection poll, not the plugin
+	## method directly.
+	var conn := McpConnection.new()
+	var spy := _SpyDebugger.new()
+	conn.debugger_plugin = spy
+	conn._last_play_state_for_run = false
+
+	conn._check_game_run_play_state(true)
+	assert_eq(spy.started, 1, "the stopped -> playing edge must adopt the run")
+	conn._check_game_run_play_state(true)
+	assert_eq(spy.started, 1, "a level, not an edge: no repeat adoption while play continues")
+	conn._check_game_run_play_state(false)
+	assert_eq(spy.stopped, 1, "the playing -> stopped edge must still end the run")
+	assert_eq(spy.started, 1, "the stop edge must not adopt")
+	conn.free()
+
+
+func test_adoption_keeps_the_attached_debugger_session() -> void:
+	## #891 review: clearing _game_session_id at adoption left every staleness
+	## guard comparing against -1, so a foreign session's `stopped` could end a
+	## live manual run (_on_debugger_session_stopped lets a manual-armed run end
+	## on any session while the id is unknown).
+	var plugin := _plugin_with_log()
+	plugin._setup_session(5)
+	plugin.note_editor_play_started()
+	assert_eq(plugin._game_session_id, 5,
+		"adoption must keep the session the game is already attached on")
+	plugin._on_debugger_session_stopped(9)
+	assert_true(plugin._game_run_active,
+		"a foreign session's stop must not end the adopted run")
+	plugin._on_debugger_session_stopped(5)
+	assert_false(plugin._game_run_active,
+		"the run's own session stopping still ends it")
+
+
+func test_adoption_preserves_a_pre_adoption_debugger_break() -> void:
+	## #891 review: a boot parse error breaks the game before the play-state
+	## edge. Adoption used to clear that break, losing the actionable #645
+	## diagnosis -- and the beacon never arrives for a game parked at a break,
+	## so nothing restored it.
+	var plugin := _plugin_with_log()
+	plugin._setup_session(1)
+	plugin.note_debug_break(true, "Parse error in res://broken.gd")
+	plugin.note_editor_play_started()
+	assert_true(plugin._break_active, "the break must survive adoption")
+	assert_eq(plugin._break_reason, "Parse error in res://broken.gd",
+		"the break reason must survive adoption")
+	assert_true(plugin._break_pre_live,
+		"the break must be re-evaluated as pre-live for the adopted run")
+
+
+func test_boot_output_stays_visible_under_the_adopted_run_id() -> void:
+	## #891 review: the helper flushes boot/main-scene output immediately after
+	## its beacon. If adoption rotated the run id afterwards, those lines stayed
+	## tagged with the superseded id -- and logs_read(source="game") returns the
+	## CURRENT run only, so a game whose only output happens in _ready() read as
+	## an empty log while the bridge reported live.
+	var plugin := _plugin_with_log()
+	var game_log := McpGameLogBuffer.new()
+	plugin._game_log_buffer = game_log
+	var run_before := game_log.run_id()
+
+	plugin._setup_session(1)
+	plugin._capture("mcp:hello", [], 1)
+	plugin._capture("mcp:log_batch", [[["info", "boot line from _ready"]]], 1)
+	var run_at_boot := game_log.run_id()
+	assert_true(run_at_boot != run_before,
+		"holding the beacon must start this game's run identity")
+
+	plugin.note_editor_play_started()
+	assert_eq(game_log.run_id(), run_at_boot,
+		"adoption must not rotate again and orphan the boot output")
+
+	var page := game_log.get_run_page(game_log.run_id(), 0, 10)
+	var entries: Array = page.get("entries", [])
+	assert_eq(entries.size(), 1,
+		"the boot line must be readable in the current run, the way logs_read returns it")
+	assert_eq(str(entries[0].get("text", "")), "boot line from _ready")

--- a/test_project/tests/test_manual_play_adoption.gd
+++ b/test_project/tests/test_manual_play_adoption.gd
@@ -100,3 +100,33 @@ func test_mcp_started_run_accepts_the_same_hello() -> void:
 	assert_true(consumed, "the hello is consumed off the debugger wire")
 	assert_true(plugin.is_game_capture_ready(),
 		"project_run's begin_game_run() makes the identical hello land")
+
+
+func test_hello_from_another_debugger_session_is_never_held() -> void:
+	## #891 review: the beacon must be rejected on ARRIVAL, not at replay time.
+	## Adoption clears _game_session_id, so a beacon validated only on replay
+	## could never be rejected -- another game's hello would mark this run ready
+	## before its own helper had registered, letting runtime tools skip the
+	## readiness wait.
+	var plugin := _plugin_with_log()
+	plugin._setup_session(1)
+	var consumed := plugin._capture("mcp:hello", [], 2)
+	assert_true(consumed, "the foreign hello is still consumed off the wire")
+	assert_eq(plugin._pending_hello_session_id, -1,
+		"a beacon from a session other than the attached one must not be held")
+	plugin.note_editor_play_started()
+	assert_false(plugin.is_game_capture_ready(),
+		"adoption must not go ready on another debugger session's beacon")
+
+
+func test_accepted_hello_binds_the_run_to_its_debugger_session() -> void:
+	## Adoption clears _game_session_id; accepting a beacon re-binds the run to
+	## the game that announced itself, so later staleness checks have something
+	## to compare against instead of silently passing.
+	var plugin := _plugin_with_log()
+	plugin._setup_session(7)
+	plugin._capture("mcp:hello", [], 7)
+	plugin.note_editor_play_started()
+	assert_true(plugin.is_game_capture_ready(), "precondition: held beacon replayed")
+	assert_eq(plugin._game_session_id, 7,
+		"the replayed beacon must bind the run to its own debugger session")

--- a/test_project/tests/test_manual_play_adoption.gd.uid
+++ b/test_project/tests/test_manual_play_adoption.gd.uid
@@ -1,0 +1,1 @@
+uid://gptiymwq7dga


### PR DESCRIPTION
## Problem

Pressing **Play (F5/F6) in the editor** could leave every MCP runtime tool dead for that run — silently. `game_eval` returned `EVAL_GAME_NOT_READY`, `logs_read(source="game")` stayed empty, and `game_status` reported `stopped` while the editor reported `is_playing=true`. Launching the same scene through `project_run` worked fine, which is why this went unnoticed.

Caught live on v3.2.1 while trying to read a running game's FPS. The plugin log names the cause:

```
MCP | [event] play_state_changed -> playing
MCP | [debug] ignored mcp:hello with no active game run
MCP | [debug] ignored mcp:hello with no active game run
MCP | [debug] waiting for game_helper hello before eval
```

`begin_game_run()` has exactly **one** caller — `project_handler.gd`'s `project_run`. So an editor-started play depends entirely on the adoption branch in `_setup_session`, which fires only when `EditorInterface.is_playing_scene()` is **already** true at the instant Godot attaches the debugger session. An F5/F6 launch routinely loses that race. The run is then never adopted, and the game helper's boot beacon is discarded — and because the beacon is a one-shot, nothing ever retries. The bridge stays dead for the run's whole lifetime while `game_eval` waits for the very hello that was thrown away.

## Fix

Both halves of the race are closed, so ordering no longer matters:

- **`connection.gd`** — the `stopped → playing` edge (already polled every tick for the stop side, independent of socket state) calls the new `note_editor_play_started()`, adopting a run `_setup_session` could not. Inert for MCP-started runs, which `project_run` already adopted.
- **`mcp_debugger_plugin.gd`** — an `mcp:hello` arriving *before* adoption is **held** (`_pending_hello_session_id`) rather than discarded, and replayed at the end of run-tracking setup. The held beacon is cleared on every run end and dropped if it belongs to a different debugger session, so it can never make a later or unrelated run look live. The accept path is factored into `_accept_game_hello()` so a replayed beacon produces identical state and side effects (including the #641 deferred error scans).

## Tests

New `manual_play_adoption` suite (5 tests) covering both orderings plus two safety properties: a stale held beacon must not carry into a later run, and the play-state edge must not re-adopt (and thus invalidate) an already-live MCP-started run. **Its first test fails on the pre-fix code** — that failure is how the bug was confirmed before any fix was written.

## Verification

- `ruff` clean; `pytest` **1815 passed**; full GDScript suite **2263 passed / 0 failed** (70 suites).
- **End-to-end live check**: drove `EditorInterface.play_custom_scene()` inside a live editor — the editor's own Play path, bypassing `project_run` entirely — then polled. Result: `status=live, run_token=1, helper_live=true, ready=true`, and `game_eval` answered `{"fps": 60.0}`. The same launch pre-fix left `run_token=0, helper_live=false, status=stopped`. Trace is clean: `-> mcp:eval_liveness → mcp:eval → eval_ack → eval_compiled → eval_response`, with no discarded hello.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved debugger support for games started through the editor’s Play button.
  * Preserved startup connection signals, debugger sessions, breakpoints, and boot logs under the correct run.
  * Prevented stale signals from affecting later runs.
  * Improved play and stop event handling without disrupting MCP-started runs.

* **Tests**
  * Added coverage for editor-started runs, startup timing conditions, session validation, signal cleanup, breakpoints, and MCP-started runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->