### PR TITLE
ci: post to Discord when a v4 promotion run succeeds

### DIFF
--- a/.github/workflows/discord-changelog.yml
+++ b/.github/workflows/discord-changelog.yml
@@ -4,13 +4,20 @@ name: Discord changelog
 ## the channel-scoped DISCORD_CHANGELOG_WEBHOOK secret. The v3 line did this as
 ## the last step of its release workflow. The v4 promotion (release.yml)
 ## publishes from a protected environment and runs nothing that is not needed
-## to publish, so the post lives here and fires on the `published` release
-## event GitHub emits when the promotion flips the draft release live.
+## to publish, so the post lives here and runs once a promotion completes
+## successfully. It reads the tag from the `v4-publication-receipt` artifact
+## that promotion uploaded, so the announcement follows from the same run
+## that published.
+##
+## The `published` release event GitHub emits when the draft flips live is
+## only a fallback for a draft published by hand: the promotion publishes with
+## the workflow token, and an event raised by the workflow token never starts
+## another workflow.
 ##
 ## A missing webhook secret fails the run: an unannounced release must not
 ## look like a success.
 ##
-## Dispatch it by hand with a tag to post a release the event did not cover,
+## Dispatch it by hand with a tag to post a release neither trigger covered,
 ## such as 4.0.0 to 4.0.2, which were published before this workflow existed.
 ##
 ## The post is silent: flags 4096 is Discord's SUPPRESS_NOTIFICATIONS, so the
@@ -20,6 +27,9 @@ name: Discord changelog
 on:
   release:
     types: [published]
+  workflow_run:
+    workflows: ["Promote qualified v4 release"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       tag:
@@ -27,8 +37,10 @@ on:
         required: true
         type: string
 
+## actions: read downloads the promotion run's publication receipt.
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: discord-changelog
@@ -37,15 +49,34 @@ concurrency:
 jobs:
   post:
     runs-on: ubuntu-latest
-    ## A fork has neither the webhook nor the channel.
-    if: github.repository == 'hi-godot/godot-ai'
+    ## A fork has neither the webhook nor the channel. A promotion that was
+    ## cancelled or failed published nothing, so there is nothing to announce.
+    if: >-
+      github.repository == 'hi-godot/godot-ai'
+      && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
     steps:
+      - name: Resolve the tag from the promotion's publication receipt
+        if: github.event_name == 'workflow_run'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PROMOTION_RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          gh run download "$PROMOTION_RUN_ID" --name v4-publication-receipt --dir receipt
+          tag=$(jq -r '.tag' receipt/publication.json)
+          case "$tag" in
+            v[0-9]*) ;;
+            *) echo "::error::publication receipt of run $PROMOTION_RUN_ID names no release tag." >&2; exit 1 ;;
+          esac
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+        id: receipt
       - name: Post release notes to Discord
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_CHANGELOG_WEBHOOK }}
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-          TAG: ${{ inputs.tag || github.event.release.tag_name }}
+          TAG: ${{ inputs.tag || github.event.release.tag_name || steps.receipt.outputs.tag }}
         run: |
           set -euo pipefail
           # `gh secret set` keeps a trailing newline when the value was piped

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -141,16 +141,21 @@ list, the body carries the two links alone and the operator edits the notes by
 hand; notes are mutable and are not a trust anchor, so this is never a reason
 to refuse publication.
 
-Publishing the draft emits GitHub's `release: published` event, which runs
-`discord-changelog.yml`. That workflow posts the release name, URL, and notes
-to the Discord `#changelog` channel through the `DISCORD_CHANGELOG_WEBHOOK`
-repository secret, silently (no push notifications), and fails red when the
-post fails so a broken webhook is noticed. The v3 line posted from inside its
-release workflow; the v4 publishing jobs deliberately run nothing but the
-promotion, so the post moved to its own workflow. Dispatch it by hand with a
-`tag` input to re-post a release or to backfill one published before the
-workflow existed. The workflow file is read from the tagged commit, so v3 tags
-never trigger it.
+A successful promotion run starts `discord-changelog.yml` through its
+`workflow_run` trigger. That workflow downloads the promotion's
+`v4-publication-receipt` artifact, reads the released tag from it, and posts
+the release name, URL, and notes to the Discord `#changelog` channel through
+the `DISCORD_CHANGELOG_WEBHOOK` repository secret, silently (no push
+notifications). It fails red when the post fails so a broken webhook is
+noticed. A failed or cancelled promotion published nothing and is skipped.
+
+The workflow also listens for GitHub's `release: published` event, but the
+promotion publishes the draft with the workflow token, and GitHub never starts
+a workflow from an event the workflow token raised. That trigger only fires
+for a draft flipped live by hand. The v3 line posted from inside its release
+workflow; the v4 publishing jobs deliberately run nothing but the promotion,
+so the post lives in its own workflow. Dispatch it by hand with a `tag` input
+to re-post a release or to backfill one that neither trigger covered.
 
 ### Operator setup before candidate signing
 

--- a/tests/unit/test_signing_workflows.py
+++ b/tests/unit/test_signing_workflows.py
@@ -168,3 +168,33 @@ def test_nightly_diagnostics_are_credential_free_and_not_a_release_gate() -> Non
 
 def test_legacy_auto_bump_tag_push_workflow_is_retired() -> None:
     assert not (WORKFLOWS / "bump-and-release.yml").exists()
+
+
+def test_discord_changelog_follows_a_successful_promotion() -> None:
+    raw = (WORKFLOWS / "discord-changelog.yml").read_text(encoding="utf-8")
+    workflow = yaml.safe_load(raw)
+    release = yaml.safe_load((WORKFLOWS / "release.yml").read_text(encoding="utf-8"))
+    triggers = workflow.get(True, workflow.get("on"))
+    assert set(triggers) == {"release", "workflow_run", "workflow_dispatch"}
+    # The promotion publishes with the workflow token, so `release: published`
+    # never starts this workflow; the promotion run completing is what does.
+    assert triggers["workflow_run"] == {
+        "workflows": [release["name"]],
+        "types": ["completed"],
+    }
+    assert workflow["permissions"] == {"contents": "read", "actions": "read"}
+    post = workflow["jobs"]["post"]
+    assert "github.event.workflow_run.conclusion == 'success'" in post["if"]
+    receipt = next(step for step in post["steps"] if step.get("id") == "receipt")
+    assert receipt["if"] == "github.event_name == 'workflow_run'"
+    assert "--name v4-publication-receipt" in receipt["run"]
+    assert "steps.receipt.outputs.tag" in post["steps"][-1]["env"]["TAG"]
+    # The receipt artifact the announcement reads is the one promotion uploads.
+    upload = next(
+        step
+        for step in release["jobs"]["publish-github"]["steps"]
+        if step.get("uses", "").startswith("actions/upload-artifact@")
+    )
+    assert upload["with"]["name"] == "v4-publication-receipt"
+    # Publication jobs stay untouched: no announcement step joins them.
+    assert "discord" not in str(release).lower()


### PR DESCRIPTION
## Why

`discord-changelog.yml` only listened for `release: published`. The promotion (`release.yml`) publishes the release with the workflow token, and GitHub never starts a workflow from an event that token raised, so the event has never fired. Both 4.0.3 and 4.0.4 had to be posted to Discord by manual dispatch.

## What changes

- **`discord-changelog.yml`** gains a `workflow_run` trigger on "Promote qualified v4 release". When a promotion completes with `success`, a new step downloads that run's `v4-publication-receipt` artifact, reads `.tag` from `publication.json`, and the existing post step announces it. Failed or cancelled promotions are skipped by the job `if`. The workflow gets `actions: read` for the artifact download.
- The `release: published` trigger stays as a fallback for a draft flipped live by hand, and manual `tag` dispatch still works for backfills.
- **`docs/releasing.md`** describes the new flow and why the release event does not fire.
- **`tests/unit/test_signing_workflows.py`** pins the trigger, the permission, the success guard, the receipt step, and that the artifact name matches what `publish-github` uploads.

The publication jobs in `release.yml` are untouched, keeping the protected environment jobs limited to publishing.

## Verification

- `ruff check` and `ruff format --check` on the test file pass.
- `pytest tests/unit/test_signing_workflows.py`: 8 passed.
- The end-to-end trigger can only be exercised by the next real promotion; the receipt artifact it reads is the one 4.0.4's run uploaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hWUmuMAQh5PYz2HNGqjPX

---
_Generated by [Claude Code](https://claude.ai/code/session_015hWUmuMAQh5PYz2HNGqjPX)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Discord changelog announcements now publish automatically after a successful release promotion.
  - Announcements use the promoted release tag, helping ensure the correct release is posted.
  - Manual publishing remains available for reposting or backfilling announcements by tag.

- **Bug Fixes**
  - Cancelled or failed release promotions no longer trigger Discord changelog announcements.
  - Announcement failures are now reported as workflow failures.

- **Documentation**
  - Updated release guidance to describe automatic, manual, and failure-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->