### PR TITLE
fix: bound send_command's write as well as its response wait

### DIFF
--- a/src/godot_ai/transport/websocket.py
+++ b/src/godot_ai/transport/websocket.py
@@ -543,9 +543,13 @@ class GodotWebSocketServer:
         ## raise / TimeoutError / cancellation it prevents Futures leaking
         ## into _pending forever.
         try:
-            await ws.send(request.model_dump_json())
-            return await asyncio.wait_for(future, timeout=timeout)
-        except asyncio.TimeoutError:
+            # One deadline for the write and the response wait. A paused
+            # WebSocket drain used to block forever in `ws.send` because
+            # only the recv side was wrapped (#910).
+            async with asyncio.timeout(timeout):
+                await ws.send(request.model_dump_json())
+                return await future
+        except TimeoutError:
             raise TimeoutError(
                 f"Command {command} timed out after {timeout}s on session {session_id}"
             )

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -1596,6 +1596,33 @@ class TestPendingFutureCleanup:
         assert harness.server._pending == {}, "send-time exception must not leak _pending entries"
         await plugin.close()
 
+    async def test_timeout_covers_write_stall(self, harness):
+        ## A never-completing `ws.send` used to ignore the per-command
+        ## timeout because the deadline started only after the write
+        ## returned (#910).
+        plugin = await harness.connect_plugin(session_id="write-stall")
+        ws = harness.server._connections["write-stall"]
+        stall = asyncio.Event()
+
+        async def hanging_send(_payload: str) -> None:
+            await stall.wait()
+
+        ws.send = hanging_send  # type: ignore[assignment]
+
+        with pytest.raises(TimeoutError, match="timed out after 0.2"):
+            await asyncio.wait_for(
+                harness.server.send_command(
+                    session_id="write-stall",
+                    command="will_stall",
+                    timeout=0.2,
+                ),
+                timeout=1.5,
+            )
+
+        assert harness.server._pending == {}, "write-stall timeout must not leak _pending entries"
+        stall.set()
+        await plugin.close()
+
 
 # --- Issue #262: editor_state self-heals a stale "playing" cache ---
 


### PR DESCRIPTION
## Summary
- `send_command` now applies one deadline to both `ws.send` and the response wait, so a write-paused editor cannot hang a tool call forever.
- Existing TimeoutError handling and `_pending` cleanup are unchanged.
- Fixes #910.

## Test plan
- [x] `ruff check` on the touched files
- [x] `pytest -q tests/integration/test_websocket.py::TestPendingFutureCleanup` (3 passed, including write-stall timeout)

Made with [Cursor](https://cursor.com)