### PR TITLE
fix: record descendant ownership inside reparent and duplicate undo

### DIFF
--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -148,21 +148,27 @@ func reparent_node(params: Dictionary) -> Dictionary:
 
 	var old_parent := node.get_parent()
 	var old_idx := node.get_index()
+	## Snapshot descendants before commit: remove_child clears owner on any
+	## child whose owner sits outside the pruned subtree, so both do and undo
+	## must restore those owners as part of the recorded action (#904).
+	var descendants := _collect_descendants(node)
 
 	_undo_redo.create_action("MCP: Reparent %s" % node.name)
 	_undo_redo.add_do_method(old_parent, "remove_child", node)
 	_undo_redo.add_do_method(new_parent, "add_child", node, true)
 	_undo_redo.add_do_method(node, "set_owner", scene_root)
+	for child in descendants:
+		_undo_redo.add_do_method(child, "set_owner", scene_root)
 	_undo_redo.add_do_reference(node)
 	_undo_redo.add_undo_method(new_parent, "remove_child", node)
 	_undo_redo.add_undo_method(old_parent, "add_child", node, true)
 	_undo_redo.add_undo_method(old_parent, "move_child", node, old_idx)
 	_undo_redo.add_undo_method(node, "set_owner", scene_root)
+	for child in descendants:
+		var prior_owner: Node = child.owner if child.owner != null else scene_root
+		_undo_redo.add_undo_method(child, "set_owner", prior_owner)
 	_undo_redo.add_undo_reference(node)
 	_undo_redo.commit_action()
-
-	# Re-set owner for all descendants (reparent can break ownership chain)
-	_set_owner_recursive(node, scene_root)
 
 	return {
 		"data": {
@@ -381,15 +387,19 @@ func duplicate_node(params: Dictionary) -> Dictionary:
 	if not new_name.is_empty():
 		dup.name = new_name
 
+	## Record descendant owners inside the action so redo restores them.
+	## Undo is just remove_child of the copy; descendants live on `dup`
+	## via add_do_reference and do not need their own undo set_owner (#904).
+	var descendants := _collect_descendants(dup)
+
 	_undo_redo.create_action("MCP: Duplicate %s" % node.name)
 	_undo_redo.add_do_method(parent, "add_child", dup, true)
 	_undo_redo.add_do_method(dup, "set_owner", scene_root)
+	for child in descendants:
+		_undo_redo.add_do_method(child, "set_owner", scene_root)
 	_undo_redo.add_do_reference(dup)
 	_undo_redo.add_undo_method(parent, "remove_child", dup)
 	_undo_redo.commit_action()
-
-	# Set owner for all descendants of the duplicate
-	_set_owner_recursive(dup, scene_root)
 
 	return {
 		"data": {
@@ -536,10 +546,15 @@ func set_selection(params: Dictionary) -> Dictionary:
 	}
 
 
-func _set_owner_recursive(node: Node, owner: Node) -> void:
+## All descendants of `node` (not including `node` itself), depth-first.
+## Used to record per-child set_owner inside an undo action without
+## targeting the handler as an UndoRedo receiver (#904).
+static func _collect_descendants(node: Node) -> Array[Node]:
+	var out: Array[Node] = []
 	for child in node.get_children():
-		child.set_owner(owner)
-		_set_owner_recursive(child, owner)
+		out.append(child)
+		out.append_array(_collect_descendants(child))
+	return out
 
 
 ## Canonical dict-key sets for dict→Variant coercion. Alpha on `COLOR_KEYS`

--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -165,7 +165,9 @@ func reparent_node(params: Dictionary) -> Dictionary:
 	_undo_redo.add_undo_method(old_parent, "move_child", node, old_idx)
 	_undo_redo.add_undo_method(node, "set_owner", scene_root)
 	for child in descendants:
-		var prior_owner: Node = child.owner if child.owner != null else scene_root
+		## Keep a null owner as null. Substituting scene_root would make an
+		## intentionally unowned descendant scene-owned on undo (#904).
+		var prior_owner: Node = child.owner
 		_undo_redo.add_undo_method(child, "set_owner", prior_owner)
 	_undo_redo.add_undo_reference(node)
 	_undo_redo.commit_action()

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -424,10 +424,47 @@ func test_reparent_to_ancestor_is_allowed() -> void:
 	chain.teardown.call()
 
 
+func test_reparent_preserves_descendant_owner_on_undo() -> void:
+	## Issue #904: descendant ownership was applied after commit_action, so
+	## undo of reparent left children with a null owner (Godot's remove_child
+	## clears owner on the pruned subtree).
+	var chain := _build_temp_chain(
+		["_McpTestOwnerParent", "_McpTestOwnerChild"] as Array[String]
+	)
+	var dest := _handler.create_node({
+		"type": "Node3D",
+		"name": "_McpTestOwnerDest",
+		"parent_path": "/Main",
+	})
+	assert_has_key(dest, "data")
+	assert_eq(dest.data.name, "_McpTestOwnerDest")
+
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var result := _handler.reparent_node({
+		"path": "/Main/_McpTestOwnerParent",
+		"new_parent": "/Main/_McpTestOwnerDest",
+	})
+	assert_has_key(result, "data")
+	assert_true(result.data.undoable, "reparent should be undoable")
+
+	var child_after := scene_root.get_node_or_null(
+		"_McpTestOwnerDest/_McpTestOwnerParent/_McpTestOwnerChild"
+	)
+	assert_ne(child_after, null, "child must exist under the new parent")
+	assert_eq(child_after.owner, scene_root, "child owner should be scene root after reparent")
+
+	assert_true(editor_undo(_undo_redo), "undo reparent should succeed")
+	var child := scene_root.get_node_or_null("_McpTestOwnerParent/_McpTestOwnerChild")
+	assert_ne(child, null, "child must exist under original parent after undo")
+	assert_ne(child.owner, null, "child owner must not be null after undo")
+	assert_eq(child.owner, scene_root, "child owner must still be the scene root after undo")
+
+	assert_true(editor_undo(_undo_redo), "undo dest create should succeed")
+	chain.teardown.call()
+
+
 ## Build a nested chain of throwaway Node3D test nodes under /Main, returning
 ## the deepest path and a teardown closure that unwinds each create via undo.
-## Used by the reparent regression tests; promote to test_suite.gd if a third
-## caller appears.
 func _build_temp_chain(names: Array[String]) -> Dictionary:
 	var parent_path := "/Main"
 	for name in names:
@@ -1491,6 +1528,39 @@ func test_duplicate_scene_root() -> void:
 func test_duplicate_node_invalid_path() -> void:
 	var result := _handler.duplicate_node({"path": "/Main/NoSuchNode"})
 	assert_is_error(result, ErrorCodes.NODE_NOT_FOUND)
+
+
+func test_duplicate_restores_descendant_owner_on_redo() -> void:
+	## Issue #904: descendant ownership was applied after commit_action, so
+	## redo of duplicate restored the copy without setting child owners.
+	var chain := _build_temp_chain(
+		["_McpTestDupSrc", "_McpTestDupChild"] as Array[String]
+	)
+	var scene_root := EditorInterface.get_edited_scene_root()
+
+	var result := _handler.duplicate_node({
+		"path": "/Main/_McpTestDupSrc",
+		"name": "_McpTestDupCopy",
+	})
+	assert_has_key(result, "data")
+	assert_true(result.data.undoable, "duplicate should be undoable")
+	assert_true(str(result.data.name).begins_with("_McpTestDupCopy"))
+
+	var copy_child := scene_root.get_node_or_null("_McpTestDupCopy/_McpTestDupChild")
+	assert_ne(copy_child, null, "duplicate child must exist")
+	assert_eq(copy_child.owner, scene_root, "duplicate child owner should be scene root")
+
+	assert_true(editor_undo(_undo_redo), "undo duplicate should succeed")
+	assert_eq(scene_root.get_node_or_null("_McpTestDupCopy"), null, "copy should be gone after undo")
+
+	assert_true(editor_redo(_undo_redo), "redo duplicate should succeed")
+	var copy_child_redo := scene_root.get_node_or_null("_McpTestDupCopy/_McpTestDupChild")
+	assert_ne(copy_child_redo, null, "duplicate child must exist after redo")
+	assert_ne(copy_child_redo.owner, null, "copy child's owner must not be null after redo")
+	assert_eq(copy_child_redo.owner, scene_root, "copy child's owner must be the scene root after redo")
+
+	assert_true(editor_undo(_undo_redo), "undo duplicate after redo should succeed")
+	chain.teardown.call()
 
 
 # ----- move_node -----

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -463,6 +463,76 @@ func test_reparent_preserves_descendant_owner_on_undo() -> void:
 	chain.teardown.call()
 
 
+func test_reparent_restores_owned_and_unowned_descendants_on_undo_redo() -> void:
+	## #904 review: undo must restore a null owner unchanged rather than
+	## substituting scene_root. One subtree with both a scene-owned and an
+	## unowned child, covering do / undo / redo.
+	var parent_res := _handler.create_node({
+		"type": "Node3D",
+		"name": "_McpTestMixParent",
+		"parent_path": "/Main",
+	})
+	assert_has_key(parent_res, "data")
+	assert_eq(parent_res.data.name, "_McpTestMixParent")
+	var owned_res := _handler.create_node({
+		"type": "Node3D",
+		"name": "_McpTestMixOwned",
+		"parent_path": "/Main/_McpTestMixParent",
+	})
+	assert_has_key(owned_res, "data")
+	assert_eq(owned_res.data.name, "_McpTestMixOwned")
+	var unowned_res := _handler.create_node({
+		"type": "Node3D",
+		"name": "_McpTestMixUnowned",
+		"parent_path": "/Main/_McpTestMixParent",
+	})
+	assert_has_key(unowned_res, "data")
+	assert_eq(unowned_res.data.name, "_McpTestMixUnowned")
+
+	var scene_root := EditorInterface.get_edited_scene_root()
+	var owned := scene_root.get_node_or_null("_McpTestMixParent/_McpTestMixOwned")
+	var unowned := scene_root.get_node_or_null("_McpTestMixParent/_McpTestMixUnowned")
+	assert_ne(owned, null, "precondition: owned child exists")
+	assert_ne(unowned, null, "precondition: unowned child exists")
+	assert_eq(owned.owner, scene_root, "precondition: owned child is scene-owned")
+	unowned.owner = null
+	assert_eq(unowned.owner, null, "precondition: unowned child has a null owner")
+
+	var dest := _handler.create_node({
+		"type": "Node3D",
+		"name": "_McpTestMixDest",
+		"parent_path": "/Main",
+	})
+	assert_has_key(dest, "data")
+	assert_eq(dest.data.name, "_McpTestMixDest")
+
+	var result := _handler.reparent_node({
+		"path": "/Main/_McpTestMixParent",
+		"new_parent": "/Main/_McpTestMixDest",
+	})
+	assert_has_key(result, "data")
+	assert_true(result.data.undoable, "reparent should be undoable")
+	assert_eq(owned.owner, scene_root, "owned child is scene-owned after reparent")
+	assert_eq(unowned.owner, scene_root, "unowned child is scene-owned after reparent")
+
+	assert_true(editor_undo(_undo_redo), "undo reparent should succeed")
+	assert_eq(owned.owner, scene_root, "owned child owner restored to scene root on undo")
+	assert_eq(unowned.owner, null, "unowned child owner restored to null on undo")
+
+	assert_true(editor_redo(_undo_redo), "redo reparent should succeed")
+	assert_eq(owned.owner, scene_root, "owned child is scene-owned after redo")
+	assert_eq(unowned.owner, scene_root, "unowned child is scene-owned after redo")
+
+	assert_true(editor_undo(_undo_redo), "undo reparent after redo should succeed")
+	assert_eq(owned.owner, scene_root, "owned child owner restored after second undo")
+	assert_eq(unowned.owner, null, "unowned child owner restored to null after second undo")
+
+	assert_true(editor_undo(_undo_redo), "undo dest create should succeed")
+	assert_true(editor_undo(_undo_redo), "undo unowned create should succeed")
+	assert_true(editor_undo(_undo_redo), "undo owned create should succeed")
+	assert_true(editor_undo(_undo_redo), "undo parent create should succeed")
+
+
 ## Build a nested chain of throwaway Node3D test nodes under /Main, returning
 ## the deepest path and a teardown closure that unwinds each create via undo.
 func _build_temp_chain(names: Array[String]) -> Dictionary:


### PR DESCRIPTION
## Summary
- Record descendant `set_owner` inside the `reparent_node` and `duplicate_node` undo actions instead of calling `_set_owner_recursive` after `commit_action`.
- Reparent undo now restores each descendant's prior owner (Godot `remove_child` clears owners on the pruned subtree). Duplicate redo now restores owners on the copy's children.
- Add GDScript regressions in `test_node.gd` for reparent undo and duplicate undo/redo owner restoration.

## Test plan
- [ ] `test_reparent_preserves_descendant_owner_on_undo` — parent+child, reparent parent, undo, child's owner remains the scene root
- [ ] `test_duplicate_restores_descendant_owner_on_redo` — duplicate a node with a child, undo, redo, copy child's owner is the scene root
- [ ] Existing `test_duplicate_node_basic` still covers undo removing the copy
- Live GDScript suite was not run because no editor is connected.

Fixes #904

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed undo and redo behavior for reparenting nodes, preserving descendant ownership correctly.
  * Fixed duplicated node hierarchies so descendant ownership is restored when the action is redone.

* **Tests**
  * Added regression coverage for owned and unowned descendants across reparent and duplicate undo/redo workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->