### PR TITLE
fix: recovery installer proves Windows liveness itself and repins owned entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ reading. Release engineering: [docs/releasing.md](docs/releasing.md).
 
 ### Fixed
 
+- **Closed-editor recovery installer** (`script/v4-release install`, the
+  #999 procedure): on Windows it treated every update-lock holder as dead
+  when `psutil` was not installed, which the published command never
+  installs, so a live editor's lock was replaced instead of refused; the
+  check now asks the kernel directly and needs no third-party module. A
+  recovery over an existing 4.x tree also records
+  `replace_owned_mismatches`, so the plugin's first start may repin every
+  owned client entry that launches Godot AI, whatever the live tree's
+  version, instead of refusing startup over a leftover v3-shaped entry
+  ([#999](https://github.com/hi-godot/godot-ai/issues/999)).
 - **Windows:** the server launched to replace an older godot-ai backend gave
   up waiting for the port after 5 s, before the plugin had finished proving
   the new process and killing the old one (each identity probe is a

--- a/script/qualification_resources.py
+++ b/script/qualification_resources.py
@@ -44,9 +44,50 @@ class ProcessBinding:
             raise ResourceError("process creation time must be positive and finite")
 
 
+def _windows_process_has_exited(pid: int) -> bool:
+    """True when the Windows kernel already reports an exit code for ``pid``.
+
+    psutil proves a Windows process alive by opening it and reading its
+    creation time. A process that has exited while its parent still holds the
+    handle keeps its pid, its creation time and, on some hosts, its
+    system-table entry, so it can pass every psutil check with a thread count
+    right after the parent's own wait returned. GetExitCodeProcess is the
+    kernel's answer and is settled from the moment that wait released the
+    parent. A process this account cannot open, or one Windows reports as
+    still active, is left to psutil's own outcome; a process that chose exit
+    code 259 (STILL_ACTIVE) reads as running to Windows itself.
+    """
+    import ctypes
+    from ctypes import wintypes
+
+    if pid <= 0:
+        return False
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.GetExitCodeProcess.argtypes = (wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD))
+    kernel32.GetExitCodeProcess.restype = wintypes.BOOL
+    kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+    process_query_limited_information = 0x1000
+    still_active = 259
+    handle = kernel32.OpenProcess(process_query_limited_information, False, pid)
+    if not handle:
+        return False
+    try:
+        code = wintypes.DWORD()
+        if not kernel32.GetExitCodeProcess(handle, ctypes.byref(code)):
+            return False
+        return code.value != still_active
+    finally:
+        kernel32.CloseHandle(handle)
+
+
 def _process(pid: int):
     process = psutil.Process(pid)
     if process.status() in (psutil.STATUS_DEAD, psutil.STATUS_ZOMBIE):
+        raise ResourceError("requested process is dead or a zombie")
+    # psutil never reports a dead Windows process by status; ask the kernel.
+    if os.name == "nt" and _windows_process_has_exited(pid):
         raise ResourceError("requested process is dead or a zombie")
     return process
 

--- a/script/v4-release
+++ b/script/v4-release
@@ -487,6 +487,10 @@ def _process_is_live(pid: int) -> bool:
     lock holder as dead when psutil was absent, so a live editor's lock was
     replaced instead of refused.
     """
+    if pid <= 0:
+        # os.kill(0, 0) signals the caller's own process group and "succeeds";
+        # no lock is ever held by pid 0.
+        return False
     if os.name == "nt":
         return _windows_process_is_live(pid)
     try:

--- a/script/v4-release
+++ b/script/v4-release
@@ -480,13 +480,15 @@ def _write_json(path: Path, record: dict[str, object]) -> None:
 
 
 def _process_is_live(pid: int) -> bool:
-    """``os.kill(pid, 0)`` semantics; Windows asks psutil, or treats the pid as dead."""
+    """``os.kill(pid, 0)`` semantics on every OS, with no third-party dependency.
+
+    Windows asks the kernel directly. The published recovery command installs
+    only ``cryptography``; the earlier psutil lookup silently treated every
+    lock holder as dead when psutil was absent, so a live editor's lock was
+    replaced instead of refused.
+    """
     if os.name == "nt":
-        try:
-            import psutil
-        except ImportError:
-            return False
-        return psutil.pid_exists(pid)
+        return _windows_process_is_live(pid)
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
@@ -494,6 +496,34 @@ def _process_is_live(pid: int) -> bool:
     except PermissionError:
         return True
     return True
+
+
+def _windows_process_is_live(pid: int) -> bool:
+    import ctypes
+    from ctypes import wintypes
+
+    if pid <= 0:
+        return False
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.GetExitCodeProcess.argtypes = (wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD))
+    kernel32.GetExitCodeProcess.restype = wintypes.BOOL
+    kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+    process_query_limited_information = 0x1000
+    error_access_denied = 5
+    still_active = 259
+    handle = kernel32.OpenProcess(process_query_limited_information, False, pid)
+    if not handle:
+        # A process this account may not open still exists.
+        return ctypes.get_last_error() == error_access_denied
+    try:
+        code = wintypes.DWORD()
+        if not kernel32.GetExitCodeProcess(handle, ctypes.byref(code)):
+            return True
+        return code.value == still_active
+    finally:
+        kernel32.CloseHandle(handle)
 
 
 def _foreign_lock_holder(lock: Path) -> int | None:
@@ -663,9 +693,13 @@ def install_verified_release(
         "to_version": expected[3],
         "manifest_sha256": manifest_sha256,
         "expected_tree_sha256": expected_tree,
-        # A pre-v4 tree carries v3-shaped owned client entries; the plugin's
-        # first start may replace them outright, as the capsule crossing does.
-        "replace_owned_mismatches": not from_version.startswith("4."),
+        # The user ran this recovery by hand, outside the editor, usually
+        # because the in-editor path left stale entries behind (a v3 client
+        # pin, a 4.0.0/4.0.1 install whose updater could not download). The
+        # plugin's first start may therefore replace every owned entry that
+        # launches Godot AI, whatever version the live tree carried; entries
+        # that launch something else are still left alone (#999).
+        "replace_owned_mismatches": True,
         "backup_root": str(update / "backup" / from_version) if from_version else "",
     }
     _write_json(lock, {"pid": os.getpid(), "owner": "script/v4-release install"})

--- a/tests/unit/test_qualification_resources.py
+++ b/tests/unit/test_qualification_resources.py
@@ -2,7 +2,10 @@
 
 import copy
 import json
+import os
 import runpy
+import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -38,6 +41,15 @@ class Process:
 
     def num_handles(self):
         return self.handles
+
+
+REAL_WINDOWS_EXIT_REPORT = resources._windows_process_has_exited
+
+
+@pytest.fixture(autouse=True)
+def no_kernel_exit_report(monkeypatch):
+    """Fake psutil processes have no kernel behind them; pin the Windows probe."""
+    monkeypatch.setattr(resources, "_windows_process_has_exited", lambda pid: False)
 
 
 @pytest.fixture
@@ -93,6 +105,35 @@ def test_dead_or_zombie_is_not_a_successful_sample(process, status):
         resources.bind_process(100)
     with pytest.raises(resources.ResourceError, match="dead or a zombie"):
         resources.sample_process(resources.ProcessBinding(100, 123.5))
+
+
+@pytest.mark.parametrize("os_name", ["nt", "posix"])
+def test_kernel_exit_report_outranks_psutil_only_on_windows(process, monkeypatch, os_name):
+    """An exited child that psutil still answers for is dead on Windows."""
+    monkeypatch.setattr(resources.os, "name", os_name)
+    monkeypatch.setattr(resources, "_windows_process_has_exited", lambda pid: True)
+    if os_name == "nt":
+        with pytest.raises(resources.ResourceError, match="dead or a zombie"):
+            resources.bind_process(100)
+        with pytest.raises(resources.ResourceError, match="dead or a zombie"):
+            resources.sample_process(resources.ProcessBinding(100, 123.5))
+    else:
+        assert resources.sample_process(resources.bind_process(100))["threads"] == 3
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows kernel exit codes")
+def test_windows_exit_report_marks_a_still_open_child_dead(process, monkeypatch):
+    child = subprocess.Popen([sys.executable, "-c", "pass"])
+    child.wait(timeout=30)
+    # The Popen still holds the process handle, so the pid cannot be reused.
+    assert REAL_WINDOWS_EXIT_REPORT(child.pid) is True
+    assert REAL_WINDOWS_EXIT_REPORT(os.getpid()) is False
+    assert REAL_WINDOWS_EXIT_REPORT(0) is False
+    monkeypatch.setattr(resources, "_windows_process_has_exited", REAL_WINDOWS_EXIT_REPORT)
+    with pytest.raises(resources.ResourceError, match="dead or a zombie"):
+        resources.sample_process(resources.ProcessBinding(child.pid, 123.5))
+    binding = resources.bind_process(os.getpid())
+    assert resources.sample_process(binding)["pid"] == os.getpid()
 
 
 @pytest.mark.parametrize("when", ["before", "during"])

--- a/tests/unit/test_release_verify.py
+++ b/tests/unit/test_release_verify.py
@@ -501,6 +501,32 @@ def test_install_rollback_on_a_fresh_project_leaves_no_live_tree(release, tmp_pa
     )
 
 
+def test_process_liveness_needs_no_third_party_module():
+    assert v4_release._process_is_live(os.getpid())
+    finished = subprocess.Popen([sys.executable, "-c", "pass"])
+    finished.wait()
+    assert not v4_release._process_is_live(finished.pid)
+    assert not v4_release._process_is_live(0)
+    assert "import psutil" not in Path(v4_release.__file__).read_text(encoding="utf-8")
+
+
+def test_install_over_a_v4_tree_still_replaces_owned_mismatches(release, tmp_path):
+    """A hand-run recovery may repin every owned entry, whatever the live version."""
+    project = _project(tmp_path)
+    live = project / "addons/godot_ai"
+    config = live / "plugin.cfg"
+    config.write_text(
+        config.read_text(encoding="utf-8").replace('version="3.2.4"', 'version="4.0.1"'),
+        encoding="utf-8",
+    )
+
+    assert v4_release.main(_install_args(release, project)) == 0
+
+    marker = _marker(project)
+    assert marker["from_version"] == "4.0.1"
+    assert marker["replace_owned_mismatches"] is True
+
+
 def test_install_refuses_a_lock_held_by_another_live_process(release, tmp_path):
     project = _project(tmp_path)
     update = project / "addons/.godot_ai_update"


### PR DESCRIPTION
## What

`script/v4-release install` is the closed-editor recovery in #999 for users whose 4.0.0/4.0.1 updater cannot download. Two gaps on that path:

- **Windows liveness check.** `_process_is_live` asked `psutil`, and treated every pid as dead when `psutil` was not importable. The published command (`uv run --no-project --with cryptography …`) never installs it, so a lock held by a live editor was replaced instead of refused. `tests/unit/test_release_verify.py::test_install_refuses_a_lock_held_by_another_live_process` failed on every Windows machine running the documented command. The check now asks the kernel through `OpenProcess`/`GetExitCodeProcess` and needs no third-party module.
- **Owned mismatches after a 4.x recovery.** The marker recorded `replace_owned_mismatches` only when the live tree was pre-v4. Users who recovered a 4.0.x tree that still carried a v3-shaped entry then hit the post-update drift barrier on first start. A hand-run recovery may repin every owned entry that launches Godot AI, whatever version the live tree carried; entries that launch something else are still left alone.

## Verification

- `ruff check` clean; `pytest -m "not editor"` green in a clean worktree venv on Windows 11, including the previously failing lock test, a new liveness test that runs without psutil, and a new test that a recovery over a 4.0.1 tree records `replace_owned_mismatches: true`.
- Live smoke on Windows with the real v4.0.2 release assets: the published #999 command, run from this branch against a scratch project holding a stale 4.0.1 tree, installs 4.0.2, retains the backup, and records the marker with `replace_owned_mismatches: true`.

Pairs with the drift-deferral change (separate PR), which makes the barrier non-fatal for the remaining cases. Addresses the recovery gaps discussed in #999.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows recovery installs to detect whether an update lock is held by a live process, even when optional process utilities are unavailable.
  - Recovery installs over existing 4.x installations now record modified, plugin-owned client entries for repinning on first startup.
  - Improved handling of dead, invalid, self-referencing, and non-positive process IDs in update locks.

- **Tests**
  - Added coverage for process detection and recovery installation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->