### PR TITLE
release: 4.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ this file at the release's exact source commit, and its "What's Changed"
 section lists every merged pull request; this file keeps the part worth
 reading. Release engineering: [docs/releasing.md](docs/releasing.md).
 
-## Unreleased
+## 4.0.3 (2026-09-08)
+
+Stabilizes the v4 line on Windows and Linux after the 3.x crossing: the
+private capability directory the account could not use, the post-update
+client barrier, servers left behind by a client's old 3.x bridge, the
+closed-editor recovery installer, the Reload Plugin crash, and the updater's
+lock. Quit and relaunch AI clients that were connected during the update.
+[Compare v4.0.2...v4.0.3](https://github.com/hi-godot/godot-ai/compare/v4.0.2...v4.0.3).
 
 ### Fixed
 

--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -300,7 +300,7 @@ header works only until the next server start.
      "args": [
        "-T", "-o", "BatchMode=yes", "-o", "LogLevel=ERROR",
        "you@host.docker.internal",
-       "uvx --isolated --no-config --no-env-file --no-sources --no-build --index-strategy first-index --keyring-provider disabled --index https://pypi.org/simple --default-index https://pypi.org/simple --find-links https://pypi.org/simple/godot-ai/ --link-mode copy --from godot-ai==4.0.2 godot-ai attach --port 8000 --ws-port 9500"
+       "uvx --isolated --no-config --no-env-file --no-sources --no-build --index-strategy first-index --keyring-provider disabled --index https://pypi.org/simple --default-index https://pypi.org/simple --find-links https://pypi.org/simple/godot-ai/ --link-mode copy --from godot-ai==4.0.3 godot-ai attach --port 8000 --ws-port 9500"
      ]
    }
    ```

--- a/plugin/addons/godot_ai/plugin.cfg
+++ b/plugin/addons/godot_ai/plugin.cfg
@@ -3,5 +3,5 @@
 name="Godot AI"
 description="MCP server and AI tools for Godot"
 author="Godot AI"
-version="4.0.2"
+version="4.0.3"
 script="plugin.gd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "godot-ai"
-version = "4.0.2"
+version = "4.0.3"
 description = "Production-grade MCP server and AI tools for the Godot engine"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11,<3.15"


### PR DESCRIPTION
## What

Candidate A for the **4.0.3** patch release, per [docs/releasing.md](https://github.com/hi-godot/godot-ai/blob/main/docs/releasing.md): the two version fields (`pyproject.toml`, `plugin.cfg`), the dated `CHANGELOG.md` entry with its compare link, and the example pin in the client-configuration recipe. No code changes.

## What 4.0.3 carries (all merged to main today)

- #1013 Windows capability-directory lockout (#988, #1012) and the server startup report
- #1014 closed-editor recovery installer: kernel liveness, owned-entry repin (#999)
- #1016 post-update client drift deferred and named instead of blocking startup (#999)
- #1017 a 3.x server left by a client's old bridge is named; slow post-update re-probe
- #1018 OpenCode `opencode.jsonc` merge tier (#1011)
- #1015 Camera2D `make_current`
- #1020 plugin reload waits 60 s for its filesystem scan
- Earlier on main since 4.0.2: #1000, #1001, #1002, #1006, #1007

## Next

After merge: `prepare-b`, push the `qualify/v4.0.3-b` branch, dispatch `release-qualification.yml`, live three-OS sign-off, then `release.yml` (patch, previous 4.0.2) with the `release-publish` approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when connecting to remote projects after updates.
  * Fixed recovery for closed editors and prevented crashes when reloading the plugin.
  * Resolved issues involving leftover background servers and updater locking.
  * Improved capability directory handling.

* **Documentation**
  * Updated the remote SSH setup example to use version 4.0.3.

* **Chores**
  * Updated the plugin and project version to 4.0.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->