### PR TITLE
fix: launch failures quote the startup report; a held WebSocket port is diagnosed before launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ this file at the release's exact source commit, and its "What's Changed"
 section lists every merged pull request; this file keeps the part worth
 reading. Release engineering: [docs/releasing.md](docs/releasing.md).
 
+## Unreleased
+
+### Fixed
+
+- A server that refused to start now says why in the dock. The launch-failure
+  message (`The launched process identity could not be captured…`) appends the
+  server's own startup report, which two 4.0.3 reports had on disk unread:
+  `WebSocket port 19630 is already in use by another process`.
+- Moving the HTTP port alone no longer lands the next launch on a WebSocket
+  port the previous server still holds: the lifecycle preflights the WebSocket
+  port before launching and names `godot_ai/ws_port`, and the dock's port picker
+  moves both ports, keeping whichever one is free.
+- `Port N is occupied by another process` now says why a godot-ai record for
+  that port did not authenticate the occupant (a probe timeout, a different
+  instance, a non-godot-ai listener), so the report is actionable.
+
 ## 4.0.3 (2026-09-08)
 
 Stabilizes the v4 line on Windows and Linux after the 3.x crossing: the

--- a/docs/server-lifecycle.md
+++ b/docs/server-lifecycle.md
@@ -68,8 +68,13 @@ in `BLOCKED`.
    bound.
 3. If the authenticated endpoint has the expected version and WS port, adopt
    its transport authority. Adoption deliberately carries no process grant.
-4. If the port is free, launch the configured command with fresh independent
-   HTTP and WebSocket capabilities.
+4. If the HTTP port is free, check the WebSocket port too: the server binds
+   both before it publishes anything, so a held WebSocket port (a server moved
+   off the HTTP port, another editor) blocks the start with `ws_occupied` and
+   names `godot_ai/ws_port` instead of dying at the server's preflight. The
+   dock's port picker moves both ports and keeps whichever one is free. Then
+   launch the configured command with fresh independent HTTP and WebSocket
+   capabilities.
 5. Wait for the new capability record, authenticate status, and bind the live
    process fingerprint before publishing `READY`.
 
@@ -85,8 +90,12 @@ side. The plugin also passes `--startup-report <user://...json>` beside
 fails before publishing its record writes `{pid, error, message, hint}` there
 (a port already in use, an unwritable directory, an import error); the first
 report wins and the record's publication disarms it. The dock appends that
-text to "exited before publishing capabilities" and to the proof timeout. The
-report is quoted, bounded and never interpreted.
+text to "exited before publishing capabilities", to the proof timeout, and to
+a launch whose process identity could not be captured (the process usually
+died refusing to start, and the report says why). The report is quoted,
+bounded and never interpreted. When the HTTP port is held and a capability
+record exists for it but does not authenticate the occupant, the block names
+the reason (a probe timeout, a different instance, a non-godot-ai listener).
 
 The Python server owns the private record and a per-port launch claim. HTTP,
 status, and lease routes require the HTTP bearer. The editor WebSocket stays on

--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -349,6 +349,17 @@ static func apply_endpoint_settings(changes: Dictionary) -> Dictionary:
 				if float(value) != float(port) or port < MIN_PORT or port > MAX_PORT:
 					return {"ok": false, "error": "HTTP port is outside the supported range"}
 				normalized[McpSettings.SETTING_HTTP_PORT] = port
+			"ws_port":
+				if not (value is int or value is float):
+					return {"ok": false, "error": "WebSocket port must be an integer"}
+				var ws_port_value := int(value)
+				if (
+					float(value) != float(ws_port_value)
+					or ws_port_value < MIN_PORT
+					or ws_port_value > MAX_PORT
+				):
+					return {"ok": false, "error": "WebSocket port is outside the supported range"}
+				normalized[SETTING_WS_PORT] = ws_port_value
 			"excluded_domains":
 				if not (value is String):
 					return {"ok": false, "error": "excluded domains must be text"}
@@ -366,6 +377,10 @@ static func apply_endpoint_settings(changes: Dictionary) -> Dictionary:
 				normalized[McpSettings.SETTING_ALLOW_HOSTS] = allowed
 			_:
 				return {"ok": false, "error": "unknown endpoint setting: %s" % key}
+	var next_http := int(normalized.get(McpSettings.SETTING_HTTP_PORT, http_port()))
+	var next_ws := int(normalized.get(SETTING_WS_PORT, ws_port()))
+	if next_http == next_ws:
+		return {"ok": false, "error": "HTTP and WebSocket ports must differ"}
 	var es := EditorInterface.get_editor_settings()
 	if es == null:
 		return {"ok": false, "error": "EditorSettings is unavailable"}

--- a/plugin/addons/godot_ai/dock_panels/port_picker_panel.gd
+++ b/plugin/addons/godot_ai/dock_panels/port_picker_panel.gd
@@ -2,18 +2,27 @@
 extends VBoxContainer
 
 ## Dock subpanel — port-change escape hatch surfaced inside the spawn-failure
-## crash panel when the HTTP port is contested (PORT_EXCLUDED, FOREIGN_PORT).
-## Emits `port_apply_requested(new_port)` after range-validation; the dock
-## handles writing the EditorSetting and reloading the plugin.
+## crash panel when a port is contested (PORT_EXCLUDED, FOREIGN_PORT).
+##
+## It moves BOTH ports. A godot-ai server binds its HTTP and WebSocket ports
+## together, so moving only the HTTP port onto a free number lands the next
+## launch on a WebSocket port the previous server still holds, and the server
+## dies at preflight ("WebSocket port 19630 is already in use"). Emits
+## `port_apply_requested(new_http_port, new_ws_port)` after range-validation;
+## the dock writes the EditorSettings and reloads the plugin.
 ##
 ## Extracted from mcp_dock.gd as part of audit-v2 #360 — see the comment at
 ## the top of mcp_dock.gd for the broader extraction story.
 
 const ClientConfigurator := preload("res://addons/godot_ai/client_configurator.gd")
+const PortResolver := preload("res://addons/godot_ai/utils/port_resolver.gd")
 
-signal port_apply_requested(new_port: int)
+signal port_apply_requested(new_http_port: int, new_ws_port: int)
 
 var _spinbox: SpinBox
+var _ws_spinbox: SpinBox
+## Bind probe used when seeding; tests substitute a deterministic one.
+var port_in_use_probe: Callable = Callable(PortResolver, "is_port_in_use")
 
 
 ## Build the UI synchronously here so callers (and detached-tree tests that
@@ -35,19 +44,17 @@ func _build_ui() -> void:
 	var picker_row := HBoxContainer.new()
 	picker_row.add_theme_constant_override("separation", 6)
 
-	_spinbox = SpinBox.new()
-	_spinbox.min_value = ClientConfigurator.MIN_PORT
-	_spinbox.max_value = ClientConfigurator.MAX_PORT
-	_spinbox.step = 1
-	_spinbox.value = ClientConfigurator.http_port()
-	_spinbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_spinbox = _port_spinbox(ClientConfigurator.http_port(), "HTTP port (godot_ai/http_port)")
 	picker_row.add_child(_spinbox)
+	_ws_spinbox = _port_spinbox(ClientConfigurator.ws_port(), "WebSocket port (godot_ai/ws_port)")
+	picker_row.add_child(_ws_spinbox)
 
 	var apply_btn := Button.new()
 	apply_btn.text = "Apply + Reload"
 	apply_btn.tooltip_text = (
-		"Saves godot_ai/http_port to Editor Settings and reloads the plugin so"
-		+ " the server spawns on the new port."
+		"Saves godot_ai/http_port and godot_ai/ws_port to Editor Settings and reloads"
+		+ " the plugin so the server spawns on the new ports. Reconfigure your AI"
+		+ " clients afterwards so their bridges use the new ports."
 	)
 	apply_btn.pressed.connect(_on_apply_pressed)
 	picker_row.add_child(apply_btn)
@@ -55,24 +62,45 @@ func _build_ui() -> void:
 	add_child(picker_row)
 
 
-## Re-seed the spinbox with a fresh suggestion every time the panel surfaces,
-## so a stale value from a previous spawn-failure round can't carry over. Note
-## that this OVERWRITES any unsaved user input — fine in practice because the
-## dock's `_update_crash_panel` only calls this on `server_status` transitions
-## (`if server_status == _last_server_status: return` short-circuit), so a
-## user typing into the spinbox between transitions keeps their value. If the
-## state flips while the picker is visible (e.g. `PORT_EXCLUDED` → `FOREIGN_PORT`),
-## the in-flight edit is clobbered — accept that, the suggestion is more current.
-func seed_suggested_port() -> void:
+static func _port_spinbox(value: int, tooltip: String) -> SpinBox:
+	var spinbox := SpinBox.new()
+	spinbox.min_value = ClientConfigurator.MIN_PORT
+	spinbox.max_value = ClientConfigurator.MAX_PORT
+	spinbox.step = 1
+	spinbox.value = value
+	spinbox.tooltip_text = tooltip
+	spinbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	return spinbox
+
+
+## Seed both boxes every time the panel surfaces, so a stale value from a
+## previous spawn-failure round cannot carry over. The diagnosed
+## `conflict_port` and any port that is simply in use get a fresh free
+## suggestion; a port that is free keeps its value, so clients whose entries
+## carry it keep working. Note that this OVERWRITES unsaved user input — fine
+## in practice because the dock only calls this on `server_status`
+## transitions (`if server_status == _last_server_status: return`).
+func seed_suggested_ports(conflict_port := 0) -> void:
 	if _spinbox == null:
 		return
-	_spinbox.value = ClientConfigurator.suggest_free_port(
-		ClientConfigurator.http_port() + 1
-	)
+	var http := ClientConfigurator.http_port()
+	var ws := ClientConfigurator.ws_port()
+	if conflict_port == http or bool(port_in_use_probe.call(http)):
+		http = ClientConfigurator.suggest_free_port(http + 1)
+	if conflict_port == ws or ws == http or bool(port_in_use_probe.call(ws)):
+		ws = ClientConfigurator.suggest_free_port(ws + 1)
+		if ws == http:
+			ws = ClientConfigurator.suggest_free_port(ws + 1)
+	_spinbox.value = http
+	_ws_spinbox.value = ws
 
 
 func _on_apply_pressed() -> void:
-	var new_port: int = int(_spinbox.value)
-	if new_port < ClientConfigurator.MIN_PORT or new_port > ClientConfigurator.MAX_PORT:
+	var new_http: int = int(_spinbox.value)
+	var new_ws: int = int(_ws_spinbox.value)
+	for port in [new_http, new_ws]:
+		if port < ClientConfigurator.MIN_PORT or port > ClientConfigurator.MAX_PORT:
+			return
+	if new_http == new_ws:
 		return
-	port_apply_requested.emit(new_port)
+	port_apply_requested.emit(new_http, new_ws)

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -946,21 +946,16 @@ func _update_crash_panel(server_status: Dictionary) -> void:
 			and not bool(server_status.get("can_recover_incompatible", false))
 		)
 
-	## #647: the quick picker only moves `godot_ai/http_port`, so hide it
-	## when the diagnosed conflict is on the WebSocket port — the crash
-	## body already points at `godot_ai/ws_port` in Editor Settings.
+	## The picker moves both ports (#647 hid it for a WebSocket-side
+	## conflict when it could only move the HTTP port), seeded with the
+	## diagnosed conflict so only the contested port changes.
 	var conflict_port := int(server_status.get("conflict_port", 0))
-	var http_conflict := conflict_port <= 0 or conflict_port == ClientConfigurator.http_port()
 	var port_picker_visible := (
-		state == ServerStateScript.PORT_EXCLUDED
-		or (state == ServerStateScript.FOREIGN_PORT and http_conflict)
+		state == ServerStateScript.PORT_EXCLUDED or state == ServerStateScript.FOREIGN_PORT
 	)
 	_port_picker_panel.visible = port_picker_visible
 	if port_picker_visible:
-		## Seed the spinbox with a suggested non-reserved port each time the
-		## panel surfaces. Idempotent when the user already has a good
-		## candidate queued up.
-		_port_picker_panel.seed_suggested_port()
+		_port_picker_panel.seed_suggested_ports(conflict_port)
 
 
 static func _crash_body_for_state(state: int, server_status: Dictionary = {}) -> String:
@@ -1073,8 +1068,8 @@ func _on_log_logging_enabled_changed(enabled: bool) -> void:
 
 ## Signal handler for the extracted PortPickerPanel. The replaceable Dock emits
 ## a copied value intent; the composition root owns persistence and reload.
-func _on_port_apply_requested(new_port: int) -> void:
-	settings_apply_requested.emit({"http_port": new_port}, true)
+func _on_port_apply_requested(new_http_port: int, new_ws_port: int) -> void:
+	settings_apply_requested.emit({"http_port": new_http_port, "ws_port": new_ws_port}, true)
 
 
 func _refresh_server_label(server_status: Dictionary = {}) -> void:

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -398,7 +398,13 @@ func _complete_probe(result: Dictionary) -> void:
 
 func _complete_launch(result: Dictionary) -> void:
 	if not bool(result.get("ok", false)):
-		_block(str(result.get("reason", "launch_failed")), str(result.get("message", "Server launch failed.")))
+		## The process usually died before its identity could be captured
+		## because it refused to start; it says why in its startup report.
+		_block(
+			str(result.get("reason", "launch_failed")),
+			str(result.get("message", "Server launch failed."))
+			+ startup_report_summary(str(_plan.get("startup_report", ""))),
+		)
 		return
 	var pid := int(result.get("pid", 0))
 	var fingerprint := str(result.get("fingerprint", ""))
@@ -672,15 +678,48 @@ func _effect_probe(payload: Dictionary) -> Dictionary:
 			}
 		return _blocked_probe_result("incompatible", port, live, true)
 	if PortResolver.is_port_in_use(port):
-		var blocked := _blocked_probe_result("occupied", port, live)
+		var detail := _record_probe_failure_detail(capability, live)
+		var blocked := _blocked_probe_result("occupied", port, live, false, detail)
 		var pre_v4 := _untrusted_pre_v4_occupant_version(port, int(payload.timeout_ms))
 		if not pre_v4.is_empty():
 			blocked["message"] = stale_pre_v4_message(port, pre_v4)
 			blocked["target"]["hint"] = STALE_PRE_V4_HINT
 		return blocked
+	## The server binds both ports before it publishes anything. A held
+	## WebSocket port (a server moved off the HTTP port, or another editor)
+	## would kill the launch at preflight; say so now and name the setting.
+	if expected_ws_port > 0 and PortResolver.is_port_in_use(expected_ws_port):
+		return ws_port_blocked_result(expected_ws_port)
 	return {
 		"outcome": "free",
 		"baseline_instance_id": str(capability.get("instance_nonce", "")),
+	}
+
+
+## Why an existing capability record did not authenticate the occupant, so a
+## "held by another process" report can be acted on. Empty when there was no
+## record to try, or when the probe succeeded and the mismatch is elsewhere.
+static func _record_probe_failure_detail(capability: Dictionary, live: Dictionary) -> String:
+	if str(capability.get("http", "")).is_empty():
+		return ""
+	var error := str(live.get("error", "")).strip_edges()
+	if error.is_empty():
+		if str(live.get("name", "")) != "godot-ai":
+			return "a godot-ai record for this port exists, but the listener did not answer as godot-ai"
+		return "a godot-ai record for this port exists, but it belongs to a different server instance"
+	return "a godot-ai record for this port exists, but its status probe failed: %s" % error
+
+
+static func ws_port_blocked_result(ws_port: int) -> Dictionary:
+	return {
+		"outcome": "blocked",
+		"reason": "ws_occupied",
+		"message": (
+			"WebSocket port %d is already in use by another process. "
+			+ "Set `godot_ai/ws_port` in Editor Settings to a free port "
+			+ "(the dock's port picker moves both ports), then reconfigure your AI clients."
+		) % ws_port,
+		"target": {"instance_id": "", "version": "", "port": ws_port, "replaceable": false},
 	}
 
 
@@ -1183,7 +1222,7 @@ static func _transport_from(port: int, ws_port: int, live: Dictionary, capabilit
 
 
 static func _blocked_probe_result(
-	reason: String, port: int, live: Dictionary, allow_replacement := false
+	reason: String, port: int, live: Dictionary, allow_replacement := false, detail := ""
 ) -> Dictionary:
 	var instance_id := str(live.get("instance_id", ""))
 	var version := str(live.get("version", ""))
@@ -1194,6 +1233,8 @@ static func _blocked_probe_result(
 		and not version.is_empty()
 	)
 	var message := "Port %d is occupied by another process." % port
+	if not detail.is_empty():
+		message = "Port %d is occupied by another process (%s)." % [port, detail]
 	if replaceable:
 		message = "Port %d is occupied by godot-ai v%s; choose Replace to continue." % [port, version]
 	return {

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -1872,9 +1872,9 @@ func test_recoverable_incompatible_hides_docs_link_button() -> void:
 ## lambdas with closure-captured locals don't reliably evaluate the body
 ## under the test runner, so a typed receiver is the safe form.
 class _PortApplySpy:
-	var captured: Array[int] = []
-	func on_apply(new_port: int) -> void:
-		captured.append(new_port)
+	var captured: Array = []
+	func on_apply(new_http_port: int, new_ws_port: int) -> void:
+		captured.append([new_http_port, new_ws_port])
 
 
 class _LogToggleSpy:
@@ -1901,9 +1901,14 @@ func test_port_picker_panel_emits_apply_requested_for_in_range_port() -> void:
 	var spy := _PortApplySpy.new()
 	panel.port_apply_requested.connect(spy.on_apply)
 	panel._spinbox.value = 9000
+	panel._ws_spinbox.value = 9501
 	panel._on_apply_pressed()
-	assert_eq(spy.captured.size(), 1, "in-range port must emit exactly once")
-	assert_eq(spy.captured[0], 9000, "emitted port must match the spinbox value")
+	assert_eq(spy.captured.size(), 1, "in-range ports must emit exactly once")
+	assert_eq(spy.captured[0], [9000, 9501], "emitted ports must match both spinboxes")
+	## Equal ports can never bind together; the panel refuses them itself.
+	panel._ws_spinbox.value = 9000
+	panel._on_apply_pressed()
+	assert_eq(spy.captured.size(), 1, "equal HTTP and WebSocket ports must not emit")
 	panel.free()
 
 
@@ -1927,11 +1932,48 @@ func test_port_picker_panel_skips_emit_for_out_of_range_port() -> void:
 	panel.free()
 
 
+func test_port_picker_seeds_only_the_contested_port() -> void:
+	## The server binds HTTP and WebSocket together. Moving only the HTTP port
+	## onto a free number left the launch dying on the WebSocket port the old
+	## server still held; the picker now moves whichever port is contested or
+	## in use and keeps the other so client entries stay valid where they can.
+	var panel := PortPickerPanelScript.new()
+	panel.setup()
+	var http := McpClientConfigurator.http_port()
+	var ws := McpClientConfigurator.ws_port()
+	panel.port_in_use_probe = func(port: int) -> bool: return port == ws
+	panel.seed_suggested_ports(0)
+	assert_eq(int(panel._spinbox.value), http, "a free HTTP port keeps its value")
+	assert_true(int(panel._ws_spinbox.value) != ws, "a held WebSocket port gets a suggestion")
+	assert_true(int(panel._ws_spinbox.value) != int(panel._spinbox.value))
+	panel.port_in_use_probe = func(_port: int) -> bool: return false
+	panel.seed_suggested_ports(http)
+	assert_true(int(panel._spinbox.value) != http, "the diagnosed conflict port moves")
+	assert_eq(int(panel._ws_spinbox.value), ws, "a free WebSocket port keeps its value")
+	panel.free()
+
+
+func test_websocket_port_conflict_shows_the_picker_and_names_the_setting() -> void:
+	## The lifecycle now refuses to launch onto a held WebSocket port and names
+	## `godot_ai/ws_port`; the picker can move that port, so it is offered.
+	_dock._build_ui()
+	_dock._port_picker_panel.port_in_use_probe = func(_port: int) -> bool: return false
+	var ws := McpClientConfigurator.ws_port()
+	_dock._update_crash_panel({
+		"state": McpServerState.FOREIGN_PORT,
+		"conflict_port": ws,
+		"message": "WebSocket port %d is already in use by another process. Set `godot_ai/ws_port` in Editor Settings." % ws,
+	})
+	assert_true(_dock._crash_panel.visible, "diagnostic panel shows")
+	assert_true(_dock._port_picker_panel.visible, "the picker moves both ports, so a WS conflict offers it")
+	assert_true(_dock._crash_output.get_parsed_text().contains("godot_ai/ws_port"), _dock._crash_output.get_parsed_text())
+
+
 func test_dock_emits_copied_endpoint_setting_intents_without_persisting() -> void:
 	var dock := McpDockScript.new()
 	var spy := _SettingsApplySpy.new()
 	dock.settings_apply_requested.connect(spy.on_apply)
-	dock._on_port_apply_requested(23000)
+	dock._on_port_apply_requested(23000, 23500)
 	dock._tools_pending_excluded = PackedStringArray(["audio"])
 	dock._telemetry_pending_enabled = false
 	dock._on_tools_apply()
@@ -1940,7 +1982,7 @@ func test_dock_emits_copied_endpoint_setting_intents_without_persisting() -> voi
 	dock._allow_hosts_edit.text = "10.0.0.5"
 	dock._on_allow_hosts_apply()
 	assert_eq(spy.captured.size(), 3)
-	assert_eq(spy.captured[0], {"changes": {"http_port": 23000}, "reload": true})
+	assert_eq(spy.captured[0], {"changes": {"http_port": 23000, "ws_port": 23500}, "reload": true})
 	assert_eq(str(spy.captured[1].changes.excluded_domains), "audio")
 	assert_false(bool(spy.captured[1].changes.telemetry_enabled))
 	assert_eq(str(spy.captured[2].changes.allow_hosts), "10.0.0.5")

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -624,6 +624,83 @@ func test_server_flags_carry_the_startup_report_path() -> void:
 	assert_false(without.has("--startup-report"))
 
 
+func test_launch_failure_carries_the_startup_report() -> void:
+	## A server that refused to start dies before its identity is captured;
+	## the launch-unproven block must still quote why (the WebSocket port
+	## conflict behind two 4.0.3 reports showed only "identity could not be
+	## captured" while the report on disk named the port).
+	var path := OS.get_user_data_dir().path_join("lifecycle_launch_report_test.json")
+	var file := FileAccess.open(path, FileAccess.WRITE)
+	file.store_string(JSON.stringify({
+		"pid": 1, "error": "OSError",
+		"message": "WebSocket port 9500 is already in use by another process.", "hint": "",
+	}))
+	file.close()
+	var manager := _manager({"startup_report": path})
+	manager.start_server()
+	var episode := manager.episode_snapshot()
+	assert_true(manager.complete_effect(episode.id, Lifecycle.PROBE, {"outcome": "free", "baseline_instance_id": ""}))
+	episode = manager.episode_snapshot()
+	assert_true(manager.complete_effect(episode.id, Lifecycle.LAUNCH, {
+		"ok": false, "reason": "launch_unproven",
+		"message": "The launched process identity could not be captured in 58 attempts over 15.0 s.",
+	}))
+	var message := str(manager.get_status_dict().message)
+	assert_true(message.contains("could not be captured"), message)
+	assert_true(message.contains("Server reported: OSError: WebSocket port 9500"), message)
+	DirAccess.remove_absolute(path)
+
+
+func test_probe_blocks_on_a_held_websocket_port_before_launch() -> void:
+	## Both ports bind together; a held WebSocket port would kill the launch at
+	## the server's preflight. The probe names it and the setting instead.
+	var ws_port := McpClientConfigurator.suggest_free_port(41000)
+	var listener := TCPServer.new()
+	assert_eq(listener.listen(ws_port, "127.0.0.1"), OK)
+	var http_port := McpClientConfigurator.suggest_free_port(ws_port + 1)
+	var manager := _manager({"http_port": http_port, "ws_port": ws_port})
+	var result := manager._effect_probe({
+		"http_port": http_port, "expected_version": VERSION,
+		"expected_ws_port": ws_port, "timeout_ms": 200,
+	})
+	listener.stop()
+	assert_eq(str(result.outcome), "blocked")
+	assert_eq(str(result.reason), "ws_occupied")
+	assert_true(str(result.message).contains("WebSocket port %d" % ws_port), result.message)
+	assert_true(str(result.message).contains("godot_ai/ws_port"), result.message)
+	assert_eq(int(result.target.port), ws_port)
+	assert_false(bool(result.target.replaceable))
+	## With the WebSocket port free again the same probe reports free.
+	var free_result := manager._effect_probe({
+		"http_port": http_port, "expected_version": VERSION,
+		"expected_ws_port": ws_port, "timeout_ms": 200,
+	})
+	assert_eq(str(free_result.outcome), "free")
+
+
+func test_occupied_block_names_why_the_record_did_not_authenticate() -> void:
+	## "Held by another process" hid the interesting fact: a godot-ai record
+	## existed for the port and its authenticated probe failed. Say why.
+	var record := {"http": "token", "websocket": "ws", "instance_nonce": "abc"}
+	assert_eq(
+		Lifecycle._record_probe_failure_detail(record, {"reachable": false, "error": "connect_timeout"}),
+		"a godot-ai record for this port exists, but its status probe failed: connect_timeout"
+	)
+	assert_eq(
+		Lifecycle._record_probe_failure_detail(record, {"reachable": true, "name": "godot-ai", "instance_id": "other", "error": ""}),
+		"a godot-ai record for this port exists, but it belongs to a different server instance"
+	)
+	assert_eq(Lifecycle._record_probe_failure_detail({}, {"error": "connect_timeout"}), "", "no record, nothing to explain")
+	var result := Lifecycle._blocked_probe_result(
+		"occupied", 8000, {"error": "connect_timeout"}, false,
+		"a godot-ai record for this port exists, but its status probe failed: connect_timeout"
+	)
+	assert_true(str(result.message).begins_with("Port 8000 is occupied by another process (a godot-ai record"), result.message)
+	assert_false(bool(result.target.replaceable))
+	var plain := Lifecycle._blocked_probe_result("occupied", 8000, {})
+	assert_eq(str(plain.message), "Port 8000 is occupied by another process.")
+
+
 func test_startup_report_summary_quotes_the_server_failure() -> void:
 	var path := OS.get_user_data_dir().path_join("lifecycle_startup_report_test.json")
 	var file := FileAccess.open(path, FileAccess.WRITE)

--- a/tests/unit/test_post_update_stale_server.py
+++ b/tests/unit/test_post_update_stale_server.py
@@ -270,9 +270,8 @@ def test_untrusted_pre_v4_peek_never_enters_the_trusted_probe_outcome() -> None:
 
     ## The peek result is a version string used for wording, applied only to
     ## the already-built blocked result, after the authenticated branch.
-    assert probe.index('_blocked_probe_result("occupied", port, live)') < probe.index(
-        "_untrusted_pre_v4_occupant_version("
-    )
+    occupied = probe.index('_blocked_probe_result("occupied", port, live, false, detail)')
+    assert occupied < probe.index("_untrusted_pre_v4_occupant_version(")
     assert 'blocked["message"] = stale_pre_v4_message(' in probe
     assert 'blocked["target"]["hint"] = STALE_PRE_V4_HINT' in probe
     assert "replaceable" not in probe.split("_untrusted_pre_v4_occupant_version(", 1)[1]


### PR DESCRIPTION
## What

First PR of the 4.1 "update with clients attached" plan. Three plugin-side fixes, two of them straight from today's 4.0.3 reports on Windows.

1. **A server that refused to start now says why in the dock.** Two projects on this machine showed `Server exited after 0.0s — The launched process identity could not be captured in 58 attempts…` while the server's own startup report on disk said `[Errno 10048] WebSocket port 19630 is already in use by another process`. The launch-failure block now appends the startup report the same way the proof-timeout block already did (`_complete_launch`).

2. **A held WebSocket port is diagnosed before launch, and the port picker moves both ports.** The dock suggested a free *HTTP* port and Apply + Reload moved only `godot_ai/http_port`; the next launch died at the server's preflight because the previous server still held the WebSocket port. `_effect_probe` now preflights `expected_ws_port` when the HTTP port is free and blocks with `ws_occupied`, naming `godot_ai/ws_port`. The port picker has HTTP and WS boxes, seeds only the contested or in-use port (a free one keeps its value so client entries stay valid), refuses equal ports, and `apply_endpoint_settings` accepts `ws_port` (#647 hid the picker for WS conflicts because it could only move HTTP; it is shown again).

3. **`Port N is occupied by another process` says why the record did not authenticate.** When a godot-ai capability record exists for the port but the authenticated probe fails, the block names the reason (`its status probe failed: connect_timeout`, `belongs to a different server instance`, `listener did not answer as godot-ai`). The tesy dock today showed the bare sentence for a port whose record authenticated fine from a shell, and nothing in the message could say what the plugin saw.

## Tests

- `test_server_lifecycle.gd`: launch failure carries the startup report; a real bound WebSocket port blocks the probe with `ws_occupied` and frees cleanly; occupied-block detail wording.
- `test_dock.gd`: two-port picker emits both / refuses equal ports; seeding moves only the contested port; a WS conflict shows the picker and names the setting; endpoint intents carry `ws_port`.
- `tests/unit/test_post_update_stale_server.py` source gate updated for the probe call shape.

## Verification

- Full GDScript suite, headless 4.7.2 editor via CI's flow on this Windows box: 2259 passed, 0 failed, 43 skipped.
- `pytest -m "not editor"`: 2509 passed, 44 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Port conflicts now detect both HTTP and WebSocket ports before launch.
  - Port settings can be changed together, with safeguards preventing duplicate ports.
  - Port conflict messages now explain authentication failures and identify the affected setting.
  - Launch failures and startup timeouts now include details from the server’s startup report.
  - The port picker is available for WebSocket conflicts and changes only the affected port when appropriate.

- **Documentation**
  - Updated server lifecycle documentation and unreleased changelog entries to describe these fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->