### PR TITLE
release: 4.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ this file at the release's exact source commit, and its "What's Changed"
 section lists every merged pull request; this file keeps the part worth
 reading. Release engineering: [docs/releasing.md](docs/releasing.md).
 
-## Unreleased
+## 4.0.4 (2026-09-09)
+
+Updating with AI clients attached no longer means quitting and relaunching
+them: from this version a client's `godot-ai attach` bridge keeps serving a
+server of the same major version, and the restarted editor replaces the
+server an old bridge left on the port by itself. Clients attached through
+4.0.3 or earlier still need one last relaunch after this update. Also the
+dock names each activation phase, a held WebSocket port is diagnosed before
+launch, `physics_shape_generate` lands, and release qualification updates
+with a real attached bridge.
+[Compare v4.0.3...v4.0.4](https://github.com/hi-godot/godot-ai/compare/v4.0.3...v4.0.4).
 
 ### Added
 
@@ -41,7 +51,7 @@ reading. Release engineering: [docs/releasing.md](docs/releasing.md).
   of 800 ms so a backend still settling on the port is not reported as
   "held by another process" with nothing replacing it.
 - The post-update banner and log line say "AI clients keep working" when the
-  clients were attached through 4.1.0 or newer (their bridges follow the new
+  clients were attached through 4.0.4 or newer (their bridges follow the new
   server), and keep telling the user to quit and relaunch only for bridges
   that predate it.
 

--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -300,7 +300,7 @@ header works only until the next server start.
      "args": [
        "-T", "-o", "BatchMode=yes", "-o", "LogLevel=ERROR",
        "you@host.docker.internal",
-       "uvx --isolated --no-config --no-env-file --no-sources --no-build --index-strategy first-index --keyring-provider disabled --index https://pypi.org/simple --default-index https://pypi.org/simple --find-links https://pypi.org/simple/godot-ai/ --link-mode copy --from godot-ai==4.0.3 godot-ai attach --port 8000 --ws-port 9500"
+       "uvx --isolated --no-config --no-env-file --no-sources --no-build --index-strategy first-index --keyring-provider disabled --index https://pypi.org/simple --default-index https://pypi.org/simple --find-links https://pypi.org/simple/godot-ai/ --link-mode copy --from godot-ai==4.0.4 godot-ai attach --port 8000 --ws-port 9500"
      ]
    }
    ```
@@ -325,7 +325,7 @@ header works only until the next server start.
 
 The bridge launched this way authenticates itself on every start, so a server
 restart needs no manual step, and neither does a Godot AI **update** within
-the same major version: a bridge at 4.1.0 or newer keeps serving the updated
+the same major version: a bridge at 4.0.4 or newer keeps serving the updated
 server. A major-version update does, and so does the one-time move off a
 bridge at 4.0.3 or earlier: the dock repins owned entries in config files on
 the editor machine but cannot see a file on another machine, so refresh the

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -40,7 +40,7 @@ All steps run inside the editor, on the main thread except the download.
    release exposing the six-name asset set. Dev checkouts skip this. Clicking
    Update asks first: the update saves the project and relaunches the
    editor. AI clients connected during the update keep working when the
-   version they were attached through is 4.1.0 or newer (their bridge follows
+   version they were attached through is 4.0.4 or newer (their bridge follows
    a server of the same major version); from an older version they must be
    quit and relaunched afterwards (a client that keeps its MCP configuration
    in memory respawns the old bridge on a mere server restart).
@@ -124,12 +124,12 @@ All steps run inside the editor, on the main thread except the download.
     hands that very socket to its HTTP and WebSocket servers, so the port is
     never free between the old backend's death and ours listening: a bridge
     polling for a free port to spawn again never sees one. The
-    old bridge, when it predates 4.1.0, refuses the new backend as
+    old bridge, when it predates 4.0.4, refuses the new backend as
     incompatible, so the dock tells the user to quit and relaunch AI clients
     that were connected during the update; the repinned client configuration
     launches the new version. Quit, not restart: Claude Desktop keeps its MCP
     configuration in memory and respawns the old bridge from it until the
-    application itself is relaunched. A 4.1.0+ bridge keeps serving a server
+    application itself is relaunched. A 4.0.4+ bridge keeps serving a server
     of the same major version and follows the replacement on its own, so the
     dock says the clients keep working instead. That post-update replacement
     probes with a longer timeout than an ordinary start, so a backend still

--- a/plugin/addons/godot_ai/plugin.cfg
+++ b/plugin/addons/godot_ai/plugin.cfg
@@ -3,5 +3,5 @@
 name="Godot AI"
 description="MCP server and AI tools for Godot"
 author="Godot AI"
-version="4.0.3"
+version="4.0.4"
 script="plugin.gd"

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -156,7 +156,7 @@ const POST_UPDATE_PROBE_TIMEOUT_MS := 3000
 ## major version (#1024). A client attached through an update from an older
 ## version still runs a bridge that refuses the new server and must be quit
 ## and relaunched; from this version on it follows the new server itself.
-const FIRST_BRIDGE_TOLERANT_VERSION := "4.1.0"
+const FIRST_BRIDGE_TOLERANT_VERSION := "4.0.4"
 ## Set once the live tree has been renamed; the lock then belongs to the restart.
 var _update_swapped := false
 var _post_update_action := ""
@@ -932,7 +932,7 @@ func _present_post_update_complete() -> void:
 
 
 ## Whether a bridge a client attached at `from_version` keeps serving the
-## server at `to_version` (#1024: same major version, from 4.1.0 on).
+## server at `to_version` (#1024: same major version, from 4.0.4 on).
 static func attached_bridges_follow(from_version: String, to_version: String) -> bool:
 	var from_tuple := McpServerVersionCheck.version_tuple(from_version)
 	var to_tuple := McpServerVersionCheck.version_tuple(to_version)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "godot-ai"
-version = "4.0.3"
+version = "4.0.4"
 description = "Production-grade MCP server and AI tools for the Godot engine"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11,<3.15"

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -433,6 +433,7 @@ func test_post_update_banner_depends_on_whether_bridges_can_follow() -> void:
 	assert_true(label.begins_with("AI clients that were connected during the update keep working on v4.1.1"), label)
 	assert_true(Plugin.attached_bridges_follow("4.1.0", "4.2.0"))
 	assert_true(Plugin.attached_bridges_follow("4.1.0", "4.1.0"))
+	assert_true(Plugin.attached_bridges_follow("4.0.4", "4.0.5"), "the tolerant bridge shipped in 4.0.4")
 	assert_false(Plugin.attached_bridges_follow("4.1.0", "5.0.0"), "a major change needs new bridges")
 	assert_false(Plugin.attached_bridges_follow("4.0.3", "4.1.0"), "a 4.0.x bridge refuses the new server")
 	assert_false(Plugin.attached_bridges_follow("3.2.5", "4.1.0"))

--- a/tests/integration/test_self_update_upgrade_paths.py
+++ b/tests/integration/test_self_update_upgrade_paths.py
@@ -530,10 +530,10 @@ def test_signed_update_restarts_into_matching_live_server(
     print(f"server A: {'stopped' if 'MCP | stopped server' in initial_log else 'detached (lease)'}")
     print(f"replacement: {'needed' if replaced_line in restarted_log else 'not needed'}")
     print(f"blocks before the start: {blocks_before_start}")
-    ## From 4.1.0 on the attached bridge follows the new server (same major);
+    ## From 4.0.4 on the attached bridge follows the new server (same major);
     ## an older bridge refuses it and the user is told to quit and relaunch.
     base_tuple = tuple(int(part) for part in base_version.split(".")[:3])
-    if base_tuple >= (4, 1, 0):
+    if base_tuple >= (4, 0, 4):
         expected_client_line = f"keep working on v{next_version}"
     else:
         expected_client_line = f"must be quit and relaunched to use v{next_version}"


### PR DESCRIPTION
## Summary

Version bump for 4.0.4: the attached-client update work (#1024 bridge same-major tolerance, #1025 diagnostics and WS port, #1026 post-update replacement, #1027 qualification with a real bridge, #1028 `physics_shape_generate`, #1029 activation phase labels) ships as a patch release.

- `pyproject.toml` and `plugin.cfg` → 4.0.4
- `FIRST_BRIDGE_TOLERANT_VERSION` → "4.0.4" (the bridge that follows a same-major server ships in this version, not 4.1.0); the lifecycle test covers `attached_bridges_follow("4.0.4", "4.0.5")`
- The self-update integration fixture expects "keep working" from base 4.0.4 on
- docs/self-update.md, docs/client-configuration.md and the CHANGELOG say 4.0.4 where they said 4.1.0; the Unreleased section becomes `4.0.4 (2026-09-09)` with the compare link

## Verification

- `pytest -m "not editor"` (unit): 2155 passed, 43 skipped
- GDScript suite headless against the bump tree: see the CI job (local run in progress at push time)
- Live on this box (main + #1029, before the bump): 4.0.3 → synthetic 4.0.4 smoke with a scripted Update click showed the dock's "Staging the verified tree…" phase; the restarted editor replaced the old server on its own; a bridge that stayed attached across the update created a green sphere in the updated editor with no relaunch

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for updating the server without quitting and relaunching compatible AI clients.
  * Added activation-phase names in the dock.
  * Added diagnostics for occupied WebSocket ports before launch.
  * Added `physics_shape_generate`.

* **Bug Fixes**
  * Improved post-update messaging to accurately reflect client compatibility.

* **Documentation**
  * Updated self-update and connection guidance for version 4.0.4 compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->