### PR TITLE
test: the #988 ACL check compares against plain and 0o700 siblings

### DIFF
--- a/tests/unit/test_transport_capability.py
+++ b/tests/unit/test_transport_capability.py
@@ -492,9 +492,9 @@ def test_windows_capability_directory_inherits_the_parent_acl(tmp_path) -> None:
     ## qualification row's C: profile temp shows OWNER RIGHTS on plain
     ## children), so the assertions compare against these siblings rather
     ## than against an absolute picture of inherited entries.
-    control = tmp_path / "control"
+    control = directory.parent / "control"
     control.mkdir()
-    restricted = tmp_path / "restricted"
+    restricted = directory.parent / "restricted"
     restricted.mkdir(mode=0o700)
 
     def aces(path: Path) -> list[str]:

--- a/tests/unit/test_transport_capability.py
+++ b/tests/unit/test_transport_capability.py
@@ -481,25 +481,31 @@ def test_publishing_into_an_unwritable_directory_raises_the_repair_hint(
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows DACL inheritance")
 def test_windows_capability_directory_inherits_the_parent_acl(tmp_path) -> None:
-    """The regression behind #988: no OWNER RIGHTS-only DACL, inherited ACEs only."""
+    """The regression behind #988: the capability directory gets what a plain
+    mkdir gets in this parent, never the explicit ``mode=0o700`` DACL."""
     directory = tmp_path / "godot-ai" / "capabilities"
     write_capabilities(8122, HTTP, WEBSOCKET, instance_nonce=NONCE, directory=directory)
-    ## The DACL a plain mkdir yields in this parent is the environment's
-    ## baseline (a CI temp root may carry explicit, non-inheritable ACEs). The
-    ## capability directory must match it exactly: the 0o700 signature is a
-    ## different, explicit SYSTEM/Administrators/OWNER RIGHTS-only DACL.
+    ## Two siblings define the environment: what a plain mkdir yields here is
+    ## the baseline, and what ``mode=0o700`` yields is the #988 signature. A
+    ## CI temp root can hand a plain child explicit, non-inherited ACEs of its
+    ## own (pytest creates its temp tree with 0o700, and the release
+    ## qualification row's C: profile temp shows OWNER RIGHTS on plain
+    ## children), so the assertions compare against these siblings rather
+    ## than against an absolute picture of inherited entries.
     control = tmp_path / "control"
     control.mkdir()
+    restricted = tmp_path / "restricted"
+    restricted.mkdir(mode=0o700)
 
     def aces(path: Path) -> list[str]:
         listing = subprocess.run(
             ["icacls", str(path)], capture_output=True, text=True, check=True
         ).stdout
         return sorted(
-            line.replace(str(path), "").strip()
-            for line in listing.splitlines()
-            if ":(" in line
+            line.replace(str(path), "").strip() for line in listing.splitlines() if ":(" in line
         )
 
+    if aces(restricted) == aces(control):
+        pytest.skip("this interpreter or volume gives mode=0o700 the plain-mkdir DACL")
     assert aces(directory) == aces(control)
-    assert not any("OWNER RIGHTS" in ace and "(I)" not in ace for ace in aces(directory))
+    assert aces(directory) != aces(restricted)


### PR DESCRIPTION
## What

The second 4.0.3 qualification run ([34282584926](https://github.com/hi-godot/godot-ai/actions/runs/34282584926)) got past signing and failed one row: **Exact Python artifacts / windows-latest / 3.14**, on `test_windows_capability_directory_inherits_the_parent_acl` (the #988 regression check). The other five Python rows passed; ordinary CI's Windows 3.14 job passes the same test on the same commit.

The difference is where pytest puts its temp root. The row uses the runner's `C:` profile temp; ordinary CI passes `--basetemp` under the `D:` runner temp. Under `C:`, a **plain** `mkdir` child of pytest's `0o700` temp tree carries an explicit, non-inherited `OWNER RIGHTS` entry of its own (the row's log shows the control directory and ours with identical ACLs). The test's second assertion, "no non-inherited OWNER RIGHTS entry", was asserting an environment property, not our code. CPython's Windows mkdir security code is identical between 3.14.0 and 3.14.7, so the interpreter is not the variable.

## Change (test only)

The test now proves the actual contract with two siblings in the same parent:
- the capability directory's DACL **equals** a plain `mkdir` sibling's, and
- **differs** from a `mkdir(mode=0o700)` sibling's (the #988 signature),
- and skips honestly where an interpreter or volume gives both siblings the same DACL.

## Verification

Run locally on this Windows box under Python 3.12 (venv), 3.14 and 3.11 (`uv run --with-editable .[dev]`): passes on all three. Full `tests/unit/test_transport_capability.py`: green.

After merge this becomes the new candidate A for 4.0.3 and qualification is re-dispatched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated Windows permission inheritance coverage to create comparison directories alongside the capability directory.
  * Preserved comparisons using standard directory creation and restrictive `0o700` permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->