### PR TITLE
fix: decide GDScript reload before registering the write with the editor

### DIFF
--- a/plugin/addons/godot_ai/handlers/script_handler.gd
+++ b/plugin/addons/godot_ai/handlers/script_handler.gd
@@ -76,23 +76,16 @@ func create_script(params: Dictionary) -> Dictionary:
 			+ "when its window regains focus."
 		)
 
-	# Register just this file with the editor instead of a full recursive
-	# scan(). A scan() per write stacks `update_scripts_classes` /
-	# `update_script_paths_documentation` WorkerThreadPool tasks under concurrent
-	# script creation ("Task ... already exists" / "!tasks.has(p_task)"), which
-	# races the global-class registry and can SIGABRT in
-	# ScriptServer::remove_global_class_by_path (see dsarno/godot#6).
-	# update_file() is the single-file path the rest of the plugin already uses.
-	var efs := EditorInterface.get_resource_filesystem()
-	if efs != null:
-		efs.update_file(path)
-
 	# An overwrite can target a script that is already loaded (attached to a
-	# node, preloaded, open in the script editor). update_file() registers the
-	# bytes but leaves that live GDScript on the old source (#937), so the very
-	# next call would run stale code after a "successful" write. Refresh it.
+	# node, preloaded, open in the script editor). Registering the bytes with
+	# the editor leaves that live GDScript on the old source (#937), so the very
+	# next call would run stale code after a "successful" write. Refresh it
+	# BEFORE registering the file: a GUI editor loads the script inside
+	# update_file() (see _refresh_loaded_gdscript for the ordering contract).
 	if existed_before:
 		_refresh_loaded_gdscript(data, path, content)
+
+	_register_written_file(path)
 
 	# `.gd.uid` is the sidecar Godot generates on scan; list both so the caller
 	# can rm the full set in one go.
@@ -206,15 +199,44 @@ func _attach_gdscript_diagnostics(data: Dictionary, path: String, content: Strin
 	data["diagnostics_status"] = diagnostics_status
 
 
+## Register just this file with the editor instead of a full recursive
+## scan(). A scan() per write stacks `update_scripts_classes` /
+## `update_script_paths_documentation` WorkerThreadPool tasks under concurrent
+## script creation ("Task ... already exists" / "!tasks.has(p_task)"), which
+## races the global-class registry and can SIGABRT in
+## ScriptServer::remove_global_class_by_path (see dsarno/godot#6).
+## update_file() is the single-file path the rest of the plugin already uses.
+##
+## Call it only after `_refresh_loaded_gdscript` has taken its decision (see
+## the ordering contract there). Instance (not static) so a test can stand in
+## for what a GUI editor does inside update_file() — load or reload the
+## script — and lock that ordering from a headless run.
+func _register_written_file(path: String) -> void:
+	var efs := EditorInterface.get_resource_filesystem()
+	if efs != null:
+		efs.update_file(path)
+
+
 ## Bring an already-loaded GDScript back in step with the bytes just written.
 ##
-## ResourceLoader caches GDScript by path, and EditorFileSystem.update_file()
-## does not touch that cache — so after a successful write, a script that a
-## node, a preload(), or the script editor already holds keeps executing the
-## previous source (#937). When the path is cached and the new source parsed,
-## push the source into the live object and reload it in place (keep_state so
-## existing instances survive). Reports `reloaded` plus a `reload_reason` when
-## it did not, so a caller can tell "the file changed" from "the code changed".
+## ResourceLoader caches GDScript by path, and registering the write with
+## EditorFileSystem does not refresh that cache in a headless editor — so after
+## a successful write, a script that a node, a preload(), or the script editor
+## already holds keeps executing the previous source (#937). When the path is
+## cached and the new source parsed, push the source into the live object and
+## reload it in place (keep_state so existing instances survive). Reports
+## `reloaded` plus a `reload_reason` when it did not, so a caller can tell
+## "the file changed" from "the code changed".
+##
+## Ordering contract: this runs BEFORE `_register_written_file`. A GUI editor
+## (not a headless one — EditorNode's cmdline mode skips the step) runs its
+## script-documentation pass synchronously inside update_file(), which
+## ResourceLoader.load()s the script, caching a never-loaded one, and
+## reload_from_file()s a cached one that is not open in the script editor.
+## Deciding after that call reports a false `already_current` for a script
+## nobody held (instead of `not_loaded`) and for one this helper should have
+## refreshed itself. The question is what was loaded before the write, so it
+## is answered first; the editor's own pass then meets the same bytes.
 ##
 ## Skipped when validation failed: the diagnostics capture above has already
 ## reloaded the shared GDScriptCache entry with the broken source, so there is
@@ -365,13 +387,12 @@ func patch_script(params: Dictionary) -> Dictionary:
 	}
 	_attach_gdscript_diagnostics(data, path, new_content)
 
-	# Single-file register, not a full scan() — see create_script (dsarno/godot#6).
-	var efs := EditorInterface.get_resource_filesystem()
-	if efs != null:
-		efs.update_file(path)
 	# The file is fresh but any already-loaded GDScript for it is not (#937);
 	# make "patch succeeded" mean the loaded code changed, not just the bytes.
+	# Decide and refresh before registering the file with the editor — a GUI
+	# editor loads the script inside update_file() (see _refresh_loaded_gdscript).
 	_refresh_loaded_gdscript(data, path, new_content)
+	_register_written_file(path)
 
 	return {"data": data}
 

--- a/test_project/tests/test_script.gd
+++ b/test_project/tests/test_script.gd
@@ -830,7 +830,12 @@ class _GuiEditorScriptHandler extends ScriptHandler:
 	func _register_written_file(path: String) -> void:
 		super(path)
 		if ResourceLoader.has_cached(path):
-			# EditorFileSystem::_should_reload_script -> Script::reload_from_file
+			# EditorFileSystem::_should_reload_script -> Script::reload_from_file.
+			# CACHE_MODE_IGNORE is the mode that refreshes the cached object:
+			# ResourceFormatLoaderGDScript maps it to GDScriptCache::get_full_script
+			# (update_from_disk=true), i.e. load_source_code() + reload(true) on the
+			# entry every holder shares — the same thing the handler's diagnostics
+			# capture relies on. CACHE_MODE_REPLACE returns the cached script untouched.
 			ResourceLoader.load(path, "", ResourceLoader.CACHE_MODE_IGNORE)
 		else:
 			ResourceLoader.load(path)

--- a/test_project/tests/test_script.gd
+++ b/test_project/tests/test_script.gd
@@ -813,6 +813,29 @@ func _load_reload_helper(path: String) -> GDScript:
 	return loaded
 
 
+## Every invocation writes a fresh path, so also drop the `.uid` sidecar the
+## editor generates on register — otherwise each run leaves one behind.
+func _remove_reload_helper(path: String) -> void:
+	DirAccess.remove_absolute(path)
+	if FileAccess.file_exists(path + ".uid"):
+		DirAccess.remove_absolute(path + ".uid")
+
+
+## Stand-in for a GUI editor. There, EditorFileSystem.update_file() runs the
+## script-documentation pass synchronously (a headless editor skips it): it
+## ResourceLoader.load()s a never-loaded script into the cache and reloads a
+## cached one from disk. Replaying that inside the handler's register seam
+## lets a headless run lock the decide-before-register ordering.
+class _GuiEditorScriptHandler extends ScriptHandler:
+	func _register_written_file(path: String) -> void:
+		super(path)
+		if ResourceLoader.has_cached(path):
+			# EditorFileSystem::_should_reload_script -> Script::reload_from_file
+			ResourceLoader.load(path, "", ResourceLoader.CACHE_MODE_IGNORE)
+		else:
+			ResourceLoader.load(path)
+
+
 func test_patch_script_refreshes_loaded_gdscript() -> void:
 	## Regression for #937: a loaded GDScript kept the old body after a patch.
 	var path := _unique_reload_path("patch")
@@ -829,7 +852,7 @@ func test_patch_script_refreshes_loaded_gdscript() -> void:
 	# The SAME object an agent (or a node) already holds now runs the new code.
 	assert_eq(loaded.new().value(), "new")
 	assert_eq(ResourceLoader.load(path).new().value(), "new")
-	DirAccess.remove_absolute(path)
+	_remove_reload_helper(path)
 
 
 func test_create_script_overwrite_refreshes_loaded_gdscript() -> void:
@@ -844,7 +867,7 @@ func test_create_script_overwrite_refreshes_loaded_gdscript() -> void:
 	assert_eq(result.data.import_settle, "already_known")
 	assert_eq(result.data.reloaded, true)
 	assert_eq(loaded.new().value(), "newer")
-	DirAccess.remove_absolute(path)
+	_remove_reload_helper(path)
 
 
 func test_patch_script_reports_not_loaded_when_nothing_cached() -> void:
@@ -858,7 +881,7 @@ func test_patch_script_reports_not_loaded_when_nothing_cached() -> void:
 	assert_has_key(result, "data")
 	assert_eq(result.data.reloaded, false)
 	assert_eq(result.data.reload_reason, "not_loaded")
-	DirAccess.remove_absolute(path)
+	_remove_reload_helper(path)
 
 
 func test_patch_script_skips_reload_on_parse_error() -> void:
@@ -881,4 +904,39 @@ func test_patch_script_skips_reload_on_parse_error() -> void:
 	assert_eq(result.data.reload_reason, "parse_error")
 	assert_eq(result.data.diagnostics_status, "checked")
 	assert_true(result.data.diagnostics.size() >= 1, "the parse error is reported as a diagnostic")
-	DirAccess.remove_absolute(path)
+	_remove_reload_helper(path)
+
+
+func test_patch_script_reports_not_loaded_when_the_editor_caches_on_register() -> void:
+	## GUI-editor regression: the editor's own load inside update_file() must
+	## not turn "nobody held this script" into a false already_current.
+	var path := _unique_reload_path("gui_cold")
+	_write_reload_helper("old", path)
+	assert_false(ResourceLoader.has_cached(path), "fixture must start uncached")
+	var gui := _GuiEditorScriptHandler.new(_undo_redo)
+	var result := gui.patch_script({"path": path, "old_text": "\"old\"", "new_text": "\"new\""})
+	assert_has_key(result, "data")
+	assert_eq(result.data.reloaded, false)
+	assert_eq(result.data.reload_reason, "not_loaded")
+	assert_true(ResourceLoader.has_cached(path), "the stand-in editor cached the script on register")
+	assert_eq(
+		EditorInterface.get_resource_filesystem().get_file_type(path), "GDScript",
+		"the write is still registered with the editor")
+	_remove_reload_helper(path)
+
+
+func test_patch_script_refreshes_before_the_editor_reloads_on_register() -> void:
+	## GUI-editor regression: the handler refreshes the held object itself, so
+	## `reloaded` carries no skip reason even though the editor's register pass
+	## reloads the same bytes right after it.
+	var path := _unique_reload_path("gui_patch")
+	_write_reload_helper("old", path)
+	var loaded: GDScript = _load_reload_helper(path)
+	assert_eq(loaded.new().value(), "old")
+	var gui := _GuiEditorScriptHandler.new(_undo_redo)
+	var result := gui.patch_script({"path": path, "old_text": "\"old\"", "new_text": "\"new\""})
+	assert_has_key(result, "data")
+	assert_eq(result.data.reloaded, true)
+	assert_false(result.data.has("reload_reason"), "a reloaded script carries no skip reason")
+	assert_eq(loaded.new().value(), "new")
+	_remove_reload_helper(path)


### PR DESCRIPTION
## Summary

Fixes the two `script.test_patch_script_*` failures that appear when the full GDScript suite runs against a **GUI** Godot 4.7 editor. They pass headless, so CI never saw them.

- **Root cause:** `EditorFileSystem.update_file()` calls `_process_update_pending()` synchronously, and outside cmdline mode (what `--headless` sets) that runs `_update_script_documentation()`, which `ResourceLoader.load()`s every updated `.gd` and `reload_from_file()`s an already-cached one that is not open in the script editor. `script_patch` / `script_create(overwrite)` registered the file first and only then asked whether the script was loaded, so in a GUI editor a script nobody held was already cached with the new bytes and the response said `reloaded: true, reload_reason: already_current` instead of `not_loaded` (confirmed live through MCP before changing anything).
- **Fix** (`script_handler.gd`): `_refresh_loaded_gdscript` now runs *before* the file is registered with the editor in both write paths. The register call moves into a small instance seam, `_register_written_file`, following the handler's existing subclass-override pattern; the docstrings carry the ordering contract and why GUI and headless differ. The documented `reloaded` / `reload_reason` contract from #944 is unchanged.
- **Tests** (`test_script.gd`): the four #944 tests are untouched apart from cleanup. Two new tests use a stand-in handler that replays the GUI documentation pass inside the seam, so the ordering is locked from headless CI too. The reload fixtures now also remove the `.uid` sidecar they generate, so reruns stop leaving one per test.

## Verification (macOS, Godot 4.7.beta3, isolated editor stack on alt ports)

| Run | Result |
|---|---|
| GUI, baseline (main @ 070c0f3) | 2 failed — exactly the two tests above |
| GUI, this branch | 2258 passed, 0 failed, 11 skipped |
| Headless, this branch | 2245 passed, 0 failed, 24 skipped |
| Headless, old ordering restored, `script` suite | 52/54 — only the two new tests fail, with the same messages the GUI editor produced |
| `ruff check` / `pytest` | clean / 2499 passed, 60 skipped |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Script changes now refresh loaded files before editor registration.
  * Prevented stale scripts and inaccurate reload-status reporting when creating, overwriting, or patching scripts.
  * Improved reload handling for scripts not previously loaded by the editor.
  * Preserved parse-error reporting and reload status during script updates.

* **Tests**
  * Added coverage for reload behavior, cache handling, status reporting, and cleanup of script fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->