### PR TITLE
ci: keep pytest tmp ancestors short and build the candidate pair once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,13 +51,24 @@ jobs:
 
       # Keep these conditions complementary so every matrix cell runs pytest
       # exactly once: with coverage on the Codecov cell, plain everywhere else.
+      #
+      # --basetemp keeps every tmp_path under the runner's short temp directory
+      # (D:\a\_temp on Windows) instead of the deep per-user Temp tree. The
+      # updater canonicalizes paths by enumerating each ancestor directory on
+      # Windows and macOS, so ancestor fan-out is a per-call cost for the
+      # transaction, updater and qualification suites; together with the
+      # failed-only tmp_path retention in pyproject.toml this keeps that walk
+      # short for the whole run. --durations reports the slowest tests so a
+      # regression in a single test is visible in the hosted log.
       - name: Run tests
         if: matrix.os != 'ubuntu-latest' || matrix.python-version != '3.13'
-        run: pytest -v
+        run: pytest -v --durations=25 --basetemp="${{ runner.temp }}/pytest-basetemp"
 
       - name: Run tests with coverage
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
-        run: pytest --cov=godot_ai --cov-report=xml -v
+        run: >-
+          pytest --cov=godot_ai --cov-report=xml -v --durations=25
+          --basetemp="${{ runner.temp }}/pytest-basetemp"
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
@@ -200,10 +211,21 @@ jobs:
         shell: bash
         timeout-minutes: 12
         run: |
+          # Same short --basetemp as the Python matrix (see that job); the
+          # editor projects these tests build are hashed through the same
+          # ancestor-enumerating canonicalization. --durations=0 lists every
+          # test's time so per-platform editor costs are visible in the log.
+          pytest_args=(-v -s --durations=0 --basetemp="${RUNNER_TEMP}/pytest-basetemp"
+            tests/integration/test_godot_editor_restart.py
+            tests/integration/test_migration_bridge_failures.py
+            tests/integration/test_self_update_upgrade_paths.py
+            tests/integration/test_qualification_https.py
+            tests/integration/test_plugin_reload_persistence.py
+            tests/integration/test_runtime_qualification_driver.py)
           if [ "${{ runner.os }}" = "Linux" ]; then
-            xvfb-run -a env GODOT_BIN=godot pytest -v -s tests/integration/test_godot_editor_restart.py tests/integration/test_migration_bridge_failures.py tests/integration/test_self_update_upgrade_paths.py tests/integration/test_qualification_https.py tests/integration/test_plugin_reload_persistence.py tests/integration/test_runtime_qualification_driver.py
+            xvfb-run -a env GODOT_BIN=godot pytest "${pytest_args[@]}"
           else
-            GODOT_BIN=godot pytest -v -s tests/integration/test_godot_editor_restart.py tests/integration/test_migration_bridge_failures.py tests/integration/test_self_update_upgrade_paths.py tests/integration/test_qualification_https.py tests/integration/test_plugin_reload_persistence.py tests/integration/test_runtime_qualification_driver.py
+            GODOT_BIN=godot pytest "${pytest_args[@]}"
           fi
 
       - name: Start MCP server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,16 @@ where = ["src"]
 testpaths = ["tests"]
 asyncio_mode = "auto"
 pythonpath = ["src"]
+# Remove each passed test's tmp_path at teardown; failed tests keep theirs.
+# update_transaction canonicalizes every path it touches by enumerating each
+# ancestor directory on Windows and macOS (Linux never scans), so a basetemp
+# that accumulates one entry per test makes every later transaction, updater
+# and qualification test slower than the one before it. Measured on the
+# hosted Windows runner: a 0.55s median per transaction test against 0.05s on
+# Linux, and a 2s stage-live barrier missed outright once the run directory
+# held roughly two thousand entries. CI also points --basetemp at the short
+# runner temp directory for the same reason.
+tmp_path_retention_policy = "failed"
 
 [tool.ruff]
 target-version = "py311"

--- a/tests/unit/test_release_support.py
+++ b/tests/unit/test_release_support.py
@@ -35,13 +35,46 @@ def distribution(root: Path, version: str) -> None:
         archive.addfile(info, io.BytesIO(metadata))
 
 
-@pytest.fixture
-def pair(tmp_path, signing_key, monkeypatch):
+def _trust_fixture_key(patch: pytest.MonkeyPatch, public: str) -> None:
+    patch.setattr(v4_release, "PUBLIC_KEY_PEM", public)
+    patch.setattr(v4_release._verify, "PUBLIC_KEY_PEM", public)
+    patch.setattr(support, "verifier", lambda: v4_release._verify)
+
+
+@pytest.fixture(scope="module")
+def pair_template(tmp_path_factory, signing_key):
+    """Build the signed A/B candidate pair once per module.
+
+    Building a pair runs about thirty git and openssl subprocesses (two
+    commits, two tags, two release sets, two capsules). Process spawn is cheap
+    on Linux but each spawn costs well over 100 ms on the hosted Windows
+    runner, which made this fixture 4-13 s per test there against 0.3 s on
+    Linux. Every test still receives its own private copy from ``pair`` and
+    mutates only that copy, so per-test isolation is unchanged; only the
+    construction is shared.
+    """
     key, public = signing_key
-    monkeypatch.setattr(v4_release, "PUBLIC_KEY_PEM", public)
-    monkeypatch.setattr(v4_release._verify, "PUBLIC_KEY_PEM", public)
-    monkeypatch.setattr(support, "verifier", lambda: v4_release._verify)
-    repo, _ = _repository(tmp_path, public)
+    root = tmp_path_factory.mktemp("promotion-pair")
+    with pytest.MonkeyPatch.context() as patch:
+        _trust_fixture_key(patch, public)
+        repo, candidates, a, b = _build_pair(root, key, public)
+    return repo, candidates, a, b
+
+
+@pytest.fixture
+def pair(tmp_path, signing_key, monkeypatch, pair_template):
+    _, public = signing_key
+    _trust_fixture_key(monkeypatch, public)
+    template_repo, template_candidates, a, b = pair_template
+    repo = tmp_path / "repo"
+    candidates = tmp_path / "candidates"
+    shutil.copytree(template_repo, repo, symlinks=True)
+    shutil.copytree(template_candidates, candidates, symlinks=True)
+    return repo, candidates, a, b
+
+
+def _build_pair(root: Path, key: Path, public: str) -> tuple[Path, Path, str, str]:
+    repo, _ = _repository(root, public)
     readme = repo / "plugin/addons/godot_ai/README.md"
     readme.write_text("runtime-inert documentation\n")
     # Source pair checks use the production canonical version line format.
@@ -60,20 +93,20 @@ def pair(tmp_path, signing_key, monkeypatch):
     _run("git", "commit", "-qm", "qualification B", cwd=repo)
     b = _run("git", "rev-parse", "HEAD", cwd=repo).decode().strip()
     _run("git", "tag", "v4.0.1", cwd=repo)
-    candidates = tmp_path / "candidates"
+    candidates = root / "candidates"
     for name, source, version in (("a", a, "4.0.0"), ("b", b, "4.0.1")):
-        root = candidates / name
+        candidate = candidates / name
         _run("git", "switch", "--detach", source, cwd=repo)
         v4_release.build_release_set(
-            repo, root / "release", key, "stable", "v" + version, version, source
+            repo, candidate / "release", key, "stable", "v" + version, version, source
         )
-        distribution(root / "dist", version)
+        distribution(candidate / "dist", version)
         for file in support.VERIFIER_PATHS:
-            target = root / "verifier" / file
+            target = candidate / "verifier" / file
             target.parent.mkdir(parents=True, exist_ok=True)
             shutil.copyfile(support.ROOT / file, target)
-        record = support.candidate_record(root, name, source, version, a, "123", 1)
-        (root / "evidence.json").write_bytes(support.canonical(record))
+        record = support.candidate_record(candidate, name, source, version, a, "123", 1)
+        (candidate / "evidence.json").write_bytes(support.canonical(record))
     return repo, candidates, a, b
 
 


### PR DESCRIPTION
Targets `codex/v4-release-promotion` (#949): every test this touches exists only on that branch, and it is the branch whose Windows matrix runs 10+ minutes.

## What was slow, measured from the hosted logs

Per-test wall time recovered from the timestamped `-v` output of run [33789951696](https://github.com/hi-godot/godot-ai/actions/runs/33789951696) (same shape in [33791240304](https://github.com/hi-godot/godot-ai/actions/runs/33791240304)):

| `Run tests` step | Linux | macOS | Windows |
|---|---|---|---|
| whole step | 212–292 s | 452–465 s | 622–696 s |
| `tests/unit/test_release_support.py` | 12 s | 54 s | 185 s |
| `tests/unit/test_update_transaction.py` | 36 s | 170 s | 180 s |
| `tests/integration/test_attach_bridge.py` | 48 s | 46 s | 60 s |
| `test_clean_major_installer_cli_retains_exact_pre_v4_tree` (Python job) | 2 s | 1 s | 25 s |

Two files account for roughly 320 s of the ~400 s Windows excess.

## Root causes

**1. `update_transaction._canonical_path` enumerates every ancestor directory.** On Windows and macOS it recovers the on-disk spelling of each path component with `os.scandir` over the whole parent directory (macOS additionally `lstat`s every entry). Linux never scans. Under pytest one ancestor is the run's basetemp, which gains one entry per test, so by the time `test_update_transaction.py` runs the directory holds ~2,000 entries and each of the module's ~86 canonicalizing call sites pays for all of them. That is the 0.55 s median per transaction test on Windows against 0.05 s on Linux, and it is why the second run's Windows 3.13 cell missed the 2 s stage-live barrier in `test_write_readiness_rejects_changed_live_tree`: the actor could not reach its second journal commit in time. A local cProfile of eight crash-state tests put 11.0 s of 12.5 s in `_canonical_path`. The production code is untouched here; the fix keeps the ancestors short.

**2. The `pair` fixture in `test_release_support.py` rebuilt the signed A/B candidate pair for every test**: two commits, two tags, two release sets and two capsules, about thirty `git`/`openssl` spawns. Spawn cost is what differs by platform: 0.26 s per build on Linux, 1.2 s on macOS, 3.7–13.4 s on Windows, times ~25 tests.

## Changes

- `pyproject.toml`: `tmp_path_retention_policy = "failed"`. Passed tests' `tmp_path` directories are removed at teardown; failed tests keep theirs for inspection. The basetemp no longer grows across the run.
- `.github/workflows/ci.yml`: the Python matrix and the Godot self-update step pass `--basetemp="${{ runner.temp }}/pytest-basetemp"` so every `tmp_path` sits under the runner's short temp tree (`D:\a\_temp` on Windows rather than `C:\Users\runneradmin\AppData\Local\Temp\pytest-of-runneradmin\pytest-0`), and `--durations=25` (`--durations=0` for the 39-test Godot step) so the slowest tests are printed in the hosted log. Passed on the command line, not through `PYTEST_ADDOPTS`, because `release_qualification.py` runs a nested pytest that must not inherit and wipe the outer basetemp.
- `tests/unit/test_release_support.py`: the pair is built once per module (`pair_template`, with the fixture key trusted for the build only) and `pair` gives each test its own `copytree` copy inside its `tmp_path`. Every test still mutates only its private copy; assertions, mutations, and the exact-candidate checks are unchanged.

Nothing was skipped, no timeout was raised, no test floor was lowered, and no assertion was weakened.

## Local measurement (macOS, Python 3.13)

| | before | after |
|---|---|---|
| `test_update_transaction.py` | 332 s | 127 s |
| `test_release_support.py` | 61 s | ~12 s (109 tests inside a 26 s run of 344) |

Full suite locally after the change: see the validation section. The CI run on this PR gives the Windows numbers.

## Validation

- Full Python suite locally under the new configuration (macOS, 3.13): 2676 passed, 36 skipped, 1 pre-existing Starlette deprecation warning, 323 s.
- `ruff check` at the CI scope, `ruff format --check` on the edited test, `actionlint` on `ci.yml`, `git diff --check`, and `script/architecture_simplification_gates.py --check` all pass.
- No plugin/GDScript code changed, so no live-editor `test_run` was needed; the Godot jobs on this PR exercise the changed self-update step on all three platforms.

## Remaining Windows overhead this PR does not touch

- **Godot tests / Windows** (`Self-update forward upgrade regression` 573 s vs 180 s Linux; `Reload smoke test` 154 s vs 25 s). Every editor phase that starts, adopts, or stops a server proves process identity through `port_resolver.gd`'s PowerShell `Get-CimInstance` helpers (`process_commandline`, `process_parent`, `process_fingerprint`), each a fresh `powershell.exe` spawn that the code itself measures at ~1.2 s; a managed launch proof runs at least five of them, twice. Batching the three projections into one query per proof, and taking one process-table snapshot per proof rather than one spawn per hop, would remove most of that without changing what is proven. That is production lifecycle code and deserves its own PR with the GDScript tests updated.
- `script/ci-godot-tests` still has a fixed `sleep 8` before opening `main.tscn` on every platform; replacing it needs a read-only scan-completion signal, which the plugin does not expose today.
- `test_slow_downstream_tool_has_no_bridge_read_deadline` deliberately waits ~35 s on every platform to prove the bridge outlives the 30 s MCP default; that is the assertion, so it stays.
- Python process start and `git`/`openssl` spawn are simply slower on Windows; what remains after this PR is that per-spawn cost in tests that legitimately exercise real subprocesses.
- pytest removes passed `tmp_path` directories with `ignore_errors=True`, so directories holding read-only git objects (the `test_v4_release.py` and `test_release_support.py` repositories) may linger on Windows. That bounds the basetemp at a couple of hundred entries instead of ~2,400, which is enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
