### PR TITLE
fix: coerce numeric strings to float across MCP value handlers (#964)

### DIFF
--- a/plugin/addons/godot_ai/handlers/animation_values.gd
+++ b/plugin/addons/godot_ai/handlers/animation_values.gd
@@ -374,8 +374,12 @@ static func coerce_for_type(value: Variant, prop_type: int, prop_name: String) -
 				return {"ok": v3}
 			return {"error": "Cannot coerce value to Vector3 for property '%s' (expected {x,y,z}, [x,y,z], or Vector3)" % prop_name}
 		TYPE_FLOAT:
-			if value is int or value is float:
-				return {"ok": float(value)}
+			## Canonical scalar parser (#964): int/float passthrough plus
+			## strictly-numeric strings. Null falls through to the generic
+			## passthrough below, matching the old behavior for garbage.
+			var parsed: Variant = McpJsonValues.parse_float(value)
+			if parsed != null:
+				return {"ok": parsed}
 		TYPE_INT:
 			if value is float or value is int:
 				return {"ok": int(value)}

--- a/plugin/addons/godot_ai/handlers/audio_handler.gd
+++ b/plugin/addons/godot_ai/handlers/audio_handler.gd
@@ -344,14 +344,16 @@ func _resolve_player(player_path: String) -> Dictionary:
 	return {"player": node}
 
 
-## Coerce a playback param value to the expected type. int→float is allowed
-## so JSON integers pass through; everything else requires the exact type.
+## Coerce a playback param value to the expected type. int→float and
+## strictly-numeric strings are allowed so JSON integers and stringified
+## floats (#964) pass through; everything else requires the exact type.
 ## Returns the coerced value, or null on type mismatch.
 static func _coerce_playback_value(value: Variant, expected_type: int) -> Variant:
 	match expected_type:
 		TYPE_FLOAT:
-			if value is float or value is int:
-				return float(value)
+			var parsed: Variant = McpJsonValues.parse_float(value)
+			if parsed != null:
+				return parsed
 		TYPE_BOOL:
 			if value is bool:
 				return value

--- a/plugin/addons/godot_ai/handlers/camera_values.gd
+++ b/plugin/addons/godot_ai/handlers/camera_values.gd
@@ -110,10 +110,10 @@ static func coerce(property: String, value: Variant, target_type: int) -> Dictio
 				return {"ok": true, "value": int(value)}
 			return {"ok": false, "error": "Expected int for %s" % property}
 		TYPE_FLOAT:
-			if value is float:
-				return {"ok": true, "value": value}
-			if value is int:
-				return {"ok": true, "value": float(value)}
+			## Canonical scalar parser (#964): numeric strings coerce too.
+			var parsed: Variant = McpJsonValues.parse_float(value)
+			if parsed != null:
+				return {"ok": true, "value": parsed}
 			return {"ok": false, "error": "Expected number for %s" % property}
 		TYPE_STRING:
 			return {"ok": true, "value": String(value)}

--- a/plugin/addons/godot_ai/handlers/material_values.gd
+++ b/plugin/addons/godot_ai/handlers/material_values.gd
@@ -153,10 +153,10 @@ static func coerce_material_value(property: String, value: Variant, target_type:
 				return {"ok": true, "value": int(value)}
 			return {"ok": false, "error": "Expected int for %s" % property}
 		TYPE_FLOAT:
-			if value is float:
-				return {"ok": true, "value": value}
-			if value is int:
-				return {"ok": true, "value": float(value)}
+			## Canonical scalar parser (#964): numeric strings coerce too.
+			var parsed: Variant = McpJsonValues.parse_float(value)
+			if parsed != null:
+				return {"ok": true, "value": parsed}
 			return {"ok": false, "error": "Expected number for %s" % property}
 		TYPE_OBJECT:
 			if value == null:

--- a/plugin/addons/godot_ai/handlers/node_handler.gd
+++ b/plugin/addons/godot_ai/handlers/node_handler.gd
@@ -766,6 +766,14 @@ static func _coerce_value(value: Variant, target_type: int) -> Variant:
 		TYPE_FLOAT:
 			if value is int:
 				return float(value)
+			if value is String:
+				## #964: some MCP clients stringify float arguments ("4.0").
+				## Accept strictly-numeric strings; unparseable ones flow
+				## through unchanged so _check_coerced raises the typed
+				## WRONG_TYPE error instead of a silent zero/null write.
+				var parsed: Variant = McpJsonValues.parse_float(value)
+				if parsed != null:
+					return parsed
 		TYPE_STRING_NAME:
 			if value is String:
 				return StringName(value)

--- a/plugin/addons/godot_ai/utils/json_values.gd
+++ b/plugin/addons/godot_ai/utils/json_values.gd
@@ -88,5 +88,21 @@ static func parse_vector3(value: Variant) -> Variant:
 	return null
 
 
+## Parse a scalar float from the wire shapes agents send: float passthrough,
+## int (JSON integers land as numbers, not strings), and strictly-numeric
+## strings — some MCP clients stringify float arguments ("4.0"; #964).
+## Anything else returns null so callers turn it into their own typed
+## error; null input stays null (callers gate on the input's type first
+## when null is a meaningful "clear" value).
+static func parse_float(value: Variant) -> Variant:
+	if _is_number(value):
+		return float(value)
+	if value is String:
+		var text := value as String
+		if text.is_valid_float():
+			return text.to_float()
+	return null
+
+
 static func _is_number(v: Variant) -> bool:
 	return v is int or v is float

--- a/test_project/tests/test_json_values.gd
+++ b/test_project/tests/test_json_values.gd
@@ -81,6 +81,32 @@ func test_vector3_rejects_wrong_shapes() -> void:
 	assert_eq(McpJsonValues.parse_vector3({"x": 1, "y": 2, "z": "3"}), null)
 
 
+# ----- parse_float -----
+
+func test_float_passthrough_int_and_numeric_string() -> void:
+	## #964: some MCP clients stringify float arguments; the canonical
+	## scalar parser accepts them alongside ints and floats.
+	assert_eq(McpJsonValues.parse_float(4.5), 4.5)
+	assert_eq(McpJsonValues.parse_float(4), 4.0)
+	assert_true(McpJsonValues.parse_float(4) is float, "int input must land as float, not int")
+	assert_eq(McpJsonValues.parse_float("4.0"), 4.0)
+	assert_eq(McpJsonValues.parse_float("4"), 4.0)
+	assert_eq(McpJsonValues.parse_float("-2.5"), -2.5)
+	assert_eq(McpJsonValues.parse_float("1e2"), 100.0)
+
+
+func test_float_rejects_non_numeric_and_wrong_shapes() -> void:
+	## Strict contract: garbage returns null (never a silent 0.0) so
+	## callers turn it into their own typed error.
+	assert_eq(McpJsonValues.parse_float("4.0.1"), null)
+	assert_eq(McpJsonValues.parse_float("not-a-number"), null)
+	assert_eq(McpJsonValues.parse_float(""), null)
+	assert_eq(McpJsonValues.parse_float(true), null)
+	assert_eq(McpJsonValues.parse_float([4.0]), null)
+	assert_eq(McpJsonValues.parse_float({"x": 4}), null)
+	assert_eq(McpJsonValues.parse_float(null), null)
+
+
 # ----- delegation spot checks: the handler copies now share one parser -----
 
 func test_material_theme_parsers_accept_arrays() -> void:
@@ -109,3 +135,22 @@ func test_animation_serialize_value_round_trips_quaternion() -> void:
 	assert_true(serialized is Dictionary, "Quaternion must serialize to a dict, not str()")
 	assert_true(abs(float(serialized.x) - 0.1) < 0.0001)
 	assert_true(abs(float(serialized.w) - 0.9273618) < 0.0001)
+
+
+func test_handler_float_coercers_accept_numeric_strings() -> void:
+	## #964 delegation: every float-coercing handler accepts the same
+	## strictly-numeric strings through the canonical parser.
+	var cam_script := preload("res://addons/godot_ai/handlers/camera_values.gd")
+	var cam: Dictionary = cam_script.coerce("fov", "4.0", TYPE_FLOAT)
+	assert_true(cam.ok, "camera float coercion must accept numeric strings")
+	assert_eq(cam.value, 4.0)
+	var mat_script := preload("res://addons/godot_ai/handlers/material_values.gd")
+	var mat: Dictionary = mat_script.coerce_material_value("metallic", "0.5", TYPE_FLOAT)
+	assert_true(mat.ok, "material float coercion must accept numeric strings")
+	assert_eq(mat.value, 0.5)
+	var anim_script := preload("res://addons/godot_ai/handlers/animation_values.gd")
+	var anim: Dictionary = anim_script.coerce_for_type("2.5", TYPE_FLOAT, "value")
+	assert_eq(anim.get("ok"), 2.5, "animation float coercion must accept numeric strings")
+	var audio_script := preload("res://addons/godot_ai/handlers/audio_handler.gd")
+	var audio: Variant = audio_script._coerce_playback_value("0.8", TYPE_FLOAT)
+	assert_eq(audio, 0.8, "audio float coercion must accept numeric strings")

--- a/test_project/tests/test_node.gd
+++ b/test_project/tests/test_node.gd
@@ -561,6 +561,47 @@ func test_set_property_float() -> void:
 	assert_true(editor_undo(_undo_redo), "undo should succeed")
 
 
+func test_set_property_float_accepts_numeric_string() -> void:
+	## #964: MCP clients that stringify float arguments ("4.0") used to hit
+	## "Cannot write String to a float property". Strictly-numeric strings
+	## must coerce and land — read back the stored Variant, not just status.
+	var result := _handler.set_property({
+		"path": "/Main/Camera3D",
+		"property": "fov",
+		"value": "75.5",
+	})
+	assert_has_key(result, "data")
+	var cam := EditorInterface.get_edited_scene_root().get_node("Camera3D") as Camera3D
+	assert_eq(cam.fov, 75.5, "numeric string must land as the float value")
+	assert_true(editor_undo(_undo_redo), "undo should succeed")
+
+
+func test_set_property_float_rejects_non_numeric_string() -> void:
+	## #964 negative guard: only strictly-numeric strings coerce — garbage
+	## still returns the typed WRONG_TYPE error instead of silently
+	## writing 0.0 or null.
+	var cam := EditorInterface.get_edited_scene_root().get_node("Camera3D") as Camera3D
+	var original := cam.fov
+	var result := _handler.set_property({
+		"path": "/Main/Camera3D",
+		"property": "fov",
+		"value": "ninety",
+	})
+	assert_is_error(result, ErrorCodes.WRONG_TYPE)
+	assert_eq(cam.fov, original, "fov must be unchanged after a rejected coerce")
+
+
+func test_coerce_value_float_from_numeric_string() -> void:
+	## #964 regression at the coercer boundary: a valid string coerces to a
+	## real float; garbage flows through unchanged so _check_coerced flags it.
+	var coerced = NodeHandler._coerce_value("4.0", TYPE_FLOAT)
+	assert_true(coerced is float, "numeric string must coerce to float")
+	assert_eq(coerced, 4.0)
+	var garbage = NodeHandler._coerce_value("4.0.1", TYPE_FLOAT)
+	assert_true(garbage is String, "unparseable string must flow through unchanged")
+	assert_is_error(NodeHandler._check_coerced(garbage, TYPE_FLOAT), ErrorCodes.WRONG_TYPE)
+
+
 func test_set_property_missing_property() -> void:
 	var result := _handler.set_property({"path": "/Main/Camera3D", "value": 10})
 	assert_is_error(result, ErrorCodes.MISSING_REQUIRED_PARAM)


### PR DESCRIPTION
## Summary

Some MCP clients stringify float arguments — Claude Code sends `"fov": "4.0"` — and every float coercion branch rejected Strings outright: `node_set_property(..., "fov", "4.0")` returned `WRONG_TYPE: Cannot write String to a float property; godot-ai has no coercion for that type`. JSON integers pass (int→float coercion existed), so only stringified floats hit the wall. #964.

Typed-dictionary *keys* already accepted strictly-numeric strings via `is_valid_float()` (`node_handler.gd::_coerce_typed_dict_key`); this gives property values the same treatment through one canonical parser. Unparseable strings still flow through unchanged so `_check_coerced` raises the typed WRONG_TYPE error — no silent zero/null writes.

## What changes

- `utils/json_values.gd`: `McpJsonValues.parse_float` — float passthrough, int→float, strictly-numeric strings (`is_valid_float()` + `to_float()`); anything else returns null.
- `node_handler.gd::_coerce_value` TYPE_FLOAT: numeric strings coerce. `node_set_property`, resources, curves, textures, and typed-array elements inherit the fix through this path.
- `camera_values.coerce`, `material_values.coerce_material_value`, `animation_values.coerce_for_type`, `audio_handler._coerce_playback_value`: same routing, keeping scalars consistent with the #714 parser-family consolidation for vectors/colors.

This branch changes no Python.

## Not included

TYPE_INT string coercion (JSON ints arrive as numbers; the reported defect is floats) and packed-float-array string elements — both can follow separately if wanted.

## Test plan

New GDScript coverage:

- `test_json_values.gd`: `test_float_passthrough_int_and_numeric_string` (4.5/4/"4.0"/"4"/"-2.5"/"1e2"; int lands as float), `test_float_rejects_non_numeric_and_wrong_shapes` ("4.0.1"/"not-a-number"/""/true/[]/{}), `test_handler_float_coercers_accept_numeric_strings` (delegation across all four handler surfaces)
- `test_node.gd`: `test_set_property_float_accepts_numeric_string` (fov "75.5" read back from the node, undo clean), `test_set_property_float_rejects_non_numeric_string` ("ninety" → WRONG_TYPE, property unchanged), `test_coerce_value_float_from_numeric_string` (coercer boundary; garbage flows through for `_check_coerced`)

Run locally against Godot 4.7.2 (Windows):

- `godot --headless --path test_project --import` — no parse errors
- `script/ci-godot-tests` against a live headless editor — 2207/2245 passed, 0 failed, 38 skipped, 72/72 suites (floor 2050 met)
- targeted re-runs: node suite filtered to `numeric_string` → 3/3; `json_values` → 17/17
- live before/after: the same `node_set_property(fov, "4.0")` call that errors on released 3.2.4 returns `{value: 4.0, old_value: 90.0, undoable: true}` on this branch
- `ruff check src/ tests/` — clean
- `pytest` — 2160 passed, 54 skipped, with the 8 release/ci-harness modules excluded: they shell out to `C:\Windows\system32\bash.EXE`, which resolves to a distro-less WSL on this Windows host. All 21 failures + 107 errors in a full run trace to that one mechanism (reproduced with the fix stashed); none touch coercion or tooling modules.

Fixes #964
