### PR TITLE
fix: treat backslash paths as sensitive writes

### DIFF
--- a/plugin/addons/godot_ai/utils/path_validator.gd
+++ b/plugin/addons/godot_ai/utils/path_validator.gd
@@ -158,9 +158,12 @@ static func _reject_sensitive_write(path: String) -> String:
 		return "Refusing to write res://project.godot (project manifest)"
 	if file_lower == "override.cfg":
 		return "Refusing to write res://override.cfg (startup config override)"
-	# Reject the `.godot/` editor-metadata dir at any depth. Split drops empty
-	# segments so a trailing slash can't hide a segment from the check.
-	var segments := path.trim_prefix("res://").split("/", false)
+	# Reject the `.godot/` editor-metadata dir at any depth. Normalize
+	# backslashes first — a Windows-style `res://.godot\uid_cache.bin`
+	# would otherwise be a single segment and skip both this check and the
+	# loaded-plugin clause below. Split drops empty segments so a trailing
+	# slash can't hide a segment from the check.
+	var segments := path.replace("\\", "/").trim_prefix("res://").split("/", false)
 	for segment in segments:
 		if segment.to_lower() == ".godot":
 			return "Refusing to write under res://.godot/ (editor metadata)"

--- a/test_project/tests/test_path_validator.gd
+++ b/test_project/tests/test_path_validator.gd
@@ -148,6 +148,23 @@ func test_write_rejects_godot_metadata_dir() -> void:
 	assert_contains(err, ".godot")
 
 
+func test_write_rejects_godot_metadata_dir_backslash() -> void:
+	## Windows-style separators must not skip the `.godot/` segment check
+	## (issue #905). `"\\"` in a GDScript literal is one backslash.
+	var err := McpPathValidator.validate_resource_path("res://.godot\\uid_cache.bin", true)
+	assert_false(err.is_empty(), "writing res://.godot\\uid_cache.bin must be rejected")
+	assert_contains(err, ".godot")
+
+
+func test_path_error_rejects_godot_metadata_dir_backslash() -> void:
+	var err: Variant = McpPathValidator.path_error("res://.godot\\uid_cache.bin", "path", true)
+	assert_true(err is Dictionary, "path_error must reject backslash .godot write")
+	assert_has_key(err, "error")
+	var inner: Dictionary = err["error"]
+	assert_eq(inner.get("code", ""), "VALUE_OUT_OF_RANGE")
+	assert_contains(str(inner.get("message", "")), ".godot")
+
+
 func test_write_allows_import_sidecar() -> void:
 	## .import sidecars are source-controlled import config; editing them then
 	## reimporting is a legitimate, recoverable workflow, so writes are allowed.
@@ -195,6 +212,28 @@ func test_write_rejects_loaded_plugin_tree() -> void:
 	var err := McpPathValidator.validate_resource_path("res://addons/godot_ai/plugin.gd", true)
 	assert_false(err.is_empty(), "writing under res://addons/godot_ai/ must be rejected")
 	assert_contains(err, "addons/godot_ai")
+
+
+func test_write_rejects_loaded_plugin_tree_backslash() -> void:
+	## Same guard as above, with Windows separators (#905).
+	var err := McpPathValidator.validate_resource_path("res://addons\\godot_ai\\plugin.gd", true)
+	assert_false(err.is_empty(), "writing res://addons\\godot_ai\\plugin.gd must be rejected")
+	assert_contains(err, "addons/godot_ai")
+
+
+func test_write_rejects_loaded_plugin_tree_mixed_separators() -> void:
+	var err := McpPathValidator.validate_resource_path("res://addons\\godot_ai/plugin.gd", true)
+	assert_false(err.is_empty(), "mixed-separator plugin path must be rejected")
+	assert_contains(err, "addons/godot_ai")
+
+
+func test_path_error_rejects_loaded_plugin_tree_backslash() -> void:
+	var err: Variant = McpPathValidator.path_error("res://addons\\godot_ai\\plugin.gd", "path", true)
+	assert_true(err is Dictionary, "path_error must reject backslash plugin-tree write")
+	assert_has_key(err, "error")
+	var inner: Dictionary = err["error"]
+	assert_eq(inner.get("code", ""), "VALUE_OUT_OF_RANGE")
+	assert_contains(str(inner.get("message", "")), "addons/godot_ai")
 
 
 func test_write_rejects_loaded_plugin_tree_nested() -> void:


### PR DESCRIPTION
## Summary
- Normalize backslashes to `/` in `_reject_sensitive_write` before the segment split so Windows-style paths cannot skip the `.godot/` and `addons/godot_ai/` write guards.
- Add GDScript coverage for backslash, mixed-separator, and `path_error(...)` forms of those writes.
- Leave the `project.godot` / `override.cfg` clauses unchanged; they already use `get_file()`.

## Test plan
- [ ] Run `test_run suite=path_validator` against a live Godot editor (skipped here: no editor connected; Godot was not launched)
- [ ] Confirm write of `res://.godot\uid_cache.bin` is rejected
- [ ] Confirm write of `res://addons\godot_ai\plugin.gd` is rejected
- [ ] Confirm mixed-separator write `res://addons\godot_ai/plugin.gd` is rejected
- [ ] Confirm `path_error(...)` returns `VALUE_OUT_OF_RANGE` for both backslash paths
- [ ] Confirm existing forward-slash forms still reject as before
- [ ] No Python files changed; ruff not run

Fixes #905

Made with [Cursor](https://cursor.com)