### PR TITLE
fix: follow validated GitHub release redirects

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -284,6 +284,27 @@ embedded triple ([v4-migration.md](v4-migration.md)).
 from outside a running editor. It exists for release qualification and for
 recovery; it is not an end-user path.
 
+## Recovering the 4.0.0 / 4.0.1 HTTP 302 download failure
+
+These versions reject GitHub's download redirect before staging an update.
+The fix in 4.0.2 cannot repair an already-installed updater through that same
+broken download path. Release support must use the existing closed-editor
+installer to install a published, verified release once; normal in-editor
+updates can resume afterward. Do not overlay files into the installed add-on.
+
+Close the project's editor. From a trusted checkout of the published release,
+download its canonical ZIP, manifest, and signature using a client that follows
+HTTPS redirects, then run `script/v4-release install` with those three files,
+`--project-root` set to the affected project, and all `--expected-*` fields set
+to the published repository, stable channel, tag, version, and full source SHA.
+The installer verifies the signature and complete inventory before swapping
+the tree and retains the previous add-on for recovery. Reopen Godot and confirm
+the installed version and client connection. An unqualified candidate is not a
+recovery release.
+
+The private qualification origin now redirects asset URLs before serving
+their bytes, so every exact A-to-B update test exercises this path.
+
 ## Recovery: the three marker states
 
 Everything the updater writes lives under `addons/.godot_ai_update/` inside the

--- a/docs/v4-migration.md
+++ b/docs/v4-migration.md
@@ -19,10 +19,11 @@ managed server automatically.
 Cherry Studio is not supported in v4; remove its stale v3 entry in Cherry
 Studio itself. Godot AI cannot safely edit that application's internal database.
 
-The public v4 release is not available yet: publication remains fail-closed
-until the cross-platform qualification run is complete and the maintainer
-approves promotion. The steps above describe the supported flow once
-publication opens. Do not install an unpublished candidate into a real project.
+Use a published, signed v4 release. If an installed 4.0.0 or 4.0.1 reports
+`download failed (302)` when updating, retrying cannot fix its redirect bug.
+See the [release-support recovery procedure](releasing.md#recovering-the-400--401-http-302-download-failure)
+for a verified closed-editor installation; do not overlay add-on files or
+install an unpublished candidate into a real project.
 
 ## What the Update click does
 

--- a/plugin/addons/godot_ai/plugin.cfg
+++ b/plugin/addons/godot_ai/plugin.cfg
@@ -3,5 +3,5 @@
 name="Godot AI"
 description="MCP server and AI tools for Godot"
 author="Godot AI"
-version="4.0.1"
+version="4.0.2"
 script="plugin.gd"

--- a/plugin/addons/godot_ai/utils/update_manager.gd
+++ b/plugin/addons/godot_ai/utils/update_manager.gd
@@ -323,6 +323,13 @@ static func _is_trusted_download_url(url: String, qualification: Dictionary = {}
 	var parts := _https_url_parts(url)
 	if parts.is_empty():
 		return false
+	## Current GitHub release assets use a slash-delimited repository ID;
+	## retain the older CDN namespace below for existing release URLs.
+	if (
+		parts.host == "release-assets.githubusercontent.com"
+		and str(parts.path).begins_with("/github-production-release-asset/1208239711/")
+	):
+		return true
 	if (
 		str(parts.origin) == str(qualification.get("asset_origin", ""))
 		and str(parts.path).begins_with(str(qualification.get("asset_path", "")))
@@ -447,7 +454,13 @@ func _on_asset_completed(
 	if _asset_request != null:
 		_asset_request.queue_free()
 		_asset_request = null
-	if result == HTTPRequest.RESULT_SUCCESS and response_code in [301, 302, 303, 307, 308]:
+	## With max_redirects = 0 Godot returns REDIRECT_LIMIT_REACHED on the
+	## first redirect, including its status and Location. Validate that hop
+	## ourselves; other transport failures must still fail closed.
+	if (
+		result in [HTTPRequest.RESULT_SUCCESS, HTTPRequest.RESULT_REDIRECT_LIMIT_REACHED]
+		and response_code in [301, 302, 303, 307, 308]
+	):
 		var redirect := _redirect_url(headers)
 		DirAccess.remove_absolute(_download_path(_active_asset))
 		if (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "godot-ai"
-version = "4.0.1"
+version = "4.0.2"
 description = "Production-grade MCP server and AI tools for the Godot engine"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11,<3.15"

--- a/script/qualification_https.py
+++ b/script/qualification_https.py
@@ -83,7 +83,7 @@ def private_release_origin(
                 {
                     "name": name,
                     "size": expected[name]["size"],
-                    "browser_download_url": ORIGIN + ASSET_PATH + name,
+                    "browser_download_url": ORIGIN + ASSET_PATH + "redirect/" + name,
                 }
                 for name in sorted(expected)
             ],
@@ -121,6 +121,15 @@ def private_release_origin(
                 self.send_error(400)
                 return
             name = self.path.removeprefix(ASSET_PATH)
+            if (
+                self.path.startswith(ASSET_PATH + "redirect/")
+                and name.removeprefix("redirect/") in expected
+            ):
+                self.send_response(302)
+                self.send_header("Location", ORIGIN + ASSET_PATH + name.removeprefix("redirect/"))
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                return
             if self.path == RELEASE_PATH:
                 payload = metadata
                 content_type = "application/json"

--- a/test_project/tests/test_update_manager.gd
+++ b/test_project/tests/test_update_manager.gd
@@ -4,6 +4,57 @@ extends McpTestSuite
 const Manager := preload("res://addons/godot_ai/utils/update_manager.gd")
 
 
+class RedirectProbe extends Manager:
+	var requested_url := ""
+	var failure := ""
+
+	func _request_active_asset(url: String) -> void:
+		requested_url = url
+
+	func _fail_download(reason: String) -> void:
+		failure = reason
+
+
+func test_manual_redirect_accepts_godot_redirect_limit_result() -> void:
+	var target := "https://release-assets.githubusercontent.com/github-production-release-asset/1208239711/test"
+	for code in [301, 302, 303, 307, 308]:
+		var manager := RedirectProbe.new()
+		manager._on_asset_completed(HTTPRequest.RESULT_REDIRECT_LIMIT_REACHED, code,
+			PackedStringArray(["Location: " + target]), PackedByteArray())
+		assert_eq(manager.requested_url, target)
+		assert_eq(manager._redirect_count, 1)
+		assert_eq(manager.failure, "")
+		manager.free()
+
+
+func test_manual_redirect_still_rejects_unsafe_targets_and_excess_hops() -> void:
+	for headers in [PackedStringArray(), PackedStringArray(["Location: http://github.com/x"]),
+		PackedStringArray(["Location: https://evil.invalid/x"]),
+		PackedStringArray(["Location: /relative"]),
+		PackedStringArray(["Location: https://github.com/x", "Location: https://github.com/y"])]:
+		var manager := RedirectProbe.new()
+		manager._on_asset_completed(HTTPRequest.RESULT_REDIRECT_LIMIT_REACHED, 302, headers, PackedByteArray())
+		assert_eq(manager.requested_url, "")
+		assert_eq(manager.failure, "untrusted or excessive redirect")
+		manager.free()
+	var exhausted := RedirectProbe.new()
+	exhausted._redirect_count = Manager.MAX_REDIRECTS
+	exhausted._on_asset_completed(HTTPRequest.RESULT_REDIRECT_LIMIT_REACHED, 302,
+		PackedStringArray(["Location: https://release-assets.githubusercontent.com/github-production-release-asset-1/test"]), PackedByteArray())
+	assert_eq(exhausted.requested_url, "")
+	assert_eq(exhausted.failure, "untrusted or excessive redirect")
+	exhausted.free()
+
+
+func test_manual_redirect_does_not_accept_other_transport_failures() -> void:
+	for pair in [[HTTPRequest.RESULT_CANT_CONNECT, 302], [HTTPRequest.RESULT_REDIRECT_LIMIT_REACHED, 200]]:
+		var manager := RedirectProbe.new()
+		manager._on_asset_completed(pair[0], pair[1], PackedStringArray(), PackedByteArray())
+		assert_eq(manager.requested_url, "")
+		assert_true(manager.failure.begins_with("download failed"))
+		manager.free()
+
+
 func suite_name() -> String:
 	return "update_manager"
 
@@ -108,7 +159,12 @@ func test_download_url_parser_rejects_spoofing_and_path_traversal() -> void:
 	assert_true(Manager._is_trusted_download_url(
 		"https://release-assets.githubusercontent.com/github-production-release-asset-1/x?sig=y"
 	))
+	assert_true(Manager._is_trusted_download_url(
+		"https://release-assets.githubusercontent.com/github-production-release-asset/1208239711/x?sig=y"
+	))
 	for url in [
+		"https://release-assets.githubusercontent.com/github-production-release-asset/999/x",
+		"https://release-assets.githubusercontent.com/github-production-release-asset/12082397110/x",
 		"http://github.com/hi-godot/godot-ai/releases/download/v4.1.0/x",
 		"https://github.com.evil.invalid/hi-godot/godot-ai/releases/download/v4.1.0/x",
 		"https://github.com@evil.invalid/hi-godot/godot-ai/releases/download/v4.1.0/x",

--- a/tests/integration/test_qualification_https.py
+++ b/tests/integration/test_qualification_https.py
@@ -167,11 +167,11 @@ def test_real_godot_uses_verified_default_port_https_without_system_changes(tmp_
             assert report["metadata"]["result"] == 0
             assert report["metadata"]["status"] == 200
             assert report["asset"] == {
-                "result": 0,
-                "status": 200,
-                "sha256": hashlib.sha256(b"godot-ai-v4-plugin.zip").hexdigest(),
+                "result": 12,  # RESULT_REDIRECT_LIMIT_REACHED with max_redirects=0
+                "status": 302,
+                "sha256": hashlib.sha256(b"").hexdigest(),
             }
-            assert endpoint.downloads == ["godot-ai-v4-plugin.zip"]
+            assert endpoint.downloads == []
         elif mode == "wrong-token":
             assert report["metadata"]["result"] == 0
             assert report["metadata"]["status"] == 401
@@ -250,7 +250,7 @@ def test_unchanged_update_manager_discovers_and_downloads_over_private_https(tmp
                 "manifest": "godot-ai-v4-plugin.manifest.json",
                 "signature": "godot-ai-v4-plugin.manifest.sig",
             }
-            assert report["requests"] == 4
+            assert report["requests"] == 7  # metadata + redirect and download for each asset
             assert endpoint.downloads == list(expected_paths.values())
             assert report["hashes"] == {
                 field: inventory[name]["sha256"] for field, name in expected_paths.items()

--- a/tests/unit/test_qualification_https.py
+++ b/tests/unit/test_qualification_https.py
@@ -69,6 +69,11 @@ def test_origin_serves_exact_bytes_over_verified_tls_and_keeps_token_private(
         assert {row["name"] for row in metadata["assets"]} == support.RELEASE_NAMES
         for row in metadata["assets"]:
             path = ASSET_PATH + row["name"]
+            redirect_path = row["browser_download_url"].removeprefix(https.ORIGIN)
+            code, empty, headers = request(endpoint, certificate, redirect_path)
+            assert code == 302 and empty == b""
+            assert headers["Location"] == https.ORIGIN + path
+            assert request(endpoint, certificate, redirect_path, headers={})[0] == 401
             code, empty, headers = request(endpoint, certificate, path, method="HEAD")
             assert code == 200 and empty == b""
             assert int(headers["Content-Length"]) == inventory[row["name"]]["size"]


### PR DESCRIPTION
Godot AI 4.0.0 and 4.0.1 detect updates but reject GitHub's normal asset redirect, leaving the Update button at `download failed (302)`. With automatic redirects disabled, Godot reports `RESULT_REDIRECT_LIMIT_REACHED`, not success. Accept that result only for redirect statuses and retain per-hop HTTPS destination validation and the five-hop limit. Also recognize GitHub's current CDN path scoped to this repository's numeric ID; the old allowlist recognized only the legacy path.

Make the private qualification origin return an authenticated 302 before every asset. Real-Godot tests now require the redirect result and seven requests for metadata plus three redirected downloads. Add GDScript coverage for accepted statuses, unrelated transport failures, unsafe targets, and excessive hops. Prepare version 4.0.2 and document verified closed-editor recovery, because the already-installed broken updater cannot download its own fix.

Validation:
- Before the fix, the real-editor HTTPS update failed with the new redirecting origin.
- The fixed production downloader fetched all three canonical v4.0.1 assets through public GitHub redirects; signature, release identity, archive, and complete inventory verification passed.
- All 73 live Godot suites passed (2,242 passed, zero failed). Ruff passed.
- Full Python run: 2,534 passed, with two obsolete direct-download assertions subsequently corrected; all 37 focused HTTPS tests and the failed-test rerun passed. Real signed update/restart and closed-editor recovery cases ran in the full suite.

Related to #989; leave it open for reporter confirmation after release/recovery.

Authored by Codex on behalf of @dsarno.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed update failures caused by HTTP 302 redirects when downloading releases.
  - Version 4.0.2 now safely follows approved release-download redirects, including redirects used by GitHub asset hosting.
  - Improved handling prevents unsafe or excessive redirects from being followed.

- **Documentation**
  - Added recovery guidance for installations of versions 4.0.0 and 4.0.1 affected by `download failed (302)`.
  - Updated v4 migration guidance to recommend installing a published, signed release through the closed-editor installer when required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->