### PR TITLE
fix: defer drifted client entries after an update instead of blocking startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ reading. Release engineering: [docs/releasing.md](docs/releasing.md).
   refused` and a Retry that failed the same way. The entry is still never
   rewritten (#890), but it no longer holds the server: it is left
   unchanged, named in the completion banner with a Configure hint, and
+  startup continues. While an update brings the server back the dock now
+  reads `Finishing update — starting server…` instead of a red
+  `Connection blocked`
   startup continues
 - **Closed-editor recovery installer** (`script/v4-release install`, the
   #999 procedure): on Windows it treated every update-lock holder as dead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ reading. Release engineering: [docs/releasing.md](docs/releasing.md).
 
 ### Fixed
 
+- **Closed-editor recovery installer** (`script/v4-release install`, the
+  #999 procedure): on Windows it treated every update-lock holder as dead
+  when `psutil` was not installed, which the published command never
+  installs, so a live editor's lock was replaced instead of refused; the
+  check now asks the kernel directly and needs no third-party module. A
+  recovery over an existing 4.x tree also records
+  `replace_owned_mismatches`, so the plugin's first start may repin every
+  owned client entry that launches Godot AI, whatever the live tree's
+  version, instead of refusing startup over a leftover v3-shaped entry
+  ([#999](https://github.com/hi-godot/godot-ai/issues/999)).
 - **Windows:** the server launched to replace an older godot-ai backend gave
   up waiting for the port after 5 s, before the plugin had finished proving
   the new process and killing the old one (each identity probe is a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ reading. Release engineering: [docs/releasing.md](docs/releasing.md).
 
 ### Fixed
 
+- After an update, a client entry the migration could not prove as
+  "what Configure wrote before the update" (a project `.mcp.json` with a
+  v3 `type: http` entry, an unreadable file) blocked the server with
+  `<client> has non-version configuration drift; automatic migration
+  refused` and a Retry that failed the same way. The entry is still never
+  rewritten (#890), but it no longer holds the server: it is left
+  unchanged, named in the completion banner with a Configure hint, and
+  startup continues
 - **Closed-editor recovery installer** (`script/v4-release install`, the
   #999 procedure): on Windows it treated every update-lock holder as dead
   when `psutil` was not installed, which the published command never

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -89,8 +89,13 @@ All steps run inside the editor, on the main thread except the download.
      stale-server recovery arm and the pin-only auto-repin gate already read),
      repin owned client configuration once and record `clients_migrated` in
      the marker, emit the `self_update` telemetry event, and continue normal
-     startup. A success marker that records its migration is the durable
-     record of the last update and is nothing pending on later starts;
+     startup. An entry the migration cannot prove as what Configure wrote
+     before the update (a hand-edited or v3-shaped entry, an unreadable
+     file) is never rewritten (#890) and never blocks the server either: it
+     is left unchanged, named in the completion banner, and left to the
+     dock's Configure (#999). A success marker that records its migration is
+     the durable record of the last update and is nothing pending on later
+     starts;
    - different: rename the live tree to `.godot_ai_update/quarantine/`, rename
      the backup back into place, mark `status: rolled_back` with the reason,
      and show it in the dock. If the backup is missing too, mark

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -2805,6 +2805,12 @@ func present_update_state(state: Dictionary) -> void:
 		_post_update_server_pending = true
 		if _status_label != null:
 			_update_status()
+	elif state.has("install_in_flight"):
+		## The install ended without a swap (`_fail_update`): the previous
+		## version is live and the transport status is the truth again.
+		_post_update_server_pending = false
+		if _status_label != null:
+			_update_status()
 	if state.has("button_text") and _update_btn != null:
 		_update_btn.text = String(state["button_text"])
 	if state.has("button_disabled") and _update_btn != null:

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -255,6 +255,11 @@ var _update_btn: Button
 const _UPDATE_ACTION_TEXT := "Update"
 const _UPDATE_LABEL_COLOR := Color(1.0, 0.85, 0.3)
 var _post_update_action := ""
+## True from the moment an update starts its client migration until the
+## server it then starts is connected. The transport reads "blocked" for
+## that whole window (the migration barrier, then the launch), which is
+## not a fault: name the phase instead of alarming the user (#999).
+var _post_update_server_pending := false
 
 func _ready() -> void:
 	_startup_grace_until_msec = Time.get_ticks_msec() + STARTUP_GRACE_MSEC
@@ -792,6 +797,8 @@ func _update_status() -> void:
 	var state: int = int(server_status.get("state", ServerStateScript.UNINITIALIZED))
 	if ServerStateScript.blocks_client_health(state):
 		connected = false
+	if connected:
+		_post_update_server_pending = false
 
 	## One `match`/`elif` chain, one source of truth. Adding a new
 	## spawn outcome = one `ServerStateScript` constant + one arm here +
@@ -829,6 +836,11 @@ func _update_status() -> void:
 	elif state == ServerStateScript.NO_COMMAND:
 		status_text = "No server command found"
 		status_color = Color.RED
+	elif _post_update_server_pending:
+		## Every terminal spawn failure matched above; what is left is the
+		## post-update window where the server is being brought back.
+		status_text = "Finishing update — starting server…"
+		status_color = COLOR_AMBER
 	elif not transport_status.is_empty():
 		var transport_phase := str(transport_status.get("phase", ""))
 		if transport_phase == "connecting":
@@ -2786,6 +2798,13 @@ func present_update_state(state: Dictionary) -> void:
 			_update_btn.text = _UPDATE_ACTION_TEXT
 	if state.has("install_in_flight"):
 		_update_install_in_flight = bool(state["install_in_flight"])
+	if String(state.get("post_update_action", "")) == "retry":
+		## The migration barrier refused: the connection really is blocked.
+		_post_update_server_pending = false
+	elif bool(state.get("install_in_flight", false)) or String(state.get("outcome", "")) == "success":
+		_post_update_server_pending = true
+		if _status_label != null:
+			_update_status()
 	if state.has("button_text") and _update_btn != null:
 		_update_btn.text = String(state["button_text"])
 	if state.has("button_disabled") and _update_btn != null:

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -127,7 +127,9 @@ var _post_update_outcome: Dictionary = {}
 var _post_update_replaced_version := ""
 ## Clients the post-update migration left unchanged (`{id, reason}`), named
 ## in the dock's completion banner so the user knows to click Configure.
-var _post_update_deferred: Array[Dictionary] = []
+## Untyped on purpose: a typed collection field is the hot-reload crash
+## class (#245) the self-update smoke injects to prove the swap survives it.
+var _post_update_deferred := []
 var _last_logged_block := ""
 ## Bounded re-probes while that backend is still binding its port: a port
 ## that is bound but not yet answering status reads as merely occupied.
@@ -910,15 +912,13 @@ func _post_update_complete_label() -> String:
 	)
 	if _post_update_deferred.is_empty():
 		return text
-	var names: Array[String] = []
+	var named: Array[String] = []
 	for entry in _post_update_deferred:
-		var client := McpClientRegistry.get_by_id(str(entry.get("id", "")))
-		names.append(client.display_name if client != null else str(entry.get("id", "")))
-	return (
-		text
-		+ " Not migrated because their godot-ai entry differs from what Configure wrote: %s. Use Configure to replace them."
-		% ", ".join(names)
-	)
+		var client_id := str(entry.get("id", ""))
+		var client := McpClientRegistry.get_by_id(client_id)
+		var name: String = client.display_name if client != null else client_id
+		named.append("%s (%s)" % [name, str(entry.get("reason", "not migrated"))])
+	return text + " Not migrated: %s. Use Configure to replace them." % ", ".join(named)
 
 
 ## Sole release point for ordinary work and the server lifecycle. Keeping

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -125,6 +125,9 @@ var _post_update_outcome: Dictionary = {}
 ## update may spawn a backend of that version into the restart window; the
 ## restarted editor replaces it once instead of asking the user to.
 var _post_update_replaced_version := ""
+## Clients the post-update migration left unchanged (`{id, reason}`), named
+## in the dock's completion banner so the user knows to click Configure.
+var _post_update_deferred: Array[Dictionary] = []
 var _last_logged_block := ""
 ## Bounded re-probes while that backend is still binding its port: a port
 ## that is bound but not yet answering status reads as merely occupied.
@@ -811,6 +814,14 @@ func _on_post_update_repin_completed(result: Dictionary) -> void:
 			"MCP | the %s entry named godot-ai launches something else; it was left unchanged. Use Configure in the dock to replace it."
 			% str(client_id)
 		)
+	_post_update_deferred = []
+	for entry in result.get("deferred", []):
+		if entry is Dictionary:
+			_post_update_deferred.append((entry as Dictionary).duplicate(true))
+			push_warning(
+				"MCP | %s was not migrated automatically because %s; it was left unchanged. Use Configure in the dock."
+				% [str(entry.get("id", "")), str(entry.get("reason", ""))]
+			)
 	## A click cannot prove that an external client restarted. The enforceable
 	## boundary is the one we own: repin its configuration, mark the update
 	## complete, then start and authenticate that server. Clients reconnect to
@@ -885,14 +896,29 @@ func _present_post_update_complete() -> void:
 			"install_in_flight": false,
 			"status_text": "Update complete",
 			"button_disabled": true,
-			"label_text": (
-				"Restart AI clients that were connected during the update so they use v%s."
-				% str(_post_update_outcome.get("to_version", ""))
-			),
+			"label_text": _post_update_complete_label(),
 			"banner_visible": true,
 			"post_update_action": "",
 			"outcome": "success",
 		})
+
+
+func _post_update_complete_label() -> String:
+	var text := (
+		"Quit and relaunch AI clients that were connected during the update so they use v%s."
+		% str(_post_update_outcome.get("to_version", ""))
+	)
+	if _post_update_deferred.is_empty():
+		return text
+	var names: Array[String] = []
+	for entry in _post_update_deferred:
+		var client := McpClientRegistry.get_by_id(str(entry.get("id", "")))
+		names.append(client.display_name if client != null else str(entry.get("id", "")))
+	return (
+		text
+		+ " Not migrated because their godot-ai entry differs from what Configure wrote: %s. Use Configure to replace them."
+		% ", ".join(names)
+	)
 
 
 ## Sole release point for ordinary work and the server lifecycle. Keeping

--- a/plugin/addons/godot_ai/utils/client_job_owner.gd
+++ b/plugin/addons/godot_ai/utils/client_job_owner.gd
@@ -296,6 +296,7 @@ func _run_post_update_repin(
 	var configured_ids: Array[String] = []
 	var repinned_ids: Array[String] = []
 	var foreign_ids: Array[String] = []
+	var deferred: Array[Dictionary] = []
 	if bool(prewarm.get("termination_failed", false)):
 		return _post_update_result(
 			false,
@@ -324,8 +325,15 @@ func _run_post_update_repin(
 		if status == Client.Status.NOT_CONFIGURED:
 			continue
 		if status == Client.Status.ERROR:
-			return _post_update_result(false, generation, configured_ids, repinned_ids,
-				"%s status failed: %s" % [client_id, str(details.get("error_msg", "unknown error"))], prewarm)
+			## One client whose configuration cannot even be read must not
+			## hold every other client and the server itself hostage: leave
+			## it for the dock's Configure and say so.
+			deferred.append({
+				"id": client_id,
+				"reason": "its configuration could not be read: %s"
+				% str(details.get("error_msg", "unknown error")),
+			})
+			continue
 		if status == Client.Status.CONFIGURED:
 			configured_ids.append(client_id)
 			continue
@@ -339,8 +347,16 @@ func _run_post_update_repin(
 		elif not ClientConfigurator.entry_drift_is_version_pin_only(
 			client_id, from_version, context
 		):
-			return _post_update_result(false, generation, configured_ids, repinned_ids,
-				"%s has non-version configuration drift; automatic migration refused." % client_id, prewarm)
+			## #890's write restriction stands: an entry that is not provably
+			## what Configure wrote before the update is never rewritten here.
+			## But refusing the write is not a reason to refuse the server
+			## (#999): the entry is left untouched, named, and deferred to
+			## the dock's Configure, and startup continues.
+			deferred.append({
+				"id": client_id,
+				"reason": "its godot-ai entry differs from what Configure wrote before the update",
+			})
+			continue
 		var configured := ClientConfigurator.configure(client_id, server_url, context)
 		if str(configured.get("status", "error")) != "ok":
 			return _post_update_result(false, generation, configured_ids, repinned_ids,
@@ -363,8 +379,9 @@ func _run_post_update_repin(
 	configured_ids.sort()
 	repinned_ids.sort()
 	foreign_ids.sort()
+	deferred.sort_custom(func(a: Dictionary, b: Dictionary) -> bool: return str(a.id) < str(b.id))
 	return _post_update_result(
-		true, generation, configured_ids, repinned_ids, "", prewarm, false, "", foreign_ids
+		true, generation, configured_ids, repinned_ids, "", prewarm, false, "", foreign_ids, deferred
 	)
 
 
@@ -378,6 +395,7 @@ static func _post_update_result(
 	termination_failed: bool = false,
 	unsafe_client_id: String = "",
 	foreign_ids: Array[String] = [],
+	deferred: Array[Dictionary] = [],
 ) -> Dictionary:
 	return {
 		"ok": ok,
@@ -390,6 +408,10 @@ static func _post_update_result(
 		"unsafe_client_id": unsafe_client_id,
 		## Entries under our name that launch something else; left unchanged.
 		"foreign_ids": foreign_ids.duplicate(),
+		## `{id, reason}` for entries the migration left unchanged because
+		## they were unreadable or drifted beyond the version pin (#999).
+		## They are the dock's Configure job, not a startup barrier.
+		"deferred": deferred.duplicate(true),
 	}
 
 

--- a/script/qualification_resources.py
+++ b/script/qualification_resources.py
@@ -44,9 +44,50 @@ class ProcessBinding:
             raise ResourceError("process creation time must be positive and finite")
 
 
+def _windows_process_has_exited(pid: int) -> bool:
+    """True when the Windows kernel already reports an exit code for ``pid``.
+
+    psutil proves a Windows process alive by opening it and reading its
+    creation time. A process that has exited while its parent still holds the
+    handle keeps its pid, its creation time and, on some hosts, its
+    system-table entry, so it can pass every psutil check with a thread count
+    right after the parent's own wait returned. GetExitCodeProcess is the
+    kernel's answer and is settled from the moment that wait released the
+    parent. A process this account cannot open, or one Windows reports as
+    still active, is left to psutil's own outcome; a process that chose exit
+    code 259 (STILL_ACTIVE) reads as running to Windows itself.
+    """
+    import ctypes
+    from ctypes import wintypes
+
+    if pid <= 0:
+        return False
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.GetExitCodeProcess.argtypes = (wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD))
+    kernel32.GetExitCodeProcess.restype = wintypes.BOOL
+    kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+    process_query_limited_information = 0x1000
+    still_active = 259
+    handle = kernel32.OpenProcess(process_query_limited_information, False, pid)
+    if not handle:
+        return False
+    try:
+        code = wintypes.DWORD()
+        if not kernel32.GetExitCodeProcess(handle, ctypes.byref(code)):
+            return False
+        return code.value != still_active
+    finally:
+        kernel32.CloseHandle(handle)
+
+
 def _process(pid: int):
     process = psutil.Process(pid)
     if process.status() in (psutil.STATUS_DEAD, psutil.STATUS_ZOMBIE):
+        raise ResourceError("requested process is dead or a zombie")
+    # psutil never reports a dead Windows process by status; ask the kernel.
+    if os.name == "nt" and _windows_process_has_exited(pid):
         raise ResourceError("requested process is dead or a zombie")
     return process
 

--- a/script/v4-release
+++ b/script/v4-release
@@ -487,6 +487,10 @@ def _process_is_live(pid: int) -> bool:
     lock holder as dead when psutil was absent, so a live editor's lock was
     replaced instead of refused.
     """
+    if pid <= 0:
+        # os.kill(0, 0) signals the caller's own process group and "succeeds";
+        # no lock is ever held by pid 0.
+        return False
     if os.name == "nt":
         return _windows_process_is_live(pid)
     try:

--- a/script/v4-release
+++ b/script/v4-release
@@ -480,13 +480,15 @@ def _write_json(path: Path, record: dict[str, object]) -> None:
 
 
 def _process_is_live(pid: int) -> bool:
-    """``os.kill(pid, 0)`` semantics; Windows asks psutil, or treats the pid as dead."""
+    """``os.kill(pid, 0)`` semantics on every OS, with no third-party dependency.
+
+    Windows asks the kernel directly. The published recovery command installs
+    only ``cryptography``; the earlier psutil lookup silently treated every
+    lock holder as dead when psutil was absent, so a live editor's lock was
+    replaced instead of refused.
+    """
     if os.name == "nt":
-        try:
-            import psutil
-        except ImportError:
-            return False
-        return psutil.pid_exists(pid)
+        return _windows_process_is_live(pid)
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
@@ -494,6 +496,34 @@ def _process_is_live(pid: int) -> bool:
     except PermissionError:
         return True
     return True
+
+
+def _windows_process_is_live(pid: int) -> bool:
+    import ctypes
+    from ctypes import wintypes
+
+    if pid <= 0:
+        return False
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.GetExitCodeProcess.argtypes = (wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD))
+    kernel32.GetExitCodeProcess.restype = wintypes.BOOL
+    kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+    process_query_limited_information = 0x1000
+    error_access_denied = 5
+    still_active = 259
+    handle = kernel32.OpenProcess(process_query_limited_information, False, pid)
+    if not handle:
+        # A process this account may not open still exists.
+        return ctypes.get_last_error() == error_access_denied
+    try:
+        code = wintypes.DWORD()
+        if not kernel32.GetExitCodeProcess(handle, ctypes.byref(code)):
+            return True
+        return code.value == still_active
+    finally:
+        kernel32.CloseHandle(handle)
 
 
 def _foreign_lock_holder(lock: Path) -> int | None:
@@ -663,9 +693,13 @@ def install_verified_release(
         "to_version": expected[3],
         "manifest_sha256": manifest_sha256,
         "expected_tree_sha256": expected_tree,
-        # A pre-v4 tree carries v3-shaped owned client entries; the plugin's
-        # first start may replace them outright, as the capsule crossing does.
-        "replace_owned_mismatches": not from_version.startswith("4."),
+        # The user ran this recovery by hand, outside the editor, usually
+        # because the in-editor path left stale entries behind (a v3 client
+        # pin, a 4.0.0/4.0.1 install whose updater could not download). The
+        # plugin's first start may therefore replace every owned entry that
+        # launches Godot AI, whatever version the live tree carried; entries
+        # that launch something else are still left alone (#999).
+        "replace_owned_mismatches": True,
         "backup_root": str(update / "backup" / from_version) if from_version else "",
     }
     _write_json(lock, {"pid": os.getpid(), "owner": "script/v4-release install"})

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -510,6 +510,49 @@ class _RepinRecordingOwner extends ClientJobOwnerScript:
 		}
 
 
+func test_post_update_window_reads_as_finishing_not_blocked() -> void:
+	_dock._build_ui()
+	## Restarted editor after an update: lifecycle dormant, transport blocked.
+	_dock.present_lifecycle_snapshot({"state": McpServerState.UNINITIALIZED})
+	_dock.present_transport_snapshot({"connected": false, "status": {"phase": "blocked"}})
+	_dock.present_update_state({
+		"install_in_flight": true,
+		"status_text": "Migrating client configuration…",
+		"banner_visible": true,
+		"post_update_action": "",
+	})
+	_dock._update_status()
+	assert_eq(_dock._status_label.text, "Finishing update — starting server…")
+	_dock.present_update_state({
+		"install_in_flight": false,
+		"status_text": "Update complete",
+		"post_update_action": "",
+		"outcome": "success",
+	})
+	_dock._update_status()
+	assert_eq(_dock._status_label.text, "Finishing update — starting server…")
+	## A real failure still wins over the friendly phase text.
+	_dock.present_lifecycle_snapshot({
+		"state": McpServerState.FOREIGN_PORT, "conflict_port": 8000, "message": "",
+	})
+	_dock._update_status()
+	assert_eq(_dock._status_label.text, "Port 8000 held by another process")
+	## Once connected the window is over and stays over.
+	_dock.present_lifecycle_snapshot({"state": McpServerState.READY})
+	_dock.present_transport_snapshot({"connected": true, "status": {"phase": "connected"}})
+	_dock._update_status()
+	assert_true(_dock._status_label.text.begins_with("Server connected"), _dock._status_label.text)
+	_dock.present_transport_snapshot({"connected": false, "status": {"phase": "blocked"}})
+	_dock._update_status()
+	assert_eq(_dock._status_label.text, "Connection blocked")
+	## A refused migration barrier is a real block.
+	_dock._post_update_server_pending = true
+	_dock.present_update_state({"post_update_action": "retry", "label_text": "blocked"})
+	_dock._update_status()
+	assert_eq(_dock._status_label.text, "Connection blocked")
+	_dock._post_update_server_pending = false
+
+
 func test_configure_all_dispatches_while_incompatible() -> void:
 	## The write path must run while INCOMPATIBLE — Configure writes an
 	## explicit url + live plugin version and does not need a healthy occupant.

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -553,6 +553,31 @@ func test_post_update_window_reads_as_finishing_not_blocked() -> void:
 	_dock._post_update_server_pending = false
 
 
+func test_failed_update_ends_the_finishing_window() -> void:
+	_dock._build_ui()
+	_dock.present_lifecycle_snapshot({"state": McpServerState.UNINITIALIZED})
+	_dock.present_transport_snapshot({"connected": false, "status": {"phase": "blocked"}})
+	_dock.present_update_state({
+		"install_in_flight": true,
+		"status_text": "Verifying…",
+		"banner_visible": true,
+		"post_update_action": "",
+	})
+	_dock._update_status()
+	assert_eq(_dock._status_label.text, "Finishing update — starting server…")
+	## `_fail_update`: no swap happened, the previous version is live, and
+	## nothing is starting, so the transport status is the truth again.
+	_dock.present_update_state({
+		"install_in_flight": false,
+		"status_text": "Update failed — previous version restored",
+		"button_disabled": false,
+	})
+	assert_false(_dock._post_update_server_pending)
+	assert_eq(_dock._status_label.text, "Connection blocked")
+	_dock._update_status()
+	assert_eq(_dock._status_label.text, "Connection blocked")
+
+
 func test_configure_all_dispatches_while_incompatible() -> void:
 	## The write path must run while INCOMPATIBLE — Configure writes an
 	## explicit url + live plugin version and does not need a healthy occupant.

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -416,13 +416,19 @@ func test_deferred_clients_do_not_block_startup_and_are_named_for_configure() ->
 		"foreign_ids": [],
 		"deferred": [
 			{"id": "pi", "reason": "its godot-ai entry differs from what Configure wrote before the update"},
+			{"id": "cursor", "reason": "its configuration could not be read: unexpected token"},
 		],
 	})
 	assert_eq(plugin.finished, 1, "a deferred client must not turn success into a barrier failure")
-	assert_eq(plugin._post_update_deferred.size(), 1)
+	assert_eq(plugin._post_update_deferred.size(), 2)
 	var label := plugin._post_update_complete_label()
 	assert_true(label.begins_with("Quit and relaunch AI clients"), label)
-	assert_true(label.contains("Pi Agent"), label)
+	## Each client carries its own reason: an unreadable file is not drift.
+	assert_true(
+		label.contains("Pi Agent (its godot-ai entry differs from what Configure wrote before the update)"),
+		label
+	)
+	assert_true(label.contains("Cursor (its configuration could not be read: unexpected token)"), label)
 	assert_true(label.contains("Configure"), label)
 	plugin._post_update_deferred = []
 	assert_false(plugin._post_update_complete_label().contains("Not migrated"))

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -393,3 +393,38 @@ func test_capability_pair_is_distinct_for_dev_and_managed_spawns() -> void:
 	assert_eq(str(pair.http).length(), 64)
 	assert_eq(str(pair.websocket).length(), 64)
 	assert_ne(pair.http, pair.websocket)
+
+
+class _DeferralRecordingPlugin extends Plugin:
+	var finished := 0
+
+	func _finish_post_update() -> void:
+		finished += 1
+
+
+func test_deferred_clients_do_not_block_startup_and_are_named_for_configure() -> void:
+	var plugin := _DeferralRecordingPlugin.new()
+	plugin._post_update_outcome = {
+		"outcome": "success",
+		"from_version": "3.2.4",
+		"to_version": VERSION,
+	}
+	plugin._on_post_update_repin_completed({
+		"ok": true,
+		"configured_ids": ["codex"],
+		"repinned_ids": ["codex"],
+		"foreign_ids": [],
+		"deferred": [
+			{"id": "pi", "reason": "its godot-ai entry differs from what Configure wrote before the update"},
+		],
+	})
+	assert_eq(plugin.finished, 1, "a deferred client must not turn success into a barrier failure")
+	assert_eq(plugin._post_update_deferred.size(), 1)
+	var label := plugin._post_update_complete_label()
+	assert_true(label.begins_with("Quit and relaunch AI clients"), label)
+	assert_true(label.contains("Pi Agent"), label)
+	assert_true(label.contains("Configure"), label)
+	plugin._post_update_deferred = []
+	assert_false(plugin._post_update_complete_label().contains("Not migrated"))
+	plugin._lifecycle = null
+	plugin.free()

--- a/tests/unit/test_dock_cli_timeout.py
+++ b/tests/unit/test_dock_cli_timeout.py
@@ -472,3 +472,16 @@ def test_dock_emits_endpoint_setting_values_and_root_owns_persistence() -> None:
     )
     assert "ClientConfigurator.apply_endpoint_settings(changes.duplicate(true))" in routed
     assert "func apply_endpoint_settings(changes: Dictionary) -> Dictionary:" in configurator_source
+
+
+def test_post_update_drift_is_deferred_to_configure_not_a_startup_barrier() -> None:
+    """#999: an entry that is not provably ours is left alone and named, never a block."""
+    owner_source = (PLUGIN_ROOT / "utils" / "client_job_owner.gd").read_text(encoding="utf-8")
+    post_update = get_func_block(owner_source, "func _run_post_update_repin(")
+    result = get_func_block(owner_source, "func _post_update_result(")
+
+    assert "automatic migration refused" not in post_update
+    assert post_update.count("deferred.append(") == 2
+    assert "entry_drift_is_version_pin_only(" in post_update
+    assert "ClientConfigurator.configure(" in post_update, "#890 write restriction stays"
+    assert '"deferred": deferred.duplicate(true)' in result

--- a/tests/unit/test_qualification_resources.py
+++ b/tests/unit/test_qualification_resources.py
@@ -2,7 +2,10 @@
 
 import copy
 import json
+import os
 import runpy
+import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -38,6 +41,15 @@ class Process:
 
     def num_handles(self):
         return self.handles
+
+
+REAL_WINDOWS_EXIT_REPORT = resources._windows_process_has_exited
+
+
+@pytest.fixture(autouse=True)
+def no_kernel_exit_report(monkeypatch):
+    """Fake psutil processes have no kernel behind them; pin the Windows probe."""
+    monkeypatch.setattr(resources, "_windows_process_has_exited", lambda pid: False)
 
 
 @pytest.fixture
@@ -93,6 +105,35 @@ def test_dead_or_zombie_is_not_a_successful_sample(process, status):
         resources.bind_process(100)
     with pytest.raises(resources.ResourceError, match="dead or a zombie"):
         resources.sample_process(resources.ProcessBinding(100, 123.5))
+
+
+@pytest.mark.parametrize("os_name", ["nt", "posix"])
+def test_kernel_exit_report_outranks_psutil_only_on_windows(process, monkeypatch, os_name):
+    """An exited child that psutil still answers for is dead on Windows."""
+    monkeypatch.setattr(resources.os, "name", os_name)
+    monkeypatch.setattr(resources, "_windows_process_has_exited", lambda pid: True)
+    if os_name == "nt":
+        with pytest.raises(resources.ResourceError, match="dead or a zombie"):
+            resources.bind_process(100)
+        with pytest.raises(resources.ResourceError, match="dead or a zombie"):
+            resources.sample_process(resources.ProcessBinding(100, 123.5))
+    else:
+        assert resources.sample_process(resources.bind_process(100))["threads"] == 3
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows kernel exit codes")
+def test_windows_exit_report_marks_a_still_open_child_dead(process, monkeypatch):
+    child = subprocess.Popen([sys.executable, "-c", "pass"])
+    child.wait(timeout=30)
+    # The Popen still holds the process handle, so the pid cannot be reused.
+    assert REAL_WINDOWS_EXIT_REPORT(child.pid) is True
+    assert REAL_WINDOWS_EXIT_REPORT(os.getpid()) is False
+    assert REAL_WINDOWS_EXIT_REPORT(0) is False
+    monkeypatch.setattr(resources, "_windows_process_has_exited", REAL_WINDOWS_EXIT_REPORT)
+    with pytest.raises(resources.ResourceError, match="dead or a zombie"):
+        resources.sample_process(resources.ProcessBinding(child.pid, 123.5))
+    binding = resources.bind_process(os.getpid())
+    assert resources.sample_process(binding)["pid"] == os.getpid()
 
 
 @pytest.mark.parametrize("when", ["before", "during"])

--- a/tests/unit/test_release_verify.py
+++ b/tests/unit/test_release_verify.py
@@ -501,6 +501,32 @@ def test_install_rollback_on_a_fresh_project_leaves_no_live_tree(release, tmp_pa
     )
 
 
+def test_process_liveness_needs_no_third_party_module():
+    assert v4_release._process_is_live(os.getpid())
+    finished = subprocess.Popen([sys.executable, "-c", "pass"])
+    finished.wait()
+    assert not v4_release._process_is_live(finished.pid)
+    assert not v4_release._process_is_live(0)
+    assert "import psutil" not in Path(v4_release.__file__).read_text(encoding="utf-8")
+
+
+def test_install_over_a_v4_tree_still_replaces_owned_mismatches(release, tmp_path):
+    """A hand-run recovery may repin every owned entry, whatever the live version."""
+    project = _project(tmp_path)
+    live = project / "addons/godot_ai"
+    config = live / "plugin.cfg"
+    config.write_text(
+        config.read_text(encoding="utf-8").replace('version="3.2.4"', 'version="4.0.1"'),
+        encoding="utf-8",
+    )
+
+    assert v4_release.main(_install_args(release, project)) == 0
+
+    marker = _marker(project)
+    assert marker["from_version"] == "4.0.1"
+    assert marker["replace_owned_mismatches"] is True
+
+
 def test_install_refuses_a_lock_held_by_another_live_process(release, tmp_path):
     project = _project(tmp_path)
     update = project / "addons/.godot_ai_update"


### PR DESCRIPTION
## What

Two users in #999 could not start the server after the manual 4.0.2 recovery:

```
MCP | post-update client migration blocked startup: pi has non-version configuration drift; automatic migration refused.
```

The post-update migration probes every automatic client descriptor. Pi's descriptor lists the project-scope `.mcp.json` as a merge tier, so a Claude Code `.mcp.json` carrying a v3-style `type: http` entry is attributed to Pi, fails the pin-only drift check from #890, and the whole migration returns a failure. That failure is a startup barrier: the server never starts, and the dock's "Retry client migration" runs the same check and fails the same way. An unreadable client file blocked startup identically.

## Fix

#890's write restriction stands: an entry that is not provably what Configure wrote before the update is never rewritten. But refusing the write is no reason to refuse the server. Such entries are now **deferred**: left unchanged, reported as `{id, reason}` in the migration result, named in the dock's completion banner with a Configure hint, and logged as a warning. Startup continues. The fatal outcomes stay fatal: tree verification, target-version mismatch, a repin write that fails or cannot be verified, and unproven worker termination.

The completion banner now also says "Quit and relaunch" rather than "Restart" the AI clients: Claude Desktop keeps its MCP configuration in memory and respawns the old bridge until the application itself is relaunched.

- `plugin/addons/godot_ai/utils/client_job_owner.gd`: drift and unreadable-config outcomes append to `deferred` and continue; `_post_update_result` carries `deferred`.
- `plugin/addons/godot_ai/plugin.gd`: records deferred entries, warns per client, and builds the completion label from them.
- `docs/self-update.md` step 9 documents the deferral.

Stacked on #1013 (the Windows harness fixes there are what let the real-editor rows pass on Windows); merge that first, then this rebases to `main` cleanly.

## Verification

- `ruff check` clean; `pytest -m "not editor"` green, including the new source contract in `tests/unit/test_dock_cli_timeout.py` that pins deferral over refusal while keeping the `ClientConfigurator.configure` authority path.
- Full GDScript suite in a live Godot 4.7.2 GUI editor on this worktree: 2250 passed, 0 failed, including `test_deferred_clients_do_not_block_startup_and_are_named_for_configure`.
- Real-editor rows (`pytest -m editor` with `GODOT_BIN` = 4.7.2 on Windows 11): see the final comment on this PR.

Addresses the startup block reported in #999 by fdasoghe and igorthenomad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Interactive smoke evidence (Windows 11, Godot 4.7.2 GUI editor, 2026-09-08)

Run with `script/local-self-update-smoke` from the combined #1013 + #1016 tree, the operator clicking Update in a real editor:

- `--from-v3-tag v3.2.4` (the 3.2.x to 4.x crossing): all seven harness checks PASS. Version advanced 3.2.4 to candidate; click, extract, swap, restart and client migration logged in order; update marker records success with the 3.2.4 backup retained; backup is the v3 tree with its capsule overlay; live tree is the canonical v4 tree; isolated Codex entry repinned; post-update `/godot-ai/status` live at the new version.
- `--base-from-release-tag v4.0.2 --next-version 4.0.3` (published 4.0.2 to candidate via the Update button): all eight checks PASS, including "self-update stopped the managed smoke server", "no server/plugin version mismatch", and the restarted editor completing client migration with the server live at 4.0.3.

One harness limitation found on this box: a v3 tree installed from a tag reads the global `godot_ai/http_port` editor setting, so on a machine whose global port is in use the crossing smoke needs the global ports pointed at the fixture ports for its duration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updates no longer stop startup when client configuration drift is unreadable or cannot be safely migrated.
  * Deferred client changes are reported in the completion message with guidance to use Configure.
  * Windows update-lock detection is now more reliable.
  * Owned client entries are correctly refreshed during updates.

* **User Experience**
  * Added a “Finishing update — starting server…” status while post-update startup completes.

* **Documentation**
  * Updated self-update guidance to explain deferred and successful client migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->