### PR TITLE
test: fix Windows nightly attached-client launch and isolation

### DIFF
--- a/tests/integration/_self_update_fixture.py
+++ b/tests/integration/_self_update_fixture.py
@@ -16,7 +16,7 @@ from typing import Callable
 
 import pytest
 
-from godot_ai.transport.capability import CAPABILITY_DIR_ENV, read_capabilities
+from godot_ai.transport.capability import read_capabilities
 
 ROOT = Path(__file__).resolve().parents[2]
 PLUGIN_ROOT = ROOT / "plugin" / "addons" / "godot_ai"
@@ -572,12 +572,19 @@ class AttachedAgent:
     """
 
     def __init__(
-        self, project_dir: Path, http_port: int, ws_port: int, *, capability_dir: Path
+        self,
+        project_dir: Path,
+        http_port: int,
+        ws_port: int,
+        *,
+        capability_dir: Path,
+        environment: dict[str, str],
     ) -> None:
         self.project_dir = project_dir
         self.http_port = http_port
         self.ws_port = ws_port
         self.capability_dir = capability_dir
+        self.environment = environment
         self.ok = 0
         self.errors: list[str] = []
         self.fault: str = ""
@@ -609,8 +616,10 @@ class AttachedAgent:
                 raise AssertionError("server A never published capabilities")
             await asyncio.sleep(0.25)
         transport = StdioTransport(
-            command=str(Path(sys.executable).parent / "godot-ai"),
+            command=sys.executable,
             args=[
+                "-m",
+                "godot_ai",
                 "attach",
                 "--port",
                 str(self.http_port),
@@ -620,7 +629,7 @@ class AttachedAgent:
             ],
             env={
                 **os.environ,
-                CAPABILITY_DIR_ENV: str(capability_dir),
+                **self.environment,
                 "GODOT_AI_DISABLE_TELEMETRY": "true",
             },
         )

--- a/tests/integration/test_self_update_upgrade_paths.py
+++ b/tests/integration/test_self_update_upgrade_paths.py
@@ -474,7 +474,9 @@ def test_signed_update_restarts_into_matching_live_server(
     # AI client would be. Its bridge loses server A, spawns a backend of the
     # old version into the restart window, and the restarted editor must
     # replace that backend on its own rather than ask the user to.
-    with AttachedAgent(project, http_port, ws_port, capability_dir=capability_dir) as agent:
+    with AttachedAgent(
+        project, http_port, ws_port, capability_dir=capability_dir, environment=environment
+    ) as agent:
         try:
             log = run_godot_editor(
                 project,

--- a/tests/unit/test_self_update_editor_harness.py
+++ b/tests/unit/test_self_update_editor_harness.py
@@ -122,3 +122,49 @@ def test_timeout_reports_progress_without_suppressing_failure(
         fixture.run_godot_editor(tmp_path, "godot", allow_headless=True, timeout=20)
     assert stopped == ["terminate", "kill"]
     assert "remaining=4s" in capsys.readouterr().out
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("capability_env", ["LOCALAPPDATA", "GODOT_AI_CAPABILITY_DIR"])
+async def test_attached_agent_uses_python_and_the_editors_isolated_environment(
+    monkeypatch, tmp_path, capability_env
+):
+    import fastmcp
+    from fastmcp.client import transports
+
+    environment = {
+        capability_env: str(tmp_path / "private storage"),
+        "CODEX_HOME": str(tmp_path / "codex"),
+        "GODOT_AI_MODE": "user",
+    }
+    monkeypatch.setenv(capability_env, "unrelated-user-storage")
+    agent = fixture.AttachedAgent(
+        tmp_path, 18000, 19500, capability_dir=tmp_path, environment=environment
+    )
+    captured = {}
+    monkeypatch.setattr(fixture, "read_capabilities", lambda *_args: object())
+
+    def transport(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    class Client:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        async def __aenter__(self):
+            agent._stop.set()
+            return self
+
+        async def __aexit__(self, *_args):
+            pass
+
+    monkeypatch.setattr(transports, "StdioTransport", transport)
+    monkeypatch.setattr(fastmcp, "Client", Client)
+    await agent._poll()
+
+    assert captured["command"] == fixture.sys.executable
+    assert captured["args"][:3] == ["-m", "godot_ai", "attach"]
+    for name, value in environment.items():
+        assert captured["env"][name] == value
+    assert captured["env"]["GODOT_AI_DISABLE_TELEMETRY"] == "true"

--- a/tests/unit/test_self_update_editor_harness.py
+++ b/tests/unit/test_self_update_editor_harness.py
@@ -138,6 +138,7 @@ async def test_attached_agent_uses_python_and_the_editors_isolated_environment(
         "GODOT_AI_MODE": "user",
     }
     monkeypatch.setenv(capability_env, "unrelated-user-storage")
+    monkeypatch.setenv("ATTACHED_AGENT_INHERITED_SENTINEL", "preserved")
     agent = fixture.AttachedAgent(
         tmp_path, 18000, 19500, capability_dir=tmp_path, environment=environment
     )
@@ -168,3 +169,4 @@ async def test_attached_agent_uses_python_and_the_editors_isolated_environment(
     for name, value in environment.items():
         assert captured["env"][name] == value
     assert captured["env"]["GODOT_AI_DISABLE_TELEMETRY"] == "true"
+    assert captured["env"]["ATTACHED_AGENT_INHERITED_SENTINEL"] == "preserved"


### PR DESCRIPTION
The Windows updater nightly failed before its attached MCP client made any successful call (`WinError 2`), then timed out waiting for that client. The fixture constructed a Unix-style sibling `godot-ai` path beside `python.exe`; Windows puts console entry points under `Scripts`. It also gave the client a POSIX capability override instead of the editor's isolated Windows `LOCALAPPDATA`.

Launch the client with the current Python interpreter and `-m godot_ai attach`, and pass the editor's isolated environment to the bridge. The regression test covers Windows and POSIX capability storage and ensures the interpreter is used directly.

This is distinct from #978's post-update backend shutdown wait. No production updater or timeout behavior changes.

Validation: Ruff, the full Python suite, the full Godot handler suite, and the real signed private-HTTPS updater scenario passed locally. A branch run of nightly diagnostics will validate the Windows real-editor scenario.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed attached-agent startup so it uses the same isolated environment as the editor.
  - Preserved user-specific configuration and capability settings when restarting during signed updates.
  - Ensured unrelated environment settings remain available while telemetry stays disabled in the isolated editor environment.

- **Tests**
  - Added coverage verifying that the attached agent uses the active Python interpreter and correctly inherits configured environment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Authored and validated by Codex.
