### PR TITLE
fix: reuse MCP sessions and select CI interpreters

### DIFF
--- a/script/_ci_mcp.sh
+++ b/script/_ci_mcp.sh
@@ -1,0 +1,38 @@
+# Shared MCP session lifetime. Source after SERVER_URL and HEADERS are set.
+# Call in the parent shell so SESSION_ID survives; callers own their EXIT trap.
+close_mcp_session() {
+  if [ -z "$SESSION_ID" ]; then
+    return
+  fi
+  curl -fsS --connect-timeout 3 --max-time 10 "$SERVER_URL" -X DELETE "${HEADERS[@]}" \
+    -H "Mcp-Session-Id: $SESSION_ID" > /dev/null 2>&1 || true
+  SESSION_ID=""
+}
+
+initialize_mcp_session() {
+  local response
+  local new_session_id
+  if ! response=$(curl -fsiS --connect-timeout 3 --max-time 10 \
+    "$SERVER_URL" -X POST "${HEADERS[@]}" \
+    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"ci","version":"1.0"}}}'); then
+    return 1
+  fi
+  new_session_id=$(printf '%s\n' "$response" | tr -d '\r' | awk '
+    tolower($1) == "mcp-session-id:" {
+      print $2
+      exit
+    }
+  ')
+  if [ -z "$new_session_id" ]; then
+    return 1
+  fi
+  SESSION_ID="$new_session_id"
+  if ! curl -fsS --connect-timeout 3 --max-time 10 \
+    "$SERVER_URL" -X POST "${HEADERS[@]}" \
+    -H "Mcp-Session-Id: $SESSION_ID" \
+    -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' > /dev/null; then
+    close_mcp_session
+    return 1
+  fi
+}
+

--- a/script/ci-godot-tests
+++ b/script/ci-godot-tests
@@ -17,42 +17,8 @@ ci_load_http_auth
 HEADERS=("${HTTP_AUTH_HEADERS[@]}" -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream")
 SESSION_ID=""
 
-close_mcp_session() {
-  if [ -z "$SESSION_ID" ]; then
-    return
-  fi
-  curl -fsS --connect-timeout 3 --max-time 10 "$SERVER_URL" -X DELETE "${HEADERS[@]}" \
-    -H "Mcp-Session-Id: $SESSION_ID" > /dev/null 2>&1 || true
-  SESSION_ID=""
-}
+source "$SCRIPT_DIR/_ci_mcp.sh"
 trap close_mcp_session EXIT
-
-initialize_mcp_session() {
-  local response
-  local new_session_id
-  if ! response=$(curl -fsiS --connect-timeout 3 --max-time 10 \
-    "$SERVER_URL" -X POST "${HEADERS[@]}" \
-    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"ci","version":"1.0"}}}'); then
-    return 1
-  fi
-  new_session_id=$(printf '%s\n' "$response" | tr -d '\r' | awk '
-    tolower($1) == "mcp-session-id:" {
-      print $2
-      exit
-    }
-  ')
-  if [ -z "$new_session_id" ]; then
-    return 1
-  fi
-  SESSION_ID="$new_session_id"
-  if ! curl -fsS --connect-timeout 3 --max-time 10 \
-    "$SERVER_URL" -X POST "${HEADERS[@]}" \
-    -H "Mcp-Session-Id: $SESSION_ID" \
-    -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' > /dev/null; then
-    close_mcp_session
-    return 1
-  fi
-}
 
 # FastMCP can return streamable HTTP tool results as either an SSE ``data:``
 # frame or a plain JSON body. Normalize both to the structured content object.

--- a/script/ci-quit-test
+++ b/script/ci-quit-test
@@ -7,12 +7,17 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PYTHON_CMD="${1:-${PYTHON_CMD:-python}}"
+export PYTHON_CMD
 source "$SCRIPT_DIR/_ci_env.sh"
 source "$SCRIPT_DIR/_ci_session_guard.sh"
 
 SERVER_URL="$MCP_SERVER_URL"
 ci_load_http_auth
 HEADERS=("${HTTP_AUTH_HEADERS[@]}" -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream")
+SESSION_ID=""
+source "$SCRIPT_DIR/_ci_mcp.sh"
+trap close_mcp_session EXIT
 REQ_ID=0
 
 # Helper: call an MCP tool and extract the content JSON from the SSE response.
@@ -27,7 +32,7 @@ mcp_call() {
   raw=$(curl -s --max-time 30 "$SERVER_URL" -X POST "${HEADERS[@]}" \
     -H "Mcp-Session-Id: $SESSION_ID" \
     -d "{\"jsonrpc\":\"2.0\",\"id\":$REQ_ID,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args}}")
-  echo "$raw" | python3 -c "
+  echo "$raw" | "$PYTHON_CMD" -c "
 import json, sys
 raw = sys.stdin.read()
 for line in raw.split('\n'):
@@ -53,20 +58,10 @@ sys.exit(1)
 
 # Initialize MCP session
 echo "Initializing MCP session..."
-SESSION_ID=$(curl -si "$SERVER_URL" -X POST "${HEADERS[@]}" \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"ci-quit","version":"1.0"}}}' \
-  2>&1 | grep -i 'mcp-session-id' | tr -d '\r' | awk '{print $2}' || true)
-  # `|| true`: under pipefail a header miss would abort the script instead of
-  # falling through to the empty-SESSION_ID check below (#668).
-
-if [ -z "$SESSION_ID" ]; then
+if ! initialize_mcp_session; then
   echo "ERROR: Could not initialize MCP session"
   exit 1
 fi
-
-curl -s "$SERVER_URL" -X POST "${HEADERS[@]}" \
-  -H "Mcp-Session-Id: $SESSION_ID" \
-  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' > /dev/null
 
 # Verify Godot is connected before quitting
 echo "Verifying Godot session..."
@@ -76,7 +71,7 @@ if ! TARGET_GODOT_SESSION=$(ci_select_godot_session \
   exit 1
 fi
 echo "Godot session selected: $TARGET_GODOT_SESSION"
-TARGET_EDITOR_PID=$(TARGET_GODOT_SESSION="$TARGET_GODOT_SESSION" python3 -c "
+TARGET_EDITOR_PID=$(TARGET_GODOT_SESSION="$TARGET_GODOT_SESSION" "$PYTHON_CMD" -c "
 import json, os, sys
 target = os.environ['TARGET_GODOT_SESSION']
 payload = json.loads(sys.stdin.read())
@@ -93,7 +88,7 @@ print(pid)
 " <<< "$SESSIONS")
 
 editor_process_is_alive() {
-  python3 - "$TARGET_EDITOR_PID" <<'PY'
+  "$PYTHON_CMD" - "$TARGET_EDITOR_PID" <<'PY'
 import os
 import subprocess
 import sys
@@ -129,7 +124,7 @@ PY
 # Call editor_quit
 echo "Calling editor_quit..."
 QUIT_RESULT=$(mcp_call editor_manage '{"op":"quit"}')
-echo "$QUIT_RESULT" | python3 -c "
+echo "$QUIT_RESULT" | "$PYTHON_CMD" -c "
 import json, sys
 content = json.loads(sys.stdin.read())
 status = content.get('status', '')
@@ -163,7 +158,7 @@ for i in $(seq 1 20); do
     echo "Session status check failed on attempt $i; retrying..." >&2
     continue
   fi
-  if ! TARGET_PRESENT=$(TARGET_GODOT_SESSION="$TARGET_GODOT_SESSION" python3 -c "
+  if ! TARGET_PRESENT=$(TARGET_GODOT_SESSION="$TARGET_GODOT_SESSION" "$PYTHON_CMD" -c "
 import json, os, sys
 target = os.environ['TARGET_GODOT_SESSION']
 payload = json.loads(sys.stdin.read())

--- a/script/ci-reload-test
+++ b/script/ci-reload-test
@@ -10,15 +10,15 @@
 # _ci_env.sh), Godot editor with plugin connected.
 set -euo pipefail
 STRESS=0
-case "${1:-}" in
-  "") ;;
-  --stress) STRESS=1; shift ;;
-  *) echo "Usage: $0 [--stress]" >&2; exit 2 ;;
-esac
-if [ "$#" -ne 0 ]; then
-  echo "Usage: $0 [--stress]" >&2
+if [ "${1:-}" = "--stress" ]; then STRESS=1; shift; fi
+PYTHON_CMD="${1:-${PYTHON_CMD:-python}}"
+if [ "$#" -gt 0 ]; then shift; fi
+if [ "${1:-}" = "--stress" ]; then STRESS=1; shift; fi
+if [ "$#" -ne 0 ] || [[ "$PYTHON_CMD" == --* ]]; then
+  echo "Usage: $0 [--stress] [python-command]" >&2
   exit 2
 fi
+export PYTHON_CMD
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 source "$SCRIPT_DIR/_ci_env.sh"
@@ -41,31 +41,8 @@ refresh_http_headers() {
   )
 }
 
-initialize_mcp_session() {
-  local response
-  local new_session_id
-  if ! response=$(curl -fsiS --connect-timeout 3 --max-time 10 \
-    "$SERVER_URL" -X POST "${HEADERS[@]}" \
-    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"ci-reload","version":"1.0"}}}'); then
-    return 1
-  fi
-  new_session_id=$(printf '%s\n' "$response" | tr -d '\r' | awk '
-    tolower($1) == "mcp-session-id:" {
-      print $2
-      exit
-    }
-  ')
-  if [ -z "$new_session_id" ]; then
-    return 1
-  fi
-  if ! curl -fsS --connect-timeout 3 --max-time 10 \
-    "$SERVER_URL" -X POST "${HEADERS[@]}" \
-    -H "Mcp-Session-Id: $new_session_id" \
-    -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' > /dev/null; then
-    return 1
-  fi
-  SESSION_ID="$new_session_id"
-}
+source "$SCRIPT_DIR/_ci_mcp.sh"
+trap close_mcp_session EXIT
 
 refresh_http_headers
 
@@ -82,7 +59,7 @@ mcp_call() {
   raw=$(curl -s --max-time "$MCP_CALL_TIMEOUT_SECONDS" "$SERVER_URL" -X POST "${HEADERS[@]}" \
     -H "Mcp-Session-Id: $SESSION_ID" \
     -d "{\"jsonrpc\":\"2.0\",\"id\":$REQ_ID,\"method\":\"tools/call\",\"params\":{\"name\":\"$tool\",\"arguments\":$args}}")
-  echo "$raw" | python3 -c "
+  echo "$raw" | "$PYTHON_CMD" -c "
 import json, sys
 raw = sys.stdin.read()
 for line in raw.split('\n'):
@@ -138,7 +115,7 @@ wait_for_managed_reload() {
       if [ "$HTTP_AUTH_CAPABILITY" != "$candidate_capability" ]; then
         candidate_capability="$HTTP_AUTH_CAPABILITY"
         initialized_capability=""
-        SESSION_ID=""
+        close_mcp_session
         refresh_http_headers
       fi
 
@@ -170,7 +147,7 @@ wait_for_managed_reload() {
         # The capability record can be published just before the new listener
         # is stable. Reinitialize rather than reusing an uncertain HTTP session.
         initialized_capability=""
-        SESSION_ID=""
+        close_mcp_session
       fi
     fi
     sleep "$MANAGED_RELOAD_POLL_SECONDS"
@@ -195,7 +172,7 @@ accept_reload_result() {
   local status
   local new_session_id
 
-  if ! parsed=$(python3 -c '
+  if ! parsed=$("$PYTHON_CMD" -c '
 import json
 import sys
 
@@ -265,7 +242,7 @@ fi
 # --- Step 1: Create a cube with the OLD plugin ---
 echo "Creating test node with old plugin..."
 CREATE_RESULT=$(mcp_call_or_die "node_create" node_create '{"type":"MeshInstance3D","name":"ReloadTestCube","parent_path":""}')
-echo "$CREATE_RESULT" | python3 -c "
+echo "$CREATE_RESULT" | "$PYTHON_CMD" -c "
 import json, sys
 content = json.loads(sys.stdin.read())
 path = content.get('path', '')
@@ -287,7 +264,7 @@ fi
 # --- Step 3: Verify log buffer is fresh (proves plugin fully rebuilt) ---
 echo "Checking log buffer..."
 LOGS_RESULT=$(mcp_call_or_die "logs_read" logs_read '{"count":20}')
-echo "$LOGS_RESULT" | python3 -c "
+echo "$LOGS_RESULT" | "$PYTHON_CMD" -c "
 import json, sys
 content = json.loads(sys.stdin.read())
 lines = content.get('lines', [])
@@ -306,7 +283,7 @@ print(f'Log buffer OK: {total} lines, starts with \"{lines[0]}\"')
 # --- Step 4: Find the cube with the NEW plugin (scene tree survived) ---
 echo "Finding test node with new plugin..."
 FIND_RESULT=$(mcp_call_or_die "node_find" node_find '{"name":"ReloadTestCube"}')
-echo "$FIND_RESULT" | python3 -c "
+echo "$FIND_RESULT" | "$PYTHON_CMD" -c "
 import json, sys
 content = json.loads(sys.stdin.read())
 nodes = content.get('nodes', [])
@@ -320,7 +297,7 @@ print(f'Found node: {node.get(\"name\", \"?\")} ({node.get(\"type\", \"?\")})')
 # --- Step 5: Verify editor_state works ---
 echo "Verifying editor_state..."
 HEALTH_RESULT=$(mcp_call_or_die "editor_state" editor_state '{}')
-echo "$HEALTH_RESULT" | python3 -c "
+echo "$HEALTH_RESULT" | "$PYTHON_CMD" -c "
 import json, sys
 content = json.loads(sys.stdin.read())
 version = content.get('godot_version', '')
@@ -338,7 +315,7 @@ print(f'Post-reload health OK: {project} on Godot {version}')
 # access. This asserts the handler's typed array stays valid across a reload.
 echo "Verifying logs_read source=game..."
 GAMELOGS_RESULT=$(mcp_call_or_die "logs_read source=game" logs_read '{"count":10,"source":"game"}')
-echo "$GAMELOGS_RESULT" | python3 -c "
+echo "$GAMELOGS_RESULT" | "$PYTHON_CMD" -c "
 import json, sys
 content = json.loads(sys.stdin.read())
 # A fresh editor has no game logs yet — we only care the call returned
@@ -402,7 +379,7 @@ done
 # `plugin/addons/godot_ai/testing/test_runner.gd`.
 echo "Running GDScript test suite on reloaded plugin..."
 TESTS_RESULT=$(mcp_call_or_die "test_run post-churn" test_run '{"verbose":false,"exclude_test_name":"test_configure_current_sibling_unmark_single_undo,test_get_returns_current_when_path_empty"}')
-echo "$TESTS_RESULT" | python3 -c "
+echo "$TESTS_RESULT" | "$PYTHON_CMD" -c "
 import json, sys
 content = json.loads(sys.stdin.read())
 failed = content.get('failed', -1)

--- a/script/ci-slow-suite-smoke
+++ b/script/ci-slow-suite-smoke
@@ -21,6 +21,8 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PYTHON_CMD="${1:-${PYTHON_CMD:-python}}"
+export PYTHON_CMD
 source "$SCRIPT_DIR/_ci_env.sh"
 source "$SCRIPT_DIR/_ci_session_guard.sh"
 
@@ -32,35 +34,38 @@ EXPECTED_TESTS=25
 SERVER_URL="$MCP_SERVER_URL"
 ci_load_http_auth
 HEADERS=("${HTTP_AUTH_HEADERS[@]}" -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream")
+SESSION_ID=""
+source "$SCRIPT_DIR/_ci_mcp.sh"
 
 cleanup() {
+  close_mcp_session
   rm -f "$FIXTURE_DST" "$FIXTURE_DST.uid"
 }
 trap cleanup EXIT
 
-# Shared SSE-response field extractor: prints structuredContent JSON for the
-# first data: line, or exits 3 when none is present.
+# Extract structuredContent from a JSON or SSE response, retaining its id.
 extract_content() {
-  python3 -c "
+  "$PYTHON_CMD" -c "
 import json, sys
-raw = sys.stdin.read()
-for line in raw.split('\n'):
-    if line.startswith('data: '):
-        data = json.loads(line[6:])
-        result = data.get('result', {})
-        sc = result.get('structuredContent', {})
-        if not sc:
-            text = result.get('content', [{}])[0].get('text', '{}')
-            try:
-                sc = json.loads(text)
-            except json.JSONDecodeError:
-                sc = {'_raw_text': text}
-        sc['_is_error'] = bool(result.get('isError'))
-        sc['_rpc_id'] = data.get('id')
-        print(json.dumps(sc))
-        break
-else:
+raw = sys.stdin.read().lstrip('\\ufeff').strip()
+try:
+    data = json.loads(raw)
+except json.JSONDecodeError:
+    data = next((json.loads(line[5:].lstrip()) for line in raw.splitlines()
+                 if line.startswith('data:')), None)
+if not isinstance(data, dict):
     sys.exit(3)
+result = data.get('result', {})
+sc = result.get('structuredContent', {})
+if not sc:
+    text = result.get('content', [{}])[0].get('text', '{}')
+    try:
+        sc = json.loads(text)
+    except json.JSONDecodeError:
+        sc = {'_raw_text': text}
+sc['_is_error'] = bool(result.get('isError') or data.get('error'))
+sc['_rpc_id'] = data.get('id')
+print(json.dumps(sc))
 "
 }
 
@@ -75,7 +80,7 @@ mcp_call() { # id name arguments-json
 }
 
 godot_sessions() {
-  mcp_call 7 session_manage '{"op":"list"}' | extract_content | python3 -c "
+  mcp_call 7 session_manage '{"op":"list"}' | extract_content | "$PYTHON_CMD" -c "
 import json, sys
 sc = json.loads(sys.stdin.read())
 sc.pop('_is_error', None)
@@ -85,7 +90,7 @@ print(json.dumps(sc))
 }
 
 godot_target_session_id() {
-  godot_sessions | TARGET_GODOT_SESSION="$TARGET_GODOT_SESSION" python3 -c "
+  godot_sessions | TARGET_GODOT_SESSION="$TARGET_GODOT_SESSION" "$PYTHON_CMD" -c "
 import json, os, sys
 target = os.environ['TARGET_GODOT_SESSION']
 sessions = json.loads(sys.stdin.read()).get('sessions', [])
@@ -97,14 +102,12 @@ print(target if any(s.get('session_id') == target for s in sessions) else '')
 echo "Waiting for Godot plugin to connect..."
 SESSION_ID=""
 for i in $(seq 1 60); do
-  SESSION_ID=$(curl -si "$SERVER_URL" -X POST "${HEADERS[@]}" \
-    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"slow-smoke","version":"1.0"}}}' \
-    2>&1 | grep -i 'mcp-session-id' | tr -d '\r' | awk '{print $2}' || true)
-  if [ -z "$SESSION_ID" ]; then sleep 2; continue; fi
-  curl -s "$SERVER_URL" -X POST "${HEADERS[@]}" -H "Mcp-Session-Id: $SESSION_ID" \
-    -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' > /dev/null || true
+  if [ -z "$SESSION_ID" ] && ! initialize_mcp_session; then
+    sleep 2
+    continue
+  fi
   SESSIONS=$(godot_sessions || true)
-  SESSION_COUNT=$(python3 -c "import json,sys; print(len(json.loads(sys.stdin.read()).get('sessions', [])))" \
+  SESSION_COUNT=$("$PYTHON_CMD" -c "import json,sys; print(len(json.loads(sys.stdin.read()).get('sessions', [])))" \
     <<< "$SESSIONS" 2>/dev/null || echo "0")
   if [ "$SESSION_COUNT" -gt 0 ] 2>/dev/null; then
     if ! TARGET_GODOT_SESSION=$(ci_select_godot_session \
@@ -141,12 +144,12 @@ RESULT=$(mcp_call 42 test_run "{\"suite\":\"$SUITE_NAME\"}")
 ELAPSED=$(( $(date +%s) - START_TS ))
 
 CONTENT=$(echo "$RESULT" | extract_content) || {
-  echo "REPRODUCED/FAIL: no SSE data line from test_run after ${ELAPSED}s"
+  echo "REPRODUCED/FAIL: no JSON-RPC result from test_run after ${ELAPSED}s"
   echo "Raw response (first 500 chars): $(echo "$RESULT" | head -c 500)"
   exit 1
 }
 
-echo "$CONTENT" | python3 -c "
+echo "$CONTENT" | "$PYTHON_CMD" -c "
 import json, sys
 sc = json.loads(sys.stdin.read())
 elapsed = $ELAPSED

--- a/tests/unit/test_ci_godot_tests_runner.py
+++ b/tests/unit/test_ci_godot_tests_runner.py
@@ -92,6 +92,7 @@ def _handler(
     state: _RunnerState,
     project_path: Path,
     response_shape: str,
+    runner_name: str = "ci-godot-tests",
 ) -> type[BaseHTTPRequestHandler]:
     suite_names = sorted(
         path.stem.removeprefix("test_") for path in project_path.glob("tests/test_*.gd")
@@ -182,14 +183,16 @@ def _handler(
                         else []
                     ),
                 }
+            elif tool == "filesystem_manage":
+                content = {"scanned": True}
             elif tool == "scene_open":
                 content = {"path": "res://main.tscn"}
             elif tool == "test_run":
                 content = {
-                    "passed": 2200,
+                    "passed": 25 if runner_name == "ci-slow-suite-smoke" else 2200,
                     "failed": 0,
                     "skipped": 0,
-                    "total": 2200,
+                    "total": 25 if runner_name == "ci-slow-suite-smoke" else 2200,
                     "failures": [],
                     "load_errors": [],
                     "suite_count": len(suite_names),
@@ -210,15 +213,17 @@ def _handler(
     return Handler
 
 
+@pytest.mark.parametrize("runner_name", ("ci-godot-tests", "ci-slow-suite-smoke"))
 @pytest.mark.parametrize("response_shape", ("json", "sse"))
 def test_runner_reuses_one_mcp_session_and_accepts_both_response_shapes(
     tmp_path: Path,
     response_shape: str,
+    runner_name: str,
 ) -> None:
     state = _RunnerState()
     server = ThreadingHTTPServer(
         ("127.0.0.1", 0),
-        _handler(state, ROOT / "test_project", response_shape),
+        _handler(state, ROOT / "test_project", response_shape, runner_name),
     )
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
@@ -242,7 +247,7 @@ def test_runner_reuses_one_mcp_session_and_accepts_both_response_shapes(
                     'export -f sleep python3; exec bash "$1" "$2"'
                 ),
                 "ci-godot-tests-regression",
-                str(RUNNER),
+                str(ROOT / "script" / runner_name),
                 sys.executable,
             ],
             cwd=ROOT,
@@ -264,4 +269,8 @@ def test_runner_reuses_one_mcp_session_and_accepts_both_response_shapes(
     assert state.sessions_created == 1
     assert state.session_list_calls == 3
     assert state.deleted_sessions == ["ci-session-1"]
-    assert "Godot tests: 2200/2200 passed, 0 failed, 0 skipped" in result.stdout
+    if runner_name == "ci-godot-tests":
+        assert "Godot tests: 2200/2200 passed, 0 failed, 0 skipped" in result.stdout
+    else:
+        assert "PASS: slow suite completed" in result.stdout
+        assert not (ROOT / "test_project/tests/test_mcp_slow_smoke.gd").exists()


### PR DESCRIPTION
The slow-suite wait loop initialized a fresh MCP session on every attempt and could exhaust the 32-session limit before Godot connected. Share the existing ci-godot-tests handshake/DELETE helper across the runners, reuse the slow-suite session, and close sessions on exit, failed initialization, and reload retry.

ci-reload-test, ci-quit-test and ci-slow-suite-smoke now accept an explicit Python executable (or PYTHON_CMD), so Windows Git Bash does not need a python3 alias. Slow-suite parsing also accepts JSON and SSE responses while preserving the original request ID check.

Validation: full Ruff scope; full Python suite; real-editor handler suite; updater scenarios; delayed-connect JSON/SSE regression with bare python3 disabled; live slow-suite, reload and quit smokes.

Closes #959.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - CI smoke tests can now use a configurable Python interpreter, improving compatibility across environments.
  - Shared MCP session handling provides consistent initialization and cleanup across automated tests.

- **Bug Fixes**
  - Improved parsing of streamed responses, including UTF-8 byte-order marks, flexible event formatting, and reported errors.
  - Session cleanup now runs reliably when tests exit or encounter failures.

- **Tests**
  - Expanded regression coverage for multiple CI test runners, including filesystem-management scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Authored and validated by Codex.
