### PR TITLE
fix(batch_execute): roll back what the batch committed, not what it succeeded

### DIFF
--- a/plugin/addons/godot_ai/handlers/batch_handler.gd
+++ b/plugin/addons/godot_ai/handlers/batch_handler.gd
@@ -127,6 +127,10 @@ func batch_execute(params: Dictionary) -> Dictionary:
 			before.append(ur.get_version())
 
 		var raw_result: Dictionary = _dispatcher.dispatch_direct(cmd_name, sub_params)
+		## Record before reading status. A handler can commit_action() and still
+		## return an error; those actions must be in `committed` so a later
+		## (or this) failure rolls them back.
+		_record_committed(tracked, before, committed)
 		var status: String = raw_result.get("status", "ok")
 
 		var result_entry: Dictionary = {"command": cmd_name, "status": status}
@@ -140,7 +144,6 @@ func batch_execute(params: Dictionary) -> Dictionary:
 			result_entry["data"] = data
 			if typeof(data) == TYPE_DICTIONARY and data.get("undoable", false) != true:
 				all_undoable = false
-			_record_committed(tracked, before, committed)
 			results.append(result_entry)
 			succeeded += 1
 

--- a/plugin/addons/godot_ai/handlers/batch_handler.gd
+++ b/plugin/addons/godot_ai/handlers/batch_handler.gd
@@ -102,14 +102,29 @@ func batch_execute(params: Dictionary) -> Dictionary:
 	var succeeded := 0
 	var stopped_at = null
 	var all_undoable := true
-	# Captured after the first successful commit — get_history_undo_redo()
-	# errors if called before any action exists in the history_map.
-	var histories: Array = []
+	## One entry per action a sub-command actually committed, in commit order,
+	## naming the UndoRedo that received it. Rollback replays this in reverse.
+	##
+	## Measured rather than inferred. Counting *successes* over-undoes, because
+	## a sub-command can succeed without committing anything (`create_script`
+	## and `write_text_file` write straight to disk) — the extra undos then eat
+	## the user's own pre-batch edits. Trusting the response's `undoable` flag
+	## instead under-undoes, because `custom_tool:` sub-commands never carry one
+	## (`custom_tool_wrapper.gd` returns the addon handler's dict verbatim) even
+	## when their spec declares `undoable = true` and they did commit. Comparing
+	## `UndoRedo.get_version()` across the call is the only reading that can't
+	## disagree with what the editor actually recorded.
+	var committed: Array = []
 
 	for idx in range(commands.size()):
 		var item: Dictionary = commands[idx]
 		var cmd_name: String = item["command"]
 		var sub_params: Dictionary = item.get("params", {})
+
+		var tracked := _tracked_histories()
+		var before: Array = []
+		for ur in tracked:
+			before.append(ur.get_version())
 
 		var raw_result: Dictionary = _dispatcher.dispatch_direct(cmd_name, sub_params)
 		var status: String = raw_result.get("status", "ok")
@@ -125,13 +140,13 @@ func batch_execute(params: Dictionary) -> Dictionary:
 			result_entry["data"] = data
 			if typeof(data) == TYPE_DICTIONARY and data.get("undoable", false) != true:
 				all_undoable = false
+			_record_committed(tracked, before, committed)
 			results.append(result_entry)
 			succeeded += 1
-			_capture_histories(histories)
 
 	var rolled_back := false
-	if stopped_at != null and undo and succeeded > 0:
-		rolled_back = _rollback(succeeded, histories)
+	if stopped_at != null and undo and not committed.is_empty():
+		rolled_back = _rollback(committed)
 
 	var response_data: Dictionary = {
 		"succeeded": succeeded,
@@ -146,19 +161,39 @@ func batch_execute(params: Dictionary) -> Dictionary:
 	return {"data": response_data}
 
 
-## Capture the scene's UndoRedo reference for batch rollback. Safe to call
-## multiple times; appends only the new reference. MCP write handlers all pin
-## their actions to the scene history, so the scene UndoRedo is the only one
-## rollback needs. Must be called only after at least one action has been
-## committed to the scene history.
-func _capture_histories(histories: Array) -> void:
+## The histories a batch sub-command can commit into.
+##
+## Most write handlers pin their action to the edited scene, but not all:
+## handlers that `create_action(label)` without a context object bind it to the
+## handler `RefCounted` instead, and it lands in `GLOBAL_HISTORY` (see
+## `animation_handler.gd`'s note on mismatched histories, and
+## `testing/test_suite.gd`, which watches both for the same reason). Watching
+## only the scene history would leave those actions un-rolled-back.
+func _tracked_histories() -> Array:
+	var out: Array = []
 	var scene_root := EditorInterface.get_edited_scene_root()
-	if scene_root == null:
-		return
-	var scene_id := _undo_redo.get_object_history_id(scene_root)
-	var scene_ur := _undo_redo.get_history_undo_redo(scene_id)
-	if scene_ur != null and not scene_ur in histories:
-		histories.append(scene_ur)
+	if scene_root != null:
+		var scene_ur := _undo_redo.get_history_undo_redo(
+			_undo_redo.get_object_history_id(scene_root)
+		)
+		if scene_ur != null:
+			out.append(scene_ur)
+	var global_ur := _undo_redo.get_history_undo_redo(EditorUndoRedoManager.GLOBAL_HISTORY)
+	if global_ur != null and not global_ur in out:
+		out.append(global_ur)
+	return out
+
+
+## Append one entry to `committed` per action the just-finished sub-command
+## pushed, by diffing each watched history's version against `before`.
+## `UndoRedo.get_version()` advances once per `commit_action`, so the delta is
+## the action count — a handler that commits twice is recorded twice, and one
+## that commits nothing is recorded not at all.
+func _record_committed(tracked: Array, before: Array, committed: Array) -> void:
+	for i in range(tracked.size()):
+		var delta: int = tracked[i].get_version() - int(before[i])
+		for _n in range(delta):
+			committed.append(tracked[i])
 
 
 ## Build the unknown-command error for a sub-command. Clarifies that
@@ -174,17 +209,17 @@ func _unknown_command_error(idx: int, cmd_name: String) -> Dictionary:
 	return err
 
 
-## Undo `count` actions by calling undo() on captured histories in LIFO order.
-## Returns true iff all undo calls succeeded.
-func _rollback(count: int, histories: Array) -> bool:
-	if histories.is_empty():
+## Undo every action the batch committed, newest first, against the history
+## that actually received it. Returns true iff every undo() reported success.
+##
+## Strict LIFO across histories matters: undoing a scene action before a global
+## one committed after it would replay them out of order. Walking `committed`
+## in reverse preserves commit order regardless of which history each landed in.
+func _rollback(committed: Array) -> bool:
+	if committed.is_empty():
 		return false
-	for _i in range(count):
-		var undone := false
-		for ur in histories:
-			if ur.undo():
-				undone = true
-				break
-		if not undone:
-			return false
-	return true
+	var ok := true
+	for i in range(committed.size() - 1, -1, -1):
+		if not committed[i].undo():
+			ok = false
+	return ok

--- a/test_project/tests/test_batch.gd
+++ b/test_project/tests/test_batch.gd
@@ -36,6 +36,18 @@ func suite_setup(ctx: Dictionary) -> void:
 		_call_log.append("_fail_pure")
 		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, "forced failure"))
 
+	## Commits a real undo action but reports no `undoable` key — the shape a
+	## `custom_tool:` sub-command has, since `custom_tool_wrapper.gd` returns the
+	## addon handler's dict verbatim and never stamps the spec's flag. Rollback
+	## must still revert it, so this stub pins that the depth is measured from
+	## the editor's history rather than read off the response.
+	_dispatcher.register("_commits_unreported", func(_p: Dictionary) -> Dictionary:
+		_call_log.append("_commits_unreported")
+		_node_handler.create_node({
+			"type": "Node3D", "name": "_BatchUnreported", "parent_path": "/Main",
+		})
+		return {"data": {}})
+
 	_handler = BatchHandler.new(_dispatcher, _undo_redo)
 
 
@@ -200,6 +212,127 @@ func test_rollback_on_failure_with_undo_true() -> void:
 	# Rollback undid the create
 	var after_count := scene_root.get_child_count()
 	assert_eq(after_count, before_count)
+
+
+## Rollback depth is the number of actions the batch actually committed, not the
+## number of sub-commands that succeeded. `_ok_pure` succeeds without pushing an
+## action — the shape of `create_script` / `write_text_file`, which write to disk
+## and report `undoable: false`. Counting it undoes one action too many, and the
+## extra undo lands on the editor's shared history: the user's pre-batch edits.
+##
+## Cleanup is guarded on presence throughout: `assert_*` records a failure and
+## returns rather than aborting the body, so an unguarded trailing undo would
+## consume an unrelated action from shared history on every regression.
+func test_rollback_does_not_undo_actions_the_batch_did_not_create() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	## The "user's prior edit" — committed, undoable, and not part of the batch.
+	var sentinel := _node_handler.create_node({
+		"type": "Node3D", "name": "_BatchSentinel", "parent_path": "/Main",
+	})
+	assert_eq(sentinel.data.undoable, true, "sentinel must be an undoable action")
+
+	var result := _handler.batch_execute({
+		"commands": [
+			{"command": "_ok_pure", "params": {}},
+			{"command": "create_node", "params": {"type": "Node3D", "name": "_BatchVictim", "parent_path": "/Main"}},
+			{"command": "_fail_pure", "params": {}},
+		],
+	})
+	assert_true(scene_root.has_node(^"_BatchSentinel"),
+		"rollback must not walk past the batch into pre-batch history")
+	assert_eq(result.data.stopped_at, 2)
+	assert_eq(result.data.succeeded, 2, "both non-error sub-commands are still counted as succeeded")
+	assert_eq(result.data.rolled_back, true)
+	assert_false(scene_root.has_node(^"_BatchVictim"), "rollback undid the batch's own create")
+
+	_undo_leftovers([^"_BatchSentinel", ^"_BatchVictim"])
+
+
+## The mirror ordering: undoable first, non-undoable second. Guards against a
+## refactor that ties history capture to the first iteration only.
+func test_rollback_correct_when_the_undoable_sub_command_runs_first() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var sentinel := _node_handler.create_node({
+		"type": "Node3D", "name": "_BatchSentinelC", "parent_path": "/Main",
+	})
+	assert_eq(sentinel.data.undoable, true, "sentinel setup")
+
+	var result := _handler.batch_execute({
+		"commands": [
+			{"command": "create_node", "params": {"type": "Node3D", "name": "_BatchVictimC", "parent_path": "/Main"}},
+			{"command": "_ok_pure", "params": {}},
+			{"command": "_fail_pure", "params": {}},
+		],
+	})
+	assert_true(scene_root.has_node(^"_BatchSentinelC"),
+		"rollback must not reach the pre-batch sentinel")
+	assert_eq(result.data.rolled_back, true)
+	assert_false(scene_root.has_node(^"_BatchVictimC"), "the batch's own create was undone")
+
+	_undo_leftovers([^"_BatchSentinelC", ^"_BatchVictimC"])
+
+
+## A sub-command can commit an action without reporting `undoable` — every
+## `custom_tool:` does, because the wrapper returns the addon's dict verbatim.
+## Rollback must still revert it, so the depth cannot be read off the response.
+func test_rollback_reverts_a_commit_that_reported_no_undoable_flag() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var sentinel := _node_handler.create_node({
+		"type": "Node3D", "name": "_BatchSentinelU", "parent_path": "/Main",
+	})
+	assert_eq(sentinel.data.undoable, true, "sentinel setup")
+
+	var result := _handler.batch_execute({
+		"commands": [
+			{"command": "_commits_unreported", "params": {}},
+			{"command": "_fail_pure", "params": {}},
+		],
+	})
+	assert_eq(result.data.stopped_at, 1)
+	assert_false(scene_root.has_node(^"_BatchUnreported"),
+		"an action committed without an `undoable` flag must still be rolled back")
+	assert_eq(result.data.rolled_back, true)
+	assert_true(scene_root.has_node(^"_BatchSentinelU"),
+		"and rollback still must not reach pre-batch history")
+
+	_undo_leftovers([^"_BatchSentinelU", ^"_BatchUnreported"])
+
+
+## A batch whose successful sub-commands committed nothing has nothing to roll
+## back, and `rolled_back` must say so rather than undoing unrelated history.
+func test_rollback_is_a_noop_when_nothing_was_committed() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var sentinel := _node_handler.create_node({
+		"type": "Node3D", "name": "_BatchSentinel2", "parent_path": "/Main",
+	})
+	assert_eq(sentinel.data.undoable, true, "sentinel setup")
+
+	var result := _handler.batch_execute({
+		"commands": [
+			{"command": "_ok_pure", "params": {}},
+			{"command": "_ok_pure", "params": {}},
+			{"command": "_fail_pure", "params": {}},
+		],
+	})
+	assert_true(scene_root.has_node(^"_BatchSentinel2"),
+		"a batch that committed nothing must leave prior history alone")
+	assert_eq(result.data.stopped_at, 2)
+	assert_eq(result.data.succeeded, 2)
+	assert_eq(result.data.rolled_back, false, "nothing was committed, so nothing was rolled back")
+
+	_undo_leftovers([^"_BatchSentinel2"])
+
+
+## Undo one action per node in `names` that is still present, so a regression
+## leaves the shared history where it started instead of eating an unrelated
+## action. Never asserts: cleanup failures must not mask the real assertion.
+func _undo_leftovers(names: Array) -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		return
+	for n in names:
+		if scene_root.has_node(n):
+			editor_undo(_undo_redo)
 
 
 func test_real_multi_step_success() -> void:

--- a/test_project/tests/test_batch.gd
+++ b/test_project/tests/test_batch.gd
@@ -47,6 +47,14 @@ func suite_setup(ctx: Dictionary) -> void:
 			"type": "Node3D", "name": "_BatchUnreported", "parent_path": "/Main",
 		})
 		return {"data": {}})
+	## Commits, then returns an error. Rollback must still see the commit —
+	## `_record_committed` cannot wait for `status == "ok"`.
+	_dispatcher.register("_commits_then_errors", func(_p: Dictionary) -> Dictionary:
+		_call_log.append("_commits_then_errors")
+		_node_handler.create_node({
+			"type": "Node3D", "name": "_BatchCommittedError", "parent_path": "/Main",
+		})
+		return ErrorCodes.make(ErrorCodes.INVALID_PARAMS, "committed then failed"))
 
 	_handler = BatchHandler.new(_dispatcher, _undo_redo)
 
@@ -296,6 +304,32 @@ func test_rollback_reverts_a_commit_that_reported_no_undoable_flag() -> void:
 		"and rollback still must not reach pre-batch history")
 
 	_undo_leftovers([^"_BatchSentinelU", ^"_BatchUnreported"])
+
+
+## A handler can `commit_action()` and still return an error dict. Recording
+## only on `status == "ok"` would leave that mutation out of `committed`.
+func test_rollback_reverts_a_commit_from_a_failing_subcommand() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var sentinel := _node_handler.create_node({
+		"type": "Node3D", "name": "_BatchSentinelE", "parent_path": "/Main",
+	})
+	assert_eq(sentinel.data.undoable, true, "sentinel setup")
+
+	var result := _handler.batch_execute({
+		"commands": [
+			{"command": "_commits_then_errors", "params": {}},
+		],
+	})
+	assert_eq(result.data.stopped_at, 0)
+	assert_eq(result.data.succeeded, 0)
+	assert_eq(result.data.rolled_back, true)
+	assert_false(scene_root.has_node(^"_BatchCommittedError"),
+		"a commit that preceded an error status must still be rolled back")
+	assert_true(scene_root.has_node(^"_BatchSentinelE"),
+		"and rollback still must not reach pre-batch history")
+	assert_eq(_call_log, ["_commits_then_errors"])
+
+	_undo_leftovers([^"_BatchSentinelE", ^"_BatchCommittedError"])
 
 
 ## A batch whose successful sub-commands committed nothing has nothing to roll


### PR DESCRIPTION
Fixes #903.

### The bug

On a failed sub-command, rollback called `ur.undo()` once per **successful**
sub-command. But a sub-command can succeed without committing an undo action —
`create_script` and `write_text_file` write straight to disk. Each such success
made the rollback undo one action too many, and the surplus landed on the
editor's *shared* history: the user's own edits from before the batch ran.
`_rollback` only stopped early on a completely empty history, so a populated one
was silently walked backwards — while the response still said `rolled_back: true`.

### Why not just count the `undoable` flag

That was my first attempt, and review caught that it swaps the bug rather than
fixing it. `custom_tool:` sub-commands never carry that flag —
`custom_tool_wrapper.gd` returns the addon handler's dict verbatim and never
stamps `spec.undoable`. Trusting the flag would silently **skip** a custom tool
that did commit, leaving a partial batch applied while still reporting a
rollback. That is worse than the over-rollback: the caller is told it was
reverted.

### Measure, don't infer

Each sub-command is bracketed by `UndoRedo.get_version()` snapshots, and every
action it committed is recorded against the history that received it. Rollback
replays that list in reverse. This is the only reading that cannot disagree with
what the editor actually recorded — it covers non-committing successes,
unflagged commits, and a handler that commits twice, without trusting any
per-command metadata.

It also tracks **both** histories. Handlers that `create_action(label)` without a
context object bind to the handler `RefCounted` and land in `GLOBAL_HISTORY`
rather than the scene's — `material_handler` and `theme_handler` still do — and
the previous scene-only capture could never roll those back. Note the old
`_rollback` could not simply be handed a second history: its
`for ur in histories: if ur.undo(): break` drained whichever accepted an undo
first, so a count of two could spend both on the scene.

### Behaviour change

`rolled_back` is now `false` for a batch that committed nothing, where it used to
report `true` after undoing unrelated actions. That is the honest answer and
matches the documented contract in `tools/batch.py` ("whether rollback was
performed"). I grepped `src/`, `plugin/`, `docs/` and the tests — nothing
branches on the field. `succeeded` is unchanged.

### Verification

Four new tests, all mutation-checked against a live editor:

| mutation | killed |
|---|---|
| original upstream code | 3 of 4 (the over-rollback cases) |
| flag-trusting variant | `test_rollback_reverts_a_commit_that_reported_no_undoable_flag` |

That fourth test registers `_commits_unreported`, which reproduces the
custom-tool shape exactly: commits a real action, reports no flag.

Cleanup is presence-guarded throughout — `McpTestSuite.assert_*` records a
failure and *returns* rather than aborting the body, so an unguarded trailing
undo would eat an unrelated action from shared history on every regression.

Full GDScript suite against a live Godot 4.7.2 editor: **2301 passed, 0 failed**.
`ruff` clean; Python suite unaffected (no Python files touched).

### Follow-up, not in this PR

`material_handler` and `theme_handler` create unpinned actions that land in
`GLOBAL_HISTORY` while their siblings pin to the scene. This PR makes those
roll back correctly, but pinning them at the source — as `animation_handler` and
`camera_handler` already do — would be the tidier fix. Happy to open that
separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batch operation rollback to undo exactly the actions committed during the batch.
  * Preserved existing undo history from before the batch.
  * Correctly handles actions committed by operations that return errors or do not report undo details.
  * Avoids rollback when no changes were actually committed.

* **Tests**
  * Added coverage for rollback order, rollback depth, unreported changes, error responses, and no-op batches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->