### PR TITLE
feat: configure CodeBuddy as an MCP client

### DIFF
--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -266,6 +266,7 @@ CodeBuddy uses the standard `mcpServers` JSON map with `type: "stdio"` and
 `command`/`args`/`env` ([official MCP documentation](https://www.codebuddy.ai/docs/zh/ide/User-guide/MCP)).
 Configure writes the user-scoped `~/.codebuddy/mcp.json` (Windows:
 `%USERPROFILE%/.codebuddy/mcp.json`), whose location was verified by the
-reporter of #941. CodeBuddy also accepts `<project>/.codebuddy/mcp.json`;
-use its MCP settings and the dock's manual attach entry for project scope.
-Automatic project-scope selection is not part of this descriptor.
+reporter of #941. For project scope, use the file opened by CodeBuddy IDE's
+MCP settings and the dock's manual attach entry. Project paths vary between
+CodeBuddy IDE and CodeBuddy Code (CLI); automatic project-scope selection is
+not part of this descriptor.

--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -259,3 +259,13 @@ actionable diagnostic, such as an ambiguous package path or unreadable config.
 The dock renders one row per client with a status dot, Configure/Remove buttons,
 and a per-row "Run this manually" fallback for cases when auto-configure cannot
 find a CLI.
+
+### CodeBuddy IDE
+
+CodeBuddy uses the standard `mcpServers` JSON map with `type: "stdio"` and
+`command`/`args`/`env` ([official MCP documentation](https://www.codebuddy.ai/docs/zh/ide/User-guide/MCP)).
+Configure writes the user-scoped `~/.codebuddy/mcp.json` (Windows:
+`%USERPROFILE%/.codebuddy/mcp.json`), whose location was verified by the
+reporter of #941. CodeBuddy also accepts `<project>/.codebuddy/mcp.json`;
+use its MCP settings and the dock's manual attach entry for project scope.
+Automatic project-scope selection is not part of this descriptor.

--- a/plugin/addons/godot_ai/clients/_registry.gd
+++ b/plugin/addons/godot_ai/clients/_registry.gd
@@ -16,6 +16,7 @@ const _CLIENT_SCRIPT_PATHS := [
 	"res://addons/godot_ai/clients/claude_code.gd",
 	"res://addons/godot_ai/clients/claude_desktop.gd",
 	"res://addons/godot_ai/clients/codex.gd",
+	"res://addons/godot_ai/clients/codebuddy.gd",
 	"res://addons/godot_ai/clients/grok.gd",
 	"res://addons/godot_ai/clients/antigravity.gd",
 	"res://addons/godot_ai/clients/cursor.gd",

--- a/plugin/addons/godot_ai/clients/codebuddy.gd
+++ b/plugin/addons/godot_ai/clients/codebuddy.gd
@@ -1,0 +1,25 @@
+@tool
+extends McpClient
+
+## CodeBuddy IDE: https://www.codebuddy.ai/docs/zh/ide/User-guide/MCP
+## Official docs specify mcpServers + type:stdio + command/args/env.
+## Global ~/.codebuddy/mcp.json and project .codebuddy/mcp.json were verified
+## by the reporter in #941. This descriptor uses the global user scope,
+## matching the registry's absolute user-path contract; project configuration
+## remains available manually in CodeBuddy's MCP settings.
+
+
+func _init() -> void:
+	id = "codebuddy"
+	display_name = "CodeBuddy"
+	config_type = "json"
+	path_template = {
+		"unix": "~/.codebuddy/mcp.json",
+		"windows": "$USERPROFILE/.codebuddy/mcp.json",
+	}
+	server_key_path = PackedStringArray(["mcpServers"])
+	command_shape = McpClient.CommandShape.FLAT
+	command_transport_key = "type"
+	command_transport_value = "stdio"
+	command_legacy_keys = PackedStringArray(["url", "headers"])
+	command_user_fields = PackedStringArray(["env", "description"])

--- a/plugin/addons/godot_ai/clients/codebuddy.gd
+++ b/plugin/addons/godot_ai/clients/codebuddy.gd
@@ -3,8 +3,8 @@ extends McpClient
 
 ## CodeBuddy IDE: https://www.codebuddy.ai/docs/zh/ide/User-guide/MCP
 ## Official docs specify mcpServers + type:stdio + command/args/env.
-## Global ~/.codebuddy/mcp.json and project .codebuddy/mcp.json were verified
-## by the reporter in #941. This descriptor uses the global user scope,
+## Global ~/.codebuddy/mcp.json was verified by the reporter in #941.
+## This descriptor uses the global user scope,
 ## matching the registry's absolute user-path contract; project configuration
 ## remains available manually in CodeBuddy's MCP settings.
 

--- a/plugin/addons/godot_ai/clients/codebuddy.gd.uid
+++ b/plugin/addons/godot_ai/clients/codebuddy.gd.uid
@@ -1,0 +1,1 @@
+uid://cutvvrwaef0rk

--- a/test_project/tests/test_client_attach_config.gd
+++ b/test_project/tests/test_client_attach_config.gd
@@ -666,6 +666,7 @@ func test_registry_wide_attach_shape_declarations() -> void:
 		"claude_code": [McpClient.CommandShape.FLAT, "stdio", ["url"]],
 		"claude_desktop": [McpClient.CommandShape.FLAT, null, ["url"]],
 		"codex": [McpClient.CommandShape.COMMAND_ARRAY, null, ["url"]],
+		"codebuddy": [McpClient.CommandShape.FLAT, "stdio", ["url", "headers"]],
 		"cursor": [McpClient.CommandShape.FLAT, "stdio", ["url"]],
 		"antigravity": [McpClient.CommandShape.FLAT, null, ["serverUrl"]],
 		"gemini_cli": [McpClient.CommandShape.FLAT, null, ["httpUrl", "url"]],

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -92,7 +92,7 @@ func test_registry_loads_all_clients() -> void:
 		"Every registered client script must load; got %d of %d" % [ids.size(), McpClientRegistry._CLIENT_SCRIPT_PATHS.size()]
 	)
 	# Each existing client must remain registered for behaviour parity.
-	for required in ["claude_code", "claude_desktop", "codex", "grok", "antigravity", "zoo_code", "hermes", "pi", "deepseek_harness"]:
+	for required in ["claude_code", "claude_desktop", "codex", "grok", "antigravity", "zoo_code", "hermes", "pi", "deepseek_harness", "codebuddy"]:
 		assert_true(McpClientRegistry.has_id(required), "Missing client: %s" % required)
 
 
@@ -6424,3 +6424,26 @@ func test_json_mismatch_reports_whether_the_existing_entry_is_ours() -> void:
 		launch,
 	)
 	assert_false(bool(docs_link.get("owned", true)), "a URL containing our name is not a launch")
+
+
+func test_codebuddy_descriptor_and_stdio_entry() -> void:
+	var c := McpClientRegistry.get_by_id("codebuddy")
+	assert_true(c != null, "CodeBuddy must be registered")
+	assert_eq(c.display_name, "CodeBuddy")
+	assert_eq(c.config_type, "json")
+	assert_eq(c.path_template.get("unix"), "~/.codebuddy/mcp.json")
+	assert_eq(c.path_template.get("windows"), "$USERPROFILE/.codebuddy/mcp.json")
+	assert_eq(c.server_key_path, PackedStringArray(["mcpServers"]))
+	var launch := _test_attach_launch()
+	var entry := McpJsonStrategy.build_entry(c, "http://unused", {
+		"type": "http", "url": "http://old", "headers": {"Authorization": "old"},
+		"env": {"USER_SENTINEL": "preserved"}, "description": "My tools",
+	}, launch)
+	assert_eq(entry.get("type"), "stdio")
+	assert_eq(entry.get("command"), launch.get("command"))
+	assert_eq(entry.get("args"), launch.get("args"))
+	assert_eq(entry.get("env", {}).get("USER_SENTINEL"), "preserved")
+	assert_eq(entry.get("description"), "My tools")
+	assert_false(entry.has("url"))
+	assert_false(entry.has("headers"))
+	assert_true(McpJsonStrategy.verify_entry(c, entry, "http://unused", launch))


### PR DESCRIPTION
Add CodeBuddy IDE to client auto-configuration with its documented `mcpServers` / `type: stdio` command shape. Configure writes the reporter-verified user file (`~/.codebuddy/mcp.json`); the docs explain manual project scope. Existing environment and description settings survive reconfiguration, and obsolete HTTP fields are removed.

Verified against https://www.codebuddy.ai/docs/zh/ide/User-guide/MCP and the reporter's #941 path confirmation. Validation: full Ruff scope; 2,521 Python tests passed (including real-editor integration tests); full Godot suite 2,219 passed, 0 failed; descriptor, registry shape and stdio migration assertions.

Closes #941.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CodeBuddy IDE support for configuring MCP servers using the standard `mcpServers` format.
  * CodeBuddy is now available in client configuration options, with support for stdio commands, environment variables, and descriptions.
  * Project scope can use the file opened through CodeBuddy IDE’s MCP settings or a manually attached dock entry.

* **Documentation**
  * Updated CodeBuddy setup guidance, including differences between IDE and CLI project paths and user-level configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Authored and validated by Codex.
