### PR TITLE
fix: a plugin reload waits up to 60 s for its filesystem scan, not 5 s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ reading. Release engineering: [docs/releasing.md](docs/releasing.md).
 
 ### Fixed
 
+- `editor_reload_plugin` (and the dock's Reload) gave up after 5 s when the
+  editor was still scanning or importing, left the plugin unchanged with only
+  an editor-log error, and the calling AI client then waited out the server's
+  90 s reconnect budget for a replacement session that never came. The
+  reload now waits up to 60 s for its filesystem scan.
+
 - **OpenCode:** Configure wrote only `opencode.json` while OpenCode merges
   it with `opencode.jsonc`, the latter winning per key, so a stale
   `godot-ai` entry in an existing `opencode.jsonc` kept overriding the new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ reading. Release engineering: [docs/releasing.md](docs/releasing.md).
   an editor-log error, and the calling AI client then waited out the server's
   90 s reconnect budget for a replacement session that never came. The
   reload now waits up to 60 s for its filesystem scan.
-
 - **OpenCode:** Configure wrote only `opencode.json` while OpenCode merges
   it with `opencode.jsonc`, the latter winning per key, so a stale
   `godot-ai` entry in an existing `opencode.jsonc` kept overriding the new

--- a/plugin/addons/godot_ai/utils/plugin_reload.gd
+++ b/plugin/addons/godot_ai/utils/plugin_reload.gd
@@ -5,7 +5,11 @@ extends RefCounted
 ## quiescence, lock and readiness protocol; this is not a hot-update grant.
 const PLUGIN_CFG := "res://addons/godot_ai/plugin.cfg"
 const ScriptWork := preload("res://addons/godot_ai/utils/script_work.gd")
-const SCAN_TIMEOUT_SECONDS := 5.0
+## A reload waits for the filesystem scan it asks for. An editor that is
+## still importing at startup can take well over 5 s to answer on a slow
+## host, and a reload abandoned then leaves the plugin unchanged while the
+## caller keeps waiting; stay under the server's 90 s reconnect budget.
+const SCAN_TIMEOUT_SECONDS := 60.0
 
 ## One command-scoped native-signal handoff, not a suspended GDScript frame.
 ## Named callbacks survive the source reload caused by the scan itself.
@@ -52,7 +56,10 @@ static func _finish_scan(work: int, timed_out: bool) -> void:
 		return
 	var pending := _take_scan()
 	if timed_out:
-		push_error("MCP | filesystem scan did not finish; plugin left unchanged, retry reload")
+		push_error(
+			"MCP | filesystem scan did not finish within %d s; plugin left unchanged, retry reload"
+			% int(SCAN_TIMEOUT_SECONDS)
+		)
 	else:
 		reload_enabled_plugin()
 	ScriptWork.finish(pending.work)

--- a/plugin/addons/godot_ai/utils/plugin_reload.gd
+++ b/plugin/addons/godot_ai/utils/plugin_reload.gd
@@ -10,6 +10,9 @@ const ScriptWork := preload("res://addons/godot_ai/utils/script_work.gd")
 ## host, and a reload abandoned then leaves the plugin unchanged while the
 ## caller keeps waiting; stay under the server's 90 s reconnect budget.
 const SCAN_TIMEOUT_SECONDS := 60.0
+## The native timer's budget; tests shorten it to prove the timer itself
+## (not its length) settles an unfinished scan under a paused time scale.
+static var _scan_timeout_seconds: float = SCAN_TIMEOUT_SECONDS
 
 ## One command-scoped native-signal handoff, not a suspended GDScript frame.
 ## Named callbacks survive the source reload caused by the scan itself.
@@ -29,7 +32,7 @@ static func _start_scan(filesystem: Object, timer: Object, work: int) -> void:
 		return
 	if timer == null:
 		# Editor deadlines must not inherit a project's pause or time scale.
-		timer = Engine.get_main_loop().create_timer(SCAN_TIMEOUT_SECONDS, true, false, true)
+		timer = Engine.get_main_loop().create_timer(_scan_timeout_seconds, true, false, true)
 	var complete := _finish_scan.bind(work, false)
 	var timeout := _finish_scan.bind(work, true)
 	_pending_scan = {"work": work, "filesystem": filesystem, "timer": timer,
@@ -58,7 +61,7 @@ static func _finish_scan(work: int, timed_out: bool) -> void:
 	if timed_out:
 		push_error(
 			"MCP | filesystem scan did not finish within %d s; plugin left unchanged, retry reload"
-			% int(SCAN_TIMEOUT_SECONDS)
+			% int(_scan_timeout_seconds)
 		)
 	else:
 		reload_enabled_plugin()

--- a/script/ci-stale-server-smoke
+++ b/script/ci-stale-server-smoke
@@ -338,7 +338,9 @@ async def reload_and_probe(http_capability: str) -> tuple[dict, dict]:
         f"http://127.0.0.1:{HTTP_PORT}/mcp",
         headers={"Authorization": f"Bearer {http_capability}"},
     )
-    async with Client(transport, timeout=30, init_timeout=30) as client:
+    ## `editor_reload_plugin` legitimately waits up to the server's 90 s
+    ## reconnect budget while the editor finishes its scan and re-registers.
+    async with Client(transport, timeout=120, init_timeout=30) as client:
         deadline = time.monotonic() + 60
         while True:
             sessions = await client.call_tool("session_manage", {"op": "list"})

--- a/tests/integration/test_plugin_reload_persistence.py
+++ b/tests/integration/test_plugin_reload_persistence.py
@@ -178,6 +178,7 @@ func _exercise() -> void:
     else:
         if mode == "native-timeout":
             Engine.time_scale = 0.0
+            Reload._scan_timeout_seconds = 5.0
             Reload._start_scan(filesystem, null, work)
         else:
             Reload._start_scan(filesystem, timer, work)
@@ -216,7 +217,7 @@ func _exercise() -> void:
             assert(ProjectSettings.save() == OK)
             filesystem.filesystem_changed.emit()
         elif mode == "native-timeout":
-            pass # Real five-second timer must settle this uncompleted scan.
+            pass # The real (shortened) timer must settle this uncompleted scan.
         elif mode == "notification":
             filesystem.filesystem_changed.emit()
             assert(int(Engine.get_meta("reload_enters")) == 1,
@@ -229,6 +230,7 @@ func _exercise() -> void:
     assert(Work.quiescence().ok, "reload work must settle")
     if mode == "native-timeout":
         Engine.time_scale = 1.0
+        Reload._scan_timeout_seconds = Reload.SCAN_TIMEOUT_SECONDS
         assert(Time.get_ticks_msec() - started >= 4500)
         assert(Time.get_ticks_msec() - started < 8000)
     assert(Reload._pending_scan.is_empty())

--- a/tests/unit/test_runtime_handlers.py
+++ b/tests/unit/test_runtime_handlers.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import re
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -1998,6 +2000,24 @@ async def test_reload_plugin_reports_structured_failure_when_replacement_never_c
     assert error.data["project_path"] == "/tmp/test_project"
     assert error.data["timeout_seconds"] == 0.01
     assert error.data["diagnostics"]["check_sessions"] == "session_manage(op='list')"
+
+
+def test_plugin_scan_wait_fits_inside_the_reconnect_budget():
+    """The plugin's own scan wait must be long enough for a slow editor and
+    shorter than the server's reconnect wait, or a reload abandoned by the
+    plugin leaves the caller waiting for a replacement that never comes."""
+    root = Path(__file__).resolve().parents[2]
+    reload_script = (root / "plugin/addons/godot_ai/utils/plugin_reload.gd").read_text(
+        encoding="utf-8"
+    )
+    match = re.search(r"^const SCAN_TIMEOUT_SECONDS := ([0-9.]+)$", reload_script, re.M)
+    assert match, "plugin_reload.gd must declare SCAN_TIMEOUT_SECONDS"
+    scan_wait = float(match.group(1))
+    assert 30.0 <= scan_wait < editor_handlers.PLUGIN_RELOAD_RECONNECT_TIMEOUT_SEC
+    smoke = (root / "script/ci-stale-server-smoke").read_text(encoding="utf-8")
+    client = re.search(r"Client\(transport, timeout=(\d+), init_timeout=\d+\)", smoke)
+    assert client, "the ownership smoke must bound its MCP client"
+    assert int(client.group(1)) > editor_handlers.PLUGIN_RELOAD_RECONNECT_TIMEOUT_SEC
 
 
 def test_reload_plugin_default_reconnect_budget_covers_slow_editor_imports():


### PR DESCRIPTION
## What

A plugin reload (`editor_reload_plugin`, the dock's Reload) waited only 5 s for the filesystem scan it asks for. On a slow host where the editor is still importing at startup, that wait ran out, the plugin was left unchanged with only an editor-log error, and the calling AI client then sat through the server's 90 s reconnect budget for a replacement session that never came.

Found by the Windows **Server ownership smoke** row on a `fix/opencode-jsonc-merge-tiers` run (`stale-compatible-reload` failed with a bare 30 s `ClientRequest` timeout; the dumped editor log shows `filesystem scan did not finish; plugin left unchanged, retry reload`).

## Changes

- `plugin_reload.gd`: `SCAN_TIMEOUT_SECONDS` 5 → 60, inside the server's 90 s reconnect budget; the error names the budget.
- `script/ci-stale-server-smoke`: the MCP client allows a reload to take that long instead of failing at 30 s.
- `tests/unit/test_runtime_handlers.py`: contract test pins the plugin wait between 30 s and the server budget, and the smoke's client timeout above it.
- CHANGELOG entry.

## Verification

- `ruff check` / `ruff format --check` on the changed Python.
- `pytest tests/unit/test_runtime_handlers.py -k "reload or scan_wait"`: 15 passed.
- The `Server ownership smoke` rows on this PR exercise the reload path on all three OSes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
