### PR TITLE
fix: keep the UTF-8 BOM through a token-preserving Remove

### DIFF
--- a/plugin/addons/godot_ai/clients/_json_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_json_strategy.gd
@@ -825,9 +825,13 @@ static func _text_remove_server_entry(text: String, key_path: PackedStringArray,
 	# itself stays in `text` so the byte-survival F5 contract still holds
 	# (codex round 3, F-3-6 — without it, files saved with a Windows BOM
 	# left the entry in place after Remove).
-	while cursor < text.length() and _is_json_ws(text[cursor]):
-		cursor += 1
+	# The BOM can only ever be byte 0, so it is skipped BEFORE the whitespace
+	# walk: a file saved as BOM + newline + `{` (common from Windows editors)
+	# otherwise leaves the cursor on the newline, the root `{` is never
+	# consumed, and the entry silently survives Remove.
 	if cursor < text.length() and text[cursor] == "﻿":
+		cursor += 1
+	while cursor < text.length() and _is_json_ws(text[cursor]):
 		cursor += 1
 	if cursor < text.length() and (text[cursor] == "{" or text[cursor] == "["):
 		cursor += 1

--- a/plugin/addons/godot_ai/clients/_json_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_json_strategy.gd
@@ -441,16 +441,25 @@ static func _read_file_text(path: String) -> Dictionary:
 	if file == null:
 		var open_err := FileAccess.get_open_error()
 		return {"exists": true, "ok": false, "error": "could not open for reading (error %d)" % open_err, "original_text": ""}
-	var content := file.get_as_text()
+	# Read bytes, not `get_as_text()`. Godot's UTF-8 decoder (both `get_as_text`
+	# and `get_string_from_utf8`) silently consumes a leading EF BB BF, so a
+	# text-only read dropped the BOM from `original_text` and the next Remove
+	# wrote it back out of the user's file — a byte mutation outside the entry
+	# we were asked to touch. Detect the marker on the raw buffer and restore
+	# U+FEFF when the decoder ate it.
+	var buf := file.get_buffer(file.get_length())
 	file.close()
-	if content.strip_edges().is_empty():
+	var had_bom := buf.size() >= 3 and buf[0] == 0xEF and buf[1] == 0xBB and buf[2] == 0xBF
+	var content := buf.get_string_from_utf8()
+	if had_bom and not content.begins_with("﻿"):
+		content = "﻿" + content
+	# Everything downstream of the BOM parses and measures the body: JSON.parse
+	# rejects a leading U+FEFF outright, and a BOM-only file is empty, not
+	# broken. `original_text` keeps the marker so writes round-trip it.
+	var body := content.substr(1) if content.begins_with("﻿") else content
+	if body.strip_edges().is_empty():
 		return {"exists": true, "ok": true, "data": {}, "original_text": content}
-	var parse_copy := content
-	# Strip a UTF-8 BOM if present — some editors (notably on Windows) save
-	# JSON with a leading ﻿, which Godot's JSON.parse rejects outright.
-	# Previously this landed on the "unparseable → wipe" path.
-	if parse_copy.begins_with("﻿"):
-		parse_copy = parse_copy.substr(1)
+	var parse_copy := body
 	var json := JSON.new()
 	if json.parse(parse_copy) != OK:
 		var msg := "JSON parse error on line %d: %s" % [json.get_error_line(), json.get_error_message()]

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -2807,6 +2807,74 @@ func test_json_strategy_tolerates_utf8_bom() -> void:
 	assert_true(parsed["mcpServers"].has("godot-ai"), "godot-ai entry not added")
 
 
+func test_json_strategy_remove_preserves_utf8_bom() -> void:
+	## Godot's UTF-8 decoder eats a leading EF BB BF, so a `get_as_text()` read
+	## dropped the BOM from `original_text` and Remove spliced-and-wrote a
+	## BOM-less file — a byte mutation outside the entry we were asked to
+	## touch, which is exactly what the byte-survival contract forbids.
+	## Asserted on raw bytes: decoding the result would hide the loss.
+	var path := _scratch_dir.path_join("bom_remove.json")
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	f.store_buffer(PackedByteArray([0xEF, 0xBB, 0xBF]))
+	f.store_string(
+		"{\n\t\"mcpServers\": {\n\t\t\"godot-ai\": {\"url\": \"http://x\"},\n"
+		+ "\t\t\"other\": {\"url\": \"http://y\"}\n\t}\n}\n"
+	)
+	f.close()
+
+	var client := _make_test_json_client(path)
+	var removed := McpJsonStrategy.remove(client, "godot-ai")
+
+	var check := FileAccess.open(path, FileAccess.READ)
+	var after := check.get_buffer(check.get_length())
+	check.close()
+	_remove_if_exists(path)
+
+	assert_eq(removed.get("status"), "ok", str(removed.get("message", "")))
+	assert_true(
+		after.size() >= 3 and after[0] == 0xEF and after[1] == 0xBB and after[2] == 0xBF,
+		"BOM must survive Remove; got first bytes %s" % [Array(after.slice(0, 4))],
+	)
+	var text := after.get_string_from_utf8()
+	assert_false(text.contains("godot-ai"), "the entry must still be removed")
+	assert_true(text.contains("other"), "unrelated entries must survive")
+
+
+func test_json_strategy_status_reads_bom_prefixed_file() -> void:
+	## The BOM now reaches `original_text`, which makes the parse-copy strip
+	## load-bearing rather than dead code: JSON.parse rejects a leading U+FEFF.
+	var path := _scratch_dir.path_join("bom_status.json")
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	f.store_buffer(PackedByteArray([0xEF, 0xBB, 0xBF]))
+	f.store_string("{\"mcpServers\": {\"godot-ai\": {\"url\": \"http://x\"}}}")
+	f.close()
+
+	var client := _make_test_json_client(path)
+	var details := McpJsonStrategy.check_status_details(client, "godot-ai", "http://x")
+	_remove_if_exists(path)
+
+	assert_eq(
+		details.get("status"),
+		McpClient.Status.CONFIGURED,
+		"a BOM must not read as a broken file: %s" % String(details.get("error_msg", "")),
+	)
+
+
+func test_json_strategy_treats_bom_only_file_as_empty() -> void:
+	## A BOM-only file is empty, not broken — emptiness is measured on the body
+	## so Configure still seeds it instead of refusing with a parse error.
+	var path := _scratch_dir.path_join("bom_only.json")
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	f.store_buffer(PackedByteArray([0xEF, 0xBB, 0xBF]))
+	f.close()
+
+	var client := _make_test_json_client(path)
+	var configured := McpJsonStrategy.configure(client, "godot-ai", "http://x")
+	_remove_if_exists(path)
+
+	assert_eq(configured.get("status"), "ok", str(configured.get("message", "")))
+
+
 func test_json_strategy_remove_refuses_unparseable_file() -> void:
 	## remove() has the same wipe-risk as configure() — it also round-trips
 	## through _read_or_init and writes back. Must refuse on bad input.

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -2840,6 +2840,37 @@ func test_json_strategy_remove_preserves_utf8_bom() -> void:
 	assert_true(text.contains("other"), "unrelated entries must survive")
 
 
+func test_json_strategy_remove_preserves_utf8_bom_before_leading_newline() -> void:
+	## Windows editors commonly write BOM + newline before the root object. The
+	## splice must skip the BOM before the whitespace walk, or the root `{` is
+	## never consumed and Remove reports ok while leaving the entry in place.
+	var path := _scratch_dir.path_join("bom_newline_remove.json")
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	f.store_buffer(PackedByteArray([0xEF, 0xBB, 0xBF]))
+	f.store_string(
+		"\n{\n\t\"mcpServers\": {\n\t\t\"godot-ai\": {\"url\": \"http://x\"},\n"
+		+ "\t\t\"other\": {\"url\": \"http://y\"}\n\t}\n}\n"
+	)
+	f.close()
+
+	var client := _make_test_json_client(path)
+	var removed := McpJsonStrategy.remove(client, "godot-ai")
+
+	var check := FileAccess.open(path, FileAccess.READ)
+	var after := check.get_buffer(check.get_length())
+	check.close()
+	_remove_if_exists(path)
+
+	assert_eq(removed.get("status"), "ok", str(removed.get("message", "")))
+	assert_true(
+		after.size() >= 4 and after[0] == 0xEF and after[1] == 0xBB and after[2] == 0xBF and after[3] == 0x0A,
+		"BOM and the leading newline must survive; got first bytes %s" % [Array(after.slice(0, 4))],
+	)
+	var text := after.get_string_from_utf8()
+	assert_false(text.contains("godot-ai"), "the entry must be removed even behind BOM + newline")
+	assert_true(text.contains("other"), "unrelated entries must survive")
+
+
 func test_json_strategy_status_reads_bom_prefixed_file() -> void:
 	## The BOM now reaches `original_text`, which makes the parse-copy strip
 	## load-bearing rather than dead code: JSON.parse rejects a leading U+FEFF.


### PR DESCRIPTION
## Summary

Remove silently deletes a UTF-8 BOM from the user's config file. Independent of #954 (which is read-only) and branched from `main`.

Godot's UTF-8 decoder consumes a leading `EF BB BF`. Verified on 4.7.2 — both `FileAccess.get_as_text()` and `PackedByteArray.get_string_from_utf8()` return a string whose first code point is `{` (123), and `begins_with("\uFEFF")` is `false`. So `original_text` never carried the BOM, and the token-preserving `remove()` spliced the entry out and wrote the file back without it.

Reproduced end to end through the real `McpJsonStrategy.remove()` on a two-entry config:

```
BEFORE first bytes : EF BB BF 7B 0A
REMOVE status      : ok / configuration removed
AFTER  first bytes : 7B 0A 09 22 6D
BOM SURVIVED       : false
```

The entry removal itself is correct; the BOM is collateral. That is a byte mutation outside the entry we were asked to touch, which is what the byte-survival contract exists to prevent.

## Fix

Read bytes, detect the marker on the raw buffer, restore `U+FEFF` when the decoder ate it. Two things fall out of that:

- **The existing parse-copy BOM strip stops being dead code.** `if parse_copy.begins_with("\uFEFF")` could never be true from a file read. With the BOM restored it is load-bearing — `JSON.parse` rejects a leading `U+FEFF` outright, so the two halves have to land together.
- **Emptiness is now measured on the BOM-stripped body.** Otherwise a BOM-only file would flip from "empty, seed it" to a parse error that refuses Configure.

The BOM skip in `_text_remove_server_entry` (the F-3-6 fix) was unreachable from a real file read for the same reason, and is live again.

## Scope

Configure still re-serializes through `JSON.stringify` and drops the BOM along with all other formatting — unchanged here, and consistent with that path already rewriting the whole file.

## Test plan

- `test_json_strategy_remove_preserves_utf8_bom` — asserts on **raw bytes** after `remove()`; decoding the result would hide the loss, since the decoder strips the BOM either way. Fails on `main`.
- `test_json_strategy_status_reads_bom_prefixed_file` — guards the now-load-bearing parse-copy strip.
- `test_json_strategy_treats_bom_only_file_as_empty` — guards the emptiness-on-body change.

Existing `test_text_remove_server_entry_skips_utf8_bom` passes a BOM-prefixed `String` directly — an input shape `_read_file_text` could not produce before this change. It becomes reachable rather than notional.

Run locally against Godot 4.7.2:

- `ruff check` — clean
- `script/ci-check-gdscript` — clean
- `script/ci-godot-tests` against a live editor — 2118/2155 passed, 0 failed, 37 skipped, 71/71 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of JSON configuration files containing a UTF-8 byte order mark (BOM).
  * Preserves BOM data when updating configuration files.
  * Correctly recognizes BOM-prefixed configurations as configured.
  * Treats BOM-only files as empty, allowing configuration setup to proceed normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->