### PR TITLE
release: prepare v4.0.1 source version

### DIFF
--- a/plugin/addons/godot_ai/plugin.cfg
+++ b/plugin/addons/godot_ai/plugin.cfg
@@ -3,5 +3,5 @@
 name="Godot AI"
 description="MCP server and AI tools for Godot"
 author="Godot AI"
-version="4.0.0"
+version="4.0.1"
 script="plugin.gd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "godot-ai"
-version = "4.0.0"
+version = "4.0.1"
 description = "Production-grade MCP server and AI tools for the Godot engine"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11,<3.15"


### PR DESCRIPTION
Set the Python package and Godot plugin versions to 4.0.1 for the patch containing #991's client-worker polling fix, #994's Windows restart/reconnection coverage, and #995's Bazzite capability-directory workaround.

The polling fix addresses the stuck Installing/Checking symptom in #989. Keep #989 open for post-release confirmation of its remaining connection/PowerShell report, and keep #988 open because the affected Windows capability-permissions failure has not been reproduced on clean runners.

Validation: Ruff passed; 2,534 Python/integration tests passed (23 skipped), including real-editor update scenarios, followed by both newly merged client regression checks passing on the assembled tree. All 73 live Godot suites passed (2,239 passed, zero failed). The local wheel builds and package/plugin/wheel metadata agree on 4.0.1.

This prepares reviewed source A only. The release-side operator must freeze the final main SHA, prepare its qualification-only 4.0.2 child, qualify the exact candidate bytes, and publish via the existing release workflow. No qualification or publication workflow was dispatched from this task.

Authored by Codex on behalf of @dsarno.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the Godot AI plugin and project version to **4.0.1**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->