### PR TITLE
fix: release_verify imports nothing from the godot_ai package again

### DIFF
--- a/src/godot_ai/release_verify.py
+++ b/src/godot_ai/release_verify.py
@@ -19,8 +19,6 @@ import zipfile
 from pathlib import Path
 from typing import Any, NoReturn
 
-from godot_ai.transport.capability import private_mkdir
-
 REPOSITORY = "hi-godot/godot-ai"
 ASSET_NAME = "godot-ai-v4-plugin.zip"
 MANIFEST_NAME = "godot-ai-v4-plugin.manifest.json"
@@ -492,6 +490,23 @@ def _verify_installed_tree(root: Path, manifest: dict[str, Any]) -> None:
     }
     if hash_tree(root)["files"] != expected:
         _fail("installed v4 tree", "files do not exactly match the signed inventory")
+
+
+def private_mkdir(path: Path, *, windows: bool | None = None) -> None:
+    """Create one directory only this user can read; standard library only.
+
+    The same rule as ``godot_ai.transport.capability.private_mkdir``: POSIX
+    gets mode ``0o700``, Windows deliberately no mode, because CPython turns
+    ``mode=0o700`` into an OWNER RIGHTS-only DACL there (#988). It lives here
+    too because ``script/v4-release`` loads this file standalone, on a runner
+    where the ``godot_ai`` package is not installed, so this module may
+    import nothing from the package.
+    """
+    on_windows = os.name == "nt" if windows is None else windows
+    if on_windows:
+        path.mkdir(exist_ok=True)
+    else:
+        path.mkdir(mode=0o700, exist_ok=True)
 
 
 def _private_mkdir_parents(directory: Path) -> None:

--- a/tests/unit/test_release_verify.py
+++ b/tests/unit/test_release_verify.py
@@ -646,3 +646,29 @@ def test_verify_signature_falls_back_to_openssl_without_cryptography(release, tr
     verify._verify_signature(release.raw, release.signature.read_bytes(), trusted.public)
     with pytest.raises(verify.ReleaseError, match="verification failed"):
         verify._verify_signature(release.raw + b"x", release.signature.read_bytes(), trusted.public)
+
+
+def test_release_verify_loads_without_the_godot_ai_package(tmp_path):
+    """``script/v4-release`` loads this file standalone on a runner that has
+    only the interpreter; ``-I -S`` hides the editable install the same way."""
+    module_path = str(Path(verify.__file__).resolve())
+    target = str(tmp_path / "standalone")
+    probe = "\n".join(
+        [
+            "import importlib.util, sys",
+            "from pathlib import Path",
+            f"spec = importlib.util.spec_from_file_location('standalone_verify', {module_path!r})",
+            "module = importlib.util.module_from_spec(spec)",
+            "spec.loader.exec_module(module)",
+            "loaded = sorted(name for name in sys.modules if name.startswith('godot_ai'))",
+            "assert not loaded, loaded",
+            f"module.private_mkdir(Path({target!r}))",
+            "print('standalone-ok')",
+        ]
+    )
+    result = subprocess.run(
+        [sys.executable, "-I", "-S", "-c", probe], capture_output=True, text=True, timeout=60
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "standalone-ok"
+    assert (tmp_path / "standalone").is_dir()

--- a/tests/unit/test_release_verify.py
+++ b/tests/unit/test_release_verify.py
@@ -672,3 +672,19 @@ def test_release_verify_loads_without_the_godot_ai_package(tmp_path):
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == "standalone-ok"
     assert (tmp_path / "standalone").is_dir()
+
+
+def test_standalone_private_mkdir_matches_the_transport_rule(tmp_path, monkeypatch) -> None:
+    """Both forced branches, not just the host's: no mode on Windows (#988), 0o700 elsewhere."""
+    modes: list[int] = []
+    real_mkdir = Path.mkdir
+
+    def record(self, mode=0o777, parents=False, exist_ok=False):
+        modes.append(mode)
+        return real_mkdir(self, parents=parents, exist_ok=exist_ok)
+
+    monkeypatch.setattr(Path, "mkdir", record)
+    verify.private_mkdir(tmp_path / "windows", windows=True)
+    verify.private_mkdir(tmp_path / "posix", windows=False)
+    assert modes == [0o777, 0o700]
+    assert (tmp_path / "windows").is_dir() and (tmp_path / "posix").is_dir()


### PR DESCRIPTION
## What

The 4.0.3 qualification run ([34280734457](https://github.com/hi-godot/godot-ai/actions/runs/34280734457)) failed in both **Build unsigned candidate** jobs with `ModuleNotFoundError: No module named 'godot_ai'`. `script/v4-release` loads `src/godot_ai/release_verify.py` standalone, and the build job installs only `build`, so the `from godot_ai.transport.capability import private_mkdir` that #1013 added to that module cannot resolve there.

## Changes

- `release_verify.py` carries its own standard-library `private_mkdir` (same rule as the transport one: no mode on Windows because of the #988 DACL, `0o700` elsewhere) and imports nothing from the package again, as its docstring promises.
- `tests/unit/test_release_verify.py`: loads the module under `python -I -S` (no site, so the editable install is invisible), asserts no `godot_ai` module was imported, and exercises `private_mkdir`.

## Verification

- `pytest tests/unit/test_release_verify.py tests/unit/test_v4_release.py tests/unit/test_release_support.py tests/unit/test_transport_capability.py`: 250 passed.
- The workflow's exact build command (`python -m script.release_support package --root … --repo … --source d14e0e6b --version 4.0.3`) reproduced locally on Windows under `uv run --python 3.13 --no-project --with build==1.6.0`, an interpreter with no `godot_ai` installed: it now builds `godot_ai-4.0.3` wheel + sdist and the plugin zip + manifest; before the fix it failed with the same `ModuleNotFoundError` as the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Release verification now runs successfully in standalone environments where the package is unavailable.
  - Directory setup applies secure permissions on POSIX systems while preserving compatible behavior on Windows.

- **Tests**
  - Added coverage for standalone loading without package dependencies.
  - Verified directory creation, platform-specific permissions, package isolation, successful execution, and expected command output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->