### PR TITLE
docs: create addons/ before copying the plugin into it

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ animation, particles, cameras, and environments.
 
 ```bash
 git clone https://github.com/hi-godot/godot-ai.git
+mkdir -p your-project/addons   # without this, cp makes addons/ a copy of godot_ai
 cp -r godot-ai/plugin/addons/godot_ai your-project/addons/
 ```
 
@@ -73,6 +74,11 @@ Marketplace releases may lag behind GitHub.
 In Godot: **Project > Project Settings > Plugins** — enable **Godot AI**.
 
 The plugin will automatically start the MCP server, connect over WebSocket, and show status in the **Godot AI** dock.
+
+> **Not listed under Plugins?** Godot scans each subdirectory of `res://addons/`
+> for a `plugin.cfg`. Check that your project has `addons/godot_ai/plugin.cfg`
+> and not `addons/plugin.cfg` — the latter means the plugin contents were copied
+> one directory too high.
 
 <p align="center"><img src="docs/images/dock.png" alt="Godot AI dock — Clients & Tools button highlighted" width="350"></p>
 


### PR DESCRIPTION
Fixes #906.

### The bug

```bash
cp -r godot-ai/plugin/addons/godot_ai your-project/addons/
```

lands correctly only when `addons/` already exists. On a freshly created Godot
project it does not, so `cp -r` creates `addons/` **as a copy of** `godot_ai`:

```
your-project/addons/plugin.cfg      <- ends up here
your-project/addons/godot_ai/...    <- never created
```

`cp` exits 0, nothing warns, and since Godot scans `res://addons/<dir>/plugin.cfg`
the plugin simply never appears under Project Settings > Plugins. It is the first
command a new user runs.

### The fix

`mkdir -p your-project/addons`, and leave the `cp` alone.

I first wrote this as an explicit destination (`.../addons/godot_ai`). Review
caught that it regresses the re-install path: with `addons/godot_ai/` already
present, `cp -r src dest/godot_ai` nests to `addons/godot_ai/godot_ai/` and
leaves the **stale** `plugin.cfg` at the scanned path — so the plugin keeps
loading the old version silently. That is worse than the original bug on a path
the README labels "From source (latest)" and therefore expects to be re-run
after a pull. The missing parent directory was the entire defect.

This also matches `.github/workflows/release.yml`, which already pairs
`mkdir -p staging/addons` with the same `cp -r`.

### Verified

Both forms, both cases, GNU coreutils and PowerShell 7:

| case | before | after |
|---|---|---|
| fresh project, no `addons/` | `addons/plugin.cfg` (broken) | `addons/godot_ai/plugin.cfg` |
| re-install over existing | correct | correct, `plugin.cfg` advances, no nesting |

Also adds a short troubleshooting note on the enable step, since the symptom —
plugin simply absent from the list — gives no clue where to look.

Docs only; no code paths touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to create the `addons` directory before copying the plugin.
  * Added troubleshooting guidance for incorrect plugin directory placement and missing plugin detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->