### PR TITLE
ci(capture): bound startup waits and preserve failure diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -560,9 +560,18 @@ jobs:
       ## jobs) so a failed run keeps the boot/driver evidence — before #675
       ## the smoke job's editor output was only interleaved into whichever
       ## step happened to be running, and a stalled run left no artifact.
+      ## GODOT_AI_STARTUP_TRACE makes the plugin print "MCP startup trace |
+      ## phase=... total_ms=..." lines to that log as it boots. The smoke
+      ## streams them with elapsed stamps while it waits for the session,
+      ## so a slow start says where the time went (editor boot before the
+      ## plugin's first phase vs. probe/connect inside it) instead of a bare
+      ## "never registered" — the macOS registration wait runs 42–90s on
+      ## the paravirtualized runner and has timed out with no evidence.
       - name: Start Godot editor (Linux / xvfb)
         if: matrix.os == 'ubuntu-latest'
         shell: bash
+        env:
+          GODOT_AI_STARTUP_TRACE: "1"
         run: |
           xvfb-run -a --server-args="-screen 0 1280x720x24" \
             godot --rendering-driver opengl3 --path test_project --editor \
@@ -571,6 +580,8 @@ jobs:
       - name: Start Godot editor (windowed)
         if: matrix.os != 'ubuntu-latest'
         shell: bash
+        env:
+          GODOT_AI_STARTUP_TRACE: "1"
         run: godot --path test_project --editor > godot-editor.log 2>&1 &
 
       ## Surface which rendering driver actually engaged, pass or fail.
@@ -602,9 +613,10 @@ jobs:
           fi
 
       - name: Run capture smoke test
-        ## Covers the worst case of the script's internal ceilings: 120s
-        ## session wait + 180s capture-ready wait + 120s capture budget.
-        timeout-minutes: 10
+        ## Covers the worst case of the script's internal ceilings: 240s
+        ## session wait + 180s capture-ready wait + 120s capture budget
+        ## (9 min), plus initialize and failure diagnostics.
+        timeout-minutes: 12
         shell: bash
         env:
           ## Stream output as it happens — a killed/timed-out step otherwise

--- a/script/ci-game-capture-smoke
+++ b/script/ci-game-capture-smoke
@@ -6,7 +6,9 @@ Drives a running Godot editor (launched separately by CI with a real
 rendering driver, typically under xvfb-run on Linux) through the MCP
 streamable-HTTP transport:
 
-  1. wait for the plugin's WebSocket session to register
+  1. wait for the plugin's WebSocket session to register, streaming the
+     editor's own stdout (GODOT_EDITOR_LOG, default godot-editor.log) into
+     this log as it boots so a slow or stuck editor leaves a timeline
   2. open res://capture_smoke.tscn (four colored quadrants)
   3. run the project in that scene
   4. poll editor_state until is_playing=true AND game_capture_ready=true
@@ -42,6 +44,7 @@ import base64
 import io
 import json
 import os
+import subprocess
 import sys
 import time
 import traceback
@@ -94,6 +97,34 @@ DIAG_DIR = os.environ.get("CAPTURE_DIAG_DIR", "capture-smoke-diag")
 ## editor bridge is gone and the remaining minutes of ready-wait can only
 ## end in a misleading "never registered" timeout (#675).
 SESSION_LOSS_GRACE_SEC = 45.0
+## Editor-registration wait: how long the editor may take from launch to
+## its WebSocket session appearing in session_manage(op="list"). The poll
+## exits the moment the session registers, so the ceiling only costs time
+## when something is genuinely wrong.
+##
+## 240s, not 120 (2026-09-08, runs 34268748773 and 34270440762): the macOS
+## job failed twice in 39 runs with "Godot session never registered; last
+## err: None". Every poll got a clean count=0 reply, godot-editor.log held
+## only the engine banner and the Metal driver line, and mcp-server.log
+## showed no WebSocket attempt — the editor was still booting when the
+## budget ran out. Launch→registered measured over the preceding 41 passing
+## macOS runs: median 60s, p90 73s, max 90s (Linux 8–25s, Windows 20–57s)
+## against an effective ~125s budget, so the failures are the tail of that
+## distribution on a busy paravirtualized runner, not a connection bug.
+## 240s is ~2.7× the observed maximum; the CI step timeout covers it.
+SESSION_WAIT_SEC = float(os.environ.get("SESSION_WAIT_SEC", "240"))
+SESSION_POLL_DELAY_SEC = 2.0
+## Cadence of the "[session-wait +Ns]" progress line. New editor-log lines
+## are streamed on every poll regardless, so the plugin's boot markers
+## ("MCP startup trace | phase=...", "MCP | plugin loaded", "MCP | connected
+## to server") land here with an elapsed stamp the moment they print.
+SESSION_WAIT_PROGRESS_SEC = 15.0
+## The editor's redirected stdout/stderr — the workflow starts it with
+## `godot ... > godot-editor.log 2>&1 &`. Streamed during the session wait
+## and tailed on timeout. Missing locally is fine: the wait then only
+## reports elapsed time.
+EDITOR_LOG = os.environ.get("GODOT_EDITOR_LOG", "godot-editor.log")
+EDITOR_LOG_TAIL_LINES = 40
 
 
 def _post(session_id: str | None, body: dict, timeout: float = 10.0) -> dict:
@@ -173,19 +204,176 @@ def _initialize_session() -> str:
     return session_id
 
 
-def _wait_for_godot_session(session_id: str, timeout: float = 120.0) -> None:
-    deadline = time.monotonic() + timeout
+class _EditorLogTail:
+    """Stream new lines of the editor's redirected stdout as they land.
+
+    Reads incrementally from a byte offset so a multi-minute wait costs one
+    small read per poll, tolerates the file not existing yet (the editor is
+    started by a separate CI step), and caps what one flush prints so a
+    chatty editor cannot flood the job log.
+    """
+
+    MAX_LINES_PER_FLUSH = 40
+
+    def __init__(self, path: str, sink) -> None:
+        self._path = path
+        self.sink = sink
+        self._offset = 0
+        self._partial = b""
+        self.lines_seen = 0
+
+    def flush(self) -> None:
+        try:
+            with open(self._path, "rb") as fh:
+                fh.seek(self._offset)
+                chunk = fh.read()
+        except OSError:
+            return
+        if not chunk:
+            return
+        self._offset += len(chunk)
+        pieces = (self._partial + chunk).split(b"\n")
+        self._partial = pieces.pop()
+        lines = [piece.decode("utf-8", "replace").rstrip("\r") for piece in pieces]
+        lines = [line for line in lines if line.strip()]
+        if not lines:
+            return
+        self.lines_seen += len(lines)
+        for line in lines[: self.MAX_LINES_PER_FLUSH]:
+            self.sink(f"[editor-log] {line}")
+        hidden = len(lines) - self.MAX_LINES_PER_FLUSH
+        if hidden > 0:
+            self.sink(f"[editor-log] (+{hidden} more lines)")
+
+    def tail(self, count: int = EDITOR_LOG_TAIL_LINES) -> list[str]:
+        try:
+            with open(self._path, "rb") as fh:
+                data = fh.read()
+        except OSError as exc:
+            return [f"({self._path} unreadable: {exc})"]
+        lines = [line.decode("utf-8", "replace").rstrip("\r") for line in data.split(b"\n")]
+        lines = [line for line in lines if line.strip()]
+        if not lines:
+            return [f"({self._path} is empty)"]
+        return lines[-count:]
+
+
+def _godot_process_snapshot() -> list[str]:
+    """Best-effort `ps`/`tasklist` rows for Godot processes.
+
+    On a session-wait timeout this is what separates "the editor is still
+    booting" (alive, burning CPU, silent log) from "the editor died" (no
+    row, no crash banner) from "the plugin is up but cannot connect"
+    (alive, MCP lines in the log).
+    """
+    if sys.platform == "win32":
+        cmd = ["tasklist", "/FI", "IMAGENAME eq godot*"]
+    else:
+        cmd = ["ps", "-eo", "pid,etime,pcpu,rss,command"]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=10, check=False)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return [f"(process snapshot unavailable: {exc})"]
+    rows = [line.rstrip() for line in proc.stdout.splitlines() if "godot" in line.lower()]
+    return rows or ["(no godot process found)"]
+
+
+def _summarize_session_reply(reply: dict | None) -> str:
+    if reply is None:
+        return "no reply yet"
+    if "count" in reply:
+        return f"count={reply['count']}"
+    ## A reply without `count` is a tool error or an unexpected shape —
+    ## surfacing it is the difference between "server said no sessions" and
+    ## "server said something else entirely" (both used to read as
+    ## "last err: None").
+    return "unexpected reply " + json.dumps(reply, default=str)[:300]
+
+
+def _wait_for_godot_session(
+    session_id: str,
+    timeout: float = SESSION_WAIT_SEC,
+    editor_log: _EditorLogTail | None = None,
+    history: list[str] | None = None,
+) -> float:
+    """Poll until the editor's session registers; return the seconds it took.
+
+    Every poll streams whatever the editor has printed since the last one,
+    so the job log carries the boot timeline (engine banner → rendering
+    driver → plugin startup-trace phases → "plugin loaded" → probing →
+    connected) stamped with elapsed time. On timeout the raise names how
+    long it waited and what the server said, and the editor-log tail plus a
+    process snapshot go to the job log and the diag artifacts — the old
+    "never registered; last err: None" carried none of that (2026-09-08).
+    """
+    start = time.monotonic()
+    deadline = start + timeout
+
+    def _note(line: str) -> None:
+        stamped = f"[session-wait +{time.monotonic() - start:.1f}s] {line}"
+        print(stamped)
+        if history is not None:
+            history.append(stamped)
+
+    if editor_log is None:
+        editor_log = _EditorLogTail(EDITOR_LOG, _note)
+    else:
+        editor_log.sink = _note
     last_err: Exception | None = None
-    while time.monotonic() < deadline:
+    last_reply: dict | None = None
+    polls = 0
+    next_progress = start + SESSION_WAIT_PROGRESS_SEC
+    print(
+        f"Waiting up to {timeout:.0f}s for the editor's session to register "
+        f"(streaming {EDITOR_LOG})"
+    )
+    while True:
+        polls += 1
         try:
             result = _tool_call(session_id, "session_manage", {"op": "list"}, 2)
-            if result.get("count", 0) > 0:
-                print(f"Godot session connected: {result.get('active_session_id') or result}")
-                return
-        except (urllib.error.URLError, RuntimeError) as exc:
+        except (urllib.error.URLError, TimeoutError, OSError, RuntimeError) as exc:
             last_err = exc
-        time.sleep(2)
-    raise RuntimeError(f"Godot session never registered; last err: {last_err}")
+        else:
+            last_reply = result
+            if isinstance(result.get("count"), (int, float)) and result["count"] > 0:
+                elapsed = time.monotonic() - start
+                editor_log.flush()
+                print(
+                    f"Godot session connected after {elapsed:.1f}s ({polls} polls): "
+                    f"{result.get('active_session_id') or result}"
+                )
+                return elapsed
+        editor_log.flush()
+        now = time.monotonic()
+        if now >= next_progress:
+            _note(
+                f"no editor session yet ({polls} polls; server reply: "
+                f"{_summarize_session_reply(last_reply)}; transport error: {last_err!r})"
+            )
+            next_progress = now + SESSION_WAIT_PROGRESS_SEC
+        if now >= deadline:
+            break
+        time.sleep(min(SESSION_POLL_DELAY_SEC, max(0.0, deadline - now)))
+
+    _note(f"giving up after {polls} polls; last {EDITOR_LOG_TAIL_LINES} editor-log lines:")
+    for line in editor_log.tail():
+        _note(f"    {line}")
+    _note("godot processes:")
+    for row in _godot_process_snapshot():
+        _note(f"    {row}")
+    if last_err is None:
+        verdict = (
+            "every poll got a reply with no sessions — the MCP server was up and the "
+            "editor never connected to it, so look at the editor-log timeline above "
+            "(still booting, crashed, or plugin loaded but not connecting), not at "
+            "the transport"
+        )
+    else:
+        verdict = f"last transport error: {last_err!r}"
+    raise RuntimeError(
+        f"Godot session never registered within {timeout:.0f}s ({polls} polls; "
+        f"server reply: {_summarize_session_reply(last_reply)}); {verdict}"
+    )
 
 
 ## 180s, not 60: run 28326896176 (macOS) showed the game subprocess taking
@@ -411,7 +599,18 @@ def _write_diag_artifacts(attempt_log: list[str], last_png: bytes | None) -> Non
 def main() -> int:
     print(f"Connecting to MCP server at {SERVER_URL}")
     session_id = _initialize_session()
-    _wait_for_godot_session(session_id)
+    attempt_log: list[str] = []
+    editor_log = _EditorLogTail(EDITOR_LOG, print)
+    try:
+        _wait_for_godot_session(session_id, editor_log=editor_log, history=attempt_log)
+    except Exception:
+        ## The wait's own timeline (streamed editor lines, log tail, process
+        ## snapshot) is the evidence for a boot-time failure; keep it in the
+        ## uploaded artifacts alongside the traceback.
+        attempt_log.append("")
+        attempt_log.append(traceback.format_exc().rstrip())
+        _write_diag_artifacts(attempt_log, None)
+        raise
 
     ## Dump autoload state BEFORE we touch the game — tells us whether the
     ## plugin's _enter_tree actually persisted _mcp_game_helper, which is the
@@ -422,7 +621,6 @@ def main() -> int:
     _tool_call(session_id, "scene_open", {"path": SCENE_PATH}, 10)
     time.sleep(1)
 
-    attempt_log: list[str] = []
     last_png: bytes | None = None
     try:
         print("Running project (current scene)")
@@ -483,6 +681,11 @@ def main() -> int:
         _write_diag_artifacts(attempt_log, last_png)
         raise
     finally:
+        ## Whatever the editor printed after registration (the startup
+        ## trace's "done" line, game-run output) belongs in the job log on
+        ## pass as well as fail — it is the only per-run record of where the
+        ## editor's boot time went.
+        editor_log.flush()
         try:
             ## "stop" has no named tool — it lives only under the project_manage
             ## rollup, so calling "project_stop" returns an unknown-tool error

--- a/script/ci-game-capture-smoke
+++ b/script/ci-game-capture-smoke
@@ -309,16 +309,24 @@ def _wait_for_godot_session(
     start = time.monotonic()
     deadline = start + timeout
 
-    def _note(line: str) -> None:
-        stamped = f"[session-wait +{time.monotonic() - start:.1f}s] {line}"
+    def _record(stamped: str) -> None:
         print(stamped)
         if history is not None:
             history.append(stamped)
 
+    def _note(line: str) -> None:
+        _record(f"[session-wait +{time.monotonic() - start:.1f}s] {line}")
+
+    ## Editor lines keep flowing through this sink after registration (the
+    ## caller flushes once more at exit), so they carry a bare elapsed stamp
+    ## rather than the wait's own label.
+    def _stamp_editor_line(line: str) -> None:
+        _record(f"[+{time.monotonic() - start:.1f}s] {line}")
+
     if editor_log is None:
-        editor_log = _EditorLogTail(EDITOR_LOG, _note)
+        editor_log = _EditorLogTail(EDITOR_LOG, _stamp_editor_line)
     else:
-        editor_log.sink = _note
+        editor_log.sink = _stamp_editor_line
     last_err: Exception | None = None
     last_reply: dict | None = None
     polls = 0

--- a/tests/unit/test_ci_game_capture_smoke.py
+++ b/tests/unit/test_ci_game_capture_smoke.py
@@ -94,7 +94,7 @@ def test_wait_returns_elapsed_and_streams_editor_log(
     out = capsys.readouterr().out
     assert "Godot session connected after 4.0s (3 polls): test-project@abc" in out
     ## The editor's boot lines were streamed with an elapsed stamp.
-    assert "[session-wait +0.0s] [editor-log] Godot Engine v4.7" in out
+    assert "[+0.0s] [editor-log] Godot Engine v4.7" in out
     assert "[editor-log] Metal 4.0 - Forward+" in out
     assert any("[editor-log] Godot Engine v4.7" in line for line in history)
 

--- a/tests/unit/test_ci_game_capture_smoke.py
+++ b/tests/unit/test_ci_game_capture_smoke.py
@@ -1,0 +1,250 @@
+"""The capture smoke's editor-registration wait (script/ci-game-capture-smoke).
+
+Locks the behaviour added after the 2026-09-08 macOS flake: the wait streams
+the editor's log with elapsed stamps, reports how long registration took, and
+a timeout names what the server said plus the editor-log tail instead of the
+bare "never registered; last err: None".
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "script" / "ci-game-capture-smoke"
+
+
+def _load_smoke() -> ModuleType:
+    loader = importlib.machinery.SourceFileLoader("ci_game_capture_smoke", str(SCRIPT))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+class _FakeClock:
+    """monotonic()/sleep() stand-in so the wait runs without real delays."""
+
+    def __init__(self) -> None:
+        self.now = 1000.0
+        self.slept: list[float] = []
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.slept.append(seconds)
+        self.now += seconds
+
+
+@pytest.fixture
+def smoke(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> tuple[ModuleType, _FakeClock, Path]:
+    module = _load_smoke()
+    clock = _FakeClock()
+    monkeypatch.setattr(module.time, "monotonic", clock.monotonic)
+    monkeypatch.setattr(module.time, "sleep", clock.sleep)
+    monkeypatch.setattr(module, "_godot_process_snapshot", lambda: ["12345 godot --editor"])
+    editor_log = tmp_path / "godot-editor.log"
+    monkeypatch.setattr(module, "EDITOR_LOG", str(editor_log))
+    return module, clock, editor_log
+
+
+def _replies(module: ModuleType, monkeypatch: pytest.MonkeyPatch, sequence: list) -> list[int]:
+    """Feed session_manage replies in order; the last one repeats forever."""
+    calls: list[int] = []
+
+    def fake_tool_call(session_id, name, args, request_id, timeout=30.0):
+        assert name == "session_manage" and args == {"op": "list"}
+        calls.append(request_id)
+        item = sequence[min(len(calls) - 1, len(sequence) - 1)]
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    monkeypatch.setattr(module, "_tool_call", fake_tool_call)
+    return calls
+
+
+def test_wait_returns_elapsed_and_streams_editor_log(
+    smoke, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    module, clock, editor_log = smoke
+    editor_log.write_text("Godot Engine v4.7\nMetal 4.0 - Forward+\n", encoding="utf-8")
+    calls = _replies(
+        module,
+        monkeypatch,
+        [
+            {"count": 0, "sessions": []},
+            {"count": 0, "sessions": []},
+            {"count": 1, "sessions": [{}], "active_session_id": "test-project@abc"},
+        ],
+    )
+    history: list[str] = []
+
+    elapsed = module._wait_for_godot_session("sid", timeout=60.0, history=history)
+
+    assert len(calls) == 3
+    assert elapsed == pytest.approx(2 * module.SESSION_POLL_DELAY_SEC)
+    out = capsys.readouterr().out
+    assert "Godot session connected after 4.0s (3 polls): test-project@abc" in out
+    ## The editor's boot lines were streamed with an elapsed stamp.
+    assert "[session-wait +0.0s] [editor-log] Godot Engine v4.7" in out
+    assert "[editor-log] Metal 4.0 - Forward+" in out
+    assert any("[editor-log] Godot Engine v4.7" in line for line in history)
+
+
+def test_wait_streams_lines_as_they_land_and_only_once(
+    smoke, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    module, clock, editor_log = smoke
+    ## The log does not exist on the first poll (the editor is started by a
+    ## separate step), then grows across polls, including a partial line.
+    state = {"n": 0}
+
+    def fake_tool_call(session_id, name, args, request_id, timeout=30.0):
+        state["n"] += 1
+        if state["n"] == 2:
+            editor_log.write_bytes(b"Godot Engine v4.7\nMCP startup trace | phase=set")
+        if state["n"] == 3:
+            with editor_log.open("ab") as fh:
+                fh.write(b"tings_registered total_ms=10\nMCP | plugin loaded\n")
+        if state["n"] == 4:
+            return {"count": 1, "active_session_id": "s"}
+        return {"count": 0}
+
+    monkeypatch.setattr(module, "_tool_call", fake_tool_call)
+
+    module._wait_for_godot_session("sid", timeout=60.0)
+
+    out = capsys.readouterr().out
+    assert out.count("[editor-log] Godot Engine v4.7") == 1
+    ## The partial line was held back until its newline arrived, then
+    ## printed whole.
+    assert "[editor-log] MCP startup trace | phase=settings_registered total_ms=10" in out
+    assert out.count("[editor-log] MCP | plugin loaded") == 1
+    assert "phase=set\n" not in out
+
+
+def test_wait_reports_progress_at_the_configured_cadence(
+    smoke, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    module, clock, editor_log = smoke
+    monkeypatch.setattr(module, "SESSION_WAIT_PROGRESS_SEC", 6.0)
+    ## Polls land at 0, 2, 4, ... seconds; registration on the ninth poll
+    ## (16s) leaves two progress ticks, at +6s and +12s.
+    sequence = [{"count": 0}] * 8 + [{"count": 1, "active_session_id": "s"}]
+    _replies(module, monkeypatch, sequence)
+
+    module._wait_for_godot_session("sid", timeout=60.0)
+
+    progress = [
+        line for line in capsys.readouterr().out.splitlines() if "no editor session yet" in line
+    ]
+    assert [line.split("]")[0] for line in progress] == [
+        "[session-wait +6.0s",
+        "[session-wait +12.0s",
+    ]
+    assert "server reply: count=0; transport error: None" in progress[0]
+
+
+def test_timeout_names_the_server_reply_and_tails_the_editor_log(
+    smoke, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    module, clock, editor_log = smoke
+    editor_log.write_text(
+        "Godot Engine v4.7.stable.official\nMetal 4.0 - Forward+ - Apple Paravirtual device\n",
+        encoding="utf-8",
+    )
+    _replies(module, monkeypatch, [{"count": 0, "sessions": []}])
+    history: list[str] = []
+
+    with pytest.raises(RuntimeError) as excinfo:
+        module._wait_for_godot_session("sid", timeout=10.0, history=history)
+
+    message = str(excinfo.value)
+    assert message.startswith(
+        "Godot session never registered within 10s (6 polls; server reply: count=0)"
+    )
+    assert "every poll got a reply with no sessions" in message
+    assert "editor never connected" in message
+    ## Polls stop at the deadline: 0, 2, 4, 6, 8, 10 seconds.
+    assert clock.slept == [2.0] * 5
+    out = capsys.readouterr().out
+    assert "giving up after 6 polls; last 40 editor-log lines:" in out
+    assert "    Metal 4.0 - Forward+ - Apple Paravirtual device" in out
+    assert "godot processes:" in out
+    assert "    12345 godot --editor" in out
+    ## The same timeline reached the diag history for the uploaded artifact.
+    assert any("Apple Paravirtual device" in line for line in history)
+    assert any("12345 godot --editor" in line for line in history)
+
+
+def test_timeout_reports_transport_errors_and_unexpected_replies(
+    smoke, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module, clock, editor_log = smoke
+    _replies(
+        module,
+        monkeypatch,
+        [
+            {"error": {"code": "UNAUTHORIZED", "message": "bad bearer"}},
+            module.urllib.error.URLError("connection refused"),
+        ],
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        module._wait_for_godot_session("sid", timeout=4.0)
+
+    message = str(excinfo.value)
+    ## A reply without `count` is surfaced verbatim rather than read as
+    ## "no sessions", and a transport error replaces the boot verdict.
+    assert 'unexpected reply {"error": {"code": "UNAUTHORIZED"' in message
+    assert "last transport error: URLError" in message
+    assert "every poll got a reply" not in message
+
+
+def test_timeout_without_an_editor_log_still_explains_itself(
+    smoke, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    module, clock, editor_log = smoke
+    _replies(module, monkeypatch, [{"count": 0}])
+
+    with pytest.raises(RuntimeError, match="never registered within 2s"):
+        module._wait_for_godot_session("sid", timeout=2.0)
+
+    out = capsys.readouterr().out
+    assert "unreadable" in out
+
+
+def test_editor_log_tail_caps_lines_per_flush(smoke) -> None:
+    module, clock, editor_log = smoke
+    editor_log.write_text("".join(f"line {i}\n" for i in range(50)), encoding="utf-8")
+    seen: list[str] = []
+    tail = module._EditorLogTail(str(editor_log), seen.append)
+
+    tail.flush()
+
+    assert tail.lines_seen == 50
+    assert seen[0] == "[editor-log] line 0"
+    assert seen[-2] == "[editor-log] line 39"
+    assert seen[-1] == "[editor-log] (+10 more lines)"
+    assert tail.tail(3) == ["line 47", "line 48", "line 49"]
+
+
+def test_session_wait_budget_covers_the_measured_macos_boot() -> None:
+    ## 2026-09-08: launch→registered on the macOS runner peaked at 90s over
+    ## 41 runs and two runs exceeded the old 120s budget. Keep the ceiling
+    ## comfortably above the observed maximum and documented where it lives.
+    module = _load_smoke()
+    assert module.SESSION_WAIT_SEC >= 240.0
+    assert module.SESSION_WAIT_SEC + 180.0 + 120.0 <= 12 * 60
+    workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    smoke_step = workflow[workflow.index("- name: Run capture smoke test") :]
+    smoke_step = smoke_step[: smoke_step.index("run: python script/ci-game-capture-smoke")]
+    assert "timeout-minutes: 12" in smoke_step


### PR DESCRIPTION
Capture smoke requests could outlive their phase budget while SSE keepalive bytes continued arriving. Use an async HTTPX boundary behind the synchronous caller to cancel the complete network request at the smaller of the per-call cap and remaining phase time. Preserve error status/headers/body, strict UTF-8 parsing and late-result rejection; refuse redirects to avoid redispatching authenticated writes.

Registration diagnostics now describe the latest outcome, and editor-log reads, partial lines and output are byte-bounded. Initialization failures reach artifact capture, writes are never retried, and cleanup stops a game only when its start was attempted. The 16-minute CI allowance includes bounded diagnostics and margin for the separately verified #1070 capture checks.

Validation:

- Real-socket regressions fail against the previous implementation and verify cancellation, disconnect, artifacts and one conditional stop.
- Focused tests: 50 passed; separate #1070 integration tests: 72 passed.
- Full Ruff passed; full Python: 2,745 passed, 115 skipped.
- Fresh live Godot: 2,332 passed, 0 failed, 31 skipped; standalone actual capture passed with normal editor exit.
- Separate #1070 integration: Forward+ HDR, Forward+ SDR and Compatibility SDR all passed native/64px editor and game captures, encoder tests and normal editor exits.
- Native updater plus receipt regression checks: 32 passed, 11 skipped.

An initial updater attempt reproduced the known Windows receipt-read PermissionError (#1073); its failure is retained. The full native module and receipt regressions passed with the reviewed test-only correction, which was removed before committing this two-file follow-up. No updater fix is included here.

Network cancellation is cooperative: synchronous client construction/parsing and cancellation teardown can add finite overhead. #1070 production changes remain outside this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automated game-capture checks with clearer timeout reporting, editor logs, process diagnostics, and failure artifacts.
  - Added safeguards to prevent stalled or late responses from exceeding allotted test phases.
  - Increased capture workflow time allowances for setup, diagnostics, and cleanup.

- **Tests**
  - Added comprehensive coverage for session registration, capture timing, diagnostic output, failure handling, HTTP behavior, and log-size limits.

- **Chores**
  - Updated CI tooling and artifact handling for more reliable workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->