### PR TITLE
fix(update): activate verified plugins without restarting the editor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          # Unit fixture preparation archives published v3 tags, including v3.2.5.
+          fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
       - "docs/**"
       - "**.md"
   pull_request:
-    branches: [main, codex/v4-release-promotion]
     paths-ignore:
       - "docs/**"
       - "**.md"
@@ -284,6 +283,8 @@ jobs:
             tests/integration/test_godot_editor_restart.py \
             tests/integration/test_test_run_cache_warning.py \
             tests/integration/test_migration_bridge_failures.py \
+            tests/integration/test_linux_listener_tools.py \
+            tests/integration/test_self_update_status_driver.py \
             tests/integration/test_self_update_upgrade_paths.py \
             tests/integration/test_qualification_https.py \
             tests/integration/test_plugin_reload_persistence.py \

--- a/docs/poteto-workflow.md
+++ b/docs/poteto-workflow.md
@@ -1,0 +1,93 @@
+# Poteto workflow for Godot AI
+
+This project applies the poteto approach by starting with a failed user journey,
+measuring it in a real editor, and making the smallest change that removes the
+demonstrated failure or duplicated work. Simpler code is useful when it makes
+startup, connection, updating, and recovery easier to understand and verify.
+
+## Working loop
+
+1. Name the observable outcome before editing: a usable authenticated connection,
+   an update that retains the editor, or recovery without losing scene state.
+   Record the allowed editor/client restarts separately.
+2. Reproduce on an isolated project using a relevant published starting version.
+   Record plugin, backend, client bridge, engine, process identity, and source or
+   artifact hashes. A new version label is not proof that new code runs.
+3. Measure the complete journey, then its components. Use comparable caches,
+   observation schedules, and endpoints; interleave comparison arms when
+   practical. Preserve slow runs and failures. An optimization must improve the
+   whole journey, not merely its isolated microbenchmark.
+4. Remove unnecessary work or duplicated ownership decisions. Preserve required
+   signature checks, exact-tree verification, authentication, loopback binding,
+   process identity, and bounded recovery. Do not trade those boundaries for a
+   shorter happy path.
+5. Verify during implementation in a rendered editor. Inspect startup and every
+   relevant reload/update, including failed states. Ordinary unchanged timing
+   repetitions use sampled screenshots plus continuous error monitoring; a
+   screenshot must actually be inspected. Keep capture outside measured startup.
+6. Turn demonstrated failures into meaningful regressions. Exercise changed code,
+   retained typed state and undo callbacks, authenticated tool responses, and
+   the exact ordering boundary involved. Where feasible, show that the old
+   implementation fails the new test.
+7. Finish the repository gauntlet and feature-specific smoke before committing.
+   Publish one coherent milestone per PR. Retain exact validation results and
+   describe incomplete production or platform qualification explicitly.
+8. Close disposable editors and clients after inspection. Remove generated
+   caches only after exit; retain compact evidence. Exclude isolated cache and
+   settings directories from the project scanner before its first launch.
+
+## What this produced
+
+- PR #1039 repairs Windows startup and lifecycle recovery without another
+  transport rewrite. It removes redundant connection/proof work while retaining
+  ownership checks. Measurements and their limits are in
+  [the milestone-one review](lifecycle-review-2026-09.md). That document is a
+  historical checkpoint; its next priorities are not the current completion list.
+- PR #1042 addresses published-v3 upgrades with connected clients and Windows
+  port reservation handling.
+- PR #1043 restores in-editor activation through a shared independent runner.
+  It waits for actual scan completion, keeps old script graphs usable for undo,
+  and loads the verified replacement at canonical paths. The already-shipped
+  4.0.4 updater still restarts on its first hop; the new updater and new v3
+  capsule retain the editor. See [self-update](self-update.md).
+
+## Reusable procedures and tests
+
+- [Verification procedure](verification.md): full checks, visible-editor cadence,
+  published-version scenarios, isolation, evidence, and cleanup.
+- `script/local-self-update-smoke`: local signed update and migration fixtures.
+- `tests/integration/_self_update_fixture.py`: shared real-editor test support.
+- `tests/integration/test_self_update_upgrade_paths.py`: update, migration,
+  continuity, connection, and recovery scenarios.
+- `tests/integration/test_migration_bridge_failures.py`: activation ordering,
+  successive script generations, and failure-path regressions.
+- `test_project/tests/test_update_activation.gd` and `test_dock.gd`: live
+  activation and dock behavior checks.
+- `script/stormtest.py`: concurrent tool calls and reload churn; see
+  [stress testing](STRESS_TESTING.md).
+- `.github/workflows/ci.yml`: automated platform checks, including Linux
+  real-editor updater scenarios under Xvfb.
+
+## Evidence and remaining portability work
+
+The Windows session's raw receipts live in its owned worktree at
+`.pstack-local/lifecycle/`, `.pstack-local/m2/`, `.pstack-local/m3/`, and
+`.pstack-local/m4/`.
+They contain experiment commands, source substitution manifests, logs, test
+results, screenshots, PID/version records, and cleanup receipts. They are
+untracked local evidence, not a repository backup or a production release
+qualification bundle. Some fixture directories contain private runtime records;
+do not publish or broadly stage this directory.
+
+The manual 3.2.5 -> 4.0.5 -> simulated 4.0.6 Windows preparations and observers
+are also local under `.pstack-local/m3/`. An independent Linux cloud run reported
+the rendered two-hop sequence passing with authenticated reads, reversible
+writes, retained scene/selection, and cross-update undo/redo after installing
+missing listener-discovery tools. Its initial failure and successful rerun are
+separate evidence. Portable fixture preparation does not itself automate the
+entire native-button sequence; do not call preparation a complete CI gate.
+
+Local signing keys, redirected delivery, and version-stamped candidate runtimes
+exercise implementation behavior. They do not replace qualification against
+the exact production-signed release artifacts. Follow the existing release
+contract for that final check.

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -2,10 +2,25 @@
 
 Part of the Godot AI agent guide — see [AGENTS.md](../AGENTS.md) for the always-loaded rules.
 
-How the plugin updates itself, what that path defends against, and what it
-deliberately does not. This replaces the transaction-actor design: there is no
-separate update process, no journal, no repair mode, no editor leases, and no
-hot reload. An update is verify, stage, swap, restart, then verify again.
+How the plugin updates itself and what that path defends against. The current
+implementation verifies, stages, swaps, verifies again, and activates the new
+plugin inside the same editor. A source-free runner survives the replacement;
+there is no separate update process or resident helper.
+
+Windows verification covers a native-click HTTPS update and a published 3.2.5
+capsule crossing that retain the editor process, unsaved scene state, selection,
+and undo history. Both load the exact verified tree and serve authenticated
+project-pinned reads afterwards. A separate untouched 4.0.4 fixture verifies its
+first update through the legacy restart path. Local test keys and version
+substitutions exercise these paths; production release qualification still runs
+against the exact signed release artifacts on every supported OS.
+
+An untouched published 4.0.4 installation still uses its already-shipped
+restart path for its first update. Installing new files cannot change the old
+updater already executing that operation. Updates initiated by the new updater,
+and final-v3 updates through the new capsule, retain the editor
+process. Restart-based startup recovery remains available for an interrupted
+installation.
 
 ## Goals
 
@@ -15,8 +30,10 @@ hot reload. An update is verify, stage, swap, restart, then verify again.
   tree, and the old tree is retained until the next successful update.
 - No editor start depends on any external process. `uvx` runs the server, not
   the plugin.
-- The whole path is two small GDScript files, a verifier and an installer, a
-  maintainer can read in a sitting.
+- Preserve the edited scene instance, unsaved changes, selection, and undo/redo
+  history. Updating neither autosaves scenes nor restarts the editor.
+- Keep activation coordination separate from signature verification and the
+  existing installer; the runner carries only its own source and copied values.
 
 ## Trust and delivery
 
@@ -38,12 +55,10 @@ All steps run inside the editor, on the main thread except the download.
 
 1. **Check.** The dock polls the releases API; a candidate is a newer `4.x`
    release exposing the six-name asset set. Dev checkouts skip this. Clicking
-   Update asks first: the update saves the project and relaunches the
-   editor. AI clients connected during the update keep working when the
-   version they were attached through is 4.0.4 or newer (their bridge follows
-   a server of the same major version); from an older version they must be
-   quit and relaunched afterwards (a client that keeps its MCP configuration
-   in memory respawns the old bridge on a mere server restart).
+   Update asks for confirmation before installing in this editor. Files being
+   installed does not mean the server or AI client connection is ready; the dock
+   reports migration and connection work separately. Client refresh requirements
+   are described below.
 2. **Download** the three canonical assets into
    `user://godot_ai_update/download/`, enforcing the release-declared sizes and
    trusted asset URLs exactly as today.
@@ -72,88 +87,108 @@ All steps run inside the editor, on the main thread except the download.
    `.gdignore` and a `.gitignore`. It lives beside the live tree on purpose:
    an atomic rename requires the same filesystem, and a project on one drive
    with user data on another must still swap atomically.
-5. **Quiesce.** Wait, bounded, until the dispatcher has no in-flight request,
-   then run the existing `prepare_for_update_reload()` server preparation.
-6. **Lock.** `res://addons/.godot_ai_update/lock.json` holds the editor's PID
-   and process fingerprint. A lock held by a live process that is not this
-   editor refuses the update; a lock from a dead process is replaced. The lock
-   covers download, stage and swap only: once the marker records the swap it
-   is released, and the marker itself refuses a second update until the
-   restarted editor has verified the tree.
-7. **Swap.** Rename the live tree to `.godot_ai_update/backup/<old version>/`,
+5. **Quiesce and hand off.** Wait, bounded, until the dispatcher has no
+   in-flight request and client workers have stopped, then run
+   `prepare_for_update_reload()`. The existing click-time lock at
+   `res://addons/.godot_ai_update/lock.json` identifies the editor by PID and
+   process fingerprint; another live owner refuses the update. Compile
+   `utils/update_activation_runner.gd` into a script without a resource path
+   and attach its node outside the plugin. Pass only the staged path and the
+   installer's record. The caller returns before the runner disables the old
+   plugin and drains deferred work. No suspended plugin callback crosses the
+   tree replacement.
+6. **Swap.** Request an old-tree filesystem scan and wait for its actual
+   `sources_changed` completion callback, bounded by a deadline. A generic
+   `filesystem_changed` notification is insufficient. Snapshot cached old script
+   references while their complete source tree still exists.
+   Rename the live tree to `.godot_ai_update/backup/<old version>/`,
    then rename the stage into place. Two renames, no file-by-file overlay.
    Write `.godot_ai_update/pending.json`: from and to versions, the manifest
-   SHA-256, the expected tree hash, the backup path, and the editor nonce.
-8. **Restart.** Persist the add-on in `editor_plugins/enabled` without enabling
-   it in the old process, then `EditorInterface.restart_editor(true)`. Updates
-   are interactive-only; headless and export launches never update. The one
-   exception is the `GODOT_AI_ALLOW_HEADLESS` override the plugin and the
-   capsule both honour, which exists so CI can drive these paths in a
-   headless editor and is never set for a real install.
-9. **Verify again, in the new process.** On start, if `pending.json` exists,
-   hash the live tree and compare it to the expected tree hash:
-   - equal: delete the marker's pending state, record success in the marker
-     (`status: success`, `from_version`, `to_version`, which the existing
-     stale-server recovery arm and the pin-only auto-repin gate already read),
-     repin owned client configuration once and record `clients_migrated` in
-     the marker, emit the `self_update` telemetry event, and continue normal
-     startup. An entry the migration cannot prove as what Configure wrote
-     before the update (a hand-edited or v3-shaped entry, an unreadable
-     file) is never rewritten (#890) and never blocks the server either: it
-     is left unchanged, named in the completion banner, and left to the
-     dock's Configure (#999). A success marker that records its migration is
-     the durable record of the last update and is nothing pending on later
-     starts;
-   - different: rename the live tree to `.godot_ai_update/quarantine/`, rename
-     the backup back into place, mark `status: rolled_back` with the reason,
-     and show it in the dock. If the backup is missing too, mark
-     `status: repair_required`, keep the plugin inactive, and show the exact
-     paths. Nothing is deleted automatically in either case.
-10. **Retain.** One successful update replaces the previous retained backup.
-    Backups are never deleted on a failure path.
-11. **Attached AI clients.** A client attached through `godot-ai attach`
-    during the update loses server A at the swap. Its bridge then does what
-    it always does without a backend: it spawns one, of the old version,
-    into the restart window. The restarted editor replaces a godot-ai server
-    at the version it just updated from, or any older server of its own
-    major version, once and without asking; a newer server, another major,
-    or any other conflict keeps the dock's explicit Restart Server
-    authority. Every
-    replacement launches our server before killing the occupant; that server
-    reports through its startup report the moment it reaches its bounded
-    60-second port wait
-    (a launch through uvx may spend seconds installing the new version
-    first), and only then is the occupant killed. The server binds and
-    listens the instant the port frees and hands that very socket to its
-    HTTP and WebSocket servers, so the port is never free between the old
-    backend's death and ours listening: a bridge polling for a free port to
-    spawn again never sees one. A 4.0.4+ bridge whose backend vanishes with
-    the port free also waits five seconds for a replacement to answer before
-    it spawns one of its own. The
-    old bridge, when it predates 4.0.4, refuses the new backend as
-    incompatible, so the dock tells the user to quit and relaunch AI clients
-    that were connected during the update; the repinned client configuration
-    launches the new version. Quit, not restart: Claude Desktop keeps its MCP
-    configuration in memory and respawns the old bridge from it until the
-    application itself is relaunched. A 4.0.4+ bridge keeps serving a server
-    of the same major version and follows the replacement on its own, so the
-    dock says those clients can reconnect without restarting. Ordinary starts
-    and post-update replacement use the same three-second probe timeout, so
-    both allow a backend time to answer before reporting a blocked connection.
+   SHA-256, expected tree hash, backup path, and editor nonce.
+7. **Verify again, before activation.** The runner calls the existing
+   installer's verification against the exact expected tree hash:
+   - equal: record success in the marker and proceed to activation;
+   - different: quarantine the replacement, restore the backup, and record
+     `rolled_back` with the reason;
+   - no provable usable tree: retain the evidence, leave the plugin inactive,
+     and report the recovery paths. Backups are not deleted on a failure.
+   The same verification remains available on the next editor start after an
+   interrupted update. The update lock is released before script discovery.
+8. **Refresh and enable.** Before another scan or frame yield, move the captured
+   old scripts to their actual
+   paths under the retained backup using `take_over_path()`. First verify that
+   the backup exactly matches the previous live tree and that no existing
+   retained generation occupies those paths. Existing undo callbacks keep their
+   old compiled code and typed state; canonical paths now load a fresh graph,
+   including fresh static variables. This does not reload new source into old
+   objects. Release installer/verifier references and request the new-tree scan.
+   Its actual `sources_changed` completion callback gates enabling the fresh
+   plugin; another scan started by an earlier listener cannot be skipped. Open user scenes/resources that serialize references to add-on
+   scripts are refused before replacement, so their next save cannot silently
+   point into a backup.
+   Enable the plugin, require its loaded version to match, and persist
+   `editor_plugins/enabled`. Scan, load, or persistence failures produce an
+   explicit activation failure rather than a success banner. The runner records
+   the outcome and original editor PID in `.godot_ai_update/activation.json`.
+9. **Migrate and reconnect.** The new plugin handles the verified update marker,
+   repins provably owned client entries, and records `clients_migrated` before
+   releasing normal server startup. Foreign or unprovable entries stay unchanged
+   and are reported for explicit Configure. A migration failure is not described
+   as a usable connection. The durable success marker is not a pending update on
+   subsequent starts. Backend ownership checks and the authenticated connection
+   are separate from successful file installation.
+10. **Retain.** Backups backing old compiled scripts remain available for the
+    lifetime of this editor, including across further in-editor updates. Normal
+    pruning resumes on a fresh editor start, when those undo references no
+    longer exist. Updates remain interactive-only; headless and export launches do not update.
+    `GODOT_AI_ALLOW_HEADLESS` exists only so CI can exercise the real path inside
+    an isolated headless editor.
+
+### Attached AI clients and endpoint migration
+
+A same-major update can temporarily lose its backend while the plugin reloads.
+Bridges from 4.0.4 onward can follow a compatible replacement of the same major;
+this does not promise compatibility for an older process merely because the
+plugin has been updated. Existing lifecycle replacement checks still require
+exact process identity and ownership authority. An unsigned status response or
+an occupied port grants no permission to terminate its owner. Ordinary starts
+and post-update probes allow an occupied listener up to three seconds to answer.
+
+A verified pre-v4 to v4 crossing selects a distinct free loopback HTTP/WS pair
+before capability paths, launch context, or client migration are fixed. The
+atomic `godot_ai/v4_endpoint_ports` override is reused by later updated editors;
+legacy port settings remain available to older plugins. Normal v4 updates
+without an override keep their existing custom ports. A malformed override
+blocks startup with an explicit endpoint retry; it does not silently fall back.
+
+The editor can therefore connect to v4 while an old v3 bridge still holds its
+server on the old ports. The migration neither kills that server nor treats its
+status as authenticated. The old bridge cannot authenticate to v4: reload the
+AI client's MCP configuration and reconnect once. An application relaunch is
+needed only when the host cannot reload that configuration. Repinning a global
+client entry also redirects it away from other projects still using old
+plugins; those projects need their own update or explicit endpoint configuration
+to join the new server. See [server-lifecycle.md](server-lifecycle.md#upgrading-from-a-pre-v4-installation).
 
 ## The v3-to-v4 capsule
 
 Final v3 installs update through their own signed-sidecar runner, which
 extracts a zip over the add-on and re-enables it. The capsule is that zip: a
-small bridge plugin plus the embedded canonical triple. The bridge runs steps 3
-to 8 with the same installer script shipped inside it, keeps the two fixes the
-crossing needed (removing v3's `game_helper` autoload before the swap, #946,
-and persisting the next-start enabled entry without loading v4 in the old
-process, #957), and restarts. The v4 plugin then runs step 9 as on any update.
+small bridge plugin plus the embedded canonical triple. The bridge verifies and
+stages that triple, removes only v3's matching `game_helper` autoload entry
+before the swap (#946), and acquires the existing process-identity lock. Its
+coordinator passes copied values to the same source-free activation runner and
+returns. The runner then disables the capsule, swaps, verifies, discovers the
+new scripts, enables v4, and persists enablement (#957) in the original editor.
+The coordinator's own source does not remain on a suspended stack through the
+swap. Canonical releases retain signed compatibility files at the former capsule
+paths so outstanding parser dependencies can still resolve; these inert shims
+are distinct from the capsule payload and its old update runner, which are absent
+from the canonical installation.
 
 The capsule also carries the final v3 add-on (`migration_payload/godot-ai-v3-plugin.zip`,
 re-packed from the `v3.2.5` tag). Pre-v4 updaters offer whatever release is
-latest and cannot know that v4 needs Godot 4.7, and they discard their
+latest and cannot know the new release's Godot version floor, and they discard their
 per-file backups once the overlay succeeds; on a Godot below the floor the
 bridge therefore puts that final v3 back and re-enables it instead of leaving
 a dead tree, and the user updates again after upgrading Godot. The fallback
@@ -177,8 +212,10 @@ still repins owned client entries to the installed version before serving.
 - Malformed archives: traversal, absolute paths, links, duplicate or
   case-colliding paths, oversized trees, extra or missing files.
 - A mixed-version live tree, from any interruption before the swap (nothing
-  was touched) or after it (the new-process verification restores the backup).
-- Stale in-memory scripts after a swap (every update restarts the editor).
+  was touched) or after it (exact-tree verification can restore the backup).
+- Stale in-memory scripts are an explicit activation acceptance boundary:
+  relocation separates old and new compiled graphs; real tests execute changed
+  dependencies and handlers, not just check a new version label.
 - A second editor on the same project starting an update concurrently (the
   lock).
 - A project whose client configs were configured elsewhere (the existing
@@ -193,7 +230,8 @@ still repins owned client entries to the installed version before serving.
   that is the whole guarantee.
 - Malicious code already running as the same user, or an administrator.
 - Two editors on the same project racing past the lock's process check.
-- The restart landing in a different Godot. On macOS the editor relaunches
+- On the already-published restart path, landing in a different Godot. On
+  macOS the editor relaunches
   through LaunchServices by bundle, and with several Godot copies installed
   that has been seen to start another copy once under test. The marker then
   stays `swapped`, an unsupported Godot says so instead of refusing blindly,
@@ -206,13 +244,14 @@ still repins owned client entries to the installed version before serving.
   archive and inventory rejections, stage hashing, marker states, rollback and
   repair decisions.
 - Four real-editor scenarios in `tests/integration/test_self_update_upgrade_paths.py`:
-  a signed v4-to-v4 update restarts into a working server; a final-v3 install
-  crosses the capsule; a tampered live tree after a swap is rolled back; the
+  a current-source signed update must retain the editor process and scene
+  state while loading changed code and serving authenticated, project-pinned
+  reads/writes; a final-v3 install crosses the capsule in the same editor; a tampered live tree after a swap is rolled back; the
   closed-editor installer's first start completes client migration. The
   capsule crossing is parametrized over the v3 versions the installed fleet
   runs; a pull request proves the two newest and the nightly run proves all
   of them. With the
-  capsule coordinator's restart handoff in
+  capsule coordinator's activation handoff in
   `tests/integration/test_migration_bridge_failures.py`, they run on Linux on
   every pull request (private HTTPS delivery) and on all three desktop OSes
   nightly (also local-file delivery on Linux/macOS), and the release
@@ -220,9 +259,9 @@ still repins owned client entries to the installed version before serving.
   on every OS before publication.
 - Interactive pass: `script/local-self-update-smoke` prepares a signed
   A-to-B project with a one-run key and opens it in a real editor. Click
-  Update in the dock; the harness waits for the editor the swap restarts
-  into, checks the marker, backup, live server and crash reports, and leaves
-  that editor open for inspection. `--from-v3-tag v3.2.4` does the same for
+  Update in the dock; the harness checks the expected activation mode (same
+  editor for the new updater, restart for an untouched old updater), marker,
+  backup, live server and crash reports, and leaves the editor open for inspection. `--from-v3-tag v3.2.4` does the same for
   the crossing: it installs that exact final-v3 tree with a locally built
   capsule, and you click Update in the v3 dock.
   With `GODOT_AI_TEST_GODOT_FLOOR=unmet` in the environment the same
@@ -230,19 +269,15 @@ still repins owned client entries to the installed version before serving.
   final v3 in place, and the harness verifies that restored tree rather than
   waiting for a restart.
 
-## Known limits (4.0.0)
+## Known limits
 
-These are accepted for 4.0.0 after an independent review; each has a manual
-route and none has field incidence yet.
-
-- **A replacement tree that does not load cannot recover itself.** Recovery
-  runs inside the new tree's own `plugin.gd`, after signature, hash and
-  inventory checks passed. A signed release whose scripts fail to parse on the
-  user's Godot leaves the marker `swapped` with the previous tree intact under
-  `addons/.godot_ai_update/backup/<version>/`. Recovery is manual: run
-  `script/v4-release install` with a good release, or move the backup back
-  over `addons/godot_ai/`. A pre-swap load check or a bootstrap outside the
-  tree would remove this limit at the cost of another maintained component.
+- **A signed tree can still fail to parse or activate.** Signature and tree
+  hashes do not prove Godot compatibility. The independent runner can report
+  that activation failed and retain the backup; it does not establish that a
+  broken signed release can always roll itself back after a script-load failure.
+  Recovery remains manual when required: install a good release with
+  `script/v4-release install`, or restore the retained backup under
+  `addons/.godot_ai_update/backup/<version>/`.
 - **The two-rename swap has crash windows.** A crash between the renames
   leaves no live tree and no new marker; a crash after the second rename but
   before the marker leaves an unverified replacement. Both are seconds wide and

--- a/docs/self-update.md
+++ b/docs/self-update.md
@@ -269,6 +269,31 @@ still repins owned client entries to the installed version before serving.
   final v3 in place, and the harness verifies that restored tree rather than
   waiting for a restart.
 
+## Preparing a two-hop interactive fixture
+
+Prepare both locally signed updates before opening the editor:
+
+```bash
+script/local-self-update-smoke --project-dir /tmp/godot-ai-two-hop \
+  --from-v3-tag v3.2.5 --target-version 4.0.5 --then-version 4.0.6 \
+  --start-published-v3-server --no-launch
+```
+
+The first signed v4 tree advertises the second signed package. No installed
+add-on files need to change between clicks. The published v3 server startup
+remains intact; the v4 backends are frozen local snapshots stamped with the
+test versions. Linux requires `lsof` or `ss` before preparation in this mode.
+
+This command prepares a fixture; it does not execute or certify both updates.
+Use the printed launch command, which runs an isolated child through a generated
+wrapper. A custom driver must use `godot_child_environment(project_dir)` as well.
+Use the two native dock update actions,
+and check process identity, scene/undo continuity, exact trees, and authenticated
+tool responses after each hop. The fixture refuses client configuration writes
+when its isolated Codex environment is missing or mismatched. Preserve screenshots
+and receipts, then close the editor and clean generated caches as described in
+[verification](verification.md).
+
 ## Known limits
 
 - **A signed tree can still fail to parse or activate.** Signature and tree

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -92,6 +92,17 @@ Use the actual Git installation directory for a non-default installation.
 `bash` must resolve to Git's executable, not the Windows WSL launcher. These
 tools create disposable signing/TLS fixtures and exercise the CI shell helpers.
 
+Prepare and launch Windows fixtures under the same user context. Files created
+by a separate sandbox account can deny the editor's child Python process access
+to its launcher. If startup exits before publishing proof, inspect captured
+stderr and fixture ACLs before attributing the failure to the plugin.
+
+On Linux, listener ownership checks require `lsof` or `ss` (provided by
+`iproute2`). Normal desktop installations commonly include `ss`; minimal test
+containers may include neither. Install one before live verification, for
+example `sudo apt-get install lsof` on Debian/Ubuntu. Missing tools must produce
+an actionable failure, never a bypass of the process ownership checks.
+
 1. Run the same Ruff scope as CI — production, tests, the `script/` Python
    package, and the executable Python release/smoke scripts:
    ```bash
@@ -150,6 +161,16 @@ After exit, remove disposable generated caches from the verified fixture paths.
 Keep source snapshots, logs, receipts, and the small evidence needed to explain
 failures; do not retain entire thumbnail/import caches as test evidence. Never
 clean a live fixture or a user's settings/cache directories.
+
+Full handler suites include deliberate error cases. Label their editor clearly
+and attribute console diagnostics to specific tests; passing assertions do not
+excuse errors from valid-input cases. Use a separate clean editor for the
+user-facing startup and update checks.
+
+For interactive pytest runs, pass `-o tmp_path_retention_policy=all` and copy
+the compact evidence before releasing the visual-review gate. The default
+retains only failed tests; passing assertions can otherwise delete the editor
+log even when visual review found a transient error worth investigating.
 
 Keep isolated settings and caches outside the Godot project, or create a
 `.gdignore` in their directory before the first editor launch. Otherwise Godot

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -140,6 +140,21 @@ tools create disposable signing/TLS fixtures and exercise the CI shell helpers.
 
 ## Verify lifecycle and updates throughout implementation
 
+Close each disposable editor when its test is finished. Preserve logs and
+receipts, inspect the final screenshot, then request a normal exit and verify
+that the exact process has stopped. Match both its project path and process
+creation identity before closing it. Discard only known smoke-test mutations;
+leave user editors and unsaved user work alone. Release test-owned client
+connections normally, and keep only editors needed for active checks running.
+After exit, remove disposable generated caches from the verified fixture paths.
+Keep source snapshots, logs, receipts, and the small evidence needed to explain
+failures; do not retain entire thumbnail/import caches as test evidence. Never
+clean a live fixture or a user's settings/cache directories.
+
+Keep isolated settings and caches outside the Godot project, or create a
+`.gdignore` in their directory before the first editor launch. Otherwise Godot
+can import its own thumbnail cache and produce misleading scan/load timings.
+
 Run a visible Godot editor before and after each meaningful lifecycle or update
 change. Load real scenes and exercise handlers before testing recovery or an
 update. A clean startup with no handlers loaded does not cover retained script

--- a/migration_bridge/migration_coordinator.gd
+++ b/migration_bridge/migration_coordinator.gd
@@ -1,16 +1,12 @@
 @tool
 extends Node
 
-## Value-only handoff across the capsule -> v4 tree swap. This node is parented
-## outside the EditorPlugin so it survives the capsule being disabled. It owns
-## the #946 autoload cleanup, the editor lock, the two-rename swap performed by
-## `utils/update_installer.gd`, the #957 next-start persistence, and the
-## restart. Nothing here spawns a process or loads a v4 runtime script.
+## Prepare the capsule's value-only handoff to the shared activation runner.
+## This coordinator finishes before the runner disables the capsule or swaps
+## its source. The runner alone owns the scan and in-editor activation.
 
-const PLUGIN_CFG := "res://addons/godot_ai/plugin.cfg"
-const LIVE_ROOT := "res://addons/godot_ai"
-const CAPSULE_MARKER := "res://addons/godot_ai/migration_bridge.gd"
 const INSTALLER_SCRIPT := "res://addons/godot_ai/utils/update_installer.gd"
+const ACTIVATION_SCRIPT := "res://addons/godot_ai/utils/update_activation_runner.gd"
 const PORT_RESOLVER_SCRIPT := "res://addons/godot_ai/utils/port_resolver.gd"
 const STATUS_SETTING := "godot_ai/v4_migration_bridge_status"
 ## v3's `plugin.gd::_ensure_game_helper_autoload` wrote
@@ -22,10 +18,9 @@ const STATUS_SETTING := "godot_ai/v4_migration_bridge_status"
 const GAME_HELPER_AUTOLOAD_SETTING := "autoload/_mcp_game_helper"
 const GAME_HELPER_AUTOLOAD_TARGET := "res://addons/godot_ai/runtime/game_helper.gd"
 const REQUIRED_INSTALLER_METHODS := [
-	"acquire_lock", "release_lock", "swap", "persist_next_start_enabled", "request_restart",
+	"acquire_lock", "release_lock", "discard_stage",
 ]
 const PRE_DISABLE_DRAIN_FRAMES := 2
-const POST_DISABLE_DRAIN_FRAMES := 2
 ## Unknown pre-v4 versions still describe a major crossing. Manual-major
 ## client repinning replaces any owned pre-v4 entry, so this fallback is
 ## identity metadata rather than a client-selection authority.
@@ -33,7 +28,7 @@ const UNKNOWN_V3_VERSION := "3.0.0"
 
 signal state_changed(message: String, failed: bool)
 
-enum Phase { IDLE, DRAIN, DISABLED, WAIT_SCAN, DONE }
+enum Phase { IDLE, DRAIN, DONE }
 
 var _package: Dictionary = {}
 var _phase := Phase.IDLE
@@ -60,10 +55,6 @@ func _process(_delta: float) -> void:
 			_frames -= 1
 			if _frames <= 0:
 				_prepare_swap()
-		Phase.DISABLED:
-			_frames -= 1
-			if _frames <= 0:
-				_swap()
 		_:
 			set_process(false)
 
@@ -78,6 +69,11 @@ func _prepare_swap() -> void:
 				"The migration capsule is incomplete (utils/update_installer.gd is missing or invalid)."
 			)
 			return
+	var activation := GDScript.new()
+	activation.source_code = FileAccess.get_file_as_string(ACTIVATION_SCRIPT)
+	if activation.source_code.is_empty() or activation.reload() != OK or not _script_declares(activation, "start"):
+		_fail_before_swap("The migration capsule's activation runner is missing or invalid.")
+		return
 	var cleared := _remove_v3_game_helper_autoload()
 	if cleared != OK:
 		_fail_before_swap(
@@ -94,16 +90,6 @@ func _prepare_swap() -> void:
 		_fail_before_swap(_error_of(locked, "Another editor holds the Godot AI update lock."))
 		return
 	_lock_held = true
-	print("MCP | v3 bridge disabling transition plugin")
-	EditorInterface.set_plugin_enabled(PLUGIN_CFG, false)
-	if EditorInterface.is_plugin_enabled(PLUGIN_CFG):
-		_fail_before_swap("Godot could not disable the migration capsule safely.")
-		return
-	_frames = POST_DISABLE_DRAIN_FRAMES
-	_phase = Phase.DISABLED
-
-
-func _swap() -> void:
 	var from_version := str(_package.get("from_version", ""))
 	var record := {
 		"from_version": from_version if not from_version.is_empty() else UNKNOWN_V3_VERSION,
@@ -111,47 +97,27 @@ func _swap() -> void:
 		"manifest_sha256": str(_package.get("manifest_sha256", "")),
 		"expected_tree_sha256": str(_package.get("expected_tree_sha256", "")),
 		"editor_nonce": Crypto.new().generate_random_bytes(16).hex_encode(),
-		## The v4 plugin reads this after the restart: a v3-to-v4 crossing
+		## The v4 plugin reads this after activation: a v3-to-v4 crossing
 		## may replace owned client-config entries broadly, which an
 		## ordinary v4-to-v4 update must not do.
 		"replace_owned_mismatches": true,
 	}
-	print("MCP | v3 bridge swapping in the verified canonical v4 tree")
-	var swapped: Variant = _installer.call("swap", str(_package.get("stage_root", "")), LIVE_ROOT, record)
-	if not swapped is Dictionary or not bool(swapped.get("ok", false)):
-		_after_swap_failure(_error_of(swapped, "The v4 tree swap failed."))
+	var runner: Node = activation.new()
+	get_tree().root.add_child(runner)
+	var accepted: Variant = runner.call("start", {"stage_root": str(_package.stage_root), "record": record})
+	if not accepted is bool or not accepted:
+		var reason := str(runner.get("refusal_reason"))
+		runner.queue_free()
+		_fail_before_swap(reason if not reason.is_empty() else "The migration activation runner refused the prepared handoff.")
 		return
-	_release_lock()
-	## Disabling the capsule also removed it from editor_plugins/enabled.
-	## Persist the next-start intent without enabling the plugin in this
-	## process: that would load v4 scripts into the old class cache (#957).
-	var persisted: Variant = _installer.call("persist_next_start_enabled", PLUGIN_CFG)
-	if not persisted is int or int(persisted) != OK:
-		var reason := error_string(int(persisted)) if persisted is int else "no result"
-		_stop(
-			"Could not save v4 startup settings (%s); explicit recovery is required."
-			% reason
-		)
-		return
-	print("MCP | v3 bridge restarting editor into canonical v4 tree")
+	## No capsule Script or suspended callback crosses into the scan. The
+	## runner holds only its independent source and copied package values.
+	_lock_held = false
+	_installer = null
 	_phase = Phase.DONE
 	set_process(false)
-	_installer.call("request_restart")
-
-
-## The installer restores the backup when its second rename fails. If the
-## capsule tree is back in place, re-enable it after a scan so the dock can
-## offer Retry; anything else stays disabled and needs explicit recovery.
-func _after_swap_failure(error: String) -> void:
-	_release_lock()
-	record_status(error)
-	push_error("Godot AI v4 migration: %s" % error)
-	if FileAccess.file_exists(CAPSULE_MARKER):
-		_discard_stage()
-		_scan_then_enable()
-		return
-	_phase = Phase.DONE
-	set_process(false)
+	print("MCP | v3 bridge handing verified tree to in-editor activation")
+	queue_free()
 
 
 func _fail_before_swap(message: String) -> void:
@@ -161,40 +127,8 @@ func _fail_before_swap(message: String) -> void:
 	push_error("Godot AI v4 migration: %s" % message)
 	_phase = Phase.DONE
 	set_process(false)
-	if EditorInterface.is_plugin_enabled(PLUGIN_CFG):
-		## The capsule dock is still alive; let it present Retry directly.
-		state_changed.emit(message, true)
-		queue_free()
-		return
-	_scan_then_enable()
-
-
-func _scan_then_enable() -> void:
-	_phase = Phase.WAIT_SCAN
-	set_process(false)
-	var filesystem := EditorInterface.get_resource_filesystem()
-	if filesystem == null:
-		_enable_after_scan.call_deferred()
-		return
-	if not filesystem.filesystem_changed.is_connected(_enable_after_scan):
-		filesystem.filesystem_changed.connect(_enable_after_scan, CONNECT_ONE_SHOT)
-	filesystem.scan()
-
-
-func _enable_after_scan() -> void:
-	if _phase != Phase.WAIT_SCAN:
-		return
-	_phase = Phase.DONE
-	EditorInterface.set_plugin_enabled(PLUGIN_CFG, true)
+	state_changed.emit(message, true)
 	queue_free()
-
-
-func _stop(message: String) -> void:
-	_release_lock()
-	record_status(message)
-	_phase = Phase.DONE
-	set_process(false)
-	push_error("Godot AI v4 migration: %s" % message)
 
 
 func _release_lock() -> void:

--- a/migration_bridge/plugin.gd
+++ b/migration_bridge/plugin.gd
@@ -4,7 +4,7 @@ extends EditorPlugin
 ## Temporary v3-compatible entry point delivered through the signed legacy
 ## updater asset. It owns presentation only. Verification and staging run in
 ## the detached bridge node; the value-only coordinator survives this plugin
-## being disabled and performs the swap and restart.
+## handing off to the shared in-editor activation runner.
 
 const MigrationBridge := preload("res://addons/godot_ai/migration_bridge.gd")
 const MigrationCoordinator := preload("res://addons/godot_ai/migration_coordinator.gd")

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -2100,7 +2100,7 @@ func _build_tools_tab(tabs: TabContainer) -> void:
 
 	_update_confirm = ConfirmationDialog.new()
 	_update_confirm.title = "Update Godot AI?"
-	_update_confirm.ok_button_text = "Update and restart"
+	_update_confirm.ok_button_text = "Update plugin"
 	_update_confirm.cancel_button_text = "Later"
 	_update_confirm.confirmed.connect(_on_update_confirmed)
 	add_child(_update_confirm)
@@ -2742,10 +2742,8 @@ func _on_update_pressed() -> void:
 	if not _post_update_action.is_empty():
 		post_update_action_requested.emit(_post_update_action)
 		return
-	## The update saves every open scene, swaps the add-on tree and relaunches
-	## the editor (docs/self-update.md, step 8). Ask before doing that to a
-	## user's session. A dock that is not in a scene tree has no dialog to
-	## show and proceeds directly.
+	## Updating briefly disconnects AI tools while the add-on is replaced.
+	## A dock outside the scene tree has no dialog and proceeds directly.
 	if _update_confirm != null and is_inside_tree():
 		_update_confirm.dialog_text = update_confirm_text(
 			_update_candidate_version, ClientConfigurator.get_plugin_version()
@@ -2767,7 +2765,7 @@ static func update_confirm_text(version: String, current_version: String) -> Str
 		else "Quit and relaunch connected AI clients after the update."
 	)
 	return (
-		"This will save your project and restart the Godot editor to install %s.\n\n%s"
+		"Install %s in this editor? Open scenes and unsaved changes stay in place. AI tools briefly disconnect while the plugin reloads.\n\n%s"
 	) % [target, clients]
 
 

--- a/plugin/addons/godot_ai/mcp_dock.gd
+++ b/plugin/addons/godot_ai/mcp_dock.gd
@@ -815,6 +815,9 @@ func _update_status() -> void:
 	elif connected:
 		status_text = _connected_status_text()
 		status_color = Color.GREEN
+	elif bool(server_status.get("handoff_retry_pending", false)):
+		status_text = "Recovering after update…"
+		status_color = COLOR_AMBER
 	elif state == ServerStateScript.CRASHED:
 		var exit_ms: int = server_status.get("exit_ms", 0)
 		status_text = "Server exited after %.1fs" % (exit_ms / 1000.0)
@@ -840,6 +843,9 @@ func _update_status() -> void:
 		## Every terminal spawn failure matched above; what is left is the
 		## post-update window where the server is being brought back.
 		status_text = "Finishing update — starting server…"
+		status_color = COLOR_AMBER
+	elif state == ServerStateScript.SPAWNING:
+		status_text = "Starting server…"
 		status_color = COLOR_AMBER
 	elif not transport_status.is_empty():
 		var transport_phase := str(transport_status.get("phase", ""))
@@ -2759,14 +2765,12 @@ func _on_update_confirmed() -> void:
 
 static func update_confirm_text(version: String, current_version: String) -> String:
 	var target := "Godot AI v%s" % version if not version.is_empty() else "the new Godot AI"
-	var clients := (
-		"AI clients already using v%s can reconnect without restarting. Relaunch clients still using an older version." % current_version
-		if McpServerVersionCheck.attached_bridges_follow(current_version, version)
-		else "Quit and relaunch connected AI clients after the update."
-	)
-	return (
-		"Install %s in this editor? Open scenes and unsaved changes stay in place. AI tools briefly disconnect while the plugin reloads.\n\n%s"
-	) % [target, clients]
+	var text := "Update to %s? Unsaved changes are kept." % target
+	if McpServerVersionCheck.attached_bridges_follow(current_version, version):
+		text += "\n\nRestart AI clients older than v4.0.4."
+	else:
+		text += "\n\nRestart your AI client after updating."
+	return text
 
 
 func present_update_check(result: Dictionary) -> void:

--- a/plugin/addons/godot_ai/migration_bridge.gd
+++ b/plugin/addons/godot_ai/migration_bridge.gd
@@ -1,0 +1,8 @@
+@tool
+extends Node
+
+## Retained capsule path: Godot can finish an old parser's dependency list
+## while loading the new plugin. Migration is complete in the canonical tree;
+## the verified capsule carries the active implementation at this same path.
+func start() -> void:
+	queue_free()

--- a/plugin/addons/godot_ai/migration_bridge.gd.uid
+++ b/plugin/addons/godot_ai/migration_bridge.gd.uid
@@ -1,0 +1,1 @@
+uid://e3r4fem8egus

--- a/plugin/addons/godot_ai/migration_coordinator.gd
+++ b/plugin/addons/godot_ai/migration_coordinator.gd
@@ -1,0 +1,20 @@
+@tool
+extends Node
+
+## Compatibility path for cached capsule dependencies after a signed update.
+## The canonical plugin has no remaining capsule installation to coordinate.
+const STATUS_SETTING := "godot_ai/v4_migration_bridge_status"
+
+
+func start(_package: Dictionary) -> void:
+	queue_free()
+
+
+static func record_status(error: String) -> void:
+	var settings := EditorInterface.get_editor_settings()
+	if settings != null:
+		settings.set_setting(status_setting(), JSON.stringify({"error": error}))
+
+
+static func status_setting() -> String:
+	return STATUS_SETTING + "_" + ProjectSettings.globalize_path("res://").sha256_text()

--- a/plugin/addons/godot_ai/migration_coordinator.gd.uid
+++ b/plugin/addons/godot_ai/migration_coordinator.gd.uid
@@ -1,0 +1,1 @@
+uid://qqsn55jmog6v

--- a/plugin/addons/godot_ai/migration_fallback.gd
+++ b/plugin/addons/godot_ai/migration_fallback.gd
@@ -1,0 +1,11 @@
+@tool
+extends Node
+
+## Retained capsule dependency path. The canonical v4 tree has no embedded
+## v3 fallback; keeping this path must never initiate a downgrade.
+static func available() -> bool:
+	return false
+
+
+func start() -> void:
+	queue_free()

--- a/plugin/addons/godot_ai/migration_fallback.gd.uid
+++ b/plugin/addons/godot_ai/migration_fallback.gd.uid
@@ -1,0 +1,1 @@
+uid://bym2nenea1nvd

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -135,6 +135,7 @@ var _last_logged_block := ""
 ## that is bound but not yet answering status reads as merely occupied.
 const POST_UPDATE_REPROBE_LIMIT := 10
 var _post_update_reprobes_left := POST_UPDATE_REPROBE_LIMIT
+var _post_update_retry_episode := 0
 ## A pre-v4 server left on the port by a still-running v3 attach bridge
 ## outlives the fast budget above: its lease lasts 30 s after that client
 ## quits and its idle backstop another 120 s. Poll slowly across that
@@ -713,6 +714,12 @@ func _lifecycle_snapshot_for_dock() -> Dictionary:
 		_normal_start_released and bool(snapshot.get("can_recover_incompatible", false))
 	)
 	snapshot["normal_start_released"] = _normal_start_released
+	if _post_update_retry_episode > 0 and int(snapshot.get("episode_id", 0)) == _post_update_retry_episode:
+		var episode: Dictionary = _lifecycle.episode_snapshot()
+		if str(episode.get("state", "")) == "BLOCKED" and str(episode.get("reason", "")) == "launch_gone" and str(episode.get("proof_pending_reason", "")) == "capability_pair":
+			## Only the presentation changes; transport remains blocked until proof.
+			snapshot["state"] = ServerStateScript.SPAWNING
+			snapshot["handoff_retry_pending"] = true
 	return snapshot
 
 
@@ -1339,11 +1346,13 @@ static func _supports_godot_version(version_info: Dictionary) -> bool:
 
 
 func _on_lifecycle_snapshot_changed(snapshot: Dictionary) -> void:
+	if int(snapshot.get("episode_id", 0)) != _post_update_retry_episode or str(snapshot.get("episode_state", "")) != "BLOCKED":
+		_post_update_retry_episode = 0
 	if _connection != null and bool(snapshot.get("connection_blocked", true)):
 		_connection.connect_blocked = true
 		_connection.connect_block_reason = str(snapshot.get("message", ""))
-	_log_lifecycle_block(snapshot)
 	_replace_server_left_by_update(snapshot)
+	_log_lifecycle_block(snapshot)
 	if _client_jobs != null:
 		_client_jobs.set_client_health_blocked(
 			ServerStateScript.blocks_client_health(
@@ -1363,7 +1372,8 @@ func _log_lifecycle_block(snapshot: Dictionary) -> void:
 	if message.is_empty() or message == _last_logged_block:
 		return
 	_last_logged_block = message
-	print("MCP | server start blocked: %s" % message)
+	var retry_pending := bool(_lifecycle_snapshot_for_dock().get("handoff_retry_pending", false))
+	print("MCP | %s: %s" % ["server handoff retry pending" if retry_pending else "server start blocked", message])
 
 
 ## Once, right after an update: a godot-ai server at the version we just
@@ -1385,6 +1395,9 @@ func _replace_server_left_by_update(snapshot: Dictionary) -> void:
 		## the remaining path.
 		if str(snapshot.get("episode_state", "")) != "BLOCKED":
 			return
+		var episode_id := int(snapshot.get("episode_id", 0))
+		if episode_id <= 0 or episode_id == _post_update_retry_episode:
+			return
 		if str(snapshot.get("blocked_hint", "")) == ServerLifecycleManager.STALE_PRE_V4_HINT:
 			if _post_update_stale_reprobes_left <= 0:
 				return
@@ -1394,13 +1407,15 @@ func _replace_server_left_by_update(snapshot: Dictionary) -> void:
 					% int(snapshot.get("conflict_port", 0))
 				)
 			_post_update_stale_reprobes_left -= 1
+			_post_update_retry_episode = episode_id
 			get_tree().create_timer(POST_UPDATE_STALE_REPROBE_SECONDS).timeout.connect(
-				_reprobe_after_update, CONNECT_ONE_SHOT
+				_reprobe_after_update.bind(episode_id), CONNECT_ONE_SHOT
 			)
 			return
 		if _post_update_reprobes_left > 0:
 			_post_update_reprobes_left -= 1
-			get_tree().create_timer(1.0).timeout.connect(_reprobe_after_update, CONNECT_ONE_SHOT)
+			_post_update_retry_episode = episode_id
+			get_tree().create_timer(1.0).timeout.connect(_reprobe_after_update.bind(episode_id), CONNECT_ONE_SHOT)
 		return
 	var version := str(snapshot.get("conflict_version", ""))
 	if not _update_may_replace(version):
@@ -1433,8 +1448,16 @@ func _update_may_replace(conflict_version: String) -> bool:
 	)
 
 
-func _reprobe_after_update() -> void:
+func _reprobe_after_update(episode_id: int) -> void:
+	if episode_id != _post_update_retry_episode:
+		return
+	_post_update_retry_episode = 0
 	if _post_update_replaced_version.is_empty() or _lifecycle == null or not _normal_start_released:
+		_publish_dock_status_snapshots()
+		return
+	var snapshot: Dictionary = _lifecycle.get_status_dict()
+	if int(snapshot.get("episode_id", 0)) != episode_id or str(snapshot.get("episode_state", "")) != "BLOCKED":
+		_publish_dock_status_snapshots()
 		return
 	_lifecycle.start_server()
 

--- a/plugin/addons/godot_ai/plugin.gd
+++ b/plugin/addons/godot_ai/plugin.gd
@@ -930,9 +930,10 @@ func _finish_post_update() -> void:
 	var recorded := UpdateInstaller.record_clients_migrated()
 	if recorded != OK:
 		push_warning("MCP | could not record client migration in the update marker: %s" % error_string(recorded))
-	## Backups are named by the version they hold: keep the one this update
-	## just retained (the previous version) and drop older ones.
-	UpdateInstaller.prune_backups(str(_post_update_outcome.get("from_version", "")))
+	## In-editor updates retain old script graphs for undo. Keep their backing
+	## files until a fresh editor process can safely prune older generations.
+	if not get_tree().root.has_meta("godot_ai_retained_update_scripts"):
+		UpdateInstaller.prune_backups(str(_post_update_outcome.get("from_version", "")))
 	_post_update_replaced_version = str(_post_update_outcome.get("from_version", ""))
 	_post_update_reprobes_left = POST_UPDATE_REPROBE_LIMIT
 	_post_update_stale_reprobes_left = POST_UPDATE_STALE_REPROBE_LIMIT
@@ -1561,7 +1562,7 @@ static func _remove_tree(path: String) -> void:
 	DirAccess.remove_absolute(path)
 
 
-## Verify, stage, quiesce, swap, restart. Every check runs in this editor
+## Verify, stage, quiesce, then hand activation to an independent runner. Every check runs in this editor
 ## against the downloaded bytes; nothing outside the editor is executed. The
 ## live tree is touched only by the two renames inside `swap`, and only after
 ## the staged tree has been re-hashed against the signed manifest.
@@ -1629,31 +1630,31 @@ func install_downloaded_update(package: Dictionary) -> void:
 		"editor_nonce": Crypto.new().generate_random_bytes(16).hex_encode(),
 		"replace_owned_mismatches": false,
 	}
-	var swapped: Dictionary = UpdateInstaller.swap(
-		str(staged.get("stage_root", "")), LIVE_ADDON_ROOT, record
+	## Compile an independent script with no resource path. Loading this as a
+	## normal Script would let the filesystem scan replace our live runner.
+	var runner_script := GDScript.new()
+	runner_script.source_code = FileAccess.get_file_as_string(
+		"res://addons/godot_ai/utils/update_activation_runner.gd"
 	)
-	if not bool(swapped.get("ok", false)):
-		var refused := "update swap refused: %s" % str(swapped.get("error", ""))
-		if not FileAccess.file_exists(PLUGIN_CFG):
-			_fail_update(
-				"Update failed — repair required",
-				refused + "; the previous tree is not live: run `script/v4-release install` or restore the backup by hand",
-			)
-			return
+	if runner_script.source_code.is_empty() or runner_script.reload() != OK:
 		UpdateInstaller.discard_stage()
-		_fail_update("Update failed — previous version kept", refused)
-		## Quiescence already stopped the server and cleared the dispatcher;
-		## the old tree is still live, so rebuild the plugin from it.
+		_fail_update("Update cancelled safely", "could not compile the independent activation runner")
 		_reload_plugin_after_failed_update()
 		return
+	var runner = runner_script.new()
+	get_tree().root.add_child(runner)
+	if not runner.start({"stage_root": str(staged.get("stage_root", "")), "record": record}):
+		var refusal_reason := str(runner.refusal_reason)
+		runner.queue_free()
+		UpdateInstaller.discard_stage()
+		_fail_update("Update cancelled safely", refusal_reason)
+		_reload_plugin_after_failed_update()
+		return
+	## The runner now owns the lock. Teardown's cancellation signal must not
+	## release it before the deferred disable/drain/swap sequence completes.
 	_update_swapped = true
-	## The lock covered download, stage and swap. From here the marker itself
-	## refuses a second update until the restarted editor verifies the tree,
-	## and that editor cannot prove this process dead, so release it now.
-	UpdateInstaller.release_lock()
-	UpdateInstaller.persist_next_start_enabled(PLUGIN_CFG)
-	print("MCP | update to %s swapped in; restarting the editor" % to_version)
-	UpdateInstaller.request_restart.call_deferred()
+	## Return: no frame of this plugin may be suspended across source replacement.
+
 
 
 ## Name the activation phase in the dock and let it repaint before the

--- a/plugin/addons/godot_ai/utils/port_resolver.gd
+++ b/plugin/addons/godot_ai/utils/port_resolver.gd
@@ -28,6 +28,20 @@ static func unlock_process_spawn() -> void:
 	_process_spawn_mutex.unlock()
 
 
+## A managed Linux server needs a listener PID tool to prove ownership.
+## Query each launch so installing the missing tool makes Retry work.
+static func listener_tools_problem() -> String:
+	if OS.get_name() != "Linux":
+		return ""
+	var output: Array = []
+	var available := OS.execute("/bin/sh", ["-c",
+		"command -v lsof >/dev/null 2>&1 || command -v ss >/dev/null 2>&1"
+	], output, true)
+	if available == 0:
+		return ""
+	return "Cannot verify Linux listener ownership: neither lsof nor ss is available on the editor's PATH. Install lsof or iproute2 (which provides ss), then retry starting the server."
+
+
 static func can_bind_local_port(port: int) -> bool:
 	var server := TCPServer.new()
 	var err := server.listen(port, "127.0.0.1")

--- a/plugin/addons/godot_ai/utils/release_verifier.gd
+++ b/plugin/addons/godot_ai/utils/release_verifier.gd
@@ -284,7 +284,8 @@ static func tree_hash_from_files(files: Dictionary) -> String:
 static func sha256_bytes(bytes: PackedByteArray) -> String:
 	var context := HashingContext.new()
 	context.start(HashingContext.HASH_SHA256)
-	context.update(bytes)
+	if not bytes.is_empty():
+		context.update(bytes)
 	return context.finish().hex_encode()
 
 

--- a/plugin/addons/godot_ai/utils/server_lifecycle.gd
+++ b/plugin/addons/godot_ai/utils/server_lifecycle.gd
@@ -773,6 +773,9 @@ func _effect_launch(payload: Dictionary) -> Dictionary:
 	var server_command: Array = payload.get("server_command", [])
 	if server_command.is_empty():
 		return {"ok": false, "reason": "no_command", "message": "No godot-ai server command was found."}
+	var listener_problem := PortResolver.listener_tools_problem()
+	if not listener_problem.is_empty():
+		return {"ok": false, "reason": "listener_tools_missing", "message": listener_problem}
 	## Do not spawn into a directory the server cannot publish from (#988):
 	## the failure would only surface as a proof timeout three minutes later.
 	var directory_problem := TransportCapability.directory_write_problem(port)
@@ -1151,7 +1154,7 @@ func _effect_stop(payload: Dictionary) -> Dictionary:
 	if disposition == "owned":
 		grants.append({"pid": pid, "fingerprint": fingerprint})
 	PortResolver.kill_exact_processes(grants, true)
-	if port > 0:
+	if port > 0 and not grants.is_empty():
 		PortResolver.wait_for_port_free(port, 3.0)
 	var targets_gone := true
 	for exact in grants:

--- a/plugin/addons/godot_ai/utils/update_activation_runner.gd
+++ b/plugin/addons/godot_ai/utils/update_activation_runner.gd
@@ -1,0 +1,367 @@
+@tool
+extends Node
+
+## Compile this source into a GDScript with no resource_path before creating
+## the node. Its named callbacks must survive replacement of the file itself.
+## The caller verifies/stages/quiesces and owns the update lock. No plugin,
+## dock, handler, or suspended caller frame crosses the deferred handoff.
+const LIVE_ROOT := "res://addons/godot_ai"
+const PLUGIN_CFG := LIVE_ROOT + "/plugin.cfg"
+const STAGE_ROOT := "res://addons/.godot_ai_update/stage/addons/godot_ai"
+const INSTALLER_PATH := LIVE_ROOT + "/utils/update_installer.gd"
+const VERIFIER_PATH := LIVE_ROOT + "/utils/release_verifier.gd"
+const RECEIPT_PATH := "res://addons/.godot_ai_update/activation.json"
+const SCAN_TIMEOUT_MS := 60000
+
+enum Phase { IDLE, DRAIN, REQUEST_OLD_SCAN, WAIT_OLD_SCAN, SWAPPING, REQUEST_NEW_SCAN, WAIT_NEW_SCAN, ENABLING, DONE }
+
+var _phase := Phase.IDLE
+var _package: Dictionary = {}
+var _installer: Script
+var _verifier: Script
+var _frames := 0
+var _deadline := 0
+var _filesystem: EditorFileSystem
+var _failure := ""
+var _outcome := ""
+var _backup_root := ""
+var _retired_scripts: Array[Script] = []
+var _inspected_objects := {}
+var _inspection_budget := 100000
+## Copied by a caller when start() refuses, before the runner is freed.
+var refusal_reason := "The independent activation handoff was refused."
+
+
+func start(package: Dictionary) -> bool:
+	if _phase != Phase.IDLE or not is_inside_tree():
+		return false
+	if not str(get_script().resource_path).is_empty():
+		return false  # A file-backed runner can be replaced by the scan it starts.
+	if package.get("stage_root") != STAGE_ROOT or not package.get("record") is Dictionary:
+		return false
+	var record: Dictionary = package.record
+	for key in ["from_version", "to_version", "manifest_sha256", "expected_tree_sha256", "editor_nonce"]:
+		if not record.get(key) is String or str(record[key]).is_empty():
+			return false
+	if not record.get("replace_owned_mismatches") is bool:
+		return false
+	# Copy only values that belong to the existing installer's swap record.
+	_package = {"stage_root": STAGE_ROOT, "record": {}}
+	for key in ["from_version", "to_version", "manifest_sha256", "expected_tree_sha256", "editor_nonce", "replace_owned_mismatches"]:
+		_package.record[key] = record[key]
+	_installer = ResourceLoader.load(INSTALLER_PATH, "", ResourceLoader.CACHE_MODE_IGNORE_DEEP) as Script
+	_verifier = ResourceLoader.load(VERIFIER_PATH, "", ResourceLoader.CACHE_MODE_IGNORE_DEEP) as Script
+	if _installer == null or _verifier == null:
+		return false
+	for method in ["swap", "verify_after_restart", "release_lock", "read_lock", "discard_stage"]:
+		if not _declares(_installer, method):
+			return false
+	if not _declares(_verifier, "hash_tree"):
+		return false
+	var lock: Dictionary = _installer.call("read_lock")
+	if int(lock.get("pid", 0)) != OS.get_process_id() or str(lock.get("fingerprint", "")).is_empty():
+		return false
+	_inspected_objects.clear()
+	_inspection_budget = 100000
+	if not _user_resources_can_keep_paths():
+		return false
+	refusal_reason = ""
+	process_mode = Node.PROCESS_MODE_ALWAYS
+	_phase = Phase.DRAIN
+	set_process(false)
+	_begin.call_deferred()
+	return true
+
+
+func _declares(script: Script, method: String) -> bool:
+	for entry in script.get_script_method_list():
+		if str(entry.get("name", "")) == method:
+			return true
+	return false
+
+
+func _begin() -> void:
+	_filesystem = EditorInterface.get_resource_filesystem()
+	if _filesystem == null:
+		_stop("The editor filesystem is unavailable; no update swap was attempted.")
+		return
+	_filesystem.sources_changed.connect(_scan_completed)
+	EditorInterface.set_plugin_enabled(PLUGIN_CFG, false)
+	if EditorInterface.is_plugin_enabled(PLUGIN_CFG):
+		_stop("Godot could not disable the plugin; the verified stage was retained.")
+		return
+	_frames = 2
+	set_process(true)
+
+
+func _process(_delta: float) -> void:
+	if _phase == Phase.DRAIN:
+		_frames -= 1
+		if _frames <= 0:
+			_phase = Phase.REQUEST_OLD_SCAN
+			_deadline = Time.get_ticks_msec() + SCAN_TIMEOUT_MS
+	elif _phase in [Phase.REQUEST_OLD_SCAN, Phase.WAIT_OLD_SCAN, Phase.REQUEST_NEW_SCAN, Phase.WAIT_NEW_SCAN]:
+		if Time.get_ticks_msec() >= _deadline:
+			_stop("The filesystem scan did not complete. The plugin remains disabled; the staged update and any backup were retained.")
+		elif _phase in [Phase.REQUEST_OLD_SCAN, Phase.REQUEST_NEW_SCAN] and not _filesystem.is_scanning():
+			_phase = Phase.WAIT_OLD_SCAN if _phase == Phase.REQUEST_OLD_SCAN else Phase.WAIT_NEW_SCAN
+			# scan() may decline while a finished worker still awaits GUI
+			# completion. Its sources_changed signal remains a valid barrier.
+			_filesystem.scan()
+
+
+func _swap() -> void:
+	set_process(false)
+	# A cache lookup may resolve dependencies even when the requested script
+	# is cached. Retain all old references while their complete tree exists;
+	# never load a canonical path after the swap to recover an old script.
+	if not _collect_cached_scripts(LIVE_ROOT):
+		_stop("The previous script cache could not be captured safely; no update swap was attempted.")
+		return
+	var before: Dictionary = _verifier.call("hash_tree", LIVE_ROOT)
+	if not bool(before.get("ok", false)):
+		_stop("Could not hash the previous tree before activation; no swap was attempted.")
+		return
+	var swapped: Dictionary = _installer.call("swap", STAGE_ROOT, LIVE_ROOT, _package.record)
+	if not bool(swapped.get("ok", false)):
+		_failure = "Update swap failed: %s" % str(swapped.get("error", "unknown error"))
+		var restored: Dictionary = _verifier.call("hash_tree", LIVE_ROOT)
+		if not bool(restored.get("ok", false)) or restored.get("tree_sha256") != before.get("tree_sha256"):
+			_stop(_failure + "; the original tree could not be proven restored. Explicit repair is required.")
+			return
+		_installer.call("discard_stage")
+		_outcome = "previous_tree_retained"
+	else:
+		print("MCP | update to %s swapped in; reloading the plugin in this editor" % str(_package.record.to_version))
+		var verified: Dictionary = _installer.call("verify_after_restart", LIVE_ROOT)
+		_outcome = str(verified.get("status", ""))
+		if _outcome != "success" and _outcome != "rolled_back":
+			_stop("The installed tree could not be verified: %s" % str(verified.get("error", "unknown outcome")))
+			return
+		if _outcome == "rolled_back":
+			_failure = "Update verification failed; the previous tree was restored: %s" % str(verified.get("error", ""))
+		else:
+			_backup_root = str(verified.get("backup_root", ""))
+			var expected_backup := "res://addons/.godot_ai_update/backup/" + str(_package.record.from_version)
+			if _backup_root != expected_backup:
+				_stop("The update marker names an unexpected backup. The plugin remains disabled.")
+				return
+			var backup: Dictionary = _verifier.call("hash_tree", _backup_root)
+			if not bool(backup.get("ok", false)) or backup.get("tree_sha256") != before.get("tree_sha256"):
+				_stop("The retained backup could not be proven to match the previous tree. The plugin remains disabled.")
+				return
+	if _outcome == "success" and not _retire_cached_scripts(_backup_root):
+		_stop("The previous script cache could not be retained safely. The plugin remains disabled.")
+		return
+	_release_scripts()
+	_phase = Phase.REQUEST_NEW_SCAN
+	_deadline = Time.get_ticks_msec() + SCAN_TIMEOUT_MS
+	set_process(true)
+
+
+func _scan_completed(_sources_changed: bool) -> void:
+	if _phase not in [Phase.WAIT_OLD_SCAN, Phase.WAIT_NEW_SCAN]:
+		return
+	if _filesystem.is_scanning():
+		return  # Another completion listener already started a newer scan.
+	if Time.get_ticks_msec() >= _deadline:
+		_stop("The filesystem scan completion arrived after the activation deadline. The plugin remains disabled.")
+		return
+	set_process(false)
+	# sources_changed follows scan actions, documentation, and GUI updates.
+	# filesystem_changed can occur earlier; a deferred completion can become
+	# stale during a newer GUI scan. Consume this boundary synchronously.
+	if _phase == Phase.WAIT_OLD_SCAN:
+		_phase = Phase.SWAPPING
+		_swap()
+	else:
+		_phase = Phase.ENABLING
+		_filesystem.sources_changed.disconnect(_scan_completed)
+		_enable()
+
+
+func _enable() -> void:
+	if not _failure.is_empty() and str(_package.record.from_version).get_slice(".", 0).to_int() < 4:
+		# A restored capsule must show Retry instead of automatically repeating
+		# the failed update. This is its existing project-scoped status key.
+		var settings := EditorInterface.get_editor_settings()
+		if settings != null:
+			var key := "godot_ai/v4_migration_bridge_status_" + ProjectSettings.globalize_path("res://").sha256_text()
+			settings.set_setting(key, JSON.stringify({"error": _failure}))
+	EditorInterface.set_plugin_enabled(PLUGIN_CFG, true)
+	if not EditorInterface.is_plugin_enabled(PLUGIN_CFG):
+		_stop("The scanned plugin could not be enabled. The installed tree and backup were retained.")
+		return
+	if _outcome == "success":
+		var plugin := _find_plugin(get_tree().root)
+		if plugin == null or str(plugin.get("_loaded_plugin_version")) != str(_package.record.to_version):
+			EditorInterface.set_plugin_enabled(PLUGIN_CFG, false)
+			_stop("The enabled plugin did not report the installed version. The update evidence was retained.")
+			return
+	var saved := ProjectSettings.save()
+	if saved != OK:
+		_stop("The plugin is enabled, but saving its enabled state failed: %s" % error_string(saved))
+		return
+	_phase = Phase.DONE
+	_record(_outcome, _failure)
+	if not _failure.is_empty():
+		_show_failure(_failure)
+		return
+	print("MCP | update activation completed in editor PID %d" % OS.get_process_id())
+	queue_free()
+
+
+func _user_resources_can_keep_paths() -> bool:
+	# Retiring a Script changes resource_path for all its existing users.
+	# Refuse serializable scene/resource references instead of silently making
+	# a user's next save point into the updater's retained backup directory.
+	var roots: Array = []
+	if EditorInterface.has_method("get_open_scene_roots"):
+		roots = EditorInterface.call("get_open_scene_roots")
+	else:
+		if EditorInterface.get_open_scenes().size() > 1:
+			refusal_reason = "This Godot version cannot inspect every open scene safely. Close the other scene tabs before retrying the update."
+			return false
+		var current := EditorInterface.get_edited_scene_root()
+		if current != null:
+			roots.append(current)
+	for root in roots:
+		if not _inspect_user_node(root):
+			return false
+	var inspected := EditorInterface.get_inspector().get_edited_object()
+	if inspected is Resource and not _inspect_user_value(inspected, 0):
+		return false
+	return true
+
+
+func _inspect_user_node(node: Node) -> bool:
+	if not _inspect_user_value(node, 0):
+		return false
+	for child in node.get_children():
+		if not _inspect_user_node(child):
+			return false
+	return true
+
+
+func _inspect_user_value(value: Variant, depth: int) -> bool:
+	_inspection_budget -= 1
+	if _inspection_budget < 0 or depth > 64:
+		refusal_reason = "Open scene or resource data exceeded the safe inspection limit. Close the affected scenes or resources before retrying the update."
+		return false
+	if value is Script:
+		if value.resource_path.begins_with(LIVE_ROOT + "/"):
+			refusal_reason = "An open scene or resource references addon script %s. In-editor activation would change its saved script path. Close the scene or resource before retrying; the update was not installed." % value.resource_path
+			return false
+		return true
+	if value is Resource or value is Node:
+		var identity: int = value.get_instance_id()
+		if _inspected_objects.has(identity):
+			return true
+		_inspected_objects[identity] = true
+		for property in value.get_property_list():
+			if int(property.usage) & PROPERTY_USAGE_STORAGE:
+				if not _inspect_user_value(value.get(property.name), depth + 1):
+					return false
+	elif value is Array:
+		for entry in value:
+			if not _inspect_user_value(entry, depth + 1):
+				return false
+	elif value is Dictionary:
+		for key in value:
+			if not _inspect_user_value(key, depth + 1) or not _inspect_user_value(value[key], depth + 1):
+				return false
+	return true
+
+
+func _retire_cached_scripts(backup_root: String) -> bool:
+	# All references were captured before replacement. Godot moves
+	# both its resource and GDScript cache entries through take_over_path().
+	# Existing UndoRedo callbacks keep the old compiled code and typed state;
+	# canonical loads create a fresh graph, including fresh static variables.
+	for script in _retired_scripts:
+		var previous_path := script.resource_path
+		var retained_path := backup_root + previous_path.trim_prefix(LIVE_ROOT)
+		if not previous_path.begins_with(LIVE_ROOT + "/") or not FileAccess.file_exists(retained_path):
+			return false
+		if ResourceLoader.has_cached(retained_path):
+			return false  # Never displace a different retained generation.
+	# A later update in this same editor must not prune source files still
+	# referenced by an earlier generation's undo callbacks.
+	get_tree().root.set_meta("godot_ai_retained_update_scripts", true)
+	for script in _retired_scripts:
+		var retained_path := backup_root + script.resource_path.trim_prefix(LIVE_ROOT)
+		script.take_over_path(retained_path)
+		if script.resource_path != retained_path:
+			return false
+	return true
+
+
+func _collect_cached_scripts(folder: String) -> bool:
+	var directory := DirAccess.open(folder)
+	if directory == null:
+		return false
+	for filename in directory.get_files():
+		if not filename.ends_with(".gd"):
+			continue
+		var canonical := folder.path_join(filename)
+		if ResourceLoader.has_cached(canonical):
+			var script := ResourceLoader.load(canonical) as Script
+			if script == null or script.resource_path != canonical:
+				return false
+			_retired_scripts.append(script)
+	for child in directory.get_directories():
+		if not _collect_cached_scripts(folder.path_join(child)):
+			return false
+	return true
+
+
+func _find_plugin(node: Node) -> Node:
+	var script := node.get_script() as Script
+	if script != null and script.resource_path == LIVE_ROOT + "/plugin.gd":
+		return node
+	for child in node.get_children():
+		var found := _find_plugin(child)
+		if found != null:
+			return found
+	return null
+
+
+func _release_scripts() -> void:
+	if _installer != null:
+		_installer.call("release_lock")
+	_installer = null
+	_verifier = null
+
+
+func _stop(message: String) -> void:
+	_phase = Phase.DONE
+	set_process(false)
+	if _filesystem != null and _filesystem.sources_changed.is_connected(_scan_completed):
+		_filesystem.sources_changed.disconnect(_scan_completed)
+	_release_scripts()
+	_record("activation_failed", message)
+	_show_failure(message)
+
+
+func _record(status: String, message: String) -> void:
+	var file := FileAccess.open(RECEIPT_PATH, FileAccess.WRITE)
+	if file != null:
+		file.store_string(JSON.stringify({"status": status, "error": message,
+			"editor_pid": OS.get_process_id(), "from_version": _package.record.from_version,
+			"to_version": _package.record.to_version, "unix": Time.get_unix_time_from_system()}))
+	else:
+		push_error("MCP | could not write update activation evidence: %s" % error_string(FileAccess.get_open_error()))
+
+
+func _show_failure(message: String) -> void:
+	push_error("MCP | %s" % message)
+	if DisplayServer.get_name() == "headless":
+		queue_free()
+		return
+	var dialog := AcceptDialog.new()
+	dialog.title = "Godot AI update needs attention"
+	dialog.dialog_text = message + "\nUpdate evidence: res://addons/.godot_ai_update/"
+	add_child(dialog)
+	dialog.confirmed.connect(queue_free)
+	dialog.canceled.connect(queue_free)
+	dialog.popup_centered(Vector2i(620, 220))

--- a/plugin/addons/godot_ai/utils/update_activation_runner.gd.uid
+++ b/plugin/addons/godot_ai/utils/update_activation_runner.gd.uid
@@ -1,0 +1,1 @@
+uid://mj7jpaq6wt27

--- a/plugin/addons/godot_ai/utils/update_mixed_state.gd
+++ b/plugin/addons/godot_ai/utils/update_mixed_state.gd
@@ -1,0 +1,140 @@
+@tool
+extends RefCounted
+
+## Scanner that detects whether `addons/godot_ai/` is in a half-installed
+## state left behind by a self-update whose rollback couldn't restore the
+## previous addon contents (`UpdateReloadRunner.InstallStatus.FAILED_MIXED`).
+##
+## Without this surface the user sees "plugin won't start" with no actionable
+## context, re-runs the update, and compounds the mismatch (issue #354 /
+## audit-v2 #10). The dock paints a banner from `diagnose()` and
+## `editor_handler.gd::get_editor_state` includes the same Dictionary so an
+## MCP agent can see and report the state.
+
+const ADDON_DIR := "res://addons/godot_ai/"
+## Producer is `update_reload_runner.gd::INSTALL_BACKUP_SUFFIX`. Inlined as a
+## literal because old two-phase runners can parse this diagnostic script
+## against stale runner Script-object content during their mixed-snapshot
+## scan. `test_update_backup_suffix_stays_in_sync` guards against drift.
+const BACKUP_SUFFIX := ".update_backup"
+## Cap so a runaway addons tree (someone parented the wrong dir, an old
+## crashed install left thousands of artifacts) can't blow the
+## `editor_state` payload size or freeze the editor on first paint.
+const MAX_BACKUP_RESULTS := 200
+## TTL for the `diagnose()` cache. `editor_state` is one of the highest-
+## traffic MCP tools (agents poll it constantly) and a recursive
+## `DirAccess` walk on every call would put I/O on the 4ms `_process()`
+## budget. Mixed-state is rare and persistent across editor restarts, so
+## a few seconds of staleness is acceptable; the dock's Re-scan button
+## bypasses the cache via `force=true` for immediate feedback.
+const CACHE_TTL_MSEC := 5000
+
+static var _cache_value: Dictionary = {}
+static var _cache_timestamp_msec: int = -1
+
+
+## Walk `dir` recursively and return every `res://`-relative path that ends
+## in `.update_backup`, sorted ascending. Truncates at `MAX_BACKUP_RESULTS`
+## — the truncation flag is exposed via `diagnose()`.
+##
+## Walk order is deterministic: entries within each directory are sorted
+## alphabetically, subdirs pushed reverse-sorted so DFS pops them in
+## ascending order. Without this two scans of the same mixed tree could
+## return different 200-file slices when truncation kicks in (Godot's
+## `list_dir` order isn't guaranteed stable across filesystems).
+static func find_backups(dir: String = ADDON_DIR) -> Array:
+	var results: Array = []
+	var stack: Array = [dir]
+	while not stack.is_empty():
+		if results.size() >= MAX_BACKUP_RESULTS:
+			break
+		var current: String = stack.pop_back()
+		var d := DirAccess.open(current)
+		## Missing dir, permission error, or unreadable junction — skip
+		## silently. A missing addons dir is the bare-clone case; mid-walk
+		## errors stay quiet so a single permission glitch can't block the
+		## diagnostic the rest of the scan would have produced.
+		if d == null:
+			continue
+		var entries: Array = []
+		d.list_dir_begin()
+		while true:
+			var entry := d.get_next()
+			if entry.is_empty():
+				break
+			if entry == "." or entry == "..":
+				continue
+			entries.append({"name": entry, "is_dir": d.current_is_dir()})
+		d.list_dir_end()
+		entries.sort_custom(func(a, b): return a["name"] < b["name"])
+		## Push subdirs reverse-sorted so the next outer iteration pops
+		## them in ascending order — see method docstring for why this
+		## determinism matters for the truncated case.
+		for i in range(entries.size() - 1, -1, -1):
+			var entry: Dictionary = entries[i]
+			if entry["is_dir"]:
+				stack.append(current.path_join(entry["name"]))
+		for entry in entries:
+			if entry["is_dir"]:
+				continue
+			if not String(entry["name"]).ends_with(BACKUP_SUFFIX):
+				continue
+			results.append(current.path_join(entry["name"]))
+			if results.size() >= MAX_BACKUP_RESULTS:
+				break
+	results.sort()
+	return results
+
+
+## Build the structured diagnostic Dictionary surfaced via `editor_state`
+## and the dock banner. Empty when the addons tree is clean — callers
+## gate banner visibility / response field on `is_empty()`.
+##
+## Cached for `CACHE_TTL_MSEC` when scanning the default `ADDON_DIR` so
+## per-`editor_state` polls don't re-walk the addons tree every frame.
+## Tests passing a custom `dir` always see a fresh scan (cache only
+## tracks the production path). `force=true` bypasses the cache — used
+## by the dock's Re-scan button so a manual fix is reflected immediately.
+static func diagnose(dir: String = ADDON_DIR, force: bool = false) -> Dictionary:
+	var use_cache := dir == ADDON_DIR and not force
+	if use_cache and _cache_timestamp_msec >= 0:
+		if Time.get_ticks_msec() - _cache_timestamp_msec < CACHE_TTL_MSEC:
+			return _cache_value.duplicate(true)
+
+	var backups := find_backups(dir)
+	var result: Dictionary = {}
+	if not backups.is_empty():
+		## Most commonly produced by `_rollback_paths_written` returning
+		## FAILED_MIXED, but `_finalize_install_success` removes backups on
+		## a best-effort basis so a successful install can also leave them
+		## behind if the cleanup `remove_absolute` hit a permission error.
+		## The recovery action — delete the *.update_backup files — is the
+		## same in both cases, so the message acknowledges both
+		## possibilities rather than asserting the alarming one.
+		result = {
+			"addon_dir": dir,
+			"backup_files": backups,
+			"backup_count": backups.size(),
+			"truncated": backups.size() >= MAX_BACKUP_RESULTS,
+			"message": (
+				"Found .update_backup files in addons/godot_ai/. This usually"
+				+ " means a self-update rollback couldn't restore the previous"
+				+ " addon contents (FAILED_MIXED) — the plugin may load a mix"
+				+ " of old and new files. Restore the addon from your VCS or a"
+				+ " fresh release ZIP, then delete the listed *.update_backup"
+				+ " files. If the plugin runs without issues these are likely"
+				+ " stale from a successful install and safe to delete."
+			),
+		}
+	if use_cache:
+		_cache_value = result.duplicate(true)
+		_cache_timestamp_msec = Time.get_ticks_msec()
+	return result
+
+
+## Reset the `diagnose()` cache. Tests that flip the addons-tree state
+## between calls use this to avoid TTL-bound flakiness; the dock's
+## Re-scan button uses `force=true` instead.
+static func clear_cache() -> void:
+	_cache_value = {}
+	_cache_timestamp_msec = -1

--- a/plugin/addons/godot_ai/utils/update_mixed_state.gd.uid
+++ b/plugin/addons/godot_ai/utils/update_mixed_state.gd.uid
@@ -1,0 +1,1 @@
+uid://dd5rti52vgs71

--- a/script/local-self-update-smoke
+++ b/script/local-self-update-smoke
@@ -54,6 +54,9 @@ SMOKE_STAGED_LOG = "MCP | self-update smoke: staged signed local bundle"
 # tree (docs/self-update.md); nothing of it lives outside the project.
 UPDATE_STATE_DIR = "addons/.godot_ai_update"
 SMOKE_SWAP_LOG_SUFFIX = "swapped in; restarting the editor"
+IN_EDITOR_SWAP_LOG_SUFFIX = "swapped in; reloading the plugin in this editor"
+IN_EDITOR_COMPLETED_LOG = "MCP | update activation completed in editor PID "
+V3_BRIDGE_HANDOFF_LOG = "MCP | v3 bridge handing verified tree to in-editor activation"
 SMOKE_MIGRATED_LOG = "MCP | client migration completed"
 RESTARTED_EDITOR_LOG_NAME = "godot-editor-restarted.log"
 RESTARTED_EDITOR_TIMEOUT_SECONDS = 120.0
@@ -78,6 +81,7 @@ CAPSULE_ONLY_ENTRIES = (
 CAPSULE_INSTALLER_SCRIPTS = (
     "release_verifier.gd",
     "update_installer.gd",
+    "update_activation_runner.gd",
     "port_resolver.gd",
     "windows_port_reservation.gd",
 )
@@ -1261,16 +1265,17 @@ def print_instructions(
     print("Manual step:")
     print("  1. In the Godot AI dock, click Update, then confirm the update dialog.")
     print("  2. The editor verifies, stages and swaps the bundle, prints")
-    print(f"     '... {SMOKE_SWAP_LOG_SUFFIX}' and restarts itself. Nothing else to click.")
-    print(f"  3. The restarted editor verifies the tree, prints '{SMOKE_MIGRATED_LOG}',")
+    print("     its activation result. The new updater keeps this editor open;")
+    print("     a published 4.0.4 updater still restarts on its first update.")
+    print(f"  3. The activated plugin verifies the tree, prints '{SMOKE_MIGRATED_LOG}',")
     print("     shows the update as complete in the dock, and brings the server back")
     print("     at the new version.")
-    print("  4. This script waits for that restarted editor, checks disk state, /godot-ai/status")
+    print("  4. This script checks the expected editor continuity, disk state, /godot-ai/status")
     print("     and .ips files, then leaves the editor open for inspection.")
     print("")
     print("Failure signals:")
     print("  - Godot exits without the swap line, exits non-zero, or a new Godot*.ips appears.")
-    print("  - The restarted editor never prints the migration line, or its server is not")
+    print("  - The activated plugin never prints the migration line, or its server is not")
     print("    listening at the new version.")
     print("  - The update marker does not record success, or the retained backup is missing.")
     print("  - 'MCP | [self-update-smoke vnext _exit_tree]' prints before the swap.")
@@ -1293,6 +1298,9 @@ def launch_and_verify(
     if godot_path is None or not Path(godot_path).exists():
         raise HarnessError(f"Godot executable not found: {godot_bin}")
 
+    same_editor = "update_activation_runner.gd" in (
+        project_dir / "addons/godot_ai/plugin.gd"
+    ).read_text(encoding="utf-8")
     started = time.time()
     log_path = project_dir / ".godot-ai-self-update-smoke" / "godot-editor.log"
     child_environment = os.environ.copy()
@@ -1316,24 +1324,25 @@ def launch_and_verify(
     )
     lines: list[str] = []
     assert proc.stdout is not None
-    for line in proc.stdout:
-        print(line, end="")
-        lines.append(line.rstrip("\n"))
-    code = proc.wait()
-    if code != 0:
-        print(f"FAIL: Godot exited with code {code}")
-        print_new_reports(baseline, started, Path(godot_path))
-        return code or 1
-    if not smoke_restart_requested(lines):
-        print("FAIL: the editor closed before an update was swapped in (click Update in the dock)")
-        return 1
-
-    ## The swapping editor is gone; the one it restarted into verifies the
-    ## tree, repins clients and starts the new server. Its log is forwarded
-    ## by patch_restart_log; wait for it there, then for the live server.
-    restarted_log = project_dir / ".godot-ai-self-update-smoke" / RESTARTED_EDITOR_LOG_NAME
-    restarted_lines = wait_for_restarted_editor(restarted_log)
-    lines.extend(restarted_lines)
+    drain = threading.Thread(target=_drain_editor_output, args=(proc.stdout, lines), daemon=True)
+    drain.start()
+    if same_editor:
+        if not wait_for_in_editor_activation(proc, lines):
+            print("FAIL: the original editor did not complete in-editor activation")
+            print_new_reports(baseline, started, Path(godot_path))
+            return 1
+    else:
+        code = proc.wait()
+        drain.join()
+        if code != 0:
+            print(f"FAIL: Godot exited with code {code}")
+            print_new_reports(baseline, started, Path(godot_path))
+            return code or 1
+        if not smoke_restart_requested(lines):
+            print("FAIL: the editor closed before an update was swapped in (click Update)")
+            return 1
+        restarted_log = project_dir / ".godot-ai-self-update-smoke" / RESTARTED_EDITOR_LOG_NAME
+        lines.extend(wait_for_restarted_editor(restarted_log))
     post_update_status = wait_for_live_status(
         http_port,
         next_server_version,
@@ -1351,8 +1360,12 @@ def launch_and_verify(
         post_update_status=post_update_status,
         next_server_version=next_server_version,
         godot_path=Path(godot_path),
+        same_editor_pid=proc.pid if same_editor else None,
     )
-    print("The restarted editor stays open for inspection; close it when you are done.")
+    if same_editor and proc.poll() is not None:
+        print("FAIL: the original editor exited during verification")
+        ok = False
+    print("The editor stays open for inspection; close it when you are done.")
     return 0 if ok else 1
 
 
@@ -1643,8 +1656,8 @@ def print_v3_instructions(
     print("Manual step:")
     print(f"  1. In the v{from_version} Godot AI dock, click Update.")
     print("  2. v3's own updater extracts the capsule; the bridge verifies, stages and swaps")
-    print(f"     the v4 tree, prints '{V3_BRIDGE_RESTART_LOG}' and restarts the editor.")
-    print(f"  3. The restarted v4 editor verifies the tree, prints '{SMOKE_MIGRATED_LOG}',")
+    print("     the v4 tree and reloads the plugin in the same editor process.")
+    print(f"  3. The v4 plugin verifies the tree, prints '{SMOKE_MIGRATED_LOG}',")
     print("     repins the isolated Codex entry and starts the local server.")
     print("  4. This script waits for that editor, checks disk state, /godot-ai/status and")
     print("     .ips files, then leaves the editor open for inspection.")
@@ -1695,10 +1708,11 @@ def launch_and_verify_v3_crossing(
     drain = threading.Thread(target=_drain_editor_output, args=(proc.stdout, lines), daemon=True)
     drain.start()
     refusal = floor_forced_unmet()
-    while proc.poll() is None:
-        if refusal and _restored_final_v3_loaded(lines):
-            break
-        time.sleep(POST_UPDATE_STATUS_POLL_SECONDS)
+    if refusal:
+        while proc.poll() is None:
+            if _restored_final_v3_loaded(lines):
+                break
+            time.sleep(POST_UPDATE_STATUS_POLL_SECONDS)
     if refusal and proc.poll() is None:
         ## The refusal never restarts the editor: final v3 is restored and
         ## re-enabled in place, so verify while that editor stays open.
@@ -1707,20 +1721,17 @@ def launch_and_verify_v3_crossing(
         )
         print("The editor stays open with the restored final v3; close it when you are done.")
         return 0 if ok else 1
-    drain.join()
-    code = proc.wait()
-    if code != 0:
-        print(f"FAIL: Godot exited with code {code}")
+    if proc.poll() is not None:
+        drain.join()
+        print(f"FAIL: original Godot exited ({proc.returncode}); expected in-editor crossing")
         print_new_reports(baseline, started, Path(godot_path))
-        return code or 1
+        return 1
     if refusal:
         print("FAIL: the editor closed before the capsule restored final v3 (click Update)")
         return 1
-    if not any(V3_BRIDGE_RESTART_LOG in line for line in lines):
-        print("FAIL: the editor closed before the capsule swapped the v4 tree in (click Update)")
+    if not wait_for_in_editor_activation(proc, lines):
+        print("FAIL: the original editor did not complete capsule activation")
         return 1
-    restarted_lines = wait_for_restarted_editor(marker_dir / RESTARTED_EDITOR_LOG_NAME)
-    lines.extend(restarted_lines)
     post_update_status = None
     try:
         selected_ports = fixture_client_ports(project_dir, target_version)
@@ -1747,8 +1758,12 @@ def launch_and_verify_v3_crossing(
         lines,
         post_update_status=post_update_status,
         godot_path=Path(godot_path),
+        same_editor_pid=proc.pid,
     )
-    print("The restarted editor stays open for inspection; close it when you are done.")
+    if proc.poll() is not None:
+        print("FAIL: the original editor exited during verification")
+        ok = False
+    print("The original editor stays open for inspection; close it when you are done.")
     return 0 if ok else 1
 
 
@@ -1792,8 +1807,9 @@ def verify_v3_crossing(
     *,
     post_update_status: dict | None,
     godot_path: Path | None = None,
+    same_editor_pid: int | None = None,
 ) -> bool:
-    ok = True
+    ok = verify_script_diagnostics(lines)
     live = project_dir / "addons" / "godot_ai"
     installed = read_plugin_version(live / "plugin.cfg")
     if installed == target_version:
@@ -1802,12 +1818,16 @@ def verify_v3_crossing(
         print(f"FAIL: plugin version is {installed}, expected {target_version}")
         ok = False
 
+    activation_steps = (
+        (V3_BRIDGE_HANDOFF_LOG, IN_EDITOR_SWAP_LOG_SUFFIX)
+        if same_editor_pid is not None
+        else ("MCP | v3 bridge swapping in the verified canonical v4 tree", V3_BRIDGE_RESTART_LOG)
+    )
     expected_order = (
         V3_CLICK_LOG,
         "MCP | self-update release signature verified",
         "MCP | update runner disabling old plugin",
-        "MCP | v3 bridge swapping in the verified canonical v4 tree",
-        V3_BRIDGE_RESTART_LOG,
+        *activation_steps,
         SMOKE_MIGRATED_LOG,
         "MCP | plugin loaded",
     )
@@ -1823,7 +1843,10 @@ def verify_v3_crossing(
         print(f"FAIL: crossing log is missing or out of order at {missing!r}")
         ok = False
     else:
-        print("PASS: click, extract, swap, restart and client migration logged in order")
+        print("PASS: click, extract, swap, activation and client migration logged in order")
+    if same_editor_pid is not None and not smoke_in_editor_completed(lines, same_editor_pid):
+        print("FAIL: activation did not complete in the original editor PID")
+        ok = False
     if any("Failed to create an autoload" in line for line in lines):
         print("FAIL: an autoload failed to load during the crossing (#946)")
         ok = False
@@ -1850,8 +1873,6 @@ def verify_v3_crossing(
     leftovers = [
         name
         for name in (
-            "migration_bridge.gd",
-            "migration_coordinator.gd",
             "update_reload_runner.gd",
             "migration_payload",
         )
@@ -1861,7 +1882,7 @@ def verify_v3_crossing(
         print(f"FAIL: live tree still carries {leftovers}")
         ok = False
     else:
-        print("PASS: live tree is the canonical v4 tree (no bridge, runner or payload)")
+        print("PASS: live tree has no capsule payload or legacy update runner")
 
     codex_config = fixture_environment_paths(project_dir)["codex_home"] / "config.toml"
     config_text = codex_config.read_text(encoding="utf-8") if codex_config.is_file() else ""
@@ -2037,8 +2058,9 @@ def verify_post_run(
     post_update_status: dict | None,
     next_server_version: str,
     godot_path: Path | None = None,
+    same_editor_pid: int | None = None,
 ) -> bool:
-    ok = True
+    ok = verify_script_diagnostics(lines)
     installed_version = read_plugin_version(project_dir / "addons" / "godot_ai" / "plugin.cfg")
     if installed_version == next_version:
         print(f"PASS: plugin version advanced to {installed_version}")
@@ -2062,10 +2084,15 @@ def verify_post_run(
     else:
         print("PASS: vNext _exit_tree trigger did not run before the swap")
 
-    if smoke_restart_requested(lines) and any(SMOKE_MIGRATED_LOG in line for line in lines):
-        print("PASS: the editor restarted and the restarted editor completed client migration")
+    activated = (
+        smoke_in_editor_completed(lines, same_editor_pid)
+        if same_editor_pid is not None
+        else smoke_restart_requested(lines)
+    )
+    if activated and any(SMOKE_MIGRATED_LOG in line for line in lines):
+        print("PASS: expected editor activation and client migration completed")
     else:
-        print("FAIL: no swap-and-restart followed by client migration in the logs")
+        print("FAIL: expected editor activation or client migration is missing")
         ok = False
 
     if smoke_adopted_existing_server_before_update(lines):
@@ -2118,6 +2145,20 @@ def verify_post_run(
     return ok
 
 
+def verify_script_diagnostics(lines: list[str]) -> bool:
+    failures = [
+        line for line in lines
+        if any(marker in line for marker in (
+            "SCRIPT ERROR", "Parse Error", "Compile Error",
+            "ERROR: Failed to load script", "Failed to create an autoload",
+            "ERROR: Attempt to open script",
+        ))
+    ]
+    for line in failures:
+        print(f"FAIL: editor script diagnostic: {line}")
+    return not failures
+
+
 def verify_lean_update_state(project_dir: Path, next_version: str) -> tuple[dict, Path]:
     """Check the on-disk state one successful update leaves (docs/self-update.md)."""
     project = project_dir.resolve(strict=True)
@@ -2157,13 +2198,38 @@ def smoke_restart_requested(lines: list[str]) -> bool:
     return any(smoke_swap_line(line) for line in lines)
 
 
+def smoke_in_editor_completed(lines: list[str], pid: int) -> bool:
+    return any(line.strip() == f"{IN_EDITOR_COMPLETED_LOG}{pid}" for line in lines)
+
+
+def wait_for_in_editor_activation(proc: subprocess.Popen, lines: list[str]) -> bool:
+    """Wait for the operator, then bound activation in the original child process."""
+    deadline = None
+    while proc.poll() is None:
+        snapshot = list(lines)
+        if deadline is None and any(
+            marker in line
+            for line in snapshot
+            for marker in (SMOKE_STAGED_LOG, V3_CLICK_LOG, V3_BRIDGE_HANDOFF_LOG)
+        ):
+            deadline = time.monotonic() + RESTARTED_EDITOR_TIMEOUT_SECONDS
+        if smoke_in_editor_completed(snapshot, proc.pid) and any(
+            SMOKE_MIGRATED_LOG in line for line in snapshot
+        ):
+            return True
+        if deadline is not None and time.monotonic() >= deadline:
+            return False
+        time.sleep(POST_UPDATE_STATUS_POLL_SECONDS)
+    return False
+
+
 def vnext_exit_tree_during_update(lines: list[str]) -> bool:
     """True when the vNext trigger ran in the update window (staged, not yet swapped)."""
     staged = False
     for line in lines:
         if SMOKE_STAGED_LOG in line:
             staged = True
-        if staged and smoke_swap_line(line):
+        if staged and (smoke_swap_line(line) or IN_EDITOR_SWAP_LOG_SUFFIX in line):
             return False
         if staged and SMOKE_TRIGGER_LOG in line:
             return True

--- a/script/local-self-update-smoke
+++ b/script/local-self-update-smoke
@@ -19,6 +19,7 @@ import json
 import os
 import platform
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -136,6 +137,27 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--then-version",
+        default="",
+        help=(
+            "With --from-v3-tag, make the signed v4 target advertise a second "
+            "already-signed local update (for example 4.0.6)."
+        ),
+    )
+    parser.add_argument(
+        "--target-version",
+        default="",
+        help="With --from-v3-tag, stamp the locally signed v4 capsule target version.",
+    )
+    parser.add_argument(
+        "--start-published-v3-server",
+        action="store_true",
+        help=(
+            "Keep the published v3 plugin.gd server startup intact. This downloads/runs "
+            "the actual pinned v3 backend and is intended for interactive qualification."
+        ),
+    )
+    parser.add_argument(
         "--base-from-release-tag",
         default="",
         help=(
@@ -201,6 +223,13 @@ def main() -> int:
     args = parse_args()
     try:
         project_dir = args.project_dir.expanduser().resolve()
+        if not args.from_v3_tag and (
+            args.then_version or args.target_version or args.start_published_v3_server
+        ):
+            raise HarnessError(
+                "--then-version, --target-version and --start-published-v3-server "
+                "require --from-v3-tag"
+            )
         if args.from_v3_tag:
             return run_v3_crossing(args, project_dir)
         if args.base_from_release_tag and args.base_from_zip:
@@ -672,6 +701,9 @@ def patch_isolated_client_launch(path: Path, command: Path) -> None:
         f"""static func resolve_attach_launch(
 \tlaunch_context: Dictionary, _discovery_override: Dictionary = {{}}
 ) -> Dictionary:
+\tvar isolation_error := _self_update_smoke_config_error()
+\tif not isolation_error.is_empty():
+\t\treturn {{"ok": false, "error": isolation_error}}
 \tvar version := str(launch_context.get("plugin_version", "")).strip_edges()
 \treturn {{
 \t\t"ok": not version.is_empty(),
@@ -685,6 +717,31 @@ def patch_isolated_client_launch(path: Path, command: Path) -> None:
 \t\t],
 \t}}""",
     )
+    signature = "static func _config_path_resolution_error(client: Client) -> String:\n"
+    text = replace_once(
+        path,
+        text,
+        signature,
+        signature
+        + "\tvar isolation_error := _self_update_smoke_config_error()\n"
+        + "\tif not isolation_error.is_empty():\n\t\treturn isolation_error\n",
+        "fixture config destination guard",
+    )
+    text += r"""
+
+static func _self_update_smoke_config_error() -> String:
+	var expected := ProjectSettings.globalize_path(
+		"res://.godot-ai-self-update-smoke/client-environment/codex"
+	).replace("\\", "/").simplify_path()
+	var integration := ProjectSettings.globalize_path(
+		"res://.self-update-integration/codex"
+	).replace("\\", "/").simplify_path()
+	var actual := OS.get_environment("CODEX_HOME").replace("\\", "/").simplify_path()
+	if actual != expected and actual != integration:
+		return ("Self-update fixture refuses client configuration outside its isolated CODEX_HOME; "
+			+ "use the harness launch environment.")
+	return ""
+"""
     path.write_text(text, encoding="utf-8")
 
 
@@ -1236,6 +1293,29 @@ def write_baseline(project_dir: Path, baseline: set[Path]) -> None:
     )
 
 
+def print_manual_launch(project_dir: Path, godot_bin: str, log_path: Path) -> None:
+    """Print a shell-safe wrapper that applies isolation only to the Godot child."""
+    wrapper = project_dir / ".godot-ai-self-update-smoke" / "launch-editor.py"
+    command = [godot_bin, "--editor", "--path", str(project_dir), "--log-file", str(log_path)]
+    wrapper.write_text(
+        "import os, subprocess\n"
+        "environment = os.environ.copy()\n"
+        + (f"environment.pop({CAPABILITY_DIR_ENV!r}, None)\n" if os.name == "nt" else "")
+        + f"environment.update({godot_child_environment(project_dir)!r})\n"
+        + f"raise SystemExit(subprocess.call({command!r}, env=environment))\n",
+        encoding="utf-8",
+    )
+    argv = [str(smoke_python()), str(wrapper)]
+    quoted = (
+        "& " + " ".join("'" + value.replace("'", "''") + "'" for value in argv)
+        if os.name == "nt"
+        else shlex.join(argv)
+    )
+    print("Launch command (PowerShell):" if os.name == "nt" else "Launch command:")
+    print(f"  {quoted}")
+    print(f"  Editor log (--log-file): {log_path}")
+
+
 def print_instructions(
     project_dir: Path,
     godot_bin: str,
@@ -1280,8 +1360,7 @@ def print_instructions(
     print("  - The update marker does not record success, or the retained backup is missing.")
     print("  - 'MCP | [self-update-smoke vnext _exit_tree]' prints before the swap.")
     print("")
-    print("Launch command:")
-    print(f"  {godot_bin} --editor --path {project_dir} --log-file {log_path}")
+    print_manual_launch(project_dir, godot_bin, log_path)
     print("")
 
 
@@ -1370,10 +1449,32 @@ def launch_and_verify(
 
 
 def run_v3_crossing(args: argparse.Namespace, project_dir: Path) -> int:
+    if any(
+        (
+            args.base_version,
+            args.base_from_release_tag,
+            args.base_from_zip,
+            args.next_version,
+            args.server_version,
+            args.next_server_version,
+        )
+    ):
+        raise HarnessError(
+            "--from-v3-tag uses --target-version/--then-version, not v4 base/server overrides"
+        )
     from_version = release_tag_to_version(args.from_v3_tag)
     if re.fullmatch(r"3\.\d+\.\d+", from_version) is None:
         raise HarnessError("--from-v3-tag must name a v3 release tag, like v3.2.4")
-    target_version = read_plugin_version(PLUGIN_ROOT / "plugin.cfg")
+    target_version = args.target_version or read_plugin_version(PLUGIN_ROOT / "plugin.cfg")
+    if re.fullmatch(r"4\.\d+\.\d+", target_version) is None:
+        raise HarnessError("--target-version must be a canonical v4 version")
+    validate_v3_chain_versions(target_version, args.then_version or None)
+    if args.then_version and not args.no_launch:
+        raise HarnessError(
+            "two-hop fixtures require --no-launch and both native dock Update buttons"
+        )
+    if args.start_published_v3_server:
+        require_linux_listener_pid_tool()
     ensure_safe_project_dir(project_dir, args.force)
     baseline = diagnostic_reports_snapshot()
     marker_dir = project_dir / ".godot-ai-self-update-smoke"
@@ -1385,6 +1486,8 @@ def run_v3_crossing(args: argparse.Namespace, project_dir: Path) -> int:
         ws_port=args.ws_port,
         restart_log=marker_dir / RESTARTED_EDITOR_LOG_NAME,
         preserve_port_settings=args.preserve_port_settings,
+        next_version=args.then_version or None,
+        start_published_v3_server=args.start_published_v3_server,
     )
     write_baseline(project_dir, baseline)
     print_v3_instructions(project_dir, args.godot, from_version, target_version)
@@ -1400,6 +1503,32 @@ def run_v3_crossing(args: argparse.Namespace, project_dir: Path) -> int:
     )
 
 
+def validate_v3_chain_versions(target_version: str, next_version: str | None) -> None:
+    """Validate before touching an existing fixture or creating runtime files."""
+    for version in (target_version, next_version):
+        if (
+            version is not None
+            and re.fullmatch(r"4\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)", version) is None
+        ):
+            raise HarnessError("capsule and second-hop versions must be canonical v4 versions")
+    if next_version is not None and tuple(map(int, next_version.split("."))) <= tuple(
+        map(int, target_version.split("."))
+    ):
+        raise HarnessError("second-hop version must be greater than the capsule target")
+
+
+def require_linux_listener_pid_tool() -> None:
+    """Fail before a Linux qualification run that cannot prove listener ownership."""
+    if platform.system() != "Linux":
+        return
+    if shutil.which("lsof") is not None or shutil.which("ss") is not None:
+        return
+    raise HarnessError(
+        "Linux process-identity verification requires lsof or ss; install lsof "
+        "or iproute2 before running with --start-published-v3-server"
+    )
+
+
 def prepare_v3_crossing_project(
     project_dir: Path,
     *,
@@ -1409,46 +1538,89 @@ def prepare_v3_crossing_project(
     ws_port: int,
     restart_log: Path | None = None,
     preserve_port_settings: bool = False,
-) -> dict[str, Path]:
+    next_version: str | None = None,
+    start_published_v3_server: bool = False,
+) -> dict[str, Path | None]:
     """Install exact final-v3 that will cross into this checkout's v4 via the capsule.
 
     The v3 tree is ``git archive v<from_version>``; its updater is patched only
     to trust the one-run key and to offer the locally built capsule instead of
-    a GitHub release, and its server start is disabled (the v4 editor starts
-    the frozen local runtime). The capsule is the bridge plus this checkout's
-    installer scripts and a signed bundle of this checkout's plugin, laid out
-    as ``script/v4-release build_migration_capsule`` lays it out. Returns the
-    live add-on, the extracted v3 add-on source, the work dir and the
-    capability dir.
+    a GitHub release. By default its server start is disabled (the v4 editor
+    starts the frozen local runtime); interactive release qualification can
+    retain the untouched v3 startup with ``start_published_v3_server``.
+
+    When ``next_version`` is supplied, the signed target tree itself advertises
+    a separately signed second bundle in ``res://self_update_smoke``. This is a
+    continuous two-hop fixture: nothing edits the installed add-on between
+    clicks. The capsule is laid out like ``script/v4-release
+    build_migration_capsule``. Returns the live add-on, extracted v3 source,
+    work directory, capability directory, and optional second bundle.
     """
+    validate_v3_chain_versions(target_version, next_version)
+    if start_published_v3_server:
+        require_linux_listener_pid_tool()
     project_dir.mkdir(parents=True, exist_ok=True)
     write_project_files(project_dir)
     work = project_dir / ".godot-ai-self-update-smoke"
     work.mkdir(exist_ok=True)
+    (work / ".gdignore").write_text("", encoding="utf-8")
     (work / "marker.txt").write_text("v3 crossing fixture\n", encoding="utf-8")
 
-    server_command, _runtime_source = prepare_local_server_runtime(
+    target_server, _runtime_source = prepare_local_server_runtime(
         work, "bridge-server", target_version
     )
+    if next_version is not None:
+        next_server, _ = prepare_local_server_runtime(work, "second-hop-server", next_version)
+        server_command = prepare_server_selector(
+            work,
+            project_dir / "addons" / "godot_ai" / "plugin.cfg",
+            {target_version: target_server, next_version: next_server},
+        )
+    else:
+        server_command = target_server
     private_key, public_key = prepare_smoke_signing_key(work)
     client_command = prepare_isolated_client_environment(
         project_dir, base_version=from_version, http_port=http_port, ws_port=ws_port
     )
     release_tree = work / "release-tree"
     shutil.copytree(PLUGIN_ROOT, release_tree, ignore=copy_ignore)
+    if next_version is not None:
+        second_tree = work / "second-hop-tree"
+        shutil.copytree(PLUGIN_ROOT, second_tree, ignore=copy_ignore)
+        patch_fixture_plugin(
+            second_tree,
+            version=next_version,
+            server_version=next_version,
+            http_port=http_port,
+            ws_port=ws_port,
+            force_local_update=False,
+            next_version=next_version,
+            server_command=server_command,
+            isolate_client_migration=True,
+            client_launch_command=client_command,
+            preserve_port_settings=preserve_port_settings,
+        )
+        patch_vnext_hot_reload_trigger(second_tree / "mcp_dock.gd")
+        patch_vnext_topology_change(second_tree)
+        second_bundle = project_dir / SMOKE_DIR
+        second_bundle.mkdir()
+        (second_bundle / ".gdignore").write_text("", encoding="utf-8")
+        create_signed_v4_bundle(second_tree, second_bundle, next_version, private_key, public_key)
     patch_fixture_plugin(
         release_tree,
         version=target_version,
         server_version=target_version,
         http_port=http_port,
         ws_port=ws_port,
-        force_local_update=False,
-        next_version=target_version,
+        force_local_update=next_version is not None,
+        next_version=next_version or target_version,
         server_command=server_command,
         isolate_client_migration=True,
         client_launch_command=client_command,
         preserve_port_settings=preserve_port_settings,
     )
+    if next_version is not None:
+        patch_release_signing_key(release_tree / "utils" / "update_manager.gd", public_key)
     bundle = work / "release"
     bundle.mkdir()
     create_signed_v4_bundle(release_tree, bundle, target_version, private_key, public_key)
@@ -1532,15 +1704,16 @@ def prepare_v3_crossing_project(
     v3_source = extracted / "plugin/addons/godot_ai"
     live = project_dir / "addons" / "godot_ai"
     shutil.copytree(v3_source, live)
-    old_plugin = live / "plugin.gd"
-    old_plugin.write_text(
-        replace_function(
-            old_plugin.read_text(encoding="utf-8"),
-            "func _start_server() -> void:",
-            "func _start_server() -> void:\n\tpass",
-        ),
-        encoding="utf-8",
-    )
+    if not start_published_v3_server:
+        old_plugin = live / "plugin.gd"
+        old_plugin.write_text(
+            replace_function(
+                old_plugin.read_text(encoding="utf-8"),
+                "func _start_server() -> void:",
+                "func _start_server() -> void:\n\tpass",
+            ),
+            encoding="utf-8",
+        )
     old_manager = live / "utils" / "update_manager.gd"
     manager_text = old_manager.read_text(encoding="utf-8")
     manager_text = subn_once(
@@ -1605,6 +1778,7 @@ def prepare_v3_crossing_project(
         "v3_source": v3_source,
         "work": work,
         "capability_dir": fixture_environment_paths(project_dir)["capability_dir"],
+        "second_bundle": project_dir / SMOKE_DIR if next_version is not None else None,
     }
 
 
@@ -1649,8 +1823,7 @@ def print_v3_instructions(
         print("  3. This script verifies the restored tree, the log order and .ips files, then")
         print("     leaves the editor open for inspection.")
         print("")
-        print("Launch command:")
-        print(f"  {godot_bin} --editor --path {project_dir} --log-file {log_path}")
+        print_manual_launch(project_dir, godot_bin, log_path)
         print("")
         return
     print("Manual step:")
@@ -1662,8 +1835,7 @@ def print_v3_instructions(
     print("  4. This script waits for that editor, checks disk state, /godot-ai/status and")
     print("     .ips files, then leaves the editor open for inspection.")
     print("")
-    print("Launch command:")
-    print(f"  {godot_bin} --editor --path {project_dir} --log-file {log_path}")
+    print_manual_launch(project_dir, godot_bin, log_path)
     print("")
 
 
@@ -2147,12 +2319,19 @@ def verify_post_run(
 
 def verify_script_diagnostics(lines: list[str]) -> bool:
     failures = [
-        line for line in lines
-        if any(marker in line for marker in (
-            "SCRIPT ERROR", "Parse Error", "Compile Error",
-            "ERROR: Failed to load script", "Failed to create an autoload",
-            "ERROR: Attempt to open script",
-        ))
+        line
+        for line in lines
+        if any(
+            marker in line
+            for marker in (
+                "SCRIPT ERROR",
+                "Parse Error",
+                "Compile Error",
+                "ERROR: Failed to load script",
+                "Failed to create an autoload",
+                "ERROR: Attempt to open script",
+            )
+        )
     ]
     for line in failures:
         print(f"FAIL: editor script diagnostic: {line}")

--- a/script/v4-release
+++ b/script/v4-release
@@ -68,6 +68,7 @@ MIGRATION_PAYLOAD_PREFIX = f"{PLUGIN_PREFIX}migration_payload/"
 MIGRATION_INSTALLER_SCRIPTS = (
     "utils/release_verifier.gd",
     "utils/update_installer.gd",
+    "utils/update_activation_runner.gd",
     "utils/port_resolver.gd",
 )
 MIGRATION_INSTALLER_MAX_FILES = 32

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -737,10 +737,11 @@ func test_post_update_retry_button_emits_barrier_action_instead_of_a_second_upda
 	dock.free()
 
 
-func test_update_confirmation_names_editor_restart_and_client_compatibility() -> void:
+func test_update_confirmation_preserves_editor_and_names_client_compatibility() -> void:
 	var text := McpDockScript.update_confirm_text("4.1.0", "4.0.4")
-	assert_true(text.contains("save your project"), text)
-	assert_true(text.contains("restart the Godot editor"), text)
+	assert_true(text.contains("Open scenes and unsaved changes stay in place"), text)
+	assert_true(text.contains("AI tools briefly disconnect"), text)
+	assert_false(text.contains("restart the Godot editor"), text)
 	assert_true(text.contains("Godot AI v4.1.0"), text)
 	assert_true(text.contains("AI clients already using v4.0.4 can reconnect without restarting."), text)
 	assert_true(text.contains("Relaunch clients still using an older version."), text)
@@ -756,7 +757,7 @@ func test_update_dialog_defers_until_confirmation() -> void:
 	dock._build_ui()
 	var update_calls := [0]
 	dock.update_requested.connect(func() -> void: update_calls[0] += 1)
-	assert_eq(dock._update_confirm.get_ok_button().text, "Update and restart")
+	assert_eq(dock._update_confirm.get_ok_button().text, "Update plugin")
 	assert_eq(dock._update_confirm.get_cancel_button().text, "Later")
 	dock._update_confirm.canceled.emit()
 	assert_eq(update_calls[0], 0, "Later must leave the update unrequested")

--- a/test_project/tests/test_dock.gd
+++ b/test_project/tests/test_dock.gd
@@ -510,6 +510,26 @@ class _RepinRecordingOwner extends ClientJobOwnerScript:
 		}
 
 
+func test_active_startup_stays_amber_with_blocked_transport_after_grace() -> void:
+	_dock._build_ui()
+	_dock._startup_grace_until_msec = 0
+	_dock._post_update_server_pending = false
+	var manager := McpServerLifecycleManager.new()
+	manager.configure({"automatic_effects": false})
+	manager.start_server()
+	_dock.present_lifecycle_snapshot(manager.get_status_dict())
+	_dock.present_transport_snapshot({"connected": false, "status": {"phase": "blocked"}})
+	_dock._update_status()
+	assert_eq(_dock._status_label.text, "Starting server…")
+	assert_eq(_dock._status_icon.color, McpDockScript.COLOR_AMBER)
+	assert_true(manager.is_connection_blocked(), "startup presentation grants no transport authority")
+	manager._block("launch_gone", "The server exited")
+	_dock.present_lifecycle_snapshot(manager.get_status_dict())
+	_dock._update_status()
+	assert_true(_dock._status_label.text.begins_with("Server exited"), _dock._status_label.text)
+	assert_eq(_dock._status_icon.color, Color.RED)
+
+
 func test_post_update_window_reads_as_finishing_not_blocked() -> void:
 	_dock._build_ui()
 	## Restarted editor after an update: lifecycle dormant, transport blocked.
@@ -739,16 +759,10 @@ func test_post_update_retry_button_emits_barrier_action_instead_of_a_second_upda
 
 func test_update_confirmation_preserves_editor_and_names_client_compatibility() -> void:
 	var text := McpDockScript.update_confirm_text("4.1.0", "4.0.4")
-	assert_true(text.contains("Open scenes and unsaved changes stay in place"), text)
-	assert_true(text.contains("AI tools briefly disconnect"), text)
-	assert_false(text.contains("restart the Godot editor"), text)
-	assert_true(text.contains("Godot AI v4.1.0"), text)
-	assert_true(text.contains("AI clients already using v4.0.4 can reconnect without restarting."), text)
-	assert_true(text.contains("Relaunch clients still using an older version."), text)
+	assert_eq(text, "Update to Godot AI v4.1.0? Unsaved changes are kept.\n\nRestart AI clients older than v4.0.4.")
 	for versions in [["4.0.3", "4.1.0"], ["4.1.0", "5.0.0"], ["", "4.1.0"], ["4.0.4", ""]]:
 		text = McpDockScript.update_confirm_text(versions[1], versions[0])
-		assert_true(text.contains("Quit and relaunch connected AI clients"), text)
-		assert_false(text.contains("without restarting"), text)
+		assert_true(text.ends_with("Restart your AI client after updating."), text)
 	assert_true(McpDockScript.update_confirm_text("", "4.0.4").contains("the new Godot AI"))
 
 

--- a/test_project/tests/test_plugin_lifecycle.gd
+++ b/test_project/tests/test_plugin_lifecycle.gd
@@ -122,6 +122,14 @@ class EndpointActivationPlugin extends Plugin:
 		normal_starts += 1
 
 
+class HandoffPresentationPlugin extends Plugin:
+	func _enter_tree() -> void:
+		pass
+
+	func _exit_tree() -> void:
+		pass
+
+
 class EndpointJobs extends FakeClientJobs:
 	var lifecycle
 	var activation_seen := {}
@@ -482,6 +490,54 @@ func test_post_update_replaces_only_older_servers_of_our_major() -> void:
 	plugin._replace_server_left_by_update(blocked.merged({"conflict_version": "4.0.1"}))
 	plugin._replace_server_left_by_update(blocked.merged({"conflict_version": "4.0.1"}))
 	assert_eq(lifecycle.recover_calls, 3, "bounded by the replacement limit")
+	plugin._lifecycle = null
+	plugin.free()
+
+
+func test_post_update_handoff_retry_is_amber_only_while_scheduled() -> void:
+	var plugin := HandoffPresentationPlugin.new()
+	var tree := Engine.get_main_loop() as SceneTree
+	tree.root.add_child(plugin)
+	var manager := _manual_lifecycle()
+	plugin._lifecycle = manager
+	plugin._normal_start_released = true
+	plugin._post_update_replaced_version = "4.0.4"
+	plugin._post_update_reprobes_left = 1
+	var dock := Dock.new()
+	dock._build_ui()
+	plugin._dock = dock
+	manager.snapshot_changed.connect(plugin._on_lifecycle_snapshot_changed)
+	manager.start_server()
+	assert_false(plugin._lifecycle_snapshot_for_dock().get("handoff_retry_pending", false))
+	manager._episode["proof_pending_reason"] = "capability_pair"
+	manager._block("launch_gone", "HTTP port already claimed")
+	dock._update_status()
+	assert_true(plugin._post_update_retry_episode > 0)
+	assert_true(dock._lifecycle_snapshot.get("handoff_retry_pending", false))
+	assert_eq(dock._status_label.text, "Recovering after update…")
+	assert_eq(dock._status_icon.color, Dock.COLOR_AMBER)
+	assert_true(manager.is_connection_blocked(), "presentation cannot authorize transport")
+	assert_eq(manager.get_status_dict().episode_state, "BLOCKED")
+	assert_eq(manager.authority_snapshot().transport, {})
+	await tree.create_timer(1.1).timeout
+	assert_eq(plugin._post_update_retry_episode, 0, "the actual timer consumed its episode")
+	assert_eq(manager.get_status_dict().phase, "PROBE", "the timer really requested a fresh probe")
+	manager._episode["proof_pending_reason"] = "capability_pair"
+	manager._block("launch_gone", "HTTP port still claimed")
+	dock._update_status()
+	assert_false(dock._lifecycle_snapshot.get("handoff_retry_pending", false), "exhaustion is terminal")
+	assert_eq(dock._status_icon.color, Color.RED)
+	plugin._post_update_reprobes_left = 1
+	manager._block_without_effect("listener_tools_missing", "Install lsof or iproute2")
+	dock._update_status()
+	assert_false(dock._lifecycle_snapshot.get("handoff_retry_pending", false), "a genuine failure stays red even with a retry scheduled")
+	assert_eq(dock._status_icon.color, Color.RED)
+	manager.stop_server()
+	var stopped := manager.episode_snapshot()
+	await tree.create_timer(1.1).timeout
+	assert_eq(manager.episode_snapshot(), stopped, "Stop supersedes the pending retry")
+	plugin._dock = null
+	dock.free()
 	plugin._lifecycle = null
 	plugin.free()
 

--- a/test_project/tests/test_port_resolver.gd
+++ b/test_project/tests/test_port_resolver.gd
@@ -483,3 +483,10 @@ func test_process_snapshot_pair_accepts_escaped_members_near_the_inner_limit() -
 	var pair := McpPortResolver._parse_process_snapshot_pair(outer, 4242)
 	assert_eq(McpPortResolver.process_commandline(4242, pair[0]), command)
 	assert_eq(McpPortResolver.process_commandline(4242, pair[1]), command)
+
+
+func test_listener_tool_preflight_is_inert_outside_linux() -> void:
+	if OS.get_name() == "Linux":
+		skip("Isolated Linux PATH cases run in the integration fixture")
+		return
+	assert_eq(McpPortResolver.listener_tools_problem(), "")

--- a/test_project/tests/test_release_verifier.gd
+++ b/test_project/tests/test_release_verifier.gd
@@ -36,6 +36,13 @@ const PARITY_ORDER := [
 const SHA256_ABC := "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
 const SHA256_EMPTY := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
+
+class _HashErrors extends Logger:
+	var errors: Array[String] = []
+
+	func _log_error(_function: String, _file: String, _line: int, code: String, rationale: String, _editor_notify: bool, _error_type: int, _script_backtraces: Array) -> void:
+		errors.append(code + rationale)
+
 var _crypto := Crypto.new()
 var _key: CryptoKey
 var _other_key: CryptoKey
@@ -680,8 +687,12 @@ func test_hash_tree_refuses_links() -> void:
 
 
 func test_sha256_helpers() -> void:
+	var errors := _HashErrors.new()
+	OS.add_logger(errors)
 	assert_eq(McpReleaseVerifier.sha256_bytes("abc".to_utf8_buffer()), SHA256_ABC)
 	assert_eq(McpReleaseVerifier.sha256_bytes(PackedByteArray()), SHA256_EMPTY)
+	OS.remove_logger(errors)
+	assert_eq(errors.errors, [], "valid byte buffers must hash without engine errors")
 	var path := FIXTURE_DIR + "/abc.bin"
 	assert_true(write_fixture(path, "abc".to_utf8_buffer()))
 	var hashed := McpReleaseVerifier.sha256_file(path)

--- a/test_project/tests/test_server_lifecycle.gd
+++ b/test_project/tests/test_server_lifecycle.gd
@@ -15,6 +15,14 @@ class _StaleCapabilityLifecycle extends Lifecycle:
 		return {"http": HTTP, "websocket": WS, "instance_nonce": INSTANCE}
 
 
+class _PortWaitWarnings extends Logger:
+	var waits: Array[String] = []
+
+	func _log_error(_function: String, _file: String, _line: int, code: String, rationale: String, _editor_notify: bool, error_type: int, _script_backtraces: Array) -> void:
+		if error_type == ERROR_TYPE_WARNING and (code + rationale).contains("still in use after"):
+			waits.append(code + rationale)
+
+
 func suite_name() -> String:
 	return "server_lifecycle"
 
@@ -570,12 +578,28 @@ func test_stop_of_a_gone_process_succeeds_even_while_a_foreign_listener_remains(
 	if holder.listen(port, "127.0.0.1") != OK:
 		skip("could not seize port for stop postcondition")
 		return
-	var gone_grant = Authority.OwnedProcessGrant.new(2147483000, "gone", 1)
+	var gone_pid := OS.create_process(OS.get_executable_path(), ["--headless", "--version"])
+	assert_true(gone_pid > 1, "create our short-lived child")
+	var deadline := Time.get_ticks_msec() + 5000
+	while gone_pid > 1 and OS.is_process_running(gone_pid) and Time.get_ticks_msec() < deadline:
+		await (Engine.get_main_loop() as SceneTree).create_timer(0.05).timeout
+	assert_false(OS.is_process_running(gone_pid), "our child must have exited before stop")
+	var gone_grant = Authority.OwnedProcessGrant.new(gone_pid, "gone", 1)
+	var warnings := _PortWaitWarnings.new()
+	OS.add_logger(warnings)
 	var result := Lifecycle.new()._effect_stop({
 		"grant": gone_grant,
 		"http_port": port,
 		"launch": {},
 	})
+	OS.remove_logger(warnings)
+	assert_eq(warnings.waits, [], "do not wait for an unrelated listener to exit")
+	assert_true(holder.is_listening(), "the unrelated listener survives")
+	var client := StreamPeerTCP.new()
+	assert_eq(client.connect_to_host("127.0.0.1", port), OK)
+	client.poll()
+	assert_true(client.get_status() in [StreamPeerTCP.STATUS_CONNECTING, StreamPeerTCP.STATUS_CONNECTED])
+	client.disconnect_from_host()
 	holder.stop()
 	assert_true(bool(result.get("ok", false)), str(result))
 	assert_false(bool(result.get("already_gone", true)), "the port was not free, so nothing is 'already gone'")

--- a/test_project/tests/test_update_activation.gd
+++ b/test_project/tests/test_update_activation.gd
@@ -1,0 +1,52 @@
+@tool
+extends McpTestSuite
+
+const RUNNER_PATH := "res://addons/godot_ai/utils/update_activation_runner.gd"
+const PLUGIN_CFG := "res://addons/godot_ai/plugin.cfg"
+
+
+func suite_name() -> String:
+	return "update_activation"
+
+
+func test_file_backed_runner_cannot_disable_the_editor_plugin() -> void:
+	var runner: Node = load(RUNNER_PATH).new()
+	Engine.get_main_loop().root.add_child(runner)
+	var enabled := EditorInterface.is_plugin_enabled(PLUGIN_CFG)
+	var accepted: bool = runner.call("start", _package())
+	assert_false(accepted, "a runner whose source can be replaced must refuse activation")
+	assert_eq(EditorInterface.is_plugin_enabled(PLUGIN_CFG), enabled)
+	runner.free()
+
+
+func test_incomplete_handoff_leaves_the_live_plugin_untouched() -> void:
+	var script := GDScript.new()
+	script.source_code = FileAccess.get_file_as_string(RUNNER_PATH)
+	var error := script.reload()
+	assert_eq(error, OK, "independent activation source must compile")
+	if error != OK:
+		return
+	var enabled := EditorInterface.is_plugin_enabled(PLUGIN_CFG)
+	var wrong_path := _package()
+	wrong_path.stage_root = "res://addons/other_plugin"
+	var missing_hash := _package()
+	missing_hash.record.erase("expected_tree_sha256")
+	var wrong_authority_type := _package()
+	wrong_authority_type.record.replace_owned_mismatches = "true"
+	for package in [{}, wrong_path, missing_hash, wrong_authority_type]:
+		var runner: Node = script.new()
+		Engine.get_main_loop().root.add_child(runner)
+		assert_false(runner.call("start", package), "incomplete handoff must be refused")
+		assert_eq(EditorInterface.is_plugin_enabled(PLUGIN_CFG), enabled)
+		runner.free()
+
+
+func _package() -> Dictionary:
+	return {
+		"stage_root": "res://addons/.godot_ai_update/stage/addons/godot_ai",
+		"record": {
+			"from_version": "4.0.4", "to_version": "4.0.5",
+			"manifest_sha256": "0".repeat(64), "expected_tree_sha256": "0".repeat(64),
+			"editor_nonce": "test", "replace_owned_mismatches": false,
+		},
+	}

--- a/test_project/tests/test_update_activation.gd.uid
+++ b/test_project/tests/test_update_activation.gd.uid
@@ -1,0 +1,1 @@
+uid://dr2evlxap2a4j

--- a/tests/integration/_self_update_fixture.py
+++ b/tests/integration/_self_update_fixture.py
@@ -975,6 +975,7 @@ var _tool_probe_ready := false
 var _finished := false
 var _status_wait_started_ms := 0
 var _pre_instance_id := ""
+var _last_native_status := ""
 
 
 func _ready() -> void:
@@ -990,7 +991,34 @@ func _ready() -> void:
 \tset_process(true)
 
 
+func _sample_native_dock() -> void:
+\tvar current := DriverSupport.find_godot_ai_plugin()
+\tvar value := {{"loaded_version": "", "text": "", "color": "",
+\t\t"state": "plugin_absent", "handoff_retry_pending": false}}
+\tif current != null:
+\t\tvalue.loaded_version = str(current.get("_loaded_plugin_version"))
+\t\tvar snapshot: Dictionary = current.call("_lifecycle_snapshot_for_dock")
+\t\tvalue.state = str(snapshot.get("episode_state", snapshot.get("state", "")))
+\t\tvalue.handoff_retry_pending = bool(snapshot.get("handoff_retry_pending", false))
+\t\tvar dock: Variant = current.get("_dock")
+\t\tif is_instance_valid(dock):
+\t\t\tvar label: Variant = dock.get("_status_label")
+\t\t\tvar icon: Variant = dock.get("_status_icon")
+\t\t\tif is_instance_valid(label):
+\t\t\t\tvalue.text = str(label.text)
+\t\t\tif is_instance_valid(icon):
+\t\t\t\tvalue.color = icon.color.to_html(true)
+\tvar encoded := JSON.stringify(value)
+\tif encoded != _last_native_status:
+\t\t_last_native_status = encoded
+\t\tvalue.pid = OS.get_process_id()
+\t\tvalue.ticks_msec = Time.get_ticks_msec()
+\t\tprint("SELF_UPDATE_DOCK_TRACE | " + JSON.stringify(value))
+
+
 func _process(_delta: float) -> void:
+\tif NATIVE_UPDATE:
+\t\t_sample_native_dock()
 \tif _finished:
 \t\treturn
 \t_frames += 1
@@ -1005,6 +1033,8 @@ func _process(_delta: float) -> void:
 \t\t\t\tvar manager: Variant = current.get("_update_manager")
 \t\t\t\tif manager == null or not manager.is_install_in_flight():
 \t\t\t\t\treturn
+\t\t\t\tDriverSupport._scene_history_trace("install_started", current.get_undo_redo(),
+\t\t\t\t\t_scene_state.scene, _scene_state)
 \t\t\t\t_native_started = true
 \t\t\t\t_status_wait_started_ms = Time.get_ticks_msec()
 \t\t\tif (current != null and current.get_instance_id() != _old_plugin_id
@@ -1224,6 +1254,8 @@ static func capture_scene_state(plugin: EditorPlugin) -> Dictionary:
 \tundo.add_do_property(scene, "process_priority", 123)
 \tundo.add_undo_property(scene, "process_priority", scene.process_priority)
 \tundo.commit_action()
+\tstate["history_id"] = undo.get_object_history_id(scene)
+\t_scene_history_trace("captured", undo, scene, state)
 \tEditorInterface.get_selection().clear()
 \tEditorInterface.get_selection().add_node(scene)
 \treturn state
@@ -1239,11 +1271,37 @@ static func verify_scene_state(plugin: EditorPlugin, state: Dictionary) -> Strin
 \t\treturn "selection changed or dirty scene was saved"
 \tvar undo := plugin.get_undo_redo()
 \tvar history := undo.get_history_undo_redo(undo.get_object_history_id(scene))
-\tif history == null or not history.undo() or scene.process_priority != state.priority:
+\t_scene_history_trace("before_undo", undo, scene, state)
+\tif history == null:
+\t\treturn "scene undo history did not survive activation: history is null"
+\tvar did_undo := history.undo()
+\t_scene_history_trace("after_undo", undo, scene, state, did_undo)
+\tif not did_undo or scene.process_priority != state.priority:
 \t\treturn "scene undo history did not survive activation"
-\tif not history.redo() or scene.process_priority != 123:
+\tvar did_redo := history.redo()
+\t_scene_history_trace("after_redo", undo, scene, state, did_redo)
+\tif not did_redo or scene.process_priority != 123:
 \t\treturn "scene redo history did not survive activation"
 \treturn ""
+
+
+static func _scene_history_trace(phase: String, undo: EditorUndoRedoManager,
+\tscene: Node, state: Dictionary, operation_result: Variant = null) -> void:
+\tvar history_id := undo.get_object_history_id(scene)
+\tvar history := undo.get_history_undo_redo(history_id)
+\tvar record := {"phase": phase, "pid": OS.get_process_id(),
+\t\t"ticks_msec": Time.get_ticks_msec(), "history_id": history_id,
+\t\t"captured_history_id": state.get("history_id", -1),
+\t\t"priority": scene.process_priority, "expected_original": state.priority,
+\t\t"operation_result": operation_result, "history_present": history != null}
+\tif history != null:
+\t\trecord["history_instance"] = history.get_instance_id()
+\t\trecord["version"] = history.get_version()
+\t\tif history.has_method("get_current_action_name"):
+\t\t\trecord["current_action"] = history.call("get_current_action_name")
+\t\tif history.has_method("get_history_count"):
+\t\t\trecord["action_count"] = history.call("get_history_count")
+\tprint("SELF_UPDATE_SCENE_TRACE | " + JSON.stringify(record))
 
 
 static func fetch_status(port: int) -> Dictionary:
@@ -1278,10 +1336,14 @@ static func fetch_status(port: int) -> Dictionary:
 \t\tOS.delay_msec(10)
 \tif not http.has_response() or http.get_response_code() != 200:
 \t\treturn {}
+\tvar expected_size := http.get_response_body_length()
+\tif expected_size > MAX_STATUS_BYTES:
+\t\treturn {}
 \tvar body := PackedByteArray()
 \tdeadline = Time.get_ticks_msec() + 2000
 \twhile http.get_status() == HTTPClient.STATUS_BODY:
-\t\thttp.poll()
+\t\tif http.poll() != OK or http.get_status() != HTTPClient.STATUS_BODY:
+\t\t\treturn {}
 \t\tvar chunk := http.read_response_body_chunk()
 \t\tif chunk.size() > 0:
 \t\t\tif body.size() + chunk.size() > MAX_STATUS_BYTES:
@@ -1291,7 +1353,12 @@ static func fetch_status(port: int) -> Dictionary:
 \t\t\tOS.delay_msec(5)
 \t\tif Time.get_ticks_msec() > deadline:
 \t\t\treturn {}
-\tvar parsed: Variant = JSON.parse_string(body.get_string_from_utf8())
+\tif body.is_empty() or (expected_size >= 0 and body.size() != expected_size):
+\t\treturn {}
+\tvar json := JSON.new()
+\tif json.parse(body.get_string_from_utf8()) != OK:
+\t\treturn {}
+\tvar parsed: Variant = json.data
 \tif typeof(parsed) != TYPE_DICTIONARY:
 \t\treturn {}
 \tif parsed.get("instance_id") != record["instance_nonce"]:
@@ -1699,7 +1766,9 @@ def run_godot_editor(
         raise AssertionError(f"{failure}\n{output}") from failure
     if live_probe is not None:
         assert probe_ran, output
-    assert proc.returncode == expected_exit_code, output
+    assert proc.returncode == expected_exit_code, (
+        f"editor exit code {proc.returncode}, expected {expected_exit_code}\n{output}"
+    )
     return output
 
 

--- a/tests/integration/_self_update_fixture.py
+++ b/tests/integration/_self_update_fixture.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import configparser
 import hashlib
 import json
 import os
@@ -14,6 +15,7 @@ from pathlib import Path
 from types import ModuleType
 from typing import Callable
 
+import psutil
 import pytest
 
 from godot_ai.transport.capability import read_capabilities
@@ -38,7 +40,8 @@ RESTARTED_EDITOR_LOG = "_test_restarted_editor.log"
 AGENT_ATTACHED_FILE = "_test_agent_attached.done"
 
 PARSE_ERROR_PATTERNS = (
-    "SCRIPT ERROR: Parse Error",
+    "SCRIPT ERROR:",
+    "ERROR: Attempt to open script",
     "ERROR: Failed to load script",
     "Could not resolve script",
 )
@@ -586,6 +589,7 @@ class AttachedAgent:
         self.capability_dir = capability_dir
         self.environment = environment
         self.ok = 0
+        self.post_update: dict[str, str] = {}
         self.errors: list[str] = []
         self.fault: str = ""
         self._stop = threading.Event()
@@ -599,6 +603,16 @@ class AttachedAgent:
         self._stop.set()
         self._thread.join(timeout=60)
 
+    def wait_for_post_update(self, version: str) -> None:
+        deadline = time.monotonic() + 90
+        while self.post_update.get("version") != version:
+            assert not self.fault, self.fault
+            assert self._thread.is_alive(), "the original attached bridge stopped"
+            assert time.monotonic() < deadline, (
+                "the same attached bridge never read the updated editor", self.errors[-3:]
+            )
+            time.sleep(0.1)
+
     def _run(self) -> None:
         try:
             asyncio.run(self._poll())
@@ -611,7 +625,13 @@ class AttachedAgent:
 
         capability_dir = self.capability_dir
         deadline = time.monotonic() + 120
-        while read_capabilities(self.http_port, capability_dir) is None:
+        while True:
+            pre_receipt = self.project_dir / PRE_INSTANCE_ID_FILE
+            capability = read_capabilities(self.http_port, capability_dir)
+            expected_nonce = (pre_receipt.read_text(encoding="utf-8").strip()
+                              if pre_receipt.is_file() else "")
+            if capability is not None and expected_nonce == capability.instance_nonce:
+                break
             if self._stop.is_set() or time.monotonic() > deadline:
                 raise AssertionError("server A never published capabilities")
             await asyncio.sleep(0.25)
@@ -642,6 +662,33 @@ class AttachedAgent:
                         self.errors.append(str(texts)[:300])
                     else:
                         self.ok += 1
+                        status_path = self.project_dir / POST_UPDATE_STATUS_FILE
+                        if status_path.is_file() and not self.post_update:
+                            receipt = json.loads(status_path.read_text(encoding="utf-8"))
+                            sessions = await client.call_tool(
+                                "session_manage", {"op": "list", "params": {}}
+                            )
+                            matches = [row for row in sessions.data.get("sessions", [])
+                                       if Path(row["project_path"]).resolve()
+                                       == self.project_dir.resolve()]
+                            assert len(matches) == 1, "expected the updated fixture editor session"
+                            session_id = matches[0]["session_id"]
+                            state = await client.call_tool(
+                                "editor_state", {"session_id": session_id}
+                            )
+                            assert not state.is_error
+                            cfg = await client.call_tool("filesystem_manage", {
+                                "session_id": session_id, "op": "read_text",
+                                "params": {"path": "res://addons/godot_ai/plugin.cfg"},
+                            })
+                            parsed = configparser.ConfigParser()
+                            parsed.read_string(cfg.data["content"])
+                            version = parsed["plugin"]["version"].strip('"')
+                            assert version == receipt["server_version"]
+                            self.post_update = {"version": version, "session_id": session_id}
+                            (self.project_dir / "_test_same_bridge_post_update.json").write_text(
+                                json.dumps(self.post_update), encoding="utf-8",
+                            )
                         gate = self.project_dir / AGENT_ATTACHED_FILE
                         if not gate.exists():
                             gate.write_text("attached\n", encoding="utf-8")
@@ -893,16 +940,9 @@ def write_install_update_driver(
     base_version: str,
     next_version: str,
     agent_gate: bool = False,
+    native_update: bool = False,
 ) -> None:
-    """Click Update in the base editor, then prove B live after the restart.
-
-    The initial process records its receipt and the pre-update server
-    instance, verifies the A pin, and presses the production update entry
-    point; the plugin swaps and restarts the editor. The restarted process
-    validates the installed tree, waits for the automatic repin and the new
-    server, writes the status snapshot, waits for the harness's authenticated
-    probe, then writes the completion file and quits.
-    """
+    """Click Update and require B to load in the same editor, preserving scene state."""
     write_driver_support(project_dir)
     (project_dir / "_test_runner_driver.gd").write_text(
         f"""@tool
@@ -917,13 +957,17 @@ const COMPLETE_PATH := "res://{POST_UPDATE_COMPLETE_FILE}"
 const PRE_ID_PATH := "res://{PRE_INSTANCE_ID_FILE}"
 const AGENT_GATE_PATH := "res://{AGENT_ATTACHED_FILE}"
 const AGENT_GATE := {"true" if agent_gate else "false"}
+const NATIVE_UPDATE := {"true" if native_update else "false"}
 const DriverSupport := preload("res://_test_self_update_driver_support.gd")
 const START_AFTER_FRAMES := 45
 const MAX_FRAMES := 1800
 const STATUS_WAIT_MS := 120000
 
 var _frames := 0
-var _restarted := false
+var _activated := false
+var _old_plugin_id := 0
+var _native_started := false
+var _scene_state: Dictionary = {{}}
 var _started := false
 var _validated := false
 var _repin_observed := false
@@ -940,10 +984,9 @@ func _ready() -> void:
 \tif OS.get_environment("_SELF_UPDATE_DRIVER_SKIP") == "1":
 \t\tqueue_free()
 \t\treturn
-\t_restarted = _write_receipt()
-\tif _restarted:
-\t\t_pre_instance_id = FileAccess.get_file_as_string(PRE_ID_PATH).strip_edges()
-\t\t_status_wait_started_ms = Time.get_ticks_msec()
+\tif _write_receipt():
+\t\t_fail(17, "update unexpectedly restarted the editor")
+\t\treturn
 \tset_process(true)
 
 
@@ -951,16 +994,27 @@ func _process(_delta: float) -> void:
 \tif _finished:
 \t\treturn
 \t_frames += 1
-\tif not _restarted:
+\tif not _activated:
 \t\tif _started:
-\t\t\tif _frames > MAX_FRAMES:
-\t\t\t\t_fail(10, "signed install did not restart the editor")
+\t\t\tvar current := DriverSupport.find_godot_ai_plugin()
+\t\t\tif (current != null and str(current.get("_loaded_plugin_version")) == NEXT_VERSION):
+\t\t\t\t_native_started = true
+\t\t\tif NATIVE_UPDATE and not _native_started:
+\t\t\t\tif current == null:
+\t\t\t\t\treturn
+\t\t\t\tvar manager: Variant = current.get("_update_manager")
+\t\t\t\tif manager == null or not manager.is_install_in_flight():
+\t\t\t\t\treturn
+\t\t\t\t_native_started = true
+\t\t\t\t_status_wait_started_ms = Time.get_ticks_msec()
+\t\t\tif (current != null and current.get_instance_id() != _old_plugin_id
+\t\t\t\t\tand str(current.get("_loaded_plugin_version")) == NEXT_VERSION):
+\t\t\t\t_activated = true
+\t\t\t\t_write_receipt()
+\t\t\tif Time.get_ticks_msec() - _status_wait_started_ms > STATUS_WAIT_MS:
+\t\t\t\t_fail(10, "signed install did not activate B in this editor")
 \t\t\treturn
 \t\tif _frames < START_AFTER_FRAMES:
-\t\t\treturn
-\t\tif AGENT_GATE and not FileAccess.file_exists(AGENT_GATE_PATH):
-\t\t\tif Time.get_ticks_msec() > STATUS_WAIT_MS:
-\t\t\t\t_fail(16, "the attached agent never made a successful call")
 \t\t\treturn
 \t\tif _frames > MAX_FRAMES:
 \t\t\t_fail(12, "pre-update /godot-ai/status timed out")
@@ -974,6 +1028,10 @@ func _process(_delta: float) -> void:
 \t\tif pre_file != null:
 \t\t\tpre_file.store_string(pre_id)
 \t\t\tpre_file.close()
+\t\tif AGENT_GATE and not FileAccess.file_exists(AGENT_GATE_PATH):
+\t\t\tif Time.get_ticks_msec() > STATUS_WAIT_MS:
+\t\t\t\t_fail(16, "the attached agent never made a successful call")
+\t\t\treturn
 \t\tif not _update_candidate_ready():
 \t\t\treturn
 \t\tprint("SELF_UPDATE_TEST | pre-update instance_id=%s" % _pre_instance_id)
@@ -987,7 +1045,7 @@ func _process(_delta: float) -> void:
 \t\tif _try_validate_install():
 \t\t\t_validated = true
 \t\telif Time.get_ticks_msec() - _status_wait_started_ms > STATUS_WAIT_MS:
-\t\t\t_fail(10, "restarted editor does not run the signed B tree")
+\t\t\t_fail(10, "same editor does not run the signed B tree")
 \t\treturn
 \tif not _repin_observed:
 \t\t_observe_automatic_repin()
@@ -999,6 +1057,17 @@ func _process(_delta: float) -> void:
 \t\t_tool_probe_ready = true
 \t\treturn
 \tif _tool_probe_ready and FileAccess.file_exists(TOOL_PROBE_DONE_PATH):
+\t\tif NATIVE_UPDATE and not FileAccess.file_exists("res://visible-update-reviewed.done"):
+\t\t\tif not FileAccess.file_exists("res://visible-update-complete.json"):
+\t\t\t\tvar visible_done := FileAccess.open("res://visible-update-complete.json", FileAccess.WRITE)
+\t\t\t\tif visible_done == null:
+\t\t\t\t\t_fail(25, "could not publish native completion")
+\t\t\t\t\treturn
+\t\t\t\tvisible_done.store_string(JSON.stringify({{"pid": OS.get_process_id(),
+\t\t\t\t\t"version": NEXT_VERSION, "authenticated_probes_passed": true}}))
+\t\t\t\tvisible_done.close()
+\t\t\t\tprint("SELF_UPDATE_TEST | native update complete; waiting for visual review")
+\t\t\treturn
 \t\tprint("SELF_UPDATE_TEST | authenticated read/write tool probe completed")
 \t\tvar complete := FileAccess.open(COMPLETE_PATH, FileAccess.WRITE)
 \t\tif complete != null:
@@ -1023,13 +1092,33 @@ func _call_install() -> void:
 \tif plugin == null:
 \t\t_fail(11, "failed to find Godot AI plugin")
 \t\treturn
+\t_old_plugin_id = plugin.get_instance_id()
+\t_status_wait_started_ms = Time.get_ticks_msec()
+\t_scene_state = DriverSupport.capture_scene_state(plugin)
+\tif _scene_state.is_empty():
+\t\t_fail(18, "fixture scene was not opened")
+\t\treturn
 \tprint("SELF_UPDATE_TEST | requesting canonical signed install")
+\tif NATIVE_UPDATE:
+\t\tvar ready := FileAccess.open("res://visible-update-ready.json", FileAccess.WRITE)
+\t\tif ready == null:
+\t\t\t_fail(24, "could not publish native-click readiness")
+\t\t\treturn
+\t\tready.store_string(JSON.stringify({{"pid": OS.get_process_id(),
+\t\t\t"version": BASE_VERSION, "target": NEXT_VERSION,
+\t\t\t"scene_captured": true, "attached_agent_ready": true}}))
+\t\tready.close()
+\t\tprint("SELF_UPDATE_TEST | ready for native Update and confirmation clicks")
+\t\treturn
 \tplugin.call("_on_dock_update_requested")
 
 
 func _update_candidate_ready() -> bool:
 \tvar plugin := DriverSupport.find_godot_ai_plugin()
 \tif plugin == null:
+\t\treturn false
+\tif EditorInterface.get_edited_scene_root() == null:
+\t\tEditorInterface.open_scene_from_path("res://empty.tscn")
 \t\treturn false
 \tvar manager: Variant = plugin.get("_update_manager")
 \treturn manager != null and bool(manager.call("has_install_candidate"))
@@ -1065,11 +1154,28 @@ func _try_validate_install() -> bool:
 \t\treturn false
 \tif not base_source.contains("class_name McpSelfUpdateSmokeBase"):
 \t\treturn false
+\tvar plugin := DriverSupport.find_godot_ai_plugin()
+\tvar dock: Variant = plugin.get("_dock")
+\tif dock == null:
+\t\treturn false
+\tvar constants: Dictionary = dock.get_script().get_script_constant_map()
+\tif (not constants.has("SelfUpdateSmokeChild")
+\t\t\tor constants.SelfUpdateSmokeChild.new().marker() != "child:base"):
+\t\t_fail(19, "new dock did not execute the signed topology dependency")
+\t\treturn false
+\tvar continuity_error := DriverSupport.verify_scene_state(plugin, _scene_state)
+\tif not continuity_error.is_empty():
+\t\t_fail(20, continuity_error)
+\t\treturn false
+\tprint("SELF_UPDATE_TEST | loaded topology, dirty scene, selection and undo/redo preserved")
 \treturn true
 
 
 func _try_write_status() -> bool:
-\tvar payload := DriverSupport.fetch_status(HTTP_PORT)
+\tvar plugin := DriverSupport.find_godot_ai_plugin()
+\tif plugin == null:
+\t\treturn false
+\tvar payload := DriverSupport.fetch_selected_status(plugin)
 \tif payload.get("name") != "godot-ai":
 \t\treturn false
 \tvar version := str(payload.get("server_version", ""))
@@ -1103,6 +1209,41 @@ def write_driver_support(project_dir: Path) -> None:
 extends RefCounted
 
 const MAX_STATUS_BYTES := 64 * 1024
+
+
+static func capture_scene_state(plugin: EditorPlugin) -> Dictionary:
+\tvar scene := EditorInterface.get_edited_scene_root()
+\tif scene == null:
+\t\treturn {}
+\tvar state := {"scene": scene, "hash": FileAccess.get_sha256(scene.scene_file_path),
+\t\t"priority": scene.process_priority}
+\tif str(state.hash).length() != 64:
+\t\treturn {}
+\tvar undo := plugin.get_undo_redo()
+\tundo.create_action("Self-update continuity", UndoRedo.MERGE_DISABLE, scene)
+\tundo.add_do_property(scene, "process_priority", 123)
+\tundo.add_undo_property(scene, "process_priority", scene.process_priority)
+\tundo.commit_action()
+\tEditorInterface.get_selection().clear()
+\tEditorInterface.get_selection().add_node(scene)
+\treturn state
+
+
+static func verify_scene_state(plugin: EditorPlugin, state: Dictionary) -> String:
+\tvar scene: Variant = state.get("scene")
+\tif (not is_instance_valid(scene) or EditorInterface.get_edited_scene_root() != scene
+\t\t\tor scene.process_priority != 123):
+\t\treturn "edited scene instance or unsaved property changed"
+\tif (EditorInterface.get_selection().get_selected_nodes() != [scene]
+\t\t\tor FileAccess.get_sha256(scene.scene_file_path) != state.hash):
+\t\treturn "selection changed or dirty scene was saved"
+\tvar undo := plugin.get_undo_redo()
+\tvar history := undo.get_history_undo_redo(undo.get_object_history_id(scene))
+\tif history == null or not history.undo() or scene.process_priority != state.priority:
+\t\treturn "scene undo history did not survive activation"
+\tif not history.redo() or scene.process_priority != 123:
+\t\treturn "scene redo history did not survive activation"
+\treturn ""
 
 
 static func fetch_status(port: int) -> Dictionary:
@@ -1425,6 +1566,7 @@ def run_godot_editor(
     phase: str = "editor",
     expected_exit_code: int = 0,
     restart_completion_file: str | None = None,
+    require_same_editor: bool = False,
 ) -> str:
     env = os.environ.copy()
     if allow_headless:
@@ -1482,6 +1624,7 @@ def run_godot_editor(
             flush=True,
         )
         try:
+            editor_created = psutil.Process(proc.pid).create_time() if require_same_editor else None
             completion_path = (
                 project_dir / restart_completion_file
                 if restart_completion_file is not None
@@ -1495,7 +1638,20 @@ def run_godot_editor(
                     and not probe_ran
                     and (project_dir / probe_ready_file).is_file()
                 ):
+                    if require_same_editor:
+                        assert proc.poll() is None, "the initial editor exited before the probe"
+                        initial, activated = read_editor_receipts(project_dir)
+                        assert initial["pid"] == activated["pid"] == proc.pid, (initial, activated)
+                        assert psutil.Process(proc.pid).create_time() == editor_created
                     live_probe()
+                    if require_same_editor:
+                        assert proc.poll() is None, "the initial editor exited during the probe"
+                        assert psutil.Process(proc.pid).create_time() == editor_created
+                        (project_dir / "_test_editor_process_identity.json").write_text(
+                            json.dumps({"pid": proc.pid, "create_time": editor_created,
+                                        "alive_after_authenticated_probe": True}),
+                            encoding="utf-8",
+                        )
                     (project_dir / probe_done_file).write_text(
                         "authenticated read/write probe passed\n", encoding="utf-8"
                     )

--- a/tests/integration/test_linux_listener_tools.py
+++ b/tests/integration/test_linux_listener_tools.py
@@ -1,0 +1,96 @@
+"""Linux launch prerequisites use the editor PATH without caching a missing tool."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.integration._self_update_fixture import PLUGIN_ROOT, godot_bin_or_skip, run_godot_editor
+
+pytestmark = pytest.mark.editor
+
+DRIVER = """@tool
+extends Node
+const Ports := preload("res://addons/godot_ai/utils/port_resolver.gd")
+const Lifecycle := preload("res://addons/godot_ai/utils/server_lifecycle.gd")
+func _ready() -> void:
+    if Engine.is_editor_hint(): run.call_deferred()
+func run() -> void:
+    var original := OS.get_environment("PATH")
+    OS.set_environment("PATH", ProjectSettings.globalize_path("res://bin"))
+    var initial := Ports.listener_tools_problem()
+    var manager := Lifecycle.new()
+    var marker := ProjectSettings.globalize_path("res://unexpected-launch")
+    var payload := {"http_port": 8000, "server_command": ["/bin/sh",
+        ProjectSettings.globalize_path("res://spawn.sh"), marker],
+        "pid_file": ProjectSettings.globalize_path("res://existing.pid")}
+    var available := OS.get_environment("LISTENER_TOOL")
+    var missing := {}
+    if available.is_empty():
+        missing = manager._effect_launch(payload)
+    else:
+        assert(DirAccess.remove_absolute("res://bin/" + available) == OK)
+    var after_removal := Ports.listener_tools_problem()
+    var file := FileAccess.open("res://bin/ss", FileAccess.WRITE)
+    file.store_string("#!/bin/sh\\nexit 0\\n")
+    file.close()
+    var ignored: Array = []
+    assert(OS.execute("/bin/chmod", ["+x", ProjectSettings.globalize_path("res://bin/ss")],
+        ignored) == 0)
+    var after_install := Ports.listener_tools_problem()
+    OS.set_environment("PATH", original)
+    manager = null
+    file = FileAccess.open("res://result.json", FileAccess.WRITE)
+    file.store_string(JSON.stringify({"initial": initial, "missing": missing,
+        "after_removal": after_removal, "after_install": after_install,
+        "spawned": FileAccess.file_exists(marker),
+        "pid_file": FileAccess.get_file_as_string("res://existing.pid")}))
+    file.close()
+    get_tree().quit()
+"""
+
+
+@pytest.mark.parametrize("available", ["", "ss", "lsof"])
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux PATH")
+def test_linux_listener_prerequisite_refuses_before_spawn_and_recovers(
+    tmp_path: Path,
+    available: str,
+) -> None:
+    godot = godot_bin_or_skip()
+    project = tmp_path / "listener-tools"
+    shutil.copytree(PLUGIN_ROOT, project / "addons/godot_ai")
+    commands = project / "bin"
+    commands.mkdir()
+    if available:
+        tool = commands / available
+        tool.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        tool.chmod(0o700)
+    (project / "spawn.sh").write_text('printf launched > "$1"\n', encoding="utf-8")
+    (project / "existing.pid").write_text("preserved", encoding="utf-8")
+    (project / "driver.gd").write_text(DRIVER, encoding="utf-8")
+    (project / "project.godot").write_text(
+        'config_version=5\n[autoload]\nDriver="*res://driver.gd"\n',
+        encoding="utf-8",
+    )
+    environment = {"LISTENER_TOOL": available, "GODOT_AI_DISABLE_TELEMETRY": "true"}
+    for name in ("HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_CACHE_HOME"):
+        directory = tmp_path / name.lower()
+        directory.mkdir()
+        environment[name] = str(directory)
+    log = run_godot_editor(project, godot, allow_headless=True, environment=environment)
+    assert "SCRIPT ERROR" not in log, log
+    result = json.loads((project / "result.json").read_bytes())
+    if available:
+        assert result["initial"] == "", result
+    else:
+        assert result["missing"]["ok"] is False, result
+        assert result["missing"]["reason"] == "listener_tools_missing", result
+        assert result["missing"]["message"] == result["initial"], result
+    assert "Install lsof or iproute2" in result["after_removal"], result
+    assert "retry" in result["after_removal"], result
+    assert result["after_install"] == "", result
+    assert not result["spawned"] and result["pid_file"] == "preserved", result

--- a/tests/integration/test_migration_bridge_failures.py
+++ b/tests/integration/test_migration_bridge_failures.py
@@ -1,24 +1,16 @@
-"""Exercise the capsule coordinator's swap-then-restart handoff in a real editor."""
+"""Actual capsule coordinator/installer/activation handoff in an isolated editor."""
 
 from __future__ import annotations
 
-import hashlib
 import json
+import os
 import shutil
 from pathlib import Path
 
 import pytest
 
-from tests.integration._self_update_fixture import (
-    PLUGIN_ROOT,
-    append_driver_autoload,
-    godot_bin_or_skip,
-    load_smoke_script,
-    run_godot_editor,
-)
+from tests.integration._self_update_fixture import PLUGIN_ROOT, godot_bin_or_skip, run_godot_editor
 
-## Needs a real Godot editor (GODOT_BIN); skipped without one and excluded
-## from the iteration loop by `pytest -m "not editor"`.
 pytestmark = pytest.mark.editor
 
 INSTALLER_SCRIPTS = (
@@ -26,164 +18,395 @@ INSTALLER_SCRIPTS = (
     "update_installer.gd",
     "port_resolver.gd",
     "windows_port_reservation.gd",
+    "update_activation_runner.gd",
 )
 
+PLUGIN = """@tool
+extends EditorPlugin
+const Handler := preload("res://addons/godot_ai/handler.gd")
+var _loaded_plugin_version := "VERSION"
+var handler = Handler.new()
+func active_value() -> String: return handler.value()
+func _exit_tree() -> void: handler = null
+"""
 
-@pytest.mark.parametrize("case", ["disabled", "already-listed", "save-failure"])
-def test_bridge_restart_preserves_next_start_without_live_enable(tmp_path: Path, case: str) -> None:
-    """After the swap the coordinator persists intent, never loads v4 into the old VM.
-
-    ``disabled`` and ``already-listed`` run the real installer's next-start
-    persistence and restart; ``save-failure`` substitutes an installer whose
-    persistence fails and proves the coordinator refuses to restart, restores
-    the enabled list, and asks for explicit recovery.
-    """
-    godot = godot_bin_or_skip()
-    smoke = load_smoke_script()
-    project = tmp_path / "bridge-restart"
-    project.mkdir()
-    smoke.write_project_files(project)
-    append_driver_autoload(project / "project.godot")
-    for name in ("godot_ai", "companion"):
-        addon = project / "addons" / name
-        addon.mkdir(parents=True)
-        (addon / "plugin.cfg").write_text(
-            '[plugin]\nname="Restart fixture"\nversion="1.0"\nscript="plugin.gd"\n',
-            encoding="utf-8",
-        )
-        (addon / "plugin.gd").write_text("@tool\nextends EditorPlugin\n", encoding="utf-8")
-    shutil.copy2(
-        PLUGIN_ROOT.parents[2] / "migration_bridge" / "migration_coordinator.gd",
-        project / "addons/godot_ai",
-    )
-    utils = project / "addons/godot_ai/utils"
-    utils.mkdir()
-    for name in INSTALLER_SCRIPTS:
-        shutil.copy2(PLUGIN_ROOT / "utils" / name, utils / name)
-    (project / "_test_runner_driver.gd").write_text(
-        '''@tool
+DRIVER = """@tool
 extends Node
-const Coordinator := preload("res://addons/godot_ai/migration_coordinator.gd")
 const CONFIG := "res://addons/godot_ai/plugin.cfg"
 const COMPANION := "res://addons/companion/plugin.cfg"
-const KEY := "editor_plugins/enabled"
-const CASE := "''' + case + '''"
-const FAILING_INSTALLER := """
-static func swap(_stage: String, _live: String, _record: Dictionary) -> Dictionary:
-\treturn {"ok": true, "error": ""}
-static func release_lock() -> void:
-\tpass
-static func persist_next_start_enabled(_plugin_cfg: String) -> Error:
-\treturn ERR_CANT_CREATE
-static func request_restart() -> void:
-\tpass
-"""
-var _frames := 10
+const UPDATE := "res://addons/.godot_ai_update"
+const STAGE := UPDATE + "/stage/addons/godot_ai"
+var frames := 0
+var before := {}
+var failure := ""
+var started := 0
+var done := false
+var first_activation := {}
+var first_value := ""
+var first_state := {}
+var second_started := false
+var retained: WeakRef
+var history: UndoRedo
+var target: Node2D
+var scan_completions: Array[Dictionary] = []
+var unrelated_notifications := 0
+var ordering_errors: Array[String] = []
+func find_plugin(node: Node) -> Node:
+    if node.get_script() != null and node.get_script().resource_path == "res://addons/godot_ai/plugin.gd":
+        return node
+    for child in node.get_children():
+        var found := find_plugin(child)
+        if found != null: return found
+    return null
 func _process(_delta: float) -> void:
-    _frames -= 1
-    if _frames != 0:
+    if not Engine.is_editor_hint() or done: return
+    frames += 1
+    if frames == 15 and OS.get_environment("BRIDGE_CASE") == "user-scene":
+        EditorInterface.open_scene_from_path("res://user.tscn")
+    if frames == 45: begin.call_deferred()
+    if started > 0:
+        check_unrelated_notification()
+        if not failure.is_empty() or FileAccess.file_exists(UPDATE + "/activation.json"):
+            if (failure.is_empty() and OS.get_environment("BRIDGE_CASE") == "success"
+                    and not second_started):
+                second_started = true
+                started = 0
+                next_activation.call_deferred()
+            else:
+                done = true
+                finish.call_deferred()
+        elif Time.get_ticks_msec() - started > 75000:
+            failure = "test_deadline"
+            done = true
+            finish.call_deferred()
+func disk_version() -> String:
+    var config := ConfigFile.new()
+    assert(config.load("res://addons/godot_ai/plugin.cfg") == OK)
+    return str(config.get_value("plugin", "version"))
+func on_scan_completed(_changed: bool) -> void:
+    if started > 0 and not EditorInterface.is_plugin_enabled(CONFIG):
+        scan_completions.append({"activation": 2 if second_started else 1,
+            "version": disk_version()})
+func check_unrelated_notification() -> void:
+    if EditorInterface.is_plugin_enabled(CONFIG): return
+    var before_version := disk_version()
+    EditorInterface.get_resource_filesystem().filesystem_changed.emit()
+    unrelated_notifications += 1
+    if disk_version() != before_version or EditorInterface.is_plugin_enabled(CONFIG):
+        ordering_errors.append("Generic filesystem notification advanced activation")
+func begin() -> void:
+    EditorInterface.get_resource_filesystem().sources_changed.connect(on_scan_completed)
+    var plugin := find_plugin(get_tree().root)
+    if plugin == null:
+        failure = "initial_plugin_missing"
+        done = true
+        finish()
         return
-    set_process(false)
-    if FileAccess.file_exists("res://first.json"):
-        _write("res://second.json", {
-            "pid": OS.get_process_id(),
-            "enabled": EditorInterface.is_plugin_enabled(CONFIG),
-            "companion": EditorInterface.is_plugin_enabled(COMPANION),
-            "setting": Array(ProjectSettings.get_setting(KEY)),
-        })
-        get_tree().quit(0)
-        return
-    EditorInterface.set_plugin_enabled(COMPANION, true)
-    EditorInterface.set_plugin_enabled(CONFIG, false)
-    if ProjectSettings.save() != OK:
-        get_tree().quit(44)
-        return
-    var previous: Variant = ProjectSettings.get_setting(KEY)
-    if CASE == "already-listed":
-        previous.append(CONFIG)
-        ProjectSettings.set_setting(KEY, previous)
-    var installer: Script
-    if CASE == "save-failure":
-        var failing := GDScript.new()
-        failing.source_code = FAILING_INSTALLER
-        failing.reload()
-        installer = failing
-    else:
-        installer = load("res://addons/godot_ai/utils/update_installer.gd")
-    var coordinator = Coordinator.new()
+    before = {"pid": OS.get_process_id(), "instance": plugin.get_instance_id(),
+        "value": plugin.call("active_value"),
+        "companion": EditorInterface.is_plugin_enabled(COMPANION)}
+    target = Node2D.new()
+    add_child(target)
+    var handler = plugin.get("handler")
+    handler.prepare_static()
+    retained = weakref(handler)
+    var undo = plugin.get_undo_redo()
+    undo.create_action("Retained handler fixture", UndoRedo.MERGE_DISABLE, target)
+    undo.add_do_property(target, "position", Vector2(42, 17))
+    undo.add_do_method(handler, "record", target, "after")
+    undo.add_undo_property(target, "position", Vector2.ZERO)
+    undo.add_undo_method(handler, "record", target, "before")
+    undo.commit_action()
+    history = undo.get_history_undo_redo(undo.get_object_history_id(target))
+    before["mark"] = target.get_meta("mark", "missing")
+    before["state"] = handler.snapshot()
+    var verifier = load("res://addons/godot_ai/utils/release_verifier.gd")
+    var tree: Dictionary = verifier.hash_tree(STAGE)
+    assert(tree.ok)
+    var expected := str(tree.tree_sha256)
+    var mode := OS.get_environment("BRIDGE_CASE")
+    if mode == "wrong-hash": expected = "0".repeat(64)
+    if mode == "backup-exists":
+        assert(DirAccess.make_dir_recursive_absolute(UPDATE + "/backup/3.2.5") == OK)
+    var coordinator = load("res://addons/godot_ai/migration_coordinator.gd").new()
     get_tree().root.add_child(coordinator)
-    coordinator._installer = installer
-    coordinator._lock_held = false
-    coordinator._package = {
-        "from_version": "3.2.4",
-        "to_version": "4.0.0",
-        "manifest_sha256": "0".repeat(64),
-        "expected_tree_sha256": "0".repeat(64),
-        "stage_root": "res://addons/.godot_ai_update/stage/addons/godot_ai",
-    }
-    var companion_enabled := EditorInterface.is_plugin_enabled(COMPANION)
-    if CASE == "save-failure":
-        coordinator._swap()
-    else:
-        # The real installer refuses a fake stage; drive the persistence and
-        # restart steps the swap hands off to, exactly as _swap() does.
-        var persisted: Variant = installer.call("persist_next_start_enabled", CONFIG)
-        if not persisted is int or int(persisted) != OK:
-            get_tree().quit(47)
-            return
-        print("MCP | v3 bridge restarting editor into canonical v4 tree")
-        installer.call("request_restart")
+    coordinator.state_changed.connect(on_state)
+    coordinator.start({"from_version": "3.2.5", "to_version": "4.0.5",
+        "manifest_sha256": "a".repeat(64), "expected_tree_sha256": expected,
+        "stage_root": STAGE})
+    started = Time.get_ticks_msec()
+func next_activation() -> void:
+    first_activation = JSON.parse_string(FileAccess.get_file_as_string(UPDATE + "/activation.json"))
+    var plugin := find_plugin(get_tree().root)
+    first_value = plugin.call("active_value")
+    first_state = plugin.get("handler").snapshot()
+    assert(DirAccess.rename_absolute(UPDATE + "/activation.json",
+        UPDATE + "/first-activation.json") == OK)
+    var made := DirAccess.make_dir_recursive_absolute(STAGE.get_base_dir())
+    assert(made == OK, "prepare next stage: " + error_string(made))
+    var moved := DirAccess.rename_absolute(UPDATE + "/next/addons/godot_ai", STAGE)
+    assert(moved == OK, "move next stage: " + error_string(moved))
+    var verifier = load("res://addons/godot_ai/utils/release_verifier.gd")
+    var tree: Dictionary = verifier.hash_tree(STAGE)
+    assert(tree.ok)
+    var coordinator = load("res://addons/godot_ai/migration_coordinator.gd").new()
+    get_tree().root.add_child(coordinator)
+    coordinator.state_changed.connect(on_state)
+    coordinator.start({"from_version": "4.0.5", "to_version": "4.0.6",
+        "manifest_sha256": "b".repeat(64), "expected_tree_sha256": tree.tree_sha256,
+        "stage_root": STAGE})
+    started = Time.get_ticks_msec()
+func on_state(message: String, failed: bool) -> void:
+    if failed: failure = message
+func finish() -> void:
+    var plugin := find_plugin(get_tree().root)
+    var activation := {}
+    if FileAccess.file_exists(UPDATE + "/activation.json"):
+        activation = JSON.parse_string(FileAccess.get_file_as_string(UPDATE + "/activation.json"))
     var saved := ConfigFile.new()
-    if saved.load("res://project.godot") != OK:
-        get_tree().quit(45)
-        return
-    _write("res://first.json", {
-        "pid": OS.get_process_id(),
-        "enabled_in_old_process": EditorInterface.is_plugin_enabled(CONFIG),
-        "companion": companion_enabled,
-        "saved": Array(saved.get_value("editor_plugins", "enabled", PackedStringArray())),
-        "restored": ProjectSettings.get_setting(KEY) == previous,
-        "status_key": Coordinator.status_setting(),
-        "project_root": ProjectSettings.globalize_path("res://"),
-    })
-    if CASE == "save-failure":
-        get_tree().quit(0)
-func _write(path: String, value: Dictionary) -> void:
-    var file := FileAccess.open(path, FileAccess.WRITE)
-    if file == null:
-        get_tree().quit(46)
-        return
-    file.store_string(JSON.stringify(value))
+    var save_read := saved.load("res://project.godot")
+    var result := {"before": before, "pid": OS.get_process_id(), "failure": failure,
+        "enabled": EditorInterface.is_plugin_enabled(CONFIG),
+        "companion": EditorInterface.is_plugin_enabled(COMPANION),
+        "value": plugin.call("active_value") if plugin != null else "",
+        "instance": plugin.get_instance_id() if plugin != null else 0,
+        "activation": activation, "first_activation": first_activation,
+        "scan_completions": scan_completions,
+        "unrelated_notifications": unrelated_notifications, "ordering_errors": ordering_errors,
+        "first_value": first_value, "first_state": first_state,
+        "first_backup_exists": FileAccess.file_exists(UPDATE + "/backup/3.2.5/handler.gd"),
+        "second_backup_exists": FileAccess.file_exists(UPDATE + "/backup/4.0.5/handler.gd"),
+        "lock_present": FileAccess.file_exists(UPDATE + "/lock.json"),
+        "retention_marker": get_tree().root.has_meta("godot_ai_retained_update_scripts"),
+        "pending": FileAccess.file_exists(UPDATE + "/pending.json"),
+        "stage_present": DirAccess.dir_exists_absolute(STAGE),
+        "save_read": save_read,
+        "saved_enabled": Array(saved.get_value("editor_plugins", "enabled",
+            PackedStringArray())) if save_read == OK else []}
+    var previous_handler = retained.get_ref() if retained != null else null
+    result["retained_alive"] = previous_handler != null
+    if previous_handler != null:
+        result["retained_state"] = previous_handler.snapshot()
+        result["retained_script_path"] = previous_handler.get_script().resource_path
+    if plugin != null:
+        result["new_state"] = plugin.get("handler").snapshot()
+    if history != null:
+        result["undo_ok"] = history.undo()
+        result["undo_position"] = [target.position.x, target.position.y]
+        result["undo_mark"] = target.get_meta("mark", "missing")
+        result["redo_ok"] = history.redo()
+        result["redo_position"] = [target.position.x, target.position.y]
+        result["redo_mark"] = target.get_meta("mark", "missing")
+    var file := FileAccess.open("res://result.json", FileAccess.WRITE)
+    file.store_string(JSON.stringify(result))
     file.close()
-''',
+    get_tree().quit()
+"""
+
+
+def _project(tmp_path: Path, case: str) -> Path:
+    project = tmp_path / case
+    live = project / "addons/godot_ai"
+    live.mkdir(parents=True)
+    (live / "utils").mkdir()
+    for name in INSTALLER_SCRIPTS:
+        shutil.copy2(PLUGIN_ROOT / "utils" / name, live / "utils" / name)
+    shutil.copy2(PLUGIN_ROOT.parents[2] / "migration_bridge/migration_coordinator.gd", live)
+    (live / "plugin.cfg").write_text(
+        '[plugin]\nname="Activation fixture"\nversion="3.2.5"\nscript="plugin.gd"\n',
         encoding="utf-8",
     )
-    succeeds = case != "save-failure"
-    log = run_godot_editor(
-        project,
-        godot,
-        allow_headless=True,
-        timeout=90,
-        restart_completion_file="second.json" if succeeds else None,
+    (live / "plugin.gd").write_text(PLUGIN.replace("VERSION", "3.2.5"), encoding="utf-8")
+    (live / "handler.gd").write_text(
+        '@tool\nextends RefCounted\nconst Leaf := preload("res://addons/godot_ai/leaf.gd")\n'
+        'var storage: Dictionary = {"value": "A"}\n'
+        'func value() -> String: return storage.value if Leaf.value() == "A" else "wrong"\n',
+        encoding="utf-8",
     )
-    first = json.loads((project / "first.json").read_text(encoding="utf-8"))
-    assert first["status_key"] == "godot_ai/v4_migration_bridge_status_" + hashlib.sha256(
-        first["project_root"].encode("utf-8")
-    ).hexdigest()
-    assert not first["enabled_in_old_process"], first
-    assert first["companion"], first
+    (live / "leaf.gd").write_text(
+        "@tool\nclass_name McpBridgeFixtureLeaf\nextends RefCounted\n"
+        'static func value() -> String: return "A"\n',
+        encoding="utf-8",
+    )
+    handler_methods = (
+        "func record(target: Node, argument: String) -> void:\n"
+        '    target.set_meta("mark", McpBridgeFixtureLeaf.value() + ":" + argument)\n'
+        "func snapshot() -> Dictionary:\n"
+        '    return {"type": typeof(storage), "value": storage, '
+        '"static": McpBridgeFixtureLeaf.snapshot()}\n'
+    )
+    leaf_methods = (
+        "static func snapshot() -> Dictionary:\n"
+        '    return {"type": typeof(state), "value": state}\n'
+    )
+    with (live / "handler.gd").open("a", encoding="utf-8") as file:
+        file.write(
+            handler_methods + "func prepare_static() -> void:\n    McpBridgeFixtureLeaf.mutate()\n"
+        )
+    with (live / "leaf.gd").open("a", encoding="utf-8") as file:
+        file.write(
+            'static var state: Dictionary = {"marker": "initial-A"}\n'
+            'static func mutate() -> void: state["marker"] = "mutated-A"\n' + leaf_methods
+        )
+    (live / "attached.gd").write_text("@tool\nextends Node\n", encoding="utf-8")
+    stage = project / "addons/.godot_ai_update/stage/addons/godot_ai"
+    shutil.copytree(live, stage)
+    (project / "addons/.godot_ai_update/.gdignore").write_text("", encoding="utf-8")
+    (stage / "plugin.gd").write_text(PLUGIN.replace("VERSION", "4.0.5"), encoding="utf-8")
+    (stage / "plugin.cfg").write_text(
+        (live / "plugin.cfg").read_text(encoding="utf-8").replace("3.2.5", "4.0.5"),
+        encoding="utf-8",
+    )
+    (stage / "handler.gd").write_text(
+        '@tool\nextends RefCounted\nconst Leaf := preload("res://addons/godot_ai/leaf.gd")\n'
+        'var storage: Array[String] = ["B"]\n'
+        "func value() -> String: return storage[0] + Leaf.added_api()\n",
+        encoding="utf-8",
+    )
+    (stage / "leaf.gd").write_text(
+        "@tool\nclass_name McpBridgeFixtureLeaf\nextends RefCounted\n"
+        'static func value() -> String: return "B"\n'
+        'static func added_api() -> String: return "-new-api"\n',
+        encoding="utf-8",
+    )
+    with (stage / "handler.gd").open("a", encoding="utf-8") as file:
+        file.write(handler_methods)
+    with (stage / "leaf.gd").open("a", encoding="utf-8") as file:
+        file.write('static var state: Array[String] = ["B-static"]\n' + leaf_methods)
+    # Deliberately collide scanner timestamp seconds; source bytes still differ.
+    for source in stage.rglob("*.gd"):
+        timestamp = int((live / source.relative_to(stage)).stat().st_mtime)
+        os.utime(source, (timestamp, timestamp))
+    if case == "success":
+        following = project / "addons/.godot_ai_update/next/addons/godot_ai"
+        shutil.copytree(stage, following)
+        for name in ("plugin.gd", "plugin.cfg", "handler.gd", "leaf.gd"):
+            path = following / name
+            text = path.read_text(encoding="utf-8")
+            text = (
+                text.replace("4.0.5", "4.0.6").replace('"B"', '"C"').replace("B-static", "C-static")
+            )
+            path.write_text(text, encoding="utf-8")
+            timestamp = int((live / name).stat().st_mtime)
+            os.utime(path, (timestamp, timestamp))
+    if case == "missing-runner":
+        (live / "utils/update_activation_runner.gd").unlink()
+    companion = project / "addons/companion"
+    companion.mkdir()
+    (companion / "plugin.cfg").write_text(
+        '[plugin]\nname="Companion"\nversion="1"\nscript="plugin.gd"\n', encoding="utf-8"
+    )
+    (companion / "plugin.gd").write_text("@tool\nextends EditorPlugin\n", encoding="utf-8")
+    (project / "project.godot").write_text(
+        'config_version=5\n[application]\nconfig/name="Bridge activation"\n'
+        '[autoload]\nDriver="*res://driver.gd"\n[editor_plugins]\n'
+        'enabled=PackedStringArray("res://addons/companion/plugin.cfg", '
+        '"res://addons/godot_ai/plugin.cfg")\n',
+        encoding="utf-8",
+    )
+    (project / "user.tscn").write_text(
+        "[gd_scene load_steps=2 format=3]\n"
+        '[ext_resource type="Script" path="res://addons/godot_ai/attached.gd" id="1"]\n'
+        '[node name="UserScene" type="Node"]\nscript = ExtResource("1")\n',
+        encoding="utf-8",
+    )
+    (project / "driver.gd").write_text(DRIVER, encoding="utf-8")
+    return project
+
+
+@pytest.mark.parametrize(
+    "case", ["success", "missing-runner", "wrong-hash", "backup-exists", "user-scene"]
+)
+def test_bridge_actual_activation_preserves_companion_and_fails_closed(
+    tmp_path: Path,
+    case: str,
+) -> None:
+    godot = godot_bin_or_skip()
+    project = _project(tmp_path, case)
+    environment = {"BRIDGE_CASE": case, "GODOT_AI_DISABLE_TELEMETRY": "true"}
+    for key in ("APPDATA", "LOCALAPPDATA", "HOME", "XDG_CONFIG_HOME"):
+        directory = tmp_path / key.lower()
+        directory.mkdir()
+        environment[key] = str(directory)
+    log = run_godot_editor(
+        project, godot, allow_headless=True, timeout=100, environment=environment
+    )
     assert "SCRIPT ERROR" not in log, log
-    if succeeds:
-        second = json.loads((project / "second.json").read_text(encoding="utf-8"))
-        assert first["pid"] != second["pid"]
-        assert second["enabled"] and second["companion"], second
-        assert first["saved"] == second["setting"] == [
+    result = json.loads((project / "result.json").read_bytes())
+    assert result["before"]["value"] == "A", result
+    assert result["before"]["pid"] == result["pid"], result
+    assert result["before"]["companion"] and result["companion"], result
+    assert not result["lock_present"], result
+    assert result["retention_marker"] == (case == "success"), result
+    old_state = {
+        "type": 27,
+        "value": {"value": "A"},
+        "static": {"type": 27, "value": {"marker": "mutated-A"}},
+    }
+    assert result["before"]["state"] == old_state, result
+    assert result["retained_alive"] and result["retained_state"] == old_state, result
+    assert result["before"]["mark"] == "A:after", result
+    assert result["undo_ok"] and result["undo_position"] == [0, 0], result
+    assert result["redo_ok"] and result["redo_position"] == [42, 17], result
+    assert result["undo_mark"] == "A:before" and result["redo_mark"] == "A:after", result
+    assert result["failure"] != "test_deadline", result
+    if case == "missing-runner":
+        assert "activation runner is missing or invalid" in result["failure"], result
+        assert result["activation"] == {} and not result["pending"], result
+        assert result["instance"] == result["before"]["instance"], result
+        assert result["value"] == "A" and result["enabled"], result
+        assert not result["stage_present"], result
+    elif case == "user-scene":
+        assert result["activation"] == {}, result
+        assert "open scene or resource references addon script" in result["failure"], result
+        assert "res://addons/godot_ai/attached.gd" in result["failure"], result
+        assert result["instance"] == result["before"]["instance"], result
+        assert result["value"] == "A" and result["enabled"], result
+        assert not result["pending"] and not result["stage_present"], result
+        assert result["retained_script_path"] == "res://addons/godot_ai/handler.gd", result
+        assert 'path="res://addons/godot_ai/attached.gd"' in (project / "user.tscn").read_text(
+            encoding="utf-8"
+        )
+    else:
+        expected = {
+            "success": "success",
+            "wrong-hash": "rolled_back",
+            "backup-exists": "previous_tree_retained",
+        }[case]
+        assert result["activation"]["status"] == expected, result
+        assert result["instance"] != result["before"]["instance"], result
+        assert result["enabled"], result
+        assert result["value"] == ("C-new-api" if case == "success" else "A"), result
+        assert result["save_read"] == 0, result
+        assert set(result["saved_enabled"]) == {
             "res://addons/companion/plugin.cfg",
             "res://addons/godot_ai/plugin.cfg",
-        ]
-        assert "restarting editor into canonical v4 tree" in log
-    else:
-        assert first["saved"] == ["res://addons/companion/plugin.cfg"], first
-        assert not (project / "second.json").exists()
-        assert "restarting editor into canonical v4 tree" not in log
-        assert "explicit recovery is required" in log
+        }, result
+        if case == "success":
+            assert result["unrelated_notifications"] > 0, result
+            assert result["ordering_errors"] == [], result
+            for generation, old, new in [(1, "3.2.5", "4.0.5"), (2, "4.0.5", "4.0.6")]:
+                versions = [
+                    entry["version"]
+                    for entry in result["scan_completions"]
+                    if entry["activation"] == generation
+                ]
+                assert len(versions) >= 2 and versions[0] == old and versions[-1] == new, result
+            assert result["first_activation"]["status"] == "success", result
+            assert result["first_value"] == "B-new-api", result
+            assert result["first_state"] == {
+                "type": 28,
+                "value": ["B"],
+                "static": {"type": 28, "value": ["B-static"]},
+            }, result
+            assert result["first_backup_exists"] and result["second_backup_exists"], result
+            assert result["new_state"] == {
+                "type": 28,
+                "value": ["C"],
+                "static": {"type": 28, "value": ["C-static"]},
+            }, result
+            assert result["retained_script_path"].startswith(
+                "res://addons/.godot_ai_update/backup/3.2.5/"
+            ), result
+            assert result["activation"]["error"] == "", result
+            assert "update activation completed in editor PID" in log

--- a/tests/integration/test_self_update_status_driver.py
+++ b/tests/integration/test_self_update_status_driver.py
@@ -1,0 +1,108 @@
+"""Exercise the update driver's HTTP status polling against real socket failures."""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import socketserver
+import subprocess
+import threading
+import time
+
+import pytest
+
+from tests.integration._self_update_fixture import godot_bin_or_skip, write_driver_support
+
+pytestmark = pytest.mark.editor
+
+
+def test_status_driver_quietly_rejects_interrupted_and_invalid_responses(tmp_path):
+    nonce = "fixture-status-instance"
+    valid = json.dumps({"instance_id": nonce, "server_version": "4.0.5"}).encode()
+    responses = [
+        valid,
+        b'{"broken":',
+        valid,
+        b"x" * (64 * 1024 + 1),
+        json.dumps({"instance_id": "wrong"}).encode(),
+        valid,
+    ]
+    observed = []
+
+    class Handler(socketserver.BaseRequestHandler):
+        def handle(self):
+            request = b""
+            while b"\r\n\r\n" not in request:
+                chunk = self.request.recv(4096)
+                if not chunk:
+                    return
+                request += chunk
+            index = len(observed)
+            observed.append(b"Authorization: Bearer fixture-status-auth" in request)
+            body = responses[index]
+            size = len(body) + 10 if index == 2 else len(body)
+            self.request.sendall(
+                f"HTTP/1.1 200 OK\r\nContent-Length: {size}\r\nConnection: close\r\n\r\n".encode()
+            )
+            if index == 2:
+                # Give Godot time to enter STATUS_BODY before the connection drops.
+                time.sleep(0.05)
+            self.request.sendall(body)
+            if index == 2:
+                time.sleep(0.05)
+                self.request.shutdown(socket.SHUT_RDWR)
+
+    with socketserver.TCPServer(("127.0.0.1", 0), Handler) as server:
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+            write_driver_support(tmp_path)
+            capabilities = tmp_path / "local/godot-ai/capabilities"
+            capabilities.mkdir(parents=True)
+            (capabilities / f"http-{port}.json").write_text(
+                json.dumps({"http": "fixture-status-auth", "instance_nonce": nonce}),
+                encoding="utf-8",
+            )
+            driver = tmp_path / "driver.gd"
+            driver.write_text(
+                'extends SceneTree\nconst Support = preload("res://_test_self_update_driver_support.gd")\n'
+                "func _initialize() -> void:\n"
+                f"\tvar first := Support.fetch_status({port})\n"
+                '\tassert(first.get("server_version") == "4.0.5")\n'
+                "\tfor _index in range(4):\n"
+                f"\t\tassert(Support.fetch_status({port}).is_empty())\n"
+                f'\tassert(Support.fetch_status({port}).get("instance_id") == "{nonce}")\n'
+                '\tprint("STATUS_DRIVER_SOCKET_CASES_PASSED")\n\tquit()\n',
+                encoding="utf-8",
+            )
+            env = {
+                **os.environ,
+                "LOCALAPPDATA": str(tmp_path / "local"),
+                "GODOT_AI_CAPABILITY_DIR": str(capabilities),
+                "GODOT_AI_DISABLE_TELEMETRY": "true",
+            }
+            result = subprocess.run(
+                [
+                    godot_bin_or_skip(),
+                    "--headless",
+                    "--path",
+                    str(tmp_path),
+                    "--script",
+                    str(driver),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                env=env,
+            )
+            output = result.stdout + result.stderr
+            assert result.returncode == 0, output
+            assert "ERROR" not in output, output
+            assert "STATUS_DRIVER_SOCKET_CASES_PASSED" in output
+            assert observed == [True] * len(responses)
+        finally:
+            server.shutdown()
+            thread.join(timeout=5)

--- a/tests/integration/test_self_update_upgrade_paths.py
+++ b/tests/integration/test_self_update_upgrade_paths.py
@@ -1,15 +1,15 @@
 """Real-editor scenarios for the lean self-updater (docs/self-update.md).
 
 Each scenario drives the production entry points inside a real editor and
-proves the state one update leaves behind: a signed v4-to-v4 update restarts
-into a working server, the final-v3 capsule crosses into v4, a tampered live
-tree after a swap is rolled back, and the closed-editor installer's first
-start completes client migration.
+proves the state one update leaves behind: a signed current-source update reloads in the same editor
+with preserved scene state and a working server. The final-v3 capsule crosses into
+v4, a tampered tree is rolled back, and the closed-editor installer completes migration.
 """
 
 from __future__ import annotations
 
 import asyncio
+import configparser
 import contextlib
 import hashlib
 import json
@@ -470,12 +470,13 @@ def signed_update_delivery(request):
         yield configure
 
 
-def test_signed_update_restarts_into_matching_live_server(
+def test_signed_update_loads_matching_live_server_in_same_editor(
     tmp_path: Path,
     signed_update_delivery,
 ) -> None:
-    """Click Update on A; the editor swaps, restarts, repins, and serves B."""
+    """Click Update on A; the same editor loads B and preserves editing state."""
     godot_bin = godot_bin_or_skip()
+    visible = os.environ.get("GODOT_AI_VISIBLE_SELF_UPDATE") == "1"
     smoke = load_smoke_script()
     project = tmp_path / "signed-self-update"
     http_port, ws_port = allocate_free_ports(2)
@@ -496,9 +497,9 @@ def test_signed_update_restarts_into_matching_live_server(
         base_version=base_version,
         next_version=next_version,
         agent_gate=True,
+        native_update=visible,
     )
     base_addon = project / "addons" / "godot_ai"
-    patch_restart_diagnostics(base_addon, project / RESTARTED_EDITOR_LOG)
     isolated = project / ".self-update-integration"
     environment, capability_dir = _isolated_environment(isolated)
     codex_home = Path(environment["CODEX_HOME"])
@@ -508,6 +509,30 @@ def test_signed_update_restarts_into_matching_live_server(
         version=base_version,
         reload_before_quit=True,
     )
+
+    if visible:
+        # Match the native compatibility-rendered fixture that exposed the crash.
+        project_settings = project / "project.godot"
+        text = project_settings.read_text(encoding="utf-8")
+        assert "[rendering]" not in text
+        project_settings.write_text(
+            text + '\n[rendering]\nrenderer/rendering_method="gl_compatibility"\n'
+            'renderer/rendering_method.mobile="gl_compatibility"\n',
+            encoding="utf-8",
+        )
+
+    parsed_project = configparser.ConfigParser(interpolation=None)
+    parsed_project.read_string(
+        "[__project__]\n" + (project / "project.godot").read_text(encoding="utf-8")
+    )
+    assert parsed_project["autoload"]["_SelfUpdateRunnerDriver"] == (
+        '"*res://_test_runner_driver.gd"'
+    )
+    assert parsed_project["autoload"]["_SelfUpdateClientPrep"] == (
+        '"*res://_test_configure_client.gd"'
+    )
+    if visible:
+        assert parsed_project["rendering"]["renderer/rendering_method"] == '"gl_compatibility"'
 
     delivery = signed_update_delivery(project, next_version, environment)
     prep_environment = dict(environment)
@@ -534,20 +559,31 @@ def test_signed_update_restarts_into_matching_live_server(
 
     # An agent stays attached through the whole update, exactly as a user's
     # AI client would be. Its bridge loses server A, spawns a backend of the
-    # old version into the restart window, and the restarted editor must
+    # old version during the plugin reload, and the new plugin must
     # replace that backend on its own rather than ask the user to.
     with AttachedAgent(
         project, http_port, ws_port, capability_dir=capability_dir, environment=environment
     ) as agent:
+        def probe_updated_editor() -> None:
+            _selected_endpoint_tool_probe(
+                project, POST_UPDATE_STATUS_FILE, capability_dir,
+                legacy_ports=(http_port, ws_port), migrated=False,
+                expected_version=next_version,
+                resource_path="res://_test_authenticated_tool_probe.txt",
+                content="signed self-update authenticated write\n",
+            )
+            agent.wait_for_post_update(next_version)
+
         try:
             log = run_godot_editor(
                 project,
                 godot_bin,
-                allow_headless=True,
-                timeout=240,
+                allow_headless=not visible,
+                headless=not visible,
+                timeout=360 if visible else 240,
                 environment=environment,
-                live_probe=lambda: _authenticated_tool_probe(http_port, capability_dir),
-                restart_completion_file=POST_UPDATE_COMPLETE_FILE,
+                live_probe=probe_updated_editor,
+                require_same_editor=True,
             )
         except AssertionError as exc:
             raise AssertionError(
@@ -555,28 +591,10 @@ def test_signed_update_restarts_into_matching_live_server(
             ) from exc
     assert not agent.fault, agent.fault
     assert agent.ok >= 1, agent.errors
-    # What the old bridge reports afterwards varies with timing (a refused
-    # incompatible backend, a lost lease, a backend without an editor); the
-    # contract is only that the editor came back live on its own, above.
+    assert agent.post_update["version"] == next_version
+    assert agent.post_update["session_id"]
+    # The original stdio bridge must recover as well as the separate HTTP probe.
     print(f"attached agent: ok={agent.ok} errors={len(agent.errors)} last={agent.errors[-1:]}")
-    # Whether the bridge's spawned backend takes the port before the editor's
-    # probe, between its probe and its launch, or not at all is a race; the
-    # editor recovers from each on its own (the ordered markers and the live
-    # probe below are the contract). Say which path this run took.
-    replaced_line = (
-        f"MCP | replacing the v{base_version} server left on port {http_port} by the update"
-    )
-    restarted_log = log[log.index("SELF_UPDATE_HARNESS | replacement editor log:") :]
-    started_at = restarted_log.index("MCP | started server (PID ")
-    blocks_before_start = [
-        line.split("MCP | server start blocked: ", 1)[1]
-        for line in restarted_log[:started_at].splitlines()
-        if "MCP | server start blocked: " in line
-    ]
-    initial_log = log[: log.index("SELF_UPDATE_HARNESS | replacement editor log:")]
-    print(f"server A: {'stopped' if 'MCP | stopped server' in initial_log else 'detached (lease)'}")
-    print(f"replacement: {'needed' if replaced_line in restarted_log else 'not needed'}")
-    print(f"blocks before the start: {blocks_before_start}")
     ## From 4.0.4 on the attached bridge follows the new server (same major);
     ## an older bridge needs a new MCP connection using the updated configuration.
     base_tuple = tuple(int(part) for part in base_version.split(".")[:3])
@@ -593,8 +611,13 @@ def test_signed_update_restarts_into_matching_live_server(
     assert expected_client_line in log
 
     initial_editor, restarted_editor = read_editor_receipts(project)
-    assert initial_editor["pid"] != restarted_editor["pid"], (initial_editor, restarted_editor)
-    assert initial_editor["display"] == restarted_editor["display"] == "headless"
+    assert initial_editor["pid"] == restarted_editor["pid"], (initial_editor, restarted_editor)
+    assert initial_editor["display"] == restarted_editor["display"]
+    assert (initial_editor["display"] == "headless") is (not visible)
+    assert (project / POST_UPDATE_COMPLETE_FILE).is_file()
+    assert ("SELF_UPDATE_TEST | loaded topology, dirty scene, selection and undo/redo preserved"
+            in log)
+    assert f"MCP | update activation completed in editor PID {initial_editor['pid']}" in log
     assert_no_update_parse_errors(log)
     _assert_ordered(
         log,
@@ -606,21 +629,23 @@ def test_signed_update_restarts_into_matching_live_server(
             # connected after the plugin's activation listener, but activation
             # names each phase in the dock and yields a frame before verifying,
             # staging and quiescing, so the observer's line lands before the
-            # restart announcement. Whether A is stopped or merely detached
+            # activation announcement. Whether A is stopped or merely detached
             # before the swap depends on the attached agent holding a lease at
-            # that instant; the restarted editor replaces either occupant.
+            # that instant; the new plugin replaces either occupant.
             *(
                 [
                     "SELF_UPDATE_TEST | HTTPS canonical triple downloaded",
-                    f"MCP | update to {next_version} swapped in; restarting the editor",
+                    f"MCP | update to {next_version} swapped in; "
+                    "reloading the plugin in this editor",
                 ]
                 if delivery is not None
                 else [
                     smoke.SMOKE_STAGED_LOG,
-                    f"MCP | update to {next_version} swapped in; restarting the editor",
+                    f"MCP | update to {next_version} swapped in; "
+                    "reloading the plugin in this editor",
                 ]
             ),
-            # Everything below runs in the restarted editor process. The driver
+            # Everything below runs in the same editor process. The driver
             # sees the new server answer /godot-ai/status before the plugin
             # logs the handshake that follows the spawn.
             "MCP | client migration completed",
@@ -749,6 +774,8 @@ const DEADLINE_MSEC := 180000
 var _deadline := 0
 var _migration_ready := false
 var _clicked := false
+var _scene_state: Dictionary = {{}}
+var _old_plugin_id := 0
 
 
 func _ready() -> void:
@@ -756,7 +783,11 @@ func _ready() -> void:
 \t\tqueue_free()
 \t\treturn
 \tvar restarted := FileAccess.file_exists(INITIAL_RECEIPT)
-\tvar receipt_path := RESTARTED_RECEIPT if restarted else INITIAL_RECEIPT
+\tif restarted:
+\t\tpush_error("V3_BRIDGE_TEST | migration unexpectedly restarted the editor")
+\t\tget_tree().quit(44)
+\t\treturn
+\tvar receipt_path := INITIAL_RECEIPT
 \tvar receipt := FileAccess.open(receipt_path, FileAccess.WRITE)
 \tif receipt == null:
 \t\tget_tree().quit(43)
@@ -781,6 +812,15 @@ func _process(_delta: float) -> void:
 \t\tvar dock: Variant = old_plugin.get("_dock")
 \t\tif dock == null or not dock.has_method("_on_update_pressed"):
 \t\t\treturn
+\t\tif EditorInterface.get_edited_scene_root() == null:
+\t\t\tEditorInterface.open_scene_from_path("res://empty.tscn")
+\t\t\treturn
+\t\t_old_plugin_id = old_plugin.get_instance_id()
+\t\t_scene_state = DriverSupport.capture_scene_state(old_plugin)
+\t\tif _scene_state.is_empty():
+\t\t\tpush_error("V3_BRIDGE_TEST | could not capture scene continuity state")
+\t\t\tget_tree().quit(46)
+\t\t\treturn
 \t\tdock.call("_on_update_pressed")
 \t\t_clicked = true
 \t\treturn
@@ -796,11 +836,28 @@ func _process(_delta: float) -> void:
 \tvar plugin := DriverSupport.find_godot_ai_plugin()
 \tif plugin == null or not bool(plugin.call("has_managed_server")):
 \t\treturn
+\tif (plugin.get_instance_id() == _old_plugin_id
+\t\t\tor str(plugin.get("_loaded_plugin_version")) != TARGET_VERSION):
+\t\treturn
 \tif not DriverSupport.client_config_has_pin(TARGET_VERSION):
 \t\treturn
 \tvar status := DriverSupport.fetch_selected_status(plugin)
 \tif str(status.get("server_version", "")) != TARGET_VERSION:
 \t\treturn
+\tvar continuity_error := DriverSupport.verify_scene_state(plugin, _scene_state)
+\tif not continuity_error.is_empty():
+\t\tpush_error("V3_BRIDGE_TEST | " + continuity_error)
+\t\tget_tree().quit(45)
+\t\treturn
+\tvar receipt := FileAccess.open(RESTARTED_RECEIPT, FileAccess.WRITE)
+\tif receipt == null:
+\t\tget_tree().quit(43)
+\t\treturn
+\treceipt.store_string(JSON.stringify({{
+\t\t"pid": OS.get_process_id(), "display": DisplayServer.get_name(),
+\t}}))
+\treceipt.close()
+\tprint("V3_BRIDGE_TEST | dirty scene, selection and undo/redo preserved")
 \tvar file := FileAccess.open(STATUS_PATH, FileAccess.WRITE)
 \tif file == null:
 \t\tget_tree().quit(42)
@@ -821,26 +878,30 @@ func _process(_delta: float) -> void:
         allow_headless=True,
         timeout=360 if os.name == "nt" else 240,
         environment=environment,
+        require_same_editor=True,
         live_probe=lambda: _selected_endpoint_tool_probe(
             project, POST_UPDATE_STATUS_FILE, capability_dir,
             legacy_ports=(http_port, ws_port), migrated=True, expected_version=target_version,
             resource_path="res://_test_v3_bridge_probe.txt",
             content="v3 bridge authenticated write\n",
         ),
-        restart_completion_file=POST_UPDATE_COMPLETE_FILE,
     )
 
     initial_editor, restarted_editor = read_editor_receipts(project)
-    assert initial_editor["pid"] != restarted_editor["pid"], (initial_editor, restarted_editor)
+    assert initial_editor["pid"] == restarted_editor["pid"], (initial_editor, restarted_editor)
     assert initial_editor["display"] == restarted_editor["display"] == "headless", (
         initial_editor,
         restarted_editor,
     )
+    assert (project / POST_UPDATE_COMPLETE_FILE).is_file()
+    assert "V3_BRIDGE_TEST | dirty scene, selection and undo/redo preserved" in log
+    assert f"MCP | update activation completed in editor PID {initial_editor['pid']}" in log
     assert "Failed to create an autoload" not in log, log
-    disable = log.find("MCP | v3 bridge disabling transition plugin")
+    disable = log.find("MCP | v3 bridge handing verified tree to in-editor activation")
     assert disable >= 0, log
     for pattern in (
-        "SCRIPT ERROR: Parse Error",
+        "SCRIPT ERROR:",
+        "ERROR: Attempt to open script",
         "ERROR: Failed to load script",
         "Could not resolve script",
     ):
@@ -853,10 +914,9 @@ func _process(_delta: float) -> void:
             "MCP | update runner disabling old plugin",
             "MCP | v3 bridge verifying and staging the signed v4 tree",
             "MCP | v3 bridge activating canonical v4 tree",
-            "MCP | v3 bridge disabling transition plugin",
-            "MCP | v3 bridge swapping in the verified canonical v4 tree",
-            "MCP | v3 bridge restarting editor into canonical v4 tree",
-            # Everything below runs in the restarted editor on the v4 tree.
+            "MCP | v3 bridge handing verified tree to in-editor activation",
+            f"MCP | update to {target_version} swapped in; reloading the plugin in this editor",
+            # The original editor now runs the loaded v4 plugin.
             "MCP | client migration completed",
             "V3_BRIDGE_TEST | v4 server and client pin ready",
             "V3_BRIDGE_TEST | authenticated tool probe completed",
@@ -865,7 +925,9 @@ func _process(_delta: float) -> void:
     assert read_plugin_version(live / "plugin.cfg") == target_version
     assert not (live / "migration_payload").exists()
     assert not (live / "update_reload_runner.gd").exists()
-    assert not (live / "migration_bridge.gd").exists()
+    # Signed canonical compatibility shims are intentional; capsule payload is not.
+    for shim in ("migration_bridge.gd", "migration_coordinator.gd", "migration_fallback.gd"):
+        assert (live / shim).read_bytes() == (PLUGIN_ROOT / shim).read_bytes()
     codex_home = smoke.fixture_environment_paths(project)["codex_home"]
     config_text = _read_client_toml(codex_home / "config.toml")
     assert f"godot-ai=={target_version}" in config_text
@@ -1097,7 +1159,8 @@ func _process(_delta: float) -> void:
     )
     restored_at = log.index("MCP | v3 bridge restored Godot AI v3.2.5")
     for pattern in (
-        "SCRIPT ERROR: Parse Error",
+        "SCRIPT ERROR:",
+        "ERROR: Attempt to open script",
         "ERROR: Failed to load script",
         "Could not resolve script",
     ):
@@ -1169,9 +1232,9 @@ def test_refused_swap_restores_the_old_runtime(tmp_path: Path) -> None:
         log,
         (
             "REFUSED_SWAP_TEST | clicked Update with a backup collision in place",
-            "update swap refused: swap: backup already exists",
             "MCP | plugin unloaded",
             "MCP | plugin loaded",
+            "MCP | Update swap failed: swap: backup already exists",
             "REFUSED_SWAP_TEST | old runtime serves again after the refused swap",
             "REFUSED_SWAP_TEST | authenticated tool probe completed after the refused swap",
         ),

--- a/tests/unit/test_self_update_editor_harness.py
+++ b/tests/unit/test_self_update_editor_harness.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from godot_ai.transport.capability import CapabilityRecord
 from tests.integration import _self_update_fixture as fixture
 
 
@@ -143,7 +144,11 @@ async def test_attached_agent_uses_python_and_the_editors_isolated_environment(
         tmp_path, 18000, 19500, capability_dir=tmp_path, environment=environment
     )
     captured = {}
-    monkeypatch.setattr(fixture, "read_capabilities", lambda *_args: object())
+    capability = CapabilityRecord("h" * 64, "a" * 64, "b" * 32)
+    (tmp_path / fixture.PRE_INSTANCE_ID_FILE).write_text(
+        capability.instance_nonce, encoding="utf-8"
+    )
+    monkeypatch.setattr(fixture, "read_capabilities", lambda *_args: capability)
 
     def transport(**kwargs):
         captured.update(kwargs)

--- a/tests/unit/test_self_update_smoke_harness.py
+++ b/tests/unit/test_self_update_smoke_harness.py
@@ -37,6 +37,23 @@ def load_smoke_script() -> ModuleType:
     return module
 
 
+def test_linux_interactive_v3_server_requires_listener_pid_scraper(monkeypatch) -> None:
+    smoke = load_smoke_script()
+    monkeypatch.setattr(smoke.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(smoke.shutil, "which", lambda _name: None)
+
+    with pytest.raises(smoke.HarnessError, match="requires lsof or ss"):
+        smoke.require_linux_listener_pid_tool()
+
+
+def test_linux_interactive_v3_server_accepts_ss_fallback(monkeypatch) -> None:
+    smoke = load_smoke_script()
+    monkeypatch.setattr(smoke.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(smoke.shutil, "which", lambda name: "/usr/bin/ss" if name == "ss" else None)
+
+    smoke.require_linux_listener_pid_tool()
+
+
 def _static_func_block(text: str, signature: str) -> str:
     """Return one top-level GDScript function, stopping at the next top-level func."""
     start = text.index(signature)
@@ -383,7 +400,8 @@ def test_launch_passes_isolation_only_to_godot_child(
     addon.mkdir(parents=True)
     (addon / "plugin.gd").write_text(
         'const RUNNER = "update_activation_runner.gd"\n'
-        if same_editor else "extends EditorPlugin\n",
+        if same_editor
+        else "extends EditorPlugin\n",
         encoding="utf-8",
     )
     godot = tmp_path / "Godot"
@@ -405,7 +423,8 @@ def test_launch_passes_isolation_only_to_godot_child(
                 f"{smoke.SMOKE_STAGED_LOG}\n",
                 "MCP | stopped server (PID [123])\n",
                 f"MCP | update to 4.0.1 {smoke.IN_EDITOR_SWAP_LOG_SUFFIX}\n"
-                if same_editor else "MCP | update to 4.0.1 swapped in; restarting the editor\n",
+                if same_editor
+                else "MCP | update to 4.0.1 swapped in; restarting the editor\n",
                 f"{smoke.IN_EDITOR_COMPLETED_LOG}1234\n" if same_editor else "",
                 smoke.SMOKE_MIGRATED_LOG + "\n" if same_editor else "",
             ]
@@ -968,13 +987,16 @@ def test_verify_post_run_requires_live_status(
     assert "post-update /godot-ai/status was not live" in captured
 
 
-@pytest.mark.parametrize("diagnostic", [
-    None,
-    "SCRIPT ERROR: Compile Error: Failed to compile depended scripts.",
-    'ERROR: Failed to load script "res://addons/godot_ai/plugin.gd".',
-    "ERROR: Attempt to open script 'res://addons/godot_ai/migration_bridge.gd' "
-    "resulted in error 'File not found'.",
-])
+@pytest.mark.parametrize(
+    "diagnostic",
+    [
+        None,
+        "SCRIPT ERROR: Compile Error: Failed to compile depended scripts.",
+        'ERROR: Failed to load script "res://addons/godot_ai/plugin.gd".',
+        "ERROR: Attempt to open script 'res://addons/godot_ai/migration_bridge.gd' "
+        "resulted in error 'File not found'.",
+    ],
+)
 def test_verify_post_run_accepts_live_status_only_without_script_errors(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -1028,3 +1050,170 @@ def test_crash_report_filter_ignores_an_unrelated_godot_binary(tmp_path: Path) -
 
     assert smoke._report_matches_executable(report, launched) is False
     assert smoke._report_matches_executable(report, unrelated) is True
+
+
+@pytest.mark.parametrize("next_version", ["4.0.5", "4.0.4", "4.00.6", "5.0.0", "garbage"])
+def test_v3_chain_rejects_invalid_version_before_creating_fixture(tmp_path, next_version):
+    smoke = load_smoke_script()
+    project = tmp_path / "must-not-exist"
+    with pytest.raises(smoke.HarnessError):
+        smoke.prepare_v3_crossing_project(
+            project,
+            from_version="3.2.5",
+            target_version="4.0.5",
+            next_version=next_version,
+            http_port=18000,
+            ws_port=19500,
+        )
+    assert not project.exists()
+
+
+def test_v3_chain_compares_versions_numerically():
+    smoke = load_smoke_script()
+    smoke.validate_v3_chain_versions("4.0.9", "4.0.10")
+    with pytest.raises(smoke.HarnessError, match="greater"):
+        smoke.validate_v3_chain_versions("4.1.0", "4.0.99")
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        ["--then-version", "4.0.6"],
+        ["--target-version", "4.0.5"],
+        ["--start-published-v3-server"],
+        ["--from-v3-tag", "v3.2.5", "--next-version", "4.0.6", "--no-launch"],
+        ["--from-v3-tag", "v3.2.5", "--then-version", "4.0.6"],
+    ],
+)
+def test_invalid_chain_cli_options_preserve_existing_fixture(tmp_path, monkeypatch, options):
+    smoke = load_smoke_script()
+    marker = tmp_path / "keep.txt"
+    marker.write_text("keep", encoding="utf-8")
+    monkeypatch.setattr(
+        sys, "argv", [str(SCRIPT), "--project-dir", str(tmp_path), "--force", *options]
+    )
+    assert smoke.main() == 1
+    assert marker.read_text(encoding="utf-8") == "keep"
+    assert list(tmp_path.iterdir()) == [marker]
+
+
+@pytest.mark.parametrize("next_version", [None, "4.0.6"])
+def test_v3_chain_signs_onward_bundle_without_changing_single_hop(
+    tmp_path, monkeypatch, next_version
+):
+    smoke = load_smoke_script()
+    project = tmp_path / "chain"
+    result = smoke.prepare_v3_crossing_project(
+        project,
+        from_version="3.2.5",
+        target_version="4.0.5",
+        next_version=next_version,
+        http_port=18000,
+        ws_port=19500,
+    )
+    target = result["work"] / "release-tree"
+    manager = (target / "utils/update_manager.gd").read_text(encoding="utf-8")
+    assert (result["work"] / ".gdignore").is_file()
+    assert not (result["work"] / "smoke-release-key.pem").exists()
+    assert not (target / "utils/self_update_smoke_base.gd").exists()
+    assert "_self_update_smoke_trigger" not in (target / "mcp_dock.gd").read_text(encoding="utf-8")
+    if next_version is None:
+        assert result["second_bundle"] is None
+        assert "SELF_UPDATE_SMOKE_NEXT_VERSION" not in manager
+    else:
+        assert 'SELF_UPDATE_SMOKE_NEXT_VERSION := "4.0.6"' in manager
+        bundle = result["second_bundle"]
+        assert (bundle / ".gdignore").is_file()
+        manifest = json.loads((bundle / smoke.SMOKE_MANIFEST_NAME).read_bytes())
+        assert manifest["version"] == "4.0.6"
+        with zipfile.ZipFile(bundle / smoke.SMOKE_ARCHIVE_NAME) as archive:
+            assert 'version="4.0.6"' in archive.read("addons/godot_ai/plugin.cfg").decode()
+            assert "addons/godot_ai/utils/self_update_smoke_base.gd" in archive.namelist()
+
+
+def test_fixture_config_guard_executes_for_missing_wrong_and_expected_home(tmp_path):
+    smoke = load_smoke_script()
+    godot = os.environ.get("GODOT_BIN") or shutil.which("godot")
+    if not godot:
+        pytest.skip("Godot executable required to exercise the generated fixture guard")
+    path = tmp_path / "configurator.gd"
+    shutil.copyfile(ROOT / "plugin/addons/godot_ai/client_configurator.gd", path)
+    smoke.patch_isolated_client_launch(path, tmp_path / "client-sentinel")
+    patched = path.read_text(encoding="utf-8")
+    guard = _static_func_block(patched, "static func _self_update_smoke_config_error()")
+    for signature in (
+        "static func _config_path_resolution_error(",
+        "static func resolve_attach_launch(",
+    ):
+        assert "_self_update_smoke_config_error()" in _static_func_block(patched, signature)
+    (tmp_path / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    driver = tmp_path / "guard.gd"
+    driver.write_text(
+        "extends SceneTree\n"
+        + guard.replace("\t", "    ")
+        + """
+func _initialize() -> void:
+    OS.set_environment("CODEX_HOME", "")
+    assert(not _self_update_smoke_config_error().is_empty())
+    OS.set_environment("CODEX_HOME", ProjectSettings.globalize_path("res://wrong-home"))
+    assert(not _self_update_smoke_config_error().is_empty())
+    OS.set_environment("CODEX_HOME", ProjectSettings.globalize_path("res://.godot-ai-self-update-smoke/client-environment/codex"))
+    assert(_self_update_smoke_config_error().is_empty())
+    OS.set_environment("CODEX_HOME", ProjectSettings.globalize_path("res://.self-update-integration/codex"))
+    assert(_self_update_smoke_config_error().is_empty())
+    OS.set_environment("CODEX_HOME", ProjectSettings.globalize_path("res://.self-update-integration/codex-other"))
+    assert(not _self_update_smoke_config_error().is_empty())
+    print("FIXTURE_CONFIG_GUARD_PASSED")
+    quit()
+""",
+        encoding="utf-8",
+    )
+    run = subprocess.run(
+        [godot, "--headless", "--path", str(tmp_path), "--script", str(driver)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert run.returncode == 0, run.stdout + run.stderr
+    assert "SCRIPT ERROR" not in run.stdout + run.stderr
+    assert "FIXTURE_CONFIG_GUARD_PASSED" in run.stdout
+
+
+
+def test_printed_manual_launcher_preserves_isolation_and_exact_argv(
+    tmp_path, monkeypatch, capsys
+):
+    import runpy
+
+    smoke = load_smoke_script()
+    project = tmp_path / "fixture with spaces and ' apostrophe"
+    work = project / ".godot-ai-self-update-smoke"
+    work.mkdir(parents=True)
+    godot = "Godot with spaces & punctuation"
+    log = work / "editor.log"
+    monkeypatch.setenv("CODEX_HOME", "host-must-not-be-used")
+    monkeypatch.setenv(CAPABILITY_DIR_ENV, "host-capabilities-must-not-be-used")
+    smoke.print_manual_launch(project, godot, log)
+    output = capsys.readouterr().out
+    assert "launch-editor.py" in output
+    if os.name == "nt":
+        assert "PowerShell" in output
+        assert "'' apostrophe" in output
+    captured = {}
+
+    def launch(command, *, env):
+        captured.update(command=command, environment=env)
+        return 7
+
+    monkeypatch.setattr(subprocess, "call", launch)
+    with pytest.raises(SystemExit) as exited:
+        runpy.run_path(str(work / "launch-editor.py"), run_name="__main__")
+    assert exited.value.code == 7
+    assert captured["command"] == [
+        godot, "--editor", "--path", str(project), "--log-file", str(log)
+    ]
+    expected = smoke.godot_child_environment(project)
+    assert all(captured["environment"][key] == value for key, value in expected.items())
+    if os.name == "nt":
+        assert CAPABILITY_DIR_ENV not in captured["environment"]
+    assert os.environ["CODEX_HOME"] == "host-must-not-be-used"

--- a/tests/unit/test_self_update_smoke_harness.py
+++ b/tests/unit/test_self_update_smoke_harness.py
@@ -373,11 +373,19 @@ def test_cli_preparation_never_uses_parent_client_or_capability_paths(tmp_path: 
     assert fixture["capability_dir"].is_dir()
 
 
+@pytest.mark.parametrize("same_editor", [False, True])
 def test_launch_passes_isolation_only_to_godot_child(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, same_editor: bool
 ) -> None:
     smoke = load_smoke_script()
     project = tmp_path / "self-update-smoke"
+    addon = project / "addons/godot_ai"
+    addon.mkdir(parents=True)
+    (addon / "plugin.gd").write_text(
+        'const RUNNER = "update_activation_runner.gd"\n'
+        if same_editor else "extends EditorPlugin\n",
+        encoding="utf-8",
+    )
     godot = tmp_path / "Godot"
     godot.write_text("not executed\n", encoding="utf-8")
     parent_home = tmp_path / "parent-home"
@@ -391,17 +399,25 @@ def test_launch_passes_isolation_only_to_godot_child(
     captured: dict[str, Any] = {}
 
     class FakeGodot:
+        pid = 1234
         stdout = iter(
             [
                 f"{smoke.SMOKE_STAGED_LOG}\n",
                 "MCP | stopped server (PID [123])\n",
-                "MCP | update to 4.0.1 swapped in; restarting the editor\n",
+                f"MCP | update to 4.0.1 {smoke.IN_EDITOR_SWAP_LOG_SUFFIX}\n"
+                if same_editor else "MCP | update to 4.0.1 swapped in; restarting the editor\n",
+                f"{smoke.IN_EDITOR_COMPLETED_LOG}1234\n" if same_editor else "",
+                smoke.SMOKE_MIGRATED_LOG + "\n" if same_editor else "",
             ]
         )
 
         @staticmethod
         def wait() -> int:
             return 0
+
+        @staticmethod
+        def poll() -> int | None:
+            return None if same_editor else 0
 
     def fake_popen(command: list[str], **kwargs: Any) -> FakeGodot:
         captured["command"] = command
@@ -756,6 +772,44 @@ def test_smoke_restart_requested_needs_the_swap_line() -> None:
     assert smoke.vnext_exit_tree_during_update(before_swap + [smoke.SMOKE_TRIGGER_LOG])
 
 
+@pytest.mark.parametrize("reported_pid", [123, 124])
+def test_in_editor_wait_requires_original_process(
+    monkeypatch: pytest.MonkeyPatch, reported_pid: int
+) -> None:
+    smoke = load_smoke_script()
+    lines = [
+        smoke.SMOKE_STAGED_LOG,
+        f"{smoke.IN_EDITOR_COMPLETED_LOG}{reported_pid}",
+        smoke.SMOKE_MIGRATED_LOG,
+    ]
+
+    class Editor:
+        pid = 123
+
+        @staticmethod
+        def poll() -> None:
+            return None
+
+    ticks = iter([0.0, 121.0])
+    monkeypatch.setattr(smoke.time, "monotonic", lambda: next(ticks))
+    assert smoke.wait_for_in_editor_activation(Editor(), lines) is (reported_pid == 123)
+
+
+def test_in_editor_wait_bounds_a_failure_before_swap(monkeypatch: pytest.MonkeyPatch) -> None:
+    smoke = load_smoke_script()
+
+    class Editor:
+        pid = 123
+
+        @staticmethod
+        def poll() -> None:
+            return None
+
+    ticks = iter([0.0, 121.0])
+    monkeypatch.setattr(smoke.time, "monotonic", lambda: next(ticks))
+    assert not smoke.wait_for_in_editor_activation(Editor(), [smoke.V3_BRIDGE_HANDOFF_LOG])
+
+
 def test_status_reports_live_version_requires_name_and_pin() -> None:
     smoke = load_smoke_script()
     assert not smoke.status_reports_live_version(None, "3.2.4")
@@ -914,10 +968,18 @@ def test_verify_post_run_requires_live_status(
     assert "post-update /godot-ai/status was not live" in captured
 
 
-def test_verify_post_run_accepts_live_status(
+@pytest.mark.parametrize("diagnostic", [
+    None,
+    "SCRIPT ERROR: Compile Error: Failed to compile depended scripts.",
+    'ERROR: Failed to load script "res://addons/godot_ai/plugin.gd".',
+    "ERROR: Attempt to open script 'res://addons/godot_ai/migration_bridge.gd' "
+    "resulted in error 'File not found'.",
+])
+def test_verify_post_run_accepts_live_status_only_without_script_errors(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
+    diagnostic: str | None,
 ) -> None:
     smoke = load_smoke_script()
     project = _minimal_smoke_project(tmp_path, "4.0.1")
@@ -934,6 +996,8 @@ def test_verify_post_run_accepts_live_status(
         "MCP | client migration completed",
         "MCP | plugin loaded",
     ]
+    if diagnostic is not None:
+        lines.insert(-1, diagnostic)
     ok = smoke.verify_post_run(
         project,
         "4.0.1",
@@ -944,7 +1008,9 @@ def test_verify_post_run_accepts_live_status(
         next_server_version="4.0.0",
     )
     captured = capsys.readouterr().out
-    assert ok is True
+    assert ok is (diagnostic is None)
+    if diagnostic is not None:
+        assert f"FAIL: editor script diagnostic: {diagnostic}" in captured
     assert "PASS: post-update /godot-ai/status live v4.0.0" in captured
 
 


### PR DESCRIPTION
Updating Godot AI activates the verified replacement inside the running editor and preserves open scenes, unsaved changes, selection, and undo history. A source-free runner serves both the v4 updater and the v3 migration capsule, waits for filesystem scans, retains scripts needed by existing undo callbacks, and loads a fresh canonical script graph. Signature verification, exact-tree checks, locking, and authenticated connections remain in place.

The update crash is now reproduced and fixed. Godot can leave its shared native ProgressDialog under the Update confirmation after an import. Plugin teardown destroyed that borrowed child; the next class-registration scan crashed. Teardown now returns the same native dialog to the editor root before removing the dock. Failure-dialog dismissal applies the same ownership rule. A real-editor regression verifies destruction of the old confirmation, survival of the native dialog, and registration of two new script classes.

Published 3.2.5 uses the new capsule without an editor restart. Published 4.0.4 still restarts once through its shipped updater; subsequent updates use the in-editor path. Compatibility files retain published script paths. Unsafe user-resource references refuse activation with a reason, and ambiguous failures retain repair evidence.

The follow-up also distinguishes unavailable Windows process evidence from an exited process, exposes port selection for unrecoverable incompatible servers, reuses the Windows reservation query while retaining bind checks, and skips linked child directories during backup scans. Test fixtures now enforce complete status-response framing, start the attached-client timeout at the actual gate, and restore endpoint settings.

Validation of the final source:

- Full Windows Python suite: **2,644 passed, 58 skipped**; one dependency deprecation warning. Ruff passed its full CI scope.
- Full rendered Godot suite after reload stress: **2,330 passed, 0 failed, 33 skipped**, across 74 suites. All three native-dialog regressions passed.
- Reload stress: **10/10 isolated reloads**; a fresh rendered concurrent run made **1,185 calls with 0 unexpected errors and 2/2 reloads**, with 14 tolerated reload transients.
- The natural import-under-confirmation reproduction crashed before the fix. With the fix, the same native object moved to the editor root before confirmation destruction, and the update completed in the same PID. Removing only the rescue call from a copied regression fixture failed with `plugin disable destroyed native shared progress`.
- Local signed fixtures passed 3.2.5 to the fixed version, then another update in the same editor; 4.0.4 passed with its expected first restart. Authenticated reads and writes passed after activation. Disposable editors exited normally, and generated caches were removed.

Earlier native checks covered attached-client and undo continuity. This latest run does not requalify every earlier release contract. The earlier editor-exit and undo findings remain tracked in #1044 and #1045; the captured progress-dialog crash establishes this mechanism without claiming every historical exit shares it. Configure all remains tracked separately in #1047.

Local fixtures use test signing keys and version substitutions. Cross-platform qualification of the exact signed 4.1.0 artifacts remains required before publication. [Fresh CI passed all 22 jobs](https://github.com/hi-godot/godot-ai/actions/runs/34625416480) on the final progress-dialog fix. All six existing review threads are resolved; CodeRabbit skipped a fresh review because reviews are disabled for this stacked base branch.

The remaining poll-loop review suggestion was checked against Godot's native HTTP client: normal body completion occurs in `read_response_body_chunk()`, after the guard, while `poll()` retains BODY or reports an error. The guard remains, with passing length/chunked/interruption regressions. See [the pinned engine source](https://github.com/godotengine/godot/blob/4.7.2-stable/core/io/http_client_tcp.cpp#L403-L418).

Stacked on #1042, which is stacked on #1039. Merge in that order.
