### PR TITLE
fix: name a pre-v4 godot-ai occupant and wait for it after an update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ reading. Release engineering: [docs/releasing.md](docs/releasing.md).
   refused` and a Retry that failed the same way. The entry is still never
   rewritten (#890), but it no longer holds the server: it is left
   unchanged, named in the completion banner with a Configure hint, and
+  startup continues. While an update brings the server back the dock now
+  reads `Finishing update — starting server…` instead of a red
+  `Connection blocked`
   startup continues
 - **Closed-editor recovery installer** (`script/v4-release install`, the
   #999 procedure): on Windows it treated every update-lock holder as dead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ reading. Release engineering: [docs/releasing.md](docs/releasing.md).
 
 ### Fixed
 
+- A Godot AI 3.x server left on the port by an AI client whose bridge
+  attached before the update was reported as "held by another process". The
+  lifecycle now performs one untrusted, tokenless status read solely to word
+  the block: it names the pre-v4 server, tells the user to quit and relaunch
+  that client, and re-probes slowly for about three and a half minutes so
+  the editor comes up green once the old server's lease and idle backstop
+  run out. The read grants no adoption, replacement or kill authority. The
+  dock and the migration guide now say "quit and relaunch" rather than
+  "restart": Claude Desktop keeps its MCP configuration in memory and
+  respawns the old bridge until the application itself is relaunched.
 - After an update, a client entry the migration could not prove as
   "what Configure wrote before the update" (a project `.mcp.json` with a
   v3 `type: http` entry, an unreadable file) blocked the server with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ reading. Release engineering: [docs/releasing.md](docs/releasing.md).
 
 ### Fixed
 
+- **Closed-editor recovery installer** (`script/v4-release install`, the
+  #999 procedure): on Windows it treated every update-lock holder as dead
+  when `psutil` was not installed, which the published command never
+  installs, so a live editor's lock was replaced instead of refused; the
+  check now asks the kernel directly and needs no third-party module. A
+  recovery over an existing 4.x tree also records
+  `replace_owned_mismatches`, so the plugin's first start may repin every
+  owned client entry that launches Godot AI, whatever the live tree's
+  version, instead of refusing startup over a leftover v3-shaped entry
+  ([#999](https://github.com/hi-godot/godot-ai/issues/999)).
 - **Windows:** the server launched to replace an older godot-ai backend gave
   up waiting for the port after 5 s, before the plugin had finished proving
   the new process and killing the old one (each identity probe is a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ reading. Release engineering: [docs/releasing.md](docs/releasing.md).
 
 ### Fixed
 
+- After an update, a client entry the migration could not prove as
+  "what Configure wrote before the update" (a project `.mcp.json` with a
+  v3 `type: http` entry, an unreadable file) blocked the server with
+  `<client> has non-version configuration drift; automatic migration
+  refused` and a Retry that failed the same way. The entry is still never
+  rewritten (#890), but it no longer holds the server: it is left
+  unchanged, named in the completion banner with a Configure hint, and
+  startup continues
 - **Closed-editor recovery installer** (`script/v4-release install`, the
   #999 procedure): on Windows it treated every update-lock holder as dead
   when `psutil` was not installed, which the published command never

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -39,7 +39,9 @@ All steps run inside the editor, on the main thread except the download.
 1. **Check.** The dock polls the releases API; a candidate is a newer `4.x`
    release exposing the six-name asset set. Dev checkouts skip this. Clicking
    Update asks first: the update saves the project, relaunches the editor,
-   and connected AI clients must be restarted afterwards.
+   and AI clients connected during the update must be quit and relaunched
+   afterwards (a client that keeps its MCP configuration in memory respawns
+   the old bridge on a mere server restart).
 2. **Download** the three canonical assets into
    `user://godot_ai_update/download/`, enforcing the release-declared sizes and
    trusted asset URLs exactly as today.

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -89,8 +89,13 @@ All steps run inside the editor, on the main thread except the download.
      stale-server recovery arm and the pin-only auto-repin gate already read),
      repin owned client configuration once and record `clients_migrated` in
      the marker, emit the `self_update` telemetry event, and continue normal
-     startup. A success marker that records its migration is the durable
-     record of the last update and is nothing pending on later starts;
+     startup. An entry the migration cannot prove as what Configure wrote
+     before the update (a hand-edited or v3-shaped entry, an unreadable
+     file) is never rewritten (#890) and never blocks the server either: it
+     is left unchanged, named in the completion banner, and left to the
+     dock's Configure (#999). A success marker that records its migration is
+     the durable record of the last update and is nothing pending on later
+     starts;
    - different: rename the live tree to `.godot_ai_update/quarantine/`, rename
      the backup back into place, mark `status: rolled_back` with the reason,
      and show it in the dock. If the backup is missing too, mark

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -115,8 +115,11 @@ All steps run inside the editor, on the main thread except the download.
     never free between the old backend's death and ours listening: a bridge
     polling for a free port to spawn again never sees one. The
     old bridge itself refuses the new backend as incompatible, so the dock
-    tells the user to restart AI clients that were connected during the
-    update; the repinned client configuration launches the new version.
+    tells the user to quit and relaunch AI clients that were connected
+    during the update; the repinned client configuration launches the new
+    version. Quit, not restart: Claude Desktop keeps its MCP configuration
+    in memory and respawns the old bridge from it until the application
+    itself is relaunched.
 
 ## The v3-to-v4 capsule
 

--- a/docs/server-lifecycle.md
+++ b/docs/server-lifecycle.md
@@ -92,7 +92,17 @@ The Python server owns the private record and a per-port launch claim. HTTP,
 status, and lease routes require the HTTP bearer. The editor WebSocket stays on
 IPv4 loopback and uses a transcript-bound challenge/response before the editor
 reveals project metadata. There is no v3 parser, tokenless retry, or bare URL
-fallback in v4.
+fallback in v4. One deliberately untrusted read exists beside the probe:
+when the port is bound and the authenticated probe finds no record, the
+lifecycle performs a single bounded, tokenless GET of `/godot-ai/status`
+and, only if the body claims `name: godot-ai` with a `3.x`
+`server_version`, words the BLOCKED message as a pre-v4 server kept
+alive by a client's old bridge. That result never enters the probe
+outcome, never becomes a transport, and grants no replacement or kill
+authority; the occupant stays `replaceable: false`. After an update the
+plugin re-probes such a block slowly for about three and a half minutes,
+long enough for the old bridge's lease and the server's idle backstop to
+run out once the user quits and relaunches that client.
 
 An adopted backend remains external. Ordinary teardown drops the transport and
 leaves it running. A plugin-launched backend is stopped only with its matching

--- a/docs/server-lifecycle.md
+++ b/docs/server-lifecycle.md
@@ -91,8 +91,9 @@ report is quoted, bounded and never interpreted.
 The Python server owns the private record and a per-port launch claim. HTTP,
 status, and lease routes require the HTTP bearer. The editor WebSocket stays on
 IPv4 loopback and uses a transcript-bound challenge/response before the editor
-reveals project metadata. There is no v3 parser, tokenless retry, or bare URL
-fallback in v4. One deliberately untrusted read exists beside the probe:
+reveals project metadata. There is no legacy v3 protocol fallback, tokenless
+retry, or bare URL fallback in v4. One deliberately untrusted read exists
+beside the probe:
 when the port is bound and the authenticated probe finds no record, the
 lifecycle performs a single bounded, tokenless GET of `/godot-ai/status`
 and, only if the body claims `name: godot-ai` with a `3.x`

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -2805,6 +2805,12 @@ func present_update_state(state: Dictionary) -> void:
 		_post_update_server_pending = true
 		if _status_label != null:
 			_update_status()
+	elif state.has("install_in_flight"):
+		## The install ended without a swap (`_fail_update`): the previous
+		## version is live and the transport status is the truth again.
+		_post_update_server_pending = false
+		if _status_label != null:
+			_update_status()
 	if state.has("button_text") and _update_btn != null:
 		_update_btn.text = String(state["button_text"])
 	if state.has("button_disabled") and _update_btn != null:

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -255,6 +255,11 @@ var _update_btn: Button
 const _UPDATE_ACTION_TEXT := "Update"
 const _UPDATE_LABEL_COLOR := Color(1.0, 0.85, 0.3)
 var _post_update_action := ""
+## True from the moment an update starts its client migration until the
+## server it then starts is connected. The transport reads "blocked" for
+## that whole window (the migration barrier, then the launch), which is
+## not a fault: name the phase instead of alarming the user (#999).
+var _post_update_server_pending := false
 
 func _ready() -> void:
 	_startup_grace_until_msec = Time.get_ticks_msec() + STARTUP_GRACE_MSEC
@@ -792,6 +797,8 @@ func _update_status() -> void:
 	var state: int = int(server_status.get("state", ServerStateScript.UNINITIALIZED))
 	if ServerStateScript.blocks_client_health(state):
 		connected = false
+	if connected:
+		_post_update_server_pending = false
 
 	## One `match`/`elif` chain, one source of truth. Adding a new
 	## spawn outcome = one `ServerStateScript` constant + one arm here +
@@ -829,6 +836,11 @@ func _update_status() -> void:
 	elif state == ServerStateScript.NO_COMMAND:
 		status_text = "No server command found"
 		status_color = Color.RED
+	elif _post_update_server_pending:
+		## Every terminal spawn failure matched above; what is left is the
+		## post-update window where the server is being brought back.
+		status_text = "Finishing update — starting server…"
+		status_color = COLOR_AMBER
 	elif not transport_status.is_empty():
 		var transport_phase := str(transport_status.get("phase", ""))
 		if transport_phase == "connecting":
@@ -2786,6 +2798,13 @@ func present_update_state(state: Dictionary) -> void:
 			_update_btn.text = _UPDATE_ACTION_TEXT
 	if state.has("install_in_flight"):
 		_update_install_in_flight = bool(state["install_in_flight"])
+	if String(state.get("post_update_action", "")) == "retry":
+		## The migration barrier refused: the connection really is blocked.
+		_post_update_server_pending = false
+	elif bool(state.get("install_in_flight", false)) or String(state.get("outcome", "")) == "success":
+		_post_update_server_pending = true
+		if _status_label != null:
+			_update_status()
 	if state.has("button_text") and _update_btn != null:
 		_update_btn.text = String(state["button_text"])
 	if state.has("button_disabled") and _update_btn != null:

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -127,7 +127,9 @@ var _post_update_outcome: Dictionary = {}
 var _post_update_replaced_version := ""
 ## Clients the post-update migration left unchanged (`{id, reason}`), named
 ## in the dock's completion banner so the user knows to click Configure.
-var _post_update_deferred: Array[Dictionary] = []
+## Untyped on purpose: a typed collection field is the hot-reload crash
+## class (#245) the self-update smoke injects to prove the swap survives it.
+var _post_update_deferred := []
 var _last_logged_block := ""
 ## Bounded re-probes while that backend is still binding its port: a port
 ## that is bound but not yet answering status reads as merely occupied.
@@ -910,15 +912,13 @@ func _post_update_complete_label() -> String:
 	)
 	if _post_update_deferred.is_empty():
 		return text
-	var names: Array[String] = []
+	var named: Array[String] = []
 	for entry in _post_update_deferred:
-		var client := McpClientRegistry.get_by_id(str(entry.get("id", "")))
-		names.append(client.display_name if client != null else str(entry.get("id", "")))
-	return (
-		text
-		+ " Not migrated because their godot-ai entry differs from what Configure wrote: %s. Use Configure to replace them."
-		% ", ".join(names)
-	)
+		var client_id := str(entry.get("id", ""))
+		var client := McpClientRegistry.get_by_id(client_id)
+		var name: String = client.display_name if client != null else client_id
+		named.append("%s (%s)" % [name, str(entry.get("reason", "not migrated"))])
+	return text + " Not migrated: %s. Use Configure to replace them." % ", ".join(named)
 
 
 ## Sole release point for ordinary work and the server lifecycle. Keeping

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -135,6 +135,15 @@ var _last_logged_block := ""
 ## that is bound but not yet answering status reads as merely occupied.
 const POST_UPDATE_REPROBE_LIMIT := 10
 var _post_update_reprobes_left := POST_UPDATE_REPROBE_LIMIT
+## A pre-v4 server left on the port by a still-running v3 attach bridge
+## outlives the fast budget above: its lease lasts 30 s after that client
+## quits and its idle backstop another 120 s. Poll slowly across that
+## window so the editor comes up green once the user has relaunched the
+## client, without any replacement authority over a server we cannot
+## authenticate.
+const POST_UPDATE_STALE_REPROBE_SECONDS := 10.0
+const POST_UPDATE_STALE_REPROBE_LIMIT := 21
+var _post_update_stale_reprobes_left := POST_UPDATE_STALE_REPROBE_LIMIT
 ## An old bridge spawns again as soon as the port frees, so one replacement
 ## may not be the last; a few are allowed before the dock takes over.
 const POST_UPDATE_REPLACEMENT_LIMIT := 3
@@ -866,9 +875,10 @@ func _finish_post_update() -> void:
 	UpdateInstaller.prune_backups(str(_post_update_outcome.get("from_version", "")))
 	_post_update_replaced_version = str(_post_update_outcome.get("from_version", ""))
 	_post_update_reprobes_left = POST_UPDATE_REPROBE_LIMIT
+	_post_update_stale_reprobes_left = POST_UPDATE_STALE_REPROBE_LIMIT
 	_post_update_replacements_left = POST_UPDATE_REPLACEMENT_LIMIT
 	print(
-		"MCP | AI clients attached before the update must restart to use v%s"
+		"MCP | AI clients attached before the update must be quit and relaunched to use v%s"
 		% str(_post_update_outcome.get("to_version", ""))
 	)
 	_present_post_update_complete()
@@ -1304,7 +1314,22 @@ func _replace_server_left_by_update(snapshot: Dictionary) -> void:
 		## bounded number of times; the re-probe finds that backend answering
 		## and takes the replacement path. Then the dock's Restart Server is
 		## the remaining path.
-		if str(snapshot.get("episode_state", "")) == "BLOCKED" and _post_update_reprobes_left > 0:
+		if str(snapshot.get("episode_state", "")) != "BLOCKED":
+			return
+		if str(snapshot.get("blocked_hint", "")) == ServerLifecycleManager.STALE_PRE_V4_HINT:
+			if _post_update_stale_reprobes_left <= 0:
+				return
+			if _post_update_stale_reprobes_left == POST_UPDATE_STALE_REPROBE_LIMIT:
+				print(
+					"MCP | a pre-v4 godot-ai server holds port %d; waiting for it to exit once its AI client is relaunched"
+					% int(snapshot.get("conflict_port", 0))
+				)
+			_post_update_stale_reprobes_left -= 1
+			get_tree().create_timer(POST_UPDATE_STALE_REPROBE_SECONDS).timeout.connect(
+				_reprobe_after_update, CONNECT_ONE_SHOT
+			)
+			return
+		if _post_update_reprobes_left > 0:
 			_post_update_reprobes_left -= 1
 			get_tree().create_timer(1.0).timeout.connect(_reprobe_after_update, CONNECT_ONE_SHOT)
 		return

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -125,6 +125,9 @@ var _post_update_outcome: Dictionary = {}
 ## update may spawn a backend of that version into the restart window; the
 ## restarted editor replaces it once instead of asking the user to.
 var _post_update_replaced_version := ""
+## Clients the post-update migration left unchanged (`{id, reason}`), named
+## in the dock's completion banner so the user knows to click Configure.
+var _post_update_deferred: Array[Dictionary] = []
 var _last_logged_block := ""
 ## Bounded re-probes while that backend is still binding its port: a port
 ## that is bound but not yet answering status reads as merely occupied.
@@ -811,6 +814,14 @@ func _on_post_update_repin_completed(result: Dictionary) -> void:
 			"MCP | the %s entry named godot-ai launches something else; it was left unchanged. Use Configure in the dock to replace it."
 			% str(client_id)
 		)
+	_post_update_deferred = []
+	for entry in result.get("deferred", []):
+		if entry is Dictionary:
+			_post_update_deferred.append((entry as Dictionary).duplicate(true))
+			push_warning(
+				"MCP | %s was not migrated automatically because %s; it was left unchanged. Use Configure in the dock."
+				% [str(entry.get("id", "")), str(entry.get("reason", ""))]
+			)
 	## A click cannot prove that an external client restarted. The enforceable
 	## boundary is the one we own: repin its configuration, mark the update
 	## complete, then start and authenticate that server. Clients reconnect to
@@ -885,14 +896,29 @@ func _present_post_update_complete() -> void:
 			"install_in_flight": false,
 			"status_text": "Update complete",
 			"button_disabled": true,
-			"label_text": (
-				"Restart AI clients that were connected during the update so they use v%s."
-				% str(_post_update_outcome.get("to_version", ""))
-			),
+			"label_text": _post_update_complete_label(),
 			"banner_visible": true,
 			"post_update_action": "",
 			"outcome": "success",
 		})
+
+
+func _post_update_complete_label() -> String:
+	var text := (
+		"Quit and relaunch AI clients that were connected during the update so they use v%s."
+		% str(_post_update_outcome.get("to_version", ""))
+	)
+	if _post_update_deferred.is_empty():
+		return text
+	var names: Array[String] = []
+	for entry in _post_update_deferred:
+		var client := McpClientRegistry.get_by_id(str(entry.get("id", "")))
+		names.append(client.display_name if client != null else str(entry.get("id", "")))
+	return (
+		text
+		+ " Not migrated because their godot-ai entry differs from what Configure wrote: %s. Use Configure to replace them."
+		% ", ".join(names)
+	)
 
 
 ## Sole release point for ordinary work and the server lifecycle. Keeping

--- a/plugin/addons/godot_ai/utils/client_job_owner.gd
+++ b/plugin/addons/godot_ai/utils/client_job_owner.gd
@@ -296,6 +296,7 @@ func _run_post_update_repin(
 	var configured_ids: Array[String] = []
 	var repinned_ids: Array[String] = []
 	var foreign_ids: Array[String] = []
+	var deferred: Array[Dictionary] = []
 	if bool(prewarm.get("termination_failed", false)):
 		return _post_update_result(
 			false,
@@ -324,8 +325,15 @@ func _run_post_update_repin(
 		if status == Client.Status.NOT_CONFIGURED:
 			continue
 		if status == Client.Status.ERROR:
-			return _post_update_result(false, generation, configured_ids, repinned_ids,
-				"%s status failed: %s" % [client_id, str(details.get("error_msg", "unknown error"))], prewarm)
+			## One client whose configuration cannot even be read must not
+			## hold every other client and the server itself hostage: leave
+			## it for the dock's Configure and say so.
+			deferred.append({
+				"id": client_id,
+				"reason": "its configuration could not be read: %s"
+				% str(details.get("error_msg", "unknown error")),
+			})
+			continue
 		if status == Client.Status.CONFIGURED:
 			configured_ids.append(client_id)
 			continue
@@ -339,8 +347,16 @@ func _run_post_update_repin(
 		elif not ClientConfigurator.entry_drift_is_version_pin_only(
 			client_id, from_version, context
 		):
-			return _post_update_result(false, generation, configured_ids, repinned_ids,
-				"%s has non-version configuration drift; automatic migration refused." % client_id, prewarm)
+			## #890's write restriction stands: an entry that is not provably
+			## what Configure wrote before the update is never rewritten here.
+			## But refusing the write is not a reason to refuse the server
+			## (#999): the entry is left untouched, named, and deferred to
+			## the dock's Configure, and startup continues.
+			deferred.append({
+				"id": client_id,
+				"reason": "its godot-ai entry differs from what Configure wrote before the update",
+			})
+			continue
 		var configured := ClientConfigurator.configure(client_id, server_url, context)
 		if str(configured.get("status", "error")) != "ok":
 			return _post_update_result(false, generation, configured_ids, repinned_ids,
@@ -363,8 +379,9 @@ func _run_post_update_repin(
 	configured_ids.sort()
 	repinned_ids.sort()
 	foreign_ids.sort()
+	deferred.sort_custom(func(a: Dictionary, b: Dictionary) -> bool: return str(a.id) < str(b.id))
 	return _post_update_result(
-		true, generation, configured_ids, repinned_ids, "", prewarm, false, "", foreign_ids
+		true, generation, configured_ids, repinned_ids, "", prewarm, false, "", foreign_ids, deferred
 	)
 
 
@@ -378,6 +395,7 @@ static func _post_update_result(
 	termination_failed: bool = false,
 	unsafe_client_id: String = "",
 	foreign_ids: Array[String] = [],
+	deferred: Array[Dictionary] = [],
 ) -> Dictionary:
 	return {
 		"ok": ok,
@@ -390,6 +408,10 @@ static func _post_update_result(
 		"unsafe_client_id": unsafe_client_id,
 		## Entries under our name that launch something else; left unchanged.
 		"foreign_ids": foreign_ids.duplicate(),
+		## `{id, reason}` for entries the migration left unchanged because
+		## they were unreadable or drifted beyond the version pin (#999).
+		## They are the dock's Configure job, not a startup barrier.
+		"deferred": deferred.duplicate(true),
 	}
 
 

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -37,6 +37,7 @@ const STOP := "STOP"
 
 const STATUS_PATH := "/godot-ai/status"
 const DEFAULT_PROBE_TIMEOUT_MS := 800
+const STALE_PRE_V4_HINT := "stale_pre_v4_server"
 const DEFAULT_PROVE_TIMEOUT_MS := 180_000
 const LAUNCH_FINGERPRINT_TIMEOUT_MS := 15_000
 const REPLACEMENT_TTL_MS := 15_000
@@ -671,7 +672,12 @@ func _effect_probe(payload: Dictionary) -> Dictionary:
 			}
 		return _blocked_probe_result("incompatible", port, live, true)
 	if PortResolver.is_port_in_use(port):
-		return _blocked_probe_result("occupied", port, live)
+		var blocked := _blocked_probe_result("occupied", port, live)
+		var pre_v4 := _untrusted_pre_v4_occupant_version(port, int(payload.timeout_ms))
+		if not pre_v4.is_empty():
+			blocked["message"] = stale_pre_v4_message(port, pre_v4)
+			blocked["target"]["hint"] = STALE_PRE_V4_HINT
+		return blocked
 	return {
 		"outcome": "free",
 		"baseline_instance_id": str(capability.get("instance_nonce", "")),
@@ -1298,6 +1304,78 @@ static func startup_report_summary(path: String, max_chars := 600) -> String:
 	if text.length() > max_chars:
 		text = text.substr(0, max_chars - 1) + "…"
 	return text
+## Untrusted, bounded, tokenless read of `/godot-ai/status`, used ONLY to
+## word the BLOCKED message when a pre-v4 godot-ai server holds the port. A
+## v3 server never wrote a v4 capability record, so the authenticated probe
+## cannot even name it, and the dock could only say "another process". This
+## peek is not a fallback: its result never enters the probe outcome, never
+## becomes a transport, and never contributes to replacement or kill
+## authority; `_blocked_probe_result` keeps `replaceable` false. It answers
+## one question, "is that a Godot AI 3.x server?", so the user is told to
+## quit the AI client whose bridge keeps it alive instead of hunting for a
+## foreign process. docs/server-lifecycle.md states the exception.
+static func _untrusted_pre_v4_occupant_version(port: int, timeout_ms: int) -> String:
+	var client := HTTPClient.new()
+	if client.connect_to_host("127.0.0.1", port) != OK:
+		return ""
+	var deadline := Time.get_ticks_msec() + maxi(1, timeout_ms)
+	while client.get_status() in [HTTPClient.STATUS_RESOLVING, HTTPClient.STATUS_CONNECTING]:
+		client.poll()
+		if Time.get_ticks_msec() >= deadline:
+			return ""
+		OS.delay_msec(10)
+	if client.get_status() != HTTPClient.STATUS_CONNECTED:
+		return ""
+	if client.request(HTTPClient.METHOD_GET, STATUS_PATH, ["Accept: application/json"]) != OK:
+		return ""
+	var body := PackedByteArray()
+	while true:
+		var status := client.get_status()
+		if status == HTTPClient.STATUS_REQUESTING:
+			client.poll()
+		elif status == HTTPClient.STATUS_BODY:
+			client.poll()
+			var chunk := client.read_response_body_chunk()
+			if body.size() + chunk.size() > MAX_STATUS_BODY_BYTES:
+				return ""
+			body.append_array(chunk)
+		elif status == HTTPClient.STATUS_CONNECTED:
+			break
+		else:
+			return ""
+		if Time.get_ticks_msec() >= deadline:
+			return ""
+		OS.delay_msec(10)
+	if client.get_response_code() != 200:
+		return ""
+	var parsed: Variant = JSON.parse_string(body.get_string_from_utf8())
+	return pre_v4_version_from_status(parsed)
+
+
+## "3.2.4" for a payload that claims to be a godot-ai server below v4, else "".
+## Pure and bounded so the contract is unit-testable without a socket.
+static func pre_v4_version_from_status(parsed: Variant) -> String:
+	if not (parsed is Dictionary):
+		return ""
+	if str(parsed.get("name", "")) != "godot-ai":
+		return ""
+	var version := str(parsed.get("server_version", "")).strip_edges()
+	if version.length() > 32 or not version.begins_with("3."):
+		return ""
+	for index in range(version.length()):
+		var code := version.unicode_at(index)
+		if not ((code >= 48 and code <= 57) or code == 46):
+			return ""
+	return version
+
+
+static func stale_pre_v4_message(port: int, version: String) -> String:
+	return (
+		"Port %d is held by a Godot AI %s server that an AI client attached before the update "
+		+ "keeps alive. Quit and relaunch that client (restarting its MCP server is not enough); "
+		+ "the old server exits on its own within about three minutes, and the editor retries "
+		+ "meanwhile. Otherwise click Restart Server afterwards."
+	) % [port, version]
 
 
 static func active_lease_count(live: Dictionary) -> int:
@@ -1336,6 +1414,8 @@ func get_status_dict() -> Dictionary:
 		"can_recover_incompatible": can_recover_incompatible_server(),
 		"conflict_port": int(_episode.get("blocked_target", {}).get("port", 0)),
 		"conflict_version": str(_episode.get("blocked_target", {}).get("version", "")),
+		## Wording-only hint from the untrusted pre-v4 peek; never authority.
+		"blocked_hint": str(_episode.get("blocked_target", {}).get("hint", "")),
 		"keep_alive": bool(_plan.get("keep_alive", false)),
 		"recovery_attempt": _endpoint_recovery_attempts,
 		"recovery_limit": ENDPOINT_RECOVERY_DELAYS_SECONDS.size(),

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -1362,10 +1362,16 @@ static func pre_v4_version_from_status(parsed: Variant) -> String:
 	var version := str(parsed.get("server_version", "")).strip_edges()
 	if version.length() > 32 or not version.begins_with("3."):
 		return ""
-	for index in range(version.length()):
-		var code := version.unicode_at(index)
-		if not ((code >= 48 and code <= 57) or code == 46):
+	## Every dot-separated component must be digits and non-empty: "3.",
+	## "3..2" and "3.2." are not versions and must not earn the stale-server
+	## wording or the slow post-update retry.
+	for part in version.split("."):
+		if part.is_empty():
 			return ""
+		for index in range(part.length()):
+			var code := part.unicode_at(index)
+			if code < 48 or code > 57:
+				return ""
 	return version
 
 

--- a/script/qualification_resources.py
+++ b/script/qualification_resources.py
@@ -44,9 +44,50 @@ class ProcessBinding:
             raise ResourceError("process creation time must be positive and finite")
 
 
+def _windows_process_has_exited(pid: int) -> bool:
+    """True when the Windows kernel already reports an exit code for ``pid``.
+
+    psutil proves a Windows process alive by opening it and reading its
+    creation time. A process that has exited while its parent still holds the
+    handle keeps its pid, its creation time and, on some hosts, its
+    system-table entry, so it can pass every psutil check with a thread count
+    right after the parent's own wait returned. GetExitCodeProcess is the
+    kernel's answer and is settled from the moment that wait released the
+    parent. A process this account cannot open, or one Windows reports as
+    still active, is left to psutil's own outcome; a process that chose exit
+    code 259 (STILL_ACTIVE) reads as running to Windows itself.
+    """
+    import ctypes
+    from ctypes import wintypes
+
+    if pid <= 0:
+        return False
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.GetExitCodeProcess.argtypes = (wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD))
+    kernel32.GetExitCodeProcess.restype = wintypes.BOOL
+    kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+    process_query_limited_information = 0x1000
+    still_active = 259
+    handle = kernel32.OpenProcess(process_query_limited_information, False, pid)
+    if not handle:
+        return False
+    try:
+        code = wintypes.DWORD()
+        if not kernel32.GetExitCodeProcess(handle, ctypes.byref(code)):
+            return False
+        return code.value != still_active
+    finally:
+        kernel32.CloseHandle(handle)
+
+
 def _process(pid: int):
     process = psutil.Process(pid)
     if process.status() in (psutil.STATUS_DEAD, psutil.STATUS_ZOMBIE):
+        raise ResourceError("requested process is dead or a zombie")
+    # psutil never reports a dead Windows process by status; ask the kernel.
+    if os.name == "nt" and _windows_process_has_exited(pid):
         raise ResourceError("requested process is dead or a zombie")
     return process
 

--- a/script/v4-release
+++ b/script/v4-release
@@ -487,6 +487,10 @@ def _process_is_live(pid: int) -> bool:
     lock holder as dead when psutil was absent, so a live editor's lock was
     replaced instead of refused.
     """
+    if pid <= 0:
+        # os.kill(0, 0) signals the caller's own process group and "succeeds";
+        # no lock is ever held by pid 0.
+        return False
     if os.name == "nt":
         return _windows_process_is_live(pid)
     try:

--- a/script/v4-release
+++ b/script/v4-release
@@ -480,13 +480,15 @@ def _write_json(path: Path, record: dict[str, object]) -> None:
 
 
 def _process_is_live(pid: int) -> bool:
-    """``os.kill(pid, 0)`` semantics; Windows asks psutil, or treats the pid as dead."""
+    """``os.kill(pid, 0)`` semantics on every OS, with no third-party dependency.
+
+    Windows asks the kernel directly. The published recovery command installs
+    only ``cryptography``; the earlier psutil lookup silently treated every
+    lock holder as dead when psutil was absent, so a live editor's lock was
+    replaced instead of refused.
+    """
     if os.name == "nt":
-        try:
-            import psutil
-        except ImportError:
-            return False
-        return psutil.pid_exists(pid)
+        return _windows_process_is_live(pid)
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
@@ -494,6 +496,34 @@ def _process_is_live(pid: int) -> bool:
     except PermissionError:
         return True
     return True
+
+
+def _windows_process_is_live(pid: int) -> bool:
+    import ctypes
+    from ctypes import wintypes
+
+    if pid <= 0:
+        return False
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.GetExitCodeProcess.argtypes = (wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD))
+    kernel32.GetExitCodeProcess.restype = wintypes.BOOL
+    kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+    process_query_limited_information = 0x1000
+    error_access_denied = 5
+    still_active = 259
+    handle = kernel32.OpenProcess(process_query_limited_information, False, pid)
+    if not handle:
+        # A process this account may not open still exists.
+        return ctypes.get_last_error() == error_access_denied
+    try:
+        code = wintypes.DWORD()
+        if not kernel32.GetExitCodeProcess(handle, ctypes.byref(code)):
+            return True
+        return code.value == still_active
+    finally:
+        kernel32.CloseHandle(handle)
 
 
 def _foreign_lock_holder(lock: Path) -> int | None:
@@ -663,9 +693,13 @@ def install_verified_release(
         "to_version": expected[3],
         "manifest_sha256": manifest_sha256,
         "expected_tree_sha256": expected_tree,
-        # A pre-v4 tree carries v3-shaped owned client entries; the plugin's
-        # first start may replace them outright, as the capsule crossing does.
-        "replace_owned_mismatches": not from_version.startswith("4."),
+        # The user ran this recovery by hand, outside the editor, usually
+        # because the in-editor path left stale entries behind (a v3 client
+        # pin, a 4.0.0/4.0.1 install whose updater could not download). The
+        # plugin's first start may therefore replace every owned entry that
+        # launches Godot AI, whatever version the live tree carried; entries
+        # that launch something else are still left alone (#999).
+        "replace_owned_mismatches": True,
         "backup_root": str(update / "backup" / from_version) if from_version else "",
     }
     _write_json(lock, {"pid": os.getpid(), "owner": "script/v4-release install"})

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -510,6 +510,49 @@ class _RepinRecordingOwner extends ClientJobOwnerScript:
 		}
 
 
+func test_post_update_window_reads_as_finishing_not_blocked() -> void:
+	_dock._build_ui()
+	## Restarted editor after an update: lifecycle dormant, transport blocked.
+	_dock.present_lifecycle_snapshot({"state": McpServerState.UNINITIALIZED})
+	_dock.present_transport_snapshot({"connected": false, "status": {"phase": "blocked"}})
+	_dock.present_update_state({
+		"install_in_flight": true,
+		"status_text": "Migrating client configuration…",
+		"banner_visible": true,
+		"post_update_action": "",
+	})
+	_dock._update_status()
+	assert_eq(_dock._status_label.text, "Finishing update — starting server…")
+	_dock.present_update_state({
+		"install_in_flight": false,
+		"status_text": "Update complete",
+		"post_update_action": "",
+		"outcome": "success",
+	})
+	_dock._update_status()
+	assert_eq(_dock._status_label.text, "Finishing update — starting server…")
+	## A real failure still wins over the friendly phase text.
+	_dock.present_lifecycle_snapshot({
+		"state": McpServerState.FOREIGN_PORT, "conflict_port": 8000, "message": "",
+	})
+	_dock._update_status()
+	assert_eq(_dock._status_label.text, "Port 8000 held by another process")
+	## Once connected the window is over and stays over.
+	_dock.present_lifecycle_snapshot({"state": McpServerState.READY})
+	_dock.present_transport_snapshot({"connected": true, "status": {"phase": "connected"}})
+	_dock._update_status()
+	assert_true(_dock._status_label.text.begins_with("Server connected"), _dock._status_label.text)
+	_dock.present_transport_snapshot({"connected": false, "status": {"phase": "blocked"}})
+	_dock._update_status()
+	assert_eq(_dock._status_label.text, "Connection blocked")
+	## A refused migration barrier is a real block.
+	_dock._post_update_server_pending = true
+	_dock.present_update_state({"post_update_action": "retry", "label_text": "blocked"})
+	_dock._update_status()
+	assert_eq(_dock._status_label.text, "Connection blocked")
+	_dock._post_update_server_pending = false
+
+
 func test_configure_all_dispatches_while_incompatible() -> void:
 	## The write path must run while INCOMPATIBLE — Configure writes an
 	## explicit url + live plugin version and does not need a healthy occupant.

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -553,6 +553,31 @@ func test_post_update_window_reads_as_finishing_not_blocked() -> void:
 	_dock._post_update_server_pending = false
 
 
+func test_failed_update_ends_the_finishing_window() -> void:
+	_dock._build_ui()
+	_dock.present_lifecycle_snapshot({"state": McpServerState.UNINITIALIZED})
+	_dock.present_transport_snapshot({"connected": false, "status": {"phase": "blocked"}})
+	_dock.present_update_state({
+		"install_in_flight": true,
+		"status_text": "Verifying…",
+		"banner_visible": true,
+		"post_update_action": "",
+	})
+	_dock._update_status()
+	assert_eq(_dock._status_label.text, "Finishing update — starting server…")
+	## `_fail_update`: no swap happened, the previous version is live, and
+	## nothing is starting, so the transport status is the truth again.
+	_dock.present_update_state({
+		"install_in_flight": false,
+		"status_text": "Update failed — previous version restored",
+		"button_disabled": false,
+	})
+	assert_false(_dock._post_update_server_pending)
+	assert_eq(_dock._status_label.text, "Connection blocked")
+	_dock._update_status()
+	assert_eq(_dock._status_label.text, "Connection blocked")
+
+
 func test_configure_all_dispatches_while_incompatible() -> void:
 	## The write path must run while INCOMPATIBLE — Configure writes an
 	## explicit url + live plugin version and does not need a healthy occupant.

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -416,13 +416,19 @@ func test_deferred_clients_do_not_block_startup_and_are_named_for_configure() ->
 		"foreign_ids": [],
 		"deferred": [
 			{"id": "pi", "reason": "its godot-ai entry differs from what Configure wrote before the update"},
+			{"id": "cursor", "reason": "its configuration could not be read: unexpected token"},
 		],
 	})
 	assert_eq(plugin.finished, 1, "a deferred client must not turn success into a barrier failure")
-	assert_eq(plugin._post_update_deferred.size(), 1)
+	assert_eq(plugin._post_update_deferred.size(), 2)
 	var label := plugin._post_update_complete_label()
 	assert_true(label.begins_with("Quit and relaunch AI clients"), label)
-	assert_true(label.contains("Pi Agent"), label)
+	## Each client carries its own reason: an unreadable file is not drift.
+	assert_true(
+		label.contains("Pi Agent (its godot-ai entry differs from what Configure wrote before the update)"),
+		label
+	)
+	assert_true(label.contains("Cursor (its configuration could not be read: unexpected token)"), label)
 	assert_true(label.contains("Configure"), label)
 	plugin._post_update_deferred = []
 	assert_false(plugin._post_update_complete_label().contains("Not migrated"))

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -393,3 +393,38 @@ func test_capability_pair_is_distinct_for_dev_and_managed_spawns() -> void:
 	assert_eq(str(pair.http).length(), 64)
 	assert_eq(str(pair.websocket).length(), 64)
 	assert_ne(pair.http, pair.websocket)
+
+
+class _DeferralRecordingPlugin extends Plugin:
+	var finished := 0
+
+	func _finish_post_update() -> void:
+		finished += 1
+
+
+func test_deferred_clients_do_not_block_startup_and_are_named_for_configure() -> void:
+	var plugin := _DeferralRecordingPlugin.new()
+	plugin._post_update_outcome = {
+		"outcome": "success",
+		"from_version": "3.2.4",
+		"to_version": VERSION,
+	}
+	plugin._on_post_update_repin_completed({
+		"ok": true,
+		"configured_ids": ["codex"],
+		"repinned_ids": ["codex"],
+		"foreign_ids": [],
+		"deferred": [
+			{"id": "pi", "reason": "its godot-ai entry differs from what Configure wrote before the update"},
+		],
+	})
+	assert_eq(plugin.finished, 1, "a deferred client must not turn success into a barrier failure")
+	assert_eq(plugin._post_update_deferred.size(), 1)
+	var label := plugin._post_update_complete_label()
+	assert_true(label.begins_with("Quit and relaunch AI clients"), label)
+	assert_true(label.contains("Pi Agent"), label)
+	assert_true(label.contains("Configure"), label)
+	plugin._post_update_deferred = []
+	assert_false(plugin._post_update_complete_label().contains("Not migrated"))
+	plugin._lifecycle = null
+	plugin.free()

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -655,3 +655,39 @@ func test_launch_unproven_message_summarises_the_refusals() -> void:
 	assert_true(message.contains("not_alive×2, unbranded×1"), message)
 	var empty := Lifecycle._launch_unproven_message(2147480000, [], 0)
 	assert_true(empty.contains("none recorded"), empty)
+func test_pre_v4_version_is_read_only_from_a_godot_ai_3x_claim() -> void:
+	assert_eq(Lifecycle.pre_v4_version_from_status({"name": "godot-ai", "server_version": "3.2.4"}), "3.2.4")
+	assert_eq(Lifecycle.pre_v4_version_from_status({"name": "godot-ai", "server_version": "4.0.2"}), "")
+	assert_eq(Lifecycle.pre_v4_version_from_status({"name": "other", "server_version": "3.2.4"}), "")
+	assert_eq(Lifecycle.pre_v4_version_from_status({"name": "godot-ai", "server_version": "3.2.4 <b>x</b>"}), "")
+	assert_eq(Lifecycle.pre_v4_version_from_status({"name": "godot-ai"}), "")
+	assert_eq(Lifecycle.pre_v4_version_from_status("not a dictionary"), "")
+	assert_eq(Lifecycle.pre_v4_version_from_status(null), "")
+
+
+func test_stale_pre_v4_block_is_worded_but_never_replaceable() -> void:
+	var manager := _manager()
+	manager.start_server()
+	var episode := manager.episode_snapshot()
+	var message := Lifecycle.stale_pre_v4_message(8000, "3.2.4")
+	assert_true(message.contains("Godot AI 3.2.4 server"), message)
+	assert_true(message.contains("Quit and relaunch"), message)
+	assert_true(manager.complete_effect(episode.id, Lifecycle.PROBE, {
+		"outcome": "blocked",
+		"reason": "occupied",
+		"message": message,
+		"target": {
+			"instance_id": "",
+			"version": "",
+			"port": 8000,
+			"replaceable": false,
+			"hint": Lifecycle.STALE_PRE_V4_HINT,
+		},
+	}))
+	var status := manager.get_status_dict()
+	assert_eq(status.state, McpServerState.FOREIGN_PORT)
+	assert_eq(status.blocked_hint, Lifecycle.STALE_PRE_V4_HINT)
+	assert_eq(status.message, message)
+	assert_false(bool(status.can_recover_incompatible), "an unauthenticated occupant is never recoverable")
+	assert_false(manager.request_replacement(), "the untrusted peek must never mint replacement authority")
+	assert_eq(manager.get_status_dict().blocked_hint, Lifecycle.STALE_PRE_V4_HINT)

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -660,6 +660,13 @@ func test_pre_v4_version_is_read_only_from_a_godot_ai_3x_claim() -> void:
 	assert_eq(Lifecycle.pre_v4_version_from_status({"name": "godot-ai", "server_version": "4.0.2"}), "")
 	assert_eq(Lifecycle.pre_v4_version_from_status({"name": "other", "server_version": "3.2.4"}), "")
 	assert_eq(Lifecycle.pre_v4_version_from_status({"name": "godot-ai", "server_version": "3.2.4 <b>x</b>"}), "")
+	for malformed in ["3.", "3..2", "3.2.", "3.2.4.", "3.-1", "3"]:
+		assert_eq(
+			Lifecycle.pre_v4_version_from_status({"name": "godot-ai", "server_version": malformed}),
+			"",
+			"malformed version must not be trusted: %s" % malformed
+		)
+	assert_eq(Lifecycle.pre_v4_version_from_status({"name": "godot-ai", "server_version": "3.10.12"}), "3.10.12")
 	assert_eq(Lifecycle.pre_v4_version_from_status({"name": "godot-ai"}), "")
 	assert_eq(Lifecycle.pre_v4_version_from_status("not a dictionary"), "")
 	assert_eq(Lifecycle.pre_v4_version_from_status(null), "")

--- a/tests/integration/test_self_update_upgrade_paths.py
+++ b/tests/integration/test_self_update_upgrade_paths.py
@@ -519,7 +519,10 @@ def test_signed_update_restarts_into_matching_live_server(
     print(f"server A: {'stopped' if 'MCP | stopped server' in initial_log else 'detached (lease)'}")
     print(f"replacement: {'needed' if replaced_line in restarted_log else 'not needed'}")
     print(f"blocks before the start: {blocks_before_start}")
-    assert f"MCP | AI clients attached before the update must restart to use v{next_version}" in log
+    assert (
+        "MCP | AI clients attached before the update must be quit and relaunched "
+        f"to use v{next_version}" in log
+    )
 
     initial_editor, restarted_editor = read_editor_receipts(project)
     assert initial_editor["pid"] != restarted_editor["pid"], (initial_editor, restarted_editor)

--- a/tests/unit/test_dock_cli_timeout.py
+++ b/tests/unit/test_dock_cli_timeout.py
@@ -472,3 +472,16 @@ def test_dock_emits_endpoint_setting_values_and_root_owns_persistence() -> None:
     )
     assert "ClientConfigurator.apply_endpoint_settings(changes.duplicate(true))" in routed
     assert "func apply_endpoint_settings(changes: Dictionary) -> Dictionary:" in configurator_source
+
+
+def test_post_update_drift_is_deferred_to_configure_not_a_startup_barrier() -> None:
+    """#999: an entry that is not provably ours is left alone and named, never a block."""
+    owner_source = (PLUGIN_ROOT / "utils" / "client_job_owner.gd").read_text(encoding="utf-8")
+    post_update = get_func_block(owner_source, "func _run_post_update_repin(")
+    result = get_func_block(owner_source, "func _post_update_result(")
+
+    assert "automatic migration refused" not in post_update
+    assert post_update.count("deferred.append(") == 2
+    assert "entry_drift_is_version_pin_only(" in post_update
+    assert "ClientConfigurator.configure(" in post_update, "#890 write restriction stays"
+    assert '"deferred": deferred.duplicate(true)' in result

--- a/tests/unit/test_post_update_stale_server.py
+++ b/tests/unit/test_post_update_stale_server.py
@@ -258,3 +258,48 @@ def test_process_kill_boundary_revalidates_exact_identity_without_child_heuristi
     assert 'taskkill", ["/PID", str(pid), "/T", "/F"]' in kill
     assert "not require_tree_proof and not pid_alive(pid)" in kill
     assert "find_windows_spawn_children" not in source
+
+
+def test_untrusted_pre_v4_peek_never_enters_the_trusted_probe_outcome() -> None:
+    """The tokenless read words the block only; it grants nothing."""
+    source = _lifecycle()
+    probe = get_func_block(source, "func _effect_probe(payload: Dictionary) -> Dictionary:")
+    peek = get_func_block(
+        source,
+        "static func _untrusted_pre_v4_occupant_version(port: int, timeout_ms: int) -> String:",
+    )
+
+    ## The peek result is a version string used for wording, applied only to
+    ## the already-built blocked result, after the authenticated branch.
+    assert probe.index("_blocked_probe_result(\"occupied\", port, live)") < probe.index(
+        "_untrusted_pre_v4_occupant_version("
+    )
+    assert 'blocked["message"] = stale_pre_v4_message(' in probe
+    assert 'blocked["target"]["hint"] = STALE_PRE_V4_HINT' in probe
+    assert "replaceable" not in probe.split("_untrusted_pre_v4_occupant_version(", 1)[1]
+    assert "_transport_from(" not in probe.split("_untrusted_pre_v4_occupant_version(", 1)[1]
+    ## The peek itself sends no capability and returns nothing but a version.
+    assert "Authorization" not in peek
+    assert "http_capability" not in peek
+    assert "return pre_v4_version_from_status(parsed)" in peek
+    ## Replacement still requires the authenticated, instance-bound match.
+    replace = get_func_block(source, "func _effect_replace(payload: Dictionary) -> Dictionary:")
+    assert "_untrusted_pre_v4_occupant_version" not in replace
+    assert "_replacement_target_matches" in replace
+
+
+def test_post_update_stale_pre_v4_block_is_reprobed_slowly_within_a_bound() -> None:
+    plugin_source = (PLUGIN / "plugin.gd").read_text(encoding="utf-8")
+    block = get_func_block(
+        plugin_source, "func _replace_server_left_by_update(snapshot: Dictionary) -> void:"
+    )
+
+    assert "const POST_UPDATE_STALE_REPROBE_SECONDS := 10.0" in plugin_source
+    assert "const POST_UPDATE_STALE_REPROBE_LIMIT := 21" in plugin_source
+    assert "ServerLifecycleManager.STALE_PRE_V4_HINT" in block
+    assert "_post_update_stale_reprobes_left -= 1" in block
+    assert "create_timer(POST_UPDATE_STALE_REPROBE_SECONDS)" in block
+    ## Never a replacement: the stale-bridge branch returns before request_replacement.
+    after_hint = block.split("STALE_PRE_V4_HINT", 1)[1]
+    stale_branch = after_hint.split("if _post_update_reprobes_left > 0:", 1)[0]
+    assert "request_replacement" not in stale_branch

--- a/tests/unit/test_post_update_stale_server.py
+++ b/tests/unit/test_post_update_stale_server.py
@@ -110,8 +110,7 @@ def test_owned_launch_waits_boundedly_for_a_stable_branded_process_grant() -> No
     ## capture was refused and never changes the result.
     assert launch.count("capture_process_kill_grant(pid, true, attempts)") == 2
     assert (
-        "while exact_grant.is_empty() and Time.get_ticks_msec() < fingerprint_deadline:"
-        in launch
+        "while exact_grant.is_empty() and Time.get_ticks_msec() < fingerprint_deadline:" in launch
     )
     assert '"reason": "launch_unproven" if fingerprint.is_empty() else ""' in launch
     assert "kill_exact_processes" not in launch
@@ -271,7 +270,7 @@ def test_untrusted_pre_v4_peek_never_enters_the_trusted_probe_outcome() -> None:
 
     ## The peek result is a version string used for wording, applied only to
     ## the already-built blocked result, after the authenticated branch.
-    assert probe.index("_blocked_probe_result(\"occupied\", port, live)") < probe.index(
+    assert probe.index('_blocked_probe_result("occupied", port, live)') < probe.index(
         "_untrusted_pre_v4_occupant_version("
     )
     assert 'blocked["message"] = stale_pre_v4_message(' in probe

--- a/tests/unit/test_qualification_resources.py
+++ b/tests/unit/test_qualification_resources.py
@@ -2,7 +2,10 @@
 
 import copy
 import json
+import os
 import runpy
+import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -38,6 +41,15 @@ class Process:
 
     def num_handles(self):
         return self.handles
+
+
+REAL_WINDOWS_EXIT_REPORT = resources._windows_process_has_exited
+
+
+@pytest.fixture(autouse=True)
+def no_kernel_exit_report(monkeypatch):
+    """Fake psutil processes have no kernel behind them; pin the Windows probe."""
+    monkeypatch.setattr(resources, "_windows_process_has_exited", lambda pid: False)
 
 
 @pytest.fixture
@@ -93,6 +105,35 @@ def test_dead_or_zombie_is_not_a_successful_sample(process, status):
         resources.bind_process(100)
     with pytest.raises(resources.ResourceError, match="dead or a zombie"):
         resources.sample_process(resources.ProcessBinding(100, 123.5))
+
+
+@pytest.mark.parametrize("os_name", ["nt", "posix"])
+def test_kernel_exit_report_outranks_psutil_only_on_windows(process, monkeypatch, os_name):
+    """An exited child that psutil still answers for is dead on Windows."""
+    monkeypatch.setattr(resources.os, "name", os_name)
+    monkeypatch.setattr(resources, "_windows_process_has_exited", lambda pid: True)
+    if os_name == "nt":
+        with pytest.raises(resources.ResourceError, match="dead or a zombie"):
+            resources.bind_process(100)
+        with pytest.raises(resources.ResourceError, match="dead or a zombie"):
+            resources.sample_process(resources.ProcessBinding(100, 123.5))
+    else:
+        assert resources.sample_process(resources.bind_process(100))["threads"] == 3
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows kernel exit codes")
+def test_windows_exit_report_marks_a_still_open_child_dead(process, monkeypatch):
+    child = subprocess.Popen([sys.executable, "-c", "pass"])
+    child.wait(timeout=30)
+    # The Popen still holds the process handle, so the pid cannot be reused.
+    assert REAL_WINDOWS_EXIT_REPORT(child.pid) is True
+    assert REAL_WINDOWS_EXIT_REPORT(os.getpid()) is False
+    assert REAL_WINDOWS_EXIT_REPORT(0) is False
+    monkeypatch.setattr(resources, "_windows_process_has_exited", REAL_WINDOWS_EXIT_REPORT)
+    with pytest.raises(resources.ResourceError, match="dead or a zombie"):
+        resources.sample_process(resources.ProcessBinding(child.pid, 123.5))
+    binding = resources.bind_process(os.getpid())
+    assert resources.sample_process(binding)["pid"] == os.getpid()
 
 
 @pytest.mark.parametrize("when", ["before", "during"])

--- a/tests/unit/test_release_verify.py
+++ b/tests/unit/test_release_verify.py
@@ -501,6 +501,32 @@ def test_install_rollback_on_a_fresh_project_leaves_no_live_tree(release, tmp_pa
     )
 
 
+def test_process_liveness_needs_no_third_party_module():
+    assert v4_release._process_is_live(os.getpid())
+    finished = subprocess.Popen([sys.executable, "-c", "pass"])
+    finished.wait()
+    assert not v4_release._process_is_live(finished.pid)
+    assert not v4_release._process_is_live(0)
+    assert "import psutil" not in Path(v4_release.__file__).read_text(encoding="utf-8")
+
+
+def test_install_over_a_v4_tree_still_replaces_owned_mismatches(release, tmp_path):
+    """A hand-run recovery may repin every owned entry, whatever the live version."""
+    project = _project(tmp_path)
+    live = project / "addons/godot_ai"
+    config = live / "plugin.cfg"
+    config.write_text(
+        config.read_text(encoding="utf-8").replace('version="3.2.4"', 'version="4.0.1"'),
+        encoding="utf-8",
+    )
+
+    assert v4_release.main(_install_args(release, project)) == 0
+
+    marker = _marker(project)
+    assert marker["from_version"] == "4.0.1"
+    assert marker["replace_owned_mismatches"] is True
+
+
 def test_install_refuses_a_lock_held_by_another_live_process(release, tmp_path):
     project = _project(tmp_path)
     update = project / "addons/.godot_ai_update"


### PR DESCRIPTION
## What

After a 3.2.x to 4.x update with an AI client attached, the client's old v3 `godot-ai attach` bridge keeps its 3.2.x backend alive on the port (and respawns it if killed). The v4 plugin cannot authenticate a v3 server, so the dock could only say `Port N held by another process`, and the post-update re-probe gave up after ten seconds. Users hunted for a foreign process; the actual fix was to quit and relaunch the client. Seen on Windows with Claude Desktop, which also keeps its MCP configuration in memory and respawns the old bridge until the application itself is relaunched.

## Fix

- **Untrusted wording only.** When the port is bound and the authenticated probe finds no record, the lifecycle performs one bounded, tokenless GET of `/godot-ai/status`. If the body claims `name: godot-ai` with a `3.x` `server_version`, the BLOCKED message names the pre-v4 server and tells the user to quit and relaunch the client. That result never enters the probe outcome, never becomes a transport, and grants no replacement or kill authority: the occupant stays `replaceable: false` and `_effect_replace` is untouched. The version string is validated to digits and dots. `docs/server-lifecycle.md` states the exception next to the no-v3-fallback rule.
- **Slow re-probe after an update.** With that hint present, the plugin re-probes every 10 s for 21 attempts (about three and a half minutes), long enough for the old bridge's 30 s lease and the server's 120 s idle backstop to run out once the user relaunches the client, so the editor comes up green on its own.
- **Wording.** The dock's completion banner, the plugin's log line and the migration guide now say "quit and relaunch" rather than "restart".

## Verification

- Unit: `pre_v4_version_from_status` accepts only a godot-ai 3.x claim; a blocked probe carrying the hint renders as FOREIGN_PORT with the hint and message, is not recoverable, and `request_replacement()` is refused. Python source contracts pin that the peek runs after the trusted branch, sends no capability, and never reaches `_effect_replace` or the transport, and that the stale branch never calls `request_replacement`.
- GDScript suites in a live Godot 4.7.2 editor; `pytest -m "not editor"`.
- Live: reproduced the original state on Windows (3.2.4 attach-owned server on 18130 held by Claude Desktop's pre-update bridge) and observed the lease drop and idle exit within the re-probe window.

Follows the reviewed decision to keep the block and explain it rather than replace an unauthenticated server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Live check on Windows: with a real 3.2.4 server (`godot-ai==3.2.4` from the uv cache) listening on a spare port, the peek returned `3.2.4` and produced the quit-and-relaunch message; against a running v4 server (which answers 401 without a bearer) it returned nothing. Lifecycle, plugin, dock and port_resolver suites green in a live Godot 4.7.2 GUI editor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection and messaging for older servers left running during updates, with slower follow-up checks and no automatic replacement.
  - Client configuration issues no longer block server startup; affected clients are listed for later configuration.
  - Improved recovery of closed-editor installations and Windows update replacement handling.
  - Improved Windows permissions and process detection.
  - Failed server launches now provide a startup report.
  - Improved Camera2D viewport updates and post-update status messaging.

- **Documentation**
  - Updated self-update and server lifecycle guidance for stale-server handling and client recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Stacked on #1013 (its Windows launch fixes are what let the real-editor rows pass here); merge that first and this rebases to `main` cleanly. Review follow-up: malformed 3.x version strings (`3.`, `3..2`, `3.2.`) are rejected, and the signed-update row expects the new quit-and-relaunch log line. Signed-update row green locally on Windows after the rebase.
