### PR TITLE
fix: qualification servers bind loopback without a 35 s FQDN lookup on macOS

### DIFF
--- a/script/qualification_https.py
+++ b/script/qualification_https.py
@@ -186,7 +186,7 @@ def private_release_origin(
                 pass  # Bad TLS, a timeout or a disconnected client grants no access.
             self.close_connection = True
 
-    class Server(HTTPServer):
+    class Server(support.LoopbackBind, HTTPServer):
         request_queue_size = 8
 
         def get_request(self):

--- a/script/qualification_index.py
+++ b/script/qualification_index.py
@@ -118,7 +118,10 @@ def retained_index(packages: Path, dependencies: list[dict]):
             if not head_only:
                 self.wfile.write(payload)
 
-    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    class Server(support.LoopbackBind, ThreadingHTTPServer):
+        pass
+
+    server = Server(("127.0.0.1", 0), Handler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:

--- a/script/release_support.py
+++ b/script/release_support.py
@@ -12,6 +12,7 @@ import importlib.util
 import json
 import os
 import re
+import socketserver
 import stat
 import subprocess
 import sys
@@ -23,6 +24,24 @@ from email.parser import BytesParser
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 from typing import Any
+
+
+class LoopbackBind:
+    """Bind a loopback ``HTTPServer`` without resolving its host name.
+
+    ``HTTPServer.server_bind`` looks up the bind address's fully qualified
+    name. On the macOS runners that reverse lookup of 127.0.0.1 stalls for
+    about 35 s per process, which is how the qualification's private origin,
+    its index and the test suite's own servers each paid 35 s on macOS and the
+    shutdown-bound test there failed. Mix in ahead of the server class.
+    """
+
+    def server_bind(self) -> None:
+        socketserver.TCPServer.server_bind(self)  # type: ignore[arg-type]
+        host, port = self.server_address[:2]  # type: ignore[attr-defined]
+        self.server_name = host  # type: ignore[attr-defined]
+        self.server_port = port  # type: ignore[attr-defined]
+
 
 ROOT = Path(__file__).resolve().parents[1]
 REPOSITORY = "hi-godot/godot-ai"

--- a/tests/unit/test_ci_godot_tests_runner.py
+++ b/tests/unit/test_ci_godot_tests_runner.py
@@ -20,8 +20,15 @@ from godot_ai.transport.capability import (
     WS_CAPABILITY_ENV,
     write_capabilities,
 )
+from script import release_support
 
 ROOT = Path(__file__).resolve().parents[2]
+
+
+class _LoopbackServer(release_support.LoopbackBind, ThreadingHTTPServer):
+    """No FQDN lookup of 127.0.0.1: that stalls ~35 s per process on macOS."""
+
+
 RUNNER = ROOT / "script" / "ci-godot-tests"
 HTTP_CAPABILITY = "ci-runner-http-capability-0123456789abcdef"
 WS_CAPABILITY = "0123456789abcdef" * 4
@@ -221,7 +228,7 @@ def test_runner_reuses_one_mcp_session_and_accepts_both_response_shapes(
     runner_name: str,
 ) -> None:
     state = _RunnerState()
-    server = ThreadingHTTPServer(
+    server = _LoopbackServer(
         ("127.0.0.1", 0),
         _handler(state, ROOT / "test_project", response_shape, runner_name),
     )

--- a/tests/unit/test_release_support.py
+++ b/tests/unit/test_release_support.py
@@ -8,6 +8,7 @@ import io
 import json
 import re
 import shutil
+import socket
 import tarfile
 import zipfile
 from pathlib import Path
@@ -1192,3 +1193,26 @@ def test_capsule_carries_what_the_installer_preloads(tmp_path, signing_key, monk
     source = _commit_and_retag(repo, "drop transitive dependency")
     with pytest.raises(v4_release.ReleaseError, match="lock_inner.gd"):
         _build_set(repo, tmp_path / "without", key, source)
+
+
+def test_loopback_bind_never_resolves_the_bind_host(monkeypatch) -> None:
+    """HTTPServer.server_bind reverse-resolves 127.0.0.1; on the macOS runners
+    that stalls ~35 s per process (the 4.0.4 qualification's macOS 3.14 row)."""
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+
+    def forbidden(_host: str) -> str:
+        raise AssertionError("server_bind must not call socket.getfqdn")
+
+    monkeypatch.setattr(socket, "getfqdn", forbidden)
+
+    class Server(support.LoopbackBind, HTTPServer):
+        pass
+
+    server = Server(("127.0.0.1", 0), BaseHTTPRequestHandler)
+    try:
+        assert server.server_name == "127.0.0.1"
+        assert server.server_port == server.server_address[1] > 0
+    finally:
+        server.server_close()
+    with pytest.raises(AssertionError):
+        HTTPServer(("127.0.0.1", 0), BaseHTTPRequestHandler)


### PR DESCRIPTION
## Summary

The 4.0.4 qualification rerun ([34309510300](https://github.com/hi-godot/godot-ai/actions/runs/34309510300)) failed its `Exact Python artifacts / macos-latest / 3.14` row twice on `test_origin_bounds_an_incomplete_tls_client_during_shutdown`: the private origin's context exit took 35.3 s instead of under 2 s. It had passed on the previous run.

**Cause.** The row's junit durations show every test that constructs an `HTTPServer` paying ~35 s on the macOS runners, once per xdist worker: the private HTTPS origin (`test_origin_serves_exact_bytes…` 35.2 s in both runs), the qualification index (`test_index_serves_only_hashed…` 35.6 s), and the runner test's fake MCP server (36.6 s). `HTTPServer.server_bind` calls `socket.getfqdn("127.0.0.1")`, a reverse lookup that stalls until the resolver gives up on those runners. Whichever test creates its worker's first server pays it, so the shutdown-bound test fails only when it runs first, which is why it passed once and failed twice.

**Fix.** `release_support.LoopbackBind` binds through `TCPServer.server_bind` and names the server by its bound address, no lookup. The private origin, the qualification index and the runner test's server mix it in. A unit test forbids `socket.getfqdn` during bind.

## Verification

- `tests/unit/test_release_support.py`, `test_ci_godot_tests_runner.py`, `test_qualification_https.py`, `test_qualification_index.py`, `tests/integration/test_qualification_https.py`: 174 passed locally
- The macOS row itself is only run by the qualification workflow (CI has no macOS Python job); the next qualification run is the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced delays when starting local HTTP/HTTPS servers on macOS by avoiding unnecessary host-name lookups for loopback addresses.
  * Improved reliability and startup speed for qualification workflows and CI test environments using local servers.

* **Tests**
  * Added coverage to verify loopback servers bind correctly without reverse DNS resolution while preserving expected server address and port information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->