### PR TITLE
feat(project): add set_main_scene so a scaffolded project can boot

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -197,7 +197,7 @@ Calls take the form:
 | `scene_manage` | `create`, `save_as`, `get_roots` |
 | `node_manage` | `get_children`, `get_groups`, `delete`, `duplicate`, `rename`, `move`, `reparent`, `add_to_group`, `remove_from_group` |
 | `script_manage` | `read`, `detach`, `find_symbols` |
-| `project_manage` | `stop`, `settings_get`, `settings_set` |
+| `project_manage` | `stop`, `settings_get`, `settings_set`, `set_main_scene` |
 | `editor_manage` | `state`, `selection_get`, `selection_set`, `monitors_get`, `quit`, `logs_clear`, `game_eval` |
 | `session_manage` | `list` |
 | `test_manage` | `results_get` |

--- a/plugin/addons/godot_ai/handlers/project_handler.gd
+++ b/plugin/addons/godot_ai/handlers/project_handler.gd
@@ -18,10 +18,12 @@ const RUN_READY_WAIT_SEC := 3.0
 ##     settings_set key="autoload/Boot" value="*res://../../evil.gd"
 ##
 ## would land arbitrary code on the next project open, and a `project.godot`
-## diff is easy to miss in review. Autoloads have a validated route of their
-## own (`autoload_handler.add_autoload`, which runs the path through
-## `McpPathValidator`); the rest are refused outright because there is no
-## legitimate agent workflow for repointing the engine's startup execution.
+## diff is easy to miss in review. Blocked keys that DO have a legitimate agent
+## workflow get a narrow validated op of their own instead of an exception
+## carved into this list — `autoload_handler.add_autoload` for `autoload/`,
+## `set_main_scene` below for the main scene — so the denylist stays a flat set
+## of keys with no escape hatches to reason about. The rest are refused
+## outright.
 ##
 ## Deliberately NARROW. A denylist that over-blocks turns settings_set into a
 ## tool agents can't use, so only keys that actually carry code (or a command
@@ -45,6 +47,20 @@ const STARTUP_EXECUTION_KEYS_EXACT: Array[String] = [
 	"editor/run/main_run_args",             ## command line for the run
 ]
 
+## ProjectSettings key that names the scene the game boots into.
+const MAIN_SCENE_KEY := "application/run/main_scene"
+
+## Validated routes for blocked keys, appended to the refusal. `settings_get`
+## on a blocked key works, so an agent can read the value it needs to change
+## and then be refused the write — without a pointer it reads that asymmetry as
+## "this workflow is closed" and hands a non-bootable project back to the user
+## (#915). Keyed by the lowercased exact entry above.
+const STARTUP_EXECUTION_KEY_ALTERNATIVES := {
+	"application/run/main_scene":
+		"Use project_manage(op='set_main_scene', params={'path': 'res://<scene>.tscn'}), "
+		+ "which accepts only an existing PackedScene inside the project.",
+}
+
 
 ## Returns "" when `key` may be written via set_project_setting, or a
 ## human-readable refusal reason otherwise. Static so it is unit-testable
@@ -64,10 +80,14 @@ static func startup_execution_key_refusal(key: String) -> String:
 			)
 	for exact in STARTUP_EXECUTION_KEYS_EXACT:
 		if lowered == exact:
-			return (
+			var message := (
 				"Refusing to set '%s' — this key controls what the engine loads " % key
 				+ "or executes at project startup."
 			)
+			var alternative := str(STARTUP_EXECUTION_KEY_ALTERNATIVES.get(exact, ""))
+			if not alternative.is_empty():
+				message += " " + alternative
+			return message
 	return ""
 
 var _connection: McpConnection
@@ -138,6 +158,69 @@ func set_project_setting(params: Dictionary) -> Dictionary:
 			"value": NodeHandler._serialize_value(value),
 			"old_value": NodeHandler._serialize_value(old_value),
 			"type": type_string(typeof(value)),
+			"undoable": false,
+			"reason": "ProjectSettings changes are saved to disk",
+		}
+	}
+
+
+## The validated route to `application/run/main_scene`, which
+## `set_project_setting` refuses (STARTUP_EXECUTION_KEYS_EXACT) because a
+## generic setter has no way to tell a scene path from an arbitrary payload.
+## Without it an agent can create every scene, script, node and resource for a
+## new project and still not make it bootable: `project_run(mode="main")` has
+## nothing to launch, and the last step — pure mechanical configuration — has
+## to be finished by hand in the editor (#915).
+##
+## The blocklist's intent survives because the value can only ever name a scene
+## the project already contains: the path is confined under `res://` by
+## `McpPathValidator`, must resolve through `ResourceLoader`, and must load as
+## a `PackedScene`. No new startup-execution surface is opened.
+func set_main_scene(params: Dictionary) -> Dictionary:
+	var path: String = params.get("path", "")
+	var path_err = McpPathValidator.path_error(path, "path")
+	if path_err != null:
+		return path_err
+
+	if not ResourceLoader.exists(path):
+		return ErrorCodes.make(ErrorCodes.RESOURCE_NOT_FOUND, "Scene not found: %s" % path)
+	## Load rather than trusting `ResourceLoader.exists(path, "PackedScene")`:
+	## the type hint there comes from the loader's guess for the extension, so a
+	## `.tscn` that fails to parse would still pass it. A main scene that cannot
+	## load is a project that cannot boot, so pay for the real load here instead
+	## of surfacing the failure as a mystified `project_run`.
+	var resource := ResourceLoader.load(path)
+	if resource == null:
+		return ErrorCodes.make(
+			ErrorCodes.RESOURCE_NOT_FOUND,
+			"Failed to load scene (it may be corrupt or have a broken dependency): %s" % path
+		)
+	if not (resource is PackedScene):
+		return ErrorCodes.make(
+			ErrorCodes.WRONG_TYPE,
+			"path must be a PackedScene, got %s: %s" % [resource.get_class(), path]
+		)
+
+	var had_setting := ProjectSettings.has_setting(MAIN_SCENE_KEY)
+	var old_value = ProjectSettings.get_setting(MAIN_SCENE_KEY) if had_setting else null
+	ProjectSettings.set_setting(MAIN_SCENE_KEY, path)
+	var err := ProjectSettings.save()
+	if err != OK:
+		if had_setting:
+			ProjectSettings.set_setting(MAIN_SCENE_KEY, old_value)
+		else:
+			ProjectSettings.clear(MAIN_SCENE_KEY)
+		return ErrorCodes.make(
+			ErrorCodes.INTERNAL_ERROR,
+			"Failed to save project settings while setting the main scene: %s (error %d)"
+			% [error_string(err), err]
+		)
+
+	return {
+		"data": {
+			"key": MAIN_SCENE_KEY,
+			"path": path,
+			"old_value": NodeHandler._serialize_value(old_value),
 			"undoable": false,
 			"reason": "ProjectSettings changes are saved to disk",
 		}

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -406,6 +406,7 @@ func _enter_tree() -> void:
 	_dispatcher.register_lazy("game_command", "editor", &"game_command")
 	_dispatcher.register_lazy("get_project_setting", "project", &"get_project_setting")
 	_dispatcher.register_lazy("set_project_setting", "project", &"set_project_setting")
+	_dispatcher.register_lazy("set_main_scene", "project", &"set_main_scene")
 	_dispatcher.register_lazy("run_project", "project", &"run_project")
 	_dispatcher.register_lazy("stop_project", "project", &"stop_project")
 	_dispatcher.register_lazy("search_filesystem", "project", &"search_filesystem")

--- a/src/godot_ai/handlers/project.py
+++ b/src/godot_ai/handlers/project.py
@@ -98,6 +98,18 @@ async def project_settings_set(runtime: DirectRuntime, key: str, value: Any) -> 
     return await runtime.send_command("set_project_setting", {"key": key, "value": value})
 
 
+async def project_set_main_scene(runtime: DirectRuntime, path: str) -> dict:
+    """Point ``application/run/main_scene`` at an existing scene.
+
+    ``settings_set`` refuses that key — it is part of the startup-execution
+    surface a generic setter can't validate — which left a scaffolded project
+    unbootable through MCP alone (#915). The plugin-side op accepts only a
+    ``res://`` path inside the project that loads as a ``PackedScene``.
+    """
+    await require_writable_async(runtime)
+    return await runtime.send_command("set_main_scene", {"path": path})
+
+
 def project_info_resource_data(runtime: DirectRuntime) -> dict:
     session = runtime.get_active_session()
     if session is None:

--- a/src/godot_ai/server.py
+++ b/src/godot_ai/server.py
@@ -211,7 +211,10 @@ _ROLLUP_BLOCKS: tuple[tuple[str | None, str], ...] = (
         "                   move, reparent, add_to_group, remove_from_group\n",
     ),
     ("script", "  script_manage    read, detach, find_symbols\n"),
-    ("project", "  project_manage   stop, settings_get, settings_set\n"),
+    (
+        "project",
+        "  project_manage   stop, settings_get, settings_set, set_main_scene\n",
+    ),
     (
         "editor",
         "  editor_manage    state, selection_get/set, monitors_get, quit, logs_clear,\n"

--- a/src/godot_ai/tools/project.py
+++ b/src/godot_ai/tools/project.py
@@ -32,6 +32,18 @@ Ops:
         Read a ProjectSettings key (e.g. "application/config/name").
   • settings_set(key, value)
         Write a ProjectSettings key and persist to project.godot.
+        Refuses the startup-execution keys (``autoload/*``,
+        ``editor_plugins/*``, ``application/run/main_scene``,
+        ``editor/run/main_run_args``, ``editor/script/templates_search_path``);
+        use ``set_main_scene`` / ``autoload_manage(op="add")`` for the two
+        that have a validated route.
+  • set_main_scene(path)
+        Set the project's main scene — the scene ``project_run(mode="main")``
+        boots and the engine loads at startup. Writes
+        ``application/run/main_scene`` and persists to project.godot. ``path``
+        must be a ``res://`` scene inside the project that already exists and
+        loads as a PackedScene, so a scaffolded project can be made runnable
+        without opening the generic startup-execution surface.
 """
 
 
@@ -96,6 +108,7 @@ def register_project_tools(mcp: FastMCP) -> None:
             "stop": project_handlers.project_stop,
             "settings_get": project_handlers.project_settings_get,
             "settings_set": project_handlers.project_settings_set,
+            "set_main_scene": project_handlers.project_set_main_scene,
         },
         read_resource_forms={
             ## stop ends a play session; not a read in the URI sense.

--- a/test_project/tests/test_project.gd
+++ b/test_project/tests/test_project.gd
@@ -128,6 +128,93 @@ func test_set_project_setting_refuses_startup_execution_keys() -> void:
 		)
 
 
+func test_set_project_setting_main_scene_refusal_names_the_validated_route() -> void:
+	## #915: settings_get on application/run/main_scene works, so an agent can
+	## read the value it needs to change and then be refused the write. Without
+	## a pointer to set_main_scene that asymmetry reads as "this workflow is
+	## closed" and the project is handed back unbootable.
+	var result := _handler.set_project_setting({
+		"key": "application/run/main_scene",
+		"value": "res://main.tscn",
+	})
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
+	assert_contains(String(result.error.message), "set_main_scene")
+
+
+# ----- set_main_scene -----
+
+func test_set_main_scene_roundtrip() -> void:
+	## The whole point of the op: the key settings_set refuses must actually be
+	## writable through this route, and the STORED value must change — not just
+	## the response echo. Uses a scene that is NOT the current main scene so a
+	## no-op write can't pass this.
+	var original := _handler.get_project_setting({"key": "application/run/main_scene"})
+	var old_scene = original.data.value
+	var target := "res://snowman.tscn"
+	if old_scene == target:
+		skip("test project already boots %s; pick a different fixture scene" % target)
+		return
+
+	var result := _handler.set_main_scene({"path": target})
+	var readback := _handler.get_project_setting({"key": "application/run/main_scene"})
+
+	## Restore BEFORE asserting so a failed assert can't leak the override into
+	## the tracked project.godot (same pattern as test_runner's main_scene test).
+	_handler.set_main_scene({"path": old_scene})
+
+	assert_has_key(result, "data")
+	assert_eq(result.data.key, "application/run/main_scene")
+	assert_eq(result.data.path, target)
+	assert_eq(result.data.old_value, old_scene)
+	assert_eq(result.data.undoable, false)
+	assert_eq(readback.data.value, target,
+		"stored main scene must reflect the write, not just the response echo")
+
+
+func test_set_main_scene_missing_path() -> void:
+	var result := _handler.set_main_scene({})
+	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)
+
+
+func test_set_main_scene_rejects_traversal_and_absolute_paths() -> void:
+	## The op is the narrow exception to the startup-execution blocklist, so
+	## the containment check is what keeps it narrow.
+	for path in [
+		"res://../../etc/passwd.tscn",
+		"res://../outside.tscn",
+		"/etc/passwd.tscn",
+		"user://elsewhere.tscn",
+		"uid://abc123",
+	]:
+		var result := _handler.set_main_scene({"path": path})
+		assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE,
+			"non-confined res:// path must be refused: %s" % path)
+
+
+func test_set_main_scene_rejects_missing_scene() -> void:
+	var result := _handler.set_main_scene({"path": "res://zzz_no_such_scene.tscn"})
+	assert_is_error(result, ErrorCodes.RESOURCE_NOT_FOUND)
+
+
+func test_set_main_scene_rejects_non_packed_scene() -> void:
+	## A path that loads fine but isn't a scene would leave the project
+	## unbootable in a way project_run can only report as a mystery.
+	var script_path := "res://addons/godot_ai/handlers/project_handler.gd"
+	assert_true(ResourceLoader.exists(script_path), "precondition: the plugin script is loadable")
+	var result := _handler.set_main_scene({"path": script_path})
+	assert_is_error(result, ErrorCodes.WRONG_TYPE)
+	assert_contains(String(result.error.message), "PackedScene")
+
+
+func test_set_main_scene_refusal_leaves_setting_untouched() -> void:
+	var before := _handler.get_project_setting({"key": "application/run/main_scene"})
+	var result := _handler.set_main_scene({"path": "res://zzz_no_such_scene.tscn"})
+	assert_is_error(result)
+	var after := _handler.get_project_setting({"key": "application/run/main_scene"})
+	assert_eq(after.data.value, before.data.value,
+		"a refused path must never reach ProjectSettings")
+
+
 func test_startup_execution_key_refusal_is_case_folded() -> void:
 	## macOS/Windows users and LLM-generated calls both produce case variants.
 	assert_false(

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -1209,6 +1209,44 @@ class TestProjectSettingsSetTool:
 
 
 # ---------------------------------------------------------------------------
+# project_set_main_scene
+# ---------------------------------------------------------------------------
+
+
+class TestProjectSetMainSceneTool:
+    async def test_set_main_scene(self, mcp_stack):
+        ## #915: the op exists because settings_set refuses
+        ## application/run/main_scene, which left an agent-scaffolded project
+        ## with nothing for project_run(mode="main") to launch.
+        client, plugin = mcp_stack
+
+        async def respond():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "set_main_scene"
+            assert cmd["params"] == {"path": "res://levels/level1.tscn"}
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "key": "application/run/main_scene",
+                    "path": "res://levels/level1.tscn",
+                    "old_value": "res://main.tscn",
+                    "undoable": False,
+                },
+            )
+
+        task = asyncio.create_task(respond())
+        result = await client.call_tool(
+            "project_manage",
+            {"op": "set_main_scene", "params": {"path": "res://levels/level1.tscn"}},
+        )
+        await task
+
+        assert result.data["key"] == "application/run/main_scene"
+        assert result.data["path"] == "res://levels/level1.tscn"
+        assert result.data["old_value"] == "res://main.tscn"
+
+
+# ---------------------------------------------------------------------------
 # filesystem_search
 # ---------------------------------------------------------------------------
 

--- a/tests/integration/test_project_tools.py
+++ b/tests/integration/test_project_tools.py
@@ -87,6 +87,56 @@ class TestProjectSettingsSet:
         await plugin.close()
 
 
+class TestProjectSetMainScene:
+    async def test_set_main_scene_roundtrip(self, harness):
+        plugin = await harness.connect_plugin()
+        client = GodotClient(harness.server, harness.registry)
+
+        async def mock_handler():
+            cmd = await plugin.recv_command()
+            assert cmd["command"] == "set_main_scene"
+            assert cmd["params"] == {"path": "res://levels/level1.tscn"}
+            await plugin.send_response(
+                cmd["request_id"],
+                {
+                    "key": "application/run/main_scene",
+                    "path": "res://levels/level1.tscn",
+                    "old_value": "res://main.tscn",
+                    "undoable": False,
+                },
+            )
+
+        handler_task = asyncio.create_task(mock_handler())
+        result = await client.send("set_main_scene", {"path": "res://levels/level1.tscn"})
+        await handler_task
+
+        assert result["key"] == "application/run/main_scene"
+        assert result["path"] == "res://levels/level1.tscn"
+        assert result["old_value"] == "res://main.tscn"
+        await plugin.close()
+
+    async def test_set_main_scene_non_scene_error_propagates(self, harness):
+        plugin = await harness.connect_plugin()
+        client = GodotClient(harness.server, harness.registry)
+
+        async def mock_handler():
+            cmd = await plugin.recv_command()
+            await plugin.send_error(
+                cmd["request_id"],
+                "WRONG_TYPE",
+                "path must be a PackedScene, got GDScript: res://main.gd",
+            )
+
+        handler_task = asyncio.create_task(mock_handler())
+        with pytest.raises(GodotCommandError) as exc_info:
+            await client.send("set_main_scene", {"path": "res://main.gd"})
+        await handler_task
+
+        assert exc_info.value.code == "WRONG_TYPE"
+        assert "PackedScene" in exc_info.value.message
+        await plugin.close()
+
+
 class TestFilesystemSearch:
     async def test_search_by_name(self, harness):
         plugin = await harness.connect_plugin()

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -249,6 +249,13 @@ class StubClient:
                 "type": type(value).__name__,
                 "undoable": False,
             }
+        if command == "set_main_scene":
+            return {
+                "key": "application/run/main_scene",
+                "path": params.get("path", ""),
+                "old_value": "res://old.tscn",
+                "undoable": False,
+            }
         if command == "get_editor_state":
             return {
                 "current_scene": "res://main.tscn",
@@ -2981,6 +2988,18 @@ async def test_project_settings_set_handler():
         "key": "display/window/size/viewport_width",
         "value": 1920,
     }
+
+
+async def test_project_set_main_scene_handler():
+    ## #915: settings_set refuses application/run/main_scene, so the only way
+    ## to make a scaffolded project bootable is this dedicated plugin command.
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+    result = await project_handlers.project_set_main_scene(runtime, path="res://main.tscn")
+    assert result["key"] == "application/run/main_scene"
+    assert result["path"] == "res://main.tscn"
+    assert client.calls[-1]["command"] == "set_main_scene"
+    assert client.calls[-1]["params"] == {"path": "res://main.tscn"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_server_instructions.py
+++ b/tests/unit/test_server_instructions.py
@@ -45,7 +45,7 @@ _FROZEN_NO_EXCLUSION_TEXT = (
     "  node_manage      get_children, get_groups, delete, duplicate, rename,\n"
     "                   move, reparent, add_to_group, remove_from_group\n"
     "  script_manage    read, detach, find_symbols\n"
-    "  project_manage   stop, settings_get, settings_set\n"
+    "  project_manage   stop, settings_get, settings_set, set_main_scene\n"
     "  editor_manage    state, selection_get/set, monitors_get, quit, logs_clear,\n"
     "                   game_eval\n"
     "  session_manage   list\n"


### PR DESCRIPTION
Closes #915

## Problem

`settings_set` refuses `application/run/main_scene` as part of the startup-execution blocklist, while `settings_get` on the same key works. An agent could create every scene, script, node and resource for a new project, read the main scene it needed to change, and then be refused the write — `project_run(mode="main")` had nothing to launch, and the last step, pure mechanical configuration, fell back to the user in the editor.

## Fix

A narrow `project_manage(op="set_main_scene", params={"path": "res://<scene>.tscn"})`, rather than an exception carved into `settings_set`, so the denylist stays a flat set of keys with no escape hatches to reason about.

The blocklist's intent survives because the value can only ever name a scene the project already contains:

- confined under `res://` by `McpPathValidator` (traversal, absolute, `uid://` and `user://` all refused),
- resolvable through `ResourceLoader`,
- and loading as a `PackedScene`.

The load is real rather than a `ResourceLoader.exists(path, "PackedScene")` type hint — that hint comes from the loader's guess for the extension, so a `.tscn` that fails to parse would pass it and surface later as a mystified `project_run`.

The `main_scene` refusal now also names the validated route, mirroring how the `autoload/` refusal points at `autoload_manage(op='add')`. Without it, the readable/unwritable asymmetry reads to an agent as a closed workflow.

## Verification

- `ruff check src tests` — clean
- `pytest -v` — 1843 passed, 20 skipped
- `script/ci-check-gdscript` against a 4.7.2 `--import` log — all GDScript OK
- `test_run` against a live editor on this worktree — 2331 passed, 0 failed, 23 skipped across 70 suites (6 new tests in the `project` suite)
- Live smoke over the real transport: set → read back → restore round-trip; refusals for traversal, missing scene, and a non-`PackedScene` path; the `settings_set` refusal message naming `set_main_scene`
- End-to-end: `set_main_scene("res://snowman.tscn")` → `project_run(mode="main")` → the running game's scene tree root is `/Snowman`, confirming the op makes a project bootable. Editor stopped and the main scene restored afterwards; `test_project/project.godot` left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated `project_manage` operation for setting the project’s main scene.
  - Validates that the selected path is an existing, loadable scene within the project.
  - Saves the setting and reports the updated path and previous value.

- **Documentation**
  - Updated project-management guidance to describe the new operation and explain the supported route for main-scene configuration.

- **Bug Fixes**
  - Improved refusal messages for unsupported direct edits to startup-execution settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->