### PR TITLE
feat: release qualification updates with a real attached bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ reading. Release engineering: [docs/releasing.md](docs/releasing.md).
   instance. The attach protocol version, ports and excluded domains are still
   gated exactly. Bridges from 4.0.3 and earlier still refuse a newer server,
   so the first update onto this version needs one last relaunch.
+- Release qualification's real-editor A-to-B update now runs with a real
+  `godot-ai attach` bridge attached through the update, and passes only when
+  that same bridge process serves the updated editor afterwards, so the gate
+  measures the workflow users actually run.
 
 ## 4.0.3 (2026-09-08)
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -34,7 +34,12 @@ those exact bytes:
 
 `complete-qualification` requires every one of those rows to be present,
 passed, and bound to the same candidate pair; the runtime row's required case
-set is exactly `exact-a-to-b-hot-update`. The full contract is in the
+set is exactly `exact-a-to-b-hot-update`, and that case runs with a real
+`godot-ai attach` bridge, pinned to A and resolved from the retained index,
+attached through the whole update: the driver clicks Update only once the
+bridge has listed the session A serves, and the case passes only once the
+same bridge process has listed the session B serves (the row's
+`attached_bridge` evidence). The full contract is in the
 [verification plan](architecture-simplification-verification-plan.md); the
 [PR #949 follow-up](v4-release-review-followup.md) records the development
 evidence behind it.

--- a/script/release_qualification.py
+++ b/script/release_qualification.py
@@ -137,6 +137,14 @@ def validate_rows(output: Path, bindings: dict[str, Any]) -> dict[str, Any]:
                     case for case in row["cases"] if case["id"] == "exact-a-to-b-hot-update"
                 )
                 engine.validate_identity(hot_update.get("godot"), row["godot_version"], row["os"])
+                bridge = hot_update.get("attached_bridge")
+                support.require(
+                    type(bridge) is dict
+                    and bridge.get("served_b") is True
+                    and type(bridge.get("ok_before_update")) is int
+                    and bridge["ok_before_update"] >= 1,
+                    "runtime row lacks the attached-bridge evidence",
+                )
         found[key] = row
     missing = required - set(found)
     support.require(

--- a/script/runtime_qualification.py
+++ b/script/runtime_qualification.py
@@ -11,11 +11,13 @@ import argparse
 import json
 import os
 import platform
+import queue
 import shutil
 import socket
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 from pathlib import Path
 from typing import Any
@@ -41,6 +43,14 @@ UPDATE_STATE = "addons/.godot_ai_update"
 # but not the --headless shorthand (Godot 4.7). The update restarts the editor,
 # and the restarted editor must stay headless on a display-less runner.
 HEADLESS_EDITOR_ARGUMENTS = ("--display-driver", "headless", "--audio-driver", "Dummy")
+## Gate files the attached bridge writes into the project for the driver:
+## the first after it has served candidate A, so Update is clicked with a
+## client attached; the second after the same bridge process has listed the
+## editor session served by candidate B and closed, so the driver may quit.
+BRIDGE_ATTACHED_FILE = "_bridge_attached.done"
+BRIDGE_SERVED_B_FILE = "_bridge_served_b.done"
+BRIDGE_ATTACH_TIMEOUT_SECONDS = 180.0
+BRIDGE_CALL_TIMEOUT_SECONDS = 60.0
 
 
 def current_python_version() -> str:
@@ -334,7 +344,10 @@ func _configure(node: Node) -> void:
         encoding="utf-8",
     )
     (project / "_qualification_driver.gd").write_text(
-        _DRIVER.replace("@VERSION_A@", version_a).replace("@VERSION_B@", version_b),
+        _DRIVER.replace("@VERSION_A@", version_a)
+        .replace("@VERSION_B@", version_b)
+        .replace("@BRIDGE_ATTACHED@", BRIDGE_ATTACHED_FILE)
+        .replace("@BRIDGE_SERVED_B@", BRIDGE_SERVED_B_FILE),
         encoding="utf-8",
     )
 
@@ -349,6 +362,7 @@ const DEADLINE_MS := 300000
 const PROGRESS_PATH := "res://runtime-progress.json"
 var deadline := 0
 var started := false
+var b_live := false
 var old_instance := ""
 
 func _ready() -> void:
@@ -368,7 +382,10 @@ func _ready() -> void:
 
 func _process(_delta: float) -> void:
     if Time.get_ticks_msec() >= deadline:
-        _finish(41, {"error": "runtime qualification timed out"})
+        if b_live:
+            _finish(44, {"error": "the attached bridge never served candidate B"})
+        else:
+            _finish(41, {"error": "runtime qualification timed out"})
         return
     var plugin := _find_plugin()
     if plugin == null:
@@ -381,6 +398,8 @@ func _process(_delta: float) -> void:
             return
         if not _client_pin(VERSION_A):
             _finish(42, {"error": "candidate A client pin missing"})
+            return
+        if not FileAccess.file_exists("res://@BRIDGE_ATTACHED@"):
             return
         started = true
         var progress := FileAccess.open(PROGRESS_PATH, FileAccess.WRITE)
@@ -405,9 +424,13 @@ func _process(_delta: float) -> void:
         or not _client_pin(VERSION_B)
     ):
         return
+    b_live = true
+    if not FileAccess.file_exists("res://@BRIDGE_SERVED_B@"):
+        return
     _finish(0, {
         "status": "passed", "from_version": VERSION_A, "to_version": VERSION_B,
         "old_instance": old_instance, "new_instance": instance,
+        "attached_bridge_served_b": true,
     })
 
 func _finish(code: int, report: Dictionary) -> void:
@@ -485,6 +508,222 @@ func _capability() -> Dictionary:
     var parsed: Variant = JSON.parse_string(FileAccess.get_file_as_string(path))
     return parsed if parsed is Dictionary else {}
 """
+
+
+class AttachedBridge:
+    """A real ``godot-ai attach`` bridge, attached through the whole update.
+
+    The bridge is the published package pinned to candidate A, resolved from
+    the retained index exactly as a client entry written for A would run it.
+    It speaks MCP over stdio itself (newline-delimited JSON-RPC; the runner
+    has no MCP client library), lists the editor session before the update
+    so the driver may click Update with a client attached, keeps calling
+    through the swap and the editor restart, and passes only when the same
+    bridge process lists a session served by candidate B. That is the
+    contract #1024 gives users: a plugin update within a major version needs
+    no client relaunch.
+    """
+
+    def __init__(
+        self,
+        command: list[str],
+        environment: dict[str, str],
+        project: Path,
+        capability_dir: Path,
+        version_a: str,
+        version_b: str,
+        log_path: Path,
+    ) -> None:
+        self.command = command
+        self.environment = environment
+        self.project = project
+        self.capability_dir = capability_dir
+        self.version_a = version_a
+        self.version_b = version_b
+        self.log_path = log_path
+        self.ok_before_update = 0
+        self.served_b = False
+        self.errors: list[str] = []
+        self.fault = ""
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, name="attached-bridge", daemon=True)
+        self._lines: queue.Queue[str | None] = queue.Queue()
+        self._next_id = 0
+
+    def __enter__(self) -> AttachedBridge:
+        self._thread.start()
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self._stop.set()
+        self._thread.join(timeout=BRIDGE_CALL_TIMEOUT_SECONDS + 30)
+
+    def report(self) -> dict[str, Any]:
+        return {
+            "pin": self.version_a,
+            "ok_before_update": self.ok_before_update,
+            "served_b": self.served_b,
+            "errors": self.errors[-5:],
+            "fault": self.fault,
+        }
+
+    def _run(self) -> None:
+        try:
+            self._attach_and_follow()
+        except Exception as exc:  # surfaced by the row after the run
+            self.fault = f"{type(exc).__name__}: {exc}"
+
+    def _attach_and_follow(self) -> None:
+        deadline = time.monotonic() + BRIDGE_ATTACH_TIMEOUT_SECONDS
+        record = self.capability_dir / f"http-{HTTP_PORT}.json"
+        while not record.is_file():
+            if self._stop.is_set() or time.monotonic() > deadline:
+                raise RuntimeError("candidate A never published its capability record")
+            time.sleep(0.25)
+        with self.log_path.open("ab") as log:
+            process = subprocess.Popen(
+                self.command,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=log,
+                env=self.environment,
+                cwd=str(self.project.parent),
+            )
+            reader = threading.Thread(target=self._read, args=(process,), daemon=True)
+            reader.start()
+            try:
+                self._handshake(process)
+                self._follow(process)
+            finally:
+                self._close(process)
+
+    def _read(self, process: subprocess.Popen[bytes]) -> None:
+        assert process.stdout is not None
+        for raw in process.stdout:
+            self._lines.put(raw.decode("utf-8", errors="replace"))
+        self._lines.put(None)
+
+    def _send(self, process: subprocess.Popen[bytes], message: dict[str, Any]) -> None:
+        assert process.stdin is not None
+        process.stdin.write((json.dumps(message) + "\n").encode("utf-8"))
+        process.stdin.flush()
+
+    def _request(
+        self, process: subprocess.Popen[bytes], method: str, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        self._next_id += 1
+        request_id = self._next_id
+        self._send(
+            process, {"jsonrpc": "2.0", "id": request_id, "method": method, "params": params}
+        )
+        deadline = time.monotonic() + BRIDGE_CALL_TIMEOUT_SECONDS
+        while True:
+            remaining = deadline - time.monotonic()
+            support.require(remaining > 0, f"attached bridge did not answer {method}")
+            try:
+                line = self._lines.get(timeout=remaining)
+            except queue.Empty:
+                continue
+            support.require(line is not None, "attached bridge closed its output")
+            line = line.strip()
+            if not line.startswith("{"):
+                continue
+            try:
+                message = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if message.get("id") == request_id:
+                return message
+
+    def _handshake(self, process: subprocess.Popen[bytes]) -> None:
+        response = self._request(
+            process,
+            "initialize",
+            {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "godot-ai-qualification", "version": "1"},
+            },
+        )
+        support.require("result" in response, f"attached bridge refused initialize: {response}")
+        self._send(process, {"jsonrpc": "2.0", "method": "notifications/initialized"})
+
+    def _sessions(self, process: subprocess.Popen[bytes]) -> list[dict[str, Any]] | str:
+        response = self._request(
+            process, "tools/call", {"name": "session_manage", "arguments": {"op": "list"}}
+        )
+        if "error" in response:
+            return json.dumps(response["error"])[:300]
+        result = response.get("result", {})
+        texts = [
+            item.get("text", "") for item in result.get("content", []) if isinstance(item, dict)
+        ]
+        if result.get("isError"):
+            return (" ".join(texts) or "tool error")[:300]
+        payload: Any = result.get("structuredContent")
+        if payload is None:
+            try:
+                payload = json.loads(texts[0]) if texts else None
+            except json.JSONDecodeError:
+                payload = None
+        if not isinstance(payload, dict):
+            return f"unexpected session_manage payload: {str(result)[:200]}"
+        sessions = payload.get("sessions", [])
+        return [session for session in sessions if isinstance(session, dict)]
+
+    def _follow(self, process: subprocess.Popen[bytes]) -> None:
+        attached = self.project / BRIDGE_ATTACHED_FILE
+        while not self._stop.is_set():
+            sessions = self._sessions(process)
+            if isinstance(sessions, str):
+                self.errors.append(sessions)
+            else:
+                versions = {
+                    (str(s.get("plugin_version", "")), str(s.get("server_version", "")))
+                    for s in sessions
+                }
+                if (self.version_a, self.version_a) in versions and not attached.exists():
+                    attached.write_text("attached\n", encoding="utf-8")
+                if attached.exists() and not self.served_b:
+                    self.ok_before_update += 1
+                if (self.version_b, self.version_b) in versions:
+                    self.served_b = True
+                    return
+            time.sleep(0.5)
+
+    def _close(self, process: subprocess.Popen[bytes]) -> None:
+        """Close the client side first so the bridge releases its lease, then
+        tell the driver the same bridge served B; the editor may quit now."""
+        try:
+            if process.stdin is not None:
+                process.stdin.close()
+        except OSError:
+            pass
+        try:
+            process.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=10)
+        if self.served_b:
+            (self.project / BRIDGE_SERVED_B_FILE).write_text("served\n", encoding="utf-8")
+
+
+def _bridge_command(uvx: str, version: str) -> list[str]:
+    """The exact launch a client entry written for ``version`` performs."""
+    return [
+        uvx,
+        "--link-mode",
+        "copy",
+        "--from",
+        f"godot-ai=={version}",
+        "godot-ai",
+        "attach",
+        "--port",
+        str(HTTP_PORT),
+        "--ws-port",
+        str(WS_PORT),
+        "--disable-telemetry",
+    ]
 
 
 def _manifest_tree(candidate: Path) -> dict[str, dict[str, Any]]:
@@ -707,24 +946,50 @@ def exact_a_to_b(
                     }
                 )
                 print(f"Running the A-to-B update in Godot {godot_version}", flush=True)
-                completed = subprocess.run(
-                    _editor_command(executable, project),
-                    cwd=work,
-                    env=environment,
-                    capture_output=True,
-                    timeout=TIMEOUT_SECONDS,
-                    check=False,
+                bridge_log = work / "attached-bridge.log"
+                bridge = AttachedBridge(
+                    _bridge_command(uvx, records["a"]["version"]),
+                    environment,
+                    project,
+                    _capability_directory(environment),
+                    records["a"]["version"],
+                    records["b"]["version"],
+                    bridge_log,
                 )
+                with bridge:
+                    completed = subprocess.run(
+                        _editor_command(executable, project),
+                        cwd=work,
+                        env=environment,
+                        capture_output=True,
+                        timeout=TIMEOUT_SECONDS,
+                        check=False,
+                    )
+                    _write_secret_free_log(
+                        output / "godot.log",
+                        completed.stdout + completed.stderr,
+                        (release.token, index),
+                    )
+                    support.require(completed.returncode == 0, "real Godot A-to-B update failed")
+                    # The swap restarts the editor; the process above exits and
+                    # the restarted editor finishes the case once the attached
+                    # bridge has listed the session candidate B serves.
+                    print("Waiting for the restarted editor to report candidate B", flush=True)
+                    _wait_for_runtime_result(project / "runtime-result.json", TIMEOUT_SECONDS)
                 _write_secret_free_log(
-                    output / "godot.log",
-                    completed.stdout + completed.stderr,
+                    output / "attached-bridge.log",
+                    bridge_log.read_bytes() if bridge_log.is_file() else b"",
                     (release.token, index),
                 )
-                support.require(completed.returncode == 0, "real Godot A-to-B update failed")
-                # The swap restarts the editor; the process above exits and
-                # the restarted editor finishes the case and writes the result.
-                print("Waiting for the restarted editor to report candidate B", flush=True)
-                _wait_for_runtime_result(project / "runtime-result.json", TIMEOUT_SECONDS)
+                support.require(not bridge.fault, f"attached bridge failed: {bridge.fault}")
+                support.require(
+                    bridge.ok_before_update >= 1,
+                    "the attached bridge never served candidate A before the update",
+                )
+                support.require(
+                    bridge.served_b,
+                    f"the attached bridge never served candidate B: {bridge.errors[-3:]}",
+                )
                 support.require(
                     release.downloads
                     == [
@@ -742,6 +1007,10 @@ def exact_a_to_b(
         print("Verifying update evidence and private-data cleanup", flush=True)
         result = _read_runtime_result(project)
         support.require(result.get("status") == "passed", "runtime driver did not pass")
+        support.require(
+            result.get("attached_bridge_served_b") is True,
+            "runtime driver finished without the attached bridge serving B",
+        )
         live = project / "addons/godot_ai"
         live_tree = support.inventory(live)
         support.require(live_tree == _manifest_tree(candidates / "b"), "live tree is not exact B")
@@ -768,6 +1037,7 @@ def exact_a_to_b(
             "index_artifacts_requested": sorted(set(index_requests)),
             "live_tree": live_tree,
             "backend_stopped": True,
+            "attached_bridge": bridge.report(),
             **update,
         }
 

--- a/script/runtime_qualification.py
+++ b/script/runtime_qualification.py
@@ -51,6 +51,8 @@ BRIDGE_ATTACHED_FILE = "_bridge_attached.done"
 BRIDGE_SERVED_B_FILE = "_bridge_served_b.done"
 BRIDGE_ATTACH_TIMEOUT_SECONDS = 180.0
 BRIDGE_CALL_TIMEOUT_SECONDS = 60.0
+## A stop must finish one 1 s poll slice plus the close's own process waits.
+BRIDGE_STOP_TIMEOUT_SECONDS = 50.0
 
 
 def current_python_version() -> str:
@@ -549,14 +551,24 @@ class AttachedBridge:
         self._thread = threading.Thread(target=self._run, name="attached-bridge", daemon=True)
         self._lines: queue.Queue[str | None] = queue.Queue()
         self._next_id = 0
+        self._process: subprocess.Popen[bytes] | None = None
 
     def __enter__(self) -> AttachedBridge:
         self._thread.start()
         return self
 
     def __exit__(self, *_exc: object) -> None:
+        """Stop the bridge and prove it stopped: the row reads the bridge log,
+        scans the project and waits for the ports right after this, so a
+        thread that outlived its budget must not keep a process alive."""
         self._stop.set()
-        self._thread.join(timeout=BRIDGE_CALL_TIMEOUT_SECONDS + 30)
+        self._thread.join(timeout=BRIDGE_STOP_TIMEOUT_SECONDS)
+        if self._thread.is_alive():
+            process = self._process
+            if process is not None and process.poll() is None:
+                process.kill()
+            self._thread.join(timeout=15)
+            self.fault = self.fault or "attached bridge did not stop within its budget"
 
     def report(self) -> dict[str, Any]:
         return {
@@ -589,6 +601,7 @@ class AttachedBridge:
                 env=self.environment,
                 cwd=str(self.project.parent),
             )
+            self._process = process
             reader = threading.Thread(target=self._read, args=(process,), daemon=True)
             reader.start()
             try:
@@ -618,10 +631,13 @@ class AttachedBridge:
         )
         deadline = time.monotonic() + BRIDGE_CALL_TIMEOUT_SECONDS
         while True:
+            ## Poll in short slices so a stop request ends a call promptly
+            ## instead of waiting out the full call budget.
+            support.require(not self._stop.is_set(), "attached bridge was stopped")
             remaining = deadline - time.monotonic()
             support.require(remaining > 0, f"attached bridge did not answer {method}")
             try:
-                line = self._lines.get(timeout=remaining)
+                line = self._lines.get(timeout=min(1.0, remaining))
             except queue.Empty:
                 continue
             support.require(line is not None, "attached bridge closed its output")

--- a/tests/integration/test_client_owner_restarts.py
+++ b/tests/integration/test_client_owner_restarts.py
@@ -146,7 +146,11 @@ def test_codex_workers_complete_after_two_ordinary_editor_restarts(tmp_path: Pat
         assert "--port" in entry["args"] and "--ws-port" in entry["args"], entry
         pids.append(result["pid"])
         (project / "result.json").unlink()
-    assert len(set(pids)) == 3, pids
+    ## Three boots produced three fresh results (each result.json is unlinked
+    ## after it is read). Windows reuses process ids freely, so distinct pids
+    ## are not evidence of distinct boots and are not asserted (CI saw
+    ## [5036, 3004, 5036]).
+    assert all(type(pid) is int and pid > 0 for pid in pids), pids
 
 
 def _stop_process_tree(process: subprocess.Popen) -> None:

--- a/tests/unit/test_runtime_qualification.py
+++ b/tests/unit/test_runtime_qualification.py
@@ -824,3 +824,33 @@ def test_row_validation_requires_the_attached_bridge_evidence(monkeypatch, tmp_p
         (directory / "row.json").write_bytes(support.canonical(row))
     with pytest.raises(support.ReleaseError, match="attached-bridge evidence"):
         qualification.validate_rows(tmp_path, bindings)
+
+
+def test_attached_bridge_stop_is_prompt_even_when_the_bridge_never_answers(tmp_path):
+    """A silent bridge must not hold the row for the full call budget."""
+    project = tmp_path / "project"
+    project.mkdir()
+    capability_dir = tmp_path / "capabilities"
+    capability_dir.mkdir()
+    (capability_dir / f"http-{runtime.HTTP_PORT}.json").write_text("{}", encoding="utf-8")
+    silent = tmp_path / "silent_bridge.py"
+    silent.write_text(
+        "\n".join(["import sys", "for _line in sys.stdin:", "    pass", ""]),
+        encoding="utf-8",
+    )
+    bridge = runtime.AttachedBridge(
+        [sys.executable, str(silent)],
+        dict(os.environ),
+        project,
+        capability_dir,
+        "4.1.0",
+        "4.1.1",
+        tmp_path / "bridge.log",
+    )
+    started = time.monotonic()
+    with bridge:
+        time.sleep(1.0)
+    assert time.monotonic() - started < runtime.BRIDGE_CALL_TIMEOUT_SECONDS
+    assert not bridge._thread.is_alive()
+    assert bridge._process is not None and bridge._process.poll() is not None
+    assert bridge.served_b is False

--- a/tests/unit/test_runtime_qualification.py
+++ b/tests/unit/test_runtime_qualification.py
@@ -2,6 +2,8 @@ import hashlib
 import json
 import os
 import shutil
+import sys
+import time
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -124,6 +126,13 @@ def test_aggregate_rejects_a_missing_engine_row(monkeypatch, tmp_path):
                     case["godot"] = {
                         **engine.build_pin(godot, os_label),
                         "version": f"{godot.removesuffix('.0')}.stable.official.fixture",
+                    }
+                    case["attached_bridge"] = {
+                        "pin": "4.1.0",
+                        "ok_before_update": 3,
+                        "served_b": True,
+                        "errors": [],
+                        "fault": "",
                     }
             if os_label == "windows-latest":
                 omitted = directory / "row.json"
@@ -672,3 +681,146 @@ def test_ports_free_wait_reports_elapsed_and_refuses_a_lingering_backend(monkeyp
     with pytest.raises(support.ReleaseError, match="remained live after editor exit"):
         runtime._wait_for_ports_free(8000, 9500, timeout=0.2)
     assert runtime.EDITOR_EXIT_TIMEOUT_SECONDS >= 60.0
+
+
+## A stand-in for `godot-ai attach` over stdio: it answers `initialize` and
+## `session_manage` with whatever version the file named on its command line
+## holds, so a test can move the "editor" from A to B underneath the client.
+FAKE_BRIDGE = """
+import json
+import sys
+from pathlib import Path
+
+version_file = Path(sys.argv[1])
+for line in sys.stdin:
+    message = json.loads(line)
+    method = message.get("method")
+    if method == "initialize":
+        result = {"protocolVersion": "2024-11-05", "capabilities": {}, "serverInfo": {}}
+    elif method == "tools/call":
+        version = version_file.read_text(encoding="utf-8").strip()
+        if version == "error":
+            result = {"isError": True, "content": [{"type": "text", "text": "backend gone"}]}
+        else:
+            sessions = [{"plugin_version": version, "server_version": version}]
+            result = {"content": [{"type": "text", "text": json.dumps({"sessions": sessions})}]}
+    else:
+        continue
+    print(json.dumps({"jsonrpc": "2.0", "id": message["id"], "result": result}), flush=True)
+"""
+
+
+def _wait_for(path: Path, timeout: float = 30.0) -> None:
+    deadline = time.monotonic() + timeout
+    while not path.exists():
+        assert time.monotonic() < deadline, f"{path.name} never appeared"
+        time.sleep(0.05)
+
+
+def test_attached_bridge_client_follows_the_update_over_stdio(tmp_path):
+    """The bridge process attached for A must list the session B serves."""
+    project = tmp_path / "project"
+    project.mkdir()
+    capability_dir = tmp_path / "capabilities"
+    capability_dir.mkdir()
+    version_file = tmp_path / "version.txt"
+    version_file.write_text("4.1.0", encoding="utf-8")
+    fake = tmp_path / "fake_bridge.py"
+    fake.write_text(FAKE_BRIDGE, encoding="utf-8")
+    bridge = runtime.AttachedBridge(
+        [sys.executable, str(fake), str(version_file)],
+        dict(os.environ),
+        project,
+        capability_dir,
+        "4.1.0",
+        "4.1.1",
+        tmp_path / "bridge.log",
+    )
+    with bridge:
+        assert not (project / runtime.BRIDGE_ATTACHED_FILE).exists()
+        # The bridge waits for A's capability record before it launches.
+        (capability_dir / f"http-{runtime.HTTP_PORT}.json").write_text("{}", encoding="utf-8")
+        _wait_for(project / runtime.BRIDGE_ATTACHED_FILE)
+        version_file.write_text("error", encoding="utf-8")
+        time.sleep(1.2)
+        version_file.write_text("4.1.1", encoding="utf-8")
+        _wait_for(project / runtime.BRIDGE_SERVED_B_FILE)
+    report = bridge.report()
+    assert report["served_b"] is True
+    assert report["ok_before_update"] >= 1
+    assert report["fault"] == ""
+    assert any("backend gone" in error for error in report["errors"])
+
+
+def test_attached_bridge_client_reports_a_backend_that_never_reaches_b(tmp_path):
+    project = tmp_path / "project"
+    project.mkdir()
+    capability_dir = tmp_path / "capabilities"
+    capability_dir.mkdir()
+    (capability_dir / f"http-{runtime.HTTP_PORT}.json").write_text("{}", encoding="utf-8")
+    version_file = tmp_path / "version.txt"
+    version_file.write_text("4.1.0", encoding="utf-8")
+    fake = tmp_path / "fake_bridge.py"
+    fake.write_text(FAKE_BRIDGE, encoding="utf-8")
+    bridge = runtime.AttachedBridge(
+        [sys.executable, str(fake), str(version_file)],
+        dict(os.environ),
+        project,
+        capability_dir,
+        "4.1.0",
+        "4.1.1",
+        tmp_path / "bridge.log",
+    )
+    with bridge:
+        _wait_for(project / runtime.BRIDGE_ATTACHED_FILE)
+    assert bridge.served_b is False
+    assert not (project / runtime.BRIDGE_SERVED_B_FILE).exists()
+
+
+def test_bridge_command_is_the_client_entry_launch():
+    command = runtime._bridge_command("/tools/uvx", "4.1.0")
+    assert command[:5] == ["/tools/uvx", "--link-mode", "copy", "--from", "godot-ai==4.1.0"]
+    assert command[5:8] == ["godot-ai", "attach", "--port"]
+    assert "--disable-telemetry" in command
+
+
+def test_row_validation_requires_the_attached_bridge_evidence(monkeypatch, tmp_path):
+    monkeypatch.setattr(qualification, "dependency_inventory", lambda _root: [])
+    bindings = {"a": "candidate-a", "b": "candidate-b"}
+    for number, (kind, os_label, python, godot) in enumerate(
+        sorted(qualification.required_row_keys())
+    ):
+        directory = tmp_path / str(number)
+        directory.mkdir()
+        row = {
+            "kind": kind,
+            "os": os_label,
+            "python": python,
+            "status": "passed",
+            "candidates": bindings,
+            "files": {},
+        }
+        if kind == "python":
+            row.update(
+                dependencies=[],
+                installs={
+                    name: {"status": "passed", "managed_tree": {"plugin.cfg": {}}}
+                    for name in bindings
+                },
+                tests={"a": {"tests": 1, "failures": 0, "errors": 0}},
+            )
+        else:
+            case = {
+                "id": "exact-a-to-b-hot-update",
+                "status": "passed",
+                "godot": {
+                    **engine.build_pin(godot, os_label),
+                    "version": f"{godot.removesuffix('.0')}.stable.official.fixture",
+                },
+                ## The bridge attached, but the same process never listed B.
+                "attached_bridge": {"pin": "4.1.0", "ok_before_update": 2, "served_b": False},
+            }
+            row.update(required_skips=0, godot_version=godot, cases=[case])
+        (directory / "row.json").write_bytes(support.canonical(row))
+    with pytest.raises(support.ReleaseError, match="attached-bridge evidence"):
+        qualification.validate_rows(tmp_path, bindings)


### PR DESCRIPTION
## What

Fourth PR of the 4.1 "update with clients attached" plan: the release gate now measures the workflow users actually run.

The exact A-to-B runtime case (`exact-a-to-b-hot-update`, one per desktop OS) updated with **no client attached**, so nothing in qualification could see the bug class behind #1024 and #1026. It now runs with a real `godot-ai attach` bridge:

- pinned to candidate **A** and resolved from the **retained index**, i.e. the exact launch a client entry written for A performs (`_bridge_command` mirrors `_write_client_pin`);
- attached **before** Update: the driver clicks Update only once the bridge has listed the editor session A serves (`_bridge_attached.done`);
- kept through the swap and the editor restart;
- and the case passes only once the **same bridge process** has listed the session B serves (`_bridge_served_b.done`), which the driver waits for before it quits. The bridge closes first so its lease is released and the editor's exit still stops the backend, keeping the row's port and capability cleanup as before.

The qualification runner has only the interpreter and `uv`, so the bridge is driven with newline-delimited JSON-RPC over stdio (`initialize`, `notifications/initialized`, `tools/call session_manage`), no MCP client library.

`release_qualification.validate_rows` requires the case's `attached_bridge` evidence (`served_b: true`, `ok_before_update >= 1`); a row without it fails the gate. Same case id, no second editor run, no timeout change.

## Tests

- `test_attached_bridge_client_follows_the_update_over_stdio`: a fake stdio bridge moves from A to B underneath the client; the gate files appear in order, tool errors are recorded, the report is what the row expects.
- `test_attached_bridge_client_reports_a_backend_that_never_reaches_b`.
- `test_bridge_command_is_the_client_entry_launch`.
- `test_row_validation_requires_the_attached_bridge_evidence` (negative), and the synthetic rows in `test_aggregate_rejects_a_missing_engine_row` carry the evidence.
- `tests/integration/test_runtime_qualification_driver.py`: the changed driver parses in a real Godot (run here).
- Docs: `docs/releasing.md`, CHANGELOG.

## Verification

- `tests/unit/test_runtime_qualification.py`: 47 passed; the driver parse row: passed.
- The real proof is the next `release-qualification.yml` run for 4.1.0, where A = 4.1.0 carries #1024 and the bridge must follow B = 4.1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changed**
  - Release qualification now verifies that the same live bridge remains connected throughout the editor update.
  - The update passes only when that bridge successfully serves both the original and updated editor versions.
  - Qualification results require evidence confirming the bridge remained attached and served the updated editor.

- **Documentation**
  - Updated release guidance and the unreleased changelog to describe the attached-bridge qualification requirements.

- **Tests**
  - Improved coverage for bridge transitions, failures, shutdown behavior, and platform-specific process ID reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->