### PR TITLE
fix: follow root-owned links in capability paths so Fedora Atomic's /home works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,16 @@ reading. Release engineering: [docs/releasing.md](docs/releasing.md).
 ### Fixed
 
 - **Bazzite / Fedora Atomic:** the server exited before publishing its
-  capability record because `/home` is a symbolic link to `/var/home` and 4.0.x
-  refused every link in a capability path. The server and the plugin now follow
-  a link when it is root-owned and sits in a root-owned directory that other
-  accounts cannot write, which is exactly the ostree layout; every other link
-  still fails closed. The `GODOT_AI_CAPABILITY_DIR` workaround is no longer
-  needed there ([#993](https://github.com/hi-godot/godot-ai/issues/993),
-  reported again in [#989](https://github.com/hi-godot/godot-ai/issues/989)).
+  capability record because `/home` is a symbolic link to `/var/home` on
+  ostree systems and 4.0.x refused every link in a capability path. The server
+  now follows a link when it is root-owned and sits in a root-owned directory
+  that other accounts cannot write, which is exactly the ostree layout. The
+  plugin, which cannot see file ownership, follows a link only below a
+  directory closed to group and other writes. Every other link still fails
+  closed on both sides, and the record file itself is never followed. The
+  `GODOT_AI_CAPABILITY_DIR` workaround is no longer needed there
+  ([#993](https://github.com/hi-godot/godot-ai/issues/993), reported again in
+  [#989](https://github.com/hi-godot/godot-ai/issues/989)).
 - The dock's **Reload Plugin** button no longer crashes the editor
   ([#1000](https://github.com/hi-godot/godot-ai/pull/1000)).
 - After an in-session update the dock's Update button is an action again and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ this file at the release's exact source commit, and its "What's Changed"
 section lists every merged pull request; this file keeps the part worth
 reading. Release engineering: [docs/releasing.md](docs/releasing.md).
 
+## Unreleased
+
+### Fixed
+
+- **Bazzite / Fedora Atomic:** the server exited before publishing its
+  capability record because `/home` is a symbolic link to `/var/home` and 4.0.x
+  refused every link in a capability path. The server and the plugin now follow
+  a link when it is root-owned and sits in a root-owned directory that other
+  accounts cannot write, which is exactly the ostree layout; every other link
+  still fails closed. The `GODOT_AI_CAPABILITY_DIR` workaround is no longer
+  needed there ([#993](https://github.com/hi-godot/godot-ai/issues/993),
+  reported again in [#989](https://github.com/hi-godot/godot-ai/issues/989)).
+- The dock's **Reload Plugin** button no longer crashes the editor
+  ([#1000](https://github.com/hi-godot/godot-ai/pull/1000)).
+- After an in-session update the dock's Update button is an action again and
+  re-arms for a newer release without an editor restart
+  ([#1002](https://github.com/hi-godot/godot-ai/pull/1002)).
+- A failed download releases the update lock
+  ([#1001](https://github.com/hi-godot/godot-ai/pull/1001)).
+
 ## 4.0.2 (2026-09-07)
 
 Fixes the in-editor updater's download. Nothing else changed.

--- a/README.md
+++ b/README.md
@@ -137,13 +137,14 @@ Opt-out creates no telemetry UUID, worker, or files.
 
 ### Bazzite / Fedora Atomic Desktop: server exits before publishing capabilities
 
-On Bazzite and other Fedora Atomic desktops, `/home` is a symbolic link to
-`/var/home`. Godot AI 4.0.2 and earlier refuse every capability-directory path
-that passes through a link, so the server exits with
-`Last pending: capability_record` ([#993](https://github.com/hi-godot/godot-ai/issues/993)).
-The next release follows a link when it is root-owned and sits in a root-owned
-directory that other accounts cannot write, which is exactly the ostree layout;
-no configuration is needed there.
+On Bazzite and other Fedora Atomic desktops, `/home` is normally a symbolic
+link to `/var/home` (the ostree layout). Godot AI 4.0.2 and earlier refuse
+every capability-directory path that passes through a link, so on such a
+system the server exits with `Last pending: capability_record`
+([#993](https://github.com/hi-godot/godot-ai/issues/993)). The next release
+follows a link when it is root-owned and sits in a root-owned directory that
+other accounts cannot write, which is exactly that layout; no configuration is
+needed there.
 
 On 4.0.2 or earlier, close Godot and your MCP client, then run this in a
 terminal as your normal user:

--- a/README.md
+++ b/README.md
@@ -137,13 +137,16 @@ Opt-out creates no telemetry UUID, worker, or files.
 
 ### Bazzite / Fedora Atomic Desktop: server exits before publishing capabilities
 
-On Bazzite, `/home` can point to `/var/home` through a symbolic link. Godot AI
-v4 rejects capability-directory paths that pass through symbolic links. This
-can prevent startup with `Last pending: capability_record`. A Bazzite user
-confirmed that selecting the canonical path fixes this ([#993](https://github.com/hi-godot/godot-ai/issues/993)).
-Other Atomic Desktop installations with the same home layout may be affected.
+On Bazzite and other Fedora Atomic desktops, `/home` is a symbolic link to
+`/var/home`. Godot AI 4.0.2 and earlier refuse every capability-directory path
+that passes through a link, so the server exits with
+`Last pending: capability_record` ([#993](https://github.com/hi-godot/godot-ai/issues/993)).
+The next release follows a link when it is root-owned and sits in a root-owned
+directory that other accounts cannot write, which is exactly the ostree layout;
+no configuration is needed there.
 
-Close Godot and your MCP client, then run this in a terminal as your normal user:
+On 4.0.2 or earlier, close Godot and your MCP client, then run this in a
+terminal as your normal user:
 
 ```bash
 export GODOT_AI_CAPABILITY_DIR="$(
@@ -156,8 +159,7 @@ printf 'Using: %s\n' "$GODOT_AI_CAPABILITY_DIR"
 Launch **both Godot and your MCP client from that terminal** so the backend and
 `godot-ai attach` inherit the same directory. A desktop launcher does not
 automatically inherit a terminal's `export`; for persistent use, set the same
-canonical path in the launch environment of both applications. Retry the
-connection and check that the server starts and the client connects. Keep the
+canonical path in the launch environment of both applications. Keep the
 directory private to your user; do not copy capability tokens into client
 configuration. This workaround is for Linux; `GODOT_AI_CAPABILITY_DIR` is not
 supported on Windows.

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -502,10 +502,19 @@ with a guessed request ID.
 
 HTTP is separately bearer-authenticated and bounded. Status/lease routes do not
 form an unauthenticated side channel. Private capability records are owner-only
-on POSIX; caller-selected roots reject link traversal and unsafe ancestors. On
-Windows, v4 uses fixed per-user roots and rejects detectable reparse traversal,
-but does not claim secrecy or integrity against another local account or
-malicious code already running as the same user.
+on POSIX, and every ancestor of the record must be owned by root or the user
+and closed to group/other writes (the canonical sticky temp roots excepted). A
+link component is followed only when the link is root-owned and sits in a
+root-owned directory closed to group/other writes, which no other account can
+arrange; ostree's `/home -> /var/home` is the case that needs it (#993). The
+target's components are walked under the same rules, the record file itself
+is never followed, and a chain longer than eight links fails closed. The
+plugin, which cannot see file ownership, follows a link only below a directory
+closed to group/other writes; the server, which publishes the record, is the
+side that requires root ownership. On Windows, v4 uses fixed per-user roots
+and rejects detectable reparse traversal, but does not claim secrecy or
+integrity against another local account or malicious code already running as
+the same user.
 
 ---
 

--- a/plugin/addons/godot_ai/utils/transport_capability.gd
+++ b/plugin/addons/godot_ai/utils/transport_capability.gd
@@ -11,6 +11,7 @@ const MAX_RECORD_BYTES := 1024
 const _POSIX_PERMISSION_MASK := 0x1ff  ## 0777
 const _GROUP_OTHER_PERMISSION_MASK := 0x3f  ## 0077
 const _GROUP_OTHER_WRITE_MASK := 0x12  ## 0022
+const _MAX_LINK_HOPS := 8
 const _SYSTEM_TEMP_ROOTS: Array[String] = ["/tmp", "/private/tmp", "/var/tmp"]
 const _KEYS: Array[String] = [
 	"version", "http", "websocket", "instance_nonce",
@@ -25,16 +26,19 @@ static func read_for_http_port(http_port: int, captured_path := "") -> Dictionar
 
 
 static func _read_path(path: String) -> Dictionary:
-	if path.is_empty() or not path.is_absolute_path() or _path_has_link(path):
+	if path.is_empty() or not path.is_absolute_path():
 		return {}
-	var directory := path.get_base_dir()
+	var resolved := _resolve_trusted_path(path)
+	if resolved.is_empty():
+		return {}
+	var directory := resolved.get_base_dir()
 	if (
 		not _safe_posix_ancestors(directory)
 		or not _private_path(directory, true)
-		or not _private_path(path, false)
+		or not _private_path(resolved, false)
 	):
 		return {}
-	var file := FileAccess.open(path, FileAccess.READ)
+	var file := FileAccess.open(resolved, FileAccess.READ)
 	if file == null:
 		return {}
 	var length := file.get_length()
@@ -101,6 +105,56 @@ static func _private_path(path: String, directory: bool) -> bool:
 	## that group/other access is closed; it is not an owner-identity proof.
 	var mode := FileAccess.get_unix_permissions(path) & _POSIX_PERMISSION_MASK
 	return mode != 0 and (mode & _GROUP_OTHER_PERMISSION_MASK) == 0
+
+
+## Walk `path` from its root and return it with every accepted link component
+## replaced by its target, or "" when the path must not be trusted. A link is
+## followed only when the directory holding it is closed to group and other
+## writes, so only that directory's owner or root could have placed it; ostree
+## distributions need this for `/home -> /var/home` (#993). Godot exposes no
+## owning UID, so this is the strongest proof available here; Python, which
+## publishes the record, additionally requires such a link to be root-owned.
+## The record file itself is never followed, and a chain longer than
+## `_MAX_LINK_HOPS` fails closed. Windows keeps rejecting every detectable
+## link or reparse point.
+static func _resolve_trusted_path(path: String) -> String:
+	if OS.get_name() == "Windows":
+		return "" if _path_has_link(path) else path
+	var remaining := path.simplify_path().split("/", false)
+	var current := "/"
+	var hops := 0
+	while not remaining.is_empty():
+		var part := remaining[0]
+		remaining.remove_at(0)
+		var candidate := current.path_join(part)
+		var parent := DirAccess.open(current)
+		if parent == null:
+			return ""
+		if parent.is_link(candidate):
+			if (
+				remaining.is_empty()
+				or hops >= _MAX_LINK_HOPS
+				or not _closed_to_group_and_other(current)
+			):
+				return ""
+			hops += 1
+			var target := parent.read_link(candidate)
+			if target.is_empty():
+				return ""
+			if not target.is_absolute_path():
+				target = current.path_join(target)
+			var target_parts := target.simplify_path().split("/", false)
+			target_parts.append_array(remaining)
+			remaining = target_parts
+			current = "/"
+			continue
+		current = candidate
+	return current
+
+
+static func _closed_to_group_and_other(directory: String) -> bool:
+	var mode := FileAccess.get_unix_permissions(directory) & _POSIX_PERMISSION_MASK
+	return mode != 0 and (mode & _GROUP_OTHER_WRITE_MASK) == 0
 
 
 static func _path_has_link(path: String) -> bool:

--- a/src/godot_ai/transport/capability.py
+++ b/src/godot_ai/transport/capability.py
@@ -26,6 +26,8 @@ _WS_TOKEN = re.compile(r"[0-9a-f]{64}\Z")
 _NONCE = re.compile(r"[A-Fa-f0-9]{32}\Z")
 _KEYS = frozenset({"version", "http", "websocket", "instance_nonce"})
 _REPARSE_POINT = 0x400
+# Bound on link components followed while resolving one capability path.
+_MAX_LINK_HOPS = 8
 
 
 @dataclass(frozen=True)
@@ -137,9 +139,7 @@ def capability_directory() -> Path:
             raise ValueError(f"{CAPABILITY_DIR_ENV} must be an absolute path")
         directory = base
     elif sys.platform == "darwin":
-        directory = (
-            Path.home() / "Library" / "Application Support" / "godot-ai" / "capabilities"
-        )
+        directory = Path.home() / "Library" / "Application Support" / "godot-ai" / "capabilities"
     else:
         config = os.environ.get("XDG_CONFIG_HOME", "").strip()
         if config:
@@ -152,7 +152,7 @@ def capability_directory() -> Path:
     if os.name != "nt":
         if not directory.is_absolute():
             raise ValueError("capability directory must be an absolute path")
-        _reject_unsafe_posix_ancestors(directory)
+        directory = _reject_unsafe_posix_ancestors(directory)
     return directory
 
 
@@ -164,7 +164,7 @@ def record_path(http_port: int, directory: Path | None = None) -> Path:
     if os.name != "nt":
         if not selected.is_absolute():
             raise ValueError("capability directory must be an absolute path")
-        _reject_unsafe_posix_ancestors(selected)
+        selected = _reject_unsafe_posix_ancestors(selected)
     return selected / f"http-{port}.json"
 
 
@@ -196,31 +196,69 @@ def _is_safe_posix_ancestor(path: Path, info: os.stat_result) -> bool:
         and stat.S_ISDIR(info.st_mode)
         and bool(mode & stat.S_ISVTX)
     )
-    return info.st_uid in {0, os.getuid()} and (
-        mode & 0o022 == 0 or root_sticky_directory
+    return info.st_uid in {0, os.getuid()} and (mode & 0o022 == 0 or root_sticky_directory)
+
+
+def _is_root_private_directory(path: Path) -> bool:
+    """A root-owned directory closed to group and other writes; no sticky exception."""
+
+    try:
+        info = path.lstat()
+    except OSError:
+        return False
+    return (
+        stat.S_ISDIR(info.st_mode) and info.st_uid == 0 and stat.S_IMODE(info.st_mode) & 0o022 == 0
     )
 
 
-def _reject_unsafe_posix_ancestors(path: Path) -> None:
-    """Reject any POSIX capability namespace mutable by another account."""
+def _reject_unsafe_posix_ancestors(path: Path) -> Path:
+    """Reject any POSIX capability namespace mutable by another account.
+
+    Returns ``path`` with every accepted link component replaced by its
+    target, so callers operate on a link-free path. A link is followed only
+    when it is owned by root, sits in a root-owned directory that group and
+    other cannot write, and every ancestor before it already passed: another
+    account cannot place such a link, and ostree-based distributions rely on
+    one (``/home -> /var/home`` on Fedora Atomic and Bazzite, #993). Every
+    other link fails closed, as does a chain longer than ``_MAX_LINK_HOPS``.
+    The target's own components are walked under the same rules, so lexical
+    ``..`` resolution against the already-resolved parent matches the kernel.
+    """
 
     if os.name == "nt":  # pragma: no cover - overrides are already disabled
-        return
+        return path
+    remaining = list(path.parts[1:])
     current = Path(path.anchor)
-    for part in path.parts[1:]:
-        current /= part
+    hops = 0
+    while remaining:
+        current = current / remaining.pop(0)
         try:
             info = current.lstat()
         except FileNotFoundError:
-            break
+            # Nothing below a missing component exists yet; it is created 0700.
+            return current.joinpath(*remaining)
         if _is_link_or_reparse(info):
-            raise OSError(
-                errno.ELOOP,
-                "capability path traverses a link or reparse point",
-                current,
-            )
+            if (
+                info.st_uid != 0
+                or hops >= _MAX_LINK_HOPS
+                or not _is_root_private_directory(current.parent)
+            ):
+                raise OSError(
+                    errno.ELOOP,
+                    "capability path traverses a link or reparse point",
+                    current,
+                )
+            hops += 1
+            target = Path(os.readlink(current))
+            if not target.is_absolute():
+                target = current.parent / target
+            target = Path(os.path.normpath(target))
+            remaining = list(target.parts[1:]) + remaining
+            current = Path(target.anchor)
+            continue
         if not _is_safe_posix_ancestor(current, info):
             raise OSError(errno.EACCES, "capability path has an unsafe ancestor", current)
+    return current
 
 
 def _prepare_directory(directory: Path) -> None:

--- a/test_project/tests/test_transport_capability.gd
+++ b/test_project/tests/test_transport_capability.gd
@@ -102,40 +102,119 @@ func test_rejects_permissive_posix_mode() -> void:
 	assert_true(McpTransportCapability._read_path(_record_path).is_empty())
 
 
-func test_rejects_symlinked_ancestor_on_posix() -> void:
+func test_follows_a_link_below_a_closed_parent_on_posix() -> void:
 	if OS.get_name() == "Windows":
 		skip("creating POSIX symlinks is not portable on Windows")
 		return
 	var real_dir := _scratch_dir + "_real"
-	var linked_dir := _scratch_dir + "_link"
-	DirAccess.make_dir_recursive_absolute(real_dir)
-	FileAccess.set_unix_permissions(
-		real_dir,
-		FileAccess.UNIX_READ_OWNER
-		| FileAccess.UNIX_WRITE_OWNER
-		| FileAccess.UNIX_EXECUTE_OWNER,
-	)
-	var real_record := real_dir.path_join("http-8122.json")
-	var file := FileAccess.open(real_record, FileAccess.WRITE)
-	file.store_string(_canonical_record())
-	file.close()
-	FileAccess.set_unix_permissions(
-		real_record, FileAccess.UNIX_READ_OWNER | FileAccess.UNIX_WRITE_OWNER
-	)
+	var real_record := _private_record_in(real_dir)
+	## The link lives inside the suite's 0700 scratch directory: only its owner
+	## or root could have placed it, so the walk follows it (#993).
+	var linked_dir := _scratch_dir.path_join("closed-link")
 	DirAccess.remove_absolute(linked_dir)
-	var rc := OS.execute("ln", ["-s", real_dir, linked_dir])
-	if rc != 0:
+	if OS.execute("ln", ["-s", real_dir, linked_dir]) != 0:
+		skip("could not create a POSIX symlink")
+	else:
+		var result := McpTransportCapability._read_path(linked_dir.path_join("http-8122.json"))
+		assert_eq(
+			result.get("http", ""),
+			HTTP,
+			"a link placed in a directory closed to group/other writes is followed",
+		)
+		assert_eq(
+			McpTransportCapability._resolve_trusted_path(linked_dir.path_join("http-8122.json")),
+			real_record,
+		)
+	DirAccess.remove_absolute(linked_dir)
+	_remove_private_record_in(real_dir)
+
+
+func test_follows_a_relative_link_target_on_posix() -> void:
+	if OS.get_name() == "Windows":
+		skip("creating POSIX symlinks is not portable on Windows")
+		return
+	var real_dir := _scratch_dir + "_real"
+	var real_record := _private_record_in(real_dir)
+	## ostree writes `/home -> var/home`, a relative target; resolve it against
+	## the already-walked parent, as the kernel does.
+	var linked_dir := _scratch_dir.path_join("relative-link")
+	DirAccess.remove_absolute(linked_dir)
+	if OS.execute("ln", ["-s", "../" + real_dir.get_file(), linked_dir]) != 0:
+		skip("could not create a POSIX symlink")
+	else:
+		assert_eq(
+			McpTransportCapability._resolve_trusted_path(linked_dir.path_join("http-8122.json")),
+			real_record,
+		)
+		assert_eq(
+			McpTransportCapability._read_path(linked_dir.path_join("http-8122.json")).get("http", ""),
+			HTTP,
+		)
+	DirAccess.remove_absolute(linked_dir)
+	_remove_private_record_in(real_dir)
+
+
+func test_rejects_a_link_below_a_writable_parent_on_posix() -> void:
+	if OS.get_name() == "Windows":
+		skip("creating POSIX symlinks is not portable on Windows")
+		return
+	var real_dir := _scratch_dir + "_real"
+	_private_record_in(real_dir)
+	var open_dir := _scratch_dir.path_join("open")
+	DirAccess.make_dir_recursive_absolute(open_dir)
+	FileAccess.set_unix_permissions(open_dir, _WORLD_WRITABLE)
+	var linked_dir := open_dir.path_join("link")
+	DirAccess.remove_absolute(linked_dir)
+	if OS.execute("ln", ["-s", real_dir, linked_dir]) != 0:
 		skip("could not create a POSIX symlink")
 	else:
 		assert_true(
-			McpTransportCapability._read_path(
-				linked_dir.path_join("http-8122.json")
-			).is_empty(),
-			"an otherwise-private record below a symlinked ancestor must fail closed",
+			McpTransportCapability._read_path(linked_dir.path_join("http-8122.json")).is_empty(),
+			"a link that any account could have placed must fail closed",
 		)
+	FileAccess.set_unix_permissions(open_dir, _OWNER_ONLY)
 	DirAccess.remove_absolute(linked_dir)
-	DirAccess.remove_absolute(real_record)
-	DirAccess.remove_absolute(real_dir)
+	DirAccess.remove_absolute(open_dir)
+	_remove_private_record_in(real_dir)
+
+
+func test_rejects_a_linked_record_file_on_posix() -> void:
+	if OS.get_name() == "Windows":
+		skip("creating POSIX symlinks is not portable on Windows")
+		return
+	var real_dir := _scratch_dir + "_real"
+	var real_record := _private_record_in(real_dir)
+	var linked_record := _scratch_dir.path_join("http-8122.json")
+	DirAccess.remove_absolute(linked_record)
+	if OS.execute("ln", ["-s", real_record, linked_record]) != 0:
+		skip("could not create a POSIX symlink")
+	else:
+		assert_true(
+			McpTransportCapability._read_path(linked_record).is_empty(),
+			"the record file itself is never followed",
+		)
+	DirAccess.remove_absolute(linked_record)
+	_remove_private_record_in(real_dir)
+
+
+func test_rejects_a_link_loop_on_posix() -> void:
+	if OS.get_name() == "Windows":
+		skip("creating POSIX symlinks is not portable on Windows")
+		return
+	var first := _scratch_dir.path_join("loop-a")
+	var second := _scratch_dir.path_join("loop-b")
+	DirAccess.remove_absolute(first)
+	DirAccess.remove_absolute(second)
+	if OS.execute("ln", ["-s", second, first]) != 0 or OS.execute("ln", ["-s", first, second]) != 0:
+		skip("could not create a POSIX symlink")
+	else:
+		assert_eq(
+			McpTransportCapability._resolve_trusted_path(first.path_join("http-8122.json")),
+			"",
+			"a link chain past the hop bound must fail closed",
+		)
+	DirAccess.remove_absolute(first)
+	DirAccess.remove_absolute(second)
 
 
 func test_rejects_world_writable_posix_ancestor() -> void:
@@ -251,3 +330,34 @@ func _canonical_record() -> String:
 		'{"version":1,"http":"%s","websocket":"%s","instance_nonce":"%s"}'
 		% [HTTP, WEBSOCKET, NONCE]
 	)
+
+
+const _OWNER_ONLY := (
+	FileAccess.UNIX_READ_OWNER | FileAccess.UNIX_WRITE_OWNER | FileAccess.UNIX_EXECUTE_OWNER
+)
+const _WORLD_WRITABLE := (
+	_OWNER_ONLY
+	| FileAccess.UNIX_READ_GROUP
+	| FileAccess.UNIX_WRITE_GROUP
+	| FileAccess.UNIX_EXECUTE_GROUP
+	| FileAccess.UNIX_READ_OTHER
+	| FileAccess.UNIX_WRITE_OTHER
+	| FileAccess.UNIX_EXECUTE_OTHER
+)
+
+
+## A canonical record in a fresh 0700 directory; returns the record path.
+func _private_record_in(directory: String) -> String:
+	DirAccess.make_dir_recursive_absolute(directory)
+	FileAccess.set_unix_permissions(directory, _OWNER_ONLY)
+	var record := directory.path_join("http-8122.json")
+	var file := FileAccess.open(record, FileAccess.WRITE)
+	file.store_string(_canonical_record())
+	file.close()
+	FileAccess.set_unix_permissions(record, FileAccess.UNIX_READ_OWNER | FileAccess.UNIX_WRITE_OWNER)
+	return record
+
+
+func _remove_private_record_in(directory: String) -> void:
+	DirAccess.remove_absolute(directory.path_join("http-8122.json"))
+	DirAccess.remove_absolute(directory)

--- a/tests/unit/test_transport_capability.py
+++ b/tests/unit/test_transport_capability.py
@@ -68,9 +68,7 @@ def test_only_root_owned_sticky_directory_is_safe_as_writable_ancestor() -> None
     assert capability_module._is_safe_posix_ancestor(Path("/tmp"), root_sticky)
     assert not capability_module._is_safe_posix_ancestor(Path("/tmp"), user_writable)
     assert not capability_module._is_safe_posix_ancestor(Path("/tmp"), other_sticky)
-    assert not capability_module._is_safe_posix_ancestor(
-        Path("/untrusted-sticky"), root_sticky
-    )
+    assert not capability_module._is_safe_posix_ancestor(Path("/untrusted-sticky"), root_sticky)
 
 
 @pytest.mark.parametrize("length", [31, 129])
@@ -242,9 +240,7 @@ def test_capability_directory_rejects_relative_xdg(monkeypatch) -> None:
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX XDG ancestor mode contract")
-def test_default_xdg_capability_directory_rejects_writable_ancestor(
-    monkeypatch, tmp_path
-) -> None:
+def test_default_xdg_capability_directory_rejects_writable_ancestor(monkeypatch, tmp_path) -> None:
     unsafe = tmp_path / "unsafe-xdg-parent"
     unsafe.mkdir(mode=0o700)
     unsafe.chmod(0o777)
@@ -264,3 +260,159 @@ def test_explicit_capability_directory_rejects_writable_ancestor(tmp_path) -> No
 
     with pytest.raises(OSError, match="unsafe ancestor"):
         record_path(8128, unsafe / "records")
+
+
+FAKE_ROOT = "/godot-ai-fake-root"
+
+
+def _directory(uid: int, mode: int = 0o755) -> os.stat_result:
+    return os.stat_result((stat.S_IFDIR | mode, 0, 0, 0, uid, 0, 0, 0, 0, 0))
+
+
+def _link(uid: int) -> os.stat_result:
+    return os.stat_result((stat.S_IFLNK | 0o777, 0, 0, 0, uid, 0, 0, 0, 0, 0))
+
+
+def _fake_tree(monkeypatch, entries: dict[str, os.stat_result], links: dict[str, str]) -> None:
+    """Overlay a synthetic directory tree onto lstat/readlink for the listed paths only."""
+
+    real_lstat = Path.lstat
+    real_readlink = os.readlink
+
+    def lstat(self):
+        key = str(self)
+        if key in entries:
+            return entries[key]
+        if key.startswith(FAKE_ROOT):
+            raise FileNotFoundError(key)
+        return real_lstat(self)
+
+    def readlink(path, *args, **kwargs):
+        key = str(path)
+        if key in links:
+            return links[key]
+        return real_readlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "lstat", lstat)
+    monkeypatch.setattr(capability_module.os, "readlink", readlink)
+
+
+def _ostree_home(monkeypatch, link_uid: int = 0, parent_mode: int = 0o755) -> None:
+    """Fedora Atomic's layout: ``/home -> var/home`` (relative, root-owned)."""
+
+    me = os.getuid()
+    _fake_tree(
+        monkeypatch,
+        {
+            FAKE_ROOT: _directory(0, parent_mode),
+            f"{FAKE_ROOT}/home": _link(link_uid),
+            f"{FAKE_ROOT}/var": _directory(0),
+            f"{FAKE_ROOT}/var/home": _directory(0),
+            f"{FAKE_ROOT}/var/home/me": _directory(me, 0o700),
+            f"{FAKE_ROOT}/var/home/me/.config": _directory(me, 0o700),
+        },
+        {f"{FAKE_ROOT}/home": "var/home"},
+    )
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX link contract")
+def test_root_owned_home_link_is_followed_to_its_canonical_path(monkeypatch) -> None:
+    _ostree_home(monkeypatch)
+    requested = Path(f"{FAKE_ROOT}/home/me/.config/godot-ai/capabilities")
+
+    resolved = capability_module._reject_unsafe_posix_ancestors(requested)
+
+    assert resolved == Path(f"{FAKE_ROOT}/var/home/me/.config/godot-ai/capabilities")
+    assert record_path(8000, requested) == resolved / "http-8000.json"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX link contract")
+def test_default_directory_resolves_through_the_home_link(monkeypatch) -> None:
+    _ostree_home(monkeypatch)
+    monkeypatch.delenv("GODOT_AI_CAPABILITY_DIR", raising=False)
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.setenv("HOME", f"{FAKE_ROOT}/home/me")
+    monkeypatch.setattr(capability_module.sys, "platform", "linux")
+
+    assert capability_directory() == Path(f"{FAKE_ROOT}/var/home/me/.config/godot-ai/capabilities")
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX link contract")
+@pytest.mark.parametrize("link_uid", ["self", "other"])
+def test_links_not_owned_by_root_fail_closed(monkeypatch, link_uid) -> None:
+    _ostree_home(monkeypatch, link_uid=os.getuid() if link_uid == "self" else os.getuid() + 1)
+
+    with pytest.raises(OSError, match="link or reparse"):
+        capability_module._reject_unsafe_posix_ancestors(Path(f"{FAKE_ROOT}/home/me/.config"))
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX link contract")
+def test_root_owned_link_in_a_writable_directory_fails_closed(monkeypatch) -> None:
+    # /tmp is an accepted sticky ancestor, but a link inside it is not followed.
+    me = os.getuid()
+    _fake_tree(
+        monkeypatch,
+        {
+            "/tmp": _directory(0, 0o1777),
+            "/tmp/godot-ai-link": _link(0),
+            f"{FAKE_ROOT}": _directory(0),
+            f"{FAKE_ROOT}/real": _directory(me, 0o700),
+        },
+        {"/tmp/godot-ai-link": f"{FAKE_ROOT}/real"},
+    )
+
+    with pytest.raises(OSError, match="link or reparse"):
+        capability_module._reject_unsafe_posix_ancestors(Path("/tmp/godot-ai-link/records"))
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX link contract")
+def test_link_chain_past_the_hop_bound_fails_closed(monkeypatch) -> None:
+    _fake_tree(
+        monkeypatch,
+        {FAKE_ROOT: _directory(0), f"{FAKE_ROOT}/a": _link(0), f"{FAKE_ROOT}/b": _link(0)},
+        {f"{FAKE_ROOT}/a": f"{FAKE_ROOT}/b", f"{FAKE_ROOT}/b": f"{FAKE_ROOT}/a"},
+    )
+
+    with pytest.raises(OSError, match="link or reparse"):
+        capability_module._reject_unsafe_posix_ancestors(Path(f"{FAKE_ROOT}/a/records"))
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX link contract")
+def test_relative_parent_link_target_resolves_against_the_walked_parent(monkeypatch) -> None:
+    # ostree's tmpfiles line: L /var/home - - - - ../sysroot/home
+    me = os.getuid()
+    _fake_tree(
+        monkeypatch,
+        {
+            FAKE_ROOT: _directory(0),
+            f"{FAKE_ROOT}/var": _directory(0),
+            f"{FAKE_ROOT}/var/home": _link(0),
+            f"{FAKE_ROOT}/sysroot": _directory(0),
+            f"{FAKE_ROOT}/sysroot/home": _directory(0),
+            f"{FAKE_ROOT}/sysroot/home/me": _directory(me, 0o700),
+        },
+        {f"{FAKE_ROOT}/var/home": "../sysroot/home"},
+    )
+
+    resolved = capability_module._reject_unsafe_posix_ancestors(
+        Path(f"{FAKE_ROOT}/var/home/me/.config")
+    )
+
+    assert resolved == Path(f"{FAKE_ROOT}/sysroot/home/me/.config")
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX link contract")
+def test_target_ancestors_are_held_to_the_same_rule(monkeypatch) -> None:
+    # A root-owned link may not lead into a tree another account can write to.
+    _fake_tree(
+        monkeypatch,
+        {
+            FAKE_ROOT: _directory(0),
+            f"{FAKE_ROOT}/home": _link(0),
+            f"{FAKE_ROOT}/shared": _directory(0, 0o777),
+        },
+        {f"{FAKE_ROOT}/home": f"{FAKE_ROOT}/shared"},
+    )
+
+    with pytest.raises(OSError, match="unsafe ancestor"):
+        capability_module._reject_unsafe_posix_ancestors(Path(f"{FAKE_ROOT}/home/me"))


### PR DESCRIPTION
## Summary

Fixes the Bazzite / Fedora Atomic startup failure from #993, reported again on #989 after 4.0.2: `/home` is a symbolic link to `/var/home` on ostree systems, and 4.0.x refused every link in a capability path, so the server exited before publishing its record (`Last pending proof: capability_record`) and only the `GODOT_AI_CAPABILITY_DIR` override made it start.

**Rule.** The ancestor check exists so no other account can redirect the record path through a link it planted. A link that is owned by root and sits in a root-owned directory closed to group/other writes cannot be planted by another account, so:

- **Server** (`capability.py`): `_reject_unsafe_posix_ancestors` follows exactly that shape, walks the target's components under the same ancestor rules, bounds the chain at eight hops, and now returns the link-free path; `capability_directory()` and `record_path()` use it, so every later check and file operation runs on a path with no links. Every other link still fails closed, and the record and lock files are never followed.
- **Plugin** (`transport_capability.gd`): `_resolve_trusted_path` follows a link only below a directory closed to group/other writes (Godot exposes no owning UID, so that is the strongest available proof; the server is the side that requires root ownership). The record file itself is never followed. Windows keeps rejecting every detectable link or reparse point.

**Not taken:** resolving the path first and checking the result. That skips the original components, so a link inside a directory another account can write to would be followed without that directory ever being examined.

**Docs:** README's Bazzite section now says the next release needs no override and keeps the 4.0.2 workaround; the security-model paragraph in `docs/plugin-architecture.md` states the link rule; `CHANGELOG.md` gains an Unreleased section (this fix plus #1000, #1001, #1002).

## Tests

- Python: a synthetic tree overlays `lstat`/`readlink` for the ostree layout. Accepts the relative `var/home` target and `../sysroot/home`; rejects a self-owned link, an other-owned link, a root-owned link inside sticky `/tmp`, a loop past the hop bound, and a root link whose target tree is world-writable. The default XDG directory resolves through the fake `/home`.
- GDScript: real symlinks in the suite's 0700 scratch directory. Follows a link below a closed parent and a relative target; rejects a link below a 0777 parent, a linked record file, and a loop.

## Verification

- `ruff check` / `ruff format --check` clean; `pytest tests/unit -n auto`: 2127 passed, 13 skipped.
- Godot 4.7.beta3 headless import + `script/ci-check-gdscript`: clean.
- Full GDScript suite against an isolated editor stack running this worktree's server (ports 8020/9520, scratch HOME, scratch capability dir): 2255/2279 passed, 0 failed, 24 skipped. Targeted `transport_capability` run: 14 passed, 0 failed, 1 skipped (the Linux-only XDG test).
- Not exercised: a real Bazzite host. The Python tests model its layout from the ostree and Fedora Silverblue documentation (`/home -> var/home`, relative target).

Closes #993 for real; addresses rderoock's report on #989.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved capability discovery on Fedora Atomic systems by safely following trusted, root-owned symlinks.
  - Fixed crashes when reloading the plugin from the Godot editor.
  - The Update button now remains available after an in-session update and can re-arm for newer releases.
  - Failed downloads now release the update lock, allowing future update attempts.
- **Documentation**
  - Clarified supported Fedora Atomic environments and updated troubleshooting guidance.
  - Documented capability-record path security rules and trusted symlink behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->