### PR TITLE
fix: keep the client job owner polling after activate()

### DIFF
--- a/plugin/addons/godot_ai/utils/client_job_owner.gd
+++ b/plugin/addons/godot_ai/utils/client_job_owner.gd
@@ -90,11 +90,19 @@ func _init() -> void:
 
 
 func _ready() -> void:
-	## Work can start before this node is ready: the plugin begins post-update
-	## client migration while it is still entering the tree, and this callback
-	## runs after that. Idle only when nothing is in flight; becoming ready
-	## must never cancel the poll for a thread that is already running.
-	set_process(_has_work_in_flight())
+	## Work can start — and the owner can be activated — before this node is
+	## ready. The composition root adds this child, wires it, and calls
+	## `activate()` inside the plugin's `_enter_tree`; Godot defers a child's
+	## `_ready` until that returns, so this callback runs LAST, after both the
+	## post-update migration thread and the ordinary activation seam.
+	##
+	## Scripts that define `_process` are processing by default, so an inert
+	## owner still has to turn it off here. What it must never do is turn it
+	## off again once work has been admitted: `_process` is the only thing that
+	## joins finished workers, so disabling it after `activate()` strands every
+	## refresh and client action for the rest of the session — the sweep never
+	## leaves RUNNING, Configure never leaves its last published phase.
+	set_process(_accepting_work or _has_work_in_flight())
 
 
 func _has_work_in_flight() -> bool:
@@ -469,6 +477,9 @@ func _start_action(client_id: String, action: String, request_id: String) -> Dic
 		_action_names.erase(client_id)
 		_action_request_ids.erase(client_id)
 		return {"ok": false, "error": "Could not start client worker thread."}
+	## Same invariant `begin_post_update_repin` states: a live Thread is only
+	## ever joined from `_process`, so spawning one must guarantee the poll.
+	set_process(true)
 	_publish_snapshot()
 	return {
 		"ok": true,
@@ -719,6 +730,8 @@ func request_status_refresh(ids: Array[String], force := false) -> bool:
 		_refresh_state = RefreshState.IDLE
 		_publish_snapshot()
 		return false
+	## See `_start_action`: the sweep leaves RUNNING only through `_poll_refresh`.
+	set_process(true)
 	_publish_snapshot()
 	return true
 

--- a/test_project/tests/test_client_job_owner.gd
+++ b/test_project/tests/test_client_job_owner.gd
@@ -1,0 +1,112 @@
+@tool
+extends McpTestSuite
+
+## Lifecycle coverage for `ClientJobOwner`'s processing gate.
+##
+## `_process` is the only place a finished worker Thread is ever joined:
+## `_poll_refresh` is the sole exit from RUNNING, `_poll_actions` the sole exit
+## from an in-flight client action, and `_check_action_timeouts` the sole
+## watchdog. If processing is off while a worker is alive, that worker runs to
+## completion and is never realised — the status sweep stays RUNNING forever
+## (which also disables Configure all) and a Configure row keeps its last
+## published phase label. Nothing recovers short of an editor restart, which
+## lands in the same state.
+##
+## The ordering that matters is not obvious: the composition root adds this
+## node, wires it, and calls `activate()` all inside the plugin's
+## `_enter_tree`, and Godot defers a child's `_ready` until the parent's tree
+## entry returns. `_ready` therefore runs LAST, after activation — so a
+## `_ready` that recomputes the gate from in-flight work alone silently
+## cancels the activation that already happened.
+
+const ClientJobOwner := preload("res://addons/godot_ai/utils/client_job_owner.gd")
+
+
+func suite_name() -> String:
+	return "client_job_owner"
+
+
+## Reproduce the real startup order: the owner is parented while the parent is
+## still outside the tree (so `_ready` is deferred exactly as it is inside
+## `EditorPlugin._enter_tree`), activated, and only then does the tree entry
+## complete and fire `_ready`.
+func _enter_tree_like_the_plugin(activate_before_ready: bool) -> Dictionary:
+	var parent := Node.new()
+	var owner: Node = ClientJobOwner.new()
+	## Parent is out of tree, so this does NOT fire `_ready` yet.
+	parent.add_child(owner)
+	if activate_before_ready:
+		owner.activate()
+	var root := (Engine.get_main_loop() as SceneTree).root
+	## Tree entry completes here; `_ready` fires during this call.
+	root.add_child(parent)
+	return {"parent": parent, "owner": owner, "root": root}
+
+
+func _tear_down(context: Dictionary) -> void:
+	var parent: Node = context["parent"]
+	(context["root"] as Node).remove_child(parent)
+	parent.free()
+
+
+func test_ready_after_activate_keeps_processing() -> void:
+	## Regression: `_ready` used to recompute the gate from in-flight work only,
+	## so an owner activated during `_enter_tree` had processing switched back
+	## off the moment its deferred `_ready` ran. Every later refresh and client
+	## action then completed on its worker and was never joined.
+	var context := _enter_tree_like_the_plugin(true)
+	var owner: Node = context["owner"]
+	assert_true(
+		owner.is_processing(),
+		"activate() ran before the deferred _ready(); _ready must not cancel the poll loop"
+	)
+	_tear_down(context)
+
+
+func test_ready_without_activation_stays_inert() -> void:
+	## The other half of the contract: construction is inert. A script that
+	## defines `_process` is processing by default, so an owner that was never
+	## activated and has no work in flight still has to switch it off.
+	var context := _enter_tree_like_the_plugin(false)
+	var owner: Node = context["owner"]
+	assert_false(
+		owner.is_processing(),
+		"An unactivated owner with no work in flight must not poll"
+	)
+	_tear_down(context)
+
+
+func test_ready_with_work_in_flight_keeps_processing() -> void:
+	## The post-update migration path: `begin_post_update_repin` starts its
+	## worker before this node is ready, so `_ready` must not cancel the poll
+	## for a thread that is already running. This case was already correct and
+	## is why the bug only reproduced on ordinary starts.
+	var parent := Node.new()
+	var owner: Node = ClientJobOwner.new()
+	parent.add_child(owner)
+	## Stand in for a live action slot without spawning a real Thread —
+	## `_has_work_in_flight()` only asks whether the slot table is populated.
+	owner._action_threads["claude_code"] = null
+	var root := (Engine.get_main_loop() as SceneTree).root
+	root.add_child(parent)
+	assert_true(
+		owner.is_processing(),
+		"_ready() must keep polling for work that was admitted before it ran"
+	)
+	owner._action_threads.clear()
+	root.remove_child(parent)
+	parent.free()
+
+
+func test_activate_is_inert_after_shutdown() -> void:
+	## `quiesce()` makes SHUTTING_DOWN sticky; a late activate() must not
+	## reopen the owner or restart its poll loop behind a drained worker pool.
+	var owner: Node = ClientJobOwner.new()
+	owner.quiesce()
+	owner.activate()
+	assert_false(
+		owner.is_processing(),
+		"activate() must stay inert once the owner has been quiesced"
+	)
+	assert_false(owner.snapshot().get("accepting_work", true))
+	owner.free()


### PR DESCRIPTION
Fixes #990. Probably also the stuck-dock half of #989.

## Cause

`ClientJobOwner._ready()` recomputed its processing gate from in-flight work alone:

```gdscript
set_process(_has_work_in_flight())
```

`plugin.gd` adds the owner, wires it, and calls `activate()` (which does `set_process(true)`) all inside the plugin's `_enter_tree`. Godot defers a child's `_ready` until the parent's tree entry returns, so `_ready` runs after `activate()` and turns processing back off. Instrumented on a live editor:

```
1618876  activate(): set_process(true), is_processing=true inside_tree=true
1618880  _ready() BEFORE set_process: is_processing=true  work_in_flight=false  accepting=true
1618884  _ready() AFTER  set_process: is_processing=false
```

`_process` is the only place a finished worker `Thread` is ever joined. With it off for the whole session:

- `_poll_actions()` never joins a finished Configure. The action completes, config written and pre-warm done, but the row keeps its last published phase label. That is the "Installing…" that never clears.
- `_poll_refresh()` never joins the status sweep. The worker itself finishes in about 85 ms, but `_refresh_state` stays `RUNNING` permanently, so `should_disable_client_actions(RUNNING)` greys out Configure all and every later `check_client_status` coalesces into `_refresh_pending` and never answers. MCP `client_manage op=status` times out at 30 s, every time.
- `_check_action_timeouts()` never fires, so nothing recovers. Restarting the editor lands in the same state.

Only ordinary starts are affected. The first start after an update takes the post-update migration path, which has a thread in flight when `_ready` runs, so `_has_work_in_flight()` is true and processing survives. That is why the fault shows up one restart after upgrading, and why 3.2.x was fine: this polling lived in `mcp_dock.gd`, which has no deferred-`_ready` hazard.

## Change

`_ready` still switches processing off for an inert owner. Scripts defining `_process` are processing by default, so that part of the contract is real. It no longer does so once work has been admitted:

```gdscript
set_process(_accepting_work or _has_work_in_flight())
```

The two remaining spawn sites, `_start_action` and `request_status_refresh`, now assert the same invariant `begin_post_update_repin` already did: a live `Thread` is only ever joined from `_process`, so spawning one guarantees the poll.

## Tests

`test_project/tests/test_client_job_owner.gd` is new. The owner shipped with no lifecycle coverage, which is how a dead `_process` got released. Four tests; the key one reproduces the real ordering by parenting the owner while the parent is still outside the tree, activating, and only then completing tree entry so `_ready` fires deferred.

On this branch:

```
test_run suite=client_job_owner  ->  4 passed, 0 failed
```

Reverting only the `_ready` line, same suite:

```
1 failed: test_ready_after_activate_keeps_processing
  "activate() ran before the deferred _ready(); _ready must not cancel the poll loop"
3 passed
```

## Manual verification

Windows 11, Godot 4.7.2, plugin 4.0.0, in a real editor. Before: `client_manage op=status` timed out at 30 s on four consecutive attempts, dock rows stuck on "Installing…". After: status returns immediately with all rows correct, and `client_manage op=configure client=claude_code` returns `{"status":"ok","message":"Claude Code configured (stdio attach)"}`.

## Separate observation, not addressed here

`_cli_exec.gd` calls `PortResolver.capture_process_kill_grant()` after every spawn, including the success path where nothing will be killed. On Windows that is up to three `tasklist` plus two PowerShell `Get-CimInstance` invocations per CLI call: `process_fingerprint()` runs twice to close the capture window, and `execute_windows_powershell()` falls through `powershell.exe` to `pwsh.exe`. I measured a single `capture_process_kill_grant()` against a live child at 1679 ms.

The grant only has to exist on the timeout and cancel branches, where it proves which process is being killed. Capturing it eagerly is what makes PowerShell a hard runtime dependency (#989) and adds seconds to each client probe, which will squeeze the 30 s status budget for anyone with several client CLIs installed. I left it alone to keep this PR to the one fault, and can open a separate issue if that is useful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background job processing during startup and worker-thread execution.
  * Ensured completed worker tasks are consistently detected and finalized.
  * Preserved processing behavior when activation occurs before initialization.

* **Tests**
  * Added coverage for activation, deferred initialization, in-flight work, and quiesced states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->