### PR TITLE
fix: stop an empty write path from leaking a stray file into the project root

### DIFF
--- a/plugin/addons/godot_ai/clients/_atomic_write.gd
+++ b/plugin/addons/godot_ai/clients/_atomic_write.gd
@@ -15,6 +15,17 @@ extends RefCounted
 
 
 static func write(path: String, content: String) -> bool:
+	# An empty path is never a writable target, but it is not inert either:
+	# in the editor Godot's safe-save is on, so opening "" for WRITE runs
+	# mkstemp on the template "" + "-XXXXXX", which succeeds and drops a
+	# randomly-named file with the payload bytes in the process's working
+	# directory (the project root). The close-time rename back to "" then
+	# fails, orphaning it. `write` already reported false for this case, so
+	# refusing up front changes no caller behavior — it only stops the
+	# stray file from being created.
+	if path.is_empty():
+		return false
+
 	# If the target is a symlink (stow/chezmoi-managed dotfiles), rename-over
 	# would replace the LINK with a regular file, silently detaching the
 	# config from the user's dotfile repo (#534). Resolve the link chain and

--- a/test_project/tests/test_client_attach_config.gd
+++ b/test_project/tests/test_client_attach_config.gd
@@ -960,6 +960,8 @@ func test_pi_json_strategy_honors_merged_config_tier_precedence() -> void:
 func test_json_merge_transaction_rolls_back_earlier_write_failure() -> void:
 	var first_path := _scratch_dir.path_join("merge_transaction_first.json")
 	_write(first_path, "original")
+	# "" is the unwritable second tier: McpAtomicWrite refuses an empty target
+	# outright, so this fails without touching the filesystem.
 	var result := McpJsonStrategy._write_transaction([
 		{"path": first_path, "text": "changed", "original_text": "original"},
 		{"path": "", "text": "cannot-write", "original_text": ""},

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -3070,14 +3070,24 @@ func test_atomic_write_rejects_empty_path_without_creating_a_file() -> void:
 
 ## Names of the files directly under `res://`, hidden ones included — the
 ## directory a relative or empty write target resolves against in the editor.
+##
+## Asserts rather than returning a quiet [] when the root cannot be read: the
+## caller diffs two of these snapshots, so a silently-empty list on EITHER
+## call makes the diff vacuously empty and the test passes without ever
+## having looked for the debris it exists to catch.
 func _project_root_files() -> Array[String]:
 	var out: Array[String] = []
 	var dir := DirAccess.open("res://")
+	assert_true(dir != null, "project root must be readable to snapshot it")
 	if dir == null:
 		return out
 	dir.include_hidden = true
 	for f in dir.get_files():
 		out.append(f)
+	assert_false(
+		out.is_empty(),
+		"project root snapshot came back empty — enumeration is not trustworthy",
+	)
 	return out
 
 

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -3048,6 +3048,39 @@ func test_atomic_write_leaves_no_stale_tmp_after_failed_write() -> void:
 	assert_eq(leftovers.size(), 0, "no .tmp staging file may linger after a failed write: %s" % str(leftovers))
 
 
+func test_atomic_write_rejects_empty_path_without_creating_a_file() -> void:
+	## An empty target used to leak a randomly-named file holding the payload
+	## into the editor's working directory (the project root): with safe-save
+	## on, Godot opens "" for WRITE by running mkstemp on "" + "-XXXXXX", which
+	## succeeds, and only the close-time rename back to "" fails. `write` said
+	## false either way, so the stray was invisible except in `git status`.
+	## Scan the project root because that is where the debris landed.
+	var before := _project_root_files()
+	assert_false(
+		McpAtomicWrite.write("", "cannot-write"),
+		"an empty path must be refused",
+	)
+	var after := _project_root_files()
+	var strays: Array[String] = []
+	for name in after:
+		if not before.has(name):
+			strays.append(name)
+	assert_eq(strays.size(), 0, "an empty-path write must create no file: %s" % str(strays))
+
+
+## Names of the files directly under `res://`, hidden ones included — the
+## directory a relative or empty write target resolves against in the editor.
+func _project_root_files() -> Array[String]:
+	var out: Array[String] = []
+	var dir := DirAccess.open("res://")
+	if dir == null:
+		return out
+	dir.include_hidden = true
+	for f in dir.get_files():
+		out.append(f)
+	return out
+
+
 func test_atomic_write_does_not_use_fixed_tmp_name() -> void:
 	## #534: two editors clicking Configure at once must not interleave bytes
 	## on a shared "<path>.tmp". Prove the fixed name is no longer the staging


### PR DESCRIPTION
## What

Running the full GDScript suite via `test_run` left an untracked, randomly-named 12-byte file in the project root after **every** local verification run (observed: `test_project/-gmXQbF`, contents `cannot-write`). It dirtied `git status` after every gauntlet and could confuse later smoke runs.

`McpAtomicWrite.write()` now refuses an empty path up front.

## Why — the mechanism is not what it looks like

`test_json_merge_transaction_rolls_back_earlier_write_failure` passes `{"path": ""}` as the deliberately-unwritable second tier. That looks inert, and headless it is. In the **editor** it is not.

When `McpAtomicWrite.write` reaches its copy fallback, it calls `DirAccess.copy_absolute(tmp, "")`. Godot's editor-only **safe-save** does not `fopen` the destination directly — it runs `mkstemp` on the template `<path> + "-XXXXXX"`. With `path == ""` the template is just `-XXXXXX`, so mkstemp **succeeds**, creating a randomly-named file in the process's working directory (the project root) and writing the payload bytes into it. Only the close-time rename back to `""` fails, orphaning the file.

`write()` returned `false` either way, so the leak was invisible to callers and to the test — the only symptom was `git status`. This is also why it never reproduced headless: safe-save is off there, `fopen("")` fails outright, and nothing is created. I confirmed that asymmetry with a standalone headless probe before concluding.

## Changes

- `plugin/addons/godot_ai/clients/_atomic_write.gd` — reject an empty path at the top of `write()`. Behavior-neutral for every caller (they already got `false`); it only stops the file from being created. Covers all 12 call sites, including the rollback write inside `_write_transaction`.
- `test_project/tests/test_clients.gd` — regression test: snapshots the project root, asserts the write is refused, asserts no new file appeared.
- `test_project/tests/test_client_attach_config.gd` — kept `""` as the unwritable tier (its intent is unchanged); added a comment tying it to the new guard.

No production call site passes an empty path today — merge-tier paths come from the client descriptors — so this is a hardening guard plus the hygiene fix, not a user-facing behavior change.

## Verification

Run on an **isolated stack** (worktree server + headless editor on 8020/9520 under a scratch `HOME`). The shared `:8000` server belongs to the maintainer's own editor on released v3.2.1 and this worktree is v3.2.2, so attaching there would have killed it — confirmed intact afterward.

Before/after on the same setup, differing **only** in whether the guard was present:

| | result | untracked after run |
|---|---|---|
| unfixed | 2269/2297, **1 failed** | `test_project/-0XoRdL`, `test_project/-rXUuO8` (both 12 bytes, `cannot-write`) |
| fixed | 2270/2297, 0 failed, 27 skipped, 70/70 suites | **none** |

Also: `ruff check` clean, `script/ci-check-gdscript` clean.

## Notes for a reviewer

- The new test **fails on unfixed code**, naming the exact stray it caught (`["-rXUuO8"]`) — it is a real guard, not a tautology.
- The unfixed run produced **two** strays: the pre-existing one plus one from the new test. That confirms the mechanism is general to the empty path, not specific to one call site.
- The test scans `res://` because that is where the debris actually landed (the editor's working directory is the project root. The comment in the test records that coupling.
- Full ============================= test session starts ==============================
platform darwin -- Python 3.13.3, pytest-8.4.2, pluggy-1.6.0
rootdir: /Users/davidsarno/godot-ai/.claude/worktrees/blissful-almeida-af27a3
configfile: pyproject.toml
testpaths: tests
plugins: asyncio-1.2.0, cov-7.1.0, anyio-4.10.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1829 items / 1 error

==================================== ERRORS ====================================
________ ERROR collecting tests/unit/test_tileset_handler_properties.py ________
ImportError while importing test module '/Users/davidsarno/godot-ai/.claude/worktrees/blissful-almeida-af27a3/tests/unit/test_tileset_handler_properties.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/unit/test_tileset_handler_properties.py:17: in <module>
    from hypothesis import given, settings
E   ModuleNotFoundError: No module named 'hypothesis'
=========================== short test summary info ============================
ERROR tests/unit/test_tileset_handler_properties.py
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
=============================== 1 error in 1.97s =============================== was not re-run: the change is GDScript-only and touches no Python, and the suite binds fixed ports that collide with other concurrent sessions on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented empty-path save attempts from creating stray files in the project directory.
  * Preserved existing failure behavior for invalid write requests.

* **Tests**
  * Added coverage confirming empty-path writes are rejected without modifying the filesystem.
  * Improved transaction rollback test documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->