### PR TITLE
fix: refresh an already-loaded GDScript after script writes

### DIFF
--- a/plugin/addons/godot_ai/handlers/script_handler.gd
+++ b/plugin/addons/godot_ai/handlers/script_handler.gd
@@ -87,6 +87,13 @@ func create_script(params: Dictionary) -> Dictionary:
 	if efs != null:
 		efs.update_file(path)
 
+	# An overwrite can target a script that is already loaded (attached to a
+	# node, preloaded, open in the script editor). update_file() registers the
+	# bytes but leaves that live GDScript on the old source (#937), so the very
+	# next call would run stale code after a "successful" write. Refresh it.
+	if existed_before:
+		_refresh_loaded_gdscript(data, path, content)
+
 	# `.gd.uid` is the sidecar Godot generates on scan; list both so the caller
 	# can rm the full set in one go.
 	McpResourceIO.attach_cleanup_hint(data, existed_before, [path, path + ".uid"])
@@ -197,6 +204,46 @@ func _attach_gdscript_diagnostics(data: Dictionary, path: String, content: Strin
 	data["diagnostics_detail"] = diagnostics_detail
 	data["diagnostics_scope"] = "this_file"
 	data["diagnostics_status"] = diagnostics_status
+
+
+## Bring an already-loaded GDScript back in step with the bytes just written.
+##
+## ResourceLoader caches GDScript by path, and EditorFileSystem.update_file()
+## does not touch that cache — so after a successful write, a script that a
+## node, a preload(), or the script editor already holds keeps executing the
+## previous source (#937). When the path is cached and the new source parsed,
+## push the source into the live object and reload it in place (keep_state so
+## existing instances survive). Reports `reloaded` plus a `reload_reason` when
+## it did not, so a caller can tell "the file changed" from "the code changed".
+##
+## Skipped when validation failed: the diagnostics capture above has already
+## reloaded the shared GDScriptCache entry with the broken source, so there is
+## no good code to push; `reload_reason: parse_error` tells the caller the
+## loaded code did NOT change to something runnable.
+static func _refresh_loaded_gdscript(data: Dictionary, path: String, content: String) -> void:
+	data["reloaded"] = false
+	if _script_has_error_diagnostics(data):
+		data["reload_reason"] = "parse_error"
+		return
+	if not ResourceLoader.has_cached(path):
+		data["reload_reason"] = "not_loaded"
+		return
+	var loaded := ResourceLoader.load(path)
+	if not (loaded is GDScript):
+		data["reload_reason"] = "not_gdscript"
+		return
+	var script := loaded as GDScript
+	if script.source_code == content:
+		data["reloaded"] = true
+		data["reload_reason"] = "already_current"
+		return
+	script.source_code = content
+	var err := script.reload(true)
+	if err != OK:
+		data["reload_reason"] = "reload_failed"
+		data["reload_error"] = err
+		return
+	data["reloaded"] = true
 
 
 static func _validate_gdscript_source(content: String) -> Dictionary:
@@ -322,6 +369,9 @@ func patch_script(params: Dictionary) -> Dictionary:
 	var efs := EditorInterface.get_resource_filesystem()
 	if efs != null:
 		efs.update_file(path)
+	# The file is fresh but any already-loaded GDScript for it is not (#937);
+	# make "patch succeeded" mean the loaded code changed, not just the bytes.
+	_refresh_loaded_gdscript(data, path, new_content)
 
 	return {"data": data}
 

--- a/src/godot_ai/tools/script.py
+++ b/src/godot_ai/tools/script.py
@@ -63,7 +63,9 @@ def register_script_tools(mcp: FastMCP) -> None:
 
         Finds an exact ``old_text`` and replaces with ``new_text``. Fails
         on multiple matches unless ``replace_all=True``; fails on zero matches.
-        Exact byte match (whitespace significant). Triggers filesystem scan.
+        Exact byte match (whitespace significant). Triggers filesystem scan and
+        refreshes an already-loaded GDScript in place so the next call runs the
+        new code (response reloaded=true; otherwise reload_reason says why).
         Not undoable via Ctrl+Z.
 
         Args:

--- a/test_project/tests/test_script.gd
+++ b/test_project/tests/test_script.gd
@@ -782,34 +782,45 @@ func test_find_symbols_class_name_with_extends_tail() -> void:
 
 # ----- #937: refresh an already-loaded GDScript after a write -----
 
-## One path per test: a GDScript stays in ResourceLoader's cache while any
-## reference is alive, so reusing a path across tests would hand the next
-## test the previous test's cached body — the very staleness under test.
-const RELOAD_HELPER_PATH := "res://tests/_mcp_test_reload_helper.gd"
-const RELOAD_OVERWRITE_PATH := "res://tests/_mcp_test_reload_overwrite.gd"
-const RELOAD_PARSE_PATH := "res://tests/_mcp_test_reload_parse.gd"
+## A GDScript stays in GDScriptCache (keyed by path) while any reference is
+## alive, and ResourceLoader cache modes do not refresh it — so a reused
+## fixture path hands the next test, or the next test_run in the same editor
+## session (CI reruns the suite after reload churn), the previous body or a
+## broken parse: the very staleness under test. Every invocation therefore
+## gets a path that has never been loaded.
 const RELOAD_RETURN_PARSE_ERROR := "Expected end of statement after return statement"
+
+
+func _unique_reload_path(tag: String) -> String:
+	return "res://tests/_mcp_test_reload_%s_%d.gd" % [tag, Time.get_ticks_usec()]
 
 
 func _reload_helper_source(value: String) -> String:
 	return "extends RefCounted\nstatic func value() -> String:\n\treturn \"%s\"\n" % value
 
 
-func _write_reload_helper(value: String, path: String = RELOAD_HELPER_PATH) -> void:
+func _write_reload_helper(value: String, path: String) -> void:
 	var file := FileAccess.open(path, FileAccess.WRITE)
 	assert_true(file != null, "helper fixture must be writable")
 	file.store_string(_reload_helper_source(value))
 	file.close()
 
 
+## Load a never-before-loaded fixture path so the object IS the cache entry.
+func _load_reload_helper(path: String) -> GDScript:
+	var loaded: GDScript = ResourceLoader.load(path)
+	assert_true(loaded != null, "fixture must load")
+	return loaded
+
+
 func test_patch_script_refreshes_loaded_gdscript() -> void:
 	## Regression for #937: a loaded GDScript kept the old body after a patch.
-	_write_reload_helper("old")
-	var loaded: GDScript = ResourceLoader.load(RELOAD_HELPER_PATH)
-	assert_true(loaded != null, "fixture must load")
+	var path := _unique_reload_path("patch")
+	_write_reload_helper("old", path)
+	var loaded: GDScript = _load_reload_helper(path)
 	assert_eq(loaded.new().value(), "old")
 	var result := _handler.patch_script({
-		"path": RELOAD_HELPER_PATH, "old_text": "\"old\"", "new_text": "\"new\"",
+		"path": path, "old_text": "\"old\"", "new_text": "\"new\"",
 	})
 	assert_has_key(result, "data")
 	assert_eq(result.data.replacements, 1)
@@ -817,27 +828,28 @@ func test_patch_script_refreshes_loaded_gdscript() -> void:
 	assert_false(result.data.has("reload_reason"), "a reloaded script carries no skip reason")
 	# The SAME object an agent (or a node) already holds now runs the new code.
 	assert_eq(loaded.new().value(), "new")
-	assert_eq(ResourceLoader.load(RELOAD_HELPER_PATH).new().value(), "new")
-	DirAccess.remove_absolute(RELOAD_HELPER_PATH)
+	assert_eq(ResourceLoader.load(path).new().value(), "new")
+	DirAccess.remove_absolute(path)
 
 
 func test_create_script_overwrite_refreshes_loaded_gdscript() -> void:
-	_write_reload_helper("old", RELOAD_OVERWRITE_PATH)
-	var loaded: GDScript = ResourceLoader.load(RELOAD_OVERWRITE_PATH)
+	var path := _unique_reload_path("overwrite")
+	_write_reload_helper("old", path)
+	var loaded: GDScript = _load_reload_helper(path)
 	assert_eq(loaded.new().value(), "old")
 	var result := _handler.create_script({
-		"path": RELOAD_OVERWRITE_PATH, "content": _reload_helper_source("newer"),
+		"path": path, "content": _reload_helper_source("newer"),
 	})
 	assert_has_key(result, "data")
 	assert_eq(result.data.import_settle, "already_known")
 	assert_eq(result.data.reloaded, true)
 	assert_eq(loaded.new().value(), "newer")
-	DirAccess.remove_absolute(RELOAD_OVERWRITE_PATH)
+	DirAccess.remove_absolute(path)
 
 
 func test_patch_script_reports_not_loaded_when_nothing_cached() -> void:
 	## A script nobody has loaded has nothing to refresh; say so explicitly.
-	var path := "res://tests/_mcp_test_reload_cold.gd"
+	var path := _unique_reload_path("cold")
 	var file := FileAccess.open(path, FileAccess.WRITE)
 	file.store_string(_reload_helper_source("old"))
 	file.close()
@@ -854,18 +866,19 @@ func test_patch_script_skips_reload_on_parse_error() -> void:
 	## loaded code changed. (The handler's diagnostics capture reloads the shared
 	## cache entry with the broken source, so the live object is already in an
 	## error state here — the point is the honest signal, not preservation.)
-	_write_reload_helper("old", RELOAD_PARSE_PATH)
-	var loaded: GDScript = ResourceLoader.load(RELOAD_PARSE_PATH)
+	var path := _unique_reload_path("parse")
+	_write_reload_helper("old", path)
+	var loaded: GDScript = _load_reload_helper(path)
 	assert_eq(loaded.new().value(), "old")
 	# Godot 4.7 surfaces the parse diagnostic through several logger copies.
 	for _i in 4:
 		expect_script_error_containing(RELOAD_RETURN_PARSE_ERROR)
 	var result := _handler.patch_script({
-		"path": RELOAD_PARSE_PATH, "old_text": "return \"old\"", "new_text": "return if",
+		"path": path, "old_text": "return \"old\"", "new_text": "return if",
 	})
 	assert_has_key(result, "data")
 	assert_eq(result.data.reloaded, false)
 	assert_eq(result.data.reload_reason, "parse_error")
 	assert_eq(result.data.diagnostics_status, "checked")
 	assert_true(result.data.diagnostics.size() >= 1, "the parse error is reported as a diagnostic")
-	DirAccess.remove_absolute(RELOAD_PARSE_PATH)
+	DirAccess.remove_absolute(path)

--- a/test_project/tests/test_script.gd
+++ b/test_project/tests/test_script.gd
@@ -778,3 +778,94 @@ func test_find_symbols_class_name_with_extends_tail() -> void:
 	assert_has_key(result, "data")
 	assert_eq(result.data.class_name, "_McpCnFormProbe",
 		"the `extends` tail must not leak into the class_name symbol")
+
+
+# ----- #937: refresh an already-loaded GDScript after a write -----
+
+## One path per test: a GDScript stays in ResourceLoader's cache while any
+## reference is alive, so reusing a path across tests would hand the next
+## test the previous test's cached body — the very staleness under test.
+const RELOAD_HELPER_PATH := "res://tests/_mcp_test_reload_helper.gd"
+const RELOAD_OVERWRITE_PATH := "res://tests/_mcp_test_reload_overwrite.gd"
+const RELOAD_PARSE_PATH := "res://tests/_mcp_test_reload_parse.gd"
+const RELOAD_RETURN_PARSE_ERROR := "Expected end of statement after return statement"
+
+
+func _reload_helper_source(value: String) -> String:
+	return "extends RefCounted\nstatic func value() -> String:\n\treturn \"%s\"\n" % value
+
+
+func _write_reload_helper(value: String, path: String = RELOAD_HELPER_PATH) -> void:
+	var file := FileAccess.open(path, FileAccess.WRITE)
+	assert_true(file != null, "helper fixture must be writable")
+	file.store_string(_reload_helper_source(value))
+	file.close()
+
+
+func test_patch_script_refreshes_loaded_gdscript() -> void:
+	## Regression for #937: a loaded GDScript kept the old body after a patch.
+	_write_reload_helper("old")
+	var loaded: GDScript = ResourceLoader.load(RELOAD_HELPER_PATH)
+	assert_true(loaded != null, "fixture must load")
+	assert_eq(loaded.new().value(), "old")
+	var result := _handler.patch_script({
+		"path": RELOAD_HELPER_PATH, "old_text": "\"old\"", "new_text": "\"new\"",
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.replacements, 1)
+	assert_eq(result.data.reloaded, true)
+	assert_false(result.data.has("reload_reason"), "a reloaded script carries no skip reason")
+	# The SAME object an agent (or a node) already holds now runs the new code.
+	assert_eq(loaded.new().value(), "new")
+	assert_eq(ResourceLoader.load(RELOAD_HELPER_PATH).new().value(), "new")
+	DirAccess.remove_absolute(RELOAD_HELPER_PATH)
+
+
+func test_create_script_overwrite_refreshes_loaded_gdscript() -> void:
+	_write_reload_helper("old", RELOAD_OVERWRITE_PATH)
+	var loaded: GDScript = ResourceLoader.load(RELOAD_OVERWRITE_PATH)
+	assert_eq(loaded.new().value(), "old")
+	var result := _handler.create_script({
+		"path": RELOAD_OVERWRITE_PATH, "content": _reload_helper_source("newer"),
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.import_settle, "already_known")
+	assert_eq(result.data.reloaded, true)
+	assert_eq(loaded.new().value(), "newer")
+	DirAccess.remove_absolute(RELOAD_OVERWRITE_PATH)
+
+
+func test_patch_script_reports_not_loaded_when_nothing_cached() -> void:
+	## A script nobody has loaded has nothing to refresh; say so explicitly.
+	var path := "res://tests/_mcp_test_reload_cold.gd"
+	var file := FileAccess.open(path, FileAccess.WRITE)
+	file.store_string(_reload_helper_source("old"))
+	file.close()
+	assert_false(ResourceLoader.has_cached(path), "fixture must start uncached")
+	var result := _handler.patch_script({"path": path, "old_text": "\"old\"", "new_text": "\"new\""})
+	assert_has_key(result, "data")
+	assert_eq(result.data.reloaded, false)
+	assert_eq(result.data.reload_reason, "not_loaded")
+	DirAccess.remove_absolute(path)
+
+
+func test_patch_script_skips_reload_on_parse_error() -> void:
+	## A broken patch reports reload_reason=parse_error instead of claiming the
+	## loaded code changed. (The handler's diagnostics capture reloads the shared
+	## cache entry with the broken source, so the live object is already in an
+	## error state here — the point is the honest signal, not preservation.)
+	_write_reload_helper("old", RELOAD_PARSE_PATH)
+	var loaded: GDScript = ResourceLoader.load(RELOAD_PARSE_PATH)
+	assert_eq(loaded.new().value(), "old")
+	# Godot 4.7 surfaces the parse diagnostic through several logger copies.
+	for _i in 4:
+		expect_script_error_containing(RELOAD_RETURN_PARSE_ERROR)
+	var result := _handler.patch_script({
+		"path": RELOAD_PARSE_PATH, "old_text": "return \"old\"", "new_text": "return if",
+	})
+	assert_has_key(result, "data")
+	assert_eq(result.data.reloaded, false)
+	assert_eq(result.data.reload_reason, "parse_error")
+	assert_eq(result.data.diagnostics_status, "checked")
+	assert_true(result.data.diagnostics.size() >= 1, "the parse error is reported as a diagnostic")
+	DirAccess.remove_absolute(RELOAD_PARSE_PATH)


### PR DESCRIPTION
## Summary

Fixes #937. After `script_create` (overwrite) or `script_patch` writes a `.gd` file, an already-loaded `GDScript` for that path kept executing the previous source: `EditorFileSystem.update_file()` registers the bytes but never touches the ResourceLoader/GDScriptCache entry. An agent saw a successful write and then ran stale code.

- `script_handler.gd`: new `_refresh_loaded_gdscript()` runs after the write in both paths. If the path is cached and the new source validated, it pushes `source_code` into the live object and `reload(true)` (keep_state, so existing instances survive). The response now carries `reloaded: true|false`, and when false a `reload_reason` (`not_loaded`, `parse_error`, `not_gdscript`, `reload_failed`, or `already_current` with `reloaded: true`) — so "patch succeeded" means the *loaded code* changed, not just the file.
- `tools/script.py`: `script_patch` docstring documents the contract.
- `test_script.gd`: four regressions — patch refreshes a loaded script (same object an agent already holds now returns the new body), overwrite refreshes, uncached path reports `not_loaded`, broken patch reports `parse_error`.

Reproduced first on Godot 4.7.2, headless and in-editor: after write + `update_file`, both the loaded object and a fresh default-cache load returned the old body; `source_code` + `reload(true)` returned the new one. Details on #937.

One thing the tests surfaced: on a *failed* parse, the existing diagnostics capture (`ResourceLoader.load(path, "", CACHE_MODE_IGNORE)`) already reloads the shared GDScriptCache entry with the broken source, so the live object is in an error state before this helper runs. The helper therefore does nothing extra there and reports `parse_error` honestly; it does not claim to preserve the last good compile.

## Verification (Windows 11, Godot 4.7.2, this branch)

- `ruff check src/ tests/ script/` clean
- `pytest tests/unit` on the pre-rebase base (18bcb11): 1833 passed, 48 skipped, 1 failed — the failure was the pre-existing Windows symlink-privilege case in `test_build_refuses_linked_plugin_content`, which main reworked in 6c8422f; on the rebased branch that test: 1 passed in 6.27s
- Live GDScript `script` suite over MCP on 4.7.2: **52 passed, 0 failed** (includes the 4 new tests)
- Full live GDScript suite on 4.7.2 (71 suites): **2119 passed, 0 failed, 37 skipped**

## Notes

Developed against the v4 branch and rebased onto `main` after #943 merged (c6ba797); the script write path is identical on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Script creation and patching now refresh already-loaded GDScript resources after successful writes.
  * Updated scripts can run immediately without requiring a manual reload.
  * Responses indicate whether a script was reloaded and provide a reason when it was not.

* **Bug Fixes**
  * Invalid script changes are no longer applied when parsing fails.
  * Added clear diagnostics for scripts that are not loaded, unavailable, non-GDScript, or cannot be reloaded.

* **Documentation**
  * Documented script refresh behavior and response details for successful patches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->