### PR TITLE
fix: close recovery and config permission gaps

### DIFF
--- a/plugin/addons/godot_ai/clients/_atomic_write.gd
+++ b/plugin/addons/godot_ai/clients/_atomic_write.gd
@@ -95,8 +95,18 @@ static func write(path: String, content: String) -> bool:
 	if had_original:
 		DirAccess.remove_absolute(backup_path)
 		if DirAccess.copy_absolute(path, backup_path) == OK:
+			if not _apply_mode(backup_path, target_mode):
+				## The backup contains the same secrets as the live config. Do
+				## not leave that copy behind — or touch the destination — when
+				## it cannot be restricted to the intended mode.
+				DirAccess.remove_absolute(backup_path)
+				DirAccess.remove_absolute(tmp_path)
+				return false
 			backup_made = true
-			_apply_mode(backup_path, target_mode)
+		else:
+			## copy_absolute may leave a partial destination on failure. It
+			## contains config bytes under the process umask, so remove it.
+			DirAccess.remove_absolute(backup_path)
 
 	if DirAccess.rename_absolute(tmp_path, path) == OK:
 		return true
@@ -107,10 +117,13 @@ static func write(path: String, content: String) -> bool:
 	# leaves the user's prior config in place rather than nuking it.
 	if DirAccess.copy_absolute(tmp_path, path) == OK and _written_size_matches(path, content):
 		# copy_absolute creates the destination with the default mode, so
-		# re-apply the preserved/owner-only mode after the copy lands.
-		_apply_mode(path, target_mode)
-		DirAccess.remove_absolute(tmp_path)
-		return true
+		# re-apply the preserved/owner-only mode after the copy lands. A
+		# permission failure is a failed write: fall through to the same
+		# restore/remove path as a partial copy instead of reporting success
+		# with a potentially exposed token-bearing config.
+		if _apply_mode(path, target_mode):
+			DirAccess.remove_absolute(tmp_path)
+			return true
 
 	# Copy didn't land cleanly. Restore the destination to its pre-call state.
 	if backup_made:
@@ -121,8 +134,17 @@ static func write(path: String, content: String) -> bool:
 		# user's prior bytes are still in `.backup` for manual recovery
 		# and the false return value tells the caller the swap didn't
 		# complete.
-		DirAccess.copy_absolute(backup_path, path)
-		_apply_mode(path, target_mode)
+		var restored := (
+			DirAccess.copy_absolute(backup_path, path) == OK
+			and _apply_mode(path, target_mode)
+		)
+		if not restored:
+			## The backup's mode was already verified before the swap. Remove
+			## any partial/default-mode destination, then move that restricted
+			## inode back into place. If even the same-directory rename fails,
+			## the complete prior contents remain in `.backup` for recovery.
+			DirAccess.remove_absolute(path)
+			DirAccess.rename_absolute(backup_path, path)
 	elif not had_original and FileAccess.file_exists(path):
 		# No prior file existed but copy_absolute landed partial bytes at
 		# `path`. Remove them so the failure leaves nothing on disk rather
@@ -214,7 +236,7 @@ static func _apply_mode(path: String, mode: int) -> bool:
 		return true
 	# Surface a real chmod failure (not the Windows no-op) so permission
 	# hardening on a sensitive config doesn't fail completely silently.
-	push_warning("MCP | could not set permissions on %s (error %d)" % [path, err])
+	push_warning("MCP | could not set permissions on %s: %s" % [path, error_string(err)])
 	return false
 
 

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -120,6 +120,14 @@ var _stale_recovery_budget: int = 0
 ## stale handshake verdicts into it so an older continuation cannot kill the
 ## fresh server that another continuation just spawned.
 var _recovery_in_flight: bool = false
+## Generation-scoped capability for the startup walk spawned by
+## `_recover_incompatible_server_impl`. The outer recovery keeps
+## `_recovery_in_flight` armed so handshakes and unrelated recovery calls still
+## coalesce, while this token lets only that exact owned walk spend another
+## bounded stale-recovery round if an attach bridge reclaims the port after the
+## kill. A later walk created by invalidation gets a different generation and
+## cannot inherit the authority.
+var _recovery_owned_startup_generation: int = -1
 
 ## Bounded deadline for the foreign-port adoption-confirmation watcher.
 ## Zero when disarmed.
@@ -1624,9 +1632,14 @@ func _recover_startup_port_occupant(
 	current_version: String,
 	async_gen: int,
 ) -> bool:
-	if _recovery_in_flight:
+	var owns_recovery := not _recovery_in_flight
+	var is_owned_startup := (
+		_recovery_in_flight and async_gen == _recovery_owned_startup_generation
+	)
+	if not owns_recovery and not is_owned_startup:
 		return false
-	_recovery_in_flight = true
+	if owns_recovery:
+		_recovery_in_flight = true
 	## Forward `live` so the strong proof helper reuses our snapshot. The kill
 	## invalidates it; every later consumer re-probes before using live status.
 	var recovered: bool = await recover_strong_port_occupant(port, 3.0, live)
@@ -1639,7 +1652,10 @@ func _recover_startup_port_occupant(
 			% [live_version, port, _stale_recovery_budget]
 		)
 		recovered = await _recover_stale_port_occupant_impl(port, 3.0)
-	_recovery_in_flight = false
+	## A nested recovery-owned startup must leave the outer transaction armed;
+	## only the path that acquired ownership here may release it.
+	if owns_recovery:
+		_recovery_in_flight = false
 	return recovered
 
 
@@ -2091,7 +2107,15 @@ func _recover_incompatible_server_impl(stale_version: String = "") -> bool:
 	## the automatic handshake-mismatch trigger reuses this manager flow and
 	## must only SPEND budget; re-arming inside it would unbound the
 	## kill/respawn loop against a persistent bridge respawner.
+	## Keep the outer transaction armed while the respawn walk runs so stale WS
+	## handshakes and unrelated recovery calls still coalesce. Grant only this
+	## owned startup walk permission to spend a remaining recovery round if the
+	## old attach bridge reclaims the port between the kill and the respawn.
+	var owned_startup_gen := _async_generation
+	_recovery_owned_startup_generation = owned_startup_gen
 	await start_server()
+	if _recovery_owned_startup_generation == owned_startup_gen:
+		_recovery_owned_startup_generation = -1
 	return true
 
 

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -973,6 +973,72 @@ func test_walk_spends_budget_and_weak_kills_stale_occupant_when_authorized() -> 
 		"fixture: the still-held port must stop the walk before a real spawn")
 
 
+func test_recovery_owned_respawn_can_replace_reclaimed_stale_listener() -> void:
+	## The first recovery kill freed the port, but an attach bridge immediately
+	## reclaimed it with the same old backend before the owned respawn walk ran.
+	## The outer transaction must remain armed (so unrelated callers/handshakes
+	## coalesce) while this nested walk spends the second bounded recovery round.
+	## Pre-fix, `_recovery_in_flight` rejected this walk at its first line and
+	## stranded the update at INCOMPATIBLE.
+	var host := _stale_occupant_host()
+	## The reclaimed listener releases after the nested weak-proof kill.
+	host.port_in_use_sequence = [false] as Array[bool]
+	var manager := McpServerLifecycleManagerScript.new(host)
+	manager.authorize_stale_recovery()
+	manager._recovery_in_flight = true
+	manager._recovery_owned_startup_generation = manager._async_generation
+
+	var recovered: bool = await manager._recover_startup_port_occupant(
+		TEST_PORT,
+		host.live_status,
+		"0.0.1",
+		McpClientConfigurator.get_plugin_version(),
+		manager._async_generation,
+	)
+	var killed := host.killed_targets.duplicate()
+	var budget := int(manager.get_status_dict().get("stale_recovery_budget", -1))
+	var outer_still_owns: bool = manager._recovery_in_flight
+	manager._recovery_owned_startup_generation = -1
+	manager._recovery_in_flight = false
+	host.free()
+
+	assert_true(recovered, "the recovery-owned respawn walk must recover the reclaimed port")
+	assert_eq(killed, [13131] as Array[int],
+		"the reclaimed stale listener must receive the second bounded kill")
+	assert_eq(budget, 1, "the nested walk must spend exactly one remaining round")
+	assert_true(outer_still_owns,
+		"the nested walk must not release the outer transaction's coalescing guard")
+
+
+func test_cancelled_walk_cannot_inherit_recovery_owned_startup_authority() -> void:
+	## A concurrent force-restart/invalidation creates a new startup generation.
+	## It must not inherit the narrow authority granted to the outer recovery's
+	## original respawn walk.
+	var host := _stale_occupant_host()
+	var manager := McpServerLifecycleManagerScript.new(host)
+	manager.authorize_stale_recovery()
+	manager._recovery_in_flight = true
+	manager._recovery_owned_startup_generation = manager._async_generation
+	manager._async_generation += 1
+
+	var recovered: bool = await manager._recover_startup_port_occupant(
+		TEST_PORT,
+		host.live_status,
+		"0.0.1",
+		McpClientConfigurator.get_plugin_version(),
+		manager._async_generation,
+	)
+	var killed := host.killed_targets.duplicate()
+	var budget := int(manager.get_status_dict().get("stale_recovery_budget", -1))
+	manager._recovery_owned_startup_generation = -1
+	manager._recovery_in_flight = false
+	host.free()
+
+	assert_false(recovered, "a replacement generation must coalesce, not recover")
+	assert_true(killed.is_empty(), "a replacement generation must not use stale-kill authority")
+	assert_eq(budget, 2, "a rejected replacement walk must not spend recovery budget")
+
+
 func test_walk_stale_budget_ignores_same_version_occupant() -> void:
 	## The budget only ever targets a version DRIFT. A same-version occupant
 	## that fails compatibility another way (here: WS port mismatch) must not

--- a/tests/unit/test_audit_data_loss_safeguards.py
+++ b/tests/unit/test_audit_data_loss_safeguards.py
@@ -279,6 +279,41 @@ def test_atomic_write_uses_copy_then_verify_as_rename_fallback() -> None:
     )
 
 
+def test_atomic_write_copy_paths_fail_closed_on_permission_errors() -> None:
+    """Every successful copy must also prove its intended file mode.
+
+    Configs and their backups can contain access tokens. Treating a copied
+    payload as successful after chmod failed leaves those secrets under the
+    process umask, commonly 0644 on POSIX systems.
+    """
+
+    source = ATOMIC_WRITE_PATH.read_text(encoding="utf-8")
+    write_block = get_func_block(source, "static func write(")
+
+    backup_copy = write_block.index("DirAccess.copy_absolute(path, backup_path) == OK")
+    backup_mode = write_block.index("if not _apply_mode(backup_path, target_mode):", backup_copy)
+    backup_success = write_block.index("backup_made = true", backup_mode)
+    assert backup_copy < backup_mode < backup_success
+
+    backup_failure = write_block.index("DirAccess.remove_absolute(backup_path)", backup_success)
+    assert backup_failure > backup_success
+
+    destination_copy = write_block.index("DirAccess.copy_absolute(tmp_path, path) == OK")
+    destination_mode = write_block.index("if _apply_mode(path, target_mode):", destination_copy)
+    destination_success = write_block.index("return true", destination_mode)
+    assert destination_copy < destination_mode < destination_success
+
+    restore_copy = write_block.index("DirAccess.copy_absolute(backup_path, path) == OK")
+    restore_mode = write_block.index("and _apply_mode(path, target_mode)", restore_copy)
+    assert restore_copy < restore_mode
+
+
+def test_atomic_write_permission_warning_includes_godot_error_text() -> None:
+    source = ATOMIC_WRITE_PATH.read_text(encoding="utf-8")
+    mode_block = get_func_block(source, "static func _apply_mode(")
+    assert "error_string(err)" in mode_block
+
+
 def test_atomic_write_restores_from_backup_when_swap_fails() -> None:
     source = ATOMIC_WRITE_PATH.read_text(encoding="utf-8")
     write_block = get_func_block(source, "static func write(")

--- a/tests/unit/test_audit_data_loss_safeguards.py
+++ b/tests/unit/test_audit_data_loss_safeguards.py
@@ -265,6 +265,8 @@ def test_atomic_write_does_not_remove_target_before_swap() -> None:
 
 
 def test_atomic_write_uses_copy_then_verify_as_rename_fallback() -> None:
+    """A rejected atomic rename must overwrite-copy and verify the new bytes."""
+
     source = ATOMIC_WRITE_PATH.read_text(encoding="utf-8")
     write_block = get_func_block(source, "static func write(")
     assert "DirAccess.copy_absolute(tmp_path, path)" in write_block, (
@@ -322,6 +324,8 @@ def test_atomic_write_permission_warning_includes_godot_error_text() -> None:
 
 
 def test_atomic_write_restores_from_backup_when_swap_fails() -> None:
+    """A failed swap must restore the prior config from its restricted backup."""
+
     source = ATOMIC_WRITE_PATH.read_text(encoding="utf-8")
     write_block = get_func_block(source, "static func write(")
     assert "DirAccess.copy_absolute(path, backup_path)" in write_block, (

--- a/tests/unit/test_audit_data_loss_safeguards.py
+++ b/tests/unit/test_audit_data_loss_safeguards.py
@@ -292,11 +292,16 @@ def test_atomic_write_copy_paths_fail_closed_on_permission_errors() -> None:
 
     backup_copy = write_block.index("DirAccess.copy_absolute(path, backup_path) == OK")
     backup_mode = write_block.index("if not _apply_mode(backup_path, target_mode):", backup_copy)
+    backup_mode_cleanup = write_block.index(
+        "DirAccess.remove_absolute(backup_path)", backup_mode
+    )
     backup_success = write_block.index("backup_made = true", backup_mode)
-    assert backup_copy < backup_mode < backup_success
+    assert backup_copy < backup_mode < backup_mode_cleanup < backup_success
 
-    backup_failure = write_block.index("DirAccess.remove_absolute(backup_path)", backup_success)
-    assert backup_failure > backup_success
+    partial_backup_cleanup = write_block.index(
+        "DirAccess.remove_absolute(backup_path)", backup_success
+    )
+    assert partial_backup_cleanup > backup_success
 
     destination_copy = write_block.index("DirAccess.copy_absolute(tmp_path, path) == OK")
     destination_mode = write_block.index("if _apply_mode(path, target_mode):", destination_copy)
@@ -309,6 +314,8 @@ def test_atomic_write_copy_paths_fail_closed_on_permission_errors() -> None:
 
 
 def test_atomic_write_permission_warning_includes_godot_error_text() -> None:
+    """Permission failures should name Godot's readable error, not only its number."""
+
     source = ATOMIC_WRITE_PATH.read_text(encoding="utf-8")
     mode_block = get_func_block(source, "static func _apply_mode(")
     assert "error_string(err)" in mode_block

--- a/tests/unit/test_self_update_orphan_recovery.py
+++ b/tests/unit/test_self_update_orphan_recovery.py
@@ -52,6 +52,16 @@ def test_recover_incompatible_success_unblocks_existing_connection() -> None:
     assert "_recover_incompatible_server_impl(stale_version)" in lifecycle_recover_block
     assert "start_server()" in lifecycle_recover_impl
 
+    # The outer transaction stays armed to coalesce unrelated recovery, but
+    # grants its own respawn walk a narrow capability to recover an old attach
+    # bridge that reclaims the port after the first kill.
+    assert "_recovery_owned_startup_generation = owned_startup_gen" in lifecycle_recover_impl
+    assert lifecycle_recover_impl.index(
+        "_recovery_owned_startup_generation = owned_startup_gen"
+    ) < (
+        lifecycle_recover_impl.index("await start_server()")
+    ) < lifecycle_recover_impl.index("_recovery_owned_startup_generation = -1")
+
     assert "state != ServerStateScript.SPAWNING" in resume_block
     assert "state != ServerStateScript.READY" in resume_block
     assert "_lifecycle.is_connection_blocked()" in resume_block


### PR DESCRIPTION
## Summary

- allow only the exact recovery-owned startup generation to spend the remaining bounded stale-server recovery round when an attach bridge reclaims the port
- keep unrelated recovery calls and later cancelled/replacement startup generations coalesced behind the active transaction
- fail closed when permissions cannot be applied to copied configs or backups, restoring the verified restricted backup inode when possible
- include Godot's readable error text in permission warnings

This addresses all actionable CodeRabbit feedback left on #901.

## Validation

- full Python suite: 1817 passed, 5 skipped
- focused Python contracts: 31 passed
- Godot 4.6.3 lifecycle suite: 94 passed
- Godot 4.6.3 atomic-write tests: 19 passed
- Godot 4.6.3 GDScript import: clean
- Ruff: clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-update safety by failing closed when backup, restore, or permission changes fail.
  * Removed incomplete backups and temporary files after unsuccessful write operations.
  * Improved permission warnings with clearer error details.
  * Improved recovery of stale server processes and reclaimed ports while preventing cancelled recovery attempts from consuming recovery capacity.

* **Tests**
  * Added coverage for permission failures, cleanup behavior, and generation-aware server recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->