### PR TITLE
docs: 4.0 changelog, generated release notes, and the Discord changelog post

### DIFF
--- a/.github/workflows/discord-changelog.yml
+++ b/.github/workflows/discord-changelog.yml
@@ -7,6 +7,9 @@ name: Discord changelog
 ## to publish, so the post lives here and fires on the `published` release
 ## event GitHub emits when the promotion flips the draft release live.
 ##
+## A missing webhook secret fails the run: an unannounced release must not
+## look like a success.
+##
 ## Dispatch it by hand with a tag to post a release the event did not cover,
 ## such as 4.0.0 to 4.0.2, which were published before this workflow existed.
 ##
@@ -50,8 +53,8 @@ jobs:
           # has no internal whitespace, so stripping all of it is safe.
           DISCORD_WEBHOOK=$(printf '%s' "$DISCORD_WEBHOOK" | tr -d '[:space:]')
           if [ -z "$DISCORD_WEBHOOK" ]; then
-            echo "::warning::DISCORD_CHANGELOG_WEBHOOK is not set; nothing posted for $TAG."
-            exit 0
+            echo "::error::DISCORD_CHANGELOG_WEBHOOK is not set; nothing posted for $TAG." >&2
+            exit 1
           fi
           case "$TAG" in
             v[0-9]*) ;;

--- a/.github/workflows/discord-changelog.yml
+++ b/.github/workflows/discord-changelog.yml
@@ -1,0 +1,85 @@
+name: Discord changelog
+
+## Posts a published release's notes to the Discord #changelog channel through
+## the channel-scoped DISCORD_CHANGELOG_WEBHOOK secret. The v3 line did this as
+## the last step of its release workflow. The v4 promotion (release.yml)
+## publishes from a protected environment and runs nothing that is not needed
+## to publish, so the post lives here and fires on the `published` release
+## event GitHub emits when the promotion flips the draft release live.
+##
+## Dispatch it by hand with a tag to post a release the event did not cover,
+## such as 4.0.0 to 4.0.2, which were published before this workflow existed.
+##
+## The post is silent: flags 4096 is Discord's SUPPRESS_NOTIFICATIONS, so the
+## message lands in the channel and marks it unread without pushing a
+## notification to anyone. allowed_mentions.parse:[] keeps any @mention in the
+## notes from pinging.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Published release tag to post, for example v4.0.2"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: discord-changelog
+  cancel-in-progress: false
+
+jobs:
+  post:
+    runs-on: ubuntu-latest
+    ## A fork has neither the webhook nor the channel.
+    if: github.repository == 'hi-godot/godot-ai'
+    steps:
+      - name: Post release notes to Discord
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_CHANGELOG_WEBHOOK }}
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag || github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          # `gh secret set` keeps a trailing newline when the value was piped
+          # with one, and curl then rejects the URL as malformed. A webhook URL
+          # has no internal whitespace, so stripping all of it is safe.
+          DISCORD_WEBHOOK=$(printf '%s' "$DISCORD_WEBHOOK" | tr -d '[:space:]')
+          if [ -z "$DISCORD_WEBHOOK" ]; then
+            echo "::warning::DISCORD_CHANGELOG_WEBHOOK is not set; nothing posted for $TAG."
+            exit 0
+          fi
+          case "$TAG" in
+            v[0-9]*) ;;
+            *) echo "::error::'$TAG' is not a release tag." >&2; exit 1 ;;
+          esac
+          name=$(gh release view "$TAG" --json name --jq '.name')
+          url=$(gh release view "$TAG" --json url --jq '.url')
+          notes=$(gh release view "$TAG" --json body --jq '.body')
+          # Discord caps an embed description at 4096 characters; leave
+          # headroom and end with a link so the full notes are one click away.
+          desc=$(printf '%s' "$notes" | head -c 3900)
+          payload=$(jq -n \
+            --arg title "$name" \
+            --arg url "$url" \
+            --arg desc "$desc" \
+            '{
+               username: "Godot AI",
+               allowed_mentions: { parse: [] },
+               flags: 4096,
+               embeds: [ {
+                 title: $title,
+                 url: $url,
+                 description: ($desc + "\n\n[View full release →](" + $url + ")"),
+                 color: 5793266
+               } ]
+             }')
+          # The release is already public; a failure here is the changelog
+          # bot's problem, and a red run is how it gets noticed.
+          curl -fsS --retry 3 --retry-delay 2 -H "Content-Type: application/json" \
+            -X POST -d "$payload" "$DISCORD_WEBHOOK"
+          echo "Posted the $TAG release notes to Discord."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,9 +159,9 @@ Or in cmd: `mklink /J test_project\addons\godot_ai ..\..\plugin\addons\godot_ai`
 **When troubleshooting any dev-environment / setup / dependency / symlink issue, scan `script/` first** for an existing fixer before doing it by hand. The project ships scripts for a reason — bypassing them re-introduces the bugs they were written to handle.
 
 - Server start/adopt/teardown, discovery tiers, `editor_reload_plugin`: [docs/server-lifecycle.md](docs/server-lifecycle.md)
-- Cutting a release: [docs/releasing.md](docs/releasing.md). The reviewed A
-  commit carries the release's `CHANGELOG.md` entry; the published notes link
-  to that file at A.
+- Cutting a release: [docs/releasing.md](docs/releasing.md). The release
+  candidate's source commit carries the release's `CHANGELOG.md` entry; the
+  published notes link to that file at that commit.
 - Self-update, migration capsule, or release verification changes:
   [docs/self-update.md](docs/self-update.md). **Any change touching update
   discovery, `update_manager.gd`, `release_verifier.gd`, `update_installer.gd`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,9 @@ Or in cmd: `mklink /J test_project\addons\godot_ai ..\..\plugin\addons\godot_ai`
 **When troubleshooting any dev-environment / setup / dependency / symlink issue, scan `script/` first** for an existing fixer before doing it by hand. The project ships scripts for a reason — bypassing them re-introduces the bugs they were written to handle.
 
 - Server start/adopt/teardown, discovery tiers, `editor_reload_plugin`: [docs/server-lifecycle.md](docs/server-lifecycle.md)
-- Cutting a release: [docs/releasing.md](docs/releasing.md).
+- Cutting a release: [docs/releasing.md](docs/releasing.md). The reviewed A
+  commit carries the release's `CHANGELOG.md` entry; the published notes link
+  to that file at A.
 - Self-update, migration capsule, or release verification changes:
   [docs/self-update.md](docs/self-update.md). **Any change touching update
   discovery, `update_manager.gd`, `release_verifier.gd`, `update_installer.gd`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,14 +224,17 @@ last shared tag).
   because `/home` is a symbolic link
   ([#993](https://github.com/hi-godot/godot-ai/issues/993)); the README
   documents the `GODOT_AI_CAPABILITY_DIR` workaround.
-- The dock's **Reload Plugin** button can crash the editor (fix in review,
-  [#1000](https://github.com/hi-godot/godot-ai/pull/1000)).
+- The dock's **Reload Plugin** button can crash the editor. Fixed on `main` by
+  [#1000](https://github.com/hi-godot/godot-ai/pull/1000); ships in the next
+  release.
 - After an in-session update the dock's Update button reads **Update
-  complete** and cannot take a newer release until the editor restarts (fix in
-  review, [#1002](https://github.com/hi-godot/godot-ai/pull/1002)).
+  complete** and cannot take a newer release until the editor restarts. Fixed
+  on `main` by [#1002](https://github.com/hi-godot/godot-ai/pull/1002); ships
+  in the next release.
 - A failed download leaves the update lock in place; clicking Update again in
-  the same editor still works (fix in review,
-  [#1001](https://github.com/hi-godot/godot-ai/pull/1001)).
+  the same editor still works. Fixed on `main` by
+  [#1001](https://github.com/hi-godot/godot-ai/pull/1001); ships in the next
+  release.
 - The limits accepted for 4.0.0 after independent review are recorded in
   [docs/self-update.md](docs/self-update.md#known-limits-400).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,241 @@
+# Changelog
+
+User-facing changes in Godot AI, newest first. Every GitHub Release links to
+this file at the release's exact source commit, and its "What's Changed"
+section lists every merged pull request; this file keeps the part worth
+reading. Release engineering: [docs/releasing.md](docs/releasing.md).
+
+## 4.0.2 (2026-09-07)
+
+Fixes the in-editor updater's download. Nothing else changed.
+[Compare v4.0.1...v4.0.2](https://github.com/hi-godot/godot-ai/compare/v4.0.1...v4.0.2).
+
+### Fixed
+
+- The dock's **Update** failed with `download failed (302)` on Windows, macOS,
+  and Linux. Two independent causes: with `max_redirects = 0`, Godot's
+  `HTTPRequest` reports `RESULT_REDIRECT_LIMIT_REACHED` for GitHub's first
+  redirect instead of a success carrying a 3xx code, so the manual redirect
+  branch was unreachable; and GitHub's release-asset CDN now uses a
+  `/github-production-release-asset/<repository id>/...` path that the trusted
+  path check rejected. The updater now treats that result as a redirect and
+  pins the current CDN namespace to this repository's ID, keeping the
+  destination validation and redirect limit
+  ([#997](https://github.com/hi-godot/godot-ai/pull/997); reported in
+  [#998](https://github.com/hi-godot/godot-ai/issues/998) and
+  [#989](https://github.com/hi-godot/godot-ai/issues/989)).
+- The private origin used by release qualification issues a real redirect
+  before serving bytes, so every A-to-B update test now exercises this path.
+
+### Upgrading
+
+- **From 3.2.5:** click **Update** with Godot 4.7 or newer. You go directly to
+  4.0.2.
+- **From 4.0.0 or 4.0.1:** those versions cannot download this fix with their
+  own Update button. Follow the one-time recovery in
+  [#999](https://github.com/hi-godot/godot-ai/issues/999) (also documented in
+  [docs/releasing.md](docs/releasing.md#recovering-the-400--401-http-302-download-failure)).
+  Afterwards the Update button works again.
+
+## 4.0.1 (2026-09-07)
+
+[Compare v4.0.0...v4.0.1](https://github.com/hi-godot/godot-ai/compare/v4.0.0...v4.0.1).
+
+### Fixed
+
+- After the first ordinary editor start following the v4 migration, client
+  rows stayed on **Installing…** or **Checking…**, **Configure all** was greyed
+  out, and `client_manage(op="status")` timed out. The client job owner's
+  `_ready` ran after `activate()` and switched its polling off
+  ([#991](https://github.com/hi-godot/godot-ai/pull/991) by @Noniv; closes
+  [#990](https://github.com/hi-godot/godot-ai/issues/990), and the stuck-dock
+  half of [#989](https://github.com/hi-godot/godot-ai/issues/989)).
+
+### Changed
+
+- The README documents the Bazzite / Fedora Atomic capability-directory
+  workaround ([#995](https://github.com/hi-godot/godot-ai/pull/995); closes
+  [#993](https://github.com/hi-godot/godot-ai/issues/993)).
+- Release tooling resumes a hidden draft release and waits for PyPI's index
+  ([#987](https://github.com/hi-godot/godot-ai/pull/987)); Windows client
+  configuration is tested across editor restarts
+  ([#994](https://github.com/hi-godot/godot-ai/pull/994)).
+
+4.0.1 shares the download bug fixed in 4.0.2, so it could not be installed
+from 4.0.0 through the dock.
+
+## 4.0.0 (2026-09-07)
+
+Godot AI 4 is a breaking release built around one signed add-on tree, one
+authenticated transport, and an updater that replaces the whole tree or
+nothing. Migration guide: [docs/v4-migration.md](docs/v4-migration.md).
+[Compare v3.2.4...v4.0.0](https://github.com/hi-godot/godot-ai/compare/v3.2.4...v4.0.0)
+(3.2.5 was cut from the `release/v3` branch, so the comparison starts at the
+last shared tag).
+
+### Requirements and compatibility (breaking)
+
+- **Godot 4.7 or newer.** Godot 4.5 and 4.6 load the migration bridge only far
+  enough to report the requirement; below the floor the bridge restores the
+  previous 3.2.5 add-on instead of leaving a dead plugin. Upgrade Godot, reopen
+  the project, and retry the migration
+  ([#943](https://github.com/hi-godot/godot-ai/pull/943),
+  [#968](https://github.com/hi-godot/godot-ai/pull/968)).
+- **Python 3.11 through 3.14** for the server, provided through `uv`. Every
+  runtime dependency is an exact pin (FastMCP 3.4.7, MCP 1.29.1, websockets
+  17.1, Uvicorn 0.52.4, Starlette 1.6.0, Pydantic 2.13.5, httpx 0.28.1) and
+  the pins are checked again when the server starts. Dependency upgrades are
+  reviewed release changes ([#943](https://github.com/hi-godot/godot-ai/pull/943)).
+- **Clients connect through `godot-ai attach` over stdio.** A bare
+  `http://127.0.0.1:8000/mcp` entry can no longer authenticate. Use the dock's
+  **Configure**, or the **Run this manually** command it shows
+  ([#943](https://github.com/hi-godot/godot-ai/pull/943)).
+- **v3 and v4 do not interoperate.** A v3 plugin against a v4 server, or the
+  reverse, fails closed; there is no tokenless or legacy-handshake fallback
+  ([#943](https://github.com/hi-godot/godot-ai/pull/943)).
+- **Cherry Studio is no longer supported.** Its servers live in an internal
+  database Godot AI cannot safely edit; remove stale v3 entries in Cherry
+  Studio itself. **Zed** is manual-edit only, and the dock now reads Zed's
+  commented `settings.json` for status instead of reporting a parse error
+  ([#954](https://github.com/hi-godot/godot-ai/pull/954); closes
+  [#914](https://github.com/hi-godot/godot-ai/issues/914)).
+- **Distribution is GitHub Releases only.** The Godot Asset Store and Asset
+  Library listings stay on the last v3 release. A stable release publishes six
+  assets: the canonical `godot-ai-v4-plugin.zip` with its signed manifest and
+  signature, and the legacy-named `godot-ai-plugin.zip` triple, which is now
+  the v3-to-v4 migration capsule rather than an installable add-on. Never
+  extract release files over an existing `addons/godot_ai/`
+  ([#943](https://github.com/hi-godot/godot-ai/pull/943),
+  [#949](https://github.com/hi-godot/godot-ai/pull/949)).
+
+### Update and migration
+
+- **One-click migration from 3.2.5.** Click **Update**; Godot restarts once,
+  owned client entries are repinned, and the matching v4 server starts.
+  Nothing to download, verify, or edit by hand
+  ([#943](https://github.com/hi-godot/godot-ai/pull/943),
+  [#968](https://github.com/hi-godot/godot-ai/pull/968)).
+- **New in-editor updater.** The release manifest is RSA-4096 signed and binds
+  repository, channel, tag, version, source commit, archive hash, and every
+  file's size and hash. The updater verifies it, stages the tree under
+  `addons/.godot_ai_update/stage/`, swaps the live add-on with two renames,
+  restarts the editor, and hashes the new tree again before it runs. The
+  previous add-on is kept at `addons/.godot_ai_update/backup/<old version>/`
+  until the next successful update. The outcome is recorded in
+  `addons/.godot_ai_update/pending.json` as `success`, `rolled_back`, or
+  `repair_required`; nothing needs deleting by hand to make progress
+  ([#968](https://github.com/hi-godot/godot-ai/pull/968);
+  [docs/self-update.md](docs/self-update.md)).
+- An update refuses before touching anything when another editor is using the
+  same add-on, and it never overlays files into the live tree.
+- After an update, the plugin replaces a leftover server of the version it
+  just updated from and asks you to restart AI clients that were connected
+  during the update ([#968](https://github.com/hi-godot/godot-ai/pull/968)).
+- Client entries under the `godot-ai` name that launch something other than
+  Godot AI are reported in the editor output, not rewritten; ownership is
+  matched on exact launch tokens
+  ([#971](https://github.com/hi-godot/godot-ai/pull/971),
+  [#973](https://github.com/hi-godot/godot-ai/pull/973),
+  [#975](https://github.com/hi-godot/godot-ai/pull/975)).
+- **Gated publication.** Only bytes that passed the cross-platform
+  qualification run, including a real-editor update on Linux, macOS, and
+  Windows, can be signed and published, behind a required reviewer
+  ([#949](https://github.com/hi-godot/godot-ai/pull/949)).
+- `script/v4-release install` performs the same verify, stage, swap sequence
+  with the editor closed, for qualification and recovery.
+
+### Security and transport
+
+- **Both local hops are authenticated.** The MCP HTTP endpoint requires a
+  bearer capability and the editor WebSocket a separate 32-byte capability;
+  neither accepts a tokenless connection. Capabilities are generated per
+  server instance and published through a private, owner-only record under
+  `~/.config/godot-ai/capabilities` (Linux),
+  `~/Library/Application Support/godot-ai/capabilities` (macOS), or
+  `%LOCALAPPDATA%\godot-ai\capabilities` (Windows). `GODOT_AI_CAPABILITY_DIR`
+  overrides the location on Linux and macOS
+  ([#943](https://github.com/hi-godot/godot-ai/pull/943)).
+- Connection, body, frame, and session budgets are bounded. Duplicate JSON
+  keys, replayed nonces, and v3 protocol frames are rejected.
+- Capability paths that pass through a symbolic link are refused. On Bazzite
+  and other Fedora Atomic desktops, where `/home` links to `/var/home`, follow
+  the README workaround ([#993](https://github.com/hi-godot/godot-ai/issues/993)).
+- The `uvx` launch is isolated (`--isolated --no-config --no-env-file
+  --no-sources --no-build`) and names the public PyPI index explicitly, so an
+  ambient alternate index or uv configuration cannot change what runs.
+- **Telemetry opt-out reaches adopted servers.** Unchecking telemetry now
+  sends a one-way `telemetry_opt_out` event over the authenticated WebSocket,
+  so a server the plugin adopted rather than spawned stops sending too, and
+  `/godot-ai/status` reports what the running server will actually send
+  ([#955](https://github.com/hi-godot/godot-ai/pull/955); closes
+  [#913](https://github.com/hi-godot/godot-ai/issues/913)).
+
+### Tools
+
+- `game_manage` gains `suspend`, `resume`, `next_frame`, and `debug_status`,
+  driven through Godot's native debugger: the Embedded Game View when it is
+  available, the debugger session otherwise
+  ([#953](https://github.com/hi-godot/godot-ai/pull/953) by @quakquak86;
+  closes [#939](https://github.com/hi-godot/godot-ai/issues/939)).
+- `test_run` and `test_manage(op="results_get")` return `cache_warning` when
+  preloaded GDScript may be stale after an edit in the same editor. Restart
+  the editor before validating dependency changes
+  ([#985](https://github.com/hi-godot/godot-ai/pull/985); closes
+  [#938](https://github.com/hi-godot/godot-ai/issues/938)).
+- Numeric strings such as `"4.0"` are coerced to floats across node, camera,
+  material, animation, and audio value handlers, for clients that stringify
+  float arguments ([#969](https://github.com/hi-godot/godot-ai/pull/969) by
+  @robbe1912; closes [#964](https://github.com/hi-godot/godot-ai/issues/964)).
+- The tool surface is 46 tools: 19 named tools plus 27 `<domain>_manage`
+  rollups ([docs/TOOLS.md](docs/TOOLS.md)).
+
+### Clients
+
+- CodeBuddy IDE is configured automatically through `~/.codebuddy/mcp.json`
+  ([#983](https://github.com/hi-godot/godot-ai/pull/983); closes
+  [#941](https://github.com/hi-godot/godot-ai/issues/941)).
+
+### Reliability
+
+- Losing the authenticated editor-server session is no longer terminal. The
+  plugin re-probes with a 1, 2, 4, 8, 16 second backoff, five attempts per
+  outage, before asking for **Restart**
+  ([#982](https://github.com/hi-godot/godot-ai/pull/982); closes
+  [#962](https://github.com/hi-godot/godot-ai/issues/962)).
+- Concurrent `godot-ai attach` clients on Windows no longer fail on the
+  startup lock race ([#986](https://github.com/hi-godot/godot-ai/pull/986)).
+- Also in 4.0.0, and already shipped in 3.2.5: an already-loaded GDScript is
+  refreshed after script writes
+  ([#944](https://github.com/hi-godot/godot-ai/pull/944)); a UTF-8 BOM
+  survives a token-preserving Remove
+  ([#956](https://github.com/hi-godot/godot-ai/pull/956)); the editor
+  WebSocket keepalive deadline is wider
+  ([#961](https://github.com/hi-godot/godot-ai/pull/961)); the Windows
+  `test_project` junction repair never deletes a real plugin copy
+  ([#947](https://github.com/hi-godot/godot-ai/pull/947)); the version-check
+  refcount cycle and descendant ownership on reparent and duplicate undo are
+  fixed.
+
+### Known issues in 4.0.x
+
+- 4.0.0 and 4.0.1 cannot download an update (`download failed (302)`). Fixed
+  in 4.0.2; recovery in [#999](https://github.com/hi-godot/godot-ai/issues/999).
+- Bazzite / Fedora Atomic: the server exits before publishing capabilities
+  because `/home` is a symbolic link
+  ([#993](https://github.com/hi-godot/godot-ai/issues/993)); the README
+  documents the `GODOT_AI_CAPABILITY_DIR` workaround.
+- The dock's **Reload Plugin** button can crash the editor (fix in review,
+  [#1000](https://github.com/hi-godot/godot-ai/pull/1000)).
+- After an in-session update the dock's Update button reads **Update
+  complete** and cannot take a newer release until the editor restarts (fix in
+  review, [#1002](https://github.com/hi-godot/godot-ai/pull/1002)).
+- A failed download leaves the update lock in place; clicking Update again in
+  the same editor still works (fix in review,
+  [#1001](https://github.com/hi-godot/godot-ai/pull/1001)).
+- The limits accepted for 4.0.0 after independent review are recorded in
+  [docs/self-update.md](docs/self-update.md#known-limits-400).
+
+## Earlier releases
+
+3.x release notes are on the
+[GitHub Releases](https://github.com/hi-godot/godot-ai/releases) pages.

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ supported on Windows.
 - [Write and run tests for your game](docs/testing.md)
 - [Client configuration details](docs/client-configuration.md)
 - [Upgrading from v3 and recovering interrupted migrations](docs/v4-migration.md)
+- [Changelog](CHANGELOG.md)
 - [Contributing and development setup](docs/CONTRIBUTING.md)
 - [Discord](https://discord.gg/FDZ5fr2QkP) for questions and showcases;
   [GitHub Issues](https://github.com/hi-godot/godot-ai/issues) for bug reports

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -124,16 +124,17 @@ the embedded public key; it is not release qualification.
 ### Release notes, the changelog, and Discord
 
 `CHANGELOG.md` at the repository root is the human-facing changelog. Add the
-release's entry (version, date, what changed for users, known issues) to the
-reviewed A commit before dispatching qualification: the published release
-body links to that file at A, so an entry added afterwards is invisible from
-the release page until the next release. The body the promotion writes is
-`release_notes()` in `script/release_promotion.py`: the version-pinned
-migration guide, the pinned `CHANGELOG.md`, then GitHub's generated "What's
-Changed" list from the `previous_version` tag to A. If GitHub cannot generate
-the list, the body carries the two links alone and the operator edits the
-notes by hand; notes are mutable and are not a trust anchor, so this is never
-a reason to refuse publication.
+release's entry (version, date, what changed for users, known issues) to
+candidate A, the reviewed `main` commit, before dispatching qualification: the
+published release body links to that file at candidate A's commit, so an entry
+added afterward is invisible from the release page until the next release. The
+body the promotion writes is `release_notes()` in
+`script/release_promotion.py`: the version-pinned migration guide, the pinned
+`CHANGELOG.md`, then GitHub's generated "What's Changed" list from the
+`previous_version` tag to candidate A's commit. If GitHub cannot generate the
+list, the body carries the two links alone and the operator edits the notes by
+hand; notes are mutable and are not a trust anchor, so this is never a reason
+to refuse publication.
 
 Publishing the draft emits GitHub's `release: published` event, which runs
 `discord-changelog.yml`. That workflow posts the release name, URL, and notes

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -121,6 +121,31 @@ published, the published bytes are a fresh reviewed A, not the retained B.
 nothing. A green signing check proves only that the stored private key matches
 the embedded public key; it is not release qualification.
 
+### Release notes, the changelog, and Discord
+
+`CHANGELOG.md` at the repository root is the human-facing changelog. Add the
+release's entry (version, date, what changed for users, known issues) to the
+reviewed A commit before dispatching qualification: the published release
+body links to that file at A, so an entry added afterwards is invisible from
+the release page until the next release. The body the promotion writes is
+`release_notes()` in `script/release_promotion.py`: the version-pinned
+migration guide, the pinned `CHANGELOG.md`, then GitHub's generated "What's
+Changed" list from the `previous_version` tag to A. If GitHub cannot generate
+the list, the body carries the two links alone and the operator edits the
+notes by hand; notes are mutable and are not a trust anchor, so this is never
+a reason to refuse publication.
+
+Publishing the draft emits GitHub's `release: published` event, which runs
+`discord-changelog.yml`. That workflow posts the release name, URL, and notes
+to the Discord `#changelog` channel through the `DISCORD_CHANGELOG_WEBHOOK`
+repository secret, silently (no push notifications), and fails red when the
+post fails so a broken webhook is noticed. The v3 line posted from inside its
+release workflow; the v4 publishing jobs deliberately run nothing but the
+promotion, so the post moved to its own workflow. Dispatch it by hand with a
+`tag` input to re-post a release or to backfill one published before the
+workflow existed. The workflow file is read from the tagged commit, so v3 tags
+never trigger it.
+
 ### Operator setup before candidate signing
 
 Inspect the live repository configuration; an environment name in YAML does

--- a/script/release_promotion.py
+++ b/script/release_promotion.py
@@ -290,7 +290,47 @@ def github_preflight(record: dict[str, Any]) -> dict[str, Any] | None:
     return release
 
 
-def publish_github(candidate: Path, record: dict[str, Any]) -> dict[str, Any]:
+def release_notes(record: dict[str, Any], previous: str) -> str:
+    """The GitHub Release body: pinned guide links, then GitHub's generated notes.
+
+    The migration guide and CHANGELOG.md are linked at the promoted source
+    commit so the notes describe exactly the published tree. The generated
+    "What's Changed" list covers the previous published tag to that commit.
+    Release notes are mutable and are not a trust anchor (the signed manifest
+    is), so a notes-generation failure falls back to the links alone instead
+    of refusing the release.
+    """
+    blob = f"https://github.com/{support.REPOSITORY}/blob/{record['source']}"
+    lines = [
+        f"See the version-pinned migration guide: {blob}/docs/v4-migration.md",
+        f"Changelog: {blob}/CHANGELOG.md",
+    ]
+    try:
+        generated = gh(
+            "--method",
+            "POST",
+            f"repos/{support.REPOSITORY}/releases/generate-notes",
+            "-f",
+            f"tag_name={record['tag']}",
+            "-f",
+            f"target_commitish={record['source']}",
+            "-f",
+            f"previous_tag_name=v{previous}",
+        )
+        body = generated.get("body", "") if isinstance(generated, dict) else ""
+    except support.ReleaseError as exc:
+        print(
+            f"release notes: GitHub did not generate notes ({exc}); "
+            "publishing the pinned links alone",
+            file=sys.stderr,
+        )
+        body = ""
+    if isinstance(body, str) and body.strip():
+        lines += ["", body.strip()]
+    return "\n".join(lines) + "\n"
+
+
+def publish_github(candidate: Path, record: dict[str, Any], previous: str) -> dict[str, Any]:
     verify_pypi(record)
     release = github_preflight(record)
     base = f"repos/{support.REPOSITORY}"
@@ -320,8 +360,7 @@ def publish_github(candidate: Path, record: dict[str, Any]) -> dict[str, Any]:
             "-f",
             f"name=Godot AI {record['version']}",
             "-f",
-            "body=See the version-pinned migration guide: "
-            f"https://github.com/{support.REPOSITORY}/blob/{record['source']}/docs/v4-migration.md",
+            "body=" + release_notes(record, previous),
         )
     existing = {row["name"] for row in release["assets"]}
     missing = sorted(support.RELEASE_NAMES - existing)
@@ -409,7 +448,7 @@ def main(argv: list[str] | None = None) -> int:
         elif args.command == "verify-pypi":
             result["pypi"] = verify_pypi(record)
         elif args.command == "github":
-            result["github"] = publish_github(args.root / "a", record)
+            result["github"] = publish_github(args.root / "a", record, args.previous)
             result["pypi"] = verify_pypi(record)
         args.output.write_bytes(support.canonical(result))
     except (support.ReleaseError, OSError, ValueError, subprocess.CalledProcessError) as exc:

--- a/tests/unit/test_release_promotion.py
+++ b/tests/unit/test_release_promotion.py
@@ -91,3 +91,112 @@ def test_verify_pypi_never_waits_past_its_deadline(monkeypatch):
     with pytest.raises(support.ReleaseError, match="still does not list 4.0.0"):
         promotion.verify_pypi(record)
     assert sleeps == [5.0], "a sleep is clamped to the remaining budget"
+
+
+def test_release_notes_pin_the_guides_at_the_source_and_append_generated_notes(monkeypatch):
+    record = {"tag": "v4.0.3", "source": "abc123"}
+    calls = []
+
+    def fake_gh(*args, allow_missing=False):
+        calls.append(args)
+        return {
+            "body": "## What's Changed\n* fix: x by @y in https://github.com/hi-godot/godot-ai/pull/1\n\n"
+        }
+
+    monkeypatch.setattr(promotion, "gh", fake_gh)
+    body = promotion.release_notes(record, "4.0.2")
+
+    assert calls == [
+        (
+            "--method",
+            "POST",
+            f"{BASE}/releases/generate-notes",
+            "-f",
+            "tag_name=v4.0.3",
+            "-f",
+            "target_commitish=abc123",
+            "-f",
+            "previous_tag_name=v4.0.2",
+        )
+    ]
+    blob = f"https://github.com/{support.REPOSITORY}/blob/abc123"
+    assert body.splitlines() == [
+        f"See the version-pinned migration guide: {blob}/docs/v4-migration.md",
+        f"Changelog: {blob}/CHANGELOG.md",
+        "",
+        "## What's Changed",
+        "* fix: x by @y in https://github.com/hi-godot/godot-ai/pull/1",
+    ]
+    assert body.endswith("\n")
+
+
+def test_release_notes_fall_back_to_the_links_when_generation_fails(monkeypatch, capsys):
+    def failing_gh(*args, allow_missing=False):
+        raise support.ReleaseError("GitHub API request failed: HTTP 422")
+
+    monkeypatch.setattr(promotion, "gh", failing_gh)
+    body = promotion.release_notes({"tag": "v4.0.3", "source": "abc123"}, "4.0.2")
+
+    blob = f"https://github.com/{support.REPOSITORY}/blob/abc123"
+    assert body == (
+        f"See the version-pinned migration guide: {blob}/docs/v4-migration.md\n"
+        f"Changelog: {blob}/CHANGELOG.md\n"
+    )
+    assert "did not generate notes" in capsys.readouterr().err
+
+    monkeypatch.setattr(promotion, "gh", lambda *a, allow_missing=False: {"body": "   \n"})
+    assert promotion.release_notes({"tag": "v4.0.3", "source": "abc123"}, "4.0.2") == body
+
+
+def test_publish_github_creates_the_draft_with_the_composed_notes(monkeypatch, tmp_path):
+    files = {f"release/{name}": {"size": 1, "sha256": "0" * 64} for name in support.RELEASE_NAMES}
+    record = {"version": "4.0.3", "tag": "v4.0.3", "source": "abc123", "files": files}
+    create_values = []
+    state = {"release": None}
+
+    def fake_gh(*args, allow_missing=False):
+        if args[0] == f"{BASE}/git/ref/tags/v4.0.3":
+            return None
+        if args[:3] == ("--method", "POST", f"{BASE}/git/refs"):
+            return {}
+        if args[:3] == ("--method", "POST", f"{BASE}/releases/generate-notes"):
+            return {"body": "## What's Changed\n* one\n"}
+        if args[:3] == ("--method", "POST", f"{BASE}/releases"):
+            create_values.extend(args[4::2])  # the values after each -f / -F flag
+            state["release"] = {"id": 7, "draft": True, "prerelease": False, "assets": []}
+            return state["release"]
+        if args[:3] == ("--method", "PATCH", f"{BASE}/releases/7"):
+            state["release"] = {**state["release"], "draft": False}
+            return state["release"]
+        raise AssertionError(args)
+
+    def fake_preflight(_record):
+        release = state["release"]
+        if release is not None and not release["assets"]:
+            release["assets"] = [
+                {"name": name, "browser_download_url": f"https://github.com/x/{name}"}
+                for name in sorted(support.RELEASE_NAMES)
+            ]
+        return release
+
+    monkeypatch.setattr(promotion, "gh", fake_gh)
+    monkeypatch.setattr(promotion, "verify_pypi", lambda _record: {})
+    monkeypatch.setattr(promotion, "github_preflight", fake_preflight)
+    monkeypatch.setattr(promotion, "verify_public_file", lambda url, expected, hosts: None)
+    uploads = []
+    monkeypatch.setattr(
+        promotion.subprocess, "run", lambda argv, check: uploads.append(argv) or None
+    )
+
+    result = promotion.publish_github(tmp_path, record, "4.0.2")
+
+    blob = f"https://github.com/{support.REPOSITORY}/blob/abc123"
+    assert "draft=true" in create_values and "name=Godot AI 4.0.3" in create_values
+    assert create_values[-1] == (
+        f"body=See the version-pinned migration guide: {blob}/docs/v4-migration.md\n"
+        f"Changelog: {blob}/CHANGELOG.md\n"
+        "\n"
+        "## What's Changed\n* one\n"
+    )
+    assert len(uploads) == 1 and uploads[0][:3] == ["gh", "release", "upload"]
+    assert set(result) == set(support.RELEASE_NAMES)

--- a/tests/unit/test_release_support.py
+++ b/tests/unit/test_release_support.py
@@ -697,7 +697,7 @@ def test_github_publication_resumes_without_clobber_or_rebuilding(
     monkeypatch.setattr(promotion.subprocess, "run", upload)
     downloads = []
     monkeypatch.setattr(promotion, "verify_public_file", lambda *args: downloads.append(args))
-    assert set(promotion.publish_github(candidates / "a", record)) == support.RELEASE_NAMES
+    assert set(promotion.publish_github(candidates / "a", record, "3.2.5")) == support.RELEASE_NAMES
     assert events[0] == ("pypi-verified",)
     assert not state["release"]["draft"]
     assert len(downloads) == 6


### PR DESCRIPTION
## Summary

Answers #1003 and restores the Discord changelog post that the v4 promotion pipeline dropped.

- **`CHANGELOG.md`** (new, repo root): curated entries for 4.0.0, 4.0.1, and 4.0.2 (requirements and compatibility breaks, migration and updater, transport security, tools, clients, fixes, known issues), linked from the README's reference list and from `AGENTS.md`'s release line.
- **Release body.** `release_notes()` in `script/release_promotion.py` composes the GitHub Release body: the version-pinned migration guide, the pinned `CHANGELOG.md`, then GitHub's generated "What's Changed" list from the `previous_version` tag to A. If generation fails the body carries the two links (notes are mutable and not a trust anchor, so this never refuses a release). `publish_github` takes the previous version; the CLI already had it.
- **`discord-changelog.yml`** (new): posts the published release's name, URL, and notes to the `#changelog` webhook (`DISCORD_CHANGELOG_WEBHOOK`, existing repo secret) on `release: published`, silently, and fails red when the post fails. `workflow_dispatch` with a `tag` input re-posts or backfills a release (4.0.0–4.0.2 were published before this file existed). The v3 line posted from inside `release.yml`; the v4 publishing jobs deliberately run nothing but the promotion, so the post lives in its own workflow. The workflow file is read from the tagged commit, so v3 tags never trigger it.
- **`docs/releasing.md`**: "Release notes, the changelog, and Discord" section; the A commit carries the release's changelog entry.

## Verification

- `ruff check` and `ruff format --check` on the touched Python files.
- `pytest tests/unit/test_release_promotion.py tests/unit/test_release_support.py`: 116 passed (three new tests: composed notes, fallback on generation failure, `publish_github` passes the composed body to the create call; the existing resume test now passes the previous version).
- `actionlint` on the new workflow; `git diff --check`.
- The `generate-notes` request shape was exercised read-only against the live API for v4.0.0, v4.0.1, and v4.0.2.
- Not exercised: a real promotion run (needs the next qualification) and a real Discord post (the secret is write-only; the first dispatch after merge proves the webhook).

## Operator follow-ups after merge

1. Update the 4.0.0, 4.0.1, and 4.0.2 release bodies (drafts prepared) so the backfilled Discord posts carry real notes.
2. `gh workflow run discord-changelog.yml -f tag=v4.0.2` to backfill.
3. Reply on #1003 and #998 (drafts prepared).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a user-facing changelog covering releases 4.0.0–4.0.2, including breaking changes, migration guidance, fixes, and known issues.
  - Published releases now include version-specific migration and changelog links alongside generated release notes.
  - Published release notes can be automatically posted to the Discord changelog channel, with manual repost support.

- **Documentation**
  - Added a changelog link to the README.
  - Clarified how release commits, changelog entries, and published release notes are linked.
  - Documented the release-note and changelog generation process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->