### PR TITLE
chore: track the test_client_job_owner.gd uid sidecar

### DIFF
--- a/test_project/tests/test_client_job_owner.gd.uid
+++ b/test_project/tests/test_client_job_owner.gd.uid
@@ -1,0 +1,1 @@
+uid://cgv3m6t028jpe


### PR DESCRIPTION
## Summary

ddf3f9b added `test_project/tests/test_client_job_owner.gd` without the `.uid` sidecar Godot writes next to every script (72 sidecars for 73 `test_*.gd` files). Every editor that opened `test_project/` regenerated it as an untracked file, leaving `?? test_project/tests/test_client_job_owner.gd.uid` in `git status`.

This commits the sidecar a Godot 4.7.beta3 headless `--import` run produced. One line, one file, nothing else.

## Verification

- Sidecar is a single `uid://cgv3m6t028jpe` line with trailing newline, same shape as the tracked sidecars; the uid is unique across the repo.
- A second headless `--import` in the worktree leaves `git status` clean and the file byte-identical.
- A headless `--import` of a clean `git archive HEAD` export (no `.godot` cache) accepts the committed uid, creates no files outside `.godot`, and leaves all 170 tracked `test_project` files unchanged.
- `ruff check .` passes. No code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added project metadata to associate the client job owner test script with a stable unique identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->