### PR TITLE
fix: pin the active session for the duration of an unpinned write

### DIFF
--- a/src/godot_ai/runtime/direct.py
+++ b/src/godot_ai/runtime/direct.py
@@ -47,6 +47,22 @@ class DirectRuntime:
     ) -> DirectRuntime:
         return cls(registry=app.registry, client=app.client, session_id=session_id)
 
+    def _pin_active_session_id(self) -> str | None:
+        """Resolve the active session once and keep it for this runtime.
+
+        Unpinned calls used to re-read the process-global active session
+        in both ``require_writable_async`` and ``send_command``. On the
+        readiness slow path that pair can disagree if ``session_activate``
+        interleaves (#911). Per-call ``session_id`` already pinned; the
+        default path must too.
+        """
+        if self._bound_session_id is not None:
+            return self._bound_session_id
+        session = self._registry.get_active()
+        if session is not None:
+            self._bound_session_id = session.session_id
+        return self._bound_session_id
+
     async def send_command(
         self,
         command: str,
@@ -55,7 +71,9 @@ class DirectRuntime:
         timeout: float = 5.0,
         hint_policy: HintPolicy | None = None,
     ) -> dict[str, Any]:
-        resolved_session_id = session_id if session_id is not None else self._bound_session_id
+        resolved_session_id = (
+            session_id if session_id is not None else self._pin_active_session_id()
+        )
         return await self._client.send(
             command=command,
             params=params,
@@ -68,16 +86,18 @@ class DirectRuntime:
         return self._registry.list_all()
 
     def get_active_session(self) -> Session | None:
-        if self._bound_session_id is not None:
-            return self._registry.get(self._bound_session_id)
-        return self._registry.get_active()
+        pinned = self._pin_active_session_id()
+        if pinned is not None:
+            return self._registry.get(pinned)
+        return None
 
     @property
     def active_session_id(self) -> str | None:
-        return self._bound_session_id or self._registry.active_session_id
+        return self._pin_active_session_id()
 
     def set_active_session(self, session_id: str) -> None:
         self._registry.set_active(session_id)
+        self._bound_session_id = session_id
 
     async def wait_for_session(
         self,

--- a/tests/unit/test_readiness.py
+++ b/tests/unit/test_readiness.py
@@ -453,3 +453,58 @@ def test_known_readiness_matches_plugin_get_readiness_source():
         f"gd-only={sorted(emitted - set(KNOWN_READINESS))}, "
         f"py-only={sorted(set(KNOWN_READINESS) - emitted)}"
     )
+
+
+async def test_require_writable_async_pins_session_across_slow_path():
+    """#911: an unpinned write must not retarget if session_activate
+    flips the global active session while the live readiness probe is
+    in flight.
+    """
+    session_a = Session(
+        session_id="sess-a",
+        godot_version="4.4.1",
+        project_path="/tmp/a",
+        plugin_version="0.0.1",
+        readiness="importing",
+    )
+    session_b = Session(
+        session_id="sess-b",
+        godot_version="4.4.1",
+        project_path="/tmp/b",
+        plugin_version="0.0.1",
+        readiness="playing",
+    )
+    registry = SessionRegistry()
+    registry.register(session_a)
+    registry.register(session_b)
+    registry.set_active("sess-a")
+
+    class _FlipOnProbe:
+        def __init__(self) -> None:
+            self.calls: list[str | None] = []
+
+        async def send(
+            self,
+            command: str,
+            params: dict | None = None,
+            session_id: str | None = None,
+            timeout: float = 5.0,
+            hint_policy=None,
+        ) -> dict:
+            self.calls.append(session_id)
+            registry.set_active("sess-b")
+            return {
+                "current_scene": "res://main.tscn",
+                "project_name": "p",
+                "is_playing": False,
+                "godot_version": "4.4.1",
+                "readiness": "ready",
+            }
+
+    client = _FlipOnProbe()
+    runtime = DirectRuntime(registry=registry, client=client)
+    await require_writable_async(runtime)
+    assert client.calls == ["sess-a"]
+    assert runtime.active_session_id == "sess-a"
+    assert registry.active_session_id == "sess-b"
+    assert session_a.readiness == "ready"

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -1369,17 +1369,25 @@ def test_direct_runtime_bound_id_missing_returns_none_session():
     assert runtime.get_active_session() is None
 
 
-async def test_direct_runtime_unbound_preserves_active_routing():
+async def test_direct_runtime_unbound_pins_active_for_call_duration():
     registry = SessionRegistry()
     registry.register(_make_session("a"))
+    registry.register(_make_session("b"))
     registry.set_active("a")
     client = StubClient()
     runtime = DirectRuntime(registry=registry, client=client)
 
     await runtime.send_command("get_editor_state")
 
-    ## Unbound runtime passes None so client falls back to registry active.
-    assert client.calls[-1]["session_id"] is None
+    ## Unbound runtime pins the then-active session so a later activate
+    ## cannot retarget this call (#911).
+    assert client.calls[-1]["session_id"] == "a"
+    assert runtime.active_session_id == "a"
+
+    registry.set_active("b")
+    await runtime.send_command("get_editor_state")
+    assert client.calls[-1]["session_id"] == "a"
+    assert runtime.get_active_session().session_id == "a"
 
 
 class _LifespanCtxStub:


### PR DESCRIPTION
## Summary
- Unpinned `DirectRuntime` calls now resolve the active session once and keep that pin for the runtime's lifetime, so readiness gating and `send_command` cannot target different editors.
- A concurrent `session_activate` during the readiness slow path no longer retargets an in-flight write.
- Fixes #911.

## Test plan
- [x] `ruff check` on the touched files
- [x] `pytest -q tests/unit/test_readiness.py` plus the DirectRuntime session-routing tests (30 passed)