### PR TITLE
fix: pre-warm the pinned uv environment at Configure time (#851)

### DIFF
--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -49,6 +49,18 @@ telemetry toggle, or tool-domain change. Never silently fall back to a bare `uvx
 command for these entries—report ERROR and leave the config untouched when no
 verified tier exists.
 
+Configure pre-builds the pinned `godot-ai==X` uv environment before it
+returns (`prewarm_attach_plan` / `prewarm_attach_launch`), so the first
+client spawn is a warm cache hit. Without it the *client* pays for building
+~67 packages on its own critical path, which flashes a terminal window on
+Windows (#851) and can overrun an MCP client's default 30s connect timeout —
+the tools then appear to vanish until a restart. Only the `uvx` tier is
+warmed; dev-venv and system launches run an already-installed package. The
+warm is best-effort and never downgrades a successful Configure: the config
+file is already written, and a failure only restores the old cold-start cost.
+The dock relabels the button `Installing…` while it runs so a cold build does
+not read as a hang.
+
 Per-strategy command rendering (`CommandShape` docs in `_base.gd`):
 
 - **JSON** — FLAT (`command` string + `args` array, optional

--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -1500,6 +1500,15 @@ static func get_server_launch_mode() -> String:
 	return "unknown"
 
 
+## Wall-clock budget for the Configure-time pre-warm. Far above
+## `McpCliExec.DEFAULT_TIMEOUT_MS` (8s) on purpose: this call is *expected* to
+## take tens of seconds on a cold cache — downloading and unpacking the tool
+## environment is the entire point — so the usual CLI-registry budget would
+## kill it right when it is doing useful work. Still bounded so a wedged uv
+## can't hold the worker thread forever.
+const PREWARM_TIMEOUT_MS := 180000
+
+
 static func find_uvx() -> String:
 	return CliFinder.find(_uvx_cli_names())
 
@@ -1550,6 +1559,87 @@ static func prewarm_server_package_argv(version: String) -> Array[String]:
 	if re.compile("^[A-Za-z0-9.+!-]+$") != OK or re.search(pinned) == null:
 		return []
 	return ["--from", "godot-ai==%s" % pinned, "godot-ai", "--version"]
+
+
+## Blocking sibling of `prewarm_server_package`, for the user-initiated
+## Configure flow (#851, and the reconnect timeouts reported alongside it).
+##
+## Why Configure needs its own pre-warm: `prewarm_server_package` only fires
+## on self-update and on server-lifecycle recovery. Neither covers the case
+## that actually bites — the plugin ADOPTS an already-running server (no uvx
+## spawn, so nothing warms the env), the user clicks Configure, and the first
+## client launch is the one that pays for building the whole tool environment.
+## That build is ~67 packages; a warm launch is ~0.1s. Two symptoms fall out
+## of the cold path: a visible terminal window on Windows (#851), and a spawn
+## that overruns the MCP client's default 30s connect timeout, which the user
+## sees as the Godot AI tools silently disappearing.
+##
+## Why blocking, unlike the fire-and-forget server-side pre-warm: Configure is
+## a deliberate click, so the cost is attributable and the dock can show it as
+## progress rather than as an unexplained pause. Runs on the dock's client
+## action worker thread — never the main thread — and `McpCliExec.run` bounds
+## it, so a wedged uv cannot trap the worker.
+##
+## Best-effort by contract. The config file is already written and correct
+## when this runs; a failure here only means the next client launch pays the
+## cold cost it always used to. Callers must NOT downgrade a successful
+## Configure because of this result.
+##
+## Returns the `McpCliExec.run` dict, plus `skipped` (true when there is no
+## uvx tier to warm or no usable version pin).
+static func prewarm_server_package_blocking(
+	version: String, timeout_ms: int = PREWARM_TIMEOUT_MS
+) -> Dictionary:
+	var args := prewarm_server_package_argv(version)
+	if args.is_empty():
+		return {"skipped": true, "reason": "no version pin"}
+	var uvx := find_uvx()
+	if uvx.is_empty():
+		## dev-venv and system tiers have no per-version cache to warm.
+		return {"skipped": true, "reason": "no uvx"}
+	var result := McpCliExec.run(uvx, args, timeout_ms, true)
+	result["skipped"] = false
+	return result
+
+
+## Decide whether the freshly-written entry has an environment worth warming.
+##
+## Pure and side-effect free, split from the spawn below so tests can pin the
+## decision without building a real uv environment — the same split
+## `prewarm_server_package_argv` uses for the argv (#890).
+##
+## Warms only the `uvx` tier: dev-venv and system launches run an
+## already-installed package and have no per-version environment to build.
+## Resolving the tier here rather than in the dock keeps launcher knowledge in
+## the configurator; the dock stays free of tier branching.
+##
+## Returns `{warm: bool, version: String, reason: String}`.
+static func prewarm_attach_plan(
+	launch_context: Dictionary, discovery_override: Dictionary = {}
+) -> Dictionary:
+	var launch := resolve_attach_launch(launch_context, discovery_override)
+	if not bool(launch.get("ok", false)):
+		return {"warm": false, "version": "", "reason": "launch discovery failed"}
+	var tier := str(launch.get("tier", ""))
+	if tier != "uvx":
+		return {"warm": false, "version": "", "reason": "tier %s has no env to warm" % tier}
+	var version := _pypi_pin_version(str(launch_context.get("plugin_version", "")))
+	if version.is_empty():
+		return {"warm": false, "version": "", "reason": "no version pin"}
+	return {"warm": true, "version": version, "reason": ""}
+
+
+## Warm the environment the freshly-written entry will actually launch.
+## Thin wrapper over `prewarm_attach_plan` + `prewarm_server_package_blocking`.
+static func prewarm_attach_launch(
+	launch_context: Dictionary,
+	timeout_ms: int = PREWARM_TIMEOUT_MS,
+	discovery_override: Dictionary = {},
+) -> Dictionary:
+	var plan := prewarm_attach_plan(launch_context, discovery_override)
+	if not bool(plan.get("warm", false)):
+		return {"skipped": true, "reason": str(plan.get("reason", ""))}
+	return prewarm_server_package_blocking(str(plan.get("version", "")), timeout_ms)
 
 
 static func _uvx_cli_names() -> Array[String]:

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -220,6 +220,16 @@ var _client_action_names: Dictionary = {}
 ## Timed-out Configure/Remove workers are abandoned but retained here until
 ## they finish, so GDScript does not destroy a live Thread object.
 static var _orphaned_client_action_threads: Array[Thread] = []
+## Which client each abandoned worker belonged to, so a row whose worker was
+## abandoned but is STILL RUNNING can't start a second one on top of it.
+## The flat array above exists to keep Thread objects alive; it carries no
+## client association, and `_abandon_client_action_thread` erases the row's
+## `_client_action_threads` slot — so the dispatch guard alone would let a
+## re-click spawn an overlapping worker. Two concurrent Configure workers for
+## one client means two uv builds and two writers on the same config file.
+## Static for the same reason as the array: a script reload must not GC a
+## live Thread.
+static var _orphaned_client_action_owners: Dictionary = {}
 
 # Dev-mode only
 var _dev_section: VBoxContainer
@@ -415,6 +425,7 @@ func _drain_client_action_workers() -> void:
 		if thread != null:
 			thread.wait_to_finish()
 	_orphaned_client_action_threads.clear()
+	_orphaned_client_action_owners.clear()
 	_client_action_started_msec.clear()
 	_client_action_names.clear()
 	_client_action_phase_mutex.lock()
@@ -460,13 +471,21 @@ func _abandon_client_action_thread(client_id: String) -> void:
 	var worker_alive := thread != null and thread.is_alive()
 	if thread != null:
 		_orphaned_client_action_threads.append(thread)
+		if worker_alive:
+			var owned: Array = _orphaned_client_action_owners.get(client_id, [])
+			owned.append(thread)
+			_orphaned_client_action_owners[client_id] = owned
 	_client_action_threads.erase(client_id)
 	_client_action_started_msec.erase(client_id)
 	_clear_client_action_phase(client_id)
 	var action := str(_client_action_names.get(client_id, "configure"))
 	_client_action_names.erase(client_id)
 	_client_action_generations[client_id] = int(_client_action_generations.get(client_id, 0)) + 1
-	_finalize_action_buttons(client_id)
+	## Only hand the row back when nothing is still running for it. Re-enabling
+	## while the abandoned worker is mid-build invites a second worker on top
+	## of the first; the prune below re-enables the row once it actually ends.
+	if not worker_alive:
+		_finalize_action_buttons(client_id)
 	print("MCP | client action timed out: client=%s action=%s elapsed_ms=%d worker_alive=%s" % [
 		client_id,
 		action,
@@ -474,11 +493,12 @@ func _abandon_client_action_thread(client_id: String) -> void:
 		str(worker_alive),
 	])
 	var label := "Remove" if action == "remove" else "Configure"
-	_apply_row_status(
-		client_id,
-		Client.Status.ERROR,
-		"%s did not report completion in time; refreshing current status." % label
+	var detail := (
+		"%s is taking longer than expected and is still running; refreshing current status." % label
+		if worker_alive
+		else "%s did not report completion in time; refreshing current status." % label
 	)
+	_apply_row_status(client_id, Client.Status.ERROR, detail)
 	_refresh_clients_summary()
 	if is_inside_tree():
 		_request_client_status_refresh(true)
@@ -494,8 +514,35 @@ func _prune_orphaned_client_action_threads() -> void:
 			thread.wait_to_finish()
 			_orphaned_client_action_threads.remove_at(i)
 			completed_orphan = true
+	_release_finished_orphan_owners()
 	if completed_orphan and is_inside_tree():
 		_request_client_action_completion_refresh()
+
+
+## Hand a row back once its abandoned worker has actually finished. Pairs with
+## `_abandon_client_action_thread`, which deliberately leaves the buttons
+## disabled while the orphan is still running — without this the row would stay
+## disabled forever.
+func _release_finished_orphan_owners() -> void:
+	for client_id in _orphaned_client_action_owners.keys():
+		var owned: Array = _orphaned_client_action_owners[client_id]
+		for i in range(owned.size() - 1, -1, -1):
+			var t: Thread = owned[i]
+			if t == null or not t.is_alive():
+				owned.remove_at(i)
+		if owned.is_empty():
+			_orphaned_client_action_owners.erase(client_id)
+			if not _client_action_threads.has(client_id):
+				_finalize_action_buttons(String(client_id))
+
+
+## True while a previously-abandoned worker for this client is still running.
+static func _has_live_orphan(client_id: String) -> bool:
+	var owned: Array = _orphaned_client_action_owners.get(client_id, [])
+	for t in owned:
+		if t != null and (t as Thread).is_alive():
+			return true
+	return false
 
 
 func _request_client_action_completion_refresh() -> void:
@@ -2088,6 +2135,11 @@ func _dispatch_client_action(client_id: String, action: String) -> void:
 		## SIGABRT in `GDScriptFunction::call`. See `_update_manager`.
 		return
 	if _client_action_threads.has(client_id):
+		return
+	## An abandoned-but-still-running worker owns this row's config file just
+	## as much as a tracked one does. Defensive: `_abandon_client_action_thread`
+	## already leaves the buttons disabled in that state.
+	if _has_live_orphan(client_id):
 		return
 	var row: Dictionary = _client_rows.get(client_id, {})
 	if row.is_empty():

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -401,6 +401,7 @@ func _drain_client_action_workers() -> void:
 		_client_action_generations[client_id] = int(_client_action_generations.get(client_id, 0)) + 1
 		_client_action_started_msec.erase(client_id)
 		_client_action_names.erase(client_id)
+		_clear_client_action_phase(String(client_id))
 		_finalize_action_buttons(String(client_id))
 		var row: Dictionary = _client_rows.get(String(client_id), {})
 		if not row.is_empty():
@@ -416,6 +417,10 @@ func _drain_client_action_workers() -> void:
 	_orphaned_client_action_threads.clear()
 	_client_action_started_msec.clear()
 	_client_action_names.clear()
+	_client_action_phase_mutex.lock()
+	_client_action_phases.clear()
+	_client_action_phase_mutex.unlock()
+	_client_action_phase_shown.clear()
 
 
 func _check_client_action_timeouts() -> void:
@@ -424,8 +429,27 @@ func _check_client_action_timeouts() -> void:
 		if not _client_action_started_msec.has(client_id):
 			continue
 		var started := int(_client_action_started_msec.get(client_id, 0))
-		if now - started >= CLIENT_ACTION_TIMEOUT_MSEC:
+		if now - started >= _client_action_budget_msec(String(client_id)):
 			_abandon_client_action_thread(String(client_id))
+
+
+## Watchdog budget for an in-flight client action.
+##
+## The 30s default is sized for a CLI registry call. Once the worker reports it
+## has moved on to building the pinned uv environment, that budget is far too
+## short: a cold build is *expected* to run for tens of seconds, and abandoning
+## it would report a false Configure timeout for exactly the slow cold start the
+## pre-warm exists to absorb — re-enabling the row and discarding the worker's
+## completion while the build is still running and about to succeed.
+##
+## The prewarm phase therefore gets the base budget plus the pre-warm's own
+## ceiling. The action still cannot hang forever: `McpCliExec.run` bounds the
+## build at `PREWARM_TIMEOUT_MS` on its own, so this is a backstop above a
+## backstop rather than the only limit.
+func _client_action_budget_msec(client_id: String) -> int:
+	if _read_client_action_phase(client_id) == _PHASE_PREWARM:
+		return CLIENT_ACTION_TIMEOUT_MSEC + ClientConfigurator.PREWARM_TIMEOUT_MS
+	return CLIENT_ACTION_TIMEOUT_MSEC
 
 
 func _abandon_client_action_thread(client_id: String) -> void:
@@ -438,6 +462,7 @@ func _abandon_client_action_thread(client_id: String) -> void:
 		_orphaned_client_action_threads.append(thread)
 	_client_action_threads.erase(client_id)
 	_client_action_started_msec.erase(client_id)
+	_clear_client_action_phase(client_id)
 	var action := str(_client_action_names.get(client_id, "configure"))
 	_client_action_names.erase(client_id)
 	_client_action_generations[client_id] = int(_client_action_generations.get(client_id, 0)) + 1

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -2068,6 +2068,10 @@ func _dispatch_client_action(client_id: String, action: String) -> void:
 	if row.is_empty():
 		return
 
+	## Drop any phase left behind by a previous action on this row — a
+	## generation-mismatch or shutdown return can skip the normal finalize,
+	## and a stale phase would suppress the label for this new action.
+	_clear_client_action_phase(client_id)
 	_set_row_action_in_flight(client_id, action)
 	## Snapshot `server_url` on main: `http_url()` reads
 	## `EditorInterface.get_editor_settings()`, which is main-thread-only.
@@ -2108,14 +2112,30 @@ func _run_client_action_worker(
 	generation: int,
 ) -> Dictionary:
 	var result: Dictionary
+	var prewarm: Dictionary = {}
 	if action == "remove":
 		result = ClientConfigurator.remove(client_id, server_url, launch_context)
 	else:
 		result = ClientConfigurator.configure(client_id, server_url, launch_context)
+		## #851: the entry we just wrote pins an exact `godot-ai==X`. If uv has
+		## never built that environment, the FIRST client spawn builds it —
+		## ~67 packages — which is what flashes a terminal window on Windows
+		## and what can push a bridge spawn past the MCP client's default 30s
+		## connect timeout, so the tools appear to vanish. Pay that cost here,
+		## on a deliberate click the dock can label, instead of on the client's
+		## critical path.
+		##
+		## Best-effort: the config file is already written and correct. A
+		## failed or timed-out warm only means the next launch pays the cold
+		## cost it always used to, so `result` is deliberately left untouched.
+		if result.get("status") == "ok":
+			_set_client_action_phase(client_id, _PHASE_PREWARM)
+			prewarm = ClientConfigurator.prewarm_attach_launch(launch_context)
 	return {
 		"client_id": client_id,
 		"action": action,
 		"result": result,
+		"prewarm": prewarm,
 		"generation": generation,
 	}
 
@@ -2123,13 +2143,19 @@ func _run_client_action_worker(
 func _poll_completed_client_action_threads() -> void:
 	for client_id in _client_action_threads.keys():
 		var thread: Thread = _client_action_threads[client_id]
-		if thread == null or thread.is_alive():
+		if thread == null:
+			continue
+		if thread.is_alive():
+			_apply_client_action_phase(String(client_id))
 			continue
 		var payload: Variant = thread.wait_to_finish()
 		_client_action_threads[client_id] = null
 		if payload is Dictionary:
 			var data := payload as Dictionary
 			var result: Dictionary = data.get("result", {})
+			_report_prewarm_outcome(
+				String(data.get("client_id", client_id)), data.get("prewarm", {})
+			)
 			_apply_client_action_result(
 				String(data.get("client_id", client_id)),
 				String(data.get("action", _client_action_names.get(client_id, "configure"))),
@@ -2161,6 +2187,7 @@ func _apply_client_action_result(client_id: String, action: String, result: Dict
 	_client_action_threads.erase(client_id)
 	_client_action_started_msec.erase(client_id)
 	_client_action_names.erase(client_id)
+	_clear_client_action_phase(client_id)
 	_finalize_action_buttons(client_id)
 	if _server_blocks_client_health():
 		_apply_row_status(client_id, Client.Status.ERROR, _server_blocked_client_message())
@@ -2185,6 +2212,85 @@ func _apply_client_action_result(client_id: String, action: String, result: Dict
 		if action == "configure":
 			_show_manual_command_for(client_id)
 	_refresh_clients_summary()
+
+
+## Phase label for the Configure worker's pre-warm step. The config write
+## itself is fast; building the pinned uv environment is the part that can
+## run for tens of seconds, so it gets its own label rather than sitting
+## under a motionless "Configuring…".
+const _PHASE_PREWARM := "prewarm"
+
+## Worker-written, main-read. `Dictionary` writes are not atomic across
+## threads, so both sides take the mutex — the same discipline `CliFinder`
+## uses for its cache. Held only across the dictionary access, never across
+## the subprocess, so the main thread can never block on uv.
+var _client_action_phase_mutex := Mutex.new()
+var _client_action_phases: Dictionary = {}
+## Rows whose button text already reflects their phase, so the per-frame poll
+## rewrites the label once instead of on every frame.
+var _client_action_phase_shown: Dictionary = {}
+
+
+func _set_client_action_phase(client_id: String, phase: String) -> void:
+	_client_action_phase_mutex.lock()
+	_client_action_phases[client_id] = phase
+	_client_action_phase_mutex.unlock()
+
+
+func _read_client_action_phase(client_id: String) -> String:
+	_client_action_phase_mutex.lock()
+	var phase := String(_client_action_phases.get(client_id, ""))
+	_client_action_phase_mutex.unlock()
+	return phase
+
+
+func _clear_client_action_phase(client_id: String) -> void:
+	_client_action_phase_mutex.lock()
+	_client_action_phases.erase(client_id)
+	_client_action_phase_mutex.unlock()
+	_client_action_phase_shown.erase(client_id)
+
+
+## Per-frame, for a still-running worker: promote the button label when the
+## worker reports it has moved on to warming the package environment. Keeps
+## the dock honest about why Configure is taking a while — otherwise a cold
+## uv build looks like a hang.
+func _apply_client_action_phase(client_id: String) -> void:
+	if _read_client_action_phase(client_id) != _PHASE_PREWARM:
+		return
+	if _client_action_phase_shown.get(client_id, "") == _PHASE_PREWARM:
+		return
+	var row: Dictionary = _client_rows.get(client_id, {})
+	if row.is_empty():
+		return
+	_client_action_phase_shown[client_id] = _PHASE_PREWARM
+	(row["configure_btn"] as Button).text = "Installing…"
+
+
+## One line per Configure so a cold build is attributable after the fact —
+## the dock label is transient, and #851's symptom (a terminal window on
+## Windows) is easiest to correlate against a timestamped log entry. Silent
+## on the skip paths: a dev-venv/system tier having no env to warm is the
+## normal case, not news.
+func _report_prewarm_outcome(client_id: String, prewarm: Variant) -> void:
+	if not (prewarm is Dictionary):
+		return
+	var data := prewarm as Dictionary
+	if data.is_empty() or bool(data.get("skipped", false)):
+		return
+	if bool(data.get("timed_out", false)):
+		print(
+			"MCP | %s: package pre-warm timed out; the first client launch will build the environment"
+			% client_id
+		)
+		return
+	if int(data.get("exit_code", -1)) != 0:
+		print(
+			"MCP | %s: package pre-warm failed (exit %d); the first client launch will build the environment"
+			% [client_id, int(data.get("exit_code", -1))]
+		)
+		return
+	print("MCP | %s: package environment pre-warmed" % client_id)
 
 
 ## In-flight visual: rewrite the verb onto the button the user just

--- a/test_project/tests/test_client_attach_config.gd
+++ b/test_project/tests/test_client_attach_config.gd
@@ -1142,6 +1142,111 @@ func test_prewarm_argv_rejects_empty_and_non_pep440_versions() -> void:
 	)
 
 
+## ----- Configure-time pre-warm planning (#851) -----
+#
+# The entry Configure writes pins an exact `godot-ai==X`. If uv has never
+# built that environment, the first CLIENT spawn builds it (~67 packages) —
+# which flashes a terminal window on Windows (#851) and can push the spawn
+# past an MCP client's default 30s connect timeout, so the tools look like
+# they vanished. Configure pays that cost up front instead. These pin the
+# decision only; the plan is pure, so no environment is ever built here.
+
+func _prewarm_overrides(tier: String) -> Dictionary:
+	var overrides := {
+		"venv_python": "",
+		"uvx_path": "",
+		"system_path": "",
+		"consoleless_python": "C:/Python313/pythonw.exe",
+	}
+	match tier:
+		"dev_venv":
+			overrides["venv_python"] = "C:/repo/.venv/Scripts/python.exe"
+			overrides["consoleless_python"] = "C:/repo/.venv/Scripts/pythonw.exe"
+		"uvx":
+			overrides["uvx_path"] = "C:/Tools/uv/uvx.exe"
+		"system":
+			overrides["system_path"] = "C:/Python313/Scripts/godot-ai.exe"
+			overrides["system_version_result"] = {
+				"exit_code": 0, "stdout": "godot-ai 3.0.6", "stderr": "",
+				"output": "godot-ai 3.0.6", "timed_out": false, "spawn_failed": false,
+			}
+	return overrides
+
+
+func test_prewarm_plan_warms_the_uvx_tier_with_the_written_pin() -> void:
+	## The warmed version must be exactly the pin the entry carries, or the
+	## warm builds an environment the client never launches.
+	var plan := McpClientConfigurator.prewarm_attach_plan(
+		_context(), _prewarm_overrides("uvx")
+	)
+	assert_true(bool(plan.get("warm", false)), "the uvx tier must be warmed")
+	assert_eq(plan.get("version"), "3.0.6")
+
+
+func test_prewarm_plan_skips_tiers_with_no_environment_to_build() -> void:
+	## dev-venv and system launches run an already-installed package — there
+	## is no per-version uv environment, so warming would be pure waste.
+	for tier in ["dev_venv", "system"]:
+		var plan := McpClientConfigurator.prewarm_attach_plan(
+			_context(), _prewarm_overrides(tier)
+		)
+		assert_false(bool(plan.get("warm", false)), "%s tier must not be warmed" % tier)
+		assert_contains(str(plan.get("reason", "")), tier)
+
+
+func test_prewarm_plan_skips_when_launch_discovery_fails() -> void:
+	## No launcher resolved means Configure itself failed; there is nothing
+	## to warm and nothing to report.
+	var plan := McpClientConfigurator.prewarm_attach_plan(
+		_context(), _prewarm_overrides("none")
+	)
+	assert_false(bool(plan.get("warm", false)))
+	assert_contains(str(plan.get("reason", "")), "discovery")
+
+
+func test_prewarm_plan_strips_local_version_metadata_from_the_pin() -> void:
+	## The pin written into the entry drops any `+local` segment, so the
+	## warm must drop it identically — otherwise uv resolves a different
+	## requirement and the client still cold-starts.
+	var context := _context()
+	context["plugin_version"] = "3.0.6+dev"
+	var plan := McpClientConfigurator.prewarm_attach_plan(
+		context, _prewarm_overrides("uvx")
+	)
+	assert_true(bool(plan.get("warm", false)))
+	assert_eq(plan.get("version"), "3.0.6", "the +local segment must be stripped")
+
+
+func test_prewarm_launch_skips_without_spawning_when_plan_declines() -> void:
+	## The wrapper must surface the plan's reason and never reach a spawn.
+	var result := McpClientConfigurator.prewarm_attach_launch(
+		_context(), McpClientConfigurator.PREWARM_TIMEOUT_MS, _prewarm_overrides("dev_venv")
+	)
+	assert_true(bool(result.get("skipped", false)), "a declined plan must skip")
+	assert_contains(str(result.get("reason", "")), "dev_venv")
+
+
+func test_prewarm_blocking_skips_when_version_is_unusable() -> void:
+	## Same PEP 440 hardening as the fire-and-forget spawn: an unusable pin
+	## must skip rather than hand uv something it can reinterpret.
+	for bad in ["", "   ", "3.2.*", "3.2.0 --index-url http://evil"]:
+		var result := McpClientConfigurator.prewarm_server_package_blocking(bad, 1000)
+		assert_true(
+			bool(result.get("skipped", false)),
+			"version %s must not reach a spawn" % [bad]
+		)
+
+
+func test_prewarm_timeout_budget_exceeds_the_cli_registry_default() -> void:
+	## A cold build is expected to take tens of seconds. Reusing the 8s
+	## registry budget would kill the warm exactly when it is doing the work
+	## this feature exists to do.
+	assert_true(
+		McpClientConfigurator.PREWARM_TIMEOUT_MS > McpCliExec.DEFAULT_TIMEOUT_MS * 5,
+		"pre-warm needs a budget sized for a cold package build"
+	)
+
+
 func _pi_clone(path: String) -> McpClient:
 	var registered := McpClientRegistry.get_by_id("pi")
 	var client := McpClient.new()

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -1777,6 +1777,53 @@ func test_configure_phase_labels_the_package_build_instead_of_hanging_silent() -
 	dock.free()
 
 
+func test_abandoned_worker_blocks_an_overlapping_action_for_that_row() -> void:
+	## The watchdog abandons a worker by erasing the row's `_client_action_threads`
+	## slot — which is also the dispatch guard. So without a per-client orphan
+	## record, a re-click after a timeout starts a SECOND worker while the first
+	## is still running: two uv builds and two writers on the same config file.
+	var dock := McpDockScript.new()
+	McpDockScript._orphaned_client_action_owners.clear()
+
+	assert_false(
+		McpDockScript._has_live_orphan("claude_code"),
+		"a row with no abandoned worker must be dispatchable"
+	)
+
+	## A live orphan holds the row.
+	var live := Thread.new()
+	live.start(func() -> int:
+		## Long enough to still be running when the assertion below reads it.
+		OS.delay_msec(400)
+		return 0
+	)
+	McpDockScript._orphaned_client_action_owners["claude_code"] = [live]
+	assert_true(
+		McpDockScript._has_live_orphan("claude_code"),
+		"a still-running abandoned worker must block a new action on its row"
+	)
+	## A different row is unaffected — the guard is per client, not global.
+	assert_false(
+		McpDockScript._has_live_orphan("codex"),
+		"one row's orphan must not block every other client"
+	)
+
+	live.wait_to_finish()
+	assert_false(
+		McpDockScript._has_live_orphan("claude_code"),
+		"a finished orphan must release the row"
+	)
+
+	## The prune must drop the finished orphan so the row is not held forever.
+	dock._release_finished_orphan_owners()
+	assert_false(
+		McpDockScript._orphaned_client_action_owners.has("claude_code"),
+		"prune must clear the finished orphan record"
+	)
+	McpDockScript._orphaned_client_action_owners.clear()
+	dock.free()
+
+
 func test_prewarm_phase_widens_the_client_action_watchdog() -> void:
 	## Regression (#894 CodeRabbit): the action watchdog abandons a worker after
 	## CLIENT_ACTION_TIMEOUT_MSEC (30s), sized for a CLI registry call. The

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -1777,6 +1777,43 @@ func test_configure_phase_labels_the_package_build_instead_of_hanging_silent() -
 	dock.free()
 
 
+func test_prewarm_phase_widens_the_client_action_watchdog() -> void:
+	## Regression (#894 CodeRabbit): the action watchdog abandons a worker after
+	## CLIENT_ACTION_TIMEOUT_MSEC (30s), sized for a CLI registry call. The
+	## Configure pre-warm can legitimately run far longer while uv builds the
+	## pinned environment — so a cold build would trip the watchdog, re-enable
+	## the row, discard the worker's completion, and report a false Configure
+	## timeout for exactly the slow cold start the pre-warm exists to absorb.
+	var dock := McpDockScript.new()
+
+	assert_eq(
+		dock._client_action_budget_msec("claude_code"),
+		McpDockScript.CLIENT_ACTION_TIMEOUT_MSEC,
+		"a plain config write keeps the short registry budget"
+	)
+
+	dock._set_client_action_phase("claude_code", "prewarm")
+	var warmed := dock._client_action_budget_msec("claude_code")
+	assert_true(
+		warmed >= McpClientConfigurator.PREWARM_TIMEOUT_MS,
+		"the watchdog must outlast the pre-warm's own ceiling, not fire mid-build"
+	)
+	assert_true(
+		warmed > McpDockScript.CLIENT_ACTION_TIMEOUT_MSEC,
+		"the prewarm phase must widen the budget"
+	)
+
+	## A cleared phase must fall back to the short budget, or one slow Configure
+	## would leave the row's next action effectively unwatched.
+	dock._clear_client_action_phase("claude_code")
+	assert_eq(
+		dock._client_action_budget_msec("claude_code"),
+		McpDockScript.CLIENT_ACTION_TIMEOUT_MSEC,
+		"a cleared phase must restore the short budget"
+	)
+	dock.free()
+
+
 func test_configure_phase_is_ignored_for_an_unknown_row() -> void:
 	## A row can be rebuilt (status refresh) while its worker is still in
 	## flight; the poll must not fault on the vanished row.

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -1743,6 +1743,51 @@ func test_dock_log_toggle_mutes_buffer_console_echo() -> void:
 	dock.free()
 
 
+func test_configure_phase_labels_the_package_build_instead_of_hanging_silent() -> void:
+	## #851: Configure now pre-builds the pinned uv environment so the first
+	## CLIENT spawn is warm. That build can run for tens of seconds on a cold
+	## cache, and a motionless "Configuring…" reads as a hang — so the worker
+	## reports a phase and the poll promotes the label.
+	var dock := McpDockScript.new()
+	var btn := Button.new()
+	btn.text = "Configuring…"
+	dock._client_rows["claude_code"] = {"configure_btn": btn}
+
+	## Config-write phase: the label must not move yet.
+	dock._apply_client_action_phase("claude_code")
+	assert_eq(btn.text, "Configuring…", "label must not move before the warm starts")
+
+	## Worker reports it reached the package warm.
+	dock._set_client_action_phase("claude_code", "prewarm")
+	dock._apply_client_action_phase("claude_code")
+	assert_eq(btn.text, "Installing…", "a cold package build must be labelled, not silent")
+
+	## The poll runs every frame — the rewrite must happen once, not forever.
+	btn.text = "sentinel"
+	dock._apply_client_action_phase("claude_code")
+	assert_eq(btn.text, "sentinel", "the label must be rewritten once, not every frame")
+
+	## Cleared state must not resurrect the label under the next action.
+	dock._clear_client_action_phase("claude_code")
+	btn.text = "Configuring…"
+	dock._apply_client_action_phase("claude_code")
+	assert_eq(btn.text, "Configuring…", "a cleared phase must not relabel a new action")
+
+	btn.free()
+	dock.free()
+
+
+func test_configure_phase_is_ignored_for_an_unknown_row() -> void:
+	## A row can be rebuilt (status refresh) while its worker is still in
+	## flight; the poll must not fault on the vanished row.
+	var dock := McpDockScript.new()
+	dock._set_client_action_phase("ghost", "prewarm")
+	dock._apply_client_action_phase("ghost")
+	dock._clear_client_action_phase("ghost")
+	assert_true(true, "phase handling must tolerate a missing row")
+	dock.free()
+
+
 ## Save/restore helpers so tests that drive the (now persisted) log toggle
 ## don't clobber the user's actual EditorSetting.
 func _save_mcp_logging_setting() -> Dictionary:


### PR DESCRIPTION
Refs #851. Implements the maintainer direction recorded in https://github.com/hi-godot/godot-ai/issues/851#issuecomment-5411134699 (steps 3 and 4): pre-warm the exact pinned `godot-ai==X` environment during the user-initiated Configure flow, with visible progress in the dock, and keep client startup on the already-warm environment.

Does **not** touch the hidden-console approach, and does not claim the upstream uv question is resolved — the Windows `EnumWindows` re-run named as #851's gate is still outstanding.

## Why this is more than cosmetic

#851 was filed as a cosmetic Windows terminal flash. A Discord report surfaced a second symptom with the same root cause: every couple of hours the Godot AI tools "disappear" and the user has to restart both the client and Godot. Their MCP logs show a clean stdio recycle after ~20h, then:

```
Starting connection with timeout of 30000ms
Server stderr: Installed 69 packages in 12.71s
Connection failed after 30105ms (CONNECT_TIMEOUT)
```

Same cold path. The entry pins an exact version, uv has never built that environment, and the first **client** spawn builds it — on the client's connect-timeout critical path.

Measured on this tree: a cold `uvx --from godot-ai==3.2.2 godot-ai --version` builds 67 packages (~78 MB); the same command warm is **0.11 s**.

## The gap this closes

`prewarm_server_package` already exists from #890, but fires only on self-update and server-lifecycle recovery. Neither covers the case that actually bites: the plugin **adopts** an already-running server, so no uvx spawn ever happens, nothing warms the env, and the user's first client launch pays in full.

## Shape

- **`prewarm_attach_plan`** is pure and decides whether there is anything to warm — the same split `prewarm_server_package_argv` uses in #890, so tests pin the decision without building a real environment. Only the `uvx` tier is warmed; dev-venv and system launches run an already-installed package and have no per-version env.
- The warmed version is the pin the entry actually carries, run through the same `_pypi_pin_version`, so a `+local` segment can't warm one requirement while the entry launches another.
- **`prewarm_server_package_blocking`** bounds the build via `McpCliExec.run` at 180 s — far above the 8 s CLI-registry default, which would otherwise kill the build exactly when it is doing the work this exists to do.
- Runs on the dock's existing client-action worker, **never the main thread**. The dock relabels the button `Installing…` so a cold build reads as progress, not a hang. Phase state is mutex-guarded across the worker/main boundary and cleared at dispatch, so a generation-mismatch return can't leak a stale label.

**Best-effort by contract**: the config file is already written and correct before the warm starts. A failure or timeout only restores the cold cost that was already there — a successful Configure is never downgraded because the warm failed. The outcome is logged instead.

## One thing worth double-checking in review

The client entry carries `--link-mode copy`; the prewarm argv does not. I verified empirically that this does **not** split uv's environment cache — a `--link-mode copy` launch reuses an env warmed without it — so the warmed environment is the one the client actually launches. If that ever stops holding upstream, this fix silently becomes a no-op, which is the failure mode to watch.

## Verification

- Full GDScript suite: **2280 passed, 0 failed**, 70 suites (+9 new tests).
- Editor errors after a full run: 39, the identical three benign buckets as baseline (InputMap negative-path setup noise x38, plus the deliberate parse error from `test_expected_script_error_does_not_abort`). No new buckets.
- Live end-to-end through the real code path: cold build exit 0 in 1540 ms (observed downloading `cryptography`, `pydantic-core`, ...), warm 162 ms, unusable pins (empty, `3.2.*`, flag smuggling) skipped without spawning.
- `script/ci-check-gdscript`: clean. No Python touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure now pre-installs the pinned AI package environment before completing, reducing first-use delays.
  * The Configure button displays “Installing…” while package installation is in progress.
  * Pre-installation runs only when applicable and remains best-effort, so successful configuration is not blocked by failures or timeouts.

* **Documentation**
  * Added guidance explaining pre-installation behavior, timing, and its impact on connection reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->