### PR TITLE
feat(game): expose native suspend/resume and frame stepping

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -258,6 +258,13 @@ network round-trip happens to complete on, so the timing drifts and the run
 isn't reproducible. The game applies each step's action on its scheduled frame,
 awaits `settle_frames` more, then replies once.
 
+`game_manage(op="suspend"|"resume"|"next_frame")` uses Godot's native debugger
+control path. Successful mutations report `path="embed_signal"` when Embedded
+Game View accepted the shortcut, or `path="direct_session"` when the plugin
+sent the native scene debugger message directly. The direct fallback works for
+standalone/non-embedded runs, but `game_view_ui_synced=false` warns that the
+Game View suspend button's visual pressed state was not updated.
+
 Each step is `{at_frame, action, pressed=True, strength=1.0}`. Steps must be
 ordered by non-decreasing `at_frame`; two steps sharing a frame is a valid
 combo. Frames (not milliseconds) are the timing basis — that's what reproduces

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -208,7 +208,7 @@ Calls take the form:
 | `camera_manage` | `create`, `configure`, `set_limits_2d`, `set_damping_2d`, `follow_2d`, `get`, `list`, `apply_preset` |
 | `signal_manage` | `list`, `connect`, `disconnect` |
 | `input_map_manage` | `list`, `add_action`, `ensure_action`, `remove_action`, `bind_event`, `ensure_binding` |
-| `game_manage` | `get_scene_tree`, `get_node_info`, `get_ui_elements`, `input_key`, `input_mouse`, `input_gamepad`, `input_action`, `input_sequence`, `input_state` |
+| `game_manage` | `get_scene_tree`, `get_node_info`, `get_ui_elements`, `suspend`, `resume`, `next_frame`, `debug_status`, `input_key`, `input_mouse`, `input_gamepad`, `input_action`, `input_sequence`, `input_state` |
 | `autoload_manage` | `list`, `add`, `remove` |
 | `filesystem_manage` | `read_text`, `write_text`, `reimport`, `scan`, `search` |
 | `theme_manage` | `create`, `set_color`, `set_constant`, `set_font_size`, `set_stylebox_flat`, `apply` |

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -1601,6 +1601,17 @@ static func game_debug_verification(
 	return {"status": "failed", "reason": "unsupported_action", "ticks_advanced": ticks_advanced}
 
 
+func _active_game_debug_mutation() -> Dictionary:
+	for raw_request_id in _pending.keys():
+		var pending_entry: Dictionary = _pending.get(raw_request_id, {})
+		if str(pending_entry.get("kind", "")) != "game_debug_control":
+			continue
+		var active_action := str(pending_entry.get("action", ""))
+		if active_action in ["suspend", "resume", "next_frame"]:
+			return {"request_id": str(raw_request_id), "action": active_action}
+	return {}
+
+
 func request_game_debug_control(
 	action: String,
 	request_id: String,
@@ -1635,6 +1646,20 @@ func _begin_game_debug_control(
 		_send_error_response(connection, request_id,
 			_explain_not_live(get_game_status(-1, GAME_READY_WAIT_SEC), ErrorCodes.INTERNAL_ERROR))
 		return
+	if action != "debug_status":
+		var active_mutation := _active_game_debug_mutation()
+		if not active_mutation.is_empty():
+			var busy := ErrorCodes.make(
+				ErrorCodes.EDITOR_NOT_READY,
+				"Another game runtime-control mutation is already in flight — retry after it completes."
+			)
+			busy["error"]["data"] = {
+				"action": action,
+				"active_action": str(active_mutation.get("action", "")),
+				"retryable": true,
+			}
+			_send_error_response(connection, request_id, busy)
+			return
 	var session := _first_active_session()
 	if session == null:
 		_send_error(connection, request_id, ErrorCodes.INTERNAL_ERROR,
@@ -1655,6 +1680,8 @@ func _begin_game_debug_control(
 				"state_before": pending_entry.get("state_before", {}),
 				"state_after": pending_entry.get("state_after", {}),
 				"focus_handoff": pending_entry.get("focus_handoff", {}),
+				"path": pending_entry.get("path", ""),
+				"game_view_ui_synced": pending_entry.get("game_view_ui_synced", false),
 			}
 			_send_error_response(conn, request_id, err)
 	timer.timeout.connect(timeout_callable)
@@ -1736,11 +1763,16 @@ func _handle_game_debug_before(
 		return
 	if action == "next_frame":
 		focus_handoff = _focus_embedded_game_view()
-	var native_action := "next_frame" if action == "next_frame" else "toggle_suspend"
-	if not _emit_embedded_runtime_action(native_action):
+	var desired_suspended := action == "suspend"
+	var control := _emit_game_debug_runtime_action(action, desired_suspended)
+	if not bool(control.get("ok", false)):
 		var err := ErrorCodes.make(ErrorCodes.INTERNAL_ERROR,
-			"Embedded Game View debugger is unavailable — no connected ScriptEditorDebugger accepted the action")
-		err["error"]["data"] = {"action": action, "focus_handoff": focus_handoff}
+			"No active debugger path accepted the native game runtime action")
+		err["error"]["data"] = {
+			"action": action,
+			"reason": control.get("reason", "runtime_control_unavailable"),
+			"focus_handoff": focus_handoff,
+		}
 		_clear_pending(request_id)
 		if connection != null and is_instance_valid(connection):
 			_send_error_response(connection, request_id, err)
@@ -1748,6 +1780,8 @@ func _handle_game_debug_before(
 	pending_entry["phase"] = "verify"
 	pending_entry["state_before"] = state
 	pending_entry["focus_handoff"] = focus_handoff
+	pending_entry["path"] = str(control.get("path", ""))
+	pending_entry["game_view_ui_synced"] = bool(control.get("game_view_ui_synced", false))
 	_request_game_debug_verify.call_deferred(request_id)
 
 
@@ -1793,6 +1827,8 @@ func _handle_game_debug_verify(
 				"state_before": state_before,
 				"state_after": state_after,
 				"focus_handoff": pending_entry.get("focus_handoff", {}),
+				"path": pending_entry.get("path", ""),
+				"game_view_ui_synced": pending_entry.get("game_view_ui_synced", false),
 			}
 			_clear_pending(request_id)
 			if connection != null and is_instance_valid(connection):
@@ -1805,6 +1841,8 @@ func _handle_game_debug_verify(
 		"state_before": state_before,
 		"state_after": state_after,
 		"focus_handoff": pending_entry.get("focus_handoff", {}),
+		"path": pending_entry.get("path", ""),
+		"game_view_ui_synced": pending_entry.get("game_view_ui_synced", false),
 	}
 	if action == "next_frame":
 		payload["ticks_advanced"] = int(verdict.get("ticks_advanced", -1))
@@ -1836,21 +1874,39 @@ func _focus_embedded_game_view() -> Dictionary:
 	return result
 
 
-func _emit_embedded_runtime_action(action: String) -> bool:
+static func direct_game_debug_message(action: String, desired_suspended: bool) -> Dictionary:
+	match action:
+		"suspend", "resume":
+			return {"message": "scene:suspend_changed", "data": [desired_suspended]}
+		"next_frame":
+			return {"message": "scene:next_frame", "data": []}
+	return {}
+
+
+func _emit_game_debug_runtime_action(action: String, desired_suspended: bool) -> Dictionary:
 	var embed_action := EMBED_NEXT_FRAME if action == "next_frame" else EMBED_SUSPEND_TOGGLE
 	var base := EditorInterface.get_base_control()
-	if base == null:
-		return false
-	var debuggers: Array[Node] = []
-	_collect_nodes_of_class(base, "ScriptEditorDebugger", debuggers)
-	for debugger in debuggers:
-		if not debugger.has_signal("embed_shortcut_requested"):
-			continue
-		if debugger.get_signal_connection_list("embed_shortcut_requested").is_empty():
-			continue
-		debugger.emit_signal("embed_shortcut_requested", embed_action)
-		return true
-	return false
+	if base != null:
+		var debuggers: Array[Node] = []
+		_collect_nodes_of_class(base, "ScriptEditorDebugger", debuggers)
+		for debugger in debuggers:
+			if not debugger.has_signal("embed_shortcut_requested"):
+				continue
+			if debugger.get_signal_connection_list("embed_shortcut_requested").is_empty():
+				continue
+			debugger.emit_signal("embed_shortcut_requested", embed_action)
+			return {"ok": true, "path": "embed_signal", "game_view_ui_synced": true}
+
+	var session := _first_active_session()
+	if session == null or not session.is_active():
+		return {"ok": false, "reason": "no_active_debugger_session"}
+	var direct := direct_game_debug_message(action, desired_suspended)
+	if direct.is_empty():
+		return {"ok": false, "reason": "unsupported_action"}
+	session.send_message(str(direct.message), direct.data as Array)
+	## The direct debugger-session path works without embedding, but bypasses
+	## Game View's suspend button, so its visual pressed state is not synchronized.
+	return {"ok": true, "path": "direct_session", "game_view_ui_synced": false}
 
 
 func _fail_pending_game_debug_controls_not_ready(message: String) -> void:

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -67,6 +67,9 @@ const EVAL_COMPILE_GRACE_SEC := 3.0
 ## ticking, so it drives the poll. 0.35s keeps detection well under a second
 ## without flooding the channel; most evals reply before the first probe.
 const EVAL_PROBE_INTERVAL_SEC := 0.35
+const GAME_DEBUG_CONTROL_TIMEOUT_SEC := 5.0
+const EMBED_SUSPEND_TOGGLE := 0
+const EMBED_NEXT_FRAME := 1
 
 const VisionRoutingScript := preload("res://addons/godot_ai/vision_routing.gd")
 
@@ -232,6 +235,9 @@ func _editor_log_cursor() -> int:
 func end_game_run() -> void:
 	_fail_pending_evals_not_ready(
 		"The game run ended before game_eval completed — the game stopped, crashed, or is restarting. Confirm it is running and retry."
+	)
+	_fail_pending_game_debug_controls_not_ready(
+		"The game run ended before runtime control completed — confirm it is running and retry."
 	)
 	## Never carry a held beacon across a run boundary (#891).
 	_pending_hello_session_id = -1
@@ -846,6 +852,9 @@ func _capture(message: String, data: Array, session_id: int) -> bool:
 			return true
 		"mcp:eval_liveness_response":
 			_on_eval_liveness_response(data)
+			return true
+		"mcp:debug_status_response":
+			_on_debug_status_response(data)
 			return true
 		"mcp:eval_response":
 			_on_eval_response(data)
@@ -1566,6 +1575,281 @@ func _on_eval_probe_tick(request_id: String) -> void:
 	if session != null and session.is_active():
 		session.send_message("mcp:eval_check", [request_id])
 	_arm_eval_probe(request_id)
+
+
+## --- native embedded Game View runtime control (#939) ---
+
+static func game_debug_verification(
+	action: String, state_before: Dictionary, state_after: Dictionary
+) -> Dictionary:
+	var before_ticks := int(state_before.get("process_ticks", -1))
+	var after_ticks := int(state_after.get("process_ticks", -1))
+	var ticks_advanced := after_ticks - before_ticks if before_ticks >= 0 and after_ticks >= 0 else -1
+	match action:
+		"suspend":
+			return {"status": "verified" if bool(state_after.get("suspended", false)) else "pending", "ticks_advanced": ticks_advanced}
+		"resume":
+			return {"status": "verified" if not bool(state_after.get("suspended", true)) else "pending", "ticks_advanced": ticks_advanced}
+		"next_frame":
+			if before_ticks < 0 or after_ticks < 0:
+				return {"status": "failed", "reason": "missing_process_ticks", "ticks_advanced": ticks_advanced}
+			if ticks_advanced > 1:
+				return {"status": "failed", "reason": "multiple_process_ticks", "ticks_advanced": ticks_advanced}
+			if ticks_advanced == 1 and bool(state_after.get("suspended", false)):
+				return {"status": "verified", "ticks_advanced": 1}
+			return {"status": "pending", "ticks_advanced": ticks_advanced}
+	return {"status": "failed", "reason": "unsupported_action", "ticks_advanced": ticks_advanced}
+
+
+func request_game_debug_control(
+	action: String,
+	request_id: String,
+	connection: McpConnection,
+	timeout_sec: float = GAME_DEBUG_CONTROL_TIMEOUT_SEC,
+) -> void:
+	if request_id.is_empty():
+		push_warning("MCP debugger: game debug control missing request_id")
+		return
+	if action not in ["suspend", "resume", "next_frame", "debug_status"]:
+		_send_error(connection, request_id, ErrorCodes.VALUE_OUT_OF_RANGE,
+			"Unsupported game debug action: %s" % action)
+		return
+	var tree := Engine.get_main_loop() as SceneTree
+	if tree == null:
+		_send_error(connection, request_id, ErrorCodes.INTERNAL_ERROR,
+			"Editor main loop is not a SceneTree — cannot schedule game debug control")
+		return
+	if not is_game_capture_ready():
+		_send_error_response(connection, request_id,
+			_explain_not_live(get_game_status(-1, GAME_READY_WAIT_SEC), ErrorCodes.INTERNAL_ERROR))
+		return
+	var session := _first_active_session()
+	if session == null:
+		_send_error(connection, request_id, ErrorCodes.INTERNAL_ERROR,
+			"No active debugger session — is the game actually running?")
+		return
+	var timer := tree.create_timer(timeout_sec)
+	var timeout_callable := func() -> void:
+		var pending_entry: Dictionary = _pending.get(request_id, {})
+		if pending_entry.is_empty():
+			return
+		_pending.erase(request_id)
+		var conn: McpConnection = pending_entry.get("connection")
+		if conn != null and is_instance_valid(conn):
+			var err := ErrorCodes.make(ErrorCodes.INTERNAL_ERROR,
+				"Game debug action '%s' timed out after %.0fs" % [action, timeout_sec])
+			err["error"]["data"] = {
+				"action": action,
+				"state_before": pending_entry.get("state_before", {}),
+				"state_after": pending_entry.get("state_after", {}),
+				"focus_handoff": pending_entry.get("focus_handoff", {}),
+			}
+			_send_error_response(conn, request_id, err)
+	timer.timeout.connect(timeout_callable)
+	_pending[request_id] = {
+		"kind": "game_debug_control",
+		"phase": "before",
+		"action": action,
+		"connection": connection,
+		"timer": timer,
+		"timeout_callable": timeout_callable,
+		"run_token": _game_run_token,
+	}
+	session.send_message("mcp:debug_status", [request_id])
+
+
+func _on_debug_status_response(data: Array) -> void:
+	if data.size() < 2 or not (data[1] is Dictionary):
+		push_warning("MCP debugger: malformed debug_status response")
+		return
+	var request_id := str(data[0])
+	var pending_entry: Dictionary = _pending.get(request_id, {})
+	if str(pending_entry.get("kind", "")) != "game_debug_control":
+		return
+	var connection: McpConnection = pending_entry.get("connection")
+	if not _is_current_game_run(int(pending_entry.get("run_token", -1))):
+		_clear_pending(request_id)
+		if connection != null and is_instance_valid(connection):
+			_send_error(connection, request_id, ErrorCodes.EVAL_GAME_NOT_READY,
+				"The game run changed while runtime control was in flight — retry against the current run.")
+		return
+	var state: Dictionary = (data[1] as Dictionary).duplicate(true)
+	pending_entry["state_after"] = state
+	match str(pending_entry.get("phase", "before")):
+		"before":
+			_handle_game_debug_before(request_id, pending_entry, state)
+		"verify":
+			_handle_game_debug_verify(request_id, pending_entry, state)
+		_:
+			_clear_pending(request_id)
+			if connection != null and is_instance_valid(connection):
+				_send_error(connection, request_id, ErrorCodes.INTERNAL_ERROR,
+					"Invalid game debug control phase")
+
+
+func _default_focus_handoff() -> Dictionary:
+	return {"attempted": false, "main_screen": "", "embedded_process_found": false, "focused": false}
+
+
+func _handle_game_debug_before(
+	request_id: String, pending_entry: Dictionary, state: Dictionary
+) -> void:
+	var action := str(pending_entry.get("action", ""))
+	var connection: McpConnection = pending_entry.get("connection")
+	var focus_handoff := _default_focus_handoff()
+	if action == "debug_status":
+		_clear_pending(request_id)
+		if connection != null and is_instance_valid(connection):
+			connection.send_deferred_response(request_id, {"data": {
+				"action": action, "state": state, "focus_handoff": focus_handoff,
+			}})
+		return
+	var suspended := bool(state.get("suspended", false))
+	if action in ["suspend", "resume"]:
+		var desired := action == "suspend"
+		if suspended == desired:
+			_clear_pending(request_id)
+			if connection != null and is_instance_valid(connection):
+				connection.send_deferred_response(request_id, {"data": {
+					"action": action, "changed": false, "verified": true,
+					"state_before": state, "state_after": state,
+					"focus_handoff": focus_handoff,
+				}})
+			return
+	elif action == "next_frame" and not suspended:
+		_clear_pending(request_id)
+		if connection != null and is_instance_valid(connection):
+			_send_error(connection, request_id, ErrorCodes.INVALID_PARAMS,
+				"next_frame requires a suspended game — call suspend first")
+		return
+	if action == "next_frame":
+		focus_handoff = _focus_embedded_game_view()
+	var native_action := "next_frame" if action == "next_frame" else "toggle_suspend"
+	if not _emit_embedded_runtime_action(native_action):
+		var err := ErrorCodes.make(ErrorCodes.INTERNAL_ERROR,
+			"Embedded Game View debugger is unavailable — no connected ScriptEditorDebugger accepted the action")
+		err["error"]["data"] = {"action": action, "focus_handoff": focus_handoff}
+		_clear_pending(request_id)
+		if connection != null and is_instance_valid(connection):
+			_send_error_response(connection, request_id, err)
+		return
+	pending_entry["phase"] = "verify"
+	pending_entry["state_before"] = state
+	pending_entry["focus_handoff"] = focus_handoff
+	_request_game_debug_verify.call_deferred(request_id)
+
+
+func _request_game_debug_verify(request_id: String) -> void:
+	var tree := Engine.get_main_loop() as SceneTree
+	if tree == null:
+		return
+	await tree.process_frame
+	var pending_entry: Dictionary = _pending.get(request_id, {})
+	if str(pending_entry.get("phase", "")) != "verify":
+		return
+	var session := _first_active_session()
+	if session == null:
+		var connection: McpConnection = pending_entry.get("connection")
+		_clear_pending(request_id)
+		if connection != null and is_instance_valid(connection):
+			_send_error(connection, request_id, ErrorCodes.EVAL_GAME_NOT_READY,
+				"The debugger session ended before runtime control could be verified")
+		return
+	session.send_message("mcp:debug_status", [request_id])
+
+
+func _handle_game_debug_verify(
+	request_id: String, pending_entry: Dictionary, state_after: Dictionary
+) -> void:
+	var action := str(pending_entry.get("action", ""))
+	var connection: McpConnection = pending_entry.get("connection")
+	var state_before: Dictionary = pending_entry.get("state_before", {})
+	var verdict := game_debug_verification(action, state_before, state_after)
+	match str(verdict.get("status", "failed")):
+		"pending":
+			_request_game_debug_verify.call_deferred(request_id)
+			return
+		"verified":
+			pass
+		_:
+			var err := ErrorCodes.make(ErrorCodes.INTERNAL_ERROR,
+				"Game debug action '%s' violated its verification contract" % action)
+			err["error"]["data"] = {
+				"action": action,
+				"reason": verdict.get("reason", "verification_failed"),
+				"ticks_advanced": verdict.get("ticks_advanced", -1),
+				"state_before": state_before,
+				"state_after": state_after,
+				"focus_handoff": pending_entry.get("focus_handoff", {}),
+			}
+			_clear_pending(request_id)
+			if connection != null and is_instance_valid(connection):
+				_send_error_response(connection, request_id, err)
+			return
+	var payload := {
+		"action": action,
+		"changed": true,
+		"verified": true,
+		"state_before": state_before,
+		"state_after": state_after,
+		"focus_handoff": pending_entry.get("focus_handoff", {}),
+	}
+	if action == "next_frame":
+		payload["ticks_advanced"] = int(verdict.get("ticks_advanced", -1))
+	_clear_pending(request_id)
+	if connection != null and is_instance_valid(connection):
+		connection.send_deferred_response(request_id, {"data": payload})
+
+
+func _focus_embedded_game_view() -> Dictionary:
+	var result := {
+		"attempted": true,
+		"main_screen": "Game",
+		"embedded_process_found": false,
+		"focused": false,
+	}
+	EditorInterface.set_main_screen_editor("Game")
+	var base := EditorInterface.get_base_control()
+	if base == null:
+		return result
+	var embedded_nodes: Array[Node] = []
+	_collect_nodes_of_class(base, "EmbeddedProcess", embedded_nodes)
+	for node in embedded_nodes:
+		if node is Control:
+			var embedded := node as Control
+			result["embedded_process_found"] = true
+			embedded.grab_focus()
+			result["focused"] = embedded.has_focus()
+			break
+	return result
+
+
+func _emit_embedded_runtime_action(action: String) -> bool:
+	var embed_action := EMBED_NEXT_FRAME if action == "next_frame" else EMBED_SUSPEND_TOGGLE
+	var base := EditorInterface.get_base_control()
+	if base == null:
+		return false
+	var debuggers: Array[Node] = []
+	_collect_nodes_of_class(base, "ScriptEditorDebugger", debuggers)
+	for debugger in debuggers:
+		if not debugger.has_signal("embed_shortcut_requested"):
+			continue
+		if debugger.get_signal_connection_list("embed_shortcut_requested").is_empty():
+			continue
+		debugger.emit_signal("embed_shortcut_requested", embed_action)
+		return true
+	return false
+
+
+func _fail_pending_game_debug_controls_not_ready(message: String) -> void:
+	for request_id in _pending.keys():
+		var pending_entry: Dictionary = _pending.get(request_id, {})
+		if str(pending_entry.get("kind", "")) != "game_debug_control":
+			continue
+		var connection: McpConnection = pending_entry.get("connection")
+		_clear_pending(str(request_id))
+		if connection != null and is_instance_valid(connection):
+			_send_error(connection, str(request_id), ErrorCodes.EVAL_GAME_NOT_READY, message)
 
 
 ## --- game_command: curated runtime game operations ---

--- a/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
+++ b/plugin/addons/godot_ai/debugger/mcp_debugger_plugin.gd
@@ -1610,6 +1610,18 @@ func request_game_debug_control(
 	if request_id.is_empty():
 		push_warning("MCP debugger: game debug control missing request_id")
 		return
+	## The dispatcher registers the deferred request only after the handler returns.
+	## Start the entire guard/control flow deferred so even fast failures cannot race
+	## that registration and get dropped as an expired response.
+	_begin_game_debug_control.call_deferred(action, request_id, connection, timeout_sec)
+
+
+func _begin_game_debug_control(
+	action: String,
+	request_id: String,
+	connection: McpConnection,
+	timeout_sec: float,
+) -> void:
 	if action not in ["suspend", "resume", "next_frame", "debug_status"]:
 		_send_error(connection, request_id, ErrorCodes.VALUE_OUT_OF_RANGE,
 			"Unsupported game debug action: %s" % action)

--- a/plugin/addons/godot_ai/dispatcher.gd
+++ b/plugin/addons/godot_ai/dispatcher.gd
@@ -43,6 +43,9 @@ const DEFERRED_TIMEOUT_MS_BY_COMMAND := {
 	"check_client_status": 30000,
 	"game_eval": 15000,
 	"game_command": 15000,
+	## The editor-side runtime-control timer owns 5s; keep the dispatcher
+	## outside it so the actionable control result wins before DEFERRED_TIMEOUT.
+	"game_debug_control": 6500,
 	"scan_filesystem": 30000,
 }
 const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")

--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -1027,7 +1027,7 @@ func game_debug_control(params: Dictionary) -> Dictionary:
 	var request_id := str(params.get("_request_id", ""))
 	if request_id.is_empty():
 		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR,
-			"Missing request_id — cannot correlate deferred response")
+			"Missing internal _request_id — cannot correlate deferred response")
 	_debugger_plugin.request_game_debug_control(action, request_id, _connection)
 	return McpDispatcher.DEFERRED_RESPONSE
 

--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -1009,6 +1009,29 @@ func game_eval(params: Dictionary) -> Dictionary:
 	return McpDispatcher.DEFERRED_RESPONSE
 
 
+func game_debug_control(params: Dictionary) -> Dictionary:
+	var action := str(params.get("action", ""))
+	if action not in ["suspend", "resume", "next_frame", "debug_status"]:
+		return ErrorCodes.make(
+			ErrorCodes.VALUE_OUT_OF_RANGE,
+			"Invalid game debug action '%s' — use suspend, resume, next_frame, or debug_status" % action,
+		)
+	if _debugger_plugin == null or _connection == null:
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR,
+			"Debugger bridge unavailable — plugin may not be fully initialised")
+	if not EditorInterface.is_playing_scene():
+		return ErrorCodes.make_not_ready(
+			ErrorCodes.SUB_EDITOR_GAME_NOT_RUNNING,
+			"Game is not running — start the project first", false,
+			"Start the game with project_run (or wait for the user to run it), then retry.")
+	var request_id := str(params.get("_request_id", ""))
+	if request_id.is_empty():
+		return ErrorCodes.make(ErrorCodes.INTERNAL_ERROR,
+			"Missing request_id — cannot correlate deferred response")
+	_debugger_plugin.request_game_debug_control(action, request_id, _connection)
+	return McpDispatcher.DEFERRED_RESPONSE
+
+
 func game_command(params: Dictionary) -> Dictionary:
 	var op: String = str(params.get("op", ""))
 	if op.is_empty():

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -377,6 +377,7 @@ func _continue_enter_tree_after_update_barrier() -> void:
 	_dispatcher.register_lazy("quit_editor", "editor", &"quit_editor")
 	_dispatcher.register_lazy("game_eval", "editor", &"game_eval")
 	_dispatcher.register_lazy("game_command", "editor", &"game_command")
+	_dispatcher.register_lazy("game_debug_control", "editor", &"game_debug_control")
 	_dispatcher.register_lazy("get_project_setting", "project", &"get_project_setting")
 	_dispatcher.register_lazy("set_project_setting", "project", &"set_project_setting")
 	_dispatcher.register_lazy("set_main_scene", "project", &"set_main_scene")

--- a/plugin/addons/godot_ai/runtime/game_helper.gd
+++ b/plugin/addons/godot_ai/runtime/game_helper.gd
@@ -218,11 +218,15 @@ func _reply_eval_liveness(data: Array) -> void:
 
 
 func _debug_status_snapshot() -> Dictionary:
-	var tree := get_tree()
+	var inside_tree := is_inside_tree()
+	var tree := get_tree() if inside_tree else null
 	return {
 		"probe_version": 1,
 		"helper_found": true,
-		"suspended": is_zero_approx(Engine.time_scale),
+		## GameHelper is PROCESS_MODE_ALWAYS, so pause does not stop it; native
+		## SceneTree suspension does. This exposes Godot's debugger-owned suspend
+		## bit through Node::can_process() without conflating it with pause/time scale.
+		"suspended": inside_tree and not can_process(),
 		"loop_live": not _main_loop_appears_stalled(),
 		"loop_tick_msec": _last_loop_tick_msec,
 		"process_ticks": _mcp_runtime_process_ticks,

--- a/plugin/addons/godot_ai/runtime/game_helper.gd
+++ b/plugin/addons/godot_ai/runtime/game_helper.gd
@@ -222,7 +222,7 @@ func _debug_status_snapshot() -> Dictionary:
 	return {
 		"probe_version": 1,
 		"helper_found": true,
-		"suspended": not can_process(),
+		"suspended": is_zero_approx(Engine.time_scale),
 		"loop_live": not _main_loop_appears_stalled(),
 		"loop_tick_msec": _last_loop_tick_msec,
 		"process_ticks": _mcp_runtime_process_ticks,

--- a/plugin/addons/godot_ai/runtime/game_helper.gd
+++ b/plugin/addons/godot_ai/runtime/game_helper.gd
@@ -85,6 +85,8 @@ var _eval_token_counter: int = 0
 ## _handle_take_screenshot (running inside that capture) detects the freeze
 ## synchronously. -1 until the first tick.
 var _last_loop_tick_msec: int = -1
+var _mcp_runtime_process_ticks: int = 0
+var _last_debug_status_reply: Dictionary = {}
 ## Rendering-freeze beacon for the Windows-minimize state (#794 smoke, 1b):
 ## the frames_drawn value last observed in _process, and when it last
 ## advanced. -1 until the first observed advance, so a booting or
@@ -135,6 +137,7 @@ func _ready() -> void:
 
 
 func _process(_delta: float) -> void:
+	_mcp_runtime_process_ticks += 1
 	## #777: liveness beacon for _handle_take_screenshot's stalled-loop check.
 	## Recorded before the early returns below so the signal stays truthful
 	## even when the logger or debugger channel is unavailable.
@@ -188,6 +191,9 @@ func _on_debug_message(message: String, data: Array) -> bool:
 		"eval_liveness":
 			_reply_eval_liveness(data)
 			return true
+		"debug_status":
+			_reply_debug_status(data)
+			return true
 		"eval":
 			_handle_eval(data)
 			return true
@@ -209,6 +215,31 @@ func _reply_eval_liveness(data: Array) -> void:
 	_last_eval_liveness_reply = {"request_id": request_id, "loop_live": loop_live}
 	if EngineDebugger.is_active():
 		EngineDebugger.send_message("mcp:eval_liveness_response", [request_id, loop_live])
+
+
+func _debug_status_snapshot() -> Dictionary:
+	var tree := get_tree()
+	return {
+		"probe_version": 1,
+		"helper_found": true,
+		"suspended": not can_process(),
+		"loop_live": not _main_loop_appears_stalled(),
+		"loop_tick_msec": _last_loop_tick_msec,
+		"process_ticks": _mcp_runtime_process_ticks,
+		"tree_paused": tree.paused if tree != null else false,
+		"frames_drawn": Engine.get_frames_drawn(),
+		"process_frames": Engine.get_process_frames(),
+		"physics_frames": Engine.get_physics_frames(),
+		"time_scale": Engine.time_scale,
+	}
+
+
+func _reply_debug_status(data: Array) -> void:
+	var request_id: String = data[0] if data.size() > 0 else ""
+	var state := _debug_status_snapshot()
+	_last_debug_status_reply = {"request_id": request_id, "state": state.duplicate(true)}
+	if EngineDebugger.is_active():
+		EngineDebugger.send_message("mcp:debug_status_response", [request_id, state])
 
 
 func _handle_take_screenshot(data: Array) -> void:

--- a/src/godot_ai/handlers/game.py
+++ b/src/godot_ai/handlers/game.py
@@ -9,7 +9,9 @@ from godot_ai.protocol.errors import ErrorCode
 from godot_ai.runtime.direct import DirectRuntime
 
 GAME_COMMAND_TIMEOUT_SEC = 15.0
-GAME_DEBUG_TIMEOUT_SEC = 5.0
+# The editor owns a 5s action timer and the dispatcher allows 6.5s. The MCP
+# client must outlive both so their structured result wins over transport timeout.
+GAME_DEBUG_TIMEOUT_SEC = 8.0
 
 ## input_sequence drives the game forward one frame per step, so its reply
 ## legitimately takes seconds — it gets a wider client timeout than the

--- a/src/godot_ai/handlers/game.py
+++ b/src/godot_ai/handlers/game.py
@@ -9,6 +9,7 @@ from godot_ai.protocol.errors import ErrorCode
 from godot_ai.runtime.direct import DirectRuntime
 
 GAME_COMMAND_TIMEOUT_SEC = 15.0
+GAME_DEBUG_TIMEOUT_SEC = 5.0
 
 ## input_sequence drives the game forward one frame per step, so its reply
 ## legitimately takes seconds — it gets a wider client timeout than the
@@ -29,6 +30,28 @@ async def _game_command(runtime: DirectRuntime, op: str, params: dict[str, Any])
         {"op": op, "params": params},
         timeout=GAME_COMMAND_TIMEOUT_SEC,
     )
+
+
+async def _game_debug_control(runtime: DirectRuntime, action: str) -> dict:
+    return await runtime.send_command(
+        "game_debug_control", {"action": action}, timeout=GAME_DEBUG_TIMEOUT_SEC
+    )
+
+
+async def game_suspend(runtime: DirectRuntime) -> dict:
+    return await _game_debug_control(runtime, "suspend")
+
+
+async def game_resume(runtime: DirectRuntime) -> dict:
+    return await _game_debug_control(runtime, "resume")
+
+
+async def game_next_frame(runtime: DirectRuntime) -> dict:
+    return await _game_debug_control(runtime, "next_frame")
+
+
+async def game_debug_status(runtime: DirectRuntime) -> dict:
+    return await _game_debug_control(runtime, "debug_status")
 
 
 async def game_get_scene_tree(

--- a/src/godot_ai/tools/game.py
+++ b/src/godot_ai/tools/game.py
@@ -25,13 +25,15 @@ Ops:
         Inspect visible runtime Control nodes for UI testing. Includes path,
         type, text where present, disabled state, and rect metadata.
   - suspend()
-        Suspend the running game through Godot's embedded Game View debugger.
+        Suspend the running game through Godot's native debugger path.
   - resume()
         Resume a suspended game. Idempotent when it is already running.
   - next_frame()
-        Advance exactly one process tick while suspended. Returns the tick
-        target to verify with debug_status(). May focus the embedded Game View;
-        any focus handoff is reported explicitly in the response.
+        Advance exactly one process tick while suspended. The response reports
+        verification and any Embedded Game View focus handoff. Runtime-control
+        mutations also report path="embed_signal" or "direct_session"; the
+        direct fallback works without embedding but cannot synchronize the
+        Game View suspend button's visual pressed state.
   - debug_status()
         Probe suspend state and the game-helper process tick counter through
         the debugger capture, including while SceneTree processing is suspended.

--- a/src/godot_ai/tools/game.py
+++ b/src/godot_ai/tools/game.py
@@ -24,6 +24,17 @@ Ops:
                     include_disabled=True, max_depth=10)
         Inspect visible runtime Control nodes for UI testing. Includes path,
         type, text where present, disabled state, and rect metadata.
+  - suspend()
+        Suspend the running game through Godot's embedded Game View debugger.
+  - resume()
+        Resume a suspended game. Idempotent when it is already running.
+  - next_frame()
+        Advance exactly one process tick while suspended. Returns the tick
+        target to verify with debug_status(). May focus the embedded Game View;
+        any focus handoff is reported explicitly in the response.
+  - debug_status()
+        Probe suspend state and the game-helper process tick counter through
+        the debugger capture, including while SceneTree processing is suspended.
   - input_key(key, pressed=True, echo=False)
         Send a key press/release to the running game.
   - input_mouse(event, position=None, button="left", pressed=True)
@@ -59,6 +70,10 @@ def register_game_tools(mcp: FastMCP) -> None:
             "get_scene_tree": game_handlers.game_get_scene_tree,
             "get_node_info": game_handlers.game_get_node_info,
             "get_ui_elements": game_handlers.game_get_ui_elements,
+            "suspend": game_handlers.game_suspend,
+            "resume": game_handlers.game_resume,
+            "next_frame": game_handlers.game_next_frame,
+            "debug_status": game_handlers.game_debug_status,
             "input_key": game_handlers.game_input_key,
             "input_mouse": game_handlers.game_input_mouse,
             "input_gamepad": game_handlers.game_input_gamepad,
@@ -70,6 +85,10 @@ def register_game_tools(mcp: FastMCP) -> None:
             "get_scene_tree": None,
             "get_node_info": None,
             "get_ui_elements": None,
+            "suspend": None,
+            "resume": None,
+            "next_frame": None,
+            "debug_status": None,
             "input_key": None,
             "input_mouse": None,
             "input_gamepad": None,

--- a/test_project/tests/test_dispatcher.gd
+++ b/test_project/tests/test_dispatcher.gd
@@ -231,6 +231,15 @@ func test_run_project_has_deferred_timeout_budget() -> void:
 	)
 
 
+func test_game_debug_control_deferred_timeout_outlives_editor_timer() -> void:
+	assert_has_key(McpDispatcher.DEFERRED_TIMEOUT_MS_BY_COMMAND, "game_debug_control")
+	assert_gt(
+		int(McpDispatcher.DEFERRED_TIMEOUT_MS_BY_COMMAND.game_debug_control),
+		int(McpDebuggerPlugin.GAME_DEBUG_CONTROL_TIMEOUT_SEC * 1000.0),
+		"dispatcher timeout must outlive the editor-side runtime-control timer",
+	)
+
+
 func test_client_status_has_30_second_deferred_timeout_budget() -> void:
 	assert_has_key(McpDispatcher.DEFERRED_TIMEOUT_MS_BY_COMMAND, "check_client_status")
 	assert_eq(

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -475,6 +475,37 @@ class _StubConnection:
 		captured.append({"request_id": request_id, "payload": payload})
 
 
+func test_game_debug_direct_session_message_mapping() -> void:
+	var suspend := McpDebuggerPlugin.direct_game_debug_message("suspend", true)
+	assert_eq(suspend.message, "scene:suspend_changed")
+	assert_eq(suspend.data, [true])
+	var resume := McpDebuggerPlugin.direct_game_debug_message("resume", false)
+	assert_eq(resume.message, "scene:suspend_changed")
+	assert_eq(resume.data, [false])
+	var step := McpDebuggerPlugin.direct_game_debug_message("next_frame", false)
+	assert_eq(step.message, "scene:next_frame")
+	assert_eq(step.data, [])
+	assert_true(McpDebuggerPlugin.direct_game_debug_message("bad", false).is_empty())
+
+
+func test_game_debug_control_rejects_overlapping_mutation() -> void:
+	var plugin := McpDebuggerPlugin.new()
+	var conn := _StubConnection.new()
+	_mark_game_live(plugin)
+	plugin._pending["rid-active-suspend"] = {
+		"kind": "game_debug_control",
+		"action": "suspend",
+	}
+	plugin._begin_game_debug_control("resume", "rid-overlap", conn, 5.0)
+	assert_eq(conn.captured.size(), 1, "overlapping mutation must fail before another native toggle")
+	assert_eq(conn.captured[0].payload.error.code, ErrorCodes.EDITOR_NOT_READY)
+	assert_eq(conn.captured[0].payload.error.data.active_action, "suspend")
+	assert_eq(conn.captured[0].payload.error.data.action, "resume")
+	assert_true(conn.captured[0].payload.error.data.retryable)
+	plugin._pending.erase("rid-active-suspend")
+	conn.free()
+
+
 func test_game_debug_control_guard_reply_waits_for_deferred_registration() -> void:
 	var tree := Engine.get_main_loop() as SceneTree
 	if tree == null:

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -226,6 +226,42 @@ func test_screenshot_game_not_playing() -> void:
 	assert_eq(result.error.data.sub_code, ErrorCodes.SUB_EDITOR_GAME_NOT_RUNNING)
 
 
+# ----- game debug control (#939) -----
+
+func test_game_debug_verification_requires_exact_tick() -> void:
+	var before := {"process_ticks": 10, "suspended": true}
+	var pending := McpDebuggerPlugin.game_debug_verification(
+		"next_frame", before, {"process_ticks": 10, "suspended": true})
+	assert_eq(pending.status, "pending")
+	assert_eq(pending.ticks_advanced, 0)
+	var exact := McpDebuggerPlugin.game_debug_verification(
+		"next_frame", before, {"process_ticks": 11, "suspended": true})
+	assert_eq(exact.status, "verified")
+	assert_eq(exact.ticks_advanced, 1)
+	var not_resuspended := McpDebuggerPlugin.game_debug_verification(
+		"next_frame", before, {"process_ticks": 11, "suspended": false})
+	assert_eq(not_resuspended.status, "pending")
+	var too_many := McpDebuggerPlugin.game_debug_verification(
+		"next_frame", before, {"process_ticks": 12, "suspended": true})
+	assert_eq(too_many.status, "failed")
+	assert_eq(too_many.reason, "multiple_process_ticks")
+
+
+func test_game_debug_verification_suspend_resume_state() -> void:
+	var before := {"process_ticks": 3, "suspended": false}
+	var suspended := McpDebuggerPlugin.game_debug_verification(
+		"suspend", before, {"process_ticks": 3, "suspended": true})
+	assert_eq(suspended.status, "verified")
+	var resumed := McpDebuggerPlugin.game_debug_verification(
+		"resume", {"process_ticks": 3, "suspended": true},
+		{"process_ticks": 3, "suspended": false})
+	assert_eq(resumed.status, "verified")
+	var still_suspended := McpDebuggerPlugin.game_debug_verification(
+		"resume", {"process_ticks": 3, "suspended": true},
+		{"process_ticks": 3, "suspended": true})
+	assert_eq(still_suspended.status, "pending")
+
+
 # ----- game_command -----
 
 func test_game_command_missing_op() -> void:

--- a/test_project/tests/test_editor.gd
+++ b/test_project/tests/test_editor.gd
@@ -475,6 +475,22 @@ class _StubConnection:
 		captured.append({"request_id": request_id, "payload": payload})
 
 
+func test_game_debug_control_guard_reply_waits_for_deferred_registration() -> void:
+	var tree := Engine.get_main_loop() as SceneTree
+	if tree == null:
+		skip("No SceneTree available")
+		return
+	var plugin := McpDebuggerPlugin.new()
+	var conn := _StubConnection.new()
+	plugin.request_game_debug_control("not_an_action", "rid-debug-guard", conn)
+	assert_eq(conn.captured.size(), 0, "guard reply must not race the dispatcher registration")
+	await tree.process_frame
+	assert_eq(conn.captured.size(), 1, "deferred guard should reply on a later editor turn")
+	assert_eq(conn.captured[0].request_id, "rid-debug-guard")
+	assert_eq(conn.captured[0].payload.error.code, ErrorCodes.VALUE_OUT_OF_RANGE)
+	conn.free()
+
+
 ## Records the positive liveness transition without requiring a real debugger
 ## session. The production method is still covered end-to-end by live smoke.
 class _RecordingEvalPlugin:

--- a/test_project/tests/test_game_helper.gd
+++ b/test_project/tests/test_game_helper.gd
@@ -306,6 +306,24 @@ func test_eval_liveness_probe_reports_loop_beacon() -> void:
 	helper.free()
 
 
+func test_debug_status_probe_reports_tick_counter() -> void:
+	var helper: Node = GameHelper.new()
+	helper._mcp_runtime_process_ticks = 7
+	helper._last_loop_tick_msec = Time.get_ticks_msec()
+	var state: Dictionary = helper._debug_status_snapshot()
+	assert_eq(state.process_ticks, 7)
+	assert_has_key(state, "suspended")
+	assert_has_key(state, "time_scale")
+	assert_true(helper._on_debug_message("mcp:debug_status", ["rid-status"]),
+		"the helper should capture suspended-runtime status probes")
+	assert_eq(helper._last_debug_status_reply.request_id, "rid-status")
+	assert_eq(helper._last_debug_status_reply.state.process_ticks, 7)
+	helper._process(0.016)
+	assert_eq(helper._mcp_runtime_process_ticks, 8,
+		"each helper _process call advances the verification counter exactly once")
+	helper.free()
+
+
 func test_rendering_appears_stalled_false_before_first_advance() -> void:
 	## A game that has never presented (booting, render-less) has no
 	## trustworthy frame — the -1 sentinel must read as NOT render-stalled so

--- a/test_project/tests/test_game_helper.gd
+++ b/test_project/tests/test_game_helper.gd
@@ -324,6 +324,31 @@ func test_debug_status_probe_reports_tick_counter() -> void:
 	helper.free()
 
 
+func test_debug_status_suspended_tracks_native_zero_time_scale() -> void:
+	var tree := Engine.get_main_loop() as SceneTree
+	if tree == null:
+		skip("No SceneTree available")
+		return
+	var helper := GameHelper.new()
+	helper.process_mode = Node.PROCESS_MODE_ALWAYS
+	tree.root.add_child(helper)
+	var was_paused := tree.paused
+	var was_time_scale := Engine.time_scale
+	tree.paused = false
+	Engine.time_scale = 1.0
+	var running_state: Dictionary = helper._debug_status_snapshot()
+	Engine.time_scale = 0.0
+	var can_process_at_zero_scale := helper.can_process()
+	var suspended_state: Dictionary = helper._debug_status_snapshot()
+	Engine.time_scale = was_time_scale
+	tree.paused = was_paused
+	helper.free()
+	assert_true(can_process_at_zero_scale, "PROCESS_MODE_ALWAYS cannot identify native Game View suspension")
+	assert_false(running_state.suspended)
+	assert_true(suspended_state.suspended, "native Game View suspend is exposed as Engine.time_scale == 0")
+	assert_false(suspended_state.tree_paused, "native Game View suspend does not pause SceneTree")
+
+
 func test_rendering_appears_stalled_false_before_first_advance() -> void:
 	## A game that has never presented (booting, render-less) has no
 	## trustworthy frame — the -1 sentinel must read as NOT render-stalled so

--- a/test_project/tests/test_game_helper.gd
+++ b/test_project/tests/test_game_helper.gd
@@ -311,8 +311,9 @@ func test_debug_status_probe_reports_tick_counter() -> void:
 	helper._mcp_runtime_process_ticks = 7
 	helper._last_loop_tick_msec = Time.get_ticks_msec()
 	var state: Dictionary = helper._debug_status_snapshot()
+	assert_eq(state.probe_version, 1)
 	assert_eq(state.process_ticks, 7)
-	assert_has_key(state, "suspended")
+	assert_false(state.suspended, "a detached helper must not report debugger suspension")
 	assert_has_key(state, "time_scale")
 	assert_true(helper._on_debug_message("mcp:debug_status", ["rid-status"]),
 		"the helper should capture suspended-runtime status probes")
@@ -324,7 +325,7 @@ func test_debug_status_probe_reports_tick_counter() -> void:
 	helper.free()
 
 
-func test_debug_status_suspended_tracks_native_zero_time_scale() -> void:
+func test_debug_status_suspend_signal_ignores_pause_and_user_time_scale() -> void:
 	var tree := Engine.get_main_loop() as SceneTree
 	if tree == null:
 		skip("No SceneTree available")
@@ -334,19 +335,19 @@ func test_debug_status_suspended_tracks_native_zero_time_scale() -> void:
 	tree.root.add_child(helper)
 	var was_paused := tree.paused
 	var was_time_scale := Engine.time_scale
-	tree.paused = false
-	Engine.time_scale = 1.0
-	var running_state: Dictionary = helper._debug_status_snapshot()
+	tree.paused = true
 	Engine.time_scale = 0.0
-	var can_process_at_zero_scale := helper.can_process()
-	var suspended_state: Dictionary = helper._debug_status_snapshot()
+	var state: Dictionary = helper._debug_status_snapshot()
+	var can_process_without_suspend := helper.can_process()
 	Engine.time_scale = was_time_scale
 	tree.paused = was_paused
 	helper.free()
-	assert_true(can_process_at_zero_scale, "PROCESS_MODE_ALWAYS cannot identify native Game View suspension")
-	assert_false(running_state.suspended)
-	assert_true(suspended_state.suspended, "native Game View suspend is exposed as Engine.time_scale == 0")
-	assert_false(suspended_state.tree_paused, "native Game View suspend does not pause SceneTree")
+	assert_true(can_process_without_suspend,
+		"PROCESS_MODE_ALWAYS stays processable through pause and user time_scale=0")
+	assert_false(state.suspended,
+		"debugger suspension must not be inferred from pause or project-writable time scale")
+	assert_true(state.tree_paused)
+	assert_eq(state.time_scale, 0.0)
 
 
 func test_rendering_appears_stalled_false_before_first_advance() -> void:

--- a/tests/unit/test_deferred_timeout_ladder.py
+++ b/tests/unit/test_deferred_timeout_ladder.py
@@ -94,6 +94,7 @@ COMMAND_DRIVERS: dict[str, Callable[[DirectRuntime], Awaitable[object]]] = {
     "check_client_status": lambda rt: client_handlers.client_status(rt),
     "game_eval": lambda rt: editor_handlers.game_eval(rt, "return 1"),
     "game_command": lambda rt: game_handlers.game_get_scene_tree(rt),
+    "game_debug_control": lambda rt: game_handlers.game_debug_status(rt),
     ## Only source="game" defers plugin-side (editor_handler.gd's game branch
     ## hands off to the debugger); viewport/cinematic captures reply inline, so
     ## the 30 s budget belongs to the game path. The one exception — a

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -1759,6 +1759,23 @@ async def test_logs_read_handler_plugin_normalizes_structured_payload():
 # ---------------------------------------------------------------------------
 
 
+async def test_game_debug_control_ops_use_editor_bridge():
+    client = StubClient()
+    runtime = DirectRuntime(registry=SessionRegistry(), client=client)
+
+    cases = [
+        (game_handlers.game_suspend, "suspend"),
+        (game_handlers.game_resume, "resume"),
+        (game_handlers.game_next_frame, "next_frame"),
+        (game_handlers.game_debug_status, "debug_status"),
+    ]
+    for handler, action in cases:
+        await handler(runtime)
+        assert client.calls[-1]["command"] == "game_debug_control"
+        assert client.calls[-1]["params"] == {"action": action}
+        assert client.calls[-1]["timeout"] == game_handlers.GAME_DEBUG_TIMEOUT_SEC
+
+
 async def test_game_get_scene_tree_sends_game_command():
     client = StubClient()
     runtime = DirectRuntime(registry=SessionRegistry(), client=client)


### PR DESCRIPTION
Closes #939.

## Summary

- add `game_manage` ops for `suspend`, `resume`, `next_frame`, and `debug_status`
- route runtime control through Godot's native debugger path:
  - prefer Embedded Game View via `ScriptEditorDebugger.embed_shortcut_requested`
  - fall back to the active `EditorDebuggerSession` with `scene:suspend_changed` / `scene:next_frame` for standalone, non-embedded, Wayland, and similar runs
- report the control path as `path="embed_signal" | "direct_session"` and expose whether the Embedded Game View suspend-button UI is synchronized
- derive debugger suspension from Godot's native SceneTree suspend gate exposed through the `PROCESS_MODE_ALWAYS` helper's `can_process()` state; keep `Engine.time_scale` diagnostic only
- add a suspend-safe helper `process_ticks` probe and only verify `next_frame` when it advances exactly one helper process tick and returns to suspended state
- fail closed on overlapping runtime-control mutations and preserve structured timeout diagnostics
- explicitly report the Embedded Game View focus handoff used before single-frame stepping
- add focused Python/GDScript regression coverage and document the new `game_manage` ops

## Verification

Official Godot 4.7.2 on Windows:

- **Embedded GUI E2E:** PASS
  - project-side `Engine.time_scale = 0.0` does not impersonate debugger suspension
  - `suspend` -> verified `suspended=true`, `path="embed_signal"`
  - `next_frame` -> exactly `ticks_advanced=1`, returns to suspended
  - `resume` -> verified running
- **Standalone GUI E2E with `run/window_placement/game_embed_mode=-1`:** PASS
  - suspend/resume/step all use `path="direct_session"`
  - `game_view_ui_synced=false` is reported explicitly
  - `next_frame` advances exactly one helper process tick and re-suspends
- **Full live Godot handler suite:** `2123/2160 passed`, `0 failed`, `37 skipped`, `71/71` expected suites
- **Full Python suite:** `2231 passed`, `50 skipped`
- **Focused runtime/tool Python gate:** `309 passed`
- **Deferred-timeout ladder:** `13 passed`
- **GDScript import/parse:** clean
- **Ruff:** clean
- **`git diff --check`:** clean

Latest review fix: `3fd9fa0` (`fix: support standalone game runtime control`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added runtime game debugging controls to suspend, resume, and advance the game by one frame.
  - Added a debug-status operation showing runtime state, pause status, frame activity, and timing information.
  - Added these operations to the `game_manage` tool.

- **Bug Fixes**
  - Controls now verify requested state changes and report failures or incomplete transitions.
  - Prevented conflicting debug-control actions from running simultaneously.

- **Documentation**
  - Updated domain-rollup documentation to include the new debugging operations and control-path details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->