### PR TITLE
test: fail self-update CI when GODOT_BIN is set but missing

### DIFF
--- a/tests/integration/_self_update_fixture.py
+++ b/tests/integration/_self_update_fixture.py
@@ -36,16 +36,82 @@ def load_smoke_script() -> ModuleType:
     return module
 
 
+def _path_is_file(path: Path) -> bool:
+    try:
+        return path.is_file()
+    except OSError:
+        return False
+
+
+def _windows_godot_fallbacks(name: str) -> Path | None:
+    """Resolve ``GODOT_BIN=godot`` on Windows CI.
+
+    chickensoft ``setup-godot`` adds ``~/bin`` to PATH and hard-links the
+    real ``Godot_v*_win64.exe`` as an *extensionless* ``godot`` alias, then
+    exports ``GODOT`` / ``GODOT4`` to that path. Git Bash can invoke
+    ``godot``; ``shutil.which("godot")`` does not (PATHEXT is ``.exe``-only).
+    Skipping would hide a missing engine (#917); failing without this
+    lookup fails CI even when the engine is present.
+    """
+    names = [name]
+    if not name.lower().endswith(".exe"):
+        names.append(f"{name}.exe")
+
+    for candidate in names:
+        found = shutil.which(candidate)
+        if found is not None:
+            path = Path(found)
+            if _path_is_file(path):
+                return path
+
+    # shutil.which skips extensionless files; walk PATH for the alias.
+    for directory in os.environ.get("PATH", "").split(os.pathsep):
+        if not directory:
+            continue
+        folder = Path(directory)
+        for candidate in names:
+            hit = folder / candidate
+            if _path_is_file(hit):
+                return hit
+
+    if name.lower() not in {"godot", "godot.exe"}:
+        return None
+
+    for key in ("GODOT", "GODOT4"):
+        raw = os.environ.get(key, "")
+        if not raw:
+            continue
+        env_path = Path(raw)
+        if _path_is_file(env_path):
+            return env_path
+        exe = env_path.parent / "godot.exe"
+        if _path_is_file(exe):
+            return exe
+
+    home = Path.home()
+    for hit in (home / "bin" / "godot.exe", home / "bin" / "godot"):
+        if _path_is_file(hit):
+            return hit
+    install = home / "godot"
+    if install.is_dir():
+        matches = sorted(install.rglob("Godot_v*.exe"))
+        if matches:
+            return matches[0]
+    return None
+
+
 def godot_bin_or_skip() -> str:
     godot_bin = os.environ.get("GODOT_BIN", "")
     if not godot_bin:
         pytest.skip("GODOT_BIN is not set; skipping Godot self-update integration test")
     candidate = Path(godot_bin).expanduser()
     if candidate.exists() or candidate.is_absolute() or "/" in godot_bin or "\\" in godot_bin:
-        resolved = candidate
+        resolved = candidate if candidate.exists() else None
     else:
         found = shutil.which(godot_bin)
         resolved = Path(found) if found is not None else None
+        if (resolved is None or not resolved.exists()) and os.name == "nt":
+            resolved = _windows_godot_fallbacks(godot_bin)
     if resolved is None or not resolved.exists():
         # CI sets GODOT_BIN=godot. Skipping here would make pytest exit 0
         # with zero tests run and hide a missing engine (#917).

--- a/tests/integration/_self_update_fixture.py
+++ b/tests/integration/_self_update_fixture.py
@@ -43,6 +43,16 @@ def _path_is_file(path: Path) -> bool:
         return False
 
 
+def _is_windows() -> bool:
+    """Host check isolated so tests can fake Windows without patching ``os.name``.
+
+    ``os.name`` is the real ``os`` module attribute. Patching it on Linux makes
+    ``pathlib.Path`` construct ``WindowsPath`` and crashes the pytest session
+    (``NotImplementedError`` during report/cache writes).
+    """
+    return os.name == "nt"
+
+
 def _windows_godot_fallbacks(name: str) -> Path | None:
     """Resolve ``GODOT_BIN=godot`` on Windows CI.
 
@@ -110,7 +120,7 @@ def godot_bin_or_skip() -> str:
     else:
         found = shutil.which(godot_bin)
         resolved = Path(found) if found is not None else None
-        if (resolved is None or not resolved.exists()) and os.name == "nt":
+        if (resolved is None or not resolved.exists()) and _is_windows():
             resolved = _windows_godot_fallbacks(godot_bin)
     if resolved is None or not resolved.exists():
         # CI sets GODOT_BIN=godot. Skipping here would make pytest exit 0

--- a/tests/integration/_self_update_fixture.py
+++ b/tests/integration/_self_update_fixture.py
@@ -47,7 +47,9 @@ def godot_bin_or_skip() -> str:
         found = shutil.which(godot_bin)
         resolved = Path(found) if found is not None else None
     if resolved is None or not resolved.exists():
-        pytest.skip(f"GODOT_BIN does not resolve to an executable: {godot_bin}")
+        # CI sets GODOT_BIN=godot. Skipping here would make pytest exit 0
+        # with zero tests run and hide a missing engine (#917).
+        pytest.fail(f"GODOT_BIN does not resolve to an executable: {godot_bin}")
     return str(resolved)
 
 

--- a/tests/integration/_self_update_fixture.py
+++ b/tests/integration/_self_update_fixture.py
@@ -115,14 +115,14 @@ def godot_bin_or_skip() -> str:
     if not godot_bin:
         pytest.skip("GODOT_BIN is not set; skipping Godot self-update integration test")
     candidate = Path(godot_bin).expanduser()
-    if candidate.exists() or candidate.is_absolute() or "/" in godot_bin or "\\" in godot_bin:
-        resolved = candidate if candidate.exists() else None
+    if _path_is_file(candidate) or candidate.is_absolute() or "/" in godot_bin or "\\" in godot_bin:
+        resolved = candidate if _path_is_file(candidate) else None
     else:
         found = shutil.which(godot_bin)
         resolved = Path(found) if found is not None else None
-        if (resolved is None or not resolved.exists()) and _is_windows():
+        if (resolved is None or not _path_is_file(resolved)) and _is_windows():
             resolved = _windows_godot_fallbacks(godot_bin)
-    if resolved is None or not resolved.exists():
+    if resolved is None or not _path_is_file(resolved):
         # CI sets GODOT_BIN=godot. Skipping here would make pytest exit 0
         # with zero tests run and hide a missing engine (#917).
         pytest.fail(f"GODOT_BIN does not resolve to an executable: {godot_bin}")

--- a/tests/unit/test_self_update_godot_bin.py
+++ b/tests/unit/test_self_update_godot_bin.py
@@ -1,0 +1,30 @@
+"""Unit tests for GODOT_BIN resolution in the self-update fixture.
+
+Issue #917: when CI sets GODOT_BIN to a name that does not resolve,
+pytest.skip() made the whole step exit 0 with zero tests executed.
+Unset still skips so a local run without an engine stays optional.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.integration._self_update_fixture import godot_bin_or_skip
+
+
+def test_godot_bin_unset_skips(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GODOT_BIN", raising=False)
+
+    with pytest.raises(pytest.skip.Exception, match="GODOT_BIN is not set"):
+        godot_bin_or_skip()
+
+
+def test_godot_bin_set_but_unresolvable_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GODOT_BIN", "godot-ai-missing-binary-917")
+    monkeypatch.setattr(
+        "tests.integration._self_update_fixture.shutil.which",
+        lambda _name: None,
+    )
+
+    with pytest.raises(pytest.fail.Exception, match="does not resolve"):
+        godot_bin_or_skip()

--- a/tests/unit/test_self_update_godot_bin.py
+++ b/tests/unit/test_self_update_godot_bin.py
@@ -28,6 +28,21 @@ def test_godot_bin_unset_skips(monkeypatch: pytest.MonkeyPatch) -> None:
         godot_bin_or_skip()
 
 
+def test_godot_bin_directory_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("GODOT_BIN", str(tmp_path))
+    monkeypatch.delenv("GODOT", raising=False)
+    monkeypatch.delenv("GODOT4", raising=False)
+    monkeypatch.setattr(
+        "tests.integration._self_update_fixture.shutil.which",
+        lambda _name: None,
+    )
+
+    with pytest.raises(pytest.fail.Exception, match="does not resolve"):
+        godot_bin_or_skip()
+
+
 def test_godot_bin_set_but_unresolvable_fails(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GODOT_BIN", "godot-ai-missing-binary-917")
     monkeypatch.delenv("GODOT", raising=False)

--- a/tests/unit/test_self_update_godot_bin.py
+++ b/tests/unit/test_self_update_godot_bin.py
@@ -116,7 +116,12 @@ def test_godot_bin_uses_windows_fallbacks_when_which_misses(
     exe = tmp_path / "godot.exe"
     exe.write_bytes(b"fake")
     monkeypatch.setenv("GODOT_BIN", "godot")
-    monkeypatch.setattr("tests.integration._self_update_fixture.os.name", "nt")
+    # Patch the local helper, not os.name — that aliases the real os module
+    # and makes pathlib instantiate WindowsPath on Linux CI.
+    monkeypatch.setattr(
+        "tests.integration._self_update_fixture._is_windows",
+        lambda: True,
+    )
     monkeypatch.setattr(
         "tests.integration._self_update_fixture.shutil.which",
         lambda name: str(exe) if name == "godot.exe" else None,

--- a/tests/unit/test_self_update_godot_bin.py
+++ b/tests/unit/test_self_update_godot_bin.py
@@ -3,13 +3,22 @@
 Issue #917: when CI sets GODOT_BIN to a name that does not resolve,
 pytest.skip() made the whole step exit 0 with zero tests executed.
 Unset still skips so a local run without an engine stays optional.
+
+On Windows, setup-godot's ``godot`` alias is extensionless, so
+``shutil.which("godot")`` misses an engine that later bash steps can
+invoke. Resolution must find ``godot.exe`` / the setup-godot path.
 """
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
-from tests.integration._self_update_fixture import godot_bin_or_skip
+from tests.integration._self_update_fixture import (
+    _windows_godot_fallbacks,
+    godot_bin_or_skip,
+)
 
 
 def test_godot_bin_unset_skips(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -21,6 +30,8 @@ def test_godot_bin_unset_skips(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_godot_bin_set_but_unresolvable_fails(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GODOT_BIN", "godot-ai-missing-binary-917")
+    monkeypatch.delenv("GODOT", raising=False)
+    monkeypatch.delenv("GODOT4", raising=False)
     monkeypatch.setattr(
         "tests.integration._self_update_fixture.shutil.which",
         lambda _name: None,
@@ -28,3 +39,89 @@ def test_godot_bin_set_but_unresolvable_fails(monkeypatch: pytest.MonkeyPatch) -
 
     with pytest.raises(pytest.fail.Exception, match="does not resolve"):
         godot_bin_or_skip()
+
+
+def test_windows_fallback_resolves_godot_exe(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    exe = tmp_path / "godot.exe"
+    exe.write_bytes(b"fake")
+    monkeypatch.setattr(
+        "tests.integration._self_update_fixture.shutil.which",
+        lambda name: str(exe) if name == "godot.exe" else None,
+    )
+    monkeypatch.delenv("GODOT", raising=False)
+    monkeypatch.delenv("GODOT4", raising=False)
+
+    assert _windows_godot_fallbacks("godot") == exe
+
+
+def test_windows_fallback_walks_path_for_extensionless_alias(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    alias = tmp_path / "godot"
+    alias.write_bytes(b"fake")
+    monkeypatch.setattr(
+        "tests.integration._self_update_fixture.shutil.which",
+        lambda _name: None,
+    )
+    monkeypatch.delenv("GODOT", raising=False)
+    monkeypatch.delenv("GODOT4", raising=False)
+    monkeypatch.setenv("PATH", str(tmp_path))
+
+    assert _windows_godot_fallbacks("godot") == alias
+
+
+def test_windows_fallback_uses_setup_godot_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    alias = tmp_path / "bin" / "godot"
+    alias.parent.mkdir()
+    alias.write_bytes(b"fake")
+    monkeypatch.setattr(
+        "tests.integration._self_update_fixture.shutil.which",
+        lambda _name: None,
+    )
+    monkeypatch.setenv("GODOT", str(alias))
+    monkeypatch.delenv("GODOT4", raising=False)
+    monkeypatch.setenv("PATH", "")
+
+    assert _windows_godot_fallbacks("godot") == alias
+
+
+def test_windows_fallback_finds_setup_godot_install_exe(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    exe = tmp_path / "godot" / "Godot_v4.7.0-stable_win64.exe"
+    exe.parent.mkdir()
+    exe.write_bytes(b"fake")
+    monkeypatch.setattr(
+        "tests.integration._self_update_fixture.shutil.which",
+        lambda _name: None,
+    )
+    monkeypatch.delenv("GODOT", raising=False)
+    monkeypatch.delenv("GODOT4", raising=False)
+    monkeypatch.setenv("PATH", "")
+    monkeypatch.setattr(
+        "tests.integration._self_update_fixture.Path.home",
+        lambda: tmp_path,
+    )
+
+    assert _windows_godot_fallbacks("godot") == exe
+
+
+def test_godot_bin_uses_windows_fallbacks_when_which_misses(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    exe = tmp_path / "godot.exe"
+    exe.write_bytes(b"fake")
+    monkeypatch.setenv("GODOT_BIN", "godot")
+    monkeypatch.setattr("tests.integration._self_update_fixture.os.name", "nt")
+    monkeypatch.setattr(
+        "tests.integration._self_update_fixture.shutil.which",
+        lambda name: str(exe) if name == "godot.exe" else None,
+    )
+    monkeypatch.delenv("GODOT", raising=False)
+    monkeypatch.delenv("GODOT4", raising=False)
+
+    assert godot_bin_or_skip() == str(exe)


### PR DESCRIPTION
## Summary
- The self-update integration fixture now fails when GODOT_BIN is set but does not resolve, instead of pytest.skip() that made CI exit 0 with zero tests run.
- Local runs with GODOT_BIN unset still skip so an engine-less checkout stays optional.
- Closes #917.

## Test plan
- [x] ruff check on the touched files
- [x] pytest -q tests/unit/test_self_update_godot_bin.py (unset skips; set-but-missing fails)
- [ ] Confirm the CI self-update step still runs when godot is on PATH

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Self-update checks now fail clearly when a configured Godot executable cannot be found instead of incorrectly passing with skipped tests.
  * Improved Godot executable discovery on Windows, including PATH aliases, environment variables, and common home-directory installations.
  * Invalid executable paths are no longer treated as valid resolutions.

* **Tests**
  * Added coverage for executable resolution and Windows fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->