### PR TITLE
fix: parse Zed settings.json comments as JSONC

### DIFF
--- a/plugin/addons/godot_ai/clients/_json_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_json_strategy.gd
@@ -446,8 +446,9 @@ static func _arrays_equal(left: Variant, right: Variant) -> bool:
 ## Callers must NOT treat the error path as an empty config — doing so blows
 ## away the user's other MCP entries on the next write. The `original_text`
 ## is the exact captured source so transactional rollback can restore
-## byte-for-byte; the UTF-8 BOM and JSONC comments are stripped only from
-## the parsing copy.
+## byte-for-byte; the UTF-8 BOM is restored on `original_text` when the
+## decoder skipped the on-disk EF BB BF, and JSONC comments are stripped
+## only from the parsing copy.
 static func _read_file_text(path: String) -> Dictionary:
 	if not FileAccess.file_exists(path):
 		return {"exists": false, "ok": true, "data": {}, "original_text": ""}
@@ -455,16 +456,22 @@ static func _read_file_text(path: String) -> Dictionary:
 	if file == null:
 		var open_err := FileAccess.get_open_error()
 		return {"exists": true, "ok": false, "error": "could not open for reading (error %d)" % open_err, "original_text": ""}
-	var content := file.get_as_text()
+	# Read bytes, not `get_as_text()`. Godot's UTF-8 decoder (both
+	# `get_as_text()` and `PackedByteArray.get_string_from_utf8()`) skips a
+	# leading EF BB BF, so a text-only read would drop the BOM from
+	# `original_text` and the next configure/remove write would strip it
+	# from disk. Detect the marker on the raw buffer and restore U+FEFF
+	# when the decoder ate it (#914 F-3-6 / F5).
+	var buf := file.get_buffer(file.get_length())
 	file.close()
-	if content.strip_edges().is_empty():
+	var had_bom := buf.size() >= 3 and buf[0] == 0xEF and buf[1] == 0xBB and buf[2] == 0xBF
+	var content := buf.get_string_from_utf8()
+	if had_bom and not content.begins_with("\uFEFF"):
+		content = "\uFEFF" + content
+	var body := content.substr(1) if content.begins_with("\uFEFF") else content
+	if body.strip_edges().is_empty():
 		return {"exists": true, "ok": true, "data": {}, "original_text": content}
-	var parse_copy := content
-	# Strip a UTF-8 BOM if present — some editors (notably on Windows) save
-	# JSON with a leading ﻿, which Godot's JSON.parse rejects outright.
-	# Previously this landed on the "unparseable → wipe" path.
-	if parse_copy.begins_with("﻿"):
-		parse_copy = parse_copy.substr(1)
+	var parse_copy := body
 	# Zed ships settings.json with a `//` comment header (JSONC). Godot's
 	# JSON.parse has no comment support, so strip line/block comments from
 	# the parse copy only — original_text stays byte-for-byte for rollback
@@ -916,9 +923,8 @@ static func _write_config_entry(
 	server_name: String,
 	entry: Dictionary,
 ) -> Dictionary:
-	var source := original_text
-	if source.begins_with("﻿"):
-		source = source.substr(1)
+	var had_bom := original_text.begins_with("\uFEFF")
+	var source := original_text.substr(1) if had_bom else original_text
 	if source.strip_edges().is_empty():
 		if _has_lossy_numbers(config):
 			return {
@@ -926,6 +932,8 @@ static func _write_config_entry(
 				"error": "Refusing to rewrite %s: contains integers above 2^53 that Godot's JSON parser would re-emit imprecise. Edit the file by hand." % path,
 			}
 		var serialized := JSON.stringify(_narrow_integral_numbers(config), "\t", false)
+		if had_bom:
+			serialized = "\uFEFF" + serialized
 		if not McpAtomicWrite.write(path, serialized):
 			return {"ok": false, "error": "Cannot write to %s" % path}
 		return {"ok": true}

--- a/plugin/addons/godot_ai/clients/_json_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_json_strategy.gd
@@ -433,7 +433,8 @@ static func _arrays_equal(left: Variant, right: Variant) -> bool:
 ## Callers must NOT treat the error path as an empty config — doing so blows
 ## away the user's other MCP entries on the next write. The `original_text`
 ## is the exact captured source so transactional rollback can restore
-## byte-for-byte; the UTF-8 BOM is stripped only from the parsing copy.
+## byte-for-byte; the UTF-8 BOM and JSONC comments are stripped only from
+## the parsing copy.
 static func _read_file_text(path: String) -> Dictionary:
 	if not FileAccess.file_exists(path):
 		return {"exists": false, "ok": true, "data": {}, "original_text": ""}
@@ -451,6 +452,11 @@ static func _read_file_text(path: String) -> Dictionary:
 	# Previously this landed on the "unparseable → wipe" path.
 	if parse_copy.begins_with("﻿"):
 		parse_copy = parse_copy.substr(1)
+	# Zed ships settings.json with a `//` comment header (JSONC). Godot's
+	# JSON.parse has no comment support, so strip line/block comments from
+	# the parse copy only — original_text stays byte-for-byte for rollback
+	# and token-preserving remove.
+	parse_copy = _strip_jsonc(parse_copy)
 	var json := JSON.new()
 	if json.parse(parse_copy) != OK:
 		var msg := "JSON parse error on line %d: %s" % [json.get_error_line(), json.get_error_message()]
@@ -459,6 +465,51 @@ static func _read_file_text(path: String) -> Dictionary:
 	if not (json.data is Dictionary):
 		return {"exists": true, "ok": false, "error": "top-level value is %s, expected object" % type_string(typeof(json.data)), "original_text": content}
 	return {"exists": true, "ok": true, "data": json.data, "original_text": content}
+
+
+## Strip JSONC `//` line comments and `/* */` block comments. Sequences
+## inside JSON strings are left intact. Used only on the parse copy —
+## callers keep `original_text` for byte-for-byte rollback.
+static func _strip_jsonc(text: String) -> String:
+	var out := ""
+	var i := 0
+	var n := text.length()
+	var in_string := false
+	var escape := false
+	while i < n:
+		var c := text[i]
+		if in_string:
+			out += c
+			if escape:
+				escape = false
+			elif c == "\\":
+				escape = true
+			elif c == '"':
+				in_string = false
+			i += 1
+			continue
+		if c == '"':
+			in_string = true
+			out += c
+			i += 1
+			continue
+		if c == "/" and i + 1 < n and text[i + 1] == "/":
+			i += 2
+			while i < n and text[i] != "\n":
+				i += 1
+			continue
+		if c == "/" and i + 1 < n and text[i + 1] == "*":
+			i += 2
+			while i + 1 < n and not (text[i] == "*" and text[i + 1] == "/"):
+				i += 1
+			if i + 1 < n:
+				i += 2
+			else:
+				i = n
+			continue
+		out += c
+		i += 1
+	return out
 
 
 ## Returns {"ok": true, "data": Dictionary} when the file is absent or parses

--- a/plugin/addons/godot_ai/clients/_json_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_json_strategy.gd
@@ -26,14 +26,17 @@ static func configure(
 
 	var seed_path := str(resolution.get("seed_path", ""))
 	var read_path := seed_path if not FileAccess.file_exists(path) and not seed_path.is_empty() else path
-	var read := _read_or_init(read_path)
+	# Token-preserving configure (#914): parse via `_read_file_text` so JSONC
+	# comments stay in `original_text`, then splice only the target entry.
+	var read := _read_file_text(read_path)
 	if not read["ok"]:
 		return {"status": "error", "message": "Refusing to overwrite %s: %s. Fix or move the file, then re-run Configure." % [read_path, read["error"]]}
 	var launch_error := command_launch_error(client, launch)
 	if not launch_error.is_empty():
 		return {"status": "error", "message": launch_error}
 	var config: Dictionary = read["data"]
-	var holder := _ensure_path(config, select_server_key_path(config, client))
+	var key_path := select_server_key_path(config, client)
+	var holder := _ensure_path(config, key_path)
 	## Pass the existing entry through so `build_entry` can preserve user-mutable
 	## state (auto-approval lists, `disabled` toggles) instead of resetting it
 	## to descriptor defaults on every Configure click. See `entry_initial_fields`
@@ -41,13 +44,18 @@ static func configure(
 	var existing: Variant = holder.get(server_name, null)
 	holder[server_name] = build_entry(client, server_url, existing, launch)
 
-	# F5: refuse to re-serialize a file whose parsed integers above 2^53 would
-	# lose precision. Editing by hand keeps those values intact.
-	if _has_lossy_numbers(config):
-		return {"status": "error", "message": "Refusing to rewrite %s: contains integers above 2^53 that Godot's JSON parser would re-emit imprecise. Edit the file by hand." % path}
-	if not McpAtomicWrite.write(path, JSON.stringify(_narrow_integral_numbers(config), "\t", false)):
-		return {"status": "error", "message": "Cannot write to %s" % path}
+	var written := _write_config_entry(
+		path,
+		str(read.get("original_text", "")),
+		config,
+		key_path,
+		server_name,
+		holder[server_name],
+	)
+	if not written.get("ok", false):
+		return {"status": "error", "message": str(written.get("error", "Cannot write to %s" % path))}
 	return {"status": "ok", "message": McpClient.configured_message(client, server_url)}
+
 
 ## Pi-style clients merge several global config files. Update the effective
 ## highest-precedence definition; fail closed when a project override exists
@@ -86,12 +94,17 @@ static func _configure_merged(
 	var existing: Variant = holder.get(server_name, null)
 	holder[server_name] = build_entry(client, server_url, existing, launch)
 	var path := str(tier["path"])
-	# F5: refuse to re-serialize a tier whose parsed integers above 2^53 would
-	# lose precision. The same check guards the simple `configure` path.
-	if _has_lossy_numbers(config):
-		return {"status": "error", "message": "Refusing to rewrite %s: contains integers above 2^53 that Godot's JSON parser would re-emit imprecise. Edit the file by hand." % path}
-	if not McpAtomicWrite.write(path, JSON.stringify(_narrow_integral_numbers(config), "\t", false)):
-		return {"status": "error", "message": "Cannot write to %s" % path}
+	var key_path := select_server_key_path(config, client)
+	var written := _write_config_entry(
+		path,
+		str(tier.get("original_text", "")),
+		config,
+		key_path,
+		server_name,
+		holder[server_name],
+	)
+	if not written.get("ok", false):
+		return {"status": "error", "message": str(written.get("error", "Cannot write to %s" % path))}
 	# Codex F1 caveat: when we wrote a global tier but couldn't find any project
 	# override in the roots we probed AND the user hasn't told us where Pi (or any
 	# external cwd client) actually runs from, we can't prove this write is the
@@ -455,8 +468,14 @@ static func _read_file_text(path: String) -> Dictionary:
 	# Zed ships settings.json with a `//` comment header (JSONC). Godot's
 	# JSON.parse has no comment support, so strip line/block comments from
 	# the parse copy only — original_text stays byte-for-byte for rollback
-	# and token-preserving remove.
-	parse_copy = _strip_jsonc(parse_copy)
+	# and token-preserving configure/remove. Unterminated block comments
+	# fail closed so we never treat leftover source as valid JSON (#914).
+	var stripped := _strip_jsonc(parse_copy)
+	if not stripped.get("ok", false):
+		var strip_msg := str(stripped.get("error", "invalid JSONC"))
+		push_warning("MCP | %s in %s" % [strip_msg, path])
+		return {"exists": true, "ok": false, "error": strip_msg, "original_text": content}
+	parse_copy = str(stripped.get("text", ""))
 	var json := JSON.new()
 	if json.parse(parse_copy) != OK:
 		var msg := "JSON parse error on line %d: %s" % [json.get_error_line(), json.get_error_message()]
@@ -470,7 +489,8 @@ static func _read_file_text(path: String) -> Dictionary:
 ## Strip JSONC `//` line comments and `/* */` block comments. Sequences
 ## inside JSON strings are left intact. Used only on the parse copy —
 ## callers keep `original_text` for byte-for-byte rollback.
-static func _strip_jsonc(text: String) -> String:
+## Returns `{"ok": true, "text": String}` or `{"ok": false, "error": String}`.
+static func _strip_jsonc(text: String) -> Dictionary:
 	var out := ""
 	var i := 0
 	var n := text.length()
@@ -493,23 +513,58 @@ static func _strip_jsonc(text: String) -> String:
 			out += c
 			i += 1
 			continue
-		if c == "/" and i + 1 < n and text[i + 1] == "/":
-			i += 2
-			while i < n and text[i] != "\n":
-				i += 1
-			continue
-		if c == "/" and i + 1 < n and text[i + 1] == "*":
-			i += 2
-			while i + 1 < n and not (text[i] == "*" and text[i + 1] == "/"):
-				i += 1
-			if i + 1 < n:
-				i += 2
-			else:
-				i = n
+		var skipped := _skip_jsonc_comment_at(text, i)
+		if skipped < 0:
+			return {"ok": false, "error": "unterminated block comment"}
+		if skipped != i:
+			i = skipped
 			continue
 		out += c
 		i += 1
-	return out
+	if in_string:
+		return {"ok": false, "error": "unterminated string"}
+	return {"ok": true, "text": out}
+
+
+## Skip a JSONC comment starting at `i`. Returns `i` unchanged when `i` is
+## not a comment opener, the index after a consumed comment, or -1 when a
+## block comment runs to EOF without `*/`.
+static func _skip_jsonc_comment_at(text: String, i: int) -> int:
+	var n := text.length()
+	if i + 1 >= n or text[i] != "/":
+		return i
+	if text[i + 1] == "/":
+		i += 2
+		while i < n and text[i] != "\n":
+			i += 1
+		return i
+	if text[i + 1] == "*":
+		i += 2
+		while i + 1 < n:
+			if text[i] == "*" and text[i + 1] == "/":
+				return i + 2
+			i += 1
+		return -1
+	return i
+
+
+## Skip JSON whitespace and JSONC comments. Returns -1 on an unterminated
+## block comment (callers that already parsed the file treat that as a
+## scanner failure rather than swallowing source).
+static func _skip_jsonc_trivia(text: String, i: int) -> int:
+	var n := text.length()
+	while i < n:
+		if _is_json_ws(text[i]):
+			i += 1
+			continue
+		var skipped := _skip_jsonc_comment_at(text, i)
+		if skipped < 0:
+			return -1
+		if skipped != i:
+			i = skipped
+			continue
+		break
+	return i
 
 
 ## Returns {"ok": true, "data": Dictionary} when the file is absent or parses
@@ -819,9 +874,8 @@ static func _narrow_integral_numbers(value: Variant) -> Variant:
 
 ## True when `value` contains any float outside the IEEE-754 exact-int range
 ## (`abs(f) > 2^53`) that would lose precision when JSON.stringify re-emits it.
-## The configure path refuses such files instead of silently mutating unrelated
-## integers; the remove path never needs this check because it does
-## token-preserving surgery (F5).
+## Only the empty-file stringify path consults this: token-preserving
+## configure/remove splice a single entry and leave unrelated literals intact (F5).
 static func _has_lossy_numbers(value: Variant) -> bool:
 	match typeof(value):
 		TYPE_FLOAT:
@@ -843,6 +897,149 @@ static func _has_lossy_numbers(value: Variant) -> bool:
 	return false
 
 
+## Write `entry` under `key_path[server_name]`. Existing files are patched in
+## place so comments, formatting, and unrelated literals stay byte-for-byte
+## (#914). Empty files still stringify the whole object.
+static func _write_config_entry(
+	path: String,
+	original_text: String,
+	config: Dictionary,
+	key_path: PackedStringArray,
+	server_name: String,
+	entry: Dictionary,
+) -> Dictionary:
+	var source := original_text
+	if source.begins_with("﻿"):
+		source = source.substr(1)
+	if source.strip_edges().is_empty():
+		if _has_lossy_numbers(config):
+			return {
+				"ok": false,
+				"error": "Refusing to rewrite %s: contains integers above 2^53 that Godot's JSON parser would re-emit imprecise. Edit the file by hand." % path,
+			}
+		var serialized := JSON.stringify(_narrow_integral_numbers(config), "\t", false)
+		if not McpAtomicWrite.write(path, serialized):
+			return {"ok": false, "error": "Cannot write to %s" % path}
+		return {"ok": true}
+	var patched := _text_upsert_server_entry(original_text, key_path, server_name, entry)
+	if not patched.get("ok", false):
+		return {
+			"ok": false,
+			"error": "Refusing to rewrite %s: %s. Fix or move the file, then re-run Configure." % [
+				path, patched.get("error", "could not update entry in place"),
+			],
+		}
+	if not McpAtomicWrite.write(path, str(patched.get("text", ""))):
+		return {"ok": false, "error": "Cannot write to %s" % path}
+	return {"ok": true}
+
+
+## Token-preserving entry upsert. Locates `key_path[server_name]` in `text`
+## and replaces just that value, or inserts the key (and any missing parent
+## objects) so unrelated comments and formatting survive Configure (#914).
+static func _text_upsert_server_entry(
+	text: String,
+	key_path: PackedStringArray,
+	server_name: String,
+	entry: Dictionary,
+) -> Dictionary:
+	var entry_json := JSON.stringify(_narrow_integral_numbers(entry.duplicate(true)))
+	var root_open := _root_object_open(text)
+	if root_open < 0:
+		return {"ok": false, "error": "no top-level object to patch"}
+	var container_open := root_open
+	var inner_start := root_open + 1
+	var path_keys: Array[String] = []
+	for key in key_path:
+		path_keys.append(String(key))
+	for ki in range(path_keys.size()):
+		var key := path_keys[ki]
+		var found := _find_key_at_container_depth(text, inner_start, JSON.stringify(key))
+		if found.is_empty():
+			var nested: Dictionary = {}
+			nested[server_name] = entry.duplicate(true)
+			for rj in range(path_keys.size() - 1, ki, -1):
+				var wrap: Dictionary = {}
+				wrap[path_keys[rj]] = nested
+				nested = wrap
+			var value_json := JSON.stringify(_narrow_integral_numbers(nested))
+			return _insert_object_property(text, container_open, key, value_json)
+		var child_start: int = found["value_start"]
+		if child_start >= text.length() or text[child_start] != "{":
+			return {"ok": false, "error": "key '%s' is not an object" % key}
+		container_open = child_start
+		inner_start = child_start + 1
+	var existing := _find_key_at_container_depth(text, inner_start, JSON.stringify(server_name))
+	if existing.is_empty():
+		return _insert_object_property(text, container_open, server_name, entry_json)
+	var value_start: int = existing["value_start"]
+	var value_end: int = existing["value_end"]
+	return {"ok": true, "text": text.substr(0, value_start) + entry_json + text.substr(value_end)}
+
+
+## Index of the root `{`, skipping a leading BOM and JSONC trivia. -1 when
+## the file has no top-level object.
+static func _root_object_open(text: String) -> int:
+	var cursor := 0
+	if cursor < text.length() and text[cursor] == "﻿":
+		cursor += 1
+	cursor = _skip_jsonc_trivia(text, cursor)
+	if cursor < 0 or cursor >= text.length() or text[cursor] != "{":
+		return -1
+	return cursor
+
+
+## Insert `"key": value_json` into the object that opens at `obj_open`.
+static func _insert_object_property(
+	text: String, obj_open: int, key: String, value_json: String
+) -> Dictionary:
+	if obj_open < 0 or obj_open >= text.length() or text[obj_open] != "{":
+		return {"ok": false, "error": "insert target is not an object"}
+	var span_end := _json_value_span_end(text, obj_open)
+	if span_end < 0:
+		return {"ok": false, "error": "unterminated object"}
+	var close := span_end - 1
+	var rendered := JSON.stringify(key) + ": " + value_json
+	var inner := _skip_jsonc_trivia(text, obj_open + 1)
+	if inner < 0:
+		return {"ok": false, "error": "unterminated block comment"}
+	if inner == close:
+		return {"ok": true, "text": text.substr(0, obj_open + 1) + rendered + text.substr(close)}
+	var i := inner
+	var saw_trailing_comma := false
+	while i < close:
+		i = _skip_jsonc_trivia(text, i)
+		if i < 0:
+			return {"ok": false, "error": "unterminated block comment"}
+		if i >= close:
+			break
+		if text[i] != '"':
+			return {"ok": false, "error": "object is not a sequence of properties"}
+		var key_end := _json_value_span_end(text, i)
+		if key_end < 0:
+			return {"ok": false, "error": "unterminated property name"}
+		var after_key := _skip_jsonc_trivia(text, key_end)
+		if after_key < 0 or after_key >= text.length() or text[after_key] != ":":
+			return {"ok": false, "error": "missing colon in object"}
+		var value_start := _skip_jsonc_trivia(text, after_key + 1)
+		if value_start < 0:
+			return {"ok": false, "error": "unterminated block comment"}
+		var value_end := _json_value_span_end(text, value_start)
+		if value_end < 0:
+			return {"ok": false, "error": "unterminated property value"}
+		i = _skip_jsonc_trivia(text, value_end)
+		if i < 0:
+			return {"ok": false, "error": "unterminated block comment"}
+		if i < close and text[i] == ",":
+			saw_trailing_comma = true
+			i += 1
+		else:
+			saw_trailing_comma = false
+			break
+	var comma := "" if saw_trailing_comma else ","
+	return {"ok": true, "text": text.substr(0, close) + comma + rendered + text.substr(close)}
+
+
 ## Token-preserving entry removal. Walks the JSON text with a brace-balanced
 ## scanner to locate the entry at `key_path[0]/.../[server_name]` and returns
 ## `text` with that entry's bytes deleted (along with the surrounding
@@ -856,21 +1053,21 @@ static func _text_remove_server_entry(text: String, key_path: PackedStringArray,
 	# After the loop, `cursor` is positioned just past the opening bracket of the
 	# container that holds our entry, and `container_depth` tracks how deeply
 	# nested that container is from the root (0 = root object/array).
-	var cursor := 0
-	# Skip past the root's opening `{` or `[` (and any leading whitespace or
-	# UTF-8 BOM) so `_find_key_at_container_depth` starts scanning from
-	# inside the root container with `inner_depth == 0`. Without this step,
-	# the first character encountered is the root's `{`, which bumps
-	# `inner_depth` to 1 and makes the top-level key check fail. The BOM
-	# skip mirrors `_read_file_text`'s parse_copy BOM-strip above so the
-	# scanner sees the same view of the file the parser does; the BOM
+	# Skip past the root's opening `{` or `[` (and any leading whitespace,
+	# JSONC comments, or UTF-8 BOM) so `_find_key_at_container_depth`
+	# starts scanning from inside the root container with `inner_depth == 0`.
+	# The BOM skip mirrors `_read_file_text`'s parse_copy BOM-strip above so
+	# the scanner sees the same view of the file the parser does; the BOM
 	# itself stays in `text` so the byte-survival F5 contract still holds
-	# (codex round 3, F-3-6 — without it, files saved with a Windows BOM
-	# left the entry in place after Remove).
-	while cursor < text.length() and _is_json_ws(text[cursor]):
-		cursor += 1
+	# (codex round 3, F-3-6). JSONC trivia (#914) must be skipped too —
+	# otherwise a Zed `//` header leaves the cursor on `/` and the root `{`
+	# is treated as nested.
+	var cursor := 0
 	if cursor < text.length() and text[cursor] == "﻿":
 		cursor += 1
+	cursor = _skip_jsonc_trivia(text, cursor)
+	if cursor < 0:
+		return text
 	if cursor < text.length() and (text[cursor] == "{" or text[cursor] == "["):
 		cursor += 1
 	var container_depth := 0
@@ -899,18 +1096,19 @@ static func _text_remove_server_entry(text: String, key_path: PackedStringArray,
 	# middle-position entry into `"x"}"y"` with no separator — codex-review
 	# finding F5 (regression after the initial round).
 	var remove_end := value_end
-	# Skip JSON whitespace before checking for the trailing comma — valid
-	# (if unusual) formats like `"godot-ai":{}   ,"other":{}` put whitespace
-	# between the value and its separator. codex round 4 finding.
-	var trailing_scan := remove_end
-	while trailing_scan < text.length() and _is_json_ws(text[trailing_scan]):
-		trailing_scan += 1
+	# Skip JSON whitespace and JSONC comments before checking for the trailing
+	# comma — valid formats like `"godot-ai":{}   ,"other":{}` put trivia
+	# between the value and its separator.
+	var trailing_scan := _skip_jsonc_trivia(text, remove_end)
+	if trailing_scan < 0:
+		return text
 	var had_trailing_comma := trailing_scan < text.length() and text[trailing_scan] == ","
 	if had_trailing_comma:
-		# Jump past the comma (and any whitespace before it we just skipped).
 		remove_end = trailing_scan + 1
-	while remove_end < text.length() and _is_json_ws(text[remove_end]):
-		remove_end += 1
+	var after_comma := _skip_jsonc_trivia(text, remove_end)
+	if after_comma < 0:
+		return text
+	remove_end = after_comma
 	var remove_start := key_start
 	if not had_trailing_comma:
 		while remove_start > 0 and _is_json_ws(text[remove_start - 1]):
@@ -949,18 +1147,24 @@ static func _find_key_at_container_depth(text: String, start: int, key_bytes: St
 			continue
 		if c == '"':
 			if text.substr(i, key_bytes.length()) == key_bytes:
-				var after_key := i + key_bytes.length()
-				while after_key < text.length() and _is_json_ws(text[after_key]):
-					after_key += 1
+				var after_key := _skip_jsonc_trivia(text, i + key_bytes.length())
+				if after_key < 0:
+					return {}
 				if after_key < text.length() and text[after_key] == ":":
-					var value_start := after_key + 1
-					while value_start < text.length() and _is_json_ws(text[value_start]):
-						value_start += 1
+					var value_start := _skip_jsonc_trivia(text, after_key + 1)
+					if value_start < 0:
+						return {}
 					var value_end := _json_value_span_end(text, value_start)
 					if value_end >= 0 and inner_depth == 0:
 						return {"key_start": i, "value_start": value_start, "value_end": value_end}
 			in_string = true
 			i += 1
+			continue
+		var skipped := _skip_jsonc_comment_at(text, i)
+		if skipped < 0:
+			return {}
+		if skipped != i:
+			i = skipped
 			continue
 		if c == "{" or c == "[":
 			inner_depth += 1
@@ -1006,10 +1210,17 @@ static func _json_value_span_end(text: String, value_start: int) -> int:
 				continue
 			if ch == '"':
 				in_string = true
-			elif ch == open_char:
-				depth += 1
-			elif ch == close_char:
-				depth -= 1
+			else:
+				var skipped := _skip_jsonc_comment_at(text, i)
+				if skipped < 0:
+					return -1
+				if skipped != i:
+					i = skipped
+					continue
+				if ch == open_char:
+					depth += 1
+				elif ch == close_char:
+					depth -= 1
 			i += 1
 		return i if depth == 0 else -1
 	if c == '"':

--- a/plugin/addons/godot_ai/clients/_json_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_json_strategy.gd
@@ -1004,7 +1004,11 @@ static func _insert_object_property(
 	if inner < 0:
 		return {"ok": false, "error": "unterminated block comment"}
 	if inner == close:
-		return {"ok": true, "text": text.substr(0, obj_open + 1) + rendered + text.substr(close)}
+		## Comments-only (or whitespace-only) objects still have no
+		## properties, but replacing the inner span would drop them.
+		## Insert the new property just before `}` so `{ /* keep */ }`
+		## becomes `{ /* keep */ "key": ...}` instead of `{"key": ...}`.
+		return {"ok": true, "text": text.substr(0, close) + rendered + text.substr(close)}
 	var i := inner
 	var saw_trailing_comma := false
 	while i < close:
@@ -1237,11 +1241,13 @@ static func _json_value_span_end(text: String, value_start: int) -> int:
 			i += 1
 		return -1
 	# Bare literal: number / true / false / null. Walk until a JSON-significant
-	# delimiter (`,`, `}`, `]`, or whitespace).
+	# delimiter (`,`, `}`, `]`, whitespace, or a glued JSONC comment opener).
 	var i := value_start
 	while i < text.length():
 		var ch := text[i]
 		if ch == "," or ch == "}" or ch == "]" or _is_json_ws(ch):
+			break
+		if ch == "/" and i + 1 < text.length() and (text[i + 1] == "/" or text[i + 1] == "*"):
 			break
 		i += 1
 	return i

--- a/plugin/addons/godot_ai/clients/_json_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_json_strategy.gd
@@ -491,15 +491,15 @@ static func _read_file_text(path: String) -> Dictionary:
 ## callers keep `original_text` for byte-for-byte rollback.
 ## Returns `{"ok": true, "text": String}` or `{"ok": false, "error": String}`.
 static func _strip_jsonc(text: String) -> Dictionary:
-	var out := ""
+	var parts: PackedStringArray = PackedStringArray()
 	var i := 0
 	var n := text.length()
 	var in_string := false
 	var escape := false
+	var run_start := 0
 	while i < n:
 		var c := text[i]
 		if in_string:
-			out += c
 			if escape:
 				escape = false
 			elif c == "\\":
@@ -510,20 +510,28 @@ static func _strip_jsonc(text: String) -> Dictionary:
 			continue
 		if c == '"':
 			in_string = true
-			out += c
 			i += 1
 			continue
 		var skipped := _skip_jsonc_comment_at(text, i)
 		if skipped < 0:
 			return {"ok": false, "error": "unterminated block comment"}
 		if skipped != i:
+			if i > run_start:
+				parts.append(text.substr(run_start, i - run_start))
+			## Keep block-comment newlines so JSON.parse error lines still
+			## match the source file (`/*\n*/{"a": }` errors on line 2).
+			for j in range(i, skipped):
+				if text[j] == "\n":
+					parts.append("\n")
 			i = skipped
+			run_start = i
 			continue
-		out += c
 		i += 1
 	if in_string:
 		return {"ok": false, "error": "unterminated string"}
-	return {"ok": true, "text": out}
+	if n > run_start:
+		parts.append(text.substr(run_start, n - run_start))
+	return {"ok": true, "text": "".join(parts)}
 
 
 ## Skip a JSONC comment starting at `i`. Returns `i` unchanged when `i` is
@@ -965,8 +973,25 @@ static func _text_upsert_server_entry(
 			var value_json := JSON.stringify(_narrow_integral_numbers(nested))
 			return _insert_object_property(text, container_open, key, value_json)
 		var child_start: int = found["value_start"]
-		if child_start >= text.length() or text[child_start] != "{":
+		if child_start >= text.length():
 			return {"ok": false, "error": "key '%s' is not an object" % key}
+		if text[child_start] != "{":
+			## Mirror `_ensure_path`: a scalar/array holder is replaced by
+			## the object that carries our entry (`select_server_key_path`).
+			var repaired: Dictionary = {}
+			repaired[server_name] = entry.duplicate(true)
+			for rj in range(path_keys.size() - 1, ki, -1):
+				var repaired_wrap: Dictionary = {}
+				repaired_wrap[path_keys[rj]] = repaired
+				repaired = repaired_wrap
+			var child_end: int = found["value_end"]
+			if child_end < child_start:
+				return {"ok": false, "error": "key '%s' is not an object" % key}
+			var repaired_json := JSON.stringify(_narrow_integral_numbers(repaired))
+			return {
+				"ok": true,
+				"text": text.substr(0, child_start) + repaired_json + text.substr(child_end),
+			}
 		container_open = child_start
 		inner_start = child_start + 1
 	var existing := _find_key_at_container_depth(text, inner_start, JSON.stringify(server_name))
@@ -1109,10 +1134,10 @@ static func _text_remove_server_entry(text: String, key_path: PackedStringArray,
 	var had_trailing_comma := trailing_scan < text.length() and text[trailing_scan] == ","
 	if had_trailing_comma:
 		remove_end = trailing_scan + 1
-	var after_comma := _skip_jsonc_trivia(text, remove_end)
-	if after_comma < 0:
-		return text
-	remove_end = after_comma
+	# Whitespace only after the comma: a comment there documents the NEXT
+	# entry (`"godot-ai": {},\n// note about other\n"other": {}`).
+	while remove_end < text.length() and _is_json_ws(text[remove_end]):
+		remove_end += 1
 	var remove_start := key_start
 	if not had_trailing_comma:
 		while remove_start > 0 and _is_json_ws(text[remove_start - 1]):

--- a/plugin/addons/godot_ai/clients/_json_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_json_strategy.gd
@@ -527,9 +527,16 @@ static func _strip_jsonc(text: String) -> Dictionary:
 				parts.append(text.substr(run_start, i - run_start))
 			## Keep block-comment newlines so JSON.parse error lines still
 			## match the source file (`/*\n*/{"a": }` errors on line 2).
+			var emitted_nl := false
 			for j in range(i, skipped):
 				if text[j] == "\n":
 					parts.append("\n")
+					emitted_nl = true
+			## A comment must not glue the tokens on either side
+			## (`tru/* x */e` must not parse as `true`). A newline already
+			## splits tokens; otherwise insert one space.
+			if not emitted_nl:
+				parts.append(" ")
 			i = skipped
 			run_start = i
 			continue

--- a/script/ci-reload-test
+++ b/script/ci-reload-test
@@ -37,8 +37,11 @@ mcp_call() {
   echo "$raw" | python3 -c "
 import json, sys
 raw = sys.stdin.read()
-for line in raw.splitlines():
-    line = line.lstrip('\ufeff').rstrip('\r')
+# SSE records are delimited by CR/LF only. str.splitlines() also splits on
+# U+0085/U+2028/U+2029, which are legal inside JSON strings.
+normalized = raw.replace('\r\n', '\n').replace('\r', '\n')
+for line in normalized.split('\n'):
+    line = line.lstrip('\ufeff')
     # SSE comments / keepalives (`: ping - ...`) are not payload.
     if not line or line.startswith(':'):
         continue

--- a/script/ci-reload-test
+++ b/script/ci-reload-test
@@ -19,21 +19,29 @@ REQ_ID=0
 
 # Helper: call an MCP tool and extract the content JSON from the SSE response.
 # Prints parsed content to stdout; diagnostics to stderr. Returns 1 on failure.
+# Optional third arg is curl --max-time (seconds); default 30. Post-churn
+# test_run needs longer: FastMCP keepalives (`: ping`) arrive first, and a
+# 30s cut-off on Windows left the harness with only the comment line.
 mcp_call() {
   local tool="$1"
   local args="$2"
+  local max_time="${3:-30}"
   if [ "$tool" != "session_manage" ] && [ -n "${TARGET_GODOT_SESSION:-}" ]; then
     args=$(ci_pin_tool_args "$args" "$TARGET_GODOT_SESSION") || return 1
   fi
   REQ_ID=$((REQ_ID + 1))
   local raw
-  raw=$(curl -s --max-time 30 "$SERVER_URL" -X POST "${HEADERS[@]}" \
+  raw=$(curl -s --max-time "$max_time" "$SERVER_URL" -X POST "${HEADERS[@]}" \
     -H "Mcp-Session-Id: $SESSION_ID" \
     -d "{\"jsonrpc\":\"2.0\",\"id\":$REQ_ID,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args}}")
   echo "$raw" | python3 -c "
 import json, sys
 raw = sys.stdin.read()
-for line in raw.split('\n'):
+for line in raw.splitlines():
+    line = line.lstrip('\ufeff').rstrip('\r')
+    # SSE comments / keepalives (`: ping - ...`) are not payload.
+    if not line or line.startswith(':'):
+        continue
     if line.startswith('data: '):
         data = json.loads(line[6:])
         result = data.get('result', {})
@@ -246,7 +254,7 @@ done
 # form is parsed by `McpTestRunner._parse_exclusions` — see
 # `plugin/addons/godot_ai/testing/test_runner.gd`.
 echo "Running GDScript test suite on reloaded plugin..."
-TESTS_RESULT=$(mcp_call_or_die "test_run post-churn" test_run '{"verbose":false,"exclude_test_name":"test_configure_current_sibling_unmark_single_undo,test_get_returns_current_when_path_empty"}')
+TESTS_RESULT=$(mcp_call_or_die "test_run post-churn" test_run '{"verbose":false,"exclude_test_name":"test_configure_current_sibling_unmark_single_undo,test_get_returns_current_when_path_empty"}' 180)
 echo "$TESTS_RESULT" | python3 -c "
 import json, sys
 content = json.loads(sys.stdin.read())

--- a/test_project/tests/test_client_attach_config.gd
+++ b/test_project/tests/test_client_attach_config.gd
@@ -1046,11 +1046,10 @@ func test_pi_remove_merged_returns_not_configured_when_no_match() -> void:
 
 func test_pi_load_merge_tiers_accepts_bom_prefixed_valid_object() -> void:
 	var bom_path := _scratch_dir.path_join("pi_bom_merge.json")
-	# A leading U+FEFF must not break the parse path. The captured text is what
-	# rollback would restore; whether Godot's text read surfaces that byte
-	# verbatim or silently strips it is implementation-dependent, so this
-	# assertion concentrates on the strategy contract: parse success plus
-	# non-empty original_text for rollback.
+	# A leading U+FEFF must not break the parse path. `_read_file_text`
+	# restores the marker in `original_text` even though Godot's UTF-8
+	# decoder skips the on-disk EF BB BF, so rollback/configure can write
+	# the BOM back.
 	var bom_text := "\ufeff" + JSON.stringify({"mcpServers": {"unrelated": {"command": "untouched", "args": []}}})
 	var file := FileAccess.open(bom_path, FileAccess.WRITE)
 	assert_true(file != null, "could not write BOM-prefixed fixture: %s" % bom_path)
@@ -1074,6 +1073,7 @@ func test_pi_load_merge_tiers_accepts_bom_prefixed_valid_object() -> void:
 	assert_true(parsed.has("mcpServers"), "parsed data must surface the canonical map")
 	var original_text: String = tiers[0].get("original_text", "")
 	assert_ne(original_text, "", "original_text must capture non-empty source for rollback")
+	assert_true(original_text.begins_with("\uFEFF"), "original_text must restore the on-disk UTF-8 BOM")
 
 
 func test_pi_json_strategy_fails_closed_on_project_override() -> void:

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -2550,14 +2550,15 @@ func test_json_strategy_preserves_integer_fields() -> void:
 	var content := content_file.get_as_text()
 	content_file.close()
 	# Integers must survive as integers — not be floatified to "8080.0".
-	assert_true(content.contains('"port": 8080'), "port int must be present")
-	assert_false(content.contains('"port": 8080.0'), "port must not become 8080.0")
-	assert_false(content.contains('"retries": 3.0'), "retries must not be floatified")
-	assert_false(content.contains('"numStartups": 47.0'), "top-level int must not be floatified")
-	# Check each element regardless of trailing comma/newline so a floatified
-	# last element ("3.0" with no comma) is also caught.
-	for floatified in ["1.0", "2.0", "3.0"]:
-		assert_false(content.contains(floatified), "array int must not be floatified (%s)" % floatified)
+	# Token-preserving configure keeps the original literals, which may be
+	# compact (`"port":8080`) or spaced (`"port": 8080`).
+	assert_false(content.contains("8080.0"), "port must not become 8080.0")
+	assert_false(content.contains("1.0"), "array int must not be floatified (1.0)")
+	assert_false(content.contains("2.0"), "array int must not be floatified (2.0)")
+	assert_false(content.contains("3.0"), "retries / array ints must not be floatified")
+	assert_false(content.contains("47.0"), "top-level int must not be floatified")
+	assert_true(content.contains("8080"), "port int must be present")
+	assert_true(content.contains("47"), "top-level int must be present")
 	# Still valid JSON, other entry preserved, our entry added.
 	var parsed = JSON.parse_string(content)
 	assert_true(parsed["mcpServers"].has("someone-else"))
@@ -2627,9 +2628,13 @@ func test_json_strategy_tolerates_utf8_bom() -> void:
 	assert_eq(result.get("status"), "ok", "BOM-prefixed JSON should parse after strip")
 
 	var check_file := FileAccess.open(path, FileAccess.READ)
-	var parsed = JSON.parse_string(check_file.get_as_text())
+	var written := check_file.get_as_text()
 	check_file.close()
-	assert_true(parsed is Dictionary and parsed.has("mcpServers"))
+	assert_true(written.begins_with("﻿"), "UTF-8 BOM must survive configure")
+	var reread := McpJsonStrategy._read_file_text(path)
+	assert_true(reread.get("ok"), "BOM-prefixed write must still parse: %s" % reread.get("error", ""))
+	var parsed: Dictionary = reread.get("data")
+	assert_true(parsed.has("mcpServers"))
 	assert_true(parsed["mcpServers"].has("someone-else"), "Existing entry wiped after BOM parse recovery")
 	assert_true(parsed["mcpServers"].has("godot-ai"), "godot-ai entry not added")
 
@@ -2650,9 +2655,13 @@ func test_json_strategy_tolerates_zed_jsonc_header() -> void:
 	assert_eq(result.get("status"), "ok", "Zed JSONC header should parse after strip: %s" % result.get("message", ""))
 
 	var check_file := FileAccess.open(path, FileAccess.READ)
-	var parsed = JSON.parse_string(check_file.get_as_text())
+	var written := check_file.get_as_text()
 	check_file.close()
-	assert_true(parsed is Dictionary and parsed.has("mcpServers"))
+	assert_true(written.begins_with("// Zed settings\n"), "Zed header must survive configure; got: %s" % written)
+	var reread := McpJsonStrategy._read_file_text(path)
+	assert_true(reread.get("ok"), "written JSONC must still parse: %s" % reread.get("error", ""))
+	var parsed: Dictionary = reread.get("data")
+	assert_true(parsed.has("mcpServers"))
 	assert_true(parsed["mcpServers"].has("someone-else"), "Existing entry wiped after JSONC parse recovery")
 	assert_true(parsed["mcpServers"].has("godot-ai"), "godot-ai entry not added")
 
@@ -2699,14 +2708,17 @@ func test_read_file_text_strips_jsonc_block_comments() -> void:
 func test_strip_jsonc_preserves_comment_markers_inside_strings() -> void:
 	## A `//` or `/* */` sequence inside a JSON string is data, not a comment.
 	var src := '{"url": "http://example.com//path", "note": "use /* not */ here"}'
-	var stripped: String = McpJsonStrategy._strip_jsonc(src)
-	assert_eq(stripped, src, "comment markers inside strings must be preserved")
-	var parsed: Variant = JSON.parse_string(stripped)
+	var stripped: Dictionary = McpJsonStrategy._strip_jsonc(src)
+	assert_true(stripped.get("ok"), "valid JSON with in-string markers must strip: %s" % stripped.get("error", ""))
+	assert_eq(str(stripped.get("text")), src, "comment markers inside strings must be preserved")
+	var parsed: Variant = JSON.parse_string(str(stripped.get("text")))
 	assert_true(parsed is Dictionary, "stripped text must remain valid JSON")
 	assert_eq((parsed as Dictionary).get("url"), "http://example.com//path")
 	assert_eq((parsed as Dictionary).get("note"), "use /* not */ here")
 	var escaped := '{"a": "foo\\" // not a comment"}'
-	assert_eq(McpJsonStrategy._strip_jsonc(escaped), escaped, "escaped quotes must not end the string early")
+	var escaped_stripped: Dictionary = McpJsonStrategy._strip_jsonc(escaped)
+	assert_true(escaped_stripped.get("ok"))
+	assert_eq(str(escaped_stripped.get("text")), escaped, "escaped quotes must not end the string early")
 
 
 func test_read_file_text_jsonc_still_errors_on_invalid_json() -> void:
@@ -2726,6 +2738,70 @@ func test_read_file_text_jsonc_still_errors_on_invalid_json() -> void:
 
 	var init := McpJsonStrategy._read_or_init(path)
 	assert_false(init.get("ok"), "_read_or_init must also fail on invalid JSONC")
+
+
+func test_read_file_text_rejects_unterminated_block_comment() -> void:
+	## Fail-closed: `{"theme":"x"} /* unfinished` must not strip-to-EOF and
+	## parse as valid JSON (#914 review).
+	var path := _scratch_dir.path_join("jsonc_unterminated.json")
+	var body := "{\"theme\": \"x\"} /* unfinished"
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	f.store_string(body)
+	f.close()
+
+	var stripped: Dictionary = McpJsonStrategy._strip_jsonc(body)
+	assert_false(stripped.get("ok"), "unterminated block comment must fail strip")
+	assert_true(str(stripped.get("error", "")).contains("unterminated block comment"))
+
+	var read := McpJsonStrategy._read_file_text(path)
+	assert_false(read.get("ok"), "unterminated block comment must fail read")
+	assert_true(str(read.get("error", "")).contains("unterminated block comment"))
+	assert_eq(read.get("original_text"), body, "failed read must still return original_text")
+
+	var client := _make_test_json_client(path)
+	var result := McpJsonStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+	assert_eq(result.get("status"), "error", "configure must refuse unterminated JSONC")
+	var check_file := FileAccess.open(path, FileAccess.READ)
+	assert_eq(check_file.get_as_text(), body, "unterminated JSONC must not be mutated")
+	check_file.close()
+
+
+func test_json_strategy_configure_preserves_unrelated_jsonc_byte_for_byte() -> void:
+	## Configure must splice only the target server entry. The Zed header,
+	## inner comments, and unrelated keys stay byte-for-byte (#914 review).
+	var path := _scratch_dir.path_join("jsonc_preserve.json")
+	var body := (
+		"// Zed settings\n"
+		+ "// keep this header\n"
+		+ "{\n"
+		+ "\t\"theme\": \"one-dark\", /* keep inner */\n"
+		+ "\t\"mcpServers\": {\n"
+		+ "\t\t\"someone-else\": {\"url\": \"http://other/\"}\n"
+		+ "\t}\n"
+		+ "}\n"
+	)
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	f.store_string(body)
+	f.close()
+
+	var client := _make_test_json_client(path)
+	var result := McpJsonStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+	assert_eq(result.get("status"), "ok", "JSONC configure should succeed: %s" % result.get("message", ""))
+
+	var check_file := FileAccess.open(path, FileAccess.READ)
+	var written := check_file.get_as_text()
+	check_file.close()
+	assert_true(written.begins_with("// Zed settings\n// keep this header\n"), "header comments must survive; got: %s" % written)
+	assert_true(written.contains("\t\"theme\": \"one-dark\", /* keep inner */\n"), "unrelated key and inner comment must survive; got: %s" % written)
+	assert_true(written.contains("\t\t\"someone-else\": {\"url\": \"http://other/\"}"), "unrelated server entry must survive verbatim; got: %s" % written)
+	assert_true(written.contains("godot-ai"), "godot-ai entry must be inserted")
+
+	var reread := McpJsonStrategy._read_file_text(path)
+	assert_true(reread.get("ok"), "preserved JSONC must still parse: %s" % reread.get("error", ""))
+	var servers: Dictionary = (reread.get("data") as Dictionary).get("mcpServers")
+	assert_true(servers.has("someone-else"))
+	assert_true(servers.has("godot-ai"))
+	assert_eq((servers["godot-ai"] as Dictionary).get("url"), "http://127.0.0.1:8000/mcp")
 
 
 func test_json_strategy_remove_refuses_unparseable_file() -> void:
@@ -5680,10 +5756,10 @@ func test_json_strategy_pi_merge_remove_omits_only_target_entry() -> void:
 	assert_false(after.contains(McpClientConfigurator.SERVER_NAME), "our server entry must be gone")
 
 
-func test_json_strategy_configure_refuses_when_file_has_lossy_numbers() -> void:
-	## F5 (simple path): configure must fail closed when the file contains an
-	## integer above 2^53, and the file must be byte-for-byte unchanged.
-	var scratch := _scratch_dir.path_join("f5_simple_refuse")
+func test_json_strategy_configure_preserves_lossy_numbers() -> void:
+	## F5 (simple path): token-preserving configure must leave integers above
+	## 2^53 byte-for-byte while still updating the target entry.
+	var scratch := _scratch_dir.path_join("f5_simple_preserve")
 	DirAccess.make_dir_recursive_absolute(scratch)
 	var path := scratch.path_join("lossy.json")
 	var body := (
@@ -5697,17 +5773,16 @@ func test_json_strategy_configure_refuses_when_file_has_lossy_numbers() -> void:
 	_write_raw_json(path, body)
 	var client := _make_test_json_client(path)
 	var result := McpJsonStrategy.configure(client, McpClientConfigurator.SERVER_NAME, "http://127.0.0.1:8000/mcp")
-	assert_eq(result.get("status"), "error", "configure must refuse a lossy file; got %s" % result.get("message", ""))
-	assert_true(
-		str(result.get("message", "")).contains("2^53") or str(result.get("message", "")).contains("imprecise"),
-		"refusal message must explain why; got: %s" % result.get("message", ""),
-	)
-	assert_eq(_read_raw_json(path), body, "the file must NOT be mutated on refusal")
+	assert_eq(result.get("status"), "ok", "configure must patch in place; got %s" % result.get("message", ""))
+	var after := _read_raw_json(path)
+	assert_true(after.contains('"bigId": 9007199254740993'), "lossy integer literal must survive; got: %s" % after)
+	assert_true(after.contains("http://127.0.0.1:8000/mcp"), "target URL must update; got: %s" % after)
+	assert_false(after.contains("http://127.0.0.1:9000/mcp"), "old URL must be replaced")
 
 
-func test_json_strategy_pi_merge_configure_refuses_when_file_has_lossy_numbers() -> void:
-	## F5 (merge path): same refusal contract as the simple path.
-	var scratch := _scratch_dir.path_join("f5_merge_refuse")
+func test_json_strategy_pi_merge_configure_preserves_lossy_numbers() -> void:
+	## F5 (merge path): same token-preserving contract as the simple path.
+	var scratch := _scratch_dir.path_join("f5_merge_preserve")
 	DirAccess.make_dir_recursive_absolute(scratch)
 	var tier := scratch.path_join("lossy.json")
 	var body := (
@@ -5721,8 +5796,10 @@ func test_json_strategy_pi_merge_configure_refuses_when_file_has_lossy_numbers()
 	_write_raw_json(tier, body)
 	var client := _make_merged_json_client(PackedStringArray([tier]))
 	var result := McpJsonStrategy.configure(client, McpClientConfigurator.SERVER_NAME, "http://127.0.0.1:8000/mcp")
-	assert_eq(result.get("status"), "error", "merge-configure must refuse a lossy tier; got %s" % result.get("message", ""))
-	assert_eq(_read_raw_json(tier), body, "the tier must NOT be mutated on refusal")
+	assert_eq(result.get("status"), "ok", "merge-configure must patch in place; got %s" % result.get("message", ""))
+	var after := _read_raw_json(tier)
+	assert_true(after.contains('"bigId": 9007199254740993'), "lossy integer literal must survive; got: %s" % after)
+	assert_true(after.contains("http://127.0.0.1:8000/mcp"), "target URL must update; got: %s" % after)
 
 
 func test_text_remove_server_entry_is_byte_for_byte_outside_target() -> void:
@@ -5747,6 +5824,81 @@ func test_text_remove_server_entry_is_byte_for_byte_outside_target() -> void:
 	var parsed = JSON.parse_string(updated)
 	assert_true(parsed is Dictionary, "result must remain valid JSON")
 	assert_false((parsed as Dictionary)["mcpServers"].has(McpClientConfigurator.SERVER_NAME), "our server must not appear")
+
+
+func test_text_upsert_server_entry_preserves_unrelated_jsonc() -> void:
+	## Direct coverage of configure's splice helper (#914). Header comments,
+	## inner comments, and unrelated keys must survive byte-for-byte.
+	var helper := McpJsonStrategy
+	var body := (
+		"// Zed settings\n"
+		+ "{\n"
+		+ "\t\"theme\": \"one-dark\", /* keep */\n"
+		+ "\t\"mcpServers\": {\n"
+		+ "\t\t\"keep\": {\"url\": \"http://other/\"}\n"
+		+ "\t}\n"
+		+ "}\n"
+	)
+	var patched: Dictionary = helper._text_upsert_server_entry(
+		body,
+		PackedStringArray(["mcpServers"]),
+		McpClientConfigurator.SERVER_NAME,
+		{"url": "http://127.0.0.1:8000/mcp"},
+	)
+	assert_true(patched.get("ok"), "upsert must succeed: %s" % patched.get("error", ""))
+	var updated: String = str(patched.get("text"))
+	assert_true(updated.begins_with("// Zed settings\n"), "header must survive")
+	assert_true(updated.contains("\t\"theme\": \"one-dark\", /* keep */\n"), "inner comment must survive")
+	assert_true(updated.contains("\t\t\"keep\": {\"url\": \"http://other/\"}"), "unrelated entry must survive verbatim")
+	assert_true(updated.contains(McpClientConfigurator.SERVER_NAME), "target entry must be inserted")
+	var stripped: Dictionary = helper._strip_jsonc(updated)
+	assert_true(stripped.get("ok"))
+	var parsed = JSON.parse_string(str(stripped.get("text")))
+	assert_true(parsed is Dictionary)
+	assert_true((parsed as Dictionary)["mcpServers"].has("keep"))
+	assert_true((parsed as Dictionary)["mcpServers"].has(McpClientConfigurator.SERVER_NAME))
+
+
+func test_text_upsert_replaces_existing_entry_only() -> void:
+	var helper := McpJsonStrategy
+	var body := (
+		"{\n"
+		+ "\t\"mcpServers\": {\n"
+		+ "\t\t\"keep\": {\"url\": \"http://other/\"},\n"
+		+ "\t\t\"" + McpClientConfigurator.SERVER_NAME + "\": {\"url\": \"http://old/\"}\n"
+		+ "\t}\n"
+		+ "}\n"
+	)
+	var patched: Dictionary = helper._text_upsert_server_entry(
+		body,
+		PackedStringArray(["mcpServers"]),
+		McpClientConfigurator.SERVER_NAME,
+		{"url": "http://new/"},
+	)
+	assert_true(patched.get("ok"), "upsert must succeed: %s" % patched.get("error", ""))
+	var updated: String = str(patched.get("text"))
+	assert_true(updated.contains("\t\t\"keep\": {\"url\": \"http://other/\"}"), "unrelated entry must survive")
+	assert_true(updated.contains("http://new/"))
+	assert_false(updated.contains("http://old/"))
+
+
+func test_text_remove_server_entry_preserves_jsonc_header() -> void:
+	var helper := McpJsonStrategy
+	var body := (
+		"// Zed settings\n"
+		+ "{\n"
+		+ "\t\"mcpServers\": {\n"
+		+ "\t\t\"keep\": {\"url\": \"http://other/\"},\n"
+		+ "\t\t\"" + McpClientConfigurator.SERVER_NAME + "\": {\"url\": \"http://127.0.0.1:8000/mcp\"}\n"
+		+ "\t}\n"
+		+ "}\n"
+	)
+	var updated: String = helper._text_remove_server_entry(
+		body, PackedStringArray(["mcpServers"]), McpClientConfigurator.SERVER_NAME
+	)
+	assert_true(updated.begins_with("// Zed settings\n"), "JSONC header must survive remove")
+	assert_false(updated.contains(McpClientConfigurator.SERVER_NAME), "entry must be removed")
+	assert_true(updated.contains("\t\t\"keep\": {\"url\": \"http://other/\"}"), "unrelated entry must survive")
 
 
 # ----- F5 scanner regression: middle-position + sibling-collision coverage -----

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -2566,10 +2566,11 @@ func test_json_strategy_preserves_integer_fields() -> void:
 
 func test_json_strategy_refuses_to_overwrite_unparseable_file() -> void:
 	## Regression: if the config file exists but we can't parse it (trailing
-	## comma, stray comment, truncated write), `configure()` used to silently
-	## fall back to `{}` and write only the godot-ai entry — wiping every
-	## other MCP the user had configured. Now it must refuse and surface an
-	## error so the user can inspect and recover.
+	## comma, truncated write), `configure()` used to silently fall back to
+	## `{}` and write only the godot-ai entry — wiping every other MCP the
+	## user had configured. Now it must refuse and surface an error so the
+	## user can inspect and recover. JSONC comments are stripped before
+	## parse; this fixture stays unparseable because of the trailing comma.
 	var path := _scratch_dir.path_join("unparseable.json")
 	var bogus := "{\n  \"mcpServers\": {\n    \"someone-else\": {\"url\": \"http://other/\"},  // trailing comment\n  }\n"
 	var f := FileAccess.open(path, FileAccess.WRITE)
@@ -2631,6 +2632,100 @@ func test_json_strategy_tolerates_utf8_bom() -> void:
 	assert_true(parsed is Dictionary and parsed.has("mcpServers"))
 	assert_true(parsed["mcpServers"].has("someone-else"), "Existing entry wiped after BOM parse recovery")
 	assert_true(parsed["mcpServers"].has("godot-ai"), "godot-ai entry not added")
+
+
+func test_json_strategy_tolerates_zed_jsonc_header() -> void:
+	## Zed ships settings.json with a `// Zed settings` comment header.
+	## Godot's JSON.parse rejects comments, so Configure used to refuse
+	## forever on a stock install. Strip JSONC on the parse copy only.
+	var path := _scratch_dir.path_join("zed_jsonc.json")
+	var seed := {"mcpServers": {"someone-else": {"url": "http://other/"}}}
+	var body := "// Zed settings\n" + JSON.stringify(seed)
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	f.store_string(body)
+	f.close()
+
+	var client := _make_test_json_client(path)
+	var result := McpJsonStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+	assert_eq(result.get("status"), "ok", "Zed JSONC header should parse after strip: %s" % result.get("message", ""))
+
+	var check_file := FileAccess.open(path, FileAccess.READ)
+	var parsed = JSON.parse_string(check_file.get_as_text())
+	check_file.close()
+	assert_true(parsed is Dictionary and parsed.has("mcpServers"))
+	assert_true(parsed["mcpServers"].has("someone-else"), "Existing entry wiped after JSONC parse recovery")
+	assert_true(parsed["mcpServers"].has("godot-ai"), "godot-ai entry not added")
+
+
+func test_read_file_text_parses_zed_jsonc_header() -> void:
+	## Focused unit path: `_read_file_text` / `_read_or_init` must accept a
+	## file that begins with `// Zed settings` and leave original_text intact.
+	var path := _scratch_dir.path_join("zed_read_jsonc.json")
+	var body := "// Zed settings\n{\"theme\": \"one-dark\", \"context_servers\": {}}\n"
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	f.store_string(body)
+	f.close()
+
+	var read := McpJsonStrategy._read_file_text(path)
+	assert_true(read.get("ok"), "Zed JSONC header must parse: %s" % read.get("error", ""))
+	assert_true(read.get("data") is Dictionary)
+	var data: Dictionary = read.get("data")
+	assert_eq(data.get("theme"), "one-dark")
+	assert_true(data.has("context_servers"), "parsed object must keep context_servers")
+	assert_eq(read.get("original_text"), body, "comments must stay in original_text")
+
+	var init := McpJsonStrategy._read_or_init(path)
+	assert_true(init.get("ok"), "_read_or_init must succeed on Zed JSONC: %s" % init.get("error", ""))
+	assert_eq((init.get("data") as Dictionary).get("theme"), "one-dark")
+
+
+func test_read_file_text_strips_jsonc_block_comments() -> void:
+	## `/* block */` comments (including inner ones) are stripped on the
+	## parse copy; original_text keeps them.
+	var path := _scratch_dir.path_join("jsonc_block.json")
+	var body := "/* block */\n{\"a\": \"keep\", /* inner */ \"b\": \"also\"}\n"
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	f.store_string(body)
+	f.close()
+
+	var read := McpJsonStrategy._read_file_text(path)
+	assert_true(read.get("ok"), "block comments must parse: %s" % read.get("error", ""))
+	var data: Dictionary = read.get("data")
+	assert_eq(data.get("a"), "keep")
+	assert_eq(data.get("b"), "also")
+	assert_eq(read.get("original_text"), body, "block comments must stay in original_text")
+
+
+func test_strip_jsonc_preserves_comment_markers_inside_strings() -> void:
+	## A `//` or `/* */` sequence inside a JSON string is data, not a comment.
+	var src := '{"url": "http://example.com//path", "note": "use /* not */ here"}'
+	var stripped: String = McpJsonStrategy._strip_jsonc(src)
+	assert_eq(stripped, src, "comment markers inside strings must be preserved")
+	var parsed: Variant = JSON.parse_string(stripped)
+	assert_true(parsed is Dictionary, "stripped text must remain valid JSON")
+	assert_eq((parsed as Dictionary).get("url"), "http://example.com//path")
+	assert_eq((parsed as Dictionary).get("note"), "use /* not */ here")
+	var escaped := '{"a": "foo\\" // not a comment"}'
+	assert_eq(McpJsonStrategy._strip_jsonc(escaped), escaped, "escaped quotes must not end the string early")
+
+
+func test_read_file_text_jsonc_still_errors_on_invalid_json() -> void:
+	## Comment stripping is not a license to accept broken JSON. A Zed-style
+	## header in front of invalid JSON must still fail closed.
+	var path := _scratch_dir.path_join("jsonc_invalid.json")
+	var body := "// Zed settings\n{not-valid-json\n"
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	f.store_string(body)
+	f.close()
+
+	var read := McpJsonStrategy._read_file_text(path)
+	assert_false(read.get("ok"), "invalid JSON after comment strip must still error")
+	var err: String = str(read.get("error", ""))
+	assert_true(err.find("JSON parse error") >= 0, "error should mention JSON parse: %s" % err)
+	assert_eq(read.get("original_text"), body, "failed parse must still return original_text")
+
+	var init := McpJsonStrategy._read_or_init(path)
+	assert_false(init.get("ok"), "_read_or_init must also fail on invalid JSONC")
 
 
 func test_json_strategy_remove_refuses_unparseable_file() -> void:

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -5997,6 +5997,31 @@ func test_strip_jsonc_preserves_newlines_inside_block_comments() -> void:
 	assert_true(str(stripped.get("text")).begins_with("\n\n{"), "block-comment newlines must remain for parse line numbers")
 
 
+func test_strip_jsonc_does_not_glue_literal_fragments() -> void:
+	## Comments inside `true`/`false`/`null`/numbers must not splice the
+	## fragments into a different token. `_strip_jsonc` inserts a space so
+	## the later JSON.parse fails closed instead of accepting `tru/*x*/e`
+	## as `true`.
+	var helper := McpJsonStrategy
+	var glued := [
+		'{"enabled": tru/* x */e}',
+		'{"enabled": fal/* x */se}',
+		'{"v": nu/* x */ll}',
+		'{"n": 12/* x */34}',
+	]
+	for src in glued:
+		var stripped: Dictionary = helper._strip_jsonc(src)
+		assert_true(stripped.get("ok"), "strip itself must succeed: %s -> %s" % [src, stripped.get("error", "")])
+		var json := JSON.new()
+		assert_ne(json.parse(str(stripped.get("text"))), OK, "glued literal must not parse: %s -> %s" % [src, stripped.get("text")])
+	var trailing := '{"enabled": true/* x */, "n": 1}'
+	var keep: Dictionary = helper._strip_jsonc(trailing)
+	assert_true(keep.get("ok"), "comment after a complete token must strip: %s" % keep.get("error", ""))
+	var keep_json := JSON.new()
+	assert_eq(keep_json.parse(str(keep.get("text"))), OK, "true/* x */ must still parse: %s" % keep.get("text"))
+	assert_eq((keep_json.data as Dictionary).get("enabled"), true)
+
+
 func test_text_upsert_server_entry_preserves_unrelated_jsonc() -> void:
 	## Direct coverage of configure's splice helper (#914). Header comments,
 	## inner comments, and unrelated keys must survive byte-for-byte.

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -2804,6 +2804,39 @@ func test_json_strategy_configure_preserves_unrelated_jsonc_byte_for_byte() -> v
 	assert_eq((servers["godot-ai"] as Dictionary).get("url"), "http://127.0.0.1:8000/mcp")
 
 
+func test_json_strategy_configure_preserves_comment_in_empty_server_map() -> void:
+	## Empty `mcpServers: { /* keep */ }` is the stock "no servers yet"
+	## shape. Inserting our entry must not drop the inner comment.
+	var path := _scratch_dir.path_join("jsonc_empty_map.json")
+	var body := (
+		"// Zed settings\n"
+		+ "{\n"
+		+ "\t\"theme\": \"one-dark\",\n"
+		+ "\t\"mcpServers\": { /* keep inner */ }\n"
+		+ "}\n"
+	)
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	f.store_string(body)
+	f.close()
+
+	var client := _make_test_json_client(path)
+	var result := McpJsonStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+	assert_eq(result.get("status"), "ok", "empty-map JSONC configure should succeed: %s" % result.get("message", ""))
+
+	var check_file := FileAccess.open(path, FileAccess.READ)
+	var written := check_file.get_as_text()
+	check_file.close()
+	assert_true(written.begins_with("// Zed settings\n"), "header must survive; got: %s" % written)
+	assert_true(written.contains("/* keep inner */"), "inner empty-object comment must survive; got: %s" % written)
+	assert_true(written.contains("\t\"theme\": \"one-dark\",\n"), "unrelated key must survive; got: %s" % written)
+
+	var reread := McpJsonStrategy._read_file_text(path)
+	assert_true(reread.get("ok"), "preserved JSONC must still parse: %s" % reread.get("error", ""))
+	var servers: Dictionary = (reread.get("data") as Dictionary).get("mcpServers")
+	assert_true(servers.has("godot-ai"))
+	assert_eq((servers["godot-ai"] as Dictionary).get("url"), "http://127.0.0.1:8000/mcp")
+
+
 func test_json_strategy_remove_refuses_unparseable_file() -> void:
 	## remove() has the same wipe-risk as configure() — it also round-trips
 	## through _read_or_init and writes back. Must refuse on bad input.
@@ -5824,6 +5857,47 @@ func test_text_remove_server_entry_is_byte_for_byte_outside_target() -> void:
 	var parsed = JSON.parse_string(updated)
 	assert_true(parsed is Dictionary, "result must remain valid JSON")
 	assert_false((parsed as Dictionary)["mcpServers"].has(McpClientConfigurator.SERVER_NAME), "our server must not appear")
+
+
+func test_text_upsert_preserves_comments_inside_empty_object() -> void:
+	## `{ /* keep */ }` has no properties, so the insert path used to treat
+	## the object as empty and rewrite from `{` to `}`, dropping the comment.
+	var helper := McpJsonStrategy
+	var body := (
+		"// Zed settings\n"
+		+ "{\n"
+		+ "\t\"mcpServers\": { /* keep inner */ }\n"
+		+ "}\n"
+	)
+	var patched: Dictionary = helper._text_upsert_server_entry(
+		body,
+		PackedStringArray(["mcpServers"]),
+		McpClientConfigurator.SERVER_NAME,
+		{"url": "http://127.0.0.1:8000/mcp"},
+	)
+	assert_true(patched.get("ok"), "upsert into comments-only object must succeed: %s" % patched.get("error", ""))
+	var updated: String = str(patched.get("text"))
+	assert_true(updated.begins_with("// Zed settings\n"), "header must survive")
+	assert_true(updated.contains("/* keep inner */"), "comment inside empty object must survive; got: %s" % updated)
+	var stripped: Dictionary = helper._strip_jsonc(updated)
+	assert_true(stripped.get("ok"), "result must still strip: %s" % stripped.get("error", ""))
+	var parsed = JSON.parse_string(str(stripped.get("text")))
+	assert_true(parsed is Dictionary)
+	assert_true((parsed as Dictionary)["mcpServers"].has(McpClientConfigurator.SERVER_NAME))
+
+
+func test_json_value_span_end_stops_before_glued_comment() -> void:
+	## `9007199254740993/* keep */` must not swallow the comment into the
+	## literal span, or a later splice would rewrite it away.
+	var helper := McpJsonStrategy
+	var body := "{\"bigId\": 9007199254740993/* keep */, \"ok\": true}"
+	var found: Dictionary = helper._find_key_at_container_depth(
+		body, 1, JSON.stringify("bigId")
+	)
+	assert_false(found.is_empty(), "bigId key must be found")
+	var value_end: int = found["value_end"]
+	assert_eq(body.substr(int(found["value_start"]), value_end - int(found["value_start"])), "9007199254740993")
+	assert_true(body.substr(value_end).begins_with("/* keep */"), "span must stop before the glued comment")
 
 
 func test_text_upsert_server_entry_preserves_unrelated_jsonc() -> void:

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -5900,6 +5900,73 @@ func test_json_value_span_end_stops_before_glued_comment() -> void:
 	assert_true(body.substr(value_end).begins_with("/* keep */"), "span must stop before the glued comment")
 
 
+func test_text_upsert_repairs_scalar_server_map() -> void:
+	## `_ensure_path` replaces a non-object holder. Token-preserving
+	## configure must do the same instead of refusing the splice.
+	var helper := McpJsonStrategy
+	var body := "// header\n{\"theme\": \"x\", \"mcpServers\": 5}\n"
+	var patched: Dictionary = helper._text_upsert_server_entry(
+		body,
+		PackedStringArray(["mcpServers"]),
+		McpClientConfigurator.SERVER_NAME,
+		{"url": "http://127.0.0.1:8000/mcp"},
+	)
+	assert_true(patched.get("ok"), "scalar holder must be repaired: %s" % patched.get("error", ""))
+	var updated: String = str(patched.get("text"))
+	assert_true(updated.begins_with("// header\n"), "header must survive scalar repair")
+	assert_true(updated.contains("\"theme\": \"x\""), "unrelated key must survive")
+	assert_false(updated.contains("\"mcpServers\": 5"), "scalar holder must be replaced")
+	var stripped: Dictionary = helper._strip_jsonc(updated)
+	assert_true(stripped.get("ok"))
+	var parsed = JSON.parse_string(str(stripped.get("text")))
+	assert_true(parsed is Dictionary)
+	assert_true((parsed as Dictionary)["mcpServers"].has(McpClientConfigurator.SERVER_NAME))
+
+
+func test_json_strategy_configure_repairs_scalar_server_map() -> void:
+	var path := _scratch_dir.path_join("scalar_map.json")
+	var body := "{\"mcpServers\": 5, \"keep\": true}\n"
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	f.store_string(body)
+	f.close()
+	var client := _make_test_json_client(path)
+	var result := McpJsonStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+	assert_eq(result.get("status"), "ok", "scalar mcpServers must be repairable: %s" % result.get("message", ""))
+	var reread := McpJsonStrategy._read_file_text(path)
+	assert_true(reread.get("ok"), "repaired file must parse: %s" % reread.get("error", ""))
+	var data: Dictionary = reread.get("data")
+	assert_eq(data.get("keep"), true)
+	assert_true((data.get("mcpServers") as Dictionary).has("godot-ai"))
+
+
+func test_text_remove_keeps_comment_documenting_next_entry() -> void:
+	## A comment after the target's trailing comma belongs to the next
+	## entry and must not be consumed with the removed property.
+	var helper := McpJsonStrategy
+	var body := (
+		"{\n"
+		+ "\t\"mcpServers\": {\n"
+		+ "\t\t\"" + McpClientConfigurator.SERVER_NAME + "\": {},\n"
+		+ "\t\t// note about other\n"
+		+ "\t\t\"other\": {\"url\": \"http://other/\"}\n"
+		+ "\t}\n"
+		+ "}\n"
+	)
+	var updated: String = helper._text_remove_server_entry(
+		body, PackedStringArray(["mcpServers"]), McpClientConfigurator.SERVER_NAME
+	)
+	assert_false(updated.contains(McpClientConfigurator.SERVER_NAME), "entry must be removed")
+	assert_true(updated.contains("// note about other"), "next-entry comment must survive; got: %s" % updated)
+	assert_true(updated.contains("\"other\": {\"url\": \"http://other/\"}"), "next entry must survive")
+
+
+func test_strip_jsonc_preserves_newlines_inside_block_comments() -> void:
+	var src := "/*\n\n*/{\"a\": true}\n"
+	var stripped: Dictionary = McpJsonStrategy._strip_jsonc(src)
+	assert_true(stripped.get("ok"), "multiline block comment must strip: %s" % stripped.get("error", ""))
+	assert_true(str(stripped.get("text")).begins_with("\n\n{"), "block-comment newlines must remain for parse line numbers")
+
+
 func test_text_upsert_server_entry_preserves_unrelated_jsonc() -> void:
 	## Direct coverage of configure's splice helper (#914). Header comments,
 	## inner comments, and unrelated keys must survive byte-for-byte.

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -2611,6 +2611,24 @@ func test_json_strategy_refuses_to_overwrite_non_object_root() -> void:
 	check_file.close()
 
 
+func test_read_file_text_restores_utf8_bom_in_original_text() -> void:
+	## Godot's UTF-8 decoder skips EF BB BF. `_read_file_text` must still
+	## put U+FEFF back on `original_text` so configure/remove can write it.
+	var path := _scratch_dir.path_join("bom_read.json")
+	var body := "\uFEFF" + JSON.stringify({"mcpServers": {}})
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	f.store_string(body)
+	f.close()
+	var read := McpJsonStrategy._read_file_text(path)
+	assert_true(read.get("ok"), "BOM-prefixed JSON must parse: %s" % read.get("error", ""))
+	assert_true(
+		str(read.get("original_text", "")).begins_with("\uFEFF"),
+		"original_text must restore U+FEFF after Godot skips the on-disk BOM"
+	)
+	assert_true((read.get("data") as Dictionary).has("mcpServers"))
+	_remove_if_exists(path)
+
+
 func test_json_strategy_tolerates_utf8_bom() -> void:
 	## JSON saved with a UTF-8 BOM (common from Windows editors) parses as
 	## invalid under Godot's JSON.parse. Under the old strategy that meant a
@@ -2627,12 +2645,24 @@ func test_json_strategy_tolerates_utf8_bom() -> void:
 	var result := McpJsonStrategy.configure(client, "godot-ai", "http://127.0.0.1:8000/mcp")
 	assert_eq(result.get("status"), "ok", "BOM-prefixed JSON should parse after strip")
 
+	# `get_as_text()` skips EF BB BF, so a string-prefix check cannot prove
+	# the BOM survived on disk. Inspect the raw leading bytes instead.
 	var check_file := FileAccess.open(path, FileAccess.READ)
-	var written := check_file.get_as_text()
+	var written_bytes := check_file.get_buffer(check_file.get_length())
 	check_file.close()
-	assert_true(written.begins_with("﻿"), "UTF-8 BOM must survive configure")
+	assert_true(
+		written_bytes.size() >= 3
+		and written_bytes[0] == 0xEF
+		and written_bytes[1] == 0xBB
+		and written_bytes[2] == 0xBF,
+		"UTF-8 BOM bytes must survive configure"
+	)
 	var reread := McpJsonStrategy._read_file_text(path)
 	assert_true(reread.get("ok"), "BOM-prefixed write must still parse: %s" % reread.get("error", ""))
+	assert_true(
+		str(reread.get("original_text", "")).begins_with("\uFEFF"),
+		"original_text must keep U+FEFF so the next write can round-trip the BOM"
+	)
 	var parsed: Dictionary = reread.get("data")
 	assert_true(parsed.has("mcpServers"))
 	assert_true(parsed["mcpServers"].has("someone-else"), "Existing entry wiped after BOM parse recovery")


### PR DESCRIPTION
## Summary
- Zed ships `settings.json` with a `//` comment header. Godot's `JSON.parse` has no comment support, so a default install failed Configure permanently.
- `_read_file_text` now strips `//` line comments and `/* */` block comments from the parse copy only (after the existing BOM strip). Sequences inside JSON strings are left intact; `original_text` is unchanged so remove/rollback stay byte-for-byte.
- Added GDScript tests for the Zed header, block comments, in-string `//`, and invalid JSON still erroring.

## Test plan
- [ ] `test_json_strategy_tolerates_zed_jsonc_header` / `test_read_file_text_parses_zed_jsonc_header`
- [ ] `test_read_file_text_strips_jsonc_block_comments`
- [ ] `test_strip_jsonc_preserves_comment_markers_inside_strings`
- [ ] `test_read_file_text_jsonc_still_errors_on_invalid_json`
- [ ] Existing BOM / unparseable-file tests still pass
- Live GDScript tests were not run (Godot was not launched, per issue instructions).

Fixes #914

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Configuration updates preserve existing formatting, comments, UTF-8 markers, and large numeric values.
  - JSONC files are handled more reliably, including commented and empty files.
  - Unrelated entries remain unchanged when servers are added or removed.

- **Bug Fixes**
  - Improved streamed-response handling for keepalive lines, carriage returns, and UTF-8 markers.
  - Extended timeout support for lengthy operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->