### PR TITLE
release: refuse output directories Windows cannot stage under (#945)

### DIFF
--- a/script/v4-release
+++ b/script/v4-release
@@ -400,7 +400,21 @@ def _write_zip(path: Path, snapshot: list[tuple[str, bytes]]) -> None:
             archive.writestr(info, data)
 
 
+# Windows without long-path support refuses paths past 260 characters, and the
+# staging directories under the output directory add about 40 more (#945).
+MAX_WINDOWS_OUTPUT_PATH = 200
+
+
 def _require_new_destinations(destinations: tuple[Path, ...]) -> None:
+    for path in destinations:
+        parent = str(path.parent)
+        if os.name == "nt" and len(parent) > MAX_WINDOWS_OUTPUT_PATH:
+            _fail(
+                "output",
+                f"output directory is {len(parent)} characters; Windows without long-path"
+                f" support fails once staging directories are added (limit"
+                f" {MAX_WINDOWS_OUTPUT_PATH}): choose a shorter --output-dir or enable long paths",
+            )
     occupied = [path for path in destinations if os.path.lexists(path)]
     if occupied:
         _fail("output", f"immutable destination already exists: {occupied[0]}")
@@ -653,7 +667,7 @@ def package_release(
     output_dir.mkdir(parents=True, exist_ok=True)
     destinations = tuple(output_dir / name for name in (ASSET_NAME, MANIFEST_NAME))
     _require_new_destinations(destinations)
-    with tempfile.TemporaryDirectory(prefix=".v4-release-", dir=output_dir) as temporary:
+    with tempfile.TemporaryDirectory(prefix=".pkg-", dir=output_dir) as temporary:
         archive, manifest_path = (Path(temporary) / path.name for path in destinations)
         _write_zip(archive, snapshot)
         size, digest = _hash_file(archive, MAX_ARCHIVE_SIZE)
@@ -699,7 +713,7 @@ def sign_release(
     raw = _read_bounded(manifest_path, MAX_MANIFEST_SIZE)
     _validate_manifest(raw, expected)
     signature.parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.TemporaryDirectory(prefix=".v4-sign-", dir=signature.parent) as temporary:
+    with tempfile.TemporaryDirectory(prefix=".sig-", dir=signature.parent) as temporary:
         candidate = Path(temporary) / SIGNATURE_NAME
         # OpenSSL's Windows file APIs may reject nested staging paths even
         # when Python supports them. Only the key needs a filesystem argument.
@@ -723,7 +737,7 @@ def build_release(
     destinations = tuple(output_dir / name for name in (ASSET_NAME, MANIFEST_NAME, SIGNATURE_NAME))
     _require_new_destinations(destinations)
     expected = (REPOSITORY, channel, tag, version, source_commit)
-    with tempfile.TemporaryDirectory(prefix=".v4-build-", dir=output_dir) as temporary:
+    with tempfile.TemporaryDirectory(prefix=".bld-", dir=output_dir) as temporary:
         root = Path(temporary)
         archive, manifest = package_release(repo_root, root, channel, tag, version, source_commit)
         signature = sign_release(manifest, root / SIGNATURE_NAME, private_key, expected)
@@ -809,7 +823,7 @@ def build_migration_capsule(
     if sum(len(data) for _path, data in snapshot) > LEGACY_MAX_ARCHIVE_SIZE:
         _fail("migration capsule", "expanded payload exceeds release bound")
 
-    with tempfile.TemporaryDirectory(prefix=".v4-bridge-", dir=output_dir) as temporary:
+    with tempfile.TemporaryDirectory(prefix=".brg-", dir=output_dir) as temporary:
         root = Path(temporary)
         archive = root / LEGACY_ASSET_NAME
         checksum = root / LEGACY_CHECKSUM_NAME
@@ -849,7 +863,7 @@ def build_release_set(
     destinations = tuple(output_dir / name for name in names)
     _require_new_destinations(destinations)
     expected = (REPOSITORY, channel, tag, version, source_commit)
-    with tempfile.TemporaryDirectory(prefix=".v4-release-set-", dir=output_dir) as temporary:
+    with tempfile.TemporaryDirectory(prefix=".set-", dir=output_dir) as temporary:
         root = Path(temporary)
         canonical = build_release(
             repo_root, root, private_key, channel, tag, version, source_commit

--- a/script/v4-release
+++ b/script/v4-release
@@ -405,10 +405,30 @@ def _write_zip(path: Path, snapshot: list[tuple[str, bytes]]) -> None:
 MAX_WINDOWS_OUTPUT_PATH = 200
 
 
+def _windows_long_paths_enabled() -> bool:
+    """Whether this Windows lets paths pass 260 characters (registry opt-in)."""
+    if os.name != "nt":
+        return True
+    try:
+        import winreg
+
+        with winreg.OpenKey(
+            winreg.HKEY_LOCAL_MACHINE, r"SYSTEM\CurrentControlSet\Control\FileSystem"
+        ) as key:
+            value, _kind = winreg.QueryValueEx(key, "LongPathsEnabled")
+            return int(value) == 1
+    except OSError:
+        return False
+
+
 def _require_new_destinations(destinations: tuple[Path, ...]) -> None:
     for path in destinations:
         parent = str(path.parent)
-        if os.name == "nt" and len(parent) > MAX_WINDOWS_OUTPUT_PATH:
+        if (
+            os.name == "nt"
+            and len(parent) > MAX_WINDOWS_OUTPUT_PATH
+            and not _windows_long_paths_enabled()
+        ):
             _fail(
                 "output",
                 f"output directory is {len(parent)} characters; Windows without long-path"

--- a/script/v4-release
+++ b/script/v4-release
@@ -421,20 +421,27 @@ def _windows_long_paths_enabled() -> bool:
         return False
 
 
+def _require_workable_output_dir(output_dir: Path) -> None:
+    """Refuse, before anything is created, a directory Windows cannot stage under.
+
+    Only the operator's own --output-dir is measured; the staging roots the
+    build nests under it are internal and add a known ~40 characters.
+    """
+    chosen = str(output_dir)
+    if (
+        os.name == "nt"
+        and len(chosen) > MAX_WINDOWS_OUTPUT_PATH
+        and not _windows_long_paths_enabled()
+    ):
+        _fail(
+            "output",
+            f"output directory is {len(chosen)} characters; Windows without long-path"
+            f" support fails once staging directories are added (limit"
+            f" {MAX_WINDOWS_OUTPUT_PATH}): choose a shorter --output-dir or enable long paths",
+        )
+
+
 def _require_new_destinations(destinations: tuple[Path, ...]) -> None:
-    for path in destinations:
-        parent = str(path.parent)
-        if (
-            os.name == "nt"
-            and len(parent) > MAX_WINDOWS_OUTPUT_PATH
-            and not _windows_long_paths_enabled()
-        ):
-            _fail(
-                "output",
-                f"output directory is {len(parent)} characters; Windows without long-path"
-                f" support fails once staging directories are added (limit"
-                f" {MAX_WINDOWS_OUTPUT_PATH}): choose a shorter --output-dir or enable long paths",
-            )
     occupied = [path for path in destinations if os.path.lexists(path)]
     if occupied:
         _fail("output", f"immutable destination already exists: {occupied[0]}")
@@ -955,6 +962,10 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     args = _parser().parse_args(argv)
     try:
+        ## The operator's directory is checked once, before any command creates it.
+        output_dir = getattr(args, "output_dir", None)
+        if output_dir is not None:
+            _require_workable_output_dir(Path(output_dir).resolve())
         if args.command == "package":
             outputs = package_release(
                 args.repo_root,

--- a/tests/unit/test_v4_release.py
+++ b/tests/unit/test_v4_release.py
@@ -892,9 +892,14 @@ def test_windows_refuses_an_output_directory_too_long_for_staging(tmp_path, monk
     original = v4_release.os.name
     try:
         monkeypatch.setattr(v4_release.os, "name", "nt")
+        monkeypatch.setattr(v4_release, "_windows_long_paths_enabled", lambda: False)
         with pytest.raises(v4_release.ReleaseError, match="shorter --output-dir"):
             v4_release._require_new_destinations((long_destination,))
         v4_release._require_new_destinations((short_destination,))
+        # A Windows with long paths enabled (the hosted runners) stages anywhere.
+        monkeypatch.setattr(v4_release, "_windows_long_paths_enabled", lambda: True)
+        v4_release._require_new_destinations((long_destination,))
+        monkeypatch.setattr(v4_release, "_windows_long_paths_enabled", lambda: False)
         monkeypatch.setattr(v4_release.os, "name", "posix")
         v4_release._require_new_destinations((long_destination,))
     finally:

--- a/tests/unit/test_v4_release.py
+++ b/tests/unit/test_v4_release.py
@@ -882,3 +882,20 @@ def test_workspace_mutation_after_source_check_cannot_enter_package(
     )
     with zipfile.ZipFile(archive) as package:
         assert package.read(f"{v4_release.PLUGIN_PREFIX}plugin.gd") == committed
+
+
+def test_windows_refuses_an_output_directory_too_long_for_staging(tmp_path, monkeypatch):
+    # Paths are built before os.name is patched: pathlib picks its flavour
+    # from os.name, and the check must only read the strings.
+    long_destination = tmp_path / ("d" * 220) / "godot-ai-v4-plugin.zip"
+    short_destination = tmp_path / "godot-ai-v4-plugin.zip"
+    original = v4_release.os.name
+    try:
+        monkeypatch.setattr(v4_release.os, "name", "nt")
+        with pytest.raises(v4_release.ReleaseError, match="shorter --output-dir"):
+            v4_release._require_new_destinations((long_destination,))
+        v4_release._require_new_destinations((short_destination,))
+        monkeypatch.setattr(v4_release.os, "name", "posix")
+        v4_release._require_new_destinations((long_destination,))
+    finally:
+        monkeypatch.setattr(v4_release.os, "name", original)

--- a/tests/unit/test_v4_release.py
+++ b/tests/unit/test_v4_release.py
@@ -887,20 +887,54 @@ def test_workspace_mutation_after_source_check_cannot_enter_package(
 def test_windows_refuses_an_output_directory_too_long_for_staging(tmp_path, monkeypatch):
     # Paths are built before os.name is patched: pathlib picks its flavour
     # from os.name, and the check must only read the strings.
-    long_destination = tmp_path / ("d" * 220) / "godot-ai-v4-plugin.zip"
-    short_destination = tmp_path / "godot-ai-v4-plugin.zip"
+    long_dir = tmp_path / ("d" * 220)
+    short_dir = tmp_path / "out"
     original = v4_release.os.name
     try:
         monkeypatch.setattr(v4_release.os, "name", "nt")
         monkeypatch.setattr(v4_release, "_windows_long_paths_enabled", lambda: False)
         with pytest.raises(v4_release.ReleaseError, match="shorter --output-dir"):
-            v4_release._require_new_destinations((long_destination,))
-        v4_release._require_new_destinations((short_destination,))
+            v4_release._require_workable_output_dir(long_dir)
+        v4_release._require_workable_output_dir(short_dir)
+        # Internal staging roots are never measured: only the operator's directory is.
+        v4_release._require_new_destinations((long_dir / ".bld-abc" / "godot-ai-v4-plugin.zip",))
         # A Windows with long paths enabled (the hosted runners) stages anywhere.
         monkeypatch.setattr(v4_release, "_windows_long_paths_enabled", lambda: True)
-        v4_release._require_new_destinations((long_destination,))
+        v4_release._require_workable_output_dir(long_dir)
         monkeypatch.setattr(v4_release, "_windows_long_paths_enabled", lambda: False)
         monkeypatch.setattr(v4_release.os, "name", "posix")
-        v4_release._require_new_destinations((long_destination,))
+        v4_release._require_workable_output_dir(long_dir)
     finally:
         monkeypatch.setattr(v4_release.os, "name", original)
+
+
+def test_cli_checks_the_output_directory_before_creating_it(tmp_path, monkeypatch, capsys):
+    target = tmp_path / "never-created"
+
+    def refuse(output_dir):
+        assert output_dir == target.resolve()
+        raise v4_release.ReleaseError("output: too long for this Windows")
+
+    monkeypatch.setattr(v4_release, "_require_workable_output_dir", refuse)
+    code = v4_release.main(
+        [
+            "build",
+            "--repo-root",
+            str(tmp_path),
+            "--output-dir",
+            str(target),
+            "--private-key",
+            str(tmp_path / "missing.pem"),
+            "--channel",
+            "stable",
+            "--tag",
+            "v4.0.0",
+            "--version",
+            "4.0.0",
+            "--source-commit",
+            "0" * 40,
+        ]
+    )
+    assert code == 1
+    assert "too long for this Windows" in capsys.readouterr().err
+    assert not target.exists(), "the refusal must come before mkdir"


### PR DESCRIPTION
## Summary

Fixes #945. `script/v4-release build` nested three staging directories under `--output-dir` (about 75 extra characters), and on Windows without long-path support a path past 260 characters failed with a misleading openssl error.

- Staging names are short now (`.set-`, `.bld-`, `.pkg-`, `.sig-`, `.brg-` plus the random suffix): about 40 characters of nesting.
- On Windows, `_require_new_destinations` refuses an output directory longer than 200 characters before anything is staged, naming the limit and the two remedies (a shorter `--output-dir`, or enabling long paths).
- Unit test covers the refusal, the short path, and that POSIX is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Release builds now check Windows long-path support before creating the selected output directory.
  * On systems without long-path support, overly long output directories are rejected with guidance to choose a shorter path.
  * Long output paths remain supported when Windows long-path capability is enabled.
  * Internal staging paths are no longer incorrectly rejected because they are nested under a long output directory.

* **Tests**
  * Expanded coverage for Windows path limits, long-path support, cross-platform behavior, and preventing output-directory creation after validation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->