### PR TITLE
fix: Windows capability directory, startup report, and replacement launch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,7 @@ cd ~/godot-ai
 script/setup-dev             # creates .venv, installs deps, applies macOS .pth fix
 source .venv/bin/activate
 pytest -v                    # run tests
+pytest -m "not editor"       # iterate: skip the rows that launch a real editor
 ```
 
 `uv.lock` is intentionally untracked: dependencies resolve from `pyproject.toml`, and CI installs with pip (`pip install -e ".[dev]"`) rather than enforcing a uv lockfile.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,10 +215,25 @@ A test that passes for the wrong reason is worse than a missing test: it ships a
 
 ## Before you commit
 
-**Always run the full gauntlet before every commit** — `ruff check`, `pytest -v`,
-then `test_run` against a live Godot editor, plus a live smoke of anything you
-changed. Python mocks do not catch GDScript bugs, editor API regressions, or
-undo/redo breakage. Steps: [docs/verification.md](docs/verification.md).
+**Before every commit:** `ruff check`, `pytest -m "not editor"`, then `test_run`
+against a live Godot editor, plus a live smoke of anything you changed. Python
+mocks do not catch GDScript bugs, editor API regressions, or undo/redo
+breakage. Steps: [docs/verification.md](docs/verification.md).
+
+**Turn the real-editor rows on deliberately, not by default.** The tests marked
+`editor` launch a real Godot editor (needs `GODOT_BIN` pointing at a 4.7+
+engine) and take about fifteen minutes. Run the full `pytest -v` with them:
+
+- before a commit that touches the server lifecycle, `update_manager.gd`,
+  `update_installer.gd`, `release_verifier.gd`, `release_verify.py`, the
+  migration bridge, plugin disable/enable, the attach bridge, or client
+  configuration;
+- before cutting a release, on each desktop OS the release claims.
+
+CI runs them nightly and in release qualification on Linux, macOS and
+Windows, so a skipped local run is never the last line of defence; a wrong
+`GODOT_BIN` (an engine below 4.7) is worse than an unset one, because the
+rows then run, fail slowly, and prove nothing.
 
 ## Tool inventory sources
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ reading. Release engineering: [docs/releasing.md](docs/releasing.md).
 
 ### Fixed
 
+- **Windows:** the server launched to replace an older godot-ai backend gave
+  up waiting for the port after 5 s, before the plugin had finished proving
+  the new process and killing the old one (each identity probe is a
+  PowerShell start), so a post-update replacement could loop on `The launched
+  process identity could not be captured`. The replacement now waits 15 s,
+  and that message names the process, whether it is still alive, and which
+  check refused it on each attempt.
+- **Windows:** the server created its private capability directory with
+  `mode=0o700`, which CPython turns into a DACL of SYSTEM, Administrators and
+  OWNER RIGHTS alone. A directory first created by an elevated process is
+  then owned by Administrators, and the user's own unelevated editor, server
+  and `godot-ai attach` bridge can never read or write it: the dock showed
+  `The managed server proof timed out at capability_record` and the bridge
+  reported `PORT_OCCUPIED` for a healthy backend. The directory now inherits
+  the per-user `%LOCALAPPDATA%` permissions; the plugin probes it before
+  spawning and the bridge checks it before blaming a foreign process, and
+  both name the directory and the elevated `Remove-Item` repair when the
+  account cannot use it
+  ([#988](https://github.com/hi-godot/godot-ai/issues/988)).
+- A plugin-spawned server that fails before publishing its capability record
+  now writes the failure to a startup report (`--startup-report`, beside the
+  pid file) and the dock appends it to the proof failure, so a port in use, an
+  unwritable directory or a crashed import is named instead of a bare
+  `proof timed out at capability_record`
+  ([#1012](https://github.com/hi-godot/godot-ai/issues/1012)).
 - `camera_create` / `camera_configure` / `camera_apply_preset` with
   `make_current` on a **Camera2D** could leave the camera not current while
   the response and `camera_get` said it was. Godot's `Camera2D.make_current()`

--- a/docs/server-lifecycle.md
+++ b/docs/server-lifecycle.md
@@ -73,6 +73,21 @@ in `BLOCKED`.
 5. Wait for the new capability record, authenticate status, and bind the live
    process fingerprint before publishing `READY`.
 
+Two diagnostics sit around step 4. On Windows the plugin creates and probes
+the capability directory before it spawns: the server would otherwise create
+it with `mode=0o700`, which CPython renders as a DACL of SYSTEM, Administrators
+and OWNER RIGHTS only, and a directory first created by an elevated process is
+unusable from the user's unelevated editor, server and bridge (#988). A failed
+probe blocks the start with the directory path and the elevated `Remove-Item`
+repair; the server and the `attach` bridge report the same message from their
+side. The plugin also passes `--startup-report <user://...json>` beside
+`--pid-file` and removes any stale report before the spawn. A server that
+fails before publishing its record writes `{pid, error, message, hint}` there
+(a port already in use, an unwritable directory, an import error); the first
+report wins and the record's publication disarms it. The dock appends that
+text to "exited before publishing capabilities" and to the proof timeout. The
+report is quoted, bounded and never interpreted.
+
 The Python server owns the private record and a per-port launch claim. HTTP,
 status, and lease routes require the HTTP bearer. The editor WebSocket stays on
 IPv4 loopback and uses a transcript-bound challenge/response before the editor

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -88,7 +88,10 @@ editor to *look at* — the step 6 smoke test — or when nothing is running yet
      script/local-game-capture-diag script/v4-release
    ```
    Lint must pass.
-2. `pytest -v` — all environment-independent Python tests pass. Then run the
+2. `pytest -v` — all environment-independent Python tests pass. While
+   iterating, `pytest -m "not editor"` leaves out the rows that launch a
+   real editor (they take minutes each and skip anyway without
+   `GODOT_BIN`); the pre-commit run is the full `pytest -v`. Then run the
    Godot-backed updater row explicitly; those tests otherwise skip:
    ```bash
    GODOT_BIN=/absolute/path/to/Godot pytest -v \

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -1214,6 +1214,7 @@ func _capture_lifecycle_plan() -> Dictionary:
 		"expected_version": ClientConfigurator.get_plugin_version(),
 		"server_command": ClientConfigurator.get_server_command(),
 		"pid_file": ProjectSettings.globalize_path(PortResolver.SERVER_PID_FILE),
+		"startup_report": ProjectSettings.globalize_path(PortResolver.SERVER_STARTUP_REPORT),
 		"http_port_reserved": WindowsPortReservation.is_port_excluded(http_port),
 		"excluded_domains": str(policy.get("excluded_domains", "")),
 		"allow_hosts": str(policy.get("allow_hosts", "")),

--- a/plugin/addons/godot_ai/utils/port_resolver.gd
+++ b/plugin/addons/godot_ai/utils/port_resolver.gd
@@ -9,6 +9,10 @@ extends RefCounted
 ## Canonical pid-file path. plugin.gd::SERVER_PID_FILE re-exports this so
 ## external readers and tests can use either name.
 const SERVER_PID_FILE := "user://godot_ai_server.pid"
+## Where a plugin-spawned server reports a failure that happens before it
+## publishes its capability record (`--startup-report`). Removed before every
+## spawn, so a report that exists afterwards belongs to that launch.
+const SERVER_STARTUP_REPORT := "user://godot_ai_server_startup.json"
 const WindowsPortReservation := preload("res://addons/godot_ai/utils/windows_port_reservation.gd")
 static var _process_spawn_mutex := Mutex.new()
 
@@ -428,8 +432,11 @@ static func commandline_is_godot_ai_server(commandline: String) -> bool:
 	var lower := commandline.to_lower()
 	var expression := RegEx.new()
 	var brand_search := lower
-	if expression.compile("--pid-file(?:=|\\s+)\\S+") == OK:
-		brand_search = expression.sub(lower, "--pid-file ", true)
+	## Paths we choose ourselves must not satisfy the brand: strip the pid-file
+	## and startup-report values (they live under user:// and carry our name)
+	## before searching for it.
+	if expression.compile("--(pid-file|startup-report)(?:=|\\s+)\\S+") == OK:
+		brand_search = expression.sub(lower, "--$1 ", true)
 	var branded := brand_search.contains("godot-ai") or brand_search.contains("godot_ai")
 	return branded and (lower.contains("--pid-file") or lower.contains("--transport"))
 
@@ -484,19 +491,31 @@ static func process_fingerprint(pid: int) -> String:
 ## Capture the process identity that a later destructive call must present.
 ## A PID or command-line brand alone is never kill authority: either can refer
 ## to a different process by the time a worker reaches the effect boundary.
-static func capture_process_kill_grant(pid: int, require_brand := false) -> Dictionary:
-	if pid <= 1 or pid == OS.get_process_id() or not pid_alive(pid):
+## `diagnostics`, when given, receives one word naming the check that
+## refused the grant. It costs no extra probe and never changes the result.
+static func capture_process_kill_grant(
+	pid: int, require_brand := false, diagnostics: Array = []
+) -> Dictionary:
+	if pid <= 1 or pid == OS.get_process_id():
+		diagnostics.append("invalid_pid")
+		return {}
+	if not pid_alive(pid):
+		diagnostics.append("not_alive")
 		return {}
 	if require_brand and not pid_cmdline_is_godot_ai(pid):
+		diagnostics.append("unbranded")
 		return {}
 	var fingerprint := process_fingerprint(pid)
 	if fingerprint.is_empty():
+		diagnostics.append("fingerprint_unavailable")
 		return {}
 	## Close the capture window: both identity and optional lineage/brand must
 	## still describe the same process after the fingerprint read.
 	if process_fingerprint(pid) != fingerprint:
+		diagnostics.append("fingerprint_changed")
 		return {}
 	if require_brand and not pid_cmdline_is_godot_ai(pid):
+		diagnostics.append("brand_changed")
 		return {}
 	return {"pid": pid, "fingerprint": fingerprint}
 

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -23,7 +23,10 @@ const READY := "READY"
 const BLOCKED := "BLOCKED"
 const RECOVERING := "RECOVERING"
 ## How long a server launched to replace an occupant may wait for the port.
-const REPLACEMENT_WAIT_FOR_PORT_MS := 5000
+## 15 s, not 5: on Windows every identity probe is a PowerShell start (about
+## 0.6 s each) and the launch must capture the new process, then re-read and
+## kill the old one, before the replacement gives up waiting for the port.
+const REPLACEMENT_WAIT_FOR_PORT_MS := 15_000
 const STOPPING := "STOPPING"
 
 const PROBE := "PROBE"
@@ -427,7 +430,8 @@ func _complete_prove(result: Dictionary) -> void:
 			_block(
 				"proof_timeout",
 				"The managed server proof timed out at %s."
-				% str(_episode.get("proof_pending_reason", "unknown")),
+				% str(_episode.get("proof_pending_reason", "unknown"))
+				+ startup_report_summary(str(_plan.get("startup_report", ""))),
 			)
 			return
 		_retry_effect_after(PROVE, _prove_payload(), 0.15)
@@ -681,6 +685,11 @@ func _effect_launch(payload: Dictionary) -> Dictionary:
 	var server_command: Array = payload.get("server_command", [])
 	if server_command.is_empty():
 		return {"ok": false, "reason": "no_command", "message": "No godot-ai server command was found."}
+	## Do not spawn into a directory the server cannot publish from (#988):
+	## the failure would only surface as a proof timeout three minutes later.
+	var directory_problem := TransportCapability.directory_write_problem(port)
+	if not directory_problem.is_empty():
+		return {"ok": false, "reason": "capability_dir_unwritable", "message": directory_problem}
 	var args: Array[String] = []
 	args.assign(server_command.slice(1))
 	args.append_array(_server_flags(payload))
@@ -705,6 +714,9 @@ func _effect_launch(payload: Dictionary) -> Dictionary:
 	var pid_file := str(payload.get("pid_file", ""))
 	if not pid_file.is_empty() and FileAccess.file_exists(pid_file):
 		DirAccess.remove_absolute(pid_file)
+	var startup_report := str(payload.get("startup_report", ""))
+	if not startup_report.is_empty() and FileAccess.file_exists(startup_report):
+		DirAccess.remove_absolute(startup_report)
 	var spawned := spawn_capability_process(str(server_command[0]), args, environment)
 	var pid := int(spawned.pid)
 	if pid <= 1:
@@ -712,22 +724,62 @@ func _effect_launch(payload: Dictionary) -> Dictionary:
 	## OS.create_process can return before POSIX exec replaces the child image.
 	## Capture only after the command is branded and its exact fingerprint is
 	## stable across two reads; otherwise a legitimate exec looks like PID reuse.
-	var exact_grant := PortResolver.capture_process_kill_grant(pid, true)
-	var fingerprint_deadline := Time.get_ticks_msec() + LAUNCH_FINGERPRINT_TIMEOUT_MS
+	var capture_started := Time.get_ticks_msec()
+	var attempts: Array = []
+	var exact_grant := PortResolver.capture_process_kill_grant(pid, true, attempts)
+	var fingerprint_deadline := capture_started + LAUNCH_FINGERPRINT_TIMEOUT_MS
 	while exact_grant.is_empty() and Time.get_ticks_msec() < fingerprint_deadline:
 		OS.delay_msec(100)
-		exact_grant = PortResolver.capture_process_kill_grant(pid, true)
+		exact_grant = PortResolver.capture_process_kill_grant(pid, true, attempts)
 	var fingerprint := str(exact_grant.get("fingerprint", ""))
 	return {
 		"ok": not fingerprint.is_empty(),
 		"reason": "launch_unproven" if fingerprint.is_empty() else "",
-		"message": "The launched process identity could not be captured." if fingerprint.is_empty() else "",
+		"message": (
+			_launch_unproven_message(pid, attempts, Time.get_ticks_msec() - capture_started)
+			if fingerprint.is_empty()
+			else ""
+		),
 		"pid": pid,
 		"fingerprint": fingerprint,
 		"http_capability": spawned.http,
 		"ws_capability": spawned.websocket,
 		"baseline_instance_id": str(payload.get("baseline_instance_id", "")),
 	}
+
+
+## Name which identity check failed so a Windows report can be acted on
+## (#988, #1012 both surfaced as this bare sentence). Diagnostic only: the
+## values are read once more after the capture budget and never grant
+## authority.
+static func _launch_unproven_message(pid: int, attempts: Array, elapsed_ms: int) -> String:
+	var alive := PortResolver.pid_alive(pid)
+	var commandline := PortResolver.process_commandline(pid) if alive else ""
+	if commandline.length() > 200:
+		commandline = commandline.substr(0, 199) + "…"
+	## Summarise the per-attempt refusals as "reason×count" in first-seen order.
+	var counts := {}
+	var order: Array[String] = []
+	for entry in attempts:
+		var key := str(entry)
+		if not counts.has(key):
+			counts[key] = 0
+			order.append(key)
+		counts[key] = int(counts[key]) + 1
+	var summary: Array[String] = []
+	for key in order:
+		summary.append("%s×%d" % [key, int(counts[key])])
+	return (
+		"The launched process identity could not be captured in %d attempts over %.1f s "
+		+ "(pid %d, now alive=%s, refusals: %s%s)."
+	) % [
+		attempts.size(),
+		elapsed_ms / 1000.0,
+		pid,
+		"yes" if alive else "no",
+		", ".join(summary) if not summary.is_empty() else "none recorded",
+		"" if commandline.is_empty() else "; command: " + commandline,
+	]
 
 
 func _effect_prove(payload: Dictionary) -> Dictionary:
@@ -748,7 +800,10 @@ func _effect_prove(payload: Dictionary) -> Dictionary:
 		return {
 			"ok": false,
 			"reason": "launch_%s" % launch_disposition,
-			"message": "The launched server process exited or changed identity before publishing capabilities.",
+			"message": (
+				"The launched server process exited or changed identity before publishing capabilities."
+				+ startup_report_summary(str(payload.get("startup_report", "")))
+			),
 		}
 	var port := int(payload.http_port)
 	var capability := _read_capability(port)
@@ -971,6 +1026,7 @@ func _prove_payload() -> Dictionary:
 		"expected_version": str(_plan.expected_version),
 		"timeout_ms": int(_plan.probe_timeout_ms),
 		"pid_file": str(_plan.get("pid_file", "")),
+		"startup_report": str(_plan.get("startup_report", "")),
 		"http_capability": str(launch.get("http_capability", "")),
 		"ws_capability": str(launch.get("ws_capability", "")),
 		"baseline_instance_id": str(launch.get("baseline_instance_id", "")),
@@ -1199,6 +1255,9 @@ static func _server_flags(plan: Dictionary) -> Array[String]:
 		"--ws-port", str(plan.ws_port),
 		"--pid-file", str(plan.get("pid_file", "")),
 	]
+	var startup_report := str(plan.get("startup_report", ""))
+	if not startup_report.is_empty():
+		flags.append_array(["--startup-report", startup_report])
 	var excluded := str(plan.get("excluded_domains", ""))
 	if not excluded.is_empty():
 		flags.append_array(["--exclude-domains", excluded])
@@ -1206,6 +1265,39 @@ static func _server_flags(plan: Dictionary) -> Array[String]:
 	if not allow_hosts.is_empty():
 		flags.append_array(["--allow-host", allow_hosts])
 	return flags
+
+
+## " Server reported: <type>: <message> <hint>" from the launch's startup
+## report, or "" when there is none. Bounded and single-line: the report is a
+## file the spawned server wrote, so it is quoted, never interpreted.
+static func startup_report_summary(path: String, max_chars := 600) -> String:
+	if path.is_empty() or not FileAccess.file_exists(path):
+		return ""
+	var file := FileAccess.open(path, FileAccess.READ)
+	if file == null:
+		return ""
+	var raw := file.get_as_text().strip_edges()
+	file.close()
+	if raw.is_empty() or raw.length() > 8192:
+		return ""
+	var parsed: Variant = JSON.parse_string(raw)
+	if not (parsed is Dictionary):
+		return ""
+	var error := str(parsed.get("error", "")).strip_edges()
+	var message := str(parsed.get("message", "")).strip_edges()
+	var hint := str(parsed.get("hint", "")).strip_edges()
+	if error.is_empty() and message.is_empty():
+		return ""
+	var text := " Server reported: "
+	if not error.is_empty():
+		text += error + (": " if not message.is_empty() else "")
+	text += message
+	if not hint.is_empty():
+		text += " " + hint
+	text = text.replace("\n", " ").replace("\r", " ")
+	if text.length() > max_chars:
+		text = text.substr(0, max_chars - 1) + "…"
+	return text
 
 
 static func active_lease_count(live: Dictionary) -> int:

--- a/plugin/addons/godot_ai/utils/transport_capability.gd
+++ b/plugin/addons/godot_ai/utils/transport_capability.gd
@@ -234,6 +234,61 @@ static func is_lower_hex(value: String, length: int) -> bool:
 	return is_hex(value, length) and value == value.to_lower()
 
 
+## Windows only: "" when this account can create and write the capability
+## directory, else a repair message. Python creates the directory with
+## ``mode=0o700`` on POSIX, but on Windows that mode yields a DACL of SYSTEM,
+## Administrators and OWNER RIGHTS alone; a directory first created by an
+## elevated process is then owned by Administrators and unusable from the
+## user's own unelevated editor, server and bridge (#988). Creating it here
+## first inherits the per-user %LOCALAPPDATA% DACL, and probing it before the
+## spawn turns a silent "proof timed out at capability_record" into a message
+## that names the directory and the fix.
+static func directory_write_problem(http_port: int) -> String:
+	if OS.get_name() != "Windows":
+		return ""
+	var record := path_for_http_port(http_port)
+	if record.is_empty():
+		return ""
+	return directory_write_problem_for(record.get_base_dir())
+
+
+static func directory_write_problem_for(directory: String) -> String:
+	if DirAccess.open(directory) == null:
+		var created := DirAccess.make_dir_recursive_absolute(directory)
+		if created != OK:
+			return windows_repair_hint(directory, error_string(created))
+	var probe := directory.path_join(".access-probe-%d-%s" % [
+		OS.get_process_id(), Crypto.new().generate_random_bytes(4).hex_encode(),
+	])
+	var file := FileAccess.open(probe, FileAccess.WRITE)
+	if file == null:
+		return windows_repair_hint(directory, error_string(FileAccess.get_open_error()))
+	file.close()
+	DirAccess.remove_absolute(probe)
+	return ""
+
+
+static func windows_repair_hint(directory: String, detail: String) -> String:
+	var root := directory
+	var current := directory
+	while not current.is_empty():
+		if current.get_file() == "godot-ai":
+			root = current
+			break
+		var parent := current.get_base_dir()
+		if parent.is_empty() or parent == current:
+			break
+		current = parent
+	return (
+		"Godot AI cannot use its private directory %s (%s): this Windows account "
+		+ "has no access to it, which happens when it was first created by an "
+		+ "elevated (Run as administrator) process. Close Godot and every AI "
+		+ "client, then from an elevated PowerShell run: "
+		+ "Remove-Item -Recurse -Force \"%s\" ; reopen the project unelevated and "
+		+ "the directory is recreated with your account's permissions."
+	) % [directory, detail, root]
+
+
 static func path_for_http_port(http_port: int) -> String:
 	if http_port < 1 or http_port > 65535:
 		return ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,9 @@ asyncio_mode = "auto"
 pythonpath = ["src"]
 # Drop each passed test's tmp_path at teardown so a long run's basetemp stays small and fast.
 tmp_path_retention_policy = "failed"
+markers = [
+    "editor: launches a real Godot editor (needs GODOT_BIN); run `pytest -m 'not editor'` to iterate",
+]
 
 [tool.ruff]
 target-version = "py311"

--- a/script/_dev_env.py
+++ b/script/_dev_env.py
@@ -90,12 +90,25 @@ def worktree_src(worktree: Path | None = None) -> Path:
 def find_venv_python(worktree: Path | None = None) -> Path | None:
     """The checkout's venv interpreter, or ``None`` if it isn't a real file.
 
-    ``is_file()`` (not ``exists()``) so a directory sitting at the interpreter
-    path is treated as "no venv" rather than handed to ``execv()``, which would
-    crash with an OSError instead of cleanly falling through.
+    A worktree that carries its own ``.venv`` (``script/setup-dev`` creates
+    one) wins over the main checkout's: the two can sit on different
+    branches, and a script re-executed under the main checkout's interpreter
+    would silently run that branch's ``godot_ai`` against this worktree's
+    tests. ``is_file()`` (not ``exists()``) so a directory sitting at the
+    interpreter path is treated as "no venv" rather than handed to
+    ``execv()``, which would crash with an OSError instead of cleanly falling
+    through.
     """
-    candidate = venv_python(root_repo(worktree) / ".venv")
-    return candidate if candidate.is_file() else None
+    wt = worktree or worktree_root()
+    for base in (wt, root_repo(wt)):
+        candidate = venv_python(base / ".venv")
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _is_windows() -> bool:
+    return os.name == "nt"
 
 
 def reexec_into_venv(*, guard_env: str, opt_out_env: str | None = None) -> None:
@@ -120,6 +133,14 @@ def reexec_into_venv(*, guard_env: str, opt_out_env: str | None = None) -> None:
     except OSError:
         return
     os.environ[guard_env] = "1"
+    if _is_windows():
+        ## Windows has no exec: ``os.execv`` starts the new interpreter as a
+        ## separate process and returns control to the caller, which exits 0
+        ## at once. Anyone capturing the script (a test, CI, a shell ``&&``)
+        ## then sees exit 0 and empty output whatever the script did. Run the
+        ## child and forward its exit code instead.
+        completed = subprocess.run([str(target), *sys.argv], check=False)
+        sys.exit(completed.returncode)
     os.execv(str(target), [str(target), *sys.argv])
 
 

--- a/src/godot_ai/__init__.py
+++ b/src/godot_ai/__init__.py
@@ -13,6 +13,7 @@ from collections.abc import Sequence
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 from pathlib import Path
+from typing import Any
 
 
 def _resolve_version(package_file: str | Path) -> str:
@@ -120,12 +121,15 @@ def preflight_check_port(
                 ## condition this preflight exists to catch: let the real
                 ## server startup produce its existing failure mode.
                 return
-            print(
-                    f"godot-ai: {label} port {port} is already in use by another "
-                    f"process. Stop it or change the port ({setting} in Godot "
-                    "Editor Settings).",
-                    file=sys.stderr,
-                )
+            text = (
+                f"godot-ai: {label} port {port} is already in use by another "
+                f"process. Stop it or change the port ({setting} in Godot "
+                "Editor Settings)."
+            )
+            print(text, file=sys.stderr)
+            from godot_ai.runtime_info import report_startup_failure
+
+            report_startup_failure(OSError(errno.EADDRINUSE, text))
             raise SystemExit(EXIT_PORT_IN_USE) from exc
         finally:
             if not keep:
@@ -199,6 +203,16 @@ def main(argv: Sequence[str] | None = None) -> None:
         ),
     )
     parser.add_argument(
+        "--startup-report",
+        default=None,
+        help=(
+            "When startup fails before the capability record is published, "
+            "write the failure (type, message, hint) as JSON to this path. The "
+            "Godot plugin passes it beside --pid-file and shows the content in "
+            "the dock instead of a bare proof timeout."
+        ),
+    )
+    parser.add_argument(
         "--owner-pid",
         type=int,
         default=None,
@@ -251,7 +265,7 @@ def main(argv: Sequence[str] | None = None) -> None:
 
     ## #421: parse --allow-host CIDRs. A typo here fails loudly at startup
     ## rather than silently binding loopback-only (or worse, wide open).
-    from godot_ai.transport.origin_guard import bind_host_for_networks, parse_allow_hosts
+    from godot_ai.transport.origin_guard import parse_allow_hosts
 
     try:
         allow_host_networks = parse_allow_hosts(args.allow_host or [])
@@ -270,6 +284,8 @@ def main(argv: Sequence[str] | None = None) -> None:
             parser.error("--owner-pid requires an HTTP transport")
         if args.pid_file is not None:
             parser.error("--pid-file requires an HTTP transport")
+        if args.startup_report is not None:
+            parser.error("--startup-report requires an HTTP transport")
         from godot_ai.attach.main import main as attach_main
 
         attach_args = ["--port", str(args.port), "--ws-port", str(args.ws_port)]
@@ -284,6 +300,28 @@ def main(argv: Sequence[str] | None = None) -> None:
         capabilities = launch_capabilities_from_env()
     except ValueError as exc:
         parser.error(str(exc))
+
+    from godot_ai.runtime_info import install_startup_report, report_startup_failure
+
+    install_startup_report(args.startup_report)
+    try:
+        _serve(args, capabilities, exclude_domains, allow_host_networks)
+    except BaseException as exc:
+        ## Anything that escapes before the capability record is published is
+        ## invisible to the editor otherwise (the report is disarmed once the
+        ## record exists, so runtime faults are not misreported as startup).
+        if not isinstance(exc, KeyboardInterrupt):
+            report_startup_failure(exc)
+        raise
+
+
+def _serve(
+    args: argparse.Namespace,
+    capabilities: Any,
+    exclude_domains: Any,
+    allow_host_networks: Any,
+) -> None:
+    from godot_ai.transport.origin_guard import bind_host_for_networks
 
     ## Widen the HTTP bind off loopback only when an allowlist is named. The
     ## DNS-rebinding guard still gates every request by the CIDR(s); binding

--- a/src/godot_ai/attach/ensure.py
+++ b/src/godot_ai/attach/ensure.py
@@ -181,7 +181,9 @@ def user_runtime_dir() -> Path:
             f"Choose a private directory owned by your user with {RUNTIME_DIR_ENV}, "
             "or correct the directory ownership and permissions."
         )
-        if os.name == "nt" and isinstance(exc, PermissionError):
+        ## The destructive repair is only ever offered for our own default
+        ## location; a GODOT_AI_RUNTIME_DIR override is the user's directory.
+        if os.name == "nt" and isinstance(exc, PermissionError) and not override:
             hint = windows_repair_hint(path)
         raise AttachStartupError(
             "ATTACH_RUNTIME_DIR_ERROR",

--- a/src/godot_ai/attach/ensure.py
+++ b/src/godot_ai/attach/ensure.py
@@ -31,11 +31,13 @@ from godot_ai.transport.capability import (
     HTTP_CAPABILITY_ENV,
     WS_CAPABILITY_ENV,
     LaunchCapabilities,
+    directory_access_error,
     generate_capabilities,
     read_capabilities,
     validate_capability,
     validate_instance_nonce,
     validate_launch_capabilities,
+    windows_repair_hint,
 )
 
 DEFAULT_HTTP_PORT = 8000
@@ -175,13 +177,16 @@ def user_runtime_dir() -> Path:
             if stat.S_IMODE(path.lstat().st_mode) != 0o700:
                 raise OSError(errno.EACCES, "runtime directory mode is not 0700", str(path))
     except OSError as exc:
+        hint = (
+            f"Choose a private directory owned by your user with {RUNTIME_DIR_ENV}, "
+            "or correct the directory ownership and permissions."
+        )
+        if os.name == "nt" and isinstance(exc, PermissionError):
+            hint = windows_repair_hint(path)
         raise AttachStartupError(
             "ATTACH_RUNTIME_DIR_ERROR",
             f"Cannot use attach runtime directory {path}: {exc}.",
-            hint=(
-                f"Choose a private directory owned by your user with {RUNTIME_DIR_ENV}, "
-                "or correct the directory ownership and permissions."
-            ),
+            hint=hint,
             data={"path": str(path), "errno": exc.errno},
         ) from exc
     return path.resolve()
@@ -665,6 +670,12 @@ class BackendEnsurer:
             if self._port_check(self.port):
                 return None
             if time.monotonic() >= deadline:
+                ## A listener that never answers an authenticated probe is
+                ## usually a godot-ai backend whose record this account cannot
+                ## read (#988): say so rather than blaming a foreign process.
+                access_problem = directory_access_error()
+                if access_problem:
+                    raise _capability_directory_inaccessible(self.port, access_problem)
                 raise _foreign_occupant(
                     self.port, "listener did not answer the godot-ai status probe"
                 )
@@ -700,6 +711,16 @@ class BackendEnsurer:
                 },
             )
         return status
+
+
+def _capability_directory_inaccessible(port: int, repair: str) -> AttachStartupError:
+    return AttachStartupError(
+        "CAPABILITY_DIR_INACCESSIBLE",
+        f"Port {port} is bound, but this account cannot read the godot-ai capability directory.",
+        hint=repair,
+        exit_code=98,
+        data={"port": port},
+    )
 
 
 def _foreign_occupant(port: int, detail: str) -> AttachStartupError:

--- a/src/godot_ai/release_verify.py
+++ b/src/godot_ai/release_verify.py
@@ -19,6 +19,8 @@ import zipfile
 from pathlib import Path
 from typing import Any, NoReturn
 
+from godot_ai.transport.capability import private_mkdir
+
 REPOSITORY = "hi-godot/godot-ai"
 ASSET_NAME = "godot-ai-v4-plugin.zip"
 MANIFEST_NAME = "godot-ai-v4-plugin.manifest.json"
@@ -492,13 +494,25 @@ def _verify_installed_tree(root: Path, manifest: dict[str, Any]) -> None:
         _fail("installed v4 tree", "files do not exactly match the signed inventory")
 
 
+def _private_mkdir_parents(directory: Path) -> None:
+    """``mkdir -p`` for a staged plugin path, one private directory at a time."""
+
+    missing: list[Path] = []
+    current = directory
+    while not current.exists():
+        missing.append(current)
+        current = current.parent
+    for path in reversed(missing):
+        private_mkdir(path)
+
+
 def _extract_verified_archive(archive_data: bytes, destination: Path) -> Path:
     plugin_root = destination / "addons" / "godot_ai"
     try:
         with zipfile.ZipFile(io.BytesIO(archive_data)) as archive:
             for info in archive.infolist():
                 target = plugin_root.joinpath(*info.filename[len(PLUGIN_PREFIX) :].split("/"))
-                target.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+                _private_mkdir_parents(target.parent)
                 flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
                 descriptor = os.open(target, flags, 0o600)
                 with os.fdopen(descriptor, "wb") as handle:
@@ -543,7 +557,7 @@ def stage_verified_release(
     )
     if os.path.lexists(destination):
         _fail("staging", "destination already exists")
-    destination.mkdir(mode=0o700)
+    private_mkdir(destination)
     _sync_directory(destination.parent)
     try:
         plugin = _extract_verified_archive(archive_data, destination)

--- a/src/godot_ai/runtime_info.py
+++ b/src/godot_ai/runtime_info.py
@@ -11,10 +11,72 @@ PID from the file and doesn't care whether we cleaned up.
 from __future__ import annotations
 
 import atexit
+import json
 import os
 from pathlib import Path
 
 _PID_FILE_PATH: Path | None = None
+_STARTUP_REPORT_PATH: Path | None = None
+_STARTUP_REPORT_WRITTEN = False
+_STARTUP_REPORT_MAX_CHARS = 2000
+
+
+def install_startup_report(path: str | os.PathLike[str] | None) -> Path | None:
+    """Remember where a startup failure should be reported.
+
+    The plugin passes ``--startup-report <absolute path>`` beside the pid
+    file and removes any stale report before it spawns us, so a report that
+    exists after a launch was written by that launch. Nothing is written
+    here; :func:`report_startup_failure` writes only when startup fails
+    before the capability record is published, which is exactly the window
+    the plugin otherwise sees as "exited before publishing capabilities".
+    """
+    global _STARTUP_REPORT_PATH, _STARTUP_REPORT_WRITTEN
+    _STARTUP_REPORT_PATH = Path(path).expanduser() if path else None
+    _STARTUP_REPORT_WRITTEN = False
+    return _STARTUP_REPORT_PATH
+
+
+def startup_report_path() -> Path | None:
+    return _STARTUP_REPORT_PATH
+
+
+def disarm_startup_report() -> None:
+    """Stop reporting: the capability record is published, startup is over."""
+    global _STARTUP_REPORT_PATH
+    _STARTUP_REPORT_PATH = None
+
+
+def report_startup_failure(exc: BaseException, *, hint: str = "") -> Path | None:
+    """Write ``exc`` to the startup report so the editor dock can show it.
+
+    The first report wins: a site that knows the cause (the port preflight,
+    the capability directory) reports a specific message before the generic
+    exception reaches ``main``'s catch-all. Best effort: a report that
+    cannot be written must never mask the failure it describes, so every
+    error here is swallowed.
+    """
+    global _STARTUP_REPORT_WRITTEN
+    path = _STARTUP_REPORT_PATH
+    if path is None or _STARTUP_REPORT_WRITTEN:
+        return None
+    if isinstance(exc, SystemExit) and not isinstance(exc.code, str):
+        message = f"exited with code {exc.code}"
+    else:
+        message = str(exc).strip() or exc.__class__.__name__
+    payload = {
+        "pid": os.getpid(),
+        "error": exc.__class__.__name__,
+        "message": message[:_STARTUP_REPORT_MAX_CHARS],
+        "hint": hint[:_STARTUP_REPORT_MAX_CHARS],
+    }
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=True) + "\n", encoding="utf-8")
+    except OSError:
+        return None
+    _STARTUP_REPORT_WRITTEN = True
+    return path
 
 
 def install_pid_file(path: str | os.PathLike[str] | None) -> Path | None:

--- a/src/godot_ai/server.py
+++ b/src/godot_ai/server.py
@@ -60,6 +60,7 @@ from godot_ai.resources.project import register_project_resources
 from godot_ai.resources.scenes import register_scene_resources
 from godot_ai.resources.scripts import register_script_resources
 from godot_ai.resources.sessions import register_session_resources
+from godot_ai.runtime_info import disarm_startup_report, report_startup_failure
 from godot_ai.services.custom_tool_service import CustomToolService
 from godot_ai.services.promoted_tools import PromotedToolRegistrar
 from godot_ai.sessions.registry import SessionRegistry
@@ -459,10 +460,17 @@ def create_server(
                 break
             except PortClaimUnavailable as exc:
                 if loop.time() >= claim_deadline:
-                    raise RuntimeError(
+                    claimed = RuntimeError(
                         f"HTTP port {http_port} is already claimed by another godot-ai server"
-                    ) from exc
+                    )
+                    report_startup_failure(claimed)
+                    raise claimed from exc
                 await asyncio.sleep(0.05)
+            except OSError as exc:
+                ## The claim lives in the capability directory; a directory
+                ## this account cannot use fails here, before any listener.
+                report_startup_failure(exc)
+                raise
 
         ws_task = asyncio.create_task(ws_server.start())
         logger.info("WebSocket server starting on port %d", ws_server.port)
@@ -474,7 +482,14 @@ def create_server(
                 capabilities.websocket,
                 instance_nonce=SERVER_INSTANCE_ID,
             )
-        except BaseException:
+            ## Published: from here on a failure is a runtime fault the
+            ## plugin sees through the authenticated status route.
+            disarm_startup_report()
+        except BaseException as exc:
+            ## Uvicorn swallows a lifespan startup failure into a log line and
+            ## an exit code; the report is how the editor learns the cause.
+            if not isinstance(exc, asyncio.CancelledError):
+                report_startup_failure(exc)
             ws_task.cancel()
             try:
                 await ws_task

--- a/src/godot_ai/transport/capability.py
+++ b/src/godot_ai/transport/capability.py
@@ -280,13 +280,25 @@ def private_mkdir(path: Path, *, windows: bool | None = None) -> None:
 
 
 def windows_repair_hint(directory: Path) -> str:
-    """How a user repairs a capability directory their account cannot use."""
+    """How a user repairs a private directory their account cannot use.
 
-    root = directory
+    The destructive step (remove the ``godot-ai`` tree and let it be
+    recreated) is offered only for a path inside a directory named
+    ``godot-ai``, which is the layout we create under ``%LOCALAPPDATA%``.
+    A path the user chose themselves gets non-destructive guidance.
+    """
+
+    root = None
     for candidate in (directory, *directory.parents):
         if candidate.name == "godot-ai":
             root = candidate
             break
+    if root is None:
+        return (
+            f"Godot AI cannot use the directory {directory}: this Windows account "
+            "has no access to it. Grant your account full control of that "
+            "directory, or point Godot AI at a directory your account owns."
+        )
     return (
         f"Godot AI cannot use its private directory {directory}: this Windows "
         "account has no access to it, which happens when it was first created "

--- a/src/godot_ai/transport/capability.py
+++ b/src/godot_ai/transport/capability.py
@@ -261,6 +261,78 @@ def _reject_unsafe_posix_ancestors(path: Path) -> Path:
     return current
 
 
+def private_mkdir(path: Path, *, windows: bool | None = None) -> None:
+    """Create one directory that only this user can read.
+
+    POSIX gets mode ``0o700``. Windows deliberately gets no mode: CPython
+    (3.12.4+, 3.13) turns ``mode=0o700`` into a non-inherited DACL holding
+    only SYSTEM, Administrators and OWNER RIGHTS. When the creating process
+    was elevated the owner is the Administrators group, so the user's own
+    unelevated editor, server and bridge can no longer read or write the
+    directory (#988). Inheriting ``%LOCALAPPDATA%``'s per-user DACL is what
+    makes the directory private on Windows.
+    """
+    on_windows = os.name == "nt" if windows is None else windows
+    if on_windows:
+        path.mkdir(exist_ok=True)
+    else:
+        path.mkdir(mode=0o700, exist_ok=True)
+
+
+def windows_repair_hint(directory: Path) -> str:
+    """How a user repairs a capability directory their account cannot use."""
+
+    root = directory
+    for candidate in (directory, *directory.parents):
+        if candidate.name == "godot-ai":
+            root = candidate
+            break
+    return (
+        f"Godot AI cannot use its private directory {directory}: this Windows "
+        "account has no access to it, which happens when it was first created "
+        "by an elevated (Run as administrator) process. Close Godot and every "
+        "AI client, then from an elevated PowerShell run: "
+        f'Remove-Item -Recurse -Force "{root}" ; reopen the project unelevated '
+        "and the directory is recreated with your account's permissions."
+    )
+
+
+def _windows_access_probe(directory: Path) -> OSError | None:
+    """Return the error a write into ``directory`` raises for this account."""
+
+    probe = directory / f".access-probe.{os.getpid()}.{secrets.token_hex(4)}"
+    try:
+        fd = os.open(probe, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except OSError as exc:
+        return exc
+    os.close(fd)
+    try:
+        probe.unlink()
+    except OSError:
+        pass
+    return None
+
+
+def directory_access_error(directory: Path | None = None) -> str | None:
+    """A repair message when this account cannot use the capability directory.
+
+    Windows only; ``None`` on POSIX, when the directory does not exist yet,
+    or when a write probe succeeds. Used by the bridge to explain an
+    unanswered status probe and by the server before it publishes.
+    """
+    if os.name != "nt":
+        return None
+    selected = Path(directory).expanduser() if directory is not None else capability_directory()
+    try:
+        if not selected.exists():
+            return None
+    except OSError:
+        return windows_repair_hint(selected)
+    if _windows_access_probe(selected) is None:
+        return None
+    return windows_repair_hint(selected)
+
+
 def _prepare_directory(directory: Path) -> None:
     if os.name != "nt":
         if not directory.is_absolute():
@@ -269,11 +341,16 @@ def _prepare_directory(directory: Path) -> None:
     _reject_link_components(directory)
     missing: list[Path] = []
     current = directory
-    while not current.exists():
-        missing.append(current)
-        current = current.parent
-    for path in reversed(missing):
-        path.mkdir(mode=0o700, exist_ok=True)
+    try:
+        while not current.exists():
+            missing.append(current)
+            current = current.parent
+        for path in reversed(missing):
+            private_mkdir(path)
+    except PermissionError as exc:
+        if os.name == "nt":
+            raise OSError(errno.EACCES, windows_repair_hint(directory), directory) from exc
+        raise
     if os.name != "nt":
         _reject_unsafe_posix_ancestors(directory)
     _reject_link_components(directory)
@@ -286,6 +363,8 @@ def _prepare_directory(directory: Path) -> None:
         directory.chmod(0o700)
         if stat.S_IMODE(directory.lstat().st_mode) != 0o700:
             raise OSError(errno.EACCES, "capability directory mode is not 0700", directory)
+    elif _windows_access_probe(directory) is not None:
+        raise OSError(errno.EACCES, windows_repair_hint(directory), directory)
 
 
 def acquire_port_claim(http_port: int, directory: Path | None = None) -> PortClaim:

--- a/test_project/tests/test_port_resolver.gd
+++ b/test_project/tests/test_port_resolver.gd
@@ -279,3 +279,38 @@ func test_find_all_pids_sees_live_listener_via_netstat_windows() -> void:
 	holder.stop()
 	assert_true(pids.has(OS.get_process_id()), "the editor's own listener should be reported")
 	assert_false(counters.has("powershell"), "netstat found the listener; PowerShell must not run")
+
+
+# ----- command-line brand ----------------------------------------------
+
+func test_brand_ignores_paths_the_plugin_chose_itself() -> void:
+	## The pid-file and startup-report values live under user:// and carry our
+	## name; a foreign command must not pass the brand because of them.
+	var unbranded := (
+		"C:/tools/python.exe -I C:/scratch/selector.py --transport streamable-http "
+		+ "--pid-file C:/u/godot_ai_server.pid --startup-report C:/u/godot_ai_server_startup.json"
+	)
+	assert_false(McpPortResolver.commandline_is_godot_ai_server(unbranded))
+	var branded := (
+		"C:/tools/python.exe -m godot_ai --transport streamable-http "
+		+ "--pid-file C:/u/godot_ai_server.pid --startup-report C:/u/godot_ai_server_startup.json"
+	)
+	assert_true(McpPortResolver.commandline_is_godot_ai_server(branded))
+	assert_true(McpPortResolver.commandline_is_godot_ai_server(
+		"/opt/venv/bin/godot-ai --transport streamable-http --startup-report=/tmp/r.json"
+	))
+	assert_false(McpPortResolver.commandline_is_godot_ai_server("python -m something --transport x"))
+
+
+func test_kill_grant_capture_names_the_check_that_refused() -> void:
+	var diagnostics: Array = []
+	assert_true(McpPortResolver.capture_process_kill_grant(0, true, diagnostics).is_empty())
+	assert_eq(diagnostics, ["invalid_pid"])
+	diagnostics.clear()
+	## The editor's own pid is refused before any probe runs.
+	assert_true(McpPortResolver.capture_process_kill_grant(OS.get_process_id(), true, diagnostics).is_empty())
+	assert_eq(diagnostics, ["invalid_pid"])
+	diagnostics.clear()
+	## An implausible pid is not alive.
+	assert_true(McpPortResolver.capture_process_kill_grant(2147480000, true, diagnostics).is_empty())
+	assert_eq(diagnostics, ["not_alive"])

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -594,3 +594,64 @@ func test_replacement_target_match_is_instance_and_version_bound() -> void:
 	assert_true(Lifecycle._replacement_target_matches(target, live, record))
 	live.instance_id = "c".repeat(32)
 	assert_false(Lifecycle._replacement_target_matches(target, live, record))
+
+
+func test_unwritable_capability_directory_blocks_the_launch_with_its_repair() -> void:
+	var manager := _manager()
+	manager.start_server()
+	var episode := manager.episode_snapshot()
+	manager.complete_effect(episode.id, Lifecycle.PROBE, {"outcome": "free", "baseline_instance_id": ""})
+	episode = manager.episode_snapshot()
+	var repair := "Godot AI cannot use its private directory C:/x; run Remove-Item"
+	assert_true(manager.complete_effect(episode.id, Lifecycle.LAUNCH, {
+		"ok": false, "reason": "capability_dir_unwritable", "message": repair,
+	}))
+	var snapshot := manager.episode_snapshot()
+	assert_eq(snapshot.state, Lifecycle.BLOCKED)
+	assert_eq(snapshot.reason, "capability_dir_unwritable")
+	assert_eq(snapshot.message, repair)
+	assert_eq(manager.get_server_pid(), -1, "nothing was spawned")
+
+
+func test_server_flags_carry_the_startup_report_path() -> void:
+	var flags := Lifecycle._server_flags({
+		"http_port": 8000, "ws_port": 9500, "pid_file": "/tmp/p.pid", "startup_report": "/tmp/r.json",
+	})
+	var index := flags.find("--startup-report")
+	assert_true(index >= 0, "flag present: %s" % str(flags))
+	assert_eq(flags[index + 1], "/tmp/r.json")
+	var without := Lifecycle._server_flags({"http_port": 8000, "ws_port": 9500, "pid_file": "/tmp/p.pid"})
+	assert_false(without.has("--startup-report"))
+
+
+func test_startup_report_summary_quotes_the_server_failure() -> void:
+	var path := OS.get_user_data_dir().path_join("lifecycle_startup_report_test.json")
+	var file := FileAccess.open(path, FileAccess.WRITE)
+	file.store_string(
+		'{"pid": 1, "error": "PermissionError", "message": "denied\\nsecond", "hint": "run Remove-Item"}'
+	)
+	file.close()
+	assert_eq(
+		Lifecycle.startup_report_summary(path),
+		" Server reported: PermissionError: denied second run Remove-Item"
+	)
+	assert_true(Lifecycle.startup_report_summary(path, 30).length() <= 30, "bounded")
+	file = FileAccess.open(path, FileAccess.WRITE)
+	file.store_string("not json")
+	file.close()
+	assert_eq(Lifecycle.startup_report_summary(path), "")
+	DirAccess.remove_absolute(path)
+	assert_eq(Lifecycle.startup_report_summary(path), "")
+	assert_eq(Lifecycle.startup_report_summary(""), "")
+
+
+func test_launch_unproven_message_summarises_the_refusals() -> void:
+	var message := Lifecycle._launch_unproven_message(
+		2147480000, ["not_alive", "not_alive", "unbranded"], 15200
+	)
+	assert_true(message.contains("3 attempts over 15.2 s"), message)
+	assert_true(message.contains("pid 2147480000"), message)
+	assert_true(message.contains("now alive=no"), message)
+	assert_true(message.contains("not_alive×2, unbranded×1"), message)
+	var empty := Lifecycle._launch_unproven_message(2147480000, [], 0)
+	assert_true(empty.contains("none recorded"), empty)

--- a/test_project/tests/test_transport_capability.gd
+++ b/test_project/tests/test_transport_capability.gd
@@ -361,3 +361,36 @@ func _private_record_in(directory: String) -> String:
 func _remove_private_record_in(directory: String) -> void:
 	DirAccess.remove_absolute(directory.path_join("http-8122.json"))
 	DirAccess.remove_absolute(directory)
+
+
+func test_directory_write_problem_is_empty_for_a_writable_directory() -> void:
+	var directory := _scratch_dir.path_join("writable")
+	assert_eq(McpTransportCapability.directory_write_problem_for(directory), "")
+	assert_true(DirAccess.dir_exists_absolute(directory), "the probe creates the directory")
+	assert_eq(DirAccess.get_files_at(directory).size(), 0, "the probe file is removed")
+	DirAccess.remove_absolute(directory)
+
+
+func test_directory_write_problem_names_the_directory_and_the_repair() -> void:
+	## A regular file where the directory must go fails creation on every OS,
+	## standing in for the Administrators-owned directory of #988.
+	var blocker := _scratch_dir.path_join("godot-ai")
+	var file := FileAccess.open(blocker, FileAccess.WRITE)
+	file.store_string("x")
+	file.close()
+	var directory := blocker.path_join("capabilities")
+	var problem := McpTransportCapability.directory_write_problem_for(directory)
+	assert_true(problem.contains(directory), "names the directory: %s" % problem)
+	assert_true(
+		problem.contains("Remove-Item -Recurse -Force \"%s\"" % blocker),
+		"names the godot-ai root to remove: %s" % problem
+	)
+	assert_true(problem.contains("elevated"), "explains the cause: %s" % problem)
+	DirAccess.remove_absolute(blocker)
+
+
+func test_directory_write_problem_is_windows_only() -> void:
+	if OS.get_name() == "Windows":
+		skip("POSIX leaves capability directory creation to the server")
+		return
+	assert_eq(McpTransportCapability.directory_write_problem(8122), "")

--- a/tests/integration/_self_update_fixture.py
+++ b/tests/integration/_self_update_fixture.py
@@ -1038,6 +1038,13 @@ func _update_candidate_ready() -> bool:
 func _observe_automatic_repin() -> void:
 \tif not DriverSupport.client_config_has_pin(NEXT_VERSION):
 \t\treturn
+\t## The migration worker rewrites the client file before the main thread
+\t## records completion and releases startup. Report only once the plugin
+\t## has released, so this marker follows "client migration completed" on
+\t## every platform rather than by scheduling luck.
+\tvar plugin := DriverSupport.find_godot_ai_plugin()
+\tif plugin == null or not bool(plugin.get("_normal_start_released")):
+\t\treturn
 \tprint("SELF_UPDATE_TEST | repinned Codex command pin=%s" % NEXT_VERSION)
 \t_repin_observed = true
 

--- a/tests/integration/test_client_owner_restarts.py
+++ b/tests/integration/test_client_owner_restarts.py
@@ -21,6 +21,10 @@ from tests.integration._self_update_fixture import (
     run_godot_editor,
 )
 
+## Needs a real Godot editor (GODOT_BIN); skipped without one and excluded
+## from the iteration loop by `pytest -m "not editor"`.
+pytestmark = pytest.mark.editor
+
 PROBE = '''@tool
 extends EditorPlugin
 
@@ -145,6 +149,29 @@ def test_codex_workers_complete_after_two_ordinary_editor_restarts(tmp_path: Pat
     assert len(set(pids)) == 3, pids
 
 
+def _stop_process_tree(process: subprocess.Popen) -> None:
+    """Stop the backend and everything it spawned.
+
+    A uv-created venv's Windows ``python.exe`` is a launcher whose real
+    interpreter runs as a child. ``terminate()`` alone kills the launcher and
+    leaves the server alive, still holding the capability lock, which then
+    fails the unlink below and leaks a listener into the next boot.
+    """
+    if os.name == "nt":
+        subprocess.run(
+            ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+            capture_output=True,
+            check=False,
+        )
+    else:
+        process.terminate()
+    try:
+        process.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=5)
+
+
 async def test_native_capability_record_survives_backend_restarts(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -195,12 +222,7 @@ async def test_native_capability_record_survives_backend_restarts(
                 instances.append(first.instance_id)
                 print(f"NATIVE_BACKEND_{boot}: record readable; two authenticated adoptions passed")
             finally:
-                process.terminate()
-                try:
-                    process.wait(timeout=10)
-                except subprocess.TimeoutExpired:
-                    process.kill()
-                    process.wait(timeout=5)
+                _stop_process_tree(process)
         # Windows TerminateProcess does not run Python lifespan cleanup.
         path.unlink(missing_ok=True)
         path.with_suffix(".lock").unlink(missing_ok=True)

--- a/tests/integration/test_godot_editor_restart.py
+++ b/tests/integration/test_godot_editor_restart.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from tests.integration._self_update_fixture import godot_bin_or_skip, run_godot_editor
+
+## Needs a real Godot editor (GODOT_BIN); skipped without one and excluded
+## from the iteration loop by `pytest -m "not editor"`.
+pytestmark = pytest.mark.editor
 
 
 def test_headless_editor_restart_preserves_display_driver(tmp_path: Path) -> None:

--- a/tests/integration/test_migration_bridge_failures.py
+++ b/tests/integration/test_migration_bridge_failures.py
@@ -17,6 +17,10 @@ from tests.integration._self_update_fixture import (
     run_godot_editor,
 )
 
+## Needs a real Godot editor (GODOT_BIN); skipped without one and excluded
+## from the iteration loop by `pytest -m "not editor"`.
+pytestmark = pytest.mark.editor
+
 INSTALLER_SCRIPTS = (
     "release_verifier.gd",
     "update_installer.gd",

--- a/tests/integration/test_plugin_reload_persistence.py
+++ b/tests/integration/test_plugin_reload_persistence.py
@@ -12,6 +12,10 @@ from tests.integration._self_update_fixture import (
     run_godot_editor,
 )
 
+## Needs a real Godot editor (GODOT_BIN); skipped without one and excluded
+## from the iteration loop by `pytest -m "not editor"`.
+pytestmark = pytest.mark.editor
+
 PLUGIN = '''@tool
 extends EditorPlugin
 

--- a/tests/integration/test_qualification_https.py
+++ b/tests/integration/test_qualification_https.py
@@ -19,6 +19,10 @@ from tests.integration._self_update_fixture import (
     read_plugin_version,
 )
 
+## Needs a real Godot editor (GODOT_BIN); skipped without one and excluded
+## from the iteration loop by `pytest -m "not editor"`.
+pytestmark = pytest.mark.editor
+
 DRIVER = """extends SceneTree
 
 var certificate := X509Certificate.new()

--- a/tests/integration/test_runtime_qualification_driver.py
+++ b/tests/integration/test_runtime_qualification_driver.py
@@ -1,8 +1,14 @@
 import shutil
 import subprocess
 
+import pytest
+
 from script import runtime_qualification as runtime
 from tests.integration._self_update_fixture import PLUGIN_ROOT, godot_bin_or_skip
+
+## Needs a real Godot editor (GODOT_BIN); skipped without one and excluded
+## from the iteration loop by `pytest -m "not editor"`.
+pytestmark = pytest.mark.editor
 
 
 def test_external_exact_candidate_driver_parses_in_real_godot(tmp_path):

--- a/tests/integration/test_self_update_upgrade_paths.py
+++ b/tests/integration/test_self_update_upgrade_paths.py
@@ -64,6 +64,10 @@ from tests.integration._self_update_fixture import (
     write_refused_swap_driver,
 )
 
+## Needs a real Godot editor (GODOT_BIN); skipped without one and excluded
+## from the iteration loop by `pytest -m "not editor"`.
+pytestmark = pytest.mark.editor
+
 
 def _tree_bytes(root: Path) -> dict[str, bytes]:
     return {

--- a/tests/integration/test_test_run_cache_warning.py
+++ b/tests/integration/test_test_run_cache_warning.py
@@ -6,7 +6,13 @@ import shutil
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from tests.integration._self_update_fixture import godot_bin_or_skip, run_godot_editor
+
+## Needs a real Godot editor (GODOT_BIN); skipped without one and excluded
+## from the iteration loop by `pytest -m "not editor"`.
+pytestmark = pytest.mark.editor
 
 ROOT = Path(__file__).resolve().parents[2]
 

--- a/tests/unit/test_attach_ensure.py
+++ b/tests/unit/test_attach_ensure.py
@@ -1250,5 +1250,26 @@ def test_user_runtime_dir_windows_permission_error_carries_the_repair_hint(
         user_runtime_dir()
 
     assert exc_info.value.code == "ATTACH_RUNTIME_DIR_ERROR"
+    ## An override names the user's own directory: never suggest deleting it.
+    assert "Remove-Item" not in exc_info.value.hint
+    assert ensure_module.RUNTIME_DIR_ENV in exc_info.value.hint
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows repair hint")
+def test_default_runtime_dir_permission_error_carries_the_destructive_repair(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv(ensure_module.RUNTIME_DIR_ENV, raising=False)
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+
+    def deny(self, *_args, **_kwargs):
+        raise PermissionError(13, "denied", str(self))
+
+    monkeypatch.setattr(Path, "mkdir", deny)
+
+    with pytest.raises(AttachStartupError) as exc_info:
+        user_runtime_dir()
+
+    assert exc_info.value.code == "ATTACH_RUNTIME_DIR_ERROR"
     assert "Remove-Item" in exc_info.value.hint
     assert str(tmp_path / "godot-ai") in exc_info.value.hint

--- a/tests/unit/test_attach_ensure.py
+++ b/tests/unit/test_attach_ensure.py
@@ -1234,12 +1234,12 @@ async def test_unanswered_listener_with_a_usable_directory_stays_port_occupied(
     assert exc_info.value.code == "PORT_OCCUPIED"
 
 
+@pytest.mark.skipif(os.name != "nt", reason="Windows repair hint; faking os.name breaks pathlib")
 def test_user_runtime_dir_windows_permission_error_carries_the_repair_hint(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     runtime = tmp_path / "godot-ai" / "runtime"
     monkeypatch.setenv(ensure_module.RUNTIME_DIR_ENV, str(runtime))
-    monkeypatch.setattr(ensure_module.os, "name", "nt")
 
     def deny(self, *_args, **_kwargs):
         raise PermissionError(13, "denied", str(self))

--- a/tests/unit/test_attach_ensure.py
+++ b/tests/unit/test_attach_ensure.py
@@ -1183,3 +1183,72 @@ import godot_ai.orphan_reaper
         check=False,
     )
     assert completed.returncode == 0, completed.stderr
+
+
+async def test_unanswered_listener_names_an_inaccessible_capability_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#988: a bound port whose record this account cannot read is not a foreign process."""
+    monkeypatch.setattr(ensure_module, "directory_access_error", lambda: "run Remove-Item")
+
+    async def probe(_port: int, *_args) -> BackendStatus | None:
+        return None
+
+    ensurer = BackendEnsurer(
+        probe=probe,
+        spawn=lambda *_args: pytest.fail("must not spawn"),  # type: ignore[arg-type,return-value]
+        port_check=lambda _port: False,
+        runtime_dir=tmp_path,
+        health_timeout_seconds=0.01,
+        poll_seconds=0.001,
+    )
+
+    with pytest.raises(AttachStartupError) as exc_info:
+        await ensurer.ensure()
+
+    assert exc_info.value.code == "CAPABILITY_DIR_INACCESSIBLE"
+    assert exc_info.value.hint == "run Remove-Item"
+    assert exc_info.value.exit_code == 98
+
+
+async def test_unanswered_listener_with_a_usable_directory_stays_port_occupied(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(ensure_module, "directory_access_error", lambda: None)
+
+    async def probe(_port: int, *_args) -> BackendStatus | None:
+        return None
+
+    ensurer = BackendEnsurer(
+        probe=probe,
+        spawn=lambda *_args: pytest.fail("must not spawn"),  # type: ignore[arg-type,return-value]
+        port_check=lambda _port: False,
+        runtime_dir=tmp_path,
+        health_timeout_seconds=0.01,
+        poll_seconds=0.001,
+    )
+
+    with pytest.raises(AttachStartupError) as exc_info:
+        await ensurer.ensure()
+
+    assert exc_info.value.code == "PORT_OCCUPIED"
+
+
+def test_user_runtime_dir_windows_permission_error_carries_the_repair_hint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = tmp_path / "godot-ai" / "runtime"
+    monkeypatch.setenv(ensure_module.RUNTIME_DIR_ENV, str(runtime))
+    monkeypatch.setattr(ensure_module.os, "name", "nt")
+
+    def deny(self, *_args, **_kwargs):
+        raise PermissionError(13, "denied", str(self))
+
+    monkeypatch.setattr(Path, "mkdir", deny)
+
+    with pytest.raises(AttachStartupError) as exc_info:
+        user_runtime_dir()
+
+    assert exc_info.value.code == "ATTACH_RUNTIME_DIR_ERROR"
+    assert "Remove-Item" in exc_info.value.hint
+    assert str(tmp_path / "godot-ai") in exc_info.value.hint

--- a/tests/unit/test_dev_env.py
+++ b/tests/unit/test_dev_env.py
@@ -41,11 +41,13 @@ def test_find_venv_python_present(monkeypatch, tmp_path):
     exe = _dev_env.venv_python(tmp_path / ".venv")
     exe.parent.mkdir(parents=True)
     exe.write_text("")
+    monkeypatch.setattr(_dev_env, "worktree_root", lambda start=None: tmp_path)
     monkeypatch.setattr(_dev_env, "root_repo", lambda worktree=None: tmp_path)
     assert _dev_env.find_venv_python() == exe
 
 
 def test_find_venv_python_absent(monkeypatch, tmp_path):
+    monkeypatch.setattr(_dev_env, "worktree_root", lambda start=None: tmp_path)
     monkeypatch.setattr(_dev_env, "root_repo", lambda worktree=None: tmp_path)
     assert _dev_env.find_venv_python() is None
 
@@ -55,6 +57,7 @@ def test_find_venv_python_rejects_directory(monkeypatch, tmp_path):
     # handed to execv() — is_file() guards that (exists() would not).
     exe = _dev_env.venv_python(tmp_path / ".venv")
     exe.mkdir(parents=True)
+    monkeypatch.setattr(_dev_env, "worktree_root", lambda start=None: tmp_path)
     monkeypatch.setattr(_dev_env, "root_repo", lambda worktree=None: tmp_path)
     assert _dev_env.find_venv_python() is None
 
@@ -200,8 +203,57 @@ def test_reexec_noop_when_already_in_venv(monkeypatch):
     assert calls == []
 
 
+def test_find_venv_python_prefers_the_worktree_venv(monkeypatch, tmp_path):
+    """A worktree with its own .venv must not re-exec into the main checkout's."""
+    worktree = tmp_path / "worktree"
+    root = tmp_path / "root"
+    for base in (worktree, root):
+        exe = _dev_env.venv_python(base / ".venv")
+        exe.parent.mkdir(parents=True)
+        exe.write_text("")
+    monkeypatch.setattr(_dev_env, "worktree_root", lambda start=None: worktree)
+    monkeypatch.setattr(_dev_env, "root_repo", lambda worktree=None: root)
+    assert _dev_env.find_venv_python() == _dev_env.venv_python(worktree / ".venv")
+    _dev_env.venv_python(worktree / ".venv").unlink()
+    assert _dev_env.find_venv_python() == _dev_env.venv_python(root / ".venv")
+
+
+def test_reexec_on_windows_runs_the_child_and_forwards_its_exit_code(monkeypatch, tmp_path):
+    """Windows has no exec: os.execv returns and the parent exits 0, losing the code."""
+    monkeypatch.delenv("GUARD_NT", raising=False)
+    monkeypatch.setattr(_dev_env, "_is_windows", lambda: True)
+    fake_python = tmp_path / "python.exe"
+    fake_python.write_text("")
+    monkeypatch.setattr(_dev_env, "find_venv_python", lambda worktree=None: fake_python)
+    monkeypatch.setattr(_dev_env.sys, "argv", ["script/stormtest.py", "--flag"])
+    monkeypatch.setattr(
+        _dev_env.os, "execv", lambda *a: pytest.fail("execv must not be used on Windows")
+    )
+    captured = {}
+
+    def fake_run(args, check):
+        captured["args"] = args
+        captured["check"] = check
+
+        class Completed:
+            returncode = 7
+
+        return Completed()
+
+    monkeypatch.setattr(_dev_env.subprocess, "run", fake_run)
+    try:
+        with pytest.raises(SystemExit) as exc_info:
+            _dev_env.reexec_into_venv(guard_env="GUARD_NT")
+    finally:
+        monkeypatch.delenv("GUARD_NT", raising=False)
+    assert exc_info.value.code == 7
+    assert captured["args"] == [str(fake_python), "script/stormtest.py", "--flag"]
+    assert captured["check"] is False
+
+
 def test_reexec_execs_into_venv(monkeypatch, tmp_path):
     monkeypatch.delenv("GUARD_V", raising=False)
+    monkeypatch.setattr(_dev_env, "_is_windows", lambda: False)
     fake_python = tmp_path / "python"
     fake_python.write_text("")
     monkeypatch.setattr(_dev_env, "find_venv_python", lambda worktree=None: fake_python)

--- a/tests/unit/test_editor_marker_contract.py
+++ b/tests/unit/test_editor_marker_contract.py
@@ -1,0 +1,21 @@
+"""Every module that launches a real Godot editor must carry the `editor` marker.
+
+`pytest -m "not editor"` is the documented iteration loop; a new real-editor
+row without the marker would silently put minutes back into it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+TESTS = Path(__file__).resolve().parents[1]
+
+
+def test_real_editor_modules_carry_the_editor_marker() -> None:
+    missing = []
+    for module in sorted((TESTS / "integration").glob("test_*.py")):
+        source = module.read_text(encoding="utf-8")
+        launches_editor = "godot_bin_or_skip" in source or "run_godot_editor" in source
+        if launches_editor and "pytestmark = pytest.mark.editor" not in source:
+            missing.append(module.name)
+    assert missing == [], f"add `pytestmark = pytest.mark.editor` to: {missing}"

--- a/tests/unit/test_post_update_stale_server.py
+++ b/tests/unit/test_post_update_stale_server.py
@@ -105,8 +105,10 @@ def test_owned_launch_waits_boundedly_for_a_stable_branded_process_grant() -> No
     launch = get_func_block(source, "func _effect_launch(payload: Dictionary) -> Dictionary:")
 
     assert "const LAUNCH_FINGERPRINT_TIMEOUT_MS := 15_000" in source
-    assert "Time.get_ticks_msec() + LAUNCH_FINGERPRINT_TIMEOUT_MS" in launch
-    assert "capture_process_kill_grant(pid, true)" in launch
+    assert "capture_started + LAUNCH_FINGERPRINT_TIMEOUT_MS" in launch
+    ## Brand is required on every capture; the trailing list only records why a
+    ## capture was refused and never changes the result.
+    assert launch.count("capture_process_kill_grant(pid, true, attempts)") == 2
     assert (
         "while exact_grant.is_empty() and Time.get_ticks_msec() < fingerprint_deadline:"
         in launch

--- a/tests/unit/test_runtime_info.py
+++ b/tests/unit/test_runtime_info.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import atexit
+import json
 import os
 from pathlib import Path
 
@@ -195,3 +196,97 @@ def test_main_plumbs_pid_file_into_runtime_info(monkeypatch, tmp_path):
         "port": 8123,
         "uvicorn_config": asgi.hardened_uvicorn_config(access_log=False),
     }
+
+
+@pytest.fixture
+def _reset_startup_report():
+    saved = runtime_info._STARTUP_REPORT_PATH
+    yield
+    runtime_info._STARTUP_REPORT_PATH = saved
+
+
+def test_startup_report_is_written_only_while_armed(tmp_path, _reset_startup_report):
+    runtime_info.install_startup_report(None)
+    assert runtime_info.report_startup_failure(RuntimeError("unarmed")) is None
+
+    path = tmp_path / "startup.json"
+    assert runtime_info.install_startup_report(path) == path
+    assert runtime_info.report_startup_failure(PermissionError(13, "denied"), hint="fix") == path
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["pid"] == os.getpid()
+    assert payload["error"] == "PermissionError"
+    assert "denied" in payload["message"]
+    assert payload["hint"] == "fix"
+
+    ## Published: later faults are runtime faults, never startup reports.
+    runtime_info.disarm_startup_report()
+    path.unlink()
+    assert runtime_info.report_startup_failure(RuntimeError("late")) is None
+    assert not path.exists()
+
+
+def test_startup_report_is_bounded_and_never_masks_the_failure(tmp_path, _reset_startup_report):
+    blocker = tmp_path / "not-a-directory"
+    blocker.write_text("x", encoding="utf-8")
+    runtime_info.install_startup_report(blocker / "report.json")
+    assert runtime_info.report_startup_failure(RuntimeError("boom")) is None
+
+    path = tmp_path / "report.json"
+    runtime_info.install_startup_report(path)
+    runtime_info.report_startup_failure(RuntimeError("m" * 5000))
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert len(payload["message"]) == runtime_info._STARTUP_REPORT_MAX_CHARS
+
+
+def test_main_reports_a_startup_failure_before_publication(
+    monkeypatch, tmp_path, _reset_startup_report
+):
+    """A server that dies before its capability record is published tells the dock why."""
+    report = tmp_path / "startup.json"
+
+    def _explode(**_kwargs):
+        raise RuntimeError("capability directory is not writable")
+
+    monkeypatch.setattr("godot_ai.server.create_server", _explode)
+
+    import godot_ai
+
+    monkeypatch.setattr(godot_ai, "preflight_check_port", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(RuntimeError, match="not writable"):
+        godot_ai.main(
+            [
+                "--transport",
+                "streamable-http",
+                "--port",
+                "8123",
+                "--ws-port",
+                "9555",
+                "--startup-report",
+                str(report),
+            ]
+        )
+
+    payload = json.loads(report.read_text(encoding="utf-8"))
+    assert payload["error"] == "RuntimeError"
+    assert "not writable" in payload["message"]
+
+
+def test_first_startup_report_wins_and_system_exit_is_named(tmp_path, _reset_startup_report):
+    path = tmp_path / "startup.json"
+    runtime_info.install_startup_report(path)
+    assert runtime_info.report_startup_failure(OSError(98, "WebSocket port in use")) == path
+    ## The generic catch-all in main() must not overwrite the specific cause.
+    assert runtime_info.report_startup_failure(SystemExit(98)) is None
+    assert "WebSocket port in use" in json.loads(path.read_text(encoding="utf-8"))["message"]
+
+    runtime_info.install_startup_report(path)
+    runtime_info.report_startup_failure(SystemExit(98))
+    assert json.loads(path.read_text(encoding="utf-8"))["message"] == "exited with code 98"
+
+
+def test_startup_report_requires_an_http_transport(_reset_startup_report):
+    import godot_ai
+
+    with pytest.raises(SystemExit):
+        godot_ai.main(["--transport", "stdio", "--startup-report", "x.json"])

--- a/tests/unit/test_transport_capability.py
+++ b/tests/unit/test_transport_capability.py
@@ -443,6 +443,12 @@ def test_windows_repair_hint_names_the_directory_and_the_godot_ai_root(tmp_path)
     assert "elevated" in hint
 
 
+def test_windows_repair_hint_is_non_destructive_outside_a_godot_ai_tree(tmp_path) -> None:
+    hint = capability_module.windows_repair_hint(tmp_path / "custom" / "runtime")
+    assert "Remove-Item" not in hint
+    assert str(tmp_path / "custom" / "runtime") in hint
+
+
 def test_directory_access_error_is_none_when_missing_or_writable(tmp_path) -> None:
     assert capability_module.directory_access_error(tmp_path / "missing") is None
     assert capability_module.directory_access_error(tmp_path) is None

--- a/tests/unit/test_transport_capability.py
+++ b/tests/unit/test_transport_capability.py
@@ -476,12 +476,22 @@ def test_windows_capability_directory_inherits_the_parent_acl(tmp_path) -> None:
     """The regression behind #988: no OWNER RIGHTS-only DACL, inherited ACEs only."""
     directory = tmp_path / "godot-ai" / "capabilities"
     write_capabilities(8122, HTTP, WEBSOCKET, instance_nonce=NONCE, directory=directory)
-    listing = subprocess.run(
-        ["icacls", str(directory)], capture_output=True, text=True, check=True
-    ).stdout
-    ## pytest's own temp root is created with mode 0o700, so an inherited
-    ## OWNER RIGHTS ACE can appear here; what must not appear is an explicit,
-    ## non-inherited ACE, the signature of the 0o700 DACL.
-    aces = [line for line in listing.splitlines() if ":(" in line]
-    assert aces, listing
-    assert all("(I)" in ace for ace in aces), listing
+    ## The DACL a plain mkdir yields in this parent is the environment's
+    ## baseline (a CI temp root may carry explicit, non-inheritable ACEs). The
+    ## capability directory must match it exactly: the 0o700 signature is a
+    ## different, explicit SYSTEM/Administrators/OWNER RIGHTS-only DACL.
+    control = tmp_path / "control"
+    control.mkdir()
+
+    def aces(path: Path) -> list[str]:
+        listing = subprocess.run(
+            ["icacls", str(path)], capture_output=True, text=True, check=True
+        ).stdout
+        return sorted(
+            line.replace(str(path), "").strip()
+            for line in listing.splitlines()
+            if ":(" in line
+        )
+
+    assert aces(directory) == aces(control)
+    assert not any("OWNER RIGHTS" in ace and "(I)" not in ace for ace in aces(directory))

--- a/tests/unit/test_transport_capability.py
+++ b/tests/unit/test_transport_capability.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import errno
 import json
 import os
 import stat
+import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -416,3 +418,70 @@ def test_target_ancestors_are_held_to_the_same_rule(monkeypatch) -> None:
 
     with pytest.raises(OSError, match="unsafe ancestor"):
         capability_module._reject_unsafe_posix_ancestors(Path(f"{FAKE_ROOT}/home/me"))
+
+
+def test_private_mkdir_passes_no_mode_on_windows(tmp_path, monkeypatch) -> None:
+    """CPython turns mode=0o700 into an OWNER RIGHTS-only DACL on Windows (#988)."""
+    modes: list[int] = []
+    real_mkdir = Path.mkdir
+
+    def record(self, mode=0o777, parents=False, exist_ok=False):
+        modes.append(mode)
+        return real_mkdir(self, parents=parents, exist_ok=exist_ok)
+
+    monkeypatch.setattr(Path, "mkdir", record)
+    capability_module.private_mkdir(tmp_path / "windows", windows=True)
+    capability_module.private_mkdir(tmp_path / "posix", windows=False)
+    assert modes == [0o777, 0o700]
+
+
+def test_windows_repair_hint_names_the_directory_and_the_godot_ai_root(tmp_path) -> None:
+    directory = tmp_path / "godot-ai" / "capabilities"
+    hint = capability_module.windows_repair_hint(directory)
+    assert str(directory) in hint
+    assert f'Remove-Item -Recurse -Force "{tmp_path / "godot-ai"}"' in hint
+    assert "elevated" in hint
+
+
+def test_directory_access_error_is_none_when_missing_or_writable(tmp_path) -> None:
+    assert capability_module.directory_access_error(tmp_path / "missing") is None
+    assert capability_module.directory_access_error(tmp_path) is None
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows access probe")
+def test_directory_access_error_reports_a_failed_probe(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        capability_module, "_windows_access_probe", lambda _d: PermissionError(13, "denied")
+    )
+    hint = capability_module.directory_access_error(tmp_path)
+    assert hint is not None
+    assert str(tmp_path) in hint
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows access probe")
+def test_publishing_into_an_unwritable_directory_raises_the_repair_hint(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        capability_module, "_windows_access_probe", lambda _d: PermissionError(13, "denied")
+    )
+    with pytest.raises(OSError) as exc_info:
+        write_capabilities(8122, HTTP, WEBSOCKET, instance_nonce=NONCE, directory=tmp_path)
+    assert exc_info.value.errno == errno.EACCES
+    assert "Remove-Item" in str(exc_info.value)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows DACL inheritance")
+def test_windows_capability_directory_inherits_the_parent_acl(tmp_path) -> None:
+    """The regression behind #988: no OWNER RIGHTS-only DACL, inherited ACEs only."""
+    directory = tmp_path / "godot-ai" / "capabilities"
+    write_capabilities(8122, HTTP, WEBSOCKET, instance_nonce=NONCE, directory=directory)
+    listing = subprocess.run(
+        ["icacls", str(directory)], capture_output=True, text=True, check=True
+    ).stdout
+    ## pytest's own temp root is created with mode 0o700, so an inherited
+    ## OWNER RIGHTS ACE can appear here; what must not appear is an explicit,
+    ## non-inherited ACE, the signature of the 0o700 DACL.
+    aces = [line for line in listing.splitlines() if ":(" in line]
+    assert aces, listing
+    assert all("(I)" in ace for ace in aces), listing

--- a/tests/unit/test_transport_capability.py
+++ b/tests/unit/test_transport_capability.py
@@ -471,10 +471,12 @@ def test_publishing_into_an_unwritable_directory_raises_the_repair_hint(
     monkeypatch.setattr(
         capability_module, "_windows_access_probe", lambda _d: PermissionError(13, "denied")
     )
+    directory = tmp_path / "godot-ai" / "capabilities"
     with pytest.raises(OSError) as exc_info:
-        write_capabilities(8122, HTTP, WEBSOCKET, instance_nonce=NONCE, directory=tmp_path)
+        write_capabilities(8122, HTTP, WEBSOCKET, instance_nonce=NONCE, directory=directory)
     assert exc_info.value.errno == errno.EACCES
     assert "Remove-Item" in str(exc_info.value)
+    assert str(tmp_path / "godot-ai") in str(exc_info.value)
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows DACL inheritance")


### PR DESCRIPTION
## What

Windows users on 4.0.x report the dock stuck on `The managed server proof timed out at capability_record` (#1012) and `godot-ai attach` failing with `PORT_OCCUPIED` against a healthy backend (#988). Both come from the same place: the server creates its private capability directory with `mode=0o700`, and on Windows CPython renders that mode as a non-inherited DACL holding only SYSTEM, Administrators and OWNER RIGHTS. A directory first created by an elevated process is then owned by Administrators, and the user's own unelevated editor, server and bridge can never read or write it. Verified on this machine: `%LOCALAPPDATA%\godot-ai\capabilities` had exactly that DACL, created by our own `mkdir`; it matches the ACL the #988 reporter posted.

A second, general gap made it worse: a plugin-spawned server that dies before publishing its record leaves no trace the dock can show, so every such failure surfaced as the same bare proof timeout.

## Fix

- `transport/capability.py`: `private_mkdir` keeps `0o700` on POSIX and passes no mode on Windows so the directory inherits the per-user `%LOCALAPPDATA%` DACL; `_prepare_directory` probes the directory for write access on Windows and raises the repair (close Godot and clients, elevated `Remove-Item` of the `godot-ai` root, reopen unelevated). `release_verify.py` staging uses the same helper. `directory_access_error` gives the bridge the same diagnosis.
- `attach/ensure.py`: an unanswered status probe on a bound port now reports `CAPABILITY_DIR_INACCESSIBLE` with the repair instead of `PORT_OCCUPIED` when the directory is the problem; the runtime-directory error carries the repair on Windows too.
- Plugin: `McpTransportCapability.directory_write_problem` creates and probes the directory before the spawn (Windows only) and blocks the launch with the repair text instead of a three-minute timeout.
- Startup report: the plugin passes `--startup-report <user://...json>` beside `--pid-file` and removes any stale report before spawning. The server writes `{pid, error, message, hint}` there on any failure before publication (port preflight, unwritable directory, import error); the first report wins and publication disarms it. The dock appends it to "exited before publishing capabilities" and to the proof timeout. Quoted, bounded, never interpreted.
- Brand check: `--startup-report <path>` is stripped from the command-line brand search like `--pid-file`, so a path we chose cannot brand a foreign command.
- Replacement launch on Windows: the server launched to replace an older backend waited 5 s for the port, less than the plugin needs to prove the new process and kill the old one when every probe is a PowerShell start. It now waits 15 s, and "identity could not be captured" names the pid, liveness and the per-attempt refusal.

Found and fixed on the way (all reproduce on untouched `main` on Windows):

- `script/_dev_env.py`: the venv re-exec used `os.execv`, which on Windows starts a new process and returns while the parent exits 0, so `script/stormtest.py` always exited 0 and the five `test_baseline_cli_has_explicit_mode…` tests failed. It also preferred the main checkout's venv over the worktree's. Now runs the child and forwards its exit code, and prefers the worktree venv.
- `tests/integration/test_client_owner_restarts.py`: uv's venv `python.exe` is a launcher; `terminate()` killed it and left the real server holding the capability lock. The test now kills the process tree on Windows.
- `tests/integration/_self_update_fixture.py`: the driver printed "repinned Codex command pin" as soon as the worker rewrote the file, racing the main thread's "client migration completed"; it now waits for the plugin to release startup, so the ordered markers hold on every platform.

## Iteration loop

With `GODOT_BIN` set, plain `pytest` runs the rows that launch a real editor, which is most of a 20-minute run. Those eight modules now carry `pytestmark = pytest.mark.editor` (registered in `pyproject.toml`), `pytest -m "not editor"` is the documented iteration command in `AGENTS.md` and `docs/verification.md`, and `tests/unit/test_editor_marker_contract.py` fails if a new real-editor module forgets the marker. The full `pytest -v` remains the pre-commit gate.

## Verification

- `ruff check` (full CI scope) clean.
- `pytest -v` with `GODOT_BIN` = Godot 4.7.2 stable on Windows 11: full suite green, including the three real-editor self-update rows and the backend-restart row (both previously failing here).
- Full GDScript suite in a live Godot 4.7.2 GUI editor on this worktree: 2257 passed, 0 failed (one load-sensitive camera test flaked once during concurrent integration runs and passes in isolation; tracked separately).
- Live smoke: this worktree's server started with `--pid-file` and `--startup-report` publishes normally with no report; started against an occupied WebSocket port it writes the report with the port message, and a real 4.0.2-style update on Windows now replaces the old backend and serves the new version.
- Windows regression test asserts the capability directory carries only inherited ACEs (no explicit OWNER RIGHTS DACL).

Closes #988. Addresses the diagnosis gap behind #1012.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows capability-directory permission handling with actionable recovery guidance.
  - Increased tolerance for server replacement waits.
  - Added clearer diagnostics for startup failures, process identity issues, and port or directory conflicts.
  - Fixed Camera2D viewport updates in affected scenarios.
  - Startup failures before readiness now provide additional diagnostic details.

- **Documentation**
  - Expanded lifecycle and verification guidance, including startup reports and Windows recovery steps.

- **Developer Experience**
  - Added an option to skip real-editor integration tests during iteration while retaining the full suite for verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Interactive smoke evidence (Windows 11, Godot 4.7.2 GUI editor, 2026-09-08)

Run with `script/local-self-update-smoke` from the combined #1013 + #1016 tree, the operator clicking Update in a real editor:

- `--from-v3-tag v3.2.4` (the 3.2.x to 4.x crossing): all seven harness checks PASS. Version advanced 3.2.4 to candidate; click, extract, swap, restart and client migration logged in order; update marker records success with the 3.2.4 backup retained; backup is the v3 tree with its capsule overlay; live tree is the canonical v4 tree; isolated Codex entry repinned; post-update `/godot-ai/status` live at the new version.
- `--base-from-release-tag v4.0.2 --next-version 4.0.3` (published 4.0.2 to candidate via the Update button): all eight checks PASS, including "self-update stopped the managed smoke server", "no server/plugin version mismatch", and the restarted editor completing client migration with the server live at 4.0.3.

One harness limitation found on this box: a v3 tree installed from a tag reads the global `godot_ai/http_port` editor setting, so on a machine whose global port is in use the crossing smoke needs the global ports pointed at the fixture ports for its duration.
