### PR TITLE
fix: keep the dock's Update button an action and re-arm it for a new release

### DIFF
--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -56,7 +56,8 @@ All steps run inside the editor, on the main thread except the download.
      collisions, reserved names, directory entries or links, within the file
      count and size bounds; every entry's size and SHA-256 equal its inventory
      row.
-   Any failure discards the download and surfaces the reason in the dock.
+   Any failure discards the download, surfaces the reason in the dock, and
+   reports the install as over so the plugin releases the click-time lock.
 4. **Stage.** Extract into `res://addons/.godot_ai_update/stage/addons/godot_ai/`
    and re-hash the extracted files against the inventory. The dot-prefixed
    directory is ignored by Godot's filesystem scanner and carries a

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -157,7 +157,7 @@ var _drift_label: Label
 ## tests/unit/test_editor_focus_refocus.py locates the notification handler
 ## by first occurrence of that token.)
 var _uv_recheck_pending := false
-## Handles for the Setup section's "Server" row. `_update_status` keeps
+## Handles for the Setup section's "Server" row. `_update_status_label` keeps
 ## the label text/color in sync with `McpConnection.server_version` so the
 ## dock reports the TRUE running server version, not the plugin's
 ## expected version. See #174 follow-up — a plugin upgrade via self-
@@ -165,7 +165,7 @@ var _uv_recheck_pending := false
 ## (foreign-port branch never sets `_server_pid`, so `_stop_server`
 ## can't kill it); the line has to show the mismatch honestly.
 var _setup_server_label: Label
-## Last rendered server-version string. `_update_status` runs every
+## Last rendered server-version string. `_update_status_label` runs every
 ## frame; early-outs text repaint when nothing changed. Empty means
 ## "no line rendered yet" (dev-checkout branch doesn't render a
 ## user-mode Server line).
@@ -248,7 +248,12 @@ const STARTUP_GRACE_MSEC := 60 * 1000
 # installation remain root-owned and arrive here as copied presentation state.
 var _update_banner: VBoxContainer
 var _update_label: Label
+var _update_status_label: Label
 var _update_btn: Button
+## The button is an action, never a status line: progress and failure text
+## goes to `_update_status_label`, and the button only enables or disables.
+const _UPDATE_ACTION_TEXT := "Update"
+const _UPDATE_LABEL_COLOR := Color(1.0, 0.85, 0.3)
 var _post_update_action := ""
 
 func _ready() -> void:
@@ -355,7 +360,7 @@ func _build_ui() -> void:
 	status_row.add_child(icon_center)
 
 	_status_label = Label.new()
-	# Start in grace state — _update_status will take over on the next frame
+	# Start in grace state — _update_status_label will take over on the next frame
 	# once the connection is available. Never show bare "Disconnected" on
 	# first paint because that's misleading while the server is still
 	# spinning up.
@@ -453,7 +458,7 @@ func _build_ui() -> void:
 
 	_update_label = Label.new()
 	_update_label.add_theme_font_size_override("font_size", 15)
-	_update_label.add_theme_color_override("font_color", Color(1.0, 0.85, 0.3))
+	_update_label.add_theme_color_override("font_color", _UPDATE_LABEL_COLOR)
 	## Wrap long banner text (e.g. the < 4.5 support-floor guidance) instead
 	## of letting a single line stretch the whole dock wide. The dock is a
 	## fixed-width side panel, so constrain horizontally and wrap.
@@ -462,11 +467,19 @@ func _build_ui() -> void:
 	_update_label.custom_minimum_size = Vector2(0, 0)
 	_update_banner.add_child(_update_label)
 
+	_update_status_label = Label.new()
+	_update_status_label.add_theme_font_size_override("font_size", 13)
+	_update_status_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_update_status_label.size_flags_horizontal = Control.SIZE_FILL
+	_update_status_label.custom_minimum_size = Vector2(0, 0)
+	_update_status_label.visible = false
+	_update_banner.add_child(_update_status_label)
+
 	var update_btn_row := HBoxContainer.new()
 	update_btn_row.add_theme_constant_override("separation", 6)
 
 	_update_btn = Button.new()
-	_update_btn.text = "Update"
+	_update_btn.text = _UPDATE_ACTION_TEXT
 	_update_btn.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	_update_btn.pressed.connect(_on_update_pressed)
 	update_btn_row.add_child(_update_btn)
@@ -1207,7 +1220,7 @@ func _apply_dev_mode_visibility() -> void:
 	# (so users can install uv from the dock) — but not while the server
 	# launch is still settling (#744): mid-launch a red "uv: not found" row
 	# is usually a transient probe failure (#739) or irrelevant because the
-	# launch is succeeding via the .venv or system tiers. `_update_status`
+	# launch is succeeding via the .venv or system tiers. `_update_status_label`
 	# re-applies visibility on every status transition, so the section
 	# appears the moment the launch outcome makes it relevant.
 	var is_dev := ClientConfigurator.is_dev_checkout()
@@ -1228,7 +1241,7 @@ static func _setup_section_should_show(
 ## True while the server launch outcome is still unknown: not connected,
 ## no terminal diagnosis yet, and the startup grace window ("Starting
 ## server…" in the status row) is still running. Mirrors the status-label
-## logic in `_update_status` so the Setup section and the amber status
+## logic in `_update_status_label` so the Setup section and the amber status
 ## text agree on what "still launching" means.
 func _server_launch_pending() -> bool:
 	if _last_connected:
@@ -2747,21 +2760,38 @@ static func update_confirm_text(version: String) -> String:
 func present_update_check(result: Dictionary) -> void:
 	_update_candidate_version = String(result.get("version", ""))
 	_update_label.text = String(result.get("label_text", ""))
+	_update_label.add_theme_color_override("font_color", _UPDATE_LABEL_COLOR)
 	_update_banner.visible = true
+	## A fresh candidate re-arms the action. The restarted editor after an
+	## update shows "Update complete" with the button disabled; a newer release
+	## found later in that same session must still be installable. A running
+	## install or a pending post-update action keeps ownership of the button.
+	if _update_install_in_flight or not _post_update_action.is_empty():
+		return
+	_set_update_status("")
+	if _update_btn != null:
+		_update_btn.text = _UPDATE_ACTION_TEXT
+		_update_btn.disabled = false
 
 
 ## Apply only the keys present so the manager can ship partial updates
-## (e.g. button-text-only during the download phase) without clobbering
-## banner state.
+## (e.g. status-only during the download phase) without clobbering banner
+## state. `button_text` names an action ("Retry client migration");
+## progress and failure messages arrive as `status_text` and never replace
+## the button label.
 func present_update_state(state: Dictionary) -> void:
 	if state.has("post_update_action"):
 		_post_update_action = String(state["post_update_action"])
+		if _post_update_action.is_empty() and _update_btn != null:
+			_update_btn.text = _UPDATE_ACTION_TEXT
 	if state.has("install_in_flight"):
 		_update_install_in_flight = bool(state["install_in_flight"])
 	if state.has("button_text") and _update_btn != null:
 		_update_btn.text = String(state["button_text"])
 	if state.has("button_disabled") and _update_btn != null:
 		_update_btn.disabled = bool(state["button_disabled"])
+	if state.has("status_text"):
+		_set_update_status(String(state["status_text"]))
 	if state.has("label_text") and _update_label != null:
 		_update_label.text = String(state["label_text"])
 	if state.has("banner_visible") and _update_banner != null:
@@ -2769,3 +2799,10 @@ func present_update_state(state: Dictionary) -> void:
 	if String(state.get("outcome", "")) == "success" and _update_label != null:
 		## Visual confirmation for successful terminal update states.
 		_update_label.add_theme_color_override("font_color", Color.GREEN)
+
+
+func _set_update_status(text: String) -> void:
+	if _update_status_label == null:
+		return
+	_update_status_label.text = text
+	_update_status_label.visible = not text.is_empty()

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -791,7 +791,7 @@ func _begin_startup_release() -> void:
 	if _dock != null:
 		_dock.present_update_state({
 			"install_in_flight": true,
-			"button_text": "Migrating client configuration…",
+			"status_text": "Migrating client configuration…",
 			"button_disabled": true,
 			"label_text": "The server remains stopped until configured clients are repinned.",
 			"banner_visible": true,
@@ -869,7 +869,7 @@ func _present_post_update_failure() -> void:
 	if _dock != null:
 		_dock.present_update_state({
 			"install_in_flight": false,
-			"button_text": "Update failed — previous version restored",
+			"status_text": "Update failed — previous version restored",
 			"button_disabled": false,
 			"label_text": error,
 			"banner_visible": true,
@@ -882,7 +882,7 @@ func _present_post_update_complete() -> void:
 	if _dock != null:
 		_dock.present_update_state({
 			"install_in_flight": false,
-			"button_text": "Update complete",
+			"status_text": "Update complete",
 			"button_disabled": true,
 			"label_text": (
 				"Restart AI clients that were connected during the update so they use v%s."
@@ -1474,7 +1474,7 @@ func install_downloaded_update(package: Dictionary) -> void:
 		return
 	_on_update_install_state_changed({
 		"install_in_flight": true,
-		"button_text": "Activating verified update…",
+		"status_text": "Activating verified update…",
 		"button_disabled": true,
 	})
 	var to_version := str(manifest.get("version", ""))
@@ -1513,13 +1513,13 @@ func install_downloaded_update(package: Dictionary) -> void:
 	UpdateInstaller.request_restart.call_deferred()
 
 
-func _fail_update(button_text: String, error: String) -> void:
+func _fail_update(status_text: String, error: String) -> void:
 	if _update_manager != null:
 		_update_manager.discard_downloads()
 	push_error("MCP | %s" % error)
 	_on_update_install_state_changed({
 		"install_in_flight": false,
-		"button_text": button_text,
+		"status_text": status_text,
 		"button_disabled": false,
 	})
 

--- a/plugin/addons/godot_ai/utils/update_manager.gd
+++ b/plugin/addons/godot_ai/utils/update_manager.gd
@@ -117,6 +117,7 @@ func start_install(preflight: Dictionary) -> void:
 		return
 	if not bool(preflight.get("ok", false)):
 		install_state_changed.emit({
+			"install_in_flight": false,
 			"button_text": "Update blocked — resolve recovery state",
 			"button_disabled": false,
 		})
@@ -128,13 +129,18 @@ func start_install(preflight: Dictionary) -> void:
 		or not _directory_is_empty(directory)
 	):
 		install_state_changed.emit({
+			"install_in_flight": false,
 			"button_text": "Update blocked — private download directory unavailable",
 			"button_disabled": false,
 		})
 		return
 	_download_root = directory
 	_queue.assign([ASSET_NAME, MANIFEST_NAME, SIGNATURE_NAME])
-	install_state_changed.emit({"button_text": "Downloading…", "button_disabled": true})
+	install_state_changed.emit({
+		"install_in_flight": true,
+		"button_text": "Downloading…",
+		"button_disabled": true,
+	})
 	_download_next()
 
 
@@ -518,7 +524,10 @@ func _fail_download(reason: String) -> void:
 	_qualification.clear()
 	discard_downloads()
 	push_error("MCP | v4 update preparation failed: %s" % reason)
+	## The click-time lock and any quiesced client work are the plugin's to
+	## release, and it only does so when it hears the install is over.
 	install_state_changed.emit({
+		"install_in_flight": false,
 		"button_text": "Update preparation failed",
 		"button_disabled": false,
 	})

--- a/plugin/addons/godot_ai/utils/update_manager.gd
+++ b/plugin/addons/godot_ai/utils/update_manager.gd
@@ -108,7 +108,7 @@ func check_for_updates() -> void:
 func start_install(preflight: Dictionary) -> void:
 	if is_install_in_flight():
 		install_state_changed.emit({
-			"button_text": "Update already in progress",
+			"status_text": "Update already in progress",
 			"button_disabled": true,
 		})
 		return
@@ -118,7 +118,7 @@ func start_install(preflight: Dictionary) -> void:
 	if not bool(preflight.get("ok", false)):
 		install_state_changed.emit({
 			"install_in_flight": false,
-			"button_text": "Update blocked — resolve recovery state",
+			"status_text": "Update blocked — resolve recovery state",
 			"button_disabled": false,
 		})
 		return
@@ -130,7 +130,7 @@ func start_install(preflight: Dictionary) -> void:
 	):
 		install_state_changed.emit({
 			"install_in_flight": false,
-			"button_text": "Update blocked — private download directory unavailable",
+			"status_text": "Update blocked — private download directory unavailable",
 			"button_disabled": false,
 		})
 		return
@@ -138,7 +138,7 @@ func start_install(preflight: Dictionary) -> void:
 	_queue.assign([ASSET_NAME, MANIFEST_NAME, SIGNATURE_NAME])
 	install_state_changed.emit({
 		"install_in_flight": true,
-		"button_text": "Downloading…",
+		"status_text": "Downloading…",
 		"button_disabled": true,
 	})
 	_download_next()
@@ -528,6 +528,6 @@ func _fail_download(reason: String) -> void:
 	## release, and it only does so when it hears the install is over.
 	install_state_changed.emit({
 		"install_in_flight": false,
-		"button_text": "Update preparation failed",
+		"status_text": "Update preparation failed",
 		"button_disabled": false,
 	})

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -866,6 +866,74 @@ func test_self_update_in_progress_blocks_request_refresh() -> void:
 	_dock.present_update_state({"install_in_flight": false})
 
 
+func test_update_status_text_never_replaces_the_button_action() -> void:
+	## The Update button is an action, not a status line (2026-09-07 live
+	## update review). Progress and failure text goes to the status label
+	## and the button only enables or disables.
+	_dock._build_ui()
+	_dock.present_update_check({"version": "4.0.3", "label_text": "Update available: v4.0.3"})
+	for status in ["Downloading…", "Update preparation failed", "Activating verified update…"]:
+		_dock.present_update_state({
+			"install_in_flight": true, "status_text": status, "button_disabled": true,
+		})
+		assert_eq(_dock._update_btn.text, "Update", status)
+		assert_eq(_dock._update_status_label.text, status)
+		assert_true(_dock._update_status_label.visible, status)
+		assert_true(_dock._update_btn.disabled, status)
+	_dock.present_update_state({"install_in_flight": false, "status_text": "", "button_disabled": false})
+	assert_false(_dock._update_status_label.visible)
+	assert_false(_dock._update_btn.disabled)
+	assert_eq(_dock._update_btn.text, "Update")
+
+
+func test_new_update_candidate_rearms_the_button_after_a_completed_update() -> void:
+	## The restarted editor after an update shows "Update complete" with the
+	## button disabled. A newer release found later in that same session (the
+	## fleet's 4.0.0 -> 4.0.2 morning) must be installable without another
+	## editor restart.
+	_dock._build_ui()
+	_dock.present_update_state({
+		"install_in_flight": false,
+		"status_text": "Update complete",
+		"button_disabled": true,
+		"label_text": "Restart AI clients that were connected during the update so they use v4.0.2.",
+		"banner_visible": true,
+		"post_update_action": "",
+		"outcome": "success",
+	})
+	assert_true(_dock._update_btn.disabled)
+	assert_eq(_dock._update_label.get_theme_color("font_color"), Color.GREEN)
+	_dock.present_update_check({"version": "4.0.3", "label_text": "Update available: v4.0.3"})
+	assert_false(_dock._update_btn.disabled)
+	assert_eq(_dock._update_btn.text, "Update")
+	assert_eq(_dock._update_candidate_version, "4.0.3")
+	assert_eq(_dock._update_label.text, "Update available: v4.0.3")
+	assert_false(_dock._update_status_label.visible)
+	assert_true(_dock._update_label.get_theme_color("font_color") != Color.GREEN)
+
+
+func test_update_candidate_does_not_rearm_during_install_or_pending_action() -> void:
+	_dock._build_ui()
+	_dock.present_update_state({
+		"install_in_flight": true, "status_text": "Downloading…", "button_disabled": true,
+	})
+	_dock.present_update_check({"version": "4.0.3", "label_text": "Update available: v4.0.3"})
+	assert_true(_dock._update_btn.disabled, "a running install keeps the button disabled")
+	assert_eq(_dock._update_status_label.text, "Downloading…")
+	_dock.present_update_state({"install_in_flight": false, "button_disabled": false})
+	_dock.present_update_state({
+		"install_in_flight": false,
+		"button_text": "Retry client migration",
+		"button_disabled": false,
+		"post_update_action": "retry",
+	})
+	_dock.present_update_check({"version": "4.0.4", "label_text": "Update available: v4.0.4"})
+	assert_eq(_dock._update_btn.text, "Retry client migration",
+		"a pending post-update action owns the button")
+	_dock.present_update_state({"post_update_action": ""})
+	assert_eq(_dock._update_btn.text, "Update")
+
+
 func test_drain_helper_does_not_poison_shutdown_flag() -> void:
 	## `McpUpdateManager._install_zip` calls `_drain_client_status_refresh_workers`
 	## (via `_drain_dock_workers`) to clear any in-flight refresh worker

--- a/test_project/tests/test_update_manager.gd
+++ b/test_project/tests/test_update_manager.gd
@@ -59,6 +59,82 @@ func suite_name() -> String:
 	return "update_manager"
 
 
+class DownloadProbe extends Manager:
+	var downloads_started := 0
+
+	func _download_next() -> void:
+		downloads_started += 1
+
+
+static func _candidate_release() -> Dictionary:
+	return {
+		"urls": {},
+		"sizes": {},
+		"channel": "stable",
+		"tag": "v4.1.0",
+		"version": "4.1.0",
+	}
+
+
+static func _record_states(manager: Manager) -> Array[Dictionary]:
+	var states: Array[Dictionary] = []
+	manager.install_state_changed.connect(func(state: Dictionary) -> void:
+		states.append(state)
+	)
+	return states
+
+
+## The plugin takes the update lock before the download and releases it, and
+## resumes any quiesced client work, only when an install state says the
+## install is over. A failure that stays silent about that leaves lock.json
+## behind for the rest of the editor session (seen live after a 4.0.0
+## "download failed (302)" on 2026-09-07).
+func test_failed_download_reports_the_install_as_over() -> void:
+	var manager := Manager.new()
+	var states := _record_states(manager)
+	manager._download_root = OS.get_user_data_dir().path_join("godot_ai_test_never_created")
+	manager._fail_download("download failed (302)")
+	assert_eq(states.size(), 1)
+	assert_true(states[0].has("install_in_flight"), "a failed download must say the install is over")
+	assert_false(bool(states[0]["install_in_flight"]))
+	assert_false(bool(states[0]["button_disabled"]))
+	assert_eq(manager._download_root, "")
+	manager.free()
+
+
+func test_refused_install_reports_the_install_as_over() -> void:
+	for preflight in [{"ok": false}, {"ok": true, "download_root": "relative/path"}]:
+		var manager := Manager.new()
+		manager._release = _candidate_release()
+		var states := _record_states(manager)
+		manager.start_install(preflight)
+		assert_eq(states.size(), 1, str(preflight))
+		assert_true(states[0].has("install_in_flight"), str(preflight))
+		assert_false(bool(states[0]["install_in_flight"]), str(preflight))
+		manager.free()
+
+
+func test_download_start_and_repeat_click_keep_the_install_in_flight() -> void:
+	var root := OS.get_user_data_dir().path_join("godot_ai_test_download_root")
+	assert_eq(DirAccess.make_dir_recursive_absolute(root), OK)
+	var manager := DownloadProbe.new()
+	manager._release = _candidate_release()
+	var states := _record_states(manager)
+	manager.start_install({"ok": true, "download_root": root})
+	assert_eq(manager.downloads_started, 1)
+	assert_eq(states.size(), 1)
+	assert_true(bool(states[0].get("install_in_flight", false)), "Downloading must hold the lock")
+	assert_true(bool(states[0]["button_disabled"]))
+	## A second click while the first download is queued must not report the
+	## install as over: that would release the lock under the running download.
+	manager.start_install({"ok": true, "download_root": root})
+	assert_eq(manager.downloads_started, 1)
+	assert_eq(states.size(), 2)
+	assert_true(bool(states[1].get("install_in_flight", true)))
+	manager.free()
+	DirAccess.remove_absolute(root)
+
+
 static func _asset(name: String, size: int = 32) -> Dictionary:
 	return {
 		"name": name,


### PR DESCRIPTION
Stacked on #1001 (base branch); retarget to `main` once that merges.

## What

Two problems seen in the live 2026-09-07 update review:

1. **The Update button doubled as a status line.** "Downloading…", "Update preparation failed", "Update complete" all replaced the button label, so it read as a message rather than something to press.
2. **A newer release could not be taken from a freshly updated editor session.** After an update the restarted editor shows "Update complete" with the button disabled, and `present_update_check` only rewrote the headline. When 4.0.2 shipped, every editor that had crossed to 4.0.0 that morning and stayed open showed "Update available: v4.0.2" over a dead "Update complete" button until it was restarted again.

## Fix

- `mcp_dock.gd`: a status label under the banner headline. Progress and failure messages arrive as `status_text` and never touch the button; `button_text` is reserved for real actions ("Retry client migration"), and clearing the post-update action restores the "Update" label. A fresh candidate from `present_update_check` clears the status, restores the banner colour and re-enables the button unless an install is running or a post-update action still owns it.
- `plugin.gd`, `utils/update_manager.gd`: the state emits use `status_text` for messages; `_fail_update`'s first argument is now the status text.
- `test_project/tests/test_dock.gd`: three tests (status never replaces the action label; a new candidate re-arms after "Update complete"; no re-arm during an install or a pending post-update action).

## Verification

- Full GDScript suite in a real GUI Godot 4.7.beta3 editor: 2260 passed (incl. the 3 new), 11 skipped, 2 failed. The 2 failures are the `script.test_patch_script_*` GUI-editor issue also present with main's untouched handler code; a separate task tracks them.
- `GODOT_BIN=… pytest tests/integration/test_self_update_upgrade_paths.py`: 14 passed, 10 skipped (nightly-only fleet crossings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update failure handling so installation state is correctly released after failed downloads or refused installations.
  * Clarified update progress and failure messages without changing the Update button’s action text.
  * Ensured newly discovered updates re-enable the Update button only when no installation or follow-up action is in progress.

* **Tests**
  * Added coverage for update button behavior and installation-state lifecycle scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->