### PR TITLE
fix: the post-update replacement fires for any older server of our major; relaunch banner only when bridges cannot follow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ reading. Release engineering: [docs/releasing.md](docs/releasing.md).
 - `Port N is occupied by another process` now says why a godot-ai record for
   that port did not authenticate the occupant (a probe timeout, a different
   instance, a non-godot-ai listener), so the report is actionable.
+- After an update the restarted plugin replaces any older server of its
+  major version that an attach bridge left on the port, not only the exact
+  version it superseded, and its post-update status probe waits 3 s instead
+  of 800 ms so a backend still settling on the port is not reported as
+  "held by another process" with nothing replacing it.
+- The post-update banner and log line say "AI clients keep working" when the
+  clients were attached through 4.1.0 or newer (their bridges follow the new
+  server), and keep telling the user to quit and relaunch only for bridges
+  that predate it.
 
 ### Changed
 

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -111,8 +111,10 @@ All steps run inside the editor, on the main thread except the download.
     during the update loses server A at the swap. Its bridge then does what
     it always does without a backend: it spawns one, of the old version,
     into the restart window. The restarted editor replaces a godot-ai server
-    at exactly the version it just updated from without asking; any other
-    conflict keeps the dock's explicit Restart Server authority. Every
+    at the version it just updated from, or any older server of its own
+    major version, once and without asking; a newer server, another major,
+    or any other conflict keeps the dock's explicit Restart Server
+    authority. Every
     replacement launches our server before killing the occupant; that server
     waits for the port to free, binds and listens the instant it does, and
     hands that very socket to its HTTP and WebSocket servers, so the port is
@@ -125,11 +127,9 @@ All steps run inside the editor, on the main thread except the download.
     configuration in memory and respawns the old bridge from it until the
     application itself is relaunched. A 4.1.0+ bridge keeps serving a server
     of the same major version and follows the replacement on its own, so the
-    dock says the clients keep working instead. The restarted plugin replaces
-    the superseded server, or any older server of its major version a bridge
-    left on the port, once, probing with a longer timeout than an ordinary
-    start so a backend still settling on the port is not mistaken for a
-    foreign process.
+    dock says the clients keep working instead. That post-update replacement
+    probes with a longer timeout than an ordinary start, so a backend still
+    settling on the port is not mistaken for a foreign process.
 
 ## The v3-to-v4 capsule
 

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -38,10 +38,12 @@ All steps run inside the editor, on the main thread except the download.
 
 1. **Check.** The dock polls the releases API; a candidate is a newer `4.x`
    release exposing the six-name asset set. Dev checkouts skip this. Clicking
-   Update asks first: the update saves the project, relaunches the editor,
-   and AI clients connected during the update must be quit and relaunched
-   afterwards (a client that keeps its MCP configuration in memory respawns
-   the old bridge on a mere server restart).
+   Update asks first: the update saves the project and relaunches the
+   editor. AI clients connected during the update keep working when the
+   version they were attached through is 4.1.0 or newer (their bridge follows
+   a server of the same major version); from an older version they must be
+   quit and relaunched afterwards (a client that keeps its MCP configuration
+   in memory respawns the old bridge on a mere server restart).
 2. **Download** the three canonical assets into
    `user://godot_ai_update/download/`, enforcing the release-declared sizes and
    trusted asset URLs exactly as today.
@@ -116,12 +118,18 @@ All steps run inside the editor, on the main thread except the download.
     hands that very socket to its HTTP and WebSocket servers, so the port is
     never free between the old backend's death and ours listening: a bridge
     polling for a free port to spawn again never sees one. The
-    old bridge itself refuses the new backend as incompatible, so the dock
-    tells the user to quit and relaunch AI clients that were connected
-    during the update; the repinned client configuration launches the new
-    version. Quit, not restart: Claude Desktop keeps its MCP configuration
-    in memory and respawns the old bridge from it until the application
-    itself is relaunched.
+    old bridge, when it predates 4.1.0, refuses the new backend as
+    incompatible, so the dock tells the user to quit and relaunch AI clients
+    that were connected during the update; the repinned client configuration
+    launches the new version. Quit, not restart: Claude Desktop keeps its MCP
+    configuration in memory and respawns the old bridge from it until the
+    application itself is relaunched. A 4.1.0+ bridge keeps serving a server
+    of the same major version and follows the replacement on its own, so the
+    dock says the clients keep working instead. The restarted plugin replaces
+    the superseded server, or any older server of its major version a bridge
+    left on the port, once, probing with a longer timeout than an ordinary
+    start so a backend still settling on the port is not mistaken for a
+    foreign process.
 
 ## The v3-to-v4 capsule
 

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -1280,9 +1280,11 @@ func _capture_lifecycle_plan() -> Dictionary:
 		"server_command": ClientConfigurator.get_server_command(),
 		"pid_file": ProjectSettings.globalize_path(PortResolver.SERVER_PID_FILE),
 		"startup_report": ProjectSettings.globalize_path(PortResolver.SERVER_STARTUP_REPORT),
+		## The lifecycle is configured before the post-update migration runs,
+		## so the arm's own state is not set yet; the recorded outcome is.
 		"probe_timeout_ms": (
 			POST_UPDATE_PROBE_TIMEOUT_MS
-			if not _post_update_replaced_version.is_empty()
+			if str(_post_update_outcome.get("outcome", "")) == "success"
 			else ServerLifecycleManager.DEFAULT_PROBE_TIMEOUT_MS
 		),
 		"http_port_reserved": WindowsPortReservation.is_port_excluded(http_port),

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -148,6 +148,15 @@ var _post_update_stale_reprobes_left := POST_UPDATE_STALE_REPROBE_LIMIT
 ## may not be the last; a few are allowed before the dock takes over.
 const POST_UPDATE_REPLACEMENT_LIMIT := 3
 var _post_update_replacements_left := POST_UPDATE_REPLACEMENT_LIMIT
+## Right after an update the old bridge's backend may still be settling on
+## the port; a status probe that gives up in 800 ms reads it as a foreign
+## process and nothing replaces it. The post-update probe waits longer.
+const POST_UPDATE_PROBE_TIMEOUT_MS := 3000
+## First version whose attach bridge keeps serving a server of the same
+## major version (#1024). A client attached through an update from an older
+## version still runs a bridge that refuses the new server and must be quit
+## and relaunched; from this version on it follows the new server itself.
+const FIRST_BRIDGE_TOLERANT_VERSION := "4.1.0"
 ## Set once the live tree has been renamed; the lock then belongs to the restart.
 var _update_swapped := false
 var _post_update_action := ""
@@ -877,10 +886,14 @@ func _finish_post_update() -> void:
 	_post_update_reprobes_left = POST_UPDATE_REPROBE_LIMIT
 	_post_update_stale_reprobes_left = POST_UPDATE_STALE_REPROBE_LIMIT
 	_post_update_replacements_left = POST_UPDATE_REPLACEMENT_LIMIT
-	print(
-		"MCP | AI clients attached before the update must be quit and relaunched to use v%s"
-		% str(_post_update_outcome.get("to_version", ""))
-	)
+	var to_version := str(_post_update_outcome.get("to_version", ""))
+	if attached_bridges_follow(_post_update_replaced_version, to_version):
+		print("MCP | AI clients attached before the update keep working on v%s" % to_version)
+	else:
+		print(
+			"MCP | AI clients attached before the update must be quit and relaunched to use v%s"
+			% to_version
+		)
 	_present_post_update_complete()
 	_fan_post_update_outcome()
 	_release_normal_startup()
@@ -915,10 +928,26 @@ func _present_post_update_complete() -> void:
 		})
 
 
+## Whether a bridge a client attached at `from_version` keeps serving the
+## server at `to_version` (#1024: same major version, from 4.1.0 on).
+static func attached_bridges_follow(from_version: String, to_version: String) -> bool:
+	var from_tuple := McpServerVersionCheck.version_tuple(from_version)
+	var to_tuple := McpServerVersionCheck.version_tuple(to_version)
+	if from_tuple.is_empty() or to_tuple.is_empty():
+		return false
+	if int(from_tuple[0]) != int(to_tuple[0]):
+		return false
+	var floor_tuple := McpServerVersionCheck.version_tuple(FIRST_BRIDGE_TOLERANT_VERSION)
+	return McpServerVersionCheck.compare(from_tuple, floor_tuple) >= 0
+
+
 func _post_update_complete_label() -> String:
+	var to_version := str(_post_update_outcome.get("to_version", ""))
 	var text := (
-		"Quit and relaunch AI clients that were connected during the update so they use v%s."
-		% str(_post_update_outcome.get("to_version", ""))
+		"AI clients that were connected during the update keep working on v%s." % to_version
+		if attached_bridges_follow(str(_post_update_outcome.get("from_version", "")), to_version)
+		else "Quit and relaunch AI clients that were connected during the update so they use v%s."
+		% to_version
 	)
 	if _post_update_deferred.is_empty():
 		return text
@@ -1251,6 +1280,11 @@ func _capture_lifecycle_plan() -> Dictionary:
 		"server_command": ClientConfigurator.get_server_command(),
 		"pid_file": ProjectSettings.globalize_path(PortResolver.SERVER_PID_FILE),
 		"startup_report": ProjectSettings.globalize_path(PortResolver.SERVER_STARTUP_REPORT),
+		"probe_timeout_ms": (
+			POST_UPDATE_PROBE_TIMEOUT_MS
+			if not _post_update_replaced_version.is_empty()
+			else ServerLifecycleManager.DEFAULT_PROBE_TIMEOUT_MS
+		),
 		"http_port_reserved": WindowsPortReservation.is_port_excluded(http_port),
 		"excluded_domains": str(policy.get("excluded_domains", "")),
 		"allow_hosts": str(policy.get("allow_hosts", "")),
@@ -1333,12 +1367,12 @@ func _replace_server_left_by_update(snapshot: Dictionary) -> void:
 			_post_update_reprobes_left -= 1
 			get_tree().create_timer(1.0).timeout.connect(_reprobe_after_update, CONNECT_ONE_SHOT)
 		return
-	if str(snapshot.get("conflict_version", "")) != _post_update_replaced_version:
+	var version := str(snapshot.get("conflict_version", ""))
+	if not _update_may_replace(version):
 		return
 	if _post_update_replacements_left <= 0:
 		return
 	_post_update_replacements_left -= 1
-	var version := _post_update_replaced_version
 	print(
 		"MCP | replacing the v%s server left on port %d by the update"
 		% [version, int(snapshot.get("conflict_port", 0))]
@@ -1348,6 +1382,20 @@ func _replace_server_left_by_update(snapshot: Dictionary) -> void:
 			"MCP | could not replace the v%s server automatically; use Restart Server in the dock"
 			% version
 		)
+
+
+## The server the update superseded, or any older server of our major
+## version an attach bridge left on the port (a client pinned further back).
+## Never a newer one: that is another editor's server, and adoption or the
+## dock's explicit Restart Server decides there.
+func _update_may_replace(conflict_version: String) -> bool:
+	if conflict_version.is_empty():
+		return false
+	if conflict_version == _post_update_replaced_version:
+		return true
+	return McpServerVersionCheck.is_older_same_major(
+		conflict_version, ClientConfigurator.get_plugin_version()
+	)
 
 
 func _reprobe_after_update() -> void:

--- a/plugin/addons/godot_ai/utils/server_version_check.gd
+++ b/plugin/addons/godot_ai/utils/server_version_check.gd
@@ -7,6 +7,38 @@ extends RefCounted
 ## connection, or manager reference.
 
 
+## Leading numeric `major.minor.patch` of a version as `[major, minor, patch]`,
+## or `[]` when it does not start that way (a dev build, a malformed pin).
+## A suffix after the patch (`4.0.3+local.1`, `4.1.0-rc1`) is ignored; a
+## dangling separator (`4.0.3+`) is not a version.
+static func version_tuple(version: String) -> Array:
+	var regex := RegEx.create_from_string("^(\\d+)\\.(\\d+)\\.(\\d+)(?:$|[.+-][0-9A-Za-z][0-9A-Za-z.+-]*$)")
+	var found := regex.search(version.strip_edges())
+	if found == null:
+		return []
+	return [int(found.get_string(1)), int(found.get_string(2)), int(found.get_string(3))]
+
+
+static func compare(a: Array, b: Array) -> int:
+	for index in range(3):
+		if int(a[index]) != int(b[index]):
+			return -1 if int(a[index]) < int(b[index]) else 1
+	return 0
+
+
+## `candidate` is a parseable version older than `reference` within the same
+## major version. Unparseable, equal, newer, or another major all read false:
+## a caller may only replace what it can prove is older than itself.
+static func is_older_same_major(candidate: String, reference: String) -> bool:
+	var candidate_tuple := version_tuple(candidate)
+	var reference_tuple := version_tuple(reference)
+	if candidate_tuple.is_empty() or reference_tuple.is_empty():
+		return false
+	if int(candidate_tuple[0]) != int(reference_tuple[0]):
+		return false
+	return compare(candidate_tuple, reference_tuple) < 0
+
+
 static func evaluate(actual_version: String, expected_version: String) -> Dictionary:
 	if actual_version.is_empty():
 		return {"compatible": false, "reason": "missing_version"}

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -395,6 +395,64 @@ func test_capability_pair_is_distinct_for_dev_and_managed_spawns() -> void:
 	assert_ne(pair.http, pair.websocket)
 
 
+func test_post_update_replaces_only_older_servers_of_our_major() -> void:
+	## The arm existed for exactly the version the update replaced; a client
+	## pinned further back leaves an even older server, which is just as much
+	## ours to replace. A newer server or another major never is.
+	var plugin := Plugin.new()
+	var lifecycle := FakeLifecycleActions.new()
+	plugin._lifecycle = lifecycle
+	plugin._post_update_replaced_version = "4.0.2"
+	plugin._post_update_replacements_left = 3
+	var blocked := {
+		"connection_blocked": true, "can_recover_incompatible": true,
+		"episode_state": "BLOCKED", "conflict_port": 8000,
+	}
+	plugin._replace_server_left_by_update(blocked.merged({"conflict_version": "4.0.2"}))
+	assert_eq(lifecycle.recover_calls, 1, "the version the update replaced")
+	plugin._replace_server_left_by_update(blocked.merged({"conflict_version": "4.0.0"}))
+	assert_eq(lifecycle.recover_calls, 2, "an older server of our major")
+	plugin._replace_server_left_by_update(blocked.merged({"conflict_version": "9.9.9"}))
+	plugin._replace_server_left_by_update(blocked.merged({"conflict_version": "3.2.5"}))
+	plugin._replace_server_left_by_update(blocked.merged({"conflict_version": ""}))
+	assert_eq(lifecycle.recover_calls, 2, "never a newer server, another major, or an unnamed one")
+	plugin._replace_server_left_by_update(blocked.merged({"conflict_version": "4.0.1"}))
+	plugin._replace_server_left_by_update(blocked.merged({"conflict_version": "4.0.1"}))
+	assert_eq(lifecycle.recover_calls, 3, "bounded by the replacement limit")
+	plugin._lifecycle = null
+	plugin.free()
+
+
+func test_post_update_banner_depends_on_whether_bridges_can_follow() -> void:
+	var plugin := Plugin.new()
+	plugin._post_update_outcome = {"outcome": "success", "from_version": "4.0.3", "to_version": "4.1.0"}
+	var label := plugin._post_update_complete_label()
+	assert_true(label.begins_with("Quit and relaunch AI clients"), label)
+	plugin._post_update_outcome = {"outcome": "success", "from_version": "4.1.0", "to_version": "4.1.1"}
+	label = plugin._post_update_complete_label()
+	assert_true(label.begins_with("AI clients that were connected during the update keep working on v4.1.1"), label)
+	assert_true(Plugin.attached_bridges_follow("4.1.0", "4.2.0"))
+	assert_true(Plugin.attached_bridges_follow("4.1.0", "4.1.0"))
+	assert_false(Plugin.attached_bridges_follow("4.1.0", "5.0.0"), "a major change needs new bridges")
+	assert_false(Plugin.attached_bridges_follow("4.0.3", "4.1.0"), "a 4.0.x bridge refuses the new server")
+	assert_false(Plugin.attached_bridges_follow("3.2.5", "4.1.0"))
+	assert_false(Plugin.attached_bridges_follow("", "4.1.0"))
+	plugin._lifecycle = null
+	plugin.free()
+
+
+func test_post_update_plan_waits_longer_for_the_status_probe() -> void:
+	## An old bridge's backend may still be settling right after the restart;
+	## 800 ms read it as a foreign process and nothing replaced it.
+	var plugin := Plugin.new()
+	plugin._post_update_replaced_version = "4.0.2"
+	assert_eq(int(plugin._capture_lifecycle_plan().probe_timeout_ms), Plugin.POST_UPDATE_PROBE_TIMEOUT_MS)
+	plugin._post_update_replaced_version = ""
+	assert_eq(int(plugin._capture_lifecycle_plan().probe_timeout_ms), Lifecycle.DEFAULT_PROBE_TIMEOUT_MS)
+	plugin._lifecycle = null
+	plugin.free()
+
+
 class _DeferralRecordingPlugin extends Plugin:
 	var finished := 0
 

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -444,10 +444,15 @@ func test_post_update_banner_depends_on_whether_bridges_can_follow() -> void:
 func test_post_update_plan_waits_longer_for_the_status_probe() -> void:
 	## An old bridge's backend may still be settling right after the restart;
 	## 800 ms read it as a foreign process and nothing replaced it.
+	## The lifecycle is configured in _enter_tree, before _finish_post_update
+	## arms the replacement, so the plan must read the recorded outcome.
 	var plugin := Plugin.new()
-	plugin._post_update_replaced_version = "4.0.2"
+	plugin._post_update_outcome = {"outcome": "success", "from_version": "4.0.2", "to_version": "4.0.3"}
+	assert_true(plugin._post_update_replaced_version.is_empty(), "the arm is not set yet at configure time")
 	assert_eq(int(plugin._capture_lifecycle_plan().probe_timeout_ms), Plugin.POST_UPDATE_PROBE_TIMEOUT_MS)
-	plugin._post_update_replaced_version = ""
+	plugin._post_update_outcome = {}
+	assert_eq(int(plugin._capture_lifecycle_plan().probe_timeout_ms), Lifecycle.DEFAULT_PROBE_TIMEOUT_MS)
+	plugin._post_update_outcome = {"outcome": "failed", "from_version": "4.0.2"}
 	assert_eq(int(plugin._capture_lifecycle_plan().probe_timeout_ms), Lifecycle.DEFAULT_PROBE_TIMEOUT_MS)
 	plugin._lifecycle = null
 	plugin.free()

--- a/test_project/tests/test_server_version_check.gd
+++ b/test_project/tests/test_server_version_check.gd
@@ -12,6 +12,24 @@ func test_exact_v4_version_is_compatible() -> void:
 	assert_eq(result.reason, "")
 
 
+func test_version_tuple_and_older_same_major() -> void:
+	assert_eq(McpServerVersionCheck.version_tuple("4.0.3"), [4, 0, 3])
+	assert_eq(McpServerVersionCheck.version_tuple("4.1.0+local.1"), [4, 1, 0])
+	assert_eq(McpServerVersionCheck.version_tuple("4.2.0-rc1"), [4, 2, 0])
+	assert_eq(McpServerVersionCheck.version_tuple("older-client-pin"), [])
+	assert_eq(McpServerVersionCheck.version_tuple(""), [])
+	assert_eq(McpServerVersionCheck.version_tuple("4.0.3+"), [], "a dangling separator is not a version")
+	assert_eq(McpServerVersionCheck.version_tuple("4.0"), [])
+	assert_eq(McpServerVersionCheck.compare([4, 0, 3], [4, 1, 0]), -1)
+	assert_eq(McpServerVersionCheck.compare([4, 1, 0], [4, 1, 0]), 0)
+	assert_true(McpServerVersionCheck.is_older_same_major("4.0.2", "4.0.3"))
+	assert_true(McpServerVersionCheck.is_older_same_major("4.0.9", "4.1.0"))
+	assert_false(McpServerVersionCheck.is_older_same_major("4.0.3", "4.0.3"), "equal is not older")
+	assert_false(McpServerVersionCheck.is_older_same_major("4.1.0", "4.0.3"), "never a newer server")
+	assert_false(McpServerVersionCheck.is_older_same_major("3.2.5", "4.0.3"), "another major is not ours")
+	assert_false(McpServerVersionCheck.is_older_same_major("weird", "4.0.3"))
+
+
 func test_missing_or_different_version_fails_closed() -> void:
 	assert_eq(McpServerVersionCheck.evaluate("", "4.0.0").reason, "missing_version")
 	assert_eq(

--- a/tests/integration/test_self_update_upgrade_paths.py
+++ b/tests/integration/test_self_update_upgrade_paths.py
@@ -95,12 +95,23 @@ def _isolated_environment(isolated: Path) -> tuple[dict[str, str], Path]:
         "HOME": str(home),
         "USERPROFILE": str(home),
     }
+    ## The editor's own settings (`godot_ai/*` included) live under
+    ## %APPDATA%\Godot on Windows and $XDG_CONFIG_HOME/godot elsewhere; give
+    ## the fixture editor its own so a developer's global settings (a port, MCP
+    ## logging switched off in the dock) cannot change what the row observes.
+    ## macOS derives its path from HOME, which is already isolated above.
     if os.name == "nt":
         local_app_data = isolated / "local-app-data"
         local_app_data.mkdir(exist_ok=True)
         environment["LOCALAPPDATA"] = str(local_app_data)
+        app_data = isolated / "app-data"
+        app_data.mkdir(exist_ok=True)
+        environment["APPDATA"] = str(app_data)
         capability_dir = local_app_data / "godot-ai" / "capabilities"
     else:
+        config_home = isolated / "xdg-config"
+        config_home.mkdir(exist_ok=True)
+        environment["XDG_CONFIG_HOME"] = str(config_home)
         capability_dir = isolated / "capabilities"
         environment[CAPABILITY_DIR_ENV] = str(capability_dir)
     return environment, capability_dir
@@ -519,10 +530,14 @@ def test_signed_update_restarts_into_matching_live_server(
     print(f"server A: {'stopped' if 'MCP | stopped server' in initial_log else 'detached (lease)'}")
     print(f"replacement: {'needed' if replaced_line in restarted_log else 'not needed'}")
     print(f"blocks before the start: {blocks_before_start}")
-    assert (
-        "MCP | AI clients attached before the update must be quit and relaunched "
-        f"to use v{next_version}" in log
-    )
+    ## From 4.1.0 on the attached bridge follows the new server (same major);
+    ## an older bridge refuses it and the user is told to quit and relaunch.
+    base_tuple = tuple(int(part) for part in base_version.split(".")[:3])
+    if base_tuple >= (4, 1, 0):
+        expected_client_line = f"keep working on v{next_version}"
+    else:
+        expected_client_line = f"must be quit and relaunched to use v{next_version}"
+    assert f"MCP | AI clients attached before the update {expected_client_line}" in log
 
     initial_editor, restarted_editor = read_editor_receipts(project)
     assert initial_editor["pid"] != restarted_editor["pid"], (initial_editor, restarted_editor)


### PR DESCRIPTION
## What

Third PR of the 4.1 "update with clients attached" plan: the plugin side of what #1024 (bridge tolerance) needs so that an update ends green without the user waiting or clicking.

1. **The post-update replacement fires for any older server of our major version.** `_replace_server_left_by_update` only replaced a server whose version equalled the exact version the update superseded. A client pinned two patches back leaves an older server that is just as much ours; it is now replaced too (once, within the existing bounded limit). A newer server or another major is never touched: that is another editor's server, and adoption or the dock's explicit Restart Server decides there. `McpServerVersionCheck` gains `version_tuple`, `compare` and `is_older_same_major`.

2. **The post-update status probe waits 3 s instead of 800 ms.** Right after the restart the old bridge's backend may still be settling on the port; the 800 ms probe read it as a foreign process ("held by another process"), which is not replaceable, so nothing replaced it and the user waited for leases and the idle backstop to expire. `_capture_lifecycle_plan` sets `probe_timeout_ms` from `POST_UPDATE_PROBE_TIMEOUT_MS` while the post-update arm is active.

3. **The relaunch banner and log line are conditional.** With #1024 a bridge from 4.1.0 or newer keeps serving the new server, so the dock says "AI clients that were connected during the update keep working on vX" and logs `MCP | AI clients attached before the update keep working on vX`. Clients attached through an older version still run a bridge that refuses the new server, so those keep the "Quit and relaunch" wording. `FIRST_BRIDGE_TOLERANT_VERSION = "4.1.0"`; `attached_bridges_follow(from, to)` is the single rule (same major, from >= 4.1.0).

## Tests

- `test_server_version_check.gd`: tuple parsing (local build metadata, pre-release suffixes, unparsable), compare, older-same-major rules.
- `test_plugin_lifecycle.gd`: the arm replaces the superseded version and an older 4.x, never a newer one, another major or an unnamed one, bounded by the limit (the arm had no direct test before); banner wording for both cases; the post-update plan carries the longer probe timeout.
- `tests/integration/test_self_update_upgrade_paths.py`: the attached-client assertion is now version-aware (relaunch line below 4.1.0, keep-working line from 4.1.0), so the 4.1.0 bump does not break it.
- Docs: `docs/self-update.md` (both places that described the relaunch), CHANGELOG.

## Verification

- Full GDScript suite, headless 4.7.2 editor on this Windows box: 2258 passed, 0 failed, 43 skipped.
- Python source gates (`test_post_update_stale_server.py`, `test_dock_cli_timeout.py`, `test_plugin_reload_deferral.py`): green.
- `test_signed_update_restarts_into_matching_live_server` (real editor, bridge attached) on this box: passed (the `local-files` variant is skipped here as always). It only passed after the fixture change: with the box's global `godot_ai/mcp_logging=false` leaking in, the restarted editor never echoed `plugin loaded`.

Depends on #1024 for the "keep working" outcome to be true in practice; merges independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved post-update server handling to replace outdated servers from the same major version while avoiding newer or incompatible servers.
  - Extended the post-update status check to reduce false recovery prompts while replacement servers start.
  - Clients connected through version 4.1.0 or newer bridges can continue working after an editor update; older bridge versions still require quitting and relaunching.

- **Documentation**
  - Clarified self-update behavior, compatibility requirements, and recovery steps for attached AI clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->