### PR TITLE
lifecycle: re-probe a lost endpoint with a bounded backoff (#962)

### DIFF
--- a/docs/server-lifecycle.md
+++ b/docs/server-lifecycle.md
@@ -28,6 +28,13 @@ READY   -> STOPPING -> DORMANT
 BLOCKED -> RECOVERING -> STARTING
 ```
 
+An authenticated endpoint that drops moves `READY -> BLOCKED(endpoint_lost)`
+and revokes the connection, then re-probes on its own with a bounded backoff
+(1, 2, 4, 8, 16 s; five attempts per outage), each attempt running the same
+start path a dock Restart would, so the server must re-prove its capability.
+After the last attempt the block stays until Restart. A server that holds for
+a minute earns a fresh budget; one that flaps faster spends it and stops.
+
 Startup effects are `PROBE`, `LAUNCH`, and `PROVE`; control effects are
 `REPLACE` and `STOP`. Every effect carries the active episode ID. Completion
 for an older or cancelled episode is discarded, so a late worker cannot revive

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -37,6 +37,18 @@ const DEFAULT_PROBE_TIMEOUT_MS := 800
 const DEFAULT_PROVE_TIMEOUT_MS := 180_000
 const LAUNCH_FINGERPRINT_TIMEOUT_MS := 15_000
 const REPLACEMENT_TTL_MS := 15_000
+## An authenticated endpoint that drops (a late keepalive, a server restart)
+## is re-probed automatically with this backoff, each attempt re-proving the
+## server exactly as a start does; after the last one the block stays until
+## the dock's Restart (#962). A server that stays ready this long earns a
+## fresh budget, so a flapping one cannot loop forever.
+const ENDPOINT_RECOVERY_DELAYS_SECONDS: Array[float] = [1.0, 2.0, 4.0, 8.0, 16.0]
+const ENDPOINT_RECOVERY_STABLE_MS := 60_000
+
+var _endpoint_recovery_attempts := 0
+var _endpoint_recovery_started_msec := 0
+## The episode whose re-probe is scheduled; 0 when none is pending.
+var _endpoint_recovery_pending_episode := 0
 const MAX_STATUS_BODY_BYTES := 8 * 1024
 
 var _episode: Dictionary = _dormant_episode(0)
@@ -277,7 +289,55 @@ func transport_lost(reason := "Authenticated server endpoint was lost.") -> void
 	if str(_episode.get("state")) != READY:
 		return
 	_transport = null
-	_block("endpoint_lost", reason)
+	var limit := ENDPOINT_RECOVERY_DELAYS_SECONDS.size()
+	if _endpoint_recovery_attempts >= limit:
+		_block(
+			"endpoint_lost",
+			"%s Automatic re-probing gave up after %d attempts; click Restart." % [reason, limit],
+		)
+		return
+	_endpoint_recovery_attempts += 1
+	var delay := float(ENDPOINT_RECOVERY_DELAYS_SECONDS[_endpoint_recovery_attempts - 1])
+	_block(
+		"endpoint_lost",
+		"%s Re-probing in %ds (attempt %d of %d)." % [
+			reason, int(delay), _endpoint_recovery_attempts, limit,
+		],
+	)
+	print(
+		"MCP | server endpoint lost (%s); re-probing in %ds (attempt %d of %d)"
+		% [reason, int(delay), _endpoint_recovery_attempts, limit]
+	)
+	_endpoint_recovery_pending_episode = int(_episode.get("id", 0))
+	if bool(_plan.get("automatic_effects", true)):
+		_recover_lost_endpoint_after(delay, _endpoint_recovery_pending_episode)
+
+
+## The scheduled re-probe. Only the episode that lost its endpoint, and only
+## while its attempt is still pending, may start it: a dock Restart or a
+## newer loss in between supersedes the timer.
+func recover_lost_endpoint(episode_id: int) -> bool:
+	if episode_id <= 0 or episode_id != _endpoint_recovery_pending_episode:
+		return false
+	if episode_id != int(_episode.get("id", -1)):
+		_endpoint_recovery_pending_episode = 0
+		return false
+	if str(_episode.get("state")) != BLOCKED or str(_episode.get("reason")) != "endpoint_lost":
+		_endpoint_recovery_pending_episode = 0
+		return false
+	_endpoint_recovery_pending_episode = 0
+	_endpoint_recovery_started_msec = Time.get_ticks_msec()
+	start_server()
+	return str(_episode.get("state")) != BLOCKED
+
+
+func _recover_lost_endpoint_after(delay_seconds: float, episode_id: int) -> void:
+	var tree := Engine.get_main_loop()
+	if tree is SceneTree:
+		await (tree as SceneTree).create_timer(delay_seconds).timeout
+	if not is_instance_valid(self):
+		return
+	recover_lost_endpoint(episode_id)
 
 
 func complete_effect(episode_id: int, effect: String, result: Dictionary) -> bool:
@@ -433,6 +493,13 @@ func _ready(kind: String, transport, version: String) -> void:
 		_block("invalid_transport", "The server returned invalid transport authority.")
 		return
 	_transport = transport
+	## A recovery that reaches READY spends budget until the server has held
+	## for a while; a fresh start, or a stable server, gets the full budget.
+	if (
+		_endpoint_recovery_started_msec == 0
+		or Time.get_ticks_msec() - _endpoint_recovery_started_msec >= ENDPOINT_RECOVERY_STABLE_MS
+	):
+		_endpoint_recovery_attempts = 0
 	_episode["state"] = READY
 	_episode["phase"] = ""
 	_episode["ready_kind"] = kind
@@ -1178,6 +1245,8 @@ func get_status_dict() -> Dictionary:
 		"conflict_port": int(_episode.get("blocked_target", {}).get("port", 0)),
 		"conflict_version": str(_episode.get("blocked_target", {}).get("version", "")),
 		"keep_alive": bool(_plan.get("keep_alive", false)),
+		"recovery_attempt": _endpoint_recovery_attempts,
+		"recovery_limit": ENDPOINT_RECOVERY_DELAYS_SECONDS.size(),
 	}
 
 

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -140,15 +140,61 @@ func test_episode_snapshot_never_exposes_transport_capabilities() -> void:
 	assert_false(launch.has("ws_capability"))
 
 
-func test_authenticated_endpoint_loss_blocks_without_recovery_loop() -> void:
+func test_authenticated_endpoint_loss_blocks_then_schedules_a_bounded_reprobe() -> void:
 	var manager := _manager()
 	_complete_adoption(manager)
 	manager.transport_lost("endpoint vanished")
 	var snapshot := manager.get_status_dict()
 	assert_eq(snapshot.episode_state, Lifecycle.BLOCKED)
 	assert_eq(manager.episode_snapshot().reason, "endpoint_lost")
-	assert_true(snapshot.connection_blocked)
+	assert_true(snapshot.connection_blocked, "the connection is revoked until the server re-proves itself")
 	assert_false(snapshot.can_recover_incompatible)
+	assert_eq(int(snapshot.recovery_attempt), 1)
+	assert_contains(str(snapshot.message), "attempt 1 of 5")
+	## The scheduled attempt runs the ordinary start path: probe first.
+	var episode_id := int(manager.episode_snapshot().id)
+	assert_true(manager.recover_lost_endpoint(episode_id))
+	var episode := manager.episode_snapshot()
+	assert_eq(episode.state, Lifecycle.STARTING)
+	assert_eq(episode.phase, Lifecycle.PROBE)
+	## A stale timer (older episode) never disturbs a newer start.
+	assert_false(manager.recover_lost_endpoint(episode_id))
+
+
+func test_endpoint_reprobe_for_an_owned_server_stops_the_exact_grant_first() -> void:
+	var manager := _manager()
+	_complete_owned_start(manager)
+	manager.transport_lost("child exited")
+	assert_true(manager.recover_lost_endpoint(int(manager.episode_snapshot().id)))
+	var episode := manager.episode_snapshot()
+	assert_eq(episode.state, Lifecycle.STOPPING)
+	assert_eq(episode.after_stop, "start")
+
+
+func test_endpoint_reprobe_gives_up_after_its_budget() -> void:
+	var manager := _manager()
+	manager._endpoint_recovery_attempts = Lifecycle.ENDPOINT_RECOVERY_DELAYS_SECONDS.size()
+	## Still inside the stability window when READY arrives: the budget carries over.
+	manager._endpoint_recovery_started_msec = Time.get_ticks_msec()
+	_complete_adoption(manager)
+	manager.transport_lost("endpoint vanished")
+	var snapshot := manager.get_status_dict()
+	assert_eq(snapshot.episode_state, Lifecycle.BLOCKED)
+	assert_contains(str(snapshot.message), "gave up after 5 attempts")
+	assert_eq(int(snapshot.recovery_attempt), 5)
+	assert_false(manager.recover_lost_endpoint(int(manager.episode_snapshot().id)),
+		"no attempt is left; the dock's Restart is the route")
+	assert_eq(manager.episode_snapshot().state, Lifecycle.BLOCKED)
+
+
+func test_endpoint_reprobe_budget_resets_once_the_server_holds() -> void:
+	var manager := _manager()
+	manager._endpoint_recovery_attempts = 3
+	manager._endpoint_recovery_started_msec = Time.get_ticks_msec() - Lifecycle.ENDPOINT_RECOVERY_STABLE_MS
+	_complete_adoption(manager)
+	assert_eq(int(manager.get_status_dict().recovery_attempt), 0, "a server that held for a minute earns a fresh budget")
+	manager.transport_lost("endpoint vanished")
+	assert_eq(int(manager.get_status_dict().recovery_attempt), 1)
 
 
 func test_owned_endpoint_loss_stops_exact_grant_before_new_start() -> void:


### PR DESCRIPTION
## Summary

Closes #962. Since #943, losing an authenticated editor-server WebSocket session was terminal: `READY -> BLOCKED(endpoint_lost)`, connection revoked, nothing re-dialed until the dock's Restart. A late keepalive during a long synchronous editor operation or a server restart parked the plugin.

The authority model is unchanged: the block and the revocation stay, and every recovery attempt runs the ordinary start path (probe, adopt or launch, prove), so the server must re-prove its capability exactly as on a Restart click.

- Backoff 1, 2, 4, 8, 16 s: five attempts per outage, then the blocked message says it gave up and Restart is the route.
- Only the episode that lost its endpoint may run its scheduled attempt; a Restart or a newer loss in between supersedes the timer.
- A server that stays ready for a minute earns a fresh budget; one that flaps faster spends it and stops.
- One log line per attempt; `recovery_attempt` and `recovery_limit` are in the status snapshot.
- `docs/server-lifecycle.md` describes the loop.

## Verification

- GDScript suite: 2221 passed, 0 failed (four lifecycle tests: scheduled re-probe runs the start path and ignores a stale timer; owned server stops its exact grant first; budget exhaustion; budget reset after a stable minute).
- Live: headless editor adopted a server, the server was killed, the editor logged "server endpoint lost; re-probing in 1s (attempt 1 of 5)" and one second later "started server", "authenticated with server".

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authenticated server connections now automatically retry after an endpoint loss using bounded, progressively longer delays.
  * Recovery attempts follow the standard startup verification process.
  * Recovery status now displays the current attempt and maximum retry limit.
  * Successful recovery resets the retry budget after a stable connection period.

* **Bug Fixes**
  * Prevented stale recovery attempts from overriding restarts or newer connection failures.

* **Documentation**
  * Documented endpoint-loss recovery behavior, retry limits, and stability requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->