### PR TITLE
fix(clients): keep an unresolvable path token instead of expanding it to ""

### DIFF
--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -28,6 +28,24 @@ rules are not visible in the code:
   dispatched on `config_type "dsh"`), plus the matching branch in
   `client_configurator.gd` and `_manual_command.gd`.
 
+### Path resolution fails closed
+
+Every descriptor path is `~`- or `$VAR`-rooted and expands through
+`_path_template.gd`. A token that cannot be resolved — the variable is unset, or
+a dock worker is reading an env snapshot that was never warmed — is **left in
+the string** rather than replaced with an empty string. Substituting the empty
+string is what turned `$USERPROFILE/godot` into `/godot`, a root-relative path
+that `is_absolute_path()` accepts, so every fail-closed guard in this layer
+waved it through and Configure wrote somewhere the user never named.
+
+The invariant that replaces it: **a resolved config path is absolute or it is an
+error**. `McpClient.resolved_config_path_details()` enforces it for every
+descriptor path (both env overrides, `config_path_candidates`, and plain
+`path_template`), `_json_strategy.gd::_load_merge_tiers` enforces it for Pi's
+merge tiers, and `McpAtomicWrite.write` refuses a non-absolute destination as a
+last line of defence. The dock reports the unexpanded path, which still shows
+what failed to resolve.
+
 MCP tools `client_configure`, `client_remove`, and `client_status` expose this to
 AI clients.
 

--- a/plugin/addons/godot_ai/clients/_atomic_write.gd
+++ b/plugin/addons/godot_ai/clients/_atomic_write.gd
@@ -15,6 +15,14 @@ extends RefCounted
 
 
 static func write(path: String, content: String) -> bool:
+	# Last line of defence for the path-resolution layer above. A relative (or
+	# empty) destination resolves against the EDITOR's working directory, not
+	# the caller's: the staging file lands inside the Godot project, the rename
+	# to the mangled destination fails, and the debris stays there. Callers gate
+	# this already (`McpClient.resolved_config_path_details`), but a writer that
+	# cannot tell where it is writing must refuse rather than guess.
+	if not path.is_absolute_path():
+		return false
 	# If the target is a symlink (stow/chezmoi-managed dotfiles), rename-over
 	# would replace the LINK with a regular file, silently detaching the
 	# config from the user's dotfile repo (#534). Resolve the link chain and

--- a/plugin/addons/godot_ai/clients/_base.gd
+++ b/plugin/addons/godot_ai/clients/_base.gd
@@ -270,6 +270,35 @@ func resolved_config_path() -> String:
 ## is empty for ordinary unsupported/missing path mappings to preserve the
 ## long-standing status behavior for clients not installed on this platform.
 func resolved_config_path_details() -> Dictionary:
+	var details := _resolve_config_path_details()
+	var path := str(details.get("path", ""))
+	if path.is_empty() or path.is_absolute_path():
+		return details
+	## Last gate before every strategy's read/write. `McpPathTemplate.expand`
+	## leaves a token it cannot resolve in place, so an unset `$USERPROFILE` (or
+	## a `~` with no HOME) reaches here as a RELATIVE path rather than as the
+	## root-relative `/godot` that sails through `is_absolute_path()`. Acting on
+	## it would resolve against the editor's own working directory and create a
+	## literal `$USERPROFILE` folder in the Godot project. No descriptor
+	## template is intentionally relative — every one is `~`- or `$VAR`-rooted —
+	## so a non-absolute survivor is always a resolution failure. Report it with
+	## the unexpanded path, which still shows what could not be resolved.
+	return {"path": "", "error": unresolved_config_path_error(display_name, path)}
+
+
+## Shared wording for a path template `McpPathTemplate.expand` could not fully
+## resolve. Used by the guard above and by the merge-tier loader in
+## `_json_strategy.gd`, which resolves its own templates and never passes
+## through `resolved_config_path_details`.
+static func unresolved_config_path_error(client_name: String, path: String) -> String:
+	return (
+		"Could not resolve %s's config path: %s did not expand to an absolute "
+		+ "path. Set HOME/USERPROFILE (or the variable the path names) in the "
+		+ "environment the editor was launched from."
+	) % [client_name, path]
+
+
+func _resolve_config_path_details() -> Dictionary:
 	## Reflected reads: after an in-session self-update, an instance created
 	## before the update can answer Nil for vars the update added, and the
 	## typed calls below would each hard-error (Nil -> Dictionary, #850's

--- a/plugin/addons/godot_ai/clients/_json_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_json_strategy.gd
@@ -595,6 +595,18 @@ static func _project_override_message(
 static func _load_merge_tiers(client: McpClient) -> Dictionary:
 	var tiers: Array[Dictionary] = []
 	for path in _merge_paths(client):
+		## These templates never pass through `resolved_config_path_details`,
+		## so they need its fail-closed gate here: `McpPathTemplate.expand`
+		## leaves a token it cannot resolve in place, and the relative survivor
+		## would be read — and on Configure, written — against the editor's own
+		## working directory. Fail the whole fold rather than dropping the tier:
+		## a dropped tier reads as "the user has no config there", which is
+		## exactly the wrong thing to conclude when we could not look.
+		if not path.is_absolute_path():
+			return {
+				"ok": false,
+				"error": McpClient.unresolved_config_path_error(client.display_name, path),
+			}
 		var read := _read_file_text(path)
 		if not read.get("ok", false):
 			return {

--- a/plugin/addons/godot_ai/clients/_path_template.gd
+++ b/plugin/addons/godot_ai/clients/_path_template.gd
@@ -154,28 +154,64 @@ static func expand_path_candidates(template: String) -> PackedStringArray:
 
 
 ## Substitute env vars and ~ in a single template string.
+##
+## A token that cannot be resolved — the var is unset and no home-derived
+## fallback applies, or a dock worker's env snapshot was never warmed with it —
+## is LEFT IN PLACE rather than replaced with "". Substituting "" is what turns
+## `$USERPROFILE/godot` into `/godot`: a root-relative path that
+## `is_absolute_path()` accepts, so every fail-closed guard downstream waves it
+## through and the caller reads or writes a directory the user never named.
+## `$USERPROFILE` is the easy repro (unset off Windows, and the only one of
+## these vars with no fallback), but `$HOME`/`$XDG_CONFIG_HOME`/`$APPDATA`/
+## `$LOCALAPPDATA` reach the same state whenever `_home()` is empty, which the
+## missing-warm-up degradation above makes reachable on a worker thread.
+##
+## The surviving token keeps the result non-absolute, so those guards catch it,
+## and the unexpanded path they report still shows what failed to resolve.
+## `~` is left alone for the same reason: collapsing `~/godot` to the relative
+## `godot` aims it at the editor's own working directory.
 static func expand(template: String) -> String:
 	if template.is_empty():
 		return ""
 	var out := template
 	if out.begins_with("~/") or out == "~":
 		var home := _home()
-		out = home if out == "~" else home.path_join(out.substr(2))
+		if not home.is_empty():
+			out = home if out == "~" else home.path_join(out.substr(2))
 	# $HOME, $APPDATA, $LOCALAPPDATA, $USERPROFILE, $XDG_CONFIG_HOME
 	for var_name in ["XDG_CONFIG_HOME", "LOCALAPPDATA", "USERPROFILE", "APPDATA", "HOME"]:
 		var token := "$%s" % var_name
-		if out.find(token) >= 0:
-			var value := env_lookup(var_name)
-			if value.is_empty() and var_name == "XDG_CONFIG_HOME":
-				value = _home().path_join(".config")
-			if value.is_empty() and var_name == "APPDATA":
-				value = _home().path_join("AppData/Roaming")
-			if value.is_empty() and var_name == "LOCALAPPDATA":
-				value = _home().path_join("AppData/Local")
-			if value.is_empty() and var_name == "HOME":
-				value = _home()
-			out = out.replace(token, value)
+		if out.find(token) < 0:
+			continue
+		var value := env_lookup(var_name)
+		if value.is_empty():
+			value = _home_fallback(var_name)
+		if value.is_empty():
+			continue
+		out = out.replace(token, value)
 	return out
+
+
+## Home-derived default for a var the environment does not define. Returns ""
+## when home itself is unresolvable so `expand` leaves the token alone: rooting
+## these at an empty home yields a RELATIVE path, not an absent one —
+## `"".path_join(".config")` is `.config`, which reads against the editor's
+## working directory rather than the user's config dir. `USERPROFILE` has no
+## fallback (it is the thing `_home()` itself falls back to).
+static func _home_fallback(var_name: String) -> String:
+	var home := _home()
+	if home.is_empty():
+		return ""
+	match var_name:
+		"XDG_CONFIG_HOME":
+			return home.path_join(".config")
+		"APPDATA":
+			return home.path_join("AppData/Roaming")
+		"LOCALAPPDATA":
+			return home.path_join("AppData/Local")
+		"HOME":
+			return home
+	return ""
 
 
 static func _os_key() -> String:

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -967,6 +967,83 @@ func test_path_template_xdg_fallback() -> void:
 	assert_true(resolved.ends_with("/foo"))
 
 
+func test_path_template_leaves_unresolvable_token_in_place() -> void:
+	## Substituting "" for a token that resolves to nothing turned
+	## `$USERPROFILE/godot` into `/godot` — root-relative, which
+	## `is_absolute_path()` ACCEPTS, so every fail-closed guard in this layer
+	## waved it through and the caller read (or wrote) a directory the user
+	## never named. `$USERPROFILE` is the cheap repro: unset off Windows, and
+	## the only one of these vars with no home-derived fallback.
+	var saved := OS.get_environment("USERPROFILE")
+	OS.unset_environment("USERPROFILE")
+	var resolved := McpPathTemplate.expand("$USERPROFILE/godot")
+	# Restore before asserting so a failure can't leak into later tests.
+	if not saved.is_empty():
+		OS.set_environment("USERPROFILE", saved)
+
+	assert_eq(resolved, "$USERPROFILE/godot",
+		"an unresolvable token must be left in place, not replaced with an empty string")
+	assert_false(resolved.is_absolute_path(),
+		"the survivor must stay non-absolute so is_absolute_path() guards catch it: %s" % resolved)
+
+
+func test_path_template_still_expands_a_set_userprofile() -> void:
+	## The counterpart to the test above: leaving tokens alone must not cost us
+	## the substitution itself on Windows, where `$USERPROFILE` is the primary
+	## spelling in every windows-keyed descriptor template.
+	var saved := OS.get_environment("USERPROFILE")
+	var fake := "/tmp/godot-ai-test-userprofile-set"
+	OS.set_environment("USERPROFILE", fake)
+	var resolved := McpPathTemplate.expand("$USERPROFILE/godot")
+	if saved.is_empty():
+		OS.unset_environment("USERPROFILE")
+	else:
+		OS.set_environment("USERPROFILE", saved)
+
+	assert_eq(resolved, fake.path_join("godot"))
+	assert_true(resolved.is_absolute_path())
+
+
+func test_path_template_leaves_home_derived_tokens_in_place_without_home() -> void:
+	## Every remaining token reaches the same state as `$USERPROFILE` once
+	## `_home()` is empty — reachable in production when a dock worker reads a
+	## snapshot that was never warmed (see `env_lookup`), not only when the user
+	## really has no HOME. The home-derived fallbacks must NOT fire either:
+	## `"".path_join(".config")` is the relative `.config`, which reads against
+	## the editor's own working directory instead of the user's config dir.
+	##
+	## `~` is in here too. It was already the caught spelling — it collapsed to
+	## a relative path — but it collapsed to `godot`, which names nothing the
+	## user could act on. Both spellings of the same intent now fail the same
+	## way, and both still say what failed.
+	const VARS := ["HOME", "USERPROFILE", "XDG_CONFIG_HOME", "APPDATA", "LOCALAPPDATA"]
+	var saved := {}
+	for var_name in VARS:
+		saved[var_name] = OS.get_environment(var_name)
+		OS.unset_environment(var_name)
+
+	var templates := PackedStringArray([
+		"~/godot",
+		"$HOME/godot",
+		"$XDG_CONFIG_HOME/godot",
+		"$APPDATA/godot",
+		"$LOCALAPPDATA/godot",
+	])
+	var resolved := PackedStringArray()
+	for template in templates:
+		resolved.append(McpPathTemplate.expand(template))
+	# Restore before asserting: leaving HOME unset would break every later test.
+	for var_name in VARS:
+		if not str(saved[var_name]).is_empty():
+			OS.set_environment(var_name, str(saved[var_name]))
+
+	for index in range(templates.size()):
+		assert_eq(resolved[index], templates[index],
+			"%s must survive expansion unchanged when home is unresolvable" % templates[index])
+		assert_false(resolved[index].is_absolute_path(),
+			"%s must not expand to an absolute path" % templates[index])
+
+
 func test_path_candidate_expansion_supports_directory_wildcard_and_missing_leaf() -> void:
 	var root := _scratch_dir.path_join("candidate_expand")
 	_remove_dir_recursive(root)
@@ -1558,6 +1635,81 @@ func test_config_file_env_relative_path_fails_closed() -> void:
 		OS.set_environment(TEST_CFG_FILE_ENV, prior_env)
 	assert_eq(details.get("path"), "")
 	assert_contains(str(details.get("error", "")), "absolute config-file path")
+
+
+func test_unresolvable_path_template_fails_closed() -> void:
+	## The descriptor's own `path_template` had no gate at all — the two env
+	## overrides above are checked, but the path every other client resolves
+	## through was taken on trust. That was survivable only while `expand`
+	## replaced an unresolvable token with "", which produced the root-relative
+	## `/godot_ai_unresolved/config.toml` and read as absolute. Now the token
+	## survives, so the path is relative and would resolve against the EDITOR's
+	## working directory — Configure would create a literal `$USERPROFILE`
+	## folder in the Godot project. Fail closed, and say which variable failed.
+	var relative_root := "$USERPROFILE/godot_ai_unresolved"
+	var client := _make_test_toml_client(relative_root.path_join("config.toml"))
+	client.display_name = "Unresolved Template Test"
+	var leak_dir := ProjectSettings.globalize_path("res://").path_join("$USERPROFILE")
+	var saved := OS.get_environment("USERPROFILE")
+	OS.unset_environment("USERPROFILE")
+
+	var details := client.resolved_config_path_details()
+	var path := client.resolved_config_path()
+	var configured := McpTomlStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+	var status := McpTomlStrategy.check_status(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+
+	if not saved.is_empty():
+		OS.set_environment("USERPROFILE", saved)
+
+	var error := str(details.get("error", ""))
+	assert_eq(details.get("path"), "",
+		"an unresolved template must not be handed to the write layer")
+	assert_eq(path, "", "the plain accessor must fail closed too")
+	assert_contains(error, "$USERPROFILE",
+		"the error must name the variable that failed to resolve: %s" % error)
+	assert_contains(error, client.display_name,
+		"the error must name the client whose path failed: %s" % error)
+	assert_eq(configured.get("status"), "error")
+	assert_eq(configured.get("message"), error,
+		"Configure must surface the resolution failure, not a generic write error")
+	assert_eq(status, McpClient.Status.ERROR,
+		"the dock row must read ERROR, not a silently-unconfigured grey")
+	assert_false(DirAccess.dir_exists_absolute(leak_dir),
+		"an unresolved template must never create a token-named directory in the project")
+
+
+func test_unresolvable_merge_tier_template_fails_closed() -> void:
+	## Pi-style merge tiers resolve their own templates and never pass through
+	## `resolved_config_path_details`, so they need the same gate. Failing the
+	## whole fold — rather than dropping the tier — is the point: a dropped
+	## tier reads as "the user has no config there", which is exactly the wrong
+	## conclusion to draw from a path we could not resolve well enough to look
+	## at. Pi's real windows tiers are `$USERPROFILE`-rooted.
+	var readable_tier := _scratch_dir.path_join("merge_unresolved/mcp.json")
+	_remove_if_exists(readable_tier)
+	_write_text(readable_tier, JSON.stringify({"mcpServers": {}}))
+	var client := _make_merged_json_client(PackedStringArray([
+		"$USERPROFILE/godot_ai_unresolved/mcp.json",
+		readable_tier,
+	]))
+	var saved := OS.get_environment("USERPROFILE")
+	OS.unset_environment("USERPROFILE")
+
+	var status := McpJsonStrategy.check_status_details(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+	var configured := McpJsonStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+
+	if not saved.is_empty():
+		OS.set_environment("USERPROFILE", saved)
+
+	assert_eq(status.get("status"), McpClient.Status.ERROR,
+		"an unresolvable tier must not read as NOT_CONFIGURED")
+	assert_contains(str(status.get("error_msg", "")), "$USERPROFILE",
+		"the status error must name the variable that failed: %s" % status.get("error_msg", ""))
+	assert_eq(configured.get("status"), "error")
+	assert_contains(str(configured.get("message", "")), "$USERPROFILE")
+	assert_eq(_read_text(readable_tier), JSON.stringify({"mcpServers": {}}),
+		"the resolvable tier must be left untouched — the fold fails as a whole")
+	_remove_if_exists(readable_tier)
 
 
 func test_codex_declares_codex_home_override() -> void:
@@ -3046,6 +3198,24 @@ func test_atomic_write_leaves_no_stale_tmp_after_failed_write() -> void:
 	)
 	var leftovers := _leftover_tmp_files("tmp_fail_dir.txt.tmp")
 	assert_eq(leftovers.size(), 0, "no .tmp staging file may linger after a failed write: %s" % str(leftovers))
+
+
+func test_atomic_write_refuses_a_non_absolute_destination() -> void:
+	## A relative destination resolves against the EDITOR's working directory,
+	## so the staging file is created inside the Godot project and left there
+	## when the rename to the mangled destination fails. The empty path is the
+	## live repro: `_write_transaction`'s own failure test passes `""`, and each
+	## run of it used to drop an mkstemp-named file into `test_project/`.
+	var project_root := ProjectSettings.globalize_path("res://")
+	var before := _project_root_entries(project_root)
+
+	assert_false(McpAtomicWrite.write("", "cannot-write"),
+		"an empty destination must be refused, not staged relative to the editor")
+	assert_false(McpAtomicWrite.write("relative/config.json", "cannot-write"),
+		"a relative destination must be refused")
+
+	assert_eq(_project_root_entries(project_root), before,
+		"a refused write must leave nothing behind in the project directory")
 
 
 func test_atomic_write_does_not_use_fixed_tmp_name() -> void:
@@ -4639,6 +4809,18 @@ func _make_test_toml_client(path: String) -> McpClient:
 	c.toml_section_path = PackedStringArray(["mcp_servers", "godot-ai"])
 	c.toml_body_template = PackedStringArray(["url = \"{url}\"", "enabled = true"])
 	return c
+
+
+## Sorted file listing of the project root, used to prove a refused write
+## leaves no debris there. Files only: the editor may touch directories
+## (`.godot/`) for unrelated reasons mid-suite.
+func _project_root_entries(project_root: String) -> PackedStringArray:
+	var dir := DirAccess.open(project_root)
+	if dir == null:
+		return PackedStringArray()
+	var entries := dir.get_files()
+	entries.sort()
+	return entries
 
 
 func _remove_if_exists(path: String) -> void:


### PR DESCRIPTION
## The bug

`McpPathTemplate.expand()` replaced a token that resolved to nothing with the empty string, so `$USERPROFILE/godot` became `/godot` — root-relative, which `is_absolute_path()` accepts. Every fail-closed guard in this layer tests exactly that, so the mangled path sailed through all of them:

- `McpClient.config_file_override_details()` — the `$OPENCODE_CONFIG` gate
- `McpClient.config_home_override()` — the `$CODEX_HOME` / `$CLAUDE_CONFIG_DIR` path
- plain `path_template` / `config_path_candidates` resolution for every descriptor, which had **no gate at all**

`$USERPROFILE` is the cheap repro: unset off Windows, and the only one of these vars with no home-derived fallback. `$HOME`, `$XDG_CONFIG_HOME`, `$APPDATA` and `$LOCALAPPDATA` reach the same state whenever `_home()` is empty — reachable in production when a dock worker reads an env snapshot that was never warmed, which `_path_template.gd`'s own docstring calls out as "missing warm-up degrades resolution".

There was also an asymmetry: `~/codex-alt` under a broken environment collapsed to the relative `codex-alt` and **was** caught, while `$HOME/codex-alt` became `/codex-alt` and was **not** — two spellings of the same intent behaving differently.

Verified live on macOS (Godot 4.6.3, headless `--script` probe against `test_project`), before then after:

```
expand($USERPROFILE/godot) = '/godot'              absolute=true
expand($USERPROFILE/godot) = '$USERPROFILE/godot'  absolute=false
```

## The fix

**`_path_template.gd`** — an unresolved token now survives expansion. The result stays non-absolute, so the existing guards catch it and the diagnostic still shows what failed to resolve. `_home_fallback()` returns `""` when home itself is unresolvable rather than rooting the defaults at nothing: `"".path_join(".config")` is the relative `.config`, the same defect one layer down. `~` gets the same treatment, which removes the asymmetry above.

Leaving the token literal only helps if every consumer has a gate, and two did not. Without them this would trade a wrong-absolute path for a *relative* one resolving against the editor's cwd — creating a literal `$USERPROFILE` directory inside the Godot project:

- **`_base.gd`** — `resolved_config_path_details()` is now a guard around its old body, so every path it returns is absolute or carries an error. Covers the previously ungated `path_template` / `config_path_candidates` branches and the config-home override. Wording is shared via `McpClient.unresolved_config_path_error()`.
- **`_json_strategy.gd`** — `_load_merge_tiers` gates Pi's merge tiers, which resolve their own templates and never pass through that funnel. It fails the whole fold rather than dropping a tier: a dropped tier reads as "the user has no config there", the opposite of what is true when we could not look.

**`_atomic_write.gd`** also refuses a non-absolute destination as a last line of defence. That one was already leaking: `_write_transaction`'s own failure test passes `path: ""`, and every suite run staged an mkstemp-named file (`test_project/-RyzngU`, content `cannot-write`) into the project and left it there. Easy to split out if you'd rather keep this PR to the resolution layer.

## Verification

- `ruff check src/ tests/` clean; `pytest` 1815 passed, 5 skipped
- Full GDScript suite against a live editor (Godot 4.6.3): **2275/2302 passed, 0 failed**, 27 skipped, 70/70 suites. Named suites: `clients` 228/229 (1 skipped), `client_attach_config` 42/42, `path_validator` 30/30
- **Mutation check** — reverting `expand()` to the old substitution makes 4 of the 5 new client tests fail; the 5th (`test_path_template_still_expands_a_set_userprofile`) is the positive control and correctly stays green
- **Live probe across all 24 descriptors**: normal environment resolves every path absolute and unchanged; with `HOME`/`USERPROFILE`/`XDG_CONFIG_HOME` unset all 24 fail closed naming the unexpanded template, e.g.

  ```
  Could not resolve Claude Code's config path: ~/.claude.json did not expand to an
  absolute path. Set HOME/USERPROFILE (or the variable the path names) in the
  environment the editor was launched from.
  ```

New coverage: `test_path_template_leaves_unresolvable_token_in_place`, `test_path_template_still_expands_a_set_userprofile`, `test_path_template_leaves_home_derived_tokens_in_place_without_home`, `test_unresolvable_path_template_fails_closed`, `test_unresolvable_merge_tier_template_fails_closed`, `test_atomic_write_refuses_a_non_absolute_destination`. None needs environment tampering beyond unset/restore, and the `$USERPROFILE` cases need none on macOS/Linux.

## Rebase note

#898 is still open, so this branch has the pre-#898 `config_home_override() -> String` with no gate. The new funnel guard already fails that path closed, but with the generic message; #898's env-var-specific one is better and the two compose (its error passes straight through). Expect a small conflict in `_base.gd` — adjacent hunks in the same function.

Raised by CodeRabbit on #898 and deliberately left out of it: pre-existing, repo-wide, and fixing it only inside `config_home_override_details` would have created a new asymmetry with the exact-file sibling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration paths with unresolved environment variables or home-directory tokens now fail safely instead of being treated as relative paths.
  * Invalid or empty paths are rejected before files are created or modified.
  * Merge-tier configuration loading now reports an error when paths cannot be resolved.

* **Documentation**
  * Added guidance explaining configuration path resolution and fail-closed behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->