### PR TITLE
fix: honor a later telemetry opt-out on an already-running server

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -88,6 +88,19 @@ spawns). Attach entries written before the toggle changed read as
 `configured_mismatch` — re-run Configure so the client relaunches the bridge
 with the current preference.
 
+Apply & Restart does **not** mutate the environment of a server the plugin
+adopted rather than spawned (a hand-started dev server, CI backend, or
+attach-owned process). That process keeps whatever telemetry state it was
+born with until *its* environment changes or it is replaced. `/godot-ai/status`
+publishes `telemetry_enabled` from a live env re-read so the dock can show
+when the checkbox and the running server disagree; it is a report, not an
+opt-out channel.
+
+Record/send paths in an already-running Python process re-read
+`GODOT_AI_DISABLE_TELEMETRY` / `DISABLE_TELEMETRY` on each event, so an
+in-process env change in that server takes effect without reconstructing
+the collector.
+
 ### Via environment variable
 
 Set either environment variable to `true` / `1` / `yes` / `on`:

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -1559,8 +1559,8 @@ func _on_telemetry_toggled(pressed: bool) -> void:
 
 
 ## Report the running server's telemetry state, not just this editor's
-## checkbox. An adopted backend ignores the EditorSetting until its own
-## environment is changed (#913).
+## checkbox. Apply & Restart injects opt-out into a server this plugin
+## spawns; it cannot change the environment of an adopted process (#913).
 func _live_telemetry_tooltip(local_enabled: bool) -> String:
 	if _plugin == null or not _plugin.has_method("_probe_live_server_status"):
 		return ""

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -1548,12 +1548,33 @@ func _load_telemetry_setting() -> void:
 		)
 	else:
 		_telemetry_toggle.disabled = false
-		_telemetry_toggle.tooltip_text = ""
+		_telemetry_toggle.tooltip_text = _live_telemetry_tooltip(enabled)
 
 
 func _on_telemetry_toggled(pressed: bool) -> void:
 	_telemetry_pending_enabled = pressed
+	if _telemetry_toggle != null:
+		_telemetry_toggle.tooltip_text = _live_telemetry_tooltip(pressed)
 	_refresh_tools_ui_state()
+
+
+## Report the running server's telemetry state, not just this editor's
+## checkbox. An adopted backend ignores the EditorSetting until its own
+## environment is changed (#913).
+func _live_telemetry_tooltip(local_enabled: bool) -> String:
+	if _plugin == null or not _plugin.has_method("_probe_live_server_status"):
+		return ""
+	var live: Dictionary = _plugin._probe_live_server_status(ClientConfigurator.http_port())
+	if not (live.get("telemetry_enabled") is bool):
+		return ""
+	var server_enabled: bool = live.get("telemetry_enabled")
+	if server_enabled == local_enabled:
+		return "Running server telemetry is %s." % ("on" if server_enabled else "off")
+	return (
+		"This editor wants telemetry %s, but the running server still has it %s. "
+		+ "Opt-out only reaches a server this plugin spawned. Stop that process "
+		+ "or set GODOT_AI_DISABLE_TELEMETRY in its environment."
+	) % ["on" if local_enabled else "off", "on" if server_enabled else "off"]
 
 
 # --- Dev mode persistence ---

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -1019,6 +1019,11 @@ static func _project_status_payload(parsed: Dictionary) -> Dictionary:
 		## skew. Older servers omit it; treat the missing field as "".
 		"package_path": str(parsed.get("package_path", "")),
 	}
+	## #913: live server telemetry state. Absent on older backends so the
+	## dock can tell "too old to publish" from an explicit false.
+	var telemetry_enabled: Variant = parsed.get("telemetry_enabled")
+	if telemetry_enabled is bool:
+		projected["telemetry_enabled"] = telemetry_enabled
 	## #824: advisory attach-lease count, consumed by teardown to decide
 	## detach-vs-kill. Absent stays absent rather than defaulting to 0, so
 	## `ServerLifecycleManager.active_lease_count` keeps distinguishing "backend

--- a/src/godot_ai/server.py
+++ b/src/godot_ai/server.py
@@ -660,8 +660,9 @@ def create_server(
                 ## ``instance_id`` it belongs to, so it cannot be stale
                 ## relative to that instance.
                 "active_lease_count": leases.active_count(),
-                ## Live opt-out, not the construction-time snapshot, so the
-                ## dock can show what this process will actually send (#913).
+                ## Live env re-read so the dock can show what this process
+                ## will actually send. Advisory only — this route does not
+                ## accept an opt-out mutation (#913).
                 "telemetry_enabled": not TelemetryConfig._is_disabled_via_env(),
             }
         )

--- a/src/godot_ai/server.py
+++ b/src/godot_ai/server.py
@@ -66,6 +66,7 @@ from godot_ai.sessions.registry import SessionRegistry
 from godot_ai.telemetry import (
     MilestoneType,
     RecordType,
+    TelemetryConfig,
     install_fastmcp_wraps,
     record_milestone,
     record_telemetry,
@@ -659,6 +660,9 @@ def create_server(
                 ## ``instance_id`` it belongs to, so it cannot be stale
                 ## relative to that instance.
                 "active_lease_count": leases.active_count(),
+                ## Live opt-out, not the construction-time snapshot, so the
+                ## dock can show what this process will actually send (#913).
+                "telemetry_enabled": not TelemetryConfig._is_disabled_via_env(),
             }
         )
 

--- a/src/godot_ai/telemetry.py
+++ b/src/godot_ai/telemetry.py
@@ -201,6 +201,16 @@ class TelemetryConfig:
         else:
             self._cleanup_local_files()
 
+    def live_enabled(self) -> bool:
+        """Re-read opt-out env vars on every call.
+
+        ``enabled`` is the construction-time snapshot used to decide
+        whether to create on-disk artifacts and start the worker. An
+        adopted server the plugin did not spawn keeps that snapshot for
+        life unless we re-check here (#913).
+        """
+        return not self._is_disabled_via_env()
+
     # --- env helpers -----------------------------------------------------
 
     @staticmethod
@@ -393,7 +403,7 @@ class TelemetryCollector:
         session_id: str | None = None,
     ) -> None:
         """Enqueue an event. Non-blocking; drops on queue full."""
-        if not self.config.enabled:
+        if not self.config.enabled or not self.config.live_enabled():
             return
 
         record = TelemetryRecord(
@@ -419,7 +429,7 @@ class TelemetryCollector:
         self, milestone: MilestoneType, data: dict[str, Any] | None = None
     ) -> bool:
         """Record a one-shot milestone. Returns ``True`` only on first call."""
-        if not self.config.enabled:
+        if not self.config.enabled or not self.config.live_enabled():
             return False
         key = milestone.value
         ## Mark in memory under the lock; persistence is enqueued for the
@@ -492,6 +502,8 @@ class TelemetryCollector:
                     self._queue.task_done()
 
     def _send(self, record: TelemetryRecord) -> None:
+        if not self.config.live_enabled():
+            return
         endpoint = self.config.endpoint
         if not endpoint:
             ## Pre-backend phase: log exactly once at debug level so an

--- a/src/godot_ai/telemetry.py
+++ b/src/godot_ai/telemetry.py
@@ -205,9 +205,16 @@ class TelemetryConfig:
         """Re-read opt-out env vars on every call.
 
         ``enabled`` is the construction-time snapshot used to decide
-        whether to create on-disk artifacts and start the worker. An
-        adopted server the plugin did not spawn keeps that snapshot for
-        life unless we re-check here (#913).
+        whether to create on-disk artifacts and start the worker.
+        Record/send paths consult this method so an in-process change
+        to ``GODOT_AI_DISABLE_TELEMETRY`` / ``DISABLE_TELEMETRY`` takes
+        effect without reconstructing the collector (#913).
+
+        This does not receive the dock checkbox: the Godot editor cannot
+        mutate another process's environment. An adopted server keeps
+        sending until *that* process sees the env var. Status
+        ``telemetry_enabled`` reports this live read so the dock can
+        show the disagreement instead of claiming the checkbox applied.
         """
         return not self._is_disabled_via_env()
 

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -1969,8 +1969,9 @@ func test_status_projection_carries_the_lease_count_to_the_consumer() -> void:
 
 
 func test_status_projection_surfaces_telemetry_enabled() -> void:
-	## #913: the dock reads the live server's opt-out from the projected
-	## probe, not from EditorSettings.
+	## #913: the dock reads the live server's env-derived state from the
+	## projected probe, not from EditorSettings. This is a report, not a
+	## channel that applies the checkbox to an adopted process.
 	var off := GodotAiPlugin._project_status_payload({
 		"name": "godot-ai", "telemetry_enabled": false,
 	})

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -1968,6 +1968,27 @@ func test_status_projection_carries_the_lease_count_to_the_consumer() -> void:
 	assert_true(bool(projected.get("reachable")))
 
 
+func test_status_projection_surfaces_telemetry_enabled() -> void:
+	## #913: the dock reads the live server's opt-out from the projected
+	## probe, not from EditorSettings.
+	var off := GodotAiPlugin._project_status_payload({
+		"name": "godot-ai", "telemetry_enabled": false,
+	})
+	assert_true(off.has("telemetry_enabled"))
+	assert_eq(off.get("telemetry_enabled"), false)
+	var on := GodotAiPlugin._project_status_payload({
+		"name": "godot-ai", "telemetry_enabled": true,
+	})
+	assert_eq(on.get("telemetry_enabled"), true)
+
+
+func test_status_projection_leaves_telemetry_enabled_absent_on_old_backend() -> void:
+	var projected := GodotAiPlugin._project_status_payload({
+		"name": "godot-ai", "server_version": "3.0.6",
+	})
+	assert_false(projected.has("telemetry_enabled"))
+
+
 func test_status_projection_leaves_an_older_backends_field_absent() -> void:
 	## "Too old to publish it" must stay distinguishable from "reports zero",
 	## which is what the absent-stays-absent rule buys. Both stop the server.

--- a/tests/unit/test_server_status.py
+++ b/tests/unit/test_server_status.py
@@ -13,6 +13,7 @@ from godot_ai.protocol.attach import (
     owner_type_from_env,
 )
 from godot_ai.server import create_server
+from godot_ai.telemetry import TelemetryConfig
 
 
 def test_status_route_reports_live_server_version():
@@ -30,6 +31,7 @@ def test_status_route_reports_live_server_version():
     payload = response.json()
     instance_id = payload.pop("instance_id")
     catalog_hash = payload.pop("tool_catalog_hash")
+    telemetry_enabled = payload.pop("telemetry_enabled")
     assert payload == {
         "name": "godot-ai",
         "server_version": __version__,
@@ -41,9 +43,22 @@ def test_status_route_reports_live_server_version():
         "attach_protocol_version": 1,
         "active_lease_count": 0,
     }
+    assert telemetry_enabled is (not TelemetryConfig._is_disabled_via_env())
     assert len(instance_id) == 32
     assert len(catalog_hash) == 64
     assert set(catalog_hash) <= set("0123456789abcdef")
+
+
+def test_status_route_telemetry_enabled_rereads_env(monkeypatch) -> None:
+    monkeypatch.setenv("GODOT_AI_DISABLE_TELEMETRY", "true")
+    server = create_server(ws_port=9557)
+    app = server.http_app(transport="streamable-http")
+    client = TestClient(app, base_url="http://127.0.0.1")
+
+    response = client.get("/godot-ai/status")
+
+    assert response.status_code == 200
+    assert response.json()["telemetry_enabled"] is False
 
 
 def test_status_route_package_path_points_at_loaded_package_dir():

--- a/tests/unit/test_server_status.py
+++ b/tests/unit/test_server_status.py
@@ -50,11 +50,20 @@ def test_status_route_reports_live_server_version():
 
 
 def test_status_route_telemetry_enabled_rereads_env(monkeypatch) -> None:
-    monkeypatch.setenv("GODOT_AI_DISABLE_TELEMETRY", "true")
+    ## Prove a live env re-read on an already-constructed server, not a
+    ## construction-time snapshot (#913). Pytest's conftest setdefault
+    ## would otherwise leave opt-out on before create_server.
+    monkeypatch.delenv("GODOT_AI_DISABLE_TELEMETRY", raising=False)
+    monkeypatch.delenv("DISABLE_TELEMETRY", raising=False)
     server = create_server(ws_port=9557)
     app = server.http_app(transport="streamable-http")
     client = TestClient(app, base_url="http://127.0.0.1")
 
+    before = client.get("/godot-ai/status")
+    assert before.status_code == 200
+    assert before.json()["telemetry_enabled"] is True
+
+    monkeypatch.setenv("GODOT_AI_DISABLE_TELEMETRY", "true")
     response = client.get("/godot-ai/status")
 
     assert response.status_code == 200

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -124,7 +124,9 @@ class TestTelemetryConfig:
     def test_live_enabled_rereads_env_after_construction(
         self, monkeypatch, clean_env, isolated_data_dir
     ) -> None:
-        ## #913: an adopted process must honor a later opt-out without restart.
+        ## #913: in-process env changes are re-read; this is not a
+        ## dock-to-adopted-server channel (the editor cannot mutate
+        ## another process's environment).
         monkeypatch.delenv("GODOT_AI_DISABLE_TELEMETRY", raising=False)
         monkeypatch.delenv("DISABLE_TELEMETRY", raising=False)
         config = tel.TelemetryConfig()
@@ -272,6 +274,8 @@ class TestTelemetryCollector:
     def test_runtime_env_opt_out_drops_later_records(
         self, monkeypatch, clean_env, isolated_data_dir
     ) -> None:
+        ## In-process env changes are honored on the next record(); the
+        ## dock checkbox still cannot reach an adopted server's env.
         collector = tel.TelemetryCollector()
         sent: list[tel.TelemetryRecord] = []
         _drain_to(collector, sent)

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -121,6 +121,19 @@ class TestTelemetryConfig:
         monkeypatch.setenv(var, "true")
         assert tel.TelemetryConfig().enabled is False
 
+    def test_live_enabled_rereads_env_after_construction(
+        self, monkeypatch, clean_env, isolated_data_dir
+    ) -> None:
+        ## #913: an adopted process must honor a later opt-out without restart.
+        monkeypatch.delenv("GODOT_AI_DISABLE_TELEMETRY", raising=False)
+        monkeypatch.delenv("DISABLE_TELEMETRY", raising=False)
+        config = tel.TelemetryConfig()
+        assert config.enabled is True
+        assert config.live_enabled() is True
+        monkeypatch.setenv("GODOT_AI_DISABLE_TELEMETRY", "true")
+        assert config.enabled is True
+        assert config.live_enabled() is False
+
     @pytest.mark.parametrize("value", ["1", "true", "TRUE", "YES", "On"])
     def test_truthy_variants(self, monkeypatch, clean_env, isolated_data_dir, value: str) -> None:
         monkeypatch.setenv("GODOT_AI_DISABLE_TELEMETRY", value)
@@ -254,6 +267,24 @@ class TestTelemetryCollector:
         collector.record(tel.RecordType.USAGE, {"x": 1})
         time.sleep(0.1)
         assert sent == []
+        collector.shutdown()
+
+    def test_runtime_env_opt_out_drops_later_records(
+        self, monkeypatch, clean_env, isolated_data_dir
+    ) -> None:
+        collector = tel.TelemetryCollector()
+        sent: list[tel.TelemetryRecord] = []
+        _drain_to(collector, sent)
+        collector.record(tel.RecordType.USAGE, {"x": 1})
+        for _ in range(40):
+            if sent:
+                break
+            time.sleep(0.05)
+        assert len(sent) == 1
+        monkeypatch.setenv("GODOT_AI_DISABLE_TELEMETRY", "true")
+        collector.record(tel.RecordType.USAGE, {"x": 2})
+        time.sleep(0.1)
+        assert len(sent) == 1
         collector.shutdown()
 
     def test_record_enqueues_and_worker_drains(self, clean_env, isolated_data_dir) -> None:


### PR DESCRIPTION
## Summary
- Telemetry record/send paths re-read `GODOT_AI_DISABLE_TELEMETRY` / `DISABLE_TELEMETRY` so an adopted process stops sending after a later opt-out.
- `/godot-ai/status` now publishes `telemetry_enabled`, and the dock tooltip reports that live server state when it disagrees with the EditorSetting.
- Fixes #913.

## Test plan
- [x] `ruff check` on the touched Python files
- [x] `pytest -q tests/unit/test_telemetry.py tests/unit/test_server_status.py` (61 passed)
- [ ] Live dock tooltip against an adopted server (no editor connected in this pass)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Telemetry status is now shown in the editor based on the running server’s current state.
  - The editor indicates when its local telemetry setting differs from the server’s setting.
  - Telemetry opt-out environment changes now take effect without restarting the running process.

- **Bug Fixes**
  - Clarified that editor telemetry settings only update servers launched by the plugin.
  - Older server versions continue to report status without unsupported telemetry details.

- **Documentation**
  - Added guidance explaining telemetry behavior, status reporting, and runtime environment changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->