### PR TITLE
fix: avoid writes before acquiring Windows startup lock

### DIFF
--- a/src/godot_ai/attach/ensure.py
+++ b/src/godot_ai/attach/ensure.py
@@ -221,14 +221,9 @@ class AdvisoryFileLock:
             handle = self.path.open("a+b")
         except OSError as exc:
             raise self._lock_error("open", exc) from exc
-        try:
-            handle.seek(0, os.SEEK_END)
-            if handle.tell() == 0:
-                handle.write(b"\0")
-                handle.flush()
-        except OSError as exc:
-            handle.close()
-            raise self._lock_error("prepare", exc) from exc
+        # Both backends can lock an empty file. Do not initialize its first
+        # byte before acquiring: another opener may already hold that byte's
+        # Windows lock, making an otherwise valid contender fail on the write.
         deadline = time.monotonic() + self.timeout_seconds
         while True:
             try:

--- a/tests/unit/test_attach_ensure.py
+++ b/tests/unit/test_attach_ensure.py
@@ -372,28 +372,28 @@ async def test_advisory_lock_wraps_open_failure(
     }
 
 
-def test_advisory_lock_wraps_lock_file_preparation_failure(
+def test_advisory_lock_wraps_seek_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     class FailingHandle:
         closed = False
 
         def seek(self, *_args) -> None:
-            raise OSError(errno.EIO, "write failed")
+            raise OSError(errno.EIO, "seek failed")
 
         def close(self) -> None:
             self.closed = True
 
     handle = FailingHandle()
     monkeypatch.setattr(Path, "open", lambda *_args, **_kwargs: handle)
-    lock = AdvisoryFileLock(tmp_path / "prepare-error.lock")
+    lock = AdvisoryFileLock(tmp_path / "seek-error.lock")
 
     with pytest.raises(AttachStartupError) as exc_info:
         lock._acquire()
 
     assert handle.closed
     assert exc_info.value.code == "ATTACH_LOCK_ERROR"
-    assert exc_info.value.data["operation"] == "prepare"
+    assert exc_info.value.data["operation"] == "acquire"
     assert exc_info.value.data["errno"] == errno.EIO
 
 
@@ -451,17 +451,33 @@ async def test_cancelled_acquire_ignores_worker_failure(tmp_path: Path) -> None:
     assert not released.is_set()
 
 
-async def test_advisory_lock_is_cross_process(tmp_path: Path) -> None:
+@pytest.mark.parametrize("empty_file", [False, True])
+async def test_advisory_lock_is_cross_process(tmp_path: Path, empty_file: bool) -> None:
     lock_path = tmp_path / "cross-process.lock"
     ready_path = tmp_path / "holder.ready"
     release_path = tmp_path / "holder.release"
     script = """
 import asyncio
+import os
 import sys
 from pathlib import Path
 from godot_ai.attach.ensure import AdvisoryFileLock
 
 async def main():
+    if sys.argv[4] == "empty":
+        # Exercise the native lock independently of AdvisoryFileLock, before
+        # any writer has initialized the file (the first-opener race).
+        with open(sys.argv[1], "a+b") as handle:
+            if os.name == "nt":
+                import msvcrt
+                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+            else:
+                import fcntl
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            Path(sys.argv[2]).write_text("ready", encoding="utf-8")
+            while not Path(sys.argv[3]).exists():
+                await asyncio.sleep(0.01)
+        return
     async with AdvisoryFileLock(Path(sys.argv[1]), timeout_seconds=5):
         Path(sys.argv[2]).write_text("ready", encoding="utf-8")
         while not Path(sys.argv[3]).exists():
@@ -470,7 +486,10 @@ async def main():
 asyncio.run(main())
 """
     holder = subprocess.Popen(
-        [sys.executable, "-c", script, str(lock_path), str(ready_path), str(release_path)],
+        [
+            sys.executable, "-c", script, str(lock_path), str(ready_path),
+            str(release_path), "empty" if empty_file else "normal",
+        ],
         stdin=subprocess.DEVNULL,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -486,13 +505,21 @@ asyncio.run(main())
             _stdout, stderr = await asyncio.to_thread(holder.communicate, timeout=5)
             pytest.fail(f"lock holder did not become ready: {stderr.decode(errors='replace')}")
 
+        if empty_file and os.name == "nt":
+            # Prove that the old pre-lock initialization write is rejected by
+            # Windows, while the contender below must report ordinary contention.
+            assert lock_path.stat().st_size == 0
+            with lock_path.open("a+b", buffering=0) as handle:
+                with pytest.raises(PermissionError):
+                    handle.write(b"\0")
+
         contender = AdvisoryFileLock(lock_path, timeout_seconds=0.1, poll_seconds=0.01)
         with pytest.raises(AttachStartupError) as exc_info:
             await contender.__aenter__()
-        assert exc_info.value.code == "ATTACH_LOCK_TIMEOUT"
+        assert exc_info.value.code == "ATTACH_LOCK_TIMEOUT", exc_info.value
 
         release_path.write_text("release", encoding="utf-8")
-        await asyncio.to_thread(holder.wait, 5)
+        assert await asyncio.to_thread(holder.wait, 5) == 0
         async with AdvisoryFileLock(lock_path, timeout_seconds=1):
             pass
     finally:
@@ -853,7 +880,7 @@ async def test_three_concurrent_bridges_with_two_version_pins_choose_one_backend
     compatible = [result for result in results if isinstance(result, BackendStatus)]
     incompatible = [result for result in results if isinstance(result, AttachStartupError)]
     assert state["spawns"] == 1
-    assert len(compatible) == 2
+    assert len(compatible) == 2, results
     assert len(incompatible) == 1
     assert incompatible[0].code == "NEW_CLIENT_SESSION_REQUIRED"
     assert "cannot be repaired" in incompatible[0].hint


### PR DESCRIPTION
Concurrent attach clients can fail before acquiring the Windows startup lock: two first openers can observe an empty file, and one can lock byte zero before the other flushes its initialization byte. Windows rejects that write, so the second client fails instead of waiting for the existing lock. Remove the unnecessary initialization write; both native lock backends support locking an empty file.

This addresses the concrete startup race found while investigating the Windows Python 3.14 failure on #983. That earlier CI log did not retain the gathered exceptions, so the original three-client assertion now includes them.

The cross-process regression uses an independent native holder to lock an empty file. On Windows it first proves that the old initialization write is denied, then verifies that the corrected contender reports a bounded contention timeout and successfully acquires after release. Existing cancellation, error, and platform-lock tests remain covered.

Validation: complete CI Ruff scope; 2,531 Python tests passed with 23 platform skips, including real-editor integrations; full Godot suite 2,235 passed, zero failures, 24 skips across 72 suites; live concurrent-client smoke adopted the same editor backend twice and rejected a mismatched client version. Windows-native validation runs in this PR's CI.

References: [Python msvcrt locking](https://docs.python.org/3/library/msvcrt.html#msvcrt.locking), [Windows byte-range locking](https://learn.microsoft.com/en-us/windows/win32/fileio/locking-and-unlocking-byte-ranges-in-files).

Implemented and validated by Codex.
