### PR TITLE
fix: widen the editor WebSocket keepalive deadline and keep the server log in CI (#958)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,8 @@ jobs:
           tail -n 500 godot-editor.log || echo "(log not found)"
           echo "===== godot-import.log (last 200 lines) ====="
           tail -n 200 godot-import.log || echo "(log not found)"
+          echo "===== mcp-server.log (last 300 lines) ====="
+          tail -n 300 mcp-server.log || echo "(log not found)"
 
   unsupported-godot-floor:
     name: Unsupported Godot refusal / ${{ matrix.godot-version }}
@@ -665,6 +667,10 @@ jobs:
           tail -n 500 godot-editor.log || echo "(log not found)"
           echo "===== godot-import.log (last 200 lines) ====="
           tail -n 200 godot-import.log || echo "(log not found)"
+          ## The server's side of a bridge drop (#958): keepalive kills,
+          ## circuit-breaker trips, command timeouts, with timestamps.
+          echo "===== mcp-server.log (last 300 lines) ====="
+          tail -n 300 mcp-server.log || echo "(log not found)"
 
       - name: Upload capture diagnostics
         if: failure()
@@ -674,4 +680,5 @@ jobs:
           path: |
             capture-smoke-diag/
             godot-editor.log
+            mcp-server.log
           if-no-files-found: ignore

--- a/docs/test-run-transport-starvation-plan.md
+++ b/docs/test-run-transport-starvation-plan.md
@@ -17,7 +17,11 @@ Origin: Discord report (SloppyMayor, 2026-07-21/22, Godot 4.7.1 + plugin
 (`test_handler.gd:51` → `test_runner.gd:110-172`). The WebSocket is serviced
 only by `McpConnection._process` (`connection.gd:124-154`); the Python server
 uses `websockets` default heartbeats (20 s ping interval / 20 s timeout, no
-overrides at `websocket.py:140`). Any suite whose synchronous run exceeds
+overrides at `websocket.py:140`). *Since #958 the server pins these
+explicitly — `DEFAULT_KEEPALIVE_PING_INTERVAL_SECONDS` (20 s) and
+`DEFAULT_KEEPALIVE_PING_TIMEOUT_SECONDS` (60 s) in
+`transport/websocket.py` — so the starvation threshold below is now
+~20–80 s rather than ~20–40 s; the servicing design is unchanged.* Any suite whose synchronous run exceeds
 ~20–40 s starves the pong; the server closes the socket (1011), unregisters
 the session (`websocket.py:354-374`), and fails the in-flight `test_run`
 future with `ConnectionError`. The 120 s `TEST_RUN_TIMEOUT_SEC` never fires —

--- a/docs/test-run-transport-starvation-plan.md
+++ b/docs/test-run-transport-starvation-plan.md
@@ -16,13 +16,15 @@ Origin: Discord report (SloppyMayor, 2026-07-21/22, Godot 4.7.1 + plugin
 `run_tests` runs the whole suite synchronously on the editor main thread
 (`test_handler.gd:51` → `test_runner.gd:110-172`). The WebSocket is serviced
 only by `McpConnection._process` (`connection.gd:124-154`); the Python server
-uses `websockets` default heartbeats (20 s ping interval / 20 s timeout, no
-overrides at `websocket.py:140`). *Since #958 the server pins these
-explicitly — `DEFAULT_KEEPALIVE_PING_INTERVAL_SECONDS` (20 s) and
+pings every editor peer and closes the session when the pong is late. At the
+time of this plan the server inherited the `websockets` defaults (20 s ping
+interval / 20 s pong deadline, so a ~20–40 s window); since #958 it pins the
+keepalive explicitly — `DEFAULT_KEEPALIVE_PING_INTERVAL_SECONDS` (20 s) and
 `DEFAULT_KEEPALIVE_PING_TIMEOUT_SECONDS` (60 s) in
-`transport/websocket.py` — so the starvation threshold below is now
-~20–80 s rather than ~20–40 s; the servicing design is unchanged.* Any suite whose synchronous run exceeds
-~20–40 s starves the pong; the server closes the socket (1011), unregisters
+`transport/websocket.py` — so the window is now ~20–80 s. The numbers below
+were written against the historical 20/20 defaults; the servicing design is
+unchanged, only the threshold moved. Any suite whose synchronous run exceeds
+the window starves the pong; the server closes the socket (1011), unregisters
 the session (`websocket.py:354-374`), and fails the in-flight `test_run`
 future with `ConnectionError`. The 120 s `TEST_RUN_TIMEOUT_SEC` never fires —
 the heartbeat always wins. Threshold is duration, not count: our
@@ -154,7 +156,9 @@ success.
   checkpoints. **Best-effort, not a guarantee**: an atomic phase (test body,
   setup/teardown, one script load) that starts before the ceiling can
   overshoot it, and a hard main-thread block still dies by heartbeat
-  (~40 s) — which is the desired fail-fast for genuine hangs, and the
+  (~40 s under the historical 20/20 defaults, ~80 s with the 60 s pong
+  deadline pinned since #958) — which is the desired fail-fast for genuine
+  hangs, and the
   server fails the in-flight future immediately on that disconnect (#690).
   No cancel op in Phase 1 (nothing can be dispatched mid-run to deliver
   one); a client that cancels early leaves the plugin finishing a run
@@ -281,7 +285,8 @@ guidance actionable.
 - `run_tests` inside `batch_execute` is rejected with a clear error.
 - Per-test `duration_ms` in verbose results.
 - **Residual limitation:** any single non-serviced atomic phase longer than
-  the heartbeat window (~20–40 s) — a long test body, `suite_setup`/
+  the heartbeat window (~20–40 s historically, ~20–80 s since #958) — a long
+  test body, `suite_setup`/
   `suite_teardown`, `setup`/`teardown`, one huge script load, a pathological
   cleanup walk — can still starve the transport and end in a heartbeat
   disconnect (which doubles as the hang fail-fast). Servicing happens

--- a/plugin/addons/godot_ai/connection.gd
+++ b/plugin/addons/godot_ai/connection.gd
@@ -959,8 +959,9 @@ const _SERVICE_REJECT_LOG_EVERY := 100
 ## Service the WebSocket transport from inside a long synchronous handler
 ## (an "exclusive run" — the test runner). The editor main thread is
 ## blocked, so `_process` cannot poll; without this the server keepalive
-## (20s ping interval / 20s timeout) closes the session mid-run. See
-## docs/test-run-transport-starvation-plan.md.
+## (`DEFAULT_KEEPALIVE_PING_INTERVAL_SECONDS` / `_PING_TIMEOUT_SECONDS` in
+## `transport/websocket.py` — 20s interval, 60s pong deadline since #958)
+## closes the session mid-run. See docs/test-run-transport-starvation-plan.md.
 ##
 ## Contract — do NOT extend this method to dispatch:
 ## - `WebSocketPeer.poll()` has no heartbeat-only mode; it also buffers

--- a/script/ci-start-server
+++ b/script/ci-start-server
@@ -29,7 +29,17 @@ elif [ -z "${GODOT_AI_HTTP_CAPABILITY:-}" ] || [ -z "${GODOT_AI_WS_TOKEN:-}" ]; 
 fi
 export GODOT_AI_HTTP_CAPABILITY GODOT_AI_WS_TOKEN
 
-$PYTHON_CMD -m godot_ai --transport streamable-http --port $PORT &
+## Server output goes to mcp-server.log (mirroring godot-editor.log) so a
+## failed job keeps the server's side of the bridge — WebSocket keepalive
+## kills ("Session disconnected ... close code 1011"), circuit-breaker
+## trips, command timeouts. Before #958 the background process's output was
+## lost once this step ended, so the editor-side log was the only evidence
+## for a bridge drop and the server's view of the same window was gone.
+## Jobs that dump godot-editor.log on failure should tail this one too.
+MCP_SERVER_LOG="${MCP_SERVER_LOG:-mcp-server.log}"
+$PYTHON_CMD -m godot_ai --transport streamable-http --port $PORT \
+  > "$MCP_SERVER_LOG" 2>&1 &
+echo "Server output -> $MCP_SERVER_LOG"
 
 for i in $(seq 1 30); do
   if curl --fail --silent --output /dev/null --max-filesize 65536 \

--- a/src/godot_ai/transport/websocket.py
+++ b/src/godot_ai/transport/websocket.py
@@ -45,6 +45,23 @@ DEFAULT_HANDSHAKE_TIMEOUT_SECONDS = 5.0
 DEFAULT_MAX_HANDSHAKE_FRAME_BYTES = 8 * 1024
 DEFAULT_MAX_MESSAGE_BYTES = 4 * 1024 * 1024
 DEFAULT_MAX_DECODED_MESSAGES = 4
+## Keepalive: `websockets` pings every editor peer and closes the session
+## with 1011 "keepalive ping timeout" when the pong is late. The editor can
+## only answer a ping from `McpConnection._process` → `WebSocketPeer.poll()`
+## on the Godot main thread, so any stall longer than the deadline reaps a
+## session whose editor is merely busy: a long synchronous editor operation
+## the exclusive-run servicing does not cover, or a CPU-starved CI runner
+## where the editor and the game subprocess both software-render under
+## lavapipe (#958 — the pong went missing for >20s right after
+## `run_project`, and the plugin's v4 lifecycle treats the resulting drop as
+## terminal, so one late pong killed the whole smoke). The interval keeps
+## the library default so ping cadence is unchanged; only the tolerance for
+## a late pong is widened, to a budget that comfortably exceeds the smoke's
+## 45s session-loss grace. A stall past this is a genuinely hung editor. A
+## dead editor process still closes the socket immediately — this deadline
+## only bounds how long a *silent* peer keeps its session.
+DEFAULT_KEEPALIVE_PING_INTERVAL_SECONDS = 20.0
+DEFAULT_KEEPALIVE_PING_TIMEOUT_SECONDS = 60.0
 
 ## RFC 6455 reserves 4000-4999 for application-defined close codes; we use
 ## 4001 to flag a handshake rejected for duplicate session_id so a debugging
@@ -382,6 +399,10 @@ class GodotWebSocketServer:
                 max_queue=DEFAULT_MAX_DECODED_MESSAGES,
                 open_timeout=DEFAULT_OPEN_TIMEOUT_SECONDS,
                 close_timeout=1.0,
+                ## Explicit, not the library default: see the constants'
+                ## rationale (#958). Pinned by tests/unit/test_websocket_keepalive.py.
+                ping_interval=DEFAULT_KEEPALIVE_PING_INTERVAL_SECONDS,
+                ping_timeout=DEFAULT_KEEPALIVE_PING_TIMEOUT_SECONDS,
                 compression=None,
                 create_connection=partial(
                     _BoundedOpeningServerConnection,

--- a/tests/unit/test_websocket_keepalive.py
+++ b/tests/unit/test_websocket_keepalive.py
@@ -1,0 +1,69 @@
+"""GodotWebSocketServer.start() keepalive (ping/pong) configuration.
+
+The editor answers server pings only from `McpConnection._process` →
+`WebSocketPeer.poll()` on the Godot main thread. Any stall longer than the
+pong deadline — a long synchronous editor operation, or a CPU-starved CI
+runner where the editor and the game subprocess both software-render under
+lavapipe (#958) — makes `websockets` close the session with 1011
+"keepalive ping timeout". These tests pin the deadline the server hands to
+`websockets.serve` so it cannot silently fall back to the library default.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import patch
+
+from godot_ai.sessions.registry import SessionRegistry
+from godot_ai.transport import websocket as websocket_module
+from godot_ai.transport.websocket import (
+    DEFAULT_KEEPALIVE_PING_INTERVAL_SECONDS,
+    DEFAULT_KEEPALIVE_PING_TIMEOUT_SECONDS,
+    GodotWebSocketServer,
+)
+
+
+async def _capture_serve_kwargs() -> dict[str, Any]:
+    """Run start() against a fake `websockets.serve` and return its kwargs."""
+    captured: dict[str, Any] = {}
+
+    @asynccontextmanager
+    async def _fake_serve(*_args: Any, **kwargs: Any):
+        captured.update(kwargs)
+        yield object()
+        ## Let start() reach `await asyncio.Future()`; the caller cancels it.
+
+    server = GodotWebSocketServer(SessionRegistry(), port=19998)
+    with patch("godot_ai.transport.websocket.websockets.serve", _fake_serve):
+        task = asyncio.create_task(server.start())
+        await server.wait_until_ready()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+    return captured
+
+
+async def test_start_passes_explicit_keepalive_settings() -> None:
+    kwargs = await _capture_serve_kwargs()
+    assert kwargs["ping_interval"] == DEFAULT_KEEPALIVE_PING_INTERVAL_SECONDS
+    assert kwargs["ping_timeout"] == DEFAULT_KEEPALIVE_PING_TIMEOUT_SECONDS
+
+
+def test_keepalive_deadline_tolerates_a_long_editor_stall() -> None:
+    ## #958: the CI editor missed a pong for >20s while the game subprocess
+    ## booted under lavapipe, and the smoke's 45s session-loss grace could
+    ## not save a session the server had already reaped. The pong deadline
+    ## must comfortably exceed that grace so a bounded stall is survivable;
+    ## a stall past this budget is a genuinely hung editor.
+    assert DEFAULT_KEEPALIVE_PING_TIMEOUT_SECONDS >= 60.0
+    ## Pings stay frequent so `last_seen` / latency observations keep their
+    ## cadence — only the tolerance for a late pong is widened.
+    assert DEFAULT_KEEPALIVE_PING_INTERVAL_SECONDS <= 20.0
+    ## Sanity: the constants are what serve() actually receives, not shadows.
+    assert websocket_module.DEFAULT_KEEPALIVE_PING_TIMEOUT_SECONDS > (
+        websocket_module.DEFAULT_KEEPALIVE_PING_INTERVAL_SECONDS
+    )


### PR DESCRIPTION
Fixes #958.

## What happened in the failing run

From the job log and the `capture-smoke-diag-Windows` artifact of the run reported in #958 (lavapipe engaged, editor pid alive at cleanup):

1. The editor's plugin log ends with `connection lost after being open for 43.2s (code 1011, reason keepalive ping timeout ...); reconnecting` — the **server** closed the session. `websockets` sends that 1011 when a pong is late: with the library defaults the server pings 20 s after connect and gives up 20 s later, which lands exactly at the observed ~40 s (plus one editor frame to notice).
2. That 20 s window is the one right after `run_project`: the plugin had received it, spawned the game, seen `play_state_changed -> playing`, and the game's `mcp:hello` arrived — all before the drop. The editor can only answer a ping from `McpConnection._process` → `WebSocketPeer.poll()` on the main thread, so it went ≥20 s without a frame that polled the socket.
3. It was not only the editor: the smoke's `project_run` call (server-side deadline 8 s) did not return until after the session was gone, and the first `editor_state` poll was already `PLUGIN_DISCONNECTED`. The runner as a whole was starved while the game subprocess booted under lavapipe alongside the editor — the same environment where `list_autoloads` routinely needs 4–6 s (it hits the 5 s budget in passing runs too, so that early timeout is not a precursor).
4. After the drop the plugin never re-dialed. Since #943, `server_lifecycle.transport_lost()` moves READY → BLOCKED(`endpoint_lost`) with no recovery loop and `revoke_transport()` stops `_process` (covered by `test_authenticated_endpoint_loss_blocks_without_recovery_loop`), so a still-healthy server is never reconnected until someone clicks Restart in the dock. The silent 48 s after "reconnecting" and the missing block notice are both explained by that (the once-only notice was already spent on the startup probe line). The smoke's 45 s session-loss grace therefore could not help.

## Changes

- `src/godot_ai/transport/websocket.py`: pass `ping_interval=20s` / `ping_timeout=60s` to `websockets.serve` explicitly (new `DEFAULT_KEEPALIVE_*` constants carry the rationale). Ping cadence is unchanged; only the tolerance for a late pong widens, to a budget that comfortably exceeds the smoke's grace window. A dead editor process still closes the socket immediately — this only bounds how long a *silent* peer keeps its session. Pinned by `tests/unit/test_websocket_keepalive.py`.
- `script/ci-start-server`: the server's output now goes to `mcp-server.log` (mirroring `godot-editor.log`). The smoke and godot-tests jobs tail it on failure and the smoke uploads it with the diag artifact. Today the background process's output is lost the moment the start step ends, so the server's side of a bridge drop (its `Session disconnected ... close code 1011` line with a timestamp, circuit-breaker trips, command timeouts) never reaches the log — the next recurrence will carry it.
- `connection.gd` and the test-run starvation plan doc: comments name the constants instead of the old hardcoded 20 s / 20 s.

## Verification

- `tests/unit` + `tests/integration/test_websocket.py`: 1958 passed, 43 skipped (one pre-existing Windows MAX_PATH failure in `test_v4_release.py` deselected locally; unrelated).
- `ruff check` / `ruff format --check` clean on the touched Python files; `bash -n` on the script; the workflow YAML parses.
- The GDScript change is a comment only.

## Follow-up worth a decision (not changed here)

The v4 lifecycle's "endpoint lost → BLOCKED forever" means any single WebSocket drop — a keepalive miss during a long synchronous editor operation, a server restart, a transient socket error — leaves the plugin disconnected until a manual Restart, where pre-v4 the `RECONNECT_DELAYS` loop re-dialed within a second. That was an explicit design choice in #943, so this PR does not touch it, but a *bounded* re-probe on `endpoint_lost` (re-running PROBE, which re-proves the server's capability, a few times with backoff before settling in BLOCKED) would keep the authority model intact and would have recovered this run on its own. Happy to open that as a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved WebSocket connection reliability by explicitly configuring keepalive pings and allowing up to 60 seconds for pong responses.
  - Reduced unexpected session losses during editor stalls or resource-constrained environments.

- **Diagnostics**
  - Server output is now captured in a configurable log file.
  - Failure reports include recent server logs alongside existing diagnostic information.

- **Documentation**
  - Updated transport behavior and troubleshooting guidance to reflect the current keepalive timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->