### PR TITLE
fix(windows): never delete a real plugin copy when repairing the test_project junction

### DIFF
--- a/script/_plugin_junction.ps1
+++ b/script/_plugin_junction.ps1
@@ -1,0 +1,128 @@
+﻿# Ensure test_project\addons\godot_ai is a directory junction to this
+# checkout's plugin\addons\godot_ai - the one Windows implementation shared by
+# script\setup-dev.ps1 (invoked as a script) and script\verify-worktree
+# (invoked from Git Bash).
+#
+# Policy (#935):
+#   * Only a verified reparse point (junction/symlink) is ever removed, and only
+#     with `cmd /c rmdir`, which drops the pointer without recursing into the
+#     target.
+#   * A real directory (or file) at the link path is NEVER deleted. It is moved
+#     to `<link>.stale.<timestamp>` with a warning - it may hold uncommitted
+#     plugin edits from a manual copy or a botched checkout.
+#   * A junction is accepted only when its target resolves to the expected
+#     plugin directory; a stale or dangling junction is repaired.
+#
+# Exit codes: 0 = link OK (already valid, created, or repaired); 2 = could not
+# create the junction; 3 = -CheckOnly and the link is missing/wrong.
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)] [string] $LinkPath,
+    [Parameter(Mandatory = $true)] [string] $TargetPath,
+    [switch] $CheckOnly
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Convert-ToComparablePath([string] $Path) {
+    if ([string]::IsNullOrWhiteSpace($Path)) { return '' }
+    $p = $Path
+    if ($p.StartsWith('\\?\')) { $p = $p.Substring(4) }
+    $p = $p.Replace('/', '\')
+    try { $p = [System.IO.Path]::GetFullPath($p) } catch { }
+    return $p.TrimEnd('\').ToLowerInvariant()
+}
+
+function Get-ReparseInfo([string] $Path) {
+    # Returns @{ IsReparse = bool; Target = string } for an existing path.
+    $info = @{ IsReparse = $false; Target = '' }
+    $item = Get-Item -LiteralPath $Path -Force
+    $flag = [int][System.IO.FileAttributes]::ReparsePoint
+    if (([int]$item.Attributes -band $flag) -ne 0) {
+        $info.IsReparse = $true
+        $t = $null
+        try { $t = $item.Target } catch { $t = $null }
+        if ($t -is [System.Array]) {
+            if ($t.Length -gt 0) { $t = $t[0] } else { $t = '' }
+        }
+        if ($null -eq $t) { $t = '' }
+        $info.Target = [string] $t
+    }
+    return $info
+}
+
+function Remove-ReparsePointOnly([string] $Path) {
+    # rmdir on a junction removes the pointer only (no recursion into target).
+    & cmd /c rmdir $Path.Replace('/', '\')
+    if (Test-Path -LiteralPath $Path) {
+        throw "could not remove reparse point at $Path"
+    }
+}
+
+function New-PluginJunction([string] $Link, [string] $Target) {
+    $parent = Split-Path -Parent $Link
+    if (-not (Test-Path -LiteralPath $parent)) {
+        New-Item -ItemType Directory -Path $parent -Force | Out-Null
+    }
+    & cmd /c mklink /J $Link.Replace('/', '\') $Target.Replace('/', '\') | Out-Null
+    if ($LASTEXITCODE -ne 0) { return $false }
+    $made = Get-ReparseInfo $Link
+    if (-not $made.IsReparse) { return $false }
+    return ((Convert-ToComparablePath $made.Target) -eq (Convert-ToComparablePath $Target))
+}
+
+function Move-AsideStale([string] $Path) {
+    $stamp = Get-Date -Format 'yyyyMMddHHmmss'
+    $stale = "$Path.stale.$stamp"
+    $n = 0
+    while (Test-Path -LiteralPath $stale) { $n++; $stale = "$Path.stale.$stamp.$n" }
+    Move-Item -LiteralPath $Path -Destination $stale
+    return $stale
+}
+
+$expected = Convert-ToComparablePath $TargetPath
+
+if (-not (Test-Path -LiteralPath $TargetPath -PathType Container)) {
+    Write-Host "[FAIL] plugin target does not exist: $TargetPath" -ForegroundColor Red
+    exit 2
+}
+
+$linkExists = Test-Path -LiteralPath $LinkPath
+
+if (-not $linkExists) {
+    if ($CheckOnly) {
+        Write-Host "[warn] $LinkPath is missing" -ForegroundColor Yellow
+        exit 3
+    }
+} else {
+    $info = Get-ReparseInfo $LinkPath
+    if ($info.IsReparse) {
+        if ((Convert-ToComparablePath $info.Target) -eq $expected) {
+            Write-Host "[ok] $LinkPath -> $TargetPath (junction)"
+            exit 0
+        }
+        if ($CheckOnly) {
+            Write-Host "[warn] $LinkPath is a junction to '$($info.Target)', expected '$TargetPath'" -ForegroundColor Yellow
+            exit 3
+        }
+        Write-Host "[warn] $LinkPath pointed at '$($info.Target)' - repairing to $TargetPath" -ForegroundColor Yellow
+        Remove-ReparsePointOnly $LinkPath
+    } else {
+        if ($CheckOnly) {
+            Write-Host "[warn] $LinkPath is a real directory/file, not a junction" -ForegroundColor Yellow
+            exit 3
+        }
+        $stale = Move-AsideStale $LinkPath
+        Write-Host "[warn] $LinkPath was a real directory, not a junction - moved to $stale (delete it once you have confirmed nothing in it matters)." -ForegroundColor Yellow
+    }
+}
+
+if (New-PluginJunction $LinkPath $TargetPath) {
+    Write-Host "[ok] Created $LinkPath as a directory junction -> $TargetPath"
+    exit 0
+}
+
+Write-Host "[FAIL] Could not create junction $LinkPath -> $TargetPath" -ForegroundColor Red
+exit 2

--- a/script/setup-dev.ps1
+++ b/script/setup-dev.ps1
@@ -60,31 +60,12 @@ if (-not (Test-Path -LiteralPath $addonsDir)) {
 $linkPath = Join-Path $addonsDir 'godot_ai'
 $targetPath = Join-Path $repoRoot 'plugin\addons\godot_ai'
 
-# If something already exists at the link path (stale junction, leftover
-# text file from an old clone, or a copy), remove it so we can build fresh.
-if (Test-Path -LiteralPath $linkPath) {
-    $existing = Get-Item -LiteralPath $linkPath -Force
-    $isReparse = ($existing.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0
-    if ($isReparse) {
-        # Use cmd /c rmdir so Windows treats the junction as a pointer and
-        # does NOT recurse into the target directory — avoids the Windows
-        # junction-deletion data-loss footgun that motivated #185.
-        & cmd /c rmdir (($linkPath) -replace '/', '\')
-    } else {
-        Remove-Item -LiteralPath $linkPath -Force -Recurse
-    }
-}
-
-& cmd /c mklink /J (($linkPath) -replace '/', '\') (($targetPath) -replace '/', '\') | Out-Null
-if ($LASTEXITCODE -ne 0) { throw "mklink /J failed for $linkPath -> $targetPath" }
-
-$item = Get-Item -LiteralPath $linkPath -Force
-$isSymlinkOrJunction = ($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0
-if ($isSymlinkOrJunction -and (Test-Path -LiteralPath (Join-Path $linkPath 'plugin.gd'))) {
-    Write-Host "[ok] test_project\addons\godot_ai -> plugin\addons\godot_ai (junction)"
-} else {
-    throw "test_project\addons\godot_ai did not materialize as a working junction."
-}
+# One shared implementation with script/verify-worktree (#935): a verified
+# junction is accepted or repaired (pointer removed with rmdir, never recursed
+# into); a REAL directory at the link path is moved to a timestamped .stale.*
+# sibling instead of deleted, because it may hold uncommitted plugin edits.
+& (Join-Path $PSScriptRoot '_plugin_junction.ps1') -LinkPath $linkPath -TargetPath $targetPath
+if ($LASTEXITCODE -ne 0) { throw "could not establish test_project\addons\godot_ai junction (exit $LASTEXITCODE)" }
 
 # --- 3. Python venv via uv ------------------------------------------------
 $uv = Get-Command uv -ErrorAction SilentlyContinue

--- a/script/verify-worktree
+++ b/script/verify-worktree
@@ -48,6 +48,19 @@ case "${OS:-}${OSTYPE:-}" in
     *Windows_NT*|*msys*|*cygwin*) is_windows=1 ;;
 esac
 
+# Windows only: shared junction policy (accept/repair/move-aside) — see
+# script/_plugin_junction.ps1. Paths are converted to Windows form because
+# PowerShell resolves them; MSYS path conversion is left on since no argument
+# begins with a slash.
+_junction_ps() {
+    local link_win target_win
+    link_win="$(cygpath -w "$repo_root/$link" 2>/dev/null || echo "$repo_root\\test_project\\addons\\godot_ai")"
+    target_win="$(cygpath -w "$expected_target_abs" 2>/dev/null || echo "$expected_target_abs")"
+    powershell.exe -NoProfile -ExecutionPolicy Bypass \
+        -File "$(cygpath -w "$repo_root/script/_plugin_junction.ps1" 2>/dev/null || echo "$repo_root/script/_plugin_junction.ps1")" \
+        -LinkPath "$link_win" -TargetPath "$target_win" "$@"
+}
+
 link_ok=0
 if [ -L "$link" ]; then
     # POSIX symlink — resolve and compare
@@ -55,13 +68,13 @@ if [ -L "$link" ]; then
     if [ "$resolved" = "$expected_target_abs" ]; then
         link_ok=1
     fi
-elif [ "$is_windows" = "1" ] && [ -d "$link" ]; then
-    # On Windows, directory junctions appear as plain directories to bash and
-    # can't be told apart from real dirs the way `-L` distinguishes symlinks.
-    # Accept a junction-shaped dir via plugin.gd presence. (Not reachable on
-    # macOS/Linux: there, a real dir here is a stale copy and falls through to
-    # the rm -rf + recreate path below.)
-    if [ -f "$link/plugin.gd" ]; then
+elif [ "$is_windows" = "1" ]; then
+    # On Windows, directory junctions appear as plain directories to bash, so
+    # `-L`/`-d` cannot tell a junction from a stale real copy. Ask PowerShell,
+    # which reads the reparse target and compares it to this worktree's
+    # plugin/ (#935). A real directory here is a stale copy holding possibly
+    # uncommitted edits and must never be accepted — nor deleted (see below).
+    if _junction_ps -CheckOnly >/dev/null 2>&1; then
         link_ok=1
     fi
 fi
@@ -76,22 +89,17 @@ mkdir -p "$(dirname "$link")"
 
 case "${OS:-}${OSTYPE:-}" in
     *Windows_NT*|*msys*|*cygwin*)
-        # Remove whatever's there (text file, empty dir, broken link)
-        rm -rf "$link" 2>/dev/null || true
-        # cmd.exe mklink /J doesn't need admin or Developer Mode.
-        # IMPORTANT: mklink /J resolves a RELATIVE target against cmd.exe's
-        # cwd, not the link's parent dir. Use absolute paths to avoid that
-        # footgun. Junctions store the absolute target anyway.
-        link_win="$(cygpath -w "$repo_root/test_project/addons/godot_ai" 2>/dev/null || echo "$repo_root\\test_project\\addons\\godot_ai")"
-        target_win="$(cygpath -w "$expected_target_abs" 2>/dev/null || echo "$expected_target_abs")"
-        # MSYS_NO_PATHCONV=1 prevents git-bash from rewriting /J and /C as paths.
-        if MSYS_NO_PATHCONV=1 cmd.exe /C mklink /J "$link_win" "$target_win" >/dev/null 2>&1; then
-            green "[ok] Created $link as a directory junction."
+        # Delegate to the shared policy (#935): a wrong/dangling junction is
+        # removed with rmdir (pointer only) and recreated; a REAL directory is
+        # moved to test_project/addons/godot_ai.stale.<timestamp> — never
+        # rm -rf'd — because it may hold uncommitted plugin edits. mklink /J
+        # needs no admin rights or Developer Mode.
+        if _junction_ps; then
+            green "[ok] $link -> plugin/addons/godot_ai (junction verified)"
             exit 0
         else
-            red "[FAIL] Could not create junction. Run manually from PowerShell:"
-            echo "       Remove-Item -LiteralPath test_project\\addons\\godot_ai -Force -ErrorAction SilentlyContinue"
-            echo "       New-Item -ItemType Junction -Path test_project\\addons\\godot_ai -Target ..\\..\\plugin\\addons\\godot_ai"
+            red "[FAIL] Could not establish the junction. Run manually from PowerShell:"
+            echo "       .\\script\\_plugin_junction.ps1 -LinkPath test_project\\addons\\godot_ai -TargetPath plugin\\addons\\godot_ai"
             exit 2
         fi
         ;;

--- a/tests/unit/test_plugin_junction_windows.py
+++ b/tests/unit/test_plugin_junction_windows.py
@@ -1,0 +1,258 @@
+"""Windows regression tests for the test_project plugin junction policy (#935).
+
+``script/_plugin_junction.ps1`` is the single Windows implementation behind
+``script/setup-dev.ps1`` and the Windows branch of ``script/verify-worktree``.
+The data-loss rule it enforces: a *real* directory at the link path is never
+deleted (it may hold uncommitted plugin edits) — it is moved to a timestamped
+``.stale.*`` sibling — and only a verified reparse point is removed, via
+``rmdir`` so the target is never recursed into.
+
+Driven against a throwaway sandbox (copies of the scripts plus a minimal
+``plugin/`` tree) so the real worktree link is never touched. Junctions need no
+admin rights or Developer Mode, so these run on any Windows checkout.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+JUNCTION_SCRIPT = REPO_ROOT / "script" / "_plugin_junction.ps1"
+VERIFY_SCRIPT = REPO_ROOT / "script" / "verify-worktree"
+
+pytestmark = pytest.mark.skipif(os.name != "nt", reason="Windows junction policy")
+
+CANONICAL = "# canonical plugin source\n"
+
+
+def _make_sandbox(tmp_path: Path) -> Path:
+    root = tmp_path / "sandbox"
+    (root / "script").mkdir(parents=True)
+    plugin = root / "plugin" / "addons" / "godot_ai"
+    plugin.mkdir(parents=True)
+    (plugin / "plugin.gd").write_text(CANONICAL, encoding="utf-8")
+    (root / "test_project" / "addons").mkdir(parents=True)
+    shutil.copy2(JUNCTION_SCRIPT, root / "script" / "_plugin_junction.ps1")
+    shutil.copy2(VERIFY_SCRIPT, root / "script" / "verify-worktree")
+    return root
+
+
+def _link(root: Path) -> Path:
+    return root / "test_project" / "addons" / "godot_ai"
+
+
+def _target(root: Path) -> Path:
+    return root / "plugin" / "addons" / "godot_ai"
+
+
+def _mklink(link: Path, target: Path) -> None:
+    subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(link), str(target)],
+        check=True,
+        capture_output=True,
+    )
+
+
+def _is_reparse(path: Path) -> bool:
+    return bool(os.lstat(path).st_file_attributes & 0x400)  # FILE_ATTRIBUTE_REPARSE_POINT
+
+
+def _run_ps(root: Path, *extra: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [
+            "powershell.exe",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(root / "script" / "_plugin_junction.ps1"),
+            "-LinkPath",
+            str(_link(root)),
+            "-TargetPath",
+            str(_target(root)),
+            *extra,
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _git_bash() -> str:
+    """Git Bash, not the WSL launcher that Windows also installs as bash.exe."""
+    candidates = []
+    git = shutil.which("git")
+    if git:
+        candidates.append(Path(git).resolve().parent.parent / "bin" / "bash.exe")
+    for env in ("ProgramFiles", "ProgramFiles(x86)", "LocalAppData"):
+        base = os.environ.get(env)
+        if base:
+            candidates.append(Path(base) / "Git" / "bin" / "bash.exe")
+            candidates.append(Path(base) / "Programs" / "Git" / "bin" / "bash.exe")
+    for candidate in candidates:
+        if candidate.is_file():
+            return str(candidate)
+    pytest.skip("Git Bash not found; the verify-worktree entrypoint needs it")
+
+
+def _run_verify(root: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [_git_bash(), str(root / "script" / "verify-worktree")],
+        capture_output=True,
+        text=True,
+        cwd=root,
+    )
+
+
+def _stale_dirs(root: Path) -> list[Path]:
+    return sorted((root / "test_project" / "addons").glob("godot_ai.stale.*"))
+
+
+def _assert_healthy(root: Path) -> None:
+    link = _link(root)
+    assert link.is_dir()
+    assert _is_reparse(link), "link must be a junction"
+    assert (link / "plugin.gd").read_text(encoding="utf-8") == CANONICAL
+
+
+def test_correct_junction_is_accepted_untouched(tmp_path: Path) -> None:
+    root = _make_sandbox(tmp_path)
+    _mklink(_link(root), _target(root))
+    before = os.lstat(_link(root)).st_ctime_ns
+
+    result = _run_ps(root)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "[ok]" in result.stdout
+    assert os.lstat(_link(root)).st_ctime_ns == before, "healthy junction must not be recreated"
+    assert _stale_dirs(root) == []
+    _assert_healthy(root)
+
+
+def test_wrong_target_junction_is_repaired_without_touching_other_dir(tmp_path: Path) -> None:
+    root = _make_sandbox(tmp_path)
+    elsewhere = root / "elsewhere"
+    elsewhere.mkdir()
+    (elsewhere / "keep.txt").write_text("precious\n", encoding="utf-8")
+    _mklink(_link(root), elsewhere)
+
+    result = _run_ps(root)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    _assert_healthy(root)
+    assert (elsewhere / "keep.txt").read_text(encoding="utf-8") == "precious\n"
+    assert _stale_dirs(root) == [], "a junction is removed, never moved aside"
+
+
+def test_real_dir_with_edits_is_moved_aside_not_deleted(tmp_path: Path) -> None:
+    root = _make_sandbox(tmp_path)
+    link = _link(root)
+    link.mkdir()
+    (link / "plugin.gd").write_text("# OUTDATED copy with uncommitted work\n", encoding="utf-8")
+    (link / "handlers").mkdir()
+    (link / "handlers" / "mine.gd").write_text("# my edits\n", encoding="utf-8")
+
+    result = _run_ps(root)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "moved to" in result.stdout
+    _assert_healthy(root)
+    stale = _stale_dirs(root)
+    assert len(stale) == 1
+    assert (stale[0] / "handlers" / "mine.gd").read_text(encoding="utf-8") == "# my edits\n"
+
+
+def test_real_dir_without_plugin_gd_is_moved_aside(tmp_path: Path) -> None:
+    root = _make_sandbox(tmp_path)
+    link = _link(root)
+    link.mkdir()
+    (link / "notes.txt").write_text("not a plugin, still not yours to delete\n", encoding="utf-8")
+
+    result = _run_ps(root)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    _assert_healthy(root)
+    stale = _stale_dirs(root)
+    assert len(stale) == 1
+    assert (stale[0] / "notes.txt").exists()
+
+
+def test_dangling_junction_is_repaired(tmp_path: Path) -> None:
+    root = _make_sandbox(tmp_path)
+    gone = root / "gone"
+    gone.mkdir()
+    _mklink(_link(root), gone)
+    gone.rmdir()
+
+    result = _run_ps(root)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    _assert_healthy(root)
+    assert _stale_dirs(root) == []
+
+
+def test_missing_link_is_created(tmp_path: Path) -> None:
+    root = _make_sandbox(tmp_path)
+
+    result = _run_ps(root)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    _assert_healthy(root)
+
+
+def test_check_only_reports_without_mutating(tmp_path: Path) -> None:
+    root = _make_sandbox(tmp_path)
+    link = _link(root)
+    link.mkdir()
+    (link / "plugin.gd").write_text("# OUTDATED\n", encoding="utf-8")
+
+    result = _run_ps(root, "-CheckOnly")
+
+    assert result.returncode == 3
+    assert not _is_reparse(link)
+    assert (link / "plugin.gd").read_text(encoding="utf-8") == "# OUTDATED\n"
+    assert _stale_dirs(root) == []
+
+
+def test_verify_worktree_delegates_real_dir_to_move_aside(tmp_path: Path) -> None:
+    """The bash entrypoint must reach the same policy: no rm -rf of a real dir."""
+    root = _make_sandbox(tmp_path)
+    link = _link(root)
+    link.mkdir()
+    (link / "plugin.gd").write_text("# OUTDATED stale copy\n", encoding="utf-8")
+
+    result = _run_verify(root)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    _assert_healthy(root)
+    assert len(_stale_dirs(root)) == 1
+
+
+def test_verify_worktree_rejects_real_dir_that_merely_has_plugin_gd(tmp_path: Path) -> None:
+    """Regression: plugin.gd presence alone used to pass as 'junction-shaped'."""
+    root = _make_sandbox(tmp_path)
+    link = _link(root)
+    link.mkdir()
+    (link / "plugin.gd").write_text("# OUTDATED\n", encoding="utf-8")
+
+    result = _run_verify(root)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert _is_reparse(link), "a real dir must be replaced by a junction, not accepted"
+    assert (link / "plugin.gd").read_text(encoding="utf-8") == CANONICAL
+
+
+def test_verify_worktree_accepts_correct_junction(tmp_path: Path) -> None:
+    root = _make_sandbox(tmp_path)
+    _mklink(_link(root), _target(root))
+
+    result = _run_verify(root)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "[ok]" in result.stdout
+    _assert_healthy(root)
+    assert _stale_dirs(root) == []


### PR DESCRIPTION
## Summary

Fixes #935. On Windows, `script/setup-dev.ps1` deleted any non-junction at `test_project/addons/godot_ai` with `Remove-Item -Recurse`, and the Windows branch of `script/verify-worktree` accepted any directory containing `plugin.gd` as "junction-shaped" (never checking the target) and `rm -rf`'d the rest. A manually copied plugin tree with uncommitted edits could be destroyed by the documented setup command, or silently left active by the checkout hook.

One implementation now backs both entrypoints, `script/_plugin_junction.ps1`:

- reads the reparse target and accepts the link **only** when it resolves to this checkout's `plugin/addons/godot_ai`;
- removes a wrong or dangling junction with `cmd /c rmdir` (pointer only — never recurses into the target) and recreates it;
- **never deletes a real directory or file**: it is moved to `test_project/addons/godot_ai.stale.<timestamp>` with a warning, matching the POSIX branch's existing policy;
- `-CheckOnly` reports without mutating (exit 3 when the link is missing or wrong), which `verify-worktree` uses for its Windows acceptance test instead of the `plugin.gd` heuristic.

`setup-dev.ps1` calls the helper for its whole link step; `verify-worktree`'s Windows branch delegates both the check and the repair to it. The POSIX branch is unchanged.

## Tests

`tests/unit/test_plugin_junction_windows.py` (Windows-only; junctions need no admin/Developer Mode): correct junction accepted untouched · wrong-target junction repaired without touching the other directory · real dir with edits moved aside with contents intact · real dir without `plugin.gd` moved aside · dangling junction repaired · missing link created · `-CheckOnly` non-mutating · and three end-to-end `verify-worktree` runs under Git Bash (real dir moved aside; real dir with `plugin.gd` no longer accepted; correct junction accepted). The existing POSIX test file is untouched.

## Verification (Windows 11, main at c6ba797)

- new tests: **10 passed**
- `ruff check src/ tests/ script/` clean; `ruff format --check` clean on the new file
- `pytest tests/unit`: 1851 passed, 43 skipped, 1 warning in 190.36s (0:03:10)
- Real worktree: `bash script/verify-worktree` → `[ok]` via the new PowerShell check; `.\script\setup-dev.ps1` → junction re-verified, no `.stale.*` created, target confirmed with `(Get-Item).Target`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable Windows plugin junction setup and validation.
  * Missing or incorrect junctions are created or repaired automatically.
  * Existing directories at the junction location are preserved by moving them aside instead of deleting them.
  * Added check-only validation to report issues without making changes.

* **Bug Fixes**
  * Improved detection of dangling, incorrect, and non-junction plugin paths.
  * Standardized junction handling across development setup and worktree verification.

* **Tests**
  * Added Windows regression coverage for junction creation, repair, validation, and preservation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->