### PR TITLE
Fix version-check lifecycle-manager refcount cycle

### DIFF
--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -622,6 +622,10 @@ func _exit_tree() -> void:
 	if _headless_disabled:
 		_server_started_this_session = false
 		_headless_disabled = false
+		## `_lifecycle` is built in _init(), before the headless guard in
+		## _enter_tree() runs, so it exists even on this path — null it here
+		## too (the full teardown below is skipped).
+		_lifecycle = null
 		return
 
 	if _custom_tool_registry != null:
@@ -679,6 +683,12 @@ func _exit_tree() -> void:
 	## same-session disable/enable cycle) to adopt. Explicit stops (dock
 	## Restart, update reload) still kill via _stop_server.
 	_lifecycle.teardown_for_editor_exit()
+	## Match the nulling every sibling field gets above. `_lifecycle` was built
+	## as ServerLifecycleManager.new(self), so it holds the plugin back —
+	## leaving the field set keeps the manager and its scripts alive past
+	## plugin teardown (surfaces as leaked ObjectDB instances / "resource still
+	## in use" for server_lifecycle.gd + server_version_check.gd at editor exit).
+	_lifecycle = null
 	## Symmetric with prepare_for_update_reload: the static guard persists
 	## across disable/enable within a single editor session, so the re-enabled
 	## plugin instance's _start_server would short-circuit and never respawn.

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -384,6 +384,12 @@ func arm_version_check(connection, expected_version: String) -> void:
 func disarm_version_check() -> void:
 	if _version_check != null:
 		_version_check.disarm()
+		## `_version_check` was built as McpServerVersionCheck.new(self), so it
+		## holds this manager back — leaving the field set is a
+		## RefCounted<->RefCounted cycle GDScript's refcounting can't collect
+		## (both instances and both scripts leak until the process exits). Drop
+		## it; arm_version_check() reconstructs it lazily on the next arm.
+		_version_check = null
 
 
 func get_version_check():
@@ -1790,6 +1796,11 @@ func _recover_stale_port_occupant_impl(port: int, wait_s: float) -> bool:
 ## so enabling the setting mid-session takes effect on the next server
 ## start instead of leaving a record that points at a soon-reaped PID.
 func teardown_for_editor_exit() -> void:
+	## Break the version-check <-> manager refcount cycle up front, regardless
+	## of which exit branch runs below (detach / lease-handover / stop). The
+	## other disarm_version_check() call sites only cover terminal-diagnosis
+	## paths, so a normal editor close would otherwise leak the pair.
+	disarm_version_check()
 	if _server_keep_alive:
 		detach_server()
 		return


### PR DESCRIPTION
McpServerLifecycleManager.arm_version_check() builds `_version_check = McpServerVersionCheck.new(self)`, and McpServerVersionCheck._init() stores `_manager = <that same manager>`. That is a RefCounted <-> RefCounted cycle, which GDScript's reference counting cannot collect. Once arm_version_check() has run even once, both instances and both scripts stay alive for the rest of the session. Surfaces at editor close as:

    WARNING: N ObjectDB instances were leaked at exit
    ERROR: N resources still in use at exit
    Resource still in use: res://addons/godot_ai/utils/server_lifecycle.gd
    Resource still in use: res://addons/godot_ai/utils/server_version_check.gd
    (+ the two scripts' method/property StringNames as orphans)

disarm_version_check()'s docstring already says it "releases the connection / manager references", but disarm() only nulled _connection.

- disarm_version_check(): also drop `_version_check`. arm_version_check() already reconstructs it lazily (`if _version_check == null`), and every get_version_check() / is_awaiting_server_version() reader is null-safe, so the observable contract is unchanged (a disarmed check and a nulled one both report not-awaiting).
- teardown_for_editor_exit(): call disarm_version_check() up front. The existing call sites only cover terminal-diagnosis paths, so a plain editor close never broke the cycle.
- plugin.gd::_exit_tree(): null `_lifecycle` after teardown, matching the nulling every sibling field already gets (the manager holds the plugin back via ServerLifecycleManager.new(self)).

Verified: `godot --headless --path test_project --import` parses clean; editor open/close (`--editor --quit`) reports zero leaked ObjectDB / resources / RIDs from the plugin, vs the counts above before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resource leaks when closing the editor.
  * Improved cleanup of server lifecycle and version-check resources during shutdown.
  * Prevented “resource still in use” warnings and leaked object messages from appearing at editor exit.
  * Ensured version checks can be initialized again when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->