### PR TITLE
feat: add resource_manage(op="set_property")

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -213,7 +213,7 @@ Calls take the form:
 | `filesystem_manage` | `read_text`, `write_text`, `reimport`, `scan`, `search` |
 | `theme_manage` | `create`, `set_color`, `set_constant`, `set_font_size`, `set_stylebox_flat`, `apply` |
 | `ui_manage` | `set_anchor_preset`, `set_text`, `build_layout`, `draw_recipe` |
-| `resource_manage` | `search`, `load`, `assign`, `get_info`, `create`, `curve_set_points`, `environment_create`, `physics_shape_autofit`, `gradient_texture_create`, `noise_texture_create` |
+| `resource_manage` | `search`, `load`, `assign`, `get_info`, `create`, `set_property`, `curve_set_points`, `environment_create`, `physics_shape_autofit`, `gradient_texture_create`, `noise_texture_create` |
 | `api_manage` | `get_class` |
 | `client_manage` | `status`, `configure`, `remove` |
 | `tilemap_manage` | `tilemap_set_cell`, `tilemap_set_cells_rect`, `tilemap_clear`, `tilemap_get_cells` |
@@ -235,6 +235,20 @@ models, and audio. Godot scripts (`.gd`) are not imported resources: a successfu
 `.gd` entry only refreshes its editor filesystem cache entry and does not prove the
 script was parsed or diagnostics were produced. Use `script_patch` or
 `script_create` to save scripts and receive fresh diagnostics.
+
+`resource_manage(op="set_property")` is the **only safe way to change a field on
+an existing `.tres`/`.res` while the editor is running.** Editing the file as
+text from outside Godot is not: the editor holds the resource in `ResourceCache`,
+nothing reachable from the MCP evicts that cache (a `filesystem_manage(op="scan")`,
+a `scene_open(force_reload=true)`, and a fresh `resource_manage(op="load")` all
+keep returning the stale copy — see godotengine/godot#73602 and #75865), and the
+editor re-serializes its stale copy over the file as soon as anything marks the
+resource dirty. `set_property` mutates the instance the editor is already holding
+and saves that, so the cache and the file cannot diverge — the same property that
+makes `node_set_property` + `scene_save` safe for scenes. It requires the file to
+already exist (creating one is `op="create"`), takes a `{name: value}` dict so
+several fields land in one save, and is not undoable (it writes the file). Editing
+a sub-resource in place (`path.tres::SubID`) is not supported yet.
 
 `api_manage(op="get_class")` inspects Godot API/ClassDB metadata for a class
 without creating an instance. By default it returns **only `properties`**

--- a/plugin/addons/godot_ai/handlers/resource_handler.gd
+++ b/plugin/addons/godot_ai/handlers/resource_handler.gd
@@ -486,7 +486,10 @@ func set_resource_property(params: Dictionary) -> Dictionary:
 	if not (properties_raw is Dictionary):
 		return ErrorCodes.make(
 			ErrorCodes.WRONG_TYPE,
-			"properties must be a dictionary of {name: value}, got %s" % type_string(typeof(properties_raw))
+			"properties must be a dictionary of {name: value}, got %s: %s" % [
+				type_string(typeof(properties_raw)),
+				_abbreviate_value(properties_raw),
+			]
 		)
 	var properties: Dictionary = properties_raw
 	if properties.is_empty():
@@ -542,7 +545,8 @@ func set_resource_property(params: Dictionary) -> Dictionary:
 		"reason": "File save is persistent; edit the .tres file manually to revert",
 	}, _connection)
 	if result.has("error"):
-		_restore_properties(res, prior_values)
+		if _should_restore_after_save_error(result):
+			_restore_properties(res, prior_values)
 		return result
 
 	# #737: a resave must not drop the file's uid — any uid:// reference
@@ -575,6 +579,34 @@ static func _snapshot_properties(res: Resource, keys: Array) -> Dictionary:
 static func _restore_properties(res: Resource, snapshot: Dictionary) -> void:
 	for key in snapshot:
 		res.set(key, snapshot[key])
+
+
+## Whether a `McpResourceIO.save_to_disk` error means nothing reached the file,
+## so the cached instance must be rolled back.
+##
+## False for the one branch where the save succeeded and only the uid write
+## failed (`data.persisted`): the file already carries the new values there, so
+## rolling the cached instance back would leave the editor BEHIND the file, and
+## the editor's stale copy would be re-serialized over the good file later. That
+## is this op's own failure mode, mirrored. Keep the applied values instead and
+## let the caller act on the uid error.
+static func _should_restore_after_save_error(result: Dictionary) -> bool:
+	var err: Variant = result.get("error", {})
+	if not (err is Dictionary):
+		return true
+	var data: Variant = (err as Dictionary).get("data", {})
+	if not (data is Dictionary):
+		return true
+	return not bool((data as Dictionary).get("persisted", false))
+
+
+## A caller-supplied value rendered for an error message, capped so a huge
+## payload can't bloat the response the agent reads back.
+static func _abbreviate_value(value: Variant, limit: int = 120) -> String:
+	var text := str(value)
+	if text.length() <= limit:
+		return text
+	return text.substr(0, limit) + "... (truncated)"
 
 
 ## Introspect a Resource class — return its editor-visible properties, parent,

--- a/plugin/addons/godot_ai/handlers/resource_handler.gd
+++ b/plugin/addons/godot_ai/handlers/resource_handler.gd
@@ -460,6 +460,123 @@ func _save_created_resource(res: Resource, type_str: String, resource_path: Stri
 	}, _connection)
 
 
+## Mutate properties on a resource that already exists on disk, in place.
+##
+## Deliberately loads through the CACHED instance (plain `ResourceLoader.load`,
+## default cache mode) rather than duplicating it: while the editor is running
+## it holds the resource in ResourceCache, and nothing reachable from the MCP
+## evicts that cache (`filesystem_manage(op="scan")`, `scene_open(force_reload)`
+## and a fresh `load_resource` all keep returning the stale copy — engine
+## behaviour, godotengine/godot#73602 and #75865). So editing a .tres as text
+## from outside Godot is unsafe: the editor re-serializes its stale copy over
+## the file the next time anything marks the resource dirty. Mutating the
+## instance the editor is already holding and saving THAT leaves no second copy
+## to diverge — the same property that makes set_property + save_scene safe for
+## scenes.
+##
+## Not undoable (a file write, like create_resource's save branch). Both failure
+## paths restore the prior values so a rejected property or a failed save can't
+## leave the cached instance ahead of the file.
+func set_resource_property(params: Dictionary) -> Dictionary:
+	var resource_path: String = params.get("resource_path", "")
+	if resource_path.is_empty():
+		return ErrorCodes.make(ErrorCodes.MISSING_REQUIRED_PARAM, "Missing required param: resource_path")
+
+	var properties_raw: Variant = params.get("properties", {})
+	if not (properties_raw is Dictionary):
+		return ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
+			"properties must be a dictionary of {name: value}, got %s" % type_string(typeof(properties_raw))
+		)
+	var properties: Dictionary = properties_raw
+	if properties.is_empty():
+		return ErrorCodes.make(
+			ErrorCodes.MISSING_REQUIRED_PARAM,
+			"Missing required param: properties (non-empty dictionary of {name: value})"
+		)
+
+	# for_write: this path resaves the file, so it must refuse the same targets
+	# every other write refuses (project.godot, .godot/, the loaded plugin tree)
+	# and reject uid:// / user:// up front rather than at ResourceSaver time.
+	var rpath_err = McpPathValidator.path_error(resource_path, "resource_path", true)
+	if rpath_err != null:
+		return rpath_err
+
+	var ext := resource_path.get_extension().to_lower()
+	if ext == "tscn" or ext == "scn":
+		return ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
+			"%s is a scene, not a resource file — use node_set_property then scene_save to edit a scene" % resource_path
+		)
+
+	if not ResourceLoader.exists(resource_path):
+		return ErrorCodes.make(
+			ErrorCodes.RESOURCE_NOT_FOUND,
+			(
+				"Resource not found: %s — set_property edits an existing file. "
+				+ "To make a new one call resource_manage(op=\"create\", params={\"type\": \"...\", \"resource_path\": \"%s\"})."
+			) % [resource_path, resource_path]
+		)
+
+	var res: Resource = ResourceLoader.load(resource_path)
+	if res == null:
+		return ErrorCodes.make(
+			ErrorCodes.INTERNAL_ERROR,
+			"Failed to load resource from %s (file exists but load returned null — may be corrupt)" % resource_path
+		)
+
+	# Snapshot before mutating: _apply_resource_properties applies key-by-key and
+	# returns on the first rejection, so a bad name in position 2 would otherwise
+	# leave key 1 written to the cached instance but never saved.
+	var prior_values := _snapshot_properties(res, properties.keys())
+	var prior_uid := ResourceLoader.get_resource_uid(resource_path)
+
+	var apply_err: Variant = _apply_resource_properties(res, properties)
+	if apply_err != null:
+		_restore_properties(res, prior_values)
+		return apply_err
+
+	var result := McpResourceIO.save_to_disk(res, resource_path, true, "Resource", {
+		"resource_class": res.get_class(),
+		"properties_applied": properties.size(),
+		"reason": "File save is persistent; edit the .tres file manually to revert",
+	}, _connection)
+	if result.has("error"):
+		_restore_properties(res, prior_values)
+		return result
+
+	# #737: a resave must not drop the file's uid — any uid:// reference
+	# elsewhere in the project resolves through it. A file that had no uid to
+	# begin with (INVALID_ID) counts as preserved: save_to_disk minted one and
+	# nothing was lost.
+	var new_uid := ResourceLoader.get_resource_uid(resource_path)
+	result.data["uid_preserved"] = prior_uid == ResourceUID.INVALID_ID or new_uid == prior_uid
+
+	# Nudge any inspector currently showing this resource to redraw. The file and
+	# the cached instance already agree at this point; this only refreshes the UI.
+	res.emit_changed()
+	return result
+
+
+## Current values of `keys` that actually exist on `res`, for rollback. Names
+## the resource doesn't have are skipped — _apply_resource_properties rejects
+## them, and `set()`ing them back would be a no-op at best.
+static func _snapshot_properties(res: Resource, keys: Array) -> Dictionary:
+	var known := {}
+	for prop in res.get_property_list():
+		known[prop.name] = true
+	var snapshot := {}
+	for key in keys:
+		if known.has(key):
+			snapshot[key] = res.get(key)
+	return snapshot
+
+
+static func _restore_properties(res: Resource, snapshot: Dictionary) -> void:
+	for key in snapshot:
+		res.set(key, snapshot[key])
+
+
 ## Introspect a Resource class — return its editor-visible properties, parent,
 ## whether it's abstract, and (for abstract bases) the list of concrete
 ## subclasses that resource_create can instantiate. Read-only.

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -422,6 +422,7 @@ func _enter_tree() -> void:
 	_dispatcher.register_lazy("load_resource", "resource", &"load_resource")
 	_dispatcher.register_lazy("assign_resource", "resource", &"assign_resource")
 	_dispatcher.register_lazy("create_resource", "resource", &"create_resource")
+	_dispatcher.register_lazy("set_resource_property", "resource", &"set_resource_property")
 	_dispatcher.register_lazy("get_resource_info", "resource", &"get_resource_info")
 	_dispatcher.register_lazy("get_class_info", "api", &"get_class_info")
 	_dispatcher.register_lazy("read_file", "filesystem", &"read_file")

--- a/plugin/addons/godot_ai/utils/resource_io.gd
+++ b/plugin/addons/godot_ai/utils/resource_io.gd
@@ -120,10 +120,18 @@ static func save_to_disk(
 		)
 	var uid_err := ensure_uid(resource_path, prior_uid)
 	if uid_err != OK:
-		return ErrorCodes.make(
+		# The bytes already landed; only the uid bookkeeping failed. Say so in
+		# the payload: this is the one error branch after which the file on disk
+		# carries the caller's new values, so a caller that rolls its in-memory
+		# copy back on failure (resource_handler.set_resource_property) would
+		# leave the editor's cached instance BEHIND the file. Absence of this
+		# key means nothing reached the file.
+		var uid_failure := ErrorCodes.make(
 			ErrorCodes.INTERNAL_ERROR,
 			"%s saved to %s but failed to write its uid: %s" % [label, resource_path, error_string(uid_err)]
 		)
+		uid_failure["error"]["data"] = {"persisted": true}
+		return uid_failure
 
 	var efs := EditorInterface.get_resource_filesystem()
 	if efs != null:

--- a/src/godot_ai/handlers/resource.py
+++ b/src/godot_ai/handlers/resource.py
@@ -58,3 +58,15 @@ async def resource_create(
         params["properties"] = properties
     params.update(target_params(path, property, resource_path, overwrite))
     return await runtime.send_command("create_resource", params)
+
+
+async def resource_set_property(
+    runtime: DirectRuntime,
+    resource_path: str,
+    properties: dict,
+) -> dict:
+    await require_writable_async(runtime)
+    return await runtime.send_command(
+        "set_resource_property",
+        {"resource_path": resource_path, "properties": properties},
+    )

--- a/src/godot_ai/server.py
+++ b/src/godot_ai/server.py
@@ -268,7 +268,7 @@ _ROLLUP_BLOCKS: tuple[tuple[str | None, str], ...] = (
     (
         "resource",
         "  resource_manage  search, load, assign, get_info, create,\n"
-        "                   curve_set_points, environment_create,\n"
+        "                   set_property, curve_set_points, environment_create,\n"
         "                   physics_shape_autofit, gradient_texture_create,\n"
         "                   noise_texture_create\n",
     ),

--- a/src/godot_ai/tools/resource.py
+++ b/src/godot_ai/tools/resource.py
@@ -37,6 +37,15 @@ Ops:
         Instantiate a Resource subclass. Either path+property (assign to a
         node, undoable) or resource_path (save to .tres). For specific
         families (Curve, Environment, etc.) prefer the dedicated ops.
+  • set_property(resource_path, properties)
+        Change fields on a .tres / .res that already exists, in place.
+        properties is {name: value} — one call, one save. Use this
+        instead of rewriting the file as text: while Godot is running it
+        holds the resource in ResourceCache, nothing reachable from MCP
+        evicts that cache (godot#73602, godot#75865), and the editor
+        re-serializes its stale copy over an external edit as soon as
+        anything marks the resource dirty. Errors if the file does not
+        exist (that is create's job). Not undoable — it writes the file.
   • curve_set_points(points, path="", property="", resource_path="")
         Replace all points on a Curve / Curve2D / Curve3D. Auto-creates
         the curve resource if the slot is empty (curve_created flag).
@@ -79,6 +88,7 @@ def register_resource_tools(mcp: FastMCP) -> None:
             "assign": resource_handlers.resource_assign,
             "get_info": resource_handlers.resource_get_info,
             "create": resource_handlers.resource_create,
+            "set_property": resource_handlers.resource_set_property,
             "curve_set_points": curve_handlers.curve_set_points,
             "environment_create": environment_handlers.environment_create,
             "physics_shape_autofit": physics_shape_handlers.physics_shape_autofit,

--- a/test_project/tests/test_resource.gd
+++ b/test_project/tests/test_resource.gd
@@ -320,6 +320,161 @@ func test_create_resource_unknown_property_in_properties_dict() -> void:
 	_remove_node(mi)
 
 
+# ----- set_resource_property -----
+
+func _rm_tmp(path: String) -> void:
+	if FileAccess.file_exists(path):
+		DirAccess.remove_absolute(ProjectSettings.globalize_path(path))
+
+
+## Read `path` straight off disk, bypassing the editor's ResourceCache. The whole
+## point of set_property is that the cached instance and the file agree, so every
+## round-trip assertion has to check the file itself — a plain load() would hand
+## back the very instance the handler just mutated and pass either way.
+func _load_from_disk(path: String) -> Resource:
+	return ResourceLoader.load(path, "", ResourceLoader.CACHE_MODE_IGNORE)
+
+
+func test_set_resource_property_missing_resource_path() -> void:
+	var result := _handler.set_resource_property({"properties": {"size": 1}})
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_contains(result.error.message, "resource_path")
+
+
+func test_set_resource_property_empty_properties() -> void:
+	var result := _handler.set_resource_property({"resource_path": "res://test_tmp_setprop.tres"})
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
+	assert_contains(result.error.message, "properties")
+
+
+func test_set_resource_property_non_dict_properties() -> void:
+	var result := _handler.set_resource_property({
+		"resource_path": "res://test_tmp_setprop.tres",
+		"properties": ["size"],
+	})
+	assert_is_error(result, ErrorCodes.WRONG_TYPE)
+	assert_contains(result.error.message, "properties")
+
+
+func test_set_resource_property_rejects_path_outside_project() -> void:
+	var result := _handler.set_resource_property({
+		"resource_path": "/tmp/bad.tres",
+		"properties": {"size": 1},
+	})
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
+
+
+func test_set_resource_property_rejects_scene_file() -> void:
+	# A .tscn loads as a PackedScene; resaving one from here would rewrite the
+	# scene's bundled state behind the caller's back. Steer to the scene verbs.
+	var result := _handler.set_resource_property({
+		"resource_path": "res://main.tscn",
+		"properties": {"resource_name": "nope"},
+	})
+	assert_is_error(result, ErrorCodes.WRONG_TYPE)
+	assert_contains(result.error.message, "node_set_property")
+
+
+func test_set_resource_property_missing_file_points_at_create() -> void:
+	var result := _handler.set_resource_property({
+		"resource_path": "res://test_tmp_never_created.tres",
+		"properties": {"size": 1},
+	})
+	assert_is_error(result, ErrorCodes.RESOURCE_NOT_FOUND)
+	# A typo in the path must not silently mint a resource — name the verb that does.
+	assert_contains(result.error.message, "resource_manage(op=\"create\"")
+
+
+func test_set_resource_property_round_trip_updates_file_and_cache() -> void:
+	var out_path := "res://test_tmp_setprop_roundtrip.tres"
+	_rm_tmp(out_path)
+	var created := _handler.create_resource({
+		"type": "BoxShape3D",
+		"resource_path": out_path,
+		"properties": {"size": {"x": 1, "y": 1, "z": 1}},
+	})
+	assert_has_key(created, "data")
+	var original_uid := ResourceLoader.get_resource_uid(out_path)
+	# Warm the editor's ResourceCache the way an open scene would, so the test
+	# exercises the cached-instance path rather than a fresh load.
+	var cached: Resource = ResourceLoader.load(out_path)
+
+	var result := _handler.set_resource_property({
+		"resource_path": out_path,
+		"properties": {"size": {"x": 4, "y": 5, "z": 6}},
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.resource_class, "BoxShape3D")
+	assert_eq(result.data.properties_applied, 1)
+	assert_false(result.data.undoable, "a file write is not scene-undoable")
+	assert_true(result.data.overwritten, "set_property always rewrites an existing file")
+
+	var on_disk := _load_from_disk(out_path)
+	assert_true(on_disk is BoxShape3D)
+	assert_true(on_disk.size is Vector3, "size must land as a typed Vector3, not a Dictionary")
+	assert_eq(on_disk.size, Vector3(4, 5, 6), "the file on disk must carry the new value")
+	# The claim that makes this op safe: the instance the editor is holding
+	# matches the file, so nothing can re-serialize a stale copy over it.
+	assert_eq(cached.size, Vector3(4, 5, 6), "the cached instance must match the file")
+	# #737: any uid:// reference elsewhere in the project must keep resolving.
+	assert_true(result.data.uid_preserved, "resave must not drop the file's uid")
+	assert_eq(ResourceLoader.get_resource_uid(out_path), original_uid)
+	_rm_tmp(out_path)
+
+
+func test_set_resource_property_bad_name_rolls_back_earlier_keys() -> void:
+	var out_path := "res://test_tmp_setprop_rollback.tres"
+	_rm_tmp(out_path)
+	var created := _handler.create_resource({
+		"type": "BoxShape3D",
+		"resource_path": out_path,
+		"properties": {"size": {"x": 1, "y": 1, "z": 1}},
+	})
+	assert_has_key(created, "data")
+	var cached: Resource = ResourceLoader.load(out_path)
+
+	# `size` applies, then `not_a_real_field` is rejected. Nothing is saved, so
+	# the already-applied key must be rolled back — otherwise the cached instance
+	# ends up ahead of the file, which is the divergence this op exists to avoid.
+	var result := _handler.set_resource_property({
+		"resource_path": out_path,
+		"properties": {"size": {"x": 9, "y": 9, "z": 9}, "not_a_real_field": 42},
+	})
+	assert_is_error(result, ErrorCodes.PROPERTY_NOT_ON_CLASS)
+	assert_has_key(result.error, "data")
+	assert_has_key(result.error.data, "valid_properties")
+	assert_contains(result.error.data.valid_properties, "size")
+	assert_eq(cached.size, Vector3(1, 1, 1), "rejected call must leave the cached instance untouched")
+	assert_eq(_load_from_disk(out_path).size, Vector3(1, 1, 1), "rejected call must not write the file")
+	_rm_tmp(out_path)
+
+
+func test_set_resource_property_custom_class_name_resource() -> void:
+	# #580's failure class: custom `class_name` Resources are where the
+	# create/save path historically broke, and the .tres that motivated this op
+	# was one. Exercise the same shape here.
+	var out_path := "res://tests/_mcp_test_setprop_custom.tres"
+	_rm_tmp(out_path)
+	var created := _handler.create_resource({
+		"type": "MyTestResource",
+		"resource_path": out_path,
+		"properties": {"label": "before"},
+	})
+	assert_has_key(created, "data")
+	var cached: Resource = ResourceLoader.load(out_path)
+
+	var result := _handler.set_resource_property({
+		"resource_path": out_path,
+		"properties": {"label": "after"},
+	})
+	assert_has_key(result, "data")
+	var on_disk := _load_from_disk(out_path)
+	assert_true(on_disk is MyTestResource, "resaved file must still load as MyTestResource")
+	assert_eq(on_disk.label, "after")
+	assert_eq(cached.label, "after", "the cached instance must match the file")
+	_rm_tmp(out_path)
+
+
 # ----- get_resource_info -----
 
 func test_get_resource_info_missing_type() -> void:

--- a/test_project/tests/test_resource.gd
+++ b/test_project/tests/test_resource.gd
@@ -354,6 +354,9 @@ func test_set_resource_property_non_dict_properties() -> void:
 	})
 	assert_is_error(result, ErrorCodes.WRONG_TYPE)
 	assert_contains(result.error.message, "properties")
+	# The rejected value itself, not just its type: the caller needs to see what
+	# the plugin actually received to correct the call.
+	assert_contains(result.error.message, "size")
 
 
 func test_set_resource_property_rejects_path_outside_project() -> void:
@@ -394,6 +397,7 @@ func test_set_resource_property_round_trip_updates_file_and_cache() -> void:
 		"properties": {"size": {"x": 1, "y": 1, "z": 1}},
 	})
 	assert_has_key(created, "data")
+	assert_eq(created.data.resource_class, "BoxShape3D", "setup fixture must be the resource these assertions assume")
 	var original_uid := ResourceLoader.get_resource_uid(out_path)
 	# Warm the editor's ResourceCache the way an open scene would, so the test
 	# exercises the cached-instance path rather than a fresh load.
@@ -431,6 +435,7 @@ func test_set_resource_property_bad_name_rolls_back_earlier_keys() -> void:
 		"properties": {"size": {"x": 1, "y": 1, "z": 1}},
 	})
 	assert_has_key(created, "data")
+	assert_eq(created.data.resource_class, "BoxShape3D", "setup fixture must be the resource these assertions assume")
 	var cached: Resource = ResourceLoader.load(out_path)
 
 	# `size` applies, then `not_a_real_field` is rejected. Nothing is saved, so
@@ -461,6 +466,9 @@ func test_set_resource_property_custom_class_name_resource() -> void:
 		"properties": {"label": "before"},
 	})
 	assert_has_key(created, "data")
+	# `type` is the requested class; `resource_class` is res.get_class(), which
+	# for a scripted Resource is the native base, not the script's class_name.
+	assert_eq(created.data.type, "MyTestResource", "setup fixture must be the resource these assertions assume")
 	var cached: Resource = ResourceLoader.load(out_path)
 
 	var result := _handler.set_resource_property({
@@ -473,6 +481,50 @@ func test_set_resource_property_custom_class_name_resource() -> void:
 	assert_eq(on_disk.label, "after")
 	assert_eq(cached.label, "after", "the cached instance must match the file")
 	_rm_tmp(out_path)
+
+
+func test_set_resource_property_rolls_back_when_nothing_reached_the_file() -> void:
+	# A real save_to_disk refusal (overwrite gating, checked before any write)
+	# carries no persisted marker, so the cached instance must be rolled back.
+	var out_path := "res://test_tmp_setprop_prewrite.tres"
+	_rm_tmp(out_path)
+	var created := _handler.create_resource({
+		"type": "BoxShape3D",
+		"resource_path": out_path,
+	})
+	assert_has_key(created, "data")
+	assert_eq(created.data.resource_class, "BoxShape3D", "setup fixture must be the resource these assertions assume")
+	var refused := McpResourceIO.save_to_disk(BoxShape3D.new(), out_path, false, "Resource")
+	assert_is_error(refused)
+	assert_false(refused.error.get("data", {}).has("persisted"),
+		"an error raised before the write must not claim the file was persisted")
+	assert_true(ResourceHandler._should_restore_after_save_error(refused),
+		"nothing reached the file, so the cached instance must be rolled back")
+	_rm_tmp(out_path)
+
+
+func test_set_resource_property_keeps_values_when_only_the_uid_write_failed() -> void:
+	# save_to_disk's uid branch runs AFTER ResourceSaver.save succeeded, so the
+	# file already carries the new values. Rolling back there would leave the
+	# editor's cached copy behind the file, and the editor would later
+	# re-serialize that stale copy over the good file: this op's own failure
+	# mode, mirrored. A real set_uid failure isn't reachable from a test, so
+	# this pins the decision on the marker; the sibling test above pins that
+	# pre-write errors don't carry it.
+	var persisted_err := ErrorCodes.make(
+		ErrorCodes.INTERNAL_ERROR,
+		"Resource saved to res://x.tres but failed to write its uid: Permission denied"
+	)
+	persisted_err["error"]["data"] = {"persisted": true}
+	assert_false(ResourceHandler._should_restore_after_save_error(persisted_err),
+		"the file carries the new values, so the cached instance must keep them")
+
+
+func test_set_resource_property_restore_defaults_to_rolling_back() -> void:
+	# An error with no data at all (any future save_to_disk branch) must take
+	# the safe path: assume the file is unchanged and restore.
+	var bare := ErrorCodes.make(ErrorCodes.INTERNAL_ERROR, "something else failed")
+	assert_true(ResourceHandler._should_restore_after_save_error(bare))
 
 
 # ----- get_resource_info -----

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -2161,6 +2161,55 @@ class TestResourceCreateTool:
 
 
 # ---------------------------------------------------------------------------
+# resource_set_property
+# ---------------------------------------------------------------------------
+
+
+class TestResourceSetPropertyTool:
+    async def test_set_property_on_existing_resource(self, mcp_stack):
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "set_resource_property"
+            assert cmd["params"] == {
+                "resource_path": "res://settings/ocean.tres",
+                "properties": {"wave_height": 2.5, "wind_speed": 12.0},
+            }
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "resource_path": "res://settings/ocean.tres",
+                    "resource_class": "Resource",
+                    "properties_applied": 2,
+                    "overwritten": True,
+                    "uid_preserved": True,
+                    "undoable": False,
+                    "reason": (
+                        "File save is persistent; edit the .tres file manually to revert"
+                    ),
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "resource_manage",
+            {
+                "op": "set_property",
+                "params": {
+                    "resource_path": "res://settings/ocean.tres",
+                    "properties": {"wave_height": 2.5, "wind_speed": 12.0},
+                },
+            },
+        )
+        await task
+
+        assert result.data["properties_applied"] == 2
+        assert result.data["uid_preserved"] is True
+        assert result.data["undoable"] is False
+
+
+# ---------------------------------------------------------------------------
 # resource_get_info
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -582,6 +582,16 @@ class StubClient:
                 "properties_applied": len(params.get("properties", {}) or {}),
                 "undoable": True,
             }
+        if command == "set_resource_property":
+            return {
+                "resource_path": params.get("resource_path", ""),
+                "resource_class": "BoxShape3D",
+                "properties_applied": len(params.get("properties", {}) or {}),
+                "overwritten": True,
+                "uid_preserved": True,
+                "undoable": False,
+                "reason": "File save is persistent; edit the .tres file manually to revert",
+            }
         if command == "read_file":
             return {
                 "path": params.get("path", ""),
@@ -3176,6 +3186,24 @@ async def test_resource_create_minimal_omits_empty_params():
     assert "properties" not in params
 
 
+async def test_resource_set_property_handler():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await resource_handlers.resource_set_property(
+        runtime,
+        resource_path="res://shapes/box.tres",
+        properties={"size": {"x": 1, "y": 2, "z": 3}},
+    )
+    assert result["properties_applied"] == 1
+    assert result["undoable"] is False
+    assert result["uid_preserved"] is True
+    assert client.calls[-1]["command"] == "set_resource_property"
+    assert client.calls[-1]["params"] == {
+        "resource_path": "res://shapes/box.tres",
+        "properties": {"size": {"x": 1, "y": 2, "z": 3}},
+    }
+
+
 async def test_resource_get_info_handler_forwards_type():
     client = StubClient()
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)
@@ -3542,6 +3570,32 @@ async def test_resource_create_requires_writable():
             type="BoxMesh",
             path="/Main/Mesh",
             property="mesh",
+        )
+
+
+async def test_resource_set_property_requires_writable():
+    """set_property writes a file — it must gate on readiness like create."""
+    from godot_ai.godot_client.client import GodotCommandError
+    from godot_ai.sessions.registry import Session
+
+    client = StubClient()
+    client.live_readiness = "importing"
+    session = Session(
+        session_id="s1",
+        godot_version="4.4",
+        project_path="/tmp/p",
+        plugin_version="0.1",
+        readiness="importing",
+    )
+    registry = SessionRegistry()
+    registry.register(session)
+    runtime = DirectRuntime(registry=registry, client=client)
+
+    with pytest.raises(GodotCommandError):
+        await resource_handlers.resource_set_property(
+            runtime,
+            resource_path="res://shapes/box.tres",
+            properties={"size": {"x": 1, "y": 1, "z": 1}},
         )
 
 

--- a/tests/unit/test_server_instructions.py
+++ b/tests/unit/test_server_instructions.py
@@ -73,7 +73,7 @@ _FROZEN_NO_EXCLUSION_TEXT = (
     "                   set_stylebox_flat, apply\n"
     "  ui_manage        set_anchor_preset, set_text, build_layout, draw_recipe\n"
     "  resource_manage  search, load, assign, get_info, create,\n"
-    "                   curve_set_points, environment_create,\n"
+    "                   set_property, curve_set_points, environment_create,\n"
     "                   physics_shape_autofit, gradient_texture_create,\n"
     "                   noise_texture_create\n"
     "  api_manage       get_class\n"


### PR DESCRIPTION
## The Problem

There is no way to change one field of an existing .tres through the editor. resource_manage can load (read), assign (point a node property at a resource file), and create (make a new resource, optionally saving it), but nothing mutates a resource that already exists on disk.

The obvious workaround is to edit the .tres as text from outside Godot, which is unsafe while the editor is running. Measuring on 4.7.1 against a custom class_name Resource whose exports had been corrupted to null: after fixing the file on disk, filesystem_manage(op="scan") had no effect, scene_open(force_reload=true) on a scene that ext_resources it had no effect, and resource_manage(op="load") still returned the stale copy.  Only ResourceLoader.load(path, "", CACHE_MODE_IGNORE) inside the game subprocess saw the new values. Nothing reachable from the MCP evicts the editor's ResourceCache, so the editor re-serializes its stale copy over the file the moment anything marks that resource dirty. This is upstream engine behaviour (godotengine/godot#73602, godotengine/godot#75865), not an MCP defect, but the MCP can offer the operation that sidesteps it.

## The Solution

set_property loads through the cached instance deliberately, applies the properties, and saves that instance back. There is no second copy, so cache and file cannot diverge, so the same property that makes node_set_property + scene_save safe for scenes today.

Composed from existing pieces: _apply_resource_properties already validates names against the resource's real property list, returns data.valid_properties on a miss, coerces types, and supports the nested {"__class__": ...} shortcut. McpResourceIO.save_to_disk already handles path validation, directory creation, the #288 re-entrancy guard, and uid preservation on resave.

Both failure paths restore the prior values:
_apply_resource_properties applies key-by-key and returns on the first rejection, so without the rollback a bad name in position 2 would leave key 1 written to the cached instance but never saved, reintroducing the divergence the op exists to prevent.

Scope of this change: the file must already exist (creating one is op="create", so a typo in a path cannot silently mint a resource); .tscn/.scn are refused with a pointer at node_set_property + scene_save; sub-resource targets
(path.tres::SubID) are not supported yet. Not undoable, matching create's save branch, so a file write is not scene-undoable.

## Tests

9 new GDScript tests, including the two that carry the argument:

* round_trip_updates_file_and_cache: warms the cache the way an open scene would, sets size, then asserts the new value both on disk (read with CACHE_MODE_IGNORE, so a plain load() cannot pass it by handing back the instance the handler just mutated) and on the cached instance, plus uid_preserved and the original uid.
* bad_name_rolls_back_earlier_keys: {size: ..., not_a_real_field: ...} leaves both the cached instance and the file untouched, and returns data.valid_properties.

Plus: missing/empty/non-dict params, a path outside the project, the .tscn refusal, the missing-file pointer at create, and a custom class_name Resource (the #580 failure class, and what the motivating .tres was).

## Verification
* ruff check src tests — clean
* pytest — 1822 passed, 3 skipped
* script/ci-check-gdscript — clean
* test_run against a live 4.7.1 editor — 2315/2342 passed, 0 failed, 27 skipped, 70/70 suites; the 9 new tests pass individually
* Live MCP smoke: create a .tres, set_property it, and read the file back off disk — size = Vector3(4, 5, 6), uid_preserved: true; the unknown-property call returns PROPERTY_NOT_ON_CLASS with valid_properties

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `set_property` operation for updating fields in existing `.tres` and `.res` resource files.
  * Supports updating multiple properties in one operation and saving changes directly to disk.
  * Preserves resource UIDs and rolls back changes when updates cannot be saved.

* **Documentation**
  * Added guidance covering validation requirements, save behavior, limitations, and non-undoable updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->