### PR TITLE
fix: stop path validation from printing a bogus NUL Unicode error (#889)

### DIFF
--- a/plugin/addons/godot_ai/utils/path_validator.gd
+++ b/plugin/addons/godot_ai/utils/path_validator.gd
@@ -55,6 +55,34 @@ static func _user_root() -> String:
 	return _cached_user_root
 
 
+## True when `path` carries a codepoint that must never reach a filesystem API.
+##
+## Issue #889: the previous guard built its sentinel with `String.chr(0)`, and
+## Godot emits `Unicode parsing error … Unexpected NUL character` while
+## *constructing* that string. Every validated call — including reads that then
+## failed with "File not found" — printed an alarming engine error that had
+## nothing to do with the caller's path. Reading codepoints instead never
+## materialises a NUL String, so the noise is gone.
+##
+## Both codepoints are rejected, for different reasons:
+##   * `0x0000` — a real embedded NUL can truncate a C string, so the path that
+##     is validated is not the path that gets opened. Current Godot cannot
+##     retain one in a String, making this a no-op today; it stays as
+##     defense-in-depth for any build or input path that can.
+##   * `0xFFFD` — what current Godot actually substitutes for a NUL or any other
+##     undecodable input. Once the engine has replaced the byte there is no way
+##     left to tell an attempted NUL from malformed UTF-8 from a literal
+##     replacement character, so the only safe reading at a security boundary is
+##     to refuse all three. A legitimate filename containing U+FFFD is rejected
+##     too; that false positive is deliberate and vanishingly rare.
+static func _contains_invalid_path_codepoint(path: String) -> bool:
+	for i in path.length():
+		var codepoint := path.unicode_at(i)
+		if codepoint == 0x0000 or codepoint == 0xFFFD:
+			return true
+	return false
+
+
 ## Returns "" when the path is a safe `res://`-rooted reference inside the
 ## project root. Returns a human-readable error message otherwise.
 ## Prefer `path_error` over calling this directly — it wraps the message in the
@@ -68,12 +96,8 @@ static func _user_root() -> String:
 static func validate_resource_path(path: String, for_write: bool = false) -> String:
 	if path.is_empty():
 		return "Missing required param: path"
-	## Guard the sentinel: on builds where String.chr(0) yields "" (some engines
-	## normalize embedded nulls away, e.g. 4.3), contains("") would be true and
-	## reject every path. A String that can't hold a null can't smuggle one.
-	var nul := String.chr(0)
-	if not nul.is_empty() and path.contains(nul):
-		return "Path must not contain null bytes"
+	if _contains_invalid_path_codepoint(path):
+		return "Path must not contain null bytes or invalid Unicode"
 	if not path.begins_with("res://"):
 		return "Path must start with res://"
 	var confine_err := _confine_under(path, _res_root(), "res://")
@@ -94,12 +118,8 @@ static func validate_resource_path(path: String, for_write: bool = false) -> Str
 static func validate_loadable_path(path: String) -> String:
 	if path.is_empty():
 		return "Missing required param: path"
-	## Guard the sentinel: on builds where String.chr(0) yields "" (some engines
-	## normalize embedded nulls away, e.g. 4.3), contains("") would be true and
-	## reject every path. A String that can't hold a null can't smuggle one.
-	var nul := String.chr(0)
-	if not nul.is_empty() and path.contains(nul):
-		return "Path must not contain null bytes"
+	if _contains_invalid_path_codepoint(path):
+		return "Path must not contain null bytes or invalid Unicode"
 	if path.begins_with("uid://"):
 		return ""
 	if path.begins_with("user://"):

--- a/test_project/tests/test_path_validator.gd
+++ b/test_project/tests/test_path_validator.gd
@@ -98,22 +98,36 @@ func test_well_formed_nested_path_passes_boundary_check() -> void:
 
 # ----- null byte (truncation trap, audit GH-4) -----
 
-func test_rejects_embedded_null_byte() -> void:
+func test_rejects_replacement_character() -> void:
 	## A NUL can truncate a C string, so the path written could differ from the
-	## one validated/reported. Reject any path containing one.
+	## one validated/reported. Godot cannot hold U+0000 in a String — it decodes
+	## an attempted NUL (and any other malformed input) to U+FFFD — so U+FFFD is
+	## what an embedded-null payload actually looks like by the time it reaches
+	## the validator. Reject it.
 	##
-	## Some Godot builds (e.g. 4.3) strip embedded nulls from String, so the
-	## payload can't be constructed there — the validator's check is simply a
-	## harmless no-op on those builds (a String that can't hold a null can't
-	## smuggle one past the guard). Skip rather than assert 4.6-only behavior.
-	var nul := String.chr(0)
-	if nul.is_empty() or not ("res://a" + nul + "b").contains(nul):
-		skip("this Godot build does not retain embedded null bytes in String")
-		return
-	# No "..": the ONLY reason to reject this path is the embedded null.
-	var err := McpPathValidator.validate_resource_path("res://safe" + nul + "name.gd")
-	assert_false(err.is_empty(), "path with an embedded null byte must be rejected")
+	## Deliberately does NOT build the payload with `String.chr(0)`: constructing
+	## that string is itself what made the engine print "Unexpected NUL
+	## character" on every validated path (issue #889).
+	# No "..": the ONLY reason to reject this path is the bad codepoint.
+	var err := McpPathValidator.validate_resource_path("res://safe\uFFFDname.gd")
+	assert_false(err.is_empty(), "path with a replacement character must be rejected")
 	assert_contains(err, "null")
+
+
+func test_loadable_rejects_replacement_character() -> void:
+	## The same guard must cover the ResourceLoader entry point.
+	var err := McpPathValidator.validate_loadable_path("res://safe\uFFFDname.tscn")
+	assert_false(err.is_empty(), "loadable path with a replacement character must be rejected")
+
+
+func test_valid_path_survives_codepoint_scan() -> void:
+	## Regression for #889: ordinary and non-ASCII paths must pass the scan
+	## cleanly. Accented/CJK characters decode fine and must not be mistaken for
+	## the replacement character.
+	assert_eq(McpPathValidator.validate_resource_path("res://scripts/player.gd"), "",
+		"plain ASCII path must validate")
+	assert_eq(McpPathValidator.validate_resource_path("res://scènes/日本語.gd"), "",
+		"valid non-ASCII path must validate")
 
 
 # ----- write blocklist: project-critical files (audit GH-3) -----


### PR DESCRIPTION
Closes #889.

## The report

Every `read_script` call printed this to the Godot console, whether the path was valid or not:

```
ERROR: Unicode parsing error, some characters were replaced with � (U+FFFD): Unexpected NUL character
```

@BaconEggsRL root-caused it to `McpPathValidator` and supplied a patch. The path was never the cause — `String.chr(0)` emits that error while *constructing* the sentinel, so the guard printed it on every call regardless of input. That's why a nonexistent path produced the Unicode error *and* a "File not found".

## The part that wasn't just noise

`String.chr(0)` does not return a NUL. Reproduced on 4.6.3:

```gdscript
var nul := String.chr(0)
# ERROR: Unicode parsing error … Unexpected NUL character
print(nul.is_empty(), " ", nul.length(), " ", nul.unicode_at(0))
# false 1 65533
```

It returns a **one-character string whose codepoint is 65533 (U+FFFD)** — the replacement the engine substitutes for the character it refused to build. So the old `path.contains(nul)` was a U+FFFD check mislabelled as a null check, and the null branch was unreachable on every build. The comment about builds where `chr(0)` yields `""` described a case that doesn't occur.

## The fix

Scan codepoints with `unicode_at()` instead, which never materialises a NUL String. Rejects `0xFFFD` for the same practical reason the old code effectively did, and adds the `0x0000` test the old code only claimed to perform.

Behaviour is a **strict superset** of the old guard — nothing that used to be rejected is now accepted. Rejecting `U+FFFD` stays deliberate: once the engine has replaced a byte there is no way left to distinguish an attempted NUL from malformed UTF-8 from a literal replacement character, so a security boundary must refuse all three.

## Tests

The suite's own null-byte test built its payload with `String.chr(0)` and then `skip()`ped — it emitted the error it was meant to police and asserted nothing. It now asserts on a U+FFFD payload, covers `validate_loadable_path`, and pins that ordinary and non-ASCII paths still validate.

## Verification

- Full GDScript suite: **2280 passed, 0 failed**, 70 suites.
- `path_validator` suite: 32/32, **0 skipped** (was skipping before).
- **Zero `Unicode parsing error` lines** across the full run — previously reproduced directly on 4.6.3.
- Headless probe confirms valid ASCII/non-ASCII paths validate, U+FFFD is rejected on both entry points, and traversal + write-blocklist rejections are unchanged.
- `script/ci-check-gdscript`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path validation to reject invalid Unicode replacement characters and embedded null-byte representations.
  * Applied consistent validation across resource and loadable paths.
  * Preserved support for valid ASCII and non-ASCII paths.

* **Tests**
  * Added coverage for invalid Unicode paths and confirmed valid paths continue to pass validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->