### PR TITLE
fix: report test-run preload freshness limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,6 +276,7 @@ jobs:
         run: |
           xvfb-run -a env GODOT_BIN=godot pytest -v -s --durations=0 -k 'not local-files' --basetemp="${RUNNER_TEMP}/pytest-basetemp" \
             tests/integration/test_godot_editor_restart.py \
+            tests/integration/test_test_run_cache_warning.py \
             tests/integration/test_migration_bridge_failures.py \
             tests/integration/test_self_update_upgrade_paths.py \
             tests/integration/test_qualification_https.py \

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -320,3 +320,10 @@ don't, and the only path that supports `session_id` pinning.
 | `godot://input_map` | Project input actions and their bound events |
 | `godot://performance` | Performance singleton snapshot |
 | `godot://test/results` | Most recent `test_run` results |
+
+### Test-run cache warning
+
+`test_run` and `test_manage(op="results_get")` include `cache_warning` because
+preloaded GDScript dependencies can remain stale after edits in the same
+editor. Restart the editor before validating dependency changes; see the
+[freshness contract](tool-surface.md#test-run-freshness-after-dependency-edits).

--- a/docs/tool-surface.md
+++ b/docs/tool-surface.md
@@ -47,3 +47,22 @@ When using `batch_execute`'s `commands[].command` field, use the **plugin comman
 8. Write a description with natural-language keywords a user would search for (e.g. `screenshot`, `keybinding`, `asset`) alongside the Godot term. For ops inside a rollup, edit the `_DESCRIPTION` block of the domain's tool file so the rolled-up tool's docstring stays exhaustive.
 9. **Consider a resource form**: pure reads with no `session_id` filtering benefit from a matching `godot://...` resource (or template) in `src/godot_ai/resources/`. The tool form remains for `session_id`-pinned reads; clients that surface resources prefer the URI. When you add a resource form, append `Resource form: godot://...` to the tool's description so aware clients can route reads through the URI.
 10. Add tests: handler unit test, Python integration test, AND GDScript test in `test_project/tests/`. Migrate any integration tests for an existing verb when you move it under a rollup — the form changes from `client.call_tool("domain_verb", {...})` to `client.call_tool("domain_manage", {"op": "verb", "params": {...}, "session_id": ...})`.
+
+## Test-run freshness after dependency edits
+
+`test_run` reloads suite scripts, but **does not guarantee fresh preloaded
+GDScript dependencies** in an existing editor process (#938). Results and
+`test_manage(op="results_get")` include `cache_warning`: restart the editor
+before treating a rerun as validation of changes to a preloaded helper or its
+nested dependencies. A passing rerun can otherwise validate old code.
+
+`CACHE_MODE_IGNORE_DEEP` and `CACHE_MODE_REPLACE` do not invalidate the
+GDScript compile-time preload cache. #944 makes `script_patch` and
+`script_create(overwrite=true)` refresh the specific cached script they write
+using `source_code` and `reload(true)`; inspect `reloaded` / `reload_reason`.
+That targeted refresh is not a general dependency-graph freshness guarantee
+for filesystem writes, external edits, or already-compiled consumers. The
+runner does not recursively reload arbitrary live scripts, which may include
+its own executing plugin code and stateful script instances. A fresh editor
+process is the supported general workaround; a filesystem scan or plugin
+reload alone is insufficient.

--- a/plugin/addons/godot_ai/handlers/test_handler.gd
+++ b/plugin/addons/godot_ai/handlers/test_handler.gd
@@ -161,6 +161,7 @@ static func unknown_suite_error(suite_filter: String, suites: Array) -> Dictiona
 	err["error"]["data"] = {
 		"suite": suite_filter,
 		"suites_available": Array(names),
+		"cache_warning": CACHE_WARNING,
 	}
 	return err
 
@@ -245,6 +246,7 @@ func _abort_data(
 ) -> Dictionary:
 	var data := {
 		"phase": phase,
+		"cache_warning": CACHE_WARNING,
 		"elapsed_ms": elapsed_ms,
 		"budget_sec": budget_sec,
 		"passed": int(results.get("passed", 0)),

--- a/plugin/addons/godot_ai/handlers/test_handler.gd
+++ b/plugin/addons/godot_ai/handlers/test_handler.gd
@@ -14,6 +14,12 @@ extends "res://addons/godot_ai/handlers/command_handler.gd"
 
 const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
 
+const CACHE_WARNING := (
+	"Preloaded GDScript dependencies may be stale after source edits. "
+	+ "Restart the editor before treating this run as validation of dependency changes. "
+	+ "ResourceLoader cache modes do not invalidate GDScript's preload cache."
+)
+
 ## Clamp bounds for the server-provided ``timeout_budget_sec`` param. The
 ## floor is purely defensive (a malformed or buggy server value must not
 ## abort every run instantly); the param is not user-facing.
@@ -106,7 +112,7 @@ func run_tests(params: Dictionary) -> Dictionary:
 				discovery.errors.size(),
 				", ".join(discovery.errors),
 			]
-		var no_suites := {"error": msg, "total": 0, "load_errors": discovery.errors}
+		var no_suites := {"error": msg, "total": 0, "load_errors": discovery.errors, "cache_warning": CACHE_WARNING}
 		## Keep the edited_scene annotation on the no-suites error payload too,
 		## so the response contract is consistent across every return path.
 		_annotate_edited_scene(no_suites)
@@ -170,6 +176,7 @@ func _map_outcome(
 	started_ms: int,
 	budget_sec: float,
 ) -> Dictionary:
+	results["cache_warning"] = CACHE_WARNING
 	var elapsed_ms := Time.get_ticks_msec() - started_ms
 	match outcome:
 		"completed":
@@ -288,7 +295,9 @@ func _annotate_edited_scene(results: Dictionary) -> void:
 
 func get_test_results(params: Dictionary) -> Dictionary:
 	var verbose: bool = params.get("verbose", false)
-	return {"data": _runner.get_results(verbose)}
+	var results := _runner.get_results(verbose)
+	results["cache_warning"] = CACHE_WARNING
+	return {"data": results}
 
 
 ## Returns {"suites": Array, "errors": Array[String], "outcome": String}.

--- a/src/godot_ai/tools/testing.py
+++ b/src/godot_ai/tools/testing.py
@@ -42,6 +42,11 @@ def register_testing_tools(mcp: FastMCP) -> None:
         suite names, duration) plus failures only. verbose=True includes
         every individual test result (each with per-test ``duration_ms``).
 
+        Preloaded GDScript dependencies may remain stale after source edits;
+        the response includes cache_warning. Restart the editor before using
+        a rerun to validate dependency edits. ResourceLoader cache modes alone
+        do not refresh the GDScript preload cache.
+
         The whole run has a 300s budget; the plugin aborts between tests
         shortly before it expires and returns TEST_RUN_TIMEOUT with the
         partial summary (full partials via test_manage(op="results_get")).

--- a/test_project/tests/test_serviced_test_run.gd
+++ b/test_project/tests/test_serviced_test_run.gd
@@ -207,6 +207,7 @@ func test_handler_map_outcome_timeout_shape() -> void:
 		"timeout", "run", results, 7, Time.get_ticks_msec() - 5000, 120.0
 	)
 	assert_eq(envelope["error"]["code"], ErrorCodes.TEST_RUN_TIMEOUT, "timeout error code")
+	assert_contains(envelope.error.data.cache_warning, "Restart the editor")
 	var data: Dictionary = envelope["error"]["data"]
 	assert_eq(int(data["tests_not_run"]), 7, "remaining estimate carried")
 	assert_eq(int(data["passed"]), 4, "partial pass count carried")
@@ -222,6 +223,7 @@ func test_handler_map_outcome_paused_shape() -> void:
 		2, Time.get_ticks_msec(), 110.0
 	)
 	assert_eq(envelope["error"]["code"], ErrorCodes.INTERNAL_ERROR, "paused is an invariant violation")
+	assert_contains(envelope.error.data.cache_warning, "Restart the editor")
 	assert_true(envelope["error"]["data"].has("pause_depth"), "pause depth surfaced")
 
 
@@ -379,6 +381,7 @@ func test_unknown_suite_filter_is_an_error_not_an_empty_run() -> void:
 	## A protocol error, never an "error" key inside a data success envelope —
 	## the same ErrorCodes.make contract as the paused/timeout aborts.
 	assert_is_error(unknown, ErrorCodes.INVALID_PARAMS)
+	assert_contains(unknown.error.data.cache_warning, "Restart the editor")
 	var message := str(unknown["error"]["message"])
 	assert_contains(message, "custom_tools")
 	assert_contains(message, "truncated",

--- a/tests/integration/test_test_run_cache_warning.py
+++ b/tests/integration/test_test_run_cache_warning.py
@@ -1,0 +1,83 @@
+"""Real-editor evidence for the documented preload freshness limit (#938)."""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+from tests.integration._self_update_fixture import godot_bin_or_skip, run_godot_editor
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_rerun_warns_about_stale_preload_and_fresh_editor_observes_edit(tmp_path: Path) -> None:
+    godot = godot_bin_or_skip()
+    project = tmp_path / "preload-cache"
+    (project / "tests").mkdir(parents=True)
+    shutil.copytree(ROOT / "plugin/addons/godot_ai", project / "addons/godot_ai")
+    config = project / "project.godot"
+    config.write_text('config_version=5\n[application]\nconfig/name="Preload cache regression"\n')
+    (project / "tests/helper.gd").write_text(
+        '@tool\nextends RefCounted\nstatic func value() -> String:\n\treturn "old"\n'
+    )
+    (project / "expected.txt").write_text("old")
+    (project / "tests/test_cache.gd").write_text('''@tool
+extends McpTestSuite
+const Helper = preload("res://tests/helper.gd")
+func suite_name() -> String:
+    return "cache"
+func test_value() -> void:
+    assert_eq(Helper.value(), FileAccess.get_file_as_string("res://expected.txt"))
+''')
+    imported = subprocess.run(
+        [godot, "--headless", "--editor", "--path", str(project), "--import"],
+        capture_output=True, text=True, timeout=90, check=False,
+    )
+    assert imported.returncode == 0, imported.stdout + imported.stderr
+    (project / "driver.gd").write_text('''@tool
+extends Node
+var frames := 15
+var retained: GDScript
+func _process(_delta: float) -> void:
+    if not Engine.is_editor_hint():
+        return
+    frames -= 1
+    if frames != 0:
+        return
+    set_process(false)
+    retained = load("res://tests/test_cache.gd")
+    var handler = load("res://addons/godot_ai/handlers/test_handler.gd").new(null, null)
+    if FileAccess.file_exists("res://before.json"):
+        write_json("res://fresh.json", handler.run_tests({"suite": "cache"}))
+    else:
+        write_json("res://before.json", handler.run_tests({"suite": "cache"}))
+        var helper = FileAccess.open("res://tests/helper.gd", FileAccess.WRITE)
+        helper.store_string('@tool\\nextends RefCounted\\n'
+            + 'static func value() -> String:\\n\\treturn "new"\\n')
+        helper.close()
+        var expected = FileAccess.open("res://expected.txt", FileAccess.WRITE)
+        expected.store_string("new")
+        expected.close()
+        EditorInterface.get_resource_filesystem().update_file("res://tests/helper.gd")
+        write_json("res://rerun.json", handler.run_tests({"suite": "cache"}))
+        write_json("res://saved.json", handler.get_test_results({}))
+    get_tree().quit(0)
+func write_json(path: String, data: Dictionary) -> void:
+    var file = FileAccess.open(path, FileAccess.WRITE)
+    file.store_string(JSON.stringify(data))
+    file.close()
+''')
+    config.write_text(config.read_text(encoding="utf-8") + '[autoload]\nDriver="*res://driver.gd"\n')
+    run_godot_editor(project, godot, allow_headless=False, timeout=90)
+    before = json.loads((project / "before.json").read_text(encoding="utf-8"))["data"]
+    rerun = json.loads((project / "rerun.json").read_text(encoding="utf-8"))["data"]
+    saved = json.loads((project / "saved.json").read_text(encoding="utf-8"))["data"]
+    assert before["passed"] == 1 and before["failed"] == 0
+    assert 'return "new"' in (project / "tests/helper.gd").read_text(encoding="utf-8")
+    assert rerun["failed"] == 1, rerun
+    assert "Restart the editor" in rerun["cache_warning"]
+    assert saved["cache_warning"] == rerun["cache_warning"]
+    run_godot_editor(project, godot, allow_headless=False, timeout=90)
+    fresh = json.loads((project / "fresh.json").read_text(encoding="utf-8"))["data"]
+    assert fresh["passed"] == 1 and fresh["failed"] == 0, fresh


### PR DESCRIPTION
A test rerun can execute stale preloaded GDScript helpers after their files change. Document that freshness limit and include `cache_warning` in test_run and saved-result responses so a passing rerun is not mistaken for validation of dependency edits.

This takes #938's documented-limitation path: ResourceLoader IGNORE_DEEP/REPLACE do not invalidate GDScript's preload cache. #944 refreshes the specific cached script written by script_patch/script_create; it does not guarantee freshness of an arbitrary already-compiled dependency graph. Restarting the editor is the supported general workaround, rather than recursively reloading potentially executing plugin scripts.

A real-editor regression loads/runs a suite, edits its preloaded helper on disk, reruns in the same editor, verifies the stale result and warning, then proves a fresh editor observes the new helper. Validation: full Ruff and Python suites, full live Godot suite (2,218 passed, 0 failed), real-editor updater row, cache regression and authenticated MCP saved-results smoke.

The real-editor cache regression is included in the Linux CI editor job; timeout, paused and invalid-suite responses also preserve the warning.

Closes #938.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Test results and error responses now include a warning when preloaded script dependencies may be stale after edits.
  * Responses provide guidance to restart the editor before validating dependency changes.
* **Documentation**
  * Added guidance describing cache freshness limitations, targeted refresh behavior, and the supported workaround.
* **Tests**
  * Added integration and regression coverage for stale-cache warnings across completed, paused, timed-out, and unknown-suite results, including validation in a fresh editor session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Authored and validated by Codex.
