### PR TITLE
ci: streamline normal checks and retain nightly reload stress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Lint
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
         run: >-
           ruff check src/ tests/ script/
           script/ci-game-capture-smoke
@@ -124,8 +125,35 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
         run: python script/architecture_simplification_gates.py --check
 
+  build-distributions:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install "build==1.6.0"
+          python -m build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: dist
+          path: dist/
+
   release-smoke:
     name: Release smoke / ${{ matrix.os }}
+    needs: build-distributions
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -144,10 +172,11 @@ jobs:
           cache: pip
           cache-dependency-path: pyproject.toml
 
-      - name: Build sdist and wheel
-        run: |
-          python -m pip install "build==1.6.0"
-          python -m build
+      - name: Download shared distributions
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: dist
+          path: dist/
 
       - name: Install built wheel in a clean venv
         shell: bash
@@ -181,13 +210,6 @@ jobs:
           fi
           "$PY" -m pip install dist/*.tar.gz
           "$GODOT_AI" --version
-
-      - name: Upload build artifacts
-        if: matrix.os == 'ubuntu-latest'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: dist
-          path: dist/
 
   godot-tests:
     name: Godot tests / ${{ matrix.label }}
@@ -246,12 +268,13 @@ jobs:
         # suites. Windows and macOS run the same files nightly
         # (nightly-diagnostics.yml); their editor starts are 3-5x slower and the
         # per-OS Godot and smoke jobs already prove the plugin and server start
-        # on every OS. See docs/self-update.md.
+        # on every OS. The local-files delivery duplicate runs nightly;
+        # ordinary CI exercises private HTTPS. See docs/self-update.md.
         if: matrix.os == 'ubuntu-latest'
         shell: bash
         timeout-minutes: 12
         run: |
-          xvfb-run -a env GODOT_BIN=godot pytest -v -s --durations=0 --basetemp="${RUNNER_TEMP}/pytest-basetemp" \
+          xvfb-run -a env GODOT_BIN=godot pytest -v -s --durations=0 -k 'not local-files' --basetemp="${RUNNER_TEMP}/pytest-basetemp" \
             tests/integration/test_godot_editor_restart.py \
             tests/integration/test_migration_bridge_failures.py \
             tests/integration/test_self_update_upgrade_paths.py \
@@ -288,9 +311,6 @@ jobs:
 
       - name: Reload smoke test
         shell: bash
-        ## Ten Windows reload/import cycles consume roughly two minutes before
-        ## the post-reload suite begins. Keep the outer step budget above the
-        ## script's independent 90-second MCP-call ceiling.
         timeout-minutes: 5
         run: bash script/ci-reload-test
 
@@ -341,8 +361,8 @@ jobs:
   # Verifies that startup refuses an authenticated but mismatched godot-ai
   # server without spending destructive authority. The occupant remains alive;
   # only a later explicit Dock recovery intent may authorize kill/restart.
-  stale-server-smoke:
-    name: Stale server smoke / ${{ matrix.label }}
+  server-ownership-smoke:
+    name: Server ownership smoke / ${{ matrix.label }}
     runs-on: ${{ matrix.os }}
     env:
       GODOT_AI_MODE: dev
@@ -388,153 +408,30 @@ jobs:
           godot --headless --path test_project --import > godot-import.log 2>&1 || true
           bash script/ci-check-gdscript godot-import.log
 
+      # Each invocation starts fresh processes and restores/removes its private
+      # capability record in finally. The next invocation checks both ports
+      # are free before starting; a leaked process fails the next smoke.
       - name: Run stale-server smoke
         shell: bash
         timeout-minutes: 3
         run: python script/ci-stale-server-smoke --log-dir .
 
-      - name: Dump editor log on failure
-        if: failure()
-        shell: bash
-        run: |
-          echo "===== godot-stale-smoke.log (last 500 lines) ====="
-          tail -n 500 godot-stale-smoke.log || echo "(log not found)"
-          echo "===== stale-occupant.log (last 200 lines) ====="
-          tail -n 200 stale-occupant.log || echo "(log not found)"
-          echo "===== godot-import.log (last 200 lines) ====="
-          tail -n 200 godot-import.log || echo "(log not found)"
-
-  # #759/#764 integration regression: a matching-version EditorSettings
-  # record naming a dead PID must not transfer teardown ownership to the
-  # compatible external server now occupying the port. Reload must preserve
-  # that server and reconnect through a distinct replacement editor session.
-  stale-compatible-reload-smoke:
-    name: Stale compatible reload smoke / ${{ matrix.label }}
-    runs-on: ${{ matrix.os }}
-    env:
-      GODOT_AI_MODE: dev
-    strategy:
-      fail-fast: false
-      # macOS runners are the scarce pool (five concurrent). On pull requests
-      # the macOS row of this smoke moves to pushes to main, so a PR runs
-      # five macOS jobs instead of seven and none of them queue behind the
-      # limit. macOS keeps the stale-server smoke and the Godot suite on
-      # every PR, which exercise its lsof-based port scraping.
-      matrix: ${{ fromJSON(github.event_name == 'pull_request' && '{"include":[{"os":"ubuntu-latest","label":"Linux"},{"os":"windows-latest","label":"Windows"}]}' || '{"include":[{"os":"ubuntu-latest","label":"Linux"},{"os":"macos-latest","label":"macOS"},{"os":"windows-latest","label":"Windows"}]}') }}
-
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Build plugin link
-        shell: bash
-        run: bash script/verify-worktree
-
-      - uses: chickensoft-games/setup-godot@c233594225991af5aec714e52457cc76d6df8fa2 # v2
-        with:
-          version: 4.7.0
-          use-dotnet: false
-
-      - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.13"
-          cache: pip
-          cache-dependency-path: pyproject.toml
-
-      - name: Install dependencies
-        run: pip install -e ".[dev]"
-
-      - name: Import and validate GDScript
-        shell: bash
-        timeout-minutes: 3
-        run: |
-          godot --headless --path test_project --import > godot-import.log 2>&1 || true
-          bash script/ci-check-gdscript godot-import.log
-
       - name: Run stale-compatible reload smoke
+        if: ${{ !cancelled() }}
         shell: bash
         timeout-minutes: 3
         run: python script/ci-stale-server-smoke --mode stale-compatible-reload --log-dir .
 
-      - name: Dump editor and server logs on failure
-        if: failure()
-        shell: bash
-        run: |
-          echo "===== godot-stale-compatible-reload-smoke.log (last 500 lines) ====="
-          tail -n 500 godot-stale-compatible-reload-smoke.log || echo "(log not found)"
-          echo "===== stale-compatible-external-server.log (last 300 lines) ====="
-          tail -n 300 stale-compatible-external-server.log || echo "(log not found)"
-          echo "===== godot-import.log (last 200 lines) ====="
-          tail -n 200 godot-import.log || echo "(log not found)"
-
-  # Mirror image of stale-server-smoke: verifies the plugin's NON-recoverable
-  # path when port 8000 is held by a genuinely foreign (non-godot-ai) process.
-  # It gets no ownership proof, so it must land in terminal INCOMPATIBLE with
-  # can_recover_incompatible == false, log a suggested free port, and make NO
-  # kill attempt — leaving the foreign occupant alive. Covered today only by
-  # mocked GDScript unit tests (test_dock.gd); this drives the real upstream
-  # classification in CI. Separate job (not a step in stale-server-smoke) so
-  # the stale run's respawned port-8000 server can't bleed into this scenario.
-  foreign-server-smoke:
-    name: Foreign server smoke / ${{ matrix.label }}
-    runs-on: ${{ matrix.os }}
-    env:
-      GODOT_AI_MODE: dev
-    strategy:
-      fail-fast: false
-      # macOS runners are the scarce pool (five concurrent). On pull requests
-      # the macOS row of this smoke moves to pushes to main, so a PR runs
-      # five macOS jobs instead of seven and none of them queue behind the
-      # limit. macOS keeps the stale-server smoke and the Godot suite on
-      # every PR, which exercise its lsof-based port scraping.
-      matrix: ${{ fromJSON(github.event_name == 'pull_request' && '{"include":[{"os":"ubuntu-latest","label":"Linux"},{"os":"windows-latest","label":"Windows"}]}' || '{"include":[{"os":"ubuntu-latest","label":"Linux"},{"os":"macos-latest","label":"macOS"},{"os":"windows-latest","label":"Windows"}]}') }}
-
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-
-      - name: Build plugin link
-        shell: bash
-        run: bash script/verify-worktree
-
-      - uses: chickensoft-games/setup-godot@c233594225991af5aec714e52457cc76d6df8fa2 # v2
-        with:
-          version: 4.7.0
-          use-dotnet: false
-
-      - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.13"
-          cache: pip
-          cache-dependency-path: pyproject.toml
-
-      - name: Install dependencies
-        run: pip install -e ".[dev]"
-
-      - name: Import and validate GDScript
-        shell: bash
-        timeout-minutes: 3
-        run: |
-          godot --headless --path test_project --import > godot-import.log 2>&1 || true
-          bash script/ci-check-gdscript godot-import.log
-
       - name: Run foreign-server smoke
+        if: ${{ !cancelled() }}
         shell: bash
         timeout-minutes: 3
         run: python script/ci-stale-server-smoke --mode foreign --log-dir .
 
-      - name: Dump editor log on failure
+      - name: Dump ownership smoke logs on failure
         if: failure()
         shell: bash
-        run: |
-          echo "===== godot-foreign-smoke.log (last 500 lines) ====="
-          tail -n 500 godot-foreign-smoke.log || echo "(log not found)"
-          echo "===== godot-import.log (last 200 lines) ====="
-          tail -n 200 godot-import.log || echo "(log not found)"
+        run: tail -n 300 ./godot-*.log ./*-occupant.log ./stale-compatible-external-server.log
 
   # Separate job from godot-tests: the capture smoke test needs a real
   # rendering driver (null RenderingDevice in --headless produces empty

--- a/.github/workflows/nightly-diagnostics.yml
+++ b/.github/workflows/nightly-diagnostics.yml
@@ -87,6 +87,43 @@ jobs:
             pytest "${pytest_args[@]}"
           fi
 
+      - name: Start MCP server
+        shell: bash
+        run: MCP_SERVER_LOG=diagnostics/mcp-server.log bash script/ci-start-server
+
+      - name: Import and validate GDScript
+        shell: bash
+        timeout-minutes: 3
+        run: |
+          godot --headless --path test_project --import > diagnostics/godot-import.log 2>&1 || true
+          bash script/ci-check-gdscript diagnostics/godot-import.log
+
+      - name: Start Godot editor (headless)
+        shell: bash
+        run: GODOT_AI_ALLOW_HEADLESS=1 godot --headless --path test_project --editor > diagnostics/godot-editor.log 2>&1 &
+
+      - name: Run handler tests
+        shell: bash
+        timeout-minutes: 3
+        env:
+          # #882: floor on test_run's `total`, catching in-suite discovery
+          # truncation that the script's suite-count gate cannot see (a suite
+          # can register and still run fewer tests than it has). Keep this a
+          # little below the real count so ordinary churn doesn't trip it;
+          # lower it deliberately when tests are legitimately removed.
+          GODOT_AI_MIN_TESTS: "2050"
+        run: bash script/ci-godot-tests
+
+      - name: Ten-reload stress test
+        shell: bash
+        timeout-minutes: 5
+        run: bash script/ci-reload-test --stress
+
+      - name: Quit smoke test
+        shell: bash
+        timeout-minutes: 2
+        run: bash script/ci-quit-test
+
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,38 @@
 
 This guide is for any AI assistant working in this repository. Keep Claude-specific files such as `.claude/CLAUDE.md` and `.claude/skills/*` as thin pointers to this shared guidance.
 
+## PR activity monitoring
+
+Whenever a PR is created, opened, or identified in the conversation, check its
+state and start monitoring without asking again, unless it is already closed
+or merged. This authorizes read-only monitoring and notifications, not posting
+comments, changing code, rerunning CI, or merging.
+
+- Discover the current environment's tools. Prefer a native PR activity
+  subscription (such as `subscribe_pr_activity`) when actually available;
+  confirm success and retain its subscription identifier. Do not assume a
+  particular tool namespace or that GitHub access includes subscriptions.
+- If subscriptions are unavailable but durable task automations are supported,
+  reuse an existing monitor for the same repository and PR or create a
+  15-minute heartbeat attached to the current task. Poll PR comments, inline
+  review comments, submitted reviews, CI results, merge conflicts, and PR state
+  using the authenticated GitHub connector or `gh`. Keep the last seen state,
+  report existing actionable feedback once, and notify only on new actionable
+  feedback, failures, conflicts, access failures, or closure/merge. Stay quiet
+  otherwise; stop the monitor after closure/merge.
+- If neither capability is available, check current feedback and CI, then
+  explicitly report that persistent monitoring was not started and which
+  capability is missing. A one-time read, shell polling process, GitHub email
+  subscription, or written instruction is not a durable task subscription.
+- Report the confirmed monitoring mechanism when starting it. Never claim
+  monitoring is active without a successful subscription/automation response.
+
+This policy applies to local and cloud sessions. Check capabilities separately
+in each environment: local Codex settings and credentials do not establish
+cloud tool availability. Do not add a guessed MCP endpoint or install an
+integration merely because it has GitHub in its name. A future provider must
+be verified to expose the subscription and deliver events to the task.
+
 ## What this project is
 
 A production-grade MCP server for Godot. Python server (FastMCP v3) communicates over WebSocket with a GDScript editor plugin. AI clients call MCP tools → Python routes commands → Godot plugin executes against the editor API → results flow back.

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -185,7 +185,8 @@ still repins owned client entries to the installed version before serving.
   of them. With the
   capsule coordinator's restart handoff in
   `tests/integration/test_migration_bridge_failures.py`, they run on Linux on
-  every pull request and on all three desktop OSes nightly, and the release
+  every pull request (private HTTPS delivery) and on all three desktop OSes
+  nightly (also local-file delivery on Linux/macOS), and the release
   pipeline's A-to-B row runs the signed update on the exact signed candidate
   on every OS before publication.
 - Interactive pass: `script/local-self-update-smoke` prepares a signed

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -3,6 +3,11 @@
 Part of the Godot AI agent guide — see [AGENTS.md](../AGENTS.md) for the always-loaded rules.
 
 
+Normal CI runs the full handler suite once per OS, followed by a single
+`script/ci-reload-test` reload with session, scene-continuity, and log probes.
+Nightly diagnostics use `script/ci-reload-test --stress`: ten reloads followed
+by another handler-suite run, preserving the cumulative crash regression.
+
 The full pre-commit gauntlet. Run this before every commit — Python mocks do not
 catch GDScript bugs, editor API regressions, or undo/redo issues.
 

--- a/script/ci-reload-test
+++ b/script/ci-reload-test
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Smoke-test the editor_reload_plugin tool in CI.
+# Use --stress for ten reloads followed by the full handler suite (nightly).
 # 1. Creates a node (cube) via the OLD plugin
 # 2. Reloads the plugin, verifies new session ID
 # 3. Checks the log buffer is fresh (proves handlers were rebuilt)
@@ -8,6 +9,16 @@
 # Expects: Python server reachable at $MCP_SERVER_URL (default :8000, set in
 # _ci_env.sh), Godot editor with plugin connected.
 set -euo pipefail
+STRESS=0
+case "${1:-}" in
+  "") ;;
+  --stress) STRESS=1; shift ;;
+  *) echo "Usage: $0 [--stress]" >&2; exit 2 ;;
+esac
+if [ "$#" -ne 0 ]; then
+  echo "Usage: $0 [--stress]" >&2
+  exit 2
+fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/_ci_env.sh"
@@ -341,6 +352,13 @@ if total < 0:
     sys.exit(1)
 print(f'Game-logs path OK: total={total}, returned={content.get(\"returned_count\", 0)}')
 "
+
+# Normal CI already ran the full handler suite. The probes above prove a
+# single reload preserves the scene and rebuilds a working plugin session.
+if [ "$STRESS" -eq 0 ]; then
+  echo "Reload smoke test passed (1 reload)"
+  exit 0
+fi
 
 # --- Step 7: Multi-reload churn (cumulative corruption regression) ---
 # The original issue report saw crashes after ~10 reloads. Do 9 more


### PR DESCRIPTION
Normal CI repeats the full Godot handler suite after ten plugin reloads, rebuilds identical distributions on every OS, and repeats setup for three server ownership jobs per OS. This change reduces that repeated work while retaining the cumulative reload regression in nightly diagnostics.

- Run one reload with session, scene-continuity, and log probes in normal CI; retain ten reloads and the post-reload handler suite nightly on all three desktop platforms.
- Keep private-HTTPS updater delivery in normal CI and run the duplicate local-file delivery nightly.
- Run Ruff once, build the wheel and sdist once, and install those same artifacts in clean environments across all three platforms.
- Consolidate the three ownership checks into one job per OS, retaining separate processes and cleanup for each check. All three checks also run on macOS pull requests.

The repository agent instructions also define PR monitoring for local and cloud sessions: prefer verified native subscriptions, use a durable 15-minute polling automation when available, and explicitly report when neither capability exists.

Based on the reviewed v4 commit `68ca976`. No production plugin or server behavior changes.

Validation: 2,478 Python tests passed; the full Godot 4.7 handler suite passed (2,216 passed, 24 skipped); normal and ten-reload stress checks, quit, all three sequential ownership checks, and the signed private-HTTPS updater scenario passed locally on macOS. Wheel and sdist builds and clean installation checks passed. Ruff, actionlint, shell syntax, and architecture gates passed. Hosted CI will validate Linux and Windows execution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Testing & Reliability**
  - Continuous integration now reuses shared distribution artifacts and consolidates server ownership, reload, and compatibility smoke tests.
  - Nightly diagnostics validate server startup, GDScript imports, editor launches, handler tests, repeated reloads, and clean shutdowns.
  - Reload testing supports an optional stress mode for extended multi-reload validation.

- **Documentation**
  - Updated self-update and verification guides to clarify platform coverage, delivery modes, reload checks, and nightly stress diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->