### PR TITLE
fix(path_validator): normalize paths the way the engine does before splitting

### DIFF
--- a/plugin/addons/godot_ai/utils/path_validator.gd
+++ b/plugin/addons/godot_ai/utils/path_validator.gd
@@ -160,7 +160,31 @@ static func _reject_sensitive_write(path: String) -> String:
 		return "Refusing to write res://override.cfg (startup config override)"
 	# Reject the `.godot/` editor-metadata dir at any depth. Split drops empty
 	# segments so a trailing slash can't hide a segment from the check.
-	var segments := path.trim_prefix("res://").split("/", false)
+	#
+	# Normalize the way the engine does before splitting. `FileAccess::fix_path`
+	# rewrites `\` to `/` on EVERY platform, and `FileAccessWindows` additionally
+	# runs `simplify_path()` -- so the writer resolves separators, `//`, and `.`
+	# segments that a raw `split("/")` here would not. Two consequences:
+	#
+	#   - `res://.godot\uid_cache.bin` used to collapse to one fused segment
+	#     and match neither this check nor the loaded-plugin one below, while the
+	#     write itself still landed in `.godot/`.
+	#   - a `.` segment shifts the *anchored* plugin-tree check below, so
+	#     `res://./addons/godot_ai/plugin.gd` slipped past it even once the
+	#     separators were normalized.
+	#
+	# `simplify_path()` closes both in one call, and matching the engine own
+	# normalizer is what keeps validator and writer agreeing. `..` never reaches
+	# here -- `_confine_under` refuses it first -- so its folding is inert.
+	#
+	# Because the engine normalizes backslashes on Linux too, a POSIX file
+	# literally named `addons\godot_ai\x.gd` is not addressable through
+	# `res://` at all, so normalizing costs no legitimate write.
+	#
+	# The `get_file()` clauses above need no such fix: `String.get_file()` splits
+	# on both separators already, which is why the manifest and override.cfg
+	# guards were never bypassable this way.
+	var segments := path.replace("\\", "/").simplify_path().trim_prefix("res://").split("/", false)
 	for segment in segments:
 		if segment.to_lower() == ".godot":
 			return "Refusing to write under res://.godot/ (editor metadata)"

--- a/plugin/addons/godot_ai/utils/path_validator.gd
+++ b/plugin/addons/godot_ai/utils/path_validator.gd
@@ -153,18 +153,11 @@ static func _confine_under(path: String, root: String, label: String) -> String:
 ## source-controlled). The blocked set is the startup-execution surface only:
 ## the manifest, its `override.cfg` shadow, and the `.godot/` cache dir.
 static func _reject_sensitive_write(path: String) -> String:
-	var file_lower := path.get_file().to_lower()
-	if file_lower == "project.godot":
-		return "Refusing to write res://project.godot (project manifest)"
-	if file_lower == "override.cfg":
-		return "Refusing to write res://override.cfg (startup config override)"
-	# Reject the `.godot/` editor-metadata dir at any depth. Split drops empty
-	# segments so a trailing slash can't hide a segment from the check.
-	#
-	# Normalize the way the engine does before splitting. `FileAccess::fix_path`
-	# rewrites `\` to `/` on EVERY platform, and `FileAccessWindows` additionally
-	# runs `simplify_path()` -- so the writer resolves separators, `//`, and `.`
-	# segments that a raw `split("/")` here would not. Two consequences:
+	# Normalize once, then reuse for filename and segment checks. The writer
+	# (`FileAccess::fix_path` / `FileAccessWindows`) folds `\`, `//`, and `.`
+	# the same way, so `res://project.godot/.` and `res://override.cfg/.` must
+	# not slip past `get_file()` as a trailing `.` while still opening the
+	# protected file.
 	#
 	#   - `res://.godot\uid_cache.bin` used to collapse to one fused segment
 	#     and match neither this check nor the loaded-plugin one below, while the
@@ -173,18 +166,19 @@ static func _reject_sensitive_write(path: String) -> String:
 	#     `res://./addons/godot_ai/plugin.gd` slipped past it even once the
 	#     separators were normalized.
 	#
-	# `simplify_path()` closes both in one call, and matching the engine own
-	# normalizer is what keeps validator and writer agreeing. `..` never reaches
-	# here -- `_confine_under` refuses it first -- so its folding is inert.
-	#
-	# Because the engine normalizes backslashes on Linux too, a POSIX file
-	# literally named `addons\godot_ai\x.gd` is not addressable through
-	# `res://` at all, so normalizing costs no legitimate write.
-	#
-	# The `get_file()` clauses above need no such fix: `String.get_file()` splits
-	# on both separators already, which is why the manifest and override.cfg
-	# guards were never bypassable this way.
-	var segments := path.replace("\\", "/").simplify_path().trim_prefix("res://").split("/", false)
+	# `..` never reaches here -- `_confine_under` refuses it first -- so its
+	# folding is inert. Because the engine normalizes backslashes on Linux too,
+	# a POSIX file literally named `addons\godot_ai\x.gd` is not addressable
+	# through `res://` at all, so normalizing costs no legitimate write.
+	var normalized := path.replace("\\", "/").simplify_path()
+	var file_lower := normalized.get_file().to_lower()
+	if file_lower == "project.godot":
+		return "Refusing to write res://project.godot (project manifest)"
+	if file_lower == "override.cfg":
+		return "Refusing to write res://override.cfg (startup config override)"
+	# Reject the `.godot/` editor-metadata dir at any depth. Split drops empty
+	# segments so a trailing slash can't hide a segment from the check.
+	var segments := normalized.trim_prefix("res://").split("/", false)
 	for segment in segments:
 		if segment.to_lower() == ".godot":
 			return "Refusing to write under res://.godot/ (editor metadata)"

--- a/test_project/tests/test_path_validator.gd
+++ b/test_project/tests/test_path_validator.gd
@@ -227,13 +227,28 @@ func test_write_rejects_dot_segments_into_loaded_plugin_tree() -> void:
 
 
 func test_write_rejects_backslash_before_the_project_manifest() -> void:
-	## Load-bearing for the fix's scope: the manifest and override.cfg clauses
-	## are filename-based via `String.get_file()`, which already splits on both
-	## separators — which is why they needed no change here. If that ever stops
-	## being true, this fails rather than the gap going unnoticed.
+	## Manifest and override.cfg checks run on the normalized path, so a
+	## backslash before the filename cannot hide it from get_file().
 	assert_false(McpPathValidator.validate_resource_path(
 		"res://sub\\project.godot", true).is_empty(),
-		"get_file() is separator-aware, so the manifest guard covers backslashes")
+		"normalization plus get_file() must still refuse the manifest")
+
+
+func test_write_rejects_dot_suffixed_protected_files() -> void:
+	## `res://project.godot/.` has get_file() == "." until simplify_path()
+	## folds the trailing segment. The writer still opens project.godot.
+	assert_false(McpPathValidator.validate_resource_path(
+		"res://project.godot/.", true).is_empty(),
+		"a trailing /. must not bypass the project.godot guard")
+	assert_false(McpPathValidator.validate_resource_path(
+		"res://override.cfg/.", true).is_empty(),
+		"a trailing /. must not bypass the override.cfg guard")
+	assert_false(McpPathValidator.validate_resource_path(
+		"res://project.godot/./", true).is_empty(),
+		"a trailing /./ must not bypass the project.godot guard")
+	assert_false(McpPathValidator.validate_resource_path(
+		"res://override.cfg\\.", true).is_empty(),
+		"a trailing \\. must not bypass the override.cfg guard")
 
 
 func test_write_still_allows_backslash_paths_outside_the_blocklist() -> void:

--- a/test_project/tests/test_path_validator.gd
+++ b/test_project/tests/test_path_validator.gd
@@ -173,6 +173,78 @@ func test_write_still_rejects_traversal() -> void:
 	assert_false(McpPathValidator.validate_resource_path("res://../etc/passwd", true).is_empty())
 
 
+# ----- write blocklist: separator normalization -----
+#
+# The segment-based clauses split on "/" only. A Windows-style separator would
+# fuse the path into a single segment that matches neither, while Godot's own
+# FileAccess resolves the backslash and performs the write — so the blocklist
+# has to normalize before splitting.
+
+func test_write_rejects_backslash_godot_metadata_dir() -> void:
+	var err := McpPathValidator.validate_resource_path("res://.godot\\uid_cache.bin", true)
+	assert_false(err.is_empty(),
+		"a backslash-separated path into res://.godot/ must be refused for write "
+		+ "just like the forward-slash form")
+	assert_contains(err, ".godot")
+
+
+func test_write_rejects_backslash_loaded_plugin_tree() -> void:
+	var err := McpPathValidator.validate_resource_path("res://addons\\godot_ai\\plugin.gd", true)
+	assert_false(err.is_empty(),
+		"a backslash-separated path into the loaded plugin tree must be refused "
+		+ "for write — overwriting a live .gd can crash the editor")
+	assert_contains(err, "addons/godot_ai")
+
+
+func test_write_rejects_mixed_separators_into_blocked_dirs() -> void:
+	## Real callers on Windows produce mixed forms; both halves of the split
+	## must survive normalization.
+	assert_false(McpPathValidator.validate_resource_path(
+		"res://addons/godot_ai\\utils\\path_validator.gd", true).is_empty(),
+		"a mixed-separator path into the plugin tree must be refused")
+	assert_false(McpPathValidator.validate_resource_path(
+		"res://sub\\.godot\\x.bin", true).is_empty(),
+		"a mixed-separator path into a nested .godot/ must be refused")
+
+
+func test_write_rejects_dot_segments_into_loaded_plugin_tree() -> void:
+	## The plugin-tree clause is ANCHORED on segments[0]/segments[1], so a `.`
+	## segment shifts it out of position. `split("/", false)` only drops EMPTY
+	## segments — `.` survives as a real one. The engine folds it away before
+	## writing, so every form below reaches the live plugin script.
+	assert_false(McpPathValidator.validate_resource_path(
+		"res://./addons/godot_ai/plugin.gd", true).is_empty(),
+		"a leading ./ must not shift the plugin-tree check out of position")
+	assert_false(McpPathValidator.validate_resource_path(
+		"res://addons/./godot_ai/plugin.gd", true).is_empty(),
+		"an interior ./ must not shift the plugin-tree check out of position")
+	assert_false(McpPathValidator.validate_resource_path(
+		"res://.\\addons\\godot_ai\\plugin.gd", true).is_empty(),
+		"the ./ and backslash bypasses must not compose into a hole")
+	assert_false(McpPathValidator.validate_resource_path(
+		"res://addons//godot_ai/plugin.gd", true).is_empty(),
+		"a doubled separator must not shift the check either")
+
+
+func test_write_rejects_backslash_before_the_project_manifest() -> void:
+	## Load-bearing for the fix's scope: the manifest and override.cfg clauses
+	## are filename-based via `String.get_file()`, which already splits on both
+	## separators — which is why they needed no change here. If that ever stops
+	## being true, this fails rather than the gap going unnoticed.
+	assert_false(McpPathValidator.validate_resource_path(
+		"res://sub\\project.godot", true).is_empty(),
+		"get_file() is separator-aware, so the manifest guard covers backslashes")
+
+
+func test_write_still_allows_backslash_paths_outside_the_blocklist() -> void:
+	## Normalization must not turn every backslash path into a rejection —
+	## only the blocked prefixes are affected.
+	assert_eq(McpPathValidator.validate_resource_path("res://scenes\\level.tscn", true), "")
+	assert_eq(McpPathValidator.validate_resource_path("res://addons\\other_addon\\x.gd", true), "")
+
+
+# ----- write blocklist: startup surface and the loaded plugin tree -----
+
 func test_write_rejects_override_cfg() -> void:
 	## override.cfg is applied over project.godot at startup — same takeover
 	## surface as the manifest, so writes must be refused too.


### PR DESCRIPTION
Fixes #905.

### The bug

`_reject_sensitive_write` split segments with
`path.trim_prefix("res://").split("/", false)` — forward slash only, and it drops
only *empty* segments. Two of its four clauses are segment-based, and both were
addressable around:

| path | segments | result |
|---|---|---|
| `res://.godot\uid_cache.bin` | one fused segment | **allowed** |
| `res://./addons/godot_ai/plugin.gd` | `.` shifts the anchor | **allowed** |
| `res://.\addons\godot_ai\plugin.gd` | both at once | **allowed** |

The engine resolves every one of those before writing — `FileAccess::fix_path`
rewrites `\` to `/` on all platforms, and `FileAccessWindows` additionally runs
`simplify_path()`. So the write landed in `.godot/` or over a live plugin
script, while the validator saw a path matching nothing.

### The fix

`simplify_path()` — the engine's own normalizer — closes separators, `//`, and
`.` segments in one call, so validator and writer finally agree.

I first fixed only the separator. Review caught that the `.`-segment variant
stayed open **and composes with the backslash form**, so that patch's own
proof-of-concept was defeated by prepending two characters. That third row above
is the case that made this a `simplify_path()` change rather than a `replace()`.

`..` never reaches this clause — `_confine_under` refuses it first — so its
folding is inert. `update_reload_runner.gd::_is_safe_zip_addon_file` already
treats `.` segments as hostile; this brings the write blocklist in line.

### Scope

The `get_file()` clauses need no change: `String.get_file()` splits on **both**
separators, which is why the manifest and `override.cfg` guards were never
bypassable this way. That is load-bearing for this PR's scope, so a test now
pins it rather than leaving it as a claim in a comment.

Normalizing cannot newly *allow* anything — it only splits segments further, and
a segment that is exactly `.godot` or `godot_ai` contains no separator. It costs
no legitimate write either: the engine rewrites backslashes on Linux too, so a
POSIX file literally named `addons\godot_ai\x.gd` was never addressable through
`res://` to begin with.

### Verification

Seven tests, mutation-checked against a live Godot 4.7.2 editor:

| mutation | killed |
|---|---|
| original upstream code | 3 |
| separator-only (my pre-review version) | `test_write_rejects_dot_segments_into_loaded_plugin_tree` |

A negative test keeps the plausible over-fix — reject any path containing a
backslash — honest.

Full GDScript suite: **2303 passed, 0 failed**.

### Known limitations, unchanged by this PR

The blocklist is lexical, so on Windows/NTFS an 8.3 alias (`GODOT~1`) or an ADS
suffix (`::$DATA`), and on any platform a symlink/junction inside the project
pointing at `addons/godot_ai`, still route around it. Same class as the symlink
caveat already documented on `_confine_under`. Happy to extend that docblock or
open a separate issue if you'd like it tracked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection for sensitive project and plugin files when paths use backslashes, duplicate separators, or dot segments.
  * Prevented path-format variations from bypassing write restrictions.
  * Preserved access to valid, non-protected paths.

* **Tests**
  * Added regression coverage for mixed path separators, normalized paths, protected files, and allowed paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->