### PR TITLE
fix(websocket): bound the send, and say which leg timed out

### DIFF
--- a/src/godot_ai/transport/websocket.py
+++ b/src/godot_ai/transport/websocket.py
@@ -542,10 +542,37 @@ class GodotWebSocketServer:
         ## pops on the happy path, so this is a no-op there; on `ws.send`
         ## raise / TimeoutError / cancellation it prevents Futures leaking
         ## into _pending forever.
+        ## The deadline covers the SEND as well as the response wait. When the
+        ## transport is write-paused by TCP backpressure — an editor that has
+        ## stopped reading its socket — `ws.send` blocks for the whole stall, and
+        ## with the timeout wrapped around the future alone it never even
+        ## started: the tool call hung unbounded instead of failing with an
+        ## actionable message. Nothing else bounds it; websockets' own keepalive
+        ## ping queues behind the same paused drain.
+        ##
+        ## The two legs get distinct messages, because they mean opposite things
+        ## to a caller deciding whether to retry. `websockets` hands the COMPLETE
+        ## frame to the transport before awaiting `drain()`, so a send-leg
+        ## timeout leaves a well-formed request buffered — the editor executes it
+        ## in full once it drains. Reporting that as a plain timeout invites a
+        ## retry that duplicates the mutation. A response-leg timeout means the
+        ## request was delivered and the reply did not arrive in budget, which is
+        ## the ordinary case. Conflating the two is the same failure the
+        ## disconnect-vs-timeout split below exists to prevent.
+        sent = False
         try:
-            await ws.send(request.model_dump_json())
-            return await asyncio.wait_for(future, timeout=timeout)
+            async with asyncio.timeout(timeout):
+                await ws.send(request.model_dump_json())
+                sent = True
+                return await future
         except asyncio.TimeoutError:
+            if not sent:
+                raise TimeoutError(
+                    f"Command {command} timed out after {timeout}s on session {session_id} "
+                    "before the request left the socket (transport write-paused). "
+                    "It may still execute when the editor resumes reading — do not "
+                    "retry a mutating command without checking editor state first."
+                )
             raise TimeoutError(
                 f"Command {command} timed out after {timeout}s on session {session_id}"
             )

--- a/tests/unit/test_ws_send_deadline.py
+++ b/tests/unit/test_ws_send_deadline.py
@@ -1,0 +1,210 @@
+"""``send_command``'s timeout budget must cover the outbound write, not just the wait.
+
+``GodotWebSocketServer.send_command`` does ``await ws.send(...)`` and only then
+``asyncio.wait_for(future, timeout=timeout)``. If the transport is write-paused
+(TCP backpressure from a stalled editor, a full send buffer), the ``send`` itself
+never returns, so the per-command deadline never starts counting and the MCP tool
+call hangs for as long as the editor is wedged.
+
+Both tests below assert the acceptance criterion — ``send_command`` raises its own
+``TimeoutError`` within roughly ``timeout`` seconds even when the write never
+completes — rather than characterising today's behaviour.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import time
+
+import pytest
+
+from godot_ai.sessions.registry import SessionRegistry
+from godot_ai.transport.websocket import GodotWebSocketServer
+
+## Short command budget, generous backstop. The gap between them is what makes
+## "the deadline fired" distinguishable from "the suite rescued a hang".
+_COMMAND_TIMEOUT_S = 0.2
+_BACKSTOP_S = 2.0
+_BUDGET_CEILING_S = 1.0
+
+
+class StalledConnection:
+    """Stand-in for ``ServerConnection`` whose ``send`` never completes.
+
+    Models a write-paused transport: the coroutine is entered (so the payload
+    was handed to the transport) and then parks forever on an Event nothing
+    sets. ``send_command`` only ever touches ``.send`` on the connection it
+    pulls out of ``_connections``, so nothing else needs faking.
+    """
+
+    def __init__(self) -> None:
+        self.send_entered = asyncio.Event()
+        self._never_set = asyncio.Event()
+
+    async def send(self, _payload: str) -> None:
+        self.send_entered.set()
+        await self._never_set.wait()
+
+
+def _server_with_stalled_write(session_id: str) -> tuple[GodotWebSocketServer, StalledConnection]:
+    """Construct the server the way ``tests/conftest.py::harness`` does — registry
+    plus port — but never call ``start()``: this test is about ``send_command``'s
+    deadline, not about binding a socket. The connection is injected into
+    ``_connections`` directly, the same private-attribute reach that
+    ``test_websocket.py::TestPendingFutureCleanup`` uses to force a send failure.
+    """
+    server = GodotWebSocketServer(SessionRegistry(), port=19998)
+    ws = StalledConnection()
+    server._connections[session_id] = ws  # type: ignore[assignment]
+    return server, ws
+
+
+async def _settle(coro) -> tuple[BaseException | None, float]:
+    """Run ``coro`` under a backstop and return ``(exception, elapsed)``.
+
+    The backstop must NOT be an ``asyncio.wait_for``/``pytest.raises(TimeoutError)``
+    pair: since 3.11 ``asyncio.TimeoutError`` *is* ``TimeoutError``, so the rescue
+    timeout would satisfy the assertion and the test would go green on exactly the
+    hang it exists to catch. Instead a hang is turned into an explicit failure and
+    the raised exception is handed back for inspection.
+    """
+    task = asyncio.create_task(coro)
+    started = time.monotonic()
+    done, _pending = await asyncio.wait({task}, timeout=_BACKSTOP_S)
+    elapsed = time.monotonic() - started
+    if not done:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+        pytest.fail(
+            f"send_command never returned: still running {elapsed:.2f}s after a "
+            f"{_COMMAND_TIMEOUT_S}s budget, because the timeout wraps only the "
+            "response wait and not the `await ws.send(...)` before it"
+        )
+    return task.exception(), elapsed
+
+
+async def test_send_command_deadline_covers_a_stalled_write() -> None:
+    session_id = "stalled-writer"
+    server, ws = _server_with_stalled_write(session_id)
+
+    exc, elapsed = await _settle(
+        server.send_command(
+            session_id=session_id,
+            command="save_scene",
+            timeout=_COMMAND_TIMEOUT_S,
+        )
+    )
+
+    assert ws.send_entered.is_set(), "the fake never saw the write — test wired up wrong"
+    assert isinstance(exc, TimeoutError), (
+        f"expected send_command to raise TimeoutError on a write-paused transport, got {exc!r}"
+    )
+    assert "timed out after" in str(exc), (
+        f"expected send_command's own timeout message, got {str(exc)!r}"
+    )
+    assert elapsed < _BUDGET_CEILING_S, (
+        f"deadline fired {elapsed:.2f}s in, well past the {_COMMAND_TIMEOUT_S}s budget"
+    )
+
+
+async def test_stalled_write_timeout_pops_the_pending_entry() -> None:
+    ## Same contract as TestPendingFutureCleanup in tests/integration/test_websocket.py:
+    ## however send_command exits, the request_id must not be left in _pending.
+    session_id = "stalled-writer-leak"
+    server, _ws = _server_with_stalled_write(session_id)
+
+    exc, _elapsed = await _settle(
+        server.send_command(
+            session_id=session_id,
+            command="save_scene",
+            timeout=_COMMAND_TIMEOUT_S,
+        )
+    )
+
+    assert isinstance(exc, TimeoutError), f"expected a bounded TimeoutError, got {exc!r}"
+    assert server._pending == {}, "a write-stall timeout must not leak _pending entries"
+
+
+async def test_live_connection_write_stall_is_bounded(harness) -> None:
+    ## The fake above stands in for ServerConnection; this one pins the same
+    ## contract against a real registered connection, monkeypatching only `send`
+    ## exactly as test_websocket.py::test_send_failure_pops_pending_entry does
+    ## (a raising send there, a never-returning one here).
+    session_id = "stalled-live"
+    plugin = await harness.connect_plugin(session_id=session_id)
+    ws = harness.server._connections[session_id]
+    parked = asyncio.Event()
+
+    async def stalling_send(_payload: str) -> None:
+        await parked.wait()
+
+    ws.send = stalling_send  # type: ignore[assignment]
+
+    try:
+        exc, elapsed = await _settle(
+            harness.server.send_command(
+                session_id=session_id,
+                command="save_scene",
+                timeout=_COMMAND_TIMEOUT_S,
+            )
+        )
+        assert isinstance(exc, TimeoutError), (
+            f"expected TimeoutError from a write-paused live connection, got {exc!r}"
+        )
+        assert elapsed < _BUDGET_CEILING_S, (
+            f"deadline fired {elapsed:.2f}s in, well past the {_COMMAND_TIMEOUT_S}s budget"
+        )
+    finally:
+        parked.set()
+        await plugin.close()
+
+
+class SilentConnection:
+    """Accepts the write, then never answers — the response-leg stall.
+
+    The opposite of ``StalledConnection``: the request genuinely reaches the
+    editor, so a timeout here carries no risk of the command executing later.
+    """
+
+    async def send(self, _payload: str) -> None:
+        return None
+
+
+async def test_send_leg_and_response_leg_timeouts_are_distinguishable() -> None:
+    """A stalled write must not read like an unanswered request.
+
+    `websockets` hands the COMPLETE frame to the transport before awaiting
+    `drain()`, so a send-leg timeout leaves a well-formed request buffered that
+    the editor executes in full once it drains. An agent that retries on that
+    duplicates the mutation — `node_create` twice, `script_create` twice. The
+    response leg means the request was delivered and the reply was late, which is
+    the ordinary retryable case. The two must not share a message.
+    """
+    send_leg_id = "write-paused"
+    server, _ws = _server_with_stalled_write(send_leg_id)
+    send_exc, _ = await _settle(
+        server.send_command(
+            session_id=send_leg_id, command="node_create", timeout=_COMMAND_TIMEOUT_S
+        )
+    )
+    assert isinstance(send_exc, TimeoutError)
+    assert "before the request left the socket" in str(send_exc), (
+        "a send-leg timeout must warn that the command may still execute, so an "
+        f"agent does not retry an already-queued mutation. Got: {str(send_exc)!r}"
+    )
+
+    response_leg_id = "silent-editor"
+    server2 = GodotWebSocketServer(SessionRegistry(), port=19997)
+    server2._connections[response_leg_id] = SilentConnection()  # type: ignore[assignment]
+    resp_exc, _ = await _settle(
+        server2.send_command(
+            session_id=response_leg_id, command="node_create", timeout=_COMMAND_TIMEOUT_S
+        )
+    )
+    assert isinstance(resp_exc, TimeoutError)
+    assert "before the request left the socket" not in str(resp_exc), (
+        "a response-leg timeout means the request WAS delivered; it must not carry "
+        f"the send-leg warning. Got: {str(resp_exc)!r}"
+    )


### PR DESCRIPTION
Fixes #910.

### The bug

```python
await ws.send(request.model_dump_json())
return await asyncio.wait_for(future, timeout=timeout)
```

The deadline wrapped only the response wait. When the transport is write-paused
by TCP backpressure — an editor that has stopped reading its socket — `ws.send`
blocks for the whole stall and the timeout **never starts**. Nothing else bounds
it: websockets' own keepalive ping queues behind the same `drain()`, and the
disconnect teardown only runs once the connection actually drops. The tool call
hung indefinitely with no error.

Reproduced against a raw socket peer that completes the handshake and stops
reading: `send()` blocks with 60 KB buffered and `paused=True`.

### The fix, and the part that matters

Wrapping both statements in one `asyncio.timeout` bounds it. That leg is
low-risk: on 3.12+ `wait_for` *is* `async with timeout(...)` internally, so the
response path is the same machinery; `asyncio.TimeoutError is TimeoutError` on
3.11+ so the existing `except` still catches it; and caller cancellation still
surfaces as `CancelledError` rather than being converted to a timeout.

The **distinct messages per leg** are the correctness change. `websockets` hands
the *complete* frame to the transport before awaiting `drain()`, so a send-leg
timeout leaves a well-formed request buffered — the editor executes it in full
once it drains. Verified: after a cancelled send, three more commands, then
letting the peer resume, all 8 frames arrived well-formed and in order, none
lost. So "timed out" on the send leg is actively misleading: a caller retries,
and for `node_create` / `script_create` / `filesystem_write_text` that duplicates
the mutation.

The send leg now says the command may still execute. The response leg keeps its
original wording, because there the request *was* delivered and only the reply
was late. This mirrors the disconnect-vs-timeout split already documented in this
file, which exists to stop exactly that conflation degrading circuit-breaker
diagnostics.

### Verification

| mutation | result |
|---|---|
| revert to `wait_for(future)` only | all 3 stall tests fail — `still running 2.01s after a 0.2s budget` |
| collapse the two messages into one | the leg-distinction test fails |

Full suite **1807 passed, 19 skipped**; `ruff` clean.

Note: `docs/verification.md` also wants a live-editor `test_run` for a change in
this hot path. This branch is Python-only so the GDScript suite is unaffected,
but I'm happy to run it against a live editor before you merge if you'd prefer.

### Deliberately not in this PR

- **Aborting the transport after a send-leg timeout.** It's what websockets
  recommends, but an unconditional abort would kill a merely-slow editor — a
  large `script_create` to a busy main thread can legitimately exceed the budget
  inside `drain()`. It wants a consecutive-failure threshold, and this distinct
  error is the prerequisite for building one.
- **`_handle_connection`'s handshake-ack send** (unbounded, and it runs *after*
  the session is registered and routable) and the two reject-path `ws.close()`
  calls (which drain before the close timeout applies). Same bug class, one layer
  up. Say the word and I'll open an issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Command timeouts now cover both sending the request and waiting for its response.
  * Prevented commands from hanging when the connection cannot write.
  * Improved timeout messages to distinguish unsent commands from commands already sent.
  * Ensured timed-out requests are cleaned up properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->