### PR TITLE
ci: remove duplicate runtime evidence scans and show progress

### DIFF
--- a/script/runtime_qualification.py
+++ b/script/runtime_qualification.py
@@ -651,6 +651,7 @@ def exact_a_to_b(
             uvx = shutil.which("uvx", path=environment.get("PATH"))
             support.require(uvx is not None, "uvx is required for runtime qualification")
             _write_client_pin(Path(environment["CODEX_HOME"]), uvx, records["a"]["version"])
+            print("Installing signed candidate A in the disposable project", flush=True)
             command = [
                 sys.executable,
                 str(support.ROOT / "script/v4-release"),
@@ -696,6 +697,7 @@ def exact_a_to_b(
                         "PRIVATE_HTTPS_CERTIFICATE": str(certificate),
                     }
                 )
+                print(f"Running the A-to-B update in Godot {godot_version}", flush=True)
                 completed = subprocess.run(
                     _editor_command(executable, project),
                     cwd=work,
@@ -712,6 +714,7 @@ def exact_a_to_b(
                 support.require(completed.returncode == 0, "real Godot A-to-B update failed")
                 # The swap restarts the editor; the process above exits and
                 # the restarted editor finishes the case and writes the result.
+                print("Waiting for the restarted editor to report candidate B", flush=True)
                 _wait_for_runtime_result(project / "runtime-result.json", TIMEOUT_SECONDS)
                 support.require(
                     release.downloads
@@ -726,12 +729,12 @@ def exact_a_to_b(
             capability_dir = _capability_directory(environment)
             _wait_for_capability_release(capability_dir)
             _scrub_private_material(key, capability_dir)
+        print("Verifying update evidence and private-data cleanup", flush=True)
         result = _read_runtime_result(project)
         support.require(result.get("status") == "passed", "runtime driver did not pass")
         live = project / "addons/godot_ai"
-        support.require(
-            support.inventory(live) == _manifest_tree(candidates / "b"), "live tree is not exact B"
-        )
+        live_tree = support.inventory(live)
+        support.require(live_tree == _manifest_tree(candidates / "b"), "live tree is not exact B")
         config = Path(environment["CODEX_HOME"]) / "config.toml"
         text = config.read_text(encoding="utf-8")
         support.require(
@@ -744,7 +747,6 @@ def exact_a_to_b(
         update = _verify_lean_update(project, candidates, records)
         private_values = (release.token, index, _private_index_capability(index), ORIGIN)
         _require_values_absent(project, private_values)
-        _require_values_absent(project / UPDATE_STATE, private_values)
         _require_values_absent(output, private_values)
         return {
             **result,
@@ -754,7 +756,7 @@ def exact_a_to_b(
                 "version": actual_godot_version,
             },
             "index_artifacts_requested": sorted(set(index_requests)),
-            "live_tree": support.inventory(live),
+            "live_tree": live_tree,
             "backend_stopped": True,
             **update,
         }

--- a/tests/unit/test_runtime_qualification.py
+++ b/tests/unit/test_runtime_qualification.py
@@ -246,15 +246,16 @@ def test_private_capability_is_never_written_to_retained_log(tmp_path):
     )
 
 
-def test_private_capability_scan_covers_nested_retained_files(tmp_path):
-    nested = tmp_path / "nested"
-    nested.mkdir()
+@pytest.mark.parametrize("relative", ["nested", "addons/.godot_ai_update/backup/4.0.0"])
+def test_private_capability_scan_covers_nested_retained_files(tmp_path, relative):
+    nested = tmp_path / relative
+    nested.mkdir(parents=True)
     (nested / "clean.bin").write_bytes(b"ordinary retained evidence")
     runtime._require_values_absent(tmp_path, ("private-token",))
     (nested / "leak.bin").write_bytes(b"prefix private-token suffix")
     with pytest.raises(support.ReleaseError) as caught:
         runtime._require_values_absent(tmp_path, ("private-token",))
-    assert f"persisted in {Path('nested') / 'leak.bin'}" in str(caught.value)
+    assert f"persisted in {Path(relative) / 'leak.bin'}" in str(caught.value)
 
 
 def test_private_index_path_capability_can_be_scanned_independently():


### PR DESCRIPTION
The exact A-to-B runtime harness recursively scanned the update-state directory twice and read the live add-on inventory twice. Scan the project once (including its nested update state) and reuse the verified inventory in the final report. Add progress messages for installing A, running the update, waiting for the restarted editor, and verifying retained evidence.

All four runtime rows and their signed-artifact, restart, client-pin, backup, leak, and shutdown assertions remain in place. Each row runs one actual upgrade; this change does not remove platform coverage or change retries/timeouts.

The Windows shutdown-wait failure from run 34079902982 is being addressed separately by #978. Its patch applies cleanly alongside this change; the shutdown fix and run-5 preparation are left to that work.

Validation: expanded the existing private-data scan regression to cover the nested retained updater backup; Ruff, the full Python suite, and the full live Godot handler suite passed. The modified runtime harness also ran against the exact signed A/B candidates locally on macOS with Godot 4.7.0 and Python 3.14, using the retained dependency evidence from the Python qualification row.
