### PR TITLE
clients: check launch values one by one, never a URI, for ownership

### DIFF
--- a/plugin/addons/godot_ai/clients/_base.gd
+++ b/plugin/addons/godot_ai/clients/_base.gd
@@ -540,29 +540,39 @@ static func _packed_slice(packed: PackedStringArray, from: int, to: int) -> Pack
 ## project directory) does not count. The post-update major migration
 ## rewrites only such entries; anything else is the user's own server.
 static func launch_mentions_godot_ai(text: String) -> bool:
-	for raw_token in text.split(" ", false):
-		var token := raw_token.strip_edges().lstrip("\"'[{(").rstrip("\"'])},")
-		if token.is_empty():
+	## Free text (a CLI probe's output) is split on spaces; structured launch
+	## values should go through `launch_values_mention_godot_ai` unsplit.
+	return launch_values_mention_godot_ai(PackedStringArray(text.split(" ", false)))
+
+
+## Each value is one command, argument or URL. A URI never names an
+## executable, and Windows separators are normalized before the basename
+## check so `C:\Program Files\Godot AI\godot-ai.exe` is recognized whole.
+static func launch_values_mention_godot_ai(values: PackedStringArray) -> bool:
+	for raw_value in values:
+		var value := raw_value.strip_edges().lstrip("\"'[{(").rstrip("\"'])},")
+		if value.is_empty() or value.contains("://"):
 			continue
-		if token == "godot-ai" or token == "godot_ai" or token.begins_with("godot-ai=="):
+		if value == "godot-ai" or value == "godot_ai" or value.begins_with("godot-ai=="):
 			return true
-		var base := token.get_file()
+		var base := value.replace("\\", "/").get_file()
 		if base == "godot-ai" or base == "godot-ai.exe":
 			return true
 	return false
 
 
-## The launch-bearing fields of an entry, as text for the check above. The
-## entry sits under our server name, so the name itself must not count.
-static func entry_launch_text(entry: Dictionary) -> String:
-	var tokens := PackedStringArray()
+## The launch-bearing fields of an entry, one value each, for the check
+## above. The entry sits under our server name, so the name itself must not
+## count.
+static func entry_launch_values(entry: Dictionary) -> PackedStringArray:
+	var values := PackedStringArray()
 	for key in ["command", "args", "url"]:
 		if not entry.has(key):
 			continue
 		var value: Variant = entry[key]
 		if value is Array:
 			for item in value:
-				tokens.append(str(item))
+				values.append(str(item))
 		else:
-			tokens.append(str(value))
-	return " ".join(tokens)
+			values.append(str(value))
+	return values

--- a/plugin/addons/godot_ai/clients/_dsh_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_dsh_strategy.gd
@@ -183,7 +183,7 @@ static func check_status_details(
 	return {
 		"status": McpClient.Status.CONFIGURED_MISMATCH,
 		"error_msg": "",
-		"owned": McpClient.launch_mentions_godot_ai(McpClient.entry_launch_text(config)),
+		"owned": McpClient.launch_values_mention_godot_ai(McpClient.entry_launch_values(config)),
 	}
 
 

--- a/plugin/addons/godot_ai/clients/_json_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_json_strategy.gd
@@ -208,7 +208,7 @@ static func _entry_status_details(
 	return {
 		"status": McpClient.Status.CONFIGURED_MISMATCH,
 		"error_msg": "",
-		"owned": McpClient.launch_mentions_godot_ai(McpClient.entry_launch_text(entry)),
+		"owned": McpClient.launch_values_mention_godot_ai(McpClient.entry_launch_values(entry)),
 	}
 
 

--- a/plugin/addons/godot_ai/clients/_toml_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_toml_strategy.gd
@@ -155,7 +155,7 @@ static func check_status_details(
 	var mismatch := {
 		"status": McpClient.Status.CONFIGURED_MISMATCH,
 		"error_msg": "",
-		"owned": McpClient.launch_mentions_godot_ai(" ".join(launch_tokens)),
+		"owned": McpClient.launch_values_mention_godot_ai(launch_tokens),
 	}
 
 	if client.command_shape != McpClient.CommandShape.NONE:

--- a/plugin/addons/godot_ai/clients/_yaml_strategy.gd
+++ b/plugin/addons/godot_ai/clients/_yaml_strategy.gd
@@ -97,7 +97,7 @@ static func check_status_details(
 	return {
 		"status": McpClient.Status.CONFIGURED_MISMATCH,
 		"error_msg": "",
-		"owned": McpClient.launch_mentions_godot_ai(McpClient.entry_launch_text(entry)),
+		"owned": McpClient.launch_values_mention_godot_ai(McpClient.entry_launch_values(entry)),
 	}
 
 

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -6366,6 +6366,14 @@ func test_launch_mentions_godot_ai_recognizes_our_launch_shapes_only() -> void:
 	assert_false(McpClient.launch_mentions_godot_ai("my-godot-ai-proxy --port 1"))
 	assert_false(McpClient.launch_mentions_godot_ai("godot-ai-helper"))
 	assert_false(McpClient.launch_mentions_godot_ai(""))
+	## Structured values: a path with spaces stays whole; a URI is never an executable.
+	assert_true(McpClient.launch_values_mention_godot_ai(
+		PackedStringArray(["C:\\Program Files\\Godot AI\\godot-ai.exe", "attach"])
+	))
+	assert_true(McpClient.launch_values_mention_godot_ai(PackedStringArray(["/opt/godot ai/bin/godot-ai"])))
+	assert_false(McpClient.launch_values_mention_godot_ai(PackedStringArray(["https://example.com/godot-ai"])))
+	assert_false(McpClient.launch_values_mention_godot_ai(PackedStringArray(["curl", "http://x/godot-ai/"])))
+	assert_false(McpClient.launch_mentions_godot_ai("node https://example.com/godot-ai"))
 
 
 func test_json_mismatch_reports_whether_the_existing_entry_is_ours() -> void:
@@ -6397,7 +6405,18 @@ func test_json_mismatch_reports_whether_the_existing_entry_is_ours() -> void:
 		client, {"name": "godot-ai", "command": "/usr/bin/python3", "args": ["srv.py"]}, "http://x", launch
 	)
 	assert_false(bool(named.get("owned", true)), "the entry name is not a launch")
-	assert_eq(McpClient.entry_launch_text({"name": "godot-ai", "command": "x", "args": ["a", 1]}), "x a 1")
+	assert_eq(
+		McpClient.entry_launch_values({"name": "godot-ai", "command": "x", "args": ["a", 1]}),
+		PackedStringArray(["x", "a", "1"]),
+	)
+	var url_entry := McpJsonStrategy._entry_status_details(
+		client, {"command": "node", "args": ["https://example.com/godot-ai"]}, "http://x", launch
+	)
+	assert_false(bool(url_entry.get("owned", true)), "a URL ending in our name is not a launch")
+	var spaced := McpJsonStrategy._entry_status_details(
+		client, {"command": "C:\\Program Files\\Godot AI\\godot-ai.exe", "args": ["attach"]}, "http://x", launch
+	)
+	assert_true(bool(spaced.get("owned", false)), "a Windows path with spaces is ours")
 	var docs_link := McpJsonStrategy._entry_status_details(
 		client,
 		{"command": "node", "args": ["server.js", "https://example.com/godot-ai/docs"]},


### PR DESCRIPTION
## Summary

Follow-up to #973 for CodeRabbit's two findings on it, which were posted after CI had gone green and before the merge:

1. **Structured values instead of flattened text.** `entry_launch_values` now hands each command, argument and URL value to `launch_values_mention_godot_ai` whole, so a Windows path with spaces such as `C:\Program Files\Godot AI\godot-ai.exe` is recognized by its basename after separator normalization. The space-splitting variant stays only for CLI probe output.
2. **URIs are never executables.** A value containing `://` is skipped before the basename check, so `https://example.com/godot-ai` no longer marks a foreign entry as ours.

Tests: GDScript cases for the spaced Windows path, a URL ending in `/godot-ai`, and a JSON entry carrying that URL; the foreign-entry and fresh-project first-start scenarios re-run in a real editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of Godot AI launch configurations across JSON, TOML, YAML, and other client entries.
  * Correctly recognizes executable paths containing spaces and Windows-style paths.
  * Prevents URLs and other URI values from being incorrectly identified as Godot AI launches.
  * Improves ownership reporting for mismatched existing configurations.

* **Tests**
  * Added coverage for structured launch values, paths with spaces, Windows paths, and URL handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->