### PR TITLE
docs: how an agent in a container or on another machine connects in v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ reading. Release engineering: [docs/releasing.md](docs/releasing.md).
 - A failed download releases the update lock
   ([#1001](https://github.com/hi-godot/godot-ai/pull/1001)).
 
+### Changed
+
+- Documented the supported way to connect an agent that runs in a container,
+  in WSL2, or on another machine: the `godot-ai attach` bridge launched on the
+  editor machine over SSH, with the Docker Desktop, Docker Engine, and WSL2
+  host names ([#1008](https://github.com/hi-godot/godot-ai/issues/1008);
+  a first-class remote mode is tracked in
+  [#1009](https://github.com/hi-godot/godot-ai/issues/1009)).
+
 ## 4.0.2 (2026-09-07)
 
 Fixes the in-editor updater's download. Nothing else changed.

--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ MCP client
 ```
 
 Both local hops use independent rotating capabilities; neither falls back to
-unauthenticated access. The editor WebSocket stays loopback-only. For remote
-access, prefer an SSH-launched attach command on the server host rather than
-storing a capability in client configuration.
+unauthenticated access. The editor WebSocket stays loopback-only. An agent in
+a container or on another machine runs the bridge on the editor machine over
+SSH; see [Agents on another machine or in a container](docs/client-configuration.md#agents-on-another-machine-or-in-a-container).
 
 These controls do not protect against a compromised same-user process. Windows
 also does not claim isolation from other local accounts. See the

--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -260,6 +260,76 @@ The dock renders one row per client with a status dot, Configure/Remove buttons,
 and a per-row "Run this manually" fallback for cases when auto-configure cannot
 find a CLI.
 
+### Agents on another machine or in a container
+
+Every v4 HTTP request carries a bearer capability. The server generates it at
+each start and publishes it only in the private record on the editor machine
+(`~/.config/godot-ai/capabilities/http-<port>.json` on Linux,
+`~/Library/Application Support/godot-ai/capabilities/` on macOS,
+`%LOCALAPPDATA%\godot-ai\capabilities\` on Windows). The `godot-ai attach`
+bridge reads that record and presents the capability; it has no remote mode
+and talks only to loopback. An AI client that does not run on the editor
+machine (a coding agent in Docker, a WSL2 distribution against a Windows
+editor, another computer on the LAN) therefore runs the bridge **on the editor
+machine** and reaches it over SSH. That is the supported path. A bare HTTP URL
+cannot carry a rotating credential and must not be persisted (above), and
+pasting the record's current `http` value into an `Authorization: Bearer`
+header works only until the next server start.
+
+1. **On the editor machine:** install `uv`, enable an SSH server, and set up
+   key-based login for the **same user account that runs Godot**, because the
+   bridge reads that user's capability record. On Windows, OpenSSH Server is
+   an optional feature (`Add-WindowsCapability -Online -Name
+   OpenSSH.Server~~~~0.0.1.0`, then `Start-Service sshd` and `Set-Service sshd
+   -StartupType Automatic`; the feature adds its own firewall rule). Keys for
+   an administrator account belong in
+   `C:\ProgramData\ssh\administrators_authorized_keys`, not in the user's
+   `.ssh\authorized_keys`.
+2. **In the dock:** open the client row's **Run this manually** entry and copy
+   the command. It has the shape
+   `uvx --isolated --no-config ... --from godot-ai==<plugin version> godot-ai
+   attach --port <http port> --ws-port <ws port>` plus `--exclude-domains` and
+   `--disable-telemetry` when those settings apply.
+3. **On the client's machine:** configure the MCP server as a stdio command
+   that runs SSH with the copied command as the remote command. For a JSON
+   `mcpServers` map:
+
+   ```json
+   "godot-ai": {
+     "command": "ssh",
+     "args": [
+       "-T", "-o", "LogLevel=ERROR",
+       "you@host.docker.internal",
+       "uvx --isolated --no-config --no-env-file --no-sources --no-build --index-strategy first-index --keyring-provider disabled --index https://pypi.org/simple --default-index https://pypi.org/simple --find-links https://pypi.org/simple/godot-ai/ --link-mode copy --from godot-ai==4.0.2 godot-ai attach --port 8000 --ws-port 9500"
+     ]
+   }
+   ```
+
+   `-T` refuses a pseudo-terminal and `LogLevel=ERROR` silences banners, so
+   nothing but the MCP stream reaches stdout. Use the dock's command verbatim
+   in place of the example; the version pin must equal the installed plugin's
+   version or the bridge refuses the server.
+4. **Host name:** Docker Desktop on Windows or macOS resolves
+   `host.docker.internal` to the host; Docker Engine on Linux needs
+   `--add-host=host.docker.internal:host-gateway` on the container. From WSL2
+   in the default NAT mode, the Windows host is the address in
+   `/etc/resolv.conf`'s `nameserver` line; in mirrored networking mode it is
+   `localhost`. For another machine, use its name on a network you trust, or
+   a VPN such as Tailscale; do not expose the editor port itself.
+
+The bridge launched this way authenticates itself on every start, so a server
+restart needs no manual step. A Godot AI **update** does: the dock repins
+owned entries in config files on the editor machine but cannot see a file on
+another machine, so refresh the SSH command's version pin from **Run this
+manually** after each update. The Settings tab's **Allow remote hosts (CIDR)**
+allowlist is not needed for this recipe; it widens the HTTP bind for peers in
+the named ranges, and those peers still need the bearer.
+
+As of 4.0.2 this recipe is derived from the code rather than exercised by the
+maintainers on Windows with Docker Desktop; reports either way belong on
+[#1009](https://github.com/hi-godot/godot-ai/issues/1009), which also tracks
+whether a first-class remote mode is worth building.
+
 ### CodeBuddy IDE
 
 CodeBuddy uses the standard `mcpServers` JSON map with `type: "stdio"` and

--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -298,7 +298,7 @@ header works only until the next server start.
    "godot-ai": {
      "command": "ssh",
      "args": [
-       "-T", "-o", "LogLevel=ERROR",
+       "-T", "-o", "BatchMode=yes", "-o", "LogLevel=ERROR",
        "you@host.docker.internal",
        "uvx --isolated --no-config --no-env-file --no-sources --no-build --index-strategy first-index --keyring-provider disabled --index https://pypi.org/simple --default-index https://pypi.org/simple --find-links https://pypi.org/simple/godot-ai/ --link-mode copy --from godot-ai==4.0.2 godot-ai attach --port 8000 --ws-port 9500"
      ]
@@ -306,9 +306,14 @@ header works only until the next server start.
    ```
 
    `-T` refuses a pseudo-terminal and `LogLevel=ERROR` silences banners, so
-   nothing but the MCP stream reaches stdout. Use the dock's command verbatim
-   in place of the example; the version pin must equal the installed plugin's
-   version or the bridge refuses the server.
+   nothing but the MCP stream reaches stdout. `BatchMode=yes` makes SSH fail
+   instead of prompting, which a stdio MCP client could never answer. Before
+   persisting the entry, connect once by hand from the client machine
+   (`ssh -T you@<host> true`), check the host key fingerprint, and accept it so
+   `known_hosts` carries it; do not turn off host-key checking to skip that
+   step. Use the dock's command verbatim in place of the example; the version
+   pin must equal the installed plugin's version or the bridge refuses the
+   server.
 4. **Host name:** Docker Desktop on Windows or macOS resolves
    `host.docker.internal` to the host; Docker Engine on Linux needs
    `--add-host=host.docker.internal:host-gateway` on the container. From WSL2

--- a/docs/v4-migration.md
+++ b/docs/v4-migration.md
@@ -16,6 +16,12 @@ confirmation button, or restart Godot yourself. Godot AI prepares and authentica
 complete add-on tree, updates owned client entries, and restarts the matching
 managed server automatically.
 
+If an AI client runs on another machine or in a container and reached v3 at
+`http://<host>:8000/mcp`, set up the SSH-launched bridge described in
+[Agents on another machine or in a container](client-configuration.md#agents-on-another-machine-or-in-a-container)
+before you update. v4 accepts no bare URL, so that client stays disconnected
+until the bridge exists.
+
 Cherry Studio is not supported in v4; remove its stale v3 entry in Cherry
 Studio itself. Godot AI cannot safely edit that application's internal database.
 


### PR DESCRIPTION
## Summary

Documents the supported way for an AI client that does not run on the editor machine (Docker, WSL2, another computer) to connect in v4: run the `godot-ai attach` bridge on the editor machine over SSH. Prompted by #1008; the design question of a first-class remote mode is tracked in #1009 and deferred.

- `docs/client-configuration.md`: new section "Agents on another machine or in a container". Why a bare URL cannot work (per-instance bearer, local-only bridge), the recipe (same user as the editor; Windows OpenSSH Server, including the `administrators_authorized_keys` gotcha; the dock's Run-this-manually command wrapped in `ssh -T -o LogLevel=ERROR`; host names for Docker Desktop, Docker Engine, and WSL2), the version-pin refresh after an update since the dock cannot repin a file on another machine, and why the CIDR allowlist is not needed for it.
- `docs/v4-migration.md`: remote users set the bridge up before updating, or that client stays disconnected.
- `README.md`: the one-sentence hint becomes a link to the section.
- `CHANGELOG.md`: Unreleased → Changed.

## Verification

Docs only. `git diff --check` clean; the section anchor matches the links from the README and migration guide. The `uvx` command in the example is the exact argv `client_configurator.gd` writes (`UvResolution.args()` + `--link-mode copy --from godot-ai==<pin> godot-ai attach --port --ws-port`).

Not exercised: the recipe on Windows with Docker Desktop. The doc says so and asks for reports on #1009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added instructions for connecting agents in containers, WSL2, or on remote machines through an SSH-launched bridge on the editor machine.
  - Updated remote-access guidance with non-interactive SSH configuration and host-key verification steps.
  - Updated the README with the revised remote connection workflow.
  - Added migration guidance for clients previously using direct v3 MCP URLs, including the required bridge setup before upgrading to v4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->