### PR TITLE
fix: fail closed with an explanation on a relative config-home env override

### DIFF
--- a/plugin/addons/godot_ai/clients/_base.gd
+++ b/plugin/addons/godot_ai/clients/_base.gd
@@ -216,6 +216,7 @@ var config_file_env: String = ""
 ## override to apply. Only declare a mapping when the client's docs guarantee
 ## the env var relocates the exact file we write — a wrong mapping writes the
 ## MCP entry somewhere the client never reads and Configure false-succeeds.
+## Relative values fail closed for the same reason `config_file_env`'s do.
 var config_home_env: String = ""
 ## Path of the config file relative to the env var's directory, e.g.
 ## "config.toml". Joined verbatim — no per-OS variants needed because the env
@@ -285,10 +286,10 @@ func resolved_config_path_details() -> Dictionary:
 	if not str(file_override.get("path", "")).is_empty() or not str(file_override.get("error", "")).is_empty():
 		_clear_config_path_warning()
 		return file_override
-	var override := config_home_override()
-	if not override.is_empty():
+	var home_override := config_home_override_details()
+	if not str(home_override.get("path", "")).is_empty() or not str(home_override.get("error", "")).is_empty():
 		_clear_config_path_warning()
-		return {"path": override, "error": ""}
+		return home_override
 	var candidate_key := McpPathTemplate.platform_key(candidates)
 	if not candidate_key.is_empty():
 		return _resolve_ordered_config_path_candidates(candidates[candidate_key])
@@ -390,18 +391,40 @@ func _clear_config_path_warning() -> void:
 	_config_path_warning_mutex.unlock()
 
 
-## The env-var-relocated config path, or "" when no override applies
-## (no mapping declared, env var unset, or env var empty/whitespace).
-func config_home_override() -> String:
+## The config-home env override plus any fail-closed diagnostic. Empty path and
+## error means no override applies (no mapping declared, env var unset, or env
+## var empty/whitespace).
+func config_home_override_details() -> Dictionary:
 	if config_home_env.is_empty() or config_home_env_subpath.is_empty():
-		return ""
+		return {"path": "", "error": ""}
 	## env_lookup, not OS.get_environment: this runs on dock worker threads,
 	## which must not race the spawn window's setenv/unsetenv (#691).
 	var home := McpPathTemplate.env_lookup(config_home_env).strip_edges()
 	if home.is_empty():
-		return ""
+		return {"path": "", "error": ""}
 	# Expand a leading ~ so `CODEX_HOME=~/codex-alt` behaves like the shell.
-	return McpPathTemplate.expand(home).path_join(config_home_env_subpath)
+	var expanded := McpPathTemplate.expand(home)
+	## Same fail-closed rule as `config_file_override_details`: a relative value
+	## resolves against the EDITOR's working directory, not the client's, so
+	## honouring it silently aims the write at the Godot project directory
+	## instead of the file the client reads. The write layer can only name the
+	## mangled path it was handed; only here do we still know which env var
+	## produced it, so this is where the user-facing explanation belongs.
+	if not expanded.is_absolute_path():
+		return {
+			"path": "",
+			"error": "%s's $%s override must be an absolute config-home directory path; got %s" % [
+				display_name, config_home_env, home,
+			],
+		}
+	return {"path": expanded.path_join(config_home_env_subpath), "error": ""}
+
+
+## The env-var-relocated config path, or "" when no override applies (no
+## mapping declared, env var unset, env var empty/whitespace, or a value that
+## failed closed — `config_home_override_details` carries that diagnostic).
+func config_home_override() -> String:
+	return str(config_home_override_details().get("path", ""))
 
 
 ## True when a CLI client also declares where its config file lives, so it can

--- a/plugin/addons/godot_ai/clients/_path_template.gd
+++ b/plugin/addons/godot_ai/clients/_path_template.gd
@@ -24,7 +24,7 @@ static var _env_snapshot := {}
 static var _env_snapshot_mutex := Mutex.new()
 
 ## Every var this layer and its sibling consumers (`_base.gd`
-## `config_file_override_details`, `config_home_override`, `_cli_finder.gd` lookups,
+## `config_file_override_details`, `config_home_override_details`, `_cli_finder.gd` lookups,
 ## `client_configurator.gd` mode/trace reads) can touch off-main.
 ## Descriptor-declared config-file/config-home env names are passed as extras
 ## by the warm callers.

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -1560,6 +1560,83 @@ func test_config_file_env_relative_path_fails_closed() -> void:
 	assert_contains(str(details.get("error", "")), "absolute config-file path")
 
 
+func test_config_home_env_relative_path_fails_closed() -> void:
+	## A relative $CODEX_HOME / $CLAUDE_CONFIG_DIR resolves against the EDITOR's
+	## working directory, not the client's, so honouring it aims Configure at
+	## the Godot project directory instead of the file the client reads. Fail
+	## closed with the same variable-naming diagnostic the exact-file override
+	## gives: the write layer's generic "Cannot write to <relative path>" never
+	## says which env var mangled the path, so the user has nothing to fix.
+	var default_path := _scratch_dir.path_join("home_env_default_untouched.toml")
+	_remove_if_exists(default_path)
+	var client := _make_env_override_toml_client(default_path)
+	var relative_home := "godot_ai_relative_cfg_home"
+	var leak_dir := ProjectSettings.globalize_path("res://").path_join(relative_home)
+	var project_leak := leak_dir.path_join("config.toml")
+	_remove_if_exists(project_leak)
+	DirAccess.remove_absolute(leak_dir)
+	var prior_env := OS.get_environment(TEST_CFG_HOME_ENV)
+	OS.set_environment(TEST_CFG_HOME_ENV, relative_home)
+
+	var details := client.resolved_config_path_details()
+	var override := client.config_home_override()
+	var configured := McpTomlStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+	var status := McpTomlStrategy.check_status(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+
+	if prior_env.is_empty():
+		OS.unset_environment(TEST_CFG_HOME_ENV)
+	else:
+		OS.set_environment(TEST_CFG_HOME_ENV, prior_env)
+
+	var error := str(details.get("error", ""))
+	assert_eq(override, "", "a relative config-home value must not resolve to a path")
+	assert_eq(details.get("path"), "",
+		"a failed-closed override must not fall back to path_template")
+	assert_contains(error, "$%s" % TEST_CFG_HOME_ENV,
+		"the error must name the env var that produced the path: %s" % error)
+	assert_contains(error, "absolute",
+		"the error must say the value has to be absolute: %s" % error)
+	assert_contains(error, relative_home,
+		"the error must echo the offending value: %s" % error)
+	assert_eq(configured.get("status"), "error")
+	assert_eq(configured.get("message"), error,
+		"Configure must surface the env-var explanation, not a generic write failure")
+	assert_eq(status, McpClient.Status.ERROR,
+		"the dock row must read ERROR, not a silently-unconfigured green/grey")
+	assert_false(FileAccess.file_exists(default_path),
+		"a failed-closed override must not fall back to writing the path_template default")
+	assert_false(FileAccess.file_exists(project_leak),
+		"a relative override must never write a config into the Godot project directory")
+	## The atomic write creates the parent before it discovers it cannot open
+	## the file, so the un-gated path leaves a stray directory in the project
+	## even on the "Cannot write to ..." failure. Nothing may be created here.
+	assert_false(DirAccess.dir_exists_absolute(leak_dir),
+		"a relative override must not create a directory in the Godot project either")
+	_remove_if_exists(project_leak)
+	DirAccess.remove_absolute(leak_dir)
+
+
+func test_config_home_env_tilde_value_still_resolves() -> void:
+	## The absolute-path gate must not reject the shell-style value it was
+	## always meant to accept: `CODEX_HOME=~/codex-alt` expands to an absolute
+	## home-relative directory before the check runs.
+	var default_path := _scratch_dir.path_join("home_env_tilde_default.toml")
+	var client := _make_env_override_toml_client(default_path)
+	var prior_env := OS.get_environment(TEST_CFG_HOME_ENV)
+	OS.set_environment(TEST_CFG_HOME_ENV, "~/godot_ai_tilde_cfg_home")
+	var details := client.resolved_config_path_details()
+	if prior_env.is_empty():
+		OS.unset_environment(TEST_CFG_HOME_ENV)
+	else:
+		OS.set_environment(TEST_CFG_HOME_ENV, prior_env)
+
+	assert_eq(details.get("error"), "", "a ~-prefixed config home must not fail closed")
+	var path := str(details.get("path", ""))
+	assert_true(path.is_absolute_path(), "~ must expand to an absolute path: %s" % path)
+	assert_true(path.ends_with("godot_ai_tilde_cfg_home/config.toml"),
+		"the subpath must still be joined onto the expanded home: %s" % path)
+
+
 func test_codex_declares_codex_home_override() -> void:
 	var client := McpClientRegistry.get_by_id("codex")
 	assert_true(client != null, "codex must be registered")


### PR DESCRIPTION
## Problem

`McpClient.config_file_override_details()` already refuses a relative exact-file override and names the variable in the message:

> `OpenCode's $OPENCODE_CONFIG override must be an absolute config-file path; got relative/opencode.json`

Its sibling `config_home_override()` had no such check. It returned `McpPathTemplate.expand(home).path_join(config_home_env_subpath)` verbatim, so a relative `$CODEX_HOME` / `$CLAUDE_CONFIG_DIR` yielded a relative config path like `relative/dir/config.toml`. The write layer then reported only the generic `Cannot write to <relative path>` — nothing tells the user which env var mangled it — and the attempt left a stray directory inside the Godot project.

## Change

- `config_home_override_details() -> Dictionary` now holds the logic and mirrors the exact-file sibling: after `~` / `$VAR` expansion, a non-absolute value returns `{"path": "", "error": "<Client>'s $<VAR> override must be an absolute config-home directory path; got <raw value>"}`.
- `resolved_config_path_details()` propagates that dict the same way it already propagated the exact-file one, so the diagnostic reaches every consumer: the dock row (`_config_path_resolution_error` → `error_msg`), Configure, Remove, status, and the manual-command panel.
- `config_home_override() -> String` stays as a thin path-only wrapper, so the descriptor API and its existing test are unchanged.
- `~`-prefixed values still resolve — the gate runs *after* expansion, so `CODEX_HOME=~/codex-alt` behaves as before.

CLI clients are deliberately untouched: `_config_path_resolution_error` returns `""` for `config_type == "cli"`, because a CLI that honours the env var itself resolves it against its own working directory.

## Verification

Isolated stack (worktree server on :8010/:9510 + scratch-HOME headless editor), leaving the shared :8000 stack alone.

- `ruff check src/ tests/` clean; `pytest` 1815 passed, 5 skipped
- `test_run suite=clients` 224/0 · `suite=client_attach_config` 42/0
- Full GDScript suite **2271 passed, 0 failed**, 70 suites — also re-run with `CODEX_HOME` deliberately set to a relative value, still 0 failures
- **Mutation check**: with the `is_absolute_path()` gate removed, the new test fails on its first assertion, and the run leaves a stray `test_project/godot_ai_relative_cfg_home/` behind — reproducing the hazard directly
- **Live smoke** against a real descriptor (`CODEX_HOME=smoke-relative-codex-home`): `client_manage(op="status")` returns

  ```json
  {"id": "codex", "status": "error",
   "error": "Codex's $CODEX_HOME override must be an absolute config-home directory path; got smoke-relative-codex-home"}
  ```

  `configure` and `remove` both fail with that same message instead of `Cannot write to …`; no directory created in the project; `~/.codex/config.toml` untouched.

## Tests

Two added to `test_clients.gd`, alongside the existing exact-file override tests:

- `test_config_home_env_relative_path_fails_closed` — the error names the env var, says "absolute", echoes the offending value; Configure surfaces that message verbatim; status reads `ERROR`; neither the `path_template` default nor anything in the Godot project directory is written.
- `test_config_home_env_tilde_value_still_resolves` — regression guard that the gate does not reject the shell-style value it was always meant to accept.

## Note on an unrelated pre-existing issue

Every run of `test_json_merge_transaction_rolls_back_earlier_write_failure` drops a randomly-named 12-byte file (`-AyOeVz`, `-NlFd6L`, …) into `test_project/`: it passes `{"path": ""}` into `McpJsonStrategy._write_transaction`, and `McpAtomicWrite.write("")` stages a temp under `res://` before failing. Confirmed pre-existing and unrelated to this change. It is exactly what the `McpAtomicWrite.write()` absolute-path guard in flight on `dlight/hungry-edison-0f736d` eliminates, so this PR deliberately does not duplicate that guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid relative configuration-home environment values are now rejected safely with a clear diagnostic.
  * Configuration status reports an error instead of attempting to write to an unintended location.
  * Tilde-prefixed configuration paths continue to resolve correctly.
  * Prevented accidental creation of malformed paths or directories within the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->