### PR TITLE
fix: read Zed's JSONC settings for status without a write path

### DIFF
--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -193,6 +193,17 @@ Harness writes the loader `insert` row into `$DSH_HOME/cordis.patch.yml`
 command fields, rejects `url` next to them, and honors `$DSH_HOME` for the
 whole home root.
 
+`automatic_config_edits = false` marks a client whose settings file the dock
+never rewrites: Configure and Remove return the manual entry instead.
+`config_allows_comments = true` is its read-side companion for JSONC clients —
+Zed's `settings.json` opens with a `//` header that `JSON.parse` rejects, so
+without it a stock install shows a permanent parse error. Status, the manual
+instructions, and Open/Reveal strip `//` and `/* */` from a throwaway parse
+copy; markers inside JSON strings survive, and an unterminated block comment
+fails closed. No write path takes that branch, and the flag is honored only
+while `automatic_config_edits` is false, so a JSONC descriptor cannot pick up a
+comment-destroying rewrite by flipping one field.
+
 Command migrations deep-copy existing JSON entries before replacing pinned
 launch fields. `command_user_fields` documents known client-owned settings but
 is not a preservation whitelist: unknown future fields survive too.

--- a/plugin/addons/godot_ai/clients/_base.gd
+++ b/plugin/addons/godot_ai/clients/_base.gd
@@ -56,6 +56,13 @@ var config_type: String = ""                     ## "json" | "toml" | "yaml" | "
 ## return the existing manual instructions without touching the file.
 var automatic_config_edits: bool = true
 
+## True when the config file is JSONC (Zed ships a `//` header). Honored by the
+## JSON strategy's reads only — comments are stripped from a throwaway parse
+## copy, so the row shows a real status instead of a permanent parse error
+## (#914). Requires `automatic_config_edits = false`; the strategy ignores it
+## otherwise rather than let a re-serializing Configure drop the comments.
+var config_allows_comments: bool = false
+
 # JSON / TOML clients ------------------------------------------------------
 ## {"darwin": "~/...", "windows": "$APPDATA/...", "linux": "$XDG_CONFIG_HOME/..."}
 ## Keys may also use "unix" as a shorthand for darwin+linux.

--- a/plugin/addons/godot_ai/clients/_json_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_json_strategy.gd
@@ -551,7 +551,7 @@ static func _skip_jsonc_comment_at(text: String, i: int) -> int:
 		return i
 	if text[i + 1] == "/":
 		i += 2
-		# `get_as_text()` keeps CR, so a CR-only file never presents a `\n` and
+		# `get_string_from_utf8()` keeps CR, so a CR-only file never presents a `\n` and
 		# a `\n`-only terminator would swallow the rest of the file.
 		while i < n and text[i] != "\n" and text[i] != "\r":
 			i += 1

--- a/plugin/addons/godot_ai/clients/_json_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_json_strategy.gd
@@ -138,7 +138,7 @@ static func check_status_details(
 		return {"status": McpClient.Status.ERROR, "error_msg": path_error}
 	if path.is_empty() or not FileAccess.file_exists(path):
 		return {"status": McpClient.Status.NOT_CONFIGURED, "error_msg": ""}
-	var read := _read_or_init(path)
+	var read := _read_or_init(path, _status_allows_comments(client))
 	if not read["ok"]:
 		return {"status": McpClient.Status.ERROR, "error_msg": String(read["error"])}
 	var config: Dictionary = read["data"]
@@ -156,7 +156,8 @@ static func _check_status_merged(
 	launch: Dictionary,
 	project_roots: PackedStringArray,
 ) -> Dictionary:
-	var loaded := _load_merge_tiers(client)
+	var allow_comments := _status_allows_comments(client)
+	var loaded := _load_merge_tiers(client, allow_comments)
 	if not loaded.get("ok", false):
 		return {"status": McpClient.Status.ERROR, "error_msg": str(loaded.get("error", "Cannot read merged config tiers"))}
 	var effective: Variant = null
@@ -165,7 +166,7 @@ static func _check_status_merged(
 		var holder := _walk_path(config, select_server_key_path(config, client))
 		if holder is Dictionary and holder.has(server_name):
 			effective = holder[server_name]
-	var project := _load_project_definitions(client, server_name, project_roots)
+	var project := _load_project_definitions(client, server_name, project_roots, allow_comments)
 	if not project.get("ok", false):
 		return {"status": McpClient.Status.ERROR, "error_msg": str(project.get("error", "Cannot inspect project config tiers"))}
 	var project_tiers: Array = project.get("tiers", [])
@@ -434,7 +435,9 @@ static func _arrays_equal(left: Variant, right: Variant) -> bool:
 ## away the user's other MCP entries on the next write. The `original_text`
 ## is the exact captured source so transactional rollback can restore
 ## byte-for-byte; the UTF-8 BOM is stripped only from the parsing copy.
-static func _read_file_text(path: String) -> Dictionary:
+## `allow_comments` also strips JSONC comments from the parsing copy; only
+## read-only callers pass it (see `_status_allows_comments`).
+static func _read_file_text(path: String, allow_comments: bool = false) -> Dictionary:
 	if not FileAccess.file_exists(path):
 		return {"exists": false, "ok": true, "data": {}, "original_text": ""}
 	var file := FileAccess.open(path, FileAccess.READ)
@@ -460,6 +463,16 @@ static func _read_file_text(path: String) -> Dictionary:
 	if body.strip_edges().is_empty():
 		return {"exists": true, "ok": true, "data": {}, "original_text": content}
 	var parse_copy := body
+	if allow_comments:
+		# Parse copy only — `original_text` stays byte-for-byte, and an
+		# unterminated block comment fails closed rather than letting the
+		# leftover source parse as valid JSON.
+		var stripped := _strip_jsonc(parse_copy)
+		if not stripped.get("ok", false):
+			var strip_msg := str(stripped.get("error", "invalid JSONC"))
+			push_warning("MCP | %s in %s" % [strip_msg, path])
+			return {"exists": true, "ok": false, "error": strip_msg, "original_text": content}
+		parse_copy = str(stripped.get("text", ""))
 	var json := JSON.new()
 	if json.parse(parse_copy) != OK:
 		var msg := "JSON parse error on line %d: %s" % [json.get_error_line(), json.get_error_message()]
@@ -470,13 +483,94 @@ static func _read_file_text(path: String) -> Dictionary:
 	return {"exists": true, "ok": true, "data": json.data, "original_text": content}
 
 
+## Read-only by construction: requiring both flags means no Configure/Remove
+## can parse a file it would then re-serialize without the discarded comments.
+## Re-enabling automatic edits restores the parse error instead of a lossy write.
+static func _status_allows_comments(client: McpClient) -> bool:
+	return client.config_allows_comments and not client.automatic_config_edits
+
+
+## Strip `//` and `/* */` comments, leaving sequences inside JSON strings
+## intact. Parse copies only.
+## Returns `{"ok": true, "text": String}` or `{"ok": false, "error": String}`.
+static func _strip_jsonc(text: String) -> Dictionary:
+	var parts := PackedStringArray()
+	var i := 0
+	var n := text.length()
+	var in_string := false
+	var escape := false
+	var run_start := 0
+	while i < n:
+		var c := text[i]
+		if in_string:
+			if escape:
+				escape = false
+			elif c == "\\":
+				escape = true
+			elif c == '"':
+				in_string = false
+			i += 1
+			continue
+		if c == '"':
+			in_string = true
+			i += 1
+			continue
+		var skipped := _skip_jsonc_comment_at(text, i)
+		if skipped < 0:
+			return {"ok": false, "error": "unterminated block comment"}
+		if skipped != i:
+			if i > run_start:
+				parts.append(text.substr(run_start, i - run_start))
+			# Re-emit newlines so JSON.parse error lines still match the source.
+			var emitted_nl := false
+			for j in range(i, skipped):
+				if text[j] == "\n":
+					parts.append("\n")
+					emitted_nl = true
+			# A comment must not glue its neighbours (`tru/* x */e` is not
+			# `true`). A newline already splits them; otherwise use a space.
+			if not emitted_nl:
+				parts.append(" ")
+			i = skipped
+			run_start = i
+			continue
+		i += 1
+	if in_string:
+		return {"ok": false, "error": "unterminated string"}
+	if n > run_start:
+		parts.append(text.substr(run_start, n - run_start))
+	return {"ok": true, "text": "".join(parts)}
+
+
+## Skip a JSONC comment starting at `i`. Returns `i` unchanged when `i` is not
+## a comment opener, the index after a consumed comment, or -1 when a block
+## comment runs to EOF without `*/`.
+static func _skip_jsonc_comment_at(text: String, i: int) -> int:
+	var n := text.length()
+	if i + 1 >= n or text[i] != "/":
+		return i
+	if text[i + 1] == "/":
+		i += 2
+		while i < n and text[i] != "\n":
+			i += 1
+		return i
+	if text[i + 1] == "*":
+		i += 2
+		while i + 1 < n:
+			if text[i] == "*" and text[i + 1] == "/":
+				return i + 2
+			i += 1
+		return -1
+	return i
+
+
 ## Returns {"ok": true, "data": Dictionary} when the file is absent or parses
 ## cleanly, and {"ok": false, "error": String} when the file exists with
 ## non-empty content we cannot safely round-trip. Callers must NOT fall back
 ## to an empty dict on the error path — doing so blows away the user's other
 ## MCP entries on the next write.
-static func _read_or_init(path: String) -> Dictionary:
-	var read := _read_file_text(path)
+static func _read_or_init(path: String, allow_comments: bool = false) -> Dictionary:
+	var read := _read_file_text(path, allow_comments)
 	var result: Dictionary = {"ok": read.get("ok", false), "data": read.get("data", {})}
 	if not result.get("ok", false):
 		result["error"] = read.get("error", "")
@@ -572,11 +666,14 @@ static func _project_candidate_paths(
 
 
 static func _load_project_definitions(
-	client: McpClient, server_name: String, project_roots: PackedStringArray
+	client: McpClient,
+	server_name: String,
+	project_roots: PackedStringArray,
+	allow_comments: bool = false,
 ) -> Dictionary:
 	var tiers: Array[Dictionary] = []
 	for path in _project_candidate_paths(client, project_roots):
-		var read := _read_or_init(path)
+		var read := _read_or_init(path, allow_comments)
 		if not read.get("ok", false):
 			return {"ok": false, "error": "Cannot inspect project config %s: %s" % [path, read.get("error", "invalid JSON")]}
 		var config: Dictionary = read["data"]
@@ -601,7 +698,7 @@ static func _project_override_message(
 	return "%s project config overrides %s at %s. %s resolves project files from its own working directory, so the dock cannot safely choose one; %s the entry manually." % [client_name, server_name, ", ".join(paths), client_name, action]
 
 
-static func _load_merge_tiers(client: McpClient) -> Dictionary:
+static func _load_merge_tiers(client: McpClient, allow_comments: bool = false) -> Dictionary:
 	var tiers: Array[Dictionary] = []
 	for path in _merge_paths(client):
 		## These templates never pass through `resolved_config_path_details`,
@@ -616,7 +713,7 @@ static func _load_merge_tiers(client: McpClient) -> Dictionary:
 				"ok": false,
 				"error": McpClient.unresolved_config_path_error(client.display_name, path),
 			}
-		var read := _read_file_text(path)
+		var read := _read_file_text(path, allow_comments)
 		if not read.get("ok", false):
 			return {
 				"ok": false,
@@ -675,7 +772,8 @@ static func authoritative_tier_path(
 ) -> String:
 	if not _uses_merge_tiers(client):
 		return ""
-	var project := _load_project_definitions(client, server_name, project_roots)
+	var allow_comments := _status_allows_comments(client)
+	var project := _load_project_definitions(client, server_name, project_roots, allow_comments)
 	if not bool(project.get("ok", false)):
 		return ""
 	var project_tiers: Array = project.get("tiers", [])
@@ -685,7 +783,7 @@ static func authoritative_tier_path(
 		# latest, so the Open/Reveal buttons should send them there too.
 		var latest: Dictionary = project_tiers[project_tiers.size() - 1]
 		return str(latest.get("path", ""))
-	var loaded := _load_merge_tiers(client)
+	var loaded := _load_merge_tiers(client, allow_comments)
 	if not bool(loaded.get("ok", false)):
 		return ""
 	var tiers: Array = loaded.get("tiers", [])
@@ -709,8 +807,11 @@ static func manual_target_details(
 	fallback_path: String,
 	project_roots: PackedStringArray = PackedStringArray(),
 ) -> Dictionary:
+	# A read: the instructions a JSONC client is sent to must not carry
+	# "Target inspection failed" for the file its own client ships.
+	var allow_comments := _status_allows_comments(client)
 	if _uses_merge_tiers(client):
-		var project := _load_project_definitions(client, server_name, project_roots)
+		var project := _load_project_definitions(client, server_name, project_roots, allow_comments)
 		if not project.get("ok", false):
 			return {"ok": false, "error": project.get("error", "Cannot inspect project config tiers")}
 		var project_tiers: Array = project.get("tiers", [])
@@ -723,7 +824,7 @@ static func manual_target_details(
 				"path": selected_project["path"],
 				"key_path": selected_project["key_path"],
 			}
-		var loaded := _load_merge_tiers(client)
+		var loaded := _load_merge_tiers(client, allow_comments)
 		if not loaded.get("ok", false):
 			return {"ok": false, "error": loaded.get("error", "Cannot read merged config tiers")}
 		var tiers: Array = loaded.get("tiers", [])
@@ -740,7 +841,7 @@ static func manual_target_details(
 				"path": selected["path"],
 				"key_path": select_server_key_path(config, client),
 			}
-	var read := _read_or_init(fallback_path)
+	var read := _read_or_init(fallback_path, allow_comments)
 	if not read.get("ok", false):
 		return {"ok": false, "error": "Cannot inspect %s: %s" % [fallback_path, read.get("error", "invalid JSON")]}
 	return {

--- a/plugin/addons/godot_ai/clients/_json_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_json_strategy.gd
@@ -551,7 +551,9 @@ static func _skip_jsonc_comment_at(text: String, i: int) -> int:
 		return i
 	if text[i + 1] == "/":
 		i += 2
-		while i < n and text[i] != "\n":
+		# `get_as_text()` keeps CR, so a CR-only file never presents a `\n` and
+		# a `\n`-only terminator would swallow the rest of the file.
+		while i < n and text[i] != "\n" and text[i] != "\r":
 			i += 1
 		return i
 	if text[i + 1] == "*":

--- a/plugin/addons/godot_ai/clients/zed.gd
+++ b/plugin/addons/godot_ai/clients/zed.gd
@@ -13,6 +13,9 @@ func _init() -> void:
 	## comments would make the shared JSON strategy much harder to trust. Keep
 	## status checks read-only and give users the exact manual entry instead.
 	automatic_config_edits = false
+	## Reads still have to cope with the `//` header Zed ships, or a stock
+	## install shows a parse error in the row instead of a status.
+	config_allows_comments = true
 	path_template = {
 		"darwin": "~/.config/zed/settings.json",
 		"linux": "$XDG_CONFIG_HOME/zed/settings.json",

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -4308,6 +4308,185 @@ func test_zed_configure_and_remove_never_mutate_jsonc() -> void:
 	assert_eq(after, body, "manual-only operations must preserve Zed settings byte-for-byte")
 
 
+# ----- #914: comment-tolerant READ for JSONC clients -----
+#
+# Zed ships settings.json with a `//` header, which Godot's JSON.parse rejects,
+# so a stock install reported a permanent parse error. Comments are stripped
+# from a throwaway parse copy and only for clients nothing rewrites.
+
+
+func test_zed_descriptor_opts_into_read_only_jsonc() -> void:
+	var c := McpClientRegistry.get_by_id("zed")
+	assert_true(c.config_allows_comments, "Zed settings.json is JSONC — its reads must tolerate comments")
+	assert_false(
+		c.automatic_config_edits,
+		"comment tolerance is only safe while nothing re-serializes the file",
+	)
+
+
+func test_zed_status_reads_stock_jsonc_settings() -> void:
+	## A default install carries a comment header and must show a real status.
+	var client := McpClientRegistry.get_by_id("zed")
+	var saved_paths: Dictionary = client.path_template.duplicate(true)
+	var path := _scratch_dir.path_join("zed-stock-jsonc.json")
+	var launch := _test_attach_launch()
+	client.path_template = {"darwin": path, "linux": path, "windows": path, "unix": path}
+
+	_write_text(path, "// Zed settings\n/* multi\n   line */\n{\n\t\"theme\": \"One Dark\"\n}\n")
+	var absent := McpJsonStrategy.check_status_details(client, "godot-ai", "http://unused", launch)
+
+	var entry := McpJsonStrategy.build_entry(client, "http://unused", null, launch)
+	_write_text(
+		path,
+		"// Zed settings\n{\n\t\"context_servers\": {\n\t\t\"godot-ai\": %s\n\t}\n}\n" % JSON.stringify(entry),
+	)
+	var present := McpJsonStrategy.check_status_details(client, "godot-ai", "http://unused", launch)
+
+	client.path_template = saved_paths
+	_remove_if_exists(path)
+
+	assert_eq(
+		absent.get("status"),
+		McpClient.Status.NOT_CONFIGURED,
+		"a commented file without our entry is not configured, not broken",
+	)
+	assert_eq(String(absent.get("error_msg", "")), "", "a JSONC header is not an error")
+	assert_eq(
+		present.get("status"),
+		McpClient.Status.CONFIGURED,
+		"our entry must verify through a commented file: %s" % String(present.get("error_msg", "")),
+	)
+
+
+func test_zed_manual_instructions_do_not_report_a_parse_failure() -> void:
+	## `manual_target_details` backs the "Run this manually" block Zed users are
+	## sent to precisely because Configure will not write, so it must not
+	## decorate those instructions with "Target inspection failed".
+	var client := McpClientRegistry.get_by_id("zed")
+	var path := _scratch_dir.path_join("zed-manual-target.json")
+	_write_text(path, "// Zed settings\n{\n\t\"context_servers\": {}\n}\n")
+
+	var target := McpJsonStrategy.manual_target_details(client, "godot-ai", path)
+	_remove_if_exists(path)
+
+	assert_true(
+		target.get("ok", false),
+		"manual target inspection must survive a JSONC header: %s" % str(target.get("error", "")),
+	)
+	assert_eq(str(target.get("path", "")), path)
+	var key_path: PackedStringArray = target.get("key_path", PackedStringArray())
+	assert_eq(key_path.size(), 1, "Zed's map is a single top-level key")
+	if key_path.size() == 1:
+		assert_eq(key_path[0], "context_servers")
+
+
+func test_json_comment_tolerance_is_gated_on_manual_edit_descriptors() -> void:
+	## `configure` re-serializes the parsed dict, so tolerating comments for a
+	## writable client would hand back a comment-free rewrite. The gate is the
+	## pair of flags, not either one alone.
+	var path := _scratch_dir.path_join("jsonc_gate.json")
+	_write_text(path, "// header\n{\n\t\"mcpServers\": {}\n}\n")
+	var client := _make_test_json_client(path)
+
+	var plain := McpJsonStrategy.check_status_details(client, "godot-ai", "http://x")
+	client.config_allows_comments = true
+	var writable := McpJsonStrategy.check_status_details(client, "godot-ai", "http://x")
+	client.automatic_config_edits = false
+	var manual := McpJsonStrategy.check_status_details(client, "godot-ai", "http://x")
+	_remove_if_exists(path)
+
+	assert_eq(plain.get("status"), McpClient.Status.ERROR, "a plain JSON client keeps the strict parser")
+	assert_contains(String(plain.get("error_msg", "")), "parse error")
+	assert_eq(
+		writable.get("status"),
+		McpClient.Status.ERROR,
+		"opting in while the dock still writes the file must stay strict",
+	)
+	assert_contains(String(writable.get("error_msg", "")), "parse error")
+	assert_eq(
+		manual.get("status"),
+		McpClient.Status.NOT_CONFIGURED,
+		"a manual-edit JSONC client reads the commented file: %s" % String(manual.get("error_msg", "")),
+	)
+
+
+func test_json_jsonc_read_fails_closed_on_unterminated_block_comment() -> void:
+	## Parsing the leftover source is worse than the error we set out to remove.
+	var path := _scratch_dir.path_join("jsonc_unterminated.json")
+	_write_text(path, "/* never closed\n{\n\t\"mcpServers\": {}\n}\n")
+	var client := _make_test_json_client(path)
+	client.config_allows_comments = true
+	client.automatic_config_edits = false
+
+	var details := McpJsonStrategy.check_status_details(client, "godot-ai", "http://x")
+	_remove_if_exists(path)
+
+	assert_eq(details.get("status"), McpClient.Status.ERROR)
+	assert_contains(String(details.get("error_msg", "")), "unterminated block comment")
+
+
+func test_merged_json_status_reads_jsonc_tiers() -> void:
+	## Merge-tier reads fold through `_load_merge_tiers`; gating only the
+	## single-file read would half-support the next JSONC descriptor.
+	var tier := _scratch_dir.path_join("merge_jsonc/mcp.json")
+	_write_text(
+		tier,
+		"// tier header\n{\n\t\"mcpServers\": {\n\t\t\"godot-ai\": {\"url\": \"http://127.0.0.1:8000/mcp\"}\n\t}\n}\n",
+	)
+	var client := _make_merged_json_client(PackedStringArray([tier]))
+	client.config_allows_comments = true
+	client.automatic_config_edits = false
+
+	var details := McpJsonStrategy.check_status_details(client, "godot-ai", "http://127.0.0.1:8000/mcp")
+	_remove_if_exists(tier)
+
+	assert_eq(
+		details.get("status"),
+		McpClient.Status.CONFIGURED,
+		"a commented merge tier must still verify: %s" % String(details.get("error_msg", "")),
+	)
+
+
+func test_strip_jsonc_preserves_comment_markers_inside_strings() -> void:
+	var stripped := McpJsonStrategy._strip_jsonc('{"a": "// not a comment", "b": "/* also not */"}')
+	assert_true(stripped.get("ok", false))
+	var parsed: Variant = JSON.parse_string(str(stripped.get("text", "")))
+	assert_true(parsed is Dictionary, "in-string comment markers must not break the parse")
+	if parsed is Dictionary:
+		assert_eq(parsed.get("a"), "// not a comment")
+		assert_eq(parsed.get("b"), "/* also not */")
+
+
+func test_strip_jsonc_does_not_glue_tokens_across_a_comment() -> void:
+	## `tru/* x */e` must not be welded into the literal `true`.
+	var stripped := McpJsonStrategy._strip_jsonc('{"a": tru/* x */e}')
+	assert_true(stripped.get("ok", false))
+	var json := JSON.new()
+	assert_ne(
+		json.parse(str(stripped.get("text", ""))),
+		OK,
+		"two half-tokens either side of a comment must not become one literal",
+	)
+
+
+func test_strip_jsonc_keeps_block_comment_newlines() -> void:
+	## So JSON.parse error lines still point at the user's source line.
+	var stripped := McpJsonStrategy._strip_jsonc("/* one\ntwo */{\"a\": 1}")
+	assert_true(stripped.get("ok", false))
+	var text := str(stripped.get("text", ""))
+	assert_eq(text.count("\n"), 1, "the comment's newline must be re-emitted")
+	assert_true(text.strip_edges().begins_with("{"), "only the comment bytes are dropped")
+
+
+func test_strip_jsonc_rejects_unterminated_comment_and_string() -> void:
+	var comment := McpJsonStrategy._strip_jsonc("{\n\t\"a\": 1 /* open")
+	assert_false(comment.get("ok", true))
+	assert_contains(str(comment.get("error", "")), "unterminated block comment")
+	var string_run := McpJsonStrategy._strip_jsonc('{"a": "open')
+	assert_false(string_run.get("ok", true))
+	assert_contains(str(string_run.get("error", "")), "unterminated string")
+
+
 func test_vscode_attach_entry_flips_type_pin_to_stdio() -> void:
 	for id in ["vscode", "vscode_insiders"]:
 		var c := McpClientRegistry.get_by_id(id)

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -4469,6 +4469,34 @@ func test_strip_jsonc_does_not_glue_tokens_across_a_comment() -> void:
 	)
 
 
+func test_strip_jsonc_terminates_line_comments_on_cr() -> void:
+	## `get_as_text()` keeps CR, so a CR-only file gives the scanner no `\n`.
+	## Ending the comment only on `\n` would swallow the JSON behind it.
+	var stripped := McpJsonStrategy._strip_jsonc("// header\r{\"a\": 1}\r")
+	assert_true(stripped.get("ok", false))
+	var parsed: Variant = JSON.parse_string(str(stripped.get("text", "")))
+	assert_true(parsed is Dictionary, "a CR-terminated comment must not eat the object")
+	if parsed is Dictionary:
+		assert_eq(parsed.get("a"), 1.0)
+
+
+func test_json_jsonc_read_handles_cr_only_line_endings() -> void:
+	var path := _scratch_dir.path_join("jsonc_cr_only.json")
+	_write_text(path, "// header\r{\r\t\"mcpServers\": {}\r}\r")
+	var client := _make_test_json_client(path)
+	client.config_allows_comments = true
+	client.automatic_config_edits = false
+
+	var details := McpJsonStrategy.check_status_details(client, "godot-ai", "http://x")
+	_remove_if_exists(path)
+
+	assert_eq(
+		details.get("status"),
+		McpClient.Status.NOT_CONFIGURED,
+		"CR-only JSONC must read, not error: %s" % String(details.get("error_msg", "")),
+	)
+
+
 func test_strip_jsonc_keeps_block_comment_newlines() -> void:
 	## So JSON.parse error lines still point at the user's source line.
 	var stripped := McpJsonStrategy._strip_jsonc("/* one\ntwo */{\"a\": 1}")


### PR DESCRIPTION
## Summary

Follow-up to #930, scoped down per review: read-only, no write path.

v4 made Zed manual-edit-only (`automatic_config_edits = false`), so the dead-Configure half of #914 is gone by construction. What remained is the read: Zed ships `settings.json` with a `//` comment header, and status still went through `JSON.parse`. A stock install therefore showed a permanent parse error in its dock row — and `manual_target_details` appended `Target inspection failed: JSON parse error…` to the very manual instructions the user is pointed at *because* Configure won't write.

- New `config_allows_comments` descriptor flag; `zed.gd` opts in.
- `_strip_jsonc` strips `//` and `/* */` from a throwaway parse copy. Markers inside JSON strings survive, a comment never glues the tokens on either side (`tru/* x */e` is not `true`), block-comment newlines are re-emitted so parse-error line numbers still match the source, and an unterminated block comment fails closed.
- Threaded through the three read entry points only: `check_status_details`, `manual_target_details`, `authoritative_tier_path`. `configure`, `remove`, and their merged variants keep the strict parser via the default argument.

`original_text` is untouched, so nothing about the byte-preservation contract changes.

### Why it can't leak into a write

`_status_allows_comments` requires **both** `config_allows_comments` and `not automatic_config_edits`. `configure` re-serializes the parsed dict, so tolerating comments for a writable client would hand the user back a comment-free rewrite. Re-enabling automatic edits on a JSONC descriptor restores the parse error rather than silently enabling a lossy write — the noisy failure is the safe one. `test_json_comment_tolerance_is_gated_on_manual_edit_descriptors` locks all three states.

## Not included

The token-preserving splice, the `_text_remove_server_entry` comment handling, and the `script/ci-reload-test` SSE changes from #930 are all write-path or out of scope for this one, and are dropped.

Separately: #930 carried a commit claiming Godot's text decoder eats a leading UTF-8 BOM, which would mean `original_text` loses it and `remove` strips the BOM from disk. If that holds it is a live bug on `main`, but it is write-path, so it is deliberately not addressed here.

## Test plan

New GDScript coverage in `test_clients.gd`:

- `test_zed_descriptor_opts_into_read_only_jsonc`
- `test_zed_status_reads_stock_jsonc_settings` — commented file without the entry is NOT_CONFIGURED with an empty `error_msg`; with the entry it verifies as CONFIGURED
- `test_zed_manual_instructions_do_not_report_a_parse_failure`
- `test_json_comment_tolerance_is_gated_on_manual_edit_descriptors`
- `test_json_jsonc_read_fails_closed_on_unterminated_block_comment`
- `test_merged_json_status_reads_jsonc_tiers`
- `test_strip_jsonc_*` — in-string markers, token gluing, newline preservation, unterminated comment/string

Run locally against Godot 4.7.2:

- `ruff check` — clean
- `script/ci-check-gdscript` — clean
- `script/ci-godot-tests` against a live editor — 2125/2162 passed, 0 failed, 37 skipped, 71/71 suites
- `pytest` — 2226 passed, 2 failed, both pre-existing and environment-specific on this Windows box (a `MAX_PATH` overflow in the release-signing test, and a local proxy-environment integration test). This branch changes no Python.

Fixes #914

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added read-only support for JSON configuration files containing `//` and `/* */` comments.
  * Zed settings now display status and manual instructions correctly with their standard commented configuration format.
  * Added support for commented configuration files in merged status checks and other read-only views.

* **Bug Fixes**
  * Preserved comment markers inside strings and UTF-8 byte-order marks.
  * Added safe handling for incomplete comments or strings.
  * Improved parsing across different line-ending formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->