### PR TITLE
chore(release): prepare 4.1.0 and complete artifact validation

### DIFF
--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -1,0 +1,195 @@
+name: Validate release migration and public installs
+run-name: Release validation / ${{ inputs.mode }} / qualification ${{ inputs.qualification_run_id }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        type: choice
+        options: [predecessor, public]
+        required: true
+      qualification_run_id:
+        description: Successful exact-candidate qualification run
+        type: string
+        required: true
+      previous_version:
+        description: Published predecessor for the migration lane
+        type: string
+        default: "4.0.4"
+      publication_run_id:
+        description: Successful promotion run (public mode only)
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+env:
+  GODOT_AI_DISABLE_TELEMETRY: "true"
+  QUALIFICATION_RUN_ID: ${{ inputs.qualification_run_id }}
+  PREVIOUS_VERSION: ${{ inputs.previous_version }}
+  PUBLICATION_RUN_ID: ${{ inputs.publication_run_id }}
+  VALIDATION_MODE: ${{ inputs.mode }}
+
+jobs:
+  validate:
+    name: ${{ inputs.mode }} / ${{ matrix.os }} / Python ${{ matrix.python }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python: ["3.11", "3.14"]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Verify qualification provenance before downloading
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = refs/heads/main
+          python - <<'PY'
+          import os
+          from pathlib import Path
+          from script.release_promotion import check_run_provenance
+          from script.release_support import canonical
+          Path("qualification-run.json").write_bytes(canonical(check_run_provenance(os.environ["QUALIFICATION_RUN_ID"])))
+          PY
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.qualification_run_id }}
+          repository: hi-godot/godot-ai
+          name: v4-candidate-a
+          path: candidate
+      - name: Bind downloaded candidate to the checked run and attempt
+        shell: bash
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          from script import release_support as support
+          record = support.verify_candidate(Path("candidate"), "a")
+          support.validate_run(support.read_json(Path("qualification-run.json")), record["workflow_sha"], record["run_id"], record["run_attempt"])
+          PY
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        if: inputs.mode == 'predecessor'
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.qualification_run_id }}
+          repository: hi-godot/godot-ai
+          name: v4-row-python-${{ matrix.os }}-${{ matrix.python }}
+          path: python-row
+      - uses: chickensoft-games/setup-godot@f166999204a4f2722c6fe042fbaa3b3ea0d9c789 # v2
+        if: inputs.mode == 'predecessor'
+        with:
+          version: "4.7.0"
+          use-dotnet: false
+      - name: Verify published predecessor updates to exact candidate A
+        if: inputs.mode == 'predecessor'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ROW_OS: ${{ matrix.os }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install uv==0.11.7
+          python -m script.release_predecessor --candidate candidate --python-row python-row --previous-version "$PREVIOUS_VERSION" --godot "$GODOT" --godot-version 4.7.0 --output row --os "$ROW_OS"
+      - name: Verify public bytes and resolve fresh public installs
+        if: inputs.mode == 'public'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ROW_OS: ${{ matrix.os }}
+        shell: bash
+        run: python -m script.release_public_verify --candidate candidate --output row --os "$ROW_OS"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        if: always()
+        with:
+          name: validation-${{ inputs.mode }}-${{ matrix.os }}-${{ matrix.python }}
+          path: row/
+          if-no-files-found: error
+          retention-days: 90
+
+  complete:
+    name: Require complete supplemental release evidence
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13"
+      - name: Verify qualification provenance before downloading
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python - <<'PY'
+          import os
+          from pathlib import Path
+          from script.release_promotion import check_run_provenance
+          from script.release_support import canonical
+          Path("qualification-run.json").write_bytes(canonical(check_run_provenance(os.environ["QUALIFICATION_RUN_ID"])))
+          PY
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.qualification_run_id }}
+          repository: hi-godot/godot-ai
+          name: v4-candidate-a
+          path: candidate
+      - name: Bind downloaded candidate to the checked run and attempt
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          from script import release_support as support
+          record = support.verify_candidate(Path("candidate"), "a")
+          support.validate_run(support.read_json(Path("qualification-run.json")), record["workflow_sha"], record["run_id"], record["run_attempt"])
+          PY
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          pattern: validation-${{ inputs.mode }}-*
+          path: rows
+      - name: Verify publication provenance before downloading its receipt
+        if: inputs.mode == 'public'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python - <<'PY'
+          import os
+          from pathlib import Path
+          from script.release_validation import check_publication_run
+          check_publication_run(os.environ["PUBLICATION_RUN_ID"], Path("candidate"))
+          PY
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        if: inputs.mode == 'public'
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.publication_run_id }}
+          repository: hi-godot/godot-ai
+          name: v4-publication-receipt
+          path: publication
+      - name: Bind every platform row to candidate A
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir attestation
+          args=()
+          if [ "$VALIDATION_MODE" = public ]; then
+            args+=(--publication publication/publication.json)
+          fi
+          python -m script.release_validation --candidate candidate --rows rows --output attestation/validation.json --kind "$VALIDATION_MODE" "${args[@]}"
+          cp -R rows attestation/rows
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: v4-${{ inputs.mode }}-attestation
+          path: attestation/
+          if-no-files-found: error
+          retention-days: 90

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ this file at the release's exact source commit, and its "What's Changed"
 section lists every merged pull request; this file keeps the part worth
 reading. Release engineering: [docs/releasing.md](docs/releasing.md).
 
+## 4.1.0 (2026-09-11)
+
+Plugin updates now activate inside the running editor, preserving open scenes,
+unsaved changes, selection, and undo history. Updating from published 4.0.4
+still restarts the editor once through its existing updater; later updates use
+the new in-editor path. Published 3.2.5 can migrate through the new update
+capsule without restarting the editor. Older AI clients may still need one
+relaunch after migration.
+[Compare v4.0.4...v4.1.0](https://github.com/hi-godot/godot-ai/compare/v4.0.4...v4.1.0).
+
+### Fixed
+
+- Fixed a native editor crash when an import runs while the Update confirmation
+  is open. Godot's shared progress dialog survives plugin replacement and can
+  be reused by the next filesystem scan.
+- Updates wait for filesystem scans before replacing and enabling scripts,
+  retain scripts needed by existing undo callbacks, and explain why an unsafe
+  activation was refused.
+- Startup and update recovery stay in a pending state until the server is
+  ready. Genuine failures retain their error state and diagnostics.
+- Windows process-inspection failures no longer masquerade as an exited
+  process. Server ownership checks retain the evidence needed for recovery.
+- Migration chooses an independent HTTP/WebSocket port pair. The dock's port
+  picker updates the effective pair, including migrated settings, and also
+  supports incompatible servers that cannot be reclaimed.
+- Backup scans skip linked child directories, and Linux startup explains when
+  required listener tools are missing.
+
+### Known issue
+
+- **Configure all** can report a client-configuration lock error when requests
+  overlap. Configure clients individually, waiting for each operation to finish,
+  and retry an affected client after the active operation completes. Tracked in
+  [#1047](https://github.com/hi-godot/godot-ai/issues/1047).
+
 ## 4.0.4 (2026-09-09)
 
 Updating with AI clients attached no longer means quitting and relaunching

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -67,7 +67,15 @@ Python-side signature check runs through the OpenSSL command line there; with
 the `cryptography` package present (the dev extra) the same check uses it.
 
 After the qualification run's `Require complete release evidence` job is
-green, dispatch `release.yml`. Select **patch**, **minor**, or **major**, and
+green, run `release-validation.yml` in **predecessor** mode with that
+`qualification_run_id` and the previous published version. Its six OS/Python
+rows install the published predecessor and update to the exact signed A bytes,
+with the same attached bridge across the update. This is required for 4.1.0;
+the A-to-B qualification row does not substitute for the public-to-A hop.
+Require `Require complete supplemental release evidence` to pass and retain
+the `v4-predecessor-attestation` artifact before promotion.
+
+Then dispatch `release.yml`. Select **patch**, **minor**, or **major**, and
 provide the previous published version and the qualification run ID. The
 `verify-approval` job checks the run's provenance before downloading anything,
 then rebuilds the expected release record from the downloaded candidates and
@@ -98,8 +106,16 @@ upload, a pre-existing GitHub tag/release must also match the approved source
 and asset inventory. A partial matching draft release can resume; mismatches
 fail without overwriting tags or clobbering assets. The GitHub job verifies
 public PyPI bytes again before publishing and re-downloads all six public
-assets afterward. This receipt does not yet replace the required cross-platform
-public dependency re-resolution and immutable post-publication attestation.
+assets afterward.
+
+After successful promotion, run `release-validation.yml` in **public** mode,
+with the same qualification run and the successful `publication_run_id`.
+It re-downloads the public distributions and six assets, checks their approved
+digests, resolves fresh wheel and sdist installs on all three OSes with Python
+3.11 and 3.14, and verifies each resolved public dependency's bytes. The final
+job binds every row to A and the publication receipt. Retain the immutable
+`v4-public-attestation` Actions artifact and its digest; it has a 90-day
+retention window. The release is complete only after that job passes.
 
 The old `bump-and-release.yml` remains retired. Version changes are reviewed
 source changes: prepare A with the chosen next semantic version and B as its

--- a/plugin/addons/godot_ai/plugin.cfg
+++ b/plugin/addons/godot_ai/plugin.cfg
@@ -3,5 +3,5 @@
 name="Godot AI"
 description="MCP server and AI tools for Godot"
 author="Godot AI"
-version="4.0.4"
+version="4.1.0"
 script="plugin.gd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "godot-ai"
-version = "4.0.4"
+version = "4.1.0"
 description = "Production-grade MCP server and AI tools for the Godot engine"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.11,<3.15"

--- a/script/release_predecessor.py
+++ b/script/release_predecessor.py
@@ -1,0 +1,501 @@
+"""Verify an unmodified public predecessor updates into sealed candidate A.
+
+This is separate release evidence, not an A/B qualification row. Only the
+external project and transport driver are generated; neither add-on is patched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import platform
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from script import release_promotion as public
+from script import release_qualification as qualification
+from script import release_support as support
+from script import runtime_qualification as runtime
+
+CASE_ID = "exact-published-predecessor-to-a"
+GITHUB_HOSTS = {
+    "github.com",
+    "release-assets.githubusercontent.com",
+    "objects.githubusercontent.com",
+}
+MANIFEST = "godot-ai-v4-plugin.manifest.json"
+
+
+def download(url: str, path: Path, size: int, digest: str | None, hosts: set[str]) -> dict:
+    support.require(
+        type(size) is int and 0 < size <= support.MAX_FILE_BYTES, "invalid public artifact size"
+    )
+    support.require(digest is None or support.DIGEST.fullmatch(digest), "invalid public digest")
+    actual_size, actual_digest = 0, hashlib.sha256()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with public.open_public_artifact(url, hosts) as response, path.open("xb") as output:
+        public.validate_public_url(response.url, hosts)
+        while chunk := response.read(1024 * 1024):
+            actual_size += len(chunk)
+            support.require(actual_size <= size, "public artifact exceeds declared size")
+            actual_digest.update(chunk)
+            output.write(chunk)
+    actual = {"size": actual_size, "sha256": actual_digest.hexdigest()}
+    support.require(
+        actual_size == size and (digest is None or actual["sha256"] == digest),
+        "public artifact digest or size mismatch",
+    )
+    return {"url": url, **actual}
+
+
+def public_source(version: str) -> str:
+    support.version_tuple(version)
+    base = f"repos/{support.REPOSITORY}/git"
+    obj = public.gh(f"{base}/ref/tags/v{version}")["object"]
+    for _ in range(5):
+        support.require(
+            isinstance(obj, dict) and support.SHA.fullmatch(str(obj.get("sha", ""))),
+            "invalid public tag object",
+        )
+        if obj.get("type") == "commit":
+            return obj["sha"]
+        support.require(obj.get("type") == "tag", "public tag does not identify a commit")
+        obj = public.gh(f"{base}/tags/{obj['sha']}")["object"]
+    raise support.ReleaseError("public tag nesting exceeds bound")
+
+
+def fetch_predecessor(version: str, destination: Path) -> dict:
+    source = public_source(version)
+    release = public.gh(f"repos/{support.REPOSITORY}/releases/tags/v{version}")
+    support.require(
+        release.get("tag_name") == "v" + version
+        and not release.get("draft")
+        and not release.get("prerelease"),
+        "predecessor is not a public stable release",
+    )
+    assets = release.get("assets", [])
+    support.require(
+        len(assets) == 6 and {row["name"] for row in assets} == support.RELEASE_NAMES,
+        "public predecessor asset inventory differs",
+    )
+    files = {}
+    for row in assets:
+        digest = row.get("digest")
+        if digest is not None:
+            support.require(
+                isinstance(digest, str) and digest.startswith("sha256:"),
+                "unsupported public asset digest",
+            )
+            digest = digest.removeprefix("sha256:")
+        files["release/" + row["name"]] = download(
+            row["browser_download_url"],
+            destination / "release" / row["name"],
+            row["size"],
+            digest,
+            GITHUB_HOSTS,
+        )
+    record = {"version": version, "tag": "v" + version, "source": source}
+    support.verify_signed_assets(destination / "release", record)
+    metadata = public.public_json(f"https://pypi.org/pypi/godot-ai/{version}/json")
+    distributions = metadata.get("urls", [])
+    support.require(
+        len(distributions) == 2
+        and {row["filename"] for row in distributions} == support.distribution_names(version),
+        "public distribution inventory differs",
+    )
+    for row in distributions:
+        support.require(not row.get("yanked"), "public predecessor distribution is yanked")
+        path = destination / "dist" / row["filename"]
+        files["dist/" + row["filename"]] = download(
+            row["url"],
+            path,
+            row["size"],
+            row["digests"]["sha256"],
+            {"files.pythonhosted.org"},
+        )
+        support.check_distribution_metadata(path, version)
+    support.require(
+        public_source(version) == source, "public predecessor tag moved during download"
+    )
+    return {**record, "files": files, "spki_sha256": support.verifier().PUBLIC_KEY_SPKI_SHA256}
+
+
+def validate_inputs(
+    candidate: Path, python_row: Path, previous: str, os_label: str
+) -> tuple[dict, list]:
+    support.require(
+        os_label in support.PLATFORMS and os_label == runtime.engine.host_row(),
+        "predecessor row differs from actual host",
+    )
+    python = runtime.current_python_version()
+    support.require(python in support.PYTHONS, "unsupported predecessor Python row")
+    record = support.verify_candidate(candidate, "a")
+    support.require(
+        record["source"] == record["workflow_sha"], "candidate A is not reviewed workflow source"
+    )
+    old, new = support.version_tuple(previous), support.version_tuple(record["version"])
+    support.require(
+        old[0] == new[0] == 4 and old < new, "predecessor must be an earlier v4 release"
+    )
+    row = support.read_json(python_row / "row.json")
+    support.require(
+        row.get("kind") == "python"
+        and row.get("status") == "passed"
+        and row.get("os") == os_label
+        and row.get("python") == python
+        and row.get("candidates", {}).get("a") == support.fingerprint(candidate / "evidence.json"),
+        "retained Python row is not bound to candidate A and this platform",
+    )
+    dependencies = qualification.dependency_inventory(python_row / "packages")
+    support.require(row.get("dependencies") == dependencies, "retained Python dependencies changed")
+    wheel = f"godot_ai-{record['version']}-py3-none-any.whl"
+    support.require(
+        support.fingerprint(python_row / "packages" / wheel) == record["files"]["dist/" + wheel],
+        "retained candidate wheel differs from sealed A",
+    )
+    return record, dependencies
+
+
+def verify_update(
+    project: Path, predecessor: Path, candidate: Path, previous: dict, record: dict
+) -> dict:
+    manifests = [
+        support.read_json(root / "release" / MANIFEST) for root in (predecessor, candidate)
+    ]
+    expected_old, expected_new = [
+        runtime.release_verify.inventory_tree_hash(value) for value in manifests
+    ]
+    state = project / runtime.UPDATE_STATE
+    marker_path = state / "pending.json"
+    marker = support.read_json(marker_path, canonical_required=False)
+    expected_marker = {
+        "status": "success",
+        "clients_migrated": True,
+        "from_version": previous["version"],
+        "to_version": record["version"],
+        "manifest_sha256": support.fingerprint(candidate / "release" / MANIFEST)["sha256"],
+        "expected_tree_sha256": expected_new,
+    }
+    support.require(
+        marker.get("clients_migrated") is True
+        and all(marker.get(key) == value for key, value in expected_marker.items()),
+        "predecessor update marker differs from signed identities",
+    )
+    live = project / "addons/godot_ai"
+    support.require(
+        support.inventory(live) == runtime._manifest_tree(candidate),
+        "live tree is not exact candidate A",
+    )
+    backups = state / "backup"
+    support.require(
+        backups.is_dir()
+        and sorted(path.name for path in backups.iterdir()) == [previous["version"]],
+        "predecessor backup inventory differs",
+    )
+    backup = backups / previous["version"]
+    support.require(
+        runtime.release_verify.hash_tree(backup)["tree_sha256"] == expected_old,
+        "retained backup differs from signed public predecessor",
+    )
+    support.require(
+        str(marker.get("backup_root", ""))
+        .replace("\\", "/")
+        .rstrip("/")
+        .endswith("backup/" + previous["version"]),
+        "update marker names another backup",
+    )
+    for name in ("lock.json", "stage", "quarantine"):
+        support.require(not (state / name).exists(), "predecessor update retained " + name)
+    return {
+        "update_marker": support.fingerprint(marker_path),
+        "update_state": expected_marker,
+        "live_tree": support.inventory(live),
+        "live_tree_sha256": expected_new,
+        "backup_tree_sha256": expected_old,
+        "backup_tree": support.inventory(backup),
+    }
+
+
+def isolated_environment(root: Path, index: str) -> dict[str, str]:
+    environment = runtime._isolated_environment(root, index)
+    for name in ("GH_TOKEN", "GITHUB_TOKEN"):
+        environment.pop(name, None)
+    app_data = root / "app-data"
+    app_data.mkdir()
+    environment["APPDATA"] = str(app_data)
+    return environment
+
+
+def run_update(
+    candidate: Path,
+    python_row: Path,
+    dependencies: list,
+    predecessor: Path,
+    previous: dict,
+    record: dict,
+    godot: str,
+    godot_version: str,
+    output: Path,
+) -> dict:
+    executable = shutil.which(godot) if not Path(godot).is_absolute() else godot
+    support.require(
+        executable is not None and Path(executable).is_file(), "Godot executable missing"
+    )
+    engine = runtime.engine.verify_executable(Path(executable), godot_version)
+    executable = engine["path"]
+    actual_version = runtime._validate_godot_version(str(executable), godot_version)
+    support.require(
+        runtime._free_port(runtime.HTTP_PORT) and runtime._free_port(runtime.WS_PORT),
+        "predecessor qualification ports are busy",
+    )
+    with tempfile.TemporaryDirectory(
+        prefix="godot-ai-predecessor-", ignore_cleanup_errors=True
+    ) as temporary:
+        work = Path(temporary).resolve()
+        packages, project = work / "packages", work / "project"
+        packages.mkdir()
+        project.mkdir()
+        for row in dependencies:
+            if row["name"] != "godot-ai" or row["version"] == record["version"]:
+                shutil.copyfile(
+                    python_row / "packages" / row["filename"], packages / row["filename"]
+                )
+        old_wheel = f"godot_ai-{previous['version']}-py3-none-any.whl"
+        shutil.copyfile(predecessor / "dist" / old_wheel, packages / old_wheel)
+        index_inventory = qualification.dependency_inventory(packages)
+        certificate, key = runtime._tls_material(work / "tls")
+        with runtime.retained_index(packages, index_inventory) as (index, requests):
+            environment = isolated_environment(work / "environment", index)
+            uvx = shutil.which("uvx", path=environment.get("PATH"))
+            support.require(uvx is not None, "uvx is required for predecessor qualification")
+            runtime._write_client_pin(Path(environment["CODEX_HOME"]), uvx, previous["version"])
+            (project / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+            command = [sys.executable, str(support.ROOT / "script/v4-release"), "install"]
+            for flag, filename in (
+                ("archive", "godot-ai-v4-plugin.zip"),
+                ("manifest", MANIFEST),
+                ("signature", "godot-ai-v4-plugin.manifest.sig"),
+            ):
+                command += ["--" + flag, str(predecessor / "release" / filename)]
+            for flag, value in (
+                ("repository", support.REPOSITORY),
+                ("channel", "stable"),
+                ("tag", previous["tag"]),
+                ("version", previous["version"]),
+                ("source", previous["source"]),
+            ):
+                command += ["--expected-" + flag, value]
+            command += ["--project-root", str(project)]
+            runtime._execute_sensitive(
+                command,
+                output / "install-predecessor.log",
+                cwd=work,
+                environment=environment,
+                secrets=(index,),
+            )
+            support.require(
+                support.inventory(project / "addons/godot_ai")
+                == runtime._manifest_tree(predecessor),
+                "installed predecessor tree differs from signed public bytes",
+            )
+            runtime._write_project(project, certificate, previous["version"], record["version"])
+            with runtime.private_release_origin(
+                candidate / "release",
+                support.inventory(candidate / "release"),
+                version=record["version"],
+                certificate=certificate,
+                private_key=key,
+            ) as release:
+                environment.update(release.environment())
+                environment.update(
+                    PRIVATE_HTTPS_PORT=str(release.proxy_port),
+                    PRIVATE_HTTPS_CERTIFICATE=str(certificate),
+                )
+                bridge_log = work / "attached-bridge.log"
+                bridge = runtime.AttachedBridge(
+                    runtime._bridge_command(uvx, previous["version"]),
+                    environment,
+                    project,
+                    runtime._capability_directory(environment),
+                    previous["version"],
+                    record["version"],
+                    bridge_log,
+                )
+                with bridge:
+                    completed = subprocess.run(
+                        runtime._editor_command(executable, project),
+                        cwd=work,
+                        env=environment,
+                        capture_output=True,
+                        timeout=runtime.TIMEOUT_SECONDS,
+                        check=False,
+                    )
+                    runtime._write_secret_free_log(
+                        output / "godot.log",
+                        completed.stdout + completed.stderr,
+                        (release.token, index),
+                    )
+                    support.require(completed.returncode == 0, "public predecessor update failed")
+                    runtime._wait_for_runtime_result(
+                        project / "runtime-result.json", runtime.TIMEOUT_SECONDS
+                    )
+                runtime._write_secret_free_log(
+                    output / "attached-bridge.log",
+                    bridge_log.read_bytes() if bridge_log.exists() else b"",
+                    (release.token, index),
+                )
+                support.require(
+                    not bridge.fault and bridge.ok_before_update >= 1 and bridge.served_b,
+                    "same attached predecessor bridge did not serve both versions",
+                )
+                support.require(
+                    release.downloads
+                    == ["godot-ai-v4-plugin.zip", MANIFEST, "godot-ai-v4-plugin.manifest.sig"],
+                    "update did not download exact canonical triple",
+                )
+            runtime._wait_for_ports_free(
+                runtime.HTTP_PORT, runtime.WS_PORT, timeout=runtime.EDITOR_EXIT_TIMEOUT_SECONDS
+            )
+            capability_dir = runtime._capability_directory(environment)
+            runtime._wait_for_capability_release(capability_dir)
+            runtime._scrub_private_material(key, capability_dir)
+        result = runtime._read_runtime_result(project)
+        support.require(
+            result.get("status") == "passed" and result.get("attached_bridge_served_b") is True,
+            "predecessor driver did not report a passed attached-bridge update",
+        )
+        support.require(
+            result.get("from_version") == previous["version"]
+            and result.get("to_version") == record["version"],
+            "driver reported different versions",
+        )
+        config = (Path(environment["CODEX_HOME"]) / "config.toml").read_text(encoding="utf-8")
+        support.require(
+            f"godot-ai=={record['version']}" in config and index not in config,
+            "updated client pin does not name candidate A cleanly",
+        )
+        evidence = verify_update(project, predecessor, candidate, previous, record)
+        private_values = (
+            release.token,
+            index,
+            runtime._private_index_capability(index),
+            runtime.ORIGIN,
+        )
+        support.require(
+            not any(secret in json.dumps(result) for secret in private_values),
+            "private qualification value leaked into runtime result",
+        )
+        runtime._require_values_absent(project, private_values)
+        runtime._require_values_absent(output, private_values)
+        support.require(
+            support.verify_candidate(candidate, "a") == record,
+            "candidate A changed during predecessor validation",
+        )
+        return {
+            "id": CASE_ID,
+            "status": "passed",
+            "from_version": previous["version"],
+            "to_version": record["version"],
+            "runtime_result": result,
+            "godot": {**engine, "version": actual_version},
+            "attached_bridge": bridge.report(),
+            "backend_stopped": True,
+            "index_artifacts_requested": sorted(set(requests)),
+            "index_inventory": index_inventory,
+            **evidence,
+        }
+
+
+def predecessor_row(
+    candidate: Path,
+    python_row: Path,
+    previous_version: str,
+    godot: str,
+    godot_version: str,
+    output: Path,
+    os_label: str,
+) -> None:
+    record, dependencies = validate_inputs(candidate, python_row, previous_version, os_label)
+    support.require(
+        godot_version in qualification.RUNTIME_GODOT_VERSIONS, "unsupported predecessor Godot row"
+    )
+    support.require(not output.exists(), "predecessor output already exists")
+    output.mkdir(parents=True)
+    report: dict[str, Any] = {
+        "schema": 1,
+        "kind": "predecessor",
+        "status": "failed",
+        "required_skips": 0,
+        "os": os_label,
+        "python": runtime.current_python_version(),
+        "godot_version": godot_version,
+        "platform": platform.platform(),
+        "previous_version": previous_version,
+        "candidate": support.fingerprint(candidate / "evidence.json"),
+        "source": record["source"],
+        "version": record["version"],
+        "run_id": record["run_id"],
+        "run_attempt": record["run_attempt"],
+        "python_row": support.fingerprint(python_row / "row.json"),
+        "cases": [],
+    }
+    try:
+        with tempfile.TemporaryDirectory(prefix="godot-ai-public-predecessor-") as temporary:
+            predecessor = Path(temporary)
+            previous = fetch_predecessor(previous_version, predecessor)
+            report["predecessor"] = previous
+            case = run_update(
+                candidate,
+                python_row,
+                dependencies,
+                predecessor,
+                previous,
+                record,
+                godot,
+                godot_version,
+                output,
+            )
+            support.require(
+                case.get("id") == CASE_ID and case.get("status") == "passed",
+                "predecessor runtime did not provide the required passed case",
+            )
+            report["cases"].append(case)
+        report["status"] = "passed"
+    finally:
+        report["files"] = support.inventory(output)
+        (output / "row.json").write_bytes(support.canonical(report))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidate", type=Path, required=True)
+    parser.add_argument("--python-row", type=Path, required=True)
+    parser.add_argument("--previous-version", required=True)
+    parser.add_argument("--godot", required=True)
+    parser.add_argument("--godot-version", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--os", choices=support.PLATFORMS, required=True)
+    args = parser.parse_args(argv)
+    try:
+        predecessor_row(
+            args.candidate.resolve(),
+            args.python_row.resolve(),
+            args.previous_version,
+            args.godot,
+            args.godot_version,
+            args.output.resolve(),
+            args.os,
+        )
+    except (support.ReleaseError, OSError, ValueError, subprocess.SubprocessError) as error:
+        print(f"predecessor validation refused: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/script/release_public_verify.py
+++ b/script/release_public_verify.py
@@ -1,0 +1,231 @@
+"""Verify public release bytes and fresh dependency installs without publishing."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tarfile
+import tempfile
+import tomllib
+import urllib.parse
+import venv
+from pathlib import Path
+from typing import Any
+
+from script import release_promotion as promotion
+from script import release_qualification as qualification
+from script import release_support as support
+
+
+def verify_resolution(
+    report: dict[str, Any], record: dict[str, Any], *, require_release: bool = True
+) -> list[dict[str, Any]]:
+    installed = report.get("install", [])
+    support.require(bool(installed), "empty public dependency resolution")
+    result = []
+    found_release = False
+    for item in installed:
+        name, version = item["metadata"]["name"], item["metadata"]["version"]
+        download = item["download_info"]
+        url = download["url"]
+        promotion.validate_public_url(url, {"files.pythonhosted.org"})
+        metadata = promotion.public_json(
+            "https://pypi.org/pypi/"
+            + urllib.parse.quote(name, safe="")
+            + "/"
+            + urllib.parse.quote(version, safe="")
+            + "/json"
+        )
+        matches = [entry for entry in metadata["urls"] if entry["url"] == url]
+        support.require(
+            len(matches) == 1 and not matches[0].get("yanked"),
+            "resolved dependency is absent or yanked on public PyPI",
+        )
+        entry = matches[0]
+        expected = {"sha256": entry["digests"]["sha256"], "size": entry["size"]}
+        support.require(
+            download["archive_info"]["hashes"]["sha256"] == expected["sha256"],
+            "installed dependency digest differs from public PyPI",
+        )
+        if name.lower().replace("_", "-") == "godot-ai":
+            support.require(
+                not found_release and version == record["version"],
+                "installed release version mismatch",
+            )
+            support.require(
+                record["files"].get("dist/" + entry["filename"]) == expected,
+                "installed release differs from qualified bytes",
+            )
+            found_release = True
+        promotion.verify_public_file(url, expected, {"files.pythonhosted.org"})
+        result.append({"name": name, "version": version, "url": url, **expected})
+    support.require(
+        found_release or not require_release, "public resolution did not install godot-ai"
+    )
+    return result
+
+
+def read_resolution(path: Path) -> dict[str, Any]:
+    return support.read_json(path, canonical_required=False)
+
+
+def build_requirements(candidate: Path, version: str) -> list[str]:
+    archive = candidate / "dist" / f"godot_ai-{version}.tar.gz"
+    with tarfile.open(archive) as source:
+        member = source.getmember(f"godot_ai-{version}/pyproject.toml")
+        support.require(
+            member.isfile() and member.size <= support.MAX_JSON_BYTES,
+            "invalid source build metadata",
+        )
+        stream = source.extractfile(member)
+        support.require(stream is not None, "source build metadata missing")
+        requirements = tomllib.loads(stream.read().decode())["build-system"]["requires"]
+    support.require(
+        isinstance(requirements, list)
+        and requirements
+        and all(isinstance(value, str) and not value.startswith("-") for value in requirements),
+        "invalid build requirements",
+    )
+    return requirements
+
+
+def public_row(candidate: Path, output: Path, os_label: str) -> None:
+    from script import qualification_engine as engine
+
+    support.require(os_label == engine.host_row(), "public row differs from actual host")
+    python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+    support.require(python_version in {"3.11", "3.14"}, "unsupported public Python row")
+    support.require(not output.exists(), "public verification output already exists")
+    record = support.verify_candidate(candidate, "a")
+    output.mkdir(parents=True)
+    pypi = promotion.verify_pypi(record)
+    release = promotion.github_preflight(record)
+    support.require(release is not None and not release["draft"], "release is not public")
+    migration = (
+        f"https://github.com/{support.REPOSITORY}/blob/{record['source']}/docs/v4-migration.md"
+    )
+    support.require(migration in release["body"], "canonical migration link is missing")
+    assets = {}
+    for asset in release["assets"]:
+        expected = record["files"]["release/" + asset["name"]]
+        url = asset["browser_download_url"]
+        promotion.verify_public_file(
+            url, expected, {"github.com", "release-assets.githubusercontent.com"}
+        )
+        assets[asset["name"]] = {"url": url, **expected}
+    resolutions = {}
+    with tempfile.TemporaryDirectory(prefix="godot-ai-public-") as temporary:
+        work = Path(temporary)
+        environment = {
+            key: value
+            for key, value in os.environ.items()
+            if not key.startswith(("PIP_", "UV_", "PYTHON"))
+            and key not in {"GH_TOKEN", "GITHUB_TOKEN"}
+        }
+        environment["GODOT_AI_DISABLE_TELEMETRY"] = "true"
+        for kind in ("wheel", "sdist"):
+            target = work / kind
+            venv.EnvBuilder(with_pip=True).create(target)
+            python = str(qualification.environment_python(target))
+            if kind == "sdist":
+                build_report = output / "build-resolution.json"
+                qualification.execute(
+                    [
+                        python,
+                        "-I",
+                        "-m",
+                        "pip",
+                        "--isolated",
+                        "install",
+                        "--no-cache-dir",
+                        "--force-reinstall",
+                        "--index-url",
+                        "https://pypi.org/simple",
+                        "--report",
+                        str(build_report),
+                        *build_requirements(candidate, record["version"]),
+                    ],
+                    output / "build.log",
+                    cwd=work,
+                    environment=environment,
+                )
+                resolutions["build"] = verify_resolution(
+                    read_resolution(build_report),
+                    record,
+                    require_release=False,
+                )
+            report = output / f"{kind}-resolution.json"
+            command = [
+                python,
+                "-I",
+                "-m",
+                "pip",
+                "--isolated",
+                "install",
+                "--no-cache-dir",
+                "--index-url",
+                "https://pypi.org/simple",
+                "--report",
+                str(report),
+            ]
+            command += ["--only-binary" if kind == "wheel" else "--no-binary", "godot-ai"]
+            if kind == "sdist":
+                command.append("--no-build-isolation")
+            command.append("godot-ai==" + record["version"])
+            qualification.execute(
+                command, output / f"{kind}.log", cwd=work, environment=environment
+            )
+            resolutions[kind] = verify_resolution(read_resolution(report), record)
+            for args in (
+                ["-m", "pip", "check"],
+                ["-m", "godot_ai", "--version"],
+                [
+                    "-c",
+                    "import importlib.metadata as m; import godot_ai; from pathlib import Path; "
+                    f"assert m.version('godot-ai') == {record['version']!r}; "
+                    f"assert Path(godot_ai.__file__).resolve().is_relative_to({str(target)!r})",
+                ],
+            ):
+                qualification.execute(
+                    [python, "-I", *args], output / f"{kind}.log", cwd=work, environment=environment
+                )
+    result = {
+        "schema": 1,
+        "kind": "public",
+        "status": "passed",
+        "os": os_label,
+        "python": python_version,
+        "candidate": support.fingerprint(candidate / "evidence.json"),
+        "version": record["version"],
+        "source": record["source"],
+        "pypi": pypi,
+        "github": assets,
+        "resolutions": resolutions,
+    }
+    (output / "row.json").write_bytes(support.canonical(result))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidate", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--os", required=True, choices=support.PLATFORMS)
+    args = parser.parse_args(argv)
+    try:
+        public_row(args.candidate.resolve(), args.output.resolve(), args.os)
+    except (
+        support.ReleaseError,
+        OSError,
+        ValueError,
+        KeyError,
+        subprocess.CalledProcessError,
+    ) as exc:
+        print(f"public verification failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/script/release_validation.py
+++ b/script/release_validation.py
@@ -1,0 +1,286 @@
+"""Bind supplemental release validation rows to one qualified candidate."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from script import release_support as support
+
+
+def file_metadata(value: dict) -> dict:
+    support.require(
+        isinstance(value, dict)
+        and type(value.get("size")) is int
+        and 0 < value["size"] <= support.MAX_FILE_BYTES
+        and isinstance(value.get("sha256"), str)
+        and support.DIGEST.fullmatch(value["sha256"]),
+        "invalid validation file metadata",
+    )
+    return {key: value[key] for key in ("size", "sha256")}
+
+
+def public_files(files: dict, expected: dict, hosts: set[str]) -> None:
+    from script import release_promotion as promotion
+
+    support.require(
+        isinstance(files, dict) and files.keys() == expected.keys(), "public inventory mismatch"
+    )
+    for name, metadata in files.items():
+        support.require(
+            file_metadata(metadata) == expected[name], "public file differs from candidate"
+        )
+        promotion.validate_public_url(metadata.get("url", ""), hosts)
+
+
+def public_evidence(row: dict, record: dict) -> None:
+    from script import release_promotion as promotion
+
+    for key, prefix, hosts in (
+        ("pypi", "dist/", {"files.pythonhosted.org"}),
+        ("github", "release/", {"github.com", "release-assets.githubusercontent.com"}),
+    ):
+        expected = {
+            name.removeprefix(prefix): value
+            for name, value in record["files"].items()
+            if name.startswith(prefix)
+        }
+        public_files(row.get(key), expected, hosts)
+    resolutions = row.get("resolutions")
+    support.require(
+        isinstance(resolutions, dict) and resolutions.keys() == {"wheel", "sdist", "build"},
+        "public resolutions are incomplete",
+    )
+    for kind, entries in resolutions.items():
+        support.require(isinstance(entries, list) and entries, "empty public resolution")
+        names = set()
+        releases = []
+        for entry in entries:
+            file_metadata(entry)
+            name, version = entry.get("name"), entry.get("version")
+            support.require(
+                isinstance(name, str) and name and isinstance(version, str) and version,
+                "invalid resolved package",
+            )
+            normalized = name.lower().replace("_", "-").replace(".", "-")
+            support.require(normalized not in names, "duplicate resolved package")
+            names.add(normalized)
+            promotion.validate_public_url(entry.get("url", ""), {"files.pythonhosted.org"})
+            if normalized == "godot-ai":
+                releases.append(entry)
+        if kind != "build":
+            filename = f"godot_ai-{record['version']}" + (
+                "-py3-none-any.whl" if kind == "wheel" else ".tar.gz"
+            )
+            support.require(
+                len(releases) == 1
+                and releases[0]["version"] == record["version"]
+                and file_metadata(releases[0]) == record["files"]["dist/" + filename],
+                "resolved release differs from candidate format",
+            )
+
+
+def predecessor_evidence(row: dict, path: Path, candidate: Path, record: dict) -> dict:
+    from script import qualification_engine as engine
+    from script import release_predecessor as predecessor
+
+    inventory = support.inventory(path.parent)
+    inventory.pop("row.json")
+    support.require(row.get("files") == inventory, "predecessor retained files changed")
+    previous = row.get("predecessor", {})
+    version = previous.get("version", "")
+    support.require(
+        row.get("previous_version") == version
+        and previous.get("tag") == "v" + version
+        and support.SHA.fullmatch(str(previous.get("source", ""))),
+        "invalid predecessor identity",
+    )
+    old, new = support.version_tuple(version), support.version_tuple(record["version"])
+    support.require(
+        old[0] == new[0] == 4
+        and old < new
+        and previous.get("spki_sha256") == record["spki_sha256"],
+        "invalid predecessor release",
+    )
+    expected_names = {"release/" + name for name in support.RELEASE_NAMES} | {
+        "dist/" + name for name in support.distribution_names(version)
+    }
+    files = previous.get("files", {})
+    support.require(files.keys() == expected_names, "incomplete predecessor public inventory")
+    for name, metadata in files.items():
+        public_files(
+            {name: metadata},
+            {name: file_metadata(metadata)},
+            {"files.pythonhosted.org"} if name.startswith("dist/") else predecessor.GITHUB_HOSTS,
+        )
+    support.require(
+        row.get("required_skips") == 0
+        and row.get("run_id") == record["run_id"]
+        and row.get("run_attempt") == record["run_attempt"],
+        "predecessor qualification binding mismatch",
+    )
+    cases = row.get("cases", [])
+    support.require(len(cases) == 1, "missing predecessor native case")
+    case = cases[0]
+    support.require(row.get("godot_version") == "4.7.0", "unexpected predecessor Godot row")
+    engine.validate_identity(case.get("godot"), row["godot_version"], row["os"])
+    support.require(
+        case.get("id") == predecessor.CASE_ID
+        and case.get("status") == "passed"
+        and case.get("backend_stopped") is True
+        and case.get("from_version") == version
+        and case.get("to_version") == record["version"],
+        "predecessor native case did not pass",
+    )
+    result, bridge = case.get("runtime_result", {}), case.get("attached_bridge", {})
+    support.require(
+        result.get("status") == "passed"
+        and result.get("attached_bridge_served_b") is True
+        and result.get("from_version") == version
+        and result.get("to_version") == record["version"]
+        and bridge.get("pin") == version
+        and type(bridge.get("ok_before_update")) is int
+        and bridge["ok_before_update"] >= 1
+        and bridge.get("served_b") is True
+        and not bridge.get("fault"),
+        "predecessor attached bridge evidence missing",
+    )
+    manifest = support.read_json(candidate / "release" / predecessor.MANIFEST)
+    tree = {
+        item["path"].removeprefix("addons/godot_ai/"): {
+            key: item[key] for key in ("size", "sha256")
+        }
+        for item in manifest["inventory"]
+    }
+    tree_hash = support.verifier().inventory_tree_hash(manifest)
+    support.require(
+        case.get("live_tree") == tree and case.get("live_tree_sha256") == tree_hash,
+        "predecessor live tree differs from candidate",
+    )
+    expected_state = {
+        "status": "success",
+        "clients_migrated": True,
+        "from_version": version,
+        "to_version": record["version"],
+        "manifest_sha256": support.fingerprint(candidate / "release" / predecessor.MANIFEST)[
+            "sha256"
+        ],
+        "expected_tree_sha256": tree_hash,
+    }
+    support.require(
+        case.get("update_state") == expected_state,
+        "predecessor update state differs from candidate",
+    )
+    file_metadata(case.get("update_marker"))
+    backup = case.get("backup_tree")
+    support.require(isinstance(backup, dict) and backup, "missing predecessor backup")
+    backup_manifest = {
+        "inventory": [
+            {"path": "addons/godot_ai/" + name, **file_metadata(value)}
+            for name, value in backup.items()
+        ]
+    }
+    support.require(
+        case.get("backup_tree_sha256") == support.verifier().inventory_tree_hash(backup_manifest),
+        "predecessor backup evidence differs",
+    )
+    return previous
+
+
+def check_publication_run(run_id: str, candidate: Path) -> dict:
+    from script import release_promotion as promotion
+
+    support.require(run_id.isdecimal(), "invalid publication run ID")
+    record = support.verify_candidate(candidate, "a")
+    run = promotion.gh(f"repos/{support.REPOSITORY}/actions/runs/{run_id}")
+    support.require(
+        run.get("id") == int(run_id)
+        and run.get("repository", {}).get("full_name") == support.REPOSITORY
+        and run.get("path") == ".github/workflows/release.yml"
+        and run.get("event") == "workflow_dispatch"
+        and run.get("head_branch") == "main"
+        and run.get("head_sha") == record["source"]
+        and run.get("conclusion") == "success",
+        "publication run provenance mismatch",
+    )
+    return run
+
+
+def complete(
+    candidate: Path, rows: Path, output: Path, kind: str, publication: Path | None = None
+) -> None:
+    support.require(kind in {"predecessor", "public"}, "unknown validation kind")
+    record = support.verify_candidate(candidate, "a")
+    binding = support.fingerprint(candidate / "evidence.json")
+    required = {(os_label, python) for os_label in support.PLATFORMS for python in ("3.11", "3.14")}
+    found = set()
+    previous = None
+    for path in rows.glob("*/row.json"):
+        row = support.read_json(path)
+        key = (row.get("os"), row.get("python"))
+        support.require(
+            key in required and key not in found, "unexpected or duplicate validation row"
+        )
+        support.require(
+            row.get("schema") == 1 and row.get("status") == "passed" and row.get("kind") == kind,
+            "validation row did not pass",
+        )
+        support.require(
+            row.get("candidate") == binding
+            and row.get("version") == record["version"]
+            and row.get("source") == record["source"],
+            "validation candidate mismatch",
+        )
+        if kind == "predecessor":
+            identity = predecessor_evidence(row, path, candidate, record)
+            support.require(
+                previous is None or previous == identity, "validation predecessors differ"
+            )
+            previous = identity
+        else:
+            public_evidence(row, record)
+        found.add(key)
+    support.require(found == required, "required validation rows are missing")
+    result = {
+        "schema": 1,
+        "kind": kind,
+        "status": "passed",
+        "candidate": binding,
+        "version": record["version"],
+        "source": record["source"],
+        "files": support.inventory(rows),
+    }
+    if kind == "public":
+        support.require(publication is not None, "public attestation requires publication receipt")
+        receipt = support.read_json(publication)
+        for key in (
+            "version",
+            "tag",
+            "source",
+            "workflow_sha",
+            "run_id",
+            "run_attempt",
+            "spki_sha256",
+            "files",
+        ):
+            support.require(
+                support.canonical(receipt.get(key)) == support.canonical(record[key]),
+                "publication receipt differs from qualified candidate",
+            )
+        result["publication"] = {"receipt": receipt, "digest": support.fingerprint(publication)}
+    output.write_bytes(support.canonical(result))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidate", type=Path, required=True)
+    parser.add_argument("--rows", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--kind", choices=("predecessor", "public"), required=True)
+    parser.add_argument("--publication", type=Path)
+    args = parser.parse_args()
+    complete(args.candidate, args.rows, args.output, args.kind, args.publication)
+
+
+if __name__ == "__main__":
+    main()

--- a/test_project/tests/test_update_manager.gd
+++ b/test_project/tests/test_update_manager.gd
@@ -335,6 +335,11 @@ func test_failed_refresh_clears_a_previous_install_candidate() -> void:
 
 func test_release_candidate_does_not_alias_emitted_view_model() -> void:
 	var manager := Manager.new()
+	var next_minor := int(McpClientConfigurator.get_plugin_version().get_slice(".", 1)) + 1
+	var candidate_tag := "v4.%d.0" % next_minor
+	var assets := _valid_assets()
+	for asset in assets:
+		asset.browser_download_url = str(asset.browser_download_url).replace("/v4.1.0/", "/%s/" % candidate_tag)
 	var emissions: Array[Dictionary] = []
 	manager.update_check_completed.connect(func(result: Dictionary) -> void:
 		emissions.append(result)
@@ -343,14 +348,17 @@ func test_release_candidate_does_not_alias_emitted_view_model() -> void:
 		HTTPRequest.RESULT_SUCCESS,
 		200,
 		PackedStringArray(),
-		_response(_valid_assets()),
+		_response(assets, candidate_tag),
 	)
 	assert_true(bool(manager._release.get("has_update", false)))
 	assert_eq(emissions.size(), 1)
+	if not bool(manager._release.get("has_update", false)) or emissions.size() != 1:
+		manager.free()
+		return
 	var emitted := emissions[0]
 	var original_url := str(manager._release.urls[Manager.ASSET_NAME])
 	emitted["tag"] = "mutated"
 	emitted.urls[Manager.ASSET_NAME] = "https://attacker.invalid/payload"
-	assert_eq(str(manager._release.tag), "v4.1.0")
+	assert_eq(str(manager._release.tag), candidate_tag)
 	assert_eq(str(manager._release.urls[Manager.ASSET_NAME]), original_url)
 	manager.free()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,17 +78,50 @@ def allocate_free_ports(count: int) -> list[int]:
     "4001 session id already registered". All sockets stay open until every
     port is allocated so the OS can't hand the same port out twice (a caller
     that needs both an HTTP and a WS port must get two distinct values).
-    The ports are free at allocation time; the caller is expected to bind
-    them promptly.
+    Session claims prevent another worker from selecting a released port
+    while a test deliberately stops and restarts its backend. They do not
+    reserve ports against unrelated processes outside this test suite.
     """
     probes = [socket.socket(socket.AF_INET, socket.SOCK_STREAM) for _ in range(count)]
     try:
-        for probe in probes:
-            probe.bind(("127.0.0.1", 0))
+        claim_root = os.environ.get("GODOT_AI_TEST_PORT_CLAIMS")
+        for index in range(count):
+            for _attempt in range(1000):
+                probe = probes[index]
+                probe.bind(("127.0.0.1", 0))
+                if claim_root is None:
+                    break
+                try:
+                    (Path(claim_root) / str(probe.getsockname()[1])).touch(exist_ok=False)
+                except FileExistsError:
+                    probe.close()
+                    probes[index] = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                else:
+                    break
+            else:
+                raise RuntimeError("Could not allocate an unclaimed test port")
         return [probe.getsockname()[1] for probe in probes]
     finally:
         for probe in probes:
             probe.close()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _claim_test_ports(tmp_path_factory, request):
+    root = tmp_path_factory.getbasetemp()
+    if hasattr(request.config, "workerinput"):
+        root = root.parent
+    claims = root / "port-claims"
+    claims.mkdir(exist_ok=True)
+    previous = os.environ.get("GODOT_AI_TEST_PORT_CLAIMS")
+    os.environ["GODOT_AI_TEST_PORT_CLAIMS"] = str(claims)
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("GODOT_AI_TEST_PORT_CLAIMS", None)
+        else:
+            os.environ["GODOT_AI_TEST_PORT_CLAIMS"] = previous
 
 
 def allocate_free_port() -> int:

--- a/tests/unit/test_release_predecessor.py
+++ b/tests/unit/test_release_predecessor.py
@@ -1,0 +1,347 @@
+import hashlib
+import io
+import json
+
+import pytest
+
+from script import release_predecessor as predecessor
+from script import release_support as support
+
+
+class Response(io.BytesIO):
+    url = "https://files.pythonhosted.org/package.whl"
+
+
+def test_editor_environment_does_not_inherit_github_tokens_or_user_settings(monkeypatch, tmp_path):
+    monkeypatch.setenv("GH_TOKEN", "read-only-fixture-token")
+    monkeypatch.setenv("GITHUB_TOKEN", "another-fixture-token")
+    monkeypatch.setenv("APPDATA", "host-settings")
+    environment = predecessor.isolated_environment(
+        tmp_path / "environment", "http://127.0.0.1/index"
+    )
+    assert "GH_TOKEN" not in environment and "GITHUB_TOKEN" not in environment
+    assert environment["APPDATA"] == str(tmp_path / "environment/app-data")
+    assert environment["UV_INDEX"] == "http://127.0.0.1/index"
+
+
+@pytest.mark.parametrize(
+    "body,size,digest,expected",
+    [
+        (b"good", 4, hashlib.sha256(b"good").hexdigest(), None),
+        (b"bad", 4, hashlib.sha256(b"good").hexdigest(), "digest or size"),
+        (b"evil", 4, hashlib.sha256(b"good").hexdigest(), "digest or size"),
+        (b"excess", 4, None, "exceeds declared size"),
+    ],
+)
+def test_download_checks_actual_bytes(monkeypatch, tmp_path, body, size, digest, expected):
+    monkeypatch.setattr(predecessor.public, "open_public_artifact", lambda *_: Response(body))
+    target = tmp_path / "artifact.whl"
+    if expected:
+        with pytest.raises(support.ReleaseError, match=expected):
+            predecessor.download(Response.url, target, size, digest, {"files.pythonhosted.org"})
+    else:
+        receipt = predecessor.download(
+            Response.url, target, size, digest, {"files.pythonhosted.org"}
+        )
+        assert target.read_bytes() == body
+        assert receipt == {"url": Response.url, "size": size, "sha256": digest}
+
+
+def test_public_tag_is_peeled_and_bounded(monkeypatch):
+    calls = []
+
+    def api(path):
+        calls.append(path)
+        return {"object": {"type": "tag" if len(calls) == 1 else "commit", "sha": "a" * 40}}
+
+    monkeypatch.setattr(predecessor.public, "gh", api)
+    assert predecessor.public_source("4.0.4") == "a" * 40
+    assert calls == [
+        "repos/hi-godot/godot-ai/git/ref/tags/v4.0.4",
+        "repos/hi-godot/godot-ai/git/tags/" + "a" * 40,
+    ]
+    monkeypatch.setattr(
+        predecessor.public, "gh", lambda _: {"object": {"type": "tag", "sha": "a" * 40}}
+    )
+    with pytest.raises(support.ReleaseError, match="nesting exceeds"):
+        predecessor.public_source("4.0.4")
+
+
+def test_public_predecessor_cannot_be_draft_or_missing_assets(monkeypatch, tmp_path):
+    monkeypatch.setattr(predecessor, "public_source", lambda _: "a" * 40)
+    monkeypatch.setattr(predecessor.public, "gh", lambda _: {"tag_name": "v4.0.4", "draft": True})
+    with pytest.raises(support.ReleaseError, match="public stable"):
+        predecessor.fetch_predecessor("4.0.4", tmp_path)
+    monkeypatch.setattr(predecessor.public, "gh", lambda _: {"tag_name": "v4.0.4", "assets": []})
+    with pytest.raises(support.ReleaseError, match="asset inventory"):
+        predecessor.fetch_predecessor("4.0.4", tmp_path)
+
+
+def _public_fixture(monkeypatch, tmp_path):
+    version, source = "4.0.4", "a" * 40
+    monkeypatch.setattr(predecessor, "public_source", lambda _: source)
+    assets = [
+        {"name": name, "size": 4, "browser_download_url": "https://github.com/" + name}
+        for name in sorted(support.RELEASE_NAMES)
+    ]
+    monkeypatch.setattr(
+        predecessor.public,
+        "gh",
+        lambda _: {
+            "tag_name": "v" + version,
+            "draft": False,
+            "prerelease": False,
+            "assets": assets,
+        },
+    )
+    distributions = [
+        {
+            "filename": name,
+            "url": "https://files.pythonhosted.org/" + name,
+            "size": 4,
+            "digests": {"sha256": "b" * 64},
+            "yanked": False,
+        }
+        for name in sorted(support.distribution_names(version))
+    ]
+    monkeypatch.setattr(predecessor.public, "public_json", lambda _: {"urls": distributions})
+    downloaded = []
+
+    def download(url, path, size, digest, hosts):
+        downloaded.append((url, path, digest))
+        return {"url": url, "size": size, "sha256": digest or "c" * 64}
+
+    monkeypatch.setattr(predecessor, "download", download)
+    verified = []
+    monkeypatch.setattr(
+        support, "verify_signed_assets", lambda path, record: verified.append((path, record))
+    )
+    monkeypatch.setattr(
+        support,
+        "check_distribution_metadata",
+        lambda path, version: verified.append((path, version)),
+    )
+    return distributions, downloaded, verified
+
+
+def test_public_receipt_requires_signatures_and_both_distribution_identities(monkeypatch, tmp_path):
+    _, downloads, verified = _public_fixture(monkeypatch, tmp_path)
+    result = predecessor.fetch_predecessor("4.0.4", tmp_path)
+    assert len(downloads) == 8
+    assert verified[0] == (
+        tmp_path / "release",
+        {"version": "4.0.4", "tag": "v4.0.4", "source": "a" * 40},
+    )
+    assert {path.name for path, version in verified[1:]} == support.distribution_names("4.0.4")
+    assert {version for path, version in verified[1:]} == {"4.0.4"}
+    assert len(result["files"]) == 8
+    assert result["source"] == "a" * 40
+
+
+def test_public_predecessor_refuses_moved_tag_and_yanked_distribution(monkeypatch, tmp_path):
+    distributions, _, _ = _public_fixture(monkeypatch, tmp_path)
+    distributions[0]["yanked"] = True
+    with pytest.raises(support.ReleaseError, match="yanked"):
+        predecessor.fetch_predecessor("4.0.4", tmp_path)
+    distributions[0]["yanked"] = False
+    sources = iter(["a" * 40, "d" * 40])
+    monkeypatch.setattr(predecessor, "public_source", lambda _: next(sources))
+    with pytest.raises(support.ReleaseError, match="tag moved"):
+        predecessor.fetch_predecessor("4.0.4", tmp_path)
+
+
+def _input_fixture(monkeypatch, tmp_path):
+    candidate, row_root = tmp_path / "candidate", tmp_path / "python"
+    candidate.mkdir()
+    (row_root / "packages").mkdir(parents=True)
+    (candidate / "evidence.json").write_text("sealed", encoding="utf-8")
+    wheel = row_root / "packages/godot_ai-4.1.0-py3-none-any.whl"
+    wheel.write_bytes(b"candidate-wheel")
+    record = {
+        "version": "4.1.0",
+        "source": "a" * 40,
+        "workflow_sha": "a" * 40,
+        "run_id": "123",
+        "run_attempt": 1,
+        "files": {"dist/" + wheel.name: support.fingerprint(wheel)},
+    }
+    dependencies = [
+        {
+            "filename": wheel.name,
+            "name": "godot-ai",
+            "version": "4.1.0",
+            **support.fingerprint(wheel),
+        }
+    ]
+    row = {
+        "kind": "python",
+        "status": "passed",
+        "os": "windows-latest",
+        "python": "3.11",
+        "candidates": {"a": support.fingerprint(candidate / "evidence.json")},
+        "dependencies": dependencies,
+    }
+    (row_root / "row.json").write_bytes(support.canonical(row))
+    monkeypatch.setattr(predecessor.runtime.engine, "host_row", lambda: "windows-latest")
+    monkeypatch.setattr(predecessor.runtime, "current_python_version", lambda: "3.11")
+    monkeypatch.setattr(
+        support,
+        "verify_candidate",
+        lambda root, role: record if role == "a" else pytest.fail("relabelled A"),
+    )
+    monkeypatch.setattr(predecessor.qualification, "dependency_inventory", lambda _: dependencies)
+    return candidate, row_root, row, record, dependencies
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("status", "failed"),
+        ("os", "macos-latest"),
+        ("python", "3.14"),
+        ("candidates", {"a": {}}),
+        ("dependencies", []),
+    ],
+)
+def test_predecessor_rejects_wrong_retained_row(monkeypatch, tmp_path, field, value):
+    candidate, row_root, row, _, _ = _input_fixture(monkeypatch, tmp_path)
+    row[field] = value
+    (row_root / "row.json").write_bytes(support.canonical(row))
+    with pytest.raises(support.ReleaseError):
+        predecessor.validate_inputs(candidate, row_root, "4.0.4", "windows-latest")
+
+
+def test_predecessor_rejects_changed_retained_candidate_wheel(monkeypatch, tmp_path):
+    candidate, row_root, _, _, _ = _input_fixture(monkeypatch, tmp_path)
+    (row_root / "packages/godot_ai-4.1.0-py3-none-any.whl").write_bytes(b"substitution")
+    with pytest.raises(support.ReleaseError, match="wheel differs"):
+        predecessor.validate_inputs(candidate, row_root, "4.0.4", "windows-latest")
+
+
+@pytest.mark.parametrize("previous", ["3.2.5", "4.1.0", "4.1.1", "5.0.0"])
+def test_predecessor_requires_an_earlier_published_v4(monkeypatch, tmp_path, previous):
+    candidate, row_root, _, _, _ = _input_fixture(monkeypatch, tmp_path)
+    with pytest.raises(support.ReleaseError, match="earlier v4"):
+        predecessor.validate_inputs(candidate, row_root, previous, "windows-latest")
+
+
+def test_predecessor_row_retains_real_candidate_identity(monkeypatch, tmp_path):
+    candidate, row_root, _, record, dependencies = _input_fixture(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        predecessor,
+        "fetch_predecessor",
+        lambda version, destination: {"version": version, "source": "b" * 40},
+    )
+    calls = []
+
+    def update(*args):
+        calls.append(args)
+        return {"id": predecessor.CASE_ID, "status": "passed"}
+
+    monkeypatch.setattr(predecessor, "run_update", update)
+    output = tmp_path / "output"
+    predecessor.predecessor_row(
+        candidate, row_root, "4.0.4", "godot", "4.7.0", output, "windows-latest"
+    )
+    report = support.read_json(output / "row.json")
+    assert report["candidate"] == support.fingerprint(candidate / "evidence.json")
+    assert report["status"] == "passed" and report["source"] == record["source"]
+    assert report["predecessor"]["source"] == "b" * 40
+    assert calls[0][:3] == (candidate, row_root, dependencies)
+    assert report["cases"] == [{"id": predecessor.CASE_ID, "status": "passed"}]
+
+
+def test_failed_runtime_cannot_produce_a_passed_predecessor_receipt(monkeypatch, tmp_path):
+    candidate, row_root, _, _, _ = _input_fixture(monkeypatch, tmp_path)
+    monkeypatch.setattr(predecessor, "fetch_predecessor", lambda *_: {"version": "4.0.4"})
+    monkeypatch.setattr(
+        predecessor, "run_update", lambda *_: {"id": "exact-a-to-b-hot-update", "status": "passed"}
+    )
+    output = tmp_path / "output"
+    with pytest.raises(support.ReleaseError, match="required passed case"):
+        predecessor.predecessor_row(
+            candidate, row_root, "4.0.4", "godot", "4.7.0", output, "windows-latest"
+        )
+    result = support.read_json(output / "row.json")
+    assert result["status"] == "failed"
+    assert result["cases"] == []
+
+
+def _updated_project(tmp_path):
+    roots = [tmp_path / name for name in ("predecessor", "candidate")]
+    project = tmp_path / "project"
+    manifests = []
+    for root, content in zip(roots, (b"old", b"new"), strict=True):
+        release = root / "release"
+        release.mkdir(parents=True)
+        manifest = {
+            "inventory": [
+                {
+                    "path": "addons/godot_ai/plugin.cfg",
+                    "size": len(content),
+                    "sha256": hashlib.sha256(content).hexdigest(),
+                }
+            ]
+        }
+        (release / predecessor.MANIFEST).write_bytes(support.canonical(manifest))
+        manifests.append(manifest)
+    for relative, content in (
+        ("addons/godot_ai/plugin.cfg", b"new"),
+        ("addons/.godot_ai_update/backup/4.0.4/plugin.cfg", b"old"),
+    ):
+        path = project / relative
+        path.parent.mkdir(parents=True)
+        path.write_bytes(content)
+    marker = {
+        "status": "success",
+        "clients_migrated": True,
+        "from_version": "4.0.4",
+        "to_version": "4.1.0",
+        "manifest_sha256": support.fingerprint(roots[1] / "release" / predecessor.MANIFEST)[
+            "sha256"
+        ],
+        "expected_tree_sha256": predecessor.runtime.release_verify.inventory_tree_hash(
+            manifests[1]
+        ),
+        "backup_root": "res://addons/.godot_ai_update/backup/4.0.4",
+    }
+    (project / predecessor.runtime.UPDATE_STATE / "pending.json").write_text(
+        json.dumps(marker), encoding="utf-8"
+    )
+    return project, roots, marker
+
+
+def test_update_evidence_binds_exact_live_and_backup_bytes(tmp_path):
+    project, roots, _ = _updated_project(tmp_path)
+    result = predecessor.verify_update(project, *roots, {"version": "4.0.4"}, {"version": "4.1.0"})
+    assert result["live_tree"] == {
+        "plugin.cfg": support.fingerprint(project / "addons/godot_ai/plugin.cfg")
+    }
+    assert result["backup_tree"] == {
+        "plugin.cfg": support.fingerprint(
+            project / "addons/.godot_ai_update/backup/4.0.4/plugin.cfg"
+        )
+    }
+
+
+@pytest.mark.parametrize("corruption", ["live", "backup", "marker", "lock", "migration-flag"])
+def test_update_evidence_rejects_wrong_tree_or_incomplete_cleanup(tmp_path, corruption):
+    project, roots, marker = _updated_project(tmp_path)
+    if corruption == "live":
+        (project / "addons/godot_ai/plugin.cfg").write_bytes(b"wrong")
+    elif corruption == "backup":
+        (project / "addons/.godot_ai_update/backup/4.0.4/plugin.cfg").write_bytes(b"wrong")
+    elif corruption in {"marker", "migration-flag"}:
+        if corruption == "marker":
+            marker["from_version"] = "4.0.3"
+        else:
+            marker["clients_migrated"] = 1
+        (project / predecessor.runtime.UPDATE_STATE / "pending.json").write_text(
+            json.dumps(marker), encoding="utf-8"
+        )
+    else:
+        (project / predecessor.runtime.UPDATE_STATE / "lock.json").write_text(
+            "{}", encoding="utf-8"
+        )
+    with pytest.raises(support.ReleaseError):
+        predecessor.verify_update(project, *roots, {"version": "4.0.4"}, {"version": "4.1.0"})

--- a/tests/unit/test_release_public_verify.py
+++ b/tests/unit/test_release_public_verify.py
@@ -1,0 +1,111 @@
+"""Public re-resolution must retain the approved release digest."""
+
+import copy
+import io
+import json
+import tarfile
+
+import pytest
+
+from script import release_public_verify as public
+from script import release_support as support
+
+
+@pytest.fixture
+def resolution(monkeypatch):
+    url = "https://files.pythonhosted.org/packages/godot_ai-4.1.0-py3-none-any.whl"
+    metadata = {
+        "urls": [
+            {
+                "filename": "godot_ai-4.1.0-py3-none-any.whl",
+                "url": url,
+                "size": 123,
+                "digests": {"sha256": "a" * 64},
+            }
+        ]
+    }
+    report = {
+        "install": [
+            {
+                "metadata": {"name": "godot-ai", "version": "4.1.0"},
+                "download_info": {"url": url, "archive_info": {"hashes": {"sha256": "a" * 64}}},
+            }
+        ]
+    }
+    record = {
+        "version": "4.1.0",
+        "files": {"dist/godot_ai-4.1.0-py3-none-any.whl": {"size": 123, "sha256": "a" * 64}},
+    }
+    reads = []
+    monkeypatch.setattr(public.promotion, "public_json", lambda url: metadata)
+    monkeypatch.setattr(public.promotion, "verify_public_file", lambda *args: reads.append(args))
+    return report, record, metadata, reads
+
+
+def test_public_resolution_redownloads_approved_bytes(resolution):
+    report, record, _, reads = resolution
+    result = public.verify_resolution(report, record)
+    assert result[0]["sha256"] == "a" * 64 and result[0]["size"] == 123
+    assert reads == [
+        (result[0]["url"], {"size": 123, "sha256": "a" * 64}, {"files.pythonhosted.org"})
+    ]
+
+
+@pytest.mark.parametrize(
+    "fault",
+    [
+        "installed_hash",
+        "approved_hash",
+        "version",
+        "yanked",
+        "foreign_host",
+        "missing_release",
+        "duplicate",
+    ],
+)
+def test_public_resolution_rejects_unapproved_or_incomplete_install(resolution, fault):
+    report, record, metadata, _ = resolution
+    item = report["install"][0]
+    if fault == "installed_hash":
+        item["download_info"]["archive_info"]["hashes"]["sha256"] = "b" * 64
+    elif fault == "approved_hash":
+        next(iter(record["files"].values()))["sha256"] = "b" * 64
+    elif fault == "version":
+        item["metadata"]["version"] = "4.1.1"
+    elif fault == "yanked":
+        metadata["urls"][0]["yanked"] = True
+    elif fault == "foreign_host":
+        item["download_info"]["url"] = "https://example.com/package.whl"
+    elif fault == "missing_release":
+        report["install"] = []
+    else:
+        report["install"].append(copy.deepcopy(item))
+    with pytest.raises(support.ReleaseError):
+        public.verify_resolution(report, record)
+
+
+def test_reads_indented_pip_report_and_still_rejects_duplicate_keys(tmp_path):
+    report = tmp_path / "pip.json"
+    report.write_text(json.dumps({"version": "1", "install": []}, indent=2))
+    assert public.read_resolution(report) == {"version": "1", "install": []}
+    report.write_text('{"install": [], "install": [1]}')
+    with pytest.raises(support.ReleaseError):
+        public.read_resolution(report)
+
+
+def test_build_requirements_come_from_qualified_source_archive(tmp_path):
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    content = b'[build-system]\nrequires = ["setuptools==84.0.0"]\n'
+    with tarfile.open(dist / "godot_ai-4.1.0.tar.gz", "w:gz") as archive:
+        member = tarfile.TarInfo("godot_ai-4.1.0/pyproject.toml")
+        member.size = len(content)
+        archive.addfile(member, io.BytesIO(content))
+    assert public.build_requirements(tmp_path, "4.1.0") == ["setuptools==84.0.0"]
+
+
+def test_build_resolution_does_not_require_release_package(resolution):
+    report, record, _, reads = resolution
+    report["install"][0]["metadata"] = {"name": "setuptools", "version": "84.0.0"}
+    result = public.verify_resolution(report, record, require_release=False)
+    assert result[0]["name"] == "setuptools" and len(reads) == 1

--- a/tests/unit/test_release_validation.py
+++ b/tests/unit/test_release_validation.py
@@ -1,0 +1,344 @@
+"""Supplemental release evidence requires native proof and public byte inventories."""
+
+import copy
+
+import pytest
+
+from script import qualification_engine as engine
+from script import release_promotion as promotion
+from script import release_support as support
+from script import release_validation as validation
+
+DIGEST = {"sha256": "b" * 64, "size": 12}
+MANIFEST = "godot-ai-v4-plugin.manifest.json"
+
+
+def public_inventory(version):
+    return {
+        **{
+            "release/" + name: {
+                "url": "https://github.com/hi-godot/godot-ai/releases/download/v"
+                + version
+                + "/"
+                + name,
+                **DIGEST,
+            }
+            for name in support.RELEASE_NAMES
+        },
+        **{
+            "dist/" + name: {"url": "https://files.pythonhosted.org/" + name, **DIGEST}
+            for name in support.distribution_names(version)
+        },
+    }
+
+
+@pytest.fixture
+def rows(tmp_path, monkeypatch):
+    candidate = tmp_path / "candidate"
+    (candidate / "release").mkdir(parents=True)
+    (candidate / "evidence.json").write_text("qualified candidate")
+    manifest = {"inventory": [{"path": "addons/godot_ai/plugin.gd", **DIGEST}]}
+    (candidate / "release" / MANIFEST).write_bytes(support.canonical(manifest))
+    record = {
+        "version": "4.1.0",
+        "tag": "v4.1.0",
+        "source": "a" * 40,
+        "workflow_sha": "a" * 40,
+        "run_id": "123",
+        "run_attempt": "1",
+        "spki_sha256": "c" * 64,
+        "files": {name: DIGEST for name in public_inventory("4.1.0")},
+    }
+    monkeypatch.setattr(support, "verify_candidate", lambda *args: record)
+    tree_hash = support.verifier().inventory_tree_hash(manifest)
+    case = {
+        "id": "exact-published-predecessor-to-a",
+        "status": "passed",
+        "backend_stopped": True,
+        "from_version": "4.0.4",
+        "to_version": "4.1.0",
+        "runtime_result": {
+            "status": "passed",
+            "attached_bridge_served_b": True,
+            "from_version": "4.0.4",
+            "to_version": "4.1.0",
+        },
+        "attached_bridge": {"pin": "4.0.4", "ok_before_update": 1, "served_b": True, "fault": ""},
+        "live_tree": {"plugin.gd": DIGEST},
+        "live_tree_sha256": tree_hash,
+        "backup_tree": {"plugin.gd": DIGEST},
+        "backup_tree_sha256": tree_hash,
+        "update_marker": DIGEST,
+        "update_state": {
+            "status": "success",
+            "clients_migrated": True,
+            "from_version": "4.0.4",
+            "to_version": "4.1.0",
+            "manifest_sha256": support.fingerprint(candidate / "release" / MANIFEST)["sha256"],
+            "expected_tree_sha256": tree_hash,
+        },
+    }
+    root = tmp_path / "rows"
+    for os_label in support.PLATFORMS:
+        for python in ("3.11", "3.14"):
+            path = root / f"{os_label}-{python}"
+            path.mkdir(parents=True)
+            (path / "godot.log").write_text("native evidence")
+            case["godot"] = {
+                **engine.build_pin("4.7.0", os_label),
+                "version": "4.7.stable.official.fixture",
+            }
+            row = {
+                "godot_version": "4.7.0",
+                "schema": 1,
+                "kind": "predecessor",
+                "status": "passed",
+                "os": os_label,
+                "python": python,
+                "candidate": support.fingerprint(candidate / "evidence.json"),
+                "version": record["version"],
+                "source": record["source"],
+                "run_id": "123",
+                "run_attempt": "1",
+                "required_skips": 0,
+                "previous_version": "4.0.4",
+                "predecessor": {
+                    "version": "4.0.4",
+                    "tag": "v4.0.4",
+                    "source": "d" * 40,
+                    "spki_sha256": record["spki_sha256"],
+                    "files": public_inventory("4.0.4"),
+                },
+                "cases": [case],
+                "files": support.inventory(path),
+            }
+            (path / "row.json").write_bytes(support.canonical(row))
+    return candidate, root, tmp_path / "result.json", record
+
+
+def public_rows(rows):
+    candidate, root, output, record = rows
+    inventory = public_inventory(record["version"])
+    for path in root.glob("*/row.json"):
+        row = support.read_json(path)
+        row.update(
+            kind="public",
+            github={
+                key.removeprefix("release/"): value
+                for key, value in inventory.items()
+                if key.startswith("release/")
+            },
+            pypi={
+                key.removeprefix("dist/"): value
+                for key, value in inventory.items()
+                if key.startswith("dist/")
+            },
+        )
+        row["resolutions"] = {
+            kind: [
+                {
+                    "name": "godot-ai",
+                    "version": record["version"],
+                    **inventory["dist/godot_ai-4.1.0" + suffix],
+                }
+            ]
+            for kind, suffix in (("wheel", "-py3-none-any.whl"), ("sdist", ".tar.gz"))
+        }
+        row["resolutions"]["build"] = [
+            {
+                "name": "setuptools",
+                "version": "84.0.0",
+                "url": "https://files.pythonhosted.org/setuptools.whl",
+                **DIGEST,
+            }
+        ]
+        path.write_bytes(support.canonical(row))
+    receipt = root.parent / "publication.json"
+    receipt.write_bytes(support.canonical(record))
+    return receipt
+
+
+def test_complete_binds_all_six_native_rows(rows):
+    candidate, root, output, _ = rows
+    validation.complete(candidate, root, output, "predecessor")
+    result = support.read_json(output)
+    assert result["status"] == "passed" and len(result["files"]) == 12
+    assert result["candidate"] == support.fingerprint(candidate / "evidence.json")
+
+
+@pytest.mark.parametrize(
+    "fault",
+    [
+        "missing",
+        "failed",
+        "wrong_candidate",
+        "wrong_source",
+        "duplicate",
+        "empty_cases",
+        "wrong_case",
+        "no_bridge",
+        "bridge_fault",
+        "wrong_tree",
+        "wrong_state",
+        "wrong_backup",
+        "no_stop",
+        "retained_file",
+        "previous_source",
+        "previous_version",
+        "public_inventory",
+        "skipped",
+        "missing_engine",
+        "wrong_engine",
+        "wrong_engine_row",
+    ],
+)
+def test_complete_rejects_partial_or_mixed_evidence(rows, fault):
+    candidate, root, output, _ = rows
+    path = next(root.glob("*/row.json"))
+    row = support.read_json(path)
+    if fault == "missing":
+        path.unlink()
+    elif fault == "duplicate":
+        duplicate = root / "duplicate"
+        duplicate.mkdir()
+        (duplicate / "row.json").write_bytes(path.read_bytes())
+    else:
+        if fault in {"failed", "wrong_candidate", "wrong_source"}:
+            row[
+                {"failed": "status", "wrong_candidate": "candidate", "wrong_source": "source"}[
+                    fault
+                ]
+            ] = "wrong"
+        elif fault == "empty_cases":
+            row["cases"] = []
+        elif fault == "wrong_case":
+            row["cases"][0]["id"] = "exact-a-to-b"
+        elif fault == "no_bridge":
+            row["cases"][0]["runtime_result"]["attached_bridge_served_b"] = False
+        elif fault == "bridge_fault":
+            row["cases"][0]["attached_bridge"]["fault"] = "disconnected"
+        elif fault == "wrong_tree":
+            row["cases"][0]["live_tree"] = {}
+        elif fault == "wrong_state":
+            row["cases"][0]["update_state"]["manifest_sha256"] = "e" * 64
+        elif fault == "wrong_backup":
+            row["cases"][0]["backup_tree_sha256"] = "e" * 64
+        elif fault == "no_stop":
+            row["cases"][0]["backend_stopped"] = False
+        elif fault == "retained_file":
+            (path.parent / "godot.log").write_text("changed")
+        elif fault == "previous_source":
+            row["predecessor"]["source"] = "e" * 40
+        elif fault == "previous_version":
+            row["previous_version"] = "4.0.3"
+        elif fault == "public_inventory":
+            row["predecessor"]["files"].pop(next(iter(row["predecessor"]["files"])))
+        elif fault == "skipped":
+            row["required_skips"] = 1
+        elif fault == "missing_engine":
+            row["cases"][0].pop("godot")
+        elif fault == "wrong_engine":
+            row["cases"][0]["godot"]["sha256"] = "e" * 64
+        elif fault == "wrong_engine_row":
+            row["godot_version"] = "4.7.2"
+        path.write_bytes(support.canonical(row))
+    with pytest.raises(support.ReleaseError):
+        validation.complete(candidate, root, output, "predecessor")
+    assert not output.exists()
+
+
+def test_public_attestation_binds_receipt_and_resolutions(rows):
+    candidate, root, output, record = rows
+    receipt = public_rows(rows)
+    validation.complete(candidate, root, output, "public", receipt)
+    result = support.read_json(output)
+    assert result["publication"] == {"receipt": record, "digest": support.fingerprint(receipt)}
+
+
+@pytest.mark.parametrize(
+    "fault",
+    [
+        "missing_pypi",
+        "changed_asset",
+        "private_url",
+        "missing_build",
+        "empty_build",
+        "missing_release",
+        "wrong_release",
+        "duplicate_package",
+        "bad_digest",
+    ],
+)
+def test_public_attestation_rejects_incomplete_evidence(rows, fault):
+    candidate, root, output, _ = rows
+    receipt = public_rows(rows)
+    path = next(root.glob("*/row.json"))
+    row = support.read_json(path)
+    if fault == "missing_pypi":
+        row.pop("pypi")
+    elif fault == "changed_asset":
+        next(iter(row["github"].values()))["sha256"] = "e" * 64
+    elif fault == "private_url":
+        row["resolutions"]["build"][0]["url"] = "https://private.example/package.whl"
+    elif fault == "missing_build":
+        row["resolutions"].pop("build")
+    elif fault == "empty_build":
+        row["resolutions"]["build"] = []
+    elif fault == "missing_release":
+        row["resolutions"]["wheel"][0]["name"] = "unrelated"
+    elif fault == "wrong_release":
+        row["resolutions"]["sdist"][0]["version"] = "4.0.4"
+    elif fault == "duplicate_package":
+        row["resolutions"]["build"] *= 2
+    elif fault == "bad_digest":
+        row["resolutions"]["build"][0]["sha256"] = "bad"
+    path.write_bytes(support.canonical(row))
+    with pytest.raises(support.ReleaseError):
+        validation.complete(candidate, root, output, "public", receipt)
+    assert not output.exists()
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["version", "tag", "source", "workflow_sha", "run_id", "run_attempt", "spki_sha256", "files"],
+)
+def test_public_receipt_must_match_qualified_candidate(rows, field):
+    candidate, root, output, record = rows
+    receipt = public_rows(rows)
+    changed = copy.deepcopy(record)
+    changed[field] = "wrong"
+    receipt.write_bytes(support.canonical(changed))
+    with pytest.raises(support.ReleaseError, match="publication receipt"):
+        validation.complete(candidate, root, output, "public", receipt)
+    assert not output.exists()
+
+
+def test_public_requires_publication_receipt(rows):
+    candidate, root, output, _ = rows
+    public_rows(rows)
+    with pytest.raises(support.ReleaseError, match="requires publication receipt"):
+        validation.complete(candidate, root, output, "public")
+
+
+@pytest.mark.parametrize(
+    "field", [None, "id", "repository", "path", "event", "head_branch", "head_sha", "conclusion"]
+)
+def test_publication_run_provenance(rows, monkeypatch, field):
+    candidate, _, _, record = rows
+    run = {
+        "id": 123,
+        "repository": {"full_name": support.REPOSITORY},
+        "path": ".github/workflows/release.yml",
+        "event": "workflow_dispatch",
+        "head_branch": "main",
+        "head_sha": record["source"],
+        "conclusion": "success",
+    }
+    if field is not None:
+        run[field] = {} if field == "repository" else "wrong"
+    monkeypatch.setattr(promotion, "gh", lambda endpoint: run)
+    if field is None:
+        assert validation.check_publication_run("123", candidate) == run
+    else:
+        with pytest.raises(support.ReleaseError, match="provenance"):
+            validation.check_publication_run("123", candidate)

--- a/tests/unit/test_test_port_allocation.py
+++ b/tests/unit/test_test_port_allocation.py
@@ -1,0 +1,65 @@
+"""Keep backend restart ports out of other pytest workers' allocations."""
+
+import json
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+from tests.conftest import allocate_free_ports
+
+
+def test_released_port_is_not_reallocated_by_another_worker(tmp_path, monkeypatch):
+    claims = tmp_path / "claims"
+    claims.mkdir()
+    monkeypatch.setenv("GODOT_AI_TEST_PORT_CLAIMS", str(claims))
+    with socket.socket() as first, socket.socket() as second:
+        first.bind(("127.0.0.1", 0))
+        second.bind(("127.0.0.1", 0))
+        candidates = [first.getsockname()[1], second.getsockname()[1]]
+
+    # Force the OS's permitted reuse of the same now-closed port in two
+    # separate workers, without depending on ephemeral allocation luck.
+    worker = """
+import json
+import socket
+import sys
+sys.path[:] = json.loads(sys.argv[2])
+from tests.conftest import allocate_free_ports
+
+candidates = iter(json.loads(sys.argv[1]))
+class CandidateSocket(socket.socket):
+    def bind(self, address):
+        host, port = address
+        return super().bind((host, next(candidates) if port == 0 else port))
+
+socket.socket = CandidateSocket
+print(json.dumps(allocate_free_ports(1)))
+"""
+
+    def allocate_in_worker():
+        root = Path(__file__).resolve().parents[2]
+        completed = subprocess.run(
+            [sys.executable, "-c", worker, json.dumps(candidates), json.dumps(sys.path)],
+            cwd=root,
+            capture_output=True, text=True, check=True, timeout=30,
+        )
+        return json.loads(completed.stdout)[0]
+
+    original = allocate_in_worker()
+    with socket.socket() as restarted:
+        restarted.bind(("127.0.0.1", original))
+    other_worker = allocate_in_worker()
+
+    assert original == candidates[0]
+    assert other_worker == candidates[1]
+    with socket.socket() as restarted:
+        restarted.bind(("127.0.0.1", original))
+
+
+def test_port_batch_is_distinct_and_released():
+    ports = allocate_free_ports(3)
+    assert len(set(ports)) == 3
+    for port in ports:
+        with socket.socket() as listener:
+            listener.bind(("127.0.0.1", port))


### PR DESCRIPTION
Prepare 4.1.0 with matching Python and plugin versions and release notes for the merged lifecycle, migration, and in-editor update changes. The notes explain the one-time restart from published 4.0.4 and carry Configure all (#1047) as a known issue with the individual-client workaround.

The release contract requires checks beyond the existing signed A-to-B qualification. A separate manual workflow now verifies published 4.0.4 to the exact signed candidate A, then, after promotion, verifies public wheel/sdist and GitHub bytes and fresh dependency installs. Both modes cover three operating systems and Python 3.11/3.14. The final artifact binds all six rows to the same candidate; public evidence also binds the promotion receipt. Candidate signing, promotion permissions, and the A/B evidence format remain unchanged.

The predecessor lane installs the stock published add-on, uses the existing private HTTPS/index and external editor driver, retains one attached bridge through the update, and verifies the resulting live and backup trees. It does not rewrite either add-on or relabel A as B. Public verification retains pip reports, independently checks public dependency downloads, and includes the sdist build dependencies.

Two test fixes accompany preparation: the update view-model test derives a future version rather than assuming 4.1.0 is newer forever; the shared pytest allocator retains atomic port claims across workers so another test cannot reuse a backend's port during a deliberate restart. The latter addresses the HTTP 426 recovery failure in main CI run 34626318591. That log did not capture the competing PID; the forced two-process regression fails with the old allocator and passes with the fix.

Validation: the final combined gauntlet passed **2,733 Python tests, 58 skipped**, with one dependency deprecation warning. The rendered Compatibility suite passed **2,330 tests, 0 failed, 33 skipped**, and authenticated 4.1.0 reads/writes. Two default-Vulkan startup stalls occurred before plugin startup and remain recorded as an environment limitation. The port fix passed 100 parallel attach/WebSocket/allocation tests. Ruff and Actionlint passed. The public checker passed against the original sealed 4.0.4 candidate: both distributions, all six GitHub assets, fresh wheel/source installs, and all resolved dependency bytes. The exact 4.0.4-to-4.1.0 native lane awaits signed candidate A and must pass before promotion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugin updates now activate within the running editor while preserving open scenes, unsaved changes, selection, and undo history.
  * Version 4.1.0 supports migration from version 3.2.5 without restarting the editor.

* **Bug Fixes**
  * Fixed native crashes during imports, filesystem-scan delays, recovery states, Windows process handling, port migration, linked-directory backups, and Linux listener diagnostics.
  * Fixed migration behavior for independent HTTP and WebSocket ports.

* **Known Issues**
  * “Configure all” may report a client-configuration lock error when requests overlap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->