### PR TITLE
fix: consolidate path safety and cold-start hardening

### DIFF
--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -28,6 +28,24 @@ rules are not visible in the code:
   dispatched on `config_type "dsh"`), plus the matching branch in
   `client_configurator.gd` and `_manual_command.gd`.
 
+### Path resolution fails closed
+
+Every descriptor path is `~`- or `$VAR`-rooted and expands through
+`_path_template.gd`. A token that cannot be resolved — the variable is unset, or
+a dock worker is reading an env snapshot that was never warmed — is **left in
+the string** rather than replaced with an empty string. Substituting the empty
+string is what turned `$USERPROFILE/godot` into `/godot`, a root-relative path
+that `is_absolute_path()` accepts, so every fail-closed guard in this layer
+waved it through and Configure wrote somewhere the user never named.
+
+The invariant that replaces it: **a resolved config path is absolute or it is an
+error**. `McpClient.resolved_config_path_details()` enforces it for every
+descriptor path (both env overrides, `config_path_candidates`, and plain
+`path_template`), `_json_strategy.gd::_load_merge_tiers` enforces it for Pi's
+merge tiers, and `McpAtomicWrite.write` refuses a non-absolute destination as a
+last line of defence. The dock reports the unexpanded path, which still shows
+what failed to resolve.
+
 MCP tools `client_configure`, `client_remove`, and `client_status` expose this to
 AI clients.
 

--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -49,6 +49,18 @@ telemetry toggle, or tool-domain change. Never silently fall back to a bare `uvx
 command for these entries—report ERROR and leave the config untouched when no
 verified tier exists.
 
+Configure pre-builds the pinned `godot-ai==X` uv environment before it
+returns (`prewarm_attach_plan` / `prewarm_attach_launch`), so the first
+client spawn is a warm cache hit. Without it the *client* pays for building
+~67 packages on its own critical path, which flashes a terminal window on
+Windows (#851) and can overrun an MCP client's default 30s connect timeout —
+the tools then appear to vanish until a restart. Only the `uvx` tier is
+warmed; dev-venv and system launches run an already-installed package. The
+warm is best-effort and never downgrades a successful Configure: the config
+file is already written, and a failure only restores the old cold-start cost.
+The dock relabels the button `Installing…` while it runs so a cold build does
+not read as a hang.
+
 Per-strategy command rendering (`CommandShape` docs in `_base.gd`):
 
 - **JSON** — FLAT (`command` string + `args` array, optional

--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -1500,6 +1500,15 @@ static func get_server_launch_mode() -> String:
 	return "unknown"
 
 
+## Wall-clock budget for the Configure-time pre-warm. Far above
+## `McpCliExec.DEFAULT_TIMEOUT_MS` (8s) on purpose: this call is *expected* to
+## take tens of seconds on a cold cache — downloading and unpacking the tool
+## environment is the entire point — so the usual CLI-registry budget would
+## kill it right when it is doing useful work. Still bounded so a wedged uv
+## can't hold the worker thread forever.
+const PREWARM_TIMEOUT_MS := 180000
+
+
 static func find_uvx() -> String:
 	return CliFinder.find(_uvx_cli_names())
 
@@ -1550,6 +1559,87 @@ static func prewarm_server_package_argv(version: String) -> Array[String]:
 	if re.compile("^[A-Za-z0-9.+!-]+$") != OK or re.search(pinned) == null:
 		return []
 	return ["--from", "godot-ai==%s" % pinned, "godot-ai", "--version"]
+
+
+## Blocking sibling of `prewarm_server_package`, for the user-initiated
+## Configure flow (#851, and the reconnect timeouts reported alongside it).
+##
+## Why Configure needs its own pre-warm: `prewarm_server_package` only fires
+## on self-update and on server-lifecycle recovery. Neither covers the case
+## that actually bites — the plugin ADOPTS an already-running server (no uvx
+## spawn, so nothing warms the env), the user clicks Configure, and the first
+## client launch is the one that pays for building the whole tool environment.
+## That build is ~67 packages; a warm launch is ~0.1s. Two symptoms fall out
+## of the cold path: a visible terminal window on Windows (#851), and a spawn
+## that overruns the MCP client's default 30s connect timeout, which the user
+## sees as the Godot AI tools silently disappearing.
+##
+## Why blocking, unlike the fire-and-forget server-side pre-warm: Configure is
+## a deliberate click, so the cost is attributable and the dock can show it as
+## progress rather than as an unexplained pause. Runs on the dock's client
+## action worker thread — never the main thread — and `McpCliExec.run` bounds
+## it, so a wedged uv cannot trap the worker.
+##
+## Best-effort by contract. The config file is already written and correct
+## when this runs; a failure here only means the next client launch pays the
+## cold cost it always used to. Callers must NOT downgrade a successful
+## Configure because of this result.
+##
+## Returns the `McpCliExec.run` dict, plus `skipped` (true when there is no
+## uvx tier to warm or no usable version pin).
+static func prewarm_server_package_blocking(
+	version: String, timeout_ms: int = PREWARM_TIMEOUT_MS
+) -> Dictionary:
+	var args := prewarm_server_package_argv(version)
+	if args.is_empty():
+		return {"skipped": true, "reason": "no version pin"}
+	var uvx := find_uvx()
+	if uvx.is_empty():
+		## dev-venv and system tiers have no per-version cache to warm.
+		return {"skipped": true, "reason": "no uvx"}
+	var result := McpCliExec.run(uvx, args, timeout_ms, true)
+	result["skipped"] = false
+	return result
+
+
+## Decide whether the freshly-written entry has an environment worth warming.
+##
+## Pure and side-effect free, split from the spawn below so tests can pin the
+## decision without building a real uv environment — the same split
+## `prewarm_server_package_argv` uses for the argv (#890).
+##
+## Warms only the `uvx` tier: dev-venv and system launches run an
+## already-installed package and have no per-version environment to build.
+## Resolving the tier here rather than in the dock keeps launcher knowledge in
+## the configurator; the dock stays free of tier branching.
+##
+## Returns `{warm: bool, version: String, reason: String}`.
+static func prewarm_attach_plan(
+	launch_context: Dictionary, discovery_override: Dictionary = {}
+) -> Dictionary:
+	var launch := resolve_attach_launch(launch_context, discovery_override)
+	if not bool(launch.get("ok", false)):
+		return {"warm": false, "version": "", "reason": "launch discovery failed"}
+	var tier := str(launch.get("tier", ""))
+	if tier != "uvx":
+		return {"warm": false, "version": "", "reason": "tier %s has no env to warm" % tier}
+	var version := _pypi_pin_version(str(launch_context.get("plugin_version", "")))
+	if version.is_empty():
+		return {"warm": false, "version": "", "reason": "no version pin"}
+	return {"warm": true, "version": version, "reason": ""}
+
+
+## Warm the environment the freshly-written entry will actually launch.
+## Thin wrapper over `prewarm_attach_plan` + `prewarm_server_package_blocking`.
+static func prewarm_attach_launch(
+	launch_context: Dictionary,
+	timeout_ms: int = PREWARM_TIMEOUT_MS,
+	discovery_override: Dictionary = {},
+) -> Dictionary:
+	var plan := prewarm_attach_plan(launch_context, discovery_override)
+	if not bool(plan.get("warm", false)):
+		return {"skipped": true, "reason": str(plan.get("reason", ""))}
+	return prewarm_server_package_blocking(str(plan.get("version", "")), timeout_ms)
 
 
 static func _uvx_cli_names() -> Array[String]:

--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -1588,7 +1588,9 @@ static func prewarm_server_package_argv(version: String) -> Array[String]:
 ## Returns the `McpCliExec.run` dict, plus `skipped` (true when there is no
 ## uvx tier to warm or no usable version pin).
 static func prewarm_server_package_blocking(
-	version: String, timeout_ms: int = PREWARM_TIMEOUT_MS
+	version: String,
+	timeout_ms: int = PREWARM_TIMEOUT_MS,
+	cancel_check: Callable = Callable(),
 ) -> Dictionary:
 	var args := prewarm_server_package_argv(version)
 	if args.is_empty():
@@ -1597,7 +1599,7 @@ static func prewarm_server_package_blocking(
 	if uvx.is_empty():
 		## dev-venv and system tiers have no per-version cache to warm.
 		return {"skipped": true, "reason": "no uvx"}
-	var result := McpCliExec.run(uvx, args, timeout_ms, true)
+	var result := McpCliExec.run(uvx, args, timeout_ms, true, cancel_check)
 	result["skipped"] = false
 	return result
 
@@ -1635,11 +1637,14 @@ static func prewarm_attach_launch(
 	launch_context: Dictionary,
 	timeout_ms: int = PREWARM_TIMEOUT_MS,
 	discovery_override: Dictionary = {},
+	cancel_check: Callable = Callable(),
 ) -> Dictionary:
 	var plan := prewarm_attach_plan(launch_context, discovery_override)
 	if not bool(plan.get("warm", false)):
 		return {"skipped": true, "reason": str(plan.get("reason", ""))}
-	return prewarm_server_package_blocking(str(plan.get("version", "")), timeout_ms)
+	return prewarm_server_package_blocking(
+		str(plan.get("version", "")), timeout_ms, cancel_check
+	)
 
 
 static func _uvx_cli_names() -> Array[String]:

--- a/plugin/addons/godot_ai/clients/_atomic_write.gd
+++ b/plugin/addons/godot_ai/clients/_atomic_write.gd
@@ -15,6 +15,14 @@ extends RefCounted
 
 
 static func write(path: String, content: String) -> bool:
+	# Last line of defence for the path-resolution layer above. A relative (or
+	# empty) destination resolves against the EDITOR's working directory, not
+	# the caller's: the staging file lands inside the Godot project, the rename
+	# to the mangled destination fails, and the debris stays there. Callers gate
+	# this already (`McpClient.resolved_config_path_details`), but a writer that
+	# cannot tell where it is writing must refuse rather than guess.
+	if not path.is_absolute_path():
+		return false
 	# If the target is a symlink (stow/chezmoi-managed dotfiles), rename-over
 	# would replace the LINK with a regular file, silently detaching the
 	# config from the user's dotfile repo (#534). Resolve the link chain and

--- a/plugin/addons/godot_ai/clients/_atomic_write.gd
+++ b/plugin/addons/godot_ai/clients/_atomic_write.gd
@@ -15,6 +15,17 @@ extends RefCounted
 
 
 static func write(path: String, content: String) -> bool:
+	# An empty path is never a writable target, but it is not inert either:
+	# in the editor Godot's safe-save is on, so opening "" for WRITE runs
+	# mkstemp on the template "" + "-XXXXXX", which succeeds and drops a
+	# randomly-named file with the payload bytes in the process's working
+	# directory (the project root). The close-time rename back to "" then
+	# fails, orphaning it. `write` already reported false for this case, so
+	# refusing up front changes no caller behavior — it only stops the
+	# stray file from being created.
+	if path.is_empty():
+		return false
+
 	# If the target is a symlink (stow/chezmoi-managed dotfiles), rename-over
 	# would replace the LINK with a regular file, silently detaching the
 	# config from the user's dotfile repo (#534). Resolve the link chain and

--- a/plugin/addons/godot_ai/clients/_base.gd
+++ b/plugin/addons/godot_ai/clients/_base.gd
@@ -216,6 +216,7 @@ var config_file_env: String = ""
 ## override to apply. Only declare a mapping when the client's docs guarantee
 ## the env var relocates the exact file we write — a wrong mapping writes the
 ## MCP entry somewhere the client never reads and Configure false-succeeds.
+## Relative values fail closed for the same reason `config_file_env`'s do.
 var config_home_env: String = ""
 ## Path of the config file relative to the env var's directory, e.g.
 ## "config.toml". Joined verbatim — no per-OS variants needed because the env
@@ -285,10 +286,10 @@ func resolved_config_path_details() -> Dictionary:
 	if not str(file_override.get("path", "")).is_empty() or not str(file_override.get("error", "")).is_empty():
 		_clear_config_path_warning()
 		return file_override
-	var override := config_home_override()
-	if not override.is_empty():
+	var home_override := config_home_override_details()
+	if not str(home_override.get("path", "")).is_empty() or not str(home_override.get("error", "")).is_empty():
 		_clear_config_path_warning()
-		return {"path": override, "error": ""}
+		return home_override
 	var candidate_key := McpPathTemplate.platform_key(candidates)
 	if not candidate_key.is_empty():
 		return _resolve_ordered_config_path_candidates(candidates[candidate_key])
@@ -390,18 +391,40 @@ func _clear_config_path_warning() -> void:
 	_config_path_warning_mutex.unlock()
 
 
-## The env-var-relocated config path, or "" when no override applies
-## (no mapping declared, env var unset, or env var empty/whitespace).
-func config_home_override() -> String:
+## The config-home env override plus any fail-closed diagnostic. Empty path and
+## error means no override applies (no mapping declared, env var unset, or env
+## var empty/whitespace).
+func config_home_override_details() -> Dictionary:
 	if config_home_env.is_empty() or config_home_env_subpath.is_empty():
-		return ""
+		return {"path": "", "error": ""}
 	## env_lookup, not OS.get_environment: this runs on dock worker threads,
 	## which must not race the spawn window's setenv/unsetenv (#691).
 	var home := McpPathTemplate.env_lookup(config_home_env).strip_edges()
 	if home.is_empty():
-		return ""
+		return {"path": "", "error": ""}
 	# Expand a leading ~ so `CODEX_HOME=~/codex-alt` behaves like the shell.
-	return McpPathTemplate.expand(home).path_join(config_home_env_subpath)
+	var expanded := McpPathTemplate.expand(home)
+	## Same fail-closed rule as `config_file_override_details`: a relative value
+	## resolves against the EDITOR's working directory, not the client's, so
+	## honouring it silently aims the write at the Godot project directory
+	## instead of the file the client reads. The write layer can only name the
+	## mangled path it was handed; only here do we still know which env var
+	## produced it, so this is where the user-facing explanation belongs.
+	if not expanded.is_absolute_path():
+		return {
+			"path": "",
+			"error": "%s's $%s override must be an absolute config-home directory path; got %s" % [
+				display_name, config_home_env, home,
+			],
+		}
+	return {"path": expanded.path_join(config_home_env_subpath), "error": ""}
+
+
+## The env-var-relocated config path, or "" when no override applies (no
+## mapping declared, env var unset, env var empty/whitespace, or a value that
+## failed closed — `config_home_override_details` carries that diagnostic).
+func config_home_override() -> String:
+	return str(config_home_override_details().get("path", ""))
 
 
 ## True when a CLI client also declares where its config file lives, so it can

--- a/plugin/addons/godot_ai/clients/_base.gd
+++ b/plugin/addons/godot_ai/clients/_base.gd
@@ -363,6 +363,17 @@ func _resolve_ordered_config_path_candidates(templates: Variant) -> Dictionary:
 	var fallback_create_path := ""
 	for index in range(ordered_templates.size()):
 		var template := str(ordered_templates[index])
+		var expanded_template := McpPathTemplate.expand(template)
+		# An empty wildcard group ordinarily means "this package is not
+		# installed", but an unresolved root token produces the same empty
+		# group. Do not silently treat "could not inspect" as "not present" and
+		# fall through to a later writable candidate.
+		if not expanded_template.is_absolute_path():
+			_clear_config_path_warning()
+			return {
+				"path": "",
+				"error": unresolved_config_path_error(display_name, expanded_template),
+			}
 		var group := McpPathTemplate.expand_path_candidates(template)
 		if group.size() > 1:
 			var message := (

--- a/plugin/addons/godot_ai/clients/_base.gd
+++ b/plugin/addons/godot_ai/clients/_base.gd
@@ -270,6 +270,35 @@ func resolved_config_path() -> String:
 ## is empty for ordinary unsupported/missing path mappings to preserve the
 ## long-standing status behavior for clients not installed on this platform.
 func resolved_config_path_details() -> Dictionary:
+	var details := _resolve_config_path_details()
+	var path := str(details.get("path", ""))
+	if path.is_empty() or path.is_absolute_path():
+		return details
+	## Last gate before every strategy's read/write. `McpPathTemplate.expand`
+	## leaves a token it cannot resolve in place, so an unset `$USERPROFILE` (or
+	## a `~` with no HOME) reaches here as a RELATIVE path rather than as the
+	## root-relative `/godot` that sails through `is_absolute_path()`. Acting on
+	## it would resolve against the editor's own working directory and create a
+	## literal `$USERPROFILE` folder in the Godot project. No descriptor
+	## template is intentionally relative — every one is `~`- or `$VAR`-rooted —
+	## so a non-absolute survivor is always a resolution failure. Report it with
+	## the unexpanded path, which still shows what could not be resolved.
+	return {"path": "", "error": unresolved_config_path_error(display_name, path)}
+
+
+## Shared wording for a path template `McpPathTemplate.expand` could not fully
+## resolve. Used by the guard above and by the merge-tier loader in
+## `_json_strategy.gd`, which resolves its own templates and never passes
+## through `resolved_config_path_details`.
+static func unresolved_config_path_error(client_name: String, path: String) -> String:
+	return (
+		"Could not resolve %s's config path: %s did not expand to an absolute "
+		+ "path. Set HOME/USERPROFILE (or the variable the path names) in the "
+		+ "environment the editor was launched from."
+	) % [client_name, path]
+
+
+func _resolve_config_path_details() -> Dictionary:
 	## Reflected reads: after an in-session self-update, an instance created
 	## before the update can answer Nil for vars the update added, and the
 	## typed calls below would each hard-error (Nil -> Dictionary, #850's

--- a/plugin/addons/godot_ai/clients/_base.gd
+++ b/plugin/addons/godot_ai/clients/_base.gd
@@ -394,26 +394,40 @@ func _resolve_ordered_config_path_candidates(templates: Variant) -> Dictionary:
 		# anything currently visible through read-through by naming the first
 		# later existing candidate as a one-time seed source.
 		if template.contains("*"):
-			var seed_path := _first_existing_later_candidate(ordered_templates, index + 1)
+			var seed := _first_existing_later_candidate(ordered_templates, index + 1)
+			if not str(seed.get("error", "")).is_empty():
+				_clear_config_path_warning()
+				return {"path": "", "error": seed["error"]}
 			_clear_config_path_warning()
-			return {"path": path, "error": "", "seed_path": seed_path}
+			return {"path": path, "error": "", "seed_path": seed.get("path", "")}
 		if fallback_create_path.is_empty():
 			fallback_create_path = path
 	_clear_config_path_warning()
 	return {"path": fallback_create_path, "error": ""}
 
 
-func _first_existing_later_candidate(templates: Array, start_index: int) -> String:
+## Find a readable seed for a newly-created authoritative wildcard target.
+## An unresolved later root is an error, not an absent seed: writing without
+## inspecting it could silently discard configuration visible through the
+## package's read-through fallback.
+func _first_existing_later_candidate(templates: Array, start_index: int) -> Dictionary:
 	for index in range(start_index, templates.size()):
-		var group := McpPathTemplate.expand_path_candidates(str(templates[index]))
+		var template := str(templates[index])
+		var expanded_template := McpPathTemplate.expand(template)
+		if not expanded_template.is_absolute_path():
+			return {
+				"path": "",
+				"error": unresolved_config_path_error(display_name, expanded_template),
+			}
+		var group := McpPathTemplate.expand_path_candidates(template)
 		# A seed is optional. Never choose among an ambiguous later wildcard;
 		# the authoritative target was already resolved by the earlier group.
 		if group.size() != 1:
 			continue
 		var path := String(group[0])
 		if FileAccess.file_exists(path):
-			return path
-	return ""
+			return {"path": path, "error": ""}
+	return {"path": "", "error": ""}
 
 
 func _warn_config_path_once(message: String) -> void:

--- a/plugin/addons/godot_ai/clients/_cli_exec.gd
+++ b/plugin/addons/godot_ai/clients/_cli_exec.gd
@@ -30,6 +30,7 @@ extends RefCounted
 ##                 stderr, so callers that only read `stdout` would surface
 ##                 a generic "exit code 1" instead.
 ##   timed_out:    true if we killed the process at the wall-clock budget.
+##   cancelled:    true if the caller requested a cooperative early stop.
 ##   spawn_failed: true if `OS.execute_with_pipe` didn't return a usable PID.
 
 const DEFAULT_TIMEOUT_MS := 8000
@@ -41,11 +42,12 @@ static func run(
 	exe: String,
 	args: Array,
 	timeout_ms: int = DEFAULT_TIMEOUT_MS,
-	capture_stderr: bool = true
+	capture_stderr: bool = true,
+	cancel_check: Callable = Callable(),
 ) -> Dictionary:
 	if exe.is_empty():
 		return _spawn_failed_result()
-	return _run_piped(exe, args, timeout_ms, capture_stderr)
+	return _run_piped(exe, args, timeout_ms, capture_stderr, cancel_check)
 
 
 static func _run_piped(
@@ -53,6 +55,7 @@ static func _run_piped(
 	args: Array,
 	timeout_ms: int,
 	capture_stderr: bool,
+	cancel_check: Callable,
 ) -> Dictionary:
 
 	var spawn_exe := exe
@@ -85,7 +88,8 @@ static func _run_piped(
 
 	var deadline := Time.get_ticks_msec() + maxi(timeout_ms, _POLL_INTERVAL_MS)
 	while OS.is_process_running(pid):
-		if Time.get_ticks_msec() >= deadline:
+		var cancelled := cancel_check.is_valid() and bool(cancel_check.call())
+		if cancelled or Time.get_ticks_msec() >= deadline:
 			## Kill before draining: a pipe read can block while the child is
 			## still alive. Once it exits, drain any buffered partial output.
 			OS.kill(pid)
@@ -104,7 +108,8 @@ static func _run_piped(
 				"stdout": partial_stdout,
 				"stderr": partial_stderr,
 				"output": _join_streams(partial_stdout, partial_stderr),
-				"timed_out": true,
+				"timed_out": not cancelled,
+				"cancelled": cancelled,
 				"spawn_failed": false,
 			}
 		OS.delay_msec(_POLL_INTERVAL_MS)
@@ -119,6 +124,7 @@ static func _run_piped(
 		"stderr": stderr_text,
 		"output": _join_streams(stdout, stderr_text),
 		"timed_out": false,
+		"cancelled": false,
 		"spawn_failed": false,
 	}
 
@@ -130,6 +136,7 @@ static func _spawn_failed_result() -> Dictionary:
 		"stderr": "",
 		"output": "",
 		"timed_out": false,
+		"cancelled": false,
 		"spawn_failed": true,
 	}
 

--- a/plugin/addons/godot_ai/clients/_json_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_json_strategy.gd
@@ -595,6 +595,18 @@ static func _project_override_message(
 static func _load_merge_tiers(client: McpClient) -> Dictionary:
 	var tiers: Array[Dictionary] = []
 	for path in _merge_paths(client):
+		## These templates never pass through `resolved_config_path_details`,
+		## so they need its fail-closed gate here: `McpPathTemplate.expand`
+		## leaves a token it cannot resolve in place, and the relative survivor
+		## would be read — and on Configure, written — against the editor's own
+		## working directory. Fail the whole fold rather than dropping the tier:
+		## a dropped tier reads as "the user has no config there", which is
+		## exactly the wrong thing to conclude when we could not look.
+		if not path.is_absolute_path():
+			return {
+				"ok": false,
+				"error": McpClient.unresolved_config_path_error(client.display_name, path),
+			}
 		var read := _read_file_text(path)
 		if not read.get("ok", false):
 			return {

--- a/plugin/addons/godot_ai/clients/_path_template.gd
+++ b/plugin/addons/godot_ai/clients/_path_template.gd
@@ -24,7 +24,7 @@ static var _env_snapshot := {}
 static var _env_snapshot_mutex := Mutex.new()
 
 ## Every var this layer and its sibling consumers (`_base.gd`
-## `config_file_override_details`, `config_home_override`, `_cli_finder.gd` lookups,
+## `config_file_override_details`, `config_home_override_details`, `_cli_finder.gd` lookups,
 ## `client_configurator.gd` mode/trace reads) can touch off-main.
 ## Descriptor-declared config-file/config-home env names are passed as extras
 ## by the warm callers.

--- a/plugin/addons/godot_ai/clients/_path_template.gd
+++ b/plugin/addons/godot_ai/clients/_path_template.gd
@@ -154,28 +154,64 @@ static func expand_path_candidates(template: String) -> PackedStringArray:
 
 
 ## Substitute env vars and ~ in a single template string.
+##
+## A token that cannot be resolved — the var is unset and no home-derived
+## fallback applies, or a dock worker's env snapshot was never warmed with it —
+## is LEFT IN PLACE rather than replaced with "". Substituting "" is what turns
+## `$USERPROFILE/godot` into `/godot`: a root-relative path that
+## `is_absolute_path()` accepts, so every fail-closed guard downstream waves it
+## through and the caller reads or writes a directory the user never named.
+## `$USERPROFILE` is the easy repro (unset off Windows, and the only one of
+## these vars with no fallback), but `$HOME`/`$XDG_CONFIG_HOME`/`$APPDATA`/
+## `$LOCALAPPDATA` reach the same state whenever `_home()` is empty, which the
+## missing-warm-up degradation above makes reachable on a worker thread.
+##
+## The surviving token keeps the result non-absolute, so those guards catch it,
+## and the unexpanded path they report still shows what failed to resolve.
+## `~` is left alone for the same reason: collapsing `~/godot` to the relative
+## `godot` aims it at the editor's own working directory.
 static func expand(template: String) -> String:
 	if template.is_empty():
 		return ""
 	var out := template
 	if out.begins_with("~/") or out == "~":
 		var home := _home()
-		out = home if out == "~" else home.path_join(out.substr(2))
+		if not home.is_empty():
+			out = home if out == "~" else home.path_join(out.substr(2))
 	# $HOME, $APPDATA, $LOCALAPPDATA, $USERPROFILE, $XDG_CONFIG_HOME
 	for var_name in ["XDG_CONFIG_HOME", "LOCALAPPDATA", "USERPROFILE", "APPDATA", "HOME"]:
 		var token := "$%s" % var_name
-		if out.find(token) >= 0:
-			var value := env_lookup(var_name)
-			if value.is_empty() and var_name == "XDG_CONFIG_HOME":
-				value = _home().path_join(".config")
-			if value.is_empty() and var_name == "APPDATA":
-				value = _home().path_join("AppData/Roaming")
-			if value.is_empty() and var_name == "LOCALAPPDATA":
-				value = _home().path_join("AppData/Local")
-			if value.is_empty() and var_name == "HOME":
-				value = _home()
-			out = out.replace(token, value)
+		if out.find(token) < 0:
+			continue
+		var value := env_lookup(var_name)
+		if value.is_empty():
+			value = _home_fallback(var_name)
+		if value.is_empty():
+			continue
+		out = out.replace(token, value)
 	return out
+
+
+## Home-derived default for a var the environment does not define. Returns ""
+## when home itself is unresolvable so `expand` leaves the token alone: rooting
+## these at an empty home yields a RELATIVE path, not an absent one —
+## `"".path_join(".config")` is `.config`, which reads against the editor's
+## working directory rather than the user's config dir. `USERPROFILE` has no
+## fallback (it is the thing `_home()` itself falls back to).
+static func _home_fallback(var_name: String) -> String:
+	var home := _home()
+	if home.is_empty():
+		return ""
+	match var_name:
+		"XDG_CONFIG_HOME":
+			return home.path_join(".config")
+		"APPDATA":
+			return home.path_join("AppData/Roaming")
+		"LOCALAPPDATA":
+			return home.path_join("AppData/Local")
+		"HOME":
+			return home
+	return ""
 
 
 static func _os_key() -> String:

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -487,6 +487,10 @@ func _abandon_client_action_thread(client_id: String) -> void:
 	if thread != null:
 		_orphaned_client_action_threads.append(thread)
 		if worker_alive:
+			## The worker can cross the base watchdog immediately before it
+			## announces PREWARM. Cancel now so it cannot become an orphan and
+			## then begin a fresh 180s uvx operation outside timeout tracking.
+			_set_client_action_cancel_requested(client_id, true)
 			var owned: Array = _orphaned_client_action_owners.get(client_id, [])
 			owned.append(thread)
 			_orphaned_client_action_owners[client_id] = owned

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -220,6 +220,16 @@ var _client_action_names: Dictionary = {}
 ## Timed-out Configure/Remove workers are abandoned but retained here until
 ## they finish, so GDScript does not destroy a live Thread object.
 static var _orphaned_client_action_threads: Array[Thread] = []
+## Which client each abandoned worker belonged to, so a row whose worker was
+## abandoned but is STILL RUNNING can't start a second one on top of it.
+## The flat array above exists to keep Thread objects alive; it carries no
+## client association, and `_abandon_client_action_thread` erases the row's
+## `_client_action_threads` slot — so the dispatch guard alone would let a
+## re-click spawn an overlapping worker. Two concurrent Configure workers for
+## one client means two uv builds and two writers on the same config file.
+## Static for the same reason as the array: a script reload must not GC a
+## live Thread.
+static var _orphaned_client_action_owners: Dictionary = {}
 
 # Dev-mode only
 var _dev_section: VBoxContainer
@@ -415,6 +425,7 @@ func _drain_client_action_workers() -> void:
 		if thread != null:
 			thread.wait_to_finish()
 	_orphaned_client_action_threads.clear()
+	_orphaned_client_action_owners.clear()
 	_client_action_started_msec.clear()
 	_client_action_names.clear()
 	_client_action_phase_mutex.lock()
@@ -460,13 +471,21 @@ func _abandon_client_action_thread(client_id: String) -> void:
 	var worker_alive := thread != null and thread.is_alive()
 	if thread != null:
 		_orphaned_client_action_threads.append(thread)
+		if worker_alive:
+			var owned: Array = _orphaned_client_action_owners.get(client_id, [])
+			owned.append(thread)
+			_orphaned_client_action_owners[client_id] = owned
 	_client_action_threads.erase(client_id)
 	_client_action_started_msec.erase(client_id)
 	_clear_client_action_phase(client_id)
 	var action := str(_client_action_names.get(client_id, "configure"))
 	_client_action_names.erase(client_id)
 	_client_action_generations[client_id] = int(_client_action_generations.get(client_id, 0)) + 1
-	_finalize_action_buttons(client_id)
+	## Only hand the row back when nothing is still running for it. Re-enabling
+	## while the abandoned worker is mid-build invites a second worker on top
+	## of the first; the prune below re-enables the row once it actually ends.
+	if not worker_alive:
+		_finalize_action_buttons(client_id)
 	print("MCP | client action timed out: client=%s action=%s elapsed_ms=%d worker_alive=%s" % [
 		client_id,
 		action,
@@ -474,11 +493,12 @@ func _abandon_client_action_thread(client_id: String) -> void:
 		str(worker_alive),
 	])
 	var label := "Remove" if action == "remove" else "Configure"
-	_apply_row_status(
-		client_id,
-		Client.Status.ERROR,
-		"%s did not report completion in time; refreshing current status." % label
+	var detail := (
+		"%s is taking longer than expected and is still running; refreshing current status." % label
+		if worker_alive
+		else "%s did not report completion in time; refreshing current status." % label
 	)
+	_apply_row_status(client_id, Client.Status.ERROR, detail)
 	_refresh_clients_summary()
 	if is_inside_tree():
 		_request_client_status_refresh(true)
@@ -494,8 +514,35 @@ func _prune_orphaned_client_action_threads() -> void:
 			thread.wait_to_finish()
 			_orphaned_client_action_threads.remove_at(i)
 			completed_orphan = true
+	_release_finished_orphan_owners()
 	if completed_orphan and is_inside_tree():
 		_request_client_action_completion_refresh()
+
+
+## Hand a row back once its abandoned worker has actually finished. Pairs with
+## `_abandon_client_action_thread`, which deliberately leaves the buttons
+## disabled while the orphan is still running — without this the row would stay
+## disabled forever.
+func _release_finished_orphan_owners() -> void:
+	for client_id in _orphaned_client_action_owners.keys():
+		var owned: Array = _orphaned_client_action_owners[client_id]
+		for i in range(owned.size() - 1, -1, -1):
+			var t: Thread = owned[i]
+			if t == null or not t.is_alive():
+				owned.remove_at(i)
+		if owned.is_empty():
+			_orphaned_client_action_owners.erase(client_id)
+			if not _client_action_threads.has(client_id):
+				_finalize_action_buttons(String(client_id))
+
+
+## True while a previously-abandoned worker for this client is still running.
+static func _has_live_orphan(client_id: String) -> bool:
+	var owned: Array = _orphaned_client_action_owners.get(client_id, [])
+	for t in owned:
+		if t != null and (t as Thread).is_alive():
+			return true
+	return false
 
 
 func _request_client_action_completion_refresh() -> void:
@@ -2088,6 +2135,11 @@ func _dispatch_client_action(client_id: String, action: String) -> void:
 		## SIGABRT in `GDScriptFunction::call`. See `_update_manager`.
 		return
 	if _client_action_threads.has(client_id):
+		return
+	## An abandoned-but-still-running worker owns this row's config file just
+	## as much as a tracked one does. Defensive: `_abandon_client_action_thread`
+	## already leaves the buttons disabled in that state.
+	if _has_live_orphan(client_id):
 		return
 	var row: Dictionary = _client_rows.get(client_id, {})
 	if row.is_empty():

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -230,6 +230,11 @@ static var _orphaned_client_action_threads: Array[Thread] = []
 ## Static for the same reason as the array: a script reload must not GC a
 ## live Thread.
 static var _orphaned_client_action_owners: Dictionary = {}
+## Cooperative stop shared across dock instances because orphan action
+## threads survive script/dock replacement. A new action clears its row's
+## flag before starting; teardown sets every active/orphaned row before join.
+static var _client_action_cancel_mutex := Mutex.new()
+static var _client_action_cancelled_clients: Dictionary = {}
 
 # Dev-mode only
 var _dev_section: VBoxContainer
@@ -404,6 +409,13 @@ func _drain_client_action_workers() -> void:
 	## user-visible failure mode for the install-update bail-out branch
 	## (zip extract failure on the manager clears `_install_in_flight` and
 	## the dock stays alive).
+	## Signal every worker before joining any one of them. Normal Configure
+	## keeps its full cold-install budget, while shutdown/update can stop all
+	## in-flight uvx poll loops concurrently and avoid a 180s editor stall.
+	for client_id in _client_action_threads.keys():
+		_set_client_action_cancel_requested(String(client_id), true)
+	for client_id in _orphaned_client_action_owners.keys():
+		_set_client_action_cancel_requested(String(client_id), true)
 	for client_id in _client_action_threads.keys():
 		var t: Thread = _client_action_threads[client_id]
 		if t != null:
@@ -432,6 +444,9 @@ func _drain_client_action_workers() -> void:
 	_client_action_phases.clear()
 	_client_action_phase_mutex.unlock()
 	_client_action_phase_shown.clear()
+	_client_action_cancel_mutex.lock()
+	_client_action_cancelled_clients.clear()
+	_client_action_cancel_mutex.unlock()
 
 
 func _check_client_action_timeouts() -> void:
@@ -2149,6 +2164,7 @@ func _dispatch_client_action(client_id: String, action: String) -> void:
 	## generation-mismatch or shutdown return can skip the normal finalize,
 	## and a stale phase would suppress the label for this new action.
 	_clear_client_action_phase(client_id)
+	_set_client_action_cancel_requested(client_id, false)
 	_set_row_action_in_flight(client_id, action)
 	## Snapshot `server_url` on main: `http_url()` reads
 	## `EditorInterface.get_editor_settings()`, which is main-thread-only.
@@ -2207,7 +2223,12 @@ func _run_client_action_worker(
 		## cost it always used to, so `result` is deliberately left untouched.
 		if result.get("status") == "ok":
 			_set_client_action_phase(client_id, _PHASE_PREWARM)
-			prewarm = ClientConfigurator.prewarm_attach_launch(launch_context)
+			prewarm = ClientConfigurator.prewarm_attach_launch(
+				launch_context,
+				ClientConfigurator.PREWARM_TIMEOUT_MS,
+				{},
+				Callable(self, "_is_client_action_cancel_requested").bind(client_id),
+			)
 	return {
 		"client_id": client_id,
 		"action": action,
@@ -2306,6 +2327,23 @@ var _client_action_phases: Dictionary = {}
 ## Rows whose button text already reflects their phase, so the per-frame poll
 ## rewrites the label once instead of on every frame.
 var _client_action_phase_shown: Dictionary = {}
+
+
+## Thread-safe cancellation state read by McpCliExec's 50ms poll loop.
+func _set_client_action_cancel_requested(client_id: String, requested: bool) -> void:
+	_client_action_cancel_mutex.lock()
+	if requested:
+		_client_action_cancelled_clients[client_id] = true
+	else:
+		_client_action_cancelled_clients.erase(client_id)
+	_client_action_cancel_mutex.unlock()
+
+
+func _is_client_action_cancel_requested(client_id: String) -> bool:
+	_client_action_cancel_mutex.lock()
+	var requested := bool(_client_action_cancelled_clients.get(client_id, false))
+	_client_action_cancel_mutex.unlock()
+	return requested
 
 
 func _set_client_action_phase(client_id: String, phase: String) -> void:

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -401,6 +401,7 @@ func _drain_client_action_workers() -> void:
 		_client_action_generations[client_id] = int(_client_action_generations.get(client_id, 0)) + 1
 		_client_action_started_msec.erase(client_id)
 		_client_action_names.erase(client_id)
+		_clear_client_action_phase(String(client_id))
 		_finalize_action_buttons(String(client_id))
 		var row: Dictionary = _client_rows.get(String(client_id), {})
 		if not row.is_empty():
@@ -416,6 +417,10 @@ func _drain_client_action_workers() -> void:
 	_orphaned_client_action_threads.clear()
 	_client_action_started_msec.clear()
 	_client_action_names.clear()
+	_client_action_phase_mutex.lock()
+	_client_action_phases.clear()
+	_client_action_phase_mutex.unlock()
+	_client_action_phase_shown.clear()
 
 
 func _check_client_action_timeouts() -> void:
@@ -424,8 +429,27 @@ func _check_client_action_timeouts() -> void:
 		if not _client_action_started_msec.has(client_id):
 			continue
 		var started := int(_client_action_started_msec.get(client_id, 0))
-		if now - started >= CLIENT_ACTION_TIMEOUT_MSEC:
+		if now - started >= _client_action_budget_msec(String(client_id)):
 			_abandon_client_action_thread(String(client_id))
+
+
+## Watchdog budget for an in-flight client action.
+##
+## The 30s default is sized for a CLI registry call. Once the worker reports it
+## has moved on to building the pinned uv environment, that budget is far too
+## short: a cold build is *expected* to run for tens of seconds, and abandoning
+## it would report a false Configure timeout for exactly the slow cold start the
+## pre-warm exists to absorb — re-enabling the row and discarding the worker's
+## completion while the build is still running and about to succeed.
+##
+## The prewarm phase therefore gets the base budget plus the pre-warm's own
+## ceiling. The action still cannot hang forever: `McpCliExec.run` bounds the
+## build at `PREWARM_TIMEOUT_MS` on its own, so this is a backstop above a
+## backstop rather than the only limit.
+func _client_action_budget_msec(client_id: String) -> int:
+	if _read_client_action_phase(client_id) == _PHASE_PREWARM:
+		return CLIENT_ACTION_TIMEOUT_MSEC + ClientConfigurator.PREWARM_TIMEOUT_MS
+	return CLIENT_ACTION_TIMEOUT_MSEC
 
 
 func _abandon_client_action_thread(client_id: String) -> void:
@@ -438,6 +462,7 @@ func _abandon_client_action_thread(client_id: String) -> void:
 		_orphaned_client_action_threads.append(thread)
 	_client_action_threads.erase(client_id)
 	_client_action_started_msec.erase(client_id)
+	_clear_client_action_phase(client_id)
 	var action := str(_client_action_names.get(client_id, "configure"))
 	_client_action_names.erase(client_id)
 	_client_action_generations[client_id] = int(_client_action_generations.get(client_id, 0)) + 1

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -2068,6 +2068,10 @@ func _dispatch_client_action(client_id: String, action: String) -> void:
 	if row.is_empty():
 		return
 
+	## Drop any phase left behind by a previous action on this row — a
+	## generation-mismatch or shutdown return can skip the normal finalize,
+	## and a stale phase would suppress the label for this new action.
+	_clear_client_action_phase(client_id)
 	_set_row_action_in_flight(client_id, action)
 	## Snapshot `server_url` on main: `http_url()` reads
 	## `EditorInterface.get_editor_settings()`, which is main-thread-only.
@@ -2108,14 +2112,30 @@ func _run_client_action_worker(
 	generation: int,
 ) -> Dictionary:
 	var result: Dictionary
+	var prewarm: Dictionary = {}
 	if action == "remove":
 		result = ClientConfigurator.remove(client_id, server_url, launch_context)
 	else:
 		result = ClientConfigurator.configure(client_id, server_url, launch_context)
+		## #851: the entry we just wrote pins an exact `godot-ai==X`. If uv has
+		## never built that environment, the FIRST client spawn builds it —
+		## ~67 packages — which is what flashes a terminal window on Windows
+		## and what can push a bridge spawn past the MCP client's default 30s
+		## connect timeout, so the tools appear to vanish. Pay that cost here,
+		## on a deliberate click the dock can label, instead of on the client's
+		## critical path.
+		##
+		## Best-effort: the config file is already written and correct. A
+		## failed or timed-out warm only means the next launch pays the cold
+		## cost it always used to, so `result` is deliberately left untouched.
+		if result.get("status") == "ok":
+			_set_client_action_phase(client_id, _PHASE_PREWARM)
+			prewarm = ClientConfigurator.prewarm_attach_launch(launch_context)
 	return {
 		"client_id": client_id,
 		"action": action,
 		"result": result,
+		"prewarm": prewarm,
 		"generation": generation,
 	}
 
@@ -2123,13 +2143,19 @@ func _run_client_action_worker(
 func _poll_completed_client_action_threads() -> void:
 	for client_id in _client_action_threads.keys():
 		var thread: Thread = _client_action_threads[client_id]
-		if thread == null or thread.is_alive():
+		if thread == null:
+			continue
+		if thread.is_alive():
+			_apply_client_action_phase(String(client_id))
 			continue
 		var payload: Variant = thread.wait_to_finish()
 		_client_action_threads[client_id] = null
 		if payload is Dictionary:
 			var data := payload as Dictionary
 			var result: Dictionary = data.get("result", {})
+			_report_prewarm_outcome(
+				String(data.get("client_id", client_id)), data.get("prewarm", {})
+			)
 			_apply_client_action_result(
 				String(data.get("client_id", client_id)),
 				String(data.get("action", _client_action_names.get(client_id, "configure"))),
@@ -2161,6 +2187,7 @@ func _apply_client_action_result(client_id: String, action: String, result: Dict
 	_client_action_threads.erase(client_id)
 	_client_action_started_msec.erase(client_id)
 	_client_action_names.erase(client_id)
+	_clear_client_action_phase(client_id)
 	_finalize_action_buttons(client_id)
 	if _server_blocks_client_health():
 		_apply_row_status(client_id, Client.Status.ERROR, _server_blocked_client_message())
@@ -2185,6 +2212,85 @@ func _apply_client_action_result(client_id: String, action: String, result: Dict
 		if action == "configure":
 			_show_manual_command_for(client_id)
 	_refresh_clients_summary()
+
+
+## Phase label for the Configure worker's pre-warm step. The config write
+## itself is fast; building the pinned uv environment is the part that can
+## run for tens of seconds, so it gets its own label rather than sitting
+## under a motionless "Configuring…".
+const _PHASE_PREWARM := "prewarm"
+
+## Worker-written, main-read. `Dictionary` writes are not atomic across
+## threads, so both sides take the mutex — the same discipline `CliFinder`
+## uses for its cache. Held only across the dictionary access, never across
+## the subprocess, so the main thread can never block on uv.
+var _client_action_phase_mutex := Mutex.new()
+var _client_action_phases: Dictionary = {}
+## Rows whose button text already reflects their phase, so the per-frame poll
+## rewrites the label once instead of on every frame.
+var _client_action_phase_shown: Dictionary = {}
+
+
+func _set_client_action_phase(client_id: String, phase: String) -> void:
+	_client_action_phase_mutex.lock()
+	_client_action_phases[client_id] = phase
+	_client_action_phase_mutex.unlock()
+
+
+func _read_client_action_phase(client_id: String) -> String:
+	_client_action_phase_mutex.lock()
+	var phase := String(_client_action_phases.get(client_id, ""))
+	_client_action_phase_mutex.unlock()
+	return phase
+
+
+func _clear_client_action_phase(client_id: String) -> void:
+	_client_action_phase_mutex.lock()
+	_client_action_phases.erase(client_id)
+	_client_action_phase_mutex.unlock()
+	_client_action_phase_shown.erase(client_id)
+
+
+## Per-frame, for a still-running worker: promote the button label when the
+## worker reports it has moved on to warming the package environment. Keeps
+## the dock honest about why Configure is taking a while — otherwise a cold
+## uv build looks like a hang.
+func _apply_client_action_phase(client_id: String) -> void:
+	if _read_client_action_phase(client_id) != _PHASE_PREWARM:
+		return
+	if _client_action_phase_shown.get(client_id, "") == _PHASE_PREWARM:
+		return
+	var row: Dictionary = _client_rows.get(client_id, {})
+	if row.is_empty():
+		return
+	_client_action_phase_shown[client_id] = _PHASE_PREWARM
+	(row["configure_btn"] as Button).text = "Installing…"
+
+
+## One line per Configure so a cold build is attributable after the fact —
+## the dock label is transient, and #851's symptom (a terminal window on
+## Windows) is easiest to correlate against a timestamped log entry. Silent
+## on the skip paths: a dev-venv/system tier having no env to warm is the
+## normal case, not news.
+func _report_prewarm_outcome(client_id: String, prewarm: Variant) -> void:
+	if not (prewarm is Dictionary):
+		return
+	var data := prewarm as Dictionary
+	if data.is_empty() or bool(data.get("skipped", false)):
+		return
+	if bool(data.get("timed_out", false)):
+		print(
+			"MCP | %s: package pre-warm timed out; the first client launch will build the environment"
+			% client_id
+		)
+		return
+	if int(data.get("exit_code", -1)) != 0:
+		print(
+			"MCP | %s: package pre-warm failed (exit %d); the first client launch will build the environment"
+			% [client_id, int(data.get("exit_code", -1))]
+		)
+		return
+	print("MCP | %s: package environment pre-warmed" % client_id)
 
 
 ## In-flight visual: rewrite the verb onto the button the user just

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -1161,11 +1161,12 @@ func _on_server_version_unverified() -> void:
 	_update_process_enabled()
 
 
-## Start a 1s-tick timer that watches the spawned server for up to
-## SERVER_WATCH_MS. If the process dies inside the window we drain the
-## captured pipes and mark the server as crashed so the dock can surface
-## what went wrong. After the window expires we close the pipes so they
-## don't pin file descriptors or fill their kernel buffers. See #146.
+## Start a 1s-tick timer that watches the spawned server through its cold-start
+## window, then for SERVER_WATCH_MS after pid-file publication. If the process
+## dies inside the active window we drain the captured pipes and mark the server
+## as crashed so the dock can surface what went wrong. After the window expires
+## we close the pipes so they don't pin file descriptors or fill their kernel
+## buffers. See #146 and #896.
 func _start_server_watch() -> void:
 	_stop_server_watch()
 	_server_watch_timer = Timer.new()

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -83,10 +83,25 @@ const HANDLERS_DIR := "res://addons/godot_ai/handlers/"
 ## resolver, and characterization tests share one source of truth.
 const SERVER_PID_FILE := PortResolver.SERVER_PID_FILE
 
-## How long we watch the spawned server for early exit. If the process is
-## still alive when this expires, we stop watching. Mid-session crashes
-## after this point get caught by the WebSocket disconnect flow.
+## How long we watch the spawned server for early exit once it has PROVEN it
+## started — i.e. published its pid-file. If the process is still alive when
+## this expires, we stop watching. Mid-session crashes after this point get
+## caught by the WebSocket disconnect flow.
 const SERVER_WATCH_MS := 30 * 1000
+## Watch ceiling for a spawn that has NOT yet published its pid-file (#896).
+##
+## The short window above justifies itself with "mid-session crashes surface
+## via WebSocket disconnect" — which is only true for a server that got far
+## enough to be connected to. A cold `uvx` spawn on a slow link can still be
+## resolving and downloading its ~67-package environment at 30s, having proven
+## nothing; stopping the watch there means a launcher that dies at 45s is never
+## observed, `_diagnose_spawn_fast_exit` never runs (it is only reachable from
+## inside the watch), and the plugin redials forever while the dock shows a
+## bare "Disconnected".
+##
+## Sized to cover that download. Independent of any pre-warm: this window has
+## to hold even when nothing warmed the cache first.
+const SERVER_COLD_START_WATCH_MS := 180 * 1000
 ## Python's import graph (FastMCP + Rich + uvicorn) plus the pid-file write
 ## take a beat on cold starts, especially on Windows. Hold off on declaring
 ## a spawn a crash until this window elapses so the watch loop has time to

--- a/plugin/addons/godot_ai/utils/path_validator.gd
+++ b/plugin/addons/godot_ai/utils/path_validator.gd
@@ -55,6 +55,34 @@ static func _user_root() -> String:
 	return _cached_user_root
 
 
+## True when `path` carries a codepoint that must never reach a filesystem API.
+##
+## Issue #889: the previous guard built its sentinel with `String.chr(0)`, and
+## Godot emits `Unicode parsing error … Unexpected NUL character` while
+## *constructing* that string. Every validated call — including reads that then
+## failed with "File not found" — printed an alarming engine error that had
+## nothing to do with the caller's path. Reading codepoints instead never
+## materialises a NUL String, so the noise is gone.
+##
+## Both codepoints are rejected, for different reasons:
+##   * `0x0000` — a real embedded NUL can truncate a C string, so the path that
+##     is validated is not the path that gets opened. Current Godot cannot
+##     retain one in a String, making this a no-op today; it stays as
+##     defense-in-depth for any build or input path that can.
+##   * `0xFFFD` — what current Godot actually substitutes for a NUL or any other
+##     undecodable input. Once the engine has replaced the byte there is no way
+##     left to tell an attempted NUL from malformed UTF-8 from a literal
+##     replacement character, so the only safe reading at a security boundary is
+##     to refuse all three. A legitimate filename containing U+FFFD is rejected
+##     too; that false positive is deliberate and vanishingly rare.
+static func _contains_invalid_path_codepoint(path: String) -> bool:
+	for i in path.length():
+		var codepoint := path.unicode_at(i)
+		if codepoint == 0x0000 or codepoint == 0xFFFD:
+			return true
+	return false
+
+
 ## Returns "" when the path is a safe `res://`-rooted reference inside the
 ## project root. Returns a human-readable error message otherwise.
 ## Prefer `path_error` over calling this directly — it wraps the message in the
@@ -68,12 +96,8 @@ static func _user_root() -> String:
 static func validate_resource_path(path: String, for_write: bool = false) -> String:
 	if path.is_empty():
 		return "Missing required param: path"
-	## Guard the sentinel: on builds where String.chr(0) yields "" (some engines
-	## normalize embedded nulls away, e.g. 4.3), contains("") would be true and
-	## reject every path. A String that can't hold a null can't smuggle one.
-	var nul := String.chr(0)
-	if not nul.is_empty() and path.contains(nul):
-		return "Path must not contain null bytes"
+	if _contains_invalid_path_codepoint(path):
+		return "Path must not contain null bytes or invalid Unicode"
 	if not path.begins_with("res://"):
 		return "Path must start with res://"
 	var confine_err := _confine_under(path, _res_root(), "res://")
@@ -94,12 +118,8 @@ static func validate_resource_path(path: String, for_write: bool = false) -> Str
 static func validate_loadable_path(path: String) -> String:
 	if path.is_empty():
 		return "Missing required param: path"
-	## Guard the sentinel: on builds where String.chr(0) yields "" (some engines
-	## normalize embedded nulls away, e.g. 4.3), contains("") would be true and
-	## reject every path. A String that can't hold a null can't smuggle one.
-	var nul := String.chr(0)
-	if not nul.is_empty() and path.contains(nul):
-		return "Path must not contain null bytes"
+	if _contains_invalid_path_codepoint(path):
+		return "Path must not contain null bytes or invalid Unicode"
 	if path.begins_with("uid://"):
 		return ""
 	if path.begins_with("user://"):

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -1288,9 +1288,31 @@ func check_server_health() -> void:
 		if elapsed >= int(_host.SPAWN_GRACE_MS) and not McpServerStateScript.is_terminal_diagnosis(_server_state):
 			_diagnose_spawn_fast_exit(_spawn_dead_since_ms)
 		return
-	if elapsed >= int(_host.SERVER_WATCH_MS):
-		## Survived startup — mid-session crashes surface via WebSocket disconnect.
+	if elapsed >= watch_budget_ms(real_pid, int(_host.SERVER_WATCH_MS), int(_host.SERVER_COLD_START_WATCH_MS)):
+		## #896: past the budget we stop watching either way, but a spawn that
+		## never published a pid-file did not "survive startup" — it just never
+		## proved anything. Say so, or the only remaining signal is a silent
+		## reconnect loop.
+		if real_pid <= 0:
+			print(
+				"MCP | server spawn never published a pid-file within %ds; "
+				% int(_host.SERVER_COLD_START_WATCH_MS / 1000)
+				+ "no longer watching it. If the editor stays disconnected, "
+				+ "check the Godot output log for the server's own errors."
+			)
 		_host._stop_server_watch()
+
+
+## How long to keep watching a spawn, given whether it has published its
+## pid-file yet.
+##
+## Pure so tests can drive the decision without a live spawn. `pid_from_file`
+## is the authoritative "the server got far enough to run" signal: the Python
+## server writes it during import, before uvicorn binds. Until it appears, a
+## live launcher PID proves only that `uvx` has not exited — on a cold start
+## that is usually a download still in progress, not a started server.
+static func watch_budget_ms(pid_from_file: int, warm_ms: int, cold_ms: int) -> int:
+	return warm_ms if pid_from_file > 0 else cold_ms
 
 
 ## The spawned server died inside the SPAWN_GRACE_MS window. Decide what

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -45,6 +45,10 @@ var _server_pid: int = -1
 var _server_keep_alive := false
 var _server_spawn_ms: int = 0
 var _server_exit_ms: int = 0
+## Elapsed-since-spawn when the pid-file first appeared. The warm watch window
+## starts here, not at process creation: a cold uvx download may consume most
+## of the cold-start budget before Python starts and publishes the file.
+var _server_pid_published_elapsed_ms: int = 0
 ## Elapsed-since-spawn at the first watch tick that saw the spawn PID dead, or
 ## 0 when it is alive / has been healed onto the real PID. Only meaningful
 ## while a Windows trampoline handoff is being waited out (#797): it preserves
@@ -1066,6 +1070,7 @@ func _start_server_impl(async_gen: int) -> void:
 	if spawned_pid > 0:
 		_server_spawn_ms = Time.get_ticks_msec()
 		_server_exit_ms = 0
+		_server_pid_published_elapsed_ms = 0
 		_spawn_dead_since_ms = 0
 		_server_keep_alive = keep_alive_env_set
 		_host._server_started_this_session = true
@@ -1248,7 +1253,8 @@ static func format_spawn_exit_forensics(facts: Dictionary) -> String:
 	]
 
 
-## Watch-loop callback (1 Hz, capped by SERVER_WATCH_MS).
+## Watch-loop callback (1 Hz, cold-start budget until pid-file publication,
+## then the warm budget from the publication tick).
 ## `--pid-file` is the source of truth on Windows / uvx where the
 ## launcher PID dies quickly after spawning the real interpreter.
 func check_server_health() -> void:
@@ -1257,6 +1263,8 @@ func check_server_health() -> void:
 		return
 	var elapsed := Time.get_ticks_msec() - int(_server_spawn_ms)
 	var real_pid := PortResolver.read_pid_file()
+	if real_pid > 0 and _server_pid_published_elapsed_ms == 0:
+		_server_pid_published_elapsed_ms = elapsed
 	var spawn_pid := int(_server_pid)
 	if real_pid > 0 and real_pid != spawn_pid and PortResolver.pid_alive(real_pid):
 		_spawn_dead_since_ms = 0
@@ -1288,7 +1296,12 @@ func check_server_health() -> void:
 		if elapsed >= int(_host.SPAWN_GRACE_MS) and not McpServerStateScript.is_terminal_diagnosis(_server_state):
 			_diagnose_spawn_fast_exit(_spawn_dead_since_ms)
 		return
-	if elapsed >= watch_budget_ms(real_pid, int(_host.SERVER_WATCH_MS), int(_host.SERVER_COLD_START_WATCH_MS)):
+	var watch_elapsed := watch_window_elapsed_ms(
+		elapsed, real_pid, _server_pid_published_elapsed_ms
+	)
+	if watch_elapsed >= watch_budget_ms(
+		real_pid, int(_host.SERVER_WATCH_MS), int(_host.SERVER_COLD_START_WATCH_MS)
+	):
 		## #896: past the budget we stop watching either way, but a spawn that
 		## never published a pid-file did not "survive startup" — it just never
 		## proved anything. Say so, or the only remaining signal is a silent
@@ -1313,6 +1326,18 @@ func check_server_health() -> void:
 ## that is usually a download still in progress, not a started server.
 static func watch_budget_ms(pid_from_file: int, warm_ms: int, cold_ms: int) -> int:
 	return warm_ms if pid_from_file > 0 else cold_ms
+
+
+## Elapsed time in the currently-active watch window. Before startup proof,
+## the window begins at process creation. Once the pid-file appears, begin a
+## fresh warm watch window so a 45-second download still gets 30 seconds of
+## early-exit coverage after Python starts.
+static func watch_window_elapsed_ms(
+	spawn_elapsed_ms: int, pid_from_file: int, pid_published_elapsed_ms: int
+) -> int:
+	if pid_from_file <= 0 or pid_published_elapsed_ms <= 0:
+		return spawn_elapsed_ms
+	return maxi(0, spawn_elapsed_ms - pid_published_elapsed_ms)
 
 
 ## The spawned server died inside the SPAWN_GRACE_MS window. Decide what
@@ -1502,6 +1527,7 @@ func respawn_with_refresh() -> void:
 	if spawn_pid > 0:
 		_server_spawn_ms = Time.get_ticks_msec()
 		_server_exit_ms = 0
+		_server_pid_published_elapsed_ms = 0
 		_spawn_dead_since_ms = 0
 		_server_keep_alive = keep_alive_env_set
 		var current_version := _expected_server_version()
@@ -1806,6 +1832,7 @@ func detach_server(
 	_host._stop_server_watch()
 	var detached_pid := int(_server_pid)
 	_server_pid = -1
+	_server_pid_published_elapsed_ms = 0
 	transition_state(McpServerStateScript.STOPPED)
 	if detached_pid > 0:
 		print("MCP | %s (PID %d)" % [log_reason, detached_pid])
@@ -1858,6 +1885,7 @@ func stop_server() -> void:
 		print("MCP | stopped server (PID %s)" % str(killed))
 	_server_pid = -1
 	_server_keep_alive = false
+	_server_pid_published_elapsed_ms = 0
 	_host._wait_for_port_free(port, 2.0)
 	## Preserve record/pid-file when port is still held — the drift
 	## branch on the next start_server retries the kill (#159 follow-up).
@@ -1992,6 +2020,7 @@ func recover_incompatible_server() -> bool:
 	_can_recover_incompatible = false
 	_host._server_started_this_session = false
 	_server_pid = -1
+	_server_pid_published_elapsed_ms = 0
 	## Await the respawn walk: the plugin gates its connection unblock on
 	## the post-walk state (SPAWNING/READY), so returning true while the
 	## walk is still suspended would leave the connection blocked forever

--- a/plugin/addons/godot_ai/utils/update_manager.gd
+++ b/plugin/addons/godot_ai/utils/update_manager.gd
@@ -217,6 +217,23 @@ static func _manual_update_label(version: String) -> String:
 		+ "Upgrade to Godot 4.5+ to keep receiving updates."
 	)
 
+
+## PID of the detached package pre-warm started alongside the zip download,
+## or <= 0 when none is running (no uvx tier, unusable version pin, or it has
+## already been waited out). See `_wait_for_prewarm_before_install`.
+var _prewarm_pid := -1
+## When the install first found the pre-warm still running, so the wait below
+## is bounded from the first check rather than re-armed on every poll.
+var _prewarm_wait_started_ms := 0
+## Ceiling on how long install will wait for the pre-warm. Matches the budget
+## the Configure-time pre-warm allows for the same download.
+const PREWARM_WAIT_BUDGET_MS := 180 * 1000
+## Poll interval while waiting. Deliberately not sub-second: `pid_alive` shells
+## out to `tasklist` on Windows via a blocking `OS.execute` on the main thread,
+## so a tight poll would make the editor sluggish for the whole wait.
+const PREWARM_POLL_SECONDS := 2.0
+
+
 ## Driven by the dock's Update button. On Godot < 4.5 (see _can_self_update)
 ## the in-editor install is disabled so users cannot install an incompatible
 ## latest release. With no resolved download URL, falls back to opening the
@@ -294,22 +311,6 @@ func start_install() -> void:
 ## deferred initial refresh) — true while plugin scripts are being
 ## overwritten. A worker mid-`GDScriptFunction::call` into a half-
 ## overwritten script SIGABRTs the editor.
-## PID of the detached package pre-warm started alongside the zip download,
-## or <= 0 when none is running (no uvx tier, unusable version pin, or it has
-## already been waited out). See `_wait_for_prewarm_before_install`.
-var _prewarm_pid := -1
-## When the install first found the pre-warm still running, so the wait below
-## is bounded from the first check rather than re-armed on every poll.
-var _prewarm_wait_started_ms := 0
-## Ceiling on how long install will wait for the pre-warm. Matches the budget
-## the Configure-time pre-warm allows for the same download.
-const PREWARM_WAIT_BUDGET_MS := 180 * 1000
-## Poll interval while waiting. Deliberately not sub-second: `pid_alive` shells
-## out to `tasklist` on Windows via a blocking `OS.execute` on the main thread,
-## so a tight poll would make the editor sluggish for the whole wait.
-const PREWARM_POLL_SECONDS := 2.0
-
-
 func is_install_in_flight() -> bool:
 	return _install_in_flight
 

--- a/plugin/addons/godot_ai/utils/update_manager.gd
+++ b/plugin/addons/godot_ai/utils/update_manager.gd
@@ -33,6 +33,7 @@ const RELEASES_PAGE := "https://github.com/hi-godot/godot-ai/releases/latest"
 const UPDATE_TEMP_DIR := "user://godot_ai_update/"
 const UPDATE_TEMP_ZIP := "user://godot_ai_update/update.zip"
 const ClientConfigurator := preload("res://addons/godot_ai/client_configurator.gd")
+const PortResolver := preload("res://addons/godot_ai/utils/port_resolver.gd")
 
 ## RSA-4096 public key for release-signature verification (#687). The paired
 ## private key exists only in the GitHub Actions secret RELEASE_SIGNING_KEY_PEM
@@ -262,7 +263,8 @@ func start_install() -> void:
 	## almost always cached in the CliFinder by now (the dock's setup probe);
 	## a cold lookup is the same bounded main-thread cost as
 	## `_reprobe_uv_if_negative`, on the same rare click-driven path.
-	ClientConfigurator.prewarm_server_package(_latest_remote_version)
+	_prewarm_pid = ClientConfigurator.prewarm_server_package(_latest_remote_version)
+	_prewarm_wait_started_ms = 0
 
 	if _download_request != null:
 		_download_request.queue_free()
@@ -292,6 +294,22 @@ func start_install() -> void:
 ## deferred initial refresh) — true while plugin scripts are being
 ## overwritten. A worker mid-`GDScriptFunction::call` into a half-
 ## overwritten script SIGABRTs the editor.
+## PID of the detached package pre-warm started alongside the zip download,
+## or <= 0 when none is running (no uvx tier, unusable version pin, or it has
+## already been waited out). See `_wait_for_prewarm_before_install`.
+var _prewarm_pid := -1
+## When the install first found the pre-warm still running, so the wait below
+## is bounded from the first check rather than re-armed on every poll.
+var _prewarm_wait_started_ms := 0
+## Ceiling on how long install will wait for the pre-warm. Matches the budget
+## the Configure-time pre-warm allows for the same download.
+const PREWARM_WAIT_BUDGET_MS := 180 * 1000
+## Poll interval while waiting. Deliberately not sub-second: `pid_alive` shells
+## out to `tasklist` on Windows via a blocking `OS.execute` on the main thread,
+## so a tight poll would make the editor sluggish for the whole wait.
+const PREWARM_POLL_SECONDS := 2.0
+
+
 func is_install_in_flight() -> bool:
 	return _install_in_flight
 
@@ -724,6 +742,40 @@ static func _parse_sha256_digest(text: String) -> String:
 
 # ---- Install orchestration ---------------------------------------------
 
+## True when install may proceed now. False means "come back later" — this
+## call has already scheduled the retry.
+##
+## Deliberately placed AFTER the symlink check in `_install_zip` so a dev
+## checkout (which never installs) is never delayed by it.
+func _wait_for_prewarm_before_install() -> bool:
+	if _prewarm_pid <= 0 or not PortResolver.pid_alive(_prewarm_pid):
+		_prewarm_pid = -1
+		return true
+	if _prewarm_wait_started_ms == 0:
+		_prewarm_wait_started_ms = Time.get_ticks_msec()
+	if Time.get_ticks_msec() - _prewarm_wait_started_ms >= PREWARM_WAIT_BUDGET_MS:
+		## Proceed rather than strand the update: a pre-warm this slow means the
+		## post-update spawn will be cold, which is now survivable — the startup
+		## watch stays alive until the pid-file appears (#896).
+		print(
+			"MCP | self-update: package pre-warm still running after %ds; "
+			% int(PREWARM_WAIT_BUDGET_MS / 1000)
+			+ "installing anyway, the new server may start cold"
+		)
+		_prewarm_pid = -1
+		return true
+	install_state_changed.emit({"button_text": "Preparing packages...", "button_disabled": true})
+	if is_inside_tree():
+		get_tree().create_timer(PREWARM_POLL_SECONDS).timeout.connect(
+			_install_zip, CONNECT_ONE_SHOT
+		)
+		return false
+	## Detached from the tree (dock teardown mid-update): no timer to re-arm on,
+	## so let the install proceed rather than silently dropping it.
+	_prewarm_pid = -1
+	return true
+
+
 func _install_zip() -> void:
 	## Symlinked addons dir means an extract would clobber canonical
 	## `plugin/` source through the link. Symlink detection is independent
@@ -734,6 +786,21 @@ func _install_zip() -> void:
 			"button_disabled": true,
 			"banner_visible": false,
 		})
+		return
+
+	## #896: do not tear the old server down until the NEW version's uv
+	## environment is actually built. `install_downloaded_update` below kills
+	## the server and hands off to the reload runner; the new plugin instance
+	## then spawns a server that, on a cold cache, is still downloading ~67
+	## packages. The pre-warm was started alongside the zip download precisely
+	## to cover this, but nothing waited for it — so on a slow link the update
+	## proceeded while the environment was still being fetched, which is the
+	## window where a failed spawn goes undiagnosed.
+	##
+	## Non-blocking: re-arms itself on a timer rather than stalling the main
+	## thread, and gives up after PREWARM_WAIT_BUDGET_MS so a wedged pre-warm
+	## cannot strand the update. Fully inert when no pre-warm is running.
+	if not _wait_for_prewarm_before_install():
 		return
 
 	## Drain in-flight workers + block new ones BEFORE any disk write.

--- a/test_project/tests/test_cli_exec.gd
+++ b/test_project/tests/test_cli_exec.gd
@@ -113,6 +113,32 @@ func test_run_kills_subprocess_when_budget_expires() -> void:
 		"Timeout kill must return within ~budget+poll, not wait for sleep to finish (elapsed=%dms)" % elapsed_msec)
 
 
+func test_run_cancels_subprocess_without_reporting_timeout() -> void:
+	## Teardown/update cancellation must retain the long normal cold-install
+	## budget while still letting the editor stop an in-flight uvx promptly.
+	if OS.get_name() == "Windows":
+		skip("Windows lacks `sleep` as a standalone exe; cover via Unix")
+		return
+	var sleep_exe := "/bin/sleep"
+	if not FileAccess.file_exists(sleep_exe):
+		sleep_exe = "/usr/bin/sleep"
+	if not FileAccess.file_exists(sleep_exe):
+		skip("No /bin/sleep or /usr/bin/sleep on this host")
+		return
+	var started_msec := Time.get_ticks_msec()
+	var result := McpCliExec.run(
+		sleep_exe, ["5"], 5000, true, func() -> bool: return true
+	)
+	var elapsed_msec := Time.get_ticks_msec() - started_msec
+	assert_true(bool(result.get("cancelled", false)),
+		"a requested stop must be reported as cancellation")
+	assert_false(bool(result.get("timed_out", false)),
+		"cooperative shutdown is not a wall-clock timeout")
+	assert_eq(int(result.get("exit_code", 0)), -1)
+	assert_true(elapsed_msec < 3000,
+		"Cancellation must kill promptly instead of waiting for the child (elapsed=%dms)" % elapsed_msec)
+
+
 func test_run_wraps_cmd_files_through_cmd_exe_on_windows() -> void:
 	## Regression for #251: `McpCliFinder` resolving a Node-style CLI to
 	## its `.cmd` wrapper used to trip CreateProcessW with

--- a/test_project/tests/test_client_attach_config.gd
+++ b/test_project/tests/test_client_attach_config.gd
@@ -1142,6 +1142,111 @@ func test_prewarm_argv_rejects_empty_and_non_pep440_versions() -> void:
 	)
 
 
+## ----- Configure-time pre-warm planning (#851) -----
+#
+# The entry Configure writes pins an exact `godot-ai==X`. If uv has never
+# built that environment, the first CLIENT spawn builds it (~67 packages) —
+# which flashes a terminal window on Windows (#851) and can push the spawn
+# past an MCP client's default 30s connect timeout, so the tools look like
+# they vanished. Configure pays that cost up front instead. These pin the
+# decision only; the plan is pure, so no environment is ever built here.
+
+func _prewarm_overrides(tier: String) -> Dictionary:
+	var overrides := {
+		"venv_python": "",
+		"uvx_path": "",
+		"system_path": "",
+		"consoleless_python": "C:/Python313/pythonw.exe",
+	}
+	match tier:
+		"dev_venv":
+			overrides["venv_python"] = "C:/repo/.venv/Scripts/python.exe"
+			overrides["consoleless_python"] = "C:/repo/.venv/Scripts/pythonw.exe"
+		"uvx":
+			overrides["uvx_path"] = "C:/Tools/uv/uvx.exe"
+		"system":
+			overrides["system_path"] = "C:/Python313/Scripts/godot-ai.exe"
+			overrides["system_version_result"] = {
+				"exit_code": 0, "stdout": "godot-ai 3.0.6", "stderr": "",
+				"output": "godot-ai 3.0.6", "timed_out": false, "spawn_failed": false,
+			}
+	return overrides
+
+
+func test_prewarm_plan_warms_the_uvx_tier_with_the_written_pin() -> void:
+	## The warmed version must be exactly the pin the entry carries, or the
+	## warm builds an environment the client never launches.
+	var plan := McpClientConfigurator.prewarm_attach_plan(
+		_context(), _prewarm_overrides("uvx")
+	)
+	assert_true(bool(plan.get("warm", false)), "the uvx tier must be warmed")
+	assert_eq(plan.get("version"), "3.0.6")
+
+
+func test_prewarm_plan_skips_tiers_with_no_environment_to_build() -> void:
+	## dev-venv and system launches run an already-installed package — there
+	## is no per-version uv environment, so warming would be pure waste.
+	for tier in ["dev_venv", "system"]:
+		var plan := McpClientConfigurator.prewarm_attach_plan(
+			_context(), _prewarm_overrides(tier)
+		)
+		assert_false(bool(plan.get("warm", false)), "%s tier must not be warmed" % tier)
+		assert_contains(str(plan.get("reason", "")), tier)
+
+
+func test_prewarm_plan_skips_when_launch_discovery_fails() -> void:
+	## No launcher resolved means Configure itself failed; there is nothing
+	## to warm and nothing to report.
+	var plan := McpClientConfigurator.prewarm_attach_plan(
+		_context(), _prewarm_overrides("none")
+	)
+	assert_false(bool(plan.get("warm", false)))
+	assert_contains(str(plan.get("reason", "")), "discovery")
+
+
+func test_prewarm_plan_strips_local_version_metadata_from_the_pin() -> void:
+	## The pin written into the entry drops any `+local` segment, so the
+	## warm must drop it identically — otherwise uv resolves a different
+	## requirement and the client still cold-starts.
+	var context := _context()
+	context["plugin_version"] = "3.0.6+dev"
+	var plan := McpClientConfigurator.prewarm_attach_plan(
+		context, _prewarm_overrides("uvx")
+	)
+	assert_true(bool(plan.get("warm", false)))
+	assert_eq(plan.get("version"), "3.0.6", "the +local segment must be stripped")
+
+
+func test_prewarm_launch_skips_without_spawning_when_plan_declines() -> void:
+	## The wrapper must surface the plan's reason and never reach a spawn.
+	var result := McpClientConfigurator.prewarm_attach_launch(
+		_context(), McpClientConfigurator.PREWARM_TIMEOUT_MS, _prewarm_overrides("dev_venv")
+	)
+	assert_true(bool(result.get("skipped", false)), "a declined plan must skip")
+	assert_contains(str(result.get("reason", "")), "dev_venv")
+
+
+func test_prewarm_blocking_skips_when_version_is_unusable() -> void:
+	## Same PEP 440 hardening as the fire-and-forget spawn: an unusable pin
+	## must skip rather than hand uv something it can reinterpret.
+	for bad in ["", "   ", "3.2.*", "3.2.0 --index-url http://evil"]:
+		var result := McpClientConfigurator.prewarm_server_package_blocking(bad, 1000)
+		assert_true(
+			bool(result.get("skipped", false)),
+			"version %s must not reach a spawn" % [bad]
+		)
+
+
+func test_prewarm_timeout_budget_exceeds_the_cli_registry_default() -> void:
+	## A cold build is expected to take tens of seconds. Reusing the 8s
+	## registry budget would kill the warm exactly when it is doing the work
+	## this feature exists to do.
+	assert_true(
+		McpClientConfigurator.PREWARM_TIMEOUT_MS > McpCliExec.DEFAULT_TIMEOUT_MS * 5,
+		"pre-warm needs a budget sized for a cold package build"
+	)
+
+
 func _pi_clone(path: String) -> McpClient:
 	var registered := McpClientRegistry.get_by_id("pi")
 	var client := McpClient.new()

--- a/test_project/tests/test_client_attach_config.gd
+++ b/test_project/tests/test_client_attach_config.gd
@@ -960,6 +960,8 @@ func test_pi_json_strategy_honors_merged_config_tier_precedence() -> void:
 func test_json_merge_transaction_rolls_back_earlier_write_failure() -> void:
 	var first_path := _scratch_dir.path_join("merge_transaction_first.json")
 	_write(first_path, "original")
+	# "" is the unwritable second tier: McpAtomicWrite refuses an empty target
+	# outright, so this fails without touching the filesystem.
 	var result := McpJsonStrategy._write_transaction([
 		{"path": first_path, "text": "changed", "original_text": "original"},
 		{"path": "", "text": "cannot-write", "original_text": ""},

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -980,6 +980,7 @@ func test_path_template_leaves_unresolvable_token_in_place() -> void:
 	# Restore before asserting so a failure can't leak into later tests.
 	if not saved.is_empty():
 		OS.set_environment("USERPROFILE", saved)
+	McpClientConfigurator.warm_env_snapshot()
 
 	assert_eq(resolved, "$USERPROFILE/godot",
 		"an unresolvable token must be left in place, not replaced with an empty string")
@@ -999,6 +1000,7 @@ func test_path_template_still_expands_a_set_userprofile() -> void:
 		OS.unset_environment("USERPROFILE")
 	else:
 		OS.set_environment("USERPROFILE", saved)
+	McpClientConfigurator.warm_env_snapshot()
 
 	assert_eq(resolved, fake.path_join("godot"))
 	assert_true(resolved.is_absolute_path())
@@ -1036,6 +1038,7 @@ func test_path_template_leaves_home_derived_tokens_in_place_without_home() -> vo
 	for var_name in VARS:
 		if not str(saved[var_name]).is_empty():
 			OS.set_environment(var_name, str(saved[var_name]))
+	McpClientConfigurator.warm_env_snapshot()
 
 	for index in range(templates.size()):
 		assert_eq(resolved[index], templates[index],
@@ -1244,6 +1247,7 @@ func test_ordered_config_candidates_fail_closed_for_unresolvable_root() -> void:
 
 	if not saved.is_empty():
 		OS.set_environment("USERPROFILE", saved)
+	McpClientConfigurator.warm_env_snapshot()
 
 	assert_eq(resolution.get("path"), "",
 		"an unresolvable higher-priority candidate must not fall through")
@@ -1253,6 +1257,47 @@ func test_ordered_config_candidates_fail_closed_for_unresolvable_root() -> void:
 	assert_false(FileAccess.file_exists(fallback),
 		"Configure must not write the later candidate when the first cannot be inspected")
 	_remove_if_exists(fallback)
+
+
+func test_authoritative_wildcard_target_fails_closed_for_unresolvable_seed() -> void:
+	## An installed Store package makes its private config authoritative, but
+	## a later read-through root can contain the user's current config. If that
+	## root cannot be resolved, creating an empty private file would mask it.
+	var root := _scratch_dir.path_join("candidate_unresolved_seed")
+	_remove_dir_recursive(root)
+	var package_root := root.path_join("Packages/Claude_store")
+	DirAccess.make_dir_recursive_absolute(package_root)
+	var private_path := package_root.path_join(
+		"LocalCache/Roaming/Claude/claude_desktop_config.json"
+	)
+	var client := _make_test_json_client(private_path)
+	client.display_name = "Unresolved Seed Test"
+	var candidates := [
+		root.path_join("Packages/Claude_*/LocalCache/Roaming/Claude/claude_desktop_config.json"),
+		"$USERPROFILE/godot_ai_unresolved/claude_desktop_config.json",
+	]
+	client.config_path_candidates = {
+		"darwin": candidates,
+		"windows": candidates,
+		"linux": candidates,
+		"unix": candidates,
+	}
+	var saved := OS.get_environment("USERPROFILE")
+	OS.unset_environment("USERPROFILE")
+
+	var resolution := client.resolved_config_path_details()
+	var configured := McpJsonStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+
+	if not saved.is_empty():
+		OS.set_environment("USERPROFILE", saved)
+	McpClientConfigurator.warm_env_snapshot()
+	assert_eq(resolution.get("path"), "",
+		"an unresolvable read-through seed must block the private target write")
+	assert_contains(str(resolution.get("error", "")), "$USERPROFILE")
+	assert_eq(configured.get("status"), "error")
+	assert_false(FileAccess.file_exists(private_path),
+		"Configure must not mask an unknown fallback with a fresh private file")
+	_remove_dir_recursive(root)
 
 
 func test_candidate_detect_path_marks_store_package_installed_without_config() -> void:
@@ -1775,6 +1820,7 @@ func test_unresolvable_path_template_fails_closed() -> void:
 
 	if not saved.is_empty():
 		OS.set_environment("USERPROFILE", saved)
+	McpClientConfigurator.warm_env_snapshot()
 
 	var error := str(details.get("error", ""))
 	assert_eq(details.get("path"), "",
@@ -1815,6 +1861,7 @@ func test_unresolvable_merge_tier_template_fails_closed() -> void:
 
 	if not saved.is_empty():
 		OS.set_environment("USERPROFILE", saved)
+	McpClientConfigurator.warm_env_snapshot()
 
 	assert_eq(status.get("status"), McpClient.Status.ERROR,
 		"an unresolvable tier must not read as NOT_CONFIGURED")

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -967,6 +967,83 @@ func test_path_template_xdg_fallback() -> void:
 	assert_true(resolved.ends_with("/foo"))
 
 
+func test_path_template_leaves_unresolvable_token_in_place() -> void:
+	## Substituting "" for a token that resolves to nothing turned
+	## `$USERPROFILE/godot` into `/godot` — root-relative, which
+	## `is_absolute_path()` ACCEPTS, so every fail-closed guard in this layer
+	## waved it through and the caller read (or wrote) a directory the user
+	## never named. `$USERPROFILE` is the cheap repro: unset off Windows, and
+	## the only one of these vars with no home-derived fallback.
+	var saved := OS.get_environment("USERPROFILE")
+	OS.unset_environment("USERPROFILE")
+	var resolved := McpPathTemplate.expand("$USERPROFILE/godot")
+	# Restore before asserting so a failure can't leak into later tests.
+	if not saved.is_empty():
+		OS.set_environment("USERPROFILE", saved)
+
+	assert_eq(resolved, "$USERPROFILE/godot",
+		"an unresolvable token must be left in place, not replaced with an empty string")
+	assert_false(resolved.is_absolute_path(),
+		"the survivor must stay non-absolute so is_absolute_path() guards catch it: %s" % resolved)
+
+
+func test_path_template_still_expands_a_set_userprofile() -> void:
+	## The counterpart to the test above: leaving tokens alone must not cost us
+	## the substitution itself on Windows, where `$USERPROFILE` is the primary
+	## spelling in every windows-keyed descriptor template.
+	var saved := OS.get_environment("USERPROFILE")
+	var fake := "/tmp/godot-ai-test-userprofile-set"
+	OS.set_environment("USERPROFILE", fake)
+	var resolved := McpPathTemplate.expand("$USERPROFILE/godot")
+	if saved.is_empty():
+		OS.unset_environment("USERPROFILE")
+	else:
+		OS.set_environment("USERPROFILE", saved)
+
+	assert_eq(resolved, fake.path_join("godot"))
+	assert_true(resolved.is_absolute_path())
+
+
+func test_path_template_leaves_home_derived_tokens_in_place_without_home() -> void:
+	## Every remaining token reaches the same state as `$USERPROFILE` once
+	## `_home()` is empty — reachable in production when a dock worker reads a
+	## snapshot that was never warmed (see `env_lookup`), not only when the user
+	## really has no HOME. The home-derived fallbacks must NOT fire either:
+	## `"".path_join(".config")` is the relative `.config`, which reads against
+	## the editor's own working directory instead of the user's config dir.
+	##
+	## `~` is in here too. It was already the caught spelling — it collapsed to
+	## a relative path — but it collapsed to `godot`, which names nothing the
+	## user could act on. Both spellings of the same intent now fail the same
+	## way, and both still say what failed.
+	const VARS := ["HOME", "USERPROFILE", "XDG_CONFIG_HOME", "APPDATA", "LOCALAPPDATA"]
+	var saved := {}
+	for var_name in VARS:
+		saved[var_name] = OS.get_environment(var_name)
+		OS.unset_environment(var_name)
+
+	var templates := PackedStringArray([
+		"~/godot",
+		"$HOME/godot",
+		"$XDG_CONFIG_HOME/godot",
+		"$APPDATA/godot",
+		"$LOCALAPPDATA/godot",
+	])
+	var resolved := PackedStringArray()
+	for template in templates:
+		resolved.append(McpPathTemplate.expand(template))
+	# Restore before asserting: leaving HOME unset would break every later test.
+	for var_name in VARS:
+		if not str(saved[var_name]).is_empty():
+			OS.set_environment(var_name, str(saved[var_name]))
+
+	for index in range(templates.size()):
+		assert_eq(resolved[index], templates[index],
+			"%s must survive expansion unchanged when home is unresolvable" % templates[index])
+		assert_false(resolved[index].is_absolute_path(),
+			"%s must not expand to an absolute path" % templates[index])
+
+
 func test_path_candidate_expansion_supports_directory_wildcard_and_missing_leaf() -> void:
 	var root := _scratch_dir.path_join("candidate_expand")
 	_remove_dir_recursive(root)
@@ -1558,6 +1635,81 @@ func test_config_file_env_relative_path_fails_closed() -> void:
 		OS.set_environment(TEST_CFG_FILE_ENV, prior_env)
 	assert_eq(details.get("path"), "")
 	assert_contains(str(details.get("error", "")), "absolute config-file path")
+
+
+func test_unresolvable_path_template_fails_closed() -> void:
+	## The descriptor's own `path_template` had no gate at all — the two env
+	## overrides above are checked, but the path every other client resolves
+	## through was taken on trust. That was survivable only while `expand`
+	## replaced an unresolvable token with "", which produced the root-relative
+	## `/godot_ai_unresolved/config.toml` and read as absolute. Now the token
+	## survives, so the path is relative and would resolve against the EDITOR's
+	## working directory — Configure would create a literal `$USERPROFILE`
+	## folder in the Godot project. Fail closed, and say which variable failed.
+	var relative_root := "$USERPROFILE/godot_ai_unresolved"
+	var client := _make_test_toml_client(relative_root.path_join("config.toml"))
+	client.display_name = "Unresolved Template Test"
+	var leak_dir := ProjectSettings.globalize_path("res://").path_join("$USERPROFILE")
+	var saved := OS.get_environment("USERPROFILE")
+	OS.unset_environment("USERPROFILE")
+
+	var details := client.resolved_config_path_details()
+	var path := client.resolved_config_path()
+	var configured := McpTomlStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+	var status := McpTomlStrategy.check_status(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+
+	if not saved.is_empty():
+		OS.set_environment("USERPROFILE", saved)
+
+	var error := str(details.get("error", ""))
+	assert_eq(details.get("path"), "",
+		"an unresolved template must not be handed to the write layer")
+	assert_eq(path, "", "the plain accessor must fail closed too")
+	assert_contains(error, "$USERPROFILE",
+		"the error must name the variable that failed to resolve: %s" % error)
+	assert_contains(error, client.display_name,
+		"the error must name the client whose path failed: %s" % error)
+	assert_eq(configured.get("status"), "error")
+	assert_eq(configured.get("message"), error,
+		"Configure must surface the resolution failure, not a generic write error")
+	assert_eq(status, McpClient.Status.ERROR,
+		"the dock row must read ERROR, not a silently-unconfigured grey")
+	assert_false(DirAccess.dir_exists_absolute(leak_dir),
+		"an unresolved template must never create a token-named directory in the project")
+
+
+func test_unresolvable_merge_tier_template_fails_closed() -> void:
+	## Pi-style merge tiers resolve their own templates and never pass through
+	## `resolved_config_path_details`, so they need the same gate. Failing the
+	## whole fold — rather than dropping the tier — is the point: a dropped
+	## tier reads as "the user has no config there", which is exactly the wrong
+	## conclusion to draw from a path we could not resolve well enough to look
+	## at. Pi's real windows tiers are `$USERPROFILE`-rooted.
+	var readable_tier := _scratch_dir.path_join("merge_unresolved/mcp.json")
+	_remove_if_exists(readable_tier)
+	_write_text(readable_tier, JSON.stringify({"mcpServers": {}}))
+	var client := _make_merged_json_client(PackedStringArray([
+		"$USERPROFILE/godot_ai_unresolved/mcp.json",
+		readable_tier,
+	]))
+	var saved := OS.get_environment("USERPROFILE")
+	OS.unset_environment("USERPROFILE")
+
+	var status := McpJsonStrategy.check_status_details(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+	var configured := McpJsonStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+
+	if not saved.is_empty():
+		OS.set_environment("USERPROFILE", saved)
+
+	assert_eq(status.get("status"), McpClient.Status.ERROR,
+		"an unresolvable tier must not read as NOT_CONFIGURED")
+	assert_contains(str(status.get("error_msg", "")), "$USERPROFILE",
+		"the status error must name the variable that failed: %s" % status.get("error_msg", ""))
+	assert_eq(configured.get("status"), "error")
+	assert_contains(str(configured.get("message", "")), "$USERPROFILE")
+	assert_eq(_read_text(readable_tier), JSON.stringify({"mcpServers": {}}),
+		"the resolvable tier must be left untouched — the fold fails as a whole")
+	_remove_if_exists(readable_tier)
 
 
 func test_codex_declares_codex_home_override() -> void:
@@ -3046,6 +3198,24 @@ func test_atomic_write_leaves_no_stale_tmp_after_failed_write() -> void:
 	)
 	var leftovers := _leftover_tmp_files("tmp_fail_dir.txt.tmp")
 	assert_eq(leftovers.size(), 0, "no .tmp staging file may linger after a failed write: %s" % str(leftovers))
+
+
+func test_atomic_write_refuses_a_non_absolute_destination() -> void:
+	## A relative destination resolves against the EDITOR's working directory,
+	## so the staging file is created inside the Godot project and left there
+	## when the rename to the mangled destination fails. The empty path is the
+	## live repro: `_write_transaction`'s own failure test passes `""`, and each
+	## run of it used to drop an mkstemp-named file into `test_project/`.
+	var project_root := ProjectSettings.globalize_path("res://")
+	var before := _project_root_entries(project_root)
+
+	assert_false(McpAtomicWrite.write("", "cannot-write"),
+		"an empty destination must be refused, not staged relative to the editor")
+	assert_false(McpAtomicWrite.write("relative/config.json", "cannot-write"),
+		"a relative destination must be refused")
+
+	assert_eq(_project_root_entries(project_root), before,
+		"a refused write must leave nothing behind in the project directory")
 
 
 func test_atomic_write_does_not_use_fixed_tmp_name() -> void:
@@ -4639,6 +4809,18 @@ func _make_test_toml_client(path: String) -> McpClient:
 	c.toml_section_path = PackedStringArray(["mcp_servers", "godot-ai"])
 	c.toml_body_template = PackedStringArray(["url = \"{url}\"", "enabled = true"])
 	return c
+
+
+## Sorted file listing of the project root, used to prove a refused write
+## leaves no debris there. Files only: the editor may touch directories
+## (`.godot/`) for unrelated reasons mid-suite.
+func _project_root_entries(project_root: String) -> PackedStringArray:
+	var dir := DirAccess.open(project_root)
+	if dir == null:
+		return PackedStringArray()
+	var entries := dir.get_files()
+	entries.sort()
+	return entries
 
 
 func _remove_if_exists(path: String) -> void:

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -1560,6 +1560,83 @@ func test_config_file_env_relative_path_fails_closed() -> void:
 	assert_contains(str(details.get("error", "")), "absolute config-file path")
 
 
+func test_config_home_env_relative_path_fails_closed() -> void:
+	## A relative $CODEX_HOME / $CLAUDE_CONFIG_DIR resolves against the EDITOR's
+	## working directory, not the client's, so honouring it aims Configure at
+	## the Godot project directory instead of the file the client reads. Fail
+	## closed with the same variable-naming diagnostic the exact-file override
+	## gives: the write layer's generic "Cannot write to <relative path>" never
+	## says which env var mangled the path, so the user has nothing to fix.
+	var default_path := _scratch_dir.path_join("home_env_default_untouched.toml")
+	_remove_if_exists(default_path)
+	var client := _make_env_override_toml_client(default_path)
+	var relative_home := "godot_ai_relative_cfg_home"
+	var leak_dir := ProjectSettings.globalize_path("res://").path_join(relative_home)
+	var project_leak := leak_dir.path_join("config.toml")
+	_remove_if_exists(project_leak)
+	DirAccess.remove_absolute(leak_dir)
+	var prior_env := OS.get_environment(TEST_CFG_HOME_ENV)
+	OS.set_environment(TEST_CFG_HOME_ENV, relative_home)
+
+	var details := client.resolved_config_path_details()
+	var override := client.config_home_override()
+	var configured := McpTomlStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+	var status := McpTomlStrategy.check_status(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+
+	if prior_env.is_empty():
+		OS.unset_environment(TEST_CFG_HOME_ENV)
+	else:
+		OS.set_environment(TEST_CFG_HOME_ENV, prior_env)
+
+	var error := str(details.get("error", ""))
+	assert_eq(override, "", "a relative config-home value must not resolve to a path")
+	assert_eq(details.get("path"), "",
+		"a failed-closed override must not fall back to path_template")
+	assert_contains(error, "$%s" % TEST_CFG_HOME_ENV,
+		"the error must name the env var that produced the path: %s" % error)
+	assert_contains(error, "absolute",
+		"the error must say the value has to be absolute: %s" % error)
+	assert_contains(error, relative_home,
+		"the error must echo the offending value: %s" % error)
+	assert_eq(configured.get("status"), "error")
+	assert_eq(configured.get("message"), error,
+		"Configure must surface the env-var explanation, not a generic write failure")
+	assert_eq(status, McpClient.Status.ERROR,
+		"the dock row must read ERROR, not a silently-unconfigured green/grey")
+	assert_false(FileAccess.file_exists(default_path),
+		"a failed-closed override must not fall back to writing the path_template default")
+	assert_false(FileAccess.file_exists(project_leak),
+		"a relative override must never write a config into the Godot project directory")
+	## The atomic write creates the parent before it discovers it cannot open
+	## the file, so the un-gated path leaves a stray directory in the project
+	## even on the "Cannot write to ..." failure. Nothing may be created here.
+	assert_false(DirAccess.dir_exists_absolute(leak_dir),
+		"a relative override must not create a directory in the Godot project either")
+	_remove_if_exists(project_leak)
+	DirAccess.remove_absolute(leak_dir)
+
+
+func test_config_home_env_tilde_value_still_resolves() -> void:
+	## The absolute-path gate must not reject the shell-style value it was
+	## always meant to accept: `CODEX_HOME=~/codex-alt` expands to an absolute
+	## home-relative directory before the check runs.
+	var default_path := _scratch_dir.path_join("home_env_tilde_default.toml")
+	var client := _make_env_override_toml_client(default_path)
+	var prior_env := OS.get_environment(TEST_CFG_HOME_ENV)
+	OS.set_environment(TEST_CFG_HOME_ENV, "~/godot_ai_tilde_cfg_home")
+	var details := client.resolved_config_path_details()
+	if prior_env.is_empty():
+		OS.unset_environment(TEST_CFG_HOME_ENV)
+	else:
+		OS.set_environment(TEST_CFG_HOME_ENV, prior_env)
+
+	assert_eq(details.get("error"), "", "a ~-prefixed config home must not fail closed")
+	var path := str(details.get("path", ""))
+	assert_true(path.is_absolute_path(), "~ must expand to an absolute path: %s" % path)
+	assert_true(path.ends_with("godot_ai_tilde_cfg_home/config.toml"),
+		"the subpath must still be joined onto the expanded home: %s" % path)
+
+
 func test_codex_declares_codex_home_override() -> void:
 	var client := McpClientRegistry.get_by_id("codex")
 	assert_true(client != null, "codex must be registered")

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -3070,14 +3070,24 @@ func test_atomic_write_rejects_empty_path_without_creating_a_file() -> void:
 
 ## Names of the files directly under `res://`, hidden ones included — the
 ## directory a relative or empty write target resolves against in the editor.
+##
+## Asserts rather than returning a quiet [] when the root cannot be read: the
+## caller diffs two of these snapshots, so a silently-empty list on EITHER
+## call makes the diff vacuously empty and the test passes without ever
+## having looked for the debris it exists to catch.
 func _project_root_files() -> Array[String]:
 	var out: Array[String] = []
 	var dir := DirAccess.open("res://")
+	assert_true(dir != null, "project root must be readable to snapshot it")
 	if dir == null:
 		return out
 	dir.include_hidden = true
 	for f in dir.get_files():
 		out.append(f)
+	assert_false(
+		out.is_empty(),
+		"project root snapshot came back empty — enumeration is not trustworthy",
+	)
 	return out
 
 

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -1217,6 +1217,44 @@ func test_ordered_config_candidates_fail_closed_for_ambiguous_store_roots() -> v
 	_remove_dir_recursive(root)
 
 
+func test_ordered_config_candidates_fail_closed_for_unresolvable_root() -> void:
+	## An unresolved candidate expands to an empty wildcard group, which used to
+	## look identical to an absent package and fall through to the later path.
+	## We cannot conclude that the higher-priority config is absent when its
+	## root could not be resolved, so the entire resolution must fail closed.
+	var fallback := _scratch_dir.path_join("candidate_unresolved/fallback.json")
+	_remove_if_exists(fallback)
+	var client := _make_test_json_client(fallback)
+	client.display_name = "Unresolved Candidate Test"
+	var candidates := [
+		"$USERPROFILE/godot_ai_unresolved/config.json",
+		fallback,
+	]
+	client.config_path_candidates = {
+		"darwin": candidates,
+		"windows": candidates,
+		"linux": candidates,
+		"unix": candidates,
+	}
+	var saved := OS.get_environment("USERPROFILE")
+	OS.unset_environment("USERPROFILE")
+
+	var resolution := client.resolved_config_path_details()
+	var configured := McpJsonStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+
+	if not saved.is_empty():
+		OS.set_environment("USERPROFILE", saved)
+
+	assert_eq(resolution.get("path"), "",
+		"an unresolvable higher-priority candidate must not fall through")
+	assert_contains(str(resolution.get("error", "")), "$USERPROFILE")
+	assert_eq(configured.get("status"), "error")
+	assert_eq(configured.get("message"), resolution.get("error"))
+	assert_false(FileAccess.file_exists(fallback),
+		"Configure must not write the later candidate when the first cannot be inspected")
+	_remove_if_exists(fallback)
+
+
 func test_candidate_detect_path_marks_store_package_installed_without_config() -> void:
 	var root := _scratch_dir.path_join("candidate_detect")
 	_remove_dir_recursive(root)

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -3048,6 +3048,39 @@ func test_atomic_write_leaves_no_stale_tmp_after_failed_write() -> void:
 	assert_eq(leftovers.size(), 0, "no .tmp staging file may linger after a failed write: %s" % str(leftovers))
 
 
+func test_atomic_write_rejects_empty_path_without_creating_a_file() -> void:
+	## An empty target used to leak a randomly-named file holding the payload
+	## into the editor's working directory (the project root): with safe-save
+	## on, Godot opens "" for WRITE by running mkstemp on "" + "-XXXXXX", which
+	## succeeds, and only the close-time rename back to "" fails. `write` said
+	## false either way, so the stray was invisible except in `git status`.
+	## Scan the project root because that is where the debris landed.
+	var before := _project_root_files()
+	assert_false(
+		McpAtomicWrite.write("", "cannot-write"),
+		"an empty path must be refused",
+	)
+	var after := _project_root_files()
+	var strays: Array[String] = []
+	for name in after:
+		if not before.has(name):
+			strays.append(name)
+	assert_eq(strays.size(), 0, "an empty-path write must create no file: %s" % str(strays))
+
+
+## Names of the files directly under `res://`, hidden ones included — the
+## directory a relative or empty write target resolves against in the editor.
+func _project_root_files() -> Array[String]:
+	var out: Array[String] = []
+	var dir := DirAccess.open("res://")
+	if dir == null:
+		return out
+	dir.include_hidden = true
+	for f in dir.get_files():
+		out.append(f)
+	return out
+
+
 func test_atomic_write_does_not_use_fixed_tmp_name() -> void:
 	## #534: two editors clicking Configure at once must not interleave bytes
 	## on a shared "<path>.tmp". Prove the fixed name is no longer the staging

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -1777,6 +1777,53 @@ func test_configure_phase_labels_the_package_build_instead_of_hanging_silent() -
 	dock.free()
 
 
+func test_abandoned_worker_blocks_an_overlapping_action_for_that_row() -> void:
+	## The watchdog abandons a worker by erasing the row's `_client_action_threads`
+	## slot — which is also the dispatch guard. So without a per-client orphan
+	## record, a re-click after a timeout starts a SECOND worker while the first
+	## is still running: two uv builds and two writers on the same config file.
+	var dock := McpDockScript.new()
+	McpDockScript._orphaned_client_action_owners.clear()
+
+	assert_false(
+		McpDockScript._has_live_orphan("claude_code"),
+		"a row with no abandoned worker must be dispatchable"
+	)
+
+	## A live orphan holds the row.
+	var live := Thread.new()
+	live.start(func() -> int:
+		## Long enough to still be running when the assertion below reads it.
+		OS.delay_msec(400)
+		return 0
+	)
+	McpDockScript._orphaned_client_action_owners["claude_code"] = [live]
+	assert_true(
+		McpDockScript._has_live_orphan("claude_code"),
+		"a still-running abandoned worker must block a new action on its row"
+	)
+	## A different row is unaffected — the guard is per client, not global.
+	assert_false(
+		McpDockScript._has_live_orphan("codex"),
+		"one row's orphan must not block every other client"
+	)
+
+	live.wait_to_finish()
+	assert_false(
+		McpDockScript._has_live_orphan("claude_code"),
+		"a finished orphan must release the row"
+	)
+
+	## The prune must drop the finished orphan so the row is not held forever.
+	dock._release_finished_orphan_owners()
+	assert_false(
+		McpDockScript._orphaned_client_action_owners.has("claude_code"),
+		"prune must clear the finished orphan record"
+	)
+	McpDockScript._orphaned_client_action_owners.clear()
+	dock.free()
+
+
 func test_prewarm_phase_widens_the_client_action_watchdog() -> void:
 	## Regression (#894 CodeRabbit): the action watchdog abandons a worker after
 	## CLIENT_ACTION_TIMEOUT_MSEC (30s), sized for a CLI registry call. The

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -1777,6 +1777,43 @@ func test_configure_phase_labels_the_package_build_instead_of_hanging_silent() -
 	dock.free()
 
 
+func test_prewarm_phase_widens_the_client_action_watchdog() -> void:
+	## Regression (#894 CodeRabbit): the action watchdog abandons a worker after
+	## CLIENT_ACTION_TIMEOUT_MSEC (30s), sized for a CLI registry call. The
+	## Configure pre-warm can legitimately run far longer while uv builds the
+	## pinned environment — so a cold build would trip the watchdog, re-enable
+	## the row, discard the worker's completion, and report a false Configure
+	## timeout for exactly the slow cold start the pre-warm exists to absorb.
+	var dock := McpDockScript.new()
+
+	assert_eq(
+		dock._client_action_budget_msec("claude_code"),
+		McpDockScript.CLIENT_ACTION_TIMEOUT_MSEC,
+		"a plain config write keeps the short registry budget"
+	)
+
+	dock._set_client_action_phase("claude_code", "prewarm")
+	var warmed := dock._client_action_budget_msec("claude_code")
+	assert_true(
+		warmed >= McpClientConfigurator.PREWARM_TIMEOUT_MS,
+		"the watchdog must outlast the pre-warm's own ceiling, not fire mid-build"
+	)
+	assert_true(
+		warmed > McpDockScript.CLIENT_ACTION_TIMEOUT_MSEC,
+		"the prewarm phase must widen the budget"
+	)
+
+	## A cleared phase must fall back to the short budget, or one slow Configure
+	## would leave the row's next action effectively unwatched.
+	dock._clear_client_action_phase("claude_code")
+	assert_eq(
+		dock._client_action_budget_msec("claude_code"),
+		McpDockScript.CLIENT_ACTION_TIMEOUT_MSEC,
+		"a cleared phase must restore the short budget"
+	)
+	dock.free()
+
+
 func test_configure_phase_is_ignored_for_an_unknown_row() -> void:
 	## A row can be rebuilt (status refresh) while its worker is still in
 	## flight; the poll must not fault on the vanished row.

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -1521,6 +1521,34 @@ func test_drain_cancels_active_and_orphaned_action_workers_before_join() -> void
 		"Drain must clear cancellation state after every worker has joined")
 
 
+func test_watchdog_cancels_live_worker_before_orphaning() -> void:
+	## A worker can cross the 30s base budget just before setting PREWARM. Once
+	## orphaned it is no longer checked by the watchdog, so it must carry a
+	## cancellation request into any uvx poll loop it reaches afterward.
+	var client_id := "cancel-watchdog"
+	_dock._set_client_action_cancel_requested(client_id, false)
+	var worker := Thread.new()
+	var start_err := worker.start(func() -> void:
+		var deadline := Time.get_ticks_msec() + 2000
+		while not _dock._is_client_action_cancel_requested(client_id) \
+			and Time.get_ticks_msec() < deadline:
+			OS.delay_msec(10)
+	)
+	assert_eq(start_err, OK)
+	_dock._client_action_threads[client_id] = worker
+	_dock._client_action_started_msec[client_id] = Time.get_ticks_msec() - 100
+	_dock._client_action_names[client_id] = "configure"
+
+	_dock._abandon_client_action_thread(client_id)
+
+	assert_true(_dock._is_client_action_cancel_requested(client_id),
+		"A live watchdog orphan must be cancelled before it can enter prewarm")
+	worker.wait_to_finish()
+	_dock._prune_orphaned_client_action_threads()
+	_dock._set_client_action_cancel_requested(client_id, false)
+	assert_false(McpDockScript._has_live_orphan(client_id))
+
+
 func test_drain_client_action_workers_restores_in_flight_row_buttons() -> void:
 	## Issue #239 follow-up: `McpUpdateManager._install_zip` has a bail-out
 	## branch (zip extract failure) that clears `_install_in_flight` on the

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -1483,6 +1483,44 @@ func test_drain_client_action_workers_clears_threads_and_bumps_generation() -> v
 		"Drain must bump generation so any late result from the drained worker is rejected as stale")
 
 
+func test_drain_cancels_active_and_orphaned_action_workers_before_join() -> void:
+	## A cold uvx prewarm has a deliberate 180s normal budget. Teardown must
+	## signal all worker rows first, including watchdog-orphaned ones, before
+	## waiting for threads or editor close/update can inherit that full delay.
+	var active_id := "cancel-active"
+	var orphan_id := "cancel-orphan"
+	var active := Thread.new()
+	var orphan := Thread.new()
+	var active_err := active.start(func() -> void:
+		var deadline := Time.get_ticks_msec() + 2000
+		while not _dock._is_client_action_cancel_requested(active_id) \
+			and Time.get_ticks_msec() < deadline:
+			OS.delay_msec(10)
+	)
+	var orphan_err := orphan.start(func() -> void:
+		var deadline := Time.get_ticks_msec() + 2000
+		while not _dock._is_client_action_cancel_requested(orphan_id) \
+			and Time.get_ticks_msec() < deadline:
+			OS.delay_msec(10)
+	)
+	assert_eq(active_err, OK)
+	assert_eq(orphan_err, OK)
+	_dock._client_action_threads[active_id] = active
+	McpDockScript._orphaned_client_action_threads.append(orphan)
+	McpDockScript._orphaned_client_action_owners[orphan_id] = [orphan]
+	var started_msec := Time.get_ticks_msec()
+
+	_dock._drain_client_action_workers()
+
+	var elapsed_msec := Time.get_ticks_msec() - started_msec
+	assert_true(elapsed_msec < 1000,
+		"Drain must cancel both workers before joining (elapsed=%dms)" % elapsed_msec)
+	assert_true(McpDockScript._orphaned_client_action_threads.is_empty())
+	assert_true(McpDockScript._orphaned_client_action_owners.is_empty())
+	assert_false(_dock._is_client_action_cancel_requested(active_id),
+		"Drain must clear cancellation state after every worker has joined")
+
+
 func test_drain_client_action_workers_restores_in_flight_row_buttons() -> void:
 	## Issue #239 follow-up: `McpUpdateManager._install_zip` has a bail-out
 	## branch (zip extract failure) that clears `_install_in_flight` on the

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -1743,6 +1743,51 @@ func test_dock_log_toggle_mutes_buffer_console_echo() -> void:
 	dock.free()
 
 
+func test_configure_phase_labels_the_package_build_instead_of_hanging_silent() -> void:
+	## #851: Configure now pre-builds the pinned uv environment so the first
+	## CLIENT spawn is warm. That build can run for tens of seconds on a cold
+	## cache, and a motionless "Configuring…" reads as a hang — so the worker
+	## reports a phase and the poll promotes the label.
+	var dock := McpDockScript.new()
+	var btn := Button.new()
+	btn.text = "Configuring…"
+	dock._client_rows["claude_code"] = {"configure_btn": btn}
+
+	## Config-write phase: the label must not move yet.
+	dock._apply_client_action_phase("claude_code")
+	assert_eq(btn.text, "Configuring…", "label must not move before the warm starts")
+
+	## Worker reports it reached the package warm.
+	dock._set_client_action_phase("claude_code", "prewarm")
+	dock._apply_client_action_phase("claude_code")
+	assert_eq(btn.text, "Installing…", "a cold package build must be labelled, not silent")
+
+	## The poll runs every frame — the rewrite must happen once, not forever.
+	btn.text = "sentinel"
+	dock._apply_client_action_phase("claude_code")
+	assert_eq(btn.text, "sentinel", "the label must be rewritten once, not every frame")
+
+	## Cleared state must not resurrect the label under the next action.
+	dock._clear_client_action_phase("claude_code")
+	btn.text = "Configuring…"
+	dock._apply_client_action_phase("claude_code")
+	assert_eq(btn.text, "Configuring…", "a cleared phase must not relabel a new action")
+
+	btn.free()
+	dock.free()
+
+
+func test_configure_phase_is_ignored_for_an_unknown_row() -> void:
+	## A row can be rebuilt (status refresh) while its worker is still in
+	## flight; the poll must not fault on the vanished row.
+	var dock := McpDockScript.new()
+	dock._set_client_action_phase("ghost", "prewarm")
+	dock._apply_client_action_phase("ghost")
+	dock._clear_client_action_phase("ghost")
+	assert_true(true, "phase handling must tolerate a missing row")
+	dock.free()
+
+
 ## Save/restore helpers so tests that drive the (now persisted) log toggle
 ## don't clobber the user's actual EditorSetting.
 func _save_mcp_logging_setting() -> Dictionary:

--- a/test_project/tests/test_path_validator.gd
+++ b/test_project/tests/test_path_validator.gd
@@ -98,22 +98,36 @@ func test_well_formed_nested_path_passes_boundary_check() -> void:
 
 # ----- null byte (truncation trap, audit GH-4) -----
 
-func test_rejects_embedded_null_byte() -> void:
+func test_rejects_replacement_character() -> void:
 	## A NUL can truncate a C string, so the path written could differ from the
-	## one validated/reported. Reject any path containing one.
+	## one validated/reported. Godot cannot hold U+0000 in a String — it decodes
+	## an attempted NUL (and any other malformed input) to U+FFFD — so U+FFFD is
+	## what an embedded-null payload actually looks like by the time it reaches
+	## the validator. Reject it.
 	##
-	## Some Godot builds (e.g. 4.3) strip embedded nulls from String, so the
-	## payload can't be constructed there — the validator's check is simply a
-	## harmless no-op on those builds (a String that can't hold a null can't
-	## smuggle one past the guard). Skip rather than assert 4.6-only behavior.
-	var nul := String.chr(0)
-	if nul.is_empty() or not ("res://a" + nul + "b").contains(nul):
-		skip("this Godot build does not retain embedded null bytes in String")
-		return
-	# No "..": the ONLY reason to reject this path is the embedded null.
-	var err := McpPathValidator.validate_resource_path("res://safe" + nul + "name.gd")
-	assert_false(err.is_empty(), "path with an embedded null byte must be rejected")
+	## Deliberately does NOT build the payload with `String.chr(0)`: constructing
+	## that string is itself what made the engine print "Unexpected NUL
+	## character" on every validated path (issue #889).
+	# No "..": the ONLY reason to reject this path is the bad codepoint.
+	var err := McpPathValidator.validate_resource_path("res://safe\uFFFDname.gd")
+	assert_false(err.is_empty(), "path with a replacement character must be rejected")
 	assert_contains(err, "null")
+
+
+func test_loadable_rejects_replacement_character() -> void:
+	## The same guard must cover the ResourceLoader entry point.
+	var err := McpPathValidator.validate_loadable_path("res://safe\uFFFDname.tscn")
+	assert_false(err.is_empty(), "loadable path with a replacement character must be rejected")
+
+
+func test_valid_path_survives_codepoint_scan() -> void:
+	## Regression for #889: ordinary and non-ASCII paths must pass the scan
+	## cleanly. Accented/CJK characters decode fine and must not be mistaken for
+	## the replacement character.
+	assert_eq(McpPathValidator.validate_resource_path("res://scripts/player.gd"), "",
+		"plain ASCII path must validate")
+	assert_eq(McpPathValidator.validate_resource_path("res://scènes/日本語.gd"), "",
+		"valid non-ASCII path must validate")
 
 
 # ----- write blocklist: project-critical files (audit GH-3) -----

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -1521,6 +1521,28 @@ func test_watch_budget_extends_until_the_pid_file_appears() -> void:
 		"an unreadable pid-file must be treated as not-yet-published")
 
 
+func test_warm_watch_window_starts_when_the_pid_file_appears() -> void:
+	## A cold download may already be older than SERVER_WATCH_MS when Python
+	## finally publishes its pid-file. Comparing total spawn age to the warm
+	## budget would stop watching on that same tick, leaving no post-start
+	## coverage at all.
+	assert_eq(
+		McpServerLifecycleManagerScript.watch_window_elapsed_ms(45_000, 4242, 45_000),
+		0,
+		"pid-file publication must begin a fresh warm watch window",
+	)
+	assert_eq(
+		McpServerLifecycleManagerScript.watch_window_elapsed_ms(74_999, 4242, 45_000),
+		29_999,
+		"the warm window must be measured from startup proof, not process creation",
+	)
+	assert_eq(
+		McpServerLifecycleManagerScript.watch_window_elapsed_ms(45_000, 0, 0),
+		45_000,
+		"before publication the cold window still begins at process creation",
+	)
+
+
 func test_cold_start_watch_outlasts_a_package_build() -> void:
 	## The extended window exists to cover a cold environment build, so it must
 	## be at least as long as the budget allowed for that same download

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -1497,6 +1497,47 @@ func test_handoff_not_pending_once_the_pid_file_lands() -> void:
 		"a published pid-file ends the handoff wait")
 
 
+## ----- startup watch budget (#896) -----
+
+func test_watch_budget_extends_until_the_pid_file_appears() -> void:
+	## #896: the short watch justifies itself with "mid-session crashes surface
+	## via WebSocket disconnect" — which is only true once there IS a connection.
+	## A cold uvx spawn can still be downloading its ~67-package environment at
+	## SERVER_WATCH_MS, having proven nothing. Stopping the watch there means a
+	## launcher that dies afterwards is never observed, `_diagnose_spawn_fast_exit`
+	## never runs (it is only reachable from inside the watch), and the plugin
+	## redials forever behind a bare "Disconnected".
+	var warm := int(GodotAiPlugin.SERVER_WATCH_MS)
+	var cold := int(GodotAiPlugin.SERVER_COLD_START_WATCH_MS)
+
+	## pid-file published: the server proved it started, short budget applies.
+	assert_eq(McpServerLifecycleManagerScript.watch_budget_ms(4242, warm, cold), warm,
+		"a published pid-file means the short watch is enough")
+
+	## No pid-file: keep watching, because nothing has been proven yet.
+	assert_eq(McpServerLifecycleManagerScript.watch_budget_ms(0, warm, cold), cold,
+		"without a pid-file the spawn has proven nothing and must stay watched")
+	assert_eq(McpServerLifecycleManagerScript.watch_budget_ms(-1, warm, cold), cold,
+		"an unreadable pid-file must be treated as not-yet-published")
+
+
+func test_cold_start_watch_outlasts_a_package_build() -> void:
+	## The extended window exists to cover a cold environment build, so it must
+	## be at least as long as the budget allowed for that same download
+	## elsewhere — otherwise the watch still ends before the evidence arrives.
+	assert_true(
+		int(GodotAiPlugin.SERVER_COLD_START_WATCH_MS) > int(GodotAiPlugin.SERVER_WATCH_MS),
+		"the cold-start watch must be longer than the warm one"
+	)
+	## Stated in absolute terms rather than against the Configure pre-warm's
+	## constant: that lives on a separate change, and this watch must hold on
+	## its own regardless of whether a pre-warm ran at all.
+	assert_true(
+		int(GodotAiPlugin.SERVER_COLD_START_WATCH_MS) >= 180 * 1000,
+		"the watch must outlast a cold ~67-package environment build"
+	)
+
+
 func test_handoff_expires_so_a_dead_windows_spawn_is_still_diagnosed() -> void:
 	## The wait is bounded: a genuinely dead spawn that never publishes must
 	## still reach the fast-exit diagnosis, inside SERVER_WATCH_MS.

--- a/test_project/tests/test_update_manager.gd
+++ b/test_project/tests/test_update_manager.gd
@@ -1156,3 +1156,49 @@ func test_mode_override_dropdown_wins_over_env() -> void:
 	_restore_mode_override(prior)
 	assert_eq(resolved, "user",
 		"Dropdown override must resolve to 'user' regardless of env")
+
+
+## ----- install gate on the package pre-warm (#896) -----
+
+func test_install_proceeds_immediately_when_no_prewarm_is_running() -> void:
+	## The gate must be completely inert on the normal path — no pre-warm
+	## started (no uvx tier, unusable pin), or one that already finished.
+	var mgr := McpUpdateManager.new()
+	mgr._prewarm_pid = -1
+	assert_true(mgr._wait_for_prewarm_before_install(),
+		"install must not be delayed when no pre-warm is running")
+
+	## A PID that is not alive must also fall straight through.
+	mgr._prewarm_pid = 999999999
+	assert_true(mgr._wait_for_prewarm_before_install(),
+		"a finished pre-warm must not delay install")
+	assert_eq(mgr._prewarm_pid, -1, "a settled pre-warm must clear its pid")
+	mgr.free()
+
+
+func test_install_gate_gives_up_rather_than_stranding_the_update() -> void:
+	## #896: waiting is an optimisation, not a precondition. A wedged pre-warm
+	## must never strand a self-update — past the budget the install proceeds
+	## and the (now longer) startup watch covers a cold spawn.
+	var mgr := McpUpdateManager.new()
+	## OS.get_process_id() is this editor: reliably alive, so the gate sees a
+	## live pre-warm without spawning anything.
+	mgr._prewarm_pid = OS.get_process_id()
+	mgr._prewarm_wait_started_ms = (
+		Time.get_ticks_msec() - McpUpdateManager.PREWARM_WAIT_BUDGET_MS - 1
+	)
+	assert_true(mgr._wait_for_prewarm_before_install(),
+		"an over-budget wait must let the install proceed")
+	assert_eq(mgr._prewarm_pid, -1, "giving up must clear the pid so it is not re-waited")
+	mgr.free()
+
+
+func test_install_gate_budget_covers_a_cold_package_build() -> void:
+	## Too short a budget defeats the point: the install would resume while the
+	## environment is still downloading, which is the case #896 is about.
+	assert_true(McpUpdateManager.PREWARM_WAIT_BUDGET_MS >= 180 * 1000,
+		"the wait must cover a cold ~67-package environment build")
+	## The poll must not be sub-second: pid_alive shells out to tasklist on
+	## Windows from the main thread, so a tight poll stalls the editor.
+	assert_true(McpUpdateManager.PREWARM_POLL_SECONDS >= 1.0,
+		"polling faster than 1s would make the editor sluggish on Windows")

--- a/tests/unit/test_editor_focus_refocus.py
+++ b/tests/unit/test_editor_focus_refocus.py
@@ -298,7 +298,12 @@ def test_install_update_drains_workers_and_blocks_spawning_before_extract() -> N
 
     flag_set_idx = install_block.find("_install_in_flight = true")
     drain_idx = install_block.find("_drain_dock_workers()")
-    handoff_idx = install_block.find("install_downloaded_update")
+    # Match the CALL, not the name. A bare `install_downloaded_update` search
+    # also matches any comment that mentions the function, and a comment above
+    # the drain would then read as a handoff before it — failing this test for
+    # prose rather than for ordering (hit for real when #896 documented the
+    # pre-warm gate directly above the drain).
+    handoff_idx = install_block.find("_plugin.install_downloaded_update(")
     symlink_return_idx = install_block.find("addons_dir_is_symlink()")
 
     assert flag_set_idx > 0, (
@@ -312,6 +317,11 @@ def test_install_update_drains_workers_and_blocks_spawning_before_extract() -> N
         "if not joined first."
     )
     assert symlink_return_idx > 0, "Test fixture broken: could not locate the symlink-safety check."
+    assert handoff_idx > 0, (
+        "Test fixture broken: could not locate the `_plugin.install_downloaded_update(` "
+        "handoff. Without this the ordering assertion below compares against -1 and "
+        "fails for the wrong reason."
+    )
 
     assert symlink_return_idx < flag_set_idx, (
         "Order: symlink-safety check → set _install_in_flight flag. Setting "

--- a/tests/unit/test_self_update_smoke_harness.py
+++ b/tests/unit/test_self_update_smoke_harness.py
@@ -63,6 +63,12 @@ def test_self_update_smoke_harness_prepares_fixture(tmp_path: Path) -> None:
     )
     assert "FileAccess.get_file_as_bytes(src)" in base_manager
     assert "user-update-path.txt" in base_manager
+    # `patch_local_update_banner` replaces `start_install()` by source range.
+    # Keep update-manager state outside that range so train additions are not
+    # silently stripped from the fixture and only discovered as parse errors
+    # in the interactive smoke.
+    assert "var _prewarm_pid := -1" in base_manager
+    assert "const PREWARM_WAIT_BUDGET_MS := 180 * 1000" in base_manager
 
     base_configurator = (project / "addons" / "godot_ai" / "client_configurator.gd").read_text(
         encoding="utf-8"
@@ -114,6 +120,8 @@ def test_self_update_smoke_harness_prepares_fixture(tmp_path: Path) -> None:
     # manager); the dock should not contain it either.
     assert "smoke://local-prestaged" not in vnext_dock
     assert "smoke://local-prestaged" not in vnext_manager
+    assert "var _prewarm_pid := -1" in vnext_manager
+    assert "const PREWARM_WAIT_BUDGET_MS := 180 * 1000" in vnext_manager
     assert 'var _self_update_smoke_trigger: Dictionary = {"armed": true}' in vnext_dock
     assert 'var _self_update_smoke_array_trigger: Array[String] = ["armed"]' in vnext_dock
     assert "MCP | [self-update-smoke vnext _exit_tree]" in vnext_dock


### PR DESCRIPTION
## Summary

Consolidates the related fixes from #893, #894, #895, #897, #898, and #899 in reviewed dependency order. PR #892 is intentionally excluded as unrelated resource/physics work.

The consolidation review also fixes three integration defects found only in the combined train:

- starts a fresh 30-second server watch window when the PID file appears, so a slow uvx download does not consume post-start crash coverage
- keeps prewarm state outside the self-update smoke source-replacement range, preventing the fixture from stripping declarations and producing parse errors
- fails closed when a higher-priority ordered config candidate has an unresolvable root instead of writing a lower-priority fallback

## Validation

- Ruff: passed
- GDScript import validation: passed
- Python: 1,815 passed, 5 skipped
- Live Godot: 2,308/2,324 passed, 0 failed, 16 skipped, 70/70 suites
- In-editor self-update/reload smoke: passed, including managed-server stop/restart, temp cleanup, version alignment, and no new crash report

## Incorporated PRs

- #893
- #894
- #895
- #897
- #898
- #899


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure now pre-warms the pinned server environment, reducing delays when starting the first client.
  * The Configure button displays “Installing…” during preparation.
  * Server startup monitoring allows additional time for cold environment builds.
  * Client operations can stop cleanly during shutdown or cancellation.

* **Bug Fixes**
  * Unresolved or relative configuration paths now fail safely.
  * Invalid path characters are rejected more reliably.
  * Overlapping or abandoned client actions are safely managed.
  * Updates proceed safely when environment preparation is unavailable or delayed.

* **Documentation**
  * Updated the client configuration guide with path-resolution and pre-warming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->