### PR TITLE
qualification: make the real-editor runtime row pass end to end

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -27,7 +27,10 @@ those exact bytes:
   3.11, plus one Linux row at Godot 4.7.2, the newest supported engine: one
   real-editor exact A -> B hot update through the private HTTPS
   origin and the retained package index, with the engine executable checked
-  against its reviewed pin.
+  against its reviewed pin. The row launches the editor with explicit headless
+  display and audio drivers rather than `--headless`, because Godot forwards
+  only the explicit options when the update restarts the editor, and it waits
+  for that restarted editor to report the case's result.
 
 `complete-qualification` requires every one of those rows to be present,
 passed, and bound to the same candidate pair; the runtime row's required case

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -136,7 +136,10 @@ v4, the capsule triple stops being published and the fallback goes with it.
 `script/v4-release install` performs the same verify, stage, swap sequence from
 outside a running editor, for release qualification and for recovery. It uses
 the `cryptography` package for signature verification and is a development
-dependency only; the server package imports nothing from it at runtime.
+dependency only; the server package imports nothing from it at runtime. Into a
+project that has no add-on (how release qualification installs candidate A) it
+records an empty `from_version` and retains no backup; the first editor start
+still repins owned client entries to the installed version before serving.
 
 ## What this defends against
 

--- a/mcp-server.log
+++ b/mcp-server.log
@@ -1,0 +1,45 @@
+
+
+╭──────────────────────────────────────────────────────────────────────────────╮
+│                                                                              │
+│                                                                              │
+│                         ▄▀▀ ▄▀█ █▀▀ ▀█▀ █▀▄▀█ █▀▀ █▀█                        │
+│                         █▀  █▀█ ▄▄█  █  █ ▀ █ █▄▄ █▀▀                        │
+│                                                                              │
+│                                                                              │
+│                                                                              │
+│                                FastMCP 3.4.7                                 │
+│                            https://gofastmcp.com                             │
+│                                                                              │
+│                  🖥  Server:      Godot AI, 4.0.0                             │
+│                  🚀 Deploy free: https://horizon.prefect.io                  │
+│                                                                              │
+╰──────────────────────────────────────────────────────────────────────────────╯
+╭──────────────────────────────────────────────────────────────────────────────╮
+│                          🎉 Update available: 4.0.3                          │
+│                      Run: pip install --upgrade fastmcp                      │
+╰──────────────────────────────────────────────────────────────────────────────╯
+
+
+godot_ai.server | WebSocket server starting on port 9500
+godot_ai.transport.websocket | Starting WebSocket server on port 9500
+websockets.server | server listening on 127.0.0.1:9500
+[09/06/26 18:48:14] INFO     Starting MCP server 'Godot AI'     transport.py:361
+                             with transport 'streamable-http'                   
+                             on http://127.0.0.1:8000/mcp                       
+INFO:     Started server process [30171]
+INFO:     Waiting for application startup.
+mcp.server.streamable_http_manager | StreamableHTTP session manager started
+INFO:     Application startup complete.
+INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
+mcp.server.streamable_http_manager | Created new transport with session ID: 36cc4ada762d47a08bb6d732a6a41eb2
+mcp.server.lowlevel.server | Processing request of type CallToolRequest
+godot-ai-telemetry | Telemetry disabled
+websockets.server | connection open
+godot_ai.transport.websocket | Session connected: test-project@73eef376bad375d4 (pid=30176, Godot 4.7-beta3 (official), /Users/davidsarno/godot-ai/.claude/worktrees/lean-updater/test_project/)
+godot_ai.transport.websocket | Session test-pro: custom tools -> 0 registered (0 enabled)
+godot_ai.transport.websocket | Session test-pro opted this server out of telemetry for the rest of its life; restart it to re-enable.
+godot_ai.transport.websocket | Session test-pro: scene changed to res://main.tscn
+mcp.server.lowlevel.server | Processing request of type CallToolRequest
+mcp.server.lowlevel.server | Processing request of type CallToolRequest
+mcp.server.lowlevel.server | Processing request of type CallToolRequest

--- a/plugin/addons/godot_ai/utils/client_job_owner.gd
+++ b/plugin/addons/godot_ai/utils/client_job_owner.gd
@@ -216,10 +216,13 @@ func resume_after_quiesce() -> void:
 func begin_post_update_repin(
 	from_version: String, to_version: String, replace_owned_mismatches: bool = false
 ) -> Dictionary:
+	## `from_version` is empty when the closed-editor installer put v4 into a
+	## project that had no add-on: nothing was replaced, and owned client
+	## entries still repin to the installed version on this first start.
 	var replaced := from_version.strip_edges()
 	var installed := to_version.strip_edges()
-	if replaced.is_empty() or installed.is_empty():
-		return {"ok": false, "error": "Post-update versions are incomplete."}
+	if installed.is_empty():
+		return {"ok": false, "error": "Post-update target version is missing."}
 	if installed != ClientConfigurator.get_plugin_version():
 		return {"ok": false, "error": "Post-update target does not match the loaded plugin."}
 	if MutationLock.is_locked():

--- a/script/release_qualification.py
+++ b/script/release_qualification.py
@@ -35,6 +35,10 @@ RUNTIME_PYTHONS = ("3.11",)
 # One extra real-editor row at the newest supported engine on Linux, so a
 # 4.7.x regression is caught before publication without tripling the matrix.
 EXTRA_RUNTIME_ROWS = (("ubuntu-latest", "3.11", "4.7.2"),)
+# Every engine a runtime row may name: the pinned matrix plus the extra rows.
+RUNTIME_GODOT_VERSIONS = GODOT_BUILDS + tuple(
+    sorted({godot for _os, _python, godot in EXTRA_RUNTIME_ROWS} - set(GODOT_BUILDS))
+)
 
 # The release gate is the exact-artifact Python rows plus one real-editor
 # A -> B hot update per desktop OS. Failpoint/crash and storm matrices are

--- a/script/runtime_qualification.py
+++ b/script/runtime_qualification.py
@@ -37,6 +37,10 @@ MANIFEST_NAME = "release/godot-ai-v4-plugin.manifest.json"
 # The lean updater keeps its marker, lock and retained backup beside the live
 # tree; nothing of it lives outside the project (docs/self-update.md).
 UPDATE_STATE = "addons/.godot_ai_update"
+# EditorInterface.restart_editor forwards explicit display/audio driver options
+# but not the --headless shorthand (Godot 4.7). The update restarts the editor,
+# and the restarted editor must stay headless on a display-less runner.
+HEADLESS_EDITOR_ARGUMENTS = ("--display-driver", "headless", "--audio-driver", "Dummy")
 
 
 def current_python_version() -> str:
@@ -64,6 +68,24 @@ def _free_port(port: int) -> bool:
         except OSError:
             return False
     return True
+
+
+def _editor_command(executable: str | Path, project: Path) -> list[str]:
+    return [str(executable), *HEADLESS_EDITOR_ARGUMENTS, "--editor", "--path", str(project)]
+
+
+def _read_runtime_result(project: Path) -> dict[str, Any]:
+    """The driver writes its report with GDScript's JSON.stringify, not canonically."""
+    result = support.read_json(project / "runtime-result.json", canonical_required=False)
+    support.require(type(result) is dict, "runtime driver result is not an object")
+    return result
+
+
+def _wait_for_runtime_result(path: Path, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    while not path.is_file():
+        support.require(time.monotonic() < deadline, "the restarted editor did not report a result")
+        time.sleep(0.5)
 
 
 def _wait_for_ports_free(*ports: int, timeout: float = 15.0) -> None:
@@ -244,6 +266,8 @@ extends Node
 const VERSION_A := "@VERSION_A@"
 const VERSION_B := "@VERSION_B@"
 const DEADLINE_MS := 300000
+## The update restarts the editor; the restarted driver resumes from here.
+const PROGRESS_PATH := "res://runtime-progress.json"
 var deadline := 0
 var started := false
 var old_instance := ""
@@ -255,6 +279,11 @@ func _ready() -> void:
     if OS.get_environment("GODOT_AI_RUNTIME_QUALIFICATION_PARSE_ONLY") == "1":
         get_tree().quit(0)
         return
+    if FileAccess.file_exists(PROGRESS_PATH):
+        var progress: Variant = JSON.parse_string(FileAccess.get_file_as_string(PROGRESS_PATH))
+        if progress is Dictionary:
+            started = bool(progress.get("started", false))
+            old_instance = str(progress.get("old_instance", ""))
     deadline = Time.get_ticks_msec() + DEADLINE_MS
     set_process(true)
 
@@ -275,6 +304,12 @@ func _process(_delta: float) -> void:
             _finish(42, {"error": "candidate A client pin missing"})
             return
         started = true
+        var progress := FileAccess.open(PROGRESS_PATH, FileAccess.WRITE)
+        if progress == null:
+            _finish(43, {"error": "cannot record qualification progress"})
+            return
+        progress.store_string(JSON.stringify({"started": true, "old_instance": old_instance}))
+        progress.close()
         plugin.call("_on_dock_update_requested")
         return
     var config := ConfigFile.new()
@@ -586,7 +621,7 @@ def exact_a_to_b(
                     }
                 )
                 completed = subprocess.run(
-                    [str(executable), "--headless", "--editor", "--path", str(project)],
+                    _editor_command(executable, project),
                     cwd=work,
                     env=environment,
                     capture_output=True,
@@ -599,6 +634,9 @@ def exact_a_to_b(
                     (release.token, index),
                 )
                 support.require(completed.returncode == 0, "real Godot A-to-B update failed")
+                # The swap restarts the editor; the process above exits and
+                # the restarted editor finishes the case and writes the result.
+                _wait_for_runtime_result(project / "runtime-result.json", TIMEOUT_SECONDS)
                 support.require(
                     release.downloads
                     == [
@@ -609,7 +647,7 @@ def exact_a_to_b(
                     "update did not download exactly B's canonical signed triple",
                 )
             _wait_for_ports_free(HTTP_PORT, WS_PORT)
-        result = support.read_json(project / "runtime-result.json")
+        result = _read_runtime_result(project)
         support.require(result.get("status") == "passed", "runtime driver did not pass")
         live = project / "addons/godot_ai"
         support.require(
@@ -710,7 +748,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--candidates", type=Path, required=True)
     parser.add_argument("--python-row", type=Path, required=True)
     parser.add_argument("--godot", default=os.environ.get("GODOT_BIN", "godot"))
-    parser.add_argument("--godot-version", choices=qualification.GODOT_BUILDS, required=True)
+    parser.add_argument(
+        "--godot-version", choices=qualification.RUNTIME_GODOT_VERSIONS, required=True
+    )
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--os", choices=support.PLATFORMS, required=True)
     args = parser.parse_args(argv)

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -594,11 +594,29 @@ func test_manual_major_repin_marks_owned_mismatches_replaceable() -> void:
 	owner.free()
 
 
-func test_post_update_repin_rejects_missing_or_wrong_versions() -> void:
+func test_post_update_repin_rejects_a_missing_or_wrong_target() -> void:
 	var owner := _RepinRecordingOwner.new()
-	assert_false(bool(owner.begin_post_update_repin("", "4.0.0").get("ok", true)))
+	assert_false(bool(owner.begin_post_update_repin("3.1.2", "").get("ok", true)))
 	assert_false(bool(owner.begin_post_update_repin("3.1.2", "99.0.0").get("ok", true)))
 	assert_eq(owner._post_update_thread, null)
+	owner.free()
+
+
+## The closed-editor installer records no previous version when it installs
+## into a project without an add-on; that first start still repins.
+func test_fresh_install_repins_without_a_previous_version() -> void:
+	var owner := _RepinRecordingOwner.new()
+	var target := McpClientConfigurator.get_plugin_version()
+	var started := owner.begin_post_update_repin("", target, true)
+	assert_true(bool(started.get("ok", false)), str(started.get("error", "")))
+	while owner._post_update_thread != null and owner._post_update_thread.is_alive():
+		OS.delay_msec(1)
+	owner._poll_post_update_repin()
+	assert_eq(owner.calls, [{
+		"from": "",
+		"to": target,
+		"replace_owned_mismatches": true,
+	}])
 	owner.free()
 
 

--- a/tests/integration/_self_update_fixture.py
+++ b/tests/integration/_self_update_fixture.py
@@ -191,8 +191,14 @@ def prepare_clean_major_migration_project(
     target_version: str,
     http_port: int,
     ws_port: int,
+    fresh: bool = False,
 ) -> tuple[list[str], Path]:
-    """Prepare a synthetic pre-v4 project and locally signed clean v4 release."""
+    """Prepare a synthetic pre-v4 project and locally signed clean v4 release.
+
+    ``fresh`` leaves the project without any add-on, as the release
+    qualification's runtime row installs it; the owned Codex entry still
+    carries a stale ``from_version`` pin for the first start to repin.
+    """
     smoke = load_smoke_script()
     project_dir.mkdir()
     smoke.write_project_files(project_dir)
@@ -240,11 +246,14 @@ def prepare_clean_major_migration_project(
 
     verifier_root = work / "verifier"
     _write_fixture_verifier(verifier_root, public_key)
-    old_addon = project_dir / "addons" / "godot_ai"
-    (old_addon / "legacy").mkdir(parents=True)
-    (old_addon / "plugin.cfg").write_text(f'[plugin]\nversion="{from_version}"\n', encoding="utf-8")
-    (old_addon / "old_only.gd").write_text("extends RefCounted\n", encoding="utf-8")
-    (old_addon / "legacy" / "state.txt").write_text("retained pre-v4 state\n", encoding="utf-8")
+    if not fresh:
+        old_addon = project_dir / "addons" / "godot_ai"
+        (old_addon / "legacy").mkdir(parents=True)
+        (old_addon / "plugin.cfg").write_text(
+            f'[plugin]\nversion="{from_version}"\n', encoding="utf-8"
+        )
+        (old_addon / "old_only.gd").write_text("extends RefCounted\n", encoding="utf-8")
+        (old_addon / "legacy" / "state.txt").write_text("retained pre-v4 state\n", encoding="utf-8")
     write_owned_codex_pin(
         codex_home,
         command=fake_uvx,
@@ -455,9 +464,7 @@ func _write_receipt() -> bool:
 """
 
 
-def write_post_restart_driver(
-    project_dir: Path, *, http_port: int, expected_version: str
-) -> None:
+def write_post_restart_driver(project_dir: Path, *, http_port: int, expected_version: str) -> None:
     """Wait through a plugin-initiated restart, then prove the live server.
 
     The initial process only writes its receipt: the plugin under test decides
@@ -936,6 +943,7 @@ func _try_write_status() -> bool:
 {_RECEIPT_GDSCRIPT}""",
         encoding="utf-8",
     )
+
 
 def write_driver_support(project_dir: Path) -> None:
     """Write shared authenticated status and plugin-discovery primitives."""

--- a/tests/integration/test_self_update_upgrade_paths.py
+++ b/tests/integration/test_self_update_upgrade_paths.py
@@ -144,8 +144,13 @@ def _install_clean_major_fixture(
     target_version: str,
     http_port: int = LIVE_HTTP_PORT,
     ws_port: int = LIVE_WS_PORT,
+    fresh: bool = False,
 ) -> tuple[Path, Path]:
-    """Run the closed-editor installer over a synthetic pre-v4 project."""
+    """Run the closed-editor installer over a synthetic pre-v4 project.
+
+    ``fresh`` installs into a project without an add-on: the marker then
+    names no previous version and retains no backup.
+    """
     from_version = "3.2.4"
     project = tmp_path / "clean-major-migration"
     isolated = tmp_path / "clean-major-environment"
@@ -156,6 +161,7 @@ def _install_clean_major_fixture(
         target_version=target_version,
         http_port=http_port,
         ws_port=ws_port,
+        fresh=fresh,
     )
     write_clean_major_driver(
         project,
@@ -164,7 +170,7 @@ def _install_clean_major_fixture(
         target_version=target_version,
     )
     old_addon = project / "addons" / "godot_ai"
-    old_tree = _tree_bytes(old_addon)
+    old_tree = {} if fresh else _tree_bytes(old_addon)
     install_environment = os.environ.copy()
     install_environment["PATH"] = (
         str(project / ".clean-major-smoke" / "fake-bin")
@@ -185,10 +191,15 @@ def _install_clean_major_fixture(
     assert read_plugin_version(old_addon / "plugin.cfg") == target_version
     assert not (old_addon / "old_only.gd").exists()
     state = project / UPDATE_STATE_RELATIVE
-    assert _tree_bytes(state / "backup" / from_version) == old_tree
     marker = json.loads((project / CLEAN_MAJOR_MARKER_RELATIVE).read_text(encoding="utf-8"))
     assert marker["status"] == "success", marker
-    assert marker["from_version"] == from_version
+    if fresh:
+        assert not (state / "backup").exists()
+        assert marker["from_version"] == ""
+        assert marker["backup_root"] == ""
+    else:
+        assert _tree_bytes(state / "backup" / from_version) == old_tree
+        assert marker["from_version"] == from_version
     assert marker["to_version"] == target_version
     assert marker["replace_owned_mismatches"] is True
     assert not (state / "lock.json").exists()
@@ -206,10 +217,31 @@ def test_clean_major_installer_cli_retains_exact_pre_v4_tree(tmp_path: Path) -> 
 
 def test_closed_editor_install_then_first_start_completes_migration(tmp_path: Path) -> None:
     """The first editor start after a closed install repins clients, then serves."""
+    project, marker = _first_start_after_closed_install(tmp_path)
+    assert (project / UPDATE_STATE_RELATIVE / "backup" / "3.2.4" / "old_only.gd").is_file()
+    assert marker["from_version"] == "3.2.4"
+
+
+def test_closed_editor_install_into_fresh_project_then_first_start_serves(
+    tmp_path: Path,
+) -> None:
+    """No add-on before the install: the marker names no previous version.
+
+    This is how the release qualification's runtime row installs candidate A;
+    the first start must still repin the stale owned entry and serve.
+    """
+    project, marker = _first_start_after_closed_install(tmp_path, fresh=True)
+    assert not (project / UPDATE_STATE_RELATIVE / "backup").exists()
+    assert marker["from_version"] == ""
+
+
+def _first_start_after_closed_install(tmp_path: Path, *, fresh: bool = False) -> tuple[Path, dict]:
     godot_bin = godot_bin_or_skip()
     target_version = read_plugin_version(PLUGIN_ROOT / "plugin.cfg")
     http_port, ws_port = allocate_free_ports(2)
-    project, isolated = _install_clean_major_fixture(tmp_path, target_version, http_port, ws_port)
+    project, isolated = _install_clean_major_fixture(
+        tmp_path, target_version, http_port, ws_port, fresh=fresh
+    )
     environment, capability_dir = _isolated_environment(isolated)
     environment["PATH"] = (
         str(project / ".clean-major-smoke" / "fake-bin") + os.pathsep + os.environ.get("PATH", "")
@@ -247,11 +279,11 @@ def test_closed_editor_install_then_first_start_completes_migration(tmp_path: Pa
     marker = json.loads((project / CLEAN_MAJOR_MARKER_RELATIVE).read_text(encoding="utf-8"))
     assert marker["status"] == "success", marker
     assert marker["clients_migrated"] is True, marker
-    assert (project / UPDATE_STATE_RELATIVE / "backup" / "3.2.4" / "old_only.gd").is_file()
     assert not (project / UPDATE_STATE_RELATIVE / "lock.json").exists()
     assert (project / "_test_clean_major_probe.txt").read_text(encoding="utf-8") == (
         "clean major authenticated write\n"
     )
+    return project, marker
 
 
 def _authenticated_tool_probe(
@@ -271,9 +303,7 @@ def _authenticated_tool_probe(
         async with Client(transport, timeout=10, init_timeout=10) as client:
             deadline = asyncio.get_running_loop().time() + 90
             while True:
-                sessions = await client.call_tool(
-                    "session_manage", {"op": "list", "params": {}}
-                )
+                sessions = await client.call_tool("session_manage", {"op": "list", "params": {}})
                 if int(sessions.data.get("count", 0)) > 0:
                     break
                 if asyncio.get_running_loop().time() >= deadline:
@@ -689,7 +719,8 @@ func _process(_delta: float) -> void:
     initial_editor, restarted_editor = read_editor_receipts(project)
     assert initial_editor["pid"] != restarted_editor["pid"], (initial_editor, restarted_editor)
     assert initial_editor["display"] == restarted_editor["display"] == "headless", (
-        initial_editor, restarted_editor
+        initial_editor,
+        restarted_editor,
     )
     assert "Failed to create an autoload" not in log, log
     disable = log.find("MCP | v3 bridge disabling transition plugin")

--- a/tests/unit/test_runtime_qualification.py
+++ b/tests/unit/test_runtime_qualification.py
@@ -202,6 +202,38 @@ def test_runtime_project_driver_is_external_to_candidate_tree(tmp_path):
     assert 'const VERSION_A := "4.0.0"' in driver
     assert 'const VERSION_B := "4.0.1"' in driver
     assert 'plugin.call("_on_dock_update_requested")' in driver
+    # The update restarts the editor; the driver must resume as "started" there.
+    assert driver.index("FileAccess.file_exists(PROGRESS_PATH)") < driver.index("set_process(true)")
+    assert driver.index('{"started": true') < driver.index(
+        'plugin.call("_on_dock_update_requested")'
+    )
+
+
+def test_editor_launch_keeps_the_restarted_editor_headless(tmp_path):
+    command = runtime._editor_command("godot", tmp_path / "project")
+    assert "--headless" not in command
+    assert command[1:5] == ["--display-driver", "headless", "--audio-driver", "Dummy"]
+    assert command[-3:] == ["--editor", "--path", str(tmp_path / "project")]
+
+
+def test_runtime_result_is_read_as_the_driver_writes_it(tmp_path):
+    # GDScript's JSON.stringify keeps insertion order and spacing; the driver's
+    # report is a plain object, not canonical signed evidence.
+    (tmp_path / "runtime-result.json").write_text(
+        '{"status": "passed", "to_version": "4.0.1", "from_version": "4.0.0"}', encoding="utf-8"
+    )
+    assert runtime._read_runtime_result(tmp_path)["status"] == "passed"
+    (tmp_path / "runtime-result.json").write_text("[]", encoding="utf-8")
+    with pytest.raises(support.ReleaseError, match="not an object"):
+        runtime._read_runtime_result(tmp_path)
+
+
+def test_runtime_result_wait_needs_the_restarted_editor_to_report(tmp_path):
+    result = tmp_path / "runtime-result.json"
+    with pytest.raises(support.ReleaseError, match="restarted editor did not report"):
+        runtime._wait_for_runtime_result(result, 0.3)
+    result.write_text("{}", encoding="utf-8")
+    runtime._wait_for_runtime_result(result, 0.3)
 
 
 def test_private_capability_is_never_written_to_retained_log(tmp_path):
@@ -472,3 +504,30 @@ def test_lean_update_evidence_rejects_every_leftover_or_mismatch(
 
     with pytest.raises(support.ReleaseError, match=message):
         runtime._verify_lean_update(project, candidates, records)
+
+
+def test_cli_accepts_every_engine_a_required_runtime_row_names(monkeypatch, tmp_path):
+    seen = []
+    monkeypatch.setattr(runtime, "runtime_row", lambda *args: seen.append(args[3]))
+    versions = sorted({key[3] for key in qualification.required_row_keys() if key[0] == "runtime"})
+    assert versions == ["4.7.0", "4.7.2"]
+    assert set(versions) <= set(qualification.RUNTIME_GODOT_VERSIONS)
+    for version in versions:
+        argv = [
+            "--candidates",
+            str(tmp_path),
+            "--python-row",
+            str(tmp_path),
+            "--godot",
+            "godot",
+            "--godot-version",
+            version,
+            "--output",
+            str(tmp_path / "row"),
+            "--os",
+            "ubuntu-latest",
+        ]
+        assert runtime.main(argv) == 0
+    assert seen == versions
+    with pytest.raises(SystemExit):
+        runtime.main([*argv[:-4], "--godot-version", "4.7.1", *argv[-4:]])


### PR DESCRIPTION
## Summary

The first qualification run ([33915395430](https://github.com/hi-godot/godot-ai/actions/runs/33915395430)) passed every Python row and failed all four real-editor runtime rows. Investigating showed the row had never completed in any real editor; four defects, fixed in the order the row hits them:

1. **Fresh-install barrier.** `script/v4-release install` records an empty `from_version` when it installs into a project without an add-on, which is how the row installs candidate A. The plugin's post-update barrier refused that as "Post-update versions are incomplete" and blocked startup. A fresh install now repins owned client entries to the installed version; only a missing target version is refused. New real-editor scenario `test_closed_editor_install_into_fresh_project_then_first_start_serves` reproduces the CI failure without the fix (verified by mutation) and passes with it.
2. **Runtime CLI choices.** `--godot-version` accepted only the pinned 4.7.0 while the matrix names the extra Linux 4.7.2 row. Choices now cover every engine a required row names, with a test.
3. **Headless restart.** Godot's `restart_editor` forwards explicit display/audio driver options but not `--headless`, so the editor the update restarted into was windowed (needs a display on Linux runners). The row launches with `--display-driver headless --audio-driver Dummy`, the driver persists its progress across the restart, and the script waits for the restarted editor's result instead of reading it the instant the first process exits.
4. **Result parsing.** The driver's report is GDScript `JSON.stringify` output; it was read with the canonical-JSON requirement meant for signed evidence.

## Verification

- Local dry run of the row's `exact_a_to_b` against the run's real signed candidates and the macOS Python row's retained packages, Godot 4.7.beta3 with the engine identity check skipped and a previous add-on seeded so the unfixed candidate A passes the barrier: first start, A→B update through the private HTTPS origin, headless restart, restarted editor's verification and repin, marker/backup/live-tree checks all pass (`DRY RUN: passed from 4.0.0 to 4.0.1`).
- `tests/integration/test_self_update_upgrade_paths.py -k closed_editor_install`: both closed-install scenarios pass in a real editor.
- `pytest tests/unit -n auto`: 2091 passed. ruff clean.

## Notes for the maintainer

- The signed 4.0.0 candidates from run 33915395430 were never published; publication is bound to a qualification run ID and `next_version(3.2.5, major)` is 4.0.0, so re-qualifying 4.0.0 from this commit is the path (a 4.0.1 first release cannot be published as a major bump from 3.2.5).
- Observed in the row's editor log: the candidate server's FastMCP performs its own PyPI version check (`GET https://pypi.org/pypi/fastmcp/json`) inside the qualification environment. Not a failure; worth silencing in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated release qualification guidance to keep restarted editor sessions headless and wait for reported results.
  - Clarified closed-editor installation behavior for projects without an existing add-on.

- **Bug Fixes**
  - Fresh installations now support repinning owned client entries when no previous version exists.
  - Runtime qualification now remains headless across editor restarts and correctly captures the restarted editor’s result.
  - Runtime qualification supports all engine versions required by configured runtime scenarios.

- **Tests**
  - Expanded coverage for fresh installs, post-update repinning, editor restarts, result handling, and supported engine versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->