### PR TITLE
fix: let Configure all run while the server is INCOMPATIBLE

### DIFF
--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -2453,7 +2453,14 @@ func _on_refresh_clients_pressed() -> void:
 
 
 func _on_configure_all_clients() -> void:
-	if ClientRefreshStateScript.should_disable_client_actions(_refresh_state):
+	## Per-row Configure already bypasses the RUNNING gate. INCOMPATIBLE
+	## skips health interpretation (#916), so Configure all must do the same
+	## even if a status sweep is still in flight — `_set_incompatible_server`
+	## does not reset `_refresh_state`.
+	if (
+		ClientRefreshStateScript.should_disable_client_actions(_refresh_state)
+		and not _server_blocks_client_health()
+	):
 		return
 	for client_id in _client_rows:
 		var status: Client.Status = _client_rows[client_id].get("status", Client.Status.NOT_CONFIGURED)
@@ -3054,7 +3061,10 @@ func _refresh_clients_summary() -> void:
 		)
 	_clients_summary_label.text = text
 	if _client_configure_all_btn != null:
-		_client_configure_all_btn.disabled = ClientRefreshStateScript.should_disable_client_actions(_refresh_state)
+		_client_configure_all_btn.disabled = (
+			ClientRefreshStateScript.should_disable_client_actions(_refresh_state)
+			and not _server_blocks_client_health()
+		)
 	if _client_empty_cta_btn != null:
 		_client_empty_cta_btn.visible = configured == 0 and _client_status_refresh_has_completed()
 	_refresh_drift_banner(mismatched_ids)

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -2123,10 +2123,9 @@ func _on_install_uv() -> void:
 # --- Client section ---
 
 func _on_configure_client(client_id: String) -> void:
-	if _server_blocks_client_health():
-		_apply_row_status(client_id, Client.Status.ERROR, _server_blocked_client_message())
-		_refresh_clients_summary()
-		return
+	## Configure writes an explicit url + live plugin version; it does not
+	## need a healthy occupant. INCOMPATIBLE only suppresses status
+	## interpretation (#916).
 	_dispatch_client_action(client_id, "configure")
 
 
@@ -2291,10 +2290,6 @@ func _apply_client_action_result(client_id: String, action: String, result: Dict
 	_client_action_names.erase(client_id)
 	_clear_client_action_phase(client_id)
 	_finalize_action_buttons(client_id)
-	if _server_blocks_client_health():
-		_apply_row_status(client_id, Client.Status.ERROR, _server_blocked_client_message())
-		_refresh_clients_summary()
-		return
 
 	var success_status := Client.Status.NOT_CONFIGURED if action == "remove" else Client.Status.CONFIGURED
 	if result.get("status") == "ok":
@@ -2458,11 +2453,6 @@ func _on_refresh_clients_pressed() -> void:
 
 
 func _on_configure_all_clients() -> void:
-	if _server_blocks_client_health():
-		for client_id in _client_rows:
-			_apply_row_status(String(client_id), Client.Status.ERROR, _server_blocked_client_message())
-		_refresh_clients_summary()
-		return
 	if ClientRefreshStateScript.should_disable_client_actions(_refresh_state):
 		return
 	for client_id in _client_rows:
@@ -3140,9 +3130,7 @@ func _refresh_all_client_statuses() -> void:
 	## refresh: it bypasses focus-in cooldown but still runs probes off the editor
 	## main thread.
 	if _server_blocks_client_health():
-		for client_id in _client_rows:
-			_apply_row_status(String(client_id), Client.Status.ERROR, _server_blocked_client_message())
-		_refresh_clients_summary()
+		## Skip interpretation — do not paint every row ERROR (#916).
 		return
 	_request_client_status_refresh(true)
 
@@ -3251,9 +3239,7 @@ func _perform_initial_client_status_refresh() -> void:
 		return
 
 	if _server_blocks_client_health():
-		for client_id in _client_rows:
-			_apply_row_status(String(client_id), Client.Status.ERROR, _server_blocked_client_message())
-		_refresh_clients_summary()
+		## Skip interpretation — do not paint every row ERROR (#916).
 		return
 
 	_warm_strategy_bytecode()
@@ -3338,9 +3324,7 @@ func _request_client_status_refresh(force: bool = false) -> bool:
 	## when a refresh is requested. The existing UI remains visible until the
 	## background worker's result is applied on the main thread.
 	if _server_blocks_client_health():
-		for client_id in _client_rows:
-			_apply_row_status(String(client_id), Client.Status.ERROR, _server_blocked_client_message())
-		_refresh_clients_summary()
+		## Skip interpretation — do not paint every row ERROR (#916).
 		return false
 	if _is_self_update_in_progress():
 		## Self-update is overwriting plugin scripts on disk; spawning a worker
@@ -3511,8 +3495,7 @@ func _apply_client_status_refresh_results(results: Dictionary, generation: int) 
 		_client_status_refresh_thread.wait_to_finish()
 		_client_status_refresh_thread = null
 	if _server_blocks_client_health():
-		for client_id in _client_rows:
-			_apply_row_status(String(client_id), Client.Status.ERROR, _server_blocked_client_message())
+		## Skip interpretation — do not paint every row ERROR (#916).
 		_finalize_completed_refresh()
 		return
 

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -3607,9 +3607,9 @@ func _maybe_auto_repin_after_update() -> void:
 	if not _pending_post_update_repin:
 		return
 	## While the server is INCOMPATIBLE (post-update stale-occupant recovery
-	## still in flight) every row reads ERROR, not CONFIGURED_MISMATCH — a
-	## consume here would see an empty mismatch list and drop the repin on
-	## the floor. Stay pending for the sweep that lands after recovery.
+	## still in flight) health interpretation is skipped (#916), so this
+	## sweep cannot observe CONFIGURED_MISMATCH. Consuming here would drop
+	## the repin on the floor. Stay pending for the sweep after recovery.
 	if _server_blocks_client_health():
 		return
 	if ClientRefreshStateScript.should_disable_client_actions(_refresh_state):

--- a/plugin/addons/godot_ai/utils/mcp_server_state.gd
+++ b/plugin/addons/godot_ai/utils/mcp_server_state.gd
@@ -106,10 +106,11 @@ static func is_terminal_diagnosis(state: int) -> bool:
 	)
 
 
-## True when the dock should consider the server unsuitable for client
-## health checks (incompatible tool surface). Currently just INCOMPATIBLE
-## — FOREIGN_PORT is transitional and may resolve to READY if the
-## foreign occupant turns out to speak our handshake.
+## True when the dock should skip interpreting client health (incompatible
+## tool surface). This must NOT block Configure writes — those take an
+## explicit url and the live plugin version (#916). Currently just
+## INCOMPATIBLE — FOREIGN_PORT is transitional and may resolve to READY
+## if the foreign occupant turns out to speak our handshake.
 static func blocks_client_health(state: int) -> bool:
 	return state == INCOMPATIBLE
 

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -629,9 +629,10 @@ static func _incompatible_server_message(
 	## first; "stop the old server" alone reads as a dead end when the server
 	## respawns the moment the user kills it.
 	var repair := (
-		"If AI-client attach bridges are keeping it alive, run Configure all to "
-		+ "repin them, then restart those client apps — the old server exits on "
-		+ "its own. Otherwise stop it manually or change both HTTP and WS ports."
+		"Restart Server first so this plugin owns the port, then run Configure all "
+		+ "to repin AI-client attach bridges and restart those client apps — the "
+		+ "old server exits on its own. Otherwise stop it manually or change both "
+		+ "HTTP and WS ports."
 	)
 	if not version.is_empty():
 		if actual_ws_port > 0 and actual_ws_port != expected_ws_port:

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -644,6 +644,29 @@ func test_configure_all_dispatches_while_incompatible() -> void:
 		"Configure all must dispatch writes for unconfigured rows while INCOMPATIBLE")
 
 
+func test_configure_all_dispatches_while_incompatible_refresh_running() -> void:
+	## `_set_incompatible_server()` can flip INCOMPATIBLE without clearing
+	## `_refresh_state`. Per-row Configure already ignores RUNNING; Configure
+	## all must too, or the button stays dead until the sweep finishes.
+	var plugin := _RestartDispatchPlugin.new()
+	plugin.status = {
+		"state": McpServerState.INCOMPATIBLE,
+		"message": "Port 8000 is occupied by godot-ai server v1.2.10; plugin expects v2.2.0.",
+	}
+	var dock := _RepinRecordingDock.new()
+	dock._plugin = plugin
+	dock._refresh_state = McpClientRefreshState.RUNNING
+	dock._client_rows["claude_code"] = {"status": McpClient.Status.NOT_CONFIGURED}
+
+	dock._on_configure_all_clients()
+	var configured := dock.configured_ids.duplicate()
+	dock.free()
+	plugin.free()
+
+	assert_eq(configured, ["claude_code"] as Array[String],
+		"Configure all must dispatch while INCOMPATIBLE even if a refresh is RUNNING")
+
+
 func test_post_update_repin_reconfigures_pin_only_rows_once() -> void:
 	## After a self-update the plugin arms the one-shot repin; the first
 	## completed sweep with drift must reconfigure the rows whose only drift

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -541,11 +541,10 @@ func test_client_rows_show_config_file_buttons_only_for_file_clients() -> void:
 		"Pure CLI clients should not show a dead Reveal in folder button")
 
 
-func test_incompatible_server_marks_clients_unhealthy() -> void:
-	## URL-only client checks are not enough when the URL points at an old
-	## server with an incompatible tool surface. The dock must not show green
-	## client rows while the plugin has blocked server adoption.
-	_dock._build_ui()
+func test_incompatible_server_does_not_paint_client_rows_error() -> void:
+	## INCOMPATIBLE skips health interpretation so Configure / Configure all
+	## can still write pins (#916). Rows must not be painted ERROR/red with
+	## the blocked-server paragraph — that made Configure all unusable.
 	var plugin := _RestartDispatchPlugin.new()
 	plugin.status = {
 		"state": McpServerState.INCOMPATIBLE,
@@ -553,17 +552,23 @@ func test_incompatible_server_marks_clients_unhealthy() -> void:
 		"connection_blocked": true,
 	}
 	_dock._plugin = plugin
+	_dock._build_ui()
 
 	var any_id := McpClientConfigurator.client_ids()[0]
-	_dock._refresh_all_client_statuses()
 	var row: Dictionary = _dock._client_rows[any_id]
 	var dot: ColorRect = row["dot"]
-	assert_eq(dot.color, Color.RED, "Blocked incompatible server must render client rows red")
-	assert_contains(
-		(row["name_label"] as Label).text,
-		"Port 8000 is occupied by godot-ai server v1.2.10",
-		"Client row must explain the live server mismatch instead of looking healthy"
+	var name_label := row["name_label"] as Label
+	var display_name := McpClientConfigurator.client_display_name(any_id)
+	_dock._refresh_all_client_statuses()
+	assert_ne(dot.color, Color.RED, "INCOMPATIBLE must not paint client rows ERROR/red")
+	assert_eq(dot.color, McpDockScript.COLOR_MUTED,
+		"skipped interpretation leaves the initial muted dot")
+	assert_false(
+		name_label.text.contains("Port 8000 is occupied by godot-ai server v1.2.10"),
+		"blocked-server message must not be stamped onto every client row"
 	)
+	assert_eq(name_label.text, display_name,
+		"row caption stays the display name so Configure all remains usable")
 	plugin.free()
 
 
@@ -615,6 +620,28 @@ class _RepinRecordingDock extends McpDockScript:
 	) -> bool:
 		gate_from_versions.append(from_version)
 		return pin_only_ids.has(client_id)
+
+
+func test_configure_all_dispatches_while_incompatible() -> void:
+	## The write path must run while INCOMPATIBLE — Configure writes an
+	## explicit url + live plugin version and does not need a healthy occupant.
+	var plugin := _RestartDispatchPlugin.new()
+	plugin.status = {
+		"state": McpServerState.INCOMPATIBLE,
+		"message": "Port 8000 is occupied by godot-ai server v1.2.10; plugin expects v2.2.0.",
+	}
+	var dock := _RepinRecordingDock.new()
+	dock._plugin = plugin
+	dock._client_rows["claude_code"] = {"status": McpClient.Status.NOT_CONFIGURED}
+	dock._client_rows["cursor"] = {"status": McpClient.Status.CONFIGURED}
+
+	dock._on_configure_all_clients()
+	var configured := dock.configured_ids.duplicate()
+	dock.free()
+	plugin.free()
+
+	assert_eq(configured, ["claude_code"] as Array[String],
+		"Configure all must dispatch writes for unconfigured rows while INCOMPATIBLE")
 
 
 func test_post_update_repin_reconfigures_pin_only_rows_once() -> void:
@@ -691,9 +718,9 @@ func test_post_update_repin_requires_a_from_version() -> void:
 
 func test_post_update_repin_stays_pending_while_server_blocks_health() -> void:
 	## While the post-update stale-occupant recovery is still in flight the
-	## server state is INCOMPATIBLE and every row reads ERROR — consuming the
-	## flag on that sweep would drop the repin. It must stay pending and fire
-	## on the first healthy sweep.
+	## server state is INCOMPATIBLE and health interpretation is skipped
+	## (#916) — consuming the flag on that sweep would drop the repin. It
+	## must stay pending and fire on the first healthy sweep.
 	var plugin := _RestartDispatchPlugin.new()
 	plugin.status = {"state": McpServerState.INCOMPATIBLE, "message": "incompatible"}
 	var dock := _RepinRecordingDock.new()
@@ -716,7 +743,7 @@ func test_post_update_repin_stays_pending_while_server_blocks_health() -> void:
 	assert_true(pending_while_blocked,
 		"an INCOMPATIBLE-server sweep must keep the repin pending")
 	assert_true(configured_while_blocked.is_empty(),
-		"no reconfigure may run while rows read ERROR")
+		"auto-repin must not fire while the server is INCOMPATIBLE")
 	assert_eq(configured_after_recovery, ["claude_code"] as Array[String],
 		"the first healthy sweep must run the deferred repin")
 

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -1118,9 +1118,14 @@ func test_incompatible_server_message_names_actual_version_when_discoverable() -
 	## attach-bridge leases; the message must name the full repair that
 	## actually works — repin AND restart the client apps — not just "stop
 	## the old server", which the bridges would undo by respawning it.
+	assert_contains(message, "Restart Server")
 	assert_contains(message, "Configure all")
 	assert_contains(message, "repin")
 	assert_contains(message, "restart those client apps")
+	assert_true(
+		message.find("Restart Server") < message.find("Configure all"),
+		"Restart Server must be named before Configure all (#916)",
+	)
 
 
 func test_incompatible_server_message_names_ws_port_mismatch() -> void:

--- a/test_project/tests/test_server_state.gd
+++ b/test_project/tests/test_server_state.gd
@@ -52,9 +52,9 @@ func test_is_terminal_diagnosis_excludes_non_diagnostic_states() -> void:
 
 
 func test_blocks_client_health_only_for_incompatible() -> void:
-	## Dock's `_server_blocks_client_health` gates the client-row red state
+	## Dock's `_server_blocks_client_health` skips health interpretation
 	## on this — narrowing it to only INCOMPATIBLE keeps SPAWNING / FOREIGN_PORT
-	## from misclassifying the dock as broken.
+	## from misclassifying the dock as broken. Configure writes stay allowed.
 	assert_true(McpServerState.blocks_client_health(McpServerState.INCOMPATIBLE))
 	assert_false(McpServerState.blocks_client_health(McpServerState.READY))
 	assert_false(McpServerState.blocks_client_health(McpServerState.FOREIGN_PORT))


### PR DESCRIPTION
## Summary
- Configure / Configure all now write client pins even when the occupant is INCOMPATIBLE, instead of painting every row ERROR.
- Health refresh skips interpretation in that state rather than turning 21 rows red with the same paragraph.
- The crash-panel repair text names Restart Server before Configure all.
- Fixes #916.

## Test plan
- [x] Updated GDScript assertions for message order and `blocks_client_health` docs
- [ ] Live INCOMPATIBLE dock: Configure all should write pins without 21 red rows (no editor connected in this pass)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Client rows are no longer incorrectly marked as errors when the server’s health status prevents client-health checks.
  * Client configuration remains available even when the server is in an incompatible state.
  * Updated repair guidance to recommend restarting the server before selecting “Configure all.”

* **Tests**
  * Added coverage to verify the revised repair-action order and server-state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->