### PR TITLE
qualification: give the restarted editor two minutes to take its backend down

### DIFF
--- a/script/runtime_qualification.py
+++ b/script/runtime_qualification.py
@@ -156,11 +156,20 @@ def _scrub_private_material(*paths: Path) -> None:
         support.require(not path.exists(), f"private material remains at {path}")
 
 
-def _wait_for_ports_free(*ports: int, timeout: float = 15.0) -> None:
-    deadline = time.monotonic() + timeout
+# The restarted editor writes its result, then quits; its teardown kills the
+# backend tree, and on a loaded Windows runner the whole exit has taken longer
+# than 15 s (qualification run 34079902982) while run 34077763471 cleared it.
+# A backend that never lets go is still refused, just later.
+EDITOR_EXIT_TIMEOUT_SECONDS = 120.0
+
+
+def _wait_for_ports_free(*ports: int, timeout: float = 15.0) -> float:
+    """Seconds until every port was free; refuses when the backend stays up."""
+    started = time.monotonic()
+    deadline = started + timeout
     while time.monotonic() < deadline:
         if all(_free_port(port) for port in ports):
-            return
+            return time.monotonic() - started
         time.sleep(0.1)
     raise support.ReleaseError("candidate backend remained live after editor exit")
 
@@ -722,7 +731,8 @@ def exact_a_to_b(
                     ],
                     "update did not download exactly B's canonical signed triple",
                 )
-            _wait_for_ports_free(HTTP_PORT, WS_PORT)
+            released = _wait_for_ports_free(HTTP_PORT, WS_PORT, timeout=EDITOR_EXIT_TIMEOUT_SECONDS)
+            print(f"backend released its ports {released:.1f}s after the editor's result")
             capability_dir = _capability_directory(environment)
             _wait_for_capability_release(capability_dir)
             _scrub_private_material(key, capability_dir)

--- a/tests/unit/test_runtime_qualification.py
+++ b/tests/unit/test_runtime_qualification.py
@@ -660,3 +660,14 @@ def test_capability_directory_follows_the_isolated_environment(monkeypatch, tmp_
         tmp_path / "win" / "local-app-data" / "godot-ai" / "capabilities"
     )
     assert runtime._capability_directory(posix) == tmp_path / "posix" / "capabilities"
+
+
+def test_ports_free_wait_reports_elapsed_and_refuses_a_lingering_backend(monkeypatch):
+    answers = iter([False, False, True])
+    monkeypatch.setattr(runtime, "_free_port", lambda port: next(answers))
+    monkeypatch.setattr(runtime.time, "sleep", lambda seconds: None)
+    assert runtime._wait_for_ports_free(8000, timeout=5.0) >= 0.0
+    monkeypatch.setattr(runtime, "_free_port", lambda port: False)
+    with pytest.raises(support.ReleaseError, match="remained live after editor exit"):
+        runtime._wait_for_ports_free(8000, 9500, timeout=0.2)
+    assert runtime.EDITOR_EXIT_TIMEOUT_SECONDS >= 60.0


### PR DESCRIPTION
## Summary

Qualification run 4 ([34079902982](https://github.com/hi-godot/godot-ai/actions/runs/34079902982)) passed the Linux 4.7.0, Linux 4.7.2 and macOS rows. The Windows row got through the first start, the A-to-B update, the headless restart, and the restarted editor served B and wrote its result; then the row's 15-second wait for the backend's ports expired ("candidate backend remained live after editor exit"). Run 3 had cleared that same wait, so this is shutdown-time variance on the Windows runner: the editor kills its backend tree (`taskkill /T`) during its own exit, which takes longer there.

- The post-exit wait is now two minutes, and the row prints how long the release actually took, so the next run leaves a number behind.
- A backend that never releases its ports is still refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
