### PR TITLE
release: resume a draft the tag endpoint hides, and wait for PyPI's index

### DIFF
--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -46,7 +46,8 @@ const ENDPOINT_RECOVERY_DELAYS_SECONDS: Array[float] = [1.0, 2.0, 4.0, 8.0, 16.0
 const ENDPOINT_RECOVERY_STABLE_MS := 60_000
 
 var _endpoint_recovery_attempts := 0
-var _endpoint_recovery_started_msec := 0
+## When the current READY began; a loss after a stable minute earns a fresh budget.
+var _ready_since_msec := 0
 ## The episode whose re-probe is scheduled; 0 when none is pending.
 var _endpoint_recovery_pending_episode := 0
 const MAX_STATUS_BODY_BYTES := 8 * 1024
@@ -289,6 +290,12 @@ func transport_lost(reason := "Authenticated server endpoint was lost.") -> void
 	if str(_episode.get("state")) != READY:
 		return
 	_transport = null
+	## Stability is measured from the moment the server became READY, not
+	## from when a recovery started, so a slow recovery cannot refresh its
+	## own budget and a server that held for a minute does.
+	if _ready_since_msec != 0 and Time.get_ticks_msec() - _ready_since_msec >= ENDPOINT_RECOVERY_STABLE_MS:
+		_endpoint_recovery_attempts = 0
+	_ready_since_msec = 0
 	var limit := ENDPOINT_RECOVERY_DELAYS_SECONDS.size()
 	if _endpoint_recovery_attempts >= limit:
 		_block(
@@ -326,7 +333,6 @@ func recover_lost_endpoint(episode_id: int) -> bool:
 		_endpoint_recovery_pending_episode = 0
 		return false
 	_endpoint_recovery_pending_episode = 0
-	_endpoint_recovery_started_msec = Time.get_ticks_msec()
 	start_server()
 	return str(_episode.get("state")) != BLOCKED
 
@@ -493,13 +499,7 @@ func _ready(kind: String, transport, version: String) -> void:
 		_block("invalid_transport", "The server returned invalid transport authority.")
 		return
 	_transport = transport
-	## A recovery that reaches READY spends budget until the server has held
-	## for a while; a fresh start, or a stable server, gets the full budget.
-	if (
-		_endpoint_recovery_started_msec == 0
-		or Time.get_ticks_msec() - _endpoint_recovery_started_msec >= ENDPOINT_RECOVERY_STABLE_MS
-	):
-		_endpoint_recovery_attempts = 0
+	_ready_since_msec = maxi(1, Time.get_ticks_msec())
 	_episode["state"] = READY
 	_episode["phase"] = ""
 	_episode["ready_kind"] = kind

--- a/script/release_promotion.py
+++ b/script/release_promotion.py
@@ -15,6 +15,7 @@ import os
 import re
 import shutil
 import subprocess
+import time
 import sys
 import urllib.error
 import urllib.parse
@@ -202,7 +203,15 @@ def pypi_preflight(candidate: Path, record: dict[str, Any], pending: Path) -> di
 
 
 def verify_pypi(record: dict[str, Any]) -> dict[str, Any]:
-    metadata = public_json(f"https://pypi.org/pypi/godot-ai/{record['version']}/json")
+    url = f"https://pypi.org/pypi/godot-ai/{record['version']}/json"
+    deadline = time.monotonic() + PYPI_INDEX_WAIT_SECONDS
+    metadata = public_json(url, allow_missing=True)
+    while metadata is None:
+        support.require(
+            time.monotonic() < deadline, f"PyPI still does not list {record['version']}"
+        )
+        time.sleep(PYPI_INDEX_POLL_SECONDS)
+        metadata = public_json(url, allow_missing=True)
     urls = metadata["urls"]
     support.require(
         len(urls) == 2
@@ -216,6 +225,27 @@ def verify_pypi(record: dict[str, Any]) -> dict[str, Any]:
         verify_public_file(row["url"], expected, {"files.pythonhosted.org"})
         result[row["filename"]] = {"url": row["url"], **expected}
     return result
+
+
+# PyPI's per-version JSON can 404 for a minute or two after an upload while its
+# CDN catches up; the release's own verification runs seconds after the upload.
+PYPI_INDEX_WAIT_SECONDS = 300.0
+PYPI_INDEX_POLL_SECONDS = 15.0
+
+
+def _release_for_tag(base: str, tag: str) -> dict[str, Any] | None:
+    """The release for ``tag``, draft included.
+
+    GitHub's by-tag endpoint sees only published releases; the draft this
+    workflow creates before publishing is found by listing.
+    """
+    release = gh(f"{base}/releases/tags/{tag}", allow_missing=True)
+    if release is not None:
+        return release
+    for row in gh(f"{base}/releases?per_page=100"):
+        if row.get("tag_name") == tag:
+            return row
+    return None
 
 
 def github_preflight(record: dict[str, Any]) -> dict[str, Any] | None:
@@ -233,7 +263,7 @@ def github_preflight(record: dict[str, Any]) -> dict[str, Any] | None:
             },
             "existing release tag does not point to approved source",
         )
-    release = gh(f"{base}/releases/tags/{record['tag']}", allow_missing=True)
+    release = _release_for_tag(base, record["tag"])
     if release is not None:
         support.require(
             ref is not None and not release["prerelease"], "existing release identity mismatch"

--- a/script/release_promotion.py
+++ b/script/release_promotion.py
@@ -205,13 +205,17 @@ def pypi_preflight(candidate: Path, record: dict[str, Any], pending: Path) -> di
 def verify_pypi(record: dict[str, Any]) -> dict[str, Any]:
     url = f"https://pypi.org/pypi/godot-ai/{record['version']}/json"
     deadline = time.monotonic() + PYPI_INDEX_WAIT_SECONDS
-    metadata = public_json(url, allow_missing=True)
-    while metadata is None:
-        support.require(
-            time.monotonic() < deadline, f"PyPI still does not list {record['version']}"
-        )
-        time.sleep(PYPI_INDEX_POLL_SECONDS)
-        metadata = public_json(url, allow_missing=True)
+    while True:
+        try:
+            metadata = public_json(url)
+            break
+        except urllib.error.HTTPError as exc:
+            if exc.code != 404:
+                raise
+            support.require(
+                time.monotonic() < deadline, f"PyPI still does not list {record['version']}"
+            )
+            time.sleep(PYPI_INDEX_POLL_SECONDS)
     urls = metadata["urls"]
     support.require(
         len(urls) == 2
@@ -242,7 +246,7 @@ def _release_for_tag(base: str, tag: str) -> dict[str, Any] | None:
     release = gh(f"{base}/releases/tags/{tag}", allow_missing=True)
     if release is not None:
         return release
-    for row in gh(f"{base}/releases?per_page=100"):
+    for row in gh(f"{base}/releases?per_page=100") or []:
         if row.get("tag_name") == tag:
             return row
     return None

--- a/script/release_promotion.py
+++ b/script/release_promotion.py
@@ -15,8 +15,8 @@ import os
 import re
 import shutil
 import subprocess
-import time
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request

--- a/script/release_promotion.py
+++ b/script/release_promotion.py
@@ -212,10 +212,9 @@ def verify_pypi(record: dict[str, Any]) -> dict[str, Any]:
         except urllib.error.HTTPError as exc:
             if exc.code != 404:
                 raise
-            support.require(
-                time.monotonic() < deadline, f"PyPI still does not list {record['version']}"
-            )
-            time.sleep(PYPI_INDEX_POLL_SECONDS)
+            remaining = deadline - time.monotonic()
+            support.require(remaining > 0, f"PyPI still does not list {record['version']}")
+            time.sleep(min(PYPI_INDEX_POLL_SECONDS, remaining))
     urls = metadata["urls"]
     support.require(
         len(urls) == 2

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -174,9 +174,8 @@ func test_endpoint_reprobe_for_an_owned_server_stops_the_exact_grant_first() -> 
 func test_endpoint_reprobe_gives_up_after_its_budget() -> void:
 	var manager := _manager()
 	manager._endpoint_recovery_attempts = Lifecycle.ENDPOINT_RECOVERY_DELAYS_SECONDS.size()
-	## Still inside the stability window when READY arrives: the budget carries over.
-	manager._endpoint_recovery_started_msec = Time.get_ticks_msec()
 	_complete_adoption(manager)
+	## Lost again well inside the stability minute: the budget carries over.
 	manager.transport_lost("endpoint vanished")
 	var snapshot := manager.get_status_dict()
 	assert_eq(snapshot.episode_state, Lifecycle.BLOCKED)
@@ -190,11 +189,12 @@ func test_endpoint_reprobe_gives_up_after_its_budget() -> void:
 func test_endpoint_reprobe_budget_resets_once_the_server_holds() -> void:
 	var manager := _manager()
 	manager._endpoint_recovery_attempts = 3
-	manager._endpoint_recovery_started_msec = Time.get_ticks_msec() - Lifecycle.ENDPOINT_RECOVERY_STABLE_MS
 	_complete_adoption(manager)
-	assert_eq(int(manager.get_status_dict().recovery_attempt), 0, "a server that held for a minute earns a fresh budget")
+	assert_eq(int(manager.get_status_dict().recovery_attempt), 3, "reaching READY alone keeps the spent budget")
+	## The server then holds for the stability minute before the next loss.
+	manager._ready_since_msec = Time.get_ticks_msec() - Lifecycle.ENDPOINT_RECOVERY_STABLE_MS
 	manager.transport_lost("endpoint vanished")
-	assert_eq(int(manager.get_status_dict().recovery_attempt), 1)
+	assert_eq(int(manager.get_status_dict().recovery_attempt), 1, "a server that held for a minute earns a fresh budget")
 
 
 func test_owned_endpoint_loss_stops_exact_grant_before_new_start() -> void:

--- a/tests/unit/test_release_promotion.py
+++ b/tests/unit/test_release_promotion.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import urllib.error
+
 import pytest
 
 from script import release_promotion as promotion
@@ -30,15 +32,34 @@ def test_release_for_tag_finds_the_draft_the_tag_endpoint_hides(monkeypatch):
     assert promotion._release_for_tag(BASE, "v4.0.0") is published
 
 
+def _not_found(url):
+    raise urllib.error.HTTPError(url, 404, "Not Found", {}, None)
+
+
 def test_verify_pypi_waits_for_the_index_to_list_a_fresh_upload(monkeypatch):
     record = {"version": "4.0.0", "files": {}}
-    answers = iter([None, None, {"urls": []}])
-    monkeypatch.setattr(promotion, "public_json", lambda url, allow_missing=False: next(answers))
+    calls = []
+
+    def lagging_index(url):
+        calls.append(url)
+        if len(calls) < 3:
+            _not_found(url)
+        return {"urls": []}
+
+    monkeypatch.setattr(promotion, "public_json", lagging_index)
     monkeypatch.setattr(promotion.time, "sleep", lambda seconds: None)
     with pytest.raises(support.ReleaseError, match="incomplete or unexpected"):
         promotion.verify_pypi(record)  # listed on the third try, then the inventory check runs
+    assert len(calls) == 3
 
-    monkeypatch.setattr(promotion, "public_json", lambda url, allow_missing=False: None)
+    monkeypatch.setattr(promotion, "public_json", _not_found)
     monkeypatch.setattr(promotion, "PYPI_INDEX_WAIT_SECONDS", 0.0)
     with pytest.raises(support.ReleaseError, match="still does not list 4.0.0"):
         promotion.verify_pypi(record)
+
+    def forbidden(url):
+        raise urllib.error.HTTPError(url, 403, "Forbidden", {}, None)
+
+    monkeypatch.setattr(promotion, "public_json", forbidden)
+    with pytest.raises(urllib.error.HTTPError):
+        promotion.verify_pypi(record)  # only a 404 is the index lagging

--- a/tests/unit/test_release_promotion.py
+++ b/tests/unit/test_release_promotion.py
@@ -14,7 +14,7 @@ def test_release_for_tag_finds_the_draft_the_tag_endpoint_hides(monkeypatch):
     draft = {"tag_name": "v4.0.0", "draft": True, "id": 1}
 
     def fake_gh(*args, allow_missing=False):
-        if args[0] == f"{BASE}/releases/tags/v4.0.0":
+        if args[0].startswith(f"{BASE}/releases/tags/"):
             assert allow_missing
             return None
         if args[0] == f"{BASE}/releases?per_page=100":

--- a/tests/unit/test_release_promotion.py
+++ b/tests/unit/test_release_promotion.py
@@ -1,0 +1,44 @@
+"""Publication resume paths that the first v4.0.0 release exercised for real."""
+
+from __future__ import annotations
+
+import pytest
+
+from script import release_promotion as promotion
+from script import release_support as support
+
+BASE = f"repos/{support.REPOSITORY}"
+
+
+def test_release_for_tag_finds_the_draft_the_tag_endpoint_hides(monkeypatch):
+    draft = {"tag_name": "v4.0.0", "draft": True, "id": 1}
+
+    def fake_gh(*args, allow_missing=False):
+        if args[0] == f"{BASE}/releases/tags/v4.0.0":
+            assert allow_missing
+            return None
+        if args[0] == f"{BASE}/releases?per_page=100":
+            return [{"tag_name": "v3.2.5", "draft": False}, draft]
+        raise AssertionError(args)
+
+    monkeypatch.setattr(promotion, "gh", fake_gh)
+    assert promotion._release_for_tag(BASE, "v4.0.0") == draft
+    assert promotion._release_for_tag(BASE, "v4.0.1") is None
+
+    published = {"tag_name": "v4.0.0", "draft": False}
+    monkeypatch.setattr(promotion, "gh", lambda *a, allow_missing=False: published)
+    assert promotion._release_for_tag(BASE, "v4.0.0") is published
+
+
+def test_verify_pypi_waits_for_the_index_to_list_a_fresh_upload(monkeypatch):
+    record = {"version": "4.0.0", "files": {}}
+    answers = iter([None, None, {"urls": []}])
+    monkeypatch.setattr(promotion, "public_json", lambda url, allow_missing=False: next(answers))
+    monkeypatch.setattr(promotion.time, "sleep", lambda seconds: None)
+    with pytest.raises(support.ReleaseError, match="incomplete or unexpected"):
+        promotion.verify_pypi(record)  # listed on the third try, then the inventory check runs
+
+    monkeypatch.setattr(promotion, "public_json", lambda url, allow_missing=False: None)
+    monkeypatch.setattr(promotion, "PYPI_INDEX_WAIT_SECONDS", 0.0)
+    with pytest.raises(support.ReleaseError, match="still does not list 4.0.0"):
+        promotion.verify_pypi(record)

--- a/tests/unit/test_release_promotion.py
+++ b/tests/unit/test_release_promotion.py
@@ -63,3 +63,31 @@ def test_verify_pypi_waits_for_the_index_to_list_a_fresh_upload(monkeypatch):
     monkeypatch.setattr(promotion, "public_json", forbidden)
     with pytest.raises(urllib.error.HTTPError):
         promotion.verify_pypi(record)  # only a 404 is the index lagging
+
+
+def test_verify_pypi_never_waits_past_its_deadline(monkeypatch):
+    # A controlled clock: each lookup costs 100 s, so the third 404 lands at
+    # 300 s and the wait must clamp to the budget rather than add a poll.
+    record = {"version": "4.0.0", "files": {}}
+    clock = {"now": 0.0}
+    sleeps = []
+    monkeypatch.setattr(promotion.time, "monotonic", lambda: clock["now"])
+    monkeypatch.setattr(promotion.time, "sleep", lambda seconds: sleeps.append(seconds))
+    monkeypatch.setattr(promotion, "PYPI_INDEX_WAIT_SECONDS", 300.0)
+    monkeypatch.setattr(promotion, "PYPI_INDEX_POLL_SECONDS", 15.0)
+
+    def lookup(url):
+        clock["now"] += 100.0
+        _not_found(url)
+
+    monkeypatch.setattr(promotion, "public_json", lookup)
+    with pytest.raises(support.ReleaseError, match="still does not list 4.0.0"):
+        promotion.verify_pypi(record)
+    assert sleeps == [15.0, 15.0], "the third lookup hit the deadline; no sleep past it"
+
+    clock["now"] = 0.0
+    sleeps.clear()
+    monkeypatch.setattr(promotion, "PYPI_INDEX_WAIT_SECONDS", 105.0)
+    with pytest.raises(support.ReleaseError, match="still does not list 4.0.0"):
+        promotion.verify_pypi(record)
+    assert sleeps == [5.0], "a sleep is clamped to the remaining budget"


### PR DESCRIPTION
## Summary

Two defects the first v4.0.0 publication exercised for real (runs [34086710704](https://github.com/hi-godot/godot-ai/actions/runs/34086710704) and [34087154058](https://github.com/hi-godot/godot-ai/actions/runs/34087154058)):

1. **PyPI index lag.** `verify-pypi` read `/pypi/godot-ai/4.0.0/json` two seconds after the upload, while that endpoint still returned 404. The upload itself had succeeded with matching bytes. `verify_pypi` now waits up to five minutes for the index to list the version.
2. **Drafts are invisible by tag.** `publish-github` created the tag and a draft release, uploaded all six assets, then re-fetched the release via `releases/tags/<tag>`, which GitHub answers only for published releases, and reported "GitHub upload incomplete". A resume would have created a second draft for the same tag. Releases are now resolved by listing when the tag lookup misses.

Current state: tag `v4.0.0` points at the qualified source, PyPI has 4.0.0 with bytes equal to the qualified candidate, and a single draft release holds all six assets with matching digests. Re-dispatching the release workflow after this merge resumes and publishes that draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved server endpoint recovery by resetting recovery limits only after the server remains stable for at least 60 seconds.
  - Improved release verification by retrying while newly uploaded packages become available in PyPI, with bounded waiting.
  - Release checks now correctly identify draft releases when direct tag lookup does not return them.
  - Release verification now handles missing package versions and reports non-retryable errors more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->