### PR TITLE
fix: the dock names each activation phase instead of freezing on Downloading…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ reading. Release engineering: [docs/releasing.md](docs/releasing.md).
 
 ### Fixed
 
+- The dock no longer looks frozen on "Downloading…" after the download has
+  finished: activation now names each phase ("Verifying signed update…",
+  "Staging the verified tree…", "Waiting for client workers…", "Activating
+  verified update…") and lets the dock repaint before the phase's work runs.
 - A server that refused to start now says why in the dock. The launch-failure
   message (`The launched process identity could not be captured…`) appends the
   server's own startup report, which two 4.0.3 reports had on disk unread:

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -47,7 +47,11 @@ All steps run inside the editor, on the main thread except the download.
 2. **Download** the three canonical assets into
    `user://godot_ai_update/download/`, enforcing the release-declared sizes and
    trusted asset URLs exactly as today.
-3. **Verify** (`McpReleaseVerifier`, pure, unit-testable):
+3. **Verify** (`McpReleaseVerifier`, pure, unit-testable). From here each
+   phase names itself in the dock ("Verifying signed update…", "Staging the
+   verified tree…", "Waiting for client workers…", "Activating verified
+   update…") and yields a frame before its main-thread work, so the dock
+   repaints instead of freezing on "Downloading…":
    - the manifest parses as canonical JSON with `schema_version` 1 and the
      fixed key set; the signature verifies over the manifest bytes with the
      embedded key (`Crypto.verify`, SHA-256, PKCS#1 v1.5, the same primitive

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -1533,7 +1533,13 @@ static func _remove_tree(path: String) -> void:
 ## against the downloaded bytes; nothing outside the editor is executed. The
 ## live tree is touched only by the two renames inside `swap`, and only after
 ## the staged tree has been re-hashed against the signed manifest.
+## Activation runs on the main thread: verification hashes the archive,
+## staging extracts it, and the worker quiescence waits for threads. Each
+## phase names itself in the dock and yields one frame first so the label
+## repaints; without that the dock sat on "Downloading…" for seconds after
+## the download had finished, looking frozen.
 func install_downloaded_update(package: Dictionary) -> void:
+	await _present_install_phase("Verifying signed update…")
 	var manifest_bytes := FileAccess.get_file_as_bytes(str(package.get("manifest", "")))
 	var signature := FileAccess.get_file_as_bytes(str(package.get("signature", "")))
 	var verified: Dictionary = ReleaseVerifier.verify_manifest(
@@ -1554,12 +1560,14 @@ func install_downloaded_update(package: Dictionary) -> void:
 	if not bool(checked.get("ok", false)):
 		_fail_update("Update verification failed", "signed update refused: %s" % str(checked.get("error", "")))
 		return
+	await _present_install_phase("Staging the verified tree…")
 	var staged: Dictionary = UpdateInstaller.stage(str(package.get("archive", "")), manifest)
 	if not bool(staged.get("ok", false)):
 		_fail_update("Update staging failed", "update staging refused: %s" % str(staged.get("error", "")))
 		return
 	if _update_manager != null:
 		_update_manager.discard_downloads()
+	await _present_install_phase("Waiting for client workers…")
 	if _client_jobs != null:
 		var jobs_quiesced: Dictionary = _client_jobs.quiesce(
 			Time.get_ticks_msec() + ClientConfigurator.PREWARM_TIMEOUT_MS
@@ -1614,6 +1622,19 @@ func install_downloaded_update(package: Dictionary) -> void:
 	UpdateInstaller.persist_next_start_enabled(PLUGIN_CFG)
 	print("MCP | update to %s swapped in; restarting the editor" % to_version)
 	UpdateInstaller.request_restart.call_deferred()
+
+
+## Name the activation phase in the dock and let it repaint before the
+## phase's main-thread work begins.
+func _present_install_phase(status_text: String) -> void:
+	_on_update_install_state_changed({
+		"install_in_flight": true,
+		"status_text": status_text,
+		"button_disabled": true,
+	})
+	var tree := get_tree()
+	if tree != null:
+		await tree.process_frame
 
 
 func _fail_update(status_text: String, error: String) -> void:

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -940,7 +940,10 @@ func test_update_status_text_never_replaces_the_button_action() -> void:
 	## and the button only enables or disables.
 	_dock._build_ui()
 	_dock.present_update_check({"version": "4.0.3", "label_text": "Update available: v4.0.3"})
-	for status in ["Downloading…", "Update preparation failed", "Activating verified update…"]:
+	for status in [
+		"Downloading…", "Verifying signed update…", "Staging the verified tree…",
+		"Waiting for client workers…", "Update preparation failed", "Activating verified update…",
+	]:
 		_dock.present_update_state({
 			"install_in_flight": true, "status_text": status, "button_disabled": true,
 		})

--- a/tests/integration/test_self_update_upgrade_paths.py
+++ b/tests/integration/test_self_update_upgrade_paths.py
@@ -549,16 +549,17 @@ def test_signed_update_restarts_into_matching_live_server(
             "SELF_UPDATE_TEST | pre-update instance_id=",
             f"SELF_UPDATE_TEST | configured Codex command pin={base_version}",
             "SELF_UPDATE_TEST | requesting canonical signed install",
-            # The local bundle is staged before the swap; the HTTPS observer is
-            # connected after the plugin's activation listener, which runs the
-            # whole swap synchronously, so its line lands after the restart
-            # announcement. Whether A is stopped or merely detached before the
-            # swap depends on the attached agent holding a lease at that
-            # instant; the restarted editor replaces either occupant.
+            # The local bundle is staged before the swap. The HTTPS observer is
+            # connected after the plugin's activation listener, but activation
+            # names each phase in the dock and yields a frame before verifying,
+            # staging and quiescing, so the observer's line lands before the
+            # restart announcement. Whether A is stopped or merely detached
+            # before the swap depends on the attached agent holding a lease at
+            # that instant; the restarted editor replaces either occupant.
             *(
                 [
-                    f"MCP | update to {next_version} swapped in; restarting the editor",
                     "SELF_UPDATE_TEST | HTTPS canonical triple downloaded",
+                    f"MCP | update to {next_version} swapped in; restarting the editor",
                 ]
                 if delivery is not None
                 else [

--- a/tests/unit/test_dock_cli_timeout.py
+++ b/tests/unit/test_dock_cli_timeout.py
@@ -320,6 +320,21 @@ def test_root_owned_workers_quiesce_during_update_and_plugin_exit() -> None:
         "_dispatcher.clear()"
     )
     assert "var script_quiesced := prepare_for_update_reload()" in install_block
+    ## Each main-thread phase names itself in the dock and yields a frame first,
+    ## so the label repaints instead of the dock freezing on "Downloading…".
+    for label, work in (
+        ("Verifying signed update…", "ReleaseVerifier.verify_manifest("),
+        ("Staging the verified tree…", "UpdateInstaller.stage("),
+        ("Waiting for client workers…", "_client_jobs.quiesce("),
+    ):
+        phase = f'await _present_install_phase("{label}")'
+        assert phase in install_block, label
+        assert install_block.index(phase) < install_block.index(work), label
+    present = get_func_block(
+        plugin_source, "func _present_install_phase(status_text: String) -> void:"
+    )
+    assert '"install_in_flight": true' in present
+    assert "await tree.process_frame" in present
     exit_block = get_func_block(plugin_source, "func _exit_tree() -> void:")
     assert "_client_jobs.quiesce()" in exit_block
 


### PR DESCRIPTION
## What

After clicking Update the dock sat on "Downloading…" and looked frozen for about five seconds even when the download itself was instant (local file). Everything after the download runs synchronously on the editor's main thread: signature verification, hashing the archive, staging the tree, waiting for client workers to quiesce, the script quiescence, then the swap and restart. "Activating verified update…" was only set at the very end of that chain, and nothing yielded a frame, so the label never repainted.

`install_downloaded_update` now names each phase in the dock ("Verifying signed update…", "Staging the verified tree…", "Waiting for client workers…", then the existing "Activating verified update…") and yields one frame before the phase's work through `_present_install_phase`, so the dock repaints. The heavy work is unchanged and still on the main thread; this PR makes it visible, not faster.

## Tests

- `tests/unit/test_dock_cli_timeout.py`: source gate that each phase label precedes its blocking call inside `install_downloaded_update`, and that `_present_install_phase` sets `install_in_flight` and yields a frame.
- `test_dock.gd`: the in-flight status loop now includes the new labels.
- Full GDScript suite headless on this Windows box: 2263 passed, 0 failed. Live check in a GUI editor on this box with the phases captured on screen: see the follow-up comment.
- Docs: `docs/self-update.md` step 3; CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the dock remaining stuck on “Downloading…” after an update finishes downloading.
  * Added clear progress messages for verification, staging, waiting for client workers, and activation.
  * Improved screen refreshes between update phases so the latest status appears promptly.

* **Documentation**
  * Updated the self-update guide to describe the new progress phases and status behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->