### PR TITLE
fix(lifecycle): reduce Windows startup cost and stabilize reloads

### DIFF
--- a/docs/lifecycle-review-2026-09.md
+++ b/docs/lifecycle-review-2026-09.md
@@ -1,0 +1,120 @@
+# Windows startup and lifecycle review, September 2026
+
+Focused repairs improve startup and recovery without another transport rewrite.
+The changes retain authentication, signed updates and exact process ownership.
+They do not complete production upgrade qualification or restore self-update
+without an editor restart.
+
+## Changes and their purpose
+
+- Recover a lost editor socket by probing the existing backend. Retain an owned
+  process only when its fingerprint and authenticated listener still match.
+  A healthy shared backend no longer restarts merely because its socket dropped.
+- Use one three-second status-probe deadline. On Windows, skip a dead TCP connect
+  when a temporary loopback bind proves that no listener occupies the port.
+  An occupied port still receives the authenticated HTTP probe.
+- Collect bounded Windows process ancestry once per proof boundary. Prefer an
+  existing PowerShell 7 installation and retain the Windows PowerShell fallback.
+  Reuse a worker snapshot for the launcher only when its ancestry proves the
+  relationship. Capture both independent kill-grant snapshots in one shell
+  invocation; revalidate identity again before a kill.
+- Give short discovery commands up to 250ms to finish before expensive process
+  grant capture. This time counts against the command deadline, and cancellation
+  remains latched. Resolve a Python launcher's base interpreter when its own
+  directory has no `pythonw.exe`.
+- Block nested dispatcher ticks and reserve reload before scheduling it. Hold
+  later commands until the filesystem scan and reload settle; release the
+  reservation on timeout. Reject reload inside a batch before any operation runs.
+- Allow replacement to wait up to 60 seconds for the old listener to exit. One
+  Windows handoff took 25.262 seconds, exceeding the former 15-second bound.
+  This prevents premature failure; it does not establish acceptable handoff speed.
+- Distinguish installed files from a usable connection in update messages. Remove
+  permission-repair advice that could recommend deleting a repository merely
+  because an ancestor directory was named `godot-ai`.
+
+The [lifecycle reference](server-lifecycle.md) documents the ownership and reload
+contracts. The dispatcher reservation covers queued commands, not quiescence of
+all previously started deferred work or dock callbacks during an active handler.
+
+## Startup measurements
+
+Visible-editor runs used one Windows machine with Godot 4.7.2 and an installed
+PowerShell 7. The endpoint was the observer's authenticated editor connection.
+Warm runs reopened an imported project with the backend closed and its package
+cache retained. Excluded warmups and sampled screenshots followed the
+[verification procedure](verification.md).
+
+| Comparison | Baseline | Candidate | Interpretation |
+| --- | ---: | ---: | --- |
+| Skip an unbound Windows connect, three runs per arm | 13.014s median | 10.171s median | Matched comparison; 2.844s saved. |
+| Reuse worker ancestry, ABBA order | 10.432s mean | 9.558s mean | Two runs per arm; 0.874s saved. |
+| Combine ancestry reuse with paired snapshot collection | Prior baseline about 10.2–10.4s | 9.023s median | Three runs, not interleaved with baseline. |
+
+The combined samples were 8.965, 9.708 and 9.023 seconds. They qualify the normal
+warm path on this machine, not a tail-latency bound or a gain on every Windows
+installation. Shared-snapshot experiments also produced 14.916- and 15.114-second
+starts. Those outliers remain unexplained. Instrumented repeats completed in
+about 9.2–9.4 seconds but did not explain the slow cases.
+
+Paired snapshot collection alone reduced a grant capture from about 1.70 to
+0.94 seconds without improving whole-editor startup in its separate series.
+The combined candidate, rather than that isolated operation, justified adoption.
+Hidden Tools and Settings tabs took approximately 22ms to construct. No lazy-tab
+refactor was accepted. Visible client rows took approximately 335–379ms.
+
+Earlier published-version observations were 8.4 seconds warm for plugin 3.2.5
+and 41.1 seconds for 4.0.4. The v3 endpoint was a handshake acknowledgement,
+not v4 authentication, and the runs used different Python and dependency
+versions. Early cold runs also had unequal package-cache preparation. Those
+observations describe the regression seen here but cannot isolate architecture
+cost or establish comparable failure rates.
+
+## Verification
+
+The final production snapshot passed the full live Godot suite with 2,318 passed,
+zero failed and 30 skipped across 73 suites. Concurrent stress made 1,143 calls:
+1,126 succeeded, 17 had tolerated reload transients, and none had unexpected
+failures. Both reloads recovered within the 30-second deadline. A separately
+inspected plugin-only reload kept the same editor process, showed a connected
+dock and returned an authenticated ready editor state.
+
+Actual dock-button updates from local 3.2.5 and 4.0.4 fixtures to local 4.0.5
+completed installation, restart and client migration. Each updated dock was
+visually inspected and each exact project returned authenticated editor-state
+and scene-hierarchy reads. These fixtures substitute local signing keys,
+release metadata and runtimes. The v3 fixture does not run its published old
+backend. They do not qualify the untouched production update journey.
+
+The full pre-commit Python run passed 2,592 tests with 55 skips, with
+`GODOT_BIN` set so the real-editor rows ran. The full CI Ruff scope also passed.
+An earlier test-only UTF-8 omission was corrected. A separate run lacked Git
+Bash/OpenSSL on PATH; its failures are retained locally, and the full suite
+was rerun with those installed tools available.
+
+Detailed experiment receipts and failed runs remain local. They include the
+matched ABBA comparison, individual startup observations, full suite logs,
+concurrent stress results and before/after upgrade screenshots. Private runtime
+records, caches and signing material are not release artifacts.
+
+## Remaining release gates and priorities
+
+1. **Seamless upgrade from the published 3.2.5 stack with a client still attached.**
+   The untouched 3.2.5-to-4.0.4 journey failed: files installed, Python GUI-launcher
+   discovery broke migration, and an old client retained the port. Closing the
+   client manually did not satisfy the seamless-upgrade requirement. This is the
+   next priority because 3.2.5 remains the asset-store starting point.
+2. **Self-update without restarting Godot.** Plugin-only reload is verified,
+   but in-editor installation and activation remain unimplemented. Startup
+   process-proof improvements can be reused by that path.
+3. **Actionable startup status.** Routine loading can still show red
+   **Connection blocked**. An absent `exit_ms` can display a fabricated **0.0s**
+   lifetime. Show progress during startup and an observed reason on failure.
+4. **Startup variability and package-path robustness.** A diagnostic backend
+   failed before publishing capabilities while installing into a 261-character
+   cache path. A shorter isolated cache succeeded. The OS long-path setting did
+   not prevent the failure. That diagnosis is not a production path-length fix,
+   and it does not explain the separate slow warm starts.
+
+These checks qualify this repair set for review, not a production release.
+Further refactoring should start from a reproduced failed user journey and
+remove duplicated work or ownership decisions demonstrated by that journey.

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -120,7 +120,8 @@ All steps run inside the editor, on the main thread except the download.
     or any other conflict keeps the dock's explicit Restart Server
     authority. Every
     replacement launches our server before killing the occupant; that server
-    reports through its startup report the moment it reaches its port wait
+    reports through its startup report the moment it reaches its bounded
+    60-second port wait
     (a launch through uvx may spend seconds installing the new version
     first), and only then is the occupant killed. The server binds and
     listens the instant the port frees and hands that very socket to its
@@ -136,9 +137,9 @@ All steps run inside the editor, on the main thread except the download.
     configuration in memory and respawns the old bridge from it until the
     application itself is relaunched. A 4.0.4+ bridge keeps serving a server
     of the same major version and follows the replacement on its own, so the
-    dock says the clients keep working instead. That post-update replacement
-    probes with a longer timeout than an ordinary start, so a backend still
-    settling on the port is not mistaken for a foreign process.
+    dock says those clients can reconnect without restarting. Ordinary starts
+    and post-update replacement use the same three-second probe timeout, so
+    both allow a backend time to answer before reporting a blocked connection.
 
 ## The v3-to-v4 capsule
 

--- a/docs/server-lifecycle.md
+++ b/docs/server-lifecycle.md
@@ -29,11 +29,21 @@ BLOCKED -> RECOVERING -> STARTING
 ```
 
 An authenticated endpoint that drops moves `READY -> BLOCKED(endpoint_lost)`
-and revokes the connection, then re-probes on its own with a bounded backoff
-(1, 2, 4, 8, 16 s; five attempts per outage), each attempt running the same
-start path a dock Restart would, so the server must re-prove its capability.
-After the last attempt the block stays until Restart. A server that holds for
-a minute earns a fresh budget; one that flaps faster spends it and stops.
+and revokes the connection, then schedules one re-probe. Successive losses
+without a full minute in `READY` use delays of 1, 2, 4, 8, and 16 seconds.
+Automatic recovery probes the existing backend before deciding whether to
+launch. A lost socket does not
+authorize killing a healthy shared backend. For an owned process, the probe
+checks the PID, fingerprint, authenticated endpoint, and listener identity
+before retaining ownership. If the process is dead and both ports are free,
+recovery may launch a replacement through the normal startup path. An identity
+that cannot be proven blocks recovery. The dock's explicit Restart remains a
+separate process-control action.
+
+After five recovery attempts, another loss stays blocked until Restart. A
+server that holds `READY` for 60 seconds earns a fresh budget on its next loss.
+A failed recovery probe can leave the lifecycle blocked immediately; the five
+delays limit repeated disconnects, not retries of a single failed probe.
 
 Startup effects are `PROBE`, `LAUNCH`, and `PROVE`; control effects are
 `REPLACE` and `STOP`. Every effect carries the active episode ID. Completion
@@ -63,6 +73,13 @@ in `BLOCKED`.
 
 ## Startup and adoption
 
+Status probes share a three-second deadline during normal startup, recovery,
+and post-update adoption. The former 800 ms normal-start window could reject
+a healthy backend whose authenticated status took over a second. This gives
+slow responses a finite settling window; it does not retry a failed probe or
+eliminate concurrent-launch races. An unanswered bound endpoint can still
+leave startup blocked when that deadline expires.
+
 1. Read the private per-port capability record.
 2. Probe `/godot-ai/status` with its HTTP bearer and enforce the 8 KiB response
    bound.
@@ -83,9 +100,11 @@ the capability directory before it spawns: the server would otherwise create
 it with `mode=0o700`, which CPython renders as a DACL of SYSTEM, Administrators
 and OWNER RIGHTS only, and a directory first created by an elevated process is
 unusable from the user's unelevated editor, server and bridge (#988). A failed
-probe blocks the start with the directory path and the elevated `Remove-Item`
-repair; the server and the `attach` bridge report the same message from their
-side. The plugin also passes `--startup-report <user://...json>` beside
+probe blocks the start with the exact directory path and permission guidance;
+the server and the `attach` bridge report the same message from their side.
+Restore the Windows account's access to that directory and reopen the editor
+and clients unelevated. The diagnostic never recommends deleting a directory
+based on its name. The plugin also passes `--startup-report <user://...json>` beside
 `--pid-file` and removes any stale report before the spawn. A server that
 fails before publishing its record writes `{pid, error, message, hint}` there
 (a port already in use, an unwritable directory, an import error); the first
@@ -120,6 +139,14 @@ owned-process grant, except when `keep_server_on_exit` is enabled or a live
 attach lease requires continuity; in either case the plugin deliberately
 detaches. Lease counts are finite and authenticated like every other HTTP
 route.
+
+Replacement keeps the new child in its port wait for at most 60 seconds. A
+Windows upgrade recorded the old 15-second wait expiring after 15.020 seconds,
+while the incumbent released the port 25.262 seconds after the wait began.
+The longer bound preserves the existing process checks before termination.
+Python applies the same 60-second cap. Waiting for the child to announce its
+port-wait phase remains bounded at 120 seconds; capability proof starts after
+replacement returns and has a separate 180-second deadline.
 
 ## Command discovery
 
@@ -163,11 +190,21 @@ according to the rules above. The Python handler waits for a distinct
 authenticated replacement session; it never treats the old session entry as a
 successful reload.
 
+The tool reserves its reload before scheduling the scan. The dispatcher blocks
+nested ticks and stops starting queued handlers after returning the reload
+response. The reservation holds through scan completion and plugin teardown;
+a scan timeout releases it so queued commands can resume. This prevents a later
+handler's filesystem operation from pumping an already-scheduled tool reload.
+`reload_plugin` is rejected inside `batch_execute` before any batch operation
+runs. Previously started deferred work retains its existing lifetime rules;
+this command-dispatch gate does not certify its quiescence or cover a Dock
+callback scheduled while a handler is already executing.
+
 The editor tool first waits for the filesystem's main-thread completion
 notification, not merely `is_scanning() == false`: that worker flag can clear
 before Godot applies resource/script reloads. One bounded native-signal handoff
 survives those script reloads without retaining a suspended handler coroutine.
-A real-time five-second deadline leaves the plugin unchanged on timeout;
+A real-time sixty-second deadline leaves the plugin unchanged on timeout;
 duplicate requests are refused, stale callbacks cannot consume a later request,
 and direct reload cancels pending scan work. The script-work ledger remains
 busy until this handoff actually completes or is cancelled. The transaction

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -79,6 +79,19 @@ editor to *look at* — the step 6 smoke test — or when nothing is running yet
 
 **Always do this before every commit.** Python mocks don't catch GDScript bugs, editor API regressions, or undo/redo issues.
 
+On Windows, make Git for Windows' Bash and OpenSSL available to the test
+process. An installed Git can be on PATH while those companion tools are not.
+For the default installation, set this in the current PowerShell session:
+
+```powershell
+$env:PATH = "$env:ProgramFiles\Git\bin;$env:ProgramFiles\Git\usr\bin;$env:PATH"
+Get-Command bash, openssl
+```
+
+Use the actual Git installation directory for a non-default installation.
+`bash` must resolve to Git's executable, not the Windows WSL launcher. These
+tools create disposable signing/TLS fixtures and exercise the CI shell helpers.
+
 1. Run the same Ruff scope as CI — production, tests, the `script/` Python
    package, and the executable Python release/smoke scripts:
    ```bash
@@ -121,8 +134,71 @@ editor to *look at* — the step 6 smoke test — or when nothing is running yet
 7. If the change touches self-update, the migration bridge, or plugin
    disable/enable, the updater row in step 2 and
    `test_project/tests/test_update_installer.gd` in step 5 are the required
-   coverage ([self-update.md](self-update.md)).
+   automated coverage ([self-update.md](self-update.md)). Also complete the
+   visible-editor checks below for lifecycle and update changes.
 8. Only commit when all of the above are green
+
+## Verify lifecycle and updates throughout implementation
+
+Run a visible Godot editor before and after each meaningful lifecycle or update
+change. Load real scenes and exercise handlers before testing recovery or an
+update. A clean startup with no handlers loaded does not cover retained script
+state. Repeat these checks during implementation, not only before the commit.
+
+Watch the editor during startup, reload, and update, including failure states.
+Do not wait for a successful connection before inspecting the dock. For
+automated interactive runs, inspect startup after each relevant change, and
+inspect every plugin reload and upgrade. For unchanged benchmark repetitions,
+review the first and last runs; intermediate runs may advance automatically.
+Monitor every run for errors, crashes, connection loss and unexpectedly slow
+startup. On an anomaly, stop the series, capture the exact editor window when
+available, and preserve its logs for inspection. Choose and record the slow-start
+threshold before running. Keep foreground capture out of routine measured
+startup intervals; use an excluded warmup for startup visual observation.
+Continue monitoring for connection loss while awaiting visual review. A saved screenshot
+without visual inspection is not a completed UI check. Check the editor's actual
+exit code as well as the harness result. Use the same observation schedule in
+both arms of a performance comparison.
+
+Use isolated projects owned by the current session. Keep client configuration
+and capability directories separate from the user's normal environment. Follow
+the [worktree and scene safety rules](worktrees.md).
+
+1. Start from each published release, **3.2.5 and 4.0.4**. Verify the release
+   signatures and record the untouched add-on's file hashes. Record the actual
+   backend and attach-bridge package versions as well as the plugin version.
+2. Connect a real client through that release's bridge. Open a scene and call
+   scene, node, and script handlers. Verify a scene mutation and its undo.
+3. Exercise connection loss, plugin disable and enable, plugin reload, and
+   editor restart. Check the scene, reconnecting client, and subsequent tool
+   responses after each action. A socket loss must not kill a healthy backend.
+4. Click **Update** in the actual dock. Observe its confirmation, progress,
+   activation, and completion. Verify the installed tree, client configuration,
+   and authenticated tool calls after activation, including after any restart.
+5. Record editor and server PIDs, versions, logs, scene continuity, and every
+   manual recovery action. Agree on the allowed editor and client restarts
+   before evaluating whether the update is seamless. A harness that expects a
+   restart does not by itself establish that UX requirement.
+
+A failed visible-editor check fails verification even when unit tests pass.
+Keep the failure open until the exact sequence passes. Report any unavailable
+check as incomplete.
+
+Distinguish local fixtures from exact release evidence. The interactive
+`script/local-self-update-smoke` supports `--from-v3-tag v3.2.5` and
+`--base-from-release-tag v4.0.4`, but modifies fixture code and uses local server
+snapshots. Record those substitutions. These runs help catch regressions during
+development, but cannot prove an untouched published stack upgrades correctly.
+
+An untouched published updater accepts only a candidate signed by its trusted
+release key. Obtain that candidate through the existing
+[release qualification workflow](releasing.md), then verify both published
+origins against it. Reuse `script/runtime_qualification.py` for immutable
+artifact and packaged-runtime checks, and add the visible dock interaction.
+Its automated headless run does not cover that interaction. Do not replace the
+trust key or bypass signature verification and report the result as exact
+release evidence. A pristine published-to-published run is useful baseline
+evidence, but does not verify an unpublished candidate.
 
 ## Testing against Godot
 

--- a/plugin/addons/godot_ai/client_configurator.gd
+++ b/plugin/addons/godot_ai/client_configurator.gd
@@ -1440,13 +1440,41 @@ static func _resolve_consoleless_python(
 			if int(probe.get("exit_code", -1)) == 0:
 				var python := str(probe.get("stdout", "")).strip_edges()
 				if not python.is_empty():
-					var managed_pythonw := python.get_base_dir().path_join("pythonw.exe")
-					if FileAccess.file_exists(managed_pythonw):
+					var managed_pythonw := _consoleless_python_for_interpreter(python)
+					if not managed_pythonw.is_empty():
 						return managed_pythonw
 
 	## A system Python GUI launcher is sufficient for the non-dev bootstrap;
 	## it does not import godot_ai itself.
 	return CliFinder.find(["pythonw.exe"])
+
+
+## uv can return a launcher in ~/.local/bin whose GUI interpreter lives in
+## the managed Python installation. Ask that interpreter for its base path.
+## The optional result keeps tests independent of installed executables.
+static func _consoleless_python_for_interpreter(
+	python: String, probe_result: Dictionary = {}
+) -> String:
+	if not python.is_absolute_path() or not FileAccess.file_exists(python):
+		return ""
+	var sibling := python.get_base_dir().path_join("pythonw.exe")
+	if FileAccess.file_exists(sibling):
+		return sibling
+	var probe := probe_result
+	if probe.is_empty():
+		probe = McpCliExec.run(
+			python, ["-I", "-c", "import sys; print(getattr(sys, '_base_executable', sys.executable))"],
+			_DISCOVERY_TIMEOUT_MS, false
+		)
+	if int(probe.get("exit_code", -1)) != 0 or not probe.get("stdout") is String:
+		return ""
+	var base_python := str(probe["stdout"]).strip_edges()
+	if base_python.contains("\n") or base_python.contains("\r"):
+		return ""
+	if not base_python.is_absolute_path() or not FileAccess.file_exists(base_python):
+		return ""
+	var base_pythonw := base_python.get_base_dir().path_join("pythonw.exe")
+	return base_pythonw if FileAccess.file_exists(base_pythonw) else ""
 
 
 static func _system_version_from_probe(probe: Dictionary) -> Dictionary:

--- a/plugin/addons/godot_ai/clients/_cli_exec.gd
+++ b/plugin/addons/godot_ai/clients/_cli_exec.gd
@@ -39,6 +39,7 @@ extends RefCounted
 
 const DEFAULT_TIMEOUT_MS := 8000
 const _POLL_INTERVAL_MS := 50
+const _QUICK_EXIT_WINDOW_MS := 250
 const _KILL_GRACE_MS := 500
 const PortResolver := preload("res://addons/godot_ai/utils/port_resolver.gd")
 const UvResolution := preload("res://addons/godot_ai/utils/uv_resolution_policy.gd")
@@ -101,11 +102,24 @@ static func _run_piped(
 	if pid <= 0:
 		_close_pipes(stdio, stderr_pipe)
 		return _spawn_failed_result()
-	var kill_grant := PortResolver.capture_process_kill_grant(pid)
-
 	var deadline := Time.get_ticks_msec() + maxi(timeout_ms, _POLL_INTERVAL_MS)
+	var kill_grant: Dictionary = {}
+	## Most discovery commands finish within a few polls. Do not spend Windows
+	## identity-query time capturing kill authority for an already-exited child.
+	## This short window shares the command deadline and observes cancellation;
+	## a child still running afterward needs the same exact grant as before.
+	var quick_deadline := mini(deadline, Time.get_ticks_msec() + _QUICK_EXIT_WINDOW_MS)
+	var cancellation_requested := false
+	while OS.is_process_running(pid) and Time.get_ticks_msec() < quick_deadline:
+		if cancel_check.is_valid() and bool(cancel_check.call()):
+			cancellation_requested = true
+			break
+		OS.delay_msec(mini(_POLL_INTERVAL_MS, maxi(0, quick_deadline - Time.get_ticks_msec())))
+	if OS.is_process_running(pid):
+		kill_grant = PortResolver.capture_process_kill_grant(pid)
+
 	while OS.is_process_running(pid):
-		var cancelled := cancel_check.is_valid() and bool(cancel_check.call())
+		var cancelled := cancellation_requested or (cancel_check.is_valid() and bool(cancel_check.call()))
 		if cancelled or Time.get_ticks_msec() >= deadline:
 			## Kill before draining: a pipe read can block while the launcher or
 			## one of its descendants still owns the write end. Windows taskkill

--- a/plugin/addons/godot_ai/dispatcher.gd
+++ b/plugin/addons/godot_ai/dispatcher.gd
@@ -19,6 +19,7 @@ var _lazy_handler_specs: Dictionary = {}  # handler_key -> {path: String, args: 
 var _lazy_handler_cache: Dictionary = {}  # handler_key -> handler instance
 var _lazy_commands: Dictionary = {}  # command_name -> {handler: String, method: StringName}
 var _pending_deferred: Dictionary = {}  # request_id -> {command, started_ms, timeout_ms}
+var _tick_active := false
 var _log_buffer
 var _surfaced_error_tracker
 ## The McpConnection whose pause_processing handlers flip around unsafe
@@ -50,6 +51,7 @@ const DEFERRED_TIMEOUT_MS_BY_COMMAND := {
 }
 const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
 const FuzzySuggestions := preload("res://addons/godot_ai/utils/fuzzy_suggestions.gd")
+const PluginReload := preload("res://addons/godot_ai/utils/plugin_reload.gd")
 
 
 func _init(log_buffer: McpLogBuffer, surfaced_error_tracker = null) -> void:
@@ -247,6 +249,11 @@ const DEFERRED_RESPONSE := {"_deferred": true}
 ## Process queued commands within a frame budget (milliseconds).
 ## Returns an array of response dictionaries to send back.
 func tick(budget_ms: float = 4.0) -> Array[Dictionary]:
+	## Editor filesystem operations can pump another frame before the handler
+	## returns. That frame must not dispatch the still-queued command again.
+	if _tick_active or PluginReload.is_reload_pending():
+		return []
+	_tick_active = true
 	var responses: Array[Dictionary] = _collect_deferred_timeouts()
 	var start := Time.get_ticks_msec()
 	var idx := 0
@@ -257,10 +264,13 @@ func tick(budget_ms: float = 4.0) -> Array[Dictionary]:
 		if not response.get("_deferred", false):
 			responses.append(response)
 		idx += 1
+		if PluginReload.is_reload_pending():
+			break
 
 	if idx > 0:
 		_command_queue = _command_queue.slice(idx)
 
+	_tick_active = false
 	return responses
 
 

--- a/plugin/addons/godot_ai/handlers/batch_handler.gd
+++ b/plugin/addons/godot_ai/handlers/batch_handler.gd
@@ -10,6 +10,8 @@ const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
 ## Commands that cannot run as batch sub-commands, each with the reason a batch
 ## can't host it.
 ## - batch_execute: would recurse.
+## - reload_plugin: schedules teardown; later batch operations could pump
+##   its callback while the batch handler is still executing.
 ## - run_tests: a batch executes synchronously inside one dispatcher tick with
 ##   NO transport servicing, so a full suite starves the WebSocket heartbeat
 ##   (the exact disconnect the serviced test_run path exists to prevent) and
@@ -21,6 +23,7 @@ const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
 ##   no completion channel and hang or lose its reply. input_sequence made this
 ##   concrete (#814); the whole game_command surface shares the deferred path.
 const FORBIDDEN_SUBCOMMANDS := {
+	"reload_plugin": "reload_plugin must be called directly so no batch continues during reload",
 	"batch_execute": "batch_execute cannot be nested inside another batch",
 	"run_tests":
 		"run_tests is not allowed as a sub-command — a batch runs synchronously "

--- a/plugin/addons/godot_ai/handlers/editor_handler.gd
+++ b/plugin/addons/godot_ai/handlers/editor_handler.gd
@@ -948,12 +948,15 @@ func _clear_debugger_error_trees() -> int:
 
 
 func reload_plugin(_params: Dictionary) -> Dictionary:
+	var work := PluginReload.reserve_reload()
+	if work == 0:
+		return ErrorCodes.make(ErrorCodes.EDITOR_NOT_READY, "A plugin reload is already pending.")
 	_log_buffer.log("reload_plugin requested, reloading next frame")
 	## Persist a pending plugin_reload telemetry event *before* the
 	## disable kills the live WebSocket. The re-enabled plugin's
 	## _enter_tree flushes via `_telemetry.flush_pending_plugin_reload()`.
 	Telemetry.record_pending_plugin_reload("mcp_tool")
-	_do_reload_plugin.call_deferred(ScriptWork.begin("reload_plugin"))
+	_do_reload_plugin.call_deferred(work)
 	return {"data": {"status": "reloading", "message": "Plugin reload initiated"}}
 
 

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -2100,7 +2100,8 @@ func _build_tools_tab(tabs: TabContainer) -> void:
 
 	_update_confirm = ConfirmationDialog.new()
 	_update_confirm.title = "Update Godot AI?"
-	_update_confirm.ok_button_text = "Save & Update"
+	_update_confirm.ok_button_text = "Update and restart"
+	_update_confirm.cancel_button_text = "Later"
 	_update_confirm.confirmed.connect(_on_update_confirmed)
 	add_child(_update_confirm)
 
@@ -2746,7 +2747,9 @@ func _on_update_pressed() -> void:
 	## user's session. A dock that is not in a scene tree has no dialog to
 	## show and proceeds directly.
 	if _update_confirm != null and is_inside_tree():
-		_update_confirm.dialog_text = update_confirm_text(_update_candidate_version)
+		_update_confirm.dialog_text = update_confirm_text(
+			_update_candidate_version, ClientConfigurator.get_plugin_version()
+		)
 		_update_confirm.popup_centered()
 		return
 	update_requested.emit()
@@ -2756,12 +2759,16 @@ func _on_update_confirmed() -> void:
 	update_requested.emit()
 
 
-static func update_confirm_text(version: String) -> String:
+static func update_confirm_text(version: String, current_version: String) -> String:
 	var target := "Godot AI v%s" % version if not version.is_empty() else "the new Godot AI"
+	var clients := (
+		"AI clients already using v%s can reconnect without restarting. Relaunch clients still using an older version." % current_version
+		if McpServerVersionCheck.attached_bridges_follow(current_version, version)
+		else "Quit and relaunch connected AI clients after the update."
+	)
 	return (
-		"This will save your project and relaunch the editor to install %s.\n"
-		+ "AI clients connected right now must be restarted afterwards.\n\nContinue?"
-	) % target
+		"This will save your project and restart the Godot editor to install %s.\n\n%s"
+	) % [target, clients]
 
 
 func present_update_check(result: Dictionary) -> void:
@@ -2770,7 +2777,7 @@ func present_update_check(result: Dictionary) -> void:
 	_update_label.add_theme_color_override("font_color", _UPDATE_LABEL_COLOR)
 	_update_banner.visible = true
 	## A fresh candidate re-arms the action. The restarted editor after an
-	## update shows "Update complete" with the button disabled; a newer release
+	## update shows "Godot AI installed" with the button disabled; a newer release
 	## found later in that same session must still be installable. A running
 	## install or a pending post-update action keeps ownership of the button.
 	if _update_install_in_flight or not _post_update_action.is_empty():
@@ -2816,9 +2823,10 @@ func present_update_state(state: Dictionary) -> void:
 		_update_label.text = String(state["label_text"])
 	if state.has("banner_visible") and _update_banner != null:
 		_update_banner.visible = bool(state["banner_visible"])
-	if String(state.get("outcome", "")) == "success" and _update_label != null:
-		## Visual confirmation for successful terminal update states.
-		_update_label.add_theme_color_override("font_color", Color.GREEN)
+	if state.has("label_text") and _update_label != null:
+		## Installation is distinct from server/client readiness. Instructions
+		## can still name failed migrations or clients that must reconnect.
+		_update_label.add_theme_color_override("font_color", _UPDATE_LABEL_COLOR)
 
 
 func _set_update_status(text: String) -> void:

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -148,15 +148,6 @@ var _post_update_stale_reprobes_left := POST_UPDATE_STALE_REPROBE_LIMIT
 ## may not be the last; a few are allowed before the dock takes over.
 const POST_UPDATE_REPLACEMENT_LIMIT := 3
 var _post_update_replacements_left := POST_UPDATE_REPLACEMENT_LIMIT
-## Right after an update the old bridge's backend may still be settling on
-## the port; a status probe that gives up in 800 ms reads it as a foreign
-## process and nothing replaces it. The post-update probe waits longer.
-const POST_UPDATE_PROBE_TIMEOUT_MS := 3000
-## First version whose attach bridge keeps serving a server of the same
-## major version (#1024). A client attached through an update from an older
-## version still runs a bridge that refuses the new server and must be quit
-## and relaunched; from this version on it follows the new server itself.
-const FIRST_BRIDGE_TOLERANT_VERSION := "4.0.4"
 ## Set once the live tree has been renamed; the lock then belongs to the restart.
 var _update_swapped := false
 var _post_update_action := ""
@@ -860,6 +851,7 @@ func _present_post_update_barrier_failure(error: String) -> void:
 		_dock.present_update_state({
 			"install_in_flight": false,
 			"button_text": "Retry client migration",
+			"status_text": "Installed — client migration failed",
 			"button_disabled": false,
 			"label_text": "Server startup is blocked: %s" % error,
 			"banner_visible": true,
@@ -890,8 +882,8 @@ func _finish_post_update() -> void:
 	_post_update_stale_reprobes_left = POST_UPDATE_STALE_REPROBE_LIMIT
 	_post_update_replacements_left = POST_UPDATE_REPLACEMENT_LIMIT
 	var to_version := str(_post_update_outcome.get("to_version", ""))
-	if attached_bridges_follow(_post_update_replaced_version, to_version):
-		print("MCP | AI clients attached before the update keep working on v%s" % to_version)
+	if McpServerVersionCheck.attached_bridges_follow(_post_update_replaced_version, to_version):
+		print("MCP | AI clients using v%s can reconnect to v%s; relaunch clients still using older versions" % [_post_update_replaced_version, to_version])
 	else:
 		print(
 			"MCP | AI clients attached before the update must be quit and relaunched to use v%s"
@@ -922,7 +914,7 @@ func _present_post_update_complete() -> void:
 	if _dock != null:
 		_dock.present_update_state({
 			"install_in_flight": false,
-			"status_text": "Update complete",
+			"status_text": "Godot AI installed" if _post_update_deferred.is_empty() else "Installed — client setup needed",
 			"button_disabled": true,
 			"label_text": _post_update_complete_label(),
 			"banner_visible": true,
@@ -931,24 +923,12 @@ func _present_post_update_complete() -> void:
 		})
 
 
-## Whether a bridge a client attached at `from_version` keeps serving the
-## server at `to_version` (#1024: same major version, from 4.0.4 on).
-static func attached_bridges_follow(from_version: String, to_version: String) -> bool:
-	var from_tuple := McpServerVersionCheck.version_tuple(from_version)
-	var to_tuple := McpServerVersionCheck.version_tuple(to_version)
-	if from_tuple.is_empty() or to_tuple.is_empty():
-		return false
-	if int(from_tuple[0]) != int(to_tuple[0]):
-		return false
-	var floor_tuple := McpServerVersionCheck.version_tuple(FIRST_BRIDGE_TOLERANT_VERSION)
-	return McpServerVersionCheck.compare(from_tuple, floor_tuple) >= 0
-
-
 func _post_update_complete_label() -> String:
 	var to_version := str(_post_update_outcome.get("to_version", ""))
+	var from_version := str(_post_update_outcome.get("from_version", ""))
 	var text := (
-		"AI clients that were connected during the update keep working on v%s." % to_version
-		if attached_bridges_follow(str(_post_update_outcome.get("from_version", "")), to_version)
+		"AI clients already using v%s can reconnect to v%s without restarting. Relaunch clients still using an older version." % [from_version, to_version]
+		if McpServerVersionCheck.attached_bridges_follow(from_version, to_version)
 		else "Quit and relaunch AI clients that were connected during the update so they use v%s."
 		% to_version
 	)
@@ -1283,13 +1263,6 @@ func _capture_lifecycle_plan() -> Dictionary:
 		"server_command": ClientConfigurator.get_server_command(),
 		"pid_file": ProjectSettings.globalize_path(PortResolver.SERVER_PID_FILE),
 		"startup_report": ProjectSettings.globalize_path(PortResolver.SERVER_STARTUP_REPORT),
-		## The lifecycle is configured before the post-update migration runs,
-		## so the arm's own state is not set yet; the recorded outcome is.
-		"probe_timeout_ms": (
-			POST_UPDATE_PROBE_TIMEOUT_MS
-			if str(_post_update_outcome.get("outcome", "")) == "success"
-			else ServerLifecycleManager.DEFAULT_PROBE_TIMEOUT_MS
-		),
 		"http_port_reserved": WindowsPortReservation.is_port_excluded(http_port),
 		"excluded_domains": str(policy.get("excluded_domains", "")),
 		"allow_hosts": str(policy.get("allow_hosts", "")),

--- a/plugin/addons/godot_ai/utils/plugin_reload.gd
+++ b/plugin/addons/godot_ai/utils/plugin_reload.gd
@@ -19,15 +19,37 @@ static var _scan_timeout_seconds: float = SCAN_TIMEOUT_SECONDS
 static var _pending_scan: Dictionary = {}
 
 
+static func is_reload_pending() -> bool:
+	return not _pending_scan.is_empty()
+
+
+## Reserve before deferring the scan so the current dispatcher tick cannot
+## start another handler which pumps the already-scheduled reload callback.
+static func reserve_reload() -> int:
+	if is_reload_pending():
+		return 0
+	var work := ScriptWork.begin("reload_plugin")
+	_pending_scan = {"work": work}
+	return work
+
+
 static func reload_after_scan(work: int = 0) -> void:
 	if work == 0:
-		work = ScriptWork.begin("reload_plugin")
+		work = reserve_reload()
+		if work == 0:
+			return
+	elif _pending_scan.get("work", 0) != work or bool(_pending_scan.get("toggling", false)):
+		return  # A direct reload or cancellation consumed this deferred request.
 	_start_scan(EditorInterface.get_resource_filesystem(), null, work)
 
 
 static func _start_scan(filesystem: Object, timer: Object, work: int) -> void:
-	if not _pending_scan.is_empty():
-		ScriptWork.finish(work)
+	if not _pending_scan.is_empty() and (
+		_pending_scan.get("work", 0) != work or _pending_scan.has("filesystem")
+		or bool(_pending_scan.get("toggling", false))
+	):
+		if _pending_scan.get("work", 0) != work:
+			ScriptWork.finish(work)
 		push_error("MCP | a plugin reload is already waiting for its filesystem scan")
 		return
 	if timer == null:
@@ -45,7 +67,7 @@ static func _start_scan(filesystem: Object, timer: Object, work: int) -> void:
 static func _take_scan() -> Dictionary:
 	var pending := _pending_scan
 	_pending_scan = {}
-	if not pending.is_empty():
+	if pending.has("filesystem"):
 		if pending.filesystem.filesystem_changed.is_connected(pending.complete):
 			pending.filesystem.filesystem_changed.disconnect(pending.complete)
 		if pending.timer.timeout.is_connected(pending.timeout):
@@ -55,24 +77,37 @@ static func _take_scan() -> Dictionary:
 
 static func _finish_scan(work: int, timed_out: bool) -> void:
 	# A queued callback from an earlier scan can never consume a later request.
-	if _pending_scan.get("work", 0) != work:
+	if _pending_scan.get("work", 0) != work or not _pending_scan.has("filesystem"):
 		return
-	var pending := _take_scan()
 	if timed_out:
+		var pending := _take_scan()
+		ScriptWork.finish(pending.work)
 		push_error(
 			"MCP | filesystem scan did not finish within %d s; plugin left unchanged, retry reload"
 			% int(_scan_timeout_seconds)
 		)
 	else:
 		reload_enabled_plugin()
-	ScriptWork.finish(pending.work)
 
 
 static func reload_enabled_plugin() -> Error:
-	# An explicit direct reload supersedes a still-pending ordinary scan.
+	# Keep the existing reservation through teardown: toggling the plugin can
+	# itself pump frames. Direct callers also gate dispatch during the toggle.
+	if not is_reload_pending():
+		reserve_reload()
+	elif bool(_pending_scan.get("toggling", false)):
+		return ERR_BUSY
+	# Disconnect scan signals before a toggle pumps frames, but retain the
+	# work reservation so already-queued callbacks cannot start another toggle.
 	var pending := _take_scan()
-	if not pending.is_empty():
-		ScriptWork.finish(pending.work)
+	_pending_scan = {"work": pending.work, "toggling": true}
+	var result := _toggle_enabled_plugin()
+	_take_scan()
+	ScriptWork.finish(pending.work)
+	return result
+
+
+static func _toggle_enabled_plugin() -> Error:
 	if not EditorInterface.is_plugin_enabled(PLUGIN_CFG):
 		push_error("MCP | cannot reload a disabled plugin")
 		return ERR_UNAVAILABLE

--- a/plugin/addons/godot_ai/utils/port_resolver.gd
+++ b/plugin/addons/godot_ai/utils/port_resolver.gd
@@ -173,6 +173,13 @@ static func execute_windows_powershell(script: String, output: Array) -> int:
 
 static func windows_powershell_candidates() -> Array[String]:
 	var candidates: Array[String] = []
+	## Prefer an already-installed PowerShell 7 at its fixed machine path.
+	## Missing or failing installations retain every existing fallback below.
+	var program_files := OS.get_environment("ProgramFiles").replace("\\", "/").trim_suffix("/")
+	if not program_files.is_empty():
+		var pwsh := program_files.path_join("PowerShell/7/pwsh.exe")
+		if FileAccess.file_exists(pwsh):
+			candidates.append(pwsh)
 	var system_root := OS.get_environment("SystemRoot")
 	if system_root.is_empty():
 		system_root = "C:/Windows"
@@ -336,9 +343,11 @@ static func clear_pid_file() -> void:
 ## uvx launcher lingers as a zombie forever and `kill -0` would block
 ## the spawn-failure branch in check_server_health from firing. Use
 ## `ps -o stat=` instead. State codes: R/S/D/I/T (live), Z (zombie). #172.
-static func pid_alive(pid: int) -> bool:
+static func pid_alive(pid: int, snapshot: Variant = null) -> bool:
 	if pid <= 0:
 		return false
+	if snapshot != null:
+		return not _process_snapshot_row(snapshot, pid).is_empty()
 	if OS.get_name() == "Windows":
 		var output: Array = []
 		var exit_code := OS.execute("tasklist", ["/FI", "PID eq %d" % pid, "/NH", "/FO", "CSV"], output, true)
@@ -359,9 +368,127 @@ static func pid_alive(pid: int) -> bool:
 ## Read-only process identity helpers.  Lifecycle authority is granted only
 ## after capturing a fingerprint and every later stop re-reads the fingerprint
 ## before acting, so PID reuse fails closed.
-static func process_commandline(pid: int) -> String:
+## One Windows query captures the target and at most fifteen ancestors. The
+## dictionary belongs to one proof boundary, never a cache: callers must take
+## a fresh snapshot when closing the capture window or authorizing a kill.
+## Non-Windows callers receive null and keep the existing live-query path.
+## The process enumeration stays inside PowerShell; only the bounded target
+## ancestry crosses back into Godot, without logging command-line metadata.
+static func capture_process_snapshot(pid: int) -> Variant:
+	if OS.get_name() != "Windows":
+		return null
+	if pid <= 1:
+		return {}
+	var script := _windows_process_snapshot_script(pid)
+	var output: Array = []
+	if execute_windows_powershell(script, output) != 0 or output.is_empty():
+		return {}
+	return parse_process_snapshot(str(output[0]), pid)
+
+
+static func _windows_process_snapshot_script(pid: int) -> String:
+	return (
+		"$rows = @(); $current = %d; $seen = @{}; "
+		+ "$processes = @{}; try { Get-CimInstance Win32_Process -ErrorAction Stop | "
+		+ "ForEach-Object { $processes[[int]$_.ProcessId] = $_ } } catch {}; "
+		+ "for ($depth = 0; $depth -lt 16 -and $current -gt 1; $depth++) { "
+		+ "if ($seen.ContainsKey($current)) { break }; $seen[$current] = $true; "
+		+ "$p = $processes[$current]; "
+		+ "if ($null -eq $p) { "
+		+ "try { $identity = [string](Get-Process -Id $current -ErrorAction Stop).StartTime.ToFileTimeUtc(); "
+		+ "$rows += @{pid=$current;parent_pid=0;identity=$identity;commandline=''} } catch {}; break }; "
+		+ "$rows += @{pid=[int]$p.ProcessId;parent_pid=[int]$p.ParentProcessId; "
+		+ "identity=([string]$p.CreationDate + '|' + [string]$p.CommandLine);commandline=[string]$p.CommandLine}; "
+		+ "$current = [int]$p.ParentProcessId }; "
+		+ "ConvertTo-Json -InputObject @($rows) -Compress -Depth 3"
+	) % pid
+
+
+## Independent CIM maps in separate scriptblock scopes are
+## captured within one shell invocation. No snapshot crosses a grant call.
+static func _capture_windows_process_snapshot_pair(pid: int) -> Array:
+	var query := _windows_process_snapshot_script(pid)
+	var script := (
+		"$first = & { %s }; $final = & { %s }; "
+		+ "ConvertTo-Json -InputObject @([string]$first,[string]$final) -Compress"
+	) % [query, query]
+	var output: Array = []
+	if execute_windows_powershell(script, output) != 0 or output.is_empty():
+		return [{}, {}]
+	return _parse_process_snapshot_pair(str(output[0]), pid)
+
+
+static func _parse_process_snapshot_pair(raw: String, pid: int) -> Array:
+	if raw.length() > 4 * 1024 * 1024 + 16:
+		return [{}, {}]
+	var pair: Variant = JSON.parse_string(raw)
+	if not (pair is Array) or pair.size() != 2 or not (pair[0] is String and pair[1] is String):
+		return [{}, {}]
+	return [parse_process_snapshot(pair[0], pid), parse_process_snapshot(pair[1], pid)]
+
+
+static func parse_process_snapshot(raw: String, expected_pid: int) -> Dictionary:
+	if raw.length() > 1024 * 1024:
+		return {}
+	var rows: Variant = JSON.parse_string(raw)
+	if not (rows is Array) or rows.is_empty() or rows.size() > 16:
+		return {}
+	var snapshot := {}
+	var next_pid := expected_pid
+	for row in rows:
+		if not (row is Dictionary):
+			return {}
+		var value: Variant = row.get("pid")
+		if (
+			not (value is int or value is float) or not is_finite(float(value))
+			or float(value) <= 1.0 or float(value) > 4294967295.0
+			or float(value) != float(int(value))
+		):
+			return {}
+		var pid := int(value)
+		if pid <= 1 or pid != next_pid or snapshot.has(pid):
+			return {}
+		snapshot[pid] = row
+		if _process_snapshot_row(snapshot, pid).is_empty():
+			return {}
+		next_pid = int(row.parent_pid)
+		if snapshot.has(next_pid):
+			return {}
+	return snapshot
+
+
+static func _process_snapshot_row(snapshot: Variant, pid: int) -> Dictionary:
+	if not (snapshot is Dictionary) or pid <= 1:
+		return {}
+	var row: Variant = snapshot.get(pid)
+	if not (row is Dictionary) or row.size() != 4:
+		return {}
+	var parent: Variant = row.get("parent_pid")
+	if (
+		row.get("pid") != pid
+		or not (parent is int or parent is float)
+		or not is_finite(float(parent)) or float(parent) < 0.0 or float(parent) > 4294967295.0
+		or float(parent) != float(int(parent))
+		or not (row.get("identity") is String) or str(row.identity).strip_edges().is_empty()
+		or not (row.get("commandline") is String)
+	):
+		return {}
+	var identity := str(row.identity)
+	var commandline := str(row.commandline)
+	var separator := identity.find("|")
+	if separator >= 0:
+		if separator == 0 or identity.substr(separator + 1) != commandline:
+			return {}
+	elif not identity.is_valid_int() or not commandline.is_empty() or int(parent) != 0:
+		return {}
+	return row
+
+
+static func process_commandline(pid: int, snapshot: Variant = null) -> String:
 	if pid <= 1:
 		return ""
+	if snapshot != null:
+		return str(_process_snapshot_row(snapshot, pid).get("commandline", ""))
 	if OS.get_name() == "Windows":
 		var output: Array = []
 		var script := (
@@ -394,9 +521,11 @@ static func process_commandline(pid: int) -> String:
 	return str(output[0]).strip_edges() if not output.is_empty() else ""
 
 
-static func process_parent(pid: int) -> int:
+static func process_parent(pid: int, snapshot: Variant = null) -> int:
 	if pid <= 1:
 		return 0
+	if snapshot != null:
+		return int(_process_snapshot_row(snapshot, pid).get("parent_pid", 0))
 	var output: Array = []
 	if OS.get_name() == "Windows":
 		var script := (
@@ -412,14 +541,18 @@ static func process_parent(pid: int) -> int:
 	return int(raw) if raw.is_valid_int() else 0
 
 
-static func process_descends_from(pid: int, ancestor_pid: int) -> bool:
+static func process_descends_from(pid: int, ancestor_pid: int, snapshot: Variant = null) -> bool:
 	if pid <= 1 or ancestor_pid <= 1:
+		return false
+	if snapshot != null and _process_snapshot_row(snapshot, pid).is_empty():
 		return false
 	var current := pid
 	for _depth in range(16):
+		if snapshot != null and _process_snapshot_row(snapshot, current).is_empty():
+			return false
 		if current == ancestor_pid:
 			return true
-		var parent := process_parent(current)
+		var parent := process_parent(current, snapshot)
 		if parent <= 1 or parent == current:
 			return false
 		current = parent
@@ -441,26 +574,28 @@ static func commandline_is_godot_ai_server(commandline: String) -> bool:
 	return branded and (lower.contains("--pid-file") or lower.contains("--transport"))
 
 
-static func pid_cmdline_is_godot_ai(pid: int) -> bool:
+static func pid_cmdline_is_godot_ai(pid: int, snapshot: Variant = null) -> bool:
 	var current := pid
 	for _depth in range(5):
 		if current <= 1:
 			return false
-		if commandline_is_godot_ai_server(process_commandline(current)):
+		if commandline_is_godot_ai_server(process_commandline(current, snapshot)):
 			return true
-		current = process_parent(current)
+		current = process_parent(current, snapshot)
 	return false
 
 
-static func process_fingerprint(pid: int) -> String:
-	if not pid_alive(pid):
+static func process_fingerprint(pid: int, snapshot: Variant = null) -> String:
+	if not pid_alive(pid, snapshot):
 		return ""
 	var output: Array = []
 	var identity := ""
-	if OS.get_name() == "Windows":
+	if snapshot != null:
+		identity = str(_process_snapshot_row(snapshot, pid).get("identity", "")).strip_edges()
+	elif OS.get_name() == "Windows":
 		var script := (
 			"Get-CimInstance Win32_Process -Filter 'ProcessId = %d' | "
-			+ "ForEach-Object { \"$($_.CreationDate)|$($_.CommandLine)\" }"
+			+ "ForEach-Object { [string]$_.CreationDate + '|' + [string]$_.CommandLine }"
 		) % pid
 		if execute_windows_powershell(script, output) == 0 and not output.is_empty():
 			identity = str(output[0]).strip_edges()
@@ -499,22 +634,25 @@ static func capture_process_kill_grant(
 	if pid <= 1 or pid == OS.get_process_id():
 		diagnostics.append("invalid_pid")
 		return {}
-	if not pid_alive(pid):
+	var pair: Array = _capture_windows_process_snapshot_pair(pid) if OS.get_name() == "Windows" else []
+	var first: Variant = pair[0] if not pair.is_empty() else capture_process_snapshot(pid)
+	if not pid_alive(pid, first):
 		diagnostics.append("not_alive")
 		return {}
-	if require_brand and not pid_cmdline_is_godot_ai(pid):
+	if require_brand and not pid_cmdline_is_godot_ai(pid, first):
 		diagnostics.append("unbranded")
 		return {}
-	var fingerprint := process_fingerprint(pid)
+	var fingerprint := process_fingerprint(pid, first)
 	if fingerprint.is_empty():
 		diagnostics.append("fingerprint_unavailable")
 		return {}
 	## Close the capture window: both identity and optional lineage/brand must
-	## still describe the same process after the fingerprint read.
-	if process_fingerprint(pid) != fingerprint:
+	## still describe the same process in the independently collected final snapshot.
+	var final: Variant = pair[1] if not pair.is_empty() else capture_process_snapshot(pid)
+	if process_fingerprint(pid, final) != fingerprint:
 		diagnostics.append("fingerprint_changed")
 		return {}
-	if require_brand and not pid_cmdline_is_godot_ai(pid):
+	if require_brand and not pid_cmdline_is_godot_ai(pid, final):
 		diagnostics.append("brand_changed")
 		return {}
 	return {"pid": pid, "fingerprint": fingerprint}
@@ -533,13 +671,12 @@ static func kill_exact_processes(
 			continue
 		var pid := int(grant.get("pid", 0))
 		var fingerprint := str(grant.get("fingerprint", ""))
+		if pid <= 1 or pid == OS.get_process_id() or seen.has(pid) or fingerprint.is_empty():
+			continue
+		var snapshot: Variant = capture_process_snapshot(pid)
 		if (
-			pid <= 1
-			or pid == OS.get_process_id()
-			or seen.has(pid)
-			or fingerprint.is_empty()
-			or process_fingerprint(pid) != fingerprint
-			or (require_brand and not pid_cmdline_is_godot_ai(pid))
+			process_fingerprint(pid, snapshot) != fingerprint
+			or (require_brand and not pid_cmdline_is_godot_ai(pid, snapshot))
 		):
 			continue
 		seen.append(pid)

--- a/plugin/addons/godot_ai/utils/port_resolver.gd
+++ b/plugin/addons/godot_ai/utils/port_resolver.gd
@@ -175,11 +175,12 @@ static func windows_powershell_candidates() -> Array[String]:
 	var candidates: Array[String] = []
 	## Prefer an already-installed PowerShell 7 at its fixed machine path.
 	## Missing or failing installations retain every existing fallback below.
-	var program_files := OS.get_environment("ProgramFiles").replace("\\", "/").trim_suffix("/")
-	if not program_files.is_empty():
-		var pwsh := program_files.path_join("PowerShell/7/pwsh.exe")
-		if FileAccess.file_exists(pwsh):
-			candidates.append(pwsh)
+	for variable in ["ProgramW6432", "ProgramFiles"]:
+		var program_files := OS.get_environment(variable).replace("\\", "/").trim_suffix("/")
+		if not program_files.is_empty():
+			var pwsh := program_files.path_join("PowerShell/7/pwsh.exe")
+			if FileAccess.file_exists(pwsh) and not candidates.has(pwsh):
+				candidates.append(pwsh)
 	var system_root := OS.get_environment("SystemRoot")
 	if system_root.is_empty():
 		system_root = "C:/Windows"
@@ -378,17 +379,17 @@ static func capture_process_snapshot(pid: int) -> Variant:
 	if OS.get_name() != "Windows":
 		return null
 	if pid <= 1:
-		return {}
+		return {"capture_error": true}
 	var script := _windows_process_snapshot_script(pid)
 	var output: Array = []
 	if execute_windows_powershell(script, output) != 0 or output.is_empty():
-		return {}
+		return {"capture_error": true}
 	return parse_process_snapshot(str(output[0]), pid)
 
 
 static func _windows_process_snapshot_script(pid: int) -> String:
 	return (
-		"$rows = @(); $current = %d; $seen = @{}; "
+		"$rows = @(); $current = %d; $seen = @{}; $capture_failed = $false; "
 		+ "$processes = @{}; try { Get-CimInstance Win32_Process -ErrorAction Stop | "
 		+ "ForEach-Object { $processes[[int]$_.ProcessId] = $_ } } catch {}; "
 		+ "for ($depth = 0; $depth -lt 16 -and $current -gt 1; $depth++) { "
@@ -396,11 +397,11 @@ static func _windows_process_snapshot_script(pid: int) -> String:
 		+ "$p = $processes[$current]; "
 		+ "if ($null -eq $p) { "
 		+ "try { $identity = [string](Get-Process -Id $current -ErrorAction Stop).StartTime.ToFileTimeUtc(); "
-		+ "$rows += @{pid=$current;parent_pid=0;identity=$identity;commandline=''} } catch {}; break }; "
+		+ "$rows += @{pid=$current;parent_pid=0;identity=$identity;commandline=''} } catch { if ($_.CategoryInfo.Category -ne 'ObjectNotFound') { $capture_failed = $true } }; break }; "
 		+ "$rows += @{pid=[int]$p.ProcessId;parent_pid=[int]$p.ParentProcessId; "
 		+ "identity=([string]$p.CreationDate + '|' + [string]$p.CommandLine);commandline=[string]$p.CommandLine}; "
 		+ "$current = [int]$p.ParentProcessId }; "
-		+ "ConvertTo-Json -InputObject @($rows) -Compress -Depth 3"
+		+ "if ($capture_failed) { 'null' } else { ConvertTo-Json -InputObject @($rows) -Compress -Depth 3 }"
 	) % pid
 
 
@@ -414,51 +415,62 @@ static func _capture_windows_process_snapshot_pair(pid: int) -> Array:
 	) % [query, query]
 	var output: Array = []
 	if execute_windows_powershell(script, output) != 0 or output.is_empty():
-		return [{}, {}]
+		return [{"capture_error": true}, {"capture_error": true}]
 	return _parse_process_snapshot_pair(str(output[0]), pid)
 
 
 static func _parse_process_snapshot_pair(raw: String, pid: int) -> Array:
 	if raw.length() > 4 * 1024 * 1024 + 16:
-		return [{}, {}]
-	var pair: Variant = JSON.parse_string(raw)
+		return [{"capture_error": true}, {"capture_error": true}]
+	var json := JSON.new()
+	if json.parse(raw) != OK:
+		return [{"capture_error": true}, {"capture_error": true}]
+	var pair: Variant = json.data
 	if not (pair is Array) or pair.size() != 2 or not (pair[0] is String and pair[1] is String):
-		return [{}, {}]
+		return [{"capture_error": true}, {"capture_error": true}]
 	return [parse_process_snapshot(pair[0], pid), parse_process_snapshot(pair[1], pid)]
 
 
 static func parse_process_snapshot(raw: String, expected_pid: int) -> Dictionary:
 	if raw.length() > 1024 * 1024:
-		return {}
-	var rows: Variant = JSON.parse_string(raw)
-	if not (rows is Array) or rows.is_empty() or rows.size() > 16:
-		return {}
+		return {"capture_error": true}
+	var json := JSON.new()
+	if json.parse(raw) != OK:
+		return {"capture_error": true}
+	var rows: Variant = json.data
+	if not (rows is Array) or rows.size() > 16:
+		return {"capture_error": true}
 	var snapshot := {}
 	var next_pid := expected_pid
 	for row in rows:
 		if not (row is Dictionary):
-			return {}
+			return {"capture_error": true}
 		var value: Variant = row.get("pid")
 		if (
 			not (value is int or value is float) or not is_finite(float(value))
 			or float(value) <= 1.0 or float(value) > 4294967295.0
 			or float(value) != float(int(value))
 		):
-			return {}
+			return {"capture_error": true}
 		var pid := int(value)
 		if pid <= 1 or pid != next_pid or snapshot.has(pid):
-			return {}
+			return {"capture_error": true}
 		snapshot[pid] = row
 		if _process_snapshot_row(snapshot, pid).is_empty():
-			return {}
+			return {"capture_error": true}
 		next_pid = int(row.parent_pid)
 		if snapshot.has(next_pid):
-			return {}
+			return {"capture_error": true}
 	return snapshot
 
 
+## An unavailable capture is not evidence that its PID has exited.
+static func capture_failed(snapshot: Variant) -> bool:
+	return snapshot is Dictionary and bool(snapshot.get("capture_error", false))
+
+
 static func _process_snapshot_row(snapshot: Variant, pid: int) -> Dictionary:
-	if not (snapshot is Dictionary) or pid <= 1:
+	if not (snapshot is Dictionary) or capture_failed(snapshot) or pid <= 1:
 		return {}
 	var row: Variant = snapshot.get(pid)
 	if not (row is Dictionary) or row.size() != 4:
@@ -636,6 +648,9 @@ static func capture_process_kill_grant(
 		return {}
 	var pair: Array = _capture_windows_process_snapshot_pair(pid) if OS.get_name() == "Windows" else []
 	var first: Variant = pair[0] if not pair.is_empty() else capture_process_snapshot(pid)
+	if capture_failed(first):
+		diagnostics.append("identity_unavailable")
+		return {}
 	if not pid_alive(pid, first):
 		diagnostics.append("not_alive")
 		return {}
@@ -649,6 +664,9 @@ static func capture_process_kill_grant(
 	## Close the capture window: both identity and optional lineage/brand must
 	## still describe the same process in the independently collected final snapshot.
 	var final: Variant = pair[1] if not pair.is_empty() else capture_process_snapshot(pid)
+	if capture_failed(final):
+		diagnostics.append("identity_unavailable")
+		return {}
 	if process_fingerprint(pid, final) != fingerprint:
 		diagnostics.append("fingerprint_changed")
 		return {}

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -23,10 +23,11 @@ const READY := "READY"
 const BLOCKED := "BLOCKED"
 const RECOVERING := "RECOVERING"
 ## How long a server launched to replace an occupant may wait for the port.
-## 15 s, not 5: on Windows every identity probe is a PowerShell start (about
-## 0.6 s each) and the launch must capture the new process, then re-read and
-## kill the old one, before the replacement gives up waiting for the port.
-const REPLACEMENT_WAIT_FOR_PORT_MS := 15_000
+## A Windows update took 25.262 s from the child's port-wait phase until the
+## incumbent released the port. Keep time for those exact identity checks
+## and termination before the child gives up. Python caps this at the same
+## 60 s; the later capability proof has its own 180 s deadline.
+const REPLACEMENT_WAIT_FOR_PORT_MS := 60_000
 ## How long the replacement gives its launched server to reach that port
 ## wait before it kills the occupant. The launch may be uvx installing the
 ## version the update just brought in; until the server reports it is at its
@@ -43,7 +44,9 @@ const REPLACE := "REPLACE"
 const STOP := "STOP"
 
 const STATUS_PATH := "/godot-ai/status"
-const DEFAULT_PROBE_TIMEOUT_MS := 800
+## Normal starts and recovery need the same settling window as post-update
+## adoption. A healthy authenticated status response can take over a second.
+const DEFAULT_PROBE_TIMEOUT_MS := 3000
 const STALE_PRE_V4_HINT := "stale_pre_v4_server"
 const DEFAULT_PROVE_TIMEOUT_MS := 180_000
 const LAUNCH_FINGERPRINT_TIMEOUT_MS := 15_000
@@ -127,6 +130,7 @@ func _begin_start_episode(existing_id := 0, probe := true) -> void:
 		"expected_version": str(_plan.expected_version),
 		"expected_ws_port": int(_plan.ws_port),
 		"timeout_ms": int(_plan.probe_timeout_ms),
+		"grant": _process_grant,
 	})
 
 
@@ -344,7 +348,9 @@ func recover_lost_endpoint(episode_id: int) -> bool:
 		_endpoint_recovery_pending_episode = 0
 		return false
 	_endpoint_recovery_pending_episode = 0
-	start_server()
+	## Losing a socket does not prove that the shared backend needs restarting.
+	## The probe retains ownership only after checking the exact listener again.
+	_begin_start_episode()
 	return str(_episode.get("state")) != BLOCKED
 
 
@@ -386,9 +392,20 @@ func _complete_probe(result: Dictionary) -> void:
 			if transport == null or not transport.is_valid():
 				_block("invalid_transport", "The server returned invalid transport authority.")
 				return
-			_process_grant = null
-			_ready("adopted", transport, str(result.get("version", "")))
+			var disposition := str(result.get("owned_disposition", ""))
+			if _process_grant != null and disposition == "owned":
+				_ready("owned", transport, str(result.get("version", "")))
+			elif _process_grant == null or disposition in ["gone", "replaced"]:
+				_process_grant = null
+				_ready("adopted", transport, str(result.get("version", "")))
+			else:
+				_block("process_authority_mismatch", "Managed process identity could not be proven during recovery. Click Restart to retry.")
 		"free":
+			if _process_grant != null:
+				if str(result.get("owned_disposition", "")) not in ["gone", "replaced"]:
+					_block("process_authority_mismatch", "The managed process is still running without a proven endpoint. Click Restart to retry.")
+					return
+				_process_grant = null
 			_episode["phase"] = LAUNCH
 			_episode["message"] = "Launching the managed server."
 			_publish()
@@ -672,14 +689,32 @@ func _effect_probe(payload: Dictionary) -> Dictionary:
 	var port := int(payload.http_port)
 	var expected_version := str(payload.expected_version)
 	var expected_ws_port := int(payload.expected_ws_port)
+	var grant = payload.get("grant")
+	var disposition := "gone"
+	if grant != null:
+		var pid := int(grant.process_id())
+		var alive := PortResolver.pid_alive(pid)
+		disposition = _owned_process_disposition(
+			grant, alive, PortResolver.process_fingerprint(pid) if alive else "",
+		)
+		if disposition == "unproven":
+			return _blocked_probe_result("process_authority_mismatch", port, {}, false,
+				"managed process identity could not be proven; click Restart to retry")
 	var capability := _read_capability(port)
 	var live := _probe_with_capability(port, capability, int(payload.timeout_ms))
 	if _authenticated_status_matches_record(live, capability):
 		var version := str(live.get("version", ""))
 		var ws_port := int(live.get("ws_port", 0))
 		if _server_status_compatibility(version, expected_version, ws_port, expected_ws_port).get("compatible", false):
+			if disposition == "owned" and (
+				not PortResolver.find_all_pids_on_port(port).has(int(grant.process_id()))
+				or not grant.matches(int(grant.process_id()), PortResolver.process_fingerprint(int(grant.process_id())))
+			):
+				return _blocked_probe_result("process_authority_mismatch", port, live, false,
+					"the authenticated endpoint does not match the managed process; click Restart to retry")
 			return {
 				"outcome": "compatible",
+				"owned_disposition": disposition,
 				"version": version,
 				"transport": _transport_from(port, ws_port, live, capability),
 			}
@@ -699,6 +734,7 @@ func _effect_probe(payload: Dictionary) -> Dictionary:
 		return ws_port_blocked_result(expected_ws_port)
 	return {
 		"outcome": "free",
+		"owned_disposition": disposition,
 		"baseline_instance_id": str(capability.get("instance_nonce", "")),
 	}
 
@@ -851,9 +887,24 @@ static func _launch_unproven_message(pid: int, attempts: Array, elapsed_ms: int)
 func _effect_prove(payload: Dictionary) -> Dictionary:
 	var launch_grant = payload.get("grant")
 	var launch_pid := int(launch_grant.process_id()) if launch_grant != null else -1
-	var launch_alive := PortResolver.pid_alive(launch_pid)
+	## The pid file is an untrusted hint. Reuse its ancestor snapshot only
+	## when it includes the launcher; the original PID read and all final
+	## capability, listener, identity, and lineage checks still follow.
+	var hinted_pid := -1
+	var first_snapshot: Variant = null
+	var launch_snapshot: Variant = null
+	if OS.get_name() == "Windows" and launch_pid > 1:
+		hinted_pid = PortResolver.read_pid_file(str(payload.get("pid_file", "")))
+		if hinted_pid > 1:
+			first_snapshot = PortResolver.capture_process_snapshot(hinted_pid)
+			if PortResolver.process_descends_from(hinted_pid, launch_pid, first_snapshot):
+				launch_snapshot = first_snapshot
+	if launch_snapshot == null:
+		launch_snapshot = PortResolver.capture_process_snapshot(launch_pid)
+		first_snapshot = null
+	var launch_alive := PortResolver.pid_alive(launch_pid, launch_snapshot)
 	var launch_fingerprint := (
-		PortResolver.process_fingerprint(launch_pid)
+		PortResolver.process_fingerprint(launch_pid, launch_snapshot)
 		if launch_alive
 		else ""
 	)
@@ -894,11 +945,15 @@ func _effect_prove(payload: Dictionary) -> Dictionary:
 		return {"pending": true, "reason": "pid_file"}
 	if not PortResolver.find_all_pids_on_port(port).has(pid):
 		return {"pending": true, "reason": "listener_pid"}
-	if not PortResolver.pid_cmdline_is_godot_ai(pid):
+	if first_snapshot == null or pid != hinted_pid:
+		first_snapshot = (
+			launch_snapshot if pid == launch_pid else PortResolver.capture_process_snapshot(pid)
+		)
+	if not PortResolver.pid_cmdline_is_godot_ai(pid, first_snapshot):
 		return {"pending": true, "reason": "process_brand"}
-	if not PortResolver.process_descends_from(pid, launch_pid):
+	if not PortResolver.process_descends_from(pid, launch_pid, first_snapshot):
 		return {"pending": true, "reason": "launch_lineage"}
-	var fingerprint := PortResolver.process_fingerprint(pid)
+	var fingerprint := PortResolver.process_fingerprint(pid, first_snapshot)
 	if fingerprint.is_empty():
 		return {"pending": true, "reason": "process_fingerprint"}
 	## Close every capture window before minting process authority. The same
@@ -907,11 +962,13 @@ func _effect_prove(payload: Dictionary) -> Dictionary:
 	## fingerprint must remain unchanged after the final probe.
 	var final_capability := _read_capability(port)
 	var final_live := _probe_with_capability(port, final_capability, int(payload.timeout_ms))
+	var final_snapshot: Variant = PortResolver.capture_process_snapshot(pid)
 	if (
 		PortResolver.read_pid_file(str(payload.get("pid_file", ""))) != pid
 		or not PortResolver.find_all_pids_on_port(port).has(pid)
-		or not PortResolver.process_descends_from(pid, launch_pid)
-		or PortResolver.process_fingerprint(pid) != fingerprint
+		or not PortResolver.process_descends_from(pid, launch_pid, final_snapshot)
+		or not PortResolver.pid_cmdline_is_godot_ai(pid, final_snapshot)
+		or PortResolver.process_fingerprint(pid, final_snapshot) != fingerprint
 		or final_capability != capability
 		or not _authenticated_status_matches_record(final_live, final_capability)
 		or str(final_live.get("instance_id", "")) != str(live.get("instance_id", ""))
@@ -1217,6 +1274,12 @@ static func _probe_with_capability(port: int, capability: Dictionary, timeout_ms
 	var http_capability := str(capability.get("http", ""))
 	if http_capability.is_empty():
 		result.error = "missing_capability"
+		return result
+	## Windows can otherwise spend the whole connect deadline on an unbound
+	## loopback port. This is only an unreachable probe; callers still check
+	## occupancy and prove any later listener before using it.
+	if OS.get_name() == "Windows" and PortResolver.can_bind_local_port(port):
+		result.error = "port_unbound"
 		return result
 	var client := HTTPClient.new()
 	var error := client.connect_to_host("127.0.0.1", port)

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -854,9 +854,10 @@ func _effect_launch(payload: Dictionary) -> Dictionary:
 ## (#988, #1012 both surfaced as this bare sentence). Diagnostic only: the
 ## values are read once more after the capture budget and never grant
 ## authority.
-static func _launch_unproven_message(pid: int, attempts: Array, elapsed_ms: int) -> String:
-	var alive := PortResolver.pid_alive(pid)
-	var commandline := PortResolver.process_commandline(pid) if alive else ""
+func _launch_unproven_message(pid: int, attempts: Array, elapsed_ms: int) -> String:
+	var snapshot: Variant = _capture_process_snapshot(pid)
+	var alive := PortResolver.pid_alive(pid, snapshot)
+	var commandline := PortResolver.process_commandline(pid, snapshot) if alive else ""
 	if commandline.length() > 200:
 		commandline = commandline.substr(0, 199) + "…"
 	## Summarise the per-attempt refusals as "reason×count" in first-seen order.
@@ -878,10 +879,14 @@ static func _launch_unproven_message(pid: int, attempts: Array, elapsed_ms: int)
 		attempts.size(),
 		elapsed_ms / 1000.0,
 		pid,
-		"yes" if alive else "no",
+		"unknown" if PortResolver.capture_failed(snapshot) else ("yes" if alive else "no"),
 		", ".join(summary) if not summary.is_empty() else "none recorded",
 		"" if commandline.is_empty() else "; command: " + commandline,
 	]
+
+
+func _capture_process_snapshot(pid: int) -> Variant:
+	return PortResolver.capture_process_snapshot(pid)
 
 
 func _effect_prove(payload: Dictionary) -> Dictionary:
@@ -896,12 +901,14 @@ func _effect_prove(payload: Dictionary) -> Dictionary:
 	if OS.get_name() == "Windows" and launch_pid > 1:
 		hinted_pid = PortResolver.read_pid_file(str(payload.get("pid_file", "")))
 		if hinted_pid > 1:
-			first_snapshot = PortResolver.capture_process_snapshot(hinted_pid)
+			first_snapshot = _capture_process_snapshot(hinted_pid)
 			if PortResolver.process_descends_from(hinted_pid, launch_pid, first_snapshot):
 				launch_snapshot = first_snapshot
 	if launch_snapshot == null:
-		launch_snapshot = PortResolver.capture_process_snapshot(launch_pid)
+		launch_snapshot = _capture_process_snapshot(launch_pid)
 		first_snapshot = null
+	if PortResolver.capture_failed(launch_snapshot):
+		return {"pending": true, "reason": "identity_unavailable"}
 	var launch_alive := PortResolver.pid_alive(launch_pid, launch_snapshot)
 	var launch_fingerprint := (
 		PortResolver.process_fingerprint(launch_pid, launch_snapshot)
@@ -947,8 +954,10 @@ func _effect_prove(payload: Dictionary) -> Dictionary:
 		return {"pending": true, "reason": "listener_pid"}
 	if first_snapshot == null or pid != hinted_pid:
 		first_snapshot = (
-			launch_snapshot if pid == launch_pid else PortResolver.capture_process_snapshot(pid)
+			launch_snapshot if pid == launch_pid else _capture_process_snapshot(pid)
 		)
+	if PortResolver.capture_failed(first_snapshot):
+		return {"pending": true, "reason": "identity_unavailable"}
 	if not PortResolver.pid_cmdline_is_godot_ai(pid, first_snapshot):
 		return {"pending": true, "reason": "process_brand"}
 	if not PortResolver.process_descends_from(pid, launch_pid, first_snapshot):
@@ -962,7 +971,9 @@ func _effect_prove(payload: Dictionary) -> Dictionary:
 	## fingerprint must remain unchanged after the final probe.
 	var final_capability := _read_capability(port)
 	var final_live := _probe_with_capability(port, final_capability, int(payload.timeout_ms))
-	var final_snapshot: Variant = PortResolver.capture_process_snapshot(pid)
+	var final_snapshot: Variant = _capture_process_snapshot(pid)
+	if PortResolver.capture_failed(final_snapshot):
+		return {"pending": true, "reason": "identity_unavailable"}
 	if (
 		PortResolver.read_pid_file(str(payload.get("pid_file", ""))) != pid
 		or not PortResolver.find_all_pids_on_port(port).has(pid)

--- a/plugin/addons/godot_ai/utils/server_version_check.gd
+++ b/plugin/addons/godot_ai/utils/server_version_check.gd
@@ -6,6 +6,21 @@ extends RefCounted
 ## handshake and episode transition; this class intentionally owns no timer,
 ## connection, or manager reference.
 
+## First release whose attached bridge follows servers of the same major.
+const FIRST_BRIDGE_TOLERANT_VERSION := "4.0.4"
+
+
+## Whether clients attached at `from_version` can reconnect after updating
+## to `to_version` without restarting their bridge (#1024).
+static func attached_bridges_follow(from_version: String, to_version: String) -> bool:
+	var from_tuple := version_tuple(from_version)
+	var to_tuple := version_tuple(to_version)
+	if from_tuple.is_empty() or to_tuple.is_empty():
+		return false
+	if int(from_tuple[0]) != int(to_tuple[0]):
+		return false
+	return compare(from_tuple, version_tuple(FIRST_BRIDGE_TOLERANT_VERSION)) >= 0
+
 
 ## Leading numeric `major.minor.patch` of a version as `[major, minor, patch]`,
 ## or `[]` when it does not start that way (a dev build, a malformed pin).

--- a/plugin/addons/godot_ai/utils/transport_capability.gd
+++ b/plugin/addons/godot_ai/utils/transport_capability.gd
@@ -269,24 +269,13 @@ static func directory_write_problem_for(directory: String) -> String:
 
 
 static func windows_repair_hint(directory: String, detail: String) -> String:
-	var root := directory
-	var current := directory
-	while not current.is_empty():
-		if current.get_file() == "godot-ai":
-			root = current
-			break
-		var parent := current.get_base_dir()
-		if parent.is_empty() or parent == current:
-			break
-		current = parent
 	return (
-		"Godot AI cannot use its private directory %s (%s): this Windows account "
-		+ "has no access to it, which happens when it was first created by an "
-		+ "elevated (Run as administrator) process. Close Godot and every AI "
-		+ "client, then from an elevated PowerShell run: "
-		+ "Remove-Item -Recurse -Force \"%s\" ; reopen the project unelevated and "
-		+ "the directory is recreated with your account's permissions."
-	) % [directory, detail, root]
+		"Godot AI cannot use the directory %s (%s): this Windows account cannot "
+		+ "access it. This can happen when an elevated (Run as administrator) "
+		+ "process created it. Check this directory's permissions and grant your "
+		+ "Windows account access, then reopen Godot and your AI clients without "
+		+ "Run as administrator."
+	) % [directory, detail]
 
 
 static func path_for_http_port(http_port: int) -> String:

--- a/script/local-self-update-smoke
+++ b/script/local-self-update-smoke
@@ -1236,7 +1236,7 @@ def print_instructions(
         print("  crash report: non-macOS; .ips check is skipped")
     print("")
     print("Manual step:")
-    print("  1. In the Godot AI dock, click Update, then confirm 'Save & Update'.")
+    print("  1. In the Godot AI dock, click Update, then confirm the update dialog.")
     print("  2. The editor verifies, stages and swaps the bundle, prints")
     print(f"     '... {SMOKE_SWAP_LOG_SUFFIX}' and restarts itself. Nothing else to click.")
     print(f"  3. The restarted editor verifies the tree, prints '{SMOKE_MIGRATED_LOG}',")

--- a/src/godot_ai/__init__.py
+++ b/src/godot_ai/__init__.py
@@ -156,7 +156,9 @@ def preflight_check_port(
 WAIT_FOR_PORT_ENV = "GODOT_AI_WAIT_FOR_PORT_MS"
 LAUNCH_ID_ENV = "GODOT_AI_LAUNCH_ID"
 WAIT_FOR_PORT_RETRY_SECONDS = 0.05
-WAIT_FOR_PORT_MAX_SECONDS = 30.0
+# Match the plugin's bounded replacement wait. Windows identity checks and
+# termination have taken over 25 seconds after this process entered the wait.
+WAIT_FOR_PORT_MAX_SECONDS = 60.0
 
 
 def _wait_for_port_seconds() -> float:

--- a/src/godot_ai/attach/ensure.py
+++ b/src/godot_ai/attach/ensure.py
@@ -188,8 +188,8 @@ def user_runtime_dir() -> Path:
             f"Choose a private directory owned by your user with {RUNTIME_DIR_ENV}, "
             "or correct the directory ownership and permissions."
         )
-        ## The destructive repair is only ever offered for our own default
-        ## location; a GODOT_AI_RUNTIME_DIR override is the user's directory.
+        ## Explain Windows permissions for the default location; an explicit
+        ## runtime override retains the directory-selection guidance above.
         if os.name == "nt" and isinstance(exc, PermissionError) and not override:
             hint = windows_repair_hint(path)
         raise AttachStartupError(

--- a/src/godot_ai/transport/capability.py
+++ b/src/godot_ai/transport/capability.py
@@ -280,32 +280,13 @@ def private_mkdir(path: Path, *, windows: bool | None = None) -> None:
 
 
 def windows_repair_hint(directory: Path) -> str:
-    """How a user repairs a private directory their account cannot use.
-
-    The destructive step (remove the ``godot-ai`` tree and let it be
-    recreated) is offered only for a path inside a directory named
-    ``godot-ai``, which is the layout we create under ``%LOCALAPPDATA%``.
-    A path the user chose themselves gets non-destructive guidance.
-    """
-
-    root = None
-    for candidate in (directory, *directory.parents):
-        if candidate.name == "godot-ai":
-            root = candidate
-            break
-    if root is None:
-        return (
-            f"Godot AI cannot use the directory {directory}: this Windows account "
-            "has no access to it. Grant your account full control of that "
-            "directory, or point Godot AI at a directory your account owns."
-        )
+    """Directory-specific permission guidance without destructive repair commands."""
     return (
-        f"Godot AI cannot use its private directory {directory}: this Windows "
-        "account has no access to it, which happens when it was first created "
-        "by an elevated (Run as administrator) process. Close Godot and every "
-        "AI client, then from an elevated PowerShell run: "
-        f'Remove-Item -Recurse -Force "{root}" ; reopen the project unelevated '
-        "and the directory is recreated with your account's permissions."
+        f"Godot AI cannot use the directory {directory}: this Windows account "
+        "cannot access it. This can happen when an elevated (Run as administrator) "
+        "process created it. Check this directory's permissions and grant your "
+        "Windows account access, then reopen Godot and your AI clients without "
+        "Run as administrator."
     )
 
 

--- a/test_project/tests/test_batch.gd
+++ b/test_project/tests/test_batch.gd
@@ -76,13 +76,16 @@ func setup() -> void:
 
 
 func test_reload_is_rejected_before_any_batch_command_runs() -> void:
+	_dispatcher.register("reload_plugin", func(_p: Dictionary) -> Dictionary:
+		_call_log.append("reload_plugin")
+		return {"data": {"undoable": false}})
 	var result: Dictionary = _handler.batch_execute({"commands": [
 		{"command": "_ok_pure", "params": {}},
 		{"command": "reload_plugin", "params": {}},
 		{"command": "_ok_pure", "params": {}},
 	]})
-	assert_true(result.has("error"))
-	assert_contains(str(result.error.message), "reload_plugin")
+	assert_is_error(result, ErrorCodes.VALUE_OUT_OF_RANGE)
+	assert_contains(str(result.get("error", {}).get("message", "")), "reload_plugin must be called directly")
 	assert_eq(_call_log, [], "reload cannot leave an executing batch behind")
 
 

--- a/test_project/tests/test_batch.gd
+++ b/test_project/tests/test_batch.gd
@@ -75,6 +75,17 @@ func setup() -> void:
 	_call_log.clear()
 
 
+func test_reload_is_rejected_before_any_batch_command_runs() -> void:
+	var result: Dictionary = _handler.batch_execute({"commands": [
+		{"command": "_ok_pure", "params": {}},
+		{"command": "reload_plugin", "params": {}},
+		{"command": "_ok_pure", "params": {}},
+	]})
+	assert_true(result.has("error"))
+	assert_contains(str(result.error.message), "reload_plugin")
+	assert_eq(_call_log, [], "reload cannot leave an executing batch behind")
+
+
 func _undo_for_scene(scene_root: Node) -> UndoRedo:
 	return _undo_redo.get_history_undo_redo(_undo_redo.get_object_history_id(scene_root))
 

--- a/test_project/tests/test_cli_exec.gd
+++ b/test_project/tests/test_cli_exec.gd
@@ -128,14 +128,19 @@ func test_run_cancels_subprocess_without_reporting_timeout() -> void:
 		skip("No /bin/sleep or /usr/bin/sleep on this host")
 		return
 	var started_msec := Time.get_ticks_msec()
+	var cancellation_polls := [0]
+	var cancel_once := func() -> bool:
+		cancellation_polls[0] += 1
+		return cancellation_polls[0] == 1
 	var result := McpCliExec.run(
-		sleep_exe, ["5"], 5000, true, func() -> bool: return true
+		sleep_exe, ["5"], 5000, true, cancel_once
 	)
 	var elapsed_msec := Time.get_ticks_msec() - started_msec
 	assert_true(bool(result.get("cancelled", false)),
 		"a requested stop must be reported as cancellation")
 	assert_false(bool(result.get("timed_out", false)),
 		"cooperative shutdown is not a wall-clock timeout")
+	assert_eq(cancellation_polls[0], 1, "a quick-window cancellation stays latched through cleanup")
 	assert_eq(int(result.get("exit_code", 0)), -1)
 	assert_true(bool(result.get("termination_failed", false)),
 		"POSIX cancellation cannot prove the launcher had no descendants")

--- a/test_project/tests/test_clients.gd
+++ b/test_project/tests/test_clients.gd
@@ -4164,6 +4164,46 @@ func test_claude_desktop_migration_omits_empty_env() -> void:
 	assert_false(entry.has("env"), "an env object emptied by migration must be omitted")
 
 
+func test_consoleless_python_keeps_direct_sibling_without_probe() -> void:
+	var directory := _scratch_dir.path_join("direct_python")
+	DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path(directory))
+	var python := ProjectSettings.globalize_path(directory.path_join("python.exe"))
+	var pythonw := ProjectSettings.globalize_path(directory.path_join("pythonw.exe"))
+	_write_text(python, "fixture interpreter")
+	_write_text(pythonw, "fixture GUI interpreter")
+	assert_eq(McpClientConfigurator._consoleless_python_for_interpreter(
+		python, {"exit_code": 1, "stdout": ""}
+	), pythonw, "an installed sibling needs no subprocess")
+
+
+func test_consoleless_python_resolves_uv_launcher_base_interpreter() -> void:
+	var directory := _scratch_dir.path_join("managed_python")
+	DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path(directory))
+	var launcher := ProjectSettings.globalize_path(_scratch_dir.path_join("python3.14.exe"))
+	var python := ProjectSettings.globalize_path(directory.path_join("python.exe"))
+	var pythonw := ProjectSettings.globalize_path(directory.path_join("pythonw.exe"))
+	_write_text(launcher, "fixture uv launcher")
+	_write_text(python, "fixture base interpreter")
+	_write_text(pythonw, "fixture GUI interpreter")
+	assert_eq(McpClientConfigurator._consoleless_python_for_interpreter(
+		launcher, {"exit_code": 0, "stdout": python + "\r\n"}
+	), pythonw, "a launcher without a sibling resolves the installed GUI interpreter")
+	for invalid in [
+		{"exit_code": 1, "stdout": python},
+		{"exit_code": 0, "stdout": "relative/python.exe"},
+		{"exit_code": 0, "stdout": python + "\nextra output"},
+		{"exit_code": 0, "stdout": python + ".missing"},
+		{"exit_code": 0, "stdout": 42},
+	]:
+		assert_eq(McpClientConfigurator._consoleless_python_for_interpreter(
+			launcher, invalid
+		), "", "failed or malformed interpreter discovery must not produce a launch")
+	DirAccess.remove_absolute(pythonw)
+	assert_eq(McpClientConfigurator._consoleless_python_for_interpreter(
+		launcher, {"exit_code": 0, "stdout": python}
+	), "", "a missing GUI interpreter must keep discovery unavailable")
+
+
 func test_claude_desktop_missing_launch_is_error_without_write() -> void:
 	var path := _scratch_dir.path_join("claude_attach_missing_launch.json")
 	_remove_if_exists(path)

--- a/test_project/tests/test_dispatcher.gd
+++ b/test_project/tests/test_dispatcher.gd
@@ -4,6 +4,16 @@ extends McpTestSuite
 const ErrorCodes := preload("res://addons/godot_ai/utils/error_codes.gd")
 const ProjectHandler := preload("res://addons/godot_ai/handlers/project_handler.gd")
 const ScriptWork := preload("res://addons/godot_ai/utils/script_work.gd")
+const PluginReload := preload("res://addons/godot_ai/utils/plugin_reload.gd")
+
+class _ReloadFilesystem extends RefCounted:
+	signal filesystem_changed
+	var scans := 0
+	func scan() -> void:
+		scans += 1
+
+class _ReloadDeadline extends RefCounted:
+	signal timeout
 
 ## Tests for McpDispatcher — specifically the crash-detection guardrail
 ## that catches handlers returning malformed results (null, empty dict,
@@ -313,6 +323,81 @@ func test_tick_suppresses_deferred_response_and_threads_request_id() -> void:
 
 
 # ----- envelope-level readiness stamp (server-side stale-cache self-heal) -----
+
+
+func test_nested_tick_cannot_repeat_or_reorder_queued_commands() -> void:
+	var d := _make_dispatcher()
+	d.mcp_logging = false
+	var calls: Array[String] = []
+	var nested: Array[Dictionary] = []
+	d.register("pumps_editor", func(_p):
+		calls.append("first")
+		if calls.size() == 1:
+			d.enqueue({"request_id": "third", "command": "later", "params": {"value": "third"}})
+			nested.assign(d.tick(100.0))
+		return {"data": {"value": "first"}}
+	)
+	d.register("later", func(p):
+		calls.append(p.value)
+		return {"data": {"value": p.value}}
+	)
+	d.enqueue({"request_id": "first", "command": "pumps_editor", "params": {}})
+	d.enqueue({"request_id": "second", "command": "later", "params": {"value": "second"}})
+	var responses := d.tick(100.0)
+	assert_eq(nested.size(), 0, "a reentered tick must not dispatch or emit responses")
+	assert_eq(calls, ["first", "second", "third"], "queued commands execute once in order")
+	var returned_ids: Array[String] = []
+	var returned_values: Array[String] = []
+	for response in responses:
+		returned_ids.append(response.request_id)
+		returned_values.append(response.data.value)
+	assert_eq(returned_ids, ["first", "second", "third"])
+	assert_eq(returned_values, ["first", "second", "third"])
+	d.enqueue({"request_id": "fourth", "command": "later", "params": {"value": "fourth"}})
+	responses = d.tick(100.0)
+	assert_eq(responses.size(), 1, "the outer tick releases the guard for later frames")
+	assert_eq(responses[0].data.value, "fourth")
+	assert_eq(d.tick(100.0).size(), 0, "all commands are consumed")
+	d.release_after_teardown()  # Break the handler's captured dispatcher reference.
+
+
+func test_reload_reservation_holds_later_commands_until_scan_timeout() -> void:
+	var d := _make_dispatcher()
+	d.mcp_logging = false
+	var work := [0]
+	var calls: Array[String] = []
+	d.register("reserve_reload", func(_p):
+		work[0] = PluginReload.reserve_reload()
+		calls.append("reload")
+		return {"data": {"status": "reloading"}}
+	)
+	d.register("write_after_reload", func(_p):
+		calls.append("write")
+		return {"data": {"written": true}}
+	)
+	d.enqueue({"request_id": "reload", "command": "reserve_reload", "params": {}})
+	d.enqueue({"request_id": "write", "command": "write_after_reload", "params": {}})
+	var responses := d.tick(100.0)
+	assert_eq(responses.size(), 1, "reload response still returns before the deferred scan")
+	assert_eq(responses[0].request_id, "reload")
+	assert_eq(calls, ["reload"], "no later handler starts in the reservation frame")
+	assert_eq(d.tick(100.0).size(), 0, "later frames remain gated before scan starts")
+	assert_eq(PluginReload.reserve_reload(), 0, "a duplicate cannot replace the reservation")
+	var filesystem := _ReloadFilesystem.new()
+	var timer := _ReloadDeadline.new()
+	PluginReload._start_scan(filesystem, timer, work[0])
+	assert_eq(filesystem.scans, 1)
+	assert_eq(d.tick(100.0).size(), 0, "an unfinished scan retains the gate")
+	timer.timeout.emit()
+	assert_false(PluginReload.is_reload_pending(), "timeout releases the reservation")
+	assert_false(ScriptWork._active.has(work[0]), "timeout settles the same work entry")
+	PluginReload._finish_scan(work[0], false)  # A late completion cannot restart the reload.
+	responses = d.tick(100.0)
+	assert_eq(calls, ["reload", "write"], "timeout resumes the untouched queued command once")
+	assert_eq(responses.size(), 1)
+	assert_eq(responses[0].request_id, "write")
+	assert_true(responses[0].data.written)
+	d.release_after_teardown()
 
 
 func test_tick_stamps_envelope_readiness_on_success_response() -> void:

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -525,7 +525,7 @@ func test_post_update_window_reads_as_finishing_not_blocked() -> void:
 	assert_eq(_dock._status_label.text, "Finishing update — starting server…")
 	_dock.present_update_state({
 		"install_in_flight": false,
-		"status_text": "Update complete",
+		"status_text": "Godot AI installed",
 		"post_update_action": "",
 		"outcome": "success",
 	})
@@ -737,19 +737,30 @@ func test_post_update_retry_button_emits_barrier_action_instead_of_a_second_upda
 	dock.free()
 
 
-func test_update_asks_before_saving_and_relaunching() -> void:
-	## A dock outside a scene tree has no dialog to show and proceeds directly
-	## (the test above); the confirmation itself is what a click really does.
-	var text := McpDockScript.update_confirm_text("4.1.0")
+func test_update_confirmation_names_editor_restart_and_client_compatibility() -> void:
+	var text := McpDockScript.update_confirm_text("4.1.0", "4.0.4")
 	assert_true(text.contains("save your project"), text)
-	assert_true(text.contains("relaunch the editor"), text)
+	assert_true(text.contains("restart the Godot editor"), text)
 	assert_true(text.contains("Godot AI v4.1.0"), text)
-	assert_true(text.contains("AI clients connected right now must be restarted"), text)
-	assert_true(McpDockScript.update_confirm_text("").contains("the new Godot AI"))
+	assert_true(text.contains("AI clients already using v4.0.4 can reconnect without restarting."), text)
+	assert_true(text.contains("Relaunch clients still using an older version."), text)
+	for versions in [["4.0.3", "4.1.0"], ["4.1.0", "5.0.0"], ["", "4.1.0"], ["4.0.4", ""]]:
+		text = McpDockScript.update_confirm_text(versions[1], versions[0])
+		assert_true(text.contains("Quit and relaunch connected AI clients"), text)
+		assert_false(text.contains("without restarting"), text)
+	assert_true(McpDockScript.update_confirm_text("", "4.0.4").contains("the new Godot AI"))
+
+
+func test_update_dialog_defers_until_confirmation() -> void:
 	var dock := McpDockScript.new()
+	dock._build_ui()
 	var update_calls := [0]
 	dock.update_requested.connect(func() -> void: update_calls[0] += 1)
-	dock._on_update_confirmed()
+	assert_eq(dock._update_confirm.get_ok_button().text, "Update and restart")
+	assert_eq(dock._update_confirm.get_cancel_button().text, "Later")
+	dock._update_confirm.canceled.emit()
+	assert_eq(update_calls[0], 0, "Later must leave the update unrequested")
+	dock._update_confirm.confirmed.emit()
 	assert_eq(update_calls[0], 1, "confirming is what requests the update")
 	dock.free()
 
@@ -958,14 +969,14 @@ func test_update_status_text_never_replaces_the_button_action() -> void:
 
 
 func test_new_update_candidate_rearms_the_button_after_a_completed_update() -> void:
-	## The restarted editor after an update shows "Update complete" with the
+	## The restarted editor after an update shows "Godot AI installed" with the
 	## button disabled. A newer release found later in that same session (the
 	## fleet's 4.0.0 -> 4.0.2 morning) must be installable without another
 	## editor restart.
 	_dock._build_ui()
 	_dock.present_update_state({
 		"install_in_flight": false,
-		"status_text": "Update complete",
+		"status_text": "Godot AI installed",
 		"button_disabled": true,
 		"label_text": "Restart AI clients that were connected during the update so they use v4.0.2.",
 		"banner_visible": true,
@@ -973,7 +984,9 @@ func test_new_update_candidate_rearms_the_button_after_a_completed_update() -> v
 		"outcome": "success",
 	})
 	assert_true(_dock._update_btn.disabled)
-	assert_eq(_dock._update_label.get_theme_color("font_color"), Color.GREEN)
+	assert_true(_dock._update_label.has_theme_color_override("font_color"))
+	assert_eq(_dock._update_label.get_theme_color("font_color"), McpDockScript._UPDATE_LABEL_COLOR,
+		"installed files do not prove clients have reconnected")
 	_dock.present_update_check({"version": "4.0.3", "label_text": "Update available: v4.0.3"})
 	assert_false(_dock._update_btn.disabled)
 	assert_eq(_dock._update_btn.text, "Update")

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -430,31 +430,37 @@ func test_post_update_banner_depends_on_whether_bridges_can_follow() -> void:
 	assert_true(label.begins_with("Quit and relaunch AI clients"), label)
 	plugin._post_update_outcome = {"outcome": "success", "from_version": "4.1.0", "to_version": "4.1.1"}
 	label = plugin._post_update_complete_label()
-	assert_true(label.begins_with("AI clients that were connected during the update keep working on v4.1.1"), label)
-	assert_true(Plugin.attached_bridges_follow("4.1.0", "4.2.0"))
-	assert_true(Plugin.attached_bridges_follow("4.1.0", "4.1.0"))
-	assert_true(Plugin.attached_bridges_follow("4.0.4", "4.0.5"), "the tolerant bridge shipped in 4.0.4")
-	assert_false(Plugin.attached_bridges_follow("4.1.0", "5.0.0"), "a major change needs new bridges")
-	assert_false(Plugin.attached_bridges_follow("4.0.3", "4.1.0"), "a 4.0.x bridge refuses the new server")
-	assert_false(Plugin.attached_bridges_follow("3.2.5", "4.1.0"))
-	assert_false(Plugin.attached_bridges_follow("", "4.1.0"))
+	assert_true(label.begins_with("AI clients already using v4.1.0 can reconnect to v4.1.1 without restarting."), label)
+	assert_true(label.contains("Relaunch clients still using an older version."), label)
+	assert_true(McpServerVersionCheck.attached_bridges_follow("4.1.0", "4.2.0"))
+	assert_true(McpServerVersionCheck.attached_bridges_follow("4.1.0", "4.1.0"))
+	assert_true(McpServerVersionCheck.attached_bridges_follow("4.0.4", "4.0.5"), "the tolerant bridge shipped in 4.0.4")
+	assert_false(McpServerVersionCheck.attached_bridges_follow("4.1.0", "5.0.0"), "a major change needs new bridges")
+	assert_false(McpServerVersionCheck.attached_bridges_follow("4.0.3", "4.1.0"), "an older bridge refuses the new server")
+	assert_false(McpServerVersionCheck.attached_bridges_follow("3.2.5", "4.1.0"))
+	assert_false(McpServerVersionCheck.attached_bridges_follow("", "4.1.0"))
 	plugin._lifecycle = null
 	plugin.free()
 
 
-func test_post_update_plan_waits_longer_for_the_status_probe() -> void:
-	## An old bridge's backend may still be settling right after the restart;
-	## 800 ms read it as a foreign process and nothing replaced it.
-	## The lifecycle is configured in _enter_tree, before _finish_post_update
-	## arms the replacement, so the plan must read the recorded outcome.
+func test_normal_and_post_update_starts_share_the_status_probe_window() -> void:
+	## A healthy delayed status must get the same three-second window during
+	## ordinary startup as after an update, before any launch decision.
 	var plugin := Plugin.new()
-	plugin._post_update_outcome = {"outcome": "success", "from_version": "4.0.2", "to_version": "4.0.3"}
-	assert_true(plugin._post_update_replaced_version.is_empty(), "the arm is not set yet at configure time")
-	assert_eq(int(plugin._capture_lifecycle_plan().probe_timeout_ms), Plugin.POST_UPDATE_PROBE_TIMEOUT_MS)
-	plugin._post_update_outcome = {}
-	assert_eq(int(plugin._capture_lifecycle_plan().probe_timeout_ms), Lifecycle.DEFAULT_PROBE_TIMEOUT_MS)
-	plugin._post_update_outcome = {"outcome": "failed", "from_version": "4.0.2"}
-	assert_eq(int(plugin._capture_lifecycle_plan().probe_timeout_ms), Lifecycle.DEFAULT_PROBE_TIMEOUT_MS)
+	for outcome in [{}, {"outcome": "success"}, {"outcome": "failed"}]:
+		plugin._post_update_outcome = outcome
+		var plan: Dictionary = plugin._capture_lifecycle_plan()
+		plan["automatic_effects"] = false
+		var manager := Lifecycle.new()
+		manager.configure(plan)
+		var effects: Array[Dictionary] = []
+		manager.effect_requested.connect(func(_id: int, kind: String, payload: Dictionary):
+			effects.append({"kind": kind, "payload": payload})
+		)
+		manager.start_server()
+		assert_eq(effects.size(), 1)
+		assert_eq(effects[0].kind, Lifecycle.PROBE)
+		assert_eq(int(effects[0].payload.timeout_ms), 3000)
 	plugin._lifecycle = null
 	plugin.free()
 
@@ -494,7 +500,21 @@ func test_deferred_clients_do_not_block_startup_and_are_named_for_configure() ->
 	)
 	assert_true(label.contains("Cursor (its configuration could not be read: unexpected token)"), label)
 	assert_true(label.contains("Configure"), label)
+	var dock := Dock.new()
+	dock._build_ui()
+	plugin._dock = dock
+	plugin._present_post_update_complete()
+	assert_eq(dock._update_status_label.text, "Installed — client setup needed")
+	assert_eq(dock._update_label.text, label, "the client-specific failure remains visible")
+	assert_true(dock._update_label.has_theme_color_override("font_color"))
+	assert_eq(dock._update_label.get_theme_color("font_color"), Dock._UPDATE_LABEL_COLOR,
+		"deferred migrations must not display green success")
 	plugin._post_update_deferred = []
 	assert_false(plugin._post_update_complete_label().contains("Not migrated"))
+	plugin._present_post_update_complete()
+	assert_eq(dock._update_status_label.text, "Godot AI installed",
+		"installation alone does not claim the server or clients are ready")
+	plugin._dock = null
+	dock.free()
 	plugin._lifecycle = null
 	plugin.free()

--- a/test_project/tests/test_port_resolver.gd
+++ b/test_project/tests/test_port_resolver.gd
@@ -126,11 +126,48 @@ func test_read_pid_file_round_trips_value() -> void:
 	assert_eq(McpPortResolver.read_pid_file(), 0)
 
 
-func test_windows_powershell_candidates_prefers_system32_path() -> void:
-	## System32 must come first so a hijacked PATH can't intercept.
+func test_windows_powershell_candidates_prefers_installed_path_and_preserves_fallbacks() -> void:
+	var had_program_files := OS.has_environment("ProgramFiles")
+	var program_files := OS.get_environment("ProgramFiles")
 	var candidates := McpPortResolver.windows_powershell_candidates()
-	assert_true(candidates.size() >= 3)
-	assert_true(candidates[0].ends_with("powershell.exe"))
+	OS.unset_environment("ProgramFiles")
+	var absent := McpPortResolver.windows_powershell_candidates()
+	OS.set_environment("ProgramFiles", "")
+	var empty := McpPortResolver.windows_powershell_candidates()
+	if had_program_files:
+		OS.set_environment("ProgramFiles", program_files)
+	else:
+		OS.unset_environment("ProgramFiles")
+	var system_root := OS.get_environment("SystemRoot")
+	if system_root.is_empty():
+		system_root = "C:/Windows"
+	var expected: Array[String] = [
+		system_root.replace("\\", "/").trim_suffix("/") + "/System32/WindowsPowerShell/v1.0/powershell.exe",
+		"powershell.exe", "pwsh.exe",
+	]
+	assert_eq(absent, expected, "missing ProgramFiles keeps every original fallback in order")
+	assert_eq(empty, expected, "empty ProgramFiles cannot introduce a relative executable path")
+	var pwsh := program_files.replace("\\", "/").trim_suffix("/").path_join("PowerShell/7/pwsh.exe")
+	if not program_files.is_empty() and FileAccess.file_exists(pwsh):
+		expected.push_front(pwsh)
+	assert_eq(candidates, expected, "only an existing installation precedes the original candidates")
+
+
+func test_windows_failed_powershell7_query_uses_existing_powershell5_fallback() -> void:
+	if OS.get_name() != "Windows":
+		skip("Windows PowerShell execution boundary")
+		return
+	var candidates := McpPortResolver.windows_powershell_candidates()
+	if not candidates[0].ends_with("/PowerShell/7/pwsh.exe"):
+		skip("Optional PowerShell 7 is not installed at the configured ProgramFiles path")
+		return
+	var output: Array = []
+	var exit_code := McpPortResolver.execute_windows_powershell(
+		"if ($PSVersionTable.PSVersion.Major -ge 7) { exit 7 }; $PSVersionTable.PSVersion.Major", output
+	)
+	assert_eq(exit_code, 0, "nonzero PS7 exit must continue to the existing shell fallback")
+	assert_eq(str(output[0]).strip_edges() if not output.is_empty() else "", "5",
+		"the fallback must actually run Windows PowerShell 5")
 
 
 func test_netstat_parse_is_locale_independent() -> void:
@@ -314,3 +351,135 @@ func test_kill_grant_capture_names_the_check_that_refused() -> void:
 	## An implausible pid is not alive.
 	assert_true(McpPortResolver.capture_process_kill_grant(2147480000, true, diagnostics).is_empty())
 	assert_eq(diagnostics, ["not_alive"])
+
+
+func _snapshot_rows() -> Array:
+	var command := "python -m godot_ai --transport streamable-http"
+	return [
+		{"pid": 4242, "parent_pid": 4241, "identity": "09/09/2026 12:00:00|" + command, "commandline": command},
+		{"pid": 4241, "parent_pid": 0, "identity": "09/09/2026 11:59:59|launcher", "commandline": "launcher"},
+	]
+
+
+func test_process_snapshot_preserves_fingerprint_brand_and_lineage() -> void:
+	var rows := _snapshot_rows()
+	var snapshot := McpPortResolver.parse_process_snapshot(JSON.stringify(rows), 4242)
+	assert_eq(snapshot.size(), 2)
+	assert_true(McpPortResolver.pid_alive(4242, snapshot))
+	assert_eq(McpPortResolver.process_parent(4242, snapshot), 4241)
+	assert_eq(McpPortResolver.process_commandline(4242, snapshot), rows[0].commandline)
+	assert_eq(McpPortResolver.process_fingerprint(4242, snapshot), ("4242|" + str(rows[0].identity)).sha256_text())
+	assert_true(McpPortResolver.pid_cmdline_is_godot_ai(4242, snapshot))
+	assert_true(McpPortResolver.process_descends_from(4242, 4241, snapshot))
+	assert_true(McpPortResolver.process_descends_from(4242, 4242, snapshot))
+	assert_false(McpPortResolver.process_descends_from(4242, 9999, snapshot))
+
+
+func test_process_snapshot_changed_identity_brand_and_parent_do_not_preserve_proof() -> void:
+	var rows := _snapshot_rows()
+	var original := McpPortResolver.parse_process_snapshot(JSON.stringify(rows), 4242)
+	rows[0].identity = "09/09/2026 12:01:00|" + str(rows[0].commandline)
+	var reused := McpPortResolver.parse_process_snapshot(JSON.stringify(rows), 4242)
+	assert_ne(McpPortResolver.process_fingerprint(4242, original), McpPortResolver.process_fingerprint(4242, reused))
+	rows[0].commandline = "python -m unrelated --transport streamable-http"
+	rows[0].identity = "09/09/2026 12:01:00|" + str(rows[0].commandline)
+	var unbranded := McpPortResolver.parse_process_snapshot(JSON.stringify(rows), 4242)
+	assert_false(McpPortResolver.pid_cmdline_is_godot_ai(4242, unbranded))
+	rows[0].parent_pid = 9999
+	rows.resize(1)
+	var moved := McpPortResolver.parse_process_snapshot(JSON.stringify(rows), 4242)
+	assert_false(McpPortResolver.process_descends_from(4242, 4241, moved))
+	assert_false(McpPortResolver.process_descends_from(4242, 9999, moved), "an omitted ancestor is not proof")
+
+
+func test_process_snapshot_rejects_missing_malformed_and_tampered_records() -> void:
+	for raw in ["{}", "[]", "null", "not json", JSON.stringify([{"pid": 4242}])]:
+		assert_true(McpPortResolver.parse_process_snapshot(raw, 4242).is_empty())
+	var rows := _snapshot_rows()
+	assert_true(McpPortResolver.parse_process_snapshot(JSON.stringify(rows), 5555).is_empty())
+	rows[0].commandline = "changed without changing fingerprint identity"
+	assert_true(McpPortResolver.parse_process_snapshot(JSON.stringify(rows), 4242).is_empty())
+	rows = _snapshot_rows()
+	rows[1].pid = 5555
+	assert_true(McpPortResolver.parse_process_snapshot(JSON.stringify(rows), 4242).is_empty())
+	rows = _snapshot_rows()
+	rows[1].parent_pid = 4242
+	assert_true(McpPortResolver.parse_process_snapshot(JSON.stringify(rows), 4242).is_empty(), "a cycle truncated by the collector is still invalid")
+	rows.resize(1)
+	rows[0].parent_pid = 4242
+	assert_true(McpPortResolver.parse_process_snapshot(JSON.stringify(rows), 4242).is_empty(), "self-parent cycles are invalid")
+	for invalid in [{}, [], {4242: {"pid": 4242}}]:
+		assert_false(McpPortResolver.pid_alive(OS.get_process_id(), invalid), "explicit empty snapshots never query the live editor")
+		assert_eq(McpPortResolver.process_fingerprint(OS.get_process_id(), invalid), "")
+		assert_false(McpPortResolver.pid_cmdline_is_godot_ai(4242, invalid))
+		assert_false(McpPortResolver.process_descends_from(4242, 4242, invalid))
+
+
+func test_process_snapshot_fallback_keeps_start_time_identity_without_inventing_brand() -> void:
+	var snapshot := McpPortResolver.parse_process_snapshot(JSON.stringify([
+		{"pid": 4242, "parent_pid": 0, "identity": "134019180000000000", "commandline": ""},
+	]), 4242)
+	assert_eq(McpPortResolver.process_fingerprint(4242, snapshot), "4242|134019180000000000".sha256_text())
+	assert_false(McpPortResolver.pid_cmdline_is_godot_ai(4242, snapshot))
+	assert_false(McpPortResolver.process_descends_from(4242, 4241, snapshot))
+
+
+func test_process_snapshot_keeps_the_sixteen_process_lineage_limit() -> void:
+	var rows: Array = []
+	for index in range(16):
+		rows.append({"pid": 5000 + index, "parent_pid": 5001 + index, "identity": "time|launcher", "commandline": "launcher"})
+	var snapshot := McpPortResolver.parse_process_snapshot(JSON.stringify(rows), 5000)
+	assert_eq(snapshot.size(), 16)
+	assert_true(McpPortResolver.process_descends_from(5000, 5015, snapshot))
+	assert_false(McpPortResolver.process_descends_from(5000, 5016, snapshot))
+	rows.append({"pid": 5016, "parent_pid": 0, "identity": "time|launcher", "commandline": "launcher"})
+	assert_true(McpPortResolver.parse_process_snapshot(JSON.stringify(rows), 5000).is_empty())
+
+
+func test_windows_process_snapshot_matches_live_editor_fingerprint() -> void:
+	if OS.get_name() != "Windows":
+		skip("Windows process snapshot boundary")
+		return
+	var pid := OS.get_process_id()
+	var snapshot: Variant = McpPortResolver.capture_process_snapshot(pid)
+	var fingerprint := McpPortResolver.process_fingerprint(pid, snapshot)
+	assert_false(fingerprint.is_empty(), "the editor must have a captured process identity")
+	assert_eq(fingerprint, McpPortResolver.process_fingerprint(pid), "batched identity must match existing grant representation")
+
+
+func test_process_snapshot_pair_preserves_both_independent_identities() -> void:
+	var rows := _snapshot_rows()
+	var first := JSON.stringify(rows)
+	rows[0].identity = "09/09/2026 12:01:00|" + str(rows[0].commandline)
+	var final := JSON.stringify(rows)
+	var pair := McpPortResolver._parse_process_snapshot_pair(JSON.stringify([first, final]), 4242)
+	assert_eq(pair[0], McpPortResolver.parse_process_snapshot(first, 4242))
+	assert_eq(pair[1], McpPortResolver.parse_process_snapshot(final, 4242))
+	assert_eq(McpPortResolver.process_fingerprint(4242, pair[0]), ("4242|09/09/2026 12:00:00|" + str(rows[0].commandline)).sha256_text())
+	assert_eq(McpPortResolver.process_fingerprint(4242, pair[1]), ("4242|" + str(rows[0].identity)).sha256_text())
+
+
+func test_process_snapshot_pair_rejects_invalid_envelopes_and_members() -> void:
+	var valid := JSON.stringify(_snapshot_rows())
+	for raw in ["{}", "[]", JSON.stringify([valid]), JSON.stringify([valid, valid, valid]), JSON.stringify([{}, valid]), " ".repeat(4 * 1024 * 1024 + 17)]:
+		assert_eq(McpPortResolver._parse_process_snapshot_pair(raw, 4242), [{}, {}])
+	assert_eq(McpPortResolver._parse_process_snapshot_pair(JSON.stringify([valid, valid]), 9999), [{}, {}])
+	for invalid in ["{}", JSON.stringify([{"pid": 4242}]), " ".repeat(1024 * 1024 + 1)]:
+		var pair := McpPortResolver._parse_process_snapshot_pair(JSON.stringify([valid, invalid]), 4242)
+		assert_eq(McpPortResolver.process_commandline(4242, pair[0]), str(_snapshot_rows()[0].commandline))
+		assert_true(pair[1].is_empty(), "an invalid final member cannot reuse the first snapshot")
+		assert_eq(McpPortResolver.process_fingerprint(4242, pair[1]), "")
+		pair = McpPortResolver._parse_process_snapshot_pair(JSON.stringify([invalid, valid]), 4242)
+		assert_true(pair[0].is_empty())
+		assert_eq(McpPortResolver.process_commandline(4242, pair[1]), str(_snapshot_rows()[0].commandline))
+
+
+func test_process_snapshot_pair_accepts_escaped_members_near_the_inner_limit() -> void:
+	var command := String.chr(34).repeat(250000)
+	var inner := JSON.stringify([{"pid": 4242, "parent_pid": 0, "identity": "time|" + command, "commandline": command}])
+	var outer := JSON.stringify([inner, inner])
+	assert_true(inner.length() <= 1024 * 1024)
+	assert_true(outer.length() > 2 * 1024 * 1024, "escaping expands two valid inner snapshots beyond the old outer limit")
+	var pair := McpPortResolver._parse_process_snapshot_pair(outer, 4242)
+	assert_eq(McpPortResolver.process_commandline(4242, pair[0]), command)
+	assert_eq(McpPortResolver.process_commandline(4242, pair[1]), command)

--- a/test_project/tests/test_port_resolver.gd
+++ b/test_project/tests/test_port_resolver.gd
@@ -127,30 +127,42 @@ func test_read_pid_file_round_trips_value() -> void:
 
 
 func test_windows_powershell_candidates_prefers_installed_path_and_preserves_fallbacks() -> void:
-	var had_program_files := OS.has_environment("ProgramFiles")
-	var program_files := OS.get_environment("ProgramFiles")
-	var candidates := McpPortResolver.windows_powershell_candidates()
-	OS.unset_environment("ProgramFiles")
+	var saved := {}
+	for key in ["ProgramW6432", "ProgramFiles"]:
+		saved[key] = {"present": OS.has_environment(key), "value": OS.get_environment(key)}
+		OS.unset_environment(key)
 	var absent := McpPortResolver.windows_powershell_candidates()
+	var root := "user://_test_pwsh_candidates"
+	var native := ProjectSettings.globalize_path(root + "/native")
+	var x86 := ProjectSettings.globalize_path(root + "/x86")
+	for path in [native, x86]:
+		DirAccess.make_dir_recursive_absolute(path.path_join("PowerShell/7"))
+		var file := FileAccess.open(path.path_join("PowerShell/7/pwsh.exe"), FileAccess.WRITE)
+		file.close()
+	OS.set_environment("ProgramW6432", native)
+	OS.set_environment("ProgramFiles", x86)
+	var candidates := McpPortResolver.windows_powershell_candidates()
+	OS.set_environment("ProgramFiles", native)
+	var duplicate := McpPortResolver.windows_powershell_candidates()
+	OS.set_environment("ProgramW6432", "")
 	OS.set_environment("ProgramFiles", "")
 	var empty := McpPortResolver.windows_powershell_candidates()
-	if had_program_files:
-		OS.set_environment("ProgramFiles", program_files)
-	else:
-		OS.unset_environment("ProgramFiles")
-	var system_root := OS.get_environment("SystemRoot")
-	if system_root.is_empty():
-		system_root = "C:/Windows"
-	var expected: Array[String] = [
-		system_root.replace("\\", "/").trim_suffix("/") + "/System32/WindowsPowerShell/v1.0/powershell.exe",
-		"powershell.exe", "pwsh.exe",
-	]
-	assert_eq(absent, expected, "missing ProgramFiles keeps every original fallback in order")
-	assert_eq(empty, expected, "empty ProgramFiles cannot introduce a relative executable path")
-	var pwsh := program_files.replace("\\", "/").trim_suffix("/").path_join("PowerShell/7/pwsh.exe")
-	if not program_files.is_empty() and FileAccess.file_exists(pwsh):
-		expected.push_front(pwsh)
-	assert_eq(candidates, expected, "only an existing installation precedes the original candidates")
+	for key in saved:
+		if saved[key].present:
+			OS.set_environment(key, saved[key].value)
+		else:
+			OS.unset_environment(key)
+	for path in [native, x86]:
+		DirAccess.remove_absolute(path.path_join("PowerShell/7/pwsh.exe"))
+		DirAccess.remove_absolute(path.path_join("PowerShell/7"))
+		DirAccess.remove_absolute(path.path_join("PowerShell"))
+		DirAccess.remove_absolute(path)
+	DirAccess.remove_absolute(root)
+	assert_eq(empty, absent, "empty environment cannot add a relative executable")
+	assert_eq(candidates.slice(0, 2), [native.path_join("PowerShell/7/pwsh.exe"), x86.path_join("PowerShell/7/pwsh.exe")])
+	assert_eq(candidates.slice(2), absent, "all previous fallbacks remain")
+	assert_eq(duplicate.size(), absent.size() + 1, "the same installation occurs once")
+	assert_eq(absent.slice(-2), ["powershell.exe", "pwsh.exe"])
 
 
 func test_windows_failed_powershell7_query_uses_existing_powershell5_fallback() -> void:
@@ -393,21 +405,21 @@ func test_process_snapshot_changed_identity_brand_and_parent_do_not_preserve_pro
 
 
 func test_process_snapshot_rejects_missing_malformed_and_tampered_records() -> void:
-	for raw in ["{}", "[]", "null", "not json", JSON.stringify([{"pid": 4242}])]:
-		assert_true(McpPortResolver.parse_process_snapshot(raw, 4242).is_empty())
+	for raw in ["{}", "null", "not json", JSON.stringify([{"pid": 4242}])]:
+		assert_true(McpPortResolver.capture_failed(McpPortResolver.parse_process_snapshot(raw, 4242)))
 	var rows := _snapshot_rows()
-	assert_true(McpPortResolver.parse_process_snapshot(JSON.stringify(rows), 5555).is_empty())
+	assert_true(McpPortResolver.capture_failed(McpPortResolver.parse_process_snapshot(JSON.stringify(rows), 5555)))
 	rows[0].commandline = "changed without changing fingerprint identity"
-	assert_true(McpPortResolver.parse_process_snapshot(JSON.stringify(rows), 4242).is_empty())
+	assert_true(McpPortResolver.capture_failed(McpPortResolver.parse_process_snapshot(JSON.stringify(rows), 4242)))
 	rows = _snapshot_rows()
 	rows[1].pid = 5555
-	assert_true(McpPortResolver.parse_process_snapshot(JSON.stringify(rows), 4242).is_empty())
+	assert_true(McpPortResolver.capture_failed(McpPortResolver.parse_process_snapshot(JSON.stringify(rows), 4242)))
 	rows = _snapshot_rows()
 	rows[1].parent_pid = 4242
-	assert_true(McpPortResolver.parse_process_snapshot(JSON.stringify(rows), 4242).is_empty(), "a cycle truncated by the collector is still invalid")
+	assert_true(McpPortResolver.capture_failed(McpPortResolver.parse_process_snapshot(JSON.stringify(rows), 4242)), "a cycle truncated by the collector is still invalid")
 	rows.resize(1)
 	rows[0].parent_pid = 4242
-	assert_true(McpPortResolver.parse_process_snapshot(JSON.stringify(rows), 4242).is_empty(), "self-parent cycles are invalid")
+	assert_true(McpPortResolver.capture_failed(McpPortResolver.parse_process_snapshot(JSON.stringify(rows), 4242)), "self-parent cycles are invalid")
 	for invalid in [{}, [], {4242: {"pid": 4242}}]:
 		assert_false(McpPortResolver.pid_alive(OS.get_process_id(), invalid), "explicit empty snapshots never query the live editor")
 		assert_eq(McpPortResolver.process_fingerprint(OS.get_process_id(), invalid), "")
@@ -433,7 +445,7 @@ func test_process_snapshot_keeps_the_sixteen_process_lineage_limit() -> void:
 	assert_true(McpPortResolver.process_descends_from(5000, 5015, snapshot))
 	assert_false(McpPortResolver.process_descends_from(5000, 5016, snapshot))
 	rows.append({"pid": 5016, "parent_pid": 0, "identity": "time|launcher", "commandline": "launcher"})
-	assert_true(McpPortResolver.parse_process_snapshot(JSON.stringify(rows), 5000).is_empty())
+	assert_true(McpPortResolver.capture_failed(McpPortResolver.parse_process_snapshot(JSON.stringify(rows), 5000)))
 
 
 func test_windows_process_snapshot_matches_live_editor_fingerprint() -> void:
@@ -462,15 +474,15 @@ func test_process_snapshot_pair_preserves_both_independent_identities() -> void:
 func test_process_snapshot_pair_rejects_invalid_envelopes_and_members() -> void:
 	var valid := JSON.stringify(_snapshot_rows())
 	for raw in ["{}", "[]", JSON.stringify([valid]), JSON.stringify([valid, valid, valid]), JSON.stringify([{}, valid]), " ".repeat(4 * 1024 * 1024 + 17)]:
-		assert_eq(McpPortResolver._parse_process_snapshot_pair(raw, 4242), [{}, {}])
-	assert_eq(McpPortResolver._parse_process_snapshot_pair(JSON.stringify([valid, valid]), 9999), [{}, {}])
+		assert_eq(McpPortResolver._parse_process_snapshot_pair(raw, 4242), [{"capture_error": true}, {"capture_error": true}])
+	assert_eq(McpPortResolver._parse_process_snapshot_pair(JSON.stringify([valid, valid]), 9999), [{"capture_error": true}, {"capture_error": true}])
 	for invalid in ["{}", JSON.stringify([{"pid": 4242}]), " ".repeat(1024 * 1024 + 1)]:
 		var pair := McpPortResolver._parse_process_snapshot_pair(JSON.stringify([valid, invalid]), 4242)
 		assert_eq(McpPortResolver.process_commandline(4242, pair[0]), str(_snapshot_rows()[0].commandline))
-		assert_true(pair[1].is_empty(), "an invalid final member cannot reuse the first snapshot")
+		assert_true(McpPortResolver.capture_failed(pair[1]), "an invalid final member cannot reuse the first snapshot")
 		assert_eq(McpPortResolver.process_fingerprint(4242, pair[1]), "")
 		pair = McpPortResolver._parse_process_snapshot_pair(JSON.stringify([invalid, valid]), 4242)
-		assert_true(pair[0].is_empty())
+		assert_true(McpPortResolver.capture_failed(pair[0]))
 		assert_eq(McpPortResolver.process_commandline(4242, pair[1]), str(_snapshot_rows()[0].commandline))
 
 
@@ -483,3 +495,39 @@ func test_process_snapshot_pair_accepts_escaped_members_near_the_inner_limit() -
 	var pair := McpPortResolver._parse_process_snapshot_pair(outer, 4242)
 	assert_eq(McpPortResolver.process_commandline(4242, pair[0]), command)
 	assert_eq(McpPortResolver.process_commandline(4242, pair[1]), command)
+
+
+func test_process_capture_distinguishes_absence_from_unavailable_evidence() -> void:
+	var absent := McpPortResolver.parse_process_snapshot("[]", 4242)
+	assert_eq(absent, {})
+	assert_false(McpPortResolver.capture_failed(absent))
+	for raw in ["", "null", "not JSON", "{}", "[{bad", JSON.stringify([{"pid": 4242}])]:
+		var failed := McpPortResolver.parse_process_snapshot(raw, 4242)
+		assert_true(McpPortResolver.capture_failed(failed), raw)
+		assert_false(McpPortResolver.pid_alive(OS.get_process_id(), failed))
+		assert_eq(McpPortResolver.process_fingerprint(OS.get_process_id(), failed), "")
+		assert_false(McpPortResolver.pid_cmdline_is_godot_ai(OS.get_process_id(), failed))
+		assert_false(McpPortResolver.process_descends_from(OS.get_process_id(), OS.get_process_id(), failed))
+	var mixed := McpPortResolver.parse_process_snapshot(JSON.stringify(_snapshot_rows()), 4242)
+	mixed["capture_error"] = true
+	assert_eq(McpPortResolver.process_fingerprint(4242, mixed), "", "failure cannot carry usable rows")
+
+
+func test_windows_capture_distinguishes_get_process_not_found_and_permission_error() -> void:
+	if OS.get_name() != "Windows":
+		skip("Windows PowerShell process collector")
+		return
+	for category in ["ObjectNotFound", "PermissionDenied"]:
+		var output: Array = []
+		var script := (
+			"function Get-CimInstance { throw 'CIM unavailable' }; "
+			+ "function Get-Process { [CmdletBinding()]param($Id); Write-Error -Message 'unavailable' -Category %s -ErrorAction Stop }; "
+		) % category + McpPortResolver._windows_process_snapshot_script(4242)
+		assert_eq(McpPortResolver.execute_windows_powershell(script, output), 0)
+		assert_false(output.is_empty())
+		var captured := McpPortResolver.parse_process_snapshot(str(output[0]), 4242)
+		assert_eq(McpPortResolver.capture_failed(captured), category == "PermissionDenied", category)
+		assert_false(McpPortResolver.pid_alive(4242, captured))
+	var diagnostics: Array = []
+	assert_eq(McpPortResolver.capture_process_kill_grant(2147483000, false, diagnostics), {})
+	assert_eq(diagnostics, ["not_alive"], "a successfully observed absent PID is distinct from query failure")

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -831,14 +831,15 @@ func test_startup_report_summary_quotes_the_server_failure() -> void:
 
 
 func test_launch_unproven_message_summarises_the_refusals() -> void:
-	var message := Lifecycle._launch_unproven_message(
+	var manager := Lifecycle.new()
+	var message := manager._launch_unproven_message(
 		2147480000, ["not_alive", "not_alive", "unbranded"], 15200
 	)
 	assert_true(message.contains("3 attempts over 15.2 s"), message)
 	assert_true(message.contains("pid 2147480000"), message)
 	assert_true(message.contains("now alive=no"), message)
 	assert_true(message.contains("not_alive×2, unbranded×1"), message)
-	var empty := Lifecycle._launch_unproven_message(2147480000, [], 0)
+	var empty := manager._launch_unproven_message(2147480000, [], 0)
 	assert_true(empty.contains("none recorded"), empty)
 func test_pre_v4_version_is_read_only_from_a_godot_ai_3x_claim() -> void:
 	assert_eq(Lifecycle.pre_v4_version_from_status({"name": "godot-ai", "server_version": "3.2.4"}), "3.2.4")

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -10,6 +10,11 @@ const WS := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 const INSTANCE := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 
 
+class _StaleCapabilityLifecycle extends Lifecycle:
+	func _read_capability(_port: int) -> Dictionary:
+		return {"http": HTTP, "websocket": WS, "instance_nonce": INSTANCE}
+
+
 func suite_name() -> String:
 	return "server_lifecycle"
 
@@ -161,14 +166,90 @@ func test_authenticated_endpoint_loss_blocks_then_schedules_a_bounded_reprobe() 
 	assert_false(manager.recover_lost_endpoint(episode_id))
 
 
-func test_endpoint_reprobe_for_an_owned_server_stops_the_exact_grant_first() -> void:
+func test_endpoint_reprobe_preserves_the_healthy_owned_server_and_stop_grant() -> void:
 	var manager := _manager()
 	_complete_owned_start(manager)
-	manager.transport_lost("child exited")
+	var grant = manager._process_grant
+	var effects: Array[Dictionary] = []
+	manager.effect_requested.connect(func(id: int, kind: String, payload: Dictionary):
+		effects.append({"id": id, "kind": kind, "payload": payload})
+	)
+	manager.transport_lost("socket closed")
 	assert_true(manager.recover_lost_endpoint(int(manager.episode_snapshot().id)))
 	var episode := manager.episode_snapshot()
-	assert_eq(episode.state, Lifecycle.STOPPING)
-	assert_eq(episode.after_stop, "start")
+	assert_eq(episode.state, Lifecycle.STARTING)
+	assert_eq(episode.phase, Lifecycle.PROBE)
+	assert_eq(effects.size(), 1)
+	assert_eq(effects[0].kind, Lifecycle.PROBE)
+	assert_true(effects[0].payload.grant == grant)
+	assert_true(manager.complete_effect(episode.id, Lifecycle.PROBE, {
+		"outcome": "compatible", "version": VERSION, "transport": _transport(),
+		"owned_disposition": "owned",
+	}))
+	assert_eq(manager.get_status_dict().ready_kind, "owned")
+	assert_true(manager._process_grant == grant, "recovery preserves the original exact grant")
+	assert_eq(manager.get_server_pid(), 4242)
+	assert_eq(effects.size(), 1, "healthy recovery neither stops nor launches a backend")
+	manager.stop_server()
+	assert_eq(effects[1].kind, Lifecycle.STOP)
+	assert_true(effects[1].payload.grant == grant, "explicit teardown keeps its original authority")
+	assert_true(manager.complete_effect(effects[1].id, Lifecycle.STOP, {"ok": true}))
+	assert_false(manager.has_managed_server())
+
+
+func test_endpoint_reprobe_of_dead_or_reused_owned_pid_launches_without_killing() -> void:
+	for disposition in ["gone", "replaced"]:
+		var manager := _manager()
+		_complete_owned_start(manager)
+		var effects: Array[String] = []
+		manager.effect_requested.connect(func(_id: int, kind: String, _payload: Dictionary):
+			effects.append(kind)
+		)
+		manager.transport_lost("backend disappeared")
+		assert_true(manager.recover_lost_endpoint(int(manager.episode_snapshot().id)))
+		assert_true(manager.complete_effect(manager.episode_snapshot().id, Lifecycle.PROBE, {
+			"outcome": "free", "owned_disposition": disposition,
+		}))
+		assert_eq(manager.episode_snapshot().phase, Lifecycle.LAUNCH)
+		assert_false(manager.has_managed_server(), "the dead or reused PID loses its old grant")
+		assert_eq(effects, [Lifecycle.PROBE, Lifecycle.LAUNCH], "no STOP is needed for a gone process")
+
+
+func test_endpoint_reprobe_adopts_replacement_without_transferring_old_grant() -> void:
+	var manager := _manager()
+	_complete_owned_start(manager)
+	manager.transport_lost("backend replaced")
+	assert_true(manager.recover_lost_endpoint(int(manager.episode_snapshot().id)))
+	assert_true(manager.complete_effect(manager.episode_snapshot().id, Lifecycle.PROBE, {
+		"outcome": "compatible", "version": VERSION,
+		"transport": _transport("cccccccccccccccccccccccccccccccc"),
+		"owned_disposition": "gone",
+	}))
+	assert_eq(manager.get_status_dict().ready_kind, "adopted")
+	assert_false(manager.has_managed_server(), "authenticated replacement does not inherit kill authority")
+	assert_eq(manager.get_server_pid(), -1)
+
+
+func test_endpoint_reprobe_failure_keeps_grant_without_stopping_or_launching() -> void:
+	for result in [
+		{"outcome": "blocked", "reason": "occupied", "message": "probe timed out"},
+		{"outcome": "blocked", "reason": "process_authority_mismatch", "message": "identity unproven"},
+		{"outcome": "free", "owned_disposition": "owned"},
+		{"outcome": "compatible", "version": VERSION, "transport": _transport()},
+	]:
+		var manager := _manager()
+		_complete_owned_start(manager)
+		var grant = manager._process_grant
+		var effects: Array[String] = []
+		manager.effect_requested.connect(func(_id: int, kind: String, _payload: Dictionary):
+			effects.append(kind)
+		)
+		manager.transport_lost("endpoint lost")
+		assert_true(manager.recover_lost_endpoint(int(manager.episode_snapshot().id)))
+		assert_true(manager.complete_effect(manager.episode_snapshot().id, Lifecycle.PROBE, result))
+		assert_eq(manager.episode_snapshot().state, Lifecycle.BLOCKED)
+		assert_true(manager._process_grant == grant)
+		assert_eq(effects, [Lifecycle.PROBE], "inconclusive probes never kill or duplicate a live backend")
 
 
 func test_endpoint_reprobe_gives_up_after_its_budget() -> void:
@@ -651,6 +732,28 @@ func test_launch_failure_carries_the_startup_report() -> void:
 	DirAccess.remove_absolute(path)
 
 
+func test_windows_unbound_status_probe_retains_missing_capability_priority() -> void:
+	if OS.get_name() != "Windows":
+		skip("Windows positive-bind shortcut")
+		return
+	var port := McpClientConfigurator.suggest_free_port(41000)
+	var listener := TCPServer.new()
+	var bound := listener.listen(port, "127.0.0.1")
+	listener.stop()
+	assert_eq(bound, OK, "the test owns and releases an actual loopback port")
+	if bound != OK:
+		return
+	var missing := Lifecycle._probe_with_capability(port, {}, 3000)
+	assert_eq(str(missing.error), "missing_capability")
+	var result := Lifecycle._probe_with_capability(port, {
+		"http": HTTP, "websocket": WS, "instance_nonce": INSTANCE,
+	}, 3000)
+	assert_false(bool(result.reachable))
+	assert_eq(str(result.error), "port_unbound")
+	assert_eq(str(result.instance_id), "", "free-port evidence cannot authenticate an instance")
+	assert_eq(int(result.status_code), 0, "no HTTP response was claimed")
+
+
 func test_probe_blocks_on_a_held_websocket_port_before_launch() -> void:
 	## Both ports bind together; a held WebSocket port would kill the launch at
 	## the server's preflight. The probe names it and the setting instead.
@@ -658,7 +761,10 @@ func test_probe_blocks_on_a_held_websocket_port_before_launch() -> void:
 	var listener := TCPServer.new()
 	assert_eq(listener.listen(ws_port, "127.0.0.1"), OK)
 	var http_port := McpClientConfigurator.suggest_free_port(ws_port + 1)
-	var manager := _manager({"http_port": http_port, "ws_port": ws_port})
+	## A stale record must exercise the HTTP probe rather than bypass it for
+	## missing credentials. The held socket remains the real refusal boundary.
+	var manager := _StaleCapabilityLifecycle.new()
+	manager.configure({"automatic_effects": false})
 	var result := manager._effect_probe({
 		"http_port": http_port, "expected_version": VERSION,
 		"expected_ws_port": ws_port, "timeout_ms": 200,
@@ -670,12 +776,14 @@ func test_probe_blocks_on_a_held_websocket_port_before_launch() -> void:
 	assert_true(str(result.message).contains("godot_ai/ws_port"), result.message)
 	assert_eq(int(result.target.port), ws_port)
 	assert_false(bool(result.target.replaceable))
+	assert_false(result.has("transport"), "a held WS port grants no transport")
 	## With the WebSocket port free again the same probe reports free.
 	var free_result := manager._effect_probe({
 		"http_port": http_port, "expected_version": VERSION,
 		"expected_ws_port": ws_port, "timeout_ms": 200,
 	})
 	assert_eq(str(free_result.outcome), "free")
+	assert_false(free_result.has("transport"))
 
 
 func test_occupied_block_names_why_the_record_did_not_authenticate() -> void:

--- a/test_project/tests/test_transport_capability.gd
+++ b/test_project/tests/test_transport_capability.gd
@@ -381,12 +381,23 @@ func test_directory_write_problem_names_the_directory_and_the_repair() -> void:
 	var directory := blocker.path_join("capabilities")
 	var problem := McpTransportCapability.directory_write_problem_for(directory)
 	assert_true(problem.contains(directory), "names the directory: %s" % problem)
-	assert_true(
-		problem.contains("Remove-Item -Recurse -Force \"%s\"" % blocker),
-		"names the godot-ai root to remove: %s" % problem
-	)
+	assert_false(problem.contains("Remove-Item"), "never suggests deleting a named ancestor")
+	assert_true(problem.contains("permissions"), "explains how to restore access")
 	assert_true(problem.contains("elevated"), "explains the cause: %s" % problem)
 	DirAccess.remove_absolute(blocker)
+
+
+func test_windows_repair_hint_preserves_path_and_detail_without_deletion_advice() -> void:
+	for directory in [
+		"C:/workspace/godot-ai/.worktrees/project/custom/runtime",
+		"C:/custom/runtime",
+		"C:/Users/user/AppData/Local/godot-ai/capabilities",
+	]:
+		var problem := McpTransportCapability.windows_repair_hint(directory, "permission-detail")
+		assert_true(problem.contains(directory), "names the actual inaccessible directory")
+		assert_true(problem.contains("permission-detail"), "retains the underlying error detail")
+		assert_true(problem.contains("permissions"), "offers directory-specific access guidance")
+		assert_false(problem.contains("Remove-Item"), "managed, repository and custom paths are non-destructive")
 
 
 func test_directory_write_problem_is_windows_only() -> void:

--- a/tests/integration/_godot_ai_process_proof_backend.py
+++ b/tests/integration/_godot_ai_process_proof_backend.py
@@ -1,0 +1,55 @@
+"""Real Godot AI backend: only its private PID file changes during status replies."""
+
+import json
+import os
+import signal
+import sys
+import threading
+from functools import wraps
+from pathlib import Path
+
+from godot_ai import main
+from godot_ai.server import GodotAIFastMCP
+
+
+def serve() -> None:
+    work = Path(os.environ["PROOF_WORK"])
+    original = GodotAIFastMCP.custom_route
+    requests: dict[str, int] = {}
+
+    def custom_route(self, path, *args, **kwargs):
+        register = original(self, path, *args, **kwargs)
+        if path != "/godot-ai/status":
+            return register
+
+        def decorate(handler):
+            @wraps(handler)
+            async def controlled(request):
+                response = await handler(request)
+                control_path = work / "control.json"
+                if response.status_code == 200 and control_path.exists():
+                    control = json.loads(control_path.read_text(encoding="utf-8"))
+                    case = control["case"]
+                    requests[case] = requests.get(case, 0) + 1
+                    if requests[case] == control["change_on_request"]:
+                        (work / "worker.pid").write_text(str(control["replacement_pid"]))
+                    (work / "route-receipt.json").write_text(json.dumps({
+                        "case": case, "authenticated_requests": requests[case],
+                    }))
+                return response
+
+            return register(controlled)
+
+        return decorate
+
+    GodotAIFastMCP.custom_route = custom_route
+    # Bound a surviving actual backend even if its test parent disappears.
+    timer = threading.Timer(240, lambda: os.kill(os.getpid(), signal.SIGTERM))
+    timer.daemon = True
+    timer.start()
+    (work / "backend-process.json").write_text(json.dumps({"pid": os.getpid()}))
+    main(sys.argv[1:])
+
+
+if __name__ == "__main__":
+    serve()

--- a/tests/integration/_lifecycle_process_proof.gd
+++ b/tests/integration/_lifecycle_process_proof.gd
@@ -6,6 +6,23 @@ const Resolver := preload("res://addons/godot_ai/utils/port_resolver.gd")
 const Capability := preload("res://addons/godot_ai/utils/transport_capability.gd")
 const Authority := preload("res://addons/godot_ai/utils/server_authority.gd")
 const Config := preload("res://addons/godot_ai/client_configurator.gd")
+class CaptureFailureLifecycle extends Lifecycle:
+	var failure_stage := ""
+	var receipt_path := ""
+	var case_name := ""
+	var injected := false
+
+	func _capture_process_snapshot(pid: int) -> Variant:
+		if failure_stage == "initial":
+			injected = true
+			return {"capture_error": true}
+		if failure_stage == "final" and FileAccess.file_exists(receipt_path):
+			var receipt: Dictionary = JSON.parse_string(FileAccess.get_file_as_string(receipt_path))
+			if str(receipt.get("case", "")) == case_name and int(receipt.get("authenticated_requests", 0)) >= 2:
+				injected = true
+				return {"capture_error": true}
+		return super._capture_process_snapshot(pid)
+
 var failures: Array[String] = []
 var rows: Array[Dictionary] = []
 
@@ -47,6 +64,9 @@ func run() -> void:
 		finish()
 		return
 	var cases := [
+		{"name": "initial_capture_failure", "hint": worker_pid, "request": 0, "replacement": worker_pid, "expected": "identity_unavailable"},
+		{"name": "final_capture_failure", "hint": worker_pid, "request": 2, "replacement": worker_pid, "expected": "identity_unavailable"},
+		{"name": "exited_launcher", "hint": worker_pid, "request": 0, "replacement": worker_pid, "expected": "launch_gone"},
 		{"name": "owned_child", "hint": worker_pid, "request": 0, "replacement": worker_pid, "expected": "ok"},
 		{"name": "changed_hint", "hint": launch_pid, "request": 1, "replacement": worker_pid, "expected": "ok"},
 		{"name": "stale_hint_corrected", "hint": stale_pid, "request": 1, "replacement": worker_pid, "expected": "ok"},
@@ -60,12 +80,20 @@ func run() -> void:
 		FileAccess.open(work.path_join("worker.pid"), FileAccess.WRITE).store_string(str(case.hint))
 		write_json(work.path_join("control.json"), {"case": label, "change_on_request": case.request, "replacement_pid": case.replacement})
 		var fingerprint := str(exact.fingerprint) + ("changed" if case.name == "wrong_launch_identity" else "")
-		var grant := Authority.OwnedProcessGrant.new(launch_pid, fingerprint, maxi(1, Time.get_ticks_msec()))
-		var manager := Lifecycle.new()
+		var grant := Authority.OwnedProcessGrant.new(stale_pid if label == "exited_launcher" else launch_pid, fingerprint, maxi(1, Time.get_ticks_msec()))
+		var manager := CaptureFailureLifecycle.new()
+		manager.failure_stage = "initial" if label == "initial_capture_failure" else ("final" if label == "final_capture_failure" else "")
+		manager.receipt_path = work.path_join("route-receipt.json")
+		manager.case_name = label
 		manager.configure({"capability_path": capability_path, "automatic_effects": false})
 		var result := manager._effect_prove({"grant": grant, "http_port": http_port, "expected_ws_port": ws_port, "expected_version": Config.get_plugin_version(), "timeout_ms": 3000, "pid_file": work.path_join("worker.pid"), "http_capability": cap.http, "ws_capability": cap.websocket, "baseline_instance_id": ""})
 		var reason := str(result.get("reason", "ok" if result.get("ok", false) else "missing_result"))
 		require(reason == case.expected, label + " expected " + str(case.expected) + " got " + reason)
+		if not manager.failure_stage.is_empty():
+			require(manager.injected, label + " reaches intended capture failure")
+			if manager.failure_stage == "initial":
+				var diagnostic := manager._launch_unproven_message(launch_pid, ["identity_unavailable"], 1)
+				require("alive=unknown" in diagnostic and "identity_unavailable" in diagnostic, label + " diagnostic does not claim death")
 		if int(case.request) > 0:
 			var route: Dictionary = JSON.parse_string(FileAccess.get_file_as_string(work.path_join("route-receipt.json")))
 			require(str(route.get("case", "")) == label and int(route.get("authenticated_requests", 0)) >= int(case.request), label + " real authenticated route performed scheduled mutation")
@@ -79,7 +107,7 @@ func run() -> void:
 				require(result.transport.server_instance_id() == cap.instance_nonce, label + " authenticates exact instance")
 		else:
 			require(not result.has("transport") and not result.has("fingerprint"), label + " grants no authority")
-			if case.expected != "launch_replaced":
+			if case.expected not in ["launch_replaced", "launch_gone"]:
 				require(result.get("pending", false), label + " remains pending")
 		rows.append({"case": case.name, "reason": reason})
 	finish()

--- a/tests/integration/_lifecycle_process_proof.gd
+++ b/tests/integration/_lifecycle_process_proof.gd
@@ -1,0 +1,91 @@
+@tool
+extends Node
+
+const Lifecycle := preload("res://addons/godot_ai/utils/server_lifecycle.gd")
+const Resolver := preload("res://addons/godot_ai/utils/port_resolver.gd")
+const Capability := preload("res://addons/godot_ai/utils/transport_capability.gd")
+const Authority := preload("res://addons/godot_ai/utils/server_authority.gd")
+const Config := preload("res://addons/godot_ai/client_configurator.gd")
+var failures: Array[String] = []
+var rows: Array[Dictionary] = []
+
+func _ready() -> void:
+	if Engine.is_editor_hint():
+		run.call_deferred()
+
+func require(value: bool, message: String) -> void:
+	if not value:
+		failures.append(message)
+
+func write_json(path: String, value: Dictionary) -> void:
+	FileAccess.open(path, FileAccess.WRITE).store_string(JSON.stringify(value))
+
+func run() -> void:
+	var work := OS.get_environment("PROOF_WORK")
+	var configuration: Dictionary = JSON.parse_string(FileAccess.get_file_as_string(work.path_join("processes.json")))
+	var launch_pid := int(configuration.launch_pid)
+	var worker_pid := int(configuration.worker_pid)
+	var unrelated_pid := int(configuration.unrelated_pid)
+	var stale_pid := int(configuration.stale_pid)
+	var http_port := int(configuration.http_port)
+	var ws_port := int(configuration.ws_port)
+	require(not Resolver.pid_alive(stale_pid), "reaped stale hint PID has not been reused")
+	var exact := Resolver.capture_process_kill_grant(launch_pid)
+	require(not exact.is_empty(), "real launcher exact grant can be captured")
+	var worker_snapshot: Variant = Resolver.capture_process_snapshot(worker_pid)
+	var worker_fingerprint := Resolver.process_fingerprint(worker_pid, worker_snapshot)
+	require(not worker_fingerprint.is_empty(), "real worker fingerprint available")
+	require(Resolver.process_descends_from(worker_pid, launch_pid, worker_snapshot), "actual backend is launcher's descendant")
+	require(Resolver.pid_cmdline_is_godot_ai(worker_pid, worker_snapshot), "real backend command line satisfies unchanged branding")
+	require(Resolver.find_all_pids_on_port(http_port).has(worker_pid), "actual backend receipt PID owns HTTP listener")
+	var unrelated_snapshot: Variant = Resolver.capture_process_snapshot(unrelated_pid)
+	require(not Resolver.process_descends_from(unrelated_pid, launch_pid, unrelated_snapshot), "unrelated fixture is not launcher's descendant")
+	var capability_path := work.path_join("local-app-data/godot-ai/capabilities/http-%d.json" % http_port)
+	var cap := Capability.read_for_http_port(http_port, capability_path)
+	require(not cap.is_empty(), "real private capability readable")
+	if not failures.is_empty():
+		finish()
+		return
+	var cases := [
+		{"name": "owned_child", "hint": worker_pid, "request": 0, "replacement": worker_pid, "expected": "ok"},
+		{"name": "changed_hint", "hint": launch_pid, "request": 1, "replacement": worker_pid, "expected": "ok"},
+		{"name": "stale_hint_corrected", "hint": stale_pid, "request": 1, "replacement": worker_pid, "expected": "ok"},
+		{"name": "unrelated_hint_corrected", "hint": unrelated_pid, "request": 1, "replacement": worker_pid, "expected": "ok"},
+		{"name": "unrelated_hint_retained", "hint": unrelated_pid, "request": 0, "replacement": worker_pid, "expected": "listener_pid"},
+		{"name": "wrong_launch_identity", "hint": worker_pid, "request": 0, "replacement": worker_pid, "expected": "launch_replaced"},
+		{"name": "final_pid_changed", "hint": worker_pid, "request": 2, "replacement": unrelated_pid, "expected": "final_capture_window"},
+	]
+	for case in cases:
+		var label: String = str(case.name)
+		FileAccess.open(work.path_join("worker.pid"), FileAccess.WRITE).store_string(str(case.hint))
+		write_json(work.path_join("control.json"), {"case": label, "change_on_request": case.request, "replacement_pid": case.replacement})
+		var fingerprint := str(exact.fingerprint) + ("changed" if case.name == "wrong_launch_identity" else "")
+		var grant := Authority.OwnedProcessGrant.new(launch_pid, fingerprint, maxi(1, Time.get_ticks_msec()))
+		var manager := Lifecycle.new()
+		manager.configure({"capability_path": capability_path, "automatic_effects": false})
+		var result := manager._effect_prove({"grant": grant, "http_port": http_port, "expected_ws_port": ws_port, "expected_version": Config.get_plugin_version(), "timeout_ms": 3000, "pid_file": work.path_join("worker.pid"), "http_capability": cap.http, "ws_capability": cap.websocket, "baseline_instance_id": ""})
+		var reason := str(result.get("reason", "ok" if result.get("ok", false) else "missing_result"))
+		require(reason == case.expected, label + " expected " + str(case.expected) + " got " + reason)
+		if int(case.request) > 0:
+			var route: Dictionary = JSON.parse_string(FileAccess.get_file_as_string(work.path_join("route-receipt.json")))
+			require(str(route.get("case", "")) == label and int(route.get("authenticated_requests", 0)) >= int(case.request), label + " real authenticated route performed scheduled mutation")
+			require(Resolver.read_pid_file(work.path_join("worker.pid")) == int(case.replacement), label + " actual PID file contains scheduled replacement")
+		if case.expected == "ok":
+			require(bool(result.get("ok", false)), label + " explicitly succeeds")
+			require(int(result.get("pid", -1)) == worker_pid, label + " grants actual worker PID")
+			require(str(result.get("fingerprint", "")) == worker_fingerprint, label + " grants actual worker fingerprint")
+			require(result.has("transport"), label + " returns transport")
+			if result.has("transport"):
+				require(result.transport.server_instance_id() == cap.instance_nonce, label + " authenticates exact instance")
+		else:
+			require(not result.has("transport") and not result.has("fingerprint"), label + " grants no authority")
+			if case.expected != "launch_replaced":
+				require(result.get("pending", false), label + " remains pending")
+		rows.append({"case": case.name, "reason": reason})
+	finish()
+
+func finish() -> void:
+	var result := {"rows": rows, "failures": failures}
+	write_json("res://result.json", result)
+	print(JSON.stringify(result))
+	get_tree().quit()

--- a/tests/integration/test_lifecycle_process_proof.py
+++ b/tests/integration/test_lifecycle_process_proof.py
@@ -1,0 +1,139 @@
+"""Prove actual backend ownership while an authenticated route changes PID hints."""
+
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import httpx
+import psutil
+import pytest
+
+from godot_ai.transport.capability import read_capabilities
+from tests.integration._self_update_fixture import (
+    PLUGIN_ROOT,
+    ROOT,
+    godot_bin_or_skip,
+    run_godot_editor,
+)
+
+pytestmark = pytest.mark.editor
+
+
+def test_real_lifecycle_proof_revalidates_pid_hints_and_final_identity(tmp_path: Path) -> None:
+    godot = godot_bin_or_skip()
+    project = tmp_path / "proof"
+    shutil.copytree(PLUGIN_ROOT, project / "addons" / "godot_ai")
+    (project / "project.godot").write_text(
+        'config_version=5\n[application]\nconfig/name="Process proof test"\n'
+        '[autoload]\nProofDriver="*res://driver.gd"\n', encoding="utf-8",
+    )
+    shutil.copyfile(Path(__file__).with_name("_lifecycle_process_proof.gd"), project / "driver.gd")
+    # Allocate distinct available ports without relying on a shared fixed pair.
+    with socket.socket() as http_socket, socket.socket() as ws_socket:
+        http_socket.bind(("127.0.0.1", 0))
+        ws_socket.bind(("127.0.0.1", 0))
+        http_port, ws_port = http_socket.getsockname()[1], ws_socket.getsockname()[1]
+    capability_dir = tmp_path / "local-app-data" / "godot-ai" / "capabilities"
+    environment = {
+        "PROOF_WORK": str(tmp_path), "GODOT_AI_DISABLE_TELEMETRY": "true",
+        "LOCALAPPDATA": str(tmp_path / "local-app-data"),
+        "GODOT_AI_CAPABILITY_DIR": "" if os.name == "nt" else str(capability_dir),
+        "PYTHONPATH": os.pathsep.join([str(ROOT / "src"), *sys.path]),
+    }
+    child_env = {**os.environ, **environment}
+    stale = subprocess.Popen([sys.executable, "-c", "pass"], env=child_env)
+    stale.wait(timeout=10)
+    command = [
+        sys.executable, str(Path(__file__).with_name("_godot_ai_process_proof_backend.py")),
+        "--transport", "streamable-http", "--port", str(http_port), "--ws-port", str(ws_port),
+    ]
+    with (tmp_path / "backend.log").open("w", encoding="utf-8") as output:
+        backend = subprocess.Popen(command, env=child_env, stdout=output, stderr=subprocess.STDOUT)
+        identity = None
+        owned = {}
+
+        def capture_owned() -> None:
+            if identity is None:
+                return
+            try:
+                parent = psutil.Process(backend.pid)
+                assert (parent.create_time(), parent.cmdline()) == identity
+                for process in [parent, *parent.children(recursive=True)]:
+                    value = (process.create_time(), process.cmdline())
+                    assert process.pid not in owned or owned[process.pid] == value
+                    owned.setdefault(process.pid, value)
+            except psutil.NoSuchProcess:
+                return  # A reaped fixture grants no new cleanup authority.
+
+        try:
+            parent = psutil.Process(backend.pid)
+            identity = (parent.create_time(), parent.cmdline())
+            owned[backend.pid] = identity
+            with httpx.Client(trust_env=False, timeout=3) as client:
+                deadline = time.monotonic() + 30
+                while time.monotonic() < deadline:
+                    capture_owned()
+                    assert backend.poll() is None, "backend exited; inspect backend.log"
+                    record = read_capabilities(http_port, capability_dir)
+                    if record is not None:
+                        try:
+                            status = client.get(f"http://127.0.0.1:{http_port}/godot-ai/status",
+                                                headers={"Authorization": f"Bearer {record.http}"})
+                            if (status.status_code == 200
+                                    and status.json()["instance_id"] == record.instance_nonce):
+                                break
+                        except httpx.TransportError:
+                            pass  # Binding/publication can precede HTTP readiness.
+                    time.sleep(.05)
+                else:
+                    pytest.fail("real authenticated backend did not become ready")
+                denied = client.get(f"http://127.0.0.1:{http_port}/godot-ai/status")
+                assert denied.status_code == 401
+            capture_owned()
+            worker_record = json.loads(
+                (tmp_path / "backend-process.json").read_text(encoding="utf-8")
+            )
+            worker_pid = int(worker_record["pid"])
+            assert worker_pid in owned, "actual worker must belong to the spawned tree"
+            assert any(parent.pid == os.getpid() for parent in psutil.Process(worker_pid).parents())
+            (tmp_path / "processes.json").write_text(json.dumps({
+                "launch_pid": os.getpid(), "worker_pid": worker_pid,
+                "unrelated_pid": os.getppid(), "stale_pid": stale.pid,
+                "http_port": http_port, "ws_port": ws_port,
+            }))
+            log = run_godot_editor(project, godot, allow_headless=False, timeout=180,
+                                   environment=environment)
+            assert "SCRIPT ERROR:" not in log
+            result = json.loads((project / "result.json").read_text(encoding="utf-8"))
+            assert result["failures"] == [], result
+            assert {row["case"]: row["reason"] for row in result["rows"]} == {
+                "owned_child": "ok", "changed_hint": "ok", "stale_hint_corrected": "ok",
+                "unrelated_hint_corrected": "ok", "unrelated_hint_retained": "listener_pid",
+                "wrong_launch_identity": "launch_replaced",
+                "final_pid_changed": "final_capture_window",
+            }
+        finally:
+            try:
+                capture_owned()
+                processes = []
+                for pid, expected in reversed(list(owned.items())):
+                    try:
+                        process = psutil.Process(pid)
+                        assert (process.create_time(), process.cmdline()) == expected
+                        process.terminate()
+                        processes.append(process)
+                    except psutil.NoSuchProcess:
+                        continue
+                _, alive = psutil.wait_procs(processes, timeout=10)
+                assert not alive, "owned backend cleanup must complete"
+            finally:
+                # The owned Popen handle still permits cleanup if initial
+                # psutil identity acquisition failed immediately after spawn.
+                if backend.poll() is None:
+                    backend.terminate()
+                backend.wait(timeout=10)

--- a/tests/integration/test_lifecycle_process_proof.py
+++ b/tests/integration/test_lifecycle_process_proof.py
@@ -112,6 +112,8 @@ def test_real_lifecycle_proof_revalidates_pid_hints_and_final_identity(tmp_path:
             result = json.loads((project / "result.json").read_text(encoding="utf-8"))
             assert result["failures"] == [], result
             assert {row["case"]: row["reason"] for row in result["rows"]} == {
+                "initial_capture_failure": "identity_unavailable",
+                "final_capture_failure": "identity_unavailable", "exited_launcher": "launch_gone",
                 "owned_child": "ok", "changed_hint": "ok", "stale_hint_corrected": "ok",
                 "unrelated_hint_corrected": "ok", "unrelated_hint_retained": "listener_pid",
                 "wrong_launch_identity": "launch_replaced",

--- a/tests/integration/test_lifecycle_status_probe.py
+++ b/tests/integration/test_lifecycle_status_probe.py
@@ -1,0 +1,116 @@
+"""Exercise the real Godot status probe against delayed and refusing listeners."""
+
+import json
+import shutil
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+
+from tests.integration._self_update_fixture import (
+    PLUGIN_ROOT,
+    godot_bin_or_skip,
+    run_godot_editor,
+)
+
+pytestmark = pytest.mark.editor
+HTTP = "h" * 32
+INSTANCE = "b" * 32
+
+DRIVER = '''@tool
+extends Node
+const Lifecycle := preload("res://addons/godot_ai/utils/server_lifecycle.gd")
+
+func _ready() -> void:
+    if Engine.is_editor_hint():
+        run.call_deferred()
+
+func run() -> void:
+    var record := {"http": OS.get_environment("PROBE_TOKEN"),
+        "instance_nonce": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}
+    var result := Lifecycle._probe_with_capability(
+        int(OS.get_environment("PROBE_PORT")), record, 3000)
+    result["matches_record"] = Lifecycle._authenticated_status_matches_record(result, record)
+    var file := FileAccess.open("res://result.json", FileAccess.WRITE)
+    file.store_string(JSON.stringify(result))
+    file.close()
+    get_tree().quit()
+'''
+
+
+@pytest.mark.parametrize("authorized", [True, False], ids=["slow-authenticated", "foreign-403"])
+def test_real_godot_status_probe_preserves_occupied_listener_checks(
+    tmp_path: Path, authorized: bool,
+) -> None:
+    godot = godot_bin_or_skip()
+    project = tmp_path / "probe"
+    shutil.copytree(PLUGIN_ROOT, project / "addons" / "godot_ai")
+    (project / "project.godot").write_text(
+        'config_version=5\n[application]\nconfig/name="Status probe test"\n'
+        '[autoload]\nProbeDriver="*res://driver.gd"\n', encoding="utf-8",
+    )
+    (project / "driver.gd").write_text(DRIVER, encoding="utf-8")
+    requests: list[tuple[str, str | None]] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        # Keep explicit-length responses persistent, like the real backend.
+        # An HTTP/1.0 zero-body close is safely refused by Godot but can surface
+        # as response_status_8 before its status code is projected.
+        protocol_version = "HTTP/1.1"
+
+        def setup(self) -> None:
+            super().setup()
+            self.connection.settimeout(5)
+
+        def do_GET(self) -> None:
+            token = self.headers.get("Authorization")
+            requests.append((self.path, token))
+            if token != f"Bearer {HTTP}":
+                self.send_response(403)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                return
+            # Longer than the former 800 ms probe budget, inside the current
+            # three-second allowance. Assert behavior, not a narrow timing band.
+            time.sleep(1.2)
+            body = json.dumps({"name": "godot-ai", "server_version": "4.0.0",
+                               "ws_port": 19500, "instance_id": INSTANCE}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, _format: str, *args: object) -> None:
+            pass
+
+    with HTTPServer(("127.0.0.1", 0), Handler) as server:
+        worker = threading.Thread(target=server.serve_forever, daemon=True)
+        worker.start()
+        try:
+            token = HTTP if authorized else "x" * 32
+            log = run_godot_editor(
+                project, godot, allow_headless=False, timeout=60,
+                environment={"PROBE_PORT": str(server.server_port), "PROBE_TOKEN": token},
+            )
+        finally:
+            server.shutdown()
+            worker.join(timeout=6)
+        assert not worker.is_alive(), "bounded HTTP fixture must finish before teardown"
+    assert "SCRIPT ERROR:" not in log
+    assert requests == [("/godot-ai/status", f"Bearer {token}")]
+    result = json.loads((project / "result.json").read_text(encoding="utf-8"))
+    assert result["status_code"] == (200 if authorized else 403), result
+    assert result["matches_record"] is authorized, result
+    assert result["reachable"] is authorized, result
+    if authorized:
+        assert result["name"] == "godot-ai"
+        assert result["version"] == "4.0.0"
+        assert result["instance_id"] == INSTANCE
+        assert result["ws_port"] == 19500
+        assert result["error"] == ""
+    else:
+        assert result["error"] == "http_403"
+        assert result["instance_id"] == ""

--- a/tests/integration/test_plugin_reload_persistence.py
+++ b/tests/integration/test_plugin_reload_persistence.py
@@ -21,6 +21,12 @@ extends EditorPlugin
 
 func _enter_tree() -> void:
     Engine.set_meta("reload_enters", int(Engine.get_meta("reload_enters", 0)) + 1)
+    if int(Engine.get_meta("reload_enters")) > 1:
+        var reload := load("res://plugin_reload.gd")
+        assert(reload.is_reload_pending(), "reload must gate dispatch through re-enable")
+        assert(reload.reload_enabled_plugin() == ERR_BUSY, "a nested toggle must be refused")
+        reload._finish_scan(int(reload._pending_scan.work), false)
+        assert(int(Engine.get_meta("reload_enters")) == 2, "queued completion cannot toggle twice")
     var fail_save := OS.get_environment("RELOAD_CASE") == "save-failure"
     if FileAccess.file_exists("res://armed") and fail_save:
         assert(DirAccess.rename_absolute("res://project.godot", "res://saved-project") == OK)
@@ -66,6 +72,7 @@ func _process(_delta: float) -> void:
             expected = ERR_FILE_CANT_OPEN
             assert(DirAccess.remove_absolute("res://project.godot") == OK)
             assert(DirAccess.rename_absolute("res://saved-project", "res://project.godot") == OK)
+        assert(not Reload.is_reload_pending(), "every toggle result releases dispatch")
     var saved := ConfigFile.new()
     assert(saved.load("res://project.godot") == OK)
     var enabled: PackedStringArray = saved.get_value(
@@ -233,6 +240,8 @@ func _exercise() -> void:
         Reload._scan_timeout_seconds = Reload.SCAN_TIMEOUT_SECONDS
         assert(Time.get_ticks_msec() - started >= 4500)
         assert(Time.get_ticks_msec() - started < 8000)
+    assert(Reload._pending_scan.is_empty())
+    Reload.reload_after_scan(work) # A cancelled deferred entry cannot revive old work.
     assert(Reload._pending_scan.is_empty())
     assert(filesystem.filesystem_changed.get_connections().is_empty())
     assert(timer.timeout.get_connections().is_empty())

--- a/tests/integration/test_self_update_upgrade_paths.py
+++ b/tests/integration/test_self_update_upgrade_paths.py
@@ -534,10 +534,16 @@ def test_signed_update_restarts_into_matching_live_server(
     ## an older bridge refuses it and the user is told to quit and relaunch.
     base_tuple = tuple(int(part) for part in base_version.split(".")[:3])
     if base_tuple >= (4, 0, 4):
-        expected_client_line = f"keep working on v{next_version}"
+        expected_client_line = (
+            f"MCP | AI clients using v{base_version} can reconnect to v{next_version}; "
+            "relaunch clients still using older versions"
+        )
     else:
-        expected_client_line = f"must be quit and relaunched to use v{next_version}"
-    assert f"MCP | AI clients attached before the update {expected_client_line}" in log
+        expected_client_line = (
+            "MCP | AI clients attached before the update "
+            f"must be quit and relaunched to use v{next_version}"
+        )
+    assert expected_client_line in log
 
     initial_editor, restarted_editor = read_editor_receipts(project)
     assert initial_editor["pid"] != restarted_editor["pid"], (initial_editor, restarted_editor)

--- a/tests/unit/test_attach_ensure.py
+++ b/tests/unit/test_attach_ensure.py
@@ -1245,7 +1245,9 @@ async def test_unanswered_listener_names_an_inaccessible_capability_directory(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """#988: a bound port whose record this account cannot read is not a foreign process."""
-    monkeypatch.setattr(ensure_module, "directory_access_error", lambda: "run Remove-Item")
+    monkeypatch.setattr(
+        ensure_module, "directory_access_error", lambda: "check directory permissions"
+    )
 
     async def probe(_port: int, *_args) -> BackendStatus | None:
         return None
@@ -1263,7 +1265,7 @@ async def test_unanswered_listener_names_an_inaccessible_capability_directory(
         await ensurer.ensure()
 
     assert exc_info.value.code == "CAPABILITY_DIR_INACCESSIBLE"
-    assert exc_info.value.hint == "run Remove-Item"
+    assert exc_info.value.hint == "check directory permissions"
     assert exc_info.value.exit_code == 98
 
 
@@ -1312,7 +1314,7 @@ def test_user_runtime_dir_windows_permission_error_carries_the_repair_hint(
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows repair hint")
-def test_default_runtime_dir_permission_error_carries_the_destructive_repair(
+def test_default_runtime_dir_permission_error_carries_directory_permission_guidance(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.delenv(ensure_module.RUNTIME_DIR_ENV, raising=False)
@@ -1327,8 +1329,9 @@ def test_default_runtime_dir_permission_error_carries_the_destructive_repair(
         user_runtime_dir()
 
     assert exc_info.value.code == "ATTACH_RUNTIME_DIR_ERROR"
-    assert "Remove-Item" in exc_info.value.hint
-    assert str(tmp_path / "godot-ai") in exc_info.value.hint
+    assert "Remove-Item" not in exc_info.value.hint
+    assert "permissions" in exc_info.value.hint
+    assert str(tmp_path / "godot-ai" / "runtime") in exc_info.value.hint
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_port_preflight.py
+++ b/tests/unit/test_port_preflight.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 import json
+import re
 import socket
 import threading
 import time
 from contextlib import closing
+from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
+import godot_ai
 from godot_ai import EXIT_PORT_IN_USE, main, preflight_check_port
 
 
@@ -174,6 +178,52 @@ def test_preflight_returns_nothing_on_the_ordinary_path(monkeypatch) -> None:
         reusable.bind(("127.0.0.1", port))
     finally:
         reusable.close()
+
+
+@pytest.mark.parametrize("release_after", [25.262, 45.0, None])
+def test_replacement_budget_survives_delayed_handoff_and_stays_bounded(
+    monkeypatch, release_after
+) -> None:
+    # Use the actual plugin request so this catches either side reverting its
+    # budget. A real socket stays occupied while a controlled clock advances.
+    lifecycle = (
+        Path(__file__).resolve().parents[2]
+        / "plugin/addons/godot_ai/utils/server_lifecycle.gd"
+    ).read_text(encoding="utf-8")
+    match = re.search(r"const REPLACEMENT_WAIT_FOR_PORT_MS := ([\d_]+)", lifecycle)
+    assert match is not None
+    requested_ms = int(match[1].replace("_", ""))
+    monkeypatch.setenv("GODOT_AI_WAIT_FOR_PORT_MS", str(requested_ms))
+    holder, port = _hold_port()
+    elapsed = 0.0
+
+    def advance(_seconds: float) -> None:
+        nonlocal elapsed
+        elapsed += 1.0
+        if release_after is not None and elapsed >= release_after:
+            holder.close()
+
+    monkeypatch.setattr(
+        godot_ai, "time", SimpleNamespace(monotonic=lambda: elapsed, sleep=advance)
+    )
+    held = None
+    try:
+        if release_after is None:
+            with pytest.raises(SystemExit) as raised:
+                preflight_check_port(port, label="HTTP", setting="godot_ai/http_port")
+            assert raised.value.code == EXIT_PORT_IN_USE
+            assert elapsed == 60.0
+        else:
+            held = preflight_check_port(port, label="HTTP", setting="godot_ai/http_port")
+            assert release_after <= elapsed < release_after + 1.0
+            assert held is not None and held.getsockname()[1] == port
+            with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as other:
+                with pytest.raises(OSError):
+                    other.bind(("127.0.0.1", port))
+    finally:
+        holder.close()
+        if held is not None:
+            held.close()
 
 
 def test_preflight_still_fails_fast_without_the_wait(monkeypatch) -> None:

--- a/tests/unit/test_post_update_stale_server.py
+++ b/tests/unit/test_post_update_stale_server.py
@@ -118,7 +118,9 @@ def test_owned_launch_waits_boundedly_for_a_stable_branded_process_grant() -> No
 
 def test_windows_fingerprint_has_a_reuse_resistant_non_cim_fallback() -> None:
     source = (PLUGIN / "utils" / "port_resolver.gd").read_text(encoding="utf-8")
-    block = get_func_block(source, "static func process_fingerprint(pid: int) -> String:")
+    block = get_func_block(
+        source, "static func process_fingerprint(pid: int, snapshot: Variant = null) -> String:"
+    )
 
     assert "Get-CimInstance Win32_Process" in block
     assert "Get-Process -Id %d -ErrorAction Stop" in block
@@ -252,8 +254,9 @@ def test_process_kill_boundary_revalidates_exact_identity_without_child_heuristi
         "static func kill_exact_processes(",
     )
 
-    assert "process_fingerprint(pid) != fingerprint" in kill
-    assert "require_brand and not pid_cmdline_is_godot_ai(pid)" in kill
+    assert "var snapshot: Variant = capture_process_snapshot(pid)" in kill
+    assert "process_fingerprint(pid, snapshot) != fingerprint" in kill
+    assert "require_brand and not pid_cmdline_is_godot_ai(pid, snapshot)" in kill
     assert 'taskkill", ["/PID", str(pid), "/T", "/F"]' in kill
     assert "not require_tree_proof and not pid_alive(pid)" in kill
     assert "find_windows_spawn_children" not in source

--- a/tests/unit/test_transport_capability.py
+++ b/tests/unit/test_transport_capability.py
@@ -435,11 +435,15 @@ def test_private_mkdir_passes_no_mode_on_windows(tmp_path, monkeypatch) -> None:
     assert modes == [0o777, 0o700]
 
 
-def test_windows_repair_hint_names_the_directory_and_the_godot_ai_root(tmp_path) -> None:
-    directory = tmp_path / "godot-ai" / "capabilities"
+@pytest.mark.parametrize(
+    "relative", ["godot-ai/capabilities", "godot-ai/.worktrees/project/custom/runtime"]
+)
+def test_windows_repair_hint_names_only_the_directory_to_repair(tmp_path, relative) -> None:
+    directory = tmp_path / relative
     hint = capability_module.windows_repair_hint(directory)
     assert str(directory) in hint
-    assert f'Remove-Item -Recurse -Force "{tmp_path / "godot-ai"}"' in hint
+    assert "Remove-Item" not in hint
+    assert "permissions" in hint
     assert "elevated" in hint
 
 
@@ -447,6 +451,7 @@ def test_windows_repair_hint_is_non_destructive_outside_a_godot_ai_tree(tmp_path
     hint = capability_module.windows_repair_hint(tmp_path / "custom" / "runtime")
     assert "Remove-Item" not in hint
     assert str(tmp_path / "custom" / "runtime") in hint
+    assert "permissions" in hint
 
 
 def test_directory_access_error_is_none_when_missing_or_writable(tmp_path) -> None:
@@ -475,8 +480,9 @@ def test_publishing_into_an_unwritable_directory_raises_the_repair_hint(
     with pytest.raises(OSError) as exc_info:
         write_capabilities(8122, HTTP, WEBSOCKET, instance_nonce=NONCE, directory=directory)
     assert exc_info.value.errno == errno.EACCES
-    assert "Remove-Item" in str(exc_info.value)
-    assert str(tmp_path / "godot-ai") in str(exc_info.value)
+    assert "Remove-Item" not in str(exc_info.value)
+    assert "permissions" in str(exc_info.value)
+    assert str(directory) in str(exc_info.value)
 
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows DACL inheritance")


### PR DESCRIPTION
## Why

Windows startup repeatedly spawned process-inspection tools, and socket recovery could restart a healthy shared backend. A queued plugin reload could also run during a handler's filesystem work and free objects still in use.

Reduce repeated process inspection and retain exact identity checks. Probe before recovery, and reserve reload before the dispatcher starts another command.

## Scope

- Batch Windows ancestry queries, prefer installed PowerShell 7 (including the native installation seen from 32-bit editors), reuse validated launcher ancestry, and skip TCP waits on proven-unbound ports.
- Preserve short-command cancellation, resolve Python GUI launchers, and give replacement a bounded 60-second port wait.
- Guard dispatcher reentry and reload reservations; reject reload inside batches.
- Separate update installation from connection status and replace destructive permission-repair advice.
- Add process, HTTP, reload and editor regressions plus the [measurement and qualification report](https://github.com/hi-godot/godot-ai/blob/fix/lifecycle-live-verification/docs/lifecycle-review-2026-09.md).

## Review follow-up

Failed or malformed process queries now report unavailable identity instead of a dead process. A successful empty snapshot still proves absence. The lifecycle retries unavailable evidence within its existing deadline, and neither initial nor final query failure grants ownership. The diagnostic uses the same captured snapshot and quiet JSON parsing avoids secondary engine errors.

The batch reload test now registers a harmless reload callback and checks the specific prohibition. An actual-Godot counterfactual proves that removing the guard fails the new test while the old test falsely passed. Process-proof regressions reach a failed final query after two real authenticated backend replies; the old code fails the corrected diagnosis checks.

The IPv6-only endpoint mismatch predates this PR and is tracked in #1046. CodeRabbit accepted the source-history evidence, withdrew that finding, and resolved its thread. This PR does not change allowlist or network binding policy.

Review-fix validation: full CI Ruff scope passed; full Windows Python suite **2,592 passed, 55 skipped** (one existing Starlette deprecation warning); fresh live Godot **2,320 passed, 0 failed, 30 skipped**. Focused resolver/lifecycle/batch suites passed. Reload stress: **1,219 calls, 0 unexpected failures, 2/2 reloads recovered**. Actual-Godot counterfactuals fail with the old code, and the real authenticated backend test covers unavailable initial/final captures plus a genuinely exited launcher. Independent diff review found no additional blockers. Source and real client configuration were checked for drift; disposable editors were closed and their generated caches cleaned.

Full-suite diagnostics are attributed rather than claimed clean: deliberate negative cases and a renderer limitation remain, as do empty-hash and foreign-listener-wait diagnostics already corrected in the later stacked PR #1043. No new unclassified diagnostic appeared during this run.

## Blast Radius

This affects Windows startup and discovery, shared-backend recovery, and plugin reload. Authentication, signed-update verification and fresh identity checks remain. Seamless upgrades with an existing 3.x client and self-update without an editor restart remain open release gates.

## Verification

- Warm Windows startup: roughly 10.2–10.4s → 9.02s median in the final optimization pass. Small samples; intermittent slow starts remain.
- Full CI Ruff scope passed.
- Full `pytest -v` with `GODOT_BIN` set: 2,592 passed, 55 skipped.
- Fresh interactive Godot suite: 2,318 passed, zero failed, 30 skipped; plugin-only reload retained the editor and authenticated reads succeeded.
- Concurrent stress: 1,143 calls, zero unexpected failures, both reloads recovered.
- Actual UI upgrades from locally signed 3.2.5 and 4.0.4 fixtures passed, followed by visual inspection and authenticated reads. These substitute local release/runtime inputs and do not qualify the untouched production upgrade path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved Windows startup, recovery, and update handoff reliability with stronger process and connection validation.
  * Extended bounded waits for port availability and startup checks to better support slower systems.
  * Coordinated plugin reloads to prevent duplicate or conflicting operations.
  * Windows permission errors now provide specific, non-destructive guidance instead of deletion commands.

* **User Experience**
  * Update dialogs and completion messages now clarify restart requirements and client reconnection compatibility.

* **Documentation**
  * Expanded lifecycle, self-update, verification, and Windows setup guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


