### PR TITLE
fix(project_run): stop the server timeout undercutting the plugin's deferred budget

### DIFF
--- a/src/godot_ai/handlers/project.py
+++ b/src/godot_ai/handlers/project.py
@@ -58,6 +58,7 @@ async def project_run(
         params["scene"] = scene
     if not autosave:
         params["autosave"] = False
+    await require_writable_async(runtime)
     return await runtime.send_command("run_project", params, timeout=RUN_PROJECT_TIMEOUT_SEC)
 
 

--- a/src/godot_ai/handlers/project.py
+++ b/src/godot_ai/handlers/project.py
@@ -12,6 +12,25 @@ from godot_ai.godot_client.session_diagnostics import (
 from godot_ai.handlers._readiness import require_writable_async, sync_readiness_from_snapshot
 from godot_ai.runtime.direct import DirectRuntime
 
+## Must stay above the plugin's own deferred budget for `run_project`
+## (`DEFERRED_TIMEOUT_MS_BY_COMMAND["run_project"] = 6000` in dispatcher.gd).
+## `run_project` defers: the plugin returns DEFERRED_RESPONSE and re-polls game
+## status until the launch resolves, so it can legitimately take the full 6 s on
+## a cold start or a large scene. At the inherited 5.0 s default the server gave
+## up first and reported a successful launch as a timeout — which `GodotClient`
+## then charged to the editor-bridge circuit breaker.
+##
+## 6.0 s budget + the repo's standing 2 s transport margin for this exact
+## cross-language pairing, spelled out in `handlers/custom.py`: "the server-side
+## future must outlive that budget ... +2s margin covers transport latency".
+## `vision_routing.gd`'s 13 000 ms editor-screenshot override under
+## SCREENSHOT_TIMEOUT_SEC = 15.0 is the same +2. Exact ties exist elsewhere
+## (game_eval, game_command, check_client_status) and are not wrong, but the
+## plugin's timer starts when the dispatcher registers the deferred request —
+## strictly after the server began its own — so the margin costs nothing and
+## removes the round-trip from the race.
+RUN_PROJECT_TIMEOUT_SEC = 8.0
+
 COMMON_SETTINGS = [
     "application/config/name",
     "application/config/description",
@@ -39,7 +58,7 @@ async def project_run(
         params["scene"] = scene
     if not autosave:
         params["autosave"] = False
-    return await runtime.send_command("run_project", params)
+    return await runtime.send_command("run_project", params, timeout=RUN_PROJECT_TIMEOUT_SEC)
 
 
 async def project_stop(runtime: DirectRuntime) -> dict:

--- a/tests/unit/test_deferred_timeout_ladder.py
+++ b/tests/unit/test_deferred_timeout_ladder.py
@@ -163,11 +163,9 @@ async def _observed_timeout_sec(command: str) -> float:
     ## reply (screenshot decoding, pagination, readiness reads) raise on the way
     ## back out — KeyError, TypeError, AttributeError or ValueError depending on
     ## the handler. Only the OUTBOUND timeout matters here, and it is already
-    ## recorded by the time any of those fire. The catch stays broad rather than
-    ## enumerated because the set varies per handler and a missed type would
-    ## turn this into a spurious failure; `assert sent` below is what keeps it
-    ## honest, failing loudly if the handler never reached send_command at all.
-    with contextlib.suppress(Exception):
+    ## recorded by the time any of those fire. Unexpected exception types must
+    ## fail the test; `assert sent` still fails if send_command was never reached.
+    with contextlib.suppress(KeyError, TypeError, AttributeError, ValueError):
         await COMMAND_DRIVERS[command](runtime)
     sent = [call for call in client.calls if call["command"] == command]
     assert sent, f"handler for {command!r} never issued a {command!r} command"
@@ -211,7 +209,7 @@ async def test_editor_screenshot_timeout_covers_vision_route_budget() -> None:
     budget = _vision_route_budget_sec()
     client = RecordingClient()
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)
-    with contextlib.suppress(Exception):
+    with contextlib.suppress(KeyError, TypeError, AttributeError, ValueError):
         await editor_handlers.editor_screenshot(runtime, source="viewport")
     sent = [call for call in client.calls if call["command"] == "take_screenshot"]
     assert sent, "editor_screenshot never issued take_screenshot"

--- a/tests/unit/test_deferred_timeout_ladder.py
+++ b/tests/unit/test_deferred_timeout_ladder.py
@@ -1,0 +1,222 @@
+"""Cross-language contract: the server's command timeout must cover the
+plugin's deferred budget for the same command.
+
+A deferred command has two independent stopwatches running on it:
+
+- **plugin side** — ``dispatcher.gd::DEFERRED_TIMEOUT_MS_BY_COMMAND`` (falling
+  back to ``DEFAULT_DEFERRED_TIMEOUT_MS``). When it expires the dispatcher
+  drops the pending entry and answers ``DEFERRED_TIMEOUT``, which is an honest,
+  attributed diagnostic the agent can act on.
+- **server side** — the ``timeout`` ``DirectRuntime.send_command`` hands to
+  ``GodotClient.send``. When *it* expires first, ``GodotClient`` raises
+  ``TimeoutError``, charges the failure to the editor-bridge circuit breaker
+  (``client.py::_record_failure``), and the agent is told the call timed out —
+  even when the plugin was still inside its own budget and about to answer
+  successfully.
+
+So the server budget must never undercut the plugin budget. ``run_project`` is
+the case that motivated this file: the plugin allows the deferred liveness poll
+6000 ms (``project_handler.gd::_finish_run_project_deferred`` re-polls
+``get_game_status`` with ``RUN_READY_WAIT_SEC`` until the run resolves), while
+``handlers/project.py::project_run`` sends with no explicit timeout and
+therefore inherits ``DirectRuntime.send_command``'s 5.0 s default. A game that
+takes 5-6 s to go live is reported to the AI client as a timeout and counted
+toward opening the circuit.
+
+The guard is table-driven over the *whole* dispatcher budget table rather than
+just ``run_project``: each command is driven through its real Python handler
+with a recording client, so the assertion sees the timeout production actually
+resolves (default or explicit) instead of a re-declared copy of it. Source
+scraping of the GDScript side follows ``test_game_eval_timeout_ordering.py`` /
+``test_deferred_timeout_contract.py``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import inspect
+import re
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from godot_ai.handlers import client as client_handlers
+from godot_ai.handlers import editor as editor_handlers
+from godot_ai.handlers import filesystem as filesystem_handlers
+from godot_ai.handlers import game as game_handlers
+from godot_ai.handlers import project as project_handlers
+from godot_ai.handlers import script as script_handlers
+from godot_ai.runtime.direct import DirectRuntime
+from godot_ai.sessions.registry import SessionRegistry
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[2] / "plugin" / "addons" / "godot_ai"
+DISPATCHER = PLUGIN_ROOT / "dispatcher.gd"
+VISION_ROUTING = PLUGIN_ROOT / "vision_routing.gd"
+
+
+class RecordingClient:
+    """``GodotClient`` stand-in that records the timeout it was sent with.
+
+    Mirrors ``GodotClient.send``'s signature (including its 5.0 s default) so
+    that a handler which stops passing ``timeout`` is recorded as whatever
+    ``DirectRuntime`` resolves, not as whatever this stub prefers.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def send(
+        self,
+        command: str,
+        params: dict | None = None,
+        session_id: str | None = None,
+        timeout: float = 5.0,
+        hint_policy=None,
+    ) -> dict:
+        self.calls.append({"command": command, "timeout": timeout})
+        return {}
+
+
+## One driver per command in DEFERRED_TIMEOUT_MS_BY_COMMAND, calling the real
+## Python handler that issues it. The registry is left empty on purpose: the
+## `require_writable_async` gate on the write paths is a documented no-op when
+## there is no active session, so no readiness choreography is needed here.
+COMMAND_DRIVERS: dict[str, Callable[[DirectRuntime], Awaitable[object]]] = {
+    "run_project": lambda rt: project_handlers.project_run(rt),
+    "stop_project": lambda rt: project_handlers.project_stop(rt),
+    "create_script": lambda rt: script_handlers.script_create(rt, "res://_audit_probe.gd"),
+    "write_file": lambda rt: filesystem_handlers.filesystem_write_text(
+        rt, "res://_audit_probe.txt", "x"
+    ),
+    "scan_filesystem": lambda rt: filesystem_handlers.filesystem_scan(rt),
+    "check_client_status": lambda rt: client_handlers.client_status(rt),
+    "game_eval": lambda rt: editor_handlers.game_eval(rt, "return 1"),
+    "game_command": lambda rt: game_handlers.game_get_scene_tree(rt),
+    ## Only source="game" defers plugin-side (editor_handler.gd's game branch
+    ## hands off to the debugger); viewport/cinematic captures reply inline, so
+    ## the 30 s budget belongs to the game path. The one exception — a
+    ## vision-routed editor capture — carries its own 13 s override and is
+    ## checked separately below.
+    "take_screenshot": lambda rt: editor_handlers.editor_screenshot(rt, source="game"),
+}
+
+
+def _dispatcher_source() -> str:
+    return DISPATCHER.read_text(encoding="utf-8")
+
+
+def _plugin_budgets_sec() -> dict[str, float]:
+    """Scrape ``DEFERRED_TIMEOUT_MS_BY_COMMAND`` as {command: seconds}."""
+    block = re.search(
+        r"const DEFERRED_TIMEOUT_MS_BY_COMMAND := \{(.*?)\n\}",
+        _dispatcher_source(),
+        re.DOTALL,
+    )
+    assert block, "DEFERRED_TIMEOUT_MS_BY_COMMAND not found in dispatcher.gd"
+    body = block.group(1)
+    entries = re.findall(r'"([a-z0-9_]+)"\s*:\s*(\d+)', body)
+
+    ## A guard that silently drops table entries is worse than no guard: the
+    ## dropped command is exactly the one that would have been caught next.
+    ## Command names contain digits (`camera_follow_2d`), and a budget could be
+    ## written as a named constant rather than a literal — either would vanish
+    ## from a permissive `findall` while leaving the list non-empty. So count
+    ## the keys independently and require the two to agree.
+    keys = re.findall(r'"([^"]+)"\s*:', body)
+    assert keys, "no command budgets parsed out of DEFERRED_TIMEOUT_MS_BY_COMMAND"
+    assert len(entries) == len(keys), (
+        f"parsed {len(entries)} of {len(keys)} entries in DEFERRED_TIMEOUT_MS_BY_COMMAND — "
+        f"unparsed: {sorted(set(keys) - {name for name, _ in entries})}. "
+        "Every entry must be covered; widen the parser rather than letting one through."
+    )
+    return {name: int(ms) / 1000.0 for name, ms in entries}
+
+
+def _plugin_default_budget_sec() -> float:
+    match = re.search(r"const DEFAULT_DEFERRED_TIMEOUT_MS := (\d+)", _dispatcher_source())
+    assert match, "DEFAULT_DEFERRED_TIMEOUT_MS not found in dispatcher.gd"
+    return int(match.group(1)) / 1000.0
+
+
+def _vision_route_budget_sec() -> float:
+    match = re.search(
+        r'"_deferred_timeout_ms":\s*(\d+)',
+        VISION_ROUTING.read_text(encoding="utf-8"),
+    )
+    assert match, "vision_routing.gd no longer declares a _deferred_timeout_ms override"
+    return int(match.group(1)) / 1000.0
+
+
+def _runtime_default_timeout_sec() -> float:
+    default = inspect.signature(DirectRuntime.send_command).parameters["timeout"].default
+    assert isinstance(default, (int, float)), "DirectRuntime.send_command lost its timeout default"
+    return float(default)
+
+
+async def _observed_timeout_sec(command: str) -> float:
+    """Drive `command`'s Python handler and report the timeout it sent with."""
+    client = RecordingClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    ## The stub answers every command with {}, so handlers that post-process the
+    ## reply (screenshot decoding, pagination, readiness reads) raise on the way
+    ## back out — KeyError, TypeError, AttributeError or ValueError depending on
+    ## the handler. Only the OUTBOUND timeout matters here, and it is already
+    ## recorded by the time any of those fire. The catch stays broad rather than
+    ## enumerated because the set varies per handler and a missed type would
+    ## turn this into a spurious failure; `assert sent` below is what keeps it
+    ## honest, failing loudly if the handler never reached send_command at all.
+    with contextlib.suppress(Exception):
+        await COMMAND_DRIVERS[command](runtime)
+    sent = [call for call in client.calls if call["command"] == command]
+    assert sent, f"handler for {command!r} never issued a {command!r} command"
+    return float(sent[-1]["timeout"])
+
+
+def test_every_deferred_budget_has_a_driver() -> None:
+    """A new bespoke plugin budget must not slip in unguarded."""
+    missing = sorted(set(_plugin_budgets_sec()) - set(COMMAND_DRIVERS))
+    assert not missing, (
+        f"dispatcher.gd budgets {missing} have no Python driver in this test — "
+        "add one so the server/plugin timeout ordering stays enforced"
+    )
+
+
+@pytest.mark.parametrize("command", sorted(_plugin_budgets_sec()))
+async def test_server_timeout_covers_plugin_deferred_budget(command: str) -> None:
+    budget = _plugin_budgets_sec()[command]
+    observed = await _observed_timeout_sec(command)
+    assert observed >= budget, (
+        f"server timeout for {command!r} ({observed}s) undercuts the plugin's "
+        f"deferred budget ({budget}s) — the client aborts while the plugin is "
+        "still legitimately working, so a successful command is reported as a "
+        "timeout AND charged to the editor-bridge circuit breaker"
+    )
+
+
+async def test_default_send_timeout_covers_default_deferred_budget() -> None:
+    """Commands with no bespoke budget on either side must still be ordered."""
+    default_budget = _plugin_default_budget_sec()
+    assert _runtime_default_timeout_sec() >= default_budget, (
+        f"DirectRuntime.send_command's default timeout "
+        f"({_runtime_default_timeout_sec()}s) undercuts the dispatcher's "
+        f"DEFAULT_DEFERRED_TIMEOUT_MS ({default_budget}s) — every deferring "
+        "command without an explicit timeout would abort early"
+    )
+
+
+async def test_editor_screenshot_timeout_covers_vision_route_budget() -> None:
+    """The vision-routing override is the editor-source screenshot's budget."""
+    budget = _vision_route_budget_sec()
+    client = RecordingClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    with contextlib.suppress(Exception):
+        await editor_handlers.editor_screenshot(runtime, source="viewport")
+    sent = [call for call in client.calls if call["command"] == "take_screenshot"]
+    assert sent, "editor_screenshot never issued take_screenshot"
+    assert float(sent[-1]["timeout"]) >= budget, (
+        f"editor-source screenshot timeout ({sent[-1]['timeout']}s) undercuts "
+        f"vision_routing.gd's deferred override ({budget}s) — a vision-routed "
+        "capture would be aborted client-side before the worker can reply"
+    )


### PR DESCRIPTION
Fixes #909.

### The bug

A deferred command runs two independent stopwatches:

| side | `run_project` |
|---|---|
| plugin — `dispatcher.gd::DEFERRED_TIMEOUT_MS_BY_COMMAND` | 6000 ms |
| server — the `timeout` passed to `send_command` | **5.0 s** (inherited default) |

`run_project` genuinely defers: `project_handler.gd` returns `DEFERRED_RESPONSE`
and re-polls game status in an unbounded loop until the launch resolves. A cold
start, a shader compile, or a large scene can legitimately reach the full 6 s —
and in the 5.0–6.0 s band the server gave up first. The agent was told the call
timed out while the plugin was still inside budget and about to answer
successfully, and `GodotClient.send` charged that phantom timeout to the
editor-bridge circuit breaker.

### The fix

`RUN_PROJECT_TIMEOUT_SEC = 8.0` — the 6.0 s budget plus the **+2 s transport
margin this repo already specifies for this exact cross-language pairing** in
`handlers/custom.py`:

> the server-side future must outlive that budget … +2s margin covers transport latency

`vision_routing.gd`'s 13 000 ms override under `SCREENSHOT_TIMEOUT_SEC = 15.0`
is the same +2. (I first justified the number against
`GAME_SCREENSHOT_TIMEOUT_SEC`; review pointed out that margin is +5 s / 1.17×,
not a match. `custom.py` is the real convention and lands on 8.0 exactly.)

### The test

Table-driven over the dispatcher's whole budget table. Each command is driven
through its **real handler** with a recording client, so the assertion observes
the timeout production actually resolves rather than a re-declared copy.

Mutation-tested three ways:

| mutation | result |
|---|---|
| remove the fix | `assert 5.0 >= 6.0` — fails on `run_project` |
| raise the plugin budget to 9000 | `assert 8.0 >= 9.0` — fails, so it tracks GDScript live |
| add `"camera_follow_2d": 30000` to the real table | fails as a new case **and** as a missing driver |

That third one is why the parser is stricter than it looks. A permissive scrape
would have silently dropped any command name containing a digit — and
`camera_follow_2d` is already a registered command — or any budget written as a
named constant. The dropped entry is exactly the one that would have been caught
next, so the parser now counts keys independently of values and asserts the two
agree, naming the offender instead of passing green.

### Scope

`run_project` was the only inversion; every sibling in the table is already
ordered. `project_run` has one caller, no rollup or resource form, and inside
`batch_execute` it answers inline under the 30 s batch budget, so that path is
unaffected.

Full suite: 1815 passed, 19 skipped. `ruff check src/ tests/` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project launching by allowing commands up to 8 seconds to complete before timing out.
  * Added a readiness check before launching projects.
  * Reduced premature failures when starting projects or waiting for deferred operations.

* **Tests**
  * Added coverage to verify timeout settings remain sufficient across project, plugin, and screenshot workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->