### PR TITLE
qualification: wait for the backend to release its capability lock on Windows

### DIFF
--- a/script/runtime_qualification.py
+++ b/script/runtime_qualification.py
@@ -88,6 +88,37 @@ def _wait_for_runtime_result(path: Path, timeout: float) -> None:
         time.sleep(0.5)
 
 
+def _capability_directory(environment: dict[str, str]) -> Path:
+    """Where the row's backend publishes capabilities (see _isolated_environment)."""
+    override = environment.get("GODOT_AI_CAPABILITY_DIR", "")
+    if override:
+        return Path(override)
+    return Path(environment["LOCALAPPDATA"]) / "godot-ai" / "capabilities"
+
+
+def _wait_for_capability_release(directory: Path, timeout: float = 30.0) -> None:
+    """A stopped backend releases its capability lock a moment after its ports.
+
+    Windows refuses to delete a file another process still holds, so removing
+    the lock files is the proof that the backend is gone; a lock that stays
+    held past the deadline means a backend outlived the editor.
+    """
+    deadline = time.monotonic() + timeout
+    for lock in sorted(directory.glob("*.lock")) if directory.is_dir() else []:
+        while True:
+            try:
+                lock.unlink()
+                break
+            except FileNotFoundError:
+                break
+            except OSError as error:
+                support.require(
+                    time.monotonic() < deadline,
+                    f"candidate backend still holds {lock.name} after editor exit: {error}",
+                )
+                time.sleep(0.5)
+
+
 def _wait_for_ports_free(*ports: int, timeout: float = 15.0) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
@@ -565,7 +596,12 @@ def exact_a_to_b(
     actual_godot_version = _validate_godot_version(str(executable), godot_version)
     support.require(_free_port(HTTP_PORT) and _free_port(WS_PORT), "qualification ports are busy")
     output.mkdir(parents=True)
-    with tempfile.TemporaryDirectory(prefix="godot-ai-exact-runtime-") as temporary:
+    # A backend that has just been stopped can still hold its capability lock
+    # for a moment on Windows; the wait below covers the normal case and the
+    # cleanup must never fail a row whose evidence is already written.
+    with tempfile.TemporaryDirectory(
+        prefix="godot-ai-exact-runtime-", ignore_cleanup_errors=True
+    ) as temporary:
         work = Path(temporary).resolve()
         project = work / "project"
         project.mkdir()
@@ -649,6 +685,7 @@ def exact_a_to_b(
                     "update did not download exactly B's canonical signed triple",
                 )
             _wait_for_ports_free(HTTP_PORT, WS_PORT)
+            _wait_for_capability_release(_capability_directory(environment))
         result = _read_runtime_result(project)
         support.require(result.get("status") == "passed", "runtime driver did not pass")
         live = project / "addons/godot_ai"

--- a/script/runtime_qualification.py
+++ b/script/runtime_qualification.py
@@ -99,24 +99,61 @@ def _capability_directory(environment: dict[str, str]) -> Path:
 def _wait_for_capability_release(directory: Path, timeout: float = 30.0) -> None:
     """A stopped backend releases its capability lock a moment after its ports.
 
-    Windows refuses to delete a file another process still holds, so removing
-    the lock files is the proof that the backend is gone; a lock that stays
-    held past the deadline means a backend outlived the editor.
+    A lock still held past the deadline means a backend outlived the editor.
     """
     deadline = time.monotonic() + timeout
     for lock in sorted(directory.glob("*.lock")) if directory.is_dir() else []:
-        while True:
+        while not _lock_released(lock):
+            remaining = deadline - time.monotonic()
+            support.require(
+                remaining > 0, f"candidate backend still holds {lock.name} after editor exit"
+            )
+            time.sleep(min(0.5, remaining))
+
+
+def _lock_released(lock: Path) -> bool:
+    """Whether no process holds the backend's port-claim lock any more.
+
+    Windows refuses to delete a file another process holds open, so a
+    successful delete is the proof there. On POSIX the backend holds an
+    advisory flock and deleting the file says nothing, so the proof is taking
+    that lock ourselves; the file is removed once we hold it.
+    """
+    if os.name == "nt":
+        try:
+            lock.unlink()
+        except FileNotFoundError:
+            return True
+        except OSError:
+            return False
+        return True
+    import fcntl
+
+    try:
+        with lock.open("rb") as handle:
             try:
-                lock.unlink()
-                break
-            except FileNotFoundError:
-                break
-            except OSError as error:
-                support.require(
-                    time.monotonic() < deadline,
-                    f"candidate backend still holds {lock.name} after editor exit: {error}",
-                )
-                time.sleep(0.5)
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except OSError:
+                return False
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    except FileNotFoundError:
+        return True
+    lock.unlink(missing_ok=True)
+    return True
+
+
+def _scrub_private_material(*paths: Path) -> None:
+    """Remove the row's private key and capability records before the
+    best-effort temp cleanup, so a cleanup failure can never retain them."""
+    for path in paths:
+        try:
+            if path.is_dir():
+                shutil.rmtree(path)
+            else:
+                path.unlink(missing_ok=True)
+        except OSError as error:
+            raise support.ReleaseError(f"could not remove private material {path}: {error}")
+        support.require(not path.exists(), f"private material remains at {path}")
 
 
 def _wait_for_ports_free(*ports: int, timeout: float = 15.0) -> None:
@@ -597,8 +634,9 @@ def exact_a_to_b(
     support.require(_free_port(HTTP_PORT) and _free_port(WS_PORT), "qualification ports are busy")
     output.mkdir(parents=True)
     # A backend that has just been stopped can still hold its capability lock
-    # for a moment on Windows; the wait below covers the normal case and the
-    # cleanup must never fail a row whose evidence is already written.
+    # for a moment; the row waits for that release and removes every private
+    # file itself, so this best-effort cleanup can only ever leave public
+    # scratch (retained wheels, the project) behind on a runner.
     with tempfile.TemporaryDirectory(
         prefix="godot-ai-exact-runtime-", ignore_cleanup_errors=True
     ) as temporary:
@@ -685,7 +723,9 @@ def exact_a_to_b(
                     "update did not download exactly B's canonical signed triple",
                 )
             _wait_for_ports_free(HTTP_PORT, WS_PORT)
-            _wait_for_capability_release(_capability_directory(environment))
+            capability_dir = _capability_directory(environment)
+            _wait_for_capability_release(capability_dir)
+            _scrub_private_material(key, capability_dir)
         result = _read_runtime_result(project)
         support.require(result.get("status") == "passed", "runtime driver did not pass")
         live = project / "addons/godot_ai"

--- a/tests/unit/test_runtime_qualification.py
+++ b/tests/unit/test_runtime_qualification.py
@@ -649,11 +649,13 @@ def test_capability_directory_follows_the_isolated_environment(monkeypatch, tmp_
     # anything constructs a Path: pathlib picks its flavour from os.name, and a
     # mismatch raises on the host (and crashes pytest's failure reporting).
     original = runtime.os.name
-    monkeypatch.setattr(runtime.os, "name", "nt")
-    windows = runtime._isolated_environment(tmp_path / "win", "http://127.0.0.1:1/")
-    monkeypatch.setattr(runtime.os, "name", "posix")
-    posix = runtime._isolated_environment(tmp_path / "posix", "http://127.0.0.1:1/")
-    monkeypatch.setattr(runtime.os, "name", original)
+    try:
+        monkeypatch.setattr(runtime.os, "name", "nt")
+        windows = runtime._isolated_environment(tmp_path / "win", "http://127.0.0.1:1/")
+        monkeypatch.setattr(runtime.os, "name", "posix")
+        posix = runtime._isolated_environment(tmp_path / "posix", "http://127.0.0.1:1/")
+    finally:
+        monkeypatch.setattr(runtime.os, "name", original)
     assert runtime._capability_directory(windows) == (
         tmp_path / "win" / "local-app-data" / "godot-ai" / "capabilities"
     )

--- a/tests/unit/test_runtime_qualification.py
+++ b/tests/unit/test_runtime_qualification.py
@@ -574,3 +574,42 @@ def test_runtime_row_accepts_the_extra_engine_row(monkeypatch, tmp_path):
     output = tmp_path / "output"
     runtime.runtime_row(candidates, python_row, "godot", "4.7.2", output, "ubuntu-latest")
     assert support.read_json(output / "row.json")["godot_version"] == "4.7.2"
+
+
+def test_capability_release_waits_for_a_lock_the_backend_still_holds(monkeypatch, tmp_path):
+    lock = tmp_path / "http-8000.lock"
+    lock.write_text("", encoding="utf-8")
+    attempts = []
+    real_unlink = Path.unlink
+
+    def flaky_unlink(self, *args, **kwargs):
+        attempts.append(self.name)
+        if len(attempts) < 3:
+            raise PermissionError(32, "The process cannot access the file")
+        return real_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", flaky_unlink)
+    monkeypatch.setattr(runtime.time, "sleep", lambda seconds: None)
+    runtime._wait_for_capability_release(tmp_path, timeout=5.0)
+    assert attempts == ["http-8000.lock"] * 3
+    assert not lock.exists()
+
+    lock.write_text("", encoding="utf-8")
+    monkeypatch.setattr(
+        Path, "unlink", lambda self, *a, **k: (_ for _ in ()).throw(PermissionError(32, "held"))
+    )
+    with pytest.raises(support.ReleaseError, match="still holds http-8000.lock"):
+        runtime._wait_for_capability_release(tmp_path, timeout=0.2)
+    # No directory or no locks: nothing to wait for.
+    runtime._wait_for_capability_release(tmp_path / "missing", timeout=0.1)
+
+
+def test_capability_directory_follows_the_isolated_environment(monkeypatch, tmp_path):
+    monkeypatch.setattr(runtime.os, "name", "nt")
+    windows = runtime._isolated_environment(tmp_path / "win", "http://127.0.0.1:1/")
+    monkeypatch.setattr(runtime.os, "name", "posix")
+    posix = runtime._isolated_environment(tmp_path / "posix", "http://127.0.0.1:1/")
+    assert runtime._capability_directory(windows) == (
+        tmp_path / "win" / "local-app-data" / "godot-ai" / "capabilities"
+    )
+    assert runtime._capability_directory(posix) == tmp_path / "posix" / "capabilities"

--- a/tests/unit/test_runtime_qualification.py
+++ b/tests/unit/test_runtime_qualification.py
@@ -605,10 +605,15 @@ def test_capability_release_waits_for_a_lock_the_backend_still_holds(monkeypatch
 
 
 def test_capability_directory_follows_the_isolated_environment(monkeypatch, tmp_path):
+    # Build both environments under a patched os.name, then restore it before
+    # anything constructs a Path: pathlib picks its flavour from os.name, and a
+    # mismatch raises on the host (and crashes pytest's failure reporting).
+    original = runtime.os.name
     monkeypatch.setattr(runtime.os, "name", "nt")
     windows = runtime._isolated_environment(tmp_path / "win", "http://127.0.0.1:1/")
     monkeypatch.setattr(runtime.os, "name", "posix")
     posix = runtime._isolated_environment(tmp_path / "posix", "http://127.0.0.1:1/")
+    monkeypatch.setattr(runtime.os, "name", original)
     assert runtime._capability_directory(windows) == (
         tmp_path / "win" / "local-app-data" / "godot-ai" / "capabilities"
     )

--- a/tests/unit/test_runtime_qualification.py
+++ b/tests/unit/test_runtime_qualification.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import os
 import shutil
 from pathlib import Path
 from types import SimpleNamespace
@@ -577,31 +578,70 @@ def test_runtime_row_accepts_the_extra_engine_row(monkeypatch, tmp_path):
 
 
 def test_capability_release_waits_for_a_lock_the_backend_still_holds(monkeypatch, tmp_path):
-    lock = tmp_path / "http-8000.lock"
-    lock.write_text("", encoding="utf-8")
-    attempts = []
-    real_unlink = Path.unlink
-
-    def flaky_unlink(self, *args, **kwargs):
-        attempts.append(self.name)
-        if len(attempts) < 3:
-            raise PermissionError(32, "The process cannot access the file")
-        return real_unlink(self, *args, **kwargs)
-
-    monkeypatch.setattr(Path, "unlink", flaky_unlink)
-    monkeypatch.setattr(runtime.time, "sleep", lambda seconds: None)
-    runtime._wait_for_capability_release(tmp_path, timeout=5.0)
-    assert attempts == ["http-8000.lock"] * 3
-    assert not lock.exists()
-
-    lock.write_text("", encoding="utf-8")
+    (tmp_path / "http-8000.lock").write_text("", encoding="utf-8")
+    checks = []
     monkeypatch.setattr(
-        Path, "unlink", lambda self, *a, **k: (_ for _ in ()).throw(PermissionError(32, "held"))
+        runtime, "_lock_released", lambda lock: checks.append(lock.name) or len(checks) >= 3
     )
+    sleeps = []
+    monkeypatch.setattr(runtime.time, "sleep", lambda seconds: sleeps.append(seconds))
+    runtime._wait_for_capability_release(tmp_path, timeout=5.0)
+    assert checks == ["http-8000.lock"] * 3
+    assert sleeps and all(0 < s <= 0.5 for s in sleeps)
+
+    checks.clear()
+    monkeypatch.setattr(runtime, "_lock_released", lambda lock: False)
+    monkeypatch.setattr(runtime.time, "sleep", lambda seconds: None)
     with pytest.raises(support.ReleaseError, match="still holds http-8000.lock"):
         runtime._wait_for_capability_release(tmp_path, timeout=0.2)
     # No directory or no locks: nothing to wait for.
     runtime._wait_for_capability_release(tmp_path / "missing", timeout=0.1)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX advisory locks")
+def test_lock_released_takes_the_posix_flock_as_proof(tmp_path):
+    import fcntl
+
+    lock = tmp_path / "http-8000.lock"
+    lock.write_text("", encoding="utf-8")
+    with lock.open("rb") as holder:
+        fcntl.flock(holder.fileno(), fcntl.LOCK_EX)
+        assert runtime._lock_released(lock) is False, "a held flock is not released"
+        assert lock.exists(), "the file must not be deleted while held"
+        fcntl.flock(holder.fileno(), fcntl.LOCK_UN)
+    assert runtime._lock_released(lock) is True
+    assert not lock.exists()
+    assert runtime._lock_released(lock) is True, "a missing lock counts as released"
+
+
+def test_lock_released_on_windows_is_a_successful_delete(monkeypatch, tmp_path):
+    lock = tmp_path / "http-8000.lock"
+    lock.write_text("", encoding="utf-8")
+    monkeypatch.setattr(runtime.os, "name", "nt")
+    held = lambda self, *a, **k: (_ for _ in ()).throw(PermissionError(32, "held"))  # noqa: E731
+    monkeypatch.setattr(Path, "unlink", held)
+    assert runtime._lock_released(lock) is False
+    monkeypatch.undo()
+    monkeypatch.setattr(runtime.os, "name", "nt")
+    assert runtime._lock_released(lock) is True
+    assert runtime._lock_released(lock) is True, "already gone"
+
+
+def test_scrub_private_material_removes_key_and_capabilities_or_fails(monkeypatch, tmp_path):
+    key = tmp_path / "private-key.pem"
+    key.write_text("secret", encoding="utf-8")
+    capabilities = tmp_path / "capabilities"
+    capabilities.mkdir()
+    (capabilities / "http-8000.json").write_text("{}", encoding="utf-8")
+    runtime._scrub_private_material(key, capabilities, tmp_path / "absent")
+    assert not key.exists() and not capabilities.exists()
+
+    capabilities.mkdir()
+    monkeypatch.setattr(
+        runtime.shutil, "rmtree", lambda path: (_ for _ in ()).throw(OSError(32, "held"))
+    )
+    with pytest.raises(support.ReleaseError, match="could not remove private material"):
+        runtime._scrub_private_material(capabilities)
 
 
 def test_capability_directory_follows_the_isolated_environment(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

The third qualification run ([34077763471](https://github.com/hi-godot/godot-ai/actions/runs/34077763471)) passed the Linux 4.7.0, macOS 4.7.0 and Linux 4.7.2 runtime rows. The Windows row got through the first start, the A-to-B update and the headless restart, then failed with `WinError 32` on `capabilities/http-8000.lock` during temp-directory cleanup: the backend the restarted editor had just stopped still held its lock file for a moment after its ports were free, and Windows refuses to delete a held file.

- After the ports free up, the row now waits (bounded, 30 s) for the capability lock files to become removable; a lock held past the deadline is reported as a backend that outlived the editor.
- Temp-directory cleanup uses `ignore_cleanup_errors`, so cleanup can never fail a row whose evidence is already written.
- `_capability_directory` derives the location from the isolated environment the same way the server does.

Unit tests cover the wait (transient sharing violation, held lock, no locks) and the directory derivation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform runtime shutdown by verifying capability locks are released before cleanup.
  * Added bounded retry handling to reduce cleanup delays and clearly report unreleased locks.
  * Ensured private TLS and capability files are removed after backend shutdown, with failures reported appropriately.

* **Tests**
  * Added coverage for POSIX and Windows lock-release behavior.
  * Added coverage for private-material cleanup, retry limits, timeouts, and missing runtime directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->