### PR TITLE
fix: release the update lock when a download fails

### DIFF
--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -56,7 +56,8 @@ All steps run inside the editor, on the main thread except the download.
      collisions, reserved names, directory entries or links, within the file
      count and size bounds; every entry's size and SHA-256 equal its inventory
      row.
-   Any failure discards the download and surfaces the reason in the dock.
+   Any failure discards the download, surfaces the reason in the dock, and
+   reports the install as over so the plugin releases the click-time lock.
 4. **Stage.** Extract into `res://addons/.godot_ai_update/stage/addons/godot_ai/`
    and re-hash the extracted files against the inventory. The dot-prefixed
    directory is ignored by Godot's filesystem scanner and carries a

--- a/plugin/addons/godot_ai/utils/update_manager.gd
+++ b/plugin/addons/godot_ai/utils/update_manager.gd
@@ -117,6 +117,7 @@ func start_install(preflight: Dictionary) -> void:
 		return
 	if not bool(preflight.get("ok", false)):
 		install_state_changed.emit({
+			"install_in_flight": false,
 			"button_text": "Update blocked — resolve recovery state",
 			"button_disabled": false,
 		})
@@ -128,13 +129,18 @@ func start_install(preflight: Dictionary) -> void:
 		or not _directory_is_empty(directory)
 	):
 		install_state_changed.emit({
+			"install_in_flight": false,
 			"button_text": "Update blocked — private download directory unavailable",
 			"button_disabled": false,
 		})
 		return
 	_download_root = directory
 	_queue.assign([ASSET_NAME, MANIFEST_NAME, SIGNATURE_NAME])
-	install_state_changed.emit({"button_text": "Downloading…", "button_disabled": true})
+	install_state_changed.emit({
+		"install_in_flight": true,
+		"button_text": "Downloading…",
+		"button_disabled": true,
+	})
 	_download_next()
 
 
@@ -518,7 +524,10 @@ func _fail_download(reason: String) -> void:
 	_qualification.clear()
 	discard_downloads()
 	push_error("MCP | v4 update preparation failed: %s" % reason)
+	## The click-time lock and any quiesced client work are the plugin's to
+	## release, and it only does so when it hears the install is over.
 	install_state_changed.emit({
+		"install_in_flight": false,
 		"button_text": "Update preparation failed",
 		"button_disabled": false,
 	})

--- a/test_project/tests/test_update_manager.gd
+++ b/test_project/tests/test_update_manager.gd
@@ -59,6 +59,82 @@ func suite_name() -> String:
 	return "update_manager"
 
 
+class DownloadProbe extends Manager:
+	var downloads_started := 0
+
+	func _download_next() -> void:
+		downloads_started += 1
+
+
+static func _candidate_release() -> Dictionary:
+	return {
+		"urls": {},
+		"sizes": {},
+		"channel": "stable",
+		"tag": "v4.1.0",
+		"version": "4.1.0",
+	}
+
+
+static func _record_states(manager: Manager) -> Array[Dictionary]:
+	var states: Array[Dictionary] = []
+	manager.install_state_changed.connect(func(state: Dictionary) -> void:
+		states.append(state)
+	)
+	return states
+
+
+## The plugin takes the update lock before the download and releases it, and
+## resumes any quiesced client work, only when an install state says the
+## install is over. A failure that stays silent about that leaves lock.json
+## behind for the rest of the editor session (seen live after a 4.0.0
+## "download failed (302)" on 2026-09-07).
+func test_failed_download_reports_the_install_as_over() -> void:
+	var manager := Manager.new()
+	var states := _record_states(manager)
+	manager._download_root = OS.get_user_data_dir().path_join("godot_ai_test_never_created")
+	manager._fail_download("download failed (302)")
+	assert_eq(states.size(), 1)
+	assert_true(states[0].has("install_in_flight"), "a failed download must say the install is over")
+	assert_false(bool(states[0]["install_in_flight"]))
+	assert_false(bool(states[0]["button_disabled"]))
+	assert_eq(manager._download_root, "")
+	manager.free()
+
+
+func test_refused_install_reports_the_install_as_over() -> void:
+	for preflight in [{"ok": false}, {"ok": true, "download_root": "relative/path"}]:
+		var manager := Manager.new()
+		manager._release = _candidate_release()
+		var states := _record_states(manager)
+		manager.start_install(preflight)
+		assert_eq(states.size(), 1, str(preflight))
+		assert_true(states[0].has("install_in_flight"), str(preflight))
+		assert_false(bool(states[0]["install_in_flight"]), str(preflight))
+		manager.free()
+
+
+func test_download_start_and_repeat_click_keep_the_install_in_flight() -> void:
+	var root := OS.get_user_data_dir().path_join("godot_ai_test_download_root")
+	assert_eq(DirAccess.make_dir_recursive_absolute(root), OK)
+	var manager := DownloadProbe.new()
+	manager._release = _candidate_release()
+	var states := _record_states(manager)
+	manager.start_install({"ok": true, "download_root": root})
+	assert_eq(manager.downloads_started, 1)
+	assert_eq(states.size(), 1)
+	assert_true(bool(states[0].get("install_in_flight", false)), "Downloading must hold the lock")
+	assert_true(bool(states[0]["button_disabled"]))
+	## A second click while the first download is queued must not report the
+	## install as over: that would release the lock under the running download.
+	manager.start_install({"ok": true, "download_root": root})
+	assert_eq(manager.downloads_started, 1)
+	assert_eq(states.size(), 2)
+	assert_true(bool(states[1].get("install_in_flight", true)))
+	manager.free()
+	DirAccess.remove_absolute(root)
+
+
 static func _asset(name: String, size: int = 32) -> Dictionary:
 	return {
 		"name": name,


### PR DESCRIPTION
## What

`_preflight_update` takes `addons/.godot_ai_update/lock.json` before the download, and the plugin releases it from `_on_update_install_state_changed` only when a state carries `install_in_flight: false`. `McpUpdateManager._fail_download` and the two refused-install paths emitted without that key, so the plugin read the default (`true`), kept the lock, and skipped `resume_after_quiesce`.

Seen live on 2026-09-07: a 4.0.0 editor's `download failed (302)` left `lock.json` behind for the rest of the session. A repeat click still worked because the same process owns the lock, so the damage is a stale lock, not a stuck updater, but the contract in `docs/self-update.md` ("released by every failure path before the swap") was not being honoured.

## Fix

- `utils/update_manager.gd`: every terminal state from the manager says the install is over; the download-start state says it is in flight; the "already in progress" reply stays silent about it so a repeat click cannot release the lock under a running download.
- `test_project/tests/test_update_manager.gd`: three tests lock those shapes.
- `docs/self-update.md`: one sentence on what a failed download does.

## Verification

- Full GDScript suite in a real GUI Godot 4.7.beta3 editor: 2257 passed (incl. the 3 new), 11 skipped, 2 failed. The 2 failures are `script.test_patch_script_refreshes_loaded_gdscript` and `script.test_patch_script_reports_not_loaded_when_nothing_cached`, which fail identically on a branch with main's untouched handler code in the same GUI editor and pass headless; a separate task tracks them.
- `GODOT_BIN=… pytest tests/integration/test_self_update_upgrade_paths.py`: 14 passed, 10 skipped (nightly-only fleet crossings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Update failures now clearly finish the installation attempt, releasing the update lock so users can try again.
  - Update status now accurately indicates whether an installation is in progress.
  - Repeated clicks during an active download remain safely blocked.
  - Trusted GitHub redirects are accepted, while unsafe destinations, excessive redirects, and transport failures continue to be rejected.

- **Documentation**
  - Clarified self-update behavior when verification fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->