### PR TITLE
qualification: record a download before writing its body

### DIFF
--- a/script/qualification_https.py
+++ b/script/qualification_https.py
@@ -155,9 +155,11 @@ def private_release_origin(
             self.send_header("Content-Length", str(len(payload)))
             self.end_headers()
             if not head_only:
-                self.wfile.write(payload)
+                # Record before writing: a client that has read the whole body
+                # may inspect the record before this thread returns from write.
                 if self.path != RELEASE_PATH:
                     downloads.append(name)
+                self.wfile.write(payload)
 
     class ConnectHandler(QuietHandler):
         def do_CONNECT(self):


### PR DESCRIPTION
## Summary

Main's CI on the #972 merge commit ([34078702104](https://github.com/hi-godot/godot-ai/actions/runs/34078702104)) failed once on macOS 3.14 in `test_origin_serves_exact_bytes_over_verified_tls_and_keeps_token_private`: the private origin appended the download record only after `wfile.write` returned, so a client that had already read the full body (Content-Length is known) could assert on `downloads` before the server thread recorded the last asset. The record now precedes the write. Pre-existing race, unrelated to #972.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Download records are now available as soon as the full asset response is received, improving consistency for clients tracking downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->