### PR TITLE
fix: keep watching a spawn that has not proven it started (#896)

### DIFF
--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -83,10 +83,25 @@ const HANDLERS_DIR := "res://addons/godot_ai/handlers/"
 ## resolver, and characterization tests share one source of truth.
 const SERVER_PID_FILE := PortResolver.SERVER_PID_FILE
 
-## How long we watch the spawned server for early exit. If the process is
-## still alive when this expires, we stop watching. Mid-session crashes
-## after this point get caught by the WebSocket disconnect flow.
+## How long we watch the spawned server for early exit once it has PROVEN it
+## started — i.e. published its pid-file. If the process is still alive when
+## this expires, we stop watching. Mid-session crashes after this point get
+## caught by the WebSocket disconnect flow.
 const SERVER_WATCH_MS := 30 * 1000
+## Watch ceiling for a spawn that has NOT yet published its pid-file (#896).
+##
+## The short window above justifies itself with "mid-session crashes surface
+## via WebSocket disconnect" — which is only true for a server that got far
+## enough to be connected to. A cold `uvx` spawn on a slow link can still be
+## resolving and downloading its ~67-package environment at 30s, having proven
+## nothing; stopping the watch there means a launcher that dies at 45s is never
+## observed, `_diagnose_spawn_fast_exit` never runs (it is only reachable from
+## inside the watch), and the plugin redials forever while the dock shows a
+## bare "Disconnected".
+##
+## Sized to cover that download. Independent of any pre-warm: this window has
+## to hold even when nothing warmed the cache first.
+const SERVER_COLD_START_WATCH_MS := 180 * 1000
 ## Python's import graph (FastMCP + Rich + uvicorn) plus the pid-file write
 ## take a beat on cold starts, especially on Windows. Hold off on declaring
 ## a spawn a crash until this window elapses so the watch loop has time to

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -1288,9 +1288,31 @@ func check_server_health() -> void:
 		if elapsed >= int(_host.SPAWN_GRACE_MS) and not McpServerStateScript.is_terminal_diagnosis(_server_state):
 			_diagnose_spawn_fast_exit(_spawn_dead_since_ms)
 		return
-	if elapsed >= int(_host.SERVER_WATCH_MS):
-		## Survived startup — mid-session crashes surface via WebSocket disconnect.
+	if elapsed >= watch_budget_ms(real_pid, int(_host.SERVER_WATCH_MS), int(_host.SERVER_COLD_START_WATCH_MS)):
+		## #896: past the budget we stop watching either way, but a spawn that
+		## never published a pid-file did not "survive startup" — it just never
+		## proved anything. Say so, or the only remaining signal is a silent
+		## reconnect loop.
+		if real_pid <= 0:
+			print(
+				"MCP | server spawn never published a pid-file within %ds; "
+				% int(_host.SERVER_COLD_START_WATCH_MS / 1000)
+				+ "no longer watching it. If the editor stays disconnected, "
+				+ "check the Godot output log for the server's own errors."
+			)
 		_host._stop_server_watch()
+
+
+## How long to keep watching a spawn, given whether it has published its
+## pid-file yet.
+##
+## Pure so tests can drive the decision without a live spawn. `pid_from_file`
+## is the authoritative "the server got far enough to run" signal: the Python
+## server writes it during import, before uvicorn binds. Until it appears, a
+## live launcher PID proves only that `uvx` has not exited — on a cold start
+## that is usually a download still in progress, not a started server.
+static func watch_budget_ms(pid_from_file: int, warm_ms: int, cold_ms: int) -> int:
+	return warm_ms if pid_from_file > 0 else cold_ms
 
 
 ## The spawned server died inside the SPAWN_GRACE_MS window. Decide what

--- a/plugin/addons/godot_ai/utils/update_manager.gd
+++ b/plugin/addons/godot_ai/utils/update_manager.gd
@@ -33,6 +33,7 @@ const RELEASES_PAGE := "https://github.com/hi-godot/godot-ai/releases/latest"
 const UPDATE_TEMP_DIR := "user://godot_ai_update/"
 const UPDATE_TEMP_ZIP := "user://godot_ai_update/update.zip"
 const ClientConfigurator := preload("res://addons/godot_ai/client_configurator.gd")
+const PortResolver := preload("res://addons/godot_ai/utils/port_resolver.gd")
 
 ## RSA-4096 public key for release-signature verification (#687). The paired
 ## private key exists only in the GitHub Actions secret RELEASE_SIGNING_KEY_PEM
@@ -262,7 +263,8 @@ func start_install() -> void:
 	## almost always cached in the CliFinder by now (the dock's setup probe);
 	## a cold lookup is the same bounded main-thread cost as
 	## `_reprobe_uv_if_negative`, on the same rare click-driven path.
-	ClientConfigurator.prewarm_server_package(_latest_remote_version)
+	_prewarm_pid = ClientConfigurator.prewarm_server_package(_latest_remote_version)
+	_prewarm_wait_started_ms = 0
 
 	if _download_request != null:
 		_download_request.queue_free()
@@ -292,6 +294,22 @@ func start_install() -> void:
 ## deferred initial refresh) — true while plugin scripts are being
 ## overwritten. A worker mid-`GDScriptFunction::call` into a half-
 ## overwritten script SIGABRTs the editor.
+## PID of the detached package pre-warm started alongside the zip download,
+## or <= 0 when none is running (no uvx tier, unusable version pin, or it has
+## already been waited out). See `_wait_for_prewarm_before_install`.
+var _prewarm_pid := -1
+## When the install first found the pre-warm still running, so the wait below
+## is bounded from the first check rather than re-armed on every poll.
+var _prewarm_wait_started_ms := 0
+## Ceiling on how long install will wait for the pre-warm. Matches the budget
+## the Configure-time pre-warm allows for the same download.
+const PREWARM_WAIT_BUDGET_MS := 180 * 1000
+## Poll interval while waiting. Deliberately not sub-second: `pid_alive` shells
+## out to `tasklist` on Windows via a blocking `OS.execute` on the main thread,
+## so a tight poll would make the editor sluggish for the whole wait.
+const PREWARM_POLL_SECONDS := 2.0
+
+
 func is_install_in_flight() -> bool:
 	return _install_in_flight
 
@@ -724,6 +742,40 @@ static func _parse_sha256_digest(text: String) -> String:
 
 # ---- Install orchestration ---------------------------------------------
 
+## True when install may proceed now. False means "come back later" — this
+## call has already scheduled the retry.
+##
+## Deliberately placed AFTER the symlink check in `_install_zip` so a dev
+## checkout (which never installs) is never delayed by it.
+func _wait_for_prewarm_before_install() -> bool:
+	if _prewarm_pid <= 0 or not PortResolver.pid_alive(_prewarm_pid):
+		_prewarm_pid = -1
+		return true
+	if _prewarm_wait_started_ms == 0:
+		_prewarm_wait_started_ms = Time.get_ticks_msec()
+	if Time.get_ticks_msec() - _prewarm_wait_started_ms >= PREWARM_WAIT_BUDGET_MS:
+		## Proceed rather than strand the update: a pre-warm this slow means the
+		## post-update spawn will be cold, which is now survivable — the startup
+		## watch stays alive until the pid-file appears (#896).
+		print(
+			"MCP | self-update: package pre-warm still running after %ds; "
+			% int(PREWARM_WAIT_BUDGET_MS / 1000)
+			+ "installing anyway, the new server may start cold"
+		)
+		_prewarm_pid = -1
+		return true
+	install_state_changed.emit({"button_text": "Preparing packages...", "button_disabled": true})
+	if is_inside_tree():
+		get_tree().create_timer(PREWARM_POLL_SECONDS).timeout.connect(
+			_install_zip, CONNECT_ONE_SHOT
+		)
+		return false
+	## Detached from the tree (dock teardown mid-update): no timer to re-arm on,
+	## so let the install proceed rather than silently dropping it.
+	_prewarm_pid = -1
+	return true
+
+
 func _install_zip() -> void:
 	## Symlinked addons dir means an extract would clobber canonical
 	## `plugin/` source through the link. Symlink detection is independent
@@ -734,6 +786,21 @@ func _install_zip() -> void:
 			"button_disabled": true,
 			"banner_visible": false,
 		})
+		return
+
+	## #896: do not tear the old server down until the NEW version's uv
+	## environment is actually built. `install_downloaded_update` below kills
+	## the server and hands off to the reload runner; the new plugin instance
+	## then spawns a server that, on a cold cache, is still downloading ~67
+	## packages. The pre-warm was started alongside the zip download precisely
+	## to cover this, but nothing waited for it — so on a slow link the update
+	## proceeded while the environment was still being fetched, which is the
+	## window where a failed spawn goes undiagnosed.
+	##
+	## Non-blocking: re-arms itself on a timer rather than stalling the main
+	## thread, and gives up after PREWARM_WAIT_BUDGET_MS so a wedged pre-warm
+	## cannot strand the update. Fully inert when no pre-warm is running.
+	if not _wait_for_prewarm_before_install():
 		return
 
 	## Drain in-flight workers + block new ones BEFORE any disk write.

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -1497,6 +1497,47 @@ func test_handoff_not_pending_once_the_pid_file_lands() -> void:
 		"a published pid-file ends the handoff wait")
 
 
+## ----- startup watch budget (#896) -----
+
+func test_watch_budget_extends_until_the_pid_file_appears() -> void:
+	## #896: the short watch justifies itself with "mid-session crashes surface
+	## via WebSocket disconnect" — which is only true once there IS a connection.
+	## A cold uvx spawn can still be downloading its ~67-package environment at
+	## SERVER_WATCH_MS, having proven nothing. Stopping the watch there means a
+	## launcher that dies afterwards is never observed, `_diagnose_spawn_fast_exit`
+	## never runs (it is only reachable from inside the watch), and the plugin
+	## redials forever behind a bare "Disconnected".
+	var warm := int(GodotAiPlugin.SERVER_WATCH_MS)
+	var cold := int(GodotAiPlugin.SERVER_COLD_START_WATCH_MS)
+
+	## pid-file published: the server proved it started, short budget applies.
+	assert_eq(McpServerLifecycleManagerScript.watch_budget_ms(4242, warm, cold), warm,
+		"a published pid-file means the short watch is enough")
+
+	## No pid-file: keep watching, because nothing has been proven yet.
+	assert_eq(McpServerLifecycleManagerScript.watch_budget_ms(0, warm, cold), cold,
+		"without a pid-file the spawn has proven nothing and must stay watched")
+	assert_eq(McpServerLifecycleManagerScript.watch_budget_ms(-1, warm, cold), cold,
+		"an unreadable pid-file must be treated as not-yet-published")
+
+
+func test_cold_start_watch_outlasts_a_package_build() -> void:
+	## The extended window exists to cover a cold environment build, so it must
+	## be at least as long as the budget allowed for that same download
+	## elsewhere — otherwise the watch still ends before the evidence arrives.
+	assert_true(
+		int(GodotAiPlugin.SERVER_COLD_START_WATCH_MS) > int(GodotAiPlugin.SERVER_WATCH_MS),
+		"the cold-start watch must be longer than the warm one"
+	)
+	## Stated in absolute terms rather than against the Configure pre-warm's
+	## constant: that lives on a separate change, and this watch must hold on
+	## its own regardless of whether a pre-warm ran at all.
+	assert_true(
+		int(GodotAiPlugin.SERVER_COLD_START_WATCH_MS) >= 180 * 1000,
+		"the watch must outlast a cold ~67-package environment build"
+	)
+
+
 func test_handoff_expires_so_a_dead_windows_spawn_is_still_diagnosed() -> void:
 	## The wait is bounded: a genuinely dead spawn that never publishes must
 	## still reach the fast-exit diagnosis, inside SERVER_WATCH_MS.

--- a/test_project/tests/test_update_manager.gd
+++ b/test_project/tests/test_update_manager.gd
@@ -1156,3 +1156,49 @@ func test_mode_override_dropdown_wins_over_env() -> void:
 	_restore_mode_override(prior)
 	assert_eq(resolved, "user",
 		"Dropdown override must resolve to 'user' regardless of env")
+
+
+## ----- install gate on the package pre-warm (#896) -----
+
+func test_install_proceeds_immediately_when_no_prewarm_is_running() -> void:
+	## The gate must be completely inert on the normal path — no pre-warm
+	## started (no uvx tier, unusable pin), or one that already finished.
+	var mgr := McpUpdateManager.new()
+	mgr._prewarm_pid = -1
+	assert_true(mgr._wait_for_prewarm_before_install(),
+		"install must not be delayed when no pre-warm is running")
+
+	## A PID that is not alive must also fall straight through.
+	mgr._prewarm_pid = 999999999
+	assert_true(mgr._wait_for_prewarm_before_install(),
+		"a finished pre-warm must not delay install")
+	assert_eq(mgr._prewarm_pid, -1, "a settled pre-warm must clear its pid")
+	mgr.free()
+
+
+func test_install_gate_gives_up_rather_than_stranding_the_update() -> void:
+	## #896: waiting is an optimisation, not a precondition. A wedged pre-warm
+	## must never strand a self-update — past the budget the install proceeds
+	## and the (now longer) startup watch covers a cold spawn.
+	var mgr := McpUpdateManager.new()
+	## OS.get_process_id() is this editor: reliably alive, so the gate sees a
+	## live pre-warm without spawning anything.
+	mgr._prewarm_pid = OS.get_process_id()
+	mgr._prewarm_wait_started_ms = (
+		Time.get_ticks_msec() - McpUpdateManager.PREWARM_WAIT_BUDGET_MS - 1
+	)
+	assert_true(mgr._wait_for_prewarm_before_install(),
+		"an over-budget wait must let the install proceed")
+	assert_eq(mgr._prewarm_pid, -1, "giving up must clear the pid so it is not re-waited")
+	mgr.free()
+
+
+func test_install_gate_budget_covers_a_cold_package_build() -> void:
+	## Too short a budget defeats the point: the install would resume while the
+	## environment is still downloading, which is the case #896 is about.
+	assert_true(McpUpdateManager.PREWARM_WAIT_BUDGET_MS >= 180 * 1000,
+		"the wait must cover a cold ~67-package environment build")
+	## The poll must not be sub-second: pid_alive shells out to tasklist on
+	## Windows from the main thread, so a tight poll stalls the editor.
+	assert_true(McpUpdateManager.PREWARM_POLL_SECONDS >= 1.0,
+		"polling faster than 1s would make the editor sluggish on Windows")

--- a/tests/unit/test_editor_focus_refocus.py
+++ b/tests/unit/test_editor_focus_refocus.py
@@ -298,7 +298,12 @@ def test_install_update_drains_workers_and_blocks_spawning_before_extract() -> N
 
     flag_set_idx = install_block.find("_install_in_flight = true")
     drain_idx = install_block.find("_drain_dock_workers()")
-    handoff_idx = install_block.find("install_downloaded_update")
+    # Match the CALL, not the name. A bare `install_downloaded_update` search
+    # also matches any comment that mentions the function, and a comment above
+    # the drain would then read as a handoff before it — failing this test for
+    # prose rather than for ordering (hit for real when #896 documented the
+    # pre-warm gate directly above the drain).
+    handoff_idx = install_block.find("_plugin.install_downloaded_update(")
     symlink_return_idx = install_block.find("addons_dir_is_symlink()")
 
     assert flag_set_idx > 0, (
@@ -312,6 +317,11 @@ def test_install_update_drains_workers_and_blocks_spawning_before_extract() -> N
         "if not joined first."
     )
     assert symlink_return_idx > 0, "Test fixture broken: could not locate the symlink-safety check."
+    assert handoff_idx > 0, (
+        "Test fixture broken: could not locate the `_plugin.install_downloaded_update(` "
+        "handoff. Without this the ordering assertion below compares against -1 and "
+        "fails for the wrong reason."
+    )
 
     assert symlink_return_idx < flag_set_idx, (
         "Order: symlink-safety check → set _install_in_flight flag. Setting "


### PR DESCRIPTION
Closes #896.

## The bug

`SERVER_WATCH_MS` (30s) is not a process-killing timeout — it is a *monitoring cutoff*, and it treated "launcher process still alive" as proof that startup succeeded (`server_lifecycle.gd`):

```gdscript
if elapsed >= int(_host.SERVER_WATCH_MS):
    ## Survived startup — mid-session crashes surface via WebSocket disconnect.
    _host._stop_server_watch()
```

The only precondition reaching that line is `pid_alive(spawn_pid)`. Nothing checks the pid-file, port binding, or handshake. On a slow link a cold `uvx` spawn is still resolving and downloading its ~67-package environment at 30s, having proven nothing.

The comment's own justification does not hold for that case: **a server that never came up has no WebSocket connection to lose**, so the disconnect flow can never fire for it. And `_diagnose_spawn_fast_exit` is only reachable from inside the watch — so past 30s the failure was undiagnosable by construction.

Verified downstream consequences:

- Reconnect never gives up — `_reconnect_delay_for_attempt()` clamps to the last entry in `RECONNECT_DELAYS` and there is no give-up path.
- The dock flips `Starting server…` → `Disconnected` at `STARTUP_GRACE_MSEC` (60s) with no diagnosis.
- A slow-but-successful download still connects eventually, so this is silent and intermittent — it only bites when the download actually fails.

## Fix

**1. Budget conditioned on the pid-file**, which is the real "it got far enough to run" signal (Python writes it during import, before uvicorn binds):

- pid-file published → short window still applies, and its rationale holds.
- not published → keep watching to `SERVER_COLD_START_WATCH_MS` (180s), so a launcher that dies at 45s lands in the existing fast-exit diagnosis instead of vanishing.

Stopping without a pid-file now also *says so*, instead of leaving a silent reconnect loop as the only symptom. Split into a pure `watch_budget_ms()` so the decision is testable without a live spawn.

This narrowing matters: the unsafe case is specifically *launcher alive **and** no pid-file*. Where the pid-file has landed, `_server_pid` has already been healed to the real server PID and the short watch is correct — so the change does not blanket-extend every spawn.

**2. Self-update no longer races its own pre-warm.** `prewarm_server_package` was fired detached alongside the zip download with nothing waiting for it, so `install_downloaded_update` could kill the old server and hand off to the reload runner while the new version's environment was still downloading — landing the new spawn in exactly the window above.

Install now waits for the pre-warm to exit first: non-blocking (re-arms on a timer rather than stalling the main thread), polls at 2s because `pid_alive` shells out to `tasklist` on Windows from the main thread, bounded at 180s so a wedged pre-warm can never strand an update, and completely inert when no pre-warm is running.

## Relationship to #894

Independent by design. #894 warms the *client-spawned* bridge's environment at Configure time; this is the *plugin-spawned* server's own startup path. The budget here is stated in absolute terms rather than against #894's `PREWARM_TIMEOUT_MS`, because this window has to hold even when nothing warmed the cache first. The two branches do not depend on each other and can merge in either order.

## Verification

- Full GDScript suite: **2274 passed, 0 failed**, 70 suites (2301 total = main's 2296 + 5 new tests).
- Editor errors after a full run: 39, the same three benign buckets as baseline. No new buckets.
- `script/ci-check-gdscript`: clean.

Note for reviewers: the static `--import` check does **not** catch undeclared identifiers in test files — it passed twice on code that failed to instantiate at runtime (`cannot instantiate — abstract or broken`). Only the live `test_run` caught it. Worth knowing when relying on the static gate alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
