### PR TITLE
fix: retry attach adopt probes before condemning a live backend

### DIFF
--- a/src/godot_ai/attach/ensure.py
+++ b/src/godot_ai/attach/ensure.py
@@ -481,13 +481,9 @@ class BackendEnsurer:
             timeout_seconds=self._lock_timeout_seconds,
         )
         async with lock:
-            status = await self._probe(self.port)
+            status = await self._adopt_existing()
             if status is not None:
                 return self._validate(status)
-            if not self._port_check(self.port):
-                raise _foreign_occupant(
-                    self.port, "listener did not answer the godot-ai status probe"
-                )
             if not self._port_check(self.ws_port):
                 raise _foreign_occupant(self.ws_port, "WebSocket port is already occupied")
 
@@ -516,6 +512,27 @@ class BackendEnsurer:
                 retryable=True,
                 data={"log_path": str(spawned.log_path)},
             )
+
+    async def _adopt_existing(self) -> BackendStatus | None:
+        """Retry the status probe while the HTTP port is bound.
+
+        ``None`` from the probe means no answer yet, including a timeout.
+        A raised foreign-occupant error is not retried. If the port frees,
+        return ``None`` so the caller can spawn. After the health deadline
+        with the port still bound, raise ``PORT_OCCUPIED``.
+        """
+        deadline = time.monotonic() + self._health_timeout_seconds
+        while True:
+            status = await self._probe(self.port)
+            if status is not None:
+                return status
+            if self._port_check(self.port):
+                return None
+            if time.monotonic() >= deadline:
+                raise _foreign_occupant(
+                    self.port, "listener did not answer the godot-ai status probe"
+                )
+            await asyncio.sleep(self._poll_seconds)
 
     def _validate(self, status: BackendStatus) -> BackendStatus:
         differences: dict[str, Any] = {}

--- a/tests/unit/test_attach_ensure.py
+++ b/tests/unit/test_attach_ensure.py
@@ -766,6 +766,8 @@ async def test_foreign_http_occupant_never_spawns(tmp_path: Path) -> None:
         spawn=lambda *_args: spawns.append(True),  # type: ignore[arg-type,return-value]
         port_check=lambda port: port != 8000,
         runtime_dir=tmp_path,
+        health_timeout_seconds=0.05,
+        poll_seconds=0.001,
     )
 
     with pytest.raises(AttachStartupError) as exc_info:
@@ -773,6 +775,92 @@ async def test_foreign_http_occupant_never_spawns(tmp_path: Path) -> None:
 
     assert exc_info.value.code == "PORT_OCCUPIED"
     assert spawns == []
+
+
+async def test_slow_backend_is_adopted_after_retry(tmp_path: Path) -> None:
+    calls = {"n": 0}
+    spawns: list[bool] = []
+
+    async def probe(_port: int) -> BackendStatus | None:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return None
+        return status()
+
+    ensurer = BackendEnsurer(
+        probe=probe,
+        spawn=lambda *_args: spawns.append(True),  # type: ignore[arg-type,return-value]
+        port_check=lambda _port: False,
+        runtime_dir=tmp_path,
+        health_timeout_seconds=1,
+        poll_seconds=0.001,
+    )
+
+    result = await ensurer.ensure()
+
+    assert result.instance_id == "instance-a"
+    assert calls["n"] == 2
+    assert spawns == []
+
+
+async def test_answered_foreign_occupant_is_not_retried(tmp_path: Path) -> None:
+    calls = {"n": 0}
+    spawns: list[bool] = []
+
+    async def probe(_port: int) -> BackendStatus | None:
+        calls["n"] += 1
+        raise ensure_module._foreign_occupant(_port, "status probe returned HTTP 503")
+
+    ensurer = BackendEnsurer(
+        probe=probe,
+        spawn=lambda *_args: spawns.append(True),  # type: ignore[arg-type,return-value]
+        port_check=lambda _port: False,
+        runtime_dir=tmp_path,
+        health_timeout_seconds=1,
+        poll_seconds=0.001,
+    )
+
+    with pytest.raises(AttachStartupError) as exc_info:
+        await ensurer.ensure()
+
+    assert exc_info.value.code == "PORT_OCCUPIED"
+    assert calls["n"] == 1
+    assert spawns == []
+
+
+async def test_bound_http_port_that_frees_falls_through_to_spawn(tmp_path: Path) -> None:
+    calls = {"n": 0}
+    spawns = {"n": 0}
+
+    async def probe(_port: int) -> BackendStatus | None:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            return None
+        return status()
+
+    def port_check(port: int) -> bool:
+        if port != 8000:
+            return True
+        return calls["n"] >= 2
+
+    def spawn(_port: int, _ws_port: int, _domains: tuple[str, ...]) -> SpawnedBackend:
+        spawns["n"] += 1
+        return SpawnedBackend(FakeProcess(), tmp_path / "backend.log")
+
+    ensurer = BackendEnsurer(
+        probe=probe,
+        spawn=spawn,
+        port_check=port_check,
+        runtime_dir=tmp_path,
+        health_timeout_seconds=1,
+        poll_seconds=0.001,
+    )
+
+    result = await ensurer.ensure()
+
+    assert result.instance_id == "instance-a"
+    assert calls["n"] == 3
+    assert spawns["n"] == 1
 
 
 async def test_foreign_websocket_occupant_never_spawns(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- `BackendEnsurer.ensure` now retries the adopt probe for the same `health_timeout_seconds` / `poll_seconds` budget used by spawn, instead of treating one missed 1s probe plus a bound HTTP port as a foreign occupant.
- A probe that returns `None` (timeout / no answer) is retried while the HTTP port stays bound. A listener that answers as something else still fails immediately. If the port frees during retry, attach falls through to spawn. After the deadline with the port still bound, it raises `PORT_OCCUPIED`.

## Test plan
- [x] `ruff check` on `src/godot_ai/attach/ensure.py` and `tests/unit/test_attach_ensure.py`
- [x] `pytest -q tests/unit/test_attach_ensure.py` (41 passed, 6 skipped)
- [x] Reproduction: first probe `None`, second a valid `BackendStatus`, both ports bound — adopt succeeds, no spawn, no `PORT_OCCUPIED`
- [x] Foreign HTTP occupant still fails after a short health timeout without spawning
- [x] Foreign WebSocket occupant path unchanged (HTTP free, no adopt retry)
- [x] Answered-as-something-else probe raises immediately (no retry)
- [x] HTTP port that frees during retry falls through to spawn

Fixes #912

Made with [Cursor](https://cursor.com)