### PR TITLE
fix(release): canonicalize public verify temp dir before location check

### DIFF
--- a/script/release_public_verify.py
+++ b/script/release_public_verify.py
@@ -117,7 +117,7 @@ def public_row(candidate: Path, output: Path, os_label: str) -> None:
         assets[asset["name"]] = {"url": url, **expected}
     resolutions = {}
     with tempfile.TemporaryDirectory(prefix="godot-ai-public-") as temporary:
-        work = Path(temporary)
+        work = Path(temporary).resolve()
         environment = {
             key: value
             for key, value in os.environ.items()

--- a/tests/unit/test_release_public_verify.py
+++ b/tests/unit/test_release_public_verify.py
@@ -4,6 +4,7 @@ import copy
 import io
 import json
 import tarfile
+from pathlib import Path
 
 import pytest
 
@@ -109,3 +110,79 @@ def test_build_resolution_does_not_require_release_package(resolution):
     report["install"][0]["metadata"] = {"name": "setuptools", "version": "84.0.0"}
     result = public.verify_resolution(report, record, require_release=False)
     assert result[0]["name"] == "setuptools" and len(reads) == 1
+
+
+def _uncanonical_directory(tmp_path):
+    """A directory whose resolve() differs from its spelling: a symlink, else an 8.3 name."""
+    import ctypes
+    import os
+
+    real = tmp_path / "real-directory-name"
+    real.mkdir()
+    link = tmp_path / "link"
+    try:
+        link.symlink_to(real, target_is_directory=True)
+        return link
+    except (OSError, NotImplementedError):
+        pass
+    if os.name == "nt":
+        buffer = ctypes.create_unicode_buffer(1024)
+        if ctypes.windll.kernel32.GetShortPathNameW(str(real), buffer, 1024):
+            short = Path(buffer.value)
+            if short != real and short.resolve() == real.resolve():
+                return short
+    pytest.skip("no symlink or short-name support")
+
+
+def test_install_location_check_uses_canonical_temporary_directory(tmp_path, monkeypatch):
+    """macOS /var -> /private/var and Windows 8.3 names must not fail the location check."""
+    import contextlib
+    import types
+
+    link = _uncanonical_directory(tmp_path)
+    candidate = tmp_path / "candidate"
+    candidate.mkdir()
+    (candidate / "evidence.json").write_bytes(b"{}")
+    record = {"version": "4.1.0", "source": "abc", "files": {}}
+
+    @contextlib.contextmanager
+    def fake_temporary(prefix):
+        yield str(link)
+
+    commands = []
+    monkeypatch.setattr(
+        public, "sys", types.SimpleNamespace(version_info=types.SimpleNamespace(major=3, minor=11))
+    )
+    monkeypatch.setattr(public.tempfile, "TemporaryDirectory", fake_temporary)
+    monkeypatch.setattr(public.support, "verify_candidate", lambda *args: record)
+    monkeypatch.setattr(public.promotion, "verify_pypi", lambda record: {})
+    monkeypatch.setattr(
+        public.promotion,
+        "github_preflight",
+        lambda record: {
+            "draft": False,
+            "assets": [],
+            "body": f"https://github.com/{support.REPOSITORY}/blob/abc/docs/v4-migration.md",
+        },
+    )
+    monkeypatch.setattr(
+        public.venv,
+        "EnvBuilder",
+        lambda **kwargs: types.SimpleNamespace(create=lambda target: None),
+    )
+    monkeypatch.setattr(public, "build_requirements", lambda candidate, version: ["build"])
+    monkeypatch.setattr(public, "read_resolution", lambda report: {})
+    monkeypatch.setattr(public, "verify_resolution", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        public.qualification,
+        "execute",
+        lambda command, log, *, cwd, environment: commands.append(command),
+    )
+    import script.qualification_engine as engine
+
+    public.public_row(candidate, tmp_path / "row", engine.host_row())
+
+    checks = [command[-1] for command in commands if command[-2] == "-c"]
+    assert len(checks) == 2
+    for kind, check in zip(("wheel", "sdist"), checks, strict=True):
+        assert check.endswith(f".is_relative_to({str(link.resolve() / kind)!r})")


### PR DESCRIPTION
## Why

[Release validation run 34632966803](https://github.com/hi-godot/godot-ai/actions/runs/34632966803) failed all four macOS and Windows `public` rows for 4.1.0 even though the published wheel installed cleanly, `pip check` was clean, and `godot_ai --version` printed 4.1.0.

The failing step is the install-location assertion in `script/release_public_verify.py`. It compares `Path(godot_ai.__file__).resolve()` against the *unresolved* temp dir string:

- macOS: venv created at `/var/folders/...`, package resolves to `/private/var/folders/...`
- Windows: venv created at `C:\Users\RUNNER~1\...`, package resolves to the long `runneradmin` path
- Ubuntu: `/tmp` is a real directory, so it passed

(The fifth failure, Ubuntu 3.11, was PyPI CDN propagation lag: pip listed versions only through 4.0.4 about 45 s after promotion finished. A rerun clears it.)

## What

- Resolve the temp dir once (`Path(temporary).resolve()`) so `target` is canonical when embedded in the assertion.
- Regression test that drives `public_row` through a symlinked temp dir (falls back to a Windows 8.3 short name when symlinks need elevation, which is the real Windows failure shape). Verified locally: fails on `main`, passes with the fix.

## Verification

- `ruff format` / `ruff check` clean on both files
- `pytest tests/unit/test_release_public_verify.py`: 12 passed
- Same test with the one-line fix reverted: 1 failed with the exact CI failure shape (`REAL-D~1\wheel` embedded in the check)

## After merge

Re-dispatch **Release validation / public** for qualification run 34631183901 with publication run 34632699355. Both failure causes should clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release verification so package installation checks work correctly when temporary directories use symlinked or alternate path representations.
  * Prevented false verification failures caused by differences between temporary directory paths and their canonical locations.

* **Tests**
  * Added coverage for canonical temporary directory handling across supported path formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->