### PR TITLE
Surface cross-worktree claims at session start

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,10 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          },
+          {
+            "type": "command",
+            "command": "knos status 2>/dev/null || true"
           }
         ]
       }

--- a/.knos/decisions.md
+++ b/.knos/decisions.md
@@ -1,0 +1,25 @@
+# Decisions and current work
+
+<!-- Written by `knos export`. Commit this file. -->
+
+A second clone reads this on its first question — it is one of the decision
+records knos looks for. Nothing here is private: secrets and private paths
+never reach it.
+
+
+## Decisions
+
+- **AGENTS.md is the source of truth** — Project structure, workflow, tool changes, testing and worktree safety live in `AGENTS.md`. Update it first when changing general operating guidance.  _(.claude/CLAUDE.md)_
+- **no tokenless fallback** — WebSocket stays loopback-only and HTTP localhost-first, but neither relies on loopback as authentication. Never add tokenless, bare-URL, or legacy-handshake fallback.  _(AGENTS.md, Architecture)_
+- **handshake fails closed** — Missing or wrong capabilities, protocol-1 frames, duplicate keys and downgrade attempts all fail closed.  _(AGENTS.md, Architecture)_
+- **writes check readiness first** — Python write handlers must `await require_writable_async()`, and every new plugin response builder stamps the envelope-level `readiness` field. `EDITOR_NOT_READY` is frozen as a top-level code; never promote a `data.sub_code` into `error.code`.  _(AGENTS.md, Architecture)_
+- **middleware order is load-bearing** — `src/godot_ai/middleware/` registration order matters; see Key conventions before reordering.  _(AGENTS.md, Project structure)_
+- **skills must be named SKILL.md** — Discovery is case-sensitive and a lowercase `skill.md` is silently never loaded.  _(.claude/CLAUDE.md)_
+- **verify the active worktree before editing plugin code** — Claude Code sessions may run in `.claude/worktrees/<name>`; check the active worktree and the connected Godot `test_project/` first.  _(.claude/CLAUDE.md)_
+
+## Being worked on right now
+
+_Nothing claimed._
+
+---
+<sub>knos export. Claims lapse after 30 minutes.</sub>

--- a/.knos/decisions.md
+++ b/.knos/decisions.md
@@ -2,6 +2,14 @@
 
 <!-- Written by `knos export`. Commit this file. -->
 
+<!--
+Reading this file needs nothing installed: it is plain markdown, and a fresh
+clone picks it up as-is. The live claim/withhold server is a separate, optional
+step - `pip install knos` (Python 3.10+), which the MCP entry launches as
+`python -m knos.mcp`. Without it, everything below still reads normally.
+-->
+
+
 A second clone reads this on its first question — it is one of the decision
 records knos looks for. Nothing here is private: secrets and private paths
 never reach it.


### PR DESCRIPTION
`.claude/CLAUDE.md` already tells a session to *"verify the active worktree and connected Godot `test_project/` before editing or testing plugin code."* That check is per-session and asks the agent to look. It has no way to know a session in a sibling `.claude/worktrees/<name>` is mid-change on the same handler.

**What's in the PR**

- `.knos/decisions.md` — the standing rules from `AGENTS.md` and `.claude/CLAUDE.md`, in a file a fresh clone reads without installing anything. Every line cites the file it came from. All worktrees of one repo resolve to the same record, because it keys on `git rev-parse --git-common-dir` rather than `--show-toplevel`.
- One line in `.claude/settings.json` — a second `SessionStart` hook, after the existing `session-start.sh`, printing who is working on what. `|| true` so a machine without knos installed loses nothing and the session still starts.

**The worktree point is the reason this is worth anything here.** `--show-toplevel` returns the worktree root, so anything keyed on it treats every `.claude/worktrees/<name>` as a separate project. `--git-common-dir` is shared across all of them. That is the difference between a per-worktree record and a per-repo one.

**Disclosure:** I wrote Knos. The record is seeded from your own docs rather than mine so it is checkable rather than promotional. Close it if you'd rather not carry a third-party hook — the `.knos/decisions.md` half works with no hook at all, since it is plain markdown in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a project decisions record covering development guidance, security expectations, protocol behavior, middleware ordering, skill naming, and worktree verification.
  * Clarified that recorded decisions exclude secrets and private paths, can be read without additional setup, and that live claim services are optional.
  * Documented that active work items are empty and recorded claims expire after 30 minutes.

* **Chores**
  * Added a session-start status check to display project state when a session begins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->