### PR TITLE
clients: match Godot AI launches by token, keep ownership through project tiers

### DIFF
--- a/plugin/addons/godot_ai/clients/_base.gd
+++ b/plugin/addons/godot_ai/clients/_base.gd
@@ -533,19 +533,36 @@ static func _packed_slice(packed: PackedStringArray, from: int, to: int) -> Pack
 	return out
 
 
-## Whether an existing entry's launch text refers to Godot AI at all: the
-## PyPI/console name `godot-ai` or the module `godot_ai`. The post-update
-## major migration rewrites only such entries; anything else is the user's
-## own server and stays for an explicit Configure.
+## Whether an existing entry's launch text launches Godot AI: an executable
+## named `godot-ai`, a `godot-ai==<version>` package pin, the bare `godot-ai`
+## console-script argument, or the `godot_ai` module. Tokens are matched
+## exactly, so a URL or path that merely contains the name (a docs link, a
+## project directory) does not count. The post-update major migration
+## rewrites only such entries; anything else is the user's own server.
 static func launch_mentions_godot_ai(text: String) -> bool:
-	return text.contains("godot-ai") or text.contains("godot_ai")
+	for raw_token in text.split(" ", false):
+		var token := raw_token.strip_edges().lstrip("\"'[{(").rstrip("\"'])},")
+		if token.is_empty():
+			continue
+		if token == "godot-ai" or token == "godot_ai" or token.begins_with("godot-ai=="):
+			return true
+		var base := token.get_file()
+		if base == "godot-ai" or base == "godot-ai.exe":
+			return true
+	return false
 
 
 ## The launch-bearing fields of an entry, as text for the check above. The
 ## entry sits under our server name, so the name itself must not count.
 static func entry_launch_text(entry: Dictionary) -> String:
-	var launch := {}
+	var tokens := PackedStringArray()
 	for key in ["command", "args", "url"]:
-		if entry.has(key):
-			launch[key] = entry[key]
-	return JSON.stringify(launch)
+		if not entry.has(key):
+			continue
+		var value: Variant = entry[key]
+		if value is Array:
+			for item in value:
+				tokens.append(str(item))
+		else:
+			tokens.append(str(value))
+	return " ".join(tokens)

--- a/plugin/addons/godot_ai/clients/_json_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_json_strategy.gd
@@ -180,7 +180,12 @@ static func _check_status_merged(
 		var latest: Dictionary = project_tiers[project_tiers.size() - 1]
 		var details := _entry_status_details(client, latest["entry"], server_url, launch)
 		if details.get("status") != McpClient.Status.CONFIGURED:
-			return {"status": McpClient.Status.CONFIGURED_MISMATCH, "error_msg": _project_override_message([latest], "update or remove", client.display_name, server_name)}
+			## Keep `owned` from the effective entry: the post-update migration
+			## decides from it whether this mismatch is ours to repin.
+			var mismatch := details.duplicate()
+			mismatch["status"] = McpClient.Status.CONFIGURED_MISMATCH
+			mismatch["error_msg"] = _project_override_message([latest], "update or remove", client.display_name, server_name)
+			return mismatch
 		return {"status": McpClient.Status.CONFIGURED, "error_msg": ""}
 	if effective == null:
 		return {"status": McpClient.Status.NOT_CONFIGURED, "error_msg": ""}

--- a/plugin/addons/godot_ai/clients/_toml_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_toml_strategy.gd
@@ -141,14 +141,21 @@ static func check_status_details(
 	## Whether the existing entry launches Godot AI at all: a major migration
 	## may rewrite such an entry, never a foreign one (client_job_owner.gd).
 	## Only the launch values count; the section header carries our name.
-	var launch_text := ""
-	for launch_key in ["command", "args", "url"]:
+	var launch_tokens := PackedStringArray()
+	for launch_key in ["command", "url"]:
 		if by_key.has(launch_key):
-			launch_text += _item_value(by_key[launch_key]) + "\n"
+			var decoded := _decode_toml_string(_item_value(by_key[launch_key]))
+			if bool(decoded.get("ok", false)):
+				launch_tokens.append(str(decoded.get("value", "")))
+	if by_key.has("args"):
+		var decoded_args := _decode_toml_string_array(_item_value(by_key["args"]))
+		if bool(decoded_args.get("ok", false)):
+			for argument in decoded_args.get("value", []):
+				launch_tokens.append(str(argument))
 	var mismatch := {
 		"status": McpClient.Status.CONFIGURED_MISMATCH,
 		"error_msg": "",
-		"owned": McpClient.launch_mentions_godot_ai(launch_text),
+		"owned": McpClient.launch_mentions_godot_ai(" ".join(launch_tokens)),
 	}
 
 	if client.command_shape != McpClient.CommandShape.NONE:

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -6355,9 +6355,16 @@ func test_text_remove_server_entry_bom_no_match_returns_unchanged() -> void:
 
 func test_launch_mentions_godot_ai_recognizes_our_launch_shapes_only() -> void:
 	assert_true(McpClient.launch_mentions_godot_ai("uvx --from godot-ai==3.2.4 godot-ai"))
-	assert_true(McpClient.launch_mentions_godot_ai('{"command": "/x/bin/godot-ai", "args": ["attach"]}'))
+	assert_true(McpClient.launch_mentions_godot_ai("/x/bin/godot-ai attach"))
+	assert_true(McpClient.launch_mentions_godot_ai("C:\\Tools\\godot-ai.exe attach"))
 	assert_true(McpClient.launch_mentions_godot_ai("python -m godot_ai"))
-	assert_false(McpClient.launch_mentions_godot_ai('{"command": "/usr/bin/python3", "args": ["my_server.py"]}'))
+	assert_true(McpClient.launch_mentions_godot_ai("uvx godot-ai==4.0.0"))
+	assert_false(McpClient.launch_mentions_godot_ai("/usr/bin/python3 my_server.py"))
+	## Mentions that are not launches: a docs URL, a project directory, a name.
+	assert_false(McpClient.launch_mentions_godot_ai("node server.js https://example.com/godot-ai/docs"))
+	assert_false(McpClient.launch_mentions_godot_ai("/home/me/projects/godot-ai/run.sh"))
+	assert_false(McpClient.launch_mentions_godot_ai("my-godot-ai-proxy --port 1"))
+	assert_false(McpClient.launch_mentions_godot_ai("godot-ai-helper"))
 	assert_false(McpClient.launch_mentions_godot_ai(""))
 
 
@@ -6390,4 +6397,11 @@ func test_json_mismatch_reports_whether_the_existing_entry_is_ours() -> void:
 		client, {"name": "godot-ai", "command": "/usr/bin/python3", "args": ["srv.py"]}, "http://x", launch
 	)
 	assert_false(bool(named.get("owned", true)), "the entry name is not a launch")
-	assert_eq(McpClient.entry_launch_text({"name": "godot-ai", "command": "x"}), '{"command":"x"}')
+	assert_eq(McpClient.entry_launch_text({"name": "godot-ai", "command": "x", "args": ["a", 1]}), "x a 1")
+	var docs_link := McpJsonStrategy._entry_status_details(
+		client,
+		{"command": "node", "args": ["server.js", "https://example.com/godot-ai/docs"]},
+		"http://x",
+		launch,
+	)
+	assert_false(bool(docs_link.get("owned", true)), "a URL containing our name is not a launch")

--- a/tests/integration/_self_update_fixture.py
+++ b/tests/integration/_self_update_fixture.py
@@ -789,7 +789,7 @@ const STATUS_PATH := "res://{REFUSED_SWAP_STATUS_FILE}"
 const TOOL_PROBE_DONE_PATH := "res://{REFUSED_SWAP_TOOL_PROBE_FILE}"
 const DriverSupport := preload("res://_test_self_update_driver_support.gd")
 const START_AFTER_FRAMES := 45
-const DEADLINE_MS := 240000
+const DEADLINE_MS := 200000
 
 var _frames := 0
 var _deadline_ms := 0


### PR DESCRIPTION
## Summary

Follow-up to #971 for the three CodeRabbit findings on it, taken before the next qualification dispatch:

1. **Exact-token ownership.** `launch_mentions_godot_ai` used substring matching, so a foreign entry whose arguments carried a docs URL or a project path containing "godot-ai" would have counted as ours and been rewritten by the major migration. It now matches exact tokens: an executable named `godot-ai`, a `godot-ai==<version>` pin, the bare `godot-ai` argument, or the `godot_ai` module. TOML launch values are decoded before matching rather than scanned as raw text. Negative cases added (`https://example.com/godot-ai/docs`, a project directory, `my-godot-ai-proxy`).
2. **JSON project tier keeps `owned`.** The project-tier mismatch branch rebuilt its result and dropped the flag, so an owned entry in a project tier would have been skipped instead of repinned.
3. **Driver deadline** in the refused-swap scenario now sits under the harness timeout so a stall keeps its diagnostic.

## Verification

- GDScript suite: 2218 passed, 0 failed, 24 skipped (ownership tests extended with the negatives).
- Real editor: closed install (existing, fresh, foreign Codex entry), refused swap then tool call, signed A→B update: 5 passed.
- `pytest tests/unit -n auto` green, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recognition of Godot AI launch configurations, including version-pinned commands and executable paths on Unix and Windows.
  - Prevented documentation URLs, project directories, and similarly named paths from being incorrectly identified as Godot AI launches.
  - Improved configuration status reporting by retaining ownership details when reporting project-level mismatches.
  - Improved handling of command and argument values in TOML-based configurations for more consistent status checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->