### PR TITLE
fix(camera): repair Camera2D make_current dropped by the engine's group-call skip set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ reading. Release engineering: [docs/releasing.md](docs/releasing.md).
 
 ### Fixed
 
+- `camera_create` / `camera_configure` / `camera_apply_preset` with
+  `make_current` on a **Camera2D** could leave the camera not current while
+  the response and `camera_get` said it was. Godot's `Camera2D.make_current()`
+  dispatches through a scene-tree group call that silently skips a node
+  allocated at the address of a node removed and freed earlier in the same
+  editor frame, which happens after undo-history trimming, `free()`, or an
+  editor panel rebuild. The handler now detects the dropped call and applies
+  the same viewport update directly. This was the "engine-state lag" behind
+  the long-running camera test flake (#140, #278, #301, #316); the retry and
+  sleep loops written for it are gone.
 - **Bazzite / Fedora Atomic:** the server exited before publishing its
   capability record because `/home` is a symbolic link to `/var/home` on
   ostree systems and 4.0.x refused every link in a capability path. The server

--- a/plugin/addons/godot_ai/handlers/camera_handler.gd
+++ b/plugin/addons/godot_ai/handlers/camera_handler.gd
@@ -254,15 +254,13 @@ func _resolve_current_with_logicals(cam: Node, logical_2d: Node, logical_3d: Nod
 #
 # Both DO and UNDO route through `_apply_make_current` / `_apply_clear_current`
 # on the handler itself rather than calling Camera.make_current() directly.
-# The helpers do the make_current (or clear_current) call plus bounded sync
-# settling when the viewport hasn't yet reflected the change — headless CI
-# occasionally reports `is_current() == false` immediately after a committed
-# make_current (observed CI run 24682342469) and symmetrically still reports
-# the displaced camera as current immediately after an undo (observed CI runs
-# 24682342469, 24692250322, 24696571517, 25079965242 — tracked in #140).
-# Later #278 runs broadened the same current-camera timing flake across more
-# platforms and assertions, so the settle budget is deliberately above one
-# fast local frame.
+# The helpers do the make_current (or clear_current) call and then verify the
+# viewport slot synchronously. CI used to report `is_current() == false`
+# immediately after a committed make_current (#140 / #278 / #301 / #316); that
+# was never engine lag — Camera2D's current state is a synchronous viewport
+# read — but `Camera2D.make_current()` being silently dropped by the engine's
+# group-call skip set. See `_broadcast_make_current_2d` for the mechanism and
+# the deterministic repair.
 #
 # Because those callables bind to `self` (a RefCounted handler, not a scene
 # node), every action that calls this helper must pin its history via
@@ -293,40 +291,62 @@ func _add_make_current_to_action(node: Node, type_str: String, scene_root: Node)
 		_undo_redo.add_undo_method(self, "_apply_clear_current", node)
 
 
-# Apply make_current on `cam` with bounded synchronous settling. Registered as the
-# do/undo callable by `_add_make_current_to_action`. See that function's
-# comment for why the undo path needs the retry inside the action itself.
-# Safe against a freed camera node — short-circuits if the node is gone
-# or not in the tree.
+# Apply make_current on `cam` and verify the viewport slot. Registered as the
+# do/undo callable by `_add_make_current_to_action`. Safe against a freed
+# camera node — short-circuits if the node is gone or not in the tree.
+#
+# Everything here is synchronous: `Camera2D.is_current()` is literally
+# `viewport->get_camera_2d() == this` and `Camera3D.is_current()` reads the
+# node's own flag while it is part of the edited scene, so there is no engine
+# state that a delay or a retry could wait for. The one way `make_current()`
+# fails is the group-call skip described on `_broadcast_make_current_2d`, and
+# that is repaired in place.
 func _apply_make_current(cam: Node) -> void:
 	if cam == null or not is_instance_valid(cam) or not cam.is_inside_tree():
 		return
 	_set_logical_current(cam)
 	var scene_root := EditorInterface.get_edited_scene_root()
 	var type_str := _camera_type_str(cam)
-	for attempt in range(_CURRENT_SETTLE_ATTEMPTS):
-		cam.make_current()
-		_force_camera_refresh(cam)
-		# Godot's make_current is supposed to atomically displace siblings,
-		# but on macOS headless the displaced camera occasionally still
-		# answers is_current() == true after this returns (#140 / #278 / #301).
-		# Sweep same-class siblings and clear any that lag.
-		_force_clear_other_currents(cam, type_str, scene_root)
-		if not _is_current_settled(cam):
-			_displace_stale_camera_2d(cam)
-			_force_clear_other_currents(cam, type_str, scene_root)
-		var waited_this_attempt := false
-		if _is_current_settled(cam):
-			if not (cam is Camera2D):
-				return
-			OS.delay_msec(_CURRENT_SETTLE_DELAY_MSEC)
-			waited_this_attempt = true
-			_force_camera_refresh(cam)
-			_force_clear_other_currents(cam, type_str, scene_root)
-			if _is_current_settled(cam):
-				return
-		if attempt < _CURRENT_SETTLE_ATTEMPTS - 1 and not waited_this_attempt:
-			OS.delay_msec(_CURRENT_SETTLE_DELAY_MSEC)
+	cam.make_current()
+	if cam is Camera2D and not _is_current_settled(cam):
+		_broadcast_make_current_2d(cam as Camera2D, scene_root)
+	_force_camera_refresh(cam)
+	# In the editor a displaced Camera3D keeps its own `current` flag (the
+	# viewport's LOST_CURRENT notification does not clear it), so it still
+	# answers is_current() == true. Sweep same-class siblings and clear them.
+	_force_clear_other_currents(cam, type_str, scene_root)
+
+
+# `Camera2D.make_current()` does not touch the viewport itself: it calls
+# `SceneTree.call_group("__cameras_<viewport>", "_make_current", self)` and
+# every camera in the group sets or releases `Viewport.camera_2d` in
+# `_make_current(which)`. `call_group` skips any node whose pointer is in
+# `SceneTree::nodes_removed_on_group_call` — a raw-pointer set of every node
+# removed from the tree since the current `_process()` pass (or the outermost
+# group call) began, cleared only when that pass unwinds. A camera allocated
+# into the address of a node removed and freed earlier in the same frame — a
+# `memdelete`d undo reference, a `free()`d node, an editor Control rebuild —
+# is therefore silently skipped: `make_current()` returns, the slot never
+# changes, and `is_current()` stays false while the handler's own bookkeeping
+# says current. Reproduced deterministically on 4.7.2 (49/50 iterations with
+# a same-frame `free()`); this is the "engine-state lag" behind #140 / #278 /
+# #301 / #316. Camera3D is not affected: it writes the viewport directly.
+#
+# Repair by replicating the broadcast with the same bound `_make_current`
+# method the engine's group call invokes: every other Camera2D in the scene
+# releases the slot, then the target claims it. `_make_current` is engine
+# API, not documented — guard on `has_method` so a future engine that drops
+# it degrades to the plain `make_current()` result instead of erroring.
+func _broadcast_make_current_2d(cam: Camera2D, scene_root: Node) -> void:
+	if not cam.has_method("_make_current"):
+		return
+	if scene_root != null:
+		for other in _list_cameras_in_scene(scene_root, "2d"):
+			if other == cam or not is_instance_valid(other) or not other.is_inside_tree():
+				continue
+			if other.has_method("_make_current"):
+				other.call("_make_current", cam)
+	cam.call("_make_current", cam)
 
 
 # Walk same-class siblings and force-clear any that still report is_current().
@@ -376,40 +396,6 @@ func _is_current_settled(cam: Node) -> bool:
 		if viewport != null and viewport.get_camera_2d() != cam:
 			return false
 	return true
-
-
-func _displace_stale_camera_2d(target: Node) -> void:
-	if not (target is Camera2D):
-		return
-	var viewport := target.get_viewport()
-	if viewport == null:
-		return
-	var stale := viewport.get_camera_2d()
-	if stale == null or stale == target or not is_instance_valid(stale):
-		_nudge_camera_2d_current(target)
-		return
-	var was_enabled := stale.enabled
-	if was_enabled:
-		stale.enabled = false
-	target.make_current()
-	_force_camera_refresh(target)
-	if was_enabled:
-		stale.enabled = true
-	target.make_current()
-	_force_camera_refresh(target)
-
-
-func _nudge_camera_2d_current(target: Node) -> void:
-	if not (target is Camera2D):
-		return
-	var cam := target as Camera2D
-	if not cam.enabled:
-		return
-	cam.enabled = false
-	_force_camera_refresh(cam)
-	cam.enabled = true
-	cam.make_current()
-	_force_camera_refresh(cam)
 
 
 # Symmetric counterpart to `_apply_make_current` for the "no previous

--- a/test_project/tests/test_camera.gd
+++ b/test_project/tests/test_camera.gd
@@ -109,42 +109,31 @@ func _camera_current_settled(cam: Node, expected: bool) -> bool:
 	return not bool(cam.is_current()) and not viewport_matches
 
 
-func _wait_for_camera_current(cam: Node, expected: bool) -> bool:
-	for _i in range(20):
-		if _camera_current_settled(cam, expected):
-			return true
-		OS.delay_msec(10)
-	return _camera_current_settled(cam, expected)
-
-
+## Read the camera's current state once and package it with the diagnostic.
+##
+## This used to spin 20 x `OS.delay_msec(10)` "waiting for the engine to
+## settle". It cannot settle anything: a test body runs synchronously on the
+## main thread, so no frame advances during the sleep, and there is nothing
+## frame-driven to wait for anyway — `Camera2D.is_current()` is a synchronous
+## `viewport.get_camera_2d() == self` read and `make_current()` writes that
+## slot before it returns (Godot 4.7.2 `camera_2d.cpp`). The first read is
+## definitive. The `attempts` / `elapsed_msec` keys are kept for the
+## diagnostic callers; both are trivially 1 / ~0 now.
 func _wait_for_camera_current_report(cam: Node, expected: bool) -> Dictionary:
 	var start := Time.get_ticks_msec()
-	var attempts := 0
-	for i in range(20):
-		attempts = i + 1
-		if _camera_current_settled(cam, expected):
-			return {
-				"settled": true,
-				"attempts": attempts,
-				"elapsed_msec": Time.get_ticks_msec() - start,
-				"message": _camera_current_wait_timeout_message(cam, expected, attempts, Time.get_ticks_msec() - start),
-			}
-		OS.delay_msec(10)
 	var settled := _camera_current_settled(cam, expected)
 	var elapsed := Time.get_ticks_msec() - start
 	return {
 		"settled": settled,
-		"attempts": attempts,
+		"attempts": 1,
 		"elapsed_msec": elapsed,
-		"message": _camera_current_wait_timeout_message(cam, expected, attempts, elapsed),
+		"message": _camera_current_mismatch_message(cam, expected, 1, elapsed),
 	}
 
 
-func _camera_current_wait_timeout_message(cam: Node, expected: bool, attempts: int, elapsed_msec: int) -> String:
-	return "Timed out waiting for camera current=%s after %d attempts/%dms. %s" % [
+func _camera_current_mismatch_message(cam: Node, expected: bool, attempts: int, elapsed_msec: int) -> String:
+	return "Camera current=%s not observed after make_current/clear_current (state is synchronous; a retry cannot change it). %s" % [
 		expected,
-		attempts,
-		elapsed_msec,
 		_camera_current_diag(cam, expected, attempts, elapsed_msec),
 	]
 
@@ -239,18 +228,17 @@ func _camera_current_diag(cam: Node, expected: bool, attempts: int, elapsed_msec
 	]
 
 
-# Issue #316 gate. After 12+ fix attempts, `Camera2D.make_current()` →
-# `Viewport.camera_2d` (and the same dispatch for Camera3D →
-# `Viewport.camera_3d`, exercised by `test_make_current_does_not_cross_classes`)
-# still occasionally lags in headless mode (originally observed on macOS,
-# then on Windows after PR #380's diagnostic landed — same handler-agrees /
-# engine-disagrees signature, same `viewport_camera=<none>` end state). The
-# handler-side logical bookkeeping (#311) stays correct in that race — only
-# the engine-side viewport slot doesn't catch up. Per the issue's acceptance
-# criterion #2, the headless failure is gated when the handler view agrees
-# with the expectation: skip with the full diagnostic so the next
-# investigator still sees the state divergence, but don't fail the build for
-# a known upstream race we can't close at the plugin level.
+# Issue #316 gate. The "engine-state lag" it guards against — handler agrees,
+# `is_current()` false, `viewport_camera=<none>` — was never lag. It is
+# Godot's `SceneTree` group-call skip set: `Camera2D.make_current()` fans out
+# through `call_group`, which skips any node whose pointer matches a node
+# removed from the tree earlier in the same `_process()` pass, so a camera
+# allocated into a just-freed node's address is silently never made current.
+# The handler now repairs that in place
+# (`CameraHandler._broadcast_make_current_2d`) and
+# `test_make_current_survives_same_frame_freed_node_alias` reproduces it on
+# purpose. The gate stays as a belt-and-braces skip for headless CI only; if it
+# ever fires again the diagnostic still carries the full state divergence.
 #
 # Deliberately scoped to headless DisplayServer only — Linux CI runs under
 # xvfb with a real display server, and a developer running the suite in a
@@ -397,6 +385,49 @@ func test_make_current_does_not_cross_classes() -> void:
 	assert_true(cam3_current.settled, cam3_current.message)
 	assert_eq(n2.is_current(), true, "Camera2D current should not be touched when Camera3D becomes current. %s" % _camera_current_diag(n2, true, cam2_current.attempts, cam2_current.elapsed_msec))
 	assert_eq(n3.is_current(), true, "Direct is_current mismatch after wait succeeded. %s" % _camera_current_diag(n3, true, cam3_current.attempts, cam3_current.elapsed_msec))
+
+
+# Regression for the load-sensitive `test_make_current_does_not_cross_classes`
+# failure (handler_current=true, node_is_current=false, viewport_camera=<none>).
+# `Camera2D.make_current()` dispatches through `SceneTree.call_group`, which
+# skips every node whose pointer is in the tree's removed-this-frame set. Free
+# a camera in the same frame and the next `Camera2D.new()` usually lands on
+# its address (49/50 on Windows 4.7.2), so without the handler's direct
+# `_make_current` broadcast the freshly created camera is never made current.
+# Five rounds make the aliasing practically certain on every allocator.
+func test_make_current_survives_same_frame_freed_node_alias() -> void:
+	var scene_root := EditorInterface.get_edited_scene_root()
+	if scene_root == null:
+		assert_true(false, "No scene open")
+		return
+	var viewport := scene_root.get_viewport()
+	for round in range(5):
+		var victim := Camera2D.new()
+		victim.name = "_McpTestAliasVictim%d" % round
+		scene_root.add_child(victim)
+		scene_root.remove_child(victim)
+		victim.free()
+		var created := _create("AliasCam%d" % round, "2d", true)
+		assert_has_key(created, "data")
+		if not created.has("data"):
+			return
+		var cam := McpScenePath.resolve(created.data.path, scene_root) as Camera2D
+		assert_true(cam != null, "AliasCam%d should resolve" % round)
+		if cam == null:
+			return
+		assert_true(
+			cam.is_current() and viewport.get_camera_2d() == cam,
+			"Round %d: camera created after a same-frame free must be current. %s" % [
+				round, _camera_current_diag(cam, true, 1, 0),
+			]
+		)
+		# Retire this round's camera the same way the test cleanup does
+		# (queue_free keeps its address occupied until the frame ends, so the
+		# next round's victim/new-camera pair is the only aliasing in play).
+		_clear_camera_current_for_removal(cam)
+		scene_root.remove_child(cam)
+		cam.queue_free()
+		_created_paths.erase(created.data.path)
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

`test_camera.gd::test_make_current_does_not_cross_classes` failed once on Windows 11 while the full GDScript suite ran in a GUI editor concurrently with the Python integration suite (heavy CPU load): `handler_current=true node_is_current=false viewport_camera=<none>`. This PR identifies the real cause, fixes it in the handler, adds a deterministic regression test, and removes the retry/sleep machinery that was written for a "lag" that never existed.

### Root cause (Godot 4.7.2 engine, verified against `camera_2d.cpp` / `scene_tree.cpp` at `4.7.2-stable`)

- `Camera2D.is_current()` is literally `viewport->get_camera_2d() == this`, and `make_current()` writes that slot before it returns. The state is synchronous; no frame can settle it later, so both the test's `OS.delay_msec` spin and the handler's 8×10 ms retry loops were no-ops.
- `Camera2D.make_current()` fans out through `SceneTree.call_group("__cameras_<vp>", "_make_current", self)`. `call_group` skips every node whose pointer is in `SceneTree::nodes_removed_on_group_call` — a **raw-pointer** set of nodes removed from the tree since the current `_process()` pass began, cleared only when the pass unwinds.
- A `Camera2D` allocated into the address of a node removed **and freed** earlier in the same frame (a `memdelete`d undo reference, a `free()`d node, an editor Control rebuild) is therefore silently skipped: `make_current()` returns, the slot never changes, the handler's logical bookkeeping says current.
- Camera3D is unaffected (it writes the viewport directly), so there is **no cross-class regression**; the Camera3D create simply came after a Camera2D that had never become current.

Reproduced in a live 4.7.2 GUI editor with a throwaway probe suite: after a same-frame `add_child`/`remove_child`/`free()` of a victim camera, **49/50** raw `make_current()` calls and **19/20** handler-driven `create_camera(make_current=true)` calls missed, and a direct `_make_current(self)` repaired every single miss. This is the mechanism behind the long-running "engine-state lag" flake (#140, #278, #301, #316).

### Changes

- **Handler** (`camera_handler.gd`): after `make_current()`, if a Camera2D still does not own the viewport slot, replay the broadcast through the same bound `_make_current(which)` method the engine's group call invokes (siblings release, target claims), guarded on `has_method`. The settle loops, `enabled` toggling and stale-camera displacement are removed from the make_current path. The Camera3D sibling sweep stays: a displaced Camera3D keeps its own `current` flag in the editor.
- **Test** (`test_camera.gd`): the wait helper is a single synchronous read with the diagnostic; the #316 gate comment states the real cause (gate kept as a headless-only safety net); new `test_make_current_survives_same_frame_freed_node_alias` forces the aliasing five times per run.
- **CHANGELOG**: Unreleased / Fixed entry.

### Verification (Windows 11, Godot 4.7.2 GUI editor on this worktree)

- `ruff check` (CI scope): clean.
- Camera suite: 38/38, then **45/45 consecutive runs under load** — three headless editors churning (166 boots) plus the integration suite's own editors, CPU ~90%.
- Full GDScript suite: **2251 passed, 0 failed, 29 skipped** (73 suites).
- Full `pytest`: 2508 passed, 55 skipped, 10 failed — none touch this change (Python is untouched). 5× `test_stormtest_support.py::test_baseline_cli_has_explicit_mode_without_weakening_qualification` fails deterministically on this Windows box on unmodified `main` too (CLI exits 0 with usage text; flagged separately). The 5 self-update / backend-restart integration rows failed on `WinError 32` lock contention in the shared `%LOCALAPPDATA%\godot-ai\capabilities` dir and server-launch proof timeouts while a second session on the same machine was running the identical rows; 2 passed on an isolated rerun, 3 still hit the same contention because that other run was still going. CI on `main` is green for the base commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `Camera2D` operations with `make_current` so the requested camera reliably becomes current, including when another camera was freed earlier in the same editor frame.
  - Improved camera-current diagnostics with clearer synchronous state-mismatch reporting.
  - Added regression coverage for replacing freed cameras and restoring the current camera correctly.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->